### PR TITLE
stack deploy: handle external network when deploying

### DIFF
--- a/cli/command/stack/common.go
+++ b/cli/command/stack/common.go
@@ -37,7 +37,7 @@ func getServices(
 		types.ServiceListOptions{Filters: getStackFilter(namespace)})
 }
 
-func getNetworks(
+func getStackNetworks(
 	ctx context.Context,
 	apiclient client.APIClient,
 	namespace string,

--- a/cli/command/stack/remove.go
+++ b/cli/command/stack/remove.go
@@ -49,7 +49,7 @@ func runRemove(dockerCli *command.DockerCli, opts removeOptions) error {
 		}
 	}
 
-	networks, err := getNetworks(ctx, client, namespace)
+	networks, err := getStackNetworks(ctx, client, namespace)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #28835. There is two commits :

- If the network is marked as external, don't use the namespace on it. Otherwise, it's not found.
- It also validate that the existing networks are available `before` scheduling any services. This is more consistent with the way `docker-compose` does it and helps making sure we don't schedule an incomplete stack.

```
$ docker stack deploy --compose-file docker-compose.yml foo
Ignoring unsupported options: build

Ignoring deprecated options:

container_name: Setting the container name is not supported.

network "outside" is declared as external, but could not be found. You need to create the network before the stack is deployed (with overlay driver)

```

/cc @dnephin @aanand @thaJeztah @mavenugo 

:frog: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>