### PR TITLE
Fix incorrect comment

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -129,7 +129,7 @@ type Backend interface {
 	ContainerWait(containerID string, timeout time.Duration) (int, error)
 	// ContainerUpdateCmdOnBuild updates container.Path and container.Args
 	ContainerUpdateCmdOnBuild(containerID string, cmd []string) error
-	// ContainerCreateWorkdir creates the workdir (currently only used on Windows)
+	// ContainerCreateWorkdir creates the workdir
 	ContainerCreateWorkdir(containerID string) error
 
 	// ContainerCopy copies/extracts a source FileInfo to a destination path inside a container


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Missed this in https://github.com/docker/docker/pull/28514 - this is used by both Linux and Windows now. Just removing that bit of the comment to avoid confusion when folks are looking at this code in the future.

@duglin 