### PR TITLE
Show error message if no secret input is provided

### DIFF
--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -43,6 +43,10 @@ func runSecretCreate(dockerCli *command.DockerCli, options createOptions) error 
 	client := dockerCli.Client()
 	ctx := context.Background()
 
+	if dockerCli.In().IsTerminal() {
+		return fmt.Errorf("No input provided on STDIN")
+	}
+
 	secretData, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
 		return fmt.Errorf("Error reading content from STDIN: %v", err)


### PR DESCRIPTION
as discussed in https://github.com/docker/docker/pull/28629#issuecomment-261926844

**- What I did**

The `docker create secret` command expects data
to be provided through stdin.

If no data is provided, the command hangs, which
can be confusing for users.

This adds a check if data is provided, and prints
an error message if not.

Before this change;

    $ docker secret create foo
    > <hangs>

After this chance;

    $ docker secret create foo
    No input provided on STDIN


**- Description for the changelog**

Print an error message if no data is provided for `docker secret create`
