### PR TITLE
Docker inspect command exits with error if input objects are of mixed…

### DIFF
--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -20,6 +20,13 @@ type inspectOptions struct {
 	ids         []string
 }
 
+type inspectionResult struct {
+	objectType string
+	v          interface{}
+	raw        []byte
+	err        error
+}
+
 // NewInspectCommand creates a new cobra.Command for `docker inspect`
 func NewInspectCommand(dockerCli *command.DockerCli) *cobra.Command {
 	var opts inspectOptions
@@ -43,14 +50,28 @@ func NewInspectCommand(dockerCli *command.DockerCli) *cobra.Command {
 }
 
 func runInspect(dockerCli *command.DockerCli, opts inspectOptions) error {
-	var elementSearcher inspect.GetRefFunc
+	expectedType := ""
+	var refObjects = make(map[string]inspectionResult)
 	switch opts.inspectType {
 	case "", "container", "image", "node", "network", "service", "volume", "task", "plugin", "secret":
-		elementSearcher = inspectAll(context.Background(), dockerCli, opts.size, opts.inspectType)
+		for _, ref := range opts.ids {
+			result := inspectAll(context.Background(), dockerCli, ref, opts.size, opts.inspectType)
+
+			if result.err == nil && expectedType != "" && result.objectType != expectedType {
+				result.err = errors.Errorf("Error: all objects to inspect were expected to be of type %s (same as %s), but %s is of type %s", expectedType, opts.ids[0], ref, result.objectType)
+			}
+
+			refObjects[ref] = result
+			expectedType = result.objectType
+		}
 	default:
 		return errors.Errorf("%q is not a valid value for --type", opts.inspectType)
 	}
-	return inspect.Inspect(dockerCli.Out(), opts.ids, opts.format, elementSearcher)
+	getInspectionResult := func(ref string) (interface{}, []byte, error) {
+		obj := refObjects[ref]
+		return obj.v, obj.raw, obj.err
+	}
+	return inspect.Inspect(dockerCli.Out(), opts.ids, opts.format, getInspectionResult)
 }
 
 func inspectContainers(ctx context.Context, dockerCli *command.DockerCli, getSize bool) inspect.GetRefFunc {
@@ -107,7 +128,7 @@ func inspectSecret(ctx context.Context, dockerCli *command.DockerCli) inspect.Ge
 	}
 }
 
