### PR TITLE
Reject unspecified advertise addr on swarm init

### DIFF
--- a/daemon/cluster/listen_addr.go
+++ b/daemon/cluster/listen_addr.go
@@ -11,8 +11,8 @@ var (
 	errNoIP                    = errors.New("could not find the system's IP address")
 	errMustSpecifyListenAddr   = errors.New("must specify a listening address because the address to advertise is not recognized as a system address, and a system's IP address to use could not be uniquely identified")
 	errBadListenAddr           = errors.New("listen address must be an IP address or network interface (with optional port number)")
-	errBadAdvertiseAddr        = errors.New("advertise address must be an IP address or network interface (with optional port number)")
-	errBadDefaultAdvertiseAddr = errors.New("default advertise address must be an IP address or network interface (without a port number)")
+	errBadAdvertiseAddr        = errors.New("advertise address must be a non-zero IP address or network interface (with optional port number)")
+	errBadDefaultAdvertiseAddr = errors.New("default advertise address must be a non-zero IP address or network interface (without a port number)")
 )
 
 func resolveListenAddr(specifiedAddr string) (string, string, error) {
@@ -69,7 +69,7 @@ func (c *Cluster) resolveAdvertiseAddr(advertiseAddr, listenAddrPort string) (st
 		}
 
 		// If it's not an interface, it must be an IP (for now)
-		if net.ParseIP(advertiseHost) == nil {
+		if ip := net.ParseIP(advertiseHost); ip == nil || ip.IsUnspecified() {
 			return "", "", errBadAdvertiseAddr
 		}
 
@@ -89,7 +89,7 @@ func (c *Cluster) resolveAdvertiseAddr(advertiseAddr, listenAddrPort string) (st
 		}
 
 		// If it's not an interface, it must be an IP (for now)
-		if net.ParseIP(c.config.DefaultAdvertiseAddr) == nil {
+		if ip := net.ParseIP(c.config.DefaultAdvertiseAddr); ip == nil || ip.IsUnspecified() {
 			return "", "", errBadDefaultAdvertiseAddr
 		}
 

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -86,6 +86,13 @@ func (s *DockerSwarmSuite) TestSwarmInitIPv6(c *check.C) {
 	c.Assert(out, checker.Contains, "Swarm: active")
 }
 
+func (s *DockerSwarmSuite) TestSwarmInitUnspecifiedAdvertiseAddr(c *check.C) {
+	d := s.AddDaemon(c, false, false)
+	out, err := d.Cmd("swarm", "init", "--advertise-addr", "0.0.0.0")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "advertise address must be a non-zero IP address")
+}
+
 func (s *DockerSwarmSuite) TestSwarmIncompatibleDaemon(c *check.C) {
 	// init swarm mode and stop a daemon
 	d := s.AddDaemon(c, true, true)


### PR DESCRIPTION
This patch prevents users from specifying a Docker Swarm Manager advertise address which is a zero IP (i.e., `0.0.0.0` or `[::]`). Allowing such values results in invalid generated `docker swarm join ...` commands and perhaps other unthinkable issues.