### PR TITLE
Update check-config.sh to include modules for FTP/TFTP

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -293,6 +293,8 @@ echo '  - "'$(wrap_color 'ipvlan' blue)'":'
 check_flags IPVLAN | sed 's/^/    /'
 echo '  - "'$(wrap_color 'macvlan' blue)'":'
 check_flags MACVLAN DUMMY | sed 's/^/    /'
+echo '  - "'$(wrap_color 'ftp,tftp client in container' blue)'":'
+check_flags NF_NAT_FTP NF_CONNTRACK_FTP NF_NAT_TFTP NF_CONNTRACK_TFTP | sed 's/^/    /'
 
 # only fail if no storage drivers available
 CODE=${EXITCODE}


### PR DESCRIPTION
closes #22837

FTP/TFTP protocols use a different port number/channel and hence need additional nat and conntrack modules to be loaded. Since these are protocols used sparingly now it doesn't make sense probe them from libnetwork. Updating the check-config script to include the required modules.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>

