### PR TITLE
Avoid defunct registry/notary processes during tests

### DIFF
--- a/integration-cli/registry/registry.go
+++ b/integration-cli/registry/registry.go
@@ -138,6 +138,7 @@ func (r *V2) Ping() error {
 // Close kills the registry server
 func (r *V2) Close() {
 	r.cmd.Process.Kill()
+	r.cmd.Process.Wait()
 	os.RemoveAll(r.dir)
 }
 

--- a/integration-cli/trust_server_test.go
+++ b/integration-cli/trust_server_test.go
@@ -186,6 +186,7 @@ func (t *testNotary) Ping() error {
 
 func (t *testNotary) Close() {
 	t.cmd.Process.Kill()
+	t.cmd.Process.Wait()
 	os.RemoveAll(t.dir)
 }
 


### PR DESCRIPTION
Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>

