### PR TITLE
display network name when disconnecting network error

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -808,7 +808,7 @@ func (daemon *Daemon) disconnectFromNetwork(container *container.Container, n li
 	}
 
 	if ep == nil {
-		return fmt.Errorf("container %s is not connected to the network", container.ID)
+		return fmt.Errorf("container %s is not connected to network %s", container.ID, n.Name())
 	}
 
 	if err := ep.Leave(sbox); err != nil {


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

fixes #29711 

**- What I did**
1. display network name when disconnecting network error

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

