### PR TITLE
fix some ineffectual assignments (and minor fixes)

### DIFF
--- a/integration-cli/docker_cli_build_unix_test.go
+++ b/integration-cli/docker_cli_build_unix_test.go
@@ -140,6 +140,8 @@ func (s *DockerSuite) TestBuildCancellationKillsSleep(c *check.C) {
 	buildCmd.Dir = ctx.Dir
 
 	stdoutBuild, err := buildCmd.StdoutPipe()
+	c.Assert(err, checker.IsNil)
+
 	if err := buildCmd.Start(); err != nil {
 		c.Fatalf("failed to run build: %s", err)
 	}

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -76,7 +76,7 @@ func (s *DockerSuite) TestCommitHardlink(c *check.C) {
 	imageID, _ := dockerCmd(c, "commit", "hardlinks", "hardlinks")
 	imageID = strings.TrimSpace(imageID)
 
-	secondOutput, _ := dockerCmd(c, "run", "-t", "hardlinks", "ls", "-di", "file1", "file2")
+	secondOutput, _ := dockerCmd(c, "run", "-t", imageID, "ls", "-di", "file1", "file2")
 
 	chunks = strings.Split(strings.TrimSpace(secondOutput), " ")
 	inode = chunks[0]
@@ -90,7 +90,7 @@ func (s *DockerSuite) TestCommitTTY(c *check.C) {
 	imageID, _ := dockerCmd(c, "commit", "tty", "ttytest")
 	imageID = strings.TrimSpace(imageID)
 
-	dockerCmd(c, "run", "ttytest", "/bin/ls")
+	dockerCmd(c, "run", imageID, "/bin/ls")
 }
 
 func (s *DockerSuite) TestCommitWithHostBindMount(c *check.C) {
@@ -100,7 +100,7 @@ func (s *DockerSuite) TestCommitWithHostBindMount(c *check.C) {
 	imageID, _ := dockerCmd(c, "commit", "bind-commit", "bindtest")
 	imageID = strings.TrimSpace(imageID)
 
-	dockerCmd(c, "run", "bindtest", "true")
+	dockerCmd(c, "run", imageID, "true")
 }
 
 func (s *DockerSuite) TestCommitChange(c *check.C) {

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -442,6 +442,7 @@ func (s *DockerSuite) TestCpSpecialFiles(c *check.C) {
 
 	expected, err = readContainerFile(containerID, "hostname")
 	actual, err = ioutil.ReadFile(outDir + "/hostname")
+	c.Assert(err, checker.IsNil)
 
 	// Expected copied file to be duplicate of the container resolvconf
 	c.Assert(bytes.Equal(actual, expected), checker.True)
@@ -534,6 +535,7 @@ func (s *DockerSuite) TestCpToDot(c *check.C) {
 	c.Assert(os.Chdir(tmpdir), checker.IsNil)
 	dockerCmd(c, "cp", containerID+":/test", ".")
 	content, err := ioutil.ReadFile("./test")
+	c.Assert(err, checker.IsNil)
 	c.Assert(string(content), checker.Equals, "lololol\n")
 }
 
@@ -572,6 +574,7 @@ func (s *DockerSuite) TestCpNameHasColon(c *check.C) {
 	defer os.RemoveAll(tmpdir)
 	dockerCmd(c, "cp", containerID+":/te:s:t", tmpdir)
 	content, err := ioutil.ReadFile(tmpdir + "/te:s:t")
+	c.Assert(err, checker.IsNil)
 	c.Assert(string(content), checker.Equals, "lololol\n")
 }
 
@@ -653,6 +656,7 @@ func (s *DockerSuite) TestCpSymlinkFromConToHostFollowSymlink(c *check.C) {
 	dockerCmd(c, "cp", "-L", cleanedContainerID+":"+"/dir_link", expectedPath)
 
 	actual, err = ioutil.ReadFile(expectedPath)
+	c.Assert(err, checker.IsNil)
 
 	if !bytes.Equal(actual, expected) {
 		c.Fatalf("Expected copied file to be duplicate of the container symbol link target")

--- a/integration-cli/docker_cli_cp_to_container_test.go
+++ b/integration-cli/docker_cli_cp_to_container_test.go
@@ -57,7 +57,7 @@ func (s *DockerSuite) TestCpToErrSrcNotDir(c *check.C) {
 }
 
 // Test for error when SRC is a valid file or directory,
-// bu the DST parent directory does not exist.
+// but the DST parent directory does not exist.
 func (s *DockerSuite) TestCpToErrDstParentNotExists(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	containerID := makeTestContainer(c, testContainerOptions{addContent: true})
@@ -79,6 +79,7 @@ func (s *DockerSuite) TestCpToErrDstParentNotExists(c *check.C) {
 	// Try with a directory source.
 	srcPath = cpPath(tmpDir, "dir1")
 
+	err = runDockerCp(c, srcPath, dstPath)
 	c.Assert(err, checker.NotNil)
 
 	c.Assert(isCpNotExist(err), checker.True, check.Commentf("expected IsNotExist error, but got %T: %s", err, err))

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -363,7 +363,7 @@ func (s *DockerSuite) TestExecInspectID(c *check.C) {
 	// result in a 404 (not 'container not running')
 	out, ec := dockerCmd(c, "rm", "-f", id)
 	c.Assert(ec, checker.Equals, 0, check.Commentf("error removing container: %s", out))
-	sc, body, err = request.SockRequest("GET", "/exec/"+execID+"/json", nil, daemonHost())
+	sc, body, _ = request.SockRequest("GET", "/exec/"+execID+"/json", nil, daemonHost())
 	c.Assert(sc, checker.Equals, http.StatusNotFound, check.Commentf("received status != 404: %d\n%s", sc, body))
 }
 

--- a/integration-cli/docker_cli_external_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_unix_test.go
@@ -295,7 +295,8 @@ func (s *DockerExternalVolumeSuite) TestVolumeCLICreateOptionConflict(c *check.C
 
 	// make sure hidden --name option conflicts with positional arg name
 	out, _, err = dockerCmdWithError("volume", "create", "--name", "test2", "test2")
-	c.Assert(err, check.NotNil, check.Commentf("Conflicting options: either specify --name or provide positional arg, not both"))
+	c.Assert(err, check.NotNil)
+	c.Assert(strings.TrimSpace(out), checker.Equals, "Conflicting options: either specify --name or provide positional arg, not both")
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverNamed(c *check.C) {

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -497,6 +497,7 @@ func (s *DockerSuite) TestDockerInspectMultipleNetwork(c *check.C) {
 
 	networkResources = []types.NetworkResource{}
 	err = json.Unmarshal([]byte(result.Stdout()), &networkResources)
+	c.Assert(err, check.IsNil)
 	c.Assert(networkResources, checker.HasLen, 1)
 
 	// Should print an error and return an exitCode, nothing else

--- a/integration-cli/docker_cli_pull_local_test.go
+++ b/integration-cli/docker_cli_pull_local_test.go
@@ -459,12 +459,11 @@ func (s *DockerRegistrySuite) TestRunImplicitPullWithNoTag(c *check.C) {
 	dockerCmd(c, "rmi", repoTag1)
 	dockerCmd(c, "rmi", repoTag2)
 
-	out, _, err := dockerCmdWithError("run", repo)
-	c.Assert(err, check.IsNil)
+	out, _ := dockerCmd(c, "run", repo)
 	c.Assert(out, checker.Contains, fmt.Sprintf("Unable to find image '%s:latest' locally", repo))
 
 	// There should be only one line for repo, the one with repo:latest
-	outImageCmd, _, err := dockerCmdWithError("images", repo)
+	outImageCmd, _ := dockerCmd(c, "images", repo)
 	splitOutImageCmd := strings.Split(strings.TrimSpace(outImageCmd), "\n")
 	c.Assert(splitOutImageCmd, checker.HasLen, 2)
 }

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1296,11 +1296,11 @@ func (s *DockerSuite) TestRunDNSOptions(c *check.C) {
 		c.Fatalf("expected 'search mydomain nameserver 127.0.0.1 options ndots:9', but says: %q", actual)
 	}
 
-	out, stderr, _ = dockerCmdWithStdoutStderr(c, "run", "--dns=127.0.0.1", "--dns-search=.", "--dns-opt=ndots:3", "busybox", "cat", "/etc/resolv.conf")
+	out, _ = dockerCmd(c, "run", "--dns=1.1.1.1", "--dns-search=.", "--dns-opt=ndots:3", "busybox", "cat", "/etc/resolv.conf")
 
 	actual = strings.Replace(strings.Trim(strings.Trim(out, "\r\n"), " "), "\n", " ", -1)
-	if actual != "nameserver 127.0.0.1 options ndots:3" {
-		c.Fatalf("expected 'nameserver 127.0.0.1 options ndots:3', but says: %q", actual)
+	if actual != "nameserver 1.1.1.1 options ndots:3" {
+		c.Fatalf("expected 'nameserver 1.1.1.1 options ndots:3', but says: %q", actual)
 	}
 }
 
@@ -1376,7 +1376,6 @@ func (s *DockerSuite) TestRunDNSOptionsBasedOnHostResolvConf(c *check.C) {
 		c.Fatalf("/etc/resolv.conf does not exist")
 	}
 
-	hostNameservers = resolvconf.GetNameservers(resolvConf, types.IP)
 	hostSearch = resolvconf.GetSearchDomains(resolvConf)
 
 	out, _ = dockerCmd(c, "run", "busybox", "cat", "/etc/resolv.conf")

--- a/integration-cli/docker_cli_search_test.go
+++ b/integration-cli/docker_cli_search_test.go
@@ -122,10 +122,10 @@ func (s *DockerSuite) TestSearchWithLimit(c *check.C) {
 	c.Assert(outSlice, checker.HasLen, limit+2) // 1 header, 1 carriage return
 
 	limit = 0
-	out, _, err = dockerCmdWithError("search", fmt.Sprintf("--limit=%d", limit), "docker")
+	_, _, err = dockerCmdWithError("search", fmt.Sprintf("--limit=%d", limit), "docker")
 	c.Assert(err, checker.Not(checker.IsNil))
 
 	limit = 200
-	out, _, err = dockerCmdWithError("search", fmt.Sprintf("--limit=%d", limit), "docker")
+	_, _, err = dockerCmdWithError("search", fmt.Sprintf("--limit=%d", limit), "docker")
 	c.Assert(err, checker.Not(checker.IsNil))
 }

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -324,7 +324,7 @@ func (s *DockerSwarmSuite) TestSwarmContainerAttachByNetworkId(c *check.C) {
 	_, err = d.Cmd("rm", "-f", cID)
 	c.Assert(err, checker.IsNil)
 
-	out, err = d.Cmd("network", "rm", "testnet")
+	_, err = d.Cmd("network", "rm", "testnet")
 	c.Assert(err, checker.IsNil)
 
 	checkNetwork := func(*check.C) (interface{}, check.CommentInterface) {

--- a/pkg/ioutils/buffer_test.go
+++ b/pkg/ioutils/buffer_test.go
@@ -21,6 +21,9 @@ func TestFixedBufferWrite(t *testing.T) {
 	}
 
 	n, err = buf.Write(bytes.Repeat([]byte{1}, 64))
+	if n != 59 {
+		t.Fatalf("expected 59 bytes written before buffer is full, got %d", n)
+	}
 	if err != errBufferFull {
 		t.Fatalf("expected errBufferFull, got %v - %v", err, buf.buf[:64])
 	}


### PR DESCRIPTION
To make [goreportcard](https://goreportcard.com/report/github.com/docker/docker) a bit happier

Also found that

- `TestCpToErrDstParentNotExists()` was partially broken, because a `runDockerCp()` was inadvertently removed in f26a31e80cfcc77daba0872ddb14bf03f4398311
- `TestDaemonRestartSaveContainerExitCode()` didn't verify the actual _Error_ message, so added that to the test.
- `TestVolumeCLICreateOptionConflict()` only checked for an error to occur, but didn't validate if the error was due to conflicting options.

**- How to verify it**

Wait for Janky to (hopefully) become 💚 