### PR TITLE
Windows: Fix TP5 volume unit tests TODOs

### DIFF
--- a/volume/volume_test.go
+++ b/volume/volume_test.go
@@ -22,7 +22,6 @@ func TestParseMountRaw(t *testing.T) {
 			`d:`,
 			`d:\path`,
 			`d:\path with space`,
-			// TODO Windows post TP5 - readonly support `d:\pathandmode:ro`,
 			`c:\:d:\`,
 			`c:\windows\:d:`,
 			`c:\windows:d:\s p a c e`,
@@ -33,9 +32,9 @@ func TestParseMountRaw(t *testing.T) {
 			`name:D:`,
 			`name:D::rW`,
 			`name:D::RW`,
-			// TODO Windows post TP5 - readonly support `name:D::RO`,
+			`name:D::RO`,
 			`c:/:d:/forward/slashes/are/good/too`,
-			// TODO Windows post TP5 - readonly support `c:/:d:/including with/spaces:ro`,
+			`c:/:d:/including with/spaces:ro`,
 			`c:\Windows`,             // With capital
 			`c:\Program Files (x86)`, // With capitals and brackets
 		}
@@ -59,6 +58,7 @@ func TestParseMountRaw(t *testing.T) {
 			`name?:d:`:                         `invalid volume specification`,
 			`name/:d:`:                         `invalid volume specification`,
 			`d:\pathandmode:rw`:                `invalid volume specification`,
+			`d:\pathandmode:ro`:                `invalid volume specification`,
 			`con:d:`:                           `cannot be a reserved word for Windows filenames`,
 			`PRN:d:`:                           `cannot be a reserved word for Windows filenames`,
 			`aUx:d:`:                           `cannot be a reserved word for Windows filenames`,
@@ -157,12 +157,12 @@ func TestParseMountRawSplit(t *testing.T) {
 		cases = []testParseMountRaw{
 			{`c:\:d:`, "local", `d:`, `c:\`, ``, "", true, false},
 			{`c:\:d:\`, "local", `d:\`, `c:\`, ``, "", true, false},
-			// TODO Windows post TP5 - Add readonly support {`c:\:d:\:ro`, "local", `d:\`, `c:\`, ``, "", false, false},
+			{`c:\:d:\:ro`, "local", `d:\`, `c:\`, ``, "", false, false},
 			{`c:\:d:\:rw`, "local", `d:\`, `c:\`, ``, "", true, false},
 			{`c:\:d:\:foo`, "local", `d:\`, `c:\`, ``, "", false, true},
 			{`name:d::rw`, "local", `d:`, ``, `name`, "local", true, false},
 			{`name:d:`, "local", `d:`, ``, `name`, "local", true, false},
-			// TODO Windows post TP5 - Add readonly support {`name:d::ro`, "local", `d:`, ``, `name`, "local", false, false},
+			{`name:d::ro`, "local", `d:`, ``, `name`, "local", false, false},
 			{`name:c:`, "", ``, ``, ``, "", true, true},
 			{`driver/name:c:`, "", ``, ``, ``, "", true, true},
 		}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This PR fixes some old TP5 TODOs in volume_test.go, validating read-only volume functionality.