### PR TITLE
add link query in container rm api doc

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4082,6 +4082,11 @@ paths:
           description: "If the container is running, kill it before removing it."
           type: "boolean"
           default: false
+        - name: "link"
+          in: "query"
+          description: "Remove the specified link associated with the container."
+          type: "boolean"
+          default: false
       tags: ["Container"]
   /containers/{id}/archive:
     head:

--- a/docs/api/v1.18.md
+++ b/docs/api/v1.18.md
@@ -1056,6 +1056,8 @@ Remove the container `id` from the filesystem
         associated to the container. Default `false`.
 -   **force** - 1/True/true or 0/False/false, Kill then remove the container.
         Default `false`.
+-   **link** - 1/True/true or 0/False/false, Remove the specified
+        link associated to the container. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.19.md
+++ b/docs/api/v1.19.md
@@ -1095,6 +1095,8 @@ Remove the container `id` from the filesystem
         associated to the container. Default `false`.
 -   **force** - 1/True/true or 0/False/false, Kill then remove the container.
         Default `false`.
+-   **link** - 1/True/true or 0/False/false, Remove the specified
+        link associated to the container. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.20.md
+++ b/docs/api/v1.20.md
@@ -1102,6 +1102,8 @@ Remove the container `id` from the filesystem
         associated to the container. Default `false`.
 -   **force** - 1/True/true or 0/False/false, Kill then remove the container.
         Default `false`.
+-   **link** - 1/True/true or 0/False/false, Remove the specified
+        link associated to the container. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -1185,6 +1185,8 @@ Remove the container `id` from the filesystem
         associated to the container. Default `false`.
 -   **force** - 1/True/true or 0/False/false, Kill then remove the container.
         Default `false`.
+-   **link** - 1/True/true or 0/False/false, Remove the specified
+        link associated to the container. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -1364,6 +1364,8 @@ Remove the container `id` from the filesystem
         associated to the container. Default `false`.
 -   **force** - 1/True/true or 0/False/false, Kill then remove the container.
         Default `false`.
+-   **link** - 1/True/true or 0/False/false, Remove the specified
+        link associated to the container. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -1399,6 +1399,8 @@ Remove the container `id` from the filesystem
         associated to the container. Default `false`.
 -   **force** - 1/True/true or 0/False/false, Kill then remove the container.
         Default `false`.
+-   **link** - 1/True/true or 0/False/false, Remove the specified
+        link associated to the container. Default `false`.
 
 **Status codes**:
 

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -1441,6 +1441,8 @@ Remove the container `id` from the filesystem
         associated to the container. Default `false`.
 -   **force** - 1/True/true or 0/False/false, Kill then remove the container.
         Default `false`.
+-   **link** - 1/True/true or 0/False/false, Remove the specified
+        link associated to the container. Default `false`.
 
 **Status codes**:
 


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. add link query in container rm api in swagger.yml
2. test from docker 1.6.x to 1.13.x, same link query is missing, add them back to api docs.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

