### PR TITLE
judge manager if locked before parsing key

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -592,6 +592,11 @@ func (c *Cluster) UnlockSwarm(req types.UnlockRequest) error {
 			return err
 		}
 	}
+
+	if c.node != nil || c.locked != true {
+		c.RUnlock()
+		return errors.New("swarm is not locked")
+	}
 	c.RUnlock()
 
 	key, err := encryption.ParseHumanReadableKey(req.UnlockKey)
@@ -600,11 +605,6 @@ func (c *Cluster) UnlockSwarm(req types.UnlockRequest) error {
 	}
 
 	c.Lock()
-	if c.node != nil || c.locked != true {
-		c.Unlock()
-		return errors.New("swarm is not locked")
-	}
-
 	config := *c.lastNodeConfig
 	config.lockKey = key
 	n, err := c.startNewNode(config)


### PR DESCRIPTION
We have a swarm manager, now manager may not be locked, and it is just a normal manager.

When it is a normal manager which is not locked at all. If a user executes `docker swarm unlock`, I think it is better to return `swarm is not locked`, rather than parsing user-input key.

**- What I did**
1. judge manager if it is locked before parsing unlock key

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: allencloud <allen.sun@daocloud.io>