### PR TITLE
Add tracking to elided layer pulls.

### DIFF
--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -126,6 +126,11 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 					topLayer = l
 					missingLayer = false
 					rootFS.Append(diffID)
+					// Register this repository as a source of this layer.
+					withRegistered, hasRegistered := descriptor.(DownloadDescriptorWithRegistered)
+					if hasRegistered {
+						withRegistered.Registered(diffID)
+					}
 					continue
 				}
 			}


### PR DESCRIPTION
Today if I pull an image from multiple repositories/registries, only the one from which the layer is originally downloaded is "Registered"; this inhibits the docker client's ability to "mount" a layer from any of these secondary repositories, even if that secondary repository is the only repository in which a given layer pre-exists for a particular registry domain.

For example, if I pull:
```
   docker pull a.com/foo/bar
   docker pull b.com/baz/blah
```

Any layers that are shared between these will be associated with the first repository.  So if I turn around and push:
```
  docker tag b.com/baz/blah b.com/bloop/blop
  docker push b.com/bloop/blop
```

Since the client has only associated the common layers with a repository on registry `a.com`, and cross-repository mounting only works intra-registry, no mounting will be attempted for the common layers and they will be re-uploaded even though they exist on registry `b.com`.

This change adds the same metadata registration logic that exists for when a layer pull completes to the logic for when a layer download is elided.