### PR TITLE
fix docker stack omit external volume's "nocopy" parameter

### DIFF
--- a/cli/compose/convert/volume.go
+++ b/cli/compose/convert/volume.go
@@ -75,6 +75,9 @@ func convertVolumeToMount(volumeSpec string, stackVolumes volumes, namespace Nam
 
 	var volumeOptions *mount.VolumeOptions
 	if stackVolume.External.Name != "" {
+		volumeOptions = &mount.VolumeOptions{
+			NoCopy: isNoCopy(mode),
+		}
 		source = stackVolume.External.Name
 	} else {
 		volumeOptions = &mount.VolumeOptions{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix docker stack omit volume's "nocopy" parameter.
**- How I did it**
Process external volume mount's "nocopy" parameter when create stack's services.
**- How to verify it**
deploy stack file link as follow:   
```yaml
version: "3"
services:
  test:
    image: 'busybox'
    command: sh -c "sleep 1000"
    volumes:
      - nfs:/data:nocopy
volumes:
  nfs:
    external: true
```

Then Inspect the `test` service's  task container, should got the "Mount" Mode has "nocopy" option.
**- Description for the changelog**
Process external volume mount's "nocopy" parameter when create stack's services.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![](http://www.aspca.org/sites/default/files/cat-care_cat-nutrition-tips_overweight_body4_left.jpg)
