### PR TITLE
Fix flaky windows TestRestartRunningContainer test

### DIFF
--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -29,7 +30,12 @@ func (s *DockerSuite) TestRestartStoppedContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestRestartRunningContainer(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", "echo foobar && sleep 30 && echo 'should not print this'")
+	sleepTime := 30
+	if DaemonIsWindows() {
+		sleepTime = 60
+	}
+	cmd := fmt.Sprintf("echo foobar && sleep %d && echo 'should not print this'", sleepTime)
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", cmd)
 
 	cleanedContainerID := strings.TrimSpace(out)
 


### PR DESCRIPTION
I was seeing this for windowsRS1 testing:
```
17:20:36 ----------------------------------------------------------------------
17:20:36 FAIL: docker_cli_restart_test.go:31: DockerSuite.TestRestartRunningContainer
17:20:36
17:20:36 docker_cli_restart_test.go:39:
17:20:36     c.Assert(out, checker.Equals, "foobar\n")
17:20:36 ... obtained string = ""
17:20:36 ... expected string = "foobar\n"
17:20:36
17:20:59
17:20:59 ----------------------------------------------------------------------
```
and I think its because we didn't wait long enough for the Windows daemon
to start the container - so we should give it more time, but just when the
daemon is running on windows.

ping @jhowardmsft  - seem reasonable?

Signed-off-by: Doug Davis <dug@us.ibm.com>
