### PR TITLE
Add Aliyun mirror support to hack/install.sh

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -112,6 +112,10 @@ case "$mirror" in
 		apt_url="https://mirror.azure.cn/docker-engine/apt"
 		yum_url="https://mirror.azure.cn/docker-engine/yum"
 		;;
+	Aliyun)
+		apt_url="https://mirrors.aliyun.com/docker-engine/apt"
+		yum_url="https://mirrors.aliyun.com/docker-engine/yum"
+		;;
 esac
 
 command_exists() {


### PR DESCRIPTION
Signed-off-by: hyzhou.zhy <hyzhou.zhy@alibaba-inc.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Add Aliyun mirror support to hack/install.sh
I received an email today, The https transformation for Aliyun mirror is complete. @friism @thaJeztah 

we will just run this:
```
curl -sSL https://get.docker.com/ | sh -s -- --mirror Aliyun
```

Tested in Aliyun ECS：Ubuntu 16.04、CentOS7.2

**- A picture of a cute animal (not mandatory but encouraged)**

