### PR TITLE
Add bash completion for secret management

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -23,6 +23,7 @@
 # DOCKER_COMPLETION_SHOW_CONTAINER_IDS
 # DOCKER_COMPLETION_SHOW_NETWORK_IDS
 # DOCKER_COMPLETION_SHOW_NODE_IDS
+# DOCKER_COMPLETION_SHOW_SECRET_IDS
 # DOCKER_COMPLETION_SHOW_SERVICE_IDS
 #   "no"  - Show names only (default)
 #   "yes" - Show names and ids
@@ -309,6 +310,22 @@ __docker_runtimes() {
 
 __docker_complete_runtimes() {
 	COMPREPLY=( $(compgen -W "$(__docker_runtimes)" -- "$cur") )
+}
+
+# __docker_secrets returns a list of all secrets.
+# By default, only names of secrets are returned.
+# Set DOCKER_COMPLETION_SHOW_SECRET_IDS=yes to also complete IDs of secrets.
+__docker_secrets() {
+	local fields='$2'  # default: name only
+	[ "${DOCKER_COMPLETION_SHOW_SECRET_IDS}" = yes ] && fields='$1,$2' # ID and name
+
+	__docker_q secret ls | awk "NR>1 {print $fields}"
+}
+
+# __docker_complete_secrets applies completion of secrets based on the current value
+# of `$cur`.
+__docker_complete_secrets() {
+	COMPREPLY=( $(compgen -W "$(__docker_secrets)" -- "$cur") )
 }
 
 # __docker_stacks returns a list of all stacks.
@@ -2736,6 +2753,7 @@ _docker_service_update() {
 			--mode
 			--name
 			--port
+			--secret
 		"
 
 		case "$prev" in
@@ -2753,6 +2771,10 @@ _docker_service_update() {
 				;;
 			--mode)
 				COMPREPLY=( $( compgen -W "global replicated" -- "$cur" ) )
+				return
+				;;
+			--secret)
+				__docker_complete_secrets
 				return
 				;;
 			--group)
@@ -2779,6 +2801,8 @@ _docker_service_update() {
 			--image
 			--port-add
 			--port-rm
+			--secret-add
+			--secret-rm
 		"
 
 		case "$prev" in
@@ -2800,6 +2824,10 @@ _docker_service_update() {
 				;;
 			--image)
 				__docker_complete_image_repos_and_tags
+				return
+				;;
+			--secret-add|--secret-rm)
+				__docker_complete_secrets
 				return
 				;;
 		esac
@@ -3329,6 +3357,90 @@ _docker_save() {
 	_docker_image_save
 }
 
+
+_docker_secret() {
+	local subcommands="
+		create
+		inspect
+		ls
+		rm
+	"
+	local aliases="
+		list
+		remove
+	"
+	__docker_subcommands "$subcommands $aliases" && return
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_secret_create() {
+	case "$prev" in
+		--label|-l)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help --label -l" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_secret_inspect() {
+	case "$prev" in
+		--format|-f)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--format -f --help" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_secrets
+			;;
+	esac
+}
+
+_docker_secret_list() {
+	_docker_secret_ls
+}
+
+_docker_secret_ls() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help --quiet -q" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_secret_remove() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_secrets
+			;;
+	esac
+}
+
+_docker_secret_rm() {
+	_docker_secret_remove
+}
+
+
+
 _docker_search() {
 	local key=$(__docker_map_key_of_current_option '--filter|-f')
 	case "$key" in
@@ -3852,6 +3964,7 @@ _docker() {
 		run
 		save
 		search
+		secret
 		service
 		stack
 		start


### PR DESCRIPTION
Ref: #27794

Notes: For `docker service create --secret` and `docker service update --secret-add`, only the short syntax (just the secret name) is supported.
That's because the long syntax with its comma-separated key-value list is very challenging to implement, and I will probably not get it done before 1.13.0. So this is the slightly trimmed-down version for 1.13.0.

**A picture of a cute animal (not mandatory but encouraged)**
![Anton](https://cloud.githubusercontent.com/assets/2901725/20868697/dd35a066-ba61-11e6-9d13-e89595c3f844.jpg)
_Our local squirrel, Anton, enjoys the snowman on our balcony_