### PR TITLE
Randomly assigned pull requests after 2 weeks

### DIFF
--- a/poule.yml
+++ b/poule.yml
@@ -4,7 +4,7 @@
   operations:
       - type:       label
         filters: {
-            ~labels: [ " status/0-triage", "status/1-design-review", "status/2-code-review", "status/3-docs-review", "status/4-merge" ],
+            ~labels: [ "status/0-triage", "status/1-design-review", "status/2-code-review", "status/3-docs-review", "status/4-merge" ],
         }
         settings: {
             patterns: {

--- a/poule.yml
+++ b/poule.yml
@@ -99,4 +99,28 @@
         settings: {
             configurations: [ z ],
             label:          "rebuild/z",
+
+# Once a day, randomly assign pull requests older than 2 weeks.
+- schedule:         "@daily"
+  operations:
+      - type:       random-assign
+        filters: {
+            age:    "2w",
+            is:     "pr",
+        }
+        settings: {
+            users: [
+                "anusha-ragunathan",
+                "cpuguy83",
+                "crosbymichael",
+                "dnephin",
+                "justincormack",
+                "lk4d4",
+                "mlaventure",
+                "thajeztah",
+                "tiborvass",
+                "tonistiigi",
+                "vdemeester",
+                "vieux",
+            ]
         }


### PR DESCRIPTION
Add a daily job to randomly assign pull requests which have been opened for more than two weeks.