### PR TITLE
Revendor Microsoft/go-winio v0.3.8

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,7 +1,7 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm 388960b655244e76e24c75f48631564eaefade62
 github.com/Microsoft/hcsshim v0.5.10
-github.com/Microsoft/go-winio v0.3.7
+github.com/Microsoft/go-winio v0.3.8
 github.com/Sirupsen/logrus v0.11.0
 github.com/davecgh/go-spew 6d212800a42e8ab5c146b8ace3490ee17e5225f9
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a

--- a/vendor/github.com/Microsoft/go-winio/backuptar/tar.go
+++ b/vendor/github.com/Microsoft/go-winio/backuptar/tar.go
@@ -339,7 +339,7 @@ func WriteBackupStreamFromTarFile(w io.Writer, t *tar.Reader, hdr *tar.Header) (
 		bhdr := winio.BackupHeader{
 			Id:   winio.BackupAlternateData,
 			Size: ahdr.Size,
-			Name: ahdr.Name[len(hdr.Name)+1:] + ":$DATA",
+			Name: ahdr.Name[len(hdr.Name):] + ":$DATA",
 		}
 		err = bw.WriteHeader(&bhdr)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes https://github.com/docker/docker/issues/29849

There was a +1 length check error in go-winio causing an invalid filename on alternate data-streams as described in #29849. This is fixed in Microsoft/go-winio v0.3.8

@swernli 