### PR TITLE
Fixes: #29654: forbid removing the container being committed

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -33,6 +33,11 @@ func (daemon *Daemon) ContainerRm(name string, config *types.ContainerRmConfig) 
 	}
 	defer container.ResetRemovalInProgress()
 
+	if container.IsCommitInProgress() {
+		err := fmt.Errorf("You cannot remove container %s which is being committed", container.ID)
+		return errors.NewBadRequestError(err)
+	}
+
 	// check if container wasn't deregistered by previous rm since Get
 	if c := daemon.containers.Get(container.ID); c == nil {
 		return nil


### PR DESCRIPTION
fixes #29654 

Add a new state to container for the daemon to track if a container is
being committed.

The reason why I use a `int32` not a `bool` value for `CommitInProgress` is to avoid 
removing a container while multiple commit routines are going on.

If this fix is acceptable, then I will add some tests.

Signed-off-by: Yuanhong Peng <pengyuanhong@huawei.com>