### PR TITLE
fix TestPullFailsWithAlteredLayer

### DIFF
--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -31,7 +31,10 @@ func setupImage(c *check.C) (digest.Digest, error) {
 func setupImageWithTag(c *check.C, tag string) (digest.Digest, error) {
 	containerName := "busyboxbydigest"
 
-	dockerCmd(c, "run", "-e", "digest=1", "--name", containerName, "busybox")
+	// new file is committed because this layer is used for detecting malicious
+	// changes. if this was committed as empty layer it would be skipped on pull
+	// and malicious changes would never be detected.
+	dockerCmd(c, "run", "-e", "digest=1", "--name", containerName, "busybox", "touch", "anewfile")
 
 	// tag the image to upload it to the private registry
 	repoAndTag := repoName + ":" + tag


### PR DESCRIPTION
This test was failing after the busybox image switched to a
single layer.

The test fails because it alters the data of an empty layer and
relies on a side effect of another empty layer not being skipped
on pull to pass.

Thanks to @tonistiigi for providing the patch https://github.com/docker/docker/pull/29030#issuecomment-268389298
