### PR TITLE
[WIP]make remove multiple secret run normally

### DIFF
--- a/cli/command/secret/utils.go
+++ b/cli/command/secret/utils.go
@@ -1,7 +1,6 @@
 package secret
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -29,46 +28,25 @@ func getCliRequestedSecretIDs(ctx context.Context, client client.APIClient, term
 		return nil, err
 	}
 
-	if len(secrets) > 0 {
-		found := make(map[string]struct{})
-	next:
-		for _, term := range terms {
+	for index, term := range terms {
+		for _, s := range secrets {
 			// attempt to lookup secret by full ID
-			for _, s := range secrets {
-				if s.ID == term {
-					found[s.ID] = struct{}{}
-					continue next
-				}
+			if s.ID == term {
+				break
 			}
+
 			// attempt to lookup secret by full name
-			for _, s := range secrets {
-				if s.Spec.Annotations.Name == term {
-					found[s.ID] = struct{}{}
-					continue next
-				}
+			if s.Spec.Annotations.Name == term {
+				terms[index] = s.ID
+				break
 			}
+
 			// attempt to lookup secret by partial ID (prefix)
-			// return error if more than one matches found (ambiguous)
-			n := 0
-			for _, s := range secrets {
-				if strings.HasPrefix(s.ID, term) {
-					found[s.ID] = struct{}{}
-					n++
-				}
-			}
-			if n > 1 {
-				return nil, fmt.Errorf("secret %s is ambiguous (%d matches found)", term, n)
+			if strings.HasPrefix(s.ID, term) {
+				terms[index] = s.ID
+				break
 			}
 		}
-
-		// We already collected all the IDs found.
-		// Now we will remove duplicates by converting the map to slice
-		ids := []string{}
-		for id := range found {
-			ids = append(ids, id)
-		}
-
-		return ids, nil
 	}
 
 	return terms, nil

--- a/integration-cli/docker_cli_secret_rm_test.go
+++ b/integration-cli/docker_cli_secret_rm_test.go
@@ -1,0 +1,32 @@
+// +build !windows
+
+package main
+
+import (
+	"strings"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSwarmSuite) TestSecretRm(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	testName := "test_secret"
+	id := d.createSecret(c, swarm.SecretSpec{
+		swarm.Annotations{
+			Name: testName,
+		},
+		[]byte("TESTINGDATA"),
+	})
+	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
+
+	secret := d.getSecret(c, id)
+	c.Assert(secret.Spec.Name, checker.Equals, testName)
+
+	out, _ := d.Cmd("secret", "rm", "test_secret", "non-exist", "non-exist2")
+	c.Assert(strings.TrimSpace(out), checker.Contains, id)
+	c.Assert(strings.TrimSpace(out), checker.Contains, "could not find secret non-exist")
+	c.Assert(strings.TrimSpace(out), checker.Contains, "could not find secret non-exist2")
+}


### PR DESCRIPTION
fix https://github.com/docker/docker/issues/29125

**- What I did**
1. make `getCliRequestedSecretIDs` returned slice have equal length of input slice
2. add a secret remove test file

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: allencloud <allen.sun@daocloud.io>