### PR TITLE
Use CMD instead of CMD-SHELL for --healthcheck-cmd

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -369,7 +369,7 @@ func (opts *healthCheckOptions) toHealthConfig() (*container.HealthConfig, error
 	} else if haveHealthSettings {
 		var test []string
 		if opts.cmd != "" {
-			test = []string{"CMD-SHELL", opts.cmd}
+			test = []string{"CMD", opts.cmd}
 		}
 		var interval, timeout time.Duration
 		if ptr := opts.interval.Value(); ptr != nil {

--- a/cli/command/service/opts_test.go
+++ b/cli/command/service/opts_test.go
@@ -79,7 +79,7 @@ func TestHealthCheckOptionsToHealthConfig(t *testing.T) {
 	config, err := opt.toHealthConfig()
 	assert.NilError(t, err)
 	assert.Equal(t, reflect.DeepEqual(config, &container.HealthConfig{
-		Test:     []string{"CMD-SHELL", "curl"},
+		Test:     []string{"CMD", "curl"},
 		Interval: time.Second,
 		Timeout:  time.Second,
 		Retries:  10,

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -846,7 +846,7 @@ func updateHealthcheck(flags *pflag.FlagSet, containerSpec *swarm.ContainerSpec)
 	if flags.Changed(flagHealthCmd) {
 		cmd, _ := flags.GetString(flagHealthCmd)
 		if cmd != "" {
-			containerSpec.Healthcheck.Test = []string{"CMD-SHELL", cmd}
+			containerSpec.Healthcheck.Test = []string{"CMD", cmd}
 		} else {
 			containerSpec.Healthcheck.Test = nil
 		}

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -266,7 +266,7 @@ func TestUpdateHealthcheckTable(t *testing.T) {
 		{
 			flags:    [][2]string{{"health-cmd", "cmd1"}},
 			initial:  &container.HealthConfig{Test: []string{"NONE"}},
-			expected: &container.HealthConfig{Test: []string{"CMD-SHELL", "cmd1"}},
+			expected: &container.HealthConfig{Test: []string{"CMD", "cmd1"}},
 		},
 		{
 			flags:    [][2]string{{"health-retries", "10"}},

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -505,7 +505,7 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 	} else if haveHealthSettings {
 		var probe strslice.StrSlice
 		if copts.healthCmd != "" {
-			args := []string{"CMD-SHELL", copts.healthCmd}
+			args := []string{"CMD", copts.healthCmd}
 			probe = strslice.StrSlice(args)
 		}
 		if copts.healthInterval < 0 {

--- a/runconfig/opts/parse_test.go
+++ b/runconfig/opts/parse_test.go
@@ -609,7 +609,7 @@ func TestParseHealth(t *testing.T) {
 	}
 
 	health = checkOk("--health-cmd=/check.sh -q", "img", "cmd")
-	if len(health.Test) != 2 || health.Test[0] != "CMD-SHELL" || health.Test[1] != "/check.sh -q" {
+	if len(health.Test) != 2 || health.Test[0] != "CMD" || health.Test[1] != "/check.sh -q" {
 		t.Fatalf("--health-cmd: got %#v", health.Test)
 	}
 	if health.Timeout != 0 {


### PR DESCRIPTION
Using `CMD-SHELL` will not work on any image that do not ship with a
shell (`/bin/sh`) and/or that do not define a default shell using
`SHELL` in `Dockerfile`.

This changes that so it uses `CMD` instead. It should act the same for
most of the case. And if a shell is really needed, it can be passed with
the command.

Closes #28385

/cc @thaJeztah @talex5 @justincormack @dnephin @cpuguy83 @vieux 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>