### PR TITLE
Aliased docker images with docker image ls in docker images

### DIFF
--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -38,6 +38,7 @@ func NewImagesCommand(dockerCli *command.DockerCli) *cobra.Command {
 		},
 	}
 
+	cmd.Aliases = []string{"docker image ls", "docker image list"}
 	flags := cmd.Flags()
 
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Only show numeric IDs")


### PR DESCRIPTION
When I use `docker images` it doesn't show the alias command `docker image ls` or `docker image list`. 

**- What I did**
I added the alias for the `docker image ls`  and `docker image list`command to `docker images` command
**- How I did it**
I add `cmd.Aliases` to the function that returns a new `docker images` command.

**- How to verify it**
I ran this command in a docker container per the contributing guidelines.

**- Description for the changelog**
Aliased `docker images` command to `docker image ls` and `docker image list`

**- A picture of a cute animal (not mandatory but encouraged)**
![cute-cat](https://cloud.githubusercontent.com/assets/5985850/22622186/e61639c2-eb01-11e6-8e94-845b6a199547.jpg)


