### PR TITLE
Fix regular expression for PowerShell DCO check

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -184,7 +184,7 @@ Function Validate-DCO($headCommit, $upstreamCommit) {
     $usernameRegex='[a-zA-Z0-9][a-zA-Z0-9-]+'
 
     $dcoPrefix="Signed-off-by:"
-    $dcoRegex="^(Docker-DCO-1.1-)?$dcoPrefix ([^<]+) <([^<>@]+@[^<>]+)>( \\(github: ($usernameRegex)\\))?$"
+    $dcoRegex="^(Docker-DCO-1.1-)?$dcoPrefix ([^<]+) <([^<>@]+@[^<>]+)>( \(github: ($usernameRegex)\))?$"
 
     $counts = Invoke-Expression "git diff --numstat $upstreamCommit...$headCommit"
     if ($LASTEXITCODE -ne 0) { Throw "Failed git diff --numstat" }


### PR DESCRIPTION
Signed-off-by: John Stephens <johnstep@docker.com>

This corrects the remaining issue from #29494. In PowerShell, the escape character is the grave accent, not the backslash. Therefore, the backslash in this string must _not_ be escaped with another backslash.