### PR TITLE
Add NILVALUE for STRUCTURED-DATA in RFC5424 logs

### DIFF
--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -68,7 +68,7 @@ func init() {
 func rfc5424formatterWithAppNameAsTag(p syslog.Priority, hostname, tag, content string) string {
 	timestamp := time.Now().Format(time.RFC3339)
 	pid := os.Getpid()
-	msg := fmt.Sprintf("<%d>%d %s %s %s %d %s %s",
+	msg := fmt.Sprintf("<%d>%d %s %s %s %d %s - %s",
 		p, 1, timestamp, hostname, tag, pid, tag, content)
 	return msg
 }
@@ -79,7 +79,7 @@ func rfc5424formatterWithAppNameAsTag(p syslog.Priority, hostname, tag, content 
 func rfc5424microformatterWithAppNameAsTag(p syslog.Priority, hostname, tag, content string) string {
 	timestamp := time.Now().Format("2006-01-02T15:04:05.999999Z07:00")
 	pid := os.Getpid()
-	msg := fmt.Sprintf("<%d>%d %s %s %s %d %s %s",
+	msg := fmt.Sprintf("<%d>%d %s %s %s %d %s - %s",
 		p, 1, timestamp, hostname, tag, pid, tag, content)
 	return msg
 }


### PR DESCRIPTION
RFC 5424 (https://tools.ietf.org/html/rfc5424#section-6.2) requires that
STRUCTURED-DATA be present, either as NILVALUE (-) or as one or more
SD-ELEMENT items. Because Docker doesn't ever create any SD-ELEMENT items,
the format should output the NILVALUE instead. This resolves parsing issues
in various RFC 5424-compliant syslog servers. Fixes #26937 but does not 
address the suggestion there for allowing the contained application to
supply a SD-ELEMENT value.

Signed-off-by: Mark Parker <godefroi@gmail.com>


**- What I did**
Add NILVALUE (-) to the RFC 5424 format strings

**- How I did it**

**- How to verify it**

**- Description for the changelog**
Correct RFC 5424 (syslog) log message formatting

**- A picture of a cute animal (not mandatory but encouraged)**

```
 ^..^
( oo )  )~
  ,,  ,,
```