### PR TITLE
Windows to Linux build warning to stdout

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -334,7 +334,7 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 	// Windows: show error message about modified file permissions if the
 	// daemon isn't running Windows.
 	if response.OSType != "windows" && runtime.GOOS == "windows" && !options.quiet {
-		fmt.Fprintln(dockerCli.Err(), `SECURITY WARNING: You are building a Docker image from Windows against a non-Windows Docker host. All files and directories added to build context will have '-rwxr-xr-x' permissions. It is recommended to double check and reset permissions for sensitive files and directories.`)
+		fmt.Fprintln(dockerCli.Out(), `SECURITY WARNING: You are building a Docker image from Windows against a non-Windows Docker host. All files and directories added to build context will have '-rwxr-xr-x' permissions. It is recommended to double check and reset permissions for sensitive files and directories.`)
 	}
 
 	// Everything worked so if -q was provided the output from the daemon

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4644,23 +4644,20 @@ func (s *DockerSuite) TestBuildStderr(c *check.C) {
 	// This test just makes sure that no non-error output goes
 	// to stderr
 	name := "testbuildstderr"
-	_, _, stderr, err := buildImageWithStdoutStderr(name,
+	_, stdout, stderr, err := buildImageWithStdoutStderr(name,
 		"FROM busybox\nRUN echo one", true)
 	if err != nil {
 		c.Fatal(err)
 	}
 
-	if runtime.GOOS == "windows" &&
-		daemonPlatform != "windows" {
-		// Windows to non-Windows should have a security warning
-		if !strings.Contains(stderr, "SECURITY WARNING:") {
-			c.Fatalf("Stderr contains unexpected output: %q", stderr)
-		}
-	} else {
-		// Other platform combinations should have no stderr written too
-		if stderr != "" {
-			c.Fatalf("Stderr should have been empty, instead it's: %q", stderr)
-		}
+	// Windows to non-Windows should have a security warning
+	if runtime.GOOS == "windows" && daemonPlatform != "windows" && !strings.Contains(stdout, "SECURITY WARNING:") {
+		c.Fatalf("Stdout contains unexpected output: %q", stdout)
+	}
+
+	// Stderr should always be empty
+	if stderr != "" {
+		c.Fatalf("Stderr should have been empty, instead it's: %q", stderr)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@thaJeztah Fixes https://github.com/docker/docker/issues/29209. Writes the warning when building from Windows to non-Windows go to stdout rather than stderr.
