### PR TITLE
fix swagger description for `DELETE /plugin/{name}`

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6583,6 +6583,7 @@ paths:
           required: true
           type: "string"
       tags: ["Plugin"]
+  /plugins/{name}:
     delete:
       summary: "Remove a plugin"
       operationId: "PluginDelete"


### PR DESCRIPTION
Only a minor fix to remove the `.../json` path segment for the `DELETE /plugins/{name}` endpoint description. 

Signed-off-by: Tobias Gesellchen <tobias@gesellix.de>
