### PR TITLE
Optimize image ls filtering

### DIFF
--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -27,6 +27,9 @@ type ImageContext struct {
 }
 
 func isDangling(image types.ImageSummary) bool {
+	if image.RepoTags == nil && image.RepoDigests == nil {
+		return true
+	}
 	return len(image.RepoTags) == 1 && image.RepoTags[0] == "<none>:<none>" && len(image.RepoDigests) == 1 && image.RepoDigests[0] == "<none>@<none>"
 }
 

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -154,11 +154,6 @@ func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs
 			continue
 		}
 
-		if newImage.RepoDigests == nil && newImage.RepoTags == nil {
-			newImage.RepoDigests = []string{"<none>@<none>"}
-			newImage.RepoTags = []string{"<none>:<none>"}
-		}
-
 		// Collect image's VirtualSize
 		layerID := img.RootFS.ChainID()
 		if layerID != "" {


### PR DESCRIPTION
This is built on top of https://github.com/docker/docker/pull/29912, so needs to be rebased if that is merged before this one.

This PR makes some modifications for `docker image ls`;

**simplify check for dangling images**
 
simplify filtering on dangling images to be more readable, and moving it to the start of the function. There's no need to match on actual references if we're not looking for dangling images.

**calculate container-counts only once**

add a map to store container-counts per image, instead of looping over the list of containers for each image.

**do not calculate VirtualSize if not needed**

There's no need to calculate an image's VirtualSize if the image did not match the provided filters. Move the calculation of an image's VirtualSize after all filters have been applied.

**do not use magic values for dangling images**

Removes the magic `<none>:<none>` / `<none>@<none>` from the images API. These values should be left to the client, as they are only used for "presenting" the images, and are no valid references. Instead of checking for these magic values, consider an image without RepoTags and RepoDigests to be dangling.
