### PR TITLE
[1.13.x] Add two arm specific syscalls to seccomp profile

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -417,6 +417,8 @@
 		},
 		{
 			"names": [
+				"arm_fadvise64_64",
+				"arm_sync_file_range",
 				"breakpoint",
 				"cacheflush",
 				"set_tls"

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -390,6 +390,8 @@ func DefaultProfile() *types.Seccomp {
 		},
 		{
 			Names: []string{
+				"arm_fadvise64_64",
+				"arm_sync_file_range",
 				"breakpoint",
 				"cacheflush",
 				"set_tls",


### PR DESCRIPTION
cherry pick #30545

These are arm variants with different argument ordering because of
register alignment requirements.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

