### PR TITLE
Fix pluginv1 Windows volumes

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -78,12 +78,6 @@ type Plugin struct {
 	handlersRun bool
 }
 
-// BasePath returns the path to which all paths returned by the plugin are relative to.
-// For v1 plugins, this always returns the host's root directory.
-func (p *Plugin) BasePath() string {
-	return "/"
-}
-
 // Name returns the name of the plugin.
 func (p *Plugin) Name() string {
 	return p.name

--- a/pkg/plugins/plugins_linux.go
+++ b/pkg/plugins/plugins_linux.go
@@ -1,0 +1,7 @@
+package plugins
+
+// BasePath returns the path to which all paths returned by the plugin are relative to.
+// For v1 plugins, this always returns the host's root directory.
+func (p *Plugin) BasePath() string {
+	return "/"
+}

--- a/pkg/plugins/plugins_windows.go
+++ b/pkg/plugins/plugins_windows.go
@@ -1,0 +1,8 @@
+package plugins
+
+// BasePath returns the path to which all paths returned by the plugin are relative to.
+// For Windows v1 plugins, this returns an empty string, since the plugin is already aware
+// of the absolute path of the mount.
+func (p *Plugin) BasePath() string {
+	return ""
+}


### PR DESCRIPTION
c54b717 caused a regression for pluginv1 on Windows, where extraneous
backslashes were added to BasePath of the plugin. For pluginv1 on windows,
BasePath() should return an empty string, since the plugin is fully aware
of the mount path. Also, unlike Linux where all paths are relative to "/",
Windows paths are dependent on system drives and mapped drives.

Fixes #30148

Signed-off-by: Anusha Ragunathan <anusha.ragunathan@docker.com>

cc @tiborvass 
