### PR TITLE
fixed Repeated use of --mount-add adds the same mount multiple times,…

### DIFF
--- a/api/client/service/update.go
+++ b/api/client/service/update.go
@@ -153,7 +153,9 @@ func updateService(flags *pflag.FlagSet, spec *swarm.ServiceSpec) error {
 	updateEnvironment(flags, &cspec.Env)
 	updateString("workdir", &cspec.Dir)
 	updateString(flagUser, &cspec.User)
-	updateMounts(flags, &cspec.Mounts)
+	if err := updateMounts(flags, &cspec.Mounts); err != nil {
+		return err
+	}
 
 	if flags.Changed(flagLimitCPU) || flags.Changed(flagLimitMemory) {
 		taskResources().Limits = &swarm.Resources{}
@@ -246,12 +248,33 @@ func anyChanged(flags *pflag.FlagSet, fields ...string) bool {
 	return false
 }
 
+func rmDuplicateSwarmPlacement(list *[]string) []string {
+	var x []string = []string{}
+	for _, i := range *list {
+		if len(x) == 0 {
+			x = append(x, i)
+		} else {
+			for k, v := range x {
+				if i == v {
+					break
+				}
+				if k == len(x)-1 {
+					x = append(x, i)
+				}
+			}
+		}
+	}
+	return x
+}
+
 func updatePlacement(flags *pflag.FlagSet, placement *swarm.Placement) {
 	field, _ := flags.GetStringSlice(flagConstraintAdd)
+
 	placement.Constraints = append(placement.Constraints, field...)
 
 	toRemove := buildToRemoveSet(flags, flagConstraintRemove)
 	placement.Constraints = removeItems(placement.Constraints, toRemove, itemKey)
+	placement.Constraints = rmDuplicateSwarmPlacement(&placement.Constraints)
 }
 
 func updateContainerLabels(flags *pflag.FlagSet, field *map[string]string) {
@@ -353,20 +376,51 @@ func removeItems(
 	return newSeq
 }
 
-func updateMounts(flags *pflag.FlagSet, mounts *[]swarm.Mount) {
+type byMountSource []swarm.Mount
+
+func (m byMountSource) Len() int      { return len(m) }
+func (m byMountSource) Swap(i, j int) { m[i], m[j] = m[j], m[i] }
+func (m byMountSource) Less(i, j int) bool {
+	a, b := m[i], m[j]
+
+	if a.Source == b.Source {
+		return a.Target < b.Target
+	}
+
+	return a.Source < b.Source
+}
+
+func updateMounts(flags *pflag.FlagSet, mounts *[]swarm.Mount) error {
+
+	mountsByTarget := map[string]swarm.Mount{}
+
 	if flags.Changed(flagMountAdd) {
 		values := flags.Lookup(flagMountAdd).Value.(*MountOpt).Value()
-		*mounts = append(*mounts, values...)
+		for _, mount := range values {
+			if _, ok := mountsByTarget[mount.Target]; ok {
+				return fmt.Errorf("duplicate mount target")
+			}
+			mountsByTarget[mount.Target] = mount
+		}
 	}
+
+	for _, mount := range *mounts {
+		if _, ok := mountsByTarget[mount.Target]; !ok {
+			mountsByTarget[mount.Target] = mount
+		}
+	}
+
 	toRemove := buildToRemoveSet(flags, flagMountRemove)
 
 	newMounts := []swarm.Mount{}
-	for _, mount := range *mounts {
+	for _, mount := range mountsByTarget {
 		if _, exists := toRemove[mount.Target]; !exists {
 			newMounts = append(newMounts, mount)
 		}
 	}
+	sort.Sort(byMountSource(newMounts))
 	*mounts = newMounts
+	return nil
 }
 
 type byPortConfig []swarm.PortConfig


### PR DESCRIPTION
… causing the container to crash #29717

Signed-off-by: zhaoqingjie <zhaoqingjie@baidu.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Updating a service with mount-add allows the same mount to be added multiple times, which causes the container to crash. the issue:29823

**- How I did it**
for mount-add, I filter the same mount.target, for constraint-add, I filter by same string.
**- How to verify it**
repro the steps which user provided. 
**- Description for the changelog**
One service have identical mount and constraint.
**- A picture of a cute animal (not mandatory but encouraged)**

