### PR TITLE
Refactoring ineffectual assignments

### DIFF
--- a/api/types/filters/parse.go
+++ b/api/types/filters/parse.go
@@ -79,8 +79,8 @@ func ToParamWithVersion(version string, a Args) (string, error) {
 	}
 
 	// for daemons older than v1.10, filter must be of the form map[string][]string
-	buf := []byte{}
-	err := errors.New("")
+	var buf []byte
+	var err error
 	if version != "" && versions.LessThan(version, "1.22") {
 		buf, err = json.Marshal(convertArgsToSlice(a.fields))
 	} else {

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -204,10 +204,7 @@ func from(b *Builder, args []string, attributes map[string]bool, original string
 
 	name := args[0]
 
-	var (
-		image builder.Image
-		err   error
-	)
+	var image builder.Image
 
 	// Windows cannot support a container with no base image.
 	if name == api.NoBaseImageSpecifier {
@@ -219,10 +216,11 @@ func from(b *Builder, args []string, attributes map[string]bool, original string
 	} else {
 		// TODO: don't use `name`, instead resolve it to a digest
 		if !b.options.PullParent {
-			image, err = b.docker.GetImageOnBuild(name)
+			image, _ = b.docker.GetImageOnBuild(name)
 			// TODO: shouldn't we error out if error is different from "not found" ?
 		}
 		if image == nil {
+			var err error
 			image, err = b.docker.PullOnBuild(b.clientCtx, name, b.options.AuthConfigs, b.Output)
 			if err != nil {
 				return err

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -113,7 +113,6 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowLocalD
 	var err error
 	for _, orig := range args[0 : len(args)-1] {
 		var fi builder.FileInfo
-		decompress := allowLocalDecompression
 		if urlutil.IsURL(orig) {
 			if !allowRemote {
 				return fmt.Errorf("Source can't be a URL for %s", cmdName)
@@ -123,8 +122,10 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowLocalD
 				return err
 			}
 			defer os.RemoveAll(filepath.Dir(fi.Path()))
-			decompress = false
-			infos = append(infos, copyInfo{fi, decompress})
+			infos = append(infos, copyInfo{
+				FileInfo:   fi,
+				decompress: false,
+			})
 			continue
 		}
 		// not a URL

--- a/cli/command/container/stats_helpers.go
+++ b/cli/command/container/stats_helpers.go
@@ -81,14 +81,11 @@ func collect(ctx context.Context, s *formatter.ContainerStats, cli client.APICli
 	go func() {
 		for {
 			var (
-				v                 *types.StatsJSON
-				memPercent        = 0.0
-				cpuPercent        = 0.0
-				blkRead, blkWrite uint64 // Only used on Linux
-				mem               = 0.0
-				memLimit          = 0.0
-				memPerc           = 0.0
-				pidsStatsCurrent  uint64
+				v                      *types.StatsJSON
+				memPercent, cpuPercent float64
+				blkRead, blkWrite      uint64 // Only used on Linux
+				mem, memLimit, memPerc float64
+				pidsStatsCurrent       uint64
 			)
 
 			if err := dec.Decode(&v); err != nil {

--- a/cli/command/plugin/create.go
+++ b/cli/command/plugin/create.go
@@ -41,7 +41,9 @@ func validateConfig(path string) error {
 // validateContextDir validates the given dir and returns abs path on success.
 func validateContextDir(contextDir string) (string, error) {
 	absContextDir, err := filepath.Abs(contextDir)
-
+	if err != nil {
+		return "", err
+	}
 	stat, err := os.Lstat(absContextDir)
 	if err != nil {
 		return "", err

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -497,7 +497,7 @@ func UsingSystemd(config *Config) bool {
 // verifyPlatformContainerSettings performs platform-specific validation of the
 // hostconfig and config structures.
 func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.HostConfig, config *containertypes.Config, update bool) ([]string, error) {
-	warnings := []string{}
+	var warnings []string
 	sysInfo := sysinfo.New(true)
 
 	warnings, err := daemon.verifyExperimentalContainerSettings(hostConfig, config)
@@ -925,7 +925,6 @@ func parseRemappedRoot(usergrp string) (string, string, error) {
 			if err != nil {
 				return "", "", fmt.Errorf("Error during gid lookup for %q: %v", lookupName, err)
 			}
-			groupID = group.Gid
 			groupname = group.Name
 		}
 	}

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -64,7 +64,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 	s.Process.User.Username = c.Config.User
 
 	// In spec.Root. This is not set for Hyper-V containers
-	isHyperV := false
+	var isHyperV bool
 	if c.HostConfig.Isolation.IsDefault() {
 		// Container using default isolation, so take the default from the daemon configuration
 		isHyperV = daemon.defaultIsolation.IsHyperV()

--- a/distribution/push_v1.go
+++ b/distribution/push_v1.go
@@ -121,7 +121,7 @@ type v1DependencyImage struct {
 func newV1DependencyImage(l layer.Layer, parent *v1DependencyImage) *v1DependencyImage {
 	v1ID := digest.Digest(l.ChainID()).Hex()
 
-	config := ""
+	var config string
 	if parent != nil {
 		config = fmt.Sprintf(`{"id":"%s","parent":"%s"}`, v1ID, parent.V1ID())
 	} else {

--- a/pkg/chrootarchive/diff_unix.go
+++ b/pkg/chrootarchive/diff_unix.go
@@ -29,7 +29,7 @@ type applyLayerResponse struct {
 func applyLayer() {
 
 	var (
-		tmpDir  = ""
+		tmpDir  string
 		err     error
 		options *archive.TarOptions
 	)

--- a/pkg/testutil/utils.go
+++ b/pkg/testutil/utils.go
@@ -35,7 +35,6 @@ func IsKilled(err error) bool {
 }
 
 func runCommandWithOutput(cmd *exec.Cmd) (output string, exitCode int, err error) {
-	exitCode = 0
 	out, err := cmd.CombinedOutput()
 	exitCode = system.ProcessExitCode(err)
 	output = string(out)

--- a/registry/session.go
+++ b/registry/session.go
@@ -290,7 +290,7 @@ func (r *Session) GetRemoteImageLayer(imgID, registry string, imgSize int64) (io
 	if err != nil {
 		return nil, fmt.Errorf("Error while getting from the server: %v", err)
 	}
-	statusCode = 0
+
 	res, err = r.client.Do(req)
 	if err != nil {
 		logrus.Debugf("Error contacting registry %s: %v", registry, err)

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -200,12 +200,12 @@ func GetAllDrivers() ([]volume.Driver, error) {
 
 	for _, p := range plugins {
 		name := p.Name()
-		ext, ok := drivers.extensions[name]
-		if ok {
+
+		if _, ok := drivers.extensions[name]; ok {
 			continue
 		}
 
-		ext = NewVolumeDriver(name, p.BasePath(), p.Client())
+		ext := NewVolumeDriver(name, p.BasePath(), p.Client())
 		if p.IsV1() {
 			drivers.extensions[name] = ext
 		}


### PR DESCRIPTION
Hi i tried to run [gometalinter](https://github.com/alecthomas/gometalinter) with [ineffassign](https://github.com/gordonklaus/ineffassign). That tools detects ineffectual assignments, i refactoring those lines.(execept test file. ineffassign shows tons of code line in test file, so i fixed non-test source code first)

This patch fixed below 3 types of code line
1. Remove unnecessary variable assignment
ex) 
```
-	statusCode = 0
+
```
2. Use variables declaration instead of explicit initial zero value
```
- 	isHyperV := false
+	var isHyperV bool
```
3. Change variable name to underbar when variable not used
Mostly `err` which not checked or ignored.
```
-	absContextDir, err := filepath.Abs(contextDir)
+	absContextDir, _ := filepath.Abs(contextDir)
 
 	stat, err := os.Lstat(absContextDir)
```

Definitely first case is not a problem. but i not sure about second, third cases. maybe just keep value and name is more readable.