### PR TITLE
Add support for xdg config folder for docker cli

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -165,7 +165,7 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions) error {
 	cli.defaultVersion = cli.client.ClientVersion()
 
 	if opts.Common.TrustKey == "" {
-		cli.keyFile = filepath.Join(cliconfig.Dir(), cliflags.DefaultTrustKeyFile)
+		cli.keyFile = filepath.Join(cliconfig.GetDir(""), cliflags.DefaultTrustKeyFile)
 	} else {
 		cli.keyFile = opts.Common.TrustKey
 	}
@@ -195,9 +195,9 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer) *DockerCli {
 // LoadDefaultConfigFile attempts to load the default config file and returns
 // an initialized ConfigFile struct if none is found.
 func LoadDefaultConfigFile(err io.Writer) *configfile.ConfigFile {
-	configFile, e := cliconfig.Load(cliconfig.Dir())
+	configFile, e := cliconfig.Load()
 	if e != nil {
-		fmt.Fprintf(err, "WARNING: Error loading config file:%v\n", e)
+		fmt.Fprintf(err, "WARNING: %v\n", e)
 	}
 	if !configFile.ContainsAuth() {
 		credentials.DetectDefaultStore(configFile)

--- a/cli/config/config_linux.go
+++ b/cli/config/config_linux.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/cli/config/xdg"
+	"github.com/docker/docker/pkg/homedir"
+)
+
+func init() {
+	if readConfigDir == "" {
+		xdgConfigDir, err := xdg.GetConfigFile(configFileDir)
+		if err != nil {
+			legacyConfigDir := filepath.Join(homedir.Get(), dotconfigFileDir)
+			//_, err := os.Stat(filepath.Join(legacyConfigDir, ConfigFileName))
+			_, err := os.Stat(legacyConfigDir)
+			if err == nil || os.IsExist(err) {
+				readConfigDir = legacyConfigDir
+			}
+		} else {
+			_, err := os.Stat(filepath.Join(xdgConfigDir, ConfigFileName))
+			if err == nil || os.IsExist(err) {
+				readConfigDir = xdgConfigDir
+			}
+		}
+		writeConfigDir = xdgConfigDir
+	}
+}

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -20,7 +20,7 @@ func TestEmptyConfigDir(t *testing.T) {
 
 	SetDir(tmpHome)
 
-	config, err := Load("")
+	config, err := Load()
 	if err != nil {
 		t.Fatalf("Failed loading on empty config dir: %q", err)
 	}
@@ -28,22 +28,6 @@ func TestEmptyConfigDir(t *testing.T) {
 	expectedConfigFilename := filepath.Join(tmpHome, ConfigFileName)
 	if config.Filename != expectedConfigFilename {
 		t.Fatalf("Expected config filename %s, got %s", expectedConfigFilename, config.Filename)
-	}
-
-	// Now save it and make sure it shows up in new form
-	saveConfigAndValidateNewFormat(t, config, tmpHome)
-}
-
-func TestMissingFile(t *testing.T) {
-	tmpHome, err := ioutil.TempDir("", "config-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpHome)
-
-	config, err := Load(tmpHome)
-	if err != nil {
-		t.Fatalf("Failed loading on missing file: %q", err)
 	}
 
 	// Now save it and make sure it shows up in new form
@@ -58,8 +42,9 @@ func TestSaveFileToDirs(t *testing.T) {
 	defer os.RemoveAll(tmpHome)
 
 	tmpHome += "/.docker"
+	SetDir(tmpHome)
 
-	config, err := Load(tmpHome)
+	config, err := Load()
 	if err != nil {
 		t.Fatalf("Failed loading on missing file: %q", err)
 	}
@@ -80,7 +65,9 @@ func TestEmptyFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = Load(tmpHome)
+	SetDir(tmpHome)
+
+	_, err = Load()
 	if err == nil {
 		t.Fatalf("Was supposed to fail")
 	}
@@ -97,8 +84,9 @@ func TestEmptyJSON(t *testing.T) {
 	if err := ioutil.WriteFile(fn, []byte("{}"), 0600); err != nil {
 		t.Fatal(err)
 	}
+	SetDir(tmpHome)
 
-	config, err := Load(tmpHome)
+	config, err := Load()
 	if err != nil {
 		t.Fatalf("Failed loading on empty json file: %q", err)
 	}
@@ -134,7 +122,7 @@ email`: "Invalid auth configuration file",
 			t.Fatal(err)
 		}
 
-		config, err := Load(tmpHome)
+		config, err := Load()
 		// Use Contains instead of == since the file name will change each time
 		if err == nil || !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("Should have failed\nConfig: %v\nGot: %v\nExpected: %v", config, err, expectedError)
@@ -166,7 +154,8 @@ func TestOldValidAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config, err := Load(tmpHome)
+	SetDir(tmpHome)
+	config, err := Load()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +201,8 @@ func TestOldJSONInvalid(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config, err := Load(tmpHome)
+	SetDir(tmpHome)
+	config, err := Load()
 	// Use Contains instead of == since the file name will change each time
 	if err == nil || !strings.Contains(err.Error(), "Invalid auth configuration file") {
 		t.Fatalf("Expected an error got : %v, %v", config, err)
@@ -238,7 +228,8 @@ func TestOldJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config, err := Load(tmpHome)
+	SetDir(tmpHome)
+	config, err := Load()
 	if err != nil {
 		t.Fatalf("Failed loading on empty json file: %q", err)
 	}
@@ -278,7 +269,8 @@ func TestNewJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config, err := Load(tmpHome)
+	SetDir(tmpHome)
+	config, err := Load()
 	if err != nil {
 		t.Fatalf("Failed loading on empty json file: %q", err)
 	}
@@ -317,7 +309,8 @@ func TestNewJSONNoEmail(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config, err := Load(tmpHome)
+	SetDir(tmpHome)
+	config, err := Load()
 	if err != nil {
 		t.Fatalf("Failed loading on empty json file: %q", err)
 	}
@@ -359,7 +352,8 @@ func TestJSONWithPsFormat(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config, err := Load(tmpHome)
+	SetDir(tmpHome)
+	config, err := Load()
 	if err != nil {
 		t.Fatalf("Failed loading on empty json file: %q", err)
 	}
@@ -392,7 +386,8 @@ func TestJSONWithCredentialStore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config, err := Load(tmpHome)
+	SetDir(tmpHome)
+	config, err := Load()
 	if err != nil {
 		t.Fatalf("Failed loading on empty json file: %q", err)
 	}
@@ -425,7 +420,8 @@ func TestJSONWithCredentialHelpers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config, err := Load(tmpHome)
+	SetDir(tmpHome)
+	config, err := Load()
 	if err != nil {
 		t.Fatalf("Failed loading on empty json file: %q", err)
 	}
@@ -471,15 +467,15 @@ func TestConfigDir(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpHome)
 
-	if Dir() == tmpHome {
+	if GetDir("") == tmpHome {
 		t.Fatalf("Expected ConfigDir to be different than %s by default, but was the same", tmpHome)
 	}
 
 	// Update configDir
 	SetDir(tmpHome)
 
-	if Dir() != tmpHome {
-		t.Fatalf("Expected ConfigDir to %s, but was %s", tmpHome, Dir())
+	if GetDir("") != tmpHome {
+		t.Fatalf("Expected ConfigDir to %s, but was %s", tmpHome, GetDir(""))
 	}
 }
 

--- a/cli/config/xdg/xdg.go
+++ b/cli/config/xdg/xdg.go
@@ -1,0 +1,50 @@
+package xdg
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/docker/pkg/homedir"
+)
+
+const (
+	defaultConfig          = ".config"
+	defaultGlobalConfigDir = "/etc/xdg"
+)
+
+// GetConfigFile returns the path of the specified file following xdg base directory specifications
+func GetConfigFile(filename string) (string, error) {
+	return getFileNameFromDirs(filename, getConfigDirs())
+}
+func getConfigDirs() []string {
+	dirs := []string{}
+	xdgHomeConfig := os.Getenv("XDG_CONFIG_HOME")
+	if xdgHomeConfig != "" {
+		dirs = append(dirs, xdgHomeConfig)
+	} else {
+		dirs = append(dirs, filepath.Join(homedir.Get(), defaultConfig))
+	}
+	xdgConfigDirs := os.Getenv("XDG_CONFIG_DIRS")
+	if xdgConfigDirs != "" {
+		configDirs := strings.Split(xdgConfigDirs, ":")
+		for _, configDir := range configDirs {
+			dirs = append(dirs, configDir)
+		}
+	} else {
+		dirs = append(dirs, defaultGlobalConfigDir)
+	}
+	return dirs
+}
+
+func getFileNameFromDirs(filename string, dirs []string) (string, error) {
+	defaultDir := dirs[0]
+	for _, dir := range dirs {
+		fileLoc := filepath.Join(dir, filename)
+		if _, err := os.Stat(fileLoc); err != nil {
+			continue
+		}
+		return fileLoc, nil
+	}
+	return filepath.Join(defaultDir, filename), os.ErrNotExist
+}

--- a/cli/config/xdg/xdg_test.go
+++ b/cli/config/xdg/xdg_test.go
@@ -1,0 +1,113 @@
+// +build linux
+
+package xdg
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/pkg/homedir"
+)
+
+func TestGetConfigFileEmptyEnvironmentAndNoFile(t *testing.T) {
+	defer withEnv(map[string]string{})()
+	actual, err := GetConfigFile("a/path")
+	if err == nil {
+		t.Fatalf("expected an error, got nothing : %s", actual)
+	}
+	expected := filepath.Join(homedir.Get(), ".config/a/path")
+	if actual != expected {
+		t.Fatalf("expected %s, got %s", expected, actual)
+	}
+}
+
+func TestGetConfigFileWithXDGConfigAndNoFile(t *testing.T) {
+	defer withEnv(map[string]string{"XDG_CONFIG_HOME": "/a/config/path"})()
+	actual, err := GetConfigFile("a/path")
+	if err == nil {
+		t.Fatalf("expected an error, got nothing : %s", actual)
+	}
+	expected := "/a/config/path/a/path"
+	if actual != expected {
+		t.Fatalf("expected %s, got %s", expected, actual)
+	}
+}
+
+func TestGetConfigFileXdgConfigDirsAndNoFile(t *testing.T) {
+	defer withEnv(map[string]string{"XDG_CONFIG_DIRS": "/a/config/path:/another/config/path"})()
+	actual, err := GetConfigFile("a/path")
+	if err == nil {
+		t.Fatalf("expected an error, got nothing : %s", actual)
+	}
+	expected := filepath.Join(homedir.Get(), ".config/a/path")
+	if actual != expected {
+		t.Fatalf("expected %s, got %s", expected, actual)
+	}
+}
+
+func TestGetConfigFileWithXDGConfigHomeAndAFile(t *testing.T) {
+	folder, cleanTemporaryFn := createTemporaryFile(t, "a/path")
+	defer cleanTemporaryFn()
+	defer withEnv(map[string]string{"XDG_CONFIG_HOME": folder})()
+	actual, err := GetConfigFile("a/path")
+	if err != nil {
+		t.Fatalf("expected no error, got %v : %s", err, actual)
+	}
+	expected := filepath.Join(folder, "a/path")
+	if actual != expected {
+		t.Fatalf("expected %s, got %s", expected, actual)
+	}
+}
+
+func TestGetConfigFileXdgConfigDirsAndAFile(t *testing.T) {
+	folder, cleanTemporaryFn := createTemporaryFile(t, "a/path")
+	defer cleanTemporaryFn()
+	defer withEnv(map[string]string{"XDG_CONFIG_DIRS": "/a/config/path:" + folder})()
+	actual, err := GetConfigFile("a/path")
+	if err != nil {
+		t.Fatalf("expected no error, got %v : %s", err, actual)
+	}
+	expected := filepath.Join(folder, "a/path")
+	if actual != expected {
+		t.Fatalf("expected %s, got %s", expected, actual)
+	}
+}
+
+func createTemporaryFile(t *testing.T, filename string) (string, func()) {
+	tmpFolder, err := ioutil.TempDir("", "xdg-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := filepath.Join(tmpFolder, filepath.Dir(filename))
+	if err := os.MkdirAll(d, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(tmpFolder, filename), []byte("content"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return tmpFolder, func() {
+		if err := os.RemoveAll(d); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func withEnv(envs map[string]string) func() {
+	oldEnvs := os.Environ()
+	for _, oldEnv := range oldEnvs {
+		key := strings.Split(oldEnv, "=")[0]
+		os.Unsetenv(key)
+	}
+	for key, value := range envs {
+		os.Setenv(key, value)
+	}
+	return func() {
+		for _, oldEnv := range oldEnvs {
+			e := strings.SplitN(oldEnv, "=", 2)
+			os.Setenv(e[0], e[1])
+		}
+	}
+}

--- a/cli/flags/common.go
+++ b/cli/flags/common.go
@@ -49,7 +49,7 @@ func NewCommonOptions() *CommonOptions {
 // InstallFlags adds flags for the common options on the FlagSet
 func (commonOpts *CommonOptions) InstallFlags(flags *pflag.FlagSet) {
 	if dockerCertPath == "" {
-		dockerCertPath = cliconfig.Dir()
+		dockerCertPath = cliconfig.GetDir("")
 	}
 
 	flags.BoolVarP(&commonOpts.Debug, "debug", "D", false, "Enable debug mode")

--- a/cli/flags/common_test.go
+++ b/cli/flags/common_test.go
@@ -26,7 +26,7 @@ func TestCommonOptionsInstallFlags(t *testing.T) {
 }
 
 func defaultPath(filename string) string {
-	return filepath.Join(cliconfig.Dir(), filename)
+	return filepath.Join(cliconfig.GetDir(""), filename)
 }
 
 func TestCommonOptionsInstallFlagsWithDefaults(t *testing.T) {

--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -37,7 +37,7 @@ var (
 )
 
 func trustDirectory() string {
-	return filepath.Join(cliconfig.Dir(), "trust")
+	return cliconfig.GetDir("trust")
 }
 
 // certificateDirectory returns the directory containing
@@ -49,7 +49,7 @@ func certificateDirectory(server string) (string, error) {
 		return "", err
 	}
 
-	return filepath.Join(cliconfig.Dir(), "tls", u.Host), nil
+	return filepath.Join(cliconfig.GetDir("tls"), u.Host), nil
 }
 
 // Server returns the base URL for the trust server.

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -56,7 +56,7 @@ func newDockerCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 	flags = cmd.Flags()
 	flags.BoolVarP(&opts.Version, "version", "v", false, "Print version information and quit")
-	flags.StringVar(&opts.ConfigDir, "config", cliconfig.Dir(), "Location of client config files")
+	flags.StringVar(&opts.ConfigDir, "config", cliconfig.GetDir(""), "Location of client config files")
 	opts.Common.InstallFlags(flags)
 
 	setFlagErrorFunc(dockerCli, cmd, flags, opts)
@@ -189,7 +189,7 @@ func showVersion() {
 func dockerPreRun(opts *cliflags.ClientOptions) {
 	cliflags.SetLogLevel(opts.Common.LogLevel)
 
-	if opts.ConfigDir != "" {
+	if opts.ConfigDir != "" && opts.ConfigDir != cliconfig.GetDir("") {
 		cliconfig.SetDir(opts.ConfigDir)
 	}
 

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -77,7 +77,7 @@ func migrateKey(config *config.Config) (err error) {
 	}
 
 	// Migrate trust key if exists at ~/.docker/key.json and owned by current user
-	oldPath := filepath.Join(cliconfig.Dir(), cliflags.DefaultTrustKeyFile)
+	oldPath := filepath.Join(cliconfig.GetDir(""), cliflags.DefaultTrustKeyFile)
 	newPath := filepath.Join(getDaemonConfDir(config.Root), cliflags.DefaultTrustKeyFile)
 	if _, statErr := os.Stat(newPath); os.IsNotExist(statErr) && currentUserIsOwner(oldPath) {
 		defer func() {

--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -396,6 +396,7 @@ func (s *DockerTrustSuite) SetUpTest(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TearDownTest(c *check.C) {
+	s.ds.TearDownTest(c)
 	if s.reg != nil {
 		s.reg.Close()
 	}
@@ -404,8 +405,7 @@ func (s *DockerTrustSuite) TearDownTest(c *check.C) {
 	}
 
 	// Remove trusted keys and metadata after test
-	os.RemoveAll(filepath.Join(cliconfig.Dir(), "trust"))
-	s.ds.TearDownTest(c)
+	os.RemoveAll(cliconfig.GetDir("trust"))
 }
 
 func init() {

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -521,10 +521,10 @@ func (s *DockerDaemonSuite) TestDaemonKeyMigration(c *check.C) {
 	if err != nil {
 		c.Fatalf("Error generating private key: %s", err)
 	}
-	if err := os.MkdirAll(filepath.Join(os.Getenv("HOME"), ".docker"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(os.Getenv("HOME"), ".config", "docker"), 0755); err != nil {
 		c.Fatalf("Error creating .docker directory: %s", err)
 	}
-	if err := libtrust.SaveKey(filepath.Join(os.Getenv("HOME"), ".docker", "key.json"), k1); err != nil {
+	if err := libtrust.SaveKey(filepath.Join(os.Getenv("HOME"), ".config", "docker", "key.json"), k1); err != nil {
 		c.Fatalf("Error saving private key: %s", err)
 	}
 

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -295,7 +295,7 @@ func (s *DockerTrustSuite) TestTrustedPush(c *check.C) {
 	})
 
 	// Assert that we rotated the snapshot key to the server by checking our local keystore
-	contents, err := ioutil.ReadDir(filepath.Join(cliconfig.Dir(), "trust/private/tuf_keys", privateRegistryURL, "dockerclitrusted/pushtest"))
+	contents, err := ioutil.ReadDir(filepath.Join(cliconfig.GetDir("trust"), "private", "tuf_keys", privateRegistryURL, "dockerclitrusted", "pushtest"))
 	c.Assert(err, check.IsNil, check.Commentf("Unable to read local tuf key files"))
 	// Check that we only have 1 key (targets key)
 	c.Assert(contents, checker.HasLen, 1)
@@ -442,7 +442,7 @@ func (s *DockerTrustSuite) TestTrustedPushWithReleasesDelegationOnly(c *check.C)
 	s.assertTargetNotInRoles(c, repoName, "latest", "targets")
 
 	// Try pull after push
-	os.RemoveAll(filepath.Join(cliconfig.Dir(), "trust"))
+	os.RemoveAll(filepath.Join(cliconfig.GetDir("trust")))
 
 	icmd.RunCmd(icmd.Command(dockerBinary, "pull", targetName), trustedCmd).Assert(c, icmd.Expected{
 		Out: "Status: Image is up to date",
@@ -479,7 +479,7 @@ func (s *DockerTrustSuite) TestTrustedPushSignsAllFirstLevelRolesWeHaveKeysFor(c
 	s.assertTargetNotInRoles(c, repoName, "latest", "targets")
 
 	// Try pull after push
-	os.RemoveAll(filepath.Join(cliconfig.Dir(), "trust"))
+	os.RemoveAll(filepath.Join(cliconfig.GetDir("trust")))
 
 	// pull should fail because none of these are the releases role
 	icmd.RunCmd(icmd.Command(dockerBinary, "pull", targetName), trustedCmd).Assert(c, icmd.Expected{
@@ -515,7 +515,7 @@ func (s *DockerTrustSuite) TestTrustedPushSignsForRolesWithKeysAndValidPaths(c *
 	s.assertTargetNotInRoles(c, repoName, "latest", "targets")
 
 	// Try pull after push
-	os.RemoveAll(filepath.Join(cliconfig.Dir(), "trust"))
+	os.RemoveAll(filepath.Join(cliconfig.GetDir("trust")))
 
 	// pull should fail because none of these are the releases role
 	icmd.RunCmd(icmd.Command(dockerBinary, "pull", targetName), trustedCmd).Assert(c, icmd.Expected{

--- a/integration-cli/trust_server_test.go
+++ b/integration-cli/trust_server_test.go
@@ -115,7 +115,7 @@ func newTestNotary(c *check.C) (*testNotary, error) {
 		"skipTLSVerify": true
 	}
 }`
-	if _, err = fmt.Fprintf(clientConfig, template, filepath.Join(cliconfig.Dir(), "trust"), notaryURL); err != nil {
+	if _, err = fmt.Fprintf(clientConfig, template, filepath.Join(cliconfig.GetDir("trust")), notaryURL); err != nil {
 		os.RemoveAll(tmp)
 		return nil, err
 	}


### PR DESCRIPTION
Make the docker CLI able to look for `XDG_CONFIG_HOME` for client configuration files. It will do this by default, and thus, on a clean, new docker installation it will always write on `XDG_CONFIG_HOME` (and default is `$HOME/.config`). 

But if a legacy configuration is there (`$HOME/.docker/config.json`), then it will still use it until it is moved to `XDG_CONFIG_HOME`.

This is only for **Linux**. Nothing should change for other platform.

```bash
$ docker info                                              
WARNING: configuration migrated from /root/.docker/config.json to /root/.config/docker/config.json
# […]
$ docker info
# […]
```

- [x] Should we always write to `$XDG_CONFIG_HOME/docker/config.json` or be conservative if the legacy `$HOME/.docker/config.json` is there.
- [x] This will also look at the files in `XDG_CONFIG_DIRS` (and default is `/etc/xdg/` if empty). These might not be writeable so we should probably always write on `XDG_CONFIG_HOME` or the legacy one if existing.
- [ ] Update docs

Reference https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables

Closes #20693

/cc @thaJeztah @icecrime @dnephin @tianon @runcom @cpuguy83 @tiborvass 

🐸 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
