### PR TITLE
Use GetAllByCap to get list of network plugins in docker info

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -407,6 +407,13 @@ func (daemon *Daemon) GetNetworkDriverList() []string {
 	}
 
 	pluginList := daemon.netController.BuiltinDrivers()
+
+	managedPlugins := daemon.PluginStore.GetAllManagedPluginsByCap(driverapi.NetworkPluginEndpointType)
+
+	for _, plugin := range managedPlugins {
+		pluginList = append(pluginList, plugin.Name())
+	}
+
 	pluginMap := make(map[string]bool)
 	for _, plugin := range pluginList {
 		pluginMap[plugin] = true


### PR DESCRIPTION
returned in "docker info". Currently info endpoint isnt using the
GetAllByCap, but relies on existing networks to get the plugin names.
This causes a basic issue when it comes to global network plugins which
swarm-mode relies on, wherein swarmkit will not be able to schedule the
network on the worker nodes due to the filtering logic.

In order to break this chicken & egg issue, we must start to use the
GetAllManagedPluginsByCap. We are unable to use GetAllByCap due to
various issues with Plugin-V1's lazy loading approach causing issues
especially during daemon restarts (which uses SystemInfo)

Signed-off-by: Madhu Venugopal <madhu@docker.com>
