### PR TITLE
Windows: make.ps1 calc root

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -303,7 +303,10 @@ Function Run-UnitTests() {
 # Start of main code.
 Try {
     Write-Host -ForegroundColor Cyan "INFO: make.ps1 starting at $(Get-Date)"
-    $root=$(pwd)
+
+    # Get to the root of the repo
+    $root = $(Split-Path $MyInvocation.MyCommand.Definition -Parent | Split-Path -Parent)
+    Push-Location $root
 
     # Handle the "-All" shortcut to turn on all things we can handle.
     if ($All) { $Client=$True; $Daemon=$True; $DCO=$True; $PkgImports=$True; $GoFormat=$True; $TestUnit=$True }
@@ -396,6 +399,7 @@ Catch [Exception] {
     Write-Host
 }
 Finally {
+    Pop-Location # As we pushed to the root of the repo as the very first thing
     if ($global:pushed) { Pop-Location }
     Write-Host -ForegroundColor Cyan "INFO: make.ps1 ended at $(Get-Date)"
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@johnstep Minor tweak to make.ps1 so that it calculates the root from the invocation path. So if (like me) you have an environment script to start your dev environment, and include hack\ in the path, you can just run `make.ps1 -Binary` from any location including a different drive, rather than `cd <root>; hack\make.ps1 -Binary`. Saves a lot of typing :smile: