### PR TITLE
Fix grammatical error in swarm_leave.md

### DIFF
--- a/docs/reference/commandline/swarm_leave.md
+++ b/docs/reference/commandline/swarm_leave.md
@@ -27,7 +27,7 @@ Options:
 
 When you run this command on a worker, that worker leaves the swarm.
 
-You can use the `--force` option to on a manager to remove it from the swarm.
+You can use the `--force` option on a manager to remove it from the swarm.
 However, this does not reconfigure the swarm to ensure that there are enough
 managers to maintain a quorum in the swarm. The safe way to remove a manager
 from a swarm is to demote it to a worker and then direct it to leave the quorum


### PR DESCRIPTION
Correct this sentence so it reads correctly. "to on a manager" should be
"on a manager".