### PR TITLE
Use dobi for build tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 .DS_Store
 # a .bashrc may be added to customize the build environment
 .bashrc
+.dobi
+dobi
 .editorconfig
 .gopath/
 .go-pkg-cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,6 @@ RUN apt-get update && apt-get install -y \
 	bsdmainutils \
 	btrfs-tools \
 	build-essential \
-	clang \
 	cmake \
 	createrepo \
 	curl \
@@ -98,16 +97,6 @@ RUN cd /usr/local/lvm2 \
 	&& make install_device-mapper
 # See https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
-# Configure the container for OSX cross compilation
-ENV OSX_SDK MacOSX10.11.sdk
-ENV OSX_CROSS_COMMIT a9317c18a3a457ca0a657f08cc4d0d43c6cf8953
-RUN set -x \
-	&& export OSXCROSS_PATH="/osxcross" \
-	&& git clone https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH \
-	&& ( cd $OSXCROSS_PATH && git checkout -q $OSX_CROSS_COMMIT) \
-	&& curl -sSL https://s3.dockerproject.org/darwin/v2/${OSX_SDK}.tar.xz -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" \
-	&& UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh
-ENV PATH /osxcross/target/bin:$PATH
 
 # Install seccomp: the version shipped in trusty is too old
 ENV SECCOMP_VERSION 2.3.1
@@ -134,14 +123,6 @@ RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
-
-# Compile Go for cross compilation
-ENV DOCKER_CROSSPLATFORMS \
-	linux/386 linux/arm \
-	darwin/amd64 \
-	freebsd/amd64 freebsd/386 freebsd/arm \
-	windows/amd64 windows/386 \
-	solaris/amd64
 
 # Dependency for golint
 ENV GO_TOOLS_COMMIT 823804e1ae08dbb14eb807afc7db9993bc9e3cc3
@@ -240,6 +221,9 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 COPY hack/dockerfile/binaries-commits /tmp/binaries-commits
 COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
 RUN /tmp/install-binaries.sh tomlv vndr runc containerd tini proxy
+
+# Used to detect running from within a container
+ENV FROM_DOCKERFILE=1
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ DOCKER_RUN_DOCKER := $(DOCKER_FLAGS) "$(DOCKER_IMAGE)"
 
 default: binary
 
-all: build ## validate all checks, build linux binaries, run all tests\ncross build non-linux binaries and generate archives
+all: build ## validate all checks, build linux binaries, run all tests\nbuild non-linux binaries and generate archives
 	$(DOCKER_RUN_DOCKER) bash -c 'hack/validate/default && hack/make.sh'
 
 binary: build ## build the linux binaries
@@ -89,12 +89,8 @@ build: bundles init-go-pkg-cache
 bundles:
 	mkdir bundles
 
-cross: build ## cross build the binaries for darwin, freebsd and\nwindows
-	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary binary cross
-
 deb: build  ## build the deb packages
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary build-deb
-
 
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -121,7 +117,7 @@ shell: build ## start a shell inside the build env
 	$(DOCKER_RUN_DOCKER) bash
 
 test: build ## run the unit, integration and docker-py tests
-	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary cross test-unit test-integration-cli test-docker-py
+	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary test-unit test-integration-cli test-docker-py
 
 test-docker-py: build ## run the docker-py tests
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary test-docker-py
@@ -136,11 +132,14 @@ dobi:
 test-unit: dobi ## run the unit tests
 	./dobi test-unit
 
-tgz: build ## build the archives (.zip on windows and .tgz\notherwise) containing the binaries
-	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary binary cross tgz
+tgz: build cross ## build the archives (.zip on windows and .tgz\notherwise) containing the binaries
+	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary binary tgz
 
 validate: dobi ## run full validation
 	./dobi validate
+
+cross: bundles dobi ## cross build the binaries for darwin, freebsd and\nwindows
+	./dobi cross
 
 win: build ## cross build the binary for windows
 	$(DOCKER_RUN_DOCKER) hack/make.sh win

