### PR TITLE
Correct comment in vol driver interface

### DIFF
--- a/volume/volume.go
+++ b/volume/volume.go
@@ -29,7 +29,7 @@ const (
 type Driver interface {
 	// Name returns the name of the volume driver.
 	Name() string
-	// Create makes a new volume with the given id.
+	// Create makes a new volume with the given name.
 	Create(name string, opts map[string]string) (Volume, error)
 	// Remove deletes the volume.
 	Remove(vol Volume) (err error)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

I was looking to see how hard it would be to add IDs for volumes to resolve https://github.com/docker/docker/pull/27317#issuecomment-270197003, and noticed the comment on the Create() interface of the driver is incorrect.
