### PR TITLE
[1.13.x] Change the way IPAM configuration is handled on stack deploy

### DIFF
--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -186,9 +186,13 @@ func BasicNetworkCreateToGRPC(create basictypes.NetworkCreateRequest) swarmapi.N
 		Attachable:  create.Attachable,
 	}
 	if create.IPAM != nil {
+		driver := create.IPAM.Driver
+		if driver == "" {
+			driver = "default"
+		}
 		ns.IPAM = &swarmapi.IPAMOptions{
 			Driver: &swarmapi.Driver{
-				Name:    create.IPAM.Driver,
+				Name:    driver,
 				Options: create.IPAM.Options,
 			},
 		}


### PR DESCRIPTION
We use the 'default' driver if none is specified.

Fixes #29809 
Fixes #28528 

This is opened against the 1.13.x branch directly. I'll make a PR for master if this one gets merged 👼.

/cc @dnephin @icecrime @thaJeztah @mavenugo @vieux 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>