### PR TITLE
revert "virtualSize" name change

### DIFF
--- a/daemon/images.go
+++ b/daemon/images.go
@@ -315,13 +315,13 @@ func (daemon *Daemon) SquashImage(id, parent string) (string, error) {
 	return string(newImgID), nil
 }
 
-func newImage(image *image.Image, virtualSize int64) *types.ImageSummary {
+func newImage(image *image.Image, size int64) *types.ImageSummary {
 	newImage := new(types.ImageSummary)
 	newImage.ParentID = image.Parent.String()
 	newImage.ID = image.ID().String()
 	newImage.Created = image.Created.Unix()
-	newImage.Size = virtualSize
-	newImage.VirtualSize = virtualSize
+	newImage.Size = size
+	newImage.VirtualSize = size
 	newImage.SharedSize = -1
 	newImage.Containers = -1
 	if image.Config != nil {


### PR DESCRIPTION
This came up in the discussion on https://github.com/docker/docker/pull/30061#issuecomment-272394286

Commit b717de5153db503fae61c11e30f04f400f66a6fd (https://github.com/docker/docker/pull/26108/commits/b717de5153db503fae61c11e30f04f400f66a6fd#diff-4adce79060ec85cddf1545ebadcc0d5eR244) changed the name of the "size" argument to "virtualSize", as the "VirtualSize" field was re-used for calculating the size of all layers _not_ used by other images.

be20dc15af0cb281bd6d11586cfcc96bd50d12ca (https://github.com/docker/docker/pull/30061) reverted the change in calculation, but did not change the argument name back to "size".

This changes the name back to its original name, because since the introduction of the content-addressable store in docker 1.10, there no longer is a "virtual" size, so "size" is a better name for this argument.

/cc @vdemeester @mlaventure 