### PR TITLE
API: Delete container can return 409, but that isn't documented.

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4045,6 +4045,13 @@ paths:
           examples:
             application/json:
               message: "No such container: c2ada9df5af8"
+        409:
+          description: "conflict"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+          examples:
+            application/json:
+              message: "You cannot remove a running container: c2ada9df5af8. Stop the container before attempting removal or use -f"
         500:
           description: "server error"
           schema:


### PR DESCRIPTION
API: Delete container can return 409, but that isn't documented. #29796 

Signed-off-by: Daniel Zhang <jmzwcn@gmail.com>