### PR TITLE
[test-integration] Use testEnv methods and remove most of the global variables

### DIFF
--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -16,7 +16,7 @@ import (
 func (s *DockerSuite) TestBuildAPIDockerFileRemote(c *check.C) {
 	testRequires(c, NotUserNamespace)
 	var testD string
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		testD = `FROM busybox
 COPY * /tmp/
 RUN find / -name ba*

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -919,7 +919,7 @@ func (s *DockerSuite) TestContainerAPIStart(c *check.C) {
 	c.Assert(err, checker.IsNil)
 
 	// TODO(tibor): figure out why this doesn't work on windows
-	if isLocalDaemon {
+	if testEnv.LocalDaemon() {
 		c.Assert(status, checker.Equals, http.StatusNotModified)
 	}
 }
@@ -943,7 +943,7 @@ func (s *DockerSuite) TestContainerAPIWait(c *check.C) {
 	name := "test-api-wait"
 
 	sleepCmd := "/bin/sleep"
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		sleepCmd = "sleep"
 	}
 	dockerCmd(c, "run", "--name", name, "busybox", sleepCmd, "2")
@@ -1112,7 +1112,7 @@ func (s *DockerSuite) TestContainerAPIDeleteRemoveVolume(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
 	vol := "/testvolume"
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		vol = `c:\testvolume`
 	}
 
@@ -1769,7 +1769,7 @@ func (s *DockerSuite) TestContainersAPICreateMountsCreate(c *check.C) {
 		err     error
 		testImg string
 	)
-	if daemonPlatform != "windows" {
+	if testEnv.DaemonPlatform() != "windows" {
 		testImg, err = buildImage("test-mount-config", `
 	FROM busybox
 	RUN mkdir `+destPath+` && touch `+destPath+slash+`bar
@@ -1822,7 +1822,7 @@ func (s *DockerSuite) TestContainersAPICreateMountsCreate(c *check.C) {
 		}
 	}
 
-	if daemonPlatform != "windows" { // Windows does not support volume populate
+	if testEnv.DaemonPlatform() != "windows" { // Windows does not support volume populate
 		cases = append(cases, []testCase{
 			{mounttypes.Mount{Type: "volume", Target: destPath, VolumeOptions: &mounttypes.VolumeOptions{NoCopy: true}}, types.MountPoint{Driver: volume.DefaultDriverName, Type: "volume", RW: true, Destination: destPath}},
 			{mounttypes.Mount{Type: "volume", Target: destPath + slash, VolumeOptions: &mounttypes.VolumeOptions{NoCopy: true}}, types.MountPoint{Driver: volume.DefaultDriverName, Type: "volume", RW: true, Destination: destPath}},
@@ -1872,7 +1872,7 @@ func (s *DockerSuite) TestContainersAPICreateMountsCreate(c *check.C) {
 		}
 
 		out, _, err := dockerCmdWithError("start", "-a", id)
-		if (x.cfg.Type != "volume" || (x.cfg.VolumeOptions != nil && x.cfg.VolumeOptions.NoCopy)) && daemonPlatform != "windows" {
+		if (x.cfg.Type != "volume" || (x.cfg.VolumeOptions != nil && x.cfg.VolumeOptions.NoCopy)) && testEnv.DaemonPlatform() != "windows" {
 			c.Assert(err, checker.NotNil, check.Commentf("%s\n%v", out, mps[0]))
 		} else {
 			c.Assert(err, checker.IsNil, check.Commentf("%s\n%v", out, mps[0]))

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -73,7 +73,7 @@ func (s *DockerSuite) TestAPIImagesSaveAndLoad(c *check.C) {
 }
 
 func (s *DockerSuite) TestAPIImagesDelete(c *check.C) {
-	if daemonPlatform != "windows" {
+	if testEnv.DaemonPlatform() != "windows" {
 		testRequires(c, Network)
 	}
 	name := "test-api-images-delete"
@@ -97,7 +97,7 @@ func (s *DockerSuite) TestAPIImagesDelete(c *check.C) {
 }
 
 func (s *DockerSuite) TestAPIImagesHistory(c *check.C) {
-	if daemonPlatform != "windows" {
+	if testEnv.DaemonPlatform() != "windows" {
 		testRequires(c, Network)
 	}
 	name := "test-api-images-history"

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -27,7 +27,7 @@ func (s *DockerSuite) TestInspectAPIContainerResponse(c *check.C) {
 
 	var cases []acase
 
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		cases = []acase{
 			{"v1.25", append(keysBase, "Mounts")},
 		}

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -38,7 +38,7 @@ func (s *DockerSuite) TestAPIStatsNoStreamGetCpu(c *check.C) {
 
 	var cpuPercent = 0.0
 
-	if daemonPlatform != "windows" {
+	if testEnv.DaemonPlatform() != "windows" {
 		cpuDelta := float64(v.CPUStats.CPUUsage.TotalUsage - v.PreCPUStats.CPUUsage.TotalUsage)
 		systemDelta := float64(v.CPUStats.SystemUsage - v.PreCPUStats.SystemUsage)
 		cpuPercent = (cpuDelta / systemDelta) * float64(len(v.CPUStats.CPUUsage.PercpuUsage)) * 100.0
@@ -104,7 +104,7 @@ func (s *DockerSuite) TestAPIStatsNetworkStats(c *check.C) {
 
 	// Retrieve the container address
 	net := "bridge"
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		net = "nat"
 	}
 	contIP := findContainerIP(c, id, net)
@@ -152,7 +152,7 @@ func (s *DockerSuite) TestAPIStatsNetworkStats(c *check.C) {
 	// On Linux, account for ARP.
 	expRxPkts := preRxPackets + uint64(numPings)
 	expTxPkts := preTxPackets + uint64(numPings)
-	if daemonPlatform != "windows" {
+	if testEnv.DaemonPlatform() != "windows" {
 		expRxPkts++
 		expTxPkts++
 	}

--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -36,7 +36,7 @@ func (s *DockerSuite) TestAPIGetEnabledCORS(c *check.C) {
 }
 
 func (s *DockerSuite) TestAPIClientVersionOldNotSupported(c *check.C) {
-	if daemonPlatform != runtime.GOOS {
+	if testEnv.DaemonPlatform() != runtime.GOOS {
 		c.Skip("Daemon platform doesn't match test platform")
 	}
 	if api.MinVersion == api.DefaultVersion {

--- a/integration-cli/docker_cli_authz_plugin_v2_test.go
+++ b/integration-cli/docker_cli_authz_plugin_v2_test.go
@@ -33,7 +33,7 @@ type DockerAuthzV2Suite struct {
 func (s *DockerAuthzV2Suite) SetUpTest(c *check.C) {
 	testRequires(c, DaemonIsLinux, Network)
 	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
-		Experimental: experimentalDaemon,
+		Experimental: testEnv.ExperimentalDaemon(),
 	})
 	s.d.Start(c)
 }

--- a/integration-cli/docker_cli_authz_unix_test.go
+++ b/integration-cli/docker_cli_authz_unix_test.go
@@ -65,7 +65,7 @@ type authorizationController struct {
 
 func (s *DockerAuthzSuite) SetUpTest(c *check.C) {
 	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
-		Experimental: experimentalDaemon,
+		Experimental: testEnv.ExperimentalDaemon(),
 	})
 	s.ctrl = &authorizationController{}
 }

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -36,7 +36,7 @@ func (s *DockerSuite) TestBuildJSONEmptyRun(c *check.C) {
 func (s *DockerSuite) TestBuildShCmdJSONEntrypoint(c *check.C) {
 	name := "testbuildshcmdjsonentrypoint"
 	expected := "/bin/sh -c echo test"
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		expected = "cmd /S /C echo test"
 	}
 
@@ -74,7 +74,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementVolume(c *check.C) {
 
 	var volumePath string
 
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		volumePath = "c:/quux"
 	} else {
 		volumePath = "/quux"
@@ -131,7 +131,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementWorkdir(c *check.C) {
 	res := inspectFieldJSON(c, name, "Config.WorkingDir")
 
 	expected := `"/work"`
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		expected = `"C:\\work"`
 	}
 	if res != expected {
@@ -634,7 +634,7 @@ RUN [ $(cat "/test dir/test_file6") = 'test6' ]`, command, command, command, com
 
 func (s *DockerSuite) TestBuildCopyFileWithWhitespaceOnWindows(c *check.C) {
 	testRequires(c, DaemonIsWindows)
-	dockerfile := `FROM ` + WindowsBaseImage + `
+	dockerfile := `FROM ` + testEnv.MinimalBaseImage() + `
 RUN mkdir "C:/test dir"
 RUN mkdir "C:/test_dir"
 COPY [ "test file1", "/test_file1" ]
@@ -1387,7 +1387,7 @@ func (s *DockerSuite) TestBuildRelativeWorkdir(c *check.C) {
 		expectedFinal string
 	)
 
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		expected1 = `C:/`
 		expected2 = `C:/test1`
 		expected3 = `C:/test2`
@@ -1466,7 +1466,7 @@ func (s *DockerSuite) TestBuildWorkdirWithEnvVariables(c *check.C) {
 	name := "testbuildworkdirwithenvvariables"
 
 	var expected string
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		expected = `C:\test1\test2`
 	} else {
 		expected = `/test1/test2`
@@ -1488,7 +1488,7 @@ func (s *DockerSuite) TestBuildRelativeCopy(c *check.C) {
 	testRequires(c, NotUserNamespace)
 
 	var expected string
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		expected = `C:/test1/test2`
 	} else {
 		expected = `/test1/test2`
@@ -1597,7 +1597,7 @@ func (s *DockerSuite) TestBuildContextCleanup(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
 	name := "testbuildcontextcleanup"
-	entries, err := ioutil.ReadDir(filepath.Join(dockerBasePath, "tmp"))
+	entries, err := ioutil.ReadDir(filepath.Join(testEnv.DockerBasePath(), "tmp"))
 	if err != nil {
 		c.Fatalf("failed to list contents of tmp dir: %s", err)
 	}
@@ -1605,7 +1605,7 @@ func (s *DockerSuite) TestBuildContextCleanup(c *check.C) {
 	buildImageSuccessfully(c, name, withDockerfile(`FROM `+minimalBaseImage()+`
         ENTRYPOINT ["/bin/echo"]`))
 
-	entriesFinal, err := ioutil.ReadDir(filepath.Join(dockerBasePath, "tmp"))
+	entriesFinal, err := ioutil.ReadDir(filepath.Join(testEnv.DockerBasePath(), "tmp"))
 	if err != nil {
 		c.Fatalf("failed to list contents of tmp dir: %s", err)
 	}
@@ -1619,7 +1619,7 @@ func (s *DockerSuite) TestBuildContextCleanupFailedBuild(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
 	name := "testbuildcontextcleanup"
-	entries, err := ioutil.ReadDir(filepath.Join(dockerBasePath, "tmp"))
+	entries, err := ioutil.ReadDir(filepath.Join(testEnv.DockerBasePath(), "tmp"))
 	if err != nil {
 		c.Fatalf("failed to list contents of tmp dir: %s", err)
 	}
@@ -1629,7 +1629,7 @@ func (s *DockerSuite) TestBuildContextCleanupFailedBuild(c *check.C) {
 		ExitCode: 1,
 	})
 
-	entriesFinal, err := ioutil.ReadDir(filepath.Join(dockerBasePath, "tmp"))
+	entriesFinal, err := ioutil.ReadDir(filepath.Join(testEnv.DockerBasePath(), "tmp"))
 	if err != nil {
 		c.Fatalf("failed to list contents of tmp dir: %s", err)
 	}
@@ -2253,7 +2253,7 @@ func (s *DockerSuite) TestBuildAddFileNotFound(c *check.C) {
 	name := "testbuildaddnotfound"
 	expected := "foo: no such file or directory"
 
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		expected = "foo: The system cannot find the file specified"
 	}
 
@@ -2307,7 +2307,7 @@ func (s *DockerSuite) TestBuildOnBuild(c *check.C) {
 // gh #2446
 func (s *DockerSuite) TestBuildAddToSymlinkDest(c *check.C) {
 	makeLink := `ln -s /foo /bar`
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		makeLink = `mklink /D C:\bar C:\foo`
 	}
 	name := "testbuildaddtosymlinkdest"
@@ -3299,7 +3299,7 @@ func (s *DockerSuite) TestBuildCmdShDashC(c *check.C) {
 
 	res := inspectFieldJSON(c, name, "Config.Cmd")
 	expected := `["/bin/sh","-c","echo cmd"]`
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		expected = `["cmd","/S","/C","echo cmd"]`
 	}
 	if res != expected {
@@ -3374,7 +3374,7 @@ func (s *DockerSuite) TestBuildEntrypointCanBeOverridenByChildInspect(c *check.C
 		expected = `["/bin/sh","-c","echo quux"]`
 	)
 
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		expected = `["cmd","/S","/C","echo quux"]`
 	}
 
@@ -3431,7 +3431,7 @@ func (s *DockerSuite) TestBuildVerifySingleQuoteFails(c *check.C) {
 	// it should barf on it.
 	name := "testbuildsinglequotefails"
 	expectedExitCode := 2
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		expectedExitCode = 127
 	}
 
@@ -3447,7 +3447,7 @@ func (s *DockerSuite) TestBuildVerboseOut(c *check.C) {
 	name := "testbuildverboseout"
 	expected := "\n123\n"
 
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		expected = "\n123\r\n"
 	}
 
@@ -3463,7 +3463,7 @@ func (s *DockerSuite) TestBuildWithTabs(c *check.C) {
 	res := inspectFieldJSON(c, name, "ContainerConfig.Cmd")
 	expected1 := `["/bin/sh","-c","echo\tone\t\ttwo"]`
 	expected2 := `["/bin/sh","-c","echo\u0009one\u0009\u0009two"]` // syntactically equivalent, and what Go 1.3 generates
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		expected1 = `["cmd","/S","/C","echo\tone\t\ttwo"]`
 		expected2 = `["cmd","/S","/C","echo\u0009one\u0009\u0009two"]` // syntactically equivalent, and what Go 1.3 generates
 	}
@@ -3656,7 +3656,7 @@ func (s *DockerSuite) TestBuildStderr(c *check.C) {
 	result.Assert(c, icmd.Success)
 
 	// Windows to non-Windows should have a security warning
-	if runtime.GOOS == "windows" && daemonPlatform != "windows" && !strings.Contains(result.Stdout(), "SECURITY WARNING:") {
+	if runtime.GOOS == "windows" && testEnv.DaemonPlatform() != "windows" && !strings.Contains(result.Stdout(), "SECURITY WARNING:") {
 		c.Fatalf("Stdout contains unexpected output: %q", result.Stdout())
 	}
 
@@ -3775,7 +3775,7 @@ func (s *DockerSuite) TestBuildVolumesRetainContents(c *check.C) {
 		volName  = "/foo"
 	)
 
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		volName = "C:/foo"
 	}
 
@@ -4139,7 +4139,7 @@ RUN echo "  \
 
 	expected := "\n    foo  \n"
 	// Windows uses the builtin echo, which preserves quotes
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		expected = "\"    foo  \""
 	}
 
@@ -4173,7 +4173,7 @@ func (s *DockerSuite) TestBuildMissingArgs(c *check.C) {
 		"INSERT":     {},
 	}
 
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		skipCmds = map[string]struct{}{
 			"CMD":        {},
 			"RUN":        {},
@@ -4306,7 +4306,7 @@ func (s *DockerSuite) TestBuildRUNErrMsg(c *check.C) {
 	name := "testbuildbadrunerrmsg"
 	shell := "/bin/sh -c"
 	exitCode := 127
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		shell = "cmd /S /C"
 		// architectural - Windows has to start the container to determine the exe is bad, Linux does not
 		exitCode = 1
@@ -4460,7 +4460,7 @@ func (s *DockerTrustSuite) TestTrustedBuildTagIgnoresOtherDelegationRoles(c *che
 func (s *DockerSuite) TestBuildNullStringInAddCopyVolume(c *check.C) {
 	name := "testbuildnullstringinaddcopyvolume"
 	volName := "nullvolume"
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		volName = `C:\\nullvolume`
 	}
 
@@ -4500,7 +4500,7 @@ func (s *DockerSuite) TestBuildBuildTimeArg(c *check.C) {
 	envKey := "foo"
 	envVal := "bar"
 	var dockerfile string
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		// Bugs in Windows busybox port - use the default base image and native cmd stuff
 		dockerfile = fmt.Sprintf(`FROM `+minimalBaseImage()+`
 			ARG %s
@@ -5008,7 +5008,7 @@ func (s *DockerSuite) TestBuildBuildTimeArgDefintionWithNoEnvInjection(c *check.
 func (s *DockerSuite) TestBuildNoNamedVolume(c *check.C) {
 	volName := "testname:/foo"
 
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		volName = "testname:C:\\foo"
 	}
 	dockerCmd(c, "run", "-v", volName, "busybox", "sh", "-c", "touch /foo/oops")
@@ -5226,7 +5226,7 @@ func (s *DockerSuite) TestBuildWorkdirWindowsPath(c *check.C) {
 	testRequires(c, DaemonIsWindows)
 	name := "testbuildworkdirwindowspath"
 	buildImageSuccessfully(c, name, withDockerfile(`
-	FROM `+WindowsBaseImage+`
+	FROM `+testEnv.MinimalBaseImage()+`
 	RUN mkdir C:\\work
 	WORKDIR C:\\work
 	RUN if "%CD%" NEQ "C:\work" exit -1
@@ -5911,7 +5911,7 @@ func (s *DockerSuite) TestBuildOpaqueDirectory(c *check.C) {
 func (s *DockerSuite) TestBuildWindowsUser(c *check.C) {
 	testRequires(c, DaemonIsWindows)
 	name := "testbuildwindowsuser"
-	buildImageNew(name, withDockerfile(`FROM `+WindowsBaseImage+`
+	buildImageNew(name, withDockerfile(`FROM `+testEnv.MinimalBaseImage()+`
 		RUN net user user /add
 		USER user
 		RUN set username
@@ -5942,7 +5942,7 @@ func (s *DockerSuite) TestBuildWindowsEnvCaseInsensitive(c *check.C) {
 	testRequires(c, DaemonIsWindows)
 	name := "testbuildwindowsenvcaseinsensitive"
 	buildImageSuccessfully(c, name, withDockerfile(`
-		FROM `+WindowsBaseImage+`
+		FROM `+testEnv.MinimalBaseImage()+`
 		ENV FOO=bar foo=baz
   `))
 	res := inspectFieldJSON(c, name, "Config.Env")
@@ -5962,7 +5962,7 @@ WORKDIR /foo/bar
 
 	// The Windows busybox image has a blank `cmd`
 	lookingFor := `["sh"]`
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		lookingFor = "null"
 	}
 	c.Assert(strings.TrimSpace(out), checker.Equals, lookingFor)

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -636,7 +636,7 @@ func (s *DockerRegistrySuite) TestPullFailsWithAlteredLayer(c *check.C) {
 	// digest verification for the target layer digest.
 
 	// Remove distribution cache to force a re-pull of the blobs
-	if err := os.RemoveAll(filepath.Join(dockerBasePath, "image", s.d.StorageDriver(), "distribution")); err != nil {
+	if err := os.RemoveAll(filepath.Join(testEnv.DockerBasePath(), "image", s.d.StorageDriver(), "distribution")); err != nil {
 		c.Fatalf("error clearing distribution cache: %v", err)
 	}
 
@@ -679,7 +679,7 @@ func (s *DockerSchema1RegistrySuite) TestPullFailsWithAlteredLayer(c *check.C) {
 	// digest verification for the target layer digest.
 
 	// Remove distribution cache to force a re-pull of the blobs
-	if err := os.RemoveAll(filepath.Join(dockerBasePath, "image", s.d.StorageDriver(), "distribution")); err != nil {
+	if err := os.RemoveAll(filepath.Join(testEnv.DockerBasePath(), "image", s.d.StorageDriver(), "distribution")); err != nil {
 		c.Fatalf("error clearing distribution cache: %v", err)
 	}
 

--- a/integration-cli/docker_cli_cp_to_container_unix_test.go
+++ b/integration-cli/docker_cli_cp_to_container_unix_test.go
@@ -41,7 +41,7 @@ func (s *DockerSuite) TestCpCheckDestOwnership(c *check.C) {
 }
 
 func getRootUIDGID() (int, int, error) {
-	uidgid := strings.Split(filepath.Base(dockerBasePath), ".")
+	uidgid := strings.Split(filepath.Base(testEnv.DockerBasePath()), ".")
 	if len(uidgid) == 1 {
 		//user namespace remapping is not turned on; return 0
 		return 0, 0, nil

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -58,7 +58,7 @@ func (s *DockerSuite) TestCreateArgs(c *check.C) {
 // Make sure we can grow the container's rootfs at creation time.
 func (s *DockerSuite) TestCreateGrowRootfs(c *check.C) {
 	// Windows and Devicemapper support growing the rootfs
-	if daemonPlatform != "windows" {
+	if testEnv.DaemonPlatform() != "windows" {
 		testRequires(c, Devicemapper)
 	}
 	out, _ := dockerCmd(c, "create", "--storage-opt", "size=120G", "busybox")
@@ -226,8 +226,8 @@ func (s *DockerSuite) TestCreateLabelFromImage(c *check.C) {
 func (s *DockerSuite) TestCreateHostnameWithNumber(c *check.C) {
 	image := "busybox"
 	// Busybox on Windows does not implement hostname command
-	if daemonPlatform == "windows" {
-		image = WindowsBaseImage
+	if testEnv.DaemonPlatform() == "windows" {
+		image = testEnv.MinimalBaseImage()
 	}
 	out, _ := dockerCmd(c, "run", "-h", "web.0", image, "hostname")
 	c.Assert(strings.TrimSpace(out), checker.Equals, "web.0", check.Commentf("hostname not set, expected `web.0`, got: %s", out))
@@ -411,7 +411,7 @@ func (s *DockerSuite) TestCreateWithWorkdir(c *check.C) {
 
 	dockerCmd(c, "create", "--name", name, "-w", dir, "busybox")
 	// Windows does not create the workdir until the container is started
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		dockerCmd(c, "start", name)
 	}
 	dockerCmd(c, "cp", fmt.Sprintf("%s:%s", name, dir), prefix+slash+"tmp")

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1398,7 +1398,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithSocketAsVolume(c *check.C) {
 // A subsequent daemon restart shoud clean up said mounts.
 func (s *DockerDaemonSuite) TestCleanupMountsAfterDaemonAndContainerKill(c *check.C) {
 	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
-		Experimental: experimentalDaemon,
+		Experimental: testEnv.ExperimentalDaemon(),
 	})
 	d.StartWithBusybox(c)
 
@@ -1431,7 +1431,7 @@ func (s *DockerDaemonSuite) TestCleanupMountsAfterDaemonAndContainerKill(c *chec
 // os.Interrupt should perform a graceful daemon shutdown and hence cleanup mounts.
 func (s *DockerDaemonSuite) TestCleanupMountsAfterGracefulShutdown(c *check.C) {
 	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
-		Experimental: experimentalDaemon,
+		Experimental: testEnv.ExperimentalDaemon(),
 	})
 	d.StartWithBusybox(c)
 
@@ -1652,7 +1652,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartLocalVolumes(c *check.C) {
 // FIXME(vdemeester) should be a unit test
 func (s *DockerDaemonSuite) TestDaemonCorruptedLogDriverAddress(c *check.C) {
 	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
-		Experimental: experimentalDaemon,
+		Experimental: testEnv.ExperimentalDaemon(),
 	})
 	c.Assert(d.StartWithError("--log-driver=syslog", "--log-opt", "syslog-address=corrupted:42"), check.NotNil)
 	expected := "Failed to set log opts: syslog-address should be in form proto://address"
@@ -1662,7 +1662,7 @@ func (s *DockerDaemonSuite) TestDaemonCorruptedLogDriverAddress(c *check.C) {
 // FIXME(vdemeester) should be a unit test
 func (s *DockerDaemonSuite) TestDaemonCorruptedFluentdAddress(c *check.C) {
 	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
-		Experimental: experimentalDaemon,
+		Experimental: testEnv.ExperimentalDaemon(),
 	})
 	c.Assert(d.StartWithError("--log-driver=fluentd", "--log-opt", "fluentd-address=corrupted:c"), check.NotNil)
 	expected := "Failed to set log opts: invalid fluentd-address corrupted:c: "

--- a/integration-cli/docker_cli_diff_test.go
+++ b/integration-cli/docker_cli_diff_test.go
@@ -19,7 +19,7 @@ func (s *DockerSuite) TestDiffFilenameShownInOutput(c *check.C) {
 	// a "Files/" prefix.
 	containerID := strings.TrimSpace(out)
 	lookingFor := "A /foo/bar"
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		err := waitExited(containerID, 60*time.Second)
 		c.Assert(err, check.IsNil)
 		lookingFor = "C Files/foo/bar"

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -688,7 +688,7 @@ func (s *DockerSuite) TestEventsContainerRestart(c *check.C) {
 
 	// wait until test2 is auto removed.
 	waitTime := 10 * time.Second
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		// Windows takes longer...
 		waitTime = 90 * time.Second
 	}

--- a/integration-cli/docker_cli_external_graphdriver_unix_test.go
+++ b/integration-cli/docker_cli_external_graphdriver_unix_test.go
@@ -53,7 +53,7 @@ type graphEventsCounter struct {
 
 func (s *DockerExternalGraphdriverSuite) SetUpTest(c *check.C) {
 	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
-		Experimental: experimentalDaemon,
+		Experimental: testEnv.ExperimentalDaemon(),
 	})
 }
 

--- a/integration-cli/docker_cli_external_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_unix_test.go
@@ -51,7 +51,7 @@ type DockerExternalVolumeSuite struct {
 
 func (s *DockerExternalVolumeSuite) SetUpTest(c *check.C) {
 	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
-		Experimental: experimentalDaemon,
+		Experimental: testEnv.ExperimentalDaemon(),
 	})
 	s.ec = &eventCounter{}
 }

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -118,7 +118,7 @@ func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
 		cmdsToTest = append(cmdsToTest, "network ls")
 		cmdsToTest = append(cmdsToTest, "network rm")
 
-		if experimentalDaemon {
+		if testEnv.ExperimentalDaemon() {
 			cmdsToTest = append(cmdsToTest, "checkpoint create")
 			cmdsToTest = append(cmdsToTest, "checkpoint ls")
 			cmdsToTest = append(cmdsToTest, "checkpoint rm")

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -36,7 +36,7 @@ func (s *DockerSuite) TestInfoEnsureSucceeds(c *check.C) {
 		"Live Restore Enabled:",
 	}
 
-	if daemonPlatform == "linux" {
+	if testEnv.DaemonPlatform() == "linux" {
 		stringsToCheck = append(stringsToCheck, "Init Binary:", "Security Options:", "containerd version:", "runc version:", "init version:")
 	}
 
@@ -44,7 +44,7 @@ func (s *DockerSuite) TestInfoEnsureSucceeds(c *check.C) {
 		stringsToCheck = append(stringsToCheck, "Runtimes:", "Default Runtime: runc")
 	}
 
-	if experimentalDaemon {
+	if testEnv.ExperimentalDaemon() {
 		stringsToCheck = append(stringsToCheck, "Experimental: true")
 	} else {
 		stringsToCheck = append(stringsToCheck, "Experimental: false")
@@ -72,7 +72,7 @@ func (s *DockerSuite) TestInfoDiscoveryBackend(c *check.C) {
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
-		Experimental: experimentalDaemon,
+		Experimental: testEnv.ExperimentalDaemon(),
 	})
 	discoveryBackend := "consul://consuladdr:consulport/some/path"
 	discoveryAdvertise := "1.1.1.1:2375"
@@ -91,7 +91,7 @@ func (s *DockerSuite) TestInfoDiscoveryInvalidAdvertise(c *check.C) {
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
-		Experimental: experimentalDaemon,
+		Experimental: testEnv.ExperimentalDaemon(),
 	})
 	discoveryBackend := "consul://consuladdr:consulport/some/path"
 
@@ -110,7 +110,7 @@ func (s *DockerSuite) TestInfoDiscoveryAdvertiseInterfaceName(c *check.C) {
 	testRequires(c, SameHostDaemon, Network, DaemonIsLinux)
 
 	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
-		Experimental: experimentalDaemon,
+		Experimental: testEnv.ExperimentalDaemon(),
 	})
 	discoveryBackend := "consul://consuladdr:consulport/some/path"
 	discoveryAdvertise := "eth0"
@@ -177,7 +177,7 @@ func (s *DockerSuite) TestInfoDebug(c *check.C) {
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
-		Experimental: experimentalDaemon,
+		Experimental: testEnv.ExperimentalDaemon(),
 	})
 	d.Start(c, "--debug")
 	defer d.Stop(c)
@@ -200,7 +200,7 @@ func (s *DockerSuite) TestInsecureRegistries(c *check.C) {
 	registryHost := "insecurehost.com:5000"
 
 	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
-		Experimental: experimentalDaemon,
+		Experimental: testEnv.ExperimentalDaemon(),
 	})
 	d.Start(c, "--insecure-registry="+registryCIDR, "--insecure-registry="+registryHost)
 	defer d.Stop(c)

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -53,7 +53,7 @@ func (s *DockerSuite) TestInspectDefault(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectStatus(c *check.C) {
-	if daemonPlatform != "windows" {
+	if testEnv.DaemonPlatform() != "windows" {
 		defer unpauseAllContainers(c)
 	}
 	out, _ := runSleepingContainer(c, "-d")
@@ -64,7 +64,7 @@ func (s *DockerSuite) TestInspectStatus(c *check.C) {
 
 	// Windows does not support pause/unpause on Windows Server Containers.
 	// (RS1 does for Hyper-V Containers, but production CI is not setup for that)
-	if daemonPlatform != "windows" {
+	if testEnv.DaemonPlatform() != "windows" {
 		dockerCmd(c, "pause", out)
 		inspectOut = inspectField(c, out, "State.Status")
 		c.Assert(inspectOut, checker.Equals, "paused")
@@ -209,7 +209,7 @@ func (s *DockerSuite) TestInspectContainerGraphDriver(c *check.C) {
 func (s *DockerSuite) TestInspectBindMountPoint(c *check.C) {
 	modifier := ",z"
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		modifier = ""
 		// Linux creates the host directory if it doesn't exist. Windows does not.
 		os.Mkdir(`c:\data`, os.ModeDir)
@@ -232,7 +232,7 @@ func (s *DockerSuite) TestInspectBindMountPoint(c *check.C) {
 	c.Assert(m.Driver, checker.Equals, "")
 	c.Assert(m.Source, checker.Equals, prefix+slash+"data")
 	c.Assert(m.Destination, checker.Equals, prefix+slash+"data")
-	if daemonPlatform != "windows" { // Windows does not set mode
+	if testEnv.DaemonPlatform() != "windows" { // Windows does not set mode
 		c.Assert(m.Mode, checker.Equals, "ro"+modifier)
 	}
 	c.Assert(m.RW, checker.Equals, false)

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -49,7 +49,7 @@ type DockerNetworkSuite struct {
 
 func (s *DockerNetworkSuite) SetUpTest(c *check.C) {
 	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
-		Experimental: experimentalDaemon,
+		Experimental: testEnv.ExperimentalDaemon(),
 	})
 }
 

--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -47,7 +47,7 @@ func (s *DockerSuite) TestPluginBasicOps(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, pNameWithTag)
 
-	_, err = os.Stat(filepath.Join(dockerBasePath, "plugins", id))
+	_, err = os.Stat(filepath.Join(testEnv.DockerBasePath(), "plugins", id))
 	if !os.IsNotExist(err) {
 		c.Fatal(err)
 	}

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -213,7 +213,7 @@ func (s *DockerSuite) TestPsListContainersFilterStatus(c *check.C) {
 	})
 
 	// Windows doesn't support pausing of containers
-	if daemonPlatform != "windows" {
+	if testEnv.DaemonPlatform() != "windows" {
 		// pause running container
 		out, _ = dockerCmd(c, "run", "-itd", "busybox")
 		pausedID := strings.TrimSpace(out)

--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -104,7 +104,7 @@ func (s *DockerSuite) TestRenameAnonymousContainer(c *check.C) {
 	dockerCmd(c, "start", "container1")
 
 	count := "-c"
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		count = "-n"
 	}
 

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -253,7 +253,7 @@ func (s *DockerSuite) TestRestartContainerwithRestartPolicy(c *check.C) {
 	id1 := strings.TrimSpace(string(out1))
 	id2 := strings.TrimSpace(string(out2))
 	waitTimeout := 15 * time.Second
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		waitTimeout = 150 * time.Second
 	}
 	err := waitInspect(id1, "{{ .State.Restarting }} {{ .State.Running }}", "false false", waitTimeout)

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -67,7 +67,7 @@ func (s *DockerSuite) TestRmiImgIDMultipleTag(c *check.C) {
 
 	// Wait for it to exit as cannot commit a running container on Windows, and
 	// it will take a few seconds to exit
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		err := waitExited(containerID, 60*time.Second)
 		c.Assert(err, check.IsNil)
 	}
@@ -111,7 +111,7 @@ func (s *DockerSuite) TestRmiImgIDForce(c *check.C) {
 
 	// Wait for it to exit as cannot commit a running container on Windows, and
 	// it will take a few seconds to exit
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		err := waitExited(containerID, 60*time.Second)
 		c.Assert(err, check.IsNil)
 	}

--- a/integration-cli/docker_cli_top_test.go
+++ b/integration-cli/docker_cli_top_test.go
@@ -13,7 +13,7 @@ func (s *DockerSuite) TestTopMultipleArgs(c *check.C) {
 	cleanedContainerID := strings.TrimSpace(out)
 
 	var expected icmd.Expected
-	switch daemonPlatform {
+	switch testEnv.DaemonPlatform() {
 	case "windows":
 		expected = icmd.Expected{ExitCode: 1, Err: "Windows does not support arguments to top"}
 	default:
@@ -34,7 +34,7 @@ func (s *DockerSuite) TestTopNonPrivileged(c *check.C) {
 	// Windows will list the name of the launched executable which in this case is busybox.exe, without the parameters.
 	// Linux will display the command executed in the container
 	var lookingFor string
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		lookingFor = "busybox.exe"
 	} else {
 		lookingFor = "top"

--- a/integration-cli/docker_cli_update_test.go
+++ b/integration-cli/docker_cli_update_test.go
@@ -11,7 +11,7 @@ import (
 func (s *DockerSuite) TestUpdateRestartPolicy(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "sh", "-c", "sleep 1 && false")
 	timeout := 60 * time.Second
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		timeout = 180 * time.Second
 	}
 

--- a/integration-cli/docker_deprecated_api_v124_test.go
+++ b/integration-cli/docker_deprecated_api_v124_test.go
@@ -33,7 +33,7 @@ func (s *DockerSuite) TestDeprecatedContainerAPIStartVolumeBinds(c *check.C) {
 	// TODO Windows CI: Investigate further why this fails on Windows to Windows CI.
 	testRequires(c, DaemonIsLinux)
 	path := "/foo"
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		path = `c:\foo`
 	}
 	name := "testing"
@@ -46,7 +46,7 @@ func (s *DockerSuite) TestDeprecatedContainerAPIStartVolumeBinds(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusCreated)
 
-	bindPath := testutil.RandomTmpDirPath("test", daemonPlatform)
+	bindPath := testutil.RandomTmpDirPath("test", testEnv.DaemonPlatform())
 	config = map[string]interface{}{
 		"Binds": []string{bindPath + ":" + path},
 	}
@@ -73,8 +73,8 @@ func (s *DockerSuite) TestDeprecatedContainerAPIStartDupVolumeBinds(c *check.C) 
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusCreated)
 
-	bindPath1 := testutil.RandomTmpDirPath("test1", daemonPlatform)
-	bindPath2 := testutil.RandomTmpDirPath("test2", daemonPlatform)
+	bindPath1 := testutil.RandomTmpDirPath("test1", testEnv.DaemonPlatform())
+	bindPath2 := testutil.RandomTmpDirPath("test2", testEnv.DaemonPlatform())
 
 	config = map[string]interface{}{
 		"Binds": []string{bindPath1 + ":/tmp", bindPath2 + ":/tmp"},

--- a/integration-cli/docker_hub_pull_suite_test.go
+++ b/integration-cli/docker_hub_pull_suite_test.go
@@ -41,7 +41,7 @@ func newDockerHubPullSuite() *DockerHubPullSuite {
 func (s *DockerHubPullSuite) SetUpSuite(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	s.d = daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
-		Experimental: experimentalDaemon,
+		Experimental: testEnv.ExperimentalDaemon(),
 	})
 	s.d.Start(c)
 }

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -80,7 +80,7 @@ func deleteAllNetworks(c *check.C) {
 		if n.Name == "bridge" || n.Name == "none" || n.Name == "host" {
 			continue
 		}
-		if daemonPlatform == "windows" && strings.ToLower(n.Name) == "nat" {
+		if testEnv.DaemonPlatform() == "windows" && strings.ToLower(n.Name) == "nat" {
 			// nat is a pre-defined network on Windows and cannot be removed
 			continue
 		}
@@ -290,7 +290,7 @@ func dockerCmdInDir(c *check.C, path string, args ...string) (string, int, error
 // validateArgs is a checker to ensure tests are not running commands which are
 // not supported on platforms. Specifically on Windows this is 'busybox top'.
 func validateArgs(args ...string) error {
-	if daemonPlatform != "windows" {
+	if testEnv.DaemonPlatform() != "windows" {
 		return nil
 	}
 	foundBusybox := -1
@@ -448,7 +448,7 @@ func fakeStorage(files map[string]string) (FakeStorage, error) {
 
 // fakeStorageWithContext returns either a local or remote (at daemon machine) file server
 func fakeStorageWithContext(ctx *FakeContext) (FakeStorage, error) {
-	if isLocalDaemon {
+	if testEnv.LocalDaemon() {
 		return newLocalFakeStorage(ctx)
 	}
 	return newRemoteFileServer(ctx)
@@ -1027,7 +1027,7 @@ func readFile(src string, c *check.C) (content string) {
 }
 
 func containerStorageFile(containerID, basename string) string {
-	return filepath.Join(containerStoragePath, containerID, basename)
+	return filepath.Join(testEnv.ContainerStoragePath(), containerID, basename)
 }
 
 // docker commands that use this function must be run with the '-d' switch.
@@ -1068,7 +1068,7 @@ func readContainerFileWithExec(containerID, filename string) ([]byte, error) {
 
 // daemonTime provides the current time on the daemon host
 func daemonTime(c *check.C) time.Time {
-	if isLocalDaemon {
+	if testEnv.LocalDaemon() {
 		return time.Now()
 	}
 

--- a/integration-cli/environment/environment.go
+++ b/integration-cli/environment/environment.go
@@ -8,11 +8,10 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+	"golang.org/x/net/context"
 )
 
 // Execution holds informations about the test execution environment.

--- a/integration-cli/fixtures_linux_daemon_test.go
+++ b/integration-cli/fixtures_linux_daemon_test.go
@@ -50,7 +50,7 @@ func ensureSyscallTest(c *check.C) {
 
 	// if no match, must build in docker, which is significantly slower
 	// (slower mostly because of the vfs graphdriver)
-	if daemonPlatform != runtime.GOOS {
+	if testEnv.DaemonPlatform() != runtime.GOOS {
 		ensureSyscallTestBuild(c)
 		return
 	}
@@ -105,7 +105,7 @@ func ensureSyscallTestBuild(c *check.C) {
 
 func ensureNNPTest(c *check.C) {
 	protectedImages["nnp-test:latest"] = struct{}{}
-	if daemonPlatform != runtime.GOOS {
+	if testEnv.DaemonPlatform() != runtime.GOOS {
 		ensureNNPTestBuild(c)
 		return
 	}

--- a/integration-cli/fixtures_test.go
+++ b/integration-cli/fixtures_test.go
@@ -29,7 +29,7 @@ func ensureHTTPServerImage() error {
 	}
 	defer os.RemoveAll(tmp)
 
-	goos := daemonPlatform
+	goos := testEnv.DaemonPlatform()
 	if goos == "" {
 		goos = "linux"
 	}

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func PlatformIs(platform string) bool {
-	return daemonPlatform == platform
+	return testEnv.DaemonPlatform() == platform
 }
 
 func ArchitectureIs(arch string) bool {
@@ -26,11 +26,11 @@ func ArchitectureIsNot(arch string) bool {
 }
 
 func StorageDriverIs(storageDriver string) bool {
-	return strings.HasPrefix(daemonStorageDriver, storageDriver)
+	return strings.HasPrefix(testEnv.DaemonStorageDriver(), storageDriver)
 }
 
 func StorageDriverIsNot(storageDriver string) bool {
-	return !strings.HasPrefix(daemonStorageDriver, storageDriver)
+	return !strings.HasPrefix(testEnv.DaemonStorageDriver(), storageDriver)
 }
 
 func DaemonIsWindows() bool {
@@ -42,11 +42,11 @@ func DaemonIsLinux() bool {
 }
 
 func ExperimentalDaemon() bool {
-	return experimentalDaemon
+	return testEnv.ExperimentalDaemon()
 }
 
 func NotExperimentalDaemon() bool {
-	return !experimentalDaemon
+	return !testEnv.ExperimentalDaemon()
 }
 
 func IsAmd64() bool {
@@ -70,7 +70,7 @@ func NotS390X() bool {
 }
 
 func SameHostDaemon() bool {
-	return isLocalDaemon
+	return testEnv.LocalDaemon()
 }
 
 func UnixCli() bool {
@@ -171,21 +171,21 @@ func UserNamespaceInKernel() bool {
 }
 
 func IsPausable() bool {
-	if daemonPlatform == "windows" {
-		return isolation == "hyperv"
+	if testEnv.DaemonPlatform() == "windows" {
+		return testEnv.Isolation() == "hyperv"
 	}
 	return true
 }
 
 func NotPausable() bool {
-	if daemonPlatform == "windows" {
-		return isolation == "process"
+	if testEnv.DaemonPlatform() == "windows" {
+		return testEnv.Isolation() == "process"
 	}
 	return false
 }
 
 func IsolationIs(expectedIsolation string) bool {
-	return daemonPlatform == "windows" && string(isolation) == expectedIsolation
+	return testEnv.DaemonPlatform() == "windows" && string(testEnv.Isolation()) == expectedIsolation
 }
 
 func IsolationIsHyperv() bool {

--- a/integration-cli/requirements_unix_test.go
+++ b/integration-cli/requirements_unix_test.go
@@ -101,7 +101,7 @@ func overlay2Supported() bool {
 		return false
 	}
 
-	daemonV, err := kernel.ParseRelease(daemonKernelVersion)
+	daemonV, err := kernel.ParseRelease(testEnv.DaemonKernelVersion())
 	if err != nil {
 		return false
 	}

--- a/integration-cli/test_vars_test.go
+++ b/integration-cli/test_vars_test.go
@@ -4,7 +4,7 @@ package main
 // the command is for a sleeping container based on the daemon platform.
 // The Windows busybox image does not have a `top` command.
 func sleepCommandForDaemonPlatform() []string {
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		return []string{"sleep", "240"}
 	}
 	return []string{"top"}

--- a/integration-cli/utils_test.go
+++ b/integration-cli/utils_test.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"github.com/docker/docker/pkg/testutil/cmd"
 	"os/exec"
+
+	"github.com/docker/docker/pkg/testutil/cmd"
 )
 
 func getPrefixAndSlashFromDaemonPlatform() (prefix, slash string) {
-	if daemonPlatform == "windows" {
+	if testEnv.DaemonPlatform() == "windows" {
 		return "c:", `\`
 	}
 	return "", "/"


### PR DESCRIPTION
Remove almost all global variables from integration-cli and use `testEnv` instead 👼 .

/cc @thaJeztah @icecrime @dnephin @cpuguy83 @tiborvass @tonistiigi 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>