### PR TITLE
Add bash completion for `dockerd --default-shm-size`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1923,6 +1923,7 @@ _docker_daemon() {
 		--containerd
 		--default-gateway
 		--default-gateway-v6
+		--default-shm-size
 		--default-ulimit
 		--dns
 		--dns-search


### PR DESCRIPTION
Ref: #29692