### PR TITLE
Remove unused var 'errTLSConfigUnavailable'

### DIFF
--- a/client/transport.go
+++ b/client/transport.go
@@ -2,11 +2,8 @@ package client
 
 import (
 	"crypto/tls"
-	"errors"
 	"net/http"
 )
-
-var errTLSConfigUnavailable = errors.New("TLSConfig unavailable")
 
 // transportFunc allows us to inject a mock transport for testing. We define it
 // here so we can detect the tlsconfig and return nil for only this type.


### PR DESCRIPTION
**- What I did**
Remove var 'errTLSConfigUnavailable' which is unused 

**- How I did it**

**- How to verify it**

**- Description for the changelog**


Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>