### PR TITLE
Underscoring an unused var in tests

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -356,7 +356,8 @@ func (s *DockerSuite) TestExecInspectID(c *check.C) {
 	}
 
 	// But we should still be able to query the execID
-	sc, body, err := request.SockRequest("GET", "/exec/"+execID+"/json", nil, daemonHost())
+	sc, body, _ := request.SockRequest("GET", "/exec/"+execID+"/json", nil, daemonHost())
+
 	c.Assert(sc, checker.Equals, http.StatusOK, check.Commentf("received status != 200 OK: %d\n%s", sc, body))
 
 	// Now delete the container and then an 'inspect' on the exec should


### PR DESCRIPTION
**- What I did**
I found out that are an unused var in docker_cli_exec_test.go so i added an assert to it.

**- How I did it**
Create a new Assert who will fail if err var isn't equal to Nil

**- How to verify it**
Running docker_cli_exec_test.go

**- Description for the changelog**
New test in Docker CLI Exec Unit validations

**- A picture of a cute animal (not mandatory but encouraged)**
Mountain pygmy possum. [credits](https://www.reddit.com/r/tinyanimalsonfingers/comments/5ps06c/mountain_pygmy_possum/)
![image](https://cloud.githubusercontent.com/assets/683170/22399116/4c36e9b6-e57d-11e6-98e8-d0f80bf5049c.png)

