### PR TITLE
Build Secrets

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -107,6 +107,15 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 		options.BuildArgs = buildArgs
 	}
 
+	var buildSecrets = []*types.SecretRequestOption{}
+	buildSecretJSON := r.FormValue("buildsecrets")
+	if buildSecretJSON != "" {
+		if err := json.Unmarshal([]byte(buildSecretJSON), &buildSecrets); err != nil {
+			return nil, err
+		}
+		options.BuildSecrets = buildSecrets
+	}
+
 	var labels = map[string]string{}
 	labelsJSON := r.FormValue("labels")
 	if labelsJSON != "" {

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -164,10 +164,11 @@ type ImageBuildOptions struct {
 	// we can tell the difference between "" (empty string) and no value
 	// at all (nil). See the parsing of buildArgs in
 	// api/server/router/build/build_routes.go for even more info.
-	BuildArgs   map[string]*string
-	AuthConfigs map[string]AuthConfig
-	Context     io.Reader
-	Labels      map[string]string
+	BuildArgs    map[string]*string
+	AuthConfigs  map[string]AuthConfig
+	Context      io.Reader
+	Labels       map[string]string
+	BuildSecrets []*SecretRequestOption
 	// squash the resulting image's layers to the parent
 	// preserves the original image and creates a new one from the parent with all
 	// the changes applied to a single layer

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -83,6 +83,7 @@ type Builder struct {
 
 	imageCache builder.ImageCache
 	from       builder.Image
+	bindMounts []string
 }
 
 // BuildManager implements builder.Backend and is shared across all Builder objects.

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -8,8 +8,8 @@ package dockerfile
 // package.
 
 import (
-	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"sort"
@@ -23,8 +23,10 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/builder"
+	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/go-connections/nat"
+	"github.com/pkg/errors"
 )
 
 // ENV foo bar
@@ -395,6 +397,59 @@ func run(b *Builder, args []string, attributes map[string]bool, original string)
 	b.runConfig.Env = append(b.runConfig.Env, cmdBuildEnv...)
 	// set config as already being escaped, this prevents double escaping on windows
 	b.runConfig.ArgsEscaped = true
+
+	if len(b.options.BuildSecrets) > 0 {
+		// secrets
+		m, err := setupSecretMount()
+		if err != nil {
+			return errors.Wrap(err, "unable to setup secret mount")
+		}
+
+		// inject secrets from context
+		for _, secret := range b.options.BuildSecrets {
+			baseName := filepath.Base(secret.Source)
+			logrus.WithFields(logrus.Fields{
+				"name":   baseName,
+				"source": secret.Source,
+			}).Debug("[BUILDER] setting up secret")
+
+			fi, err := b.context.Open(filepath.Join(".secrets", baseName))
+			if err != nil {
+				logrus.Warnf("[BUILDER] build context did not contain secret %s", baseName)
+				continue
+			}
+			// we build the path here so the file ends up
+			// in /run/secret/xx
+			// the actual mount in the container for the tmpfs
+			// is in /run to prevent /run/secrets from being
+			// committed to the layer
+			secretPath := filepath.Join(m.Source, "secrets")
+			if err := injectSecret(secretPath, fi, secret.Target, secret.Mode); err != nil {
+				return err
+			}
+		}
+
+		if err := mount.Mount("tmpfs", m.Source, "tmpfs", "remount,ro"); err != nil {
+			return errors.Wrap(err, "unable to remount secret dir as readonly")
+		}
+
+		defer func() {
+			if err := cleanupSecretMount(m.Source); err != nil {
+				logrus.Errorf("[BUILDER] %s", err)
+			}
+
+			// reset bind mounts
+			b.bindMounts = []string{}
+		}()
+
+		// create mount for containers
+		if m != nil {
+			bind := fmt.Sprintf("%s:%s", m.Source, m.Target)
+			b.bindMounts = append(b.bindMounts, bind)
+		}
+
+		logrus.Debugf("[BUILDER] host binds: %+v", b.bindMounts)
+	}
 
 	logrus.Debugf("[BUILDER] Command to be executed: %v", b.runConfig.Cmd)
 

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -500,6 +500,7 @@ func (b *Builder) create() (string, error) {
 		// Set a log config to override any default value set on the daemon
 		LogConfig:  defaultLogConfig,
 		ExtraHosts: b.options.ExtraHosts,
+		Binds:      b.bindMounts,
 	}
 
 	config := *b.runConfig
@@ -678,4 +679,31 @@ func (b *Builder) isBuildArgAllowed(arg string) bool {
 		return true
 	}
 	return false
+}
+
+// inject secret is used to create a file in a temporary directory to be
+// used during build
+func injectSecret(mountPath string, src io.ReadCloser, targetName string, mode os.FileMode) error {
+	destPath := filepath.Join(mountPath, targetName)
+	logrus.Debugf("[BUILDER] creating secret: %s", destPath)
+
+	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+		return err
+	}
+
+	df, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	defer df.Close()
+
+	if _, err := io.Copy(df, src); err != nil {
+		return err
+	}
+
+	if err := df.Chmod(mode); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/builder/dockerfile/internals_windows.go
+++ b/builder/dockerfile/internals_windows.go
@@ -6,7 +6,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/pkg/system"
+)
+
+const (
+	// TODO (ehazlett): need to figure this out for windows
+	secretContainerPath = ""
 )
 
 // normaliseDest normalises the destination of a COPY/ADD command in a
