### PR TITLE
refine the status code of node/image/service remove

### DIFF
--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -205,6 +205,7 @@ func (sr *swarmRouter) removeService(ctx context.Context, w http.ResponseWriter,
 		logrus.Errorf("Error removing service %s: %v", vars["id"], err)
 		return err
 	}
+	w.WriteHeader(http.StatusNoContent)
 	return nil
 }
 
@@ -315,6 +316,7 @@ func (sr *swarmRouter) removeNode(ctx context.Context, w http.ResponseWriter, r 
 		logrus.Errorf("Error removing node %s: %v", vars["id"], err)
 		return err
 	}
+	w.WriteHeader(http.StatusNoContent)
 	return nil
 }
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4754,7 +4754,7 @@ paths:
       produces:
         - "application/json"
       responses:
-        200:
+        204:
           description: "No error"
           schema:
             type: "array"
@@ -6764,7 +6764,7 @@ paths:
       summary: "Delete a node"
       operationId: "NodeDelete"
       responses:
-        200:
+        204:
           description: "no error"
         404:
           description: "no such node"
@@ -7241,7 +7241,7 @@ paths:
       summary: "Delete a service"
       operationId: "ServiceDelete"
       responses:
-        200:
+        204:
           description: "no error"
         404:
           description: "no such service"

--- a/integration-cli/daemon/daemon_swarm.go
+++ b/integration-cli/daemon/daemon_swarm.go
@@ -242,7 +242,7 @@ func (d *Swarm) UpdateService(c *check.C, service *swarm.Service, f ...ServiceCo
 func (d *Swarm) RemoveService(c *check.C, id string) {
 	status, out, err := d.SockRequest("DELETE", "/services/"+id, nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
-	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
+	c.Assert(status, checker.Equals, http.StatusNoContent, check.Commentf("output: %q", string(out)))
 }
 
 // GetNode returns a swarm node identified by the specified id
@@ -265,7 +265,7 @@ func (d *Swarm) RemoveNode(c *check.C, id string, force bool) {
 
 	status, out, err := d.SockRequest("DELETE", url, nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
-	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
+	c.Assert(status, checker.Equals, http.StatusNoContent, check.Commentf("output: %q", string(out)))
 }
 
 // UpdateNode updates a swarm node with the specified node constructor


### PR DESCRIPTION
Hi, this PR based on #28917, refine the node/image/service remove status code , in order to keep consistent with the existing remove operation (eg. container/volume/network remove).

So I edit the swagger.yaml file status code from 200 to 204 at the following locates:

service remove : https://github.com/docker/docker/blob/master/api/swagger.yaml#L7213
image remove : https://github.com/docker/docker/blob/master/api/swagger.yaml#L4743
node remove : https://github.com/docker/docker/blob/master/api/swagger.yaml#L6736

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: erxian <evelynhsu21@gmail.com>