### PR TITLE
Fix treatment of DOCKER_HIDE_LEGACY_COMMANDS in bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4029,7 +4029,8 @@ _docker() {
 		deploy
 	)
 
-	local commands=(${management_commands[*]} ${top_level_commands[*]} ${DOCKER_HIDE_LEGACY_COMMANDS:+${legacy_commands[*]}})
+	local commands=(${management_commands[*]} ${top_level_commands[*]})
+	[ -z "$DOCKER_HIDE_LEGACY_COMMANDS" ] && commands+=(${legacy_commands[*]})
 
 	# These options are valid as global options for all client commands
 	# and valid as command options for `docker daemon`


### PR DESCRIPTION
#30132 was implemented incorrectly so that setting `$DOCKER_HIDE_LEGACY_COMMANDS` would enable, not disable the legacy commands. This leaves bash completion in a quite useless state. I'm sorry for the mistake.

This PR reverses the logic.

Important: Please schedule for 1.13.0 because the buggy commit is in that milestone too.

ping @thaJeztah @vdemeester @mlaventure 