### PR TITLE
Docker is abusing HTTP 'NotModified' status

### DIFF
--- a/daemon/start.go
+++ b/daemon/start.go
@@ -35,7 +35,7 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *containertypes.Hos
 
 	if container.IsRunning() {
 		err := fmt.Errorf("Container already started")
-		return apierrors.NewErrorWithStatusCode(err, http.StatusNotModified)
+		return apierrors.NewErrorWithStatusCode(err, http.StatusConflict)
 	}
 
 	// Windows does not have the backwards compatibility issue here.

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -23,7 +23,7 @@ func (daemon *Daemon) ContainerStop(name string, seconds *int) error {
 	}
 	if !container.IsRunning() {
 		err := fmt.Errorf("Container %s is already stopped", name)
-		return errors.NewErrorWithStatusCode(err, http.StatusNotModified)
+		return errors.NewErrorWithStatusCode(err, http.StatusConflict)
 	}
 	if seconds == nil {
 		stopTimeout := container.StopTimeout()

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -910,13 +910,12 @@ func (s *DockerSuite) TestContainerAPIStart(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusNoContent)
 
-	// second call to start should give 304
+	// second call to start should give 409
 	status, _, err = request.SockRequest("POST", "/containers/"+name+"/start", nil, daemonHost())
 	c.Assert(err, checker.IsNil)
 
-	// TODO(tibor): figure out why this doesn't work on windows
 	if testEnv.LocalDaemon() {
-		c.Assert(status, checker.Equals, http.StatusNotModified)
+		c.Assert(status, checker.Equals, http.StatusConflict)
 	}
 }
 
