### PR TITLE
check both source_image_tag and target_image_tag for 'docker image tag'

### DIFF
--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -30,8 +30,19 @@ func TestImageTagInvalidReference(t *testing.T) {
 	}
 
 	err := client.ImageTag(context.Background(), "image_id", "aa/asdf$$^/aa")
-	if err == nil || err.Error() != `Error parsing reference: "aa/asdf$$^/aa" is not a valid repository/tag` {
+	if err == nil || err.Error() != `Error parsing reference: "aa/asdf$$^/aa" is not a valid repository/tag: invalid reference format` {
 		t.Fatalf("expected ErrReferenceInvalidFormat, got %v", err)
+	}
+}
+
+func TestImageTagInvalidSourceImageName(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	}
+
+	err := client.ImageTag(context.Background(), "invalid_source_image_name_", "repo:tag")
+	if err == nil || err.Error() != "Error parsing reference: \"invalid_source_image_name_\" is not a valid repository/tag: invalid reference format" {
+		t.Fatalf("expected Parsing Reference Error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: wefine <wang.xiaoren@zte.com.cn>

**- What I did**
Add a SOURCE_IMAGE_TAG check for `docker image tag`.

Why?

For the Usage:	

> root@ubuntu:~# docker image tag --help
> 
> Usage:	docker image tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]
> 
> Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
> 
> Options:
>       --help   Print usage


If there is a reason for checking **TARGET_IMAGE[:TAG]** ,
it's also suit for **SOURCE_IMAGE[:TAG]**, not only one of them, all both.

If SOURCE_IMAGE[:TAG] is invalid, and no checking in client, a post request will be sent to daemon,
system resource was wasted.

**- How I did it**
According to TARGET_IMAGE[:TAG] check, add SOURCE_IMAGE[:TAG] check, and add unit test func.

**- How to verify it**
unit test


**- A picture of a cute animal (not mandatory but encouraged)**
before, the source_image_tag will be checked by daemon:

> image tag 7ff8895d6132-source- 7ff8895d6132-target-
> Error parsing reference: "7ff8895d6132-target-" is not a valid repository/tag
> 
> image tag 7ff8895d6132-source- 7ff8895d6132-target-1
> Error response from daemon: Error parsing reference: "7ff8895d6132-source-" is not a valid repository/tag: invalid reference format

after, the source_image_tag will be checked by client first: 

> Error parsing reference: "7ff8895d6132-source-" is not a valid repository/tag