### PR TITLE
Add options for docker plugin enable and fix some typos

### DIFF
--- a/cli/command/plugin/enable.go
+++ b/cli/command/plugin/enable.go
@@ -20,7 +20,7 @@ func newEnableCommand(dockerCli *command.DockerCli) *cobra.Command {
 	var opts enableOpts
 
 	cmd := &cobra.Command{
-		Use:   "enable PLUGIN",
+		Use:   "enable [OPTIONS] PLUGIN",
 		Short: "Enable a plugin",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -26,7 +26,6 @@ Usage: docker [OPTIONS] COMMAND [ARG...]
 A self-sufficient runtime for containers.
 
 Options:
-
       --config string      Location of client config files (default "/root/.docker")
   -D, --debug              Enable debug mode
       --help               Print usage
@@ -72,8 +71,8 @@ by the `docker` command line:
   to the same URL as the registry.
 * `DOCKER_TMPDIR` Location for temporary Docker files.
 
-Because Docker is developed using 'Go', you can also use any environment
-variables used by the 'Go' runtime. In particular, you may find these useful:
+Because Docker is developed using Go, you can also use any environment
+variables used by the Go runtime. In particular, you may find these useful:
 
 * `HTTP_PROXY`
 * `HTTPS_PROXY`

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -22,7 +22,6 @@ Usage: dockerd [OPTIONS]
 A self-sufficient runtime for containers.
 
 Options:
-
       --add-runtime value                     Register an additional OCI compatible runtime (default [])
       --api-cors-header string                Set CORS headers in the Engine API
       --authorization-plugin value            Authorization plugins to load (default [])

--- a/docs/reference/commandline/plugin_enable.md
+++ b/docs/reference/commandline/plugin_enable.md
@@ -16,7 +16,7 @@ keywords: "plugin, enable"
 # plugin enable
 
 ```markdown
-Usage:  docker plugin enable PLUGIN
+Usage:  docker plugin enable [OPTIONS] PLUGIN
 
 Enable a plugin
 


### PR DESCRIPTION
**- What I did**
Add options for docker plugin enable and fix some typos

**- How I did it**

**- How to verify it**

**- Description for the changelog**
1. Add options for docker plugin enable 
2. Fix some typos


Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>