### PR TITLE
[1.13.x] Add support for dns and dns_search in deploy using composefile

### DIFF
--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -587,6 +587,7 @@ func convertService(
 				Hostname:        service.Hostname,
 				Hosts:           convertExtraHosts(service.ExtraHosts),
 				Healthcheck:     healthcheck,
+				DNSConfig:       convertDNS(service.Dns, service.DnsSearch),
 				Env:             convertEnvironment(service.Environment),
 				Labels:          getStackLabels(namespace.name, service.Labels),
 				Dir:             service.WorkingDir,
@@ -610,6 +611,12 @@ func convertService(
 	}
 
 	return serviceSpec, nil
+}
+func convertDNS(dns []string, dnsSearch []string) *swarm.DNSConfig {
+	return &swarm.DNSConfig{
+		Nameservers: dns,
+		Search:      dnsSearch,
+	}
 }
 
 func convertExtraHosts(extraHosts map[string]string) []string {

--- a/vendor/github.com/aanand/compose-file/types/types.go
+++ b/vendor/github.com/aanand/compose-file/types/types.go
@@ -10,8 +10,6 @@ var UnsupportedProperties = []string{
 	"cap_drop",
 	"cgroup_parent",
 	"devices",
-	"dns",
-	"dns_search",
 	"domainname",
 	"external_links",
 	"ipc",


### PR DESCRIPTION
Related to #29685.

The changes is small but this would need a change in `anaand/compose-file` and needs vendoring. If we are ok to do this in 1.13.x I will make a PR in `anaand/compose-file` and update this PR. I will also make a PR against master afterwards.

/cc @thaJeztah @dnephin @icecrime 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

