### PR TITLE
refactor plugin install

### DIFF
--- a/api/server/router/plugin/backend.go
+++ b/api/server/router/plugin/backend.go
@@ -16,7 +16,8 @@ type Backend interface {
 	Inspect(name string) (enginetypes.Plugin, error)
 	Remove(name string, config *enginetypes.PluginRmConfig) error
 	Set(name string, args []string) error
-	Pull(name string, metaHeaders http.Header, authConfig *enginetypes.AuthConfig) (enginetypes.PluginPrivileges, error)
+	Privileges(name string, metaHeaders http.Header, authConfig *enginetypes.AuthConfig) (enginetypes.PluginPrivileges, error)
+	Pull(name string, metaHeaders http.Header, authConfig *enginetypes.AuthConfig, privileges enginetypes.PluginPrivileges) error
 	Push(name string, metaHeaders http.Header, authConfig *enginetypes.AuthConfig) error
 	CreateFromContext(ctx context.Context, tarCtx io.Reader, options *enginetypes.PluginCreateOptions) error
 }

--- a/api/server/router/plugin/plugin.go
+++ b/api/server/router/plugin/plugin.go
@@ -25,7 +25,8 @@ func (r *pluginRouter) Routes() []router.Route {
 func (r *pluginRouter) initRoutes() {
 	r.routes = []router.Route{
 		router.NewGetRoute("/plugins", r.listPlugins),
-		router.NewGetRoute("/plugins/{name:.*}", r.inspectPlugin),
+		router.NewGetRoute("/plugins/{name:.*}/json", r.inspectPlugin),
+		router.NewGetRoute("/plugins/privileges", r.getPrivileges),
 		router.NewDeleteRoute("/plugins/{name:.*}", r.removePlugin),
 		router.NewPostRoute("/plugins/{name:.*}/enable", r.enablePlugin), // PATCH?
 		router.NewPostRoute("/plugins/{name:.*}/disable", r.disablePlugin),

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6397,14 +6397,10 @@ paths:
             $ref: "#/definitions/ErrorResponse"
       tags: ["Plugin"]
 
-  /plugins/pull:
-    post:
-      summary: "Install a plugin"
-      operationId: "PluginPull"
-      description: |
-        Pulls and installs a plugin. After the plugin is installed, it can be enabled using the [`POST /plugins/{name}/enable` endpoint](#operation/PluginEnable).
-      produces:
-        - "application/json"
+  /plugins/privileges:
+    get:
+      summary: "Get plugin privileges"
+      operationId: "GetPluginPrivileges"
       responses:
         200:
           description: "no error"
@@ -6442,6 +6438,30 @@ paths:
       parameters:
         - name: "name"
           in: "query"
+          description: "The name of the plugin. The `:latest` tag is optional, and is the default if omitted."
+          required: true
+          type: "string"
+      tags:
+        - "Plugin"
+
+  /plugins/pull:
+    post:
+      summary: "Install a plugin"
+      operationId: "PluginPull"
+      description: |
+        Pulls and installs a plugin. After the plugin is installed, it can be enabled using the [`POST /plugins/{name}/enable` endpoint](#operation/PostPluginsEnable).
+      produces:
+        - "application/json"
+      responses:
+        204:
+          description: "no error"
+        500:
+          description: "server error"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "query"
           description: |
             The plugin to install.
 
@@ -6452,8 +6472,37 @@ paths:
           in: "header"
           description: "A base64-encoded auth configuration to use when pulling a plugin from a registry. [See the authentication section for details.](#section/Authentication)"
           type: "string"
+        - name: "body"
+          in: "body"
+          schema:
+            type: "array"
+            items:
+              description: "Describes a permission accepted by the user upon installing the plugin."
+              type: "object"
+              properties:
+                Name:
+                  type: "string"
+                Description:
+                  type: "string"
+                Value:
+                  type: "array"
+                  items:
+                    type: "string"
+            example:
+              - Name: "network"
+                Description: ""
+                Value:
+                  - "host"
+              - Name: "mount"
+                Description: ""
+                Value:
+                  - "/data"
+              - Name: "device"
+                Description: ""
+                Value:
+                  - "/dev/cpu_dma_latency"
       tags: ["Plugin"]
-  /plugins/{name}:
+  /plugins/{name}/json:
     get:
       summary: "Inspect a plugin"
       operationId: "PluginInspect"

--- a/client/plugin_inspect.go
+++ b/client/plugin_inspect.go
@@ -11,7 +11,7 @@ import (
 
 // PluginInspectWithRaw inspects an existing plugin
 func (cli *Client) PluginInspectWithRaw(ctx context.Context, name string) (*types.Plugin, []byte, error) {
-	resp, err := cli.get(ctx, "/plugins/"+name, nil, nil)
+	resp, err := cli.get(ctx, "/plugins/"+name+"/json", nil, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -5,12 +5,14 @@ package plugin
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 
 	"github.com/Sirupsen/logrus"
@@ -87,59 +89,139 @@ func (pm *Manager) Inspect(refOrID string) (tp types.Plugin, err error) {
 	return tp, fmt.Errorf("no plugin name or ID associated with %q", refOrID)
 }
 
-func (pm *Manager) pull(ref reference.Named, metaHeader http.Header, authConfig *types.AuthConfig, pluginID string) (types.PluginPrivileges, error) {
-	pd, err := distribution.Pull(ref, pm.registryService, metaHeader, authConfig)
-	if err != nil {
-		logrus.Debugf("error in distribution.Pull(): %v", err)
-		return nil, err
-	}
-
-	if err := distribution.WritePullData(pd, filepath.Join(pm.libRoot, pluginID), true); err != nil {
-		logrus.Debugf("error in distribution.WritePullData(): %v", err)
-		return nil, err
-	}
-
-	tag := distribution.GetTag(ref)
-	p := v2.NewPlugin(ref.Name(), pluginID, pm.runRoot, pm.libRoot, tag)
-	if err := p.InitPlugin(); err != nil {
-		return nil, err
-	}
-	pm.pluginStore.Add(p)
-
-	pm.pluginEventLogger(pluginID, ref.String(), "pull")
-	return p.ComputePrivileges(), nil
-}
-
-// Pull pulls a plugin and computes the privileges required to install it.
-func (pm *Manager) Pull(name string, metaHeader http.Header, authConfig *types.AuthConfig) (types.PluginPrivileges, error) {
+func (pm *Manager) pull(name string, metaHeader http.Header, authConfig *types.AuthConfig) (reference.Named, distribution.PullData, error) {
 	ref, err := distribution.GetRef(name)
 	if err != nil {
 		logrus.Debugf("error in distribution.GetRef: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 	name = ref.String()
 
 	if p, _ := pm.pluginStore.GetByName(name); p != nil {
 		logrus.Debug("plugin already exists")
-		return nil, fmt.Errorf("%s exists", name)
+		return nil, nil, fmt.Errorf("%s exists", name)
+	}
+
+	pd, err := distribution.Pull(ref, pm.registryService, metaHeader, authConfig)
+	if err != nil {
+		logrus.Debugf("error in distribution.Pull(): %v", err)
+		return nil, nil, err
+	}
+	return ref, pd, nil
+}
+
+func computePrivileges(pd distribution.PullData) (types.PluginPrivileges, error) {
+	config, err := pd.Config()
+	if err != nil {
+		return nil, err
+	}
+
+	var c types.PluginConfig
+	if err := json.Unmarshal(config, &c); err != nil {
+		return nil, err
+	}
+
+	var privileges types.PluginPrivileges
+	if c.Network.Type != "null" && c.Network.Type != "bridge" {
+		privileges = append(privileges, types.PluginPrivilege{
+			Name:        "network",
+			Description: "permissions to access a network",
+			Value:       []string{c.Network.Type},
+		})
+	}
+	for _, mount := range c.Mounts {
+		if mount.Source != nil {
+			privileges = append(privileges, types.PluginPrivilege{
+				Name:        "mount",
+				Description: "host path to mount",
+				Value:       []string{*mount.Source},
+			})
+		}
+	}
+	for _, device := range c.Linux.Devices {
+		if device.Path != nil {
+			privileges = append(privileges, types.PluginPrivilege{
+				Name:        "device",
+				Description: "host device to access",
+				Value:       []string{*device.Path},
+			})
+		}
+	}
+	if c.Linux.DeviceCreation {
+		privileges = append(privileges, types.PluginPrivilege{
+			Name:        "device-creation",
+			Description: "allow creating devices inside plugin",
+			Value:       []string{"true"},
+		})
+	}
+	if len(c.Linux.Capabilities) > 0 {
+		privileges = append(privileges, types.PluginPrivilege{
+			Name:        "capabilities",
+			Description: "list of additional capabilities required",
+			Value:       c.Linux.Capabilities,
+		})
+	}
+
+	return privileges, nil
+}
+
+// Privileges pulls a plugin config and computes the privileges required to install it.
+func (pm *Manager) Privileges(name string, metaHeader http.Header, authConfig *types.AuthConfig) (types.PluginPrivileges, error) {
+	_, pd, err := pm.pull(name, metaHeader, authConfig)
+	if err != nil {
+		return nil, err
+	}
+	return computePrivileges(pd)
+}
+
+// Pull pulls a plugin, check if the correct privileges are provided and install the plugin.
+func (pm *Manager) Pull(name string, metaHeader http.Header, authConfig *types.AuthConfig, privileges types.PluginPrivileges) (err error) {
+	ref, pd, err := pm.pull(name, metaHeader, authConfig)
+	if err != nil {
+		return err
+	}
+
+	requiredPrivileges, err := computePrivileges(pd)
+	if err != nil {
+		return err
+	}
+
+	if !reflect.DeepEqual(privileges, requiredPrivileges) {
+		return errors.New("incorrect privileges")
 	}
 
 	pluginID := stringid.GenerateNonCryptoID()
 	pluginDir := filepath.Join(pm.libRoot, pluginID)
 	if err := os.MkdirAll(pluginDir, 0755); err != nil {
 		logrus.Debugf("error in MkdirAll: %v", err)
-		return nil, err
+		return err
 	}
 
-	priv, err := pm.pull(ref, metaHeader, authConfig, pluginID)
-	if err != nil {
-		if err := os.RemoveAll(pluginDir); err != nil {
-			logrus.Warnf("unable to remove %q from failed plugin pull: %v", pluginDir, err)
+	defer func() {
+		if err != nil {
+			if delErr := os.RemoveAll(pluginDir); delErr != nil {
+				logrus.Warnf("unable to remove %q from failed plugin pull: %v", pluginDir, delErr)
+			}
 		}
-		return nil, err
+	}()
+
+	err = distribution.WritePullData(pd, filepath.Join(pm.libRoot, pluginID), true)
+	if err != nil {
+		logrus.Debugf("error in distribution.WritePullData(): %v", err)
+		return err
 	}
 
-	return priv, nil
+	tag := distribution.GetTag(ref)
+	p := v2.NewPlugin(ref.Name(), pluginID, pm.runRoot, pm.libRoot, tag)
+	err = p.InitPlugin()
+	if err != nil {
+		return err
+	}
+	pm.pluginStore.Add(p)
+
+	pm.pluginEventLogger(pluginID, ref.String(), "pull")
+
+	return nil
 }
 
 // List displays the list of plugins and associated metadata.

--- a/plugin/backend_unsupported.go
+++ b/plugin/backend_unsupported.go
@@ -28,9 +28,14 @@ func (pm *Manager) Inspect(name string) (tp types.Plugin, err error) {
 	return tp, errNotSupported
 }
 
-// Pull pulls a plugin and computes the privileges required to install it.
-func (pm *Manager) Pull(name string, metaHeader http.Header, authConfig *types.AuthConfig) (types.PluginPrivileges, error) {
+// Privileges pulls a plugin config and computes the privileges required to install it.
+func (pm *Manager) Privileges(name string, metaHeaders http.Header, authConfig *types.AuthConfig) (types.PluginPrivileges, error) {
 	return nil, errNotSupported
+}
+
+// Pull pulls a plugin, check if the correct privileges are provided and install the plugin.
+func (pm *Manager) Pull(name string, metaHeader http.Header, authConfig *types.AuthConfig, privileges types.PluginPrivileges) error {
+	return errNotSupported
 }
 
 // List displays the list of plugins and associated metadata.

--- a/plugin/distribution/pull.go
+++ b/plugin/distribution/pull.go
@@ -178,7 +178,6 @@ func WritePullData(pd PullData, dest string, extract bool) error {
 		return err
 	}
 	logrus.Debugf("%#v", p)
-
 	if err := os.MkdirAll(dest, 0700); err != nil {
 		return err
 	}

--- a/plugin/v2/plugin.go
+++ b/plugin/v2/plugin.go
@@ -216,53 +216,6 @@ next:
 	return p.writeSettings()
 }
 
-// ComputePrivileges takes the config file and computes the list of access necessary
-// for the plugin on the host.
-func (p *Plugin) ComputePrivileges() types.PluginPrivileges {
-	c := p.PluginObj.Config
-	var privileges types.PluginPrivileges
-	if c.Network.Type != "null" && c.Network.Type != "bridge" {
-		privileges = append(privileges, types.PluginPrivilege{
-			Name:        "network",
-			Description: "permissions to access a network",
-			Value:       []string{c.Network.Type},
-		})
-	}
-	for _, mount := range c.Mounts {
-		if mount.Source != nil {
-			privileges = append(privileges, types.PluginPrivilege{
-				Name:        "mount",
-				Description: "host path to mount",
-				Value:       []string{*mount.Source},
-			})
-		}
-	}
-	for _, device := range c.Linux.Devices {
-		if device.Path != nil {
-			privileges = append(privileges, types.PluginPrivilege{
-				Name:        "device",
-				Description: "host device to access",
-				Value:       []string{*device.Path},
-			})
-		}
-	}
-	if c.Linux.DeviceCreation {
-		privileges = append(privileges, types.PluginPrivilege{
-			Name:        "device-creation",
-			Description: "allow creating devices inside plugin",
-			Value:       []string{"true"},
-		})
-	}
-	if len(c.Linux.Capabilities) > 0 {
-		privileges = append(privileges, types.PluginPrivilege{
-			Name:        "capabilities",
-			Description: "list of additional capabilities required",
-			Value:       c.Linux.Capabilities,
-		})
-	}
-	return privileges
-}
-
 // IsEnabled returns the active state of the plugin.
 func (p *Plugin) IsEnabled() bool {
 	p.RLock()


### PR DESCRIPTION
# before

calling `/pull` was pulling, installing a plugin, then a lists a privileges was returned.
upon a user accepting the privileges, it would enable the plugin.

### problems:

* the plugin was installed before the user accepted the privileges.
* `<ctrl-c>` the "do you accept privileges" question would leave the plugin installed on the daemon
* the whole privileges concept was entirely client side

# now

calling `/privileges` will return the list of privileges required by the plugin (noting is installed)
update a user accepting the privileges, `/pull` is called with the list of privileges accepted
the daemon now compares the required privileges and the privileges sent by the user before installing

it forces a round-trip so even through the API there is an acceptance mechanism 



ping @tiborvass @anusha-ragunathan 