### PR TITLE
28722: List of containers with networkID filter is not working

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -504,7 +504,7 @@ func includeContainerInList(container *container.Container, ctx *listContext) it
 				if nw.EndpointSettings == nil {
 					continue
 				}
-				if nw.NetworkID == value {
+				if strings.HasPrefix(nw.NetworkID, value) {
 					return networkExist
 				}
 			}

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -877,6 +877,23 @@ func (s *DockerSuite) TestPsListContainersFilterNetwork(c *check.C) {
 	containerOut = strings.TrimSpace(string(out))
 
 	c.Assert(containerOut, checker.Contains, "onbridgenetwork")
+
+	// Filter by partial network ID
+	partialnwID := string(nwID[0:4])
+
+	out, _ = dockerCmd(c, "ps", "--filter", "network="+partialnwID)
+	containerOut = strings.TrimSpace(string(out))
+
+	lines = strings.Split(containerOut, "\n")
+	// skip header
+	lines = lines[1:]
+
+	// ps output should have only one container
+	c.Assert(lines, checker.HasLen, 1)
+
+	// Making sure onbridgenetwork is on the output
+	c.Assert(containerOut, checker.Contains, "onbridgenetwork", check.Commentf("Missing the container on network\n"))
+
 }
 
 func (s *DockerSuite) TestPsByOrder(c *check.C) {


### PR DESCRIPTION
### fixes #28722 

**- What I did**
    Added support for docker ps --filter with network=Partial networkID 

**- How I did it**
    Added has_prefix to find given network ID in full network ID because while network filter full network ID is used.

**- How to verify it**
 docker ps --filter "network=<network ID in docker network ls command>"

#docker network ls
NETWORK ID          NAME                DRIVER              SCOPE
efe9b61af601        1net111             bridge              local
75ac60b510aa        bridge              bridge              local
e3ec0522da75        host                host                local
317a99c1d3f7        net1                bridge              local
28478de7a883        net11               bridge              local
13a77790105b        net111              bridge              local

#docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
ef7dd24d70de        busybox             "sh"                19 minutes ago      Up 19 minutes                           1net111
34b5e642b1ec        busybox             "sh"                19 minutes ago      Up 19 minutes                           bridge
b878a0a255d2        busybox             "sh"                7 minutes ago       Up 7 minutes                            host
a3dde8b8ff3c        busybox             "sh"                18 minutes ago      Up 18 minutes                           net1
fb060af4b644        busybox             "sh"                16 minutes ago      Up 15 minutes                           net11
b213f20a8309        busybox             "sh"                15 minutes ago      Up 15 minutes                           net111



and had running container one in each network:

Filter should work as follows:

1. Filter multiple container  whose network name is same (prefix)  
#docker ps -f network=net
a3dde8b8ff3c        busybox             "sh"                18 minutes ago      Up 18 minutes                           net1
fb060af4b644        busybox             "sh"                16 minutes ago      Up 15 minutes                           net11
d213f20a8309        busybox             "sh"                15 minutes ago      Up 15 minutes                           net111


2. filter with partial network ID 
#docker ps -f network=ef 
ef7dd24d70de        busybox             "sh"                19 minutes ago      Up 19 minutes                           1net111


3. if multiple contaner running with prefix 'eg. e' 
 #docker ps -f network=e
ef7dd24d70de        busybox             "sh"                19 minutes ago      Up 19 minutes                           1net111
b878a0a255d2        busybox             "sh"                7 minutes ago       Up 7 minutes                            host


4. if network name  and ID both have starting same prefix
#docker ps -f network=b 
 #docker ps -f network=b 
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
34b5e642b1ec        busybox             "sh"                19 minutes ago      Up 19 minutes                           bridge
d213f20a8309        busybox             "sh"                15 minutes ago      Up 15 minutes                           net111
