### PR TITLE
Changing fail-fast strategy of inspect command to show all the errors…

### DIFF
--- a/cli/command/inspect/inspector.go
+++ b/cli/command/inspect/inspector.go
@@ -60,17 +60,16 @@ func Inspect(out io.Writer, references []string, tmplStr string, getRef GetRefFu
 		return cli.StatusError{StatusCode: 64, Status: err.Error()}
 	}
 
-	var inspectErr error
+	var inspectErrs []string
 	for _, ref := range references {
 		element, raw, err := getRef(ref)
 		if err != nil {
-			inspectErr = err
-			break
+			inspectErrs = append(inspectErrs, err.Error())
+			continue
 		}
 
 		if err := inspector.Inspect(element, raw); err != nil {
-			inspectErr = err
-			break
+			inspectErrs = append(inspectErrs, err.Error())
 		}
 	}
 
@@ -78,8 +77,8 @@ func Inspect(out io.Writer, references []string, tmplStr string, getRef GetRefFu
 		logrus.Errorf("%s\n", err)
 	}
 
-	if inspectErr != nil {
-		return cli.StatusError{StatusCode: 1, Status: inspectErr.Error()}
+	if len(inspectErrs) > 0 {
+		return cli.StatusError{StatusCode: 1, Status: strings.Join(inspectErrs, "\n")}
 	}
 	return nil
 }


### PR DESCRIPTION
… occurred

Signed-off-by: Bhumika Bayani bhumikabayani@gmail.com
fixes #30599 

**- What I did**
Currently we break on the first occurrence of error. Changing this to use a string list to accumulate all the errors and then returning a single object at the end which shows all the errors.

**- How to verify it**
1. Run:
docker inspect -type container <existing id1> <non existing id1>  <existing id2> <non existing id2>  
2. Verify that error is shown for both non-existing container ids.

**- Description for the changelog**
Docker inspect will not fail on first occurrence error and instead show errors for all the containers that have failed

**- A picture of a cute animal (not mandatory but encouraged)**
![adorable-giraffe-family](https://cloud.githubusercontent.com/assets/10231863/22930487/859cd988-f2e6-11e6-8cf8-0b42a36f4170.jpg)

