### PR TITLE
run dnf upgrade before installing in fedora

### DIFF
--- a/contrib/builder/rpm/amd64/fedora-23/Dockerfile
+++ b/contrib/builder/rpm/amd64/fedora-23/Dockerfile
@@ -4,6 +4,7 @@
 
 FROM fedora:23
 
+RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 

--- a/contrib/builder/rpm/amd64/fedora-24/Dockerfile
+++ b/contrib/builder/rpm/amd64/fedora-24/Dockerfile
@@ -4,6 +4,7 @@
 
 FROM fedora:24
 
+RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 

--- a/contrib/builder/rpm/amd64/fedora-25/Dockerfile
+++ b/contrib/builder/rpm/amd64/fedora-25/Dockerfile
@@ -4,6 +4,7 @@
 
 FROM fedora:25
 
+RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 

--- a/contrib/builder/rpm/amd64/generate.sh
+++ b/contrib/builder/rpm/amd64/generate.sh
@@ -53,6 +53,9 @@ for version in "${versions[@]}"; do
 			echo "RUN yum install -y kernel-uek-devel-4.1.12-32.el6uek"  >> "$version/Dockerfile"
 			echo >> "$version/Dockerfile"
 			;;
+		fedora:*)
+			echo "RUN ${installer} -y upgrade" >> "$version/Dockerfile"
+			;;
 		*) ;;
 	esac
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Right now, building `docker-engine` rpms for fedora 25 are broken because fedora 25 repo has a new `vim-common-8.0` package that cannot be installed if `vim-minimal-7.4` is already installed. To work around this, need to do a `dnf upgrade` before installing `vim-common` to get `vim-minimal` up to version 8.0. This is similar to doing a `apt-get update` before doing a `apt-get install`.

This PR will add `dnf -y upgrade` for all fedora `Dockerfile` files used for building fedora docker-engine RPMs.

I've also filed a bugzilla ticket to fedora team about this: https://bugzilla.redhat.com/show_bug.cgi?id=1401323

**- How I did it**

Added a case statement to `contrib/builder/rpm/amd64/generate.sh` and re-ran the `generate.sh` script to generate the `Dockerfile` files.

**- How to verify it**

Just build a fedora-25 rpm. If it can build, then this PR is successful.

```
$ make DOCKER_BUILD_PKGS=fedora-25 rpm
```

Without this PR, you will get an error like this:
```
Error: Transaction check error:
  file /usr/share/man/man1/vim.1.gz from install of vim-common-2:8.0.118-1.fc25.x86_64 conflicts with file from package vim-minimal-2:7.4.1989-2.fc25.x86_64
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

😿 
