### PR TITLE
Windows: make.ps1 validate go version

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -126,6 +126,25 @@ Function Check-InContainer() {
         Write-Host ""
         Write-Warning "Not running in a container. The result might be an incorrect build."
         Write-Host ""
+        return $False
+    }
+    return $True
+}
+
+# Utility function to warn if the version of go is correct. Used for local builds
+# outside of a container where it may be out of date with master.
+Function Verify-GoVersion() {
+    Try {
+        $goVersionDockerfile=(Get-Content ".\Dockerfile" | Select-String "ENV GO_VERSION").ToString().Split(" ")[2]
+        $goVersionInstalled=(go version).ToString().Split(" ")[2].SubString(2)
+    }
+    Catch [Exception] {
+        Throw "Failed to validate go version correctness: $_"
+    }
+    if (-not($goVersionInstalled -eq $goVersionDockerfile)) {
+        Write-Host ""
+        Write-Warning "Building with golang version $goVersionInstalled. You should update to $goVersionDockerfile"
+        Write-Host ""
     }
 }
 
@@ -337,7 +356,10 @@ Try {
 
     # Give a warning if we are not running in a container and are building binaries or running unit tests.
     # Not relevant for validation tests as these are fine to run outside of a container.
-    if ($Client -or $Daemon -or $TestUnit) { Check-InContainer }
+    if ($Client -or $Daemon -or $TestUnit) { $inContainer=Check-InContainer }
+
+    # If we are not in a container, validate the version of GO that is installed.
+    if (-not $inContainer) { Verify-GoVersion }
 
     # Verify GOPATH is set
     if ($env:GOPATH.Length -eq 0) { Throw "Missing GOPATH environment variable. See https://golang.org/doc/code.html#GOPATH" }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@johnstep FYI. Another minor tweak to make.ps1 to do what CI used to do before it took the go installer out of the container to ensure the host and container were in sync. For local builds (eg running `make.ps1 -Binary`) outside of a container, this ensures that the version of GO installed on the host is correct.

(I just got caught out - my dev box still had version 1.7.3 whereas master is currently at 1.7.5). 

You now get this additional warning:

```
E:\go\src\github.com\docker\docker [jjh/makecheckgoversion]> make.ps1 -client
INFO: make.ps1 starting at 02/01/2017 10:34:52

WARNING: Not running in a container. The result might be an incorrect build.


WARNING: Building with golang version 1.7.3. You should update to 1.7.5

INFO: Invoking autogen...
INFO: Building client...

 ________   ____  __.
 \_____  \ |    |/ _|
 /   |   \|      <
 /    |    \    |  \
 \_______  /____|__ \
         \/        \/

INFO: make.ps1 ended at 02/01/2017 10:35:02
E:\go\src\github.com\docker\docker [jjh/makecheckgoversion]>
```
