### PR TITLE
Update version-history.md for `ReadOnly` parameter

### DIFF
--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -20,6 +20,7 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /containers/(id or name)/attach/ws` now returns WebSocket in binary frame format for API version >= v1.27, and returns WebSocket in text frame format for API version< v1.27, for the purpose of backward-compatibility.
 * `GET /networks` is optimised only to return list of all networks and network specific information. List of all containers attached to a specific network is removed from this API and is only available using the network specific `GET /networks/{network-id}.
 * `GET /containers/json` now supports `publish` and `expose` filters to filter containers that expose or publish certain ports.
+* `POST /services/create` and `POST /services/(id or name)/update` now accept the `ReadOnly` parameter, which mounts the container's root filesystem as read only.
 
 ## v1.26 API changes
 


### PR DESCRIPTION
This fix updates the `docs/api/version-history.md` for `ReadOnly` parameter, which is now available in `POST /services/create` and `POST /services/(id or name)/update`.

This fix is a follow up to #30162.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

/cc @vieux