### PR TITLE
[1.13.x] Update vendored swarmkit to b5f07ce49c66d2f5feee83998b23d4c905b78155

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -100,7 +100,7 @@ github.com/docker/containerd 03e5862ec0d8d3b3f750e19fca3ee367e13c090e
 github.com/tonistiigi/fifo 1405643975692217d6720f8b54aeee1bf2cd5cf4
 
 # cluster
-github.com/docker/swarmkit 999addf86dad33479756c83620ed727ef50bce57
+github.com/docker/swarmkit b5f07ce49c66d2f5feee83998b23d4c905b78155
 github.com/golang/mock bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 github.com/gogo/protobuf v0.3
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a


### PR DESCRIPTION
This fix update swarmkit to b5f07ce49c66d2f5feee83998b23d4c905b78155

The following changes have been included:
- Fix missing IPAM options in swarm network mode (docker/swarmkit#1789)

The above PR is related to docker PR #29074 and docker issue #29044.

/cc @aaronlehmann

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>