### PR TITLE
Move plugin shutdown after layerstore shtudown

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -792,18 +792,18 @@ func (daemon *Daemon) Shutdown() error {
 		})
 	}
 
-	// Shutdown plugins after containers. Don't change the order.
+	if daemon.layerStore != nil {
+		if err := daemon.layerStore.Cleanup(); err != nil {
+			logrus.Errorf("Error during layer Store.Cleanup(): %v", err)
+		}
+	}
+
+	// Shutdown plugins after containers and layerstore. Don't change the order.
 	daemon.pluginShutdown()
 
 	// trigger libnetwork Stop only if it's initialized
 	if daemon.netController != nil {
 		daemon.netController.Stop()
-	}
-
-	if daemon.layerStore != nil {
-		if err := daemon.layerStore.Cleanup(); err != nil {
-			logrus.Errorf("Error during layer Store.Cleanup(): %v", err)
-		}
 	}
 
 	if err := daemon.cleanupMounts(); err != nil {


### PR DESCRIPTION
This ensures that graphdriver plugins can properly cleanup on daemon
exit.
Also prevents errors during shutdown when it tries to send the plugin a
`Cleanup()` request but ultimately times out since it's already been
shutdown.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>