### PR TITLE
bugfix: incorrect ErrConnectFailed Comparison

### DIFF
--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -170,7 +170,7 @@ func getExecExitCode(ctx context.Context, client apiclient.ContainerAPIClient, e
 	resp, err := client.ContainerExecInspect(ctx, execID)
 	if err != nil {
 		// If we can't connect, then the daemon probably died.
-		if err != apiclient.ErrConnectionFailed {
+		if !apiclient.IsErrConnectionFailed(err) {
 			return false, -1, err
 		}
 		return false, -1, nil

--- a/cli/command/container/utils.go
+++ b/cli/command/container/utils.go
@@ -91,7 +91,7 @@ func getExitCode(ctx context.Context, dockerCli *command.DockerCli, containerID 
 	c, err := dockerCli.Client().ContainerInspect(ctx, containerID)
 	if err != nil {
 		// If we can't connect, then the daemon probably died.
-		if err != clientapi.ErrConnectionFailed {
+		if !clientapi.IsErrConnectionFailed(err) {
 			return false, -1, err
 		}
 		return false, -1, nil

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,18 +1,34 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/docker/docker/api/types/versions"
+	"github.com/pkg/errors"
 )
 
-// ErrConnectionFailed is an error raised when the connection between the client and the server failed.
-var ErrConnectionFailed = errors.New("Cannot connect to the Docker daemon. Is the docker daemon running on this host?")
+// errConnectionFailed implements an error returned when connection failed.
+type errConnectionFailed struct {
+	host string
+}
+
+// Error returns a string representation of an errConnectionFailed
+func (err errConnectionFailed) Error() string {
+	if err.host == "" {
+		return "Cannot connect to the Docker daemon. Is the docker daemon running on this host?"
+	}
+	return fmt.Sprintf("Cannot connect to the Docker daemon at %s. Is the docker daemon running?", err.host)
+}
+
+// IsErrConnectionFailed returns true if the error is caused by connection failed.
+func IsErrConnectionFailed(err error) bool {
+	_, ok := errors.Cause(err).(errConnectionFailed)
+	return ok
+}
 
 // ErrorConnectionFailed returns an error with host in the error message when connection to docker daemon failed.
 func ErrorConnectionFailed(host string) error {
-	return fmt.Errorf("Cannot connect to the Docker daemon at %s. Is the docker daemon running?", host)
+	return errConnectionFailed{host: host}
 }
 
 type notFound interface {


### PR DESCRIPTION
I found that there is a minimal bug about how docker client determine whether the connection has lost. 

```go
var ErrConnectionFailed = errors.New("Cannot connect to the Docker daemon. Is the docker daemon running on this host?")
```
client/errors.go

```go
func getExecExitCode(ctx context.Context, client apiclient.ContainerAPIClient, execID string) (bool, int, error) {
	resp, err := client.ContainerExecInspect(ctx, execID)
	if err != nil {
		// If we can't connect, then the daemon probably died.
		if !apiclient.IsErrConnectionFailed(err) {
			return false, -1, err
		}
		return false, -1, nil
	}

	return resp.Running, resp.ExitCode, nil
}
```
cli/command/container/exec.go

In the code, ```err != apiclient.ErrConnectionFailed``` should always be true. Because ```ErrConnectionFailed``` is a object invoked by ```fmt.Errorf```. and ```fmt.Errorf``` can't invoke two identical object in different place.
In another word, ```return false, -1, nil``` in 8th line should never be run ever.


**- What I did**

1. create the type called ```errConnectionFailed``` and a function called ```IsErrConnectionFailed``` so that it can be determined correctly. Exactly like how other error do in ```client/errors.go```

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Signed-off-by: Reficul <xuzhenglun@gmail.com>