### PR TITLE
Fix issues when there are spaces in `--format " table "` or `--format " raw "`

### DIFF
--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -29,7 +29,7 @@ const (
 
 // NewContainerFormat returns a Format for rendering using a Context
 func NewContainerFormat(source string, quiet bool, size bool) Format {
-	switch source {
+	switch strings.TrimSpace(source) {
 	case TableFormatKey:
 		if quiet {
 			return defaultQuietFormat

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -164,6 +164,14 @@ containerID1        ubuntu              ""                  24 hours ago        
 containerID2        ubuntu              ""                  24 hours ago                                                foobar_bar          0 B
 `,
 		},
+		// Table key with space
+		{
+			Context{Format: NewContainerFormat(" table ", false, true)},
+			`CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES               SIZE
+containerID1        ubuntu              ""                  24 hours ago                                                foobar_baz          0 B
+containerID2        ubuntu              ""                  24 hours ago                                                foobar_bar          0 B
+`,
+		},
 		{
 			Context{Format: NewContainerFormat("table", false, false)},
 			`CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
@@ -181,6 +189,11 @@ containerID2        ubuntu              ""                  24 hours ago        
 		},
 		{
 			Context{Format: NewContainerFormat("table {{.Image}}", true, false)},
+			"IMAGE\nubuntu\nubuntu\n",
+		},
+		// Table key with space
+		{
+			Context{Format: NewContainerFormat(" table {{.Image}} ", true, false)},
 			"IMAGE\nubuntu\nubuntu\n",
 		},
 		{
@@ -212,6 +225,31 @@ ports:
 		},
 		{
 			Context{Format: NewContainerFormat("raw", false, true)},
+			fmt.Sprintf(`container_id: containerID1
+image: ubuntu
+command: ""
+created_at: %s
+status:
+names: foobar_baz
+labels:
+ports:
+size: 0 B
+
+container_id: containerID2
+image: ubuntu
+command: ""
+created_at: %s
+status:
+names: foobar_bar
+labels:
+ports:
+size: 0 B
+
+`, expectedTime, expectedTime),
+		},
+		// Raw key with space
+		{
+			Context{Format: NewContainerFormat(" raw ", false, true)},
 			fmt.Sprintf(`container_id: containerID1
 image: ubuntu
 command: ""

--- a/cli/command/formatter/formatter.go
+++ b/cli/command/formatter/formatter.go
@@ -25,7 +25,7 @@ type Format string
 
 // IsTable returns true if the format is a table-type format
 func (f Format) IsTable() bool {
-	return strings.HasPrefix(string(f), TableFormatKey)
+	return strings.HasPrefix(strings.TrimSpace(string(f)), TableFormatKey)
 }
 
 // Contains returns true if the format contains the substring
@@ -53,7 +53,7 @@ func (c *Context) preFormat() {
 
 	// TODO: handle this in the Format type
 	if c.Format.IsTable() {
-		c.finalFormat = c.finalFormat[len(TableFormatKey):]
+		c.finalFormat = strings.Replace(c.finalFormat, TableFormatKey, "", 1)
 	}
 
 	c.finalFormat = strings.Trim(c.finalFormat, " ")

--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -2,6 +2,7 @@ package formatter
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/docker/distribution/reference"
@@ -32,7 +33,7 @@ func isDangling(image types.ImageSummary) bool {
 
 // NewImageFormat returns a format for rendering an ImageContext
 func NewImageFormat(source string, quiet bool, digest bool) Format {
-	switch source {
+	switch strings.TrimSpace(source) {
 	case TableFormatKey:
 		switch {
 		case quiet:

--- a/cli/command/formatter/image_test.go
+++ b/cli/command/formatter/image_test.go
@@ -114,10 +114,32 @@ image               tag2                imageID2            24 hours ago        
 <none>              <none>              imageID3            24 hours ago        0 B
 `,
 		},
+		// Table Format with spaces
+		{
+			ImageContext{
+				Context: Context{
+					Format: NewImageFormat("  table  ", false, false),
+				},
+			},
+			`REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+image               tag1                imageID1            24 hours ago        0 B
+image               tag2                imageID2            24 hours ago        0 B
+<none>              <none>              imageID3            24 hours ago        0 B
+`,
+		},
 		{
 			ImageContext{
 				Context: Context{
 					Format: NewImageFormat("table {{.Repository}}", false, false),
+				},
+			},
+			"REPOSITORY\nimage\nimage\n<none>\n",
+		},
+		// Table format with spaces
+		{
+			ImageContext{
+				Context: Context{
+					Format: NewImageFormat("  table {{.Repository}}", false, false),
 				},
 			},
 			"REPOSITORY\nimage\nimage\n<none>\n",
@@ -234,6 +256,18 @@ virtual_size: 0 B
 			ImageContext{
 				Context: Context{
 					Format: NewImageFormat("raw", true, false),
+				},
+			},
+			`image_id: imageID1
+image_id: imageID2
+image_id: imageID3
+`,
+		},
+		// Raw format with spaces
+		{
+			ImageContext{
+				Context: Context{
+					Format: NewImageFormat(" raw  ", true, false),
 				},
 			},
 			`image_id: imageID1

--- a/cli/command/formatter/network.go
+++ b/cli/command/formatter/network.go
@@ -18,7 +18,7 @@ const (
 
 // NewNetworkFormat returns a Format for rendering using a network Context
 func NewNetworkFormat(source string, quiet bool) Format {
-	switch source {
+	switch strings.TrimSpace(source) {
 	case TableFormatKey:
 		if quiet {
 			return defaultQuietFormat

--- a/cli/command/formatter/network_test.go
+++ b/cli/command/formatter/network_test.go
@@ -97,6 +97,13 @@ networkID1          foobar_baz          foo                 local
 networkID2          foobar_bar          bar                 local
 `,
 		},
+		// Table format with spaces
+		{
+			Context{Format: NewNetworkFormat(" table  ", true)},
+			`networkID1
+networkID2
+`,
+		},
 		{
 			Context{Format: NewNetworkFormat("table", true)},
 			`networkID1
@@ -105,6 +112,14 @@ networkID2
 		},
 		{
 			Context{Format: NewNetworkFormat("table {{.Name}}", false)},
+			`NAME
+foobar_baz
+foobar_bar
+`,
+		},
+		// Table format with spaces
+		{
+			Context{Format: NewNetworkFormat("  table {{.Name}}", false)},
 			`NAME
 foobar_baz
 foobar_bar
@@ -134,6 +149,13 @@ scope: local
 		},
 		{
 			Context{Format: NewNetworkFormat("raw", true)},
+			`network_id: networkID1
+network_id: networkID2
+`,
+		},
+		// Raw format with spaces
+		{
+			Context{Format: NewNetworkFormat("   raw    ", true)},
 			`network_id: networkID1
 network_id: networkID2
 `,

--- a/cli/command/formatter/plugin.go
+++ b/cli/command/formatter/plugin.go
@@ -18,7 +18,7 @@ const (
 
 // NewPluginFormat returns a Format for rendering using a plugin Context
 func NewPluginFormat(source string, quiet bool) Format {
-	switch source {
+	switch strings.TrimSpace(source) {
 	case TableFormatKey:
 		if quiet {
 			return defaultQuietFormat

--- a/cli/command/formatter/plugin_test.go
+++ b/cli/command/formatter/plugin_test.go
@@ -78,6 +78,14 @@ pluginID1           foobar_baz          description 1       true
 pluginID2           foobar_bar          description 2       false
 `,
 		},
+		// Table format with spaces
+		{
+			Context{Format: NewPluginFormat("   table  ", false)},
+			`ID                  NAME                DESCRIPTION         ENABLED
+pluginID1           foobar_baz          description 1       true
+pluginID2           foobar_bar          description 2       false
+`,
+		},
 		{
 			Context{Format: NewPluginFormat("table", true)},
 			`pluginID1
@@ -93,6 +101,14 @@ foobar_bar
 		},
 		{
 			Context{Format: NewPluginFormat("table {{.Name}}", true)},
+			`NAME
+foobar_baz
+foobar_bar
+`,
+		},
+		// Table format with spaces
+		{
+			Context{Format: NewPluginFormat("  table  {{.Name}}  ", true)},
 			`NAME
 foobar_baz
 foobar_bar
@@ -115,6 +131,13 @@ enabled: false
 		},
 		{
 			Context{Format: NewPluginFormat("raw", true)},
+			`plugin_id: pluginID1
+plugin_id: pluginID2
+`,
+		},
+		// Raw format with spaces
+		{
+			Context{Format: NewPluginFormat("  raw   ", true)},
 			`plugin_id: pluginID1
 plugin_id: pluginID2
 `,

--- a/cli/command/formatter/stats_test.go
+++ b/cli/command/formatter/stats_test.go
@@ -71,6 +71,14 @@ func TestContainerStatsContextWrite(t *testing.T) {
 -- / --
 `,
 		},
+		// Table format with spaces
+		{
+			Context{Format: "   table   {{.MemUsage}}"},
+			`MEM USAGE / LIMIT
+20 B / 20 B
+-- / --
+`,
+		},
 		{
 			Context{Format: "{{.Container}}  {{.CPUPerc}}"},
 			`container1  20.00%

--- a/cli/command/formatter/volume.go
+++ b/cli/command/formatter/volume.go
@@ -20,7 +20,7 @@ const (
 
 // NewVolumeFormat returns a format for use with a volume Context
 func NewVolumeFormat(source string, quiet bool) Format {
-	switch source {
+	switch strings.TrimSpace(source) {
 	case TableFormatKey:
 		if quiet {
 			return defaultVolumeQuietFormat

--- a/cli/command/formatter/volume_test.go
+++ b/cli/command/formatter/volume_test.go
@@ -82,6 +82,14 @@ foo                 foobar_baz
 bar                 foobar_bar
 `,
 		},
+		// Table format with spaces
+		{
+			Context{Format: NewVolumeFormat("  table   ", false)},
+			`DRIVER              VOLUME NAME
+foo                 foobar_baz
+bar                 foobar_bar
+`,
+		},
 		{
 			Context{Format: NewVolumeFormat("table", true)},
 			`foobar_baz
@@ -90,6 +98,14 @@ foobar_bar
 		},
 		{
 			Context{Format: NewVolumeFormat("table {{.Name}}", false)},
+			`VOLUME NAME
+foobar_baz
+foobar_bar
+`,
+		},
+		// Table format with spaces
+		{
+			Context{Format: NewVolumeFormat("  table   {{.Name}}  ", false)},
 			`VOLUME NAME
 foobar_baz
 foobar_bar
@@ -119,9 +135,23 @@ driver: bar
 name: foobar_bar
 `,
 		},
+		// Raw format with spaces
+		{
+			Context{Format: NewVolumeFormat("  raw  ", true)},
+			`name: foobar_baz
+name: foobar_bar
+`,
+		},
 		// Custom Format
 		{
 			Context{Format: NewVolumeFormat("{{.Name}}", false)},
+			`foobar_baz
+foobar_bar
+`,
+		},
+		// Custom Format with spaces
+		{
+			Context{Format: NewVolumeFormat("   {{.Name}}  ", false)},
 			`foobar_baz
 foobar_bar
 `,


### PR DESCRIPTION
**- What I did**
This fix tries to address the issue where spaces combined with `"table"` or `"raw"` in `--format` caused incorrect rendering. For example, `--format "    table   "` for `--format "     raw"  `

The following are examples:
```
ubuntu@ubuntu:~/docker$ docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
f183787c2d35        busybox             "top"               About an hour ago   Up About an hour                        kind_wozniak
ubuntu@ubuntu:~/docker$ docker ps --format ' table '
table
ubuntu@ubuntu:~/docker$ docker ps --format ' table {{.ID}} {{.Image}}'
table f183787c2d35 busybox
ubuntu@ubuntu:~/docker$ docker ps --format ' raw  '
raw
ubuntu@ubuntu:~/docker$
```

The reason with the above incorrect rendering is that, `table` or `raw` format checking was not compared after space trimmed.

And `IsTable()` does not take into consideration the spaces as well.

**- How I did it**

This fix fixes the issue.

**- How to verify it**

Additional test cases have been added to cover the changes

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
