### PR TITLE
plugingetter: Avoid all caps for constant declarations

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -516,7 +516,7 @@ func (cli *DaemonCli) initMiddlewares(s *apiserver.Server, cfg *apiserver.Config
 // plugins present on the host and available to the daemon
 func validateAuthzPlugins(requestedPlugins []string, pg plugingetter.PluginGetter) error {
 	for _, reqPlugin := range requestedPlugins {
-		if _, err := pg.Get(reqPlugin, authorization.AuthZApiImplements, plugingetter.LOOKUP); err != nil {
+		if _, err := pg.Get(reqPlugin, authorization.AuthZApiImplements, plugingetter.Lookup); err != nil {
 			return err
 		}
 	}

--- a/daemon/graphdriver/plugin.go
+++ b/daemon/graphdriver/plugin.go
@@ -22,7 +22,7 @@ func lookupPlugin(name string, pg plugingetter.PluginGetter, config Options) (Dr
 	if !config.ExperimentalEnabled {
 		return nil, fmt.Errorf("graphdriver plugins are only supported with experimental mode")
 	}
-	pl, err := pg.Get(name, "GraphDriver", plugingetter.ACQUIRE)
+	pl, err := pg.Get(name, "GraphDriver", plugingetter.Acquire)
 	if err != nil {
 		return nil, fmt.Errorf("Error looking up graphdriver plugin %s: %v", name, err)
 	}

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -301,9 +301,9 @@ func (daemon *Daemon) createNetwork(create types.NetworkCreateRequest, id string
 		return nil, err
 	}
 
-	daemon.pluginRefCount(driver, driverapi.NetworkPluginEndpointType, plugingetter.ACQUIRE)
+	daemon.pluginRefCount(driver, driverapi.NetworkPluginEndpointType, plugingetter.Acquire)
 	if create.IPAM != nil {
-		daemon.pluginRefCount(create.IPAM.Driver, ipamapi.PluginEndpointType, plugingetter.ACQUIRE)
+		daemon.pluginRefCount(create.IPAM.Driver, ipamapi.PluginEndpointType, plugingetter.Acquire)
 	}
 	daemon.LogNetworkEvent(n, "create")
 
@@ -450,9 +450,9 @@ func (daemon *Daemon) deleteNetwork(networkID string, dynamic bool) error {
 	if err := nw.Delete(); err != nil {
 		return err
 	}
-	daemon.pluginRefCount(nw.Type(), driverapi.NetworkPluginEndpointType, plugingetter.RELEASE)
+	daemon.pluginRefCount(nw.Type(), driverapi.NetworkPluginEndpointType, plugingetter.Release)
 	ipamType, _, _, _ := nw.Info().IpamConfig()
-	daemon.pluginRefCount(ipamType, ipamapi.PluginEndpointType, plugingetter.RELEASE)
+	daemon.pluginRefCount(ipamType, ipamapi.PluginEndpointType, plugingetter.Release)
 	daemon.LogNetworkEvent(nw, "destroy")
 	return nil
 }

--- a/pkg/authorization/plugin.go
+++ b/pkg/authorization/plugin.go
@@ -97,7 +97,7 @@ func (a *authorizationPlugin) initPlugin() error {
 			var e error
 
 			if pg := GetPluginGetter(); pg != nil {
-				plugin, e = pg.Get(a.name, AuthZApiImplements, plugingetter.LOOKUP)
+				plugin, e = pg.Get(a.name, AuthZApiImplements, plugingetter.Lookup)
 			} else {
 				plugin, e = plugins.Get(a.name, AuthZApiImplements)
 			}

--- a/pkg/plugingetter/getter.go
+++ b/pkg/plugingetter/getter.go
@@ -3,12 +3,12 @@ package plugingetter
 import "github.com/docker/docker/pkg/plugins"
 
 const (
-	// LOOKUP doesn't update RefCount
-	LOOKUP = 0
-	// ACQUIRE increments RefCount
-	ACQUIRE = 1
-	// RELEASE decrements RefCount
-	RELEASE = -1
+	// Lookup doesn't update RefCount
+	Lookup = 0
+	// Acquire increments RefCount
+	Acquire = 1
+	// Release decrements RefCount
+	Release = -1
 )
 
 // CompatPlugin is an abstraction to handle both v2(new) and v1(legacy) plugins.

--- a/plugin/v2/plugin.go
+++ b/plugin/v2/plugin.go
@@ -233,12 +233,12 @@ func (p *Plugin) AddRefCount(count int) {
 // Acquire increments the plugin's reference count
 // This should be followed up by `Release()` when the plugin is no longer in use.
 func (p *Plugin) Acquire() {
-	p.AddRefCount(plugingetter.ACQUIRE)
+	p.AddRefCount(plugingetter.Acquire)
 }
 
 // Release decrements the plugin's reference count
 // This should only be called when the plugin is no longer in use, e.g. with
-// via `Acquire()` or getter.Get("name", "type", plugingetter.ACQUIRE)
+// via `Acquire()` or getter.Get("name", "type", plugingetter.Acquire)
 func (p *Plugin) Release() {
-	p.AddRefCount(plugingetter.RELEASE)
+	p.AddRefCount(plugingetter.Release)
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -23,7 +23,7 @@ github.com/RackSec/srslog 456df3a81436d29ba874f3590eeeee25d666f8a5
 github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-github.com/docker/libnetwork 61f01cdbbda7e32e651198b04889f6d825064fa6
+github.com/docker/libnetwork 382be38ce860738d80b53d7875d83abd5970d9d6 https://github.com/aaronlehmann/libnetwork
 github.com/docker/go-events 18b43f1bc85d9cdd42c05a6cd2d444c7a200a894
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/controller.go
+++ b/vendor/github.com/docker/libnetwork/controller.go
@@ -1087,7 +1087,7 @@ func (c *controller) loadDriver(networkType string) error {
 	var err error
 
 	if pg := c.GetPluginGetter(); pg != nil {
-		_, err = pg.Get(networkType, driverapi.NetworkPluginEndpointType, plugingetter.LOOKUP)
+		_, err = pg.Get(networkType, driverapi.NetworkPluginEndpointType, plugingetter.Lookup)
 	} else {
 		_, err = plugins.Get(networkType, driverapi.NetworkPluginEndpointType)
 	}
@@ -1106,7 +1106,7 @@ func (c *controller) loadIPAMDriver(name string) error {
 	var err error
 
 	if pg := c.GetPluginGetter(); pg != nil {
-		_, err = pg.Get(name, ipamapi.PluginEndpointType, plugingetter.LOOKUP)
+		_, err = pg.Get(name, ipamapi.PluginEndpointType, plugingetter.Lookup)
 	} else {
 		_, err = plugins.Get(name, ipamapi.PluginEndpointType)
 	}

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -146,7 +146,7 @@ func GetDriver(name string) (volume.Driver, error) {
 	if name == "" {
 		name = volume.DefaultDriverName
 	}
-	return lookup(name, getter.LOOKUP)
+	return lookup(name, getter.Lookup)
 }
 
 // CreateDriver returns a volume driver by its name and increments RefCount.
@@ -155,7 +155,7 @@ func CreateDriver(name string) (volume.Driver, error) {
 	if name == "" {
 		name = volume.DefaultDriverName
 	}
-	return lookup(name, getter.ACQUIRE)
+	return lookup(name, getter.Acquire)
 }
 
 // RemoveDriver returns a volume driver by its name and decrements RefCount..
@@ -164,7 +164,7 @@ func RemoveDriver(name string) (volume.Driver, error) {
 	if name == "" {
 		name = volume.DefaultDriverName
 	}
-	return lookup(name, getter.RELEASE)
+	return lookup(name, getter.Release)
 }
 
 // GetDriverList returns list of volume drivers registered.


### PR DESCRIPTION
Go style calls for mixed caps instead of all caps:
https://golang.org/doc/effective_go.html#mixed-caps

Change `LOOKUP`, `ACQUIRE`, and `RELEASE` to `Lookup`, `Acquire`, and `Release`.

I will rebase this after #29556 is merged.

Note that vendoring will be an issue because of cyclic dependencies between repositories. We should probably vendor a fork of libnetwork, and then upstream the change.