### PR TITLE
Security fix: Provide precise mount-sharing status to stateless API

### DIFF
--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -23,7 +23,7 @@ const extName = "VolumeDriver"
 
 // NewVolumeDriver returns a driver has the given name mapped on the given client.
 func NewVolumeDriver(name string, baseHostPath string, c client) volume.Driver {
-	proxy := &volumeDriverProxy{c}
+	proxy := &volumeDriverProxy{c, make(map[string]int), sync.Mutex{}}
 	return &volumeDriverAdapter{name: name, baseHostPath: baseHostPath, proxy: proxy}
 }
 

--- a/volume/drivers/proxy_test.go
+++ b/volume/drivers/proxy_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/docker/docker/pkg/plugins"
@@ -63,7 +64,7 @@ func TestVolumeRequestError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	driver := volumeDriverProxy{client}
+	driver := volumeDriverProxy{client, make(map[string]int), sync.Mutex{}}
 
 	if err = driver.Create("volume", nil); err == nil {
 		t.Fatal("Expected error, was nil")


### PR DESCRIPTION
Most docker plugin drivers contain `mount counter` bug, which will brings
about disk security leak, such as umount filesystem before all containers
finish accessing same volume. Once it occurs, all new data are written into
a wrong place, which could be further used to intentionally do harmful
operations to the new place that doesn't belong to him/her, such as
running out of disk usage, occupying heavy I/O, etc.

This fix adds a precise mount-sharing status to API including Plugin.Mount &
Plugin.Unmount in order to guide plugin drivers correctly handling FS mount
& umount.

This fix is compatible with old API, so all old volume drivers still work
well (though they are still potential to contain security leak).

[CHANGES]
/Plugin.Mount -> request-json: {"Name": .., "ID": .., "FirstMount": true|false}
/Plugin.Unmount -> request-json: {"Name": .., "ID": .., "LastMount": true|false}