### PR TITLE
Add `Docker Version` information to `docker version`

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5199,6 +5199,17 @@ paths:
                 type: "boolean"
               BuildTime:
                 type: "string"
+              DockerVersion:
+                type: "object"
+                properties:
+                  Type:
+                    type: "string"
+                  Version:
+                    type: "string"
+                  Flavor:
+                    type: "string"
+                  Patch:
+                    type: "string"
           examples:
             application/json:
               Version: "1.14.0"
@@ -5211,6 +5222,11 @@ paths:
               MinAPIVersion: "1.12"
               BuildTime: "2016-06-14T07:09:13.444803460+00:00"
               Experimental: true
+              DockerVersion:
+                Type: CE
+                Version: "17.01"
+                Flavor: ubuntu
+                Patch: "0"
         500:
           description: "server error"
           schema:

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -268,6 +268,16 @@ func (v VersionResponse) ServerOK() bool {
 	return v.Server != nil
 }
 
+// DockerVersionOK returns true if server returned docker version informations
+func (v VersionResponse) DockerVersionOK() bool {
+	return v.Server != nil && v.Server.DockerVersion != nil
+}
+
+// DockerVersion returns docker version informations
+func (v VersionResponse) DockerVersion() string {
+	return v.Server.DockerVersion.String()
+}
+
 // NodeListOptions holds parameters to list nodes with.
 type NodeListOptions struct {
 	Filters filters.Args

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -149,9 +149,25 @@ type Version struct {
 	GoVersion     string
 	Os            string
 	Arch          string
-	KernelVersion string `json:",omitempty"`
-	Experimental  bool   `json:",omitempty"`
-	BuildTime     string `json:",omitempty"`
+	KernelVersion string         `json:",omitempty"`
+	Experimental  bool           `json:",omitempty"`
+	BuildTime     string         `json:",omitempty"`
+	DockerVersion *DockerVersion `json:",omitempty"`
+}
+
+// DockerVersion contains docker version info and
+// is returned by:
+// GET "/version"
+type DockerVersion struct {
+	Type    string // CE, EE...
+	Version string // 17.01, 18.04...
+	Flavor  string // mac, win...
+	Patch   string // 0, 1...
+}
+
+// String returns a string formated version.
+func (ev *DockerVersion) String() string {
+	return fmt.Sprintf("%s %s-%s%s", ev.Type, ev.Version, ev.Flavor, ev.Patch)
 }
 
 // Commit holds the Git-commit (SHA1) that a binary was built from, as reported

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -15,22 +15,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var versionTemplate = `Client:
- Version:      {{.Client.Version}}
- API version:  {{.Client.APIVersion}}
- Go version:   {{.Client.GoVersion}}
- Git commit:   {{.Client.GitCommit}}
- Built:        {{.Client.BuildTime}}
- OS/Arch:      {{.Client.Os}}/{{.Client.Arch}}{{if .ServerOK}}
+var versionTemplate = `{{if .DockerVersionOK}}Docker Version:  {{.DockerVersion}}
+
+{{end}}Client:
+ Engine version:  {{.Client.Version}}
+ API version:     {{.Client.APIVersion}}
+ Go version:      {{.Client.GoVersion}}
+ Git commit:      {{.Client.GitCommit}}
+ Built:           {{.Client.BuildTime}}
+ OS/Arch:         {{.Client.Os}}/{{.Client.Arch}}{{if .ServerOK}}
 
 Server:
- Version:      {{.Server.Version}}
- API version:  {{.Server.APIVersion}} (minimum version {{.Server.MinAPIVersion}})
- Go version:   {{.Server.GoVersion}}
- Git commit:   {{.Server.GitCommit}}
- Built:        {{.Server.BuildTime}}
- OS/Arch:      {{.Server.Os}}/{{.Server.Arch}}
- Experimental: {{.Server.Experimental}}{{end}}`
+ Engine version:  {{.Server.Version}}
+ API version:     {{.Server.APIVersion}} (minimum version {{.Server.MinAPIVersion}})
+ Go version:      {{.Server.GoVersion}}
+ Git commit:      {{.Server.GitCommit}}
+ Built:           {{.Server.BuildTime}}
+ OS/Arch:         {{.Server.Os}}/{{.Server.Arch}}
+ Experimental:    {{.Server.Experimental}}{{end}}`
 
 type versionOptions struct {
 	format string

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -166,6 +166,10 @@ func (daemon *Daemon) SystemVersion() types.Version {
 	}
 	v.KernelVersion = kernelVersion
 
+	dockerRelease := dockerversion.DockerRelease()
+	if dockerRelease != nil {
+		v.DockerVersion = &dockerRelease.DockerVersion
+	}
 	return v
 }
 

--- a/dockerversion/release.go
+++ b/dockerversion/release.go
@@ -1,0 +1,25 @@
+package dockerversion
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/docker/docker/api/types"
+)
+
+// DockerReleaseFile represents the content of the docker-release file
+type DockerReleaseFile struct {
+	FormatVersion string
+	DockerVersion types.DockerVersion
+}
+
+// DockerRelease returns the DockerReleaseFile
+func DockerRelease() *DockerReleaseFile {
+	if dockerReleaseFile, err := os.Open(dockerReleasePath); err == nil {
+		var dockerReleaseFileContent DockerReleaseFile
+		if err := json.NewDecoder(dockerReleaseFile).Decode(&dockerReleaseFileContent); err == nil {
+			return &dockerReleaseFileContent
+		}
+	}
+	return nil
+}

