### PR TITLE
Add support for gitlab urls

### DIFF
--- a/pkg/urlutil/urlutil_test.go
+++ b/pkg/urlutil/urlutil_test.go
@@ -14,6 +14,7 @@ var (
 	}
 	incompleteGitUrls = []string{
 		"github.com/docker/docker",
+		"gitlab.com/foo/bar",
 	}
 	invalidGitUrls = []string{
 		"http://github.com/docker/docker.git:#branch",


### PR DESCRIPTION
Docker has a special case for github.com URLs,
allowing people to build directly from a repository
on github.com.

This change adds the same special case for
gitlab.com URLs

Before this change;

    docker build -t foobar gitlab.com/thaJeztah/test-dockerfile
    unable to prepare context: unable to evaluate symlinks in context path: lstat /Users/sebastiaan/go/src/github.com/docker/docker/gitlab.com: no such file or directory

After this change;

    docker build -t foobar gitlab.com/thaJeztah/test-dockerfile
    Sending build context to Docker daemon 49.66 kB
    Step 1/2 : FROM scratch
     --->
    Step 2/2 : LABEL foo bar
     ---> Running in 19699c2eb29d
     ---> af634b368bee
    Removing intermediate container 19699c2eb29d
    Successfully built af634b368bee

**- What I did**

Added "special case" `gitlab.com` build contexts

**- How I did it**

**- How to verify it**

See above

**- Description for the changelog**

Improved support for building from gitlab.com repositories.

**- A picture of a cute animal (not mandatory but encouraged)**

