### PR TITLE
Fix issues with plugin and `--live-restore`

### DIFF
--- a/integration-cli/docker_cli_daemon_plugins_test.go
+++ b/integration-cli/docker_cli_daemon_plugins_test.go
@@ -129,7 +129,7 @@ func (s *DockerDaemonSuite) TestDaemonShutdownLiveRestoreWithPlugins(c *check.C)
 
 // TestDaemonShutdownWithPlugins shuts down running plugins.
 func (s *DockerDaemonSuite) TestDaemonShutdownWithPlugins(c *check.C) {
-	testRequires(c, IsAmd64, Network)
+	testRequires(c, IsAmd64, Network, SameHostDaemon)
 
 	s.d.Start(c)
 	if out, err := s.d.Cmd("plugin", "install", "--grant-all-permissions", pName); err != nil {
@@ -160,6 +160,11 @@ func (s *DockerDaemonSuite) TestDaemonShutdownWithPlugins(c *check.C) {
 	if out, ec, err := runCommandWithOutput(cmd); ec != 1 {
 		c.Fatalf("Expected exit code '1', got %d err: %v output: %s ", ec, err, out)
 	}
+
+	s.d.Start(c, "--live-restore")
+	cmd = exec.Command("pgrep", "-f", pluginProcessName)
+	out, _, err := runCommandWithOutput(cmd)
+	c.Assert(err, checker.IsNil, check.Commentf(out))
 }
 
 // TestVolumePlugin tests volume creation using a plugin.


### PR DESCRIPTION
Fixes an issue when starting the daemon with live-restore
where previously it was not set, plugins are not running.

Fixes an issue when starting the daemon with live-restore, the plugin
client (for interacting with the plugins HTTP interface) is not set,
causing a panic when the plugin is called.