### PR TITLE
[test-integration] Add a new request package in integration-cli

### DIFF
--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/pkg/testutil"
 	"github.com/go-check/check"
@@ -23,7 +24,7 @@ func (s *DockerSuite) TestGetContainersAttachWebsocket(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-dit", "busybox", "cat")
 
-	rwc, err := sockConn(time.Duration(10*time.Second), "")
+	rwc, err := request.SockConn(time.Duration(10*time.Second), daemonHost())
 	c.Assert(err, checker.IsNil)
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -73,22 +74,20 @@ func (s *DockerSuite) TestGetContainersAttachWebsocket(c *check.C) {
 
 // regression gh14320
 func (s *DockerSuite) TestPostContainersAttachContainerNotFound(c *check.C) {
-	req, client, err := newRequestClient("POST", "/containers/doesnotexist/attach", nil, "", "")
+	client, err := request.NewClient(daemonHost())
 	c.Assert(err, checker.IsNil)
-
+	req, err := request.New(daemonHost(), "/containers/doesnotexist/attach", request.Method(http.MethodPost))
 	resp, err := client.Do(req)
 	// connection will shutdown, err should be "persistent connection closed"
-	c.Assert(err, checker.NotNil) // Server shutdown connection
-
-	body, err := testutil.ReadBody(resp.Body)
-	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusNotFound)
+	content, err := testutil.ReadBody(resp.Body)
+	c.Assert(err, checker.IsNil)
 	expected := "No such container: doesnotexist\r\n"
-	c.Assert(string(body), checker.Equals, expected)
+	c.Assert(string(content), checker.Equals, expected)
 }
 
 func (s *DockerSuite) TestGetContainersWsAttachContainerNotFound(c *check.C) {
-	status, body, err := sockRequest("GET", "/containers/doesnotexist/attach/ws", nil)
+	status, body, err := request.SockRequest("GET", "/containers/doesnotexist/attach/ws", nil, daemonHost())
 	c.Assert(status, checker.Equals, http.StatusNotFound)
 	c.Assert(err, checker.IsNil)
 	expected := "No such container: doesnotexist"
@@ -140,12 +139,12 @@ func (s *DockerSuite) TestPostContainersAttach(c *check.C) {
 	cid, _ := dockerCmd(c, "run", "-di", "busybox", "cat")
 	cid = strings.TrimSpace(cid)
 	// Attach to the container's stdout stream.
-	conn, br, err := sockRequestHijack("POST", "/containers/"+cid+"/attach?stream=1&stdin=1&stdout=1", nil, "text/plain")
+	conn, br, err := request.SockRequestHijack("POST", "/containers/"+cid+"/attach?stream=1&stdin=1&stdout=1", nil, "text/plain", daemonHost())
 	c.Assert(err, checker.IsNil)
 	// Check if the data from stdout can be received.
 	expectSuccess(conn, br, "stdout", false)
 	// Attach to the container's stderr stream.
-	conn, br, err = sockRequestHijack("POST", "/containers/"+cid+"/attach?stream=1&stdin=1&stderr=1", nil, "text/plain")
+	conn, br, err = request.SockRequestHijack("POST", "/containers/"+cid+"/attach?stream=1&stdin=1&stderr=1", nil, "text/plain", daemonHost())
 	c.Assert(err, checker.IsNil)
 	// Since the container only emits stdout, attaching to stderr should return nothing.
 	expectTimeout(conn, br, "stdout")
@@ -153,10 +152,10 @@ func (s *DockerSuite) TestPostContainersAttach(c *check.C) {
 	// Test the similar functions of the stderr stream.
 	cid, _ = dockerCmd(c, "run", "-di", "busybox", "/bin/sh", "-c", "cat >&2")
 	cid = strings.TrimSpace(cid)
-	conn, br, err = sockRequestHijack("POST", "/containers/"+cid+"/attach?stream=1&stdin=1&stderr=1", nil, "text/plain")
+	conn, br, err = request.SockRequestHijack("POST", "/containers/"+cid+"/attach?stream=1&stdin=1&stderr=1", nil, "text/plain", daemonHost())
 	c.Assert(err, checker.IsNil)
 	expectSuccess(conn, br, "stderr", false)
-	conn, br, err = sockRequestHijack("POST", "/containers/"+cid+"/attach?stream=1&stdin=1&stdout=1", nil, "text/plain")
+	conn, br, err = request.SockRequestHijack("POST", "/containers/"+cid+"/attach?stream=1&stdin=1&stdout=1", nil, "text/plain", daemonHost())
 	c.Assert(err, checker.IsNil)
 	expectTimeout(conn, br, "stderr")
 
@@ -164,12 +163,12 @@ func (s *DockerSuite) TestPostContainersAttach(c *check.C) {
 	cid, _ = dockerCmd(c, "run", "-dit", "busybox", "/bin/sh", "-c", "cat >&2")
 	cid = strings.TrimSpace(cid)
 	// Attach to stdout only.
-	conn, br, err = sockRequestHijack("POST", "/containers/"+cid+"/attach?stream=1&stdin=1&stdout=1", nil, "text/plain")
+	conn, br, err = request.SockRequestHijack("POST", "/containers/"+cid+"/attach?stream=1&stdin=1&stdout=1", nil, "text/plain", daemonHost())
 	c.Assert(err, checker.IsNil)
 	expectSuccess(conn, br, "stdout", true)
 
 	// Attach without stdout stream.
-	conn, br, err = sockRequestHijack("POST", "/containers/"+cid+"/attach?stream=1&stdin=1&stderr=1", nil, "text/plain")
+	conn, br, err = request.SockRequestHijack("POST", "/containers/"+cid+"/attach?stream=1&stdin=1&stderr=1", nil, "text/plain", daemonHost())
 	c.Assert(err, checker.IsNil)
 	// Nothing should be received because both the stdout and stderr of the container will be
 	// sent to the client as stdout when tty is enabled.

--- a/integration-cli/docker_api_auth_test.go
+++ b/integration-cli/docker_api_auth_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
 )
 
@@ -17,7 +18,7 @@ func (s *DockerSuite) TestAuthAPI(c *check.C) {
 	}
 
 	expected := "Get https://registry-1.docker.io/v2/: unauthorized: incorrect username or password"
-	status, body, err := sockRequest("POST", "/auth", config)
+	status, body, err := request.SockRequest("POST", "/auth", config, daemonHost())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusUnauthorized)
 	msg := getErrorMessage(c, body)

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/pkg/testutil"
 	"github.com/go-check/check"
 )
@@ -31,7 +32,7 @@ RUN find /tmp/`
 	c.Assert(err, checker.IsNil)
 	defer server.Close()
 
-	res, body, err := sockRequestRaw("POST", "/build?dockerfile=baz&remote="+server.URL()+"/testD", nil, "application/json")
+	res, body, err := request.SockRequestRaw("POST", "/build?dockerfile=baz&remote="+server.URL()+"/testD", nil, "application/json", daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
@@ -72,7 +73,7 @@ func (s *DockerSuite) TestBuildAPIRemoteTarballContext(c *check.C) {
 
 	defer server.Close()
 
-	res, b, err := sockRequestRaw("POST", "/build?remote="+server.URL()+"/testT.tar", nil, "application/tar")
+	res, b, err := request.SockRequestRaw("POST", "/build?remote="+server.URL()+"/testT.tar", nil, "application/tar", daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 	b.Close()
@@ -121,7 +122,7 @@ RUN echo 'right'
 
 	defer server.Close()
 	url := "/build?dockerfile=custom&remote=" + server.URL() + "/testT.tar"
-	res, body, err := sockRequestRaw("POST", url, nil, "application/tar")
+	res, body, err := request.SockRequestRaw("POST", url, nil, "application/tar", daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
@@ -141,7 +142,7 @@ RUN echo from dockerfile`,
 	c.Assert(err, checker.IsNil)
 	defer git.Close()
 
-	res, body, err := sockRequestRaw("POST", "/build?remote="+git.RepoURL, nil, "application/json")
+	res, body, err := request.SockRequestRaw("POST", "/build?remote="+git.RepoURL, nil, "application/json", daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
@@ -163,7 +164,7 @@ RUN echo from Dockerfile`,
 	defer git.Close()
 
 	// Make sure it tries to 'dockerfile' query param value
-	res, body, err := sockRequestRaw("POST", "/build?dockerfile=baz&remote="+git.RepoURL, nil, "application/json")
+	res, body, err := request.SockRequestRaw("POST", "/build?dockerfile=baz&remote="+git.RepoURL, nil, "application/json", daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
@@ -186,7 +187,7 @@ RUN echo from dockerfile`,
 	defer git.Close()
 
 	// Make sure it tries to 'dockerfile' query param value
-	res, body, err := sockRequestRaw("POST", "/build?remote="+git.RepoURL, nil, "application/json")
+	res, body, err := request.SockRequestRaw("POST", "/build?remote="+git.RepoURL, nil, "application/json", daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
@@ -233,7 +234,7 @@ func (s *DockerSuite) TestBuildAPIUnnormalizedTarPaths(c *check.C) {
 		// failed to close tar archive
 		c.Assert(tw.Close(), checker.IsNil)
 
-		res, body, err := sockRequestRaw("POST", "/build", buffer, "application/x-tar")
+		res, body, err := request.SockRequestRaw("POST", "/build", buffer, "application/x-tar", daemonHost())
 		c.Assert(err, checker.IsNil)
 		c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 

--- a/integration-cli/docker_api_create_test.go
+++ b/integration-cli/docker_api_create_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
 )
 
@@ -14,7 +15,7 @@ func (s *DockerSuite) TestAPICreateWithNotExistImage(c *check.C) {
 		"Volumes": map[string]struct{}{"/tmp": {}},
 	}
 
-	status, body, err := sockRequest("POST", "/containers/create?name="+name, config)
+	status, body, err := request.SockRequest("POST", "/containers/create?name="+name, config, daemonHost())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusNotFound)
 	expected := "No such image: test456:v1"
@@ -25,7 +26,7 @@ func (s *DockerSuite) TestAPICreateWithNotExistImage(c *check.C) {
 		"Volumes": map[string]struct{}{"/tmp": {}},
 	}
 
-	status, body, err = sockRequest("POST", "/containers/create?name="+name, config2)
+	status, body, err = request.SockRequest("POST", "/containers/create?name="+name, config2, daemonHost())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusNotFound)
 	expected = "No such image: test456:latest"
@@ -35,7 +36,7 @@ func (s *DockerSuite) TestAPICreateWithNotExistImage(c *check.C) {
 		"Image": "sha256:0cb40641836c461bc97c793971d84d758371ed682042457523e4ae701efeaaaa",
 	}
 
-	status, body, err = sockRequest("POST", "/containers/create?name="+name, config3)
+	status, body, err = request.SockRequest("POST", "/containers/create?name="+name, config3, daemonHost())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusNotFound)
 	expected = "No such image: sha256:0cb40641836c461bc97c793971d84d758371ed682042457523e4ae701efeaaaa"
@@ -52,7 +53,7 @@ func (s *DockerSuite) TestAPICreateEmptyEnv(c *check.C) {
 		"Cmd":   []string{"true"},
 	}
 
-	status, body, err := sockRequest("POST", "/containers/create?name="+name, config)
+	status, body, err := request.SockRequest("POST", "/containers/create?name="+name, config, daemonHost())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusInternalServerError)
 	expected := "invalid environment variable:"
