### PR TITLE
add docs to describe experimental CLI argument --squash to docker build

### DIFF
--- a/experimental/README.md
+++ b/experimental/README.md
@@ -36,6 +36,7 @@ true
  * [Ipvlan Network Drivers](vlan-networks.md)
  * [Docker Stacks and Distributed Application Bundles](docker-stacks-and-bundles.md)
  * [Checkpoint & Restore](checkpoint-restore.md)
+ * [Docker build with --squash argument](docker-build-with-squash.md)
 
 ## How to comment on an experimental feature
 


### PR DESCRIPTION
Signed-off-by: erxian <evelynhsu21@gmail.com>

Hi, This PR adds docs to describe the experimental CLI argument `--squash` to docker build, includes it's problem statement and usage, which locates in `/docker/experimental/docker-build-with-squash.md `.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**



**- A picture of a cute animal (not mandatory but encouraged)**

