### PR TITLE
Fix incorrect `Scope` in `network ls/inspect` with duplicate network names

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -178,7 +178,7 @@ func (n *networkRouter) buildNetworkResource(nw libnetwork.Network) *types.Netwo
 	r.Created = info.Created()
 	r.Scope = info.Scope()
 	if n.cluster.IsManager() {
-		if _, err := n.cluster.GetNetwork(nw.Name()); err == nil {
+		if _, err := n.cluster.GetNetwork(nw.ID()); err == nil {
 			r.Scope = "swarm"
 		}
 	} else if info.Dynamic() {


### PR DESCRIPTION
**- What I did**

This fix tries to address the issue raised in comment https://github.com/docker/docker/issues/30242#issuecomment-273468307 where the `Scope` field always changed to `swarm` in the ouput of `docker network ls/inspect` when duplicate network name exists.

The reason for the issue was that `buildNetworkResource()` use network name
(which may not be unique) to check for the scope.

**- How I did it**

This fix fixes the issue by always use network ID in `buildNetworkResource()`.

**- How to verify it**

A test has been added. The test fails before the fix and passes after the fix.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![j3iz7jp](https://cloud.githubusercontent.com/assets/6932348/22071405/e9f69a0c-dd53-11e6-94f7-aa89ab7ca160.jpg)


This fix is related to #30242.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>