### PR TITLE
[RFC] add udev_wait_timeout storage option for devicemapper to fix docker ps stuck on udev wait

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -39,8 +39,11 @@ var (
 	defaultBaseFsSize           uint64 = 10 * 1024 * 1024 * 1024
 	defaultThinpBlockSize       uint32 = 128 // 64K = 128 512b sectors
 	defaultUdevSyncOverride            = false
-	maxDeviceID                        = 0xffffff // 24 bit, pool limit
-	deviceIDMapSz                      = (maxDeviceID + 1) / 8
+	// the default udve wait time out is 30s from 'man systemd-udevd'
+	// use 35 to make sure the time out really happend.
+	defaultUdevWaitTimeout = 35
+	maxDeviceID            = 0xffffff // 24 bit, pool limit
+	deviceIDMapSz          = (maxDeviceID + 1) / 8
 	// We retry device removal so many a times that even error messages
 	// will fill up console during normal operation. So only log Fatal
 	// messages by default.
@@ -2061,7 +2064,10 @@ func (devices *DeviceSet) issueDiscard(info *devInfo) error {
 // Should be called with devices.Lock() held.
 func (devices *DeviceSet) deleteDevice(info *devInfo, syncDelete bool) error {
 	if devices.doBlkDiscard {
-		devices.issueDiscard(info)
+		err := devices.issueDiscard(info)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Try to deactivate device in case it is active.
@@ -2615,6 +2621,7 @@ func NewDeviceSet(root string, doInit bool, options []string, uidMaps, gidMaps [
 	}
 
 	foundBlkDiscard := false
+	udevWaitTimeout := int64(defaultUdevWaitTimeout)
 	for _, option := range options {
 		key, val, err := parsers.ParseKeyValueOpt(option)
 		if err != nil {
@@ -2709,10 +2716,17 @@ func NewDeviceSet(root string, doInit bool, options []string, uidMaps, gidMaps [
 				return nil, err
 			}
 			devices.xfsNospaceRetries = val
+		case "dm.udev_wait_timeout":
+			udevWaitTimeout, err = strconv.ParseInt(val, 10, 32)
+			if err != nil {
+				return nil, err
+			}
 		default:
 			return nil, fmt.Errorf("devmapper: Unknown option %s\n", key)
 		}
 	}
+
+	devicemapper.SetUdevWaitTimtout(udevWaitTimeout)
 
 	// By default, don't do blk discard hack on raw devices, its rarely useful and is expensive
 	if !foundBlkDiscard && (devices.dataDevice != "" || devices.thinPoolDevice != "") {

--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"github.com/Sirupsen/logrus"
@@ -62,6 +63,7 @@ var (
 	ErrNilCookie            = errors.New("cookie ptr can't be nil")
 	ErrGetBlockSize         = errors.New("Can't get block size")
 	ErrUdevWait             = errors.New("wait on udev cookie failed")
+	ErrUdevWaitTimeout      = errors.New("wait on udev cookie time out")
 	ErrSetDevDir            = errors.New("dm_set_dev_dir failed")
 	ErrGetLibraryVersion    = errors.New("dm_get_library_version failed")
 	ErrCreateRemoveTask     = errors.New("Can't create task of type deviceRemove")
@@ -73,9 +75,10 @@ var (
 )
 
 var (
-	dmSawBusy  bool
-	dmSawExist bool
-	dmSawEnxio bool // No Such Device or Address
+	dmSawBusy         bool
+	dmSawExist        bool
+	dmSawEnxio        bool // No Such Device or Address
+	dmUdevWaitTimeout int64
 )
 
 type (
@@ -254,11 +257,31 @@ func (t *Task) getNextTarget(next unsafe.Pointer) (nextPtr unsafe.Pointer, start
 		start, length, targetType, params
 }
 
+func SetUdevWaitTimtout(t int64) {
+	dmUdevWaitTimeout = t
+}
+
 // UdevWait waits for any processes that are waiting for udev to complete the specified cookie.
 func UdevWait(cookie *uint) error {
-	if res := DmUdevWait(*cookie); res != 1 {
-		logrus.Debugf("devicemapper: Failed to wait on udev cookie %d", *cookie)
-		return ErrUdevWait
+	chError := make(chan error)
+	go func() {
+		if res := DmUdevWait(*cookie); res != 1 {
+			logrus.Debugf("Failed to wait on udev cookie %d", *cookie)
+			chError <- ErrUdevWait
+		}
+		chError <- nil
+	}()
+	select {
+	case err := <-chError:
+		return err
+	case <-time.After(time.Second * time.Duration(dmUdevWaitTimeout)):
+		logrus.Errorf("Failed to wait udev cookie %d: timeout %d", *cookie, dmUdevWaitTimeout)
+		if res := DmUdevComplete(*cookie); res != 1 {
+			logrus.Debugf("Failed to complete udev cookie %d on udev wait timeout", *cookie)
+		}
+		// wait DmUdevWait return after DmUdevComplete
+		<-chError
+		return ErrUdevWaitTimeout
 	}
 	return nil
 }
@@ -332,17 +355,17 @@ func RemoveDevice(name string) error {
 	if err := task.setCookie(&cookie, 0); err != nil {
 		return fmt.Errorf("devicemapper: Can not set cookie: %s", err)
 	}
-	defer UdevWait(&cookie)
 
 	dmSawBusy = false // reset before the task is run
 	if err = task.run(); err != nil {
+		UdevWait(&cookie)
 		if dmSawBusy {
 			return ErrBusy
 		}
 		return fmt.Errorf("devicemapper: Error running RemoveDevice %s", err)
 	}
 
-	return nil
+	return UdevWait(&cookie)
 }
 
 // RemoveDeviceDeferred is a useful helper for cleaning up a device, but deferred.
@@ -377,13 +400,13 @@ func RemoveDeviceDeferred(name string) error {
 	// this call will not wait for the deferred removal's final executing, since no
 	// udev event will be generated, and the semaphore's value will not be incremented
 	// by udev, what UdevWait is just cleaning up the semaphore.
-	defer UdevWait(&cookie)
 
 	if err = task.run(); err != nil {
+		UdevWait(&cookie)
 		return fmt.Errorf("devicemapper: Error running RemoveDeviceDeferred %s", err)
 	}
 
-	return nil
+	return UdevWait(&cookie)
 }
 
 // CancelDeferredRemove cancels a deferred remove for a device.
@@ -477,13 +500,13 @@ func CreatePool(poolName string, dataFile, metadataFile *os.File, poolBlockSize 
 	if err := task.setCookie(&cookie, flags); err != nil {
 		return fmt.Errorf("devicemapper: Can't set cookie %s", err)
 	}
-	defer UdevWait(&cookie)
 
 	if err := task.run(); err != nil {
+		UdevWait(&cookie)
 		return fmt.Errorf("devicemapper: Error running deviceCreate (CreatePool) %s", err)
 	}
 
-	return nil
+	return UdevWait(&cookie)
 }
 
 // ReloadPool is the programmatic example of "dmsetup reload".
@@ -663,13 +686,13 @@ func ResumeDevice(name string) error {
 	if err := task.setCookie(&cookie, 0); err != nil {
 		return fmt.Errorf("devicemapper: Can't set cookie %s", err)
 	}
-	defer UdevWait(&cookie)
 
 	if err := task.run(); err != nil {
+		UdevWait(&cookie)
 		return fmt.Errorf("devicemapper: Error running deviceResume %s", err)
 	}
 
-	return nil
+	return UdevWait(&cookie)
 }
 
 // CreateDevice creates a device with the specified poolName with the specified device id.
@@ -762,13 +785,12 @@ func activateDevice(poolName string, name string, deviceID int, size uint64, ext
 		return fmt.Errorf("devicemapper: Can't set cookie %s", err)
 	}
 
-	defer UdevWait(&cookie)
-
 	if err := task.run(); err != nil {
+		UdevWait(&cookie)
 		return fmt.Errorf("devicemapper: Error running deviceCreate (ActivateDevice) %s", err)
 	}
 
-	return nil
+	return UdevWait(&cookie)
 }
 
 // CreateSnapDeviceRaw creates a snapshot device. Caller needs to suspend and resume the origin device if it is active.

--- a/pkg/devicemapper/devmapper_wrapper.go
+++ b/pkg/devicemapper/devmapper_wrapper.go
@@ -72,6 +72,7 @@ var (
 	DmTaskSetRo               = dmTaskSetRoFct
 	DmTaskSetSector           = dmTaskSetSectorFct
 	DmUdevWait                = dmUdevWaitFct
+	DmUdevComplete            = dmUdevCompleteFct
 	DmUdevSetSyncSupport      = dmUdevSetSyncSupportFct
 	DmUdevGetSyncSupport      = dmUdevGetSyncSupportFct
 	DmCookieSupported         = dmCookieSupportedFct
@@ -220,6 +221,10 @@ func dmUdevGetSyncSupportFct() int {
 
 func dmUdevWaitFct(cookie uint) int {
 	return int(C.dm_udev_wait(C.uint32_t(cookie)))
+}
+
+func dmUdevCompleteFct(cookie uint) int {
+	return int(C.dm_udev_complete(C.uint32_t(cookie)))
 }
 
 func dmCookieSupportedFct() int {


### PR DESCRIPTION
This trying to fix the issue #27900
With following steps, it's easy to reproduce this issue for me:
1. run a container and do io r/w in the container
```
root@localhost docker-stress]# docker run -ti ubuntu bash
root@65ffef0e1ee9:/# while true; do dd if=/dev/zero of=/home/test.img bs=10M count=100; sync; rm /home/test.img; done
100+0 records in
100+0 records out
1048576000 bytes (1.0 GB) copied, 27.3588 s, 38.3 MB/s
```
2. run the docker-stress from  https://github.com/crosbymichael/docker-stress
```
 ./stress -c 100&
```

3. after a while,  `docker ps` stuck and you can't run any container.
and there is `udevd timeout` in system log
```
Nov 26 04:36:40 localhost.localdomain systemd-udevd[561]: worker [9707] /devices/virtual/block/dm-29 timeout; kill it
Nov 26 04:36:41 localhost.localdomain systemd-udevd[561]: seq 16045 '/devices/virtual/block/dm-29' killed
Nov 26 04:36:42 localhost.localdomain systemd-udevd[561]: worker [9707] terminated by signal 9 (Killed)
```
send SIGUSR1 to docker daemon to get the stack, you will find docker stuck on udev_wait
```
goroutine 4290 [syscall, 16 minutes, locked to thread]:
github.com/docker/docker/pkg/devicemapper._Cfunc_dm_udev_wait(0xd4d5419, 0xc200000000)
    /home/abuild/rpmbuild/BUILD/docker/.gopath/src/github.com/docker/docker/pkg/devicemapper/:194 +0x43
github.com/docker/docker/pkg/devicemapper.dmUdevWaitFct(0xd4d5419, 0xc208012000)
    /home/abuild/rpmbuild/BUILD/docker/.gopath/src/github.com/docker/docker/pkg/devicemapper/devmapper_wrapper.go:264 +0x29
github.com/docker/docker/pkg/devicemapper.UdevWait(0xc2088f68f0, 0x0, 0x0)
    /home/abuild/rpmbuild/BUILD/docker/.gopath/src/github.com/docker/docker/pkg/devicemapper/devmapper.go:314 +0x44
github.com/docker/docker/pkg/devicemapper.activateDevice(0xc208c68360, 0x26, 0xc2089540c0, 0x56, 0xc46, 0x1900000000, 0x0, 0x0, 0x0,
0x0)
    /home/abuild/rpmbuild/BUILD/docker/.gopath/src/github.com/docker/docker/pkg/devicemapper/devmapper.go:805 +0x859
github.com/docker/docker/pkg/devicemapper.ActivateDevice(0xc208c68360, 0x26, 0xc2089540c0, 0x56, 0xc46, 0x1900000000, 0x0, 0x0)
    /home/abuild/rpmbuild/BUILD/docker/.gopath/src/github.com/docker/docker/pkg/devicemapper/devmapper.go:766 +0x89
github.com/docker/docker/daemon/graphdriver/devmapper.(*DeviceSet).activateDeviceIfNeeded(0xc20806e300, 0xc208848720, 0x0, 0x0, 0x0)
    /home/abuild/rpmbuild/BUILD/docker/.gopath/src/github.com/docker/docker/daemon/graphdriver/devmapper/deviceset.go:536 +0x472
github.com/docker/docker/daemon/graphdriver/devmapper.(*DeviceSet).MountDevice(0xc20806e300, 0xc20910de80, 0x40, 0xc20877a070, 0x61, 0x0, 0x0, 0x0, 0x0)
    /home/abuild/rpmbuild/BUILD/docker/.gopath/src/github.com/docker/docker/daemon/graphdriver/devmapper/deviceset.go:2084 +0x4e9
github.com/docker/docker/daemon/graphdriver/devmapper.(*Driver).Get(0xc208826640, 0xc20910de80, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /home/abuild/rpmbuild/BUILD/docker/.gopath/src/github.com/docker/docker/daemon/graphdriver/devmapper/driver.go:192 +0x440
github.com/docker/docker/daemon/graphdriver.(*NaiveDiffDriver).Get(0xc20872b780, 0xc20910de80, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    <autogenerated>:28 +0xb1
github.com/docker/docker/daemon.(*Daemon).Mount(0xc208083040, 0xc208c07680, 0x0, 0x0)
    /home/abuild/rpmbuild/BUILD/docker/.gopath/src/github.com/docker/docker/daemon/daemon.go:925 +0xbf
github.com/docker/docker/daemon.(*Container).Mount(0xc208c07680, 0x0, 0x0)
    /home/abuild/rpmbuild/BUILD/docker/.gopath/src/github.com/docker/docker/daemon/container.go:607 +0x46
github.com/docker/docker/daemon.(*Container).Start(0xc208c07680, 0x0, 0x0)
    /home/abuild/rpmbuild/BUILD/docker/.gopath/src/github.com/docker/docker/daemon/container.go:304 +0x189
github.com/docker/docker/daemon.(*Daemon).ContainerStart(0xc208083040, 0xc20877e407, 0x40, 0x0, 0x0, 0x0)
    /home/abuild/rpmbuild/BUILD/docker/.gopath/src/github.com
```

This PR adds a timeout time to the docker daemon on waiting udev cookies, so the daemon will not
stuck there forever if udevd being killed.

ping @rhvgoyal  @estesp 


Signed-off-by: Lei Jitang <leijitang@huawei.com>