### PR TITLE
Few stack deploy network fixes

### DIFF
--- a/cli/compose/convert/compose.go
+++ b/cli/compose/convert/compose.go
@@ -43,20 +43,15 @@ func AddStackLabel(namespace Namespace, labels map[string]string) map[string]str
 type networkMap map[string]composetypes.NetworkConfig
 
 // Networks from the compose-file type to the engine API type
-func Networks(namespace Namespace, networks networkMap) (map[string]types.NetworkCreate, []string) {
+func Networks(namespace Namespace, networks networkMap, servicesNetworks map[string]struct{}) (map[string]types.NetworkCreate, []string) {
 	if networks == nil {
 		networks = make(map[string]composetypes.NetworkConfig)
 	}
 
-	// TODO: only add default network if it's used
-	if _, ok := networks["default"]; !ok {
-		networks["default"] = composetypes.NetworkConfig{}
-	}
-
 	externalNetworks := []string{}
 	result := make(map[string]types.NetworkCreate)
-
-	for internalName, network := range networks {
+	for internalName := range servicesNetworks {
+		network := networks[internalName]
 		if network.External.External {
 			externalNetworks = append(externalNetworks, network.External.Name)
 			continue

--- a/cli/compose/convert/compose_test.go
+++ b/cli/compose/convert/compose_test.go
@@ -28,6 +28,11 @@ func TestAddStackLabel(t *testing.T) {
 
 func TestNetworks(t *testing.T) {
 	namespace := Namespace{name: "foo"}
+	serviceNetworks := map[string]struct{}{
+		"normal":  {},
+		"outside": {},
+		"default": {},
+	}
 	source := networkMap{
 		"normal": composetypes.NetworkConfig{
 			Driver: "overlay",
@@ -79,7 +84,7 @@ func TestNetworks(t *testing.T) {
 		},
 	}
 
-	networks, externals := Networks(namespace, source)
+	networks, externals := Networks(namespace, source, serviceNetworks)
 	assert.DeepEqual(t, networks, expected)
 	assert.DeepEqual(t, externals, []string{"special"})
 }


### PR DESCRIPTION
Follow-up from #29994 in master 👼 

- Make sure we use the correct network name for external ones.
- Make the default network overridable and only creates networks that
  are used by services — so that default network is only created if a
  service doesn't declare a network.

Some stuff were already fixed 😝 

/cc @thaJeztah @dnephin

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
