### PR TITLE
daemon: correctly init selinux labels

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -172,11 +172,15 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 			continue
 		}
 
-		var con []string
+		var (
+			con            []string
+			selinuxConvert bool
+		)
 		if strings.Contains(opt, "=") {
 			con = strings.SplitN(opt, "=", 2)
 		} else if strings.Contains(opt, ":") {
 			con = strings.SplitN(opt, ":", 2)
+			selinuxConvert = true
 			logrus.Warn("Security options with `:` as a separator are deprecated and will be completely unsupported in 1.14, use `=` instead.")
 		}
 
@@ -186,7 +190,10 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 
 		switch con[0] {
 		case "label":
-			labelOpts = append(labelOpts, con[1])
+			if selinuxConvert {
+				opt = strings.Replace(opt, ":", "=", 1)
+			}
+			labelOpts = append(labelOpts, opt)
 		case "apparmor":
 			container.AppArmorProfile = con[1]
 		case "seccomp":


### PR DESCRIPTION
@rhatdan @mrunalp PTAL

If you run a container with security opt and a selinux label, that label won't be applied to the process. This patches fixes that. (I'm sorry I'm on my mobile right now, I'll find an hot-spot and write down a proper reproducer) 

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

