### PR TITLE
reference: Handle combination of tag and digest in AddReference

### DIFF
--- a/reference/store.go
+++ b/reference/store.go
@@ -107,6 +107,20 @@ func (store *store) AddDigest(ref reference.Canonical, id digest.Digest, force b
 }
 
 func (store *store) addReference(ref reference.Named, id digest.Digest, force bool) error {
+	// If the reference includes a digest and a tag, we must store only the
+	// digest.
+	canonical, isCanonical := ref.(reference.Canonical)
+	_, isNamedTagged := ref.(reference.NamedTagged)
+
+	if isCanonical && isNamedTagged {
+		trimmed, err := reference.WithDigest(reference.TrimNamed(canonical), canonical.Digest())
+		if err != nil {
+			// should never happen
+			return err
+		}
+		ref = trimmed
+	}
+
 	refName := reference.FamiliarName(ref)
 	refStr := reference.FamiliarString(ref)
 


### PR DESCRIPTION
With the switchover to the unified reference package, `AddReference` no
longer does the right thing when passed a reference that has both a
digest and a tag. It would put both the digest in the tag in the
reference stored in the repositories.json file, which isn't the right
format, and would mean that neither `docker run` nor docker services
could locate the image. This meant that a simple `docker service create`
command like `docker service create --name foo busybox top` would create
a service that immediately went into a restart loop, because it couldn't
use the image that had been pulled.

Fix `AddReference` to strip out the tag when both a tag and digest are
specified. We do this because we don't necessarily want to overwrite the
tag - when both a digest and tag are specified, the tag is only
advisory.

cc @dmcgowan