### PR TITLE
add status code 400 for api endpoint /events

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5383,6 +5383,10 @@ paths:
                   image: "alpine"
                   name: "my-container"
               time: 1461943101
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         500:
           description: "server error"
           schema:

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -2648,6 +2648,7 @@ Docker daemon report the following event:
 **Status codes**:
 
 -   **200** – no error
+-   **400** - bad parameter
 -   **500** – server error
 
 #### Get a tarball containing all images in a repository


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I found that in master and 1.13.x, 1.12.x, there is a status code of 400 for events endpoint, just add this status code.

code is like below:
```
return errors.NewBadRequestError(fmt.Errorf("`since` time (%s) cannot be after `until` time (%s)", r.Form.Get("since"), r.Form.Get("until")))
```

in master, code is here: https://github.com/docker/docker/blob/master/api/server/router/system/system_routes.go#L102
in docker 1.13.0, code is here: https://github.com/docker/docker/blob/v1.13.0/api/server/router/system/system_routes.go#L102
in docker 1.12.0, code is here:https://github.com/docker/docker/blob/v1.12.0/api/server/router/system/system_routes.go#L70

While in docker 1.11.0, there is no such status code of 400.

**- What I did**
1. add status code of 400 for events endpoint in swagger.yml;
2. add status code of 400 for events endpoint in api docs 1.24;

ping @thaJeztah 
It is about docker 1.13.x and 1.12.x, I think there is no need to separate PR/commits there, right?

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

