### PR TITLE
Tidy kernel version in tests

### DIFF
--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration-cli/checker"
-	"github.com/docker/docker/integration-cli/environment"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
@@ -212,10 +211,6 @@ func (s *DockerSuite) TestInspectBindMountPoint(c *check.C) {
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 	if daemonPlatform == "windows" {
 		modifier = ""
-		// TODO Windows: Temporary check - remove once TP5 support is dropped
-		if environment.WindowsKernelVersion(testEnv.DaemonKernelVersion()) < 14350 {
-			c.Skip("Needs later Windows build for RO volumes")
-		}
 		// Linux creates the host directory if it doesn't exist. Windows does not.
 		os.Mkdir(`c:\data`, os.ModeDir)
 	}

--- a/integration-cli/environment/environment.go
+++ b/integration-cli/environment/environment.go
@@ -169,16 +169,20 @@ func (e *Execution) MinimalBaseImage() string {
 	return e.baseImage
 }
 
-// DaemonKernelVersion is the kernel version of the daemon
+// DaemonKernelVersion is the kernel version of the daemon as a string, as returned
+// by an INFO call to the daemon.
 func (e *Execution) DaemonKernelVersion() string {
 	return e.daemonKernelVersion
 }
 
-// WindowsKernelVersion is used on Windows to distinguish between different
-// versions. This is necessary to enable certain tests based on whether
-// the platform supports it. For example, Windows Server 2016 TP3 did
-// not support volumes, but TP4 did.
-func WindowsKernelVersion(kernelVersion string) int {
-	winKV, _ := strconv.Atoi(strings.Split(kernelVersion, " ")[1])
-	return winKV
+// DaemonKernelVersionNumeric is the kernel version of the daemon as an integer.
+// Mostly useful on Windows where DaemonKernelVersion holds the full string such
+// as `10.0 14393 (14393.447.amd64fre.rs1_release_inmarket.161102-0100)`, but
+// integration tests really only need the `14393` piece to make decisions.
+func (e *Execution) DaemonKernelVersionNumeric() int {
+	if e.daemonPlatform != "windows" {
+		return -1
+	}
+	v, _ := strconv.Atoi(strings.Split(e.daemonKernelVersion, " ")[1])
+	return v
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@vdemeester A bit of tidying of the environment package following https://github.com/docker/docker/pull/29661. Windows tests can now use `testEnv.DaemonKernelVersionNumeric()` for comparisons between RS1/RS2. Also removed a redundant use in `TestInspectBindMountPoint` as TP5 isn't supported anymore.