### PR TITLE
Fix missing IPAM options in swarm network mode

### DIFF
--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -566,7 +566,8 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 		// ID:     na.Network.ID,
 		Driver: na.Network.DriverState.Name,
 		IPAM: &network.IPAM{
-			Driver: na.Network.IPAM.Driver.Name,
+			Driver:  na.Network.IPAM.Driver.Name,
+			Options: na.Network.IPAM.Driver.Options,
 		},
 		Options:        na.Network.DriverState.Options,
 		Labels:         na.Network.Spec.Annotations.Labels,


### PR DESCRIPTION
**- What I did**

This fix tries to fix the issue raised in #29044 where the IPAM options is missing in swarm network mode after the service is deployed. Before the service is deployed, the IPAM options is available.

The reason for the issue is that, before service is deployed, `network inspect` is querying the swarm and obtained the correct information. However, after service is deployed, swarm executor does not pass the IPAM options to the backend (daemon). Also after service is deployed, `network inspect` is actually querying the local daemon for information. At this time the network information with missing IPAM options is returned.

**- How I did it**

This fix fixes the issue by updating the swarm network allocator and swarm executor.

A separate PR for swarmkit has been opened:
https://github.com/docker/swarmkit/pull/1789

**- How to verify it**

An integration test has been added to cover the change.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![5ca7eb58dbc36790da75912f7d46e5be](https://cloud.githubusercontent.com/assets/6932348/20841662/7a138326-b869-11e6-9fb6-f4aa69d85f7c.jpg)


This fix fixes #29044.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>