### PR TITLE
add missing status code 403 for services/create in docs

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7135,6 +7135,10 @@ paths:
             example:
               ID: "ak7w3gjqoa3kuz8xcpnyy0pvl"
               Warning: "unable to pin image doesnotexist:latest to digest: image library/doesnotexist:latest not found"
+        403:
+          description: "network is not eligible for services"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         409:
           description: "name conflicts with an existing service"
           schema:

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -4563,6 +4563,11 @@ image](#create-an-image) section for more details.
           ],
           "User": "33"
         },
+        "Networks": [
+            {
+              "Target": "overlay1"
+            }
+        ],
         "LogDriver": {
           "Name": "json-file",
           "Options": {
@@ -4620,6 +4625,7 @@ image](#create-an-image) section for more details.
 **Status codes**:
 
 -   **201** – no error
+-   **403** - network is not eligible for services
 -   **406** – node is not part of a swarm
 -   **409** – name conflicts with an existing object
 -   **500** - server error


### PR DESCRIPTION
fixes #29215 

**- What I did**
1. add status code 403 for api 1.24 doc;
2. add status code 403 for swagger.yml;
3. add `Networks` field in `POST /services/create` example.

Signed-off-by: allencloud <allen.sun@daocloud.io>