### PR TITLE
Fix a error of the function 'CopyMessage' in 'daemon/logger/logger.go'

### DIFF
--- a/daemon/logger/logger.go
+++ b/daemon/logger/logger.go
@@ -49,7 +49,7 @@ func CopyMessage(msg *Message) *Message {
 	m.Timestamp = msg.Timestamp
 	m.Partial = msg.Partial
 	m.Attrs = make(LogAttributes)
-	for k, v := range m.Attrs {
+	for k, v := range msg.Attrs {
 		m.Attrs[k] = v
 	}
 	return m

--- a/daemon/logger/logger_test.go
+++ b/daemon/logger/logger_test.go
@@ -1,0 +1,26 @@
+package logger
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestCopyMessage(t *testing.T) {
+	msg := &Message{
+		Line:      []byte("test line."),
+		Source:    "stdout",
+		Timestamp: time.Now(),
+		Attrs: LogAttributes{
+			"key1": "val1",
+			"key2": "val2",
+			"key3": "val3",
+		},
+		Partial: true,
+	}
+
+	m := CopyMessage(msg)
+	if !reflect.DeepEqual(m, msg) {
+		t.Fatalf("CopyMessage failed to copy message")
+	}
+}


### PR DESCRIPTION
`CopyMessage` copy data from `msg` to `m`, so `m.Attrs` should be `msg.Attrs` in `for k, v := range m.Attrs`

Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>