### PR TITLE
do not fail fast when executing inspect command

### DIFF
--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -51,9 +51,9 @@ func (s *DockerSuite) TestVolumeCLIInspect(c *check.C) {
 func (s *DockerSuite) TestVolumeCLIInspectMulti(c *check.C) {
 	dockerCmd(c, "volume", "create", "test1")
 	dockerCmd(c, "volume", "create", "test2")
-	dockerCmd(c, "volume", "create", "not-shown")
+	dockerCmd(c, "volume", "create", "test3")
 
-	result := dockerCmdWithResult("volume", "inspect", "--format={{ .Name }}", "test1", "test2", "doesntexist", "not-shown")
+	result := dockerCmdWithResult("volume", "inspect", "--format={{ .Name }}", "test1", "test2", "doesntexist", "test3")
 	c.Assert(result, icmd.Matches, icmd.Expected{
 		ExitCode: 1,
 		Err:      "No such volume: doesntexist",
@@ -61,11 +61,11 @@ func (s *DockerSuite) TestVolumeCLIInspectMulti(c *check.C) {
 
 	out := result.Stdout()
 	outArr := strings.Split(strings.TrimSpace(out), "\n")
-	c.Assert(len(outArr), check.Equals, 2, check.Commentf("\n%s", out))
+	c.Assert(len(outArr), check.Equals, 3, check.Commentf("\n%s", out))
 
 	c.Assert(out, checker.Contains, "test1")
 	c.Assert(out, checker.Contains, "test2")
-	c.Assert(out, checker.Not(checker.Contains), "not-shown")
+	c.Assert(out, checker.Contains, "test3")
 }
 
 func (s *DockerSuite) TestVolumeCLILs(c *check.C) {


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

fixes #30599 

do not fail fast when executing inspect command.

Current if user executes a command like `docker network inspect nonexist exist1 exist2`, it will fail fast. Like:
```
root@ubuntu:~# docker network ls
NETWORK ID          NAME                DRIVER              SCOPE
b80b14598d1f        allen               bridge              local
fd6a89aad8ff        bridge              bridge              local
85ded5476b05        docker_gwbridge     bridge              local
d909a9f88b4c        host                host                local
z1sybtvc99hu        ingress             overlay             swarm
615a39ff6c47        none                null                local
root@ubuntu:~# docker network inspect nonexist bridge host
[]
Error: No such network: nonexist
```

This PR tries to fix this improper fast failing.

**- What I did**

**- How I did it**

**- How to verify it**
Choose an inspect command in which non-existent object locates at the head, and check if it fails fast.
```
root@ip-172-31-23-42:~ ./docker-1.14.0-dev network inspect allen allen2 host
[
    {
        "Name": "host",
        "Id": "04157c270e60a3f28dd72cdda45d103e640f0e89cba2c8d29d690081936cde4f",
        "Created": "0001-01-01T00:00:00Z",
        "Scope": "local",
        "Driver": "host",
        "EnableIPv6": false,
        "IPAM": {
            "Driver": "default",
            "Options": null,
            "Config": []
        },
        "Internal": false,
        "Attachable": false,
        "Containers": {},
        "Options": {},
        "Labels": {}
    }
]
Error: No such network: allen
Error: No such network: allen2
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

