### PR TITLE
[1.13.x] Few stack deploy network fixes

### DIFF
--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -9,9 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
-
 	"github.com/aanand/compose-file/loader"
 	composetypes "github.com/aanand/compose-file/types"
 	"github.com/docker/docker/api/types"
@@ -25,6 +22,8 @@ import (
 	"github.com/docker/docker/opts"
 	runconfigopts "github.com/docker/docker/runconfig/opts"
 	"github.com/docker/go-connections/nat"
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 const (
@@ -310,7 +309,7 @@ func convertServiceNetworks(
 		}
 		target := namespace.scope(networkName)
 		if networkConfig.External.External {
-			target = networkName
+			target = networkConfig.External.Name
 		}
 		nets = append(nets, swarm.NetworkAttachmentConfig{
 			Target:  target,


### PR DESCRIPTION
This includes 2 fixes for `stack deploy` with compose files.

- Make sure we use the correct network name for external ones, Fixes #29974 
- Make the `default` network overridable and only creates networks that are used by services — so that `default` network is only created if a service doesn't declare a network. FIxes #29982

/cc @thaJeztah @dnephin @vieux @icecrime @tiborvass 

I'll make a follow-up in master once this one is merged 👼 

🐸 