### PR TITLE
Give a order to AddCommands, for better read and maintenance.

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -23,23 +23,55 @@ import (
 // AddCommands adds all the commands from cli/command to the root command
 func AddCommands(cmd *cobra.Command, dockerCli *command.DockerCli) {
 	cmd.AddCommand(
-		node.NewNodeCommand(dockerCli),
-		service.NewServiceCommand(dockerCli),
-		swarm.NewSwarmCommand(dockerCli),
-		secret.NewSecretCommand(dockerCli),
+		// checkpoint
+		checkpoint.NewCheckpointCommand(dockerCli),
+
+		// container
 		container.NewContainerCommand(dockerCli),
-		image.NewImageCommand(dockerCli),
-		system.NewSystemCommand(dockerCli),
 		container.NewRunCommand(dockerCli),
+
+		// image
+		image.NewImageCommand(dockerCli),
 		image.NewBuildCommand(dockerCli),
+
+		// node
+		node.NewNodeCommand(dockerCli),
+
+		// network
 		network.NewNetworkCommand(dockerCli),
-		hide(system.NewEventsCommand(dockerCli)),
+
+		// plugin
+		plugin.NewPluginCommand(dockerCli),
+
+		// registry
 		registry.NewLoginCommand(dockerCli),
 		registry.NewLogoutCommand(dockerCli),
 		registry.NewSearchCommand(dockerCli),
+
+		// secret
+		secret.NewSecretCommand(dockerCli),
+
+		// service
+		service.NewServiceCommand(dockerCli),
+
+		// system
+		system.NewSystemCommand(dockerCli),
 		system.NewVersionCommand(dockerCli),
+
+		// stack
+		stack.NewStackCommand(dockerCli),
+		stack.NewTopLevelDeployCommand(dockerCli),
+
+		// swarm
+		swarm.NewSwarmCommand(dockerCli),
+
+		// volume
 		volume.NewVolumeCommand(dockerCli),
+
+		// legacy commands may be hidden
+		hide(system.NewEventsCommand(dockerCli)),
 		hide(system.NewInfoCommand(dockerCli)),
+		hide(system.NewInspectCommand(dockerCli)),
 		hide(container.NewAttachCommand(dockerCli)),
 		hide(container.NewCommitCommand(dockerCli)),
 		hide(container.NewCopyCommand(dockerCli)),
@@ -71,16 +103,14 @@ func AddCommands(cmd *cobra.Command, dockerCli *command.DockerCli) {
 		hide(image.NewRemoveCommand(dockerCli)),
 		hide(image.NewSaveCommand(dockerCli)),
 		hide(image.NewTagCommand(dockerCli)),
-		hide(system.NewInspectCommand(dockerCli)),
-		stack.NewStackCommand(dockerCli),
-		stack.NewTopLevelDeployCommand(dockerCli),
-		checkpoint.NewCheckpointCommand(dockerCli),
-		plugin.NewPluginCommand(dockerCli),
 	)
 
 }
 
 func hide(cmd *cobra.Command) *cobra.Command {
+	// If the environment variable with name "DOCKER_HIDE_LEGACY_COMMANDS" is not empty,
+	// these legacy commands (such as `docker ps`, `docker exec`, etc)
+	// will not be shown in output console.
 	if os.Getenv("DOCKER_HIDE_LEGACY_COMMANDS") == "" {
 		return cmd
 	}


### PR DESCRIPTION
**- What I did**
Give a order to AddCommands, put related subcommands together, and add comment for better read and maintenance, and no line removed!

**- A picture of a cute animal**
```go
// AddCommands adds all the commands from cli/command to the root command
func AddCommands(cmd *cobra.Command, dockerCli *command.DockerCli) {
	cmd.AddCommand(
		// checkpoint
		checkpoint.NewCheckpointCommand(dockerCli),

		// container
		container.NewContainerCommand(dockerCli),
		container.NewRunCommand(dockerCli),

		// image
		image.NewImageCommand(dockerCli),
		image.NewBuildCommand(dockerCli),

		// node
		node.NewNodeCommand(dockerCli),

		// network
		network.NewNetworkCommand(dockerCli),

		// plugin
		plugin.NewPluginCommand(dockerCli),

		// registry
		registry.NewLoginCommand(dockerCli),
		registry.NewLogoutCommand(dockerCli),
		registry.NewSearchCommand(dockerCli),

		// secret
		secret.NewSecretCommand(dockerCli),

		// service
		service.NewServiceCommand(dockerCli),

		// system
		system.NewSystemCommand(dockerCli),
		system.NewVersionCommand(dockerCli),

		// stack
		stack.NewStackCommand(dockerCli),
		stack.NewTopLevelDeployCommand(dockerCli),

		// swarm
		swarm.NewSwarmCommand(dockerCli),

		// volume
		volume.NewVolumeCommand(dockerCli),

		// legacy commands may be hidden
		hide(system.NewEventsCommand(dockerCli)),
		hide(system.NewInfoCommand(dockerCli)),
		hide(system.NewInspectCommand(dockerCli)),
		hide(container.NewAttachCommand(dockerCli)),
		hide(container.NewCommitCommand(dockerCli)),
		hide(container.NewCopyCommand(dockerCli)),
		hide(container.NewCreateCommand(dockerCli)),
		hide(container.NewDiffCommand(dockerCli)),
		hide(container.NewExecCommand(dockerCli)),
		hide(container.NewExportCommand(dockerCli)),
		hide(container.NewKillCommand(dockerCli)),
		hide(container.NewLogsCommand(dockerCli)),
		hide(container.NewPauseCommand(dockerCli)),
		hide(container.NewPortCommand(dockerCli)),
		hide(container.NewPsCommand(dockerCli)),
		hide(container.NewRenameCommand(dockerCli)),
		hide(container.NewRestartCommand(dockerCli)),
		hide(container.NewRmCommand(dockerCli)),
		hide(container.NewStartCommand(dockerCli)),
		hide(container.NewStatsCommand(dockerCli)),
		hide(container.NewStopCommand(dockerCli)),
		hide(container.NewTopCommand(dockerCli)),
		hide(container.NewUnpauseCommand(dockerCli)),
		hide(container.NewUpdateCommand(dockerCli)),
		hide(container.NewWaitCommand(dockerCli)),
		hide(image.NewHistoryCommand(dockerCli)),
		hide(image.NewImagesCommand(dockerCli)),
		hide(image.NewImportCommand(dockerCli)),
		hide(image.NewLoadCommand(dockerCli)),
		hide(image.NewPullCommand(dockerCli)),
		hide(image.NewPushCommand(dockerCli)),
		hide(image.NewRemoveCommand(dockerCli)),
		hide(image.NewSaveCommand(dockerCli)),
		hide(image.NewTagCommand(dockerCli)),
	)

}
```

Signed-off-by: wefine <wang.xiaoren@zte.com.cn>