### PR TITLE
Fix the usage for secret create

### DIFF
--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -25,9 +25,9 @@ func newSecretCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "create [OPTIONS] SECRET [SECRET...]",
+		Use:   "create [OPTIONS] SECRET",
 		Short: "Create a secret using stdin as content",
-		Args:  cli.RequiresMinArgs(1),
+		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			createOpts.name = args[0]
 			return runSecretCreate(dockerCli, createOpts)


### PR DESCRIPTION
**- What I did**
Fix the usage for secret create and keep the consistency between code and document 

document is
Usage:  docker secret create [OPTIONS] SECRET

code is 
Use:   "create [OPTIONS] SECRET [SECRET...]"

**- How I did it**

**- How to verify it**

**- Description for the changelog**
Remove "[SECRET...]" from the Use for secret create in code.

Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>