### PR TITLE
refine api swagger.yaml towards image create status code

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4443,6 +4443,10 @@ paths:
       responses:
         200:
           description: "no error"
+        404:
+          description: "repository does not exist or no read access"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         500:
           description: "server error"
           schema:

--- a/docs/api/v1.18.md
+++ b/docs/api/v1.18.md
@@ -1294,6 +1294,7 @@ a base64-encoded AuthConfig object.
 **Status codes**:
 
 -   **200** – no error
+-   **404** - repository does not exist or no read access
 -   **500** – server error
 
 

--- a/docs/api/v1.19.md
+++ b/docs/api/v1.19.md
@@ -1340,6 +1340,7 @@ a base64-encoded AuthConfig object.
 **Status codes**:
 
 -   **200** – no error
+-   **404** - repository does not exist or no read access
 -   **500** – server error
 
 

--- a/docs/api/v1.20.md
+++ b/docs/api/v1.20.md
@@ -1494,6 +1494,7 @@ a base64-encoded AuthConfig object.
 **Status codes**:
 
 -   **200** – no error
+-   **404** - repository does not exist or no read access
 -   **500** – server error
 
 

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -1587,6 +1587,7 @@ a base64-encoded AuthConfig object.
 **Status codes**:
 
 -   **200** – no error
+-   **404** - repository does not exist or no read access
 -   **500** – server error
 
 

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -1785,6 +1785,7 @@ a base64-encoded AuthConfig object.
 **Status codes**:
 
 -   **200** – no error
+-   **404** - repository does not exist or no read access
 -   **500** – server error
 
 

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -1821,6 +1821,7 @@ a base64-encoded AuthConfig object.
 **Status codes**:
 
 -   **200** – no error
+-   **404** - repository does not exist or no read access
 -   **500** – server error
 
 

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -1818,6 +1818,7 @@ a base64-encoded AuthConfig object.
 **Status codes**:
 
 -   **200** – no error
+-   **404** - repository does not exist or no read access
 -   **500** – server error
 
 


### PR DESCRIPTION
Hi, this PR fix  swagger.yaml and api docs towards ```image create``` status code when repository not found, which came up by issue https://github.com/docker/docker/issues/28993 

As code below, when I use postman to create image ```bogus``` 
```
POST /images/create?fromImage=bogus
```
 The status code return **404 Not Found** and following message :

```
{
  "message": "repository bogus not found: does not exist or no read access"
}
```
However, the 404 status code towards ```image create``` is not included in swagger.yaml or api docs which only returns a 200 or a 500 status code.  

https://github.com/docker/docker/blob/master/api/swagger.yaml#L4443:L4447 

So I add the 404 response into swagger.yaml and api docs, to explain the case when you try to pull an image but it can not be found in a registry. 

```
    tags: ["Images"]
  /images/create:
    post:
      summary: "Create an image"
      description: "Create an image by either pulling it from a registry or importing it."
      operationId: "ImageCreate"
      consumes:
        - "text/plain"
        - "application/octet-stream"
      produces:
        - "application/json"
      responses:
        200:
          description: "no error"
        404:
          description: "repository not found"
        500:
          description: "server error"
          schema:
            $ref: "#/definitions/ErrorResponse"
     ...
```

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: erxian <evelynhsu21@gmail.com>