### PR TITLE
Do not display the digest or size of swarm secrets [1.13] 

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2377,11 +2377,6 @@ definitions:
         format: "dateTime"
       Spec:
         $ref: "#/definitions/ServiceSpec"
-      Digest:
-        type: "string"
-      SecretSize:
-        type: "integer"
-        format: "int64"
 paths:
   /containers/json:
     get:
@@ -7540,8 +7535,6 @@ paths:
                 UpdatedAt: "2016-11-05T01:20:17.327670065Z"
                 Spec:
                   Name: "app-dev.crt"
-                Digest: "sha256:11d7c6f38253b73e608153c9f662a191ae605e1a3d9b756b0b3426388f91d3fa"
-                SecretSize: 31
         500:
           description: "server error"
           schema:
@@ -7620,8 +7613,6 @@ paths:
               UpdatedAt: "2016-11-05T01:20:17.327670065Z"
               Spec:
                 Name: "app-dev.crt"
-              Digest: "sha256:11d7c6f38253b73e608153c9f662a191ae605e1a3d9b756b0b3426388f91d3fa"
-              SecretSize: 31
         404:
           description: "secret not found"
           schema:

--- a/api/types/swarm/secret.go
+++ b/api/types/swarm/secret.go
@@ -6,9 +6,7 @@ import "os"
 type Secret struct {
 	ID string
 	Meta
-	Spec       SecretSpec
-	Digest     string
-	SecretSize int64
+	Spec SecretSpec
 }
 
 // SecretSpec represents a secret specification from a secret in swarm

--- a/cli/command/secret/ls.go
+++ b/cli/command/secret/ls.go
@@ -50,15 +50,14 @@ func runSecretList(dockerCli *command.DockerCli, opts listOptions) error {
 			fmt.Fprintf(w, "%s\n", s.ID)
 		}
 	} else {
-		fmt.Fprintf(w, "ID\tNAME\tCREATED\tUPDATED\tSIZE")
+		fmt.Fprintf(w, "ID\tNAME\tCREATED\tUPDATED")
 		fmt.Fprintf(w, "\n")
 
 		for _, s := range secrets {
 			created := units.HumanDuration(time.Now().UTC().Sub(s.Meta.CreatedAt)) + " ago"
 			updated := units.HumanDuration(time.Now().UTC().Sub(s.Meta.UpdatedAt)) + " ago"
-			size := units.HumanSizeWithPrecision(float64(s.SecretSize), 3)
 
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", s.ID, s.Spec.Annotations.Name, created, updated, size)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", s.ID, s.Spec.Annotations.Name, created, updated)
 		}
 	}
 

--- a/daemon/cluster/convert/secret.go
+++ b/daemon/cluster/convert/secret.go
@@ -9,9 +9,7 @@ import (
 // SecretFromGRPC converts a grpc Secret to a Secret.
 func SecretFromGRPC(s *swarmapi.Secret) swarmtypes.Secret {
 	secret := swarmtypes.Secret{
-		ID:         s.ID,
-		Digest:     s.Digest,
-		SecretSize: s.SecretSize,
+		ID: s.ID,
 		Spec: swarmtypes.SecretSpec{
 			Annotations: swarmtypes.Annotations{
 				Name:   s.Spec.Annotations.Name,

--- a/docs/reference/commandline/secret_inspect.md
+++ b/docs/reference/commandline/secret_inspect.md
@@ -45,8 +45,8 @@ For example, given the following secret:
 
 ```bash
 $ docker secret ls
-ID                          NAME                    CREATED                                   UPDATED                                   SIZE
-mhv17xfe3gh6xc4rij5orpfds   secret.json             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC   1679
+ID                          NAME                    CREATED                                   UPDATED
+mhv17xfe3gh6xc4rij5orpfds   secret.json             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC
 ```
 
 ```bash
@@ -60,11 +60,8 @@ $ docker secret inspect secret.json
         "CreatedAt": "2016-10-27T23:25:43.909181089Z",
         "UpdatedAt": "2016-10-27T23:25:43.909181089Z",
         "Spec": {
-            "Name": "secret.json",
-            "Data": null
-        },
-        "Digest": "sha256:8281c6d924520986e3c6af23ed8926710a611c90339db582c2a9ac480ba622b7",
-        "SecretSize": 1679
+            "Name": "secret.json"
+        }
     }
 ]
 ```
@@ -72,12 +69,12 @@ $ docker secret inspect secret.json
 ### Formatting secret output
 
 You can use the --format option to obtain specific information about a
-secret. The following example command outputs the digest of the
+secret. The following example command outputs the creation time of the
 secret.
 
 ```bash{% raw %}
-$ docker secret inspect --format='{{.Digest}}' mhv17xfe3gh6xc4rij5orpfds
-sha256:8281c6d924520986e3c6af23ed8926710a611c90339db582c2a9ac480ba622b7
+$ docker secret inspect --format='{{.CreatedAt}}' mhv17xfe3gh6xc4rij5orpfds
+2016-10-27 23:25:43.909181089 +0000 UTC
 {% endraw %}```
 
 

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -33,8 +33,8 @@ On a manager node:
 
 ```bash
 $ docker secret ls
-ID                          NAME                    CREATED                                   UPDATED                                   SIZE
-mhv17xfe3gh6xc4rij5orpfds   secret.json             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC   1679
+ID                          NAME                    CREATED                                   UPDATED
+mhv17xfe3gh6xc4rij5orpfds   secret.json             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC
 ```
 ## Related information
 


### PR DESCRIPTION
As per https://github.com/docker/swarmkit/pull/1770, we are removing secret digest and size from a secret object, so remove those things from being displayed or converted from swarm secrets.  This should be cherry-picked into 1.13.
