### PR TITLE
Remove bash completion for deprecated `docker daemon`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3955,7 +3955,6 @@ _docker() {
 		container
 		cp
 		create
-		daemon
 		diff
 		events
 		exec


### PR DESCRIPTION
`docker daemon` now is deprecated (#26834), so this PR removes its support from bash completion. This is the usual practice for deprecated features, the rationale being that users should not be encouraged to use deprecated API. 

Note that options are still completed once the user typed `docker daemon` manually.