### PR TITLE
Don't do format if it's unnecessary

### DIFF
--- a/api/server/httputils/form.go
+++ b/api/server/httputils/form.go
@@ -1,7 +1,7 @@
 package httputils
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -61,9 +61,9 @@ func ArchiveFormValues(r *http.Request, vars map[string]string) (ArchiveOptions,
 
 	switch {
 	case name == "":
-		return ArchiveOptions{}, fmt.Errorf("bad parameter: 'name' cannot be empty")
+		return ArchiveOptions{}, errors.New("bad parameter: 'name' cannot be empty")
 	case path == "":
-		return ArchiveOptions{}, fmt.Errorf("bad parameter: 'path' cannot be empty")
+		return ArchiveOptions{}, errors.New("bad parameter: 'path' cannot be empty")
 	}
 
 	return ArchiveOptions{name, path}, nil

--- a/builder/dockerfile/bflag.go
+++ b/builder/dockerfile/bflag.go
@@ -167,7 +167,7 @@ func (bf *BFlags) Parse() error {
 			flag.Value = value
 
 		default:
-			panic(fmt.Errorf("No idea what kind of flag we have! Should never get here!"))
+			panic("No idea what kind of flag we have! Should never get here!")
 		}
 
 	}

--- a/builder/dockerfile/bflag_test.go
+++ b/builder/dockerfile/bflag_test.go
@@ -35,10 +35,10 @@ func TestBuilderFlags(t *testing.T) {
 	}
 
 	if flStr1.IsUsed() == true {
-		t.Fatalf("Test3 - str1 was not used!")
+		t.Fatal("Test3 - str1 was not used!")
 	}
 	if flBool1.IsUsed() == true {
-		t.Fatalf("Test3 - bool1 was not used!")
+		t.Fatal("Test3 - bool1 was not used!")
 	}
 
 	// ---
@@ -53,16 +53,16 @@ func TestBuilderFlags(t *testing.T) {
 	}
 
 	if flStr1.Value != "HI" {
-		t.Fatalf("Str1 was supposed to default to: HI")
+		t.Fatal("Str1 was supposed to default to: HI")
 	}
 	if flBool1.IsTrue() {
-		t.Fatalf("Bool1 was supposed to default to: false")
+		t.Fatal("Bool1 was supposed to default to: false")
 	}
 	if flStr1.IsUsed() == true {
-		t.Fatalf("Str1 was not used!")
+		t.Fatal("Str1 was not used!")
 	}
 	if flBool1.IsUsed() == true {
-		t.Fatalf("Bool1 was not used!")
+		t.Fatal("Bool1 was not used!")
 	}
 
 	// ---
@@ -116,7 +116,7 @@ func TestBuilderFlags(t *testing.T) {
 	}
 
 	if !flBool1.IsTrue() {
-		t.Fatalf("Test-b1 Bool1 was supposed to be true")
+		t.Fatal("Test-b1 Bool1 was supposed to be true")
 	}
 
 	// ---
