### PR TITLE
add endpoint mode a default value

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -346,6 +346,25 @@ func newServiceOptions() *serviceOptions {
 	}
 }
 
+func (opts *serviceOptions) ToServiceMode() (swarm.ServiceMode, error) {
+	serviceMode := swarm.ServiceMode{}
+	switch opts.mode {
+	case "global":
+		if opts.replicas.Value() != nil {
+			return serviceMode, fmt.Errorf("replicas can only be used with replicated mode")
+		}
+
+		serviceMode.Global = &swarm.GlobalService{}
+	case "replicated":
+		serviceMode.Replicated = &swarm.ReplicatedService{
+			Replicas: opts.replicas.Value(),
+		}
+	default:
+		return serviceMode, fmt.Errorf("Unknown mode: %s, only replicated and global supported", opts.mode)
+	}
+	return serviceMode, nil
+}
+
 func (opts *serviceOptions) ToService() (swarm.ServiceSpec, error) {
 	var service swarm.ServiceSpec
 
@@ -366,6 +385,16 @@ func (opts *serviceOptions) ToService() (swarm.ServiceSpec, error) {
 			}
 		}
 		currentEnv = append(currentEnv, env)
+	}
+
+	healthConfig, err := opts.healthcheck.toHealthConfig()
+	if err != nil {
+		return service, err
+	}
+
+	serviceMode, err := opts.ToServiceMode()
+	if err != nil {
+		return service, err
 	}
 
 	service = swarm.ServiceSpec{
@@ -393,6 +422,7 @@ func (opts *serviceOptions) ToService() (swarm.ServiceSpec, error) {
 				Hosts:           convertExtraHostsToSwarmHosts(opts.hosts.GetAll()),
 				StopGracePeriod: opts.stopGrace.Value(),
 				Secrets:         nil,
+				Healthcheck:     healthConfig,
 			},
 			Networks:      convertNetworks(opts.networks.GetAll()),
 			Resources:     opts.resources.ToResourceRequirements(),
@@ -403,7 +433,7 @@ func (opts *serviceOptions) ToService() (swarm.ServiceSpec, error) {
 			LogDriver: opts.logDriver.toLogDriver(),
 		},
 		Networks: convertNetworks(opts.networks.GetAll()),
-		Mode:     swarm.ServiceMode{},
+		Mode:     serviceMode,
 		UpdateConfig: &swarm.UpdateConfig{
 			Parallelism:     opts.update.parallelism,
 			Delay:           opts.update.delay,
@@ -414,26 +444,6 @@ func (opts *serviceOptions) ToService() (swarm.ServiceSpec, error) {
 		EndpointSpec: opts.endpoint.ToEndpointSpec(),
 	}
 
-	healthConfig, err := opts.healthcheck.toHealthConfig()
-	if err != nil {
-		return service, err
-	}
-	service.TaskTemplate.ContainerSpec.Healthcheck = healthConfig
-
-	switch opts.mode {
-	case "global":
-		if opts.replicas.Value() != nil {
-			return service, fmt.Errorf("replicas can only be used with replicated mode")
-		}
-
-		service.Mode.Global = &swarm.GlobalService{}
-	case "replicated":
-		service.Mode.Replicated = &swarm.ReplicatedService{
-			Replicas: opts.replicas.Value(),
-		}
-	default:
-		return service, fmt.Errorf("Unknown mode: %s", opts.mode)
-	}
 	return service, nil
 }
 
@@ -465,7 +475,7 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags.StringVar(&opts.update.onFailure, flagUpdateFailureAction, "pause", "Action on update failure (pause|continue)")
 	flags.Var(&opts.update.maxFailureRatio, flagUpdateMaxFailureRatio, "Failure rate to tolerate during an update")
 
-	flags.StringVar(&opts.endpoint.mode, flagEndpointMode, "", "Endpoint mode (vip or dnsrr)")
+	flags.StringVar(&opts.endpoint.mode, flagEndpointMode, "vip", "Endpoint mode (vip or dnsrr)")
 
 	flags.BoolVar(&opts.registryAuth, flagRegistryAuth, false, "Send registry authentication details to swarm agents")
 

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -26,7 +26,7 @@ Options:
       --dns list                         Set custom DNS servers (default [])
       --dns-option list                  Set DNS options (default [])
       --dns-search list                  Set custom DNS search domains (default [])
-      --endpoint-mode string             Endpoint mode (vip or dnsrr)
+      --endpoint-mode string             Endpoint mode (vip or dnsrr) (default "vip")
   -e, --env list                         Set environment variables (default [])
       --env-file list                    Read in a file of environment variables (default [])
       --group list                       Set one or more supplementary user groups for the container (default [])

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -32,7 +32,7 @@ Options:
       --dns-rm list                      Remove a custom DNS server (default [])
       --dns-search-add list              Add or update a custom DNS search domain (default [])
       --dns-search-rm list               Remove a DNS search domain (default [])
-      --endpoint-mode string             Endpoint mode (vip or dnsrr)
+      --endpoint-mode string             Endpoint mode (vip or dnsrr) (default "vip")
       --env-add list                     Add or update an environment variable (default [])
       --env-rm list                      Remove an environment variable (default [])
       --force                            Force update even if no changes require it


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

When I create a service without specifying the endpoint mode for it, I found that this service's endpoint mode is vip. So I think maybe we should add this default value in the `docker service create --help`.

In addition, I found that when I typed a wrong endpoint mode like `DNSRsR` or `vipp`, the error message will be from docker daemon, I think client validation error will be better.
```
root@ubuntu:~# docker service create --endpoint-mode DNSRsR alpine sleep 110000
Error response from daemon: invalid resolution mode: "dnsrsr"
```

**- What I did**
1. add a default value in `docker service create --help`
2. make endpoint mode validation in client side and more strict, make Uppercase invalid;
3. make error message more readable, using `"Unknown endpoint mode: %s, only vip and dnsrr supported"` and `"Unknown mode: %s, only replicated and global supported"`.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

