### PR TITLE
"resparsify" can not be got

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -477,7 +477,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
 
     Enables or disables the use of blkdiscard when removing devicemapper
     devices. This is enabled by default (only) if using loopback devices and is
-    required to resparsify the loopback file on image/container removal.
+    required to reparse the loopback file on image/container removal.
 
     Disabling this on loopback can lead to *much* faster container removal
     times, but will make the space used in `/var/lib/docker` directory not be


### PR DESCRIPTION
Signed-off-by: Jie Luo <luo612@zju.edu.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
The description is about "dm.blkdiscard", and I cannot understand the word "resparsify" . Maybe it means "reparse", which means that when a container is removed, we should parse the loopback file again.
**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

