### PR TITLE
Validate insecure registry (`--insecure-registry`) values

### DIFF
--- a/registry/config_test.go
+++ b/registry/config_test.go
@@ -57,6 +57,22 @@ func TestLoadInsecureRegistries(t *testing.T) {
 		err        string
 	}{
 		{
+			registries: []string{"127.0.0.1"},
+			index:      "127.0.0.1",
+		},
+		{
+			registries: []string{"127.0.0.1:8080"},
+			index:      "127.0.0.1:8080",
+		},
+		{
+			registries: []string{"2001:db8::1"},
+			index:      "2001:db8::1",
+		},
+		{
+			registries: []string{"[2001:db8::1]:80"},
+			index:      "[2001:db8::1]:80",
+		},
+		{
 			registries: []string{"http://mytest.com"},
 			index:      "mytest.com",
 		},
@@ -75,6 +91,26 @@ func TestLoadInsecureRegistries(t *testing.T) {
 		{
 			registries: []string{"-invalid-registry"},
 			err:        "Cannot begin or end with a hyphen",
+		},
+		{
+			registries: []string{`mytest-.com`},
+			err:        `insecure registry mytest-.com is not valid: invalid host "mytest-.com"`,
+		},
+		{
+			registries: []string{`1200:0000:AB00:1234:0000:2552:7777:1313:8080`},
+			err:        `insecure registry 1200:0000:AB00:1234:0000:2552:7777:1313:8080 is not valid: invalid host "1200:0000:AB00:1234:0000:2552:7777:1313:8080"`,
+		},
+		{
+			registries: []string{`mytest.com:500000`},
+			err:        `insecure registry mytest.com:500000 is not valid: invalid port "500000"`,
+		},
+		{
+			registries: []string{`"mytest.com"`},
+			err:        `insecure registry "mytest.com" is not valid: invalid host "\"mytest.com\""`,
+		},
+		{
+			registries: []string{`"mytest.com:5000"`},
+			err:        `insecure registry "mytest.com:5000" is not valid: invalid host "\"mytest.com"`,
 		},
 	}
 	for _, testCase := range testCases {


### PR DESCRIPTION
**- What I did**
This fix is based on: https://github.com/docker/docker/issues/29936#issuecomment-277494885

Currently the insecure registry is only checked to see if it contains scheme (`http(s)://`) or not. No full validation is done and this caused many confusions like in #29936.

This fix tries to address the issue.

**- How I did it**

This fix adds additional validation so that an insecure registry is validated to make sure it is in `host:port` format where host could be IPv4/IPv6 or a host name, and port could be an integer between 0-65535.

**- How to verify it**

Additional unit tests have been added.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![american_shorthair_kitten-widescreen_wallpapers](https://cloud.githubusercontent.com/assets/6932348/22624646/d6fb4de4-eb36-11e6-8ed2-894ee26a7907.jpg)

This fix is related to #29936.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>