### PR TITLE
Typo fixed and this time I provide my cSpell.json

### DIFF
--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -18,7 +18,7 @@ type ContainerAttachConfig struct {
 	Stream     bool
 	DetachKeys string
 
-	// Used to signify that streams are multiplexed and therefore need a StdWriter to encode stdout/sderr messages accordingly.
+	// Used to signify that streams are multiplexed and therefore need a StdWriter to encode stdout/stderr messages accordingly.
 	// TODO @cpuguy83: This shouldn't be needed. It was only added so that http and websocket endpoints can use the same function, and the websocket function was not using a stdwriter prior to this change...
 	// HOWEVER, the websocket endpoint is using a single stream and SHOULD be encoded with stdout/stderr as is done for HTTP since it is still just a single stream.
 	// Since such a change is an API change unrelated to the current changeset we'll keep it as is here and change separately.

--- a/builder/dockerfile/bflag_test.go
+++ b/builder/dockerfile/bflag_test.go
@@ -179,9 +179,9 @@ func TestBuilderFlags(t *testing.T) {
 	}
 
 	if flStr1.Value != "BYE" {
-		t.Fatalf("Teset %s, str1 should be BYE", bf.Args)
+		t.Fatalf("Test %s, str1 should be BYE", bf.Args)
 	}
 	if !flBool1.IsTrue() {
-		t.Fatalf("Teset %s, bool1 should be true", bf.Args)
+		t.Fatalf("Test %s, bool1 should be true", bf.Args)
 	}
 }

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -724,7 +724,7 @@ func stopSignal(b *Builder, args []string, attributes map[string]bool, original 
 // ARG name[=value]
 //
 // Adds the variable foo to the trusted list of variables that can be passed
-// to builder using the --build-arg flag for expansion/subsitution or passing to 'run'.
+// to builder using the --build-arg flag for expansion/substitution or passing to 'run'.
 // Dockerfile author may optionally set a default value of this variable.
 func arg(b *Builder, args []string, attributes map[string]bool, original string) error {
 	if len(args) != 1 {

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -210,7 +210,7 @@ func TestFrom(t *testing.T) {
 		}
 
 		if b.image != "" {
-			t.Fatalf("Image shoule be empty, got: %s", b.image)
+			t.Fatalf("Image should be empty, got: %s", b.image)
 		}
 
 		if b.noBaseImage != true {

--- a/builder/dockerfile/internals_test.go
+++ b/builder/dockerfile/internals_test.go
@@ -16,7 +16,7 @@ func TestEmptyDockerfile(t *testing.T) {
 
 	createTestTempFile(t, contextDir, builder.DefaultDockerfileName, "", 0777)
 
-	readAndCheckDockerfile(t, "emptyDockefile", contextDir, "", "The Dockerfile (Dockerfile) cannot be empty")
+	readAndCheckDockerfile(t, "emptyDockerfile", contextDir, "", "The Dockerfile (Dockerfile) cannot be empty")
 }
 
 func TestSymlinkDockerfile(t *testing.T) {

--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -40,7 +40,7 @@ type Node struct {
 // parsing directives.
 type Directive struct {
 	EscapeToken           rune           // Current escape token
-	LineContinuationRegex *regexp.Regexp // Current line contination regex
+	LineContinuationRegex *regexp.Regexp // Current line continuation regex
 	LookingForDirectives  bool           // Whether we are currently looking for directives
 	EscapeSeen            bool           // Whether the escape directive has been seen
 }

--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -32,7 +32,7 @@ func newExecOptions() *execOptions {
 	}
 }
 
-// NewExecCommand creats a new cobra.Command for `docker exec`
+// NewExecCommand creates a new cobra.Command for `docker exec`
 func NewExecCommand(dockerCli *command.DockerCli) *cobra.Command {
 	opts := newExecOptions()
 

--- a/cli/command/formatter/reflect.go
+++ b/cli/command/formatter/reflect.go
@@ -22,7 +22,7 @@ func marshalMap(x interface{}) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("expected a pointer to a struct, got %v", val.Kind())
 	}
 	if val.IsNil() {
-		return nil, fmt.Errorf("expxected a pointer to a struct, got nil pointer")
+		return nil, fmt.Errorf("expected a pointer to a struct, got nil pointer")
 	}
 	valElem := val.Elem()
 	if valElem.Kind() != reflect.Struct {

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -120,7 +120,7 @@ func NewBuildCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 // lastProgressOutput is the same as progress.Output except
 // that it only output with the last update. It is used in
-// non terminal scenarios to depresss verbose messages
+// non terminal scenarios to suppress verbose messages
 type lastProgressOutput struct {
 	output progress.Output
 }

--- a/cli/command/image/build/context.go
+++ b/cli/command/image/build/context.go
@@ -91,7 +91,7 @@ func GetContextFromReader(r io.ReadCloser, dockerfileName string) (out io.ReadCl
 	// Input should be read as a Dockerfile.
 	tmpDir, err := ioutil.TempDir("", "docker-build-context-")
 	if err != nil {
-		return nil, "", fmt.Errorf("unbale to create temporary context directory: %v", err)
+		return nil, "", fmt.Errorf("unable to create temporary context directory: %v", err)
 	}
 
 	f, err := os.Create(filepath.Join(tmpDir, DefaultDockerfileName))

--- a/cli/command/network/create.go
+++ b/cli/command/network/create.go
@@ -106,7 +106,7 @@ func runCreate(dockerCli *command.DockerCli, opts createOptions) error {
 // Consolidates the ipam configuration as a group from different related configurations
 // user can configure network with multiple non-overlapping subnets and hence it is
 // possible to correlate the various related parameters and consolidate them.
-// consoidateIpam consolidates subnets, ip-ranges, gateways and auxiliary addresses into
+// consolidateIpam consolidates subnets, ip-ranges, gateways and auxiliary addresses into
 // structured ipam data.
 func consolidateIpam(subnets, ranges, gateways []string, auxaddrs map[string]string) ([]network.IPAMConfig, error) {
 	if len(subnets) < len(ranges) || len(subnets) < len(gateways) {

--- a/cli/command/swarm/init_test.go
+++ b/cli/command/swarm/init_test.go
@@ -31,7 +31,7 @@ func TestSwarmInitErrorOnAPIFailure(t *testing.T) {
 			expectedError: "error initializing the swarm",
 		},
 		{
-			name: "init-faild-with-ip-choice",
+			name: "init-failed-with-ip-choice",
 			swarmInitFunc: func() (string, error) {
 				return "", fmt.Errorf("could not choose an IP address to advertise")
 			},

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -137,7 +137,7 @@ type StringOrNumberList []string
 // key=value strings
 type MappingWithEquals map[string]string
 
-// MappingWithColon is a mapping type that can be converted from alist of
+// MappingWithColon is a mapping type that can be converted from a list of
 // 'key: value' strings
 type MappingWithColon map[string]string
 

--- a/cli/config/credentials/native_store.go
+++ b/cli/config/credentials/native_store.go
@@ -120,7 +120,7 @@ func (c *nativeStore) getCredentialsFromStore(serverAddress string) (types.AuthC
 	if err != nil {
 		if credentials.IsErrCredentialsNotFound(err) {
 			// do not return an error if the credentials are not
-			// in the keyckain. Let docker ask for new credentials.
+			// in the keychain. Let docker ask for new credentials.
 			return ret, nil
 		}
 		return ret, err

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -22,7 +22,7 @@ func TestContainerCreateError(t *testing.T) {
 		t.Fatalf("expected a Server Error while testing StatusInternalServerError, got %v", err)
 	}
 
-	// 404 doesn't automagitally means an unknown image
+	// 404 doesn't automatically means an unknown image
 	client = &Client{
 		client: newMockClient(errorMock(http.StatusNotFound, "Server error")),
 	}

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -22,7 +22,7 @@ func TestImageTagError(t *testing.T) {
 	}
 }
 
-// Note: this is not testing all the InvalidReference as it's the reponsability
+// Note: this is not testing all the InvalidReference as it's the responsibility
 // of distribution/reference package.
 func TestImageTagInvalidReference(t *testing.T) {
 	client := &Client{

--- a/client/swarm_unlock.go
+++ b/client/swarm_unlock.go
@@ -5,7 +5,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// SwarmUnlock unlockes locked swarm.
+// SwarmUnlock unlocks locked swarm.
 func (cli *Client) SwarmUnlock(ctx context.Context, req swarm.UnlockRequest) error {
 	serverResp, err := cli.post(ctx, "/swarm/unlock", nil, req, nil)
 	ensureReaderClosed(serverResp)

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -679,7 +679,7 @@ Use `df <source-dir>` to figure out the source mount and then use
 `findmnt -o TARGET,PROPAGATION <source-mount-dir>` to figure out propagation
 properties of source mount. If `findmnt` utility is not available, then one
 can look at mount entry for source mount point in `/proc/self/mountinfo`. Look
-at `optional fields` and see if any propagaion properties are specified.
+at `optional fields` and see if any propagation properties are specified.
 `shared:X` means mount is `shared`, `master:X` means mount is `slave` and if
 nothing is there that means mount is `private`.
 

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -653,7 +653,7 @@ Example use: `dockerd -s zfs --storage-opt zfs.fsname=zroot/docker`
 
 #### btrfs.min_space
 
-Specifies the mininum size to use when creating the subvolume which is used for
+Specifies the minimum size to use when creating the subvolume which is used for
 containers. If user uses disk quota for btrfs when creating or running a
 container with **--storage-opt size** option, docker should ensure the **size**
 cannot be smaller than **btrfs.min_space**.


### PR DESCRIPTION
Signed-off-by: Aaron.L.Xu <likexu@harmonycloud.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I was very annoyed by those kind of typo mistakes and maybe this file (https://github.com/xulike666/vscode-spell-checker-helper/blob/master/docker/spellcheck.txt) could help our developers in a self-discipline and distributed way.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

