### PR TITLE
Fix poule configuration

### DIFF
--- a/poule.yml
+++ b/poule.yml
@@ -99,6 +99,7 @@
         settings: {
             configurations: [ z ],
             label:          "rebuild/z",
+        }
 
 # Once a day, randomly assign pull requests older than 2 weeks.
 - schedule:         "@daily"


### PR DESCRIPTION
Poule configuration is broken by #30835 (yes, that's me).

This is an emergency fix: I'll work on having proper validation on the yaml format before merging. In the meantime, this one was verified manually:

```bash
$ poule validate --repository-config poule.yml 
2017/02/09 01:37:27 repository configuration file is valid
```