### PR TITLE
Fix docker update clear restart policy of monitor

### DIFF
--- a/daemon/update.go
+++ b/daemon/update.go
@@ -67,7 +67,9 @@ func (daemon *Daemon) update(name string, hostConfig *container.HostConfig) erro
 	}
 
 	// if Restart Policy changed, we need to update container monitor
-	container.UpdateMonitor(hostConfig.RestartPolicy)
+	if hostConfig.RestartPolicy.Name != "" {
+		container.UpdateMonitor(hostConfig.RestartPolicy)
+	}
 
 	// If container is not running, update hostConfig struct is enough,
 	// resources will be updated when the container is started again.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix docker update clear restart policy of monitor.

 If a container has a `always` restart policy, and
 then use `docker update` to update the cgroup resource
  limit, the container will not restart if it fail.

To repruduce：
```
[lei@fedora docker]$ docker run -tid --restart always --name foo busybox
bfc71b7f2d228e379b24a74bb8fb7524d3b2240b3f6c15623825d05ef558b91d
[lei@fedora docker]$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
bfc71b7f2d22        busybox             "sh"                2 seconds ago       Up 1 seconds                            foo
[lei@fedora docker]$ docker update --cpu-shares 512 foo
foo
[lei@fedora docker]$ docker attach foo
/ # exit
[lei@fedora docker]$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
[lei@fedora docker]$

```

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: Lei Jitang <leijitang@huawei.com>