### PR TITLE
Make graphdriver plugin use plugin BasePath

### DIFF
--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -154,10 +154,12 @@ func GetDriver(name, home string, options []string, uidMaps, gidMaps []idtools.I
 	if initFunc, exists := drivers[name]; exists {
 		return initFunc(filepath.Join(home, name), options, uidMaps, gidMaps)
 	}
-	if pluginDriver, err := lookupPlugin(name, home, options, pg); err == nil {
+
+	pluginDriver, err := lookupPlugin(name, home, options, pg)
+	if err == nil {
 		return pluginDriver, nil
 	}
-	logrus.Errorf("Failed to GetDriver graph %s %s", name, home)
+	logrus.WithError(err).WithField("driver", name).WithField("home-dir", home).Error("Failed to GetDriver graph")
 	return nil, ErrNotSupported
 }
 

--- a/integration-cli/docker_cli_daemon_plugins_test.go
+++ b/integration-cli/docker_cli_daemon_plugins_test.go
@@ -235,6 +235,24 @@ func (s *DockerDaemonSuite) TestVolumePlugin(c *check.C) {
 	c.Assert(exists, checker.Equals, true)
 }
 
+func (s *DockerDaemonSuite) TestGraphdriverPlugin(c *check.C) {
+	testRequires(c, Network, IsAmd64, DaemonIsLinux, overlaySupported)
+
+	s.d.Start(c)
+
+	// install the plugin
+	plugin := "cpuguy83/docker-overlay2-graphdriver-plugin"
+	out, err := s.d.Cmd("plugin", "install", "--grant-all-permissions", plugin)
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+
+	// restart the daemon with the plugin set as the storage driver
+	s.d.Restart(c, "-s", plugin)
+
+	// run a container
+	out, err = s.d.Cmd("run", "--rm", "busybox", "true") // this will pull busybox using the plugin
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+}
+
 func existsMountpointWithPrefix(mountpointPrefix string) (bool, error) {
 	mounts, err := mount.GetMounts()
 	if err != nil {

--- a/integration-cli/requirements_unix.go
+++ b/integration-cli/requirements_unix.go
@@ -3,7 +3,9 @@
 package main
 
 import (
+	"bytes"
 	"io/ioutil"
+	"os/exec"
 	"strings"
 
 	"github.com/docker/docker/pkg/sysinfo"
@@ -121,6 +123,17 @@ var (
 			return false
 		},
 		"Test cannot be run without a kernel (4.3+) supporting ambient capabilities",
+	}
+	overlaySupported = testRequirement{
+		func() bool {
+			cmd := exec.Command(dockerBinary, "run", "--rm", "busybox", "/bin/sh", "-c", "cat /proc/filesystems")
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				return false
+			}
+			return bytes.Contains(out, []byte("overlay\n"))
+		},
+		"Test cannot be run wihtout suppport for ovelayfs",
 	}
 )
 

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -156,7 +156,7 @@ func (pm *Manager) reload() error {
 
 			// We should only enable rootfs propagation for certain plugin types that need it.
 			for _, typ := range p.PluginObj.Config.Interface.Types {
-				if typ.Capability == "volumedriver" && typ.Prefix == "docker" && strings.HasPrefix(typ.Version, "1.") {
+				if (typ.Capability == "volumedriver" || typ.Capability == "graphdriver") && typ.Prefix == "docker" && strings.HasPrefix(typ.Version, "1.") {
 					if p.PluginObj.Config.PropagatedMount != "" {
 						// TODO: sanitize PropagatedMount and prevent breakout
 						p.PropagatedMount = filepath.Join(p.Rootfs, p.PluginObj.Config.PropagatedMount)


### PR DESCRIPTION
Also enables `PropagatedMount` for graphdrivers.

Verify by:

```
$ docker plugin install cpuguy83/docker-overlay2-graphdriver-plugin
# plugin is installed and enabled, restart the daemon with the new driver selected
$ pkill dockerd
$ dockerd -s cpuguy83/docker-overlay2-graphdriver-plugin
$ docker run -it --rm busybox sh
```

ping @tiborvass 