### PR TITLE
Windows: Test for run as local system

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4429,3 +4429,13 @@ func (s *DockerSuite) TestRunAddDeviceCgroupRule(c *check.C) {
 	out, _ = dockerCmd(c, "run", "--rm", fmt.Sprintf("--device-cgroup-rule=%s", deviceRule), "busybox", "grep", deviceRule, "/sys/fs/cgroup/devices/devices.list")
 	c.Assert(strings.TrimSpace(out), checker.Equals, deviceRule)
 }
+
+// Verifies that running as local system is operating correctly on Windows
+func (s *DockerSuite) TestWindowsRunAsSystem(c *check.C) {
+	testRequires(c, DaemonIsWindows)
+	if testEnv.DaemonKernelVersionNumeric() < 15000 {
+		c.Skip("Requires build 15000 or later")
+	}
+	out, _ := dockerCmd(c, "run", "--net=none", `--user=nt authority\system`, "--hostname=XYZZY", minimalBaseImage(), "cmd", "/c", `@echo %USERNAME%`)
+	c.Assert(strings.TrimSpace(out), checker.Equals, "XYZZY$")
+}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Adds a test to validate on post-RS1 builds that running a container as local system operates correctly. (Platform functionality is not in RS1)

