### PR TITLE
Optimize the log info for client test

### DIFF
--- a/client/container_copy_test.go
+++ b/client/container_copy_test.go
@@ -78,10 +78,10 @@ func TestContainerStatPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	if stat.Name != "name" {
-		t.Fatalf("expected container path stat name to be 'name', was '%s'", stat.Name)
+		t.Fatalf("expected container path stat name to be 'name', got '%s'", stat.Name)
 	}
 	if stat.Mode != 0700 {
-		t.Fatalf("expected container path stat mode to be 0700, was '%v'", stat.Mode)
+		t.Fatalf("expected container path stat mode to be 0700, got '%v'", stat.Mode)
 	}
 }
 
@@ -226,10 +226,10 @@ func TestCopyFromContainer(t *testing.T) {
 		t.Fatal(err)
 	}
 	if stat.Name != "name" {
-		t.Fatalf("expected container path stat name to be 'name', was '%s'", stat.Name)
+		t.Fatalf("expected container path stat name to be 'name', got '%s'", stat.Name)
 	}
 	if stat.Mode != 0700 {
-		t.Fatalf("expected container path stat mode to be 0700, was '%v'", stat.Mode)
+		t.Fatalf("expected container path stat mode to be 0700, got '%v'", stat.Mode)
 	}
 	content, err := ioutil.ReadAll(r)
 	if err != nil {

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -81,12 +81,12 @@ func TestImageSearchWithPrivilegedFuncNoError(t *testing.T) {
 				}, nil
 			}
 			if auth != "IAmValid" {
-				return nil, fmt.Errorf("Invalid auth header : expected %s, got %s", "IAmValid", auth)
+				return nil, fmt.Errorf("Invalid auth header : expected 'IAmValid', got %s", auth)
 			}
 			query := req.URL.Query()
 			term := query.Get("term")
 			if term != "some-image" {
-				return nil, fmt.Errorf("tag not set in URL query properly. Expected '%s', got %s", "some-image", term)
+				return nil, fmt.Errorf("term not set in URL query properly. Expected 'some-image', got %s",  term)
 			}
 			content, err := json.Marshal([]registry.SearchResult{
 				{
@@ -113,7 +113,7 @@ func TestImageSearchWithPrivilegedFuncNoError(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(results) != 1 {
-		t.Fatalf("expected a result, got %v", results)
+		t.Fatalf("expected 1 result, got %v", results)
 	}
 }
 
@@ -133,7 +133,7 @@ func TestImageSearchWithoutErrors(t *testing.T) {
 			query := req.URL.Query()
 			term := query.Get("term")
 			if term != "some-image" {
-				return nil, fmt.Errorf("tag not set in URL query properly. Expected '%s', got %s", "some-image", term)
+				return nil, fmt.Errorf("term not set in URL query properly. Expected 'some-image', got %s",  term)
 			}
 			filters := query.Get("filters")
 			if filters != expectedFilters {

--- a/client/plugin_push_test.go
+++ b/client/plugin_push_test.go
@@ -35,7 +35,7 @@ func TestPluginPush(t *testing.T) {
 			}
 			auth := req.Header.Get("X-Registry-Auth")
 			if auth != "authtoken" {
-				return nil, fmt.Errorf("Invalid auth header : expected %s, got %s", "authtoken", auth)
+				return nil, fmt.Errorf("Invalid auth header : expected 'authtoken', got %s", auth)
 			}
 			return &http.Response{
 				StatusCode: http.StatusOK,


### PR DESCRIPTION
**- What I did**
Optimize the log info for client test

**- How I did it**

**- How to verify it**

**- Description for the changelog**
1.  Use "got" instead of "was"
2.  Put the expected value into format of error and decrease a parameter for Fatalf().


Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>