### PR TITLE
Windows: Add service dependency ConDrv

### DIFF
--- a/cmd/dockerd/service_windows.go
+++ b/cmd/dockerd/service_windows.go
@@ -13,6 +13,7 @@ import (
 	"unsafe"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/system"
 	"github.com/spf13/pflag"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
@@ -165,10 +166,20 @@ func registerService() error {
 		return err
 	}
 	defer m.Disconnect()
+
+	depends := []string{}
+
+	// This dependency is required on build 14393 (RS1)
+	// it is added to the platform in newer builds
+	if system.GetOSVersion().Build == 14393 {
+		depends = append(depends, "ConDrv")
+	}
+
 	c := mgr.Config{
 		ServiceType:  windows.SERVICE_WIN32_OWN_PROCESS,
 		StartType:    mgr.StartAutomatic,
 		ErrorControl: mgr.ErrorNormal,
+		Dependencies: depends,
 		DisplayName:  "Docker Engine",
 	}
 


### PR DESCRIPTION
Signed-off-by: Darren Stahl <darst@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes #27544

Added a service dependency on the Console Driver, which is necessary for using Windows Server Containers (The missing dependency was causing failure to launch processes in containers shortly after a host reboot).

cc @jhowardmsft @jstarks 
