### PR TITLE
[1.12.x] Fix conflicts with newly updated selinux policies

### DIFF
--- a/contrib/selinux/docker-engine-selinux/docker.fc
+++ b/contrib/selinux/docker-engine-selinux/docker.fc
@@ -7,8 +7,6 @@
 /etc/docker(/.*)?		gen_context(system_u:object_r:docker_config_t,s0)
 
 /var/lib/docker(/.*)?		gen_context(system_u:object_r:docker_var_lib_t,s0)
-/var/lib/kublet(/.*)?		gen_context(system_u:object_r:docker_var_lib_t,s0)
-/var/lib/docker/vfs(/.*)?	gen_context(system_u:object_r:svirt_sandbox_file_t,s0)
 
 /var/run/docker\.pid		--	gen_context(system_u:object_r:docker_var_run_t,s0)
 /var/run/docker\.sock		-s	gen_context(system_u:object_r:docker_var_run_t,s0)

--- a/contrib/selinux/docker-engine-selinux/docker.te
+++ b/contrib/selinux/docker-engine-selinux/docker.te
@@ -6,13 +6,6 @@ policy_module(docker, 1.0.0)
 #
 
 ## <desc>
-## <p>
-## Allow sandbox containers manage fuse files
-## </p>
-## </desc>
-gen_tunable(virt_sandbox_use_fusefs, false)
-
-## <desc>
 ##  <p>
 ##  Determine whether docker can
 ##  connect to all TCP ports.

--- a/hack/make/.build-rpm/docker-engine-selinux.spec
+++ b/hack/make/.build-rpm/docker-engine-selinux.spec
@@ -13,20 +13,7 @@ URL: https://dockerproject.org
 Vendor: Docker
 Packager: Docker <support@docker.com>
 
-# Version of SELinux we were using
-%if 0%{?fedora} == 20
-%global selinux_policyver 3.12.1-197
-%endif # fedora 20
-%if 0%{?fedora} == 21
-%global selinux_policyver 3.13.1-105
-%endif # fedora 21
-%if 0%{?fedora} >= 22
-%global selinux_policyver 3.13.1-128
-%endif # fedora 22
-%if 0%{?centos} >= 7 || 0%{?rhel} >= 7 || 0%{?oraclelinux} >= 7
-%global selinux_policyver 3.13.1-23
-%endif # centos,rhel,oraclelinux 7
-
+%global selinux_policyver 3.13.1-102
 %global selinuxtype targeted
 %global moduletype  services
 %global modulenames docker
@@ -84,7 +71,7 @@ if %{_sbindir}/selinuxenabled ; then
     %{_sbindir}/load_policy
     %relabel_files
     if [ $1 -eq 1 ]; then
-	restorecon -R %{_sharedstatedir}/docker
+      restorecon -R %{_sharedstatedir}/docker
     fi
 fi
 


### PR DESCRIPTION
The base selinux policies on centos/rhel/oraclelinux have all been
updated in a way that conflicts with the policies we install with
`docker-engine-selinux`. This patch fixes these conflicts.

In addition, removes special cases for old/unsupported versions of
fedora in our selinux package, and change to use a single minimum
version for the selinux base policy package, as this is the minimum
version required to use our selinux policy package.