### PR TITLE
Windows: Make.ps1 default to build binaries

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -319,8 +319,8 @@ Try {
     # Handle the "-Binary" shortcut to build both client and daemon.
     if ($Binary) { $Client = $True; $Daemon = $True }
 
-    # Make sure we have something to do
-    if (-not($Client) -and -not($Daemon) -and -not($DCO) -and -not($PkgImports) -and -not($GoFormat) -and -not($TestUnit)) { Throw 'Nothing to do. Try adding "-All" for everything I can do' }
+    # Default to building the binaries if not asked for anything explicitly.
+    if (-not($Client) -and -not($Daemon) -and -not($DCO) -and -not($PkgImports) -and -not($GoFormat) -and -not($TestUnit)) { $Client=$True; $Daemon=$True }
 
     # Verify git is installed
     if ($(Get-Command git -ErrorAction SilentlyContinue) -eq $nil) { Throw "Git does not appear to be installed" }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@johnstep Minor tweak to make.ps1 which makes local development outside of a container on Windows a tiny bit easier for the most common operation. The default for running make.ps1 is now to build the binaries rather than throw an error. Hence can just run `make.ps1` rather than explicitly doing `make.ps1 -Binary`