### PR TITLE
Windows: Fix crash in docker system prune

### DIFF
--- a/pkg/term/windows/ansi_reader.go
+++ b/pkg/term/windows/ansi_reader.go
@@ -115,6 +115,8 @@ func readInputEvents(fd uintptr, maxBytes int) ([]winterm.INPUT_RECORD, error) {
 	countRecords := maxBytes / recordSize
 	if countRecords > ansiterm.MAX_INPUT_EVENTS {
 		countRecords = ansiterm.MAX_INPUT_EVENTS
+	} else if countRecords == 0 {
+		countRecords = 1
 	}
 	logger.Debugf("[windows] readInputEvents: Reading %v records (buffer size %v, record size %v)", countRecords, maxBytes, recordSize)
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes https://github.com/docker/for-win/issues/301 

@mlaventure Yes, verified this fixes it. You only hit it with the legacy console (or a non-native console possibly). I've a follow up PR to fix the input stream on the legacy console as the y/n user input doesn't get output.

@vieux @thaJeztah This is a 1.13 fix too to stop a client crash running `docker system prune` on Windows when running the legacy console.