### PR TITLE
Windows: make.ps1 Throw exception on failure

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -394,6 +394,8 @@ Catch [Exception] {
     Write-Host -ForegroundColor Red  " \___  /  (____  /__`|____/\___  `>____ `| "
     Write-Host -ForegroundColor Red  "     \/        \/             \/     \/ "
     Write-Host
+
+    Throw $_
 }
 Finally {
     if ($global:pushed) { Pop-Location }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@johnstep If not done, the CI script doesn't pick up the failures. 

@thaJeztah @vieux Should also be cherry-picked for 1.13