### PR TITLE
[1.12.x] ppc64le, use official go 1.6.4 binaries

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -15,7 +15,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM ppc64le/gcc:6.1
+FROM ppc64le/debian:jessie
 
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \
@@ -87,21 +87,14 @@ RUN set -x \
         && rm -rf "$SECCOMP_PATH"
 
 
-## BUILD GOLANG 1.6
-# NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
+# Install Go
+# NOTE: official ppc64le go binaries weren't available until go 1.6.4 and 1.7.4
 ENV GO_VERSION 1.6.4
-ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
-ENV GOROOT_BOOTSTRAP /usr/local
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" \
+	| tar -xzC /usr/local
 
-RUN curl -fsSL "$GO_DOWNLOAD_URL" -o golang.tar.gz \
-    && tar -C /usr/src -xzf golang.tar.gz \
-    && rm golang.tar.gz \
-    && cd /usr/src/go/src && ./make.bash 2>&1
-
-ENV GOROOT_BOOTSTRAP /usr/src/
-
-ENV PATH /usr/src/go/bin/:/go/bin:$PATH
-ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV GOPATH /go
 
 # This has been commented out and kept as reference because we don't support compiling with older Go anymore.
 # ENV GOFMT_VERSION 1.3.3


### PR DESCRIPTION
Use official go 1.6.4. binaries instead of downloading and building
from src

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>