### PR TITLE
[WIP] [test-integration] Move TearDownTest cleaning to environment package

### DIFF
--- a/integration-cli/environment/clean.go
+++ b/integration-cli/environment/clean.go
@@ -1,0 +1,142 @@
+package environment
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
+	"golang.org/x/net/context"
+)
+
+type testingT interface {
+	logT
+	Fatalf(string, ...interface{})
+}
+
+type logT interface {
+	Logf(string, ...interface{})
+}
+
+// Clean the environment, preserving protected objects (images, containers, ...)
+// and removing everything else. It's meant to run after any tests so that they don't
+// depend on each others.
+func (e *Execution) Clean(t testingT, dockerBinary string) {
+	cleans := []struct {
+		name      string
+		protected map[string]struct{}
+		listFn    func(ctx context.Context, apiClient client.APIClient) ([]string, error)
+		removeFn  func(ctx context.Context, ID string) error
+	}{
+		{
+			name:      "unpause-containers",
+			protected: e.protectedElements.containers,
+			listFn:    listPausedContainers,
+			removeFn:  e.client.ContainerUnpause,
+		},
+		{
+			name:      "containers",
+			protected: e.protectedElements.containers,
+			listFn:    listContainers,
+			removeFn: func(ctx context.Context, ID string) error {
+				err := e.client.ContainerRemove(ctx, ID, types.ContainerRemoveOptions{
+					Force:         true,
+					RemoveVolumes: true,
+				})
+				if err != nil {
+					// FIXME(vdemeester) shouldn't be there...
+					if strings.Contains(err.Error(), fmt.Sprintf("removal of container %s is already in progress", ID)) {
+						t.Logf("Skipping removing container %s, already in progress", ID)
+						return nil
+					}
+					return err
+				}
+				return nil
+			},
+		},
+		{
+			// FIXME(vdemeester) use the API instead.
+			name:      "images",
+			protected: e.protectedElements.images,
+			listFn: func(ctx context.Context, apiClient client.APIClient) ([]string, error) {
+				result := icmd.RunCommand(dockerBinary, "images", "--digests")
+				result.Assert(t, icmd.Success)
+				lines := strings.Split(string(result.Combined()), "\n")[1:]
+				imgMap := map[string]struct{}{}
+				for _, l := range lines {
+					if l == "" {
+						continue
+					}
+					fields := strings.Fields(l)
+					imgTag := fields[0] + ":" + fields[1]
+					//if _, ok := protectedImages[imgTag]; !ok {
+					if fields[0] == "<none>" || fields[1] == "<none>" {
+						if fields[2] != "<none>" {
+							imgMap[fields[0]+"@"+fields[2]] = struct{}{}
+						} else {
+							imgMap[fields[3]] = struct{}{}
+						}
+						// continue
+					} else {
+						imgMap[imgTag] = struct{}{}
+					}
+					//}
+				}
+				images := []string{}
+				for key, _ := range imgMap {
+					images = append(images, key)
+				}
+				return images, nil
+			},
+			removeFn: func(ctx context.Context, ID string) error {
+				return icmd.RunCommand(dockerBinary, "rmi", "-fv", ID).Error
+				//_, err := e.client.ImageRemove(ctx, ID, types.ImageRemoveOptions{
+				//	Force:         true,
+				//	PruneChildren: true,
+				//})
+				//return err
+			},
+		},
+		{
+			name:      "volumes",
+			protected: e.protectedElements.volumes,
+			listFn:    listVolumes,
+			removeFn: func(ctx context.Context, ID string) error {
+				return e.client.VolumeRemove(ctx, ID, true)
+			},
+		},
+		{
+			name:      "networks",
+			protected: e.protectedElements.networks,
+			listFn:    listNetworks,
+			removeFn:  e.client.NetworkRemove,
+		},
+		{
+			name:      "plugins",
+			protected: e.protectedElements.plugins,
+			listFn:    listPlugins,
+			removeFn: func(ctx context.Context, ID string) error {
+				return e.client.PluginRemove(ctx, ID, types.PluginRemoveOptions{
+					Force: true,
+				})
+			},
+		},
+	}
+
+	ctx := context.Background()
+	for _, clean := range cleans {
+		items, err := clean.listFn(ctx, e.client)
+		if err != nil {
+			t.Fatalf("error cleaning %s: %v", clean.name, err)
+		}
+		for _, item := range items {
+			if _, isProtected := clean.protected[item]; isProtected {
+				continue
+			}
+			if err := clean.removeFn(ctx, item); err != nil {
+				t.Fatalf("error removing %s element %s : %v", clean.name, item, err)
+			}
+		}
+	}
+}

