### PR TITLE
Add random-assign to poule.yml

### DIFF
--- a/poule.yml
+++ b/poule.yml
@@ -4,7 +4,7 @@
   operations:
       - type:       label
         filters: {
-            ~labels: [ " status/0-triage", "status/1-design-review", "status/2-code-review", "status/3-docs-review", "status/4-merge" ],
+            ~labels: [ "status/0-triage", "status/1-design-review", "status/2-code-review", "status/3-docs-review", "status/4-merge" ],
         }
         settings: {
             patterns: {
@@ -34,6 +34,28 @@
             }
         }
       - type:       version-label
+
+# Randomly assign newly opened pull requests.
+- triggers:
+      pull_request: [ opened ]
+  operations:
+      - type:       random-assign
+        settings: {
+            users: [
+                "anusha-ragunathan",
+                "cpuguy83",
+                "crosbymichael",
+                "dnephin",
+                "justincormack",
+                "lk4d4",
+                "mlaventure",
+                "thajeztah",
+                "tiborvass",
+                "tonistiigi",
+                "vdemeester",
+                "vieux",
+            ]
+        }
 
 # When a pull request is closed, attach it to the currently active milestone.
 - triggers:


### PR DESCRIPTION
Randomly assign incoming pull requests to one of the (Docker Inc employed) maintainers of the project.

The role of the assignee is not necessarily to review the pull request herself/himself, but to be accountable for moving it forward.

Cc @vieux @thaJeztah.