### PR TITLE
container/state.go: fix race in StateString()

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -60,6 +60,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 
 	var cRunning, cPaused, cStopped int32
 	daemon.containers.ApplyAll(func(c *container.Container) {
+		c.Lock()
 		switch c.StateString() {
 		case "paused":
 			atomic.AddInt32(&cPaused, 1)
@@ -68,6 +69,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		default:
 			atomic.AddInt32(&cStopped, 1)
 		}
+		c.Unlock()
 	})
 
 	securityOptions := []string{}


### PR DESCRIPTION
Overall State struct is extremely weird because it exposes Lock() and Unlock() which actively used by outside code. But I'm not sure how to fix that.
ping @mlaventure 