### PR TITLE
Add daemon option `--default-shm-size`

### DIFF
--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -411,8 +411,9 @@ func TestParseModes(t *testing.T) {
 		t.Fatalf("Expected a valid UTSMode, got %v", hostconfig.UTSMode)
 	}
 	// shm-size ko
-	if _, _, _, err = parseRun([]string{"--shm-size=a128m", "img", "cmd"}); err == nil || err.Error() != "invalid size: 'a128m'" {
-		t.Fatalf("Expected an error with message 'invalid size: a128m', got %v", err)
+	expectedErr := `invalid argument "a128m" for --shm-size=a128m: invalid size: 'a128m'`
+	if _, _, _, err = parseRun([]string{"--shm-size=a128m", "img", "cmd"}); err == nil || err.Error() != expectedErr {
+		t.Fatalf("Expected an error with message '%v', got %v", expectedErr, err)
 	}
 	// shm-size ok
 	_, hostconfig, _, err = parseRun([]string{"--shm-size=128m", "img", "cmd"})

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -41,7 +41,7 @@ type buildOptions struct {
 	ulimits        *opts.UlimitOpt
 	memory         string
 	memorySwap     string
-	shmSize        string
+	shmSize        opts.MemBytes
 	cpuShares      int64
 	cpuPeriod      int64
 	cpuQuota       int64
@@ -89,7 +89,7 @@ func NewBuildCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.StringVarP(&options.dockerfileName, "file", "f", "", "Name of the Dockerfile (Default is 'PATH/Dockerfile')")
 	flags.StringVarP(&options.memory, "memory", "m", "", "Memory limit")
 	flags.StringVar(&options.memorySwap, "memory-swap", "", "Swap limit equal to memory plus swap: '-1' to enable unlimited swap")
-	flags.StringVar(&options.shmSize, "shm-size", "", "Size of /dev/shm, default value is 64MB")
+	flags.Var(&options.shmSize, "shm-size", "Size of /dev/shm")
 	flags.Int64VarP(&options.cpuShares, "cpu-shares", "c", 0, "CPU shares (relative weight)")
 	flags.Int64Var(&options.cpuPeriod, "cpu-period", 0, "Limit the CPU CFS (Completely Fair Scheduler) period")
 	flags.Int64Var(&options.cpuQuota, "cpu-quota", 0, "Limit the CPU CFS (Completely Fair Scheduler) quota")
@@ -271,14 +271,6 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 		}
 	}
 
