### PR TITLE
Windows: make.ps1 emit commit ID

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -97,7 +97,7 @@ Function Get-GitCommit() {
         if ($env:DOCKER_GITCOMMIT.Length -eq 0) {
             Throw ".git directory missing and DOCKER_GITCOMMIT environment variable not specified."
         }
-        Write-Host "INFO: Git commit assumed from DOCKER_GITCOMMIT environment variable"
+        Write-Host "INFO: Git commit ($env:DOCKER_GITCOMMIT) assumed from DOCKER_GITCOMMIT environment variable"
         return $env:DOCKER_GITCOMMIT
     }
     $gitCommit=$(git rev-parse --short HEAD)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@vdemeester @thaJeztah @johnstep 

Minor follow-up to the changes to not send the .git directory during a build, emits the commit ID in the output which otherwise isn't visible on RS1 CI

eg before this change
```
00:00:57.261 INFO: Building the test binaries at 02/10/2017 03:53:24...
00:01:02.867 INFO: make.ps1 starting at 02/10/2017 03:53:29
00:01:02.993 INFO: Git commit assumed from DOCKER_GITCOMMIT environment variable
00:01:03.014 INFO: Invoking autogen...
00:01:03.475 INFO: Building daemon...
00:01:39.222 INFO: Building client...
00:01:49.821 
```

and after
```
00:01:03.650 INFO: Building the test binaries at 02/10/2017 04:02:44...
00:01:09.098 INFO: make.ps1 starting at 02/10/2017 04:02:50
00:01:09.221 INFO: Git commit (f48f1ff34) assumed from DOCKER_GITCOMMIT environment variable
00:01:09.234 INFO: Invoking autogen...
00:01:09.666 INFO: Building daemon...
```