### PR TITLE
compose: fix environment interpolation from the client

### DIFF
--- a/cli/command/stack/deploy_composefile.go
+++ b/cli/command/stack/deploy_composefile.go
@@ -115,6 +115,16 @@ func getConfigDetails(opts deployOptions) (composetypes.ConfigDetails, error) {
 	}
 	// TODO: support multiple files
 	details.ConfigFiles = []composetypes.ConfigFile{*configFile}
+	env := os.Environ()
+	details.Environment = make(map[string]string, len(env))
+	for _, s := range env {
+		// if value is empty, s is like "K=", not "K".
+		if !strings.Contains(s, "=") {
+			return details, fmt.Errorf("unexpected environment %q", s)
+		}
+		kv := strings.SplitN(s, "=", 2)
+		details.Environment[kv[0]] = kv[1]
+	}
 	return details, nil
 }
 

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -393,11 +393,16 @@ func convertEndpointSpec(endpointMode string, source []composetypes.ServicePortC
 	}, nil
 }
 
-func convertEnvironment(source map[string]string) []string {
+func convertEnvironment(source map[string]*string) []string {
 	var output []string
 
 	for name, value := range source {
-		output = append(output, fmt.Sprintf("%s=%s", name, value))
+		switch value {
+		case nil:
+			output = append(output, name)
+		default:
+			output = append(output, fmt.Sprintf("%s=%s", name, *value))
+		}
 	}
 
 	return output

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -43,10 +43,14 @@ func TestConvertRestartPolicyFromFailure(t *testing.T) {
 	assert.DeepEqual(t, policy, expected)
 }
 
+func strPtr(val string) *string {
+	return &val
+}
+
 func TestConvertEnvironment(t *testing.T) {
-	source := map[string]string{
-		"foo": "bar",
-		"key": "value",
+	source := map[string]*string{
+		"foo": strPtr("bar"),
+		"key": strPtr("value"),
 	}
 	env := convertEnvironment(source)
 	sort.Strings(env)

--- a/cli/compose/loader/example1.env
+++ b/cli/compose/loader/example1.env
@@ -1,8 +1,8 @@
 # passed through
-FOO=1
+FOO=foo_from_env_file
 
 # overridden in example2.env
-BAR=1
+BAR=bar_from_env_file
 
 # overridden in full-example.yml
-BAZ=1
+BAZ=baz_from_env_file

--- a/cli/compose/loader/example2.env
+++ b/cli/compose/loader/example2.env
@@ -1,1 +1,4 @@
 BAR=2
+
+# overridden in configDetails.Environment
+QUX=1

--- a/cli/compose/loader/example2.env
+++ b/cli/compose/loader/example2.env
@@ -1,4 +1,4 @@
-BAR=2
+BAR=bar_from_env_file_2
 
 # overridden in configDetails.Environment
-QUX=1
+QUX=quz_from_env_file_2

--- a/cli/compose/loader/full-example.yml
+++ b/cli/compose/loader/full-example.yml
@@ -77,10 +77,8 @@ services:
     # Mapping values can be strings, numbers or null
     # Booleans are not allowed - must be quoted
     environment:
-      RACK_ENV: development
-      SHOW: 'true'
-      SESSION_SECRET:
-      BAZ: 3
+      BAZ: baz_from_service_def
+      QUX:
     # environment:
     #   - RACK_ENV=development
     #   - SHOW=true

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -99,7 +99,7 @@ type ServiceConfig struct {
 	HealthCheck     *HealthCheckConfig
 	Image           string
 	Ipc             string
-	Labels          MappingWithEquals
+	Labels          Labels
 	Links           []string
 	Logging         *LoggingConfig
 	MacAddress      string `mapstructure:"mac_address"`
@@ -135,7 +135,10 @@ type StringOrNumberList []string
 
 // MappingWithEquals is a mapping type that can be converted from a list of
 // key=value strings
-type MappingWithEquals map[string]string
+type MappingWithEquals map[string]*string
+
+// Labels is a mapping type for labels
+type Labels map[string]string
 
 // MappingWithColon is a mapping type that can be converted from a list of
 // 'key: value' strings
@@ -151,7 +154,7 @@ type LoggingConfig struct {
 type DeployConfig struct {
 	Mode          string
 	Replicas      *uint64
-	Labels        MappingWithEquals
+	Labels        Labels
 	UpdateConfig  *UpdateConfig `mapstructure:"update_config"`
 	Resources     Resources
 	RestartPolicy *RestartPolicy `mapstructure:"restart_policy"`
@@ -268,7 +271,7 @@ type NetworkConfig struct {
 	External   External
 	Internal   bool
 	Attachable bool
-	Labels     MappingWithEquals
+	Labels     Labels
 }
 
 // IPAMConfig for a network
@@ -287,7 +290,7 @@ type VolumeConfig struct {
 	Driver     string
 	DriverOpts map[string]string `mapstructure:"driver_opts"`
 	External   External
-	Labels     MappingWithEquals
+	Labels     Labels
 }
 
 // External identifies a Volume or Network as a reference to a resource that is
@@ -301,5 +304,5 @@ type External struct {
 type SecretConfig struct {
 	File     string
 	External External
-	Labels   MappingWithEquals
+	Labels   Labels
 }

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -134,7 +134,9 @@ type StringList []string
 type StringOrNumberList []string
 
 // MappingWithEquals is a mapping type that can be converted from a list of
-// key=value strings
+// key[=value] strings.
+// For the key with an empty value (`key=`), the mapped value is set to a pointer to `""`.
+// For the key without value (`key`), the mapped value is set to nil.
 type MappingWithEquals map[string]*string
 
 // Labels is a mapping type for labels


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix (newly support?) environment interpolation from the client

e.g.
```yaml
services:
  x:
    environment:
# needs to be propagated from the client
      - FOO

```

**- How I did it**

Please refer to the code.

**- How to verify it**
Prepare following files:

`docker-compose.yaml`:
```yaml
version: "3"
services:
  x:
    image: "busybox"
    command: ["sh", "-c", "env; tail -f /dev/null"]
    environment:
      - FOO
      - BAR
      - QUX
      - QUUX=quux_from_yaml
    env_file: a.env
```

`a.env`:

```
FOO=foo_from_file
BAR=bar_from_file
BAZ=baz_from_file
```

on Docker Compose:

```console
$ FOO=foo_from_env QUUX=quux_from_env docker-compose up
```

on Docker Swarm-mode:

```
$ FOO=foo_from_env QUUX=quux_from_env docker stack deploy -c docker-compose.yaml stack01
$ docker service logs stack01_x
```


Result:

Composer | `FOO` | `BAR` | `BAZ`|`QUX`|`QUUX`
--- | --- | --- | ---|---|---
Compose 1.11.1, <br> Swarm-mode with this PR | `"foo_from_env"` | unset (not `""`) | `"baz_from_file"` | unset (not `""`) | `"quux_from_yaml"`
Swarm-mode 1.13.1 | `""` | `""` | `"baz_from_file"`|`""`|`"quux_from_yaml"`


~~For `BAR`, I wonder Compose's result (unset) is unexpected and should be `""`, but not sure. (Could not find any doc :sweat_smile:)~~


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
compose: support environment interpolation from the client

**- A picture of a cute animal (not mandatory but encouraged)**

![446374156](https://cloud.githubusercontent.com/assets/9248427/22686242/aa37456a-ed66-11e6-9d9c-594516861df1.png)

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
