### PR TITLE
Windows: Case insensitive env vars

### DIFF
--- a/runconfig/opts/opts.go
+++ b/runconfig/opts/opts.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"runtime"
 	"strings"
 
 	fopts "github.com/docker/docker/opts"
@@ -45,6 +46,12 @@ func ValidateEnv(val string) (string, error) {
 func doesEnvExist(name string) bool {
 	for _, entry := range os.Environ() {
 		parts := strings.SplitN(entry, "=", 2)
+		if runtime.GOOS == "windows" {
+			// Environment variable are case-insensitive on Windows. PaTh, path and PATH are equivalent.
+			if strings.EqualFold(parts[0], name) {
+				return true
+			}
+		}
 		if parts[0] == name {
 			return true
 		}

--- a/runconfig/opts/opts_test.go
+++ b/runconfig/opts/opts_test.go
@@ -3,6 +3,7 @@ package opts
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -49,6 +50,10 @@ func TestValidateEnv(t *testing.T) {
 		"some space":          "some space",
 		"  some space before": "  some space before",
 		"some space after  ":  "some space after  ",
+	}
+	// Environment variables are case in-sensitive on Windows
+	if runtime.GOOS == "windows" {
+		valids["PaTh"] = fmt.Sprintf("PaTh=%v", os.Getenv("PATH"))
 	}
 	for value, expected := range valids {
 		actual, err := ValidateEnv(value)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Make sure when looking for an environment variable that the check is done in a case insensitive manner on Windows where `PATH`, `pAtH`, and `path` are all equivalent.

@thaJeztah @vieux Probably should consider this for 1.13. 