### PR TITLE
return more accurate error message when docker kill

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -61,7 +61,7 @@ func (daemon *Daemon) killWithSignal(container *container.Container, sig int) er
 
 	// We could unpause the container for them rather than returning this error
 	if container.Paused {
-		return fmt.Errorf("Container %s is paused. Unpause the container before stopping", container.ID)
+		return fmt.Errorf("Container %s is paused. Unpause the container before stopping or killing", container.ID)
 	}
 
 	if !container.Running {


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

fixes #29708 

**- What I did**
1. modify error message when killing a paused container

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

