### PR TITLE
1.13.1 rc1 cherrypicks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,7 @@ RUN set -x \
 # IMPORTANT: If the version of Go is updated, the Windows to Linux CI machines
 #            will need updating, to avoid errors. Ping #docker-maintainers on IRC
 #            with a heads-up.
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
 	| tar -xzC /usr/local
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -97,7 +97,7 @@ RUN set -x \
 # so we use gccgo as bootstrap to build Go from source code.
 # We don't use the official ARMv6 released binaries as a GOROOT_BOOTSTRAP, because
 # not all ARM64 platforms support 32-bit mode. 32-bit mode is optional for ARMv8.
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN mkdir /usr/src/go && curl -fsSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/src/go -xz --strip-components=1 \
 	&& cd /usr/src/go/src \
 	&& GOOS=linux GOARCH=arm64 GOROOT_BOOTSTRAP="$(go env GOROOT)" ./make.bash

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -72,7 +72,7 @@ RUN cd /usr/local/lvm2 \
 # See https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
 # Install Go
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" \
 	| tar -xzC /usr/local
 ENV PATH /go/bin:/usr/local/go/bin:$PATH

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -15,8 +15,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-# ppc64le/golang is a debian:jessie based image with golang installed
-FROM ppc64le/golang:1.6.3
+FROM ppc64le/debian:jessie
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org
@@ -95,25 +94,12 @@ RUN set -x \
 
 
 # Install Go
-# ppc64le doesn't have official go binaries, so use the version of go installed from the image
-# to build go from source.
-# NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
+# NOTE: official ppc64le go binaries weren't available until go 1.6.4 and 1.7.4
 ENV GO_VERSION 1.7.4
-ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" \
+	| tar -xzC /usr/local
 
