### PR TITLE
journald logs: drain 1 more time at container exit

### DIFF
--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -245,20 +245,28 @@ func (s *journald) followJournal(logWatcher *logger.LogWatcher, config logger.Re
 	s.readers.mu.Lock()
 	s.readers.readers[logWatcher] = logWatcher
 	s.readers.mu.Unlock()
+
 	go func() {
-		// Keep copying journal data out until we're notified to stop
-		// or we hit an error.
-		status := C.wait_for_data_cancelable(j, pfd[0])
-		for status == 1 {
+		for {
+			// Keep copying journal data out until we're notified to stop
+			// or we hit an error.
+			status := C.wait_for_data_cancelable(j, pfd[0])
+			if status < 0 {
+				cerrstr := C.strerror(C.int(-status))
+				errstr := C.GoString(cerrstr)
+				fmtstr := "error %q while attempting to follow journal for container %q"
+				logrus.Errorf(fmtstr, errstr, s.vars["CONTAINER_ID_FULL"])
+				break
+			}
+
 			cursor = s.drainJournal(logWatcher, config, j, cursor)
-			status = C.wait_for_data_cancelable(j, pfd[0])
+
+			if status != 1 {
+				// We were notified to stop
+				break
+			}
 		}
-		if status < 0 {
-			cerrstr := C.strerror(C.int(-status))
-			errstr := C.GoString(cerrstr)
-			fmtstr := "error %q while attempting to follow journal for container %q"
-			logrus.Errorf(fmtstr, errstr, s.vars["CONTAINER_ID_FULL"])
-		}
+
 		// Clean up.
 		C.close(pfd[0])
 		s.readers.mu.Lock()
@@ -267,6 +275,7 @@ func (s *journald) followJournal(logWatcher *logger.LogWatcher, config logger.Re
 		C.sd_journal_close(j)
 		close(logWatcher.Msg)
 	}()
+
 	// Wait until we're told to stop.
 	select {
 	case <-logWatcher.WatchClose():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
In the journald log driver, try to retrieve container log entries that appear immediately prior to the container exiting.

**- How I did it**
Attempt to drain the journal 1 more time after being told to stop following the log. Due to a possible race condition, sometimes data is written to the journal at almost the same time the log watch is closed, and depending on the order of operations, sometimes you miss the last journal entry.

**- How to verify it**
1. Start docker using the journald log driver
1. `docker rm foo`
1. `docker create  --name foo centos:centos7 sh -c 'echo a; sleep 1; echo b; sleep 1; echo c' && docker start foo && docker logs -f foo`
1. You will frequently not see the last line (`c`)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
journald log driver: try to retrieve log entries emitted just prior to container termination when following a container's log

@runcom @nalind @jwhonce 