### PR TITLE
Mount container /dev noexec

### DIFF
--- a/oci/defaults_linux.go
+++ b/oci/defaults_linux.go
@@ -32,7 +32,7 @@ func DefaultSpec() specs.Spec {
 			Destination: "/dev",
 			Type:        "tmpfs",
 			Source:      "tmpfs",
-			Options:     []string{"nosuid", "strictatime", "mode=755"},
+			Options:     []string{"nosuid", "noexec", "strictatime", "mode=755"},
 		},
 		{
 			Destination: "/dev/pts",


### PR DESCRIPTION
There is no need for the tmpfs on /dev to be mounted with exec
as binaries should never be executed from /dev.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

This locks down the filesystems a bit more, as the user cannot specify the mount options for the default mount points.

cc @riyazdf 

![calf](https://cloud.githubusercontent.com/assets/482364/21070036/c7c6c5d0-be34-11e6-87c7-1b52ec6433e0.jpg)
