### PR TITLE
Fix race on sending stdin close event

### DIFF
--- a/libcontainerd/container_unix.go
+++ b/libcontainerd/container_unix.go
@@ -118,10 +118,14 @@ func (ctr *container) start(checkpoint string, checkpointDir string, attachStdio
 			go func() {
 				select {
 				case <-ready:
+				case <-ctx.Done():
+				}
+				select {
+				case <-ready:
 					if err := ctr.sendCloseStdin(); err != nil {
 						logrus.Warnf("failed to close stdin: %+v", err)
 					}
-				case <-ctx.Done():
+				default:
 				}
 			}()
 		})


### PR DESCRIPTION
fixes #28658

Close event could have been ignored when it happens late and both `ready` and `ctx.Done` channels are closed.

@cpuguy83 @justincormack 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>