--- a/dockerversion/release_unix.go
+++ b/dockerversion/release_unix.go
@@ -1,0 +1,5 @@
+// +build !windows
+
+package dockerversion
+
+const dockerReleasePath = "/etc/docker-release"

--- a/dockerversion/release_windows.go
+++ b/dockerversion/release_windows.go
@@ -1,0 +1,3 @@
+package dockerversion
+
+const dockerReleasePath = "docker-release"

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -82,6 +82,7 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /secrets/{id}` returns information on the secret `id`.
 * `POST /secrets/{id}/update` updates the secret `id`.
 * `POST /services/(id or name)/update` now accepts service name or prefix of service id as a parameter.
+* `GET /version` now returns DockerVersion information, including the edition, the type and the flavor of Docker.
 
 ## v1.24 API changes
 

--- a/docs/reference/commandline/version.md
+++ b/docs/reference/commandline/version.md
@@ -37,20 +37,21 @@ describes all the details of the format.
 
     $ docker version
 	Client:
-	 Version:      1.8.0
-	 API version:  1.20
-	 Go version:   go1.4.2
-	 Git commit:   f5bae0a
-	 Built:        Tue Jun 23 17:56:00 UTC 2015
-	 OS/Arch:      linux/amd64
+	 Engine Version:  1.8.0
+	 API version:     1.20
+	 Go version:      go1.4.2
+	 Git commit:      f5bae0a
+	 Built:           Tue Jun 23 17:56:00 UTC 2015
+	 OS/Arch:         linux/amd64
 
 	Server:
-	 Version:      1.8.0
-	 API version:  1.20
-	 Go version:   go1.4.2
-	 Git commit:   f5bae0a
-	 Built:        Tue Jun 23 17:56:00 UTC 2015
-	 OS/Arch:      linux/amd64
+	 Engine Version:  1.8.0
+	 API version:     1.20 (minimum version 1.12)
+	 Go version:      go1.4.2
+	 Git commit:      f5bae0a
+	 Built:           Tue Jun 23 17:56:00 UTC 2015
+	 OS/Arch:         linux/amd64
+	 Experimental:    false
 
 **Get server version:**
 

--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -70,7 +70,7 @@ func (s *DockerSuite) TestAPIDockerAPIVersion(c *check.C) {
 		Command: binaryWithArgs("-H="+server.URL[7:], "version"),
 		Env:     appendBaseEnv(false, "DOCKER_API_VERSION=xxx"),
 	})
-	c.Assert(result, icmd.Matches, icmd.Expected{Out: "API version:  xxx", ExitCode: 1})
+	c.Assert(result, icmd.Matches, icmd.Expected{Out: "API version:     xxx", ExitCode: 1})
 	c.Assert(svrVersion, check.Equals, "/vxxx/version", check.Commentf("%s", result.Compare(icmd.Success)))
 }
 


### PR DESCRIPTION
This PR adds support for a new json file located at `/etc/docker-release` containing information about the currently edition installed (Mac, Windows,...) and the version of it.

The file looks like 

```json
{
        "formatVersion":"1",
        "dockerVersion": {
                 "type": "CE",
                 "version": "17.01",
                 "flavor": "mac",
                 "patch": "0"
        }
}
```

```bash
$ docker version
Docker Version:   CE-17.01-mac-0

Client:
 Engine Version:  1.14.0-dev
 API version:     1.26
 Go version:      go1.7.4
 Git commit:      e517609-unsupported
 Built:           Fri Dec 16 15:26:18 2016
 OS/Arch:         linux/amd64

Server:
 Engine Version:  1.14.0-dev
 API version:     1.26 (minimum version 1.12)
 Go version:      go1.7.4
 Git commit:      e517609-unsupported
 Built:           Fri Dec 16 15:26:18 2016
 OS/Arch:         linux/amd64
 Experimental:    false
```