### PR TITLE
[1.13] Update go connections 1.13

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -17,7 +17,7 @@ github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://github.com/tonistiigi/net.git
 golang.org/x/sys 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
 github.com/docker/go-units 8a7beacffa3009a9ac66bad506b18ffdd110cf97
-github.com/docker/go-connections 4ccf312bf1d35e5dbda654e57a9be4c3f3cd0366
+github.com/docker/go-connections ecb4cb2dd420ada7df7f2593d6c25441f65f69f2
 
 github.com/RackSec/srslog 456df3a81436d29ba874f3590eeeee25d666f8a5
 github.com/imdario/mergo 0.2.1

--- a/vendor/github.com/docker/go-connections/tlsconfig/certpool_go17.go
+++ b/vendor/github.com/docker/go-connections/tlsconfig/certpool_go17.go
@@ -14,7 +14,7 @@ import (
 func SystemCertPool() (*x509.CertPool, error) {
 	certpool, err := x509.SystemCertPool()
 	if err != nil && runtime.GOOS == "windows" {
-		logrus.Warnf("Unable to use system certificate pool: %v", err)
+		logrus.Infof("Unable to use system certificate pool: %v", err)
 		return x509.NewCertPool(), nil
 	}
 	return certpool, err

--- a/vendor/github.com/docker/go-connections/tlsconfig/config.go
+++ b/vendor/github.com/docker/go-connections/tlsconfig/config.go
@@ -118,7 +118,7 @@ func Server(options Options) (*tls.Config, error) {
 		return nil, fmt.Errorf("Error reading X509 key pair (cert: %q, key: %q): %v. Make sure the key is not encrypted.", options.CertFile, options.KeyFile, err)
 	}
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
-	if options.ClientAuth >= tls.VerifyClientCertIfGiven {
+	if options.ClientAuth >= tls.VerifyClientCertIfGiven && options.CAFile != "" {
 		CAs, err := certPool(options.CAFile)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Changes windows message about system certificates from warn to info level. Ensures that server does not attempt to load an empty ca file.

fixes #30450 

Like #30729 but against 1.13. Uses https://github.com/docker/go-connections/tree/docker/1.13 instead of master which only contains windows fix.