@@ -144,7 +144,7 @@ func TestBuilderFlags(t *testing.T) {
 	}
 
 	if flBool1.IsTrue() {
-		t.Fatalf("Test-b3 Bool1 was supposed to be false")
+		t.Fatal("Test-b3 Bool1 was supposed to be false")
 	}
 
 	// ---

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -257,8 +257,8 @@ func (b *Builder) build(stdout io.Writer, stderr io.Writer, out io.Writer) (stri
 		select {
 		case <-b.clientCtx.Done():
 			logrus.Debug("Builder: build cancelled!")
-			fmt.Fprintf(b.Stdout, "Build cancelled")
-			return "", fmt.Errorf("Build cancelled")
+			fmt.Fprint(b.Stdout, "Build cancelled")
+			return "", errors.New("Build cancelled")
 		default:
 			// Not cancelled yet, keep going...
 		}
@@ -291,7 +291,7 @@ func (b *Builder) build(stdout io.Writer, stderr io.Writer, out io.Writer) (stri
 	}
 
 	if b.image == "" {
-		return "", fmt.Errorf("No image was generated. Is your Dockerfile empty?")
+		return "", errors.New("No image was generated. Is your Dockerfile empty?")
 	}
 
 	if b.options.Squash {

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -8,6 +8,7 @@ package dockerfile
 // package.
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"runtime"
@@ -211,7 +212,7 @@ func from(b *Builder, args []string, attributes map[string]bool, original string
 	// Windows cannot support a container with no base image.
 	if name == api.NoBaseImageSpecifier {
 		if runtime.GOOS == "windows" {
-			return fmt.Errorf("Windows does not support FROM scratch")
+			return errors.New("Windows does not support FROM scratch")
 		}
 		b.image = ""
 		b.noBaseImage = true
@@ -254,7 +255,7 @@ func onbuild(b *Builder, args []string, attributes map[string]bool, original str
 	triggerInstruction := strings.ToUpper(strings.TrimSpace(args[0]))
 	switch triggerInstruction {
 	case "ONBUILD":
-		return fmt.Errorf("Chaining ONBUILD via `ONBUILD ONBUILD` isn't allowed")
+		return errors.New("Chaining ONBUILD via `ONBUILD ONBUILD` isn't allowed")
 	case "MAINTAINER", "FROM":
 		return fmt.Errorf("%s isn't allowed as an ONBUILD trigger", triggerInstruction)
 	}
@@ -331,7 +332,7 @@ func workdir(b *Builder, args []string, attributes map[string]bool, original str
 //
 func run(b *Builder, args []string, attributes map[string]bool, original string) error {
 	if b.image == "" && !b.noBaseImage {
-		return fmt.Errorf("Please provide a source image with `from` prior to run")
+		return errors.New("Please provide a source image with `from` prior to run")
 	}
 
 	if err := b.flags.Parse(); err != nil {
@@ -499,7 +500,7 @@ func healthcheck(b *Builder, args []string, attributes map[string]bool, original
 	args = args[1:]
 	if typ == "NONE" {
 		if len(args) != 0 {
-			return fmt.Errorf("HEALTHCHECK NONE takes no arguments")
+			return errors.New("HEALTHCHECK NONE takes no arguments")
 		}
 		test := strslice.StrSlice{typ}
 		b.runConfig.Healthcheck = &container.HealthConfig{
@@ -527,7 +528,7 @@ func healthcheck(b *Builder, args []string, attributes map[string]bool, original
 		case "CMD":
 			cmdSlice := handleJSONArgs(args, attributes)
 			if len(cmdSlice) == 0 {
-				return fmt.Errorf("Missing command after HEALTHCHECK CMD")
+				return errors.New("Missing command after HEALTHCHECK CMD")
 			}
 
 			if !attributes["json"] {
@@ -688,7 +689,7 @@ func volume(b *Builder, args []string, attributes map[string]bool, original stri
 	for _, v := range args {
 		v = strings.TrimSpace(v)
 		if v == "" {
-			return fmt.Errorf("VOLUME specified can not be an empty string")
+			return errors.New("VOLUME specified can not be an empty string")
 		}
 		b.runConfig.Volumes[v] = struct{}{}
 	}

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -196,7 +196,7 @@ func TestFrom(t *testing.T) {
 
 	if runtime.GOOS == "windows" {
 		if err == nil {
-			t.Fatalf("Error not set on Windows")
+			t.Fatal("Error not set on Windows")
 		}
 
 		expectedError := "Windows does not support FROM scratch"
@@ -231,7 +231,7 @@ func TestOnbuildIllegalTriggers(t *testing.T) {
 		err := onbuild(b, []string{trigger.command}, nil, "")
 
 		if err == nil {
-			t.Fatalf("Error should not be nil")
+			t.Fatal("Error should not be nil")
 		}
 
 		if !strings.Contains(err.Error(), trigger.expectedError) {
@@ -301,7 +301,7 @@ func TestCmd(t *testing.T) {
 	}
 
 	if !b.cmdSet {
-		t.Fatalf("Command should be marked as set")
+		t.Fatal("Command should be marked as set")
 	}
 }
 
@@ -365,7 +365,7 @@ func TestEntrypoint(t *testing.T) {
 	}
 
 	if b.runConfig.Entrypoint == nil {
-		t.Fatalf("Entrypoint should be set")
+		t.Fatal("Entrypoint should be set")
 	}
 
 	var expectedEntrypoint strslice.StrSlice
@@ -391,7 +391,7 @@ func TestExpose(t *testing.T) {
 	}
 
 	if b.runConfig.ExposedPorts == nil {
-		t.Fatalf("ExposedPorts should be set")
+		t.Fatal("ExposedPorts should be set")
 	}
 
 	if len(b.runConfig.ExposedPorts) != 1 {
@@ -433,7 +433,7 @@ func TestVolume(t *testing.T) {
 	}
 
 	if b.runConfig.Volumes == nil {
-		t.Fatalf("Volumes should be set")
+		t.Fatal("Volumes should be set")
 	}
 
 	if len(b.runConfig.Volumes) != 1 {
@@ -506,7 +506,7 @@ func TestShell(t *testing.T) {
 	}
 
 	if b.runConfig.Shell == nil {
-		t.Fatalf("Shell should be set")
+		t.Fatal("Shell should be set")
 	}
 
 	expectedShell := strslice.StrSlice([]string{shellCmd})

--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -20,6 +20,7 @@
 package dockerfile
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -115,7 +116,7 @@ func (b *Builder) dispatch(stepN int, stepTotal int, ast *parser.Node) error {
 
 	if cmd == "onbuild" {
 		if ast.Next == nil {
-			return fmt.Errorf("ONBUILD requires at least one argument")
+			return errors.New("ONBUILD requires at least one argument")
 		}
 		ast = ast.Next.Children[0]
 		strList = append(strList, ast.Value)
@@ -222,7 +223,7 @@ func (b *Builder) checkDispatch(ast *parser.Node, onbuild bool) error {
 	// least one argument
 	if upperCasedCmd == "ONBUILD" {
 		if ast.Next == nil {
-			return fmt.Errorf("ONBUILD requires at least one argument")
+			return errors.New("ONBUILD requires at least one argument")
 		}
 	}
 
@@ -230,7 +231,7 @@ func (b *Builder) checkDispatch(ast *parser.Node, onbuild bool) error {
 	if onbuild {
 		switch upperCasedCmd {
 		case "ONBUILD":
-			return fmt.Errorf("Chaining ONBUILD via `ONBUILD ONBUILD` isn't allowed")
+			return errors.New("Chaining ONBUILD via `ONBUILD ONBUILD` isn't allowed")
 		case "MAINTAINER", "FROM":
 			return fmt.Errorf("%s isn't allowed as an ONBUILD trigger", upperCasedCmd)
 		}

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -43,7 +43,7 @@ func (b *Builder) commit(id string, autoCmd strslice.StrSlice, comment string) e
 		return nil
 	}
 	if b.image == "" && !b.noBaseImage {
-		return fmt.Errorf("Please provide a source image with `from` prior to commit")
+		return errors.New("Please provide a source image with `from` prior to commit")
 	}
 	b.runConfig.Image = b.image
 
@@ -137,7 +137,7 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowLocalD
 	}
 
 	if len(infos) == 0 {
-		return fmt.Errorf("No source files were specified")
+		return errors.New("No source files were specified")
 	}
 	if len(infos) > 1 && !strings.HasSuffix(dest, string(os.PathSeparator)) {
 		return fmt.Errorf("When using %s with more than one source file, the destination must be a directory and end with a /", cmdName)
@@ -456,7 +456,7 @@ func (b *Builder) probeCache() (bool, error) {
 		return false, nil
 	}
 
-	fmt.Fprintf(b.Stdout, " ---> Using cache\n")
+	fmt.Fprint(b.Stdout, " ---> Using cache\n")
 	logrus.Debugf("[BUILDER] Use cached version: %s", b.runConfig.Cmd)
 	b.image = string(cache)
 
@@ -465,7 +465,7 @@ func (b *Builder) probeCache() (bool, error) {
 
 func (b *Builder) create() (string, error) {
 	if b.image == "" && !b.noBaseImage {
-		return "", fmt.Errorf("Please provide a source image with `from` prior to run")
+		return "", errors.New("Please provide a source image with `from` prior to run")
 	}
 	b.runConfig.Image = b.image
 

--- a/builder/dockerfile/shell_parser_test.go
+++ b/builder/dockerfile/shell_parser_test.go
@@ -121,35 +121,35 @@ func TestGetEnv(t *testing.T) {
 
 	sw.envs = []string{}
 	if sw.getEnv("foo") != "" {
-		t.Fatalf("2 - 'foo' should map to ''")
+		t.Fatal("2 - 'foo' should map to ''")
 	}
 
 	sw.envs = []string{"foo"}
 	if sw.getEnv("foo") != "" {
-		t.Fatalf("3 - 'foo' should map to ''")
+		t.Fatal("3 - 'foo' should map to ''")
 	}
 
 	sw.envs = []string{"foo="}
 	if sw.getEnv("foo") != "" {
-		t.Fatalf("4 - 'foo' should map to ''")
+		t.Fatal("4 - 'foo' should map to ''")
 	}
 
 	sw.envs = []string{"foo=bar"}
 	if sw.getEnv("foo") != "bar" {
-		t.Fatalf("5 - 'foo' should map to 'bar'")
+		t.Fatal("5 - 'foo' should map to 'bar'")
 	}
 
 	sw.envs = []string{"foo=bar", "car=hat"}
 	if sw.getEnv("foo") != "bar" {
-		t.Fatalf("6 - 'foo' should map to 'bar'")
+		t.Fatal("6 - 'foo' should map to 'bar'")
 	}
 	if sw.getEnv("car") != "hat" {
-		t.Fatalf("7 - 'car' should map to 'hat'")
+		t.Fatal("7 - 'car' should map to 'hat'")
 	}
 
 	// Make sure we grab the first 'car' in the list
 	sw.envs = []string{"foo=bar", "car=hat", "car=bike"}
 	if sw.getEnv("car") != "hat" {
-		t.Fatalf("8 - 'car' should map to 'hat'")
+		t.Fatal("8 - 'car' should map to 'hat'")
 	}
 }

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -3,6 +3,7 @@ package container
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -238,7 +239,7 @@ func (c *containerAdapter) create(ctx context.Context) error {
 
 	container := c.container.task.Spec.GetContainer()
 	if container == nil {
-		return fmt.Errorf("unable to get container from task spec")
+		return errors.New("unable to get container from task spec")
 	}
 
 	// configure secrets
@@ -401,7 +402,7 @@ func (c *containerAdapter) logs(ctx context.Context, options api.LogSubscription
 		// See protobuf documentation for details of how this works.
 		apiOptions.Tail = fmt.Sprint(-options.Tail - 1)
 	} else if options.Tail > 0 {
-		return nil, fmt.Errorf("tail relative to start of logs not supported via docker API")
+		return nil, errors.New("tail relative to start of logs not supported via docker API")
 	}
 
 	if len(options.Streams) == 0 {

--- a/daemon/cluster/executor/container/errors.go
+++ b/daemon/cluster/executor/container/errors.go
@@ -1,15 +1,17 @@
 package container
 
-import "fmt"
+import (
+	"errors"
+)
 
 var (
 	// ErrImageRequired returned if a task is missing the image definition.
-	ErrImageRequired = fmt.Errorf("dockerexec: image required")
+	ErrImageRequired = errors.New("dockerexec: image required")
 
 	// ErrContainerDestroyed returned when a container is prematurely destroyed
 	// during a wait call.
-	ErrContainerDestroyed = fmt.Errorf("dockerexec: container destroyed")
+	ErrContainerDestroyed = errors.New("dockerexec: container destroyed")
 
 	// ErrContainerUnhealthy returned if controller detects the health check failure
-	ErrContainerUnhealthy = fmt.Errorf("dockerexec: unhealthy container")
+	ErrContainerUnhealthy = errors.New("dockerexec: unhealthy container")
 )

--- a/daemon/cluster/executor/container/health_test.go
+++ b/daemon/cluster/executor/container/health_test.go
@@ -87,7 +87,7 @@ func TestHealthStates(t *testing.T) {
 			}
 		case <-timer.C:
 			if expectedErr != nil {
-				t.Fatalf("time limit exceeded, didn't get expected error")
+				t.Fatal("time limit exceeded, didn't get expected error")
 			}
 		}
 	}

--- a/daemon/cluster/executor/container/validate.go
+++ b/daemon/cluster/executor/container/validate.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,7 +34,7 @@ func validateMounts(mounts []api.Mount) error {
 			}
 		case api.MountTypeTmpfs:
 			if mount.Source != "" {
-				return fmt.Errorf("invalid tmpfs source, source must be empty")
+				return errors.New("invalid tmpfs source, source must be empty")
 			}
 		default:
 			return fmt.Errorf("invalid mount type: %s", mount.Type)

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -229,7 +229,7 @@ func parseClusterAdvertiseSettings(clusterStore, clusterAdvertise string) (strin
 		return "", errDiscoveryDisabled
 	}
 	if clusterStore == "" {
-		return "", fmt.Errorf("invalid cluster configuration. --cluster-advertise must be accompanied by --cluster-store configuration")
+		return "", errors.New("invalid cluster configuration. --cluster-advertise must be accompanied by --cluster-store configuration")
 	}
 
 	advertise, err := discovery.ParseAdvertise(clusterAdvertise)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -66,7 +66,7 @@ var (
 	// DefaultInitBinary is the name of the default init binary
 	DefaultInitBinary = "docker-init"
 
-	errSystemNotSupported = fmt.Errorf("The Docker daemon is not supported on this platform.")
+	errSystemNotSupported = errors.New("The Docker daemon is not supported on this platform.")
 )
 
 // Daemon holds information about the Docker daemon.
@@ -649,7 +649,7 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 	// Check if Devices cgroup is mounted, it is hard requirement for container security,
 	// on Linux.
 	if runtime.GOOS == "linux" && !sysInfo.CgroupDevicesEnabled {
-		return nil, fmt.Errorf("Devices cgroup isn't mounted")
+		return nil, errors.New("Devices cgroup isn't mounted")
 	}
 
 	d.ID = trustKey.PublicKey().KeyID()
@@ -722,7 +722,7 @@ func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 		logrus.Debugf("Found container %s is paused, sending SIGTERM before unpausing it", c.ID)
 		sig, ok := signal.SignalMap["TERM"]
 		if !ok {
-			return fmt.Errorf("System does not support SIGTERM")
+			return errors.New("System does not support SIGTERM")
 		}
 		if err := daemon.kill(c, int(sig)); err != nil {
 			return fmt.Errorf("sending SIGTERM to container %s with error: %v", c.ID, err)
@@ -734,7 +734,7 @@ func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 			logrus.Debugf("container %s failed to exit in %d second of SIGTERM, sending SIGKILL to force", c.ID, stopTimeout)
 			sig, ok := signal.SignalMap["KILL"]
 			if !ok {
-				return fmt.Errorf("System does not support SIGKILL")
+				return errors.New("System does not support SIGKILL")
 			}
 			if err := daemon.kill(c, int(sig)); err != nil {
 				logrus.Errorf("Failed to SIGKILL container %s", c.ID)
@@ -954,7 +954,7 @@ func (daemon *Daemon) configureVolumes(rootUID, rootGID int) (*store.VolumeStore
 	volumedrivers.RegisterPluginGetter(daemon.PluginStore)
 
 	if !volumedrivers.Register(volumesDriver, volumesDriver.Name()) {
-		return nil, fmt.Errorf("local volume driver could not be registered")
+		return nil, errors.New("local volume driver could not be registered")
 	}
 	return store.New(daemon.configStore.Root)
 }
@@ -1194,7 +1194,7 @@ func (daemon *Daemon) networkOptions(dconfig *Config, pg plugingetter.PluginGett
 	if strings.TrimSpace(dconfig.ClusterStore) != "" {
 		kv := strings.Split(dconfig.ClusterStore, "://")
 		if len(kv) != 2 {
-			return nil, fmt.Errorf("kv store daemon config must be of the form KV-PROVIDER://KV-URL")
+			return nil, errors.New("kv store daemon config must be of the form KV-PROVIDER://KV-URL")
 		}
 		options = append(options, nwconfig.OptionKVProvider(kv[0]))
 		options = append(options, nwconfig.OptionKVProviderURL(kv[1]))

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -1,7 +1,7 @@
 package daemon
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"strconv"
 	"time"
@@ -22,7 +22,7 @@ import (
 // configured with the given struct.
 func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, config *backend.ContainerLogsConfig, started chan struct{}) error {
 	if !(config.ShowStdout || config.ShowStderr) {
-		return fmt.Errorf("You must choose at least one stream")
+		return errors.New("You must choose at least one stream")
 	}
 	container, err := daemon.GetContainer(containerName)
 	if err != nil {

--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -19,7 +20,7 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 	)
 
 	if oldName == "" || newName == "" {
-		return fmt.Errorf("Neither old nor new names may be empty")
+		return errors.New("Neither old nor new names may be empty")
 	}
 
 	if newName[0] != '/' {
@@ -35,7 +36,7 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 	oldIsAnonymousEndpoint := container.NetworkSettings.IsAnonymousEndpoint
 
 	if oldName == newName {
-		return fmt.Errorf("Renaming a container with the same name as its current name")
+		return errors.New("Renaming a container with the same name as its current name")
 	}
 
 	container.Lock()

--- a/daemon/search_test.go
+++ b/daemon/search_test.go
@@ -1,7 +1,7 @@
 package daemon
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 	"testing"
 
@@ -23,7 +23,7 @@ type FakeService struct {
 
 func (s *FakeService) Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registrytypes.SearchResults, error) {
 	if s.shouldReturnError {
-		return nil, fmt.Errorf("Search unknown error")
+		return nil, errors.New("Search unknown error")
 	}
 	return &registrytypes.SearchResults{
 		Query:      s.term,

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -1,6 +1,7 @@
 package distribution
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/Sirupsen/logrus"
@@ -172,7 +173,7 @@ func writeStatus(requestedTag string, out progress.Output, layersDownloaded bool
 // ValidateRepoName validates the name of a repository.
 func ValidateRepoName(name string) error {
 	if name == "" {
-		return fmt.Errorf("Repository name can't be empty")
+		return errors.New("Repository name can't be empty")
 	}
 	if name == api.NoBaseImageSpecifier {
 		return fmt.Errorf("'%s' is a reserved name", api.NoBaseImageSpecifier)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Replace printf or errorf with print, errors.New if the format without arguments. Such as:
```
fmt.Errorf("abc")
```
I think we can use ```errors.New("abc")``` directly.

**- How I did it**

The ```fmt.Errorf ``` calls ```errors.New``` in internal, so if it's unnecessary to format a string, I just replace it with ```errors.New```.
The ```fmt.Fprintf``` if no argument used to format, I just replace it with ```fmt.Fprint```.
The ```t.Fatalf``` if no argument used to format, I just replace it with ```t.Fatal```.

**- How to verify it**
Unit test.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
👍 
