### PR TITLE
Fix flaky windows TestRestartRunningContainer test

### DIFF
--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -35,16 +35,19 @@ func (s *DockerSuite) TestRestartRunningContainer(c *check.C) {
 
 	c.Assert(waitRun(cleanedContainerID), checker.IsNil)
 
-	out, _ = dockerCmd(c, "logs", cleanedContainerID)
-	c.Assert(out, checker.Equals, "foobar\n")
+	getLogs := func(c *check.C) (interface{}, check.CommentInterface) {
+		out, _ := dockerCmd(c, "logs", cleanedContainerID)
+		return out, nil
+	}
+
+	// Wait 10 seconds for the 'echo' to appear in the logs
+	waitAndAssert(c, 10*time.Second, getLogs, checker.Equals, "foobar\n")
 
 	dockerCmd(c, "restart", "-t", "1", cleanedContainerID)
-
-	out, _ = dockerCmd(c, "logs", cleanedContainerID)
-
 	c.Assert(waitRun(cleanedContainerID), checker.IsNil)
 
-	c.Assert(out, checker.Equals, "foobar\nfoobar\n")
+	// Wait 10 seconds for first 'echo' appear (again) in the logs
+	waitAndAssert(c, 10*time.Second, getLogs, checker.Equals, "foobar\nfoobar\n")
 }
 
 // Test that restarting a container with a volume does not create a new volume on restart. Regression test for #819.


### PR DESCRIPTION
I was seeing this for windowsRS1 testing:
17:20:36 ----------------------------------------------------------------------
17:20:36 FAIL: docker_cli_restart_test.go:31: DockerSuite.TestRestartRunningContainer
17:20:36
17:20:36 docker_cli_restart_test.go:39:
17:20:36     c.Assert(out, checker.Equals, "foobar\n")
17:20:36 ... obtained string = ""
17:20:36 ... expected string = "foobar\n"
17:20:36
17:20:59
17:20:59 ----------------------------------------------------------------------

and I think its because there's a delay between the time the container is
started and the 'echo' is actually run. This gives it up to 10 seconds
to do the 'echo' before giving up.

/cc @jhowardmsft

Signed-off-by: Doug Davis <dug@us.ibm.com>