### PR TITLE
Add bash completion for `{dockerd,docker run} --log-opt max-buffer-size|mode`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -712,16 +712,18 @@ __docker_complete_log_drivers() {
 }
 
 __docker_complete_log_options() {
-	# see docs/reference/logging/index.md
-	local awslogs_options="awslogs-region awslogs-group awslogs-stream awslogs-create-group"
-	local fluentd_options="env fluentd-address fluentd-async-connect fluentd-buffer-limit fluentd-retry-wait fluentd-max-retries labels tag"
-	local gcplogs_options="env gcp-log-cmd gcp-project labels"
-	local gelf_options="env gelf-address gelf-compression-level gelf-compression-type labels tag"
-	local journald_options="env labels tag"
-	local json_file_options="env labels max-file max-size"
-	local logentries_options="logentries-token"
-	local syslog_options="env labels syslog-address syslog-facility syslog-format syslog-tls-ca-cert syslog-tls-cert syslog-tls-key syslog-tls-skip-verify tag"
-	local splunk_options="env labels splunk-caname splunk-capath splunk-format splunk-gzip splunk-gzip-level splunk-index splunk-insecureskipverify splunk-source splunk-sourcetype splunk-token splunk-url splunk-verify-connection tag"
+	# see repository docker/docker.github.io/engine/admin/logging/
+	local common_options="max-buffer-size mode"
+
+	local awslogs_options="$common_options awslogs-region awslogs-group awslogs-stream awslogs-create-group"
+	local fluentd_options="$common_options env fluentd-address fluentd-async-connect fluentd-buffer-limit fluentd-retry-wait fluentd-max-retries labels tag"
+	local gcplogs_options="$common_options env gcp-log-cmd gcp-project labels"
+	local gelf_options="$common_options env gelf-address gelf-compression-level gelf-compression-type labels tag"
+	local journald_options="$common_options env labels tag"
+	local json_file_options="$common_options env labels max-file max-size"
+	local logentries_options="$common_options logentries-token"
+	local syslog_options="$common_options env labels syslog-address syslog-facility syslog-format syslog-tls-ca-cert syslog-tls-cert syslog-tls-key syslog-tls-skip-verify tag"
+	local splunk_options="$common_options env labels splunk-caname splunk-capath splunk-format splunk-gzip splunk-gzip-level splunk-index splunk-insecureskipverify splunk-source splunk-sourcetype splunk-token splunk-url splunk-verify-connection tag"
 
 	local all_options="$fluentd_options $gcplogs_options $gelf_options $journald_options $logentries_options $json_file_options $syslog_options $splunk_options"
 
@@ -782,6 +784,10 @@ __docker_complete_log_driver_options() {
 			;;
 		gelf-compression-type)
 			COMPREPLY=( $( compgen -W "gzip none zlib" -- "${cur##*=}" ) )
+			return
+			;;
+		mode)
+			COMPREPLY=( $( compgen -W "blocking nonblocking" -- "${cur##*=}" ) )
 			return
 			;;
 		syslog-address)


### PR DESCRIPTION
Ref: #28762
Also updated the link to the documentation, which moved to docker.github.io.

According to the PR,

> added 2 built-in log-opts that work on all logging drivers, `mode` (`blocking`|`non-blocking`), and `max-buffer-size` (e.g. `2m`) which enables a non-blocking log buffer

the new options are common to all log drivers, so I created a new variable for common options.

**Question**:
The log options `env`, `labels` and `tag` seem to be global, too. But in the [documentation](https://github.com/docker/docker.github.io/blob/00763da422f0e1a7c6cc366a115aab95d82df050/engine/admin/logging/overview.md), they are missing for selected drivers:
- awslogs and logentries do not support any of them
- gcplogs and json_file are missing `tag`

Is the documentation wrong here? Can (some of) these options be promoted to the common options?
