### PR TITLE
remove -f on secret create and unify usage with other commands

### DIFF
--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -27,17 +27,17 @@ func newSecretCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "create [OPTIONS] SECRET",
+		Use:   "create [OPTIONS] SECRET file|-",
 		Short: "Create a secret from a file or STDIN as content",
-		Args:  cli.ExactArgs(1),
+		Args:  cli.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			createOpts.name = args[0]
+			createOpts.file = args[1]
 			return runSecretCreate(dockerCli, createOpts)
 		},
 	}
 	flags := cmd.Flags()
 	flags.VarP(&createOpts.labels, "label", "l", "Secret labels")
-	flags.StringVarP(&createOpts.file, "file", "f", "", "Read from a file or STDIN ('-')")
 
 	return cmd
 }
@@ -45,10 +45,6 @@ func newSecretCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 func runSecretCreate(dockerCli *command.DockerCli, options createOptions) error {
 	client := dockerCli.Client()
 	ctx := context.Background()
-
-	if options.file == "" {
-		return fmt.Errorf("Please specify either a file name or STDIN ('-') with --file")
-	}
 
 	var in io.Reader = dockerCli.In()
 	if options.file != "-" {

--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -16,12 +16,11 @@ keywords: ["secret, create"]
 # secret create
 
 ```Markdown
-Usage:	docker secret create [OPTIONS] SECRET
+Usage:	docker secret create [OPTIONS] SECRET file|-
 
 Create a secret from a file or STDIN as content
 
 Options:
-  -f, --file string   Read from a file or STDIN ('-')
       --help          Print usage
   -l, --label list    Secret labels (default [])
 ```
@@ -34,7 +33,7 @@ command on a manager node.
 ### Create a secret
 
 ```bash
-$ echo <secret> | docker secret create -f - my_secret
+$ echo <secret> | docker secret create my_secret -
 mhv17xfe3gh6xc4rij5orpfds
 
 $ docker secret ls
@@ -45,7 +44,7 @@ mhv17xfe3gh6xc4rij5orpfds   my_secret               2016-10-27 23:25:43.90918108
 ### Create a secret with a file
 
 ```bash
-$ docker secret create -f secret.json my_secret
+$ docker secret create my_secret ./secret.json
 mhv17xfe3gh6xc4rij5orpfds
 
 $ docker secret ls
@@ -56,7 +55,7 @@ mhv17xfe3gh6xc4rij5orpfds   my_secret               2016-10-27 23:25:43.90918108
 ### Create a secret with labels
 
 ```bash
-$ docker secret create -f secret.json --label env=dev --label rev=20161102 my_secret
+$ docker secret create --label env=dev --label rev=20161102 my_secret ./secret.json
 jtn7g6aukl5ky7nr9gvwafoxh
 
 $ docker secret inspect my_secret

--- a/integration-cli/docker_cli_secret_create_test.go
+++ b/integration-cli/docker_cli_secret_create_test.go
@@ -121,20 +121,11 @@ func (s *DockerSwarmSuite) TestSecretCreateWithFile(c *check.C) {
 	c.Assert(err, checker.IsNil, check.Commentf("failed to write to temporary file"))
 
 	testName := "test_secret"
-	out, err := d.Cmd("secret", "create", "--file", testFile.Name(), testName)
+	out, err := d.Cmd("secret", "create", testName, testFile.Name())
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "", check.Commentf(out))
 
 	id := strings.TrimSpace(out)
 	secret := d.GetSecret(c, id)
-	c.Assert(secret.Spec.Name, checker.Equals, testName)
-
-	testName = "test_secret_2"
-	out, err = d.Cmd("secret", "create", testName, "-f", testFile.Name())
-	c.Assert(err, checker.IsNil)
-	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "", check.Commentf(out))
-
-	id = strings.TrimSpace(out)
-	secret = d.GetSecret(c, id)
 	c.Assert(secret.Spec.Name, checker.Equals, testName)
 }


### PR DESCRIPTION
the current state of the secret command is inconsistent with the rest of the docker commands.

This PR aim to fix this.

