### PR TITLE
Fix failure in `docker ps --format` when `.Label` has args

### DIFF
--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -73,6 +73,12 @@ func (o listOptionsProcessor) Size() bool {
 	return true
 }
 
+// Label is needed here as it allows the correct pre-processing
+// because Label() is a method with arguments
+func (o listOptionsProcessor) Label(name string) string {
+	return ""
+}
+
 func buildContainerListOptions(opts *psOptions) (*types.ContainerListOptions, error) {
 	options := &types.ContainerListOptions{
 		All:     opts.all,

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -917,3 +917,10 @@ func (s *DockerSuite) TestPsFilterMissingArgErrorCode(c *check.C) {
 	_, errCode, _ := dockerCmdWithError("ps", "--filter")
 	c.Assert(errCode, checker.Equals, 125)
 }
+
+// Test case for 30291
+func (s *DockerSuite) TestPsFormatTemplateWithArg(c *check.C) {
+	runSleepingContainer(c, "-d", "--name", "top", "--label", "some.label=label.foo-bar")
+	out, _ := dockerCmd(c, "ps", "--format", `{{.Names}} {{.Label "some.label"}}`)
+	c.Assert(strings.TrimSpace(out), checker.Equals, "top label.foo-bar")
+}


### PR DESCRIPTION
This fix tries to fix the issue in #30279 where  `docker ps --format` fails if `.Label` has args. For example:
```
docker ps --format '{{.ID}}\t{{.Names}}\t{{.Label "some.label"}}'
```

The reason for the failure is that during the preprocessing phase to detect the existance of `.Size`, the `listOptionsProcessor` does not has a method of `Label(name string) string`.

This results in the failure of
```
template: :1:24: executing "" at <.Label>: Label is not a method but has arguments
```

This fix fixes the issue by adding needed method of `Label(name string) string`.

This fix fixes #30279.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>