### PR TITLE
Fix cpu spin waiting for log write events

### DIFF
--- a/daemon/logger/jsonfilelog/read.go
+++ b/daemon/logger/jsonfilelog/read.go
@@ -256,9 +256,12 @@ func followLogs(f *os.File, logWatcher *logger.LogWatcher, notifyRotate chan int
 
 	handleDecodeErr := func(err error) error {
 		if err == io.EOF {
-			for err := waitRead(); err != nil; {
+			for {
+				err := waitRead()
+				if err == nil {
+					break
+				}
 				if err == errRetry {
-					// retry the waitRead
 					continue
 				}
 				return err


### PR DESCRIPTION
This loop is not ever going to return since it's never actually setting
the `err` var except on the first iteration.

Fixes #31060