### PR TITLE
Speedup build by skipping what's bind-mounted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ DOCKER_ENVS := \
 	-e no_proxy
 # note: we _cannot_ add "-e DOCKER_BUILDTAGS" here because even if it's unset in the shell, that would shadow the "ENV DOCKER_BUILDTAGS" set in our Dockerfile, which is very important for our official builds
 
+SEND_CONTEXT := $(if $(BIND_DIR),,$(if $(BINDDIR),,1))
+SEND_CONTEXT := $(if $(DOCKER_HOST),1,$(SEND_CONTEXT))
 # to allow `make BIND_DIR=. shell` or `make BIND_DIR= test`
 # (default to no bind mount if DOCKER_HOST is set)
 # note: BINDDIR is supported for backwards-compatibility here
@@ -85,7 +87,21 @@ binary: build ## build the linux binaries
 	$(DOCKER_RUN_DOCKER) hack/make.sh binary
 
 build: bundles init-go-pkg-cache
+ifdef SEND_CONTEXT
 	docker build ${BUILD_APT_MIRROR} ${DOCKER_BUILD_ARGS} -t "$(DOCKER_IMAGE)" -f "$(DOCKERFILE)" .
+else
+	# BIND_DIR is used, and source code is bind-mounted in the container so there's
+	# no need to send it as build context. Only send what's used during build
+	cp "$(DOCKERFILE)" "$(DOCKERFILE).tmp"
+	sed -e 's/COPY \./\# COPY \./g' "$(DOCKERFILE)" > "$(DOCKERFILE).tmp"
+	cp .dockerignore .dockerignore.orig && echo "*\n!contrib/download-frozen-image-v2.sh\n!hack/dockerfile" >> .dockerignore
+	cat .dockerignore
+
+	docker build ${BUILD_APT_MIRROR} ${DOCKER_BUILD_ARGS} -t "$(DOCKER_IMAGE)" -f "$(DOCKERFILE).tmp" .
+
+	mv .dockerignore.orig .dockerignore
+	rm "$(DOCKERFILE).tmp"
+endif
 
 bundles:
 	mkdir bundles


### PR DESCRIPTION
When `BIND_DIR` is used, all source-code is bind-mounted into the container, so there's no need to `COPY` the source in the image.

This patch skips the files that are bind-mounted, preventing it from being sent as build-context, and added to the image through `COPY`.

Some hacks were needed for the `.dockerignore` file, because we currently don't support specifying an alternative `.dockerignore` file.
