### PR TITLE
Fix rename error when sid is empty

### DIFF
--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -106,7 +106,7 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 	}()
 
 	sid = container.NetworkSettings.SandboxID
-	if daemon.netController != nil {
+	if sid != "" && daemon.netController != nil {
 		sb, err = daemon.netController.SandboxByID(sid)
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Wang Xing <hzwangxing@corp.netease.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
docker cannot rename a container, if it shares the other container's network 
example:

step to reproduce
docker run -d --name test hub.c.163.com/combk8s/pause:0.8.0
docker run -d --name test2 --net container:test hub.c.163.com/public/debian:7.9-common
docker rename test2 test3
Error response from daemon: invalid id:
Error: failed to rename container named test2` 

**- How I did it**
add limit: when sid is empty, don't rename sandbox

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

