### PR TITLE
Fixed a typo within pkg/authorization/api.go

### DIFF
--- a/pkg/authorization/api.go
+++ b/pkg/authorization/api.go
@@ -18,7 +18,7 @@ const (
 )
 
 // PeerCertificate is a wrapper around x509.Certificate which provides a sane
-// enconding/decoding to/from PEM format and JSON.
+// encoding/decoding to/from PEM format and JSON.
 type PeerCertificate x509.Certificate
 
 // MarshalJSON returns the JSON encoded pem bytes of a PeerCertificate.


### PR DESCRIPTION
Signed-off-by: Diego Romero <idiegoromero@gmail.com>

**- What I did**
As I was exploring the docker codebase, I found and corrected a typo within pkg/authorization/api.go

**- How I did it**
I replaced the spelling error with the correct word

**- How to verify it**
Options include Google or an old school dictionary

**- Description for the changelog**
Fixed a typo within pkg/authorization/api.go

**- A picture of a cute animal (not mandatory but encouraged)**

