### PR TITLE
Make Docker automatically update hostname for Swarm node

### DIFF
--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -94,8 +94,9 @@ func (n *nodeRunner) start(conf nodeStartConfig) error {
 		control = filepath.Join(n.cluster.runtimeRoot, controlSocket)
 	}
 
+	// Hostname is not set here. Instead, it is obtained from
+	// the node description that is reported periodically
 	swarmnodeConfig := swarmnode.Config{
-		Hostname:           n.cluster.config.Name,
 		ForceNewCluster:    conf.forceNewCluster,
 		ListenControlAPI:   control,
 		ListenRemoteAPI:    conf.ListenAddr,


### PR DESCRIPTION
Signed-off-by: Nishant Totla <nishanttotla@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix #27173

**- How I did it**
The Swarm node config (`swarmnode.Config`) sets hostname and passes it to the node object, which in turn initializes hostname for the agent object. SwarmKit design makes sure that agent hostname always overrides what is reported by the machine. Currently, since the agent hostname is set at the time of node creation, any updates (reported in the future) are automatically discarded.

This PR ensures that the agent hostname is not set by Docker, and instead picked up from the hostname reported by the machine. As a result, SwarmKit's dynamic node update ticker picks up hostname changes and reports the correct hostname in `docker node ls` and `docker node inspect`.

**- How to verify it**
Start a single node Swarm, and check the hostname reported as part of `docker node ls`. Then change the machine hostname, and run `docker node ls` again.

**- Description for the changelog**
Automatically update Swarm node name when machine hostname changes