@@ -64,7 +65,7 @@ func (s *DockerSuite) TestAPICreateEmptyEnv(c *check.C) {
 		"Env":   []string{"=", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
 		"Cmd":   []string{"true"},
 	}
-	status, body, err = sockRequest("POST", "/containers/create?name="+name, config)
+	status, body, err = request.SockRequest("POST", "/containers/create?name="+name, config, daemonHost())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusInternalServerError)
 	expected = "invalid environment variable: ="
@@ -76,7 +77,7 @@ func (s *DockerSuite) TestAPICreateEmptyEnv(c *check.C) {
 		"Env":   []string{"=foo", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
 		"Cmd":   []string{"true"},
 	}
-	status, body, err = sockRequest("POST", "/containers/create?name="+name, config)
+	status, body, err = request.SockRequest("POST", "/containers/create?name="+name, config, daemonHost())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusInternalServerError)
 	expected = "invalid environment variable: =foo"

--- a/integration-cli/docker_api_events_test.go
+++ b/integration-cli/docker_api_events_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/go-check/check"
 )
@@ -21,7 +22,7 @@ func (s *DockerSuite) TestEventsAPIEmptyOutput(c *check.C) {
 	}
 	chResp := make(chan *apiResp)
 	go func() {
-		resp, body, err := sockRequestRaw("GET", "/events", nil, "")
+		resp, body, err := request.SockRequestRaw("GET", "/events", nil, "", daemonHost())
 		body.Close()
 		chResp <- &apiResp{resp, err}
 	}()