-	var shmSize int64
-	if options.shmSize != "" {
-		shmSize, err = units.RAMInBytes(options.shmSize)
-		if err != nil {
-			return err
-		}
-	}
-
 	authConfigs, _ := dockerCli.GetAllCredentials()
 	buildOptions := types.ImageBuildOptions{
 		Memory:         memory,
@@ -297,7 +289,7 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 		CPUPeriod:      options.cpuPeriod,
 		CgroupParent:   options.cgroupParent,
 		Dockerfile:     relDockerfile,
-		ShmSize:        shmSize,
+		ShmSize:        options.shmSize.Value(),
 		Ulimits:        options.ulimits.GetList(),
 		BuildArgs:      runconfigopts.ConvertKVStringsToMapWithNil(options.buildArgs.GetAll()),
 		AuthConfigs:    authConfigs,

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -11,32 +11,11 @@ import (
 	"github.com/docker/docker/opts"
 	runconfigopts "github.com/docker/docker/runconfig/opts"
 	"github.com/docker/go-connections/nat"
-	units "github.com/docker/go-units"
 	"github.com/spf13/cobra"
 )
 
 type int64Value interface {
 	Value() int64
-}
-
-type memBytes int64
-
-func (m *memBytes) String() string {
-	return units.BytesSize(float64(m.Value()))
-}
-
-func (m *memBytes) Set(value string) error {
-	val, err := units.RAMInBytes(value)
-	*m = memBytes(val)
-	return err
-}
-
-func (m *memBytes) Type() string {
-	return "bytes"
-}
-
-func (m *memBytes) Value() int64 {
-	return int64(*m)
 }
 
 // PositiveDurationOpt is an option type for time.Duration that uses a pointer.
@@ -149,9 +128,9 @@ type updateOptions struct {
 
 type resourceOptions struct {
 	limitCPU      opts.NanoCPUs
-	limitMemBytes memBytes
+	limitMemBytes opts.MemBytes
 	resCPU        opts.NanoCPUs
-	resMemBytes   memBytes
+	resMemBytes   opts.MemBytes
 }
 
 func (r *resourceOptions) ToResourceRequirements() *swarm.ResourceRequirements {

--- a/cli/command/service/opts_test.go
+++ b/cli/command/service/opts_test.go
@@ -11,12 +11,12 @@ import (
 )
 
 func TestMemBytesString(t *testing.T) {
-	var mem memBytes = 1048576
+	var mem opts.MemBytes = 1048576
 	assert.Equal(t, mem.String(), "1 MiB")
 }
 
 func TestMemBytesSetAndValue(t *testing.T) {
-	var mem memBytes
+	var mem opts.MemBytes
 	assert.NilError(t, mem.Set("5kb"))
 	assert.Equal(t, mem.Value(), int64(5120))
 }

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -22,9 +22,7 @@ import (
 )
 
 const (
-	// DefaultSHMSize is the default size (64MB) of the SHM which will be mounted in the container
-	DefaultSHMSize           int64 = 67108864
-	containerSecretMountPath       = "/run/secrets"
+	containerSecretMountPath = "/run/secrets"
 )
 
 // Container holds the fields specific to unixen implementations.

--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -14,6 +14,7 @@ var (
 	defaultPidFile  = "/var/run/docker.pid"
 	defaultGraph    = "/var/lib/docker"
 	defaultExecRoot = "/var/run/docker"
+	defaultShmSize  = int64(67108864)
 )
 
 // Config defines the configuration of a docker daemon.
@@ -36,6 +37,7 @@ type Config struct {
 	Init                 bool                     `json:"init,omitempty"`
 	InitPath             string                   `json:"init-path,omitempty"`
 	SeccompProfile       string                   `json:"seccomp-profile,omitempty"`
+	ShmSize              opts.MemBytes            `json:"default-shm-size,omitempty"`
 }
 
 // bridgeConfig stores all the bridge driver specific
@@ -66,6 +68,9 @@ func (config *Config) InstallFlags(flags *pflag.FlagSet) {
 
 	config.Ulimits = make(map[string]*units.Ulimit)
 
+	// Set default value for `--default-shm-size`
+	config.ShmSize = opts.MemBytes(defaultShmSize)
+
 	// Then platform-specific install flags
 	flags.BoolVar(&config.EnableSelinuxSupport, "selinux-enabled", false, "Enable selinux support")
 	flags.Var(opts.NewUlimitOpt(&config.Ulimits), "default-ulimit", "Default ulimits for containers")
@@ -89,6 +94,7 @@ func (config *Config) InstallFlags(flags *pflag.FlagSet) {
 	flags.Int64Var(&config.CPURealtimePeriod, "cpu-rt-period", 0, "Limit the CPU real-time period in microseconds")
 	flags.Int64Var(&config.CPURealtimeRuntime, "cpu-rt-runtime", 0, "Limit the CPU real-time runtime in microseconds")
 	flags.StringVar(&config.SeccompProfile, "seccomp-profile", "", "Path to seccomp profile")
+	flags.Var(&config.ShmSize, "default-shm-size", "Default shm size for containers")
 
 	config.attachExperimentalFlags(flags)
 }

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -117,7 +117,7 @@ func (daemon *Daemon) setupIpcDirs(c *container.Container) error {
 				return err
 			}
 
-			shmSize := container.DefaultSHMSize
+			shmSize := int64(daemon.configStore.ShmSize)
 			if c.HostConfig.ShmSize != 0 {
 				shmSize = c.HostConfig.ShmSize
 			}

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -49,7 +49,7 @@ Options:
   -q, --quiet                   Suppress the build output and print image ID on success
       --rm                      Remove intermediate containers after a successful build (default true)
       --security-opt value      Security Options (default [])
-      --shm-size string         Size of /dev/shm, default value is 64MB.
+      --shm-size bytes          Size of /dev/shm
                                 The format is `<number><unit>`. `number` must be greater than `0`.
                                 Unit is optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes),
                                 or `g` (gigabytes). If you omit the unit, the system uses bytes.

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -106,7 +106,7 @@ Options:
       --rm                          Automatically remove the container when it exits
       --runtime string              Runtime to use for this container
       --security-opt value          Security Options (default [])
-      --shm-size string             Size of /dev/shm, default value is 64MB.
+      --shm-size bytes              Size of /dev/shm
                                     The format is `<number><unit>`. `number` must be greater than `0`.
                                     Unit is optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes),
                                     or `g` (gigabytes). If you omit the unit, the system uses bytes.

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -37,6 +37,7 @@ Options:
       --default-gateway value                 Container default gateway IPv4 address
       --default-gateway-v6 value              Container default gateway IPv6 address
       --default-runtime string                Default OCI runtime for containers (default "runc")
+      --default-shm-size bytes                Set the default shm size for containers (default 64 MiB)
       --default-ulimit value                  Default ulimits for containers (default [])
       --disable-legacy-registry               Disable contacting legacy registries
       --dns value                             DNS server to use (default [])
@@ -1161,6 +1162,7 @@ This is a full example of the allowed configuration options on Linux:
 	"cluster-advertise": "",
 	"max-concurrent-downloads": 3,
 	"max-concurrent-uploads": 5,
+	"default-shm-size": "64M",
 	"shutdown-timeout": 15,
 	"debug": true,
 	"hosts": [],

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -116,7 +116,7 @@ Options:
       --rm                          Automatically remove the container when it exits
       --runtime string              Runtime to use for this container
       --security-opt value          Security Options (default [])
-      --shm-size string             Size of /dev/shm, default value is 64MB.
+      --shm-size bytes              Size of /dev/shm
                                     The format is `<number><unit>`. `number` must be greater than `0`.
                                     Unit is optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes),
                                     or `g` (gigabytes). If you omit the unit, the system uses bytes.

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -39,7 +39,7 @@ Options:
       --hostname string                  Container hostname
   -l, --label list                       Service labels (default [])
       --limit-cpu decimal                Limit CPUs (default 0.000)
-      --limit-memory bytes               Limit Memory (default 0 B)
+      --limit-memory bytes               Limit Memory
       --log-driver string                Logging driver for service
       --log-opt list                     Logging driver options (default [])
       --mode string                      Service mode (replicated or global) (default "replicated")
@@ -50,7 +50,7 @@ Options:
   -p, --publish port                     Publish a port as a node port
       --replicas uint                    Number of tasks
       --reserve-cpu decimal              Reserve CPUs (default 0.000)
-      --reserve-memory bytes             Reserve Memory (default 0 B)
+      --reserve-memory bytes             Reserve Memory
       --restart-condition string         Restart when condition is met (none, on-failure, or any)
       --restart-delay duration           Delay between restart attempts (ns|us|ms|s|m|h)
       --restart-max-attempts uint        Maximum number of restarts before giving up

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -50,7 +50,7 @@ Options:
       --label-add list                   Add or update a service label (default [])
       --label-rm list                    Remove a label by its key (default [])
       --limit-cpu decimal                Limit CPUs (default 0.000)
-      --limit-memory bytes               Limit Memory (default 0 B)
+      --limit-memory bytes               Limit Memory
       --log-driver string                Logging driver for service
       --log-opt list                     Logging driver options (default [])
       --mount-add mount                  Add or update a mount on a service
@@ -60,7 +60,7 @@ Options:
       --publish-rm port                  Remove a published port by its target port
       --replicas uint                    Number of tasks
       --reserve-cpu decimal              Reserve CPUs (default 0.000)
-      --reserve-memory bytes             Reserve Memory (default 0 B)
+      --reserve-memory bytes             Reserve Memory
       --restart-condition string         Restart when condition is met (none, on-failure, or any)
       --restart-delay duration           Delay between restart attempts (ns|us|ms|s|m|h)
       --restart-max-attempts uint        Maximum number of restarts before giving up

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -427,7 +427,7 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *check.C) {
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c))
 	c.Assert(err, checker.IsNil)
 
