### PR TITLE
Fix image's `CMD` after `WORKDIR` in Dockerfile

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -297,17 +297,17 @@ func workdir(b *Builder, args []string, attributes map[string]bool, original str
 	}
 	b.runConfig.Image = b.image
 
-	cmd := b.runConfig.Cmd
-	b.runConfig.Cmd = strslice.StrSlice(append(getShell(b.runConfig), fmt.Sprintf("#(nop) WORKDIR %s", b.runConfig.WorkingDir)))
-	defer func(cmd strslice.StrSlice) { b.runConfig.Cmd = cmd }(cmd)
-
 	if hit, err := b.probeCache(); err != nil {
 		return err
 	} else if hit {
 		return nil
 	}
 
-	container, err := b.docker.ContainerCreate(types.ContainerCreateConfig{Config: b.runConfig})
+	// Actually copy the struct
+	workdirConfig := *b.runConfig
+	workdirConfig.Cmd = strslice.StrSlice(append(getShell(b.runConfig), fmt.Sprintf("#(nop) WORKDIR %s", b.runConfig.WorkingDir)))
+
+	container, err := b.docker.ContainerCreate(types.ContainerCreateConfig{Config: &workdirConfig})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fix tries to fix #29667 where image's `CMD` is modified after `WORKDIR` in Dockerfile.

The value of `b.runConfig.Cmd` was modified in the processing
of `WORKDIR`, in order to fix 28902. However, the same
`b.runConfig.Cmd` is passed to `commit()`.

This fix restored the `b.runConfig.Cmd` before `commit()`
the image for `WORKDIR`.

A test has been added.

This fix fixes #29667.

This fix is related to #28902, #28909, #28514.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>