### PR TITLE
correct the spelling error of driver

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -342,7 +342,7 @@ func (daemon *Daemon) restore() error {
 		// if the container has restart policy, do not
 		// prepare the mountpoints since it has been done on restarting.
 		// This is to speed up the daemon start when a restart container
-		// has a volume and the volume dirver is not available.
+		// has a volume and the volume driver is not available.
 		if _, ok := restartContainers[c]; ok {
 			continue
 		} else if _, ok := removeContainers[c.ID]; ok {


### PR DESCRIPTION
Signed-off-by: erxian <evelynhsu21@gmail.com>

Hi, this PR correct the spelling error of driver , which located in https://github.com/docker/docker/blob/master/daemon/daemon.go#L345 

So, I've correct the wrong spelling from **dirver** to **driver** :)

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

