### PR TITLE
oci/namespace: remove unnecessary variable idx

### DIFF
--- a/oci/namespaces.go
+++ b/oci/namespaces.go
@@ -4,13 +4,10 @@ import specs "github.com/opencontainers/runtime-spec/specs-go"
 
 // RemoveNamespace removes the `nsType` namespace from OCI spec `s`
 func RemoveNamespace(s *specs.Spec, nsType specs.NamespaceType) {
-	idx := -1
 	for i, n := range s.Linux.Namespaces {
 		if n.Type == nsType {
-			idx = i
+			s.Linux.Namespaces = append(s.Linux.Namespaces[:i], s.Linux.Namespaces[i+1:]...)
+			return
 		}
-	}
-	if idx >= 0 {
-		s.Linux.Namespaces = append(s.Linux.Namespaces[:idx], s.Linux.Namespaces[idx+1:]...)
 	}
 }


### PR DESCRIPTION
**- What I did**
Remove unnecessary variable `idx` from oci/namespaces.go
**- How I did it**

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>