### PR TITLE
Improve bash completion for `docker plugin enable|disable`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -289,6 +289,8 @@ __docker_complete_plugins_bundled() {
 # the Docker plugin API.
 # By default, only names are returned.
 # Set DOCKER_COMPLETION_SHOW_PLUGIN_IDS=yes to also complete IDs.
+# Additional options to `docker plugin ls` may be specified in order to filter the list,
+# e.g. `__docker_plugins_installed --filter enabled=true`
 # For built-in pugins, see `__docker_plugins_bundled`.
 __docker_plugins_installed() {
 	local format
@@ -297,12 +299,13 @@ __docker_plugins_installed() {
 	else
 		format='{{.Name}}'
 	fi
-	__docker_q plugin ls --format "$format"
+	__docker_q plugin ls --format "$format" "$@"
 }
 
 # __docker_complete_plugins_installed applies completion of plugins that were installed
 # with the Docker plugin API, based on the current value of `$cur` or the value of
 # the optional first option `--cur`, if given.
+# Additional filters may be appended, see `__docker_plugins_installed`.
 # For completion of built-in pugins, see `__docker_complete_plugins_bundled`.
 __docker_complete_plugins_installed() {
 	local current="$cur"
@@ -3367,7 +3370,7 @@ _docker_plugin_disable() {
 		*)
 			local counter=$(__docker_pos_first_nonflag)
 			if [ $cword -eq $counter ]; then
-				__docker_complete_plugins_installed
+				__docker_complete_plugins_installed --filter enabled=true
 			fi
 			;;
 	esac
@@ -3387,7 +3390,7 @@ _docker_plugin_enable() {
 		*)
 			local counter=$(__docker_pos_first_nonflag '--timeout')
 			if [ $cword -eq $counter ]; then
-				__docker_complete_plugins_installed
+				__docker_complete_plugins_installed --filter enabled=false
 			fi
 			;;
 	esac


### PR DESCRIPTION
Now that we can filter plugins by their enabled state, bash completion for  `docker plugin enable` and `docker plugin disable` can be improved so that only plugins with matching state are completed.

Ref: #28624, #28627
Ping @sdurrheimer for zsh completion