### PR TITLE
Delete invalid reference in docs/reference/index.md

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -18,4 +18,3 @@ keywords: "Engine"
 * [Dockerfile reference](builder.md)
 * [Docker run reference](run.md)
 * [Command line reference](commandline/index.md)
-* [API Reference](api/index.md)


### PR DESCRIPTION
"api/index.md" or "docs/api/index.md" not exist, delete the reference.