### PR TITLE
AcceptedFilters in router/network/filter.go should not be exported

### DIFF
--- a/api/server/router/network/filter.go
+++ b/api/server/router/network/filter.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	// AcceptedFilters is an acceptable filters for validation
-	AcceptedFilters = map[string]bool{
+	// acceptedNetworkFilters is a list of acceptable filters
+	acceptedNetworkFilters = map[string]bool{
 		"driver": true,
 		"type":   true,
 		"name":   true,
@@ -47,7 +47,7 @@ func filterNetworks(nws []types.NetworkResource, filter filters.Args) ([]types.N
 		return nws, nil
 	}
 
-	if err := filter.Validate(AcceptedFilters); err != nil {
+	if err := filter.Validate(acceptedNetworkFilters); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
It's not used elsewhere and doesn't need to be exported :angel:.

/cc @thaJeztah @runcom @AkihiroSuda @justincormack 

:frog: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>