### PR TITLE
Don't resolve or pull images referenced by ID

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/digest"
 	distreference "github.com/docker/distribution/reference"
 	apierrors "github.com/docker/docker/api/errors"
 	apitypes "github.com/docker/docker/api/types"
@@ -1021,6 +1022,9 @@ func (c *Cluster) GetServices(options apitypes.ServiceListOptions) ([]types.Serv
 // TODO(nishanttotla): After the packages converge, the function must
 // convert distreference.Named -> distreference.Canonical, and the logic simplified.
 func (c *Cluster) imageWithDigestString(ctx context.Context, image string, authConfig *apitypes.AuthConfig) (string, error) {
+	if _, err := digest.ParseDigest(image); err == nil {
+		return "", errors.New("image reference is an image ID")
+	}
 	ref, err := distreference.ParseNamed(image)
 	if err != nil {
 		return "", err

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
@@ -52,6 +53,11 @@ func newContainerAdapter(b executorpkg.Backend, task *api.Task, secrets exec.Sec
 
 func (c *containerAdapter) pullImage(ctx context.Context) error {
 	spec := c.container.spec()
+
+	// Skip pulling if the image is referenced by image ID.
+	if _, err := digest.ParseDigest(spec.Image); err == nil {
+		return nil
+	}
 
 	// Skip pulling if the image is referenced by digest and already
 	// exists locally.


### PR DESCRIPTION
If a swarm service is created using an image ID, it's useless to try to
pull this reference or resolve it to a manifest digest. Avoid doing this
when a fully qualified image ID is given.

Fixes #28034

cc @thaJeztah @nishanttotla