### PR TITLE
[ppc64le] use official go 1.7.4 binaries

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -15,8 +15,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-# ppc64le/golang is a debian:jessie based image with golang installed
-FROM ppc64le/golang:1.6.3
+FROM ppc64le/debian:jessie
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org
@@ -95,25 +94,12 @@ RUN set -x \
 
 
 # Install Go
-# ppc64le doesn't have official go binaries, so use the version of go installed from the image
-# to build go from source.
-# NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
+# NOTE: official ppc64le go binaries weren't available until go 1.6.4 and 1.7.4
 ENV GO_VERSION 1.7.4
-ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" \
+	| tar -xzC /usr/local
 
-RUN set -x \
-	&& TEMPDIR="$(mktemp -d)" \
-	&& mv /usr/local/go $TEMPDIR \
-	&& GOROOT_BOOTSTRAP=$TEMPDIR/go \
-	&& cd /usr/local \
-	&& curl -fsSL "$GO_DOWNLOAD_URL" -o golang.tar.gz \
-	&& tar -C /usr/local -xzf golang.tar.gz \
-	&& rm golang.tar.gz \
-	&& cd go/src && ./make.bash 2>&1 \
-	&& rm -rf $TEMPDIR
-
-ENV GOROOT_BOOTSTRAP /usr/local/go
-ENV PATH /usr/local/go/bin/:$PATH
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 
 # Dependency for golint

--- a/contrib/builder/deb/ppc64le/generate.sh
+++ b/contrib/builder/deb/ppc64le/generate.sh
@@ -59,22 +59,12 @@ for version in "${versions[@]}"; do
 		vim-common # tini dep
 	)
 
-	# trusty uses a different go package name then xenial and newer, so track that for later
-	goPackage=
 	case "$suite" in
 		trusty) 
-			# ppc64le doesn't have go binaries, so install go to bootstrap go
-			# trusty doesn't have a ppc64le golang-go package
-			packages+=( golang-1.6 )
-			goPackage='golang-1.6'
-
 			packages+=( libsystemd-journal-dev )
 			;;
 		*)
 			# libseccomp isn't available until ubuntu xenial and is required for "seccomp.h" & "libseccomp.so"
-			packages+=( golang-go )
-			goPackage='golang-go'
-
 			packages+=( libseccomp-dev )
 			packages+=( libsystemd-dev )
 			;;
@@ -98,25 +88,8 @@ for version in "${versions[@]}"; do
 	echo "RUN apt-get update && apt-get install -y ${packages[*]} --no-install-recommends && rm -rf /var/lib/apt/lists/*" >> "$version/Dockerfile"
 	echo >> "$version/Dockerfile"
 
-	# ppc64le doesn't have an official downloadable binary as of go 1.6.2. so use the
-	# older packaged go(v1.6.1) to bootstrap latest go, then remove the packaged go
-	echo "# Install Go" >> "$version/Dockerfile"
-	echo "# ppc64le doesn't have official go binaries, so use a distro packaged version of go" >> "$version/Dockerfile"
-	echo "# to build go from source." >> "$version/Dockerfile"
-	echo "# NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6" >> "$version/Dockerfile"
-	
 	awk '$1 == "ENV" && $2 == "GO_VERSION" { print; exit }' ../../../../Dockerfile.ppc64le >> "$version/Dockerfile"
-	echo 'ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz' >> "$version/Dockerfile"
-	echo 'ENV GOROOT_BOOTSTRAP /usr/lib/go-1.6' >> "$version/Dockerfile"
-	echo >> "$version/Dockerfile"
-	
-	echo 'RUN curl -fsSL "$GO_DOWNLOAD_URL" -o golang.tar.gz \' >> "$version/Dockerfile"
-	echo '	&& tar -C /usr/local -xzf golang.tar.gz \' >> "$version/Dockerfile"
-	echo '	&& rm golang.tar.gz \' >> "$version/Dockerfile"
-	echo '	&& cd /usr/local/go/src && ./make.bash 2>&1 \' >> "$version/Dockerfile"
-	echo "	&& apt-get purge -y $goPackage && apt-get autoremove -y" >> "$version/Dockerfile"
-	echo >> "$version/Dockerfile"
-
+	echo 'RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local' >> "$version/Dockerfile"
 	echo 'ENV PATH $PATH:/usr/local/go/bin' >> "$version/Dockerfile"
 	echo >> "$version/Dockerfile"
 

