### PR TITLE
Improve error reporting in mkimage/debootstrap

### DIFF
--- a/contrib/mkimage/debootstrap
+++ b/contrib/mkimage/debootstrap
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
+mkimgdeb="$(basename "$0")"
+mkimg="$(dirname "$0").sh"
+
+usage() {
+	echo >&2 "usage: $mkimgdeb rootfsDir suite [debootstrap-args]"
+	echo >&2 " note: $mkimgdeb meant to be used from $mkimg"
+	exit 1
+}
+
 rootfsDir="$1"
+if [ -z "$rootfsDir" ]; then
+	echo >&2 "error: rootfsDir is missing"
+	echo >&2
+	usage
+fi
 shift
 
 # we have to do a little fancy footwork to make sure "rootfsDir" becomes the second non-option argument to debootstrap
@@ -13,10 +27,21 @@ while [ $# -gt 0 ] && [[ "$1" == -* ]]; do
 done
 
 suite="$1"
+if [ -z "$suite" ]; then
+	echo >&2 "error: suite is missing"
+	echo >&2
+	usage
+fi
 shift
 
 # get path to "chroot" in our current PATH
-chrootPath="$(type -P chroot)"
+chrootPath="$(type -P chroot || :)"
+if [ -z "$chrootPath" ]; then
+	echo >&2 "error: chroot not found. Are you root?"
+	echo >&2
+	usage
+fi
+
 rootfs_chroot() {
 	# "chroot" doesn't set PATH, so we need to set it explicitly to something our new debootstrap chroot can use appropriately!
 


### PR DESCRIPTION
i run "contrib/mkimage.sh  debootstrap" (without argument) and it failed without any info.

```
                              (_)(_)
                             /     \
                            /       |
                           /   \  * |
             ________     /    /\__/
     _      /        \   /    /
    / \    /  ____    \_/    /
   //\ \  /  /    \         /
   V  \ \/  /      \       /
       \___/        \_____/
```
(http://www.asciiworld.com/-Animals-.html)


Signed-off-by: Mathieu Parent <math.parent@gmail.com>