### PR TITLE
docs/api: document the /logs endpoint wire format

### DIFF
--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -792,6 +792,29 @@ Get `stdout` and `stderr` logs from the container ``id``
 > **Note**:
 > This endpoint works only for containers with the `json-file` or `journald` logging drivers.
 
+The returned stream response is in a binary format:
+
+- Each log entry is prefixed with 8 bytes of header.
+  - First byte indicates the stream (1=stdout 2=stderr)
+  - Next three bytes are unused
+  - Next 4 bytes indicate length (N) of the log entry as uint32 encoded in big
+    endian layout
+- Then it is followed by N bytes containing the message body.
+
+An example log entry in the stream:
+
+```
+01 00 00 00 00 00 00 1f 52 6f 73 65 73 20 61 72  65 ...
+│  ─────┬── ─────┬─────  R  o  s  e  s     a  r   e ...
+│       │        │
+└stdout │        │
+        │        └─ 0x0000001f = 31 bytes (including the \n at the end, if any)
+      unused
+```
+
+You can use a third-party library such as
+[dlog](https://github.com/ahmetalpbalkan/dlog) to parse this.
+
 **Example request**:
 
      GET /v1.24/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1


### PR DESCRIPTION
This was not documented anywhere. So I'm adding a piece of explanation about the `/logs` endpoint response format. I am not sure if this is covered under any API guarantee (or documenting it makes it as such).