### PR TITLE
Restrict checkpoint name to prevent directory traversal

### DIFF
--- a/daemon/checkpoint.go
+++ b/daemon/checkpoint.go
@@ -8,6 +8,12 @@ import (
 	"path/filepath"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/utils"
+)
+
+var (
+	validCheckpointNameChars   = utils.RestrictedNameChars
+	validCheckpointNamePattern = utils.RestrictedNamePattern
 )
 
 // CheckpointCreate checkpoints the process running in a container with CRIU
@@ -26,6 +32,10 @@ func (daemon *Daemon) CheckpointCreate(name string, config types.CheckpointCreat
 		checkpointDir = config.CheckpointDir
 	} else {
 		checkpointDir = container.CheckpointDir()
+	}
+
+	if !validCheckpointNamePattern.MatchString(config.CheckpointID) {
+		return fmt.Errorf("Invalid checkpoint ID (%s), only %s are allowed", config.CheckpointID, validCheckpointNameChars)
 	}
 
 	err = daemon.containerd.CreateCheckpoint(container.ID, config.CheckpointID, checkpointDir, config.Exit)

--- a/daemon/names.go
+++ b/daemon/names.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/container"
@@ -58,7 +59,7 @@ func (daemon *Daemon) generateIDAndName(name string) (string, string, error) {
 }
 
 func (daemon *Daemon) reserveName(id, name string) (string, error) {
-	if !validContainerNamePattern.MatchString(name) {
+	if !validContainerNamePattern.MatchString(strings.TrimPrefix(name, "/")) {
 		return "", fmt.Errorf("Invalid container name (%s), only %s are allowed", name, validContainerNameChars)
 	}
 	if name[0] != '/' {

--- a/utils/names.go
+++ b/utils/names.go
@@ -6,7 +6,4 @@ import "regexp"
 const RestrictedNameChars = `[a-zA-Z0-9][a-zA-Z0-9_.-]`
 
 // RestrictedNamePattern is a regular expression to validate names against the collection of restricted characters.
-var RestrictedNamePattern = regexp.MustCompile(`^/?` + RestrictedNameChars + `+$`)
-
-// RestrictedVolumeNamePattern is a regular expression to validate volume names against the collection of restricted characters.
-var RestrictedVolumeNamePattern = regexp.MustCompile(`^` + RestrictedNameChars + `+$`)
+var RestrictedNamePattern = regexp.MustCompile(`^` + RestrictedNameChars + `+$`)

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -36,7 +36,7 @@ var (
 	// volumeNameRegex ensures the name assigned for the volume is valid.
 	// This name is used to create the bind directory, so we need to avoid characters that
 	// would make the path to escape the root directory.
-	volumeNameRegex = utils.RestrictedVolumeNamePattern
+	volumeNameRegex = utils.RestrictedNamePattern
 )
 
 type validationError struct {


### PR DESCRIPTION
**- What I did**

This fix tries to address the issue raised in #28769 where checkpoint name was not checked before passing to containerd. As a result, it was possible to use a special checkpoint name to get outside of the container's directory.

**- How I did it**

This fix add restriction `[a-zA-Z0-9][a-zA-Z0-9_.-]+` (`RestrictedNamePattern`). This is the same as container name restriction.

**- How to verify it**

```
ubuntu@ubuntu:~$ docker run -d --name my-container nginx:alpine
Unable to find image 'nginx:alpine' locally
alpine: Pulling from library/nginx
3690ec4760f9: Already exists 
e13b170882f4: Pull complete 
6a5d3c1484a0: Pull complete 
f421a9935a76: Pull complete 
Digest: sha256:5c6be3514a00db611371806c5aeb510dfd285a4b8261c6e5c3323387e396b66b
Status: Downloaded newer image for nginx:alpine
43719e0c65c60a679b1fa01a86d6e2433b4246349b92fa127275931207667639
ubuntu@ubuntu:~$ docker checkpoint create my-container ../../out-of-jail
Error response from daemon: Invalid checkpoint ID (../../out-of-jail), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed
```
**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #28769.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>