### PR TITLE
Fixes typo 'bin-mounts'

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -264,7 +264,7 @@ Docker daemon.
 
 For in-depth information about volumes, refer to [manage data in containers](https://docs.docker.com/engine/tutorials/dockervolumes/)
 
-### Add bin-mounts or volumes using the --mount flag
+### Add bind-mounts or volumes using the --mount flag
 
 The `--mount` flag allows you to mount volumes, host-directories and `tmpfs`
 mounts in a container.


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes a simple typo in the docker run documentation. @thaJeztah 