### PR TITLE
Fix a couple of incorrect version strings in swagger.yaml

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -44,7 +44,7 @@ info:
 
     The API is usually changed in each release of Docker, so API calls are versioned to ensure that clients don't break.
 
-    For Docker Engine 1.14, the API version is 1.26. To lock to this version, you prefix the URL with `/v1.25`. For example, calling `/info` is the same as calling `/v1.25/info`.
+    For Docker Engine 1.14, the API version is 1.26. To lock to this version, you prefix the URL with `/v1.26`. For example, calling `/info` is the same as calling `/v1.26/info`.
 
     Engine releases in the near future should support this version of the API, so your client will continue to work even if it is talking to a newer Engine.
 


### PR DESCRIPTION
This fix fixes a couple of incorrect version strings in swagger.yaml `v1.25` should be `v1.26`. This change applies to 1.14 version only.

Also checked 1.13 branch and it is fine.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>