### PR TITLE
Update cli reference for docker {,stack} deploy

### DIFF
--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -19,39 +19,76 @@ advisory: "experimental"
 ```markdown
 Usage:  docker deploy [OPTIONS] STACK
 
-Create and update a stack from a Distributed Application Bundle (DAB)
+Deploy a new stack or update an existing stack
+
+Aliases:
+  deploy, up
 
 Options:
-      --file   string        Path to a Distributed Application Bundle file (Default: STACK.dab)
-      --help                 Print usage
-      --with-registry-auth   Send registry authentication details to swarm agents
+      --bundle-file string    Path to a Distributed Application Bundle file
+      --compose-file string   Path to a Compose file
+      --help                  Print usage
+      --with-registry-auth    Send registry authentication details to Swarm agents
 ```
 
-Create and update a stack from a `dab` file. This command has to be
-run targeting a manager node.
+Create and update a stack from a `compose` or a `dab` file on the swarm. This command
+has to be run targeting a manager node.
+
+## Copmose file
+
+The `deploy` command supports compose file version `3.0` and above.
 
 ```bash
-$ docker deploy vossibility-stack
+$ docker stack deploy --compose-file docker-compose.yml vossibility
+Ignoring unsupported options: links
+
+Creating network vossibility_vossibility
+Creating network vossibility_default
+Creating service vossibility_nsqd
+Creating service vossibility_logstash
+Creating service vossibility_elasticsearch
+Creating service vossibility_kibana
+Creating service vossibility_ghollector
+Creating service vossibility_lookupd
+```
+
+You can verify that the services were correctly created
+
+```
+$ docker service ls
+ID            NAME                               MODE        REPLICAS  IMAGE
+29bv0vnlm903  vossibility_lookupd                replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+4awt47624qwh  vossibility_nsqd                   replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+4tjx9biia6fs  vossibility_elasticsearch          replicated  1/1       elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
+7563uuzr9eys  vossibility_kibana                 replicated  1/1       kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
+9gc5m4met4he  vossibility_logstash               replicated  1/1       logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe
+axqh55ipl40h  vossibility_vossibility-collector  replicated  1/1       icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba
+```
+
+## DAB file
+
+```bash
+$ docker stack deploy --bundle-file vossibility-stack.dab vossibility
 Loading bundle from vossibility-stack.dab
-Creating service vossibility-stack_elasticsearch
-Creating service vossibility-stack_kibana
-Creating service vossibility-stack_logstash
-Creating service vossibility-stack_lookupd
-Creating service vossibility-stack_nsqd
-Creating service vossibility-stack_vossibility-collector
+Creating service vossibility_elasticsearch
+Creating service vossibility_kibana
+Creating service vossibility_logstash
+Creating service vossibility_lookupd
+Creating service vossibility_nsqd
+Creating service vossibility_vossibility-collector
 ```
 
 You can verify that the services were correctly created:
 
 ```bash
 $ docker service ls
-ID            NAME                                     MODE         REPLICAS    IMAGE
-29bv0vnlm903  vossibility-stack_lookupd                replicated   1/1         nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
-4awt47624qwh  vossibility-stack_nsqd                   replicated   1/1         nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
-4tjx9biia6fs  vossibility-stack_elasticsearch          replicated   1/1         elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
-7563uuzr9eys  vossibility-stack_kibana                 replicated   1/1         kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
-9gc5m4met4he  vossibility-stack_logstash               replicated   1/1         logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe
-axqh55ipl40h  vossibility-stack_vossibility-collector  replicated   1/1         icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba
+ID            NAME                               MODE        REPLICAS  IMAGE
+29bv0vnlm903  vossibility_lookupd                replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+4awt47624qwh  vossibility_nsqd                   replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+4tjx9biia6fs  vossibility_elasticsearch          replicated  1/1       elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
+7563uuzr9eys  vossibility_kibana                 replicated  1/1       kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
+9gc5m4met4he  vossibility_logstash               replicated  1/1       logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe
+axqh55ipl40h  vossibility_vossibility-collector  replicated  1/1       icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba
 ```
 
 ## Related information

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -19,42 +19,76 @@ advisory: "experimental"
 ```markdown
 Usage:  docker stack deploy [OPTIONS] STACK
 
-Create and update a stack from a Distributed Application Bundle (DAB)
+Deploy a new stack or update an existing stack
 
 Aliases:
   deploy, up
 
 Options:
-      --file   string        Path to a Distributed Application Bundle file (Default: STACK.dab)
-      --help                 Print usage
-      --with-registry-auth   Send registry authentication details to swarm agents
+      --bundle-file string    Path to a Distributed Application Bundle file
+      --compose-file string   Path to a Compose file
+      --help                  Print usage
+      --with-registry-auth    Send registry authentication details to Swarm agents
 ```
 
