### PR TITLE
Add headers when using exec

### DIFF
--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -92,10 +92,16 @@ func (s *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 		defer httputils.CloseStreams(inStream, outStream)
 
 		if _, ok := r.Header["Upgrade"]; ok {
-			fmt.Fprintf(outStream, "HTTP/1.1 101 UPGRADED\r\nContent-Type: application/vnd.docker.raw-stream\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\n")
+			fmt.Fprint(outStream, "HTTP/1.1 101 UPGRADED\r\nContent-Type: application/vnd.docker.raw-stream\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n")
 		} else {
-			fmt.Fprintf(outStream, "HTTP/1.1 200 OK\r\nContent-Type: application/vnd.docker.raw-stream\r\n\r\n")
+			fmt.Fprint(outStream, "HTTP/1.1 200 OK\r\nContent-Type: application/vnd.docker.raw-stream\r\n")
 		}
+
+		// copy headers that were removed as part of hijack
+		if err := w.Header().WriteSubset(outStream, nil); err != nil {
+			return err
+		}
+		fmt.Fprint(outStream, "\r\n")
 
 		stdin = inStream
 		stdout = outStream

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -89,6 +89,16 @@ func (s *DockerSuite) TestExecAPIStart(c *check.C) {
 	startExec(c, id, http.StatusOK)
 }
 
+func (s *DockerSuite) TestExecAPIStartEnsureHeaders(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	dockerCmd(c, "run", "-d", "--name", "test", "busybox", "top")
+
+	id := createExec(c, "test")
+	resp, _, err := sockRequestRaw("POST", fmt.Sprintf("/exec/%s/start", id), strings.NewReader(`{"Detach": true}`), "application/json")
+	c.Assert(err, checker.IsNil)
+	c.Assert(resp.Header.Get("Server"), checker.Not(checker.Equals), "")
+}
+
 func (s *DockerSuite) TestExecAPIStartBackwardsCompatible(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Windows only supports 1.25 or later
 	runSleepingContainer(c, "-d", "--name", "test")


### PR DESCRIPTION
This fixes a bug where CORS headers are not added when using exec (hijack).

Closes #29068