### PR TITLE
Add bash completion for `build --squash`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2012,6 +2012,7 @@ _docker_image_build() {
 		--quiet -q
 		--rm
 	"
+	__docker_is_experimental && boolean_options+="--squash"
 
 	local all_options="$options_with_args $boolean_options"
 


### PR DESCRIPTION
Ref #22641
Completion is only enabled in experimental mode.
Please schedule for 1.13.0
Ping @sdurrheimer for zsh completion