### PR TITLE
add break when found in TestVolumeCLICreateWithOpts()

### DIFF
--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -311,6 +311,7 @@ func (s *DockerSuite) TestVolumeCLICreateWithOpts(c *check.C) {
 			c.Assert(info[4], checker.Equals, "tmpfs")
 			c.Assert(info[5], checker.Contains, "uid=1000")
 			c.Assert(info[5], checker.Contains, "size=1024k")
+			break
 		}
 	}
 	c.Assert(found, checker.Equals, true)


### PR DESCRIPTION
add break when found in TestVolumeCLICreateWithOpts() to reduce loop time.