### PR TITLE
add selinux policy for centos-7

### DIFF
--- a/contrib/builder/rpm/amd64/centos-7/Dockerfile
+++ b/contrib/builder/rpm/amd64/centos-7/Dockerfile
@@ -7,6 +7,7 @@ FROM centos:7
 RUN yum groupinstall -y "Development Tools"
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
 RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
+RUN [ `rpm -q selinux-policy-devel | grep el7_3` ] || yum -y --enablerepo=cr install selinux-policy-devel
 
 ENV GO_VERSION 1.7.3
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/rpm/amd64/generate.sh
+++ b/contrib/builder/rpm/amd64/generate.sh
@@ -142,6 +142,10 @@ for version in "${versions[@]}"; do
 			packages=( "${packages[@]/pkgconfig/pkg-config}" )
 			echo "RUN ${installer} install -y ${packages[*]}" >> "$version/Dockerfile"
 			;;
+		centos:7)
+			echo "RUN ${installer} install -y ${packages[*]}" >> "$version/Dockerfile"
+			echo 'RUN [ `rpm -q selinux-policy-devel | grep el7_3` ] || yum -y --enablerepo=cr install selinux-policy-devel' >> "$version/Dockerfile"
+			;;
 		*)
 			echo "RUN ${installer} install -y ${packages[*]}" >> "$version/Dockerfile"
 			;;

--- a/contrib/selinux-centos-7/docker-engine-selinux/LICENSE
+++ b/contrib/selinux-centos-7/docker-engine-selinux/LICENSE
@@ -1,0 +1,339 @@
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/contrib/selinux-centos-7/docker-engine-selinux/Makefile
+++ b/contrib/selinux-centos-7/docker-engine-selinux/Makefile
@@ -1,0 +1,27 @@
+TARGETS?=docker
+MODULES?=${TARGETS:=.pp.bz2}
+SHAREDIR?=/usr/share
+
+all: ${TARGETS:=.pp.bz2}
+
+%.pp.bz2: %.pp
+	@echo Compressing $^ -\> $@
+	bzip2 -9 $^
+
+%.pp: %.te
+	make -f ${SHAREDIR}/selinux/devel/Makefile $@
+
+clean:
+	rm -f *~  *.tc *.pp *.pp.bz2
+	rm -rf tmp *.tar.gz
+
+man: install-policy
+	sepolicy manpage --path . --domain ${TARGETS}_t
+
+install-policy: all
+	semodule -i ${TARGETS}.pp.bz2
+
+install: man
+	install -D -m 644 ${TARGETS}.pp.bz2 ${DESTDIR}${SHAREDIR}/selinux/packages/docker.pp.bz2
+	install -D -m 644 docker.if ${DESTDIR}${SHAREDIR}/selinux/devel/include/services/docker.if
+	install -D -m 644 docker_selinux.8 ${DESTDIR}${SHAREDIR}/man/man8/

--- a/contrib/selinux-centos-7/docker-engine-selinux/README.md
+++ b/contrib/selinux-centos-7/docker-engine-selinux/README.md
@@ -1,0 +1,1 @@
+SELinux policy for docker