@@ -46,7 +47,7 @@ func (s *DockerSuite) TestEventsAPIBackwardsCompatible(c *check.C) {
 	q := url.Values{}
 	q.Set("since", ts)
 
-	_, body, err := sockRequestRaw("GET", "/events?"+q.Encode(), nil, "")
+	_, body, err := request.SockRequestRaw("GET", "/events?"+q.Encode(), nil, "", daemonHost())
 	c.Assert(err, checker.IsNil)
 	defer body.Close()
 

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
 )
 
@@ -19,7 +20,7 @@ func (s *DockerSuite) TestExecResizeAPIHeightWidthNoInt(c *check.C) {
 	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/exec/" + cleanedContainerID + "/resize?h=foo&w=bar"
-	status, _, err := sockRequest("POST", endpoint, nil)
+	status, _, err := request.SockRequest("POST", endpoint, nil, daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusInternalServerError)
 }
@@ -35,7 +36,7 @@ func (s *DockerSuite) TestExecResizeImmediatelyAfterExecStart(c *check.C) {
 			"Cmd":         []string{"/bin/sh"},
 		}
 		uri := fmt.Sprintf("/containers/%s/exec", name)
-		status, body, err := sockRequest("POST", uri, data)
+		status, body, err := request.SockRequest("POST", uri, data, daemonHost())
 		if err != nil {
 			return err
 		}
@@ -55,13 +56,13 @@ func (s *DockerSuite) TestExecResizeImmediatelyAfterExecStart(c *check.C) {
 		}
 
 		payload := bytes.NewBufferString(`{"Tty":true}`)
-		conn, _, err := sockRequestHijack("POST", fmt.Sprintf("/exec/%s/start", execID), payload, "application/json")
+		conn, _, err := request.SockRequestHijack("POST", fmt.Sprintf("/exec/%s/start", execID), payload, "application/json", daemonHost())
 		if err != nil {
 			return fmt.Errorf("Failed to start the exec: %q", err.Error())
 		}
 		defer conn.Close()
 
