### PR TITLE
Add missing link in deprecated.md

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -23,7 +23,7 @@ see [Feature Deprecation Policy](https://docs.docker.com/engine/#feature-depreca
 
 ### Top-level network properties in NetworkSettings
 
-**Deprecated In Release: v1.13.0**
+**Deprecated In Release: [v1.13.0](https://github.com/docker/docker/releases/tag/v1.13.0)**
 
 **Target For Removal In Release: v1.16**
 


### PR DESCRIPTION
This fix adds a missing link in deprecated.md as `v1.13.0` has been released.
```
Deprecated In Release: [v1.13.0]...
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
