### PR TITLE
Improve the error print of image inspect

### DIFF
--- a/daemon/image_inspect.go
+++ b/daemon/image_inspect.go
@@ -1,12 +1,12 @@
 package daemon
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/reference"
+	"github.com/pkg/errors"
 )
 
 // LookupImage looks up an image by name and returns it as an ImageInspect
@@ -14,7 +14,7 @@ import (
 func (daemon *Daemon) LookupImage(name string) (*types.ImageInspect, error) {
 	img, err := daemon.GetImage(name)
 	if err != nil {
-		return nil, fmt.Errorf("No such image: %s", name)
+		return nil, errors.Wrapf(err, "no such image: %s", name)
 	}
 
 	refs := daemon.referenceStore.References(img.ID().Digest())

--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -761,7 +761,7 @@ func WaitInspectWithArgs(dockerBinary, name, expr, expected string, timeout time
 	for {
 		result := icmd.RunCommand(dockerBinary, args...)
 		if result.Error != nil {
-			if !strings.Contains(result.Stderr(), "No such") {
+			if !strings.Contains(strings.ToLower(result.Stderr()), "no such") {
 				return errors.Errorf("error executing docker inspect: %v\n%s",
 					result.Stderr(), result.Stdout())
 			}


### PR DESCRIPTION
I think we should return the `err` of `GetImage()`, so that user can get the reason why no such image.


Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>