### PR TITLE
Provide password to volume create command

### DIFF
--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -46,6 +46,8 @@ operation, such as creating a volume.
 In the following example, you install the `sshfs` plugin, verify that it is
 enabled, and use it to create a volume.
 
+> **Note**: This example is intended for instructional purposes only. Once the volume is created, your SSH password to the remote host will be exposed as plaintext when inspecting the volume. You should delete the volume as soon as you are done with the example.
+
 1.  Install the `sshfs` plugin.
 
     ```bash
@@ -75,13 +77,16 @@ enabled, and use it to create a volume.
 
 3.  Create a volume using the plugin.
     This example mounts the `/remote` directory on host `1.2.3.4` into a
-    volume named `sshvolume`. This volume can now be mounted into containers.
+    volume named `sshvolume`.   
+   
+    This volume can now be mounted into containers.
 
     ```bash
     $ docker volume create \
       -d vieux/sshfs \
       --name sshvolume \
-      -o sshcmd=user@1.2.3.4:/remote
+      -o sshcmd=user@1.2.3.4:/remote \
+      -o password=$(cat file_containing_password_for_remote_host)
 
     sshvolume
     ```
@@ -97,11 +102,17 @@ enabled, and use it to create a volume.
 5.  Start a container that uses the volume `sshvolume`.
 
     ```bash
-    $ docker run -v sshvolume:/data busybox ls /data
+    $ docker run --rm -v sshvolume:/data busybox ls /data
 
     <content of /remote on machine 1.2.3.4>
     ```
 
+6.  Remove the volume `sshvolume`
+    ```bash
+    docker volume rm sshvolume
+    
+    sshvolume
+    ```
 To disable a plugin, use the `docker plugin disable` command. To completely
 remove it, use the `docker plugin remove` command. For other available
 commands and options, see the


### PR DESCRIPTION
**- What I did**
Updated docs to show use of password option when creating docker volume using sshfs plugin. 

This is necessary because: depending on the host configuration between the docker engine and the remote host we wish to mount using sshfs, a password may be required.

* Confirmed syntax for optional parameter with @vieux
* Verified change works as desired with engine running on Ubuntu host and mounting a volume from a file system on a Mac.

**- How to verify it**
Follow the revised example

**- Description for the changelog**
Updated docs to show use of password option when creating docker volume using sshfs plugin. 

Signed-off-by: David Williamson <david.williamson@docker.com>

cc: @vieux 