### PR TITLE
Fix `Size` in `docker images` for v1.12 client to v1.13 daemon

### DIFF
--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -226,8 +226,7 @@ func (c *imageContext) CreatedAt() string {
 
 func (c *imageContext) Size() string {
 	c.AddHeader(sizeHeader)
-	//NOTE: For backward compatibility we need to return VirtualSize
-	return units.HumanSizeWithPrecision(float64(c.i.VirtualSize), 3)
+	return units.HumanSizeWithPrecision(float64(c.i.Size), 3)
 }
 
 func (c *imageContext) Containers() string {
@@ -253,8 +252,8 @@ func (c *imageContext) SharedSize() string {
 
 func (c *imageContext) UniqueSize() string {
 	c.AddHeader(uniqueSizeHeader)
-	if c.i.Size == -1 {
+	if c.i.VirtualSize == -1 || c.i.SharedSize == -1 {
 		return "N/A"
 	}
-	return units.HumanSize(float64(c.i.Size))
+	return units.HumanSize(float64(c.i.VirtualSize - c.i.SharedSize))
 }

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -210,7 +210,6 @@ func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs
 			rootFS := *img.RootFS
 			rootFS.DiffIDs = nil
 
-			newImage.Size = 0
 			newImage.SharedSize = 0
 			for _, id := range img.RootFS.DiffIDs {
 				rootFS.Append(id)
@@ -223,8 +222,6 @@ func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs
 
 				if layerRefs[chid] > 1 {
 					newImage.SharedSize += diffSize
-				} else {
-					newImage.Size += diffSize
 				}
 			}
 		}
@@ -323,7 +320,7 @@ func newImage(image *image.Image, virtualSize int64) *types.ImageSummary {
 	newImage.ParentID = image.Parent.String()
 	newImage.ID = image.ID().String()
 	newImage.Created = image.Created.Unix()
-	newImage.Size = -1
+	newImage.Size = virtualSize
 	newImage.VirtualSize = virtualSize
 	newImage.SharedSize = -1
 	newImage.Containers = -1


### PR DESCRIPTION
**- What I did**

This fix tries to address the issue raised in #30027 where `Size` in `docker images` always show `-1` for v1.12 client against v1.13 daemon.

The reason for the issue is that in v1.12, `Size` is used while in v1.13 `VirtualSize` is used. And in v1.13, `Size` has been always initialized as `-1`.

**- How I did it**

This fix address the issue by copy the value of `VirtualSize` to `Size` if version is less or equal to v1.24 (docker v1.12).

**- How to verify it**

An integration test has been added.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![u 1024162214 1388002003 fm 21 gp 0](https://cloud.githubusercontent.com/assets/6932348/21853212/ff0f1736-d7ca-11e6-9229-27ac405bfbc9.jpg)


This fix fixes #30027.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
