### PR TITLE
[1.13] Allow sync_file_range2 on supported architectures.

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -417,8 +417,23 @@
 		},
 		{
 			"names": [
+				"sync_file_range2"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"ppc64le"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
 				"arm_fadvise64_64",
 				"arm_sync_file_range",
+				"sync_file_range2",
 				"breakpoint",
 				"cacheflush",
 				"set_tls"

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -390,8 +390,19 @@ func DefaultProfile() *types.Seccomp {
 		},
 		{
 			Names: []string{
+				"sync_file_range2",
+			},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Arches: []string{"ppc64le"},
+			},
+		},
+		{
+			Names: []string{
 				"arm_fadvise64_64",
 				"arm_sync_file_range",
+				"sync_file_range2",
 				"breakpoint",
 				"cacheflush",
 				"set_tls",


### PR DESCRIPTION
Allow sync_file_range2 on supported architectures - this syscall is a variant due to alignment considerations on some architectures.

Signed-off-by: Gabriel Linder <linder.gabriel@gmail.com>

cherry pick of #30971

cc @vieux 