### PR TITLE
Fix the inconsistency for secret ls and secrect rm

### DIFF
--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -25,7 +25,7 @@ func newSecretInspectCommand(dockerCli *command.DockerCli) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.format, "format", "f", "", "Format the output using the given go template")
+	cmd.Flags().StringVarP(&opts.format, "format", "f", "", "Format the output using the given Go template")
 	return cmd
 }
 

--- a/cli/command/secret/ls.go
+++ b/cli/command/secret/ls.go
@@ -21,9 +21,10 @@ func newSecretListCommand(dockerCli *command.DockerCli) *cobra.Command {
 	opts := listOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "ls [OPTIONS]",
-		Short: "List secrets",
-		Args:  cli.NoArgs,
+		Use:     "ls [OPTIONS]",
+		Aliases: []string{"list"},
+		Short:   "List secrets",
+		Args:    cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSecretList(dockerCli, opts)
 		},

--- a/cli/command/secret/remove.go
+++ b/cli/command/secret/remove.go
@@ -15,9 +15,10 @@ type removeOptions struct {
 
 func newSecretRemoveCommand(dockerCli *command.DockerCli) *cobra.Command {
 	return &cobra.Command{
-		Use:   "rm SECRET [SECRET...]",
-		Short: "Remove one or more secrets",
-		Args:  cli.RequiresMinArgs(1),
+		Use:     "rm SECRET [SECRET...]",
+		Aliases: []string{"remove"},
+		Short:   "Remove one or more secrets",
+		Args:    cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts := removeOptions{
 				names: args,

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -27,9 +27,9 @@ Options:
   -q, --quiet          Only display IDs
 ```
 
-Run this command from a manager to list the secrets in the Swarm.
+Run this command on a manager node to list the secrets in the Swarm.
 
-On a manager node:
+## Examples
 
 ```bash
 $ docker secret ls


### PR DESCRIPTION
**- What I did**
Fix the inconsistency for docker secret

**- How I did it**

**- How to verify it**

**- Description for the changelog**
1. Fix some typos such as WARN and go.
2. Add aliases for docker secret ls and docker secret rm.

Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>