### PR TITLE
Update reference docs for service ps

### DIFF
--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -534,9 +534,11 @@ service's name and the node's ID where it sits.
 ```bash
 $ docker service create --name hosttempl --hostname={% raw %}"{{.Node.ID}}-{{.Service.Name}}"{% endraw %} busybox top
 va8ew30grofhjoychbr6iot8c
+
 $ docker service ps va8ew30grofhjoychbr6iot8c
-NAME                      IMAGE                                                                                   NODE          DESIRED STATE  CURRENT STATE               ERROR  PORTS
-hosttempl.1.wo41w8hg8qan  busybox:latest@sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912  2e7a8a9c4da2  Running        Running about a minute ago
+ID            NAME         IMAGE                                                                                   NODE          DESIRED STATE  CURRENT STATE               ERROR  PORTS
+wo41w8hg8qan  hosttempl.1  busybox:latest@sha256:29f5d56d12684887bdfa50dcd29fc31eea4aaf4ad3bec43daf19026a7ce69912  2e7a8a9c4da2  Running        Running about a minute ago
+
 $ docker inspect --format={% raw %}"{{.Config.Hostname}}"{% endraw %} hosttempl.1.wo41w8hg8qanxwjwsg4kxpprj
 x3ti0erg11rjpg64m75kej2mz-hosttempl
 ```

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -40,36 +40,57 @@ The following command shows all the tasks that are part of the `redis` service:
 
 ```bash
 $ docker service ps redis
-NAME                                IMAGE        NODE      DESIRED STATE  CURRENT STATE
-redis.1.0qihejybwf1x5vqi8lgzlgnpq   redis:3.0.6  manager1  Running        Running 8 seconds
-redis.2.bk658fpbex0d57cqcwoe3jthu   redis:3.0.6  worker2   Running        Running 9 seconds
-redis.3.5ls5s5fldaqg37s9pwayjecrf   redis:3.0.6  worker1   Running        Running 9 seconds
-redis.4.8ryt076polmclyihzx67zsssj   redis:3.0.6  worker1   Running        Running 9 seconds
-redis.5.1x0v8yomsncd6sbvfn0ph6ogc   redis:3.0.6  manager1  Running        Running 8 seconds
-redis.6.71v7je3el7rrw0osfywzs0lko   redis:3.0.6  worker2   Running        Running 9 seconds
-redis.7.4l3zm9b7tfr7cedaik8roxq6r   redis:3.0.6  worker2   Running        Running 9 seconds
-redis.8.9tfpyixiy2i74ad9uqmzp1q6o   redis:3.0.6  worker1   Running        Running 9 seconds
-redis.9.3w1wu13yuplna8ri3fx47iwad   redis:3.0.6  manager1  Running        Running 8 seconds
-redis.10.8eaxrb2fqpbnv9x30vr06i6vt  redis:3.0.6  manager1  Running        Running 8 seconds
+
+ID             NAME      IMAGE        NODE      DESIRED STATE  CURRENT STATE          ERROR  PORTS
+0qihejybwf1x   redis.1   redis:3.0.5  manager1  Running        Running 8 seconds
+bk658fpbex0d   redis.2   redis:3.0.5  worker2   Running        Running 9 seconds
+5ls5s5fldaqg   redis.3   redis:3.0.5  worker1   Running        Running 9 seconds
+8ryt076polmc   redis.4   redis:3.0.5  worker1   Running        Running 9 seconds
+1x0v8yomsncd   redis.5   redis:3.0.5  manager1  Running        Running 8 seconds
+71v7je3el7rr   redis.6   redis:3.0.5  worker2   Running        Running 9 seconds
+4l3zm9b7tfr7   redis.7   redis:3.0.5  worker2   Running        Running 9 seconds
+9tfpyixiy2i7   redis.8   redis:3.0.5  worker1   Running        Running 9 seconds
+3w1wu13yupln   redis.9   redis:3.0.5  manager1  Running        Running 8 seconds
+8eaxrb2fqpbn   redis.10  redis:3.0.5  manager1  Running        Running 8 seconds
 ```
+
+In addition to _running_ tasks, the output also shows the task history. For
+example, after updating the service to use the `redis:3.0.6` image, the output
+may look like this:
+
+```bash
+$ docker service ps redis
+
+ID            NAME         IMAGE        NODE      DESIRED STATE  CURRENT STATE                   ERROR  PORTS
+50qe8lfnxaxk  redis.1      redis:3.0.6  manager1  Running        Running 6 seconds ago
+ky2re9oz86r9   \_ redis.1  redis:3.0.5  manager1  Shutdown       Shutdown 8 seconds ago
+3s46te2nzl4i  redis.2      redis:3.0.6  worker2   Running        Running less than a second ago
+nvjljf7rmor4   \_ redis.2  redis:3.0.6  worker2   Shutdown       Rejected 23 seconds ago        "No such image: redis@sha256:6…"
+vtiuz2fpc0yb   \_ redis.2  redis:3.0.5  worker2   Shutdown       Shutdown 1 second ago
+jnarweeha8x4  redis.3      redis:3.0.6  worker1   Running        Running 3 seconds ago
+vs448yca2nz4   \_ redis.3  redis:3.0.5  worker1   Shutdown       Shutdown 4 seconds ago
+jf1i992619ir  redis.4      redis:3.0.6  worker1   Running        Running 10 seconds ago
+blkttv7zs8ee   \_ redis.4  redis:3.0.5  worker1   Shutdown       Shutdown 11 seconds ago
+```
+
+The number of items in the task history is determined by the
+`--task-history-limit` option that was set when initializing the swarm. You can
+change the task history retention limit using the
+[`docker swarm update`](swarm_update.md) command.
 
 When deploying a service, docker resolves the digest for the service's
 image, and pins the service to that digest. The digest is not shown by
