### PR TITLE
Clarify `cp` documentation behaviour with trailing "/."

### DIFF
--- a/docs/reference/commandline/cp.md
+++ b/docs/reference/commandline/cp.md
@@ -75,9 +75,9 @@ argument of `DEST_PATH`, the behavior is as follows:
     - `DEST_PATH` exists and is a file
         - Error condition: cannot copy a directory to a file
     - `DEST_PATH` exists and is a directory
-        - `SRC_PATH` does not end with `/.`
+        - `SRC_PATH` does not end with `/.` (that is: _slash_ followed by _dot_)
             - the source directory is copied into this directory
-        - `SRC_PATH` does end with `/.`
+        - `SRC_PATH` does end with `/.` (that is: _slash_ followed by _dot_)
             - the *content* of the source directory is copied into this
               directory
 

--- a/man/src/container/cp.md
+++ b/man/src/container/cp.md
@@ -42,9 +42,9 @@ argument of `DEST_PATH`, the behavior is as follows:
     - `DEST_PATH` exists and is a file
         - Error condition: cannot copy a directory to a file
     - `DEST_PATH` exists and is a directory
-        - `SRC_PATH` does not end with `/.`
+        - `SRC_PATH` does not end with `/.` (that is: _slash_ followed by _dot_)
             - the source directory is copied into this directory
-        - `SRC_PATH` does end with `/.`
+        - `SRC_PATH` does end with `/.` (that is: _slash_ followed by _dot_)
             - the *content* of the source directory is copied into this
               directory
 


### PR DESCRIPTION
Issue #30082 demonstrated that their is possible confusion with the "/."
where the tailing "." can appear to be merely punctuation within the
document rather than a highly pertinent part of `SRC_PATH`.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Updated the docker cp documentation (in both places) to mitigate the potential confusion as seen in #30082.

**- How I did it**

**- How to verify it**

**- Description for the changelog**

Clarified `docker cp` documentation WRT trailing `/.`.

**- A picture of a cute animal (not mandatory but encouraged)**
![Burke Shelley, Budgie](https://upload.wikimedia.org/wikipedia/commons/0/05/Burke_Shelley.JPG)

