### PR TITLE
Fix syntax in label example

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -709,7 +709,7 @@ it instead, as it enables setting any metadata you require, and can be viewed
 easily, for example with `docker inspect`. To set a label corresponding to the
 `MAINTAINER` field you could use:
 
-    LABEL maintainer "SvenDowideit@home.org.au"
+    LABEL maintainer="SvenDowideit@home.org.au"
 
 This will then be visible from `docker inspect` with the other labels.
 


### PR DESCRIPTION
Fix syntax in example about maintainer info in a label

![image](https://cloud.githubusercontent.com/assets/396417/22486657/b0daec84-e80a-11e6-8302-a5774fd75518.png)

Signed-off-by: Jeroen Franse <jeroenfranse@gmail.com>