### PR TITLE
Fix restartpolicy max-retry validation

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -268,11 +268,11 @@ func (daemon *Daemon) verifyContainerSettings(hostConfig *containertypes.HostCon
 	switch p.Name {
 	case "always", "unless-stopped", "no":
 		if p.MaximumRetryCount != 0 {
-			return nil, fmt.Errorf("maximum restart count not valid with restart policy of '%s'", p.Name)
+			return nil, fmt.Errorf("maximum retry count cannot be used with restart policy '%s'", p.Name)
 		}
 	case "on-failure":
-		if p.MaximumRetryCount < 1 {
-			return nil, fmt.Errorf("maximum restart count must be a positive integer")
+		if p.MaximumRetryCount < 0 {
+			return nil, fmt.Errorf("maximum retry count cannot be negative")
 		}
 	case "":
 	// do nothing


### PR DESCRIPTION
the restart policy validation was moved from
the client to the daemon in 94e95e4711643640701bd614902e75a2d01f12c5 (https://github.com/docker/docker/pull/24073)

As part of that change, retry-counts < 1 were marked as "invalid".
However, the default is 0 (unlimited), causing

    docker run -d --restart=on-failure nginx

To fail.

This changes the validation to only invalidate retry-counts < 0.

A test was added, and other tests renamed to allow running just these tests :)

fixes https://github.com/docker/docker/issues/29035