### PR TITLE
[test-integration] clean some runCommandWithOutput

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5433,7 +5433,7 @@ func (s *DockerTrustSuite) TestTrustedBuild(c *check.C) {
 	name := "testtrustedbuild"
 
 	buildCmd := buildImageCmd(name, dockerFile, true)
-	s.trustedCmd(buildCmd)
+	trustedExecCmd(buildCmd)
 	out, _, err := runCommandWithOutput(buildCmd)
 	if err != nil {
 		c.Fatalf("Error running trusted build: %s\n%s", err, out)
@@ -5464,7 +5464,7 @@ func (s *DockerTrustSuite) TestTrustedBuildUntrustedTag(c *check.C) {
 	name := "testtrustedbuilduntrustedtag"
 
 	buildCmd := buildImageCmd(name, dockerFile, true)
-	s.trustedCmd(buildCmd)
+	trustedExecCmd(buildCmd)
 	out, _, err := runCommandWithOutput(buildCmd)
 	if err == nil {
 		c.Fatalf("Expected error on trusted build with untrusted tag: %s\n%s", err, out)
@@ -5527,10 +5527,7 @@ func (s *DockerTrustSuite) TestTrustedBuildTagFromReleasesRole(c *check.C) {
 	otherTag := fmt.Sprintf("%s:other", repoName)
 	dockerCmd(c, "tag", "busybox", otherTag)
 
-	pushCmd := exec.Command(dockerBinary, "push", otherTag)
-	s.trustedCmd(pushCmd)
-	out, _, err := runCommandWithOutput(pushCmd)
-	c.Assert(err, check.IsNil, check.Commentf("Trusted push failed: %s", out))
+	icmd.RunCmd(icmd.Command(dockerBinary, "push", otherTag), trustedCmd).Assert(c, icmd.Success)
 	s.assertTargetInRoles(c, repoName, "other", "targets/releases")
 	s.assertTargetNotInRoles(c, repoName, "other", "targets")
 
@@ -5545,8 +5542,8 @@ func (s *DockerTrustSuite) TestTrustedBuildTagFromReleasesRole(c *check.C) {
 	name := "testtrustedbuildreleasesrole"
 
 	buildCmd := buildImageCmd(name, dockerFile, true)
-	s.trustedCmd(buildCmd)
-	out, _, err = runCommandWithOutput(buildCmd)
+	trustedExecCmd(buildCmd)
+	out, _, err := runCommandWithOutput(buildCmd)
 	c.Assert(err, check.IsNil, check.Commentf("Trusted build failed: %s", out))
 	c.Assert(out, checker.Contains, fmt.Sprintf("FROM %s@sha", repoName))
 }
@@ -5566,10 +5563,7 @@ func (s *DockerTrustSuite) TestTrustedBuildTagIgnoresOtherDelegationRoles(c *che
 	otherTag := fmt.Sprintf("%s:other", repoName)
 	dockerCmd(c, "tag", "busybox", otherTag)
 
-	pushCmd := exec.Command(dockerBinary, "push", otherTag)
-	s.trustedCmd(pushCmd)
-	out, _, err := runCommandWithOutput(pushCmd)
-	c.Assert(err, check.IsNil, check.Commentf("Trusted push failed: %s", out))
+	icmd.RunCmd(icmd.Command(dockerBinary, "push", otherTag), trustedCmd).Assert(c, icmd.Success)
 	s.assertTargetInRoles(c, repoName, "other", "targets/other")
 	s.assertTargetNotInRoles(c, repoName, "other", "targets")
 
@@ -5584,8 +5578,8 @@ func (s *DockerTrustSuite) TestTrustedBuildTagIgnoresOtherDelegationRoles(c *che
 	name := "testtrustedbuildotherrole"
 
 	buildCmd := buildImageCmd(name, dockerFile, true)
-	s.trustedCmd(buildCmd)
-	out, _, err = runCommandWithOutput(buildCmd)
+	trustedExecCmd(buildCmd)
+	out, _, err := runCommandWithOutput(buildCmd)
 	c.Assert(err, check.NotNil, check.Commentf("Trusted build expected to fail: %s", out))
 }
 

--- a/integration-cli/docker_cli_build_unix_test.go
+++ b/integration-cli/docker_cli_build_unix_test.go
@@ -103,7 +103,7 @@ func (s *DockerSuite) TestBuildAddChangeOwnership(c *check.C) {
 
 		icmd.RunCmd(icmd.Cmd{
 			Command: []string{"chown", "daemon:daemon", "foo"},
-			Dir: tmpDir,
+			Dir:     tmpDir,
 		}).Assert(c, icmd.Success)
 
 		if err := ioutil.WriteFile(filepath.Join(tmpDir, "Dockerfile"), []byte(dockerfile), 0644); err != nil {

--- a/integration-cli/docker_cli_build_unix_test.go
+++ b/integration-cli/docker_cli_build_unix_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/pkg/testutil"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/docker/go-units"
 	"github.com/go-check/check"
 )
@@ -100,12 +101,10 @@ func (s *DockerSuite) TestBuildAddChangeOwnership(c *check.C) {
 		}
 		defer testFile.Close()
 
-		chownCmd := exec.Command("chown", "daemon:daemon", "foo")
-		chownCmd.Dir = tmpDir
-		out, _, err := runCommandWithOutput(chownCmd)
-		if err != nil {
-			c.Fatal(err, out)
-		}
+		icmd.RunCmd(icmd.Cmd{
+			Command: []string{"chown", "daemon:daemon", "foo"},
+			Dir: tmpDir,
+		}).Assert(c, icmd.Success)
 
 		if err := ioutil.WriteFile(filepath.Join(tmpDir, "Dockerfile"), []byte(dockerfile), 0644); err != nil {
 			c.Fatalf("failed to open destination dockerfile: %v", err)

--- a/integration-cli/docker_cli_config_test.go
+++ b/integration-cli/docker_cli_config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/integration-cli/checker"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/go-check/check"
 )
@@ -51,15 +52,15 @@ func (s *DockerSuite) TestConfigHTTPHeader(c *check.C) {
 	err = ioutil.WriteFile(tmpCfg, []byte(data), 0600)
 	c.Assert(err, checker.IsNil)
 
-	cmd := exec.Command(dockerBinary, "-H="+server.URL[7:], "ps")
-	out, _, _ := runCommandWithOutput(cmd)
+	result := icmd.RunCommand(dockerBinary, "-H="+server.URL[7:], "ps")
+	result.Assert(c, icmd.Success)
 
 	c.Assert(headers["User-Agent"], checker.NotNil, check.Commentf("Missing User-Agent"))
 
-	c.Assert(headers["User-Agent"][0], checker.Equals, "Docker-Client/"+dockerversion.Version+" ("+runtime.GOOS+")", check.Commentf("Badly formatted User-Agent,out:%v", out))
+	c.Assert(headers["User-Agent"][0], checker.Equals, "Docker-Client/"+dockerversion.Version+" ("+runtime.GOOS+")", check.Commentf("Badly formatted User-Agent,out:%v", result.Combined()))
 
 	c.Assert(headers["Myheader"], checker.NotNil)
-	c.Assert(headers["Myheader"][0], checker.Equals, "MyValue", check.Commentf("Missing/bad header,out:%v", out))
+	c.Assert(headers["Myheader"][0], checker.Equals, "MyValue", check.Commentf("Missing/bad header,out:%v", result.Combined()))
 
 }
 
@@ -72,11 +73,10 @@ func (s *DockerSuite) TestConfigDir(c *check.C) {
 	dockerCmd(c, "--config", cDir, "ps")
 
 	// Test with env var too
-	cmd := exec.Command(dockerBinary, "ps")
-	cmd.Env = appendBaseEnv(true, "DOCKER_CONFIG="+cDir)
-	out, _, err := runCommandWithOutput(cmd)
-
-	c.Assert(err, checker.IsNil, check.Commentf("ps2 didn't work,out:%v", out))
+	icmd.RunCmd(icm.Cmd{
+		Command: []string{dockerBinary, "ps"},
+		Env: appendBaseEnv(true, "DOCKER_CONFIG="+cDir),
+	}).Assert(c, icmd.Success)
 
 	// Start a server so we can check to see if the config file was
 	// loaded properly
@@ -99,42 +99,49 @@ func (s *DockerSuite) TestConfigDir(c *check.C) {
 
 	env := appendBaseEnv(false)
 
-	cmd = exec.Command(dockerBinary, "--config", cDir, "-H="+server.URL[7:], "ps")
-	cmd.Env = env
-	out, _, err = runCommandWithOutput(cmd)
-
-	c.Assert(err, checker.NotNil, check.Commentf("out:%v", out))
+	icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "--config", cDir, "-H="+server.URL[7:], "ps"},
+		Env: env,
+	}).Assert(c, icmd.Exepected{
+		Error: "exit status 1",
+	})
 	c.Assert(headers["Myheader"], checker.NotNil)
 	c.Assert(headers["Myheader"][0], checker.Equals, "MyValue", check.Commentf("ps3 - Missing header,out:%v", out))
 
 	// Reset headers and try again using env var this time
 	headers = map[string][]string{}
-	cmd = exec.Command(dockerBinary, "-H="+server.URL[7:], "ps")
-	cmd.Env = append(env, "DOCKER_CONFIG="+cDir)
-	out, _, err = runCommandWithOutput(cmd)
-
-	c.Assert(err, checker.NotNil, check.Commentf("%v", out))
+	icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "--config", cDir, "-H="+server.URL[7:], "ps"},
+		Env: append(env, "DOCKER_CONFIG="+cDir),
+	}).Assert(c, icmd.Exepected{
+		Error: "exit status 1",
+	})
 	c.Assert(headers["Myheader"], checker.NotNil)
 	c.Assert(headers["Myheader"][0], checker.Equals, "MyValue", check.Commentf("ps4 - Missing header,out:%v", out))
 
+	// FIXME(vdemeester) should be a unit test
 	// Reset headers and make sure flag overrides the env var
 	headers = map[string][]string{}
-	cmd = exec.Command(dockerBinary, "--config", cDir, "-H="+server.URL[7:], "ps")
-	cmd.Env = append(env, "DOCKER_CONFIG=MissingDir")
-	out, _, err = runCommandWithOutput(cmd)
-
-	c.Assert(err, checker.NotNil, check.Commentf("out:%v", out))
+	icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "--config", cDir, "-H="+server.URL[7:], "ps"},
+		Env: append(env, "DOCKER_CONFIG=MissingDir"),
+	}).Assert(c, icmd.Exepected{
+		Error: "exit status 1",
+	})
 	c.Assert(headers["Myheader"], checker.NotNil)
 	c.Assert(headers["Myheader"][0], checker.Equals, "MyValue", check.Commentf("ps5 - Missing header,out:%v", out))
 
+	// FIXME(vdemeester) should be a unit test
 	// Reset headers and make sure flag overrides the env var.
 	// Almost same as previous but make sure the "MissingDir" isn't
 	// ignore - we don't want to default back to the env var.
 	headers = map[string][]string{}
-	cmd = exec.Command(dockerBinary, "--config", "MissingDir", "-H="+server.URL[7:], "ps")
-	cmd.Env = append(env, "DOCKER_CONFIG="+cDir)
-	out, _, err = runCommandWithOutput(cmd)
+	icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "--config", "MissingDir", "-H="+server.URL[7:], "ps"},
+		Env: append(env, "DOCKER_CONFIG="+cDir),
+	}).Assert(c, icmd.Exepected{
+		Error: "exit status 1",
+	})
 
-	c.Assert(err, checker.NotNil, check.Commentf("out:%v", out))
 	c.Assert(headers["Myheader"], checker.IsNil, check.Commentf("ps6 - Headers shouldn't be the expected value,out:%v", out))
 }

--- a/integration-cli/docker_cli_daemon_plugins_test.go
+++ b/integration-cli/docker_cli_daemon_plugins_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall"
 
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/pkg/mount"
 	"github.com/go-check/check"
@@ -92,10 +93,7 @@ func (s *DockerDaemonSuite) TestDaemonKillLiveRestoreWithPlugins(c *check.C) {
 		c.Fatalf("Could not kill daemon: %v", err)
 	}
 
-	cmd := exec.Command("pgrep", "-f", pluginProcessName)
-	if out, ec, err := runCommandWithOutput(cmd); ec != 0 {
-		c.Fatalf("Expected exit code '0', got %d err: %v output: %s ", ec, err, out)
-	}
+	icmd.RunCommand("pgrep", "-f", pluginProcessName).Assert(c, icmd.Success)
 }
 
 // TestDaemonShutdownLiveRestoreWithPlugins SIGTERMs daemon started with --live-restore.
@@ -121,10 +119,7 @@ func (s *DockerDaemonSuite) TestDaemonShutdownLiveRestoreWithPlugins(c *check.C)
 		c.Fatalf("Could not kill daemon: %v", err)
 	}
 
-	cmd := exec.Command("pgrep", "-f", pluginProcessName)
-	if out, ec, err := runCommandWithOutput(cmd); ec != 0 {
-		c.Fatalf("Expected exit code '0', got %d err: %v output: %s ", ec, err, out)
-	}
+	icmd.RunCommand("pgrep", "-f", pluginProcessName).Assert(c, icmd.Success)
 }
 
 // TestDaemonShutdownWithPlugins shuts down running plugins.
@@ -156,15 +151,13 @@ func (s *DockerDaemonSuite) TestDaemonShutdownWithPlugins(c *check.C) {
 		}
 	}
 
-	cmd := exec.Command("pgrep", "-f", pluginProcessName)
-	if out, ec, err := runCommandWithOutput(cmd); ec != 1 {
-		c.Fatalf("Expected exit code '1', got %d err: %v output: %s ", ec, err, out)
-	}
+	icmd.RunCommand("pgrep", "-f", pluginProcessName).Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Error: "exit status 1",
+	})
 
 	s.d.Start(c, "--live-restore")
-	cmd = exec.Command("pgrep", "-f", pluginProcessName)
-	out, _, err := runCommandWithOutput(cmd)
-	c.Assert(err, checker.IsNil, check.Commentf(out))
+	icmd.RunCommand("pgrep", "-f", pluginProcessName).Assert(c, icmd.Success)
 }
 
 // TestVolumePlugin tests volume creation using a plugin.

--- a/integration-cli/docker_cli_daemon_plugins_test.go
+++ b/integration-cli/docker_cli_daemon_plugins_test.go
@@ -4,14 +4,13 @@ package main
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
 
-	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/pkg/mount"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
 
@@ -153,7 +152,7 @@ func (s *DockerDaemonSuite) TestDaemonShutdownWithPlugins(c *check.C) {
 
 	icmd.RunCommand("pgrep", "-f", pluginProcessName).Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Error: "exit status 1",
+		Error:    "exit status 1",
 	})
 
 	s.d.Start(c, "--live-restore")

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -262,30 +262,15 @@ func (s *DockerDaemonSuite) TestDaemonIptablesClean(c *check.C) {
 		c.Fatalf("Could not run top: %s, %v", out, err)
 	}
 
-	// get output from iptables with container running
 	ipTablesSearchString := "tcp dpt:80"
-	ipTablesCmd := exec.Command("iptables", "-nvL")
-	out, _, err := runCommandWithOutput(ipTablesCmd)
-	if err != nil {
-		c.Fatalf("Could not run iptables -nvL: %s, %v", out, err)
-	}
 
-	if !strings.Contains(out, ipTablesSearchString) {
-		c.Fatalf("iptables output should have contained %q, but was %q", ipTablesSearchString, out)
-	}
+	// get output from iptables with container running
+	verifyIPTablesContains(c, ipTablesSearchString)
 
 	s.d.Stop(c)
 
 	// get output from iptables after restart
