### PR TITLE
updates to glossary re: d4mac, d4win, toolbox per user request

### DIFF
--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -95,11 +95,24 @@ develop, ship, and run applications
 
 ## Docker for Mac
 
-[Docker for Mac](https://docs.docker.com/docker-for-mac/) is an easy-to-install, lightweight Docker development environment designed specifically for the Mac. A native Mac application, Docker for Mac uses the macOS Hypervisor framework, networking, and filesystem. It's the best solution if you want to build, debug, test, package, and ship Dockerized applications on a Mac. Docker for Mac supersedes [Docker Toolbox](#toolbox) as state-of-the-art Docker for macOS.
+[Docker for Mac](https://docs.docker.com/docker-for-mac/) is an easy-to-install,
+lightweight Docker development environment designed specifically for the Mac. A
+native Mac application, Docker for Mac uses the macOS Hypervisor framework,
+networking, and filesystem. It's the best solution if you want to build, debug,
+test, package, and ship Dockerized applications on a Mac. Docker for Mac
+supersedes [Docker Toolbox](#toolbox) as state-of-the-art Docker for macOS.
 
 ## Docker for Windows
 
-[Docker for Windows](https://docs.docker.com/docker-for-windows/) is an easy-to-install, lightweight Docker development environment designed specifically for Windows systems. Docker for Windows uses Microsoft Hyper-V, and runs as a native Windows app. It works with Windows Server 2016, and gives you the ability to set up and run Windows containers as well as the standard Linux containers (with an option to switch between the two). Docker for Windows is the best solution if you want to build, debug, test, package, and ship Dockerized applications on Windows machines. It supersedes [Docker Toolbox](#toolbox) as state-of-the-art Docker on Windows.
+[Docker for Windows](https://docs.docker.com/docker-for-windows/) is an
+easy-to-install, lightweight Docker development environment designed
+specifically for Windows systems. Docker for Windows uses Microsoft Hyper-V, and
+runs as a native Windows app. It works with Windows Server 2016, and gives you
+the ability to set up and run Windows containers as well as the standard Linux
+containers (with an option to switch between the two). Docker for Windows is the
+best solution if you want to build, debug, test, package, and ship Dockerized
+applications on Windows machines. It supersedes [Docker Toolbox](#toolbox) as
+state-of-the-art Docker on Windows.
 
 ## Docker Hub
 
@@ -272,18 +285,23 @@ containers.
 
 ## Toolbox
 
-[Docker Toolbox](https://docs.docker.com/toolbox/overview/) is a legacy installer for Mac and Windows users. It uses Oracle VirtualBox for virtualization.
+[Docker Toolbox](https://docs.docker.com/toolbox/overview/) is a legacy
+installer for Mac and Windows users. It uses Oracle VirtualBox for
+virtualization.
 
-For Macs running OS X El Capitan 10.11 and newer macOS releases, [Docker for Mac](https://docs.docker.com/docker-for-mac/) is the better solution.
+For Macs running OS X El Capitan 10.11 and newer macOS releases, [Docker for
+Mac](https://docs.docker.com/docker-for-mac/) is the better solution.
 
-For Windows systems running Windows 10 Pro and Microsoft Hyper-V, [Docker for Windows](https://docs.docker.com/docker-for-windows/) is the better solution.
+For Windows 10 systems that support Microsoft Hyper-V (Professional, Enterprise
+and Education), [Docker for
+Windows](https://docs.docker.com/docker-for-windows/) is the better solution.
 
 
 ## Union file system
 
-Union file systems, or UnionFS, are file systems that operate by creating layers, making them
-very lightweight and fast. Docker uses union file systems to provide the building
-blocks for containers.
+Union file systems, or UnionFS, are file systems that operate by creating
+layers, making them very lightweight and fast. Docker uses union file systems to
+provide the building blocks for containers.
 
 
 ## virtual machine

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -93,6 +93,14 @@ develop, ship, and run applications
 - The docker daemon process running on the host which manages images and containers
 
 
+## Docker for Mac
+
+[Docker for Mac](https://docs.docker.com/docker-for-mac/) is an easy-to-install, lightweight Docker development environment designed specifically for the Mac. A native Mac application, Docker for Mac uses the macOS Hypervisor framework, networking, and filesystem. It's the best solution if you want to build, debug, test, package, and ship Dockerized applications on a Mac. Docker for Mac supersedes [Docker Toolbox](#toolbox) as state-of-the-art Docker for macOS.
+
+## Docker for Windows
+
+[Docker for Windows](https://docs.docker.com/docker-for-windows/) is an easy-to-install, lightweight Docker development environment designed specifically for Windows systems. Docker for Windows uses Microsoft Hyper-V, and runs as a native Windows app. It works with Windows Server 2016, and gives you the ability to set up and run Windows containers as well as the standard Linux containers (with an option to switch between the two). Docker for Windows is the best solution if you want to build, debug, test, package, and ship Dockerized applications on Windows machines. It supersedes [Docker Toolbox](#toolbox) as state-of-the-art Docker on Windows.
+
 ## Docker Hub
 
 The [Docker Hub](https://hub.docker.com/) is a centralized resource for working with
@@ -264,7 +272,11 @@ containers.
 
 ## Toolbox
 
-Docker Toolbox is the installer for Mac and Windows users.
+[Docker Toolbox](https://docs.docker.com/toolbox/overview/) is a legacy installer for Mac and Windows users. It uses Oracle VirtualBox for virtualization.
+
+For Macs running OS X El Capitan 10.11 and newer macOS releases, [Docker for Mac](https://docs.docker.com/docker-for-mac/) is the better solution.
+
+For Windows systems running Windows 10 Pro and Microsoft Hyper-V, [Docker for Windows](https://docs.docker.com/docker-for-windows/) is the better solution.
 
 
 ## Union file system


### PR DESCRIPTION

### What I did

Updated glossary with new entries for Docker for Mac and Docker for Windows, and new info re: Docker Toolbox (which is now legacy on newer systems, so referenced d4mac, d4win on that entry)

### Description for the changelog

Glossary updates for Docker for Mac, Docker for Windows, Toolbox

### Animal 

![giraffes](https://cloud.githubusercontent.com/assets/11660803/21335049/9570232c-c610-11e6-9348-66a918ad63e8.jpg)

### Please review, merge (I don't have permissions)

@mstanleyjones @nathanleclaire @icecrime 
