### PR TITLE
Fix `docker plugin inspect <unkown object>` issue on Windows

### DIFF
--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"fmt"
+	"strings"
 
 	"golang.org/x/net/context"
 
@@ -156,6 +157,10 @@ func inspectAll(ctx context.Context, dockerCli *command.DockerCli, getSize bool,
 		return info.Swarm.ControlAvailable
 	}
 
+	isErrNotSupported := func(err error) bool {
+		return strings.Contains(err.Error(), "not supported")
+	}
+
 	return func(ref string) (interface{}, []byte, error) {
 		const (
 			swarmSupportUnknown = iota
@@ -183,7 +188,7 @@ func inspectAll(ctx context.Context, dockerCli *command.DockerCli, getSize bool,
 			}
 			v, raw, err := inspectData.objectInspector(ref)
 			if err != nil {
-				if typeConstraint == "" && apiclient.IsErrNotFound(err) {
+				if typeConstraint == "" && (apiclient.IsErrNotFound(err) || isErrNotSupported(err)) {
 					continue
 				}
 				return v, raw, err

--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -251,3 +251,14 @@ func (s *DockerSuite) TestPluginInspect(c *check.C) {
 	_, _, err = dockerCmdWithError("plugin", "inspect", "-f", "{{.Id}}", id[:5])
 	c.Assert(err, checker.NotNil)
 }
+
+// Test case for https://github.com/docker/docker/pull/29186#discussion_r91277345
+func (s *DockerSuite) TestPluginInspectOnWindows(c *check.C) {
+	// This test should work on Windows only
+	testRequires(c, DaemonIsWindows)
+
+	out, _, err := dockerCmdWithError("plugin", "inspect", "foobar")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "plugins are not supported on this platform")
+	c.Assert(err.Error(), checker.Contains, "plugins are not supported on this platform")
+}

--- a/plugin/backend_unsupported.go
+++ b/plugin/backend_unsupported.go
@@ -4,7 +4,6 @@ package plugin
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -26,10 +25,7 @@ func (pm *Manager) Enable(name string, config *types.PluginEnableConfig) error {
 
 // Inspect examines a plugin config
 func (pm *Manager) Inspect(refOrID string) (tp types.Plugin, err error) {
-	// Even though plugin is not supported, we still want to return `not found`
-	// error so that `docker inspect` (without `--type` specified) returns correct
-	// `not found` message
-	return tp, fmt.Errorf("no such plugin name or ID associated with %q", refOrID)
+	return tp, errNotSupported
 }
 
 // Privileges pulls a plugin config and computes the privileges required to install it.


### PR DESCRIPTION
This fix is a follow up for comment:
https://github.com/docker/docker/pull/29186/files#r91277345

While #29186 addresses the issue of `docker inspect <unknown object>` on Windows, it actually makes `docker plugin inspect <unknown object>` out `object not found` on Windows as well. This is actually misleading as plugin is not supported on Windows.

This fix reverted the change in #29186 while at the same time,
checks `not supported` in `docker inspect <unknown object>` so that
- `docker plugin inspect <unknown object>` returns `not supported` on Windows
- `docker inspect <unknown object>` returns `not found` on Windows

An additional tests has been added to cover the above scenarios.

This fix is related to #29186 and #29185.

/cc @thaJeztah @jhowardmsft 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>