### PR TITLE
Fix description and link  of 'docker run [-a]'

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -123,8 +123,8 @@ and pass along signals. All of that is configurable:
     --sig-proxy=true: Proxy all received signals to the process (non-TTY mode only)
     -i              : Keep STDIN open even if not attached
 
-If you do not specify `-a` then Docker will [attach all standard
-streams]( https://github.com/docker/docker/blob/75a7f4d90cde0295bcfb7213004abce8d4779b75/commands.go#L1797).
+If you do not specify `-a` then Docker will [attach to both stdout and stderr
+]( https://github.com/docker/docker/blob/4118e0c9eebda2412a09ae66e90c34b85fae3275/runconfig/opts/parse.go#L267).
 You can specify to which of the three standard streams (`STDIN`, `STDOUT`,
 `STDERR`) you'd like to connect instead, as in:
 


### PR DESCRIPTION
Fix description and link  of `docker run [-a]` in the ` docs/reference/run.md `

Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>