### PR TITLE
Add aliases and options to `docker stack ls` docs

### DIFF
--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -19,6 +19,12 @@ keywords: "stack, ls"
 Usage:	docker stack ls
 
 List stacks
+
+Aliases:
+  ls, list
+
+Options:
+      --help   Print usage
 ```
 
 Lists the stacks.


### PR DESCRIPTION
In contrast to the other `docker stack` subcommands, the _Aliases_ and _Options_ section was missing.