### PR TITLE
Windows: Builder GETENV

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -35,6 +35,7 @@ var validCommitCommands = map[string]bool{
 	"user":        true,
 	"volume":      true,
 	"workdir":     true,
+	"getenv":      true,
 }
 
 // BuiltinAllowedBuildArgs is list of built-in allowed build args

--- a/builder/dockerfile/command/command.go
+++ b/builder/dockerfile/command/command.go
@@ -11,6 +11,7 @@ const (
 	Env         = "env"
 	Expose      = "expose"
 	From        = "from"
+	Getenv      = "getenv"
 	Healthcheck = "healthcheck"
 	Label       = "label"
 	Maintainer  = "maintainer"
@@ -33,6 +34,7 @@ var Commands = map[string]struct{}{
 	Env:         {},
 	Expose:      {},
 	From:        {},
+	Getenv:      {},
 	Healthcheck: {},
 	Label:       {},
 	Maintainer:  {},

--- a/builder/dockerfile/dispatchers_unix.go
+++ b/builder/dockerfile/dispatchers_unix.go
@@ -25,3 +25,12 @@ func normaliseWorkdir(current string, requested string) (string, error) {
 func errNotJSON(command, _ string) error {
 	return fmt.Errorf("%s requires the arguments to be in JSON form", command)
 }
+
+// GETENV
+//
+// GETENV gets the environment variables from the container to synchronise
+// back to the image configuration. This is not implemented on *nix platforms.
+//
+func getenv(b *Builder, args []string, attributes map[string]bool, original string) error {
+	return fmt.Errorf("GETENV not implemented")
+}

--- a/builder/dockerfile/dispatchers_windows.go
+++ b/builder/dockerfile/dispatchers_windows.go
@@ -1,12 +1,15 @@
 package dockerfile
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
+	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/pkg/system"
 )
 
@@ -83,4 +86,69 @@ func errNotJSON(command, original string) error {
 		extra = fmt.Sprintf(`. It looks like '%s' includes a file path without an escaped back-slash. JSON requires back-slashes to be escaped such as ["c:\\path\\to\\file.exe", "/parameter"]`, original)
 	}
 	return fmt.Errorf("%s requires the arguments to be in JSON form%s", command, extra)
+}
+
+// GETENV
+//
+// GETENV gets the environment variables from the container to synchronise
+// back to the image configuration.
+//
+func getenv(b *Builder, args []string, attributes map[string]bool, original string) error {
+	if len(args) != 1 {
+		return errExactlyOneArgument("GETENV")
+	}
+	if b.image == "" && !b.noBaseImage {
+		return fmt.Errorf("Please provide a source image with `from` prior to getenv")
+	}
+	if err := b.flags.Parse(); err != nil {
+		return err
+	}
+
+	// Construct a command that gets the value of the requested environment variable in the
+	// container, or an empty string if it is not defined. This takes some explaining:
+	//
+	// 1. Don't use powershell in case it is an optional component in the base image and not installed.
+	//
+	// 2. Use delayed expansion and ! syntax to pick up variables with newlines in them. Note the only time a "b" appears in the output:
+	//    PS C:\> $env:FOO="a`nb"
+	//    PS C:\> cmd /v:on /s /c "echo !FOO! && echo %FOO%"; echo "---"; cmd /v:off /s /c "echo !FOO! && echo %FOO%"
+	//    a
+	//    b
+	//    a
+	//    ---
+	//    !FOO!
+	//    a
+	//
+	// 3. Use command extensions to ensure defined works, otherwise the echo would error rather than return an empty value
+	//    PS C:\> cmd /e:on /s /c "if defined PATH (echo hello)"
+	//    hello
+	//    C:\> cmd /e:off /s /c "if defined PATH (echo hello)"
+	//    PATH was unexpected at this time.
+	//
+	// 4. Don't use `set PATH` as that returns anything starting PATH, which include PATHEXT. Avoids string parsing.
+	b.runConfig.Cmd = strslice.StrSlice([]string{"cmd", "/v:on", "/e:on", "/s", "/c", fmt.Sprintf("if defined %s (echo !%s!)", args[0], args[0])})
+
+	cID, err := b.create()
+	if err != nil {
+		return err
+	}
+
+	// Setup stdout and stderr so that we grab the output directly, not back to client.
+	origStdout := b.Stdout
+	origStderr := b.Stderr
+	defer func(o, e io.Writer) {
+		b.Stdout = o
+		b.Stderr = e
+	}(origStdout, origStderr)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	b.Stdout = stdout
+	b.Stderr = stderr
+
+	if err := b.run(cID); err != nil {
+		return fmt.Errorf("%v - %s", err, string(stderr.Bytes()))
+	}
+
+	// After stripping trailing CRLF, treat stdout as the value of the variable and handle the rest as a regular ENV statement
+	return env(b, []string{args[0], strings.TrimRight(string(stdout.Bytes()), "\r\n")}, attributes, original)
 }

--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -67,6 +67,7 @@ func init() {
 		command.Env:         env,
 		command.Expose:      expose,
 		command.From:        from,
+		command.Getenv:      getenv,
 		command.Healthcheck: healthcheck,
 		command.Label:       label,
 		command.Maintainer:  maintainer,

--- a/builder/dockerfile/evaluator_unix.go
+++ b/builder/dockerfile/evaluator_unix.go
@@ -2,8 +2,14 @@
 
 package dockerfile
 
+import "fmt"
+
 // platformSupports is a short-term function to give users a quality error
 // message if a Dockerfile uses a command not supported on the platform.
 func platformSupports(command string) error {
+	switch command {
+	case "getenv":
+		return fmt.Errorf("The daemon on this platform does not support the command '%s'", command)
+	}
 	return nil
 }

--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -81,6 +81,7 @@ func init() {
 		command.Env:         parseEnv,
 		command.Expose:      parseStringsWhitespaceDelimited,
 		command.From:        parseString,
+		command.Getenv:      parseString,
 		command.Healthcheck: parseHealthConfig,
 		command.Label:       parseLabel,
 		command.Maintainer:  parseString,

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1707,6 +1707,30 @@ required such as `zsh`, `csh`, `tcsh` and others.
 
 The `SHELL` feature was added in Docker 1.12.
 
+## GETENV
+
+    GETENV variable
+
+The `GETENV` instruction is only supported on Windows. It allows an environment
+variable to be retrieved from a container and stored in the image configuration.
+This is particularly useful in the case of `PATH` which is not set to a default
+value on Windows, or where the Windows registry must be manipulated on 
+nanoserver-based images. Once stored in the image configuration, it can be used 
+as per any other environment variable set through `ENV`.
+
+The `GETENV` instruction allows the following Dockerfile to operate as expected.
+Without the use of `GETENV` here, the resulting `PATH` in the container would
+be just C:\MyApp, and any built-in commands to Windows would fail as they are
+no longer on the PATH.
+
+    # escape=`
+    FROM microsoft/nanoserver
+    GETENV PATH
+    ADD myapp.exe C:\MyApp\
+    ENV PATH C:\MyApp;$PATH
+	
+The `GETENV` feature was added in Docker 1.14.
+
 ## Dockerfile examples
 
 Below you can see some examples of Dockerfile syntax. If you're interested in


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@duglin - defacto/actual builder maintainer :smile:

I'm trying to solve a very real problem which is way more predominant in Windows.

https://github.com/docker/docker/issues/22017 is one such example. And it's compounded when using nanoserver - see this workaround as a more extreme example: https://github.com/Microsoft/Virtualization-Documentation/blob/live/windows-container-samples/golang/Dockerfile#L24

On Linux, `$PATH` is defaulted, which for various reasons, on Windows cannot (and shouldn't) be done reliably. Hence in an image, `ENV` by default is blank in Windows, but has a couple of defaults on Linux. For variable substition in a Dockerfile, users expect to be able to do `ENV PATH c:\myapp\bin;$PATH` and it "just works". Unfortunately in the current docker engine design, the `$PATH` in that `ENV` statement is substituted from the configuration, not from the actual container itself. So on Windows, the PATH would end up as just `c:\myapp\bin`, which is clearly incorrect.

So what does this PR do? It introduces a new builder instruction `GETENV`.  `GETENV` retrieves the current variable from a container (that it starts) and store it back in the image configuration. That way, it can be used for substitution purposes exactly the same as for any other variable which would be set through ENV.

So anyway, taking the PATH example, rather than the current workaround necessary on Windowsservercore (simpler than nanoserver - see link at top), rather than (taken from Dockerfile.windows)

```
FROM microsoft/windowsservercore
SHELL ["powershell", "-command"]
RUN ...; `
  setx /M PATH $('C:\git\bin;C:\git\usr\bin;'+$Env:PATH+';C:\gcc\bin;C:\go\bin'); `
  $env:PATH = 'C:\gcc\bin;$env:PATH'; `
  `
...
```
you would be able to do the following which is (IMO) a lot cleaner, and would work on nanoserver without the additional Windows registry key workaround:

```
FROM microsoft/windowsservercore
GETENV PATH
ENV PATH c:\git\bin;<other paths>;$PATH
RUN ...
```

Here's a real example of it in action:

```
PS E:\docker\build\getenv> type dockerfile
#escape=`
FROM nanoserver
GETENV PATH
ENV PATH=c:\somewhere;$PATH
RUN echo %path%
PS E:\docker\build\getenv> docker build --no-cache .
Sending build context to Docker daemon 2.048 kB
Step 1/4 : FROM nanoserver
 ---> 56867d0138c3
Step 2/4 : GETENV PATH
 ---> Running in cc2ae8f580f0
 ---> ab9e18951bc3
Removing intermediate container cc2ae8f580f0
Removing intermediate container fc0c97eae902
Step 3/4 : ENV PATH c:\somewhere;$PATH
 ---> Running in 3379e6b8b7d4
 ---> 8e92892f880d
Removing intermediate container 3379e6b8b7d4
Step 4/4 : RUN echo %path%
 ---> Running in 32406d32dc32
c:\somewhere;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps
 ---> 6657af975e18
Removing intermediate container 32406d32dc32
Successfully built 6657af975e18
PS E:\docker\build\getenv>
```


@friism @StefanScherer @thaJeztah @jstarks @tianon FYI