### PR TITLE
Align output of docker version again

### DIFF
--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -24,14 +24,13 @@ var versionTemplate = `Client:
  OS/Arch:      {{.Client.Os}}/{{.Client.Arch}}{{if .ServerOK}}
 
 Server:
- Version:             {{.Server.Version}}
- API version:         {{.Server.APIVersion}}
- Minimum API version: {{.Server.MinAPIVersion}}
- Go version:          {{.Server.GoVersion}}
- Git commit:          {{.Server.GitCommit}}
- Built:               {{.Server.BuildTime}}
- OS/Arch:             {{.Server.Os}}/{{.Server.Arch}}
- Experimental:        {{.Server.Experimental}}{{end}}`
+ Version:      {{.Server.Version}}
+ API version:  {{.Server.APIVersion}} (minimum version {{.Server.MinAPIVersion}})
+ Go version:   {{.Server.GoVersion}}
+ Git commit:   {{.Server.GitCommit}}
+ Built:        {{.Server.BuildTime}}
+ OS/Arch:      {{.Server.Os}}/{{.Server.Arch}}
+ Experimental: {{.Server.Experimental}}{{end}}`
 
 type versionOptions struct {
 	format string

--- a/integration-cli/docker_cli_version_test.go
+++ b/integration-cli/docker_cli_version_test.go
@@ -14,7 +14,7 @@ func (s *DockerSuite) TestVersionEnsureSucceeds(c *check.C) {
 		"Client:":       1,
 		"Server:":       1,
 		" Version:":     2,
-		" API version:": 3,
+		" API version:": 2,
 		" Go version:":  2,
 		" Git commit:":  2,
 		" OS/Arch:":     2,
@@ -40,7 +40,7 @@ func (s *DockerSuite) TestVersionPlatform_l(c *check.C) {
 
 func testVersionPlatform(c *check.C, platform string) {
 	out, _ := dockerCmd(c, "version")
-	expected := "OS/Arch:             " + platform
+	expected := "OS/Arch:      " + platform
 
 	split := strings.Split(out, "\n")
 	c.Assert(len(split) >= 14, checker.Equals, true, check.Commentf("got %d lines from version", len(split)))


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@thaJeztah. Fixes https://github.com/docker/docker/issues/28775.

```
PS E:\go\src\github.com\docker\docker> docker version
Client:
 Version:      1.14.0-dev
 API version:  1.26
 Go version:   go1.7.3
 Git commit:   ae64cae-jhoward-JHOWARD-Z420-Dynamic
 Built:        Wed Nov 23 21:40:45 UTC 2016
 OS/Arch:      windows/amd64

Server:
 Version:      1.14.0-dev
 API version:  1.26 (Minimum version: 1.24)
 Go version:   go1.7.3
 Git commit:   ae64cae-jhoward-JHOWARD-Z420-Dynamic
 Built:        Wed Nov 23 21:40:45 UTC 2016
 OS/Arch:      windows/amd64
 Experimental: false
PS E:\go\src\github.com\docker\docker>
```