### PR TITLE
Fix inspect object by invalid reference

### DIFF
--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -456,3 +456,11 @@ func (s *DockerSuite) TestInspectUnknownObject(c *check.C) {
 	c.Assert(out, checker.Contains, "Error: No such object: foobar")
 	c.Assert(err.Error(), checker.Contains, "Error: No such object: foobar")
 }
+
+func (s *DockerSuite) TestInpectInvalidReference(c *check.C) {
+	// This test should work on both Windows and Linux
+	out, _, err := dockerCmdWithError("inspect", "FooBar")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "Error: No such object: FooBar")
+	c.Assert(err.Error(), checker.Contains, "Error: No such object: FooBar")
+}

--- a/plugin/store.go
+++ b/plugin/store.go
@@ -232,7 +232,7 @@ func (ps *Store) resolvePluginID(idOrName string) (string, error) {
 
 	ref, err := reference.ParseNamed(idOrName)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to parse %v", idOrName)
+		return "", errors.WithStack(ErrNotFound(idOrName))
 	}
 	if _, ok := ref.(reference.Canonical); ok {
 		logrus.Warnf("canonical references cannot be resolved: %v", ref.String())


### PR DESCRIPTION
Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>

Fixes flaky TestEventsOOMDisableTrue

```
04:45:32 ----------------------------------------------------------------------
04:45:32 FAIL: docker_cli_events_unix_test.go:80: DockerSuite.TestEventsOOMDisableTrue
04:45:32 
04:45:32 docker_cli_events_unix_test.go:98:
04:45:32     c.Assert(waitRun("oomTrue"), checker.IsNil)
04:45:32 ... value *errors.fundamental = error executing docker inspect: Error response from daemon: failed to parse oomTrue: Error parsing reference: "oomTrue" is not a valid repository/tag: repository name must be lowercase
04:45:32 
04:45:32 
04:45:32  ("error executing docker inspect: Error response from daemon: failed to parse oomTrue: Error parsing reference: \"oomTrue\" is not a valid repository/tag: repository name must be lowercase\n\n\n")
04:45:32 
04:45:36 
04:45:36 ----------------------------------------------------------------------
```

Test error didn't show up on PR because this test only runs in selected platforms.