### PR TITLE
Support plugin type in `docker inspect`

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -255,3 +255,24 @@ func IsErrSecretNotFound(err error) bool {
 	_, ok := err.(secretNotFoundError)
 	return ok
 }
+
+// pluginNotFoundError implements an error returned when a plugin is not in the docker host.
+type pluginNotFoundError struct {
+	name string
+}
+
+// NotFound indicates that this error type is of NotFound
+func (e pluginNotFoundError) NotFound() bool {
+	return true
+}
+
+// Error returns a string representation of a pluginNotFoundError
+func (e pluginNotFoundError) Error() string {
+	return fmt.Sprintf("Error: No such plugin: %s", e.name)
+}
+
+// IsErrPluginNotFound returns true if the error is caused
+// when a plugin is not found in the docker host.
+func IsErrPluginNotFound(err error) bool {
+	return IsErrNotFound(err)
+}

--- a/client/plugin_inspect.go
+++ b/client/plugin_inspect.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
@@ -13,6 +14,9 @@ import (
 func (cli *Client) PluginInspectWithRaw(ctx context.Context, name string) (*types.Plugin, []byte, error) {
 	resp, err := cli.get(ctx, "/plugins/"+name, nil, nil)
 	if err != nil {
+		if resp.statusCode == http.StatusNotFound {
+			return nil, nil, pluginNotFoundError{name}
+		}
 		return nil, nil, err
 	}
 

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -417,3 +417,33 @@ func (s *DockerSuite) TestInspectAmpersand(c *check.C) {
 	out, _ = dockerCmd(c, "inspect", name)
 	c.Assert(out, checker.Contains, `soanni&rtr`)
 }
+
+func (s *DockerSuite) TestInspectPlugin(c *check.C) {
+	testRequires(c, DaemonIsLinux, Network)
+	_, _, err := dockerCmdWithError("plugin", "install", "--grant-all-permissions", pNameWithTag)
+	c.Assert(err, checker.IsNil)
+
+	out, _, err := dockerCmdWithError("inspect", "--type", "plugin", "--format", "{{.Name}}", pNameWithTag)
+	c.Assert(err, checker.IsNil)
+	c.Assert(strings.TrimSpace(out), checker.Equals, pName)
+
+	out, _, err = dockerCmdWithError("inspect", "--format", "{{.Name}}", pNameWithTag)
+	c.Assert(err, checker.IsNil)
+	c.Assert(strings.TrimSpace(out), checker.Equals, pName)
+
+	// Even without tag the inspect still work
+	out, _, err = dockerCmdWithError("inspect", "--type", "plugin", "--format", "{{.Name}}", pName)
+	c.Assert(err, checker.IsNil)
+	c.Assert(strings.TrimSpace(out), checker.Equals, pName)
+
+	out, _, err = dockerCmdWithError("inspect", "--format", "{{.Name}}", pName)
+	c.Assert(err, checker.IsNil)
+	c.Assert(strings.TrimSpace(out), checker.Equals, pName)
+
+	_, _, err = dockerCmdWithError("plugin", "disable", pNameWithTag)
+	c.Assert(err, checker.IsNil)
+
+	out, _, err = dockerCmdWithError("plugin", "remove", pNameWithTag)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, pNameWithTag)
+}

--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -62,10 +62,10 @@ func (s *DockerSuite) TestRenameCheckNames(c *check.C) {
 	name := inspectField(c, newName, "Name")
 	c.Assert(name, checker.Equals, "/"+newName, check.Commentf("Failed to rename container %s", name))
 
-	result := dockerCmdWithResult("inspect", "-f={{.Name}}", "first_name")
+	result := dockerCmdWithResult("inspect", "-f={{.Name}}", "--type=container", "first_name")
 	c.Assert(result, icmd.Matches, icmd.Expected{
 		ExitCode: 1,
-		Err:      "No such object: first_name",
+		Err:      "No such container: first_name",
 	})
 }
 

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -84,7 +84,7 @@ func (pm *Manager) Inspect(refOrID string) (tp types.Plugin, err error) {
 		return tp, err
 	}
 
-	return tp, fmt.Errorf("no plugin name or ID associated with %q", refOrID)
+	return tp, fmt.Errorf("no such plugin name or ID associated with %q", refOrID)
 }
 
 func (pm *Manager) pull(ref reference.Named, metaHeader http.Header, authConfig *types.AuthConfig, pluginID string) (types.PluginPrivileges, error) {


### PR DESCRIPTION
**- What I did**

This fix tries to address the proposal raised in #28946 to support plugins in `docker inspect`.

The command `docker inspect` already supports "container", "image", "node", "network", "service", "volume", "task". However, `--type plugin` is not supported yet at the moment.

**- How I did it**

This fix address this issue by adding the support of `--type plugin` for `docker inspect`.

**- How to verify it**

An additional integration test has been added to cover the changes.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![3840x2160-animals_kitten_cute_kitten_cat-14319](https://cloud.githubusercontent.com/assets/6932348/20736405/138cc730-b65b-11e6-81a5-25c11a5f0ee6.jpg)


This fix fixes #28946.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>