### PR TITLE
List Networks need not pull all the endpoints

### DIFF
--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,8 +17,8 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.26](v1.26/) documentation
 
-* `GET /containers/(id or name)/attach/ws` now returns WebSocket in binary frame format for API version >= v1.26,
-  and returns WebSocket in text frame format for API version< v1.26, for the purpose of backward-compatibility.
+* `GET /containers/(id or name)/attach/ws` now returns WebSocket in binary frame format for API version >= v1.26, and returns WebSocket in text frame format for API version< v1.26, for the purpose of backward-compatibility.
+* `GET /networks` is optimised only to return list of all networks and network specific information. List of all containers attached to a specific network is removed from this API and is only available using the network specific `GET /networks/{network-id}.
 
 ## v1.25 API changes
 


### PR DESCRIPTION
Pulling all the endpoints is a very resource heavy operation especially
for Global-scoped networks with a backing KVStore. Such heavy operations
can be fetched for individual network inspect. These are unneccessary
for a simple network list operation.

Signed-off-by: Madhu Venugopal <madhu@docker.com>