### PR TITLE
Add zsh completion for missing 'docker plugin' commands and options

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1510,6 +1510,7 @@ __docker_plugin_commands() {
         "push:Push a plugin"
         "rm:Remove a plugin"
         "set:Change settings for a plugin"
+        "upgrade:Upgrade an existing plugin"
     )
     _describe -t docker-plugin-commands "docker plugin command" _docker_plugin_subcommands
 }
@@ -1522,22 +1523,65 @@ __docker_plugin_subcommand() {
     opts_help=("(: -)--help[Print usage]")
 
     case "$words[1]" in
-        (disable|enable|inspect|ls|push|rm)
+        (disable)
             _arguments $(__docker_arguments) \
                 $opts_help \
+                "($help -f --force)"{-f,--force}"[Force the disable of an active plugin]" \
                 "($help -)1:plugin:__docker_complete_plugins" && ret=0
+            ;;
+        (enable)
+            _arguments $(__docker_arguments) \
+                $opts_help \
+                "($help)--timeout=[HTTP client timeout (in seconds)]:timeout: " \
+                "($help -)1:plugin:__docker_complete_plugins" && ret=0
+            ;;
+        (inspect)
+            _arguments $(__docker_arguments) \
+                $opts_help \
+                "($help -f --format)"{-f=,--format=}"[Format the output using the given Go template]:template: " \
+                "($help -)*:plugin:__docker_complete_plugins" && ret=0
             ;;
         (install)
             _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help)--alias=[Local name for plugin]:alias: " \
+                "($help)--disable[Do not enable the plugin on install]" \
+                "($help)--disable-content-trust[Skip image verification (default true)]" \
+                "($help)--grant-all-permissions[Grant all permissions necessary to run the plugin]" \
+                "($help -)1:plugin:__docker_complete_plugins" \
+                "($help -)*:key=value: " && ret=0
+            ;;
+        (ls|list)
+            _arguments $(__docker_arguments) \
+                $opts_help \
+                "($help)--no-trunc[Don't truncate output]" && ret=0
+            ;;
+        (push)
+            _arguments $(__docker_arguments) \
+                $opts_help \
+                "($help)--disable-content-trust[Skip image verification (default true)]" \
                 "($help -)1:plugin:__docker_complete_plugins" && ret=0
+            ;;
+        (rm|remove)
+            _arguments $(__docker_arguments) \
+                $opts_help \
+                "($help -f --force)"{-f,--force}"[Force the removal of an active plugin]" \
+                "($help -)*:plugin:__docker_complete_plugins" && ret=0
             ;;
         (set)
             _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -)1:plugin:__docker_complete_plugins" \
-                "($help-)*:key=value: " && ret=0
+                "($help -)*:key=value: " && ret=0
+            ;;
+        (upgrade)
+            _arguments $(__docker_arguments) \
+                $opts_help \
+                "($help)--disable-content-trust[Skip image verification (default true)]" \
+                "($help)--grant-all-permissions[Grant all permissions necessary to run the plugin]" \
+                "($help)--skip-remote-check[Do not check if specified remote plugin matches existing plugin image]" \
+                "($help -)1:plugin:__docker_complete_plugins" \
+                "($help -):remote: " && ret=0
             ;;
         (help)
             _arguments $(__docker_arguments) ":subcommand:__docker_plugin_commands" && ret=0


### PR DESCRIPTION
This can be planned for `1.13.1`.

Signed-off-by: Steve Durrheimer <s.durrheimer@gmail.com>