### PR TITLE
[nit] hack/make.sh: clean up

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -234,15 +234,13 @@ copy_binaries() {
 	# them available, but only if the native OS/ARCH is the same as the
 	# OS/ARCH of the build target
 	if [ "$(go env GOOS)/$(go env GOARCH)" == "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
-		if [ -x /usr/local/bin/docker-runc ]; then
-			echo "Copying nested executables into $dir"
-			for file in containerd containerd-shim containerd-ctr runc init proxy; do
-				cp `which "docker-$file"` "$dir/"
-				if [ "$2" == "hash" ]; then
-					hash_files "$dir/docker-$file"
-				fi
-			done
-		fi
+		echo "Copying nested executables into $dir"
+		for file in containerd containerd-shim containerd-ctr runc init proxy; do
+			cp `which "docker-$file"` "$dir/"
+			if [ "$2" == "hash" ]; then
+				hash_files "$dir/docker-$file"
+			fi
+		done
 	fi
 }
 


### PR DESCRIPTION
The checking logic for /usr/local/bin/docker-runc seems wrong and unneeded.


cc @dnephin @tianon 
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
