### PR TITLE
[ppc64le/s390x] add p/z to release-deb

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -24,6 +24,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \
 	apparmor \
+	apt-utils \
 	aufs-tools \
 	automake \
 	bash-completion \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -20,6 +20,7 @@ FROM s390x/debian:jessie
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \
 	apparmor \
+	apt-utils \
 	aufs-tools \
 	automake \
 	bash-completion \

--- a/hack/make/release-deb
+++ b/hack/make/release-deb
@@ -22,7 +22,7 @@ APTDIR=$DOCKER_RELEASE_DIR/apt/repo
 mkdir -p "$APTDIR/conf" "$APTDIR/db" "$APTDIR/dists"
 
 # supported arches/sections
-arches=( amd64 i386 armhf )
+arches=( amd64 i386 armhf ppc64le s390x )
 
 # Preserve existing components but don't add any non-existing ones
 for component in main testing experimental ; do


### PR DESCRIPTION
This adds ppc64le and s390x architectures to those supported
by hack/make/release-debs

How I tested:

I built the debs, made the end repo, and then followed the release guide,
```sh
make deb
sudo mkdir -p /volumes/repos
docker build -t docker .
    docker run --rm -it --privileged \
    -v /volumes/repos:/volumes/repos \
    -v $(pwd)/bundles:/go/src/github.com/docker/docker/bundles \
    -e DOCKER_RELEASE_DIR=/volumes/repos \
    -e KEEPBUNDLE=1 \
    docker \
    hack/make.sh release-deb
```
Then verified that the debs were in /volumes/repos/pool/experimental/d/docker-engine. Then I installed the debs on my test-vm
```sh
Client:
 Version:      1.14.0-dev
 API version:  1.26
 Go version:   go1.7.5
 Git commit:   a08da82-unsupported
 Built:        Mon Jan 30 21:55:12 2017
 OS/Arch:      linux/ppc64le

Server:
 Version:      1.14.0-dev
 API version:  1.26 (minimum version 1.12)
 Go version:   go1.7.5
 Git commit:   a08da82-unsupported
 Built:        Mon Jan 30 21:55:12 2017
 OS/Arch:      linux/ppc64le
 Experimental: false
```

Note: I added apt-utils because it's required for 'apt-ftparchive',
which is used by the release-deb script. This enables us to run
the script through the p and z dockerfiles. It's also already
included in the x86 Dockerfile.

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>

![stork](http://animalia-life.club/data_images/stork/stork6.jpg)

ping @clnperez @ddingel @wfarner
