### PR TITLE
daemon: honor default runtime when starting containers

### DIFF
--- a/daemon/start_unix.go
+++ b/daemon/start_unix.go
@@ -14,7 +14,7 @@ func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Contain
 
 	// Ensure a runtime has been assigned to this container
 	if container.HostConfig.Runtime == "" {
-		container.HostConfig.Runtime = stockRuntimeName
+		container.HostConfig.Runtime = daemon.configStore.GetDefaultRuntimeName()
 		container.ToDisk()
 	}
 


### PR DESCRIPTION
If you created containers from pre-OCI docker (e.g. docker-1.10.x)
upgrade may fail when restarting containers if the new docker daemon
has `--default-runtime` set.

In Fedora, we ship docker 1.12.6 with:

```
--default-runtime=oci
--add-runtime oci=/usr/libexec/docker/docker-runc-current
```

That way we don't rely on `docker-runc` being in `$PATH`.

The issue is, on upgrade from docker 1.10.3 without this patch, the
default runtime in `daemon/start_linux.go` is unconditionally set to
`runc=docker-runc` without honoring the `--default-runtime` flag set in
the docker daemon.

Reproducer:

- (1.10.3) `docker run -d -p 5000:5000 --restart=always --name registry
registry:2`
- upgrade to docker 1.12.6 (1.11.x has likely the same issue)
- the registry container fails to restart on upgrade with the following
log message `error="exec: \"docker-runc\": executable file not
found in $PATH: \"\""`

That error comes from the fact that we're setting the runtime in the
container's HostConfig to `runc` where instead we should have honored
the `--default-runtime` flag (in our case that's set to `oci`).

Signed-off-by: Antonio Murdaca <runcom@redhat.com>