### PR TITLE
1.13.0 rc6 cherrypicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ To manually remove all plugins and resolve this problem, take the following step
 * Remove `--name` from `docker volume create` [#23830](https://github.com/docker/docker/pull/23830)
 + Add `docker stack ls` [#23886](https://github.com/docker/docker/pull/23886)
 + Add a new `is-task` ps filter [#24411](https://github.com/docker/docker/pull/24411)
-+ Add `--env-file` flag to `docker create service` [#24844](https://github.com/docker/docker/pull/24844)
++ Add `--env-file` flag to `docker service create` [#24844](https://github.com/docker/docker/pull/24844)
 + Add `--format` on `docker stats` [#24987](https://github.com/docker/docker/pull/24987)
 + Make `docker node ps` default to `self` in swarm node [#25214](https://github.com/docker/docker/pull/25214)
 + Add `--group` in `docker service create` [#25317](https://github.com/docker/docker/pull/25317)

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -297,17 +297,19 @@ func workdir(b *Builder, args []string, attributes map[string]bool, original str
 	}
 	b.runConfig.Image = b.image
 
+	cmd := b.runConfig.Cmd
+	comment := "WORKDIR " + b.runConfig.WorkingDir
+	// reset the command for cache detection
+	b.runConfig.Cmd = strslice.StrSlice(append(getShell(b.runConfig), "#(nop) "+comment))
+	defer func(cmd strslice.StrSlice) { b.runConfig.Cmd = cmd }(cmd)
+
 	if hit, err := b.probeCache(); err != nil {
 		return err
 	} else if hit {
 		return nil
 	}
 
-	// Actually copy the struct
-	workdirConfig := *b.runConfig
-	workdirConfig.Cmd = strslice.StrSlice(append(getShell(b.runConfig), fmt.Sprintf("#(nop) WORKDIR %s", b.runConfig.WorkingDir)))
-
-	container, err := b.docker.ContainerCreate(types.ContainerCreateConfig{Config: &workdirConfig})
+	container, err := b.docker.ContainerCreate(types.ContainerCreateConfig{Config: b.runConfig})
 	if err != nil {
 		return err
 	}
@@ -316,7 +318,7 @@ func workdir(b *Builder, args []string, attributes map[string]bool, original str
 		return err
 	}
 
-	return b.commit(container.ID, b.runConfig.Cmd, "WORKDIR "+b.runConfig.WorkingDir)
+	return b.commit(container.ID, cmd, comment)
 }
 
 // RUN some command yo

--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -27,17 +27,17 @@ func newSecretCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "create [OPTIONS] SECRET",
+		Use:   "create [OPTIONS] SECRET file|-",
 		Short: "Create a secret from a file or STDIN as content",
-		Args:  cli.ExactArgs(1),
+		Args:  cli.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			createOpts.name = args[0]
+			createOpts.file = args[1]
 			return runSecretCreate(dockerCli, createOpts)
 		},
 	}
 	flags := cmd.Flags()
 	flags.VarP(&createOpts.labels, "label", "l", "Secret labels")
-	flags.StringVarP(&createOpts.file, "file", "f", "", "Read from a file or STDIN ('-')")
 
 	return cmd
 }
@@ -45,10 +45,6 @@ func newSecretCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 func runSecretCreate(dockerCli *command.DockerCli, options createOptions) error {
 	client := dockerCli.Client()
 	ctx := context.Background()
-
-	if options.file == "" {
-		return fmt.Errorf("Please specify either a file name or STDIN ('-') with --file")
-	}
 
 	var in io.Reader = dockerCli.In()
 	if options.file != "-" {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -23,6 +23,7 @@
 # DOCKER_COMPLETION_SHOW_CONTAINER_IDS
 # DOCKER_COMPLETION_SHOW_NETWORK_IDS
 # DOCKER_COMPLETION_SHOW_NODE_IDS
+# DOCKER_COMPLETION_SHOW_PLUGIN_IDS
 # DOCKER_COMPLETION_SHOW_SECRET_IDS
 # DOCKER_COMPLETION_SHOW_SERVICE_IDS
 #   "no"  - Show names only (default)
@@ -286,9 +287,17 @@ __docker_complete_plugins_bundled() {
 
 # __docker_plugins_installed returns a list of all plugins that were installed with
 # the Docker plugin API.
+# By default, only names are returned.
+# Set DOCKER_COMPLETION_SHOW_PLUGIN_IDS=yes to also complete IDs.
 # For built-in pugins, see `__docker_plugins_bundled`.
 __docker_plugins_installed() {
-	__docker_q plugin ls | awk 'NR>1 {print $1}'
+	local fields
+	if [ "$DOCKER_COMPLETION_SHOW_PLUGIN_IDS" = yes ] ; then
+		fields='$1,$2'
+	else
+		fields='$2'
+	fi
+	__docker_q plugin ls | awk "NR>1 {print $fields}"
 }
 
 # __docker_complete_plugins_installed applies completion of plugins that were installed

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -917,7 +917,7 @@ __docker_image_subcommand() {
                 "($help)*--label=[Set metadata for an image]:label=value: " \
                 "($help -m --memory)"{-m=,--memory=}"[Memory limit]:Memory limit: " \
                 "($help)--memory-swap=[Total memory limit with swap]:Memory limit: " \
-                "($help)--network=[Connect a container to a network]:network mode:(bridge none container host)"
+                "($help)--network=[Connect a container to a network]:network mode:(bridge none container host)" \
                 "($help)--no-cache[Do not use cache when building the image]" \
                 "($help)--pull[Attempt to pull a newer version of the image]" \
                 "($help -q --quiet)"{-q,--quiet}"[Suppress verbose build output]" \

--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -16,12 +16,11 @@ keywords: ["secret, create"]
 # secret create
 
 ```Markdown
-Usage:	docker secret create [OPTIONS] SECRET
+Usage:	docker secret create [OPTIONS] SECRET file|-
 
 Create a secret from a file or STDIN as content
 
 Options:
-  -f, --file string   Read from a file or STDIN ('-')
       --help          Print usage
   -l, --label list    Secret labels (default [])
 ```
@@ -34,7 +33,7 @@ command on a manager node.
 ### Create a secret
 
 ```bash
-$ echo <secret> | docker secret create -f - my_secret
+$ echo <secret> | docker secret create my_secret -
 mhv17xfe3gh6xc4rij5orpfds
 
 $ docker secret ls
@@ -45,7 +44,7 @@ mhv17xfe3gh6xc4rij5orpfds   my_secret               2016-10-27 23:25:43.90918108
 ### Create a secret with a file
 
 ```bash
-$ docker secret create -f secret.json my_secret
+$ docker secret create my_secret ./secret.json
 mhv17xfe3gh6xc4rij5orpfds
 
 $ docker secret ls
@@ -56,7 +55,7 @@ mhv17xfe3gh6xc4rij5orpfds   my_secret               2016-10-27 23:25:43.90918108
 ### Create a secret with labels
 
 ```bash
-$ docker secret create -f secret.json --label env=dev --label rev=20161102 my_secret
+$ docker secret create --label env=dev --label rev=20161102 my_secret ./secret.json
 jtn7g6aukl5ky7nr9gvwafoxh
 
 $ docker secret inspect my_secret

--- a/integration-cli/docker_cli_authz_plugin_v2_test.go
+++ b/integration-cli/docker_cli_authz_plugin_v2_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 var (
-	authzPluginName            = "tonistiigi/authz-no-volume-plugin"
+	authzPluginName            = "riyaz/authz-no-volume-plugin"
 	authzPluginTag             = "latest"
 	authzPluginNameWithTag     = authzPluginName + ":" + authzPluginTag
-	authzPluginBadManifestName = "tonistiigi/authz-plugin-bad-manifest"
+	authzPluginBadManifestName = "riyaz/authz-plugin-bad-manifest"
 	nonexistentAuthzPluginName = "riyaz/nonexistent-authz-plugin"
 )
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -7394,6 +7394,10 @@ func (s *DockerSuite) TestBuildWorkdirCmd(c *check.C) {
                 FROM golang:1.7-alpine
                 WORKDIR /
                 `
-	_, err := buildImage("testbuildworkdircmd", dockerFile, false)
+	_, err := buildImage("testbuildworkdircmd", dockerFile, true)
 	c.Assert(err, checker.IsNil)
+
+	_, out, err := buildImageWithOut("testbuildworkdircmd", dockerFile, true)
+	c.Assert(err, checker.IsNil)
+	c.Assert(strings.Count(out, "Using cache"), checker.Equals, 1)
 }

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -772,7 +772,7 @@ func (s *DockerNetworkSuite) TestDockerPluginV2NetworkDriver(c *check.C) {
 	testRequires(c, DaemonIsLinux, IsAmd64, Network)
 
 	var (
-		npName        = "tonistiigi/test-docker-netplugin"
+		npName        = "tiborvass/test-docker-netplugin"
 		npTag         = "latest"
 		npNameWithTag = npName + ":" + npTag
 	)

--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -15,8 +15,8 @@ import (
 
 var (
 	pluginProcessName = "sample-volume-plugin"
-	pName             = "tonistiigi/sample-volume-plugin"
-	npName            = "tonistiigi/test-docker-netplugin"
+	pName             = "tiborvass/sample-volume-plugin"
+	npName            = "tiborvass/test-docker-netplugin"
 	pTag              = "latest"
 	pNameWithTag      = pName + ":" + pTag
 	npNameWithTag     = npName + ":" + pTag

--- a/integration-cli/docker_cli_secret_create_test.go
+++ b/integration-cli/docker_cli_secret_create_test.go
@@ -121,20 +121,11 @@ func (s *DockerSwarmSuite) TestSecretCreateWithFile(c *check.C) {
 	c.Assert(err, checker.IsNil, check.Commentf("failed to write to temporary file"))
 
 	testName := "test_secret"
-	out, err := d.Cmd("secret", "create", "--file", testFile.Name(), testName)
+	out, err := d.Cmd("secret", "create", testName, testFile.Name())
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "", check.Commentf(out))
 
 	id := strings.TrimSpace(out)
 	secret := d.getSecret(c, id)
-	c.Assert(secret.Spec.Name, checker.Equals, testName)
-
-	testName = "test_secret_2"
-	out, err = d.Cmd("secret", "create", testName, "-f", testFile.Name())
-	c.Assert(err, checker.IsNil)
-	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "", check.Commentf(out))
-
-	id = strings.TrimSpace(out)
-	secret = d.getSecret(c, id)
 	c.Assert(secret.Spec.Name, checker.Equals, testName)
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -108,7 +108,7 @@ github.com/google/certificate-transparency d90e65c3a07988180c5b1ece71791c0b65068
 golang.org/x/crypto 3fbbcd23f1cb824e69491a5930cfeff09b12f4d2
 golang.org/x/time a4bde12657593d5e90d0533a3e4fd95e635124cb
 github.com/mreiferson/go-httpclient 63fe23f7434723dc904c901043af07931f293c47
-github.com/hashicorp/go-memdb 608dda3b1410a73eaf3ac8b517c9ae7ebab6aa87 https://github.com/floridoo/go-memdb
+github.com/hashicorp/go-memdb 608dda3b1410a73eaf3ac8b517c9ae7ebab6aa87
 github.com/hashicorp/go-immutable-radix 8e8ed81f8f0bf1bdd829593fdd5c29922c1ea990
 github.com/hashicorp/golang-lru a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
 github.com/coreos/pkg fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8

--- a/vendor.conf
+++ b/vendor.conf
@@ -2,7 +2,7 @@
 github.com/Azure/go-ansiterm 388960b655244e76e24c75f48631564eaefade62
 github.com/Microsoft/hcsshim v0.5.9
 github.com/Microsoft/go-winio v0.3.7
-github.com/Sirupsen/logrus f76d643702a30fbffecdfe50831e11881c96ceb3 https://github.com/aaronlehmann/logrus
+github.com/Sirupsen/logrus v0.11.0
 github.com/davecgh/go-spew 6d212800a42e8ab5c146b8ace3490ee17e5225f9
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git


### PR DESCRIPTION
docs:
* Fix wrong command in changelog #29949
* Fix completion for zsh #29907
* Add bash completion for plugin names #29888

P0:
* Set plugins used in tests back to original names #29923
* Fix workdir cache invalidation #29956
* remove -f on secret create and unify usage with other commands #29955

misc, no code change but will help for the future
* un-fork go-memdb #29996
* Unfork logrus dependency #29924
