### PR TITLE
Fix broken relative links in old API docs

### DIFF
--- a/docs/api/v1.18.md
+++ b/docs/api/v1.18.md
@@ -1217,7 +1217,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../../reference/builder.md#add)).
+command*](../reference/builder.md#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,

--- a/docs/api/v1.19.md
+++ b/docs/api/v1.19.md
@@ -1261,7 +1261,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../../reference/builder.md#add)).
+command*](../reference/builder.md#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,

--- a/docs/api/v1.20.md
+++ b/docs/api/v1.20.md
@@ -1390,7 +1390,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../../reference/builder.md#add)).
+command*](../reference/builder.md#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -1473,7 +1473,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../../reference/builder.md#add)).
+command*](../reference/builder.md#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,
@@ -1511,7 +1511,7 @@ or being killed.
         these values at build-time. Docker uses the `buildargs` as the environment
         context for command(s) run via the Dockerfile's `RUN` instruction or for
         variable expansion in other Dockerfile instructions. This is not meant for
-        passing secret values. [Read more about the buildargs instruction](../../reference/builder.md#arg)
+        passing secret values. [Read more about the buildargs instruction](../reference/builder.md#arg)
 
 **Request Headers**:
 

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -1652,7 +1652,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../../reference/builder.md#add)).
+command*](../reference/builder.md#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,
@@ -1690,7 +1690,7 @@ or being killed.
         these values at build-time. Docker uses the `buildargs` as the environment
         context for command(s) run via the Dockerfile's `RUN` instruction or for
         variable expansion in other Dockerfile instructions. This is not meant for
-        passing secret values. [Read more about the buildargs instruction](../../reference/builder.md#arg)
+        passing secret values. [Read more about the buildargs instruction](../reference/builder.md#arg)
 -   **shmsize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
 
 **Request Headers**:

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -1687,7 +1687,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../../reference/builder.md#add)).
+command*](../reference/builder.md#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,
@@ -1725,7 +1725,7 @@ or being killed.
         these values at build-time. Docker uses the `buildargs` as the environment
         context for command(s) run via the Dockerfile's `RUN` instruction or for
         variable expansion in other Dockerfile instructions. This is not meant for
-        passing secret values. [Read more about the buildargs instruction](../../reference/builder.md#arg)
+        passing secret values. [Read more about the buildargs instruction](../reference/builder.md#arg)
 -   **shmsize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
 -   **labels** – JSON map of string pairs for labels to set on the image.
 

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -1684,7 +1684,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../../reference/builder.md#add)).
+command*](../reference/builder.md#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,
@@ -1722,7 +1722,7 @@ or being killed.
         these values at build-time. Docker uses the `buildargs` as the environment
         context for command(s) run via the Dockerfile's `RUN` instruction or for
         variable expansion in other Dockerfile instructions. This is not meant for
-        passing secret values. [Read more about the buildargs instruction](../../reference/builder.md#arg)
+        passing secret values. [Read more about the buildargs instruction](../reference/builder.md#arg)
 -   **shmsize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
 -   **labels** – JSON map of string pairs for labels to set on the image.
 
@@ -4078,7 +4078,7 @@ Remove a node from the swarm.
 
 -   **200** – no error
 -   **404** – no such node
--   **406** – node is not part of a swarm 
+-   **406** – node is not part of a swarm
 -   **500** – server error
 
 #### Update a node


### PR DESCRIPTION
**- What I did**

Fixed broken links in API docs that are affecting docs.docker.com and also Github browsing

This will need to be cherry-picked back at least to v1.12, if not further....

cc/ @aduermael 

**- A picture of a cute animal (not mandatory but encouraged)**

![duck-billed platypi](https://sites.google.com/site/duckbilledplatypusmd2012/_/rsrc/1335463273055/life-cycle/babyplatypus.jpg)