### PR TITLE
Fix completion for zsh

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -917,7 +917,7 @@ __docker_image_subcommand() {
                 "($help)*--label=[Set metadata for an image]:label=value: " \
                 "($help -m --memory)"{-m=,--memory=}"[Memory limit]:Memory limit: " \
                 "($help)--memory-swap=[Total memory limit with swap]:Memory limit: " \
-                "($help)--network=[Connect a container to a network]:network mode:(bridge none container host)"
+                "($help)--network=[Connect a container to a network]:network mode:(bridge none container host)" \
                 "($help)--no-cache[Do not use cache when building the image]" \
                 "($help)--pull[Attempt to pull a newer version of the image]" \
                 "($help -q --quiet)"{-q,--quiet}"[Suppress verbose build output]" \


### PR DESCRIPTION
Signed-off-by: Yunxiang Huang <hyxqshk@vip.qq.com>

**- What I did**
I am using "oh-my-zsh" and added the plugin `docker`.
When I input `docker build` and press TAB want to got some tips for the command, I got some error messages like below:
 ```
__docker_image_subcommand:30: command not found: (--help)--no-cache[Do not use cache when building the image]
```

**- How I did it**
Add a missing `\` in file "_docker".

**- How to verify it**
Use zsh autocomplete with `docker build`.

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**
