### PR TITLE
Fix issue caused by duplicate `docker plugin create` with same names

### DIFF
--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -124,7 +124,7 @@ func (pm *Manager) init() error {
 				return
 			}
 
-			pm.pluginStore.Add(p)
+			pm.pluginStore.Update(p)
 			requiresManualRestore := !pm.liveRestore && p.IsEnabled()
 
 			if requiresManualRestore {


### PR DESCRIPTION
**- What I did**

This fix tries to fix the issue raised in #28684:
1. Duplicate plugin create with the same name will override the old plugin reference
2. In case an error happens in the middle of the plugin creation, plugin directories in `/var/lib/docker/plugins` are not cleaned up.

**- How I did it**

This fix update the plugin store so that `Add()` will return an error if a plugin with the same name already exist.

This fix also will clean up the directory in `/var/lib/docker/plugins` in case an error happens in the middle of the plugin creation.

**- How to verify it**

An integration test has been added to cover the changes.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![600950-cute-red-kitten](https://cloud.githubusercontent.com/assets/6932348/20535309/27ebd148-b099-11e6-822c-e6c3dcd5fb84.jpg)


This fix fixes #28684.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>