### PR TITLE
Allow containers to continue even if mount failed after live restore

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -150,8 +150,13 @@ func (daemon *Daemon) restore() error {
 			}
 			container.RWLayer = rwlayer
 			if err := daemon.Mount(container); err != nil {
-				logrus.Errorf("Failed to mount container %v: %v", id, err)
-				continue
+				// The mount is unlikely to fail. However, in case mount fails
+				// the container should be allowed to restore here. Some functionalities
+				// (like docker exec -u user) might be missing but container is able to be
+				// stopped/restarted/removed.
+				// See #29365 for related information.
+				// The error is only logged here.
+				logrus.Warnf("Failed to mount container %v: %v", id, err)
 			}
 			logrus.Debugf("Loaded container %v", container.ID)
 


### PR DESCRIPTION
This fix is a follow up to #29365. In #29365 a bug was fixed for `docker exec -u user` after live restore by remounting. However, #29365 will prevent containers from restored if mount failed.

In this fix, containers will be restored even if mount in that step failed. Some functionalities might be missing (like `docker exec -u user`) but at least it is possible to do certain operations like stop/restart/delete.

This fix is related to #29365.

See https://github.com/docker/docker/pull/29365#issuecomment-267329003 for related discussion.

/cc @thaJeztah @mlaventure

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>