### PR TITLE
Fixes ImageList to be retro-compatible with older API

### DIFF
--- a/api/types/filters/parse.go
+++ b/api/types/filters/parse.go
@@ -144,6 +144,9 @@ func (filters Args) Add(name, value string) {
 func (filters Args) Del(name, value string) {
 	if _, ok := filters.fields[name]; ok {
 		delete(filters.fields[name], value)
+		if len(filters.fields[name]) == 0 {
+			delete(filters.fields, name)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #28895 — Make sure current client code can talk for ImageList can still talk to older daemon.

If the client api version is lower than `1.25`, let's send back `filter` query param and remove the `reference` filter in order to not break the image listing while talking to older daemon.

It also update the `filters.Args` `Del` method to clean the filter on remove if it's empty. And a unit tests to make sure it works.

/cc @tiborvass @thaJeztah @icecrime @cpuguy83 @crosbymichael 

:frog: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>