### PR TITLE
devmapper: Return device id in error message

### DIFF
--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -151,7 +151,7 @@ func (d *Driver) Remove(id string) error {
 
 	// This assumes the device has been properly Get/Put:ed and thus is unmounted
 	if err := d.DeviceSet.DeleteDevice(id, false); err != nil {
-		return err
+		return fmt.Errorf("failed to remove device %v:%v", id, err)
 	}
 
 	mp := path.Join(d.home, "mnt", id)


### PR DESCRIPTION
I often get complaints that container removal failed and users got following
error message.

"Driver devicemapper failed to remove root filesystem 18a69ba82aaf7a039ce7d44156215012d703001643079775190ac7dd6c6acf56:Device is Busy"

This error message talks about container id but does not give any info
about which particular device id is busy. Most likely device is mounted
in some other mount namespace and if one knows the device id, they
can try to do some debugging figuring which process and which mount
namespace is keeping the device busy and how did we reach that stage.

Without that information, it becomes almost impossible to debug the
problem.

So to improve the debuggability, when device removal fails, also return
device id in error message. Now new message looks as follows.

"Driver devicemapper failed to remove root filesystem 18a69ba82aaf7a039ce7d44156215012d703001643079775190ac7dd6c6acf56: Failed to remove device dbc15bdf9994a17c613d8ef9e924f3cffbf67f91e4f709295c901ad628377991:Device is Busy"

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>

