### PR TITLE
Fix the rm error message when a container is restarting/paused

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -191,10 +191,15 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT e2655f658408f9ad1f62abdef3eb6ed43c0cf324
+ENV DOCKER_PY_COMMIT 4a08d04aef0595322e1b5ac7c52f28a931da85a5
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \
+	# To run integration tests docker-pycreds is required.
+	# Before running the integration tests conftest.py is
+	# loaded which results in loads auth.py that
+	# imports the docker-pycreds module.
+	&& pip install docker-pycreds==0.2.1 \
 	&& pip install -r test-requirements.txt
 
 # Install yamllint for validating swagger.yaml

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -142,11 +142,15 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT e2655f658408f9ad1f62abdef3eb6ed43c0cf324
+ENV DOCKER_PY_COMMIT 4a08d04aef0595322e1b5ac7c52f28a931da85a5
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \
 	&& pip install wheel \
+	# Before running the integration tests conftest.py is
+	# loaded which results in loads auth.py that
+	# imports the docker-pycreds module.
+	&& pip install docker-pycreds==0.2.1 \
 	&& pip install -r test-requirements.txt
 
 # Install yamllint for validating swagger.yaml

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4165,7 +4165,7 @@ paths:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "You cannot remove a running container: c2ada9df5af8. Stop the container before attempting removal or use -f"
+              message: "You cannot remove a running container: c2ada9df5af8. Stop the container before attempting removal or force remove"
         500:
           description: "server error"
           schema:

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -80,7 +80,12 @@ func (daemon *Daemon) rmLink(container *container.Container, name string) error 
 func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemove, removeVolume bool) (err error) {
 	if container.IsRunning() {
 		if !forceRemove {
-			err := fmt.Errorf("You cannot remove a running container %s. Stop the container before attempting removal or use -f", container.ID)
+			state := container.StateString()
+			procedure := "Stop the container before attempting removal or force remove"
+			if state == "paused" {
+				procedure = "Unpause and then " + strings.ToLower(procedure)
+			}
+			err := fmt.Errorf("You cannot remove a %s container %s. %s", state, container.ID, procedure)
 			return apierrors.NewRequestConflictError(err)
 		}
 		if err := daemon.Kill(container); err != nil {


### PR DESCRIPTION
**- What I did**
Running the rm command on a paused/restarting container
will give an error message saying the container is running
which is incorrect.

To fix that, the error message will have the correct
container state and a procedure to remove it accordingly.

related to #30842

**- How I did it**

* Read the container state using `container.StateString()`
* If the state is "paused" then set the procedure to be `Unpause and stop the container before attempting removal`. Otherwise, set it to `Stop the container before attempting removal or use -f`.

**- How to verify it**

Run the following tests:

* `TESTFLAGS='-check.f DockerSuite.TestRmRestarting*' hack/make.sh test-integration-cli`
* `TESTFLAGS='-check.f DockerSuite.TestRmPause*' hack/make.sh test-integration-cli`
* `TESTFLAGS='-check.f DockerSuite.TestRmContainerRun*' hack/make.sh test-integration-cli`

