### PR TITLE
Document pull concurrent options

### DIFF
--- a/docs/reference/commandline/pull.md
+++ b/docs/reference/commandline/pull.md
@@ -44,6 +44,13 @@ environment variables. To set these environment variables on a host using
 `systemd`, refer to the [control and configure Docker with systemd](https://docs.docker.com/engine/admin/systemd/#http-proxy)
 for variables configuration.
 
+## Concurrent downloads
+
+By default the Docker daemon will pull three layers of an image at a time.
+If you are on a low bandwidth connection this may cause timeout issues and you may want to lower
+this via the `--max-concurrent-downloads` daemon option. See the
+[daemon documentation](dockerd.md) for more details.
+
 ## Examples
 
 ### Pull an image from Docker Hub

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -36,6 +36,13 @@ running in a terminal, terminates the push operation.
 
 Registry credentials are managed by [docker login](login.md).
 
+## Concurrent uploads
+
+By default the Docker daemon will push five layers of an image at a time.
+If you are on a low bandwidth connection this may cause timeout issues and you may want to lower
+this via the `--max-concurrent-uploads` daemon option. See the
+[daemon documentation](dockerd.md) for more details.
+
 ## Examples
 
 ### Pushing a new image to a registry


### PR DESCRIPTION
**- What I did**
Added to the `docker pull` documentation referencing the concurrent upload/download options available in the daemon.

Fixes #28724

**- Description for the changelog**
Document concurrent docker pull option


**- A picture of a cute animal (not mandatory but encouraged)**
![Documentation dog](http://cdn.lifedaily.com/wp-content/uploads/2015/07/baby-dog-reading-620x413.jpg)
