### PR TITLE
exit with status 1 if help is called on an invalid command

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -17,6 +18,7 @@ func SetupRootCommand(rootCmd *cobra.Command) {
 	rootCmd.SetUsageTemplate(usageTemplate)
 	rootCmd.SetHelpTemplate(helpTemplate)
 	rootCmd.SetFlagErrorFunc(FlagErrorFunc)
+	rootCmd.SetHelpCommand(helpCommand)
 
 	rootCmd.PersistentFlags().BoolP("help", "h", false, "Print usage")
 	rootCmd.PersistentFlags().MarkShorthandDeprecated("help", "please use --help")
@@ -37,6 +39,23 @@ func FlagErrorFunc(cmd *cobra.Command, err error) error {
 		Status:     fmt.Sprintf("%s\nSee '%s --help'.%s", err, cmd.CommandPath(), usage),
 		StatusCode: 125,
 	}
+}
+
+var helpCommand = &cobra.Command{
+	Use:               "help [command]",
+	Short:             "Help about the command",
+	PersistentPreRun:  func(cmd *cobra.Command, args []string) {},
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {},
+	RunE: func(c *cobra.Command, args []string) error {
+		cmd, args, e := c.Root().Find(args)
+		if cmd == nil || e != nil || len(args) > 0 {
+			return fmt.Errorf("unknown help topic: %v", strings.Join(args, " "))
+		}
+
+		helpFunc := cmd.HelpFunc()
+		helpFunc(cmd, args)
+		return nil
+	},
 }
 
 func hasSubCommands(cmd *cobra.Command) bool {

--- a/cmd/docker/docker_test.go
+++ b/cmd/docker/docker_test.go
@@ -1,13 +1,14 @@
 package main
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/utils"
-
 	"github.com/docker/docker/cli/command"
+	"github.com/docker/docker/pkg/testutil/assert"
+	"github.com/docker/docker/utils"
 )
 
 func TestClientDebugEnabled(t *testing.T) {
@@ -16,14 +17,16 @@ func TestClientDebugEnabled(t *testing.T) {
 	cmd := newDockerCommand(&command.DockerCli{})
 	cmd.Flags().Set("debug", "true")
 
-	if err := cmd.PersistentPreRunE(cmd, []string{}); err != nil {
-		t.Fatalf("Unexpected error: %s", err.Error())
-	}
+	err := cmd.PersistentPreRunE(cmd, []string{})
+	assert.NilError(t, err)
+	assert.Equal(t, os.Getenv("DEBUG"), "1")
+	assert.Equal(t, logrus.GetLevel(), logrus.DebugLevel)
+}
 
-	if os.Getenv("DEBUG") != "1" {
-		t.Fatal("expected debug enabled, got false")
-	}
-	if logrus.GetLevel() != logrus.DebugLevel {
-		t.Fatalf("expected logrus debug level, got %v", logrus.GetLevel())
-	}
+func TestExitStatusForInvalidSubcommandWithHelpFlag(t *testing.T) {
+	discard := ioutil.Discard
+	cmd := newDockerCommand(command.NewDockerCli(os.Stdin, discard, discard))
+	cmd.SetArgs([]string{"help", "invalid"})
+	err := cmd.Execute()
+	assert.Error(t, err, "unknown help topic: invalid")
 }


### PR DESCRIPTION
Fixes #28329 (kind of)

I don't see any way to restore the old behaviour with `--help`. Argument parsing has to happen after the help flag is processed, which means we don't know if the arg was a positional arg or an invalid subcommand.

Instead this PR restores the behaviour to `docker help <x>`, which also used to work in 1.12. I believe this should give you the functionality you need.

cc @tianon 

