### PR TITLE
Make the docker-engine RPM depend on same version for selinux package.

### DIFF
--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -92,7 +92,7 @@ Requires: device-mapper >= 1.02.90-2
 # RE: rhbz#1195804 - ensure min NVR for selinux-policy
 %if 0%{?with_selinux}
 Requires: selinux-policy >= %{selinux_policyver}
-Requires(pre): %{name}-selinux >= %{version}-%{release}
+Requires(pre): %{name}-selinux = %{version}-%{release}
 %endif # with_selinux
 
 # conflicting packages


### PR DESCRIPTION
Currently using >= means installing a specific version of docker-engine
means that you still get the latest version of docker-engine-selinux.

This is currently causing a problem with installing on systems that
don't have access to a newer version of the packages that the 1.13.0
docker-engine-selinux requires when installing older versions of Docker.

Fixes #30377

Signed-off-by: Ben Reser <Ben.Reser@cdk.com>

