### PR TITLE
Follow #28926, fix docker save can't share layers in the tar archive.

### DIFF
--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -234,7 +234,9 @@ func (s *saveSession) saveImage(id image.ID) (map[layer.DiffID]distribution.Desc
 	var foreignSrcs map[layer.DiffID]distribution.Descriptor
 	for i := range img.RootFS.DiffIDs {
 		v1Img := image.V1Image{
-			Created: img.Created,
+			// This is for backward compatibility used for
+			// pre v1.9 docker.
+			Created: time.Unix(0, 0),
 		}
 		if i == len(img.RootFS.DiffIDs)-1 {
 			v1Img = img.V1Image


### PR DESCRIPTION
After https://github.com/docker/docker/pull/28926, if saving multiple images
which have common layers at same time, the common layers can't share in the tar archive
because the hash ID changes because of the Create time. The Create time is used for
pre v1.9 which treat each layer as a image and make no sense for after v1.10.
To make the hash ID consistent and keep the image save from >1.10 working properly
on pre v1.9, using a constant Create time `time.Unix(0,0)`.

Signed-off-by: Lei Jitang <leijitang@huawei.com>

ping @tonistiigi  @stevvooe  @dmcgowan 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

