### PR TITLE
Modify the default value for network

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -94,7 +94,7 @@ Options:
       --memory-swappiness int       Tune container memory swappiness (0 to 100) (default -1)
       --name string                 Assign a name to the container
       --network-alias value         Add network-scoped alias for the container (default [])
-      --network string              Connect a container to a network
+      --network string              Connect a container to a network (default "default")
                                     'bridge': create a network stack on the default Docker bridge
                                     'none': no networking
                                     'container:<name|id>': reuse another container's network stack

--- a/man/docker-build.1.md
+++ b/man/docker-build.1.md
@@ -23,7 +23,7 @@ docker-build - Build an image from a Dockerfile
 [**-t**|**--tag**[=*[]*]]
 [**-m**|**--memory**[=*MEMORY*]]
 [**--memory-swap**[=*LIMIT*]]
-[**--network**[=*"default"*]]
+[**--network**[=*"bridge"*]]
 [**--shm-size**[=*SHM-SIZE*]]
 [**--cpu-period**[=*0*]]
 [**--cpu-quota**[=*0*]]
@@ -129,7 +129,7 @@ set as the **URL**, the repository is cloned locally and then sent as the contex
 `k` (kilobytes), `m` (megabytes), or `g` (gigabytes). If you don't specify a
 unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
-**--network**=*NETWORK*
+**--network**=*bridge*
   Set the networking mode for the RUN instructions during build. Supported standard
   values are: `bridge`, `host`, `none` and `container:<name|id>`. Any other value
   is taken as a custom network's name or ID which this container should connect to.

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -58,7 +58,7 @@ docker-create - Create a new container
 [**--memory-swappiness**[=*MEMORY-SWAPPINESS*]]
 [**--name**[=*NAME*]]
 [**--network-alias**[=*[]*]]
-[**--network**[=*"bridge"*]]
+[**--network**[=*"default"*]]
 [**--oom-kill-disable**]
 [**--oom-score-adj**[=*0*]]
 [**-P**|**--publish-all**]
@@ -305,8 +305,8 @@ unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 **--name**=""
    Assign a name to the container
 
-**--net**="*bridge*"
-   Set the Network mode for the container
+**--network**="*default*"
+   Set the Network mode for the container (default "default")
                                'bridge': create a network stack on the default Docker bridge
                                'none': no networking
                                'container:<name|id>': reuse another container's network stack

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -60,7 +60,7 @@ docker-run - Run a command in a new container
 [**--memory-swappiness**[=*MEMORY-SWAPPINESS*]]
 [**--name**[=*NAME*]]
 [**--network-alias**[=*[]*]]
-[**--network**[=*"bridge"*]]
+[**--network**[=*"default"*]]
 [**--oom-kill-disable**]
 [**--oom-score-adj**[=*0*]]
 [**-P**|**--publish-all**]
@@ -422,7 +422,7 @@ other place you need to identify a container). This works for both background
 and foreground Docker containers.
 
 **--network**="*bridge*"
-   Set the Network mode for the container
+   Set the Network mode for the container (default "default")
                                'bridge': create a network stack on the default Docker bridge
                                'none': no networking
                                'container:<name|id>': reuse another container's network stack


### PR DESCRIPTION
**- What I did**
1. Modify the default value for network 
2. Update the documents and manuals

**- How I did it**

**- How to verify it**

**- Description for the changelog**
I found that the default value of "--network" is "default. However, supported standard  values of "--network" are: `bridge`, `host`, `none` and `container:<name|id>`.  So, I think that modify the default value of network from default to bridge.

Correct me if I misunderstand it. 
Thanks


Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>