### PR TITLE
Windows: Fix a longstanding TODO

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -18,9 +18,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 		return nil, err
 	}
 
-	// TODO Windows - this can be removed. Not used (UID/GID)
-	rootUID, rootGID := daemon.GetRemappedUIDGID()
-	if err := c.SetupWorkingDirectory(rootUID, rootGID); err != nil {
+	if err := c.SetupWorkingDirectory(0, 0); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Just noticed in the code when I was talking to @duglin offline. Absolutely no need for the no-op UID/GID remapping call on Windows. Simply removing it.