### PR TITLE
add status code 404 for plugin api endpoint enable and disable

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6610,6 +6610,10 @@ paths:
       responses:
         200:
           description: "no error"
+        404:
+          description: "plugin is not installed"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         500:
           description: "server error"
           schema:
@@ -6633,6 +6637,10 @@ paths:
       responses:
         200:
           description: "no error"
+        404:
+          description: "plugin is not installed"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         500:
           description: "server error"
           schema:

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -3800,6 +3800,7 @@ Content-Type: text/plain; charset=utf-8
 **Status codes**:
 
 -   **200** - no error
+-   **404** - plugin not installed
 -   **500** - plugin is already enabled
 
 #### Disable a plugin
@@ -3828,6 +3829,7 @@ Content-Type: text/plain; charset=utf-8
 **Status codes**:
 
 -   **200** - no error
+-   **404** - plugin not installed
 -   **500** - plugin is already disabled
 
 #### Remove a plugin


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

This pr adds missing status code 404 for plugin api endpoint enable and disable

ping @anusha-ragunathan 

**- What I did**
1. add status code 404 for plugin api endpoint enable and disable in swagger.yml, tested in docker 1.13.0;
2. add status code 404 for plugin api endpoint enable and disable in api doc1.24, tested in docker-1.12.6-exeperimental;

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

