### PR TITLE
cli: mark `docker deploy` non-experimental

### DIFF
--- a/cli/command/stack/cmd.go
+++ b/cli/command/stack/cmd.go
@@ -30,6 +30,6 @@ func NewTopLevelDeployCommand(dockerCli *command.DockerCli) *cobra.Command {
 	cmd := newDeployCommand(dockerCli)
 	// Remove the aliases at the top level
 	cmd.Aliases = []string{}
-	cmd.Tags = map[string]string{"experimental": "", "version": "1.25"}
+	cmd.Tags = map[string]string{"version": "1.25"}
 	return cmd
 }

--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -2,7 +2,6 @@
 title: "deploy"
 description: "The deploy command description and usage"
 keywords: "stack, deploy"
-advisory: "experimental"
 ---
 
 <!-- This file is maintained within the docker/docker Github
@@ -14,7 +13,7 @@ advisory: "experimental"
      will be rejected.
 -->
 
-# deploy (alias for stack deploy) (experimental)
+# deploy (alias for stack deploy)
 
 ```markdown
 Usage:  docker deploy [OPTIONS] STACK


### PR DESCRIPTION
Probably this should have been in https://github.com/docker/docker/pull/28677
Fix https://github.com/docker/docker/issues/28830
cc @dnephin @albers

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>