### PR TITLE
exit collect when we get EOF

### DIFF
--- a/cli/command/container/stats_helpers.go
+++ b/cli/command/container/stats_helpers.go
@@ -155,11 +155,13 @@ func collect(ctx context.Context, s *formatter.ContainerStats, cli client.APICli
 				waitFirst.Done()
 			}
 		case err := <-u:
+			s.SetError(err)
+			if err == io.EOF {
+				break
+			}
 			if err != nil {
-				s.SetError(err)
 				continue
 			}
-			s.SetError(nil)
 			// if this is the first stat you get, release WaitGroup
 			if !getFirst {
 				getFirst = true


### PR DESCRIPTION
**- What I did**
Since when we get `EOF`, we stop collecting the container stats and exit [this goroutine](https://github.com/docker/docker/pull/29747/files#diff-6461907ebcb6301af53f701fc953b949L81). So, we should also exit the collecter when we get `EOF`. Otherwise, we will keep the collecter running, even if we have already stop collecting the container stats.

![175479607](https://cloud.githubusercontent.com/assets/1636894/21517774/dce1510a-cd1c-11e6-86bc-1747d906f387.jpg)

Signed-off-by: Xianglin Gao <xlgao@zju.edu.cn>
