### PR TITLE
Carry #27834 — Do not require `.git` in the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ bundles
 .gopath
 vendor/pkg
 .go-pkg-cache
+.git

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 bundles
+integration-cli/bundles
 .gopath
 vendor/pkg
 .go-pkg-cache

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 bundles
-integration-cli/bundles
 .gopath
 vendor/pkg
 .go-pkg-cache

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -71,8 +71,9 @@
 #
 # 4. Build the docker executable binaries by running one of the following:
 #
-#    >>   docker run --name binaries nativebuildimage hack\make.ps1 -Binary
-#    >>   docker run --name binaries -m 2GB nativebuildimage hack\make.ps1 -Binary    (if using Hyper-V containers)
+#    >>   $DOCKER_GITCOMMIT=(git rev-parse --short HEAD)
+#    >>   docker run --name binaries -e DOCKER_GITCOMMIT=$DOCKER_GITCOMMIT nativebuildimage hack\make.ps1 -Binary
+#    >>   docker run --name binaries -e DOCKER_GITCOMMIT=$DOCKER_GITCOMMIT -m 2GB nativebuildimage hack\make.ps1 -Binary    (if using Hyper-V containers)
 #
 #
 # 5. Copy the binaries out of the container, replacing HostPath with an appropriate destination 
@@ -98,18 +99,13 @@
 # -----------------------------------------------------------------------------------------
 
 
-#  The validation tests can either run in a container, or directly on the host. To run in a
-#  container, ensure you have created the nativebuildimage above. Then run one of the
-#  following from an (elevated) Windows PowerShell prompt:
-#
-#    >>   docker run --rm nativebuildimage hack\make.ps1 -DCO -PkgImports -GoFormat
-#    >>   docker run --rm -m 2GB nativebuildimage hack\make.ps1 -DCO -PkgImports -GoFormat    (if using Hyper-V containers)
-
-# To run the validation tests on the host, from the root of the repository, run the
-# following from a Windows PowerShell prompt (elevation is not required): (Note Go
-# must be installed to run these tests)
+#  The validation tests can only run directly on the host. This is because they calculate
+#  information from the git repo, but the .git directory is not passed into the image as
+#  it is excluded via .dockerignore. Run the following from a Windows PowerShell prompt
+#  (elevation is not required): (Note Go must be installed to run these tests)
 #
 #    >>   hack\make.ps1 -DCO -PkgImports -GoFormat
+
 
 # -----------------------------------------------------------------------------------------
 
@@ -124,7 +120,7 @@
 # -----------------------------------------------------------------------------------------
 
 
