### PR TITLE
swarm leave is not only for workers

### DIFF
--- a/cli/command/swarm/leave.go
+++ b/cli/command/swarm/leave.go
@@ -19,7 +19,7 @@ func newLeaveCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "leave [OPTIONS]",
-		Short: "Leave the swarm (workers only)",
+		Short: "Leave the swarm",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLeave(dockerCli, opts)

--- a/docs/reference/commandline/swarm_leave.md
+++ b/docs/reference/commandline/swarm_leave.md
@@ -18,7 +18,7 @@ keywords: "swarm, leave"
 ```markdown
 Usage:	docker swarm leave [OPTIONS]
 
-Leave the swarm (workers only)
+Leave the swarm
 
 Options:
   -f, --force   Force this node to leave the swarm, ignoring warnings


### PR DESCRIPTION
the "docker swarm leave" command description
mentioned that the command can only be used
for workers, however, the command can also
be used for managers (using the `-f` / `--force`
option).

this patch removes the "(workers only)" part
of the command description.

this was originally added in https://github.com/docker/docker/commit/7b5c3d935a7a99b282f0f859101c887894a0b00e (https://github.com/docker/docker/pull/26260)

/cc @mstanleyjones @aaronlehmann PTAL