### PR TITLE
Fix race on sending stdin close event

### DIFF
--- a/libcontainerd/container_linux.go
+++ b/libcontainerd/container_linux.go
@@ -117,10 +117,14 @@ func (ctr *container) start(attachStdio StdioCallback) error {
 			go func() {
 				select {
 				case <-ready:
+				case <-ctx.Done():
+				}
+				select {
+				case <-ready:
 					if err := ctr.sendCloseStdin(); err != nil {
 						logrus.Warnf("failed to close stdin: %+v", err)
 					}
-				case <-ctx.Done():
+				default:
 				}
 			}()
 		})


### PR DESCRIPTION
backport #28682

@vieux 

Fix https://github.com/docker/docker/issues/29421

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
(cherry picked from commit 4e262f63876018ca78d54a98eee3f533352b0ac9)