@@ -63,4 +69,20 @@ func containsWildcards(name string) bool {
 		}
 	}
 	return false
+}
+
+// setupSecretMount is used to setup a tmpfs filesystem as a host mount
+func setupSecretMount() (*mounttypes.Mount, error) {
+	// TODO (ehazlett): find a way to use tmpfs on windows
+	return nil, fmt.Errorf("secret mount not supported on windows")
+
+}
+
+// cleanupSecretMount unmounts the secret mount and removes the directory
+func cleanupSecretMount(dir string) error {
+	if err := os.RemoveAll(dir); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -6,11 +6,13 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
@@ -60,6 +62,7 @@ type buildOptions struct {
 	securityOpt    []string
 	networkMode    string
 	squash         bool
+	buildSecrets   opts.SecretOpt
 }
 
 // NewBuildCommand creates a new `docker build` command
@@ -87,6 +90,7 @@ func NewBuildCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 	flags.VarP(&options.tags, "tag", "t", "Name and optionally a tag in the 'name:tag' format")
 	flags.Var(&options.buildArgs, "build-arg", "Set build-time variables")
+	flags.Var(&options.buildSecrets, "build-secret", "Set build secrets")
 	flags.Var(options.ulimits, "ulimit", "Ulimit options")
 	flags.StringVarP(&options.dockerfileName, "file", "f", "", "Name of the Dockerfile (Default is 'PATH/Dockerfile')")
 	flags.VarP(&options.memory, "memory", "m", "Memory limit")
@@ -246,6 +250,12 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 		buildCtx = replaceDockerfileTarWrapper(ctx, buildCtx, relDockerfile, translator, &resolvedTags)
 	}
 
