### PR TITLE
Updates to swagger.yaml and API documentation

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -56,14 +56,14 @@ info:
 
     Docker version  | API version | Changes
     ----------------|-------------|---------
-    1.13.x | [1.25](/engine/api/v1.24/) | [API changes](/engine/api/version-history/#v1-24-api-changes)
-    1.12.x | [1.24](/engine/api/v1.24/) | [API changes](/engine/api/version-history/#v1-24-api-changes)
-    1.11.x | [1.23](/engine/api/v1.23/) | [API changes](/engine/api/version-history/#v1-23-api-changes)
-    1.10.x | [1.22](/engine/api/v1.22/) | [API changes](/engine/api/version-history/#v1-22-api-changes)
-    1.9.x | [1.21](/engine/api/v1.21/) | [API changes](/engine/api/version-history/#v1-21-api-changes)
-    1.8.x | [1.20](/engine/api/v1.20/) | [API changes](/engine/api/version-history/#v1-20-api-changes)
-    1.7.x | [1.19](/engine/api/v1.19/) | [API changes](/engine/api/version-history/#v1-19-api-changes)
-    1.6.x | [1.18](/engine/api/v1.18/) | [API changes](/engine/api/version-history/#v1-18-api-changes)
+    1.13.x | [1.25](https://docs.docker.com/engine/api/v1.25/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-24-api-changes)
+    1.12.x | [1.24](https://docs.docker.com/engine/api/v1.24/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-24-api-changes)
+    1.11.x | [1.23](https://docs.docker.com/engine/api/v1.23/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-23-api-changes)
+    1.10.x | [1.22](https://docs.docker.com/engine/api/v1.22/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-22-api-changes)
+    1.9.x | [1.21](https://docs.docker.com/engine/api/v1.21/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-21-api-changes)
+    1.8.x | [1.20](https://docs.docker.com/engine/api/v1.20/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-20-api-changes)
+    1.7.x | [1.19](https://docs.docker.com/engine/api/v1.19/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-19-api-changes)
+    1.6.x | [1.18](https://docs.docker.com/engine/api/v1.18/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-18-api-changes)
 
     # Authentication
 
@@ -3774,7 +3774,7 @@ paths:
 
         Either the `stream` or `logs` parameter must be `true` for this endpoint to do anything.
 
-        See [the documentation for the `docker attach` command](/engine/reference/commandline/attach/) for more details.
+        See [the documentation for the `docker attach` command](https://docs.docker.com/engine/reference/commandline/attach/) for more details.
 
         ### Hijacking
 
@@ -4289,7 +4289,7 @@ paths:
       description: |
         Build an image from a tar archive with a `Dockerfile` in it.
 
-        The `Dockerfile` specifies how the image is built from the tar archive. It is typically in the archive's root, but can be at a different path or have a different name by specifying the `dockerfile` parameter. [See the `Dockerfile` reference for more information](/engine/reference/builder/).
+        The `Dockerfile` specifies how the image is built from the tar archive. It is typically in the archive's root, but can be at a different path or have a different name by specifying the `dockerfile` parameter. [See the `Dockerfile` reference for more information](https://docs.docker.com/engine/reference/builder/).
 
         The Docker daemon performs a preliminary validation of the `Dockerfile` before starting the build, and returns an error if the syntax is incorrect. After that, each instruction is run one-by-one until the ID of the new image is output.
 
@@ -4373,7 +4373,7 @@ paths:
           type: "integer"
         - name: "buildargs"
           in: "query"
-          description: "JSON map of string pairs for build-time variables. Users pass these values at build-time. Docker uses the buildargs as the environment context for commands run via the `Dockerfile` RUN instruction, or for variable expansion in other `Dockerfile` instructions. This is not meant for passing secret values. [Read more about the buildargs instruction.](/engine/reference/builder/#arg)"
+          description: "JSON map of string pairs for build-time variables. Users pass these values at build-time. Docker uses the buildargs as the environment context for commands run via the `Dockerfile` RUN instruction, or for variable expansion in other `Dockerfile` instructions. This is not meant for passing secret values. [Read more about the buildargs instruction.](https://docs.docker.com/engine/reference/builder/#arg)"
           type: "integer"
         - name: "shmsize"
           in: "query"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1,3 +1,14 @@
+# A Swagger 2.0 (a.k.a. OpenAPI) definition of the Engine API.
+#
+# This is used for generating API documentation and the types used by the
+# client/server. See api/README.md for more information.
+#
+# Some style notes:
+# - This file is used by ReDoc, which allows GitHub Flavored Markdown in
+#   descriptions.
+# - There is no maximum line length, for ease of editing and pretty diffs.
+# - operationIds are in the format "NounVerb", with a singular noun.
+
 swagger: "2.0"
 schemes:
   - "http"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -80,7 +80,7 @@ info:
 
     The `serveraddress` is a domain/IP without a protocol. Throughout this structure, double quotes are required.
 
-    If you have already got an identity token from the [`/auth` endpoint](#operation/checkAuthentication), you can just pass this instead of credentials:
+    If you have already got an identity token from the [`/auth` endpoint](#operation/SystemAuth), you can just pass this instead of credentials:
 
     ```
     {
@@ -2441,7 +2441,7 @@ paths:
   /containers/json:
     get:
       summary: "List containers"
-      operationId: "GetContainerList"
+      operationId: "ContainerList"
       produces:
         - "application/json"
       parameters:
@@ -2823,7 +2823,7 @@ paths:
     get:
       summary: "Inspect a container"
       description: "Return low-level information about a container."
-      operationId: "GetContainerInspect"
+      operationId: "ContainerInspect"
       produces:
         - "application/json"
       responses:
@@ -3099,7 +3099,7 @@ paths:
     get:
       summary: "List processes running inside a container"
       description: "On Unix systems, this is done by running the `ps` command. This endpoint is not supported on Windows."
-      operationId: "GetContainerTop"
+      operationId: "ContainerTop"
       responses:
         200:
           description: "no error"
@@ -3178,7 +3178,7 @@ paths:
         Get `stdout` and `stderr` logs from a container.
 
         Note: This endpoint works only for containers with the `json-file` or `journald` logging driver.
-      operationId: "GetContainerLogs"
+      operationId: "ContainerLogs"
       responses:
         101:
           description: "logs returned as a stream"
@@ -3211,7 +3211,7 @@ paths:
           description: |
             Return the logs as a stream.
 
-            This will return a `101` HTTP response with a `Connection: upgrade` header, then hijack the HTTP connection to send raw output. For more information about hijacking and the stream format, [see the documentation for the attach endpoint](#operation/PostContainerAttach).
+            This will return a `101` HTTP response with a `Connection: upgrade` header, then hijack the HTTP connection to send raw output. For more information about hijacking and the stream format, [see the documentation for the attach endpoint](#operation/ContainerAttach).
           type: "boolean"
           default: false
         - name: "stdout"
@@ -3249,7 +3249,7 @@ paths:
         - `0`: Modified
         - `1`: Added
         - `2`: Deleted
-      operationId: "GetContainerChanges"
+      operationId: "ContainerChanges"
       produces:
         - "application/json"
       responses:
@@ -3300,7 +3300,7 @@ paths:
     get:
       summary: "Export a container"
       description: "Export the contents of a container as a tarball."
-      operationId: "GetContainerExport"
+      operationId: "ContainerExport"
       produces:
         - "application/octet-stream"
       responses:
@@ -3331,7 +3331,7 @@ paths:
         This endpoint returns a live stream of a container’s resource usage statistics.
 
         The `precpu_stats` is the CPU statistic of last read, which is used for calculating the CPU usage percentage. It is not the same as the `cpu_stats` field.
-      operationId: "GetContainerStats"
+      operationId: "ContainerStats"
       produces:
         - "application/json"
       responses:
@@ -3456,7 +3456,7 @@ paths:
     post:
       summary: "Resize a container TTY"
       description: "Resize the TTY for a container. You must restart the container for the resize to take effect."
-      operationId: "PostContainerResize"
+      operationId: "ContainerResize"
       consumes:
         - "application/octet-stream"
       produces:
@@ -3493,7 +3493,7 @@ paths:
   /containers/{id}/start:
     post:
       summary: "Start a container"
-      operationId: "PostContainerStart"
+      operationId: "ContainerStart"
       responses:
         204:
           description: "no error"
@@ -3526,7 +3526,7 @@ paths:
   /containers/{id}/stop:
     post:
       summary: "Stop a container"
-      operationId: "PostContainerStop"
+      operationId: "ContainerStop"
       responses:
         204:
           description: "no error"
@@ -3559,7 +3559,7 @@ paths:
   /containers/{id}/restart:
     post:
       summary: "Restart a container"
-      operationId: "PostContainerRestart"
+      operationId: "ContainerRestart"
       responses:
         204:
           description: "no error"
@@ -3589,7 +3589,7 @@ paths:
     post:
       summary: "Kill a container"
       description: "Send a POSIX signal to a container, defaulting to killing to the container."
-      operationId: "PostContainerKill"
+      operationId: "ContainerKill"
       responses:
         204:
           description: "no error"
@@ -3680,7 +3680,7 @@ paths:
   /containers/{id}/rename:
     post:
       summary: "Rename a container"
-      operationId: "PostContainerRename"
+      operationId: "ContainerRename"
       responses:
         204:
           description: "no error"
@@ -3718,7 +3718,7 @@ paths:
         Use the cgroups freezer to suspend all processes in a container.
 
         Traditionally, when suspending a process the `SIGSTOP` signal is used, which is observable by the process being suspended. With the cgroups freezer the process is unaware, and unable to capture, that it is being suspended, and subsequently resumed.
-      operationId: "PostContainerPause"
+      operationId: "ContainerPause"
       responses:
         204:
           description: "no error"
@@ -3744,7 +3744,7 @@ paths:
     post:
       summary: "Unpause a container"
       description: "Resume a container which has been paused."
-      operationId: "PostContainerUnpause"
+      operationId: "ContainerUnpause"
       responses:
         204:
           description: "no error"
@@ -3814,7 +3814,7 @@ paths:
 
         ### Stream format
 
-        When the TTY setting is disabled in [`POST /containers/create`](#operation/PostContainerCreate), the stream over the hijacked connected is multiplexed to separate out `stdout` and `stderr`. The stream consists of a series of frames, each containing a header and a payload.
+        When the TTY setting is disabled in [`POST /containers/create`](#operation/ContainerCreate), the stream over the hijacked connected is multiplexed to separate out `stdout` and `stderr`. The stream consists of a series of frames, each containing a header and a payload.
 
         The header contains the information which the stream writes (`stdout` or `stderr`). It also contains the size of the associated frame encoded in the last four bytes (`uint32`).
 
@@ -3844,9 +3844,9 @@ paths:
 
         ### Stream format when using a TTY
 
-        When the TTY setting is enabled in [`POST /containers/create`](#operation/PostContainerCreate), the stream is not multiplexed. The data exchanged over the hijacked connection is simply the raw data from the process PTY and client's `stdin`.
+        When the TTY setting is enabled in [`POST /containers/create`](#operation/ContainerCreate), the stream is not multiplexed. The data exchanged over the hijacked connection is simply the raw data from the process PTY and client's `stdin`.
 
-      operationId: "PostContainerAttach"
+      operationId: "ContainerAttach"
       produces:
         - "application/vnd.docker.raw-stream"
       responses:
@@ -3913,7 +3913,7 @@ paths:
   /containers/{id}/attach/ws:
     get:
       summary: "Attach to a container via a websocket"
-      operationId: "PostContainerAttachWebsocket"
+      operationId: "ContainerAttachWebsocket"
       responses:
         101:
           description: "no error, hints proxy about hijacking"
@@ -4008,7 +4008,7 @@ paths:
   /containers/{id}:
     delete:
       summary: "Remove a container"
-      operationId: "DeleteContainer"
+      operationId: "ContainerDelete"
       responses:
         204:
           description: "no error"
@@ -4048,7 +4048,7 @@ paths:
     head:
       summary: "Get information about files in a container"
       description: "A response header `X-Docker-Container-Path-Stat` is return containing a base64 - encoded JSON object with some filesystem header information about the path."
-      operationId: "HeadContainerArchive"
+      operationId: "ContainerArchiveHead"
       responses:
         200:
           description: "no error"
@@ -4093,7 +4093,7 @@ paths:
     get:
       summary: "Get an archive of a filesystem resource in a container"
       description: "Get an tar archive of a resource in the filesystem of container id."
-      operationId: "GetContainerArchive"
+      operationId: "ContainerGetArchive"
       produces:
         - "application/x-tar"
       responses:
@@ -4136,7 +4136,7 @@ paths:
     put:
       summary: "Extract an archive of files or folders to a directory in a container"
       description: "Upload a tar archive to be extracted to a path in the filesystem of container id."
-      operationId: "PutContainerArchive"
+      operationId: "ContainerPutArchive"
       consumes:
         - "application/x-tar"
         - "application/octet-stream"
@@ -4216,7 +4216,7 @@ paths:
     get:
       summary: "List Images"
       description: "Returns a list of images on the server. Note that it uses a different, smaller representation of an image than inspecting a single image."
-      operationId: "GetImageList"
+      operationId: "ImageList"
       produces:
         - "application/json"
       responses:
@@ -4294,7 +4294,7 @@ paths:
         The Docker daemon performs a preliminary validation of the `Dockerfile` before starting the build, and returns an error if the syntax is incorrect. After that, each instruction is run one-by-one until the ID of the new image is output.
 
         The build is canceled if the client drops the connection by quitting or being killed.
-      operationId: "PostImageBuild"
+      operationId: "ImageBuild"
       consumes:
         - "application/octet-stream"
       produces:
@@ -4434,7 +4434,7 @@ paths:
     post:
       summary: "Create an image"
       description: "Create an image by either pulling it from a registry or importing it."
-      operationId: "PostImageCreate"
+      operationId: "ImageCreate"
       consumes:
         - "text/plain"
         - "application/octet-stream"
@@ -4479,7 +4479,7 @@ paths:
     get:
       summary: "Inspect an image"
       description: "Return low-level information about an image."
-      operationId: "GetImageInspect"
+      operationId: "ImageInspect"
       produces:
         - "application/json"
       responses:
@@ -4585,7 +4585,7 @@ paths:
     get:
       summary: "Get the history of an image"
       description: "Return parent layers of an image."
-      operationId: "GetImageHistory"
+      operationId: "ImageHistory"
       produces:
         - "application/json"
       responses:
@@ -4660,7 +4660,7 @@ paths:
         If you wish to push an image on to a private registry, that image must already have a tag which references the registry. For example, `registry.example.com/myimage:latest`.
 
         The push is cancelled if the HTTP connection is closed.
-      operationId: "PostImagePush"
+      operationId: "ImagePush"
       consumes:
         - "application/octet-stream"
       responses:
@@ -4694,7 +4694,7 @@ paths:
     post:
       summary: "Tag an image"
       description: "Tag an image so that it becomes part of a repository."
-      operationId: "PostImageTag"
+      operationId: "ImageTag"
       responses:
         201:
           description: "No error"
@@ -4736,7 +4736,7 @@ paths:
         Remove an image, along with any untagged parent images that were referenced by that image.
 
         Images can't be removed if they have descendant images, are being used by a running container or are being used by a build.
-      operationId: "DeleteImage"
+      operationId: "ImageDelete"
       produces:
         - "application/json"
       responses:
@@ -4784,7 +4784,7 @@ paths:
     get:
       summary: "Search images"
       description: "Search for an image on Docker Hub."
-      operationId: "GetImageSearch"
+      operationId: "ImageSearch"
       produces:
         - "application/json"
       responses:
@@ -4888,7 +4888,7 @@ paths:
     post:
       summary: "Check auth configuration"
       description: "Validate credentials for a registry and, if available, get an identity token for accessing the registry without password."
-      operationId: "Authenticate"
+      operationId: "SystemAuth"
       consumes: ["application/json"]
       produces: ["application/json"]
       responses:
@@ -4926,7 +4926,7 @@ paths:
   /info:
     get:
       summary: "Get system information"
-      operationId: "getSystemInformation"
+      operationId: "SystemInfo"
       produces:
         - "application/json"
       responses:
@@ -5139,7 +5139,7 @@ paths:
     get:
       summary: "Get version"
       description: "Returns the version of Docker that is running and various information about the system that Docker is running on."
-      operationId: "getVersion"
+      operationId: "SystemVersion"
       produces:
         - "application/json"
       responses:
@@ -5189,7 +5189,7 @@ paths:
     get:
       summary: "Ping"
       description: "This is a dummy endpoint you can use to test if the server is accessible."
-      operationId: "ping"
+      operationId: "SystemPing"
       produces:
         - "text/plain"
       responses:
@@ -5206,7 +5206,7 @@ paths:
   /commit:
     post:
       summary: "Create a new image from a container"
-      operationId: "PostImageCommit"
+      operationId: "ImageCommit"
       consumes:
         - "application/json"
       produces:
@@ -5281,7 +5281,7 @@ paths:
 
         The Docker daemon reports these events: `reload`
 
-      operationId: "getEvents"
+      operationId: "SystemEvents"
       produces:
         - "application/json"
       responses:
@@ -5356,6 +5356,7 @@ paths:
   /system/df:
     get:
       summary: "Get data usage information"
+      operationId: "SystemDataUsage"
       responses:
         200:
           description: "no error"
@@ -5468,7 +5469,7 @@ paths:
           }
         }
         ```
-      operationId: "GetImage"
+      operationId: "ImageGet"
       produces:
         - "application/x-tar"
       responses:
@@ -5496,8 +5497,8 @@ paths:
 
         For each value of the `names` parameter: if it is a specific name and tag (e.g. `ubuntu:latest`), then only that image (and its parents) are returned; if it is an image ID, similarly only that image (and its parents) are returned and there would be no names referenced in the 'repositories' file for this image ID.
 
-        For details on the format, see [the export image endpoint](#operation/GetImage).
-      operationId: "GetImageSaveAll"
+        For details on the format, see [the export image endpoint](#operation/ImageGet).
+      operationId: "ImageGetAll"
       produces:
         - "application/x-tar"
       responses:
@@ -5524,8 +5525,8 @@ paths:
       description: |
         Load a set of images and tags into a repository.
 
-        For details on the format, see [the export image endpoint](#operation/GetImage).
-      operationId: "PostImageLoad"
+        For details on the format, see [the export image endpoint](#operation/ImageGet).
+      operationId: "ImageLoad"
       consumes:
         - "application/x-tar"
       produces:
@@ -5554,7 +5555,7 @@ paths:
     post:
       summary: "Create an exec instance"
       description: "Run a command inside a running container."
-      operationId: "PostContainerExec"
+      operationId: "ContainerExec"
       consumes:
         - "application/json"
       produces:
@@ -5640,7 +5641,7 @@ paths:
     post:
       summary: "Start an exec instance"
       description: "Starts a previously set up exec instance. If detach is true, this endpoint returns immediately after starting the command. Otherwise, it sets up an interactive session with the command."
-      operationId: "PostExecStart"
+      operationId: "ExecStart"
       consumes:
         - "application/json"
       produces:
@@ -5681,7 +5682,7 @@ paths:
     post:
       summary: "Resize an exec instance"
       description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
-      operationId: "PostExecResize"
+      operationId: "ExecResize"
       responses:
         201:
           description: "No error"
@@ -5708,7 +5709,7 @@ paths:
     get:
       summary: "Inspect an exec instance"
       description: "Return low-level information about an exec instance."
-      operationId: "PostExecInspect"
+      operationId: "ExecInspect"
       produces:
         - "application/json"
       responses:
@@ -5775,7 +5776,7 @@ paths:
   /volumes:
     get:
       summary: "List volumes"
-      operationId: "VolumesList"
+      operationId: "VolumeList"
       produces: ["application/json"]
       responses:
         200:
@@ -5837,7 +5838,7 @@ paths:
   /volumes/create:
     post:
       summary: "Create a volume"
-      operationId: "VolumesCreate"
+      operationId: "VolumeCreate"
       consumes: ["application/json"]
       produces: ["application/json"]
       responses:
@@ -5887,7 +5888,7 @@ paths:
   /volumes/{name}:
     get:
       summary: "Inspect a volume"
-      operationId: "VolumesInspect"
+      operationId: "VolumeInspect"
       produces: ["application/json"]
       responses:
         200:
@@ -5913,7 +5914,7 @@ paths:
     delete:
       summary: "Remove a volume"
       description: "Instruct the driver to remove the volume."
-      operationId: "VolumesDelete"
+      operationId: "VolumeDelete"
       responses:
         204:
           description: "The volume was removed"
@@ -5972,7 +5973,7 @@ paths:
   /networks:
     get:
       summary: "List networks"
-      operationId: "NetworksList"
+      operationId: "NetworkList"
       produces:
         - "application/json"
       responses:
@@ -6054,7 +6055,7 @@ paths:
   /networks/{id}:
     get:
       summary: "Inspect a network"
-      operationId: "NetworksInspect"
+      operationId: "NetworkInspect"
       produces:
         - "application/json"
       responses:
@@ -6076,7 +6077,7 @@ paths:
 
     delete:
       summary: "Remove a network"
-      operationId: "DeleteNetworks"
+      operationId: "NetworkDelete"
       responses:
         204:
           description: "No error"
@@ -6099,7 +6100,7 @@ paths:
   /networks/create:
     post:
       summary: "Create a network"
-      operationId: "NetworksCreate"
+      operationId: "NetworkCreate"
       consumes:
         - "application/json"
       produces:
@@ -6195,7 +6196,7 @@ paths:
   /networks/{id}/connect:
     post:
       summary: "Connect a container to a network"
-      operationId: "NetworksConnect"
+      operationId: "NetworkConnect"
       consumes:
         - "application/octet-stream"
       responses:
@@ -6241,7 +6242,7 @@ paths:
   /networks/{id}/disconnect:
     post:
       summary: "Disconnect a container from a network"
-      operationId: "NetworksDisconnect"
+      operationId: "NetworkDisconnect"
       consumes:
         - "application/json"
       responses:
@@ -6305,7 +6306,7 @@ paths:
   /plugins:
     get:
       summary: "List plugins"
-      operationId: "PluginsList"
+      operationId: "PluginList"
       description: "Returns information about installed plugins."
       produces: ["application/json"]
       responses:
@@ -6399,9 +6400,9 @@ paths:
   /plugins/pull:
     post:
       summary: "Install a plugin"
-      operationId: "PostPluginsPull"
+      operationId: "PluginPull"
       description: |
-        Pulls and installs a plugin. After the plugin is installed, it can be enabled using the [`POST /plugins/{name}/enable` endpoint](#operation/PostPluginsEnable).
+        Pulls and installs a plugin. After the plugin is installed, it can be enabled using the [`POST /plugins/{name}/enable` endpoint](#operation/PluginEnable).
       produces:
         - "application/json"
       responses:
@@ -6455,7 +6456,7 @@ paths:
   /plugins/{name}:
     get:
       summary: "Inspect a plugin"
-      operationId: "GetPluginsInspect"
+      operationId: "PluginInspect"
       responses:
         200:
           description: "no error"
@@ -6478,7 +6479,7 @@ paths:
       tags: ["Plugins"]
     delete:
       summary: "Remove a plugin"
-      operationId: "DeletePlugins"
+      operationId: "PluginDelete"
       responses:
         200:
           description: "no error"
@@ -6507,7 +6508,7 @@ paths:
   /plugins/{name}/enable:
     post:
       summary: "Enable a plugin"
-      operationId: "PostPluginsEnable"
+      operationId: "PluginEnable"
       responses:
         200:
           description: "no error"
@@ -6530,7 +6531,7 @@ paths:
   /plugins/{name}/disable:
     post:
       summary: "Disable a plugin"
-      operationId: "PostPluginsDisable"
+      operationId: "PluginDisable"
       responses:
         200:
           description: "no error"
@@ -6548,7 +6549,7 @@ paths:
   /plugins/create:
     post:
       summary: "Create a plugin"
-      operationId: "PostPluginsCreate"
+      operationId: "PluginCreate"
       consumes:
         - "application/x-tar"
       responses:
@@ -6598,7 +6599,7 @@ paths:
   /plugins/{name}/set:
     post:
       summary: "Configure a plugin"
-      operationId: "PostPluginsSet"
+      operationId: "PluginSet"
       consumes:
         - "application/json"
       parameters:
@@ -6629,7 +6630,7 @@ paths:
   /nodes:
     get:
       summary: "List nodes"
-      operationId: "GetNodesList"
+      operationId: "NodeList"
       responses:
         200:
           description: "no error"
@@ -6658,7 +6659,7 @@ paths:
   /nodes/{id}:
     get:
       summary: "Inspect a node"
-      operationId: "GetNodesInspect"
+      operationId: "NodeInspect"
       responses:
         200:
           description: "no error"
@@ -6681,7 +6682,7 @@ paths:
       tags: ["Nodes"]
     delete:
       summary: "Delete a node"
-      operationId: "DeleteNodes"
+      operationId: "NodeDelete"
       responses:
         200:
           description: "no error"
@@ -6708,7 +6709,7 @@ paths:
   /nodes/{id}/update:
     post:
       summary: "Update a node"
-      operationId: "PostNodesUpdate"
+      operationId: "NodeUpdate"
       responses:
         200:
           description: "no error"
@@ -6740,7 +6741,7 @@ paths:
   /swarm:
     get:
       summary: "Inspect swarm"
-      operationId: "GetSwarmInspect"
+      operationId: "SwarmInspect"
       responses:
         200:
           description: "no error"
@@ -6792,7 +6793,7 @@ paths:
   /swarm/init:
     post:
       summary: "Initialize a new swarm"
-      operationId: "PostSwarmInit"
+      operationId: "SwarmInit"
       produces:
         - "application/json"
         - "text/plain"
@@ -6848,7 +6849,7 @@ paths:
   /swarm/join:
     post:
       summary: "Join an existing swarm"
-      operationId: "PostSwarmJoin"
+      operationId: "SwarmJoin"
       responses:
         200:
           description: "no error"
@@ -6893,7 +6894,7 @@ paths:
   /swarm/leave:
     post:
       summary: "Leave a swarm"
-      operationId: "PostSwarmLeave"
+      operationId: "SwarmLeave"
       responses:
         200:
           description: "no error"
@@ -6915,7 +6916,7 @@ paths:
   /swarm/update:
     post:
       summary: "Update a swarm"
-      operationId: "PostSwarmUpdate"
+      operationId: "SwarmUpdate"
       responses:
         200:
           description: "no error"
@@ -7012,7 +7013,7 @@ paths:
   /services:
     get:
       summary: "List services"
-      operationId: "GetServicesList"
+      operationId: "ServiceList"
       responses:
         200:
           description: "no error"
@@ -7038,7 +7039,7 @@ paths:
   /services/create:
     post:
       summary: "Create a service"
-      operationId: "PostServicesCreate"
+      operationId: "ServiceCreate"
       consumes:
         - "application/json"
       produces:
@@ -7135,7 +7136,7 @@ paths:
   /services/{id}:
     get:
       summary: "Inspect a service"
-      operationId: "GetServicesInspect"
+      operationId: "ServiceInspect"
       responses:
         200:
           description: "no error"
@@ -7158,7 +7159,7 @@ paths:
       tags: ["Services"]
     delete:
       summary: "Delete a service"
-      operationId: "DeleteServices"
+      operationId: "ServiceDelete"
       responses:
         200:
           description: "no error"
@@ -7300,7 +7301,7 @@ paths:
           description: |
             Return the logs as a stream.
 
-            This will return a `101` HTTP response with a `Connection: upgrade` header, then hijack the HTTP connection to send raw output. For more information about hijacking and the stream format, [see the documentation for the attach endpoint](#operation/PostContainerAttach).
+            This will return a `101` HTTP response with a `Connection: upgrade` header, then hijack the HTTP connection to send raw output. For more information about hijacking and the stream format, [see the documentation for the attach endpoint](#operation/ContainerAttach).
           type: "boolean"
           default: false
         - name: "stdout"
@@ -7332,7 +7333,7 @@ paths:
   /tasks:
     get:
       summary: "List tasks"
-      operationId: "GetTasksList"
+      operationId: "TaskList"
       produces:
         - "application/json"
       responses:
@@ -7475,7 +7476,7 @@ paths:
   /tasks/{id}:
     get:
       summary: "Inspect a task"
-      operationId: "GetTasksInspect"
+      operationId: "TaskInspect"
       produces:
         - "application/json"
       responses:
@@ -7579,7 +7580,7 @@ paths:
   /secrets/{id}:
     get:
       summary: "Inspect a secret"
-      operationId: "SecretsInspect"
+      operationId: "SecretInspect"
       produces:
         - "application/json"
       responses:
@@ -7616,7 +7617,7 @@ paths:
       tags: ["Secrets"]
     delete:
       summary: "Delete a secret"
-      operationId: "SecretsDelete"
+      operationId: "SecretDelete"
       produces:
         - "application/json"
       responses:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -88,6 +88,48 @@ info:
     }
     ```
 
+# The tags on paths define the menu sections in the ReDoc documentation, so
+# the usage of tags must make sense for that:
+# - They should be plural, not singular.
+# - There should not be too many tags, or the menu becomes unwieldly. For
+#   example, it is preferable to add a path to the "System" tag instead of
+#   creating a tag with a single path in it.
+# - The order of tags in this list defines the order in the menu.
+tags:
+  # Primary objects
+  - name: "Containers"
+    description: |
+      Create and manage containers.
+  - name: "Images"
+  - name: "Networks"
+    description: |
+      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+  - name: "Volumes"
+    description: |
+      Create and manage persistent storage that can be attached to containers.
+  - name: "Exec"
+    description: |
+      Run new commands inside running containers. See the [command-line reference](https://docs.docker.com/engine/reference/commandline/exec/) for more information.
+
+      To exec a command in a container, you first need to create an exec instance, then start it. These two API endpoints are wrapped up in a single command-line command, `docker exec`.
+  - name: "Secrets"
+  # Swarm things
+  - name: "Swarm"
+    description: |
+      Engines can be clustered together in a swarm. See [the swarm mode documentation](https://docs.docker.com/engine/swarm/) for more information.
+  - name: "Nodes"
+    description: |
+      Nodes are instances of the Engine participating in a swarm. Swarm mode must be enabled for these endpoints to work.
+  - name: "Services"
+    description: |
+      Services are the definitions of tasks to run on a swarm. Swarm mode must be enabled for these endpoints to work.
+  - name: "Tasks"
+    description: |
+      A task is a container running on a swarm. It is the atomic scheduling unit of swarm. Swarm mode must be enabled for these endpoints to work.
+  # System things
+  - name: "Plugins"
+  - name: "System"
+
 definitions:
   Port:
     type: "object"
@@ -2577,8 +2619,7 @@ paths:
           description: "server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/create:
     post:
       summary: "Create a container"
@@ -2777,8 +2818,7 @@ paths:
           description: "server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/json:
     get:
       summary: "Inspect a container"
@@ -3054,8 +3094,7 @@ paths:
           type: "boolean"
           default: false
           description: "Return the size of container as fields `SizeRw` and `SizeRootFs`"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/top:
     get:
       summary: "List processes running inside a container"
@@ -3131,8 +3170,7 @@ paths:
           description: "The arguments to pass to `ps`. For example, `aux`"
           type: "string"
           default: "-ef"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/logs:
     get:
       summary: "Get container logs"
@@ -3201,8 +3239,7 @@ paths:
           description: "Only return this number of log lines from the end of the logs. Specify as an integer or `all` to output all log lines."
           type: "string"
           default: "all"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/changes:
     get:
       summary: "Get changes on a container’s filesystem"
@@ -3258,8 +3295,7 @@ paths:
           required: true
           description: "ID or name of the container"
           type: "string"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/export:
     get:
       summary: "Export a container"
@@ -3287,8 +3323,7 @@ paths:
           required: true
           description: "ID or name of the container"
           type: "string"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/stats:
     get:
       summary: "Get container stats based on resource usage"
@@ -3416,8 +3451,7 @@ paths:
           description: "Stream the output. If false, the stats will be output once and then it will disconnect."
           type: "boolean"
           default: true
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/resize:
     post:
       summary: "Resize a container TTY"
@@ -3455,8 +3489,7 @@ paths:
           in: "query"
           description: "Width of the tty session in characters"
           type: "integer"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/start:
     post:
       summary: "Start a container"
@@ -3489,8 +3522,7 @@ paths:
           in: "query"
           description: "Override the key sequence for detaching a container. Format is a single character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`."
           type: "string"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/stop:
     post:
       summary: "Stop a container"
@@ -3523,8 +3555,7 @@ paths:
           in: "query"
           description: "Number of seconds to wait before killing the container"
           type: "integer"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/restart:
     post:
       summary: "Restart a container"
@@ -3553,8 +3584,7 @@ paths:
           in: "query"
           description: "Number of seconds to wait before killing the container"
           type: "integer"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/kill:
     post:
       summary: "Kill a container"
@@ -3585,8 +3615,7 @@ paths:
           description: "Signal to send to the container as an integer or string (e.g. `SIGINT`)"
           type: "string"
           default: "SIGKILL"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/update:
     post:
       summary: "Update a container"
@@ -3647,8 +3676,7 @@ paths:
               RestartPolicy:
                 MaximumRetryCount: 4
                 Name: "on-failure"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/rename:
     post:
       summary: "Rename a container"
@@ -3682,8 +3710,7 @@ paths:
           required: true
           description: "New name for the container"
           type: "string"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/pause:
     post:
       summary: "Pause a container"
@@ -3712,8 +3739,7 @@ paths:
           required: true
           description: "ID or name of the container"
           type: "string"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/unpause:
     post:
       summary: "Unpause a container"
@@ -3739,8 +3765,7 @@ paths:
           required: true
           description: "ID or name of the container"
           type: "string"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/attach:
     post:
       summary: "Attach to a container"
@@ -3884,8 +3909,7 @@ paths:
           description: "Attach to `stderr`"
           type: "boolean"
           default: false
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/attach/ws:
     get:
       summary: "Attach to a container via a websocket"
@@ -3945,8 +3969,7 @@ paths:
           description: "Attach to `stderr`"
           type: "boolean"
           default: false
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/wait:
     post:
       summary: "Wait for a container"
@@ -3981,8 +4004,7 @@ paths:
           required: true
           description: "ID or name of the container"
           type: "string"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}:
     delete:
       summary: "Remove a container"
@@ -4021,8 +4043,7 @@ paths:
           description: "If the container is running, kill it before removing it."
           type: "boolean"
           default: false
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/{id}/archive:
     head:
       summary: "Get information about files in a container"
@@ -4068,8 +4089,7 @@ paths:
           required: true
           description: "Resource in the container’s filesystem to archive."
           type: "string"
-      tags:
-        - "Container"
+      tags: ["Containers"]
     get:
       summary: "Get an archive of a filesystem resource in a container"
       description: "Get an tar archive of a resource in the filesystem of container id."
@@ -4112,8 +4132,7 @@ paths:
           required: true
           description: "Resource in the container’s filesystem to archive."
           type: "string"
-      tags:
-        - "Container"
+      tags: ["Containers"]
     put:
       summary: "Extract an archive of files or folders to a directory in a container"
       description: "Upload a tar archive to be extracted to a path in the filesystem of container id."
@@ -4164,8 +4183,7 @@ paths:
           description: "The input stream must be a tar archive compressed with one of the following algorithms: identity (no compression), gzip, bzip2, xz."
           schema:
             type: "string"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /containers/prune:
     post:
       summary: "Delete stopped containers"
@@ -4193,8 +4211,7 @@ paths:
           description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Container"
+      tags: ["Containers"]
   /images/json:
     get:
       summary: "List Images"
@@ -4265,8 +4282,7 @@ paths:
           description: "Show digest information as a `RepoDigests` field on each image."
           type: "boolean"
           default: false
-      tags:
-        - "Image"
+      tags: ["Images"]
   /build:
     post:
       summary: "Build an image"
@@ -4413,8 +4429,7 @@ paths:
           description: "server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Image"
+      tags: ["Images"]
   /images/create:
     post:
       summary: "Create an image"
@@ -4459,8 +4474,7 @@ paths:
           in: "header"
           description: "A base64-encoded auth configuration. [See the authentication section for details.](#section/Authentication)"
           type: "string"
-      tags:
-        - "Image"
+      tags: ["Images"]
   /images/{name}/json:
     get:
       summary: "Inspect an image"
@@ -4566,8 +4580,7 @@ paths:
           description: "Image name or id"
           type: "string"
           required: true
-      tags:
-        - "Image"
+      tags: ["Images"]
   /images/{name}/history:
     get:
       summary: "Get the history of an image"
@@ -4637,8 +4650,7 @@ paths:
           description: "Image name or ID"
           type: "string"
           required: true
-      tags:
-        - "Image"
+      tags: ["Images"]
   /images/{name}/push:
     post:
       summary: "Push an image"
@@ -4677,8 +4689,7 @@ paths:
           description: "A base64-encoded auth configuration. [See the authentication section for details.](#section/Authentication)"
           type: "string"
           required: true
-      tags:
-        - "Image"
+      tags: ["Images"]
   /images/{name}/tag:
     post:
       summary: "Tag an image"
@@ -4717,8 +4728,7 @@ paths:
           in: "query"
           description: "The name of the new tag."
           type: "string"
-      tags:
-        - "Image"
+      tags: ["Images"]
   /images/{name}:
     delete:
       summary: "Remove an image"
@@ -4769,8 +4779,7 @@ paths:
           description: "Do not delete untagged parent images"
           type: "boolean"
           default: false
-      tags:
-        - "Image"
+      tags: ["Images"]
   /images/search:
     get:
       summary: "Search images"
@@ -4836,8 +4845,7 @@ paths:
             - `is-automated=(true|false)`
             - `is-official=(true|false)`
           type: "string"
-      tags:
-        - "Image"
+      tags: ["Images"]
   /images/prune:
     post:
       summary: "Delete unused images"
@@ -4875,8 +4883,7 @@ paths:
           description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Image"
+      tags: ["Images"]
   /auth:
     post:
       summary: "Check auth configuration"
@@ -4915,7 +4922,7 @@ paths:
           description: "Authentication to check"
           schema:
             $ref: "#/definitions/AuthConfig"
-      tags: ["Registry"]
+      tags: ["System"]
   /info:
     get:
       summary: "Get system information"
@@ -5127,8 +5134,7 @@ paths:
           description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Misc"
+      tags: ["System"]
   /version:
     get:
       summary: "Get version"
@@ -5178,8 +5184,7 @@ paths:
           description: "server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Misc"
+      tags: ["System"]
   /_ping:
     get:
       summary: "Ping"
@@ -5197,8 +5202,7 @@ paths:
           description: "server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Misc"
+      tags: ["System"]
   /commit:
     post:
       summary: "Create a new image from a container"
@@ -5258,8 +5262,7 @@ paths:
           in: "query"
           description: "`Dockerfile` instructions to apply while committing"
           type: "string"
-      tags:
-        - "Image"
+      tags: ["Images"]
   /events:
     get:
       summary: "Monitor events"
@@ -5349,8 +5352,7 @@ paths:
             - `network=<string>` network name or ID
             - `daemon=<string>` daemon name or ID
           type: "string"
-      tags:
-        - "Misc"
+      tags: ["System"]
   /system/df:
     get:
       summary: "Get data usage information"
@@ -5438,8 +5440,7 @@ paths:
           description: "server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Misc"
+      tags: ["System"]
   /images/{name}/get:
     get:
       summary: "Export an image"
@@ -5486,8 +5487,7 @@ paths:
           description: "Image name or ID"
           type: "string"
           required: true
-      tags:
-        - "Image"
+      tags: ["Images"]
   /images/get:
     get:
       summary: "Export several images"
@@ -5517,8 +5517,7 @@ paths:
           type: "array"
           items:
             type: "string"
-      tags:
-        - "Image"
+      tags: ["Images"]
   /images/load:
     post:
       summary: "Import images"
@@ -5550,8 +5549,7 @@ paths:
           description: "Suppress progress details during load."
           type: "boolean"
           default: false
-      tags:
-        - "Image"
+      tags: ["Images"]
   /containers/{id}/exec:
     post:
       summary: "Create an exec instance"
@@ -5637,8 +5635,7 @@ paths:
           description: "ID or name of container"
           type: "string"
           required: true
-      tags:
-        - "Exec"
+      tags: ["Exec"]
   /exec/{id}/start:
     post:
       summary: "Start an exec instance"
@@ -5679,8 +5676,7 @@ paths:
           description: "Exec instance ID"
           required: true
           type: "string"
-      tags:
-        - "Exec"
+      tags: ["Exec"]
   /exec/{id}/resize:
     post:
       summary: "Resize an exec instance"
@@ -5707,8 +5703,7 @@ paths:
           in: "query"
           description: "Width of the TTY session in characters"
           type: "integer"
-      tags:
-        - "Exec"
+      tags: ["Exec"]
   /exec/{id}/json:
     get:
       summary: "Inspect an exec instance"
@@ -5775,8 +5770,7 @@ paths:
           description: "Exec instance ID"
           required: true
           type: "string"
-      tags:
-        - "Exec"
+      tags: ["Exec"]
 
   /volumes:
     get:
@@ -5838,7 +5832,7 @@ paths:
               driver name.
           type: "string"
           format: "json"
-      tags: ["Volume"]
+      tags: ["Volumes"]
 
   /volumes/create:
     post:
@@ -5888,7 +5882,7 @@ paths:
                 com.example.some-label: "some-value"
                 com.example.some-other-label: "some-other-value"
               Driver: "custom"
-      tags: ["Volume"]
+      tags: ["Volumes"]
 
   /volumes/{name}:
     get:
@@ -5914,7 +5908,7 @@ paths:
           required: true
           description: "Volume name or ID"
           type: "string"
-      tags: ["Volume"]
+      tags: ["Volumes"]
 
     delete:
       summary: "Remove a volume"
@@ -5946,7 +5940,7 @@ paths:
           description: "Force the removal of the volume"
           type: "boolean"
           default: false
-      tags: ["Volume"]
+      tags: ["Volumes"]
   /volumes/prune:
     post:
       summary: "Delete unused volumes"
@@ -5974,8 +5968,7 @@ paths:
           description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Volume"
+      tags: ["Volumes"]
   /networks:
     get:
       summary: "List networks"
@@ -6056,7 +6049,7 @@ paths:
             - `name=<network-name>` Matches all or part of a network name.
             - `type=["custom"|"builtin"]` Filters networks by type. The `custom` keyword returns all user-defined networks.
           type: "string"
-      tags: ["Network"]
+      tags: ["Networks"]
 
   /networks/{id}:
     get:
@@ -6079,7 +6072,7 @@ paths:
           description: "Network ID or name"
           required: true
           type: "string"
-      tags: ["Network"]
+      tags: ["Networks"]
 
     delete:
       summary: "Remove a network"
@@ -6101,7 +6094,7 @@ paths:
           description: "Network ID or name"
           required: true
           type: "string"
-      tags: ["Network"]
+      tags: ["Networks"]
 
   /networks/create:
     post:
@@ -6197,7 +6190,7 @@ paths:
               Labels:
                 com.example.some-label: "some-value"
                 com.example.some-other-label: "some-other-value"
-      tags: ["Network"]
+      tags: ["Networks"]
 
   /networks/{id}/connect:
     post:
@@ -6243,7 +6236,7 @@ paths:
                 IPAMConfig:
                   IPv4Address: "172.24.56.89"
                   IPv6Address: "2001:db8::5689"
-      tags: ["Network"]
+      tags: ["Networks"]
 
   /networks/{id}/disconnect:
     post:
@@ -6284,7 +6277,7 @@ paths:
               Force:
                 type: "boolean"
                 description: "Force the container to disconnect from the network."
-      tags: ["Network"]
+      tags: ["Networks"]
   /networks/prune:
     post:
       summary: "Delete unused networks"
@@ -6308,8 +6301,7 @@ paths:
           description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Network"
+      tags: ["Networks"]
   /plugins:
     get:
       summary: "List plugins"
@@ -6459,8 +6451,7 @@ paths:
           in: "header"
           description: "A base64-encoded auth configuration to use when pulling a plugin from a registry. [See the authentication section for details.](#section/Authentication)"
           type: "string"
-      tags:
-        - "Plugins"
+      tags: ["Plugins"]
   /plugins/{name}:
     get:
       summary: "Inspect a plugin"
@@ -6484,8 +6475,7 @@ paths:
           description: "The name of the plugin. The `:latest` tag is optional, and is the default if omitted."
           required: true
           type: "string"
-      tags:
-        - "Plugins"
+      tags: ["Plugins"]
     delete:
       summary: "Remove a plugin"
       operationId: "DeletePlugins"
@@ -6513,8 +6503,7 @@ paths:
           description: "Disable the plugin before removing. This may result in issues if the plugin is in use by a container."
           type: "boolean"
           default: false
-      tags:
-        - "Plugins"
+      tags: ["Plugins"]
   /plugins/{name}/enable:
     post:
       summary: "Enable a plugin"
@@ -6537,8 +6526,7 @@ paths:
           description: "Set the HTTP client timeout (in seconds)"
           type: "integer"
           default: 0
-      tags:
-        - "Plugins"
+      tags: ["Plugins"]
   /plugins/{name}/disable:
     post:
       summary: "Disable a plugin"
@@ -6556,8 +6544,7 @@ paths:
           description: "The name of the plugin. The `:latest` tag is optional, and is the default if omitted."
           required: true
           type: "string"
-      tags:
-        - "Plugins"
+      tags: ["Plugins"]
   /plugins/create:
     post:
       summary: "Create a plugin"
@@ -6583,8 +6570,7 @@ paths:
           schema:
             type: "string"
             format: "binary"
-      tags:
-        - "Plugins"
+      tags: ["Plugins"]
   /plugins/{name}/push:
     post:
       summary: "Push a plugin"
@@ -6608,8 +6594,7 @@ paths:
           description: "server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Plugins"
+      tags: ["Plugins"]
   /plugins/{name}/set:
     post:
       summary: "Configure a plugin"
@@ -6640,8 +6625,7 @@ paths:
           description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Plugins"
+      tags: ["Plugins"]
   /nodes:
     get:
       summary: "List nodes"
@@ -6670,8 +6654,7 @@ paths:
             - `name=<node name>`
             - `role=`(`manager`|`worker`)`
           type: "string"
-      tags:
-        - "Nodes"
+      tags: ["Nodes"]
   /nodes/{id}:
     get:
       summary: "Inspect a node"
@@ -6695,8 +6678,7 @@ paths:
           description: "The ID or name of the node"
           type: "string"
           required: true
-      tags:
-        - "Nodes"
+      tags: ["Nodes"]
     delete:
       summary: "Delete a node"
       operationId: "DeleteNodes"
@@ -6722,8 +6704,7 @@ paths:
           description: "Force remove a node from the swarm"
           default: false
           type: "boolean"
-      tags:
-        - "Nodes"
+      tags: ["Nodes"]
   /nodes/{id}/update:
     post:
       summary: "Update a node"
@@ -6755,8 +6736,7 @@ paths:
           type: "integer"
           format: "int64"
           required: true
-      tags:
-        - "Nodes"
+      tags: ["Nodes"]
   /swarm:
     get:
       summary: "Inspect swarm"
@@ -6808,8 +6788,7 @@ paths:
           description: "server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Swarm"
+      tags: ["Swarm"]
   /swarm/init:
     post:
       summary: "Initialize a new swarm"
@@ -6865,8 +6844,7 @@ paths:
                 CAConfig: {}
                 EncryptionConfig:
                   AutoLockManagers: false
-      tags:
-        - "Swarm"
+      tags: ["Swarm"]
   /swarm/join:
     post:
       summary: "Join an existing swarm"
@@ -6911,8 +6889,7 @@ paths:
               RemoteAddrs:
                 - "node1:2377"
               JoinToken: "SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-7p73s1dx5in4tatdymyhg9hu2"
-      tags:
-        - "Swarm"
+      tags: ["Swarm"]
   /swarm/leave:
     post:
       summary: "Leave a swarm"
@@ -6934,8 +6911,7 @@ paths:
           in: "query"
           type: "boolean"
           default: false
-      tags:
-        - "Swarm"
+      tags: ["Swarm"]
   /swarm/update:
     post:
       summary: "Update a swarm"
@@ -6982,8 +6958,7 @@ paths:
           description: "Rotate the manager unlock key."
           type: "boolean"
           default: false
-      tags:
-        - "Swarm"
+      tags: ["Swarm"]
   /swarm/unlockkey:
     get:
       summary: "Get the unlock key"
@@ -7005,8 +6980,7 @@ paths:
           description: "server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Swarm"
+      tags: ["Swarm"]
   /swarm/unlock:
     post:
       summary: "Unlock a locked manager"
@@ -7034,8 +7008,7 @@ paths:
           description: "server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags:
-        - "Swarm"
+      tags: ["Swarm"]
   /services:
     get:
       summary: "List services"
@@ -7061,8 +7034,7 @@ paths:
             - `id=<service id>`
             - `name=<service name>`
             - `label=<service label>`
-      tags:
-        - "Services"
+      tags: ["Services"]
   /services/create:
     post:
       summary: "Create a service"
@@ -7159,8 +7131,7 @@ paths:
           in: "header"
           description: "A base64-encoded auth configuration for pulling from private registries. [See the authentication section for details.](#section/Authentication)"
           type: "string"
-      tags:
-        - "Services"
+      tags: ["Services"]
   /services/{id}:
     get:
       summary: "Inspect a service"
@@ -7184,8 +7155,7 @@ paths:
           description: "ID or name of service."
           required: true
           type: "string"
-      tags:
-        - "Services"
+      tags: ["Services"]
     delete:
       summary: "Delete a service"
       operationId: "DeleteServices"
@@ -7206,8 +7176,7 @@ paths:
           description: "ID or name of service."
           required: true
           type: "string"
-      tags:
-        - "Services"
+      tags: ["Services"]
   /services/{id}/update:
     post:
       summary: "Update a service"
@@ -7359,8 +7328,7 @@ paths:
           description: "Only return this number of log lines from the end of the logs. Specify as an integer or `all` to output all log lines."
           type: "string"
           default: "all"
-      tags:
-        - "Services"
+      tags: ["Services"]
   /tasks:
     get:
       summary: "List tasks"
@@ -7503,8 +7471,7 @@ paths:
             - `node=<node id or name>`
             - `label=key` or `label="key=value"`
             - `desired-state=(running | shutdown | accepted)`
-      tags:
-        - "Tasks"
+      tags: ["Tasks"]
   /tasks/{id}:
     get:
       summary: "Inspect a task"
@@ -7530,8 +7497,7 @@ paths:
           description: "ID of the task"
           required: true
           type: "string"
-      tags:
-        - "Tasks"
+      tags: ["Tasks"]
   /secrets:
     get:
       summary: "List secrets"
@@ -7565,8 +7531,7 @@ paths:
             A JSON encoded value of the filters (a `map[string][]string`) to process on the secrets list. Available filters:
 
             - `names=<secret name>`
-      tags:
-        - "Secrets"
+      tags: ["Secrets"]
   /secrets/create:
     post:
       summary: "Create a secret"
@@ -7610,8 +7575,7 @@ paths:
                   Labels:
                     foo: "bar"
                   Data: "VEhJUyBJUyBOT1QgQSBSRUFMIENFUlRJRklDQVRFCg=="
-      tags:
-        - "Secrets"
+      tags: ["Secrets"]
   /secrets/{id}:
     get:
       summary: "Inspect a secret"
@@ -7649,8 +7613,7 @@ paths:
           required: true
           type: "string"
           description: "ID of the secret"
-      tags:
-        - "Secrets"
+      tags: ["Secrets"]
     delete:
       summary: "Delete a secret"
       operationId: "SecretsDelete"
@@ -7673,5 +7636,4 @@ paths:
           required: true
           type: "string"
           description: "ID of the secret"
-      tags:
-        - "Secrets"
+      tags: ["Secrets"]

--- a/docs/api/v1.18.md
+++ b/docs/api/v1.18.md
@@ -16,9 +16,7 @@ redirect_from:
      will be rejected.
 -->
 
-# Docker Engine API v1.18
-
-# 1. Brief introduction
+## 1. Brief introduction
 
  - The daemon listens on `unix:///var/run/docker.sock` but you can
    [Bind Docker to another host/port or a Unix socket](../commandline/dockerd.md#bind-docker-to-another-host-port-or-a-unix-socket).
@@ -26,11 +24,11 @@ redirect_from:
    or `pull`, the HTTP connection is hijacked to transport `STDOUT`,
    `STDIN` and `STDERR`.
 
-# 2. Endpoints
+## 2. Endpoints
 
-## 2.1 Containers
+### 2.1 Containers
 
-### List containers
+#### List containers
 
 `GET /containers/json`
 
@@ -123,7 +121,7 @@ List containers
 -   **400** – bad parameter
 -   **500** – server error
 
-### Create a container
+#### Create a container
 
 `POST /containers/create`
 
@@ -310,7 +308,7 @@ Create a container
 -   **409** – conflict
 -   **500** – server error
 
-### Inspect a container
+#### Inspect a container
 
 `GET /containers/(id or name)/json`
 
@@ -443,7 +441,7 @@ Return low-level information on the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### List processes running inside a container
+#### List processes running inside a container
 
 `GET /containers/(id or name)/top`
 
@@ -507,7 +505,7 @@ supported on Windows.
 -   **404** – no such container
 -   **500** – server error
 
-### Get container logs
+#### Get container logs
 
 `GET /containers/(id or name)/logs`
 
@@ -547,7 +545,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 -   **404** – no such container
 -   **500** – server error
 
-### Inspect changes on a container's filesystem
+#### Inspect changes on a container's filesystem
 
 `GET /containers/(id or name)/changes`
 
@@ -589,7 +587,7 @@ Values for `Kind`:
 -   **404** – no such container
 -   **500** – server error
 
-### Export a container
+#### Export a container
 
 `GET /containers/(id or name)/export`
 
@@ -614,7 +612,7 @@ Export the contents of container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Get container stats based on resource usage
+#### Get container stats based on resource usage
 
 `GET /containers/(id or name)/stats`
 
@@ -702,7 +700,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 -   **404** – no such container
 -   **500** – server error
 
-### Resize a container TTY
+#### Resize a container TTY
 
 `POST /containers/(id or name)/resize?h=<height>&w=<width>`
 
@@ -729,7 +727,7 @@ Resize the TTY for container with  `id`. You must restart the container for the 
 -   **404** – No such container
 -   **500** – Cannot resize container
 
-### Start a container
+#### Start a container
 
 `POST /containers/(id or name)/start`
 
@@ -754,7 +752,7 @@ Start the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Stop a container
+#### Stop a container
 
 `POST /containers/(id or name)/stop`
 
@@ -779,7 +777,7 @@ Stop the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Restart a container
+#### Restart a container
 
 `POST /containers/(id or name)/restart`
 
@@ -803,7 +801,7 @@ Restart the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Kill a container
+#### Kill a container
 
 `POST /containers/(id or name)/kill`
 
@@ -828,7 +826,7 @@ Kill the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Rename a container
+#### Rename a container
 
 `POST /containers/(id or name)/rename`
 
@@ -853,7 +851,7 @@ Rename the container `id` to a `new_name`
 -   **409** - conflict name already assigned
 -   **500** – server error
 
-### Pause a container
+#### Pause a container
 
 `POST /containers/(id or name)/pause`
 
@@ -873,7 +871,7 @@ Pause the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Unpause a container
+#### Unpause a container
 
 `POST /containers/(id or name)/unpause`
 
@@ -893,7 +891,7 @@ Unpause the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Attach to a container
+#### Attach to a container
 
 `POST /containers/(id or name)/attach`
 
@@ -978,7 +976,7 @@ The simplest way to implement the Attach protocol is the following:
     4.  Read the extracted size and output it on the correct output.
     5.  Goto 1.
 
-### Attach to a container (websocket)
+#### Attach to a container (websocket)
 
 `GET /containers/(id or name)/attach/ws`
 
@@ -1015,7 +1013,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **404** – no such container
 -   **500** – server error
 
-### Wait a container
+#### Wait a container
 
 `POST /containers/(id or name)/wait`
 
@@ -1038,7 +1036,7 @@ Block until container `id` stops, then returns the exit code
 -   **404** – no such container
 -   **500** – server error
 
-### Remove a container
+#### Remove a container
 
 `DELETE /containers/(id or name)`
 
@@ -1067,7 +1065,7 @@ Remove the container `id` from the filesystem
 -   **409** – conflict
 -   **500** – server error
 
-### Copy files or folders from a container
+#### Copy files or folders from a container
 
 `POST /containers/(id or name)/copy`
 
@@ -1097,9 +1095,9 @@ Copy files or folders of container `id`
 -   **404** – no such container
 -   **500** – server error
 
-## 2.2 Images
+### 2.2 Images
 
-### List Images
+#### List Images
 
 `GET /images/json`
 
@@ -1185,7 +1183,7 @@ references on the command line.
   -   `label=key` or `label="key=value"` of an image label
 -   **filter** - only return images with the specified name
 
-### Build image from a Dockerfile
+#### Build image from a Dockerfile
 
 `POST /build`
 
@@ -1256,7 +1254,7 @@ or being killed.
 -   **200** – no error
 -   **500** – server error
 
-### Create an image
+#### Create an image
 
 `POST /images/create`
 
@@ -1300,7 +1298,7 @@ a base64-encoded AuthConfig object.
 
 
 
-### Inspect an image
+#### Inspect an image
 
 `GET /images/(name)/json`
 
@@ -1351,7 +1349,7 @@ Return low-level information on the image `name`
 -   **404** – no such image
 -   **500** – server error
 
-### Get the history of an image
+#### Get the history of an image
 
 `GET /images/(name)/history`
 
@@ -1385,7 +1383,7 @@ Return the history of the image `name`
 -   **404** – no such image
 -   **500** – server error
 
-### Push an image on the registry
+#### Push an image on the registry
 
 `POST /images/(name)/push`
 
@@ -1428,7 +1426,7 @@ then be used in the URL. This duplicates the command line's flow.
 -   **404** – no such image
 -   **500** – server error
 
-### Tag an image into a repository
+#### Tag an image into a repository
 
 `POST /images/(name)/tag`
 
@@ -1456,7 +1454,7 @@ Tag the image `name` into a repository
 -   **409** – conflict
 -   **500** – server error
 
-### Remove an image
+#### Remove an image
 
 `DELETE /images/(name)`
 
@@ -1489,7 +1487,7 @@ Remove the image `name` from the filesystem
 -   **409** – conflict
 -   **500** – server error
 
-### Search images
+#### Search images
 
 `GET /images/search`
 
@@ -1542,9 +1540,9 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 -   **200** – no error
 -   **500** – server error
 
-## 2.3 Misc
+### 2.3 Misc
 
-### Check auth configuration
+#### Check auth configuration
 
 `POST /auth`
 
@@ -1572,7 +1570,7 @@ Get the default username and email
 -   **204** – no error
 -   **500** – server error
 
-### Display system-wide information
+#### Display system-wide information
 
 `GET /info`
 
@@ -1637,7 +1635,7 @@ Display system-wide information
 -   **200** – no error
 -   **500** – server error
 
-### Show the docker version information
+#### Show the docker version information
 
 `GET /version`
 
@@ -1667,7 +1665,7 @@ Show the docker version information
 -   **200** – no error
 -   **500** – server error
 
-### Ping the docker server
+#### Ping the docker server
 
 `GET /_ping`
 
@@ -1689,7 +1687,7 @@ Ping the docker server
 -   **200** - no error
 -   **500** - server error
 
-### Create a new image from a container's changes
+#### Create a new image from a container's changes
 
 `POST /commit`
 
@@ -1751,7 +1749,7 @@ Create a new image from a container's changes
 -   **404** – no such container
 -   **500** – server error
 
-### Monitor Docker's events
+#### Monitor Docker's events
 
 `GET /events`
 
@@ -1793,7 +1791,7 @@ Docker images report the following events:
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images in a repository
+#### Get a tarball containing all images in a repository
 
 `GET /images/(name)/get`
 
@@ -1823,7 +1821,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images
+#### Get a tarball containing all images
 
 `GET /images/get`
 
@@ -1852,7 +1850,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Load a tarball with a set of images and tags into docker
+#### Load a tarball with a set of images and tags into docker
 
 `POST /images/load`
 
@@ -1875,7 +1873,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Image tarball format
+#### Image tarball format
 
 An image tarball contains one directory per image layer (named using its long ID),
 each containing these files:
@@ -1896,7 +1894,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 }
 ```
 
-### Exec Create
+#### Exec Create
 
 `POST /containers/(id or name)/exec`
 
@@ -1939,7 +1937,7 @@ Sets up an exec instance in a running container `id`
 -   **201** – no error
 -   **404** – no such container
 
-### Exec Start
+#### Exec Start
 
 `POST /exec/(id)/start`
 
@@ -1980,7 +1978,7 @@ interactive session with the `exec` command.
 
 Similar to the stream behavior of `POST /containers/(id or name)/attach` API
 
-### Exec Resize
+#### Exec Resize
 
 `POST /exec/(id)/resize`
 
@@ -2007,7 +2005,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 -   **201** – no error
 -   **404** – no such exec instance
 
-### Exec Inspect
+#### Exec Inspect
 
 `GET /exec/(id)/json`
 
@@ -2112,9 +2110,9 @@ Return low-level information about the `exec` command `id`.
 -   **404** – no such exec instance
 -   **500** - server error
 
-# 3. Going further
+## 3. Going further
 
-## 3.1 Inside `docker run`
+### 3.1 Inside `docker run`
 
 As an example, the `docker run` command line makes the following API calls:
 
@@ -2132,7 +2130,7 @@ As an example, the `docker run` command line makes the following API calls:
 
 - If in detached mode or only `stdin` is attached, display the container's id.
 
-## 3.2 Hijacking
+### 3.2 Hijacking
 
 In this version of the API, `/attach`, uses hijacking to transport `stdin`,
 `stdout`, and `stderr` on the same socket.
@@ -2148,7 +2146,7 @@ from **200 OK** to **101 UPGRADED** and resends the same headers.
 
 This might change in the future.
 
-## 3.3 CORS Requests
+### 3.3 CORS Requests
 
 To set cross origin requests to the Engine API please give values to
 `--api-cors-header` when running Docker in daemon mode. Set * (asterisk) allows all,

--- a/docs/api/v1.19.md
+++ b/docs/api/v1.19.md
@@ -16,8 +16,6 @@ redirect_from:
      will be rejected.
 -->
 
-# Docker Engine API v1.19
-
 ## 1. Brief introduction
 
  - The daemon listens on `unix:///var/run/docker.sock` but you can
@@ -28,11 +26,11 @@ redirect_from:
  - When the client API version is newer than the daemon's, these calls return an HTTP
    `400 Bad Request` error message.
 
-# 2. Endpoints
+## 2. Endpoints
 
-## 2.1 Containers
+### 2.1 Containers
 
-### List containers
+#### List containers
 
 `GET /containers/json`
 
@@ -125,7 +123,7 @@ List containers
 -   **400** – bad parameter
 -   **500** – server error
 
-### Create a container
+#### Create a container
 
 `POST /containers/create`
 
@@ -322,7 +320,7 @@ Create a container
 -   **409** – conflict
 -   **500** – server error
 
-### Inspect a container
+#### Inspect a container
 
 `GET /containers/(id or name)/json`
 
@@ -459,7 +457,7 @@ Return low-level information on the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### List processes running inside a container
+#### List processes running inside a container
 
 `GET /containers/(id or name)/top`
 
@@ -523,7 +521,7 @@ supported on Windows.
 -   **404** – no such container
 -   **500** – server error
 
-### Get container logs
+#### Get container logs
 
 `GET /containers/(id or name)/logs`
 
@@ -565,7 +563,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 -   **404** – no such container
 -   **500** – server error
 
-### Inspect changes on a container's filesystem
+#### Inspect changes on a container's filesystem
 
 `GET /containers/(id or name)/changes`
 
@@ -607,7 +605,7 @@ Values for `Kind`:
 -   **404** – no such container
 -   **500** – server error
 
-### Export a container
+#### Export a container
 
 `GET /containers/(id or name)/export`
 
@@ -632,7 +630,7 @@ Export the contents of container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Get container stats based on resource usage
+#### Get container stats based on resource usage
 
 `GET /containers/(id or name)/stats`
 
@@ -741,7 +739,7 @@ The precpu_stats is the cpu statistic of last read, which is used for calculatin
 -   **404** – no such container
 -   **500** – server error
 
-### Resize a container TTY
+#### Resize a container TTY
 
 `POST /containers/(id or name)/resize?h=<height>&w=<width>`
 
@@ -768,7 +766,7 @@ Resize the TTY for container with  `id`. You must restart the container for the 
 -   **404** – No such container
 -   **500** – Cannot resize container
 
-### Start a container
+#### Start a container
 
 `POST /containers/(id or name)/start`
 
@@ -793,7 +791,7 @@ Start the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Stop a container
+#### Stop a container
 
 `POST /containers/(id or name)/stop`
 
@@ -818,7 +816,7 @@ Stop the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Restart a container
+#### Restart a container
 
 `POST /containers/(id or name)/restart`
 
@@ -842,7 +840,7 @@ Restart the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Kill a container
+#### Kill a container
 
 `POST /containers/(id or name)/kill`
 
@@ -867,7 +865,7 @@ Kill the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Rename a container
+#### Rename a container
 
 `POST /containers/(id or name)/rename`
 
@@ -892,7 +890,7 @@ Rename the container `id` to a `new_name`
 -   **409** - conflict name already assigned
 -   **500** – server error
 
-### Pause a container
+#### Pause a container
 
 `POST /containers/(id or name)/pause`
 
@@ -912,7 +910,7 @@ Pause the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Unpause a container
+#### Unpause a container
 
 `POST /containers/(id or name)/unpause`
 
@@ -932,7 +930,7 @@ Unpause the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Attach to a container
+#### Attach to a container
 
 `POST /containers/(id or name)/attach`
 
@@ -1017,7 +1015,7 @@ The simplest way to implement the Attach protocol is the following:
     4.  Read the extracted size and output it on the correct output.
     5.  Goto 1.
 
-### Attach to a container (websocket)
+#### Attach to a container (websocket)
 
 `GET /containers/(id or name)/attach/ws`
 
@@ -1054,7 +1052,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **404** – no such container
 -   **500** – server error
 
-### Wait a container
+#### Wait a container
 
 `POST /containers/(id or name)/wait`
 
@@ -1077,7 +1075,7 @@ Block until container `id` stops, then returns the exit code
 -   **404** – no such container
 -   **500** – server error
 
-### Remove a container
+#### Remove a container
 
 `DELETE /containers/(id or name)`
 
@@ -1106,7 +1104,7 @@ Remove the container `id` from the filesystem
 -   **409** – conflict
 -   **500** – server error
 
-### Copy files or folders from a container
+#### Copy files or folders from a container
 
 `POST /containers/(id or name)/copy`
 
@@ -1136,9 +1134,9 @@ Copy files or folders of container `id`
 -   **404** – no such container
 -   **500** – server error
 
-## 2.2 Images
+### 2.2 Images
 
-### List Images
+#### List Images
 
 `GET /images/json`
 
@@ -1229,7 +1227,7 @@ references on the command line.
   -   `label=key` or `label="key=value"` of an image label
 -   **filter** - only return images with the specified name
 
-### Build image from a Dockerfile
+#### Build image from a Dockerfile
 
 `POST /build`
 
@@ -1302,7 +1300,7 @@ or being killed.
 -   **200** – no error
 -   **500** – server error
 
-### Create an image
+#### Create an image
 
 `POST /images/create`
 
@@ -1346,7 +1344,7 @@ a base64-encoded AuthConfig object.
 
 
 
-### Inspect an image
+#### Inspect an image
 
 `GET /images/(name)/json`
 
@@ -1397,7 +1395,7 @@ Return low-level information on the image `name`
 -   **404** – no such image
 -   **500** – server error
 
-### Get the history of an image
+#### Get the history of an image
 
 `GET /images/(name)/history`
 
@@ -1451,7 +1449,7 @@ Return the history of the image `name`
 -   **404** – no such image
 -   **500** – server error
 
-### Push an image on the registry
+#### Push an image on the registry
 
 `POST /images/(name)/push`
 
@@ -1494,7 +1492,7 @@ then be used in the URL. This duplicates the command line's flow.
 -   **404** – no such image
 -   **500** – server error
 
-### Tag an image into a repository
+#### Tag an image into a repository
 
 `POST /images/(name)/tag`
 
@@ -1522,7 +1520,7 @@ Tag the image `name` into a repository
 -   **409** – conflict
 -   **500** – server error
 
-### Remove an image
+#### Remove an image
 
 `DELETE /images/(name)`
 
@@ -1555,7 +1553,7 @@ Remove the image `name` from the filesystem
 -   **409** – conflict
 -   **500** – server error
 
-### Search images
+#### Search images
 
 `GET /images/search`
 
@@ -1614,9 +1612,9 @@ be deprecated and replaced by the `is_automated` property.
 -   **200** – no error
 -   **500** – server error
 
-## 2.3 Misc
+### 2.3 Misc
 
-### Check auth configuration
+#### Check auth configuration
 
 `POST /auth`
 
@@ -1644,7 +1642,7 @@ Get the default username and email
 -   **204** – no error
 -   **500** – server error
 
-### Display system-wide information
+#### Display system-wide information
 
 `GET /info`
 
@@ -1713,7 +1711,7 @@ Display system-wide information
 -   **200** – no error
 -   **500** – server error
 
-### Show the docker version information
+#### Show the docker version information
 
 `GET /version`
 
@@ -1743,7 +1741,7 @@ Show the docker version information
 -   **200** – no error
 -   **500** – server error
 
-### Ping the docker server
+#### Ping the docker server
 
 `GET /_ping`
 
@@ -1765,7 +1763,7 @@ Ping the docker server
 -   **200** - no error
 -   **500** - server error
 
-### Create a new image from a container's changes
+#### Create a new image from a container's changes
 
 `POST /commit`
 
@@ -1831,7 +1829,7 @@ Create a new image from a container's changes
 -   **404** – no such container
 -   **500** – server error
 
-### Monitor Docker's events
+#### Monitor Docker's events
 
 `GET /events`
 
@@ -1873,7 +1871,7 @@ Docker images report the following events:
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images in a repository
+#### Get a tarball containing all images in a repository
 
 `GET /images/(name)/get`
 
@@ -1903,7 +1901,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images
+#### Get a tarball containing all images
 
 `GET /images/get`
 
@@ -1932,7 +1930,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Load a tarball with a set of images and tags into docker
+#### Load a tarball with a set of images and tags into docker
 
 `POST /images/load`
 
@@ -1955,7 +1953,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Image tarball format
+#### Image tarball format
 
 An image tarball contains one directory per image layer (named using its long ID),
 each containing these files:
@@ -1976,7 +1974,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 }
 ```
 
-### Exec Create
+#### Exec Create
 
 `POST /containers/(id or name)/exec`
 
@@ -2022,7 +2020,7 @@ Sets up an exec instance in a running container `id`
 -   **201** – no error
 -   **404** – no such container
 
-### Exec Start
+#### Exec Start
 
 `POST /exec/(id)/start`
 
@@ -2063,7 +2061,7 @@ interactive session with the `exec` command.
 
 Similar to the stream behavior of `POST /containers/(id or name)/attach` API
 
-### Exec Resize
+#### Exec Resize
 
 `POST /exec/(id)/resize`
 
@@ -2090,7 +2088,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 -   **201** – no error
 -   **404** – no such exec instance
 
-### Exec Inspect
+#### Exec Inspect
 
 `GET /exec/(id)/json`
 
@@ -2195,9 +2193,9 @@ Return low-level information about the `exec` command `id`.
 -   **404** – no such exec instance
 -   **500** - server error
 
-# 3. Going further
+## 3. Going further
 
-## 3.1 Inside `docker run`
+### 3.1 Inside `docker run`
 
 As an example, the `docker run` command line makes the following API calls:
 
@@ -2215,7 +2213,7 @@ As an example, the `docker run` command line makes the following API calls:
 
 - If in detached mode or only `stdin` is attached, display the container's id.
 
-## 3.2 Hijacking
+### 3.2 Hijacking
 
 In this version of the API, `/attach`, uses hijacking to transport `stdin`,
 `stdout`, and `stderr` on the same socket.
@@ -2230,7 +2228,7 @@ When Docker daemon detects the `Upgrade` header, it switches its status code
 from **200 OK** to **101 UPGRADED** and resends the same headers.
 
 
-## 3.3 CORS Requests
+### 3.3 CORS Requests
 
 To set cross origin requests to the Engine API please give values to
 `--api-cors-header` when running Docker in daemon mode. Set * (asterisk) allows all,

--- a/docs/api/v1.20.md
+++ b/docs/api/v1.20.md
@@ -16,9 +16,7 @@ redirect_from:
      will be rejected.
 -->
 
-# Docker Engine API v1.20
-
-# 1. Brief introduction
+## 1. Brief introduction
 
  - The daemon listens on `unix:///var/run/docker.sock` but you can
    [Bind Docker to another host/port or a Unix socket](../commandline/dockerd.md#bind-docker-to-another-host-port-or-a-unix-socket).
@@ -26,11 +24,11 @@ redirect_from:
    or `pull`, the HTTP connection is hijacked to transport `stdout`,
    `stdin` and `stderr`.
 
-# 2. Endpoints
+## 2. Endpoints
 
-## 2.1 Containers
+### 2.1 Containers
 
-### List containers
+#### List containers
 
 `GET /containers/json`
 
@@ -123,7 +121,7 @@ List containers
 -   **400** – bad parameter
 -   **500** – server error
 
-### Create a container
+#### Create a container
 
 `POST /containers/create`
 
@@ -324,7 +322,7 @@ Create a container
 -   **409** – conflict
 -   **500** – server error
 
-### Inspect a container
+#### Inspect a container
 
 `GET /containers/(id or name)/json`
 
@@ -466,7 +464,7 @@ Return low-level information on the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### List processes running inside a container
+#### List processes running inside a container
 
 `GET /containers/(id or name)/top`
 
@@ -530,7 +528,7 @@ supported on Windows.
 -   **404** – no such container
 -   **500** – server error
 
-### Get container logs
+#### Get container logs
 
 `GET /containers/(id or name)/logs`
 
@@ -572,7 +570,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 -   **404** – no such container
 -   **500** – server error
 
-### Inspect changes on a container's filesystem
+#### Inspect changes on a container's filesystem
 
 `GET /containers/(id or name)/changes`
 
@@ -614,7 +612,7 @@ Values for `Kind`:
 -   **404** – no such container
 -   **500** – server error
 
-### Export a container
+#### Export a container
 
 `GET /containers/(id or name)/export`
 
@@ -639,7 +637,7 @@ Export the contents of container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Get container stats based on resource usage
+#### Get container stats based on resource usage
 
 `GET /containers/(id or name)/stats`
 
@@ -748,7 +746,7 @@ The precpu_stats is the cpu statistic of last read, which is used for calculatin
 -   **404** – no such container
 -   **500** – server error
 
-### Resize a container TTY
+#### Resize a container TTY
 
 `POST /containers/(id or name)/resize?h=<height>&w=<width>`
 
@@ -775,7 +773,7 @@ Resize the TTY for container with  `id`. You must restart the container for the 
 -   **404** – No such container
 -   **500** – Cannot resize container
 
-### Start a container
+#### Start a container
 
 `POST /containers/(id or name)/start`
 
@@ -800,7 +798,7 @@ Start the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Stop a container
+#### Stop a container
 
 `POST /containers/(id or name)/stop`
 
@@ -825,7 +823,7 @@ Stop the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Restart a container
+#### Restart a container
 
 `POST /containers/(id or name)/restart`
 
@@ -849,7 +847,7 @@ Restart the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Kill a container
+#### Kill a container
 
 `POST /containers/(id or name)/kill`
 
@@ -874,7 +872,7 @@ Kill the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Rename a container
+#### Rename a container
 
 `POST /containers/(id or name)/rename`
 
@@ -899,7 +897,7 @@ Rename the container `id` to a `new_name`
 -   **409** - conflict name already assigned
 -   **500** – server error
 
-### Pause a container
+#### Pause a container
 
 `POST /containers/(id or name)/pause`
 
@@ -919,7 +917,7 @@ Pause the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Unpause a container
+#### Unpause a container
 
 `POST /containers/(id or name)/unpause`
 
@@ -939,7 +937,7 @@ Unpause the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Attach to a container
+#### Attach to a container
 
 `POST /containers/(id or name)/attach`
 
@@ -1024,7 +1022,7 @@ The simplest way to implement the Attach protocol is the following:
     4.  Read the extracted size and output it on the correct output.
     5.  Goto 1.
 
-### Attach to a container (websocket)
+#### Attach to a container (websocket)
 
 `GET /containers/(id or name)/attach/ws`
 
@@ -1061,7 +1059,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **404** – no such container
 -   **500** – server error
 
-### Wait a container
+#### Wait a container
 
 `POST /containers/(id or name)/wait`
 
@@ -1084,7 +1082,7 @@ Block until container `id` stops, then returns the exit code
 -   **404** – no such container
 -   **500** – server error
 
-### Remove a container
+#### Remove a container
 
 `DELETE /containers/(id or name)`
 
@@ -1113,7 +1111,7 @@ Remove the container `id` from the filesystem
 -   **409** – conflict
 -   **500** – server error
 
-### Copy files or folders from a container
+#### Copy files or folders from a container
 
 `POST /containers/(id or name)/copy`
 
@@ -1145,14 +1143,14 @@ Copy files or folders of container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Retrieving information about files and folders in a container
+#### Retrieving information about files and folders in a container
 
 `HEAD /containers/(id or name)/archive`
 
 See the description of the `X-Docker-Container-Path-Stat` header in the
 following section.
 
-### Get an archive of a filesystem resource in a container
+#### Get an archive of a filesystem resource in a container
 
 `GET /containers/(id or name)/archive`
 
@@ -1217,7 +1215,7 @@ desired.
     - no such file or directory (**path** does not exist)
 - **500** - server error
 
-### Extract an archive of files or folders to a directory in a container
+#### Extract an archive of files or folders to a directory in a container
 
 `PUT /containers/(id or name)/archive`
 
@@ -1265,9 +1263,9 @@ Upload a tar archive to be extracted to a path in the filesystem of container
     - no such file or directory (**path** resource does not exist)
 - **500** – server error
 
-## 2.2 Images
+### 2.2 Images
 
-### List Images
+#### List Images
 
 `GET /images/json`
 
@@ -1358,7 +1356,7 @@ references on the command line.
   -   `label=key` or `label="key=value"` of an image label
 -   **filter** - only return images with the specified name
 
-### Build image from a Dockerfile
+#### Build image from a Dockerfile
 
 `POST /build`
 
@@ -1456,7 +1454,7 @@ or being killed.
 -   **200** – no error
 -   **500** – server error
 
-### Create an image
+#### Create an image
 
 `POST /images/create`
 
@@ -1500,7 +1498,7 @@ a base64-encoded AuthConfig object.
 
 
 
-### Inspect an image
+#### Inspect an image
 
 `GET /images/(name)/json`
 
@@ -1551,7 +1549,7 @@ Return low-level information on the image `name`
 -   **404** – no such image
 -   **500** – server error
 
-### Get the history of an image
+#### Get the history of an image
 
 `GET /images/(name)/history`
 
@@ -1605,7 +1603,7 @@ Return the history of the image `name`
 -   **404** – no such image
 -   **500** – server error
 
-### Push an image on the registry
+#### Push an image on the registry
 
 `POST /images/(name)/push`
 
@@ -1648,7 +1646,7 @@ then be used in the URL. This duplicates the command line's flow.
 -   **404** – no such image
 -   **500** – server error
 
-### Tag an image into a repository
+#### Tag an image into a repository
 
 `POST /images/(name)/tag`
 
@@ -1676,7 +1674,7 @@ Tag the image `name` into a repository
 -   **409** – conflict
 -   **500** – server error
 
-### Remove an image
+#### Remove an image
 
 `DELETE /images/(name)`
 
@@ -1709,7 +1707,7 @@ Remove the image `name` from the filesystem
 -   **409** – conflict
 -   **500** – server error
 
-### Search images
+#### Search images
 
 `GET /images/search`
 
@@ -1762,9 +1760,9 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 -   **200** – no error
 -   **500** – server error
 
-## 2.3 Misc
+### 2.3 Misc
 
-### Check auth configuration
+#### Check auth configuration
 
 `POST /auth`
 
@@ -1792,7 +1790,7 @@ Get the default username and email
 -   **204** – no error
 -   **500** – server error
 
-### Display system-wide information
+#### Display system-wide information
 
 `GET /info`
 
@@ -1861,7 +1859,7 @@ Display system-wide information
 -   **200** – no error
 -   **500** – server error
 
-### Show the docker version information
+#### Show the docker version information
 
 `GET /version`
 
@@ -1892,7 +1890,7 @@ Show the docker version information
 -   **200** – no error
 -   **500** – server error
 
-### Ping the docker server
+#### Ping the docker server
 
 `GET /_ping`
 
@@ -1914,7 +1912,7 @@ Ping the docker server
 -   **200** - no error
 -   **500** - server error
 
-### Create a new image from a container's changes
+#### Create a new image from a container's changes
 
 `POST /commit`
 
@@ -1986,7 +1984,7 @@ Create a new image from a container's changes
 -   **404** – no such container
 -   **500** – server error
 
-### Monitor Docker's events
+#### Monitor Docker's events
 
 `GET /events`
 
@@ -2028,7 +2026,7 @@ Docker images report the following events:
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images in a repository
+#### Get a tarball containing all images in a repository
 
 `GET /images/(name)/get`
 
@@ -2058,7 +2056,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images
+#### Get a tarball containing all images
 
 `GET /images/get`
 
@@ -2087,7 +2085,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Load a tarball with a set of images and tags into docker
+#### Load a tarball with a set of images and tags into docker
 
 `POST /images/load`
 
@@ -2110,7 +2108,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Image tarball format
+#### Image tarball format
 
 An image tarball contains one directory per image layer (named using its long ID),
 each containing these files:
@@ -2131,7 +2129,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 }
 ```
 
-### Exec Create
+#### Exec Create
 
 `POST /containers/(id or name)/exec`
 
@@ -2177,7 +2175,7 @@ Sets up an exec instance in a running container `id`
 -   **201** – no error
 -   **404** – no such container
 
-### Exec Start
+#### Exec Start
 
 `POST /exec/(id)/start`
 
@@ -2218,7 +2216,7 @@ interactive session with the `exec` command.
 
 Similar to the stream behavior of `POST /containers/(id or name)/attach` API
 
-### Exec Resize
+#### Exec Resize
 
 `POST /exec/(id)/resize`
 
@@ -2245,7 +2243,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 -   **201** – no error
 -   **404** – no such exec instance
 
-### Exec Inspect
+#### Exec Inspect
 
 `GET /exec/(id)/json`
 
@@ -2348,9 +2346,9 @@ Return low-level information about the `exec` command `id`.
 -   **404** – no such exec instance
 -   **500** - server error
 
-# 3. Going further
+## 3. Going further
 
-## 3.1 Inside `docker run`
+### 3.1 Inside `docker run`
 
 As an example, the `docker run` command line makes the following API calls:
 
@@ -2368,7 +2366,7 @@ As an example, the `docker run` command line makes the following API calls:
 
 - If in detached mode or only `stdin` is attached, display the container's id.
 
-## 3.2 Hijacking
+### 3.2 Hijacking
 
 In this version of the API, `/attach`, uses hijacking to transport `stdin`,
 `stdout`, and `stderr` on the same socket.
@@ -2383,7 +2381,7 @@ When Docker daemon detects the `Upgrade` header, it switches its status code
 from **200 OK** to **101 UPGRADED** and resends the same headers.
 
 
-## 3.3 CORS Requests
+### 3.3 CORS Requests
 
 To set cross origin requests to the Engine API please give values to
 `--api-cors-header` when running Docker in daemon mode. Set * (asterisk) allows all,

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -16,8 +16,6 @@ redirect_from:
      will be rejected.
 -->
 
-# Docker Engine API v1.21
-
 ## 1. Brief introduction
 
  - The daemon listens on `unix:///var/run/docker.sock` but you can
@@ -28,11 +26,11 @@ redirect_from:
  - When the client API version is newer than the daemon's, these calls return an HTTP
    `400 Bad Request` error message.
 
-# 2. Endpoints
+## 2. Endpoints
 
-## 2.1 Containers
+### 2.1 Containers
 
-### List containers
+#### List containers
 
 `GET /containers/json`
 
@@ -129,7 +127,7 @@ List containers
 -   **400** – bad parameter
 -   **500** – server error
 
-### Create a container
+#### Create a container
 
 `POST /containers/create`
 
@@ -347,7 +345,7 @@ Create a container
 -   **409** – conflict
 -   **500** – server error
 
-### Inspect a container
+#### Inspect a container
 
 `GET /containers/(id or name)/json`
 
@@ -537,7 +535,7 @@ Return low-level information on the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### List processes running inside a container
+#### List processes running inside a container
 
 `GET /containers/(id or name)/top`
 
@@ -601,7 +599,7 @@ supported on Windows.
 -   **404** – no such container
 -   **500** – server error
 
-### Get container logs
+#### Get container logs
 
 `GET /containers/(id or name)/logs`
 
@@ -643,7 +641,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 -   **404** – no such container
 -   **500** – server error
 
-### Inspect changes on a container's filesystem
+#### Inspect changes on a container's filesystem
 
 `GET /containers/(id or name)/changes`
 
@@ -685,7 +683,7 @@ Values for `Kind`:
 -   **404** – no such container
 -   **500** – server error
 
-### Export a container
+#### Export a container
 
 `GET /containers/(id or name)/export`
 
@@ -710,7 +708,7 @@ Export the contents of container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Get container stats based on resource usage
+#### Get container stats based on resource usage
 
 `GET /containers/(id or name)/stats`
 
@@ -831,7 +829,7 @@ The precpu_stats is the cpu statistic of last read, which is used for calculatin
 -   **404** – no such container
 -   **500** – server error
 
-### Resize a container TTY
+#### Resize a container TTY
 
 `POST /containers/(id or name)/resize`
 
@@ -858,7 +856,7 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
 -   **404** – No such container
 -   **500** – Cannot resize container
 
-### Start a container
+#### Start a container
 
 `POST /containers/(id or name)/start`
 
@@ -883,7 +881,7 @@ Start the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Stop a container
+#### Stop a container
 
 `POST /containers/(id or name)/stop`
 
@@ -908,7 +906,7 @@ Stop the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Restart a container
+#### Restart a container
 
 `POST /containers/(id or name)/restart`
 
@@ -932,7 +930,7 @@ Restart the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Kill a container
+#### Kill a container
 
 `POST /containers/(id or name)/kill`
 
@@ -957,7 +955,7 @@ Kill the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Rename a container
+#### Rename a container
 
 `POST /containers/(id or name)/rename`
 
@@ -982,7 +980,7 @@ Rename the container `id` to a `new_name`
 -   **409** - conflict name already assigned
 -   **500** – server error
 
-### Pause a container
+#### Pause a container
 
 `POST /containers/(id or name)/pause`
 
@@ -1002,7 +1000,7 @@ Pause the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Unpause a container
+#### Unpause a container
 
 `POST /containers/(id or name)/unpause`
 
@@ -1022,7 +1020,7 @@ Unpause the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Attach to a container
+#### Attach to a container
 
 `POST /containers/(id or name)/attach`
 
@@ -1107,7 +1105,7 @@ The simplest way to implement the Attach protocol is the following:
     4.  Read the extracted size and output it on the correct output.
     5.  Goto 1.
 
-### Attach to a container (websocket)
+#### Attach to a container (websocket)
 
 `GET /containers/(id or name)/attach/ws`
 
@@ -1144,7 +1142,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **404** – no such container
 -   **500** – server error
 
-### Wait a container
+#### Wait a container
 
 `POST /containers/(id or name)/wait`
 
@@ -1167,7 +1165,7 @@ Block until container `id` stops, then returns the exit code
 -   **404** – no such container
 -   **500** – server error
 
-### Remove a container
+#### Remove a container
 
 `DELETE /containers/(id or name)`
 
@@ -1196,7 +1194,7 @@ Remove the container `id` from the filesystem
 -   **409** – conflict
 -   **500** – server error
 
-### Copy files or folders from a container
+#### Copy files or folders from a container
 
 `POST /containers/(id or name)/copy`
 
@@ -1228,14 +1226,14 @@ Copy files or folders of container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Retrieving information about files and folders in a container
+#### Retrieving information about files and folders in a container
 
 `HEAD /containers/(id or name)/archive`
 
 See the description of the `X-Docker-Container-Path-Stat` header in the
 following section.
 
-### Get an archive of a filesystem resource in a container
+#### Get an archive of a filesystem resource in a container
 
 `GET /containers/(id or name)/archive`
 
@@ -1300,7 +1298,7 @@ desired.
     - no such file or directory (**path** does not exist)
 - **500** - server error
 
-### Extract an archive of files or folders to a directory in a container
+#### Extract an archive of files or folders to a directory in a container
 
 `PUT /containers/(id or name)/archive`
 
@@ -1348,9 +1346,9 @@ Upload a tar archive to be extracted to a path in the filesystem of container
     - no such file or directory (**path** resource does not exist)
 - **500** – server error
 
-## 2.2 Images
+### 2.2 Images
 
-### List Images
+#### List Images
 
 `GET /images/json`
 
@@ -1441,7 +1439,7 @@ references on the command line.
   -   `label=key` or `label="key=value"` of an image label
 -   **filter** - only return images with the specified name
 
-### Build image from a Dockerfile
+#### Build image from a Dockerfile
 
 `POST /build`
 
@@ -1545,7 +1543,7 @@ or being killed.
 -   **200** – no error
 -   **500** – server error
 
-### Create an image
+#### Create an image
 
 `POST /images/create`
 
@@ -1593,7 +1591,7 @@ a base64-encoded AuthConfig object.
 
 
 
-### Inspect an image
+#### Inspect an image
 
 `GET /images/(name)/json`
 
@@ -1704,7 +1702,7 @@ Return low-level information on the image `name`
 -   **404** – no such image
 -   **500** – server error
 
-### Get the history of an image
+#### Get the history of an image
 
 `GET /images/(name)/history`
 
@@ -1758,7 +1756,7 @@ Return the history of the image `name`
 -   **404** – no such image
 -   **500** – server error
 
-### Push an image on the registry
+#### Push an image on the registry
 
 `POST /images/(name)/push`
 
@@ -1801,7 +1799,7 @@ then be used in the URL. This duplicates the command line's flow.
 -   **404** – no such image
 -   **500** – server error
 
-### Tag an image into a repository
+#### Tag an image into a repository
 
 `POST /images/(name)/tag`
 
@@ -1829,7 +1827,7 @@ Tag the image `name` into a repository
 -   **409** – conflict
 -   **500** – server error
 
-### Remove an image
+#### Remove an image
 
 `DELETE /images/(name)`
 
@@ -1862,7 +1860,7 @@ Remove the image `name` from the filesystem
 -   **409** – conflict
 -   **500** – server error
 
-### Search images
+#### Search images
 
 `GET /images/search`
 
@@ -1915,9 +1913,9 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 -   **200** – no error
 -   **500** – server error
 
-## 2.3 Misc
+### 2.3 Misc
 
-### Check auth configuration
+#### Check auth configuration
 
 `POST /auth`
 
@@ -1945,7 +1943,7 @@ Get the default username and email
 -   **204** – no error
 -   **500** – server error
 
-### Display system-wide information
+#### Display system-wide information
 
 `GET /info`
 
@@ -2016,7 +2014,7 @@ Display system-wide information
 -   **200** – no error
 -   **500** – server error
 
-### Show the docker version information
+#### Show the docker version information
 
 `GET /version`
 
@@ -2047,7 +2045,7 @@ Show the docker version information
 -   **200** – no error
 -   **500** – server error
 
-### Ping the docker server
+#### Ping the docker server
 
 `GET /_ping`
 
@@ -2069,7 +2067,7 @@ Ping the docker server
 -   **200** - no error
 -   **500** - server error
 
-### Create a new image from a container's changes
+#### Create a new image from a container's changes
 
 `POST /commit`
 
@@ -2141,7 +2139,7 @@ Create a new image from a container's changes
 -   **404** – no such container
 -   **500** – server error
 
-### Monitor Docker's events
+#### Monitor Docker's events
 
 `GET /events`
 
@@ -2184,7 +2182,7 @@ Docker images report the following events:
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images in a repository
+#### Get a tarball containing all images in a repository
 
 `GET /images/(name)/get`
 
@@ -2214,7 +2212,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images
+#### Get a tarball containing all images
 
 `GET /images/get`
 
@@ -2243,7 +2241,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Load a tarball with a set of images and tags into docker
+#### Load a tarball with a set of images and tags into docker
 
 `POST /images/load`
 
@@ -2266,7 +2264,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Image tarball format
+#### Image tarball format
 
 An image tarball contains one directory per image layer (named using its long ID),
 each containing these files:
@@ -2287,7 +2285,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 }
 ```
 
-### Exec Create
+#### Exec Create
 
 `POST /containers/(id or name)/exec`
 
@@ -2337,7 +2335,7 @@ Sets up an exec instance in a running container `id`
 -   **409** - container is paused
 -   **500** - server error
 
-### Exec Start
+#### Exec Start
 
 `POST /exec/(id)/start`
 
@@ -2379,7 +2377,7 @@ interactive session with the `exec` command.
 
 Similar to the stream behavior of `POST /containers/(id or name)/attach` API
 
-### Exec Resize
+#### Exec Resize
 
 `POST /exec/(id)/resize`
 
@@ -2406,7 +2404,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 -   **201** – no error
 -   **404** – no such exec instance
 
-### Exec Inspect
+#### Exec Inspect
 
 `GET /exec/(id)/json`
 
@@ -2532,9 +2530,9 @@ Return low-level information about the `exec` command `id`.
 -   **404** – no such exec instance
 -   **500** - server error
 
-## 2.4 Volumes
+### 2.4 Volumes
 
-### List volumes
+#### List volumes
 
 `GET /volumes`
 
@@ -2566,7 +2564,7 @@ Return low-level information about the `exec` command `id`.
 -   **200** - no error
 -   **500** - server error
 
-### Create a volume
+#### Create a volume
 
 `POST /volumes/create`
 
@@ -2604,7 +2602,7 @@ Create a volume
 - **DriverOpts** - A mapping of driver options and values. These options are
     passed directly to the driver and are driver specific.
 
-### Inspect a volume
+#### Inspect a volume
 
 `GET /volumes/(name)`
 
@@ -2631,7 +2629,7 @@ Return low-level information on the volume `name`
 -   **404** - no such volume
 -   **500** - server error
 
-### Remove a volume
+#### Remove a volume
 
 `DELETE /volumes/(name)`
 
@@ -2652,9 +2650,9 @@ Instruct the driver to remove the volume (`name`).
 -   **409** - volume is in use and cannot be removed
 -   **500** - server error
 
-## 2.5 Networks
+### 2.5 Networks
 
-### List networks
+#### List networks
 
 `GET /networks`
 
@@ -2735,7 +2733,7 @@ Content-Type: application/json
 -   **200** - no error
 -   **500** - server error
 
-### Inspect network
+#### Inspect network
 
 `GET /networks/<network-id>`
 
@@ -2786,7 +2784,7 @@ Content-Type: application/json
 -   **200** - no error
 -   **404** - network not found
 
-### Create a network
+#### Create a network
 
 `POST /networks/create`
 
@@ -2844,7 +2842,7 @@ Content-Type: application/json
       `{"Subnet": <CIDR>, "IPRange": <CIDR>, "Gateway": <IP address>, "AuxAddress": <device_name:IP address>}`
 - **Options** - Network specific options to be used by the drivers
 
-### Connect a container to a network
+#### Connect a container to a network
 
 `POST /networks/(id)/connect`
 
@@ -2875,7 +2873,7 @@ Content-Type: application/json
 
 - **container** - container-id/name to be connected to the network
 
-### Disconnect a container from a network
+#### Disconnect a container from a network
 
 `POST /networks/(id)/disconnect`
 
@@ -2906,7 +2904,7 @@ Content-Type: application/json
 
 - **Container** - container-id/name to be disconnected from a network
 
-### Remove a network
+#### Remove a network
 
 `DELETE /networks/(id)`
 
@@ -2926,9 +2924,9 @@ Instruct the driver to remove the network (`id`).
 -   **404** - no such network
 -   **500** - server error
 
-# 3. Going further
+## 3. Going further
 
-## 3.1 Inside `docker run`
+### 3.1 Inside `docker run`
 
 As an example, the `docker run` command line makes the following API calls:
 
@@ -2946,7 +2944,7 @@ As an example, the `docker run` command line makes the following API calls:
 
 - If in detached mode or only `stdin` is attached, display the container's id.
 
-## 3.2 Hijacking
+### 3.2 Hijacking
 
 In this version of the API, `/attach`, uses hijacking to transport `stdin`,
 `stdout`, and `stderr` on the same socket.
@@ -2961,7 +2959,7 @@ When Docker daemon detects the `Upgrade` header, it switches its status code
 from **200 OK** to **101 UPGRADED** and resends the same headers.
 
 
-## 3.3 CORS Requests
+### 3.3 CORS Requests
 
 To set cross origin requests to the Engine API please give values to
 `--api-cors-header` when running Docker in daemon mode. Set * (asterisk) allows all,

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -16,9 +16,7 @@ redirect_from:
      will be rejected.
 -->
 
-# Docker Engine API v1.22
-
-# 1. Brief introduction
+## 1. Brief introduction
 
  - The daemon listens on `unix:///var/run/docker.sock` but you can
    [Bind Docker to another host/port or a Unix socket](../commandline/dockerd.md#bind-docker-to-another-host-port-or-a-unix-socket).
@@ -26,11 +24,11 @@ redirect_from:
    or `pull`, the HTTP connection is hijacked to transport `stdout`,
    `stdin` and `stderr`.
 
-# 2. Endpoints
+## 2. Endpoints
 
-## 2.1 Containers
+### 2.1 Containers
 
-### List containers
+#### List containers
 
 `GET /containers/json`
 
@@ -212,7 +210,7 @@ List containers
 -   **400** – bad parameter
 -   **500** – server error
 
-### Create a container
+#### Create a container
 
 `POST /containers/create`
 
@@ -460,7 +458,7 @@ Create a container
 -   **409** – conflict
 -   **500** – server error
 
-### Inspect a container
+#### Inspect a container
 
 `GET /containers/(id or name)/json`
 
@@ -663,7 +661,7 @@ Return low-level information on the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### List processes running inside a container
+#### List processes running inside a container
 
 `GET /containers/(id or name)/top`
 
@@ -727,7 +725,7 @@ supported on Windows.
 -   **404** – no such container
 -   **500** – server error
 
-### Get container logs
+#### Get container logs
 
 `GET /containers/(id or name)/logs`
 
@@ -769,7 +767,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 -   **404** – no such container
 -   **500** – server error
 
-### Inspect changes on a container's filesystem
+#### Inspect changes on a container's filesystem
 
 `GET /containers/(id or name)/changes`
 
@@ -811,7 +809,7 @@ Values for `Kind`:
 -   **404** – no such container
 -   **500** – server error
 
-### Export a container
+#### Export a container
 
 `GET /containers/(id or name)/export`
 
@@ -836,7 +834,7 @@ Export the contents of container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Get container stats based on resource usage
+#### Get container stats based on resource usage
 
 `GET /containers/(id or name)/stats`
 
@@ -957,7 +955,7 @@ The precpu_stats is the cpu statistic of last read, which is used for calculatin
 -   **404** – no such container
 -   **500** – server error
 
-### Resize a container TTY
+#### Resize a container TTY
 
 `POST /containers/(id or name)/resize`
 
@@ -984,7 +982,7 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
 -   **404** – No such container
 -   **500** – Cannot resize container
 
-### Start a container
+#### Start a container
 
 `POST /containers/(id or name)/start`
 
@@ -1015,7 +1013,7 @@ Start the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Stop a container
+#### Stop a container
 
 `POST /containers/(id or name)/stop`
 
@@ -1040,7 +1038,7 @@ Stop the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Restart a container
+#### Restart a container
 
 `POST /containers/(id or name)/restart`
 
@@ -1064,7 +1062,7 @@ Restart the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Kill a container
+#### Kill a container
 
 `POST /containers/(id or name)/kill`
 
@@ -1089,7 +1087,7 @@ Kill the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Update a container
+#### Update a container
 
 `POST /containers/(id or name)/update`
 
@@ -1129,7 +1127,7 @@ Update resource configs of one or more containers.
 -   **404** – no such container
 -   **500** – server error
 
-### Rename a container
+#### Rename a container
 
 `POST /containers/(id or name)/rename`
 
@@ -1154,7 +1152,7 @@ Rename the container `id` to a `new_name`
 -   **409** - conflict name already assigned
 -   **500** – server error
 
-### Pause a container
+#### Pause a container
 
 `POST /containers/(id or name)/pause`
 
@@ -1174,7 +1172,7 @@ Pause the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Unpause a container
+#### Unpause a container
 
 `POST /containers/(id or name)/unpause`
 
@@ -1194,7 +1192,7 @@ Unpause the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Attach to a container
+#### Attach to a container
 
 `POST /containers/(id or name)/attach`
 
@@ -1283,7 +1281,7 @@ The simplest way to implement the Attach protocol is the following:
     4.  Read the extracted size and output it on the correct output.
     5.  Goto 1.
 
-### Attach to a container (websocket)
+#### Attach to a container (websocket)
 
 `GET /containers/(id or name)/attach/ws`
 
@@ -1323,7 +1321,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **404** – no such container
 -   **500** – server error
 
-### Wait a container
+#### Wait a container
 
 `POST /containers/(id or name)/wait`
 
@@ -1346,7 +1344,7 @@ Block until container `id` stops, then returns the exit code
 -   **404** – no such container
 -   **500** – server error
 
-### Remove a container
+#### Remove a container
 
 `DELETE /containers/(id or name)`
 
@@ -1375,7 +1373,7 @@ Remove the container `id` from the filesystem
 -   **409** – conflict
 -   **500** – server error
 
-### Copy files or folders from a container
+#### Copy files or folders from a container
 
 `POST /containers/(id or name)/copy`
 
@@ -1407,14 +1405,14 @@ Copy files or folders of container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Retrieving information about files and folders in a container
+#### Retrieving information about files and folders in a container
 
 `HEAD /containers/(id or name)/archive`
 
 See the description of the `X-Docker-Container-Path-Stat` header in the
 following section.
 
-### Get an archive of a filesystem resource in a container
+#### Get an archive of a filesystem resource in a container
 
 `GET /containers/(id or name)/archive`
 
@@ -1479,7 +1477,7 @@ desired.
     - no such file or directory (**path** does not exist)
 - **500** - server error
 
-### Extract an archive of files or folders to a directory in a container
+#### Extract an archive of files or folders to a directory in a container
 
 `PUT /containers/(id or name)/archive`
 
@@ -1527,9 +1525,9 @@ Upload a tar archive to be extracted to a path in the filesystem of container
     - no such file or directory (**path** resource does not exist)
 - **500** – server error
 
-## 2.2 Images
+### 2.2 Images
 
-### List Images
+#### List Images
 
 `GET /images/json`
 
@@ -1620,7 +1618,7 @@ references on the command line.
   -   `label=key` or `label="key=value"` of an image label
 -   **filter** - only return images with the specified name
 
-### Build image from a Dockerfile
+#### Build image from a Dockerfile
 
 `POST /build`
 
@@ -1725,7 +1723,7 @@ or being killed.
 -   **200** – no error
 -   **500** – server error
 
-### Create an image
+#### Create an image
 
 `POST /images/create`
 
@@ -1791,7 +1789,7 @@ a base64-encoded AuthConfig object.
 
 
 
-### Inspect an image
+#### Inspect an image
 
 `GET /images/(name)/json`
 
@@ -1902,7 +1900,7 @@ Return low-level information on the image `name`
 -   **404** – no such image
 -   **500** – server error
 
-### Get the history of an image
+#### Get the history of an image
 
 `GET /images/(name)/history`
 
@@ -1956,7 +1954,7 @@ Return the history of the image `name`
 -   **404** – no such image
 -   **500** – server error
 
-### Push an image on the registry
+#### Push an image on the registry
 
 `POST /images/(name)/push`
 
@@ -2018,7 +2016,7 @@ The push is cancelled if the HTTP connection is closed.
 -   **404** – no such image
 -   **500** – server error
 
-### Tag an image into a repository
+#### Tag an image into a repository
 
 `POST /images/(name)/tag`
 
@@ -2046,7 +2044,7 @@ Tag the image `name` into a repository
 -   **409** – conflict
 -   **500** – server error
 
-### Remove an image
+#### Remove an image
 
 `DELETE /images/(name)`
 
@@ -2079,7 +2077,7 @@ Remove the image `name` from the filesystem
 -   **409** – conflict
 -   **500** – server error
 
-### Search images
+#### Search images
 
 `GET /images/search`
 
@@ -2132,9 +2130,9 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 -   **200** – no error
 -   **500** – server error
 
-## 2.3 Misc
+### 2.3 Misc
 
-### Check auth configuration
+#### Check auth configuration
 
 `POST /auth`
 
@@ -2162,7 +2160,7 @@ Get the default username and email
 -   **204** – no error
 -   **500** – server error
 
-### Display system-wide information
+#### Display system-wide information
 
 `GET /info`
 
@@ -2249,7 +2247,7 @@ Display system-wide information
 -   **200** – no error
 -   **500** – server error
 
-### Show the docker version information
+#### Show the docker version information
 
 `GET /version`
 
@@ -2281,7 +2279,7 @@ Show the docker version information
 -   **200** – no error
 -   **500** – server error
 
-### Ping the docker server
+#### Ping the docker server
 
 `GET /_ping`
 
@@ -2303,7 +2301,7 @@ Ping the docker server
 -   **200** - no error
 -   **500** - server error
 
-### Create a new image from a container's changes
+#### Create a new image from a container's changes
 
 `POST /commit`
 
@@ -2375,7 +2373,7 @@ Create a new image from a container's changes
 -   **404** – no such container
 -   **500** – server error
 
-### Monitor Docker's events
+#### Monitor Docker's events
 
 `GET /events`
 
@@ -2575,7 +2573,7 @@ Docker networks report the following events:
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images in a repository
+#### Get a tarball containing all images in a repository
 
 `GET /images/(name)/get`
 
@@ -2605,7 +2603,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images
+#### Get a tarball containing all images
 
 `GET /images/get`
 
@@ -2634,7 +2632,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Load a tarball with a set of images and tags into docker
+#### Load a tarball with a set of images and tags into docker
 
 `POST /images/load`
 
@@ -2657,7 +2655,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Image tarball format
+#### Image tarball format
 
 An image tarball contains one directory per image layer (named using its long ID),
 each containing these files:
@@ -2678,7 +2676,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 }
 ```
 
-### Exec Create
+#### Exec Create
 
 `POST /containers/(id or name)/exec`
 
@@ -2732,7 +2730,7 @@ Sets up an exec instance in a running container `id`
 -   **409** - container is paused
 -   **500** - server error
 
-### Exec Start
+#### Exec Start
 
 `POST /exec/(id)/start`
 
@@ -2774,7 +2772,7 @@ interactive session with the `exec` command.
 
 Similar to the stream behavior of `POST /containers/(id or name)/attach` API
 
-### Exec Resize
+#### Exec Resize
 
 `POST /exec/(id)/resize`
 
@@ -2801,7 +2799,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 -   **201** – no error
 -   **404** – no such exec instance
 
-### Exec Inspect
+#### Exec Inspect
 
 `GET /exec/(id)/json`
 
@@ -2844,9 +2842,9 @@ Return low-level information about the `exec` command `id`.
 -   **404** – no such exec instance
 -   **500** - server error
 
-## 2.4 Volumes
+### 2.4 Volumes
 
-### List volumes
+#### List volumes
 
 `GET /volumes`
 
@@ -2879,7 +2877,7 @@ Return low-level information about the `exec` command `id`.
 -   **200** - no error
 -   **500** - server error
 
-### Create a volume
+#### Create a volume
 
 `POST /volumes/create`
 
@@ -2917,7 +2915,7 @@ Create a volume
 - **DriverOpts** - A mapping of driver options and values. These options are
     passed directly to the driver and are driver specific.
 
-### Inspect a volume
+#### Inspect a volume
 
 `GET /volumes/(name)`
 
@@ -2944,7 +2942,7 @@ Return low-level information on the volume `name`
 -   **404** - no such volume
 -   **500** - server error
 
-### Remove a volume
+#### Remove a volume
 
 `DELETE /volumes/(name)`
 
@@ -2965,9 +2963,9 @@ Instruct the driver to remove the volume (`name`).
 -   **409** - volume is in use and cannot be removed
 -   **500** - server error
 
-## 2.5 Networks
+### 2.5 Networks
 
-### List networks
+#### List networks
 
 `GET /networks`
 
@@ -3051,7 +3049,7 @@ Content-Type: application/json
 -   **200** - no error
 -   **500** - server error
 
-### Inspect network
+#### Inspect network
 
 `GET /networks/<network-id>`
 
@@ -3107,7 +3105,7 @@ Content-Type: application/json
 -   **200** - no error
 -   **404** - network not found
 
-### Create a network
+#### Create a network
 
 `POST /networks/create`
 
@@ -3174,7 +3172,7 @@ Content-Type: application/json
   - **Options** - Driver-specific options, specified as a map: `{"option":"value" [,"option2":"value2"]}`
 - **Options** - Network specific options to be used by the drivers
 
-### Connect a container to a network
+#### Connect a container to a network
 
 `POST /networks/(id)/connect`
 
@@ -3211,7 +3209,7 @@ Content-Type: application/json
 
 - **container** - container-id/name to be connected to the network
 
-### Disconnect a container from a network
+#### Disconnect a container from a network
 
 `POST /networks/(id)/disconnect`
 
@@ -3244,7 +3242,7 @@ Content-Type: application/json
 - **Container** - container-id/name to be disconnected from a network
 - **Force** - Force the container to disconnect from a network
 
-### Remove a network
+#### Remove a network
 
 `DELETE /networks/(id)`
 
@@ -3264,9 +3262,9 @@ Instruct the driver to remove the network (`id`).
 -   **404** - no such network
 -   **500** - server error
 
-# 3. Going further
+## 3. Going further
 
-## 3.1 Inside `docker run`
+### 3.1 Inside `docker run`
 
 As an example, the `docker run` command line makes the following API calls:
 
@@ -3284,7 +3282,7 @@ As an example, the `docker run` command line makes the following API calls:
 
 - If in detached mode or only `stdin` is attached, display the container's id.
 
-## 3.2 Hijacking
+### 3.2 Hijacking
 
 In this version of the API, `/attach`, uses hijacking to transport `stdin`,
 `stdout`, and `stderr` on the same socket.
@@ -3299,7 +3297,7 @@ When Docker daemon detects the `Upgrade` header, it switches its status code
 from **200 OK** to **101 UPGRADED** and resends the same headers.
 
 
-## 3.3 CORS Requests
+### 3.3 CORS Requests
 
 To set cross origin requests to the Engine API please give values to
 `--api-cors-header` when running Docker in daemon mode. Set * (asterisk) allows all,

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -16,8 +16,6 @@ redirect_from:
      will be rejected.
 -->
 
-# Docker Engine API v1.23
-
 ## 1. Brief introduction
 
  - The daemon listens on `unix:///var/run/docker.sock` but you can
@@ -28,11 +26,11 @@ redirect_from:
  - When the client API version is newer than the daemon's, these calls return an HTTP
    `400 Bad Request` error message.
 
-# 2. Endpoints
+## 2. Endpoints
 
-## 2.1 Containers
+### 2.1 Containers
 
-### List containers
+#### List containers
 
 `GET /containers/json`
 
@@ -236,7 +234,7 @@ List containers
 -   **400** – bad parameter
 -   **500** – server error
 
-### Create a container
+#### Create a container
 
 `POST /containers/create`
 
@@ -488,7 +486,7 @@ Create a container
 -   **409** – conflict
 -   **500** – server error
 
-### Inspect a container
+#### Inspect a container
 
 `GET /containers/(id or name)/json`
 
@@ -691,7 +689,7 @@ Return low-level information on the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### List processes running inside a container
+#### List processes running inside a container
 
 `GET /containers/(id or name)/top`
 
@@ -755,7 +753,7 @@ supported on Windows.
 -   **404** – no such container
 -   **500** – server error
 
-### Get container logs
+#### Get container logs
 
 `GET /containers/(id or name)/logs`
 
@@ -797,7 +795,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 -   **404** – no such container
 -   **500** – server error
 
-### Inspect changes on a container's filesystem
+#### Inspect changes on a container's filesystem
 
 `GET /containers/(id or name)/changes`
 
@@ -839,7 +837,7 @@ Values for `Kind`:
 -   **404** – no such container
 -   **500** – server error
 
-### Export a container
+#### Export a container
 
 `GET /containers/(id or name)/export`
 
@@ -864,7 +862,7 @@ Export the contents of container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Get container stats based on resource usage
+#### Get container stats based on resource usage
 
 `GET /containers/(id or name)/stats`
 
@@ -988,7 +986,7 @@ The precpu_stats is the cpu statistic of last read, which is used for calculatin
 -   **404** – no such container
 -   **500** – server error
 
-### Resize a container TTY
+#### Resize a container TTY
 
 `POST /containers/(id or name)/resize`
 
@@ -1015,7 +1013,7 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
 -   **404** – No such container
 -   **500** – Cannot resize container
 
-### Start a container
+#### Start a container
 
 `POST /containers/(id or name)/start`
 
@@ -1046,7 +1044,7 @@ Start the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Stop a container
+#### Stop a container
 
 `POST /containers/(id or name)/stop`
 
@@ -1071,7 +1069,7 @@ Stop the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Restart a container
+#### Restart a container
 
 `POST /containers/(id or name)/restart`
 
@@ -1095,7 +1093,7 @@ Restart the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Kill a container
+#### Kill a container
 
 `POST /containers/(id or name)/kill`
 
@@ -1120,7 +1118,7 @@ Kill the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Update a container
+#### Update a container
 
 `POST /containers/(id or name)/update`
 
@@ -1164,7 +1162,7 @@ Update configuration of one or more containers.
 -   **404** – no such container
 -   **500** – server error
 
-### Rename a container
+#### Rename a container
 
 `POST /containers/(id or name)/rename`
 
@@ -1189,7 +1187,7 @@ Rename the container `id` to a `new_name`
 -   **409** - conflict name already assigned
 -   **500** – server error
 
-### Pause a container
+#### Pause a container
 
 `POST /containers/(id or name)/pause`
 
@@ -1209,7 +1207,7 @@ Pause the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Unpause a container
+#### Unpause a container
 
 `POST /containers/(id or name)/unpause`
 
@@ -1229,7 +1227,7 @@ Unpause the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Attach to a container
+#### Attach to a container
 
 `POST /containers/(id or name)/attach`
 
@@ -1318,7 +1316,7 @@ The simplest way to implement the Attach protocol is the following:
     4.  Read the extracted size and output it on the correct output.
     5.  Goto 1.
 
-### Attach to a container (websocket)
+#### Attach to a container (websocket)
 
 `GET /containers/(id or name)/attach/ws`
 
@@ -1358,7 +1356,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **404** – no such container
 -   **500** – server error
 
-### Wait a container
+#### Wait a container
 
 `POST /containers/(id or name)/wait`
 
@@ -1381,7 +1379,7 @@ Block until container `id` stops, then returns the exit code
 -   **404** – no such container
 -   **500** – server error
 
-### Remove a container
+#### Remove a container
 
 `DELETE /containers/(id or name)`
 
@@ -1410,7 +1408,7 @@ Remove the container `id` from the filesystem
 -   **409** – conflict
 -   **500** – server error
 
-### Copy files or folders from a container
+#### Copy files or folders from a container
 
 `POST /containers/(id or name)/copy`
 
@@ -1442,14 +1440,14 @@ Copy files or folders of container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Retrieving information about files and folders in a container
+#### Retrieving information about files and folders in a container
 
 `HEAD /containers/(id or name)/archive`
 
 See the description of the `X-Docker-Container-Path-Stat` header in the
 following section.
 
-### Get an archive of a filesystem resource in a container
+#### Get an archive of a filesystem resource in a container
 
 `GET /containers/(id or name)/archive`
 
@@ -1514,7 +1512,7 @@ desired.
     - no such file or directory (**path** does not exist)
 - **500** - server error
 
-### Extract an archive of files or folders to a directory in a container
+#### Extract an archive of files or folders to a directory in a container
 
 `PUT /containers/(id or name)/archive`
 
@@ -1562,9 +1560,9 @@ Upload a tar archive to be extracted to a path in the filesystem of container
     - no such file or directory (**path** resource does not exist)
 - **500** – server error
 
-## 2.2 Images
+### 2.2 Images
 
-### List Images
+#### List Images
 
 `GET /images/json`
 
@@ -1655,7 +1653,7 @@ references on the command line.
   -   `label=key` or `label="key=value"` of an image label
 -   **filter** - only return images with the specified name
 
-### Build image from a Dockerfile
+#### Build image from a Dockerfile
 
 `POST /build`
 
@@ -1761,7 +1759,7 @@ or being killed.
 -   **200** – no error
 -   **500** – server error
 
-### Create an image
+#### Create an image
 
 `POST /images/create`
 
@@ -1827,7 +1825,7 @@ a base64-encoded AuthConfig object.
 
 
 
-### Inspect an image
+#### Inspect an image
 
 `GET /images/(name)/json`
 
@@ -1945,7 +1943,7 @@ Return low-level information on the image `name`
 -   **404** – no such image
 -   **500** – server error
 
-### Get the history of an image
+#### Get the history of an image
 
 `GET /images/(name)/history`
 
@@ -1999,7 +1997,7 @@ Return the history of the image `name`
 -   **404** – no such image
 -   **500** – server error
 
-### Push an image on the registry
+#### Push an image on the registry
 
 `POST /images/(name)/push`
 
@@ -2061,7 +2059,7 @@ The push is cancelled if the HTTP connection is closed.
 -   **404** – no such image
 -   **500** – server error
 
-### Tag an image into a repository
+#### Tag an image into a repository
 
 `POST /images/(name)/tag`
 
@@ -2089,7 +2087,7 @@ Tag the image `name` into a repository
 -   **409** – conflict
 -   **500** – server error
 
-### Remove an image
+#### Remove an image
 
 `DELETE /images/(name)`
 
@@ -2122,7 +2120,7 @@ Remove the image `name` from the filesystem
 -   **409** – conflict
 -   **500** – server error
 
-### Search images
+#### Search images
 
 `GET /images/search`
 
@@ -2175,9 +2173,9 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 -   **200** – no error
 -   **500** – server error
 
-## 2.3 Misc
+### 2.3 Misc
 
-### Check auth configuration
+#### Check auth configuration
 
 `POST /auth`
 
@@ -2210,7 +2208,7 @@ if available, for accessing the registry without password.
 -   **204** – no error
 -   **500** – server error
 
-### Display system-wide information
+#### Display system-wide information
 
 `GET /info`
 
@@ -2299,7 +2297,7 @@ Display system-wide information
 -   **200** – no error
 -   **500** – server error
 
-### Show the docker version information
+#### Show the docker version information
 
 `GET /version`
 
@@ -2331,7 +2329,7 @@ Show the docker version information
 -   **200** – no error
 -   **500** – server error
 
-### Ping the docker server
+#### Ping the docker server
 
 `GET /_ping`
 
@@ -2353,7 +2351,7 @@ Ping the docker server
 -   **200** - no error
 -   **500** - server error
 
-### Create a new image from a container's changes
+#### Create a new image from a container's changes
 
 `POST /commit`
 
@@ -2425,7 +2423,7 @@ Create a new image from a container's changes
 -   **404** – no such container
 -   **500** – server error
 
-### Monitor Docker's events
+#### Monitor Docker's events
 
 `GET /events`
 
@@ -2625,7 +2623,7 @@ Docker networks report the following events:
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images in a repository
+#### Get a tarball containing all images in a repository
 
 `GET /images/(name)/get`
 
@@ -2655,7 +2653,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images
+#### Get a tarball containing all images
 
 `GET /images/get`
 
@@ -2684,7 +2682,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Load a tarball with a set of images and tags into docker
+#### Load a tarball with a set of images and tags into docker
 
 `POST /images/load`
 
@@ -2733,7 +2731,7 @@ action completes.
 -   **200** – no error
 -   **500** – server error
 
-### Image tarball format
+#### Image tarball format
 
 An image tarball contains one directory per image layer (named using its long ID),
 each containing these files:
@@ -2754,7 +2752,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 }
 ```
 
-### Exec Create
+#### Exec Create
 
 `POST /containers/(id or name)/exec`
 
@@ -2808,7 +2806,7 @@ Sets up an exec instance in a running container `id`
 -   **409** - container is paused
 -   **500** - server error
 
-### Exec Start
+#### Exec Start
 
 `POST /exec/(id)/start`
 
@@ -2850,7 +2848,7 @@ interactive session with the `exec` command.
 
 Similar to the stream behavior of `POST /containers/(id or name)/attach` API
 
-### Exec Resize
+#### Exec Resize
 
 `POST /exec/(id)/resize`
 
@@ -2877,7 +2875,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 -   **201** – no error
 -   **404** – no such exec instance
 
-### Exec Inspect
+#### Exec Inspect
 
 `GET /exec/(id)/json`
 
@@ -2920,9 +2918,9 @@ Return low-level information about the `exec` command `id`.
 -   **404** – no such exec instance
 -   **500** - server error
 
-## 2.4 Volumes
+### 2.4 Volumes
 
-### List volumes
+#### List volumes
 
 `GET /volumes`
 
@@ -2955,7 +2953,7 @@ Return low-level information about the `exec` command `id`.
 -   **200** - no error
 -   **500** - server error
 
-### Create a volume
+#### Create a volume
 
 `POST /volumes/create`
 
@@ -3002,7 +3000,7 @@ Create a volume
     passed directly to the driver and are driver specific.
 - **Labels** - Labels to set on the volume, specified as a map: `{"key":"value","key2":"value2"}`
 
-### Inspect a volume
+#### Inspect a volume
 
 `GET /volumes/(name)`
 
@@ -3033,7 +3031,7 @@ Return low-level information on the volume `name`
 -   **404** - no such volume
 -   **500** - server error
 
-### Remove a volume
+#### Remove a volume
 
 `DELETE /volumes/(name)`
 
@@ -3054,9 +3052,9 @@ Instruct the driver to remove the volume (`name`).
 -   **409** - volume is in use and cannot be removed
 -   **500** - server error
 
-## 3.5 Networks
+### 3.5 Networks
 
-### List networks
+#### List networks
 
 `GET /networks`
 
@@ -3146,7 +3144,7 @@ Content-Type: application/json
 -   **200** - no error
 -   **500** - server error
 
-### Inspect network
+#### Inspect network
 
 `GET /networks/<network-id>`
 
@@ -3208,7 +3206,7 @@ Content-Type: application/json
 -   **200** - no error
 -   **404** - network not found
 
-### Create a network
+#### Create a network
 
 `POST /networks/create`
 
@@ -3291,7 +3289,7 @@ Content-Type: application/json
 - **Options** - Network specific options to be used by the drivers
 - **Labels** - Labels to set on the network, specified as a map: `{"key":"value" [,"key2":"value2"]}`
 
-### Connect a container to a network
+#### Connect a container to a network
 
 `POST /networks/(id)/connect`
 
@@ -3328,7 +3326,7 @@ Content-Type: application/json
 
 - **container** - container-id/name to be connected to the network
 
-### Disconnect a container from a network
+#### Disconnect a container from a network
 
 `POST /networks/(id)/disconnect`
 
@@ -3361,7 +3359,7 @@ Content-Type: application/json
 - **Container** - container-id/name to be disconnected from a network
 - **Force** - Force the container to disconnect from a network
 
-### Remove a network
+#### Remove a network
 
 `DELETE /networks/(id)`
 
@@ -3381,9 +3379,9 @@ Instruct the driver to remove the network (`id`).
 -   **404** - no such network
 -   **500** - server error
 
-# 3. Going further
+## 3. Going further
 
-## 3.1 Inside `docker run`
+### 3.1 Inside `docker run`
 
 As an example, the `docker run` command line makes the following API calls:
 
@@ -3401,7 +3399,7 @@ As an example, the `docker run` command line makes the following API calls:
 
 - If in detached mode or only `stdin` is attached, display the container's id.
 
-## 3.2 Hijacking
+### 3.2 Hijacking
 
 In this version of the API, `/attach`, uses hijacking to transport `stdin`,
 `stdout`, and `stderr` on the same socket.
@@ -3416,7 +3414,7 @@ When Docker daemon detects the `Upgrade` header, it switches its status code
 from **200 OK** to **101 UPGRADED** and resends the same headers.
 
 
-## 3.3 CORS Requests
+### 3.3 CORS Requests
 
 To set cross origin requests to the Engine API please give values to
 `--api-cors-header` when running Docker in daemon mode. Set * (asterisk) allows all,

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -16,9 +16,7 @@ redirect_from:
      will be rejected.
 -->
 
-# Docker Engine API v1.24
-
-# 1. Brief introduction
+## 1. Brief introduction
 
  - The daemon listens on `unix:///var/run/docker.sock` but you can
    [Bind Docker to another host/port or a Unix socket](../commandline/dockerd.md#bind-docker-to-another-host-port-or-a-unix-socket).
@@ -26,7 +24,7 @@ redirect_from:
    or `pull`, the HTTP connection is hijacked to transport `stdout`,
    `stdin` and `stderr`.
 
-# 2. Errors
+## 2. Errors
 
 The Engine API uses standard HTTP status codes to indicate the success or failure of the API call. The body of the response will be JSON in the following format:
 
@@ -36,11 +34,11 @@ The Engine API uses standard HTTP status codes to indicate the success or failur
 
 The status codes that are returned for each endpoint are specified in the endpoint documentation below.
 
-# 3. Endpoints
+## 3. Endpoints
 
-## 3.1 Containers
+### 3.1 Containers
 
-### List containers
+#### List containers
 
 `GET /containers/json`
 
@@ -245,7 +243,7 @@ List containers
 -   **400** – bad parameter
 -   **500** – server error
 
-### Create a container
+#### Create a container
 
 `POST /containers/create`
 
@@ -511,7 +509,7 @@ Create a container
 -   **409** – conflict
 -   **500** – server error
 
-### Inspect a container
+#### Inspect a container
 
 `GET /containers/(id or name)/json`
 
@@ -721,7 +719,7 @@ Return low-level information on the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### List processes running inside a container
+#### List processes running inside a container
 
 `GET /containers/(id or name)/top`
 
@@ -785,7 +783,7 @@ supported on Windows.
 -   **404** – no such container
 -   **500** – server error
 
-### Get container logs
+#### Get container logs
 
 `GET /containers/(id or name)/logs`
 
@@ -828,7 +826,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 -   **404** – no such container
 -   **500** – server error
 
-### Inspect changes on a container's filesystem
+#### Inspect changes on a container's filesystem
 
 `GET /containers/(id or name)/changes`
 
@@ -870,7 +868,7 @@ Values for `Kind`:
 -   **404** – no such container
 -   **500** – server error
 
-### Export a container
+#### Export a container
 
 `GET /containers/(id or name)/export`
 
@@ -895,7 +893,7 @@ Export the contents of container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Get container stats based on resource usage
+#### Get container stats based on resource usage
 
 `GET /containers/(id or name)/stats`
 
@@ -1019,7 +1017,7 @@ The precpu_stats is the cpu statistic of last read, which is used for calculatin
 -   **404** – no such container
 -   **500** – server error
 
-### Resize a container TTY
+#### Resize a container TTY
 
 `POST /containers/(id or name)/resize`
 
@@ -1046,7 +1044,7 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
 -   **404** – No such container
 -   **500** – Cannot resize container
 
-### Start a container
+#### Start a container
 
 `POST /containers/(id or name)/start`
 
@@ -1073,7 +1071,7 @@ Start the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Stop a container
+#### Stop a container
 
 `POST /containers/(id or name)/stop`
 
@@ -1098,7 +1096,7 @@ Stop the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Restart a container
+#### Restart a container
 
 `POST /containers/(id or name)/restart`
 
@@ -1122,7 +1120,7 @@ Restart the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Kill a container
+#### Kill a container
 
 `POST /containers/(id or name)/kill`
 
@@ -1147,7 +1145,7 @@ Kill the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Update a container
+#### Update a container
 
 `POST /containers/(id or name)/update`
 
@@ -1191,7 +1189,7 @@ Update configuration of one or more containers.
 -   **404** – no such container
 -   **500** – server error
 
-### Rename a container
+#### Rename a container
 
 `POST /containers/(id or name)/rename`
 
@@ -1216,7 +1214,7 @@ Rename the container `id` to a `new_name`
 -   **409** - conflict name already assigned
 -   **500** – server error
 
-### Pause a container
+#### Pause a container
 
 `POST /containers/(id or name)/pause`
 
@@ -1236,7 +1234,7 @@ Pause the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Unpause a container
+#### Unpause a container
 
 `POST /containers/(id or name)/unpause`
 
@@ -1256,7 +1254,7 @@ Unpause the container `id`
 -   **404** – no such container
 -   **500** – server error
 
-### Attach to a container
+#### Attach to a container
 
 `POST /containers/(id or name)/attach`
 
@@ -1345,7 +1343,7 @@ The simplest way to implement the Attach protocol is the following:
     4.  Read the extracted size and output it on the correct output.
     5.  Goto 1.
 
-### Attach to a container (websocket)
+#### Attach to a container (websocket)
 
 `GET /containers/(id or name)/attach/ws`
 
@@ -1385,7 +1383,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 -   **404** – no such container
 -   **500** – server error
 
-### Wait a container
+#### Wait a container
 
 `POST /containers/(id or name)/wait`
 
@@ -1408,7 +1406,7 @@ Block until container `id` stops, then returns the exit code
 -   **404** – no such container
 -   **500** – server error
 
-### Remove a container
+#### Remove a container
 
 `DELETE /containers/(id or name)`
 
@@ -1437,14 +1435,14 @@ Remove the container `id` from the filesystem
 -   **409** – conflict
 -   **500** – server error
 
-### Retrieving information about files and folders in a container
+#### Retrieving information about files and folders in a container
 
 `HEAD /containers/(id or name)/archive`
 
 See the description of the `X-Docker-Container-Path-Stat` header in the
 following section.
 
-### Get an archive of a filesystem resource in a container
+#### Get an archive of a filesystem resource in a container
 
 `GET /containers/(id or name)/archive`
 
@@ -1509,7 +1507,7 @@ desired.
     - no such file or directory (**path** does not exist)
 - **500** - server error
 
-### Extract an archive of files or folders to a directory in a container
+#### Extract an archive of files or folders to a directory in a container
 
 `PUT /containers/(id or name)/archive`
 
@@ -1557,9 +1555,9 @@ Upload a tar archive to be extracted to a path in the filesystem of container
     - no such file or directory (**path** resource does not exist)
 - **500** – server error
 
-## 3.2 Images
+### 3.2 Images
 
-### List Images
+#### List Images
 
 `GET /images/json`
 
@@ -1652,7 +1650,7 @@ references on the command line.
   -   `since`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
 -   **filter** - only return images with the specified name
 
-### Build image from a Dockerfile
+#### Build image from a Dockerfile
 
 `POST /build`
 
@@ -1758,7 +1756,7 @@ or being killed.
 -   **200** – no error
 -   **500** – server error
 
-### Create an image
+#### Create an image
 
 `POST /images/create`
 
@@ -1824,7 +1822,7 @@ a base64-encoded AuthConfig object.
 
 
 
-### Inspect an image
+#### Inspect an image
 
 `GET /images/(name)/json`
 
@@ -1942,7 +1940,7 @@ Return low-level information on the image `name`
 -   **404** – no such image
 -   **500** – server error
 
-### Get the history of an image
+#### Get the history of an image
 
 `GET /images/(name)/history`
 
@@ -1996,7 +1994,7 @@ Return the history of the image `name`
 -   **404** – no such image
 -   **500** – server error
 
-### Push an image on the registry
+#### Push an image on the registry
 
 `POST /images/(name)/push`
 
@@ -2058,7 +2056,7 @@ The push is cancelled if the HTTP connection is closed.
 -   **404** – no such image
 -   **500** – server error
 
-### Tag an image into a repository
+#### Tag an image into a repository
 
 `POST /images/(name)/tag`
 
@@ -2085,7 +2083,7 @@ Tag the image `name` into a repository
 -   **409** – conflict
 -   **500** – server error
 
-### Remove an image
+#### Remove an image
 
 `DELETE /images/(name)`
 
@@ -2118,7 +2116,7 @@ Remove the image `name` from the filesystem
 -   **409** – conflict
 -   **500** – server error
 
-### Search images
+#### Search images
 
 `GET /images/search`
 
@@ -2176,9 +2174,9 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 -   **200** – no error
 -   **500** – server error
 
-## 3.3 Misc
+### 3.3 Misc
 
-### Check auth configuration
+#### Check auth configuration
 
 `POST /auth`
 
@@ -2211,7 +2209,7 @@ if available, for accessing the registry without password.
 -   **204** – no error
 -   **500** – server error
 
-### Display system-wide information
+#### Display system-wide information
 
 `GET /info`
 
@@ -2304,7 +2302,7 @@ Display system-wide information
 -   **200** – no error
 -   **500** – server error
 
-### Show the docker version information
+#### Show the docker version information
 
 `GET /version`
 
@@ -2336,7 +2334,7 @@ Show the docker version information
 -   **200** – no error
 -   **500** – server error
 
-### Ping the docker server
+#### Ping the docker server
 
 `GET /_ping`
 
@@ -2358,7 +2356,7 @@ Ping the docker server
 -   **200** - no error
 -   **500** - server error
 
-### Create a new image from a container's changes
+#### Create a new image from a container's changes
 
 `POST /commit`
 
@@ -2430,7 +2428,7 @@ Create a new image from a container's changes
 -   **404** – no such container
 -   **500** – server error
 
-### Monitor Docker's events
+#### Monitor Docker's events
 
 `GET /events`
 
@@ -2635,7 +2633,7 @@ Docker daemon report the following event:
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images in a repository
+#### Get a tarball containing all images in a repository
 
 `GET /images/(name)/get`
 
@@ -2665,7 +2663,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images
+#### Get a tarball containing all images
 
 `GET /images/get`
 
@@ -2694,7 +2692,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Load a tarball with a set of images and tags into docker
+#### Load a tarball with a set of images and tags into docker
 
 `POST /images/load`
 
@@ -2743,7 +2741,7 @@ action completes.
 -   **200** – no error
 -   **500** – server error
 
-### Image tarball format
+#### Image tarball format
 
 An image tarball contains one directory per image layer (named using its long ID),
 each containing these files:
@@ -2764,7 +2762,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 }
 ```
 
-### Exec Create
+#### Exec Create
 
 `POST /containers/(id or name)/exec`
 
@@ -2818,7 +2816,7 @@ Sets up an exec instance in a running container `id`
 -   **409** - container is paused
 -   **500** - server error
 
-### Exec Start
+#### Exec Start
 
 `POST /exec/(id)/start`
 
@@ -2860,7 +2858,7 @@ interactive session with the `exec` command.
 
 Similar to the stream behavior of `POST /containers/(id or name)/attach` API
 
-### Exec Resize
+#### Exec Resize
 
 `POST /exec/(id)/resize`
 
@@ -2887,7 +2885,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 -   **201** – no error
 -   **404** – no such exec instance
 
-### Exec Inspect
+#### Exec Inspect
 
 `GET /exec/(id)/json`
 
@@ -2930,9 +2928,9 @@ Return low-level information about the `exec` command `id`.
 -   **404** – no such exec instance
 -   **500** - server error
 
-## 3.4 Volumes
+### 3.4 Volumes
 
-### List volumes
+#### List volumes
 
 `GET /volumes`
 
@@ -2970,7 +2968,7 @@ Return low-level information about the `exec` command `id`.
 -   **200** - no error
 -   **500** - server error
 
-### Create a volume
+#### Create a volume
 
 `POST /volumes/create`
 
@@ -3027,7 +3025,7 @@ Create a volume
 Refer to the [inspect a volume](#inspect-a-volume) section or details about the
 JSON fields returned in the response.
 
-### Inspect a volume
+#### Inspect a volume
 
 `GET /volumes/(name)`
 
@@ -3079,7 +3077,7 @@ response.
 - **Scope** - Scope describes the level at which the volume exists, can be one of
     `global` for cluster-wide or `local` for machine level. The default is `local`.
 
-### Remove a volume
+#### Remove a volume
 
 `DELETE /volumes/(name)`
 
@@ -3100,9 +3098,9 @@ Instruct the driver to remove the volume (`name`).
 -   **409** - volume is in use and cannot be removed
 -   **500** - server error
 
-## 3.5 Networks
+### 3.5 Networks
 
-### List networks
+#### List networks
 
 `GET /networks`
 
@@ -3194,7 +3192,7 @@ Content-Type: application/json
 -   **200** - no error
 -   **500** - server error
 
-### Inspect network
+#### Inspect network
 
 `GET /networks/<network-id>`
 
@@ -3256,7 +3254,7 @@ Content-Type: application/json
 -   **200** - no error
 -   **404** - network not found
 
-### Create a network
+#### Create a network
 
 `POST /networks/create`
 
@@ -3339,7 +3337,7 @@ Content-Type: application/json
 - **Options** - Network specific options to be used by the drivers
 - **Labels** - Labels to set on the network, specified as a map: `{"key":"value" [,"key2":"value2"]}`
 
-### Connect a container to a network
+#### Connect a container to a network
 
 `POST /networks/(id)/connect`
 
@@ -3377,7 +3375,7 @@ Content-Type: application/json
 
 - **container** - container-id/name to be connected to the network
 
-### Disconnect a container from a network
+#### Disconnect a container from a network
 
 `POST /networks/(id)/disconnect`
 
@@ -3411,7 +3409,7 @@ Content-Type: application/json
 - **Container** - container-id/name to be disconnected from a network
 - **Force** - Force the container to disconnect from a network
 
-### Remove a network
+#### Remove a network
 
 `DELETE /networks/(id)`
 
@@ -3431,9 +3429,9 @@ Instruct the driver to remove the network (`id`).
 -   **404** - no such network
 -   **500** - server error
 
-## 3.6 Plugins (experimental)
+### 3.6 Plugins (experimental)
 
-### List plugins
+#### List plugins
 
 `GET /plugins`
 
@@ -3563,7 +3561,7 @@ Content-Type: application/json
 -   **200** - no error
 -   **500** - server error
 
-### Install a plugin
+#### Install a plugin
 
 `POST /plugins/pull?name=<plugin name>`
 
@@ -3625,7 +3623,7 @@ Content-Length: 175
       name must have at least one component
 -   **500** - plugin already exists
 
-### Inspect a plugin
+#### Inspect a plugin
 
 `GET /plugins/(plugin name)`
 
@@ -3758,7 +3756,7 @@ Content-Type: application/json
 -   **200** - no error
 -   **404** - plugin not installed
 
-### Enable a plugin
+#### Enable a plugin
 
 `POST /plugins/(plugin name)/enable`
 
@@ -3786,7 +3784,7 @@ Content-Type: text/plain; charset=utf-8
 -   **200** - no error
 -   **500** - plugin is already enabled
 
-### Disable a plugin
+#### Disable a plugin
 
 `POST /plugins/(plugin name)/disable`
 
@@ -3814,7 +3812,7 @@ Content-Type: text/plain; charset=utf-8
 -   **200** - no error
 -   **500** - plugin is already disabled
 
-### Remove a plugin
+#### Remove a plugin
 
 `DELETE /plugins/(plugin name)`
 
@@ -3844,7 +3842,7 @@ Content-Type: text/plain; charset=utf-8
 
 <!-- TODO Document "docker plugin push" endpoint once we have "plugin build"
 
-### Push a plugin
+#### Push a plugin
 
 `POST /v1.24/plugins/tiborvass/(plugin name)/push HTTP/1.1`
 
@@ -3870,11 +3868,11 @@ an image](#create-an-image) section for more details.
 
 -->
 
-## 3.7 Nodes
+### 3.7 Nodes
 
 **Note**: Node operations require the engine to be part of a swarm.
 
-### List nodes
+#### List nodes
 
 
 `GET /nodes`
@@ -3967,7 +3965,7 @@ List nodes
 - **200** – no error
 - **500** – server error
 
-### Inspect a node
+#### Inspect a node
 
 
 `GET /nodes/(id or name)`
@@ -4049,7 +4047,7 @@ Return low-level information on the node `id`
 -   **404** – no such node
 -   **500** – server error
 
-### Remove a node
+#### Remove a node
 
 
 `DELETE /nodes/(id or name)`
@@ -4077,7 +4075,7 @@ Remove a node from the swarm.
 -   **404** – no such node
 -   **500** – server error
 
-### Update a node
+#### Update a node
 
 
 `POST /nodes/(id)/update`
@@ -4132,9 +4130,9 @@ JSON Parameters:
 -   **404** – no such node
 -   **500** – server error
 
-## 3.8 Swarm
+### 3.8 Swarm
 
-### Inspect swarm
+#### Inspect swarm
 
 
 `GET /swarm`
@@ -4182,7 +4180,7 @@ Inspect swarm
 
 - **200** - no error
 
-### Initialize a new swarm
+#### Initialize a new swarm
 
 
 `POST /swarm/init`
@@ -4258,7 +4256,7 @@ JSON Parameters:
             - **Options** - An object with key/value pairs that are interpreted
               as protocol-specific options for the external CA driver.
 
-### Join an existing swarm
+#### Join an existing swarm
 
 `POST /swarm/join`
 
@@ -4300,7 +4298,7 @@ JSON Parameters:
 - **RemoteAddr** – Address of any manager node already participating in the swarm.
 - **JoinToken** – Secret token for joining this swarm.
 
-### Leave a swarm
+#### Leave a swarm
 
 
 `POST /swarm/leave`
@@ -4326,7 +4324,7 @@ Leave a swarm
 - **200** – no error
 - **406** – node is not part of a swarm
 
-### Update a swarm
+#### Update a swarm
 
 
 `POST /swarm/update`
@@ -4407,11 +4405,11 @@ JSON Parameters:
     - **Worker** - Token to use for joining as a worker.
     - **Manager** - Token to use for joining as a manager.
 
-## 3.9 Services
+### 3.9 Services
 
 **Note**: Service operations require to first be part of a swarm.
 
-### List services
+#### List services
 
 
 `GET /services`
@@ -4516,7 +4514,7 @@ List services
 - **200** – no error
 - **500** – server error
 
-### Create a service
+#### Create a service
 
 `POST /services/create`
 
@@ -4689,7 +4687,7 @@ image](#create-an-image) section for more details.
   section for more details.
 
 
-### Remove a service
+#### Remove a service
 
 
 `DELETE /services/(id or name)`
@@ -4712,7 +4710,7 @@ Stop and remove the service `id`
 -   **404** – no such service
 -   **500** – server error
 
-### Inspect one or more services
+#### Inspect one or more services
 
 
 `GET /services/(id or name)`
@@ -4801,7 +4799,7 @@ Return information on the service `id`.
 -   **404** – no such service
 -   **500** – server error
 
-### Update a service
+#### Update a service
 
 `POST /services/(id or name)/update`
 
@@ -4934,11 +4932,11 @@ image](#create-an-image) section for more details.
 -   **404** – no such service
 -   **500** – server error
 
-## 3.10 Tasks
+### 3.10 Tasks
 
 **Note**: Task operations require the engine to be part of a swarm.
 
-### List tasks
+#### List tasks
 
 
 `GET /tasks`
@@ -5136,7 +5134,7 @@ List tasks
 - **200** – no error
 - **500** – server error
 
-### Inspect a task
+#### Inspect a task
 
 
 `GET /tasks/(task id)`
@@ -5239,9 +5237,9 @@ Get details on a task
 - **404** – unknown task
 - **500** – server error
 
-# 4. Going further
+## 4. Going further
 
-## 4.1 Inside `docker run`
+### 4.1 Inside `docker run`
 
 As an example, the `docker run` command line makes the following API calls:
 
@@ -5259,7 +5257,7 @@ As an example, the `docker run` command line makes the following API calls:
 
 - If in detached mode or only `stdin` is attached, display the container's id.
 
-## 4.2 Hijacking
+### 4.2 Hijacking
 
 In this version of the API, `/attach`, uses hijacking to transport `stdin`,
 `stdout`, and `stderr` on the same socket.
@@ -5274,7 +5272,7 @@ When Docker daemon detects the `Upgrade` header, it switches its status code
 from **200 OK** to **101 UPGRADED** and resends the same headers.
 
 
-## 4.3 CORS Requests
+### 4.3 CORS Requests
 
 To set cross origin requests to the Engine API please give values to
 `--api-cors-header` when running Docker in daemon mode. Set * (asterisk) allows all,


### PR DESCRIPTION
A few things here (full details in commit messages):

* Remove double headings from old API version documentation
* Add an intro to swagger.yaml to explain what the heck it is
* Make tags in swagger.yaml consistent and work properly as docs menu items. Ideally, these would match the `operationId`, but they are the names of the menu items in the docs, so they primarily need to be for that.
* Make docs URLs in swagger.yaml absolute so it can be used out of context of the documentation.
* Make `operationId` in swagger.yaml consistent (@dnephin - you will like this :)

See https://github.com/docker/docker.github.io/pull/606 for the corresponding documentation change that vendors this.

This needs to be cherry-picked to 1.13. It should all work cleanly apart from a URL change in the version history section of `swagger.yaml`. That line can just be removed entirely, because it is referencing 1.13 as a previous version.