### PR TITLE
Fix validation of plugins without rootfs in config

### DIFF
--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -301,6 +301,10 @@ func configToRootFS(c []byte) (*image.RootFS, error) {
 	if err := json.Unmarshal(c, &pluginConfig); err != nil {
 		return nil, err
 	}
+	// validation for empty rootfs is in distribution code
+	if pluginConfig.Rootfs == nil {
+		return nil, nil
+	}
 
 	return rootFSFromPlugin(pluginConfig.Rootfs), nil
 }


### PR DESCRIPTION
This makes sure we do not get `nil pointer dereference` when installing old plugins that don't have rootfs property in config. Note that the actual validation is in https://github.com/docker/docker/blob/bf6eb855391e166a65db284567686fafbe4a9a0a/distribution/pull_v2.go#L612-L614

@dmcgowan @vikstrous 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>

