### PR TITLE
If caller specifies label overrides, don't override security options

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -156,7 +156,17 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig, managed bool) (
 	return container, nil
 }
 
-func (daemon *Daemon) generateSecurityOpt(ipcMode containertypes.IpcMode, pidMode containertypes.PidMode, privileged bool) ([]string, error) {
+func (daemon *Daemon) generateSecurityOpt(hostConfig *containertypes.HostConfig) ([]string, error) {
+	for _, opt := range hostConfig.SecurityOpt {
+		con := strings.Split(opt, "=")
+		if con[0] == "label" {
+			// Caller overrode SecurityOpts
+			return nil, nil
+		}
+	}
+	ipcMode := hostConfig.IpcMode
+	pidMode := hostConfig.PidMode
+	privileged := hostConfig.Privileged
 	if ipcMode.IsHost() || pidMode.IsHost() || privileged {
 		return label.DisableSecOpt(), nil
 	}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -274,7 +274,7 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConf
 		}
 	}
 	var err error
-	opts, err := daemon.generateSecurityOpt(hostConfig.IpcMode, hostConfig.PidMode, hostConfig.Privileged)
+	opts, err := daemon.generateSecurityOpt(hostConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If a caller specifies an SELinux type or MCS Label and still wants to
share an IPC Namespace or the host namespace, we should allow them.
Currently we are ignoring the label specification if ipcmod=container
or pidmode=host.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

