### PR TITLE
Add aliyun mirror support to hack/install.sh

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -53,6 +53,10 @@ case "$mirror" in
 		apt_url="https://mirror.azure.cn/docker-engine/apt"
 		yum_url="https://mirror.azure.cn/docker-engine/yum"
 		;;
+	Aliyun)
+		apt_url="http://mirrors.aliyun.com/docker-engine/apt"
+		yum_url="http://mirrors.aliyun.com/docker-engine/yum"
+		;;
 esac
 
 command_exists() {


### PR DESCRIPTION
Add Aliyun Docker apt/yum mirror support to `hack/install.sh`, so it will help people in China to overcome firewall issue. To use Aliyun mirror, just run 

```bash
curl -sSL https://get.docker.com/ | sh -s -- --mirror Aliyun
```

Signed-off-by: Tao Wang <twang2218@gmail.com>