### PR TITLE
print 'worker' join token after swarm init

### DIFF
--- a/cli/command/swarm/init.go
+++ b/cli/command/swarm/init.go
@@ -78,7 +78,7 @@ func runInit(dockerCli command.Cli, flags *pflag.FlagSet, opts initOptions) erro
 
 	fmt.Fprintf(dockerCli.Out(), "Swarm initialized: current node (%s) is now a manager.\n\n", nodeID)
 
-	if err := printJoinCommand(ctx, dockerCli, nodeID, false, true); err != nil {
+	if err := printJoinCommand(ctx, dockerCli, nodeID, true, false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
the changed was introduced here by mistake: https://github.com/docker/docker/commit/f151c297eb268e22dc1eb36ded0e356885f40739#diff-7b67fa7b7e1c183d348c1ee8148610a2R70

/cc @cyli @tonistiigi @vdemeester 