### PR TITLE
Windows: return err instead of panic when convert string to utf16

### DIFF
--- a/daemon/logger/etwlogs/etwlogs_windows.go
+++ b/daemon/logger/etwlogs/etwlogs_windows.go
@@ -146,7 +146,13 @@ func callEventRegister() error {
 }
 
 func callEventWriteString(message string) error {
-	ret, _, _ := procEventWriteString.Call(uintptr(providerHandle), 0, 0, uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(message))))
+	utf16message, err := syscall.UTF16FromString(message)
+
+	if err != nil {
+		return err
+	}
+
+	ret, _, _ := procEventWriteString.Call(uintptr(providerHandle), 0, 0, uintptr(unsafe.Pointer(&utf16message[0])))
 	if ret != win32CallSuccess {
 		errorMessage := fmt.Sprintf("ETWLogs provider failed to log message. Error: %d", ret)
 		logrus.Error(errorMessage)


### PR DESCRIPTION
Signed-off-by: Boshi Lian <farmer1992@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix #30074 

**- How I did it**

change `StringToUTF16Ptr` to `UTF16FromString` which will not panic docker daemon

<https://golang.org/src/syscall/syscall_windows.go>

**- How to verify it**

test with NUL string

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

return err instead of panic when convert string to utf16

**- A picture of a cute animal (not mandatory but encouraged)**

// lamina etuc
🐱 