### PR TITLE
Handle logging in compose to swarm

### DIFF
--- a/api/types/swarm/common.go
+++ b/api/types/swarm/common.go
@@ -19,3 +19,9 @@ type Annotations struct {
 	Name   string            `json:",omitempty"`
 	Labels map[string]string `json:",omitempty"`
 }
+
+// Driver represents a driver (network, logging).
+type Driver struct {
+	Name    string            `json:",omitempty"`
+	Options map[string]string `json:",omitempty"`
+}

--- a/api/types/swarm/network.go
+++ b/api/types/swarm/network.go
@@ -109,9 +109,3 @@ type IPAMConfig struct {
 	Range   string `json:",omitempty"`
 	Gateway string `json:",omitempty"`
 }
-
-// Driver represents a network driver.
-type Driver struct {
-	Name    string            `json:",omitempty"`
-	Options map[string]string `json:",omitempty"`
-}

--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -567,6 +567,14 @@ func convertService(
 		return swarm.ServiceSpec{}, err
 	}
 
+	var logDriver *swarm.Driver
+	if service.Logging != nil {
+		logDriver = &swarm.Driver{
+			Name:    service.Logging.Driver,
+			Options: service.Logging.Options,
+		}
+	}
+
 	serviceSpec := swarm.ServiceSpec{
 		Annotations: swarm.Annotations{
 			Name:   name,
@@ -589,6 +597,7 @@ func convertService(
 				TTY:             service.Tty,
 				OpenStdin:       service.StdinOpen,
 			},
+			LogDriver:     logDriver,
 			Resources:     resources,
 			RestartPolicy: restartPolicy,
 			Placement: &swarm.Placement{


### PR DESCRIPTION
Logging configuration was completely ignore when deploy a compose file to swarm. This fixes it 👼.
This also move `Driver` in `common.go` and update the comment as it's used for network *and* logging driver.

Fixes #29116 

/cc @aanand @dnephin @thaJeztah @vieux @jpetazzo 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>