### PR TITLE
check-config check for LEGACY_VSYSCALL_* options

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -222,6 +222,23 @@ echo 'Optional Features:'
 		echo "    $(wrap_color '(note that cgroup swap accounting is not enabled in your kernel config, you can enable it by setting boot option "swapaccount=1")' bold black)"
 	fi
 }
+{
+	if is_set LEGACY_VSYSCALL_NATIVE; then
+		echo -n "- "; wrap_good "CONFIG_LEGACY_VSYSCALL_NATIVE" 'enabled'
+	elif is_set LEGACY_VSYSCALL_EMULATE; then
+		echo -n "- "; wrap_good "CONFIG_LEGACY_VSYSCALL_EMULATE" 'enabled'
+	elif is_set LEGACY_VSYSCALL_NONE; then
+		echo -n "- "; wrap_bad "CONFIG_LEGACY_VSYSCALL_NONE" 'enabled'
+		echo "    $(wrap_color '(containers using eglibc <= 2.13 will not work. Switch to' bold black)"
+		echo "    $(wrap_color ' "CONFIG_VSYSCALL_[NATIVE|EMULATE]" or use "vsyscall=[native|emulate]"' bold black)"
+		echo "    $(wrap_color ' on kernel command line. Note that this will disable ASLR for the,' bold black)"
+		echo "    $(wrap_color ' VDSO which may assist in exploiting security vulnerabilities.)' bold black)"
+	# else Older kernels (prior to 3dc33bd30f3e, released in v4.40-rc1) do
+	#      not have these LEGACY_VSYSCALL options and are effectively
+	#      LEGACY_VSYSCALL_EMULATE. Even older kernels are presumably
+	#      effectively LEGACY_VSYSCALL_NATIVE.
+	fi
+}
 
 if [ "$kernelMajor" -lt 4 ] || [ "$kernelMajor" -eq 4 -a "$kernelMinor" -le 5 ]; then
 	check_flags MEMCG_KMEM


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Made `check-config` consider the various options for `CONFIG_LEGACY_VSYSCALL_*` and warn the user about configurations which are incompatible with older (glibc <= 2.13) userspaces (see #28705).

**- How I did it**

Added the checks to the script.

**- How to verify it**

Run against a variety of kernel configs. I tried (from `/boot` on my Debian system):
* `/boot/config-3.16.0-4-amd64`: No related output, good.
* `/boot/config-4.5.0-2-amd64`, `/boot/config-4.6.0-1-amd64` and `/boot/config-4.7.0-1-amd64`: Produced expected:
```
- CONFIG_LEGACY_VSYSCALL_EMULATE: enabled
```
* /boot/config-4.8.0-1-amd64: Produced expected:
```
 - CONFIG_LEGACY_VSYSCALL_NONE: enabled
    (containers using eglibc <= 2.13 will not work. Switch to
     "CONFIG_VSYSCALL_[NATIVE|EMULATE]" or use "vsyscall=[native|emulate]"
     on kernel command line. Note that this will disable ASLR for the,
     VDSO which may assist in exploiting security vulnerabilities.)
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

`check-config` now considers the various options for `CONFIG_LEGACY_VSYSCALL_*`.

**- A picture of a cute animal (not mandatory but encouraged)**
![Glenn Frey, The Eagles](https://upload.wikimedia.org/wikipedia/commons/thumb/8/8a/Glenn_Frey.jpg/440px-Glenn_Frey.jpg)

/cc @tianon @justincormack 