### PR TITLE
Windows: gofmt checker fixes

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -273,9 +273,10 @@ Function Validate-GoFormat($headCommit, $upstreamCommit) {
         $outputFile=[System.IO.Path]::GetTempFileName()
         if (Test-Path $outputFile) { Remove-Item $outputFile }
         [System.IO.File]::WriteAllText($outputFile, $content, (New-Object System.Text.UTF8Encoding($False)))
-        $valid=Invoke-Expression "gofmt -s -l $outputFile"
-        Write-Host "Checking $outputFile"
-        if ($valid.Length -ne 0) { $badFiles+=$_ }
+        $currentFile = $_ -Replace("/","\")
+        Write-Host Checking $currentFile
+        Invoke-Expression "gofmt -s -l $outputFile"
+        if ($LASTEXITCODE -ne 0) { $badFiles+=$currentFile }
         if (Test-Path $outputFile) { Remove-Item $outputFile }
     }
     if ($badFiles.Length -eq 0) {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

4 tweaks to `make.ps1` in the gofmt check.

1. It was writing out the name of the temporary file used, rather than the actual file it was checking. Otherwise you get things like this in the output which is effectively useless for diagnosis purposes 

```
INFO: Validating go formatting on changed files...
Checking C:\Users\ContainerAdministrator\AppData\Local\Temp\tmpC0F7.tmp
Congratulations!  All Go source files are properly formatted.
```

With this change you get this instead:
```
INFO: Validating go formatting on changed files...
Checking cmd\docker\docker.go
Congratulations!  All Go source files are properly formatted.
```

2. It writes the filenames using Windows path semantics (\ instead of /) :smile:

3. It writes the filename _before_ running gofmt, not after. Much more useful!

4. It actually checks the exit code correctly 😇. That was a cut and paste error previously on my part. Now make.ps1 does actually fail if gofmt checks fail. 

@johnstep 