### PR TITLE
[1.13] Update vendored swarmkit to 296fcfc

### DIFF
--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -677,18 +677,8 @@ func (s *DockerSwarmSuite) TestSwarmNetworkPlugin(c *check.C) {
 
 	d := s.AddDaemon(c, true, true)
 
-	out, err := d.Cmd("network", "create", "-d", globalNetworkPlugin, "foo")
-	c.Assert(err, checker.IsNil)
-	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
-
-	name := "top"
-	out, err = d.Cmd("service", "create", "--name", name, "--network", "foo", "busybox", "top")
-	c.Assert(err, checker.IsNil)
-	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
-
-	out, err = d.Cmd("service", "inspect", "--format", "{{range .Spec.Networks}}{{.Target}}{{end}}", name)
-	c.Assert(err, checker.IsNil)
-	c.Assert(strings.TrimSpace(out), checker.Equals, "foo")
+	_, err := d.Cmd("network", "create", "-d", globalNetworkPlugin, "foo")
+	c.Assert(err, checker.NotNil)
 }
 
 // Test case for #24712

--- a/vendor.conf
+++ b/vendor.conf
@@ -100,7 +100,7 @@ github.com/docker/containerd 03e5862ec0d8d3b3f750e19fca3ee367e13c090e
 github.com/tonistiigi/fifo 1405643975692217d6720f8b54aeee1bf2cd5cf4
 
 # cluster
-github.com/docker/swarmkit 70cb786be80c77cc983792a4259ba9098158c32e
+github.com/docker/swarmkit 296fcfcf1e86a26a3f52aa84d638fbf80f9a8443
 github.com/golang/mock bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 github.com/gogo/protobuf v0.3
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a

--- a/vendor/github.com/docker/swarmkit/manager/controlapi/common.go
+++ b/vendor/github.com/docker/swarmkit/manager/controlapi/common.go
@@ -76,7 +76,7 @@ func validateAnnotations(m api.Annotations) error {
 	return nil
 }
 
-func validateDriver(driver *api.Driver) error {
+func validateDriver(driver *api.Driver, defName string) error {
 	if driver == nil {
 		// It is ok to not specify the driver. We will choose
 		// a default driver.
@@ -87,5 +87,8 @@ func validateDriver(driver *api.Driver) error {
 		return grpc.Errorf(codes.InvalidArgument, "driver name: if driver is specified name is required")
 	}
 
+	if driver.Name != defName {
+		return grpc.Errorf(codes.InvalidArgument, "invalid driver (%s) specified", driver.Name)
+	}
 	return nil
 }

--- a/vendor/github.com/docker/swarmkit/manager/controlapi/network.go
+++ b/vendor/github.com/docker/swarmkit/manager/controlapi/network.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/identity"
+	"github.com/docker/swarmkit/manager/allocator/networkallocator"
 	"github.com/docker/swarmkit/manager/state/store"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -54,7 +56,7 @@ func validateIPAM(ipam *api.IPAMOptions) error {
 		return nil
 	}
 
-	if err := validateDriver(ipam.Driver); err != nil {
+	if err := validateDriver(ipam.Driver, ipamapi.DefaultIPAM); err != nil {
 		return err
 	}
 
@@ -76,7 +78,7 @@ func validateNetworkSpec(spec *api.NetworkSpec) error {
 		return err
 	}
 
-	if err := validateDriver(spec.DriverConfig); err != nil {
+	if err := validateDriver(spec.DriverConfig, networkallocator.DefaultDriver); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Update vendored swarmkit to 296fcfc

This brings in the following change, disabling network plugins in swarm mode:

- Gracefully fail if Network and IPAM plugins are used (https://github.com/docker/swarmkit/pull/1856)

cc @mavenugo