### PR TITLE
Add bash completion for `docker service logs`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2662,6 +2662,8 @@ _docker_service() {
 		ps
 		update
 	"
+	__docker_daemon_is_experimental && subcommands+="logs"
+
 	__docker_subcommands "$subcommands" && return
 
 	case "$cur" in
@@ -2691,6 +2693,26 @@ _docker_service_inspect() {
 			;;
 		*)
 			__docker_complete_services
+	esac
+}
+
+_docker_service_logs() {
+	case "$prev" in
+		--since|--tail)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--details --follow -f --help --no-resolve --since --tail --timestamps -t" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag '--since|--tail')
+			if [ $cword -eq $counter ]; then
+				__docker_complete_services
+			fi
+			;;
 	esac
 }
 


### PR DESCRIPTION
Sorry, missed this one: #28089.
Please schedule for 1.13.1.
Ping @sdurrheimer for zsh completion