### PR TITLE
Add test for fqdn hostname not being set in container

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4482,6 +4482,20 @@ func (s *DockerSuite) TestRunMountReadOnlyDevShm(c *check.C) {
 	c.Assert(out, checker.Contains, "Read-only file system")
 }
 
+// Test that passing a FQDN as hostname properly sets hostname, and
+// /etc/hostname. Test case for 29100
+func (s *DockerSuite) TestRunHostnameFQDN(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	expectedOutput := "foobar.example.com\nfoobar.example.com\nfoobar\nexample.com\nfoobar.example.com"
+	out, _ := dockerCmd(c, "run", "--hostname=foobar.example.com", "busybox", "sh", "-c", `cat /etc/hostname && hostname && hostname -s && hostname -d && hostname -f`)
+	c.Assert(strings.TrimSpace(out), checker.Equals, expectedOutput)
+
+	out, _ = dockerCmd(c, "run", "--hostname=foobar.example.com", "busybox", "sh", "-c", `cat /etc/hosts`)
+	expectedOutput = "foobar.example.com foobar"
+	c.Assert(strings.TrimSpace(out), checker.Contains, expectedOutput)
+}
+
 // Test case for 29129
 func (s *DockerSuite) TestRunHostnameInHostMode(c *check.C) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)


### PR DESCRIPTION
**- What I did**

Made `--hostname=fqdn.example.com` work (libnetwork changes), and added an integration test to verify the behavior.

fixes https://github.com/docker/docker/issues/29100

**- How to verify it**

run

    docker run --rm --hostname foobar.example.com busybox sh -c 'cat /etc/hostname && hostname && hostname -s && hostname -d && hostname -f'

And verify that the output looks like this;

```
foobar.example.com
foobar.example.com
foobar
example.com
foobar.example.com
```

run

    docker run -dit --hostname foobar.example.com busybox sh -c 'cat /etc/hosts'

And verify that `/etc/hosts` contains both the "hostname" and "fqdn";

```
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
172.18.0.2	foobar.example.com foobar
```

**- Description for the changelog**

Fixed an issue where FQDN hostnames where not correctly set in the container


Depends on https://github.com/docker/libnetwork/pull/1589

