### PR TITLE
Allow graphdriver plugins to use v2

### DIFF
--- a/daemon/graphdriver/plugin.go
+++ b/daemon/graphdriver/plugin.go
@@ -3,6 +3,7 @@ package graphdriver
 import (
 	"fmt"
 	"io"
+	"path/filepath"
 
 	"github.com/docker/docker/pkg/plugingetter"
 )
@@ -26,5 +27,5 @@ func lookupPlugin(name, home string, opts []string, pg plugingetter.PluginGetter
 
 func newPluginDriver(name, home string, opts []string, c pluginClient) (Driver, error) {
 	proxy := &graphDriverProxy{name, c}
-	return proxy, proxy.Init(home, opts)
+	return proxy, proxy.Init(filepath.Join(home, name), opts)
 }


### PR DESCRIPTION
Currently the plugin initialization is too late for a loaded v2 plugin
to be usable as a graph driver.

This moves the initialization up before we create the graph driver.


ping @anusha-ragunathan @tiborvass 