### PR TITLE
Add bash completion for `docker service update --hostname`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2621,6 +2621,7 @@ _docker_service_update() {
 		--health-interval
 		--health-retries
 		--health-timeout
+		--hostname
 		--label -l
 		--limit-cpu
 		--limit-memory
@@ -2664,7 +2665,6 @@ _docker_service_update() {
 			--dns-search
 			--env-file
 			--group
-			--hostname
 			--mode
 			--name
 			--port


### PR DESCRIPTION
Ref: #28771
This PR moves `--hostname` from the `create` specific completion to the shared (`create` and `update`) completion.
Please schedule for 1.13.0.