### PR TITLE
Dockerfile.s390x: Change base to debian jessie

### DIFF
--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -15,7 +15,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM s390x/gcc:6.1
+FROM s390x/debian:jessie
 
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \
@@ -49,15 +49,6 @@ RUN apt-get update && apt-get install -y \
 	tar \
 	vim-common \
 	--no-install-recommends
-
-# glibc in Debian has a bug specific to s390x that won't be fixed until Debian 8.6 is released
-# - https://github.com/docker/docker/issues/24748
-# - https://sourceware.org/git/?p=glibc.git;a=commit;h=890b7a4b33d482b5c768ab47d70758b80227e9bc
-# - https://sourceware.org/git/?p=glibc.git;a=commit;h=2e807f29595eb5b1e5d0decc6e356a3562ecc58e
-RUN echo 'deb http://httpredir.debian.org/debian jessie-proposed-updates main' >> /etc/apt/sources.list.d/pu.list \
-	&& apt-get update \
-	&& apt-get install -y libc6 \
-	&& rm -rf /var/lib/apt/lists/*
 
 # Install seccomp: the version shipped in jessie is too old
 ENV SECCOMP_VERSION 2.3.1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Changed the s390 Dockerfile for the build process to be on par with other architectures.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


With commit ee59f25c2d503cd68262679250387e140171c685 we changed from
gcc-go to golang 1.7. By switching to debian we can reduce the base
layer from 1.4 GB to around 130 MB.

Signed-off-by: Dominik Dingel <dingel@linux.vnet.ibm.com>