### PR TITLE
Fix issue where service healthcheck is `{}` in remote API

### DIFF
--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -205,17 +205,11 @@ func (r *controller) Start(ctx context.Context) error {
 	}
 
 	// no health check
-	if ctnr.Config == nil || ctnr.Config.Healthcheck == nil {
+	if ctnr.Config == nil || ctnr.Config.Healthcheck == nil || len(ctnr.Config.Healthcheck.Test) == 0 || ctnr.Config.Healthcheck.Test[0] == "NONE" {
 		if err := r.adapter.activateServiceBinding(); err != nil {
 			log.G(ctx).WithError(err).Errorf("failed to activate service binding for container %s which has no healthcheck config", r.adapter.container.name())
 			return err
 		}
-		return nil
-	}
-
-	healthCmd := ctnr.Config.Healthcheck.Test
-
-	if len(healthCmd) == 0 || healthCmd[0] == "NONE" {
 		return nil
 	}
 


### PR DESCRIPTION
**- What I did**

This fix tries to address the issue raised in #30178 where service healthcheck is `{}` in remote API will result in dns resolve failure.

The reason was that when service healthcheck is `{}`, `activateServiceBinding()` is not called.

**- How I did it**

This fix fixes the issue.

**- How to verify it**

An integration test has been added.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![unnamed](https://cloud.githubusercontent.com/assets/6932348/22009377/8ec72bc8-dc37-11e6-91bd-783cee82e660.jpg)


This fix fixes #30178.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>