### PR TITLE
Print security warning on stdout instead of stderr

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -334,7 +334,7 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 	// Windows: show error message about modified file permissions if the
 	// daemon isn't running Windows.
 	if response.OSType != "windows" && runtime.GOOS == "windows" && !options.quiet {
-		fmt.Fprintln(dockerCli.Err(), `SECURITY WARNING: You are building a Docker image from Windows against a non-Windows Docker host. All files and directories added to build context will have '-rwxr-xr-x' permissions. It is recommended to double check and reset permissions for sensitive files and directories.`)
+		fmt.Fprintln(dockerCli.Out(), `SECURITY WARNING: You are building a Docker image from Windows against a non-Windows Docker host. All files and directories added to build context will have '-rwxr-xr-x' permissions. It is recommended to double check and reset permissions for sensitive files and directories.`)
 	}
 
 	// Everything worked so if -q was provided the output from the daemon

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4640,12 +4640,11 @@ func (s *DockerSuite) TestBuildNotVerboseFailureRemote(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestBuildStderr(c *check.C) {
-	// This test just makes sure that no non-error output goes
-	// to stderr
-	name := "testbuildstderr"
-	_, _, stderr, err := buildImageWithStdoutStderr(name,
-		"FROM busybox\nRUN echo one", true)
+// TestBuildPrintWarning tests that the security warning is only printed when building an image from a Windows client
+// and a Linux / non-Windows daemon
+func (s *DockerSuite) TestBuildPrintWarning(c *check.C) {
+	name := "testbuildprintwarning"
+	_, out, err := buildImageWithOut(name,"FROM busybox\nRUN echo one", true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -4653,13 +4652,13 @@ func (s *DockerSuite) TestBuildStderr(c *check.C) {
 	if runtime.GOOS == "windows" &&
 		daemonPlatform != "windows" {
 		// Windows to non-Windows should have a security warning
-		if !strings.Contains(stderr, "SECURITY WARNING:") {
-			c.Fatalf("Stderr contains unexpected output: %q", stderr)
+		if !strings.Contains(out, "SECURITY WARNING:") {
+			c.Fatalf("Security warning not found in output: %q", out)
 		}
 	} else {
 		// Other platform combinations should have no stderr written too
-		if stderr != "" {
-			c.Fatalf("Stderr should have been empty, instead it's: %q", stderr)
+		if strings.Contains(out, "SECURITY WARNING:") {
+			c.Fatalf("Security warning should not be printed in output: %q", out)
 		}
 	}
 }


### PR DESCRIPTION
When building a Dockerfile from a Windows client
on a Linux daemon, a "security warning" is printed
on stderr.

Having this warning printed on stderr makes it
difficult to distinguish a failed build from
one that's succeeding, and the only way to
suppress the warning is through the `-q` option,
which also suppresses every output.

This change prints the warning on stdout,
instead of stderr, to resolve this situation.

Fixes https://github.com/docker/docker/issues/29209


ping @jhowardmsft ptal