### PR TITLE
Format anonymous volume name for swarm

### DIFF
--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -29,6 +29,9 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 
 	for spec := range config.Volumes {
 		name := stringid.GenerateNonCryptoID()
+		if serviceName, ok := config.Labels["com.docker.swarm.service.name"]; ok {
+			name = fmt.Sprintf("%s.%x.%s", serviceName, spec, name)
+		}
 		destination := filepath.Clean(spec)
 
 		// Skip volumes for which we already have something mounted on that

--- a/daemon/create_windows.go
+++ b/daemon/create_windows.go
@@ -26,6 +26,9 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 		// If the mountpoint doesn't have a name, generate one.
 		if len(mp.Name) == 0 {
 			mp.Name = stringid.GenerateNonCryptoID()
+			if serviceName, ok := config.Labels["com.docker.swarm.service.name"]; ok {
+				mp.Name = fmt.Sprintf("%s.%x.%s", serviceName, spec, mp.Name)
+			}
 		}
 
 		// Skip volumes for which we already have something mounted on that


### PR DESCRIPTION
This helps volume driver to detect volumes from same services even if migrated to other machines.
This change is compatible with old design since volume name is still random.

For example:

`$ docker service create registry`
`vtjahlmbjnifribduj2ko8aip`
`$ docker volume ls`
`DRIVER              VOLUME NAME`
`local               silly_jennings.2f7661722f6c6962.4f275c587169b33829a13ec7bbbd0e2f41c9d01c3cc00d7b0d434e13932c286d`

This commit fixes/closes both Issue - https://github.com/docker/docker/issues/30930 and Issue - https://github.com/docker/docker/issues/30931
This commit replaces/closes PR - https://github.com/docker/docker/pull/31049
