### PR TITLE
Fix typo in swagger.yaml for NetworkPrune operation

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6365,7 +6365,7 @@ paths:
           schema:
             type: "object"
             properties:
-              VolumesDeleted:
+              NetworksDeleted:
                 description: "Networks that were deleted"
                 type: "array"
                 items:


### PR DESCRIPTION
Verified this was the actual key name in 1.13.0 (API 1.25)