### PR TITLE
Fix bash completion for `--log-opt mode`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -790,7 +790,7 @@ __docker_complete_log_driver_options() {
 			return
 			;;
 		mode)
-			COMPREPLY=( $( compgen -W "blocking nonblocking" -- "${cur##*=}" ) )
+			COMPREPLY=( $( compgen -W "blocking non-blocking" -- "${cur##*=}" ) )
 			return
 			;;
 		syslog-address)


### PR DESCRIPTION
Ref: https://github.com/docker/docker/pull/30946#discussion_r100803777, #28762 
@LK4D4 PTAL