### PR TITLE
add filters for plugin list endpoint in swagger.yml

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6443,6 +6443,15 @@ paths:
           description: "Server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
+      parameters:
+        - name: "filters"
+          in: "query"
+          type: "string"
+          description: |
+            A JSON encoded value of the filters (a `map[string][]string`) to process on the plugin list. Available filters:
+
+            - `capability=<capability name>`
+            - `enable=<true>|<false>`
       tags: ["Plugin"]
 
   /plugins/privileges:


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I fount that in swagger.yml there is filters query missing. This pr adds the missing filters in swagger.yml.
The filter related code is here: https://github.com/docker/docker/blob/master/plugin/backend_linux.go#L40-L43

**- What I did**
1. add filters for plugin list endpoint in swagger.yml

ping @anusha-ragunathan @thaJeztah @vdemeester 
