### PR TITLE
add 400 status code for build api

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4459,6 +4459,10 @@ paths:
       responses:
         200:
           description: "no error"
+        400:
+          description: "Bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         500:
           description: "server error"
           schema:


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

This pr is related to https://github.com/docker/docker/pull/29651.
Code https://github.com/docker/docker/blob/master/builder/dockerfile/builder.go#L97-L99 here seems to introduces a status code 400, so I think it is better to add this. At the very beginning, I thought we should remove this, while it seems unreasonable here, then I try to make this change versioned in api docs.

Please correct me if I missed something. 🐱 

ping @cpuguy83 @LK4D4 @dnephin 

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

