### PR TITLE
storeLayer.Parent should return describableStoreLayers

### DIFF
--- a/distribution/config.go
+++ b/distribution/config.go
@@ -198,10 +198,18 @@ func (l *storeLayer) Parent() PushLayer {
 	if p == nil {
 		return nil
 	}
-	return &storeLayer{
+	sl := storeLayer{
 		Layer: p,
 		ls:    l.ls,
 	}
+	if d, ok := p.(distribution.Describable); ok {
+		return &describableStoreLayer{
+			storeLayer:  sl,
+			describable: d,
+		}
+	}
+
+	return &sl
 }
 
 func (l *storeLayer) Open() (io.ReadCloser, error) {


### PR DESCRIPTION
@dmcgowan @thaJeztah @jhowardmsft @jstarks 
When storeLayer.Parent returns the parent layer, it needs to use the same logic as Get where it wraps in a describablyStoreLayer if the layer is describable. Otherwise, on Windows, this can result in pushing the foreign layers, which is not supposed to be allowed.
This fixes #30080.

Signed-off-by: Stefan J. Wernli <swernli@microsoft.com>