### PR TITLE
[test-integration] global variable workingDirectory is not needed…

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -623,13 +623,14 @@ func (s *DockerSuite) TestRunCreateVolume(c *check.C) {
 func (s *DockerSuite) TestRunCreateVolumeWithSymlink(c *check.C) {
 	// Cannot run on Windows as relies on Linux-specific functionality (sh -c mount...)
 	testRequires(c, DaemonIsLinux)
+	workingDirectory, err := ioutil.TempDir("", "TestRunCreateVolumeWithSymlink")
 	image := "docker-test-createvolumewithsymlink"
 
 	buildCmd := exec.Command(dockerBinary, "build", "-t", image, "-")
 	buildCmd.Stdin = strings.NewReader(`FROM busybox
 		RUN ln -s home /bar`)
 	buildCmd.Dir = workingDirectory
-	err := buildCmd.Run()
+	err = buildCmd.Run()
 	if err != nil {
 		c.Fatalf("could not build '%s': %v", image, err)
 	}
@@ -658,6 +659,9 @@ func (s *DockerSuite) TestRunVolumesFromSymlinkPath(c *check.C) {
 	// This test cannot run on a Windows daemon as
 	// Windows does not support symlinks inside a volume path
 	testRequires(c, DaemonIsLinux)
+
+	workingDirectory, err := ioutil.TempDir("", "TestRunVolumesFromSymlinkPath")
+	c.Assert(err, checker.IsNil)
 	name := "docker-test-volumesfromsymlinkpath"
 	prefix := ""
 	dfContents := `FROM busybox
@@ -676,7 +680,7 @@ func (s *DockerSuite) TestRunVolumesFromSymlinkPath(c *check.C) {
 	buildCmd := exec.Command(dockerBinary, "build", "-t", name, "-")
 	buildCmd.Stdin = strings.NewReader(dfContents)
 	buildCmd.Dir = workingDirectory
-	err := buildCmd.Run()
+	err = buildCmd.Run()
 	if err != nil {
 		c.Fatalf("could not build 'docker-test-volumesfromsymlinkpath': %v", err)
 	}

--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -25,8 +25,6 @@ var (
 	// the private registry to use for tests
 	privateRegistryURL = "127.0.0.1:5000"
 
-	workingDirectory string
-
 	// isLocalDaemon is true if the daemon under test is on the same
 	// host as the CLI.
 	isLocalDaemon bool
@@ -84,7 +82,6 @@ func init() {
 	if registry := os.Getenv("REGISTRY_URL"); registry != "" {
 		privateRegistryURL = registry
 	}
-	workingDirectory, _ = os.Getwd()
 
 	// Deterministically working out the environment in which CI is running
 	// to evaluate whether the daemon is local or remote is not possible through


### PR DESCRIPTION
… and given where it was used, it should be quicker to create an empty
folder instead of passing potentially a big context with unrelated file.

/cc @thaJeztah @tiborvass @dnephin @cpuguy83 @AkihiroSuda @runcom 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
