### PR TITLE
Correct fmt.Fprintf and t.Fatalf

### DIFF
--- a/api/server/profiler.go
+++ b/api/server/profiler.go
@@ -29,13 +29,13 @@ func profilerSetup(mainRouter *mux.Router) {
 func expVars(w http.ResponseWriter, r *http.Request) {
 	first := true
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	fmt.Fprintf(w, "{\n")
+	fmt.Fprintln(w, "{")
 	expvar.Do(func(kv expvar.KeyValue) {
 		if !first {
-			fmt.Fprintf(w, ",\n")
+			fmt.Fprintln(w, ",")
 		}
 		first = false
 		fmt.Fprintf(w, "%q: %s", kv.Key, kv.Value)
 	})
-	fmt.Fprintf(w, "\n}\n")
+	fmt.Fprintln(w, "\n}")
 }

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -29,7 +29,7 @@ func TestMiddlewares(t *testing.T) {
 
 	localHandler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 		if httputils.VersionFromContext(ctx) == "" {
-			t.Fatalf("Expected version, got empty string")
+			t.Fatal("Expected version, got empty string")
 		}
 
 		if sv := w.Header().Get("Server"); !strings.Contains(sv, "Docker/0.1omega2") {


### PR DESCRIPTION
Signed-off-by: Helen Xie <chenjg@harmonycloud.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Correct fmt.Fprintf and t.Fatalf, because the values used for formatting text does not appear to contain a placeholder.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

