### PR TITLE
add a test for ensuring the behavior of read-only /dev/shm

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4879,3 +4879,16 @@ func (s *delayedReader) Read([]byte) (int, error) {
 	time.Sleep(500 * time.Millisecond)
 	return 0, io.EOF
 }
+
+// #28823 (originally #28639)
+func (s *DockerSuite) TestRunMountReadOnlyDevShm(c *check.C) {
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
+	emptyDir, err := ioutil.TempDir("", "test-read-only-dev-shm")
+	c.Assert(err, check.IsNil)
+	defer os.RemoveAll(emptyDir)
+	out, _, err := dockerCmdWithError("run", "--rm", "--read-only",
+		"-v", fmt.Sprintf("%s:/dev/shm:ro", emptyDir),
+		"busybox", "touch", "/dev/shm/foo")
+	c.Assert(err, checker.NotNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "Read-only file system")
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

The added test ensures that `docker run --read-only -v /var/empty:/dev/shm:ro` makes `/dev/shm` read-only

Related: https://github.com/docker/docker/issues/28639

**- How I did it**

Added a test

**- How to verify it**

Observe the CI result

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
https://www.youtube.com/watch?v=8ij9VVd6Dp8

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>