### PR TITLE
Set 0444 as default secret mode in stack deploy

### DIFF
--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -217,17 +217,25 @@ func convertServiceSecrets(
 		if gid == "" {
 			gid = "0"
 		}
+		mode := secret.Mode
+		if mode == nil {
+			mode = uint32Ptr(0444)
+		}
 
 		opts = append(opts, &types.SecretRequestOption{
 			Source: source,
 			Target: target,
 			UID:    uid,
 			GID:    gid,
-			Mode:   os.FileMode(secret.Mode),
+			Mode:   os.FileMode(*mode),
 		})
 	}
 
 	return servicecli.ParseSecrets(client, opts)
+}
+
+func uint32Ptr(value uint32) *uint32 {
+	return &value
 }
 
 func convertExtraHosts(extraHosts map[string]string) []string {

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -229,7 +229,7 @@ type ServiceSecretConfig struct {
 	Target string
 	UID    string
 	GID    string
-	Mode   uint32
+	Mode   *uint32
 }
 
 // UlimitsConfig the ulimit configuration


### PR DESCRIPTION
Change the default secret mode to match the default one used in
`service` subcommands.

Fix #30991 

/cc @dnephin @mstanleyjones @nathanleclaire @aaronlehmann @ehazlett @thaJeztah 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
