### PR TITLE
rectify the return value for NetworkCreate()

### DIFF
--- a/client/network_create.go
+++ b/client/network_create.go
@@ -16,10 +16,10 @@ func (cli *Client) NetworkCreate(ctx context.Context, name string, options types
 	var response types.NetworkCreateResponse
 	serverResp, err := cli.post(ctx, "/networks/create", nil, networkCreateRequest, nil)
 	if err != nil {
-		return response, err
+		return nil, err
 	}
 
 	json.NewDecoder(serverResp.body).Decode(&response)
 	ensureReaderClosed(serverResp)
-	return response, err
+	return response, nil
 }


### PR DESCRIPTION
In following code:

	var response types.NetworkCreateResponse
	serverResp, err := cli.post(ctx, "/networks/create", nil, networkCreateRequest, nil)
	if err != nil {
		return response, err
	}

here response is not set value, so can't be returned, should return nil.

and in following code:

	json.NewDecoder(serverResp.body).Decode(&response)
	ensureReaderClosed(serverResp)
	return response, err

here should return nil because it is success.