### PR TITLE
Set inspect type in ensure-emptyfs

### DIFF
--- a/hack/make/.ensure-emptyfs
+++ b/hack/make/.ensure-emptyfs
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if ! docker inspect emptyfs &> /dev/null; then
+if ! docker inspect -t image emptyfs &> /dev/null; then
 	# let's build a "docker save" tarball for "emptyfs"
 	# see https://github.com/docker/docker/pull/5262
 	# and also https://github.com/docker/docker/issues/4242


### PR DESCRIPTION
This keeps the test daemon logs from being flooded with calls to lookup
emptyfs for other types.

Thought about adding a picture of a "nit", but they were all grossing me out...