### PR TITLE
cluster: Refuse swarm spec not named "default"

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"encoding/json"
+	stdliberrors "errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -1322,6 +1323,8 @@ func validateAndSanitizeInitRequest(req *types.InitRequest) error {
 	// provide sane defaults instead of erroring
 	if spec.Name == "" {
 		spec.Name = "default"
+	} else if spec.Name != "default" {
+		return stdliberrors.New(`swarm spec must be named "default"`)
 	}
 	if spec.Raft.SnapshotInterval == 0 {
 		spec.Raft.SnapshotInterval = defaultSpec.Raft.SnapshotInterval


### PR DESCRIPTION
If, using the API, a user submits an init request with a spec that has a
name other than "default", the engine will rename the "default" cluster
object. Some parts of swarmkit depend on having a cluster object named
"default". Reject any specs that use other names.

Backport of #28914.

cc @vieux