### PR TITLE
Fix bash completion for `plugin enable|disable`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3222,7 +3222,10 @@ _docker_plugin_disable() {
 			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
 			;;
 		*)
-			__docker_complete_plugins_installed
+			local counter=$(__docker_pos_first_nonflag)
+			if [ $cword -eq $counter ]; then
+				__docker_complete_plugins_installed
+			fi
 			;;
 	esac
 }
@@ -3239,7 +3242,10 @@ _docker_plugin_enable() {
 			COMPREPLY=( $( compgen -W "--help --timeout" -- "$cur" ) )
 			;;
 		*)
-			__docker_complete_plugins_installed
+			local counter=$(__docker_pos_first_nonflag '--timeout')
+			if [ $cword -eq $counter ]; then
+				__docker_complete_plugins_installed
+			fi
 			;;
 	esac
 }

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3219,7 +3219,7 @@ _docker_plugin_create() {
 _docker_plugin_disable() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--force -f --help" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag)


### PR DESCRIPTION
Fixes:
* `docker plugin enable` and  `docker plugin disable` only accept one plugin, but bash completion would complete more than one.
* add missing `--force|-f` option to `docker plugin disable`

Please schedule for 1.13.0.