### PR TITLE
[1.13] Update vendored swarmkit to 8ea08a3

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -100,7 +100,7 @@ github.com/docker/containerd 03e5862ec0d8d3b3f750e19fca3ee367e13c090e
 github.com/tonistiigi/fifo 1405643975692217d6720f8b54aeee1bf2cd5cf4
 
 # cluster
-github.com/docker/swarmkit 7f910df8587ad86b62be7a023a2236183e68d879
+github.com/docker/swarmkit 8ea08a3c9372c8b5db722d9d857a568a8c5abb20
 github.com/golang/mock bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 github.com/gogo/protobuf v0.3
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a

--- a/vendor/github.com/docker/swarmkit/manager/state/raft/raft.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/raft/raft.go
@@ -505,9 +505,7 @@ func (n *Node) Run(ctx context.Context) error {
 					n.campaignWhenAble = false
 				}
 				if len(members) == 1 && members[n.Config.ID] != nil {
-					if err := n.raftNode.Campaign(ctx); err != nil {
-						panic("raft: cannot campaign to be the leader on node restore")
-					}
+					n.raftNode.Campaign(ctx)
 				}
 			}
 


### PR DESCRIPTION
Update vendored swarmkit. This brings in one fix:

- raft: Don't panic on Campaign failure (https://github.com/docker/swarmkit/pull/1848)