### PR TITLE
Add missing quote mark and fix grammar in inspect docs

### DIFF
--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -15,7 +15,7 @@ Return low-level information on a container, image or task
   -f, --format       Format the output using the given go template
   --help             Print usage
   -s, --size         Display total file sizes if the type is container
-                     values are "image" or "container" or "task
+                     values are "image" or "container" or "task"
   --type             Return JSON for specified type, (e.g image, container or task)
 ```
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Adds missing quotation mark in inspect documentation, leading to odd formatting.

**- How I did it**
Added the missing trailing quotation mark.

**- How to verify it**
Build docs and view formatting on leading markdown block.

**- Description for the changelog**
Inspect documentation fix.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


Signed-off-by: GuyTempleton <Guy.Templeton@skyscanner.net>