### PR TITLE
[test-integration] Clean utils.go from most of its content

### DIFF
--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/checker"
 	icmd "github.com/docker/docker/pkg/integration/cmd"
 	"github.com/go-check/check"
@@ -545,7 +546,7 @@ func (s *DockerSuite) TestCpToStdout(c *check.C) {
 	// failed to set up container
 	c.Assert(strings.TrimSpace(out), checker.Equals, "0")
 
-	out, _, err := runCommandPipelineWithOutput(
+	out, _, err := integration.RunCommandPipelineWithOutput(
 		exec.Command(dockerBinary, "cp", containerID+":/test", "-"),
 		exec.Command("tar", "-vtf", "-"))
 

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -12,6 +12,7 @@ import (
 
 	"io/ioutil"
 
+	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/go-connections/nat"
@@ -355,7 +356,7 @@ func (s *DockerTrustSuite) TestCreateWhenCertExpired(c *check.C) {
 	// Certificates have 10 years of expiration
 	elevenYearsFromNow := time.Now().Add(time.Hour * 24 * 365 * 11)
 
-	runAtDifferentDate(elevenYearsFromNow, func() {
+	integration.RunAtDifferentDate(elevenYearsFromNow, func() {
 		// Try create
 		createCmd := exec.Command(dockerBinary, "create", repoName)
 		s.trustedCmd(createCmd)
@@ -364,7 +365,7 @@ func (s *DockerTrustSuite) TestCreateWhenCertExpired(c *check.C) {
 		c.Assert(string(out), checker.Contains, "could not validate the path to a trusted root", check.Commentf("Missing expected output on trusted create in the distant future:\n%s", out))
 	})
 
-	runAtDifferentDate(elevenYearsFromNow, func() {
+	integration.RunAtDifferentDate(elevenYearsFromNow, func() {
 		// Try create
 		createCmd := exec.Command(dockerBinary, "create", "--disable-content-trust", repoName)
 		s.trustedCmd(createCmd)

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/daemon"
+	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/checker"
 	icmd "github.com/docker/docker/pkg/integration/cmd"
 	"github.com/docker/docker/pkg/mount"
@@ -235,11 +236,7 @@ func (s *DockerDaemonSuite) TestDaemonStartBridgeWithoutIPAssociation(c *check.C
 	s.d.Stop(c)
 
 	// now we will remove the ip from docker0 and then try starting the daemon
-	ipCmd := exec.Command("ip", "addr", "flush", "dev", "docker0")
-	stdout, stderr, _, err := runCommandWithStdoutStderr(ipCmd)
-	if err != nil {
-		c.Fatalf("failed to remove docker0 IP association: %v, stdout: %q, stderr: %q", err, stdout, stderr)
-	}
+	icmd.RunCommand("ip", "addr", "flush", "dev", "docker0").Assert(c, icmd.Success)
 
 	if err := s.d.StartWithError(); err != nil {
 		warning := "**WARNING: Docker bridge network in bad state--delete docker0 bridge interface to fix"
@@ -668,24 +665,16 @@ func (s *DockerDaemonSuite) TestDaemonBridgeIP(c *check.C) {
 	defer d.Restart(c)
 
 	ifconfigSearchString := ip.String()
-	ifconfigCmd := exec.Command("ifconfig", defaultNetworkBridge)
-	out, _, _, err := runCommandWithStdoutStderr(ifconfigCmd)
-	c.Assert(err, check.IsNil)
-
-	c.Assert(strings.Contains(out, ifconfigSearchString), check.Equals, true,
-		check.Commentf("ifconfig output should have contained %q, but was %q",
-			ifconfigSearchString, out))
+	icmd.RunCommand("ifconfig", defaultNetworkBridge).Assert(c, icmd.Expected{
+		Out: ifconfigSearchString,
+	})
 
 	ipTablesSearchString := bridgeIPNet.String()
-	ipTablesCmd := exec.Command("iptables", "-t", "nat", "-nvL")
-	out, _, err = runCommandWithOutput(ipTablesCmd)
-	c.Assert(err, check.IsNil)
+	icmd.RunCommand("iptables", "-t", "nat", "-nvL").Assert(c, icmd.Expected{
+		Out: ipTablesSearchString,
+	})
 
-	c.Assert(strings.Contains(out, ipTablesSearchString), check.Equals, true,
-		check.Commentf("iptables output should have contained %q, but was %q",
-			ipTablesSearchString, out))
-
-	out, err = d.Cmd("run", "-d", "--name", "test", "busybox", "top")
+	_, err := d.Cmd("run", "-d", "--name", "test", "busybox", "top")
 	c.Assert(err, check.IsNil)
 
 	containerIP, err := d.FindContainerIP("test")
@@ -706,24 +695,15 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithBridgeIPChange(c *check.C) {
 	bridgeIP := "192.169.100.1/24"
 	_, bridgeIPNet, _ := net.ParseCIDR(bridgeIP)
 
-	ipCmd := exec.Command("ifconfig", "docker0", bridgeIP)
-	stdout, stderr, _, err := runCommandWithStdoutStderr(ipCmd)
-	if err != nil {
-		c.Fatalf("failed to change docker0's IP association: %v, stdout: %q, stderr: %q", err, stdout, stderr)
-	}
+	icmd.RunCommand("ifconfig", "docker0", bridgeIP).Assert(c, icmd.Success)
 
 	s.d.Start(c, "--bip", bridgeIP)
 
 	//check if the iptables contains new bridgeIP MASQUERADE rule
 	ipTablesSearchString := bridgeIPNet.String()
-	ipTablesCmd := exec.Command("iptables", "-t", "nat", "-nvL")
-	out, _, err := runCommandWithOutput(ipTablesCmd)
-	if err != nil {
-		c.Fatalf("Could not run iptables -nvL: %s, %v", out, err)
-	}
-	if !strings.Contains(out, ipTablesSearchString) {
-		c.Fatalf("iptables output should have contained new MASQUERADE rule with IP %q, but was %q", ipTablesSearchString, out)
-	}
+	icmd.RunCommand("iptables", "-t", "nat", "-nvL").Assert(c, icmd.Expected{
+		Out: ipTablesSearchString,
+	})
 }
 
 func (s *DockerDaemonSuite) TestDaemonBridgeFixedCidr(c *check.C) {
@@ -1908,7 +1888,7 @@ func (s *DockerDaemonSuite) TestDaemonCgroupParent(c *check.C) {
 
 	out, err := s.d.Cmd("run", "--name", name, "busybox", "cat", "/proc/self/cgroup")
 	c.Assert(err, checker.IsNil)
-	cgroupPaths := parseCgroupPaths(string(out))
+	cgroupPaths := integration.ParseCgroupPaths(string(out))
 	c.Assert(len(cgroupPaths), checker.Not(checker.Equals), 0, check.Commentf("unexpected output - %q", string(out)))
 	out, err = s.d.Cmd("inspect", "-f", "{{.Id}}", name)
 	c.Assert(err, checker.IsNil)

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -14,6 +14,7 @@ import (
 
 	eventtypes "github.com/docker/docker/api/types/events"
 	eventstestutils "github.com/docker/docker/daemon/events/testutils"
+	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/checker"
 	icmd "github.com/docker/docker/pkg/integration/cmd"
 	"github.com/go-check/check"
@@ -221,7 +222,7 @@ func (s *DockerSuite) TestEventsImageImport(c *check.C) {
 	cleanedContainerID := strings.TrimSpace(out)
 
 	since := daemonUnixTime(c)
-	out, _, err := runCommandPipelineWithOutput(
+	out, _, err := integration.RunCommandPipelineWithOutput(
 		exec.Command(dockerBinary, "export", cleanedContainerID),
 		exec.Command(dockerBinary, "import", "-"),
 	)

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -206,6 +206,7 @@ func (s *DockerSuite) TestExecTTYWithoutStdin(c *check.C) {
 	}
 }
 
+// FIXME(vdemeester) this should be a unit tests on cli/command/container package
 func (s *DockerSuite) TestExecParseError(c *check.C) {
 	// TODO Windows CI: Requires some extra work. Consider copying the
 	// runSleepingContainer helper to have an exec version.
@@ -213,10 +214,11 @@ func (s *DockerSuite) TestExecParseError(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", "top", "busybox", "top")
 
 	// Test normal (non-detached) case first
-	cmd := exec.Command(dockerBinary, "exec", "top")
-	_, stderr, _, err := runCommandWithStdoutStderr(cmd)
-	c.Assert(err, checker.NotNil)
-	c.Assert(stderr, checker.Contains, "See 'docker exec --help'")
+	icmd.RunCommand(dockerBinary, "exec", "top").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Error:    "exit status 1",
+		Err:      "See 'docker exec --help'",
+	})
 }
 
 func (s *DockerSuite) TestExecStopNotHanging(c *check.C) {

--- a/integration-cli/docker_cli_import_test.go
+++ b/integration-cli/docker_cli_import_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/checker"
 	icmd "github.com/docker/docker/pkg/integration/cmd"
 	"github.com/go-check/check"
@@ -19,7 +20,7 @@ func (s *DockerSuite) TestImportDisplay(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _, err := runCommandPipelineWithOutput(
+	out, _, err := integration.RunCommandPipelineWithOutput(
 		exec.Command(dockerBinary, "export", cleanedContainerID),
 		exec.Command(dockerBinary, "import", "-"),
 	)
@@ -51,11 +52,10 @@ func (s *DockerSuite) TestImportFile(c *check.C) {
 	c.Assert(err, checker.IsNil, check.Commentf("failed to create temporary file"))
 	defer os.Remove(temporaryFile.Name())
 
-	runCmd := exec.Command(dockerBinary, "export", "test-import")
-	runCmd.Stdout = bufio.NewWriter(temporaryFile)
-
-	_, err = runCommand(runCmd)
-	c.Assert(err, checker.IsNil, check.Commentf("failed to export a container"))
+	icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "export", "test-import"},
+		Stdout:  bufio.NewWriter(temporaryFile),
+	}).Assert(c, icmd.Success)
 
 	out, _ := dockerCmd(c, "import", temporaryFile.Name())
 	c.Assert(out, checker.Count, "\n", 1, check.Commentf("display is expected 1 '\\n' but didn't"))
@@ -73,14 +73,12 @@ func (s *DockerSuite) TestImportGzipped(c *check.C) {
 	c.Assert(err, checker.IsNil, check.Commentf("failed to create temporary file"))
 	defer os.Remove(temporaryFile.Name())
 
-	runCmd := exec.Command(dockerBinary, "export", "test-import")
 	w := gzip.NewWriter(temporaryFile)
-	runCmd.Stdout = w
-
-	_, err = runCommand(runCmd)
-	c.Assert(err, checker.IsNil, check.Commentf("failed to export a container"))
-	err = w.Close()
-	c.Assert(err, checker.IsNil, check.Commentf("failed to close gzip writer"))
+	icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "export", "test-import"},
+		Stdout:  w,
+	}).Assert(c, icmd.Success)
+	c.Assert(w.Close(), checker.IsNil, check.Commentf("failed to close gzip writer"))
 	temporaryFile.Close()
 	out, _ := dockerCmd(c, "import", temporaryFile.Name())
 	c.Assert(out, checker.Count, "\n", 1, check.Commentf("display is expected 1 '\\n' but didn't"))
@@ -98,11 +96,10 @@ func (s *DockerSuite) TestImportFileWithMessage(c *check.C) {
 	c.Assert(err, checker.IsNil, check.Commentf("failed to create temporary file"))
 	defer os.Remove(temporaryFile.Name())
 
-	runCmd := exec.Command(dockerBinary, "export", "test-import")
-	runCmd.Stdout = bufio.NewWriter(temporaryFile)
-
-	_, err = runCommand(runCmd)
-	c.Assert(err, checker.IsNil, check.Commentf("failed to export a container"))
+	icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "export", "test-import"},
+		Stdout:  bufio.NewWriter(temporaryFile),
+	}).Assert(c, icmd.Success)
 
 	message := "Testing commit message"
 	out, _ := dockerCmd(c, "import", "-m", message, temporaryFile.Name())

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/integration/checker"
+	icmd "github.com/docker/docker/pkg/integration/cmd"
 	"github.com/go-check/check"
 )
 
@@ -142,11 +142,12 @@ func (s *DockerSuite) TestInspectImageFilterInt(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectContainerFilterInt(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-i", "-a", "stdin", "busybox", "cat")
-	runCmd.Stdin = strings.NewReader("blahblah")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	c.Assert(err, checker.IsNil, check.Commentf("failed to run container: %v, output: %q", err, out))
-
+	result := icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "run", "-i", "-a", "stdin", "busybox", "cat"},
+		Stdin:   strings.NewReader("blahblah"),
+	})
+	result.Assert(c, icmd.Success)
+	out := result.Stdout()
 	id := strings.TrimSpace(out)
 
 	out = inspectField(c, id, "State.ExitCode")
@@ -157,9 +158,9 @@ func (s *DockerSuite) TestInspectContainerFilterInt(c *check.C) {
 	//now get the exit code to verify
 	formatStr := fmt.Sprintf("--format={{eq .State.ExitCode %d}}", exitCode)
 	out, _ = dockerCmd(c, "inspect", formatStr, id)
-	result, err := strconv.ParseBool(strings.TrimSuffix(out, "\n"))
+	inspectResult, err := strconv.ParseBool(strings.TrimSuffix(out, "\n"))
 	c.Assert(err, checker.IsNil)
-	c.Assert(result, checker.Equals, true)
+	c.Assert(inspectResult, checker.Equals, true)
 }
 
 func (s *DockerSuite) TestInspectImageGraphDriver(c *check.C) {

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/docker/runconfig"
 	"github.com/go-check/check"
@@ -101,7 +102,7 @@ func (s *DockerSuite) TestLinksInspectLinksStarted(c *check.C) {
 	err := json.Unmarshal([]byte(links), &result)
 	c.Assert(err, checker.IsNil)
 
-	output := convertSliceOfStringsToMap(result)
+	output := integration.ConvertSliceOfStringsToMap(result)
 
 	c.Assert(output, checker.DeepEquals, expected)
 }
@@ -120,7 +121,7 @@ func (s *DockerSuite) TestLinksInspectLinksStopped(c *check.C) {
 	err := json.Unmarshal([]byte(links), &result)
 	c.Assert(err, checker.IsNil)
 
-	output := convertSliceOfStringsToMap(result)
+	output := integration.ConvertSliceOfStringsToMap(result)
 
 	c.Assert(output, checker.DeepEquals, expected)
 }

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/docker/pkg/jsonlog"
 	"github.com/go-check/check"
@@ -253,11 +254,11 @@ func (s *DockerSuite) TestLogsFollowSlowStdoutConsumer(c *check.C) {
 	c.Assert(logCmd.Start(), checker.IsNil)
 
 	// First read slowly
-	bytes1, err := consumeWithSpeed(stdout, 10, 50*time.Millisecond, stopSlowRead)
+	bytes1, err := integration.ConsumeWithSpeed(stdout, 10, 50*time.Millisecond, stopSlowRead)
 	c.Assert(err, checker.IsNil)
 
 	// After the container has finished we can continue reading fast
-	bytes2, err := consumeWithSpeed(stdout, 32*1024, 0, nil)
+	bytes2, err := integration.ConsumeWithSpeed(stdout, 32*1024, 0, nil)
 	c.Assert(err, checker.IsNil)
 
 	actual := bytes1 + bytes2

--- a/integration-cli/docker_cli_pull_trusted_test.go
+++ b/integration-cli/docker_cli_pull_trusted_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
@@ -69,7 +70,7 @@ func (s *DockerTrustSuite) TestPullWhenCertExpired(c *check.C) {
 	// Certificates have 10 years of expiration
 	elevenYearsFromNow := time.Now().Add(time.Hour * 24 * 365 * 11)
 
-	runAtDifferentDate(elevenYearsFromNow, func() {
+	integration.RunAtDifferentDate(elevenYearsFromNow, func() {
 		// Try pull
 		pullCmd := exec.Command(dockerBinary, "pull", repoName)
 		s.trustedCmd(pullCmd)
@@ -79,7 +80,7 @@ func (s *DockerTrustSuite) TestPullWhenCertExpired(c *check.C) {
 		c.Assert(string(out), checker.Contains, "could not validate the path to a trusted root", check.Commentf(out))
 	})
 
-	runAtDifferentDate(elevenYearsFromNow, func() {
+	integration.RunAtDifferentDate(elevenYearsFromNow, func() {
 		// Try pull
 		pullCmd := exec.Command(dockerBinary, "pull", "--disable-content-trust", repoName)
 		s.trustedCmd(pullCmd)
@@ -166,7 +167,7 @@ func (s *DockerTrustSuite) TestTrustedPullWithExpiredSnapshot(c *check.C) {
 	// Snapshots last for three years. This should be expired
 	fourYearsLater := time.Now().Add(time.Hour * 24 * 365 * 4)
 
-	runAtDifferentDate(fourYearsLater, func() {
+	integration.RunAtDifferentDate(fourYearsLater, func() {
 		// Try pull
 		pullCmd := exec.Command(dockerBinary, "pull", repoName)
 		s.trustedCmd(pullCmd)

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	cliconfig "github.com/docker/docker/cli/config"
+	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
@@ -437,7 +438,7 @@ func (s *DockerTrustSuite) TestTrustedPushWithExpiredSnapshot(c *check.C) {
 	// Snapshots last for three years. This should be expired
 	fourYearsLater := time.Now().Add(time.Hour * 24 * 365 * 4)
 
-	runAtDifferentDate(fourYearsLater, func() {
+	integration.RunAtDifferentDate(fourYearsLater, func() {
 		// Push with wrong passphrases
 		pushCmd = exec.Command(dockerBinary, "push", repoName)
 		s.trustedCmd(pushCmd)
@@ -464,7 +465,7 @@ func (s *DockerTrustSuite) TestTrustedPushWithExpiredTimestamp(c *check.C) {
 	threeWeeksLater := time.Now().Add(time.Hour * 24 * 21)
 
 	// Should succeed because the server transparently re-signs one
-	runAtDifferentDate(threeWeeksLater, func() {
+	integration.RunAtDifferentDate(threeWeeksLater, func() {
 		pushCmd := exec.Command(dockerBinary, "push", repoName)
 		s.trustedCmd(pushCmd)
 		out, _, err := runCommandWithOutput(pushCmd)

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -71,9 +71,7 @@ func (s *DockerSuite) TestRunWithVolumesIsRecursive(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer f.Close()
 
-	runCmd := exec.Command(dockerBinary, "run", "--name", "test-data", "--volume", fmt.Sprintf("%s:/tmp:ro", tmpDir), "busybox:latest", "ls", "/tmp/tmpfs")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	c.Assert(err, checker.IsNil)
+	out, _ := dockerCmd(c, "run", "--name", "test-data", "--volume", fmt.Sprintf("%s:/tmp:ro", tmpDir), "busybox:latest", "ls", "/tmp/tmpfs")
 	c.Assert(out, checker.Contains, filepath.Base(f.Name()), check.Commentf("Recursive bind mount test failed. Expected file not found"))
 }
 

--- a/integration-cli/docker_cli_save_load_unix_test.go
+++ b/integration-cli/docker_cli_save_load_unix_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/integration/checker"
+	icmd "github.com/docker/docker/pkg/integration/cmd"
 	"github.com/go-check/check"
 	"github.com/kr/pty"
 )
@@ -29,11 +30,10 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer os.Remove(tmpFile.Name())
 
-	saveCmd := exec.Command(dockerBinary, "save", repoName)
-	saveCmd.Stdout = tmpFile
-
-	_, err = runCommand(saveCmd)
-	c.Assert(err, check.IsNil)
+	icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "save", repoName},
+		Stdout:  tmpFile,
+	}).Assert(c, icmd.Success)
 
 	tmpFile, err = os.Open(tmpFile.Name())
 	c.Assert(err, check.IsNil)

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/docker/docker/pkg/integration/checker"
+	icmd "github.com/docker/docker/pkg/integration/cmd"
 	"github.com/go-check/check"
 )
 
@@ -182,8 +182,13 @@ func (s *DockerSuite) TestStartAttachWithRename(c *check.C) {
 		dockerCmd(c, "rename", "before", "after")
 		dockerCmd(c, "stop", "--time=2", "after")
 	}()
-	_, stderr, _, _ := runCommandWithStdoutStderr(exec.Command(dockerBinary, "start", "-a", "before"))
-	c.Assert(stderr, checker.Not(checker.Contains), "No such container")
+	// FIXME(vdemeester) the intent is not clear and potentially racey
+	result := icmd.RunCommand(dockerBinary, "start", "-a", "before")
+	result.Assert(c, icmd.Expected{
+		ExitCode: 137,
+		Error:    "exit status 137",
+	})
+	c.Assert(result.Stderr(), checker.Not(checker.Contains), "No such container")
 }
 
 func (s *DockerSuite) TestStartReturnCorrectExitCode(c *check.C) {

--- a/integration-cli/docker_cli_userns_test.go
+++ b/integration-cli/docker_cli_userns_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/system"
@@ -61,12 +62,12 @@ func (s *DockerDaemonSuite) TestDaemonUserNamespaceRootSetting(c *check.C) {
 	c.Assert(err, checker.IsNil, check.Commentf("Could not inspect running container: out: %q", pid))
 	// check the uid and gid maps for the PID to ensure root is remapped
 	// (cmd = cat /proc/<pid>/uid_map | grep -E '0\s+9999\s+1')
-	out, rc1, err := runCommandPipelineWithOutput(
+	out, rc1, err := integration.RunCommandPipelineWithOutput(
 		exec.Command("cat", "/proc/"+strings.TrimSpace(pid)+"/uid_map"),
 		exec.Command("grep", "-E", fmt.Sprintf("0[[:space:]]+%d[[:space:]]+", uid)))
 	c.Assert(rc1, checker.Equals, 0, check.Commentf("Didn't match uid_map: output: %s", out))
 
-	out, rc2, err := runCommandPipelineWithOutput(
+	out, rc2, err := integration.RunCommandPipelineWithOutput(
 		exec.Command("cat", "/proc/"+strings.TrimSpace(pid)+"/gid_map"),
 		exec.Command("grep", "-E", fmt.Sprintf("0[[:space:]]+%d[[:space:]]+", gid)))
 	c.Assert(rc2, checker.Equals, 0, check.Commentf("Didn't match gid_map: output: %s", out))

--- a/integration-cli/docker_deprecated_api_v124_test.go
+++ b/integration-cli/docker_deprecated_api_v124_test.go
@@ -45,7 +45,7 @@ func (s *DockerSuite) TestDeprecatedContainerAPIStartVolumeBinds(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusCreated)
 
-	bindPath := randomTmpDirPath("test", daemonPlatform)
+	bindPath := integration.RandomTmpDirPath("test", daemonPlatform)
 	config = map[string]interface{}{
 		"Binds": []string{bindPath + ":" + path},
 	}
@@ -72,8 +72,8 @@ func (s *DockerSuite) TestDeprecatedContainerAPIStartDupVolumeBinds(c *check.C) 
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusCreated)
 
-	bindPath1 := randomTmpDirPath("test1", daemonPlatform)
-	bindPath2 := randomTmpDirPath("test2", daemonPlatform)
+	bindPath1 := integration.RandomTmpDirPath("test1", daemonPlatform)
+	bindPath2 := integration.RandomTmpDirPath("test2", daemonPlatform)
 
 	config = map[string]interface{}{
 		"Binds": []string{bindPath1 + ":/tmp", bindPath2 + ":/tmp"},

--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -1,13 +1,8 @@
 package main
 
 import (
-	"io"
-	"os"
-	"os/exec"
-	"time"
-
-	"github.com/docker/docker/pkg/integration"
 	"github.com/docker/docker/pkg/integration/cmd"
+	"os/exec"
 )
 
 func getPrefixAndSlashFromDaemonPlatform() (prefix, slash string) {
@@ -23,18 +18,6 @@ func runCommandWithOutput(execCmd *exec.Cmd) (string, int, error) {
 	return result.Combined(), result.ExitCode, result.Error
 }
 
-// TODO: update code to call cmd.RunCmd directly, and remove this function
-func runCommandWithStdoutStderr(execCmd *exec.Cmd) (string, string, int, error) {
-	result := cmd.RunCmd(transformCmd(execCmd))
-	return result.Stdout(), result.Stderr(), result.ExitCode, result.Error
-}
-
-// TODO: update code to call cmd.RunCmd directly, and remove this function
-func runCommand(execCmd *exec.Cmd) (exitCode int, err error) {
-	result := cmd.RunCmd(transformCmd(execCmd))
-	return result.ExitCode, result.Error
-}
-
 // Temporary shim for migrating commands to the new function
 func transformCmd(execCmd *exec.Cmd) cmd.Cmd {
 	return cmd.Cmd{
@@ -44,36 +27,4 @@ func transformCmd(execCmd *exec.Cmd) cmd.Cmd {
 		Stdin:   execCmd.Stdin,
 		Stdout:  execCmd.Stdout,
 	}
-}
-
-func runCommandPipelineWithOutput(cmds ...*exec.Cmd) (output string, exitCode int, err error) {
-	return integration.RunCommandPipelineWithOutput(cmds...)
-}
-
-func convertSliceOfStringsToMap(input []string) map[string]struct{} {
-	return integration.ConvertSliceOfStringsToMap(input)
-}
-
-func compareDirectoryEntries(e1 []os.FileInfo, e2 []os.FileInfo) error {
-	return integration.CompareDirectoryEntries(e1, e2)
-}
-
-func listTar(f io.Reader) ([]string, error) {
-	return integration.ListTar(f)
-}
-
-func randomTmpDirPath(s string, platform string) string {
-	return integration.RandomTmpDirPath(s, platform)
-}
-
-func consumeWithSpeed(reader io.Reader, chunkSize int, interval time.Duration, stop chan bool) (n int, err error) {
-	return integration.ConsumeWithSpeed(reader, chunkSize, interval, stop)
-}
-
-func parseCgroupPaths(procCgroupData string) map[string]string {
-	return integration.ParseCgroupPaths(procCgroupData)
-}
-
-func runAtDifferentDate(date time.Time, block func()) {
-	integration.RunAtDifferentDate(date, block)
 }


### PR DESCRIPTION
Most of the code is now on pkg/integration. The last function of `utils.go` is `runCommandWithOutput` and is used 236 times, so… this will be a PR by itself :angel: 

/cc @dnephin @thaJeztah @vieux @mavenugo @tiborvass 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>