### PR TITLE
change stderr into stdout when removing stack resources

### DIFF
--- a/cli/command/stack/remove.go
+++ b/cli/command/stack/remove.go
@@ -73,7 +73,7 @@ func removeServices(
 ) bool {
 	var err error
 	for _, service := range services {
-		fmt.Fprintf(dockerCli.Err(), "Removing service %s\n", service.Spec.Name)
+		fmt.Fprintf(dockerCli.Out(), "Removing service %s\n", service.Spec.Name)
 		if err = dockerCli.Client().ServiceRemove(ctx, service.ID); err != nil {
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove service %s: %s", service.ID, err)
 		}
@@ -88,7 +88,7 @@ func removeNetworks(
 ) bool {
 	var err error
 	for _, network := range networks {
-		fmt.Fprintf(dockerCli.Err(), "Removing network %s\n", network.Name)
+		fmt.Fprintf(dockerCli.Out(), "Removing network %s\n", network.Name)
 		if err = dockerCli.Client().NetworkRemove(ctx, network.ID); err != nil {
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove network %s: %s", network.ID, err)
 		}
@@ -103,7 +103,7 @@ func removeSecrets(
 ) bool {
 	var err error
 	for _, secret := range secrets {
-		fmt.Fprintf(dockerCli.Err(), "Removing secret %s\n", secret.Spec.Name)
+		fmt.Fprintf(dockerCli.Out(), "Removing secret %s\n", secret.Spec.Name)
 		if err = dockerCli.Client().SecretRemove(ctx, secret.ID); err != nil {
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove secret %s: %s", secret.ID, err)
 		}


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I think some removing log should not be streamed to stderr and it should be stdout, so I changed that.
Since if there will is a successful removal, there is some information in the stderr.

**- What I did**
1. change stderr into stdout when removing stack resources

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