-		_, rc, err := sockRequestRaw("POST", fmt.Sprintf("/exec/%s/resize?h=24&w=80", execID), nil, "text/plain")
+		_, rc, err := request.SockRequestRaw("POST", fmt.Sprintf("/exec/%s/resize?h=24&w=80", execID), nil, "text/plain", daemonHost())
 		// It's probably a panic of the daemon if io.ErrUnexpectedEOF is returned.
 		if err == io.ErrUnexpectedEOF {
 			return fmt.Errorf("The daemon might have crashed.")

--- a/integration-cli/docker_api_info_test.go
+++ b/integration-cli/docker_api_info_test.go
@@ -4,13 +4,14 @@ import (
 	"net/http"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestInfoAPI(c *check.C) {
 	endpoint := "/info"
 
-	status, body, err := sockRequest("GET", endpoint, nil)
+	status, body, err := request.SockRequest("GET", endpoint, nil, daemonHost())
 	c.Assert(status, checker.Equals, http.StatusOK)
 	c.Assert(err, checker.IsNil)
 
@@ -43,7 +44,7 @@ func (s *DockerSuite) TestInfoAPIVersioned(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Windows only supports 1.25 or later
 	endpoint := "/v1.20/info"
 
-	status, body, err := sockRequest("GET", endpoint, nil)
+	status, body, err := request.SockRequest("GET", endpoint, nil, daemonHost())
 	c.Assert(status, checker.Equals, http.StatusOK)
 	c.Assert(err, checker.IsNil)
 

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions/v1p20"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/pkg/stringutils"
 	"github.com/go-check/check"
 )
@@ -107,7 +108,7 @@ func (s *DockerSuite) TestInspectAPIImageResponse(c *check.C) {
 	dockerCmd(c, "tag", "busybox:latest", "busybox:mytag")
 
 	endpoint := "/images/busybox/json"
-	status, body, err := sockRequest("GET", endpoint, nil)
+	status, body, err := request.SockRequest("GET", endpoint, nil, daemonHost())
 
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusOK)

--- a/integration-cli/docker_api_inspect_unix_test.go
+++ b/integration-cli/docker_api_inspect_unix_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
 )
 
@@ -19,7 +20,7 @@ func (s *DockerSuite) TestInspectAPICpusetInConfigPre120(c *check.C) {
 	name := "cpusetinconfig-pre120"
 	dockerCmd(c, "run", "--name", name, "--cpuset-cpus", "0", "busybox", "true")
 
-	status, body, err := sockRequest("GET", fmt.Sprintf("/v1.19/containers/%s/json", name), nil)
+	status, body, err := request.SockRequest("GET", fmt.Sprintf("/v1.19/containers/%s/json", name), nil, daemonHost())
 	c.Assert(status, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
 

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
 )
 
@@ -25,7 +26,7 @@ func (s *DockerSuite) TestLogsAPIWithStdout(c *check.C) {
 	chLog := make(chan logOut)
 
 	go func() {
-		res, body, err := sockRequestRaw("GET", fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&timestamps=1", id), nil, "")
+		res, body, err := request.SockRequestRaw("GET", fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&timestamps=1", id), nil, "", daemonHost())
 		if err != nil {
 			chLog <- logOut{"", nil, err}
 			return
@@ -55,7 +56,7 @@ func (s *DockerSuite) TestLogsAPINoStdoutNorStderr(c *check.C) {
 	name := "logs_test"
 	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
-	status, body, err := sockRequest("GET", fmt.Sprintf("/containers/%s/logs", name), nil)
+	status, body, err := request.SockRequest("GET", fmt.Sprintf("/containers/%s/logs", name), nil, daemonHost())
 	c.Assert(status, checker.Equals, http.StatusBadRequest)
 	c.Assert(err, checker.IsNil)
 
@@ -69,7 +70,7 @@ func (s *DockerSuite) TestLogsAPIFollowEmptyOutput(c *check.C) {
 	t0 := time.Now()
 	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "sleep", "10")
 
-	_, body, err := sockRequestRaw("GET", fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&stderr=1&tail=all", name), bytes.NewBuffer(nil), "")
+	_, body, err := request.SockRequestRaw("GET", fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&stderr=1&tail=all", name), bytes.NewBuffer(nil), "", daemonHost())
 	t1 := time.Now()
 	c.Assert(err, checker.IsNil)
 	body.Close()
@@ -81,7 +82,7 @@ func (s *DockerSuite) TestLogsAPIFollowEmptyOutput(c *check.C) {
 
 func (s *DockerSuite) TestLogsAPIContainerNotFound(c *check.C) {
 	name := "nonExistentContainer"
-	resp, _, err := sockRequestRaw("GET", fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&stderr=1&tail=all", name), bytes.NewBuffer(nil), "")
+	resp, _, err := request.SockRequestRaw("GET", fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&stderr=1&tail=all", name), bytes.NewBuffer(nil), "", daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusNotFound)
 }

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
 )
 
@@ -256,12 +257,12 @@ func createDeletePredefinedNetwork(c *check.C, name string) {
 }
 
 func isNetworkAvailable(c *check.C, name string) bool {
-	status, body, err := sockRequest("GET", "/networks", nil)
-	c.Assert(status, checker.Equals, http.StatusOK)
+	resp, body, err := request.Get(daemonHost(), "/networks")
+	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(err, checker.IsNil)
 
 	nJSON := []types.NetworkResource{}
-	err = json.Unmarshal(body, &nJSON)
+	err = json.NewDecoder(body).Decode(&nJSON)
 	c.Assert(err, checker.IsNil)
 
 	for _, n := range nJSON {
@@ -282,12 +283,12 @@ func getNetworkIDByName(c *check.C, name string) string {
 	c.Assert(err, checker.IsNil)
 	v.Set("filters", filterJSON)
 
-	status, body, err := sockRequest("GET", "/networks?"+v.Encode(), nil)
-	c.Assert(status, checker.Equals, http.StatusOK)
+	resp, body, err := request.Get(daemonHost(), "/networks?"+v.Encode())
+	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(err, checker.IsNil)
 
 	nJSON := []types.NetworkResource{}
-	err = json.Unmarshal(body, &nJSON)
+	err = json.NewDecoder(body).Decode(&nJSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(len(nJSON), checker.Equals, 1)
 
@@ -295,28 +296,28 @@ func getNetworkIDByName(c *check.C, name string) string {
 }
 
 func getNetworkResource(c *check.C, id string) *types.NetworkResource {
-	_, obj, err := sockRequest("GET", "/networks/"+id, nil)
+	_, obj, err := request.Get(daemonHost(), "/networks/"+id)
 	c.Assert(err, checker.IsNil)
 
 	nr := types.NetworkResource{}
-	err = json.Unmarshal(obj, &nr)
+	err = json.NewDecoder(obj).Decode(&nr)
 	c.Assert(err, checker.IsNil)
 
 	return &nr
 }
 
 func createNetwork(c *check.C, config types.NetworkCreateRequest, shouldSucceed bool) string {
-	status, resp, err := sockRequest("POST", "/networks/create", config)
+	resp, body, err := request.Post(daemonHost(), "/networks/create", request.JSONBody(config))
 	if !shouldSucceed {
-		c.Assert(status, checker.Not(checker.Equals), http.StatusCreated)
+		c.Assert(resp.StatusCode, checker.Not(checker.Equals), http.StatusCreated)
 		return ""
 	}
 
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusCreated)
+	c.Assert(resp.StatusCode, checker.Equals, http.StatusCreated)
 
 	var nr types.NetworkCreateResponse
-	err = json.Unmarshal(resp, &nr)
+	err = json.NewDecoder(body).Decode(&nr)
 	c.Assert(err, checker.IsNil)
 
 	return nr.ID
@@ -327,8 +328,8 @@ func connectNetwork(c *check.C, nid, cid string) {
 		Container: cid,
 	}
 
-	status, _, err := sockRequest("POST", "/networks/"+nid+"/connect", config)
-	c.Assert(status, checker.Equals, http.StatusOK)
+	resp, _, err := request.Post(daemonHost(), "/networks/"+nid+"/connect", request.JSONBody(config))
+	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(err, checker.IsNil)
 }
 
@@ -337,17 +338,17 @@ func disconnectNetwork(c *check.C, nid, cid string) {
 		Container: cid,
 	}
 
-	status, _, err := sockRequest("POST", "/networks/"+nid+"/disconnect", config)
-	c.Assert(status, checker.Equals, http.StatusOK)
+	resp, _, err := request.Post(daemonHost(), "/networks/"+nid+"/disconnect", request.JSONBody(config))
+	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(err, checker.IsNil)
 }
 
 func deleteNetwork(c *check.C, id string, shouldSucceed bool) {
-	status, _, err := sockRequest("DELETE", "/networks/"+id, nil)
+	resp, _, err := request.Delete(daemonHost(), "/networks/"+id)
 	if !shouldSucceed {
-		c.Assert(status, checker.Not(checker.Equals), http.StatusOK)
+		c.Assert(resp.StatusCode, checker.Not(checker.Equals), http.StatusOK)
 		return
 	}
-	c.Assert(status, checker.Equals, http.StatusNoContent)
+	c.Assert(resp.StatusCode, checker.Equals, http.StatusNoContent)
 	c.Assert(err, checker.IsNil)
 }

--- a/integration-cli/docker_api_resize_test.go
+++ b/integration-cli/docker_api_resize_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
 )
 
@@ -13,7 +14,7 @@ func (s *DockerSuite) TestResizeAPIResponse(c *check.C) {
 	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/containers/" + cleanedContainerID + "/resize?h=40&w=40"
-	status, _, err := sockRequest("POST", endpoint, nil)
+	status, _, err := request.SockRequest("POST", endpoint, nil, daemonHost())
 	c.Assert(status, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
 }
@@ -23,7 +24,7 @@ func (s *DockerSuite) TestResizeAPIHeightWidthNoInt(c *check.C) {
 	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/containers/" + cleanedContainerID + "/resize?h=foo&w=bar"
-	status, _, err := sockRequest("POST", endpoint, nil)
+	status, _, err := request.SockRequest("POST", endpoint, nil, daemonHost())
 	c.Assert(status, check.Equals, http.StatusInternalServerError)
 	c.Assert(err, check.IsNil)
 }
@@ -36,7 +37,7 @@ func (s *DockerSuite) TestResizeAPIResponseWhenContainerNotStarted(c *check.C) {
 	dockerCmd(c, "wait", cleanedContainerID)
 
 	endpoint := "/containers/" + cleanedContainerID + "/resize?h=40&w=40"
-	status, body, err := sockRequest("POST", endpoint, nil)
+	status, body, err := request.SockRequest("POST", endpoint, nil, daemonHost())
 	c.Assert(status, check.Equals, http.StatusInternalServerError)
 	c.Assert(err, check.IsNil)
 

--- a/integration-cli/docker_api_stats_unix_test.go
+++ b/integration-cli/docker_api_stats_unix_test.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestAPIStatsContainerGetMemoryLimit(c *check.C) {
 	testRequires(c, DaemonIsLinux, memoryLimitSupport)
 
-	resp, body, err := sockRequestRaw("GET", "/info", nil, "application/json")
+	resp, body, err := request.SockRequestRaw("GET", "/info", nil, "application/json", daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	var info types.Info
@@ -28,7 +29,7 @@ func (s *DockerSuite) TestAPIStatsContainerGetMemoryLimit(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", conName, "busybox", "top")
 	c.Assert(waitRun(conName), checker.IsNil)
 
-	resp, body, err = sockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", conName), nil, "")
+	resp, body, err = request.SockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", conName), nil, "", daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(resp.Header.Get("Content-Type"), checker.Equals, "application/json")

--- a/integration-cli/docker_api_update_unix_test.go
+++ b/integration-cli/docker_api_update_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
 )
 
@@ -20,7 +21,7 @@ func (s *DockerSuite) TestAPIUpdateContainer(c *check.C) {
 		"MemorySwap": 524288000,
 	}
 	dockerCmd(c, "run", "-d", "--name", name, "-m", "200M", "busybox", "top")
-	_, _, err := sockRequest("POST", "/containers/"+name+"/update", hostConfig)
+	_, _, err := request.SockRequest("POST", "/containers/"+name+"/update", hostConfig, daemonHost())
 	c.Assert(err, check.IsNil)
 
 	c.Assert(inspectField(c, name, "HostConfig.Memory"), checker.Equals, "314572800")

--- a/integration-cli/docker_api_version_test.go
+++ b/integration-cli/docker_api_version_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestGetVersion(c *check.C) {
-	status, body, err := sockRequest("GET", "/version", nil)
+	status, body, err := request.SockRequest("GET", "/version", nil, daemonHost())
 	c.Assert(status, checker.Equals, http.StatusOK)
 	c.Assert(err, checker.IsNil)
 

--- a/integration-cli/docker_api_volumes_test.go
+++ b/integration-cli/docker_api_volumes_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/api/types"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
 )
 
@@ -15,7 +16,7 @@ func (s *DockerSuite) TestVolumesAPIList(c *check.C) {
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 	dockerCmd(c, "run", "-v", prefix+"/foo", "busybox")
 
-	status, b, err := sockRequest("GET", "/volumes", nil)
+	status, b, err := request.SockRequest("GET", "/volumes", nil, daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusOK)
 
@@ -29,7 +30,7 @@ func (s *DockerSuite) TestVolumesAPICreate(c *check.C) {
 	config := volumetypes.VolumesCreateBody{
 		Name: "test",
 	}
-	status, b, err := sockRequest("POST", "/volumes/create", config)
+	status, b, err := request.SockRequest("POST", "/volumes/create", config, daemonHost())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusCreated, check.Commentf(string(b)))
 
@@ -44,7 +45,7 @@ func (s *DockerSuite) TestVolumesAPIRemove(c *check.C) {
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 	dockerCmd(c, "run", "-v", prefix+"/foo", "--name=test", "busybox")
 
-	status, b, err := sockRequest("GET", "/volumes", nil)
+	status, b, err := request.SockRequest("GET", "/volumes", nil, daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusOK)
 
@@ -53,12 +54,12 @@ func (s *DockerSuite) TestVolumesAPIRemove(c *check.C) {
 	c.Assert(len(volumes.Volumes), checker.Equals, 1, check.Commentf("\n%v", volumes.Volumes))
 
 	v := volumes.Volumes[0]
-	status, _, err = sockRequest("DELETE", "/volumes/"+v.Name, nil)
+	status, _, err = request.SockRequest("DELETE", "/volumes/"+v.Name, nil, daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusConflict, check.Commentf("Should not be able to remove a volume that is in use"))
 
 	dockerCmd(c, "rm", "-f", "test")
-	status, data, err := sockRequest("DELETE", "/volumes/"+v.Name, nil)
+	status, data, err := request.SockRequest("DELETE", "/volumes/"+v.Name, nil, daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusNoContent, check.Commentf(string(data)))
 
@@ -68,11 +69,11 @@ func (s *DockerSuite) TestVolumesAPIInspect(c *check.C) {
 	config := volumetypes.VolumesCreateBody{
 		Name: "test",
 	}
-	status, b, err := sockRequest("POST", "/volumes/create", config)
+	status, b, err := request.SockRequest("POST", "/volumes/create", config, daemonHost())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusCreated, check.Commentf(string(b)))
 
-	status, b, err = sockRequest("GET", "/volumes", nil)
+	status, b, err = request.SockRequest("GET", "/volumes", nil, daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf(string(b)))
 
@@ -81,7 +82,7 @@ func (s *DockerSuite) TestVolumesAPIInspect(c *check.C) {
 	c.Assert(len(volumes.Volumes), checker.Equals, 1, check.Commentf("\n%v", volumes.Volumes))
 
 	var vol types.Volume
-	status, b, err = sockRequest("GET", "/volumes/"+config.Name, nil)
+	status, b, err = request.SockRequest("GET", "/volumes/"+config.Name, nil, daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf(string(b)))
 	c.Assert(json.Unmarshal(b, &vol), checker.IsNil)

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -15,6 +15,7 @@ import (
 	eventtypes "github.com/docker/docker/api/types/events"
 	eventstestutils "github.com/docker/docker/daemon/events/testutils"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/pkg/testutil"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
@@ -494,7 +495,7 @@ func (s *DockerSuite) TestEventsResize(c *check.C) {
 	c.Assert(waitRun(cID), checker.IsNil)
 
 	endpoint := "/containers/" + cID + "/resize?h=80&w=24"
-	status, _, err := sockRequest("POST", endpoint, nil)
+	status, _, err := request.SockRequest("POST", endpoint, nil, daemonHost())
 	c.Assert(status, checker.Equals, http.StatusOK)
 	c.Assert(err, checker.IsNil)
 

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
@@ -355,14 +356,14 @@ func (s *DockerSuite) TestExecInspectID(c *check.C) {
 	}
 
 	// But we should still be able to query the execID
-	sc, body, err := sockRequest("GET", "/exec/"+execID+"/json", nil)
+	sc, body, err := request.SockRequest("GET", "/exec/"+execID+"/json", nil, daemonHost())
 	c.Assert(sc, checker.Equals, http.StatusOK, check.Commentf("received status != 200 OK: %d\n%s", sc, body))
 
 	// Now delete the container and then an 'inspect' on the exec should
 	// result in a 404 (not 'container not running')
 	out, ec := dockerCmd(c, "rm", "-f", id)
 	c.Assert(ec, checker.Equals, 0, check.Commentf("error removing container: %s", out))
-	sc, body, err = sockRequest("GET", "/exec/"+execID+"/json", nil)
+	sc, body, err = request.SockRequest("GET", "/exec/"+execID+"/json", nil, daemonHost())
 	c.Assert(sc, checker.Equals, http.StatusNotFound, check.Commentf("received status != 404: %d\n%s", sc, body))
 }
 

--- a/integration-cli/docker_cli_kill_test.go
+++ b/integration-cli/docker_cli_kill_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
 )
 
@@ -128,7 +129,7 @@ func (s *DockerSuite) TestKillStoppedContainerAPIPre120(c *check.C) {
 	runSleepingContainer(c, "--name", "docker-kill-test-api", "-d")
 	dockerCmd(c, "stop", "docker-kill-test-api")
 
-	status, _, err := sockRequest("POST", fmt.Sprintf("/v1.19/containers/%s/kill", "docker-kill-test-api"), nil)
+	status, _, err := request.SockRequest("POST", fmt.Sprintf("/v1.19/containers/%s/kill", "docker-kill-test-api"), nil, daemonHost())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusNoContent)
 }

--- a/integration-cli/docker_cli_update_unix_test.go
+++ b/integration-cli/docker_cli_update_unix_test.go
@@ -5,15 +5,16 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/kr/pty"
 	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/go-check/check"
+	"github.com/kr/pty"
 )
 
 func (s *DockerSuite) TestUpdateRunningContainer(c *check.C) {
@@ -219,7 +220,7 @@ func (s *DockerSuite) TestUpdateStats(c *check.C) {
 	c.Assert(waitRun(name), checker.IsNil)
 
 	getMemLimit := func(id string) uint64 {
-		resp, body, err := sockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", id), nil, "")
+		resp, body, err := request.SockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", id), nil, "", daemonHost())
 		c.Assert(err, checker.IsNil)
 		c.Assert(resp.Header.Get("Content-Type"), checker.Equals, "application/json")
 

--- a/integration-cli/docker_deprecated_api_v124_unix_test.go
+++ b/integration-cli/docker_deprecated_api_v124_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
 )
 
@@ -21,7 +22,7 @@ func (s *DockerNetworkSuite) TestDeprecatedDockerNetworkStartAPIWithHostconfig(c
 			"NetworkMode": netName,
 		},
 	}
-	_, _, err := sockRequest("POST", formatV123StartAPIURL("/containers/"+conName+"/start"), config)
+	_, _, err := request.SockRequest("POST", formatV123StartAPIURL("/containers/"+conName+"/start"), config, daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(waitRun(conName), checker.IsNil)
 	networks := inspectField(c, conName, "NetworkSettings.Networks")

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -11,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -26,10 +24,9 @@ import (
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/integration-cli/registry"
+	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/opts"
-	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/stringutils"
-	"github.com/docker/docker/pkg/testutil"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
@@ -40,82 +37,6 @@ func daemonHost() string {
 		daemonURLStr = daemonHostVar
 	}
 	return daemonURLStr
-}
-
-// FIXME(vdemeester) should probably completely move to daemon struct/methods
-func sockConn(timeout time.Duration, daemonStr string) (net.Conn, error) {
-	if daemonStr == "" {
-		daemonStr = daemonHost()
-	}
-	return daemon.SockConn(timeout, daemonStr)
-}
-
-func sockRequest(method, endpoint string, data interface{}) (int, []byte, error) {
-	jsonData := bytes.NewBuffer(nil)
-	if err := json.NewEncoder(jsonData).Encode(data); err != nil {
-		return -1, nil, err
-	}
-
-	res, body, err := sockRequestRaw(method, endpoint, jsonData, "application/json")
-	if err != nil {
-		return -1, nil, err
-	}
-	b, err := testutil.ReadBody(body)
-	return res.StatusCode, b, err
-}
-
-func sockRequestRaw(method, endpoint string, data io.Reader, ct string) (*http.Response, io.ReadCloser, error) {
-	return sockRequestRawToDaemon(method, endpoint, data, ct, "")
-}
-
-func sockRequestRawToDaemon(method, endpoint string, data io.Reader, ct, daemon string) (*http.Response, io.ReadCloser, error) {
-	req, client, err := newRequestClient(method, endpoint, data, ct, daemon)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		client.Close()
-		return nil, nil, err
-	}
-	body := ioutils.NewReadCloserWrapper(resp.Body, func() error {
-		defer resp.Body.Close()
-		return client.Close()
-	})
-
-	return resp, body, nil
-}
-
-func sockRequestHijack(method, endpoint string, data io.Reader, ct string) (net.Conn, *bufio.Reader, error) {
-	req, client, err := newRequestClient(method, endpoint, data, ct, "")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	client.Do(req)
-	conn, br := client.Hijack()
-	return conn, br, nil
-}
-
-func newRequestClient(method, endpoint string, data io.Reader, ct, daemon string) (*http.Request, *httputil.ClientConn, error) {
-	c, err := sockConn(time.Duration(10*time.Second), daemon)
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not dial docker daemon: %v", err)
-	}
-
-	client := httputil.NewClientConn(c, nil)
-
-	req, err := http.NewRequest(method, endpoint, data)
-	if err != nil {
-		client.Close()
-		return nil, nil, fmt.Errorf("could not create new request: %v", err)
-	}
-
-	if ct != "" {
-		req.Header.Set("Content-Type", ct)
-	}
-	return req, client, nil
 }
 
 // FIXME(vdemeester) move this away are remove ignoreNoSuchContainer bool
@@ -163,7 +84,7 @@ func deleteAllNetworks(c *check.C) {
 			// nat is a pre-defined network on Windows and cannot be removed
 			continue
 		}
-		status, b, err := sockRequest("DELETE", "/networks/"+n.Name, nil)
+		status, b, err := request.SockRequest("DELETE", "/networks/"+n.Name, nil, daemonHost())
 		if err != nil {
 			errs = append(errs, err.Error())
 			continue
@@ -177,7 +98,7 @@ func deleteAllNetworks(c *check.C) {
 
 func getAllNetworks() ([]types.NetworkResource, error) {
 	var networks []types.NetworkResource
-	_, b, err := sockRequest("GET", "/networks", nil)
+	_, b, err := request.SockRequest("GET", "/networks", nil, daemonHost())
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +114,7 @@ func deleteAllPlugins(c *check.C) {
 	var errs []string
 	for _, p := range plugins {
 		pluginName := p.Name
-		status, b, err := sockRequest("DELETE", "/plugins/"+pluginName+"?force=1", nil)
+		status, b, err := request.SockRequest("DELETE", "/plugins/"+pluginName+"?force=1", nil, daemonHost())
 		if err != nil {
 			errs = append(errs, err.Error())
 			continue
@@ -207,7 +128,7 @@ func deleteAllPlugins(c *check.C) {
 
 func getAllPlugins() (types.PluginsListResponse, error) {
 	var plugins types.PluginsListResponse
-	_, b, err := sockRequest("GET", "/plugins", nil)
+	_, b, err := request.SockRequest("GET", "/plugins", nil, daemonHost())
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +143,7 @@ func deleteAllVolumes(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	var errs []string
 	for _, v := range volumes {
-		status, b, err := sockRequest("DELETE", "/volumes/"+v.Name, nil)
+		status, b, err := request.SockRequest("DELETE", "/volumes/"+v.Name, nil, daemonHost())
 		if err != nil {
 			errs = append(errs, err.Error())
 			continue
@@ -236,7 +157,7 @@ func deleteAllVolumes(c *check.C) {
 
 func getAllVolumes() ([]*types.Volume, error) {
 	var volumes volumetypes.VolumesListOKBody
-	_, b, err := sockRequest("GET", "/volumes", nil)
+	_, b, err := request.SockRequest("GET", "/volumes", nil, daemonHost())
 	if err != nil {
 		return nil, err
 	}
@@ -1066,7 +987,7 @@ func daemonTime(c *check.C) time.Time {
 		return time.Now()
 	}
 
-	status, body, err := sockRequest("GET", "/info", nil)
+	status, body, err := request.SockRequest("GET", "/info", nil, daemonHost())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusOK)
 
@@ -1192,7 +1113,7 @@ func waitInspectWithArgs(name, expr, expected string, timeout time.Duration, arg
 
 func getInspectBody(c *check.C, version, id string) []byte {
 	endpoint := fmt.Sprintf("/%s/containers/%s/json", version, id)
-	status, body, err := sockRequest("GET", endpoint, nil)
+	status, body, err := request.SockRequest("GET", endpoint, nil, daemonHost())
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusOK)
 	return body
@@ -1224,7 +1145,7 @@ func getGoroutineNumber() (int, error) {
 	i := struct {
 		NGoroutines int
 	}{}
-	status, b, err := sockRequest("GET", "/info", nil)
+	status, b, err := request.SockRequest("GET", "/info", nil, daemonHost())
 	if err != nil {
 		return 0, err
 	}

--- a/integration-cli/request/npipe.go
+++ b/integration-cli/request/npipe.go
@@ -1,12 +1,12 @@
-package daemon
+// +build !windows
+
+package request
 
 import (
 	"net"
 	"time"
-
-	"github.com/Microsoft/go-winio"
 )
 
 func npipeDial(path string, timeout time.Duration) (net.Conn, error) {
-	return winio.DialPipe(path, &timeout)
+	panic("npipe protocol only supported on Windows")
 }

--- a/integration-cli/request/npipe_windows.go
+++ b/integration-cli/request/npipe_windows.go
@@ -1,12 +1,12 @@
-// +build !windows
-
-package daemon
+package request
 
 import (
 	"net"
 	"time"
+
+	"github.com/Microsoft/go-winio"
 )
 
 func npipeDial(path string, timeout time.Duration) (net.Conn, error) {
-	panic("npipe protocol only supported on Windows")
+	return winio.DialPipe(path, &timeout)
 }

--- a/integration-cli/request/request.go
+++ b/integration-cli/request/request.go
@@ -1,0 +1,263 @@
+package request
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	dclient "github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/pkg/testutil"
+	"github.com/docker/go-connections/sockets"
+	"github.com/docker/go-connections/tlsconfig"
+	"github.com/pkg/errors"
+)
+
+// Method creates a modifier that sets the specified string as the request method
+func Method(method string) func(*http.Request) error {
+	return func(req *http.Request) error {
+		req.Method = method
+		return nil
+	}
+}
+
+// JSON sets the Content-Type request header to json
+func JSON(req *http.Request) error {
+	req.Header.Set("Content-Type", "application/json")
+	return nil
+}
+
+// JSONBody creates a modifier that encodes the specified data to a JSON string and set it as request body. It also sets
+// the Content-Type header of the request.
+func JSONBody(data interface{}) func(*http.Request) error {
+	return func(req *http.Request) error {
+		jsonData := bytes.NewBuffer(nil)
+		if err := json.NewEncoder(jsonData).Encode(data); err != nil {
+			return err
+		}
+		req.Body = ioutil.NopCloser(jsonData)
+		req.Header.Set("Content-Type", "application/json")
+		return nil
+	}
+}
+
+// Post creates and execute a POST request on the specified host and endpoint, with the specified request modifiers
+func Post(host, endpoint string, modifiers ...func(*http.Request) error) (*http.Response, io.ReadCloser, error) {
+	return Do(host, endpoint, append(modifiers, Method(http.MethodPost))...)
+}
+
+// Delete creates and execute a DELETE request on the specified host and endpoint, with the specified request modifiers
+func Delete(host, endpoint string, modifiers ...func(*http.Request) error) (*http.Response, io.ReadCloser, error) {
+	return Do(host, endpoint, append(modifiers, Method(http.MethodDelete))...)
+}
+
+// Get creates and execute a GET request on the specified host and endpoint, with the specified request modifiers
+func Get(host, endpoint string, modifiers ...func(*http.Request) error) (*http.Response, io.ReadCloser, error) {
+	return Do(host, endpoint, modifiers...)
+}
+
+// Do creates and execute a request on the specified host and endpoint, with the specified request modifiers
+func Do(host, endpoint string, modifiers ...func(*http.Request) error) (*http.Response, io.ReadCloser, error) {
+	req, err := New(host, endpoint, modifiers...)
+	if err != nil {
+		return nil, nil, err
+	}
+	client, err := NewClient(host)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.Do(req)
+	var body io.ReadCloser
+	if resp != nil {
+		body = ioutils.NewReadCloserWrapper(resp.Body, func() error {
+			defer resp.Body.Close()
+			return nil
+		})
+	}
+	return resp, body, err
+}
+
+// New creates a new http Request to the specified host and endpoint, with the specified request modifiers
+func New(host, endpoint string, modifiers ...func(*http.Request) error) (*http.Request, error) {
+	_, addr, _, err := dclient.ParseHost(host)
+	if err != nil {
+		return nil, err
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not parse url %q", host)
+	}
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not create new request: %v", err)
+	}
+
+	req.URL.Scheme = "http"
+	req.URL.Host = addr
+
+	for _, config := range modifiers {
+		if err := config(req); err != nil {
+			return nil, err
+		}
+	}
+	return req, nil
+}
+
+// NewClient creates an http client for the specific host
+func NewClient(host string) (*http.Client, error) {
+	// FIXME(vdemeester) 10*time.Second timeout of SockRequest… ?
+	proto, addr, _, err := dclient.ParseHost(host)
+	if err != nil {
+		return nil, err
+	}
+	transport := new(http.Transport)
+	if proto == "tcp" && os.Getenv("DOCKER_TLS_VERIFY") != "" {
+		// Setup the socket TLS configuration.
+		tlsConfig, err := getTLSConfig()
+		if err != nil {
+			return nil, err
+		}
+		transport = &http.Transport{TLSClientConfig: tlsConfig}
+	}
+	err = sockets.ConfigureTransport(transport, proto, addr)
+	return &http.Client{
+		Transport: transport,
+	}, err
+}
+
+// FIXME(vdemeester) httputil.ClientConn is deprecated, use http.Client instead (closer to actual client)
+// Deprecated: Use New instead of NewRequestClient
+// Deprecated: use request.Do (or Get, Delete, Post) instead
+func newRequestClient(method, endpoint string, data io.Reader, ct, daemon string, modifiers ...func(*http.Request)) (*http.Request, *httputil.ClientConn, error) {
+	c, err := SockConn(time.Duration(10*time.Second), daemon)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not dial docker daemon: %v", err)
+	}
+
+	client := httputil.NewClientConn(c, nil)
+
+	req, err := http.NewRequest(method, endpoint, data)
+	if err != nil {
+		client.Close()
+		return nil, nil, fmt.Errorf("could not create new request: %v", err)
+	}
+
+	for _, opt := range modifiers {
+		opt(req)
+	}
+
+	if ct != "" {
+		req.Header.Set("Content-Type", ct)
+	}
+	return req, client, nil
+}
+
+// SockRequest create a request against the specified host (with method, endpoint and other request modifier) and
+// returns the status code, and the content as an byte slice
+// Deprecated: use request.Do instead
+func SockRequest(method, endpoint string, data interface{}, daemon string, modifiers ...func(*http.Request)) (int, []byte, error) {
+	jsonData := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(jsonData).Encode(data); err != nil {
+		return -1, nil, err
+	}
+
+	res, body, err := SockRequestRaw(method, endpoint, jsonData, "application/json", daemon, modifiers...)
+	if err != nil {
+		return -1, nil, err
+	}
+	b, err := testutil.ReadBody(body)
+	return res.StatusCode, b, err
+}
+
+// SockRequestRaw create a request against the specified host (with method, endpoint and other request modifier) and
+// returns the http response, the output as a io.ReadCloser
+// Deprecated: use request.Do (or Get, Delete, Post) instead
+func SockRequestRaw(method, endpoint string, data io.Reader, ct, daemon string, modifiers ...func(*http.Request)) (*http.Response, io.ReadCloser, error) {
+	req, client, err := newRequestClient(method, endpoint, data, ct, daemon, modifiers...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := client.Do(req)
+	body := ioutils.NewReadCloserWrapper(resp.Body, func() error {
+		defer resp.Body.Close()
+		return client.Close()
+	})
+	if err != nil {
+		client.Close()
+	}
+
+	return resp, body, err
+}
+
+// SockRequestHijack creates a connection to specified host (with method, contenttype, …) and returns a hijacked connection
+// and the output as a `bufio.Reader`
+func SockRequestHijack(method, endpoint string, data io.Reader, ct string, daemon string, modifiers ...func(*http.Request)) (net.Conn, *bufio.Reader, error) {
+	req, client, err := newRequestClient(method, endpoint, data, ct, daemon, modifiers...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client.Do(req)
+	conn, br := client.Hijack()
+	return conn, br, nil
+}
+
+// SockConn opens a connection on the specified socket
+func SockConn(timeout time.Duration, daemon string) (net.Conn, error) {
+	daemonURL, err := url.Parse(daemon)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not parse url %q", daemon)
+	}
+
+	var c net.Conn
+	switch daemonURL.Scheme {
+	case "npipe":
+		return npipeDial(daemonURL.Path, timeout)
+	case "unix":
+		return net.DialTimeout(daemonURL.Scheme, daemonURL.Path, timeout)
+	case "tcp":
+		if os.Getenv("DOCKER_TLS_VERIFY") != "" {
+			// Setup the socket TLS configuration.
+			tlsConfig, err := getTLSConfig()
+			if err != nil {
+				return nil, err
+			}
+			dialer := &net.Dialer{Timeout: timeout}
+			return tls.DialWithDialer(dialer, daemonURL.Scheme, daemonURL.Host, tlsConfig)
+		}
+		return net.DialTimeout(daemonURL.Scheme, daemonURL.Host, timeout)
+	default:
+		return c, errors.Errorf("unknown scheme %v (%s)", daemonURL.Scheme, daemon)
+	}
+}
+
+func getTLSConfig() (*tls.Config, error) {
+	dockerCertPath := os.Getenv("DOCKER_CERT_PATH")
+
+	if dockerCertPath == "" {
+		return nil, errors.New("DOCKER_TLS_VERIFY specified, but no DOCKER_CERT_PATH environment variable")
+	}
+
+	option := &tlsconfig.Options{
+		CAFile:   filepath.Join(dockerCertPath, "ca.pem"),
+		CertFile: filepath.Join(dockerCertPath, "cert.pem"),
+		KeyFile:  filepath.Join(dockerCertPath, "key.pem"),
+	}
+	tlsConfig, err := tlsconfig.Client(*option)
+	if err != nil {
+		return nil, err
+	}
+
+	return tlsConfig, nil
+}


### PR DESCRIPTION
The goal is to remove function from `docker_utils.go` and setup simple, one-responsability package that can be well tested ; and to ease writing request 🐻.

This moves all the calls to `sockRequest` (and similar methods) to their counterpart in the `request` package.

This introduce `request.Do` to write easier request (with functional argument to easily augment the request) with some pre-defined function for the most used http method (i.e. `request.Get`, `request.Post` and `request.Delete`).

Few of the `sockRequest` call have been moved to `request.Do` (and `Get`, etc.) to showcase the usage of the package. There is still a whole lot to do.

```go
resp, body, err := request.Do("unix://…", "/containers/json")
// Same as before as the default method for `Do` is `GET`
resp, body, err := request.Get("unix://…", "/containers/json")
// Specifiy a custom header
resp, body, err := request.Do("unix://…", "/containers/json", func (req *http.Request) error {
    req.Headers.Set("X-Custom-Header", "MyValue")
    return nil
})
// Do a POST with some JSON data
resp, body, err := request.Post("unix://…", "/containers/json", request.JSONBody(struct{}{}))
// Do an OPTION
resp, body, err := request.Do("unix://…", "/", request.Method(http.MethodOptions))
```

/cc @thaJeztah @icecrime @dnephin @cpuguy83 @tiborvass @aaronlehmann @AkihiroSuda 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
