### PR TITLE
[1.12.x]fixs duplicate mount can be added and cause the container to crash.

### DIFF
--- a/api/client/service/update.go
+++ b/api/client/service/update.go
@@ -153,7 +153,9 @@ func updateService(flags *pflag.FlagSet, spec *swarm.ServiceSpec) error {
 	updateEnvironment(flags, &cspec.Env)
 	updateString("workdir", &cspec.Dir)
 	updateString(flagUser, &cspec.User)
-	updateMounts(flags, &cspec.Mounts)
+	if err := updateMounts(flags, &cspec.Mounts); err != nil {
+		return err
+	}
 
 	if flags.Changed(flagLimitCPU) || flags.Changed(flagLimitMemory) {
 		taskResources().Limits = &swarm.Resources{}
@@ -246,12 +248,33 @@ func anyChanged(flags *pflag.FlagSet, fields ...string) bool {
 	return false
 }
 
+func rmDuplicateSwarmPlacement(list *[]string) []string {
+	var x []string = []string{}
+	for _, i := range *list {
+		if len(x) == 0 {
+			x = append(x, i)
+		} else {
+			for k, v := range x {
+				if i == v {
+					break
+				}
+				if k == len(x)-1 {
+					x = append(x, i)
+				}
+			}
+		}
+	}
+	return x
+}
+
 func updatePlacement(flags *pflag.FlagSet, placement *swarm.Placement) {
 	field, _ := flags.GetStringSlice(flagConstraintAdd)
+
 	placement.Constraints = append(placement.Constraints, field...)
 
 	toRemove := buildToRemoveSet(flags, flagConstraintRemove)
 	placement.Constraints = removeItems(placement.Constraints, toRemove, itemKey)
+	placement.Constraints = rmDuplicateSwarmPlacement(&placement.Constraints)
 }
 
 func updateContainerLabels(flags *pflag.FlagSet, field *map[string]string) {
@@ -353,20 +376,51 @@ func removeItems(
 	return newSeq
 }
 
-func updateMounts(flags *pflag.FlagSet, mounts *[]swarm.Mount) {
+type byMountSource []swarm.Mount
+
+func (m byMountSource) Len() int      { return len(m) }
+func (m byMountSource) Swap(i, j int) { m[i], m[j] = m[j], m[i] }
+func (m byMountSource) Less(i, j int) bool {
+	a, b := m[i], m[j]
+
+	if a.Source == b.Source {
+		return a.Target < b.Target
+	}
+
+	return a.Source < b.Source
+}
+
+func updateMounts(flags *pflag.FlagSet, mounts *[]swarm.Mount) error {
+
+	mountsByTarget := map[string]swarm.Mount{}
+
 	if flags.Changed(flagMountAdd) {
 		values := flags.Lookup(flagMountAdd).Value.(*MountOpt).Value()
-		*mounts = append(*mounts, values...)
+		for _, mount := range values {
+			if _, ok := mountsByTarget[mount.Target]; ok {
+				return fmt.Errorf("duplicate mount target")
+			}
+			mountsByTarget[mount.Target] = mount
+		}
 	}
+
+	for _, mount := range *mounts {
+		if _, ok := mountsByTarget[mount.Target]; !ok {
+			mountsByTarget[mount.Target] = mount
+		}
+	}
+
 	toRemove := buildToRemoveSet(flags, flagMountRemove)
 
 	newMounts := []swarm.Mount{}
-	for _, mount := range *mounts {
+	for _, mount := range mountsByTarget {
 		if _, exists := toRemove[mount.Target]; !exists {
 			newMounts = append(newMounts, mount)
 		}
 	}
+	sort.Sort(byMountSource(newMounts))
 	*mounts = newMounts
+	return nil
 }
 
 type byPortConfig []swarm.PortConfig

--- a/api/client/service/update.go
+++ b/api/client/service/update.go
@@ -249,22 +249,22 @@ func anyChanged(flags *pflag.FlagSet, fields ...string) bool {
 }
 
 func rmDuplicateSwarmPlacement(list *[]string) []string {
-	var x []string = []string{}
+	var newConstraints []string = []string{}
 	for _, i := range *list {
-		if len(x) == 0 {
-			x = append(x, i)
+		if len(newConstraints) == 0 {
+			newConstraints = append(newConstraints, i)
 		} else {
-			for k, v := range x {
+			for k, v := range newConstraints {
 				if i == v {
 					break
 				}
-				if k == len(x)-1 {
-					x = append(x, i)
+				if k == len(newConstraints)-1 {
+					newConstraints = append(newConstraints, i)
 				}
 			}
 		}
 	}
-	return x
+	return newConstraints
 }
 
 func updatePlacement(flags *pflag.FlagSet, placement *swarm.Placement) {

--- a/api/client/service/update.go
+++ b/api/client/service/update.go
@@ -249,7 +249,7 @@ func anyChanged(flags *pflag.FlagSet, fields ...string) bool {
 }
 
 func rmDuplicateSwarmPlacement(list *[]string) []string {
-	var newConstraints []string = []string{}
+	newConstraints := []string{}
 	for _, i := range *list {
 		if len(newConstraints) == 0 {
 			newConstraints = append(newConstraints, i)

--- a/api/client/service/update_test.go
+++ b/api/client/service/update_test.go
@@ -60,6 +60,20 @@ func TestUpdatePlacement(t *testing.T) {
 	assert.Equal(t, placement.Constraints[1], "node=toadd")
 }
 
+func TestUpdatePlacementDuplicateValue(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("constraint-add", "node=toadd")
+	flags.Set("constraint-rm", "node!=toremove")
+
+	placement := &swarm.Placement{
+		Constraints: []string{"node!=toremove", "node=toadd"},
+	}
+
+	updatePlacement(flags, placement)
+	assert.Equal(t, len(placement.Constraints), 1)
+	assert.Equal(t, placement.Constraints[0], "node=toadd")
+}
+
 func TestUpdateEnvironment(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("env-add", "toadd=newenv")
@@ -111,8 +125,23 @@ func TestUpdateMounts(t *testing.T) {
 
 	updateMounts(flags, &mounts)
 	assert.Equal(t, len(mounts), 2)
-	assert.Equal(t, mounts[0].Target, "/tokeep")
-	assert.Equal(t, mounts[1].Target, "/toadd")
+	assert.Equal(t, mounts[0].Target, "/toadd")
+	assert.Equal(t, mounts[1].Target, "/tokeep")
+}
+
+func TestUpdateMountsDuplicateTarget(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("mount-add", "type=volume,target=/toadd")
+	flags.Set("mount-rm", "/toremove")
+
+	mounts := []swarm.Mount{
+		{Target: "/toremove", Type: swarm.MountTypeBind},
+		{Target: "/toadd", Type: swarm.MountTypeBind},
+	}
+
+	updateMounts(flags, &mounts)
+	assert.Equal(t, len(mounts), 1)
+	assert.Equal(t, mounts[0].Target, "/toadd")
 }
 
 func TestUpdatePorts(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- What I did
Updating a service with mount-add allows the same mount to be added multiple times, which causes the container to crash. fixes [#29717](https://github.com/docker/docker/issues/29717)

- How I did it
for mount-add, I filter the same mount.target, for constraint-add, I filter by same string.
- How to verify it
1. repro the steps which user provided.
2. add two test cases in api/client/service/update_test.go, and test result is passed:
      1)TestUpdatePlacementDuplicateValue
      2)TestUpdateMountsDuplicateTarget 
- Description for the changelog
One service have identical mount and constraint. fixes [#29717](https://github.com/docker/docker/issues/29717)
- A picture of a cute animal (not mandatory but encouraged)

