### PR TITLE
Fix copypaste error 'is-automated'

### DIFF
--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -128,7 +128,7 @@ and are automated builds:
 This example displays images with a name containing 'busybox', at least
 3 stars and are official builds:
 
-    $ docker search --filter "is-automated=true" --filter "stars=3" busybox
+    $ docker search --filter "is-official=true" --filter "stars=3" busybox
     NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
     progrium/busybox                                                     50                   [OK]
     radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8                    [OK]


### PR DESCRIPTION
**- What I did**

When the `is-official` section was added to this doc, it was copy-pasted
from `is-automated` and one instance didn't get changed. I fixed it.

Original report: https://github.com/docker/docker.github.io/issues/660#event-867519885


![goat-kid](https://upload.wikimedia.org/wikipedia/commons/thumb/c/c0/Goat_kid_piggy_back.jpg/1024px-Goat_kid_piggy_back.jpg)


PTAL @thaJeztah 