### PR TITLE
Resolve race conditions in attach API call

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -365,19 +365,6 @@ func (container *Container) GetExecIDs() []string {
 	return container.ExecCommands.List()
 }
 
-// Attach connects to the container's stdio to the client streams
-func (container *Container) Attach(cfg *stream.AttachConfig) chan error {
-	ctx := container.InitAttachContext()
-
-	cfg.TTY = container.Config.Tty
-	if !container.Config.OpenStdin {
-		cfg.Stdin = nil
-	}
-	cfg.CloseStdin = cfg.Stdin != nil && container.Config.StdinOnce
-
-	return container.StreamConfig.Attach(ctx, cfg)
-}
-
 // ShouldRestart decides whether the daemon should restart the container or not.
 // This is based on the container's restart policy.
 func (container *Container) ShouldRestart() bool {

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -210,15 +210,19 @@ func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.R
 		return err
 	}
 
-	attachConfig := &stream.AttachConfig{
+	attachConfig := stream.AttachConfig{
 		TTY:        ec.Tty,
+		UseStdin:   cStdin != nil,
+		UseStdout:  cStdout != nil,
+		UseStderr:  cStderr != nil,
 		Stdin:      cStdin,
 		Stdout:     cStdout,
 		Stderr:     cStderr,
 		DetachKeys: ec.DetachKeys,
 		CloseStdin: true,
 	}
-	attachErr := ec.StreamConfig.Attach(ctx, attachConfig)
+	ec.StreamConfig.AttachStreams(&attachConfig)
+	attachErr := ec.StreamConfig.CopyStreams(ctx, &attachConfig)
 
 	systemPid, err := d.containerd.AddProcess(ctx, c.ID, name, p, ec.InitializeStdio)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Jim Minter <jminter@redhat.com>

Fixes #29285

**- What I did**

In `container/container.go`, split AttachStreams() into two pieces.  The first returns the container's streams, having registered stdout & stderr in the broadcaster.  The second does the byte copying as before.

In `daemon/attach.go` pull forward the call to container.AttachStreams() so that these are held before the HTTP response is returned to the client via c.GetStreams().

**- How to verify it**

See reproducer in #29285

**- Description for the changelog**

Resolve race conditions in attach API call