### PR TITLE
Cleanup bash completion for `service create|update`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2765,6 +2765,10 @@ _docker_service_update() {
 				_filedir
 				return
 				;;
+			--group)
+				COMPREPLY=( $(compgen -g -- "$cur") )
+				return
+				;;
 			--host)
 				case "$cur" in
 					*:)
@@ -2781,10 +2785,6 @@ _docker_service_update() {
 				__docker_complete_secrets
 				return
 				;;
-			--group)
-			COMPREPLY=( $(compgen -g -- "$cur") )
-			return
-			;;
 		esac
 	fi
 	if [ "$subcommand" = "update" ] ; then
@@ -2810,11 +2810,7 @@ _docker_service_update() {
 		"
 
 		case "$prev" in
-			--group-add)
-				COMPREPLY=( $(compgen -g -- "$cur") )
-				return
-				;;
-			--group-rm)
+			--group-add|--group-rm)
 				COMPREPLY=( $(compgen -g -- "$cur") )
 				return
 				;;


### PR DESCRIPTION
Fixes to remove stylistic inconsistencies in bash completion:

* alphabetical sorting
* correct indetation
* options with identical completion are grouped under the alphabetically first option

This PR does not include functional changes.