### PR TITLE
[WIP]emit network connect event after container toDisk

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -757,6 +757,10 @@ func (daemon *Daemon) connectToNetwork(container *container.Container, idOrName 
 
 	container.NetworkSettings.Ports = getPortMapInfo(sb)
 
+	if err := container.ToDisk(); err != nil {
+		return fmt.Errorf("Error saving container to disk: %v", err)
+	}
+
 	daemon.LogNetworkEventWithAttributes(n, "connect", map[string]string{"container": container.ID})
 	networkActions.WithValues("connect").UpdateSince(start)
 	return nil
@@ -968,15 +972,9 @@ func (daemon *Daemon) ConnectToNetwork(container *container.Container, idOrName 
 		}
 	} else if !daemon.isNetworkHotPluggable() {
 		return fmt.Errorf(runtime.GOOS + " does not support connecting a running container to a network")
-	} else {
-		if err := daemon.connectToNetwork(container, idOrName, endpointConfig, true); err != nil {
-			return err
-		}
 	}
-	if err := container.ToDiskLocking(); err != nil {
-		return fmt.Errorf("Error saving container to disk: %v", err)
-	}
-	return nil
+
+	return daemon.connectToNetwork(container, idOrName, endpointConfig, true)
 }
 
 // DisconnectFromNetwork disconnects container from network n.


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I found almost every event related to container is emitted after container config succeeded to `container.ToDiskLocking()`. While network connect is different, the order is opposite.

So this PR tries to change the `network connect` event and `ToDisk` order back.

**- What I did**
1. move `container.ToDiskLocking()` just to make it lay before `network connect event`.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

