### PR TITLE
remove 400 in endpoint `POST /build`

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	apierrors "github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
@@ -95,7 +94,7 @@ func NewBuildManager(b builder.Backend) (bm *BuildManager) {
 // BuildFromContext builds a new image from a given context.
 func (bm *BuildManager) BuildFromContext(ctx context.Context, src io.ReadCloser, remote string, buildOptions *types.ImageBuildOptions, pg backend.ProgressWriter) (string, error) {
 	if buildOptions.Squash && !bm.backend.HasExperimental() {
-		return "", apierrors.NewBadRequestError(errors.New("squash is only supported with experimental mode"))
+		return "", errors.New("squash is only supported with experimental mode")
 	}
 	buildContext, dockerfileName, err := builder.DetectContextFromRemoteURL(src, remote, pg.ProgressReaderFunc)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

remove status code of 400 from endpoint `/build`

Here is my reason:
1. in api version 1.24, there is no status code 400 for this endpoint. While master has code https://github.com/docker/docker/blob/master/builder/dockerfile/builder.go#L97-L99, while 1.25 has no this part. When adding a status code, we need to be very careful. this pr added this https://github.com/docker/docker/pull/22641
2. if we introduce a new status code, I think in the endpoint there are much more case which should return 400, since there are lots of option validation in `newImageBuildOptions`; That will bring more back compatibility issue again. 

As in swagger.yml this 400 has not been added, and the reason above, after some tradeoff, I think we had better remove this 400.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

