### PR TITLE
Show usage when `docker swarm update` has no flags

### DIFF
--- a/cli/command/swarm/update.go
+++ b/cli/command/swarm/update.go
@@ -23,6 +23,12 @@ func newUpdateCommand(dockerCli *command.DockerCli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpdate(dockerCli, cmd.Flags(), opts)
 		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().NFlag() == 0 {
+				return pflag.ErrHelp
+			}
+			return nil
+		},
 	}
 
 	cmd.Flags().BoolVar(&opts.autolock, flagAutolock, false, "Change manager autolocking setting (true|false)")

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1358,3 +1358,21 @@ func (s *DockerSwarmSuite) TestSwarmNetworkIPAMOptions(c *check.C) {
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 	c.Assert(strings.TrimSpace(out), checker.Equals, "map[foo:bar]")
 }
+
+// TODO: migrate to a unit test
+// This test could be migrated to unit test and save costly integration test,
+// once PR #29143 is merged.
+func (s *DockerSwarmSuite) TestSwarmUpdateWithoutArgs(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	expectedOutput := `
+Usage:	docker swarm update [OPTIONS]
+
+Update the swarm
+
+Options:`
+
+	out, err := d.Cmd("swarm", "update")
+	c.Assert(err, checker.IsNil, check.Commentf("out: %v", out))
+	c.Assert(out, checker.Contains, expectedOutput, check.Commentf(out))
+}


### PR DESCRIPTION
**- What I did**

This fix tries to address the issue raised in #24352. Previously, when `docker swarm update` has no flags, the output is
```
Swarm updated.
```
even though nothing was updated.

This could be misleading for users.

**- How I did it**

This fix tries to address the issue by adding a `PreRunE` function in the command so that in case no flag is provided (`cmd.Flags().NFlag() == 0`), the usage will be outputed instead.

**- How to verify it**

An integration has been added to cover the changes.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![christmas-kitten-red-blue-751769-1920x1080](https://cloud.githubusercontent.com/assets/6932348/20773103/0de7a75a-b705-11e6-880e-5f037559488d.jpg)


This fix fixes #24352.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>