### PR TITLE
Plugin PropagatedMount only needs rslave

### DIFF
--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -35,7 +35,7 @@ func (pm *Manager) enable(p *v2.Plugin, c *controller, force bool) error {
 	pm.mu.Unlock()
 
 	if p.PropagatedMount != "" {
-		if err := mount.MakeRShared(p.PropagatedMount); err != nil {
+		if err := mount.MakeRSlave(p.PropagatedMount); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Since the host does not need to propagate mounts into the plugin mount
NS, the plugin's `PropagatedMount` only requires rslave when setting up
the directory on the host side.
The mounts from the plugin container will still propagate back to the
host.

ping @tiborvass @anusha-ragunathan 