### PR TITLE
[test-integration] Should check for output, not error in deleteContainer

### DIFF
--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -124,7 +124,7 @@ func deleteContainer(ignoreNoSuchContainer bool, container ...string) error {
 	if ignoreNoSuchContainer && result.Error != nil {
 		// If the error is "No such container: ..." this means the container doesn't exists anymore,
 		// we can safely ignore that one.
-		if strings.Contains(result.Error.Error(), "No such container") {
+		if strings.Contains(result.Stderr(), "No such container") {
 			return nil
 		}
 	}


### PR DESCRIPTION
Follow-up to #29828 that did not check the right thing (error only contains `exit code 1` 😿 — so the check was really not doing any good) 😅 😓 🙇 

![facepalm-cat](https://cloud.githubusercontent.com/assets/6508/21609646/e90e943c-d1c3-11e6-8e70-de62b0954542.gif)

/cc @thaJeztah @AkihiroSuda @justincormack @dnephin @icecrime @cpuguy83 

🐸 🐪

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
