### PR TITLE
Update deprecation notes about v1 registry

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -242,7 +242,18 @@ of the `--changes` flag that allows to pass `Dockerfile` commands.
 
 ### Interacting with V1 registries
 
-Version 1.9 adds a flag (`--disable-legacy-registry=false`) which prevents the docker daemon from `pull`, `push`, and `login` operations against v1 registries.  Though disabled by default, this signals the intent to deprecate the v1 protocol.
+**Disabled By Default In Release: v1.14**
+
+**Target For Removal In Release: v1.17**
+
+Version 1.9 adds a flag (`--disable-legacy-registry=false`) which prevents the
+docker daemon from `pull`, `push`, and `login` operations against v1
+registries.  Though enabled by default, this signals the intent to deprecate
+the v1 protocol.
+
+Support for the v1 protocol to the public registry was removed in 1.13. Any
+mirror configurations using v1 should be updated to use a
+[v2 registry mirror](https://docs.docker.com/registry/recipes/mirror/).
 
 ### Docker Content Trust ENV passphrase variables name change
 **Deprecated In Release: [v1.9.0](https://github.com/docker/docker/releases/tag/v1.9.0)**


### PR DESCRIPTION
Adds section about the hub deprecating the v1 protocol. Adds note about intent to disable by default and remove support.

Change the wording `Though disabled by default`, to `Though enabled by default`, since the current default is disabled equal to false, or enabled. I found this confusing, but there might still be a better way to word it to make it clearer.

I choose 1.14 as disabled by default since we are already in freeze for 1.13 and making such a change seems unnecessary. We did add the flag in 1.9 but did not mention when the default will change, however I don't believe that means we need to wait 3 more releases to change the default if we are already waiting 3 to remove.

follow up to #28100

ping @nwt @dmp42