### PR TITLE
fix incorect login client credential save when the registry is the default docker registry

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
+	"github.com/docker/docker/registry"
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +50,7 @@ func runLogin(dockerCli *command.DockerCli, opts loginOptions) error {
 		serverAddress string
 		authServer    = command.ElectAuthServer(ctx, dockerCli)
 	)
-	if opts.serverAddress != "" {
+	if opts.serverAddress != "" && opts.serverAddress != registry.DefaultNamespace {
 		serverAddress = opts.serverAddress
 	} else {
 		serverAddress = authServer


### PR DESCRIPTION
closes #30779

- What I did
compare the user login url with the default registry and if the same just ignore

- How I did it
parsing the url using url.Parse and compare it with the default docker registry
- How to verify it
docker login index.docker.io
docker login docker.io

in the ~/.docker/config.json
before the fix the login will succeed , but docker pull/push for private images will fail as  the saved auth is not saved as the default docker registry url

"auths": {
"index.docker.io": {
"auth": "xxxxxxx"
}
}

after the fix any url that is the default docker registry will be saved properly so it can be used with docker push/pull for private images

"auths": {
"https://index.docker.io/v1/": {
"auth": "xxxxxxxx"
}
}

some more discussions
https://github.com/docker/docker/pull/30831