### PR TITLE
gcplogs: forcibly set HOME on static UNIX binary

### DIFF
--- a/daemon/logger/gcplogs/gcplogging.go
+++ b/daemon/logger/gcplogs/gcplogging.go
@@ -114,6 +114,15 @@ func New(ctx logger.Context) (logger.Logger, error) {
 		return nil, fmt.Errorf("No project was specified and couldn't read project from the meatadata server. Please specify a project")
 	}
 
+	// Issue #29344: gcplogs segfaults (static binary)
+	// If HOME is not set, logging.NewClient() will call os/user.Current() via oauth2/google.
+	// However, in static binary, os/user.Current() leads to segfault due to a glibc issue that won't be fixed
+	// in a short term. (golang/go#13470, https://sourceware.org/bugzilla/show_bug.cgi?id=19341)
+	// So we forcibly set HOME so as to avoid call to os/user/Current()
+	if err := ensureHomeIfIAmStatic(); err != nil {
+		return nil, err
+	}
+
 	c, err := logging.NewClient(context.Background(), project)
 	if err != nil {
 		return nil, err

--- a/daemon/logger/gcplogs/gcplogging_linux.go
+++ b/daemon/logger/gcplogs/gcplogging_linux.go
@@ -1,0 +1,31 @@
+// +build linux
+
+package gcplogs
+
+import (
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/dockerversion"
+	"github.com/docker/docker/pkg/homedir"
+)
+
+// ensureHomeIfIAmStatic ensure $HOME to be set if dockerversion.IAmStatic is "true".
+// See issue #29344: gcplogs segfaults (static binary)
+// If HOME is not set, logging.NewClient() will call os/user.Current() via oauth2/google.
+// However, in static binary, os/user.Current() leads to segfault due to a glibc issue that won't be fixed
+// in a short term. (golang/go#13470, https://sourceware.org/bugzilla/show_bug.cgi?id=19341)
+// So we forcibly set HOME so as to avoid call to os/user/Current()
+func ensureHomeIfIAmStatic() error {
+	// Note: dockerversion.IAmStatic and homedir.GetStatic() is only available for linux.
+	// So we need to use them in this gcplogging_linux.go rather than in gcplogging.go
+	if dockerversion.IAmStatic == "true" && os.Getenv("HOME") == "" {
+		home, err := homedir.GetStatic()
+		if err != nil {
+			return err
+		}
+		logrus.Warnf("gcplogs requires HOME to be set for static daemon binary. Forcibly setting HOME to %s.", home)
+		os.Setenv("HOME", home)
+	}
+	return nil
+}

--- a/daemon/logger/gcplogs/gcplogging_others.go
+++ b/daemon/logger/gcplogs/gcplogging_others.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package gcplogs
+
+func ensureHomeIfIAmStatic() error {
+	return nil
+}

--- a/pkg/homedir/homedir_linux.go
+++ b/pkg/homedir/homedir_linux.go
@@ -1,0 +1,23 @@
+// +build linux
+
+package homedir
+
+import (
+	"os"
+
+	"github.com/docker/docker/pkg/idtools"
+)
+
+// GetStatic returns the home directory for the current user without calling
+// os/user.Current(). This is useful for static-linked binary on glibc-based
+// system, because a call to os/user.Current() in a static binary leads to
+// segfault due to a glibc issue that won't be fixed in a short term.
+// (#29344, golang/go#13470, https://sourceware.org/bugzilla/show_bug.cgi?id=19341)
+func GetStatic() (string, error) {
+	uid := os.Getuid()
+	usr, err := idtools.LookupUID(uid)
+	if err != nil {
+		return "", err
+	}
+	return usr.Home, nil
+}

--- a/pkg/homedir/homedir_others.go
+++ b/pkg/homedir/homedir_others.go
@@ -1,0 +1,13 @@
+// +build !linux
+
+package homedir
+
+import (
+	"errors"
+)
+
+// GetStatic is not needed for non-linux systems.
+// (Precisely, it is needed only for glibc-based linux systems.)
+func GetStatic() (string, error) {
+	return "", errors.New("homedir.GetStatic() is not supported on this system")
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix #29344

~The PR consists of 3 commits, but the first and the second one are dupe of #29475 for vendoring https://github.com/golang/oauth2/commit/96382aa079b72d8c014eb0c50f6c223d1e6a2de0 .
Please review the latest commit in this PR. (I will rebase this PR when #29475 is merged)~
EDIT: rebased
    
**- How I did it**

If `HOME` is not set, the gcplogs logging driver will call `os/user.Current()` via `oauth2/google`.
However, in static binary, `os/user.Current()` leads to segfault due to a glibc issue that won't be fixed
in a short term. (golang/go#13470, https://sourceware.org/bugzilla/show_bug.cgi?id=19341)

So this PR forcibly sets `HOME` so as to avoid call to `os/user/Current()`.

**- How to verify it**

 * Build the static daemon binary (`make binary`)
 * Start the daemon without `HOME` (typically, just starting the daemon via systemd is enough)
 * Make sure the daemon prints a warning log: `level=warning msg="gcplogs requires HOME to be set for static daemon binary. Forcibly setting HOME to /root."`
 * Do `docker run --rm --log-driver=gcplogs busybox echo hello` many times and make sure all of them succeeds without SEGV

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
gcplogs: forcibly set HOME on static UNIX binary

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://cloud.githubusercontent.com/assets/9248427/21258748/c1423efa-c3c1-11e6-88f0-c9281272821e.png)

