### PR TITLE
Fix escaped go vet error

### DIFF
--- a/pkg/httputils/httputils_test.go
+++ b/pkg/httputils/httputils_test.go
@@ -24,7 +24,7 @@ func TestDownload(t *testing.T) {
 	response.Body.Close()
 
 	if err != nil || string(actual) != expected {
-		t.Fatalf("Expected the response %q, got err:%q, response:%q, actual:%q", expected, err, response, string(actual))
+		t.Fatalf("Expected the response %q, got err:%q, actual:%q", expected, err, string(actual))
 	}
 }
 


### PR DESCRIPTION
Find one escaped go vet error:

```
$ cd pkg/httputils/
$ go vet .
httputils_test.go:28: arg response for printf verb %q of wrong type:
*net/http.Response
```

You can also find it with

```
$ go vet github.com/docker/docker/pkg/httputils/
```

or

```
$ go vet ./...
```

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>
