### PR TITLE
Ensure test graphdriver plugin runs on test host

### DIFF
--- a/integration-cli/docker_cli_daemon_plugins_test.go
+++ b/integration-cli/docker_cli_daemon_plugins_test.go
@@ -236,7 +236,7 @@ func (s *DockerDaemonSuite) TestVolumePlugin(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestGraphdriverPlugin(c *check.C) {
-	testRequires(c, Network, IsAmd64, DaemonIsLinux, overlaySupported)
+	testRequires(c, Network, IsAmd64, DaemonIsLinux, overlay2Supported)
 
 	s.d.Start(c)
 
@@ -246,7 +246,7 @@ func (s *DockerDaemonSuite) TestGraphdriverPlugin(c *check.C) {
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 
 	// restart the daemon with the plugin set as the storage driver
-	s.d.Restart(c, "-s", plugin)
+	s.d.Restart(c, "-s", plugin, "--storage-opt", "overlay2.override_kernel_check=1")
 
 	// run a container
 	out, err = s.d.Cmd("run", "--rm", "busybox", "true") // this will pull busybox using the plugin

--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -66,6 +66,8 @@ var (
 
 	// daemonPid is the pid of the main test daemon
 	daemonPid int
+
+	daemonKernelVersion string
 )
 
 func init() {
@@ -111,6 +113,7 @@ func init() {
 	type Info struct {
 		DockerRootDir     string
 		ExperimentalBuild bool
+		KernelVersion     string
 	}
 	var i Info
 	status, b, err := sockRequest("GET", "/info", nil)
@@ -118,6 +121,7 @@ func init() {
 		if err = json.Unmarshal(b, &i); err == nil {
 			dockerBasePath = i.DockerRootDir
 			experimentalDaemon = i.ExperimentalBuild
+			daemonKernelVersion = i.KernelVersion
 		}
 	}
 	volumesConfigPath = dockerBasePath + "/volumes"


### PR DESCRIPTION
Sets a kernel requirement for for `TestGraphdriverPlugin` since the
graphdriver being used is overlay2.. and also makes sure to skip the
kernel check in the actual graphdriver since we may be able to detect
kernels with backported support for overlay2 style mounts a bit more
freely in the test code.

Fixes #29505 