### PR TITLE
Update criu to 2.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,7 +155,7 @@ RUN git clone https://github.com/golang/lint.git /go/src/github.com/golang/lint 
 	&& go install -v github.com/golang/lint/golint
 
 # Install CRIU for checkpoint/restore support
-ENV CRIU_VERSION 2.2
+ENV CRIU_VERSION 2.9
 RUN mkdir -p /usr/src/criu \
 	&& curl -sSL https://github.com/xemul/criu/archive/v${CRIU_VERSION}.tar.gz | tar -v -C /usr/src/criu/ -xz --strip-components=1 \
 	&& cd /usr/src/criu \


### PR DESCRIPTION
criu 2.8 and 2.9 contain various fixes, so updating the version in the Dockerfile to match the newer version.

this change should not have any impact on the binaries that are built, but allows testing more functionality of checkpoint/restore in the build container. For example;

Build docker;

```
make BINDDIR=. binary shell
```

Inside the dev-container;

```
make install
dockerd --debug --experimental&
```

Then, in a second session inside the

```
docker network create -d bridge --subnet=172.19.0.0/16 -o com.docker.network.bridge.enable_icc=false test
docker run --security-opt=seccomp:unconfined --name cr -d --net=test --ip=172.19.0.2 ubuntu /bin/bash -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
docker exec -it cr bash

apt-get update && apt-get install -y curl
curl https://www.google.com

<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
...

exit
```

Then, start the container from the checkpoint;

```
docker checkpoint create cr checkpoint1
docker start --checkpoint checkpoint1 cr
```

exec into the container and try again;

```
docker exec -it cr bash
curl https://www.google.com

<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
...
```

Before this update, starting the container from the checkpoint failed;

```
docker start --checkpoint checkpoint1 cr
Error response from daemon: oci runtime error: criu failed: type NOTIFY errno 0
```

fixes https://github.com/docker/docker/issues/27597, and possibly https://github.com/docker/docker/issues/27200 (but I was not able to reproduce https://github.com/docker/docker/issues/27200)

/cc @boucher @tswift242 @xemul