### PR TITLE
Fix the create API when fromSrc has a bad URL

### DIFF
--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -115,6 +115,29 @@ func (s *DockerSuite) TestAPIImagesHistory(c *check.C) {
 	c.Assert(historydata[0].Tags[0], checker.Equals, "test-api-images-history:latest")
 }
 
+func (s *DockerSuite) TestAPIImagesImportBadSrc(c *check.C) {
+	testRequires(c, Network)
+
+	tt := []struct {
+		statusExp int
+		fromSrc   string
+	}{
+		{http.StatusNotFound, "http://example.com/nofile.tar"},
+		{http.StatusNotFound, "example.com/nofile.tar"},
+		{http.StatusNotFound, "example.com%2Fdata%2Ffile.tar"},
+		{http.StatusInternalServerError, "%2Fdata%2Ffile.tar"},
+	}
+
+	for _, te := range tt {
+		res, b, err := request.SockRequestRaw("POST", strings.Join([]string{"/images/create?fromSrc=", te.fromSrc}, ""), nil, "application/json", daemonHost())
+		c.Assert(err, check.IsNil)
+		b.Close()
+		c.Assert(res.StatusCode, checker.Equals, te.statusExp)
+		c.Assert(res.Header.Get("Content-Type"), checker.Equals, "application/json")
+	}
+
+}
+
 // #14846
 func (s *DockerSuite) TestAPIImagesSearchJSONContentType(c *check.C) {
 	testRequires(c, Network)


### PR DESCRIPTION
**- What I did**

When a bad URL is provided in the fromSrc parameter the response status code is set to 200 although the download fails.
This commit fixes this by making sure the resource is available.

Another problem this commit fixes is when sending a URL without specifying the protocol (f.e. google.com/file.tar) the parsed raw URL is encoded and causes the download to fail. 

should close #30714

**- How I did it**

Instead of setting `u.Host` after parsing the raw URL and checking that `u.Scheme` is empty, verify that `src` has a protocol using `strings.Split` and `len` and then `url.Parse` it.
In addition, switched between the "Downloading" message writing and the actual image downloading code lines.

**- How to verify it**

Run the following tests:
`TESTFLAGS='-check.f DockerSuite.TestAPIImagesImport*' make test-integration-cli`
