### PR TITLE
[experimental] service logs: Support no-follow mode

### DIFF
--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -237,10 +237,6 @@ func (sr *swarmRouter) getServiceLogs(ctx context.Context, w http.ResponseWriter
 		OutStream: w,
 	}
 
-	if !logsConfig.Follow {
-		return fmt.Errorf("Bad parameters: Only follow mode is currently supported")
-	}
-
 	if logsConfig.Details {
 		return fmt.Errorf("Bad parameters: details is not currently supported")
 	}

--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -1275,7 +1275,7 @@ func (c *Cluster) ServiceLogs(ctx context.Context, input string, config *backend
 			ServiceIDs: []string{service.ID},
 		},
 		Options: &swarmapi.LogSubscriptionOptions{
-			Follow: true,
+			Follow: config.Follow,
 		},
 	})
 	if err != nil {

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -419,7 +419,11 @@ func (c *containerAdapter) logs(ctx context.Context, options api.LogSubscription
 	}
 
 	chStarted := make(chan struct{})
-	go c.backend.ContainerLogs(ctx, c.container.name(), apiOptions, chStarted)
+	go func() {
+		defer writer.Close()
+		c.backend.ContainerLogs(ctx, c.container.name(), apiOptions, chStarted)
+	}()
+
 	return reader, nil
 }
 


### PR DESCRIPTION
SwarmKit now supports grabbing logs in no-follow mode.

This PR removes the check that prevented `docker service logs` from working without `-f`, fixes a bug in the SwarmKit adapter (we didn't close the stream correctly after the logs terminated) and adds a test.

/cc @vieux 