### PR TITLE
[WIP]make ErrSwarmLocked and ErrSwarmCertificatesExpired return status code 503

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -81,10 +81,10 @@ var errSwarmExists = errors.New("This node is already part of a swarm. Use \"doc
 var errSwarmJoinTimeoutReached = errors.New("Timeout was reached before node was joined. The attempt to join the swarm will continue in the background. Use the \"docker info\" command to see the current swarm status of your node.")
 
 // errSwarmLocked is returned if the swarm is encrypted and needs a key to unlock it.
-var errSwarmLocked = errors.New("Swarm is encrypted and needs to be unlocked before it can be used. Please use \"docker swarm unlock\" to unlock it.")
+var errSwarmLocked = errors.New("This node is encrypted and needs to be unlocked before it can be used. Please use \"docker swarm unlock\" to unlock it.")
 
 // errSwarmCertificatesExpired is returned if docker was not started for the whole validity period and they had no chance to renew automatically.
-var errSwarmCertificatesExpired = errors.New("Swarm certificates have expired. To replace them, leave the swarm and join again.")
+var errSwarmCertificatesExpired = errors.New("Certificates of this node have expired. To replace them, leave the swarm and join again.")
 
 // NetworkSubnetsProvider exposes functions for retrieving the subnets
 // of networks managed by Docker, so they can be filtered.

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -916,7 +916,7 @@ func (s *DockerSwarmSuite) TestSwarmInitLocked(c *check.C) {
 
 	outs, err = d.Cmd("node", "ls")
 	c.Assert(err, checker.IsNil)
-	c.Assert(outs, checker.Not(checker.Contains), "Swarm is encrypted and needs to be unlocked")
+	c.Assert(outs, checker.Not(checker.Contains), "This node is encrypted and needs to be unlocked")
 
 	outs, err = d.Cmd("swarm", "update", "--autolock=false")
 	c.Assert(err, checker.IsNil, check.Commentf("out: %v", outs))
@@ -925,7 +925,7 @@ func (s *DockerSwarmSuite) TestSwarmInitLocked(c *check.C) {
 
 	outs, err = d.Cmd("node", "ls")
 	c.Assert(err, checker.IsNil)
-	c.Assert(outs, checker.Not(checker.Contains), "Swarm is encrypted and needs to be unlocked")
+	c.Assert(outs, checker.Not(checker.Contains), "This node is encrypted and needs to be unlocked")
 }
 
 func (s *DockerSwarmSuite) TestSwarmLeaveLocked(c *check.C) {
@@ -942,7 +942,7 @@ func (s *DockerSwarmSuite) TestSwarmLeaveLocked(c *check.C) {
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateLocked)
 
 	outs, _ = d.Cmd("node", "ls")
-	c.Assert(outs, checker.Contains, "Swarm is encrypted and needs to be unlocked")
+	c.Assert(outs, checker.Contains, "This node is encrypted and needs to be unlocked")
 
 	// `docker swarm leave` a locked swarm without --force will return an error
 	outs, _ = d.Cmd("swarm", "leave")
@@ -1146,7 +1146,7 @@ func (s *DockerSwarmSuite) TestSwarmRotateUnlockKey(c *check.C) {
 		c.Assert(getNodeStatus(c, d), checker.Equals, swarm.LocalNodeStateLocked)
 
 		outs, _ = d.Cmd("node", "ls")
-		c.Assert(outs, checker.Contains, "Swarm is encrypted and needs to be unlocked")
+		c.Assert(outs, checker.Contains, "This node is encrypted and needs to be unlocked")
 
 		cmd := d.Command("swarm", "unlock")
 		cmd.Stdin = bytes.NewBufferString(unlockKey)
@@ -1175,7 +1175,7 @@ func (s *DockerSwarmSuite) TestSwarmRotateUnlockKey(c *check.C) {
 		})
 
 		outs, _ = d.Cmd("node", "ls")
-		c.Assert(outs, checker.Contains, "Swarm is encrypted and needs to be unlocked")
+		c.Assert(outs, checker.Contains, "This node is encrypted and needs to be unlocked")
 
 		cmd = d.Command("swarm", "unlock")
 		cmd.Stdin = bytes.NewBufferString(newUnlockKey)
@@ -1185,7 +1185,7 @@ func (s *DockerSwarmSuite) TestSwarmRotateUnlockKey(c *check.C) {
 
 		outs, err = d.Cmd("node", "ls")
 		c.Assert(err, checker.IsNil)
-		c.Assert(outs, checker.Not(checker.Contains), "Swarm is encrypted and needs to be unlocked")
+		c.Assert(outs, checker.Not(checker.Contains), "This node is encrypted and needs to be unlocked")
 
 		unlockKey = newUnlockKey
 	}
@@ -1233,7 +1233,7 @@ func (s *DockerSwarmSuite) TestSwarmClusterRotateUnlockKey(c *check.C) {
 			c.Assert(getNodeStatus(c, d), checker.Equals, swarm.LocalNodeStateLocked)
 
 			outs, _ := d.Cmd("node", "ls")
-			c.Assert(outs, checker.Contains, "Swarm is encrypted and needs to be unlocked")
+			c.Assert(outs, checker.Contains, "This node is encrypted and needs to be unlocked")
 
 			cmd := d.Command("swarm", "unlock")
 			cmd.Stdin = bytes.NewBufferString(unlockKey)
@@ -1262,7 +1262,7 @@ func (s *DockerSwarmSuite) TestSwarmClusterRotateUnlockKey(c *check.C) {
 			})
 
 			outs, _ = d.Cmd("node", "ls")
-			c.Assert(outs, checker.Contains, "Swarm is encrypted and needs to be unlocked")
+			c.Assert(outs, checker.Contains, "This node is encrypted and needs to be unlocked")
 
 			cmd = d.Command("swarm", "unlock")
 			cmd.Stdin = bytes.NewBufferString(newUnlockKey)
@@ -1272,7 +1272,7 @@ func (s *DockerSwarmSuite) TestSwarmClusterRotateUnlockKey(c *check.C) {
 
 			outs, err = d.Cmd("node", "ls")
 			c.Assert(err, checker.IsNil)
-			c.Assert(outs, checker.Not(checker.Contains), "Swarm is encrypted and needs to be unlocked")
+			c.Assert(outs, checker.Not(checker.Contains), "This node is encrypted and needs to be unlocked")
 		}
 
 		unlockKey = newUnlockKey


### PR DESCRIPTION
In code https://github.com/docker/docker/blob/master/api/server/httputils/errors.go#L65-L71, it validates the string `this node` to return status code of 503.
```
{"this node", http.StatusServiceUnavailable},
```

While the every error related to 503 should contain string `this node`.

I found that error `ErrSwarmLocked` and `ErrSwarmCertificatesExpired` do not contain "this node".This PR makes them contain "this node" and return status code of 503 to keep consistent.

Since error `ErrSwarmLocked` and `ErrSwarmCertificatesExpired` is added from version 1.13.x, and did not appear in dockerd 1.12.x, so this change will not change the API, but enhance api 1.25.

------------------------------

In addition, in code https://github.com/docker/docker/blob/master/daemon/cluster/cluster.go#L689, there is a substring of "this node" in the error message, then this error will return status code of 503, which is unreasonable, like the following pic:
<img width="827" alt="2016-12-02 2 06 05" src="https://cloud.githubusercontent.com/assets/9465626/20806069/5d663c44-b834-11e6-9da7-288f27095174.png">


**- What I did**
1. make error  `ErrSwarmLocked` and `ErrSwarmCertificatesExpired` contain substring "this node" and return 503;
2. make another error not contain substring "this node".

/cc @stevvooe 

Signed-off-by: allencloud <allen.sun@daocloud.io>