### PR TITLE
Windows: Remove unused commandLine

### DIFF
--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -251,7 +251,6 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 					client:       clnt,
 					friendlyName: InitFriendlyName,
 				},
-				commandLine: strings.Join(spec.Process.Args, " "),
 			},
 			processes: make(map[string]*process),
 		},
@@ -354,8 +353,7 @@ func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendly
 			client:       clnt,
 			systemPid:    uint32(pid),
 		},
-		commandLine: createProcessParms.CommandLine,
-		hcsProcess:  newProcess,
+		hcsProcess: newProcess,
 	}
 
 	// Add the process to the container's list of processes

--- a/libcontainerd/process_windows.go
+++ b/libcontainerd/process_windows.go
@@ -13,10 +13,7 @@ type process struct {
 	processCommon
 
 	// Platform specific fields are below here.
-
-	// commandLine is to support returning summary information for docker top
-	commandLine string
-	hcsProcess  hcsshim.Process
+	hcsProcess hcsshim.Process
 }
 
 type autoClosingReader struct {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This removes `commandLine` which is unused in the Windows implementation of libcontainerd. It was originally introduced for a minimal implementation of the `top` call, but was superceeded later by platform support from HCS, but not removed.
