### PR TITLE
swap position of "host" and "ip"

### DIFF
--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -531,7 +531,7 @@ func convertService(
 func convertExtraHosts(extraHosts map[string]string) []string {
 	hosts := []string{}
 	for host, ip := range extraHosts {
-		hosts = append(hosts, fmt.Sprintf("%s %s", host, ip))
+		hosts = append(hosts, fmt.Sprintf("%s %s", ip, host))
 	}
 	return hosts
 }


### PR DESCRIPTION
the service definition uses the format as defined
in  http://man7.org/linux/man-pages/man5/hosts.5.html
(IP_address canonical_hostname [aliases...])

This format is the _reverse_ of the format used in
the container API.

Commit f32869d956eb175f88fd0b16992d2377d8eae79c (https://github.com/docker/docker/pull/28299)
inadvertently used the incorrect order.

This fixes the order, and correctly sets it to;

    IP-Address hostname

Fixes https://github.com/docker/docker/issues/28597

Thanks @stevvooe for spotting this