### PR TITLE
cli: long-syntax support for `--volume` (deprecates `--mount` for `docker service`)

### DIFF
--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -761,58 +761,6 @@ func callDecodeContainerConfig(volumes []string, binds []string) (*container.Con
 	return c, h, err
 }
 
-func TestVolumeSplitN(t *testing.T) {
-	for _, x := range []struct {
-		input    string
-		n        int
-		expected []string
-	}{
-		{`C:\foo:d:`, -1, []string{`C:\foo`, `d:`}},
-		{`:C:\foo:d:`, -1, nil},
-		{`/foo:/bar:ro`, 3, []string{`/foo`, `/bar`, `ro`}},
-		{`/foo:/bar:ro`, 2, []string{`/foo`, `/bar:ro`}},
-		{`C:\foo\:/foo`, -1, []string{`C:\foo\`, `/foo`}},
-
-		{`d:\`, -1, []string{`d:\`}},
-		{`d:`, -1, []string{`d:`}},
-		{`d:\path`, -1, []string{`d:\path`}},
-		{`d:\path with space`, -1, []string{`d:\path with space`}},
-		{`d:\pathandmode:rw`, -1, []string{`d:\pathandmode`, `rw`}},
-		{`c:\:d:\`, -1, []string{`c:\`, `d:\`}},
-		{`c:\windows\:d:`, -1, []string{`c:\windows\`, `d:`}},
-		{`c:\windows:d:\s p a c e`, -1, []string{`c:\windows`, `d:\s p a c e`}},
-		{`c:\windows:d:\s p a c e:RW`, -1, []string{`c:\windows`, `d:\s p a c e`, `RW`}},
-		{`c:\program files:d:\s p a c e i n h o s t d i r`, -1, []string{`c:\program files`, `d:\s p a c e i n h o s t d i r`}},
-		{`0123456789name:d:`, -1, []string{`0123456789name`, `d:`}},
-		{`MiXeDcAsEnAmE:d:`, -1, []string{`MiXeDcAsEnAmE`, `d:`}},
-		{`name:D:`, -1, []string{`name`, `D:`}},
-		{`name:D::rW`, -1, []string{`name`, `D:`, `rW`}},
-		{`name:D::RW`, -1, []string{`name`, `D:`, `RW`}},
-		{`c:/:d:/forward/slashes/are/good/too`, -1, []string{`c:/`, `d:/forward/slashes/are/good/too`}},
-		{`c:\Windows`, -1, []string{`c:\Windows`}},
-		{`c:\Program Files (x86)`, -1, []string{`c:\Program Files (x86)`}},
-
-		{``, -1, nil},
-		{`.`, -1, []string{`.`}},
-		{`..\`, -1, []string{`..\`}},
-		{`c:\:..\`, -1, []string{`c:\`, `..\`}},
-		{`c:\:d:\:xyzzy`, -1, []string{`c:\`, `d:\`, `xyzzy`}},
-
-		// Cover directories with one-character name
-		{`/tmp/x/y:/foo/x/y`, -1, []string{`/tmp/x/y`, `/foo/x/y`}},
-	} {
-		res := volumeSplitN(x.input, x.n)
-		if len(res) < len(x.expected) {
-			t.Fatalf("input: %v, expected: %v, got: %v", x.input, x.expected, res)
-		}
-		for i, e := range res {
-			if e != x.expected[i] {
-				t.Fatalf("input: %v, expected: %v, got: %v", x.input, x.expected, res)
-			}
-		}
-	}
-}
-
 func TestValidateDevice(t *testing.T) {
 	valid := []string{
 		"/home",

--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -35,7 +35,8 @@ func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.Var(&opts.containerLabels, flagContainerLabel, "Container labels")
 	flags.VarP(&opts.env, flagEnv, "e", "Set environment variables")
 	flags.Var(&opts.envFile, flagEnvFile, "Read in a file of environment variables")
-	flags.Var(&opts.mounts, flagMount, "Attach a filesystem mount to the service")
+	flags.VarP(&opts.volumes, flagVolume, "v", "Attach a filesystem mount to the service")
+	flags.Var(&opts.volumes, flagMountDeprecated, "Attach a filesystem mount to the service")
 	flags.Var(&opts.constraints, flagConstraint, "Placement constraints")
 	flags.Var(&opts.networks, flagNetwork, "Network attachments")
 	flags.Var(&opts.secrets, flagSecret, "Specify secrets to expose to the service")
@@ -47,6 +48,7 @@ func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.Var(&opts.hosts, flagHost, "Set one or more custom host-to-IP mappings (host:ip)")
 
 	flags.SetInterspersed(false)
+	flags.MarkDeprecated(flagMountDeprecated, "use --volume instead")
 	return cmd
 }
 

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2752,7 +2752,7 @@ _docker_service_update() {
 		--limit-memory
 		--log-driver
 		--log-opt
-		--mount
+		--volume
 		--network
 		--no-healthcheck
 		--publish -p

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1785,7 +1785,7 @@ __docker_service_subcommand() {
         "($help)--limit-memory=[Limit Memory]:value: "
         "($help)--log-driver=[Logging driver for service]:logging driver:__docker_complete_log_drivers"
         "($help)*--log-opt=[Logging driver options]:log driver options:__docker_complete_log_options"
-        "($help)*--mount=[Attach a filesystem mount to the service]:mount: "
+        "($help)*--volume=[Attach a filesystem mount to the service]:mount: "
         "($help)*--network=[Network attachments]:network: "
         "($help)--no-healthcheck[Disable any container-specified HEALTHCHECK]"
         "($help)*"{-p=,--publish=}"[Publish a port as a node port]:port: "

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -20,6 +20,18 @@ The following list of features are deprecated in Engine.
 To learn more about Docker Engine's deprecation policy,
 see [Feature Deprecation Policy](https://docs.docker.com/engine/#feature-deprecation-policy).
 
+### `--mount` for `docker service`
+
+**Deprecated In Release: v1.14.0**
+
+`--volume`, `--volume-add`, and `--volume-rm` replaces `--mount`, `--mount-add`,
+and `--mount-rm`.
+
+Note that now `--volume` supports the long-syntax e.g. `--volume type=bind,src=...,dst=...`.
+The long-syntax `--volume` can be also used for `docker run` as well.
+
+Refer to [#28527](https://github.com/docker/docker/pull/28527) for further
+information.
 
 ### Top-level network properties in NetworkSettings
 
@@ -40,7 +52,7 @@ docker 1.9, but kept around for backward compatibility.
 Refer to [#17538](https://github.com/docker/docker/pull/17538) for further
 information.
 
-## `filter` param for `/images/json` endpoint
+### `filter` param for `/images/json` endpoint
 **Deprecated In Release: [v1.13.0](https://github.com/docker/docker/releases/tag/v1.13.0)**
 
 **Target For Removal In Release: v1.16**

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -281,6 +281,12 @@ of a bind mount must be a local directory, not a file.
     docker run -v c:\foo:c: ...
     docker run -v c:\foo:c:\existing-directory-with-contents ...
 
+Since v1.14, `docker run` supports the long-syntax for the `-v` option, similar to `docker service`.
+
+    docker run -v type=volume,source=my-volume,destination=/path/in/container
+
+For the comparison between the long-syntax and the short-syntax, refer to [bind-mounts and volumes](volume.md).
+
 For in-depth information about volumes, refer to [manage data in containers](https://docs.docker.com/engine/tutorials/dockervolumes/)
 
 ### Publish or expose port (-p, --expose)

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -43,7 +43,6 @@ Options:
       --log-driver string                Logging driver for service
       --log-opt list                     Logging driver options (default [])
       --mode string                      Service mode (replicated or global) (default "replicated")
-      --mount mount                      Attach a filesystem mount to the service
       --name string                      Service name
       --network list                     Network attachments (default [])
       --no-healthcheck                   Disable any container-specified HEALTHCHECK
@@ -64,6 +63,7 @@ Options:
       --update-monitor duration          Duration after each task update to monitor for failure (ns|us|ms|s|m|h) (default 0s)
       --update-parallelism uint          Maximum number of tasks updated simultaneously (0 to update all at once) (default 1)
   -u, --user string                      Username or UID (format: <name|uid>[:<group|gid>])
+      --volume volume                    Attach a filesystem mount to the service (default [])
       --with-registry-auth               Send registry authentication details to swarm agents
   -w, --workdir string                   Working directory inside the container
 ```
@@ -196,126 +196,20 @@ metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/).
 
 ### Add bind-mounts or volumes
 
-Docker supports two different kinds of mounts, which allow containers to read to
-or write from files or directories on other containers or the host operating
-system. These types are _data volumes_ (often referred to simply as volumes) and
-_bind-mounts_.
+Similar to `docker run`, `docker service` supports adding bind-mounts and
+volumes to services via the `--volume` option.
 
-Additionally, Docker also supports tmpfs mounts.
+However, while `docker run` supports both the short-syntax and long-syntax,
+`docker service` does not support the short-syntax.
+i.e. while `docker service create --volume type=volume,source=my-volume,destination=/path/in/container`
+is supported, `docker service create --volume my-volume:/path/in/container` is not supported.
+Also, `--volume-driver` which is required for the short-syntax in `docker run`
+is not supported in `docker service`.
 
-A **bind-mount** makes a file or directory on the host available to the
-container it is mounted within. A bind-mount may be either read-only or
-read-write. For example, a container might share its host's DNS information by
-means of a bind-mount of the host's `/etc/resolv.conf` or a container might
-write logs to its host's `/var/log/myContainerLogs` directory. If you use
-bind-mounts and your host and containers have different notions of permissions,
-access controls, or other such details, you will run into portability issues.
+Prior to v1.14, `docker service` had supported the `--mount` option but hadn't supported the `--volume` option.
+The `--mount` option is still availabile for compatibility.
 
-A **named volume** is a mechanism for decoupling persistent data needed by your
-container from the image used to create the container and from the host machine.
-Named volumes are created and managed by Docker, and a named volume persists
-even when no container is currently using it. Data in named volumes can be
-shared between a container and the host machine, as well as between multiple
-containers. Docker uses a _volume driver_ to create, manage, and mount volumes.
-You can back up or restore volumes using Docker commands.
-
-A **tmpfs** mounts a tmpfs inside a container for volatile data.
-
-Consider a situation where your image starts a lightweight web server. You could
-use that image as a base image, copy in your website's HTML files, and package
-that into another image. Each time your website changed, you'd need to update
-the new image and redeploy all of the containers serving your website. A better
-solution is to store the website in a named volume which is attached to each of
-your web server containers when they start. To update the website, you just
-update the named volume.
-
-For more information about named volumes, see
-[Data Volumes](https://docs.docker.com/engine/tutorials/dockervolumes/).
-
-The following table describes options which apply to both bind-mounts and named
-volumes in a service:
-
-| Option                                   | Required                  | Description
-|:-----------------------------------------|:--------------------------|:-----------------------------------------------------------------------------------------
-| **type**                                 |                           | The type of mount, can be either `volume`, `bind`, or `tmpfs`. Defaults to `volume` if no type is specified.<ul><li>`volume`: mounts a [managed volume](volume_create.md) into the container.</li><li>`bind`: bind-mounts a directory or file from the host into the container.</li><li>`tmpfs`: mount a tmpfs in the container</li></ul>
-| **src** or **source**                    | for `type=bind`&nbsp;only | <ul><li>`type=volume`: `src` is an optional way to specify the name of the volume (for example, `src=my-volume`). If the named volume does not exist, it is automatically created. If no `src` is specified, the volume is assigned a random name which is guaranteed to be unique on the host, but may not be unique cluster-wide. A randomly-named volume has the same lifecycle as its container and is destroyed when the *container* is destroyed (which is upon `service update`, or when scaling or re-balancing the service).</li><li>`type=bind`: `src` is required, and specifies an absolute path to the file or directory to bind-mount (for example, `src=/path/on/host/`).  An error is produced if the file or directory does not exist.</li><li>`type=tmpfs`: `src` is not supported.</li></ul>
-| **dst** or **destination** or **target** | yes                       | Mount path inside the container, for example `/some/path/in/container/`. If the path does not exist in the container's filesystem, the Engine creates a directory at the specified location before mounting the volume or bind-mount.
-| **readonly** or **ro**                   |                           | The Engine mounts binds and volumes `read-write` unless `readonly` option is given when mounting the bind or volume.<br /><br /><ul><li>`true` or `1` or no value: Mounts the bind or volume read-only.</li><li>`false` or `0`: Mounts the bind or volume read-write.</li></ul>
-
-#### Bind Propagation
-
-Bind propagation refers to whether or not mounts created within a given
-bind-mount or named volume can be propagated to replicas of that mount. Consider
-a mount point `/mnt`, which is also mounted on `/tmp`. The propation settings
-control whether a mount on `/tmp/a` would also be available on `/mnt/a`. Each
-propagation setting has a recursive counterpoint. In the case of recursion,
-consider that `/tmp/a` is also mounted as `/foo`. The propagation settings
-control whether `/mnt/a` and/or `/tmp/a` would exist.
-
-The `bind-propagation` option defaults to `rprivate` for both bind-mounts and
-volume mounts, and is only configurable for bind-mounts. In other words, named
-volumes do not support bind propagation.
-
-- **`shared`**: Sub-mounts of the original mount are exposed to replica mounts,
-                and sub-mounts of replica mounts are also propagated to the
-                original mount.
-- **`slave`**: similar to a shared mount, but only in one direction. If the
-               original mount exposes a sub-mount, the replica mount can see it.
-               However, if the replica mount exposes a sub-mount, the original
-               mount cannot see it.
-- **`private`**: The mount is private. Sub-mounts within it are not exposed to
-                 replica mounts, and sub-mounts of replica mounts are not
-                 exposed to the original mount.
-- **`rshared`**: The same as shared, but the propagation also extends to and from
-                 mount points nested within any of the original or replica mount
-                 points.
-- **`rslave`**: The same as `slave`, but the propagation also extends to and from
-                 mount points nested within any of the original or replica mount
-                 points.
-- **`rprivate`**: The default. The same as `private`, meaning that no mount points
-                  anywhere within the original or replica mount points propagate
-                  in either direction.
-
-For more information about bind propagation, see the
-[Linux kernel documentation for shared subtree](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt).
-
-#### Options for Named Volumes
-The following options can only be used for named volumes (`type=volume`);
-
-| Option                | Description
-|:----------------------|:--------------------------------------------------------------------------------------------------------------------
-| **volume-driver**     | Name of the volume-driver plugin to use for the volume. Defaults to ``"local"``, to use the local volume driver to create the volume if the volume does not exist.
-| **volume-label**      | One or more custom metadata ("labels") to apply to the volume upon creation. For example, `volume-label=mylabel=hello-world,my-other-label=hello-mars`. For more information about labels, refer to [apply custom metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/).
-| **volume-nocopy**     | By default, if you attach an empty volume to a container, and files or directories already existed at the mount-path in the container (`dst`), the Engine copies those files and directories into the volume, allowing the host to access them. Set `volume-nocopy` to disables copying files from the container's filesystem to the volume and mount the empty volume.<br /><br />A value is optional:<ul><li>`true` or `1`: Default if you do not provide a value. Disables copying.</li><li>`false` or `0`: Enables copying.</li></ul>
-| **volume-opt**        | Options specific to a given volume driver, which will be passed to the driver when creating the volume. Options are provided as a comma-separated list of key/value pairs, for example, `volume-opt=some-option=some-value,some-other-option=some-other-value`. For available options for a given driver, refer to that driver's documentation.
-
-#### Options for tmpfs
-The following options can only be used for tmpfs mounts (`type=tmpfs`);
-
-| Option                | Description
-|:----------------------|:--------------------------------------------------------------------------------------------------------------------
-| **tmpfs-size**        | Size of the tmpfs mount in bytes. Unlimited by default in Linux.
-| **tmpfs-mode**        | File mode of the tmpfs in octal. (e.g. `"700"` or `"0700"`.) Defaults to ``"1777"`` in Linux.
-
-#### Differences between "--mount" and "--volume"
-
-The `--mount` flag supports most options that are supported by the `-v`
-or `--volume` flag for `docker run`, with some important exceptions:
-
-- The `--mount` flag allows you to specify a volume driver and volume driver
-    options *per volume*, without creating the volumes in advance. In contrast,
-    `docker run` allows you to specify a single volume driver which is shared
-    by all volumes, using the `--volume-driver` flag.
-
-- The `--mount` flag allows you to specify custom metadata ("labels") for a volume,
-    before the volume is created.
-
-- When you use `--mount` with `type=bind`, the host-path must refer to an *existing*
-    path on the host. The path will not be created for you and the service will fail
-    with an error if the path does not exist.
-
-- The `--mount` flag does not allow you to relabel a volume with `Z` or `z` flags,
-    which are used for `selinux` labeling.
+For more information, refer to [bind-mounts and volumes](volume.md).
 
 #### Create a service using a named volume
 
@@ -325,7 +219,7 @@ The following example creates a service that uses a named volume:
 $ docker service create \
   --name my-service \
   --replicas 3 \
-  --mount type=volume,source=my-volume,destination=/path/in/container,volume-label="color=red",volume-label="shape=round" \
+  --volume type=volume,source=my-volume,destination=/path/in/container,volume-label="color=red",volume-label="shape=round" \
   nginx:alpine
 ```
 
@@ -355,7 +249,7 @@ volume on `/path/in/container`:
 $ docker service create \
   --name my-service \
   --replicas 3 \
-  --mount type=volume,destination=/path/in/container \
+  --volume type=volume,destination=/path/in/container \
   nginx:alpine
 ```
 
@@ -372,7 +266,7 @@ the containers backing the service:
 ```bash
 $ docker service create \
   --name my-service \
-  --mount type=bind,source=/path/on/host,destination=/path/in/container \
+  --volume type=bind,source=/path/on/host,destination=/path/in/container \
   nginx:alpine
 ```
 
@@ -511,7 +405,7 @@ provided by the Go's [text/template](http://golange.org/pkg/text/template/) pack
 The supported flags are the following :
 
 - `--hostname`
-- `--mount`
+- `--volume` (`--mount`)
 - `--env`
 
 Valid placeholders for the Go template are listed below:

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -53,8 +53,6 @@ Options:
       --limit-memory bytes               Limit Memory (default 0 B)
       --log-driver string                Logging driver for service
       --log-opt list                     Logging driver options (default [])
-      --mount-add mount                  Add or update a mount on a service
-      --mount-rm list                    Remove a mount by its target path (default [])
       --no-healthcheck                   Disable any container-specified HEALTHCHECK
       --publish-add port                 Add or update a published port
       --publish-rm port                  Remove a published port by its target port
@@ -76,6 +74,8 @@ Options:
       --update-monitor duration          Duration after each task update to monitor for failure (ns|us|ms|s|m|h) (default 0s)
       --update-parallelism uint          Maximum number of tasks updated simultaneously (0 to update all at once) (default 1)
   -u, --user string                      Username or UID (format: <name|uid>[:<group|gid>])
+      --volume-add volume                Add or update a mount on a service (default [])
+      --volume-rm list                   Remove a mount by its target path (default [])
       --with-registry-auth               Send registry authentication details to swarm agents
   -w, --workdir string                   Working directory inside the container
 ```
@@ -113,8 +113,10 @@ that the rolling restart happens gradually.
 
 ### Adding and removing mounts
 
-Use the `--mount-add` or `--mount-rm` options add or remove a service's bind-mounts
+Use the `--volume-add` or `--volume-rm` options add or remove a service's bind-mounts
 or volumes.
+These options were known as `--mount-add` and `--mount-rm` in v1.12 and v1.13.
+`--mount-add` and `--mount-rm` are still available for compatibility.
 
 The following example creates a service which mounts the `test-data` volume to
 `/somewhere`. The next step updates the service to also mount the `other-volume`
@@ -122,17 +124,17 @@ volume to `/somewhere-else`volume, The last step unmounts the `/somewhere` mount
 point, effectively removing the `test-data` volume. Each command returns the
 service name.
 
-- The `--mount-add` flag takes the same parameters as the `--mount` flag on
+- The `--volume-add` flag takes the same parameters as the `--volume` flag on
   `service create`. Refer to the [volumes and
   bind-mounts](service_create.md#volumes-and-bind-mounts-mount) section in the
   `service create` reference for details.
 
-- The `--mount-rm` flag takes the `target` path of the mount.
+- The `--volume-rm` flag takes the `target` path of the mount.
 
 ```bash
 $ docker service create \
     --name=myservice \
-    --mount \
+    --volume \
       type=volume,source=test-data,target=/somewhere \
     nginx:alpine \
     myservice
@@ -140,13 +142,13 @@ $ docker service create \
 myservice
 
 $ docker service update \
-    --mount-add \
+    --volume-add \
       type=volume,source=other-volume,target=/somewhere-else \
     myservice
 
 myservice
 
-$ docker service update --mount-rm /somewhere myservice
+$ docker service update --volume-rm /somewhere myservice
 
 myservice
 ```

--- a/docs/reference/commandline/volume.md
+++ b/docs/reference/commandline/volume.md
@@ -1,0 +1,153 @@
+---
+title: "Bind-mounts and Volumes"
+description: "Bind-mounts and Volumes (--volume)"
+keywords: "volume"
+---
+
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
+# Bind-mounts and Volumes
+
+Docker supports two different kinds of mounts, which allow containers to read to
+or write from files or directories on other containers or the host operating
+system. These types are _data volumes_ (often referred to simply as volumes) and
+_bind-mounts_.
+
+Additionally, Docker also supports tmpfs mounts.
+
+A **bind-mount** makes a file or directory on the host available to the
+container it is mounted within. A bind-mount may be either read-only or
+read-write. For example, a container might share its host's DNS information by
+means of a bind-mount of the host's `/etc/resolv.conf` or a container might
+write logs to its host's `/var/log/myContainerLogs` directory. If you use
+bind-mounts and your host and containers have different notions of permissions,
+access controls, or other such details, you will run into portability issues.
+
+A **named volume** is a mechanism for decoupling persistent data needed by your
+container from the image used to create the container and from the host machine.
+Named volumes are created and managed by Docker, and a named volume persists
+even when no container is currently using it. Data in named volumes can be
+shared between a container and the host machine, as well as between multiple
+containers. Docker uses a _volume driver_ to create, manage, and mount volumes.
+You can back up or restore volumes using Docker commands.
+
+A **tmpfs** mounts a tmpfs inside a container for volatile data.
+
+Consider a situation where your image starts a lightweight web server. You could
+use that image as a base image, copy in your website's HTML files, and package
+that into another image. Each time your website changed, you'd need to update
+the new image and redeploy all of the containers serving your website. A better
+solution is to store the website in a named volume which is attached to each of
+your web server containers when they start. To update the website, you just
+update the named volume.
+
+For more information about named volumes, see
+[Data Volumes](https://docs.docker.com/engine/tutorials/dockervolumes/).
+
+## The short-syntax
+
+The short-syntax (e.g. `--volume my-volume:/path/in/container`) is the
+traditional syntax and only supported in `docker run` and `docker create`.
+
+The usage is described in [`docker run`](run.md).
+
+## The long-syntax
+
+The long-syntax (e.g. `--volume type=volume,source=my-volume,destination=/path/in/container`)
+is the newer and more flexible syntax originally designed for `docker service`.
+Since v1.14, the long-syntax is also available fo `docker run` and `docker create`
+as well.
+
+The following table describes options which apply to both bind-mounts and named
+volumes in the long-syntax
+
+| Option                                   | Required                  | Description
+|:-----------------------------------------|:--------------------------|:-----------------------------------------------------------------------------------------
+| **type**                                 |                           | The type of mount, can be either `volume`, `bind`, or `tmpfs`. Defaults to `volume` if no type is specified.<ul><li>`volume`: mounts a [managed volume](volume_create.md) into the container.</li><li>`bind`: bind-mounts a directory or file from the host into the container.</li><li>`tmpfs`: mount a tmpfs in the container</li></ul>
+| **src** or **source**                    | for `type=bind`&nbsp;only | <ul><li>`type=volume`: `src` is an optional way to specify the name of the volume (for example, `src=my-volume`). If the named volume does not exist, it is automatically created. If no `src` is specified, the volume is assigned a random name which is guaranteed to be unique on the host, but may not be unique cluster-wide. A randomly-named volume has the same lifecycle as its container and is destroyed when the *container* is destroyed (which is upon `service update`, or when scaling or re-balancing the service).</li><li>`type=bind`: `src` is required, and specifies an absolute path to the file or directory to bind-mount (for example, `src=/path/on/host/`).  An error is produced if the file or directory does not exist.</li><li>`type=tmpfs`: `src` is not supported.</li></ul>
+| **dst** or **destination** or **target** | yes                       | Mount path inside the container, for example `/some/path/in/container/`. If the path does not exist in the container's filesystem, the Engine creates a directory at the specified location before mounting the volume or bind-mount.
+| **readonly** or **ro**                   |                           | The Engine mounts binds and volumes `read-write` unless `readonly` option is given when mounting the bind or volume.<br /><br /><ul><li>`true` or `1` or no value: Mounts the bind or volume read-only.</li><li>`false` or `0`: Mounts the bind or volume read-write.</li></ul>
+
+### Bind Propagation
+
+Bind propagation refers to whether or not mounts created within a given
+bind-mount or named volume can be propagated to replicas of that mount. Consider
+a mount point `/mnt`, which is also mounted on `/tmp`. The propation settings
+control whether a mount on `/tmp/a` would also be available on `/mnt/a`. Each
+propagation setting has a recursive counterpoint. In the case of recursion,
+consider that `/tmp/a` is also mounted as `/foo`. The propagation settings
+control whether `/mnt/a` and/or `/tmp/a` would exist.
+
+The `bind-propagation` option defaults to `rprivate` for both bind-mounts and
+volume mounts, and is only configurable for bind-mounts. In other words, named
+volumes do not support bind propagation.
+
+- **`shared`**: Sub-mounts of the original mount are exposed to replica mounts,
+                and sub-mounts of replica mounts are also propagated to the
+                original mount.
+- **`slave`**: similar to a shared mount, but only in one direction. If the
+               original mount exposes a sub-mount, the replica mount can see it.
+               However, if the replica mount exposes a sub-mount, the original
+               mount cannot see it.
+- **`private`**: The mount is private. Sub-mounts within it are not exposed to
+                 replica mounts, and sub-mounts of replica mounts are not
+                 exposed to the original mount.
+- **`rshared`**: The same as shared, but the propagation also extends to and from
+                 mount points nested within any of the original or replica mount
+                 points.
+- **`rslave`**: The same as `slave`, but the propagation also extends to and from
+                 mount points nested within any of the original or replica mount
+                 points.
+- **`rprivate`**: The default. The same as `private`, meaning that no mount points
+                  anywhere within the original or replica mount points propagate
+                  in either direction.
+
+For more information about bind propagation, see the
+[Linux kernel documentation for shared subtree](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt).
+
+### Options for Named Volumes
+The following options can only be used for named volumes (`type=volume`);
+
+| Option                | Description
+|:----------------------|:--------------------------------------------------------------------------------------------------------------------
+| **volume-driver**     | Name of the volume-driver plugin to use for the volume. Defaults to ``"local"``, to use the local volume driver to create the volume if the volume does not exist.
+| **volume-label**      | One or more custom metadata ("labels") to apply to the volume upon creation. For example, `volume-label=mylabel=hello-world,my-other-label=hello-mars`. For more information about labels, refer to [apply custom metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/).
+| **volume-nocopy**     | By default, if you attach an empty volume to a container, and files or directories already existed at the mount-path in the container (`dst`), the Engine copies those files and directories into the volume, allowing the host to access them. Set `volume-nocopy` to disables copying files from the container's filesystem to the volume and mount the empty volume.<br /><br />A value is optional:<ul><li>`true` or `1`: Default if you do not provide a value. Disables copying.</li><li>`false` or `0`: Enables copying.</li></ul>
+| **volume-opt**        | Options specific to a given volume driver, which will be passed to the driver when creating the volume. Options are provided as a comma-separated list of key/value pairs, for example, `volume-opt=some-option=some-value,some-other-option=some-other-value`. For available options for a given driver, refer to that driver's documentation.
+
+### Options for tmpfs
+The following options can only be used for tmpfs mounts (`type=tmpfs`);
+
+| Option                | Description
+|:----------------------|:--------------------------------------------------------------------------------------------------------------------
+| **tmpfs-size**        | Size of the tmpfs mount in bytes. Unlimited by default in Linux.
+| **tmpfs-mode**        | File mode of the tmpfs in octal. (e.g. `"700"` or `"0700"`.) Defaults to ``"1777"`` in Linux.
+
+## Differences between the long-syntax and the short-syntax
+
+The long-syntax supports most options that are supported by the traditional
+short-syntax, with some important exceptions:
+
+- The long-syntax allows you to specify a volume driver and volume driver
+    options *per volume*, without creating the volumes in advance. In contrast,
+    the short-syntax allows you to specify a single volume driver which is shared
+    by all volumes, using the `--volume-driver` flag.
+
+- The long-syntax flag allows you to specify custom metadata ("labels") for a volume,
+    before the volume is created.
+
+- When you use the long-syntax with `type=bind`, the host-path must refer to an *existing*
+    path on the host. The path will not be created for you and the service will fail
+    with an error if the path does not exist.
+
+- The long-syntax does not allow you to relabel a volume with `Z` or `z` flags,
+    which are used for `selinux` labeling.
+
+- The short-syntax is not available for `docker service`.

--- a/integration-cli/docker_cli_service_create_test.go
+++ b/integration-cli/docker_cli_service_create_test.go
@@ -15,8 +15,20 @@ import (
 )
 
 func (s *DockerSwarmSuite) TestServiceCreateMountVolume(c *check.C) {
+	s.testServiceCreateMountVolume(c, false)
+}
+
+func (s *DockerSwarmSuite) TestServiceCreateMountVolumeLegacy(c *check.C) {
+	s.testServiceCreateMountVolume(c, true)
+}
+
+func (s *DockerSwarmSuite) testServiceCreateMountVolume(c *check.C, legacy bool) {
+	dashDashVolume := "--volume"
+	if legacy {
+		dashDashVolume = "--mount"
+	}
 	d := s.AddDaemon(c, true, true)
-	out, err := d.Cmd("service", "create", "--mount", "type=volume,source=foo,target=/foo,volume-nocopy", "busybox", "top")
+	out, err := d.Cmd("service", "create", dashDashVolume, "type=volume,source=foo,target=/foo,volume-nocopy", "busybox", "top")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 	id := strings.TrimSpace(out)
 
@@ -122,8 +134,20 @@ func (s *DockerSwarmSuite) TestServiceCreateWithSecretSourceTarget(c *check.C) {
 }
 
 func (s *DockerSwarmSuite) TestServiceCreateMountTmpfs(c *check.C) {
+	s.testServiceCreateMountTmpfs(c, false)
+}
+
+func (s *DockerSwarmSuite) TestServiceCreateMountTmpfsLegacy(c *check.C) {
+	s.testServiceCreateMountTmpfs(c, true)
+}
+
+func (s *DockerSwarmSuite) testServiceCreateMountTmpfs(c *check.C, legacy bool) {
+	dashDashVolume := "--volume"
+	if legacy {
+		dashDashVolume = "--mount"
+	}
 	d := s.AddDaemon(c, true, true)
-	out, err := d.Cmd("service", "create", "--mount", "type=tmpfs,target=/foo,tmpfs-size=1MB", "busybox", "sh", "-c", "mount | grep foo; tail -f /dev/null")
+	out, err := d.Cmd("service", "create", dashDashVolume, "type=tmpfs,target=/foo,tmpfs-size=1MB", "busybox", "sh", "-c", "mount | grep foo; tail -f /dev/null")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 	id := strings.TrimSpace(out)
 

--- a/integration-cli/docker_cli_swarm_unix_test.go
+++ b/integration-cli/docker_cli_swarm_unix_test.go
@@ -14,7 +14,7 @@ import (
 func (s *DockerSwarmSuite) TestSwarmVolumePlugin(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
-	out, err := d.Cmd("service", "create", "--mount", "type=volume,source=my-volume,destination=/foo,volume-driver=customvolumedriver", "--name", "top", "busybox", "top")
+	out, err := d.Cmd("service", "create", "--volume", "type=volume,source=my-volume,destination=/foo,volume-driver=customvolumedriver", "--name", "top", "busybox", "top")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 
 	// Make sure task stays pending before plugin is available

--- a/opts/volume.go
+++ b/opts/volume.go
@@ -1,0 +1,96 @@
+package opts
+
+import (
+	"fmt"
+	"regexp"
+
+	mounttypes "github.com/docker/docker/api/types/mount"
+)
+
+// VolumeType denotes the syntax type of a volume string
+type VolumeType int
+
+const (
+	// InvalidVolume should never be used
+	InvalidVolume VolumeType = iota
+	// LongVolume is the modern syntax that covers all the mount types
+	LongVolume
+	// ShortUnsplitVolume is the traditional syntax for volumes
+	ShortUnsplitVolume
+	// ShortSplitVolume is the traditional syntax for bind-mounts
+	ShortSplitVolume
+)
+
+// InferVolumeType infers the VolumeType
+func InferVolumeType(s string) VolumeType {
+	// NOTE: we can't use `(,\\w+=\\w+)*` (originally suggested in #28527),
+	// because `\w` lacks '/' and non-ASCII chars
+	matchedLong, err := regexp.MatchString(".+=.+", s)
+	if err != nil {
+		// should not happen
+		return InvalidVolume
+	}
+	if matchedLong {
+		return LongVolume
+	}
+	if len(volumeSplitN(s, 2)) > 1 {
+		return ShortSplitVolume
+	}
+	return ShortUnsplitVolume
+}
+
+// VolumeOpt is a Value type for parsing volumes
+type VolumeOpt struct {
+	raws          []string
+	longs         []mounttypes.Mount
+	shortUnsplits map[string]struct{} // for Config.
+	shortSplits   []string            // for HostConfig.Binds
+}
+
+// Set a new mount value
+func (v *VolumeOpt) Set(value string) error {
+	switch InferVolumeType(value) {
+	case LongVolume:
+		mount, err := parseLongVolume(value)
+		if err != nil {
+			return err
+		}
+		v.longs = append(v.longs, mount)
+	case ShortUnsplitVolume:
+		if v.shortUnsplits == nil {
+			v.shortUnsplits = make(map[string]struct{})
+		}
+		v.shortUnsplits[value] = struct{}{}
+	case ShortSplitVolume:
+		v.shortSplits = append(v.shortSplits, value)
+	default:
+		return fmt.Errorf("unknown volume type for %q", value)
+	}
+	v.raws = append(v.raws, value)
+	return nil
+}
+
+// Type returns the type of this option
+func (v *VolumeOpt) Type() string {
+	return "volume"
+}
+
+// String returns a string repr of this option.
+func (v *VolumeOpt) String() string {
+	return fmt.Sprintf("%v", v.raws)
+}
+
+// LongValue returns the longs
+func (v *VolumeOpt) LongValue() []mounttypes.Mount {
+	return v.longs
+}
+
+// ShortUnsplitValue returns the short unsplits
+func (v *VolumeOpt) ShortUnsplitValue() map[string]struct{} {
+	return v.shortUnsplits
+}
+
+// ShortSplitValue returns the short splits
+func (v *VolumeOpt) ShortSplitValue() []string {
+	return v.shortSplits
+}

--- a/opts/volume_long.go
+++ b/opts/volume_long.go
@@ -11,20 +11,13 @@ import (
 	"github.com/docker/go-units"
 )
 
-// MountOpt is a Value type for parsing mounts
-type MountOpt struct {
-	values []mounttypes.Mount
-}
-
-// Set a new mount value
-func (m *MountOpt) Set(value string) error {
+func parseLongVolume(value string) (mounttypes.Mount, error) {
+	mount := mounttypes.Mount{}
 	csvReader := csv.NewReader(strings.NewReader(value))
 	fields, err := csvReader.Read()
 	if err != nil {
-		return err
+		return mount, err
 	}
-
-	mount := mounttypes.Mount{}
 
 	volumeOptions := func() *mounttypes.VolumeOptions {
 		if mount.VolumeOptions == nil {
@@ -79,7 +72,7 @@ func (m *MountOpt) Set(value string) error {
 		}
 
 		if len(parts) != 2 {
-			return fmt.Errorf("invalid field '%s' must be a key=value pair", field)
+			return mount, fmt.Errorf("invalid field '%s' must be a key=value pair", field)
 		}
 
 		value := parts[1]
@@ -93,14 +86,14 @@ func (m *MountOpt) Set(value string) error {
 		case "readonly", "ro":
 			mount.ReadOnly, err = strconv.ParseBool(value)
 			if err != nil {
-				return fmt.Errorf("invalid value for %s: %s", key, value)
+				return mount, fmt.Errorf("invalid value for %s: %s", key, value)
 			}
 		case "bind-propagation":
 			bindOptions().Propagation = mounttypes.Propagation(strings.ToLower(value))
 		case "volume-nocopy":
 			volumeOptions().NoCopy, err = strconv.ParseBool(value)
 			if err != nil {
-				return fmt.Errorf("invalid value for populate: %s", value)
+				return mount, fmt.Errorf("invalid value for populate: %s", value)
 			}
 		case "volume-label":
 			setValueOnMap(volumeOptions().Labels, value)
@@ -114,58 +107,36 @@ func (m *MountOpt) Set(value string) error {
 		case "tmpfs-size":
 			sizeBytes, err := units.RAMInBytes(value)
 			if err != nil {
-				return fmt.Errorf("invalid value for %s: %s", key, value)
+				return mount, fmt.Errorf("invalid value for %s: %s", key, value)
 			}
 			tmpfsOptions().SizeBytes = sizeBytes
 		case "tmpfs-mode":
 			ui64, err := strconv.ParseUint(value, 8, 32)
 			if err != nil {
-				return fmt.Errorf("invalid value for %s: %s", key, value)
+				return mount, fmt.Errorf("invalid value for %s: %s", key, value)
 			}
 			tmpfsOptions().Mode = os.FileMode(ui64)
 		default:
-			return fmt.Errorf("unexpected key '%s' in '%s'", key, field)
+			return mount, fmt.Errorf("unexpected key '%s' in '%s'", key, field)
 		}
 	}
 
 	if mount.Type == "" {
-		return fmt.Errorf("type is required")
+		return mount, fmt.Errorf("type is required")
 	}
 
 	if mount.Target == "" {
-		return fmt.Errorf("target is required")
+		return mount, fmt.Errorf("target is required")
 	}
 
 	if mount.VolumeOptions != nil && mount.Type != mounttypes.TypeVolume {
-		return fmt.Errorf("cannot mix 'volume-*' options with mount type '%s'", mount.Type)
+		return mount, fmt.Errorf("cannot mix 'volume-*' options with mount type '%s'", mount.Type)
 	}
 	if mount.BindOptions != nil && mount.Type != mounttypes.TypeBind {
-		return fmt.Errorf("cannot mix 'bind-*' options with mount type '%s'", mount.Type)
+		return mount, fmt.Errorf("cannot mix 'bind-*' options with mount type '%s'", mount.Type)
 	}
 	if mount.TmpfsOptions != nil && mount.Type != mounttypes.TypeTmpfs {
-		return fmt.Errorf("cannot mix 'tmpfs-*' options with mount type '%s'", mount.Type)
+		return mount, fmt.Errorf("cannot mix 'tmpfs-*' options with mount type '%s'", mount.Type)
 	}
-
-	m.values = append(m.values, mount)
-	return nil
-}
-
-// Type returns the type of this option
-func (m *MountOpt) Type() string {
-	return "mount"
-}
-
-// String returns a string repr of this option
-func (m *MountOpt) String() string {
-	mounts := []string{}
-	for _, mount := range m.values {
-		repr := fmt.Sprintf("%s %s %s", mount.Type, mount.Source, mount.Target)
-		mounts = append(mounts, repr)
-	}
-	return strings.Join(mounts, ", ")
-}
-
-// Value returns the mounts
-func (m *MountOpt) Value() []mounttypes.Mount {
-	return m.values
+	return mount, nil
 }

--- a/opts/volume_long_test.go
+++ b/opts/volume_long_test.go
@@ -8,26 +8,7 @@ import (
 	"github.com/docker/docker/pkg/testutil/assert"
 )
 
-func TestMountOptString(t *testing.T) {
-	mount := MountOpt{
-		values: []mounttypes.Mount{
-			{
-				Type:   mounttypes.TypeBind,
-				Source: "/home/path",
-				Target: "/target",
-			},
-			{
-				Type:   mounttypes.TypeVolume,
-				Source: "foo",
-				Target: "/target/foo",
-			},
-		},
-	}
-	expected := "bind /home/path /target, volume foo /target/foo"
-	assert.Equal(t, mount.String(), expected)
-}
-
-func TestMountOptSetBindNoErrorBind(t *testing.T) {
+func TestVolumeOptSetBindNoErrorBind(t *testing.T) {
 	for _, testcase := range []string{
 		// tests several aliases that should have same result.
 		"type=bind,target=/target,source=/source",
@@ -35,11 +16,11 @@ func TestMountOptSetBindNoErrorBind(t *testing.T) {
 		"type=bind,source=/source,dst=/target",
 		"type=bind,src=/source,target=/target",
 	} {
-		var mount MountOpt
+		var mount VolumeOpt
 
 		assert.NilError(t, mount.Set(testcase))
 
-		mounts := mount.Value()
+		mounts := mount.LongValue()
 		assert.Equal(t, len(mounts), 1)
 		assert.Equal(t, mounts[0], mounttypes.Mount{
 			Type:   mounttypes.TypeBind,
@@ -49,7 +30,7 @@ func TestMountOptSetBindNoErrorBind(t *testing.T) {
 	}
 }
 
-func TestMountOptSetVolumeNoError(t *testing.T) {
+func TestVolumeOptSetVolumeNoError(t *testing.T) {
 	for _, testcase := range []string{
 		// tests several aliases that should have same result.
 		"type=volume,target=/target,source=/source",
@@ -57,11 +38,11 @@ func TestMountOptSetVolumeNoError(t *testing.T) {
 		"type=volume,source=/source,dst=/target",
 		"type=volume,src=/source,target=/target",
 	} {
-		var mount MountOpt
+		var mount VolumeOpt
 
 		assert.NilError(t, mount.Set(testcase))
 
-		mounts := mount.Value()
+		mounts := mount.LongValue()
 		assert.Equal(t, len(mounts), 1)
 		assert.Equal(t, mounts[0], mounttypes.Mount{
 			Type:   mounttypes.TypeVolume,
@@ -71,99 +52,99 @@ func TestMountOptSetVolumeNoError(t *testing.T) {
 	}
 }
 
-// TestMountOptDefaultType ensures that a mount without the type defaults to a
+// TestVolumeOptDefaultType ensures that a mount without the type defaults to a
 // volume mount.
-func TestMountOptDefaultType(t *testing.T) {
-	var mount MountOpt
+func TestVolumeOptDefaultType(t *testing.T) {
+	var mount VolumeOpt
 	assert.NilError(t, mount.Set("target=/target,source=/foo"))
-	assert.Equal(t, mount.values[0].Type, mounttypes.TypeVolume)
+	assert.Equal(t, mount.longs[0].Type, mounttypes.TypeVolume)
 }
 
-func TestMountOptSetErrorNoTarget(t *testing.T) {
-	var mount MountOpt
+func TestVolumeOptSetErrorNoTarget(t *testing.T) {
+	var mount VolumeOpt
 	assert.Error(t, mount.Set("type=volume,source=/foo"), "target is required")
 }
 
-func TestMountOptSetErrorInvalidKey(t *testing.T) {
-	var mount MountOpt
+func TestVolumeOptSetErrorInvalidKey(t *testing.T) {
+	var mount VolumeOpt
 	assert.Error(t, mount.Set("type=volume,bogus=foo"), "unexpected key 'bogus'")
 }
 
-func TestMountOptSetErrorInvalidField(t *testing.T) {
-	var mount MountOpt
+func TestVolumeOptSetErrorInvalidField(t *testing.T) {
+	var mount VolumeOpt
 	assert.Error(t, mount.Set("type=volume,bogus"), "invalid field 'bogus'")
 }
 
-func TestMountOptSetErrorInvalidReadOnly(t *testing.T) {
-	var mount MountOpt
+func TestVolumeOptSetErrorInvalidReadOnly(t *testing.T) {
+	var mount VolumeOpt
 	assert.Error(t, mount.Set("type=volume,readonly=no"), "invalid value for readonly: no")
 	assert.Error(t, mount.Set("type=volume,readonly=invalid"), "invalid value for readonly: invalid")
 }
 
-func TestMountOptDefaultEnableReadOnly(t *testing.T) {
-	var m MountOpt
+func TestVolumeOptDefaultEnableReadOnly(t *testing.T) {
+	var m VolumeOpt
 	assert.NilError(t, m.Set("type=bind,target=/foo,source=/foo"))
-	assert.Equal(t, m.values[0].ReadOnly, false)
+	assert.Equal(t, m.longs[0].ReadOnly, false)
 
-	m = MountOpt{}
+	m = VolumeOpt{}
 	assert.NilError(t, m.Set("type=bind,target=/foo,source=/foo,readonly"))
-	assert.Equal(t, m.values[0].ReadOnly, true)
+	assert.Equal(t, m.longs[0].ReadOnly, true)
 
-	m = MountOpt{}
+	m = VolumeOpt{}
 	assert.NilError(t, m.Set("type=bind,target=/foo,source=/foo,readonly=1"))
-	assert.Equal(t, m.values[0].ReadOnly, true)
+	assert.Equal(t, m.longs[0].ReadOnly, true)
 
-	m = MountOpt{}
+	m = VolumeOpt{}
 	assert.NilError(t, m.Set("type=bind,target=/foo,source=/foo,readonly=true"))
-	assert.Equal(t, m.values[0].ReadOnly, true)
+	assert.Equal(t, m.longs[0].ReadOnly, true)
 
-	m = MountOpt{}
+	m = VolumeOpt{}
 	assert.NilError(t, m.Set("type=bind,target=/foo,source=/foo,readonly=0"))
-	assert.Equal(t, m.values[0].ReadOnly, false)
+	assert.Equal(t, m.longs[0].ReadOnly, false)
 }
 
-func TestMountOptVolumeNoCopy(t *testing.T) {
-	var m MountOpt
+func TestVolumeOptVolumeNoCopy(t *testing.T) {
+	var m VolumeOpt
 	assert.NilError(t, m.Set("type=volume,target=/foo,volume-nocopy"))
-	assert.Equal(t, m.values[0].Source, "")
+	assert.Equal(t, m.longs[0].Source, "")
 
-	m = MountOpt{}
+	m = VolumeOpt{}
 	assert.NilError(t, m.Set("type=volume,target=/foo,source=foo"))
-	assert.Equal(t, m.values[0].VolumeOptions == nil, true)
+	assert.Equal(t, m.longs[0].VolumeOptions == nil, true)
 
-	m = MountOpt{}
+	m = VolumeOpt{}
 	assert.NilError(t, m.Set("type=volume,target=/foo,source=foo,volume-nocopy=true"))
-	assert.Equal(t, m.values[0].VolumeOptions != nil, true)
-	assert.Equal(t, m.values[0].VolumeOptions.NoCopy, true)
+	assert.Equal(t, m.longs[0].VolumeOptions != nil, true)
+	assert.Equal(t, m.longs[0].VolumeOptions.NoCopy, true)
 
-	m = MountOpt{}
+	m = VolumeOpt{}
 	assert.NilError(t, m.Set("type=volume,target=/foo,source=foo,volume-nocopy"))
-	assert.Equal(t, m.values[0].VolumeOptions != nil, true)
-	assert.Equal(t, m.values[0].VolumeOptions.NoCopy, true)
+	assert.Equal(t, m.longs[0].VolumeOptions != nil, true)
+	assert.Equal(t, m.longs[0].VolumeOptions.NoCopy, true)
 
-	m = MountOpt{}
+	m = VolumeOpt{}
 	assert.NilError(t, m.Set("type=volume,target=/foo,source=foo,volume-nocopy=1"))
-	assert.Equal(t, m.values[0].VolumeOptions != nil, true)
-	assert.Equal(t, m.values[0].VolumeOptions.NoCopy, true)
+	assert.Equal(t, m.longs[0].VolumeOptions != nil, true)
+	assert.Equal(t, m.longs[0].VolumeOptions.NoCopy, true)
 }
 
-func TestMountOptTypeConflict(t *testing.T) {
-	var m MountOpt
+func TestVolumeOptTypeConflict(t *testing.T) {
+	var m VolumeOpt
 	assert.Error(t, m.Set("type=bind,target=/foo,source=/foo,volume-nocopy=true"), "cannot mix")
 	assert.Error(t, m.Set("type=volume,target=/foo,source=/foo,bind-propagation=rprivate"), "cannot mix")
 }
 
-func TestMountOptSetTmpfsNoError(t *testing.T) {
+func TestVolumeOptSetTmpfsNoError(t *testing.T) {
 	for _, testcase := range []string{
 		// tests several aliases that should have same result.
 		"type=tmpfs,target=/target,tmpfs-size=1m,tmpfs-mode=0700",
 		"type=tmpfs,target=/target,tmpfs-size=1MB,tmpfs-mode=700",
 	} {
-		var mount MountOpt
+		var mount VolumeOpt
 
 		assert.NilError(t, mount.Set(testcase))
 
-		mounts := mount.Value()
+		mounts := mount.LongValue()
 		assert.Equal(t, len(mounts), 1)
 		assert.DeepEqual(t, mounts[0], mounttypes.Mount{
 			Type:   mounttypes.TypeTmpfs,
@@ -176,8 +157,8 @@ func TestMountOptSetTmpfsNoError(t *testing.T) {
 	}
 }
 
-func TestMountOptSetTmpfsError(t *testing.T) {
-	var m MountOpt
+func TestVolumeOptSetTmpfsError(t *testing.T) {
+	var m VolumeOpt
 	assert.Error(t, m.Set("type=tmpfs,target=/foo,tmpfs-size=foo"), "invalid value for tmpfs-size")
 	assert.Error(t, m.Set("type=tmpfs,target=/foo,tmpfs-mode=foo"), "invalid value for tmpfs-mode")
 	assert.Error(t, m.Set("type=tmpfs"), "target is required")

--- a/opts/volume_short.go
+++ b/opts/volume_short.go
@@ -1,0 +1,62 @@
+package opts
+
+// volumeSplitN splits raw into a maximum of n parts, separated by a separator colon.
+// A separator colon is the last `:` character in the regex `[:\\]?[a-zA-Z]:` (note `\\` is `\` escaped).
+// In Windows driver letter appears in two situations:
+// a. `^[a-zA-Z]:` (A colon followed  by `^[a-zA-Z]:` is OK as colon is the separator in volume option)
+// b. A string in the format like `\\?\C:\Windows\...` (UNC).
+// Therefore, a driver letter can only follow either a `:` or `\\`
+// This allows to correctly split strings such as `C:\foo:D:\:rw` or `/tmp/q:/foo`.
+func volumeSplitN(raw string, n int) []string {
+	var array []string
+	if len(raw) == 0 || raw[0] == ':' {
+		// invalid
+		return nil
+	}
+	// numberOfParts counts the number of parts separated by a separator colon
+	numberOfParts := 0
+	// left represents the left-most cursor in raw, updated at every `:` character considered as a separator.
+	left := 0
+	// right represents the right-most cursor in raw incremented with the loop. Note this
+	// starts at index 1 as index 0 is already handle above as a special case.
+	for right := 1; right < len(raw); right++ {
+		// stop parsing if reached maximum number of parts
+		if n >= 0 && numberOfParts >= n {
+			break
+		}
+		if raw[right] != ':' {
+			continue
+		}
+		potentialDriveLetter := raw[right-1]
+		if (potentialDriveLetter >= 'A' && potentialDriveLetter <= 'Z') || (potentialDriveLetter >= 'a' && potentialDriveLetter <= 'z') {
+			if right > 1 {
+				beforePotentialDriveLetter := raw[right-2]
+				// Only `:` or `\\` are checked (`/` could fall into the case of `/tmp/q:/foo`)
+				if beforePotentialDriveLetter != ':' && beforePotentialDriveLetter != '\\' {
+					// e.g. `C:` is not preceded by any delimiter, therefore it was not a drive letter but a path ending with `C:`.
+					array = append(array, raw[left:right])
+					left = right + 1
+					numberOfParts++
+				}
+				// else, `C:` is considered as a drive letter and not as a delimiter, so we continue parsing.
+			}
+			// if right == 1, then `C:` is the beginning of the raw string, therefore `:` is again not considered a delimiter and we continue parsing.
+		} else {
+			// if `:` is not preceded by a potential drive letter, then consider it as a delimiter.
+			array = append(array, raw[left:right])
+			left = right + 1
+			numberOfParts++
+		}
+	}
+	// need to take care of the last part
+	if left < len(raw) {
+		if n >= 0 && numberOfParts >= n {
+			// if the maximum number of parts is reached, just append the rest to the last part
+			// left-1 is at the last `:` that needs to be included since not considered a separator.
+			array[n-1] += raw[left-1:]
+		} else {
+			array = append(array, raw[left:])
+		}
+	}
+	return array
+}

--- a/opts/volume_short_test.go
+++ b/opts/volume_short_test.go
@@ -1,0 +1,57 @@
+package opts
+
+import (
+	"testing"
+)
+
+func TestVolumeSplitN(t *testing.T) {
+	for _, x := range []struct {
+		input    string
+		n        int
+		expected []string
+	}{
+		{`C:\foo:d:`, -1, []string{`C:\foo`, `d:`}},
+		{`:C:\foo:d:`, -1, nil},
+		{`/foo:/bar:ro`, 3, []string{`/foo`, `/bar`, `ro`}},
+		{`/foo:/bar:ro`, 2, []string{`/foo`, `/bar:ro`}},
+		{`C:\foo\:/foo`, -1, []string{`C:\foo\`, `/foo`}},
+
+		{`d:\`, -1, []string{`d:\`}},
+		{`d:`, -1, []string{`d:`}},
+		{`d:\path`, -1, []string{`d:\path`}},
+		{`d:\path with space`, -1, []string{`d:\path with space`}},
+		{`d:\pathandmode:rw`, -1, []string{`d:\pathandmode`, `rw`}},
+		{`c:\:d:\`, -1, []string{`c:\`, `d:\`}},
+		{`c:\windows\:d:`, -1, []string{`c:\windows\`, `d:`}},
+		{`c:\windows:d:\s p a c e`, -1, []string{`c:\windows`, `d:\s p a c e`}},
+		{`c:\windows:d:\s p a c e:RW`, -1, []string{`c:\windows`, `d:\s p a c e`, `RW`}},
+		{`c:\program files:d:\s p a c e i n h o s t d i r`, -1, []string{`c:\program files`, `d:\s p a c e i n h o s t d i r`}},
+		{`0123456789name:d:`, -1, []string{`0123456789name`, `d:`}},
+		{`MiXeDcAsEnAmE:d:`, -1, []string{`MiXeDcAsEnAmE`, `d:`}},
+		{`name:D:`, -1, []string{`name`, `D:`}},
+		{`name:D::rW`, -1, []string{`name`, `D:`, `rW`}},
+		{`name:D::RW`, -1, []string{`name`, `D:`, `RW`}},
+		{`c:/:d:/forward/slashes/are/good/too`, -1, []string{`c:/`, `d:/forward/slashes/are/good/too`}},
+		{`c:\Windows`, -1, []string{`c:\Windows`}},
+		{`c:\Program Files (x86)`, -1, []string{`c:\Program Files (x86)`}},
+
+		{``, -1, nil},
+		{`.`, -1, []string{`.`}},
+		{`..\`, -1, []string{`..\`}},
+		{`c:\:..\`, -1, []string{`c:\`, `..\`}},
+		{`c:\:d:\:xyzzy`, -1, []string{`c:\`, `d:\`, `xyzzy`}},
+
+		// Cover directories with one-character name
+		{`/tmp/x/y:/foo/x/y`, -1, []string{`/tmp/x/y`, `/foo/x/y`}},
+	} {
+		res := volumeSplitN(x.input, x.n)
+		if len(res) < len(x.expected) {
+			t.Fatalf("input: %v, expected: %v, got: %v", x.input, x.expected, res)
+		}
+		for i, e := range res {
+			if e != x.expected[i] {
+				t.Fatalf("input: %v, expected: %v, got: %v", x.input, x.expected, res)
+			}
+		}
+	}
+}

--- a/opts/volume_test.go
+++ b/opts/volume_test.go
@@ -1,0 +1,23 @@
+package opts
+
+import (
+	"testing"
+
+	"github.com/docker/docker/pkg/testutil/assert"
+)
+
+func TestInferVolumeType(t *testing.T) {
+	for s, typ := range map[string]VolumeType{
+		"/foo":                              ShortUnsplitVolume,
+		"foo":                               ShortUnsplitVolume,
+		"/foo:/bar":                         ShortSplitVolume,
+		"foo:/bar":                          ShortSplitVolume,
+		"//c/foo:/bar":                      ShortSplitVolume,
+		"c:/foo:/bar":                       ShortSplitVolume,
+		"type=volume,src=foo,target=/bar":   LongVolume,
+		"type=volume, src=foo, target=/bar": LongVolume,
+		"type=blah":                         LongVolume,
+	} {
+		assert.Equal(t, InferVolumeType(s), typ)
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This PR implements the new UX guideline concluded in https://github.com/docker/docker/issues/28527#issuecomment-262817805

> Mounts: deprecate --mount (maybe remove it from run immediately) and have --volume support the long syntax.

The long-syntax is compatible to `--mount` except that the flag name is `--volume`.

 * `docker run`:     supports both the short-syntax and the long-syntax
 * `docker service`: only supports the long-syntax

The long/short detection is done by using some regexp matching implemented in
`opts/volume.go`. (see `InferVolumeType()`)

This commit also introduces `--volume-add` and `--volume-rm` for `docker service`,
and hence deprecates `--mount-add` and `--mount-rm`.
Note that `--mount`, `--mount-add`, and `--mount-rm` are still available for
compatibility.

**- How I did it**

Please refer to `opts/volume.go`

```go
// InferVolumeType infers the VolumeType
func InferVolumeType(s string) VolumeType {
        // NOTE: we can't use `(,\\w+=\\w+)*` (originally suggested in #28527),
        // because `\w` lacks '/' and non-ASCII chars
        matchedLong, err := regexp.MatchString(".+=.+", s)
        if err != nil {
                // should not happen
                return InvalidVolume
        }
        if matchedLong {
                return LongVolume
        }
        if len(volumeSplitN(s, 2)) > 1 {
                return ShortSplitVolume
        }
        return ShortUnsplitVolume
}
```

**- How to verify it**

 * Make sure `docker run --volume type=volume,source=foo,destination=/bar` works
 * Make sure `docker run -v foo:/bar` works
 * Make sure `docker service create --volume type=volume,source=foo,destination=/bar` works
 * Make sure `docker service create --mount type=volume,source=foo,destination=/bar` works
 * Make sure `docker service create -v foo:/bar` fails with an error like `unsupported volumes (needs to be in long-syntax): [foo:/bar]`.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
cli: long-syntax support for `--volume` (deprecates `--mount` for `docker service`)

**- A picture of a cute animal (not mandatory but encouraged)**
![king_penguin_chick_at_salisbury_plain_ 5719980176](https://cloud.githubusercontent.com/assets/9248427/22240620/487d676c-e25f-11e6-8847-4712ba9dd724.jpg)



Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>