### PR TITLE
Windows: Wait for OOBE to prevent crashing during host update

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -260,6 +260,9 @@ func (cli *DaemonCli) start(opts daemonOptions) (err error) {
 		<-stopc // wait for daemonCli.start() to return
 	})
 
+	// Notify that the API is active, but before daemon is set up.
+	preNotifySystem()
+
 	d, err := daemon.NewDaemon(cli.Config, registryService, containerdRemote)
 	if err != nil {
 		return fmt.Errorf("Error starting daemon: %v", err)

--- a/cmd/dockerd/daemon_freebsd.go
+++ b/cmd/dockerd/daemon_freebsd.go
@@ -1,5 +1,9 @@
 package main
 
+// preNotifySystem sends a message to the host when the API is active, but before the daemon is
+func preNotifySystem() {
+}
+
 // notifySystem sends a message to the host when the server is ready to be used
 func notifySystem() {
 }

--- a/cmd/dockerd/daemon_linux.go
+++ b/cmd/dockerd/daemon_linux.go
@@ -4,6 +4,10 @@ package main
 
 import systemdDaemon "github.com/coreos/go-systemd/daemon"
 
+// preNotifySystem sends a message to the host when the API is active, but before the daemon is
+func preNotifySystem() {
+}
+
 // notifySystem sends a message to the host when the server is ready to be used
 func notifySystem() {
 	// Tell the init daemon we are accepting requests

--- a/cmd/dockerd/daemon_solaris.go
+++ b/cmd/dockerd/daemon_solaris.go
@@ -46,6 +46,10 @@ func getDaemonConfDir(_ string) string {
 func (cli *DaemonCli) setupConfigReloadTrap() {
 }
 
+// preNotifySystem sends a message to the host when the API is active, but before the daemon is
+func preNotifySystem() {
+}
+
 // notifySystem sends a message to the host when the server is ready to be used
 func notifySystem() {
 }

--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -29,14 +29,20 @@ func getDaemonConfDir(root string) string {
 	return filepath.Join(root, `\config`)
 }
 
-// notifySystem sends a message to the host when the server is ready to be used
-func notifySystem() {
+// preNotifySystem sends a message to the host when the API is active, but before the daemon is
+func preNotifySystem() {
+	// start the service now to prevent timeouts waiting for daemon to start
+	// but still (eventually) complete all requests that are sent after this
 	if service != nil {
 		err := service.started()
 		if err != nil {
 			logrus.Fatal(err)
 		}
 	}
+}
+
+// notifySystem sends a message to the host when the server is ready to be used
+func notifySystem() {
 }
 
 // notifyShutdown is called after the daemon shuts down but before the process exits.

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
+	"unsafe"
 
 	"github.com/Microsoft/hcsshim"
 	"github.com/Sirupsen/logrus"
@@ -35,6 +37,8 @@ const (
 	windowsMinCPUPercent = 1
 	windowsMaxCPUPercent = 100
 	windowsMinCPUCount   = 1
+
+	errInvalidState = syscall.Errno(0x139F)
 )
 
 func getBlkioWeightDevices(config *containertypes.HostConfig) ([]blkiodev.WeightDevice, error) {
@@ -229,7 +233,8 @@ func checkSystem() error {
 	if vmcompute.Load() != nil {
 		return fmt.Errorf("Failed to load vmcompute.dll. Ensure that the Containers role is installed.")
 	}
-	return nil
+
+	return waitOOBEComplete()
 }
 
 // configureKernelSecuritySupport configures and validate security support for the kernel
@@ -599,5 +604,37 @@ func (daemon *Daemon) verifyVolumesInfo(container *container.Container) error {
 }
 
 func (daemon *Daemon) setupSeccompProfile() error {
+	return nil
+}
+
+func waitOOBEComplete() error {
+	kernel32 := windows.NewLazySystemDLL("kernel32.dll")
+	registerWaitUntilOOBECompleted := kernel32.NewProc("RegisterWaitUntilOOBECompleted")
+	unregisterWaitUntilOOBECompleted := kernel32.NewProc("UnregisterWaitUntilOOBECompleted")
+
+	callbackChan := make(chan struct{})
+	callbackFunc := func(uintptr) uintptr {
+		close(callbackChan)
+		return 0
+	}
+	callbackFuncPtr := syscall.NewCallback(callbackFunc)
+
+	var callbackHandle syscall.Handle
+	ret, _, err := registerWaitUntilOOBECompleted.Call(callbackFuncPtr, 0, uintptr(unsafe.Pointer(&callbackHandle)))
+	if ret == 0 {
+		if err == errInvalidState {
+			return nil
+		}
+		return fmt.Errorf("failed to register OOBEComplete callback. Error: %v", err)
+	}
+
+	// Wait for the callback when OOBE is finished
+	<-callbackChan
+
+	ret, _, err = unregisterWaitUntilOOBECompleted.Call(uintptr(callbackHandle))
+	if ret == 0 {
+		return fmt.Errorf("failed to unregister OOBEComplete callback. Error: %v", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Darren Stahl <darst@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Prevent a Daemon crash during host update.

**- How I did it**

Some services Docker depends on are not active during a host update. This PR holds daemon initialization until after a host update is completed.

It also notifies the Windows Service Control Manager that the service has started as soon as the API is active to prevent service start timeouts waiting for OOBE or daemon initialization.

**- How to verify it**

Install Docker service on a machine that receives manual OS updates, such as a Windows Insider machine. After an update is installed, the daemon was not running, with an SCM log stating that it terminated unexpectedly. With this update, the daemon will be running.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Prevent crash during Windows host update.

/cc @jhowardmsft @jstarks 
