### PR TITLE
distribution: Add text/html and application/json as image mediatypes

### DIFF
--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -23,7 +23,11 @@ import (
 var ImageTypes = []string{
 	schema2.MediaTypeImageConfig,
 	// Handle unexpected values from https://github.com/docker/distribution/issues/1621
+	// (see also https://github.com/docker/docker/issues/22378,
+	// https://github.com/docker/docker/issues/30083)
 	"application/octet-stream",
+	"application/json",
+	"text/html",
 	// Treat defaulted values as images, newer types cannot be implied
 	"",
 }


### PR DESCRIPTION
As noted by #30083, the new strict checking of mediatypes misses some
cases where earlier bugs caused nonstandard mediatypes to be stored in
manifests. Two of the known cases are `text/html` and `application/json`,
which were returned by certain registries and stored by earlier versions
of Docker. Add special cases for `text/html` and `application/json`.

cc @dmcgowan