### PR TITLE
Fixup use of Error() with format string to use Errorf()

### DIFF
--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -145,7 +145,7 @@ func (s *VolumeStore) Purge(name string) {
 	v, exists := s.names[name]
 	if exists {
 		if _, err := volumedrivers.RemoveDriver(v.DriverName()); err != nil {
-			logrus.Error("Error dereferencing volume driver: %v", err)
+			logrus.Errorf("Error dereferencing volume driver: %v", err)
 		}
 	}
 	if err := s.removeMeta(name); err != nil {


### PR DESCRIPTION
Signed-off-by: Adam Eijdenberg <adam.eijdenberg@gmail.com>

**- What I did**

Fixup use of Error() with format string to use Errorf()

**- How I did it**

go vet nagged me so I fixed it.

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

