### PR TITLE
fix status-code for "locked" swarm and "certificate expired"

### DIFF
--- a/api/server/httputils/errors.go
+++ b/api/server/httputils/errors.go
@@ -64,6 +64,8 @@ func GetHTTPErrorStatusCode(err error) int {
 			{"unauthorized", http.StatusUnauthorized},
 			{"hasn't been activated", http.StatusForbidden},
 			{"this node", http.StatusServiceUnavailable},
+			{"needs to be unlocked", http.StatusServiceUnavailable},
+			{"certificates have expired", http.StatusServiceUnavailable},
 		} {
 			if strings.Contains(errStr, status.keyword) {
 				statusCode = status.code


### PR DESCRIPTION
These errors were producing the wrong status code,
changing to 503.

replaces https://github.com/docker/docker/pull/29033
closes https://github.com/docker/docker/pull/29033