### PR TITLE
Vendor swarmkit

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -139,7 +139,7 @@ clone git github.com/docker/docker-credential-helpers v0.3.0
 clone git github.com/docker/containerd 0366d7e9693c930cf18c0f50cc16acec064e96c5
 
 # cluster
-clone git github.com/docker/swarmkit 938530a15c8a0374b367f2b94ddfd8e8b9b61bad
+clone git github.com/docker/swarmkit 0cf248feec033f46dc09db40d69fd5128082b79a
 clone git github.com/golang/mock bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 clone git github.com/gogo/protobuf 43a2e0b1c32252bfbbdf81f7faa7a88fb3fa4028
 clone git github.com/cloudflare/cfssl b895b0549c0ff676f92cf09ba971ae02bb41367b

--- a/vendor/src/github.com/docker/swarmkit/manager/allocator/networkallocator/networkallocator.go
+++ b/vendor/src/github.com/docker/swarmkit/manager/allocator/networkallocator/networkallocator.go
@@ -568,9 +568,18 @@ func (na *NetworkAllocator) allocateDriverState(n *api.Network) error {
 		return err
 	}
 
-	var options map[string]string
+	options := make(map[string]string)
+	// reconcile the driver specific options from the network spec
+	// and from the operational state retrieved from the store
 	if n.Spec.DriverConfig != nil {
-		options = n.Spec.DriverConfig.Options
+		for k, v := range n.Spec.DriverConfig.Options {
+			options[k] = v
+		}
+	}
+	if n.DriverState != nil {
+		for k, v := range n.DriverState.Options {
+			options[k] = v
+		}
 	}
 
 	// Construct IPAM data for driver consumption.

--- a/vendor/src/github.com/docker/swarmkit/manager/orchestrator/global.go
+++ b/vendor/src/github.com/docker/swarmkit/manager/orchestrator/global.go
@@ -225,8 +225,8 @@ func (g *GlobalOrchestrator) reconcileOneService(ctx context.Context, service *a
 		}
 	}
 
+	var updateTasks []*api.Task
 	_, err = g.store.Batch(func(batch *store.Batch) error {
-		var updateTasks []*api.Task
 		for nodeID := range g.nodes {
 			ntasks := nodeTasks[nodeID]
 			// if restart policy considers this node has finished its task
@@ -243,13 +243,14 @@ func (g *GlobalOrchestrator) reconcileOneService(ctx context.Context, service *a
 				g.removeTasks(ctx, batch, service, ntasks[1:])
 			}
 		}
-		if len(updateTasks) > 0 {
-			g.updater.Update(ctx, g.cluster, service, updateTasks)
-		}
 		return nil
 	})
 	if err != nil {
 		log.G(ctx).WithError(err).Errorf("global orchestrator: reconcileOneService transaction failed")
+	}
+
+	if len(updateTasks) > 0 {
+		g.updater.Update(ctx, g.cluster, service, updateTasks)
 	}
 }
 


### PR DESCRIPTION
This brings in two fixes from the bump_v1.12.4 branch of swarmkit:

- orchestrator/global: Fix deadlock on updates (https://github.com/docker/swarmkit/pull/1760)
- On leader switchover preserve the vxlan id for existing networks (https://github.com/docker/swarmkit/pull/1773)