### PR TITLE
Plugins: Rename DeviceCreation to AllowAllDevices

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1444,13 +1444,13 @@ definitions:
           Linux:
             type: "object"
             x-nullable: false
-            required: [Capabilities, DeviceCreation, Devices]
+            required: [Capabilities, AllowAllDevices, Devices]
             properties:
               Capabilities:
                 type: "array"
                 items:
                   type: "string"
-              DeviceCreation:
+              AllowAllDevices:
                 type: "boolean"
                 x-nullable: false
               Devices:
@@ -1522,7 +1522,7 @@ definitions:
           Type: ""
         Linux:
           Capabilities: null
-          DeviceCreation: false
+          AllowAllDevices: false
           Devices: null
         Mounts: null
         PropagatedMount: "/data"
@@ -6364,7 +6364,7 @@ paths:
                     Type: ""
                   Linux:
                     Capabilities: null
-                    DeviceCreation: false
+                    AllowAllDevices: false
                     Devices: null
                   Mounts: null
                   PropagatedMount: "/data"

--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -120,13 +120,13 @@ type PluginConfigInterface struct {
 // swagger:model PluginConfigLinux
 type PluginConfigLinux struct {
 
+	// allow all devices
+	// Required: true
+	AllowAllDevices bool `json:"AllowAllDevices"`
+
 	// capabilities
 	// Required: true
 	Capabilities []string `json:"Capabilities"`
-
-	// device creation
-	// Required: true
-	DeviceCreation bool `json:"DeviceCreation"`
 
 	// devices
 	// Required: true

--- a/docs/extend/config.md
+++ b/docs/extend/config.md
@@ -153,6 +153,10 @@ Config provides the base accessible fields for working with V0 plugin format
 
           capabilities of the plugin (*Linux only*), see list [`here`](https://github.com/opencontainers/runc/blob/master/libcontainer/SPEC.md#security)
 
+    - **`allowAllDevices`** *boolean*
+
+	If `/dev` is bind mounted from the host, and allowAllDevices is set to true, the plugin will have `rwm` access to all devices on the host.
+
     - **`devices`** *PluginDevice array*
 
           device of the plugin, (*Linux only*), struct consisting of the following fields, see [`DEVICES`](https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#devices)
@@ -205,7 +209,7 @@ Config provides the base accessible fields for working with V0 plugin format
             },
             "Linux": {
                 "Capabilities": null,
-                "DeviceCreation": false,
+                "AllowAllDevices": false,
                 "Devices": null
             },
             "Mounts": null,

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -159,10 +159,10 @@ func computePrivileges(c types.PluginConfig) (types.PluginPrivileges, error) {
 			})
 		}
 	}
-	if c.Linux.DeviceCreation {
+	if c.Linux.AllowAllDevices {
 		privileges = append(privileges, types.PluginPrivilege{
-			Name:        "device-creation",
-			Description: "allow creating devices inside plugin",
+			Name:        "allow-all-devices",
+			Description: "allow 'rwm' access to all devices",
 			Value:       []string{"true"},
 		})
 	}

--- a/plugin/v2/plugin_linux.go
+++ b/plugin/v2/plugin_linux.go
@@ -87,7 +87,7 @@ func (p *Plugin) InitSpec(execRoot string) (*specs.Spec, error) {
 		s.Linux.RootfsPropagation = "rshared"
 	}
 
-	if p.PluginObj.Config.Linux.DeviceCreation {
+	if p.PluginObj.Config.Linux.AllowAllDevices {
 		rwm := "rwm"
 		s.Linux.Resources.Devices = []specs.DeviceCgroup{{Allow: true, Access: &rwm}}
 	}


### PR DESCRIPTION
Rename DeviceCreation to AllowAllDevices

This field was already usable as a permissive workaround for #28948. This PR clarifies the field's name.