### PR TITLE
Follow-up of 29826 Use default driver for IPAM if none

### DIFF
--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -186,9 +186,13 @@ func BasicNetworkCreateToGRPC(create basictypes.NetworkCreateRequest) swarmapi.N
 		Attachable:  create.Attachable,
 	}
 	if create.IPAM != nil {
+		driver := create.IPAM.Driver
+		if driver == "" {
+			driver = "default"
+		}
 		ns.IPAM = &swarmapi.IPAMOptions{
 			Driver: &swarmapi.Driver{
-				Name:    create.IPAM.Driver,
+				Name:    driver,
 				Options: create.IPAM.Options,
 			},
 		}


### PR DESCRIPTION
Follow up for #29826 in master this time

---

We use the 'default' driver if none is specified.

Fix #29809 
Fix #28528 

/cc @dnephin @icecrime @thaJeztah @mavenugo @vieux 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>