### PR TITLE
modify the type of advertiseAddr to unify with listenAddr

### DIFF
--- a/cli/command/swarm/init.go
+++ b/cli/command/swarm/init.go
@@ -16,9 +16,8 @@ import (
 
 type initOptions struct {
 	swarmOptions
-	listenAddr NodeAddrOption
-	// Not a NodeAddrOption because it has no default port.
-	advertiseAddr   string
+	listenAddr      NodeAddrOption
+	advertiseAddr   NodeAddrOption
 	forceNewCluster bool
 	availability    string
 }
@@ -39,7 +38,7 @@ func newInitCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.Var(&opts.listenAddr, flagListenAddr, "Listen address (format: <ip|interface>[:port])")
-	flags.StringVar(&opts.advertiseAddr, flagAdvertiseAddr, "", "Advertised address (format: <ip|interface>[:port])")
+	flags.Var(&opts.advertiseAddr, flagAdvertiseAddr, "Advertised address (format: <ip|interface>[:port])")
 	flags.BoolVar(&opts.forceNewCluster, "force-new-cluster", false, "Force create a new cluster from current state")
 	flags.BoolVar(&opts.autolock, flagAutolock, false, "Enable manager autolocking (requiring an unlock key to start a stopped manager)")
 	flags.StringVar(&opts.availability, flagAvailability, "active", "Availability of the node (active/pause/drain)")
@@ -53,7 +52,7 @@ func runInit(dockerCli command.Cli, flags *pflag.FlagSet, opts initOptions) erro
 
 	req := swarm.InitRequest{
 		ListenAddr:       opts.listenAddr.String(),
-		AdvertiseAddr:    opts.advertiseAddr,
+		AdvertiseAddr:    opts.advertiseAddr.String(),
 		ForceNewCluster:  opts.forceNewCluster,
 		Spec:             opts.swarmOptions.ToSpec(flags),
 		AutoLockManagers: opts.swarmOptions.autolock,

--- a/cli/command/swarm/join.go
+++ b/cli/command/swarm/join.go
@@ -14,10 +14,9 @@ import (
 )
 
 type joinOptions struct {
-	remote     string
-	listenAddr NodeAddrOption
-	// Not a NodeAddrOption because it has no default port.
-	advertiseAddr string
+	remote        string
+	listenAddr    NodeAddrOption
+	advertiseAddr NodeAddrOption
 	token         string
 	availability  string
 }
@@ -39,7 +38,7 @@ func newJoinCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.Var(&opts.listenAddr, flagListenAddr, "Listen address (format: <ip|interface>[:port])")
-	flags.StringVar(&opts.advertiseAddr, flagAdvertiseAddr, "", "Advertised address (format: <ip|interface>[:port])")
+	flags.Var(&opts.advertiseAddr, flagAdvertiseAddr, "Advertised address (format: <ip|interface>[:port])")
 	flags.StringVar(&opts.token, flagToken, "", "Token for entry into the swarm")
 	flags.StringVar(&opts.availability, flagAvailability, "active", "Availability of the node (active/pause/drain)")
 	return cmd
@@ -52,7 +51,7 @@ func runJoin(dockerCli command.Cli, flags *pflag.FlagSet, opts joinOptions) erro
 	req := swarm.JoinRequest{
 		JoinToken:     opts.token,
 		ListenAddr:    opts.listenAddr.String(),
-		AdvertiseAddr: opts.advertiseAddr,
+		AdvertiseAddr: opts.advertiseAddr.String(),
 		RemoteAddrs:   []string{opts.remote},
 	}
 	if flags.Changed(flagAvailability) {

--- a/cli/command/swarm/opts.go
+++ b/cli/command/swarm/opts.go
@@ -41,7 +41,7 @@ type swarmOptions struct {
 	autolock            bool
 }
 
-// NodeAddrOption is a pflag.Value for listening addresses
+// NodeAddrOption is a pflag.Value for addresses
 type NodeAddrOption struct {
 	addr string
 }

--- a/docs/reference/commandline/swarm_init.md
+++ b/docs/reference/commandline/swarm_init.md
@@ -21,7 +21,7 @@ Usage:  docker swarm init [OPTIONS]
 Initialize a swarm
 
 Options:
-      --advertise-addr string           Advertised address (format: <ip|interface>[:port])
+      --advertise-addr node-addr        Advertised address (format: <ip|interface>[:port])
       --autolock                        Enable manager autolocking (requiring an unlock key to start a stopped manager)
       --availability string             Availability of the node (active/pause/drain) (default "active")
       --cert-expiry duration            Validity period for node certificates (ns|us|ms|s|m|h) (default 2160h0m0s)

--- a/docs/reference/commandline/swarm_join.md
+++ b/docs/reference/commandline/swarm_join.md
@@ -21,11 +21,11 @@ Usage:  docker swarm join [OPTIONS] HOST:PORT
 Join a swarm as a node and/or manager
 
 Options:
-      --advertise-addr string   Advertised address (format: <ip|interface>[:port])
-      --availability string     Availability of the node (active/pause/drain) (default "active")
-      --help                    Print usage
-      --listen-addr node-addr   Listen address (format: <ip|interface>[:port]) (default 0.0.0.0:2377)
-      --token string            Token for entry into the swarm
+      --advertise-addr node-addr Advertised address (format: <ip|interface>[:port])
+      --availability string      Availability of the node (active/pause/drain) (default "active")
+      --help                     Print usage
+      --listen-addr node-addr    Listen address (format: <ip|interface>[:port]) (default 0.0.0.0:2377)
+      --token string             Token for entry into the swarm
 ```
 
 Join a node to a swarm. The node joins as a manager node or worker node based upon the token you


### PR DESCRIPTION
Signed-off-by: yupengzte <yu.peng36@zte.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
When I do it with “docker swarm”, I found that the descriptions of  advertiseAddr  and listenAddr is same, but their type is different. So modify the type of advertiseAddr to unify with listenAddr.
**- How I did it**
modify string to NodeAddrOption
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

