### PR TITLE
more descriptive error for checkpoint ls  for non existent containers

### DIFF
--- a/client/checkpoint_list.go
+++ b/client/checkpoint_list.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"net/http"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
@@ -19,6 +20,9 @@ func (cli *Client) CheckpointList(ctx context.Context, container string, options
 
 	resp, err := cli.get(ctx, "/containers/"+container+"/checkpoints", query, nil)
 	if err != nil {
+		if resp.statusCode == http.StatusNotFound {
+			return checkpoints, containerNotFoundError{container}
+		}
 		return checkpoints, err
 	}
 

--- a/client/checkpoint_list_test.go
+++ b/client/checkpoint_list_test.go
@@ -55,3 +55,14 @@ func TestCheckpointList(t *testing.T) {
 		t.Fatalf("expected 1 checkpoint, got %v", checkpoints)
 	}
 }
+
+func TestCheckpointListContainerNotFound(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusNotFound, "Server error")),
+	}
+
+	_, err := client.CheckpointList(context.Background(), "unknown", types.CheckpointListOptions{})
+	if err == nil || !IsErrContainerNotFound(err) {
+		t.Fatalf("expected a containerNotFound error, got %v", err)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Krasi Georgiev <krasi@vip-consult.solutions>

closes #28766


**- What I did**
added server reply status code change to return the conainernofound error type

**- How I did it**
instead of printing the error message from the server it checks the return code and if it is 404 (not found) it prints the containerNotFoundError error type
**- How to verify it**
docker checkpoint ls ../../
docker checkpoint ls noneexistent
**- Description for the changelog**
more descriptive message for checkpoint ls on non existing containers


**- Note**
not sure if it is by design but docker checkpoint ls ../../ returns  404 not found , not because it doesn't  find the container but because it doesn't find the endpoint.

Gorilla mux translates the call to /containers/../..//checkpoints  -> /checkpoints and it returns 404 page not found error where  /containers/noexistent/checkpoints returns 404 container not found.
(it is the same for docker inspect ../../ or any other endpoint that is in the format /endpoint/container_id/method )

the client only checks if the returning code i 404 so it doesn't matter in this case, but the code might need refactoring to check for a valid container name (similar to the reserveName function in the names.go file

if !validContainerNamePattern.MatchString(strings.TrimPrefix(name, "/")) {
return "", fmt.Errorf("Invalid container name (%s), only %s are allowed", name, validContainerNameChars)
}