### PR TITLE
Remove timeout on fifos opening

### DIFF
--- a/libcontainerd/process_unix.go
+++ b/libcontainerd/process_unix.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"strings"
-	"time"
 
 	containerd "github.com/docker/containerd/api/grpc/types"
 	"github.com/tonistiigi/fifo"
@@ -31,12 +30,10 @@ type process struct {
 	dir string
 }
 
-func (p *process) openFifos(terminal bool) (pipe *IOPipe, err error) {
+func (p *process) openFifos(ctx context.Context, terminal bool) (pipe *IOPipe, err error) {
 	if err := os.MkdirAll(p.dir, 0700); err != nil {
 		return nil, err
 	}
-
-	ctx, _ := context.WithTimeout(context.Background(), 15*time.Second)
 
 	io := &IOPipe{}
 


### PR DESCRIPTION
Instead of a timeout the context is cancelled on error to ensure
proper cleanup of the associated fifos' goroutines.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

--

Closes #29369