### PR TITLE
Mention additional dependencies of Docker daemon at runtime

### DIFF
--- a/project/PACKAGERS.md
+++ b/project/PACKAGERS.md
@@ -243,6 +243,8 @@ installed and available at runtime:
 * iptables version 1.4 or later
 * procps (or similar provider of a "ps" executable)
 * e2fsprogs version 1.4.12 or later (in use: mkfs.ext4, tune2fs)
+* git version 1.7 or later (and ssh client this needs)
+* modprobe
 * xfsprogs (in use: mkfs.xfs)
 * XZ Utils version 4.9 or later
 * a [properly


### PR DESCRIPTION
- git is used by COPY in Dockerfiles
- ssh client is used by git
- modprobe is called by docker if modules are missing

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![muntjac](https://cloud.githubusercontent.com/assets/482364/20506152/dca62188-b049-11e6-8cdb-7a0409dbfbf9.jpg)
