### PR TITLE
Add [OPTIONS] to usage of `plugin disable|push`

### DIFF
--- a/cli/command/plugin/disable.go
+++ b/cli/command/plugin/disable.go
@@ -14,7 +14,7 @@ func newDisableCommand(dockerCli *command.DockerCli) *cobra.Command {
 	var force bool
 
 	cmd := &cobra.Command{
-		Use:   "disable PLUGIN",
+		Use:   "disable [OPTIONS] PLUGIN",
 		Short: "Disable a plugin",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/plugin/push.go
+++ b/cli/command/plugin/push.go
@@ -16,7 +16,7 @@ import (
 
 func newPushCommand(dockerCli *command.DockerCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "push PLUGIN[:TAG]",
+		Use:   "push [OPTIONS] PLUGIN[:TAG]",
 		Short: "Push a plugin to a registry",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/reference/commandline/plugin_disable.md
+++ b/docs/reference/commandline/plugin_disable.md
@@ -16,7 +16,7 @@ keywords: "plugin, disable"
 # plugin disable
 
 ```markdown
-Usage:  docker plugin disable PLUGIN
+Usage:  docker plugin disable [OPTIONS] PLUGIN
 
 Disable a plugin
 

--- a/docs/reference/commandline/plugin_push.md
+++ b/docs/reference/commandline/plugin_push.md
@@ -14,7 +14,7 @@ keywords: "plugin, push"
 -->
 
 ```markdown
-Usage:	docker plugin push PLUGIN[:TAG]
+Usage:	docker plugin push [OPTIONS] PLUGIN[:TAG]
 
 Push a plugin to a registry
 


### PR DESCRIPTION
These are the usage lines from several plugin commands:
```bash
$ for command in push disable enable ; do docker plugin $command --help | grep Usage ; done
Usage:  docker plugin push PLUGIN[:TAG]
Usage:  docker plugin disable PLUGIN
Usage:  docker plugin enable [OPTIONS] PLUGIN
```
All three commands have options (other than `--help`), but only `enable` (included just for reference) has `[OPTIONS]` in the usage line.

With this fix:
```bash
$ for command in push disable enable ; do docker plugin $command --help | grep Usage ; done
Usage:  docker plugin push [OPTIONS] PLUGIN[:TAG]
Usage:  docker plugin disable [OPTIONS] PLUGIN
Usage:  docker plugin enable [OPTIONS] PLUGIN
```
The reference pages were also adjusted.