### PR TITLE
Use defer to release the JSONFileLogger lock in Log

### DIFF
--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -90,6 +90,7 @@ func (l *JSONFileLogger) Log(msg *logger.Message) error {
 		return err
 	}
 	l.mu.Lock()
+	defer l.mu.Unlock()
 	logline := msg.Line
 	if !msg.Partial {
 		logline = append(msg.Line, '\n')
@@ -101,14 +102,12 @@ func (l *JSONFileLogger) Log(msg *logger.Message) error {
 		RawAttrs: l.extra,
 	}).MarshalJSONBuf(l.buf)
 	if err != nil {
-		l.mu.Unlock()
 		return err
 	}
 
 	l.buf.WriteByte('\n')
 	_, err = l.writer.Write(l.buf.Bytes())
 	l.buf.Reset()
-	l.mu.Unlock()
 
 	return err
 }


### PR DESCRIPTION
**- What I did**
Used defer to release the JSONFileLogger lock in the JSONFileLogger's Log.

**- How I did it**
Removed all the `l.mu.Unlock()` lines and added `defer l.mu.Unlock()` after `l.mu.Lock()`

**- How to verify it**
Run integration and unit tests

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
