### PR TITLE
add suggestions in failure message in install script

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -210,7 +210,11 @@ do_install() {
 		# unofficially supported without available repositories
 		aarch64|arm64|ppc64le|s390x)
 			cat 1>&2 <<-EOF
-			Error: Docker doesn't officially support $architecture and no Docker $architecture repository exists.
+			Error: This install script does not support $architecture, because no
+			$architecture package exists in Docker's repositories.
+
+			Other install options include checking your distribution's package repository
+			for a version of Docker, or building Docker from source.
 			EOF
 			exit 1
 			;;


### PR DESCRIPTION
Adds suggestions to where you can install docker in the case
that the install script fails to install because of the architecture
not being officially supported.

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>