--- a/Makefile
+++ b/Makefile
@@ -129,14 +129,18 @@ test-docker-py: build ## run the docker-py tests
 test-integration-cli: build ## run the integration tests
 	$(DOCKER_RUN_DOCKER) hack/make.sh build-integration-test-binary dynbinary test-integration-cli
 
-test-unit: build ## run the unit tests
-	$(DOCKER_RUN_DOCKER) hack/make.sh test-unit
+dobi:
+	curl -LsS -o dobi https://github.com/dnephin/dobi/releases/download/v0.8/dobi-linux
+	chmod +x dobi
+
+test-unit: dobi ## run the unit tests
+	./dobi test-unit
 
 tgz: build ## build the archives (.zip on windows and .tgz\notherwise) containing the binaries
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary binary cross tgz
 
-validate: build ## validate DCO, Seccomp profile generation, gofmt,\n./pkg/ isolation, golint, tests, tomls, go vet and vendor
-	$(DOCKER_RUN_DOCKER) hack/validate/all
+validate: dobi ## run full validation
+	./dobi validate
 
 win: build ## cross build the binary for windows
 	$(DOCKER_RUN_DOCKER) hack/make.sh win

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -24,6 +24,13 @@ image=validator:
     dockerfile: Dockerfile.validate
     context: dockerfiles
 
+image=cross-builder:
+    image: docker-cross
+    dockerfile: Dockerfile.cross
+    context: dockerfiles
+    args:
+      APT_MIRROR: '{env.APT_MIRROR:httpredir.debian.org}'
+
 
 job=validate-vendor:
     use: validator
@@ -58,6 +65,12 @@ job=shell:
     provide-docker: true
     command: bash
     description: "Start an interactive dev environment"
+
+job=cross:
+    use: cross-builder
+    mounts: [source]
+    command: "hack/make.sh cross"
+    description: "Build binaries for non-linux platforms"
 
 
 alias=test:

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -1,0 +1,71 @@
+#
+# Docker project tasks
+#
+# Config reference: http://dnephin.github.io/dobi/config.html
+#
+meta:
+    project: docker
+    default: all
+
+mount=source:
+    bind: .
+    path: /go/src/github.com/docker/docker
+
+
+image=builder:
+    image: docker-dev
+    dockerfile: Dockerfile.build
+    context: dockerfiles
+    args:
+      APT_MIRROR: '{env.APT_MIRROR:httpredir.debian.org}'
+
+image=validator:
+    image: docker-validator
+    dockerfile: Dockerfile.validate
+    context: dockerfiles
+
+
+job=validate-vendor:
+    use: validator
+    mounts: [source]
+    command: hack/validate/vendor
+    description: "Perform a vendor and validate that no files changed"
+
+job=validate-default:
+    use: validator
+    mounts: [source]
+    command: hack/validate/default
+    description: "Run default validation checks"
+
+job=test-unit:
+    use: builder
+    mounts: [source]
+    privileged: true
+    command: "hack/make.sh test-unit"
+    description: "Run the unit test suite"
+
+job=binary-client:
+    use: builder
+    mounts: [source]
+    command: "hack/make.sh binary-client"
+    description: "Build the linux client binary"
+    artifact: bundles/latest/binary-client/docker
+
+job=shell:
+    use: builder
+    mounts: [source]
+    interactive: true
+    provide-docker: true
+    command: bash
+    description: "Start an interactive dev environment"
+
+
+alias=test:
+    tasks: [test-unit]
+
+alias=validate:
+    tasks: [validate-default, validate-vendor]
+
+alias=all:
+    tasks: [validate, test]
+    description: "Run every project task"

