### PR TITLE
distribution: Fix panic on push

### DIFF
--- a/distribution/push_v2_test.go
+++ b/distribution/push_v2_test.go
@@ -180,7 +180,7 @@ func TestLayerAlreadyExists(t *testing.T) {
 			maxExistenceChecks: 1,
 			metadata:           []metadata.V2Metadata{{Digest: digest.Digest("apple"), SourceRepository: "docker.io/library/busybox"}},
 			remoteErrors:       map[digest.Digest]error{digest.Digest("apple"): distribution.ErrAccessDenied},
-			expectedError:      distribution.ErrAccessDenied,
+			expectedError:      nil,
 			expectedRequests:   []string{"apple"},
 		},
 		{
@@ -310,7 +310,7 @@ func TestLayerAlreadyExists(t *testing.T) {
 			expectedRemovals:   []metadata.V2Metadata{taggedMetadata("key3", "apple", "docker.io/library/busybox")},
 		},
 		{
-			name:       "stop on first error",
+			name:       "don't stop on first error",
 			targetRepo: "user/app",
 			hmacKey:    "key",
 			metadata: []metadata.V2Metadata{
@@ -321,9 +321,12 @@ func TestLayerAlreadyExists(t *testing.T) {
 			maxExistenceChecks: 3,
 			remoteErrors:       map[digest.Digest]error{"orange": distribution.ErrAccessDenied},
 			remoteBlobs:        map[digest.Digest]distribution.Descriptor{digest.Digest("apple"): {}},
-			expectedError:      distribution.ErrAccessDenied,
-			expectedRequests:   []string{"plum", "orange"},
-			expectedRemovals:   []metadata.V2Metadata{taggedMetadata("key", "plum", "docker.io/user/app")},
+			expectedError:      nil,
+			expectedRequests:   []string{"plum", "orange", "banana"},
+			expectedRemovals: []metadata.V2Metadata{
+				taggedMetadata("key", "plum", "docker.io/user/app"),
+				taggedMetadata("key", "banana", "docker.io/user/app"),
+			},
 		},
 		{
 			name:       "remove outdated metadata",


### PR DESCRIPTION
When building a manifest during a push operation, all layers must have
an associated descriptor. If a layer is missing a descriptor, that leads
to a panic.

A break inside a switch in layerAlreadyExists meant to break from the
loop surrounding the switch, but instead breaks from the switch. This
causes the loop to continue, and can overwrite the descriptor with an
empty one, leading to the panic.

Also, fix layerAlreadyExists not to abort the push when a speculative
stat on a candidate layer digest fails with an error. This could happen
in situations like a potential cross-repository mount where the user
does not have permission to access the source repository.

I am going to open a separate PR in the distribution repository to
avoid the panic in the situation where a descriptor is missing.

Fixes #28596

cc @dmcgowan @miminar