### PR TITLE
add CheckDuplicate docs and logics in network

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6218,7 +6218,7 @@ paths:
                 description: "The network's name."
                 type: "string"
               CheckDuplicate:
-                description: "Check for networks with duplicate names."
+                description: "Check for networks with duplicate names. Since Network is primarily keyed based on a random ID and not on the name, and network name is strictly a user-friendly alias to the network which is uniquely identified using ID, there is no guaranteed way to check for duplicates. CheckDuplicate is there to provide a best effort checking of any networks which has the same name but it is not guaranteed to catch all name collisions."
                 type: "boolean"
               Driver:
                 description: "Name of the network driver plugin to use."

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -416,6 +416,13 @@ type EndpointResource struct {
 
 // NetworkCreate is the expected body of the "create network" http request message
 type NetworkCreate struct {
+	// Check for networks with duplicate names.
+	// Network is primarily keyed based on a random ID and not on the name.
+	// Network name is strictly a user-friendly alias to the network
+	// which is uniquely identified using ID.
+	// And there is no guaranteed way to check for duplicates.
+	// Option CheckDuplicate is there to provide a best effort checking of any networks
+	// which has the same name but it is not guaranteed to catch all name collisions.
 	CheckDuplicate bool
 	Driver         string
 	EnableIPv6     bool

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -248,6 +248,8 @@ func (daemon *Daemon) createNetwork(create types.NetworkCreateRequest, id string
 		}
 	}
 	if nw != nil {
+		// check if user defined CheckDuplicate, if set true, return err
+		// otherwise prepare a warning message
 		if create.CheckDuplicate {
 			return nil, libnetwork.NetworkNameError(create.Name)
 		}

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -2836,7 +2836,12 @@ Content-Type: application/json
 **JSON parameters**:
 
 - **Name** - The new network's name. this is a mandatory field
-- **CheckDuplicate** - Requests daemon to check for networks with same name. Defaults to `false`
+- **CheckDuplicate** - Requests daemon to check for networks with same name. Defaults to `false`.
+    Since Network is primarily keyed based on a random ID and not on the name, 
+    and network name is strictly a user-friendly alias to the network which is uniquely identified using ID, 
+    there is no guaranteed way to check for duplicates across a cluster of docker hosts. 
+    This parameter CheckDuplicate is there to provide a best effort checking of any networks 
+    which has the same name but it is not guaranteed to catch all name collisions.
 - **Driver** - Name of the network driver plugin to use. Defaults to `bridge` driver
 - **IPAM** - Optional custom IP scheme for the network
   - **Driver** - Name of the IPAM driver to use. Defaults to `default` driver

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -3165,7 +3165,12 @@ Content-Type: application/json
 **JSON parameters**:
 
 - **Name** - The new network's name. this is a mandatory field
-- **CheckDuplicate** - Requests daemon to check for networks with same name. Defaults to `false`
+- **CheckDuplicate** - Requests daemon to check for networks with same name. Defaults to `false`.
+    Since Network is primarily keyed based on a random ID and not on the name, 
+    and network name is strictly a user-friendly alias to the network 
+    which is uniquely identified using ID, there is no guaranteed way to check for duplicates. 
+    This parameter CheckDuplicate is there to provide a best effort checking of any networks 
+    which has the same name but it is not guaranteed to catch all name collisions.
 - **Driver** - Name of the network driver plugin to use. Defaults to `bridge` driver
 - **IPAM** - Optional custom IP scheme for the network
   - **Driver** - Name of the IPAM driver to use. Defaults to `default` driver

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -3279,7 +3279,12 @@ Content-Type: application/json
 **JSON parameters**:
 
 - **Name** - The new network's name. this is a mandatory field
-- **CheckDuplicate** - Requests daemon to check for networks with same name. Defaults to `false`
+- **CheckDuplicate** - Requests daemon to check for networks with same name. Defaults to `false`.
+    Since Network is primarily keyed based on a random ID and not on the name, 
+    and network name is strictly a user-friendly alias to the network 
+    which is uniquely identified using ID, there is no guaranteed way to check for duplicates. 
+    This parameter CheckDuplicate is there to provide a best effort checking of any networks 
+    which has the same name but it is not guaranteed to catch all name collisions.
 - **Driver** - Name of the network driver plugin to use. Defaults to `bridge` driver
 - **Internal** - Restrict external access to the network
 - **IPAM** - Optional custom IP scheme for the network

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -3344,7 +3344,12 @@ Content-Type: application/json
 **JSON parameters**:
 
 - **Name** - The new network's name. this is a mandatory field
-- **CheckDuplicate** - Requests daemon to check for networks with same name. Defaults to `false`
+- **CheckDuplicate** - Requests daemon to check for networks with same name. Defaults to `false`.
+    Since Network is primarily keyed based on a random ID and not on the name, 
+    and network name is strictly a user-friendly alias to the network 
+    which is uniquely identified using ID, there is no guaranteed way to check for duplicates. 
+    This parameter CheckDuplicate is there to provide a best effort checking of any networks 
+    which has the same name but it is not guaranteed to catch all name collisions.
 - **Driver** - Name of the network driver plugin to use. Defaults to `bridge` driver
 - **Internal** - Restrict external access to the network
 - **IPAM** - Optional custom IP scheme for the network


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

Recently I ran into network create option CheckDuplicate, and confused a lot. Related issues and PRs has : 
1. https://github.com/docker/docker/issues/18864 : discussed about the real meaning of CheckDuplicate
2. https://github.com/docker/docker/issues/30242 : one related bug and confusion

 This PR tries to make things consistent in API doc, struct definition and code implementation. PR also hopes to reduce the potential misunderstanding user and developers may have. 

This PR also reports a warning when creating a overlay network when there is already a bridge network with same name with CheckDuplicate false. Here is the two cases.

First Case:
Step 1, create a bridge network with name allen with CheckDuplicate false;
Step 2, create another bridge network with name allen with CheckDuplicate false.
In Step 2, we will get a warning from https://github.com/docker/docker/blob/master/daemon/network.go#L259-L262.

Second Case:
Step 1, create a bridge network with name allen with CheckDuplicate false;
Step 2, create overlay network with name allen with CheckDuplicate false.
In Step 2, we will never get a warning.

This PR also adds a warning for second case.

**- What I did**
1. add comments in CheckDuplicate field in definition;
2. add description in api docs, including swagger.yml;
3. add code logic to fix overlay network creation warning.

ping @mrjana @thaJeztah 
