### PR TITLE
Cherry-pick #30478 to 1.13.x

### DIFF
--- a/docs/api/v1.18.md
+++ b/docs/api/v1.18.md
@@ -1216,7 +1216,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../../reference/builder.md#add)).
+command*](../reference/builder.md#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,

--- a/docs/api/v1.19.md
+++ b/docs/api/v1.19.md
@@ -1260,7 +1260,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../../reference/builder.md#add)).
+command*](../reference/builder.md#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,

--- a/docs/api/v1.20.md
+++ b/docs/api/v1.20.md
@@ -1389,7 +1389,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../../reference/builder.md#add)).
+command*](../reference/builder.md#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -1472,7 +1472,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../../reference/builder.md#add)).
+command*](../reference/builder.md#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,
@@ -1510,7 +1510,7 @@ or being killed.
         these values at build-time. Docker uses the `buildargs` as the environment
         context for command(s) run via the Dockerfile's `RUN` instruction or for
         variable expansion in other Dockerfile instructions. This is not meant for
-        passing secret values. [Read more about the buildargs instruction](../../reference/builder.md#arg)
+        passing secret values. [Read more about the buildargs instruction](../reference/builder.md#arg)
 
 **Request Headers**:
 

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -1651,7 +1651,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../../reference/builder.md#add)).
+command*](../reference/builder.md#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,
@@ -1689,7 +1689,7 @@ or being killed.
         these values at build-time. Docker uses the `buildargs` as the environment
         context for command(s) run via the Dockerfile's `RUN` instruction or for
         variable expansion in other Dockerfile instructions. This is not meant for
-        passing secret values. [Read more about the buildargs instruction](../../reference/builder.md#arg)
+        passing secret values. [Read more about the buildargs instruction](../reference/builder.md#arg)
 -   **shmsize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
 
 **Request Headers**:

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -1686,7 +1686,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../../reference/builder.md#add)).
+command*](../reference/builder.md#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,
@@ -1724,7 +1724,7 @@ or being killed.
         these values at build-time. Docker uses the `buildargs` as the environment
         context for command(s) run via the Dockerfile's `RUN` instruction or for
         variable expansion in other Dockerfile instructions. This is not meant for
-        passing secret values. [Read more about the buildargs instruction](../../reference/builder.md#arg)
+        passing secret values. [Read more about the buildargs instruction](../reference/builder.md#arg)
 -   **shmsize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
 -   **labels** – JSON map of string pairs for labels to set on the image.
 

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -1683,7 +1683,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../../reference/builder.md#add)).
+command*](../reference/builder.md#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,
@@ -1721,7 +1721,7 @@ or being killed.
         these values at build-time. Docker uses the `buildargs` as the environment
         context for command(s) run via the Dockerfile's `RUN` instruction or for
         variable expansion in other Dockerfile instructions. This is not meant for
-        passing secret values. [Read more about the buildargs instruction](../../reference/builder.md#arg)
+        passing secret values. [Read more about the buildargs instruction](../reference/builder.md#arg)
 -   **shmsize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
 -   **labels** – JSON map of string pairs for labels to set on the image.
 
@@ -4077,7 +4077,7 @@ Remove a node from the swarm.
 
 -   **200** – no error
 -   **404** – no such node
--   **406** – node is not part of a swarm 
+-   **406** – node is not part of a swarm
 -   **500** – server error
 
 #### Update a node


### PR DESCRIPTION
Fix broken relative links in old API docs
(cherry picked from commit 05d4c1314efd6b2ce408734aeece0e73f5d278f0)

Signed-off-by: Misty Stanley-Jones <misty@docker.com>

I know there are other cherry-picks that need to go in but this one is affecting the live docs.