### PR TITLE
Fix double mount error when config.v2.json is wrong

### DIFF
--- a/daemon/graphdriver/counter.go
+++ b/daemon/graphdriver/counter.go
@@ -62,7 +62,9 @@ func (c *RefCounter) Decrement(path string) int {
 			m.count++
 		}
 	}
-	m.count--
+	if m.count > 0 {
+		m.count--
+	}
 	count := m.count
 	c.mu.Unlock()
 	return count


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
**environment:**
docker version 1.13.0, graph driver: overlay

**step to reproduce:**
```
root@hzwangxing02:~# docker run -d --name test hub.c.163.com/hzwangxing02/debian
root@hzwangxing02:~# reboot
// after reboot
root@hzwangxing02:~# docker start test
root@hzwangxing02:~# docker cp /bin/false test:/
root@hzwangxing02:~# docker exec test rm /bin/true
rm: cannot remove `bin/true': No such file or directory
```

**reason:**
The config.v2.json of container test is incorrect after rebooting host vm: state of container test is still marked as running(i.e., ..."State":{"Running":true...)

then docker will resotre container test:
```
// daemon/daemon.go
200 if c.IsRunning() || c.IsPaused() {
201     c.RestartManager().Cancel() // manually start containers because some need to wait for swarm networking
202     if err := daemon.containerd.Restore(c.ID, c.InitializeStdio); err != nil {
```

in fact, container test is not runnig, so containerd would return error "container not found"
```
// libcontainerd/client_linux.go
464     cont, err := clnt.getContainerdContainer(containerID)
467     if err != nil || cont.Status == "Stopped" {
500         clnt.setExited(containerID, ec)
```

one thing leads to another, mount count would be -1 finally (would be 0 after “docker start test”)
```
// daemon/graphdriver/counter.go
 52     if m == nil {
 53         m = &minfo{}
 54         c.counts[path] = m
 55     }
 59     if !m.check {
 60         m.check = true
 61         if c.checker.IsMounted(path) {
 62             m.count++
 63         }
 64     }
 65     if m.count > 0 {
 66         m.count--
 67     }
```

if we use "docker cp" or "docker commit" now, mergedDir would be mounted twice (count=1), resulting in ocrrupted overlayfs.
```
// daemon/graphdriver/overlay/overlay.go
355     if count := d.ctr.Increment(mergedDir); count > 1 {
356         return mergedDir, nil
357     }
```

**- How I did it**
Check mount count before decreasing it. After all, mount count should never below 0.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

