### PR TITLE
[test-integration] Clean more build utils

### DIFF
--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -791,6 +791,7 @@ func WaitInspectWithArgs(dockerBinary, name, expr, expected string, timeout time
 }
 
 // BuildImageCmdWithHost create a build command with the specified arguments.
+// Deprecated
 // FIXME(vdemeester) move this away
 func BuildImageCmdWithHost(dockerBinary, name, dockerfile, host string, useCache bool, buildFlags ...string) *exec.Cmd {
 	args := []string{}

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -28,8 +28,7 @@ COPY * /tmp/
 RUN find / -xdev -name ba*
 RUN find /tmp/`
 	}
-	server, err := fakeStorage(map[string]string{"testD": testD})
-	c.Assert(err, checker.IsNil)
+	server := fakeStorage(c, map[string]string{"testD": testD})
 	defer server.Close()
 
 	res, body, err := request.SockRequestRaw("POST", "/build?dockerfile=baz&remote="+server.URL()+"/testD", nil, "application/json", daemonHost())
@@ -66,11 +65,9 @@ func (s *DockerSuite) TestBuildAPIRemoteTarballContext(c *check.C) {
 	// failed to close tar archive
 	c.Assert(tw.Close(), checker.IsNil)
 
-	server, err := fakeBinaryStorage(map[string]*bytes.Buffer{
+	server := fakeBinaryStorage(c, map[string]*bytes.Buffer{
 		"testT.tar": buffer,
 	})
-	c.Assert(err, checker.IsNil)
-
 	defer server.Close()
 
 	res, b, err := request.SockRequestRaw("POST", "/build?remote="+server.URL()+"/testT.tar", nil, "application/tar", daemonHost())
@@ -115,12 +112,11 @@ RUN echo 'right'
 	// failed to close tar archive
 	c.Assert(tw.Close(), checker.IsNil)
 
-	server, err := fakeBinaryStorage(map[string]*bytes.Buffer{
+	server := fakeBinaryStorage(c, map[string]*bytes.Buffer{
 		"testT.tar": buffer,
 	})
-	c.Assert(err, checker.IsNil)
-
 	defer server.Close()
+
 	url := "/build?dockerfile=custom&remote=" + server.URL() + "/testT.tar"
 	res, body, err := request.SockRequestRaw("POST", url, nil, "application/tar", daemonHost())
 	c.Assert(err, checker.IsNil)
@@ -135,11 +131,10 @@ RUN echo 'right'
 }
 
 func (s *DockerSuite) TestBuildAPILowerDockerfile(c *check.C) {
-	git, err := newFakeGit("repo", map[string]string{
+	git := newFakeGit(c, "repo", map[string]string{
 		"dockerfile": `FROM busybox
 RUN echo from dockerfile`,
 	}, false)
-	c.Assert(err, checker.IsNil)
 	defer git.Close()
 
 	res, body, err := request.SockRequestRaw("POST", "/build?remote="+git.RepoURL, nil, "application/json", daemonHost())
@@ -154,13 +149,12 @@ RUN echo from dockerfile`,
 }
 
 func (s *DockerSuite) TestBuildAPIBuildGitWithF(c *check.C) {
-	git, err := newFakeGit("repo", map[string]string{
+	git := newFakeGit(c, "repo", map[string]string{
 		"baz": `FROM busybox
 RUN echo from baz`,
 		"Dockerfile": `FROM busybox
 RUN echo from Dockerfile`,
 	}, false)
-	c.Assert(err, checker.IsNil)
 	defer git.Close()
 
 	// Make sure it tries to 'dockerfile' query param value
@@ -177,13 +171,12 @@ RUN echo from Dockerfile`,
 
 func (s *DockerSuite) TestBuildAPIDoubleDockerfile(c *check.C) {
 	testRequires(c, UnixCli) // dockerfile overwrites Dockerfile on Windows
-	git, err := newFakeGit("repo", map[string]string{
+	git := newFakeGit(c, "repo", map[string]string{
 		"Dockerfile": `FROM busybox
 RUN echo from Dockerfile`,
 		"dockerfile": `FROM busybox
 RUN echo from dockerfile`,
 	}, false)
-	c.Assert(err, checker.IsNil)
 	defer git.Close()
 
 	// Make sure it tries to 'dockerfile' query param value

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1766,19 +1766,18 @@ func (s *DockerSuite) TestContainersAPICreateMountsCreate(c *check.C) {
 	destPath := prefix + slash + "foo"
 
 	var (
-		err     error
 		testImg string
 	)
 	if testEnv.DaemonPlatform() != "windows" {
-		testImg, err = buildImage("test-mount-config", `
+		testImg = "test-mount-config"
+		buildImageSuccessfully(c, testImg, withDockerfile(`
 	FROM busybox
 	RUN mkdir `+destPath+` && touch `+destPath+slash+`bar
 	CMD cat `+destPath+slash+`bar
-	`, true)
+	`))
 	} else {
 		testImg = "busybox"
 	}
-	c.Assert(err, checker.IsNil)
 
 	type testCase struct {
 		cfg      mounttypes.Mount

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -52,9 +52,8 @@ func (s *DockerSuite) TestAPIImagesSaveAndLoad(c *check.C) {
 	// TODO Windows to Windows CI: Investigate further why this test fails.
 	testRequires(c, Network)
 	testRequires(c, DaemonIsLinux)
-	out, err := buildImage("saveandload", "FROM busybox\nENV FOO bar", false)
-	c.Assert(err, checker.IsNil)
-	id := strings.TrimSpace(out)
+	buildImageSuccessfully(c, "saveandload", withDockerfile("FROM busybox\nENV FOO bar"))
+	id := getIDByName(c, "saveandload")
 
 	res, body, err := request.SockRequestRaw("GET", "/images/"+id+"/get", nil, "", daemonHost())
 	c.Assert(err, checker.IsNil)
@@ -77,9 +76,8 @@ func (s *DockerSuite) TestAPIImagesDelete(c *check.C) {
 		testRequires(c, Network)
 	}
 	name := "test-api-images-delete"
-	out, err := buildImage(name, "FROM busybox\nENV FOO bar", false)
-	c.Assert(err, checker.IsNil)
-	id := strings.TrimSpace(out)
+	buildImageSuccessfully(c, name, withDockerfile("FROM busybox\nENV FOO bar"))
+	id := getIDByName(c, name)
 
 	dockerCmd(c, "tag", name, "test:tag1")
 
@@ -101,10 +99,8 @@ func (s *DockerSuite) TestAPIImagesHistory(c *check.C) {
 		testRequires(c, Network)
 	}
 	name := "test-api-images-history"
-	out, err := buildImage(name, "FROM busybox\nENV FOO bar", false)
-	c.Assert(err, checker.IsNil)
-
-	id := strings.TrimSpace(out)
+	buildImageSuccessfully(c, name, withDockerfile("FROM busybox\nENV FOO bar"))
+	id := getIDByName(c, name)
 
 	status, body, err := request.SockRequest("GET", "/images/"+id+"/history", nil, daemonHost())
 	c.Assert(err, checker.IsNil)

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -193,10 +193,9 @@ func (s *DockerRegistrySuite) TestBuildByDigest(c *check.C) {
 
 	// do the build
 	name := "buildbydigest"
-	_, err = buildImage(name, fmt.Sprintf(
+	buildImageSuccessfully(c, name, withDockerfile(fmt.Sprintf(
 		`FROM %s
-     CMD ["/bin/echo", "Hello World"]`, imageReference),
-		true)
+     CMD ["/bin/echo", "Hello World"]`, imageReference)))
 	c.Assert(err, checker.IsNil)
 
 	// get the build's image id
@@ -417,20 +416,17 @@ func (s *DockerRegistrySuite) TestPsListContainersFilterAncestorImageByDigest(c 
 
 	// build an image from it
 	imageName1 := "images_ps_filter_test"
-	_, err = buildImage(imageName1, fmt.Sprintf(
+	buildImageSuccessfully(c, imageName1, withDockerfile(fmt.Sprintf(
 		`FROM %s
-		 LABEL match me 1`, imageReference), true)
-	c.Assert(err, checker.IsNil)
+		 LABEL match me 1`, imageReference)))
 
 	// run a container based on that
 	dockerCmd(c, "run", "--name=test1", imageReference, "echo", "hello")
-	expectedID, err := getIDByName("test1")
-	c.Assert(err, check.IsNil)
+	expectedID := getIDByName(c, "test1")
 
 	// run a container based on the a descendant of that too
 	dockerCmd(c, "run", "--name=test2", imageName1, "echo", "hello")
-	expectedID1, err := getIDByName("test2")
-	c.Assert(err, check.IsNil)
+	expectedID1 := getIDByName(c, "test2")
 
 	expectedIDs := []string{expectedID, expectedID1}
 

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -379,11 +379,9 @@ func (s *DockerSuite) TestEventsFilterImageLabels(c *check.C) {
 	label := "io.docker.testing=image"
 
 	// Build a test image.
-	_, err := buildImage(name, fmt.Sprintf(`
+	buildImageSuccessfully(c, name, withDockerfile(fmt.Sprintf(`
 		FROM busybox:latest
-		LABEL %s`, label), true)
-	c.Assert(err, checker.IsNil, check.Commentf("Couldn't create image"))
-
+		LABEL %s`, label)))
 	dockerCmd(c, "tag", name, "labelfiltertest:tag1")
 	dockerCmd(c, "tag", name, "labelfiltertest:tag2")
 	dockerCmd(c, "tag", "busybox:latest", "labelfiltertest:tag3")
@@ -462,10 +460,10 @@ func (s *DockerSuite) TestEventsCommit(c *check.C) {
 
 func (s *DockerSuite) TestEventsCopy(c *check.C) {
 	// Build a test image.
-	id, err := buildImage("cpimg", `
+	buildImageSuccessfully(c, "cpimg", withDockerfile(`
 		  FROM busybox
-		  RUN echo HI > /file`, true)
-	c.Assert(err, checker.IsNil, check.Commentf("Couldn't create image"))
+		  RUN echo HI > /file`))
+	id := getIDByName(c, "cpimg")
 
 	// Create an empty test file.
 	tempFile, err := ioutil.TempFile("", "test-events-copy-")
@@ -595,11 +593,9 @@ func (s *DockerSuite) TestEventsFilterType(c *check.C) {
 	label := "io.docker.testing=image"
 
 	// Build a test image.
-	_, err := buildImage(name, fmt.Sprintf(`
+	buildImageSuccessfully(c, name, withDockerfile(fmt.Sprintf(`
 		FROM busybox:latest
-		LABEL %s`, label), true)
-	c.Assert(err, checker.IsNil, check.Commentf("Couldn't create image"))
-
+		LABEL %s`, label)))
 	dockerCmd(c, "tag", name, "labelfiltertest:tag1")
 	dockerCmd(c, "tag", name, "labelfiltertest:tag2")
 	dockerCmd(c, "tag", "busybox:latest", "labelfiltertest:tag3")

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -310,11 +310,9 @@ func (s *DockerSuite) TestEventsImageUntagDelete(c *check.C) {
 	defer observer.Stop()
 
 	name := "testimageevents"
-	imageID, err := buildImage(name,
-		`FROM scratch
-		MAINTAINER "docker"`,
-		true)
-	c.Assert(err, checker.IsNil)
+	buildImageSuccessfully(c, name, withDockerfile(`FROM scratch
+		MAINTAINER "docker"`))
+	imageID := getIDByName(c, name)
 	c.Assert(deleteImages(name), checker.IsNil)
 
 	testActions := map[string]chan bool{

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -473,13 +473,9 @@ func (s *DockerSuite) TestExecWithImageUser(c *check.C) {
 	// Not applicable on Windows
 	testRequires(c, DaemonIsLinux)
 	name := "testbuilduser"
-	_, err := buildImage(name,
-		`FROM busybox
+	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
 		RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
-		USER dockerio`,
-		true)
-	c.Assert(err, checker.IsNil)
-
+		USER dockerio`))
 	dockerCmd(c, "run", "-d", "--name", "dockerioexec", name, "top")
 
 	out, _ := dockerCmd(c, "exec", "dockerioexec", "whoami")

--- a/integration-cli/docker_cli_health_test.go
+++ b/integration-cli/docker_cli_health_test.go
@@ -40,16 +40,12 @@ func (s *DockerSuite) TestHealth(c *check.C) {
 	testRequires(c, DaemonIsLinux) // busybox doesn't work on Windows
 
 	imageName := "testhealth"
-	_, err := buildImage(imageName,
-		`FROM busybox
+	buildImageSuccessfully(c, imageName, withDockerfile(`FROM busybox
 		RUN echo OK > /status
 		CMD ["/bin/sleep", "120"]
 		STOPSIGNAL SIGKILL
 		HEALTHCHECK --interval=1s --timeout=30s \
-		  CMD cat /status`,
-		true)
-
-	c.Check(err, check.IsNil)
+		  CMD cat /status`))
 
 	// No health status before starting
 	name := "test_health"
@@ -91,10 +87,8 @@ func (s *DockerSuite) TestHealth(c *check.C) {
 	dockerCmd(c, "rm", "noh")
 
 	// Disable the check with a new build
-	_, err = buildImage("no_healthcheck",
-		`FROM testhealth
-		HEALTHCHECK NONE`, true)
-	c.Check(err, check.IsNil)
+	buildImageSuccessfully(c, "no_healthcheck", withDockerfile(`FROM testhealth
+		HEALTHCHECK NONE`))
 
 	out, _ = dockerCmd(c, "inspect", "--format={{.ContainerConfig.Healthcheck.Test}}", "no_healthcheck")
 	c.Check(out, checker.Equals, "[NONE]\n")
@@ -137,15 +131,12 @@ func (s *DockerSuite) TestHealth(c *check.C) {
 	dockerCmd(c, "rm", "-f", "test")
 
 	// Check JSON-format
-	_, err = buildImage(imageName,
-		`FROM busybox
+	buildImageSuccessfully(c, imageName, withDockerfile(`FROM busybox
 		RUN echo OK > /status
 		CMD ["/bin/sleep", "120"]
 		STOPSIGNAL SIGKILL
 		HEALTHCHECK --interval=1s --timeout=30s \
-		  CMD ["cat", "/my status"]`,
-		true)
-	c.Check(err, check.IsNil)
+		  CMD ["cat", "/my status"]`))
 	out, _ = dockerCmd(c, "inspect",
 		"--format={{.Config.Healthcheck.Test}}", imageName)
 	c.Check(out, checker.Equals, "[CMD cat /my status]\n")

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -14,7 +14,7 @@ import (
 // sort is not predictable it doesn't always fail.
 func (s *DockerSuite) TestBuildHistory(c *check.C) {
 	name := "testbuildhistory"
-	_, err := buildImage(name, `FROM `+minimalBaseImage()+`
+	buildImageSuccessfully(c, name, withDockerfile(`FROM `+minimalBaseImage()+`
 LABEL label.A="A"
 LABEL label.B="B"
 LABEL label.C="C"
@@ -40,12 +40,9 @@ LABEL label.V="V"
 LABEL label.W="W"
 LABEL label.X="X"
 LABEL label.Y="Y"
-LABEL label.Z="Z"`,
-		true)
+LABEL label.Z="Z"`))
 
-	c.Assert(err, checker.IsNil)
-
-	out, _ := dockerCmd(c, "history", "testbuildhistory")
+	out, _ := dockerCmd(c, "history", name)
 	actualValues := strings.Split(out, "\n")[1:27]
 	expectedValues := [26]string{"Z", "Y", "X", "W", "V", "U", "T", "S", "R", "Q", "P", "O", "N", "M", "L", "K", "J", "I", "H", "G", "F", "E", "D", "C", "B", "A"}
 

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/pkg/stringid"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
 
@@ -45,20 +46,17 @@ func (s *DockerSuite) TestImagesEnsureImageWithBadTagIsNotListed(c *check.C) {
 }
 
 func (s *DockerSuite) TestImagesOrderedByCreationDate(c *check.C) {
-	id1, err := buildImage("order:test_a",
-		`FROM busybox
-                MAINTAINER dockerio1`, true)
-	c.Assert(err, checker.IsNil)
+	buildImageSuccessfully(c, "order:test_a", withDockerfile(`FROM busybox
+                MAINTAINER dockerio1`))
+	id1 := getIDByName(c, "order:test_a")
 	time.Sleep(1 * time.Second)
-	id2, err := buildImage("order:test_c",
-		`FROM busybox
-                MAINTAINER dockerio2`, true)
-	c.Assert(err, checker.IsNil)
+	buildImageSuccessfully(c, "order:test_c", withDockerfile(`FROM busybox
+                MAINTAINER dockerio2`))
+	id2 := getIDByName(c, "order:test_c")
 	time.Sleep(1 * time.Second)
-	id3, err := buildImage("order:test_b",
-		`FROM busybox
-                MAINTAINER dockerio3`, true)
-	c.Assert(err, checker.IsNil)
+	buildImageSuccessfully(c, "order:test_b", withDockerfile(`FROM busybox
+                MAINTAINER dockerio3`))
+	id3 := getIDByName(c, "order:test_b")
 
 	out, _ := dockerCmd(c, "images", "-q", "--no-trunc")
 	imgs := strings.Split(out, "\n")
@@ -77,20 +75,17 @@ func (s *DockerSuite) TestImagesFilterLabelMatch(c *check.C) {
 	imageName1 := "images_filter_test1"
 	imageName2 := "images_filter_test2"
 	imageName3 := "images_filter_test3"
-	image1ID, err := buildImage(imageName1,
-		`FROM busybox
-                 LABEL match me`, true)
-	c.Assert(err, check.IsNil)
+	buildImageSuccessfully(c, imageName1, withDockerfile(`FROM busybox
+                 LABEL match me`))
+	image1ID := getIDByName(c, imageName1)
 
-	image2ID, err := buildImage(imageName2,
-		`FROM busybox
-                 LABEL match="me too"`, true)
-	c.Assert(err, check.IsNil)
+	buildImageSuccessfully(c, imageName2, withDockerfile(`FROM busybox
+                 LABEL match="me too"`))
+	image2ID := getIDByName(c, imageName2)
 
-	image3ID, err := buildImage(imageName3,
-		`FROM busybox
-                 LABEL nomatch me`, true)
-	c.Assert(err, check.IsNil)
+	buildImageSuccessfully(c, imageName3, withDockerfile(`FROM busybox
+                 LABEL nomatch me`))
+	image3ID := getIDByName(c, imageName3)
 
 	out, _ := dockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=match")
 	out = strings.TrimSpace(out)
@@ -117,15 +112,15 @@ func (s *DockerSuite) TestImagesFilterLabelWithCommit(c *check.C) {
 }
 
 func (s *DockerSuite) TestImagesFilterSinceAndBefore(c *check.C) {
-	imageID1, err := buildImage("image:1", `FROM `+minimalBaseImage()+`
-LABEL number=1`, true)
-	c.Assert(err, checker.IsNil)
-	imageID2, err := buildImage("image:2", `FROM `+minimalBaseImage()+`
-LABEL number=2`, true)
-	c.Assert(err, checker.IsNil)
-	imageID3, err := buildImage("image:3", `FROM `+minimalBaseImage()+`
-LABEL number=3`, true)
-	c.Assert(err, checker.IsNil)
+	buildImageSuccessfully(c, "image:1", withDockerfile(`FROM `+minimalBaseImage()+`
+LABEL number=1`))
+	imageID1 := getIDByName(c, "image:1")
+	buildImageSuccessfully(c, "image:2", withDockerfile(`FROM `+minimalBaseImage()+`
+LABEL number=2`))
+	imageID2 := getIDByName(c, "image:2")
+	buildImageSuccessfully(c, "image:3", withDockerfile(`FROM `+minimalBaseImage()+`
+LABEL number=3`))
+	imageID3 := getIDByName(c, "image:3")
 
 	expected := []string{imageID3, imageID2}
 
@@ -185,13 +180,16 @@ func assertImageList(out string, expected []string) bool {
 	return true
 }
 
+// FIXME(vdemeester) should be a unit test on `docker image ls`
 func (s *DockerSuite) TestImagesFilterSpaceTrimCase(c *check.C) {
 	imageName := "images_filter_test"
-	buildImage(imageName,
-		`FROM busybox
+	// Build a image and fail to build so that we have dangling images ?
+	buildImage(imageName, withDockerfile(`FROM busybox
                  RUN touch /test/foo
                  RUN touch /test/bar
-                 RUN touch /test/baz`, true)
+                 RUN touch /test/baz`)).Assert(c, icmd.Expected{
+		ExitCode: 1,
+	})
 
 	filters := []string{
 		"dangling=true",
@@ -250,6 +248,7 @@ func (s *DockerSuite) TestImagesEnsureDanglingImageOnlyListedOnce(c *check.C) {
 
 }
 
+// FIXME(vdemeester) should be a unit test for `docker image ls`
 func (s *DockerSuite) TestImagesWithIncorrectFilter(c *check.C) {
 	out, _, err := dockerCmdWithError("images", "-f", "dangling=invalid")
 	c.Assert(err, check.NotNil)
@@ -261,32 +260,33 @@ func (s *DockerSuite) TestImagesEnsureOnlyHeadsImagesShown(c *check.C) {
         FROM busybox
         MAINTAINER docker
         ENV foo bar`
-
-	head, out, err := buildImageWithOut("scratch-image", dockerfile, false)
-	c.Assert(err, check.IsNil)
+	name := "scratch-image"
+	result := buildImage(name, withDockerfile(dockerfile))
+	result.Assert(c, icmd.Success)
+	id := getIDByName(c, name)
 
 	// this is just the output of docker build
 	// we're interested in getting the image id of the MAINTAINER instruction
 	// and that's located at output, line 5, from 7 to end
-	split := strings.Split(out, "\n")
+	split := strings.Split(result.Combined(), "\n")
 	intermediate := strings.TrimSpace(split[5][7:])
 
-	out, _ = dockerCmd(c, "images")
+	out, _ := dockerCmd(c, "images")
 	// images shouldn't show non-heads images
 	c.Assert(out, checker.Not(checker.Contains), intermediate)
 	// images should contain final built images
-	c.Assert(out, checker.Contains, stringid.TruncateID(head))
+	c.Assert(out, checker.Contains, stringid.TruncateID(id))
 }
 
 func (s *DockerSuite) TestImagesEnsureImagesFromScratchShown(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Windows does not support FROM scratch
-
 	dockerfile := `
         FROM scratch
         MAINTAINER docker`
 
-	id, _, err := buildImageWithOut("scratch-image", dockerfile, false)
-	c.Assert(err, check.IsNil)
+	name := "scratch-image"
+	buildImageSuccessfully(c, name, withDockerfile(dockerfile))
+	id := getIDByName(c, name)
 
 	out, _ := dockerCmd(c, "images")
 	// images should contain images built from scratch
@@ -299,9 +299,10 @@ func (s *DockerSuite) TestImagesEnsureImagesFromBusyboxShown(c *check.C) {
 	dockerfile := `
         FROM busybox
         MAINTAINER docker`
+	name := "busybox-image"
 
-	id, _, err := buildImageWithOut("busybox-image", dockerfile, false)
-	c.Assert(err, check.IsNil)
+	buildImageSuccessfully(c, name, withDockerfile(dockerfile))
+	id := getIDByName(c, name)
 
 	out, _ := dockerCmd(c, "images")
 	// images should contain images built from busybox

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -130,8 +130,7 @@ func (s *DockerSuite) TestLogsTail(c *check.C) {
 
 func (s *DockerSuite) TestLogsFollowStopped(c *check.C) {
 	dockerCmd(c, "run", "--name=test", "busybox", "echo", "hello")
-	id, err := getIDByName("test")
-	c.Assert(err, check.IsNil)
+	id := getIDByName(c, "test")
 
 	logsCmd := exec.Command(dockerBinary, "logs", "-f", id)
 	c.Assert(logsCmd.Start(), checker.IsNil)

--- a/integration-cli/docker_cli_pull_local_test.go
+++ b/integration-cli/docker_cli_pull_local_test.go
@@ -65,14 +65,13 @@ func testConcurrentPullWholeRepo(c *check.C) {
 	repos := []string{}
 	for _, tag := range []string{"recent", "fresh", "todays"} {
 		repo := fmt.Sprintf("%v:%v", repoName, tag)
-		_, err := buildImage(repo, fmt.Sprintf(`
+		buildImageSuccessfully(c, repo, withDockerfile(fmt.Sprintf(`
 		    FROM busybox
 		    ENTRYPOINT ["/bin/echo"]
 		    ENV FOO foo
 		    ENV BAR bar
 		    CMD echo %s
-		`, repo), true)
-		c.Assert(err, checker.IsNil)
+		`, repo)))
 		dockerCmd(c, "push", repo)
 		repos = append(repos, repo)
 	}
@@ -154,14 +153,13 @@ func testConcurrentPullMultipleTags(c *check.C) {
 	repos := []string{}
 	for _, tag := range []string{"recent", "fresh", "todays"} {
 		repo := fmt.Sprintf("%v:%v", repoName, tag)
-		_, err := buildImage(repo, fmt.Sprintf(`
+		buildImageSuccessfully(c, repo, withDockerfile(fmt.Sprintf(`
 		    FROM busybox
 		    ENTRYPOINT ["/bin/echo"]
 		    ENV FOO foo
 		    ENV BAR bar
 		    CMD echo %s
-		`, repo), true)
-		c.Assert(err, checker.IsNil)
+		`, repo)))
 		dockerCmd(c, "push", repo)
 		repos = append(repos, repo)
 	}
@@ -209,21 +207,15 @@ func testPullIDStability(c *check.C) {
 	derivedImage := privateRegistryURL + "/dockercli/id-stability"
 	baseImage := "busybox"
 
-	_, err := buildImage(derivedImage, fmt.Sprintf(`
+	buildImageSuccessfully(c, derivedImage, withDockerfile(fmt.Sprintf(`
 	    FROM %s
 	    ENV derived true
 	    ENV asdf true
 	    RUN dd if=/dev/zero of=/file bs=1024 count=1024
 	    CMD echo %s
-	`, baseImage, derivedImage), true)
-	if err != nil {
-		c.Fatal(err)
-	}
+	`, baseImage, derivedImage)))
 
-	originalID, err := getIDByName(derivedImage)
-	if err != nil {
-		c.Fatalf("error inspecting: %v", err)
-	}
+	originalID := getIDByName(c, derivedImage)
 	dockerCmd(c, "push", derivedImage)
 
 	// Pull
@@ -232,10 +224,7 @@ func testPullIDStability(c *check.C) {
 		c.Fatalf("repull redownloaded a layer: %s", out)
 	}
 
-	derivedIDAfterPull, err := getIDByName(derivedImage)
-	if err != nil {
-		c.Fatalf("error inspecting: %v", err)
-	}
+	derivedIDAfterPull := getIDByName(c, derivedImage)
 
 	if derivedIDAfterPull != originalID {
 		c.Fatal("image's ID unexpectedly changed after a repush/repull")
@@ -252,16 +241,10 @@ func testPullIDStability(c *check.C) {
 	dockerCmd(c, "rmi", derivedImage)
 	dockerCmd(c, "pull", derivedImage)
 
-	derivedIDAfterPull, err = getIDByName(derivedImage)
-	if err != nil {
-		c.Fatalf("error inspecting: %v", err)
-	}
+	derivedIDAfterPull = getIDByName(c, derivedImage)
 
 	if derivedIDAfterPull != originalID {
 		c.Fatal("image's ID unexpectedly changed after a repush/repull")
-	}
-	if err != nil {
-		c.Fatalf("error inspecting: %v", err)
 	}
 
 	// Make sure the image still runs
@@ -283,14 +266,9 @@ func (s *DockerSchema1RegistrySuite) TestPullIDStability(c *check.C) {
 func testPullNoLayers(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockercli/scratch", privateRegistryURL)
 
-	_, err := buildImage(repoName, `
+	buildImageSuccessfully(c, repoName, withDockerfile(`
 	FROM scratch
-	ENV foo bar`,
-		true)
-	if err != nil {
-		c.Fatal(err)
-	}
-
+	ENV foo bar`))
 	dockerCmd(c, "push", repoName)
 	dockerCmd(c, "rmi", repoName)
 	dockerCmd(c, "pull", repoName)

--- a/integration-cli/docker_cli_pull_trusted_test.go
+++ b/integration-cli/docker_cli_pull_trusted_test.go
@@ -149,11 +149,10 @@ func (s *DockerTrustSuite) TestTrustedOfflinePull(c *check.C) {
 func (s *DockerTrustSuite) TestTrustedPullDelete(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockercli/%s:latest", privateRegistryURL, "trusted-pull-delete")
 	// tag the image and upload it to the private registry
-	_, err := buildImage(repoName, `
+	buildImageSuccessfully(c, repoName, withDockerfile(`
                     FROM busybox
                     CMD echo trustedpulldelete
-                `, true)
-
+                `))
 	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 
 	dockerCmd(c, "rmi", repoName)
@@ -176,7 +175,7 @@ func (s *DockerTrustSuite) TestTrustedPullDelete(c *check.C) {
 	// rmi of tag should also remove the digest reference
 	dockerCmd(c, "rmi", repoName)
 
-	_, err = inspectFieldWithError(imageByDigest, "Id")
+	_, err := inspectFieldWithError(imageByDigest, "Id")
 	c.Assert(err, checker.NotNil, check.Commentf("digest reference should have been removed"))
 
 	_, err = inspectFieldWithError(imageID, "Id")

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -161,14 +161,13 @@ func testConcurrentPush(c *check.C) {
 	repos := []string{}
 	for _, tag := range []string{"push1", "push2", "push3"} {
 		repo := fmt.Sprintf("%v:%v", repoName, tag)
-		_, err := buildImage(repo, fmt.Sprintf(`
+		buildImageSuccessfully(c, repo, withDockerfile(fmt.Sprintf(`
 	FROM busybox
 	ENTRYPOINT ["/bin/echo"]
 	ENV FOO foo
 	ENV BAR bar
 	CMD echo %s
-`, repo), true)
-		c.Assert(err, checker.IsNil)
+`, repo)))
 		repos = append(repos, repo)
 	}
 

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -12,8 +12,7 @@ import (
 
 func (s *DockerSuite) TestRestartStoppedContainer(c *check.C) {
 	dockerCmd(c, "run", "--name=test", "busybox", "echo", "foobar")
-	cleanedContainerID, err := getIDByName("test")
-	c.Assert(err, check.IsNil)
+	cleanedContainerID := getIDByName(c, "test")
 
 	out, _ := dockerCmd(c, "logs", cleanedContainerID)
 	c.Assert(out, checker.Equals, "foobar\n")
@@ -21,7 +20,7 @@ func (s *DockerSuite) TestRestartStoppedContainer(c *check.C) {
 	dockerCmd(c, "restart", cleanedContainerID)
 
 	// Wait until the container has stopped
-	err = waitInspect(cleanedContainerID, "{{.State.Running}}", "false", 20*time.Second)
+	err := waitInspect(cleanedContainerID, "{{.State.Running}}", "false", 20*time.Second)
 	c.Assert(err, checker.IsNil)
 
 	out, _ = dockerCmd(c, "logs", cleanedContainerID)

--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -58,13 +58,12 @@ func (s *DockerSuite) TestRmContainerOrphaning(c *check.C) {
 	MAINTAINER Integration Tests`
 
 	// build first dockerfile
-	img1, err := buildImage(img, dockerfile1, true)
-	c.Assert(err, check.IsNil, check.Commentf("Could not build image %s", img))
+	buildImageSuccessfully(c, img, withDockerfile(dockerfile1))
+	img1 := getIDByName(c, img)
 	// run container on first image
 	dockerCmd(c, "run", img)
 	// rebuild dockerfile with a small addition at the end
-	_, err = buildImage(img, dockerfile2, true)
-	c.Assert(err, check.IsNil, check.Commentf("Could not rebuild image %s", img))
+	buildImageSuccessfully(c, img, withDockerfile(dockerfile2))
 	// try to remove the image, should not error out.
 	out, _, err := dockerCmdWithError("rmi", img)
 	c.Assert(err, check.IsNil, check.Commentf("Expected to removing the image, but failed: %s", out))

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -147,8 +147,8 @@ func (s *DockerSuite) TestRmiImgIDForce(c *check.C) {
 // See https://github.com/docker/docker/issues/14116
 func (s *DockerSuite) TestRmiImageIDForceWithRunningContainersAndMultipleTags(c *check.C) {
 	dockerfile := "FROM busybox\nRUN echo test 14116\n"
-	imgID, err := buildImage("test-14116", dockerfile, false)
-	c.Assert(err, checker.IsNil)
+	buildImageSuccessfully(c, "test-14116", withDockerfile(dockerfile))
+	imgID := getIDByName(c, "test-14116")
 
 	newTag := "newtag"
 	dockerCmd(c, "tag", imgID, newTag)
@@ -205,14 +205,8 @@ func (s *DockerSuite) TestRmiForceWithMultipleRepositories(c *check.C) {
 	tag1 := imageName + ":tag1"
 	tag2 := imageName + ":tag2"
 
-	_, err := buildImage(tag1,
-		`FROM busybox
-		MAINTAINER "docker"`,
-		true)
-	if err != nil {
-		c.Fatal(err)
-	}
-
+	buildImageSuccessfully(c, tag1, withDockerfile(`FROM busybox
+		MAINTAINER "docker"`))
 	dockerCmd(c, "tag", tag1, tag2)
 
 	out, _ := dockerCmd(c, "rmi", "-f", tag2)
@@ -240,8 +234,8 @@ func (s *DockerSuite) TestRmiContainerImageNotFound(c *check.C) {
 	imageIds := make([]string, 2)
 	for i, name := range imageNames {
 		dockerfile := fmt.Sprintf("FROM busybox\nMAINTAINER %s\nRUN echo %s\n", name, name)
-		id, err := buildImage(name, dockerfile, false)
-		c.Assert(err, checker.IsNil)
+		buildImageSuccessfully(c, name, withoutCache, withDockerfile(dockerfile))
+		id := getIDByName(c, name)
 		imageIds[i] = id
 	}
 
@@ -269,9 +263,7 @@ RUN echo 0 #layer0
 RUN echo 1 #layer1
 RUN echo 2 #layer2
 `
-	_, err := buildImage(image, dockerfile, false)
-	c.Assert(err, checker.IsNil)
-
+	buildImageSuccessfully(c, image, withoutCache, withDockerfile(dockerfile))
 	out, _ := dockerCmd(c, "history", "-q", image)
 	ids := strings.Split(out, "\n")
 	idToTag := ids[2]
@@ -294,7 +286,7 @@ RUN echo 2 #layer2
 
 	// At this point we have 2 containers, one based on layer2 and another based on layer0.
 	// Try to untag "tmp2" without the -f flag.
-	out, _, err = dockerCmdWithError("rmi", newTag)
+	out, _, err := dockerCmdWithError("rmi", newTag)
 	// should not be untagged without the -f flag
 	c.Assert(err, checker.NotNil)
 	c.Assert(out, checker.Contains, cid[:12])
@@ -307,10 +299,9 @@ RUN echo 2 #layer2
 }
 
 func (*DockerSuite) TestRmiParentImageFail(c *check.C) {
-	_, err := buildImage("test", `
+	buildImageSuccessfully(c, "test", withDockerfile(`
 	FROM busybox
-	RUN echo hello`, false)
-	c.Assert(err, checker.IsNil)
+	RUN echo hello`))
 
 	id := inspectField(c, "busybox", "ID")
 	out, _, err := dockerCmdWithError("rmi", id)

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -828,17 +828,11 @@ func (s *DockerSuite) TestRunTmpfsMounts(c *check.C) {
 
 func (s *DockerSuite) TestRunTmpfsMountsOverrideImageVolumes(c *check.C) {
 	name := "img-with-volumes"
-	_, err := buildImage(
-		name,
-		`
+	buildImageSuccessfully(c, name, withDockerfile(`
     FROM busybox
     VOLUME /run
     RUN touch /run/stuff
-    `,
-		true)
-	if err != nil {
-		c.Fatal(err)
-	}
+    `))
 	out, _ := dockerCmd(c, "run", "--tmpfs", "/run", name, "ls", "/run")
 	c.Assert(out, checker.Not(checker.Contains), "stuff")
 }

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -260,12 +260,9 @@ func (s *DockerSuite) TestSaveDirectoryPermissions(c *check.C) {
 	os.Mkdir(extractionDirectory, 0777)
 
 	defer os.RemoveAll(tmpDir)
-	_, err = buildImage(name,
-		`FROM busybox
+	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
 	RUN adduser -D user && mkdir -p /opt/a/b && chown -R user:user /opt/a
-	RUN touch /opt/a/b/c && chown user:user /opt/a/b/c`,
-		true)
-	c.Assert(err, checker.IsNil, check.Commentf("%v", err))
+	RUN touch /opt/a/b/c && chown user:user /opt/a/b/c`))
 
 	out, _, err := testutil.RunCommandPipelineWithOutput(
 		exec.Command(dockerBinary, "save", name),
@@ -358,9 +355,7 @@ func (s *DockerSuite) TestSaveLoadNoTag(c *check.C) {
 
 	name := "saveloadnotag"
 
-	_, err := buildImage(name, "FROM busybox\nENV foo=bar", true)
-	c.Assert(err, checker.IsNil, check.Commentf("%v", err))
-
+	buildImageSuccessfully(c, name, withDockerfile("FROM busybox\nENV foo=bar"))
 	id := inspectField(c, name, "Id")
 
 	// Test to make sure that save w/o name just shows imageID during load

--- a/integration-cli/docker_cli_save_load_unix_test.go
+++ b/integration-cli/docker_cli_save_load_unix_test.go
@@ -72,11 +72,9 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 
 func (s *DockerSuite) TestSaveAndLoadWithProgressBar(c *check.C) {
 	name := "test-load"
-	_, err := buildImage(name, `
-	FROM busybox
+	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
 	RUN touch aa
-	`, true)
-	c.Assert(err, check.IsNil)
+	`))
 
 	tmptar := name + ".tar"
 	dockerCmd(c, "save", "-o", tmptar, name)

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -142,13 +142,9 @@ func (s *DockerSuite) TestTagInvalidRepoName(c *check.C) {
 
 // ensure tags cannot create ambiguity with image ids
 func (s *DockerSuite) TestTagTruncationAmbiguity(c *check.C) {
-	imageID, err := buildImage("notbusybox:latest",
-		`FROM busybox
-		MAINTAINER dockerio`,
-		true)
-	if err != nil {
-		c.Fatal(err)
-	}
+	buildImageSuccessfully(c, "notbusybox:latest", withDockerfile(`FROM busybox
+		MAINTAINER dockerio`))
+	imageID := getIDByName(c, "notbusybox:latest")
 	truncatedImageID := stringid.TruncateID(imageID)
 	truncatedTag := fmt.Sprintf("notbusybox:%s", truncatedImageID)
 
@@ -159,7 +155,7 @@ func (s *DockerSuite) TestTagTruncationAmbiguity(c *check.C) {
 	c.Logf("Built image: %s", imageID)
 
 	// test setting tag fails
-	_, _, err = dockerCmdWithError("tag", "busybox:latest", truncatedTag)
+	_, _, err := dockerCmdWithError("tag", "busybox:latest", truncatedTag)
 	if err != nil {
 		c.Fatalf("Error tagging with an image id: %s", err)
 	}


### PR DESCRIPTION
- Remove deprecated `buildImage*` functions
- Rename `buildImageNew` to `buildImage`
- Use `*check.C` in `fakeContext*` setup and in `getIdByName`

/cc @thaJeztah @icecrime @cpuguy83 @dnephin @AkihiroSuda @runcom 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>