### PR TITLE
Add bash completion for `docker swarm unlock|unlock-key`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2931,6 +2931,8 @@ _docker_swarm() {
 		join
 		join-token
 		leave
+		unlock
+		unlock-key
 		update
 	"
 	__docker_subcommands "$subcommands" && return
@@ -3031,6 +3033,22 @@ _docker_swarm_leave() {
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "--force -f --help" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_swarm_unlock() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_swarm_unlock-key() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help --quiet -q --rotate" -- "$cur" ) )
 			;;
 	esac
 }


### PR DESCRIPTION
There seem to be new commands in 1.13.0 that were not mentioned in the release notes: https://github.com/docker/docker/pull/28275/files#r87524605.

Please add to 1.13.0
Ping @sdurrheimer for zsh completion