### PR TITLE
not export errors and forbid leave without --force when unlocked

### DIFF
--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -217,7 +217,7 @@ func (n *nodeRunner) State() nodeState {
 	ns := n.nodeState
 
 	if ns.err != nil || n.cancelReconnect != nil {
-		if errors.Cause(ns.err) == ErrSwarmLocked {
+		if errors.Cause(ns.err) == errSwarmLocked {
 			ns.status = types.LocalNodeStateLocked
 		} else {
 			ns.status = types.LocalNodeStateError

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -904,6 +904,11 @@ func (s *DockerSwarmSuite) TestSwarmLeaveLocked(c *check.C) {
 	outs, _ = d.Cmd("node", "ls")
 	c.Assert(outs, checker.Contains, "Swarm is encrypted and needs to be unlocked")
 
+	// `docker swarm leave` a locked swarm without --force will return an error
+	outs, _ = d.Cmd("swarm", "leave")
+	c.Assert(outs, checker.Contains, "Swarm is encrypted and locked.")
+
+	// It is OK for user to leave a locked swarm with --force
 	outs, err = d.Cmd("swarm", "leave", "--force")
 	c.Assert(err, checker.IsNil, check.Commentf("out: %v", outs))
 


### PR DESCRIPTION
fixes https://github.com/docker/docker/issues/29059

This PR forbids `docker swarm leave` easily when swarm is locked. 

**- What I did**
1. leave when locked returns a specified error;
2. do not export errors in cluster.go

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: allencloud <allen.sun@daocloud.io>