### PR TITLE
Use DOCKER_BUILD_ARGS on manpages make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ install: ## install the linux binaries
 	KEEPBUNDLE=1 hack/make.sh install-binary
 
 manpages: ## Generate man pages from go source and markdown
-	docker build -t docker-manpage-dev -f "man/$(DOCKERFILE)" ./man
+	docker build ${DOCKER_BUILD_ARGS} -t docker-manpage-dev -f "man/$(DOCKERFILE)" ./man
 	docker run --rm \
 		-v $(PWD):/go/src/github.com/docker/docker/ \
 		docker-manpage-dev


### PR DESCRIPTION
Closes #29031.

This make it more consistent with the other image builds and allow to build manpages behind a proxy for example.

/cc @justincormack @thaJeztah @dnephin @lhsvobodaj

🐯

Signed-off-by: Vincent Demeester <vincent@sbr.pm>