### PR TITLE
Add V2 volume plugin to the output of `docker info`

### DIFF
--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -169,3 +169,31 @@ func (s *DockerSuite) TestPluginEnableDisableNegative(c *check.C) {
 	_, _, err = dockerCmdWithError("plugin", "remove", pName)
 	c.Assert(err, checker.IsNil)
 }
+
+func (s *DockerSuite) TestPluginInstallDaemonInfo(c *check.C) {
+	testRequires(c, DaemonIsLinux, Network)
+	out, _, err := dockerCmdWithError("plugin", "install", "--grant-all-permissions", pNameWithTag)
+	c.Assert(err, checker.IsNil)
+	c.Assert(strings.TrimSpace(out), checker.Contains, pNameWithTag)
+
+	out, _, err = dockerCmdWithError("plugin", "ls")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, pName)
+	c.Assert(out, checker.Contains, pTag)
+	c.Assert(out, checker.Contains, "true")
+
+	out, _, err = dockerCmdWithError("info", "--format", "{{json .Plugins.Volume}}")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, pNameWithTag)
+
+	_, _, err = dockerCmdWithError("plugin", "disable", pNameWithTag)
+	c.Assert(err, checker.IsNil)
+
+	out, _, err = dockerCmdWithError("plugin", "remove", pNameWithTag)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, pNameWithTag)
+
+	out, _, err = dockerCmdWithError("info", "--format", "{{json .Plugins.Volume}}")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Not(checker.Contains), pNameWithTag)
+}

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -170,6 +170,12 @@ func RemoveDriver(name string) (volume.Driver, error) {
 func GetDriverList() []string {
 	var driverList []string
 	drivers.Lock()
+	plugins, err := drivers.plugingetter.GetAllByCap(extName)
+	if err == nil {
+		for _, p := range plugins {
+			driverList = append(driverList, p.Name())
+		}
+	}
 	for driverName := range drivers.extensions {
 		driverList = append(driverList, driverName)
 	}


### PR DESCRIPTION
**- What I did**

Currently when `docker info` is invoked, the output use `GetDriverList()` which does not include V2 volume plugins. However, volumedriver's `GetAllDrivers()` already includes all drivers includes V2 volume plugins.

**- How I did it**

This fix tries to address that by including V2 volume plugins to the output of `GetDriverList()` as well.

**- How to verify it**

An integration test has been added to cover the changes.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**


![cute-baby-animal-wallpapers-dog](https://cloud.githubusercontent.com/assets/6932348/20568289/d9c329fe-b150-11e6-862b-a720ca843415.jpg)


This fix is related to the discussion in #28627.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>