### PR TITLE
Improve usage output for docker run

### DIFF
--- a/opts/throttledevice.go
+++ b/opts/throttledevice.go
@@ -107,5 +107,5 @@ func (opt *ThrottledeviceOpt) GetList() []*blkiodev.ThrottleDevice {
 
 // Type returns the option type
 func (opt *ThrottledeviceOpt) Type() string {
-	return "throttled-device"
+	return "list"
 }

--- a/opts/weightdevice.go
+++ b/opts/weightdevice.go
@@ -85,5 +85,5 @@ func (opt *WeightdeviceOpt) GetList() []*blkiodev.WeightDevice {
 
 // Type returns the option type
 func (opt *WeightdeviceOpt) Type() string {
-	return "weighted-device"
+	return "list"
 }


### PR DESCRIPTION
Commit a77f2450c70312f8c26877a18bfe2baa44d4abb9 (https://github.com/docker/docker/pull/23253) switched `docker run` to use the `pflags` package. Due to this change, the usage output for the `--blkio-weight-device` and `--device-*` flags changed and now showed `weighted-device`, and `throttled-device` as value type. As a result, the output of `docker run --help` became a lot wider.

This patch changes the output to show `list` instead, which is consistent with other options that allow to be set multiple times.

Output before this change;

    Usage:	docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

    Run a command in a new container

    Options:
          --blkio-weight uint16                   Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
          --blkio-weight-device weighted-device   Block IO weight (relative device weight) (default [])
          --device list                           Add a host device to the container (default [])
          --device-read-bps throttled-device      Limit read rate (bytes per second) from a device (default [])
          --device-read-iops throttled-device     Limit read rate (IO per second) from a device (default [])
          --device-write-bps throttled-device     Limit write rate (bytes per second) to a device (default [])
          --device-write-iops throttled-device    Limit write rate (IO per second) to a device (default [])
      -w, --workdir string                        Working directory inside the container

Output after this change;

    Usage:	docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

    Run a command in a new container

    Options:
          --blkio-weight uint16         Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
          --blkio-weight-device list    Block IO weight (relative device weight) (default [])
          --device list                 Add a host device to the container (default [])
          --device-read-bps list        Limit read rate (bytes per second) from a device (default [])
          --device-read-iops list       Limit read rate (IO per second) from a device (default [])
          --device-write-bps list       Limit write rate (bytes per second) to a device (default [])
          --device-write-iops list      Limit write rate (IO per second) to a device (default [])
      -w, --workdir string              Working directory inside the container
