### PR TITLE
Carrying #26863 — Remove deprecated `:` separator for security option

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -33,7 +33,7 @@ type copyBackend interface {
 
 // stateBackend includes functions to implement to provide container state lifecycle functionality.
 type stateBackend interface {
-	ContainerCreate(config types.ContainerCreateConfig) (container.ContainerCreateCreatedBody, error)
+	ContainerCreate(config types.ContainerCreateConfig, validators ...func(*container.Config, *container.HostConfig) error) (container.ContainerCreateCreatedBody, error)
 	ContainerKill(name string, sig uint64) error
 	ContainerPause(name string) error
 	ContainerRename(oldName, newName string) error

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -116,7 +116,7 @@ type Backend interface {
 	// ContainerAttachRaw attaches to container.
 	ContainerAttachRaw(cID string, stdin io.ReadCloser, stdout, stderr io.Writer, stream bool) error
 	// ContainerCreate creates a new Docker container and returns potential warnings
-	ContainerCreate(config types.ContainerCreateConfig) (container.ContainerCreateCreatedBody, error)
+	ContainerCreate(config types.ContainerCreateConfig, validators ...func(*container.Config, *container.HostConfig) error) (container.ContainerCreateCreatedBody, error)
 	// ContainerRm removes a container specified by `id`.
 	ContainerRm(name string, config *types.ContainerRmConfig) error
 	// Commit creates a new Docker image from an existing Docker container.

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -29,7 +29,7 @@ type Backend interface {
 	FindNetwork(idName string) (libnetwork.Network, error)
 	SetupIngress(req clustertypes.NetworkCreateRequest, nodeIP string) error
 	PullImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
-	CreateManagedContainer(config types.ContainerCreateConfig) (container.ContainerCreateCreatedBody, error)
+	CreateManagedContainer(config types.ContainerCreateConfig, validators ...func(*container.Config, *container.HostConfig) error) (container.ContainerCreateCreatedBody, error)
 	ContainerStart(name string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error
 	ContainerStop(name string, seconds *int) error
 	ContainerLogs(context.Context, string, *backend.ContainerLogsConfig, chan struct{}) error

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -217,7 +217,7 @@ func (daemon *Daemon) setHostConfig(container *container.Container, hostConfig *
 
 // verifyContainerSettings performs validation of the hostconfig and config
 // structures.
-func (daemon *Daemon) verifyContainerSettings(hostConfig *containertypes.HostConfig, config *containertypes.Config, update bool) ([]string, error) {
+func (daemon *Daemon) verifyContainerSettings(hostConfig *containertypes.HostConfig, config *containertypes.Config, update bool, validators ...func(*containertypes.Config, *containertypes.HostConfig) error) ([]string, error) {
 
 	// First perform verification of settings common across all platforms.
 	if config != nil {
@@ -300,6 +300,12 @@ func (daemon *Daemon) verifyContainerSettings(hostConfig *containertypes.HostCon
 	// do nothing
 	default:
 		return nil, fmt.Errorf("invalid restart policy '%s'", p.Name)
+	}
+
+	for _, validator := range validators {
+		if err := validator(config, hostConfig); err != nil {
+			return nil, err
+		}
 	}
 
 	// Now do platform-specific verification

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -183,6 +183,10 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 		if strings.Contains(opt, "=") {
 			con = strings.SplitN(opt, "=", 2)
 		} else if strings.Contains(opt, ":") {
+			// Note: keeping this to be retro-compatible. From API 1.27 and later, a validation is
+			// done upfront and this will fail early.
+			// But as long as we support API versions lower than 1.27, we should still be
+			// able to handle `:` at this point of the code
 			con = strings.SplitN(opt, ":", 2)
 			logrus.Warn("Security options with `:` as a separator are deprecated and will be completely unsupported in 17.04, use `=` instead.")
 		}

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -123,7 +123,7 @@ The docker login command is removing the ability to automatically register for a
 ### Separator (`:`) of `--security-opt` flag on `docker run`
 **Deprecated In Release: [v1.11.0](https://github.com/docker/docker/releases/tag/v1.11.0)**
 
-**Target For Removal In Release: v17.06**
+**Removed In Release: [v17.06](https://github.com/docker/docker/releases/)**
 
 The flag `--security-opt` doesn't use the colon separator(`:`) anymore to divide keys and values, it uses the equal symbol(`=`) for consistency with other similar flags, like `--storage-opt`.
 


### PR DESCRIPTION
Carrying #26863 — with versioning the change.

I tried to keep the "version" knowledge in `api/server` and thus making other validation changes that would need to be versionned easier to write.

- [ ] Might need an integration-test though 👼 

/cc @thaJeztah @cpuguy83 @jhowardmsft @justincormack @AkihiroSuda 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
