### PR TITLE
Print checkpoint id when creating a checkpoint

### DIFF
--- a/cli/command/checkpoint/create.go
+++ b/cli/command/checkpoint/create.go
@@ -1,6 +1,8 @@
 package checkpoint
 
 import (
+	"fmt"
+
 	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
@@ -51,5 +53,6 @@ func runCreate(dockerCli *command.DockerCli, opts createOptions) error {
 		return err
 	}
 
+	fmt.Fprintf(dockerCli.Out(), "%s\n", opts.checkpoint)
 	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The checkpoint create command does not print the name (or ID) of the checkpoint that is created. This PR adds code that prints the checkpoint name if no errors were returned by the daemon. The checkpoint name is passed from the client at the time of running the command.

This PR addresses #28756.

**- How I did it**
I added a print statement in  cli/command/checkpoint/create.go. This only prints the checkpoint name if no errors were returned from the server.

**- How to verify it**
- Follow the docs on checkpoint/restore and the requirements for the feature to work.
- With the change in this PR, the checkpoint create command should now print the name of the checkpoint on success.
- In my tests, this is what worked:
        - Host OS: Ubuntu 16.04
        - Installed CRIU from source (www.criu.org/installation). Note: I made no Kernel modifications, and the checkpoint creation worked. Thanks @estesp for this hint.
         - Started the daemon with experimental features enabled: 'docker daemon --experimental -D &'
         - Started a container (alpine, with sleep command): 'docker run alpine sleep 999 &'
         - Created a checkpoint: docker checkpoint create <container-id-of-above-container> checkpoint1
         - The command output was 'checkpoint1', i.e. the checkpoint name I specified.

**- Description for the changelog**
Checkpoint create command now prints the name of the created checkpoint on success.



**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>