### PR TITLE
Fix secrets/create path in API docs

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -6034,13 +6034,13 @@ List secrets
 
 ### Create a secret
 
-`POST /secrets/create`
+`POST /secrets`
 
 Create a secret
 
 **Example request**:
 
-    POST /v1.25/secrets/create HTTP/1.1
+    POST /v1.25/secrets HTTP/1.1
     Content-Type: application/json
 
     {

--- a/docs/reference/api/docker_remote_api_v1.26.md
+++ b/docs/reference/api/docker_remote_api_v1.26.md
@@ -6034,13 +6034,13 @@ List secrets
 
 ### Create a secret
 
-`POST /secrets/create`
+`POST /secrets`
 
 Create a secret
 
 **Example request**:
 
-    POST /secrets/create HTTP/1.1
+    POST /secrets HTTP/1.1
     Content-Type: application/json
 
     {


### PR DESCRIPTION
The API endpoint for creating secrets was originally `POST /secrets/create` while in development but it was changed by @ehazlett  in https://github.com/docker/docker/commit/189f89301e0abfee32447f2ca23dacd3a96de06d after feedback. However the docs still describe the old path. This patch updates the API docs to align with the real path used by the API.