### PR TITLE
[RFC] Overlayfs mounts

### DIFF
--- a/api/types/mount/mount.go
+++ b/api/types/mount/mount.go
@@ -15,6 +15,8 @@ const (
 	TypeVolume Type = "volume"
 	// TypeTmpfs is the type for mounting tmpfs
 	TypeTmpfs Type = "tmpfs"
+	// TODO(runcom): TypeOverlay ...
+	TypeOverlay Type = "overlay"
 )
 
 // Mount represents a mount (volume).

--- a/container/container.go
+++ b/container/container.go
@@ -308,6 +308,11 @@ func (container *Container) CheckpointDir() string {
 	return filepath.Join(container.Root, "checkpoints")
 }
 
+// OverlaysDir TODO(runcom)
+func (container *Container) OverlaysDir() string {
+	return filepath.Join(container.Root, "overlays")
+}
+
 // StartLogger starts a new logger driver for the container.
 func (container *Container) StartLogger() (logger.Logger, error) {
 	cfg := container.HostConfig.LogConfig

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -408,6 +408,20 @@ func copyOwnership(source, destination string) error {
 	return os.Chmod(destination, os.FileMode(stat.Mode()))
 }
 
+func (container *Container) OverlayMounts() ([]Mount, error) {
+	var mounts []Mount
+	for dest, mnt := range container.MountPoints {
+		if mnt.Type == mounttypes.TypeOverlay {
+			mounts = append(mounts, Mount{
+				Source:      "overlay",
+				Destination: dest,
+				Data:        fmt.Sprintf("lowerdir=%s:%s", dest, filepath.Join(container.BaseFS, strings.TrimPrefix(dest, "/"))),
+			})
+		}
+	}
+	return mounts, nil
+}
+
 // TmpfsMounts returns the list of tmpfs mounts
 func (container *Container) TmpfsMounts() ([]Mount, error) {
 	var mounts []Mount

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -128,6 +128,9 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig, managed bool) (
 	if err := idtools.MkdirAs(container.CheckpointDir(), 0700, rootUID, rootGID); err != nil {
 		return nil, err
 	}
+	if err := idtools.MkdirAs(container.OverlaysDir(), 0700, rootUID, rootGID); err != nil {
+		return nil, err
+	}
 
 	if err := daemon.setHostConfig(container, params.HostConfig); err != nil {
 		return nil, err

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -516,6 +516,16 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 			continue
 		}
 
+		if m.Source == "overlay" {
+			s.Mounts = append(s.Mounts, specs.Mount{
+				Destination: m.Destination,
+				Source:      m.Source,
+				Type:        "overlay",
+				Options:     strings.Split(m.Data, ","),
+			})
+			continue
+		}
+
 		mt := specs.Mount{Destination: m.Destination, Source: m.Source, Type: "bind"}
 
 		// Determine property of RootPropagation based on volume
@@ -740,6 +750,16 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 	}
 
 	ms = append(ms, c.IpcMounts()...)
+
+	overlayfsMounts, err := c.OverlayMounts()
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Debugf("runcom 1 %v", ms)
+	logrus.Debugf("runcom 1 %v", overlayfsMounts)
+
+	ms = append(ms, overlayfsMounts...)
 
 	tmpfsMounts, err := c.TmpfsMounts()
 	if err != nil {

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/mount"
@@ -36,6 +37,9 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 		tmpfsMounts[m.Destination] = true
 	}
 	for _, m := range c.MountPoints {
+		if m.Type == mounttypes.TypeOverlay {
+			continue
+		}
 		if tmpfsMounts[m.Destination] {
 			continue
 		}

--- a/volume/validate.go
+++ b/volume/validate.go
@@ -97,6 +97,8 @@ func validateMountConfig(mnt *mount.Mount, options ...func(*validateOpts)) error
 		if _, err := ConvertTmpfsOptions(mnt.TmpfsOptions, mnt.ReadOnly); err != nil {
 			return &errMountConfig{mnt, err}
 		}
+	case mount.TypeOverlay:
+		return nil
 	default:
 		return &errMountConfig{mnt, errors.New("mount type unknown")}
 	}

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -248,6 +248,9 @@ func ParseMountRaw(raw, volumeDriver string) (*MountPoint, error) {
 	} else {
 		spec.Type = mounttypes.TypeVolume
 	}
+	if mode == string(mounttypes.TypeOverlay) {
+		spec.Type = mounttypes.TypeOverlay
+	}
 
 	spec.ReadOnly = !ReadWrite(mode)
 
@@ -309,7 +312,7 @@ func ParseMountSpec(cfg mounttypes.Mount, options ...func(*validateOpts)) (*Moun
 				mp.CopyData = false
 			}
 		}
-	case mounttypes.TypeBind:
+	case mounttypes.TypeBind, mounttypes.TypeOverlay:
 		mp.Source = clean(convertSlash(cfg.Source))
 		if cfg.BindOptions != nil {
 			if len(cfg.BindOptions.Propagation) > 0 {

--- a/volume/volume_unix.go
+++ b/volume/volume_unix.go
@@ -24,6 +24,11 @@ var rwModes = map[string]bool{
 	"ro": true,
 }
 
+// type modes
+var typeModes = map[string]bool{
+	"overlay": true,
+}
+
 // label modes
 var labelModes = map[string]bool{
 	"Z": true,
@@ -62,9 +67,12 @@ func ValidMountMode(mode string) bool {
 	labelModeCount := 0
 	propagationModeCount := 0
 	copyModeCount := 0
+	typeModeCount := 0
 
 	for _, o := range strings.Split(mode, ",") {
 		switch {
+		case typeModes[o]:
+			typeModeCount++
 		case rwModes[o]:
 			rwModeCount++
 		case labelModes[o]:
@@ -79,7 +87,7 @@ func ValidMountMode(mode string) bool {
 	}
 
 	// Only one string for each mode is allowed.
-	if rwModeCount > 1 || labelModeCount > 1 || propagationModeCount > 1 || copyModeCount > 1 {
+	if rwModeCount > 1 || typeModeCount > 1 || labelModeCount > 1 || propagationModeCount > 1 || copyModeCount > 1 {
 		return false
 	}
 	return true


### PR DESCRIPTION
This is a RFC/POC of overlayfs volumes. By overlayfs volumes I mean mounts inside a container by using overlayfs to mount the resulting directory.
The code is by any mean ready to be reviewed or _fully_ working. It just shows a working example of mounting something readonly in a container using overlayfs. This works by setting overlay's multiple lowers, specifically from the host and from the container rootfs.
The CLI is not perfect, but it works like this:
```sh
$ docker run -ti -v /etc/pki:/etc/pki:overlay fedora bash
```
The above command creates a mount by overlaying the host's `/etc/pki` and the container rootfs `/etc/pki`. The resulting mounts contains a merge of the two dirs.
It's not perfect, but I wouldn't allow complex overlay mounts at command line.

Another way of doing this could have been volume plugins, but unfortunately the `Mount` API isn't providing the container's rootfs path (otherwise it could be possible I guess?). The volume plugin would be in charge of mounting the overlay and docker will bind mount that afterwards.

I've opened this just to gather feedback and maybe find a saner way of specifying overlay mounts in the CLI.

/cc @cpuguy83 @rhatdan @rhvgoyal @mrunalp 