### PR TITLE
getAllNetworks unnecessary walks all the networks

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -96,15 +96,7 @@ func (daemon *Daemon) GetNetworksByID(partialID string) []libnetwork.Network {
 
 // getAllNetworks returns a list containing all networks
 func (daemon *Daemon) getAllNetworks() []libnetwork.Network {
-	c := daemon.netController
-	list := []libnetwork.Network{}
-	l := func(nw libnetwork.Network) bool {
-		list = append(list, nw)
-		return false
-	}
-	c.WalkNetworks(l)
-
-	return list
+	return daemon.netController.Networks()
 }
 
 func isIngressNetwork(name string) bool {


### PR DESCRIPTION
- libnetwork controller `Networks()` already returns
  a copy list. Also `Networks()` correctly skips any
  network which ahs already been marked for deletion
  while `getAllNetworks` implementation bypasses this.

**- A picture of a cute animal (not mandatory but encouraged)**
![boh](https://cloud.githubusercontent.com/assets/10080882/22672881/81e8e1f8-ec8b-11e6-81da-b1bce7b03514.jpg)

