### PR TITLE
Get rid of err altogether by just returning the assignment

### DIFF
--- a/pkg/aaparser/aaparser.go
+++ b/pkg/aaparser/aaparser.go
@@ -39,7 +39,7 @@ func cmd(dir string, arg ...string) (string, error) {
 
 	output, err := c.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("running `%s %s` failed with output: %s\nerror: %v", c.Path, strings.Join(c.Args, " "), string(output), err)
+		return "", fmt.Errorf("running `%s %s` failed with output: %s\nerror: %v", c.Path, strings.Join(c.Args, " "), output, err)
 	}
 
 	return string(output), nil

--- a/profiles/apparmor/apparmor.go
+++ b/profiles/apparmor/apparmor.go
@@ -54,10 +54,7 @@ func (p *profileData) generateDefault(out io.Writer) error {
 	}
 	p.Version = ver
 
-	if err := compiled.Execute(out, p); err != nil {
-		return err
-	}
-	return nil
+	return compiled.Execute(out, p)
 }
 
 // macrosExists checks if the passed macro exists.
@@ -87,11 +84,7 @@ func InstallDefault(name string) error {
 		return err
 	}
 
-	if err := aaparser.LoadProfile(profilePath); err != nil {
-		return err
-	}
-
-	return nil
+	return aaparser.LoadProfile(profilePath)
 }
 
 // IsLoaded checks if a profile with the given name has been loaded into the


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Remove the string(output) cast as %s already prints the byte slice as a string.
2. Get rid of err altogether by just returning the assignment.

![image](https://cloud.githubusercontent.com/assets/1636894/21130147/5f4e2dee-c141-11e6-9b34-657b929284b9.png)


Signed-off-by: Xianglin Gao <xlgao@zju.edu.cn>