### PR TITLE
Return error when insecure registry contains scheme

### DIFF
--- a/registry/config_test.go
+++ b/registry/config_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -45,6 +46,60 @@ func TestValidateMirror(t *testing.T) {
 	for _, address := range invalid {
 		if ret, err := ValidateMirror(address); err == nil || ret != "" {
 			t.Errorf("ValidateMirror(`"+address+"`) got %s %s", ret, err)
+		}
+	}
+}
+
+func TestLoadInsecureRegistries(t *testing.T) {
+	testCases := []struct {
+		registries []string
+		index      string
+		err        string
+	}{
+		{
+			registries: []string{"http://mytest.com"},
+			index:      "mytest.com",
+		},
+		{
+			registries: []string{"https://mytest.com"},
+			index:      "mytest.com",
+		},
+		{
+			registries: []string{"HTTP://mytest.com"},
+			index:      "mytest.com",
+		},
+		{
+			registries: []string{"svn://mytest.com"},
+			err:        "insecure registry svn://mytest.com should not contain '://'",
+		},
+		{
+			registries: []string{"-invalid-registry"},
+			err:        "Cannot begin or end with a hyphen",
+		},
+	}
+	for _, testCase := range testCases {
+		config := newServiceConfig(ServiceOptions{})
+		err := config.LoadInsecureRegistries(testCase.registries)
+		if testCase.err == "" {
+			if err != nil {
+				t.Fatalf("expect no error, got '%s'", err)
+			}
+			match := false
+			for index := range config.IndexConfigs {
+				if index == testCase.index {
+					match = true
+				}
+			}
+			if !match {
+				t.Fatalf("expect index configs to contain '%s', got %+v", testCase.index, config.IndexConfigs)
+			}
+		} else {
+			if err == nil {
+				t.Fatalf("expect error '%s', got no error", testCase.err)
+			}
+			if !strings.Contains(err.Error(), testCase.err) {
+				t.Fatalf("expect error '%s', got '%s'", testCase.err, err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
While investigating #29936 I noticed one potential issue in `LoadInsecureRegistries`.

The implementation of the func assumes that the format of insecure registry should be `host:port` if not CIDR. However, it is very common that user may incorrectly provide a registry with a scheme (e.g, `http://myregistry.com:5000`) Such a registry format with a scheme will cause docker pull to
always try https endpoint.

The reason is that the func of `isSecureIndex()` actually will check for the map of the index server for `myregistry.com:5000` while the insecure registry only has a record of `http://myregistry.com:5000`.
As a consequence, docker assumes that `myregistry.com:5000` is not a insecure registry and will go ahead with https endpoint.

This fix addresses the issue by error out insecure registries with scheme.

*Note: Alternatively, we could also just remove the scheme (`http://` or `https://`) and save the sanitized value*

A unit test has been added.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
