### PR TITLE
Re-add downlevel bash date hack

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -83,6 +83,10 @@ if command -v git &> /dev/null && [ -d .git ] && git rev-parse &> /dev/null; the
 		echo "#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 	fi
 	! BUILDTIME=$(date --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/') &> /dev/null
+	if [ -z $BUILDTIME ]; then 
+		# If using bash 3.x which doesn't support --rfc-3389. See #28206
+		BUILDTIME=$(date -u) 
+	fi 	
 elif [ "$DOCKER_GITCOMMIT" ]; then
 	GITCOMMIT="$DOCKER_GITCOMMIT"
 else


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@thaJeztah @vdemeester Might fix #28206.  Had discussion with @thaJeztah on slack - I truly can't see how this can fix it, and I can't repro locally, but according to https://github.com/docker/docker/issues/28206#issuecomment-264179935, it does. The only conclusion I can reach is whatever is being used to build the RPMs is using an old version of bash (eg 3.1). 

For history - this hack was originally introduced only to support the Windows to Linux CI servers where at the time (circa Nov 2015), only bash 3.1 was available on Windows. 

That said, I've tried all the distros which are listed under contrib\builder\rpm\amd64 (@thaJeztah thought it was using centos:7) and all seem to have bash version 4.2 or later. So maybe it's possible the RPMs are being built by something older?

I've locally build 1.13.0-rc2 on Ubuntu and it shows the build date fine, as does downloading the 64-bit Linux binaries from docker/docker/releases. I'm also a little confused if 1.12.x is affected as per the removal PR only went into 1.13.0-rc2. 

@vdemeester Can you see if this works as I have been unable to repro, along with some instructions so we can dig in further why, and you stated that reverting https://github.com/docker/docker/commit/5e6f8cb4a7f8bf294b3b459d2c2afed6d69fcdf1 brought the date back again.