### PR TITLE
Windows: Unify workdir handling

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -221,12 +221,6 @@ func (container *Container) SetupWorkingDirectory(rootUID, rootGID int) error {
 
 	container.Config.WorkingDir = filepath.Clean(container.Config.WorkingDir)
 
-	// If can't mount container FS at this point (e.g. Hyper-V Containers on
-	// Windows) bail out now with no action.
-	if !container.canMountFS() {
-		return nil
-	}
-
 	pth, err := container.GetResourcePath(container.Config.WorkingDir)
 	if err != nil {
 		return err

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -439,12 +439,6 @@ func cleanResourcePath(path string) string {
 	return filepath.Join(string(os.PathSeparator), path)
 }
 
-// canMountFS determines if the file system for the container
-// can be mounted locally. A no-op on non-Windows platforms
-func (container *Container) canMountFS() bool {
-	return true
-}
-
 // EnableServiceDiscoveryOnDefaultNetwork Enable service discovery on default network
 func (container *Container) EnableServiceDiscoveryOnDefaultNetwork() bool {
 	return false

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -104,13 +104,6 @@ func (container *Container) BuildHostnameFile() error {
 	return nil
 }
 
-// canMountFS determines if the file system for the container
-// can be mounted locally. In the case of Windows, this is not possible
-// for Hyper-V containers during WORKDIR execution for example.
-func (container *Container) canMountFS() bool {
-	return !containertypes.Isolation.IsHyperV(container.HostConfig.Isolation)
-}
-
 // EnableServiceDiscoveryOnDefaultNetwork Enable service discovery on default network
 func (container *Container) EnableServiceDiscoveryOnDefaultNetwork() bool {
 	return true

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -18,9 +18,9 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 		return nil, err
 	}
 
-	if err := c.SetupWorkingDirectory(0, 0); err != nil {
-		return nil, err
-	}
+	// Note, unlike Unix, we do NOT call into SetupWorkingDirectory as
+	// this is done in VMCompute. Further, we couldn't do it for Hyper-V
+	// containers anyway.
 
 	// In base spec
 	s.Hostname = c.FullHostname()

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1270,19 +1270,6 @@ For example:
 The output of the final `pwd` command in this `Dockerfile` would be
 `/path/$DIRNAME`
 
-On Windows, `WORKDIR` behaves differently depending on whether using Windows
-Server containers or Hyper-V containers. For Hyper-V containers, the engine
-is, for architectural reasons, unable to create the directory if it does not
-previously exist. For Windows Server containers, the directory is created
-if it does not exist. Hence, for consistency between Windows Server and 
-Hyper-V containers, it is strongly recommended to include an explicit instruction
-to create the directory in the Dockerfile. For example:
-
-    # escape=`
-    FROM microsoft/nanoserver
-    RUN mkdir c:\myapp
-    WORKDIR c:\myapp
-
 ## ARG
 
     ARG <name>[=<default value>]

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1717,7 +1717,7 @@ func (s *DockerSuite) TestRunWorkdirExistsAndIsFile(c *check.C) {
 	expected := "not a directory"
 	if testEnv.DaemonPlatform() == "windows" {
 		existingFile = `\windows\system32\ntdll.dll`
-		expected = `Cannot mkdir: \windows\system32\ntdll.dll is not a directory.`
+		expected = `The directory name is invalid.`
 	}
 
 	out, exitCode, err := dockerCmdWithError("run", "-w", existingFile, "busybox")


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Working directory processing was handled differently for Hyper-V and Windows-Server containers, as annotated in the builder documentation (updated in this PR). For Hyper-V containers, the working directory set by `WORKDIR` was not created. This PR makes Hyper-V containers work the same as Windows Server containers (and the same as Linux).

@swernli As discussed offline. PTAL.

Example (only applies to Hyper-V containers, so not reproducible under CI environment)

Dockerfile:
```
#escape=`
FROM microsoft/nanoserver
WORKDIR c:\installer
ENV GOROOT=c:\installer
ADD go.exe .
RUN go --help
```

Running on Windows Server 2016, using docker master without this change, but with daemon set to `--exec-opt isolation=hyperv` as it would be for Client operating systems.

```
PS E:\go\src\github.com\docker\docker> dockerd -g c:\control --exec-opt isolation=hyperv
time="2017-02-01T15:48:09.657286100-08:00" level=info msg="Windows default isolation mode: hyperv"
time="2017-02-01T15:48:09.662720900-08:00" level=info msg="[graphdriver] using prior storage driver: windowsfilter"
time="2017-02-01T15:48:10.011588000-08:00" level=info msg="Graph migration to content-addressability took 0.00 seconds"
time="2017-02-01T15:48:10.016655800-08:00" level=info msg="Loading containers: start."
time="2017-02-01T15:48:10.460820000-08:00" level=info msg="Loading containers: done."
time="2017-02-01T15:48:10.509859600-08:00" level=info msg="Daemon has completed initialization"
time="2017-02-01T15:48:10.509859600-08:00" level=info msg="Docker daemon" commit=3c64061 graphdriver=windowsfilter version=1.14.0-dev
```

First with no explicit isolation:
```
PS E:\docker\build\unifyworkdir> docker build --no-cache .
Sending build context to Docker daemon  10.1 MB
Step 1/5 : FROM microsoft/nanoserver
 ---> 89b8556cb9ca
Step 2/5 : WORKDIR c:\installer
 ---> 7e0f41d08204
Removing intermediate container 236c7802042a
Step 3/5 : ENV GOROOT c:\installer
 ---> Running in 8ea5237183c1
 ---> 394b70435261
Removing intermediate container 8ea5237183c1
Step 4/5 : ADD go.exe .
 ---> e47401a1745c
Removing intermediate container 88dcc28e74b1
Step 5/5 : RUN go --help
 ---> Running in efe90e1b6b8b
container efe90e1b6b8b76586abc5c1dc0e2797b75adc26517c48733d90651e767c8463b encountered an error during CreateProcess: failure in a Windows system call: The directory name is invalid. (0x10b) extra info: {"ApplicationName":"","CommandLine":"cmd /S /C go --help","User":"","WorkingDirectory":"C:\\installer","Environment":{"GOROOT":"c:\\installer"},"EmulateConsole":false,"CreateStdInPipe":true,"CreateStdOutPipe":true,"CreateStdErrPipe":true,"ConsoleSize":[0,0]}
PS E:\docker\build\unifyworkdir>
```

Then forcing process isolation:
```
PS E:\docker\build\unifyworkdir> docker build --isolation=process --no-cache .
Sending build context to Docker daemon  10.1 MB
Step 1/5 : FROM microsoft/nanoserver
 ---> 89b8556cb9ca
Step 2/5 : WORKDIR c:\installer
 ---> 350c955980c8
Removing intermediate container 8339c1e9250c
Step 3/5 : ENV GOROOT c:\installer
 ---> Running in bde511c5e3e0
 ---> b8820063b5b6
Removing intermediate container bde511c5e3e0
Step 4/5 : ADD go.exe .
 ---> e4ac32f8902b
Removing intermediate container d586e8492eda
Step 5/5 : RUN go --help
 ---> Running in 9e1aa235af5f
Cannot mkdir: C:\installer is not a directory
PS E:\docker\build\unifyworkdir>
```

Now compare the same results after this PR.  Again, first with no explicit isolation (defaulting to Hyper-V containers as that's what the daemon it set to) - note it now succeeds :smile:

```
PS E:\docker\build\unifyworkdir> docker build --no-cache .
Sending build context to Docker daemon  10.1 MB
Step 1/5 : FROM microsoft/nanoserver
 ---> 89b8556cb9ca
Step 2/5 : WORKDIR c:\installer
 ---> 4f319f301c69
Removing intermediate container 61b9c0b1ff6f
Step 3/5 : ENV GOROOT c:\installer
 ---> Running in c464a1d612d8
 ---> 96a26ab9a7b5
Removing intermediate container c464a1d612d8
Step 4/5 : ADD go.exe .
 ---> 0290d61faf57
Removing intermediate container dc5a085fffe3
Step 5/5 : RUN go --help
 ---> Running in 60bd56042ff8
Go is a tool for managing Go source code.

Usage:

        go command [arguments]

The commands are:

        build       compile packages and dependencies
        clean       remove object files
        doc         show documentation for package or symbol
        env         print Go environment information
        fix         run go tool fix on packages
        fmt         run gofmt on package sources
        generate    generate Go files by processing source
        get         download and install packages and dependencies
        install     compile and install packages and dependencies
        list        list packages
        run         compile and run Go program
        test        test packages
        tool        run specified go tool
        version     print Go version
        vet         run go tool vet on packages

Use "go help [command]" for more information about a command.

Additional help topics:

        c           calling between Go and C
        buildmode   description of build modes
        filetype    file types
        gopath      GOPATH environment variable
        environment environment variables
        importpath  import path syntax
        packages    description of package lists
        testflag    description of testing flags
        testfunc    description of testing functions

Use "go help [topic]" for more information about that topic.

The command 'cmd /S /C go --help' returned a non-zero code: 2
```

And the same with forcing process isolation. Also works :smile:
```
PS E:\docker\build\unifyworkdir> docker build --isolation=process --no-cache .
Sending build context to Docker daemon  10.1 MB
Step 1/5 : FROM microsoft/nanoserver
 ---> 89b8556cb9ca
Step 2/5 : WORKDIR c:\installer
 ---> f423b9cc3e78
Removing intermediate container 41330c88893d
Step 3/5 : ENV GOROOT c:\installer
 ---> Running in 0b99a2d7bf19
 ---> e051144bf8ec
Removing intermediate container 0b99a2d7bf19
Step 4/5 : ADD go.exe .
 ---> 7072e32b7c37
Removing intermediate container a7a97aa37fd1
Step 5/5 : RUN go --help
 ---> Running in 7097438a54e5
Go is a tool for managing Go source code.

Usage:

        go command [arguments]

The commands are:

        build       compile packages and dependencies
        clean       remove object files
        doc         show documentation for package or symbol
        env         print Go environment information
        fix         run go tool fix on packages
        fmt         run gofmt on package sources
        generate    generate Go files by processing source
        get         download and install packages and dependencies
        install     compile and install packages and dependencies
        list        list packages
        run         compile and run Go program
        test        test packages
        tool        run specified go tool
        version     print Go version
        vet         run go tool vet on packages

Use "go help [command]" for more information about a command.

Additional help topics:

        c           calling between Go and C
        buildmode   description of build modes
        filetype    file types
        gopath      GOPATH environment variable
        environment environment variables
        importpath  import path syntax
        packages    description of package lists
        testflag    description of testing flags
        testfunc    description of testing functions

Use "go help [topic]" for more information about that topic.

The command 'cmd /S /C go --help' returned a non-zero code: 2
PS E:\docker\build\unifyworkdir>
```

@friism @thaJeztah This might (not sure - will let you guys make the call) be an important one to pull into 1.13.1 and CS, in particular for client container scenarios. Server scenarios it's not so impactful as the default isolation is process/Windows Server containers.