### PR TITLE
Rewrite the function 'validatePrivileges' without checking order

### DIFF
--- a/api/types/plugin_responses.go
+++ b/api/types/plugin_responses.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 )
 
 // PluginsListResponse contains the response for the Engine API
@@ -62,3 +63,17 @@ type PluginPrivilege struct {
 
 // PluginPrivileges is a list of PluginPrivilege
 type PluginPrivileges []PluginPrivilege
+
+func (s PluginPrivileges) Len() int {
+	return len(s)
+}
+
+func (s PluginPrivileges) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+
+func (s PluginPrivileges) Swap(i, j int) {
+	sort.Strings(s[i].Value)
+	sort.Strings(s[j].Value)
+	s[i], s[j] = s[j], s[i]
+}

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -1,0 +1,55 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types"
+)
+
+func TestValidatePrivileges(t *testing.T) {
+	testData := map[string]struct {
+		requiredPrivileges types.PluginPrivileges
+		privileges         types.PluginPrivileges
+		result             bool
+	}{
+		"diff-len": {
+			requiredPrivileges: []types.PluginPrivilege{
+				{"Privilege1", "Description", []string{"abc", "def", "ghi"}},
+			},
+			privileges: []types.PluginPrivilege{
+				{"Privilege1", "Description", []string{"abc", "def", "ghi"}},
+				{"Privilege2", "Description", []string{"123", "456", "789"}},
+			},
+			result: false,
+		},
+		"diff-value": {
+			requiredPrivileges: []types.PluginPrivilege{
+				{"Privilege1", "Description", []string{"abc", "def", "GHI"}},
+				{"Privilege2", "Description", []string{"123", "456", "***"}},
+			},
+			privileges: []types.PluginPrivilege{
+				{"Privilege1", "Description", []string{"abc", "def", "ghi"}},
+				{"Privilege2", "Description", []string{"123", "456", "789"}},
+			},
+			result: false,
+		},
+		"diff-order-but-same-value": {
+			requiredPrivileges: []types.PluginPrivilege{
+				{"Privilege1", "Description", []string{"abc", "def", "GHI"}},
+				{"Privilege2", "Description", []string{"123", "456", "789"}},
+			},
+			privileges: []types.PluginPrivilege{
+				{"Privilege2", "Description", []string{"123", "456", "789"}},
+				{"Privilege1", "Description", []string{"GHI", "abc", "def"}},
+			},
+			result: true,
+		},
+	}
+
+	for key, data := range testData {
+		err := validatePrivileges(data.requiredPrivileges, data.privileges)
+		if (err == nil) != data.result {
+			t.Fatalf("Test item %s expected result to be %t, got %t", key, data.result, (err == nil))
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>

Rewrite the function `validatePrivileges` without checking order, and add a testcase for it.