### PR TITLE
Limit TestEventsLimit to 4 concurrent containers on Windows

### DIFF
--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -80,10 +80,15 @@ func (s *DockerSuite) TestEventsUntag(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsLimit(c *check.C) {
-	// Limit to 8 goroutines creating containers in order to prevent timeouts
-	// creating so many containers simultaneously on Windows
-	sem := make(chan bool, 8)
+	// Windows: Limit to 4 goroutines creating containers in order to prevent
+	// timeouts creating so many containers simultaneously. This is a due to
+	// a bug in the Windows platform. It will be fixed in a Windows Update.
 	numContainers := 17
+	numConcurrentContainers := numContainers
+	if testEnv.DaemonPlatform() == "windows" {
+		numConcurrentContainers = 4
+	}
+	sem := make(chan bool, numConcurrentContainers)
 	errChan := make(chan error, numContainers)
 
 	args := []string{"run", "--rm", "busybox", "true"}


### PR DESCRIPTION
This hopefully fixes the latest TestEventsLimit failures on windowsRS1.

fixes #28873

Signed-off-by: Darren Stahl <darst@microsoft.com>