### PR TITLE
[multi-arch] get go version from arch dockerfile

### DIFF
--- a/contrib/builder/deb/armhf/generate.sh
+++ b/contrib/builder/deb/armhf/generate.sh
@@ -133,7 +133,7 @@ for version in "${versions[@]}"; do
 
 	echo >> "$version/Dockerfile"
 
-	awk '$1 == "ENV" && $2 == "GO_VERSION" { print; exit }' ../../../../Dockerfile >> "$version/Dockerfile"
+	awk '$1 == "ENV" && $2 == "GO_VERSION" { print; exit }' ../../../../Dockerfile.armhf >> "$version/Dockerfile"
 	if [ "$distro" == 'raspbian' ];
 	then
 		cat <<EOF >> "$version/Dockerfile"

--- a/contrib/builder/deb/s390x/generate.sh
+++ b/contrib/builder/deb/s390x/generate.sh
@@ -78,7 +78,7 @@ for version in "${versions[@]}"; do
 
 	echo >> "$version/Dockerfile"
 
-	awk '$1 == "ENV" && $2 == "GO_VERSION" { print; exit }' ../../../../Dockerfile >> "$version/Dockerfile"
+	awk '$1 == "ENV" && $2 == "GO_VERSION" { print; exit }' ../../../../Dockerfile.s390x >> "$version/Dockerfile"
 	echo 'RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local' >> "$version/Dockerfile"
 	echo 'ENV PATH $PATH:/usr/local/go/bin' >> "$version/Dockerfile"
 

--- a/contrib/builder/rpm/ppc64le/generate.sh
+++ b/contrib/builder/rpm/ppc64le/generate.sh
@@ -85,7 +85,7 @@ for version in "${versions[@]}"; do
 
 	echo >> "$version/Dockerfile"
 
-	awk '$1 == "ENV" && $2 == "GO_VERSION" { print; exit }' ../../../../Dockerfile >> "$version/Dockerfile"
+	awk '$1 == "ENV" && $2 == "GO_VERSION" { print; exit }' ../../../../Dockerfile.ppc64le >> "$version/Dockerfile"
 	echo 'RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local' >> "$version/Dockerfile"
 	echo 'ENV PATH $PATH:/usr/local/go/bin' >> "$version/Dockerfile"
 	echo >> "$version/Dockerfile"	


### PR DESCRIPTION
Changes a couple of generate scripts so that the architecture
gets the go version from its own Dockerfile. This should cover a
rare case where the go version might have to be different from
the x86 Dockerfile.

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>

![puma](http://kids.nationalgeographic.com/content/dam/kids/photos/animals/Mammals/Q-Z/warthog-running-closeup.jpg.adapt.945.1.jpg)