### PR TITLE
remove warnings in network create response

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -245,7 +245,6 @@ func (daemon *Daemon) createNetwork(create types.NetworkCreateRequest, id string
 		return nil, apierrors.NewRequestForbiddenError(err)
 	}
 
-	var warning string
 	nw, err := daemon.GetNetworkByName(create.Name)
 	if err != nil {
 		if _, ok := err.(libnetwork.ErrNoSuchNetwork); !ok {
@@ -256,7 +255,6 @@ func (daemon *Daemon) createNetwork(create types.NetworkCreateRequest, id string
 		if create.CheckDuplicate {
 			return nil, libnetwork.NetworkNameError(create.Name)
 		}
-		warning = fmt.Sprintf("Network with name %s (id : %s) already exists", nw.Name(), nw.ID())
 	}
 
 	c := daemon.netController
@@ -301,8 +299,7 @@ func (daemon *Daemon) createNetwork(create types.NetworkCreateRequest, id string
 	daemon.LogNetworkEvent(n, "create")
 
 	return &types.NetworkCreateResponse{
-		ID:      n.ID(),
-		Warning: warning,
+		ID: n.ID(),
 	}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I think this warning the handler of network create is useless. Here is my reasons:

1. there is no things to deal this warning in client side;
2. warning in `createNetwork` is only one kind, while this is an error

Here is my test, no warning showing but shows an error:
```
root@ubuntu:~# docker network create aaa
f0e75c67115ed827cb50c78d21de158ee4832aa67a53839f5fed545552845406
root@ubuntu:~# docker network create aaa
Error response from daemon: network with name aaa already exists
```

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

