### PR TITLE
Windows: Dockerfile 2GB clarification Hyper-V

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -62,14 +62,17 @@
 #    >>   cd C:\go\src\github.com\docker\docker 
 #
 #
-# 3. Build a docker image with the components required to build the docker binaries from source:
+# 3. Build a docker image with the components required to build the docker binaries from source
+#    by running one of the following:
 #
-#    >>   docker build -t nativebuildimage -f Dockerfile.windows .
+#    >>   docker build -t nativebuildimage -f Dockerfile.windows .          
+#    >>   docker build -t nativebuildimage -f Dockerfile.windows -m 2GB .    (if using Hyper-V containers)
 #
 #
-# 4. Build the docker executable binaries:
+# 4. Build the docker executable binaries by running one of the following:
 #
 #    >>   docker run --name binaries nativebuildimage hack\make.ps1 -Binary
+#    >>   docker run --name binaries -m 2GB nativebuildimage hack\make.ps1 -Binary    (if using Hyper-V containers)
 #
 #
 # 5. Copy the binaries out of the container, replacing HostPath with an appropriate destination 
@@ -96,10 +99,11 @@
 
 
 #  The validation tests can either run in a container, or directly on the host. To run in a
-#  container, ensure you have created the nativebuildimage above. Then run the following
-#  from an (elevated) Windows PowerShell prompt:
+#  container, ensure you have created the nativebuildimage above. Then run one of the
+#  following from an (elevated) Windows PowerShell prompt:
 #
 #    >>   docker run --rm nativebuildimage hack\make.ps1 -DCO -PkgImports -GoFormat
+#    >>   docker run --rm -m 2GB nativebuildimage hack\make.ps1 -DCO -PkgImports -GoFormat    (if using Hyper-V containers)
 
 # To run the validation tests on the host, from the root of the repository, run the
 # following from a Windows PowerShell prompt (elevation is not required): (Note Go
@@ -110,20 +114,21 @@
 # -----------------------------------------------------------------------------------------
 
 
-#  To run unit tests, ensure you have created the nativebuildimage above. Then run the
-#  following from an (elevated) Windows PowerShell prompt:
+#  To run unit tests, ensure you have created the nativebuildimage above. Then run one of
+#  the following from an (elevated) Windows PowerShell prompt:
 #
 #    >>   docker run --rm nativebuildimage hack\make.ps1 -TestUnit
+#    >>   docker run --rm -m 2GB nativebuildimage hack\make.ps1 -TestUnit    (if using Hyper-V containers)
 
 
 # -----------------------------------------------------------------------------------------
 
 
 #  To run all tests and binary build, ensure you have created the nativebuildimage above. Then 
-# run the following from an (elevated) Windows PowerShell prompt:
+#  run one of the following from an (elevated) Windows PowerShell prompt:
 #
 #    >>   docker run nativebuildimage hack\make.ps1 -All
-
+#    >>   docker run -m 2GB nativebuildimage hack\make.ps1 -All    (if using Hyper-V containers)
 
 # -----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Adds explicit clarification of using `-m 2GB` for Hyper-V containers to ensure the utility VM has enough memory to complete the operation successfully.  @johnstep 