### PR TITLE
Don't encourage adding user to docker group

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -78,6 +78,12 @@ echo_docker_as_nonroot() {
 
 	Remember that you will have to log out and back in for this to take effect!
 
+	WARNING: Adding a user to the "docker" group will grant the ability to run
+	         containers which can be used to obtain root privileges on the
+	         docker host.
+	         Refer to https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface
+	         for more information.
+
 	EOF
 }
 


### PR DESCRIPTION
It's ethically wrong to encourage this:

http://www.projectatomic.io/blog/2015/08/why-we-dont-let-non-root-users-run-docker-in-centos-fedora-or-rhel/

I tried this recently on Ubuntu 16.04, with the latest version of
docker installed via this script. Adding someone to the docker group is
the equivalent of granting full root access and it at least should not
be encouraged. If you do prompt this there should at least be a major
warning here. A user is lead to believe that adding someone to the
docker group will give them access to just the docker daemon, when in
fact it gives that user access to everything.