### PR TITLE
Improve error output for `docker stats ...`

### DIFF
--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -173,14 +173,13 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 		var errs []string
 		cStats.mu.Lock()
 		for _, c := range cStats.cs {
-			cErr := c.GetError()
-			if cErr != nil {
-				errs = append(errs, fmt.Sprintf("%s: %v", c.Name, cErr))
+			if err := c.GetError(); err != nil {
+				errs = append(errs, err.Error())
 			}
 		}
 		cStats.mu.Unlock()
 		if len(errs) > 0 {
-			return fmt.Errorf("%s", strings.Join(errs, ", "))
+			return fmt.Errorf("%s", strings.Join(errs, "\n"))
 		}
 	}
 


### PR DESCRIPTION
While looking into `docker stats <c1> <c2> ...` I noticed that the error output is quite long, especially if there are multiple errors:

```sh
ubuntu@ubuntu:~/docker$ docker stats nofound
: Error response from daemon: No such container: nofound
ubuntu@ubuntu:~/docker$ docker stats nofound foo bar
: Error response from daemon: No such container: nofound, : Error response from daemon: No such container: foo, : Error response from daemon: No such container: bar
```

There are several issues,
1. There is an extra `: ` at the beginning. That is because if container is not found, the name will not be available from the daemon.
2. Multiple errors are concatenated with `, ` which will be quite long.

This fix:
1. Only print out the error from daemon.
2. Multiple errors are printed out line by line.

Below is the new output:
```sh
ubuntu@ubuntu:~/docker$ docker stats nofound
Error response from daemon: No such container: nofound
ubuntu@ubuntu:~/docker$ docker stats nofound foo bar
Error response from daemon: No such container: nofound
Error response from daemon: No such container: foo
Error response from daemon: No such container: bar
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>