### PR TITLE
Add bash completion and docs for `docker run|create --init-path`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1335,6 +1335,7 @@ _docker_container_run() {
 		--expose
 		--group-add
 		--hostname -h
+		--init-path
 		--ip
 		--ip6
 		--ipc
@@ -1447,7 +1448,7 @@ _docker_container_run() {
 			__docker_complete_capabilities
 			return
 			;;
-		--cidfile|--env-file|--label-file)
+		--cidfile|--env-file|--init-path|--label-file)
 			_filedir
 			return
 			;;

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -63,6 +63,8 @@ Options:
       --health-timeout duration     Maximum time to allow one check to run (ns|us|ms|s|m|h) (default 0s)
       --help                        Print usage
   -h, --hostname string             Container host name
+      --init                        Run an init inside the container that forwards signals and reaps processes
+      --init-path string            Path to the docker-init binary
   -i, --interactive                 Keep STDIN open even if not attached
       --io-maxbandwidth string      Maximum IO bandwidth limit for the system drive (Windows only)
       --io-maxiops uint             Maximum IOps limit for the system drive (Windows only)

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -67,6 +67,8 @@ Options:
       --health-timeout duration     Maximum time to allow one check to run (ns|us|ms|s|m|h) (default 0s)
       --help                        Print usage
   -h, --hostname string             Container host name
+      --init                        Run an init inside the container that forwards signals and reaps processes
+      --init-path string            Path to the docker-init binary
   -i, --interactive                 Keep STDIN open even if not attached
       --io-maxbandwidth string      Maximum IO bandwidth limit for the system drive (Windows only)
                                     (Windows only). The format is `<number><unit>`.

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -41,6 +41,8 @@ docker-run - Run a command in a new container
 [**--group-add**[=*[]*]]
 [**-h**|**--hostname**[=*HOSTNAME*]]
 [**--help**]
+[**--init**]
+[**--init-path**[=*[]*]]
 [**-i**|**--interactive**]
 [**--ip**[=*IPv4-ADDRESS*]]
 [**--ip6**[=*IPv6-ADDRESS*]]
@@ -309,7 +311,13 @@ redirection on the host system.
    Sets the container host name that is available inside the container.
 
 **--help**
-  Print usage statement
+   Print usage statement
+
+**--init**
+   Run an init inside the container that forwards signals and reaps processes
+
+**--init-path**=""
+   Path to the docker-init binary
 
 **-i**, **--interactive**=*true*|*false*
    Keep STDIN open even if not attached. The default is *false*.


### PR DESCRIPTION
This adds
- bash completion and docs for `docker run|create --init-path`
- docs for `--init`