### PR TITLE
daemon: remove not needed unmarshal

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -4,7 +4,6 @@ package daemon
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -1281,12 +1280,6 @@ func (daemon *Daemon) setupSeccompProfile() error {
 			return fmt.Errorf("opening seccomp profile (%s) failed: %v", daemon.configStore.SeccompProfile, err)
 		}
 		daemon.seccompProfile = b
-		p := struct {
-			DefaultAction string `json:"defaultAction"`
-		}{}
-		if err := json.Unmarshal(daemon.seccompProfile, &p); err != nil {
-			return err
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
This has been left there when there was the `SeccompProfileWeak` bool to understand if the profile was a blacklist or a whitelist. This is no more needed.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>