### PR TITLE
rename clusterProvider to cluster in router

### DIFF
--- a/api/server/router/network/network.go
+++ b/api/server/router/network/network.go
@@ -7,16 +7,16 @@ import (
 
 // networkRouter is a router to talk with the network controller
 type networkRouter struct {
-	backend         Backend
-	clusterProvider *cluster.Cluster
-	routes          []router.Route
+	backend Backend
+	cluster *cluster.Cluster
+	routes  []router.Route
 }
 
 // NewRouter initializes a new network router
 func NewRouter(b Backend, c *cluster.Cluster) router.Router {
 	r := &networkRouter{
-		backend:         b,
-		clusterProvider: c,
+		backend: b,
+		cluster: c,
 	}
 	r.initRoutes()
 	return r

--- a/api/server/router/system/system.go
+++ b/api/server/router/system/system.go
@@ -8,16 +8,16 @@ import (
 // systemRouter provides information about the Docker system overall.
 // It gathers information about host, daemon and container events.
 type systemRouter struct {
-	backend         Backend
-	clusterProvider *cluster.Cluster
-	routes          []router.Route
+	backend Backend
+	cluster *cluster.Cluster
+	routes  []router.Route
 }
 
 // NewRouter initializes a new system router
 func NewRouter(b Backend, c *cluster.Cluster) router.Router {
 	r := &systemRouter{
-		backend:         b,
-		clusterProvider: c,
+		backend: b,
+		cluster: c,
 	}
 
 	r.routes = []router.Route{

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -35,8 +35,8 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 	if err != nil {
 		return err
 	}
-	if s.clusterProvider != nil {
-		info.Swarm = s.clusterProvider.Info()
+	if s.cluster != nil {
+		info.Swarm = s.cluster.Info()
 	}
 
 	if versions.LessThan(httputils.VersionFromContext(ctx), "1.25") {


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I found that there is field `clusterProvider` in struct `systemRouter` and `networkRouter`. At first, when I read the source code, I always mix this with filed `clusterProvider` in struct `Daemon`.

In `systemRouter` and `networkRouter`, `clusterProvider` has a type of `*cluster.Cluster`;
In `Daemon`, `clusterProvider` has a type of `cluster.Provider` which is defined in libnetwork.

I think it is better to clarify that clusterProvider is only used in one place, and  this is good for user to read.

**- What I did**
1. rename clusterProvider to cluster in router to match its type 

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

