### PR TITLE
print error if unsupported flags are used

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -229,7 +229,7 @@ func IsErrPluginPermissionDenied(err error) bool {
 // if less than the current supported version
 func (cli *Client) NewVersionError(APIrequired, feature string) error {
 	if versions.LessThan(cli.version, APIrequired) {
-		return fmt.Errorf("%q requires API version %s, but the Docker server is version %s", feature, APIrequired, cli.version)
+		return fmt.Errorf("%q requires API version %s, but the Docker daemon API version is %s", feature, APIrequired, cli.version)
 	}
 	return nil
 }


### PR DESCRIPTION
Docker 1.13 and up allows a client to communicate with older daemons. As a result, flags may be
present that are not supported by the older daemon. The client already _hides_ flags that are not supported yet, but this doesn't present users from using those flags.

This change shows an error if a flag is used that is not supported by the daemon (either based on the API version, or because experimental features are not enabled).

Note that for some options, a check is already in place in the API client. For those options, this is just a minor enhancement to more clearly indicate which _flag_ is not supported.

Before this change;

    DOCKER_API_VERSION=1.24 docker run -d --stop-timeout=30 busybox top
    mjfyt3qpvnq0iwmun3sjwth9i

    echo -e "FROM busybox\nRUN echo foo > bar" |  DOCKER_API_VERSION=1.24 docker build --squash -
    "squash" requires API version 1.25, but the Docker server is version 1.24

After this change;

    DOCKER_API_VERSION=1.24 docker run -d --stop-timeout=30 busybox top
    "--stop-timeout" requires API version 1.25, but the Docker daemon is version 1.24

    echo -e "FROM busybox\nRUN echo foo > bar" | DOCKER_API_VERSION=1.24 docker build --squash -
    "--squash" requires API version 1.25, but the Docker daemon is version 1.24

    echo -e "FROM busybox\nRUN echo foo > bar" | docker build --squash -
    "--squash" is only supported on a Docker daemon with experimental features enabled

**- Description for the changelog**

- Improve error handling if a flag is not supported by the daemon (version)
