### PR TITLE
add 403 for endpoint network create

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6119,6 +6119,10 @@ paths:
             example:
               Id: "22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30"
               Warning: ""
+        403:
+          description: "operation not supported for pre-defined networks"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "plugin not found"
           schema:

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -3319,6 +3319,7 @@ Content-Type: application/json
 **Status codes**:
 
 - **201** - no error
+- **403** - operation not supported for pre-defined networks
 - **404** - plugin not found
 - **500** - server error
 


### PR DESCRIPTION
fixes #29165 

I found status 403 is missing in the docs about endpoint `POST /networks/create`.

**- What I did**
1. add 403 in api doc 1.24;
2. add 403 in swagger.yml. While for swagger side, I have no idea if it is the final step to add code in swagger.yml, do I have to do any other steps, like "swagger generate" or something else like that? 


Signed-off-by: allencloud <allen.sun@daocloud.io>