### PR TITLE
Fail to pull foreign layers when not supported

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -33,9 +33,10 @@ import (
 )
 
 var (
-	errRootFSMismatch  = errors.New("layers from manifest don't match image configuration")
-	errMediaTypePlugin = errors.New("target is a plugin")
-	errRootFSInvalid   = errors.New("invalid rootfs in image configuration")
+	errRootFSMismatch        = errors.New("layers from manifest don't match image configuration")
+	errMediaTypePlugin       = errors.New("target is a plugin")
+	errRootFSInvalid         = errors.New("invalid rootfs in image configuration")
+	errNoForeignLayerSupport = errors.New("this platform does not support foreign layers")
 )
 
 // ImageConfigPullError is an error pulling the image config blob

--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -5,9 +5,13 @@ package distribution
 import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
+	"github.com/docker/docker/distribution/xfer"
 )
 
 func (ld *v2LayerDescriptor) open(ctx context.Context) (distribution.ReadSeekCloser, error) {
+	if len(ld.src.URLs) != 0 {
+		return nil, xfer.DoNotRetry{Err: errNoForeignLayerSupport}
+	}
 	blobs := ld.repo.Blobs(ctx)
 	return blobs.Open(ctx, ld.digest)
 }

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -272,3 +272,10 @@ func (s *DockerSuite) TestPullLinuxImageFailsOnWindows(c *check.C) {
 	_, _, err := dockerCmdWithError("pull", "ubuntu")
 	c.Assert(err.Error(), checker.Contains, "cannot be used on this platform")
 }
+
+// Regression test for https://github.com/docker/docker/issues/28892
+func (s *DockerSuite) TestPullWindowsImageFailsOnLinux(c *check.C) {
+	testRequires(c, DaemonIsLinux, Network)
+	_, _, err := dockerCmdWithError("pull", "microsoft/nanoserver")
+	c.Assert(err.Error(), checker.Contains, "this platform does not support foreign layers")
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Provide a better error message when a Unix daemon attempts to pull a foreign layer.

fixes #28892

**- How I did it**

Check if the layer being pulled is foreign, and fail on Unix daemons if so.

**- How to verify it**

Added test to verify.

Signed-off-by: Darren Stahl <darst@microsoft.com>

/cc @jhowardmsft 