### PR TITLE
Remove unuse slice in registry

### DIFF
--- a/registry/types.go
+++ b/registry/types.go
@@ -5,15 +5,12 @@ import (
 	"github.com/docker/docker/reference"
 )
 
-// RepositoryData tracks the image list, list of endpoints, and list of tokens
-// for a repository
+// RepositoryData tracks the image list, list of endpoints for a repository
 type RepositoryData struct {
 	// ImgList is a list of images in the repository
 	ImgList map[string]*ImgData
 	// Endpoints is a list of endpoints returned in X-Docker-Endpoints
 	Endpoints []string
-	// Tokens is currently unused (remove it?)
-	Tokens []string
 }
 
 // ImgData is used to transfer image checksums to and from the registry


### PR DESCRIPTION
**- What I did**
Slice Tokens is currently unused in registry.  I suggest that remove Tokens.  

**- How I did it**

**- How to verify it**

**- Description for the changelog**


Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>