### PR TITLE
Add `ID` field for `docker plugin ls`

### DIFF
--- a/cli/command/plugin/list.go
+++ b/cli/command/plugin/list.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/stringutils"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
@@ -43,17 +44,19 @@ func runList(dockerCli *command.DockerCli, opts listOptions) error {
 	}
 
 	w := tabwriter.NewWriter(dockerCli.Out(), 20, 1, 3, ' ', 0)
-	fmt.Fprintf(w, "NAME \tTAG \tDESCRIPTION\tENABLED")
+	fmt.Fprintf(w, "ID \tNAME \tTAG \tDESCRIPTION\tENABLED")
 	fmt.Fprintf(w, "\n")
 
 	for _, p := range plugins {
+		id := p.ID
 		desc := strings.Replace(p.Config.Description, "\n", " ", -1)
 		desc = strings.Replace(desc, "\r", " ", -1)
 		if !opts.noTrunc {
+			id = stringid.TruncateID(p.ID)
 			desc = stringutils.Ellipsis(desc, 45)
 		}
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%v\n", p.Name, p.Tag, desc, p.Enabled)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%v\n", id, p.Name, p.Tag, desc, p.Enabled)
 	}
 	w.Flush()
 	return nil

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -36,8 +36,8 @@ Example output:
 ```bash
 $ docker plugin ls
 
-NAME                  TAG                 DESCRIPTION                ENABLED
-tiborvass/no-remove   latest              A test plugin for Docker   true
+ID                  NAME                  TAG                 DESCRIPTION                ENABLED
+69553ca1d123        tiborvass/no-remove   latest              A test plugin for Docker   true
 ```
 
 ## Related information


### PR DESCRIPTION
**- What I did**

This fix tries to address the enhancement proposed in #28708 to display ID field for the output of `docker plugin ls`.

**- How I did it**

This fix add `ID` field to the output of `docker plugin ls`

Related docs has been updated.

**- How to verify it**

The following is the sample output:
```

ubuntu@ubuntu:~/docker$ docker plugin ls
ID                  NAME                  TAG                 DESCRIPTION                ENABLED
69553ca1d123        tiborvass/no-remove   latest              A test plugin for Docker   true
ubuntu@ubuntu:~/docker$ docker plugin ls --no-trunc
ID                                                                 NAME                  TAG                 DESCRIPTION                ENABLED
69553ca1d1231d7f65b67a2bad8dcb4be56c6b6c6125d16c7f28cd554e6e3c1d   tiborvass/no-remove   latest              A test plugin for Docker   true

```

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![large](https://cloud.githubusercontent.com/assets/6932348/20548817/9a23f474-b0db-11e6-8f90-d41a8caa9498.jpg)


This fix fixes #28708.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>