-	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s (cluster-advertise=, cluster-store=, cluster-store-opts={}, debug=true, default-runtime=runc, default-shm-size=67108864, insecure-registries=[], labels=[\"bar=foo\"], live-restore=false, max-concurrent-downloads=1, max-concurrent-uploads=5, name=%s, runtimes=runc:{docker-runc []}, shutdown-timeout=10)", daemonID, daemonName))
+	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s (cluster-advertise=, cluster-store=, cluster-store-opts={}, debug=true, default-runtime=runc, default-shm-size=67108864, insecure-registries=[], labels=[\"bar=foo\"], live-restore=false, max-concurrent-downloads=1, max-concurrent-uploads=5, name=%s, registry-mirrors=[], runtimes=runc:{docker-runc []}, shutdown-timeout=10)", daemonID, daemonName))
 }
 
 func (s *DockerDaemonSuite) TestDaemonEventsWithFilters(c *check.C) {

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -427,7 +427,7 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *check.C) {
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c))
 	c.Assert(err, checker.IsNil)
 
-	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s (cluster-advertise=, cluster-store=, cluster-store-opts={}, debug=true, default-runtime=runc, insecure-registries=[], labels=[\"bar=foo\"], live-restore=false, max-concurrent-downloads=1, max-concurrent-uploads=5, name=%s, registry-mirrors=[], runtimes=runc:{docker-runc []}, shutdown-timeout=10)", daemonID, daemonName))
+	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s (cluster-advertise=, cluster-store=, cluster-store-opts={}, debug=true, default-runtime=runc, default-shm-size=67108864, insecure-registries=[], labels=[\"bar=foo\"], live-restore=false, max-concurrent-downloads=1, max-concurrent-uploads=5, name=%s, runtimes=runc:{docker-runc []}, shutdown-timeout=10)", daemonID, daemonName))
 }
 
 func (s *DockerDaemonSuite) TestDaemonEventsWithFilters(c *check.C) {

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -21,6 +21,7 @@ dockerd - Enable daemon mode
 [**--default-gateway**[=*DEFAULT-GATEWAY*]]
 [**--default-gateway-v6**[=*DEFAULT-GATEWAY-V6*]]
 [**--default-runtime**[=*runc*]]
+[**--default-shm-size**[=*64MiB*]]
 [**--default-ulimit**[=*[]*]]
 [**--disable-legacy-registry**]
 [**--dns**[=*[]*]]
@@ -163,6 +164,9 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 
 **--default-runtime**="runc"
   Set default runtime if there're more than one specified by `--add-runtime`.
+
+**--default-shm-size**=*64MiB*
+  Set the daemon-wide default shm size for containers. Default is `64MiB`.
 
 **--default-ulimit**=[]
   Default ulimits for containers.

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -409,7 +409,13 @@ type MemBytes int64
 
 // String returns the string format of the human readable memory bytes
 func (m *MemBytes) String() string {
-	return units.BytesSize(float64(m.Value()))
+	// NOTE: In spf13/pflag/flag.go, "0" is considered as "zero value" while "0 B" is not.
+	// We return "0" in case value is 0 here so that the default value is hidden.
+	// (Sometimes "default 0 B" is actually misleading)
+	if m.Value() != 0 {
+		return units.BytesSize(float64(m.Value()))
+	}
+	return "0"
 }
 
 // Set sets the value of the MemBytes by passing a string

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types/filters"
+	units "github.com/docker/go-units"
 )
 
 var (
@@ -401,4 +402,39 @@ func ParseLink(val string) (string, string, error) {
 func ValidateLink(val string) (string, error) {
 	_, _, err := ParseLink(val)
 	return val, err
+}
+
+// MemBytes is a type for human readable memory bytes (like 128M, 2g, etc)
+type MemBytes int64
+
+// String returns the string format of the human readable memory bytes
+func (m *MemBytes) String() string {
+	return units.BytesSize(float64(m.Value()))
+}
+
+// Set sets the value of the MemBytes by passing a string
+func (m *MemBytes) Set(value string) error {
+	val, err := units.RAMInBytes(value)
+	*m = MemBytes(val)
+	return err
+}
+
+// Type returns the type
+func (m *MemBytes) Type() string {
+	return "bytes"
+}
+
+// Value returns the value in int64
+func (m *MemBytes) Value() int64 {
+	return int64(*m)
+}
+
+// UnmarshalJSON is the customized unmarshaler for MemBytes
+func (m *MemBytes) UnmarshalJSON(s []byte) error {
+	if len(s) <= 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return fmt.Errorf("invalid size: %q", s)
+	}
+	val, err := units.RAMInBytes(string(s[1 : len(s)-1]))
+	*m = MemBytes(val)
+	return err
 }


### PR DESCRIPTION
**- What I did**

This fix fixes issue raised in #29492 where it was not possible to specify a default `--default-shm-size` in daemon configuration for each `docker run``.

**- How I did it**

The flag `--default-shm-size` which is reloadable, has been added to the daemon configuation.
Related docs has been updated.

**- How to verify it**

**- Description for the changelog**

Add daemon option `--default-shm-size` for default shm size of created containers.

**- A picture of a cute animal (not mandatory but encouraged)**

![u 968902900 274083092 fm 15 gp 0](https://cloud.githubusercontent.com/assets/6932348/21472098/555c2b7e-ca7e-11e6-8416-56bc6cef4678.jpg)


This fix fixes #29492.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
