### PR TITLE
remove indent from .dockerignore example

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -403,9 +403,9 @@ Here is an example `.dockerignore` file:
 
 ```
 # comment
-    */temp*
-    */*/temp*
-    temp?
+*/temp*
+*/*/temp*
+temp?
 ```
 
 This file causes the following build behavior:


### PR DESCRIPTION
**- What I did**

I apologize if there's a reason for having the example show .dockerignore file with indents. I found it confusing, so proposing it be removed.

Signed-off-by: Michael Friis <friism@gmail.com>
