### PR TITLE
add 2 seconds delay to allow gossip converge

### DIFF
--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -25,6 +25,8 @@ import (
 	"golang.org/x/time/rate"
 )
 
+const defaultGossipConvergeDelay = 2 * time.Second
+
 // controller implements agent.Controller against docker's API.
 //
 // Most operations against docker's API are done through the container name,
@@ -322,6 +324,13 @@ func (r *controller) Shutdown(ctx context.Context) error {
 		// the service binding is expected if the container was never
 		// started.
 	}
+
+	// add a delay for gossip converge
+	// TODO(dongluochen): this delay shoud be configurable to fit different cluster size and network delay.
+	// TODO(dongluochen): if there is no service binding for this container, this delay is not necessary.
+	// if r.adapter.deactivateServiceBinding can return an error to indicate that, it'd reduce service
+	// converge time.
+	time.Sleep(defaultGossipConvergeDelay)
 
 	if err := r.adapter.shutdown(ctx); err != nil {
 		if isUnknownContainer(err) || isStoppedContainer(err) {


### PR DESCRIPTION
Signed-off-by: Dong Chen <dongluo.chen@docker.com>

Fixes #30321. 

**- What I did**

There is a race condition between removing service binding (load balancer rotation, DNS records) of a container and shutting down a container. This may lead to request loss. This change adds 2 seconds sleep between removing service binding and shutting down container. 

**- How to verify it**

In rolling update, keep sending requests to published port. The requests shouldn't be lost. 

cc @sanimej @aluzzardi. 