### PR TITLE
Fixing a couple of network plugin life-cycle mgmt issues

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -23,7 +23,7 @@ github.com/RackSec/srslog 456df3a81436d29ba874f3590eeeee25d666f8a5
 github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-github.com/docker/libnetwork b908488a139e81cb8c4091cd836745aeb4d813a4
+github.com/docker/libnetwork 61f01cdbbda7e32e651198b04889f6d825064fa6
 github.com/docker/go-events 18b43f1bc85d9cdd42c05a6cd2d444c7a200a894
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/controller.go
+++ b/vendor/github.com/docker/libnetwork/controller.go
@@ -79,6 +79,9 @@ type NetworkController interface {
 	// BuiltinDrivers returns list of builtin drivers
 	BuiltinDrivers() []string
 
+	// BuiltinIPAMDrivers returns list of builtin ipam drivers
+	BuiltinIPAMDrivers() []string
+
 	// Config method returns the bootup configuration for the controller
 	Config() config.Config
 
@@ -476,12 +479,23 @@ func (c *controller) ID() string {
 
 func (c *controller) BuiltinDrivers() []string {
 	drivers := []string{}
-	for _, i := range getInitializers(c.cfg.Daemon.Experimental) {
-		if i.ntype == "remote" {
-			continue
+	c.drvRegistry.WalkDrivers(func(name string, driver driverapi.Driver, capability driverapi.Capability) bool {
+		if driver.IsBuiltIn() {
+			drivers = append(drivers, name)
 		}
-		drivers = append(drivers, i.ntype)
-	}
+		return false
+	})
+	return drivers
+}
+
+func (c *controller) BuiltinIPAMDrivers() []string {
+	drivers := []string{}
+	c.drvRegistry.WalkIPAMs(func(name string, driver ipamapi.Ipam, cap *ipamapi.Capability) bool {
+		if driver.IsBuiltIn() {
+			drivers = append(drivers, name)
+		}
+		return false
+	})
 	return drivers
 }
 

--- a/vendor/github.com/docker/libnetwork/driverapi/driverapi.go
+++ b/vendor/github.com/docker/libnetwork/driverapi/driverapi.go
@@ -74,6 +74,9 @@ type Driver interface {
 
 	// Type returns the the type of this driver, the network type this driver manages
 	Type() string
+
+	// IsBuiltIn returns true if it is a built-in driver
+	IsBuiltIn() bool
 }
 
 // NetworkInfo provides a go interface for drivers to provide network

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -1424,6 +1424,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
 func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil

--- a/vendor/github.com/docker/libnetwork/drivers/host/host.go
+++ b/vendor/github.com/docker/libnetwork/drivers/host/host.go
@@ -86,6 +86,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
 func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil

--- a/vendor/github.com/docker/libnetwork/drivers/ipvlan/ipvlan.go
+++ b/vendor/github.com/docker/libnetwork/drivers/ipvlan/ipvlan.go
@@ -84,6 +84,10 @@ func (d *driver) Type() string {
 	return ipvlanType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
 	return nil
 }

--- a/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan.go
+++ b/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan.go
@@ -86,6 +86,10 @@ func (d *driver) Type() string {
 	return macvlanType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
 	return nil
 }

--- a/vendor/github.com/docker/libnetwork/drivers/null/null.go
+++ b/vendor/github.com/docker/libnetwork/drivers/null/null.go
@@ -86,6 +86,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
 func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil

--- a/vendor/github.com/docker/libnetwork/drivers/overlay/overlay.go
+++ b/vendor/github.com/docker/libnetwork/drivers/overlay/overlay.go
@@ -211,6 +211,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 func validateSelf(node string) error {
 	advIP := net.ParseIP(node)
 	if advIP == nil {

--- a/vendor/github.com/docker/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/vendor/github.com/docker/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -229,6 +229,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
 func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return types.NotImplementedErrorf("not implemented")

--- a/vendor/github.com/docker/libnetwork/drivers/remote/driver.go
+++ b/vendor/github.com/docker/libnetwork/drivers/remote/driver.go
@@ -29,12 +29,7 @@ func newDriver(name string, client *plugins.Client) driverapi.Driver {
 // Init makes sure a remote driver is registered when a network driver
 // plugin is activated.
 func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
-	// Unit test code is unaware of a true PluginStore. So we fall back to v1 plugins.
-	handleFunc := plugins.Handle
-	if pg := dc.GetPluginGetter(); pg != nil {
-		handleFunc = pg.Handle
-	}
-	handleFunc(driverapi.NetworkPluginEndpointType, func(name string, client *plugins.Client) {
+	newPluginHandler := func(name string, client *plugins.Client) {
 		// negotiate driver capability with client
 		d := newDriver(name, client)
 		c, err := d.(*driver).getCapabilities()
@@ -45,7 +40,19 @@ func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
 		if err = dc.RegisterDriver(name, d, *c); err != nil {
 			logrus.Errorf("error registering driver for %s due to %v", name, err)
 		}
-	})
+	}
+
+	// Unit test code is unaware of a true PluginStore. So we fall back to v1 plugins.
+	handleFunc := plugins.Handle
+	if pg := dc.GetPluginGetter(); pg != nil {
+		handleFunc = pg.Handle
+		activePlugins := pg.GetAllManagedPluginsByCap(driverapi.NetworkPluginEndpointType)
+		for _, ap := range activePlugins {
+			newPluginHandler(ap.Name(), ap.Client())
+		}
+	}
+	handleFunc(driverapi.NetworkPluginEndpointType, newPluginHandler)
+
 	return nil
 }
 
@@ -303,6 +310,10 @@ func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
 
 func (d *driver) Type() string {
 	return d.networkType
+}
+
+func (d *driver) IsBuiltIn() bool {
+	return false
 }
 
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster

--- a/vendor/github.com/docker/libnetwork/drivers/solaris/bridge/bridge.go
+++ b/vendor/github.com/docker/libnetwork/drivers/solaris/bridge/bridge.go
@@ -916,6 +916,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
 func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil

--- a/vendor/github.com/docker/libnetwork/drivers/solaris/overlay/overlay.go
+++ b/vendor/github.com/docker/libnetwork/drivers/solaris/overlay/overlay.go
@@ -200,6 +200,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 func validateSelf(node string) error {
 	advIP := net.ParseIP(node)
 	if advIP == nil {

--- a/vendor/github.com/docker/libnetwork/drivers/windows/overlay/overlay_windows.go
+++ b/vendor/github.com/docker/libnetwork/drivers/windows/overlay/overlay_windows.go
@@ -176,6 +176,10 @@ func (d *driver) Type() string {
 	return networkType
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 func validateSelf(node string) error {
 	advIP := net.ParseIP(node)
 	if advIP == nil {

--- a/vendor/github.com/docker/libnetwork/drivers/windows/windows.go
+++ b/vendor/github.com/docker/libnetwork/drivers/windows/windows.go
@@ -698,6 +698,10 @@ func (d *driver) Type() string {
 	return d.name
 }
 
+func (d *driver) IsBuiltIn() bool {
+	return true
+}
+
 // DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
 func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil

--- a/vendor/github.com/docker/libnetwork/drvregistry/drvregistry.go
+++ b/vendor/github.com/docker/libnetwork/drvregistry/drvregistry.go
@@ -164,10 +164,10 @@ func (r *DrvRegistry) RegisterDriver(ntype string, driver driverapi.Driver, capa
 	}
 
 	r.Lock()
-	_, ok := r.drivers[ntype]
+	dd, ok := r.drivers[ntype]
 	r.Unlock()
 
-	if ok {
+	if ok && dd.driver.IsBuiltIn() {
 		return driverapi.ErrActiveRegistration(ntype)
 	}
 
@@ -192,9 +192,9 @@ func (r *DrvRegistry) registerIpamDriver(name string, driver ipamapi.Ipam, caps 
 	}
 
 	r.Lock()
-	_, ok := r.ipamDrivers[name]
+	dd, ok := r.ipamDrivers[name]
 	r.Unlock()
-	if ok {
+	if ok && dd.driver.IsBuiltIn() {
 		return types.ForbiddenErrorf("ipam driver %q already registered", name)
 	}
 

--- a/vendor/github.com/docker/libnetwork/ipam/allocator.go
+++ b/vendor/github.com/docker/libnetwork/ipam/allocator.go
@@ -594,3 +594,8 @@ func (a *Allocator) DumpDatabase() string {
 
 	return s
 }
+
+// IsBuiltIn returns true for builtin drivers
+func (a *Allocator) IsBuiltIn() bool {
+	return true
+}

--- a/vendor/github.com/docker/libnetwork/ipamapi/contract.go
+++ b/vendor/github.com/docker/libnetwork/ipamapi/contract.go
@@ -80,6 +80,9 @@ type Ipam interface {
 	RequestAddress(string, net.IP, map[string]string) (*net.IPNet, map[string]string, error)
 	// Release the address from the specified pool ID
 	ReleaseAddress(string, net.IP) error
+
+	//IsBuiltIn returns true if it is a built-in driver.
+	IsBuiltIn() bool
 }
 
 // Capability represents the requirements and capabilities of the IPAM driver

--- a/vendor/github.com/docker/libnetwork/ipams/null/null.go
+++ b/vendor/github.com/docker/libnetwork/ipams/null/null.go
@@ -65,6 +65,10 @@ func (a *allocator) DiscoverDelete(dType discoverapi.DiscoveryType, data interfa
 	return nil
 }
 
+func (a *allocator) IsBuiltIn() bool {
+	return true
+}
+
 // Init registers a remote ipam when its plugin is activated
 func Init(ic ipamapi.Callback, l, g interface{}) error {
 	return ic.RegisterIpamDriver(ipamapi.NullIPAM, &allocator{})

--- a/vendor/github.com/docker/libnetwork/ipams/remote/remote.go
+++ b/vendor/github.com/docker/libnetwork/ipams/remote/remote.go
@@ -31,12 +31,7 @@ func newAllocator(name string, client *plugins.Client) ipamapi.Ipam {
 // Init registers a remote ipam when its plugin is activated
 func Init(cb ipamapi.Callback, l, g interface{}) error {
 
-	// Unit test code is unaware of a true PluginStore. So we fall back to v1 plugins.
-	handleFunc := plugins.Handle
-	if pg := cb.GetPluginGetter(); pg != nil {
-		handleFunc = pg.Handle
-	}
-	handleFunc(ipamapi.PluginEndpointType, func(name string, client *plugins.Client) {
+	newPluginHandler := func(name string, client *plugins.Client) {
 		a := newAllocator(name, client)
 		if cps, err := a.(*allocator).getCapabilities(); err == nil {
 			if err := cb.RegisterIpamDriverWithCapabilities(name, a, cps); err != nil {
@@ -49,7 +44,18 @@ func Init(cb ipamapi.Callback, l, g interface{}) error {
 				logrus.Errorf("error registering remote ipam driver %s due to %v", name, err)
 			}
 		}
-	})
+	}
+
+	// Unit test code is unaware of a true PluginStore. So we fall back to v1 plugins.
+	handleFunc := plugins.Handle
+	if pg := cb.GetPluginGetter(); pg != nil {
+		handleFunc = pg.Handle
+		activePlugins := pg.GetAllManagedPluginsByCap(ipamapi.PluginEndpointType)
+		for _, ap := range activePlugins {
+			newPluginHandler(ap.Name(), ap.Client())
+		}
+	}
+	handleFunc(ipamapi.PluginEndpointType, newPluginHandler)
 	return nil
 }
 
@@ -142,4 +148,8 @@ func (a *allocator) DiscoverNew(dType discoverapi.DiscoveryType, data interface{
 // DiscoverDelete is a notification for a discovery delete event, such as a node leaving a cluster
 func (a *allocator) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil
+}
+
+func (a *allocator) IsBuiltIn() bool {
+	return false
 }

--- a/vendor/github.com/docker/libnetwork/ipams/windowsipam/windowsipam.go
+++ b/vendor/github.com/docker/libnetwork/ipams/windowsipam/windowsipam.go
@@ -101,3 +101,7 @@ func (a *allocator) DiscoverNew(dType discoverapi.DiscoveryType, data interface{
 func (a *allocator) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
 	return nil
 }
+
+func (a *allocator) IsBuiltIn() bool {
+	return true
+}


### PR DESCRIPTION
Fixes https://github.com/docker/docker/issues/29447 : Reference count is managed for network plugins using ACQUIRE and RELEASE mechanism in createNetwork and deleteNetwork.

Fixes https://github.com/docker/docker/issues/29471 : libnetwork remote driver init is modified to lookup active plugins and registered with drvRegistry

Fixes https://github.com/docker/docker/issues/29473 : Since plugin rm is not fully propagated to drvRegistry, we allowed overriding the drvRegistry map to cleanup stale plugin socket
