### PR TITLE
Fix use of **/ in .dockerignore

### DIFF
--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -161,17 +161,19 @@ func regexpMatch(pattern, path string) (bool, error) {
 				// is some flavor of "**"
 				scan.Next()
 
+				// Treat **/ as ** so eat the "/"
+				if string(scan.Peek()) == sl {
+					scan.Next()
+				}
+
 				if scan.Peek() == scanner.EOF {
 					// is "**EOF" - to align with .gitignore just accept all
 					regStr += ".*"
 				} else {
 					// is "**"
-					regStr += "((.*" + escSL + ")|([^" + escSL + "]*))"
-				}
-
-				// Treat **/ as ** so eat the "/"
-				if string(scan.Peek()) == sl {
-					scan.Next()
+					// Note that this allows for any # of /'s (even 0) because
+					// the .* will eat everything, even /'s
+					regStr += "(.*" + escSL + ")?"
 				}
 			} else {
 				// is "*" so map it to anything but "/"

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -325,7 +325,7 @@ func TestMatches(t *testing.T) {
 		{"**", "/", true},
 		{"**/", "/", true},
 		{"**", "dir/file", true},
-		{"**/", "dir/file", false},
+		{"**/", "dir/file", true},
 		{"**", "dir/file/", true},
 		{"**/", "dir/file/", true},
 		{"**/**", "dir/file", true},
@@ -379,6 +379,8 @@ func TestMatches(t *testing.T) {
 		{"abc/**", "abc", false},
 		{"abc/**", "abc/def", true},
 		{"abc/**", "abc/def/ghi", true},
+		{"**/.foo", ".foo", true},
+		{"**/.foo", "bar.foo", false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION

![img_1116](https://cloud.githubusercontent.com/assets/1944671/20816648/64354ef4-b7f1-11e6-9658-e7789e75481a.JPG)



Closes #29014

Signed-off-by: Doug Davis <dug@us.ibm.com>