### PR TITLE
Parameter name in GetPluginPrivileges is "remote"

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6480,7 +6480,7 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:
-        - name: "name"
+        - name: "remote"
           in: "query"
           description: "The name of the plugin. The `:latest` tag is optional, and is the default if omitted."
           required: true


### PR DESCRIPTION
According to the behavior of Engine 1.13.0 as well as [code in master](https://github.com/docker/docker/blob/fa49c076d44365f77f392b72fd181db0524a18fb/client/plugin_install.go#L21), the name of the query param for /plugins/privileges is `remote`, but the swagger file currently lists `name` instead.