### PR TITLE
sort volume drivers  and auth plugins in info response

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 
@@ -522,4 +523,17 @@ func ValidateConfiguration(config *Config) error {
 	}
 
 	return nil
+}
+
+// GetAuthorizationPlugins returns daemon's sorted authorization plugins
+func (config *Config) GetAuthorizationPlugins() []string {
+	config.reloadLock.Lock()
+	defer config.reloadLock.Unlock()
+
+	authPlugins := make([]string, 0, len(config.AuthorizationPlugins))
+	for _, p := range config.AuthorizationPlugins {
+		authPlugins = append(authPlugins, p)
+	}
+	sort.Strings(authPlugins)
+	return authPlugins
 }

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -174,7 +174,7 @@ func (daemon *Daemon) showPluginsInfo() types.PluginsInfo {
 
 	pluginsInfo.Volume = volumedrivers.GetDriverList()
 	pluginsInfo.Network = daemon.GetNetworkDriverList()
-	pluginsInfo.Authorization = daemon.configStore.AuthorizationPlugins
+	pluginsInfo.Authorization = daemon.configStore.GetAuthorizationPlugins()
 
 	return pluginsInfo
 }

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -4,6 +4,7 @@ package volumedrivers
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/docker/docker/pkg/locker"
@@ -176,6 +177,7 @@ func GetDriverList() []string {
 		driverList = append(driverList, driverName)
 	}
 	drivers.Unlock()
+	sort.Strings(driverList)
 	return driverList
 }
 


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I found that in API `GET /info`, there are several kinds of plugins: network, volume and authorization plugins.
When we get the response, network plugins are sorted, while others are not. This PR tries to sort volume drivers and AuthorizationPlugins.

**- What I did**
1. sort volume driver in info response;
2. sort AuthorizationPlugins in info response.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

