### PR TITLE
Flags for specifying bind mount consistency

### DIFF
--- a/api/types/mount/mount.go
+++ b/api/types/mount/mount.go
@@ -23,9 +23,10 @@ type Mount struct {
 	// Source specifies the name of the mount. Depending on mount type, this
 	// may be a volume name or a host path, or even ignored.
 	// Source is not supported for tmpfs (must be an empty value)
-	Source   string `json:",omitempty"`
-	Target   string `json:",omitempty"`
-	ReadOnly bool   `json:",omitempty"`
+	Source      string      `json:",omitempty"`
+	Target      string      `json:",omitempty"`
+	ReadOnly    bool        `json:",omitempty"`
+	Consistency Consistency `json:",omitempty"`
 
 	BindOptions   *BindOptions   `json:",omitempty"`
 	VolumeOptions *VolumeOptions `json:",omitempty"`
@@ -59,6 +60,20 @@ var Propagations = []Propagation{
 	PropagationRSlave,
 	PropagationSlave,
 }
+
+// Consistency represents the consistency requirements of a mount.
+type Consistency string
+
+const (
+	// ConsistencyFull guarantees bind-mount-like consistency
+	ConsistencyFull Consistency = "consistent"
+	// ConsistencyCached mounts can cache read data and FS structure
+	ConsistencyCached Consistency = "cached"
+	// ConsistencyDelegated mounts can cache read and written data and structure
+	ConsistencyDelegated Consistency = "delegated"
+	// ConsistencyDefault provides "consistent" behavior unless overridden
+	ConsistencyDefault Consistency = "default"
+)
 
 // BindOptions defines options specific to mounts of type "bind".
 type BindOptions struct {

--- a/opts/mount.go
+++ b/opts/mount.go
@@ -95,6 +95,8 @@ func (m *MountOpt) Set(value string) error {
 			if err != nil {
 				return fmt.Errorf("invalid value for %s: %s", key, value)
 			}
+		case "consistency":
+			mount.Consistency = mounttypes.Consistency(strings.ToLower(value))
 		case "bind-propagation":
 			bindOptions().Propagation = mounttypes.Propagation(strings.ToLower(value))
 		case "volume-nocopy":

--- a/volume/volume_unix.go
+++ b/volume/volume_unix.go
@@ -30,6 +30,13 @@ var labelModes = map[string]bool{
 	"z": true,
 }
 
+// consistency modes
+var consistencyModes = map[mounttypes.Consistency]bool{
+	mounttypes.ConsistencyFull:      true,
+	mounttypes.ConsistencyCached:    true,
+	mounttypes.ConsistencyDelegated: true,
+}
+
 // BackwardsCompatible decides whether this mount point can be
 // used in old versions of Docker or not.
 // Only bind mounts and local volumes can be used in old versions of Docker.
@@ -62,6 +69,7 @@ func ValidMountMode(mode string) bool {
 	labelModeCount := 0
 	propagationModeCount := 0
 	copyModeCount := 0
+	consistencyModeCount := 0
 
 	for _, o := range strings.Split(mode, ",") {
 		switch {
@@ -73,13 +81,15 @@ func ValidMountMode(mode string) bool {
 			propagationModeCount++
 		case copyModeExists(o):
 			copyModeCount++
+		case consistencyModes[mounttypes.Consistency(o)]:
+			consistencyModeCount++
 		default:
 			return false
 		}
 	}
 
 	// Only one string for each mode is allowed.
-	if rwModeCount > 1 || labelModeCount > 1 || propagationModeCount > 1 || copyModeCount > 1 {
+	if rwModeCount > 1 || labelModeCount > 1 || propagationModeCount > 1 || copyModeCount > 1 || consistencyModeCount > 1 {
 		return false
 	}
 	return true


### PR DESCRIPTION
This PR introduces a small change to the Docker CLI as part of a larger project to address some longstanding file sharing performance on Docker for Mac ([[1]][fs-performance-forums], [[2]][fs-performance-issues]).

The poor performance of bind mounts in Docker for Mac for some applications arises from [osxfs][osxfs] ensuring perfectly consistent views of bind mounts between container and host: reads, writes and events from within a container are propagated synchronously to the host, and vice versa.

Perfect consistency is the right default, but for some workloads where it's unnecessary it puts a low ceiling on performance.  To improve performance for such workloads, we plan to allow the user to relax consistency guarantees for individual bind-mounted directories.

The full details of the proposal are available [here][proposal].  This patch includes one small piece of the work, namely additional bind options `cached`, `delegated`, `consistent`, for selecting consistency modes.  Although the immediate aim is improving `osxfs` performance, these options are not macOS-specific; they give a general view of consistency that applies to many systems, both for bind mounts and volume plugins.  For example,
 * essentially the same consistency taxonomy is used by Infinit
 * the same approach may be used in future to improve performance on Windows
 * on systems that directly expose the host file system to a container, such as Linux, ignoring the options is an acceptable implementation of all three modes.  (Even on Linux a container runtime could in principle take advantage of the relaxed semantics associated with `delegated` and `cached`.)

[osxfs]: https://docs.docker.com/docker-for-mac/osxfs/
[fs-performance-forums]: https://forums.docker.com/t/file-access-in-mounted-volumes-extremely-slow-cpu-bound/8076
[fs-performance-issues]: https://github.com/docker/for-mac/issues/77
[proposal]: https://gist.github.com/yallop/d4af9dd1bb33ae61d48adf86692cdf9e
