### PR TITLE
Keep `Spec.Networks` and `Spec.TaskTemplate.Networks` consistent

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -1613,6 +1613,10 @@ func (c *Cluster) populateNetworkID(ctx context.Context, client swarmapi.Control
 		}
 		networks[i].Target = apiNetwork.ID
 	}
+
+	// Make s.TaskTemplate.Networks and s.Networks consistent
+	s.TaskTemplate.Networks = networks
+	s.Networks = networks
 	return nil
 }
 


### PR DESCRIPTION
**- What I did**

While looking into docker issue #28247 to support network update, noticed several potential issues in the current service spec:

1. ~~When a service is created, the `Networks` in ServiceSpec are always resolved into Network ID. This guarantees the spec for network. However, tt also means when user is doing a `docker service inspect`, the Spec returned is different from the original Spec as network might
be changed from `foo` to `d928...`.
This is quite problematic because if user wants to update the network, there is no match for network-add/network-rm. Instead, user will have to perform a network resolve on the client side, then find out which network to remove and which network to add.~~

2. Currently there are two places for `Networks`. One is in `Spec.TaskTemplate.Networks` and another is in `Spec.Networks`. As was specified in the code comment,  `Spec.Networks` was deprecated and may be removed in the future. However, `Spec.Networks` is still used in case `Spec.TaskTemplate.Networks` is not present.
Furthermore, in the current implementation when networks are resolved, only the `Spec.TaskTemplate.Networks` is updated. Therefore, a `docker service inspect` actually returns the spec with different `Networks` specifications. The value in `Spec.Networks` is the name while `Spec.TaskTemplate.Networks` is the network ID.

**- How I did it**
This fix tries to address the problem by:
1. ~~Add a `Name` field in `NetworkAttachmentConfig` to keep a copy of the original network name. `Target` is still the network ID and is still the one being used. But users will get the original network names they provide with `docker service inspect`.~~
2. In docker daemon, when network names are resolved into network IDs, both `Spec.TaskTemplate.Networks` and `Spec.Networks` are updated so that they are always in sync.

This fix will help the implementation of #28247.

**- How to verify it**

An integration test has been added.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
![world-s-cutest-kitten](https://cloud.githubusercontent.com/assets/6932348/21246329/d3f4fc76-c2dc-11e6-8279-804561fd7beb.jpg)

~~A swarmkit PR has been opened:~~
~~https://github.com/docker/swarmkit/pull/1813~~

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>