### PR TITLE
repeated volume create information

### DIFF
--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -255,6 +255,9 @@ func (s *VolumeStore) CreateWithRef(name, driverName, ref string, opts, labels m
 
 	v, err := s.create(name, driverName, opts, labels)
 	if err != nil {
+		if _, ok := err.(*OpErr); ok {
+			return nil, err
+		}
 		return nil, &OpErr{Err: err, Name: name, Op: "create"}
 	}
 


### PR DESCRIPTION
**- when I created a volume with '-d' parameter to assign a driver**

**- I ran 'docker volume create -d bzk' then return error information: 
'Error response from daemon: 
create f8677134320e374273f0526b63279226448f2a681c3c33712f92d86622bd0841: 
create f8677134320e374273f0526b63279226448f2a681c3c33712f92d86622bd0841: 
Error looking up volume plugin bzk: 
legacy plugin: plugin not found' 
I think there is two create information is repeated and unnecessary**

**- I found the function which return the second 'create' information is 'CreateDriver()' then I modified 'create' to 'create driver'
I ran 'docker volume create -d bzk' then return error information:
'Error response from daemon: 
create 2094054c1a19c508267f2eeb2f97ff48b20214b40a501461fe0a614bd89b2f16: 
create driver 2094054c1a19c508267f2eeb2f97ff48b20214b40a501461fe0a614bd89b2f16: 
Error looking up volume plugin bzk: 
legacy plugin: plugin not found'
I think this is more clearer and more exacter then before 
otherWise I do not understand why 'legacy plugin' rather than 'illegal plugin', Because  there is not volume plugin bzk
**
**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: zteBill <bi.zhenkun@zte.com.cn>