### PR TITLE
Print daemon stacktrace when trust test times out

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -454,6 +454,10 @@ type DockerTrustSuite struct {
 	not *testNotary
 }
 
+func (s *DockerTrustSuite) OnTimeout(c *check.C) {
+	s.ds.OnTimeout(c)
+}
+
 func (s *DockerTrustSuite) SetUpTest(c *check.C) {
 	testRequires(c, registry.Hosting, NotaryServerHosting)
 	s.reg = setupRegistry(c, false, "", "")


### PR DESCRIPTION
Should help to debug #30062

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>

