### PR TITLE
Caution against the use of CONFIG_LEGACY_VSYSCALL_NATIVE

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -224,7 +224,8 @@ echo 'Optional Features:'
 }
 {
 	if is_set LEGACY_VSYSCALL_NATIVE; then
-		echo -n "- "; wrap_good "CONFIG_LEGACY_VSYSCALL_NATIVE" 'enabled'
+		echo -n "- "; wrap_bad "CONFIG_LEGACY_VSYSCALL_NATIVE" 'enabled'
+		echo "    $(wrap_color '(dangerous, provides an ASLR-bypassing target with usable ROP gadgets.)' bold black)"
 	elif is_set LEGACY_VSYSCALL_EMULATE; then
 		echo -n "- "; wrap_good "CONFIG_LEGACY_VSYSCALL_EMULATE" 'enabled'
 	elif is_set LEGACY_VSYSCALL_NONE; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Switch `check-config.sh` to use `wrap_bad` instead of `wrap_good` in the `LEGACY_VSYSCALL_NATIVE` case and added an explanatory comment in the output.

https://github.com/docker/docker/issues/28705#issuecomment-264564406 has some background on the tradeoffs with these options.

**- How to verify it**

I didn't have any `CONFIG_LEGACY_VSYSCALL_NATIVE` using `.config` so I hacked one up from a Debian config (which uses `VSYSCALL_NONE`) with:
```
sed -e 's/\(CONFIG_LEGACY_VSYSCALL_NONE\)=y/# \1 is not set/; s/# \(CONFIG_LEGACY_VSYSCALL_NATIVE\) is not set/\1=y/g' /boot/config-4.8.0-1-amd64  > config-4.8.0-1-amd64
```
and ran `check-config.sh` on the result 

**- A picture of a cute animal (not mandatory but encouraged)**
![David Crosby, The Byrds](https://upload.wikimedia.org/wikipedia/commons/thumb/d/df/David_Crosby_2006.jpg/440px-David_Crosby_2006.jpg)

/cc @kees @justincormack @thaJeztah 