### PR TITLE
Fix bash completion for `start --checkpoint`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1752,12 +1752,12 @@ _docker_container_start() {
 
 	case "$prev" in
 		--checkpoint)
-			if [ __docker_is_experimental ] ; then
+			if [ __docker_daemon_is_experimental ] ; then
 				return
 			fi
 			;;
 		--checkpoint-dir)
-			if [ __docker_is_experimental ] ; then
+			if [ __docker_daemon_is_experimental ] ; then
 				_filedir -d
 				return
 			fi
@@ -1767,7 +1767,7 @@ _docker_container_start() {
 	case "$cur" in
 		-*)
 			local options="--attach -a --detach-keys --help --interactive -i"
-			__docker_is_experimental && options+=" --checkpoint --checkpoint-dir"
+			__docker_daemon_is_experimental && options+=" --checkpoint --checkpoint-dir"
 			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)


### PR DESCRIPTION
Bash completion for `--checkpoint` was added in #30444.
There was a refactoring (#30438) between its creation and merge, which renamed a helper function used by it.
This PR fixes #30444 so that it uses the new helper function.

To trigger the broken behavior:
- type `docker container start --`
- press `<tab>`

Expected result: bash completion of options
Actual result: a message *bash: __docker_is_experimental: command not found* is inserted at the cursor position.