### PR TITLE
Bugfix: set cli.manualOverride when env var not empty

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -122,7 +122,7 @@ func NewEnvClient() (*Client, error) {
 	if err != nil {
 		return cli, err
 	}
-	if version != "" {
+	if os.Getenv("DOCKER_API_VERSION") != "" {
 		cli.manualOverride = true
 	}
 	return cli, nil


### PR DESCRIPTION
<del>In function `NewEnvClient`, the `cli.manualOverride` will be set to true
always which is wrong, to fix it we should let `manualOverride` set to
true only if `os.Getenv("DOCKER_API_VERSION")` isn't empty.

<del>One more step forward, even user set `os.Getenv("DOCKER_API_VERSION")`,
we should still allow updating client API version, in case that user set
a unreasonable version number.

If env var "DOCKER_API_VERSION" is specified by user, we'll set
`cli.manualOverride`, before this, this field is always true due to
wrong logic.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>