### PR TITLE
Read password from file in "docker login"

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -14,6 +14,7 @@ type loginOptions struct {
 	serverAddress string
 	user          string
 	password      string
+	passwordfile  string
 	email         string
 }
 
@@ -37,6 +38,7 @@ func NewLoginCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.user, "username", "u", "", "Username")
 	flags.StringVarP(&opts.password, "password", "p", "", "Password")
+	flags.StringVar(&opts.passwordfile, "password-file", "", "Read password from file")
 
 	return cmd
 }
@@ -57,7 +59,8 @@ func runLogin(dockerCli *command.DockerCli, opts loginOptions) error {
 
 	isDefaultRegistry := serverAddress == authServer
 
-	authConfig, err := command.ConfigureAuth(dockerCli, opts.user, opts.password, serverAddress, isDefaultRegistry)
+	authConfig, err := command.ConfigureAuth(dockerCli, opts.user, opts.password, opts.passwordfile, serverAddress,
+		isDefaultRegistry)
 	if err != nil {
 		return err
 	}

--- a/integration-cli/docker_cli_login_test.go
+++ b/integration-cli/docker_cli_login_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/go-check/check"
+	"io/ioutil"
+	"os"
 )
 
 func (s *DockerSuite) TestLoginWithoutTTY(c *check.C) {
@@ -27,4 +29,19 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestLoginToPrivateRegistry(c *check.C)
 
 	// now it's fine
 	dockerCmd(c, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), privateRegistryURL)
+}
+
+func (s *DockerRegistryAuthHtpasswdSuite) TestLoginToPrivateRegistryWithPasswordFile(c *check.C) {
+	content := []byte(s.reg.Password())
+	tmpfile, err := ioutil.TempFile("", "dockerpass")
+	c.Assert(err, checker.IsNil)
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	_, err = tmpfile.Write(content)
+	c.Assert(err, checker.IsNil)
+
+	err = tmpfile.Close()
+	c.Assert(err, checker.IsNil)
+
+	dockerCmd(c, "login", "-u", s.reg.Username(), "--password-file", tmpfile.Name(), privateRegistryURL)
 }


### PR DESCRIPTION
Hi,

this is my first pull request here.

I added the command line option `--password-file` to `docker login`. Then the password is read from the specified file. This is intended for cases where you need to login to a registry in scripts and the password should not be visible in the process table.

I added a integration test for this case. Not sure if there should also be a unit test, but I could not find any for the docker login command.

By the way, is there any way to run just a single integration test or at least a single file containing integration tests? I could not find anything in here: https://docs.docker.com/opensource/project/test-and-docs/
