### PR TITLE
Extend 'destination' information on volume mount

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -185,7 +185,7 @@ func (container *Container) CopyImagePathContent(v volume.Volume, destination st
 	}
 
 	id := stringid.GenerateNonCryptoID()
-	path, err := v.Mount(id)
+	path, err := v.Mount(id, destination)
 	if err != nil {
 		return err
 	}

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -154,8 +154,8 @@ func (a *volumeAdapter) CachedPath() string {
 	return a.eMount
 }
 
-func (a *volumeAdapter) Mount(id string) (string, error) {
-	mountpoint, err := a.proxy.Mount(a.name, id)
+func (a *volumeAdapter) Mount(id string, dest string) (string, error) {
+	mountpoint, err := a.proxy.Mount(a.name, id, dest)
 	a.eMount = hostPath(a.baseHostPath, mountpoint)
 	return a.eMount, err
 }

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -38,7 +38,7 @@ type volumeDriver interface {
 	// Get the mountpoint of the given volume
 	Path(name string) (mountpoint string, err error)
 	// Mount the given volume and return the mountpoint
-	Mount(name, id string) (mountpoint string, err error)
+	Mount(name, id string, dest string) (mountpoint string, err error)
 	// Unmount the given volume
 	Unmount(name, id string) (err error)
 	// List lists all the volumes known to the driver

--- a/volume/drivers/proxy.go
+++ b/volume/drivers/proxy.go
@@ -100,8 +100,9 @@ func (pp *volumeDriverProxy) Path(name string) (mountpoint string, err error) {
 }
 
 type volumeDriverProxyMountRequest struct {
-	Name string
-	ID   string
+	Name        string
+	ID          string
+	Destination string
 }
 
 type volumeDriverProxyMountResponse struct {
@@ -109,7 +110,7 @@ type volumeDriverProxyMountResponse struct {
 	Err        string
 }
 
-func (pp *volumeDriverProxy) Mount(name string, id string) (mountpoint string, err error) {
+func (pp *volumeDriverProxy) Mount(name string, id string, dest string) (mountpoint string, err error) {
 	var (
 		req volumeDriverProxyMountRequest
 		ret volumeDriverProxyMountResponse
@@ -117,6 +118,7 @@ func (pp *volumeDriverProxy) Mount(name string, id string) (mountpoint string, e
 
 	req.Name = name
 	req.ID = id
+	req.Destination = dest
 	if err = pp.Call("VolumeDriver.Mount", req, &ret); err != nil {
 		return
 	}

--- a/volume/drivers/proxy_test.go
+++ b/volume/drivers/proxy_test.go
@@ -73,7 +73,7 @@ func TestVolumeRequestError(t *testing.T) {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
 
-	_, err = driver.Mount("volume", "123")
+	_, err = driver.Mount("volume", "123", "/mnt")
 	if err == nil {
 		t.Fatal("Expected error, was nil")
 	}

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -306,7 +306,7 @@ func (v *localVolume) Path() string {
 }
 
 // Mount implements the localVolume interface, returning the data location.
-func (v *localVolume) Mount(id string) (string, error) {
+func (v *localVolume) Mount(id string, dest string) (string, error) {
 	v.m.Lock()
 	defer v.m.Unlock()
 	if v.opts != nil {

--- a/volume/local/local_test.go
+++ b/volume/local/local_test.go
@@ -204,7 +204,7 @@ func TestCreateWithOpts(t *testing.T) {
 	}
 	v := vol.(*localVolume)
 
-	dir, err := v.Mount("1234")
+	dir, err := v.Mount("1234", "/mnt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -248,7 +248,7 @@ func TestCreateWithOpts(t *testing.T) {
 	}
 
 	// test double mount
-	if _, err := v.Mount("1234"); err != nil {
+	if _, err := v.Mount("1234", "/mnt"); err != nil {
 		t.Fatal(err)
 	}
 	if v.active.count != 2 {
@@ -337,7 +337,7 @@ func TestRealodNoOpts(t *testing.T) {
 		if lv.opts != nil {
 			t.Fatalf("expected opts to be nil, got: %v", lv.opts)
 		}
-		if _, err := lv.Mount("1234"); err != nil {
+		if _, err := lv.Mount("1234", "/mnt"); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/volume/testutils/testutils.go
+++ b/volume/testutils/testutils.go
@@ -19,7 +19,7 @@ func (NoopVolume) DriverName() string { return "noop" }
 func (NoopVolume) Path() string { return "noop" }
 
 // Mount mounts the volume in the container
-func (NoopVolume) Mount(_ string) (string, error) { return "noop", nil }
+func (NoopVolume) Mount(_ string, _ string) (string, error) { return "noop", nil }
 
 // Unmount unmounts the volume from the container
 func (NoopVolume) Unmount(_ string) error { return nil }
@@ -48,7 +48,7 @@ func (f FakeVolume) DriverName() string { return f.driverName }
 func (FakeVolume) Path() string { return "fake" }
 
 // Mount mounts the volume in the container
-func (FakeVolume) Mount(_ string) (string, error) { return "fake", nil }
+func (FakeVolume) Mount(_ string, _ string) (string, error) { return "fake", nil }
 
 // Unmount unmounts the volume from the container
 func (FakeVolume) Unmount(_ string) error { return nil }

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -61,7 +61,7 @@ type Volume interface {
 	Path() string
 	// Mount mounts the volume and returns the absolute path to
 	// where it can be consumed.
-	Mount(id string) (string, error)
+	Mount(id string, dest string) (string, error)
 	// Unmount unmounts the volume when it is no longer in use.
 	Unmount(id string) error
 	// Status returns low-level status information about a volume
@@ -143,7 +143,7 @@ func (m *MountPoint) Setup(mountLabel string, rootUID, rootGID int) (path string
 		if id == "" {
 			id = stringid.GenerateNonCryptoID()
 		}
-		path, err := m.Volume.Mount(id)
+		path, err := m.Volume.Mount(id, m.Destination)
 		if err != nil {
 			return "", errors.Wrapf(err, "error while mounting volume '%s'", m.Source)
 		}


### PR DESCRIPTION
This help plugin drivers to maintain non-linear volumes,
such as:
**1. grouping volumes with same prefix;**
**2. able to support quota/Qos for not only per-volume level but also group level;**
**3. reduce system resources (turning 1-mount for 1-volume into 1-mount for 1-group;**
**4. basic attribution if we want to realize default volume options in the furture;**
**5. help to provide as an identify value if volume name is anonymous;**

It changes: /Volume.Mount
	{"ID":"..", "Name":".."}
into:
	{"ID":"..", "Name":"..", "Destination":"/data-1"}

/Volume.Unmount doesn't need this since /Volume.Mount is already able to handle this mapping with the help of unique ID value.

Signed-off-by: CUI Wei <ghostplant@qq.com>
