### PR TITLE
Release the network attachment on allocation failure

### DIFF
--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -176,18 +176,31 @@ func (c *Cluster) AttachNetwork(target string, containerID string, addresses []s
 	close(attachCompleteCh)
 	c.mu.Unlock()
 
-	logrus.Debugf("Successfully attached to network %s with tid %s", target, taskID)
+	logrus.Debugf("Successfully attached to network %s with task id %s", target, taskID)
+
+	release := func() {
+		ctx, cancel := c.getRequestContext()
+		defer cancel()
+		if err := agent.ResourceAllocator().DetachNetwork(ctx, taskID); err != nil {
+			logrus.Errorf("Failed remove network attachment %s to network %s on allocation failure: %v",
+				taskID, target, err)
+		}
+	}
 
 	var config *network.NetworkingConfig
 	select {
 	case config = <-attachWaitCh:
 	case <-ctx.Done():
+		release()
 		return nil, fmt.Errorf("attaching to network failed, make sure your network options are correct and check manager logs: %v", ctx.Err())
 	}
 
 	c.mu.Lock()
 	c.attachers[aKey].config = config
 	c.mu.Unlock()
+
+	logrus.Debugf("Successfully allocated resources on network %s for task id %s", target, taskID)
+
 	return config, nil
 }
 


### PR DESCRIPTION
- otherwise the attachment task will stay in store and
  consume IP addressess and there is no way to remove it.

Fixes #31066


**- A picture of a cute animal (not mandatory but encouraged)**

![vez](https://cloud.githubusercontent.com/assets/10080882/23007135/4a05b342-f3bb-11e6-9182-76d0715fc537.jpg)