### PR TITLE
[test-integration] clean docker_cli_build_test.go

### DIFF
--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -195,7 +195,7 @@ func (s *DockerSuite) TestCreateLabels(c *check.C) {
 	dockerCmd(c, "create", "--name", name, "-l", "k1=v1", "--label", "k2=v2", "busybox")
 
 	actual := make(map[string]string)
-	inspectFieldAndMarshall(c, name, "Config.Labels", &actual)
+	inspectFieldAndUnmarshall(c, name, "Config.Labels", &actual)
 
 	if !reflect.DeepEqual(expected, actual) {
 		c.Fatalf("Expected %s got %s", expected, actual)
@@ -216,7 +216,7 @@ func (s *DockerSuite) TestCreateLabelFromImage(c *check.C) {
 	dockerCmd(c, "create", "--name", name, "-l", "k2=x", "--label", "k3=v3", imageName)
 
 	actual := make(map[string]string)
-	inspectFieldAndMarshall(c, name, "Config.Labels", &actual)
+	inspectFieldAndUnmarshall(c, name, "Config.Labels", &actual)
 
 	if !reflect.DeepEqual(expected, actual) {
 		c.Fatalf("Expected %s got %s", expected, actual)

--- a/integration-cli/docker_cli_external_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_unix_test.go
@@ -503,7 +503,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverWithDaemonRestart(c 
 
 	dockerCmd(c, "run", "--name=test", "-v", "abc1:/foo", "busybox", "true")
 	var mounts []types.MountPoint
-	inspectFieldAndMarshall(c, "test", "Mounts", &mounts)
+	inspectFieldAndUnmarshall(c, "test", "Mounts", &mounts)
 	c.Assert(mounts, checker.HasLen, 1)
 	c.Assert(mounts[0].Driver, checker.Equals, volumePluginName)
 }

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -305,17 +305,6 @@ func validateArgs(args ...string) error {
 	return nil
 }
 
-// find the State.ExitCode in container metadata
-func findContainerExitCode(c *check.C, name string, vargs ...string) string {
-	args := append(vargs, "inspect", "--format='{{ .State.ExitCode }} {{ .State.Error }}'", name)
-	cmd := exec.Command(dockerBinary, args...)
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatal(err, out)
-	}
-	return out
-}
-
 func findContainerIP(c *check.C, id string, network string) string {
 	out, _ := dockerCmd(c, "inspect", fmt.Sprintf("--format='{{ .NetworkSettings.Networks.%s.IPAddress }}'", network), id)
 	return strings.Trim(out, " \r\n'")
@@ -582,7 +571,7 @@ COPY . /static`); err != nil {
 		ctx:       ctx}, nil
 }
 
-func inspectFieldAndMarshall(c *check.C, name, field string, output interface{}) {
+func inspectFieldAndUnmarshall(c *check.C, name, field string, output interface{}) {
 	str := inspectFieldJSON(c, name, field)
 	err := json.Unmarshal([]byte(str), output)
 	if c != nil {
@@ -592,12 +581,11 @@ func inspectFieldAndMarshall(c *check.C, name, field string, output interface{})
 
 func inspectFilter(name, filter string) (string, error) {
 	format := fmt.Sprintf("{{%s}}", filter)
-	inspectCmd := exec.Command(dockerBinary, "inspect", "-f", format, name)
-	out, exitCode, err := runCommandWithOutput(inspectCmd)
-	if err != nil || exitCode != 0 {
-		return "", fmt.Errorf("failed to inspect %s: %s", name, out)
+	result := icmd.RunCommand(dockerBinary, "inspect", "-f", format, name)
+	if result.Error != nil || result.ExitCode != 0 {
+		return "", fmt.Errorf("failed to inspect %s: %s", name, result.Combined())
 	}
-	return strings.TrimSpace(out), nil
+	return strings.TrimSpace(result.Combined()), nil
 }
 
 func inspectFieldWithError(name, field string) (string, error) {
@@ -687,10 +675,12 @@ func getIDByName(name string) (string, error) {
 	return inspectFieldWithError(name, "Id")
 }
 
+// Deprecated
 func buildImageCmd(name, dockerfile string, useCache bool, buildFlags ...string) *exec.Cmd {
 	return daemon.BuildImageCmdWithHost(dockerBinary, name, dockerfile, "", useCache, buildFlags...)
 }
 
+// Deprecated
 func buildImageWithOut(name, dockerfile string, useCache bool, buildFlags ...string) (string, string, error) {
 	buildCmd := buildImageCmd(name, dockerfile, useCache, buildFlags...)
 	out, exitCode, err := runCommandWithOutput(buildCmd)
@@ -704,6 +694,7 @@ func buildImageWithOut(name, dockerfile string, useCache bool, buildFlags ...str
 	return id, out, nil
 }
 
+// Deprecated
 func buildImageWithStdoutStderr(name, dockerfile string, useCache bool, buildFlags ...string) (string, string, string, error) {
 	buildCmd := buildImageCmd(name, dockerfile, useCache, buildFlags...)
 	result := icmd.RunCmd(transformCmd(buildCmd))
@@ -719,11 +710,99 @@ func buildImageWithStdoutStderr(name, dockerfile string, useCache bool, buildFla
 	return id, result.Stdout(), result.Stderr(), nil
 }
 
+func buildImageSuccessfully(c *check.C, name string, cmdOperators ...func(*icmd.Cmd) func()) {
+	buildImageNew(name, cmdOperators...).Assert(c, icmd.Success)
+}
+
+// FIXME(vdemeester) rename this buildImage once deprecated buildImage is no more
+func buildImageNew(name string, cmdOperators ...func(*icmd.Cmd) func()) *icmd.Result {
+	cmd := icmd.Command(dockerBinary, "build", "-t", name)
+	for _, op := range cmdOperators {
+		deferFn := op(&cmd)
+		if deferFn != nil {
+			defer deferFn()
+		}
+	}
+	return icmd.RunCmd(cmd)
+}
+
+func withBuildContextPath(path string) func(*icmd.Cmd) func() {
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Command = append(cmd.Command, path)
+		return nil
+	}
+}
+
+func withBuildContext(c *check.C, contextOperators ...func(*FakeContext) error) func(*icmd.Cmd) func() {
+	ctx, err := fakeContextFromNewTempDir()
+	if err != nil {
+		c.Fatalf("error creating build context : %v", err)
+	}
+	for _, op := range contextOperators {
+		if err := op(ctx); err != nil {
+			c.Fatal(err)
+		}
+	}
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Dir = ctx.Dir
+		cmd.Command = append(cmd.Command, ".")
+		return closeBuildContext(c, ctx)
+	}
+}
+
+func withBuildFlags(flags ...string) func(*icmd.Cmd) func() {
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Command = append(cmd.Command, flags...)
+		return nil
+	}
+}
+
+func withoutCache(cmd *icmd.Cmd) func() {
+	cmd.Command = append(cmd.Command, "--no-cache")
+	return nil
+}
+
+func withFile(name, content string) func(*FakeContext) error {
+	return func(ctx *FakeContext) error {
+		return ctx.Add(name, content)
+	}
+}
+
+func closeBuildContext(c *check.C, ctx *FakeContext) func() {
+	return func() {
+		if err := ctx.Close(); err != nil {
+			c.Fatal(err)
+		}
+	}
+}
+
+func withDockerfile(dockerfile string) func(*icmd.Cmd) func() {
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Command = append(cmd.Command, "-")
+		cmd.Stdin = strings.NewReader(dockerfile)
+		return nil
+	}
+}
+
+func trustedBuild(cmd *icmd.Cmd) func() {
+	trustedCmd(cmd)
+	return nil
+}
+
+func withEnvironmentVariales(envs ...string) func(cmd *icmd.Cmd) func() {
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Env = envs
+		return nil
+	}
+}
+
+// Deprecated
 func buildImage(name, dockerfile string, useCache bool, buildFlags ...string) (string, error) {
 	id, _, err := buildImageWithOut(name, dockerfile, useCache, buildFlags...)
 	return id, err
 }
 
+// Deprecated
 func buildImageFromContext(name string, ctx *FakeContext, useCache bool, buildFlags ...string) (string, error) {
 	id, _, err := buildImageFromContextWithOut(name, ctx, useCache, buildFlags...)
 	if err != nil {
@@ -732,6 +811,7 @@ func buildImageFromContext(name string, ctx *FakeContext, useCache bool, buildFl
 	return id, nil
 }
 
+// Deprecated
 func buildImageFromContextWithOut(name string, ctx *FakeContext, useCache bool, buildFlags ...string) (string, string, error) {
 	args := []string{"build", "-t", name}
 	if !useCache {
@@ -754,6 +834,7 @@ func buildImageFromContextWithOut(name string, ctx *FakeContext, useCache bool, 
 	return id, out, nil
 }
 
+// Deprecated
 func buildImageFromContextWithStdoutStderr(name string, ctx *FakeContext, useCache bool, buildFlags ...string) (string, string, string, error) {
 	args := []string{"build", "-t", name}
 	if !useCache {
@@ -778,6 +859,7 @@ func buildImageFromContextWithStdoutStderr(name string, ctx *FakeContext, useCac
 	return id, result.Stdout(), result.Stderr(), nil
 }
 
+// Deprecated
 func buildImageFromGitWithStdoutStderr(name string, ctx *fakeGit, useCache bool, buildFlags ...string) (string, string, string, error) {
 	args := []string{"build", "-t", name}
 	if !useCache {
@@ -800,6 +882,7 @@ func buildImageFromGitWithStdoutStderr(name string, ctx *fakeGit, useCache bool,
 	return id, result.Stdout(), result.Stderr(), nil
 }
 
+// Deprecated
 func buildImageFromPath(name, path string, useCache bool, buildFlags ...string) (string, error) {
 	args := []string{"build", "-t", name}
 	if !useCache {


### PR DESCRIPTION
Refactoring a bit some piece of `docker_cli_build_test.go`.

- Introduce new `buildImage` commands (that are extensible and more readable) and deprecate old ones.

```go
buildImageSuccessfully(c, "imageName", withDockerfile("FROM …"))
buildImageSuccessfully(c, "imageName", withBuildFlag("--rm=false"), withDockerfile("FROM …"))
buildImageSuccessfully(c, "imageName", withoutCache, withDockerfile("FROM …"))
// […]
buildImageNew("imageName", withContext(c,
    withFile("Dockerfile", "FROM …"),
    withFile("foo", "bar")
).Assert(c, icmd.Expected{
    ExitCode: 1,
    Err: "something on stderr",
})
```

- Small cleanups, refactoring of tests, to make them more readable, more concise or use less compute power 😝 

There is still ways to go : some tests need more *care* to make them more readable and I didn't touch to all of them. The file is way to big (>6000 loc) so.. it's a "first part/wip" but it should lower a little the loc and ease the split later on.

/cc @thaJeztah @icecrime @dnephin @tiborvass @cpuguy83 @duglin 

🐸 🦁 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
