### PR TITLE
Close logwatcher on context cancellation

### DIFF
--- a/daemon/logger/jsonfilelog/read.go
+++ b/daemon/logger/jsonfilelog/read.go
@@ -137,7 +137,11 @@ func tailFile(f io.ReadSeeker, logWatcher *logger.LogWatcher, tail int, since ti
 		if !since.IsZero() && msg.Timestamp.Before(since) {
 			continue
 		}
-		logWatcher.Msg <- msg
+		select {
+		case <-logWatcher.WatchClose():
+			return
+		case logWatcher.Msg <- msg:
+		}
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

-- 

Fixes #30135

This patch addresses 2 issues:
 1. in `tailfile()` if somehow the `logWatcher.Msg` were to become full and the watcher closed before space was made into it, we were getting stuck there forever since we were not checking for the watcher getting closed
 2. When servicing `docker logs`, if the command was cancelled we were not closing the watcher (and hence notifying it to stop copying data)