### PR TITLE
Add a filter to reverse docker images by creation date

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4273,6 +4273,7 @@ paths:
 
             Available filters:
             - `dangling=true`
+            - `reverse=<boolean>` when set to `true` reverse the order of images by creation date
             - `label=key` or `label="key=value"` of an image label
             - `before`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
             - `since`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2144,7 +2144,7 @@ _docker_image_ls() {
 			__docker_complete_images
 			return
 			;;
-		dangling)
+		dangling|reverse)
 			COMPREPLY=( $( compgen -W "false true" -- "${cur##*=}" ) )
 			return
 			;;

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -399,14 +399,14 @@ __docker_complete_images_filters() {
     declare -a boolean_opts opts
 
     boolean_opts=('true' 'false')
-    opts=('before' 'dangling' 'label' 'reference' 'since')
+    opts=('before' 'dangling' 'label' 'reference' 'since' 'reverse')
 
     if compset -P '*='; then
         case "${${words[-1]%=*}#*=}" in
             (before|reference|since)
                 __docker_complete_images && ret=0
                 ;;
-            (dangling)
+            (dangling|reverse)
                 _describe -t boolean-filter-opts "filter options" boolean_opts && ret=0
                 ;;
             *)

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -22,6 +22,7 @@ var acceptedImageFilterTags = map[string]bool{
 	"before":    true,
 	"since":     true,
 	"reference": true,
+	"reverse":   true,
 }
 
 // byCreated is a temporary type used to sort a list of images by creation
@@ -47,6 +48,7 @@ func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs
 		allImages    map[image.ID]*image.Image
 		err          error
 		danglingOnly = false
+		reverse      = false
 	)
 
 	if err := imageFilters.Validate(acceptedImageFilterTags); err != nil {
@@ -227,7 +229,19 @@ func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs
 		}
 	}
 
-	sort.Sort(sort.Reverse(byCreated(images)))
+	if imageFilters.Include("reverse") {
+		if imageFilters.ExactMatch("reverse", "true") {
+			reverse = true
+		}
+	}
+
+	if reverse {
+		// Most recently created images will be on the bottom
+		sort.Sort(byCreated(images))
+	} else {
+		// Default behavior: most recently created images will be on the top
+		sort.Sort(sort.Reverse(byCreated(images)))
+	}
 
 	return images, nil
 }

--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -25,6 +25,7 @@ Options:
       --digests         Show digests
   -f, --filter value    Filter output based on conditions provided (default [])
                         - dangling=(true|false)
+                        - reverse=(true|false)
                         - label=<key> or label=<key>=<value>
                         - before=(<image-name>[:tag]|<image-id>|<image@digest>)
                         - since=(<image-name>[:tag]|<image-id>|<image@digest>)

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -67,6 +67,36 @@ func (s *DockerSuite) TestImagesOrderedByCreationDate(c *check.C) {
 	c.Assert(imgs[2], checker.Equals, id1, check.Commentf("First image must be %s, got %s", id1, imgs[2]))
 }
 
+func (s *DockerSuite) TestImagesOrderedInReverseByCreationDate(c *check.C) {
+	id1, err := buildImage("reverse_order:test_a",
+		`FROM busybox
+                MAINTAINER dockerio1`, true)
+	c.Assert(err, checker.IsNil)
+	time.Sleep(1 * time.Second)
+	id2, err := buildImage("reverse_order:test_c",
+		`FROM busybox
+                MAINTAINER dockerio2`, true)
+	c.Assert(err, checker.IsNil)
+	time.Sleep(1 * time.Second)
+	id3, err := buildImage("reverse_order:test_b",
+		`FROM busybox
+                MAINTAINER dockerio3`, true)
+	c.Assert(err, checker.IsNil)
+
+	out, _ := dockerCmd(c, "images", "-q", "--no-trunc", "-f", "reverse=true")
+	out = strings.TrimSpace(out)
+	imgs := strings.Split(out, "\n")
+
+	// Get the last three images
+	img0 := imgs[len(imgs)-1]
+	img1 := imgs[len(imgs)-2]
+	img2 := imgs[len(imgs)-3]
+
+	c.Assert(img0, checker.Equals, id3, check.Commentf("Image must be %s, got %s", id3, img0))
+	c.Assert(img1, checker.Equals, id2, check.Commentf("Image must be %s, got %s", id2, img1))
+	c.Assert(img2, checker.Equals, id1, check.Commentf("Image must be %s, got %s", id1, img2))
+}
+
 func (s *DockerSuite) TestImagesErrorWithInvalidFilterNameTest(c *check.C) {
 	out, _, err := dockerCmdWithError("images", "-f", "FOO=123")
 	c.Assert(err, checker.NotNil)

--- a/man/src/image/ls.md
+++ b/man/src/image/ls.md
@@ -18,6 +18,7 @@ versions.
 Filters the output based on these conditions:
 
    - dangling=(true|false) - find unused images
+   - reverse=(true|false) - sort images in reverse order by creation date
    - label=<key> or label=<key>=<value>
    - before=(<image-name>[:tag]|<image-id>|<image@digest>)
    - since=(<image-name>[:tag]|<image-id>|<image@digest>)


### PR DESCRIPTION
Signed-off-by: Tony Abboud <tdabboud@hotmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added a boolean filter to the `docker images`
command which will output the images in reverse order by
creation date, where the most recently created image will
be on the bottom.
Example Usage:
    docker images -a -f reverse=true

With a lot of images you have to scroll up the terminal to see the latest docker images that are built, or you have to pipe the output to another command:
i.e. `docker images -a | tail -r`

This will allow everyone to sort the images regardless of the underlying OS.

**- How I did it**
I added another filter flag `reverse=<true|false>` for the docker images command

**- How to verify it**
I added a unit test `TestImagesOrderedInReverseByCreationDate`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add a new filter, reverse=<true|false>, to sort the docker images by creation date


