### PR TITLE
Force copy on make install to avoid Text file busy error

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -237,7 +237,7 @@ copy_binaries() {
 		if [ -x /usr/local/bin/docker-runc ]; then
 			echo "Copying nested executables into $dir"
 			for file in containerd containerd-shim containerd-ctr runc init proxy; do
-				cp `which "docker-$file"` "$dir/"
+				cp -f `which "docker-$file"` "$dir/"
 				if [ "$2" == "hash" ]; then
 					hash_files "$dir/docker-$file"
 				fi
@@ -252,7 +252,7 @@ install_binary() {
 	if [ "$(go env GOOS)" == "linux" ]; then
 		echo "Installing $(basename $file) to ${target}"
 		mkdir -p "$target"
-		cp -L "$file" "$target"
+		cp -f -L "$file" "$target"
 	else
 		echo "Install is only supported on linux"
 		return 1


### PR DESCRIPTION
When you attempt to manually install docker on a previous install, copying binaries will fail with `Text file busy` error if docker is already running.

Add `-f` to `cp` will fix this behavior, old binaries will be removed before copying the new ones.

This issue has been encountered on `ppc64le` arch.

