### PR TITLE
bump engine API to 1.27

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -21,7 +21,7 @@ import (
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion string = "1.26"
+	DefaultVersion string = "1.27"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.26"
+basePath: "/v1.27"
 info:
   title: "Docker Engine API"
-  version: "1.26"
+  version: "1.27"
   x-logo:
     url: "https://docs.docker.com/images/logo-docker-main.png"
   description: |
@@ -44,7 +44,7 @@ info:
 
     The API is usually changed in each release of Docker, so API calls are versioned to ensure that clients don't break.
 
-    For Docker Engine 1.14, the API version is 1.26. To lock to this version, you prefix the URL with `/v1.26`. For example, calling `/info` is the same as calling `/v1.26/info`.
+    For Docker Engine 1.14, the API version is 1.27. To lock to this version, you prefix the URL with `/v1.27`. For example, calling `/info` is the same as calling `/v1.27/info`.
 
     Engine releases in the near future should support this version of the API, so your client will continue to work even if it is talking to a newer Engine.
 
@@ -52,11 +52,12 @@ info:
 
     The API uses an open schema model, which means server may add extra properties to responses. Likewise, the server will ignore any extra query parameters and request body properties. When you write clients, you need to ignore additional properties in responses to ensure they do not break when talking to newer Docker daemons.
 
-    This documentation is for version 1.26 of the API, which was introduced with Docker 1.14. Use this table to find documentation for previous versions of the API:
+    This documentation is for version 1.27 of the API, which was introduced with Docker 1.14. Use this table to find documentation for previous versions of the API:
 
     Docker version  | API version | Changes
     ----------------|-------------|---------
-    1.13.x | [1.25](https://docs.docker.com/engine/api/v1.25/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-25-api-changes)
+    1.13.1 | [1.26](https://docs.docker.com/engine/api/v1.26/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-26-api-changes)
+    1.13.0 | [1.25](https://docs.docker.com/engine/api/v1.25/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-25-api-changes)
     1.12.x | [1.24](https://docs.docker.com/engine/api/v1.24/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-24-api-changes)
     1.11.x | [1.23](https://docs.docker.com/engine/api/v1.23/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-23-api-changes)
     1.10.x | [1.22](https://docs.docker.com/engine/api/v1.22/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-22-api-changes)

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,17 +13,23 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
-## v1.26 API changes
+## v1.27 API changes
 
-[Docker Engine API v1.26](v1.26/) documentation
+[Docker Engine API v1.27](https://docs.docker.com/engine/api/v1.27/) documentation
 
-* `GET /containers/(id or name)/attach/ws` now returns WebSocket in binary frame format for API version >= v1.26, and returns WebSocket in text frame format for API version< v1.26, for the purpose of backward-compatibility.
+* `GET /containers/(id or name)/attach/ws` now returns WebSocket in binary frame format for API version >= v1.27, and returns WebSocket in text frame format for API version< v1.27, for the purpose of backward-compatibility.
 * `GET /networks` is optimised only to return list of all networks and network specific information. List of all containers attached to a specific network is removed from this API and is only available using the network specific `GET /networks/{network-id}.
 * `GET /containers/json` now supports `publish` and `expose` filters to filter containers that expose or publish certain ports.
 
+## v1.26 API changes
+
+[Docker Engine API v1.26](https://docs.docker.com/engine/api/v1.26/) documentation
+
+* `POST /plugins/(plugin name)/upgrade` upgrade a plugin.
+
 ## v1.25 API changes
 
-[Docker Engine API v1.25](v1.25.md) documentation
+[Docker Engine API v1.25](https://docs.docker.com/engine/api/v1.25/) documentation
 
 * The API version is now required in all API calls. Instead of just requesting, for example, the URL `/containers/json`, you must now request `/v1.25/containers/json`.
 * `GET /version` now returns `MinAPIVersion`.


### PR DESCRIPTION
1.26 is used by Docker 1.13.1, so master should be bumped to 1.27

/cc @thaJeztah @dnephin 