### PR TITLE
vendor: Unfork logrus dependency

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -2,7 +2,7 @@
 github.com/Azure/go-ansiterm 388960b655244e76e24c75f48631564eaefade62
 github.com/Microsoft/hcsshim v0.5.9
 github.com/Microsoft/go-winio v0.3.7
-github.com/Sirupsen/logrus f76d643702a30fbffecdfe50831e11881c96ceb3 https://github.com/aaronlehmann/logrus
+github.com/Sirupsen/logrus v0.11.0
 github.com/davecgh/go-spew 6d212800a42e8ab5c146b8ace3490ee17e5225f9
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git


### PR DESCRIPTION
Vendor the latest official logrus release instead of a custom fork (which now happens to be identical to the fork).