### PR TITLE
Fix installation using make install

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -251,6 +251,7 @@ install_binary() {
 	target="${DOCKER_MAKE_INSTALL_PREFIX:=/usr/local}/bin/"
 	if [ "$(go env GOOS)" == "linux" ]; then
 		echo "Installing $(basename $file) to ${target}"
+		mkdir -p "$target"
 		cp -L "$file" "$target"
 	else
 		echo "Install is only supported on linux"


### PR DESCRIPTION
The following command fails when the target directory does not exist.

	$ sudo make install DOCKER_MAKE_INSTALL_PREFIX=/opt/docker AUTO_GOPATH=1
	KEEPBUNDLE=1 hack/make.sh install-binary
	# WARNING! I don't seem to be running in a Docker container.
	# The result of this command might be an incorrect build, and will not be
	# officially supported.
	#
	# Try this instead: make all
	#

	---> Making bundle: install-binary (in bundles/1.14.0-dev/install-binary)
	Installing docker to /opt/docker/bin/
	cp: cannot create regular file '/opt/docker/bin/': No such file or directory
	make: *** [Makefile:119: install] Error 1

The patch installs the target directory before copying any binaries.

	$ sudo make install DOCKER_MAKE_INSTALL_PREFIX=/opt/docker AUTO_GOPATH=1
	KEEPBUNDLE=1 hack/make.sh install-binary
	# WARNING! I don't seem to be running in a Docker container.
	# The result of this command might be an incorrect build, and will not be
	# officially supported.
	#
	# Try this instead: make all
	#

	---> Making bundle: install-binary (in bundles/1.14.0-dev/install-binary)
	Installing docker to /opt/docker/bin/
	Installing dockerd to /opt/docker/bin/
	Installing docker-runc to /opt/docker/bin/
	Installing docker-containerd to /opt/docker/bin/
	Installing docker-containerd-ctr to /opt/docker/bin/
	Installing docker-containerd-shim to /opt/docker/bin/
	Installing docker-proxy to /opt/docker/bin/
	Installing docker-init to /opt/docker/bin/

Signed-off-by: Gaël PORTAY <gael.portay@savoirfairelinux.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I fixed ```sudo make install DOCKER_MAKE_INSTALL_PREFIX=/a/directory/that/does/not/exist```. 

Currently ```sudo make install``` is safe because the default directory _/usr/local/bin_  is usually present on every system.

**- How I did it**

I simply creates the target directory before copying any files, to make sure it exists.

**- How to verify it**

A simple check test consists in running ```sudo make install DOCKER_MAKE_INSTALL_PREFIX=$PWD/_install AUTO_GOPATH=1 && echo "It works!" || echo "Oops!"```.

**- Description for the changelog**

Fix installation into a destination that does not (yet) exist.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal**

![I met [Biquette] when I was in Autralia
](https://lh3.googleusercontent.com/BcV1UPXBN6xtN3hneWk2waCWkRBnw7vGm426nDVubAwbONCPkcMCYgu_iP4C7InbAXdpDiMm8EHYMA)