--- a/contrib/builder/deb/ppc64le/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/ppc64le/ubuntu-trusty/Dockerfile
@@ -4,22 +4,10 @@
 
 FROM ppc64le/ubuntu:trusty
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config vim-common golang-1.6 libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# Install Go
-# ppc64le doesn't have official go binaries, so use a distro packaged version of go
-# to build go from source.
-# NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
 ENV GO_VERSION 1.7.4
-ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
-ENV GOROOT_BOOTSTRAP /usr/lib/go-1.6
-
-RUN curl -fsSL "$GO_DOWNLOAD_URL" -o golang.tar.gz \
-	&& tar -C /usr/local -xzf golang.tar.gz \
-	&& rm golang.tar.gz \
-	&& cd /usr/local/go/src && ./make.bash 2>&1 \
-	&& apt-get purge -y golang-1.6 && apt-get autoremove -y
-
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1

--- a/contrib/builder/deb/ppc64le/ubuntu-xenial/Dockerfile
+++ b/contrib/builder/deb/ppc64le/ubuntu-xenial/Dockerfile
@@ -4,22 +4,10 @@
 
 FROM ppc64le/ubuntu:xenial
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config vim-common golang-go libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config vim-common libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# Install Go
-# ppc64le doesn't have official go binaries, so use a distro packaged version of go
-# to build go from source.
-# NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
 ENV GO_VERSION 1.7.4
-ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
-ENV GOROOT_BOOTSTRAP /usr/lib/go-1.6
-
-RUN curl -fsSL "$GO_DOWNLOAD_URL" -o golang.tar.gz \
-	&& tar -C /usr/local -xzf golang.tar.gz \
-	&& rm golang.tar.gz \
-	&& cd /usr/local/go/src && ./make.bash 2>&1 \
-	&& apt-get purge -y golang-go && apt-get autoremove -y
-
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1

--- a/contrib/builder/deb/ppc64le/ubuntu-yakkety/Dockerfile
+++ b/contrib/builder/deb/ppc64le/ubuntu-yakkety/Dockerfile
@@ -4,22 +4,10 @@
 
 FROM ppc64le/ubuntu:yakkety
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config vim-common golang-go libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config vim-common libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# Install Go
-# ppc64le doesn't have official go binaries, so use a distro packaged version of go
-# to build go from source.
-# NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
 ENV GO_VERSION 1.7.4
-ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
-ENV GOROOT_BOOTSTRAP /usr/lib/go-1.6
-
-RUN curl -fsSL "$GO_DOWNLOAD_URL" -o golang.tar.gz \
-	&& tar -C /usr/local -xzf golang.tar.gz \
-	&& rm golang.tar.gz \
-	&& cd /usr/local/go/src && ./make.bash 2>&1 \
-	&& apt-get purge -y golang-go && apt-get autoremove -y
-
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1


### PR DESCRIPTION
go 1.7.4 introduced official go ppc64le binaries, so use those
instead of building go from src. This also gets rid of the requirement
to use a custom debian:jessie + golang image, so we can just use
base debian:jessie

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>

![BA gopher](http://www.about-rodents.com/images/gopher-01.jpg)

I also verified the debs installed correctly afterwards

```sh
root@45568734c4c6:/# docker version
Client:
 Version:      1.14.0-dev
 API version:  1.26
 Go version:   go1.7.4
 Git commit:   65f327a
 Built:        Thu Dec  8 18:02:31 2016
 OS/Arch:      linux/ppc64le

Server:
 Version:      1.14.0-dev
 API version:  1.26 (minimum version 1.12)
 Go version:   go1.7.4
 Git commit:   65f327a
 Built:        Thu Dec  8 18:02:31 2016
 OS/Arch:      linux/ppc64le
 Experimental: false
```