### PR TITLE
update an incorrect url in docs

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -18,4 +18,4 @@ keywords: "Engine"
 * [Dockerfile reference](builder.md)
 * [Docker run reference](run.md)
 * [Command line reference](commandline/index.md)
-* [API Reference](api/index.md)
+* [API Reference](https://docs.docker.com/engine/api/)


### PR DESCRIPTION
Since API dir changed a lot. And now there is no corresponding index.md there.

This pr updated a useless reference from other files. 

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: allencloud <allen.sun@daocloud.io>