@@ -929,10 +928,10 @@ func (s *DockerSuite) TestContainerAPIStop(c *check.C) {
 	c.Assert(status, checker.Equals, http.StatusNoContent)
 	c.Assert(waitInspect(name, "{{ .State.Running  }}", "false", 60*time.Second), checker.IsNil)
 
-	// second call to start should give 304
+	// second call to start should give 409
 	status, _, err = request.SockRequest("POST", "/containers/"+name+"/stop?t=30", nil, daemonHost())
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusNotModified)
+	c.Assert(status, checker.Equals, http.StatusConflict)
 }
 
 func (s *DockerSuite) TestContainerAPIWait(c *check.C) {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Docker stop on a running container does not return an error.

@thaJeztah – you’ll like this one! It has been driving me nuts debugging why following this comment: https://github.com/docker/docker/issues/29768#issuecomment-280166005

Short summary: Docker is abusing the HTTP RFCs and as a result errors are not being propagated back to the client. This applies to stopping a stopped container, and starting a started container.  Due to this abuse, the client just prints the container name (or ID), even though the daemon did error on that resource, but no error is returned from the daemon in the HTTP response. The reason for this is the use of HTTP response code 304 (Not Modified). 

With this fix, you now get the correct behaviour starting from a running container:

```
PS E:\> docker ps
CONTAINER ID        IMAGE                         COMMAND               CREATED             STATUS              PORTS               NAMES
28a3d9ec23cf        microsoft/windowsservercore   "ping -t localhost"   19 hours ago        Up 5 seconds                            foo
```

```
PS E:\> docker stop foo
foo
PS E:\> docker stop foo
Error response from daemon: Container foo is already stopped
PS E:\>
```

Where-as without this fix, you get

```
PS E:\> docker stop foo
foo
PS E:\> docker stop foo
foo
PS E:\>
```

Similar the new behaviour if you try to start a running container

```
PS E:\> docker ps -a
CONTAINER ID        IMAGE                         COMMAND               CREATED             STATUS                                   PORTS               NAMES
28a3d9ec23cf        microsoft/windowsservercore   "ping -t localhost"   19 hours ago        Exited (3221225786) About a minute ago                       foo
PS E:\> docker start foo
foo
PS E:\> docker start foo
Error response from daemon: Container already started
Error: failed to start containers: foo
```

Without the fix, the second start above would just display “foo” with no error.

And finally, to demonstrate that the fix works with multiple containers (where “foox” and “foobar” don’t exist):

```
PS E:\> docker ps -a
CONTAINER ID        IMAGE                         COMMAND               CREATED             STATUS                              PORTS               NAMES
28a3d9ec23cf        microsoft/windowsservercore   "ping -t localhost"   20 hours ago        Exited (3221225786) 7 seconds ago                       foo
PS E:\> docker start foox foo foobar
Error response from daemon: No such container: foox
foo
Error response from daemon: No such container: foobar
Error: failed to start containers: foox, foobar
PS E:\> docker start foox foo foobar
Error response from daemon: No such container: foox
Error response from daemon: Container already started
Error response from daemon: No such container: foobar
Error: failed to start containers: foox, foo, foobar
PS E:\>
```




Longer version:

From https://tools.ietf.org/html/rfc7232 section 4.1, the first and last paragraphs are the relevant ones. Remember `STOP` is a POST (not a GET or HEAD). And also that the 3xx series of 
response codes are “Redirection” and generally used for caching purposes

```
4.1.  304 Not Modified


   The 304 (Not Modified) status code indicates that a conditional GET
   or HEAD request has been received and would have resulted in a 200
   (OK) response if it were not for the fact that the condition
   evaluated to false.  In other words, there is no need for the server
   to transfer a representation of the target resource because the
   request indicates that the client, which made the request




Fielding & Reschke           Standards Track                   [Page 18]
________________________________________
 
RFC 7232              HTTP/1.1 Conditional Requests            June 2014


   conditional, already has a valid representation; the server is
   therefore redirecting the client to make use of that stored
   representation as if it were the payload of a 200 (OK) response.

   The server generating a 304 response MUST generate any of the
   following header fields that would have been sent in a 200 (OK)
   response to the same request: Cache-Control, Content-Location, Date,
   ETag, Expires, and Vary.

   Since the goal of a 304 response is to minimize information transfer
   when the recipient already has one or more cached representations, a
   sender SHOULD NOT generate representation metadata other than the
   above listed fields unless said metadata exists for the purpose of
   guiding cache updates (e.g., Last-Modified might be useful if the
   response does not have an ETag field).

   Requirements on a cache that receives a 304 response are defined in
   Section 4.3.4 of [RFC7234].  If the conditional request originated
   with an outbound client, such as a user agent with its own cache
   sending a conditional GET to a shared proxy, then the proxy SHOULD
   forward the 304 response to that client.

   A 304 response cannot contain a message-body; it is always terminated
   by the first empty line after the header fields
```

So, from the above, the last paragraph indicates that there is no message-body. This is why docker stop on a running container doesn’t show the error as the encoding of the response in the HTTP writer removes the response. Strictly, attempting to STOP a running container is a client error and should be in the 4xx series when looking at this list: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes

```
1xx Informational
2xx Success
3xx Redirection
4xx Client Error
5xx Server Error
```

I would argue that either 405 Method not allowed or 409/Conflict are closest. 405 though is defined as “The response MUST include an Allow header containing a list of valid methods for the requested resource.” which isn’t really true. 

The Wikipedia definition of 409 is a little vague:

```
409 Conflict
Indicates that the request could not be processed because of conflict in the request, such as an edit conflict between multiple simultaneous updates.
```

However, RFC2616 makes it clear this is more appropriate: http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html

```
10.4.10 409 Conflict
The request could not be completed due to a conflict with the current state of the resource. This code is only allowed in situations where it is expected that the user might be able to resolve the conflict and resubmit the request. The response body SHOULD include enough 
information for the user to recognize the source of the conflict. Ideally, the response entity would include enough information for the user or user agent to fix the problem; however, that might not be possible and is not required. 
Conflicts are most likely to occur in response to a PUT request. For example, if versioning were being used and the entity being PUT included changes to a resource which conflict with those made by an earlier (third-party) request, the server might use the 409 response to indicate that it can't complete the request. In this case, the response entity would likely contain a list of the differences between the two versions in a format defined by the response Content-Type
```

I thought 412 might also be reasonable, but it’s really not a precondition failure on the request-headers.


Hence, I’ve gone with 409: The request could not be completed due to a conflict with the current state of the resource

