### PR TITLE
Fixing issue of docker top command failure when dealing with -m option

### DIFF
--- a/daemon/top_unix_test.go
+++ b/daemon/top_unix_test.go
@@ -42,17 +42,20 @@ func TestContainerTopParsePSOutput(t *testing.T) {
 		{[]byte(`  PID COMMAND
    42 foo
    43 bar
+		- -
   100 baz
 `), []int{42, 43}, false},
 		{[]byte(`  UID COMMAND
    42 foo
    43 bar
+		- -
   100 baz
 `), []int{42, 43}, true},
 		// unicode space (U+2003, 0xe2 0x80 0x83)
 		{[]byte(` PID COMMAND
    42 foo
    43 bar
+		- -
   100 baz
 `), []int{42, 43}, true},
 		// the first space is U+2003, the second one is ascii.


### PR DESCRIPTION
Signed-off-by: catinthesky <yaozaiyong@hotmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Ignore the "ps m" command's "thread line" that has "-" character as pid which can not be converted into a int. 
**- How I did it**
When detecting pid column is "-", ignore this line and continue forward.
**- How to verify it**
Using command:  "docker top <contianer-id> m" to check if the problem of  "Unexpected pid '-': strconv.ParseInt: parsing "-": invalid synta"   disappeared
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

Fix #30580 