### PR TITLE
Check for valid daemon in TearDownTest.

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -302,14 +302,16 @@ func (s *DockerSwarmSuite) TearDownTest(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	s.daemonsLock.Lock()
 	for _, d := range s.daemons {
-		d.Stop()
-		// raft state file is quite big (64MB) so remove it after every test
-		walDir := filepath.Join(d.root, "swarm/raft/wal")
-		if err := os.RemoveAll(walDir); err != nil {
-			c.Logf("error removing %v: %v", walDir, err)
-		}
+		if d != nil {
+			d.Stop()
+			// raft state file is quite big (64MB) so remove it after every test
+			walDir := filepath.Join(d.root, "swarm/raft/wal")
+			if err := os.RemoveAll(walDir); err != nil {
+				c.Logf("error removing %v: %v", walDir, err)
+			}
 
-		cleanupExecRoot(c, d.execRoot)
+			cleanupExecRoot(c, d.execRoot)
+		}
 	}
 	s.daemons = nil
 	s.daemonsLock.Unlock()

--- a/integration-cli/docker_cli_authz_plugin_v2_test.go
+++ b/integration-cli/docker_cli_authz_plugin_v2_test.go
@@ -36,8 +36,10 @@ func (s *DockerAuthzV2Suite) SetUpTest(c *check.C) {
 }
 
 func (s *DockerAuthzV2Suite) TearDownTest(c *check.C) {
-	s.d.Stop()
-	s.ds.TearDownTest(c)
+	if s.d != nil {
+		s.d.Stop()
+		s.ds.TearDownTest(c)
+	}
 }
 
 func (s *DockerAuthzV2Suite) TestAuthZPluginAllowNonVolumeRequest(c *check.C) {

--- a/integration-cli/docker_cli_authz_unix_test.go
+++ b/integration-cli/docker_cli_authz_unix_test.go
@@ -68,9 +68,11 @@ func (s *DockerAuthzSuite) SetUpTest(c *check.C) {
 }
 
 func (s *DockerAuthzSuite) TearDownTest(c *check.C) {
-	s.d.Stop()
-	s.ds.TearDownTest(c)
-	s.ctrl = nil
+	if s.d != nil {
+		s.d.Stop()
+		s.ds.TearDownTest(c)
+		s.ctrl = nil
+	}
 }
 
 func (s *DockerAuthzSuite) SetUpSuite(c *check.C) {

--- a/integration-cli/docker_cli_external_graphdriver_unix_test.go
+++ b/integration-cli/docker_cli_external_graphdriver_unix_test.go
@@ -55,8 +55,10 @@ func (s *DockerExternalGraphdriverSuite) SetUpTest(c *check.C) {
 }
 
 func (s *DockerExternalGraphdriverSuite) TearDownTest(c *check.C) {
-	s.d.Stop()
-	s.ds.TearDownTest(c)
+	if s.d != nil {
+		s.d.Stop()
+		s.ds.TearDownTest(c)
+	}
 }
 
 func (s *DockerExternalGraphdriverSuite) SetUpSuite(c *check.C) {

--- a/integration-cli/docker_cli_external_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_unix_test.go
@@ -54,8 +54,10 @@ func (s *DockerExternalVolumeSuite) SetUpTest(c *check.C) {
 }
 
 func (s *DockerExternalVolumeSuite) TearDownTest(c *check.C) {
-	s.d.Stop()
-	s.ds.TearDownTest(c)
+	if s.d != nil {
+		s.d.Stop()
+		s.ds.TearDownTest(c)
+	}
 }
 
 func (s *DockerExternalVolumeSuite) SetUpSuite(c *check.C) {

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -51,8 +51,10 @@ func (s *DockerNetworkSuite) SetUpTest(c *check.C) {
 }
 
 func (s *DockerNetworkSuite) TearDownTest(c *check.C) {
-	s.d.Stop()
-	s.ds.TearDownTest(c)
+	if s.d != nil {
+		s.d.Stop()
+		s.ds.TearDownTest(c)
+	}
 }
 
 func (s *DockerNetworkSuite) SetUpSuite(c *check.C) {


### PR DESCRIPTION
SetupTest could fail creating a Daemon object (eg, out of space when
creating daemon root dir). In such a case, TearDownTest fails when
accessing the daemon object. This commit adds the required nil check.

Signed-off-by: Anusha Ragunathan <anusha@docker.com>