### PR TITLE
Non blocking attach clients

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -464,14 +464,15 @@ func (s *containerRouter) postContainersAttach(ctx context.Context, w http.Respo
 	}
 
 	attachConfig := &backend.ContainerAttachConfig{
-		GetStreams: setupStreams,
-		UseStdin:   httputils.BoolValue(r, "stdin"),
-		UseStdout:  httputils.BoolValue(r, "stdout"),
-		UseStderr:  httputils.BoolValue(r, "stderr"),
-		Logs:       httputils.BoolValue(r, "logs"),
-		Stream:     httputils.BoolValue(r, "stream"),
-		DetachKeys: detachKeys,
-		MuxStreams: true,
+		GetStreams:  setupStreams,
+		UseStdin:    httputils.BoolValue(r, "stdin"),
+		UseStdout:   httputils.BoolValue(r, "stdout"),
+		UseStderr:   httputils.BoolValue(r, "stderr"),
+		Logs:        httputils.BoolValue(r, "logs"),
+		Stream:      httputils.BoolValue(r, "stream"),
+		NonBlocking: httputils.BoolValue(r, "non-blocking"),
+		DetachKeys:  detachKeys,
+		MuxStreams:  true,
 	}
 
 	if err = s.backend.ContainerAttach(containerName, attachConfig); err != nil {

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3896,6 +3896,10 @@ paths:
           description: "Attach to `stderr`"
           type: "boolean"
           default: false
+        - name: "non-blocking"
+          type: "boolean"
+          default: false
+          description: "Do not block the container's stdio for slow attach client"
       tags: ["Container"]
   /containers/{id}/attach/ws:
     get:

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -23,6 +23,10 @@ type ContainerAttachConfig struct {
 	// HOWEVER, the websocket endpoint is using a single stream and SHOULD be encoded with stdout/stderr as is done for HTTP since it is still just a single stream.
 	// Since such a change is an API change unrelated to the current changeset we'll keep it as is here and change separately.
 	MuxStreams bool
+
+	// Specifies if a slow attached client should block the container's stdio.
+	// For historical reasons this is defaulted to false.
+	NonBlocking bool
 }
 
 // ContainerLogsConfig holds configs for logging operations. Exists

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -31,12 +31,13 @@ type CheckpointDeleteOptions struct {
 
 // ContainerAttachOptions holds parameters to attach to a container.
 type ContainerAttachOptions struct {
-	Stream     bool
-	Stdin      bool
-	Stdout     bool
-	Stderr     bool
-	DetachKeys string
-	Logs       bool
+	Stream      bool
+	Stdin       bool
+	Stdout      bool
+	Stderr      bool
+	DetachKeys  string
+	Logs        bool
+	NonBlocking bool
 }
 
 // ContainerCommitOptions holds parameters to commit changes into a container.

--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -15,6 +15,7 @@ import (
 )
 
 type attachOptions struct {
+	noBlock    bool
 	noStdin    bool
 	proxy      bool
 	detachKeys string
@@ -40,6 +41,7 @@ func NewAttachCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.BoolVar(&opts.noStdin, "no-stdin", false, "Do not attach STDIN")
 	flags.BoolVar(&opts.proxy, "sig-proxy", true, "Proxy all received signals to the process")
 	flags.StringVar(&opts.detachKeys, "detach-keys", "", "Override the key sequence for detaching a container")
+	flags.BoolVar(&opts.noBlock, "no-block", false, "Do not block container's stdio for attached client")
 	return cmd
 }
 
@@ -69,11 +71,12 @@ func runAttach(dockerCli *command.DockerCli, opts *attachOptions) error {
 	}
 
 	options := types.ContainerAttachOptions{
-		Stream:     true,
-		Stdin:      !opts.noStdin && c.Config.OpenStdin,
-		Stdout:     true,
-		Stderr:     true,
-		DetachKeys: dockerCli.ConfigFile().DetachKeys,
+		Stream:      true,
+		Stdin:       !opts.noStdin && c.Config.OpenStdin,
+		Stdout:      true,
+		Stderr:      true,
+		DetachKeys:  dockerCli.ConfigFile().DetachKeys,
+		NonBlocking: opts.noBlock,
 	}
 
 	var in io.ReadCloser

--- a/client/container_attach.go
+++ b/client/container_attach.go
@@ -31,6 +31,9 @@ func (cli *Client) ContainerAttach(ctx context.Context, container string, option
 	if options.Logs {
 		query.Set("logs", "1")
 	}
+	if options.NonBlocking {
+		query.Set("non-blocking", "1")
+	}
 
 	headers := map[string][]string{"Content-Type": {"text/plain"}}
 	return cli.postHijacked(ctx, "/containers/"+container+"/attach", query, nil, headers)

--- a/container/container.go
+++ b/container/container.go
@@ -31,7 +31,6 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/docker/docker/pkg/promise"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/docker/docker/restartmanager"
@@ -57,13 +56,6 @@ var (
 	errInvalidEndpoint = fmt.Errorf("invalid endpoint while building port map info")
 	errInvalidNetwork  = fmt.Errorf("invalid network settings while building port map info")
 )
-
-// DetachError is special error which returned in case of container detach.
-type DetachError struct{}
-
-func (DetachError) Error() string {
-	return "detached from container"
-}
 
 // CommonContainer holds the fields for a container which are
 // applicable across all platforms supported by the daemon.
@@ -373,183 +365,17 @@ func (container *Container) GetExecIDs() []string {
 	return container.ExecCommands.List()
 }
 
-// Attach connects to the container's TTY, delegating to standard
-// streams or websockets depending on the configuration.
-func (container *Container) Attach(stdin io.ReadCloser, stdout io.Writer, stderr io.Writer, keys []byte) chan error {
+// Attach connects to the container's stdio to the client streams
+func (container *Container) Attach(cfg *stream.AttachConfig) chan error {
 	ctx := container.InitAttachContext()
-	return AttachStreams(ctx, container.StreamConfig, container.Config.OpenStdin, container.Config.StdinOnce, container.Config.Tty, stdin, stdout, stderr, keys)
-}
 
-// AttachStreams connects streams to a TTY.
-// Used by exec too. Should this move somewhere else?
-func AttachStreams(ctx context.Context, streamConfig *stream.Config, openStdin, stdinOnce, tty bool, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer, keys []byte) chan error {
-	var (
-		cStdout, cStderr io.ReadCloser
-		cStdin           io.WriteCloser
-		wg               sync.WaitGroup
-		errors           = make(chan error, 3)
-	)
-
-	if stdin != nil && openStdin {
-		cStdin = streamConfig.StdinPipe()
-		wg.Add(1)
+	cfg.TTY = container.Config.Tty
+	if !container.Config.OpenStdin {
+		cfg.Stdin = nil
 	}
+	cfg.CloseStdin = cfg.Stdin != nil && container.Config.StdinOnce
 
-	if stdout != nil {
-		cStdout = streamConfig.StdoutPipe()
-		wg.Add(1)
-	}
-
-	if stderr != nil {
-		cStderr = streamConfig.StderrPipe()
-		wg.Add(1)
-	}
-
-	// Connect stdin of container to the http conn.
-	go func() {
-		if stdin == nil || !openStdin {
-			return
-		}
-		logrus.Debug("attach: stdin: begin")
-
-		var err error
-		if tty {
-			_, err = copyEscapable(cStdin, stdin, keys)
-		} else {
-			_, err = io.Copy(cStdin, stdin)
-		}
-		if err == io.ErrClosedPipe {
-			err = nil
-		}
-		if err != nil {
-			logrus.Errorf("attach: stdin: %s", err)
-			errors <- err
-		}
-		if stdinOnce && !tty {
-			cStdin.Close()
-		} else {
-			// No matter what, when stdin is closed (io.Copy unblock), close stdout and stderr
-			if cStdout != nil {
-				cStdout.Close()
-			}
-			if cStderr != nil {
-				cStderr.Close()
-			}
-		}
-		logrus.Debug("attach: stdin: end")
-		wg.Done()
-	}()
-
-	attachStream := func(name string, stream io.Writer, streamPipe io.ReadCloser) {
-		if stream == nil {
-			return
-		}
-
-		logrus.Debugf("attach: %s: begin", name)
-		_, err := io.Copy(stream, streamPipe)
-		if err == io.ErrClosedPipe {
-			err = nil
-		}
-		if err != nil {
-			logrus.Errorf("attach: %s: %v", name, err)
-			errors <- err
-		}
-		// Make sure stdin gets closed
-		if stdin != nil {
-			stdin.Close()
-		}
-		streamPipe.Close()
-		logrus.Debugf("attach: %s: end", name)
-		wg.Done()
-	}
-
-	go attachStream("stdout", stdout, cStdout)
-	go attachStream("stderr", stderr, cStderr)
-
-	return promise.Go(func() error {
-		done := make(chan struct{})
-		go func() {
-			wg.Wait()
-			close(done)
-		}()
-		select {
-		case <-done:
-		case <-ctx.Done():
-			// close all pipes
-			if cStdin != nil {
-				cStdin.Close()
-			}
-			if cStdout != nil {
-				cStdout.Close()
-			}
-			if cStderr != nil {
-				cStderr.Close()
-			}
-			<-done
-		}
-		close(errors)
-		for err := range errors {
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-}
-
-// Code c/c from io.Copy() modified to handle escape sequence
-func copyEscapable(dst io.Writer, src io.ReadCloser, keys []byte) (written int64, err error) {
-	if len(keys) == 0 {
-		// Default keys : ctrl-p ctrl-q
-		keys = []byte{16, 17}
-	}
-	buf := make([]byte, 32*1024)
-	for {
-		nr, er := src.Read(buf)
-		if nr > 0 {
-			// ---- Docker addition
-			preservBuf := []byte{}
-			for i, key := range keys {
-				preservBuf = append(preservBuf, buf[0:nr]...)
-				if nr != 1 || buf[0] != key {
-					break
-				}
-				if i == len(keys)-1 {
-					src.Close()
-					return 0, DetachError{}
-				}
-				nr, er = src.Read(buf)
-			}
-			var nw int
-			var ew error
-			if len(preservBuf) > 0 {
-				nw, ew = dst.Write(preservBuf)
-				nr = len(preservBuf)
-			} else {
-				// ---- End of docker
-				nw, ew = dst.Write(buf[0:nr])
-			}
-			if nw > 0 {
-				written += int64(nw)
-			}
-			if ew != nil {
-				err = ew
-				break
-			}
-			if nr != nw {
-				err = io.ErrShortWrite
-				break
-			}
-		}
-		if er == io.EOF {
-			break
-		}
-		if er != nil {
-			err = er
-			break
-		}
-	}
-	return written, err
+	return container.StreamConfig.Attach(ctx, cfg)
 }
 
 // ShouldRestart decides whether the daemon should restart the container or not.

--- a/container/stream/attach.go
+++ b/container/stream/attach.go
@@ -1,0 +1,208 @@
+package stream
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/promise"
+)
+
+// DetachError is special error which returned in case of container detach.
+type DetachError struct{}
+
+func (DetachError) Error() string {
+	return "detached from container"
+}
+
+// AttachConfig is the config struct used to attach a client to a stream's stdio
+type AttachConfig struct {
+	// Tells the attach copier that the stream's stdin is a TTY and to look for
+	// escape sequences in stdin to detach from the stream.
+	// When true the escape sequence is not passed to the underlying stream
+	TTY bool
+	// Specifies the detach keys the client will be using
+	// Only useful when `TTY` is true
+	DetachKeys []byte
+
+	// CloseStdin signals that once done, stdin for the attached stream should be closed
+	// For example, this would close the attached container's stdin.
+	CloseStdin bool
+
+	// Provide client streams to wire up to
+	Stdin          io.ReadCloser
+	Stdout, Stderr io.Writer
+}
+
+// Attach attaches the stream config to the streams specified in
+// the AttachOptions
+func (c *Config) Attach(ctx context.Context, cfg *AttachConfig) chan error {
+	var (
+		cStdout, cStderr io.ReadCloser
+		cStdin           io.WriteCloser
+		wg               sync.WaitGroup
+		errors           = make(chan error, 3)
+	)
+
+	if cfg.Stdin != nil {
+		cStdin = c.StdinPipe()
+		wg.Add(1)
+	}
+
+	if cfg.Stdout != nil {
+		cStdout = c.StdoutPipe()
+		wg.Add(1)
+	}
+
+	if cfg.Stderr != nil {
+		cStderr = c.StderrPipe()
+		wg.Add(1)
+	}
+
+	// Connect stdin of container to the http conn.
+	go func() {
+		if cfg.Stdin == nil {
+			return
+		}
+		logrus.Debug("attach: stdin: begin")
+
+		var err error
+		if cfg.TTY {
+			_, err = copyEscapable(cStdin, cfg.Stdin, cfg.DetachKeys)
+		} else {
+			_, err = io.Copy(cStdin, cfg.Stdin)
+		}
+		if err == io.ErrClosedPipe {
+			err = nil
+		}
+		if err != nil {
+			logrus.Errorf("attach: stdin: %s", err)
+			errors <- err
+		}
+		if cfg.CloseStdin && !cfg.TTY {
+			cStdin.Close()
+		} else {
+			// No matter what, when stdin is closed (io.Copy unblock), close stdout and stderr
+			if cStdout != nil {
+				cStdout.Close()
+			}
+			if cStderr != nil {
+				cStderr.Close()
+			}
+		}
+		logrus.Debug("attach: stdin: end")
+		wg.Done()
+	}()
+
+	attachStream := func(name string, stream io.Writer, streamPipe io.ReadCloser) {
+		if stream == nil {
+			return
+		}
+
+		logrus.Debugf("attach: %s: begin", name)
+		_, err := io.Copy(stream, streamPipe)
+		if err == io.ErrClosedPipe {
+			err = nil
+		}
+		if err != nil {
+			logrus.Errorf("attach: %s: %v", name, err)
+			errors <- err
+		}
+		// Make sure stdin gets closed
+		if cfg.Stdin != nil {
+			cfg.Stdin.Close()
+		}
+		streamPipe.Close()
+		logrus.Debugf("attach: %s: end", name)
+		wg.Done()
+	}
+
+	go attachStream("stdout", cfg.Stdout, cStdout)
+	go attachStream("stderr", cfg.Stderr, cStderr)
+
+	return promise.Go(func() error {
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-ctx.Done():
+			// close all pipes
+			if cStdin != nil {
+				cStdin.Close()
+			}
+			if cStdout != nil {
+				cStdout.Close()
+			}
+			if cStderr != nil {
+				cStderr.Close()
+			}
+			<-done
+		}
+		close(errors)
+		for err := range errors {
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// Code c/c from io.Copy() modified to handle escape sequence
+func copyEscapable(dst io.Writer, src io.ReadCloser, keys []byte) (written int64, err error) {
+	if len(keys) == 0 {
+		// Default keys : ctrl-p ctrl-q
+		keys = []byte{16, 17}
+	}
+	buf := make([]byte, 32*1024)
+	for {
+		nr, er := src.Read(buf)
+		if nr > 0 {
+			// ---- Docker addition
+			preservBuf := []byte{}
+			for i, key := range keys {
+				preservBuf = append(preservBuf, buf[0:nr]...)
+				if nr != 1 || buf[0] != key {
+					break
+				}
+				if i == len(keys)-1 {
+					src.Close()
+					return 0, DetachError{}
+				}
+				nr, er = src.Read(buf)
+			}
+			var nw int
+			var ew error
+			if len(preservBuf) > 0 {
+				nw, ew = dst.Write(preservBuf)
+				nr = len(preservBuf)
+			} else {
+				// ---- End of docker
+				nw, ew = dst.Write(buf[0:nr])
+			}
+			if nw > 0 {
+				written += int64(nw)
+			}
+			if ew != nil {
+				err = ew
+				break
+			}
+			if nr != nw {
+				err = io.ErrShortWrite
+				break
+			}
+		}
+		if er == io.EOF {
+			break
+		}
+		if er != nil {
+			err = er
+			break
+		}
+	}
+	return written, err
+}

--- a/container/stream/attach.go
+++ b/container/stream/attach.go
@@ -26,6 +26,14 @@ type AttachConfig struct {
 	// Only useful when `TTY` is true
 	DetachKeys []byte
 
+	// Sets the mode to non-blocking, which means that none of the stream's stdio
+	// can be blocked by a slow attach client.
+	// This is deaulted to false for historical reasons.
+	// When true if the stream is not consumed quickly enough, the oldest messages
+	// will be dropped.
+	// When false the IO stream is blocked when not consumed quickly enough.
+	NonBlocking bool
+
 	// CloseStdin signals that once done, stdin for the attached stream should be closed
 	// For example, this would close the attached container's stdin.
 	CloseStdin bool

--- a/container/stream/streams.go
+++ b/container/stream/streams.go
@@ -62,6 +62,7 @@ func (c *Config) StdinPipe() io.WriteCloser {
 
 // StdoutPipe creates a new io.ReadCloser with an empty bytes pipe.
 // It adds this new out pipe to the Stdout broadcaster.
+// This will block stdout if unconsumed.
 func (c *Config) StdoutPipe() io.ReadCloser {
 	bytesPipe := ioutils.NewBytesPipe()
 	c.stdout.Add(bytesPipe)
@@ -70,6 +71,7 @@ func (c *Config) StdoutPipe() io.ReadCloser {
 
 // StderrPipe creates a new io.ReadCloser with an empty bytes pipe.
 // It adds this new err pipe to the Stderr broadcaster.
+// This will block stderr if unconsumed.
 func (c *Config) StderrPipe() io.ReadCloser {
 	bytesPipe := ioutils.NewBytesPipe()
 	c.stderr.Add(bytesPipe)

--- a/container/stream/streams.go
+++ b/container/stream/streams.go
@@ -69,6 +69,17 @@ func (c *Config) StdoutPipe() io.ReadCloser {
 	return bytesPipe
 }
 
+// StdoutBuffer creates a new io.ReadCloser with an empty buffer
+// It adds this to the stdout broadcaster
+// If the buffer is full the oldest data in the buffer will be dumped to make
+// room for new writes.
+// This cannot block stdout.
+func (c *Config) StdoutBuffer() io.ReadCloser {
+	bp := ioutils.NewBytesPipe(ioutils.WithNonBlockingWrites)
+	c.stdout.Add(bp)
+	return bp
+}
+
 // StderrPipe creates a new io.ReadCloser with an empty bytes pipe.
 // It adds this new err pipe to the Stderr broadcaster.
 // This will block stderr if unconsumed.
@@ -76,6 +87,17 @@ func (c *Config) StderrPipe() io.ReadCloser {
 	bytesPipe := ioutils.NewBytesPipe()
 	c.stderr.Add(bytesPipe)
 	return bytesPipe
+}
+
+// StderrBuffer creates a new io.ReadCloser with an empty buffer
+// It adds this to the stdout broadcaster
+// If the buffer is full the oldest data in the buffer will be dumped to make
+// room for new writes.
+// This cannot block stderr.
+func (c *Config) StderrBuffer() io.ReadCloser {
+	bp := ioutils.NewBytesPipe(ioutils.WithNonBlockingWrites)
+	c.stderr.Add(bp)
+	return bp
 }
 
 // NewInputPipes creates new pipes for both standard inputs, Stdin and StdinPipe.

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -9,10 +9,19 @@ import (
 	"github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/container/stream"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/pkg/term"
 )
+
+type containerAttachConfig struct {
+	detachKeys     []byte
+	stdin          io.ReadCloser
+	stdout, stderr io.Writer
+	showHistory    bool
+	stream         bool
+}
 
 // ContainerAttach attaches to logs according to the config passed in. See ContainerAttachConfig.
 func (daemon *Daemon) ContainerAttach(prefixOrName string, c *backend.ContainerAttachConfig) error {
@@ -45,20 +54,23 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, c *backend.ContainerA
 		outStream = stdcopy.NewStdWriter(outStream, stdcopy.Stdout)
 	}
 
-	var stdin io.ReadCloser
-	var stdout, stderr io.Writer
+	var cfg containerAttachConfig
 
 	if c.UseStdin {
-		stdin = inStream
+		cfg.stdin = inStream
 	}
 	if c.UseStdout {
-		stdout = outStream
+		cfg.stdout = outStream
 	}
 	if c.UseStderr {
-		stderr = errStream
+		cfg.stderr = errStream
 	}
 
-	if err := daemon.containerAttach(container, stdin, stdout, stderr, c.Logs, c.Stream, keys); err != nil {
+	cfg.showHistory = c.Logs
+	cfg.stream = c.Stream
+	cfg.detachKeys = keys
+
+	if err := daemon.containerAttach(container, &cfg); err != nil {
 		fmt.Fprintf(outStream, "Error attaching: %s\n", err)
 	}
 	return nil
@@ -70,11 +82,20 @@ func (daemon *Daemon) ContainerAttachRaw(prefixOrName string, stdin io.ReadClose
 	if err != nil {
 		return err
 	}
-	return daemon.containerAttach(container, stdin, stdout, stderr, false, stream, nil)
+	cfg := &containerAttachConfig{
+		stdin:  stdin,
+		stdout: stdout,
+		stderr: stderr,
+		stream: stream,
+	}
+	return daemon.containerAttach(container, cfg)
 }
 
-func (daemon *Daemon) containerAttach(c *container.Container, stdin io.ReadCloser, stdout, stderr io.Writer, logs, stream bool, keys []byte) error {
-	if logs {
+func (daemon *Daemon) containerAttach(c *container.Container, cfg *containerAttachConfig) error {
+	stdin := cfg.stdin
+	stdout := cfg.stdout
+	stderr := cfg.stderr
+	if cfg.showHistory {
 		logDriver, err := daemon.getLogger(c)
 		if err != nil {
 			return err
@@ -107,41 +128,47 @@ func (daemon *Daemon) containerAttach(c *container.Container, stdin io.ReadClose
 
 	daemon.LogContainerEvent(c, "attach")
 
-	//stream
-	if stream {
-		var stdinPipe io.ReadCloser
-		if stdin != nil {
-			r, w := io.Pipe()
-			go func() {
-				defer w.Close()
-				defer logrus.Debug("Closing buffered stdin pipe")
-				io.Copy(w, stdin)
-			}()
-			stdinPipe = r
-		}
+	if !cfg.stream {
+		return nil
+	}
 
-		waitChan := make(chan struct{})
-		if c.Config.StdinOnce && !c.Config.Tty {
-			go func() {
-				c.WaitStop(-1 * time.Second)
-				close(waitChan)
-			}()
-		}
+	var stdinPipe io.ReadCloser
+	if stdin != nil {
+		r, w := io.Pipe()
+		go func() {
+			defer w.Close()
+			defer logrus.Debug("Closing buffered stdin pipe")
+			io.Copy(w, stdin)
+		}()
+		stdinPipe = r
+	}
 
-		err := <-c.Attach(stdinPipe, stdout, stderr, keys)
-		if err != nil {
-			if _, ok := err.(container.DetachError); ok {
-				daemon.LogContainerEvent(c, "detach")
-			} else {
-				logrus.Errorf("attach failed with error: %v", err)
-			}
-		}
-
-		// If we are in stdinonce mode, wait for the process to end
-		// otherwise, simply return
-		if c.Config.StdinOnce && !c.Config.Tty {
+	waitChan := make(chan struct{})
+	if c.Config.StdinOnce && !c.Config.Tty {
+		defer func() {
 			<-waitChan
+		}()
+		go func() {
+			c.WaitStop(-1 * time.Second)
+			close(waitChan)
+		}()
+	}
+
+	aCfg := &stream.AttachConfig{
+		Stdin:       stdinPipe,
+		Stdout:      stdout,
+		Stderr:      stderr,
+		DetachKeys:  cfg.detachKeys,
+	}
+
+	err := <-c.Attach(aCfg)
+	if err != nil {
+		if _, ok := err.(stream.DetachError); ok {
+			daemon.LogContainerEvent(c, "detach")
+		} else {
+			logrus.Errorf("attach failed with error: %v", err)
 		}
 	}
+
 	return nil
 }

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -19,6 +19,7 @@ type containerAttachConfig struct {
 	detachKeys     []byte
 	stdin          io.ReadCloser
 	stdout, stderr io.Writer
+	nonBlocking    bool
 	showHistory    bool
 	stream         bool
 }
@@ -69,6 +70,7 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, c *backend.ContainerA
 	cfg.showHistory = c.Logs
 	cfg.stream = c.Stream
 	cfg.detachKeys = keys
+	cfg.nonBlocking = c.NonBlocking
 
 	if err := daemon.containerAttach(container, &cfg); err != nil {
 		fmt.Fprintf(outStream, "Error attaching: %s\n", err)
@@ -159,6 +161,7 @@ func (daemon *Daemon) containerAttach(c *container.Container, cfg *containerAtta
 		Stdout:      stdout,
 		Stderr:      stderr,
 		DetachKeys:  cfg.detachKeys,
+		NonBlocking: cfg.nonBlocking,
 	}
 
 	err := <-c.Attach(aCfg)

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/container/stream"
 	"github.com/docker/docker/daemon/exec"
 	"github.com/docker/docker/libcontainerd"
 	"github.com/docker/docker/pkg/pools"
@@ -209,7 +210,15 @@ func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.R
 		return err
 	}
 
-	attachErr := container.AttachStreams(ctx, ec.StreamConfig, ec.OpenStdin, true, ec.Tty, cStdin, cStdout, cStderr, ec.DetachKeys)
+	attachConfig := &stream.AttachConfig{
+		TTY:        ec.Tty,
+		Stdin:      cStdin,
+		Stdout:     cStdout,
+		Stderr:     cStderr,
+		DetachKeys: ec.DetachKeys,
+		CloseStdin: true,
+	}
+	attachErr := ec.StreamConfig.Attach(ctx, attachConfig)
 
 	systemPid, err := d.containerd.AddProcess(ctx, c.ID, name, p, ec.InitializeStdio)
 	if err != nil {
@@ -233,7 +242,7 @@ func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.R
 		return fmt.Errorf("context cancelled")
 	case err := <-attachErr:
 		if err != nil {
-			if _, ok := err.(container.DetachError); !ok {
+			if _, ok := err.(stream.DetachError); !ok {
 				return fmt.Errorf("exec attach failed with error: %v", err)
 			}
 			d.LogContainerEvent(c, "exec_detach")

--- a/docs/reference/commandline/attach.md
+++ b/docs/reference/commandline/attach.md
@@ -24,6 +24,7 @@ Options:
       --detach-keys string   Override the key sequence for detaching a container
       --help                 Print usage
       --no-stdin             Do not attach STDIN
+      --no-block             Do not block the container's stdio
       --sig-proxy            Proxy all received signals to the process (default true)
 ```
 


### PR DESCRIPTION
Enables clients that may be slow or prefer not to block the container's stdio to opt for dropping data over blocking stdio of the container.

This is especially useful for remote clients that may have a connection interruptions or are otherwise too slow to consume all the data produced by the container before the stdio buffers are full.

Note that to keep my sanity while adding this I did some code cleanup for `AttachStreams`.
As such there are 3 commits:
1. Adds non-blocking mode to BytesPipe
2. Cleans up some of the attach code
3. Plumbs through non-blocking options from clients.

ping @aaronlehmann 
Related (in spirit) to #28762