-func inspectAll(ctx context.Context, dockerCli *command.DockerCli, getSize bool, typeConstraint string) inspect.GetRefFunc {
+func inspectAll(ctx context.Context, dockerCli *command.DockerCli, ref string, getSize bool, typeConstraint string) inspectionResult {
 	var inspectAutodetect = []struct {
 		objectType      string
 		isSizeSupported bool
@@ -172,43 +193,54 @@ func inspectAll(ctx context.Context, dockerCli *command.DockerCli, getSize bool,
 		return strings.Contains(err.Error(), "not supported")
 	}
 
-	return func(ref string) (interface{}, []byte, error) {
-		const (
-			swarmSupportUnknown = iota
-			swarmSupported
-			swarmUnsupported
-		)
+	const (
+		swarmSupportUnknown = iota
+		swarmSupported
+		swarmUnsupported
+	)
 
-		isSwarmSupported := swarmSupportUnknown
+	isSwarmSupported := swarmSupportUnknown
 
-		for _, inspectData := range inspectAutodetect {
-			if typeConstraint != "" && inspectData.objectType != typeConstraint {
+	result := inspectionResult{}
+	alreadyFound := false
+	for _, inspectData := range inspectAutodetect {
+		if typeConstraint != "" && inspectData.objectType != typeConstraint {
+			continue
+		}
+		if typeConstraint == "" && inspectData.isSwarmObject {
+			if isSwarmSupported == swarmSupportUnknown {
+				if isSwarmManager() {
+					isSwarmSupported = swarmSupported
+				} else {
+					isSwarmSupported = swarmUnsupported
+				}
+			}
+			if isSwarmSupported == swarmUnsupported {
 				continue
 			}
-			if typeConstraint == "" && inspectData.isSwarmObject {
-				if isSwarmSupported == swarmSupportUnknown {
-					if isSwarmManager() {
-						isSwarmSupported = swarmSupported
-					} else {
-						isSwarmSupported = swarmUnsupported
-					}
-				}
-				if isSwarmSupported == swarmUnsupported {
-					continue
-				}
-			}
-			v, raw, err := inspectData.objectInspector(ref)
-			if err != nil {
-				if typeConstraint == "" && (apiclient.IsErrNotFound(err) || isErrNotSupported(err)) {
-					continue
-				}
-				return v, raw, err
-			}
-			if getSize && !inspectData.isSizeSupported {
-				fmt.Fprintf(dockerCli.Err(), "WARNING: --size ignored for %s\n", inspectData.objectType)
-			}
-			return v, raw, err
 		}
-		return nil, nil, errors.Errorf("Error: No such object: %s", ref)
+		v, raw, err := inspectData.objectInspector(ref)
+		if err != nil {
+			if typeConstraint == "" && (apiclient.IsErrNotFound(err) || isErrNotSupported(err)) {
+				continue
+			}
+			return inspectionResult{"", v, raw, err}
+		}
+
+		if getSize && !inspectData.isSizeSupported {
+			fmt.Fprintf(dockerCli.Err(), "WARNING: --size ignored for %s\n", inspectData.objectType)
+		}
+
+		if alreadyFound {
+			err := errors.Errorf("Error: multiple types returned for object %q, use --type option to inspect only the type that is needed.", ref)
+			return inspectionResult{"", nil, nil, err}
+		}
+		alreadyFound = true
+		result = inspectionResult{inspectData.objectType, v, raw, err}
 	}
+
+	if !alreadyFound {
+		return inspectionResult{"", nil, nil, errors.Errorf("Error: No such object: %s", ref)}
+	}
+	return result
 }

--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -762,7 +762,7 @@ func (d *Daemon) ReloadConfig() error {
 func WaitInspectWithArgs(dockerBinary, name, expr, expected string, timeout time.Duration, arg ...string) error {
 	after := time.After(timeout)
 
-	args := append(arg, "inspect", "-f", expr, name)
+	args := append(arg, "inspect", "--type", "container", "-f", expr, name)
 	for {
 		result := icmd.RunCommand(dockerBinary, args...)
 		if result.Error != nil {

--- a/integration-cli/docker_cli_external_graphdriver_unix_test.go
+++ b/integration-cli/docker_cli_external_graphdriver_unix_test.go
@@ -360,7 +360,7 @@ func (s *DockerExternalGraphdriverSuite) testExternalGraphDriver(name string, ex
 
 	s.d.Restart(c, "-s", name)
 
-	out, err = s.d.Cmd("inspect", "--format={{.GraphDriver.Name}}", "graphtest")
+	out, err = s.d.Cmd("inspect", "--type", "container", "--format={{.GraphDriver.Name}}", "graphtest")
 	c.Assert(err, check.IsNil, check.Commentf(out))
 	c.Assert(strings.TrimSpace(out), check.Equals, name)
 

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -45,10 +45,10 @@ func (s *DockerSuite) TestInspectDefault(c *check.C) {
 	//Both the container and image are named busybox. docker inspect will fetch the container JSON.
 	//If the container JSON is not available, it will go for the image JSON.
 
-	out, _ := dockerCmd(c, "run", "--name=busybox", "-d", "busybox", "true")
+	out, _ := dockerCmd(c, "run", "--name=busybox1", "-d", "busybox", "true")
 	containerID := strings.TrimSpace(out)
 
-	inspectOut := inspectField(c, "busybox", "Id")
+	inspectOut := inspectField(c, "busybox1", "Id")
 	c.Assert(strings.TrimSpace(inspectOut), checker.Equals, containerID)
 }
 
@@ -369,6 +369,15 @@ func (s *DockerSuite) TestInspectStopWhenNotFound(c *check.C) {
 	c.Assert(result.Stdout(), checker.Contains, "busybox1")
 	c.Assert(result.Stdout(), checker.Contains, "busybox2")
 	c.Assert(result.Stderr(), checker.Contains, "Error: No such container: missing")
+}
+
+func (s *DockerSuite) TestInspectStopWhenObjectTypesMixed(c *check.C) {
+	runSleepingContainer(c, "--name=busybox1", "-d")
+	dockerCmd(c, "volume", "create", "vol1")
+	out, _, err := dockerCmdWithError("inspect", "busybox1", "vol1")
+	c.Assert(err, checker.Not(check.IsNil))
+	c.Assert(out, checker.Contains, "Error: all objects to inspect were expected to be of type container")
+	c.Assert(out, checker.Contains, "vol1 is of type volume")
 }
 
 func (s *DockerSuite) TestInspectHistory(c *check.C) {

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions/v1p20"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/pkg/stringid"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
@@ -1403,22 +1404,26 @@ func checkUnsupportedNetworkAndIP(c *check.C, nwMode string) {
 
 func verifyIPAddressConfig(c *check.C, cName, nwname, ipv4, ipv6 string) {
 	if ipv4 != "" {
-		out := inspectField(c, cName, fmt.Sprintf("NetworkSettings.Networks.%s.IPAMConfig.IPv4Address", nwname))
-		c.Assert(strings.TrimSpace(out), check.Equals, ipv4)
+		cli.Docker(cli.Inspect(cName), cli.Format(fmt.Sprintf(".NetworkSettings.Networks.%s.IPAMConfig.IPv4Address", nwname)), cli.WithFlags("--type", "container")).Assert(c, icmd.Expected{
+			Out: ipv4,
+		})
 	}
 
 	if ipv6 != "" {
-		out := inspectField(c, cName, fmt.Sprintf("NetworkSettings.Networks.%s.IPAMConfig.IPv6Address", nwname))
-		c.Assert(strings.TrimSpace(out), check.Equals, ipv6)
+		cli.Docker(cli.Inspect(cName), cli.Format(fmt.Sprintf(".NetworkSettings.Networks.%s.IPAMConfig.IPv6Address", nwname)), cli.WithFlags("--type", "container")).Assert(c, icmd.Expected{
+			Out: ipv6,
+		})
 	}
 }
 
 func verifyIPAddresses(c *check.C, cName, nwname, ipv4, ipv6 string) {
-	out := inspectField(c, cName, fmt.Sprintf("NetworkSettings.Networks.%s.IPAddress", nwname))
-	c.Assert(strings.TrimSpace(out), check.Equals, ipv4)
+	cli.Docker(cli.Inspect(cName), cli.Format(fmt.Sprintf(".NetworkSettings.Networks.%s.IPAddress", nwname)), cli.WithFlags("--type", "container")).Assert(c, icmd.Expected{
+		Out: ipv4,
+	})
 
-	out = inspectField(c, cName, fmt.Sprintf("NetworkSettings.Networks.%s.GlobalIPv6Address", nwname))
-	c.Assert(strings.TrimSpace(out), check.Equals, ipv6)
+	cli.Docker(cli.Inspect(cName), cli.Format(fmt.Sprintf(".NetworkSettings.Networks.%s.GlobalIPv6Address", nwname)), cli.WithFlags("--type", "container")).Assert(c, icmd.Expected{
+		Out: ipv6,
+	})
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkConnectLinkLocalIP(c *check.C) {

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -100,7 +100,7 @@ func dockerCmdWithResult(args ...string) *icmd.Result {
 }
 
 func findContainerIP(c *check.C, id string, network string) string {
-	out, _ := dockerCmd(c, "inspect", fmt.Sprintf("--format='{{ .NetworkSettings.Networks.%s.IPAddress }}'", network), id)
+	out, _ := dockerCmd(c, "inspect", "--type", "container", fmt.Sprintf("--format='{{ .NetworkSettings.Networks.%s.IPAddress }}'", network), id)
 	return strings.Trim(out, " \r\n'")
 }
 


### PR DESCRIPTION
Add a check to docker inspect command to avoid generating output for objects of different types. Fixes #26493

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**- What I did**
The docker inspect command will output JSON for different types of objects (e.g. container, network, etc.) if the objects specified as its input are of different types. This PR fixes this by generating an error if the types of objects specified as input to the command are not all the same.

**- How I did it**
Added a check to the inspect command, to exit with an error on the first object name that is not of the same type as the previous one(s) specified as the command's input. This is done before generating output on any object's attributes.

**- How to verify it**
Create 2 or more objects of different types,specify all their names as the inspect command's input. 
With this PR, the command exits with an error, e.g.:

% docker network create net1
% docker volume create vol1

% docker inspect net1 vol1
Error: all objects to inspect were expected to be of type network (same as net1), but vol1 is of type volume

**- Description for the changelog**
The docker inspect command exits with error if the input names correspond to objects of different types. 


**- A picture of a cute animal (not mandatory but encouraged)**

