### PR TITLE
Ignore "failed to close stdin" if container or process not found

### DIFF
--- a/container/stream/streams.go
+++ b/container/stream/streams.go
@@ -135,7 +135,7 @@ func (c *Config) CopyToPipe(iop libcontainerd.IOPipe) {
 			go func() {
 				pools.Copy(iop.Stdin, stdin)
 				if err := iop.Stdin.Close(); err != nil {
-					logrus.Errorf("failed to close stdin: %+v", err)
+					logrus.Warnf("failed to close stdin: %+v", err)
 				}
 			}()
 		}

--- a/libcontainerd/process_unix.go
+++ b/libcontainerd/process_unix.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	goruntime "runtime"
+	"strings"
 	"time"
 
 	containerd "github.com/docker/containerd/api/grpc/types"
@@ -86,6 +87,9 @@ func (p *process) sendCloseStdin() error {
 		Pid:        p.friendlyName,
 		CloseStdin: true,
 	})
+	if err != nil && (strings.Contains(err.Error(), "container not found") || strings.Contains(err.Error(), "process not found")) {
+		return nil
+	}
 	return err
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Ignore "failed to close stdin" if container or process not found. 
Every container exit will print a warning 
```
WARN[0106] failed to close stdin: rpc error: code = 2 desc = containerd: container not found
```
on my system.
and every exec exit will print a error
```
ERRO[0178] failed to close stdin: rpc error: code = 2 desc = containerd: process not found for container
```
This make the daemon log noise. I think it's better to just ignore the warn and error if it's a `container not found` or `process not found`

**- How I did it**
check the error message if it has `not found`

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![images](https://cloud.githubusercontent.com/assets/8232360/20638780/a868b110-b3eb-11e6-839e-dad963dc5687.jpg)


ping @tonistiigi 
Signed-off-by: Lei Jitang <leijitang@huawei.com>