### PR TITLE
Stop retrying pull on UnkownBlob error

### DIFF
--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -6,6 +6,7 @@ import (
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/client"
@@ -139,6 +140,9 @@ func retryOnError(err error) error {
 	case *client.UnexpectedHTTPResponseError:
 		return xfer.DoNotRetry{Err: err}
 	case error:
+		if err == distribution.ErrBlobUnknown {
+			return xfer.DoNotRetry{Err: err}
+		}
 		if strings.Contains(err.Error(), strings.ToLower(syscall.ENOSPC.Error())) {
 			return xfer.DoNotRetry{Err: err}
 		}

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -189,9 +189,6 @@ func (ld *v2LayerDescriptor) Download(ctx context.Context, progressOutput progre
 	layerDownload, err := ld.open(ctx)
 	if err != nil {
 		logrus.Errorf("Error initiating layer download: %v", err)
-		if err == distribution.ErrBlobUnknown {
-			return nil, 0, xfer.DoNotRetry{Err: err}
-		}
 		return nil, 0, retryOnError(err)
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
As per discussion in #28903, stop retrying download when the copy to tmpFile during layer download fails with "unknown blob"

**- How I did it**

Wrap the returned error in `xfer.DoNotRetry`. Alternatively, it could be added to the list of errors to not retry in `retryOnError`, but since this was special cased elsewhere, I felt that it would be safest to just catch the creation of the error in this case.

**- How to verify it**

Currently manual verification by pulling microsoft/nanoserver on a Linux host. I don't know of a way to pull a layer that exists but does not fail to find it in the hub in order to add a regression test.

Signed-off-by: Darren Stahl <darst@microsoft.com>