### PR TITLE
Add `.CreatedAt` placeholder for `docker network ls --format`

### DIFF
--- a/cli/command/formatter/network.go
+++ b/cli/command/formatter/network.go
@@ -115,3 +115,8 @@ func (c *networkContext) Label(name string) string {
 	}
 	return c.n.Labels[name]
 }
+
+func (c *networkContext) CreatedAt() string {
+	c.AddHeader(createdAtHeader)
+	return c.n.Created.String()
+}

--- a/cli/command/formatter/network_test.go
+++ b/cli/command/formatter/network_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stringid"
@@ -144,12 +145,22 @@ network_id: networkID2
 foobar_bar
 `,
 		},
+		// Custom Format with CreatedAt
+		{
+			Context{Format: NewNetworkFormat("{{.Name}} {{.CreatedAt}}", false)},
+			`foobar_baz 2016-01-01 00:00:00 +0000 UTC
+foobar_bar 2017-01-01 00:00:00 +0000 UTC
+`,
+		},
 	}
+
+	timestamp1, _ := time.Parse("2006-01-02", "2016-01-01")
+	timestamp2, _ := time.Parse("2006-01-02", "2017-01-01")
 
 	for _, testcase := range cases {
 		networks := []types.NetworkResource{
-			{ID: "networkID1", Name: "foobar_baz", Driver: "foo", Scope: "local"},
-			{ID: "networkID2", Name: "foobar_bar", Driver: "bar", Scope: "local"},
+			{ID: "networkID1", Name: "foobar_baz", Driver: "foo", Scope: "local", Created: timestamp1},
+			{ID: "networkID2", Name: "foobar_bar", Driver: "bar", Scope: "local", Created: timestamp2},
 		}
 		out := bytes.NewBufferString("")
 		testcase.context.Output = out
@@ -168,8 +179,8 @@ func TestNetworkContextWriteJSON(t *testing.T) {
 		{ID: "networkID2", Name: "foobar_bar"},
 	}
 	expectedJSONs := []map[string]interface{}{
-		{"Driver": "", "ID": "networkID1", "IPv6": "false", "Internal": "false", "Labels": "", "Name": "foobar_baz", "Scope": ""},
-		{"Driver": "", "ID": "networkID2", "IPv6": "false", "Internal": "false", "Labels": "", "Name": "foobar_bar", "Scope": ""},
+		{"Driver": "", "ID": "networkID1", "IPv6": "false", "Internal": "false", "Labels": "", "Name": "foobar_baz", "Scope": "", "CreatedAt": "0001-01-01 00:00:00 +0000 UTC"},
+		{"Driver": "", "ID": "networkID2", "IPv6": "false", "Internal": "false", "Labels": "", "Name": "foobar_bar", "Scope": "", "CreatedAt": "0001-01-01 00:00:00 +0000 UTC"},
 	}
 
 	out := bytes.NewBufferString("")

--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -182,16 +182,17 @@ using a Go template.
 
 Valid placeholders for the Go template are listed below:
 
-Placeholder | Description
-------------|------------------------------------------------------------------------------------------
-`.ID`       | Network ID
-`.Name`     | Network name
-`.Driver`   | Network driver
-`.Scope`    | Network scope (local, global)
-`.IPv6`     | Whether IPv6 is enabled on the network or not.
-`.Internal` | Whether the network is internal or not.
-`.Labels`   | All labels assigned to the network.
-`.Label`    | Value of a specific label for this network. For example `{{.Label "project.version"}}`
+Placeholder  | Description
+-------------|------------------------------------------------------------------------------------------
+`.ID`        | Network ID
+`.Name`      | Network name
+`.Driver`    | Network driver
+`.Scope`     | Network scope (local, global)
+`.IPv6`      | Whether IPv6 is enabled on the network or not.
+`.Internal`  | Whether the network is internal or not.
+`.Labels`    | All labels assigned to the network.
+`.Label`     | Value of a specific label for this network. For example `{{.Label "project.version"}}`
+`.CreatedAt` | Time when the network was created
 
 When using the `--format` option, the `network ls` command will either
 output the data exactly as the template declares or, when using the


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This fix tries to add a placeholder `.CreatedAt` for Go format template in `docker network ls --format`.

While working on #29226, I noticed that it is not possible to display network's creation time in `docker network ls`, with or without `--format`.

We are able to find the timestamp of the network through `docker network inspect` though.

However, as we allow networks to be pruned based on the timestamp (see #29226), showing the timestamp in `docker network ls --format` would be much useful now.

**- How I did it**

This fix adds the `.CreatedAt` placeholder for `docker network ls --format`.

The default output was not changed for `docker network ls --format`.

**- How to verify it**

A test case for unit tests has been added.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>