### PR TITLE
Add "src" alias for `--secret`

### DIFF
--- a/opts/secret.go
+++ b/opts/secret.go
@@ -50,7 +50,7 @@ func (o *SecretOpt) Set(value string) error {
 
 		value := parts[1]
 		switch key {
-		case "source":
+		case "source", "src":
 			options.Source = value
 		case "target":
 			tDir, _ := filepath.Split(value)

--- a/opts/secret_test.go
+++ b/opts/secret_test.go
@@ -35,6 +35,18 @@ func TestSecretOptionsSourceTarget(t *testing.T) {
 	assert.Equal(t, req.Target, "testing")
 }
 
+func TestSecretOptionsShorthand(t *testing.T) {
+	var opt SecretOpt
+
+	testCase := "src=foo,target=testing"
+	assert.NilError(t, opt.Set(testCase))
+
+	reqs := opt.Value()
+	assert.Equal(t, len(reqs), 1)
+	req := reqs[0]
+	assert.Equal(t, req.Source, "foo")
+}
+
 func TestSecretOptionsCustomUidGid(t *testing.T) {
 	var opt SecretOpt
 


### PR DESCRIPTION
This patch adds a "src" alias for `--secret` to be consistent with `--mount`.

As noted in https://github.com/docker/docker/pull/30370#pullrequestreview-18072178, and discussed in https://github.com/docker/docker/issues/28527#issuecomment-262817805

ping @AkihiroSuda @icecrime ptal