### PR TITLE
cluster: Refuse swarm spec not named "default"

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -1825,6 +1825,12 @@ func validateAndSanitizeInitRequest(req *types.InitRequest) error {
 		return fmt.Errorf("invalid ListenAddr %q: %v", req.ListenAddr, err)
 	}
 
+	if req.Spec.Annotations.Name == "" {
+		req.Spec.Annotations.Name = "default"
+	} else if req.Spec.Annotations.Name != "default" {
+		return errors.New(`swarm spec must be named "default"`)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
If, using the API, a user submits an init request with a spec that has a
name other than "default", the engine will rename the "default" cluster
object. Some parts of swarmkit depend on having a cluster object named
"default". Reject any specs that use other names.

Fixes #28067

cc @tonistiigi