### PR TITLE
Update docker/distribution to b38e5838b7b2f2ad48e06ec4b500011976080621

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -44,7 +44,7 @@ github.com/boltdb/bolt fff57c100f4dea1905678da7e90d92429dff2904
 github.com/miekg/dns 75e6e86cc601825c5dbcd4e0c209eab180997cd7
 
 # get graph and distribution packages
-github.com/docker/distribution 545102ea07aa9796f189d82f606b7c27d7aa3ed3
+github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
 github.com/vbatts/tar-split v0.10.1
 github.com/opencontainers/go-digest a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb
 

--- a/vendor/github.com/docker/distribution/reference/regexp.go
+++ b/vendor/github.com/docker/distribution/reference/regexp.go
@@ -20,15 +20,15 @@ var (
 		optional(repeated(separatorRegexp, alphaNumericRegexp)))
 
 	// domainComponentRegexp restricts the registry domain component of a
-	// repository name to start with a component as defined by domainRegexp
+	// repository name to start with a component as defined by DomainRegexp
 	// and followed by an optional port.
 	domainComponentRegexp = match(`(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`)
 
-	// domainRegexp defines the structure of potential domain components
+	// DomainRegexp defines the structure of potential domain components
 	// that may be part of image names. This is purposely a subset of what is
 	// allowed by DNS to ensure backwards compatibility with Docker image
 	// names.
-	domainRegexp = expression(
+	DomainRegexp = expression(
 		domainComponentRegexp,
 		optional(repeated(literal(`.`), domainComponentRegexp)),
 		optional(literal(`:`), match(`[0-9]+`)))
@@ -51,14 +51,14 @@ var (
 	// regexp has capturing groups for the domain and name part omitting
 	// the separating forward slash from either.
 	NameRegexp = expression(
-		optional(domainRegexp, literal(`/`)),
+		optional(DomainRegexp, literal(`/`)),
 		nameComponentRegexp,
 		optional(repeated(literal(`/`), nameComponentRegexp)))
 
 	// anchoredNameRegexp is used to parse a name value, capturing the
 	// domain and trailing components.
 	anchoredNameRegexp = anchored(
-		optional(capture(domainRegexp), literal(`/`)),
+		optional(capture(DomainRegexp), literal(`/`)),
 		capture(nameComponentRegexp,
 			optional(repeated(literal(`/`), nameComponentRegexp))))
 


### PR DESCRIPTION
This fix updates docker/distribution to
`b38e5838b7b2f2ad48e06ec4b500011976080621`
 from
`545102ea07aa9796f189d82f606b7c27d7aa3ed3`

Changes related to docker issue:
1. Validate insecure registry (`--insecure-registry`) values (PR #30746)

This fix is needed for #30746.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
