### PR TITLE
Block pulling Windows images on non-Windows daemons

### DIFF
--- a/distribution/config.go
+++ b/distribution/config.go
@@ -142,8 +142,11 @@ func (s *imageConfigStore) RootFSFromConfig(c []byte) (*image.RootFS, error) {
 		return nil, err
 	}
 
-	// fail immediately on windows
+	// fail immediately on Windows when downloading a non-Windows image
+	// and vice versa
 	if runtime.GOOS == "windows" && unmarshalledConfig.OS == "linux" {
+		return nil, fmt.Errorf("image operating system %q cannot be used on this platform", unmarshalledConfig.OS)
+	} else if runtime.GOOS != "windows" && unmarshalledConfig.OS == "windows" {
 		return nil, fmt.Errorf("image operating system %q cannot be used on this platform", unmarshalledConfig.OS)
 	}
 

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -272,3 +272,10 @@ func (s *DockerSuite) TestPullLinuxImageFailsOnWindows(c *check.C) {
 	_, _, err := dockerCmdWithError("pull", "ubuntu")
 	c.Assert(err.Error(), checker.Contains, "cannot be used on this platform")
 }
+
+// Regression test for https://github.com/docker/docker/issues/28892
+func (s *DockerSuite) TestPullWindowsImageFailsOnLinux(c *check.C) {
+	testRequires(c, DaemonIsLinux, Network)
+	_, _, err := dockerCmdWithError("pull", "microsoft/nanoserver")
+	c.Assert(err.Error(), checker.Contains, "cannot be used on this platform")
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

This is an alternative solution to https://github.com/docker/docker/pull/28903

**- What I did**

fixes #28892

Block pulling Windows images on Linux daemons.

**- How I did it**

If the listed OS of an image's config is Windows, but the current daemon platform is not Windows, fail to download the image.

**- How to verify it**

Pull `microsoft/nanoserver` on a Linux daemon. See test that checks this.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Block pulling of Windows images on a non-windows daemon.

Signed-off-by: Darren Stahl <darst@microsoft.com>

/cc @jhowardmsft @jstarks