### PR TITLE
Minor cleanups in cli/command/container

### DIFF
--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -1,11 +1,9 @@
 package container
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"net/http/httputil"
-
-	"golang.org/x/net/context"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
@@ -13,6 +11,7 @@ import (
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type attachOptions struct {
@@ -54,11 +53,11 @@ func runAttach(dockerCli *command.DockerCli, opts *attachOptions) error {
 	}
 
 	if !c.State.Running {
-		return fmt.Errorf("You cannot attach to a stopped container, start it first")
+		return errors.New("You cannot attach to a stopped container, start it first")
 	}
 
 	if c.State.Paused {
-		return fmt.Errorf("You cannot attach to a paused container, unpause it first")
+		return errors.New("You cannot attach to a paused container, unpause it first")
 	}
 
 	if err := dockerCli.In().CheckTty(!opts.noStdin, c.Config.Tty); err != nil {

--- a/cli/command/container/cmd.go
+++ b/cli/command/container/cmd.go
@@ -1,10 +1,9 @@
 package container
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
+	"github.com/spf13/cobra"
 )
 
 // NewContainerCommand returns a cobra command for `container` subcommands

--- a/cli/command/container/commit.go
+++ b/cli/command/container/commit.go
@@ -3,13 +3,12 @@ package container
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	dockeropts "github.com/docker/docker/opts"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type commitOptions struct {

--- a/cli/command/container/cp.go
+++ b/cli/command/container/cp.go
@@ -1,13 +1,12 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli"
@@ -15,6 +14,7 @@ import (
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/system"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type copyOptions struct {
@@ -53,10 +53,10 @@ func NewCopyCommand(dockerCli *command.DockerCli) *cobra.Command {
 		Args: cli.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if args[0] == "" {
-				return fmt.Errorf("source can not be empty")
+				return errors.New("source can not be empty")
 			}
 			if args[1] == "" {
-				return fmt.Errorf("destination can not be empty")
+				return errors.New("destination can not be empty")
 			}
 			opts.source = args[0]
 			opts.destination = args[1]
@@ -96,10 +96,10 @@ func runCopy(dockerCli *command.DockerCli, opts copyOptions) error {
 		return copyToContainer(ctx, dockerCli, srcPath, dstContainer, dstPath, cpParam)
 	case acrossContainers:
 		// Copying between containers isn't supported.
-		return fmt.Errorf("copying between containers is not supported")
+		return errors.New("copying between containers is not supported")
 	default:
 		// User didn't specify any container.
-		return fmt.Errorf("must specify at least one container source")
+		return errors.New("must specify at least one container source")
 	}
 }
 
@@ -227,7 +227,7 @@ func copyToContainer(ctx context.Context, dockerCli *command.DockerCli, srcPath,
 		content = os.Stdin
 		resolvedDstPath = dstInfo.Path
 		if !dstInfo.IsDir {
-			return fmt.Errorf("destination %q must be a directory", fmt.Sprintf("%s:%s", dstContainer, dstPath))
+			return fmt.Errorf("destination \"%s:%s\" must be a directory", dstContainer, dstPath)
 		}
 	} else {
 		// Prepare source copy info.

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -5,22 +5,21 @@ import (
 	"io"
 	"os"
 
-	"golang.org/x/net/context"
-
-	"github.com/docker/docker/cli"
-	"github.com/docker/docker/cli/command"
-	"github.com/docker/docker/cli/command/image"
-	"github.com/docker/docker/pkg/jsonmessage"
-	// FIXME migrate to docker/distribution/reference
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	networktypes "github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/command"
+	"github.com/docker/docker/cli/command/image"
 	apiclient "github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
+	// FIXME migrate to docker/distribution/reference
 	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 	runconfigopts "github.com/docker/docker/runconfig/opts"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"golang.org/x/net/context"
 )
 
 type createOptions struct {
@@ -69,7 +68,7 @@ func runCreate(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *createO
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(dockerCli.Out(), "%s\n", response.ID)
+	fmt.Fprintln(dockerCli.Out(), response.ID)
 	return nil
 }
 
@@ -118,10 +117,11 @@ type cidFile struct {
 func (cid *cidFile) Close() error {
 	cid.file.Close()
 
-	if !cid.written {
-		if err := os.Remove(cid.path); err != nil {
-			return fmt.Errorf("failed to remove the CID file '%s': %s \n", cid.path, err)
-		}
+	if cid.written {
+		return nil
+	}
+	if err := os.Remove(cid.path); err != nil {
+		return fmt.Errorf("failed to remove the CID file '%s': %s \n", cid.path, err)
 	}
 
 	return nil

--- a/cli/command/container/diff.go
+++ b/cli/command/container/diff.go
@@ -1,14 +1,14 @@
 package container
 
 import (
+	"errors"
 	"fmt"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type diffOptions struct {
@@ -32,7 +32,7 @@ func NewDiffCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 func runDiff(dockerCli *command.DockerCli, opts *diffOptions) error {
 	if opts.container == "" {
-		return fmt.Errorf("Container name cannot be empty")
+		return errors.New("Container name cannot be empty")
 	}
 	ctx := context.Background()
 
@@ -51,7 +51,7 @@ func runDiff(dockerCli *command.DockerCli, opts *diffOptions) error {
 		case archive.ChangeDelete:
 			kind = "D"
 		}
-		fmt.Fprintf(dockerCli.Out(), "%s %s\n", kind, change.Path)
+		fmt.Fprintln(dockerCli.Out(), kind, change.Path)
 	}
 
 	return nil

--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"io"
 
-	"golang.org/x/net/context"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli"
@@ -15,6 +13,7 @@ import (
 	"github.com/docker/docker/pkg/promise"
 	runconfigopts "github.com/docker/docker/runconfig/opts"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type execOptions struct {
@@ -88,7 +87,7 @@ func runExec(dockerCli *command.DockerCli, opts *execOptions, container string, 
 
 	execID := response.ID
 	if execID == "" {
-		fmt.Fprintf(dockerCli.Out(), "exec ID empty")
+		fmt.Fprintln(dockerCli.Out(), "exec ID empty")
 		return nil
 	}
 
@@ -143,7 +142,7 @@ func runExec(dockerCli *command.DockerCli, opts *execOptions, container string, 
 
 	if execConfig.Tty && dockerCli.In().IsTerminal() {
 		if err := MonitorTtySize(ctx, dockerCli, execID, true); err != nil {
-			fmt.Fprintf(dockerCli.Err(), "Error monitoring TTY size: %s\n", err)
+			fmt.Fprintln(dockerCli.Err(), "Error monitoring TTY size:", err)
 		}
 	}
 

--- a/cli/command/container/export.go
+++ b/cli/command/container/export.go
@@ -4,11 +4,10 @@ import (
 	"errors"
 	"io"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type exportOptions struct {

--- a/cli/command/container/inspect.go
+++ b/cli/command/container/inspect.go
@@ -1,12 +1,11 @@
 package container
 
 import (
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/cli/command/inspect"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type inspectOptions struct {

--- a/cli/command/container/kill.go
+++ b/cli/command/container/kill.go
@@ -1,14 +1,14 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type killOptions struct {
@@ -46,11 +46,11 @@ func runKill(dockerCli *command.DockerCli, opts *killOptions) error {
 		if err := <-errChan; err != nil {
 			errs = append(errs, err.Error())
 		} else {
-			fmt.Fprintf(dockerCli.Out(), "%s\n", name)
+			fmt.Fprintln(dockerCli.Out(), name)
 		}
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("%s", strings.Join(errs, "\n"))
+		return errors.New(strings.Join(errs, "\n"))
 	}
 	return nil
 }

--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -3,8 +3,6 @@ package container
 import (
 	"io/ioutil"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
@@ -12,6 +10,7 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/templates"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type psOptions struct {

--- a/cli/command/container/logs.go
+++ b/cli/command/container/logs.go
@@ -3,13 +3,12 @@ package container
 import (
 	"io"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type logsOptions struct {

--- a/cli/command/container/pause.go
+++ b/cli/command/container/pause.go
@@ -1,14 +1,14 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type pauseOptions struct {
@@ -38,12 +38,12 @@ func runPause(dockerCli *command.DockerCli, opts *pauseOptions) error {
 	for _, container := range opts.containers {
 		if err := <-errChan; err != nil {
 			errs = append(errs, err.Error())
-		} else {
-			fmt.Fprintf(dockerCli.Out(), "%s\n", container)
+			continue
 		}
+		fmt.Fprintln(dockerCli.Out(), container)
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("%s", strings.Join(errs, "\n"))
+		return errors.New(strings.Join(errs, "\n"))
 	}
 	return nil
 }

--- a/cli/command/container/port.go
+++ b/cli/command/container/port.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/go-connections/nat"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type portOptions struct {

--- a/cli/command/container/prune.go
+++ b/cli/command/container/prune.go
@@ -3,13 +3,12 @@ package container
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	units "github.com/docker/go-units"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type pruneOptions struct {

--- a/cli/command/container/rename.go
+++ b/cli/command/container/rename.go
@@ -1,14 +1,14 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type renameOptions struct {
@@ -40,11 +40,11 @@ func runRename(dockerCli *command.DockerCli, opts *renameOptions) error {
 	newName := strings.TrimSpace(opts.newName)
 
 	if oldName == "" || newName == "" {
-		return fmt.Errorf("Error: Neither old nor new names may be empty")
+		return errors.New("Error: Neither old nor new names may be empty")
 	}
 
 	if err := dockerCli.Client().ContainerRename(ctx, oldName, newName); err != nil {
-		fmt.Fprintf(dockerCli.Err(), "%s\n", err)
+		fmt.Fprintln(dockerCli.Err(), err)
 		return fmt.Errorf("Error: failed to rename container named %s", oldName)
 	}
 	return nil

--- a/cli/command/container/restart.go
+++ b/cli/command/container/restart.go
@@ -1,15 +1,15 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type restartOptions struct {
@@ -51,12 +51,12 @@ func runRestart(dockerCli *command.DockerCli, opts *restartOptions) error {
 	for _, name := range opts.containers {
 		if err := dockerCli.Client().ContainerRestart(ctx, name, timeout); err != nil {
 			errs = append(errs, err.Error())
-		} else {
-			fmt.Fprintf(dockerCli.Out(), "%s\n", name)
+			continue
 		}
+		fmt.Fprintln(dockerCli.Out(), name)
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("%s", strings.Join(errs, "\n"))
+		return errors.New(strings.Join(errs, "\n"))
 	}
 	return nil
 }

--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -1,13 +1,12 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
@@ -16,6 +15,7 @@ import (
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/cli/command/formatter"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type statsOptions struct {
@@ -179,7 +179,7 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 		}
 		cStats.mu.Unlock()
 		if len(errs) > 0 {
-			return fmt.Errorf("%s", strings.Join(errs, "\n"))
+			return errors.New(strings.Join(errs, "\n"))
 		}
 	}
 

--- a/cli/command/container/stop.go
+++ b/cli/command/container/stop.go
@@ -1,15 +1,15 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type stopOptions struct {
@@ -56,12 +56,12 @@ func runStop(dockerCli *command.DockerCli, opts *stopOptions) error {
 	for _, container := range opts.containers {
 		if err := <-errChan; err != nil {
 			errs = append(errs, err.Error())
-		} else {
-			fmt.Fprintf(dockerCli.Out(), "%s\n", container)
+			continue
 		}
+		fmt.Fprintln(dockerCli.Out(), container)
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("%s", strings.Join(errs, "\n"))
+		return errors.New(strings.Join(errs, "\n"))
 	}
 	return nil
 }

--- a/cli/command/container/top.go
+++ b/cli/command/container/top.go
@@ -5,11 +5,10 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type topOptions struct {

--- a/cli/command/container/unpause.go
+++ b/cli/command/container/unpause.go
@@ -1,14 +1,14 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type unpauseOptions struct {
@@ -39,12 +39,12 @@ func runUnpause(dockerCli *command.DockerCli, opts *unpauseOptions) error {
 	for _, container := range opts.containers {
 		if err := <-errChan; err != nil {
 			errs = append(errs, err.Error())
-		} else {
-			fmt.Fprintf(dockerCli.Out(), "%s\n", container)
+			continue
 		}
+		fmt.Fprintln(dockerCli.Out(), container)
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("%s", strings.Join(errs, "\n"))
+		return errors.New(strings.Join(errs, "\n"))
 	}
 	return nil
 }

--- a/cli/command/container/update.go
+++ b/cli/command/container/update.go
@@ -1,10 +1,9 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/cli"
@@ -12,6 +11,7 @@ import (
 	runconfigopts "github.com/docker/docker/runconfig/opts"
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type updateOptions struct {
@@ -71,7 +71,7 @@ func runUpdate(dockerCli *command.DockerCli, opts *updateOptions) error {
 	var err error
 
 	if opts.nFlag == 0 {
-		return fmt.Errorf("You must provide one or more flags when using this command.")
+		return errors.New("You must provide one or more flags when using this command.")
 	}
 
 	var memory int64
@@ -149,15 +149,15 @@ func runUpdate(dockerCli *command.DockerCli, opts *updateOptions) error {
 		if err != nil {
 			errs = append(errs, err.Error())
 		} else {
-			fmt.Fprintf(dockerCli.Out(), "%s\n", container)
+			fmt.Fprintln(dockerCli.Out(), container)
 		}
 		warns = append(warns, r.Warnings...)
 	}
 	if len(warns) > 0 {
-		fmt.Fprintf(dockerCli.Out(), "%s", strings.Join(warns, "\n"))
+		fmt.Fprintln(dockerCli.Out(), strings.Join(warns, "\n"))
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("%s", strings.Join(errs, "\n"))
+		return errors.New(strings.Join(errs, "\n"))
 	}
 	return nil
 }

--- a/cli/command/container/utils.go
+++ b/cli/command/container/utils.go
@@ -3,8 +3,6 @@ package container
 import (
 	"strconv"
 
-	"golang.org/x/net/context"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
@@ -12,6 +10,7 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/cli/command"
 	clientapi "github.com/docker/docker/client"
+	"golang.org/x/net/context"
 )
 
 func waitExitOrRemoved(ctx context.Context, dockerCli *command.DockerCli, containerID string, waitRemove bool) chan int {

--- a/cli/command/container/wait.go
+++ b/cli/command/container/wait.go
@@ -1,14 +1,14 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type waitOptions struct {
@@ -39,12 +39,12 @@ func runWait(dockerCli *command.DockerCli, opts *waitOptions) error {
 		status, err := dockerCli.Client().ContainerWait(ctx, container)
 		if err != nil {
 			errs = append(errs, err.Error())
-		} else {
-			fmt.Fprintf(dockerCli.Out(), "%d\n", status)
+			continue
 		}
+		fmt.Fprintf(dockerCli.Out(), "%d\n", status)
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("%s", strings.Join(errs, "\n"))
+		return errors.New(strings.Join(errs, "\n"))
 	}
 	return nil
 }


### PR DESCRIPTION
Was playing around with [Gogland](https://www.jetbrains.com/go/), so thought; "lets do some cleanup" :smile: 🎄 

This change does some minor cleanups in the cli/command/container package;

- sort imports
- replace `fmt.Fprintf()` with `fmt.Fprintln()` if no formatting is used
- replace `fmt.Errorf()` with `errors.New()` if no formatting is used
- remove some redundant `else`'s
