### PR TITLE
poule: do not treat "docker service" keyword as a swarm feature

### DIFF
--- a/poule.yml
+++ b/poule.yml
@@ -26,7 +26,7 @@
                 area/networking:     [ "docker network", "ipvs", "vxlan" ],
                 area/runtime:        [ "oci runtime error" ],
                 area/security/trust: [ "docker_content_trust" ],
-                area/swarm:          [ "docker node", "docker service", "docker swarm" ],
+                area/swarm:          [ "docker node", "docker swarm", "docker service create", "docker service inspect", "docker service logs", "docker service ls", "docker service ps", "docker service rm", "docker service scale", "docker service update" ],
                 platform/desktop:    [ "docker for mac", "docker for windows" ],
                 platform/freebsd:    [ "freebsd" ],
                 platform/windows:    [ "nanoserver", "windowsservercore", "windows server" ],


### PR DESCRIPTION
"docker service" can also refer to an init system's service named docker
This would prevent labeling e.g. systemd related issues to swarm.

Signed-off-by: Tibor Vass <tibor@docker.com>

Ping @icecrime 