### PR TITLE
Fix TestSecretCreateWithLabels nondeterminism

### DIFF
--- a/integration-cli/docker_cli_secret_create_test.go
+++ b/integration-cli/docker_cli_secret_create_test.go
@@ -55,7 +55,7 @@ func (s *DockerSwarmSuite) TestSecretCreateWithLabels(c *check.C) {
 func (s *DockerSwarmSuite) TestSecretCreateResolve(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
-	name := "foo"
+	name := "test_secret"
 	id := d.CreateSecret(c, swarm.SecretSpec{
 		swarm.Annotations{
 			Name: name,


### PR DESCRIPTION
This test checks for the substring "foo" in the "secret ls" output. This
is a valid base36 substring and can sometimes show up by chance:

    docker_cli_secret_create_test.go:86:
        c.Assert(out, checker.Not(checker.Contains), name)
    ... obtained string = "" +
    ...     "ID                          NAME                        CREATED UPDATED\n" +
    ...     "ob8y4t4feuz8pn5h6vla9oxoz   stefoo7e268ozqfupi9s4se9q   Less than a second ago   Less than a second ago\n"
    ... substring string = "foo"

Change the secret name to test_secret, matching other tests. Underscores
can't appear in base36 so this name is safe to grep for.