### PR TITLE
Use namespace label on stack volumes

### DIFF
--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -347,7 +347,7 @@ func convertVolumeToMount(
 		source = stackVolume.External.Name
 	} else {
 		volumeOptions = &mount.VolumeOptions{
-			Labels: stackVolume.Labels,
+			Labels: getStackLabels(namespace.name, stackVolume.Labels),
 			NoCopy: isNoCopy(mode),
 		}
 


### PR DESCRIPTION
To be consistent with the services and networks created by stack deploy.