### PR TITLE
Add note for Debian family(such as Ubuntu)

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -546,6 +546,13 @@ RUN /bin/bash -c 'source $HOME/.bashrc; echo $HOME'
 > `RUN ["/bin/bash", "-c", "echo hello"]`
 
 > **Note**:
+> '/bin/sh' in Debian family(such as Ubuntu) point to `dash` instead of `bash`,
+> in which would lead a lot of troubles. Often you have to write `RUN command args` 
+> into `RUN ["/bin/bash", "-c", "command args"]` . But you still can simply add
+> `RUN rm /bin/sh && ln -s /bin/bash /bin/sh` under `FROM some_image`, 
+> to ensure `RUN` work as other images.
+
+> **Note**:
 > The *exec* form is parsed as a JSON array, which means that
 > you must use double-quotes (") around words not single-quotes (').
 


### PR DESCRIPTION
There are many requests that demand using `/bin/bash` instead of `/bin/sh`

https://github.com/docker/docker/issues/8100
https://github.com/docker/docker/pull/7489
https://github.com/docker/docker/issues/7281

It because they are using the image of Debian family. It is inconvenient to write all command like `RUN ["/bin/bash", "-c", "python test.py"]`. 
And here is a much more simple way:

```
FROM some-image
RUN rm /bin/sh && ln -s /bin/bash /bin/sh
```

I think this is a very useful note  should be include in docs.