### PR TITLE
return error in GetUnlockKey when swarm has no unlock key

### DIFF
--- a/cli/command/swarm/unlock_key.go
+++ b/cli/command/swarm/unlock_key.go
@@ -46,11 +46,7 @@ func newUnlockKeyCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 			unlockKeyResp, err := client.SwarmGetUnlockKey(ctx)
 			if err != nil {
-				return errors.Wrap(err, "could not fetch unlock key")
-			}
-
-			if unlockKeyResp.UnlockKey == "" {
-				return errors.New("no unlock key is set")
+				return err
 			}
 
 			if quiet {

--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -577,8 +577,8 @@ func (c *Cluster) GetUnlockKey() (string, error) {
 	}
 
 	if len(r.UnlockKey) == 0 {
-		// no key
-		return "", nil
+		// if no key, return error
+		return "", errors.New("Swarm has no unlock-key set.")
 	}
 
 	return encryption.HumanReadableKey(r.UnlockKey), nil


### PR DESCRIPTION
fixes #29063 

Make endpoint `GET /swarm/unlockkey` return an error if swarm has no unlock-key.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: allencloud <allen.sun@daocloud.io>