### PR TITLE
return err when (dis)connecting a non-exist network

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1270,6 +1270,15 @@ func (s *DockerNetworkSuite) TestDockerNetworkRestartWithMultipleNetworks(c *che
 func (s *DockerNetworkSuite) TestDockerNetworkConnectDisconnectToStoppedContainer(c *check.C) {
 	dockerCmd(c, "network", "create", "test")
 	dockerCmd(c, "create", "--name=foo", "busybox", "top")
+
+	// connect a non-running container to a non-existing network
+	out, _, err := dockerCmdWithError("network", "connect", "non-existing-network", "test")
+	c.Assert(err, checker.NotNil, check.Commentf(out))
+
+	// disconnect a non-running container from a non-existing network
+	out, _, err = dockerCmdWithError("network", "disconnect", "non-existing-network", "test")
+	c.Assert(err, checker.NotNil, check.Commentf(out))
+
 	dockerCmd(c, "network", "connect", "test", "foo")
 	networks := inspectField(c, "foo", "NetworkSettings.Networks")
 	c.Assert(networks, checker.Contains, "test", check.Commentf("Should contain 'test' network"))
@@ -1311,6 +1320,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkDisconnectContainerNonexistingNetw
 	dockerCmd(c, "network", "rm", "test")
 
 	// Test disconnecting stopped container from nonexisting network
+	// this stopped container's networking config has this network details
 	dockerCmd(c, "network", "disconnect", "-f", "test", "foo")
 	networks = inspectField(c, "foo", "NetworkSettings.Networks")
 	c.Assert(networks, checker.Not(checker.Contains), "test", check.Commentf("Should not contain 'test' network"))


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

fixes https://github.com/docker/docker/issues/29754

**- What I did**
1. simplify function `ConnectToNetwork`, since we already got the network entity.
2. check network existence in `ConnectToNetwork `;
3. simplify function `DisconnectFromNetwork` into two kinds of cases, stopped container and running container
4. add test cases for the two above cases.

**- How I did it**

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**