### PR TITLE
Add the mediaType to the error

### DIFF
--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -76,7 +76,7 @@ func runPull(dockerCli *command.DockerCli, opts pullOptions) error {
 		err = imagePullPrivileged(ctx, dockerCli, authConfig, reference.FamiliarString(distributionRef), requestPrivilege, opts.all)
 	}
 	if err != nil {
-		if strings.Contains(err.Error(), "target is plugin") {
+		if strings.Contains(err.Error(), "when fetching 'plugin'") {
 			return errors.New(err.Error() + " - Use `docker plugin install`")
 		}
 		return err

--- a/cli/command/plugin/install.go
+++ b/cli/command/plugin/install.go
@@ -152,7 +152,7 @@ func runInstall(dockerCli *command.DockerCli, opts pluginOptions) error {
 
 	responseBody, err := dockerCli.Client().PluginInstall(ctx, alias, options)
 	if err != nil {
-		if strings.Contains(err.Error(), "target is image") {
+		if strings.Contains(err.Error(), "(image) when fetching") {
 			return errors.New(err.Error() + " - Use `docker image pull`")
 		}
 		return err

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -363,7 +363,7 @@ func (p *v2Puller) pullV2Tag(ctx context.Context, ref reference.Named) (tagUpdat
 			if configClass == "" {
 				configClass = "unknown"
 			}
-			return false, fmt.Errorf("target is %s", configClass)
+			return false, fmt.Errorf("Encountered remote %q(%s) when fetching", m.Manifest.Config.MediaType, configClass)
 		}
 	}
 

--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -181,7 +181,7 @@ func (s *DockerRegistrySuite) TestPluginInstallImage(c *check.C) {
 
 	out, _, err := dockerCmdWithError("plugin", "install", repoName)
 	c.Assert(err, checker.NotNil)
-	c.Assert(out, checker.Contains, "target is image")
+	c.Assert(out, checker.Contains, `Encountered remote "application/vnd.docker.container.image.v1+json"(image) when fetching`)
 }
 
 func (s *DockerSuite) TestPluginEnableDisableNegative(c *check.C) {


### PR DESCRIPTION
Without this fix the error the client might see is:
	`target is unknown`
which wasn't helpful to me when I saw this today. With this fix I
now see:
	`MediaType is unknown: 'text/html'`
which helped me track down the issue to the registry I was talking to.

Signed-off-by: Doug Davis <dug@us.ibm.com>
