### PR TITLE
Windows: Bump to latest version of git

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -161,7 +161,7 @@ SHELL ["powershell", "-command"]
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
 ENV GO_VERSION=1.7.3 `
-    GIT_VERSION=2.10.2 `
+    GIT_VERSION=2.11.0 `
     GOPATH=C:\go `
     FROM_DOCKERFILE=1
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Bump the version of git for Windows to the latest (2.11.0)