### PR TITLE
Add on-failure to default restart policy

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -24,6 +24,10 @@ TimeoutStartSec=0
 Delegate=yes
 # kill only the docker process, not all processes in the cgroup
 KillMode=process
+# restart the docker process if it exits prematurely
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/init/systemd/docker.service.rpm
+++ b/contrib/init/systemd/docker.service.rpm
@@ -23,6 +23,10 @@ TimeoutStartSec=0
 Delegate=yes
 # kill only the docker process, not all processes in the cgroup
 KillMode=process
+# restart the docker process if it exits prematurely
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
In the event that the docker daemon is managed by systemd and spontaneously
dies the default service configuration does not have docker restart. For people
who just want to install and start docker then never worry about whether docker
is running a better default may be to restart the service on a failure.

**- What I did**

Set default docker service behavior to restart on failure

**- How I did it**

Added Restart parameter to default docker service configs

**- How to verify it**

Install Docker on a machine with systemd, kill dockerd process and see if it
restarts

**- Description for the changelog**

Set default docker service behavior to restart on failure

**- A picture of a cute animal (not mandatory but encouraged)**

![alt text](https://i.imgur.com/MmPBtKN.jpg "Coco")
