### PR TITLE
Add error checking for hostPort range

### DIFF
--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -301,9 +301,11 @@ func convertEndpointSpec(source []string) (*swarm.EndpointSpec, error) {
 	}
 
 	for port := range ports {
-		portConfigs = append(
-			portConfigs,
-			opts.ConvertPortToPortConfig(port, portBindings)...)
+		portConfig, err := opts.ConvertPortToPortConfig(port, portBindings)
+		if err != nil {
+			return nil, err
+		}
+		portConfigs = append(portConfigs, portConfig...)
 	}
 
 	return &swarm.EndpointSpec{Ports: portConfigs}, nil


### PR DESCRIPTION
fixes #29961 

Signed-off-by: Tony Abboud <tdabboud@hotmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add error handling for the case where there is a single container port
and a dynamic host port
Example docker-compose.yml snippet:
    port:
        ports:
            - "8091-8093:8091"
            - "80:8080"

**- How I did it**
Checked the return error from `strconv.ParseUint()` and handled the error if the given hostPort is not an empty string, which means that the hostPort is either a range or an invalid number

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add error handling for hostPorts when converting a Port to a PortConfig

**- A picture of a cute animal (not mandatory but encouraged)**

