### PR TITLE
Bump go-units

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -15,7 +15,7 @@ github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 # forked golang.org/x/net package includes a patch for lazy loading trace templates
 golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://github.com/tonistiigi/net.git
 golang.org/x/sys 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
-github.com/docker/go-units e30f1e79f3cd72542f2026ceec18d3bd67ab859c
+github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
 github.com/docker/go-connections 4ccf312bf1d35e5dbda654e57a9be4c3f3cd0366
 
 github.com/RackSec/srslog 456df3a81436d29ba874f3590eeeee25d666f8a5


### PR DESCRIPTION
Bump for https://github.com/docker/go-units/pull/23