### PR TITLE
Clean up tmp files for interrupted `docker build`

### DIFF
--- a/builder/tarsum.go
+++ b/builder/tarsum.go
@@ -104,7 +104,8 @@ func MakeTarSumContext(tarStream io.Reader) (ModifiableContext, error) {
 		return nil, err
 	}
 
-	if err := chrootarchive.Untar(sum, root, nil); err != nil {
+	err = chrootarchive.Untar(sum, root, nil)
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
**- What I did**

This fix tries to fix the issue raised in #29486 where interrupted `docker build` leaves some tmp files in `/var/lib/docker/tmp`, with tmp file name prefixed with `/var/lib/docker/tmp/docker-builderXXXXXX`.

The reason for the issue is that in `MakeTarSumContext()`:
```
	if err := chrootarchive.Untar(sum, root, nil); err != nil {
		return nil, err
	}
```
the `err` is shadowed and caused the clean up function in `defer func()` not being called.

This fix fixes the issue.

**- How I did it**

**- How to verify it**

This fix is tested manually, as was specified in #29486:
```
rm -rf /var/lib/docker/tmp

mkdir repro && cd repro
fallocate -l 300M bigfile

cat > Dockerfile <<EOF
FROM scratch
COPY ./bigfile /
EOF

docker build .
{Cancel}

ls -la /var/lib/docker/tmp
```

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![cute-kitten-photo-wallpaper-backgrounds-eyes-cat-close-whiskers](https://cloud.githubusercontent.com/assets/6932348/21284654/049d9efa-c3d7-11e6-9752-730317706e52.jpg)


This fix fixes #29486.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>