### PR TITLE
Fix "command.PromptForConfirmation" to accept "enter" for the "N" default

### DIFF
--- a/cli/command/plugin/install.go
+++ b/cli/command/plugin/install.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"strings"
@@ -178,13 +177,6 @@ func acceptPrivileges(dockerCli *command.DockerCli, name string) func(privileges
 		for _, privilege := range privileges {
 			fmt.Fprintf(dockerCli.Out(), " - %s: %v\n", privilege.Name, privilege.Value)
 		}
-
-		fmt.Fprint(dockerCli.Out(), "Do you grant the above permissions? [y/N] ")
-		reader := bufio.NewReader(dockerCli.In())
-		line, _, err := reader.ReadLine()
-		if err != nil {
-			return false, err
-		}
-		return strings.ToLower(string(line)) == "y", nil
+		return command.PromptForConfirmation(dockerCli.In(), dockerCli.Out(), "Do you grant the above permissions?"), nil
 	}
 }

--- a/cli/command/plugin/upgrade.go
+++ b/cli/command/plugin/upgrade.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"strings"
@@ -64,17 +63,7 @@ func runUpgrade(dockerCli *command.DockerCli, opts pluginOptions) error {
 
 	fmt.Fprintf(dockerCli.Out(), "Upgrading plugin %s from %s to %s\n", p.Name, old, remote)
 	if !opts.skipRemoteCheck && remote.String() != old.String() {
-		_, err := fmt.Fprint(dockerCli.Out(), "Plugin images do not match, are you sure? ")
-		if err != nil {
-			return errors.Wrap(err, "error writing to stdout")
-		}
-
-		rdr := bufio.NewReader(dockerCli.In())
-		line, _, err := rdr.ReadLine()
-		if err != nil {
-			return errors.Wrap(err, "error reading from stdin")
-		}
-		if strings.ToLower(string(line)) != "y" {
+		if !command.PromptForConfirmation(dockerCli.In(), dockerCli.Out(), "Plugin images do not match, are you sure?") {
 			return errors.New("canceling upgrade request")
 		}
 	}

--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -80,11 +81,7 @@ func PromptForConfirmation(ins *InStream, outs *OutStream, message string) bool 
 		ins = NewInStream(os.Stdin)
 	}
 
-	answer := ""
-	n, _ := fmt.Fscan(ins, &answer)
-	if n != 1 || (answer != "y" && answer != "Y") {
-		return false
-	}
-
-	return true
+	reader := bufio.NewReader(ins)
+	answer, _, _ := reader.ReadLine()
+	return strings.ToLower(string(answer)) == "y"
 }


### PR DESCRIPTION
**- What I did**

This adjusts `command.PromptForConfirmation` in `cli/command/utils.go` to use `bufio`'s `ReadLine` rather than using `fmt.Fscan` for reading input, which makes `<Enter>` properly accept the default value of "No" as one would expect.

**- How I did it**

This new code actually came from `cli/command/plugin/install.go`'s `acceptPrivileges` function, which I've also refactored here to use `command.PromptForConfirmation` as it should.

**- How to verify it**

I verified it by running `./bundles/latest/dynbinary-client/docker system prune` and testing different combinations of responses (just `<Enter>`, `y`, `Y`, `n`, `N`, `bogus`), and verifying that only `y` and `Y` try to reclaim space.

**- Description for the changelog**

- Fixed "default answer" handling in `y/N` prompts

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://cloud.githubusercontent.com/assets/161631/22657291/d432a552-ec4a-11e6-90c8-567c8351f019.png)