-Create and update a stack from a `dab` file on the swarm. This command
+Create and update a stack from a `compose` or a `dab` file on the swarm. This command
 has to be run targeting a manager node.
 
+## Copmose file
+
+The `deploy` command supports compose file version `3.0` and above."
+
 ```bash
-$ docker stack deploy vossibility-stack
+$ docker stack deploy --compose-file docker-compose.yml vossibility
+Ignoring unsupported options: links
+
+Creating network vossibility_vossibility
+Creating network vossibility_default
+Creating service vossibility_nsqd
+Creating service vossibility_logstash
+Creating service vossibility_elasticsearch
+Creating service vossibility_kibana
+Creating service vossibility_ghollector
+Creating service vossibility_lookupd
+```
+
+You can verify that the services were correctly created
+
+```
+$ docker service ls
+ID            NAME                               MODE        REPLICAS  IMAGE
+29bv0vnlm903  vossibility_lookupd                replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+4awt47624qwh  vossibility_nsqd                   replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+4tjx9biia6fs  vossibility_elasticsearch          replicated  1/1       elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
+7563uuzr9eys  vossibility_kibana                 replicated  1/1       kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
+9gc5m4met4he  vossibility_logstash               replicated  1/1       logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe
+axqh55ipl40h  vossibility_vossibility-collector  replicated  1/1       icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba
+```
+
+## DAB file
+
+```bash
+$ docker stack deploy --bundle-file vossibility-stack.dab vossibility
 Loading bundle from vossibility-stack.dab
-Creating service vossibility-stack_elasticsearch
-Creating service vossibility-stack_kibana
-Creating service vossibility-stack_logstash
-Creating service vossibility-stack_lookupd
-Creating service vossibility-stack_nsqd
-Creating service vossibility-stack_vossibility-collector
+Creating service vossibility_elasticsearch
+Creating service vossibility_kibana
+Creating service vossibility_logstash
+Creating service vossibility_lookupd
+Creating service vossibility_nsqd
+Creating service vossibility_vossibility-collector
 ```
 
 You can verify that the services were correctly created:
 
 ```bash
 $ docker service ls
-ID            NAME                                     MODE        REPLICAS  IMAGE
-29bv0vnlm903  vossibility-stack_lookupd                replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
-4awt47624qwh  vossibility-stack_nsqd                   replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
-4tjx9biia6fs  vossibility-stack_elasticsearch          replicated  1/1       elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
-7563uuzr9eys  vossibility-stack_kibana                 replicated  1/1       kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
-9gc5m4met4he  vossibility-stack_logstash               replicated  1/1       logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe
-axqh55ipl40h  vossibility-stack_vossibility-collector  replicated  1/1       icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba
+ID            NAME                               MODE        REPLICAS  IMAGE
+29bv0vnlm903  vossibility_lookupd                replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+4awt47624qwh  vossibility_nsqd                   replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+4tjx9biia6fs  vossibility_elasticsearch          replicated  1/1       elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
+7563uuzr9eys  vossibility_kibana                 replicated  1/1       kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
+9gc5m4met4he  vossibility_logstash               replicated  1/1       logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe
+axqh55ipl40h  vossibility_vossibility-collector  replicated  1/1       icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba
 ```
 
 ## Related information


### PR DESCRIPTION
First part of documentation *compose to swarm* : updating the commandline reference docs for `docker deploy` and `docker stack deploy`.

I wanted to link a ref to the `3.0` version but it's not there yet. @thaJeztah suggested to "describe that 3.0 is mostly backward compatible with 2.x, but does not support certain features (short list of things not supported)", might be the *best effort* for now :angel: 

/cc @thaJeztah @mstanleyjones @dnephin @aanand 

:frog: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>