### PR TITLE
Fix misleading defaults for service create/update

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -84,7 +84,7 @@ func (d *DurationOpt) String() string {
 	if d.value != nil {
 		return d.value.String()
 	}
-	return "none"
+	return ""
 }
 
 // Value returns the time.Duration
@@ -114,7 +114,7 @@ func (i *Uint64Opt) String() string {
 	if i.value != nil {
 		return fmt.Sprintf("%v", *i.value)
 	}
-	return "none"
+	return ""
 }
 
 // Value returns the uint64

--- a/cli/command/service/opts_test.go
+++ b/cli/command/service/opts_test.go
@@ -59,7 +59,7 @@ func TestUint64OptString(t *testing.T) {
 	assert.Equal(t, opt.String(), "2345678")
 
 	opt = Uint64Opt{}
-	assert.Equal(t, opt.String(), "none")
+	assert.Equal(t, opt.String(), "")
 }
 
 func TestUint64OptSetAndValue(t *testing.T) {

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -31,9 +31,9 @@ Options:
       --env-file list                    Read in a file of environment variables (default [])
       --group list                       Set one or more supplementary user groups for the container (default [])
       --health-cmd string                Command to run to check health
-      --health-interval duration         Time between running the check (ns|us|ms|s|m|h) (default none)
+      --health-interval duration         Time between running the check (ns|us|ms|s|m|h)
       --health-retries int               Consecutive failures needed to report unhealthy
-      --health-timeout duration          Maximum time to allow one check to run (ns|us|ms|s|m|h) (default none)
+      --health-timeout duration          Maximum time to allow one check to run (ns|us|ms|s|m|h)
       --help                             Print usage
       --host list                        Set one or more custom host-to-IP mappings (host:ip) (default [])
       --hostname string                  Container hostname
@@ -47,16 +47,16 @@ Options:
       --name string                      Service name
       --network list                     Network attachments (default [])
       --no-healthcheck                   Disable any container-specified HEALTHCHECK
-  -p, --publish list                     Publish a port as a node port (default [])
-      --replicas uint                    Number of tasks (default none)
+  -p, --publish port                     Publish a port as a node port
+      --replicas uint                    Number of tasks
       --reserve-cpu decimal              Reserve CPUs (default 0.000)
       --reserve-memory bytes             Reserve Memory (default 0 B)
       --restart-condition string         Restart when condition is met (none, on-failure, or any)
-      --restart-delay duration           Delay between restart attempts (ns|us|ms|s|m|h) (default none)
-      --restart-max-attempts uint        Maximum number of restarts before giving up (default none)
-      --restart-window duration          Window used to evaluate the restart policy (ns|us|ms|s|m|h) (default none)
-      --secret value                     Specify secrets to expose to the service (default [])
-      --stop-grace-period duration       Time to wait before force killing a container (ns|us|ms|s|m|h) (default none)
+      --restart-delay duration           Delay between restart attempts (ns|us|ms|s|m|h)
+      --restart-max-attempts uint        Maximum number of restarts before giving up
+      --restart-window duration          Window used to evaluate the restart policy (ns|us|ms|s|m|h)
+      --secret secret                    Specify secrets to expose to the service
+      --stop-grace-period duration       Time to wait before force killing a container (ns|us|ms|s|m|h)
   -t, --tty                              Allocate a pseudo-TTY
       --update-delay duration            Delay between updates (ns|us|ms|s|m|h) (default 0s)
       --update-failure-action string     Action on update failure (pause|continue) (default "pause")

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -39,9 +39,9 @@ Options:
       --group-add list                   Add an additional supplementary user group to the container (default [])
       --group-rm list                    Remove a previously added supplementary user group from the container (default [])
       --health-cmd string                Command to run to check health
-      --health-interval duration         Time between running the check (ns|us|ms|s|m|h) (default none)
+      --health-interval duration         Time between running the check (ns|us|ms|s|m|h)
       --health-retries int               Consecutive failures needed to report unhealthy
-      --health-timeout duration          Maximum time to allow one check to run (ns|us|ms|s|m|h) (default none)
+      --health-timeout duration          Maximum time to allow one check to run (ns|us|ms|s|m|h)
       --help                             Print usage
       --host-add list                    Add or update a custom host-to-IP mapping (host:ip) (default [])
       --host-rm list                     Remove a custom host-to-IP mapping (host:ip) (default [])
@@ -56,19 +56,19 @@ Options:
       --mount-add mount                  Add or update a mount on a service
       --mount-rm list                    Remove a mount by its target path (default [])
       --no-healthcheck                   Disable any container-specified HEALTHCHECK
-      --publish-add list                 Add or update a published port (default [])
-      --publish-rm list                  Remove a published port by its target port (default [])
-      --replicas uint                    Number of tasks (default none)
+      --publish-add port                 Add or update a published port
+      --publish-rm port                  Remove a published port by its target port
+      --replicas uint                    Number of tasks
       --reserve-cpu decimal              Reserve CPUs (default 0.000)
       --reserve-memory bytes             Reserve Memory (default 0 B)
       --restart-condition string         Restart when condition is met (none, on-failure, or any)
-      --restart-delay duration           Delay between restart attempts (ns|us|ms|s|m|h) (default none)
-      --restart-max-attempts uint        Maximum number of restarts before giving up (default none)
-      --restart-window duration          Window used to evaluate the restart policy (ns|us|ms|s|m|h) (default none)
+      --restart-delay duration           Delay between restart attempts (ns|us|ms|s|m|h)
+      --restart-max-attempts uint        Maximum number of restarts before giving up
+      --restart-window duration          Window used to evaluate the restart policy (ns|us|ms|s|m|h)
       --rollback                         Rollback to previous specification
-      --secret-add list                  Add a secret (default [])
+      --secret-add secret                Add or update a secret on a service
       --secret-rm list                   Remove a secret (default [])
-      --stop-grace-period duration       Time to wait before force killing a container (ns|us|ms|s|m|h) (default none)
+      --stop-grace-period duration       Time to wait before force killing a container (ns|us|ms|s|m|h)
   -t, --tty                              Allocate a pseudo-TTY
       --update-delay duration            Delay between updates (ns|us|ms|s|m|h) (default 0s)
       --update-failure-action string     Action on update failure (pause|continue) (default "pause")


### PR DESCRIPTION
**- What I did**

This fix tries to address the issue raised in #29291 where the output of `--replicas`, `--restart-delay`, `--restart-max-attempts`, and `--stop-grace-period` in `service create/update`:
```
      --replicas uint                    Number of tasks (default none)
...
      --restart-delay duration           Delay between restart attempts (ns|us|ms|s|m|h) (default none)
      --restart-max-attempts uint        Maximum number of restarts before giving up (default none)
...
      --stop-grace-period duration       Time to wait before force killing a container (ns|us|ms|s|m|h) (default none)
```
are misleading. For example, user might incorrectly assume the number of replicas would be `0` (`none`) by default, while the actual default is `1`.

The issue comes from the fact that some of the default values are from daemon and it is not possible for client to find out the default value.

In this case, it might be better to just simply not displaying `(default none)`.

**- How I did it**

This fix set a `noDefaultValue bool` in `Uint64Opt` so that it is possible to switch on/off the output of `(default none)` for `Uint64Opt`. This fix also sets `noDefaultValue bool` in `DurationOpt` in a similar fashion.

New Output:
```
      --replicas uint                    Number of tasks
...
      --restart-delay duration           Delay between restart attempts (ns|us|ms|s|m|h)
      --restart-max-attempts uint        Maximum number of restarts before giving up
...
      --stop-grace-period duration       Time to wait before force killing a container (ns|us|ms|s|m|h)
```

The docs has been updated. Note the docs for help output of `service create/update` is out of sync with the current master. This fix replace with the update to date help output.

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![world-s-cutest-kitten](https://cloud.githubusercontent.com/assets/6932348/21227895/9c863940-c290-11e6-8bb7-73a84013e91f.jpg)


This fix fixes #29291.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>