+	secrets := options.buildSecrets.Value()
+
+	if len(secrets) > 0 {
+		buildCtx = secretsTarWrapper(ctx, buildCtx, secrets)
+	}
+
 	// Setup an upload progress bar
 	progressOutput := streamformatter.NewStreamFormatter().NewProgressOutput(progBuff, true)
 	if !dockerCli.Out().IsTerminal() {
@@ -276,6 +286,7 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 		Ulimits:        options.ulimits.GetList(),
 		BuildArgs:      runconfigopts.ConvertKVStringsToMapWithNil(options.buildArgs.GetAll()),
 		AuthConfigs:    authConfigs,
+		BuildSecrets:   secrets,
 		Labels:         runconfigopts.ConvertKVStringsToMap(options.labels.GetAll()),
 		CacheFrom:      options.cacheFrom,
 		SecurityOpt:    options.securityOpt,
@@ -446,6 +457,69 @@ func replaceDockerfileTarWrapper(ctx context.Context, inputTarStream io.ReadClos
 				content = bytes.NewBuffer(newDockerfile)
 			}
 
+			if err := tarWriter.WriteHeader(hdr); err != nil {
+				pipeWriter.CloseWithError(err)
+				return
+			}
+
+			if _, err := io.Copy(tarWriter, content); err != nil {
+				pipeWriter.CloseWithError(err)
+				return
+			}
+		}
+	}()
+
+	return pipeReader
+}
+
+func secretsTarWrapper(ctx context.Context, inputTarStream io.ReadCloser, secrets []*types.SecretRequestOption) io.ReadCloser {
+	pipeReader, pipeWriter := io.Pipe()
+	go func() {
+		tarReader := tar.NewReader(inputTarStream)
+		tarWriter := tar.NewWriter(pipeWriter)
+
+		defer inputTarStream.Close()
+
+		// add secrets
+		for _, s := range secrets {
+			logrus.Debugf("adding secret to context source=%s", s.Source)
+			fPath := filepath.Base(s.Source)
+			data, err := ioutil.ReadFile(s.Source)
+			if err != nil {
+				logrus.Errorf("error reading secret path: %s", err)
+				continue
+			}
+			hdr := &tar.Header{
+				Name: filepath.Join(".secrets", fPath),
+				Mode: int64(s.Mode),
+				Size: int64(len(data)),
+			}
+			if err := tarWriter.WriteHeader(hdr); err != nil {
+				pipeWriter.CloseWithError(err)
+				return
+			}
+
+			content := bytes.NewBuffer(data)
+			if _, err := io.Copy(tarWriter, content); err != nil {
+				pipeWriter.CloseWithError(err)
+				return
+			}
+		}
+
+		for {
+			hdr, err := tarReader.Next()
+			if err == io.EOF {
+				// Signals end of archive.
+				tarWriter.Close()
+				pipeWriter.Close()
+				return
+			}
+			if err != nil {
+				pipeWriter.CloseWithError(err)
+				return
+			}
+
+			var content = tarReader
 			if err := tarWriter.WriteHeader(hdr); err != nil {
 				pipeWriter.CloseWithError(err)
 				return

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -108,10 +108,16 @@ func (cli *Client) imageBuildOptionsToQuery(options types.ImageBuildOptions) (ur
 	}
 	query.Set("buildargs", string(buildArgsJSON))
 
+	buildSecretsJSON, err := json.Marshal(options.BuildSecrets)
+	if err != nil {
+		return query, err
+	}
+	query.Set("buildsecrets", string(buildSecretsJSON))
 	labelsJSON, err := json.Marshal(options.Labels)
 	if err != nil {
 		return query, err
 	}
+
 	query.Set("labels", string(labelsJSON))
 
 	cacheFromJSON, err := json.Marshal(options.CacheFrom)

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -23,6 +23,7 @@ Build an image from a Dockerfile
 Options:
       --add-host value          Add a custom host-to-IP mapping (host:ip) (default [])
       --build-arg value         Set build-time variables (default [])
+      --build-secret secret     Set build secrets
       --cache-from value        Images to consider as cache sources (default [])
       --cgroup-parent string    Optional parent cgroup for the container
       --compress                Compress the build context using gzip
@@ -373,8 +374,22 @@ the command line.
 > repeatable builds on remote Docker hosts. This is also the reason why
 > `ADD ../file` will not work.
 
-### Use a custom parent cgroup (--cgroup-parent)
+### Build with Secrets
 
+Build Secrets can be specified to provide private data such as keys or
+passwords.
+
+Build an image using secrets:
+
+```bash
+docker build -t app \
+    --build-secret source=/path/to/github-key,target=git.key .
+```
+
+This will expose the contents of `github-key` in the container during build
+as `/run/secrets/git.key`.
+
+### Use a custom parent cgroup (--cgroup-parent)
 When `docker build` is run with the `--cgroup-parent` option the containers
 used in the build will be run with the [corresponding `docker run`
 flag](../run.md#specifying-custom-cgroups).


### PR DESCRIPTION
This replaces https://github.com/docker/docker/pull/28079 as I had to re-open.

This enables build time secrets using the `--build-secret` flag.

Similar to #27794 this creates a tmpfs during each run of the build and exposes the specified "secrets" into the container.  These are not committed to the image.

Here is an example Dockerfile:

```
FROM busybox:latest
RUN mount | grep tmpfs
RUN find /run
RUN cat /run/secrets/git-key
```

Given the following command:

```
docker build -t test --no-cache --build-secret source=~/git-key,target=git-key .
```

This will expose the key from `~/git-key` as `/run/secrets/git-key`.  This can be used however needed during build by the corresponding `RUN` directives.

Here is the example output:

```
Sending build context to Docker daemon 3.072 kB
Step 1/4 : FROM busybox:latest
 ---> e02e811dd08f
Step 2/4 : RUN mount | grep tmpfs
 ---> Running in 9c7863ab331b
tmpfs on /dev type tmpfs (rw,nosuid,mode=755)
tmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,relatime,mode=755)
tmpfs on /run type tmpfs (ro,nosuid,nodev,noexec,relatime)
shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=65536k)
tmpfs on /proc/kcore type tmpfs (rw,nosuid,mode=755)
tmpfs on /proc/timer_list type tmpfs (rw,nosuid,mode=755)
tmpfs on /proc/timer_stats type tmpfs (rw,nosuid,mode=755)
tmpfs on /proc/sched_debug type tmpfs (rw,nosuid,mode=755)
tmpfs on /sys/firmware type tmpfs (ro,relatime)
 ---> 60836fd9a783
Removing intermediate container 9c7863ab331b
Step 3/4 : RUN find /run
 ---> Running in 56a46a797034
/run
/run/secrets
/run/secrets/git-key
 ---> 908a73ff32a1
Removing intermediate container 56a46a797034
Step 4/4 : RUN cat /run/secrets/git-key
 ---> Running in e8f6b05e7a81
TESTKEY
 ---> 3c13c956d170
Removing intermediate container e8f6b05e7a81
Successfully built 3c13c956d170
root@dev:~/build# docker run --rm -ti test ls -lah /run/
total 8
drwxr-xr-x    2 root     root        4.0K Nov  4 19:55 .
drwxr-xr-x    1 root     root        4.0K Nov  4 19:56 ..
```

## Example using a private git key

Dockerfile
```
FROM alpine:latest
RUN apk add -U git openssh
COPY ssh_config /root/.ssh/config
RUN ls -lah /run/secrets
RUN git clone ssh://git@hello.frie.nd:/x/repo
```

```
$> docker build -t testimage --build-secret source=~/hello.key,target=id_rsa,mode=0400 .
Sending build context to Docker daemon 5.632 kB
Step 1/5 : FROM alpine:latest
 ---> 88e169ea8f46
Step 2/5 : RUN apk add -U git openssh
 ---> Using cache
 ---> fce3270066bb
Step 3/5 : COPY ssh_config /root/.ssh/config
 ---> Using cache
 ---> 7030c50fbc41
Step 4/5 : RUN ls -lah /run/secrets
 ---> Running in 90a1ec20dc54
total 4
drwxr-xr-x    2 root     root          60 Feb  7 19:57 .
drwxrwxrwt    3 root     root          60 Feb  7 19:57 ..
-r--------    1 root     root        1.6K Feb  7 19:57 id_rsa
 ---> 9f45932eb25b
Removing intermediate container 90a1ec20dc54
Step 5/5 : RUN git clone ssh://git@hello.frie.nd:/x/repo
 ---> Running in 910bcff08a04
Cloning into 'repo'...
Warning: Permanently added '[hello.frie.nd]:22,[192.251.68.254]:22' (ECDSA) to the list of known hosts.
 ---> 3939f5d3e275
Removing intermediate container 910bcff08a04
Successfully built 3939f5d3e275
```