### PR TITLE
Fix both logs commands to correctly handle errors

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/signal"
+	"github.com/docker/docker/pkg/stdcopy"
 	"golang.org/x/net/context"
 	"golang.org/x/net/websocket"
 )
@@ -108,9 +109,10 @@ func (s *containerRouter) getContainersLogs(ctx context.Context, w http.Response
 		select {
 		case <-chStarted:
 			// The client may be expecting all of the data we're sending to
-			// be multiplexed, so send it through OutStream, which will
-			// have been set up to handle that if needed.
-			fmt.Fprintf(logsConfig.OutStream, "Error running logs job: %v\n", err)
+			// be multiplexed, so mux it through the Systemerr stream, which
+			// will cause the client to throw an error when demuxing
+			stdwriter := stdcopy.NewStdWriter(logsConfig.OutStream, stdcopy.Systemerr)
+			fmt.Fprintf(stdwriter, "Error running logs job: %v\n", err)
 		default:
 			return err
 		}

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/filters"
 	types "github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/pkg/stdcopy"
 	"golang.org/x/net/context"
 )
 
@@ -252,7 +253,8 @@ func (sr *swarmRouter) getServiceLogs(ctx context.Context, w http.ResponseWriter
 			// The client may be expecting all of the data we're sending to
 			// be multiplexed, so send it through OutStream, which will
 			// have been set up to handle that if needed.
-			fmt.Fprintf(logsConfig.OutStream, "Error grabbing service logs: %v\n", err)
+			stdwriter := stdcopy.NewStdWriter(w, stdcopy.Systemerr)
+			fmt.Fprintf(stdwriter, "Error grabbing service logs: %v\n", err)
 		default:
 			return err
 		}


### PR DESCRIPTION
~*NB: This PR is a work-in-progress and does not contain unit tests; it has been submitted for a design and high-level code review, so I don't waste a bunch of time if this fix is barking up the wrong tree*~ 

This PR is ready for full review and merging if there are no errors.

**- What I did**
`docker logs` is broken, I think, and has been for a long time.  Specifically, it's programmed to multiplex many output streams (stdout and stderr) through one http response, and then demux the HTTP response in the CLI. This multiplexing and demultiplexing is done by `docker/docker/pkg/stdcopy`, which uses a `stdWriter` to write and `StdCopy` to copy to the output streams. StdCopy adds a byte header to the message which describes which stream the log message belongs to (stdout or stderr).

In `api/server/router/container/container_routes.go line 108`
```    if err := s.backend.ContainerLogs(ctx, containerName, logsConfig, chStarted); err != nil {
        select {
        case <-chStarted:
            // The client may be expecting all of the data we're sending to
            // be multiplexed, so send it through OutStream, which will
            // have been set up to handle that if needed.
            fmt.Fprintf(logsConfig.OutStream, "Error running logs job: %v\n", err)
        default:
            return err
        }
    }
```

But outstream is not a `stdWriter`, which can handled muxed streams, it's just an `https.ResponseWriter`, so the error message gets inserted verbatim into the response from the server; no byte header is ever inserted. Then, when the response is demuxed by `StdCopy` it looks at the first byte of that error that was inserted verbatim and sees that it doesn't match any known output stream (stdout or stderr), and so it returns an error which gets bubbled up to the user and displayed as `Unrecognized input header:` and the numerical representation of the first byte (`69`, usually, which is `E` as in `Error: something bad happened`)

We haven't caught this until now because errors in logging at that stage are very rare, but they do happen, as evidenced by this google search: https://www.google.com/search?q=unrecognized+input+header

It has become an issue now, however, because `docker service logs` used the same error-handling code verbatim, and errors in `docker service logs` are relatively common.

This PR fixes both `docker logs` and `docker service logs` to correctly handle errors that occur while logs are streaming.

**- How I did it**
`StdCopy` has been modified to accept another stream header, `Systemerr`, which, when demuxed, causes `StdCopy` to return an error with whatever was packed into that stream. The container router and service router have both been modified to write to the output stream with a stdwriter muxed to `Systemerr`.

**- How to verify it**
Before applying patch, do `docker service create --name test whatever && docker service logs test` and note the `Unrecognized input header: 69` error.

After applying patch, repeat and note that a real error is displayed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed rare and esoteric `docker logs` error, and fixed related common (but still esoteric) `docker service logs` error.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://cloud.githubusercontent.com/assets/2367858/22847087/c21a7c0c-ef9f-11e6-98a1-65ead5278a29.png)
