### PR TITLE
Remove deadcode from `service/opts.go` : `SecretOpt`

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -1,10 +1,7 @@
 package service
 
 import (
-	"encoding/csv"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -140,98 +137,6 @@ func (f *floatValue) String() string {
 
 func (f *floatValue) Value() float32 {
 	return float32(*f)
-}
-
-// SecretRequestSpec is a type for requesting secrets
-type SecretRequestSpec struct {
-	source string
-	target string
-	uid    string
-	gid    string
-	mode   os.FileMode
-}
-
-// SecretOpt is a Value type for parsing secrets
-type SecretOpt struct {
-	values []*SecretRequestSpec
-}
-
-// Set a new secret value
-func (o *SecretOpt) Set(value string) error {
-	csvReader := csv.NewReader(strings.NewReader(value))
-	fields, err := csvReader.Read()
-	if err != nil {
-		return err
-	}
-
-	spec := &SecretRequestSpec{
-		source: "",
-		target: "",
-		uid:    "0",
-		gid:    "0",
-		mode:   0444,
-	}
-
-	for _, field := range fields {
-		parts := strings.SplitN(field, "=", 2)
-		key := strings.ToLower(parts[0])
-
-		if len(parts) != 2 {
-			return fmt.Errorf("invalid field '%s' must be a key=value pair", field)
-		}
-
-		value := parts[1]
-		switch key {
-		case "source", "src":
-			spec.source = value
-		case "target":
-			tDir, _ := filepath.Split(value)
-			if tDir != "" {
-				return fmt.Errorf("target must not have a path")
-			}
-			spec.target = value
-		case "uid":
-			spec.uid = value
-		case "gid":
-			spec.gid = value
-		case "mode":
-			m, err := strconv.ParseUint(value, 0, 32)
-			if err != nil {
-				return fmt.Errorf("invalid mode specified: %v", err)
-			}
-
-			spec.mode = os.FileMode(m)
-		default:
-			return fmt.Errorf("invalid field in secret request: %s", key)
-		}
-	}
-
-	if spec.source == "" {
-		return fmt.Errorf("source is required")
-	}
-
-	o.values = append(o.values, spec)
-	return nil
-}
-
-// Type returns the type of this option
-func (o *SecretOpt) Type() string {
-	return "secret"
-}
-
-// String returns a string repr of this option
-func (o *SecretOpt) String() string {
-	secrets := []string{}
-	for _, secret := range o.values {
-		repr := fmt.Sprintf("%s -> %s", secret.source, secret.target)
-		secrets = append(secrets, repr)
-	}
-	return strings.Join(secrets, ", ")
-}
-
-// Value returns the secret requests
-func (o *SecretOpt) Value() []*SecretRequestSpec {
-	return o.values
 }
 
 type updateOptions struct {


### PR DESCRIPTION
`SecretOpt` is in the `opts` package, this one is never used, so it's
dead code, removing it 👼.

/cc @thaJeztah @AkihiroSuda @dnephin @cpuguy83 @ehazlett @runcom 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>