### PR TITLE
Fix `docker exec -u` issue after docker daemon restart

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -149,6 +149,10 @@ func (daemon *Daemon) restore() error {
 				continue
 			}
 			container.RWLayer = rwlayer
+			if err := daemon.Mount(container); err != nil {
+				logrus.Errorf("Failed to mount container %v: %v", id, err)
+				continue
+			}
 			logrus.Debugf("Loaded container %v", container.ID)
 
 			containers[container.ID] = container


### PR DESCRIPTION
**- What I did**

This fix tries to address the issue raised in #29342 where `docker exec -u` after docker daemon restart returns an error:
```
unable to find user test: no matching entries in passwd file
```

The reason for the issue is that `container.BaseFS` is not present after restart.

**- How I did it**

This fix adds the `daemon.Mount` during the restore to bring up the `container.BaseFS`.

**- How to verify it**

An integration test has been added to cover the changes.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![c03904d6028381a6bd0d1b1bfd1523bb](https://cloud.githubusercontent.com/assets/6932348/21148112/02bc5d88-c10c-11e6-9659-726170557699.jpg)

This fix fixes #29342.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>