### PR TITLE
image: tarexport: do not quote integers in format string

### DIFF
--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -85,7 +85,7 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 		rootFS.DiffIDs = nil
 
 		if expected, actual := len(m.Layers), len(img.RootFS.DiffIDs); expected != actual {
-			return fmt.Errorf("invalid manifest, layers length mismatch: expected %q, got %q", expected, actual)
+			return fmt.Errorf("invalid manifest, layers length mismatch: expected %d, got %d", expected, actual)
 		}
 
 		for i, diffID := range img.RootFS.DiffIDs {


### PR DESCRIPTION
Basically, prevents outputs like:
```
invalid manifest, layers length mismatch: expected '\x02', got '\x01'
```

Signed-off-by: Antonio Murdaca <runcom@redhat.com>