### PR TITLE
[ppc64le] allow replacing httpredir in dockerfile

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -18,6 +18,10 @@
 # ppc64le/golang is a debian:jessie based image with golang installed
 FROM ppc64le/golang:1.6.3
 
+# allow replacing httpredir or deb mirror
+ARG APT_MIRROR=deb.debian.org
+RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
+
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \
 	apparmor \


### PR DESCRIPTION
Extension of #28640, allows replacing of the default httpredir.debian.org in /etc/apt/sources.list
with a user-specified mirror. This will (hopefully) fix CI apt issues for ppc64le.

Note that ppc64le/golang:1.6.3 image is debian:jessie based.

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>