-	ipTablesCmd = exec.Command("iptables", "-nvL")
-	out, _, err = runCommandWithOutput(ipTablesCmd)
-	if err != nil {
-		c.Fatalf("Could not run iptables -nvL: %s, %v", out, err)
-	}
-
-	if strings.Contains(out, ipTablesSearchString) {
-		c.Fatalf("iptables output should not have contained %q, but was %q", ipTablesSearchString, out)
-	}
+	verifyIPTablesDoesNotContains(c, ipTablesSearchString)
 }
 
 func (s *DockerDaemonSuite) TestDaemonIptablesCreate(c *check.C) {
@@ -297,36 +282,36 @@ func (s *DockerDaemonSuite) TestDaemonIptablesCreate(c *check.C) {
 
 	// get output from iptables with container running
 	ipTablesSearchString := "tcp dpt:80"
-	ipTablesCmd := exec.Command("iptables", "-nvL")
-	out, _, err := runCommandWithOutput(ipTablesCmd)
-	if err != nil {
-		c.Fatalf("Could not run iptables -nvL: %s, %v", out, err)
-	}
-
-	if !strings.Contains(out, ipTablesSearchString) {
-		c.Fatalf("iptables output should have contained %q, but was %q", ipTablesSearchString, out)
-	}
+	verifyIPTablesContains(c, ipTablesSearchString)
 
 	s.d.Restart(c)
 
 	// make sure the container is not running
 	runningOut, err := s.d.Cmd("inspect", "--format={{.State.Running}}", "top")
 	if err != nil {
-		c.Fatalf("Could not inspect on container: %s, %v", out, err)
+		c.Fatalf("Could not inspect on container: %s, %v", runningOut, err)
 	}
 	if strings.TrimSpace(runningOut) != "true" {
 		c.Fatalf("Container should have been restarted after daemon restart. Status running should have been true but was: %q", strings.TrimSpace(runningOut))
 	}
 
 	// get output from iptables after restart
-	ipTablesCmd = exec.Command("iptables", "-nvL")
-	out, _, err = runCommandWithOutput(ipTablesCmd)
-	if err != nil {
-		c.Fatalf("Could not run iptables -nvL: %s, %v", out, err)
-	}
+	verifyIPTablesContains(c, ipTablesSearchString)
+}
 
-	if !strings.Contains(out, ipTablesSearchString) {
-		c.Fatalf("iptables output after restart should have contained %q, but was %q", ipTablesSearchString, out)
+func verifyIPTablesContains(c *check.C, ipTablesSearchString string) {
+	result := icmd.RunCommand("iptables", "-nvL")
+	result.Assert(c, icmd.Success)
+	if !strings.Contains(result.Combined(), ipTablesSearchString) {
+		c.Fatalf("iptables output should have contained %q, but was %q", ipTablesSearchString, result.Combined())
+	}
+}
+
+func verifyIPTablesDoesNotContains(c *check.C, ipTablesSearchString string) {
+	result := icmd.RunCommand("iptables", "-nvL")
+	result.Assert(c, icmd.Success)
+	if strings.Contains(result.Combined(), ipTablesSearchString) {
+		c.Fatalf("iptables output should not have contained %q, but was %q", ipTablesSearchString, result.Combined())
 	}
 }
 
@@ -564,10 +549,7 @@ func (s *DockerDaemonSuite) TestDaemonExitOnFailure(c *check.C) {
 			c.Fatalf("Expected daemon not to start, got %v", err)
 		}
 		// look in the log and make sure we got the message that daemon is shutting down
-		runCmd := exec.Command("grep", "Error starting daemon", s.d.LogFileName())
-		if out, _, err := runCommandWithOutput(runCmd); err != nil {
-			c.Fatalf("Expected 'Error starting daemon' message; but doesn't exist in log: %q, err: %v", out, err)
-		}
+		icmd.RunCommand("grep", "Error starting daemon", s.d.LogFileName()).Assert(c, icmd.Success)
 	} else {
 		//if we didn't get an error and the daemon is running, this is a failure
 		c.Fatal("Conflicting options should cause the daemon to error out with a failure")
@@ -584,20 +566,15 @@ func (s *DockerDaemonSuite) TestDaemonBridgeExternal(c *check.C) {
 	bridgeIP := "192.169.1.1/24"
 	_, bridgeIPNet, _ := net.ParseCIDR(bridgeIP)
 
-	out, err := createInterface(c, "bridge", bridgeName, bridgeIP)
-	c.Assert(err, check.IsNil, check.Commentf(out))
+	createInterface(c, "bridge", bridgeName, bridgeIP)
 	defer deleteInterface(c, bridgeName)
 
 	d.StartWithBusybox(c, "--bridge", bridgeName)
 
 	ipTablesSearchString := bridgeIPNet.String()
-	ipTablesCmd := exec.Command("iptables", "-t", "nat", "-nvL")
-	out, _, err = runCommandWithOutput(ipTablesCmd)
-	c.Assert(err, check.IsNil)
-
-	c.Assert(strings.Contains(out, ipTablesSearchString), check.Equals, true,
-		check.Commentf("iptables output should have contained %q, but was %q",
-			ipTablesSearchString, out))
+	icmd.RunCommand("iptables", "-t", "nat", "-nvL").Assert(c, icmd.Expected{
+		Out: ipTablesSearchString,
+	})
 
 	_, err = d.Cmd("run", "-d", "--name", "ExtContainer", "busybox", "top")
 	c.Assert(err, check.IsNil)
@@ -617,41 +594,27 @@ func (s *DockerDaemonSuite) TestDaemonBridgeNone(c *check.C) {
 	defer d.Restart(c)
 
 	// verify docker0 iface is not there
-	out, _, err := runCommandWithOutput(exec.Command("ifconfig", "docker0"))
-	c.Assert(err, check.NotNil, check.Commentf("docker0 should not be present if daemon started with --bridge=none"))
-	c.Assert(strings.Contains(out, "Device not found"), check.Equals, true)
+	icmd.RunCommand("ifconfig", "docker0").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Error:    "exit status 1",
+		Err:      "Device not found",
+	})
 
 	// verify default "bridge" network is not there
-	out, err = d.Cmd("network", "inspect", "bridge")
+	out, err := d.Cmd("network", "inspect", "bridge")
 	c.Assert(err, check.NotNil, check.Commentf("\"bridge\" network should not be present if daemon started with --bridge=none"))
 	c.Assert(strings.Contains(out, "No such network"), check.Equals, true)
 }
 
-func createInterface(c *check.C, ifType string, ifName string, ipNet string) (string, error) {
-	args := []string{"link", "add", "name", ifName, "type", ifType}
-	ipLinkCmd := exec.Command("ip", args...)
-	out, _, err := runCommandWithOutput(ipLinkCmd)
-	if err != nil {
-		return out, err
-	}
-
-	ifCfgCmd := exec.Command("ifconfig", ifName, ipNet, "up")
-	out, _, err = runCommandWithOutput(ifCfgCmd)
-	return out, err
+func createInterface(c *check.C, ifType string, ifName string, ipNet string) {
+	icmd.RunCommand("ip", "link", "add", "name", ifName, "type", ifType).Assert(c, icmd.Success)
+	icmd.RunCommand("ifconfig", ifName, ipNet, "up").Assert(c, icmd.Success)
 }
 
 func deleteInterface(c *check.C, ifName string) {
-	ifCmd := exec.Command("ip", "link", "delete", ifName)
-	out, _, err := runCommandWithOutput(ifCmd)
-	c.Assert(err, check.IsNil, check.Commentf(out))
-
-	flushCmd := exec.Command("iptables", "-t", "nat", "--flush")
-	out, _, err = runCommandWithOutput(flushCmd)
-	c.Assert(err, check.IsNil, check.Commentf(out))
-
-	flushCmd = exec.Command("iptables", "--flush")
-	out, _, err = runCommandWithOutput(flushCmd)
-	c.Assert(err, check.IsNil, check.Commentf(out))
+	icmd.RunCommand("ip", "link", "delete", ifName).Assert(c, icmd.Success)
+	icmd.RunCommand("iptables", "-t", "nat", "--flush").Assert(c, icmd.Success)
+	icmd.RunCommand("iptables", "--flush").Assert(c, icmd.Success)
 }
 
 func (s *DockerDaemonSuite) TestDaemonBridgeIP(c *check.C) {
@@ -723,8 +686,7 @@ func (s *DockerDaemonSuite) TestDaemonBridgeFixedCidr(c *check.C) {
 	bridgeName := "external-bridge"
 	bridgeIP := "192.169.1.1/24"
 
-	out, err := createInterface(c, "bridge", bridgeName, bridgeIP)
-	c.Assert(err, check.IsNil, check.Commentf(out))
+	createInterface(c, "bridge", bridgeName, bridgeIP)
 	defer deleteInterface(c, bridgeName)
 
 	args := []string{"--bridge", bridgeName, "--fixed-cidr", "192.169.1.0/30"}
@@ -747,14 +709,13 @@ func (s *DockerDaemonSuite) TestDaemonBridgeFixedCidr2(c *check.C) {
 	bridgeName := "external-bridge"
 	bridgeIP := "10.2.2.1/16"
 
-	out, err := createInterface(c, "bridge", bridgeName, bridgeIP)
-	c.Assert(err, check.IsNil, check.Commentf(out))
+	createInterface(c, "bridge", bridgeName, bridgeIP)
 	defer deleteInterface(c, bridgeName)
 
 	d.StartWithBusybox(c, "--bip", bridgeIP, "--fixed-cidr", "10.2.2.0/24")
 	defer s.d.Restart(c)
 
-	out, err = d.Cmd("run", "-d", "--name", "bb", "busybox", "top")
+	out, err := d.Cmd("run", "-d", "--name", "bb", "busybox", "top")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 	defer d.Cmd("stop", "bb")
 
@@ -772,14 +733,13 @@ func (s *DockerDaemonSuite) TestDaemonBridgeFixedCIDREqualBridgeNetwork(c *check
 	bridgeName := "external-bridge"
 	bridgeIP := "172.27.42.1/16"
 
-	out, err := createInterface(c, "bridge", bridgeName, bridgeIP)
-	c.Assert(err, check.IsNil, check.Commentf(out))
+	createInterface(c, "bridge", bridgeName, bridgeIP)
 	defer deleteInterface(c, bridgeName)
 
 	d.StartWithBusybox(c, "--bridge", bridgeName, "--fixed-cidr", bridgeIP)
 	defer s.d.Restart(c)
 
-	out, err = d.Cmd("run", "-d", "busybox", "top")
+	out, err := d.Cmd("run", "-d", "busybox", "top")
 	c.Assert(err, check.IsNil, check.Commentf(out))
 	cid1 := strings.TrimSpace(out)
 	defer d.Cmd("stop", cid1)
@@ -871,21 +831,18 @@ func (s *DockerDaemonSuite) TestDaemonIP(c *check.C) {
 	c.Assert(strings.Contains(out, "Error starting userland proxy"), check.Equals, true)
 
 	ifName := "dummy"
-	out, err = createInterface(c, "dummy", ifName, ipStr)
-	c.Assert(err, check.IsNil, check.Commentf(out))
+	createInterface(c, "dummy", ifName, ipStr)
 	defer deleteInterface(c, ifName)
 
 	_, err = d.Cmd("run", "-d", "-p", "8000:8000", "busybox", "top")
 	c.Assert(err, check.IsNil)
 
-	ipTablesCmd := exec.Command("iptables", "-t", "nat", "-nvL")
-	out, _, err = runCommandWithOutput(ipTablesCmd)
-	c.Assert(err, check.IsNil)
-
+	result := icmd.RunCommand("iptables", "-t", "nat", "-nvL")
+	result.Assert(c, icmd.Success)
 	regex := fmt.Sprintf("DNAT.*%s.*dpt:8000", ip.String())
-	matched, _ := regexp.MatchString(regex, out)
+	matched, _ := regexp.MatchString(regex, result.Combined())
 	c.Assert(matched, check.Equals, true,
-		check.Commentf("iptables output should have contained %q, but was %q", regex, out))
+		check.Commentf("iptables output should have contained %q, but was %q", regex, result.Combined()))
 }
 
 func (s *DockerDaemonSuite) TestDaemonICCPing(c *check.C) {
@@ -895,22 +852,18 @@ func (s *DockerDaemonSuite) TestDaemonICCPing(c *check.C) {
 	bridgeName := "external-bridge"
 	bridgeIP := "192.169.1.1/24"
 
-	out, err := createInterface(c, "bridge", bridgeName, bridgeIP)
-	c.Assert(err, check.IsNil, check.Commentf(out))
+	createInterface(c, "bridge", bridgeName, bridgeIP)
 	defer deleteInterface(c, bridgeName)
 
-	args := []string{"--bridge", bridgeName, "--icc=false"}
-	d.StartWithBusybox(c, args...)
+	d.StartWithBusybox(c, "--bridge", bridgeName, "--icc=false")
 	defer d.Restart(c)
 
-	ipTablesCmd := exec.Command("iptables", "-nvL", "FORWARD")
-	out, _, err = runCommandWithOutput(ipTablesCmd)
-	c.Assert(err, check.IsNil)
-
+	result := icmd.RunCommand("iptables", "-nvL", "FORWARD")
+	result.Assert(c, icmd.Success)
 	regex := fmt.Sprintf("DROP.*all.*%s.*%s", bridgeName, bridgeName)
-	matched, _ := regexp.MatchString(regex, out)
+	matched, _ := regexp.MatchString(regex, result.Combined())
 	c.Assert(matched, check.Equals, true,
-		check.Commentf("iptables output should have contained %q, but was %q", regex, out))
+		check.Commentf("iptables output should have contained %q, but was %q", regex, result.Combined()))
 
 	// Pinging another container must fail with --icc=false
 	pingContainers(c, d, true)
@@ -924,7 +877,7 @@ func (s *DockerDaemonSuite) TestDaemonICCPing(c *check.C) {
 	// But, Pinging external or a Host interface must succeed
 	pingCmd := fmt.Sprintf("ping -c 1 %s -W 1", ip.String())
 	runArgs := []string{"run", "--rm", "busybox", "sh", "-c", pingCmd}
-	_, err = d.Cmd(runArgs...)
+	_, err := d.Cmd(runArgs...)
 	c.Assert(err, check.IsNil)
 }
 
@@ -934,24 +887,20 @@ func (s *DockerDaemonSuite) TestDaemonICCLinkExpose(c *check.C) {
 	bridgeName := "external-bridge"
 	bridgeIP := "192.169.1.1/24"
 
-	out, err := createInterface(c, "bridge", bridgeName, bridgeIP)
-	c.Assert(err, check.IsNil, check.Commentf(out))
+	createInterface(c, "bridge", bridgeName, bridgeIP)
 	defer deleteInterface(c, bridgeName)
 
-	args := []string{"--bridge", bridgeName, "--icc=false"}
-	d.StartWithBusybox(c, args...)
+	d.StartWithBusybox(c, "--bridge", bridgeName, "--icc=false")
 	defer d.Restart(c)
 
-	ipTablesCmd := exec.Command("iptables", "-nvL", "FORWARD")
-	out, _, err = runCommandWithOutput(ipTablesCmd)
-	c.Assert(err, check.IsNil)
-
+	result := icmd.RunCommand("iptables", "-nvL", "FORWARD")
+	result.Assert(c, icmd.Success)
 	regex := fmt.Sprintf("DROP.*all.*%s.*%s", bridgeName, bridgeName)
-	matched, _ := regexp.MatchString(regex, out)
+	matched, _ := regexp.MatchString(regex, result.Combined())
 	c.Assert(matched, check.Equals, true,
-		check.Commentf("iptables output should have contained %q, but was %q", regex, out))
+		check.Commentf("iptables output should have contained %q, but was %q", regex, result.Combined()))
 
-	out, err = d.Cmd("run", "-d", "--expose", "4567", "--name", "icc1", "busybox", "nc", "-l", "-p", "4567")
+	out, err := d.Cmd("run", "-d", "--expose", "4567", "--name", "icc1", "busybox", "nc", "-l", "-p", "4567")
 	c.Assert(err, check.IsNil, check.Commentf(out))
 
 	out, err = d.Cmd("run", "--link", "icc1:icc1", "busybox", "nc", "icc1", "4567")
@@ -962,14 +911,13 @@ func (s *DockerDaemonSuite) TestDaemonLinksIpTablesRulesWhenLinkAndUnlink(c *che
 	bridgeName := "external-bridge"
 	bridgeIP := "192.169.1.1/24"
 
-	out, err := createInterface(c, "bridge", bridgeName, bridgeIP)
-	c.Assert(err, check.IsNil, check.Commentf(out))
+	createInterface(c, "bridge", bridgeName, bridgeIP)
 	defer deleteInterface(c, bridgeName)
 
 	s.d.StartWithBusybox(c, "--bridge", bridgeName, "--icc=false")
 	defer s.d.Restart(c)
 
-	_, err = s.d.Cmd("run", "-d", "--name", "child", "--publish", "8080:80", "busybox", "top")
+	_, err := s.d.Cmd("run", "-d", "--name", "child", "--publish", "8080:80", "busybox", "top")
 	c.Assert(err, check.IsNil)
 	_, err = s.d.Cmd("run", "-d", "--name", "parent", "--link", "child:http", "busybox", "top")
 	c.Assert(err, check.IsNil)
@@ -1464,10 +1412,7 @@ func (s *DockerDaemonSuite) TestCleanupMountsAfterDaemonAndContainerKill(c *chec
 	c.Assert(strings.Contains(string(mountOut), id), check.Equals, true, comment)
 
 	// kill the container
-	runCmd := exec.Command(ctrBinary, "--address", "unix:///var/run/docker/libcontainerd/docker-containerd.sock", "containers", "kill", id)
-	if out, ec, err := runCommandWithOutput(runCmd); err != nil {
-		c.Fatalf("Failed to run ctr, ExitCode: %d, err: %v output: %s id: %s\n", ec, err, out, id)
-	}
+	icmd.RunCommand(ctrBinary, "--address", "unix:///var/run/docker/libcontainerd/docker-containerd.sock", "containers", "kill", id).Assert(c, icmd.Success)
 
 	// restart daemon.
 	d.Restart(c)
@@ -1564,10 +1509,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartCleanupNetns(c *check.C) {
 	}
 
 	// Test if the file still exists
-	out, _, err = runCommandWithOutput(exec.Command("stat", "-c", "%n", fileName))
-	out = strings.TrimSpace(out)
-	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
-	c.Assert(out, check.Equals, fileName, check.Commentf("Output: %s", out))
+	icmd.RunCommand("stat", "-c", "%n", fileName).Assert(c, icmd.Expected{
+		Out: fileName,
+	})
 
 	// Remove the container and restart the daemon
 	if out, err := s.d.Cmd("rm", "netns"); err != nil {
@@ -1577,32 +1521,34 @@ func (s *DockerDaemonSuite) TestDaemonRestartCleanupNetns(c *check.C) {
 	s.d.Restart(c)
 
 	// Test again and see now the netns file does not exist
-	out, _, err = runCommandWithOutput(exec.Command("stat", "-c", "%n", fileName))
-	out = strings.TrimSpace(out)
-	c.Assert(err, check.Not(check.IsNil), check.Commentf("Output: %s", out))
+	icmd.RunCommand("stat", "-c", "%n", fileName).Assert(c, icmd.Expected{
+		Err:      "No such file or directory",
+		ExitCode: 1,
+	})
 }
 
 // tests regression detailed in #13964 where DOCKER_TLS_VERIFY env is ignored
 func (s *DockerDaemonSuite) TestDaemonTLSVerifyIssue13964(c *check.C) {
 	host := "tcp://localhost:4271"
 	s.d.Start(c, "-H", host)
-	cmd := exec.Command(dockerBinary, "-H", host, "info")
-	cmd.Env = []string{"DOCKER_TLS_VERIFY=1", "DOCKER_CERT_PATH=fixtures/https"}
-	out, _, err := runCommandWithOutput(cmd)
-	c.Assert(err, check.Not(check.IsNil), check.Commentf("%s", out))
-	c.Assert(strings.Contains(out, "error during connect"), check.Equals, true)
-
+	icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "-H", host, "info"},
+		Env:     []string{"DOCKER_TLS_VERIFY=1", "DOCKER_CERT_PATH=fixtures/https"},
+	}).Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err:      "error during connect",
+	})
 }
 
 func setupV6(c *check.C) {
 	// Hack to get the right IPv6 address on docker0, which has already been created
 	result := icmd.RunCommand("ip", "addr", "add", "fe80::1/64", "dev", "docker0")
-	result.Assert(c, icmd.Expected{})
+	result.Assert(c, icmd.Success)
 }
 
 func teardownV6(c *check.C) {
 	result := icmd.RunCommand("ip", "addr", "del", "fe80::1/64", "dev", "docker0")
-	result.Assert(c, icmd.Expected{})
+	result.Assert(c, icmd.Success)
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithContainerWithRestartPolicyAlways(c *check.C) {
@@ -1708,10 +1654,7 @@ func (s *DockerDaemonSuite) TestDaemonCorruptedLogDriverAddress(c *check.C) {
 	})
 	c.Assert(d.StartWithError("--log-driver=syslog", "--log-opt", "syslog-address=corrupted:42"), check.NotNil)
 	expected := "Failed to set log opts: syslog-address should be in form proto://address"
-	runCmd := exec.Command("grep", expected, d.LogFileName())
-	if out, _, err := runCommandWithOutput(runCmd); err != nil {
-		c.Fatalf("Expected %q message; but doesn't exist in log: %q, err: %v", expected, out, err)
-	}
+	icmd.RunCommand("grep", expected, d.LogFileName()).Assert(c, icmd.Success)
 }
 
 // FIXME(vdemeester) should be a unit test
@@ -1721,10 +1664,7 @@ func (s *DockerDaemonSuite) TestDaemonCorruptedFluentdAddress(c *check.C) {
 	})
 	c.Assert(d.StartWithError("--log-driver=fluentd", "--log-opt", "fluentd-address=corrupted:c"), check.NotNil)
 	expected := "Failed to set log opts: invalid fluentd-address corrupted:c: "
-	runCmd := exec.Command("grep", expected, d.LogFileName())
-	if out, _, err := runCommandWithOutput(runCmd); err != nil {
-		c.Fatalf("Expected %q message; but doesn't exist in log: %q, err: %v", expected, out, err)
-	}
+	icmd.RunCommand("grep", expected, d.LogFileName()).Assert(c, icmd.Success)
 }
 
 // FIXME(vdemeester) Use a new daemon instance instead of the Suite one
@@ -1808,13 +1748,11 @@ func (s *DockerDaemonSuite) TestDaemonNoSpaceLeftOnDeviceError(c *check.C) {
 	// create a 2MiB image and mount it as graph root
 	// Why in a container? Because `mount` sometimes behaves weirdly and often fails outright on this test in debian:jessie (which is what the test suite runs under if run from the Makefile)
 	dockerCmd(c, "run", "--rm", "-v", testDir+":/test", "busybox", "sh", "-c", "dd of=/test/testfs.img bs=1M seek=2 count=0")
-	out, _, err := runCommandWithOutput(exec.Command("mkfs.ext4", "-F", filepath.Join(testDir, "testfs.img"))) // `mkfs.ext4` is not in busybox
-	c.Assert(err, checker.IsNil, check.Commentf(out))
+	icmd.RunCommand("mkfs.ext4", "-F", filepath.Join(testDir, "testfs.img")).Assert(c, icmd.Success)
 
-	cmd := exec.Command("losetup", "-f", "--show", filepath.Join(testDir, "testfs.img"))
-	loout, err := cmd.CombinedOutput()
-	c.Assert(err, checker.IsNil)
-	loopname := strings.TrimSpace(string(loout))
+	result := icmd.RunCommand("losetup", "-f", "--show", filepath.Join(testDir, "testfs.img"))
+	result.Assert(c, icmd.Success)
+	loopname := strings.TrimSpace(string(result.Combined()))
 	defer exec.Command("losetup", "-d", loopname).Run()
 
 	dockerCmd(c, "run", "--privileged", "--rm", "-v", testDir+":/test:shared", "busybox", "sh", "-c", fmt.Sprintf("mkdir -p /test/test-mount && mount -t ext4 -no loop,rw %v /test/test-mount", loopname))
@@ -2007,10 +1945,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithKilledRunningContainer(t *check
 	}
 
 	// kill the container
-	runCmd := exec.Command(ctrBinary, "--address", "unix:///var/run/docker/libcontainerd/docker-containerd.sock", "containers", "kill", cid)
-	if out, ec, err := runCommandWithOutput(runCmd); err != nil {
-		t.Fatalf("Failed to run ctr, ExitCode: %d, err: '%v' output: '%s' cid: '%s'\n", ec, err, out, cid)
-	}
+	icmd.RunCommand(ctrBinary, "--address", "unix:///var/run/docker/libcontainerd/docker-containerd.sock", "containers", "kill", cid).Assert(c, icmd.Success)
 
 	// Give time to containerd to process the command if we don't
 	// the exit event might be received after we do the inspect

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1945,7 +1945,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithKilledRunningContainer(t *check
 	}
 
 	// kill the container
-	icmd.RunCommand(ctrBinary, "--address", "unix:///var/run/docker/libcontainerd/docker-containerd.sock", "containers", "kill", cid).Assert(c, icmd.Success)
+	icmd.RunCommand(ctrBinary, "--address", "unix:///var/run/docker/libcontainerd/docker-containerd.sock", "containers", "kill", cid).Assert(t, icmd.Success)
 
 	// Give time to containerd to process the command if we don't
 	// the exit event might be received after we do the inspect

--- a/integration-cli/docker_cli_export_import_test.go
+++ b/integration-cli/docker_cli_export_import_test.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/docker/docker/integration-cli/checker"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
 
@@ -18,12 +18,13 @@ func (s *DockerSuite) TestExportContainerAndImportImage(c *check.C) {
 
 	out, _ := dockerCmd(c, "export", containerID)
 
-	importCmd := exec.Command(dockerBinary, "import", "-", "repo/testexp:v1")
-	importCmd.Stdin = strings.NewReader(out)
-	out, _, err := runCommandWithOutput(importCmd)
-	c.Assert(err, checker.IsNil, check.Commentf("failed to import image repo/testexp:v1: %s", out))
+	result := icmd.RunCmd(icmd.Cmd{
+		Command: dockerBinary, "import", "-", "repo/testexp:v1",
+		Stdin: strings.NewReader(out),
+	})
+	result.Assert(c, icmd.Success)
 
-	cleanedImageID := strings.TrimSpace(out)
+	cleanedImageID := strings.TrimSpace(result.Combined())
 	c.Assert(cleanedImageID, checker.Not(checker.Equals), "", check.Commentf("output should have been an image id"))
 }
 
@@ -36,14 +37,15 @@ func (s *DockerSuite) TestExportContainerWithOutputAndImportImage(c *check.C) {
 	dockerCmd(c, "export", "--output=testexp.tar", containerID)
 	defer os.Remove("testexp.tar")
 
-	out, _, err := runCommandWithOutput(exec.Command("cat", "testexp.tar"))
-	c.Assert(err, checker.IsNil, check.Commentf(out))
+	resultCat := icmd.RunCommand("cat", "testexp.tar")
+	resultCat.Assert(c, icmd.Success)
 
-	importCmd := exec.Command(dockerBinary, "import", "-", "repo/testexp:v1")
-	importCmd.Stdin = strings.NewReader(out)
-	out, _, err = runCommandWithOutput(importCmd)
-	c.Assert(err, checker.IsNil, check.Commentf("failed to import image repo/testexp:v1: %s", out))
+	result := icmd.RunCmd(icmd.Cmd{
+		Command: dockerBinary, "import", "-", "repo/testexp:v1",
+		Stdin: strings.NewReader(resultCat.Combined()),
+	})
+	result.Assert(c, icmd.Success)
 
-	cleanedImageID := strings.TrimSpace(out)
+	cleanedImageID := strings.TrimSpace(result.Combined())
 	c.Assert(cleanedImageID, checker.Not(checker.Equals), "", check.Commentf("output should have been an image id"))
 }

--- a/integration-cli/docker_cli_export_import_test.go
+++ b/integration-cli/docker_cli_export_import_test.go
@@ -19,8 +19,8 @@ func (s *DockerSuite) TestExportContainerAndImportImage(c *check.C) {
 	out, _ := dockerCmd(c, "export", containerID)
 
 	result := icmd.RunCmd(icmd.Cmd{
-		Command: dockerBinary, "import", "-", "repo/testexp:v1",
-		Stdin: strings.NewReader(out),
+		Command: []string{dockerBinary, "import", "-", "repo/testexp:v1"},
+		Stdin:   strings.NewReader(out),
 	})
 	result.Assert(c, icmd.Success)
 
@@ -41,8 +41,8 @@ func (s *DockerSuite) TestExportContainerWithOutputAndImportImage(c *check.C) {
 	resultCat.Assert(c, icmd.Success)
 
 	result := icmd.RunCmd(icmd.Cmd{
-		Command: dockerBinary, "import", "-", "repo/testexp:v1",
-		Stdin: strings.NewReader(resultCat.Combined()),
+		Command: []string{dockerBinary, "import", "-", "repo/testexp:v1"},
+		Stdin:   strings.NewReader(resultCat.Combined()),
 	})
 	result.Assert(c, icmd.Success)
 

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os/exec"
 	"runtime"
 	"strings"
 	"unicode"
@@ -54,8 +53,8 @@ func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
 
 		// Check main help text to make sure its not over 80 chars
 		result := icmd.RunCmd(icmd.Cmd{
-			Command: []stirng{dockerBinary, "help"},
-			Env: newEnvs,
+			Command: []string{dockerBinary, "help"},
+			Env:     newEnvs,
 		})
 		result.Assert(c, icmd.Success)
 		lines := strings.Split(result.Combined(), "\n")

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
+	// FIXME(vdemeester) should be a unit test, probably using golden files ?
 	testRequires(c, DaemonIsLinux)
 
 	// Make sure main help text fits within 80 chars and that
@@ -52,11 +53,12 @@ func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
 		scanForHome := runtime.GOOS != "windows" && home != "/"
 
 		// Check main help text to make sure its not over 80 chars
-		helpCmd := exec.Command(dockerBinary, "help")
-		helpCmd.Env = newEnvs
-		out, _, err := runCommandWithOutput(helpCmd)
-		c.Assert(err, checker.IsNil, check.Commentf(out))
-		lines := strings.Split(out, "\n")
+		result := icmd.RunCmd(icmd.Cmd{
+			Command: []stirng{dockerBinary, "help"},
+			Env: newEnvs,
+		})
+		result.Assert(c, icmd.Success)
+		lines := strings.Split(result.Combined(), "\n")
 		for _, line := range lines {
 			// All lines should not end with a space
 			c.Assert(line, checker.Not(checker.HasSuffix), " ", check.Commentf("Line should not end with a space"))
@@ -75,16 +77,17 @@ func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
 		// Make sure each cmd's help text fits within 90 chars and that
 		// on non-windows system we use ~ when possible (to shorten things).
 		// Pull the list of commands from the "Commands:" section of docker help
-		helpCmd = exec.Command(dockerBinary, "help")
-		helpCmd.Env = newEnvs
-		out, _, err = runCommandWithOutput(helpCmd)
-		c.Assert(err, checker.IsNil, check.Commentf(out))
-		i := strings.Index(out, "Commands:")
-		c.Assert(i, checker.GreaterOrEqualThan, 0, check.Commentf("Missing 'Commands:' in:\n%s", out))
+		// FIXME(vdemeester) Why re-run help ?
+		//helpCmd = exec.Command(dockerBinary, "help")
+		//helpCmd.Env = newEnvs
+		//out, _, err = runCommandWithOutput(helpCmd)
+		//c.Assert(err, checker.IsNil, check.Commentf(out))
+		i := strings.Index(result.Combined(), "Commands:")
+		c.Assert(i, checker.GreaterOrEqualThan, 0, check.Commentf("Missing 'Commands:' in:\n%s", result.Combined()))
 
 		cmds := []string{}
 		// Grab all chars starting at "Commands:"
-		helpOut := strings.Split(out[i:], "\n")
+		helpOut := strings.Split(result.Combined()[i:], "\n")
 		// Skip first line, it is just "Commands:"
 		helpOut = helpOut[1:]
 

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
-	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/pkg/jsonlog"
 	"github.com/docker/docker/pkg/testutil"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
 
@@ -190,10 +190,10 @@ func (s *DockerSuite) TestLogsSince(c *check.C) {
 	// Test with default value specified and parameter omitted
 	expected := []string{"log1", "log2", "log3"}
 	for _, cmd := range [][]string{
-		[]string{dockerBinary, "logs", "-t", name},
-		[]string{dockerBinary, "logs", "-t", "--since=0", name},
+		{"logs", "-t", name},
+		{"logs", "-t", "--since=0", name},
 	} {
-		result := icmd.RunCommand(cmd...)
+		result := icmd.RunCommand(dockerBinary, cmd...)
 		result.Assert(c, icmd.Success)
 		for _, v := range expected {
 			c.Assert(result.Combined(), checker.Contains, v)

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/pkg/jsonlog"
 	"github.com/docker/docker/pkg/testutil"
@@ -188,14 +189,14 @@ func (s *DockerSuite) TestLogsSince(c *check.C) {
 
 	// Test with default value specified and parameter omitted
 	expected := []string{"log1", "log2", "log3"}
-	for _, cmd := range []*exec.Cmd{
-		exec.Command(dockerBinary, "logs", "-t", name),
-		exec.Command(dockerBinary, "logs", "-t", "--since=0", name),
+	for _, cmd := range [][]string{
+		[]string{dockerBinary, "logs", "-t", name},
+		[]string{dockerBinary, "logs", "-t", "--since=0", name},
 	} {
-		out, _, err = runCommandWithOutput(cmd)
-		c.Assert(err, checker.IsNil, check.Commentf("failed to log container: %s", out))
+		result := icmd.RunCommand(cmd...)
+		result.Assert(c, icmd.Success)
 		for _, v := range expected {
-			c.Assert(out, checker.Contains, v)
+			c.Assert(result.Combined(), checker.Contains, v)
 		}
 	}
 }

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -803,15 +803,14 @@ func (s *DockerDaemonSuite) TestDockerNetworkNoDiscoveryDefaultBridgeNetwork(c *
 	hostsFile := "/etc/hosts"
 	bridgeName := "external-bridge"
 	bridgeIP := "192.169.255.254/24"
-	out, err := createInterface(c, "bridge", bridgeName, bridgeIP)
-	c.Assert(err, check.IsNil, check.Commentf(out))
+	createInterface(c, "bridge", bridgeName, bridgeIP)
 	defer deleteInterface(c, bridgeName)
 
 	s.d.StartWithBusybox(c, "--bridge", bridgeName)
 	defer s.d.Restart(c)
 
 	// run two containers and store first container's etc/hosts content
-	out, err = s.d.Cmd("run", "-d", "busybox", "top")
+	out, err := s.d.Cmd("run", "-d", "busybox", "top")
 	c.Assert(err, check.IsNil)
 	cid1 := strings.TrimSpace(out)
 	defer s.d.Cmd("stop", cid1)

--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -2,15 +2,14 @@ package main
 
 import (
 	"fmt"
-	"os/exec"
-
-	"github.com/docker/docker/integration-cli/checker"
-	"github.com/go-check/check"
-
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/docker/docker/integration-cli/checker"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
+	"github.com/go-check/check"
 )
 
 var (
@@ -305,15 +304,11 @@ func (s *DockerTrustSuite) TestPluginTrustedInstall(c *check.C) {
 
 	trustedName := s.setupTrustedplugin(c, pNameWithTag, "trusted-plugin-install")
 
-	installCmd := exec.Command(dockerBinary, "plugin", "install", "--grant-all-permissions", trustedName)
-	s.trustedCmd(installCmd)
-	out, _, err := runCommandWithOutput(installCmd)
+	icmd.RunCmd(icmd.Command(dockerBinary, "plugin", "install", "--grant-all-permissions", trustedName), trustedCmd).Assert(c, icmd.Expected{
+		Out: trustedName,
+	})
 
-	c.Assert(strings.TrimSpace(out), checker.Contains, trustedName)
-	c.Assert(err, checker.IsNil)
-	c.Assert(strings.TrimSpace(out), checker.Contains, trustedName)
-
-	out, _, err = dockerCmdWithError("plugin", "ls")
+	out, _, err := dockerCmdWithError("plugin", "ls")
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, "true")
 
@@ -330,11 +325,7 @@ func (s *DockerTrustSuite) TestPluginTrustedInstall(c *check.C) {
 	c.Assert(strings.TrimSpace(out), checker.Contains, trustedName)
 
 	// Try untrusted pull to ensure we pushed the tag to the registry
-	installCmd = exec.Command(dockerBinary, "plugin", "install", "--disable-content-trust=true", "--grant-all-permissions", trustedName)
-	s.trustedCmd(installCmd)
-	out, _, err = runCommandWithOutput(installCmd)
-	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Status: Downloaded", check.Commentf(out))
+	icmd.RunCmd(icmd.Command(dockerBinary, "plugin", "install", "--disable-content-trust=true", "--grant-all-permissions", trustedName), trustedCmd).Assert(c, SuccessDownloaded)
 
 	out, _, err = dockerCmdWithError("plugin", "ls")
 	c.Assert(err, checker.IsNil)
@@ -352,12 +343,10 @@ func (s *DockerTrustSuite) TestPluginUntrustedInstall(c *check.C) {
 	dockerCmd(c, "plugin", "rm", "-f", pluginName)
 
 	// Try trusted install on untrusted plugin
-	installCmd := exec.Command(dockerBinary, "plugin", "install", "--grant-all-permissions", pluginName)
-	s.trustedCmd(installCmd)
-	out, _, err := runCommandWithOutput(installCmd)
-
-	c.Assert(err, check.NotNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Error: remote trust data does not exist", check.Commentf(out))
+	icmd.RunCmd(icmd.Command(dockerBinary, "plugin", "install", "--grant-all-permissions", pluginName), trustedCmd).Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err:      "Error: remote trust data does not exist",
+	})
 }
 
 func (s *DockerSuite) TestPluginIDPrefix(c *check.C) {

--- a/integration-cli/docker_cli_proxy_test.go
+++ b/integration-cli/docker_cli_proxy_test.go
@@ -2,20 +2,19 @@ package main
 
 import (
 	"net"
-	"os/exec"
 	"strings"
 
-	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/docker/docker/integration-cli/checker"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestCLIProxyDisableProxyUnixSock(c *check.C) {
 	testRequires(c, DaemonIsLinux, SameHostDaemon)
 
-	icmd.RunCmd(icm.Cmd{
+	icmd.RunCmd(icmd.Cmd{
 		Command: []string{dockerBinary, "info"},
-		Env: appendBaseEnv(false, "HTTP_PROXY=http://127.0.0.1:9999"),
+		Env:     appendBaseEnv(false, "HTTP_PROXY=http://127.0.0.1:9999"),
 	}).Assert(c, icmd.Success)
 }
 
@@ -42,11 +41,11 @@ func (s *DockerDaemonSuite) TestCLIProxyProxyTCPSock(c *check.C) {
 
 	icmd.RunCmd(icmd.Cmd{
 		Command: []string{dockerBinary, "info"},
-		Env: []string{"DOCKER_HOST=tcp://" + ip + ":2375", "HTTP_PROXY=127.0.0.1:9999"},
-	}).Assert(c, icmd.Expected{Error:"exit status 1", ExitCode: 1})
+		Env:     []string{"DOCKER_HOST=tcp://" + ip + ":2375", "HTTP_PROXY=127.0.0.1:9999"},
+	}).Assert(c, icmd.Expected{Error: "exit status 1", ExitCode: 1})
 	// Test with no_proxy
-	icmd.RunCommand(icmd.Cmd{
+	icmd.RunCmd(icmd.Cmd{
 		Command: []string{dockerBinary, "info"},
-		Env: []string{"DOCKER_HOST=tcp://" + ip + ":2375", "HTTP_PROXY=127.0.0.1:9999", "NO_PROXY="+ip},
+		Env:     []string{"DOCKER_HOST=tcp://" + ip + ":2375", "HTTP_PROXY=127.0.0.1:9999", "NO_PROXY=" + ip},
 	}).Assert(c, icmd.Success)
 }

--- a/integration-cli/docker_cli_proxy_test.go
+++ b/integration-cli/docker_cli_proxy_test.go
@@ -5,20 +5,18 @@ import (
 	"os/exec"
 	"strings"
 
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestCLIProxyDisableProxyUnixSock(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	testRequires(c, SameHostDaemon) // test is valid when DOCKER_HOST=unix://..
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 
-	cmd := exec.Command(dockerBinary, "info")
-	cmd.Env = appendBaseEnv(false, "HTTP_PROXY=http://127.0.0.1:9999")
-
-	out, _, err := runCommandWithOutput(cmd)
-	c.Assert(err, checker.IsNil, check.Commentf("%v", out))
-
+	icmd.RunCmd(icm.Cmd{
+		Command: []string{dockerBinary, "info"},
+		Env: appendBaseEnv(false, "HTTP_PROXY=http://127.0.0.1:9999"),
+	}).Assert(c, icmd.Success)
 }
 
 // Can't use localhost here since go has a special case to not use proxy if connecting to localhost
@@ -41,12 +39,14 @@ func (s *DockerDaemonSuite) TestCLIProxyProxyTCPSock(c *check.C) {
 	c.Assert(ip, checker.Not(checker.Equals), "")
 
 	s.d.Start(c, "-H", "tcp://"+ip+":2375")
-	cmd := exec.Command(dockerBinary, "info")
-	cmd.Env = []string{"DOCKER_HOST=tcp://" + ip + ":2375", "HTTP_PROXY=127.0.0.1:9999"}
-	out, _, err := runCommandWithOutput(cmd)
-	c.Assert(err, checker.NotNil, check.Commentf("%v", out))
+
+	icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "info"},
+		Env: []string{"DOCKER_HOST=tcp://" + ip + ":2375", "HTTP_PROXY=127.0.0.1:9999"},
+	}).Assert(c, icmd.Expected{Error:"exit status 1", ExitCode: 1})
 	// Test with no_proxy
-	cmd.Env = append(cmd.Env, "NO_PROXY="+ip)
-	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "info"))
-	c.Assert(err, checker.IsNil, check.Commentf("%v", out))
+	icmd.RunCommand(icmd.Cmd{
+		Command: []string{dockerBinary, "info"},
+		Env: []string{"DOCKER_HOST=tcp://" + ip + ":2375", "HTTP_PROXY=127.0.0.1:9999", "NO_PROXY="+ip},
+	}).Assert(c, icmd.Success)
 }

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -669,22 +669,19 @@ func (s *DockerSuite) TestPsImageIDAfterUpdate(c *check.C) {
 	originalImageName := "busybox:TestPsImageIDAfterUpdate-original"
 	updatedImageName := "busybox:TestPsImageIDAfterUpdate-updated"
 
-	runCmd := exec.Command(dockerBinary, "tag", "busybox:latest", originalImageName)
-	out, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, checker.IsNil)
+	icmd.RunCommand(dockerBinary, "tag", "busybox:latest", originalImageName).Assert(c, icmd.Success)
 
 	originalImageID, err := getIDByName(originalImageName)
 	c.Assert(err, checker.IsNil)
 
-	runCmd = exec.Command(dockerBinary, append([]string{"run", "-d", originalImageName}, sleepCommandForDaemonPlatform()...)...)
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, checker.IsNil)
-	containerID := strings.TrimSpace(out)
+	result := icmd.RunCommand(dockerBinary, append([]string{"run", "-d", originalImageName}, sleepCommandForDaemonPlatform()...)...)
+	result.Assert(c, icmd.Success)
+	containerID := strings.TrimSpace(result.Combined())
 
-	linesOut, err := exec.Command(dockerBinary, "ps", "--no-trunc").CombinedOutput()
-	c.Assert(err, checker.IsNil)
+	result = icmd.RunCommand(dockerBinary, "ps", "--no-trunc")
+	result.Assert(c, icmd.Success)
 
-	lines := strings.Split(strings.TrimSpace(string(linesOut)), "\n")
+	lines := strings.Split(strings.TrimSpace(string(result.Combined())), "\n")
 	// skip header
 	lines = lines[1:]
 	c.Assert(len(lines), checker.Equals, 1)
@@ -694,18 +691,13 @@ func (s *DockerSuite) TestPsImageIDAfterUpdate(c *check.C) {
 		c.Assert(f[1], checker.Equals, originalImageName)
 	}
 
-	runCmd = exec.Command(dockerBinary, "commit", containerID, updatedImageName)
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, checker.IsNil)
+	icmd.RunCommand(dockerBinary, "commit", containerID, updatedImageName).Assert(c, icmd.Success)
+	icmd.RunCommand(dockerBinary, "tag", updatedImageName, originalImageName).Assert(c, icmd.Success)
 
-	runCmd = exec.Command(dockerBinary, "tag", updatedImageName, originalImageName)
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, checker.IsNil)
+	result = icmd.RunCommand(dockerBinary, "ps", "--no-trunc")
+	result.Assert(c, icmd.Success)
 
-	linesOut, err = exec.Command(dockerBinary, "ps", "--no-trunc").CombinedOutput()
-	c.Assert(err, checker.IsNil)
-
-	lines = strings.Split(strings.TrimSpace(string(linesOut)), "\n")
+	lines = strings.Split(strings.TrimSpace(string(result.Combined())), "\n")
 	// skip header
 	lines = lines[1:]
 	c.Assert(len(lines), checker.Equals, 1)

--- a/integration-cli/docker_cli_pull_local_test.go
+++ b/integration-cli/docker_cli_pull_local_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/digest"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema2"
@@ -87,8 +88,8 @@ func testConcurrentPullWholeRepo(c *check.C) {
 
 	for i := 0; i != numPulls; i++ {
 		go func() {
-			_, _, err := runCommandWithOutput(exec.Command(dockerBinary, "pull", "-a", repoName))
-			results <- err
+			result := icmd.RunCommand(dockerBinary, "pull", "-a", repoName)
+			results <- result.Error
 		}()
 	}
 
@@ -125,8 +126,8 @@ func testConcurrentFailingPull(c *check.C) {
 
 	for i := 0; i != numPulls; i++ {
 		go func() {
-			_, _, err := runCommandWithOutput(exec.Command(dockerBinary, "pull", repoName+":asdfasdf"))
-			results <- err
+			result := icmd.RunCommand(dockerBinary, "pull", repoName+":asdfasdf")
+			results <- result.Error
 		}()
 	}
 
@@ -175,8 +176,8 @@ func testConcurrentPullMultipleTags(c *check.C) {
 
 	for _, repo := range repos {
 		go func(repo string) {
-			_, _, err := runCommandWithOutput(exec.Command(dockerBinary, "pull", repo))
-			results <- err
+			result := icmd.RunCommand(dockerBinary, "pull", repo)
+			results <- result.Error
 		}(repo)
 	}
 

--- a/integration-cli/docker_cli_pull_local_test.go
+++ b/integration-cli/docker_cli_pull_local_test.go
@@ -5,18 +5,17 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/digest"
-	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/docker/integration-cli/checker"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
 

--- a/integration-cli/docker_cli_pull_trusted_test.go
+++ b/integration-cli/docker_cli_pull_trusted_test.go
@@ -3,12 +3,11 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"os/exec"
-	"strings"
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/pkg/testutil"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
 
@@ -16,33 +15,18 @@ func (s *DockerTrustSuite) TestTrustedPull(c *check.C) {
 	repoName := s.setupTrustedImage(c, "trusted-pull")
 
 	// Try pull
-	pullCmd := exec.Command(dockerBinary, "pull", repoName)
-	s.trustedCmd(pullCmd)
-	out, _, err := runCommandWithOutput(pullCmd)
-
-	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Tagging", check.Commentf(out))
+	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd).Assert(c, SuccessTagging)
 
 	dockerCmd(c, "rmi", repoName)
 	// Try untrusted pull to ensure we pushed the tag to the registry
-	pullCmd = exec.Command(dockerBinary, "pull", "--disable-content-trust=true", repoName)
-	s.trustedCmd(pullCmd)
-	out, _, err = runCommandWithOutput(pullCmd)
-	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Status: Downloaded", check.Commentf(out))
-
+	icmd.RunCmd(icmd.Command(dockerBinary, "pull", "--disable-content-trust=true", repoName), trustedCmd).Assert(c, SuccessDownloaded)
 }
 
 func (s *DockerTrustSuite) TestTrustedIsolatedPull(c *check.C) {
 	repoName := s.setupTrustedImage(c, "trusted-isolated-pull")
 
 	// Try pull (run from isolated directory without trust information)
-	pullCmd := exec.Command(dockerBinary, "--config", "/tmp/docker-isolated", "pull", repoName)
-	s.trustedCmd(pullCmd)
-	out, _, err := runCommandWithOutput(pullCmd)
-
-	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Tagging", check.Commentf(string(out)))
+	icmd.RunCmd(icmd.Command(dockerBinary, "--config", "/tmp/docker-isolated", "pull", repoName), trustedCmd).Assert(c, SuccessTagging)
 
 	dockerCmd(c, "rmi", repoName)
 }
@@ -55,12 +39,10 @@ func (s *DockerTrustSuite) TestUntrustedPull(c *check.C) {
 	dockerCmd(c, "rmi", repoName)
 
 	// Try trusted pull on untrusted tag
-	pullCmd := exec.Command(dockerBinary, "pull", repoName)
-	s.trustedCmd(pullCmd)
-	out, _, err := runCommandWithOutput(pullCmd)
-
-	c.Assert(err, check.NotNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Error: remote trust data does not exist", check.Commentf(out))
+	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err:      "Error: remote trust data does not exist",
+	})
 }
 
 func (s *DockerTrustSuite) TestPullWhenCertExpired(c *check.C) {
@@ -72,22 +54,19 @@ func (s *DockerTrustSuite) TestPullWhenCertExpired(c *check.C) {
 
 	testutil.RunAtDifferentDate(elevenYearsFromNow, func() {
 		// Try pull
-		pullCmd := exec.Command(dockerBinary, "pull", repoName)
-		s.trustedCmd(pullCmd)
-		out, _, err := runCommandWithOutput(pullCmd)
-
-		c.Assert(err, check.NotNil, check.Commentf(out))
-		c.Assert(string(out), checker.Contains, "could not validate the path to a trusted root", check.Commentf(out))
+		icmd.RunCmd(icmd.Cmd{
+			Command: []string{dockerBinary, "pull", repoName},
+		}, trustedCmd).Assert(c, icmd.Expected{
+			ExitCode: 1,
+			Err:      "could not validate the path to a trusted root",
+		})
 	})
 
 	testutil.RunAtDifferentDate(elevenYearsFromNow, func() {
 		// Try pull
-		pullCmd := exec.Command(dockerBinary, "pull", "--disable-content-trust", repoName)
-		s.trustedCmd(pullCmd)
-		out, _, err := runCommandWithOutput(pullCmd)
-
-		c.Assert(err, check.IsNil, check.Commentf(out))
-		c.Assert(string(out), checker.Contains, "Status: Downloaded", check.Commentf(out))
+		icmd.RunCmd(icmd.Cmd{
+			Command: []string{dockerBinary, "pull", "--disable-content-trust", repoName},
+		}, trustedCmd).Assert(c, SuccessDownloaded)
 	})
 }
 
@@ -101,21 +80,11 @@ func (s *DockerTrustSuite) TestTrustedPullFromBadTrustServer(c *check.C) {
 	// tag the image and upload it to the private registry
 	dockerCmd(c, "tag", "busybox", repoName)
 
-	pushCmd := exec.Command(dockerBinary, "push", repoName)
-	s.trustedCmd(pushCmd)
-	out, _, err := runCommandWithOutput(pushCmd)
-
-	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Signing and pushing trust metadata", check.Commentf(out))
+	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 	dockerCmd(c, "rmi", repoName)
 
 	// Try pull
-	pullCmd := exec.Command(dockerBinary, "pull", repoName)
-	s.trustedCmd(pullCmd)
-	out, _, err = runCommandWithOutput(pullCmd)
-
-	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Tagging", check.Commentf(out))
+	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd).Assert(c, SuccessTagging)
 	dockerCmd(c, "rmi", repoName)
 
 	// Kill the notary server, start a new "evil" one.
@@ -129,23 +98,13 @@ func (s *DockerTrustSuite) TestTrustedPullFromBadTrustServer(c *check.C) {
 	dockerCmd(c, "--config", evilLocalConfigDir, "tag", "busybox", repoName)
 
 	// Push up to the new server
-	pushCmd = exec.Command(dockerBinary, "--config", evilLocalConfigDir, "push", repoName)
-	s.trustedCmd(pushCmd)
-	out, _, err = runCommandWithOutput(pushCmd)
-
-	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Signing and pushing trust metadata", check.Commentf(out))
+	icmd.RunCmd(icmd.Command(dockerBinary, "--config", evilLocalConfigDir, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 
 	// Now, try pulling with the original client from this new trust server. This should fail because the new root is invalid.
-	pullCmd = exec.Command(dockerBinary, "pull", repoName)
-	s.trustedCmd(pullCmd)
-	out, _, err = runCommandWithOutput(pullCmd)
-	if err == nil {
-		c.Fatalf("Continuing with cached data even though it's an invalid root rotation: %s\n%s", err, out)
-	}
-	if !strings.Contains(out, "could not rotate trust to a new trusted root") {
-		c.Fatalf("Missing expected output on trusted pull:\n%s", out)
-	}
+	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err:      "could not rotate trust to a new trusted root",
+	})
 }
 
 func (s *DockerTrustSuite) TestTrustedPullWithExpiredSnapshot(c *check.C) {
@@ -155,13 +114,7 @@ func (s *DockerTrustSuite) TestTrustedPullWithExpiredSnapshot(c *check.C) {
 	dockerCmd(c, "tag", "busybox", repoName)
 
 	// Push with default passphrases
-	pushCmd := exec.Command(dockerBinary, "push", repoName)
-	s.trustedCmd(pushCmd)
-	out, _, err := runCommandWithOutput(pushCmd)
-
-	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Signing and pushing trust metadata", check.Commentf(out))
-
+	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 	dockerCmd(c, "rmi", repoName)
 
 	// Snapshots last for three years. This should be expired
@@ -169,41 +122,28 @@ func (s *DockerTrustSuite) TestTrustedPullWithExpiredSnapshot(c *check.C) {
 
 	testutil.RunAtDifferentDate(fourYearsLater, func() {
 		// Try pull
-		pullCmd := exec.Command(dockerBinary, "pull", repoName)
-		s.trustedCmd(pullCmd)
-		out, _, err = runCommandWithOutput(pullCmd)
-
-		c.Assert(err, check.NotNil, check.Commentf("Missing expected error running trusted pull with expired snapshots"))
-		c.Assert(string(out), checker.Contains, "repository out-of-date", check.Commentf(out))
+		icmd.RunCmd(icmd.Cmd{
+			Command: []string{dockerBinary, "pull", repoName},
+		}, trustedCmd).Assert(c, icmd.Expected{
+			ExitCode: 1,
+			Err:      "repository out-of-date",
+		})
 	})
 }
 
 func (s *DockerTrustSuite) TestTrustedOfflinePull(c *check.C) {
 	repoName := s.setupTrustedImage(c, "trusted-offline-pull")
 
-	pullCmd := exec.Command(dockerBinary, "pull", repoName)
-	s.trustedCmdWithServer(pullCmd, "https://invalidnotaryserver")
-	out, _, err := runCommandWithOutput(pullCmd)
-
-	c.Assert(err, check.NotNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "error contacting notary server", check.Commentf(out))
+	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmdWithServer("https://invalidnotaryserver")).Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err:      "error contacting notary server",
+	})
 	// Do valid trusted pull to warm cache
-	pullCmd = exec.Command(dockerBinary, "pull", repoName)
-	s.trustedCmd(pullCmd)
-	out, _, err = runCommandWithOutput(pullCmd)
-
-	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Tagging", check.Commentf(out))
-
+	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd).Assert(c, SuccessTagging)
 	dockerCmd(c, "rmi", repoName)
 
 	// Try pull again with invalid notary server, should use cache
-	pullCmd = exec.Command(dockerBinary, "pull", repoName)
-	s.trustedCmdWithServer(pullCmd, "https://invalidnotaryserver")
-	out, _, err = runCommandWithOutput(pullCmd)
-
-	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Tagging", check.Commentf(out))
+	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmdWithServer("https://invalidnotaryserver")).Assert(c, SuccessTagging)
 }
 
 func (s *DockerTrustSuite) TestTrustedPullDelete(c *check.C) {
@@ -214,29 +154,16 @@ func (s *DockerTrustSuite) TestTrustedPullDelete(c *check.C) {
                     CMD echo trustedpulldelete
                 `, true)
 
-	pushCmd := exec.Command(dockerBinary, "push", repoName)
-	s.trustedCmd(pushCmd)
-	out, _, err := runCommandWithOutput(pushCmd)
-	if err != nil {
-		c.Fatalf("Error running trusted push: %s\n%s", err, out)
-	}
-	if !strings.Contains(string(out), "Signing and pushing trust metadata") {
-		c.Fatalf("Missing expected output on trusted push:\n%s", out)
-	}
+	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 
-	if out, status := dockerCmd(c, "rmi", repoName); status != 0 {
-		c.Fatalf("Error removing image %q\n%s", repoName, out)
-	}
+	dockerCmd(c, "rmi", repoName)
 
 	// Try pull
-	pullCmd := exec.Command(dockerBinary, "pull", repoName)
-	s.trustedCmd(pullCmd)
-	out, _, err = runCommandWithOutput(pullCmd)
+	result := icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd)
+	result.Assert(c, icmd.Success)
 
-	c.Assert(err, check.IsNil, check.Commentf(out))
-
-	matches := digestRegex.FindStringSubmatch(out)
-	c.Assert(matches, checker.HasLen, 2, check.Commentf("unable to parse digest from pull output: %s", out))
+	matches := digestRegex.FindStringSubmatch(result.Combined())
+	c.Assert(matches, checker.HasLen, 2, check.Commentf("unable to parse digest from pull output: %s", result.Combined()))
 	pullDigest := matches[1]
 
 	imageID := inspectField(c, repoName, "Id")
@@ -263,18 +190,13 @@ func (s *DockerTrustSuite) TestTrustedPullReadsFromReleasesRole(c *check.C) {
 
 	// Push with targets first, initializing the repo
 	dockerCmd(c, "tag", "busybox", targetName)
-	pushCmd := exec.Command(dockerBinary, "push", targetName)
-	s.trustedCmd(pushCmd)
-	out, _, err := runCommandWithOutput(pushCmd)
-	c.Assert(err, check.IsNil, check.Commentf(out))
+	icmd.RunCmd(icmd.Command(dockerBinary, "push", targetName), trustedCmd).Assert(c, icmd.Success)
 	s.assertTargetInRoles(c, repoName, "latest", "targets")
 
 	// Try pull, check we retrieve from targets role
-	pullCmd := exec.Command(dockerBinary, "-D", "pull", repoName)
-	s.trustedCmd(pullCmd)
-	out, _, err = runCommandWithOutput(pullCmd)
-	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "retrieving target for targets role")
+	icmd.RunCmd(icmd.Command(dockerBinary, "-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+		Err: "retrieving target for targets role",
+	})
 
 	// Now we'll create the releases role, and try pushing and pulling
 	s.notaryCreateDelegation(c, repoName, "targets/releases", s.not.keys[0].Public)
@@ -283,31 +205,23 @@ func (s *DockerTrustSuite) TestTrustedPullReadsFromReleasesRole(c *check.C) {
 
 	// try a pull, check that we can still pull because we can still read the
 	// old tag in the targets role
-	pullCmd = exec.Command(dockerBinary, "-D", "pull", repoName)
-	s.trustedCmd(pullCmd)
-	out, _, err = runCommandWithOutput(pullCmd)
-	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "retrieving target for targets role")
+	icmd.RunCmd(icmd.Command(dockerBinary, "-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+		Err: "retrieving target for targets role",
+	})
 
 	// try a pull -a, check that it succeeds because we can still pull from the
 	// targets role
-	pullCmd = exec.Command(dockerBinary, "-D", "pull", "-a", repoName)
-	s.trustedCmd(pullCmd)
-	out, _, err = runCommandWithOutput(pullCmd)
-	c.Assert(err, check.IsNil, check.Commentf(out))
+	icmd.RunCmd(icmd.Command(dockerBinary, "-D", "pull", "-a", repoName), trustedCmd).Assert(c, icmd.Success)
 
 	// Push, should sign with targets/releases
 	dockerCmd(c, "tag", "busybox", targetName)
-	pushCmd = exec.Command(dockerBinary, "push", targetName)
-	s.trustedCmd(pushCmd)
-	out, _, err = runCommandWithOutput(pushCmd)
+	icmd.RunCmd(icmd.Command(dockerBinary, "push", targetName), trustedCmd).Assert(c, icmd.Success)
 	s.assertTargetInRoles(c, repoName, "latest", "targets", "targets/releases")
 
 	// Try pull, check we retrieve from targets/releases role
-	pullCmd = exec.Command(dockerBinary, "-D", "pull", repoName)
-	s.trustedCmd(pullCmd)
-	out, _, err = runCommandWithOutput(pullCmd)
-	c.Assert(out, checker.Contains, "retrieving target for targets/releases role")
+	icmd.RunCmd(icmd.Command(dockerBinary, "-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+		Err: "retrieving target for targets/releases role",
+	})
 
 	// Create another delegation that we'll sign with
 	s.notaryCreateDelegation(c, repoName, "targets/other", s.not.keys[1].Public)
@@ -315,16 +229,13 @@ func (s *DockerTrustSuite) TestTrustedPullReadsFromReleasesRole(c *check.C) {
 	s.notaryPublish(c, repoName)
 
 	dockerCmd(c, "tag", "busybox", targetName)
-	pushCmd = exec.Command(dockerBinary, "push", targetName)
-	s.trustedCmd(pushCmd)
-	out, _, err = runCommandWithOutput(pushCmd)
+	icmd.RunCmd(icmd.Command(dockerBinary, "push", targetName), trustedCmd).Assert(c, icmd.Success)
 	s.assertTargetInRoles(c, repoName, "latest", "targets", "targets/releases", "targets/other")
 
 	// Try pull, check we retrieve from targets/releases role
-	pullCmd = exec.Command(dockerBinary, "-D", "pull", repoName)
-	s.trustedCmd(pullCmd)
-	out, _, err = runCommandWithOutput(pullCmd)
-	c.Assert(out, checker.Contains, "retrieving target for targets/releases role")
+	icmd.RunCmd(icmd.Command(dockerBinary, "-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+		Err: "retrieving target for targets/releases role",
+	})
 }
 
 func (s *DockerTrustSuite) TestTrustedPullIgnoresOtherDelegationRoles(c *check.C) {
@@ -341,26 +252,22 @@ func (s *DockerTrustSuite) TestTrustedPullIgnoresOtherDelegationRoles(c *check.C
 
 	// Push should write to the delegation role, not targets
 	dockerCmd(c, "tag", "busybox", targetName)
-	pushCmd := exec.Command(dockerBinary, "push", targetName)
-	s.trustedCmd(pushCmd)
-	out, _, err := runCommandWithOutput(pushCmd)
-	c.Assert(err, check.IsNil, check.Commentf(out))
+	icmd.RunCmd(icmd.Command(dockerBinary, "push", targetName), trustedCmd).Assert(c, icmd.Success)
 	s.assertTargetInRoles(c, repoName, "latest", "targets/other")
 	s.assertTargetNotInRoles(c, repoName, "latest", "targets")
 
 	// Try pull - we should fail, since pull will only pull from the targets/releases
 	// role or the targets role
-	pullCmd := exec.Command(dockerBinary, "-D", "pull", repoName)
-	s.trustedCmd(pullCmd)
-	out, _, err = runCommandWithOutput(pullCmd)
-	c.Assert(err, check.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "No trust data for")
+	dockerCmd(c, "tag", "busybox", targetName)
+	icmd.RunCmd(icmd.Command(dockerBinary, "-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err:      "No trust data for",
+	})
 
 	// try a pull -a: we should fail since pull will only pull from the targets/releases
 	// role or the targets role
-	pullCmd = exec.Command(dockerBinary, "-D", "pull", "-a", repoName)
-	s.trustedCmd(pullCmd)
-	out, _, err = runCommandWithOutput(pullCmd)
-	c.Assert(err, check.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "No trusted tags for")
+	icmd.RunCmd(icmd.Command(dockerBinary, "-D", "pull", "-a", repoName), trustedCmd).Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err:      "No trusted tags for",
+	})
 }

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -2,13 +2,12 @@ package main
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
-	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/pkg/stringid"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
 
@@ -179,7 +178,7 @@ func (s *DockerSuite) TestRmiForceWithExistingContainers(c *check.C) {
 	icmd.RunCmd(icmd.Cmd{
 		Command: []string{dockerBinary, "build", "--no-cache", "-t", image, "-"},
 		Stdin: strings.NewReader(`FROM busybox
-MAINTAINER foo`)
+MAINTAINER foo`),
 	}).Assert(c, icmd.Success)
 
 	dockerCmd(c, "run", "--name", "test-force-rmi", image, "/bin/true")

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/go-check/check"
@@ -175,12 +176,11 @@ func (s *DockerSuite) TestRmiTagWithExistingContainers(c *check.C) {
 func (s *DockerSuite) TestRmiForceWithExistingContainers(c *check.C) {
 	image := "busybox-clone"
 
-	cmd := exec.Command(dockerBinary, "build", "--no-cache", "-t", image, "-")
-	cmd.Stdin = strings.NewReader(`FROM busybox
+	icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "build", "--no-cache", "-t", image, "-"},
+		Stdin: strings.NewReader(`FROM busybox
 MAINTAINER foo`)
-
-	out, _, err := runCommandWithOutput(cmd)
-	c.Assert(err, checker.IsNil, check.Commentf("Could not build %s: %s", image, out))
+	}).Assert(c, icmd.Success)
 
 	dockerCmd(c, "run", "--name", "test-force-rmi", image, "/bin/true")
 

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -909,7 +909,7 @@ func (s *DockerSuite) TestRunSysctls(c *check.C) {
 
 	icmd.RunCommand(dockerBinary, "run", "--sysctl", "kernel.foobar=1", "--name", "test2",
 		"busybox", "cat", "/proc/sys/kernel/foobar").Assert(c, icmd.Expected{
-		ExitCode: 1,
+		ExitCode: 125,
 		Err:      "invalid argument",
 	})
 }
@@ -939,7 +939,7 @@ func (s *DockerSuite) TestRunSeccompProfileDenyUnshare(c *check.C) {
 		"--security-opt", "seccomp="+tmpFile.Name(),
 		"debian:jessie", "unshare", "-p", "-m", "-f", "-r", "mount", "-t", "proc", "none", "/proc").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 }
 
@@ -973,7 +973,7 @@ func (s *DockerSuite) TestRunSeccompProfileDenyChmod(c *check.C) {
 	icmd.RunCommand(dockerBinary, "run", "--security-opt", "seccomp="+tmpFile.Name(),
 		"busybox", "chmod", "400", "/etc/hostname").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 }
 
@@ -1011,7 +1011,7 @@ func (s *DockerSuite) TestRunSeccompProfileDenyUnshareUserns(c *check.C) {
 		"--security-opt", "apparmor=unconfined", "--security-opt", "seccomp="+tmpFile.Name(),
 		"debian:jessie", "unshare", "--map-root-user", "--user", "sh", "-c", "whoami").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 }
 
@@ -1023,7 +1023,7 @@ func (s *DockerSuite) TestRunSeccompProfileDenyCloneUserns(c *check.C) {
 
 	icmd.RunCommand(dockerBinary, "run", "syscall-test", "userns-test", "id").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "clone failed: Operation not permitted",
+		Err:      "clone failed: Operation not permitted",
 	})
 }
 
@@ -1152,16 +1152,16 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesChown(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_CHOWN
-	dockerCmd("run", "busybox", "chown", "100", "/tmp")
+	dockerCmd(c, "run", "busybox", "chown", "100", "/tmp")
 	// test that non root user does not have default capability CAP_CHOWN
 	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "busybox", "chown", "100", "/tmp").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 	// test that root user can drop default capability CAP_CHOWN
 	icmd.RunCommand(dockerBinary, "run", "--cap-drop", "chown", "busybox", "chown", "100", "/tmp").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 }
 
@@ -1170,11 +1170,11 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesDacOverride(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_DAC_OVERRIDE
-	dockerCmd("run", "busybox", "sh", "-c", "echo test > /etc/passwd")
+	dockerCmd(c, "run", "busybox", "sh", "-c", "echo test > /etc/passwd")
 	// test that non root user does not have default capability CAP_DAC_OVERRIDE
 	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "busybox", "sh", "-c", "echo test > /etc/passwd").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Permission denied",
+		Err:      "Permission denied",
 	})
 }
 
@@ -1183,11 +1183,11 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesFowner(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_FOWNER
-	dockerCmd("run", "busybox", "chmod", "777", "/etc/passwd")
+	dockerCmd(c, "run", "busybox", "chmod", "777", "/etc/passwd")
 	// test that non root user does not have default capability CAP_FOWNER
 	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "busybox", "chmod", "777", "/etc/passwd").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 	// TODO test that root user can drop default capability CAP_FOWNER
 }
@@ -1199,16 +1199,16 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesSetuid(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_SETUID
-	dockerCmd("run", "syscall-test", "setuid-test")
+	dockerCmd(c, "run", "syscall-test", "setuid-test")
 	// test that non root user does not have default capability CAP_SETUID
 	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "syscall-test", "setuid-test").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 	// test that root user can drop default capability CAP_SETUID
 	icmd.RunCommand(dockerBinary, "run", "--cap-drop", "setuid", "syscall-test", "setuid-test").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 }
 
@@ -1217,16 +1217,16 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesSetgid(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_SETGID
-	dockerCmd("run", "syscall-test", "setgid-test")
+	dockerCmd(c, "run", "syscall-test", "setgid-test")
 	// test that non root user does not have default capability CAP_SETGID
 	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "syscall-test", "setgid-test").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 	// test that root user can drop default capability CAP_SETGID
 	icmd.RunCommand(dockerBinary, "run", "--cap-drop", "setgid", "syscall-test", "setgid-test").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 }
 
@@ -1237,16 +1237,16 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesNetBindService(c *check.C) 
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_NET_BIND_SERVICE
-	dockerCmd("run", "syscall-test", "socket-test")
+	dockerCmd(c, "run", "syscall-test", "socket-test")
 	// test that non root user does not have default capability CAP_NET_BIND_SERVICE
 	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "syscall-test", "socket-test").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Permission denied",
+		Err:      "Permission denied",
 	})
 	// test that root user can drop default capability CAP_NET_BIND_SERVICE
 	icmd.RunCommand(dockerBinary, "run", "--cap-drop", "net_bind_service", "syscall-test", "socket-test").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Permission denied",
+		Err:      "Permission denied",
 	})
 }
 
@@ -1255,16 +1255,16 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesNetRaw(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_NET_RAW
-	dockerCmd("run", "syscall-test", "raw-test")
+	dockerCmd(c, "run", "syscall-test", "raw-test")
 	// test that non root user does not have default capability CAP_NET_RAW
 	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "syscall-test", "raw-test").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 	// test that root user can drop default capability CAP_NET_RAW
 	icmd.RunCommand(dockerBinary, "run", "--cap-drop", "net_raw", "syscall-test", "raw-test").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 }
 
@@ -1273,16 +1273,16 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesChroot(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_SYS_CHROOT
-	dockerCmd("run", "busybox", "chroot", "/", "/bin/true")
+	dockerCmd(c, "run", "busybox", "chroot", "/", "/bin/true")
 	// test that non root user does not have default capability CAP_SYS_CHROOT
 	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "busybox", "chroot", "/", "/bin/true").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 	// test that root user can drop default capability CAP_SYS_CHROOT
 	icmd.RunCommand(dockerBinary, "run", "--cap-drop", "sys_chroot", "busybox", "chroot", "/", "/bin/true").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 }
 
@@ -1291,17 +1291,17 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesMknod(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_MKNOD
-	dockerCmd("run", "busybox", "mknod", "/tmp/node", "b", "1", "2")
+	dockerCmd(c, "run", "busybox", "mknod", "/tmp/node", "b", "1", "2")
 	// test that non root user does not have default capability CAP_MKNOD
 	// test that root user can drop default capability CAP_SYS_CHROOT
 	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "busybox", "mknod", "/tmp/node", "b", "1", "2").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 	// test that root user can drop default capability CAP_MKNOD
 	icmd.RunCommand(dockerBinary, "run", "--cap-drop", "mknod", "busybox", "mknod", "/tmp/node", "b", "1", "2").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err: "Operation not permitted",
+		Err:      "Operation not permitted",
 	})
 }
 
@@ -1315,13 +1315,13 @@ func (s *DockerSuite) TestRunApparmorProcDirectory(c *check.C) {
 	result := icmd.RunCommand(dockerBinary, "run", "--security-opt", "seccomp=unconfined", "busybox", "chmod", "777", "/proc/1/cgroup")
 	result.Assert(c, icmd.Expected{ExitCode: 1})
 	if !(strings.Contains(result.Combined(), "Permission denied") || strings.Contains(result.Combined(), "Operation not permitted")) {
-		c.Fatalf("expected chmod 777 /proc/1/cgroup to fail, got %s: %v", result.Combined(), err)
+		c.Fatalf("expected chmod 777 /proc/1/cgroup to fail, got %s: %v", result.Combined(), result.Error)
 	}
 
 	result = icmd.RunCommand(dockerBinary, "run", "--security-opt", "seccomp=unconfined", "busybox", "chmod", "777", "/proc/1/attr/current")
 	result.Assert(c, icmd.Expected{ExitCode: 1})
 	if !(strings.Contains(result.Combined(), "Permission denied") || strings.Contains(result.Combined(), "Operation not permitted")) {
-		c.Fatalf("expected chmod 777 /proc/1/attr/current to fail, got %s: %v", result.Combined(), err)
+		c.Fatalf("expected chmod 777 /proc/1/attr/current to fail, got %s: %v", result.Combined(), result.Error)
 	}
 }
 

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/sysinfo"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 	"github.com/kr/pty"
 )
@@ -884,7 +885,6 @@ func (s *DockerSuite) TestRunTmpfsMountsWithOptions(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunSysctls(c *check.C) {
-
 	testRequires(c, DaemonIsLinux)
 	var err error
 
@@ -907,11 +907,11 @@ func (s *DockerSuite) TestRunSysctls(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(sysctls["net.ipv4.ip_forward"], check.Equals, "0")
 
-	runCmd := exec.Command(dockerBinary, "run", "--sysctl", "kernel.foobar=1", "--name", "test2", "busybox", "cat", "/proc/sys/kernel/foobar")
-	out, _, _ = runCommandWithOutput(runCmd)
-	if !strings.Contains(out, "invalid argument") {
-		c.Fatalf("expected --sysctl to fail, got %s", out)
-	}
+	icmd.RunCommand(dockerBinary, "run", "--sysctl", "kernel.foobar=1", "--name", "test2",
+		"busybox", "cat", "/proc/sys/kernel/foobar").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err:      "invalid argument",
+	})
 }
 
 // TestRunSeccompProfileDenyUnshare checks that 'docker run --security-opt seccomp=/tmp/profile.json debian:jessie unshare' exits with operation not permitted.
@@ -935,11 +935,12 @@ func (s *DockerSuite) TestRunSeccompProfileDenyUnshare(c *check.C) {
 	if _, err := tmpFile.Write([]byte(jsonData)); err != nil {
 		c.Fatal(err)
 	}
-	runCmd := exec.Command(dockerBinary, "run", "--security-opt", "apparmor=unconfined", "--security-opt", "seccomp="+tmpFile.Name(), "debian:jessie", "unshare", "-p", "-m", "-f", "-r", "mount", "-t", "proc", "none", "/proc")
-	out, _, _ := runCommandWithOutput(runCmd)
-	if !strings.Contains(out, "Operation not permitted") {
-		c.Fatalf("expected unshare with seccomp profile denied to fail, got %s", out)
-	}
+	icmd.RunCommand(dockerBinary, "run", "--security-opt", "apparmor=unconfined",
+		"--security-opt", "seccomp="+tmpFile.Name(),
+		"debian:jessie", "unshare", "-p", "-m", "-f", "-r", "mount", "-t", "proc", "none", "/proc").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 }
 
 // TestRunSeccompProfileDenyChmod checks that 'docker run --security-opt seccomp=/tmp/profile.json busybox chmod 400 /etc/hostname' exits with operation not permitted.
@@ -969,11 +970,11 @@ func (s *DockerSuite) TestRunSeccompProfileDenyChmod(c *check.C) {
 	if _, err := tmpFile.Write([]byte(jsonData)); err != nil {
 		c.Fatal(err)
 	}
-	runCmd := exec.Command(dockerBinary, "run", "--security-opt", "seccomp="+tmpFile.Name(), "busybox", "chmod", "400", "/etc/hostname")
-	out, _, _ := runCommandWithOutput(runCmd)
-	if !strings.Contains(out, "Operation not permitted") {
-		c.Fatalf("expected chmod with seccomp profile denied to fail, got %s", out)
-	}
+	icmd.RunCommand(dockerBinary, "run", "--security-opt", "seccomp="+tmpFile.Name(),
+		"busybox", "chmod", "400", "/etc/hostname").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 }
 
 // TestRunSeccompProfileDenyUnshareUserns checks that 'docker run debian:jessie unshare --map-root-user --user sh -c whoami' with a specific profile to
@@ -1006,11 +1007,12 @@ func (s *DockerSuite) TestRunSeccompProfileDenyUnshareUserns(c *check.C) {
 	if _, err := tmpFile.Write([]byte(jsonData)); err != nil {
 		c.Fatal(err)
 	}
-	runCmd := exec.Command(dockerBinary, "run", "--security-opt", "apparmor=unconfined", "--security-opt", "seccomp="+tmpFile.Name(), "debian:jessie", "unshare", "--map-root-user", "--user", "sh", "-c", "whoami")
-	out, _, _ := runCommandWithOutput(runCmd)
-	if !strings.Contains(out, "Operation not permitted") {
-		c.Fatalf("expected unshare userns with seccomp profile denied to fail, got %s", out)
-	}
+	icmd.RunCommand(dockerBinary, "run",
+		"--security-opt", "apparmor=unconfined", "--security-opt", "seccomp="+tmpFile.Name(),
+		"debian:jessie", "unshare", "--map-root-user", "--user", "sh", "-c", "whoami").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 }
 
 // TestRunSeccompProfileDenyCloneUserns checks that 'docker run syscall-test'
@@ -1019,11 +1021,10 @@ func (s *DockerSuite) TestRunSeccompProfileDenyCloneUserns(c *check.C) {
 	testRequires(c, SameHostDaemon, seccompEnabled)
 	ensureSyscallTest(c)
 
-	runCmd := exec.Command(dockerBinary, "run", "syscall-test", "userns-test", "id")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err == nil || !strings.Contains(out, "clone failed: Operation not permitted") {
-		c.Fatalf("expected clone userns with default seccomp profile denied to fail, got %s: %v", out, err)
-	}
+	icmd.RunCommand(dockerBinary, "run", "syscall-test", "userns-test", "id").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "clone failed: Operation not permitted",
+	})
 }
 
 // TestRunSeccompUnconfinedCloneUserns checks that
@@ -1033,10 +1034,10 @@ func (s *DockerSuite) TestRunSeccompUnconfinedCloneUserns(c *check.C) {
 	ensureSyscallTest(c)
 
 	// make sure running w privileged is ok
-	runCmd := exec.Command(dockerBinary, "run", "--security-opt", "seccomp=unconfined", "syscall-test", "userns-test", "id")
-	if out, _, err := runCommandWithOutput(runCmd); err != nil || !strings.Contains(out, "nobody") {
-		c.Fatalf("expected clone userns with --security-opt seccomp=unconfined to succeed, got %s: %v", out, err)
-	}
+	icmd.RunCommand(dockerBinary, "run", "--security-opt", "seccomp=unconfined",
+		"syscall-test", "userns-test", "id").Assert(c, icmd.Expected{
+		Out: "nobody",
+	})
 }
 
 // TestRunSeccompAllowPrivCloneUserns checks that 'docker run --privileged syscall-test'
@@ -1046,10 +1047,9 @@ func (s *DockerSuite) TestRunSeccompAllowPrivCloneUserns(c *check.C) {
 	ensureSyscallTest(c)
 
 	// make sure running w privileged is ok
-	runCmd := exec.Command(dockerBinary, "run", "--privileged", "syscall-test", "userns-test", "id")
-	if out, _, err := runCommandWithOutput(runCmd); err != nil || !strings.Contains(out, "nobody") {
-		c.Fatalf("expected clone userns with --privileged to succeed, got %s: %v", out, err)
-	}
+	icmd.RunCommand(dockerBinary, "run", "--privileged", "syscall-test", "userns-test", "id").Assert(c, icmd.Expected{
+		Out: "nobody",
+	})
 }
 
 // TestRunSeccompProfileAllow32Bit checks that 32 bit code can run on x86_64
@@ -1058,10 +1058,7 @@ func (s *DockerSuite) TestRunSeccompProfileAllow32Bit(c *check.C) {
 	testRequires(c, SameHostDaemon, seccompEnabled, IsAmd64)
 	ensureSyscallTest(c)
 
-	runCmd := exec.Command(dockerBinary, "run", "syscall-test", "exit32-test", "id")
-	if out, _, err := runCommandWithOutput(runCmd); err != nil {
-		c.Fatalf("expected to be able to run 32 bit code, got %s: %v", out, err)
-	}
+	icmd.RunCommand(dockerBinary, "run", "syscall-test", "exit32-test", "id").Assert(c, icmd.Success)
 }
 
 // TestRunSeccompAllowSetrlimit checks that 'docker run debian:jessie ulimit -v 1048510' succeeds.
@@ -1069,10 +1066,7 @@ func (s *DockerSuite) TestRunSeccompAllowSetrlimit(c *check.C) {
 	testRequires(c, SameHostDaemon, seccompEnabled)
 
 	// ulimit uses setrlimit, so we want to make sure we don't break it
-	runCmd := exec.Command(dockerBinary, "run", "debian:jessie", "bash", "-c", "ulimit -v 1048510")
-	if out, _, err := runCommandWithOutput(runCmd); err != nil {
-		c.Fatalf("expected ulimit with seccomp to succeed, got %s: %v", out, err)
-	}
+	icmd.RunCommand(dockerBinary, "run", "debian:jessie", "bash", "-c", "ulimit -v 1048510").Assert(c, icmd.Success)
 }
 
 func (s *DockerSuite) TestRunSeccompDefaultProfileAcct(c *check.C) {
@@ -1147,10 +1141,10 @@ func (s *DockerSuite) TestRunNoNewPrivSetuid(c *check.C) {
 	ensureNNPTest(c)
 
 	// test that running a setuid binary results in no effective uid transition
-	runCmd := exec.Command(dockerBinary, "run", "--security-opt", "no-new-privileges", "--user", "1000", "nnp-test", "/usr/bin/nnp-test")
-	if out, _, err := runCommandWithOutput(runCmd); err != nil || !strings.Contains(out, "EUID=1000") {
-		c.Fatalf("expected output to contain EUID=1000, got %s: %v", out, err)
-	}
+	icmd.RunCommand(dockerBinary, "run", "--security-opt", "no-new-privileges", "--user", "1000",
+		"nnp-test", "/usr/bin/nnp-test").Assert(c, icmd.Expected{
+		Out: "EUID=1000",
+	})
 }
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesChown(c *check.C) {
@@ -1158,19 +1152,17 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesChown(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_CHOWN
-	runCmd := exec.Command(dockerBinary, "run", "busybox", "chown", "100", "/tmp")
-	_, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	dockerCmd("run", "busybox", "chown", "100", "/tmp")
 	// test that non root user does not have default capability CAP_CHOWN
-	runCmd = exec.Command(dockerBinary, "run", "--user", "1000:1000", "busybox", "chown", "100", "/tmp")
-	out, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Operation not permitted")
+	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "busybox", "chown", "100", "/tmp").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 	// test that root user can drop default capability CAP_CHOWN
-	runCmd = exec.Command(dockerBinary, "run", "--cap-drop", "chown", "busybox", "chown", "100", "/tmp")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Operation not permitted")
+	icmd.RunCommand(dockerBinary, "run", "--cap-drop", "chown", "busybox", "chown", "100", "/tmp").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 }
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesDacOverride(c *check.C) {
@@ -1178,15 +1170,12 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesDacOverride(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_DAC_OVERRIDE
-	runCmd := exec.Command(dockerBinary, "run", "busybox", "sh", "-c", "echo test > /etc/passwd")
-	_, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	dockerCmd("run", "busybox", "sh", "-c", "echo test > /etc/passwd")
 	// test that non root user does not have default capability CAP_DAC_OVERRIDE
-	runCmd = exec.Command(dockerBinary, "run", "--user", "1000:1000", "busybox", "sh", "-c", "echo test > /etc/passwd")
-	out, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Permission denied")
-	// TODO test that root user can drop default capability CAP_DAC_OVERRIDE
+	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "busybox", "sh", "-c", "echo test > /etc/passwd").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Permission denied",
+	})
 }
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesFowner(c *check.C) {
@@ -1194,14 +1183,12 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesFowner(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_FOWNER
-	runCmd := exec.Command(dockerBinary, "run", "busybox", "chmod", "777", "/etc/passwd")
-	_, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	dockerCmd("run", "busybox", "chmod", "777", "/etc/passwd")
 	// test that non root user does not have default capability CAP_FOWNER
-	runCmd = exec.Command(dockerBinary, "run", "--user", "1000:1000", "busybox", "chmod", "777", "/etc/passwd")
-	out, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Operation not permitted")
+	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "busybox", "chmod", "777", "/etc/passwd").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 	// TODO test that root user can drop default capability CAP_FOWNER
 }
 
@@ -1212,19 +1199,17 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesSetuid(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_SETUID
-	runCmd := exec.Command(dockerBinary, "run", "syscall-test", "setuid-test")
-	_, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	dockerCmd("run", "syscall-test", "setuid-test")
 	// test that non root user does not have default capability CAP_SETUID
-	runCmd = exec.Command(dockerBinary, "run", "--user", "1000:1000", "syscall-test", "setuid-test")
-	out, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Operation not permitted")
+	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "syscall-test", "setuid-test").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 	// test that root user can drop default capability CAP_SETUID
-	runCmd = exec.Command(dockerBinary, "run", "--cap-drop", "setuid", "syscall-test", "setuid-test")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Operation not permitted")
+	icmd.RunCommand(dockerBinary, "run", "--cap-drop", "setuid", "syscall-test", "setuid-test").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 }
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesSetgid(c *check.C) {
@@ -1232,19 +1217,17 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesSetgid(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_SETGID
-	runCmd := exec.Command(dockerBinary, "run", "syscall-test", "setgid-test")
-	_, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	dockerCmd("run", "syscall-test", "setgid-test")
 	// test that non root user does not have default capability CAP_SETGID
-	runCmd = exec.Command(dockerBinary, "run", "--user", "1000:1000", "syscall-test", "setgid-test")
-	out, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Operation not permitted")
+	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "syscall-test", "setgid-test").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 	// test that root user can drop default capability CAP_SETGID
-	runCmd = exec.Command(dockerBinary, "run", "--cap-drop", "setgid", "syscall-test", "setgid-test")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Operation not permitted")
+	icmd.RunCommand(dockerBinary, "run", "--cap-drop", "setgid", "syscall-test", "setgid-test").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 }
 
 // TODO CAP_SETPCAP
@@ -1254,19 +1237,17 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesNetBindService(c *check.C) 
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_NET_BIND_SERVICE
-	runCmd := exec.Command(dockerBinary, "run", "syscall-test", "socket-test")
-	_, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	dockerCmd("run", "syscall-test", "socket-test")
 	// test that non root user does not have default capability CAP_NET_BIND_SERVICE
-	runCmd = exec.Command(dockerBinary, "run", "--user", "1000:1000", "syscall-test", "socket-test")
-	out, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Permission denied")
+	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "syscall-test", "socket-test").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Permission denied",
+	})
 	// test that root user can drop default capability CAP_NET_BIND_SERVICE
-	runCmd = exec.Command(dockerBinary, "run", "--cap-drop", "net_bind_service", "syscall-test", "socket-test")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Permission denied")
+	icmd.RunCommand(dockerBinary, "run", "--cap-drop", "net_bind_service", "syscall-test", "socket-test").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Permission denied",
+	})
 }
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesNetRaw(c *check.C) {
@@ -1274,19 +1255,17 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesNetRaw(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_NET_RAW
-	runCmd := exec.Command(dockerBinary, "run", "syscall-test", "raw-test")
-	_, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	dockerCmd("run", "syscall-test", "raw-test")
 	// test that non root user does not have default capability CAP_NET_RAW
-	runCmd = exec.Command(dockerBinary, "run", "--user", "1000:1000", "syscall-test", "raw-test")
-	out, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Operation not permitted")
+	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "syscall-test", "raw-test").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 	// test that root user can drop default capability CAP_NET_RAW
-	runCmd = exec.Command(dockerBinary, "run", "--cap-drop", "net_raw", "syscall-test", "raw-test")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Operation not permitted")
+	icmd.RunCommand(dockerBinary, "run", "--cap-drop", "net_raw", "syscall-test", "raw-test").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 }
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesChroot(c *check.C) {
@@ -1294,19 +1273,17 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesChroot(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_SYS_CHROOT
-	runCmd := exec.Command(dockerBinary, "run", "busybox", "chroot", "/", "/bin/true")
-	_, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	dockerCmd("run", "busybox", "chroot", "/", "/bin/true")
 	// test that non root user does not have default capability CAP_SYS_CHROOT
-	runCmd = exec.Command(dockerBinary, "run", "--user", "1000:1000", "busybox", "chroot", "/", "/bin/true")
-	out, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Operation not permitted")
+	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "busybox", "chroot", "/", "/bin/true").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 	// test that root user can drop default capability CAP_SYS_CHROOT
-	runCmd = exec.Command(dockerBinary, "run", "--cap-drop", "sys_chroot", "busybox", "chroot", "/", "/bin/true")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Operation not permitted")
+	icmd.RunCommand(dockerBinary, "run", "--cap-drop", "sys_chroot", "busybox", "chroot", "/", "/bin/true").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 }
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesMknod(c *check.C) {
@@ -1314,19 +1291,18 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesMknod(c *check.C) {
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_MKNOD
-	runCmd := exec.Command(dockerBinary, "run", "busybox", "mknod", "/tmp/node", "b", "1", "2")
-	_, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	dockerCmd("run", "busybox", "mknod", "/tmp/node", "b", "1", "2")
 	// test that non root user does not have default capability CAP_MKNOD
-	runCmd = exec.Command(dockerBinary, "run", "--user", "1000:1000", "busybox", "mknod", "/tmp/node", "b", "1", "2")
-	out, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Operation not permitted")
+	// test that root user can drop default capability CAP_SYS_CHROOT
+	icmd.RunCommand(dockerBinary, "run", "--user", "1000:1000", "busybox", "mknod", "/tmp/node", "b", "1", "2").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 	// test that root user can drop default capability CAP_MKNOD
-	runCmd = exec.Command(dockerBinary, "run", "--cap-drop", "mknod", "busybox", "mknod", "/tmp/node", "b", "1", "2")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Operation not permitted")
+	icmd.RunCommand(dockerBinary, "run", "--cap-drop", "mknod", "busybox", "mknod", "/tmp/node", "b", "1", "2").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err: "Operation not permitted",
+	})
 }
 
 // TODO CAP_AUDIT_WRITE
@@ -1336,14 +1312,16 @@ func (s *DockerSuite) TestRunApparmorProcDirectory(c *check.C) {
 	testRequires(c, SameHostDaemon, Apparmor)
 
 	// running w seccomp unconfined tests the apparmor profile
-	runCmd := exec.Command(dockerBinary, "run", "--security-opt", "seccomp=unconfined", "busybox", "chmod", "777", "/proc/1/cgroup")
-	if out, _, err := runCommandWithOutput(runCmd); err == nil || !(strings.Contains(out, "Permission denied") || strings.Contains(out, "Operation not permitted")) {
-		c.Fatalf("expected chmod 777 /proc/1/cgroup to fail, got %s: %v", out, err)
+	result := icmd.RunCommand(dockerBinary, "run", "--security-opt", "seccomp=unconfined", "busybox", "chmod", "777", "/proc/1/cgroup")
+	result.Assert(c, icmd.Expected{ExitCode: 1})
+	if !(strings.Contains(result.Combined(), "Permission denied") || strings.Contains(result.Combined(), "Operation not permitted")) {
+		c.Fatalf("expected chmod 777 /proc/1/cgroup to fail, got %s: %v", result.Combined(), err)
 	}
 
-	runCmd = exec.Command(dockerBinary, "run", "--security-opt", "seccomp=unconfined", "busybox", "chmod", "777", "/proc/1/attr/current")
-	if out, _, err := runCommandWithOutput(runCmd); err == nil || !(strings.Contains(out, "Permission denied") || strings.Contains(out, "Operation not permitted")) {
-		c.Fatalf("expected chmod 777 /proc/1/attr/current to fail, got %s: %v", out, err)
+	result = icmd.RunCommand(dockerBinary, "run", "--security-opt", "seccomp=unconfined", "busybox", "chmod", "777", "/proc/1/attr/current")
+	result.Assert(c, icmd.Expected{ExitCode: 1})
+	if !(strings.Contains(result.Combined(), "Permission denied") || strings.Contains(result.Combined(), "Operation not permitted")) {
+		c.Fatalf("expected chmod 777 /proc/1/attr/current to fail, got %s: %v", result.Combined(), err)
 	}
 }
 

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1439,7 +1439,7 @@ func (s *DockerTrustedSwarmSuite) TestTrustedServiceCreate(c *check.C) {
 
 	name := "trusted"
 	serviceCmd := d.Command("-D", "service", "create", "--name", name, repoName, "top")
-	s.trustSuite.trustedCmd(serviceCmd)
+	trustedExecCmd(serviceCmd)
 	out, _, err := runCommandWithOutput(serviceCmd)
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 	c.Assert(out, checker.Contains, "resolved image tag to", check.Commentf(out))
@@ -1458,7 +1458,7 @@ func (s *DockerTrustedSwarmSuite) TestTrustedServiceCreate(c *check.C) {
 
 	name = "untrusted"
 	serviceCmd = d.Command("service", "create", "--name", name, repoName, "top")
-	s.trustSuite.trustedCmd(serviceCmd)
+	trustedExecCmd(serviceCmd)
 	out, _, err = runCommandWithOutput(serviceCmd)
 
 	c.Assert(err, check.NotNil, check.Commentf(out))
@@ -1487,7 +1487,7 @@ func (s *DockerTrustedSwarmSuite) TestTrustedServiceUpdate(c *check.C) {
 	c.Assert(out, check.Not(checker.Contains), repoName+"@", check.Commentf(out))
 
 	serviceCmd := d.Command("-D", "service", "update", "--image", repoName, name)
-	s.trustSuite.trustedCmd(serviceCmd)
+	trustedExecCmd(serviceCmd)
 	out, _, err = runCommandWithOutput(serviceCmd)
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 	c.Assert(out, checker.Contains, "resolved image tag to", check.Commentf(out))
@@ -1505,7 +1505,7 @@ func (s *DockerTrustedSwarmSuite) TestTrustedServiceUpdate(c *check.C) {
 	dockerCmd(c, "rmi", repoName)
 
 	serviceCmd = d.Command("service", "update", "--image", repoName, name)
-	s.trustSuite.trustedCmd(serviceCmd)
+	trustedExecCmd(serviceCmd)
 	out, _, err = runCommandWithOutput(serviceCmd)
 
 	c.Assert(err, check.NotNil, check.Commentf(out))

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -229,7 +229,7 @@ func (s *DockerSuite) TestVolumeCLIRm(c *check.C) {
 
 	icmd.RunCommand(dockerBinary, "volume", "rm", "testing").Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Error: "exit status 1",
+		Error:    "exit status 1",
 	})
 
 	out, _ = dockerCmd(c, "run", "--volumes-from=test", "--name=test2", "busybox", "sh", "-c", "cat /foo/bar")

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -226,11 +226,11 @@ func (s *DockerSuite) TestVolumeCLIRm(c *check.C) {
 
 	volumeID := "testing"
 	dockerCmd(c, "run", "-v", volumeID+":"+prefix+"/foo", "--name=test", "busybox", "sh", "-c", "echo hello > /foo/bar")
-	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "volume", "rm", "testing"))
-	c.Assert(
-		err,
-		check.Not(check.IsNil),
-		check.Commentf("Should not be able to remove volume that is in use by a container\n%s", out))
+
+	icmd.RunCommand(dockerBinary, "volume", "rm", "testing").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Error: "exit status 1",
+	})
 
 	out, _ = dockerCmd(c, "run", "--volumes-from=test", "--name=test2", "busybox", "sh", "-c", "cat /foo/bar")
 	c.Assert(strings.TrimSpace(out), check.Equals, "hello")
@@ -401,8 +401,7 @@ func (s *DockerSuite) TestVolumeCLIRmForce(c *check.C) {
 	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
 	// Mountpoint is in the form of "/var/lib/docker/volumes/.../_data", removing `/_data`
 	path := strings.TrimSuffix(strings.TrimSpace(out), "/_data")
-	out, _, err := runCommandWithOutput(exec.Command("rm", "-rf", path))
-	c.Assert(err, check.IsNil)
+	icmd.RunCommand("rm", "-rf", path).Assert(c, icmd.Success)
 
 	dockerCmd(c, "volume", "rm", "-f", "test")
 	out, _ = dockerCmd(c, "volume", "ls")

--- a/integration-cli/docker_cli_wait_test.go
+++ b/integration-cli/docker_cli_wait_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/docker/docker/integration-cli/checker"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
 

--- a/integration-cli/docker_cli_wait_test.go
+++ b/integration-cli/docker_cli_wait_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/go-check/check"
 )
@@ -36,7 +37,7 @@ func (s *DockerSuite) TestWaitBlockedExitZero(c *check.C) {
 	chWait := make(chan string)
 	go func() {
 		chWait <- ""
-		out, _, _ := runCommandWithOutput(exec.Command(dockerBinary, "wait", containerID))
+		out := icmd.RunCommand(dockerBinary, "wait", containerID).Combined()
 		chWait <- out
 	}()
 

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -818,10 +818,12 @@ func buildImageFromContextWithOut(name string, ctx *FakeContext, useCache bool, 
 	}
 	args = append(args, buildFlags...)
 	args = append(args, ".")
-	buildCmd := exec.Command(dockerBinary, args...)
-	buildCmd.Dir = ctx.Dir
-	out, exitCode, err := runCommandWithOutput(buildCmd)
-	if err != nil || exitCode != 0 {
+	result := icmd.RunCmd(icmd.Cmd{
+		Command: append([]string{dockerBinary}, args...),
+		Dir:     ctx.Dir,
+	})
+	out := result.Combined()
+	if result.Error != nil || result.ExitCode != 0 {
 		return "", "", fmt.Errorf("failed to build the image: %s", out)
 	}
 	id, err := getIDByName(name)

--- a/integration-cli/trust_server_test.go
+++ b/integration-cli/trust_server_test.go
@@ -13,6 +13,7 @@ import (
 
 	cliconfig "github.com/docker/docker/cli/config"
 	"github.com/docker/docker/integration-cli/checker"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/go-check/check"
 )
@@ -33,6 +34,30 @@ type testNotary struct {
 
 const notaryHost = "localhost:4443"
 const notaryURL = "https://" + notaryHost
+
+var SuccessTagging = icmd.Expected{
+	Out: "Tagging",
+}
+
+var SuccessSigningAndPushing = icmd.Expected{
+	Out: "Signing and pushing trust metadata",
+}
+
+var SuccessDownloaded = icmd.Expected{
+	Out: "Status: Downloaded",
+}
+
+var SuccessTaggingOnStderr = icmd.Expected{
+	Err: "Tagging",
+}
+
+var SuccessSigningAndPushingOnStderr = icmd.Expected{
+	Err: "Signing and pushing trust metadata",
+}
+
+var SuccessDownloadedOnStderr = icmd.Expected{
+	Err: "Status: Downloaded",
+}
 
 func newTestNotary(c *check.C) (*testNotary, error) {
 	// generate server config
@@ -164,28 +189,38 @@ func (t *testNotary) Close() {
 	os.RemoveAll(t.dir)
 }
 
-func (s *DockerTrustSuite) trustedCmd(cmd *exec.Cmd) {
+// Deprecated: used trustedCmd instead
+func trustedExecCmd(cmd *exec.Cmd) {
 	pwd := "12345678"
-	trustCmdEnv(cmd, notaryURL, pwd, pwd)
+	cmd.Env = append(cmd.Env, trustEnv(notaryURL, pwd, pwd)...)
 }
 
-func (s *DockerTrustSuite) trustedCmdWithServer(cmd *exec.Cmd, server string) {
+func trustedCmd(cmd *icmd.Cmd) {
 	pwd := "12345678"
-	trustCmdEnv(cmd, server, pwd, pwd)
+	cmd.Env = append(cmd.Env, trustEnv(notaryURL, pwd, pwd)...)
 }
 
-func (s *DockerTrustSuite) trustedCmdWithPassphrases(cmd *exec.Cmd, rootPwd, repositoryPwd string) {
-	trustCmdEnv(cmd, notaryURL, rootPwd, repositoryPwd)
+func trustedCmdWithServer(server string) func(*icmd.Cmd) {
+	return func(cmd *icmd.Cmd) {
+		pwd := "12345678"
+		cmd.Env = append(cmd.Env, trustEnv(server, pwd, pwd)...)
+	}
 }
 
-func trustCmdEnv(cmd *exec.Cmd, server, rootPwd, repositoryPwd string) {
-	env := []string{
+func trustedCmdWithPassphrases(rootPwd, repositoryPwd string) func(*icmd.Cmd) {
+	return func(cmd *icmd.Cmd) {
+		cmd.Env = append(cmd.Env, trustEnv(notaryURL, rootPwd, repositoryPwd)...)
+	}
+}
+
+func trustEnv(server, rootPwd, repositoryPwd string) []string {
+	env := append(os.Environ(), []string{
 		"DOCKER_CONTENT_TRUST=1",
 		fmt.Sprintf("DOCKER_CONTENT_TRUST_SERVER=%s", server),
 		fmt.Sprintf("DOCKER_CONTENT_TRUST_ROOT_PASSPHRASE=%s", rootPwd),
 		fmt.Sprintf("DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=%s", repositoryPwd),
-	}
-	cmd.Env = append(os.Environ(), env...)
+	}...)
+	return env
 }
 
 func (s *DockerTrustSuite) setupTrustedImage(c *check.C, name string) string {
@@ -193,16 +228,7 @@ func (s *DockerTrustSuite) setupTrustedImage(c *check.C, name string) string {
 	// tag the image and upload it to the private registry
 	dockerCmd(c, "tag", "busybox", repoName)
 
-	pushCmd := exec.Command(dockerBinary, "push", repoName)
-	s.trustedCmd(pushCmd)
-	out, _, err := runCommandWithOutput(pushCmd)
-
-	if err != nil {
-		c.Fatalf("Error running trusted push: %s\n%s", err, out)
-	}
-	if !strings.Contains(string(out), "Signing and pushing trust metadata") {
-		c.Fatalf("Missing expected output on trusted push:\n%s", out)
-	}
+	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 
 	if out, status := dockerCmd(c, "rmi", repoName); status != 0 {
 		c.Fatalf("Error removing image %q\n%s", repoName, out)
@@ -216,16 +242,7 @@ func (s *DockerTrustSuite) setupTrustedplugin(c *check.C, source, name string) s
 	// tag the image and upload it to the private registry
 	dockerCmd(c, "plugin", "install", "--grant-all-permissions", "--alias", repoName, source)
 
-	pushCmd := exec.Command(dockerBinary, "plugin", "push", repoName)
-	s.trustedCmd(pushCmd)
-	out, _, err := runCommandWithOutput(pushCmd)
-
-	if err != nil {
-		c.Fatalf("Error running trusted plugin push: %s\n%s", err, out)
-	}
-	if !strings.Contains(string(out), "Signing and pushing trust metadata") {
-		c.Fatalf("Missing expected output on trusted push:\n%s", out)
-	}
+	icmd.RunCmd(icmd.Command(dockerBinary, "plugin", "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 
 	if out, status := dockerCmd(c, "plugin", "rm", "-f", repoName); status != 0 {
 		c.Fatalf("Error removing plugin %q\n%s", repoName, out)

--- a/integration-cli/utils_test.go
+++ b/integration-cli/utils_test.go
@@ -13,6 +13,7 @@ func getPrefixAndSlashFromDaemonPlatform() (prefix, slash string) {
 }
 
 // TODO: update code to call cmd.RunCmd directly, and remove this function
+// Deprecated: use pkg/testutil/cmd instead
 func runCommandWithOutput(execCmd *exec.Cmd) (string, int, error) {
 	result := cmd.RunCmd(transformCmd(execCmd))
 	return result.Combined(), result.ExitCode, result.Error

--- a/pkg/testutil/cmd/command.go
+++ b/pkg/testutil/cmd/command.go
@@ -215,8 +215,16 @@ type Cmd struct {
 	Env     []string
 }
 
+// Command create a simple Cmd with the specified command and arguments
+func Command(command string, args ...string) Cmd {
+	return Cmd{Command: append([]string{command}, args...)}
+}
+
 // RunCmd runs a command and returns a Result
-func RunCmd(cmd Cmd) *Result {
+func RunCmd(cmd Cmd, cmdOperators ...func(*Cmd)) *Result {
+	for _, op := range cmdOperators {
+		op(&cmd)
+	}
 	result := StartCmd(cmd)
 	if result.Error != nil {
 		return result
@@ -226,7 +234,7 @@ func RunCmd(cmd Cmd) *Result {
 
 // RunCommand parses a command line and runs it, returning a result
 func RunCommand(command string, args ...string) *Result {
-	return RunCmd(Cmd{Command: append([]string{command}, args...)})
+	return RunCmd(Command(command, args...))
 }
 
 // StartCmd starts a command, but doesn't wait for it to finish


### PR DESCRIPTION
This remove a bunch of `runCommandWithOutput` to replace it with `pkg/testutil/cmd` usage. This tries as much as possible to make the code more readable. It's far from perfect still but it's a small step towards it.

I have weird failures on some test locally, so this might fail here to… It's a little bit big too, sorry 🙇 

Also a few side notes :

- `Status: Downloaded` (and the whole pull) is on `stderr` for `create` (and other container commands) but is on `stdout` for plugins — it's a little bit inconsistent.
- On trust tests, there is a lot of repetitions, I did not tackle them all yet 👼 

/cc @thaJeztah @icecrime @dnephin @cpuguy83 @aaronlehmann @tiborvass 

🐸 
