### PR TITLE
return error when listNode fails

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -103,7 +103,7 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 			fmt.Fprintf(dockerCli.Out(), " Error: %v\n", info.Swarm.Error)
 		}
 		fmt.Fprintf(dockerCli.Out(), " Is Manager: %v\n", info.Swarm.ControlAvailable)
-		if info.Swarm.ControlAvailable {
+		if info.Swarm.ControlAvailable && info.Swarm.Error == "" && info.Swarm.LocalNodeState != swarm.LocalNodeStateError {
 			fmt.Fprintf(dockerCli.Out(), " ClusterID: %s\n", info.Swarm.Cluster.ID)
 			fmt.Fprintf(dockerCli.Out(), " Managers: %d\n", info.Swarm.Managers)
 			fmt.Fprintf(dockerCli.Out(), " Nodes: %d\n", info.Swarm.Nodes)

--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -750,7 +750,9 @@ func (c *Cluster) Info() types.Info {
 		// Strip JoinTokens
 		info.Cluster = swarm.ClusterInfo
 
-		if r, err := state.controlClient.ListNodes(ctx, &swarmapi.ListNodesRequest{}); err == nil {
+		if r, err := state.controlClient.ListNodes(ctx, &swarmapi.ListNodesRequest{}); err != nil {
+			info.Error = err.Error()
+		} else {
 			info.Nodes = len(r.Nodes)
 			for _, n := range r.Nodes {
 				if n.ManagerStatus != nil {


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

fixes #29520 

**- What I did**
1. When `c.Inspect()` and `ListNodes` fail, we set the error to Info;
2. change the client side that make swarm error stop displaying cluster info.
3. add check `LocalNodeStateError` in client side.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

