### PR TITLE
Add windows specific bash completion for `docker run|create|build`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1361,7 +1361,6 @@ _docker_container_run() {
 		--ip
 		--ip6
 		--ipc
-		--isolation
 		--kernel-memory
 		--label-file
 		--label -l
@@ -1405,6 +1404,7 @@ _docker_container_run() {
 		--credentialspec
 		--io-maxbandwidth
 		--io-maxiops
+		--isolation
 	"
 
 	local boolean_options="
@@ -1523,8 +1523,10 @@ _docker_container_run() {
 			return
 			;;
 		--isolation)
-			__docker_complete_isolation
-			return
+			if __docker_daemon_os_is windows ; then
+				__docker_complete_isolation
+				return
+			fi
 			;;
 		--link)
 			case "$cur" in
@@ -2028,7 +2030,6 @@ _docker_image_build() {
 		--cpu-period
 		--cpu-quota
 		--file -f
-		--isolation
 		--label
 		--memory -m
 		--memory-swap
@@ -2036,6 +2037,9 @@ _docker_image_build() {
 		--shm-size
 		--tag -t
 		--ulimit
+	"
+	__docker_daemon_os_is windows && options_with_args+="
+		--isolation
 	"
 
 	local boolean_options="
@@ -2067,8 +2071,10 @@ _docker_image_build() {
 			return
 			;;
 		--isolation)
-			__docker_complete_isolation
-			return
+			if __docker_daemon_os_is windows ; then
+				__docker_complete_isolation
+				return
+			fi
 			;;
 		--network)
 			case "$cur" in

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -435,10 +435,10 @@ __docker_append_to_completions() {
 	COMPREPLY=( ${COMPREPLY[@]/%/"$1"} )
 }
 
-# __docker_is_experimental tests whether the currently configured Docker daemon
-# runs in experimental mode. If so, the function exits with 0 (true).
+# __docker_daemon_is_experimental tests whether the currently configured Docker
+# daemon runs in experimental mode. If so, the function exits with 0 (true).
 # Otherwise, or if the result cannot be determined, the exit value is 1 (false).
-__docker_is_experimental() {
+__docker_daemon_is_experimental() {
 	[ "$(__docker_q version -f '{{.Server.Experimental}}')" = "true" ]
 }
 
@@ -906,7 +906,7 @@ _docker_docker() {
 		*)
 			local counter=$( __docker_pos_first_nonflag "$(__docker_to_extglob "$global_options_with_args")" )
 			if [ $cword -eq $counter ]; then
-				__docker_is_experimental && commands+=(${experimental_commands[*]})
+				__docker_daemon_is_experimental && commands+=(${experimental_commands[*]})
 				COMPREPLY=( $( compgen -W "${commands[*]} help" -- "$cur" ) )
 			fi
 			;;
@@ -1955,7 +1955,7 @@ _docker_daemon() {
 }
 
 _docker_deploy() {
-	__docker_is_experimental && _docker_stack_deploy
+	__docker_daemon_is_experimental && _docker_stack_deploy
 }
 
 _docker_diff() {
@@ -2052,7 +2052,7 @@ _docker_image_build() {
 		--quiet -q
 		--rm
 	"
-	__docker_is_experimental && boolean_options+="--squash"
+	__docker_daemon_is_experimental && boolean_options+="--squash"
 
 	local all_options="$options_with_args $boolean_options"
 
@@ -3633,7 +3633,7 @@ _docker_stack() {
 _docker_stack_deploy() {
 	case "$prev" in
 		--bundle-file)
-			if __docker_is_experimental ; then
+			if __docker_daemon_is_experimental ; then
 				_filedir dab
 				return
 			fi
@@ -3647,7 +3647,7 @@ _docker_stack_deploy() {
 	case "$cur" in
 		-*)
 			local options="--compose-file -c --help --with-registry-auth"
-			__docker_is_experimental && options+=" --bundle-file"
+			__docker_daemon_is_experimental && options+=" --bundle-file"
 			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 	esac

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -442,6 +442,18 @@ __docker_is_experimental() {
 	[ "$(__docker_q version -f '{{.Server.Experimental}}')" = "true" ]
 }
 
+# __docker_daemon_os_is tests whether the currently configured Docker daemon runs
+# on the operating system passed in as the first argument.
+# It does so by querying the daemon for its OS. The result is cached for the duration
+# of one invocation of bash completion so that this function can be used to test for
+# several different operating systems without additional costs.
+# Known operating systems: linux, windows.
+__docker_daemon_os_is() {
+	local expected_os="$1"
+	local actual_os=${daemon_os=$(__docker_q version -f '{{.Server.Os}}')}
+	[ "$actual_os" = "$expected_os" ]
+}
+
 # __docker_pos_first_nonflag finds the position of the first word that is neither
 # option nor an option's argument. If there are options that require arguments,
 # you should pass a glob describing those options, e.g. "--option1|-o|--option2"
@@ -1386,6 +1398,13 @@ _docker_container_run() {
 		--volumes-from
 		--volume -v
 		--workdir -w
+	"
+	__docker_daemon_os_is windows && options_with_args+="
+		--cpu-count
+		--cpu-percent
+		--credentialspec
+		--io-maxbandwidth
+		--io-maxiops
 	"
 
 	local boolean_options="
@@ -4132,7 +4151,7 @@ _docker() {
 		--tlskey
 	"
 
-	local host config
+	local host config daemon_os
 
 	COMPREPLY=()
 	local cur prev words cword


### PR DESCRIPTION
We already selectively enable experimental features in bash completion.
This PR extents the concept to OS specific enablement of features.
You can now write code like

```bash
local options="--foo --bar"
if __docker_daemon_os_is windows ; then
    options+=" --windows-option"
elif __docker_daemon_os_is solaris ; then
    options+=" --solaris-option"
fi
```
This PR then adds five missing windows specific options to `docker run|create` (references #21384, #23389 #24194). These options were found by executing `docker run --help | grep -i windows`.

An existing option `--isolation` is then moved to windows specific treatment.

For consistency and better naming, an existing helper function is renamed: `s/__docker_is_experimental/__docker_daemon_is_experimental/g`

In a next step, Linux specific options could be hidden in Windows daemon context.

Ping @tianon @AkihiroSuda this is what we discussed on slack, PTAL
Ping @thaJeztah Think you gonna like this one.
Ping @mlaventure for review
Ping @sdurrheimer for zsh completion