### PR TITLE
Ignore the daemon log config when building images

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -49,6 +49,8 @@ var BuiltinAllowedBuildArgs = map[string]bool{
 	"no_proxy":    true,
 }
 
+var defaultLogConfig = container.LogConfig{Type: "none"}
+
 // Builder is a Dockerfile builder
 // It implements the builder.Backend interface.
 type Builder struct {

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -308,7 +308,11 @@ func workdir(b *Builder, args []string, attributes map[string]bool, original str
 		return nil
 	}
 
-	container, err := b.docker.ContainerCreate(types.ContainerCreateConfig{Config: b.runConfig})
+	container, err := b.docker.ContainerCreate(types.ContainerCreateConfig{
+		Config: b.runConfig,
+		// Set a log config to override any default value set on the daemon
+		HostConfig: &container.HostConfig{LogConfig: defaultLogConfig},
+	})
 	if err != nil {
 		return err
 	}

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -181,7 +181,11 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowLocalD
 		return nil
 	}
 
-	container, err := b.docker.ContainerCreate(types.ContainerCreateConfig{Config: b.runConfig})
+	container, err := b.docker.ContainerCreate(types.ContainerCreateConfig{
+		Config: b.runConfig,
+		// Set a log config to override any default value set on the daemon
+		HostConfig: &container.HostConfig{LogConfig: defaultLogConfig},
+	})
 	if err != nil {
 		return err
 	}
@@ -489,6 +493,8 @@ func (b *Builder) create() (string, error) {
 		ShmSize:     b.options.ShmSize,
 		Resources:   resources,
 		NetworkMode: container.NetworkMode(b.options.NetworkMode),
+		// Set a log config to override any default value set on the daemon
+		LogConfig: defaultLogConfig,
 	}
 
 	config := *b.runConfig

--- a/daemon/workdir.go
+++ b/daemon/workdir.go
@@ -1,6 +1,6 @@
 package daemon
 
-// ContainerCreateWorkdir creates the working directory. This is solves the
+// ContainerCreateWorkdir creates the working directory. This solves the
 // issue arising from https://github.com/docker/docker/issues/27545,
 // which was initially fixed by https://github.com/docker/docker/pull/27884. But that fix
 // was too expensive in terms of performance on Windows. Instead,

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1134,6 +1134,19 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverNoneLogsError(c *check.C) {
 	c.Assert(out, checker.Contains, expected)
 }
 
+func (s *DockerDaemonSuite) TestDaemonLoggingDriverShouldBeIgnoredForBuild(c *check.C) {
+	s.d.StartWithBusybox(c, "--log-driver=splunk")
+
+	out, err := s.d.Cmd("build")
+	out, code, err := s.d.BuildImageWithOut("busyboxs", `
+        FROM busybox
+        RUN echo foo`, false)
+	comment := check.Commentf("Failed to build image. output %s, exitCode %d, err %v", out, code, err)
+	c.Assert(err, check.IsNil, comment)
+	c.Assert(code, check.Equals, 0, comment)
+	c.Assert(out, checker.Contains, "foo", comment)
+}
+
 func (s *DockerDaemonSuite) TestDaemonUnixSockCleanedUp(c *check.C) {
 	dir, err := ioutil.TempDir("", "socket-cleanup-test")
 	if err != nil {


### PR DESCRIPTION
Fixes #19259

I believe the log config setting should be ignored by the builder. The logs should also be handled by the daemon.