### PR TITLE
[carry 29727] update unit-file; wait for network to be online

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network.target docker.socket firewalld.service
+After=network-online.target docker.socket firewalld.service
+Wants=network-online.target
 Requires=docker.socket
 
 [Service]

--- a/contrib/init/systemd/docker.service.rpm
+++ b/contrib/init/systemd/docker.service.rpm
@@ -1,7 +1,8 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network.target firewalld.service
+After=network-online.target firewalld.service
+Wants=network-online.target
 
 [Service]
 Type=notify


### PR DESCRIPTION
bugfix issue 18826: containers do not restart after reboot when bound to virtual network interface

carries #29727
closes #29727

relates to #18826
