### PR TITLE
UrlEncode user input in client

### DIFF
--- a/client/checkpoint_create.go
+++ b/client/checkpoint_create.go
@@ -1,13 +1,15 @@
 package client
 
 import (
+	"net/url"
+
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
 )
 
 // CheckpointCreate creates a checkpoint from the given container with the given name
 func (cli *Client) CheckpointCreate(ctx context.Context, container string, options types.CheckpointCreateOptions) error {
-	resp, err := cli.post(ctx, "/containers/"+container+"/checkpoints", nil, options, nil)
+	resp, err := cli.post(ctx, "/containers/"+url.QueryEscape(container)+"/checkpoints", nil, options, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/checkpoint_delete.go
+++ b/client/checkpoint_delete.go
@@ -14,7 +14,7 @@ func (cli *Client) CheckpointDelete(ctx context.Context, containerID string, opt
 		query.Set("dir", options.CheckpointDir)
 	}
 
-	resp, err := cli.delete(ctx, "/containers/"+containerID+"/checkpoints/"+options.CheckpointID, query, nil)
+	resp, err := cli.delete(ctx, "/containers/"+url.QueryEscape(containerID)+"/checkpoints/"+url.QueryEscape(options.CheckpointID), query, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/checkpoint_list.go
+++ b/client/checkpoint_list.go
@@ -17,7 +17,7 @@ func (cli *Client) CheckpointList(ctx context.Context, container string, options
 		query.Set("dir", options.CheckpointDir)
 	}
 
-	resp, err := cli.get(ctx, "/containers/"+container+"/checkpoints", query, nil)
+	resp, err := cli.get(ctx, "/containers/"+url.QueryEscape(container)+"/checkpoints", query, nil)
 	if err != nil {
 		return checkpoints, err
 	}

--- a/client/container_attach.go
+++ b/client/container_attach.go
@@ -33,5 +33,5 @@ func (cli *Client) ContainerAttach(ctx context.Context, container string, option
 	}
 
 	headers := map[string][]string{"Content-Type": {"text/plain"}}
-	return cli.postHijacked(ctx, "/containers/"+container+"/attach", query, nil, headers)
+	return cli.postHijacked(ctx, "/containers/"+url.QueryEscape(container)+"/attach", query, nil, headers)
 }

--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -20,7 +20,7 @@ func (cli *Client) ContainerStatPath(ctx context.Context, containerID, path stri
 	query := url.Values{}
 	query.Set("path", filepath.ToSlash(path)) // Normalize the paths used in the API.
 
-	urlStr := fmt.Sprintf("/containers/%s/archive", containerID)
+	urlStr := fmt.Sprintf("/containers/%s/archive", url.QueryEscape(containerID))
 	response, err := cli.head(ctx, urlStr, query, nil)
 	if err != nil {
 		return types.ContainerPathStat{}, err

--- a/client/container_diff.go
+++ b/client/container_diff.go
@@ -12,7 +12,7 @@ import (
 func (cli *Client) ContainerDiff(ctx context.Context, containerID string) ([]types.ContainerChange, error) {
 	var changes []types.ContainerChange
 
-	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/changes", url.Values{}, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+url.QueryEscape(containerID)+"/changes", url.Values{}, nil)
 	if err != nil {
 		return changes, err
 	}

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
@@ -15,7 +16,7 @@ func (cli *Client) ContainerExecCreate(ctx context.Context, container string, co
 		return response, err
 	}
 
-	resp, err := cli.post(ctx, "/containers/"+container+"/exec", nil, config, nil)
+	resp, err := cli.post(ctx, "/containers/"+url.QueryEscape(container)+"/exec", nil, config, nil)
 	if err != nil {
 		return response, err
 	}
@@ -26,7 +27,7 @@ func (cli *Client) ContainerExecCreate(ctx context.Context, container string, co
 
 // ContainerExecStart starts an exec process already created in the docker host.
 func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error {
-	resp, err := cli.post(ctx, "/exec/"+execID+"/start", nil, config, nil)
+	resp, err := cli.post(ctx, "/exec/"+url.QueryEscape(execID)+"/start", nil, config, nil)
 	ensureReaderClosed(resp)
 	return err
 }
@@ -37,13 +38,13 @@ func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config
 // the hijacked connection by calling types.HijackedResponse.Close.
 func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, config types.ExecConfig) (types.HijackedResponse, error) {
 	headers := map[string][]string{"Content-Type": {"application/json"}}
-	return cli.postHijacked(ctx, "/exec/"+execID+"/start", nil, config, headers)
+	return cli.postHijacked(ctx, "/exec/"+url.QueryEscape(execID)+"/start", nil, config, headers)
 }
 
 // ContainerExecInspect returns information about a specific exec process on the docker host.
 func (cli *Client) ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error) {
 	var response types.ContainerExecInspect
-	resp, err := cli.get(ctx, "/exec/"+execID+"/json", nil, nil)
+	resp, err := cli.get(ctx, "/exec/"+url.QueryEscape(execID)+"/json", nil, nil)
 	if err != nil {
 		return response, err
 	}

--- a/client/container_export.go
+++ b/client/container_export.go
@@ -11,7 +11,7 @@ import (
 // and returns them as an io.ReadCloser. It's up to the caller
 // to close the stream.
 func (cli *Client) ContainerExport(ctx context.Context, containerID string) (io.ReadCloser, error) {
-	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/export", url.Values{}, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+url.QueryEscape(containerID)+"/export", url.Values{}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/container_inspect.go
+++ b/client/container_inspect.go
@@ -13,7 +13,7 @@ import (
 
 // ContainerInspect returns the container information.
 func (cli *Client) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
-	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", nil, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+url.QueryEscape(containerID)+"/json", nil, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return types.ContainerJSON{}, containerNotFoundError{containerID}
@@ -33,7 +33,7 @@ func (cli *Client) ContainerInspectWithRaw(ctx context.Context, containerID stri
 	if getSize {
 		query.Set("size", "1")
 	}
-	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", query, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+url.QueryEscape(containerID)+"/json", query, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return types.ContainerJSON{}, nil, containerNotFoundError{containerID}

--- a/client/container_kill.go
+++ b/client/container_kill.go
@@ -11,7 +11,7 @@ func (cli *Client) ContainerKill(ctx context.Context, containerID, signal string
 	query := url.Values{}
 	query.Set("signal", signal)
 
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/kill", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+url.QueryEscape(containerID)+"/kill", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_logs.go
+++ b/client/container_logs.go
@@ -44,7 +44,7 @@ func (cli *Client) ContainerLogs(ctx context.Context, container string, options 
 	}
 	query.Set("tail", options.Tail)
 
-	resp, err := cli.get(ctx, "/containers/"+container+"/logs", query, nil)
+	resp, err := cli.get(ctx, "/containers/"+url.QueryEscape(container)+"/logs", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/container_pause.go
+++ b/client/container_pause.go
@@ -1,10 +1,14 @@
 package client
 
-import "golang.org/x/net/context"
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+)
 
 // ContainerPause pauses the main process of a given container without terminating it.
 func (cli *Client) ContainerPause(ctx context.Context, containerID string) error {
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/pause", nil, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+url.QueryEscape(containerID)+"/pause", nil, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_remove.go
+++ b/client/container_remove.go
@@ -21,7 +21,7 @@ func (cli *Client) ContainerRemove(ctx context.Context, containerID string, opti
 		query.Set("force", "1")
 	}
 
-	resp, err := cli.delete(ctx, "/containers/"+containerID, query, nil)
+	resp, err := cli.delete(ctx, "/containers/"+url.QueryEscape(containerID), query, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_resize.go
+++ b/client/container_resize.go
@@ -10,12 +10,12 @@ import (
 
 // ContainerResize changes the size of the tty for a container.
 func (cli *Client) ContainerResize(ctx context.Context, containerID string, options types.ResizeOptions) error {
-	return cli.resize(ctx, "/containers/"+containerID, options.Height, options.Width)
+	return cli.resize(ctx, "/containers/"+url.QueryEscape(containerID), options.Height, options.Width)
 }
 
 // ContainerExecResize changes the size of the tty for an exec process running inside a container.
 func (cli *Client) ContainerExecResize(ctx context.Context, execID string, options types.ResizeOptions) error {
-	return cli.resize(ctx, "/exec/"+execID, options.Height, options.Width)
+	return cli.resize(ctx, "/exec/"+url.QueryEscape(execID), options.Height, options.Width)
 }
 
 func (cli *Client) resize(ctx context.Context, basePath string, height, width uint) error {

--- a/client/container_restart.go
+++ b/client/container_restart.go
@@ -16,7 +16,7 @@ func (cli *Client) ContainerRestart(ctx context.Context, containerID string, tim
 	if timeout != nil {
 		query.Set("t", timetypes.DurationToSecondsString(*timeout))
 	}
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/restart", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+url.QueryEscape(containerID)+"/restart", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_start.go
+++ b/client/container_start.go
@@ -18,7 +18,7 @@ func (cli *Client) ContainerStart(ctx context.Context, containerID string, optio
 		query.Set("checkpoint-dir", options.CheckpointDir)
 	}
 
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/start", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+url.QueryEscape(containerID)+"/start", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_stats.go
+++ b/client/container_stats.go
@@ -16,7 +16,7 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 		query.Set("stream", "1")
 	}
 
-	resp, err := cli.get(ctx, "/containers/"+containerID+"/stats", query, nil)
+	resp, err := cli.get(ctx, "/containers/"+url.QueryEscape(containerID)+"/stats", query, nil)
 	if err != nil {
 		return types.ContainerStats{}, err
 	}

--- a/client/container_stop.go
+++ b/client/container_stop.go
@@ -15,7 +15,7 @@ func (cli *Client) ContainerStop(ctx context.Context, containerID string, timeou
 	if timeout != nil {
 		query.Set("t", timetypes.DurationToSecondsString(*timeout))
 	}
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/stop", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+url.QueryEscape(containerID)+"/stop", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_top.go
+++ b/client/container_top.go
@@ -17,7 +17,7 @@ func (cli *Client) ContainerTop(ctx context.Context, containerID string, argumen
 		query.Set("ps_args", strings.Join(arguments, " "))
 	}
 
-	resp, err := cli.get(ctx, "/containers/"+containerID+"/top", query, nil)
+	resp, err := cli.get(ctx, "/containers/"+url.QueryEscape(containerID)+"/top", query, nil)
 	if err != nil {
 		return response, err
 	}

--- a/client/image_history.go
+++ b/client/image_history.go
@@ -11,7 +11,7 @@ import (
 // ImageHistory returns the changes in an image in history format.
 func (cli *Client) ImageHistory(ctx context.Context, imageID string) ([]types.ImageHistory, error) {
 	var history []types.ImageHistory
-	serverResp, err := cli.get(ctx, "/images/"+imageID+"/history", url.Values{}, nil)
+	serverResp, err := cli.get(ctx, "/images/"+url.QueryEscape(imageID)+"/history", url.Values{}, nil)
 	if err != nil {
 		return history, err
 	}

--- a/client/image_inspect.go
+++ b/client/image_inspect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
@@ -12,7 +13,7 @@ import (
 
 // ImageInspectWithRaw returns the image information and its raw representation.
 func (cli *Client) ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error) {
-	serverResp, err := cli.get(ctx, "/images/"+imageID+"/json", nil, nil)
+	serverResp, err := cli.get(ctx, "/images/"+url.QueryEscape(imageID)+"/json", nil, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return types.ImageInspect{}, nil, imageNotFoundError{imageID}

--- a/client/image_remove.go
+++ b/client/image_remove.go
@@ -19,7 +19,7 @@ func (cli *Client) ImageRemove(ctx context.Context, imageID string, options type
 		query.Set("noprune", "1")
 	}
 
-	resp, err := cli.delete(ctx, "/images/"+imageID, query, nil)
+	resp, err := cli.delete(ctx, "/images/"+url.QueryEscape(imageID), query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/image_tag.go
+++ b/client/image_tag.go
@@ -28,7 +28,7 @@ func (cli *Client) ImageTag(ctx context.Context, imageID, ref string) error {
 	query.Set("repo", distributionRef.Name())
 	query.Set("tag", tag)
 
-	resp, err := cli.post(ctx, "/images/"+imageID+"/tag", query, nil, nil)
+	resp, err := cli.post(ctx, "/images/"+url.QueryEscape(imageID)+"/tag", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/network_connect.go
+++ b/client/network_connect.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"net/url"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
 	"golang.org/x/net/context"
@@ -12,7 +14,7 @@ func (cli *Client) NetworkConnect(ctx context.Context, networkID, containerID st
 		Container:      containerID,
 		EndpointConfig: config,
 	}
-	resp, err := cli.post(ctx, "/networks/"+networkID+"/connect", nil, nc, nil)
+	resp, err := cli.post(ctx, "/networks/"+url.QueryEscape(networkID)+"/connect", nil, nc, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/network_disconnect.go
+++ b/client/network_disconnect.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"net/url"
+
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
 )
@@ -8,7 +10,7 @@ import (
 // NetworkDisconnect disconnects a container from an existent network in the docker host.
 func (cli *Client) NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error {
 	nd := types.NetworkDisconnect{Container: containerID, Force: force}
-	resp, err := cli.post(ctx, "/networks/"+networkID+"/disconnect", nil, nd, nil)
+	resp, err := cli.post(ctx, "/networks/"+url.QueryEscape(networkID)+"/disconnect", nil, nd, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/network_inspect.go
+++ b/client/network_inspect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
@@ -19,7 +20,7 @@ func (cli *Client) NetworkInspect(ctx context.Context, networkID string) (types.
 // NetworkInspectWithRaw returns the information for a specific network configured in the docker host and its raw representation.
 func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string) (types.NetworkResource, []byte, error) {
 	var networkResource types.NetworkResource
-	resp, err := cli.get(ctx, "/networks/"+networkID, nil, nil)
+	resp, err := cli.get(ctx, "/networks/"+url.QueryEscape(networkID), nil, nil)
 	if err != nil {
 		if resp.statusCode == http.StatusNotFound {
 			return networkResource, nil, networkNotFoundError{networkID}

--- a/client/network_remove.go
+++ b/client/network_remove.go
@@ -1,10 +1,14 @@
 package client
 
-import "golang.org/x/net/context"
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+)
 
 // NetworkRemove removes an existent network from the docker host.
 func (cli *Client) NetworkRemove(ctx context.Context, networkID string) error {
-	resp, err := cli.delete(ctx, "/networks/"+networkID, nil, nil)
+	resp, err := cli.delete(ctx, "/networks/"+url.QueryEscape(networkID), nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/node_inspect.go
+++ b/client/node_inspect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/docker/docker/api/types/swarm"
 	"golang.org/x/net/context"
@@ -12,7 +13,7 @@ import (
 
 // NodeInspectWithRaw returns the node information.
 func (cli *Client) NodeInspectWithRaw(ctx context.Context, nodeID string) (swarm.Node, []byte, error) {
-	serverResp, err := cli.get(ctx, "/nodes/"+nodeID, nil, nil)
+	serverResp, err := cli.get(ctx, "/nodes/"+url.QueryEscape(nodeID), nil, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return swarm.Node{}, nil, nodeNotFoundError{nodeID}

--- a/client/node_remove.go
+++ b/client/node_remove.go
@@ -15,7 +15,7 @@ func (cli *Client) NodeRemove(ctx context.Context, nodeID string, options types.
 		query.Set("force", "1")
 	}
 
-	resp, err := cli.delete(ctx, "/nodes/"+nodeID, query, nil)
+	resp, err := cli.delete(ctx, "/nodes/"+url.QueryEscape(nodeID), query, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/node_update.go
+++ b/client/node_update.go
@@ -12,7 +12,7 @@ import (
 func (cli *Client) NodeUpdate(ctx context.Context, nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 	query := url.Values{}
 	query.Set("version", strconv.FormatUint(version.Index, 10))
-	resp, err := cli.post(ctx, "/nodes/"+nodeID+"/update", query, node, nil)
+	resp, err := cli.post(ctx, "/nodes/"+url.QueryEscape(nodeID)+"/update", query, node, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/plugin_disable.go
+++ b/client/plugin_disable.go
@@ -1,12 +1,14 @@
 package client
 
 import (
+	"net/url"
+
 	"golang.org/x/net/context"
 )
 
 // PluginDisable disables a plugin
 func (cli *Client) PluginDisable(ctx context.Context, name string) error {
-	resp, err := cli.post(ctx, "/plugins/"+name+"/disable", nil, nil, nil)
+	resp, err := cli.post(ctx, "/plugins/"+url.QueryEscape(name)+"/disable", nil, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/plugin_enable.go
+++ b/client/plugin_enable.go
@@ -13,7 +13,7 @@ func (cli *Client) PluginEnable(ctx context.Context, name string, options types.
 	query := url.Values{}
 	query.Set("timeout", strconv.Itoa(options.Timeout))
 
-	resp, err := cli.post(ctx, "/plugins/"+name+"/enable", query, nil, nil)
+	resp, err := cli.post(ctx, "/plugins/"+url.QueryEscape(name)+"/enable", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/plugin_inspect.go
+++ b/client/plugin_inspect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
@@ -12,7 +13,7 @@ import (
 
 // PluginInspectWithRaw inspects an existing plugin
 func (cli *Client) PluginInspectWithRaw(ctx context.Context, name string) (*types.Plugin, []byte, error) {
-	resp, err := cli.get(ctx, "/plugins/"+name, nil, nil)
+	resp, err := cli.get(ctx, "/plugins/"+url.QueryEscape(name), nil, nil)
 	if err != nil {
 		if resp.statusCode == http.StatusNotFound {
 			return nil, nil, pluginNotFoundError{name}

--- a/client/plugin_install.go
+++ b/client/plugin_install.go
@@ -30,7 +30,7 @@ func (cli *Client) PluginInstall(ctx context.Context, name string, options types
 
 	defer func() {
 		if err != nil {
-			delResp, _ := cli.delete(ctx, "/plugins/"+name, nil, nil)
+			delResp, _ := cli.delete(ctx, "/plugins/"+url.QueryEscape(name), nil, nil)
 			ensureReaderClosed(delResp)
 		}
 	}()

--- a/client/plugin_push.go
+++ b/client/plugin_push.go
@@ -1,13 +1,15 @@
 package client
 
 import (
+	"net/url"
+
 	"golang.org/x/net/context"
 )
 
 // PluginPush pushes a plugin to a registry
 func (cli *Client) PluginPush(ctx context.Context, name string, registryAuth string) error {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
-	resp, err := cli.post(ctx, "/plugins/"+name+"/push", nil, nil, headers)
+	resp, err := cli.post(ctx, "/plugins/"+url.QueryEscape(name)+"/push", nil, nil, headers)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/plugin_remove.go
+++ b/client/plugin_remove.go
@@ -14,7 +14,7 @@ func (cli *Client) PluginRemove(ctx context.Context, name string, options types.
 		query.Set("force", "1")
 	}
 
-	resp, err := cli.delete(ctx, "/plugins/"+name, query, nil)
+	resp, err := cli.delete(ctx, "/plugins/"+url.QueryEscape(name), query, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/plugin_set.go
+++ b/client/plugin_set.go
@@ -1,12 +1,14 @@
 package client
 
 import (
+	"net/url"
+
 	"golang.org/x/net/context"
 )
 
 // PluginSet modifies settings for an existing plugin
 func (cli *Client) PluginSet(ctx context.Context, name string, args []string) error {
-	resp, err := cli.post(ctx, "/plugins/"+name+"/set", nil, args, nil)
+	resp, err := cli.post(ctx, "/plugins/"+url.QueryEscape(name)+"/set", nil, args, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/secret_inspect.go
+++ b/client/secret_inspect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/docker/docker/api/types/swarm"
 	"golang.org/x/net/context"
@@ -12,7 +13,7 @@ import (
 
 // SecretInspectWithRaw returns the secret information with raw data
 func (cli *Client) SecretInspectWithRaw(ctx context.Context, id string) (swarm.Secret, []byte, error) {
-	resp, err := cli.get(ctx, "/secrets/"+id, nil, nil)
+	resp, err := cli.get(ctx, "/secrets/"+url.QueryEscape(id), nil, nil)
 	if err != nil {
 		if resp.statusCode == http.StatusNotFound {
 			return swarm.Secret{}, nil, secretNotFoundError{id}

--- a/client/secret_remove.go
+++ b/client/secret_remove.go
@@ -1,10 +1,14 @@
 package client
 
-import "golang.org/x/net/context"
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+)
 
 // SecretRemove removes a Secret.
 func (cli *Client) SecretRemove(ctx context.Context, id string) error {
-	resp, err := cli.delete(ctx, "/secrets/"+id, nil, nil)
+	resp, err := cli.delete(ctx, "/secrets/"+url.QueryEscape(id), nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/service_inspect.go
+++ b/client/service_inspect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/docker/docker/api/types/swarm"
 	"golang.org/x/net/context"
@@ -12,7 +13,7 @@ import (
 
 // ServiceInspectWithRaw returns the service information and the raw data.
 func (cli *Client) ServiceInspectWithRaw(ctx context.Context, serviceID string) (swarm.Service, []byte, error) {
-	serverResp, err := cli.get(ctx, "/services/"+serviceID, nil, nil)
+	serverResp, err := cli.get(ctx, "/services/"+url.QueryEscape(serviceID), nil, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return swarm.Service{}, nil, serviceNotFoundError{serviceID}

--- a/client/service_logs.go
+++ b/client/service_logs.go
@@ -44,7 +44,7 @@ func (cli *Client) ServiceLogs(ctx context.Context, serviceID string, options ty
 	}
 	query.Set("tail", options.Tail)
 
-	resp, err := cli.get(ctx, "/services/"+serviceID+"/logs", query, nil)
+	resp, err := cli.get(ctx, "/services/"+url.QueryEscape(serviceID)+"/logs", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/service_remove.go
+++ b/client/service_remove.go
@@ -1,10 +1,14 @@
 package client
 
-import "golang.org/x/net/context"
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+)
 
 // ServiceRemove kills and removes a service.
 func (cli *Client) ServiceRemove(ctx context.Context, serviceID string) error {
-	resp, err := cli.delete(ctx, "/services/"+serviceID, nil, nil)
+	resp, err := cli.delete(ctx, "/services/"+url.QueryEscape(serviceID), nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -30,7 +30,7 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 	query.Set("version", strconv.FormatUint(version.Index, 10))
 
 	var response types.ServiceUpdateResponse
-	resp, err := cli.post(ctx, "/services/"+serviceID+"/update", query, service, headers)
+	resp, err := cli.post(ctx, "/services/"+url.QueryEscape(serviceID)+"/update", query, service, headers)
 	if err != nil {
 		return response, err
 	}

--- a/client/task_inspect.go
+++ b/client/task_inspect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/docker/docker/api/types/swarm"
 
@@ -13,7 +14,7 @@ import (
 
 // TaskInspectWithRaw returns the task information and its raw representation..
 func (cli *Client) TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error) {
-	serverResp, err := cli.get(ctx, "/tasks/"+taskID, nil, nil)
+	serverResp, err := cli.get(ctx, "/tasks/"+url.QueryEscape(taskID), nil, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return swarm.Task{}, nil, taskNotFoundError{taskID}

--- a/client/volume_inspect.go
+++ b/client/volume_inspect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
@@ -19,7 +20,7 @@ func (cli *Client) VolumeInspect(ctx context.Context, volumeID string) (types.Vo
 // VolumeInspectWithRaw returns the information about a specific volume in the docker host and its raw representation
 func (cli *Client) VolumeInspectWithRaw(ctx context.Context, volumeID string) (types.Volume, []byte, error) {
 	var volume types.Volume
-	resp, err := cli.get(ctx, "/volumes/"+volumeID, nil, nil)
+	resp, err := cli.get(ctx, "/volumes/"+url.QueryEscape(volumeID), nil, nil)
 	if err != nil {
 		if resp.statusCode == http.StatusNotFound {
 			return volume, nil, volumeNotFoundError{volumeID}

--- a/client/volume_remove.go
+++ b/client/volume_remove.go
@@ -15,7 +15,7 @@ func (cli *Client) VolumeRemove(ctx context.Context, volumeID string, force bool
 			query.Set("force", "1")
 		}
 	}
-	resp, err := cli.delete(ctx, "/volumes/"+volumeID, query, nil)
+	resp, err := cli.delete(ctx, "/volumes/"+url.QueryEscape(volumeID), query, nil)
 	ensureReaderClosed(resp)
 	return err
 }


### PR DESCRIPTION
This is linked to #29126, this disallow any `../` on a query from the client. This could lead to some really messed up queries.

Currently, a request with `../something` like `docker network rm ../foo/bar` returns a 301 which is not really handled at all. 

```bash
$ docker network rm ../foo/bar
# […]
resp &{301 Moved Permanently 301 HTTP/1.1 1 1 map[Content-Type:[text/plain; charset=utf-8] Location:[/toto] Date:[Mon, 05 Dec 2016 11:16:35 GMT] Content-Length:[0]] 0xc42000e500 0 [] false false map[] 0xc420424000 <nil>}
../foo/bar
```

We should discuss what to do about `301` http code too.

/cc @thaJeztah @dnephin @justincormack @cpuguy83

🐸 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>