### PR TITLE
Fix issue for `--hostname` when running in "--net=host"

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -101,7 +102,7 @@ func (daemon *Daemon) Register(c *container.Container) error {
 	return nil
 }
 
-func (daemon *Daemon) newContainer(name string, config *containertypes.Config, imgID image.ID, managed bool) (*container.Container, error) {
+func (daemon *Daemon) newContainer(name string, config *containertypes.Config, hostConfig *containertypes.HostConfig, imgID image.ID, managed bool) (*container.Container, error) {
 	var (
 		id             string
 		err            error
@@ -112,7 +113,16 @@ func (daemon *Daemon) newContainer(name string, config *containertypes.Config, i
 		return nil, err
 	}
 
-	daemon.generateHostname(id, config)
+	if hostConfig.NetworkMode.IsHost() {
+		if config.Hostname == "" {
+			config.Hostname, err = os.Hostname()
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		daemon.generateHostname(id, config)
+	}
 	entrypoint, args := daemon.getEntrypointAndArgs(config.Entrypoint, config.Cmd)
 
 	base := daemon.newBaseContainer(id)

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -851,9 +851,11 @@ func (daemon *Daemon) initializeNetworking(container *container.Container) error
 	}
 
 	if container.HostConfig.NetworkMode.IsHost() {
-		container.Config.Hostname, err = os.Hostname()
-		if err != nil {
-			return err
+		if container.Config.Hostname == "" {
+			container.Config.Hostname, err = os.Hostname()
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -96,7 +96,7 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig, managed bool) (
 		return nil, err
 	}
 
-	if container, err = daemon.newContainer(params.Name, params.Config, imgID, managed); err != nil {
+	if container, err = daemon.newContainer(params.Name, params.Config, params.HostConfig, imgID, managed); err != nil {
 		return nil, err
 	}
 	defer func() {

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4660,3 +4660,12 @@ func (s *DockerSuite) TestRunMountReadOnlyDevShm(c *check.C) {
 	c.Assert(err, checker.NotNil, check.Commentf(out))
 	c.Assert(out, checker.Contains, "Read-only file system")
 }
+
+// Test case for 29129
+func (s *DockerSuite) TestRunHostnameInHostMode(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	expectedOutput := "foobar\nfoobar"
+	out, _ := dockerCmd(c, "run", "--net=host", "--hostname=foobar", "busybox", "sh", "-c", `echo $HOSTNAME && hostname`)
+	c.Assert(strings.TrimSpace(out), checker.Equals, expectedOutput)
+}


### PR DESCRIPTION
**- What I did**

This fix tries to address the issue raised in #29129 where "--hostname" not working when running in "--net=host" for `docker run`.

**- How I did it**

The fix fixes the issue by not resetting the `container.Config.Hostname` if the `Hostname` has already been assigned through `--hostname`.

**- How to verify it**

An integration test has been added to cover the changes.

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

![cats-cute-christmas-cat-animal-hat-santa-kitten-cool-wallpapers-640x360](https://cloud.githubusercontent.com/assets/6932348/20894405/24b12650-baca-11e6-889f-c00255452bd7.jpg)


This fix fixes #29129.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>