### PR TITLE
Pass plugingetter as part of swarm node config.

### DIFF
--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -56,4 +56,5 @@ type Backend interface {
 	GetRepository(context.Context, reference.NamedTagged, *types.AuthConfig) (distribution.Repository, bool, error)
 	LookupImage(name string) (*types.ImageInspect, error)
 	PluginManager() *plugin.Manager
+	PluginGetter() *plugin.Store
 }

--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -108,6 +108,7 @@ func (n *nodeRunner) start(conf nodeStartConfig) error {
 		ElectionTick:       3,
 		UnlockKey:          conf.lockKey,
 		AutoLockManagers:   conf.autolock,
+		PluginGetter:       n.cluster.config.Backend.PluginGetter(),
 	}
 	if conf.availability != "" {
 		avail, ok := swarmapi.NodeSpec_Availability_value[strings.ToUpper(string(conf.availability))]

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1289,6 +1289,11 @@ func (daemon *Daemon) PluginManager() *plugin.Manager { // set up before daemon 
 	return daemon.pluginManager
 }
 
+// PluginGetter returns current pluginStore associated with the daemon
+func (daemon *Daemon) PluginGetter() *plugin.Store {
+	return daemon.PluginStore
+}
+
 // CreateDaemonRoot creates the root for the daemon
 func CreateDaemonRoot(config *Config) error {
 	// get the canonical path to the Docker root directory

--- a/vendor.conf
+++ b/vendor.conf
@@ -103,7 +103,7 @@ github.com/docker/containerd 03e5862ec0d8d3b3f750e19fca3ee367e13c090e
 github.com/tonistiigi/fifo 1405643975692217d6720f8b54aeee1bf2cd5cf4
 
 # cluster
-github.com/docker/swarmkit 62d835f478b2e4fd2768deb88fb3b32e334faaee
+github.com/docker/swarmkit 98620dd1ddfcc03d8f4b0d2910ecf6b52918a731
 github.com/golang/mock bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 github.com/gogo/protobuf v0.3
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a

--- a/vendor/github.com/docker/swarmkit/agent/worker.go
+++ b/vendor/github.com/docker/swarmkit/agent/worker.go
@@ -148,7 +148,7 @@ func (w *worker) Assign(ctx context.Context, assignments []*api.AssignmentChange
 // Update updates the set of tasks and secret for the worker.
 // Tasks in the added set will be added to the worker, and tasks in the removed set
 // will be removed from the worker
-// Serets in the added set will be added to the worker, and secrets in the removed set
+// Secrets in the added set will be added to the worker, and secrets in the removed set
 // will be removed from the worker.
 func (w *worker) Update(ctx context.Context, assignments []*api.AssignmentChange) error {
 	w.mu.Lock()

--- a/vendor/github.com/docker/swarmkit/api/specs.pb.go
+++ b/vendor/github.com/docker/swarmkit/api/specs.pb.go
@@ -140,7 +140,12 @@ type ServiceSpec struct {
 	//	*ServiceSpec_Global
 	Mode isServiceSpec_Mode `protobuf_oneof:"mode"`
 	// UpdateConfig controls the rate and policy of updates.
-	Update   *UpdateConfig              `protobuf:"bytes,6,opt,name=update" json:"update,omitempty"`
+	Update *UpdateConfig `protobuf:"bytes,6,opt,name=update" json:"update,omitempty"`
+	// ServiceSpec.Networks has been deprecated and is replaced by
+	// Networks field in Task (TaskSpec.Networks).
+	// This field (ServiceSpec.Networks) is kept for compatibility.
+	// In case TaskSpec.Networks does not exist, ServiceSpec.Networks
+	// is still honored if it exists.
 	Networks []*NetworkAttachmentConfig `protobuf:"bytes,7,rep,name=networks" json:"networks,omitempty"`
 	// Service endpoint specifies the user provided configuration
 	// to properly discover and load balance a service.

--- a/vendor/github.com/docker/swarmkit/api/specs.proto
+++ b/vendor/github.com/docker/swarmkit/api/specs.proto
@@ -72,6 +72,11 @@ message ServiceSpec {
 	// UpdateConfig controls the rate and policy of updates.
 	UpdateConfig update = 6;
 
+	// ServiceSpec.Networks has been deprecated and is replaced by
+	// Networks field in Task (TaskSpec.Networks).
+	// This field (ServiceSpec.Networks) is kept for compatibility.
+	// In case TaskSpec.Networks does not exist, ServiceSpec.Networks
+	// is still honored if it exists.
 	repeated NetworkAttachmentConfig networks = 7 [deprecated=true];
 
 	// Service endpoint specifies the user provided configuration

--- a/vendor/github.com/docker/swarmkit/ca/auth.go
+++ b/vendor/github.com/docker/swarmkit/ca/auth.go
@@ -19,7 +19,7 @@ import (
 type localRequestKeyType struct{}
 
 // LocalRequestKey is a context key to mark a request that originating on the
-// local node. The assocated value is a RemoteNodeInfo structure describing the
+// local node. The associated value is a RemoteNodeInfo structure describing the
 // local node.
 var LocalRequestKey = localRequestKeyType{}
 

--- a/vendor/github.com/docker/swarmkit/ca/external.go
+++ b/vendor/github.com/docker/swarmkit/ca/external.go
@@ -103,26 +103,9 @@ func makeExternalSignRequest(ctx context.Context, client *http.Client, url strin
 	if err != nil {
 		return nil, recoverableErr{err: errors.Wrap(err, "unable to perform certificate signing request")}
 	}
-
-	doneReading := make(chan struct{})
-	bodyClosed := make(chan struct{})
-	go func() {
-		select {
-		case <-ctx.Done():
-		case <-doneReading:
-		}
-		resp.Body.Close()
-		close(bodyClosed)
-	}()
+	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
-	close(doneReading)
-	<-bodyClosed
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
 	if err != nil {
 		return nil, recoverableErr{err: errors.Wrap(err, "unable to read CSR response body")}
 	}

--- a/vendor/github.com/docker/swarmkit/ca/server.go
+++ b/vendor/github.com/docker/swarmkit/ca/server.go
@@ -353,7 +353,7 @@ func (s *Server) issueRenewCertificate(ctx context.Context, nodeID string, csr [
 	}, nil
 }
 
-// GetRootCACertificate returns the certificate of the Root CA. It is used as a convinience for distributing
+// GetRootCACertificate returns the certificate of the Root CA. It is used as a convenience for distributing
 // the root of trust for the swarm. Clients should be using the CA hash to verify if they weren't target to
 // a MiTM. If they fail to do so, node bootstrap works with TOFU semantics.
 func (s *Server) GetRootCACertificate(ctx context.Context, request *api.GetRootCACertificateRequest) (*api.GetRootCACertificateResponse, error) {

--- a/vendor/github.com/docker/swarmkit/connectionbroker/broker.go
+++ b/vendor/github.com/docker/swarmkit/connectionbroker/broker.go
@@ -96,9 +96,9 @@ func (c *Conn) Close(success bool) error {
 	}
 
 	if success {
-		c.remotes.ObserveIfExists(c.peer, -remotes.DefaultObservationWeight)
-	} else {
 		c.remotes.ObserveIfExists(c.peer, remotes.DefaultObservationWeight)
+	} else {
+		c.remotes.ObserveIfExists(c.peer, -remotes.DefaultObservationWeight)
 	}
 
 	return c.ClientConn.Close()

--- a/vendor/github.com/docker/swarmkit/log/context.go
+++ b/vendor/github.com/docker/swarmkit/log/context.go
@@ -29,6 +29,21 @@ func WithLogger(ctx context.Context, logger *logrus.Entry) context.Context {
 	return context.WithValue(ctx, loggerKey{}, logger)
 }
 
+// WithFields returns a new context with added fields to logger.
+func WithFields(ctx context.Context, fields logrus.Fields) context.Context {
+	logger := ctx.Value(loggerKey{})
+
+	if logger == nil {
+		logger = L
+	}
+	return WithLogger(ctx, logger.(*logrus.Entry).WithFields(fields))
+}
+
+// WithField is convenience wrapper around WithFields.
+func WithField(ctx context.Context, key, value string) context.Context {
+	return WithFields(ctx, logrus.Fields{key: value})
+}
+
 // GetLogger retrieves the current logger from the context. If no logger is
 // available, the default logger is returned.
 func GetLogger(ctx context.Context) *logrus.Entry {

--- a/vendor/github.com/docker/swarmkit/manager/allocator/allocator.go
+++ b/vendor/github.com/docker/swarmkit/manager/allocator/allocator.go
@@ -3,6 +3,7 @@ package allocator
 import (
 	"sync"
 
+	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
@@ -27,6 +28,9 @@ type Allocator struct {
 	stopChan chan struct{}
 	// doneChan is closed when the allocator is finished running.
 	doneChan chan struct{}
+
+	// pluginGetter provides access to docker's plugin inventory.
+	pluginGetter plugingetter.PluginGetter
 }
 
 // taskBallot controls how the voting for task allocation is
@@ -67,14 +71,15 @@ type allocActor struct {
 
 // New returns a new instance of Allocator for use during allocation
 // stage of the manager.
-func New(store *store.MemoryStore) (*Allocator, error) {
+func New(store *store.MemoryStore, pg plugingetter.PluginGetter) (*Allocator, error) {
 	a := &Allocator{
 		store: store,
 		taskBallot: &taskBallot{
 			votes: make(map[string][]string),
 		},
-		stopChan: make(chan struct{}),
-		doneChan: make(chan struct{}),
+		stopChan:     make(chan struct{}),
+		doneChan:     make(chan struct{}),
+		pluginGetter: pg,
 	}
 
 	return a, nil

--- a/vendor/github.com/docker/swarmkit/manager/allocator/network.go
+++ b/vendor/github.com/docker/swarmkit/manager/allocator/network.go
@@ -73,7 +73,7 @@ type networkContext struct {
 }
 
 func (a *Allocator) doNetworkInit(ctx context.Context) (err error) {
-	na, err := networkallocator.New()
+	na, err := networkallocator.New(a.pluginGetter)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/docker/swarmkit/manager/allocator/networkallocator/portallocator.go
+++ b/vendor/github.com/docker/swarmkit/manager/allocator/networkallocator/portallocator.go
@@ -17,12 +17,12 @@ const (
 	dynamicPortEnd = 32767
 
 	// The start of master port range which will hold all the
-	// allocation state of ports allocated so far regerdless of
+	// allocation state of ports allocated so far regardless of
 	// whether it was user defined or not.
 	masterPortStart = 1
 
 	// The end of master port range which will hold all the
-	// allocation state of ports allocated so far regerdless of
+	// allocation state of ports allocated so far regardless of
 	// whether it was user defined or not.
 	masterPortEnd = 65535
 )
@@ -65,7 +65,7 @@ func (ps allocatedPorts) addState(p *api.PortConfig) {
 // Note multiple dynamically allocated ports might exists. In this case,
 // we will remove only at a time so both allocated ports are tracked.
 //
-// Note becasue of the potential co-existence of user-defined and dynamically
+// Note because of the potential co-existence of user-defined and dynamically
 // allocated ports, delState has to be called for user-defined port first.
 // dynamically allocated ports should be removed later.
 func (ps allocatedPorts) delState(p *api.PortConfig) *api.PortConfig {
@@ -277,7 +277,7 @@ func (pa *portAllocator) isPortsAllocated(s *api.Service) bool {
 	}
 
 	// If service has allocated endpoint while has no user-defined endpoint,
-	// we assume allocated endpoints are redudant, and they need deallocated.
+	// we assume allocated endpoints are redundant, and they need deallocated.
 	// If service has no allocated endpoint while has user-defined endpoint,
 	// we assume it is not allocated.
 	if (s.Endpoint != nil && s.Spec.Endpoint == nil) ||

--- a/vendor/github.com/docker/swarmkit/manager/controlapi/service.go
+++ b/vendor/github.com/docker/swarmkit/manager/controlapi/service.go
@@ -502,7 +502,7 @@ func (s *Server) UpdateService(ctx context.Context, request *api.UpdateServiceRe
 		}
 
 		if !reflect.DeepEqual(requestSpecNetworks, specNetworks) {
-			return errNetworkUpdateNotSupported
+			return grpc.Errorf(codes.Unimplemented, errNetworkUpdateNotSupported.Error())
 		}
 
 		// Check to see if all the secrets being added exist as objects
@@ -516,11 +516,11 @@ func (s *Server) UpdateService(ctx context.Context, request *api.UpdateServiceRe
 		// with service mode change (comparing current config with previous config).
 		// proper way to change service mode is to delete and re-add.
 		if reflect.TypeOf(service.Spec.Mode) != reflect.TypeOf(request.Spec.Mode) {
-			return errModeChangeNotAllowed
+			return grpc.Errorf(codes.Unimplemented, errModeChangeNotAllowed.Error())
 		}
 
 		if service.Spec.Annotations.Name != request.Spec.Annotations.Name {
-			return errRenameNotSupported
+			return grpc.Errorf(codes.Unimplemented, errRenameNotSupported.Error())
 		}
 
 		service.Meta.Version = *request.ServiceVersion

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/update/updater.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/update/updater.go
@@ -406,7 +406,11 @@ func (u *Updater) updateTask(ctx context.Context, slot orchestrator.Slot, update
 	}
 
 	if delayStartCh != nil {
-		<-delayStartCh
+		select {
+		case <-delayStartCh:
+		case <-u.stopChan:
+			return nil
+		}
 	}
 
 	// Wait for the new task to come up.
@@ -456,7 +460,11 @@ func (u *Updater) useExistingTask(ctx context.Context, slot orchestrator.Slot, e
 		}
 
 		if delayStartCh != nil {
-			<-delayStartCh
+			select {
+			case <-delayStartCh:
+			case <-u.stopChan:
+				return nil
+			}
 		}
 	}
 

--- a/vendor/github.com/docker/swarmkit/manager/scheduler/nodeinfo.go
+++ b/vendor/github.com/docker/swarmkit/manager/scheduler/nodeinfo.go
@@ -39,7 +39,7 @@ func newNodeInfo(n *api.Node, tasks map[string]*api.Task, availableResources api
 	return nodeInfo
 }
 
-// addTask removes a task from nodeInfo if it's tracked there, and returns true
+// removeTask removes a task from nodeInfo if it's tracked there, and returns true
 // if nodeInfo was modified.
 func (nodeInfo *NodeInfo) removeTask(t *api.Task) bool {
 	oldTask, ok := nodeInfo.Tasks[t.ID]

--- a/vendor/github.com/docker/swarmkit/manager/state/raft/storage.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/raft/storage.go
@@ -60,9 +60,25 @@ func (n *Node) loadAndStart(ctx context.Context, forceNewCluster bool) error {
 	n.Config.ID = raftNode.RaftID
 
 	if snapshot != nil {
-		// Load the snapshot data into the store
-		if err := n.restoreFromSnapshot(snapshot.Data, forceNewCluster); err != nil {
+		snapCluster, err := n.clusterSnapshot(snapshot.Data)
+		if err != nil {
 			return err
+		}
+		var bootstrapMembers []*api.RaftMember
+		if forceNewCluster {
+			for _, m := range snapCluster.Members {
+				if m.RaftID != n.Config.ID {
+					n.cluster.RemoveMember(m.RaftID)
+					continue
+				}
+				bootstrapMembers = append(bootstrapMembers, m)
+			}
+		} else {
+			bootstrapMembers = snapCluster.Members
+		}
+		n.bootstrapMembers = bootstrapMembers
+		for _, removedMember := range snapCluster.Removed {
+			n.cluster.RemoveMember(removedMember)
 		}
 	}
 
@@ -215,40 +231,18 @@ func (n *Node) doSnapshot(ctx context.Context, raftConfig api.RaftConfig) {
 	<-viewStarted
 }
 
-func (n *Node) restoreFromSnapshot(data []byte, forceNewCluster bool) error {
+func (n *Node) clusterSnapshot(data []byte) (api.ClusterSnapshot, error) {
 	var snapshot api.Snapshot
 	if err := snapshot.Unmarshal(data); err != nil {
-		return err
+		return snapshot.Membership, err
 	}
 	if snapshot.Version != api.Snapshot_V0 {
-		return fmt.Errorf("unrecognized snapshot version %d", snapshot.Version)
+		return snapshot.Membership, fmt.Errorf("unrecognized snapshot version %d", snapshot.Version)
 	}
 
 	if err := n.memoryStore.Restore(&snapshot.Store); err != nil {
-		return err
+		return snapshot.Membership, err
 	}
 
-	oldMembers := n.cluster.Members()
-
-	for _, member := range snapshot.Membership.Members {
-		if forceNewCluster && member.RaftID != n.Config.ID {
-			n.cluster.RemoveMember(member.RaftID)
-		} else {
-			if err := n.registerNode(&api.RaftMember{RaftID: member.RaftID, NodeID: member.NodeID, Addr: member.Addr}); err != nil {
-				return err
-			}
-		}
-		delete(oldMembers, member.RaftID)
-	}
-
-	for _, removedMember := range snapshot.Membership.Removed {
-		n.cluster.RemoveMember(removedMember)
-		delete(oldMembers, removedMember)
-	}
-
-	for member := range oldMembers {
-		n.cluster.ClearMember(member)
-	}
-
-	return nil
+	return snapshot.Membership, nil
 }

--- a/vendor/github.com/docker/swarmkit/manager/state/raft/transport/peer.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/raft/transport/peer.go
@@ -1,0 +1,299 @@
+package transport
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+
+	"github.com/coreos/etcd/raft"
+	"github.com/coreos/etcd/raft/raftpb"
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/log"
+	"github.com/docker/swarmkit/manager/state/raft/membership"
+	"github.com/pkg/errors"
+)
+
+type peer struct {
+	id uint64
+
+	tr *Transport
+
+	msgc chan raftpb.Message
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	mu      sync.Mutex
+	cc      *grpc.ClientConn
+	addr    string
+	newAddr string
+
+	active       bool
+	becameActive time.Time
+}
+
+func newPeer(id uint64, addr string, tr *Transport) (*peer, error) {
+	cc, err := tr.dial(addr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create conn for %x with addr %s", id, addr)
+	}
+	ctx, cancel := context.WithCancel(tr.ctx)
+	ctx = log.WithField(ctx, "peer_id", fmt.Sprintf("%x", id))
+	p := &peer{
+		id:     id,
+		addr:   addr,
+		cc:     cc,
+		tr:     tr,
+		ctx:    ctx,
+		cancel: cancel,
+		msgc:   make(chan raftpb.Message, 4096),
+		done:   make(chan struct{}),
+	}
+	go p.run(ctx)
+	return p, nil
+}
+
+func (p *peer) send(m raftpb.Message) (err error) {
+	p.mu.Lock()
+	defer func() {
+		if err != nil {
+			p.active = false
+			p.becameActive = time.Time{}
+		}
+		p.mu.Unlock()
+	}()
+	select {
+	case <-p.ctx.Done():
+		return p.ctx.Err()
+	default:
+	}
+	select {
+	case p.msgc <- m:
+	case <-p.ctx.Done():
+		return p.ctx.Err()
+	default:
+		p.tr.config.ReportUnreachable(p.id)
+		return errors.Errorf("peer is unreachable")
+	}
+	return nil
+}
+
+func (p *peer) update(addr string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.addr == addr {
+		return nil
+	}
+	cc, err := p.tr.dial(addr)
+	if err != nil {
+		return err
+	}
+
+	p.cc.Close()
+	p.cc = cc
+	p.addr = addr
+	return nil
+}
+
+func (p *peer) updateAddr(addr string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.addr == addr {
+		return nil
+	}
+	log.G(p.ctx).Debugf("peer %x updated to address %s, it will be used if old failed", p.id, addr)
+	p.newAddr = addr
+	return nil
+}
+
+func (p *peer) conn() *grpc.ClientConn {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.cc
+}
+
+func (p *peer) address() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.addr
+}
+
+func (p *peer) resolveAddr(ctx context.Context, id uint64) (string, error) {
+	resp, err := api.NewRaftClient(p.conn()).ResolveAddress(ctx, &api.ResolveAddressRequest{RaftID: id})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to resolve address")
+	}
+	return resp.Addr, nil
+}
+
+func (p *peer) reportSnapshot(failure bool) {
+	if failure {
+		p.tr.config.ReportSnapshot(p.id, raft.SnapshotFailure)
+		return
+	}
+	p.tr.config.ReportSnapshot(p.id, raft.SnapshotFinish)
+}
+
+func (p *peer) sendProcessMessage(ctx context.Context, m raftpb.Message) error {
+	ctx, cancel := context.WithTimeout(ctx, p.tr.config.SendTimeout)
+	defer cancel()
+	_, err := api.NewRaftClient(p.conn()).ProcessRaftMessage(ctx, &api.ProcessRaftMessageRequest{Message: &m})
+	if grpc.Code(err) == codes.NotFound && grpc.ErrorDesc(err) == membership.ErrMemberRemoved.Error() {
+		p.tr.config.NodeRemoved()
+	}
+	if m.Type == raftpb.MsgSnap {
+		if err != nil {
+			p.tr.config.ReportSnapshot(m.To, raft.SnapshotFailure)
+		} else {
+		}
+	}
+	p.reportSnapshot(err != nil)
+	if err != nil {
+		p.tr.config.ReportUnreachable(m.To)
+		return err
+	}
+	return nil
+}
+
+func healthCheckConn(ctx context.Context, cc *grpc.ClientConn) error {
+	resp, err := api.NewHealthClient(cc).Check(ctx, &api.HealthCheckRequest{Service: "Raft"})
+	if err != nil {
+		return errors.Wrap(err, "failed to check health")
+	}
+	if resp.Status != api.HealthCheckResponse_SERVING {
+		return errors.Errorf("health check returned status %s", resp.Status)
+	}
+	return nil
+}
+
+func (p *peer) healthCheck(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, p.tr.config.SendTimeout)
+	defer cancel()
+	return healthCheckConn(ctx, p.conn())
+}
+
+func (p *peer) setActive() {
+	p.mu.Lock()
+	if !p.active {
+		p.active = true
+		p.becameActive = time.Now()
+	}
+	p.mu.Unlock()
+}
+
+func (p *peer) setInactive() {
+	p.mu.Lock()
+	p.active = false
+	p.becameActive = time.Time{}
+	p.mu.Unlock()
+}
+
+func (p *peer) activeTime() time.Time {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.becameActive
+}
+
+func (p *peer) drain() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 16*time.Second)
+	defer cancel()
+	for {
+		select {
+		case m, ok := <-p.msgc:
+			if !ok {
+				// all messages proceeded
+				return nil
+			}
+			if err := p.sendProcessMessage(ctx, m); err != nil {
+				return errors.Wrap(err, "send drain message")
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (p *peer) handleAddressChange(ctx context.Context) error {
+	p.mu.Lock()
+	newAddr := p.newAddr
+	p.newAddr = ""
+	p.mu.Unlock()
+	if newAddr == "" {
+		return nil
+	}
+	cc, err := p.tr.dial(newAddr)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, p.tr.config.SendTimeout)
+	defer cancel()
+	if err := healthCheckConn(ctx, cc); err != nil {
+		cc.Close()
+		return err
+	}
+	// there is possibility of race if host changing address too fast, but
+	// it's unlikely and eventually thing should be settled
+	p.mu.Lock()
+	p.cc.Close()
+	p.cc = cc
+	p.addr = newAddr
+	p.tr.config.UpdateNode(p.id, p.addr)
+	p.mu.Unlock()
+	return nil
+}
+
+func (p *peer) run(ctx context.Context) {
+	defer func() {
+		p.mu.Lock()
+		p.active = false
+		p.becameActive = time.Time{}
+		// at this point we can be sure that nobody will write to msgc
+		if p.msgc != nil {
+			close(p.msgc)
+		}
+		p.mu.Unlock()
+		if err := p.drain(); err != nil {
+			log.G(ctx).WithError(err).Error("failed to drain message queue")
+		}
+		close(p.done)
+	}()
+	if err := p.healthCheck(ctx); err == nil {
+		p.setActive()
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		select {
+		case m := <-p.msgc:
+			// we do not propagate context here, because this operation should be finished
+			// or timed out for correct raft work.
+			err := p.sendProcessMessage(context.Background(), m)
+			if err != nil {
+				log.G(ctx).WithError(err).Debugf("failed to send message %s", m.Type)
+				p.setInactive()
+				if err := p.handleAddressChange(ctx); err != nil {
+					log.G(ctx).WithError(err).Error("failed to change address after failure")
+				}
+				continue
+			}
+			p.setActive()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (p *peer) stop() {
+	p.cancel()
+	<-p.done
+}

--- a/vendor/github.com/docker/swarmkit/manager/state/raft/transport/transport.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/raft/transport/transport.go
@@ -1,0 +1,382 @@
+// Package transport provides grpc transport layer for raft.
+// All methods are non-blocking.
+package transport
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/coreos/etcd/raft"
+	"github.com/coreos/etcd/raft/raftpb"
+	"github.com/docker/swarmkit/log"
+	"github.com/pkg/errors"
+)
+
+// ErrIsNotFound indicates that peer was never added to transport.
+var ErrIsNotFound = errors.New("peer not found")
+
+// Raft is interface which represents Raft API for transport package.
+type Raft interface {
+	ReportUnreachable(id uint64)
+	ReportSnapshot(id uint64, status raft.SnapshotStatus)
+	IsIDRemoved(id uint64) bool
+	UpdateNode(id uint64, addr string)
+
+	NodeRemoved()
+}
+
+// Config for Transport
+type Config struct {
+	HeartbeatInterval time.Duration
+	SendTimeout       time.Duration
+	Credentials       credentials.TransportCredentials
+	RaftID            string
+
+	Raft
+}
+
+// Transport is structure which manages remote raft peers and sends messages
+// to them.
+type Transport struct {
+	config *Config
+
+	unknownc chan raftpb.Message
+
+	mu      sync.Mutex
+	peers   map[uint64]*peer
+	stopped bool
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	deferredConns map[*grpc.ClientConn]*time.Timer
+}
+
+// New returns new Transport with specified Config.
+func New(cfg *Config) *Transport {
+	ctx, cancel := context.WithCancel(context.Background())
+	if cfg.RaftID != "" {
+		ctx = log.WithField(ctx, "raft_id", cfg.RaftID)
+	}
+	t := &Transport{
+		peers:    make(map[uint64]*peer),
+		config:   cfg,
+		unknownc: make(chan raftpb.Message),
+		done:     make(chan struct{}),
+		ctx:      ctx,
+		cancel:   cancel,
+
+		deferredConns: make(map[*grpc.ClientConn]*time.Timer),
+	}
+	go t.run(ctx)
+	return t
+}
+
+func (t *Transport) run(ctx context.Context) {
+	defer func() {
+		log.G(ctx).Debug("stop transport")
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		t.stopped = true
+		for _, p := range t.peers {
+			p.stop()
+			p.cc.Close()
+		}
+		for cc, timer := range t.deferredConns {
+			timer.Stop()
+			cc.Close()
+		}
+		t.deferredConns = nil
+		close(t.done)
+	}()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		select {
+		case m := <-t.unknownc:
+			if err := t.sendUnknownMessage(ctx, m); err != nil {
+				log.G(ctx).WithError(err).Warnf("ignored message %s to unknown peer %x", m.Type, m.To)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// Stop stops transport and waits until it finished
+func (t *Transport) Stop() {
+	t.cancel()
+	<-t.done
+}
+
+// Send sends raft message to remote peers.
+func (t *Transport) Send(m raftpb.Message) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.stopped {
+		return errors.New("transport stopped")
+	}
+	if t.config.IsIDRemoved(m.To) {
+		return errors.Errorf("refusing to send message %s to removed member %x", m.Type, m.To)
+	}
+	p, ok := t.peers[m.To]
+	if !ok {
+		log.G(t.ctx).Warningf("sending message %s to an unrecognized member ID %x", m.Type, m.To)
+		select {
+		// we need to process messages to unknown peers in separate goroutine
+		// to not block sender
+		case t.unknownc <- m:
+		case <-t.ctx.Done():
+			return t.ctx.Err()
+		default:
+			return errors.New("unknown messages queue is full")
+		}
+		return nil
+	}
+	if err := p.send(m); err != nil {
+		return errors.Wrapf(err, "failed to send message %x to %x", m.Type, m.To)
+	}
+	return nil
+}
+
+// AddPeer adds new peer with id and address addr to Transport.
+// If there is already peer with such id in Transport it will return error if
+// address is different (UpdatePeer should be used) or nil otherwise.
+func (t *Transport) AddPeer(id uint64, addr string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.stopped {
+		return errors.New("transport stopped")
+	}
+	if ep, ok := t.peers[id]; ok {
+		if ep.address() == addr {
+			return nil
+		}
+		return errors.Errorf("peer %x already added with addr %s", id, ep.addr)
+	}
+	log.G(t.ctx).Debugf("transport: add peer %x with address %s", id, addr)
+	p, err := newPeer(id, addr, t)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create peer %x with addr %s", id, addr)
+	}
+	t.peers[id] = p
+	return nil
+}
+
+// RemovePeer removes peer from Transport and wait for it to stop.
+func (t *Transport) RemovePeer(id uint64) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.stopped {
+		return errors.New("transport stopped")
+	}
+	p, ok := t.peers[id]
+	if !ok {
+		return ErrIsNotFound
+	}
+	delete(t.peers, id)
+	cc := p.conn()
+	p.stop()
+	timer := time.AfterFunc(8*time.Second, func() {
+		t.mu.Lock()
+		if !t.stopped {
+			delete(t.deferredConns, cc)
+			cc.Close()
+		}
+		t.mu.Unlock()
+	})
+	// store connection and timer for cleaning up on stop
+	t.deferredConns[cc] = timer
+
+	return nil
+}
+
+// UpdatePeer updates peer with new address. It replaces connection immediately.
+func (t *Transport) UpdatePeer(id uint64, addr string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.stopped {
+		return errors.New("transport stopped")
+	}
+	p, ok := t.peers[id]
+	if !ok {
+		return ErrIsNotFound
+	}
+	if err := p.update(addr); err != nil {
+		return err
+	}
+	log.G(t.ctx).Debugf("peer %x updated to address %s", id, addr)
+	return nil
+}
+
+// UpdatePeerAddr updates peer with new address, but delays connection creation.
+// New address won't be used until first failure on old address.
+func (t *Transport) UpdatePeerAddr(id uint64, addr string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.stopped {
+		return errors.New("transport stopped")
+	}
+	p, ok := t.peers[id]
+	if !ok {
+		return ErrIsNotFound
+	}
+	if err := p.updateAddr(addr); err != nil {
+		return err
+	}
+	return nil
+}
+
+// PeerConn returns raw grpc connection to peer.
+func (t *Transport) PeerConn(id uint64) (*grpc.ClientConn, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	p, ok := t.peers[id]
+	if !ok {
+		return nil, ErrIsNotFound
+	}
+	p.mu.Lock()
+	active := p.active
+	p.mu.Unlock()
+	if !active {
+		return nil, errors.New("peer is inactive")
+	}
+	return p.conn(), nil
+}
+
+// PeerAddr returns address of peer with id.
+func (t *Transport) PeerAddr(id uint64) (string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	p, ok := t.peers[id]
+	if !ok {
+		return "", ErrIsNotFound
+	}
+	return p.address(), nil
+}
+
+// HealthCheck checks health of particular peer.
+func (t *Transport) HealthCheck(ctx context.Context, id uint64) error {
+	t.mu.Lock()
+	p, ok := t.peers[id]
+	t.mu.Unlock()
+	if !ok {
+		return ErrIsNotFound
+	}
+	ctx, cancel := t.withContext(ctx)
+	defer cancel()
+	return p.healthCheck(ctx)
+}
+
+// Active returns true if node was recently active and false otherwise.
+func (t *Transport) Active(id uint64) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	p, ok := t.peers[id]
+	if !ok {
+		return false
+	}
+	p.mu.Lock()
+	active := p.active
+	p.mu.Unlock()
+	return active
+}
+
+func (t *Transport) longestActive() (*peer, error) {
+	var longest *peer
+	var longestTime time.Time
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, p := range t.peers {
+		becameActive := p.activeTime()
+		if becameActive.IsZero() {
+			continue
+		}
+		if longest == nil {
+			longest = p
+			continue
+		}
+		if becameActive.Before(longestTime) {
+			longest = p
+			longestTime = becameActive
+		}
+	}
+	if longest == nil {
+		return nil, errors.New("failed to find longest active peer")
+	}
+	return longest, nil
+}
+
+func (t *Transport) dial(addr string) (*grpc.ClientConn, error) {
+	grpcOptions := []grpc.DialOption{
+		grpc.WithBackoffMaxDelay(8 * time.Second),
+	}
+	if t.config.Credentials != nil {
+		grpcOptions = append(grpcOptions, grpc.WithTransportCredentials(t.config.Credentials))
+	} else {
+		grpcOptions = append(grpcOptions, grpc.WithInsecure())
+	}
+
+	if t.config.SendTimeout > 0 {
+		grpcOptions = append(grpcOptions, grpc.WithTimeout(t.config.SendTimeout))
+	}
+
+	cc, err := grpc.Dial(addr, grpcOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	return cc, nil
+}
+
+func (t *Transport) withContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-t.ctx.Done():
+			cancel()
+		}
+	}()
+	return ctx, cancel
+}
+
+func (t *Transport) resolvePeer(ctx context.Context, id uint64) (*peer, error) {
+	longestActive, err := t.longestActive()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, t.config.SendTimeout)
+	defer cancel()
+	addr, err := longestActive.resolveAddr(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return newPeer(id, addr, t)
+}
+
+func (t *Transport) sendUnknownMessage(ctx context.Context, m raftpb.Message) error {
+	p, err := t.resolvePeer(ctx, m.To)
+	if err != nil {
+		return errors.Wrapf(err, "failed to resolve peer")
+	}
+	defer p.cancel()
+	if err := p.sendProcessMessage(ctx, m); err != nil {
+		return errors.Wrapf(err, "failed to send message")
+	}
+	return nil
+}

--- a/vendor/github.com/docker/swarmkit/node/node.go
+++ b/vendor/github.com/docker/swarmkit/node/node.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
+	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/swarmkit/agent"
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
@@ -98,6 +99,9 @@ type Config struct {
 
 	// Availability allows a user to control the current scheduling status of a node
 	Availability api.NodeSpec_Availability
+
+	// PluginGetter provides access to docker's plugin inventory.
+	PluginGetter plugingetter.PluginGetter
 }
 
 // Node implements the primary node functionality for a member of a swarm
@@ -683,6 +687,7 @@ func (n *Node) runManager(ctx context.Context, securityConfig *ca.SecurityConfig
 		AutoLockManagers: n.config.AutoLockManagers,
 		UnlockKey:        n.unlockKey,
 		Availability:     n.config.Availability,
+		PluginGetter:     n.config.PluginGetter,
 	})
 	if err != nil {
 		return err

--- a/vendor/github.com/docker/swarmkit/remotes/remotes.go
+++ b/vendor/github.com/docker/swarmkit/remotes/remotes.go
@@ -91,9 +91,9 @@ func (mwr *remotesWeightedRandom) Select(excludes ...string) (api.Peer, error) {
 
 	// https://github.com/LK4D4/sample
 	//
-	// The first link applies exponential distribution weight choice reservior
+	// The first link applies exponential distribution weight choice reservoir
 	// sampling. This may be relevant if we view the master selection as a
-	// distributed reservior sampling problem.
+	// distributed reservoir sampling problem.
 
 	// bias to zero-weighted remotes have same probability. otherwise, we
 	// always select first entry when all are zero.


### PR DESCRIPTION
This is necessary for swarmkit to support cluster wide plugins, such as
globally scoped network plugins.

Signed-off-by: Anusha Ragunathan <anusha.ragunathan@docker.com>

cc @mavenugo @aaronlehmann 