### PR TITLE
cherry pick 1.13.0-rc7

### DIFF
--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -226,8 +226,7 @@ func (c *imageContext) CreatedAt() string {
 
 func (c *imageContext) Size() string {
 	c.AddHeader(sizeHeader)
-	//NOTE: For backward compatibility we need to return VirtualSize
-	return units.HumanSizeWithPrecision(float64(c.i.VirtualSize), 3)
+	return units.HumanSizeWithPrecision(float64(c.i.Size), 3)
 }
 
 func (c *imageContext) Containers() string {
@@ -253,8 +252,8 @@ func (c *imageContext) SharedSize() string {
 
 func (c *imageContext) UniqueSize() string {
 	c.AddHeader(uniqueSizeHeader)
-	if c.i.Size == -1 {
+	if c.i.VirtualSize == -1 || c.i.SharedSize == -1 {
 		return "N/A"
 	}
-	return units.HumanSize(float64(c.i.Size))
+	return units.HumanSize(float64(c.i.VirtualSize - c.i.SharedSize))
 }

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -210,7 +210,6 @@ func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs
 			rootFS := *img.RootFS
 			rootFS.DiffIDs = nil
 
-			newImage.Size = 0
 			newImage.SharedSize = 0
 			for _, id := range img.RootFS.DiffIDs {
 				rootFS.Append(id)
@@ -223,8 +222,6 @@ func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs
 
 				if layerRefs[chid] > 1 {
 					newImage.SharedSize += diffSize
-				} else {
-					newImage.Size += diffSize
 				}
 			}
 		}
@@ -323,7 +320,7 @@ func newImage(image *image.Image, virtualSize int64) *types.ImageSummary {
 	newImage.ParentID = image.Parent.String()
 	newImage.ID = image.ID().String()
 	newImage.Created = image.Created.Unix()
-	newImage.Size = -1
+	newImage.Size = virtualSize
 	newImage.VirtualSize = virtualSize
 	newImage.SharedSize = -1
 	newImage.Containers = -1

--- a/distribution/config.go
+++ b/distribution/config.go
@@ -198,10 +198,18 @@ func (l *storeLayer) Parent() PushLayer {
 	if p == nil {
 		return nil
 	}
-	return &storeLayer{
+	sl := storeLayer{
 		Layer: p,
 		ls:    l.ls,
 	}
+	if d, ok := p.(distribution.Describable); ok {
+		return &describableStoreLayer{
+			storeLayer:  sl,
+			describable: d,
+		}
+	}
+
+	return &sl
 }
 
 func (l *storeLayer) Open() (io.ReadCloser, error) {

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -127,3 +127,39 @@ func (s *DockerSuite) TestAPIImagesSearchJSONContentType(c *check.C) {
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(res.Header.Get("Content-Type"), checker.Equals, "application/json")
 }
+
+// Test case for 30027: image size reported as -1 in v1.12 client against v1.13 daemon.
+// This test checks to make sure both v1.12 and v1.13 client against v1.13 daemon get correct `Size` after the fix.
+func (s *DockerSuite) TestAPIImagesSizeCompatibility(c *check.C) {
+	status, b, err := sockRequest("GET", "/images/json", nil)
+	c.Assert(err, checker.IsNil)
+	c.Assert(status, checker.Equals, http.StatusOK)
+	var images []types.ImageSummary
+	err = json.Unmarshal(b, &images)
+	c.Assert(err, checker.IsNil)
+	c.Assert(len(images), checker.Not(checker.Equals), 0)
+	for _, image := range images {
+		c.Assert(image.Size, checker.Not(checker.Equals), int64(-1))
+	}
+
+	type v124Image struct {
+		ID          string `json:"Id"`
+		ParentID    string `json:"ParentId"`
+		RepoTags    []string
+		RepoDigests []string
+		Created     int64
+		Size        int64
+		VirtualSize int64
+		Labels      map[string]string
+	}
+	status, b, err = sockRequest("GET", "/v1.24/images/json", nil)
+	c.Assert(err, checker.IsNil)
+	c.Assert(status, checker.Equals, http.StatusOK)
+	var v124Images []v124Image
+	err = json.Unmarshal(b, &v124Images)
+	c.Assert(err, checker.IsNil)
+	c.Assert(len(v124Images), checker.Not(checker.Equals), 0)
+	for _, image := range v124Images {
+		c.Assert(image.Size, checker.Not(checker.Equals), int64(-1))
+	}
+}


### PR DESCRIPTION
* storeLayer.Parent should return describableStoreLayers #30085
* Fix `Size` in `docker images` for v1.12 client to v1.13 daemon #30061