### PR TITLE
Add variable DOCKER_BUILD_ARGS to build-deb script

### DIFF
--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -82,7 +82,7 @@ set -e
 			RUN dpkg-buildpackage -uc -us -I.git
 		EOF
 		tempImage="docker-temp/build-deb:$version"
-		( set -x && docker build -t "$tempImage" -f "$DEST/$version/Dockerfile.build" . )
+		( set -x && docker build ${DOCKER_BUILD_ARGS} -t "$tempImage" -f "$DEST/$version/Dockerfile.build" . )
 		docker run --rm "$tempImage" bash -c 'cd .. && tar -c *_*' | tar -xvC "$DEST/$version"
 		docker rmi "$tempImage"
 	done


### PR DESCRIPTION
Some containers were being built (`docker build`) without the DOCKER_BUILD_ARGS variable, which was causing some issues because of the lack of network proxy configuration.

**- What I did**
Fix the build-deb script (hack/make/build-deb)

**- How I did it**
Add `${DOCKER_BUILD_ARGS}` variable to the `docker build` command.

**- How to verify it**
```sh
make deb
```
(ensure that you are in a network behind a proxy)

**- Description for the changelog**
Add variable DOCKER_BUILD_ARGS to build-deb script

**- A picture of a cute animal (not mandatory but encouraged)**

Fixes #29132

Signed-off-by: Luiz Svoboda <luizek@gmail.com>