### PR TITLE
Remove `docker stack ps -a` to match removal of `docker service/node ps -a`

### DIFF
--- a/cli/command/stack/ps.go
+++ b/cli/command/stack/ps.go
@@ -6,7 +6,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/cli/command/idresolver"
@@ -16,7 +15,6 @@ import (
 )
 
 type psOptions struct {
-	all       bool
 	filter    opts.FilterOpt
 	noTrunc   bool
 	namespace string
@@ -36,7 +34,6 @@ func newPsCommand(dockerCli *command.DockerCli) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
-	flags.BoolVarP(&opts.all, "all", "a", false, "Display all tasks")
 	flags.BoolVar(&opts.noTrunc, "no-trunc", false, "Do not truncate output")
 	flags.BoolVar(&opts.noResolve, "no-resolve", false, "Do not map IDs to Names")
 	flags.VarP(&opts.filter, "filter", "f", "Filter output based on conditions provided")
@@ -50,10 +47,6 @@ func runPS(dockerCli *command.DockerCli, opts psOptions) error {
 	ctx := context.Background()
 
 	filter := getStackFilterFromOpt(opts.namespace, opts.filter)
-	if !opts.all && !filter.Include("desired-state") {
-		filter.Add("desired-state", string(swarm.TaskStateRunning))
-		filter.Add("desired-state", string(swarm.TaskStateAccepted))
-	}
 
 	tasks, err := client.TaskList(ctx, types.TaskListOptions{Filters: filter})
 	if err != nil {

--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -21,10 +21,10 @@ Usage:  docker stack ps [OPTIONS] STACK
 List the tasks in the stack
 
 Options:
-  -a, --all            Display all tasks
-  -f, --filter value   Filter output based on conditions provided
-      --no-resolve     Do not map IDs to Names
-      --no-trunc       Do not truncate output
+  -f, --filter filter   Filter output based on conditions provided
+      --help            Print usage
+      --no-resolve      Do not map IDs to Names
+      --no-trunc        Do not truncate output
 ```
 
 Lists the tasks that are running as part of the specified stack. This


### PR DESCRIPTION
In #28507 and #28885, `docker service/node ps -a` has been removed so that information about slots are showed up even without `-a` flag.

The output of `docker stack ps` reused the same output as `docker service/node ps`. However, the `-a` was still there. It might make sense to remove `docker stack ps -a` as well to bring consistency with `docker service/node ps`.

This fix is related to #28507, #28885, and #25983.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
