### PR TITLE
Output the configuration in the log

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -260,6 +261,12 @@ func (cli *DaemonCli) start(opts daemonOptions) (err error) {
 		<-stopc // wait for daemonCli.start() to return
 	})
 
+	if b, err := json.Marshal(cli.Config); err != nil {
+		logrus.Errorf("Cannot format configuration in JSON: %v", err)
+	} else {
+		logrus.Infof("Loaded configuration: %s", string(b))
+	}
+
 	d, err := daemon.NewDaemon(cli.Config, registryService, containerdRemote)
 	if err != nil {
 		return fmt.Errorf("Error starting daemon: %v", err)
@@ -347,6 +354,12 @@ func (cli *DaemonCli) reloadConfig() {
 		if err := cli.d.Reload(config); err != nil {
 			logrus.Errorf("Error reconfiguring the daemon: %v", err)
 			return
+		}
+
+		if b, err := json.Marshal(cli.Config); err != nil {
+			logrus.Errorf("Cannot format configuration in JSON: %v", err)
+		} else {
+			logrus.Infof("Reloaded configuration: %s", string(b))
 		}
 
 		if config.IsValueSet("debug") {


### PR DESCRIPTION

**- What I did**

As docker engine can use both command arguments and daemon.json for
the configuration, it would be easier to see the effective config if
it's in the log.

This PR will output the configuration in JSON format, at both the engine
starting and the reloading of the configuration.

Related issue: https://github.com/docker/docker/issues/21559

**- How I did it**

Modified `cmd/dockerd/daemon.go`'s `start()` and `reloadConfig()` to log the configuration in JSON format.

**- How to verify it**

After compiled `dockerd` installed and restart docker service, then run:

```bash
$ sudo journalctl -u docker | grep -i configuration
Jan 23 09:17:51 ubuntu-xenial dockerd[4361]: time="2017-01-23T09:17:51.955962688Z" level=info msg="Loaded configuration: {\"pidfile\":\"/var/run/docker.pid\",\"graph\":\"/var/lib/docker\",\"group\":\"docker\",\"live-restore\":true,\"max-concurrent-downloads\":3,\"max-concurrent-uploads\":5,\"shutdown-timeout\":15,\"hosts\":[\"unix:///var/run/docker.sock\"],\"log-level\":\"info\",\"swarm-default-advertise-addr\":\"\",\"metrics-addr\":\"\",\"log-driver\":\"json-file\",\"ip\":\"0.0.0.0\",\"icc\":true,\"iptables\":true,\"ip-forward\":true,\"ip-masq\":true,\"userland-proxy\":true,\"registry-mirrors\":[\"http://m.hub.test.com\"],\"insecure-registries\":[\"hub.test.com\"],\"experimental\":false,\"exec-root\":\"/var/run/docker\",\"default-runtime\":\"runc\",\"oom-score-adjust\":-500}"
Jan 23 09:18:55 ubuntu-xenial dockerd[4361]: time="2017-01-23T09:18:55.569796490Z" level=info msg="Got signal to reload configuration, reloading from: /etc/docker/daemon.json"
Jan 23 09:18:55 ubuntu-xenial dockerd[4361]: time="2017-01-23T09:18:55.613467674Z" level=info msg="Reloaded configuration: {\"mtu\":1500,\"pidfile\":\"/var/run/docker.pid\",\"graph\":\"/var/lib/docker\",\"group\":\"docker\",\"live-restore\":true,\"max-concurrent-downloads\":3,\"max-concurrent-uploads\":5,\"shutdown-timeout\":15,\"hosts\":[\"unix:///var/run/docker.sock\"],\"log-level\":\"info\",\"swarm-default-advertise-addr\":\"\",\"metrics-addr\":\"\",\"log-driver\":\"json-file\",\"ip\":\"0.0.0.0\",\"icc\":true,\"iptables\":true,\"ip-forward\":true,\"ip-masq\":true,\"userland-proxy\":true,\"registry-mirrors\":[\"http://m123.hub.test.com\"],\"insecure-registries\":[\"hub.test.com\"],\"experimental\":false,\"exec-root\":\"/var/run/docker\",\"runtimes\":{\"runc\":{\"path\":\"docker-runc\"}},\"default-runtime\":\"runc\",\"oom-score-adjust\":-500}"
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![wombat george milking](https://cloud.githubusercontent.com/assets/6299096/22204556/ae8c0b24-e1c6-11e6-896d-96d36699782f.jpg)

Signed-off-by: Tao Wang <twang2218@gmail.com>
