### PR TITLE
Update order of '--secret-rm' and '--secret-add'

### DIFF
--- a/cli/command/service/parse.go
+++ b/cli/command/service/parse.go
@@ -12,7 +12,7 @@ import (
 
 // parseSecrets retrieves the secrets from the requested names and converts
 // them to secret references to use with the spec
-func parseSecrets(client client.APIClient, requestedSecrets []*types.SecretRequestOption) ([]*swarmtypes.SecretReference, error) {
+func parseSecrets(client client.SecretAPIClient, requestedSecrets []*types.SecretRequestOption) ([]*swarmtypes.SecretReference, error) {
 	secretRefs := make(map[string]*swarmtypes.SecretReference)
 	ctx := context.Background()
 


### PR DESCRIPTION
When using both `--secret-rm` and `--secret-add` on `docker service update`, `--secret-rm` was always performed last. This made it impossible to update a secret that was already in use on a service (for example, to change it's permissions, or mount-location inside the container).

This patch changes the order in which `rm` and `add` are performed, allowing updating a secret in a single `docker service update`.

Before this change, the `rm` was always performed "last", so the secret was always removed:

    $ echo "foo" | docker secret create foo -f -
    foo

    $ docker service create --name myservice --secret foo nginx:alpine
    62xjcr9sr0c2hvepdzqrn3ssn

    $ docker service update --secret-rm foo --secret-add source=foo,target=foo2 myservice
    myservice

    $ docker service inspect --format '{{ json .Spec.TaskTemplate.ContainerSpec.Secrets }}' myservice | jq .
    null

After this change, the `rm` is performed _first_, allowing users to update a secret without updating the service _twice_;

    $ echo "foo" | docker secret create foo -f -
    1bllmvw3a1yaq3eixqw3f7bjl

    $ docker service create --name myservice --secret foo nginx:alpine
    lr6s3uoggli1x0hab78glpcxo

    $ docker service update --secret-rm foo --secret-add source=foo,target=foo2 myservice
    myservice

    $ docker service inspect --format '{{ json .Spec.TaskTemplate.ContainerSpec.Secrets }}' myservice | jq .

    [
      {
        "File": {
          "Name": "foo2",
          "UID": "0",
          "GID": "0",
          "Mode": 292
        },
        "SecretID": "tn9qiblgnuuut11eufquw5dev",
        "SecretName": "foo"
      }
    ]

![listen-very-carefully-i-shall-say-this-only-once](https://cloud.githubusercontent.com/assets/1804568/21577597/0d5c579e-cf61-11e6-948b-32d0c926d370.png)
