### PR TITLE
install dirmngr if needed

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -462,9 +462,15 @@ do_install() {
 				( set -x; $sh_c 'sleep 3; apt-get install -y -q curl ca-certificates' )
 				curl='curl -sSL'
 			fi
-			if [ ! -e /usr/bin/gpg ]; then
+			if ! command -v gpg > /dev/null; then
 				apt_get_update
 				( set -x; $sh_c 'sleep 3; apt-get install -y -q gnupg2 || apt-get install -y -q gnupg' )
+			fi
+
+			# dirmngr is a separate package in ubuntu yakkety; see https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1634464
+			if ! command -v dirmngr > /dev/null; then
+				apt_get_update
+				( set -x; $sh_c 'sleep 3; apt-get install -y -q dirmngr' )
 			fi
 
 			(


### PR DESCRIPTION
as of Ubuntu Yakkety, dirmngr is now in a separate
package (see https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1634464)

this patch updates the install script to install
the dirmngr package if it's not installed.

fixes https://github.com/docker/docker/issues/30601


... I hope, because DigitalOcean was having issues, so I couldn't spin up a droplet to test :blush:

<img width="1011" alt="screen shot 2017-01-31 at 5 00 27 pm" src="https://cloud.githubusercontent.com/assets/1804568/22491309/6432b2aa-e7d7-11e6-9b0f-891ad3a4bcb4.png">
