### PR TITLE
correct the http return code of secret remove

### DIFF
--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -383,6 +383,7 @@ func (sr *swarmRouter) removeSecret(ctx context.Context, w http.ResponseWriter, 
 	if err := sr.backend.RemoveSecret(vars["id"]); err != nil {
 		return err
 	}
+	w.WriteHeader(http.StatusNoContent)
 
 	return nil
 }

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -76,7 +76,11 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `DELETE /plugins/(plugin name)` delete a plugin.
 * `POST /node/(id or name)/update` now accepts both `id` or `name` to identify the node to update.
 * `GET /images/json` now support a `reference` filter.
-
+* `GET /secrets` returns information on the secrets.
+* `POST /secrets/create` creates a secret.
+* `DELETE /secrets/{id}` removes the secret `id`.
+* `GET /secrets/{id}` returns information on the secret `id`.
+* `POST /secrets/{id}/update` updates the secret `id`.
 
 ## v1.24 API changes
 

--- a/integration-cli/daemon_swarm.go
+++ b/integration-cli/daemon_swarm.go
@@ -317,7 +317,7 @@ func (d *SwarmDaemon) getSecret(c *check.C, id string) *swarm.Secret {
 func (d *SwarmDaemon) deleteSecret(c *check.C, id string) {
 	status, out, err := d.SockRequest("DELETE", "/secrets/"+id, nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
-	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
+	c.Assert(status, checker.Equals, http.StatusNoContent, check.Commentf("output: %q", string(out)))
 }
 
 func (d *SwarmDaemon) getSwarm(c *check.C) swarm.Swarm {


### PR DESCRIPTION
Hi,  this PR  solves the mismatches of http status code between `DELETE /secrets/{id}` codes and swagger.yaml file.  

when I use Postman to DELETE a secret with `/v1.25/secrets/{id}`,  the status returns `200 OK` , and here is the secret remove codes :
```
    
func (sr *swarmRouter) removeSecret(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
	if err := sr.backend.RemoveSecret(vars["id"]); err != nil {
		return err
	}

	return nil
}

 ```
however,  I find the status code does not match the swagger.yaml, because within swagger.yaml the return code of secret remove is `204` (https://github.com/docker/docker/blob/master/api/swagger.yaml#L7649)

so I correct the secret remove return code with 204 to match the swagger.yaml.

```
    
func (sr *swarmRouter) removeSecret(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
	if err := sr.backend.RemoveSecret(vars["id"]); err != nil {
		return err
	}
        w.WriteHeader(http.StatusNoContent)
	return nil
}

 ```


**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: erxian <evelynhsu21@gmail.com>