### PR TITLE
Docs: Be more clear when specifying valid formats for strings

### DIFF
--- a/docs/reference/commandline/tag.md
+++ b/docs/reference/commandline/tag.md
@@ -29,13 +29,13 @@ by a registry hostname. The hostname must comply with standard DNS rules, but
 may not contain underscores. If a hostname is present, it may optionally be
 followed by a port number in the format `:8080`. If not present, the command
 uses Docker's public registry located at `registry-1.docker.io` by default. Name
-components may contain lowercase characters, digits and separators. A separator
+components may contain lowercase letters, digits and separators. A separator
 is defined as a period, one or two underscores, or one or more dashes. A name
 component may not start or end with a separator.
 
-A tag name may contain lowercase and uppercase characters, digits, underscores,
-periods and dashes. A tag name may not start with a period or a dash and may
-contain a maximum of 128 characters.
+A tag name must be valid ASCII and may contain lowercase and uppercase letters,
+digits, underscores, periods and dashes. A tag name may not start with a
+period or a dash and may contain a maximum of 128 characters.
 
 You can group your images together using names and tags, and then upload them
 to [*Share Images via Repositories*](https://docs.docker.com/engine/tutorials/dockerrepos/#/contributing-to-docker-hub).

--- a/image/spec/v1.md
+++ b/image/spec/v1.md
@@ -92,7 +92,7 @@ This specification uses the following terms:
         often referred to as a tag as well, though it strictly refers to the
         full name of an image. Acceptable values for a tag suffix are
         implementation specific, but they SHOULD be limited to the set of
-        alphanumeric characters <code>[a-zA-z0-9]</code>, punctuation
+        alphanumeric characters <code>[a-zA-Z0-9]</code>, punctuation
         characters <code>[._-]</code>, and MUST NOT contain a <code>:</code>
         character.
     </dd>
@@ -105,7 +105,7 @@ This specification uses the following terms:
         <code>my-app:3.1.4</code>, <code>my-app</code> is the <i>Repository</i>
         component of the name. Acceptable values for repository name are
         implementation specific, but they SHOULD be limited to the set of
-        alphanumeric characters <code>[a-zA-z0-9]</code>, and punctuation
+        alphanumeric characters <code>[a-zA-Z0-9]</code>, and punctuation
         characters <code>[._-]</code>, however it MAY contain additional
         <code>/</code> and <code>:</code> characters for organizational
         purposes, with the last <code>:</code> character being interpreted

--- a/man/src/image/tag.md
+++ b/man/src/image/tag.md
@@ -9,15 +9,16 @@ entire image name including the optional `TAG` after the ':'.
    present, it may optionally be followed by a port number in the format 
    `:8080`. If not present, the command uses Docker's public registry located at
    `registry-1.docker.io` by default. Name components may contain lowercase 
-   characters, digits and separators. A separator is defined as a period, one or 
+   letters, digits and separators. A separator is defined as a period, one or
    two underscores, or one or more dashes. A name component may not start or end 
    with a separator.
 
 **TAG**
    The tag assigned to the image to version and distinguish images with the same
-   name. The tag name may contain lowercase and uppercase characters, digits, 
-   underscores, periods and dashes. A tag name may not start with a period or a 
-   dash and may contain a maximum of 128 characters.
+   name. The tag name must be valid ASCII and may contain lowercase and
+   uppercase letters, digits, underscores, periods and hyphens. A tag name
+   may not start with a period or a hyphen and may contain a maximum of 128
+   characters.
 
 # EXAMPLES
 


### PR DESCRIPTION
- Use the word letter rather than character to refer to letters ;) when trying to specify that only letters and numbers can be used, and not ANY character...
- Small corrections
- Use the word "minus sign" which is unambiguous, rather than the word "dash" which is.

Fixes #29821

Signed-off-by: Timothy Hobbs <timothy@hobbs.cz>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

