### PR TITLE
Add two arm specific syscalls to seccomp profile

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -632,6 +632,8 @@
 		},
 		{
 			"names": [
+				"arm_fadvise64_64",
+				"arm_sync_file_range",
 				"breakpoint",
 				"cacheflush",
 				"set_tls"

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -535,6 +535,8 @@ func DefaultProfile() *types.Seccomp {
 		},
 		{
 			Names: []string{
+				"arm_fadvise64_64",
+				"arm_sync_file_range",
 				"breakpoint",
 				"cacheflush",
 				"set_tls",


### PR DESCRIPTION
These are arm variants with different argument ordering because of
register alignment requirements.

fix #30516

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![robin4](https://cloud.githubusercontent.com/assets/482364/22404956/0780bcd2-e633-11e6-9bd9-9e11128d4ee7.jpg)
