### PR TITLE
return node is not a swarm when unlock a normal node

### DIFF
--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -835,6 +835,29 @@ func checkSwarmUnlockedToLocked(c *check.C, d *daemon.Swarm) {
 	c.Assert(getNodeStatus(c, d), checker.Equals, swarm.LocalNodeStateLocked)
 }
 
+func (s *DockerSwarmSuite) TestUnlockEngineAndUnlockedSwarm(c *check.C) {
+	d := s.AddDaemon(c, false, false)
+
+	// unlocking a normal engine should return an error
+	cmd := d.Command("swarm", "unlock")
+	cmd.Stdin = bytes.NewBufferString("wrong-secret-key")
+	outs, err := cmd.CombinedOutput()
+
+	c.Assert(err, checker.NotNil, check.Commentf("out: %v", string(outs)))
+	c.Assert(string(outs), checker.Contains, "This node is not a swarm manager.")
+
+	_, err = d.Cmd("swarm", "init")
+	c.Assert(err, checker.IsNil)
+
+	// unlocking an unlocked swarm should return an error
+	cmd = d.Command("swarm", "unlock")
+	cmd.Stdin = bytes.NewBufferString("wrong-secret-key")
+	outs, err = cmd.CombinedOutput()
+
+	c.Assert(err, checker.NotNil, check.Commentf("out: %v", string(outs)))
+	c.Assert(string(outs), checker.Contains, "swarm is not locked")
+}
+
 func (s *DockerSwarmSuite) TestSwarmInitLocked(c *check.C) {
 	d := s.AddDaemon(c, false, false)
 


### PR DESCRIPTION
Hi, All,

I found that in docker/master, cluster has been refactored.
And when I test new code, I found that unlock a normal node, daemon returns `swarm is not locked`. I think it is better to return an error "this node is not swarm manager...."

**- What I did**
1. make daemon return more accurate error 
2. add a test case to verify this.

This did the same thing as https://github.com/docker/docker/pull/28533
/cc @aaronlehmann @tonistiigi 

Signed-off-by: allencloud <allen.sun@daocloud.io>