### PR TITLE
allow replacing httpredir mirror for arm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,14 @@
 
 FROM debian:jessie
 
+# allow replacing httpredir or deb mirror
+ARG APT_MIRROR=deb.debian.org
+RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
+
 # Add zfs ppa
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys E871F18B51E0147C77796AC81196BA81F6B0FC61 \
 	|| apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys E871F18B51E0147C77796AC81196BA81F6B0FC61
 RUN echo deb http://ppa.launchpad.net/zfs-native/stable/ubuntu trusty main > /etc/apt/sources.list.d/zfs.list
-
-
-# Allow replacing httpredir mirror
-ARG APT_MIRROR=httpredir.debian.org
-RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
 
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -17,6 +17,10 @@
 
 FROM armhf/debian:jessie
 
+# allow replacing httpredir or deb mirror
+ARG APT_MIRROR=deb.debian.org
+RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
+
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \
 	apparmor \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -7,6 +7,10 @@
 
 FROM debian:jessie
 
+# allow replacing httpredir or deb mirror
+ARG APT_MIRROR=deb.debian.org
+RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
+
 # Compile and runtime deps
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#build-dependencies
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Allow replacing of `httpredir.debian.org` in `/etc/apt/sources.lists` with a user-specified mirror hostname for building the `docker-dev` image on arm.

**- How I did it**

With a docker `--build-arg` arg that will `sed` the hostname, same way [Dockerfile](https://github.com/docker/docker/blob/7d1a72a2866aedbc7492a0cfc5cd4e13646322fe/Dockerfile#L34-L36) does it.

**- How to verify it**

```
$ make DOCKER_BUILD_ARGS=--build-arg=APT_MIRROR=ftp.fr.debian.org build
...
docker build  --build-arg=APT_MIRROR=ftp.fr.debian.org -t "docker-dev:apt-mirror-arm" -f "Dockerfile.armhf" .
Sending build context to Docker daemon 159.8 MB
Step 1 : FROM armhf/debian:jessie
 ---> 3ea48732e06c
Step 2 : ARG APT_MIRROR=httpredir.debian.org
 ---> Using cache
 ---> 2ca315200bd0
Step 3 : RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
 ---> Using cache
 ---> fc188f8a4ad0
Step 4 : RUN apt-get update && apt-get install -y       apparmor        aufs-tools      automake        bash-completion         btrfs-tools      build-essential         createrepo      curl    cmake   dpkg-sig        git     iptables        jq      net-tools       libapparmor-dev  libcap-dev      libltdl-dev     libsqlite3-dev  libsystemd-journal-dev  libtool         mercurial       pkg-config      python-dev       python-mock     python-pip      python-websocket        xfsprogs        tar     vim-common      --no-install-recommends         && pip install awscli==1.10.15
 ---> Running in 594ab4f79868
Ign http://ftp.fr.debian.org jessie InRelease
Get:1 http://ftp.fr.debian.org jessie-updates InRelease [145 kB]
Get:2 http://security.debian.org jessie/updates InRelease [63.1 kB]
Get:3 http://ftp.fr.debian.org jessie Release.gpg [2373 B]
Get:4 http://ftp.fr.debian.org jessie Release [148 kB]
Get:5 http://ftp.fr.debian.org jessie-updates/main armhf Packages [17.5 kB]
Get:6 http://security.debian.org jessie/updates/main armhf Packages [396 kB]
Get:7 http://ftp.fr.debian.org jessie/main armhf Packages [8864 kB]
Fetched 9636 kB in 11s (834 kB/s)
...
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

* apt repo mirror override for building development image

**- A picture of a cute animal (not mandatory but encouraged)**

🐝 
