### PR TITLE
Move `docker stack` docs out of experimental

### DIFF
--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -2,7 +2,6 @@
 title: "stack deploy"
 description: "The stack deploy command description and usage"
 keywords: "stack, deploy, up"
-advisory: "experimental"
 ---
 
 <!-- This file is maintained within the docker/docker Github
@@ -14,7 +13,7 @@ advisory: "experimental"
      will be rejected.
 -->
 
-# stack deploy (experimental)
+# stack deploy
 
 ```markdown
 Usage:  docker stack deploy [OPTIONS] STACK

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -2,7 +2,6 @@
 title: "stack ls"
 description: "The stack ls command description and usage"
 keywords: "stack, ls"
-advisory: "experimental"
 ---
 
 <!-- This file is maintained within the docker/docker Github
@@ -14,7 +13,7 @@ advisory: "experimental"
      will be rejected.
 -->
 
-# stack ls (experimental)
+# stack ls
 
 ```markdown
 Usage:	docker stack ls

--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -2,7 +2,6 @@
 title: "stack ps"
 description: "The stack ps command description and usage"
 keywords: "stack, ps"
-advisory: "experimental"
 ---
 
 <!-- This file is maintained within the docker/docker Github
@@ -14,7 +13,7 @@ advisory: "experimental"
      will be rejected.
 -->
 
-# stack ps (experimental)
+# stack ps
 
 ```markdown
 Usage:  docker stack ps [OPTIONS] STACK

--- a/docs/reference/commandline/stack_rm.md
+++ b/docs/reference/commandline/stack_rm.md
@@ -2,7 +2,6 @@
 title: "stack rm"
 description: "The stack rm command description and usage"
 keywords: "stack, rm, remove, down"
-advisory: "experimental"
 ---
 
 <!-- This file is maintained within the docker/docker Github
@@ -14,7 +13,7 @@ advisory: "experimental"
      will be rejected.
 -->
 
-# stack rm (experimental)
+# stack rm
 
 ```markdown
 Usage:  docker stack rm STACK


### PR DESCRIPTION
`docker stack {deploy,ls,ps,rm,services}` are no longer experimental.