### PR TITLE
document DOCKER_HIDE_LEGACY_COMMANDS env-var

### DIFF
--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -69,6 +69,9 @@ by the `docker` command line:
   Equates to `--disable-content-trust=false` for build, create, pull, push, run.
 * `DOCKER_CONTENT_TRUST_SERVER` The URL of the Notary server to use. This defaults
   to the same URL as the registry.
+* `DOCKER_HIDE_LEGACY_COMMANDS` When set, Docker hides "legacy" top-level commands (such as `docker rm`, and 
+  `docker pull`) in `docker help` output, and only `Management commands` per object-type (e.g., `docker container`) are
+  printed. This may become the default in a future release, at which point this environment-variable is removed.
 * `DOCKER_TMPDIR` Location for temporary Docker files.
 
 Because Docker is developed using Go, you can also use any environment


### PR DESCRIPTION
The `DOCKER_HIDE_LEGACY_COMMANDS` environment variable was added in a7c8bcac2ba60d6dd25a1157085d9245bed556ce (https://github.com/docker/docker/pull/26025) but not documented.
