### PR TITLE
Fix failures on Win2lin

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -217,14 +217,14 @@ func (s *DockerDaemonSuite) OnTimeout(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) SetUpTest(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
 		Experimental: experimentalDaemon,
 	})
 }
 
 func (s *DockerDaemonSuite) TearDownTest(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	if s.d != nil {
 		s.d.Stop(c)
 	}

--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -195,7 +195,6 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 	if err != nil {
 		return errors.Wrapf(err, "[%s] could not find docker binary in $PATH", d.id)
 	}
-
 	args := append(d.GlobalFlags,
 		"--containerd", "/var/run/docker/libcontainerd/docker-containerd.sock",
 		"--graph", d.Root,

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -259,10 +259,19 @@ func (s *DockerSuite) TestRestartContainerwithRestartPolicy(c *check.C) {
 	dockerCmd(c, "restart", id1)
 	dockerCmd(c, "restart", id2)
 
+	// Make sure we can stop/start (regression test from a705e166cf3bcca62543150c2b3f9bfeae45ecfa)
 	dockerCmd(c, "stop", id1)
 	dockerCmd(c, "stop", id2)
 	dockerCmd(c, "start", id1)
 	dockerCmd(c, "start", id2)
+
+	// Kill the containers, making sure the are stopped at the end of the test
+	dockerCmd(c, "kill", id1)
+	dockerCmd(c, "kill", id2)
+	err = waitInspect(id1, "{{ .State.Restarting }} {{ .State.Running }}", "false false", waitTimeout)
+	c.Assert(err, checker.IsNil)
+	err = waitInspect(id2, "{{ .State.Restarting }} {{ .State.Running }}", "false false", waitTimeout)
+	c.Assert(err, checker.IsNil)
 }
 
 func (s *DockerSuite) TestRestartAutoRemoveContainer(c *check.C) {


### PR DESCRIPTION
Looks like https://github.com/docker/docker/pull/29210 did break Win2lin. Let's fix that :angel: 

/cc @thaJeztah @johnstep @cpuguy83 @dnephin @vieux @runcom 

---

Explanation (commit message :stuck_out_tongue_closed_eyes:)

The success of the win2lin CI before was really **"by chance" on the
DockerDaemonSuite** : the DockerDaemonSuite was panicking when starting
the daemon on the first non-skipped test.The suite panicked but as
the error returned from `StartWithBusybox` was nil, the test kept
going and was OK because the client had all the correct environment
variables set up to discuss with the remote daemon.

Then, as the suite panicked, no more test attached on the
DockerDaemonSuite ran (that's why on win2lin, `DockerDaemonSuite` was
only composed by 5 tests !). The really bad thing is, we didn't get
any report of the panic on the suite (go-check hiding something
somewhere).

This is the diff that *put this into light*.

```diff
-	dockerdBinary, err := exec.LookPath(dockerdBinary)		
-	d.c.Assert(err, check.IsNil, check.Commentf("[%s] could not find docker binary in $PATH", d.id))
+	dockerdBinary, err := exec.LookPath(d.dockerdBinary)
+	if err != nil {
+		return errors.Wrapf(err, "[%s] could not find docker binary in $PATH", d.id)
+	}
```
As DockerDaemonSuite needs to run test on the same host as it's
running, this adds a `SameHostDaemon` requirement to the Suite.

This changes also make sure `TestRestartContainerWithRestartPolicy`
does left weirdies behind it.

---

Current Win2Lin jobs is : https://jenkins.dockerproject.org/job/Docker-PRs-Win2Lin/31615/console

Signed-off-by: Vincent Demeester <vincent@sbr.pm>