### PR TITLE
Use `--file` in `docker stack deploy` for both Compose and Bundle files

### DIFF
--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -33,8 +34,7 @@ const (
 )
 
 type deployOptions struct {
-	bundlefile       string
-	composefile      string
+	file             string
 	namespace        string
 	sendRegistryAuth bool
 }
@@ -54,8 +54,7 @@ func newDeployCommand(dockerCli *command.DockerCli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	addBundlefileFlag(&opts.bundlefile, flags)
-	addComposefileFlag(&opts.composefile, flags)
+	addFileFlag(&opts.file, flags)
 	addRegistryAuthFlag(&opts.sendRegistryAuth, flags)
 	return cmd
 }
@@ -64,14 +63,10 @@ func runDeploy(dockerCli *command.DockerCli, opts deployOptions) error {
 	ctx := context.Background()
 
 	switch {
-	case opts.bundlefile == "" && opts.composefile == "":
-		return fmt.Errorf("Please specify either a bundle file (with --bundle-file) or a Compose file (with --compose-file).")
-	case opts.bundlefile != "" && opts.composefile != "":
-		return fmt.Errorf("You cannot specify both a bundle file and a Compose file.")
-	case opts.bundlefile != "":
-		return deployBundle(ctx, dockerCli, opts)
+	case opts.file == "":
+		return fmt.Errorf("Please specify either a Bundle file or a Compose file with --file.")
 	default:
-		return deployCompose(ctx, dockerCli, opts)
+		return deployFile(ctx, dockerCli, opts)
 	}
 }
 
@@ -88,6 +83,23 @@ func checkDaemonIsSwarmManager(ctx context.Context, dockerCli *command.DockerCli
 		return errors.New("This node is not a swarm manager. Use \"docker swarm init\" or \"docker swarm join\" to connect this node to swarm and try again.")
 	}
 	return nil
