### PR TITLE
remove redundant colon introduced by mistake

### DIFF
--- a/client/volume_prune.go
+++ b/client/volume_prune.go
@@ -29,7 +29,7 @@ func (cli *Client) VolumesPrune(ctx context.Context, pruneFilters filters.Args) 
 	defer ensureReaderClosed(serverResp)
 
 	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
-		return report, fmt.Errorf("Error retrieving volume prune report:: %v", err)
+		return report, fmt.Errorf("Error retrieving volume prune report: %v", err)
 	}
 
 	return report, nil


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

remove redundant colon introduced by mistake, @thaJeztah pointed out this in pr https://github.com/docker/docker/pull/30905#discussion_r100682455,

ping @thaJeztah @vdemeester 

**- What I did**
1. remove redundant colon introduced by mistake

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

