### PR TITLE
pin go-swagger 0.7.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,4 +147,4 @@ swagger-gen:
 		-w /go/src/github.com/docker/docker \
 		--entrypoint hack/generate-swagger-api.sh \
 		-e GOPATH=/go \
-		quay.io/goswagger/swagger
+		quay.io/goswagger/swagger:0.7.4


### PR DESCRIPTION
This pins the version of go-swagger used, because
the results generated by different versions
can differ quite a bit (tested between 0.7.2 - 0.7.4),
and can cause CI / validation to fail.
