### PR TITLE
Specify content type in the build request

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4399,8 +4399,8 @@ paths:
           in: "header"
           type: "string"
           enum:
-            - "application/tar"
-          default: "application/tar"
+            - "application/x-tar"
+          default: "application/x-tar"
         - name: "X-Registry-Config"
           in: "header"
           description: |

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -29,7 +29,7 @@ func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, optio
 		return types.ImageBuildResponse{}, err
 	}
 	headers.Add("X-Registry-Config", base64.URLEncoding.EncodeToString(buf))
-	headers.Set("Content-Type", "application/tar")
+	headers.Set("Content-Type", "application/x-tar")
 
 	serverResp, err := cli.postRaw(ctx, "/build", query, buildContext, headers)
 	if err != nil {

--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -170,8 +170,8 @@ func TestImageBuild(t *testing.T) {
 					return nil, fmt.Errorf("X-Registry-Config header not properly set in the request. Expected '%s', got %s", buildCase.expectedRegistryConfig, registryConfig)
 				}
 				contentType := r.Header.Get("Content-Type")
-				if contentType != "application/tar" {
-					return nil, fmt.Errorf("Content-type header not properly set in the request. Expected 'application/tar', got %s", contentType)
+				if contentType != "application/x-tar" {
+					return nil, fmt.Errorf("Content-type header not properly set in the request. Expected 'application/x-tar', got %s", contentType)
 				}
 
 				// Check query parameters

--- a/client/plugin_create.go
+++ b/client/plugin_create.go
@@ -12,7 +12,7 @@ import (
 // PluginCreate creates a plugin
 func (cli *Client) PluginCreate(ctx context.Context, createContext io.Reader, createOptions types.PluginCreateOptions) error {
 	headers := http.Header(make(map[string][]string))
-	headers.Set("Content-Type", "application/tar")
+	headers.Set("Content-Type", "application/x-tar")
 
 	query := url.Values{}
 	query.Set("name", createOptions.RepoName)

--- a/docs/api/v1.18.md
+++ b/docs/api/v1.18.md
@@ -1192,6 +1192,7 @@ Build an image from a Dockerfile
 **Example request**:
 
     POST /v1.18/build HTTP/1.1
+    Content-Type: application/x-tar
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1246,7 +1247,7 @@ or being killed.
 
 **Request Headers**:
 
--   **Content-type** – Set to `"application/tar"`.
+-   **Content-type** – Set to `"application/x-tar"`.
 -   **X-Registry-Config** – base64-encoded ConfigFile object
 
 **Status codes**:

--- a/docs/api/v1.19.md
+++ b/docs/api/v1.19.md
@@ -1236,6 +1236,7 @@ Build an image from a Dockerfile
 **Example request**:
 
     POST /v1.19/build HTTP/1.1
+    Content-Type: application/x-tar
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1292,7 +1293,7 @@ or being killed.
 
 **Request Headers**:
 
--   **Content-type** – Set to `"application/tar"`.
+-   **Content-type** – Set to `"application/x-tar"`.
 -   **X-Registry-Config** – base64-encoded ConfigFile object
 
 **Status codes**:

--- a/docs/api/v1.20.md
+++ b/docs/api/v1.20.md
@@ -1365,6 +1365,7 @@ Build an image from a Dockerfile
 **Example request**:
 
     POST /v1.20/build HTTP/1.1
+    Content-Type: application/x-tar
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1425,7 +1426,7 @@ or being killed.
 
 **Request Headers**:
 
--   **Content-type** – Set to `"application/tar"`.
+-   **Content-type** – Set to `"application/x-tar"`.
 -   **X-Registry-Config** – A base64-url-safe-encoded Registry Auth Config JSON
         object with the following structure:
 

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -1448,6 +1448,7 @@ Build an image from a Dockerfile
 **Example request**:
 
     POST /v1.21/build HTTP/1.1
+    Content-Type: application/x-tar
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1514,7 +1515,7 @@ or being killed.
 
 **Request Headers**:
 
--   **Content-type** – Set to `"application/tar"`.
+-   **Content-type** – Set to `"application/x-tar"`.
 -   **X-Registry-Config** – A base64-url-safe-encoded Registry Auth Config JSON
         object with the following structure:
 

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -1627,6 +1627,7 @@ Build an image from a Dockerfile
 **Example request**:
 
     POST /v1.22/build HTTP/1.1
+    Content-Type: application/x-tar
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1694,7 +1695,7 @@ or being killed.
 
 **Request Headers**:
 
--   **Content-type** – Set to `"application/tar"`.
+-   **Content-type** – Set to `"application/x-tar"`.
 -   **X-Registry-Config** – A base64-url-safe-encoded Registry Auth Config JSON
         object with the following structure:
 

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -1662,6 +1662,7 @@ Build an image from a Dockerfile
 **Example request**:
 
     POST /v1.23/build HTTP/1.1
+    Content-Type: application/x-tar
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1730,7 +1731,7 @@ or being killed.
 
 **Request Headers**:
 
--   **Content-type** – Set to `"application/tar"`.
+-   **Content-type** – Set to `"application/x-tar"`.
 -   **X-Registry-Config** – A base64-url-safe-encoded Registry Auth Config JSON
         object with the following structure:
 

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -1659,6 +1659,7 @@ Build an image from a Dockerfile
 **Example request**:
 
     POST /v1.24/build HTTP/1.1
+    Content-Type: application/x-tar
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1727,7 +1728,7 @@ or being killed.
 
 **Request Headers**:
 
--   **Content-type** – Set to `"application/tar"`.
+-   **Content-type** – Set to `"application/x-tar"`.
 -   **X-Registry-Config** – A base64-url-safe-encoded Registry Auth Config JSON
         object with the following structure:
 

--- a/pkg/httputils/mimetype.go
+++ b/pkg/httputils/mimetype.go
@@ -8,9 +8,8 @@ import (
 // MimeTypes stores the MIME content type.
 var MimeTypes = struct {
 	TextPlain   string
-	Tar         string
 	OctetStream string
-}{"text/plain", "application/tar", "application/octet-stream"}
+}{"text/plain", "application/octet-stream"}
 
 // DetectContentType returns a best guess representation of the MIME
 // content type for the bytes at c.  The value detected by


### PR DESCRIPTION
**- What I did**
Updated the code and the docs to use "application/x-tar" instead of "application/tar"

**- How I did it**
* Update the "build image from dockerfile" chapter in the API docs
* Set the "Content-Type" header to "application/x-tar" in the client side (both for the build and the plugin-create commands)

**- How to verify it**
Run tests.

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**
![Cute shark](http://cdn.wallpapersafari.com/18/68/AtRSwa.jpg)