--- a/contrib/selinux-centos-7/docker-engine-selinux/docker.fc
+++ b/contrib/selinux-centos-7/docker-engine-selinux/docker.fc
@@ -1,0 +1,42 @@
+/root/\.docker	gen_context(system_u:object_r:docker_home_t,s0)
+
+/usr/libexec/docker/docker.*	--	gen_context(system_u:object_r:docker_exec_t,s0)
+/usr/bin/docker.*		--	gen_context(system_u:object_r:docker_exec_t,s0)
+/usr/bin/docker-latest			--	gen_context(system_u:object_r:docker_exec_t,s0)
+/usr/bin/docker-current			--	gen_context(system_u:object_r:docker_exec_t,s0)
+/usr/bin/docker-novolume-plugin		--	gen_context(system_u:object_r:docker_auth_exec_t,s0)
+/usr/lib/docker/docker-novolume-plugin	--	gen_context(system_u:object_r:docker_auth_exec_t,s0)
+
+/usr/lib/systemd/system/docker.*		--	gen_context(system_u:object_r:docker_unit_file_t,s0)
+
+/etc/docker(/.*)?		gen_context(system_u:object_r:docker_config_t,s0)
+/etc/docker-latest(/.*)?		gen_context(system_u:object_r:docker_config_t,s0)
+
+/var/lib/docker(/.*)?		gen_context(system_u:object_r:docker_var_lib_t,s0)
+/var/lib/docker/overlay(/.*)?	gen_context(system_u:object_r:docker_share_t,s0)
+
+/var/lib/docker/init(/.*)?		gen_context(system_u:object_r:docker_share_t,s0)
+/var/lib/docker-latest/init(/.*)?		gen_context(system_u:object_r:docker_share_t,s0)
+
+/var/lib/docker/containers/.*/hosts		gen_context(system_u:object_r:docker_share_t,s0)
+/var/lib/docker-latest/containers/.*/hosts		gen_context(system_u:object_r:docker_share_t,s0)
+
+/var/lib/docker/containers/.*/hostname		gen_context(system_u:object_r:docker_share_t,s0)
+/var/lib/docker-latest/containers/.*/hostname		gen_context(system_u:object_r:docker_share_t,s0)
+
+/var/lib/docker/containers/.*/.*\.log		gen_context(system_u:object_r:docker_log_t,s0)
+/var/lib/docker-latest/containers/.*/.*\.log	gen_context(system_u:object_r:docker_log_t,s0)
+
+/var/lib/docker/.*/config\.env	gen_context(system_u:object_r:docker_share_t,s0)
+/var/lib/docker-latest/.*/config\.env	gen_context(system_u:object_r:docker_share_t,s0)
+
+/var/run/docker(/.*)?		gen_context(system_u:object_r:docker_var_run_t,s0)
+/var/run/containerd(/.*)?	gen_context(system_u:object_r:docker_var_run_t,s0)
+/var/run/docker\.pid		--	gen_context(system_u:object_r:docker_var_run_t,s0)
+/var/run/docker\.sock		-s	gen_context(system_u:object_r:docker_var_run_t,s0)
+/var/run/docker-client(/.*)?		gen_context(system_u:object_r:docker_var_run_t,s0)
+/var/run/docker/plugins(/.*)?		gen_context(system_u:object_r:docker_plugin_var_run_t,s0)
+
+/var/lock/lxc(/.*)?		gen_context(system_u:object_r:docker_lock_t,s0)
+
+/var/log/lxc(/.*)?		gen_context(system_u:object_r:docker_log_t,s0)

