### PR TITLE
Follow up #29365, fix fail to remove container after restart

### DIFF
--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -654,6 +654,11 @@ func (d *Daemon) ReadLogFile() ([]byte, error) {
 	return ioutil.ReadFile(d.logFile.Name())
 }
 
+// InspectField returns the field filter by 'filter'
+func (d *Daemon) InspectField(name, filter string) (string, error) {
+	return d.inspectFilter(name, filter)
+}
+
 func (d *Daemon) inspectFilter(name, filter string) (string, error) {
 	format := fmt.Sprintf("{{%s}}", filter)
 	out, err := d.Cmd("inspect", "-f", format, name)

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -2832,7 +2833,7 @@ func (s *DockerDaemonSuite) TestExecWithUserAfterLiveRestore(c *check.C) {
 	out, err := s.d.Cmd("run", "-d", "--name=top", "busybox", "sh", "-c", "addgroup -S test && adduser -S -G test test -D -s /bin/sh && top")
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
 
-	waitRun("top")
+	s.d.WaitRun("top")
 
 	out1, err := s.d.Cmd("exec", "-u", "test", "top", "id")
 	// uid=100(test) gid=101(test) groups=101(test)
@@ -2847,4 +2848,37 @@ func (s *DockerDaemonSuite) TestExecWithUserAfterLiveRestore(c *check.C) {
 
 	out, err = s.d.Cmd("stop", "top")
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
+}
+
+func (s *DockerDaemonSuite) TestRemoveContainerAfterLiveRestore(c *check.C) {
+	testRequires(c, DaemonIsLinux, overlayFSSupported, SameHostDaemon)
+	s.d.StartWithBusybox(c, "--live-restore", "--storage-driver", "overlay")
+	out, err := s.d.Cmd("run", "-d", "--name=top", "busybox", "top")
+	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
+
+	s.d.WaitRun("top")
+
+	// restart daemon.
+	s.d.Restart(c, "--live-restore", "--storage-driver", "overlay")
+
+	out, err = s.d.Cmd("stop", "top")
+	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
+
+	// test if the rootfs mountpoint still exist
+	mountpoint, err := s.d.InspectField("top", ".GraphDriver.Data.MergedDir")
+	c.Assert(err, check.IsNil)
+	f, err := os.Open("/proc/self/mountinfo")
+	c.Assert(err, check.IsNil)
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.Contains(line, mountpoint) {
+			c.Fatalf("mountinfo should not include the mountpoint of stop container")
+		}
+	}
+
+	out, err = s.d.Cmd("rm", "top")
+	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
+
 }


### PR DESCRIPTION
Call daemon.Mount will increase the refcount of mounted layer,
for those previous running containers, `Mount` call will make
the refcount to 2. see
https://github.com/docker/docker/blob/v1.13.0-rc4/daemon/graphdriver/counter.go#L38
```
	if !m.check {
		m.check = true
		if c.checker.IsMounted(path) {
			m.count++
		}
	}
	m.count++

```
graphdrive could restore on reboot after #22541, call
daemon.Mount to restore the graphdriver is not necessary.

And call `daemon.Mount` on restoring will mount all the containers
mounted layer even if it was stop.

````
[lei@centos docker]$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
[lei@centos docker]$ docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                     PORTS               NAMES
54fb9a9e08fe        662917bef212        "sh"                4 days ago          Exited (0) 4 days ago                          keen_archimedes
c24d30fa87bc        662917bef212        "bash"              4 days ago          Created                                        peaceful_mahavira
b78fb816e787        busybox             "sh"                5 days ago          Exited (0) 5 days ago                          loving_lamarr
7d705bb81a63        busybox             "sh"                5 days ago          Exited (0) 5 days ago                          tender_wiles
0611718b63e7        busybox             "sh"                3 weeks ago         Exited (255) 5 days ago                        lucid_heisenberg
30b80e1ff02c        busybox             "sh"                3 weeks ago         Exited (137) 3 weeks ago                       keen_newton
a5f64b4c78ef        busybox             "sh"                3 weeks ago         Exited (137) 3 weeks ago                       objective_wing
090bd488a48b        busybox             "sh"                3 weeks ago         Exited (130) 3 weeks ago                       gallant_lamport
431573f53e87        busybox             "sh"                3 weeks ago         Exited (130) 3 weeks ago                       infallible_sammet
[lei@centos docker]$ mount | grep devicemapper
/dev/mapper/centos-root on /var/lib/docker/devicemapper type xfs (rw,relatime,seclabel,attr2,inode64,noquota)
/dev/mapper/docker-253:0-135201377-e9b3ff54b53225c8ae8ed1b5dd300f0c790d95d80d7450fed1cb912fa9e6aae4 on /var/lib/docker/devicemapper/mnt/e9b3ff54b53225c8ae8ed1b5dd300f0c790d95d80d7450fed1cb912fa9e6aae4 type xfs (rw,relatime,seclabel,nouuid,attr2,inode64,logbsize=64k,sunit=128,swidth=128,noquota)
/dev/mapper/docker-253:0-135201377-81a07eb76ac0e0ca8868e8ad8abf39e03bee1ff182b00086c49be2f33aa51fed on /var/lib/docker/devicemapper/mnt/81a07eb76ac0e0ca8868e8ad8abf39e03bee1ff182b00086c49be2f33aa51fed type xfs (rw,relatime,seclabel,nouuid,attr2,inode64,logbsize=64k,sunit=128,swidth=128,noquota)
/dev/mapper/docker-253:0-135201377-c38d85dfb9de2a4437f96240f717b2f855fe12c3d35ae3aa574633d7a3eb3b18 on /var/lib/docker/devicemapper/mnt/c38d85dfb9de2a4437f96240f717b2f855fe12c3d35ae3aa574633d7a3eb3b18 type xfs (rw,relatime,seclabel,nouuid,attr2,inode64,logbsize=64k,sunit=128,swidth=128,noquota)
/dev/mapper/docker-253:0-135201377-741c2a790ea7a48dadbabbc3ba74c0ed58d6d8d141ea091c43f39737ce55a309 on /var/lib/docker/devicemapper/mnt/741c2a790ea7a48dadbabbc3ba74c0ed58d6d8d141ea091c43f39737ce55a309 type xfs (rw,relatime,seclabel,nouuid,attr2,inode64,logbsize=64k,sunit=128,swidth=128,noquota)
/dev/mapper/docker-253:0-135201377-7b3f2c52b6e11f9f1d5e9833b585e96d38d19af19f80437bb94ba010bd18bf28 on /var/lib/docker/devicemapper/mnt/7b3f2c52b6e11f9f1d5e9833b585e96d38d19af19f80437bb94ba010bd18bf28 type xfs (rw,relatime,seclabel,nouuid,attr2,inode64,logbsize=64k,sunit=128,swidth=128,noquota)
/dev/mapper/docker-253:0-135201377-7acdbd273d5ccf104018c222982776361c4d34b5155cad965fb4b8ac2d1a9e3a on /var/lib/docker/devicemapper/mnt/7acdbd273d5ccf104018c222982776361c4d34b5155cad965fb4b8ac2d1a9e3a type xfs (rw,relatime,seclabel,nouuid,attr2,inode64,logbsize=64k,sunit=128,swidth=128,noquota)
/dev/mapper/docker-253:0-135201377-cee4d9bb8de978ae6c04a2f2406e9fec1405a0d18ee22abd873c733bddfac401 on /var/lib/docker/devicemapper/mnt/cee4d9bb8de978ae6c04a2f2406e9fec1405a0d18ee22abd873c733bddfac401 type xfs (rw,relatime,seclabel,nouuid,attr2,inode64,logbsize=64k,sunit=128,swidth=128,noquota)
/dev/mapper/docker-253:0-135201377-99cfd02ecb0e73b50a13846b1d9432a26ea93424ecf037ca028cc8a8a12a38ce on /var/lib/docker/devicemapper/mnt/99cfd02ecb0e73b50a13846b1d9432a26ea93424ecf037ca028cc8a8a12a38ce type xfs (rw,relatime,seclabel,nouuid,attr2,inode64,logbsize=64k,sunit=128,swidth=128,noquota)
/dev/mapper/docker-253:0-135201377-7caf7291e38fbf7b0880556ad61408c5ed916a3833899ead9091cfd835580147 on /var/lib/docker/devicemapper/mnt/7caf7291e38fbf7b0880556ad61408c5ed916a3833899ead9091cfd835580147 type xfs (rw,relatime,seclabel,nouuid,attr2,inode64,logbsize=64k,sunit=128,swidth=128,noquota)

````

and if you use `devicemapper`, you will failed to remove container after restarting
```
[lei@centos docker]$ docker rm 7d705bb81a63
Error response from daemon: Driver devicemapper failed to remove root filesystem 7d705bb81a63282c7e2bcfe76140617670c19a909049c60678bd438be5c64d08: Device is Busy
```

This fix call Mount and then Unmount to get `BaseFs`

ping @yongtang  @vdemeester  @mlaventure @cpuguy83  @tonistiigi 

Signed-off-by: Lei Jitang <leijitang@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

