### PR TITLE
Allow continuation after comments

### DIFF
--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -176,17 +176,16 @@ func Parse(rwc io.Reader, d *Directive) (*Node, error) {
 				newline := scanner.Text()
 				currentLine++
 
-				// If escape followed by a comment line then stop
-				// Note here that comment line starts with `#` at
-				// the first pos of the line
-				if stripComments(newline) == "" {
-					break
-				}
-
 				// If escape followed by an empty line then stop
 				if strings.TrimSpace(newline) == "" {
 					break
 				}
+
+				// If escape followed by a comment line then we continue.
+				if strings.HasPrefix(strings.TrimSpace(newline), "#") {
+					continue
+				}
+
 				line, child, err = ParseLine(line+newline, d, false)
 				if err != nil {
 					return nil, err

--- a/builder/dockerfile/parser/testfiles/continueIndent/Dockerfile
+++ b/builder/dockerfile/parser/testfiles/continueIndent/Dockerfile
@@ -27,5 +27,6 @@ bye\
 frog
 
 RUN echo hello \
-# this is a comment that breaks escape continuation
-RUN echo this is some more useful stuff
+# this is a comment
+  # this is a comment not starting from pos 1
+this is some more useful stuff

--- a/builder/dockerfile/parser/testfiles/continueIndent/result
+++ b/builder/dockerfile/parser/testfiles/continueIndent/result
@@ -6,5 +6,4 @@
 (run "echo hi   world  goodnight")
 (run "echo goodbyefrog")
 (run "echo goodbyefrog")
-(run "echo hello")
-(run "echo this is some more useful stuff")
+(run "echo hello this is some more useful stuff")


### PR DESCRIPTION
This fix is to address #29005 where continuation after comments are not allowed after #24725.

This fix made the change so that #29005 could be addressed.

An integration test has been added. Other related tests have been udpated to conform to the behavior changes.

Please feel free for any suggestions.

This fix fixes #29005.

/cc @tianon @duglin @thaJeztah 