### PR TITLE
Remove `--all|-a` from `docker node ps` reference

### DIFF
--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -22,7 +22,6 @@ Usage:  docker node ps [OPTIONS] [NODE...]
 List tasks running on one or more nodes, defaults to current node.
 
 Options:
-  -a, --all            Display all instances
   -f, --filter value   Filter output based on conditions provided
       --help           Print usage
       --no-resolve     Do not map IDs to Names


### PR DESCRIPTION
.--all was added in #25983 but removed again in #28885. It is still present in the reference docs for `docker node ps`.