### PR TITLE
Fixes some integration-cli on userns

### DIFF
--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -276,7 +276,7 @@ func (s *DockerSuite) TestEventsImageLoad(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsPluginOps(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, Network)
 
 	since := daemonUnixTime(c)
 

--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -143,7 +143,7 @@ func (s *DockerSuite) TestPluginInstallArgs(c *check.C) {
 }
 
 func (s *DockerSuite) TestPluginInstallImage(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, Network)
 	out, _, err := dockerCmdWithError("plugin", "install", "redis")
 	c.Assert(err, checker.NotNil)
 	c.Assert(out, checker.Contains, "content is not a plugin")

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4570,7 +4570,7 @@ func (s *DockerSuite) TestRunServicingContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunDuplicateMount(c *check.C) {
-	testRequires(c, SameHostDaemon, DaemonIsLinux)
+	testRequires(c, SameHostDaemon, DaemonIsLinux, NotUserNamespace)
 
 	tmpFile, err := ioutil.TempFile("", "touch-me")
 	c.Assert(err, checker.IsNil)

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1312,7 +1312,7 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesChroot(c *check.C) {
 }
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesMknod(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, NotUserNamespace)
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_MKNOD


### PR DESCRIPTION
Mainly adding requirements on Network or NotUserNamespace to make it pass.
This will make https://jenkins.dockerproject.org/job/Docker%20Master%20(userns)/ green again.

I wonder if it should be in the milestone (so I added it for now, feel free to remove)

/cc @estesp @justincormack @thaJeztah @tiborvass @vieux 

:frog: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>