-#  To run all tests and binary build, ensure you have created the nativebuildimage above. Then 
+#  To run unit tests and binary build, ensure you have created the nativebuildimage above. Then 
 #  run one of the following from an (elevated) Windows PowerShell prompt:
 #
 #    >>   docker run nativebuildimage hack\make.ps1 -All

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ DOCKER_MOUNT := $(if $(BIND_DIR),-v "$(CURDIR)/$(BIND_DIR):/go/src/github.com/do
 # This allows the test suite to be able to run without worrying about the underlying fs used by the container running the daemon (e.g. aufs-on-aufs), so long as the host running the container is running a supported fs.
 # The volume will be cleaned up when the container is removed due to `--rm`.
 # Note that `BIND_DIR` will already be set to `bundles` if `DOCKER_HOST` is not set (see above BIND_DIR line), in such case this will do nothing since `DOCKER_MOUNT` will already be set.
-DOCKER_MOUNT := $(if $(DOCKER_MOUNT),$(DOCKER_MOUNT),-v /go/src/github.com/docker/docker/bundles)
+DOCKER_MOUNT := $(if $(DOCKER_MOUNT),$(DOCKER_MOUNT),-v /go/src/github.com/docker/docker/bundles) -v $(CURDIR)/.git:/go/src/github.com/docker/docker/.git
 
 # This allows to set the docker-dev container name
 DOCKER_CONTAINER_NAME := $(if $(CONTAINER_NAME),--name $(CONTAINER_NAME),)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ export DOCKER_INCREMENTAL_BINARY
 DOCKER_OSARCH := $(shell bash -c 'source hack/make/.detect-daemon-osarch && echo $${DOCKER_ENGINE_OSARCH:-$$DOCKER_CLIENT_OSARCH}')
 DOCKERFILE := $(shell bash -c 'source hack/make/.detect-daemon-osarch && echo $${DOCKERFILE}')
 
+DOCKER_GITCOMMIT := $(shell git rev-parse --short HEAD || echo unsupported)
+export DOCKER_GITCOMMIT
+
 # env vars passed through directly to Docker's build scripts
 # to allow things like `make KEEPBUNDLE=1 binary` easily
 # `project/PACKAGERS.md` have some limited documentation of some of these

--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -21,7 +21,7 @@
                 "hack\make.ps1 -Client" to build just the client 64-bit binary
                 "hack\make.ps1 -TestUnit" to run unit tests
                 "hack\make.ps1 -Binary -TestUnit" to build the binaries and run unit tests
-                "hack\make.ps1 -All" to run everything this script knows about
+                "hack\make.ps1 -All" to run everything this script knows about that can run in a container
 
 .PARAMETER Client
      Builds the client binaries.
@@ -48,24 +48,23 @@
      Adds a custom string to be appended to the commit ID (spaces are stripped).
 
 .PARAMETER DCO
-     Runs the DCO (Developer Certificate Of Origin) test.
+     Runs the DCO (Developer Certificate Of Origin) test (must be run outside a container).
 
 .PARAMETER PkgImports
-     Runs the pkg\ directory imports test.
+     Runs the pkg\ directory imports test (must be run outside a container).
 
 .PARAMETER GoFormat
-     Runs the Go formatting test.
+     Runs the Go formatting test (must be run outside a container).
 
 .PARAMETER TestUnit
      Runs unit tests.
 
 .PARAMETER All
-     Runs everything this script knows about.
+     Runs everything this script knows about that can run in a container.
 
 
 TODO
 - Unify the head commit
-- Sort out the GITCOMMIT environment variable in the absence of a .git (longer term)
 - Add golint and other checks (swagger maybe?)
 
 #>
@@ -314,7 +313,9 @@ Try {
     Push-Location $root
 
     # Handle the "-All" shortcut to turn on all things we can handle.
-    if ($All) { $Client=$True; $Daemon=$True; $DCO=$True; $PkgImports=$True; $GoFormat=$True; $TestUnit=$True }
+    # Note we expressly only include the items which can run in a container - the validations tests cannot
+    # as they require the .git directory which is excluded from the image by .dockerignore
+    if ($All) { $Client=$True; $Daemon=$True; $TestUnit=$True }
 
     # Handle the "-Binary" shortcut to build both client and daemon.
     if ($Binary) { $Client = $True; $Daemon = $True }

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -85,7 +85,6 @@ elif command -v git &> /dev/null && [ -d .git ] && git rev-parse &> /dev/null; t
 		git status --porcelain --untracked-files=no
 		echo "#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 	fi
-	! BUILDTIME=$(date --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/') &> /dev/null
 else
 	echo >&2 'error: .git directory missing and DOCKER_GITCOMMIT not specified'
 	echo >&2 '  Please either build with the .git directory accessible, or specify the'

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -70,7 +70,9 @@ DEFAULT_BUNDLES=(
 
 VERSION=$(< ./VERSION)
 ! BUILDTIME=$(date --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
-if command -v git &> /dev/null && [ -d .git ] && git rev-parse &> /dev/null; then
+if [ "$DOCKER_GITCOMMIT" ]; then
+	GITCOMMIT="$DOCKER_GITCOMMIT"
+elif command -v git &> /dev/null && [ -d .git ] && git rev-parse &> /dev/null; then
 	GITCOMMIT=$(git rev-parse --short HEAD)
 	if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 		GITCOMMIT="$GITCOMMIT-unsupported"
@@ -83,8 +85,7 @@ if command -v git &> /dev/null && [ -d .git ] && git rev-parse &> /dev/null; the
 		git status --porcelain --untracked-files=no
 		echo "#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 	fi
-elif [ "$DOCKER_GITCOMMIT" ]; then
-	GITCOMMIT="$DOCKER_GITCOMMIT"
+	! BUILDTIME=$(date --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/') &> /dev/null
 else
 	echo >&2 'error: .git directory missing and DOCKER_GITCOMMIT not specified'
 	echo >&2 '  Please either build with the .git directory accessible, or specify the'


### PR DESCRIPTION
Carry #27834 and hopefully fixes builds :angel:.

- Add `.git` to `.dockerignore`
- export DOCKER_GITCOMMIT in the Makefile
- prioritize DOCKER_GITCOMMIT against the `git` command in
  `./hack/make.sh`
- Also add `integration-cli/bundles` to gitignore (it's generated when
  using integration-cli shell)

Note that, on my laptop for example, I'm sending `30M` of context with this, and `150M` without :scream_cat:, so I really think this can be a huge win :angel: 

/cc @tianon @jhowardmsft @icecrime @thaJeztah @cpuguy83 

:frog: 