### PR TITLE
WIP [1.12.x] build docker-engine-selinux as subpackage for centos-7

### DIFF
--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -86,11 +86,7 @@ Requires: device-mapper >= 1.02.90-2
 # RE: rhbz#1195804 - ensure min NVR for selinux-policy
 %if 0%{?with_selinux}
 Requires: selinux-policy >= %{selinux_policyver}
-%if 0%{?centos} >= 7
-Requires(pre): docker-selinux
-%else
 Requires(pre): %{name}-selinux >= %{version}-%{release}
-%endif # centos 7+
 %endif # with_selinux
 
 # conflicting packages
@@ -108,6 +104,17 @@ everything in between - and they don't require you to use a particular
 language, framework or packaging system. That makes them great building blocks
 for deploying and scaling web apps, databases, and backend services without
 depending on a particular stack or provider.
+
+%if 0%{?centos} >= 7
+%package selinux
+Summary: SELinux Policies for the open-source application container engine
+Group: Tools/Docker
+BuildArch: noarch
+Requires(pre): docker-selinux
+%description selinux
+SELinux policy modules for use with Docker
+%files selinux
+%endif
 
 %prep
 %if 0%{?centos} <= 6 || 0%{?oraclelinux} <=6


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed the problem of upgrading from docker-engine 1.12.4 to 1.12.5-rc1 failing because docker-engine-selinux-1.12.4 conflicts with docker-selinux.

**- How I did it**

Added a section to the docker-engine.spec file for defining a subpackage. This will cause centos-7 builds to create a docker-engine-selinux [subpackage](http://rpm.org/max-rpm-snapshot/ch-rpm-subpack.html) (which is just another RPM built from the same spec file) that has no files but just a dependency on the `docker-selinux` package. 

**- How to verify it**

Build the `docker-engine` and `docker-engine-selinux` centos-7 RPM package:
```
$ make DOCKER_BUILD_PKGS=centos-7 rpm
```

In a `centos-7` environment with docker-engine 1.12.4 already installed:
```
$ docker run --name c7a -v `pwd`/bundles:/bundles -it centos:7
# curl -fsSL https://get.docker.com/ | sh # install docker engine 1.12.4
# rpm -qa |grep docker
docker-engine-1.12.4-1.el7.centos.x86_64
docker-engine-selinux-1.12.4-1.el7.centos.noarch
```

Install the resulting `docker-engine` and `docker-engine-selinux` packages in `bundles/1.12.5-rc1/build-rpm/centos-7/RPMS/` and see that it can successfully upgrade:
```
# yum install \
bundles/1.12.5-rc1/build-rpm/centos-7/RPMS/x86_64/docker-engine-1.12.5-0.0.20161214.232314.gite9e3ab6.el7.centos.x86_64.rpm \
bundles/1.12.5-rc1/build-rpm/centos-7/RPMS/noarch/docker-engine-selinux-1.12.5-0.0.20161214.232314.gite9e3ab6.el7.centos.noarch.rpm
...
Dependency Installed:
  docker-selinux.x86_64 0:1.10.3-46.el7.centos.14

Updated:
  docker-engine.x86_64 0:1.12.5-0.0.20161214.232314.gite9e3ab6.el7.centos                                         docker-engine-selinux.noarch 0:1.12.5-0.0.20161214.232314.gite9e3ab6.el7.centos

Complete!
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

🍶 