### PR TITLE
Optimize the function 'Context.Name()' and replace 'Context.Container…

### DIFF
--- a/daemon/logger/context.go
+++ b/daemon/logger/context.go
@@ -92,7 +92,7 @@ func (ctx *Context) FullID() string {
 
 // Name returns the ContainerName without a preceding '/'.
 func (ctx *Context) Name() string {
-	return ctx.ContainerName[1:]
+	return strings.TrimPrefix(ctx.ContainerName, "/")
 }
 
 // ImageID returns the ContainerImageID shortened to 12 characters.

--- a/daemon/logger/etwlogs/etwlogs_windows.go
+++ b/daemon/logger/etwlogs/etwlogs_windows.go
@@ -61,7 +61,7 @@ func New(ctx logger.Context) (logger.Logger, error) {
 	logrus.Debugf("logging driver etwLogs configured for container: %s.", ctx.ContainerID)
 
 	return &etwLogs{
-		containerName: fixContainerName(ctx.ContainerName),
+		containerName: ctx.Name(),
 		imageName:     ctx.ContainerImageName,
 		containerID:   ctx.ContainerID,
 		imageID:       ctx.ContainerImageID,
@@ -97,14 +97,6 @@ func createLogMessage(etwLogger *etwLogs, msg *logger.Message) string {
 		etwLogger.imageID,
 		msg.Source,
 		msg.Line)
-}
-
-// fixContainerName removes the initial '/' from the container name.
-func fixContainerName(cntName string) string {
-	if len(cntName) > 0 && cntName[0] == '/' {
-		cntName = cntName[1:]
-	}
-	return cntName
 }
 
 func registerETWProvider() error {

--- a/daemon/logger/gelf/gelf.go
+++ b/daemon/logger/gelf/gelf.go
@@ -5,7 +5,6 @@
 package gelf
 
 import (
-	"bytes"
 	"compress/flate"
 	"encoding/json"
 	"fmt"
@@ -54,9 +53,6 @@ func New(ctx logger.Context) (logger.Logger, error) {
 		return nil, fmt.Errorf("gelf: cannot access hostname to set source field")
 	}
 
-	// remove trailing slash from container name
-	containerName := bytes.TrimLeft([]byte(ctx.ContainerName), "/")
-
 	// parse log tag
 	tag, err := loggerutils.ParseLogTag(ctx, loggerutils.DefaultTemplate)
 	if err != nil {
@@ -65,7 +61,7 @@ func New(ctx logger.Context) (logger.Logger, error) {
 
 	extra := map[string]interface{}{
 		"_container_id":   ctx.ContainerID,
-		"_container_name": string(containerName),
+		"_container_name": ctx.Name(),
 		"_image_id":       ctx.ContainerImageID,
 		"_image_name":     ctx.ContainerImageName,
 		"_command":        ctx.Command(),

--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -62,12 +62,6 @@ func New(ctx logger.Context) (logger.Logger, error) {
 	if !journal.Enabled() {
 		return nil, fmt.Errorf("journald is not enabled on this host")
 	}
-	// Strip a leading slash so that people can search for
-	// CONTAINER_NAME=foo rather than CONTAINER_NAME=/foo.
-	name := ctx.ContainerName
-	if name[0] == '/' {
-		name = name[1:]
-	}
 
 	// parse log tag
 	tag, err := loggerutils.ParseLogTag(ctx, loggerutils.DefaultTemplate)
@@ -78,7 +72,7 @@ func New(ctx logger.Context) (logger.Logger, error) {
 	vars := map[string]string{
 		"CONTAINER_ID":      ctx.ContainerID[:12],
 		"CONTAINER_ID_FULL": ctx.ContainerID,
-		"CONTAINER_NAME":    name,
+		"CONTAINER_NAME":    ctx.Name(),
 		"CONTAINER_TAG":     tag,
 	}
 	extraAttrs := ctx.ExtraAttributes(sanitizeKeyMod)


### PR DESCRIPTION
Optimize the function 'Context.Name()' and replace 'Context.Container Name' that need to remove slash with 'Context.Name()'.

Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>