### PR TITLE
skip empty networks in plugin install

### DIFF
--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -125,7 +125,7 @@ func computePrivileges(pd distribution.PullData) (types.PluginPrivileges, error)
 	}
 
 	var privileges types.PluginPrivileges
-	if c.Network.Type != "null" && c.Network.Type != "bridge" {
+	if c.Network.Type != "null" && c.Network.Type != "bridge" && c.Network.Type != "" {
 		privileges = append(privileges, types.PluginPrivilege{
 			Name:        "network",
 			Description: "permissions to access a network",


### PR DESCRIPTION
to avoid

```
$ docker plugin install tiborvass/sample-volume-plugin
Plugin "tiborvass/sample-volume-plugin" is requesting the following privileges:
- network: []
Do you grant the above permissions? [y/N] 
```

ping @anusha-ragunathan @tiborvass 