### PR TITLE
Update vendored swarmkit to 62d835f

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -103,7 +103,7 @@ github.com/docker/containerd 03e5862ec0d8d3b3f750e19fca3ee367e13c090e
 github.com/tonistiigi/fifo 1405643975692217d6720f8b54aeee1bf2cd5cf4
 
 # cluster
-github.com/docker/swarmkit c97146840a26c9ce8023284d0e9c989586cc1857
+github.com/docker/swarmkit 62d835f478b2e4fd2768deb88fb3b32e334faaee
 github.com/golang/mock bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 github.com/gogo/protobuf v0.3
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a

--- a/vendor/github.com/docker/swarmkit/agent/config.go
+++ b/vendor/github.com/docker/swarmkit/agent/config.go
@@ -4,7 +4,7 @@ import (
 	"github.com/boltdb/bolt"
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
-	"github.com/docker/swarmkit/remotes"
+	"github.com/docker/swarmkit/connectionbroker"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/credentials"
 )
@@ -14,9 +14,9 @@ type Config struct {
 	// Hostname the name of host for agent instance.
 	Hostname string
 
-	// Managers provides the manager backend used by the agent. It will be
-	// updated with managers weights as observed by the agent.
-	Managers remotes.Remotes
+	// ConnBroker provides a connection broker for retrieving gRPC
+	// connections to managers.
+	ConnBroker *connectionbroker.Broker
 
 	// Executor specifies the executor to use for the agent.
 	Executor exec.Executor

--- a/vendor/github.com/docker/swarmkit/agent/resource.go
+++ b/vendor/github.com/docker/swarmkit/agent/resource.go
@@ -30,7 +30,7 @@ type ResourceAllocator interface {
 func (r *resourceAllocator) AttachNetwork(ctx context.Context, id, target string, addresses []string) (string, error) {
 	var taskID string
 	if err := r.agent.withSession(ctx, func(session *session) error {
-		client := api.NewResourceAllocatorClient(session.conn)
+		client := api.NewResourceAllocatorClient(session.conn.ClientConn)
 		r, err := client.AttachNetwork(ctx, &api.AttachNetworkRequest{
 			Config: &api.NetworkAttachmentConfig{
 				Target:    target,
@@ -53,7 +53,7 @@ func (r *resourceAllocator) AttachNetwork(ctx context.Context, id, target string
 // DetachNetwork deletes a network attachment.
 func (r *resourceAllocator) DetachNetwork(ctx context.Context, aID string) error {
 	return r.agent.withSession(ctx, func(session *session) error {
-		client := api.NewResourceAllocatorClient(session.conn)
+		client := api.NewResourceAllocatorClient(session.conn.ClientConn)
 		_, err := client.DetachNetwork(ctx, &api.DetachNetworkRequest{
 			AttachmentID: aID,
 		})

--- a/vendor/github.com/docker/swarmkit/connectionbroker/broker.go
+++ b/vendor/github.com/docker/swarmkit/connectionbroker/broker.go
@@ -1,0 +1,105 @@
+// Package connectionbroker is a layer on top of remotes that returns
+// a gRPC connection to a manager. The connection may be a local connection
+// using a local socket such as a UNIX socket.
+package connectionbroker
+
+import (
+	"sync"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/remotes"
+	"google.golang.org/grpc"
+)
+
+// Broker is a simple connection broker. It can either return a fresh
+// connection to a remote manager selected with weighted randomization, or a
+// local gRPC connection to the local manager.
+type Broker struct {
+	mu        sync.Mutex
+	remotes   remotes.Remotes
+	localConn *grpc.ClientConn
+}
+
+// New creates a new connection broker.
+func New(remotes remotes.Remotes) *Broker {
+	return &Broker{
+		remotes: remotes,
+	}
+}
+
+// SetLocalConn changes the local gRPC connection used by the connection broker.
+func (b *Broker) SetLocalConn(localConn *grpc.ClientConn) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.localConn = localConn
+}
+
+// Select a manager from the set of available managers, and return a connection.
+func (b *Broker) Select(dialOpts ...grpc.DialOption) (*Conn, error) {
+	b.mu.Lock()
+	localConn := b.localConn
+	b.mu.Unlock()
+
+	if localConn != nil {
+		return &Conn{
+			ClientConn: localConn,
+			isLocal:    true,
+		}, nil
+	}
+
+	return b.SelectRemote(dialOpts...)
+}
+
+// SelectRemote chooses a manager from the remotes, and returns a TCP
+// connection.
+func (b *Broker) SelectRemote(dialOpts ...grpc.DialOption) (*Conn, error) {
+	peer, err := b.remotes.Select()
+	if err != nil {
+		return nil, err
+	}
+
+	cc, err := grpc.Dial(peer.Addr, dialOpts...)
+	if err != nil {
+		b.remotes.ObserveIfExists(peer, -remotes.DefaultObservationWeight)
+		return nil, err
+	}
+
+	return &Conn{
+		ClientConn: cc,
+		remotes:    b.remotes,
+		peer:       peer,
+	}, nil
+}
+
+// Remotes returns the remotes interface used by the broker, so the caller
+// can make observations or see weights directly.
+func (b *Broker) Remotes() remotes.Remotes {
+	return b.remotes
+}
+
+// Conn is a wrapper around a gRPC client connection.
+type Conn struct {
+	*grpc.ClientConn
+	isLocal bool
+	remotes remotes.Remotes
+	peer    api.Peer
+}
+
+// Close closes the client connection if it is a remote connection. It also
+// records a positive experience with the remote peer if success is true,
+// otherwise it records a negative experience. If a local connection is in use,
+// Close is a noop.
+func (c *Conn) Close(success bool) error {
+	if c.isLocal {
+		return nil
+	}
+
+	if success {
+		c.remotes.ObserveIfExists(c.peer, -remotes.DefaultObservationWeight)
+	} else {
+		c.remotes.ObserveIfExists(c.peer, remotes.DefaultObservationWeight)
+	}
+
+	return c.ClientConn.Close()
+}

--- a/vendor/github.com/docker/swarmkit/manager/dispatcher/dispatcher.go
+++ b/vendor/github.com/docker/swarmkit/manager/dispatcher/dispatcher.go
@@ -133,6 +133,7 @@ type Dispatcher struct {
 }
 
 // New returns Dispatcher with cluster interface(usually raft.Node).
+// NOTE: each handler which does something with raft must add to Dispatcher.wg
 func New(cluster Cluster, c *Config) *Dispatcher {
 	d := &Dispatcher{
 		nodes:                 newNodeStore(c.HeartbeatPeriod, c.HeartbeatEpsilon, c.GracePeriodMultiplier, c.RateLimitPeriod),

--- a/vendor/github.com/docker/swarmkit/manager/state/raft/raft.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/raft/raft.go
@@ -1826,10 +1826,10 @@ func createConfigChangeEnts(ids []uint64, self uint64, term, index uint64) []raf
 // - ConfChangeAddNode, in which case the contained ID will be added into the set.
 // - ConfChangeRemoveNode, in which case the contained ID will be removed from the set.
 func getIDs(snap *raftpb.Snapshot, ents []raftpb.Entry) []uint64 {
-	ids := make(map[uint64]bool)
+	ids := make(map[uint64]struct{})
 	if snap != nil {
 		for _, id := range snap.Metadata.ConfState.Nodes {
-			ids[id] = true
+			ids[id] = struct{}{}
 		}
 	}
 	for _, e := range ents {
@@ -1845,7 +1845,7 @@ func getIDs(snap *raftpb.Snapshot, ents []raftpb.Entry) []uint64 {
 		}
 		switch cc.Type {
 		case raftpb.ConfChangeAddNode:
-			ids[cc.NodeID] = true
+			ids[cc.NodeID] = struct{}{}
 		case raftpb.ConfChangeRemoveNode:
 			delete(ids, cc.NodeID)
 		case raftpb.ConfChangeUpdateNode:


### PR DESCRIPTION
Update vendored swarmkit to 62d835f

This is mostly to keep master up to date with the fix going into 1.13 in #30034. It also happens to bring in most of the preliminary work that was merged in support of https://github.com/docker/swarmkit/pull/1826.