### PR TITLE
add missing filter type in swagger.yml and sort filter type in alphabets

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2488,6 +2488,7 @@ paths:
 
             - `ancestor`=(`<image-name>[:<tag>]`, `<image id>`, or `<image@digest>`)
             - `before`=(`<container id>` or `<container name>`)
+            - `expose`=(`<port>[/<proto>]`|`<startport-endport>/[<proto>]`)
             - `exited=<int>` containers with exit code of `<int>`
             - `health`=(`starting`|`healthy`|`unhealthy`|`none`)
             - `id=<ID>` a container's ID
@@ -2496,6 +2497,7 @@ paths:
             - `label=key` or `label="key=value"` of a container label
             - `name=<name>` a container's name
             - `network`=(`<network id>` or `<network name>`)
+            - `publish`=(`<port>[/<proto>]`|`<startport-endport>/[<proto>]`)
             - `since`=(`<container id>` or `<container name>`)
             - `status=`(`created`|`restarting`|`running`|`removing`|`paused`|`exited`|`dead`)
             - `volume`=(`<volume name>` or `<mount point destination>`)

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2484,22 +2484,21 @@ paths:
         - name: "filters"
           in: "query"
           description: |
-            Filters to process on the container list, encoded as JSON (a `map[string][]string`). For example, `{"status": ["paused"]}` will only return paused containers.
+            Filters to process on the container list, encoded as JSON (a `map[string][]string`). For example, `{"status": ["paused"]}` will only return paused containers. Available filters:
 
-            Available filters:
-            - `exited=<int>` containers with exit code of `<int>`
-            - `status=`(`created`|`restarting`|`running`|`removing`|`paused`|`exited`|`dead`)
-            - `label=key` or `label="key=value"` of a container label
-            - `isolation=`(`default`|`process`|`hyperv`) (Windows daemon only)
-            - `id=<ID>` a container's ID
-            - `name=<name>` a container's name
-            - `is-task=`(`true`|`false`)
             - `ancestor`=(`<image-name>[:<tag>]`, `<image id>`, or `<image@digest>`)
             - `before`=(`<container id>` or `<container name>`)
-            - `since`=(`<container id>` or `<container name>`)
-            - `volume`=(`<volume name>` or `<mount point destination>`)
-            - `network`=(`<network id>` or `<network name>`)
+            - `exited=<int>` containers with exit code of `<int>`
             - `health`=(`starting`|`healthy`|`unhealthy`|`none`)
+            - `id=<ID>` a container's ID
+            - `isolation=`(`default`|`process`|`hyperv`) (Windows daemon only)
+            - `is-task=`(`true`|`false`)
+            - `label=key` or `label="key=value"` of a container label
+            - `name=<name>` a container's name
+            - `network`=(`<network id>` or `<network name>`)
+            - `since`=(`<container id>` or `<container name>`)
+            - `status=`(`created`|`restarting`|`running`|`removing`|`paused`|`exited`|`dead`)
+            - `volume`=(`<volume name>` or `<mount point destination>`)
           type: "string"
       responses:
         200:
@@ -4305,14 +4304,13 @@ paths:
         - name: "filters"
           in: "query"
           description: |
-            A JSON encoded value of the filters (a `map[string][]string`) to process on the images list.
+            A JSON encoded value of the filters (a `map[string][]string`) to process on the images list. Available filters:
 
-            Available filters:
+            - `before`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
             - `dangling=true`
             - `label=key` or `label="key=value"` of an image label
-            - `before`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
-            - `since`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
             - `reference`=(`<image-name>[:<tag>]`)
+            - `since`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
           type: "string"
         - name: "digests"
           in: "query"
@@ -4894,9 +4892,9 @@ paths:
           description: |
             A JSON encoded value of the filters (a `map[string][]string`) to process on the images list. Available filters:
 
-            - `stars=<number>`
             - `is-automated=(true|false)`
             - `is-official=(true|false)`
+            - `stars=<number>` Matches images that has at least 'number' stars.
           type: "string"
       tags: ["Image"]
   /images/prune:
@@ -4909,9 +4907,8 @@ paths:
         - name: "filters"
           in: "query"
           description: |
-            Filters to process on the prune list, encoded as JSON (a `map[string][]string`).
+            Filters to process on the prune list, encoded as JSON (a `map[string][]string`). Available filters:
 
-            Available filters:
             - `dangling=<boolean>` When set to `true` (or `1`), prune only
                unused *and* untagged images. When set to `false`
                (or `0`), all unused images are pruned.
@@ -5402,13 +5399,14 @@ paths:
             A JSON encoded value of filters (a `map[string][]string`) to process on the event list. Available filters:
 
             - `container=<string>` container name or ID
+            - `daemon=<string>` daemon name or ID
             - `event=<string>` event type
             - `image=<string>` image name or ID
             - `label=<string>` image or container label
+            - `network=<string>` network name or ID
+            - `plugin`=<string> plugin name or ID
             - `type=<string>` object to filter by, one of `container`, `image`, `volume`, `network`, or `daemon`
             - `volume=<string>` volume name or ID
-            - `network=<string>` network name or ID
-            - `daemon=<string>` daemon name or ID
           type: "string"
       tags: ["System"]
   /system/df:
@@ -5882,13 +5880,14 @@ paths:
             JSON encoded value of the filters (a `map[string][]string`) to
             process on the volumes list. Available filters:
 
