### PR TITLE
[test-integration] Make privateRegistryURL (and dockerd) constant

### DIFF
--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -13,17 +13,20 @@ import (
 	"github.com/docker/docker/pkg/reexec"
 )
 
+const (
+	// the private registry to use for tests
+	privateRegistryURL = "127.0.0.1:5000"
+
+	// the docker daemon binary to use
+	dockerdBinary = "dockerd"
+)
+
 var (
 	// the docker client binary to use
 	dockerBinary = "docker"
-	// the docker daemon binary to use
-	dockerdBinary = "dockerd"
 
 	// path to containerd's ctr binary
 	ctrBinary = "docker-containerd-ctr"
-
-	// the private registry to use for tests
-	privateRegistryURL = "127.0.0.1:5000"
 
 	// isLocalDaemon is true if the daemon under test is on the same
 	// host as the CLI.
@@ -80,9 +83,6 @@ func init() {
 	if err != nil {
 		fmt.Printf("ERROR: couldn't resolve full path to the Docker binary (%v)\n", err)
 		os.Exit(1)
-	}
-	if registry := os.Getenv("REGISTRY_URL"); registry != "" {
-		privateRegistryURL = registry
 	}
 
 	// Deterministically working out the environment in which CI is running


### PR DESCRIPTION
`privateRegistryURL` should really be a constant. The use of `REGISTRY_URL` probably never work and nobody saw that / is using that, so let's use it as a constant.

`dockerdBinary` can also be a constant.

```
$ REGISTRY_URL="1.1.1.1:5000" ./hack/make.sh binary test-integration-cli
# […]
imageReference1 = 127.0.0.1:5000/dockercli/busybox-by-dgst@sha256:4799ad8fc26fe0fea7df964d939e72c29f71db5ded9011f95ca2628102760abd
imageReference2 = 127.0.0.1:5000/dockercli/busybox-by-dgst@sha256:9744246abe98aa6a2ee955d1ff798960658d34b5c5cb637005cd419137f2d4b9
# […]
# Clearly, it doesn't care at all about REGISTRY_URL.
```

/cc @thaJeztah @AkihiroSuda @dnephin @cpuguy83 @icecrime @runcom 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
