### PR TITLE
Improve bash completion for bundled plugins

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -262,7 +262,7 @@ __docker_plugins_bundled() {
 		esac
 	done
 
-	local plugins=($(__docker_q info | sed -n "/^Plugins/,/^[^ ]/s/ $type: //p"))
+	local plugins=($(__docker_q info --format "{{range \$i, \$p := .Plugins.$type}}{{.}} {{end}}"))
 	for del in "${remove[@]}" ; do
 		plugins=(${plugins[@]/$del/})
 	done


### PR DESCRIPTION
`docker info` now has a `--format` option. This allows direct access to the lists of various bundled plugin types. There is no more need to "parse" the output of `docker info` with a cryptic call to an external command.

This is a refactoring. The behaviour is not changed. To verify, manually call the old and new helper function with the available plugin types, e.g.

```bash
$ __docker_plugins_bundled --type Volumes

$ __docker_plugins_bundled --type Network
bridge host macvlan null overlay
$ __docker_plugins_bundled --type Authorization

```