### PR TITLE
Make sure we don't run integration cli test if compilation fails

### DIFF
--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -24,6 +24,7 @@ go_test_dir() {
 	testcover=()
 	testcoverprofile=()
 	(
+		set -e
 		mkdir -p "$DEST/coverprofiles"
 		export DEST="$ABS_DEST" # in a subshell this is safe -- our integration-cli tests need DEST, and "cd" screws it up
 		if [ -z $precompiled ]; then


### PR DESCRIPTION
Otherwise, while using test-integration-shell, it runs the tests using the previously compiled test binary.

To verify this, on master, run :

```
$ make BIND_DIR=. shell
# […]
$ ./hack/make.sh binary test-integration-shell
# […]
$ bundle_test_integration_cli
# […]
# Should run the entire suite
# Now edit a file so that it doesn't compile
# and re run the tests
$ bundle_test_integration_cli
# […]
# There should be a compilation error
# BUT it will run the entires suite again, using the old binary
```

/cc @tianon @dnephin @cpuguy83 

🐸