### PR TITLE
Setting the mirror with mirror address.

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -34,11 +34,11 @@ pgp.mit.edu
 keyserver.ubuntu.com
 "
 
-mirror=''
 while [ $# -gt 0 ]; do
 	case "$1" in
 		--mirror)
-			mirror="$2"
+			apt_url="$2/apt"
+			yum_url="$2/yum"
 			shift
 			;;
 		*)
@@ -47,13 +47,6 @@ while [ $# -gt 0 ]; do
 	esac
 	shift $(( $# > 0 ? 1 : 0 ))
 done
-
-case "$mirror" in
-	AzureChinaCloud)
-		apt_url="https://mirror.azure.cn/docker-engine/apt"
-		yum_url="https://mirror.azure.cn/docker-engine/yum"
-		;;
-esac
 
 command_exists() {
 	command -v "$@" > /dev/null 2>&1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

We can use the mirror address to setting the mirror. Only comply with the rules of url.
Because some user initialize the machine in Aliyun VPC environment And he can use the intranet mirror `http://mirrors.aliyuncs.com/docker-engine`.
By the way, if we add the option AliyunMirror or AliyunVPCMirror. More and more option will be added. 

```
curl -sSL https://get.docker.com/ | sh -s -- --mirror http://mirrors.aliyun.com/docker-engine
curl -sSL https://get.docker.com/ | sh -s -- --mirror http://mirrors.aliyuncs.com/docker-engine
curl -sSL https://get.docker.com/ | sh -s -- --mirror https://mirror.azure.cn/docker-engine
```

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: hyzhou.zhy <hyzhou.zhy@alibaba-inc.com>