### PR TITLE
Windows: Use sequential file access

### DIFF
--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -3,16 +3,19 @@ package command
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/docker/docker/pkg/system"
 )
 
 // CopyToFile writes the content of the reader to the specified file
 func CopyToFile(outfile string, r io.Reader) error {
-	tmpFile, err := ioutil.TempFile(filepath.Dir(outfile), ".docker_temp_")
+	// We use sequential file access here to avoid depleting the standby list
+	// on Windows. On Linux, this is a call directly to ioutil.TempFile
+	tmpFile, err := system.TempFileSequential(filepath.Dir(outfile), ".docker_temp_")
 	if err != nil {
 		return err
 	}

--- a/pkg/system/filesys.go
+++ b/pkg/system/filesys.go
@@ -3,6 +3,7 @@
 package system
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -24,7 +25,7 @@ func IsAbs(path string) bool {
 	return filepath.IsAbs(path)
 }
 
-// The functions below here are wrappers for the equivalents in the os package.
+// The functions below here are wrappers for the equivalents in the os and ioutils packages.
 // They are passthrough on Unix platforms, and only relevant on Windows.
 
 // CreateSequential creates the named file with mode 0666 (before umask), truncating
@@ -51,4 +52,17 @@ func OpenSequential(name string) (*os.File, error) {
 // If there is an error, it will be of type *PathError.
 func OpenFileSequential(name string, flag int, perm os.FileMode) (*os.File, error) {
 	return os.OpenFile(name, flag, perm)
+}
+
+// TempFileSequential creates a new temporary file in the directory dir
+// with a name beginning with prefix, opens the file for reading
+// and writing, and returns the resulting *os.File.
+// If dir is the empty string, TempFile uses the default directory
+// for temporary files (see os.TempDir).
+// Multiple programs calling TempFile simultaneously
+// will not choose the same file. The caller can use f.Name()
+// to find the pathname of the file. It is the caller's responsibility
+// to remove the file when no longer needed.
+func TempFileSequential(dir, prefix string) (f *os.File, err error) {
+	return ioutil.TempFile(dir, prefix)
 }

--- a/pkg/system/filesys_windows.go
+++ b/pkg/system/filesys_windows.go
@@ -6,8 +6,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
+	"sync"
 	"syscall"
+	"time"
 	"unsafe"
 
 	winio "github.com/Microsoft/go-winio"
@@ -233,4 +236,56 @@ func syscallOpenSequential(path string, mode int, _ uint32) (fd syscall.Handle, 
 	const fileFlagSequentialScan = 0x08000000 // FILE_FLAG_SEQUENTIAL_SCAN
 	h, e := syscall.CreateFile(pathp, access, sharemode, sa, createmode, fileFlagSequentialScan, 0)
 	return h, e
+}
+
+// Helpers for TempFileSequential
+var rand uint32
+var randmu sync.Mutex
+
+func reseed() uint32 {
+	return uint32(time.Now().UnixNano() + int64(os.Getpid()))
+}
+func nextSuffix() string {
+	randmu.Lock()
+	r := rand
+	if r == 0 {
+		r = reseed()
+	}
+	r = r*1664525 + 1013904223 // constants from Numerical Recipes
+	rand = r
+	randmu.Unlock()
+	return strconv.Itoa(int(1e9 + r%1e9))[1:]
+}
+
+// TempFileSequential is a copy of ioutil.TempFile, modified to use sequential
+// file access. Below is the original comment from golang:
+// TempFile creates a new temporary file in the directory dir
+// with a name beginning with prefix, opens the file for reading
+// and writing, and returns the resulting *os.File.
+// If dir is the empty string, TempFile uses the default directory
+// for temporary files (see os.TempDir).
+// Multiple programs calling TempFile simultaneously
+// will not choose the same file. The caller can use f.Name()
+// to find the pathname of the file. It is the caller's responsibility
+// to remove the file when no longer needed.
+func TempFileSequential(dir, prefix string) (f *os.File, err error) {
+	if dir == "" {
+		dir = os.TempDir()
+	}
+
+	nconflict := 0
+	for i := 0; i < 10000; i++ {
+		name := filepath.Join(dir, prefix+nextSuffix())
+		f, err = OpenFileSequential(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
+		if os.IsExist(err) {
+			if nconflict++; nconflict > 10 {
+				randmu.Lock()
+				rand = reseed()
+				randmu.Unlock()
+			}
+			continue
+		}
+		break
+	}
+	return
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This is a follow-on to https://github.com/docker/docker/pull/28272 and uses sequential file access in two additional locations. The perf team here have verified this change (and the positive impact). Quoting from an internal mail: "Excellent! The traces look great as well! All the changes and repurposing during export\import happen to low-pri standby, and high priority standby stays intact. In addition to AA improvement, looks like the change further improved commit as well."

Fixes Internal VSO Bug #9900466  @johnstep FYI