### PR TITLE
Update secret inspect to support IDs

### DIFF
--- a/cli/command/secret/utils.go
+++ b/cli/command/secret/utils.go
@@ -18,3 +18,30 @@ func getSecretsByName(ctx context.Context, client client.APIClient, names []stri
 		Filters: args,
 	})
 }
+
+func getCliRequestedSecretIDs(ctx context.Context, client client.APIClient, names []string) ([]string, error) {
+	ids := names
+
+	// attempt to lookup secret by name
+	secrets, err := getSecretsByName(ctx, client, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	lookup := make(map[string]struct{})
+	for _, id := range ids {
+		lookup[id] = struct{}{}
+	}
+
+	if len(secrets) > 0 {
+		ids = []string{}
+
+		for _, s := range secrets {
+			if _, ok := lookup[s.Spec.Annotations.Name]; ok {
+				ids = append(ids, s.ID)
+			}
+		}
+	}
+
+	return ids, nil
+}

--- a/integration-cli/docker_cli_secret_inspect_test.go
+++ b/integration-cli/docker_cli_secret_inspect_test.go
@@ -1,0 +1,68 @@
+// +build !windows
+
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSwarmSuite) TestSecretInspect(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	testName := "test_secret"
+	id := d.createSecret(c, swarm.SecretSpec{
+		swarm.Annotations{
+			Name: testName,
+		},
+		[]byte("TESTINGDATA"),
+	})
+	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
+
+	secret := d.getSecret(c, id)
+	c.Assert(secret.Spec.Name, checker.Equals, testName)
+
+	out, err := d.Cmd("secret", "inspect", testName)
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+
+	var secrets []swarm.Secret
+	c.Assert(json.Unmarshal([]byte(out), &secrets), checker.IsNil)
+	c.Assert(secrets, checker.HasLen, 1)
+}
+
+func (s *DockerSwarmSuite) TestSecretInspectMultiple(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	testNames := []string{
+		"test0",
+		"test1",
+	}
+	for _, n := range testNames {
+		id := d.createSecret(c, swarm.SecretSpec{
+			swarm.Annotations{
+				Name: n,
+			},
+			[]byte("TESTINGDATA"),
+		})
+		c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
+
+		secret := d.getSecret(c, id)
+		c.Assert(secret.Spec.Name, checker.Equals, n)
+
+	}
+
+	args := []string{
+		"secret",
+		"inspect",
+	}
+	args = append(args, testNames...)
+	out, err := d.Cmd(args...)
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+
+	var secrets []swarm.Secret
+	c.Assert(json.Unmarshal([]byte(out), &secrets), checker.IsNil)
+	c.Assert(secrets, checker.HasLen, 2)
+}


### PR DESCRIPTION
This updates inspect to support Secret IDs and returning multiple Secrets if specified.  It also cleans up the command help text for consistency.

Refs: #28576 