### PR TITLE
validate CHANGELOG.md dates are in descending order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ information on the list of deprecated flags and APIs please have a look at
 https://docs.docker.com/engine/deprecated/ where target removal dates can also
 be found.
 
-## 1.13.0 (2016-12-08)
+## 1.13.0 (2017-01-18)
 
 **IMPORTANT**: In Docker 1.13, the managed plugin api changed, as compared to the experimental
 version introduced in Docker 1.12. You must **uninstall** plugins which you installed with Docker 1.12

--- a/hack/validate/changelog-date-descending
+++ b/hack/validate/changelog-date-descending
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+changelogFile=${1:-CHANGELOG.md}
+
+if [ ! -r "$changelogFile" ]; then
+  echo "Unable to read file $changelogFile" >&2
+  exit 1
+fi
+
+grep -e '^## ' "$changelogFile" | awk '{print$3}' | sort -c -r || exit 2
+
+echo "Congratulations!  Changelog $changelogFile dates are in descending order."

--- a/hack/validate/default
+++ b/hack/validate/default
@@ -15,3 +15,4 @@ export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . $SCRIPTDIR/toml
 . $SCRIPTDIR/vet
 . $SCRIPTDIR/changelog-well-formed
+. $SCRIPTDIR/changelog-date-descending


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added validation script to check `CHANGELOG.md` has descending order of dates so RPM builds can process the changelog.

Fixed one line in `CHANGELOG.md` so the check succeeds.

Without this fix, builds of RPM packages will fail with error:
```
error: %changelog not in descending chronological order
```

**- How I did it**

Using `grep`, `awk`, and `sort`.

**- How to verify it**

```
$ hack/validate/default
Congratulations!  All commits are properly signed with the DCO!
Congratulations!  All Go source files are properly formatted.
Congratulations!  All Go source files have been linted.
Congratulations!  "./pkg/..." is safely isolated from internal code.
No api/types/ or api/swagger.yaml changes in diff.
Congratulations!  No testing.T found.
Congratulations!  All toml source files changed here have valid syntax.
Congratulations!  All Go source files have been vetted.
Congratulations!  Changelog CHANGELOG.md is well-formed.
Congratulations!  Changelog CHANGELOG.md dates are in descending order.
```

The validation script also accepts on argument to allow you to override the filename to validate, e.g.

```
$ hack/validate/changelog-date-descending MALFORMED-CHANGELOG.md
sort: -:2: disorder: (2017-01-10)
$ echo $?
2
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

ʕ ᵔᴥᵔ ʔ
