### PR TITLE
mkimage: add debian security updates source when available

### DIFF
--- a/contrib/mkimage/debootstrap
+++ b/contrib/mkimage/debootstrap
@@ -193,7 +193,7 @@ if [ -z "$DONT_TOUCH_SOURCES_LIST" ]; then
 	case "$lsbDist" in
 		debian)
 			# updates and security!
-			if [ "$suite" != 'sid' -a "$suite" != 'unstable' ]; then
+			if curl -o /dev/null -s --head --fail "http://security.debian.org/dists/$suite/updates/main/binary-$(rootfs_chroot dpkg --print-architecture)/Packages.gz"; then
 				(
 					set -x
 					sed -i "


### PR DESCRIPTION
**- What I did**
This change checks validity of debian updates source line before appending it to the built chroot. In debian wheezy, only some of its official architectures have updates channel. So when running a multiarched build of debian images, it fails to retrieve apt files for wheezy mips/mipsel/powerpc/s390x. See http://security.debian.org/dists/wheezy/updates/main/ for the supported list for Wheezy. Stretch has updates channel for all its official architectures.

**- How I did it**
Use curl to detect whether a remote file under the targeting folder exists.

**- How to verify it**
https://travis-ci.org/vicamo/docker-brew-debian/builds/183813495

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://scontent-mia1-1.xx.fbcdn.net/v/t31.0-8/13580462_10207044514698919_7111333069181894170_o.jpg?oh=633766db2efe0914ec884bdf43ba06c0&oe=58E4B1F6)

Signed-off-by: You-Sheng Yang (楊有勝) <vicamo@gmail.com>