### PR TITLE
[1.13] Fix parsing resources from compose file for stack deploy

### DIFF
--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -723,10 +723,14 @@ func convertUpdateConfig(source *composetypes.UpdateConfig) *swarm.UpdateConfig 
 
 func convertResources(source composetypes.Resources) (*swarm.ResourceRequirements, error) {
 	resources := &swarm.ResourceRequirements{}
+	var err error
 	if source.Limits != nil {
-		cpus, err := opts.ParseCPUs(source.Limits.NanoCPUs)
-		if err != nil {
-			return nil, err
+		var cpus int64
+		if source.Limits.NanoCPUs != "" {
+			cpus, err = opts.ParseCPUs(source.Limits.NanoCPUs)
+			if err != nil {
+				return nil, err
+			}
 		}
 		resources.Limits = &swarm.Resources{
 			NanoCPUs:    cpus,
@@ -734,9 +738,12 @@ func convertResources(source composetypes.Resources) (*swarm.ResourceRequirement
 		}
 	}
 	if source.Reservations != nil {
-		cpus, err := opts.ParseCPUs(source.Reservations.NanoCPUs)
-		if err != nil {
-			return nil, err
+		var cpus int64
+		if source.Reservations.NanoCPUs != "" {
+			cpus, err = opts.ParseCPUs(source.Reservations.NanoCPUs)
+			if err != nil {
+				return nil, err
+			}
 		}
 		resources.Reservations = &swarm.Resources{
 			NanoCPUs:    cpus,

--- a/cli/command/stack/deploy_test.go
+++ b/cli/command/stack/deploy_test.go
@@ -5,6 +5,7 @@ import (
 
 	composetypes "github.com/aanand/compose-file/types"
 	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/pkg/testutil/assert"
 )
 
@@ -27,4 +28,27 @@ func TestConvertVolumeToMountInvalidFormat(t *testing.T) {
 		_, err := convertVolumeToMount(vol, map[string]composetypes.VolumeConfig{}, namespace)
 		assert.Error(t, err, "invalid volume: "+vol)
 	}
+}
+
+func TestConvertResourcesOnlyMemory(t *testing.T) {
+	source := composetypes.Resources{
+		Limits: &composetypes.Resource{
+			MemoryBytes: composetypes.UnitBytes(300000000),
+		},
+		Reservations: &composetypes.Resource{
+			MemoryBytes: composetypes.UnitBytes(200000000),
+		},
+	}
+	resources, err := convertResources(source)
+	assert.NilError(t, err)
+
+	expected := &swarm.ResourceRequirements{
+		Limits: &swarm.Resources{
+			MemoryBytes: 300000000,
+		},
+		Reservations: &swarm.Resources{
+			MemoryBytes: 200000000,
+		},
+	}
+	assert.DeepEqual(t, resources, expected)
 }


### PR DESCRIPTION
Fixes #29998 for 1.13.x branch See #30005 for master fix