### PR TITLE
Fix duplicated ports allocation with restarted swarm

### DIFF
--- a/vendor/github.com/docker/swarmkit/manager/allocator/network.go
+++ b/vendor/github.com/docker/swarmkit/manager/allocator/network.go
@@ -231,6 +231,8 @@ func (a *Allocator) doNetworkInit(ctx context.Context) (err error) {
 
 	var allocatedServices []*api.Service
 	for _, s := range services {
+		nc.nwkAllocator.ServiceInit(s)
+
 		if nc.nwkAllocator.IsServiceAllocated(s) {
 			continue
 		}


### PR DESCRIPTION
**- What I did**
This fix fixes the issue raised in #29247 where duplicated ports (`PublishedPort`) is being allocated with restarted swarm nodes.

The reason for the issue was that `isPortsAllocated` relies on portSpace which does not capture the ports in restored services when swarm is restarted.

**- How I did it**

See SwarmKit PR: https://github.com/docker/swarmkit/pull/1802

Most of the fix is done in SwarmKit PR which adds a flag in `isPortsAllocated`. In case the allocator is still in initialization stage, dynamically allocated ports (`PublishedPort`) will always be reallocated.

This fix (docker PR) adds an integration test to prevent regression in the future.

**- How to verify it**

An integration test has been added.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![christmas-animals-004](https://cloud.githubusercontent.com/assets/6932348/21054922/57718ed2-bde4-11e6-94a0-9f1bf6afd1a3.jpg)


This fix fixes #29247.


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>