### PR TITLE
[1.12.x] ppc64le, update gopath to include vendor

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -94,7 +94,7 @@ RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" \
 	| tar -xzC /usr/local
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
-ENV GOPATH /go
+ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 
 # This has been commented out and kept as reference because we don't support compiling with older Go anymore.
 # ENV GOFMT_VERSION 1.3.3


### PR DESCRIPTION
The vendor change doesn't happen until 1.13.0, so include vendor in GOPATH.
Fixes building on ppc64le for 1.12.x.

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>