### PR TITLE
Add bash completion for experimental `docker deploy`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -409,6 +409,13 @@ __docker_append_to_completions() {
 	COMPREPLY=( ${COMPREPLY[@]/%/"$1"} )
 }
 
+# __docker_is_experimental tests whether the currently configured Docker daemon
+# runs in experimental mode. If so, the function exits with 0 (true).
+# Otherwise, or if the result cannot be determined, the exit value is 1 (false).
+__docker_is_experimental() {
+	[ "$(__docker_q version -f '{{.Server.Experimental}}')" = "true" ]
+}
+
 # __docker_pos_first_nonflag finds the position of the first word that is neither
 # option nor an option's argument. If there are options that require arguments,
 # you should pass a glob describing those options, e.g. "--option1|-o|--option2"
@@ -851,6 +858,7 @@ _docker_docker() {
 		*)
 			local counter=$( __docker_pos_first_nonflag "$(__docker_to_extglob "$global_options_with_args")" )
 			if [ $cword -eq $counter ]; then
+				__docker_is_experimental && commands+=(${experimental_commands[*]})
 				COMPREPLY=( $( compgen -W "${commands[*]} help" -- "$cur" ) )
 			fi
 			;;
@@ -3854,6 +3862,9 @@ _docker() {
 		version
 		volume
 		wait
+	)
+
+	local experimental_commands=(
 	)
 
 	# These options are valid as global options for all client commands

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1882,6 +1882,10 @@ _docker_daemon() {
 	esac
 }
 
+_docker_deploy() {
+	__docker_is_experimental && _docker_stack_deploy
+}
+
 _docker_diff() {
 	_docker_container_diff
 }
@@ -3865,6 +3869,7 @@ _docker() {
 	)
 
 	local experimental_commands=(
+		deploy
 	)
 
 	# These options are valid as global options for all client commands


### PR DESCRIPTION
#26713 redefined the role of experimental features. It now makes sense to support them in bash completion if the daemon is running in experimental mode.

So this PR does two things:
- adds a way to determine whether the current daemon is running in experimental mode
- selectively adds bash completion for the experimental `docker deploy` command

As both changes are small and tightly coupled, I put them in one PR.

Please schedule for 1.13.0.
Please merge quickly because bash completion for other experimental features will depend on this PR.
Ping @sdurrheimer PTAL at the selective activation of completion for experimental features. Perhaps you can reuse it in zsh completion.

**- A picture of a cute animal (not mandatory but encouraged)**
![Pferdinand](https://cloud.githubusercontent.com/assets/2901725/20832805/9d88ff70-b88c-11e6-9f69-db27996b6be9.jpg)

