### PR TITLE
validate CHANGELOG.md is well-formed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1119,7 +1119,7 @@ that allows to add build-time environment variables (#15182)
 
 - devicemapper: Implement deferred deletion capability (#16381)
 
-## Networking
+### Networking
 
 + `docker network` exits experimental and is part of standard release (#16645)
 + New network top-level concept, with associated subcommands and API (#16645)

--- a/hack/validate/changelog-well-formed
+++ b/hack/validate/changelog-well-formed
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+changelogFile=${1:-CHANGELOG.md}
+
+if [ ! -r "$changelogFile" ]; then
+  echo "Unable to read file $changelogFile" >&2
+  exit 1
+fi
+
+changelogWellFormed=1
+
+# e.g. "## 1.12.3 (2016-10-26)"
+VER_LINE_REGEX='^## [0-9]+\.[0-9]+\.[0-9]+ \([0-9]+-[0-9]+-[0-9]+\)$'
+while read -r line; do
+  if ! [[ "$line" =~ $VER_LINE_REGEX ]]; then
+    echo "Malformed changelog $changelogFile line \"$line\"" >&2
+    changelogWellFormed=0
+  fi
+done < <(grep '^## ' $changelogFile)
+
+if [[ "$changelogWellFormed" == "1" ]]; then
+  echo "Congratulations!  Changelog $changelogFile is well-formed."
+else
+  exit 2
+fi

--- a/hack/validate/default
+++ b/hack/validate/default
@@ -14,3 +14,4 @@ export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . $SCRIPTDIR/test-imports
 . $SCRIPTDIR/toml
 . $SCRIPTDIR/vet
+. $SCRIPTDIR/changelog-well-formed


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added validation script to check `CHANGELOG.md` is well-formed so RPM builds can process the changelog.

Also fixed one line in `CHANGELOG.md` so that all version lines are consistent.

**- How I did it**

This script just checks the version line and makes sure it is of format similar to:

```
## 1.12.3 (2016-10-26)
```

**- How to verify it**

```
$ hack/validate/default
Congratulations!  All commits are properly signed with the DCO!
Congratulations!  All Go source files are properly formatted.
Congratulations!  All Go source files have been linted.
Congratulations!  "./pkg/..." is safely isolated from internal code.
No api/types/ or api/swagger.yaml changes in diff.
Congratulations!  No testing.T found.
Congratulations!  All toml source files changed here have valid syntax.
Congratulations!  All Go source files have been vetted.
Congratulations!  Changelog CHANGELOG.md is well-formed.
```

I also added processing of the first argument to the script so you can override the changelog file to validate, e.g.
```
$ hack/validate/changelog-well-formed MALFORMED-CHANGELOG.md 
Malformed changelog MALFORMED-CHANGELOG.md line "## 1.13.0"
$ echo $?
1
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

🐋 

Signed-off-by: Andrew Hsu <andrewhsu@docker.com>