### PR TITLE
Do not panic if network is nil

### DIFF
--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -252,9 +252,13 @@ func convertServiceNetworks(
 
 	nets := []swarm.NetworkAttachmentConfig{}
 	for networkName, network := range networks {
+		var aliases []string
+		if network != nil {
+			aliases = network.Aliases
+		}
 		nets = append(nets, swarm.NetworkAttachmentConfig{
 			Target:  namespace.scope(networkName),
-			Aliases: append(network.Aliases, name),
+			Aliases: append(aliases, name),
 		})
 	}
 	return nets


### PR DESCRIPTION
Fixes #28633.

network is `nil` if the following case:

```
services:
  foo:
    image: nginx
    networks:
      mynetwork:
```

It's a valid compose so we should not panic.

/cc @aanand @dnephin 

:frog: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>