### PR TITLE
WORKDIR set cmd

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -290,6 +290,17 @@ func workdir(b *Builder, args []string, attributes map[string]bool, original str
 		return nil
 	}
 	b.runConfig.Image = b.image
+
+	cmd := b.runConfig.Cmd
+	b.runConfig.Cmd = strslice.StrSlice(append(getShell(b.runConfig), fmt.Sprintf("#(nop) WORKDIR %s", b.runConfig.WorkingDir)))
+	defer func(cmd strslice.StrSlice) { b.runConfig.Cmd = cmd }(cmd)
+
+	if hit, err := b.probeCache(); err != nil {
+		return err
+	} else if hit {
+		return nil
+	}
+
 	container, err := b.docker.ContainerCreate(types.ContainerCreateConfig{Config: b.runConfig}, true)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes https://github.com/docker/docker/issues/28902

As found by @Vieux. Using an image without a command in it (eg golang:1.7-alpine), docker build will fail on WORKDIR "no command specified". I included the same "hack" that COPY/ADD does to set/defer the unset of the CMD when calling `ContainerCreate` in the new `WORKDIR` processing. It wasn't hit on CI as that largely uses busybox which has a default CMD, same as Ubuntu, and the base Windows images.

@duglin @tiborvass Yes, I know, I need to get a test in for this - something like FROM scratch WORKDIR / and make sure it succeeds. Just rushing to get a PR in as I broke master :(