### PR TITLE
Add `--stop-signal` for `service create` and `service update`

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1900,6 +1900,9 @@ definitions:
             type: "array"
             items:
               $ref: "#/definitions/Mount"
+          StopSignal:
+            description: "Signal to stop the container."
+            type: "string"
           StopGracePeriod:
             description: "Amount of time to wait for the container to terminate before forcefully killing it."
             type: "integer"

--- a/api/types/swarm/container.go
+++ b/api/types/swarm/container.go
@@ -32,6 +32,7 @@ type ContainerSpec struct {
 	Dir             string                  `json:",omitempty"`
 	User            string                  `json:",omitempty"`
 	Groups          []string                `json:",omitempty"`
+	StopSignal      string                  `json:",omitempty"`
 	TTY             bool                    `json:",omitempty"`
 	OpenStdin       bool                    `json:",omitempty"`
 	ReadOnly        bool                    `json:",omitempty"`

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -269,6 +269,7 @@ type serviceOptions struct {
 	workdir         string
 	user            string
 	groups          opts.ListOpts
+	stopSignal      string
 	tty             bool
 	readOnly        bool
 	mounts          opts.MountOpt
@@ -372,17 +373,18 @@ func (opts *serviceOptions) ToService() (swarm.ServiceSpec, error) {
 		},
 		TaskTemplate: swarm.TaskSpec{
 			ContainerSpec: swarm.ContainerSpec{
-				Image:    opts.image,
-				Args:     opts.args,
-				Env:      currentEnv,
-				Hostname: opts.hostname,
-				Labels:   runconfigopts.ConvertKVStringsToMap(opts.containerLabels.GetAll()),
-				Dir:      opts.workdir,
-				User:     opts.user,
-				Groups:   opts.groups.GetAll(),
-				TTY:      opts.tty,
-				ReadOnly: opts.readOnly,
-				Mounts:   opts.mounts.Value(),
+				Image:      opts.image,
+				Args:       opts.args,
+				Env:        currentEnv,
+				Hostname:   opts.hostname,
+				Labels:     runconfigopts.ConvertKVStringsToMap(opts.containerLabels.GetAll()),
+				Dir:        opts.workdir,
+				User:       opts.user,
+				Groups:     opts.groups.GetAll(),
+				StopSignal: opts.stopSignal,
+				TTY:        opts.tty,
+				ReadOnly:   opts.readOnly,
+				Mounts:     opts.mounts.Value(),
 				DNSConfig: &swarm.DNSConfig{
 					Nameservers: opts.dns.GetAll(),
 					Search:      opts.dnsSearch.GetAll(),
@@ -470,6 +472,9 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 
 	flags.BoolVar(&opts.readOnly, flagReadOnly, false, "Mount the container's root filesystem as read only")
 	flags.SetAnnotation(flagReadOnly, "version", []string{"1.27"})
+
+	flags.StringVar(&opts.stopSignal, flagStopSignal, "", "Signal to stop the container")
+	flags.SetAnnotation(flagStopSignal, "version", []string{"1.27"})
 }
 
 const (
@@ -523,6 +528,7 @@ const (
 	flagRestartMaxAttempts    = "restart-max-attempts"
 	flagRestartWindow         = "restart-window"
 	flagStopGracePeriod       = "stop-grace-period"
+	flagStopSignal            = "stop-signal"
 	flagTTY                   = "tty"
 	flagUpdateDelay           = "update-delay"
 	flagUpdateFailureAction   = "update-failure-action"

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -349,6 +349,8 @@ func updateService(flags *pflag.FlagSet, spec *swarm.ServiceSpec) error {
 		cspec.ReadOnly = readOnly
 	}
 
+	updateString(flagStopSignal, &cspec.StopSignal)
+
 	return nil
 }
 

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -441,3 +441,25 @@ func TestUpdateReadOnly(t *testing.T) {
 	updateService(flags, spec)
 	assert.Equal(t, cspec.ReadOnly, false)
 }
+
+func TestUpdateStopSignal(t *testing.T) {
+	spec := &swarm.ServiceSpec{}
+	cspec := &spec.TaskTemplate.ContainerSpec
+
+	// Update with --stop-signal=SIGUSR1
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("stop-signal", "SIGUSR1")
+	updateService(flags, spec)
+	assert.Equal(t, cspec.StopSignal, "SIGUSR1")
+
+	// Update without --stop-signal, no change
+	flags = newUpdateCommand(nil).Flags()
+	updateService(flags, spec)
+	assert.Equal(t, cspec.StopSignal, "SIGUSR1")
+
+	// Update with --stop-signal=SIGWINCH
+	flags = newUpdateCommand(nil).Flags()
+	flags.Set("stop-signal", "SIGWINCH")
+	updateService(flags, spec)
+	assert.Equal(t, cspec.StopSignal, "SIGWINCH")
+}

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -14,20 +14,21 @@ import (
 
 func containerSpecFromGRPC(c *swarmapi.ContainerSpec) types.ContainerSpec {
 	containerSpec := types.ContainerSpec{
-		Image:     c.Image,
-		Labels:    c.Labels,
-		Command:   c.Command,
-		Args:      c.Args,
-		Hostname:  c.Hostname,
-		Env:       c.Env,
-		Dir:       c.Dir,
-		User:      c.User,
-		Groups:    c.Groups,
-		TTY:       c.TTY,
-		OpenStdin: c.OpenStdin,
-		ReadOnly:  c.ReadOnly,
-		Hosts:     c.Hosts,
-		Secrets:   secretReferencesFromGRPC(c.Secrets),
+		Image:      c.Image,
+		Labels:     c.Labels,
+		Command:    c.Command,
+		Args:       c.Args,
+		Hostname:   c.Hostname,
+		Env:        c.Env,
+		Dir:        c.Dir,
+		User:       c.User,
+		Groups:     c.Groups,
+		StopSignal: c.StopSignal,
+		TTY:        c.TTY,
+		OpenStdin:  c.OpenStdin,
+		ReadOnly:   c.ReadOnly,
+		Hosts:      c.Hosts,
+		Secrets:    secretReferencesFromGRPC(c.Secrets),
 	}
 
 	if c.DNSConfig != nil {
@@ -136,20 +137,21 @@ func secretReferencesFromGRPC(sr []*swarmapi.SecretReference) []*types.SecretRef
 
 func containerToGRPC(c types.ContainerSpec) (*swarmapi.ContainerSpec, error) {
 	containerSpec := &swarmapi.ContainerSpec{
-		Image:     c.Image,
-		Labels:    c.Labels,
-		Command:   c.Command,
-		Args:      c.Args,
-		Hostname:  c.Hostname,
-		Env:       c.Env,
-		Dir:       c.Dir,
-		User:      c.User,
-		Groups:    c.Groups,
-		TTY:       c.TTY,
-		OpenStdin: c.OpenStdin,
-		ReadOnly:  c.ReadOnly,
-		Hosts:     c.Hosts,
-		Secrets:   secretReferencesToGRPC(c.Secrets),
+		Image:      c.Image,
+		Labels:     c.Labels,
+		Command:    c.Command,
+		Args:       c.Args,
+		Hostname:   c.Hostname,
+		Env:        c.Env,
+		Dir:        c.Dir,
+		User:       c.User,
+		Groups:     c.Groups,
+		StopSignal: c.StopSignal,
+		TTY:        c.TTY,
+		OpenStdin:  c.OpenStdin,
+		ReadOnly:   c.ReadOnly,
+		Hosts:      c.Hosts,
+		Secrets:    secretReferencesToGRPC(c.Secrets),
 	}
 
 	if c.DNSConfig != nil {

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -185,6 +185,7 @@ func (c *containerConfig) exposedPorts() map[nat.Port]struct{} {
 func (c *containerConfig) config() *enginecontainer.Config {
 	config := &enginecontainer.Config{
 		Labels:       c.labels(),
+		StopSignal:   c.spec().StopSignal,
 		Tty:          c.spec().TTY,
 		OpenStdin:    c.spec().OpenStdin,
 		User:         c.spec().User,

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -58,6 +58,7 @@ Options:
       --restart-window duration          Window used to evaluate the restart policy (ns|us|ms|s|m|h)
       --secret secret                    Specify secrets to expose to the service
       --stop-grace-period duration       Time to wait before force killing a container (ns|us|ms|s|m|h)
+      --stop-signal string               Signal to stop the container
   -t, --tty                              Allocate a pseudo-TTY
       --update-delay duration            Delay between updates (ns|us|ms|s|m|h) (default 0s)
       --update-failure-action string     Action on update failure ("pause"|"continue") (default "pause")

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -70,6 +70,7 @@ Options:
       --secret-add secret                Add or update a secret on a service
       --secret-rm list                   Remove a secret (default [])
       --stop-grace-period duration       Time to wait before force killing a container (ns|us|ms|s|m|h)
+      --stop-signal string               Signal to stop the container
   -t, --tty                              Allocate a pseudo-TTY
       --update-delay duration            Delay between updates (ns|us|ms|s|m|h) (default 0s)
       --update-failure-action string     Action on update failure ("pause"|"continue") (default "pause")


### PR DESCRIPTION
**- What I did**

This fix tries to address the issue raised in #25696 where it was not possible to specify `--stop-signal` for `docker service create` and `docker service update`, in order to use special signal to stop the container.

**- How I did it**

This fix adds `--stop-signal` and update the `StopSignal` in `Config` through `service create` and `service update`.

A SwarmKit PR https://github.com/docker/swarmkit/pull/1924 has been opened separately.

Related docs has been updated.

**- How to verify it**

Additional unit test and Integration tests have been added.

**- Description for the changelog**

Add `--stop-signal` for `service create` and `service update`

**- A picture of a cute animal (not mandatory but encouraged)**

![0ceca72e14a484c5e428f151e2aa9484](https://cloud.githubusercontent.com/assets/6932348/22635851/9c58501e-ebeb-11e6-8d93-704ea324bc8a.jpg)


This fix fixes #25696.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>