### PR TITLE
Fix leaked connections in integration tests

### DIFF
--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -180,6 +180,7 @@ func (d *Daemon) getClientConfig() (*clientConfig, error) {
 	if err := sockets.ConfigureTransport(transport, proto, addr); err != nil {
 		return nil, err
 	}
+	transport.DisableKeepAlives = true
 
 	return &clientConfig{
 		transport: transport,
@@ -301,6 +302,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 			if err != nil {
 				continue
 			}
+			resp.Body.Close()
 			if resp.StatusCode != http.StatusOK {
 				d.log.Logf("[%s] received status != 200 OK: %s\n", d.id, resp.Status)
 			}

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1169,6 +1169,7 @@ func (s *DockerSuite) TestContainerAPIChunkedEncoding(c *check.C) {
 		return nil
 	})
 	c.Assert(err, checker.IsNil, check.Commentf("error creating container with chunked encoding"))
+	defer resp.Body.Close()
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusCreated)
 }
 

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -258,8 +258,9 @@ func createDeletePredefinedNetwork(c *check.C, name string) {
 
 func isNetworkAvailable(c *check.C, name string) bool {
 	resp, body, err := request.Get(daemonHost(), "/networks")
-	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(err, checker.IsNil)
+	defer resp.Body.Close()
+	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 
 	nJSON := []types.NetworkResource{}
 	err = json.NewDecoder(body).Decode(&nJSON)
@@ -308,12 +309,13 @@ func getNetworkResource(c *check.C, id string) *types.NetworkResource {
 
 func createNetwork(c *check.C, config types.NetworkCreateRequest, shouldSucceed bool) string {
 	resp, body, err := request.Post(daemonHost(), "/networks/create", request.JSONBody(config))
+	c.Assert(err, checker.IsNil)
+	defer resp.Body.Close()
 	if !shouldSucceed {
 		c.Assert(resp.StatusCode, checker.Not(checker.Equals), http.StatusCreated)
 		return ""
 	}
 
-	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusCreated)
 
 	var nr types.NetworkCreateResponse
@@ -345,10 +347,11 @@ func disconnectNetwork(c *check.C, nid, cid string) {
 
 func deleteNetwork(c *check.C, id string, shouldSucceed bool) {
 	resp, _, err := request.Delete(daemonHost(), "/networks/"+id)
+	c.Assert(err, checker.IsNil)
+	defer resp.Body.Close()
 	if !shouldSucceed {
 		c.Assert(resp.StatusCode, checker.Not(checker.Equals), http.StatusOK)
 		return
 	}
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusNoContent)
-	c.Assert(err, checker.IsNil)
 }

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -288,7 +288,7 @@ func (s *DockerSuite) TestLogsFollowGoroutinesWithStdout(c *check.C) {
 	}()
 	c.Assert(<-chErr, checker.IsNil)
 	c.Assert(cmd.Process.Kill(), checker.IsNil)
-
+	r.Close()
 	// NGoroutines is not updated right away, so we need to wait before failing
 	c.Assert(waitForGoroutines(nroutines), checker.IsNil)
 }

--- a/integration-cli/docker_cli_registry_user_agent_test.go
+++ b/integration-cli/docker_cli_registry_user_agent_test.go
@@ -72,21 +72,25 @@ func (s *DockerRegistrySuite) TestUserAgentPassThrough(c *check.C) {
 	)
 
 	buildReg, err := registry.NewMock(c)
+	defer buildReg.Close()
 	c.Assert(err, check.IsNil)
 	registerUserAgentHandler(buildReg, &buildUA)
 	buildRepoName := fmt.Sprintf("%s/busybox", buildReg.URL())
 
 	pullReg, err := registry.NewMock(c)
+	defer pullReg.Close()
 	c.Assert(err, check.IsNil)
 	registerUserAgentHandler(pullReg, &pullUA)
 	pullRepoName := fmt.Sprintf("%s/busybox", pullReg.URL())
 
 	pushReg, err := registry.NewMock(c)
+	defer pushReg.Close()
 	c.Assert(err, check.IsNil)
 	registerUserAgentHandler(pushReg, &pushUA)
 	pushRepoName := fmt.Sprintf("%s/busybox", pushReg.URL())
 
 	loginReg, err := registry.NewMock(c)
+	defer loginReg.Close()
 	c.Assert(err, check.IsNil)
 	registerUserAgentHandler(loginReg, &loginUA)
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3102,11 +3102,15 @@ func (s *DockerSuite) TestRunUnshareProc(c *check.C) {
 		}
 	}()
 
+	var retErr error
 	for i := 0; i < 3; i++ {
 		err := <-errChan
-		if err != nil {
-			c.Fatal(err)
+		if retErr == nil && err != nil {
+			retErr = err
 		}
+	}
+	if retErr != nil {
+		c.Fatal(retErr)
 	}
 }
 

--- a/integration-cli/docker_cli_v2_only_test.go
+++ b/integration-cli/docker_cli_v2_only_test.go
@@ -38,6 +38,7 @@ func makefile(contents string) (string, func(), error) {
 // attempt to contact any v1 registry endpoints.
 func (s *DockerRegistrySuite) TestV2Only(c *check.C) {
 	reg, err := registry.NewMock(c)
+	defer reg.Close()
 	c.Assert(err, check.IsNil)
 
 	reg.RegisterHandler("/v2/", func(w http.ResponseWriter, r *http.Request) {
@@ -70,6 +71,7 @@ func (s *DockerRegistrySuite) TestV2Only(c *check.C) {
 // login, push, pull, build & run
 func (s *DockerRegistrySuite) TestV1(c *check.C) {
 	reg, err := registry.NewMock(c)
+	defer reg.Close()
 	c.Assert(err, check.IsNil)
 
 	v2Pings := 0

--- a/integration-cli/registry/registry_mock.go
+++ b/integration-cli/registry/registry_mock.go
@@ -59,3 +59,8 @@ func NewMock(t testingT) (*Mock, error) {
 func (tr *Mock) URL() string {
 	return tr.hostport
 }
+
+// Close closes mock and releases resources
+func (tr *Mock) Close() {
+	tr.server.Close()
+}

--- a/integration-cli/request/request.go
+++ b/integration-cli/request/request.go
@@ -129,6 +129,7 @@ func NewClient(host string) (*http.Client, error) {
 		}
 		transport = &http.Transport{TLSClientConfig: tlsConfig}
 	}
+	transport.DisableKeepAlives = true
 	err = sockets.ConfigureTransport(transport, proto, addr)
 	return &http.Client{
 		Transport: transport,


### PR DESCRIPTION
This should fix 800+ goroutine leaks in the integration cli. Spotted on the trace from #30069

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>

