### PR TITLE
fix powershell dco check

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -184,7 +184,7 @@ Function Validate-DCO($headCommit, $upstreamCommit) {
     $usernameRegex='[a-zA-Z0-9][a-zA-Z0-9-]+'
 
     $dcoPrefix="Signed-off-by:"
-    $dcoRegex="^(Docker-DCO-1.1-)?$dcoPrefix ([^<]+) <([^<>@]+@[^<>]+)>( \\(github: ($githubUsernameRegex)\\))?$"
+    $dcoRegex="^(Docker-DCO-1.1-)?$dcoPrefix ([^<]+) <([^<>@]+@[^<>]+)>( \\(github: ($usernameRegex)\\))?$"
 
     $counts = Invoke-Expression "git diff --numstat $upstreamCommit...$headCommit"
     if ($LASTEXITCODE -ne 0) { Throw "Failed git diff --numstat" }


### PR DESCRIPTION
this was added in https://github.com/Microsoft/docker/commit/155435b6ceeb05b2927ecc726216666b898b6459, but it appears the `$githubUsernameRegex` was not defined, causing sign-offs using this format to fail

/cc @vieux @dmcgowan @johnstep 