-            - `name=<volume-name>` Matches all or part of a volume name.
             - `dangling=<boolean>` When set to `true` (or `1`), returns all
                volumes that are not in use by a container. When set to `false`
                (or `0`), only volumes that are in use by one or more
                containers are returned.
-            - `driver=<volume-driver-name>` Matches all or part of a volume
-              driver name.
+            - `driver=<volume-driver-name>` Matches volumes based on their driver.
+            - `label=<key>` or `label=<key>:<value>` Matches volumes based on
+               the presence of a `label` alone or a `label` and a value.
+            - `name=<volume-name>` Matches all or part of a volume name.
           type: "string"
           format: "json"
       tags: ["Volume"]
@@ -7175,8 +7174,8 @@ paths:
             A JSON encoded value of the filters (a `map[string][]string`) to process on the services list. Available filters:
 
             - `id=<service id>`
-            - `name=<service name>`
             - `label=<service label>`
+            - `name=<service name>`
       tags: ["Service"]
   /services/create:
     post:
@@ -7639,12 +7638,12 @@ paths:
           description: |
             A JSON encoded value of the filters (a `map[string][]string`) to process on the tasks list. Available filters:
 
-            - `id=<task id>`
-            - `name=<task name>`
-            - `service=<service name>`
-            - `node=<node id or name>`
-            - `label=key` or `label="key=value"`
             - `desired-state=(running | shutdown | accepted)`
+            - `id=<task id>`
+            - `label=key` or `label="key=value"`
+            - `name=<task name>`
+            - `node=<node id or name>`
+            - `service=<service name>`
       tags: ["Task"]
   /tasks/{id}:
     get:

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -82,14 +82,14 @@ container container 588a23dac085 *AND* the event type is *start*
 The currently supported filters are:
 
 * container (`container=<name or id>`)
+* daemon (`daemon=<name or id>`)
 * event (`event=<event action>`)
 * image (`image=<tag or id>`)
-* plugin (experimental) (`plugin=<name or id>`)
 * label (`label=<key>` or `label=<key>=<value>`)
+* network (`network=<name or id>`)
+* plugin (`plugin=<name or id>`)
 * type (`type=<container or image or volume or network or daemon>`)
 * volume (`volume=<name or id>`)
-* network (`network=<name or id>`)
-* daemon (`daemon=<name or id>`)
 
 ## Format
 

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -23,19 +23,20 @@ List containers
 Options:
   -a, --all             Show all containers (default shows just running)
   -f, --filter value    Filter output based on conditions provided (default [])
-                        - exited=<int> an exit code of <int>
-                        - label=<key> or label=<key>=<value>
-                        - status=(created|restarting|removing|running|paused|exited)
-                        - name=<string> a container's name
-                        - id=<ID> a container's ID
-                        - before=(<container-name>|<container-id>)
-                        - since=(<container-name>|<container-id>)
                         - ancestor=(<image-name>[:tag]|<image-id>|<image@digest>)
                           containers created from an image or a descendant.
-                        - publish=(<port>[/<proto>]|<startport-endport>/[<proto>])
-                        - expose=(<port>[/<proto>]|<startport-endport>/[<proto>])
-                        - is-task=(true|false)
+                        - before=(<container-name>|<container-id>)
+                        - exited=<int> an exit code of <int>
                         - health=(starting|healthy|unhealthy|none)
+                        - id=<ID> a container's ID
+                        - isolation=(`default`|`process`|`hyperv`) (Windows daemon only)
+                        - is-task=(true|false)
+                        - label=<key> or label=<key>=<value>
+                        - name=<string> a container's name
+                        - network=(<network-id>|<network-name>)
+                        - since=(<container-name>|<container-id>)
+                        - status=(created|restarting|removing|running|paused|exited) 
+                        - volume=(<volume name>|<mount point destination>)
       --format string   Pretty-print containers using a Go template
       --help            Print usage
   -n, --last int        Show n last created containers (includes all states) (default -1)

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -26,6 +26,7 @@ Options:
                         - ancestor=(<image-name>[:tag]|<image-id>|<image@digest>)
                           containers created from an image or a descendant.
                         - before=(<container-name>|<container-id>)
+                        - expose=(<port>[/<proto>]|<startport-endport>/[<proto>])
                         - exited=<int> an exit code of <int>
                         - health=(starting|healthy|unhealthy|none)
                         - id=<ID> a container's ID
@@ -34,6 +35,7 @@ Options:
                         - label=<key> or label=<key>=<value>
                         - name=<string> a container's name
                         - network=(<network-id>|<network-name>)
+                        - publish=(<port>[/<proto>]|<startport-endport>/[<proto>])
                         - since=(<container-name>|<container-id>)
                         - status=(created|restarting|removing|running|paused|exited) 
                         - volume=(<volume name>|<mount point destination>)


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I found that there are some missing types about filter in daemon API in swagger.yml. Here is the missing type list:

1. in `GET /containers/json`, filter type `expose` and `publish`;
2. in `GET /events`, filter type `plugin`;
3. in `GET /volumes`, filter type `label`;

Secondly, I sort the all filter type in swagger.yml sorted by alphabet sequence.

Thirdly, I add filter type `volume`, `network` and `isolation` in command `ps` and sorted this filter types. Also update events command line reference to sort filter types.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

