### PR TITLE
Reset stdin config before running build actions

### DIFF
--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -419,6 +419,10 @@ func (b *Builder) processImageFrom(img builder.Image) error {
 	onBuildTriggers := b.runConfig.OnBuild
 	b.runConfig.OnBuild = []string{}
 
+	// Reset stdin settings as all build actions run without stdin
+	b.runConfig.OpenStdin = false
+	b.runConfig.StdinOnce = false
+
 	// parse the ONBUILD triggers by invoking the parser
 	for _, step := range onBuildTriggers {
 		ast, err := parser.Parse(strings.NewReader(step), &b.directive)


### PR DESCRIPTION
fixes #31051

When base image is created with `docker commit`, stdin might be open in the `containerConfig`. When build is attempted on top of that image this config would carry on to the build actions and result a cache invalidation because all config that uses `stdin` is uncomparable https://github.com/docker/docker/blob/df5d909ac95556c861ef27560a141748c84fb5dd/image/cache/compare.go#L9.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
