### PR TITLE
Adding text/html as an accepted media type for configs.  

### DIFF
--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -24,6 +24,8 @@ var ImageTypes = []string{
 	schema2.MediaTypeImageConfig,
 	// Handle unexpected values from https://github.com/docker/distribution/issues/1621
 	"application/octet-stream",
+	// Handle unexpected values from https://github.com/docker/distribution/issues/22378
+	"text/html",
 	// Treat defaulted values as images, newer types cannot be implied
 	"",
 }


### PR DESCRIPTION
Images pushed from docker versions 1.10.0 to 1.11.0 resulted in manifests containing "text/html" media type for config. This was fixed in 1.11.1 as per #22378. So adding "text/html" to the values for config media type. Fixes #30083 

Signed-off-by: Pooja Wagh <poojashah@google.com>


