### PR TITLE
Honour $DOCKER_HIDE_LEGACY_COMMANDS in bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3966,11 +3966,30 @@ _docker() {
 	local previous_extglob_setting=$(shopt -p extglob)
 	shopt -s extglob
 
-	local commands=(
-		attach
-		build
-		commit
+	local management_commands=(
 		container
+		image
+		network
+		node
+		plugin
+		secret
+		service
+		stack
+		system
+		volume
+	)
+
+	local top_level_commands=(
+		build
+		login
+		logout
+		run
+		search
+		version
+	)
+
+	local legacy_commands=(
+		commit
 		cp
 		create
 		diff
@@ -3978,20 +3997,14 @@ _docker() {
 		exec
 		export
 		history
-		image
 		images
 		import
 		info
 		inspect
 		kill
 		load
-		login
-		logout
 		logs
-		network
-		node
 		pause
-		plugin
 		port
 		ps
 		pull
@@ -4000,29 +4013,23 @@ _docker() {
 		restart
 		rm
 		rmi
-		run
 		save
-		search
-		secret
-		service
-		stack
 		start
 		stats
 		stop
 		swarm
-		system
 		tag
 		top
 		unpause
 		update
-		version
-		volume
 		wait
 	)
 
 	local experimental_commands=(
 		deploy
 	)
+
+	local commands=(${management_commands[*]} ${top_level_commands[*]} ${DOCKER_HIDE_LEGACY_COMMANDS:+${legacy_commands[*]}})
 
 	# These options are valid as global options for all client commands
 	# and valid as command options for `docker daemon`


### PR DESCRIPTION
Ref #29803

If `$DOCKER_HIDE_LEGACY_COMMANDS` is set, all legacy commands are hidden in `docker --help` output.
With this PR, they are also hidden in bash completion.
Note that completion still works after the user manually typed a legacy command, e.g. `docker commit <tab>`.

Hint: The experimental commands are defined here but added somewhere else (in `_docker()`) because they require an extra call to `docker version`. This is done for performance reasons.

ping @sdurrheimer this could also be applied to zsh completion