### PR TITLE
[test-integration] Remove most of the runCommandWithOutput

### DIFF
--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -586,14 +586,14 @@ func (d *Daemon) GetBaseDeviceSize(c *check.C) int64 {
 // Cmd executes a docker CLI command against this daemon.
 // Example: d.Cmd("version") will run docker -H unix://path/to/unix.sock version
 func (d *Daemon) Cmd(args ...string) (string, error) {
-	b, err := d.Command(args...).CombinedOutput()
-	return string(b), err
+	result := icmd.RunCmd(d.Command(args...))
+	return result.Combined(), result.Error
 }
 
 // Command creates a docker CLI command against this daemon, to be executed later.
 // Example: d.Command("version") creates a command to run "docker -H unix://path/to/unix.sock version"
-func (d *Daemon) Command(args ...string) *exec.Cmd {
-	return exec.Command(d.dockerBinary, d.PrependHostArg(args)...)
+func (d *Daemon) Command(args ...string) icmd.Cmd {
+	return icmd.Command(d.dockerBinary, d.PrependHostArg(args)...)
 }
 
 // PrependHostArg prepend the specified arguments by the daemon host flags

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -31,9 +31,7 @@ import (
 )
 
 func (s *DockerSuite) TestContainerAPIGetAll(c *check.C) {
-	startCount, err := getContainerCount()
-	c.Assert(err, checker.IsNil, check.Commentf("Cannot query container count"))
-
+	startCount := getContainerCount(c)
 	name := "getall"
 	dockerCmd(c, "run", "--name", name, "busybox", "true")
 
@@ -354,8 +352,7 @@ func (s *DockerSuite) TestContainerAPIPause(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusNoContent)
 
-	pausedContainers, err := getPausedContainers()
-	c.Assert(err, checker.IsNil, check.Commentf("error thrown while checking if containers were paused"))
+	pausedContainers := getPausedContainers(c)
 
 	if len(pausedContainers) != 1 || stringid.TruncateID(ContainerID) != pausedContainers[0] {
 		c.Fatalf("there should be one paused container and not %d", len(pausedContainers))
@@ -365,8 +362,7 @@ func (s *DockerSuite) TestContainerAPIPause(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusNoContent)
 
-	pausedContainers, err = getPausedContainers()
-	c.Assert(err, checker.IsNil, check.Commentf("error thrown while checking if containers were paused"))
+	pausedContainers = getPausedContainers(c)
 	c.Assert(pausedContainers, checker.HasLen, 0, check.Commentf("There should be no paused container."))
 }
 

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -422,7 +422,7 @@ func (s *DockerSuite) TestCpSpecialFiles(c *check.C) {
 	// Copy actual /etc/resolv.conf
 	dockerCmd(c, "cp", containerID+":/etc/resolv.conf", outDir)
 
-	expected, err := readContainerFile(containerID, "resolv.conf")
+	expected := readContainerFile(c, containerID, "resolv.conf")
 	actual, err := ioutil.ReadFile(outDir + "/resolv.conf")
 
 	// Expected copied file to be duplicate of the container resolvconf
@@ -431,7 +431,7 @@ func (s *DockerSuite) TestCpSpecialFiles(c *check.C) {
 	// Copy actual /etc/hosts
 	dockerCmd(c, "cp", containerID+":/etc/hosts", outDir)
 
-	expected, err = readContainerFile(containerID, "hosts")
+	expected = readContainerFile(c, containerID, "hosts")
 	actual, err = ioutil.ReadFile(outDir + "/hosts")
 
 	// Expected copied file to be duplicate of the container hosts
@@ -440,7 +440,7 @@ func (s *DockerSuite) TestCpSpecialFiles(c *check.C) {
 	// Copy actual /etc/resolv.conf
 	dockerCmd(c, "cp", containerID+":/etc/hostname", outDir)
 
-	expected, err = readContainerFile(containerID, "hostname")
+	expected = readContainerFile(c, containerID, "hostname")
 	actual, err = ioutil.ReadFile(outDir + "/hostname")
 	c.Assert(err, checker.IsNil)
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1951,11 +1951,11 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithKilledRunningContainer(t *check
 
 	// Give time to containerd to process the command if we don't
 	// the exit event might be received after we do the inspect
-	pidCmd := exec.Command("kill", "-0", pid)
-	_, ec, _ := runCommandWithOutput(pidCmd)
-	for ec == 0 {
+	result := icmd.RunCommand("kill", "-0", pid)
+	for result.ExitCode == 0 {
 		time.Sleep(1 * time.Second)
-		_, ec, _ = runCommandWithOutput(pidCmd)
+		// FIXME(vdemeester) should we check it doesn't error out ?
+		result = icmd.RunCommand("kill", "-0", pid)
 	}
 
 	// restart the daemon

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -389,8 +389,7 @@ func (s *DockerSuite) TestRunMutableNetworkFiles(c *check.C) {
 	for _, fn := range []string{"resolv.conf", "hosts"} {
 		deleteAllContainers(c)
 
-		content, err := runCommandAndReadContainerFile(fn, exec.Command(dockerBinary, "run", "-d", "--name", "c1", "busybox", "sh", "-c", fmt.Sprintf("echo success >/etc/%s && top", fn)))
-		c.Assert(err, checker.IsNil)
+		content := runCommandAndReadContainerFile(c, fn, dockerBinary, "run", "-d", "--name", "c1", "busybox", "sh", "-c", fmt.Sprintf("echo success >/etc/%s && top", fn))
 
 		c.Assert(strings.TrimSpace(string(content)), checker.Equals, "success", check.Commentf("Content was not what was modified in the container", string(content)))
 
@@ -442,30 +441,27 @@ func (s *DockerSuite) TestExecWithPrivileged(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", "parent", "--cap-drop=ALL", "busybox", "sh", "-c", `while (true); do if [ -e /exec_priv ]; then cat /exec_priv && mknod /tmp/sda b 8 0 && echo "Success"; else echo "Privileged exec has not run yet"; fi; usleep 10000; done`)
 
 	// Check exec mknod doesn't work
-	cmd := exec.Command(dockerBinary, "exec", "parent", "sh", "-c", "mknod /tmp/sdb b 8 16")
-	out, _, err := runCommandWithOutput(cmd)
-	c.Assert(err, checker.NotNil, check.Commentf("exec mknod in --cap-drop=ALL container without --privileged should fail"))
-	c.Assert(out, checker.Contains, "Operation not permitted", check.Commentf("exec mknod in --cap-drop=ALL container without --privileged should fail"))
+	icmd.RunCommand(dockerBinary, "exec", "parent", "sh", "-c", "mknod /tmp/sdb b 8 16").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err:      "Operation not permitted",
+	})
 
 	// Check exec mknod does work with --privileged
-	cmd = exec.Command(dockerBinary, "exec", "--privileged", "parent", "sh", "-c", `echo "Running exec --privileged" > /exec_priv && mknod /tmp/sdb b 8 16 && usleep 50000 && echo "Finished exec --privileged" > /exec_priv && echo ok`)
-	out, _, err = runCommandWithOutput(cmd)
-	c.Assert(err, checker.IsNil)
+	result := icmd.RunCommand(dockerBinary, "exec", "--privileged", "parent", "sh", "-c", `echo "Running exec --privileged" > /exec_priv && mknod /tmp/sdb b 8 16 && usleep 50000 && echo "Finished exec --privileged" > /exec_priv && echo ok`)
+	result.Assert(c, icmd.Success)
 
-	actual := strings.TrimSpace(out)
-	c.Assert(actual, checker.Equals, "ok", check.Commentf("exec mknod in --cap-drop=ALL container with --privileged failed, output: %q", out))
+	actual := strings.TrimSpace(result.Combined())
+	c.Assert(actual, checker.Equals, "ok", check.Commentf("exec mknod in --cap-drop=ALL container with --privileged failed, output: %q", result.Combined()))
 
 	// Check subsequent unprivileged exec cannot mknod
-	cmd = exec.Command(dockerBinary, "exec", "parent", "sh", "-c", "mknod /tmp/sdc b 8 32")
-	out, _, err = runCommandWithOutput(cmd)
-	c.Assert(err, checker.NotNil, check.Commentf("repeating exec mknod in --cap-drop=ALL container after --privileged without --privileged should fail"))
-	c.Assert(out, checker.Contains, "Operation not permitted", check.Commentf("repeating exec mknod in --cap-drop=ALL container after --privileged without --privileged should fail"))
-
+	icmd.RunCommand(dockerBinary, "exec", "parent", "sh", "-c", "mknod /tmp/sdc b 8 32").Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err:      "Operation not permitted",
+	})
 	// Confirm at no point was mknod allowed
-	logCmd := exec.Command(dockerBinary, "logs", "parent")
-	out, _, err = runCommandWithOutput(logCmd)
-	c.Assert(err, checker.IsNil)
-	c.Assert(out, checker.Not(checker.Contains), "Success")
+	result = icmd.RunCommand(dockerBinary, "logs", "parent")
+	result.Assert(c, icmd.Success)
+	c.Assert(result.Combined(), checker.Not(checker.Contains), "Success")
 
 }
 

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -146,11 +146,8 @@ func (s *DockerSuite) TestLinksHostsFilesInject(c *check.C) {
 
 	c.Assert(waitRun(idTwo), checker.IsNil)
 
-	contentOne, err := readContainerFileWithExec(idOne, "/etc/hosts")
-	c.Assert(err, checker.IsNil, check.Commentf("contentOne: %s", string(contentOne)))
-
-	contentTwo, err := readContainerFileWithExec(idTwo, "/etc/hosts")
-	c.Assert(err, checker.IsNil, check.Commentf("contentTwo: %s", string(contentTwo)))
+	readContainerFileWithExec(c, idOne, "/etc/hosts")
+	contentTwo := readContainerFileWithExec(c, idTwo, "/etc/hosts")
 	// Host is not present in updated hosts file
 	c.Assert(string(contentTwo), checker.Contains, "onetwo")
 }
@@ -163,8 +160,7 @@ func (s *DockerSuite) TestLinksUpdateOnRestart(c *check.C) {
 	id := strings.TrimSpace(string(out))
 
 	realIP := inspectField(c, "one", "NetworkSettings.Networks.bridge.IPAddress")
-	content, err := readContainerFileWithExec(id, "/etc/hosts")
-	c.Assert(err, checker.IsNil)
+	content := readContainerFileWithExec(c, id, "/etc/hosts")
 
 	getIP := func(hosts []byte, hostname string) string {
 		re := regexp.MustCompile(fmt.Sprintf(`(\S*)\t%s`, regexp.QuoteMeta(hostname)))
@@ -181,8 +177,7 @@ func (s *DockerSuite) TestLinksUpdateOnRestart(c *check.C) {
 	dockerCmd(c, "restart", "one")
 	realIP = inspectField(c, "one", "NetworkSettings.Networks.bridge.IPAddress")
 
-	content, err = readContainerFileWithExec(id, "/etc/hosts")
-	c.Assert(err, checker.IsNil, check.Commentf("content: %s", string(content)))
+	content = readContainerFileWithExec(c, id, "/etc/hosts")
 	ip = getIP(content, "one")
 	c.Assert(ip, checker.Equals, realIP)
 

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -869,18 +869,15 @@ func (s *DockerNetworkSuite) TestDockerNetworkAnonymousEndpoint(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "--net", cstmBridgeNw, "busybox", "top")
 	cid1 := strings.TrimSpace(out)
 
-	hosts1, err := readContainerFileWithExec(cid1, hostsFile)
-	c.Assert(err, checker.IsNil)
+	hosts1 := readContainerFileWithExec(c, cid1, hostsFile)
 
 	out, _ = dockerCmd(c, "run", "-d", "--net", cstmBridgeNw, "busybox", "top")
 	cid2 := strings.TrimSpace(out)
 
-	hosts2, err := readContainerFileWithExec(cid2, hostsFile)
-	c.Assert(err, checker.IsNil)
+	hosts2 := readContainerFileWithExec(c, cid2, hostsFile)
 
 	// verify first container etc/hosts file has not changed
-	hosts1post, err := readContainerFileWithExec(cid1, hostsFile)
-	c.Assert(err, checker.IsNil)
+	hosts1post := readContainerFileWithExec(c, cid1, hostsFile)
 	c.Assert(string(hosts1), checker.Equals, string(hosts1post),
 		check.Commentf("Unexpected %s change on anonymous container creation", hostsFile))
 
@@ -891,11 +888,8 @@ func (s *DockerNetworkSuite) TestDockerNetworkAnonymousEndpoint(c *check.C) {
 
 	dockerCmd(c, "network", "connect", cstmBridgeNw1, cid2)
 
-	hosts2, err = readContainerFileWithExec(cid2, hostsFile)
-	c.Assert(err, checker.IsNil)
-
-	hosts1post, err = readContainerFileWithExec(cid1, hostsFile)
-	c.Assert(err, checker.IsNil)
+	hosts2 = readContainerFileWithExec(c, cid2, hostsFile)
+	hosts1post = readContainerFileWithExec(c, cid1, hostsFile)
 	c.Assert(string(hosts1), checker.Equals, string(hosts1post),
 		check.Commentf("Unexpected %s change on container connect", hostsFile))
 
@@ -910,18 +904,16 @@ func (s *DockerNetworkSuite) TestDockerNetworkAnonymousEndpoint(c *check.C) {
 
 	// Stop named container and verify first two containers' etc/hosts file hasn't changed
 	dockerCmd(c, "stop", cid3)
-	hosts1post, err = readContainerFileWithExec(cid1, hostsFile)
-	c.Assert(err, checker.IsNil)
+	hosts1post = readContainerFileWithExec(c, cid1, hostsFile)
 	c.Assert(string(hosts1), checker.Equals, string(hosts1post),
 		check.Commentf("Unexpected %s change on name container creation", hostsFile))
 
-	hosts2post, err := readContainerFileWithExec(cid2, hostsFile)
-	c.Assert(err, checker.IsNil)
+	hosts2post := readContainerFileWithExec(c, cid2, hostsFile)
 	c.Assert(string(hosts2), checker.Equals, string(hosts2post),
 		check.Commentf("Unexpected %s change on name container creation", hostsFile))
 
 	// verify that container 1 and 2 can't ping the named container now
-	_, _, err = dockerCmdWithError("exec", cid1, "ping", "-c", "1", cName)
+	_, _, err := dockerCmdWithError("exec", cid1, "ping", "-c", "1", cName)
 	c.Assert(err, check.NotNil)
 	_, _, err = dockerCmdWithError("exec", cid2, "ping", "-c", "1", cName)
 	c.Assert(err, check.NotNil)

--- a/integration-cli/docker_cli_pause_test.go
+++ b/integration-cli/docker_cli_pause_test.go
@@ -15,8 +15,7 @@ func (s *DockerSuite) TestPause(c *check.C) {
 	runSleepingContainer(c, "-d", "--name", name)
 
 	dockerCmd(c, "pause", name)
-	pausedContainers, err := getPausedContainers()
-	c.Assert(err, checker.IsNil)
+	pausedContainers := getPausedContainers(c)
 	c.Assert(len(pausedContainers), checker.Equals, 1)
 
 	dockerCmd(c, "unpause", name)
@@ -41,8 +40,7 @@ func (s *DockerSuite) TestPauseMultipleContainers(c *check.C) {
 		runSleepingContainer(c, "-d", "--name", name)
 	}
 	dockerCmd(c, append([]string{"pause"}, containers...)...)
-	pausedContainers, err := getPausedContainers()
-	c.Assert(err, checker.IsNil)
+	pausedContainers := getPausedContainers(c)
 	c.Assert(len(pausedContainers), checker.Equals, len(containers))
 
 	dockerCmd(c, append([]string{"unpause"}, containers...)...)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1464,10 +1464,7 @@ func (s *DockerSuite) TestRunResolvconfUpdate(c *check.C) {
 	dockerCmd(c, "start", "first")
 
 	// check for update in container
-	containerResolv, err := readContainerFile(containerID1, "resolv.conf")
-	if err != nil {
-		c.Fatal(err)
-	}
+	containerResolv := readContainerFile(c, containerID1, "resolv.conf")
 	if !bytes.Equal(containerResolv, bytesResolvConf) {
 		c.Fatalf("Restarted container does not have updated resolv.conf; expected %q, got %q", tmpResolvConf, string(containerResolv))
 	}
@@ -1490,11 +1487,7 @@ func (s *DockerSuite) TestRunResolvconfUpdate(c *check.C) {
 	dockerCmd(c, "start", "second")
 
 	// check for update in container
-	containerResolv, err = readContainerFile(containerID2, "resolv.conf")
-	if err != nil {
-		c.Fatal(err)
-	}
-
+	containerResolv = readContainerFile(c, containerID2, "resolv.conf")
 	if bytes.Equal(containerResolv, resolvConfSystem) {
 		c.Fatalf("Container's resolv.conf should not have been updated with host resolv.conf: %q", string(containerResolv))
 	}
@@ -1509,11 +1502,7 @@ func (s *DockerSuite) TestRunResolvconfUpdate(c *check.C) {
 	}
 
 	// check for update in container
-	containerResolv, err = readContainerFile(runningContainerID, "resolv.conf")
-	if err != nil {
-		c.Fatal(err)
-	}
-
+	containerResolv = readContainerFile(c, runningContainerID, "resolv.conf")
 	if bytes.Equal(containerResolv, bytesResolvConf) {
 		c.Fatalf("Running container should not have updated resolv.conf; expected %q, got %q", string(resolvConfSystem), string(containerResolv))
 	}
@@ -1523,10 +1512,7 @@ func (s *DockerSuite) TestRunResolvconfUpdate(c *check.C) {
 	dockerCmd(c, "restart", runningContainerID)
 
 	// check for update in container
-	containerResolv, err = readContainerFile(runningContainerID, "resolv.conf")
-	if err != nil {
-		c.Fatal(err)
-	}
+	containerResolv = readContainerFile(c, runningContainerID, "resolv.conf")
 	if !bytes.Equal(containerResolv, bytesResolvConf) {
 		c.Fatalf("Restarted container should have updated resolv.conf; expected %q, got %q", string(bytesResolvConf), string(containerResolv))
 	}
@@ -1545,11 +1531,7 @@ func (s *DockerSuite) TestRunResolvconfUpdate(c *check.C) {
 
 	// our first exited container ID should have been updated, but with default DNS
 	// after the cleanup of resolv.conf found only a localhost nameserver:
-	containerResolv, err = readContainerFile(containerID1, "resolv.conf")
-	if err != nil {
-		c.Fatal(err)
-	}
-
+	containerResolv = readContainerFile(c, containerID1, "resolv.conf")
 	expected := "\nnameserver 8.8.8.8\nnameserver 8.8.4.4\n"
 	if !bytes.Equal(containerResolv, []byte(expected)) {
 		c.Fatalf("Container does not have cleaned/replaced DNS in resolv.conf; expected %q, got %q", expected, string(containerResolv))
@@ -1582,10 +1564,7 @@ func (s *DockerSuite) TestRunResolvconfUpdate(c *check.C) {
 	dockerCmd(c, "start", "third")
 
 	// check for update in container
-	containerResolv, err = readContainerFile(containerID3, "resolv.conf")
-	if err != nil {
-		c.Fatal(err)
-	}
+	containerResolv = readContainerFile(c, containerID3, "resolv.conf")
 	if !bytes.Equal(containerResolv, bytesResolvConf) {
 		c.Fatalf("Stopped container does not have updated resolv.conf; expected\n%q\n got\n%q", tmpResolvConf, string(containerResolv))
 	}
@@ -2840,11 +2819,7 @@ func (s *DockerSuite) TestRunContainerWithRmFlagExitCodeNotEqualToZero(c *check.
 		c.Fatal("Expected docker run to fail", out, err)
 	}
 
-	out, err = getAllContainers()
-	if err != nil {
-		c.Fatal(out, err)
-	}
-
+	out = getAllContainers(c)
 	if out != "" {
 		c.Fatal("Expected not to have containers", out)
 	}
@@ -2857,11 +2832,7 @@ func (s *DockerSuite) TestRunContainerWithRmFlagCannotStartContainer(c *check.C)
 		c.Fatal("Expected docker run to fail", out, err)
 	}
 
-	out, err = getAllContainers()
-	if err != nil {
-		c.Fatal(out, err)
-	}
-
+	out = getAllContainers(c)
 	if out != "" {
 		c.Fatal("Expected not to have containers", out)
 	}

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/pkg/testutil"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 	"github.com/opencontainers/go-digest"
 )
@@ -37,10 +38,12 @@ func (s *DockerSuite) TestSaveXzAndLoadRepoStdout(c *check.C) {
 	c.Assert(err, checker.IsNil, check.Commentf("failed to save repo: %v %v", out, err))
 	deleteImages(repoName)
 
-	loadCmd := exec.Command(dockerBinary, "load")
-	loadCmd.Stdin = strings.NewReader(repoTarball)
-	out, _, err = runCommandWithOutput(loadCmd)
-	c.Assert(err, checker.NotNil, check.Commentf("expected error, but succeeded with no error and output: %v", out))
+	icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "load"},
+		Stdin:   strings.NewReader(repoTarball),
+	}).Assert(c, icmd.Expected{
+		ExitCode: 1,
+	})
 
 	after, _, err := dockerCmdWithError("inspect", repoName)
 	c.Assert(err, checker.NotNil, check.Commentf("the repo should not exist: %v", after))
@@ -65,10 +68,12 @@ func (s *DockerSuite) TestSaveXzGzAndLoadRepoStdout(c *check.C) {
 
 	deleteImages(repoName)
 
-	loadCmd := exec.Command(dockerBinary, "load")
-	loadCmd.Stdin = strings.NewReader(out)
-	out, _, err = runCommandWithOutput(loadCmd)
-	c.Assert(err, checker.NotNil, check.Commentf("expected error, but succeeded with no error and output: %v", out))
+	icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "load"},
+		Stdin:   strings.NewReader(out),
+	}).Assert(c, icmd.Expected{
+		ExitCode: 1,
+	})
 
 	after, _, err := dockerCmdWithError("inspect", repoName)
 	c.Assert(err, checker.NotNil, check.Commentf("the repo should not exist: %v", after))

--- a/integration-cli/docker_cli_save_load_unix_test.go
+++ b/integration-cli/docker_cli_save_load_unix_test.go
@@ -41,11 +41,10 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 
 	deleteImages(repoName)
 
-	loadCmd := exec.Command(dockerBinary, "load")
-	loadCmd.Stdin = tmpFile
-
-	out, _, err := runCommandWithOutput(loadCmd)
-	c.Assert(err, check.IsNil, check.Commentf(out))
+	icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "load"},
+		Stdin:   tmpFile,
+	}).Assert(c, icmd.Success)
 
 	after := inspectField(c, repoName, "Id")
 	after = strings.TrimRight(after, "\n")
@@ -67,7 +66,7 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 
 	n, err := pty.Read(buf)
 	c.Assert(err, check.IsNil) //could not read tty output
-	c.Assert(string(buf[:n]), checker.Contains, "Cowardly refusing", check.Commentf("help output is not being yielded", out))
+	c.Assert(string(buf[:n]), checker.Contains, "Cowardly refusing", check.Commentf("help output is not being yielded"))
 }
 
 func (s *DockerSuite) TestSaveAndLoadWithProgressBar(c *check.C) {


### PR DESCRIPTION
There is 5 calls left of `runCommandWithOutput`, that use StdinPipe that is not yet supported by icmd.

/cc @thaJeztah @dnephin @icecrime @AkihiroSuda @runcom @cpuguy83 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
