### PR TITLE
add testcase check connect.EndpointConfig not nil

### DIFF
--- a/client/network_connect_test.go
+++ b/client/network_connect_test.go
@@ -87,6 +87,10 @@ func TestNetworkConnect(t *testing.T) {
 				return nil, fmt.Errorf("expected 'container_id', got %s", connect.Container)
 			}
 
+			if connect.EndpointConfig == nil {
+				return nil, fmt.Errorf("expected connect.EndpointConfig to be not nil, got %v", connect.EndpointConfig)
+			}
+
 			if connect.EndpointConfig.NetworkID != "NetworkID" {
 				return nil, fmt.Errorf("expected 'NetworkID', got %s", connect.EndpointConfig.NetworkID)
 			}


### PR DESCRIPTION
Signed-off-by: chchliang <chen.chuanliang@zte.com.cn>


**- What I did**
In client/network_connect_test.go  file `func TestNetworkConnect(t *testing.T) ` add branch check connect.EndpointConfig not nil

**- How I did it**

![image](https://cloud.githubusercontent.com/assets/23158339/22768237/a47491a4-eebb-11e6-833d-911979c8d42d.png)


**- How to verify it**



