### PR TITLE
Updates some integration tests to fix userns builds

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -7386,12 +7386,12 @@ LABEL a=b
 	c.Assert(strings.TrimSpace(out), checker.Equals, `["sh"]`)
 }
 
-// Test case for 28902/28090
+// Test case for 28902/28909
 func (s *DockerSuite) TestBuildWorkdirCmd(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 
 	dockerFile := `
-                FROM golang:1.7-alpine
+                FROM busybox
                 WORKDIR /
                 `
 	_, err := buildImage("testbuildworkdircmd", dockerFile, false)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4635,7 +4635,7 @@ func (s *delayedReader) Read([]byte) (int, error) {
 
 // #28823 (originally #28639)
 func (s *DockerSuite) TestRunMountReadOnlyDevShm(c *check.C) {
-	testRequires(c, SameHostDaemon, DaemonIsLinux)
+	testRequires(c, SameHostDaemon, DaemonIsLinux, NotUserNamespace)
 	emptyDir, err := ioutil.TempDir("", "test-read-only-dev-shm")
 	c.Assert(err, check.IsNil)
 	defer os.RemoveAll(emptyDir)
@@ -4648,7 +4648,7 @@ func (s *DockerSuite) TestRunMountReadOnlyDevShm(c *check.C) {
 
 // Test case for 29129
 func (s *DockerSuite) TestRunHostnameInHostMode(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, NotUserNamespace)
 
 	expectedOutput := "foobar\nfoobar"
 	out, _ := dockerCmd(c, "run", "--net=host", "--hostname=foobar", "busybox", "sh", "-c", `echo $HOSTNAME && hostname`)


### PR DESCRIPTION
- `TestRunMountReadOnlyDevShm` and `TestRunHostnameInHostMode` needs `NotUserNamespace` requirement as these are known limitation of userns.
- `TestBuildWorkdirCmd` should use a preload image (`busybox`) instead of one that require network access.

/cc @thaJeztah @justincormack @estesp @mlaventure @AkihiroSuda 

🐸

---

From https://jenkins.dockerproject.org/job/Docker%20Master%20(userns)/4836/console 

```bash
# […]
23:31:50 ----------------------------------------------------------------------
23:31:50 FAIL: docker_cli_build_test.go:7390: DockerSuite.TestBuildWorkdirCmd
23:31:50 
23:31:50 docker_cli_build_test.go:7398:
23:31:50     c.Assert(err, checker.IsNil)
23:31:50 ... value *errors.errorString = &errors.errorString{s:"failed to build the image: Sending build context to Docker daemon 2.048 kB\r\r\nStep 1/2 : FROM golang:1.7-alpine\nGet https://registry-1.docker.io/v2/: dial tcp: lookup registry-1.docker.io on 172.31.0.2:53: dial udp 172.31.0.2:53: connect: network is unreachable\n"} ("failed to build the image: Sending build context to Docker daemon 2.048 kB\r\r\nStep 1/2 : FROM golang:1.7-alpine\nGet https://registry-1.docker.io/v2/: dial tcp: lookup registry-1.docker.io on 172.31.0.2:53: dial udp 172.31.0.2:53: connect: network is unreachable\n")
23:31:50 
23:31:53 
23:31:53 ----------------------------------------------------------------------
# […]
23:41:30 ----------------------------------------------------------------------
23:41:30 FAIL: docker_cli_run_test.go:4650: DockerSuite.TestRunHostnameInHostMode
23:41:30 
23:41:30 docker_cli_run_test.go:4654:
23:41:30     out, _ := dockerCmd(c, "run", "--net=host", "--hostname=foobar", "busybox", "sh", "-c", `echo $HOSTNAME && hostname`)
23:41:30 docker_utils_test.go:331:
23:41:30     c.Assert(result, icmd.Matches, icmd.Success)
23:41:30 ... result *cmd.Result = &cmd.Result{Cmd:(*exec.Cmd)(0xc4200766e0), ExitCode:125, Error:(*exec.ExitError)(0xc420c96760), Timeout:false, outBuffer:(*cmd.lockedBuffer)(0xc42029f9e0), errBuffer:(*cmd.lockedBuffer)(0xc42029fa70)} ("\nCommand: /go/src/github.com/docker/docker/bundles/1.14.0-dev/binary-client/docker run --net=host --hostname=foobar busybox sh -c echo $HOSTNAME && hostname\nExitCode: 125, Error: exit status 125\nStdout: \nStderr: /go/src/github.com/docker/docker/bundles/1.14.0-dev/binary-client/docker: Error response from daemon: Cannot share the host's network namespace when user namespaces are enabled.\nSee '/go/src/github.com/docker/docker/bundles/1.14.0-dev/binary-client/docker run --help'.\n\n")
23:41:30 ... expected cmd.Expected = cmd.Expected{ExitCode:0, Timeout:false, Error:"", Out:"", Err:""}
23:41:30 ... 
23:41:30 Command: /go/src/github.com/docker/docker/bundles/1.14.0-dev/binary-client/docker run --net=host --hostname=foobar busybox sh -c echo $HOSTNAME && hostname
23:41:30 ExitCode: 125, Error: exit status 125
23:41:30 Stdout: 
23:41:30 Stderr: /go/src/github.com/docker/docker/bundles/1.14.0-dev/binary-client/docker: Error response from daemon: Cannot share the host's network namespace when user namespaces are enabled.
23:41:30 See '/go/src/github.com/docker/docker/bundles/1.14.0-dev/binary-client/docker run --help'.
23:41:30 
23:41:30 
23:41:30 Failures:
23:41:30 ExitCode was 125 expected 0
23:41:30 Expected no error
23:41:30 
23:41:30 
23:41:30 
23:41:30 ----------------------------------------------------------------------
# […]
23:41:52 ----------------------------------------------------------------------
23:41:52 FAIL: docker_cli_run_test.go:4637: DockerSuite.TestRunMountReadOnlyDevShm
23:41:52 
23:41:52 docker_cli_run_test.go:4646:
23:41:52     c.Assert(out, checker.Contains, "Read-only file system")
23:41:52 ... obtained string = "" +
23:41:52 ...     "container_linux.go:247: starting container process caused \"process_linux.go:359: container init caused \\\"rootfs_linux.go:102: remounting \\\\\\\"/dev\\\\\\\" as readonly caused \\\\\\\"operation not permitted\\\\\\\"\\\"\"\n" +
23:41:52 ...     "/go/src/github.com/docker/docker/bundles/1.14.0-dev/binary-client/docker: Error response from daemon: oci runtime error: container_linux.go:247: starting container process caused \"process_linux.go:359: container init caused \\\"rootfs_linux.go:102: remounting \\\\\\\"/dev\\\\\\\" as readonly caused \\\\\\\"operation not permitted\\\\\\\"\\\"\".\n" +
23:41:52 ...     "time=\"2016-12-29T23:41:52Z\" level=error msg=\"error getting events from daemon: context canceled\" \n"
23:41:52 ... substring string = "Read-only file system"
23:41:52 
23:41:52 
23:41:52 ----------------------------------------------------------------------
```

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
