### PR TITLE
Fix bash completion for `docker service`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2703,7 +2703,7 @@ _docker_service() {
 		ps
 		update
 	"
-	__docker_daemon_is_experimental && subcommands+="logs"
+	__docker_is_experimental && subcommands+="logs"
 
 	__docker_subcommands "$subcommands" && return
 


### PR DESCRIPTION
Fixes #30858
Fixes #30910

#30510 was cherry-picked into 1.13.x but relied on a prerequisite refactoring (93e43b42be7e600a266c17c64a3d718a0a4737a6 from #30438) that was not present in this branch.
As a consequence, it calls `__docker_daemon_is_experimental` instead of `__docker_is_experimental`.

I'm sorry about the confusion that the refactoring caused. 
At that time, there were quite a few bash completion PRs pending and I forgot to update #30510.

Note: This PR is against branch *1.13.x*, so it can be abandoned if no 1.13.2 release is created.