### PR TITLE
Set plugins used in tests back to original names

### DIFF
--- a/integration-cli/docker_cli_authz_plugin_v2_test.go
+++ b/integration-cli/docker_cli_authz_plugin_v2_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 var (
-	authzPluginName            = "tonistiigi/authz-no-volume-plugin"
+	authzPluginName            = "riyaz/authz-no-volume-plugin"
 	authzPluginTag             = "latest"
 	authzPluginNameWithTag     = authzPluginName + ":" + authzPluginTag
-	authzPluginBadManifestName = "tonistiigi/authz-plugin-bad-manifest"
+	authzPluginBadManifestName = "riyaz/authz-plugin-bad-manifest"
 	nonexistentAuthzPluginName = "riyaz/nonexistent-authz-plugin"
 )
 

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -777,7 +777,7 @@ func (s *DockerNetworkSuite) TestDockerPluginV2NetworkDriver(c *check.C) {
 	testRequires(c, DaemonIsLinux, IsAmd64, Network)
 
 	var (
-		npName        = "tonistiigi/test-docker-netplugin"
+		npName        = "tiborvass/test-docker-netplugin"
 		npTag         = "latest"
 		npNameWithTag = npName + ":" + npTag
 	)

--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -15,8 +15,8 @@ import (
 
 var (
 	pluginProcessName = "sample-volume-plugin"
-	pName             = "tonistiigi/sample-volume-plugin"
-	npName            = "tonistiigi/test-docker-netplugin"
+	pName             = "tiborvass/sample-volume-plugin"
+	npName            = "tiborvass/test-docker-netplugin"
 	pTag              = "latest"
 	pNameWithTag      = pName + ":" + pTag
 	npNameWithTag     = npName + ":" + pTag


### PR DESCRIPTION
There were breaking changes in #29487 so we needed to switch to other names. With `rc-5` out we have updated new versions to the old names so they can be used again.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
