### PR TITLE
fix conversion of anonymous volumes in compose-file

### DIFF
--- a/cli/compose/convert/volume.go
+++ b/cli/compose/convert/volume.go
@@ -42,7 +42,15 @@ func convertVolumeToMount(volumeSpec string, stackVolumes volumes, namespace Nam
 	case 1:
 		target = parts[0]
 	default:
-		return mount.Mount{}, fmt.Errorf("invald volume: %s", volumeSpec)
+		return mount.Mount{}, fmt.Errorf("invalid volume: %s", volumeSpec)
+	}
+
+	if source == "" {
+		// Anonymous volume
+		return mount.Mount{
+			Type:   mount.TypeVolume,
+			Target: target,
+		}, nil
 	}
 
 	// TODO: catch Windows paths here

--- a/cli/compose/convert/volume.go
+++ b/cli/compose/convert/volume.go
@@ -31,6 +31,12 @@ func convertVolumeToMount(volumeSpec string, stackVolumes volumes, namespace Nam
 	// TODO: split Windows path mappings properly
 	parts := strings.SplitN(volumeSpec, ":", 3)
 
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			return mount.Mount{}, fmt.Errorf("invalid volume: %s", volumeSpec)
+		}
+	}
+
 	switch len(parts) {
 	case 3:
 		source = parts[0]
@@ -41,8 +47,6 @@ func convertVolumeToMount(volumeSpec string, stackVolumes volumes, namespace Nam
 		target = parts[1]
 	case 1:
 		target = parts[0]
-	default:
-		return mount.Mount{}, fmt.Errorf("invalid volume: %s", volumeSpec)
 	}
 
 	if source == "" {

--- a/cli/compose/convert/volume_test.go
+++ b/cli/compose/convert/volume_test.go
@@ -34,6 +34,18 @@ func TestGetBindOptionsNone(t *testing.T) {
 	assert.Equal(t, opts, (*mount.BindOptions)(nil))
 }
 
+func TestConvertVolumeToMountAnonymousVolume(t *testing.T) {
+	stackVolumes := volumes{}
+	namespace := NewNamespace("foo")
+	expected := mount.Mount{
+		Type:   mount.TypeVolume,
+		Target: "/foo/bar",
+	}
+	mount, err := convertVolumeToMount("/foo/bar", stackVolumes, namespace)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, mount, expected)
+}
+
 func TestConvertVolumeToMountNamedVolume(t *testing.T) {
 	stackVolumes := volumes{
 		"normal": composetypes.VolumeConfig{

--- a/cli/compose/convert/volume_test.go
+++ b/cli/compose/convert/volume_test.go
@@ -46,6 +46,15 @@ func TestConvertVolumeToMountAnonymousVolume(t *testing.T) {
 	assert.DeepEqual(t, mount, expected)
 }
 
+func TestConvertVolumeToMountInvalidFormat(t *testing.T) {
+	namespace := NewNamespace("foo")
+	invalids := []string{"::", "::cc", ":bb:", "aa::", "aa::cc", "aa:bb:", " : : ", " : :cc", " :bb: ", "aa: : ", "aa: :cc", "aa:bb: "}
+	for _, vol := range invalids {
+		_, err := convertVolumeToMount(vol, volumes{}, namespace)
+		assert.Error(t, err, "invalid volume: "+vol)
+	}
+}
+
 func TestConvertVolumeToMountNamedVolume(t *testing.T) {
 	stackVolumes := volumes{
 		"normal": composetypes.VolumeConfig{


### PR DESCRIPTION
the `convertVolumeToMount()` function did not take
anonymous volumes into account when converting
volume specifications to bind-mounts.

this resulted in the conversion to try to
look up an empty "source" volume, which
lead to an error;

    undefined volume:

this patch distinguishes "anonymous"
volumes from bind-mounts and named-volumes,
and skips further processing if no source
is defined (i.e. the volume is "anonymous").

fixes https://github.com/docker/docker/issues/29512

**- What I did**

Updated `convertVolumeToMount() to take anonymous volumes into account

**- How I did it**

Behind my computer, in pyjamas

**- How to verify it**

Deploy a docker-compose file that uses an anonymous volume, and verify that no error is produced, and the service is running afterwards;

```bash
$ cat > docker-compose.yml <<EOF
version: "3.0"
services:
  main:
    image: nginx:alpine
    volumes:
      - "/foo/bar"
EOF

$ docker stack deploy --compose-file=docker-compose.yml foo
Creating network foo_default
Creating service foo_main

$  docker service ps foo_main
ID            NAME        IMAGE         NODE          DESIRED STATE  CURRENT STATE           ERROR  PORTS
sr0u5f6vqjhr  foo_main.1  nginx:alpine  5945fab4e8ad  Running        Running 54 seconds ago
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Not needed; this functionality is new in 1.13

**- A picture of a cute animal (not mandatory but encouraged)**

![mouse](https://cloud.githubusercontent.com/assets/1804568/21294726/2936a716-c544-11e6-9589-bb0641378154.jpg)
