### PR TITLE
docker stack deploy interpolation format error due to not escaping $ now includes a hint

### DIFF
--- a/cli/compose/interpolation/interpolation.go
+++ b/cli/compose/interpolation/interpolation.go
@@ -39,7 +39,7 @@ func interpolateSectionItem(
 		interpolatedValue, err := recursiveInterpolate(value, mapping)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"Invalid interpolation format for %#v option in %s %#v: %#v",
+				"Invalid interpolation format for %#v option in %s %#v: %#v. You may need to escape any $ with another $.",
 				key, section, name, err.Template,
 			)
 		}

--- a/cli/compose/interpolation/interpolation_test.go
+++ b/cli/compose/interpolation/interpolation_test.go
@@ -55,5 +55,5 @@ func TestInvalidInterpolation(t *testing.T) {
 		},
 	}
 	_, err := Interpolate(services, "service", defaultMapping)
-	assert.EqualError(t, err, `Invalid interpolation format for "image" option in service "servicea": "${"`)
+	assert.EqualError(t, err, `Invalid interpolation format for "image" option in service "servicea": "${". You may need to escape any $ with another $.`)
 }


### PR DESCRIPTION
Added code to print a hint if not escaping the '$' character in the compose file causes an interpolation format error for docker stack deploy command. Fixes #30629.

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**- What I did**
When the command 'docker stack deploy' fails due to not escaping the '$' in the compose file, the error message does not indicate the cause of failure. This PR fixes this by adding a hint to the error message.

**- How I did it**
Added a code which checks for '$' and '$$' patterns in the template string if an error is encountered during the interpolation, and adds a hint to the error message if needed.

**- How to verify it**
Run docker stack deploy and specify the --compose-file option. Use the compose file shown in #30629.

- Current behavior:
$ docker stack deploy --compose-file=docker-compose.yml monitoring                                                            
Invalid interpolation format for "command" option in service "node-exporter": "^/(sys|proc|dev|host|etc)($|/)"

- With this PR:
$ docker stack deploy --compose-file=docker-compose.yml monitoring                                                            
Invalid interpolation format for "command" option in service "node-exporter": "^/(sys|proc|dev|host|etc)($|/)". You may need to escape any $ with another $.


**- Description for the changelog**
The error from 'docker stack deploy' includes a hint if the error is caused by '$' delimiter not having been escaped with another '$'.



**- A picture of a cute animal (not mandatory but encouraged)**

