### PR TITLE
Make markdown for man pages of `docker container ...` consistent

### DIFF
--- a/man/src/container/attach.md
+++ b/man/src/container/attach.md
@@ -45,8 +45,8 @@ In this example the top command is run inside a container, from an image called
 fedora, in detached mode. The ID from the container is passed into the **docker
 attach** command:
 
-    # ID=$(sudo docker run -d fedora /usr/bin/top -b)
-    # sudo docker attach $ID
+    $ ID=$(sudo docker run -d fedora /usr/bin/top -b)
+    $ sudo docker attach $ID
     top - 02:05:52 up  3:05,  0 users,  load average: 0.01, 0.02, 0.05
     Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
     Cpu(s):  0.1%us,  0.2%sy,  0.0%ni, 99.7%id,  0.0%wa,  0.0%hi,  0.0%si,  0.0%st

--- a/man/src/container/commit.md
+++ b/man/src/container/commit.md
@@ -15,7 +15,7 @@ An existing Fedora based container has had Apache installed while running
 in interactive mode with the bash shell. Apache is also running. To
 create a new image run `docker ps` to find the container's ID and then run:
 
-    # docker commit -m="Added Apache to Fedora base image" \
+    $ docker commit -m="Added Apache to Fedora base image" \
       -a="A D Ministrator" 98bd7fc99854 fedora/fedora_httpd:20
 
 Note that only a-z0-9-_. are allowed when naming images from an 
@@ -27,4 +27,4 @@ variable set to "true", you can create a new image based on that
 container by first getting the container's ID with `docker ps` and
 then running:
 
-    # docker container commit -c="ENV DEBUG true" 98bd7fc99854 debug-image
+    $ docker container commit -c="ENV DEBUG true" 98bd7fc99854 debug-image

--- a/man/src/container/export.md
+++ b/man/src/container/export.md
@@ -8,11 +8,11 @@ Stream to a file instead of STDOUT by using **-o**.
 Export the contents of the container called angry_bell to a tar file
 called angry_bell.tar:
 
-    # docker export angry_bell > angry_bell.tar
-    # docker export --output=angry_bell-latest.tar angry_bell
-    # ls -sh angry_bell.tar
+    $ docker export angry_bell > angry_bell.tar
+    $ docker export --output=angry_bell-latest.tar angry_bell
+    $ ls -sh angry_bell.tar
     321M angry_bell.tar
-    # ls -sh angry_bell-latest.tar
+    $ ls -sh angry_bell-latest.tar
     321M angry_bell-latest.tar
 
 # See also

--- a/man/src/container/ls.md
+++ b/man/src/container/ls.md
@@ -35,61 +35,61 @@ Filter output based on these conditions:
       .Mounts - Names of the volumes mounted in this container.
 
 # EXAMPLES
-# Display all containers, including non-running
+## Display all containers, including non-running
 
-    # docker container ls -a
+    $ docker container ls -a
     CONTAINER ID        IMAGE                 COMMAND                CREATED             STATUS      PORTS    NAMES
     a87ecb4f327c        fedora:20             /bin/sh -c #(nop) MA   20 minutes ago      Exit 0               desperate_brattain
     01946d9d34d8        vpavlin/rhel7:latest  /bin/sh -c #(nop) MA   33 minutes ago      Exit 0               thirsty_bell
     c1d3b0166030        acffc0358b9e          /bin/sh -c yum -y up   2 weeks ago         Exit 1               determined_torvalds
     41d50ecd2f57        fedora:20             /bin/sh -c #(nop) MA   2 weeks ago         Exit 0               drunk_pike
 
-# Display only IDs of all containers, including non-running
+## Display only IDs of all containers, including non-running
 
-    # docker container ls -a -q
+    $ docker container ls -a -q
     a87ecb4f327c
     01946d9d34d8
     c1d3b0166030
     41d50ecd2f57
 
-# Display only IDs of all containers that have the name `determined_torvalds`
+## Display only IDs of all containers that have the name `determined_torvalds`
 
