### PR TITLE
use golang 1.7.5 for building man pages

### DIFF
--- a/man/Dockerfile
+++ b/man/Dockerfile
@@ -1,9 +1,8 @@
-FROM    alpine:3.4
+FROM    golang:1.7.5-alpine
 
-RUN     apk add -U git go bash curl gcc musl-dev make
+RUN     apk add -U git bash curl gcc musl-dev make
 
 RUN     mkdir -p /go/src /go/bin /go/pkg
-ENV     GOPATH=/go
 RUN     export GLIDE=v0.11.1; \
         export TARGET=/go/src/github.com/Masterminds; \
         mkdir -p ${TARGET} && \

--- a/man/Dockerfile.armhf
+++ b/man/Dockerfile.armhf
@@ -9,7 +9,6 @@ RUN apt-get update && apt-get install -y \
   bash \
   curl \
   gcc \
-  musl-dev \
   make
 
 ENV GO_VERSION 1.7.5

--- a/man/Dockerfile.armhf
+++ b/man/Dockerfile.armhf
@@ -1,9 +1,28 @@
-FROM    armhf/alpine:3.4
+FROM armhf/debian:jessie
 
-RUN     apk add -U git go bash curl gcc musl-dev make
+# allow replacing httpredir or deb mirror
+ARG APT_MIRROR=deb.debian.org
+RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
+
+RUN apt-get update && apt-get install -y \
+  git \
+  bash \
+  curl \
+  gcc \
+  musl-dev \
+  make
+
+ENV GO_VERSION 1.7.5
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" \
+  | tar -xzC /usr/local
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV GOPATH /go
+
+# We're building for armhf, which is ARMv7, so let's be explicit about that
+ENV GOARCH arm
+ENV GOARM 7
 
 RUN     mkdir -p /go/src /go/bin /go/pkg
-ENV     GOPATH=/go
 RUN     export GLIDE=v0.11.1; \
         export TARGET=/go/src/github.com/Masterminds; \
         mkdir -p ${TARGET} && \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Updated `man/Dockerfile` to use golang 1.7.5 when building man pages. This is needed because builds of debian packages are failing during man page generation because the golang installed is version 1.6 which does not have `context` package:
```
docker run --rm \
-v /go/src/github.com/docker/docker:/go/src/github.com/docker/docker/ \
docker-manpage-dev
cli/command/plugin/upgrade.go:5:2: cannot find package "context" in any of:
	/go/src/github.com/docker/docker/vendor/context (vendor tree)
 	/usr/lib/go/src/context (from $GOROOT)
 	/go/src/context (from $GOPATH)
 	/manvendor/src/context
```

**- How I did it**

Using the official docker image of golang https://hub.docker.com/_/golang/

**- How to verify it**

```
$ make manpages
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

🐗 
