### PR TITLE
Fix bash completion for `docker service update`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2751,7 +2751,6 @@ _docker_service_update() {
 		--mount
 		--network
 		--no-healthcheck
-		--publish -p
 		--replicas
 		--reserve-cpu
 		--reserve-memory
@@ -2789,7 +2788,7 @@ _docker_service_update() {
 			--host
 			--mode
 			--name
-			--publish
+			--publish -p
 			--secret
 		"
 


### PR DESCRIPTION
Remove bash completion for `docker service update --publish|-p`

Before this PR, this option would be completed in both `create` and `update`.