### PR TITLE
Fix issue where volume metadata was not removed

### DIFF
--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -109,6 +109,13 @@ func (s *VolumeStore) purge(name string) {
 	delete(s.names, name)
 	delete(s.refs, name)
 	delete(s.labels, name)
+	err := s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(volumeBucketName))
+		return b.Delete([]byte(name))
+	})
+	if err != nil {
+		logrus.Errorf("Error removing volume metadata: %v", err)
+	}
 	s.globalLock.Unlock()
 }
 

--- a/volume/store/store_test.go
+++ b/volume/store/store_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"errors"
+	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -43,7 +45,13 @@ func TestRemove(t *testing.T) {
 	volumedrivers.Register(vt.NewFakeDriver("noop"), "noop")
 	defer volumedrivers.Unregister("fake")
 	defer volumedrivers.Unregister("noop")
-	s, err := New("")
+	dir, err := ioutil.TempDir("", "test-remove")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	s, err := New(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,7 +188,13 @@ func TestFilterByUsed(t *testing.T) {
 func TestDerefMultipleOfSameRef(t *testing.T) {
 	volumedrivers.Register(vt.NewFakeDriver("fake"), "fake")
 
-	s, err := New("")
+	dir, err := ioutil.TempDir("", "deref-multi-same-ref")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	s, err := New(dir)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Basically, we create some on-disk metadata about the volume to store
things like volume labels.
This was never being cleaned up when the volume is removed.

ping @vieux 