### PR TITLE
Make remove commands fail when names start with '../'

### DIFF
--- a/client/container_remove.go
+++ b/client/container_remove.go
@@ -23,5 +23,5 @@ func (cli *Client) ContainerRemove(ctx context.Context, containerID string, opti
 
 	resp, err := cli.delete(ctx, "/containers/"+containerID, query, nil)
 	ensureReaderClosed(resp)
-	return err
+	return isDeletedSuccessfully(resp, containerID, err)
 }

--- a/client/image_remove.go
+++ b/client/image_remove.go
@@ -20,8 +20,8 @@ func (cli *Client) ImageRemove(ctx context.Context, imageID string, options type
 	}
 
 	resp, err := cli.delete(ctx, "/images/"+imageID, query, nil)
-	if err != nil {
-		return nil, err
+	if failErr := isDeletedSuccessfully(resp, imageID, err); failErr != nil {
+		return nil, failErr
 	}
 
 	var dels []types.ImageDelete

--- a/client/network_remove.go
+++ b/client/network_remove.go
@@ -6,5 +6,5 @@ import "golang.org/x/net/context"
 func (cli *Client) NetworkRemove(ctx context.Context, networkID string) error {
 	resp, err := cli.delete(ctx, "/networks/"+networkID, nil, nil)
 	ensureReaderClosed(resp)
-	return err
+	return isDeletedSuccessfully(resp, networkID, err)
 }

--- a/client/request.go
+++ b/client/request.go
@@ -245,3 +245,16 @@ func ensureReaderClosed(response serverResponse) {
 		response.body.Close()
 	}
 }
+
+func isDeletedSuccessfully(response serverResponse, name string, err error) error {
+	if err != nil {
+		return err
+	}
+	// When the name starts with '../' the daemon detects this and
+	// returns status code 304. Read more here:
+	// https://github.com/docker/docker/issues/29126#issuecomment-271901605
+	if response.statusCode == http.StatusMovedPermanently {
+		return fmt.Errorf("Bad name: %s", name)
+	}
+	return nil
+}

--- a/client/secret_remove.go
+++ b/client/secret_remove.go
@@ -6,5 +6,5 @@ import "golang.org/x/net/context"
 func (cli *Client) SecretRemove(ctx context.Context, id string) error {
 	resp, err := cli.delete(ctx, "/secrets/"+id, nil, nil)
 	ensureReaderClosed(resp)
-	return err
+	return isDeletedSuccessfully(resp, id, err)
 }

--- a/client/volume_remove.go
+++ b/client/volume_remove.go
@@ -17,5 +17,5 @@ func (cli *Client) VolumeRemove(ctx context.Context, volumeID string, force bool
 	}
 	resp, err := cli.delete(ctx, "/volumes/"+volumeID, query, nil)
 	ensureReaderClosed(resp)
-	return err
+	return isDeletedSuccessfully(resp, volumeID, err)
 }

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -348,6 +348,13 @@ func (s *DockerNetworkSuite) TestDockerNetworkRmPredefined(c *check.C) {
 	}
 }
 
+// Regression test to #29126
+func (s *DockerNetworkSuite) TestDockerNetworkRmInvalidNetworkWithTwoDots(c *check.C) {
+	out, _, err := dockerCmdWithError("network", "rm", "../mynetwork")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "Bad name: ../mynetwork")
+}
+
 func (s *DockerNetworkSuite) TestDockerNetworkLsFilter(c *check.C) {
 	testNet := "testnet1"
 	testLabel := "foo"

--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -81,6 +81,13 @@ func (s *DockerSuite) TestRmInvalidContainer(c *check.C) {
 	c.Assert(out, checker.Contains, "No such container")
 }
 
+// Regression test to #29126
+func (s *DockerSuite) TestRmInvalidContainerWithTwoDots(c *check.C) {
+	out, _, err := dockerCmdWithError("rm", "../unknown")
+	c.Assert(err, checker.NotNil, check.Commentf("Expected error on rm unknown container, got none"))
+	c.Assert(out, checker.Contains, "Bad name: ../unknown")
+}
+
 func createRunningContainer(c *check.C, name string) {
 	runSleepingContainer(c, "-dt", "--name", name)
 }

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -350,3 +350,10 @@ func (s *DockerSuite) TestRmiByIDHardConflict(c *check.C) {
 	imgID2 := inspectField(c, "busybox:latest", "Id")
 	c.Assert(imgID, checker.Equals, imgID2)
 }
+
+// Regression test to #29126
+func (s *DockerSuite) TestRmiInvalidImageWithTwoDots(c *check.C) {
+	out, _, err := dockerCmdWithError("rmi", "../imgid")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "Bad name: ../imgid")
+}

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -450,3 +450,10 @@ func (s *DockerSuite) TestVolumeCliInspectWithVolumeOpts(c *check.C) {
 	c.Assert(strings.TrimSpace(out), checker.Contains, fmt.Sprintf("%s:%s", k2, v2))
 	c.Assert(strings.TrimSpace(out), checker.Contains, fmt.Sprintf("%s:%s", k3, v3))
 }
+
+// Regression test to #29126
+func (s *DockerSuite) TestVolumeCLIRmInvalidVolumeWithTwoDots(c *check.C) {
+	out, _, err := dockerCmdWithError("volume", "rm", "../my_vol_id")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "Bad name: ../my_vol_id")
+}


### PR DESCRIPTION
Fix #29126 

**- What I did**
Validate the "delete" response status is `204`

**- How I did it**
* Created a new function called `isDeletedSuccessfully` that verifies if the request sent successfully and whether the status code of the response is not `304`. If not an error message is returned.
* Used `isDeletedSuccessfully` in `SecretRemove`, `VolumeRemove`, `NetworkRemove`, `ContainerRemove` and `ImageRemove`.

**- How to verify it**
Run the following tests:
* `TESTFLAGS='-check.f ^*WithTwoDots' make test-integration-cli`
* `TESTDIRS='client' TESTFLAGS='-test.run ^TestIsDelete*' make test-unit`

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

