### PR TITLE
change secret remove logic in cli

### DIFF
--- a/cli/command/secret/remove.go
+++ b/cli/command/secret/remove.go
@@ -2,6 +2,7 @@ package secret
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
@@ -36,12 +37,19 @@ func runSecretRemove(dockerCli *command.DockerCli, opts removeOptions) error {
 		return err
 	}
 
+	var errs []string
+
 	for _, id := range ids {
 		if err := client.SecretRemove(ctx, id); err != nil {
-			fmt.Fprintf(dockerCli.Out(), "WARN: %s\n", err)
+			errs = append(errs, err.Error())
+			continue
 		}
 
 		fmt.Fprintln(dockerCli.Out(), id)
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "\n"))
 	}
 
 	return nil


### PR DESCRIPTION
I found secret removal code in cli is :
```
for _, id := range ids {
		if err := client.SecretRemove(ctx, id); err != nil {
			fmt.Fprintf(dockerCli.Out(), "WARN: %s\n", err)
                        // I think here needs a `continue`, otherwise for an error secret removal, print two lines
		}

		fmt.Fprintln(dockerCli.Out(), id)
	}
```

There is some improper, so that I try to add a `continue` fix this.
In addition, I change the logic here to be consistent with `node removal`, `plugin removal` and so on.

**- What I did**
1. add a `continue` to make this correct;
2. refactor some codes related to err dealing.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: Allen Sun <allen.sun@daocloud.io>