### PR TITLE
bump go-units to e30f1e79f3cd72542f2026ceec18d3bd67ab859c

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -16,7 +16,7 @@ github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 # forked golang.org/x/net package includes a patch for lazy loading trace templates
 golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://github.com/tonistiigi/net.git
 golang.org/x/sys 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
-github.com/docker/go-units 8a7beacffa3009a9ac66bad506b18ffdd110cf97
+github.com/docker/go-units e30f1e79f3cd72542f2026ceec18d3bd67ab859c
 github.com/docker/go-connections 4ccf312bf1d35e5dbda654e57a9be4c3f3cd0366
 
 github.com/RackSec/srslog 456df3a81436d29ba874f3590eeeee25d666f8a5

--- a/vendor/github.com/docker/go-units/duration.go
+++ b/vendor/github.com/docker/go-units/duration.go
@@ -18,9 +18,9 @@ func HumanDuration(d time.Duration) string {
 		return fmt.Sprintf("%d seconds", seconds)
 	} else if minutes := int(d.Minutes()); minutes == 1 {
 		return "About a minute"
-	} else if minutes < 60 {
+	} else if minutes < 46 {
 		return fmt.Sprintf("%d minutes", minutes)
-	} else if hours := int(d.Hours()); hours == 1 {
+	} else if hours := int(d.Hours() + 0.5); hours == 1 {
 		return "About an hour"
 	} else if hours < 48 {
 		return fmt.Sprintf("%d hours", hours)


### PR DESCRIPTION
just a minor change; https://github.com/docker/go-units/compare/8a7beacffa3009a9ac66bad506b18ffdd110cf97...e30f1e79f3cd72542f2026ceec18d3bd67ab859c
