### PR TITLE
Update docs of `docker network ls --filter`

### DIFF
--- a/cli/command/network/list.go
+++ b/cli/command/network/list.go
@@ -43,7 +43,7 @@ func newListCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Only display network IDs")
 	flags.BoolVar(&opts.noTrunc, "no-trunc", false, "Do not truncate the output")
 	flags.StringVar(&opts.format, "format", "", "Pretty-print networks using a Go template")
-	flags.VarP(&opts.filter, "filter", "f", "Provide filter values (i.e. 'dangling=true')")
+	flags.VarP(&opts.filter, "filter", "f", "Provide filter values (e.g. 'driver=bridge')")
 
 	return cmd
 }

--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -24,11 +24,11 @@ Aliases:
   ls, list
 
 Options:
-  -f, --filter value   Provide filter values (i.e. 'dangling=true') (default [])
-      --format string  Pretty-print networks using a Go template
-      --help           Print usage
-      --no-trunc       Do not truncate the output
-  -q, --quiet          Only display network IDs
+  -f, --filter filter   Provide filter values (e.g. 'driver=bridge')
+      --format string   Pretty-print networks using a Go template
+      --help            Print usage
+      --no-trunc        Do not truncate the output
+  -q, --quiet           Only display network IDs
 ```
 
 Lists all the networks the Engine `daemon` knows about. This includes the


### PR DESCRIPTION
Currently the help output of `docker network ls --filter` is:
```
Options:
  -f, --filter value   Provide filter values (i.e. 'dangling=true') (default [])
  ...
```
This caused confusion as only the following filters are supported at the moment:
 - `driver`
 - `type`
 - `name`
 - `id`
 - `label`

This fix update the help output of `docker network ls --filter` and `network_ls.md`.
The `dangling=true` description has been replace to:
```
Options:
  -f, --filter filter   Provide filter values (i.e. 'driver=bridge')
  ...
```

This fix fixes #28786.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>