### PR TITLE
install: map debian_version 9.X to debian stretch

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -178,6 +178,9 @@ check_forked() {
 				lsb_dist=debian
 				dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 				case "$dist_version" in
+					9)
+						dist_version="stretch"
+					;;
 					8|'Kali Linux 2')
 						dist_version="jessie"
 					;;


### PR DESCRIPTION
Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>

**- What I did**
Add missing case for /etc/debian_version 9.X in the install.sh script
See #30456

**- How I did it**
Add a case mapping debian_version 9.X to version "stretch"

**- How to verify it**
Launch debian stretch RC1 (e.g. in a VM), check that it only works with the patch.
Also verify that the patch doesn't break debian jessie.

**- Description for the changelog**
Fix debian stretch support in install.sh

**- A picture of a cute animal (not mandatory but encouraged)**
Should be relevant for debian stretch ;)
![octopus](https://cloud.githubusercontent.com/assets/3645581/22346363/a4fedd36-e3b8-11e6-8cfe-1a2deaa98368.jpg)

