### PR TITLE
remove description of Google Docs Folder in GOVERNANCE.md

### DIFF
--- a/project/GOVERNANCE.md
+++ b/project/GOVERNANCE.md
@@ -2,16 +2,3 @@
 
 In the spirit of openness, Docker created a Governance Advisory Board, and committed to make all materials and notes from the meetings of this group public.
 All output from the meetings should be considered proposals only, and are subject to the review and approval of the community and the project leadership.
-
-The materials from the first Docker Governance Advisory Board meeting, held on October 28, 2014, are available at 
-[Google Docs Folder](https://goo.gl/Alfj8r)
-
-These include:
-
-* First Meeting Notes 
-* DGAB Charter 
-* Presentation 1: Introductory Presentation, including State of The Project  
-* Presentation 2: Overall Contribution Structure/Docker Project Core Proposal 
-* Presentation 3: Long Term Roadmap/Statement of Direction 
- 
-


### PR DESCRIPTION
the url "https://goo.gl/Alfj8r" is already invalid, so remove the description.