### PR TITLE
Fix parsing resources from compose file for stack deploy.

### DIFF
--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -263,10 +263,14 @@ func convertUpdateConfig(source *composetypes.UpdateConfig) *swarm.UpdateConfig 
 
 func convertResources(source composetypes.Resources) (*swarm.ResourceRequirements, error) {
 	resources := &swarm.ResourceRequirements{}
+	var err error
 	if source.Limits != nil {
-		cpus, err := opts.ParseCPUs(source.Limits.NanoCPUs)
-		if err != nil {
-			return nil, err
+		var cpus int64
+		if source.Limits.NanoCPUs != "" {
+			cpus, err = opts.ParseCPUs(source.Limits.NanoCPUs)
+			if err != nil {
+				return nil, err
+			}
 		}
 		resources.Limits = &swarm.Resources{
 			NanoCPUs:    cpus,
@@ -274,9 +278,12 @@ func convertResources(source composetypes.Resources) (*swarm.ResourceRequirement
 		}
 	}
 	if source.Reservations != nil {
-		cpus, err := opts.ParseCPUs(source.Reservations.NanoCPUs)
-		if err != nil {
-			return nil, err
+		var cpus int64
+		if source.Reservations.NanoCPUs != "" {
+			cpus, err = opts.ParseCPUs(source.Reservations.NanoCPUs)
+			if err != nil {
+				return nil, err
+			}
 		}
 		resources.Reservations = &swarm.Resources{
 			NanoCPUs:    cpus,

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -80,6 +80,29 @@ func TestConvertResourcesFull(t *testing.T) {
 	assert.DeepEqual(t, resources, expected)
 }
 
+func TestConvertResourcesOnlyMemory(t *testing.T) {
+	source := composetypes.Resources{
+		Limits: &composetypes.Resource{
+			MemoryBytes: composetypes.UnitBytes(300000000),
+		},
+		Reservations: &composetypes.Resource{
+			MemoryBytes: composetypes.UnitBytes(200000000),
+		},
+	}
+	resources, err := convertResources(source)
+	assert.NilError(t, err)
+
+	expected := &swarm.ResourceRequirements{
+		Limits: &swarm.Resources{
+			MemoryBytes: 300000000,
+		},
+		Reservations: &swarm.Resources{
+			MemoryBytes: 200000000,
+		},
+	}
+	assert.DeepEqual(t, resources, expected)
+}
+
 func TestConvertHealthcheck(t *testing.T) {
 	retries := uint64(10)
 	source := &composetypes.HealthCheckConfig{


### PR DESCRIPTION
Fixes #29998 for master. See #30004 for 1.13.x fix