-RUN set -x \
-	&& TEMPDIR="$(mktemp -d)" \
-	&& mv /usr/local/go $TEMPDIR \
-	&& GOROOT_BOOTSTRAP=$TEMPDIR/go \
-	&& cd /usr/local \
-	&& curl -fsSL "$GO_DOWNLOAD_URL" -o golang.tar.gz \
-	&& tar -C /usr/local -xzf golang.tar.gz \
-	&& rm golang.tar.gz \
-	&& cd go/src && ./make.bash 2>&1 \
-	&& rm -rf $TEMPDIR
-
-ENV GOROOT_BOOTSTRAP /usr/local/go
-ENV PATH /usr/local/go/bin/:$PATH
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 
 # Dependency for golint

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -98,7 +98,7 @@ RUN set -x \
 # ppc64le doesn't have official go binaries, so use the version of go installed from the image
 # to build go from source.
 # NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
 
 RUN set -x \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -97,7 +97,7 @@ RUN cd /usr/local/lvm2 \
 	&& make install_device-mapper
 # See https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" \
 	| tar -xzC /usr/local
 

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -55,7 +55,7 @@ RUN set -x \
 # IMPORTANT: If the version of Go is updated, the Windows to Linux CI machines
 #            will need updating, to avoid errors. Ping #docker-maintainers on IRC
 #            with a heads-up.
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
 	| tar -xzC /usr/local
 ENV PATH /go/bin:/usr/local/go/bin:$PATH

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -165,7 +165,7 @@ SHELL ["powershell", "-command"]
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
-ENV GO_VERSION=1.7.3 `
+ENV GO_VERSION=1.7.4 `
     GIT_VERSION=2.10.2 `
     GOPATH=C:\go `
     FROM_DOCKERFILE=1

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -166,7 +166,7 @@ SHELL ["powershell", "-command"]
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
 ENV GO_VERSION=1.7.4 `
-    GIT_VERSION=2.10.2 `
+    GIT_VERSION=2.11.0 `
     GOPATH=C:\go `
     FROM_DOCKERFILE=1
 

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -163,7 +163,7 @@ func (n *networkRouter) buildNetworkResource(nw libnetwork.Network) *types.Netwo
 	r.Created = info.Created()
 	r.Scope = info.Scope()
 	if n.clusterProvider.IsManager() {
-		if _, err := n.clusterProvider.GetNetwork(nw.Name()); err == nil {
+		if _, err := n.clusterProvider.GetNetwork(nw.ID()); err == nil {
 			r.Scope = "swarm"
 		}
 	} else if info.Dynamic() {

--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -74,6 +74,12 @@ func (o listOptionsProcessor) Size() bool {
 	return true
 }
 
+// Label is needed here as it allows the correct pre-processing
+// because Label() is a method with arguments
+func (o listOptionsProcessor) Label(name string) string {
+	return ""
+}
+
 func buildContainerListOptions(opts *psOptions) (*types.ContainerListOptions, error) {
 	options := &types.ContainerListOptions{
 		All:     opts.all,

--- a/cli/command/formatter/disk_usage.go
+++ b/cli/command/formatter/disk_usage.go
@@ -192,7 +192,10 @@ func (c *diskUsageImagesContext) Reclaimable() string {
 	c.AddHeader(reclaimableHeader)
 	for _, i := range c.images {
 		if i.Containers != 0 {
-			used += i.Size
+			if i.VirtualSize == -1 || i.SharedSize == -1 {
+				continue
+			}
+			used += i.VirtualSize - i.SharedSize
 		}
 	}
 

--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -103,22 +103,58 @@ func inspectPlugin(ctx context.Context, dockerCli *command.DockerCli) inspect.Ge
 
 func inspectAll(ctx context.Context, dockerCli *command.DockerCli, getSize bool, typeConstraint string) inspect.GetRefFunc {
 	var inspectAutodetect = []struct {
-		ObjectType      string
-		IsSizeSupported bool
-		ObjectInspector func(string) (interface{}, []byte, error)
+		objectType      string
+		isSizeSupported bool
+		isSwarmObject   bool
+		objectInspector func(string) (interface{}, []byte, error)
 	}{
-		{"container", true, inspectContainers(ctx, dockerCli, getSize)},
-		{"image", false, inspectImages(ctx, dockerCli)},
-		{"network", false, inspectNetwork(ctx, dockerCli)},
-		{"volume", false, inspectVolume(ctx, dockerCli)},
-		{"service", false, inspectService(ctx, dockerCli)},
-		{"task", false, inspectTasks(ctx, dockerCli)},
-		{"node", false, inspectNode(ctx, dockerCli)},
-		{"plugin", false, inspectPlugin(ctx, dockerCli)},
+		{
+			objectType:      "container",
+			isSizeSupported: true,
+			objectInspector: inspectContainers(ctx, dockerCli, getSize),
+		},
+		{
+			objectType:      "image",
+			objectInspector: inspectImages(ctx, dockerCli),
+		},
+		{
+			objectType:      "network",
+			objectInspector: inspectNetwork(ctx, dockerCli),
+		},
+		{
+			objectType:      "volume",
+			objectInspector: inspectVolume(ctx, dockerCli),
+		},
+		{
+			objectType:      "service",
+			isSwarmObject:   true,
+			objectInspector: inspectService(ctx, dockerCli),
+		},
+		{
+			objectType:      "task",
+			isSwarmObject:   true,
+			objectInspector: inspectTasks(ctx, dockerCli),
+		},
+		{
+			objectType:      "node",
+			isSwarmObject:   true,
+			objectInspector: inspectNode(ctx, dockerCli),
+		},
+		{
+			objectType:      "plugin",
+			objectInspector: inspectPlugin(ctx, dockerCli),
+		},
 	}
 
-	isErrNotSwarmManager := func(err error) bool {
-		return strings.Contains(err.Error(), "This node is not a swarm manager")
+	// isSwarmManager does an Info API call to verify that the daemon is
+	// a swarm manager.
+	isSwarmManager := func() bool {
+		info, err := dockerCli.Client().Info(ctx)
+		if err != nil {
+			fmt.Fprintln(dockerCli.Err(), err)
+			return false
+		}
+		return info.Swarm.ControlAvailable
 	}
 
 	isErrNotSupported := func(err error) bool {
@@ -126,19 +162,39 @@ func inspectAll(ctx context.Context, dockerCli *command.DockerCli, getSize bool,
 	}
 
 	return func(ref string) (interface{}, []byte, error) {
+		const (
+			swarmSupportUnknown = iota
+			swarmSupported
+			swarmUnsupported
+		)
+
+		isSwarmSupported := swarmSupportUnknown
+
 		for _, inspectData := range inspectAutodetect {
-			if typeConstraint != "" && inspectData.ObjectType != typeConstraint {
+			if typeConstraint != "" && inspectData.objectType != typeConstraint {
 				continue
 			}
-			v, raw, err := inspectData.ObjectInspector(ref)
+			if typeConstraint == "" && inspectData.isSwarmObject {
+				if isSwarmSupported == swarmSupportUnknown {
+					if isSwarmManager() {
+						isSwarmSupported = swarmSupported
+					} else {
+						isSwarmSupported = swarmUnsupported
+					}
+				}
+				if isSwarmSupported == swarmUnsupported {
+					continue
+				}
+			}
+			v, raw, err := inspectData.objectInspector(ref)
 			if err != nil {
-				if typeConstraint == "" && (apiclient.IsErrNotFound(err) || isErrNotSwarmManager(err) || isErrNotSupported(err)) {
+				if typeConstraint == "" && (apiclient.IsErrNotFound(err) || isErrNotSupported(err)) {
 					continue
 				}
 				return v, raw, err
 			}
-			if getSize && !inspectData.IsSizeSupported {
-				fmt.Fprintf(dockerCli.Err(), "WARNING: --size ignored for %s\n", inspectData.ObjectType)
+			if getSize && !inspectData.isSizeSupported {
+				fmt.Fprintf(dockerCli.Err(), "WARNING: --size ignored for %s\n", inspectData.objectType)
 			}
 			return v, raw, err
 		}

--- a/cmd/dockerd/service_windows.go
+++ b/cmd/dockerd/service_windows.go
@@ -13,6 +13,7 @@ import (
 	"unsafe"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/system"
 	"github.com/spf13/pflag"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
@@ -165,10 +166,20 @@ func registerService() error {
 		return err
 	}
 	defer m.Disconnect()
+
+	depends := []string{}
+
+	// This dependency is required on build 14393 (RS1)
+	// it is added to the platform in newer builds
+	if system.GetOSVersion().Build == 14393 {
+		depends = append(depends, "ConDrv")
+	}
+
 	c := mgr.Config{
 		ServiceType:  windows.SERVICE_WIN32_OWN_PROCESS,
 		StartType:    mgr.StartAutomatic,
 		ErrorControl: mgr.ErrorNormal,
+		Dependencies: depends,
 		DisplayName:  "Docker Engine",
 	}
 

--- a/contrib/builder/deb/aarch64/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/aarch64/ubuntu-trusty/Dockerfile
@@ -11,7 +11,7 @@ RUN update-alternatives --install /usr/bin/go go /usr/lib/go-1.6/bin/go 100
 # Install Go
 # aarch64 doesn't have official go binaries, so use the version of go installed from
 # the image to build go from source.
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN mkdir /usr/src/go && curl -fsSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/src/go -xz --strip-components=1 \
 	&& cd /usr/src/go/src \
 	&& GOOS=linux GOARCH=arm64 GOROOT_BOOTSTRAP="$(go env GOROOT)" ./make.bash

--- a/contrib/builder/deb/aarch64/ubuntu-xenial/Dockerfile
+++ b/contrib/builder/deb/aarch64/ubuntu-xenial/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools bu
 # Install Go
 # aarch64 doesn't have official go binaries, so use the version of go installed from
 # the image to build go from source.
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN mkdir /usr/src/go && curl -fsSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/src/go -xz --strip-components=1 \
 	&& cd /usr/src/go/src \
 	&& GOOS=linux GOARCH=arm64 GOROOT_BOOTSTRAP="$(go env GOROOT)" ./make.bash

--- a/contrib/builder/deb/amd64/debian-jessie/Dockerfile
+++ b/contrib/builder/deb/amd64/debian-jessie/Dockerfile
@@ -10,7 +10,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/amd64/debian-stretch/Dockerfile
+++ b/contrib/builder/deb/amd64/debian-stretch/Dockerfile
@@ -10,7 +10,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev libsqlite3-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/amd64/debian-wheezy/Dockerfile
+++ b/contrib/builder/deb/amd64/debian-wheezy/Dockerfile
@@ -12,7 +12,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list.d
 RUN apt-get update && apt-get install -y -t wheezy-backports btrfs-tools --no-install-recommends && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install -y apparmor bash-completion  build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config vim-common --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/amd64/ubuntu-precise/Dockerfile
+++ b/contrib/builder/deb/amd64/ubuntu-precise/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:precise
 
 RUN apt-get update && apt-get install -y apparmor bash-completion  build-essential cmake curl ca-certificates debhelper dh-apparmor  git libapparmor-dev  libltdl-dev  libsqlite3-dev pkg-config vim-common --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/amd64/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/amd64/ubuntu-trusty/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:trusty
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/amd64/ubuntu-xenial/Dockerfile
+++ b/contrib/builder/deb/amd64/ubuntu-xenial/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev libsqlite3-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/amd64/ubuntu-yakkety/Dockerfile
+++ b/contrib/builder/deb/amd64/ubuntu-yakkety/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:yakkety
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev libsqlite3-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/armhf/debian-jessie/Dockerfile
+++ b/contrib/builder/deb/armhf/debian-jessie/Dockerfile
@@ -10,7 +10,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/armhf/raspbian-jessie/Dockerfile
+++ b/contrib/builder/deb/armhf/raspbian-jessie/Dockerfile
@@ -10,7 +10,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 # GOARM is the ARM architecture version which is unrelated to the above Golang version
 ENV GOARM 6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/deb/armhf/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/armhf/ubuntu-trusty/Dockerfile
@@ -6,7 +6,7 @@ FROM armhf/ubuntu:trusty
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/armhf/ubuntu-xenial/Dockerfile
+++ b/contrib/builder/deb/armhf/ubuntu-xenial/Dockerfile
@@ -6,7 +6,7 @@ FROM armhf/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev libsqlite3-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/armhf/ubuntu-yakkety/Dockerfile
+++ b/contrib/builder/deb/armhf/ubuntu-yakkety/Dockerfile
@@ -6,7 +6,7 @@ FROM armhf/ubuntu:yakkety
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev libsqlite3-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/ppc64le/generate.sh
+++ b/contrib/builder/deb/ppc64le/generate.sh
@@ -59,22 +59,12 @@ for version in "${versions[@]}"; do
 		vim-common # tini dep
 	)
 
-	# trusty uses a different go package name then xenial and newer, so track that for later
-	goPackage=
 	case "$suite" in
 		trusty) 
-			# ppc64le doesn't have go binaries, so install go to bootstrap go
-			# trusty doesn't have a ppc64le golang-go package
-			packages+=( golang-1.6 )
-			goPackage='golang-1.6'
-
 			packages+=( libsystemd-journal-dev )
 			;;
 		*)
 			# libseccomp isn't available until ubuntu xenial and is required for "seccomp.h" & "libseccomp.so"
-			packages+=( golang-go )
-			goPackage='golang-go'
-
 			packages+=( libseccomp-dev )
 			packages+=( libsystemd-dev )
 			;;
@@ -98,25 +88,8 @@ for version in "${versions[@]}"; do
 	echo "RUN apt-get update && apt-get install -y ${packages[*]} --no-install-recommends && rm -rf /var/lib/apt/lists/*" >> "$version/Dockerfile"
 	echo >> "$version/Dockerfile"
 
-	# ppc64le doesn't have an official downloadable binary as of go 1.6.2. so use the
-	# older packaged go(v1.6.1) to bootstrap latest go, then remove the packaged go
-	echo "# Install Go" >> "$version/Dockerfile"
-	echo "# ppc64le doesn't have official go binaries, so use a distro packaged version of go" >> "$version/Dockerfile"
-	echo "# to build go from source." >> "$version/Dockerfile"
-	echo "# NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6" >> "$version/Dockerfile"
-	
 	awk '$1 == "ENV" && $2 == "GO_VERSION" { print; exit }' ../../../../Dockerfile.ppc64le >> "$version/Dockerfile"
-	echo 'ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz' >> "$version/Dockerfile"
-	echo 'ENV GOROOT_BOOTSTRAP /usr/lib/go-1.6' >> "$version/Dockerfile"
-	echo >> "$version/Dockerfile"
-	
-	echo 'RUN curl -fsSL "$GO_DOWNLOAD_URL" -o golang.tar.gz \' >> "$version/Dockerfile"
-	echo '	&& tar -C /usr/local -xzf golang.tar.gz \' >> "$version/Dockerfile"
-	echo '	&& rm golang.tar.gz \' >> "$version/Dockerfile"
-	echo '	&& cd /usr/local/go/src && ./make.bash 2>&1 \' >> "$version/Dockerfile"
-	echo "	&& apt-get purge -y $goPackage && apt-get autoremove -y" >> "$version/Dockerfile"
-	echo >> "$version/Dockerfile"
-
+	echo 'RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local' >> "$version/Dockerfile"
 	echo 'ENV PATH $PATH:/usr/local/go/bin' >> "$version/Dockerfile"
 	echo >> "$version/Dockerfile"
 

--- a/contrib/builder/deb/ppc64le/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/ppc64le/ubuntu-trusty/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools bu
 # ppc64le doesn't have official go binaries, so use a distro packaged version of go
 # to build go from source.
 # NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
 ENV GOROOT_BOOTSTRAP /usr/lib/go-1.6
 

--- a/contrib/builder/deb/ppc64le/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/ppc64le/ubuntu-trusty/Dockerfile
@@ -4,22 +4,10 @@
 
 FROM ppc64le/ubuntu:trusty
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config vim-common golang-1.6 libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# Install Go
-# ppc64le doesn't have official go binaries, so use a distro packaged version of go
-# to build go from source.
-# NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
 ENV GO_VERSION 1.7.4
-ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
-ENV GOROOT_BOOTSTRAP /usr/lib/go-1.6
-
-RUN curl -fsSL "$GO_DOWNLOAD_URL" -o golang.tar.gz \
-	&& tar -C /usr/local -xzf golang.tar.gz \
-	&& rm golang.tar.gz \
-	&& cd /usr/local/go/src && ./make.bash 2>&1 \
-	&& apt-get purge -y golang-1.6 && apt-get autoremove -y
-
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1

--- a/contrib/builder/deb/ppc64le/ubuntu-xenial/Dockerfile
+++ b/contrib/builder/deb/ppc64le/ubuntu-xenial/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools bu
 # ppc64le doesn't have official go binaries, so use a distro packaged version of go
 # to build go from source.
 # NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
 ENV GOROOT_BOOTSTRAP /usr/lib/go-1.6
 

--- a/contrib/builder/deb/ppc64le/ubuntu-xenial/Dockerfile
+++ b/contrib/builder/deb/ppc64le/ubuntu-xenial/Dockerfile
@@ -4,22 +4,10 @@
 
 FROM ppc64le/ubuntu:xenial
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config vim-common golang-go libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config vim-common libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# Install Go
-# ppc64le doesn't have official go binaries, so use a distro packaged version of go
-# to build go from source.
-# NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
 ENV GO_VERSION 1.7.4
-ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
-ENV GOROOT_BOOTSTRAP /usr/lib/go-1.6
-
-RUN curl -fsSL "$GO_DOWNLOAD_URL" -o golang.tar.gz \
-	&& tar -C /usr/local -xzf golang.tar.gz \
-	&& rm golang.tar.gz \
-	&& cd /usr/local/go/src && ./make.bash 2>&1 \
-	&& apt-get purge -y golang-go && apt-get autoremove -y
-
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1

--- a/contrib/builder/deb/ppc64le/ubuntu-yakkety/Dockerfile
+++ b/contrib/builder/deb/ppc64le/ubuntu-yakkety/Dockerfile
@@ -4,22 +4,10 @@
 
 FROM ppc64le/ubuntu:yakkety
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config vim-common golang-go libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config vim-common libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# Install Go
-# ppc64le doesn't have official go binaries, so use a distro packaged version of go
-# to build go from source.
-# NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
 ENV GO_VERSION 1.7.4
-ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
-ENV GOROOT_BOOTSTRAP /usr/lib/go-1.6
-
-RUN curl -fsSL "$GO_DOWNLOAD_URL" -o golang.tar.gz \
-	&& tar -C /usr/local -xzf golang.tar.gz \
-	&& rm golang.tar.gz \
-	&& cd /usr/local/go/src && ./make.bash 2>&1 \
-	&& apt-get purge -y golang-go && apt-get autoremove -y
-
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1

--- a/contrib/builder/deb/ppc64le/ubuntu-yakkety/Dockerfile
+++ b/contrib/builder/deb/ppc64le/ubuntu-yakkety/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools bu
 # ppc64le doesn't have official go binaries, so use a distro packaged version of go
 # to build go from source.
 # NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
 ENV GOROOT_BOOTSTRAP /usr/lib/go-1.6
 

--- a/contrib/builder/deb/s390x/ubuntu-xenial/Dockerfile
+++ b/contrib/builder/deb/s390x/ubuntu-xenial/Dockerfile
@@ -6,7 +6,7 @@ FROM s390x/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev libsqlite3-dev pkg-config libsystemd-dev vim-common --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/amd64/centos-7/Dockerfile
+++ b/contrib/builder/rpm/amd64/centos-7/Dockerfile
@@ -8,7 +8,7 @@ RUN yum groupinstall -y "Development Tools"
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
 RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/amd64/fedora-24/Dockerfile
+++ b/contrib/builder/rpm/amd64/fedora-24/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/amd64/fedora-25/Dockerfile
+++ b/contrib/builder/rpm/amd64/fedora-25/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/amd64/opensuse-13.2/Dockerfile
+++ b/contrib/builder/rpm/amd64/opensuse-13.2/Dockerfile
@@ -7,7 +7,7 @@ FROM opensuse:13.2
 RUN zypper --non-interactive install ca-certificates* curl gzip rpm-build
 RUN zypper --non-interactive install libbtrfs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel pkg-config selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim systemd-rpm-macros
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/amd64/oraclelinux-6/Dockerfile
+++ b/contrib/builder/rpm/amd64/oraclelinux-6/Dockerfile
@@ -10,7 +10,7 @@ RUN yum install -y kernel-uek-devel-4.1.12-32.el6uek
 RUN yum groupinstall -y "Development Tools"
 RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel  tar git cmake vim-common
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/amd64/oraclelinux-7/Dockerfile
+++ b/contrib/builder/rpm/amd64/oraclelinux-7/Dockerfile
@@ -7,7 +7,7 @@ FROM oraclelinux:7
 RUN yum groupinstall -y "Development Tools"
 RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/amd64/photon-1.0/Dockerfile
+++ b/contrib/builder/rpm/amd64/photon-1.0/Dockerfile
@@ -7,7 +7,7 @@ FROM photon:1.0
 RUN tdnf install -y wget curl ca-certificates gzip make rpm-build sed gcc linux-api-headers glibc-devel binutils libseccomp libltdl-devel elfutils
 RUN tdnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkg-config selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1372,6 +1372,7 @@ _docker_container_run() {
 	local boolean_options="
 		--disable-content-trust=false
 		--help
+		--init
 		--interactive -i
 		--oom-kill-disable
 		--privileged
@@ -1728,6 +1729,7 @@ _docker_daemon() {
 		--experimental
 		--help
 		--icc=false
+		--init
 		--ip-forward=false
 		--ip-masq=false
 		--iptables=false

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3972,11 +3972,30 @@ _docker() {
 	local previous_extglob_setting=$(shopt -p extglob)
 	shopt -s extglob
 
-	local commands=(
-		attach
-		build
-		commit
+	local management_commands=(
 		container
+		image
+		network
+		node
+		plugin
+		secret
+		service
+		stack
+		system
+		volume
+	)
+
+	local top_level_commands=(
+		build
+		login
+		logout
+		run
+		search
+		version
+	)
+
+	local legacy_commands=(
+		commit
 		cp
 		create
 		diff
@@ -3984,20 +4003,14 @@ _docker() {
 		exec
 		export
 		history
-		image
 		images
 		import
 		info
 		inspect
 		kill
 		load
-		login
-		logout
 		logs
-		network
-		node
 		pause
-		plugin
 		port
 		ps
 		pull
@@ -4006,29 +4019,23 @@ _docker() {
 		restart
 		rm
 		rmi
-		run
 		save
-		search
-		secret
-		service
-		stack
 		start
 		stats
 		stop
 		swarm
-		system
 		tag
 		top
 		unpause
 		update
-		version
-		volume
 		wait
 	)
 
 	local experimental_commands=(
 		deploy
 	)
+
+	local commands=(${management_commands[*]} ${top_level_commands[*]} ${DOCKER_HIDE_LEGACY_COMMANDS:+${legacy_commands[*]}})
 
 	# These options are valid as global options for all client commands
 	# and valid as command options for `docker daemon`

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2006,6 +2006,7 @@ _docker_image_build() {
 		--quiet -q
 		--rm
 	"
+	__docker_is_experimental && boolean_options+="--squash"
 
 	local all_options="$options_with_args $boolean_options"
 

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2910,6 +2910,8 @@ _docker_swarm() {
 		join
 		join-token
 		leave
+		unlock
+		unlock-key
 		update
 	"
 	__docker_subcommands "$subcommands" && return
@@ -3006,6 +3008,22 @@ _docker_swarm_leave() {
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "--force -f --help" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_swarm_unlock() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_swarm_unlock-key() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help --quiet -q --rotate" -- "$cur" ) )
 			;;
 	esac
 }

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3320,7 +3320,7 @@ _docker_plugin_install() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--alias --disable --grant-all-permissions --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--alias --disable --disable-content-trust=false --grant-all-permissions --help" -- "$cur" ) )
 			;;
 	esac
 }

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1327,6 +1327,7 @@ _docker_container_run() {
 		--expose
 		--group-add
 		--hostname -h
+		--init-path
 		--ip
 		--ip6
 		--ipc
@@ -1439,7 +1440,7 @@ _docker_container_run() {
 			__docker_complete_capabilities
 			return
 			;;
-		--cidfile|--env-file|--label-file)
+		--cidfile|--env-file|--init-path|--label-file)
 			_filedir
 			return
 			;;

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2686,11 +2686,15 @@ _docker_service_ps() {
 			__docker_complete_services --cur "${cur##*=}" --name
 			return
 			;;
+		node)
+			__docker_complete_nodes_plus_self --cur "${cur##*=}"
+			return
+			;;
 	esac
 
 	case "$prev" in
 		--filter|-f)
-			COMPREPLY=( $( compgen -W "desired-state id name" -S = -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "desired-state id name node" -S = -- "$cur" ) )
 			__docker_nospace
 			return
 			;;

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2937,6 +2937,13 @@ _docker_swarm_init() {
 			fi
 			return
 			;;
+		--availability)
+			COMPREPLY=( $( compgen -W "active drain pause" -- "$cur" ) )
+			return
+			;;
+		--cert-expiry|--dispatcher-heartbeat|--external-ca|--max-snapshots|--snapshot-interval|--task-history-limit)
+			return
+			;;
 		--listen-addr)
 			if [[ $cur == *: ]] ; then
 				COMPREPLY=( $( compgen -W "2377" -- "${cur##*:}" ) )
@@ -2950,7 +2957,7 @@ _docker_swarm_init() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--advertise-addr --force-new-cluster --help --listen-addr" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--advertise-addr --autolock --availability --cert-expiry --dispatcher-heartbeat --external-ca --force-new-cluster --help --listen-addr --max-snapshots --snapshot-interval --task-history-limit" -- "$cur" ) )
 			;;
 	esac
 }
@@ -3030,14 +3037,14 @@ _docker_swarm_unlock-key() {
 
 _docker_swarm_update() {
 	case "$prev" in
-		--cert-expiry|--dispatcher-heartbeat|--max-snapshots|--snapshot-interval|--task-history-limit)
+		--cert-expiry|--dispatcher-heartbeat|--external-ca|--max-snapshots|--snapshot-interval|--task-history-limit)
 			return
 			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--cert-expiry --dispatcher-heartbeat --help --max-snapshots --snapshot-interval --task-history-limit" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--autolock --cert-expiry --dispatcher-heartbeat --external-ca --help --max-snapshots --snapshot-interval --task-history-limit" -- "$cur" ) )
 			;;
 	esac
 }

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -361,18 +361,33 @@ __docker_complete_stacks() {
 # An optional first option `--id|--name` may be used to limit the
 # output to the IDs or names of matching items. This setting takes
 # precedence over the environment setting.
+# Completions may be added with `--add`, e.g. `--add self`.
 __docker_nodes() {
+	local add=()
 	local fields='$2'  # default: node name only
 	[ "${DOCKER_COMPLETION_SHOW_NODE_IDS}" = yes ] && fields='$1,$2' # ID and name
 
-	if [ "$1" = "--id" ] ; then
-		fields='$1' # IDs only
-		shift
-	elif [ "$1" = "--name" ] ; then
-		fields='$2' # names only
-		shift
-	fi
-	__docker_q node ls "$@" | tr -d '*' | awk "NR>1 {print $fields}"
+	while true ; do
+		case "$1" in
+			--id)
+				fields='$1' # IDs only
+				shift
+				;;
+			--name)
+				fields='$2' # names only
+				shift
+				;;
+			--add)
+				add+=("$2")
+				shift 2
+				;;
+			*)
+				break
+				;;
+		esac
+	done
+
+	echo $(__docker_q node ls "$@" | tr -d '*' | awk "NR>1 {print $fields}") "${add[@]}"
 }
 
 # __docker_complete_nodes applies completion of nodes based on the current
@@ -388,8 +403,7 @@ __docker_complete_nodes() {
 }
 
 __docker_complete_nodes_plus_self() {
-	__docker_complete_nodes "$@"
-	COMPREPLY+=( self )
+	__docker_complete_nodes --add self "$@"
 }
 
 # __docker_services returns a list of all services. Additional options to

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4035,7 +4035,8 @@ _docker() {
 		deploy
 	)
 
-	local commands=(${management_commands[*]} ${top_level_commands[*]} ${DOCKER_HIDE_LEGACY_COMMANDS:+${legacy_commands[*]}})
+	local commands=(${management_commands[*]} ${top_level_commands[*]})
+	[ -z "$DOCKER_HIDE_LEGACY_COMMANDS" ] && commands+=(${legacy_commands[*]})
 
 	# These options are valid as global options for all client commands
 	# and valid as command options for `docker daemon`

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2734,7 +2734,6 @@ _docker_service_update() {
 		--mount
 		--network
 		--no-healthcheck
-		--publish -p
 		--replicas
 		--reserve-cpu
 		--reserve-memory
@@ -2772,7 +2771,7 @@ _docker_service_update() {
 			--host
 			--mode
 			--name
-			--publish
+			--publish -p
 			--secret
 		"
 

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1611,7 +1611,7 @@ __docker_secret_subcommand() {
 
     case "$words[1]" in
         (create)
-            _arguments $(__docker_arguments) \
+            _arguments $(__docker_arguments) -A '-*' \
                 $opts_help \
                 "($help)*"{-l=,--label=}"[Secret labels]:label: " \
                 "($help -):secret: " && ret=0
@@ -2083,9 +2083,10 @@ __docker_swarm_subcommand() {
                 "($help)--task-history-limit=[Task history retention limit]:limit: " && ret=0
             ;;
         (join)
-            _arguments $(__docker_arguments) \
+            _arguments $(__docker_arguments) -A '-*' \
                 $opts_help \
-                "($help)--advertise-addr[Advertised address]:ip\:port: " \
+                "($help)--advertise-addr=[Advertised address]:ip\:port: " \
+                "($help)--availability=[Availability of the node]:availability:(active drain pause)" \
                 "($help)--listen-addr=[Listen address]:ip\:port: " \
                 "($help)--token=[Token for entry into the swarm]:secret: " \
                 "($help -):host\:port: " && ret=0
@@ -2516,14 +2517,14 @@ __docker_subcommand() {
             esac
             ;;
         (login)
-            _arguments $(__docker_arguments) \
+            _arguments $(__docker_arguments) -A '-*' \
                 $opts_help \
                 "($help -p --password)"{-p=,--password=}"[Password]:password: " \
                 "($help -u --user)"{-u=,--user=}"[Username]:username: " \
                 "($help -)1:server: " && ret=0
             ;;
         (logout)
-            _arguments $(__docker_arguments) \
+            _arguments $(__docker_arguments) -A '-*' \
                 $opts_help \
                 "($help -)1:server: " && ret=0
             ;;
@@ -2587,7 +2588,7 @@ __docker_subcommand() {
             __docker_image_subcommand && ret=0
             ;;
         (search)
-            _arguments $(__docker_arguments) \
+            _arguments $(__docker_arguments) -A '-*' \
                 $opts_help \
                 "($help)*"{-f=,--filter=}"[Filter values]:filter:->filter-options" \
                 "($help)--limit=[Maximum returned search results]:limit:(1 5 10 25 50)" \

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -561,7 +561,7 @@ __docker_container_subcommand() {
         "($help)*--group=[Set one or more supplementary user groups for the container]:group:_groups"
         "($help -h --hostname)"{-h=,--hostname=}"[Container host name]:hostname:_hosts"
         "($help -i --interactive)"{-i,--interactive}"[Keep stdin open even if not attached]"
-        "($help)--init[Run an init inside the container that forwards signals and reaps processes]" \
+        "($help)--init[Run an init inside the container that forwards signals and reaps processes]"
         "($help)--ip=[Container IPv4 address]:IPv4: "
         "($help)--ip6=[Container IPv6 address]:IPv6: "
         "($help)--ipc=[IPC namespace to use]:IPC namespace: "

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -474,6 +474,26 @@ __docker_complete_events_filter() {
     return ret
 }
 
+__docker_complete_prune_filters() {
+    [[ $PREFIX = -* ]] && return 1
+    integer ret=1
+    declare -a opts
+
+    opts=('until')
+
+    if compset -P '*='; then
+        case "${${words[-1]%=*}#*=}" in
+            *)
+                _message 'value' && ret=0
+                ;;
+        esac
+    else
+        _describe -t filter-opts "filter options" opts -qS "=" && ret=0
+    fi
+
+    return ret
+}
+
 # BO container
 
 __docker_container_commands() {
@@ -731,6 +751,7 @@ __docker_container_subcommand() {
         (prune)
             _arguments $(__docker_arguments) \
                 $opts_help \
+                "($help)*--filter=[Filter values]:filter:__docker_complete_prune_filters" \
                 "($help -f --force)"{-f,--force}"[Do not prompt for confirmation]" && ret=0
             ;;
         (rename)
@@ -977,6 +998,7 @@ __docker_image_subcommand() {
             _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -a --all)"{-a,--all}"[Remove all unused images, not just dangling ones]" \
+                "($help)*--filter=[Filter values]:filter:__docker_complete_prune_filters" \
                 "($help -f --force)"{-f,--force}"[Do not prompt for confirmation]" && ret=0
             ;;
         (pull)
@@ -1204,6 +1226,7 @@ __docker_network_subcommand() {
         (prune)
             _arguments $(__docker_arguments) \
                 $opts_help \
+                "($help)*--filter=[Filter values]:filter:__docker_complete_prune_filters" \
                 "($help -f --force)"{-f,--force}"[Do not prompt for confirmation]" && ret=0
             ;;
         (rm)
@@ -2142,6 +2165,7 @@ __docker_system_subcommand() {
             _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -a --all)"{-a,--all}"[Remove all unused data, not just dangling ones]" \
+                "($help)*--filter=[Filter values]:filter:__docker_complete_prune_filters" \
                 "($help -f --force)"{-f,--force}"[Do not prompt for confirmation]" && ret=0
             ;;
         (help)

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1520,9 +1520,15 @@ __docker_plugin_subcommand() {
     opts_help=("(: -)--help[Print usage]")
 
     case "$words[1]" in
-        (disable|enable|inspect|install|ls|push|rm)
+        (disable|enable|inspect|ls|push|rm)
             _arguments $(__docker_arguments) \
                 $opts_help \
+                "($help -)1:plugin:__docker_complete_plugins" && ret=0
+            ;;
+        (install)
+            _arguments $(__docker_arguments) \
+                $opts_help \
+                "($help)--alias=[Local name for plugin]:alias: " \
                 "($help -)1:plugin:__docker_complete_plugins" && ret=0
             ;;
         (set)

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -561,6 +561,7 @@ __docker_container_subcommand() {
         "($help)*--group=[Set one or more supplementary user groups for the container]:group:_groups"
         "($help -h --hostname)"{-h=,--hostname=}"[Container host name]:hostname:_hosts"
         "($help -i --interactive)"{-i,--interactive}"[Keep stdin open even if not attached]"
+        "($help)--init[Run an init inside the container that forwards signals and reaps processes]" \
         "($help)--ip=[Container IPv4 address]:IPv4: "
         "($help)--ip6=[Container IPv6 address]:IPv6: "
         "($help)--ipc=[IPC namespace to use]:IPC namespace: "
@@ -2401,6 +2402,7 @@ __docker_subcommand() {
                 "($help -g --graph)"{-g=,--graph=}"[Root of the Docker runtime]:path:_directories" \
                 "($help -H --host)"{-H=,--host=}"[tcp://host:port to bind/connect to]:host: " \
                 "($help)--icc[Enable inter-container communication]" \
+                "($help)--init[Run an init inside containers to forward signals and reap processes]" \
                 "($help)--init-path=[Path to the docker-init binary]:docker-init binary:_files" \
                 "($help)*--insecure-registry=[Enable insecure registry communication]:registry: " \
                 "($help)--ip=[Default IP when binding container ports]" \

--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -351,7 +351,7 @@ func (c *Cluster) startNewNode(conf nodeStartConfig) (*node, error) {
 	c.actualLocalAddr = actualLocalAddr // not saved
 	c.saveState(conf)
 
-	c.config.Backend.SetClusterProvider(c)
+	c.config.Backend.DaemonJoinsCluster(c)
 	go func() {
 		err := detectLockedError(n.Err(ctx))
 		if err != nil {
@@ -724,6 +724,7 @@ func (c *Cluster) Leave(force bool) error {
 	if err := c.clearState(); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -751,7 +752,7 @@ func (c *Cluster) clearState() error {
 	if err := os.MkdirAll(c.root, 0700); err != nil {
 		return err
 	}
-	c.config.Backend.SetClusterProvider(nil)
+	c.config.Backend.DaemonLeavesCluster()
 	return nil
 }
 

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -47,7 +47,8 @@ type Backend interface {
 	VolumeCreate(name, driverName string, opts, labels map[string]string) (*types.Volume, error)
 	Containers(config *types.ContainerListOptions) ([]*types.Container, error)
 	SetNetworkBootstrapKeys([]*networktypes.EncryptionKey) error
-	SetClusterProvider(provider cluster.Provider)
+	DaemonJoinsCluster(provider cluster.Provider)
+	DaemonLeavesCluster()
 	IsSwarmCompatible() error
 	SubscribeToEvents(since, until time.Time, filter filters.Args) ([]events.Message, chan interface{})
 	UnsubscribeFromEvents(listener chan interface{})

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -446,8 +446,22 @@ func (daemon *Daemon) registerLink(parent, child *container.Container, alias str
 	return nil
 }
 
-// SetClusterProvider sets a component for querying the current cluster state.
-func (daemon *Daemon) SetClusterProvider(clusterProvider cluster.Provider) {
+// DaemonJoinsCluster informs the daemon has joined the cluster and provides
+// the handler to query the cluster component
+func (daemon *Daemon) DaemonJoinsCluster(clusterProvider cluster.Provider) {
+	daemon.setClusterProvider(clusterProvider)
+}
+
+// DaemonLeavesCluster informs the daemon has left the cluster
+func (daemon *Daemon) DaemonLeavesCluster() {
+	// Daemon is in charge of removing the attachable networks with
+	// connected containers when the node leaves the swarm
+	daemon.clearAttachableNetworks()
+	daemon.setClusterProvider(nil)
+}
+
+// setClusterProvider sets a component for querying the current cluster state.
+func (daemon *Daemon) setClusterProvider(clusterProvider cluster.Provider) {
 	daemon.clusterProvider = clusterProvider
 	daemon.netController.SetClusterProvider(clusterProvider)
 }

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1198,7 +1198,7 @@ func (daemon *Daemon) initCgroupsPath(path string) error {
 	}
 
 	path = filepath.Join(root, path)
-	sysinfo := sysinfo.New(false)
+	sysinfo := sysinfo.New(true)
 	if err := os.MkdirAll(path, 0755); err != nil && !os.IsExist(err) {
 		return err
 	}

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -205,7 +205,7 @@ func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs
 	}
 
 	if withExtraAttrs {
-		// Get Shared and Unique sizes
+		// Get Shared sizes
 		for img, newImage := range imagesMap {
 			rootFS := *img.RootFS
 			rootFS.DiffIDs = nil

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -581,7 +581,7 @@ func (daemon *Daemon) populateCommonSpec(s *specs.Spec, c *container.Container) 
 	if c.HostConfig.PidMode.IsPrivate() {
 		if (c.HostConfig.Init != nil && *c.HostConfig.Init) ||
 			(c.HostConfig.Init == nil && daemon.configStore.Init) {
-			s.Process.Args = append([]string{"/dev/init", c.Path}, c.Args...)
+			s.Process.Args = append([]string{"/dev/init", "--", c.Path}, c.Args...)
 			var path string
 			if daemon.configStore.InitPath == "" && c.HostConfig.InitPath == "" {
 				path, err = exec.LookPath(DefaultInitBinary)

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -23,7 +23,11 @@ import (
 var ImageTypes = []string{
 	schema2.MediaTypeImageConfig,
 	// Handle unexpected values from https://github.com/docker/distribution/issues/1621
+	// (see also https://github.com/docker/docker/issues/22378,
+	// https://github.com/docker/docker/issues/30083)
 	"application/octet-stream",
+	"application/json",
+	"text/html",
 	// Treat defaulted values as images, newer types cannot be implied
 	"",
 }

--- a/docs/extend/EBS_volume.md
+++ b/docs/extend/EBS_volume.md
@@ -1,0 +1,164 @@
+---
+description: Volume plugin for Amazon EBS
+keywords: "API, Usage, plugins, documentation, developer, amazon, ebs, rexray, volume"
+title: Volume plugin for Amazon EBS
+---
+
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
+# A proof-of-concept Rexray plugin
+
+In this example, a simple Rexray plugin will be created for the purposes of using
+it on an Amazon EC2 instance with EBS. It is not meant to be a complete Rexray plugin.
+
+The example source is available at [https://github.com/tiborvass/rexray-plugin](https://github.com/tiborvass/rexray-plugin).
+
+To learn more about Rexray: [https://github.com/codedellemc/rexray](https://github.com/codedellemc/rexray)
+
+## 1. Make a Docker image
+
+The following is the Dockerfile used to containerize rexray.
+
+```Dockerfile
+FROM debian:jessie
+RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certificates
+RUN wget https://dl.bintray.com/emccode/rexray/stable/0.6.4/rexray-Linux-x86_64-0.6.4.tar.gz -O rexray.tar.gz && tar -xvzf rexray.tar.gz -C /usr/bin && rm rexray.tar.gz
+RUN mkdir -p /run/docker/plugins /var/lib/libstorage/volumes
+ENTRYPOINT ["rexray"]
+CMD ["--help"]
+```
+
+To build it you can run `image=$(cat Dockerfile | docker build -q -)` and `$image`
+will reference the containerized rexray image.
+
+## 2. Extract rootfs
+
+```sh
+$ TMPDIR=/tmp/rexray  # for the purpose of this example
+$  # create container without running it, to extract the rootfs from image
+$ docker create --name rexray "$image"
+$  # save the rootfs to a tar archive
+$ docker export -o $TMPDIR/rexray.tar rexray
+$  # extract rootfs from tar archive to a rootfs folder
+$ ( mkdir -p $TMPDIR/rootfs; cd $TMPDIR/rootfs; tar xf ../rexray.tar )
+```
+
+## 3. Add plugin configuration
+
+We have to put the following JSON to `$TMPDIR/config.json`:
+
+```json
+{
+      "Args": {
+        "Description": "",
+        "Name": "",
+        "Settable": null,
+        "Value": null
+      },
+      "Description": "A proof-of-concept EBS plugin (using rexray) for Docker",
+      "Documentation": "https://github.com/tiborvass/rexray-plugin",
+      "Entrypoint": [
+        "/usr/bin/rexray", "service", "start", "-f"
+      ],
+      "Env": [
+        {
+          "Description": "",
+          "Name": "REXRAY_SERVICE",
+          "Settable": [
+            "value"
+          ],
+          "Value": "ebs"
+        },
+        {
+          "Description": "",
+          "Name": "EBS_ACCESSKEY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
+          "Name": "EBS_SECRETKEY",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        }
+      ],
+      "Interface": {
+        "Socket": "rexray.sock",
+        "Types": [
+          "docker.volumedriver/1.0"
+        ]
+      },
+      "Linux": {
+        "AllowAllDevices": true,
+        "Capabilities": ["CAP_SYS_ADMIN"],
+        "Devices": null
+      },
+      "Mounts": [
+        {
+          "Source": "/dev",
+          "Destination": "/dev",
+          "Type": "bind",
+          "Options": ["rbind"]
+        }
+      ],
+      "Network": {
+        "Type": "host"
+      },
+      "PropagatedMount": "/var/lib/libstorage/volumes",
+      "User": {},
+      "WorkDir": ""
+}
+```
+
+Please note a couple of points:
+- `PropagatedMount` is needed so that the docker daemon can see mounts done by the
+rexray plugin from within the container, otherwise the docker daemon is not able
+to mount a docker volume.
+- The rexray plugin needs dynamic access to host devices. For that reason, we
+have to give it access to all devices under `/dev` and set `AllowAllDevices` to
+true for proper access.
+- The user of this simple plugin can change only 3 settings: `REXRAY_SERVICE`,
+`EBS_ACCESSKEY` and `EBS_SECRETKEY`. This is because of the reduced scope of this
+plugin. Ideally other rexray parameters could also be set.
+
+## 4. Create plugin
+
+`docker plugin create tiborvass/rexray-plugin "$TMPDIR"` will create the plugin.
+
+```sh
+$ docker plugin ls
+ID                  NAME                             DESCRIPTION                         ENABLED
+2475a4bd0ca5        tiborvass/rexray-plugin:latest   A rexray volume plugin for Docker   false
+```
+
+## 5. Test plugin
+
+```sh
+$ docker plugin set tiborvass/rexray-plugin EBS_ACCESSKEY=$AWS_ACCESSKEY EBS_SECRETKEY=$AWS_SECRETKEY`
+$ docker plugin enable tiborvass/rexray-plugin
+$ docker volume create -d tiborvass/rexray-plugin my-ebs-volume
+$ docker volume ls
+DRIVER                              VOLUME NAME
+tiborvass/rexray-plugin:latest      my-ebs-volume
+$ docker run --rm -v my-ebs-volume:/volume busybox sh -c 'echo bye > /volume/hi'
+$ docker run --rm -v my-ebs-volume:/volume busybox cat /volume/hi
+bye
+```
+
+## 6. Push plugin
+
+First, ensure you are logged in with `docker login`. Then you can run:
+`docker plugin push tiborvass/rexray-plugin` to push it like a regular docker
+image to a registry, to make it available for others to install via
+`docker plugin install tiborvass/rexray-plugin EBS_ACCESSKEY=$AWS_ACCESSKEY EBS_SECRETKEY=$AWS_SECRETKEY`.

--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -154,7 +154,7 @@ This plugin is a volume driver. It requires a `host` network and the
 entrypoint and uses the `/run/docker/plugins/sshfs.sock` socket to communicate
 with Docker Engine. This plugin has no runtime parameters.
 
-### Creating the plugin
+#### Creating the plugin
 
 A new plugin can be created by running
 `docker plugin create <plugin-name> ./path/to/plugin/data` where the plugin

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -63,6 +63,8 @@ Options:
       --health-timeout duration     Maximum time to allow one check to run (ns|us|ms|s|m|h) (default 0s)
       --help                        Print usage
   -h, --hostname string             Container host name
+      --init                        Run an init inside the container that forwards signals and reaps processes
+      --init-path string            Path to the docker-init binary
   -i, --interactive                 Keep STDIN open even if not attached
       --io-maxbandwidth string      Maximum IO bandwidth limit for the system drive (Windows only)
       --io-maxiops uint             Maximum IOps limit for the system drive (Windows only)

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -67,6 +67,8 @@ Options:
       --health-timeout duration     Maximum time to allow one check to run (ns|us|ms|s|m|h) (default 0s)
       --help                        Print usage
   -h, --hostname string             Container host name
+      --init                        Run an init inside the container that forwards signals and reaps processes
+      --init-path string            Path to the docker-init binary
   -i, --interactive                 Keep STDIN open even if not attached
       --io-maxbandwidth string      Maximum IO bandwidth limit for the system drive (Windows only)
                                     (Windows only). The format is `<number><unit>`.

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -137,7 +137,7 @@ Create a service specifying the secret, target, user/group ID and mode:
 ```bash
 $ docker service create --name redis \
     --secret source=ssh-key,target=ssh \
-    --secret src=app-key,target=app,uid=1000,gid=1001,mode=0400 \
+    --secret source=app-key,target=app,uid=1000,gid=1001,mode=0400 \
     redis:3.0.6
 4cdgfyky7ozwh3htjfw0d12qv
 ```

--- a/hack/dockerfile/install-binaries.sh
+++ b/hack/dockerfile/install-binaries.sh
@@ -77,7 +77,7 @@ do
 			git clone https://github.com/krallin/tini.git "$GOPATH/tini"
 			cd "$GOPATH/tini"
 			git checkout -q "$TINI_COMMIT"
-			cmake -DMINIMAL=ON .
+			cmake .
 			make tini-static
 			cp tini-static /usr/local/bin/docker-init
 			;;

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
@@ -1309,4 +1311,57 @@ func (s *DockerSwarmSuite) TestAPISwarmSecretsDelete(c *check.C) {
 	status, out, err := d.SockRequest("GET", "/secrets/"+id, nil)
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusNotFound, check.Commentf("secret delete: %s", string(out)))
+}
+
+// Test case for 30242, where duplicate networks, with different drivers `bridge` and `overlay`,
+// caused both scopes to be `swarm` for `docker network inspect` and `docker network ls`.
+// This test makes sure the fixes correctly output scopes instead.
+func (s *DockerSwarmSuite) TestAPIDuplicateNetworks(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	name := "foo"
+	networkCreateRequest := types.NetworkCreateRequest{
+		Name: name,
+		NetworkCreate: types.NetworkCreate{
+			CheckDuplicate: false,
+		},
+	}
+
+	var n1 types.NetworkCreateResponse
+	networkCreateRequest.NetworkCreate.Driver = "bridge"
+
+	status, out, err := d.SockRequest("POST", "/networks/create", networkCreateRequest)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
+	c.Assert(status, checker.Equals, http.StatusCreated, check.Commentf(string(out)))
+
+	c.Assert(json.Unmarshal(out, &n1), checker.IsNil)
+
+	var n2 types.NetworkCreateResponse
+	networkCreateRequest.NetworkCreate.Driver = "overlay"
+
+	status, out, err = d.SockRequest("POST", "/networks/create", networkCreateRequest)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
+	c.Assert(status, checker.Equals, http.StatusCreated, check.Commentf(string(out)))
+
+	c.Assert(json.Unmarshal(out, &n2), checker.IsNil)
+
+	var r1 types.NetworkResource
+
+	status, out, err = d.SockRequest("GET", "/networks/"+n1.ID, nil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
+	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf(string(out)))
+
+	c.Assert(json.Unmarshal(out, &r1), checker.IsNil)
+
+	c.Assert(r1.Scope, checker.Equals, "local")
+
+	var r2 types.NetworkResource
+
+	status, out, err = d.SockRequest("GET", "/networks/"+n2.ID, nil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
+	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf(string(out)))
+
+	c.Assert(json.Unmarshal(out, &r2), checker.IsNil)
+
+	c.Assert(r2.Scope, checker.Equals, "swarm")
 }

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -943,3 +943,10 @@ func (s *DockerSuite) TestPsFilterMissingArgErrorCode(c *check.C) {
 	_, errCode, _ := dockerCmdWithError("ps", "--filter")
 	c.Assert(errCode, checker.Equals, 125)
 }
+
+// Test case for 30291
+func (s *DockerSuite) TestPsFormatTemplateWithArg(c *check.C) {
+	runSleepingContainer(c, "-d", "--name", "top", "--label", "some.label=label.foo-bar")
+	out, _ := dockerCmd(c, "ps", "--format", `{{.Names}} {{.Label "some.label"}}`)
+	c.Assert(strings.TrimSpace(out), checker.Equals, "top label.foo-bar")
+}

--- a/libcontainerd/process_unix.go
+++ b/libcontainerd/process_unix.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"strings"
-	"time"
 
 	containerd "github.com/docker/containerd/api/grpc/types"
 	"github.com/tonistiigi/fifo"
@@ -31,12 +30,10 @@ type process struct {
 	dir string
 }
 
-func (p *process) openFifos(terminal bool) (pipe *IOPipe, err error) {
+func (p *process) openFifos(ctx context.Context, terminal bool) (pipe *IOPipe, err error) {
 	if err := os.MkdirAll(p.dir, 0700); err != nil {
 		return nil, err
 	}
-
-	ctx, _ := context.WithTimeout(context.Background(), 15*time.Second)
 
 	io := &IOPipe{}
 

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -41,6 +41,8 @@ docker-run - Run a command in a new container
 [**--group-add**[=*[]*]]
 [**-h**|**--hostname**[=*HOSTNAME*]]
 [**--help**]
+[**--init**]
+[**--init-path**[=*[]*]]
 [**-i**|**--interactive**]
 [**--ip**[=*IPv4-ADDRESS*]]
 [**--ip6**[=*IPv6-ADDRESS*]]
@@ -309,7 +311,13 @@ redirection on the host system.
    Sets the container host name that is available inside the container.
 
 **--help**
-  Print usage statement
+   Print usage statement
+
+**--init**
+   Run an init inside the container that forwards signals and reaps processes
+
+**--init-path**=""
+   Path to the docker-init binary
 
 **-i**, **--interactive**=*true*|*false*
    Keep STDIN open even if not attached. The default is *false*.

--- a/opts/secret.go
+++ b/opts/secret.go
@@ -50,7 +50,7 @@ func (o *SecretOpt) Set(value string) error {
 
 		value := parts[1]
 		switch key {
-		case "source":
+		case "source", "src":
 			options.Source = value
 		case "target":
 			tDir, _ := filepath.Split(value)

--- a/opts/secret_test.go
+++ b/opts/secret_test.go
@@ -35,6 +35,18 @@ func TestSecretOptionsSourceTarget(t *testing.T) {
 	assert.Equal(t, req.Target, "testing")
 }
 
+func TestSecretOptionsShorthand(t *testing.T) {
+	var opt SecretOpt
+
+	testCase := "src=foo,target=testing"
+	assert.NilError(t, opt.Set(testCase))
+
+	reqs := opt.Value()
+	assert.Equal(t, len(reqs), 1)
+	req := reqs[0]
+	assert.Equal(t, req.Source, "foo")
+}
+
 func TestSecretOptionsCustomUidGid(t *testing.T) {
 	var opt SecretOpt
 

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"errors"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -17,6 +18,12 @@ func TestPluginAddHandler(t *testing.T) {
 
 	testActive(t, p)
 	Handle("bananas", func(_ string, _ *Client) {})
+	testActive(t, p)
+}
+
+func TestPluginWaitBadPlugin(t *testing.T) {
+	p := &Plugin{activateWait: sync.NewCond(&sync.Mutex{})}
+	p.activateErr = errors.New("some junk happened")
 	testActive(t, p)
 }
 

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -169,7 +169,7 @@ func (p *Plugin) activateWithLock() error {
 
 func (p *Plugin) waitActive() error {
 	p.activateWait.L.Lock()
-	for !p.activated() {
+	for !p.activated() && p.activateErr == nil {
 		p.activateWait.Wait()
 	}
 	p.activateWait.L.Unlock()

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -78,12 +78,6 @@ type Plugin struct {
 	handlersRun bool
 }
 
-// BasePath returns the path to which all paths returned by the plugin are relative to.
-// For v1 plugins, this always returns the host's root directory.
-func (p *Plugin) BasePath() string {
-	return "/"
-}
-
 // Name returns the name of the plugin.
 func (p *Plugin) Name() string {
 	return p.name

--- a/pkg/plugins/plugins_linux.go
+++ b/pkg/plugins/plugins_linux.go
@@ -1,0 +1,7 @@
+package plugins
+
+// BasePath returns the path to which all paths returned by the plugin are relative to.
+// For v1 plugins, this always returns the host's root directory.
+func (p *Plugin) BasePath() string {
+	return "/"
+}

--- a/pkg/plugins/plugins_windows.go
+++ b/pkg/plugins/plugins_windows.go
@@ -1,0 +1,8 @@
+package plugins
+
+// BasePath returns the path to which all paths returned by the plugin are relative to.
+// For Windows v1 plugins, this returns an empty string, since the plugin is already aware
+// of the absolute path of the mount.
+func (p *Plugin) BasePath() string {
+	return ""
+}

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -82,23 +82,23 @@ func checkCgroupMem(cgMounts map[string]string, quiet bool) cgroupMemInfo {
 
 	swapLimit := cgroupEnabled(mountPoint, "memory.memsw.limit_in_bytes")
 	if !quiet && !swapLimit {
-		logrus.Warn("Your kernel does not support swap memory limit.")
+		logrus.Warn("Your kernel does not support swap memory limit")
 	}
 	memoryReservation := cgroupEnabled(mountPoint, "memory.soft_limit_in_bytes")
 	if !quiet && !memoryReservation {
-		logrus.Warn("Your kernel does not support memory reservation.")
+		logrus.Warn("Your kernel does not support memory reservation")
 	}
 	oomKillDisable := cgroupEnabled(mountPoint, "memory.oom_control")
 	if !quiet && !oomKillDisable {
-		logrus.Warn("Your kernel does not support oom control.")
+		logrus.Warn("Your kernel does not support oom control")
 	}
 	memorySwappiness := cgroupEnabled(mountPoint, "memory.swappiness")
 	if !quiet && !memorySwappiness {
-		logrus.Warn("Your kernel does not support memory swappiness.")
+		logrus.Warn("Your kernel does not support memory swappiness")
 	}
 	kernelMemory := cgroupEnabled(mountPoint, "memory.kmem.limit_in_bytes")
 	if !quiet && !kernelMemory {
-		logrus.Warn("Your kernel does not support kernel memory limit.")
+		logrus.Warn("Your kernel does not support kernel memory limit")
 	}
 
 	return cgroupMemInfo{


### PR DESCRIPTION
Add zsh completion for 'docker {container,image,network,system} prune --filter #30317 
Add zsh completion for 'docker swarm --availability' #30282
Add bash completion for `dockerd --init` and `docker run|create --init` #30266
Add bash completion for `build --squash` #30200
Honour $DOCKER_HIDE_LEGACY_COMMANDS in bash completion #30132
Fix treatment of DOCKER_HIDE_LEGACY_COMMANDS in bash completion #30163
Add bash completion for `docker swarm unlock|unlock-key` #30399
Add missing options to bash completion for `docker swarm init|update` #30398
Add bash completion for `docker service ps --filter node` #30375
Fix bash completion for `docker service update` #30373
Add zsh completion for 'docker plugin install --alias' #30268
Add bash completion for `plugin install --disable-content-trust` #30125
Add zsh completion for 'dockerd --init' and 'docker {create,run} --init' #30318
Ensure proper value is used when computing reclaimable space #30378
Add bash completion and docs for `docker run|create --init-path` #30283
distribution: Add text/html and application/json as image mediatypes #30262
Remove timeout on fifos opening #30140
Ignore certificate expiry error for top-level inspect #29246
Fix pluginv1 Windows volumes #30150
Only show global warnings once #28939
do not create init-dir if not needed #29846
Fix deadlock on v1 plugin with activate error #30408
Fix failure in `docker ps --format` when `.Label` has args #30291
Fix bash completion for completing nodes #30376
plugins: add example docs for a rexray plugin #30294
[project] bump go to go 1.7.4 #29142
[ppc64le] use official go 1.7.4 binaries #29256
Windows: Bump to latest version of git #29159
Windows: Add service dependency ConDrv #30111
Fix incorrect `Scope` in `network ls/inspect` with duplicate network names #30250
Add "src" alias for `--secret` #30407
Fixed secret creation usage during service create in docs #30370
Remove attachable network on swarm leave #30157
