### PR TITLE
Update vendored swarmkit to 5a6df4b07d83e6dbd72e39e354c325dc9b91850f

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -100,7 +100,7 @@ github.com/docker/containerd 03e5862ec0d8d3b3f750e19fca3ee367e13c090e
 github.com/tonistiigi/fifo 1405643975692217d6720f8b54aeee1bf2cd5cf4
 
 # cluster
-github.com/docker/swarmkit 5fe1f720da9c8ee66b49907d6ee415e9bfb1e5ef
+github.com/docker/swarmkit 5a6df4b07d83e6dbd72e39e354c325dc9b91850f
 github.com/golang/mock bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 github.com/gogo/protobuf v0.3
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a


### PR DESCRIPTION
This fix updates swarmkit to 5a6df4b07d83e6dbd72e39e354c325dc9b91850f.

This fix is needed by #29074 (docker PR),
and is related to
docker/swarmkit#1789 (swarmkit PR)
#29044 (docker issue)

This fix may be needed for 1.13.

/cc @mavenugo @aaronlehmann @aboch @dongluochen 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>