### PR TITLE
Sort the labels passed from `build --labels`

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -203,6 +204,28 @@ func sanitizeRepoAndTags(names []string) ([]reference.Named, error) {
 	return repoAndTags, nil
 }
 
+func (b *Builder) processLabels() error {
+	if len(b.options.Labels) == 0 {
+		return nil
+	}
+
+	var labels []string
+	for k, v := range b.options.Labels {
+		labels = append(labels, fmt.Sprintf("%q='%s'", k, v))
+	}
+	// Sort the label to have a repeatable order
+	sort.Strings(labels)
+
+	line := "LABEL " + strings.Join(labels, " ")
+	_, node, err := parser.ParseLine(line, &b.directive, false)
+	if err != nil {
+		return err
+	}
+	b.dockerfile.Children = append(b.dockerfile.Children, node)
+
+	return nil
+}
+
 // build runs the Dockerfile builder from a context and a docker object that allows to make calls
 // to Docker.
 //
@@ -233,16 +256,8 @@ func (b *Builder) build(stdout io.Writer, stderr io.Writer, out io.Writer) (stri
 		return "", err
 	}
 
-	if len(b.options.Labels) > 0 {
-		line := "LABEL "
-		for k, v := range b.options.Labels {
-			line += fmt.Sprintf("%q='%s' ", k, v)
-		}
-		_, node, err := parser.ParseLine(line, &b.directive, false)
-		if err != nil {
-			return "", err
-		}
-		b.dockerfile.Children = append(b.dockerfile.Children, node)
+	if err := b.processLabels(); err != nil {
+		return "", err
 	}
 
 	var shortImgID string

--- a/builder/dockerfile/builder_test.go
+++ b/builder/dockerfile/builder_test.go
@@ -1,0 +1,54 @@
+package dockerfile
+
+import (
+	"strings"
+
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/builder/dockerfile/parser"
+)
+
+func TestBuildProcessLabels(t *testing.T) {
+	dockerfile := "FROM scratch"
+	d := parser.Directive{}
+	parser.SetEscapeToken(parser.DefaultEscapeToken, &d)
+	n, err := parser.Parse(strings.NewReader(dockerfile), &d)
+	if err != nil {
+		t.Fatalf("Error when parsing Dockerfile: %s", err)
+	}
+
+	options := &types.ImageBuildOptions{
+		Labels: map[string]string{
+			"org.e": "cli-e",
+			"org.d": "cli-d",
+			"org.c": "cli-c",
+			"org.b": "cli-b",
+			"org.a": "cli-a",
+		},
+	}
+	b := &Builder{
+		runConfig:  &container.Config{},
+		options:    options,
+		directive:  d,
+		dockerfile: n,
+	}
+	err = b.processLabels()
+	if err != nil {
+		t.Fatalf("Error when processing labels: %s", err)
+	}
+
+	expected := []string{
+		"FROM scratch",
+		`LABEL "org.a"='cli-a' "org.b"='cli-b' "org.c"='cli-c' "org.d"='cli-d' "org.e"='cli-e'`,
+	}
+	if len(b.dockerfile.Children) != 2 {
+		t.Fatalf("Expect 2, got %d", len(b.dockerfile.Children))
+	}
+	for i, v := range b.dockerfile.Children {
+		if v.Original != expected[i] {
+			t.Fatalf("Expect '%s' for %dth children, got, '%s'", expected[i], i, v.Original)
+		}
+	}
+}


### PR DESCRIPTION
**- What I did**

This fix tries to fix the issue in #29619 where labels passed from `build --labels` are not sorted.
As a result, if multiple labels have been passed, each `docker build --labels A=A --labels B=B --labels C=C` run will generate different layers.

**- How I did it**

This fix fixes the issue by sort the Labels before they are concatenated to `LABEL ...`.

**- How to verify it**

An integration test has been added to cover the changes

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![cute-kitten-865-10-400x250](https://cloud.githubusercontent.com/assets/6932348/21379497/49fb2592-c703-11e6-991c-3a4d61956bda.jpg)

This fix fixes #29619.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>