### PR TITLE
update api docs on Placement.Constraints for services

### DIFF
--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -4460,7 +4460,11 @@ List services
               "Condition": "any",
               "MaxAttempts": 0
             },
-            "Placement": {}
+            "Placement": {
+              "Constraints": [
+                "node.role == worker"
+              ]
+            }
           },
           "Mode": {
             "Replicated": {
@@ -4576,7 +4580,11 @@ image](#create-an-image) section for more details.
             "max-size": "10M"
           }
         },
-        "Placement": {},
+        "Placement": {
+          "Constraints": [
+            "node.role == worker"
+          ]
+        },
         "Resources": {
           "Limits": {
             "MemoryBytes": 104857600
@@ -4683,7 +4691,8 @@ image](#create-an-image) section for more details.
           is 0, which is ignored).
         - **Window** – Windows is the time window used to evaluate the restart policy (default value is
           0, which is unbounded).
-    - **Placement** – An array of constraints.
+    - **Placement** – Restrictions on where a service can run.
+        - **Constraints** – An array of constraints, e.g. `[ "node.role == manager" ]`.
 - **Mode** – Scheduling mode for the service (`replicated` or `global`, defaults to `replicated`).
 - **UpdateConfig** – Specification for the update strategy of the service.
     - **Parallelism** – Maximum number of tasks to be updated in one iteration (0 means unlimited
@@ -4922,7 +4931,8 @@ image](#create-an-image) section for more details.
           is 0, which is ignored).
         - **Window** – Windows is the time window used to evaluate the restart policy (default value is
           0, which is unbounded).
-    - **Placement** – An array of constraints.
+    - **Placement** – Restrictions on where a service can run.
+        - **Constraints** – An array of constraints, e.g. `[ "node.role == manager" ]`.
 - **Mode** – Scheduling mode for the service (`replicated` or `global`, defaults to `replicated`).
 - **UpdateConfig** – Specification for the update strategy of the service.
     - **Parallelism** – Maximum number of tasks to be updated in one iteration (0 means unlimited


### PR DESCRIPTION
Signed-off-by: Lars-Magnus Skog <ralphtheninja@riseup.net>

**- What I did**

I noticed that when inspecting a service with constraints, the output of `Placement` doesn't correspond with the api docs, i.e. `Placement` is not an array of constraints, but rather contains a `Constraints` property which holds the array of constraints.

**- Description for the changelog**

Document `Placement.Constraints` as the array of constraints and give some simple examples of what it can look like.

**- A picture of a cute animal (not mandatory but encouraged)**

![apa](https://cloud.githubusercontent.com/assets/308049/22332515/9dc7e68e-e3d1-11e6-8f35-5f8efd81458c.jpeg)
