### PR TITLE
move check for supported drivers to daemon

### DIFF
--- a/cli/command/container/logs.go
+++ b/cli/command/container/logs.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"fmt"
 	"io"
 
 	"golang.org/x/net/context"
@@ -12,11 +11,6 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/spf13/cobra"
 )
-
-var validDrivers = map[string]bool{
-	"json-file": true,
-	"journald":  true,
-}
 
 type logsOptions struct {
 	follow     bool
@@ -54,15 +48,6 @@ func NewLogsCommand(dockerCli *command.DockerCli) *cobra.Command {
 func runLogs(dockerCli *command.DockerCli, opts *logsOptions) error {
 	ctx := context.Background()
 
-	c, err := dockerCli.Client().ContainerInspect(ctx, opts.container)
-	if err != nil {
-		return err
-	}
-
-	if !validDrivers[c.HostConfig.LogConfig.Type] {
-		return fmt.Errorf("\"logs\" command is supported only for \"json-file\" and \"journald\" logging drivers (got: %s)", c.HostConfig.LogConfig.Type)
-	}
-
 	options := types.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
@@ -77,6 +62,11 @@ func runLogs(dockerCli *command.DockerCli, opts *logsOptions) error {
 		return err
 	}
 	defer responseBody.Close()
+
+	c, err := dockerCli.Client().ContainerInspect(ctx, opts.container)
+	if err != nil {
+		return err
+	}
 
 	if c.Config.Tty {
 		_, err = io.Copy(dockerCli.Out(), responseBody)

--- a/daemon/logger/logger.go
+++ b/daemon/logger/logger.go
@@ -18,7 +18,7 @@ import (
 )
 
 // ErrReadLogsNotSupported is returned when the logger does not support reading logs.
-var ErrReadLogsNotSupported = errors.New("configured logging reader does not support reading")
+var ErrReadLogsNotSupported = errors.New("configured logging driver does not support reading")
 
 const (
 	// TimeFormat is the time format used for timestamps sent to log readers.

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -21,13 +21,16 @@ import (
 // ContainerLogs hooks up a container's stdout and stderr streams
 // configured with the given struct.
 func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, config *backend.ContainerLogsConfig, started chan struct{}) error {
+	if !(config.ShowStdout || config.ShowStderr) {
+		return fmt.Errorf("You must choose at least one stream")
+	}
 	container, err := daemon.GetContainer(containerName)
 	if err != nil {
 		return err
 	}
 
-	if !(config.ShowStdout || config.ShowStderr) {
-		return fmt.Errorf("You must choose at least one stream")
+	if container.HostConfig.LogConfig.Type == "none" {
+		return logger.ErrReadLogsNotSupported
 	}
 
 	cLog, err := daemon.getLogger(container)

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1189,7 +1189,7 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverNoneLogsError(c *check.C) {
 
 	out, err = s.d.Cmd("logs", "test")
 	c.Assert(err, check.NotNil, check.Commentf("Logs should fail with 'none' driver"))
-	expected := `"logs" command is supported only for "json-file" and "journald" logging drivers (got: none)`
+	expected := `configured logging driver does not support reading`
 	c.Assert(out, checker.Contains, expected)
 }
 

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -310,8 +310,8 @@ func (s *DockerSuite) TestLogsFollowGoroutinesNoOutput(c *check.C) {
 func (s *DockerSuite) TestLogsCLIContainerNotFound(c *check.C) {
 	name := "testlogsnocontainer"
 	out, _, _ := dockerCmdWithError("logs", name)
-	message := fmt.Sprintf("Error: No such container: %s\n", name)
-	c.Assert(out, checker.Equals, message)
+	message := fmt.Sprintf("No such container: %s\n", name)
+	c.Assert(out, checker.Contains, message)
 }
 
 func (s *DockerSuite) TestLogsWithDetails(c *check.C) {


### PR DESCRIPTION
The `docker logs` command performed a client-side check if the container's logging driver was supported.

Now that we allow the client to connect to both "older" and "newer" daemon versions, this check is best done daemon-side.

This patch moves the check to the daemon, which should be the source of truth.
