### PR TITLE
Update API history and man page for `--filter expose/publish`

### DIFF
--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -19,6 +19,7 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 * `GET /containers/(id or name)/attach/ws` now returns WebSocket in binary frame format for API version >= v1.26, and returns WebSocket in text frame format for API version< v1.26, for the purpose of backward-compatibility.
 * `GET /networks` is optimised only to return list of all networks and network specific information. List of all containers attached to a specific network is removed from this API and is only available using the network specific `GET /networks/{network-id}.
+* `GET /containers/json` now supports `publish` and `expose` filters to filter containers that expose or publish certain ports.
 
 ## v1.25 API changes
 

--- a/man/src/container/ls.md
+++ b/man/src/container/ls.md
@@ -16,6 +16,8 @@ Filter output based on these conditions:
    - volume=(<volume-name>|<mount-point-destination>)
    - network=(<network-name>|<network-id>) - containers connected to the provided network
    - health=(starting|healthy|unhealthy|none) - filters containers based on healthcheck status
+   - publish=(<port>[/<proto>]|<startport-endport>/[<proto>]) - filters containers based on published ports
+   - expose=(<port>[/<proto>]|<startport-endport>/[<proto>]) - filters containers based on exposed ports
 
 ## Format
 
@@ -94,3 +96,15 @@ Filter output based on these conditions:
     $ docker container ls --filter volume=/data --format "table {{.ID}}\t{{.Mounts}}"
     CONTAINER ID        MOUNTS
     9c3527ed70ce        remote-volume
+
+## Display containers that have published port of 80:
+
+    $ docker ps --filter publish=80
+    CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS                   NAMES
+    fc7e477723b7        busybox             "top"               About a minute ago   Up About a minute   0.0.0.0:32768->80/tcp   admiring_roentgen
+
+## Display containers that have exposed TCP port in the range of `8000-8080`:
+
+    $ docker ps --filter expose=8000-8080/tcp
+    CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+    9833437217a5        busybox             "top"               21 seconds ago      Up 19 seconds       8080/tcp            dreamy_mccarthy


### PR DESCRIPTION
This fix updates API history and man page for
`docker ps --filter expose/publish`, from the feedback:
https://github.com/docker/docker/pull/27557#issuecomment-276832876

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

/cc @thaJeztah 