### PR TITLE
Allow user to specify default address pools for docker networks

### DIFF
--- a/cmd/dockerd/config_unix.go
+++ b/cmd/dockerd/config_unix.go
@@ -46,6 +46,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.Int64Var(&conf.CPURealtimeRuntime, "cpu-rt-runtime", 0, "Limit the CPU real-time runtime in microseconds")
 	flags.StringVar(&conf.SeccompProfile, "seccomp-profile", "", "Path to seccomp profile")
 	flags.Var(&conf.ShmSize, "default-shm-size", "Default shm size for containers")
+	flags.Var(opts.NewPoolsOpt(&conf.NetworkConfig.DefaultAddressPools), "default-address-pools", "Set the default address pools for local/global scope networks")
 
 	attachExperimentalFlags(conf, flags)
 }

--- a/daemon/config/config_unix.go
+++ b/daemon/config/config_unix.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/docker/opts"
 	units "github.com/docker/go-units"
+	"github.com/docker/libnetwork/ipamutils"
 )
 
 // Config defines the configuration of a docker daemon.
@@ -17,6 +18,8 @@ type Config struct {
 
 	// These fields are common to all unix platforms.
 	CommonUnixConfig
+
+	NetworkConfig
 
 	// Fields below here are platform specific.
 	CgroupParent         string                   `json:"cgroup-parent,omitempty"`
@@ -51,6 +54,12 @@ type BridgeConfig struct {
 	FixedCIDRv6         string `json:"fixed-cidr-v6,omitempty"`
 }
 
+// NetworkConfig stores the daemon-wide networking configurations
+type NetworkConfig struct {
+	// Default address pools for docker networks
+	DefaultAddressPools []*ipamutils.PredefinedPools `json:"default-address-pools,omitempty"`
+}
+
 // IsSwarmCompatible defines if swarm mode can be enabled in this config
 func (conf *Config) IsSwarmCompatible() error {
 	if conf.ClusterStore != "" || conf.ClusterAdvertise != "" {
@@ -60,4 +69,12 @@ func (conf *Config) IsSwarmCompatible() error {
 		return fmt.Errorf("--live-restore daemon configuration is incompatible with swarm mode")
 	}
 	return nil
+}
+
+// ProcessPoolsConfig applies the default address pools configuration, if present
+func (conf *Config) ProcessPoolsConfig() error {
+	if len(conf.NetworkConfig.DefaultAddressPools) == 0 {
+		return nil
+	}
+	return ipamutils.InitAddressPools(conf.NetworkConfig.DefaultAddressPools)
 }

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -725,6 +725,10 @@ func configureKernelSecuritySupport(config *config.Config, driverName string) er
 }
 
 func (daemon *Daemon) initNetworkController(config *config.Config, activeSandboxes map[string]interface{}) (libnetwork.NetworkController, error) {
+	if err := config.ProcessPoolsConfig(); err != nil {
+		return nil, err
+	}
+
 	netOptions, err := daemon.networkOptions(config, daemon.PluginStore, activeSandboxes)
 	if err != nil {
 		return nil, err

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -34,6 +34,7 @@ Options:
       --config-file string                    Daemon configuration file (default "/etc/docker/daemon.json")
       --containerd string                     Path to containerd socket
   -D, --debug                                 Enable debug mode
+      --default-address-pools value           Set the default address pools for local/global scope networks
       --default-gateway value                 Container default gateway IPv4 address
       --default-gateway-v6 value              Container default gateway IPv6 address
       --default-runtime string                Default OCI runtime for containers (default "runc")

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -18,6 +18,7 @@ dockerd - Enable daemon mode
 [**--config-file**[=*/etc/docker/daemon.json*]]
 [**--containerd**[=*SOCKET-PATH*]]
 [**-D**|**--debug**]
+[**--default-address-pools**[=*DEFAULT-ADDRESS-POOLS*]]
 [**--default-gateway**[=*DEFAULT-GATEWAY*]]
 [**--default-gateway-v6**[=*DEFAULT-GATEWAY-V6*]]
 [**--default-runtime**[=*runc*]]
@@ -154,6 +155,11 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 
 **-D**, **--debug**=*true*|*false*
   Enable debug mode. Default is false.
+
+**--default-address-pools**=""
+  Default address pools from which IPAM driver selects a subnet for the networks.
+  Example: scope=[local|global],base=172.30.0.0/16,size=24 will set the default
+  address pools for the selected scope networks to {172.30.[0-255].0/24}
 
 **--default-gateway**=""
   IPv4 address of the container default gateway; this address must be part of

--- a/opts/address_pools.go
+++ b/opts/address_pools.go
@@ -1,0 +1,84 @@
+package opts
+
+import (
+	"encoding/csv"
+	"fmt"
+	"strconv"
+	"strings"
+
+	types "github.com/docker/libnetwork/ipamutils"
+)
+
+// PoolsOpt is a Value type for parsing the default address pools definitions
+type PoolsOpt struct {
+	values *[]*types.PredefinedPools
+}
+
+// NewPoolsOpt creates a new PoolsOpt
+func NewPoolsOpt(ref *[]*types.PredefinedPools) *PoolsOpt {
+	return &PoolsOpt{values: ref}
+}
+
+// Set predefined pools
+func (p *PoolsOpt) Set(value string) error {
+	csvReader := csv.NewReader(strings.NewReader(value))
+	fields, err := csvReader.Read()
+	if err != nil {
+		return err
+	}
+
+	poolsDef := types.PredefinedPools{}
+
+	for _, field := range fields {
+		parts := strings.SplitN(field, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("ninvalid field '%s' must be a key=value pair", field)
+		}
+
+		key := strings.ToLower(parts[0])
+		value := strings.ToLower(parts[1])
+
+		switch key {
+		case "scope":
+			poolsDef.Scope = value
+		case "base":
+			poolsDef.Base = value
+		case "size":
+			size, err := strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("invalid size value: %q (must be integer): %v", value, err)
+			}
+			poolsDef.Size = size
+		default:
+			return fmt.Errorf("unexpected key '%s' in '%s'", key, field)
+		}
+	}
+
+	*p.values = append(*p.values, &poolsDef)
+
+	return nil
+}
+
+// Type returns the type of this option
+func (p *PoolsOpt) Type() string {
+	return "default-address-pools"
+}
+
+// String returns a string repr of this option
+func (p *PoolsOpt) String() string {
+	pools := []string{}
+	for _, pool := range *p.values {
+		repr := fmt.Sprintf("%s %s %s", pool.Scope, pool.Base, pool.Size)
+		pools = append(pools, repr)
+	}
+	return strings.Join(pools, ", ")
+}
+
+// Value returns the mounts
+func (p *PoolsOpt) Value() []*types.PredefinedPools {
+	var pd []*types.PredefinedPools
+	for _, p := range *p.values {
+		pd = append(pd, p)
+	}
+	return pd
+}


### PR DESCRIPTION
**- Description**
When user creates a network without specifying a `--subnet`, docker will pick a subnet for the network from the static set `172.[17-31].0.0/16` and `192.168.[0-240].0/20` for the local scope networks and from the static set `10.[0-255].[0-255].0/24` for the global scope networks.

For different reasons, several users have asked to be able to control these defaults.
This PR brings in a change to allow users to control the default address pools at daemon boot.

As an example,
 `dockerd --default-address-pools scope=local,base=10.10.0.0/16,size=24`
would allow user to set the 256 pools 10.10.[0-255].0/24 as default for the local scope networks.

Multiple `--default-address-pools` with `scope=[local|global]` can be specified.
To specify the option in the config json file:
```
{"default-address-pools":[{"scope":"local","base":"172.80.0.0/16","size":24},{"scope":"global","base":"172.90.0.0/16","size":24}]}
```

**- Notes**
Fixes #21776 

**- A picture of a cute animal (not mandatory but encouraged)**

![canenero](https://cloud.githubusercontent.com/assets/10080882/21162822/34463f80-c144-11e6-8a8f-0f789644d9f7.jpg)
