### PR TITLE
Inspect output on service without labels is an empty map instead of null, fixes #24631

### DIFF
--- a/api/types/swarm/common.go
+++ b/api/types/swarm/common.go
@@ -17,7 +17,7 @@ type Meta struct {
 // Annotations represents how to describe an object.
 type Annotations struct {
 	Name   string            `json:",omitempty"`
-	Labels map[string]string `json:",omitempty"`
+	Labels map[string]string `json:"Labels"`
 }
 
 // Driver represents a driver (network, logging).

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -39,8 +39,7 @@ func networkFromGRPC(n *swarmapi.Network) types.Network {
 		network.UpdatedAt, _ = gogotypes.TimestampFromProto(n.Meta.UpdatedAt)
 
 		//Annotations
-		network.Spec.Name = n.Spec.Annotations.Name
-		network.Spec.Labels = n.Spec.Annotations.Labels
+		network.Spec.Annotations = annotationsFromGRPC(n.Spec.Annotations)
 
 		//DriverConfiguration
 		if n.Spec.DriverConfig != nil {

--- a/daemon/cluster/convert/node.go
+++ b/daemon/cluster/convert/node.go
@@ -30,8 +30,7 @@ func NodeFromGRPC(n swarmapi.Node) types.Node {
 	node.UpdatedAt, _ = gogotypes.TimestampFromProto(n.Meta.UpdatedAt)
 
 	//Annotations
-	node.Spec.Name = n.Spec.Annotations.Name
-	node.Spec.Labels = n.Spec.Annotations.Labels
+	node.Spec.Annotations = annotationsFromGRPC(n.Spec.Annotations)
 
 	//Description
 	if n.Description != nil {

--- a/daemon/cluster/convert/secret.go
+++ b/daemon/cluster/convert/secret.go
@@ -11,11 +11,8 @@ func SecretFromGRPC(s *swarmapi.Secret) swarmtypes.Secret {
 	secret := swarmtypes.Secret{
 		ID: s.ID,
 		Spec: swarmtypes.SecretSpec{
-			Annotations: swarmtypes.Annotations{
-				Name:   s.Spec.Annotations.Name,
-				Labels: s.Spec.Annotations.Labels,
-			},
-			Data: s.Spec.Data,
+			Annotations: annotationsFromGRPC(s.Spec.Annotations),
+			Data:        s.Spec.Data,
 		},
 	}
 

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -70,11 +70,7 @@ func serviceSpecFromGRPC(spec *swarmapi.ServiceSpec) *types.ServiceSpec {
 
 	containerConfig := spec.Task.Runtime.(*swarmapi.TaskSpec_Container).Container
 	convertedSpec := &types.ServiceSpec{
-		Annotations: types.Annotations{
-			Name:   spec.Annotations.Name,
-			Labels: spec.Annotations.Labels,
-		},
-
+		Annotations: annotationsFromGRPC(spec.Annotations),
 		TaskTemplate: types.TaskSpec{
 			ContainerSpec: containerSpecFromGRPC(containerConfig),
 			Resources:     resourcesFromGRPC(spec.Task.Resources),
@@ -234,6 +230,19 @@ func ServiceSpecToGRPC(s types.ServiceSpec) (swarmapi.ServiceSpec, error) {
 	}
 
 	return spec, nil
+}
+
+func annotationsFromGRPC(ann swarmapi.Annotations) types.Annotations {
+	a := types.Annotations{
+		Name:   ann.Name,
+		Labels: ann.Labels,
+	}
+
+	if a.Labels == nil {
+		a.Labels = make(map[string]string)
+	}
+
+	return a
 }
 
 func resourcesFromGRPC(res *swarmapi.ResourceRequirements) *types.ResourceRequirements {

--- a/daemon/cluster/convert/swarm.go
+++ b/daemon/cluster/convert/swarm.go
@@ -56,8 +56,7 @@ func SwarmFromGRPC(c swarmapi.Cluster) types.Swarm {
 	swarm.UpdatedAt, _ = gogotypes.TimestampFromProto(c.Meta.UpdatedAt)
 
 	// Annotations
-	swarm.Spec.Name = c.Spec.Annotations.Name
-	swarm.Spec.Labels = c.Spec.Annotations.Labels
+	swarm.Spec.Annotations = annotationsFromGRPC(c.Spec.Annotations)
 
 	return swarm
 }

--- a/daemon/cluster/convert/task.go
+++ b/daemon/cluster/convert/task.go
@@ -21,14 +21,11 @@ func TaskFromGRPC(t swarmapi.Task) types.Task {
 	}
 
 	task := types.Task{
-		ID: t.ID,
-		Annotations: types.Annotations{
-			Name:   t.Annotations.Name,
-			Labels: t.Annotations.Labels,
-		},
-		ServiceID: t.ServiceID,
-		Slot:      int(t.Slot),
-		NodeID:    t.NodeID,
+		ID:          t.ID,
+		Annotations: annotationsFromGRPC(t.Annotations),
+		ServiceID:   t.ServiceID,
+		Slot:        int(t.Slot),
+		NodeID:      t.NodeID,
 		Spec: types.TaskSpec{
 			ContainerSpec: containerSpecFromGRPC(containerConfig),
 			Resources:     resourcesFromGRPC(t.Spec.Resources),


### PR DESCRIPTION
Added code to output an empty map, instead of null, by the inspect command for labels of a service that has no labels. Fixes #24631 (also changes 'null' output to an empty object for other types with labels: secret, node, task, network, swarm)

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**- What I did**
The output of inspect command for labels of a service that has no labels is currently 'null', which is inconsistent with other objects, e.g. inspect output for labels of containers without labels is an empty object: {}. This PR fixes this inconsistency by changing the output to '{}' when the service has no labels.

**- How I did it**
Added code which replaces nil labels maps on service objects with an empty map, when retrieved by the daemon.

**- How to verify it**
Create a service:
$ docker service create --name nolabels nginx:alpine

Run inspect on the service, with Labels specified in format string.

- Without this PR:
$ docker service inspect --format '{{ json .Spec.Labels }}' nolabels
null

- With this PR included:
$ docker service inspect --format '{{ json .Spec.Labels }}' nolabels
{}

**- Description for the changelog**
The inspect command outputs an empty json object, i.e. {}, instead of null, for labels of a service that has no labels


**- A picture of a cute animal (not mandatory but encouraged)**

