### PR TITLE
client: Allow Proxy Configuration in config.json

### DIFF
--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -15,8 +15,11 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
+	"github.com/docker/docker/cli/config/configfile"
+	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/promise"
 	"github.com/docker/docker/pkg/signal"
+	runconfigopts "github.com/docker/docker/runconfig/opts"
 	"github.com/docker/libnetwork/resolvconf/dns"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -82,8 +85,8 @@ func warnOnLocalhostDNS(hostConfig container.HostConfig, stderr io.Writer) {
 		}
 	}
 }
-
 func runRun(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *runOptions, copts *containerOptions) error {
+	copts.env = parseProxyConfig(dockerCli.ConfigFile(), dockerCli.Client().ClientHost(), copts.env)
 	containerConfig, err := parse(flags, copts)
 	// just in case the parse does not exit
 	if err != nil {
@@ -145,6 +148,7 @@ func runContainer(dockerCli *command.DockerCli, opts *runOptions, copts *contain
 		sigc := ForwardAllSignals(ctx, dockerCli, createResponse.ID)
 		defer signal.StopCatch(sigc)
 	}
+
 	var (
 		waitDisplayID chan struct{}
 		errCh         chan error
@@ -293,4 +297,45 @@ func runStartContainerErr(err error) error {
 	}
 
 	return statusError
+}
+
+func parseProxyConfig(cfg *configfile.ConfigFile, host string, o opts.ListOpts) opts.ListOpts {
+	var cfgKey string
+
+	if _, ok := cfg.Proxies[host]; !ok {
+		cfgKey = "default"
+	} else {
+		cfgKey = host
+	}
+
+	config, _ := cfg.Proxies[cfgKey]
+	permitted := map[string]*string{
+		"HTTP_PROXY":  &config.HTTPProxy,
+		"HTTPS_PROXY": &config.HTTPSProxy,
+		"NO_PROXY":    &config.NoProxy,
+		"FTP_PROXY":   &config.FTPProxy,
+	}
+
+	m := runconfigopts.ConvertKVStringsToMapWithNil(o.GetAll())
+	for k := range permitted {
+		if *permitted[k] == "" {
+			continue
+		}
+		if _, ok := m[k]; !ok {
+			m[k] = permitted[k]
+		}
+		if _, ok := m[strings.ToLower(k)]; !ok {
+			m[strings.ToLower(k)] = permitted[k]
+		}
+	}
+
+	result := []string{}
+	for k, v := range m {
+		if v == nil {
+			result = append(result, k)
+		} else {
+			result = append(result, fmt.Sprintf("%s=%s", k, *v))
+		}
+	}
+	return *opts.NewListOptsRef(&result, nil)
 }

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api"
@@ -19,6 +20,7 @@ import (
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/cli/command/image/build"
+	"github.com/docker/docker/cli/config/configfile"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/fileutils"
@@ -274,7 +276,7 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 		Dockerfile:     relDockerfile,
 		ShmSize:        options.shmSize.Value(),
 		Ulimits:        options.ulimits.GetList(),
-		BuildArgs:      runconfigopts.ConvertKVStringsToMapWithNil(options.buildArgs.GetAll()),
+		BuildArgs:      createBuildArgs(dockerCli.ConfigFile(), dockerCli.Client().ClientHost(), options.buildArgs),
 		AuthConfigs:    authConfigs,
 		Labels:         runconfigopts.ConvertKVStringsToMap(options.labels.GetAll()),
 		CacheFrom:      options.cacheFrom,
@@ -460,4 +462,35 @@ func replaceDockerfileTarWrapper(ctx context.Context, inputTarStream io.ReadClos
 	}()
 
 	return pipeReader
+}
+
+func createBuildArgs(cfg *configfile.ConfigFile, host string, o opts.ListOpts) map[string]*string {
+	var cfgKey string
+
+	if _, ok := cfg.Proxies[host]; !ok {
+		cfgKey = "default"
+	} else {
+		cfgKey = host
+	}
+
+	config, _ := cfg.Proxies[cfgKey]
+	permitted := map[string]*string{
+		"HTTP_PROXY":  &config.HTTPProxy,
+		"HTTPS_PROXY": &config.HTTPSProxy,
+		"NO_PROXY":    &config.NoProxy,
+		"FTP_PROXY":   &config.FTPProxy,
+	}
+	m := runconfigopts.ConvertKVStringsToMapWithNil(o.GetAll())
+	for k := range permitted {
+		if *permitted[k] == "" {
+			continue
+		}
+		if _, ok := m[k]; !ok {
+			m[k] = permitted[k]
+		}
+		if _, ok := m[strings.ToLower(k)]; !ok {
+			m[strings.ToLower(k)] = permitted[k]
+		}
+	}
+	return m
 }

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -38,6 +38,15 @@ type ConfigFile struct {
 	ServicesFormat       string                      `json:"servicesFormat,omitempty"`
 	TasksFormat          string                      `json:"tasksFormat,omitempty"`
 	SecretFormat         string                      `json:"secretFormat,omitempty"`
+	Proxies              map[string]ProxyConfig      `json:"proxies,omitempty"`
+}
+
+// ProxyConfig contains proxy configuration settings
+type ProxyConfig struct {
+	HTTPProxy  string `json:"httpProxy,omitempty"`
+	HTTPSProxy string `json:"httpsProxy,omitempty"`
+	NoProxy    string `json:"noProxy,omitempty"`
+	FTPProxy   string `json:"ftpProxy,omitempty"`
 }
 
 // LegacyLoadFromReader reads the non-nested configuration data given and sets up the

--- a/client/client.go
+++ b/client/client.go
@@ -224,6 +224,12 @@ func (cli *Client) UpdateClientVersion(v string) {
 
 }
 
+// ClientHost returns the host associated with this instance of the Client.
+// This operation doesn't acquire a mutex.
+func (cli *Client) ClientHost() string {
+	return cli.host
+}
+
 // ParseHost verifies that the given host strings is valid.
 func ParseHost(host string) (string, string, string, error) {
 	protoAddrParts := strings.SplitN(host, "://", 2)

--- a/client/interface.go
+++ b/client/interface.go
@@ -28,6 +28,7 @@ type CommonAPIClient interface {
 	SecretAPIClient
 	SystemAPIClient
 	VolumeAPIClient
+	ClientHost() string
 	ClientVersion() string
 	ServerVersion(ctx context.Context) (types.Version, error)
 	UpdateClientVersion(v string)

--- a/integration-cli/cli/cli.go
+++ b/integration-cli/cli/cli.go
@@ -127,3 +127,14 @@ func WithFlags(flags ...string) func(*icmd.Cmd) func() {
 		return nil
 	}
 }
+
+// WithConfigFile sets the location of the client config file
+func WithConfigFile(dir string) func(*icmd.Cmd) func() {
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Command = append(
+			[]string{"--config", dir},
+			cmd.Command...,
+		)
+		return nil
+	}
+}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4828,6 +4828,132 @@ func (s *DockerSuite) TestBuildBuildTimeUnusedArgMultipleFrom(c *check.C) {
 	c.Assert(result.Stdout(), checker.Not(checker.Contains), "baz")
 }
 
+func (s *DockerSuite) TestBuildBuildTimeArgFromConfig(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Windows does not support --build-arg
+	imgName := "bldargtest"
+	envKey := "HTTP_PROXY"
+	envVal := "http://127.0.0.1:9000"
+	dockerfile := fmt.Sprintf(`FROM busybox
+		RUN echo $%s
+		CMD echo $%s`, envKey, envKey)
+
+	tmp, err := ioutil.TempDir("", "integration-cli-")
+	c.Assert(err, checker.IsNil)
+
+	config := `{ "proxies": { "default": { "httpProxy": "http://127.0.0.1:9000" }}}`
+	configPath := filepath.Join(tmp, "config.json")
+	err = ioutil.WriteFile(configPath, []byte(config), 0644)
+	c.Assert(err, checker.IsNil)
+
+	result := buildImage(imgName,
+		cli.WithConfigFile(tmp),
+		build.WithDockerfile(dockerfile),
+	)
+	result.Assert(c, icmd.Success)
+	if !strings.Contains(result.Combined(), envVal) {
+		c.Fatalf("failed to access environment variable in output: %q expected: %q", result.Combined(), envVal)
+	}
+	containerName := "bldargCont"
+	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); out != "\n" {
+		c.Fatalf("run produced invalid output: %q, expected empty string", out)
+	}
+}
+
+func (s *DockerSuite) TestBuildBuildTimeArgFromConfigOverride(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Windows does not support --build-arg
+	imgName := "bldargtest"
+	envKey := "HTTP_PROXY"
+
+	envVal := "http://127.0.0.1:3000"
+	dockerfile := fmt.Sprintf(`FROM busybox
+	RUN echo $%s
+	CMD echo $%s`, envKey, envKey)
+
+	tmp, err := ioutil.TempDir("", "integration-cli-")
+	c.Assert(err, checker.IsNil)
+
+	config := `{ "proxies": { "default": { "httpProxy": "http://127.0.0.1:9000" }}}`
+	configPath := filepath.Join(tmp, "config.json")
+	err = ioutil.WriteFile(configPath, []byte(config), 0644)
+	c.Assert(err, checker.IsNil)
+
+	result := buildImage(imgName,
+		cli.WithConfigFile(tmp),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
+		build.WithDockerfile(dockerfile),
+	)
+	result.Assert(c, icmd.Success)
+	if !strings.Contains(result.Combined(), envVal) {
+		c.Fatalf("failed to access environment variable in output: %q expected: %q", result.Combined(), envVal)
+	}
+	containerName := "bldargCont"
+	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); out != "\n" {
+		c.Fatalf("run produced invalid output: %q, expected empty string", out)
+	}
+}
+
+func (s *DockerSuite) TestBuildBuildTimeArgFromSpecificConfig(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Windows does not support --build-arg
+	imgName := "bldargtest"
+	envKey := "HTTP_PROXY"
+	specificEnvVal := "http://proxy.example.com"
+	dockerfile := fmt.Sprintf(`FROM busybox
+	RUN echo $%s
+	CMD echo $%s`, envKey, envKey)
+
+	tmp, err := ioutil.TempDir("", "integration-cli-")
+	c.Assert(err, checker.IsNil)
+
+	config := `{ "proxies": { "default" : { "httpProxy": "http://127.0.0.1:9000" }, "` + os.Getenv("DOCKER_HOST") + `": { "httpProxy": "` + specificEnvVal + `" }}}`
+	configPath := filepath.Join(tmp, "config.json")
+	err = ioutil.WriteFile(configPath, []byte(config), 0644)
+	c.Assert(err, checker.IsNil)
+
+	result := buildImage(imgName,
+		cli.WithConfigFile(tmp),
+		build.WithDockerfile(dockerfile),
+	)
+	result.Assert(c, icmd.Success)
+	if !strings.Contains(result.Combined(), specificEnvVal) {
+		c.Fatalf("failed to access environment variable in output: %q expected: %q", result.Combined(), specificEnvVal)
+	}
+	containerName := "bldargCont"
+	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); out != "\n" {
+		c.Fatalf("run produced invalid output: %q, expected empty string", out)
+	}
+}
+
+func (s *DockerSuite) TestBuildBuildTimeArgFromBadConfig(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Windows does not support --build-arg
+	imgName := "bldargtest"
+	envKey := "HTTP_PROXY"
+	envVal := "http://127.0.0.1:9000"
+	dockerfile := fmt.Sprintf(`FROM busybox
+RUN echo $%s
+CMD echo $%s`, envKey, envKey)
+
+	tmp, err := ioutil.TempDir("", "integration-cli-")
+	c.Assert(err, checker.IsNil)
+
+	config := `{ "proxies": { "bad" : { "httpProxy": "http://127.0.0.1:9000" }}}`
+	configPath := filepath.Join(tmp, "config.json")
+	err = ioutil.WriteFile(configPath, []byte(config), 0644)
+	c.Assert(err, checker.IsNil)
+
+	result := buildImage(imgName,
+		cli.WithConfigFile(tmp),
+		build.WithDockerfile(dockerfile),
+	)
+	result.Assert(c, icmd.Success)
+	if strings.Contains(result.Combined(), envVal) {
+		c.Fatalf("environment variable '%q' leaked in to output: %q", envKey, result.Combined())
+	}
+	containerName := "bldargCont"
+	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); out != "\n" {
+		c.Fatalf("run produced invalid output: %q, expected empty string", out)
+	}
+}
+
 func (s *DockerSuite) TestBuildNoNamedVolume(c *check.C) {
 	volName := "testname:/foo"
 

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -496,6 +496,16 @@ func buildImage(name string, cmdOperators ...cli.CmdOperator) *icmd.Result {
 	return cli.Docker(cli.Build(name), cmdOperators...)
 }
 
+func withConfigFile(dir string) func(*icmd.Cmd) func() {
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Command = append(cmd.Command, "", "")
+		copy(cmd.Command[3:], cmd.Command[1:])
+		cmd.Command[1] = "--config"
+		cmd.Command[2] = dir
+		return nil
+	}
+}
+
 func withExternalBuildContext(ctx *FakeContext) func(*icmd.Cmd) func() {
 	return func(cmd *icmd.Cmd) func() {
 		cmd.Dir = ctx.Dir


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added a mechanism to allow HTTP/HTTPS/FTP/NO proxy variables to be configured in `config.json`. These are then automatically populated in a `docker run` command as environment variables or as `build-args` in `docker build`!

This makes it easier for users suffering behind an HTTP Proxy as they only need to configure this once as opposed to creating custom aliases or forgetting the args and being denied buildage/runnage.

Updates #30323

**- How I did it**

Extended the `configfile` with some new proxy related variables.

These are scoped per Docker Host with a `default` catchall.

The config file is then read by the `build` or `run` command and the necessary variables are exported.

A `-e` flag or `--build-arg` provided on the CLI will override these default settings.

**- How to verify it**

There are integration tests! But manually, you may:

1. Create a `config.json` with `{ "proxies" : { "httpProxy" : "http://127.0.0.1:3001" }`
2. Create a Dockerfile
```
FROM busybox
RUN echo $HTTP_PROXY
CMD echo $HTTP_PROXY
```
3. `docker --config /path/to/config build -t configtest .`
4. Verify that the `HTTP_PROXY` variable is as configured
5. `docker run --rm configtest env`
6. Verify that the HTTP_PROXY variable is as configured

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Added HTTP/HTTPS/FTP proxy configuration to `config.json`

**- A picture of a cute animal (not mandatory but encouraged)**

![](http://media-cache-ec0.pinimg.com/736x/e1/8c/21/e18c21aedb909d3553d4eae6e9c8961b.jpg)
