### PR TITLE
Add `label` filter for `docker system prune`

### DIFF
--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -72,7 +72,12 @@ func (v *volumeRouter) postVolumesPrune(ctx context.Context, w http.ResponseWrit
 		return err
 	}
 
-	pruneReport, err := v.backend.VolumesPrune(filters.Args{})
+	pruneFilters, err := filters.FromParam(r.Form.Get("filters"))
+	if err != nil {
+		return err
+	}
+
+	pruneReport, err := v.backend.VolumesPrune(pruneFilters)
 	if err != nil {
 		return err
 	}

--- a/cli/command/container/prune.go
+++ b/cli/command/container/prune.go
@@ -49,7 +49,7 @@ const warning = `WARNING! This will remove all stopped containers.
 Are you sure you want to continue?`
 
 func runPrune(dockerCli *command.DockerCli, opts pruneOptions) (spaceReclaimed uint64, output string, err error) {
-	pruneFilters := opts.filter.Value()
+	pruneFilters := command.PruneFilters(dockerCli, opts.filter.Value())
 
 	if !opts.force && !command.PromptForConfirmation(dockerCli.In(), dockerCli.Out(), warning) {
 		return

--- a/cli/command/image/prune.go
+++ b/cli/command/image/prune.go
@@ -58,6 +58,7 @@ Are you sure you want to continue?`
 func runPrune(dockerCli *command.DockerCli, opts pruneOptions) (spaceReclaimed uint64, output string, err error) {
 	pruneFilters := opts.filter.Value()
 	pruneFilters.Add("dangling", fmt.Sprintf("%v", !opts.all))
+	pruneFilters = command.PruneFilters(dockerCli, pruneFilters)
 
 	warning := danglingWarning
 	if opts.all {

--- a/cli/command/network/prune.go
+++ b/cli/command/network/prune.go
@@ -48,7 +48,7 @@ const warning = `WARNING! This will remove all networks not used by at least one
 Are you sure you want to continue?`
 
 func runPrune(dockerCli *command.DockerCli, opts pruneOptions) (output string, err error) {
-	pruneFilters := opts.filter.Value()
+	pruneFilters := command.PruneFilters(dockerCli, opts.filter.Value())
 
 	if !opts.force && !command.PromptForConfirmation(dockerCli.In(), dockerCli.Out(), warning) {
 		return

--- a/cli/command/prune/prune.go
+++ b/cli/command/prune/prune.go
@@ -37,7 +37,7 @@ func RunContainerPrune(dockerCli *command.DockerCli, filter opts.FilterOpt) (uin
 
 // RunVolumePrune executes a prune command for volumes
 func RunVolumePrune(dockerCli *command.DockerCli, filter opts.FilterOpt) (uint64, string, error) {
-	return volume.RunPrune(dockerCli)
+	return volume.RunPrune(dockerCli, filter)
 }
 
 // RunImagePrune executes a prune command for images

--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/pkg/system"
 )
 
@@ -84,4 +85,35 @@ func PromptForConfirmation(ins *InStream, outs *OutStream, message string) bool 
 	reader := bufio.NewReader(ins)
 	answer, _, _ := reader.ReadLine()
 	return strings.ToLower(string(answer)) == "y"
+}
+
+// PruneFilters returns consolidated prune filters obtained from config.json and cli
+func PruneFilters(dockerCli Cli, pruneFilters filters.Args) filters.Args {
+	if dockerCli.ConfigFile() == nil {
+		return pruneFilters
+	}
+	for _, f := range dockerCli.ConfigFile().PruneFilters {
+		parts := strings.SplitN(f, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if parts[0] == "label" {
+			// CLI label filter supersede config.json.
+			// If CLI label filter conflict with config.json,
+			// skip adding label! filter in config.json.
+			if pruneFilters.Include("label!") && pruneFilters.ExactMatch("label!", parts[1]) {
+				continue
+			}
+		} else if parts[0] == "label!" {
+			// CLI label! filter supersede config.json.
+			// If CLI label! filter conflict with config.json,
+			// skip adding label filter in config.json.
+			if pruneFilters.Include("label") && pruneFilters.ExactMatch("label", parts[1]) {
+				continue
+			}
+		}
+		pruneFilters.Add(parts[0], parts[1])
+	}
+
+	return pruneFilters
 }

--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -3,21 +3,22 @@ package volume
 import (
 	"fmt"
 
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
+	"github.com/docker/docker/opts"
 	units "github.com/docker/go-units"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 )
 
 type pruneOptions struct {
-	force bool
+	force  bool
+	filter opts.FilterOpt
 }
 
 // NewPruneCommand returns a new cobra prune command for volumes
 func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
-	var opts pruneOptions
+	opts := pruneOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
 		Use:   "prune [OPTIONS]",
@@ -39,6 +40,7 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.force, "force", "f", false, "Do not prompt for confirmation")
+	flags.Var(&opts.filter, "filter", "Provide filter values (e.g. 'label=<label>')")
 
 	return cmd
 }
@@ -47,11 +49,13 @@ const warning = `WARNING! This will remove all volumes not used by at least one 
 Are you sure you want to continue?`
 
 func runPrune(dockerCli command.Cli, opts pruneOptions) (spaceReclaimed uint64, output string, err error) {
+	pruneFilters := command.PruneFilters(dockerCli, opts.filter.Value())
+
 	if !opts.force && !command.PromptForConfirmation(dockerCli.In(), dockerCli.Out(), warning) {
 		return
 	}
 
-	report, err := dockerCli.Client().VolumesPrune(context.Background(), filters.Args{})
+	report, err := dockerCli.Client().VolumesPrune(context.Background(), pruneFilters)
 	if err != nil {
 		return
 	}
@@ -69,6 +73,6 @@ func runPrune(dockerCli command.Cli, opts pruneOptions) (spaceReclaimed uint64, 
 
 // RunPrune calls the Volume Prune API
 // This returns the amount of space reclaimed and a detailed output string
-func RunPrune(dockerCli *command.DockerCli) (uint64, string, error) {
-	return runPrune(dockerCli, pruneOptions{force: true})
+func RunPrune(dockerCli *command.DockerCli, filter opts.FilterOpt) (uint64, string, error) {
+	return runPrune(dockerCli, pruneOptions{force: true, filter: filter})
 }

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -39,6 +39,7 @@ type ConfigFile struct {
 	TasksFormat          string                      `json:"tasksFormat,omitempty"`
 	SecretFormat         string                      `json:"secretFormat,omitempty"`
 	NodesFormat          string                      `json:"nodesFormat,omitempty"`
+	PruneFilters         []string                    `json:"pruneFilters,omitempty"`
 }
 
 // LegacyLoadFromReader reads the non-nested configuration data given and sets up the

--- a/client/container_prune_test.go
+++ b/client/container_prune_test.go
@@ -40,6 +40,11 @@ func TestContainersPrune(t *testing.T) {
 	danglingUntilFilters.Add("dangling", "true")
 	danglingUntilFilters.Add("until", "2016-12-15T14:00")
 
+	labelFilters := filters.NewArgs()
+	labelFilters.Add("dangling", "true")
+	labelFilters.Add("label", "label1=foo")
+	labelFilters.Add("label", "label2!=bar")
+
 	listCases := []struct {
 		filters             filters.Args
 		expectedQueryParams map[string]string
@@ -74,6 +79,14 @@ func TestContainersPrune(t *testing.T) {
 				"until":   "",
 				"filter":  "",
 				"filters": `{"dangling":{"false":true}}`,
+			},
+		},
+		{
+			filters: labelFilters,
+			expectedQueryParams: map[string]string{
+				"until":   "",
+				"filter":  "",
+				"filters": `{"dangling":{"true":true},"label":{"label1=foo":true,"label2!=bar":true}}`,
 			},
 		},
 	}

--- a/client/image_prune_test.go
+++ b/client/image_prune_test.go
@@ -36,6 +36,11 @@ func TestImagesPrune(t *testing.T) {
 	noDanglingFilters := filters.NewArgs()
 	noDanglingFilters.Add("dangling", "false")
 
+	labelFilters := filters.NewArgs()
+	labelFilters.Add("dangling", "true")
+	labelFilters.Add("label", "label1=foo")
+	labelFilters.Add("label", "label2!=bar")
+
 	listCases := []struct {
 		filters             filters.Args
 		expectedQueryParams map[string]string
@@ -62,6 +67,14 @@ func TestImagesPrune(t *testing.T) {
 				"until":   "",
 				"filter":  "",
 				"filters": `{"dangling":{"false":true}}`,
+			},
+		},
+		{
+			filters: labelFilters,
+			expectedQueryParams: map[string]string{
+				"until":   "",
+				"filter":  "",
+				"filters": `{"dangling":{"true":true},"label":{"label1=foo":true,"label2!=bar":true}}`,
 			},
 		},
 	}

--- a/client/network_prune_test.go
+++ b/client/network_prune_test.go
@@ -38,6 +38,11 @@ func TestNetworksPrune(t *testing.T) {
 	noDanglingFilters := filters.NewArgs()
 	noDanglingFilters.Add("dangling", "false")
 
+	labelFilters := filters.NewArgs()
+	labelFilters.Add("dangling", "true")
+	labelFilters.Add("label", "label1=foo")
+	labelFilters.Add("label", "label2!=bar")
+
 	listCases := []struct {
 		filters             filters.Args
 		expectedQueryParams map[string]string
@@ -64,6 +69,14 @@ func TestNetworksPrune(t *testing.T) {
 				"until":   "",
 				"filter":  "",
 				"filters": `{"dangling":{"false":true}}`,
+			},
+		},
+		{
+			filters: labelFilters,
+			expectedQueryParams: map[string]string{
+				"until":   "",
+				"filter":  "",
+				"filters": `{"dangling":{"true":true},"label":{"label1=foo":true,"label2!=bar":true}}`,
 			},
 		},
 	}

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -295,9 +295,12 @@ func (daemon *Daemon) traverseLocalVolumes(fn func(volume.Volume) error) error {
 
 	for _, v := range vols {
 		name := v.Name()
-		_, err := daemon.volumes.Get(name)
+		vol, err := daemon.volumes.Get(name)
 		if err != nil {
 			logrus.Warnf("failed to retrieve volume %s from store: %v", name, err)
+		} else {
+			// daemon.volumes.Get will return DetailedVolume
+			v = vol
 		}
 
 		err = fn(v)


### PR DESCRIPTION
**- What I did**

This fix tries to address the issue raised in #29999 where it was not possible to mask these items (like important non-removable stuff) from `docker system prune`.

**- How I did it**


This fix adds `label` and `label!` field for `--filter` in `system prune`, so that it is possible to selectively prune items like:
```
$ docker container prune --filter label=foo

$ docker container prune --filter label!=bar
```

**- How to verify it**

Additional unit tests and integration tests have been added.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![kittens27](https://cloud.githubusercontent.com/assets/6932348/22620690/08cffffc-eac6-11e6-9c38-97fc9b0e8969.jpg)


~This fix fixes~
This fix is an improvement for #29999.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>