### PR TITLE
Fix instances of doubled words

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -32,7 +32,7 @@ The `filter` param to filter the list of image by reference (name or name:tag) i
 
 **Target For Removal In Release: v1.16**
 
-`repository:shortid` syntax for referencing images is very little used, collides with with tag references can be confused with digest references.
+`repository:shortid` syntax for referencing images is very little used, collides with tag references can be confused with digest references.
 
 ### `docker daemon` subcommand
 **Deprecated In Release: [v1.13](https://github.com/docker/docker/releases/tag/v1.13.0)**

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -658,7 +658,7 @@ The `credentialspec` must be in the format `file://spec.txt` or `registry://keyn
 
 ### Stop container with timeout (--stop-timeout)
 
-The `--stop-timeout` flag sets the the timeout (in seconds) that a pre-defined (see `--stop-signal`) system call
+The `--stop-timeout` flag sets the timeout (in seconds) that a pre-defined (see `--stop-signal`) system call
 signal that will be sent to the container to exit. After timeout elapses the container will be killed with SIGKILL.
 
 ### Specify isolation technology for container (--isolation)

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -280,7 +280,7 @@ A virtual machine is a program that emulates a complete computer and imitates de
 It shares physical hardware resources with other users but isolates the operating system. The
 end user has the same experience on a Virtual Machine as they would have on dedicated hardware.
 
-Compared to to containers, a virtual machine is heavier to run, provides more isolation,
+Compared to containers, a virtual machine is heavier to run, provides more isolation,
 gets its own set of resources and does minimal sharing.
 
 *Also known as : VM*


### PR DESCRIPTION
It's easy to accidentally double up some words. After https://github.com/docker/docker.github.io/issues/667 was reported in the docs repo, I found and fixed a few besides the reported one.


PTAL @thaJeztah 