### PR TITLE
Add tests for ID-based `docker plugin enable/disable/rm/set`

### DIFF
--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -330,3 +330,56 @@ func (s *DockerTrustSuite) TestPluginUntrustedInstall(c *check.C) {
 	c.Assert(err, check.NotNil, check.Commentf(out))
 	c.Assert(string(out), checker.Contains, "Error: remote trust data does not exist", check.Commentf(out))
 }
+
+func (s *DockerSuite) TestPluginIDPrefix(c *check.C) {
+	testRequires(c, DaemonIsLinux, Network)
+	_, _, err := dockerCmdWithError("plugin", "install", "--disable", "--grant-all-permissions", pNameWithTag)
+	c.Assert(err, checker.IsNil)
+
+	// Find ID first
+	id, _, err := dockerCmdWithError("plugin", "inspect", "-f", "{{.Id}}", pNameWithTag)
+	id = strings.TrimSpace(id)
+	c.Assert(err, checker.IsNil)
+
+	// List current state
+	out, _, err := dockerCmdWithError("plugin", "ls")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, pName)
+	c.Assert(out, checker.Contains, pTag)
+	c.Assert(out, checker.Contains, "false")
+
+	env, _ := dockerCmd(c, "plugin", "inspect", "-f", "{{.Settings.Env}}", id[:5])
+	c.Assert(strings.TrimSpace(env), checker.Equals, "[DEBUG=0]")
+
+	dockerCmd(c, "plugin", "set", id[:5], "DEBUG=1")
+
+	env, _ = dockerCmd(c, "plugin", "inspect", "-f", "{{.Settings.Env}}", id[:5])
+	c.Assert(strings.TrimSpace(env), checker.Equals, "[DEBUG=1]")
+
+	// Enable
+	_, _, err = dockerCmdWithError("plugin", "enable", id[:5])
+	c.Assert(err, checker.IsNil)
+	out, _, err = dockerCmdWithError("plugin", "ls")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, pName)
+	c.Assert(out, checker.Contains, pTag)
+	c.Assert(out, checker.Contains, "true")
+
+	// Disable
+	_, _, err = dockerCmdWithError("plugin", "disable", id[:5])
+	c.Assert(err, checker.IsNil)
+	out, _, err = dockerCmdWithError("plugin", "ls")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, pName)
+	c.Assert(out, checker.Contains, pTag)
+	c.Assert(out, checker.Contains, "false")
+
+	// Remove
+	out, _, err = dockerCmdWithError("plugin", "remove", id[:5])
+	c.Assert(err, checker.IsNil)
+	// List returns none
+	out, _, err = dockerCmdWithError("plugin", "ls")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Not(checker.Contains), pName)
+	c.Assert(out, checker.Not(checker.Contains), pTag)
+}


### PR DESCRIPTION
**- What I did**

This fix is a follow up based on comment:
https://github.com/docker/docker/pull/28789#issuecomment-264225277

As #28789 has been merged in, it is possible for `docker plugin inspect` to search based on Name or ID Prefix. However, ID-based `docker plugin enable/disable/rm/set` are still not possible.

**- How I did it**

This fix allows `docker plugin enable/disable/rm/set` to search based on:
- Full ID
- Full Name
- Partial ID (prefix)

**- How to verify it**

An additional integration test has been added to cover the changes. And all existing tests should pass.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![collection-of-christmas-kitten-wallpaper-on-wall-papers-1](https://cloud.githubusercontent.com/assets/6932348/20985763/b2c7d658-bc7a-11e6-8327-0288096d6e38.jpg)


This fix is a follow up of #28789.

/cc @anusha-ragunathan

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>