### PR TITLE
Fix check config script on 4.8 kernels

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -188,7 +188,6 @@ fi
 
 flags=(
 	NAMESPACES {NET,PID,IPC,UTS}_NS
-	DEVPTS_MULTIPLE_INSTANCES
 	CGROUPS CGROUP_CPUACCT CGROUP_DEVICE CGROUP_FREEZER CGROUP_SCHED CPUSETS MEMCG
 	KEYS
 	VETH BRIDGE BRIDGE_NETFILTER
@@ -200,6 +199,10 @@ flags=(
 	POSIX_MQUEUE
 )
 check_flags "${flags[@]}"
+if [ "$kernelMajor" -lt 4 ] || [ "$kernelMajor" -eq 4 -a "$kernelMinor" -lt 8 ]; then
+        check_flags DEVPTS_MULTIPLE_INSTANCES
+fi
+
 echo
 
 echo 'Optional Features:'


### PR DESCRIPTION
DEVPTS_MULTIPLE_INSTANCES is no longer an option on Linux 4.8+, it is always set, so
do not check for this post 4.8.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![hedgechoc](https://cloud.githubusercontent.com/assets/482364/20429060/40c61916-ad84-11e6-9ce0-6cbfd30e80d0.jpg)
