### PR TITLE
Provide correct command information and URL

### DIFF
--- a/man/src/container/top.md
+++ b/man/src/container/top.md
@@ -6,6 +6,6 @@ All displayed information is from host's point of view.
 
 Run **docker container top** with the ps option of -x:
 
-    $ docker top 8601afda2b -x
+    $ docker container top 8601afda2b -x
     PID      TTY       STAT       TIME         COMMAND
     16623    ?         Ss         0:00         sleep 99999

--- a/man/src/container/unpause.md
+++ b/man/src/container/unpause.md
@@ -2,5 +2,5 @@ The `docker container unpause` command un-suspends all processes in a container.
 On Linux, it does this using the cgroups freezer.
 
 See the [cgroups freezer documentation]
-(https://www.kernel.org/doc/Documentation/cgroups/freezer-subsystem.txt) for
+(https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt) for
 further details.


### PR DESCRIPTION
1. "docker top 8601afda2b -x" better to be "docker container top 8601afda2b -x" because of the previous description "Run **docker container top** with the ps option of -x:".

2. URL is wrong, should under cgroup-v1.