### PR TITLE
fix some typos in runconfig\opts\envfile_test.go

### DIFF
--- a/runconfig/opts/envfile_test.go
+++ b/runconfig/opts/envfile_test.go
@@ -54,7 +54,7 @@ and_underscore=working too
 	}
 
 	if !reflect.DeepEqual(lines, expectedLines) {
-		t.Fatal("lines not equal to expected_lines")
+		t.Fatal("lines not equal to expectedLines")
 	}
 }
 
@@ -128,12 +128,11 @@ another invalid line`
 	defer os.Remove(tmpFile)
 
 	_, err := ParseEnvFile(tmpFile)
-
 	if err == nil {
 		t.Fatalf("Expected an ErrBadEnvVariable, got nothing")
 	}
 	if _, ok := err.(ErrBadEnvVariable); !ok {
-		t.Fatalf("Expected an ErrBadEnvvariable, got [%v]", err)
+		t.Fatalf("Expected an ErrBadEnvVariable, got [%v]", err)
 	}
 	expectedMessage := "poorly formatted environment: variable 'first line' has white spaces"
 	if err.Error() != expectedMessage {


### PR DESCRIPTION
fix some typos in runconfig\opts\envfile_test.go