### PR TITLE
purify error message in cli for create and run command

### DIFF
--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -255,10 +255,11 @@ func runRun(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *runOptions
 // reportError is a utility method that prints a user-friendly message
 // containing the error that occurred during parsing and a suggestion to get help
 func reportError(stderr io.Writer, name string, str string, withHelp bool) {
+	str = strings.TrimSuffix(str, ".") + "."
 	if withHelp {
-		str += ".\nSee '" + os.Args[0] + " " + name + " --help'"
+		str += "\nSee '" + os.Args[0] + " " + name + " --help'."
 	}
-	fmt.Fprintf(stderr, "%s: %s.\n", os.Args[0], str)
+	fmt.Fprintf(stderr, "%s: %s\n", os.Args[0], str)
 }
 
 // if container start fails with 'not found'/'no such' error, return 127


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I found when create and run command fails, cli will return error message like this:
```
root@ubuntu:~# docker run -d --net sdasaa --name allen7 alpine sdas
docker: Error response from daemon: Conflict. The container name "/allen7" is already in use by container 7fcfde24ef171a7e690366b8376d1d2facca1d755dabbe357e80b70dec138b78. You have to remove (or rename) that container to be able to reuse that name..
See 'docker run --help'.
```

I think it should be( remove `docker:`  and remove the period at the end of error massge) : 
```
root@ubuntu:~# docker run -d --net sdasaa --name allen7 alpine sdas
Error response from daemon: Conflict. The container name "/allen7" is already in use by container 7fcfde24ef171a7e690366b8376d1d2facca1d755dabbe357e80b70dec138b78. You have to remove (or rename) that container to be able to reuse that name.
See 'docker run --help'.
```
**- What I did**

1. make error message consistent with other command for create and run 

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

