### PR TITLE
Ensure proper value is used when computing reclaimable space

### DIFF
--- a/cli/command/formatter/disk_usage.go
+++ b/cli/command/formatter/disk_usage.go
@@ -196,7 +196,10 @@ func (c *diskUsageImagesContext) Reclaimable() string {
 	c.AddHeader(reclaimableHeader)
 	for _, i := range c.images {
 		if i.Containers != 0 {
-			used += i.Size
+			if i.VirtualSize == -1 || i.SharedSize == -1 {
+				continue
+			}
+			used += i.VirtualSize - i.SharedSize
 		}
 	}
 

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -205,7 +205,7 @@ func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs
 	}
 
 	if withExtraAttrs {
-		// Get Shared and Unique sizes
+		// Get Shared sizes
 		for img, newImage := range imagesMap {
 			rootFS := *img.RootFS
 			rootFS.DiffIDs = nil


### PR DESCRIPTION
When Size was reverted to be equal to VirtualSize, the df command
formatter was not correctly updated to account for the change.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

-- 
Fixes #30257
