### PR TITLE
[1.12.x] fixed a few links that are broken in the docs

### DIFF
--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -52,4 +52,3 @@ axqh55ipl40h  vossibility-stack_vossibility-collector  1 icecrime/vossibility-co
 * [stack config](stack_config.md)
 * [stack deploy](stack_deploy.md)
 * [stack rm](stack_rm.md)
-* [stack tasks](stack_tasks.md)

--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -29,7 +29,7 @@ adding the server name.
 `docker login` requires user to use `sudo` or be `root`, except when:
 
 1.  connecting to a remote daemon, such as a `docker-machine` provisioned `docker engine`.
-2.  user is added to the `docker` group.  This will impact the security of your system; the `docker` group is `root` equivalent.  See [Docker Daemon Attack Surface](/security/security/#docker-daemon-attack-surface) for details.
+2.  user is added to the `docker` group.  This will impact the security of your system; the `docker` group is `root` equivalent.  See [Docker Daemon Attack Surface](/engine/security/security/#docker-daemon-attack-surface) for details.
 
 You can log into any public or private repository for which you have
 credentials.  When you log in, the command stores encoded credentials in

--- a/docs/reference/commandline/stack_config.md
+++ b/docs/reference/commandline/stack_config.md
@@ -26,4 +26,3 @@ Displays the configuration of a stack.
 * [stack rm](stack_rm.md)
 * [stack services](stack_services.md)
 * [stack ps](stack_ps.md)
-* [stack ls](stack_ls.md)

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -55,4 +55,3 @@ axqh55ipl40h  vossibility-stack_vossibility-collector  1 icecrime/vossibility-co
 * [stack rm](stack_rm.md)
 * [stack services](stack_services.md)
 * [stack ps](stack_ps.md)
-* [stack ls](stack_ls.md)

--- a/docs/reference/commandline/stack_rm.md
+++ b/docs/reference/commandline/stack_rm.md
@@ -29,4 +29,3 @@ a manager node.
 * [stack deploy](stack_deploy.md)
 * [stack services](stack_services.md)
 * [stack ps](stack_ps.md)
-* [stack ls](stack_ls.md)

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -60,4 +60,3 @@ The currently supported filters are:
 * [stack deploy](stack_deploy.md)
 * [stack rm](stack_rm.md)
 * [stack ps](stack_ps.md)
-* [stack ls](stack_ls.md)

--- a/docs/understanding-docker.md
+++ b/docs/understanding-docker.md
@@ -208,8 +208,8 @@ existing images and pull them from the registry to a host.
 [Docker Hub](http://hub.docker.com) is a public Docker
 registry which serves a huge collection of existing images and allows you to
 contribute your own. For more information, go to
-[Docker Registry](https://docs.docker.com/registry/overview/) and
-[Docker Trusted Registry](https://docs.docker.com/docker-trusted-registry/overview/).
+[Docker Registry](https://docs.docker.com/registry/) and
+[Docker Trusted Registry](https://docs.docker.com/datacenter/dtr/2.0/).
 
 [Docker store](http://store.docker.com) allows you to buy and sell Docker images.
 For image, you can buy a Docker image containing an application or service from


### PR DESCRIPTION
I removed a few links that were pointing to non-existent files (`docsreference/commandline/stack_tasks.md ` &  `docsreference/commandline/stack_ls.md`)

Also updated 3 links that were not really broken but pointing to redirects (301).

We need this to be able to close that issue: https://github.com/docker/docker.github.io/issues/1068 and finally merge new CI tests for links to local resources in the docs (https://github.com/docker/docker.github.io/pull/1052)