### PR TITLE
Fix network attachable option

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -172,10 +172,10 @@ func (n *networkRouter) buildNetworkResource(nw libnetwork.Network) *types.Netwo
 	r.Driver = nw.Type()
 	r.EnableIPv6 = info.IPv6Enabled()
 	r.Internal = info.Internal()
+	r.Attachable = info.Attachable()
 	r.Options = info.DriverOptions()
 	r.Containers = make(map[string]types.EndpointResource)
 	buildIpamResources(r, info)
-	r.Internal = info.Internal()
 	r.Labels = info.Labels()
 
 	peers := info.Peers()

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -571,6 +571,7 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 		Options:        na.Network.DriverState.Options,
 		Labels:         na.Network.Spec.Annotations.Labels,
 		Internal:       na.Network.Spec.Internal,
+		Attachable:     na.Network.Spec.Attachable,
 		EnableIPv6:     na.Network.Spec.Ipv6Enabled,
 		CheckDuplicate: true,
 	}

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -269,6 +269,7 @@ func (daemon *Daemon) createNetwork(create types.NetworkCreateRequest, id string
 		libnetwork.NetworkOptionEnableIPv6(create.EnableIPv6),
 		libnetwork.NetworkOptionDriverOpts(create.Options),
 		libnetwork.NetworkOptionLabels(create.Labels),
+		libnetwork.NetworkOptionAttachable(create.Attachable),
 	}
 
 	if create.IPAM != nil {

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -418,6 +418,34 @@ func (s *DockerSwarmSuite) TestSwarmContainerAttachByNetworkId(c *check.C) {
 	waitAndAssert(c, 3*time.Second, checkNetwork, checker.Not(checker.Contains), "testnet")
 }
 
+func (s *DockerSwarmSuite) TestOverlayAttachable(c *check.C) {
+	d1 := s.AddDaemon(c, true, true)
+	d2 := s.AddDaemon(c, true, false)
+
+	out, err := d1.Cmd("network", "create", "-d", "overlay", "--attachable", "ovnet")
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+
+	// validate attachable
+	out, err = d1.Cmd("network", "inspect", "--format", "{{json .Attachable}}", "ovnet")
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	c.Assert(strings.TrimSpace(out), checker.Equals, "true")
+
+	// validate containers can attache to this overlay network
+	out, err = d1.Cmd("run", "-d", "--network", "ovnet", "--name", "c1", "busybox", "top")
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	out, err = d2.Cmd("run", "-d", "--network", "ovnet", "--name", "c2", "busybox", "top")
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+
+	// redo validation, there was a bug that the value of attachable changes after
+	// containers attach to the network
+	out, err = d1.Cmd("network", "inspect", "--format", "{{json .Attachable}}", "ovnet")
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	c.Assert(strings.TrimSpace(out), checker.Equals, "true")
+	out, err = d2.Cmd("network", "inspect", "--format", "{{json .Attachable}}", "ovnet")
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	c.Assert(strings.TrimSpace(out), checker.Equals, "true")
+}
+
 func (s *DockerSwarmSuite) TestSwarmRemoveInternalNetwork(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 


### PR DESCRIPTION
Fixes #27124. 

**- What I did**

Fix network `attachable` option. 

**- How I did it**

Pass `attachable` in network resource requests. 

**- How to verify it**

```
#create network with attachable option
docker network create -d overlay --attachable rnet1
#verify attachable option
docker network inspect rnet1 | grep -i attachable
#attach a container to it
docker run -d --network rnet1 --name c1 busybox top
#verify attachable option
docker network inspect rnet1
```

cc @mavenugo @aboch. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>