### PR TITLE
Fix volume label maybe will missed in volume list

### DIFF
--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -85,6 +85,32 @@ func New(rootPath string) (*VolumeStore, error) {
 		}); err != nil {
 			return nil, err
 		}
+
+		// retrive volume labels stored in bucket
+		if err := vs.db.Update(func(tx *bolt.Tx) error {
+			b := tx.Bucket([]byte(volumeBucketName))
+			if err := b.ForEach(func(k, v []byte) error {
+				name := string(k)
+				if name == "" || string(v) == "" {
+					return nil
+				}
+
+				var meta volumeMetadata
+				buf := bytes.NewBuffer(v)
+
+				if err := json.NewDecoder(buf).Decode(&meta); err != nil {
+					return err
+				}
+				vs.labels[name] = meta.Labels
+
+				return nil
+			}); err != nil {
+				return err
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
 	}
 
 	return vs, nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix volume label maybe will missed in volume list.

**- How I did it**

Retrive volume metadata when `VolumeStore` is created.

**- How to verify it**

1. Create a labeled volume `uuz`, and we can see his labels in volume list.

```
# docker volume ls
DRIVER              VOLUME NAME
# docker volume create --name uuz --label saigyouji.yuyuko=uuz
uuz
# curl 127.0.0.1:2375/volumes | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   163  100   163    0     0  30501      0 --:--:-- --:--:-- --:--:-- 32600
{
  "Volumes": [
    {
      "Name": "uuz",
      "Driver": "local",
      "Mountpoint": "/var/lib/docker/volumes/uuz/_data",
      "Labels": {
        "saigyouji.yuyuko": "uuz"
      },
      "Scope": "local"
    }
  ],
  "Warnings": null
}
```

2. When I restart the docker daemon, and fetch volume list again, his label is displayed yet.
But it will missed in latest release.

```
# systemctl restart docker
root@ubuntu16041:~# curl 127.0.0.1:2375/volumes | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   141  100   141    0     0  24858      0 --:--:-- --:--:-- --:--:-- 28200
{
  "Volumes": [
    {
      "Name": "uuz",
      "Driver": "local",
      "Mountpoint": "/var/lib/docker/volumes/uuz/_data",
      "Labels": {
        "saigyouji.yuyuko": "uuz"
      },
      "Scope": "local"
    }
  ],
  "Warnings": null
}
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix volume label maybe will missed in volume list.

**- A picture of a cute animal (not mandatory but encouraged)**

