### PR TITLE
Fix usage message of `plugin inspect`

### DIFF
--- a/cli/command/plugin/inspect.go
+++ b/cli/command/plugin/inspect.go
@@ -17,7 +17,7 @@ func newInspectCommand(dockerCli *command.DockerCli) *cobra.Command {
 	var opts inspectOptions
 
 	cmd := &cobra.Command{
-		Use:   "inspect [OPTIONS] PLUGIN|ID [PLUGIN|ID...]",
+		Use:   "inspect [OPTIONS] PLUGIN [PLUGIN...]",
 		Short: "Display detailed information on one or more plugins",
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -16,7 +16,7 @@ keywords: "plugin, inspect"
 # plugin inspect
 
 ```markdown
-Usage:	docker plugin inspect [OPTIONS] PLUGIN|ID [PLUGIN|ID...]
+Usage:	docker plugin inspect [OPTIONS] PLUGIN [PLUGIN...]
 
 Display detailed information on one or more plugins
 


### PR DESCRIPTION
`plugin inspect` is the only `plugin` subcommand that refers to plugins as `PLUGIN|ID` in its usage message:

```bash
$ for command in inspect create disable enable install push rm set ; do docker plugin $command --help | grep Usage ; done
Usage:  docker plugin inspect [OPTIONS] PLUGIN|ID [PLUGIN|ID...]
Usage:  docker plugin create [OPTIONS] PLUGIN PLUGIN-DATA-DIR
Usage:  docker plugin disable PLUGIN
Usage:  docker plugin enable [OPTIONS] PLUGIN
Usage:  docker plugin install [OPTIONS] PLUGIN [KEY=VALUE...]
Usage:  docker plugin push PLUGIN[:TAG]
Usage:  docker plugin rm [OPTIONS] PLUGIN [PLUGIN...]
Usage:  docker plugin set PLUGIN KEY=VALUE [KEY=VALUE...]
```
This changes the term to the elsewhere used `PLUGIN` in all occurrences.
```bash
$ grep -RIF 'PLUGIN|ID'
docs/reference/commandline/plugin_inspect.md:Usage:     docker plugin inspect [OPTIONS] PLUGIN|ID [PLUGIN|ID...]
cli/command/plugin/inspect.go:          Use:   "inspect [OPTIONS] PLUGIN|ID [PLUGIN|ID...]",
```