### PR TITLE
Add a GetAll function that returns only managed plugins supported by V2

### DIFF
--- a/pkg/plugingetter/getter.go
+++ b/pkg/plugingetter/getter.go
@@ -30,5 +30,6 @@ type CountedPlugin interface {
 type PluginGetter interface {
 	Get(name, capability string, mode int) (CompatPlugin, error)
 	GetAllByCap(capability string) ([]CompatPlugin, error)
+	GetAllManagedPluginsByCap(capability string) []CompatPlugin
 	Handle(capability string, callback func(string, *plugins.Client))
 }

--- a/plugin/store/store.go
+++ b/plugin/store/store.go
@@ -206,6 +206,11 @@ func (ps *Store) Get(name, capability string, mode int) (plugingetter.CompatPlug
 	return nil, err
 }
 
+// GetAllManagedPluginsByCap returns a list of managed plugins matching the given capability.
+func (ps *Store) GetAllManagedPluginsByCap(capability string) []plugingetter.CompatPlugin {
+	return ps.getAllByCap(capability)
+}
+
 // GetAllByCap returns a list of enabled plugins matching the given capability.
 func (ps *Store) GetAllByCap(capability string) ([]plugingetter.CompatPlugin, error) {
 	result := make([]plugingetter.CompatPlugin, 0, 1)


### PR DESCRIPTION
The current GetAllByCap API handles both V2 and legacy plugins. Also due to the
nature of V1 plugins, it also loads them. This causes problems when
loading is not required. Hence adding an independent API that will
return only the plugins that are loaded using v2 mangaed plugins.

Based on discussions with @anusha-ragunathan, This patch is required to properly fix the IT failures in https://github.com/docker/docker/pull/29556.

Signed-off-by: Madhu Venugopal <madhu@docker.com>
