### PR TITLE
fix flag descriptions for content-trust

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -52,7 +52,7 @@ func NewCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	// with hostname
 	flags.Bool("help", false, "Print usage")
 
-	command.AddTrustedFlags(flags, true)
+	command.AddTrustVerificationFlags(flags)
 	copts = addFlags(flags)
 	return cmd
 }

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -61,7 +61,7 @@ func NewRunCommand(dockerCli *command.DockerCli) *cobra.Command {
 	// with hostname
 	flags.Bool("help", false, "Print usage")
 
-	command.AddTrustedFlags(flags, true)
+	command.AddTrustVerificationFlags(flags)
 	copts = addFlags(flags)
 	return cmd
 }

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -108,7 +108,7 @@ func NewBuildCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.StringSliceVar(&options.securityOpt, "security-opt", []string{}, "Security options")
 	flags.StringVar(&options.networkMode, "network", "default", "Set the networking mode for the RUN instructions during build")
 
-	command.AddTrustedFlags(flags, true)
+	command.AddTrustVerificationFlags(flags)
 
 	flags.BoolVar(&options.squash, "squash", false, "Squash newly built layers into a single new layer")
 	flags.SetAnnotation("squash", "experimental", nil)

--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -36,7 +36,7 @@ func NewPullCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags := cmd.Flags()
 
 	flags.BoolVarP(&opts.all, "all-tags", "a", false, "Download all tagged images in the repository")
-	command.AddTrustedFlags(flags, true)
+	command.AddTrustVerificationFlags(flags)
 
 	return cmd
 }

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -24,7 +24,7 @@ func NewPushCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 	flags := cmd.Flags()
 
-	command.AddTrustedFlags(flags, true)
+	command.AddTrustSigningFlags(flags)
 
 	return cmd
 }

--- a/cli/command/plugin/install.go
+++ b/cli/command/plugin/install.go
@@ -47,7 +47,7 @@ func newInstallCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.BoolVar(&options.disable, "disable", false, "Do not enable the plugin on install")
 	flags.StringVar(&options.alias, "alias", "", "Local name for plugin")
 
-	command.AddTrustedFlags(flags, true)
+	command.AddTrustVerificationFlags(flags)
 
 	return cmd
 }

--- a/cli/command/plugin/push.go
+++ b/cli/command/plugin/push.go
@@ -26,7 +26,7 @@ func newPushCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 	flags := cmd.Flags()
 
-	command.AddTrustedFlags(flags, true)
+	command.AddTrustSigningFlags(flags)
 
 	return cmd
 }

--- a/docs/reference/commandline/plugin_push.md
+++ b/docs/reference/commandline/plugin_push.md
@@ -14,12 +14,13 @@ keywords: "plugin, push"
 -->
 
 ```markdown
-Usage:  docker plugin push PLUGIN[:TAG]
+Usage:	docker plugin push PLUGIN[:TAG]
 
 Push a plugin to a registry
 
 Options:
-      --help       Print usage
+      --disable-content-trust   Skip image signing (default true)
+      --help                    Print usage
 ```
 
 Use `docker plugin create` to create the plugin. Once the plugin is ready for distribution,

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -21,7 +21,7 @@ Usage:  docker push [OPTIONS] NAME[:TAG]
 Push an image or a repository to a registry
 
 Options:
-      --disable-content-trust   Skip image verification (default true)
+      --disable-content-trust   Skip image signing (default true)
       --help                    Print usage
 ```
 


### PR DESCRIPTION
Commit ed13c3abfb242905ec012e8255dc6f26dcf122f6 (https://github.com/docker/docker/pull/14546) added flags for Docker Content Trust. Depending on the `verify` boolean, the message is "Skip image verification", or "Skip image signing". "Signing" is intended for `docker push` / `docker plugin push`.

During the migration to Cobra, this boolean got flipped for `docker push` (9640e3a4514f96a890310757a09fd77a3c70e931 https://github.com/docker/docker/pull/23256), causing `docker push` to show the incorrect flag description.

This patch changes the flags to use the correct description for `docker push`, and `docker plugin push`.

/cc @vdemeester @dmcgowan PTAL