--- a/dockerfiles/Dockerfile.build
+++ b/dockerfiles/Dockerfile.build
@@ -1,0 +1,58 @@
+#
+# Build environment for linux docker
+#
+FROM debian:jessie
+
+# add zfs ppa
+RUN apt-key adv \
+        --keyserver hkp://p80.pool.sks-keyservers.net:80 \
+        --recv-keys E871F18B51E0147C77796AC81196BA81F6B0FC61 \
+                    93763AC528C8C52568951BE0D5495F657635B973 || \
+    apt-key adv \
+        --keyserver hkp://pgp.mit.edu:80 \
+        --recv-keys E871F18B51E0147C77796AC81196BA81F6B0FC61 \
+                    93763AC528C8C52568951BE0D5495F657635B973
+RUN echo deb http://ppa.launchpad.net/zfs-native/stable/ubuntu trusty main > \
+        /etc/apt/sources.list.d/zfs.list && \
+    echo deb http://ppa.launchpad.net/ubuntu-lxc/lxd-stable/ubuntu trusty main > \
+        /etc/apt/sources.list.d/seccond.list
+
+# allow replacing httpredir mirror
+ARG APT_MIRROR=httpredir.debian.org
+RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
+
+# Packaged dependencies
+RUN apt-get update && apt-get install -y \
+    btrfs-tools \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    libapparmor-dev \
+    libcap-dev \
+    libdevmapper-dev \
+    libltdl-dev \
+    libseccomp-dev \
+    libsqlite3-dev \
+    libzfs-dev \
+    pkg-config \
+    tar \
+    --no-install-recommends
+
+# Install Go
+# IMPORTANT: If the version of Go is updated, the Windows to Linux CI machines
+#            will need updating, to avoid errors. Ping #docker-maintainers on IRC
+#            with a heads-up.
+ENV GO_VERSION 1.7.1
+RUN curl -fsSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" \
+    | tar -xzC /usr/local
+
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
+
+WORKDIR /go/src/github.com/docker/docker
+# Used to detect running from within a container
+ENV FROM_DOCKERFILE=1
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+# Used to inform hack/make.sh that this is running in a container
+ENV DOCKER_CROSSPLATFORMS=stub

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,0 +1,60 @@
+#
+# Build environment for cross-compiling docker
+#
+FROM debian:jessie
+
+# add zfs ppa
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys E871F18B51E0147C77796AC81196BA81F6B0FC61 \
+	|| apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys E871F18B51E0147C77796AC81196BA81F6B0FC61
+RUN echo deb http://ppa.launchpad.net/zfs-native/stable/ubuntu trusty main > /etc/apt/sources.list.d/zfs.list
+
+# allow replacing httpredir mirror
+ARG APT_MIRROR=httpredir.debian.org
+RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
+
+# Packaged dependencies
+RUN apt-get update && apt-get install -y \
+	automake \
+	binutils-mingw-w64 \
+	build-essential \
+	ca-certificates \
+	clang \
+	curl \
+	gcc-mingw-w64 \
+	git \
+	libapparmor-dev \
+	libcap-dev \
+	libltdl-dev \
+	libsqlite3-dev \
+	libsystemd-journal-dev \
+	libtool \
+	libzfs-dev \
+	tar \
+	--no-install-recommends
+
+# Configure the container for OSX cross compilation
+ENV OSX_SDK MacOSX10.11.sdk
+ENV OSX_CROSS_COMMIT a9317c18a3a457ca0a657f08cc4d0d43c6cf8953
+RUN set -x \
+	&& export OSXCROSS_PATH="/osxcross" \
+	&& git clone https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH \
+	&& ( cd $OSXCROSS_PATH && git checkout -q $OSX_CROSS_COMMIT) \
+	&& curl -sSL https://s3.dockerproject.org/darwin/v2/${OSX_SDK}.tar.xz -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" \
+	&& UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh
+ENV PATH /osxcross/target/bin:$PATH
+
+# Install Go
+# IMPORTANT: If the version of Go is updated, the Windows to Linux CI machines
+#            will need updating, to avoid errors. Ping #docker-maintainers on IRC
+#            with a heads-up.
+ENV GO_VERSION 1.7.3
+RUN curl -fsSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" \
+	| tar -xzC /usr/local
+
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
+
+WORKDIR /go/src/github.com/docker/docker
+# Used to detect running from within a container
+ENV FROM_DOCKERFILE=1
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux

