### PR TITLE
update status code for network api

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6320,6 +6320,10 @@ paths:
           description: "Network not found"
           schema:
             $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
       parameters:
         - name: "id"
           in: "path"
@@ -6339,6 +6343,10 @@ paths:
       responses:
         204:
           description: "No error"
+        403:
+          description: "operation not supported for pre-defined networks"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "no such network"
           schema:

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -2739,7 +2739,9 @@ Content-Type: application/json
 
 #### Inspect network
 
-`GET /networks/<network-id>`
+`GET /networks/(id or name)`
+
+Return low-level information on the network `id`
 
 **Example request**:
 
@@ -2787,6 +2789,7 @@ Content-Type: application/json
 
 -   **200** - no error
 -   **404** - network not found
+-   **500** - server error
 
 #### Create a network
 
@@ -2853,7 +2856,7 @@ Content-Type: application/json
 
 #### Connect a container to a network
 
-`POST /networks/(id)/connect`
+`POST /networks/(id or name)/connect`
 
 Connect a container to a network
 
@@ -2884,7 +2887,7 @@ Content-Type: application/json
 
 #### Disconnect a container from a network
 
-`POST /networks/(id)/disconnect`
+`POST /networks/(id or name)/disconnect`
 
 Disconnect a container from a network
 
@@ -2915,7 +2918,7 @@ Content-Type: application/json
 
 #### Remove a network
 
-`DELETE /networks/(id)`
+`DELETE /networks/(id or name)`
 
 Instruct the driver to remove the network (`id`).
 
@@ -2930,6 +2933,7 @@ Instruct the driver to remove the network (`id`).
 **Status codes**:
 
 -   **200** - no error
+-   **403** - operation not supported for pre-defined networks
 -   **404** - no such network
 -   **500** - server error
 

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -3055,7 +3055,9 @@ Content-Type: application/json
 
 #### Inspect network
 
-`GET /networks/<network-id>`
+`GET /networks/(id or name)`
+
+Return low-level information on the network `id`
 
 **Example request**:
 
@@ -3108,6 +3110,7 @@ Content-Type: application/json
 
 -   **200** - no error
 -   **404** - network not found
+-   **500** - server error
 
 #### Create a network
 
@@ -3183,7 +3186,7 @@ Content-Type: application/json
 
 #### Connect a container to a network
 
-`POST /networks/(id)/connect`
+`POST /networks/(id or name)/connect`
 
 Connect a container to a network
 
@@ -3220,7 +3223,7 @@ Content-Type: application/json
 
 #### Disconnect a container from a network
 
-`POST /networks/(id)/disconnect`
+`POST /networks/(id or name)/disconnect`
 
 Disconnect a container from a network
 
@@ -3253,7 +3256,7 @@ Content-Type: application/json
 
 #### Remove a network
 
-`DELETE /networks/(id)`
+`DELETE /networks/(id or name)`
 
 Instruct the driver to remove the network (`id`).
 
@@ -3268,6 +3271,7 @@ Instruct the driver to remove the network (`id`).
 **Status codes**:
 
 -   **200** - no error
+-   **403** - operation not supported for pre-defined networks
 -   **404** - no such network
 -   **500** - server error
 

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -3150,7 +3150,9 @@ Content-Type: application/json
 
 #### Inspect network
 
-`GET /networks/<network-id>`
+`GET /networks/(id or name)`
+
+Return low-level information on the network `id`
 
 **Example request**:
 
@@ -3209,6 +3211,7 @@ Content-Type: application/json
 
 -   **200** - no error
 -   **404** - network not found
+-   **500** - server error
 
 #### Create a network
 
@@ -3300,7 +3303,7 @@ Content-Type: application/json
 
 #### Connect a container to a network
 
-`POST /networks/(id)/connect`
+`POST /networks/(id or name)/connect`
 
 Connect a container to a network
 
@@ -3337,7 +3340,7 @@ Content-Type: application/json
 
 #### Disconnect a container from a network
 
-`POST /networks/(id)/disconnect`
+`POST /networks/(id or name)/disconnect`
 
 Disconnect a container from a network
 
@@ -3370,7 +3373,7 @@ Content-Type: application/json
 
 #### Remove a network
 
-`DELETE /networks/(id)`
+`DELETE /networks/(id or name)`
 
 Instruct the driver to remove the network (`id`).
 
@@ -3385,6 +3388,7 @@ Instruct the driver to remove the network (`id`).
 **Status codes**:
 
 -   **204** - no error
+-   **403** - operation not supported for pre-defined networks
 -   **404** - no such network
 -   **500** - server error
 

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -3214,7 +3214,9 @@ Content-Type: application/json
 
 #### Inspect network
 
-`GET /networks/<network-id>`
+`GET /networks/(id or name)`
+
+Return low-level information on the network `id`
 
 **Example request**:
 
@@ -3273,6 +3275,7 @@ Content-Type: application/json
 
 -   **200** - no error
 -   **404** - network not found
+-   **500** - server error
 
 #### Create a network
 
@@ -3365,7 +3368,7 @@ Content-Type: application/json
 
 #### Connect a container to a network
 
-`POST /networks/(id)/connect`
+`POST /networks/(id or name)/connect`
 
 Connect a container to a network
 
@@ -3403,7 +3406,7 @@ Content-Type: application/json
 
 #### Disconnect a container from a network
 
-`POST /networks/(id)/disconnect`
+`POST /networks/(id or name)/disconnect`
 
 Disconnect a container from a network
 
@@ -3437,7 +3440,7 @@ Content-Type: application/json
 
 #### Remove a network
 
-`DELETE /networks/(id)`
+`DELETE /networks/(id or name)`
 
 Instruct the driver to remove the network (`id`).
 
@@ -3452,6 +3455,7 @@ Instruct the driver to remove the network (`id`).
 **Status codes**:
 
 -   **204** - no error
+-   **403** - operation not supported for pre-defined networks
 -   **404** - no such network
 -   **500** - server error
 


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

fixes https://github.com/docker/docker/issues/30698

**- What I did**
1. add status code 500 for api endpoint `GET /networks/(id or name)`, status code 500 is from https://github.com/docker/docker/blob/master/daemon/network.go#L61;
2. add status code 403 for api endpoint `DELETE /networks/(id or name)`, status code is from https://github.com/docker/docker/blob/master/daemon/network.go#L454;
3. update network api endpoints' url, replace `id` with `id or name`.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

