### PR TITLE
Windows: Prompt fix use regular stdin

### DIFF
--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -70,6 +71,11 @@ func PromptForConfirmation(ins *InStream, outs *OutStream, message string) bool 
 	message += " [y/N] "
 
 	fmt.Fprintf(outs, message)
+
+	// On Windows, force the use of the regular OS stdin stream.
+	if runtime.GOOS == "windows" {
+		ins = NewInStream(os.Stdin)
+	}
 
 	answer := ""
 	n, _ := fmt.Fscan(ins, &answer)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Follow-up to https://github.com/docker/docker/pull/29287. This does an identical fix in https://github.com/docker/docker/blob/master/cli/command/registry.go#L76-L79 for the prompt for confirmation. Otherwise, when running the CLI on Windows with a console in legacy mode (or a non-native console possibly), the y/n prompt will not be displayed as the user types it in.

@thaJeztah Debatable whether this meets the 1.13 bar, but it probably does make sense as it's a very low-risk fix, and is bound to be reported at some point.  @vieux