-default, but is printed if `--no-trunc` is used;
+default, but is printed if `--no-trunc` is used. The `--no-trunc` option
+also shows the non-truncated task ID, and error-messages, as can be seen below;
 
 ```bash
 $ docker service ps --no-trunc redis
-NAME                                IMAGE                                                                                NODE      DESIRED STATE  CURRENT STATE
-redis.1.0qihejybwf1x5vqi8lgzlgnpq   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  manager1  Running        Running 28 seconds
-redis.2.bk658fpbex0d57cqcwoe3jthu   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker2   Running        Running 29 seconds
-redis.3.5ls5s5fldaqg37s9pwayjecrf   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker1   Running        Running 29 seconds
-redis.4.8ryt076polmclyihzx67zsssj   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker1   Running        Running 29 seconds
-redis.5.1x0v8yomsncd6sbvfn0ph6ogc   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  manager1  Running        Running 28 seconds
-redis.6.71v7je3el7rrw0osfywzs0lko   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker2   Running        Running 29 seconds
-redis.7.4l3zm9b7tfr7cedaik8roxq6r   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker2   Running        Running 29 seconds
-redis.8.9tfpyixiy2i74ad9uqmzp1q6o   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker1   Running        Running 29 seconds
-redis.9.3w1wu13yuplna8ri3fx47iwad   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  manager1  Running        Running 28 seconds
-redis.10.8eaxrb2fqpbnv9x30vr06i6vt  redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  manager1  Running        Running 28 seconds
+
+ID                          NAME         IMAGE                                                                                NODE      DESIRED STATE  CURRENT STATE            ERROR                                                                                           PORTS
+50qe8lfnxaxksi9w2a704wkp7   redis.1      redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  manager1  Running        Running 5 minutes ago
+ky2re9oz86r9556i2szb8a8af   \_ redis.1   redis:3.0.5@sha256:f8829e00d95672c48c60f468329d6693c4bdd28d1f057e755f8ba8b40008682e  worker2   Shutdown       Shutdown 5 minutes ago
+bk658fpbex0d57cqcwoe3jthu   redis.2      redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker2   Running        Running 5 seconds
+nvjljf7rmor4htv7l8rwcx7i7   \_ redis.2   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker2   Shutdown       Rejected 5 minutes ago   "No such image: redis@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842"
 ```
 
 ## Filtering
@@ -93,9 +114,10 @@ The `id` filter matches on all or a prefix of a task's ID.
 
 ```bash
 $ docker service ps -f "id=8" redis
-NAME                                IMAGE        NODE      DESIRED STATE  CURRENT STATE
-redis.4.8ryt076polmclyihzx67zsssj   redis:3.0.6  worker1   Running        Running 9 seconds
-redis.10.8eaxrb2fqpbnv9x30vr06i6vt  redis:3.0.6  manager1  Running        Running 8 seconds
+
+ID             NAME      IMAGE        NODE      DESIRED STATE  CURRENT STATE      ERROR  PORTS
+8ryt076polmc   redis.4   redis:3.0.6  worker1   Running        Running 9 seconds
+8eaxrb2fqpbn   redis.10  redis:3.0.6  manager1  Running        Running 8 seconds
 ```
 
 #### Name
@@ -104,8 +126,8 @@ The `name` filter matches on task names.
 
 ```bash
 $ docker service ps -f "name=redis.1" redis
-NAME                                IMAGE        NODE      DESIRED STATE  CURRENT STATE
-redis.1.0qihejybwf1x5vqi8lgzlgnpq   redis:3.0.6  manager1  Running        Running 8 seconds
+ID            NAME     IMAGE        NODE      DESIRED STATE  CURRENT STATE      ERROR  PORTS
+qihejybwf1x5  redis.1  redis:3.0.6  manager1  Running        Running 8 seconds
 ```
 
 
@@ -115,11 +137,11 @@ The `node` filter matches on a node name or a node ID.
 
 ```bash
 $ docker service ps -f "node=manager1" redis
-NAME                                IMAGE        NODE      DESIRED STATE  CURRENT STATE
-redis.1.0qihejybwf1x5vqi8lgzlgnpq   redis:3.0.6  manager1  Running        Running 8 seconds
-redis.5.1x0v8yomsncd6sbvfn0ph6ogc   redis:3.0.6  manager1  Running        Running 8 seconds
-redis.9.3w1wu13yuplna8ri3fx47iwad   redis:3.0.6  manager1  Running        Running 8 seconds
-redis.10.8eaxrb2fqpbnv9x30vr06i6vt  redis:3.0.6  manager1  Running        Running 8 seconds
+ID            NAME      IMAGE        NODE      DESIRED STATE  CURRENT STATE      ERROR  PORTS
+0qihejybwf1x  redis.1   redis:3.0.6  manager1  Running        Running 8 seconds
+1x0v8yomsncd  redis.5   redis:3.0.6  manager1  Running        Running 8 seconds
+3w1wu13yupln  redis.9   redis:3.0.6  manager1  Running        Running 8 seconds
+8eaxrb2fqpbn  redis.10  redis:3.0.6  manager1  Running        Running 8 seconds
 ```
 
 


### PR DESCRIPTION
commit bbd2018ee19eff5594ae3986bf56fbcd0044699d (https://github.com/docker/docker/pull/29196) changed the output format of `docker service ps`.

this patch updates the reference docs to match the updated output format.
