### PR TITLE
concurrent read and write operations on a map should use lock

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -249,9 +249,11 @@ func Handle(iface string, fn func(string, *Client)) {
 
 	hdlrs = append(hdlrs, fn)
 	handlers.extpointHandlers[iface] = hdlrs
+	storage.Lock()
 	for _, p := range storage.plugins {
 		p.activated = false
 	}
+	storage.Unlock()
 	handlers.Unlock()
 }
 
@@ -270,10 +272,13 @@ func GetAll(imp string) ([]*Plugin, error) {
 	chPl := make(chan *plLoad, len(pluginNames))
 	var wg sync.WaitGroup
 	for _, name := range pluginNames {
+		storage.Lock()
 		if pl, ok := storage.plugins[name]; ok {
+			storage.Unlock()
 			chPl <- &plLoad{pl, nil}
 			continue
 		}
+		storage.Unlock()
 
 		wg.Add(1)
 		go func(name string) {


### PR DESCRIPTION
Signed-off-by: frank yang <yyb196@gmail.com>

i bumped into a docker panic with version 1.12.3, and i checked upstream code found that it hasn't been fixed, so i commit a pull request to fix it.

raw panic output:
```
fatal error: concurrent map read and map write

goroutine 4307 [running]:
runtime.throw(0x17dae67, 0x21)
    /usr/local/go/src/runtime/panic.go:566 +0x95 fp=0xc421730a50 sp=0xc421730a30
runtime.mapaccess2_faststr(0x15ad500, 0xc420345dd0, 0xc420fc57bb, 0x49, 0xc420fc566b, 0x49)
    /usr/local/go/src/runtime/hashmap_fast.go:306 +0x52b fp=0xc421730ab0 sp=0xc421730a50
github.com/docker/docker/pkg/plugins.GetAll(0x17b4fba, 0xc, 0xc42018e9a0, 0x0, 0x0, 0x0, 0x0)
    /go/src/github.com/docker/docker/pkg/plugins/plugins.go:247 +0x10f fp=0xc421730ba0 sp=0xc421730ab0
github.com/docker/docker/plugin.FindWithCapability(0x17b4fba, 0xc, 0x6d6289af05a799e, 0xecff83c3d, 0xb, 0x2, 0x0)
    /go/src/github.com/docker/docker/plugin/legacy.go:9 +0x3f fp=0xc421730c20 sp=0xc421730ba0
github.com/docker/docker/volume/drivers.GetAllDrivers(0x0, 0x0, 0x0, 0x0, 0x0)
    /go/src/github.com/docker/docker/volume/drivers/extpoint.go:154 +0x87 fp=0xc421730d90 sp=0xc421730c20
github.com/docker/docker/volume/store.(*VolumeStore).getVolume(0xc4200eb320, 0xc420f69400, 0x40, 0x0, 0x0, 0xc420fd7d00, 0x0)
    /go/src/github.com/docker/docker/volume/store/store.go:400 +0x28f fp=0xc421730f08 sp=0xc421730d90
github.com/docker/docker/volume/store.(*VolumeStore).create(0xc4200eb320, 0xc420f69400, 0x40, 0x0, 0x0, 0xc421a13ef0, 0x0, 0x1673860, 0xc421a13f80, 0xc4218f81d8, ...)
    /go/src/github.com/docker/docker/volume/store/store.go:268 +0x83c fp=0xc421731060 sp=0xc421730f08
github.com/docker/docker/volume/store.(*VolumeStore).CreateWithRef(0xc4200eb320, 0xc420f69400, 0x40, 0x0, 0x0, 0xc420f68c00, 0x40, 0xc421a13ef0, 0x0, 0x0, ...)
    /go/src/github.com/docker/docker/volume/store/store.go:222 +0x136 fp=0xc4217310f0 sp=0xc421731060
github.com/docker/docker/daemon.(*Daemon).createContainerPlatformSpecificSettings(0xc420242000, 0xc420d2d2c0, 0xc420f9d540, 0xc4218a4000, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/create_unix.go:69 +0x567 fp=0xc4217312f8 sp=0xc4217310f0
github.com/docker/docker/daemon.(*Daemon).create(0xc420242000, 0xc421a455e3, 0x2c, 0xc420f9d540, 0xc4218a4000, 0xc420430438, 0x0, 0x0, 0x0, 0x0, ...)
    /go/src/github.com/docker/docker/daemon/create.go:253 +0x54f fp=0xc4217313a0 sp=0xc4217312f8
github.com/docker/docker/daemon.(*Daemon).containerCreate(0xc420242000, 0xc421a455e3, 0x2c, 0xc420f9d540, 0xc4218a4000, 0xc420430438, 0x0, 0x0, 0x0, 0x0, ...)
    /go/src/github.com/docker/docker/daemon/create.go:67 +0x1a8 fp=0xc4217314c0 sp=0xc4217313a0
github.com/docker/docker/daemon.(*Daemon).ContainerCreate(0xc420242000, 0xc421a455e3, 0x2c, 0xc420f9d540, 0xc4218a4000, 0xc420430438, 0x0, 0x0, 0x0, 0x0, ...)
    /go/src/github.com/docker/docker/daemon/create.go:41 +0xad fp=0xc421731570 sp=0xc4217314c0
github.com/docker/docker/api/server/router/container.(*containerRouter).postContainersCreate(0xc420e22fc0, 0x21d5320, 0xc4219f7e90, 0x21d1c60, 0xc420dfe340, 0xc42189c960, 0xc4219f7d40, 0xc421a4f301, 0xc4219f7e90)
    /go/src/github.com/docker/docker/api/server/router/container/container_routes.go:374 +0x5ec fp=0xc421731790 sp=0xc421731570
github.com/docker/docker/api/server/router/container.(*containerRouter).(github.com/docker/docker/api/server/router/container.postContainersCreate)-fm(0x21d5320, 0xc4219f7e90, 0x21d1c60, 0xc420dfe340, 0xc42189c960, 0xc4219f7d40, 0x15, 0x4)
    /go/src/github.com/docker/docker/api/server/router/container/container.go:55 +0x69 fp=0xc4217317e8 sp=0xc421731790
github.com/docker/docker/api/server/middleware.VersionMiddleware.WrapHandler.func1(0x21d5320, 0xc4219f7e60, 0x21d1c60, 0xc420dfe340, 0xc42189c960, 0xc4219f7d40, 0xc420d23320, 0x21aa2f0)
    /go/src/github.com/docker/docker/api/server/middleware/version.go:56 +0x73c fp=0xc421731970 sp=0xc4217317e8
```

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

