### PR TITLE
Small cleanup in `integration-cli/docker_utils.go` 👼

### DIFF
--- a/integration-cli/docker_cli_cp_to_container_unix_test.go
+++ b/integration-cli/docker_cli_cp_to_container_unix_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/docker/pkg/system"
@@ -36,4 +38,21 @@ func (s *DockerSuite) TestCpCheckDestOwnership(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(stat.UID(), checker.Equals, uint32(uid), check.Commentf("Copied file not owned by container root UID"))
 	c.Assert(stat.GID(), checker.Equals, uint32(gid), check.Commentf("Copied file not owned by container root GID"))
+}
+
+func getRootUIDGID() (int, int, error) {
+	uidgid := strings.Split(filepath.Base(dockerBasePath), ".")
+	if len(uidgid) == 1 {
+		//user namespace remapping is not turned on; return 0
+		return 0, 0, nil
+	}
+	uid, err := strconv.Atoi(uidgid[0])
+	if err != nil {
+		return 0, 0, err
+	}
+	gid, err := strconv.Atoi(uidgid[1])
+	if err != nil {
+		return 0, 0, err
+	}
+	return uid, gid, nil
 }

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -224,6 +224,16 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithIncreasedBasesize(c *check.C) {
 	s.d.Stop(c)
 }
 
+func convertBasesize(basesizeBytes int64) (int64, error) {
+	basesize := units.HumanSize(float64(basesizeBytes))
+	basesize = strings.Trim(basesize, " ")[:len(basesize)-3]
+	basesizeFloat, err := strconv.ParseFloat(strings.Trim(basesize, " "), 64)
+	if err != nil {
+		return 0, err
+	}
+	return int64(basesizeFloat) * 1024 * 1024 * 1024, nil
+}
+
 // Issue #8444: If docker0 bridge is modified (intentionally or unintentionally) and
 // no longer has an IP associated, we should gracefully handle that case and associate
 // an IP with it rather than fail daemon start

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -12,14 +12,6 @@ import (
 
 // tagging a named image in a new unprefixed repo should work
 func (s *DockerSuite) TestTagUnprefixedRepoByName(c *check.C) {
-	// Don't attempt to pull on Windows as not in hub. It's installed
-	// as an image through .ensure-frozen-images-windows
-	if daemonPlatform != "windows" {
-		if err := pullImageIfNotExist("busybox:latest"); err != nil {
-			c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
-		}
-	}
-
 	dockerCmd(c, "tag", "busybox:latest", "testfoobarbaz")
 }
 
@@ -53,14 +45,6 @@ func (s *DockerSuite) TestTagInvalidPrefixedRepo(c *check.C) {
 
 // ensure we allow the use of valid tags
 func (s *DockerSuite) TestTagValidPrefixedRepo(c *check.C) {
-	// Don't attempt to pull on Windows as not in hub. It's installed
-	// as an image through .ensure-frozen-images-windows
-	if daemonPlatform != "windows" {
-		if err := pullImageIfNotExist("busybox:latest"); err != nil {
-			c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
-		}
-	}
-
 	validRepos := []string{"fooo/bar", "fooaa/test", "foooo:t", "HOSTNAME.DOMAIN.COM:443/foo/bar"}
 
 	for _, repo := range validRepos {
@@ -75,25 +59,10 @@ func (s *DockerSuite) TestTagValidPrefixedRepo(c *check.C) {
 
 // tag an image with an existed tag name without -f option should work
 func (s *DockerSuite) TestTagExistedNameWithoutForce(c *check.C) {
-	// Don't attempt to pull on Windows as not in hub. It's installed
-	// as an image through .ensure-frozen-images-windows
-	if daemonPlatform != "windows" {
-		if err := pullImageIfNotExist("busybox:latest"); err != nil {
-			c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
-		}
-	}
-
 	dockerCmd(c, "tag", "busybox:latest", "busybox:test")
 }
 
 func (s *DockerSuite) TestTagWithPrefixHyphen(c *check.C) {
-	// Don't attempt to pull on Windows as not in hub. It's installed
-	// as an image through .ensure-frozen-images-windows
-	if daemonPlatform != "windows" {
-		if err := pullImageIfNotExist("busybox:latest"); err != nil {
-			c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
-		}
-	}
 	// test repository name begin with '-'
 	out, _, err := dockerCmdWithError("tag", "busybox:latest", "-busybox:test")
 	c.Assert(err, checker.NotNil, check.Commentf(out))
@@ -150,13 +119,6 @@ func (s *DockerSuite) TestTagOfficialNames(c *check.C) {
 
 // ensure tags can not match digests
 func (s *DockerSuite) TestTagMatchesDigest(c *check.C) {
-	// Don't attempt to pull on Windows as not in hub. It's installed
-	// as an image through .ensure-frozen-images-windows
-	if daemonPlatform != "windows" {
-		if err := pullImageIfNotExist("busybox:latest"); err != nil {
-			c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
-		}
-	}
 	digest := "busybox@sha256:abcdef76720241213f5303bda7704ec4c2ef75613173910a56fb1b6e20251507"
 	// test setting tag fails
 	_, _, err := dockerCmdWithError("tag", "busybox:latest", digest)
@@ -171,14 +133,6 @@ func (s *DockerSuite) TestTagMatchesDigest(c *check.C) {
 }
 
 func (s *DockerSuite) TestTagInvalidRepoName(c *check.C) {
-	// Don't attempt to pull on Windows as not in hub. It's installed
-	// as an image through .ensure-frozen-images-windows
-	if daemonPlatform != "windows" {
-		if err := pullImageIfNotExist("busybox:latest"); err != nil {
-			c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
-		}
-	}
-
 	// test setting tag fails
 	_, _, err := dockerCmdWithError("tag", "busybox:latest", "sha256:sometag")
 	if err == nil {
@@ -188,14 +142,6 @@ func (s *DockerSuite) TestTagInvalidRepoName(c *check.C) {
 
 // ensure tags cannot create ambiguity with image ids
 func (s *DockerSuite) TestTagTruncationAmbiguity(c *check.C) {
-	//testRequires(c, DaemonIsLinux)
-	// Don't attempt to pull on Windows as not in hub. It's installed
-	// as an image through .ensure-frozen-images-windows
-	if daemonPlatform != "windows" {
-		if err := pullImageIfNotExist("busybox:latest"); err != nil {
-			c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
-		}
-	}
 	imageID, err := buildImage("notbusybox:latest",
 		`FROM busybox
 		MAINTAINER dockerio`,


### PR DESCRIPTION
- Move *one-shot* (one use) function where it is actually used (easier to know what's going on).
- Remove `pullImageIfNotExist` function as it might be an artifact from way back. We don't need it as we already have frozen/loaded image of busybox.
- Remove unused functions too.

/cc @thaJeztah @icecrime @tiborvass @cpuguy83 @dnephin 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>