### PR TITLE
Ensure that the node status is no longer pending when checking lock/unlock.

### DIFF
--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -797,6 +797,7 @@ func (s *DockerSwarmSuite) TestDNSConfigUpdate(c *check.C) {
 }
 
 func getNodeStatus(c *check.C, d *SwarmDaemon) swarm.LocalNodeState {
+	waitAndAssert(c, defaultReconciliationTimeout, d.checkLocalNodeState, checker.Not(checker.Equals), swarm.LocalNodeStatePending)
 	info, err := d.info()
 	c.Assert(err, checker.IsNil)
 	return info.LocalNodeState


### PR DESCRIPTION
This is an addendum to https://github.com/docker/docker/pull/28997.  cc @aaronlehmann 