### PR TITLE
man/docker-save.1.md: fix a typo in upper case

### DIFF
--- a/man/docker-save.1.md
+++ b/man/docker-save.1.md
@@ -39,7 +39,7 @@ fedora image to a fedora-latest.tar:
 **docker-load(1)** to load an image from a tar archive on STDIN.
 
 # HISTORY
-April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+April 2014, originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 November 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>


### PR DESCRIPTION
Signed-off-by: Jie Luo <luo612@zju.edu.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

