### PR TITLE
Fix bash completion for `docker plugin ls`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3323,9 +3323,15 @@ _docker_plugin_list() {
 }
 
 _docker_plugin_ls() {
+	case "$prev" in
+		--format)
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --no-trunc --format --quiet" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--format --help --no-trunc --quiet -q" -- "$cur" ) )
 			;;
 	esac
 }


### PR DESCRIPTION
This addresses two minor glitches introduced in #29088:

- missing `-q` short option
- options with arguments should have special treatment for the argument. Although this is not strictly required in this particular case because there is no catch-all for non-option arguments, it increases robustness against future changes.