### PR TITLE
Fix docker save with empty timestamp of layer created time

### DIFF
--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -234,7 +234,9 @@ func (s *saveSession) saveImage(id image.ID) (map[layer.DiffID]distribution.Desc
 	var layers []string
 	var foreignSrcs map[layer.DiffID]distribution.Descriptor
 	for i := range img.RootFS.DiffIDs {
-		v1Img := image.V1Image{}
+		v1Img := image.V1Image{
+			Created: img.Created,
+		}
 		if i == len(img.RootFS.DiffIDs)-1 {
 			v1Img = img.V1Image
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
On docker which version under 1.10, docker load a tar archive which is save by docker which version is great than 1.9 to import an image , the `docker history` show the image's parent was created long long ago, and if use `docker save` to save the image, it will failed with `invalid argument`
````
[root@localhost tmp]# docker load -i ubuntu.tar 
[root@localhost tmp]# docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
ubuntu              latest              23a78ada0348        12 days ago         128.1 MB
ubuntu              tool                a4794f667ede        7 months ago        193.3 MB
[root@localhost tmp]# docker history ubuntu
IMAGE               CREATED             CREATED BY                             SIZE                COMMENT
23a78ada0348        12 days ago         /bin/sh -c #(nop)  CMD ["/bin/bash"]   7 B                 
6f12534822c5        292 years ago                                              1.895 kB            
3e1722599d1d        292 years ago                                              0 B                 
b7f0f1a6360e        292 years ago                                              745 B               
a940c634b64a        292 years ago                                              128.1 MB            
[root@localhost tmp]# docker save -o /tmp/ubuntu.tar ubuntu
Error response from daemon: chtimes /var/lib/docker/tmp/docker-export-366849286/6f12534822c57808e10e079842da48607c40eeb82048541320ba454af83cf021: invalid argument
````
This pr try to fix this with making the layer created time the same with the image on docker save.
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: Lei Jitang <leijitang@huawei.com>