+}
+
+func deployFile(ctx context.Context, dockerCli *command.DockerCli, opts deployOptions) error {
+	type bundlefile struct {
+		body json.RawMessage
+	}
+
+	bytes, err := ioutil.ReadFile(opts.file)
+	if err != nil {
+		return err
+	}
+	var v bundlefile
+	if err := json.Unmarshal(bytes, &v); err != nil {
+		return deployCompose(ctx, dockerCli, opts)
+	}
+
+	return deployBundle(ctx, dockerCli, opts)
 }
 
 func deployCompose(ctx context.Context, dockerCli *command.DockerCli, opts deployOptions) error {
@@ -156,7 +168,7 @@ func getConfigDetails(opts deployOptions) (composetypes.ConfigDetails, error) {
 		return details, err
 	}
 
-	configFile, err := getConfigFile(opts.composefile)
+	configFile, err := getConfigFile(opts.file)
 	if err != nil {
 		return details, err
 	}

--- a/cli/command/stack/deploy_bundlefile.go
+++ b/cli/command/stack/deploy_bundlefile.go
@@ -9,7 +9,7 @@ import (
 )
 
 func deployBundle(ctx context.Context, dockerCli *command.DockerCli, opts deployOptions) error {
-	bundle, err := loadBundlefile(dockerCli.Err(), opts.namespace, opts.bundlefile)
+	bundle, err := loadBundlefile(dockerCli.Err(), opts.namespace, opts.file)
 	if err != nil {
 		return err
 	}

--- a/cli/command/stack/opts.go
+++ b/cli/command/stack/opts.go
@@ -9,13 +9,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func addComposefileFlag(opt *string, flags *pflag.FlagSet) {
-	flags.StringVarP(opt, "compose-file", "c", "", "Path to a Compose file")
-}
-
-func addBundlefileFlag(opt *string, flags *pflag.FlagSet) {
-	flags.StringVar(opt, "bundle-file", "", "Path to a Distributed Application Bundle file")
-	flags.SetAnnotation("bundle-file", "experimental", nil)
+func addFileFlag(opt *string, flags *pflag.FlagSet) {
+	flags.StringVar(opt, "file", "docker-compose.yml", "Path to a Compose or a Distributed Application Bundle file")
 }
 
 func addRegistryAuthFlag(opt *bool, flags *pflag.FlagSet) {

--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -25,10 +25,9 @@ Aliases:
   deploy, up
 
 Options:
-      --bundle-file string    Path to a Distributed Application Bundle file
-      --compose-file string   Path to a Compose file
-      --help                  Print usage
-      --with-registry-auth    Send registry authentication details to Swarm agents
+      --file string          Path to a Compose or a Distributed Application Bundle file (default "docker-compose.yml")
+      --help                 Print usage
+      --with-registry-auth   Send registry authentication details to Swarm agents
 ```
 
 Create and update a stack from a `compose` or a `dab` file on the swarm. This command
@@ -39,7 +38,7 @@ has to be run targeting a manager node.
 The `deploy` command supports compose file version `3.0` and above.
 
 ```bash
-$ docker stack deploy --compose-file docker-compose.yml vossibility
+$ docker stack deploy --file docker-compose.yml vossibility
 Ignoring unsupported options: links
 
 Creating network vossibility_vossibility
@@ -68,7 +67,7 @@ axqh55ipl40h  vossibility_vossibility-collector  replicated  1/1       icecrime/
 ## DAB file
 
 ```bash
-$ docker stack deploy --bundle-file vossibility-stack.dab vossibility
+$ docker stack deploy --file vossibility-stack.dab vossibility
 Loading bundle from vossibility-stack.dab
 Creating service vossibility_elasticsearch
 Creating service vossibility_kibana

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -24,10 +24,9 @@ Aliases:
   deploy, up
 
 Options:
-      --bundle-file string    Path to a Distributed Application Bundle file
-  -c, --compose-file string   Path to a Compose file
-      --help                  Print usage
-      --with-registry-auth    Send registry authentication details to Swarm agents
+      --file string          Path to a Compose or a Distributed Application Bundle file (default "docker-compose.yml")
+      --help                 Print usage
+      --with-registry-auth   Send registry authentication details to Swarm agents
 ```
 
 Create and update a stack from a `compose` or a `dab` file on the swarm. This command
@@ -38,7 +37,7 @@ has to be run targeting a manager node.
 The `deploy` command supports compose file version `3.0` and above."
 
 ```bash
-$ docker stack deploy --compose-file docker-compose.yml vossibility
+$ docker stack deploy --file docker-compose.yml vossibility
 Ignoring unsupported options: links
 
 Creating network vossibility_vossibility
@@ -67,7 +66,7 @@ axqh55ipl40h  vossibility_vossibility-collector  replicated  1/1       icecrime/
 ## DAB file
 
 ```bash
-$ docker stack deploy --bundle-file vossibility-stack.dab vossibility
+$ docker stack deploy --file vossibility-stack.dab vossibility
 Loading bundle from vossibility-stack.dab
 Creating service vossibility_elasticsearch
 Creating service vossibility_kibana

--- a/integration-cli/docker_cli_stack_test.go
+++ b/integration-cli/docker_cli_stack_test.go
@@ -48,7 +48,7 @@ func (s *DockerSwarmSuite) TestStackDeployComposeFile(c *check.C) {
 	testStackName := "testdeploy"
 	stackArgs := []string{
 		"stack", "deploy",
-		"--compose-file", "fixtures/deploy/default.yaml",
+		"--file", "fixtures/deploy/default.yaml",
 		testStackName,
 	}
 	out, err := d.Cmd(stackArgs...)
@@ -95,7 +95,7 @@ func (s *DockerSwarmSuite) TestStackDeployWithDAB(c *check.C) {
 	// deploy
 	stackArgs := []string{
 		"stack", "deploy",
-		"--bundle-file", testDABFileName,
+		"--file", testDABFileName,
 		testStackName,
 	}
 	out, err := d.Cmd(stackArgs...)


### PR DESCRIPTION
**- What I did**

This fix tries to address the proposal raised in #28960. Previously `docker stack deploy` requires either `--compose-file` or `--bundle-file`, which are mutually exclusive. However, as bundle files are JSON and compose files are YAML, it is fairly easy to detect the file type.

**- How I did it**

This fix consolidate `--compose-file` and `--bundle-file` into one `--file`. The `json.RawMessage` is used to check if a file is a JSON, and pass the file to either `deployBundle()` or `deployCompose()` accordingly.

Related docs have been updated.

**- How to verify it**

Related integration tests have been updated and all tests should pass.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![cute-kittens-wearing-christmas-clothes](https://cloud.githubusercontent.com/assets/6932348/20768275/26e793ea-b6f2-11e6-93af-00406a118973.jpg)


This fix fixes #28960.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>