### PR TITLE
Do not fail in `TearDown` if container not found when removing

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1291,7 +1291,7 @@ func (s *DockerSuite) TestPutContainerArchiveErrSymlinkInVolumeToReadOnlyRootfs(
 		readOnly: true,
 		volumes:  defaultVolumes(testVol), // Our bind mount is at /vol2
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(false, cID)
 
 	// Attempt to extract to a symlink in the volume which points to a
 	// directory outside the volume. This should cause an error because the

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -39,7 +39,7 @@ func setupImageWithTag(c *check.C, tag string) (digest.Digest, error) {
 	c.Assert(err, checker.IsNil, check.Commentf("image tagging failed: %s", out))
 
 	// delete the container as we don't need it any more
-	err = deleteContainer(containerName)
+	err = deleteContainer(false, containerName)
 	c.Assert(err, checker.IsNil)
 
 	// push the image

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2117,7 +2117,7 @@ func (s *DockerSuite) TestRunDeallocatePortOnMissingIptablesRule(c *check.C) {
 	if err != nil {
 		c.Fatal(err, out)
 	}
-	if err := deleteContainer(id); err != nil {
+	if err := deleteContainer(false, id); err != nil {
 		c.Fatal(err)
 	}
 


### PR DESCRIPTION
If the container is not found when removing, it means it's already not there anymore, so it's safe to ignore. This should reduce a bit some `TearDown` flakyness..

```
17:15:30 ----------------------------------------------------------------------
17:15:30 FAIL: check_test.go:157: DockerSuite.TearDownTest
17:15:30 
17:15:30 check_test.go:159:
17:15:30     deleteAllContainers(c)
17:15:30 docker_utils_test.go:142:
17:15:30     c.Assert(err, checker.IsNil)
17:15:30 ... value *errors.errorString = &errors.errorString{s:"\nCommand: /go/src/github.com/docker/docker/bundles/1.14.0-dev/binary-client/docker rm -fv e09bc5ab6556\nExitCode: 1, Error: exit status 1\nStdout: \nStderr: Error response from daemon: No such container: e09bc5ab6556\n\n\nFailures:\nExitCode was 1 expected 0\nExpected no error\n"} ("\nCommand: /go/src/github.com/docker/docker/bundles/1.14.0-dev/binary-client/docker rm -fv e09bc5ab6556\nExitCode: 1, Error: exit status 1\nStdout: \nStderr: Error response from daemon: No such container: e09bc5ab6556\n\n\nFailures:\nExitCode was 1 expected 0\nExpected no error\n")
17:15:30 
17:15:30 
17:15:30 ----------------------------------------------------------------------
17:15:30 PANIC: docker_cli_build_unix_test.go:130: DockerSuite.TestBuildCancellationKillsSleep
17:15:30 
17:15:30 ... Panic: Fixture has panicked (see related PANIC)
17:15:30 
17:15:30 ----------------------------------------------------------------------
```

Depending on the "configuration" of the daemon and container running, the container might have killed himself between listing it `docker ps -aq` and removing it `docker rm`.

On a side note (and for a future PR 👼), these teardown helper method should really use the `API` directly (through the Go client) instead.

/cc @thaJeztah @AkihiroSuda @tonistiigi @cpuguy83 @dnephin 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
