### PR TITLE
Add hugetlb-limit option to docker run/create

### DIFF
--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -342,6 +342,15 @@ type Resources struct {
 	CPUPercent         int64  `json:"CpuPercent"` // CPU percent
 	IOMaximumIOps      uint64 // Maximum IOps for the container system drive
 	IOMaximumBandwidth uint64 // Maximum IO in bytes per second for the container system drive
+
+	// Hugetlb setting
+	Hugetlbs []Hugetlb
+}
+
+// Hugetlb represents hugepage configurations of container
+type Hugetlb struct {
+	PageSize string // PageSize should be standard hugetlb pagesize, "2MB" "1GB" .e.g
+	Limit    uint64 // Limit should be mutiple of PageSize in uint64
 }
 
 // UpdateConfig holds the mutable attributes of a Container.

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -54,6 +54,7 @@ func setResources(s *specs.Spec, r containertypes.Resources) error {
 		return err
 	}
 
+	hpRes := getHugetlbResources(r)
 	memoryRes := getMemoryResources(r)
 	cpuRes, err := getCPUResources(r)
 	if err != nil {
@@ -75,6 +76,7 @@ func setResources(s *specs.Spec, r containertypes.Resources) error {
 		Pids: &specs.LinuxPids{
 			Limit: r.PidsLimit,
 		},
+		HugepageLimits: hpRes,
 	}
 
 	if s.Linux.Resources != nil && len(s.Linux.Resources.Devices) > 0 {

--- a/integration-cli/docker_api_containers_unix_test.go
+++ b/integration-cli/docker_api_containers_unix_test.go
@@ -1,0 +1,57 @@
+// +build !windows
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
+	"github.com/docker/docker/pkg/sysinfo"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestContainersRunWithMultipleHugetlbLimit(c *check.C) {
+	testRequires(c, DaemonIsLinux, SameHostDaemon, hugetlbLimitSupport)
+
+	sysInfo := sysinfo.New(true)
+	dSize, err := sysInfo.GetDefaultHugepageSize()
+	c.Assert(err, check.IsNil)
+
+	data := map[string]interface{}{
+		"Image":      "busybox",
+		"Cmd":        []string{"/bin/sh", "-c", "ps"},
+		"HostConfig": map[string]interface{}{"Hugetlbs": []map[string]interface{}{{"Limit": 1073741824, "PageSize": dSize}, {"Limit": 2147483648, "PageSize": dSize}}},
+	}
+	status, resp, err := request.Post("/containers/create?name=test1", request.JSONBody(data))
+	b, _ := request.ReadBody(resp)
+	c.Assert(err, checker.IsNil, check.Commentf(string(b[:])))
+	c.Assert(status.StatusCode, checker.Equals, http.StatusCreated, check.Commentf(string(b[:])))
+
+	status, _, err = request.Post("/containers/test1/start")
+	c.Assert(err, checker.IsNil)
+	c.Assert(status.StatusCode, checker.Equals, http.StatusNoContent)
+
+	body := getInspectBody(c, "v1.31", "test1")
+	var inspectJSON types.ContainerJSON
+	err = json.Unmarshal(body, &inspectJSON)
+	c.Assert(err, checker.IsNil, check.Commentf("Unable to unmarshal body for version v1.26"))
+	c.Assert(len(inspectJSON.HostConfig.Hugetlbs), checker.Equals, 1, check.Commentf("expect one hugetlb limit setting, but get %d", len(inspectJSON.HostConfig.Hugetlbs)))
+	c.Assert(inspectJSON.HostConfig.Hugetlbs[0].Limit, checker.Equals, uint64(2147483648), check.Commentf("expect hugetlb limit to be 2G, get %d", inspectJSON.HostConfig.Hugetlbs[0].Limit))
+}
+
+func (s *DockerSuite) TestContainersRunWithInvalidHugetlbSize(c *check.C) {
+	testRequires(c, DaemonIsLinux, SameHostDaemon, hugetlbLimitSupport)
+
+	data := map[string]interface{}{
+		"Image":      "busybox",
+		"Cmd":        []string{"/bin/sh", "-c", "ps"},
+		"HostConfig": map[string]interface{}{"Hugetlbs": []map[string]interface{}{{"Limit": 2147483648, "PageSize": "7MB"}}},
+	}
+	_, resp, _ := request.Post("/containers/create?name=test1", request.JSONBody(data))
+	expected := "Invalid hugepage size:7MB"
+	b, _ := request.ReadBody(resp)
+	c.Assert(string(b[:]), checker.Contains, expected)
+}

--- a/integration-cli/requirements_unix_test.go
+++ b/integration-cli/requirements_unix_test.go
@@ -68,6 +68,10 @@ func memorySwappinessSupport() bool {
 	return testEnv.IsLocalDaemon() && SysInfo.MemorySwappiness
 }
 
+func hugetlbLimitSupport() bool {
+	return SysInfo.HugetlbLimit
+}
+
 func blkioWeight() bool {
 	return testEnv.IsLocalDaemon() && SysInfo.BlkioWeight
 }

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -1,6 +1,15 @@
 package sysinfo // import "github.com/docker/docker/pkg/sysinfo"
 
-import "github.com/docker/docker/pkg/parsers"
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/docker/pkg/parsers"
+	"github.com/docker/go-units"
+)
 
 // SysInfo stores information about which features a kernel supports.
 // TODO Windows: Factor out platform specific capabilities.
@@ -11,6 +20,7 @@ type SysInfo struct {
 	Seccomp bool
 
 	cgroupMemInfo
+	cgroupHugetlbInfo
 	cgroupCPUInfo
 	cgroupBlkioInfo
 	cgroupCpusetInfo
@@ -50,6 +60,11 @@ type cgroupMemInfo struct {
 
 	// Whether kernel memory TCP limit is supported or not
 	KernelMemoryTCP bool
+}
+
+type cgroupHugetlbInfo struct {
+	// Whether hugetlb limit is supported or not
+	HugetlbLimit bool
 }
 
 type cgroupCPUInfo struct {
@@ -103,6 +118,128 @@ type cgroupCpusetInfo struct {
 type cgroupPids struct {
 	// Whether Pids Limit is supported or not
 	PidsLimit bool
+}
+
+// ValidateHugetlb check whether hugetlb pagesize and limit legal
+func (c cgroupHugetlbInfo) ValidateHugetlb(pageSize string, limit uint64) (string, []string, error) {
+	var (
+		w   []string
+		err error
+	)
+	if pageSize != "" {
+		if err = isHugepageSizeValid(pageSize); err != nil {
+			return "", w, err
+		}
+	} else {
+		pageSize, err = c.GetDefaultHugepageSize()
+		if err != nil {
+			return "", w, fmt.Errorf("Failed to get system hugepage size")
+		}
+	}
+
+	warning, err := isHugeLimitValid(pageSize, limit)
+	w = append(w, warning...)
+	if err != nil {
+		return "", w, err
+	}
+
+	return pageSize, w, nil
+}
+
+// isHugeLimitValid check whether input hugetlb limit legal
+// it will check whether the limit size is times of size
+func isHugeLimitValid(size string, limit uint64) ([]string, error) {
+	var w []string
+	sizeInt, err := units.RAMInBytes(size)
+	if err != nil || sizeInt < 0 {
+		return w, fmt.Errorf("Invalid hugepage size:%s -- %s", size, err)
+	}
+	sizeUint := uint64(sizeInt)
+
+	if limit%sizeUint != 0 {
+		w = append(w, "Invalid hugetlb limit: should be multiple of huge page size")
+	}
+
+	return w, nil
+}
+
+// isHugepageSizeValid check whether input size legal
+// it will compare size with all system supported hugepage size
+func isHugepageSizeValid(size string) error {
+	hps, err := getHugepageSizes()
+	if err != nil {
+		return err
+	}
+
+	for _, hp := range hps {
+		if size == hp {
+			return nil
+		}
+	}
+	return fmt.Errorf("Invalid hugepage size:%s, shoud be one of %v", size, hps)
+}
+
+func humanSize(i int64) string {
+	// hugetlb may not surpass GB
+	uf := []string{"B", "KB", "MB", "GB"}
+	ui := 0
+	for {
+		if i < 1024 || ui >= 3 {
+			break
+		}
+		i = i / 1024
+		ui = ui + 1
+	}
+
+	return fmt.Sprintf("%d%s", i, uf[ui])
+}
+
+func getHugepageSizes() ([]string, error) {
+	var hps []string
+	hpm := make(map[string]string)
+	if err := filepath.Walk("/sys/fs/cgroup/hugetlb", func(p string, i os.FileInfo, err error) error {
+		if strings.HasSuffix(i.Name(), "limit_in_bytes") {
+			sres := strings.SplitN(i.Name(), ".", 3)
+			if len(sres) != 3 {
+				// just ignore this error and see if next file is as expected
+				return nil
+			}
+			hpm[sres[1]] = sres[1]
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	for _, v := range hpm {
+		hps = append(hps, v)
+	}
+	return hps, nil
+}
+
+// GetDefaultHugepageSize returns system default hugepage size
+func (c cgroupHugetlbInfo) GetDefaultHugepageSize() (string, error) {
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return "", fmt.Errorf("Failed to get hugepage size, cannot open /proc/meminfo")
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		if strings.Contains(s.Text(), "Hugepagesize") {
+			sres := strings.SplitN(s.Text(), ":", 2)
+			if len(sres) != 2 {
+				return "", fmt.Errorf("Failed to get hugepage size, wired /proc/meminfo format")
+			}
+
+			size := strings.Replace(sres[1], " ", "", -1)
+			// transform 2048k to 2M
+			sizeInt, _ := units.RAMInBytes(size)
+			return humanSize(sizeInt), nil
+		}
+	}
+	return "", fmt.Errorf("Failed to get hugepage size")
 }
 
 // IsCpusetCpusAvailable returns `true` if the provided string set is contained


### PR DESCRIPTION

Signed-off-by: Deng Guangxing <dengguangxi

Please provide the following information:
-->

fixes https://github.com/moby/moby/issues/38113


**- What I did**

add hugetlb-limit option to docker run/create command to provide hugetlb limitation in container


**- How I did it**

add new options to create, and use cgroup to limit hugetlb usage


**- How to verify it**

```
root@5625cd1cf658:/go/src/github.com/docker/docker# docker run -ti --hugetlb-limit 2m:6m busybox cat /sys/fs/cgroup/hugetlb/hugetlb.2MB.limit_in_bytes
6291456
```