### PR TITLE
Don't use AutoRemove on older daemons

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -369,6 +369,11 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 	version := httputils.VersionFromContext(ctx)
 	adjustCPUShares := versions.LessThan(version, "1.19")
 
+	// When using API 1.24 and under, the client is responsible for removing the container
+	if hostConfig != nil && versions.LessThan(version, "1.25") {
+		hostConfig.AutoRemove = false
+	}
+
 	ccr, err := s.backend.ContainerCreate(types.ContainerCreateConfig{
 		Name:             name,
 		Config:           config,

--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -622,6 +622,10 @@ func parse(flags *pflag.FlagSet, copts *containerOptions) (*container.Config, *c
 		Runtime:        copts.runtime,
 	}
 
+	if copts.autoRemove && !hostConfig.RestartPolicy.IsNone() {
+		return nil, nil, nil, fmt.Errorf("Conflicting options: --restart and --rm")
+	}
+
 	// only set this value if the user provided the flag, else it should default to nil
 	if flags.Changed("init") {
 		hostConfig.Init = &copts.init

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -456,6 +456,14 @@ func TestParseRestartPolicy(t *testing.T) {
 	}
 }
 
+func TestParseRestartPolicyAutoRemove(t *testing.T) {
+	expected := "Conflicting options: --restart and --rm"
+	_, _, _, err := parseRun([]string{"--rm", "--restart=always", "img", "cmd"})
+	if err == nil || err.Error() != expected {
+		t.Fatalf("Expected error %v, but got none", expected)
+	}
+}
+
 func TestParseHealth(t *testing.T) {
 	checkOk := func(args ...string) *container.HealthConfig {
 		config, _, _, err := parseRun(args)

--- a/client/container_create.go
+++ b/client/container_create.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/versions"
 	"golang.org/x/net/context"
 )
 
@@ -23,6 +24,11 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 
 	if err := cli.NewVersionError("1.25", "stop timeout"); config != nil && config.StopTimeout != nil && err != nil {
 		return response, err
+	}
+
+	// When using API 1.24 and under, the client is responsible for removing the container
+	if hostConfig != nil && versions.LessThan(cli.ClientVersion(), "1.25") {
+		hostConfig.AutoRemove = false
 	}
 
 	query := url.Values{}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Docker 1.13 moves the `--rm` flag to the daemon, through the `AutoRemove` option in `HostConfig`.

When using API 1.24 and under, AutoRemove should not be used, even if the daemon is version 1.13 or above and "supports" this feature.

This patch fixes a situation where an 1.13 client, talking to an 1.13 daemon, but using the 1.24 API version, still set the AutoRemove property.

As a result, both the client _and_ the daemon were attempting to remove the container, resulting in an error:

    ERRO[0000] error removing container: Error response from daemon:
    removal of container ce0976ad22495c7cbe9487752ea32721a282164862db036b2f3377bd07461c3a
    is already in progress

In addition, the validation of conflicting options is moved from `docker run` to `opts.parse()`, so that conflicting options are also detected when running `docker create` and `docker start` separately.

To resolve the issue, the `AutoRemove` option is now always set to `false` both by the client and the daemon, if API version 1.24 or under is used.

**- What I did**

**- How I did it**

**- How to verify it**

Override the API version and run a container with `--rm`;

    DOCKER_API_VERSION=1.23 docker run --rm hello-world

**- Description for the changelog**

Fix a `removal of container is already in progress` when using `--rm` flag on API version 1.24

**- A picture of a cute animal (not mandatory but encouraged)**
