### PR TITLE
Use vol plugin creator instead of inserting spec

### DIFF
--- a/integration-cli/docker_cli_external_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_unix_test.go
@@ -426,7 +426,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverRetryNotImmediatelyE
 
 	<-started
 	// wait for a retry to occur, then create spec to allow plugin to register
-	time.Sleep(2000 * time.Millisecond)
+	time.Sleep(2 * time.Second)
 	p := newVolumePlugin(c, driverName)
 	defer p.Close()
 

--- a/integration-cli/docker_cli_external_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_unix_test.go
@@ -412,24 +412,23 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverLookupNotBlocked(c *
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverRetryNotImmediatelyExists(c *check.C) {
 	s.d.StartWithBusybox(c)
-
-	specPath := "/etc/docker/plugins/test-external-volume-driver-retry.spec"
-	os.RemoveAll(specPath)
-	defer os.RemoveAll(specPath)
+	driverName := "test-external-volume-driver-retry"
 
 	errchan := make(chan error)
+	started := make(chan struct{})
 	go func() {
-		if out, err := s.d.Cmd("run", "--rm", "--name", "test-data-retry", "-v", "external-volume-test:/tmp/external-volume-test", "--volume-driver", "test-external-volume-driver-retry", "busybox:latest"); err != nil {
+		close(started)
+		if out, err := s.d.Cmd("run", "--rm", "--name", "test-data-retry", "-v", "external-volume-test:/tmp/external-volume-test", "--volume-driver", driverName, "busybox:latest"); err != nil {
 			errchan <- fmt.Errorf("%v:\n%s", err, out)
 		}
 		close(errchan)
 	}()
-	go func() {
-		// wait for a retry to occur, then create spec to allow plugin to register
-		time.Sleep(2000 * time.Millisecond)
-		// no need to check for an error here since it will get picked up by the timeout later
-		ioutil.WriteFile(specPath, []byte(s.Server.URL), 0644)
-	}()
+
+	<-started
+	// wait for a retry to occur, then create spec to allow plugin to register
+	time.Sleep(2000 * time.Millisecond)
+	p := newVolumePlugin(c, driverName)
+	defer p.Close()
 
 	select {
 	case err := <-errchan:
@@ -441,11 +440,11 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverRetryNotImmediatelyE
 	_, err := s.d.Cmd("volume", "rm", "external-volume-test")
 	c.Assert(err, checker.IsNil)
 
-	c.Assert(s.ec.activations, checker.Equals, 1)
-	c.Assert(s.ec.creations, checker.Equals, 1)
-	c.Assert(s.ec.removals, checker.Equals, 1)
-	c.Assert(s.ec.mounts, checker.Equals, 1)
-	c.Assert(s.ec.unmounts, checker.Equals, 1)
+	c.Assert(p.ec.activations, checker.Equals, 1)
+	c.Assert(p.ec.creations, checker.Equals, 1)
+	c.Assert(p.ec.removals, checker.Equals, 1)
+	c.Assert(p.ec.mounts, checker.Equals, 1)
+	c.Assert(p.ec.unmounts, checker.Equals, 1)
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverBindExternalVolume(c *check.C) {


### PR DESCRIPTION
This makes the test a bit more robust to change and is a bit cleaner.
As implemented before this commit, we have two named plugins pointing to
the same http service. If the daemon makes any unexpected calls to the
plugin (e.g. during startup) we'll get more counts on the event counter
than expected since the daemon sees 2 plugins.

Found this while working on #29877 which broke this test originally (but
is no longer using V1 plugins, so is this is no longer broken there) and
took some time to debug what was going on.