### PR TITLE
fix volume ls filter driver

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -623,7 +623,7 @@ func (daemon *Daemon) filterVolumes(vols []volume.Volume, filter filters.Args) (
 			}
 		}
 		if filter.Include("driver") {
-			if !filter.Match("driver", vol.DriverName()) {
+			if !filter.ExactMatch("driver", vol.DriverName()) {
 				continue
 			}
 		}

--- a/docs/reference/commandline/volume_ls.md
+++ b/docs/reference/commandline/volume_ls.md
@@ -76,9 +76,9 @@ local               rosemary
 
 ### driver
 
-The `driver` filter matches on all or part of a volume's driver name.
+The `driver` filter matches volumes based on their driver.
 
-The following filter matches all volumes with a driver name containing the `local` string.
+The following example matches volumes that are created with the `local` driver:
 
 ```bash
 $ docker volume ls -f driver=local

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -184,19 +184,6 @@ func (s *DockerSuite) TestVolumeCLILsFilterDangling(c *check.C) {
 	c.Assert(out, check.Not(checker.Contains), "testnotinuse1\n", check.Commentf("expected volume 'testnotinuse1' in output"))
 	c.Assert(out, checker.Contains, "testisinuse1\n", check.Commentf("execpeted volume 'testisinuse1' in output"))
 	c.Assert(out, checker.Contains, "testisinuse2\n", check.Commentf("expected volume 'testisinuse2' in output"))
-
-	out, _ = dockerCmd(c, "volume", "ls", "--filter", "driver=invalidDriver")
-	outArr := strings.Split(strings.TrimSpace(out), "\n")
-	c.Assert(len(outArr), check.Equals, 1, check.Commentf("%s\n", out))
-
-	out, _ = dockerCmd(c, "volume", "ls", "--filter", "driver=local")
-	outArr = strings.Split(strings.TrimSpace(out), "\n")
-	c.Assert(len(outArr), check.Equals, 4, check.Commentf("\n%s", out))
-
-	out, _ = dockerCmd(c, "volume", "ls", "--filter", "driver=loc")
-	outArr = strings.Split(strings.TrimSpace(out), "\n")
-	c.Assert(len(outArr), check.Equals, 4, check.Commentf("\n%s", out))
-
 }
 
 func (s *DockerSuite) TestVolumeCLILsErrorWithInvalidFilterName(c *check.C) {
@@ -373,6 +360,37 @@ func (s *DockerSuite) TestVolumeCLILsFilterLabels(c *check.C) {
 	c.Assert(len(outArr), check.Equals, 1, check.Commentf("\n%s", out))
 
 	out, _ = dockerCmd(c, "volume", "ls", "--filter", "label=foo=non-exist")
+	outArr = strings.Split(strings.TrimSpace(out), "\n")
+	c.Assert(len(outArr), check.Equals, 1, check.Commentf("\n%s", out))
+}
+
+func (s *DockerSuite) TestVolumeCLILsFilterDrivers(c *check.C) {
+	// using default volume driver local to create volumes
+	testVol1 := "testvol-1"
+	out, _, err := dockerCmdWithError("volume", "create", testVol1)
+	c.Assert(err, check.IsNil)
+
+	testVol2 := "testvol-2"
+	out, _, err = dockerCmdWithError("volume", "create", testVol2)
+	c.Assert(err, check.IsNil)
+
+	// filter with driver=local
+	out, _ = dockerCmd(c, "volume", "ls", "--filter", "driver=local")
+	c.Assert(out, checker.Contains, "testvol-1\n", check.Commentf("expected volume 'testvol-1' in output"))
+	c.Assert(out, checker.Contains, "testvol-2\n", check.Commentf("expected volume 'testvol-2' in output"))
+
+	// filter with driver=invaliddriver
+	out, _ = dockerCmd(c, "volume", "ls", "--filter", "driver=invaliddriver")
+	outArr := strings.Split(strings.TrimSpace(out), "\n")
+	c.Assert(len(outArr), check.Equals, 1, check.Commentf("\n%s", out))
+
+	// filter with driver=loca
+	out, _ = dockerCmd(c, "volume", "ls", "--filter", "driver=loca")
+	outArr = strings.Split(strings.TrimSpace(out), "\n")
+	c.Assert(len(outArr), check.Equals, 1, check.Commentf("\n%s", out))
+
+	// filter with driver=
+	out, _ = dockerCmd(c, "volume", "ls", "--filter", "driver=")
 	outArr = strings.Split(strings.TrimSpace(out), "\n")
 	c.Assert(len(outArr), check.Equals, 1, check.Commentf("\n%s", out))
 }


### PR DESCRIPTION
fixes #29872 

I think when we filter volume by driver, it would be better to use `ExactMatch` to get result.

in docker 1.13.0-rc4, we can get the output like this command `docker volume ls -f driver=a`:
```
root@ubuntu:~# docker volume ls -f driver=a
DRIVER              VOLUME NAME
local               0e613322f854ca38503f9c275608e273cebd29edebde0b3abb0a99565dd3aa27
```
I think the output above is not reasonable. We should use more strict filter matching.

**- What I did**
1. make volume filter using exactmatch in driver;
2. add a test case to verify this.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

