### PR TITLE
add port PublishMode to service inspect --pretty output

### DIFF
--- a/cli/command/formatter/service.go
+++ b/cli/command/formatter/service.go
@@ -103,6 +103,7 @@ Ports:
  PublishedPort {{ $port.PublishedPort }}
   Protocol = {{ $port.Protocol }}
   TargetPort = {{ $port.TargetPort }}
+  PublishMode = {{ $port.PublishMode }}
 {{- end }} {{ end -}}
 `
 

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -691,11 +691,7 @@ portLoop:
 		ports := flags.Lookup(flagPublishAdd).Value.(*opts.PortOpt).Value()
 
 		for _, port := range ports {
-			if v, ok := portSet[portConfigToString(&port)]; ok {
-				if v != port {
-					fmt.Println("v", v)
-					return fmt.Errorf("conflicting port mapping between %v:%v/%s and %v:%v/%s", port.PublishedPort, port.TargetPort, port.Protocol, v.PublishedPort, v.TargetPort, v.Protocol)
-				}
+			if _, ok := portSet[portConfigToString(&port)]; ok {
 				continue
 			}
 			//portSet[portConfigToString(&port)] = port

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -125,15 +125,18 @@ Service Mode:	REPLICATED
 Placement:
 UpdateConfig:
  Parallelism:	0
+ On failure:	pause
+ Max failure ratio:	0
 ContainerSpec:
  Image:		nginx:alpine
 Resources:
+Networks:	net1
 Endpoint Mode:  vip
 Ports:
- Name =
- Protocol = tcp
- TargetPort = 443
  PublishedPort = 4443
+  Protocol = tcp
+  TargetPort = 443
+  PublishMode = ingress
 ```
 
 You can also use `--format pretty` for the same effect.


### PR DESCRIPTION
`PublishMode` (`ingress` or `host`) was added to port config in #27917. It should be added in service inspect pretty format.

Signed-off-by: Dong Chen <dongluo.chen@docker.com>