### PR TITLE
Refactor cleanup of paused test containers

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -354,7 +354,7 @@ func (s *DockerSuite) TestContainerAPIPause(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusNoContent)
 
-	pausedContainers, err := getSliceOfPausedContainers()
+	pausedContainers, err := getPausedContainers()
 	c.Assert(err, checker.IsNil, check.Commentf("error thrown while checking if containers were paused"))
 
 	if len(pausedContainers) != 1 || stringid.TruncateID(ContainerID) != pausedContainers[0] {
@@ -365,9 +365,9 @@ func (s *DockerSuite) TestContainerAPIPause(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusNoContent)
 
-	pausedContainers, err = getSliceOfPausedContainers()
+	pausedContainers, err = getPausedContainers()
 	c.Assert(err, checker.IsNil, check.Commentf("error thrown while checking if containers were paused"))
-	c.Assert(pausedContainers, checker.IsNil, check.Commentf("There should be no paused container."))
+	c.Assert(pausedContainers, checker.HasLen, 0, check.Commentf("There should be no paused container."))
 }
 
 func (s *DockerSuite) TestContainerAPITop(c *check.C) {

--- a/integration-cli/docker_cli_pause_test.go
+++ b/integration-cli/docker_cli_pause_test.go
@@ -15,7 +15,7 @@ func (s *DockerSuite) TestPause(c *check.C) {
 	runSleepingContainer(c, "-d", "--name", name)
 
 	dockerCmd(c, "pause", name)
-	pausedContainers, err := getSliceOfPausedContainers()
+	pausedContainers, err := getPausedContainers()
 	c.Assert(err, checker.IsNil)
 	c.Assert(len(pausedContainers), checker.Equals, 1)
 
@@ -41,7 +41,7 @@ func (s *DockerSuite) TestPauseMultipleContainers(c *check.C) {
 		runSleepingContainer(c, "-d", "--name", name)
 	}
 	dockerCmd(c, append([]string{"pause"}, containers...)...)
-	pausedContainers, err := getSliceOfPausedContainers()
+	pausedContainers, err := getPausedContainers()
 	c.Assert(err, checker.IsNil)
 	c.Assert(len(pausedContainers), checker.Equals, len(containers))
 


### PR DESCRIPTION
This simplifies the code  a bit, and fixes a case where the test code was erroneously sending `POST /containers//unpause`