### PR TITLE
Fix bundle dir for integration-cli

### DIFF
--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -20,7 +20,7 @@ bundle_test_integration_cli() {
 go_test_dir() {
 	dir=$1
 	precompiled=$2
-	testbinary="$DEST/test.main"
+	testbinary="$ABS_DEST/test.main"
 	testcover=()
 	testcoverprofile=()
 	(

--- a/hack/make/build-integration-test-binary
+++ b/hack/make/build-integration-test-binary
@@ -2,7 +2,7 @@
 set -e
 
 rm -rf "$DEST"
-DEST="$DEST/../test-integration-cli"
+DEST="$ABS_DEST/../test-integration-cli"
 
 if [ -z $DOCKER_INTEGRATION_TESTS_VERIFIED ]; then
 	source ${MAKEDIR}/.integration-test-helpers


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
`test.main` was unexpectedly created under `docker/integration-cli/bundles/$VERSION/test-integration-cli `directory.
This commit moves `test.main` to `docker/bundles/$VERSION/test-integration-cli`.

"cherry-pick" https://github.com/docker/docker/pull/26684/files#r79300354


**- How I did it**
See above

**- How to verify it**
```console
$ make shell
root@c9bc09cc4e3e:/go/src/github.com/docker/docker# hack/make.sh build-integration-test-binary dynbinary test-integration-cli
root@c9bc09cc4e3e:/go/src/github.com/docker/docker# ls integration-cli/bundles
ls: cannot access integration-cli/bundles: No such file or directory
root@c9bc09cc4e3e:/go/src/github.com/docker/docker# ls bundles/latest/test-integration-cli/test.main 
bundles/latest/test-integration-cli/test.main

```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**




Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>