### PR TITLE
Add `PORTS` field for `docker service ls` (`ingress`)

### DIFF
--- a/cli/command/formatter/service_test.go
+++ b/cli/command/formatter/service_test.go
@@ -29,9 +29,9 @@ func TestServiceContextWrite(t *testing.T) {
 		// Table format
 		{
 			Context{Format: NewServiceListFormat("table", false)},
-			`ID                  NAME                MODE                REPLICAS            IMAGE
-id_baz              baz                 global              2/4                 
-id_bar              bar                 replicated          2/4                 
+			`ID                  NAME                MODE                REPLICAS            IMAGE               PORTS
+id_baz              baz                 global              2/4                                     *:80->8080/tcp
+id_bar              bar                 replicated          2/4                                     *:80->8080/tcp
 `,
 		},
 		{
@@ -62,12 +62,14 @@ name: baz
 mode: global
 replicas: 2/4
 image: 
+ports: *:80->8080/tcp
 
 id: id_bar
 name: bar
 mode: replicated
 replicas: 2/4
 image: 
+ports: *:80->8080/tcp
 
 `,
 		},
@@ -88,8 +90,38 @@ bar
 
 	for _, testcase := range cases {
 		services := []swarm.Service{
-			{ID: "id_baz", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "baz"}}},
-			{ID: "id_bar", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "bar"}}},
+			{
+				ID: "id_baz",
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{Name: "baz"},
+					EndpointSpec: &swarm.EndpointSpec{
+						Ports: []swarm.PortConfig{
+							{
+								PublishMode:   "ingress",
+								PublishedPort: 80,
+								TargetPort:    8080,
+								Protocol:      "tcp",
+							},
+						},
+					},
+				},
+			},
+			{
+				ID: "id_bar",
+				Spec: swarm.ServiceSpec{
+					Annotations: swarm.Annotations{Name: "bar"},
+					EndpointSpec: &swarm.EndpointSpec{
+						Ports: []swarm.PortConfig{
+							{
+								PublishMode:   "ingress",
+								PublishedPort: 80,
+								TargetPort:    8080,
+								Protocol:      "tcp",
+							},
+						},
+					},
+				},
+			},
 		}
 		info := map[string]ServiceListInfo{
 			"id_baz": {
@@ -114,8 +146,38 @@ bar
 
 func TestServiceContextWriteJSON(t *testing.T) {
 	services := []swarm.Service{
-		{ID: "id_baz", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "baz"}}},
-		{ID: "id_bar", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "bar"}}},
+		{
+			ID: "id_baz",
+			Spec: swarm.ServiceSpec{
+				Annotations: swarm.Annotations{Name: "baz"},
+				EndpointSpec: &swarm.EndpointSpec{
+					Ports: []swarm.PortConfig{
+						{
+							PublishMode:   "ingress",
+							PublishedPort: 80,
+							TargetPort:    8080,
+							Protocol:      "tcp",
+						},
+					},
+				},
+			},
+		},
+		{
+			ID: "id_bar",
+			Spec: swarm.ServiceSpec{
+				Annotations: swarm.Annotations{Name: "bar"},
+				EndpointSpec: &swarm.EndpointSpec{
+					Ports: []swarm.PortConfig{
+						{
+							PublishMode:   "ingress",
+							PublishedPort: 80,
+							TargetPort:    8080,
+							Protocol:      "tcp",
+						},
+					},
+				},
+			},
+		},
 	}
 	info := map[string]ServiceListInfo{
 		"id_baz": {
@@ -128,8 +190,8 @@ func TestServiceContextWriteJSON(t *testing.T) {
 		},
 	}
 	expectedJSONs := []map[string]interface{}{
-		{"ID": "id_baz", "Name": "baz", "Mode": "global", "Replicas": "2/4", "Image": ""},
-		{"ID": "id_bar", "Name": "bar", "Mode": "replicated", "Replicas": "2/4", "Image": ""},
+		{"ID": "id_baz", "Name": "baz", "Mode": "global", "Replicas": "2/4", "Image": "", "Ports": "*:80->8080/tcp"},
+		{"ID": "id_bar", "Name": "bar", "Mode": "replicated", "Replicas": "2/4", "Image": "", "Ports": "*:80->8080/tcp"},
 	}
 
 	out := bytes.NewBufferString("")

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -137,6 +137,7 @@ Placeholder | Description
 `.Mode`     | Service mode (replicated, global)
 `.Replicas` | Service replicas
 `.Image`    | Service image
+`.Ports`    | Service ports published in ingress mode
 
 When using the `--format` option, the `service ls` command will either
 output the data exactly as the template declares or, when using the


### PR DESCRIPTION
This fix is related to https://github.com/docker/docker/issues/30232#issuecomment-276525426 where `docker service ls` does not show `PORTS` information like `docker service ps`.

This fix adds `PORTS` fields for services that publish ports in ingress mode.

Additional unit tests cases have been updated.

This fix is related to #30232.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>