### PR TITLE
Windows: dedup config.Env and uppercase

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4879,3 +4879,12 @@ func (s *delayedReader) Read([]byte) (int, error) {
 	time.Sleep(500 * time.Millisecond)
 	return 0, io.EOF
 }
+
+// Ensure environment variables on Windows are deduped for case sensitivity
+// and made upper-case.
+func (s *DockerSuite) TestRunWindowsDedupEnvVars(c *check.C) {
+	testRequires(c, DaemonIsWindows)
+	dockerCmd(c, "run", "-e", "A=a", "-e", "a=a", "-e", "Foo=bar", "-e", "foo=bar", "--name", "testrunwindowsdedupenvvars", WindowsBaseImage, "cmd", "/s", "/c", "set")
+	env := inspectField(c, "testrunwindowsdedupenvvars", "Config.Env")
+	c.Assert(env, checker.Equals, "[A=a FOO=bar]")
+}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@thaJeztah @duglin @vieux This is (I believe) the final piece in the puzzle to ensure environment variables on Windows are treated as upper-case and case insensitive. This relates to https://github.com/docker/docker/pull/28725 and https://github.com/docker/docker/pull/28667, and again this PR should also probably make it into 1.13.

This PR specifically deals with the `Env` array in the container config, and upon the Windows daemon receiving them, deduplicates them and upper-cases them.

I've also added an integration test which verifies `docker run -e foo=bar -e FOO=bar` creates a container with only `FOO=bar` in it.