### PR TITLE
Add zsh completion for 'dockerd --default-shm-size'

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2390,6 +2390,7 @@ __docker_subcommand() {
                 "($help -D --debug)"{-D,--debug}"[Enable debug mode]" \
                 "($help)--default-gateway[Container default gateway IPv4 address]:IPv4 address: " \
                 "($help)--default-gateway-v6[Container default gateway IPv6 address]:IPv6 address: " \
+                "($help)--default-shm-size=[Default shm size for containers]:size:" \
                 "($help)*--default-ulimit=[Default ulimits for containers]:ulimit: " \
                 "($help)--disable-legacy-registry[Disable contacting legacy registries]" \
                 "($help)*--dns=[DNS server to use]:DNS: " \


### PR DESCRIPTION
ref. #29692

This can be planned for `1.14.0`.

Signed-off-by: Steve Durrheimer <s.durrheimer@gmail.com>