### PR TITLE
simplify unauthorizedError

### DIFF
--- a/client/login.go
+++ b/client/login.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"encoding/json"
-	"net/http"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
@@ -11,13 +10,8 @@ import (
 )
 
 // RegistryLogin authenticates the docker server with a given docker registry.
-// It returns unauthorizedError when the authentication fails.
 func (cli *Client) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
 	resp, err := cli.post(ctx, "/auth", url.Values{}, auth, nil)
-
-	if resp.statusCode == http.StatusUnauthorized {
-		return registry.AuthenticateOKBody{}, unauthorizedError{err}
-	}
 	if err != nil {
 		return registry.AuthenticateOKBody{}, err
 	}


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

remove unauthorizedError and make client side more clear.

Since unauthorizedError has never used.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

