### PR TITLE
[1.13] Vendor swarmkit 7f910df

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -100,7 +100,7 @@ github.com/docker/containerd 03e5862ec0d8d3b3f750e19fca3ee367e13c090e
 github.com/tonistiigi/fifo 1405643975692217d6720f8b54aeee1bf2cd5cf4
 
 # cluster
-github.com/docker/swarmkit 99adeb1c6b33cebc81c31dd05b163080033062f2
+github.com/docker/swarmkit 7f910df8587ad86b62be7a023a2236183e68d879
 github.com/golang/mock bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 github.com/gogo/protobuf v0.3
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a

--- a/vendor/github.com/docker/swarmkit/node/node.go
+++ b/vendor/github.com/docker/swarmkit/node/node.go
@@ -297,10 +297,12 @@ func (n *Node) run(ctx context.Context) (err error) {
 	go func() {
 		managerErr = n.runManager(ctx, securityConfig, managerReady) // store err and loop
 		wg.Done()
+		cancel()
 	}()
 	go func() {
 		agentErr = n.runAgent(ctx, db, securityConfig.ClientTLSCreds, agentReady)
 		wg.Done()
+		cancel()
 	}()
 
 	go func() {


### PR DESCRIPTION
Update swarmkit vendoring.

Fixes #29885 via https://github.com/docker/swarmkit/pull/1845

Also brings in these raft fixes:

- raft: Prevent the same manager from joining raft twice (https://github.com/docker/swarmkit/pull/1815)
- raft: Stop manager on write error (https://github.com/docker/swarmkit/pull/1820)