### PR TITLE
Fix `docker inspect <unkown object>` issue on Windows

### DIFF
--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -447,3 +447,12 @@ func (s *DockerSuite) TestInspectPlugin(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, pNameWithTag)
 }
+
+// Test case for 29185
+func (s *DockerSuite) TestInspectUnknownObject(c *check.C) {
+	// This test should work on both Windows and Linux
+	out, _, err := dockerCmdWithError("inspect", "foobar")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "Error: No such object: foobar")
+	c.Assert(err.Error(), checker.Contains, "Error: No such object: foobar")
+}

--- a/plugin/backend_unsupported.go
+++ b/plugin/backend_unsupported.go
@@ -4,6 +4,7 @@ package plugin
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -24,8 +25,11 @@ func (pm *Manager) Enable(name string, config *types.PluginEnableConfig) error {
 }
 
 // Inspect examines a plugin config
-func (pm *Manager) Inspect(name string) (tp types.Plugin, err error) {
-	return tp, errNotSupported
+func (pm *Manager) Inspect(refOrID string) (tp types.Plugin, err error) {
+	// Even though plugin is not supported, we still want to return `not found`
+	// error so that `docker inspect` (without `--type` specified) returns correct
+	// `not found` message
+	return tp, fmt.Errorf("no such plugin name or ID associated with %q", refOrID)
 }
 
 // Privileges pulls a plugin config and computes the privileges required to install it.


### PR DESCRIPTION
**- What I did**

This fix tries to address the issue raised on #29185 where `docker inspect <unknown object>` on Windows will return:
```
Error response from daemon: plugins are not supported on this platform
```

The reason was that in case `--type` is not specified, `docker inspect` will iterate through different types `container`, `image`, `network`, `plugin` etc. The `plugin` object is the last type to check.

However, as `plugin` is not supported on Windows yet, the error message is not very informative for `plugins are not supported on this platform`.

**- How I did it**

This fix tries to fix the issue by return a `not found` error on unsupported platforms as well for plugin types.

**- How to verify it**

An integration test has been added to cover the changes for Windows/Linux.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![40-beautiful-and-cute-kitten-pictures-2](https://cloud.githubusercontent.com/assets/6932348/20938744/0be13ba6-bba1-11e6-878a-4c8e147ba541.jpg)


This fix fixes #29185.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>