### PR TITLE
Modify repoName to PLUGIN for docker plugin create

### DIFF
--- a/cli/command/plugin/create.go
+++ b/cli/command/plugin/create.go
@@ -64,7 +64,7 @@ func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	options := pluginCreateOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "create [OPTIONS] reponame[:tag] PATH-TO-ROOTFS (rootfs + config.json)",
+		Use:   "create [OPTIONS] PLUGIN[:tag] PATH-TO-ROOTFS(rootfs + config.json)",
 		Short: "Create a plugin from a rootfs and config",
 		Args:  cli.RequiresMinArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/plugin/push.go
+++ b/cli/command/plugin/push.go
@@ -14,7 +14,7 @@ import (
 
 func newPushCommand(dockerCli *command.DockerCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "push NAME[:TAG]",
+		Use:   "push PLUGIN[:TAG]",
 		Short: "Push a plugin to a registry",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/reference/commandline/plugin_create.md
+++ b/docs/reference/commandline/plugin_create.md
@@ -16,7 +16,7 @@ keywords: "plugin, create"
 # plugin create
 
 ```markdown
-Usage:  docker plugin create [OPTIONS] reponame[:tag] PATH-TO-ROOTFS
+Usage:  docker plugin create [OPTIONS] PLUGIN[:tag] PATH-TO-ROOTFS(rootfs + config.json)
 
 Create a plugin from a rootfs and configuration
 

--- a/docs/reference/commandline/plugin_push.md
+++ b/docs/reference/commandline/plugin_push.md
@@ -14,7 +14,7 @@ keywords: "plugin, push"
 -->
 
 ```markdown
-Usage:  docker plugin push NAME[:TAG]
+Usage:  docker plugin push PLUGIN[:TAG]
 
 Push a plugin to a registry
 


### PR DESCRIPTION
**- What I did**
1. Modify repoName to PLUGIN for docker plugin create
2. Fix the unconsistency between code and document for docker plugin subcommands.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
1. Modify repoName to PLUGIN for docker plugin create which keeps consistency among plugin subcommands.
2. Add  "(rootfs + config.json)"  to the document of docker plugin create
3. Modify NAME to PLUGIN in docker plugin push.  

Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>