-    # docker container ls -a -q --filter=name=determined_torvalds
+    $ docker container ls -a -q --filter=name=determined_torvalds
     c1d3b0166030
 
-# Display containers with their commands
+## Display containers with their commands
 
-    # docker container ls --format "{{.ID}}: {{.Command}}"
+    $ docker container ls --format "{{.ID}}: {{.Command}}"
     a87ecb4f327c: /bin/sh -c #(nop) MA
     01946d9d34d8: /bin/sh -c #(nop) MA
     c1d3b0166030: /bin/sh -c yum -y up
     41d50ecd2f57: /bin/sh -c #(nop) MA
 
-# Display containers with their labels in a table
+## Display containers with their labels in a table
 
-    # docker container ls --format "table {{.ID}}\t{{.Labels}}"
+    $ docker container ls --format "table {{.ID}}\t{{.Labels}}"
     CONTAINER ID        LABELS
     a87ecb4f327c        com.docker.swarm.node=ubuntu,com.docker.swarm.storage=ssd
     01946d9d34d8
     c1d3b0166030        com.docker.swarm.node=debian,com.docker.swarm.cpu=6
     41d50ecd2f57        com.docker.swarm.node=fedora,com.docker.swarm.cpu=3,com.docker.swarm.storage=ssd
 
-# Display containers with their node label in a table
+## Display containers with their node label in a table
 
-    # docker container ls --format 'table {{.ID}}\t{{(.Label "com.docker.swarm.node")}}'
+    $ docker container ls --format 'table {{.ID}}\t{{(.Label "com.docker.swarm.node")}}'
     CONTAINER ID        NODE
     a87ecb4f327c        ubuntu
     01946d9d34d8
     c1d3b0166030        debian
     41d50ecd2f57        fedora
 
-# Display containers with `remote-volume` mounted
+## Display containers with `remote-volume` mounted
 
     $ docker container ls --filter volume=remote-volume --format "table {{.ID}}\t{{.Mounts}}"
     CONTAINER ID        MOUNTS
     9c3527ed70ce        remote-volume
 
-# Display containers with a volume mounted in `/data`
+## Display containers with a volume mounted in `/data`
 
     $ docker container ls --filter volume=/data --format "table {{.ID}}\t{{.Mounts}}"
     CONTAINER ID        MOUNTS

--- a/man/src/container/port.md
+++ b/man/src/container/port.md
@@ -2,25 +2,25 @@ List port mappings for the CONTAINER, or lookup the public-facing port that is N
 
 # EXAMPLES
 
-    # docker ps
+    $ docker ps
     CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                                            NAMES
     b650456536c7        busybox:latest      top                 54 minutes ago      Up 54 minutes       0.0.0.0:1234->9876/tcp, 0.0.0.0:4321->7890/tcp   test
 
 ## Find out all the ports mapped
 
-    # docker container port test
+    $ docker container port test
     7890/tcp -> 0.0.0.0:4321
     9876/tcp -> 0.0.0.0:1234
 
 ## Find out a specific mapping
 
-    # docker container port test 7890/tcp
+    $ docker container port test 7890/tcp
     0.0.0.0:4321
 
-    # docker container port test 7890
+    $ docker container port test 7890
     0.0.0.0:4321
 
 ## An example showing error for non-existent mapping
 
-    # docker container port test 7890/udp
+    $ docker container port test 7890/udp
     2014/06/24 11:53:36 Error: No public port '7890/udp' published for test


### PR DESCRIPTION
This fix updates the markdown for man pages of `docker container ...`
so that they are consistent. The changes are based on feedback:
https://github.com/docker/docker/pull/30645#discussion_r99020188
https://github.com/docker/docker/pull/30645#discussion_r99020304

1. Use `H2 (##)` as needed
2. Use unrpiviledged prompt (`$`) instead of (`#`)

This PR covers files under man/src/container/*.md

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

/cc @thaJeztah 