--- a/integration-cli/environment/protect.go
+++ b/integration-cli/environment/protect.go
@@ -1,0 +1,139 @@
+package environment
+
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"golang.org/x/net/context"
+)
+
+// ProtectImage adds the specified image(s) to be protected in case of clean
+func (e *Execution) ProtectImage(t testingT, images ...string) {
+	for _, image := range images {
+		imageInspect, _, err := e.client.ImageInspectWithRaw(context.Background(), image)
+		if err != nil {
+			t.Fatalf("error inspecting image %s: %v", image, err)
+		}
+		e.protectedElements.images[imageInspect.ID] = struct{}{}
+	}
+}
+
+// ProtectedElements holds images, containers, volumes, networks and plugins to protect when cleaning the environment
+type ProtectedElements struct {
+	containers map[string]struct{}
+	images     map[string]struct{}
+	volumes    map[string]struct{}
+	networks   map[string]struct{}
+	plugins    map[string]struct{}
+}
+
+func listExistingElement(cli client.APIClient) (*ProtectedElements, error) {
+	protectedElts := &ProtectedElements{
+		containers: map[string]struct{}{},
+		images:     map[string]struct{}{},
+		volumes:    map[string]struct{}{},
+		networks:   map[string]struct{}{},
+		plugins:    map[string]struct{}{},
+	}
+
+	protects := []struct {
+		fn    func(ctx context.Context, apiClient client.APIClient) ([]string, error)
+		field map[string]struct{}
+	}{
+		{listImages, protectedElts.images},
+		{listContainers, protectedElts.containers},
+		{listVolumes, protectedElts.volumes},
+		{listNetworks, protectedElts.networks},
+		{listPlugins, protectedElts.plugins},
+	}
+
+	ctx := context.Background()
+
+	for _, protect := range protects {
+		m, err := protect.fn(ctx, cli)
+		if err != nil {
+			return nil, err
+		}
+		for _, value := range m {
+			protect.field[value] = struct{}{}
+		}
+	}
+	return protectedElts, nil
+}
+
+func listImages(ctx context.Context, cli client.APIClient) ([]string, error) {
+	images := []string{}
+	imageList, err := cli.ImageList(ctx, types.ImageListOptions{})
+	if err != nil {
+		return images, err
+	}
+	for _, image := range imageList {
+		images = append(images, image.ID)
+	}
+	return images, nil
+}
+
+func listContainers(ctx context.Context, cli client.APIClient) ([]string, error) {
+	containers := []string{}
+	containerList, err := cli.ContainerList(ctx, types.ContainerListOptions{All: true})
+	if err != nil {
+		return containers, err
+	}
+	for _, container := range containerList {
+		containers = append(containers, container.ID)
+	}
+	return containers, nil
+}
+
+func listPausedContainers(ctx context.Context, cli client.APIClient) ([]string, error) {
+	containers := []string{}
+	filter := filters.NewArgs()
+	filter.Add("status", "paused")
+	containerList, err := cli.ContainerList(ctx, types.ContainerListOptions{
+		All:     true,
+		Filters: filter,
+	})
+	if err != nil {
+		return containers, err
+	}
+	for _, container := range containerList {
+		containers = append(containers, container.ID)
+	}
+	return containers, nil
+}
+
+func listVolumes(ctx context.Context, cli client.APIClient) ([]string, error) {
+	volumes := []string{}
+	volumeList, err := cli.VolumeList(ctx, filters.NewArgs())
+	if err != nil {
+		return volumes, err
+	}
+	for _, volume := range volumeList.Volumes {
+		volumes = append(volumes, volume.Name)
+	}
+	return volumes, nil
+}
+
+func listNetworks(ctx context.Context, cli client.APIClient) ([]string, error) {
+	networks := []string{}
+	networkList, err := cli.NetworkList(ctx, types.NetworkListOptions{})
+	if err != nil {
+		return networks, err
+	}
+	for _, network := range networkList {
+		networks = append(networks, network.ID)
+	}
+	return networks, nil
+}
+
+func listPlugins(ctx context.Context, cli client.APIClient) ([]string, error) {
+	plugins := []string{}
+	pluginList, err := cli.PluginList(ctx, filters.NewArgs())
+	if err != nil {
+		return plugins, err
+	}
+	for _, plugin := range pluginList {
+		plugins = append(plugins, plugin.ID)
+	}
+	return plugins, nil
+}

--- a/integration-cli/fixtures_linux_daemon_test.go
+++ b/integration-cli/fixtures_linux_daemon_test.go
@@ -31,9 +31,7 @@ func ensureFrozenImagesLinux(t testingT) {
 		t.Logf(dockerCmdWithError("images"))
 		t.Fatalf("%+v", err)
 	}
-	for _, img := range images {
-		protectedImages[img] = struct{}{}
-	}
+	defer testEnv.ProtectImage(t, images...)
 }
 
 var ensureSyscallTestOnce sync.Once
@@ -46,7 +44,7 @@ func ensureSyscallTest(c *check.C) {
 	if !doIt {
 		return
 	}
-	protectedImages["syscall-test:latest"] = struct{}{}
+	defer testEnv.ProtectImage(c, "syscall-test:latest")
 
 	// if no match, must build in docker, which is significantly slower
 	// (slower mostly because of the vfs graphdriver)
@@ -104,7 +102,7 @@ func ensureSyscallTestBuild(c *check.C) {
 }
 
 func ensureNNPTest(c *check.C) {
-	protectedImages["nnp-test:latest"] = struct{}{}
+	defer testEnv.ProtectImage(c, "nnp-test:latest")
 	if testEnv.DaemonPlatform() != runtime.GOOS {
 		ensureNNPTestBuild(c)
 		return


### PR DESCRIPTION
Move the clean functions of integration-cli in the `environment` package (and mainly in `testEnv.Clean(…)` function).

This does several things though:

- Use the API instead of `cli`. This, strangely, make it fail related to https://github.com/docker/docker/issues/30722 (cc @tonistiigi)
- It protects more stuff : any container, image, volume, plugin or network present in the daemon before running the integration-test would be preserved (it's not perfect but…). This mean it's a little bit safer to run in on an external daemon (or on your local daemon on your laptop 👼 ).

It currently fails (see above). I'm trying to see how to fix that (worst case scenario, I'll use the `cli` for images cleaning temporarly).

/cc @thaJeztah @tonistiigi @tiborvass @dnephin @icecrime @cpuguy83 @LK4D4 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>