### PR TITLE
Fix panic in `stats --format 'table {{.Name}}'` with no container

### DIFF
--- a/cli/command/formatter/stats.go
+++ b/cli/command/formatter/stats.go
@@ -145,8 +145,10 @@ func (c *containerStatsContext) Container() string {
 
 func (c *containerStatsContext) Name() string {
 	c.AddHeader(nameHeader)
-	name := c.s.Name[1:]
-	return name
+	if len(c.s.Name) == 0 {
+		return "--"
+	}
+	return c.s.Name[1:]
 }
 
 func (c *containerStatsContext) ID() string {


### PR DESCRIPTION
This fix fixes the issue in #30277 where `stats --format 'table {{.Name}}'` will panic when there is no container available.

The reason for the panic is becuse `c.s.Name[1:]` is out of bound.  When there is no container, the placeholder is only invoked for the header printout.

This fix fixes the issue.

This fix fixes #30277.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
