### PR TITLE
Add zsh completion for missing 'docker swarm init|update' options

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2083,7 +2083,11 @@ __docker_swarm_subcommand() {
         (init)
             _arguments $(__docker_arguments) \
                 $opts_help \
-                "($help)--advertise-addr[Advertised address]:ip\:port: " \
+                "($help)--advertise-addr=[Advertised address]:ip\:port: " \
+                "($help)--autolock[Enable manager autolocking]" \
+                "($help)--availability=[Availability of the node]:availability:(active drain pause)" \
+                "($help)--cert-expiry=[Validity period for node certificates]:duration: " \
+                "($help)--dispatcher-heartbeat=[Dispatcher heartbeat period]:duration: " \
                 "($help)*--external-ca=[Specifications of one or more certificate signing endpoints]:endpoint: " \
                 "($help)--force-new-cluster[Force create a new cluster from current state]" \
                 "($help)--listen-addr=[Listen address]:ip\:port: " \
@@ -2115,9 +2119,10 @@ __docker_swarm_subcommand() {
         (update)
             _arguments $(__docker_arguments) \
                 $opts_help \
+                "($help)--autolock[Enable manager autolocking]" \
                 "($help)--cert-expiry=[Validity period for node certificates]:duration: " \
-                "($help)*--external-ca=[Specifications of one or more certificate signing endpoints]:endpoint: " \
                 "($help)--dispatcher-heartbeat=[Dispatcher heartbeat period]:duration: " \
+                "($help)*--external-ca=[Specifications of one or more certificate signing endpoints]:endpoint: " \
                 "($help)--max-snapshots[Number of additional Raft snapshots to retain]" \
                 "($help)--snapshot-interval[Number of log entries between Raft snapshots]" \
                 "($help)--task-history-limit=[Task history retention limit]:limit: " && ret=0


### PR DESCRIPTION
Can be planned for `1.13.1`.

Signed-off-by: Steve Durrheimer <s.durrheimer@gmail.com>
