### PR TITLE
Fixes work of inspectResponse in case of ContentLength=-1

### DIFF
--- a/builder/remote.go
+++ b/builder/remote.go
@@ -129,7 +129,7 @@ func inspectResponse(ct string, r io.ReadCloser, clen int64) (string, io.ReadClo
 		return ct, r, err
 	}
 
-	preambleR := bytes.NewReader(preamble)
+	preambleR := bytes.NewReader(preamble[:rlen])
 	bodyReader := ioutil.NopCloser(io.MultiReader(preambleR, r))
 	// Some web servers will use application/octet-stream as the default
 	// content type for files without an extension (e.g. 'Dockerfile')

--- a/builder/remote_test.go
+++ b/builder/remote_test.go
@@ -151,6 +151,26 @@ func TestInspectResponseEmptyContentType(t *testing.T) {
 	}
 }
 
+func TestUnknownContentLength(t *testing.T) {
+	content := []byte(dockerfileContents)
+	ct := "text/plain"
+	br := ioutil.NopCloser(bytes.NewReader(content))
+	contentType, bReader, err := inspectResponse(ct, br, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contentType != "text/plain" {
+		t.Fatalf("Content type should be 'text/plain' but is %q", contentType)
+	}
+	body, err := ioutil.ReadAll(bReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != dockerfileContents {
+		t.Fatalf("Corrupted response body %s", body)
+	}
+}
+
 func TestMakeRemoteContext(t *testing.T) {
 	contextDir, cleanup := createTestTempDir(t, "", "builder-tarsum-test")
 	defer cleanup()


### PR DESCRIPTION
**- What I did**
Provide a fix for https://github.com/docker/docker/issues/30500. Unable to build dockerfile hosted remotely if ContentLength=-1
**- How I did it**
I've sliced ```preamble``` array for a number of bytes  actually read from stream in this  line ```	rlen, err := r.Read(preamble)```
**- How to verify it**
In ```TestMakeRemoteContext``` replace ```remoteURL := serverURL.String()```
with ```	remoteURL := "https://raw.githubusercontent.com/mkuznyetsov/dockerfiles/master/Dockerfile"```
```dockerfile``` content should be 

```[70 82 79 77 32 99 111 100 101 110 118 121 47 117 98 117 110 116 117 95 106 100 107 56 58 108 97 116 101 115 116 10]```
instead of 
```[70 82 79 77 32 99 111 100 101 110 118 121 47 117 98 117 110 116 117 95 106 100 107 56 58 108 97 116 101 115 116 10 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]```

 

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

