### PR TITLE
extract a reference check function with formated error for cli, and a…

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -3,6 +3,7 @@ package image
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -220,7 +221,7 @@ func (s *imageRouter) deleteImages(ctx context.Context, w http.ResponseWriter, r
 	name := vars["name"]
 
 	if strings.TrimSpace(name) == "" {
-		return fmt.Errorf("image name cannot be blank")
+		return errors.New("image name cannot be blank")
 	}
 
 	force := httputils.BoolValue(r, "force")

--- a/client/image_remove.go
+++ b/client/image_remove.go
@@ -2,7 +2,10 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"net/url"
+
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
@@ -10,6 +13,14 @@ import (
 
 // ImageRemove removes an image from the docker host.
 func (cli *Client) ImageRemove(ctx context.Context, imageID string, options types.ImageRemoveOptions) ([]types.ImageDelete, error) {
+	if strings.TrimSpace(imageID) == "" {
+		return nil, errors.New("image name cannot be blank")
+	}
+
+	if _, err := parseNamed(imageID); err != nil {
+		return nil, err
+	}
+
 	query := url.Values{}
 
 	if options.Force {

--- a/client/image_remove_test.go
+++ b/client/image_remove_test.go
@@ -24,6 +24,17 @@ func TestImageRemoveError(t *testing.T) {
 	}
 }
 
+func TestImageRemoveErrorWithWrongName(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	}
+
+	_, err := client.ImageRemove(context.Background(), "wrong-format@sha256:abcd", types.ImageRemoveOptions{})
+	if err == nil || err.Error() != "Error parsing reference: \"wrong-format@sha256:abcd\" is not a valid repository/tag: invalid reference format" {
+		t.Fatalf("expected a Server error, got %v", err)
+	}
+}
+
 func TestImageRemove(t *testing.T) {
 	expectedURL := "/images/image_id"
 	removeCases := []struct {

--- a/client/image_save.go
+++ b/client/image_save.go
@@ -9,9 +9,15 @@ import (
 
 // ImageSave retrieves one or more images from the docker host as an io.ReadCloser.
 // It's up to the caller to store the images and close the stream.
-func (cli *Client) ImageSave(ctx context.Context, imageIDs []string) (io.ReadCloser, error) {
+func (cli *Client) ImageSave(ctx context.Context, names []string) (io.ReadCloser, error) {
+	for _, name := range names {
+		if _, err := parseNamed(name); err != nil {
+			return nil, err
+		}
+	}
+
 	query := url.Values{
-		"names": imageIDs,
+		"names": names,
 	}
 
 	resp, err := cli.get(ctx, "/images/get", query, nil)

--- a/client/image_save_test.go
+++ b/client/image_save_test.go
@@ -23,6 +23,16 @@ func TestImageSaveError(t *testing.T) {
 	}
 }
 
+func TestImageSaveErrorWithWrongName(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	}
+	_, err := client.ImageSave(context.Background(), []string{"busybox", "wrong-format@sha256:abcd"})
+	if err == nil || err.Error() != "Error parsing reference: \"wrong-format@sha256:abcd\" is not a valid repository/tag: invalid reference format" {
+		t.Fatalf("expected a Server error, got %v", err)
+	}
+}
+
 func TestImageSave(t *testing.T) {
 	expectedURL := "/images/get"
 	client := &Client{

--- a/client/image_tag.go
+++ b/client/image_tag.go
@@ -11,13 +11,13 @@ import (
 
 // ImageTag tags an image in the docker host
 func (cli *Client) ImageTag(ctx context.Context, source, target string) error {
-	if _, err := distreference.ParseNamed(source); err != nil {
-		return errors.Wrapf(err, "Error parsing reference: %q is not a valid repository/tag", source)
+	if _, err := parseNamed(source); err != nil {
+		return err
 	}
 
-	distributionRef, err := distreference.ParseNamed(target)
+	distributionRef, err := parseNamed(target)
 	if err != nil {
-		return errors.Wrapf(err, "Error parsing reference: %q is not a valid repository/tag", target)
+		return err
 	}
 
 	if _, isCanonical := distributionRef.(distreference.Canonical); isCanonical {

--- a/client/utils.go
+++ b/client/utils.go
@@ -1,9 +1,12 @@
 package client
 
 import (
-	"github.com/docker/docker/api/types/filters"
 	"net/url"
 	"regexp"
+
+	distreference "github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/pkg/errors"
 )
 
 var headerRegexp = regexp.MustCompile(`\ADocker/.+\s\((.+)\)\z`)
@@ -30,4 +33,13 @@ func getFiltersQuery(f filters.Args) (url.Values, error) {
 		query.Set("filters", filterJSON)
 	}
 	return query, nil
+}
+
+func parseNamed(name string) (distreference.Named, error) {
+	named, err := distreference.ParseNamed(name)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error parsing reference: %q is not a valid repository/tag", name)
+	}
+
+	return named, nil
 }


### PR DESCRIPTION

Signed-off-by: wefine <wang.xiaoren@zte.com.cn>


**- What I did**
Extract a reference check function with formated error for cli, and add check for image save and image remove, etc, and add unit test. Although cli doesnot know whether the reference is existed or not in daemon, but cli can check the format of reference for daemon.

**- How I did it**
Extract a function to client/utils.go for check reference format, and invoke it in image_save and image_remove, etc.

**- How to verify it**
unit test


**- A picture of a cute animal (not mandatory but encouraged)**
before(daemon checking):

> root@ubuntu:/# docker image rm testbuildaddown- test-link-absolute-volume-
> Error response from daemon: Error parsing reference: "testbuildaddown-" is not a valid repository/tag: invalid reference format
> Error response from daemon: Error parsing reference: "test-link-absolute-volume-" is not a valid repository/tag: invalid reference format

after(cli checking):

> root@ubuntu:/# docker image rm testbuildaddown- test-link-absolute-volume-
> Error parsing reference: "testbuildaddown-" is not a valid repository/tag: invalid reference format
> Error parsing reference: "test-link-absolute-volume-" is not a valid repository/tag: invalid reference format

