### PR TITLE
Allow `docker plugin inspect` to search based on ID or name

### DIFF
--- a/cli/command/plugin/inspect.go
+++ b/cli/command/plugin/inspect.go
@@ -1,12 +1,9 @@
 package plugin
 
 import (
-	"fmt"
-
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/cli/command/inspect"
-	"github.com/docker/docker/reference"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 )
@@ -20,7 +17,7 @@ func newInspectCommand(dockerCli *command.DockerCli) *cobra.Command {
 	var opts inspectOptions
 
 	cmd := &cobra.Command{
-		Use:   "inspect [OPTIONS] PLUGIN [PLUGIN...]",
+		Use:   "inspect [OPTIONS] PLUGIN|ID [PLUGIN|ID...]",
 		Short: "Display detailed information on one or more plugins",
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -37,20 +34,8 @@ func newInspectCommand(dockerCli *command.DockerCli) *cobra.Command {
 func runInspect(dockerCli *command.DockerCli, opts inspectOptions) error {
 	client := dockerCli.Client()
 	ctx := context.Background()
-	getRef := func(name string) (interface{}, []byte, error) {
-		named, err := reference.ParseNamed(name) // FIXME: validate
-		if err != nil {
-			return nil, nil, err
-		}
-		if reference.IsNameOnly(named) {
-			named = reference.WithDefaultTag(named)
-		}
-		ref, ok := named.(reference.NamedTagged)
-		if !ok {
-			return nil, nil, fmt.Errorf("invalid name: %s", named.String())
-		}
-
-		return client.PluginInspectWithRaw(ctx, ref.String())
+	getRef := func(ref string) (interface{}, []byte, error) {
+		return client.PluginInspectWithRaw(ctx, ref)
 	}
 
 	return inspect.Inspect(dockerCli.Out(), opts.pluginNames, opts.format, getRef)

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -16,13 +16,13 @@ keywords: "plugin, inspect"
 # plugin inspect
 
 ```markdown
-Usage:  docker plugin inspect [OPTIONS] PLUGIN [PLUGIN...]
+Usage:	docker plugin inspect [OPTIONS] PLUGIN|ID [PLUGIN|ID...]
 
 Display detailed information on one or more plugins
 
 Options:
-      -f, --format string   Format the output using the given Go template
-          --help            Print usage
+  -f, --format string   Format the output using the given Go template
+      --help            Print usage
 ```
 
 Returns information about a plugin. By default, this command renders all results

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
@@ -21,6 +22,11 @@ import (
 	"github.com/docker/docker/plugin/v2"
 	"github.com/docker/docker/reference"
 	"golang.org/x/net/context"
+)
+
+var (
+	validFullID    = regexp.MustCompile(`^([a-f0-9]{64})$`)
+	validPartialID = regexp.MustCompile(`^([a-f0-9]{1,64})$`)
 )
 
 // Disable deactivates a plugin, which implies that they cannot be used by containers.
@@ -53,12 +59,32 @@ func (pm *Manager) Enable(name string, config *types.PluginEnableConfig) error {
 }
 
 // Inspect examines a plugin config
-func (pm *Manager) Inspect(name string) (tp types.Plugin, err error) {
-	p, err := pm.pluginStore.GetByName(name)
-	if err != nil {
+func (pm *Manager) Inspect(refOrID string) (tp types.Plugin, err error) {
+	// Match on full ID
+	if validFullID.MatchString(refOrID) {
+		p, err := pm.pluginStore.GetByID(refOrID)
+		if err == nil {
+			return p.PluginObj, nil
+		}
+	}
+
+	// Match on full name
+	if pluginName, err := getPluginName(refOrID); err == nil {
+		if p, err := pm.pluginStore.GetByName(pluginName); err == nil {
+			return p.PluginObj, nil
+		}
+	}
+
+	// Match on partial ID
+	if validPartialID.MatchString(refOrID) {
+		p, err := pm.pluginStore.Search(refOrID)
+		if err == nil {
+			return p.PluginObj, nil
+		}
 		return tp, err
 	}
-	return p.PluginObj, nil
+
+	return tp, fmt.Errorf("no plugin name or ID associated with %q", refOrID)
 }
 
 func (pm *Manager) pull(ref reference.Named, metaHeader http.Header, authConfig *types.AuthConfig, pluginID string) (types.PluginPrivileges, error) {
@@ -243,4 +269,19 @@ func (pm *Manager) createFromContext(ctx context.Context, pluginID, pluginDir st
 	pm.pluginEventLogger(p.GetID(), repoName, "create")
 
 	return nil
+}
+
+func getPluginName(name string) (string, error) {
+	named, err := reference.ParseNamed(name) // FIXME: validate
+	if err != nil {
+		return "", err
+	}
+	if reference.IsNameOnly(named) {
+		named = reference.WithDefaultTag(named)
+	}
+	ref, ok := named.(reference.NamedTagged)
+	if !ok {
+		return "", fmt.Errorf("invalid name: %s", named.String())
+	}
+	return ref.String(), nil
 }

--- a/plugin/store/store.go
+++ b/plugin/store/store.go
@@ -30,6 +30,13 @@ type ErrNotFound string
 
 func (name ErrNotFound) Error() string { return fmt.Sprintf("plugin %q not found", string(name)) }
 
+// ErrAmbiguous indicates that a plugin was not found locally.
+type ErrAmbiguous string
+
+func (name ErrAmbiguous) Error() string {
+	return fmt.Sprintf("multiple plugins found for %q", string(name))
+}
+
 // GetByName retreives a plugin by name.
 func (ps *Store) GetByName(name string) (*v2.Plugin, error) {
 	ps.RLock()
@@ -252,4 +259,26 @@ func (ps *Store) CallHandler(p *v2.Plugin) {
 			handler(p.Name(), p.Client())
 		}
 	}
+}
+
+// Search retreives a plugin by ID Prefix
+// If no plugin is found, then ErrNotFound is returned
+// If multiple plugins are found, then ErrAmbiguous is returned
+func (ps *Store) Search(partialID string) (*v2.Plugin, error) {
+	ps.RLock()
+	defer ps.RUnlock()
+
+	var found *v2.Plugin
+	for id, p := range ps.plugins {
+		if strings.HasPrefix(id, partialID) {
+			if found != nil {
+				return nil, ErrAmbiguous(partialID)
+			}
+			found = p
+		}
+	}
+	if found == nil {
+		return nil, ErrNotFound(partialID)
+	}
+	return found, nil
 }


### PR DESCRIPTION
**- What I did**

This fix tries to address the issue raised in discussion of PR #28735 where it was not possible to manage plugin based on plugin ID. Previously it was not possible to invoke `docker plugin inspect` with a plugin ID (or ID prefix).

**- How I did it**

This fix updates the implementation of `docker plugin inspect` so that it is possbile to search based on a plugin name, or a plugin ID. A short format of plugin ID (prefix) is also possible, as long as there is no ambiguity.

Previously the check of `docker plugin inspect` was mostly done on the client side. This could potentially cause inconsistency between API and CMD. This fix move all the checks to daemon side so that API and CMD will be consistent.

**- How to verify it**

An integration test has been added to cover the changes.

**- Description for the changelog**

Allow `docker plugin inspect` to search based on ID or name

**- A picture of a cute animal (not mandatory but encouraged)**

![10-kitten-cuteness-1](https://cloud.githubusercontent.com/assets/6932348/20586508/78ce7f40-b1b9-11e6-9f43-4b9314163a52.jpg)


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>