### PR TITLE
Fix deadlock on v1 plugin with activate error

### DIFF
--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"errors"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -17,6 +18,12 @@ func TestPluginAddHandler(t *testing.T) {
 
 	testActive(t, p)
 	Handle("bananas", func(_ string, _ *Client) {})
+	testActive(t, p)
+}
+
+func TestPluginWaitBadPlugin(t *testing.T) {
+	p := &Plugin{activateWait: sync.NewCond(&sync.Mutex{})}
+	p.activateErr = errors.New("some junk happened")
 	testActive(t, p)
 }
 

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -169,7 +169,7 @@ func (p *Plugin) activateWithLock() error {
 
 func (p *Plugin) waitActive() error {
 	p.activateWait.L.Lock()
-	for !p.activated() {
+	for !p.activated() && p.activateErr == nil {
 		p.activateWait.Wait()
 	}
 	p.activateWait.L.Unlock()


### PR DESCRIPTION
When a plugin has an activation error, it was not being checked in the
`waitActive` loop. This means it will just wait forever for a manifest
to be populated even though it may never come.

This is needed for 1.13.1 as well.