### PR TITLE
Fix issue with plugin exit.

### DIFF
--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -26,6 +26,7 @@ func (pm *Manager) enable(p *v2.Plugin, force bool) error {
 	}
 	p.Lock()
 	p.Restart = true
+	p.ExitChan = make(chan bool)
 	p.Unlock()
 	if err := pm.containerdClient.Create(p.GetID(), "", "", specs.Spec(*spec), attachToLog(p.GetID())); err != nil {
 		return err
@@ -92,7 +93,6 @@ func (pm *Manager) Shutdown() {
 		}
 		if pm.containerdClient != nil && p.IsEnabled() {
 			p.Lock()
-			p.ExitChan = make(chan bool)
 			p.Restart = false
 			p.Unlock()
 			shutdownPlugin(p, pm.containerdClient)


### PR DESCRIPTION
A plugin has an `ExitChan` channeled which is used to signal the exit of
the plugin process. In a recent change, the initialization was
incorrectly moved to the daemon Shutdown path.

Fix this by initializing the channel during plugin enable.

Tested `plugin disable` and `plugin rm -f` and observed log message stating
`Clean shutdown of plugin`, which indicates that the plugin exit event was processed.

Signed-off-by: Anusha Ragunathan <anusha@docker.com>