### PR TITLE
Ensure vmcompute.dll exists during daemon start

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/options"
 	blkiodev "github.com/opencontainers/runc/libcontainer/configs"
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -229,6 +230,11 @@ func checkSystem() error {
 	}
 	if osv.Build < 14393 {
 		return fmt.Errorf("The docker daemon requires build 14393 or later of Windows Server 2016 or Windows 10")
+	}
+
+	vmcompute := windows.NewLazySystemDLL("vmcompute.dll")
+	if vmcompute.Load() != nil {
+		return fmt.Errorf("Failed to load vmcompute.dll. Ensure that the Containers role is installed.")
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

fixes #28327 

Ensure that vmcompute.dll exists on the system during daemon startup, and fail with a message to install the Containers role to fix the problem.

**- How I did it**

Load vmcompute.dll during checkSystem.

**- How to verify it**

On a system without `vmcompute.dll` installed.

Prior to fix:
```
C:\Users\Administrator>dockerd
time="2016-11-18T12:32:00.001314800-08:00" level=info msg="Windows default isolation mode: process"
time="2016-11-18T12:32:00.006612100-08:00" level=info msg="[graphdriver] using prior storage driver: windowsfilter"
time="2016-11-18T12:32:00.109140500-08:00" level=info msg="Graph migration to content-addressability took 0.00 seconds"
time="2016-11-18T12:32:00.109140500-08:00" level=info msg="Loading containers: start."
Error starting daemon: Error initializing network controller: Failed to load vmcompute.dll: The specified module could not be found.
```

With fix:
```
C:\Users\Administrator>dockerd
Error starting daemon: Failed to load vmcompute.dll. Ensure that the Containers role is installed.
```

/cc @jhowardmsft @jstarks 

Signed-off-by: Darren Stahl <darst@microsoft.com>