### PR TITLE
Add Yong Tang to maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -51,7 +51,8 @@
 			"tonistiigi",
 			"unclejack",
 			"vdemeester",
-			"vieux"
+			"vieux",
+			"yongtang"
 		]
 
 	[Org."Docs maintainers"]
@@ -410,3 +411,9 @@
 	Name = "Vishnu Kannan"
 	Email = "vishnuk@google.com"
 	GitHub = "vishh"
+
+	[people.yongtang]
+	Name = "Yong Tang"
+	Email = "yong.tang.github@outlook.com"
+	GitHub = "yongtang"
+


### PR DESCRIPTION
This adds Yong Tang (@yongtang) as a maintainer for docker/docker, as was proposed and voted on the maintainers mailinglist 👼 🐳.

![yay-kermit](https://cloud.githubusercontent.com/assets/6508/23043069/61fef126-f49b-11e6-954f-8cde31482147.gif)


/cc @docker/core-maintainers @yongtang 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
