### PR TITLE
skip solaris and allow dry run control points

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -45,6 +45,8 @@ cd /go/src/github.com/docker/docker
 export AWS_DEFAULT_REGION
 : ${AWS_DEFAULT_REGION:=us-west-1}
 
+AWS_CLI=${AWS_CLI:-'aws'}
+
 RELEASE_BUNDLES=(
 	binary
 	cross
@@ -80,11 +82,11 @@ fi
 setup_s3() {
 	echo "Setting up S3"
 	# Try creating the bucket. Ignore errors (it might already exist).
-	aws s3 mb "s3://$BUCKET" 2>/dev/null || true
+	$AWS_CLI s3 mb "s3://$BUCKET" 2>/dev/null || true
 	# Check access to the bucket.
-	aws s3 ls "s3://$BUCKET" >/dev/null
+	$AWS_CLI s3 ls "s3://$BUCKET" >/dev/null
 	# Make the bucket accessible through website endpoints.
-	aws s3 website --index-document index --error-document error "s3://$BUCKET"
+	$AWS_CLI s3 website --index-document index --error-document error "s3://$BUCKET"
 }
 
 # write_to_s3 uploads the contents of standard input to the specified S3 url.
@@ -92,7 +94,7 @@ write_to_s3() {
 	DEST=$1
 	F=`mktemp`
 	cat > "$F"
-	aws s3 cp --acl public-read --content-type 'text/plain' "$F" "$DEST"
+	$AWS_CLI s3 cp --acl public-read --content-type 'text/plain' "$F" "$DEST"
 	rm -f "$F"
 }
 
@@ -147,12 +149,12 @@ upload_release_build() {
 	echo "Uploading $src"
 	echo "  to $dst"
 	echo
-	aws s3 cp --follow-symlinks --acl public-read "$src" "$dst"
+	$AWS_CLI s3 cp --follow-symlinks --acl public-read "$src" "$dst"
 	if [ "$latest" ]; then
 		echo
 		echo "Copying to $latest"
 		echo
-		aws s3 cp --acl public-read "$dst" "$latest"
+		$AWS_CLI s3 cp --acl public-read "$dst" "$latest"
 	fi
 
 	# get hash files too (see hash_files() in hack/make.sh)
@@ -162,12 +164,12 @@ upload_release_build() {
 			echo "Uploading $src.$hashAlgo"
 			echo "  to $dst.$hashAlgo"
 			echo
-			aws s3 cp --follow-symlinks --acl public-read --content-type='text/plain' "$src.$hashAlgo" "$dst.$hashAlgo"
+			$AWS_CLI s3 cp --follow-symlinks --acl public-read --content-type='text/plain' "$src.$hashAlgo" "$dst.$hashAlgo"
 			if [ "$latest" ]; then
 				echo
 				echo "Copying to $latest.$hashAlgo"
 				echo
-				aws s3 cp --acl public-read "$dst.$hashAlgo" "$latest.$hashAlgo"
+				$AWS_CLI s3 cp --acl public-read "$dst.$hashAlgo" "$latest.$hashAlgo"
 			fi
 		fi
 	done
@@ -204,6 +206,10 @@ release_build() {
 			;;
 		linux)
 			s3Os=Linux
+			;;
+		solaris)
+			echo skipping solaris release
+			return 0
 			;;
 		windows)
 			# this is windows use the .zip and .exe extensions for the files.
@@ -281,7 +287,7 @@ EOF
 
 	# Add redirect at /builds/info for URL-backwards-compatibility
 	rm -rf /tmp/emptyfile && touch /tmp/emptyfile
-	aws s3 cp --acl public-read --website-redirect '/builds/' --content-type='text/plain' /tmp/emptyfile "s3://$BUCKET_PATH/builds/info"
+	$AWS_CLI s3 cp --acl public-read --website-redirect '/builds/' --content-type='text/plain' /tmp/emptyfile "s3://$BUCKET_PATH/builds/info"
 
 	if [ -z "$NOLATEST" ]; then
 		echo "Advertising $VERSION on $BUCKET_PATH as most recent version"
@@ -297,7 +303,7 @@ release_index() {
 }
 
 main() {
-	build_all
+	[ "$SKIP_RELEASE_BUILD" -eq 1 ] || build_all
 	setup_s3
 	release_binaries
 	release_index


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Modified `hack/release.sh` so that it would skip over releasing solaris binaries; fixes #28326.

**- How I did it**

Added `case` statement for `solaris`. Also changed call to `aws` cli to use env variable `AWS_CLI` with default value of `aws` so that a dry-run of the script can be performed.

In addition: to skip over rebuilding the binaries again for a dry-run test, added a `SKIP_RELEASE_BUILD` env variable. When set to `1` will skip the part of rebuilding binaries. This made the script easier to verify and to re-run during deployment in case something goes wrong and it has to be re-run again.

**- How to verify it**
```
$ docker run -i -t --privileged \
  -e SKIP_RELEASE_BUILD=1 -e AWS_CLI='echo aws' \
  -e AWS_S3_BUCKET=test.docker.com -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
  -v `pwd`/bundles:/go/src/github.com/docker/docker/bundles \
  docker-dev:fix-release-sh hack/release.sh --release-regardless-of-test-failure
...
Releasing binaries
skipping solaris release
Releasing binaries
...
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

🎣 

Signed-off-by: Andrew Hsu <andrewhsu@docker.com>