--- a/dockerfiles/Dockerfile.validate
+++ b/dockerfiles/Dockerfile.validate
@@ -1,0 +1,15 @@
+
+FROM    golang:1.7.1-alpine
+
+RUN     apk add -U bash git mercurial
+
+RUN     go get github.com/golang/lint/golint && \
+        cp /go/bin/golint /usr/bin/ && \
+        rm -rf /go/src/* /go/pkg/* /go/bin/*
+
+RUN     go get github.com/lk4d4/vndr && \
+        cp /go/bin/vndr /usr/bin/ && \
+        rm -rf /go/src/* /go/pkg/* /go/bin/*
+
+
+WORKDIR /go/src/github.com/docker/docker

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -36,7 +36,7 @@ if [ "$(go env GOHOSTOS)" = 'windows' ]; then
 		unset inContainer
 	fi
 else
-	if [ "$PWD" != "/go/src/$DOCKER_PKG" ] || [ -z "$DOCKER_CROSSPLATFORMS" ]; then
+	if [ "$PWD" != "/go/src/$DOCKER_PKG" ] || [ -z "$FROM_DOCKERFILE" ]; then
 		unset inContainer
 	fi
 fi
@@ -64,7 +64,6 @@ DEFAULT_BUNDLES=(
 	test-integration-cli
 	test-docker-py
 
-	cross
 	tgz
 )
 

--- a/hack/make/.platforms
+++ b/hack/make/.platforms
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# List of platforms to cross compile
+export DOCKER_CROSSPLATFORMS="
+    linux/386 linux/arm
+	darwin/amd64
+	freebsd/amd64 freebsd/386 freebsd/arm
+	windows/amd64 windows/386"
+

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+. $MAKEDIR/.platforms
+
 # explicit list of os/arch combos that support being a daemon
 declare -A daemonSupporting
 daemonSupporting=(

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -7,6 +7,8 @@
 
 set -e
 
+source hack/make/.platforms
+
 if ! hash vndr; then
 	echo "Please install vndr with \"go get github.com/LK4D4/vndr\" and put it in your \$GOPATH"
 	exit 1


### PR DESCRIPTION
Replaces #27359

Changes:
* makefile targets will download the linux version of dobi to run the dobi task
* adds #26389
* removes the Jenkinsfile

### Independent images for different (groups of) build tasks

Instead of a single monolithic `Dockerfile` for every build task, we can split them into separate Dockerfiles for groups of related tasks. This comes with a few benefits:
- running many task is significantly faster. For example, running the `validate/all` task in a container, after a fresh checkout (or after a dependency in the image changes) only takes ~5-10s. Currently it can take easily 10+ minutes to build the monolithic image. Running tests or building the linux binary will also be faster, because we don't need to install all the dependencies required for other tasks (ex  #26389). This is not just a one-time improvement. Every time we make a dependency change to an image we invalidate everything after it. By splitting the images, a change to one doesn't force us to rebuild the image for all the other tasks. We end up with much better cache hit rates.
- maintaining dockerfiles for different platforms becomes easier. We don't need to install dependencies for every task. We only need to install dependencies for building the binary on that platform.

This PR adds two new images (from `Dockerfile.validate`, and `Dockerfile.build`),  #26389 has one for `cross`, and there is already a separate image for man page generation. In the near future we can have one for generating the swagger types (#27117). We might also want images for `build-rpm` and `build-dep`.
### dobi for running build tasks

[dobi](http://dnephin.github.io/dobi/) is a tool I've been working on for "build automation". It is designed based on my experienced writing Makefiles both here and at previous employer, as well as a lot of feedback from Compose users who are attempting to use Compose as a Makefile replacement (which it is not designed to be). dobi is aimed at being a make-like tool that exposes docker resources from a declarative config file. It would eventually be a replacement for the Makefile. 

As you can see from the initial `dobi.yaml` in this PR, you define each resource (mount, image, job) and you can execute them as you would a make target with `dobi <resource name>`. There are also "actions" for each task, so to remove the build image you could run `dobi builder:rm` (see the [task reference](http://dnephin.github.io/dobi/tasks.html)).

dobi comes with a long list of improvements over a Makefile:
- significantly better caching (http://dnephin.github.io/dobi/tasks.html#build-default)
- more intuitive syntax (I'm probably biased, but it does at least seem to be significantly less verbose than the Makefile version)

If you're interested in trying it out , you can run `dobi list` to get a list of all the resources that have descriptions.
