### PR TITLE
Specify in which line the Dockerfile parser failed

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -264,7 +264,7 @@ func (b *Builder) build(stdout io.Writer, stderr io.Writer, out io.Writer) (stri
 	total := len(b.dockerfile.Children)
 	for _, n := range b.dockerfile.Children {
 		if err := b.checkDispatch(n, false); err != nil {
-			return "", err
+			return "", perrors.Wrapf(err, "Dockerfile parse error line %d", n.StartLine)
 		}
 	}
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -7405,3 +7405,55 @@ func (s *DockerSuite) TestBuildWorkdirCmd(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.Count(out, "Using cache"), checker.Equals, 1)
 }
+
+func (s *DockerSuite) TestBuildLineErrorOnBuild(c *check.C) {
+	name := "test_build_line_error_onbuild"
+
+	_, err := buildImage(name,
+		`FROM busybox
+  ONBUILD
+  `, true)
+	c.Assert(err.Error(), checker.Contains, "Dockerfile parse error line 2: ONBUILD requires at least one argument")
+}
+
+func (s *DockerSuite) TestBuildLineErrorUknownInstruction(c *check.C) {
+	name := "test_build_line_error_unknown_instruction"
+
+	_, err := buildImage(name,
+		`FROM busybox
+  RUN echo hello world
+  NOINSTRUCTION echo ba
+  RUN echo hello
+  ERROR
+  `, true)
+	c.Assert(err.Error(), checker.Contains, "Dockerfile parse error line 3: Unknown instruction: NOINSTRUCTION")
+}
+
+func (s *DockerSuite) TestBuildLineErrorWithEmptyLines(c *check.C) {
+	name := "test_build_line_error_with_empty_lines"
+
+	_, err := buildImage(name,
+		`
+  FROM busybox
+
+  RUN echo hello world
+
+  NOINSTRUCTION echo ba
+
+  CMD ["/bin/init"]
+  `, true)
+	c.Assert(err.Error(), checker.Contains, "Dockerfile parse error line 6: Unknown instruction: NOINSTRUCTION")
+}
+
+func (s *DockerSuite) TestBuildLineErrorWithComments(c *check.C) {
+	name := "test_build_line_error_with_comments"
+
+	_, err := buildImage(name,
+		`FROM busybox
+  # This will print hello world
+  # and then ba
+  RUN echo hello world
+  RUM echo ba
+  `, true)
+	c.Assert(err.Error(), checker.Contains, "Dockerfile parse error line 5: Unknown instruction: RUM")
+}


### PR DESCRIPTION
closes #30022 

**- What I did**
Add the line number in the file in the Dockerfile parser error.

**- How I did it**
Apparently, the [parser.Node](https://github.com/docker/docker/blob/master/builder/dockerfile/parser/parser.go#L28-L37) holds the starting line of the command in the file.
Using it, it's easy to concatenate the line number where Docker fails to parse the Dockerfile. 

**- How to verify it**
Run integration-cli tests:
```shell
TESTFLAGS='-check.f DockerSuite.TestBuildLineError*' make test-integration-cli
```

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

