### PR TITLE
Warn/deprecate continuing on empty lines in `Dockerfile`

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -157,7 +157,7 @@ func NewBuilder(clientCtx context.Context, config *types.ImageBuildOptions, back
 	parser.SetEscapeToken(parser.DefaultEscapeToken, &b.directive) // Assume the default token for escape
 
 	if dockerfile != nil {
-		b.dockerfile, err = parser.Parse(dockerfile, &b.directive)
+		b.dockerfile, err = parser.Parse(dockerfile, b.Stderr, &b.directive)
 		if err != nil {
 			return nil, err
 		}
@@ -364,7 +364,7 @@ func BuildFromConfig(config *container.Config, changes []string) (*container.Con
 		return nil, err
 	}
 
-	ast, err := parser.Parse(bytes.NewBufferString(strings.Join(changes, "\n")), &b.directive)
+	ast, err := parser.Parse(bytes.NewBufferString(strings.Join(changes, "\n")), b.Stderr, &b.directive)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/dockerfile/builder_test.go
+++ b/builder/dockerfile/builder_test.go
@@ -1,6 +1,7 @@
 package dockerfile
 
 import (
+	"io/ioutil"
 	"strings"
 
 	"testing"
@@ -14,7 +15,7 @@ func TestBuildProcessLabels(t *testing.T) {
 	dockerfile := "FROM scratch"
 	d := parser.Directive{}
 	parser.SetEscapeToken(parser.DefaultEscapeToken, &d)
-	n, err := parser.Parse(strings.NewReader(dockerfile), &d)
+	n, err := parser.Parse(strings.NewReader(dockerfile), ioutil.Discard, &d)
 	if err != nil {
 		t.Fatalf("Error when parsing Dockerfile: %s", err)
 	}

--- a/builder/dockerfile/evaluator_test.go
+++ b/builder/dockerfile/evaluator_test.go
@@ -173,7 +173,7 @@ func executeTestCase(t *testing.T, testCase dispatchTestCase) {
 	r := strings.NewReader(testCase.dockerfile)
 	d := parser.Directive{}
 	parser.SetEscapeToken(parser.DefaultEscapeToken, &d)
-	n, err := parser.Parse(r, &d)
+	n, err := parser.Parse(r, ioutil.Discard, &d)
 
 	if err != nil {
 		t.Fatalf("Error when parsing Dockerfile: %s", err)

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -454,7 +454,7 @@ func (b *Builder) processImageFrom(img builder.Image) error {
 
 	// parse the ONBUILD triggers by invoking the parser
 	for _, step := range onBuildTriggers {
-		ast, err := parser.Parse(strings.NewReader(step), &b.directive)
+		ast, err := parser.Parse(strings.NewReader(step), b.Stderr, &b.directive)
 		if err != nil {
 			return err
 		}
@@ -690,7 +690,7 @@ func (b *Builder) parseDockerfile() error {
 			return fmt.Errorf("The Dockerfile (%s) cannot be empty", b.options.Dockerfile)
 		}
 	}
-	b.dockerfile, err = parser.Parse(f, &b.directive)
+	b.dockerfile, err = parser.Parse(f, b.Stderr, &b.directive)
 	if err != nil {
 		return err
 	}

--- a/builder/dockerfile/parser/dumper/main.go
+++ b/builder/dockerfile/parser/dumper/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 
 	"github.com/docker/docker/builder/dockerfile/parser"
@@ -26,7 +27,7 @@ func main() {
 		d := parser.Directive{LookingForDirectives: true}
 		parser.SetEscapeToken(parser.DefaultEscapeToken, &d)
 
-		ast, err := parser.Parse(f, &d)
+		ast, err := parser.Parse(f, ioutil.Discard, &d)
 		if err != nil {
 			panic(err)
 		} else {

--- a/builder/dockerfile/parser/parser_test.go
+++ b/builder/dockerfile/parser/parser_test.go
@@ -42,7 +42,7 @@ func TestTestNegative(t *testing.T) {
 
 		d := Directive{LookingForDirectives: true}
 		SetEscapeToken(DefaultEscapeToken, &d)
-		_, err = Parse(df, &d)
+		_, err = Parse(df, ioutil.Discard, &d)
 		if err == nil {
 			t.Fatalf("No error parsing broken dockerfile for %s", dir)
 		}
@@ -62,7 +62,7 @@ func TestTestData(t *testing.T) {
 
 		d := Directive{LookingForDirectives: true}
 		SetEscapeToken(DefaultEscapeToken, &d)
-		ast, err := Parse(df, &d)
+		ast, err := Parse(df, ioutil.Discard, &d)
 		if err != nil {
 			t.Fatalf("Error parsing %s's dockerfile: %v", dir, err)
 		}
@@ -145,7 +145,7 @@ func TestLineInformation(t *testing.T) {
 
 	d := Directive{LookingForDirectives: true}
 	SetEscapeToken(DefaultEscapeToken, &d)
-	ast, err := Parse(df, &d)
+	ast, err := Parse(df, ioutil.Discard, &d)
 	if err != nil {
 		t.Fatalf("Error parsing dockerfile %s: %v", testFileLineInfo, err)
 	}

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -20,6 +20,12 @@ The following list of features are deprecated in Engine.
 To learn more about Docker Engine's deprecation policy,
 see [Feature Deprecation Policy](https://docs.docker.com/engine/#feature-deprecation-policy).
 
+### Empty line continuation for `Dockerfile`
+**Deprecated In Release: v17.05.0**
+
+The empty lines in `Dockerfile` used to indicate continuation, as long as the last non-empty
+line ends with escape. This rule is being deprecated and a warning is generated.
+
 ### `-g` and `--graph` flags on `dockerd`
 
 **Deprecated In Release: v17.05.0**


### PR DESCRIPTION
This fix is related to #29005 and #24693. Currently in `Dockerfile` empty lines will continue as long as there is line escape before. This may cause some issues. The issue in 24693 is an example. A non-empty line after an empty line might be considered to be a separate instruction by many users. However, it is actually part of the last instruction under the current `Dockerfile` parsing rule.

This fix is an effort to reduce the confusion around the parsing of `Dockerfile`. Even though this fix does not change the behavior of the `Dockerfile` parsing, it tries to deprecate the empty line continuation and present a warning for the user. In this case, at least it prompt users to check for the Dockerfile and avoid the confusion if possible.

Here are some of the examples:
1. No warning for comments continuation
```
ubuntu@ubuntu:~/tmp$ cat Dockerfile 
FROM busybox
RUN echo \
# comment
hi
ubuntu@ubuntu:~/tmp$ sudo docker build -t test .
Sending build context to Docker daemon  11.2 MB
Step 1/2 : FROM busybox
 ---> e02e811dd08f
Step 2/2 : RUN echo hi
 ---> Running in 982812e845b2
hi
 ---> 58c355115a35
Removing intermediate container 982812e845b2
Successfully built 58c355115a35
ubuntu@ubuntu:~/tmp$ 
```

2. Warning for empty line continuation:
```
ubuntu@ubuntu:~/tmp$ cat Dockerfile 
FROM busybox
RUN echo "foo" \
#&& echo "bar";



# Do something else
RUN echo "something else"

RUN echo "end"
ubuntu@ubuntu:~/tmp$ sudo docker build -t test .
Sending build context to Docker daemon  11.2 MB
[WARNING]: Empty lines detected in the following instruction:
[WARNING]:   RUN echo "foo" \
[WARNING]:   #&& echo "bar";
[WARNING]:   
[WARNING]:   
[WARNING]:   
[WARNING]:   # Do something else
[WARNING]:   RUN echo "something else"
[WARNING]: Empty lines inside a RUN instruction is deprecated, and will be removed in Docker 1.16.
Step 1/3 : FROM busybox
 ---> e02e811dd08f
Step 2/3 : RUN echo "foo" RUN echo "something else"
 ---> Running in 0c95c73c0e6b
foo RUN echo something else
 ---> e94a89843d4b
Removing intermediate container 0c95c73c0e6b
Step 3/3 : RUN echo "end"
 ---> Running in 22d749190d5d
end
 ---> 82e486951d62
Removing intermediate container 22d749190d5d
Successfully built 82e486951d62
```

3. No warning as long as there are escaping symbols for each line:
```
ubuntu@ubuntu:~/tmp$ cat Dockerfile 
FROM busybox
RUN echo "foo"; \
\
# This is a comment
\
    # So is this
    \
    echo "and this is part of the same RUN"


RUN echo "this is the next RUN"
ubuntu@ubuntu:~/tmp$ sudo docker build -t test .
[sudo] password for ubuntu: 
Sending build context to Docker daemon  11.2 MB
Step 1/3 : FROM busybox
 ---> e02e811dd08f
Step 2/3 : RUN echo "foo";         echo "and this is part of the same RUN"
 ---> Running in cf785c61ed05
foo
and this is part of the same RUN
 ---> e375992a8a57
Removing intermediate container cf785c61ed05
Step 3/3 : RUN echo "this is the next RUN"
 ---> Running in cba814794d62
this is the next RUN
 ---> 712c017c8ef1
Removing intermediate container cba814794d62
Successfully built 712c017c8ef1
ubuntu@ubuntu:~/tmp$ 
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>