### PR TITLE
Send "Name" and "ID" when stating stopped containers

### DIFF
--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -33,7 +33,9 @@ func (daemon *Daemon) ContainerStats(ctx context.Context, prefixOrName string, c
 
 	// If the container is either not running or restarting and requires no stream, return an empty stats.
 	if (!container.IsRunning() || container.IsRestarting()) && !config.Stream {
-		return json.NewEncoder(config.OutStream).Encode(&types.Stats{})
+		return json.NewEncoder(config.OutStream).Encode(&types.StatsJSON{
+			Name: container.Name,
+			ID:   container.ID})
 	}
 
 	outStream := config.OutStream

--- a/daemon/stats/collector.go
+++ b/daemon/stats/collector.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/pubsub"
 )
@@ -84,7 +85,14 @@ func (s *Collector) Run() {
 			if err != nil {
 				if _, ok := err.(notRunningErr); !ok {
 					logrus.Errorf("collecting stats for %s: %v", pair.container.ID, err)
+					continue
 				}
+
+				// publish empty stats containing only name and ID if not running
+				pair.publisher.Publish(types.StatsJSON{
+					Name: pair.container.Name,
+					ID:   pair.container.ID,
+				})
 				continue
 			}
 			// FIXME: move to containerd on Linux (not Windows)


### PR DESCRIPTION
When `docker stats` stopped containers, client will get empty stats data,
this commit will gurantee client always get "Name" and "ID" field, so
that it can format with `ID` and `Name` fields successfully.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>


<del>
This commit fixes panic when execute stats command:

* use `--format {{.Name}}` with `--all` when there're exited containers.
* use `--format {{.Name}}` while stating exited container.

The root cause is when stating an exited container, the result from the
api didn't contain the `Name` and `ID` field, which will make `format`
process panic.

Panic log is like this:

```
panic: runtime error: slice bounds out of range [recovered]
	panic: runtime error: slice bounds out of range

goroutine 1 [running]:
panic(0xb20f80, 0xc420014110)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
text/template.errRecover(0xc4201773e8)
	/usr/local/go/src/text/template/exec.go:140 +0x2ad
panic(0xb20f80, 0xc420014110)
	/usr/local/go/src/runtime/panic.go:458 +0x243
github.com/docker/docker/cli/command/formatter.(*containerStatsContext).Name(0xc420430160,
0x0, 0x0)
	/go/src/github.com/docker/docker/cli/command/formatter/stats.go:148
+0x86
reflect.Value.call(0xb9a3a0, 0xc420430160, 0x2213, 0xbe3657, 0x4,
0x11bc9f8, 0x0, 0x0, 0x4d75b3, 0x1198940, ...)
	/usr/local/go/src/reflect/value.go:434 +0x5c8
reflect.Value.Call(0xb9a3a0, 0xc420430160, 0x2213, 0x11bc9f8, 0x0, 0x0,
0xc420424028, 0xb, 0xb)
	/usr/local/go/src/reflect/value.go:302 +0xa4
text/template.(*state).evalCall(0xc420177368, 0xb9a3a0, 0xc420430160,
0x16, 0xb9a3a0, 0xc420430160, 0x2213, 0x1178fa0, 0xc4203ea330,
0xc4203de283, ...)
	/usr/local/go/src/text/template/exec.go:658 +0x530
```

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>
</del>

Introduced in https://github.com/docker/docker/pull/27797, ping @vdemeester 