### PR TITLE
fail fast when network filter invalid

### DIFF
--- a/api/server/router/network/filter.go
+++ b/api/server/router/network/filter.go
@@ -8,17 +8,6 @@ import (
 	"github.com/docker/docker/runconfig"
 )
 
-var (
-	// acceptedNetworkFilters is a list of acceptable filters
-	acceptedNetworkFilters = map[string]bool{
-		"driver": true,
-		"type":   true,
-		"name":   true,
-		"id":     true,
-		"label":  true,
-	}
-)
-
 func filterNetworkByType(nws []types.NetworkResource, netType string) (retNws []types.NetworkResource, err error) {
 	switch netType {
 	case "builtin":
@@ -45,10 +34,6 @@ func filterNetworks(nws []types.NetworkResource, filter filters.Args) ([]types.N
 	// if filter is empty, return original network list
 	if filter.Len() == 0 {
 		return nws, nil
-	}
-
-	if err := filter.Validate(acceptedNetworkFilters); err != nil {
-		return nil, err
 	}
 
 	displayNet := []types.NetworkResource{}

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -14,6 +14,17 @@ import (
 	"github.com/docker/libnetwork/networkdb"
 )
 
+var (
+	// acceptedNetworkFilters is a list of acceptable filters
+	acceptedNetworkFilters = map[string]bool{
+		"driver": true,
+		"type":   true,
+		"name":   true,
+		"id":     true,
+		"label":  true,
+	}
+)
+
 func (n *networkRouter) getNetworksList(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
 		return err
@@ -22,6 +33,10 @@ func (n *networkRouter) getNetworksList(ctx context.Context, w http.ResponseWrit
 	filter := r.Form.Get("filters")
 	netFilters, err := filters.FromParam(filter)
 	if err != nil {
+		return err
+	}
+
+	if err := netFilters.Validate(acceptedNetworkFilters); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

This PR made a little bit change for endpoint `GET /networks`.

When a user input the wrong filters, docker daemon fails fast without calling libnetwork or even calling the distributed store of libnetwork. Sometime `docker network ls` cost much time when there is a ditributed store such as etcd store.

**- What I did**

1. move filter validation to the early dealing of endpoint `GET /networks`

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

