### PR TITLE
validate mount path for tmpfs

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/docker/docker/runconfig"
+	"github.com/docker/docker/volume"
 	"github.com/docker/libnetwork"
 	nwconfig "github.com/docker/libnetwork/config"
 	"github.com/docker/libnetwork/drivers/bridge"
@@ -551,6 +552,12 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 
 	if rt := daemon.configStore.GetRuntime(hostConfig.Runtime); rt == nil {
 		return warnings, fmt.Errorf("Unknown runtime specified %s", hostConfig.Runtime)
+	}
+
+	for dest := range hostConfig.Tmpfs {
+		if err := volume.ValidateTmpfsMountDestination(dest); err != nil {
+			return warnings, err
+		}
 	}
 
 	return warnings, nil

--- a/integration-cli/docker_cli_create_unix_test.go
+++ b/integration-cli/docker_cli_create_unix_test.go
@@ -1,0 +1,43 @@
+// +build !windows
+
+package main
+
+import (
+	"strings"
+
+	"github.com/go-check/check"
+)
+
+// Test case for #30166 (target was not validated)
+func (s *DockerSuite) TestCreateTmpfsMountsTarget(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	type testCase struct {
+		target        string
+		expectedError string
+	}
+	cases := []testCase{
+		{
+			target:        ".",
+			expectedError: "mount path must be absolute",
+		},
+		{
+			target:        "foo",
+			expectedError: "mount path must be absolute",
+		},
+		{
+			target:        "/",
+			expectedError: "destination can't be '/'",
+		},
+		{
+			target:        "//",
+			expectedError: "destination can't be '/'",
+		},
+	}
+	for _, x := range cases {
+		out, _, _ := dockerCmdWithError("create", "--tmpfs", x.target, "busybox", "sh")
+		if x.expectedError != "" && !strings.Contains(out, x.expectedError) {
+			c.Fatalf("mounting tmpfs over %q should fail with %q, but got %q",
+				x.target, x.expectedError, out)
+		}
+	}
+}

--- a/volume/validate.go
+++ b/volume/validate.go
@@ -91,6 +91,9 @@ func validateMountConfig(mnt *mount.Mount, options ...func(*validateOpts)) error
 		if len(mnt.Source) != 0 {
 			return &errMountConfig{mnt, errExtraField("Source")}
 		}
+		if err := ValidateTmpfsMountDestination(mnt.Target); err != nil {
+			return &errMountConfig{mnt, err}
+		}
 		if _, err := ConvertTmpfsOptions(mnt.TmpfsOptions, mnt.ReadOnly); err != nil {
 			return &errMountConfig{mnt, err}
 		}
@@ -122,4 +125,16 @@ func validateAbsolute(p string) error {
 		return nil
 	}
 	return fmt.Errorf("invalid mount path: '%s' mount path must be absolute", p)
+}
+
+// ValidateTmpfsMountDestination validates the destination of tmpfs mount.
+// Currently, we have only two obvious rule for validation:
+//  - path must not be "/"
+//  - path must be absolute
+// We should add more rules carefully (#30166)
+func ValidateTmpfsMountDestination(dest string) error {
+	if err := validateNotRoot(dest); err != nil {
+		return err
+	}
+	return validateAbsolute(dest)
 }


### PR DESCRIPTION


Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added validation for `docker run --tmpfs foo`.
Update #30166.

In this PR, only two obvious rules are implemented:
 - path must be absolute
 - path must not be "/"
We should add more rules carefully.

**- How I did it**

Validate the target on the daemon side.

**- How to verify it**

```console
$ docker run -it --tmpfs . busybox sh                           
docker: Error response from daemon: mount path for tmpfs must be absolute: ".".
$ docker run -it --tmpfs .. busybox sh                         
docker: Error response from daemon: mount path for tmpfs must be absolute: "..".
$ docker run -it --tmpfs foo busybox sh                             
docker: Error response from daemon: mount path for tmpfs must be absolute: "foo". 
$ docker run -it --tmpfs ///// busybox sh                       
docker: Error response from daemon: unexpected mount path for tmpfs: "/////".
$ docker run -it --tmpfs / busybox sh                           
docker: Error response from daemon: unexpected mount path for tmpfs: "/".
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

