### PR TITLE
fix apparmor load profile

### DIFF
--- a/pkg/aaparser/aaparser.go
+++ b/pkg/aaparser/aaparser.go
@@ -4,7 +4,6 @@ package aaparser
 import (
 	"fmt"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -26,7 +25,7 @@ func GetVersion() (int, error) {
 // LoadProfile runs `apparmor_parser -r` on a specified apparmor profile to
 // replace the profile.
 func LoadProfile(profilePath string) error {
-	_, err := cmd("", "-r", filepath.Dir(profilePath))
+	_, err := cmd("", "-r", profilePath)
 	if err != nil {
 		return err
 	}

--- a/profiles/apparmor/template.go
+++ b/profiles/apparmor/template.go
@@ -40,7 +40,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 
 {{if ge .Version 208095}}
   # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
-  ptrace (trace,read) peer=docker-default,
+  ptrace (trace,read) peer={{.Name}},
 {{end}}
 }
 `


### PR DESCRIPTION
**- What I did**
1. Use `profilePath` as arg for `apparmor_parser`.
2. Use `{{.Name}}` as arg for `ptrace`

**- Why I did it**
1. `apparmor_parser` requires `profilePath` rather than it's dir.
2. Since it is a template, it is better to use `{{.Name}}`. And it is consistent with [this line](https://github.com/docker/docker/compare/master...xlgao-zju:fix-apparmor-load-profile?expand=1#diff-060088dd541ee0da4b7901894b6aa2b5R11).

Signed-off-by: Xianglin Gao <xlgao@zju.edu.cn>