### PR TITLE
Display only the name of the requirement…

### DIFF
--- a/integration-cli/requirement/requirement.go
+++ b/integration-cli/requirement/requirement.go
@@ -2,8 +2,10 @@ package requirement
 
 import (
 	"fmt"
+	"path"
 	"reflect"
 	"runtime"
+	"strings"
 )
 
 type skipT interface {
@@ -20,7 +22,12 @@ func Is(s skipT, requirements ...Test) {
 		isValid := r()
 		if !isValid {
 			requirementFunc := runtime.FuncForPC(reflect.ValueOf(r).Pointer()).Name()
-			s.Skip(fmt.Sprintf("unmatched requirement %s", requirementFunc))
+			s.Skip(fmt.Sprintf("unmatched requirement %s", extractRequirement(requirementFunc)))
 		}
 	}
+}
+
+func extractRequirement(requirementFunc string) string {
+	requirement := path.Base(requirementFunc)
+	return strings.SplitN(requirement, ".", 2)[1]
 }


### PR DESCRIPTION
… relative to the integration-cli package 🐻

```bash
# before
SKIP: docker_cli_run_test.go:4476: DockerSuite.TestRunCredentialSpecFailures (unmatched requirement github.com/docker/docker/integration-cli.DaemonIsWindows)
# after
SKIP: docker_cli_run_test.go:4476: DockerSuite.TestRunCredentialSpecFailures (unmatched requirement DaemonIsWindows)
```

/cc @thaJeztah @icecrime @dnephin @cpuguy83 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
