### PR TITLE
poule: do not recognize "arm" as platform/arm

### DIFF
--- a/poule.yml
+++ b/poule.yml
@@ -30,7 +30,7 @@
                 platform/desktop:    [ "docker for mac", "docker for windows" ],
                 platform/freebsd:    [ "freebsd" ],
                 platform/windows:    [ "nanoserver", "windowsservercore", "windows server" ],
-                platform/arm:        [ "raspberry", "arm", "raspbian", "rpi", "beaglebone", "pine64" ],
+                platform/arm:        [ "raspberry", "raspbian", "rpi", "beaglebone", "pine64" ],
             }
         }
       - type:       version-label


### PR DESCRIPTION
Some words such as "swarm" and "apparmor" were recognized as "arm". 
https://github.com/docker/docker/issues/29655#issuecomment-268771674

So I suggest removing "arm" from the pattern keyword list at the moment.

Another idea is to make poule to require space/quotation/period characters around the pattern keyword. But it can be done later.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
