### PR TITLE
Return `[]` instead of `null` in case `filterNetworks` returns empty

### DIFF
--- a/api/server/router/network/filter.go
+++ b/api/server/router/network/filter.go
@@ -8,7 +8,8 @@ import (
 	"github.com/docker/docker/runconfig"
 )
 
-func filterNetworkByType(nws []types.NetworkResource, netType string) (retNws []types.NetworkResource, err error) {
+func filterNetworkByType(nws []types.NetworkResource, netType string) ([]types.NetworkResource, error) {
+	retNws := []types.NetworkResource{}
 	switch netType {
 	case "builtin":
 		for _, nw := range nws {
@@ -62,7 +63,7 @@ func filterNetworks(nws []types.NetworkResource, filter filters.Args) ([]types.N
 	}
 
 	if filter.Include("type") {
-		var typeNet []types.NetworkResource
+		typeNet := []types.NetworkResource{}
 		errFilter := filter.WalkValues("type", func(fval string) error {
 			passList, err := filterNetworkByType(displayNet, fval)
 			if err != nil {

--- a/api/server/router/network/filter_test.go
+++ b/api/server/router/network/filter_test.go
@@ -1,0 +1,115 @@
+// +build !windows
+
+package network
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+)
+
+func TestFilterNetworks(t *testing.T) {
+	networks := []types.NetworkResource{
+		{
+			Name:   "host",
+			Driver: "host",
+		},
+		{
+			Name:   "bridge",
+			Driver: "bridge",
+		},
+		{
+			Name:   "none",
+			Driver: "null",
+		},
+		{
+			Name:   "myoverlay",
+			Driver: "overlay",
+		},
+		{
+			Name:   "mydrivernet",
+			Driver: "mydriver",
+		},
+	}
+
+	bridgeDriverFilters := filters.NewArgs()
+	bridgeDriverFilters.Add("driver", "bridge")
+
+	overlayDriverFilters := filters.NewArgs()
+	overlayDriverFilters.Add("driver", "overlay")
+
+	nonameDriverFilters := filters.NewArgs()
+	nonameDriverFilters.Add("driver", "noname")
+
+	customDriverFilters := filters.NewArgs()
+	customDriverFilters.Add("type", "custom")
+
+	builtinDriverFilters := filters.NewArgs()
+	builtinDriverFilters.Add("type", "builtin")
+
+	invalidDriverFilters := filters.NewArgs()
+	invalidDriverFilters.Add("type", "invalid")
+
+	testCases := []struct {
+		filter      filters.Args
+		resultCount int
+		err         string
+	}{
+		{
+			filter:      bridgeDriverFilters,
+			resultCount: 1,
+			err:         "",
+		},
+		{
+			filter:      overlayDriverFilters,
+			resultCount: 1,
+			err:         "",
+		},
+		{
+			filter:      nonameDriverFilters,
+			resultCount: 0,
+			err:         "",
+		},
+		{
+			filter:      customDriverFilters,
+			resultCount: 2,
+			err:         "",
+		},
+		{
+			filter:      builtinDriverFilters,
+			resultCount: 3,
+			err:         "",
+		},
+		{
+			filter:      invalidDriverFilters,
+			resultCount: 0,
+			err:         "Invalid filter: 'type'='invalid'",
+		},
+	}
+
+	for _, testCase := range testCases {
+		result, err := filterNetworks(networks, testCase.filter)
+		if testCase.err != "" {
+			if err == nil {
+				t.Fatalf("expect error '%s', got no error", testCase.err)
+
+			} else if !strings.Contains(err.Error(), testCase.err) {
+				t.Fatalf("expect error '%s', got '%s'", testCase.err, err)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("expect no error, got error '%s'", err)
+			}
+			// Make sure result is not nil
+			if result == nil {
+				t.Fatal("filterNetworks should not return nil")
+			}
+
+			if len(result) != testCase.resultCount {
+				t.Fatalf("expect '%d' networks, got '%d' networks", testCase.resultCount, len(result))
+			}
+		}
+	}
+}


### PR DESCRIPTION
This fix tries to address the issue raised in #29946 where listing networks from API will return `null` if the result of network filter is empty.

The reason for the issue was that inside the `filterNetworks()`, the return value was initialized as `nil`:
```
 var typeNet []types.NetworkResource
```

This is inconsistent with other places where return value was initialized with `[]`
```
displayNet := []types.NetworkResource{}
```

This fix addresses the issue by changing `typeNet` to `[]` as well.

This fix fixes #29946.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
