### PR TITLE
fix typo in api/types/time/timestamp.go

### DIFF
--- a/api/types/time/timestamp.go
+++ b/api/types/time/timestamp.go
@@ -118,7 +118,7 @@ func ParseTimestamps(value string, def int64) (int64, int64, error) {
 	if err != nil {
 		return s, n, err
 	}
-	// should already be in nanoseconds but just in case convert n to nanoseonds
+	// should already be in nanoseconds but just in case convert n to nanoseconds
 	n = int64(float64(n) * math.Pow(float64(10), float64(9-len(sa[1]))))
 	return s, n, nil
 }


### PR DESCRIPTION
Signed-off-by: Aaron.L.Xu <likexu@harmonycloud.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

just in case convert n to[nanoseconds]

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

