### PR TITLE
Add support for running builds within an QEMU emulation

### DIFF
--- a/hack/make/.detect-daemon-osarch
+++ b/hack/make/.detect-daemon-osarch
@@ -19,7 +19,7 @@ docker-version-osarch() {
 }
 
 # Retrieve OS/ARCH of docker daemon, e.g. linux/amd64
-export DOCKER_ENGINE_OSARCH="$(docker-version-osarch 'Server')"
+export DOCKER_ENGINE_OSARCH="${DOCKER_ENGINE_OSARCH:=$(docker-version-osarch 'Server')}"
 export DOCKER_ENGINE_GOOS="${DOCKER_ENGINE_OSARCH%/*}"
 export DOCKER_ENGINE_GOARCH="${DOCKER_ENGINE_OSARCH##*/}"
 DOCKER_ENGINE_GOARCH=${DOCKER_ENGINE_GOARCH:=amd64}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add support for QEMU, enable building ARM/ARM64 binaries on Intel build machines 

**- What I did**
Add feature to overwrite the build target arch `DOCKER_ENGINE_OSARCH=`, so we can easily build binaries for a CPU architecture which is different from the arch the Docker Engine is running on. Assuming that the Docker host is enabled with QEMU binfmt kernel module to build binaries for the requested arch.

**- How I did it**
Enable to use the optional ENV variable `DOCKER_ENGINE_OSARCH` which represents the target arch (in GOARCH syntax, like `linux/arm64`) to force the build for a specific arch.

**- How to verify it / Prerequisites**
It's important that the Docker host where is build is running has to meet some basic requirements and is enabled to run QEMU. Testing is done on a Mac running Docker4Mac (Beta31 or later) which has a Linux kernel 4.8.x running. The new QEMU interpreters have to be registered before you can run a successful build. And it's recommended the test if ARM and ARM64 are emulated within the build environment first.

*Registering QEMU interpreters:*
(complete source and build instructions can be found at https://github.com/hypriot/qemu-register)
```
$ docker run --rm --privileged hypriot/qemu-register
```

*Testing for ARM:*
```
$ docker run --rm -ti armhf/debian:jessie uname -a
Linux 3ef3a2872778 4.8.10-moby #1 SMP Mon Nov 21 22:02:05 UTC 2016 armv7l GNU/Linux
```

*Testing for ARM64:*
```
$ docker run --rm -ti aarch64/ubuntu:wily uname -a
Linux ba12abc64594 4.8.10-moby #1 SMP Mon Nov 21 22:02:05 UTC 2016 aarch64 aarch64 aarch64 GNU/Linux
```

**- Detailed description and example usage**

With this change we can run a Docker build in QEMU and build ARM or ARM64 binaries directly on an Intel build machine. This feature already supports building within Docker4Mac (Beta31). So it's easy for a developer to compile and test the Docker binaries locally on his dev machine w/o the need of the target hardware. Another use case would be to run builds on a cloud CI like Travis to get an instant feedback loop for PR's, all on a common Intel platform w/o the need to set up the CI system on the real target hardware.

*Usage:* build static Docker binaries for ARM 32-bit (uses Dockerfile.armhf)
```
$ DOCKER_ENGINE_OSARCH="linux/arm" make binary
```

*Usage:* build static Docker binaries for ARM64 aka AARCH64 (uses Dockerfile.aarch64)
```
$ DOCKER_ENGINE_OSARCH="linux/arm64" make binary
```

Signed-off-by: Dieter Reuter <dieter.reuter@me.com>