### PR TITLE
fix doc about service create in docker_remote_api_v1.24.md

### DIFF
--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -4562,14 +4562,14 @@ image](#create-an-image) section for more details.
         "Placement": {},
         "Resources": {
           "Limits": {
-            "MemoryBytes": 104857600.0
+            "MemoryBytes": 104857600
           },
           "Reservations": {
           }
         },
         "RestartPolicy": {
           "Condition": "on-failure",
-          "Delay": 10000000000.0,
+          "Delay": 10000000000,
           "MaxAttempts": 10
         }
       },
@@ -4579,7 +4579,7 @@ image](#create-an-image) section for more details.
         }
       },
       "UpdateConfig": {
-        "Delay": 30000000000.0,
+        "Delay": 30000000000,
         "Parallelism": 2,
         "FailureAction": "pause"
       },


### PR DESCRIPTION
Hi,  
    This pr delete three columns in docker_remote_api_v1.24.md , because when I test service create request Example  with the following code by Postman ( A tool for network port debugging )

```
POST /v1.25/services/create 
Content-Type: application/json
    {
      "Name": "web",
      "TaskTemplate": {
        "ContainerSpec": {
          "Image": "nginx:alpine",
          "Mounts": [
            {
              "ReadOnly": true,
              "Source": "web-data",
              "Target": "/usr/share/nginx/html",
              "Type": "volume",
              "VolumeOptions": {
                "DriverConfig": {
                },
                "Labels": {
                  "com.example.something": "something-value"
                }
              }
            }
          ],
          "User": "33"
        },
        "LogDriver": {
          "Name": "json-file",
          "Options": {
            "max-file": "3",
            "max-size": "10M"
          }
        },
        "Placement": {},
        "Resources": {
          "Limits": {
            "MemoryBytes": 104857600.0
          },
          "Reservations": {
          }
        },
        "RestartPolicy": {
          "Condition": "on-failure",
          "Delay": 10000000000.0,
          "MaxAttempts": 10
        }
      },
      "Mode": {
        "Replicated": {
          "Replicas": 4
        }
      },
      "UpdateConfig": {
        "Delay": 30000000000.0,
        "Parallelism": 2,
        "FailureAction": "pause"
      },
      "EndpointSpec": {
        "Ports": [
          {
            "Protocol": "tcp",
            "PublishedPort": 8080,
            "TargetPort": 80
          }
        ]
      },
      "Labels": {
        "foo": "bar"
      }
    }
```
The response returns : 
```
500 internal server error
{
"message": "json: cannot unmarshal number 104857600.0 into Go value of type int64"
}
```
so I delete  column **"MemoryBytes": 104857600.0,**   , and try again. The response returns:

```
500 internal server error
{
"message": "json: cannot unmarshal number 10000000000.0 into Go value of type time.Duration"
}
```
Then I delete column  **"Delay": 10000000000.0,**    , it returns

```
500 internal server error
{
  "message": "json: cannot unmarshal number 30000000000.0 into Go value of type time.Duration"
}
```
After I delete column **"Delay": 30000000000.0,**   ,  the response returns the container ID :

```
201 Created
{
  "ID": "dhpov4rodg4har3fhmmc3bjdf"
}
```
I test the command with API version 1.25 and API version 1.26  using it's  individual  request Example,  the response couldn't return the container ID until I delete the following columns
 **"MemoryBytes": 104857600.0**
 **"MemoryBytes": 104857600.0**
 **"MemoryBytes": 104857600.0**




**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**



Signed-off-by: erxian <evelynhsu21@gmail.com>