### PR TITLE
ppc64le and s390x fixes for manpages

### DIFF
--- a/man/Dockerfile.ppc64le
+++ b/man/Dockerfile.ppc64le
@@ -1,9 +1,19 @@
 FROM    ppc64le/ubuntu:xenial
 
-RUN     apt-get update && apt-get install -y git golang-go
+RUN     apt-get update && apt-get install -y \
+        curl \
+        gcc \
+        git \
+        make \
+        tar
+
+ENV     GO_VERSION 1.7.5
+RUN     curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" \
+        | tar -xzC /usr/local
+ENV     PATH /usr/local/go/bin:$PATH
+ENV     GOPATH=/go
 
 RUN     mkdir -p /go/src /go/bin /go/pkg
-ENV     GOPATH=/go:/usr/lib/go-1.6
 RUN     export GLIDE=v0.11.1; \
         export TARGET=/go/src/github.com/Masterminds; \
         mkdir -p ${TARGET} && \

--- a/man/Dockerfile.s390x
+++ b/man/Dockerfile.s390x
@@ -1,9 +1,19 @@
 FROM    s390x/ubuntu:xenial
 
-RUN     apt-get update && apt-get install -y git golang-go
+RUN     apt-get update && apt-get install -y \
+        curl \
+        gcc \
+        git \
+        make \
+        tar
+
+ENV     GO_VERSION 1.7.5
+RUN     curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" \
+        | tar -xzC /usr/local
+ENV     PATH /usr/local/go/bin:$PATH
+ENV     GOPATH=/go
 
 RUN     mkdir -p /go/src /go/bin /go/pkg
-ENV     GOPATH=/go:/usr/lib/go-1.6
 RUN     export GLIDE=v0.11.1; \
         export TARGET=/go/src/github.com/Masterminds; \
         mkdir -p ${TARGET} && \


### PR DESCRIPTION
Extension of #30755

Fixes manpages for p and z by downloading a specific version
of go instead of relying on the distro version.

Note: something may need to be done for aarch64 too, but I don't have a machine that I can test that on.

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>

cc/ @vieux @justincormack @andrewhsu 