### PR TITLE
[WIP] Remove non reproducible parts from image config for stable builds

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -126,7 +126,7 @@ func (daemon *Daemon) newContainer(name string, config *containertypes.Config, h
 	entrypoint, args := daemon.getEntrypointAndArgs(config.Entrypoint, config.Cmd)
 
 	base := daemon.newBaseContainer(id)
-	base.Created = time.Now().UTC()
+	base.Created = time.Time{}
 	base.Managed = managed
 	base.Path = entrypoint
 	base.Args = args //FIXME: de-duplicate from config

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -289,7 +289,6 @@ func (daemon *Daemon) SquashImage(id, parent string) (string, error) {
 		newImage.History[i] = hi
 	}
 
-	now := time.Now()
 	var historyComment string
 	if len(parent) > 0 {
 		historyComment = fmt.Sprintf("merge %s to %s", id, parent)
@@ -298,10 +297,10 @@ func (daemon *Daemon) SquashImage(id, parent string) (string, error) {
 	}
 
 	newImage.History = append(newImage.History, image.History{
-		Created: now,
+		Created: time.Time{},
 		Comment: historyComment,
 	})
-	newImage.Created = now
+	newImage.Created = time.Time{}
 
 	b, err := json.Marshal(&newImage)
 	if err != nil {

--- a/daemon/import.go
+++ b/daemon/import.go
@@ -94,14 +94,16 @@ func (daemon *Daemon) ImportImage(src string, repository, tag string, msg string
 	}
 	defer layer.ReleaseAndLog(daemon.layerStore, l)
 
-	created := time.Now().UTC()
+	// remove hostname from config for reproducibility
+	config.Hostname = ""
+
 	imgConfig, err := json.Marshal(&image.Image{
 		V1Image: image.V1Image{
 			DockerVersion: dockerversion.Version,
 			Config:        config,
 			Architecture:  runtime.GOARCH,
 			OS:            runtime.GOOS,
-			Created:       created,
+			Created:       time.Time{},
 			Comment:       msg,
 		},
 		RootFS: &image.RootFS{
@@ -109,7 +111,7 @@ func (daemon *Daemon) ImportImage(src string, repository, tag string, msg string
 			DiffIDs: []layer.DiffID{l.DiffID()},
 		},
 		History: []image.History{{
-			Created: created,
+			Created: time.Time{},
 			Comment: msg,
 		}},
 	})


### PR DESCRIPTION
If you do the same Docker build again and again, you will currently get
a different outcome. Madness!

The reason for this is that the config file inside the image, from which
the hash is calculated, has some fields that are effectively random or
which change over time.

These are

- config.Hostname - build containers have random hostnames
- container_config.Hostname - same
- container - ID of container used to commit, effectively random
- created - timestamp of creation
- history.created - same

This PR leaves the hostname (and domainname) fields blank, and
the container ID.

Timestamps are set to Go zero time. See https://reproducible-builds.org/docs/timestamps/
for rationale. Users who want timestamps should use labels with eg the commit
time or other repeatable time.

TODO: tests, deprecation notices on fields.

With this patch:
```
whale:repro justin$ cat Dockerfile
FROM scratch
ADD . .
whale:repro justin$ docker build -q --no-cache .
sha256:d6f99a7d1f661973ecda1aa34394c0523774bd61382dee348ec8457471b95578
whale:repro justin$ docker build -q --no-cache .
sha256:d6f99a7d1f661973ecda1aa34394c0523774bd61382dee348ec8457471b95578
whale:repro justin$ docker build -q --no-cache .
sha256:d6f99a7d1f661973ecda1aa34394c0523774bd61382dee348ec8457471b95578
```
without:
```
justin@zander:~/tmp/repro$ docker build -q --no-cache .
sha256:47170bd064a699b2838ecc8b279813da1edde5b49a00d8e866863fa1da94c477
justin@zander:~/tmp/repro$ docker build -q --no-cache .
sha256:f9e5f8f8ac1e23f1d1ed45150d4c69f251056840d8745c4606001f6c340b2baa
justin@zander:~/tmp/repro$ docker build -q --no-cache .
sha256:5924b383e19182bc2d6e382041d5acc11985cdea76c18db12fcbbcd867fd66fb
```

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

cc @riyazdf @stevvooe 

![little-egret](https://cloud.githubusercontent.com/assets/482364/22488399/b30da33a-e809-11e6-9e68-7346a5d2d80e.jpg)
