### PR TITLE
do not ignore local build-contexts starting with "github.com"

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -156,12 +156,14 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 	switch {
 	case specifiedContext == "-":
 		buildCtx, relDockerfile, err = build.GetContextFromReader(dockerCli.In(), options.dockerfileName)
+	case isLocalDir(specifiedContext):
+		contextDir, relDockerfile, err = build.GetContextFromLocalDir(specifiedContext, options.dockerfileName)
 	case urlutil.IsGitURL(specifiedContext):
 		tempDir, relDockerfile, err = build.GetContextFromGitURL(specifiedContext, options.dockerfileName)
 	case urlutil.IsURL(specifiedContext):
 		buildCtx, relDockerfile, err = build.GetContextFromURL(progBuff, specifiedContext, options.dockerfileName)
 	default:
-		contextDir, relDockerfile, err = build.GetContextFromLocalDir(specifiedContext, options.dockerfileName)
+		return fmt.Errorf("unable to prepare context: path %q not found", specifiedContext)
 	}
 
 	if err != nil {
@@ -354,6 +356,11 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 	}
 
 	return nil
+}
+
+func isLocalDir(c string) bool {
+	_, err := os.Stat(c)
+	return err == nil
 }
 
 type translatorFunc func(context.Context, reference.NamedTagged) (reference.Canonical, error)


### PR DESCRIPTION
Docker special-cases build-contexts starting with `github.com`, and
treats them as remote URLs.

Because of this special treatment, local build contexts in a directory
named "github.com" are ignored by `docker build`.

This patch changes the way the build-context is detected and first
checks if a local path with the given name exists before considering
it to be a remote URL.

Before this change;

    $ mkdir -p github.com/foo/bar && echo -e "FROM scratch\nLABEL iam=local" > github.com/foo/bar/Dockerfile

    $ docker build -t dont-ignore-me github.com/foo/bar
    Username for 'https://github.com':

After this change;

    $ mkdir -p github.com/foo/bar && echo -e "FROM scratch\nLABEL iam=local" > github.com/foo/bar/Dockerfile

    $ docker build -t dont-ignore-me github.com/foo/bar
    Sending build context to Docker daemon 2.048 kB
    Step 1/2 : FROM scratch
     --->
    Step 2/2 : LABEL iam local
     ---> Using cache
     ---> ae2c603fe970
    Successfully built ae2c603fe970

