### PR TITLE
Add bash completion for `dockerd --init` and `docker run|create --init`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1380,6 +1380,7 @@ _docker_container_run() {
 	local boolean_options="
 		--disable-content-trust=false
 		--help
+		--init
 		--interactive -i
 		--oom-kill-disable
 		--privileged
@@ -1736,6 +1737,7 @@ _docker_daemon() {
 		--experimental
 		--help
 		--icc=false
+		--init
 		--ip-forward=false
 		--ip-masq=false
 		--iptables=false


### PR DESCRIPTION
Fixes #30263 
Please schedule for 1.13.0
ping @sdurrheimer also missing in zsh completion
