### PR TITLE
Fix non thread-safe Iteration around go-patricia

### DIFF
--- a/pkg/truncindex/truncindex.go
+++ b/pkg/truncindex/truncindex.go
@@ -125,8 +125,13 @@ func (idx *TruncIndex) Get(s string) (string, error) {
 	return "", ErrNotExist
 }
 
-// Iterate iterates over all stored IDs, and passes each of them to the given handler.
+// Iterate iterates over all stored IDs and passes each of them to the given
+// handler. Take care that the handler method does not call any public
+// method on truncindex as the internal locking is not reentrant/recursive
+// and will result in deadlock.
 func (idx *TruncIndex) Iterate(handler func(id string)) {
+	idx.Lock()
+	defer idx.Unlock()
 	idx.trie.Visit(func(prefix patricia.Prefix, item patricia.Item) error {
 		handler(string(prefix))
 		return nil

--- a/pkg/truncindex/truncindex_test.go
+++ b/pkg/truncindex/truncindex_test.go
@@ -3,6 +3,7 @@ package truncindex
 import (
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/pkg/stringid"
 )
@@ -98,6 +99,7 @@ func TestTruncIndex(t *testing.T) {
 	assertIndexGet(t, index, id, id, false)
 
 	assertIndexIterate(t)
+	assertIndexIterateDoNotPanic(t)
 }
 
 func assertIndexIterate(t *testing.T) {
@@ -118,6 +120,28 @@ func assertIndexIterate(t *testing.T) {
 		}
 
 		t.Fatalf("An unknown ID '%s'", targetId)
+	})
+}
+
+func assertIndexIterateDoNotPanic(t *testing.T) {
+	ids := []string{
+		"19b36c2c326ccc11e726eee6ee78a0baf166ef96",
+		"28b36c2c326ccc11e726eee6ee78a0baf166ef96",
+	}
+
+	index := NewTruncIndex(ids)
+	iterationStarted := make(chan bool, 1)
+
+	go func() {
+		<-iterationStarted
+		index.Delete("19b36c2c326ccc11e726eee6ee78a0baf166ef96")
+	}()
+
+	index.Iterate(func(targetId string) {
+		if targetId == "19b36c2c326ccc11e726eee6ee78a0baf166ef96" {
+			iterationStarted <- true
+			time.Sleep(100 * time.Millisecond)
+		}
 	})
 }
 


### PR DESCRIPTION
* Unlike other methods in truncindex, Iterate was not locking before
using the Trie, making it potentially race e.g. Delete could result in
setting a child to nil, while Iterate dereferenced that node
while walking the Trie.

Signed-off-by: Petar Petrov <pppepito86@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed a race condition that can occur when Iterate is called in parallel with other methods in truncindex, due to a lack of locking and go-patricia's thread unsafe nature.

**- How I did it**

Added locking in the Iterate method before calling Visit on the Trie.

**- How to verify it**

Run the unit test provided. Before locking in Iterate, this test should panic with a nil pointer deference and after, should complete successfully.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixed a race condition in truncindex's Iterate method.