### PR TITLE
Fix the option name for network

### DIFF
--- a/man/docker-build.1.md
+++ b/man/docker-build.1.md
@@ -129,7 +129,7 @@ set as the **URL**, the repository is cloned locally and then sent as the contex
 `k` (kilobytes), `m` (megabytes), or `g` (gigabytes). If you don't specify a
 unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
-**--network**=*NETWORK*
+**--network**=*bridge*
   Set the networking mode for the RUN instructions during build. Supported standard
   values are: `bridge`, `host`, `none` and `container:<name|id>`. Any other value
   is taken as a custom network's name or ID which this container should connect to.

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -222,12 +222,12 @@ two memory nodes.
 **--ip**=""
    Sets the container's interface IPv4 address (e.g. 172.23.0.9)
 
-   It can only be used in conjunction with **--net** for user-defined networks
+   It can only be used in conjunction with **--network** for user-defined networks
 
 **--ip6**=""
    Sets the container's interface IPv6 address (e.g. 2001:db8::1b99)
 
-   It can only be used in conjunction with **--net** for user-defined networks
+   It can only be used in conjunction with **--network** for user-defined networks
 
 **--ipc**=""
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container
@@ -305,7 +305,7 @@ unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 **--name**=""
    Assign a name to the container
 
-**--net**="*bridge*"
+**--network**="*bridge*"
    Set the Network mode for the container
                                'bridge': create a network stack on the default Docker bridge
                                'none': no networking
@@ -404,7 +404,7 @@ unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
   Network Namespace - current sysctls allowed:
       Sysctls beginning with net.*
 
-  Note: if you use --net=host using these sysctls will not be allowed.
+  Note: if you use --network=host using these sysctls will not be allowed.
 
 **-t**, **--tty**=*true*|*false*
    Allocate a pseudo-TTY. The default is *false*.

--- a/man/docker-network-connect.1.md
+++ b/man/docker-network-connect.1.md
@@ -19,10 +19,10 @@ the same network.
 $ docker network connect multi-host-network container1
 ```
 
-You can also use the `docker run --net=<network-name>` option to start a container and immediately connect it to a network.
+You can also use the `docker run --network=<network-name>` option to start a container and immediately connect it to a network.
 
 ```bash
-$ docker run -itd --net=multi-host-network --ip 172.20.88.22 --ip6 2001:db8::8822 busybox
+$ docker run -itd --network=multi-host-network --ip 172.20.88.22 --ip6 2001:db8::8822 busybox
 ```
 You can pause, restart, and stop containers that are connected to a network.
 A container connects to its configured networks when it runs.

--- a/man/docker-network-create.1.md
+++ b/man/docker-network-create.1.md
@@ -73,11 +73,11 @@ name conflicts.
 
 ## Connect containers
 
-When you start a container use the `--net` flag to connect it to a network.
+When you start a container use the `--network` flag to connect it to a network.
 This adds the `busybox` container to the `mynet` network.
 
 ```bash
-$ docker run -itd --net=mynet busybox
+$ docker run -itd --network=mynet busybox
 ```
 
 If you want to add a container to a network after the container is already

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -319,12 +319,12 @@ redirection on the host system.
 **--ip**=""
    Sets the container's interface IPv4 address (e.g. 172.23.0.9)
 
-   It can only be used in conjunction with **--net** for user-defined networks
+   It can only be used in conjunction with **--network** for user-defined networks
 
 **--ip6**=""
    Sets the container's interface IPv6 address (e.g. 2001:db8::1b99)
 
-   It can only be used in conjunction with **--net** for user-defined networks
+   It can only be used in conjunction with **--network** for user-defined networks
 
 **--ipc**=""
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container
@@ -557,7 +557,7 @@ incompatible with any restart policy other than `none`.
   Network Namespace - current sysctls allowed:
       Sysctls beginning with net.*
 
-  If you use the `--net=host` option these sysctls will not be allowed.
+  If you use the `--network=host` option these sysctls will not be allowed.
 
 **--sig-proxy**=*true*|*false*
    Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is *true*.


### PR DESCRIPTION
**- What I did**
Fix the option name from "--net" to "--network"  which keeps consistency between documents and manuals. 

**- How I did it**

**- How to verify it**

**- Description for the changelog**



Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>