### PR TITLE
[integration-tests] extract daemon to its own package

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/cliconfig"
+	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/go-check/check"
 )
@@ -39,7 +40,7 @@ type DockerSuite struct {
 
 func (s *DockerSuite) OnTimeout(c *check.C) {
 	if daemonPid > 0 && isLocalDaemon {
-		signalDaemonDump(daemonPid)
+		daemon.SignalDaemonDump(daemonPid)
 	}
 }
 
@@ -63,7 +64,7 @@ func init() {
 type DockerRegistrySuite struct {
 	ds  *DockerSuite
 	reg *testRegistryV2
-	d   *Daemon
+	d   *daemon.Daemon
 }
 
 func (s *DockerRegistrySuite) OnTimeout(c *check.C) {
@@ -73,7 +74,9 @@ func (s *DockerRegistrySuite) OnTimeout(c *check.C) {
 func (s *DockerRegistrySuite) SetUpTest(c *check.C) {
 	testRequires(c, DaemonIsLinux, RegistryHosting)
 	s.reg = setupRegistry(c, false, "", "")
-	s.d = NewDaemon(c)
+	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
+		Experimental: experimentalDaemon,
+	})
 }
 
 func (s *DockerRegistrySuite) TearDownTest(c *check.C) {
@@ -95,7 +98,7 @@ func init() {
 type DockerSchema1RegistrySuite struct {
 	ds  *DockerSuite
 	reg *testRegistryV2
-	d   *Daemon
+	d   *daemon.Daemon
 }
 
 func (s *DockerSchema1RegistrySuite) OnTimeout(c *check.C) {
@@ -105,7 +108,9 @@ func (s *DockerSchema1RegistrySuite) OnTimeout(c *check.C) {
 func (s *DockerSchema1RegistrySuite) SetUpTest(c *check.C) {
 	testRequires(c, DaemonIsLinux, RegistryHosting, NotArm64)
 	s.reg = setupRegistry(c, true, "", "")
-	s.d = NewDaemon(c)
+	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
+		Experimental: experimentalDaemon,
+	})
 }
 
 func (s *DockerSchema1RegistrySuite) TearDownTest(c *check.C) {
@@ -127,7 +132,7 @@ func init() {
 type DockerRegistryAuthHtpasswdSuite struct {
 	ds  *DockerSuite
 	reg *testRegistryV2
-	d   *Daemon
+	d   *daemon.Daemon
 }
 
 func (s *DockerRegistryAuthHtpasswdSuite) OnTimeout(c *check.C) {
@@ -137,7 +142,9 @@ func (s *DockerRegistryAuthHtpasswdSuite) OnTimeout(c *check.C) {
 func (s *DockerRegistryAuthHtpasswdSuite) SetUpTest(c *check.C) {
 	testRequires(c, DaemonIsLinux, RegistryHosting)
 	s.reg = setupRegistry(c, false, "htpasswd", "")
-	s.d = NewDaemon(c)
+	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
+		Experimental: experimentalDaemon,
+	})
 }
 
 func (s *DockerRegistryAuthHtpasswdSuite) TearDownTest(c *check.C) {
@@ -161,7 +168,7 @@ func init() {
 type DockerRegistryAuthTokenSuite struct {
 	ds  *DockerSuite
 	reg *testRegistryV2
-	d   *Daemon
+	d   *daemon.Daemon
 }
 
 func (s *DockerRegistryAuthTokenSuite) OnTimeout(c *check.C) {
@@ -170,7 +177,9 @@ func (s *DockerRegistryAuthTokenSuite) OnTimeout(c *check.C) {
 
 func (s *DockerRegistryAuthTokenSuite) SetUpTest(c *check.C) {
 	testRequires(c, DaemonIsLinux, RegistryHosting)
-	s.d = NewDaemon(c)
+	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
+		Experimental: experimentalDaemon,
+	})
 }
 
 func (s *DockerRegistryAuthTokenSuite) TearDownTest(c *check.C) {
@@ -200,7 +209,7 @@ func init() {
 
 type DockerDaemonSuite struct {
 	ds *DockerSuite
-	d  *Daemon
+	d  *daemon.Daemon
 }
 
 func (s *DockerDaemonSuite) OnTimeout(c *check.C) {
@@ -209,7 +218,9 @@ func (s *DockerDaemonSuite) OnTimeout(c *check.C) {
 
 func (s *DockerDaemonSuite) SetUpTest(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	s.d = NewDaemon(c)
+	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
+		Experimental: experimentalDaemon,
+	})
 }
 
 func (s *DockerDaemonSuite) TearDownTest(c *check.C) {
@@ -221,7 +232,7 @@ func (s *DockerDaemonSuite) TearDownTest(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TearDownSuite(c *check.C) {
-	filepath.Walk(daemonSockRoot, func(path string, fi os.FileInfo, err error) error {
+	filepath.Walk(daemon.SockRoot, func(path string, fi os.FileInfo, err error) error {
 		if err != nil {
 			// ignore errors here
 			// not cleaning up sockets is not really an error
@@ -232,7 +243,7 @@ func (s *DockerDaemonSuite) TearDownSuite(c *check.C) {
 		}
 		return nil
 	})
-	os.RemoveAll(daemonSockRoot)
+	os.RemoveAll(daemon.SockRoot)
 }
 
 const defaultSwarmPort = 2477
@@ -246,7 +257,7 @@ func init() {
 type DockerSwarmSuite struct {
 	server      *httptest.Server
 	ds          *DockerSuite
-	daemons     []*SwarmDaemon
+	daemons     []*daemon.Swarm
 	daemonsLock sync.Mutex // protect access to daemons
 	portIndex   int
 }
@@ -263,28 +274,27 @@ func (s *DockerSwarmSuite) SetUpTest(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 }
 
-func (s *DockerSwarmSuite) AddDaemon(c *check.C, joinSwarm, manager bool) *SwarmDaemon {
-	d := &SwarmDaemon{
-		Daemon: NewDaemon(c),
-		port:   defaultSwarmPort + s.portIndex,
+func (s *DockerSwarmSuite) AddDaemon(c *check.C, joinSwarm, manager bool) *daemon.Swarm {
+	d := &daemon.Swarm{
+		Daemon: daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
+			Experimental: experimentalDaemon,
+		}),
+		Port: defaultSwarmPort + s.portIndex,
 	}
-	d.listenAddr = fmt.Sprintf("0.0.0.0:%d", d.port)
+	d.ListenAddr = fmt.Sprintf("0.0.0.0:%d", d.Port)
 	args := []string{"--iptables=false", "--swarm-default-advertise-addr=lo"} // avoid networking conflicts
-	if experimentalDaemon {
-		args = append(args, "--experimental")
-	}
 	err := d.StartWithBusybox(args...)
 	c.Assert(err, check.IsNil)
 
 	if joinSwarm == true {
 		if len(s.daemons) > 0 {
-			tokens := s.daemons[0].joinTokens(c)
+			tokens := s.daemons[0].JoinTokens(c)
 			token := tokens.Worker
 			if manager {
 				token = tokens.Manager
 			}
 			c.Assert(d.Join(swarm.JoinRequest{
-				RemoteAddrs: []string{s.daemons[0].listenAddr},
+				RemoteAddrs: []string{s.daemons[0].ListenAddr},
 				JoinToken:   token,
 			}), check.IsNil)
 		} else {
@@ -306,13 +316,14 @@ func (s *DockerSwarmSuite) TearDownTest(c *check.C) {
 	for _, d := range s.daemons {
 		if d != nil {
 			d.Stop()
+			// FIXME(vdemeester) should be handled by SwarmDaemon ?
 			// raft state file is quite big (64MB) so remove it after every test
-			walDir := filepath.Join(d.root, "swarm/raft/wal")
+			walDir := filepath.Join(d.Root, "swarm/raft/wal")
 			if err := os.RemoveAll(walDir); err != nil {
 				c.Logf("error removing %v: %v", walDir, err)
 			}
 
-			cleanupExecRoot(c, d.execRoot)
+			d.CleanupExecRoot(c)
 		}
 	}
 	s.daemons = nil

--- a/integration-cli/daemon/daemon_swarm.go
+++ b/integration-cli/daemon/daemon_swarm.go
@@ -1,4 +1,4 @@
-package main
+package daemon
 
 import (
 	"encoding/json"
@@ -14,18 +14,18 @@ import (
 	"github.com/go-check/check"
 )
 
-// SwarmDaemon is a test daemon with helpers for participating in a swarm.
-type SwarmDaemon struct {
+// Swarm is a test daemon with helpers for participating in a swarm.
+type Swarm struct {
 	*Daemon
 	swarm.Info
-	port       int
-	listenAddr string
+	Port       int
+	ListenAddr string
 }
 
 // Init initializes a new swarm cluster.
-func (d *SwarmDaemon) Init(req swarm.InitRequest) error {
+func (d *Swarm) Init(req swarm.InitRequest) error {
 	if req.ListenAddr == "" {
-		req.ListenAddr = d.listenAddr
+		req.ListenAddr = d.ListenAddr
 	}
 	status, out, err := d.SockRequest("POST", "/swarm/init", req)
 	if status != http.StatusOK {
@@ -34,7 +34,7 @@ func (d *SwarmDaemon) Init(req swarm.InitRequest) error {
 	if err != nil {
 		return fmt.Errorf("initializing swarm: %v", err)
 	}
-	info, err := d.info()
+	info, err := d.SwarmInfo()
 	if err != nil {
 		return err
 	}
@@ -43,9 +43,9 @@ func (d *SwarmDaemon) Init(req swarm.InitRequest) error {
 }
 
 // Join joins a daemon to an existing cluster.
-func (d *SwarmDaemon) Join(req swarm.JoinRequest) error {
+func (d *Swarm) Join(req swarm.JoinRequest) error {
 	if req.ListenAddr == "" {
-		req.ListenAddr = d.listenAddr
+		req.ListenAddr = d.ListenAddr
 	}
 	status, out, err := d.SockRequest("POST", "/swarm/join", req)
 	if status != http.StatusOK {
@@ -54,7 +54,7 @@ func (d *SwarmDaemon) Join(req swarm.JoinRequest) error {
 	if err != nil {
 		return fmt.Errorf("joining swarm: %v", err)
 	}
-	info, err := d.info()
+	info, err := d.SwarmInfo()
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func (d *SwarmDaemon) Join(req swarm.JoinRequest) error {
 }
 
 // Leave forces daemon to leave current cluster.
-func (d *SwarmDaemon) Leave(force bool) error {
+func (d *Swarm) Leave(force bool) error {
 	url := "/swarm/leave"
 	if force {
 		url += "?force=1"
@@ -78,7 +78,8 @@ func (d *SwarmDaemon) Leave(force bool) error {
 	return err
 }
 
-func (d *SwarmDaemon) info() (swarm.Info, error) {
+// SwarmInfo returns the swarm information of the daemon
+func (d *Swarm) SwarmInfo() (swarm.Info, error) {
 	var info struct {
 		Swarm swarm.Info
 	}
@@ -95,11 +96,17 @@ func (d *SwarmDaemon) info() (swarm.Info, error) {
 	return info.Swarm, nil
 }
 
-type serviceConstructor func(*swarm.Service)
-type nodeConstructor func(*swarm.Node)
-type specConstructor func(*swarm.Spec)
+// ServiceConstructor defines a swarm service constructor function
+type ServiceConstructor func(*swarm.Service)
 
-func (d *SwarmDaemon) createService(c *check.C, f ...serviceConstructor) string {
+// NodeConstructor defines a swarm node constructor
+type NodeConstructor func(*swarm.Node)
+
+// SpecConstructor defines a swarm spec constructor
+type SpecConstructor func(*swarm.Spec)
+
+// CreateService creates a swarm service given the specified service constructor
+func (d *Swarm) CreateService(c *check.C, f ...ServiceConstructor) string {
 	var service swarm.Service
 	for _, fn := range f {
 		fn(&service)
@@ -114,7 +121,8 @@ func (d *SwarmDaemon) createService(c *check.C, f ...serviceConstructor) string 
 	return scr.ID
 }
 
-func (d *SwarmDaemon) getService(c *check.C, id string) *swarm.Service {
+// GetService returns the swarm service corresponding to the specified id
+func (d *Swarm) GetService(c *check.C, id string) *swarm.Service {
 	var service swarm.Service
 	status, out, err := d.SockRequest("GET", "/services/"+id, nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
@@ -123,7 +131,8 @@ func (d *SwarmDaemon) getService(c *check.C, id string) *swarm.Service {
 	return &service
 }
 
-func (d *SwarmDaemon) getServiceTasks(c *check.C, service string) []swarm.Task {
+// GetServiceTasks returns the swarm tasks for the specified service
+func (d *Swarm) GetServiceTasks(c *check.C, service string) []swarm.Task {
 	var tasks []swarm.Task
 
 	filterArgs := filters.NewArgs()
@@ -139,9 +148,10 @@ func (d *SwarmDaemon) getServiceTasks(c *check.C, service string) []swarm.Task {
 	return tasks
 }
 
-func (d *SwarmDaemon) checkServiceRunningTasks(service string) func(*check.C) (interface{}, check.CommentInterface) {
+// CheckServiceRunningTasks returns the number of running tasks for the specified service
+func (d *Swarm) CheckServiceRunningTasks(service string) func(*check.C) (interface{}, check.CommentInterface) {
 	return func(c *check.C) (interface{}, check.CommentInterface) {
-		tasks := d.getServiceTasks(c, service)
+		tasks := d.GetServiceTasks(c, service)
 		var runningCount int
 		for _, task := range tasks {
 			if task.Status.State == swarm.TaskStateRunning {
@@ -152,9 +162,10 @@ func (d *SwarmDaemon) checkServiceRunningTasks(service string) func(*check.C) (i
 	}
 }
 
-func (d *SwarmDaemon) checkServiceUpdateState(service string) func(*check.C) (interface{}, check.CommentInterface) {
+// CheckServiceUpdateState returns the current update state for the specified service
+func (d *Swarm) CheckServiceUpdateState(service string) func(*check.C) (interface{}, check.CommentInterface) {
 	return func(c *check.C) (interface{}, check.CommentInterface) {
-		service := d.getService(c, service)
+		service := d.GetService(c, service)
 		if service.UpdateStatus == nil {
 			return "", nil
 		}
@@ -162,14 +173,16 @@ func (d *SwarmDaemon) checkServiceUpdateState(service string) func(*check.C) (in
 	}
 }
 
-func (d *SwarmDaemon) checkServiceTasks(service string) func(*check.C) (interface{}, check.CommentInterface) {
+// CheckServiceTasks returns the number of tasks for the specified service
+func (d *Swarm) CheckServiceTasks(service string) func(*check.C) (interface{}, check.CommentInterface) {
 	return func(c *check.C) (interface{}, check.CommentInterface) {
-		tasks := d.getServiceTasks(c, service)
+		tasks := d.GetServiceTasks(c, service)
 		return len(tasks), nil
 	}
 }
 
-func (d *SwarmDaemon) checkRunningTaskImages(c *check.C) (interface{}, check.CommentInterface) {
+// CheckRunningTaskImages returns the number of different images attached to a running task
+func (d *Swarm) CheckRunningTaskImages(c *check.C) (interface{}, check.CommentInterface) {
 	var tasks []swarm.Task
 
 	filterArgs := filters.NewArgs()
@@ -191,8 +204,9 @@ func (d *SwarmDaemon) checkRunningTaskImages(c *check.C) (interface{}, check.Com
 	return result, nil
 }
 
-func (d *SwarmDaemon) checkNodeReadyCount(c *check.C) (interface{}, check.CommentInterface) {
-	nodes := d.listNodes(c)
+// CheckNodeReadyCount returns the number of ready node on the swarm
+func (d *Swarm) CheckNodeReadyCount(c *check.C) (interface{}, check.CommentInterface) {
+	nodes := d.ListNodes(c)
 	var readyCount int
 	for _, node := range nodes {
 		if node.Status.State == swarm.NodeStateReady {
@@ -202,7 +216,8 @@ func (d *SwarmDaemon) checkNodeReadyCount(c *check.C) (interface{}, check.Commen
 	return readyCount, nil
 }
 
-func (d *SwarmDaemon) getTask(c *check.C, id string) swarm.Task {
+// GetTask returns the swarm task identified by the specified id
+func (d *Swarm) GetTask(c *check.C, id string) swarm.Task {
 	var task swarm.Task
 
 	status, out, err := d.SockRequest("GET", "/tasks/"+id, nil)
@@ -212,7 +227,8 @@ func (d *SwarmDaemon) getTask(c *check.C, id string) swarm.Task {
 	return task
 }
 
-func (d *SwarmDaemon) updateService(c *check.C, service *swarm.Service, f ...serviceConstructor) {
+// UpdateService updates a swarm service with the specified service constructor
+func (d *Swarm) UpdateService(c *check.C, service *swarm.Service, f ...ServiceConstructor) {
 	for _, fn := range f {
 		fn(service)
 	}
@@ -222,13 +238,15 @@ func (d *SwarmDaemon) updateService(c *check.C, service *swarm.Service, f ...ser
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 }
 
-func (d *SwarmDaemon) removeService(c *check.C, id string) {
+// RemoveService removes the specified service
+func (d *Swarm) RemoveService(c *check.C, id string) {
 	status, out, err := d.SockRequest("DELETE", "/services/"+id, nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 }
 
-func (d *SwarmDaemon) getNode(c *check.C, id string) *swarm.Node {
+// GetNode returns a swarm node identified by the specified id
+func (d *Swarm) GetNode(c *check.C, id string) *swarm.Node {
 	var node swarm.Node
 	status, out, err := d.SockRequest("GET", "/nodes/"+id, nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
@@ -238,7 +256,8 @@ func (d *SwarmDaemon) getNode(c *check.C, id string) *swarm.Node {
 	return &node
 }
 
-func (d *SwarmDaemon) removeNode(c *check.C, id string, force bool) {
+// RemoveNode removes the specified node
+func (d *Swarm) RemoveNode(c *check.C, id string, force bool) {
 	url := "/nodes/" + id
 	if force {
 		url += "?force=1"
@@ -249,9 +268,10 @@ func (d *SwarmDaemon) removeNode(c *check.C, id string, force bool) {
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 }
 
-func (d *SwarmDaemon) updateNode(c *check.C, id string, f ...nodeConstructor) {
+// UpdateNode updates a swarm node with the specified node constructor
+func (d *Swarm) UpdateNode(c *check.C, id string, f ...NodeConstructor) {
 	for i := 0; ; i++ {
-		node := d.getNode(c, id)
+		node := d.GetNode(c, id)
 		for _, fn := range f {
 			fn(node)
 		}
@@ -267,7 +287,8 @@ func (d *SwarmDaemon) updateNode(c *check.C, id string, f ...nodeConstructor) {
 	}
 }
 
-func (d *SwarmDaemon) listNodes(c *check.C) []swarm.Node {
+// ListNodes returns the list of the current swarm nodes
+func (d *Swarm) ListNodes(c *check.C) []swarm.Node {
 	status, out, err := d.SockRequest("GET", "/nodes", nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
@@ -277,7 +298,8 @@ func (d *SwarmDaemon) listNodes(c *check.C) []swarm.Node {
 	return nodes
 }
 
-func (d *SwarmDaemon) listServices(c *check.C) []swarm.Service {
+// ListServices return the list of the current swarm services
+func (d *Swarm) ListServices(c *check.C) []swarm.Service {
 	status, out, err := d.SockRequest("GET", "/services", nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
@@ -287,7 +309,8 @@ func (d *SwarmDaemon) listServices(c *check.C) []swarm.Service {
 	return services
 }
 
-func (d *SwarmDaemon) createSecret(c *check.C, secretSpec swarm.SecretSpec) string {
+// CreateSecret creates a secret given the specified spec
+func (d *Swarm) CreateSecret(c *check.C, secretSpec swarm.SecretSpec) string {
 	status, out, err := d.SockRequest("POST", "/secrets/create", secretSpec)
 
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
@@ -298,7 +321,8 @@ func (d *SwarmDaemon) createSecret(c *check.C, secretSpec swarm.SecretSpec) stri
 	return scr.ID
 }
 
-func (d *SwarmDaemon) listSecrets(c *check.C) []swarm.Secret {
+// ListSecrets returns the list of the current swarm secrets
+func (d *Swarm) ListSecrets(c *check.C) []swarm.Secret {
 	status, out, err := d.SockRequest("GET", "/secrets", nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
@@ -308,7 +332,8 @@ func (d *SwarmDaemon) listSecrets(c *check.C) []swarm.Secret {
 	return secrets
 }
 
-func (d *SwarmDaemon) getSecret(c *check.C, id string) *swarm.Secret {
+// GetSecret returns a swarm secret identified by the specified id
+func (d *Swarm) GetSecret(c *check.C, id string) *swarm.Secret {
 	var secret swarm.Secret
 	status, out, err := d.SockRequest("GET", "/secrets/"+id, nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
@@ -317,13 +342,15 @@ func (d *SwarmDaemon) getSecret(c *check.C, id string) *swarm.Secret {
 	return &secret
 }
 
-func (d *SwarmDaemon) deleteSecret(c *check.C, id string) {
+// DeleteSecret removes the swarm secret identified by the specified id
+func (d *Swarm) DeleteSecret(c *check.C, id string) {
 	status, out, err := d.SockRequest("DELETE", "/secrets/"+id, nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusNoContent, check.Commentf("output: %q", string(out)))
 }
 
-func (d *SwarmDaemon) getSwarm(c *check.C) swarm.Swarm {
+// GetSwarm return the current swarm object
+func (d *Swarm) GetSwarm(c *check.C) swarm.Swarm {
 	var sw swarm.Swarm
 	status, out, err := d.SockRequest("GET", "/swarm", nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
@@ -332,8 +359,9 @@ func (d *SwarmDaemon) getSwarm(c *check.C) swarm.Swarm {
 	return sw
 }
 
-func (d *SwarmDaemon) updateSwarm(c *check.C, f ...specConstructor) {
-	sw := d.getSwarm(c)
+// UpdateSwarm updates the current swarm object with the specified spec constructors
+func (d *Swarm) UpdateSwarm(c *check.C, f ...SpecConstructor) {
+	sw := d.GetSwarm(c)
 	for _, fn := range f {
 		fn(&sw.Spec)
 	}
@@ -343,7 +371,8 @@ func (d *SwarmDaemon) updateSwarm(c *check.C, f ...specConstructor) {
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 }
 
-func (d *SwarmDaemon) rotateTokens(c *check.C) {
+// RotateTokens update the swarm to rotate tokens
+func (d *Swarm) RotateTokens(c *check.C) {
 	var sw swarm.Swarm
 	status, out, err := d.SockRequest("GET", "/swarm", nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
@@ -356,7 +385,8 @@ func (d *SwarmDaemon) rotateTokens(c *check.C) {
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 }
 
-func (d *SwarmDaemon) joinTokens(c *check.C) swarm.JoinTokens {
+// JoinTokens returns the current swarm join tokens
+func (d *Swarm) JoinTokens(c *check.C) swarm.JoinTokens {
 	var sw swarm.Swarm
 	status, out, err := d.SockRequest("GET", "/swarm", nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
@@ -365,20 +395,23 @@ func (d *SwarmDaemon) joinTokens(c *check.C) swarm.JoinTokens {
 	return sw.JoinTokens
 }
 
-func (d *SwarmDaemon) checkLocalNodeState(c *check.C) (interface{}, check.CommentInterface) {
-	info, err := d.info()
+// CheckLocalNodeState returns the current swarm node state
+func (d *Swarm) CheckLocalNodeState(c *check.C) (interface{}, check.CommentInterface) {
+	info, err := d.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	return info.LocalNodeState, nil
 }
 
-func (d *SwarmDaemon) checkControlAvailable(c *check.C) (interface{}, check.CommentInterface) {
-	info, err := d.info()
+// CheckControlAvailable returns the current swarm control available
+func (d *Swarm) CheckControlAvailable(c *check.C) (interface{}, check.CommentInterface) {
+	info, err := d.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateActive)
 	return info.ControlAvailable, nil
 }
 
-func (d *SwarmDaemon) checkLeader(c *check.C) (interface{}, check.CommentInterface) {
+// CheckLeader returns whether there is a leader on the swarm or not
+func (d *Swarm) CheckLeader(c *check.C) (interface{}, check.CommentInterface) {
 	errList := check.Commentf("could not get node list")
 	status, out, err := d.SockRequest("GET", "/nodes", nil)
 	if err != nil {
@@ -401,7 +434,8 @@ func (d *SwarmDaemon) checkLeader(c *check.C) (interface{}, check.CommentInterfa
 	return fmt.Errorf("no leader"), check.Commentf("could not find leader")
 }
 
-func (d *SwarmDaemon) cmdRetryOutOfSequence(args ...string) (string, error) {
+// CmdRetryOutOfSequence tries the specified command against the current daemon for 10 times
+func (d *Swarm) CmdRetryOutOfSequence(args ...string) (string, error) {
 	for i := 0; ; i++ {
 		out, err := d.Cmd(args...)
 		if err != nil {

--- a/integration-cli/daemon/daemon_unix.go
+++ b/integration-cli/daemon/daemon_unix.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package main
+package daemon
 
 import (
 	"os"
@@ -26,7 +26,8 @@ func cleanupExecRoot(c *check.C, execRoot string) {
 	})
 }
 
-func signalDaemonDump(pid int) {
+// SignalDaemonDump sends a signal to the daemon to write a dump file
+func SignalDaemonDump(pid int) {
 	syscall.Kill(pid, syscall.SIGQUIT)
 }
 

--- a/integration-cli/daemon/daemon_windows.go
+++ b/integration-cli/daemon/daemon_windows.go
@@ -1,4 +1,4 @@
-package main
+package daemon
 
 import (
 	"fmt"
@@ -32,7 +32,8 @@ func pulseEvent(handle syscall.Handle, proc *windows.LazyProc) (err error) {
 	return
 }
 
-func signalDaemonDump(pid int) {
+// SignalDaemonDump sends a signal to the daemon to write a dump file
+func SignalDaemonDump(pid int) {
 	modkernel32 := windows.NewLazySystemDLL("kernel32.dll")
 	procOpenEvent := modkernel32.NewProc("OpenEventW")
 	procPulseEvent := modkernel32.NewProc("PulseEvent")

--- a/integration-cli/daemon/npipe.go
+++ b/integration-cli/daemon/npipe.go
@@ -1,12 +1,12 @@
-package main
+// +build !windows
+
+package daemon
 
 import (
 	"net"
 	"time"
-
-	"github.com/Microsoft/go-winio"
 )
 
 func npipeDial(path string, timeout time.Duration) (net.Conn, error) {
-	return winio.DialPipe(path, &timeout)
+	panic("npipe protocol only supported on Windows")
 }

--- a/integration-cli/daemon/npipe_windows.go
+++ b/integration-cli/daemon/npipe_windows.go
@@ -1,12 +1,12 @@
-// +build !windows
-
-package main
+package daemon
 
 import (
 	"net"
 	"time"
+
+	"github.com/Microsoft/go-winio"
 )
 
 func npipeDial(path string, timeout time.Duration) (net.Conn, error) {
-	panic("npipe protocol only supported on Windows")
+	return winio.DialPipe(path, &timeout)
 }

--- a/integration-cli/daemon_swarm_hack.go
+++ b/integration-cli/daemon_swarm_hack.go
@@ -1,8 +1,11 @@
 package main
 
-import "github.com/go-check/check"
+import (
+	"github.com/docker/docker/integration-cli/daemon"
+	"github.com/go-check/check"
+)
 
-func (s *DockerSwarmSuite) getDaemon(c *check.C, nodeID string) *SwarmDaemon {
+func (s *DockerSwarmSuite) getDaemon(c *check.C, nodeID string) *daemon.Swarm {
 	s.daemonsLock.Lock()
 	defer s.daemonsLock.Unlock()
 	for _, d := range s.daemons {

--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/go-check/check"
@@ -79,7 +80,7 @@ func (s *DockerSuite) TestPostContainersAttachContainerNotFound(c *check.C) {
 	// connection will shutdown, err should be "persistent connection closed"
 	c.Assert(err, checker.NotNil) // Server shutdown connection
 
-	body, err := readBody(resp.Body)
+	body, err := integration.ReadBody(resp.Body)
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusNotFound)
 	expected := "No such container: doesnotexist\r\n"

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
@@ -34,7 +35,7 @@ RUN find /tmp/`
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
-	buf, err := readBody(body)
+	buf, err := integration.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 
 	// Make sure Dockerfile exists.
@@ -125,7 +126,7 @@ RUN echo 'right'
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
 	defer body.Close()
-	content, err := readBody(body)
+	content, err := integration.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 
 	// Build used the wrong dockerfile.
@@ -144,7 +145,7 @@ RUN echo from dockerfile`,
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
-	buf, err := readBody(body)
+	buf, err := integration.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 
 	out := string(buf)
@@ -166,7 +167,7 @@ RUN echo from Dockerfile`,
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
-	buf, err := readBody(body)
+	buf, err := integration.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 
 	out := string(buf)
@@ -189,7 +190,7 @@ RUN echo from dockerfile`,
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
-	buf, err := readBody(body)
+	buf, err := integration.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 
 	out := string(buf)
@@ -236,7 +237,7 @@ func (s *DockerSuite) TestBuildAPIUnnormalizedTarPaths(c *check.C) {
 		c.Assert(err, checker.IsNil)
 		c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
-		out, err := readBody(body)
+		out, err := integration.ReadBody(body)
 		c.Assert(err, checker.IsNil)
 		lines := strings.Split(string(out), "\n")
 		c.Assert(len(lines), checker.GreaterThan, 1)

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -723,7 +723,7 @@ func (s *DockerSuite) TestContainerAPIInvalidPortSyntax(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusInternalServerError)
 
-	b, err := readBody(body)
+	b, err := integration.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 	c.Assert(string(b[:]), checker.Contains, "invalid port")
 }
@@ -743,7 +743,7 @@ func (s *DockerSuite) TestContainerAPIRestartPolicyInvalidPolicyName(c *check.C)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusInternalServerError)
 
-	b, err := readBody(body)
+	b, err := integration.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 	c.Assert(string(b[:]), checker.Contains, "invalid restart policy")
 }
@@ -763,7 +763,7 @@ func (s *DockerSuite) TestContainerAPIRestartPolicyRetryMismatch(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusInternalServerError)
 
-	b, err := readBody(body)
+	b, err := integration.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 	c.Assert(string(b[:]), checker.Contains, "maximum retry count cannot be used with restart policy")
 }
@@ -783,7 +783,7 @@ func (s *DockerSuite) TestContainerAPIRestartPolicyNegativeRetryCount(c *check.C
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusInternalServerError)
 
-	b, err := readBody(body)
+	b, err := integration.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 	c.Assert(string(b[:]), checker.Contains, "maximum retry count cannot be negative")
 }
@@ -834,7 +834,7 @@ func (s *DockerSuite) TestContainerAPIPostCreateNull(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusCreated)
 
-	b, err := readBody(body)
+	b, err := integration.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 	type createResp struct {
 		ID string
@@ -863,7 +863,7 @@ func (s *DockerSuite) TestCreateWithTooLowMemoryLimit(c *check.C) {
 
 	res, body, err := sockRequestRaw("POST", "/containers/create", strings.NewReader(config), "application/json")
 	c.Assert(err, checker.IsNil)
-	b, err2 := readBody(body)
+	b, err2 := integration.ReadBody(body)
 	c.Assert(err2, checker.IsNil)
 
 	c.Assert(res.StatusCode, checker.Equals, http.StatusInternalServerError)

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
@@ -40,7 +41,7 @@ func (s *DockerSuite) TestExecAPICreateNoValidContentType(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusInternalServerError)
 
-	b, err := readBody(body)
+	b, err := integration.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 
 	comment := check.Commentf("Expected message when creating exec command with invalid Content-Type specified")
@@ -107,7 +108,7 @@ func (s *DockerSuite) TestExecAPIStartBackwardsCompatible(c *check.C) {
 	resp, body, err := sockRequestRaw("POST", fmt.Sprintf("/v1.20/exec/%s/start", id), strings.NewReader(`{"Detach": true}`), "text/plain")
 	c.Assert(err, checker.IsNil)
 
-	b, err := readBody(body)
+	b, err := integration.ReadBody(body)
 	comment := check.Commentf("response body: %s", b)
 	c.Assert(err, checker.IsNil, comment)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK, comment)
@@ -156,7 +157,7 @@ func (s *DockerSuite) TestExecAPIStartWithDetach(c *check.C) {
 	_, body, err := sockRequestRaw("POST", fmt.Sprintf("/exec/%s/start", createResp.ID), strings.NewReader(`{"Detach": true}`), "application/json")
 	c.Assert(err, checker.IsNil)
 
-	b, err = readBody(body)
+	b, err = integration.ReadBody(body)
 	comment := check.Commentf("response body: %s", b)
 	c.Assert(err, checker.IsNil, comment)
 
@@ -182,7 +183,7 @@ func startExec(c *check.C, id string, code int) {
 	resp, body, err := sockRequestRaw("POST", fmt.Sprintf("/exec/%s/start", id), strings.NewReader(`{"Detach": true}`), "application/json")
 	c.Assert(err, checker.IsNil)
 
-	b, err := readBody(body)
+	b, err := integration.ReadBody(body)
 	comment := check.Commentf("response body: %s", b)
 	c.Assert(err, checker.IsNil, comment)
 	c.Assert(resp.StatusCode, checker.Equals, code, comment)

--- a/integration-cli/docker_api_service_update_test.go
+++ b/integration-cli/docker_api_service_update_test.go
@@ -4,11 +4,12 @@ package main
 
 import (
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
 
-func setPortConfig(portConfig []swarm.PortConfig) serviceConstructor {
+func setPortConfig(portConfig []swarm.PortConfig) daemon.ServiceConstructor {
 	return func(s *swarm.Service) {
 		if s.Spec.EndpointSpec == nil {
 			s.Spec.EndpointSpec = &swarm.EndpointSpec{}
@@ -22,16 +23,16 @@ func (s *DockerSwarmSuite) TestAPIServiceUpdatePort(c *check.C) {
 
 	// Create a service with a port mapping of 8080:8081.
 	portConfig := []swarm.PortConfig{{TargetPort: 8081, PublishedPort: 8080}}
-	serviceID := d.createService(c, simpleTestService, setInstances(1), setPortConfig(portConfig))
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 1)
+	serviceID := d.CreateService(c, simpleTestService, setInstances(1), setPortConfig(portConfig))
+	waitAndAssert(c, defaultReconciliationTimeout, d.CheckActiveContainerCount, checker.Equals, 1)
 
 	// Update the service: changed the port mapping from 8080:8081 to 8082:8083.
 	updatedPortConfig := []swarm.PortConfig{{TargetPort: 8083, PublishedPort: 8082}}
-	remoteService := d.getService(c, serviceID)
-	d.updateService(c, remoteService, setPortConfig(updatedPortConfig))
+	remoteService := d.GetService(c, serviceID)
+	d.UpdateService(c, remoteService, setPortConfig(updatedPortConfig))
 
 	// Inspect the service and verify port mapping.
-	updatedService := d.getService(c, serviceID)
+	updatedService := d.GetService(c, serviceID)
 	c.Assert(updatedService.Spec.EndpointSpec, check.NotNil)
 	c.Assert(len(updatedService.Spec.EndpointSpec.Ports), check.Equals, 1)
 	c.Assert(updatedService.Spec.EndpointSpec.Ports[0].TargetPort, check.Equals, uint32(8083))

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
@@ -23,13 +24,13 @@ var defaultReconciliationTimeout = 30 * time.Second
 func (s *DockerSwarmSuite) TestAPISwarmInit(c *check.C) {
 	// todo: should find a better way to verify that components are running than /info
 	d1 := s.AddDaemon(c, true, true)
-	info, err := d1.info()
+	info, err := d1.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.ControlAvailable, checker.True)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateActive)
 
 	d2 := s.AddDaemon(c, true, false)
-	info, err = d2.info()
+	info, err = d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.ControlAvailable, checker.False)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateActive)
@@ -37,14 +38,14 @@ func (s *DockerSwarmSuite) TestAPISwarmInit(c *check.C) {
 	// Leaving cluster
 	c.Assert(d2.Leave(false), checker.IsNil)
 
-	info, err = d2.info()
+	info, err = d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.ControlAvailable, checker.False)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateInactive)
 
-	c.Assert(d2.Join(swarm.JoinRequest{JoinToken: d1.joinTokens(c).Worker, RemoteAddrs: []string{d1.listenAddr}}), checker.IsNil)
+	c.Assert(d2.Join(swarm.JoinRequest{JoinToken: d1.JoinTokens(c).Worker, RemoteAddrs: []string{d1.ListenAddr}}), checker.IsNil)
 
-	info, err = d2.info()
+	info, err = d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.ControlAvailable, checker.False)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateActive)
@@ -60,12 +61,12 @@ func (s *DockerSwarmSuite) TestAPISwarmInit(c *check.C) {
 	err = d2.Start()
 	c.Assert(err, checker.IsNil)
 
-	info, err = d1.info()
+	info, err = d1.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.ControlAvailable, checker.True)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateActive)
 
-	info, err = d2.info()
+	info, err = d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.ControlAvailable, checker.False)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateActive)
@@ -78,68 +79,68 @@ func (s *DockerSwarmSuite) TestAPISwarmJoinToken(c *check.C) {
 	// todo: error message differs depending if some components of token are valid
 
 	d2 := s.AddDaemon(c, false, false)
-	err := d2.Join(swarm.JoinRequest{RemoteAddrs: []string{d1.listenAddr}})
+	err := d2.Join(swarm.JoinRequest{RemoteAddrs: []string{d1.ListenAddr}})
 	c.Assert(err, checker.NotNil)
 	c.Assert(err.Error(), checker.Contains, "join token is necessary")
-	info, err := d2.info()
+	info, err := d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateInactive)
 
-	err = d2.Join(swarm.JoinRequest{JoinToken: "foobaz", RemoteAddrs: []string{d1.listenAddr}})
+	err = d2.Join(swarm.JoinRequest{JoinToken: "foobaz", RemoteAddrs: []string{d1.ListenAddr}})
 	c.Assert(err, checker.NotNil)
 	c.Assert(err.Error(), checker.Contains, "invalid join token")
-	info, err = d2.info()
+	info, err = d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateInactive)
 
-	workerToken := d1.joinTokens(c).Worker
+	workerToken := d1.JoinTokens(c).Worker
 
-	c.Assert(d2.Join(swarm.JoinRequest{JoinToken: workerToken, RemoteAddrs: []string{d1.listenAddr}}), checker.IsNil)
-	info, err = d2.info()
+	c.Assert(d2.Join(swarm.JoinRequest{JoinToken: workerToken, RemoteAddrs: []string{d1.ListenAddr}}), checker.IsNil)
+	info, err = d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateActive)
 	c.Assert(d2.Leave(false), checker.IsNil)
-	info, err = d2.info()
+	info, err = d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateInactive)
 
 	// change tokens
-	d1.rotateTokens(c)
+	d1.RotateTokens(c)
 
-	err = d2.Join(swarm.JoinRequest{JoinToken: workerToken, RemoteAddrs: []string{d1.listenAddr}})
+	err = d2.Join(swarm.JoinRequest{JoinToken: workerToken, RemoteAddrs: []string{d1.ListenAddr}})
 	c.Assert(err, checker.NotNil)
 	c.Assert(err.Error(), checker.Contains, "join token is necessary")
-	info, err = d2.info()
+	info, err = d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateInactive)
 
-	workerToken = d1.joinTokens(c).Worker
+	workerToken = d1.JoinTokens(c).Worker
 
-	c.Assert(d2.Join(swarm.JoinRequest{JoinToken: workerToken, RemoteAddrs: []string{d1.listenAddr}}), checker.IsNil)
-	info, err = d2.info()
+	c.Assert(d2.Join(swarm.JoinRequest{JoinToken: workerToken, RemoteAddrs: []string{d1.ListenAddr}}), checker.IsNil)
+	info, err = d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateActive)
 	c.Assert(d2.Leave(false), checker.IsNil)
-	info, err = d2.info()
+	info, err = d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateInactive)
 
 	// change spec, don't change tokens
-	d1.updateSwarm(c, func(s *swarm.Spec) {})
+	d1.UpdateSwarm(c, func(s *swarm.Spec) {})
 
-	err = d2.Join(swarm.JoinRequest{RemoteAddrs: []string{d1.listenAddr}})
+	err = d2.Join(swarm.JoinRequest{RemoteAddrs: []string{d1.ListenAddr}})
 	c.Assert(err, checker.NotNil)
 	c.Assert(err.Error(), checker.Contains, "join token is necessary")
-	info, err = d2.info()
+	info, err = d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateInactive)
 
-	c.Assert(d2.Join(swarm.JoinRequest{JoinToken: workerToken, RemoteAddrs: []string{d1.listenAddr}}), checker.IsNil)
-	info, err = d2.info()
+	c.Assert(d2.Join(swarm.JoinRequest{JoinToken: workerToken, RemoteAddrs: []string{d1.ListenAddr}}), checker.IsNil)
+	info, err = d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateActive)
 	c.Assert(d2.Leave(false), checker.IsNil)
-	info, err = d2.info()
+	info, err = d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateInactive)
 }
@@ -147,10 +148,10 @@ func (s *DockerSwarmSuite) TestAPISwarmJoinToken(c *check.C) {
 func (s *DockerSwarmSuite) TestAPISwarmCAHash(c *check.C) {
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, false, false)
-	splitToken := strings.Split(d1.joinTokens(c).Worker, "-")
+	splitToken := strings.Split(d1.JoinTokens(c).Worker, "-")
 	splitToken[2] = "1kxftv4ofnc6mt30lmgipg6ngf9luhwqopfk1tz6bdmnkubg0e"
 	replacementToken := strings.Join(splitToken, "-")
-	err := d2.Join(swarm.JoinRequest{JoinToken: replacementToken, RemoteAddrs: []string{d1.listenAddr}})
+	err := d2.Join(swarm.JoinRequest{JoinToken: replacementToken, RemoteAddrs: []string{d1.ListenAddr}})
 	c.Assert(err, checker.NotNil)
 	c.Assert(err.Error(), checker.Contains, "remote CA does not match fingerprint")
 }
@@ -160,48 +161,48 @@ func (s *DockerSwarmSuite) TestAPISwarmPromoteDemote(c *check.C) {
 	c.Assert(d1.Init(swarm.InitRequest{}), checker.IsNil)
 	d2 := s.AddDaemon(c, true, false)
 
-	info, err := d2.info()
+	info, err := d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.ControlAvailable, checker.False)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateActive)
 
-	d1.updateNode(c, d2.NodeID, func(n *swarm.Node) {
+	d1.UpdateNode(c, d2.NodeID, func(n *swarm.Node) {
 		n.Spec.Role = swarm.NodeRoleManager
 	})
 
-	waitAndAssert(c, defaultReconciliationTimeout, d2.checkControlAvailable, checker.True)
+	waitAndAssert(c, defaultReconciliationTimeout, d2.CheckControlAvailable, checker.True)
 
-	d1.updateNode(c, d2.NodeID, func(n *swarm.Node) {
+	d1.UpdateNode(c, d2.NodeID, func(n *swarm.Node) {
 		n.Spec.Role = swarm.NodeRoleWorker
 	})
 
-	waitAndAssert(c, defaultReconciliationTimeout, d2.checkControlAvailable, checker.False)
+	waitAndAssert(c, defaultReconciliationTimeout, d2.CheckControlAvailable, checker.False)
 
 	// Demoting last node should fail
-	node := d1.getNode(c, d1.NodeID)
+	node := d1.GetNode(c, d1.NodeID)
 	node.Spec.Role = swarm.NodeRoleWorker
 	url := fmt.Sprintf("/nodes/%s/update?version=%d", node.ID, node.Version.Index)
 	status, out, err := d1.SockRequest("POST", url, node.Spec)
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusInternalServerError, check.Commentf("output: %q", string(out)))
 	c.Assert(string(out), checker.Contains, "last manager of the swarm")
-	info, err = d1.info()
+	info, err = d1.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateActive)
 	c.Assert(info.ControlAvailable, checker.True)
 
 	// Promote already demoted node
-	d1.updateNode(c, d2.NodeID, func(n *swarm.Node) {
+	d1.UpdateNode(c, d2.NodeID, func(n *swarm.Node) {
 		n.Spec.Role = swarm.NodeRoleManager
 	})
 
-	waitAndAssert(c, defaultReconciliationTimeout, d2.checkControlAvailable, checker.True)
+	waitAndAssert(c, defaultReconciliationTimeout, d2.CheckControlAvailable, checker.True)
 }
 
 func (s *DockerSwarmSuite) TestAPISwarmServicesEmptyList(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
-	services := d.listServices(c)
+	services := d.ListServices(c)
 	c.Assert(services, checker.NotNil)
 	c.Assert(len(services), checker.Equals, 0, check.Commentf("services: %#v", services))
 }
@@ -210,16 +211,16 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesCreate(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	instances := 2
-	id := d.createService(c, simpleTestService, setInstances(instances))
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, instances)
+	id := d.CreateService(c, simpleTestService, setInstances(instances))
+	waitAndAssert(c, defaultReconciliationTimeout, d.CheckActiveContainerCount, checker.Equals, instances)
 
-	service := d.getService(c, id)
+	service := d.GetService(c, id)
 	instances = 5
-	d.updateService(c, service, setInstances(instances))
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, instances)
+	d.UpdateService(c, service, setInstances(instances))
+	waitAndAssert(c, defaultReconciliationTimeout, d.CheckActiveContainerCount, checker.Equals, instances)
 
-	d.removeService(c, service.ID)
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 0)
+	d.RemoveService(c, service.ID)
+	waitAndAssert(c, defaultReconciliationTimeout, d.CheckActiveContainerCount, checker.Equals, 0)
 }
 
 func (s *DockerSwarmSuite) TestAPISwarmServicesMultipleAgents(c *check.C) {
@@ -230,23 +231,23 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesMultipleAgents(c *check.C) {
 	time.Sleep(1 * time.Second) // make sure all daemons are ready to accept tasks
 
 	instances := 9
-	id := d1.createService(c, simpleTestService, setInstances(instances))
+	id := d1.CreateService(c, simpleTestService, setInstances(instances))
 
-	waitAndAssert(c, defaultReconciliationTimeout, d1.checkActiveContainerCount, checker.GreaterThan, 0)
-	waitAndAssert(c, defaultReconciliationTimeout, d2.checkActiveContainerCount, checker.GreaterThan, 0)
-	waitAndAssert(c, defaultReconciliationTimeout, d3.checkActiveContainerCount, checker.GreaterThan, 0)
+	waitAndAssert(c, defaultReconciliationTimeout, d1.CheckActiveContainerCount, checker.GreaterThan, 0)
+	waitAndAssert(c, defaultReconciliationTimeout, d2.CheckActiveContainerCount, checker.GreaterThan, 0)
+	waitAndAssert(c, defaultReconciliationTimeout, d3.CheckActiveContainerCount, checker.GreaterThan, 0)
 
-	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.checkActiveContainerCount, d2.checkActiveContainerCount, d3.checkActiveContainerCount), checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.CheckActiveContainerCount, d2.CheckActiveContainerCount, d3.CheckActiveContainerCount), checker.Equals, instances)
 
 	// reconciliation on d2 node down
 	c.Assert(d2.Stop(), checker.IsNil)
 
-	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.checkActiveContainerCount, d3.checkActiveContainerCount), checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.CheckActiveContainerCount, d3.CheckActiveContainerCount), checker.Equals, instances)
 
 	// test downscaling
 	instances = 5
-	d1.updateService(c, d1.getService(c, id), setInstances(instances))
-	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.checkActiveContainerCount, d3.checkActiveContainerCount), checker.Equals, instances)
+	d1.UpdateService(c, d1.GetService(c, id), setInstances(instances))
+	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.CheckActiveContainerCount, d3.CheckActiveContainerCount), checker.Equals, instances)
 
 }
 
@@ -255,27 +256,27 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesCreateGlobal(c *check.C) {
 	d2 := s.AddDaemon(c, true, false)
 	d3 := s.AddDaemon(c, true, false)
 
-	d1.createService(c, simpleTestService, setGlobalMode)
+	d1.CreateService(c, simpleTestService, setGlobalMode)
 
-	waitAndAssert(c, defaultReconciliationTimeout, d1.checkActiveContainerCount, checker.Equals, 1)
-	waitAndAssert(c, defaultReconciliationTimeout, d2.checkActiveContainerCount, checker.Equals, 1)
-	waitAndAssert(c, defaultReconciliationTimeout, d3.checkActiveContainerCount, checker.Equals, 1)
+	waitAndAssert(c, defaultReconciliationTimeout, d1.CheckActiveContainerCount, checker.Equals, 1)
+	waitAndAssert(c, defaultReconciliationTimeout, d2.CheckActiveContainerCount, checker.Equals, 1)
+	waitAndAssert(c, defaultReconciliationTimeout, d3.CheckActiveContainerCount, checker.Equals, 1)
 
 	d4 := s.AddDaemon(c, true, false)
 	d5 := s.AddDaemon(c, true, false)
 
-	waitAndAssert(c, defaultReconciliationTimeout, d4.checkActiveContainerCount, checker.Equals, 1)
-	waitAndAssert(c, defaultReconciliationTimeout, d5.checkActiveContainerCount, checker.Equals, 1)
+	waitAndAssert(c, defaultReconciliationTimeout, d4.CheckActiveContainerCount, checker.Equals, 1)
+	waitAndAssert(c, defaultReconciliationTimeout, d5.CheckActiveContainerCount, checker.Equals, 1)
 }
 
 func (s *DockerSwarmSuite) TestAPISwarmServicesUpdate(c *check.C) {
 	const nodeCount = 3
-	var daemons [nodeCount]*SwarmDaemon
+	var daemons [nodeCount]*daemon.Swarm
 	for i := 0; i < nodeCount; i++ {
 		daemons[i] = s.AddDaemon(c, true, i == 0)
 	}
 	// wait for nodes ready
-	waitAndAssert(c, 5*time.Second, daemons[0].checkNodeReadyCount, checker.Equals, nodeCount)
+	waitAndAssert(c, 5*time.Second, daemons[0].CheckNodeReadyCount, checker.Equals, nodeCount)
 
 	// service image at start
 	image1 := "busybox:latest"
@@ -291,26 +292,26 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesUpdate(c *check.C) {
 	// create service
 	instances := 5
 	parallelism := 2
-	id := daemons[0].createService(c, serviceForUpdate, setInstances(instances))
+	id := daemons[0].CreateService(c, serviceForUpdate, setInstances(instances))
 
 	// wait for tasks ready
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkRunningTaskImages, checker.DeepEquals,
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckRunningTaskImages, checker.DeepEquals,
 		map[string]int{image1: instances})
 
 	// issue service update
-	service := daemons[0].getService(c, id)
-	daemons[0].updateService(c, service, setImage(image2))
+	service := daemons[0].GetService(c, id)
+	daemons[0].UpdateService(c, service, setImage(image2))
 
 	// first batch
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkRunningTaskImages, checker.DeepEquals,
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckRunningTaskImages, checker.DeepEquals,
 		map[string]int{image1: instances - parallelism, image2: parallelism})
 
 	// 2nd batch
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkRunningTaskImages, checker.DeepEquals,
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckRunningTaskImages, checker.DeepEquals,
 		map[string]int{image1: instances - 2*parallelism, image2: 2 * parallelism})
 
 	// 3nd batch
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkRunningTaskImages, checker.DeepEquals,
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckRunningTaskImages, checker.DeepEquals,
 		map[string]int{image2: instances})
 
 	// Roll back to the previous version. This uses the CLI because
@@ -319,26 +320,26 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesUpdate(c *check.C) {
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 
 	// first batch
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkRunningTaskImages, checker.DeepEquals,
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckRunningTaskImages, checker.DeepEquals,
 		map[string]int{image2: instances - parallelism, image1: parallelism})
 
 	// 2nd batch
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkRunningTaskImages, checker.DeepEquals,
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckRunningTaskImages, checker.DeepEquals,
 		map[string]int{image2: instances - 2*parallelism, image1: 2 * parallelism})
 
 	// 3nd batch
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkRunningTaskImages, checker.DeepEquals,
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckRunningTaskImages, checker.DeepEquals,
 		map[string]int{image1: instances})
 }
 
 func (s *DockerSwarmSuite) TestAPISwarmServicesFailedUpdate(c *check.C) {
 	const nodeCount = 3
-	var daemons [nodeCount]*SwarmDaemon
+	var daemons [nodeCount]*daemon.Swarm
 	for i := 0; i < nodeCount; i++ {
 		daemons[i] = s.AddDaemon(c, true, i == 0)
 	}
 	// wait for nodes ready
-	waitAndAssert(c, 5*time.Second, daemons[0].checkNodeReadyCount, checker.Equals, nodeCount)
+	waitAndAssert(c, 5*time.Second, daemons[0].CheckNodeReadyCount, checker.Equals, nodeCount)
 
 	// service image at start
 	image1 := "busybox:latest"
@@ -347,19 +348,19 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesFailedUpdate(c *check.C) {
 
 	// create service
 	instances := 5
-	id := daemons[0].createService(c, serviceForUpdate, setInstances(instances))
+	id := daemons[0].CreateService(c, serviceForUpdate, setInstances(instances))
 
 	// wait for tasks ready
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkRunningTaskImages, checker.DeepEquals,
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckRunningTaskImages, checker.DeepEquals,
 		map[string]int{image1: instances})
 
 	// issue service update
-	service := daemons[0].getService(c, id)
-	daemons[0].updateService(c, service, setImage(image2), setFailureAction(swarm.UpdateFailureActionPause), setMaxFailureRatio(0.25), setParallelism(1))
+	service := daemons[0].GetService(c, id)
+	daemons[0].UpdateService(c, service, setImage(image2), setFailureAction(swarm.UpdateFailureActionPause), setMaxFailureRatio(0.25), setParallelism(1))
 
 	// should update 2 tasks and then pause
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkServiceUpdateState(id), checker.Equals, swarm.UpdateStatePaused)
-	v, _ := daemons[0].checkServiceRunningTasks(id)(c)
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckServiceUpdateState(id), checker.Equals, swarm.UpdateStatePaused)
+	v, _ := daemons[0].CheckServiceRunningTasks(id)(c)
 	c.Assert(v, checker.Equals, instances-2)
 
 	// Roll back to the previous version. This uses the CLI because
@@ -367,57 +368,57 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesFailedUpdate(c *check.C) {
 	out, err := daemons[0].Cmd("service", "update", "--rollback", id)
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkRunningTaskImages, checker.DeepEquals,
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckRunningTaskImages, checker.DeepEquals,
 		map[string]int{image1: instances})
 }
 
 func (s *DockerSwarmSuite) TestAPISwarmServiceConstraintRole(c *check.C) {
 	const nodeCount = 3
-	var daemons [nodeCount]*SwarmDaemon
+	var daemons [nodeCount]*daemon.Swarm
 	for i := 0; i < nodeCount; i++ {
 		daemons[i] = s.AddDaemon(c, true, i == 0)
 	}
 	// wait for nodes ready
-	waitAndAssert(c, 5*time.Second, daemons[0].checkNodeReadyCount, checker.Equals, nodeCount)
+	waitAndAssert(c, 5*time.Second, daemons[0].CheckNodeReadyCount, checker.Equals, nodeCount)
 
 	// create service
 	constraints := []string{"node.role==worker"}
 	instances := 3
-	id := daemons[0].createService(c, simpleTestService, setConstraints(constraints), setInstances(instances))
+	id := daemons[0].CreateService(c, simpleTestService, setConstraints(constraints), setInstances(instances))
 	// wait for tasks ready
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkServiceRunningTasks(id), checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckServiceRunningTasks(id), checker.Equals, instances)
 	// validate tasks are running on worker nodes
-	tasks := daemons[0].getServiceTasks(c, id)
+	tasks := daemons[0].GetServiceTasks(c, id)
 	for _, task := range tasks {
-		node := daemons[0].getNode(c, task.NodeID)
+		node := daemons[0].GetNode(c, task.NodeID)
 		c.Assert(node.Spec.Role, checker.Equals, swarm.NodeRoleWorker)
 	}
 	//remove service
-	daemons[0].removeService(c, id)
+	daemons[0].RemoveService(c, id)
 
 	// create service
 	constraints = []string{"node.role!=worker"}
-	id = daemons[0].createService(c, simpleTestService, setConstraints(constraints), setInstances(instances))
+	id = daemons[0].CreateService(c, simpleTestService, setConstraints(constraints), setInstances(instances))
 	// wait for tasks ready
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkServiceRunningTasks(id), checker.Equals, instances)
-	tasks = daemons[0].getServiceTasks(c, id)
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckServiceRunningTasks(id), checker.Equals, instances)
+	tasks = daemons[0].GetServiceTasks(c, id)
 	// validate tasks are running on manager nodes
 	for _, task := range tasks {
-		node := daemons[0].getNode(c, task.NodeID)
+		node := daemons[0].GetNode(c, task.NodeID)
 		c.Assert(node.Spec.Role, checker.Equals, swarm.NodeRoleManager)
 	}
 	//remove service
-	daemons[0].removeService(c, id)
+	daemons[0].RemoveService(c, id)
 
 	// create service
 	constraints = []string{"node.role==nosuchrole"}
-	id = daemons[0].createService(c, simpleTestService, setConstraints(constraints), setInstances(instances))
+	id = daemons[0].CreateService(c, simpleTestService, setConstraints(constraints), setInstances(instances))
 	// wait for tasks created
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkServiceTasks(id), checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckServiceTasks(id), checker.Equals, instances)
 	// let scheduler try
 	time.Sleep(250 * time.Millisecond)
 	// validate tasks are not assigned to any node
-	tasks = daemons[0].getServiceTasks(c, id)
+	tasks = daemons[0].GetServiceTasks(c, id)
 	for _, task := range tasks {
 		c.Assert(task.NodeID, checker.Equals, "")
 	}
@@ -425,23 +426,23 @@ func (s *DockerSwarmSuite) TestAPISwarmServiceConstraintRole(c *check.C) {
 
 func (s *DockerSwarmSuite) TestAPISwarmServiceConstraintLabel(c *check.C) {
 	const nodeCount = 3
-	var daemons [nodeCount]*SwarmDaemon
+	var daemons [nodeCount]*daemon.Swarm
 	for i := 0; i < nodeCount; i++ {
 		daemons[i] = s.AddDaemon(c, true, i == 0)
 	}
 	// wait for nodes ready
-	waitAndAssert(c, 5*time.Second, daemons[0].checkNodeReadyCount, checker.Equals, nodeCount)
-	nodes := daemons[0].listNodes(c)
+	waitAndAssert(c, 5*time.Second, daemons[0].CheckNodeReadyCount, checker.Equals, nodeCount)
+	nodes := daemons[0].ListNodes(c)
 	c.Assert(len(nodes), checker.Equals, nodeCount)
 
 	// add labels to nodes
-	daemons[0].updateNode(c, nodes[0].ID, func(n *swarm.Node) {
+	daemons[0].UpdateNode(c, nodes[0].ID, func(n *swarm.Node) {
 		n.Spec.Annotations.Labels = map[string]string{
 			"security": "high",
 		}
 	})
 	for i := 1; i < nodeCount; i++ {
-		daemons[0].updateNode(c, nodes[i].ID, func(n *swarm.Node) {
+		daemons[0].UpdateNode(c, nodes[i].ID, func(n *swarm.Node) {
 			n.Spec.Annotations.Labels = map[string]string{
 				"security": "low",
 			}
@@ -451,68 +452,68 @@ func (s *DockerSwarmSuite) TestAPISwarmServiceConstraintLabel(c *check.C) {
 	// create service
 	instances := 3
 	constraints := []string{"node.labels.security==high"}
-	id := daemons[0].createService(c, simpleTestService, setConstraints(constraints), setInstances(instances))
+	id := daemons[0].CreateService(c, simpleTestService, setConstraints(constraints), setInstances(instances))
 	// wait for tasks ready
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkServiceRunningTasks(id), checker.Equals, instances)
-	tasks := daemons[0].getServiceTasks(c, id)
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckServiceRunningTasks(id), checker.Equals, instances)
+	tasks := daemons[0].GetServiceTasks(c, id)
 	// validate all tasks are running on nodes[0]
 	for _, task := range tasks {
 		c.Assert(task.NodeID, checker.Equals, nodes[0].ID)
 	}
 	//remove service
-	daemons[0].removeService(c, id)
+	daemons[0].RemoveService(c, id)
 
 	// create service
 	constraints = []string{"node.labels.security!=high"}
-	id = daemons[0].createService(c, simpleTestService, setConstraints(constraints), setInstances(instances))
+	id = daemons[0].CreateService(c, simpleTestService, setConstraints(constraints), setInstances(instances))
 	// wait for tasks ready
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkServiceRunningTasks(id), checker.Equals, instances)
-	tasks = daemons[0].getServiceTasks(c, id)
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckServiceRunningTasks(id), checker.Equals, instances)
+	tasks = daemons[0].GetServiceTasks(c, id)
 	// validate all tasks are NOT running on nodes[0]
 	for _, task := range tasks {
 		c.Assert(task.NodeID, checker.Not(checker.Equals), nodes[0].ID)
 	}
 	//remove service
-	daemons[0].removeService(c, id)
+	daemons[0].RemoveService(c, id)
 
 	constraints = []string{"node.labels.security==medium"}
-	id = daemons[0].createService(c, simpleTestService, setConstraints(constraints), setInstances(instances))
+	id = daemons[0].CreateService(c, simpleTestService, setConstraints(constraints), setInstances(instances))
 	// wait for tasks created
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkServiceTasks(id), checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckServiceTasks(id), checker.Equals, instances)
 	// let scheduler try
 	time.Sleep(250 * time.Millisecond)
-	tasks = daemons[0].getServiceTasks(c, id)
+	tasks = daemons[0].GetServiceTasks(c, id)
 	// validate tasks are not assigned
 	for _, task := range tasks {
 		c.Assert(task.NodeID, checker.Equals, "")
 	}
 	//remove service
-	daemons[0].removeService(c, id)
+	daemons[0].RemoveService(c, id)
 
 	// multiple constraints
 	constraints = []string{
 		"node.labels.security==high",
 		fmt.Sprintf("node.id==%s", nodes[1].ID),
 	}
-	id = daemons[0].createService(c, simpleTestService, setConstraints(constraints), setInstances(instances))
+	id = daemons[0].CreateService(c, simpleTestService, setConstraints(constraints), setInstances(instances))
 	// wait for tasks created
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkServiceTasks(id), checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckServiceTasks(id), checker.Equals, instances)
 	// let scheduler try
 	time.Sleep(250 * time.Millisecond)
-	tasks = daemons[0].getServiceTasks(c, id)
+	tasks = daemons[0].GetServiceTasks(c, id)
 	// validate tasks are not assigned
 	for _, task := range tasks {
 		c.Assert(task.NodeID, checker.Equals, "")
 	}
 	// make nodes[1] fulfills the constraints
-	daemons[0].updateNode(c, nodes[1].ID, func(n *swarm.Node) {
+	daemons[0].UpdateNode(c, nodes[1].ID, func(n *swarm.Node) {
 		n.Spec.Annotations.Labels = map[string]string{
 			"security": "high",
 		}
 	})
 	// wait for tasks ready
-	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].checkServiceRunningTasks(id), checker.Equals, instances)
-	tasks = daemons[0].getServiceTasks(c, id)
+	waitAndAssert(c, defaultReconciliationTimeout, daemons[0].CheckServiceRunningTasks(id), checker.Equals, instances)
+	tasks = daemons[0].GetServiceTasks(c, id)
 	for _, task := range tasks {
 		c.Assert(task.NodeID, checker.Equals, nodes[1].ID)
 	}
@@ -529,14 +530,14 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesStateReporting(c *check.C) {
 	time.Sleep(1 * time.Second) // make sure all daemons are ready to accept
 
 	instances := 9
-	d1.createService(c, simpleTestService, setInstances(instances))
+	d1.CreateService(c, simpleTestService, setInstances(instances))
 
-	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.checkActiveContainerCount, d2.checkActiveContainerCount, d3.checkActiveContainerCount), checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.CheckActiveContainerCount, d2.CheckActiveContainerCount, d3.CheckActiveContainerCount), checker.Equals, instances)
 
-	getContainers := func() map[string]*SwarmDaemon {
-		m := make(map[string]*SwarmDaemon)
-		for _, d := range []*SwarmDaemon{d1, d2, d3} {
-			for _, id := range d.activeContainers() {
+	getContainers := func() map[string]*daemon.Swarm {
+		m := make(map[string]*daemon.Swarm)
+		for _, d := range []*daemon.Swarm{d1, d2, d3} {
+			for _, id := range d.ActiveContainers() {
 				m[id] = d
 			}
 		}
@@ -553,7 +554,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesStateReporting(c *check.C) {
 	_, err := containers[toRemove].Cmd("stop", toRemove)
 	c.Assert(err, checker.IsNil)
 
-	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.checkActiveContainerCount, d2.checkActiveContainerCount, d3.checkActiveContainerCount), checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.CheckActiveContainerCount, d2.CheckActiveContainerCount, d3.CheckActiveContainerCount), checker.Equals, instances)
 
 	containers2 := getContainers()
 	c.Assert(containers2, checker.HasLen, instances)
@@ -579,7 +580,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesStateReporting(c *check.C) {
 
 	time.Sleep(time.Second) // give some time to handle the signal
 
-	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.checkActiveContainerCount, d2.checkActiveContainerCount, d3.checkActiveContainerCount), checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.CheckActiveContainerCount, d2.CheckActiveContainerCount, d3.CheckActiveContainerCount), checker.Equals, instances)
 
 	containers2 = getContainers()
 	c.Assert(containers2, checker.HasLen, instances)
@@ -599,20 +600,20 @@ func (s *DockerSwarmSuite) TestAPISwarmLeaderProxy(c *check.C) {
 	d3 := s.AddDaemon(c, true, true)
 
 	// start a service by hitting each of the 3 managers
-	d1.createService(c, simpleTestService, func(s *swarm.Service) {
+	d1.CreateService(c, simpleTestService, func(s *swarm.Service) {
 		s.Spec.Name = "test1"
 	})
-	d2.createService(c, simpleTestService, func(s *swarm.Service) {
+	d2.CreateService(c, simpleTestService, func(s *swarm.Service) {
 		s.Spec.Name = "test2"
 	})
-	d3.createService(c, simpleTestService, func(s *swarm.Service) {
+	d3.CreateService(c, simpleTestService, func(s *swarm.Service) {
 		s.Spec.Name = "test3"
 	})
 
 	// 3 services should be started now, because the requests were proxied to leader
 	// query each node and make sure it returns 3 services
-	for _, d := range []*SwarmDaemon{d1, d2, d3} {
-		services := d.listServices(c)
+	for _, d := range []*daemon.Swarm{d1, d2, d3} {
+		services := d.ListServices(c)
 		c.Assert(services, checker.HasLen, 3)
 	}
 }
@@ -624,23 +625,23 @@ func (s *DockerSwarmSuite) TestAPISwarmLeaderElection(c *check.C) {
 	d3 := s.AddDaemon(c, true, true)
 
 	// assert that the first node we made is the leader, and the other two are followers
-	c.Assert(d1.getNode(c, d1.NodeID).ManagerStatus.Leader, checker.True)
-	c.Assert(d1.getNode(c, d2.NodeID).ManagerStatus.Leader, checker.False)
-	c.Assert(d1.getNode(c, d3.NodeID).ManagerStatus.Leader, checker.False)
+	c.Assert(d1.GetNode(c, d1.NodeID).ManagerStatus.Leader, checker.True)
+	c.Assert(d1.GetNode(c, d2.NodeID).ManagerStatus.Leader, checker.False)
+	c.Assert(d1.GetNode(c, d3.NodeID).ManagerStatus.Leader, checker.False)
 
 	d1.Stop() // stop the leader
 
 	var (
-		leader    *SwarmDaemon   // keep track of leader
-		followers []*SwarmDaemon // keep track of followers
+		leader    *daemon.Swarm   // keep track of leader
+		followers []*daemon.Swarm // keep track of followers
 	)
-	checkLeader := func(nodes ...*SwarmDaemon) checkF {
+	checkLeader := func(nodes ...*daemon.Swarm) checkF {
 		return func(c *check.C) (interface{}, check.CommentInterface) {
 			// clear these out before each run
 			leader = nil
 			followers = nil
 			for _, d := range nodes {
-				if d.getNode(c, d.NodeID).ManagerStatus.Leader {
+				if d.GetNode(c, d.NodeID).ManagerStatus.Leader {
 					leader = d
 				} else {
 					followers = append(followers, d)
@@ -651,7 +652,7 @@ func (s *DockerSwarmSuite) TestAPISwarmLeaderElection(c *check.C) {
 				return false, check.Commentf("no leader elected")
 			}
 
-			return true, check.Commentf("elected %v", leader.id)
+			return true, check.Commentf("elected %v", leader.ID())
 		}
 	}
 
@@ -685,21 +686,21 @@ func (s *DockerSwarmSuite) TestAPISwarmRaftQuorum(c *check.C) {
 	d2 := s.AddDaemon(c, true, true)
 	d3 := s.AddDaemon(c, true, true)
 
-	d1.createService(c, simpleTestService)
+	d1.CreateService(c, simpleTestService)
 
 	c.Assert(d2.Stop(), checker.IsNil)
 
 	// make sure there is a leader
-	waitAndAssert(c, defaultReconciliationTimeout, d1.checkLeader, checker.IsNil)
+	waitAndAssert(c, defaultReconciliationTimeout, d1.CheckLeader, checker.IsNil)
 
-	d1.createService(c, simpleTestService, func(s *swarm.Service) {
+	d1.CreateService(c, simpleTestService, func(s *swarm.Service) {
 		s.Spec.Name = "top1"
 	})
 
 	c.Assert(d3.Stop(), checker.IsNil)
 
 	// make sure there is a leader
-	waitAndAssert(c, defaultReconciliationTimeout, d1.checkLeader, checker.IsNil)
+	waitAndAssert(c, defaultReconciliationTimeout, d1.CheckLeader, checker.IsNil)
 
 	var service swarm.Service
 	simpleTestService(&service)
@@ -711,9 +712,9 @@ func (s *DockerSwarmSuite) TestAPISwarmRaftQuorum(c *check.C) {
 	c.Assert(d2.Start(), checker.IsNil)
 
 	// make sure there is a leader
-	waitAndAssert(c, defaultReconciliationTimeout, d1.checkLeader, checker.IsNil)
+	waitAndAssert(c, defaultReconciliationTimeout, d1.CheckLeader, checker.IsNil)
 
-	d1.createService(c, simpleTestService, func(s *swarm.Service) {
+	d1.CreateService(c, simpleTestService, func(s *swarm.Service) {
 		s.Spec.Name = "top3"
 	})
 }
@@ -723,12 +724,12 @@ func (s *DockerSwarmSuite) TestAPISwarmListNodes(c *check.C) {
 	d2 := s.AddDaemon(c, true, false)
 	d3 := s.AddDaemon(c, true, false)
 
-	nodes := d1.listNodes(c)
+	nodes := d1.ListNodes(c)
 	c.Assert(len(nodes), checker.Equals, 3, check.Commentf("nodes: %#v", nodes))
 
 loop0:
 	for _, n := range nodes {
-		for _, d := range []*SwarmDaemon{d1, d2, d3} {
+		for _, d := range []*daemon.Swarm{d1, d2, d3} {
 			if n.ID == d.NodeID {
 				continue loop0
 			}
@@ -740,13 +741,13 @@ loop0:
 func (s *DockerSwarmSuite) TestAPISwarmNodeUpdate(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
-	nodes := d.listNodes(c)
+	nodes := d.ListNodes(c)
 
-	d.updateNode(c, nodes[0].ID, func(n *swarm.Node) {
+	d.UpdateNode(c, nodes[0].ID, func(n *swarm.Node) {
 		n.Spec.Availability = swarm.NodeAvailabilityPause
 	})
 
-	n := d.getNode(c, nodes[0].ID)
+	n := d.GetNode(c, nodes[0].ID)
 	c.Assert(n.Spec.Availability, checker.Equals, swarm.NodeAvailabilityPause)
 }
 
@@ -756,17 +757,17 @@ func (s *DockerSwarmSuite) TestAPISwarmNodeRemove(c *check.C) {
 	d2 := s.AddDaemon(c, true, false)
 	_ = s.AddDaemon(c, true, false)
 
-	nodes := d1.listNodes(c)
+	nodes := d1.ListNodes(c)
 	c.Assert(len(nodes), checker.Equals, 3, check.Commentf("nodes: %#v", nodes))
 
 	// Getting the info so we can take the NodeID
-	d2Info, err := d2.info()
+	d2Info, err := d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 
 	// forceful removal of d2 should work
-	d1.removeNode(c, d2Info.NodeID, true)
+	d1.RemoveNode(c, d2Info.NodeID, true)
 
-	nodes = d1.listNodes(c)
+	nodes = d1.ListNodes(c)
 	c.Assert(len(nodes), checker.Equals, 2, check.Commentf("nodes: %#v", nodes))
 
 	// Restart the node that was removed
@@ -777,7 +778,7 @@ func (s *DockerSwarmSuite) TestAPISwarmNodeRemove(c *check.C) {
 	time.Sleep(1 * time.Second)
 
 	// Make sure the node didn't rejoin
-	nodes = d1.listNodes(c)
+	nodes = d1.ListNodes(c)
 	c.Assert(len(nodes), checker.Equals, 2, check.Commentf("nodes: %#v", nodes))
 }
 
@@ -789,49 +790,49 @@ func (s *DockerSwarmSuite) TestAPISwarmNodeDrainPause(c *check.C) {
 
 	// start a service, expect balanced distribution
 	instances := 8
-	id := d1.createService(c, simpleTestService, setInstances(instances))
+	id := d1.CreateService(c, simpleTestService, setInstances(instances))
 
-	waitAndAssert(c, defaultReconciliationTimeout, d1.checkActiveContainerCount, checker.GreaterThan, 0)
-	waitAndAssert(c, defaultReconciliationTimeout, d2.checkActiveContainerCount, checker.GreaterThan, 0)
-	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.checkActiveContainerCount, d2.checkActiveContainerCount), checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, d1.CheckActiveContainerCount, checker.GreaterThan, 0)
+	waitAndAssert(c, defaultReconciliationTimeout, d2.CheckActiveContainerCount, checker.GreaterThan, 0)
+	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.CheckActiveContainerCount, d2.CheckActiveContainerCount), checker.Equals, instances)
 
 	// drain d2, all containers should move to d1
-	d1.updateNode(c, d2.NodeID, func(n *swarm.Node) {
+	d1.UpdateNode(c, d2.NodeID, func(n *swarm.Node) {
 		n.Spec.Availability = swarm.NodeAvailabilityDrain
 	})
-	waitAndAssert(c, defaultReconciliationTimeout, d1.checkActiveContainerCount, checker.Equals, instances)
-	waitAndAssert(c, defaultReconciliationTimeout, d2.checkActiveContainerCount, checker.Equals, 0)
+	waitAndAssert(c, defaultReconciliationTimeout, d1.CheckActiveContainerCount, checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, d2.CheckActiveContainerCount, checker.Equals, 0)
 
 	// set d2 back to active
-	d1.updateNode(c, d2.NodeID, func(n *swarm.Node) {
+	d1.UpdateNode(c, d2.NodeID, func(n *swarm.Node) {
 		n.Spec.Availability = swarm.NodeAvailabilityActive
 	})
 
 	instances = 1
-	d1.updateService(c, d1.getService(c, id), setInstances(instances))
+	d1.UpdateService(c, d1.GetService(c, id), setInstances(instances))
 
-	waitAndAssert(c, defaultReconciliationTimeout*2, reducedCheck(sumAsIntegers, d1.checkActiveContainerCount, d2.checkActiveContainerCount), checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout*2, reducedCheck(sumAsIntegers, d1.CheckActiveContainerCount, d2.CheckActiveContainerCount), checker.Equals, instances)
 
 	instances = 8
-	d1.updateService(c, d1.getService(c, id), setInstances(instances))
+	d1.UpdateService(c, d1.GetService(c, id), setInstances(instances))
 
 	// drained node first so we don't get any old containers
-	waitAndAssert(c, defaultReconciliationTimeout, d2.checkActiveContainerCount, checker.GreaterThan, 0)
-	waitAndAssert(c, defaultReconciliationTimeout, d1.checkActiveContainerCount, checker.GreaterThan, 0)
-	waitAndAssert(c, defaultReconciliationTimeout*2, reducedCheck(sumAsIntegers, d1.checkActiveContainerCount, d2.checkActiveContainerCount), checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, d2.CheckActiveContainerCount, checker.GreaterThan, 0)
+	waitAndAssert(c, defaultReconciliationTimeout, d1.CheckActiveContainerCount, checker.GreaterThan, 0)
+	waitAndAssert(c, defaultReconciliationTimeout*2, reducedCheck(sumAsIntegers, d1.CheckActiveContainerCount, d2.CheckActiveContainerCount), checker.Equals, instances)
 
-	d2ContainerCount := len(d2.activeContainers())
+	d2ContainerCount := len(d2.ActiveContainers())
 
 	// set d2 to paused, scale service up, only d1 gets new tasks
-	d1.updateNode(c, d2.NodeID, func(n *swarm.Node) {
+	d1.UpdateNode(c, d2.NodeID, func(n *swarm.Node) {
 		n.Spec.Availability = swarm.NodeAvailabilityPause
 	})
 
 	instances = 14
-	d1.updateService(c, d1.getService(c, id), setInstances(instances))
+	d1.UpdateService(c, d1.GetService(c, id), setInstances(instances))
 
-	waitAndAssert(c, defaultReconciliationTimeout, d1.checkActiveContainerCount, checker.Equals, instances-d2ContainerCount)
-	waitAndAssert(c, defaultReconciliationTimeout, d2.checkActiveContainerCount, checker.Equals, d2ContainerCount)
+	waitAndAssert(c, defaultReconciliationTimeout, d1.CheckActiveContainerCount, checker.Equals, instances-d2ContainerCount)
+	waitAndAssert(c, defaultReconciliationTimeout, d2.CheckActiveContainerCount, checker.Equals, d2ContainerCount)
 
 }
 
@@ -839,18 +840,18 @@ func (s *DockerSwarmSuite) TestAPISwarmLeaveRemovesContainer(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	instances := 2
-	d.createService(c, simpleTestService, setInstances(instances))
+	d.CreateService(c, simpleTestService, setInstances(instances))
 
 	id, err := d.Cmd("run", "-d", "busybox", "top")
 	c.Assert(err, checker.IsNil)
 	id = strings.TrimSpace(id)
 
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, instances+1)
+	waitAndAssert(c, defaultReconciliationTimeout, d.CheckActiveContainerCount, checker.Equals, instances+1)
 
 	c.Assert(d.Leave(false), checker.NotNil)
 	c.Assert(d.Leave(true), checker.IsNil)
 
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 1)
+	waitAndAssert(c, defaultReconciliationTimeout, d.CheckActiveContainerCount, checker.Equals, 1)
 
 	id2, err := d.Cmd("ps", "-q")
 	c.Assert(err, checker.IsNil)
@@ -873,13 +874,13 @@ func (s *DockerSwarmSuite) TestAPISwarmLeaveOnPendingJoin(c *check.C) {
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), checker.Contains, "Timeout was reached")
 
-	info, err := d2.info()
+	info, err := d2.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStatePending)
 
 	c.Assert(d2.Leave(true), checker.IsNil)
 
-	waitAndAssert(c, defaultReconciliationTimeout, d2.checkActiveContainerCount, checker.Equals, 1)
+	waitAndAssert(c, defaultReconciliationTimeout, d2.CheckActiveContainerCount, checker.Equals, 1)
 
 	id2, err := d2.Cmd("ps", "-q")
 	c.Assert(err, checker.IsNil)
@@ -896,12 +897,12 @@ func (s *DockerSwarmSuite) TestAPISwarmRestoreOnPendingJoin(c *check.C) {
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), checker.Contains, "Timeout was reached")
 
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkLocalNodeState, checker.Equals, swarm.LocalNodeStatePending)
+	waitAndAssert(c, defaultReconciliationTimeout, d.CheckLocalNodeState, checker.Equals, swarm.LocalNodeStatePending)
 
 	c.Assert(d.Stop(), checker.IsNil)
 	c.Assert(d.Start(), checker.IsNil)
 
-	info, err := d.info()
+	info, err := d.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateInactive)
 }
@@ -910,43 +911,43 @@ func (s *DockerSwarmSuite) TestAPISwarmManagerRestore(c *check.C) {
 	d1 := s.AddDaemon(c, true, true)
 
 	instances := 2
-	id := d1.createService(c, simpleTestService, setInstances(instances))
+	id := d1.CreateService(c, simpleTestService, setInstances(instances))
 
-	d1.getService(c, id)
+	d1.GetService(c, id)
 	d1.Stop()
 	d1.Start()
-	d1.getService(c, id)
+	d1.GetService(c, id)
 
 	d2 := s.AddDaemon(c, true, true)
-	d2.getService(c, id)
+	d2.GetService(c, id)
 	d2.Stop()
 	d2.Start()
-	d2.getService(c, id)
+	d2.GetService(c, id)
 
 	d3 := s.AddDaemon(c, true, true)
-	d3.getService(c, id)
+	d3.GetService(c, id)
 	d3.Stop()
 	d3.Start()
-	d3.getService(c, id)
+	d3.GetService(c, id)
 
 	d3.Kill()
 	time.Sleep(1 * time.Second) // time to handle signal
 	d3.Start()
-	d3.getService(c, id)
+	d3.GetService(c, id)
 }
 
 func (s *DockerSwarmSuite) TestAPISwarmScaleNoRollingUpdate(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	instances := 2
-	id := d.createService(c, simpleTestService, setInstances(instances))
+	id := d.CreateService(c, simpleTestService, setInstances(instances))
 
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, instances)
-	containers := d.activeContainers()
+	waitAndAssert(c, defaultReconciliationTimeout, d.CheckActiveContainerCount, checker.Equals, instances)
+	containers := d.ActiveContainers()
 	instances = 4
-	d.updateService(c, d.getService(c, id), setInstances(instances))
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, instances)
-	containers2 := d.activeContainers()
+	d.UpdateService(c, d.GetService(c, id), setInstances(instances))
+	waitAndAssert(c, defaultReconciliationTimeout, d.CheckActiveContainerCount, checker.Equals, instances)
+	containers2 := d.ActiveContainers()
 
 loop0:
 	for _, c1 := range containers {
@@ -982,15 +983,15 @@ func (s *DockerSwarmSuite) TestAPISwarmForceNewCluster(c *check.C) {
 	d2 := s.AddDaemon(c, true, true)
 
 	instances := 2
-	id := d1.createService(c, simpleTestService, setInstances(instances))
-	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.checkActiveContainerCount, d2.checkActiveContainerCount), checker.Equals, instances)
+	id := d1.CreateService(c, simpleTestService, setInstances(instances))
+	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.CheckActiveContainerCount, d2.CheckActiveContainerCount), checker.Equals, instances)
 
 	// drain d2, all containers should move to d1
-	d1.updateNode(c, d2.NodeID, func(n *swarm.Node) {
+	d1.UpdateNode(c, d2.NodeID, func(n *swarm.Node) {
 		n.Spec.Availability = swarm.NodeAvailabilityDrain
 	})
-	waitAndAssert(c, defaultReconciliationTimeout, d1.checkActiveContainerCount, checker.Equals, instances)
-	waitAndAssert(c, defaultReconciliationTimeout, d2.checkActiveContainerCount, checker.Equals, 0)
+	waitAndAssert(c, defaultReconciliationTimeout, d1.CheckActiveContainerCount, checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, d2.CheckActiveContainerCount, checker.Equals, 0)
 
 	c.Assert(d2.Stop(), checker.IsNil)
 
@@ -999,18 +1000,18 @@ func (s *DockerSwarmSuite) TestAPISwarmForceNewCluster(c *check.C) {
 		Spec:            swarm.Spec{},
 	}), checker.IsNil)
 
-	waitAndAssert(c, defaultReconciliationTimeout, d1.checkActiveContainerCount, checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, d1.CheckActiveContainerCount, checker.Equals, instances)
 
 	d3 := s.AddDaemon(c, true, true)
-	info, err := d3.info()
+	info, err := d3.SwarmInfo()
 	c.Assert(err, checker.IsNil)
 	c.Assert(info.ControlAvailable, checker.True)
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateActive)
 
 	instances = 4
-	d3.updateService(c, d3.getService(c, id), setInstances(instances))
+	d3.UpdateService(c, d3.GetService(c, id), setInstances(instances))
 
-	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.checkActiveContainerCount, d3.checkActiveContainerCount), checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, reducedCheck(sumAsIntegers, d1.CheckActiveContainerCount, d3.CheckActiveContainerCount), checker.Equals, instances)
 }
 
 func simpleTestService(s *swarm.Service) {
@@ -1064,7 +1065,7 @@ func serviceForUpdate(s *swarm.Service) {
 	s.Spec.Name = "updatetest"
 }
 
-func setInstances(replicas int) serviceConstructor {
+func setInstances(replicas int) daemon.ServiceConstructor {
 	ureplicas := uint64(replicas)
 	return func(s *swarm.Service) {
 		s.Spec.Mode = swarm.ServiceMode{
@@ -1075,31 +1076,31 @@ func setInstances(replicas int) serviceConstructor {
 	}
 }
 
-func setImage(image string) serviceConstructor {
+func setImage(image string) daemon.ServiceConstructor {
 	return func(s *swarm.Service) {
 		s.Spec.TaskTemplate.ContainerSpec.Image = image
 	}
 }
 
-func setFailureAction(failureAction string) serviceConstructor {
+func setFailureAction(failureAction string) daemon.ServiceConstructor {
 	return func(s *swarm.Service) {
 		s.Spec.UpdateConfig.FailureAction = failureAction
 	}
 }
 
-func setMaxFailureRatio(maxFailureRatio float32) serviceConstructor {
+func setMaxFailureRatio(maxFailureRatio float32) daemon.ServiceConstructor {
 	return func(s *swarm.Service) {
 		s.Spec.UpdateConfig.MaxFailureRatio = maxFailureRatio
 	}
 }
 
-func setParallelism(parallelism uint64) serviceConstructor {
+func setParallelism(parallelism uint64) daemon.ServiceConstructor {
 	return func(s *swarm.Service) {
 		s.Spec.UpdateConfig.Parallelism = parallelism
 	}
 }
 
-func setConstraints(constraints []string) serviceConstructor {
+func setConstraints(constraints []string) daemon.ServiceConstructor {
 	return func(s *swarm.Service) {
 		if s.Spec.TaskTemplate.Placement == nil {
 			s.Spec.TaskTemplate.Placement = &swarm.Placement{}
@@ -1114,7 +1115,7 @@ func setGlobalMode(s *swarm.Service) {
 	}
 }
 
-func checkClusterHealth(c *check.C, cl []*SwarmDaemon, managerCount, workerCount int) {
+func checkClusterHealth(c *check.C, cl []*daemon.Swarm, managerCount, workerCount int) {
 	var totalMCount, totalWCount int
 
 	for _, d := range cl {
@@ -1125,7 +1126,7 @@ func checkClusterHealth(c *check.C, cl []*SwarmDaemon, managerCount, workerCount
 
 		// check info in a waitAndAssert, because if the cluster doesn't have a leader, `info` will return an error
 		checkInfo := func(c *check.C) (interface{}, check.CommentInterface) {
-			info, err = d.info()
+			info, err = d.SwarmInfo()
 			return err, check.Commentf("cluster not ready in time")
 		}
 		waitAndAssert(c, defaultReconciliationTimeout, checkInfo, checker.IsNil)
@@ -1138,12 +1139,12 @@ func checkClusterHealth(c *check.C, cl []*SwarmDaemon, managerCount, workerCount
 		totalMCount++
 		var mCount, wCount int
 
-		for _, n := range d.listNodes(c) {
+		for _, n := range d.ListNodes(c) {
 			waitReady := func(c *check.C) (interface{}, check.CommentInterface) {
 				if n.Status.State == swarm.NodeStateReady {
 					return true, nil
 				}
-				nn := d.getNode(c, n.ID)
+				nn := d.GetNode(c, n.ID)
 				n = *nn
 				return n.Status.State == swarm.NodeStateReady, check.Commentf("state of node %s, reported by %s", n.ID, d.Info.NodeID)
 			}
@@ -1153,7 +1154,7 @@ func checkClusterHealth(c *check.C, cl []*SwarmDaemon, managerCount, workerCount
 				if n.Spec.Availability == swarm.NodeAvailabilityActive {
 					return true, nil
 				}
-				nn := d.getNode(c, n.ID)
+				nn := d.GetNode(c, n.ID)
 				n = *nn
 				return n.Spec.Availability == swarm.NodeAvailabilityActive, check.Commentf("availability of node %s, reported by %s", n.ID, d.Info.NodeID)
 			}
@@ -1181,10 +1182,10 @@ func checkClusterHealth(c *check.C, cl []*SwarmDaemon, managerCount, workerCount
 func (s *DockerSwarmSuite) TestAPISwarmRestartCluster(c *check.C) {
 	mCount, wCount := 5, 1
 
-	var nodes []*SwarmDaemon
+	var nodes []*daemon.Swarm
 	for i := 0; i < mCount; i++ {
 		manager := s.AddDaemon(c, true, true)
-		info, err := manager.info()
+		info, err := manager.SwarmInfo()
 		c.Assert(err, checker.IsNil)
 		c.Assert(info.ControlAvailable, checker.True)
 		c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateActive)
@@ -1193,7 +1194,7 @@ func (s *DockerSwarmSuite) TestAPISwarmRestartCluster(c *check.C) {
 
 	for i := 0; i < wCount; i++ {
 		worker := s.AddDaemon(c, true, false)
-		info, err := worker.info()
+		info, err := worker.SwarmInfo()
 		c.Assert(err, checker.IsNil)
 		c.Assert(info.ControlAvailable, checker.False)
 		c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateActive)
@@ -1207,13 +1208,14 @@ func (s *DockerSwarmSuite) TestAPISwarmRestartCluster(c *check.C) {
 		errs := make(chan error, len(nodes))
 
 		for _, d := range nodes {
-			go func(daemon *SwarmDaemon) {
+			go func(daemon *daemon.Swarm) {
 				defer wg.Done()
 				if err := daemon.Stop(); err != nil {
 					errs <- err
 				}
+				// FIXME(vdemeester) This is duplicated…
 				if root := os.Getenv("DOCKER_REMAP_ROOT"); root != "" {
-					daemon.root = filepath.Dir(daemon.root)
+					daemon.Root = filepath.Dir(daemon.Root)
 				}
 			}(d)
 		}
@@ -1231,7 +1233,7 @@ func (s *DockerSwarmSuite) TestAPISwarmRestartCluster(c *check.C) {
 		errs := make(chan error, len(nodes))
 
 		for _, d := range nodes {
-			go func(daemon *SwarmDaemon) {
+			go func(daemon *daemon.Swarm) {
 				defer wg.Done()
 				if err := daemon.Start("--iptables=false"); err != nil {
 					errs <- err
@@ -1252,10 +1254,10 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesUpdateWithName(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	instances := 2
-	id := d.createService(c, simpleTestService, setInstances(instances))
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, instances)
+	id := d.CreateService(c, simpleTestService, setInstances(instances))
+	waitAndAssert(c, defaultReconciliationTimeout, d.CheckActiveContainerCount, checker.Equals, instances)
 
-	service := d.getService(c, id)
+	service := d.GetService(c, id)
 	instances = 5
 
 	setInstances(instances)(service)
@@ -1263,13 +1265,13 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesUpdateWithName(c *check.C) {
 	status, out, err := d.SockRequest("POST", url, service.Spec)
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, instances)
+	waitAndAssert(c, defaultReconciliationTimeout, d.CheckActiveContainerCount, checker.Equals, instances)
 }
 
 func (s *DockerSwarmSuite) TestAPISwarmSecretsEmptyList(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
-	secrets := d.listSecrets(c)
+	secrets := d.ListSecrets(c)
 	c.Assert(secrets, checker.NotNil)
 	c.Assert(len(secrets), checker.Equals, 0, check.Commentf("secrets: %#v", secrets))
 }
@@ -1278,7 +1280,7 @@ func (s *DockerSwarmSuite) TestAPISwarmSecretsCreate(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	testName := "test_secret"
-	id := d.createSecret(c, swarm.SecretSpec{
+	id := d.CreateSecret(c, swarm.SecretSpec{
 		swarm.Annotations{
 			Name: testName,
 		},
@@ -1286,7 +1288,7 @@ func (s *DockerSwarmSuite) TestAPISwarmSecretsCreate(c *check.C) {
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 
-	secrets := d.listSecrets(c)
+	secrets := d.ListSecrets(c)
 	c.Assert(len(secrets), checker.Equals, 1, check.Commentf("secrets: %#v", secrets))
 	name := secrets[0].Spec.Annotations.Name
 	c.Assert(name, checker.Equals, testName, check.Commentf("secret: %s", name))
@@ -1296,7 +1298,7 @@ func (s *DockerSwarmSuite) TestAPISwarmSecretsDelete(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	testName := "test_secret"
-	id := d.createSecret(c, swarm.SecretSpec{
+	id := d.CreateSecret(c, swarm.SecretSpec{
 		swarm.Annotations{
 			Name: testName,
 		},
@@ -1304,10 +1306,10 @@ func (s *DockerSwarmSuite) TestAPISwarmSecretsDelete(c *check.C) {
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 
-	secret := d.getSecret(c, id)
+	secret := d.GetSecret(c, id)
 	c.Assert(secret.ID, checker.Equals, id, check.Commentf("secret: %v", secret))
 
-	d.deleteSecret(c, secret.ID)
+	d.DeleteSecret(c, secret.ID)
 	status, out, err := d.SockRequest("GET", "/secrets/"+id, nil)
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusNotFound, check.Commentf("secret delete: %s", string(out)))

--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api"
+	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/checker"
 	icmd "github.com/docker/docker/pkg/integration/cmd"
 	"github.com/go-check/check"
@@ -78,7 +79,7 @@ func (s *DockerSuite) TestAPIErrorJSON(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(httpResp.StatusCode, checker.Equals, http.StatusInternalServerError)
 	c.Assert(httpResp.Header.Get("Content-Type"), checker.Equals, "application/json")
-	b, err := readBody(body)
+	b, err := integration.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 	c.Assert(getErrorMessage(c, b), checker.Equals, "Config cannot be empty in order to create a container")
 }
@@ -91,7 +92,7 @@ func (s *DockerSuite) TestAPIErrorPlainText(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(httpResp.StatusCode, checker.Equals, http.StatusInternalServerError)
 	c.Assert(httpResp.Header.Get("Content-Type"), checker.Contains, "text/plain")
-	b, err := readBody(body)
+	b, err := integration.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(string(b)), checker.Equals, "Config cannot be empty in order to create a container")
 }
@@ -102,7 +103,7 @@ func (s *DockerSuite) TestAPIErrorNotFoundJSON(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(httpResp.StatusCode, checker.Equals, http.StatusNotFound)
 	c.Assert(httpResp.Header.Get("Content-Type"), checker.Equals, "application/json")
-	b, err := readBody(body)
+	b, err := integration.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 	c.Assert(getErrorMessage(c, b), checker.Equals, "page not found")
 }
@@ -112,7 +113,7 @@ func (s *DockerSuite) TestAPIErrorNotFoundPlainText(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(httpResp.StatusCode, checker.Equals, http.StatusNotFound)
 	c.Assert(httpResp.Header.Get("Content-Type"), checker.Contains, "text/plain")
-	b, err := readBody(body)
+	b, err := integration.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(string(b)), checker.Equals, "page not found")
 }

--- a/integration-cli/docker_cli_authz_plugin_v2_test.go
+++ b/integration-cli/docker_cli_authz_plugin_v2_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
@@ -26,12 +27,14 @@ func init() {
 
 type DockerAuthzV2Suite struct {
 	ds *DockerSuite
-	d  *Daemon
+	d  *daemon.Daemon
 }
 
 func (s *DockerAuthzV2Suite) SetUpTest(c *check.C) {
 	testRequires(c, DaemonIsLinux, Network)
-	s.d = NewDaemon(c)
+	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
+		Experimental: experimentalDaemon,
+	})
 	c.Assert(s.d.Start(), check.IsNil)
 }
 

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -636,7 +636,7 @@ func (s *DockerRegistrySuite) TestPullFailsWithAlteredLayer(c *check.C) {
 	// digest verification for the target layer digest.
 
 	// Remove distribution cache to force a re-pull of the blobs
-	if err := os.RemoveAll(filepath.Join(dockerBasePath, "image", s.d.storageDriver, "distribution")); err != nil {
+	if err := os.RemoveAll(filepath.Join(dockerBasePath, "image", s.d.StorageDriver(), "distribution")); err != nil {
 		c.Fatalf("error clearing distribution cache: %v", err)
 	}
 
@@ -679,7 +679,7 @@ func (s *DockerSchema1RegistrySuite) TestPullFailsWithAlteredLayer(c *check.C) {
 	// digest verification for the target layer digest.
 
 	// Remove distribution cache to force a re-pull of the blobs
-	if err := os.RemoveAll(filepath.Join(dockerBasePath, "image", s.d.storageDriver, "distribution")); err != nil {
+	if err := os.RemoveAll(filepath.Join(dockerBasePath, "image", s.d.StorageDriver(), "distribution")); err != nil {
 		c.Fatalf("error clearing distribution cache: %v", err)
 	}
 

--- a/integration-cli/docker_cli_daemon_plugins_test.go
+++ b/integration-cli/docker_cli_daemon_plugins_test.go
@@ -133,7 +133,7 @@ func (s *DockerDaemonSuite) TestDaemonShutdownLiveRestoreWithPlugins(c *check.C)
 		}
 	}()
 
-	if err := s.d.cmd.Process.Signal(os.Interrupt); err != nil {
+	if err := s.d.Interrupt(); err != nil {
 		c.Fatalf("Could not kill daemon: %v", err)
 	}
 
@@ -166,12 +166,12 @@ func (s *DockerDaemonSuite) TestDaemonShutdownWithPlugins(c *check.C) {
 		}
 	}()
 
-	if err := s.d.cmd.Process.Signal(os.Interrupt); err != nil {
+	if err := s.d.Interrupt(); err != nil {
 		c.Fatalf("Could not kill daemon: %v", err)
 	}
 
 	for {
-		if err := syscall.Kill(s.d.cmd.Process.Pid, 0); err == syscall.ESRCH {
+		if err := syscall.Kill(s.d.Pid(), 0); err == syscall.ESRCH {
 			break
 		}
 	}

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -422,7 +422,7 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *check.C) {
 	fmt.Fprintf(configFile, "%s", daemonConfig)
 	configFile.Close()
 
-	syscall.Kill(s.d.cmd.Process.Pid, syscall.SIGHUP)
+	c.Assert(s.d.Signal(syscall.SIGHUP), checker.IsNil)
 
 	time.Sleep(3 * time.Second)
 
@@ -460,7 +460,7 @@ func (s *DockerDaemonSuite) TestDaemonEventsWithFilters(c *check.C) {
 	}
 	c.Assert(daemonID, checker.Not(checker.Equals), "")
 
-	syscall.Kill(s.d.cmd.Process.Pid, syscall.SIGHUP)
+	c.Assert(s.d.Signal(syscall.SIGHUP), checker.IsNil)
 
 	time.Sleep(3 * time.Second)
 

--- a/integration-cli/docker_cli_external_graphdriver_unix_test.go
+++ b/integration-cli/docker_cli_external_graphdriver_unix_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/daemon/graphdriver/vfs"
+	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/go-check/check"
@@ -29,7 +30,7 @@ type DockerExternalGraphdriverSuite struct {
 	server  *httptest.Server
 	jserver *httptest.Server
 	ds      *DockerSuite
-	d       *Daemon
+	d       *daemon.Daemon
 	ec      map[string]*graphEventsCounter
 }
 
@@ -51,7 +52,9 @@ type graphEventsCounter struct {
 }
 
 func (s *DockerExternalGraphdriverSuite) SetUpTest(c *check.C) {
-	s.d = NewDaemon(c)
+	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
+		Experimental: experimentalDaemon,
+	})
 }
 
 func (s *DockerExternalGraphdriverSuite) TearDownTest(c *check.C) {

--- a/integration-cli/docker_cli_external_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_unix_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/volume"
@@ -44,12 +45,14 @@ type eventCounter struct {
 
 type DockerExternalVolumeSuite struct {
 	ds *DockerSuite
-	d  *Daemon
+	d  *daemon.Daemon
 	*volumePlugin
 }
 
 func (s *DockerExternalVolumeSuite) SetUpTest(c *check.C) {
-	s.d = NewDaemon(c)
+	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
+		Experimental: experimentalDaemon,
+	})
 	s.ec = &eventCounter{}
 }
 

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strings"
 
+	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
@@ -70,7 +71,9 @@ func (s *DockerSuite) TestInfoFormat(c *check.C) {
 func (s *DockerSuite) TestInfoDiscoveryBackend(c *check.C) {
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
-	d := NewDaemon(c)
+	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
+		Experimental: experimentalDaemon,
+	})
 	discoveryBackend := "consul://consuladdr:consulport/some/path"
 	discoveryAdvertise := "1.1.1.1:2375"
 	err := d.Start(fmt.Sprintf("--cluster-store=%s", discoveryBackend), fmt.Sprintf("--cluster-advertise=%s", discoveryAdvertise))
@@ -88,7 +91,9 @@ func (s *DockerSuite) TestInfoDiscoveryBackend(c *check.C) {
 func (s *DockerSuite) TestInfoDiscoveryInvalidAdvertise(c *check.C) {
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
-	d := NewDaemon(c)
+	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
+		Experimental: experimentalDaemon,
+	})
 	discoveryBackend := "consul://consuladdr:consulport/some/path"
 
 	// --cluster-advertise with an invalid string is an error
@@ -105,7 +110,9 @@ func (s *DockerSuite) TestInfoDiscoveryInvalidAdvertise(c *check.C) {
 func (s *DockerSuite) TestInfoDiscoveryAdvertiseInterfaceName(c *check.C) {
 	testRequires(c, SameHostDaemon, Network, DaemonIsLinux)
 
-	d := NewDaemon(c)
+	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
+		Experimental: experimentalDaemon,
+	})
 	discoveryBackend := "consul://consuladdr:consulport/some/path"
 	discoveryAdvertise := "eth0"
 
@@ -171,7 +178,9 @@ func (s *DockerSuite) TestInfoDisplaysStoppedContainers(c *check.C) {
 func (s *DockerSuite) TestInfoDebug(c *check.C) {
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
-	d := NewDaemon(c)
+	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
+		Experimental: experimentalDaemon,
+	})
 	err := d.Start("--debug")
 	c.Assert(err, checker.IsNil)
 	defer d.Stop()
@@ -193,7 +202,9 @@ func (s *DockerSuite) TestInsecureRegistries(c *check.C) {
 	registryCIDR := "192.168.1.0/24"
 	registryHost := "insecurehost.com:5000"
 
-	d := NewDaemon(c)
+	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
+		Experimental: experimentalDaemon,
+	})
 	err := d.Start("--insecure-registry="+registryCIDR, "--insecure-registry="+registryHost)
 	c.Assert(err, checker.IsNil)
 	defer d.Stop()

--- a/integration-cli/docker_cli_prune_unix_test.go
+++ b/integration-cli/docker_cli_prune_unix_test.go
@@ -6,11 +6,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
 
-func pruneNetworkAndVerify(c *check.C, d *SwarmDaemon, kept, pruned []string) {
+func pruneNetworkAndVerify(c *check.C, d *daemon.Swarm, kept, pruned []string) {
 	_, err := d.Cmd("network", "prune", "--force")
 	c.Assert(err, checker.IsNil)
 	out, err := d.Cmd("network", "ls", "--format", "{{.Name}}")
@@ -46,7 +47,7 @@ func (s *DockerSwarmSuite) TestPruneNetwork(c *check.C) {
 		"busybox", "top")
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, replicas+1)
+	waitAndAssert(c, defaultReconciliationTimeout, d.CheckActiveContainerCount, checker.Equals, replicas+1)
 
 	// prune and verify
 	pruneNetworkAndVerify(c, d, []string{"n1", "n3"}, []string{"n2", "n4"})
@@ -56,14 +57,14 @@ func (s *DockerSwarmSuite) TestPruneNetwork(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	_, err = d.Cmd("service", "rm", serviceName)
 	c.Assert(err, checker.IsNil)
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 0)
+	waitAndAssert(c, defaultReconciliationTimeout, d.CheckActiveContainerCount, checker.Equals, 0)
 	pruneNetworkAndVerify(c, d, []string{}, []string{"n1", "n3"})
 }
 
 func (s *DockerDaemonSuite) TestPruneImageDangling(c *check.C) {
 	c.Assert(s.d.StartWithBusybox(), checker.IsNil)
 
-	out, _, err := s.d.buildImageWithOut("test",
+	out, _, err := s.d.BuildImageWithOut("test",
 		`FROM busybox
                  LABEL foo=bar`, true, "-q")
 	c.Assert(err, checker.IsNil)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4439,7 +4439,7 @@ func (s *DockerDaemonSuite) TestRunWithUlimitAndDaemonDefault(c *check.C) {
 	name := "test-A"
 	_, err := s.d.Cmd("run", "--name", name, "-d", "busybox", "top")
 	c.Assert(err, checker.IsNil)
-	c.Assert(s.d.waitRun(name), check.IsNil)
+	c.Assert(s.d.WaitRun(name), check.IsNil)
 
 	out, err := s.d.Cmd("inspect", "--format", "{{.HostConfig.Ulimits}}", name)
 	c.Assert(err, checker.IsNil)
@@ -4448,7 +4448,7 @@ func (s *DockerDaemonSuite) TestRunWithUlimitAndDaemonDefault(c *check.C) {
 	name = "test-B"
 	_, err = s.d.Cmd("run", "--name", name, "--ulimit=nofile=42", "-d", "busybox", "top")
 	c.Assert(err, checker.IsNil)
-	c.Assert(s.d.waitRun(name), check.IsNil)
+	c.Assert(s.d.WaitRun(name), check.IsNil)
 
 	out, err = s.d.Cmd("inspect", "--format", "{{.HostConfig.Ulimits}}", name)
 	c.Assert(err, checker.IsNil)

--- a/integration-cli/docker_cli_secret_create_test.go
+++ b/integration-cli/docker_cli_secret_create_test.go
@@ -12,7 +12,7 @@ func (s *DockerSwarmSuite) TestSecretCreate(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	testName := "test_secret"
-	id := d.createSecret(c, swarm.SecretSpec{
+	id := d.CreateSecret(c, swarm.SecretSpec{
 		swarm.Annotations{
 			Name: testName,
 		},
@@ -20,7 +20,7 @@ func (s *DockerSwarmSuite) TestSecretCreate(c *check.C) {
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 
-	secret := d.getSecret(c, id)
+	secret := d.GetSecret(c, id)
 	c.Assert(secret.Spec.Name, checker.Equals, testName)
 }
 
@@ -28,7 +28,7 @@ func (s *DockerSwarmSuite) TestSecretCreateWithLabels(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	testName := "test_secret"
-	id := d.createSecret(c, swarm.SecretSpec{
+	id := d.CreateSecret(c, swarm.SecretSpec{
 		swarm.Annotations{
 			Name: testName,
 			Labels: map[string]string{
@@ -40,7 +40,7 @@ func (s *DockerSwarmSuite) TestSecretCreateWithLabels(c *check.C) {
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 
-	secret := d.getSecret(c, id)
+	secret := d.GetSecret(c, id)
 	c.Assert(secret.Spec.Name, checker.Equals, testName)
 	c.Assert(len(secret.Spec.Labels), checker.Equals, 2)
 	c.Assert(secret.Spec.Labels["key1"], checker.Equals, "value1")
@@ -52,7 +52,7 @@ func (s *DockerSwarmSuite) TestSecretCreateResolve(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	name := "foo"
-	id := d.createSecret(c, swarm.SecretSpec{
+	id := d.CreateSecret(c, swarm.SecretSpec{
 		swarm.Annotations{
 			Name: name,
 		},
@@ -60,7 +60,7 @@ func (s *DockerSwarmSuite) TestSecretCreateResolve(c *check.C) {
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 
-	fake := d.createSecret(c, swarm.SecretSpec{
+	fake := d.CreateSecret(c, swarm.SecretSpec{
 		swarm.Annotations{
 			Name: id,
 		},

--- a/integration-cli/docker_cli_secret_inspect_test.go
+++ b/integration-cli/docker_cli_secret_inspect_test.go
@@ -14,7 +14,7 @@ func (s *DockerSwarmSuite) TestSecretInspect(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	testName := "test_secret"
-	id := d.createSecret(c, swarm.SecretSpec{
+	id := d.CreateSecret(c, swarm.SecretSpec{
 		swarm.Annotations{
 			Name: testName,
 		},
@@ -22,7 +22,7 @@ func (s *DockerSwarmSuite) TestSecretInspect(c *check.C) {
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 
-	secret := d.getSecret(c, id)
+	secret := d.GetSecret(c, id)
 	c.Assert(secret.Spec.Name, checker.Equals, testName)
 
 	out, err := d.Cmd("secret", "inspect", testName)
@@ -41,7 +41,7 @@ func (s *DockerSwarmSuite) TestSecretInspectMultiple(c *check.C) {
 		"test1",
 	}
 	for _, n := range testNames {
-		id := d.createSecret(c, swarm.SecretSpec{
+		id := d.CreateSecret(c, swarm.SecretSpec{
 			swarm.Annotations{
 				Name: n,
 			},
@@ -49,7 +49,7 @@ func (s *DockerSwarmSuite) TestSecretInspectMultiple(c *check.C) {
 		})
 		c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 
-		secret := d.getSecret(c, id)
+		secret := d.GetSecret(c, id)
 		c.Assert(secret.Spec.Name, checker.Equals, n)
 
 	}

--- a/integration-cli/docker_cli_service_create_test.go
+++ b/integration-cli/docker_cli_service_create_test.go
@@ -22,14 +22,14 @@ func (s *DockerSwarmSuite) TestServiceCreateMountVolume(c *check.C) {
 
 	var tasks []swarm.Task
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		tasks = d.getServiceTasks(c, id)
+		tasks = d.GetServiceTasks(c, id)
 		return len(tasks) > 0, nil
 	}, checker.Equals, true)
 
 	task := tasks[0]
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
 		if task.NodeID == "" || task.Status.ContainerStatus.ContainerID == "" {
-			task = d.getTask(c, task.ID)
+			task = d.GetTask(c, task.ID)
 		}
 		return task.NodeID != "" && task.Status.ContainerStatus.ContainerID != "", nil
 	}, checker.Equals, true)
@@ -67,7 +67,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithSecretSimple(c *check.C) {
 
 	serviceName := "test-service-secret"
 	testName := "test_secret"
-	id := d.createSecret(c, swarm.SecretSpec{
+	id := d.CreateSecret(c, swarm.SecretSpec{
 		swarm.Annotations{
 			Name: testName,
 		},
@@ -97,7 +97,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithSecretSourceTarget(c *check.C) {
 
 	serviceName := "test-service-secret"
 	testName := "test_secret"
-	id := d.createSecret(c, swarm.SecretSpec{
+	id := d.CreateSecret(c, swarm.SecretSpec{
 		swarm.Annotations{
 			Name: testName,
 		},
@@ -129,14 +129,14 @@ func (s *DockerSwarmSuite) TestServiceCreateMountTmpfs(c *check.C) {
 
 	var tasks []swarm.Task
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		tasks = d.getServiceTasks(c, id)
+		tasks = d.GetServiceTasks(c, id)
 		return len(tasks) > 0, nil
 	}, checker.Equals, true)
 
 	task := tasks[0]
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
 		if task.NodeID == "" || task.Status.ContainerStatus.ContainerID == "" {
-			task = d.getTask(c, task.ID)
+			task = d.GetTask(c, task.ID)
 		}
 		return task.NodeID != "" && task.Status.ContainerStatus.ContainerID != "", nil
 	}, checker.Equals, true)

--- a/integration-cli/docker_cli_service_health_test.go
+++ b/integration-cli/docker_cli_service_health_test.go
@@ -22,7 +22,7 @@ func (s *DockerSwarmSuite) TestServiceHealthRun(c *check.C) {
 	// build image with health-check
 	// note: use `daemon.buildImageWithOut` to build, do not use `buildImage` to build
 	imageName := "testhealth"
-	_, _, err := d.buildImageWithOut(imageName,
+	_, _, err := d.BuildImageWithOut(imageName,
 		`FROM busybox
 		RUN touch /status
 		HEALTHCHECK --interval=1s --timeout=1s --retries=1\
@@ -37,7 +37,7 @@ func (s *DockerSwarmSuite) TestServiceHealthRun(c *check.C) {
 
 	var tasks []swarm.Task
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		tasks = d.getServiceTasks(c, id)
+		tasks = d.GetServiceTasks(c, id)
 		return tasks, nil
 	}, checker.HasLen, 1)
 
@@ -45,7 +45,7 @@ func (s *DockerSwarmSuite) TestServiceHealthRun(c *check.C) {
 
 	// wait for task to start
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		task = d.getTask(c, task.ID)
+		task = d.GetTask(c, task.ID)
 		return task.Status.State, nil
 	}, checker.Equals, swarm.TaskStateRunning)
 	containerID := task.Status.ContainerStatus.ContainerID
@@ -66,7 +66,7 @@ func (s *DockerSwarmSuite) TestServiceHealthRun(c *check.C) {
 
 	// Task should be terminated
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		task = d.getTask(c, task.ID)
+		task = d.GetTask(c, task.ID)
 		return task.Status.State, nil
 	}, checker.Equals, swarm.TaskStateFailed)
 
@@ -84,7 +84,7 @@ func (s *DockerSwarmSuite) TestServiceHealthStart(c *check.C) {
 
 	// service started from this image won't pass health check
 	imageName := "testhealth"
-	_, _, err := d.buildImageWithOut(imageName,
+	_, _, err := d.BuildImageWithOut(imageName,
 		`FROM busybox
 		HEALTHCHECK --interval=1s --timeout=1s --retries=1024\
 		  CMD cat /status`,
@@ -98,7 +98,7 @@ func (s *DockerSwarmSuite) TestServiceHealthStart(c *check.C) {
 
 	var tasks []swarm.Task
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		tasks = d.getServiceTasks(c, id)
+		tasks = d.GetServiceTasks(c, id)
 		return tasks, nil
 	}, checker.HasLen, 1)
 
@@ -106,7 +106,7 @@ func (s *DockerSwarmSuite) TestServiceHealthStart(c *check.C) {
 
 	// wait for task to start
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		task = d.getTask(c, task.ID)
+		task = d.GetTask(c, task.ID)
 		return task.Status.State, nil
 	}, checker.Equals, swarm.TaskStateStarting)
 
@@ -120,7 +120,7 @@ func (s *DockerSwarmSuite) TestServiceHealthStart(c *check.C) {
 	}, checker.GreaterThan, 0)
 
 	// task should be blocked at starting status
-	task = d.getTask(c, task.ID)
+	task = d.GetTask(c, task.ID)
 	c.Assert(task.Status.State, check.Equals, swarm.TaskStateStarting)
 
 	// make it healthy
@@ -128,7 +128,7 @@ func (s *DockerSwarmSuite) TestServiceHealthStart(c *check.C) {
 
 	// Task should be at running status
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		task = d.getTask(c, task.ID)
+		task = d.GetTask(c, task.ID)
 		return task.Status.State, nil
 	}, checker.Equals, swarm.TaskStateRunning)
 }
@@ -142,7 +142,7 @@ func (s *DockerSwarmSuite) TestServiceHealthUpdate(c *check.C) {
 
 	// service started from this image won't pass health check
 	imageName := "testhealth"
-	_, _, err := d.buildImageWithOut(imageName,
+	_, _, err := d.BuildImageWithOut(imageName,
 		`FROM busybox
 		HEALTHCHECK --interval=1s --timeout=1s --retries=1024\
 		  CMD cat /status`,
@@ -156,7 +156,7 @@ func (s *DockerSwarmSuite) TestServiceHealthUpdate(c *check.C) {
 
 	var tasks []swarm.Task
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		tasks = d.getServiceTasks(c, id)
+		tasks = d.GetServiceTasks(c, id)
 		return tasks, nil
 	}, checker.HasLen, 1)
 
@@ -164,7 +164,7 @@ func (s *DockerSwarmSuite) TestServiceHealthUpdate(c *check.C) {
 
 	// wait for task to start
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		task = d.getTask(c, task.ID)
+		task = d.GetTask(c, task.ID)
 		return task.Status.State, nil
 	}, checker.Equals, swarm.TaskStateStarting)
 
@@ -178,14 +178,14 @@ func (s *DockerSwarmSuite) TestServiceHealthUpdate(c *check.C) {
 	}, checker.GreaterThan, 0)
 
 	// task should be blocked at starting status
-	task = d.getTask(c, task.ID)
+	task = d.GetTask(c, task.ID)
 	c.Assert(task.Status.State, check.Equals, swarm.TaskStateStarting)
 
 	// make it healthy
 	d.Cmd("exec", containerID, "touch", "/status")
 	// Task should be at running status
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		task = d.getTask(c, task.ID)
+		task = d.GetTask(c, task.ID)
 		return task.Status.State, nil
 	}, checker.Equals, swarm.TaskStateRunning)
 }

--- a/integration-cli/docker_cli_service_logs_experimental_test.go
+++ b/integration-cli/docker_cli_service_logs_experimental_test.go
@@ -38,7 +38,7 @@ func (s *DockerSwarmSuite) TestServiceLogs(c *check.C) {
 
 	// make sure task has been deployed.
 	waitAndAssert(c, defaultReconciliationTimeout,
-		d.checkActiveContainerCount, checker.Equals, len(services))
+		d.CheckActiveContainerCount, checker.Equals, len(services))
 
 	for name, message := range services {
 		out, err := d.Cmd("service", "logs", name)
@@ -60,10 +60,10 @@ func (s *DockerSwarmSuite) TestServiceLogsFollow(c *check.C) {
 	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
 
 	// make sure task has been deployed.
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 1)
+	waitAndAssert(c, defaultReconciliationTimeout, d.CheckActiveContainerCount, checker.Equals, 1)
 
 	args := []string{"service", "logs", "-f", name}
-	cmd := exec.Command(dockerBinary, d.prependHostArg(args)...)
+	cmd := exec.Command(dockerBinary, d.PrependHostArg(args)...)
 	r, w := io.Pipe()
 	cmd.Stdout = w
 	cmd.Stderr = w

--- a/integration-cli/docker_cli_service_update_test.go
+++ b/integration-cli/docker_cli_service_update_test.go
@@ -20,7 +20,7 @@ func (s *DockerSwarmSuite) TestServiceUpdatePort(c *check.C) {
 	// Create a service with a port mapping of 8080:8081.
 	out, err := d.Cmd(serviceArgs...)
 	c.Assert(err, checker.IsNil)
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 1)
+	waitAndAssert(c, defaultReconciliationTimeout, d.CheckActiveContainerCount, checker.Equals, 1)
 
 	// Update the service: changed the port mapping from 8080:8081 to 8082:8083.
 	_, err = d.Cmd("service", "update", "--publish-add", "8082:8083", "--publish-rm", "8081", serviceName)
@@ -50,39 +50,39 @@ func (s *DockerSwarmSuite) TestServiceUpdateLabel(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 	out, err := d.Cmd("service", "create", "--name=test", "busybox", "top")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
-	service := d.getService(c, "test")
+	service := d.GetService(c, "test")
 	c.Assert(service.Spec.Labels, checker.HasLen, 0)
 
 	// add label to empty set
 	out, err = d.Cmd("service", "update", "test", "--label-add", "foo=bar")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
-	service = d.getService(c, "test")
+	service = d.GetService(c, "test")
 	c.Assert(service.Spec.Labels, checker.HasLen, 1)
 	c.Assert(service.Spec.Labels["foo"], checker.Equals, "bar")
 
 	// add label to non-empty set
 	out, err = d.Cmd("service", "update", "test", "--label-add", "foo2=bar")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
-	service = d.getService(c, "test")
+	service = d.GetService(c, "test")
 	c.Assert(service.Spec.Labels, checker.HasLen, 2)
 	c.Assert(service.Spec.Labels["foo2"], checker.Equals, "bar")
 
 	out, err = d.Cmd("service", "update", "test", "--label-rm", "foo2")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
-	service = d.getService(c, "test")
+	service = d.GetService(c, "test")
 	c.Assert(service.Spec.Labels, checker.HasLen, 1)
 	c.Assert(service.Spec.Labels["foo2"], checker.Equals, "")
 
 	out, err = d.Cmd("service", "update", "test", "--label-rm", "foo")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
-	service = d.getService(c, "test")
+	service = d.GetService(c, "test")
 	c.Assert(service.Spec.Labels, checker.HasLen, 0)
 	c.Assert(service.Spec.Labels["foo"], checker.Equals, "")
 
 	// now make sure we can add again
 	out, err = d.Cmd("service", "update", "test", "--label-add", "foo=bar")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
-	service = d.getService(c, "test")
+	service = d.GetService(c, "test")
 	c.Assert(service.Spec.Labels, checker.HasLen, 1)
 	c.Assert(service.Spec.Labels["foo"], checker.Equals, "bar")
 }
@@ -90,7 +90,7 @@ func (s *DockerSwarmSuite) TestServiceUpdateLabel(c *check.C) {
 func (s *DockerSwarmSuite) TestServiceUpdateSecrets(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 	testName := "test_secret"
-	id := d.createSecret(c, swarm.SecretSpec{
+	id := d.CreateSecret(c, swarm.SecretSpec{
 		swarm.Annotations{
 			Name: testName,
 		},
@@ -104,7 +104,7 @@ func (s *DockerSwarmSuite) TestServiceUpdateSecrets(c *check.C) {
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 
 	// add secret
-	out, err = d.cmdRetryOutOfSequence("service", "update", "test", "--secret-add", fmt.Sprintf("source=%s,target=%s", testName, testTarget))
+	out, err = d.CmdRetryOutOfSequence("service", "update", "test", "--secret-add", fmt.Sprintf("source=%s,target=%s", testName, testTarget))
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 
 	out, err = d.Cmd("service", "inspect", "--format", "{{ json .Spec.TaskTemplate.ContainerSpec.Secrets }}", serviceName)
@@ -119,7 +119,7 @@ func (s *DockerSwarmSuite) TestServiceUpdateSecrets(c *check.C) {
 	c.Assert(refs[0].File.Name, checker.Equals, testTarget)
 
 	// remove
-	out, err = d.cmdRetryOutOfSequence("service", "update", "test", "--secret-rm", testName)
+	out, err = d.CmdRetryOutOfSequence("service", "update", "test", "--secret-rm", testName)
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 
 	out, err = d.Cmd("service", "inspect", "--format", "{{ json .Spec.TaskTemplate.ContainerSpec.Secrets }}", serviceName)

--- a/integration-cli/docker_cli_userns_test.go
+++ b/integration-cli/docker_cli_userns_test.go
@@ -36,8 +36,8 @@ func (s *DockerDaemonSuite) TestDaemonUserNamespaceRootSetting(c *check.C) {
 	defer os.RemoveAll(tmpDirNotExists)
 
 	// we need to find the uid and gid of the remapped root from the daemon's root dir info
-	uidgid := strings.Split(filepath.Base(s.d.root), ".")
-	c.Assert(uidgid, checker.HasLen, 2, check.Commentf("Should have gotten uid/gid strings from root dirname: %s", filepath.Base(s.d.root)))
+	uidgid := strings.Split(filepath.Base(s.d.Root), ".")
+	c.Assert(uidgid, checker.HasLen, 2, check.Commentf("Should have gotten uid/gid strings from root dirname: %s", filepath.Base(s.d.Root)))
 	uid, err := strconv.Atoi(uidgid[0])
 	c.Assert(err, checker.IsNil, check.Commentf("Can't parse uid"))
 	gid, err := strconv.Atoi(uidgid[1])

--- a/integration-cli/docker_deprecated_api_v124_test.go
+++ b/integration-cli/docker_deprecated_api_v124_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
@@ -150,7 +151,7 @@ func (s *DockerSuite) TestDeprecatedStartWithTooLowMemoryLimit(c *check.C) {
 
 	res, body, err := sockRequestRaw("POST", formatV123StartAPIURL("/containers/"+containerID+"/start"), strings.NewReader(config), "application/json")
 	c.Assert(err, checker.IsNil)
-	b, err2 := readBody(body)
+	b, err2 := integration.ReadBody(body)
 	c.Assert(err2, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusInternalServerError)
 	c.Assert(string(b), checker.Contains, "Minimum memory limit allowed is 4MB")

--- a/integration-cli/docker_hub_pull_suite_test.go
+++ b/integration-cli/docker_hub_pull_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
@@ -25,7 +26,7 @@ func init() {
 // relative impact of each individual operation. As part of this suite, all
 // images are removed after each test.
 type DockerHubPullSuite struct {
-	d  *Daemon
+	d  *daemon.Daemon
 	ds *DockerSuite
 }
 
@@ -39,7 +40,9 @@ func newDockerHubPullSuite() *DockerHubPullSuite {
 // SetUpSuite starts the suite daemon.
 func (s *DockerHubPullSuite) SetUpSuite(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	s.d = NewDaemon(c)
+	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
+		Experimental: experimentalDaemon,
+	})
 	err := s.d.Start()
 	c.Assert(err, checker.IsNil, check.Commentf("starting push/pull test daemon: %v", err))
 }
@@ -84,7 +87,7 @@ func (s *DockerHubPullSuite) CmdWithError(name string, arg ...string) (string, e
 
 // MakeCmd returns an exec.Cmd command to run against the suite daemon.
 func (s *DockerHubPullSuite) MakeCmd(name string, arg ...string) *exec.Cmd {
-	args := []string{"--host", s.d.sock(), name}
+	args := []string{"--host", s.d.Sock(), name}
 	args = append(args, arg...)
 	return exec.Command(dockerBinary, args...)
 }

--- a/pkg/integration/utils.go
+++ b/pkg/integration/utils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -224,4 +225,10 @@ func RunAtDifferentDate(date time.Time, block func()) {
 	icmd.RunCommand("date", date.Format(timeLayout))
 	block()
 	return
+}
+
+// ReadBody read the specified ReadCloser content and returns it
+func ReadBody(b io.ReadCloser) ([]byte, error) {
+	defer b.Close()
+	return ioutil.ReadAll(b)
 }


### PR DESCRIPTION
This extracts the integration-cli `Daemon` (and related) into its own package. This is more or less just an extract with a few fixes. It was a little bit trickier than I though at first as there is a lot a global variables used in the `integration-cli` code and loads of non exported fields used.

As it's a big PR already, I added comment to myself for the next step/refacto/enhancements. I tried to export as less as I could and did a few fixes on ignored errors :angel:.

The end goal is :
* Start the daemon from Go code and thus not requiring shell script to do it (a plain `go test` would do it :angel:).
* Start a daemon for all the suite.

One of the next step is to be able to use `Daemon` struct to start windows deamons :angel:.

/cc @thaJeztah @cpuguy83 @dnephin @icecrime @aaronlehmann @AkihiroSuda 

Some of the comments on the `daemon.Daemon` and `daemon.Swarm` are really bad because I did that quickly and mainly to pass the `golint` validation :sweat_smile:.

🐸

*hopefully this will be green :sweat_smile:*

Signed-off-by: Vincent Demeester <vincent@sbr.pm>