--- a/contrib/selinux-centos-7/docker-engine-selinux/docker.if
+++ b/contrib/selinux-centos-7/docker-engine-selinux/docker.if
@@ -1,0 +1,523 @@
+
+## <summary>The open-source application container engine.</summary>
+
+########################################
+## <summary>
+##	Execute docker in the docker domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`docker_domtrans',`
+	gen_require(`
+		type docker_t, docker_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, docker_exec_t, docker_t)
+')
+
+########################################
+## <summary>
+##	Execute docker in the caller domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`docker_exec',`
+	gen_require(`
+		type docker_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, docker_exec_t)
+')
+
+########################################
+## <summary>
+##	Search docker lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_search_lib',`
+	gen_require(`
+		type docker_var_lib_t;
+	')
+
+	allow $1 docker_var_lib_t:dir search_dir_perms;
+	files_search_var_lib($1)
+')
+
+########################################
+## <summary>
+##	Execute docker lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_exec_lib',`
+	gen_require(`
+		type docker_var_lib_t;
+	')
+
+	allow $1 docker_var_lib_t:dir search_dir_perms;
+	can_exec($1, docker_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Read docker lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_read_lib_files',`
+	gen_require(`
+		type docker_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	read_files_pattern($1, docker_var_lib_t, docker_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Read docker share files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_read_share_files',`
+	gen_require(`
+		type docker_share_t;
+	')
+
+	files_search_var_lib($1)
+	list_dirs_pattern($1, docker_share_t, docker_share_t)
+	read_files_pattern($1, docker_share_t, docker_share_t)
+	read_lnk_files_pattern($1, docker_share_t, docker_share_t)
+')
+
+######################################
+## <summary>
+##	Allow the specified domain to execute apache
+##	in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`apache_exec',`
+	gen_require(`
+		type httpd_exec_t;
+	')
+
+	can_exec($1, httpd_exec_t)
+')
+
+######################################
+## <summary>
+##	Allow the specified domain to execute docker shared files
+##	in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_exec_share_files',`
+	gen_require(`
+		type docker_share_t;
+	')
+
+	can_exec($1, docker_share_t)
+')
+
+########################################
+## <summary>
+##	Manage docker lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_manage_lib_files',`
+	gen_require(`
+		type docker_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_files_pattern($1, docker_var_lib_t, docker_var_lib_t)
+	manage_lnk_files_pattern($1, docker_var_lib_t, docker_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Manage docker lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_manage_lib_dirs',`
+	gen_require(`
+		type docker_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_dirs_pattern($1, docker_var_lib_t, docker_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Create objects in a docker var lib directory
+##	with an automatic type transition to
+##	a specified private type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="private_type">
+##	<summary>
+##	The type of the object to create.
+##	</summary>
+## </param>
+## <param name="object_class">
+##	<summary>
+##	The class of the object to be created.
+##	</summary>
+## </param>
+## <param name="name" optional="true">
+##	<summary>
+##	The name of the object being created.
+##	</summary>
+## </param>
+#
+interface(`docker_lib_filetrans',`
+	gen_require(`
+		type docker_var_lib_t;
+	')
+
+	filetrans_pattern($1, docker_var_lib_t, $2, $3, $4)
+')
+
+########################################
+## <summary>
+##	Read docker PID files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_read_pid_files',`
+	gen_require(`
+		type docker_var_run_t;
+	')
+
+	files_search_pids($1)
+	read_files_pattern($1, docker_var_run_t, docker_var_run_t)
+')
+
+########################################
+## <summary>
+##	Execute docker server in the docker domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`docker_systemctl',`
+	gen_require(`
+		type docker_t;
+		type docker_unit_file_t;
+	')
+
+	systemd_exec_systemctl($1)
+	init_reload_services($1)
+        systemd_read_fifo_file_passwd_run($1)
+	allow $1 docker_unit_file_t:file read_file_perms;
+	allow $1 docker_unit_file_t:service manage_service_perms;
+
+	ps_process_pattern($1, docker_t)
+')
+
+########################################
+## <summary>
+##	Read and write docker shared memory.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_rw_sem',`
+	gen_require(`
+		type docker_t;
+	')
+
+	allow $1 docker_t:sem rw_sem_perms;
+')
+
+#######################################
+## <summary>
+##  Read and write the docker pty type.
+## </summary>
+## <param name="domain">
+##  <summary>
+##  Domain allowed access.
+##  </summary>
+## </param>
+#
+interface(`docker_use_ptys',`
+    gen_require(`
+        type docker_devpts_t;
+    ')
+
+    allow $1 docker_devpts_t:chr_file rw_term_perms;
+')
+
+#######################################
+## <summary>
+##      Allow domain to create docker content
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`docker_filetrans_named_content',`
+
+    gen_require(`
+        type docker_var_lib_t;
+        type docker_share_t;
+    	type docker_log_t;
+	    type docker_var_run_t;
+        type docker_home_t;
+    ')
+
+    files_pid_filetrans($1, docker_var_run_t, file, "docker.pid")
+    files_pid_filetrans($1, docker_var_run_t, sock_file, "docker.sock")
+    files_pid_filetrans($1, docker_var_run_t, dir, "docker-client")
+    logging_log_filetrans($1, docker_log_t, dir, "lxc")
+    files_var_lib_filetrans($1, docker_var_lib_t, dir, "docker")
+    filetrans_pattern($1, docker_var_lib_t, docker_share_t, file, "config.env")
+    filetrans_pattern($1, docker_var_lib_t, docker_share_t, file, "hosts")
+    filetrans_pattern($1, docker_var_lib_t, docker_share_t, file, "hostname")
+    filetrans_pattern($1, docker_var_lib_t, docker_share_t, file, "resolv.conf")
+    filetrans_pattern($1, docker_var_lib_t, docker_share_t, dir, "init")
+    userdom_admin_home_dir_filetrans($1, docker_home_t, dir, ".docker")
+')
+
+########################################
+## <summary>
+##	Connect to docker over a unix stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_stream_connect',`
+	gen_require(`
+		type docker_t, docker_var_run_t;
+	')
+
+	files_search_pids($1)
+	stream_connect_pattern($1, docker_var_run_t, docker_var_run_t, docker_t)
+')
+
+########################################
+## <summary>
+##	Connect to SPC containers over a unix stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_spc_stream_connect',`
+	gen_require(`
+		type spc_t, spc_var_run_t;
+	')
+
+	files_search_pids($1)
+	files_write_all_pid_sockets($1)
+	allow $1 spc_t:unix_stream_socket connectto;
+')
+
+########################################
+## <summary>
+##	All of the rules required to administrate
+##	an docker environment
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_admin',`
+	gen_require(`
+		type docker_t;
+		type docker_var_lib_t, docker_var_run_t;
+		type docker_unit_file_t;
+		type docker_lock_t;
+		type docker_log_t;
+		type docker_config_t;
+	')
+
+	allow $1 docker_t:process { ptrace signal_perms };
+	ps_process_pattern($1, docker_t)
+
+	admin_pattern($1, docker_config_t)
+
+	files_search_var_lib($1)
+	admin_pattern($1, docker_var_lib_t)
+
+	files_search_pids($1)
+	admin_pattern($1, docker_var_run_t)
+
+	files_search_locks($1)
+	admin_pattern($1, docker_lock_t)
+
+	logging_search_logs($1)
+	admin_pattern($1, docker_log_t)
+
+	docker_systemctl($1)
+	admin_pattern($1, docker_unit_file_t)
+	allow $1 docker_unit_file_t:service all_service_perms;
+
+	optional_policy(`
+		systemd_passwd_agent_exec($1)
+		systemd_read_fifo_file_passwd_run($1)
+	')
+')
+
+########################################
+## <summary>
+##	Execute docker_auth_exec_t in the docker_auth domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`docker_auth_domtrans',`
+	gen_require(`
+		type docker_auth_t, docker_auth_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, docker_auth_exec_t, docker_auth_t)
+')
+
+######################################
+## <summary>
+##	Execute docker_auth in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_auth_exec',`
+	gen_require(`
+		type docker_auth_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, docker_auth_exec_t)
+')
+
+########################################
+## <summary>
+##	Connect to docker_auth over a unix stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_auth_stream_connect',`
+	gen_require(`
+		type docker_auth_t, docker_plugin_var_run_t;
+	')
+
+	files_search_pids($1)
+	stream_connect_pattern($1, docker_plugin_var_run_t, docker_plugin_var_run_t, docker_auth_t)
+')
+
+########################################
+## <summary>
+##	docker domain typebounds calling domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain to be typebound.
+## </summary>
+## </param>
+#
+interface(`docker_typebounds',`
+	gen_require(`
+		type docker_t;
+	')
+
+	typebounds docker_t $1;
+')
+
+########################################
+## <summary>
+##	Allow any docker_exec_t to be an entrypoint of this domain
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`docker_entrypoint',`
+	gen_require(`
+		type docker_exec_t;
+	')
+	allow $1 docker_exec_t:file entrypoint;
+')

--- a/contrib/selinux-centos-7/docker-engine-selinux/docker.te
+++ b/contrib/selinux-centos-7/docker-engine-selinux/docker.te
@@ -420,3 +420,6 @@ files_read_etc_files(docker_auth_t)
 miscfiles_read_localization(docker_auth_t)
 
 sysnet_dns_name_resolve(docker_auth_t)
+
+kernel_unlabeled_domtrans(docker_t, spc_t)
+kernel_unlabeled_entry_type(spc_t)

--- a/contrib/selinux-centos-7/docker-engine-selinux/docker.te
+++ b/contrib/selinux-centos-7/docker-engine-selinux/docker.te
@@ -1,0 +1,422 @@
+policy_module(docker, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+## <desc>
+##  <p>
+##  Determine whether docker can
+##  connect to all TCP ports.
+##  </p>
+## </desc>
+gen_tunable(docker_connect_any, false)
+
+type docker_t;
+type docker_exec_t;
+init_daemon_domain(docker_t, docker_exec_t)
+domain_subj_id_change_exemption(docker_t)
+domain_role_change_exemption(docker_t)
+
+type spc_t;
+domain_type(spc_t)
+role system_r types spc_t;
+
+type docker_auth_t;
+type docker_auth_exec_t;
+init_daemon_domain(docker_auth_t, docker_auth_exec_t)
+
+type spc_var_run_t;
+files_pid_file(spc_var_run_t)
+
+type docker_var_lib_t;
+files_type(docker_var_lib_t)
+
+type docker_home_t;
+userdom_user_home_content(docker_home_t)
+
+type docker_config_t;
+files_config_file(docker_config_t)
+
+type docker_lock_t;
+files_lock_file(docker_lock_t)
+
+type docker_log_t;
+logging_log_file(docker_log_t)
+
+type docker_tmp_t;
+files_tmp_file(docker_tmp_t)
+
+type docker_tmpfs_t;
+files_tmpfs_file(docker_tmpfs_t)
+
+type docker_var_run_t;
+files_pid_file(docker_var_run_t)
+
+type docker_plugin_var_run_t;
+files_pid_file(docker_plugin_var_run_t)
+
+type docker_unit_file_t;
+systemd_unit_file(docker_unit_file_t)
+
+type docker_devpts_t;
+term_pty(docker_devpts_t)
+
+type docker_share_t;
+files_mountpoint(docker_share_t)
+
+type docker_port_t;
+corenet_port(docker_port_t)
+
+########################################
+#
+# docker local policy
+#
+allow docker_t self:capability { chown kill fowner fsetid mknod net_admin net_bind_service net_raw setfcap };
+allow docker_t self:tun_socket relabelto;
+allow docker_t self:process { getattr signal_perms setrlimit setfscreate };
+allow docker_t self:fifo_file rw_fifo_file_perms;
+allow docker_t self:unix_stream_socket create_stream_socket_perms;
+allow docker_t self:tcp_socket create_stream_socket_perms;
+allow docker_t self:udp_socket create_socket_perms;
+allow docker_t self:capability2 block_suspend;
+allow docker_t docker_port_t:tcp_socket name_bind;
+
+docker_auth_stream_connect(docker_t)
+
+manage_files_pattern(docker_t, docker_home_t, docker_home_t)
+manage_dirs_pattern(docker_t, docker_home_t, docker_home_t)
+manage_lnk_files_pattern(docker_t, docker_home_t, docker_home_t)
+userdom_admin_home_dir_filetrans(docker_t, docker_home_t, dir, ".docker")
+
+manage_dirs_pattern(docker_t, docker_config_t, docker_config_t)
+manage_files_pattern(docker_t, docker_config_t, docker_config_t)
+files_etc_filetrans(docker_t, docker_config_t, dir, "docker")
+
+manage_dirs_pattern(docker_t, docker_lock_t, docker_lock_t)
+manage_files_pattern(docker_t, docker_lock_t, docker_lock_t)
+files_lock_filetrans(docker_t, docker_lock_t, { dir file }, "lxc")
+
+manage_dirs_pattern(docker_t, docker_log_t, docker_log_t)
+manage_files_pattern(docker_t, docker_log_t, docker_log_t)
+manage_lnk_files_pattern(docker_t, docker_log_t, docker_log_t)
+logging_log_filetrans(docker_t, docker_log_t, { dir file lnk_file })
+allow docker_t docker_log_t:dir_file_class_set { relabelfrom relabelto };
+filetrans_pattern(docker_t, docker_var_lib_t, docker_log_t, file, "container-json.log")
+
+manage_dirs_pattern(docker_t, docker_tmp_t, docker_tmp_t)
+manage_files_pattern(docker_t, docker_tmp_t, docker_tmp_t)
+manage_lnk_files_pattern(docker_t, docker_tmp_t, docker_tmp_t)
+files_tmp_filetrans(docker_t, docker_tmp_t, { dir file lnk_file })
+
+manage_dirs_pattern(docker_t, docker_tmpfs_t, docker_tmpfs_t)
+manage_files_pattern(docker_t, docker_tmpfs_t, docker_tmpfs_t)
+manage_lnk_files_pattern(docker_t, docker_tmpfs_t, docker_tmpfs_t)
+manage_fifo_files_pattern(docker_t, docker_tmpfs_t, docker_tmpfs_t)
+manage_chr_files_pattern(docker_t, docker_tmpfs_t, docker_tmpfs_t)
+manage_blk_files_pattern(docker_t, docker_tmpfs_t, docker_tmpfs_t)
+allow docker_t docker_tmpfs_t:dir relabelfrom;
+can_exec(docker_t, docker_tmpfs_t)
+fs_tmpfs_filetrans(docker_t, docker_tmpfs_t, { dir file })
+allow docker_t docker_tmpfs_t:chr_file mounton;
+
+manage_dirs_pattern(docker_t, docker_share_t, docker_share_t)
+manage_chr_files_pattern(docker_t, docker_share_t, docker_share_t)
+manage_blk_files_pattern(docker_t, docker_share_t, docker_share_t)
+manage_files_pattern(docker_t, docker_share_t, docker_share_t)
+manage_lnk_files_pattern(docker_t, docker_share_t, docker_share_t)
+allow docker_t docker_share_t:dir_file_class_set { relabelfrom relabelto };
+can_exec(docker_t, docker_share_t)
+filetrans_pattern(docker_t, docker_var_lib_t, docker_share_t, dir, "overlay")
+
+#docker_filetrans_named_content(docker_t)
+
+manage_dirs_pattern(docker_t, docker_var_lib_t, docker_var_lib_t)
+manage_files_pattern(docker_t, docker_var_lib_t, docker_var_lib_t)
+manage_chr_files_pattern(docker_t, docker_var_lib_t, docker_var_lib_t)
+manage_blk_files_pattern(docker_t, docker_var_lib_t, docker_var_lib_t)
+manage_sock_files_pattern(docker_t, docker_var_lib_t, docker_var_lib_t)
+manage_lnk_files_pattern(docker_t, docker_var_lib_t, docker_var_lib_t)
+allow docker_t docker_var_lib_t:dir_file_class_set { relabelfrom relabelto };
+files_var_lib_filetrans(docker_t, docker_var_lib_t, { dir file lnk_file })
+
+manage_dirs_pattern(docker_t, docker_var_run_t, docker_var_run_t)
+manage_files_pattern(docker_t, docker_var_run_t, docker_var_run_t)
+manage_fifo_files_pattern(docker_t, docker_var_run_t, docker_var_run_t)
+manage_sock_files_pattern(docker_t, docker_var_run_t, docker_var_run_t)
+manage_lnk_files_pattern(docker_t, docker_var_run_t, docker_var_run_t)
+files_pid_filetrans(docker_t, docker_var_run_t, { dir file lnk_file sock_file })
+
+allow docker_t docker_devpts_t:chr_file { relabelfrom rw_chr_file_perms setattr_chr_file_perms };
+term_create_pty(docker_t, docker_devpts_t)
+
+kernel_read_system_state(docker_t)
+kernel_read_network_state(docker_t)
+kernel_read_all_sysctls(docker_t)
+kernel_rw_net_sysctls(docker_t)
+kernel_setsched(docker_t)
+kernel_read_all_proc(docker_t)
+
+domain_use_interactive_fds(docker_t)
+domain_dontaudit_read_all_domains_state(docker_t)
+
+corecmd_exec_bin(docker_t)
+corecmd_exec_shell(docker_t)
+
+corenet_tcp_bind_generic_node(docker_t)
+corenet_tcp_sendrecv_generic_if(docker_t)
+corenet_tcp_sendrecv_generic_node(docker_t)
+corenet_tcp_sendrecv_generic_port(docker_t)
+corenet_tcp_bind_all_ports(docker_t)
+corenet_tcp_connect_http_port(docker_t)
+corenet_tcp_connect_commplex_main_port(docker_t)
+corenet_udp_sendrecv_generic_if(docker_t)
+corenet_udp_sendrecv_generic_node(docker_t)
+corenet_udp_sendrecv_all_ports(docker_t)
+corenet_udp_bind_generic_node(docker_t)
+corenet_udp_bind_all_ports(docker_t)
+
+files_read_config_files(docker_t)
+files_dontaudit_getattr_all_dirs(docker_t)
+files_dontaudit_getattr_all_files(docker_t)
+
+fs_read_cgroup_files(docker_t)
+fs_read_tmpfs_symlinks(docker_t)
+fs_search_all(docker_t)
+fs_getattr_all_fs(docker_t)
+
+storage_raw_rw_fixed_disk(docker_t)
+
+auth_use_nsswitch(docker_t)
+auth_dontaudit_getattr_shadow(docker_t)
+
+init_read_state(docker_t)
+init_status(docker_t)
+
+logging_send_audit_msgs(docker_t)
+logging_send_syslog_msg(docker_t)
+
+miscfiles_read_localization(docker_t)
+
+mount_domtrans(docker_t)
+
+seutil_read_default_contexts(docker_t)
+seutil_read_config(docker_t)
+
+sysnet_dns_name_resolve(docker_t)
+sysnet_exec_ifconfig(docker_t)
+
+optional_policy(`
+	rpm_exec(docker_t)
+	rpm_read_db(docker_t)
+	rpm_exec(docker_t)
+')
+
+optional_policy(`
+	fstools_domtrans(docker_t)
+')
+
+optional_policy(`
+	iptables_domtrans(docker_t)
+')
+
+optional_policy(`
+	openvswitch_stream_connect(docker_t)
+')
+
+#
+# lxc rules
+#
+
+allow docker_t self:capability { dac_override setgid setpcap setuid sys_admin sys_boot sys_chroot sys_ptrace };
+
+allow docker_t self:process { getcap setcap setexec setpgid setsched signal_perms };
+
+allow docker_t self:netlink_route_socket rw_netlink_socket_perms;;
+allow docker_t self:netlink_audit_socket create_netlink_socket_perms;
+allow docker_t self:unix_dgram_socket { create_socket_perms sendto };
+allow docker_t self:unix_stream_socket { create_stream_socket_perms connectto };
+
+allow docker_t docker_var_lib_t:dir mounton;
+allow docker_t docker_var_lib_t:chr_file mounton;
+can_exec(docker_t, docker_var_lib_t)
+
+kernel_dontaudit_setsched(docker_t)
+kernel_get_sysvipc_info(docker_t)
+kernel_request_load_module(docker_t)
+kernel_mounton_messages(docker_t)
+kernel_mounton_all_proc(docker_t)
+kernel_mounton_all_sysctls(docker_t)
+
+dev_getattr_all(docker_t)
+dev_getattr_sysfs_fs(docker_t)
+dev_read_urand(docker_t)
+dev_read_lvm_control(docker_t)
+dev_rw_sysfs(docker_t)
+dev_rw_loop_control(docker_t)
+dev_rw_lvm_control(docker_t)
+
+files_getattr_isid_type_dirs(docker_t)
+files_manage_isid_type_dirs(docker_t)
+files_manage_isid_type_files(docker_t)
+files_manage_isid_type_symlinks(docker_t)
+files_manage_isid_type_chr_files(docker_t)
+files_manage_isid_type_blk_files(docker_t)
+files_exec_isid_files(docker_t)
+files_mounton_isid(docker_t)
+files_mounton_non_security(docker_t)
+files_mounton_isid_type_chr_file(docker_t)
+
+fs_mount_all_fs(docker_t)
+fs_unmount_all_fs(docker_t)
+fs_remount_all_fs(docker_t)
+files_mounton_isid(docker_t)
+fs_manage_cgroup_dirs(docker_t)
+fs_manage_cgroup_files(docker_t)
+#fs_rw_nsfs_files(docker_t)
+# TODO Remove This block
+#########################
+gen_require(`
+	type nsfs_t;
+')
+rw_files_pattern(docker_t, nsfs_t, nsfs_t)
+fs_relabelfrom_xattr_fs(docker_t)
+fs_relabelfrom_tmpfs(docker_t)
+fs_read_tmpfs_symlinks(docker_t)
+fs_list_hugetlbfs(docker_t)
+
+term_use_generic_ptys(docker_t)
+term_use_ptmx(docker_t)
+term_getattr_pty_fs(docker_t)
+term_relabel_pty_fs(docker_t)
+term_mounton_unallocated_ttys(docker_t)
+
+modutils_domtrans_insmod(docker_t)
+
+systemd_status_all_unit_files(docker_t)
+systemd_start_systemd_services(docker_t)
+
+userdom_stream_connect(docker_t)
+userdom_search_user_home_content(docker_t)
+userdom_read_all_users_state(docker_t)
+userdom_relabel_user_home_files(docker_t)
+userdom_relabel_user_tmp_files(docker_t)
+userdom_relabel_user_tmp_dirs(docker_t)
+
+optional_policy(`
+	gpm_getattr_gpmctl(docker_t)
+')
+
+optional_policy(`
+	dbus_system_bus_client(docker_t)
+	init_dbus_chat(docker_t)
+	init_start_transient_unit(docker_t)
+
+	optional_policy(`
+		systemd_dbus_chat_logind(docker_t)
+		systemd_dbus_chat_machined(docker_t)
+	')
+
+	optional_policy(`
+		firewalld_dbus_chat(docker_t)
+	')
+')
+
+optional_policy(`
+	lvm_domtrans(docker_t)
+')
+
+optional_policy(`
+	udev_read_db(docker_t)
+')
+
+optional_policy(`
+	unconfined_domain(docker_t)
+#	unconfined_typebounds(docker_t)
+')
+
+optional_policy(`
+	virt_read_config(docker_t)
+	virt_exec(docker_t)
+	virt_stream_connect(docker_t)
+	virt_stream_connect_sandbox(docker_t)
+	virt_exec_sandbox_files(docker_t)
+	virt_manage_sandbox_files(docker_t)
+	virt_relabel_sandbox_filesystem(docker_t)
+	# for lxc
+	virt_transition_svirt_sandbox(docker_t, system_r)
+	allow svirt_sandbox_domain docker_t:fd use;
+	virt_mounton_sandbox_file(docker_t)
+#	virt_attach_sandbox_tun_iface(docker_t)
+	allow docker_t svirt_sandbox_domain:tun_socket relabelfrom;
+	virt_sandbox_entrypoint(docker_t)	
+')
+
+tunable_policy(`docker_connect_any',`
+    corenet_tcp_connect_all_ports(docker_t)
+    corenet_sendrecv_all_packets(docker_t)
+    corenet_tcp_sendrecv_all_ports(docker_t)
+')
+
+########################################
+#
+# spc local policy
+#
+allow spc_t { docker_var_lib_t docker_share_t }:file entrypoint;
+role system_r types spc_t;
+
+domtrans_pattern(docker_t, docker_share_t, spc_t)
+domtrans_pattern(docker_t, docker_var_lib_t, spc_t)
+allow docker_t spc_t:process { setsched signal_perms };
+ps_process_pattern(docker_t, spc_t)
+allow docker_t spc_t:socket_class_set { relabelto relabelfrom };
+
+optional_policy(`
+	systemd_dbus_chat_machined(spc_t)
+	systemd_dbus_chat_logind(spc_t)
+')
+
+optional_policy(`
+	dbus_chat_system_bus(spc_t)
+	dbus_chat_session_bus(spc_t)
+')
+
+optional_policy(`
+	unconfined_domain_noaudit(spc_t)
+')
+
+optional_policy(`
+	virt_stub_svirt_sandbox_file()
+	virt_transition_svirt_sandbox(spc_t, system_r)
+	virt_sandbox_entrypoint(spc_t)
+	domtrans_pattern(docker_t,svirt_sandbox_file_t, spc_t)
+')
+
+########################################
+#
+# docker_auth local policy
+#
+allow docker_auth_t self:fifo_file rw_fifo_file_perms;
+allow docker_auth_t self:unix_stream_socket create_stream_socket_perms;
+dontaudit docker_auth_t self:capability net_admin;
+
+docker_stream_connect(docker_auth_t)
+
+manage_dirs_pattern(docker_auth_t, docker_plugin_var_run_t, docker_plugin_var_run_t)
+manage_files_pattern(docker_auth_t, docker_plugin_var_run_t, docker_plugin_var_run_t)
+manage_sock_files_pattern(docker_auth_t, docker_plugin_var_run_t, docker_plugin_var_run_t)
+manage_lnk_files_pattern(docker_auth_t, docker_plugin_var_run_t, docker_plugin_var_run_t)
+files_pid_filetrans(docker_auth_t, docker_plugin_var_run_t, { dir file lnk_file sock_file })
+
+domain_use_interactive_fds(docker_auth_t)
+
+kernel_read_net_sysctls(docker_auth_t)
+
+auth_use_nsswitch(docker_auth_t)
+
+files_read_etc_files(docker_auth_t)
+
+miscfiles_read_localization(docker_auth_t)
+
+sysnet_dns_name_resolve(docker_auth_t)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added selinux policy for centos-7. Fixes issue #28406.

**- How I did it**

Sync with latest selinux policy for RHEL7 which is in RHEL RPM `docker-selinux-1.10.3-57.el7.x86_64` because that policy works on RHEL7.3.

I downloaded the SRPM on an Amazon EC2 instance of RHEL7:
```
$ sudo yumdownloader --enablerepo='*' --source docker-1.10.3-57.el7
```

And then cracked it open to get to the `docker.spec` file:
```
$ rpm2cpio docker-1.10.3-57.el7.src.rpm | cpio -idmv
```

Found the selinux policy is using lsm5/container-selinux@583a67ffdf9eef9afc233ace0f841d5eeef28fb3.

I use PR #25334 for reference in constructing this PR.

**- How to verify it**

Build a docker-engine-selinux centos-7 RPM package and install on RHEL7.3 with selinux enabled:
```
$ make DOCKER_BUILD_PKGS=centos-7 rpm
```

Should also make sure this works on CentOS7.2 with selinux enabled because CentOS7.3 is not released yet.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Update selinux policy for distros based on RHEL7.3.

**- A picture of a cute animal (not mandatory but encouraged)**

🐰 

Signed-off-by: Andrew Hsu <andrewhsu@docker.com>