### PR TITLE
remove 400 and 404 for get nodes endpoint and add 503 for secret update

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6815,14 +6815,6 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/Node"
-        400:
-          description: "bad parameter"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-        404:
-          description: "no such node"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
         500:
           description: "server error"
           schema:
@@ -7915,6 +7907,10 @@ paths:
             $ref: "#/definitions/ErrorResponse"
         500:
           description: "server error"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        503:
+          description: "node is not part of a swarm"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

We know that `GET /nodes` endpoint does not take parameters, so there will no status code of 400. In addition, this endpoint is not going to get the specific node, so no status code of 404 returned, either.

Since secret operation is supported in Swarm mode, when a node is not in Swarm Mode, we specify the status code to be 503 to show service unavailable. So I added 503 for this endpoint in swagger.yml.

**- What I did**
1. remove 400 and 404 for `GET /nodes` endpoint; 
2. add 503 for `POST /secrets/{id}/update` endpoint;


**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

