### PR TITLE
un-fork go-memdb

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -111,7 +111,7 @@ github.com/google/certificate-transparency d90e65c3a07988180c5b1ece71791c0b65068
 golang.org/x/crypto 3fbbcd23f1cb824e69491a5930cfeff09b12f4d2
 golang.org/x/time a4bde12657593d5e90d0533a3e4fd95e635124cb
 github.com/mreiferson/go-httpclient 63fe23f7434723dc904c901043af07931f293c47
-github.com/hashicorp/go-memdb 608dda3b1410a73eaf3ac8b517c9ae7ebab6aa87 https://github.com/floridoo/go-memdb
+github.com/hashicorp/go-memdb 608dda3b1410a73eaf3ac8b517c9ae7ebab6aa87
 github.com/hashicorp/go-immutable-radix 8e8ed81f8f0bf1bdd829593fdd5c29922c1ea990
 github.com/hashicorp/golang-lru a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
 github.com/coreos/pkg fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8


### PR DESCRIPTION
commit 9322636c8926f155a10d9679e364e3f8e86203d6 (https://github.com/docker/docker/pull/28077) temporarily switched to a fork of go-memdb, because a pull request that was needed (https://github.com/hashicorp/go-memdb/pull/17) was not yet merged upstream. This pull request was merged, so we can un-fork this dependency.

This change does not bump the dependency, and only un-forks. bumping the dependency should be done in a separate change, if needed.