### PR TITLE
fix docker daemon reload bug

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1160,7 +1160,7 @@ func (daemon *Daemon) reloadClusterDiscovery(conf *config.Config) error {
 	}
 
 	// check discovery modifications
-	if !config.ModifiedDiscoverySettings(daemon.configStore, newAdvertise, newClusterStore, conf.ClusterOpts) {
+	if !config.ModifiedDiscoverySettings(daemon.configStore, newClusterStore, newAdvertise, conf.ClusterOpts) {
 		return nil
 	}
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix daemon reload discovery config bug. 
**- How I did it**
Fix the wrong  arguments in [modifiedDiscoverySettings](https://github.com/docker/docker/blob/master/daemon/daemon.go#L1163) calling of [ModifiedDiscoverySettings](https://github.com/docker/docker/blob/master/daemon/config/config.go#L504-L507) function.
**- How to verify it**
Try reload docker daemon by `/etc/docker/daemon.json ` with the same discovery config(cluster-store, advertise).
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```diff
-	if !modifiedDiscoverySettings(daemon.configStore, newAdvertise, newClusterStore, config.ClusterOpts) {
+	if !modifiedDiscoverySettings(daemon.configStore, newClusterStore, newAdvertise, config.ClusterOpts) {
```

**- A picture of a cute animal (not mandatory but encouraged)**

![](http://ichef.bbci.co.uk/news/320/cpsprodpb/169F6/production/_91026629_gettyimages-519508400.jpg)