### PR TITLE
Updated dockerd docs with note about user namespaces

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -993,6 +993,19 @@ with user namespaces enabled or not. If the daemon is configured with user
 namespaces, the Security Options entry in the response will list "userns" as
 one of the enabled security features.
 
+#### Behavior differences when user namespaces are enabled
+
+When you start the Docker daemon with `--userns-remap`, Docker segregates the graph directory
+where the images are stored by adding an extra directory with a name corresponding to the
+remapped UID and GID. For example, if the remapped UID and GID begin with `165536`, all
+images and containers running with that remap setting are located in `/var/lib/docker/165536.165536`
+instead of `/var/lib/docker/`.
+
+In addition, the files and directories within the new directory, which correspond to
+images and container layers, are also owned by the new UID and GID. To set the ownership
+correctly, you need to re-pull the images and restart the containers after starting the
+daemon with `--userns-remap`.
+
 ### Detailed information on `subuid`/`subgid` ranges
 
 Given potential advanced use of the subordinate ID ranges by power users, the


### PR DESCRIPTION
Signed-off-by: Lewis Daly <lewisdaly@me.com>

**- What I did**
Added a note about docker image caching when using `--userns-remap` documentation to `docs/reference/commandline/dockerd.md` 

closes #21050 

**- How I did it**
Simple documentation fix.

**- How to verify it**
Look at the commandline reference docs for dockerd.

**- Description for the changelog**
Added note for dockerd reference about docker image caching when using `--userns-remap`


**- A picture of a cute animal (not mandatory but encouraged)**
![superthumb](https://cloud.githubusercontent.com/assets/1683980/22419980/e5d96298-e72f-11e6-8a09-f329f5148bc2.gif)

