### PR TITLE
support registry mirror config reload

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1289,6 +1289,7 @@ The list of currently supported options that can be reconfigured is this:
   be used to run containers
 - `authorization-plugin`: specifies the authorization plugins to use.
 - `insecure-registries`: it replaces the daemon insecure registries with a new set of insecure registries. If some existing insecure registries in daemon's configuration are not in newly reloaded insecure resgitries, these existing ones will be removed from daemon's config.
+- `registry-mirrors`: it replaces the daemon registry mirrors with a new set of registry mirrors. If some existing registry mirrors in daemon's configuration are not in newly reloaded registry mirrors, these existing ones will be removed from daemon's config.
 
 Updating and reloading the cluster configurations such as `--cluster-store`,
 `--cluster-advertise` and `--cluster-store-opts` will take effect only if

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -429,7 +429,7 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *check.C) {
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c))
 	c.Assert(err, checker.IsNil)
 
-	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s (cluster-advertise=, cluster-store=, cluster-store-opts={}, debug=true, default-runtime=runc, insecure-registries=[], labels=[\"bar=foo\"], live-restore=false, max-concurrent-downloads=1, max-concurrent-uploads=5, name=%s, runtimes=runc:{docker-runc []}, shutdown-timeout=10)", daemonID, daemonName))
+	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s (cluster-advertise=, cluster-store=, cluster-store-opts={}, debug=true, default-runtime=runc, insecure-registries=[], labels=[\"bar=foo\"], live-restore=false, max-concurrent-downloads=1, max-concurrent-uploads=5, name=%s, registry-mirrors=[], runtimes=runc:{docker-runc []}, shutdown-timeout=10)", daemonID, daemonName))
 }
 
 func (s *DockerDaemonSuite) TestDaemonEventsWithFilters(c *check.C) {

--- a/registry/config_test.go
+++ b/registry/config_test.go
@@ -7,7 +7,9 @@ import (
 func TestValidateMirror(t *testing.T) {
 	valid := []string{
 		"http://mirror-1.com",
+		"http://mirror-1.com/",
 		"https://mirror-1.com",
+		"https://mirror-1.com/",
 		"http://localhost",
 		"https://localhost",
 		"http://localhost:5000",
@@ -21,15 +23,14 @@ func TestValidateMirror(t *testing.T) {
 	invalid := []string{
 		"!invalid!://%as%",
 		"ftp://mirror-1.com",
-		"http://mirror-1.com/",
 		"http://mirror-1.com/?q=foo",
 		"http://mirror-1.com/v1/",
 		"http://mirror-1.com/v1/?q=foo",
 		"http://mirror-1.com/v1/?q=foo#frag",
 		"http://mirror-1.com?q=foo",
 		"https://mirror-1.com#frag",
-		"https://mirror-1.com/",
 		"https://mirror-1.com/#frag",
+		"http://foo:bar@mirror-1.com/",
 		"https://mirror-1.com/v1/",
 		"https://mirror-1.com/v1/#",
 		"https://mirror-1.com?q",

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -663,7 +663,7 @@ func TestMirrorEndpointLookup(t *testing.T) {
 		}
 		return false
 	}
-	s := DefaultService{config: makeServiceConfig([]string{"my.mirror"}, nil)}
+	s := DefaultService{config: makeServiceConfig([]string{"https://my.mirror"}, nil)}
 
 	imageName, err := reference.WithName(IndexName + "/test/image")
 	if err != nil {

--- a/registry/service.go
+++ b/registry/service.go
@@ -31,6 +31,7 @@ type Service interface {
 	Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registrytypes.SearchResults, error)
 	ServiceConfig() *registrytypes.ServiceConfig
 	TLSConfig(hostname string) (*tls.Config, error)
+	LoadMirrors([]string) error
 	LoadInsecureRegistries([]string) error
 }
 
@@ -71,6 +72,14 @@ func (s *DefaultService) ServiceConfig() *registrytypes.ServiceConfig {
 	servConfig.Mirrors = append(servConfig.Mirrors, s.config.ServiceConfig.Mirrors...)
 
 	return &servConfig
+}
+
+// LoadMirrors loads registry mirrors for Service
+func (s *DefaultService) LoadMirrors(mirrors []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.config.LoadMirrors(mirrors)
 }
 
 // LoadInsecureRegistries loads insecure registries for Service


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

fixes https://github.com/docker/docker/issues/29594

this PR makes docker daemon support reload config registry mirror.

**- What I did**
1. add registry-mirror enable reload
2. fix a bug that duplicated mirrors will appear in the daemon and `docker info`
3. add a test case for that

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

