### PR TITLE
Fix missing whitespace between words in manpage

### DIFF
--- a/man/src/image/ls.md
+++ b/man/src/image/ls.md
@@ -48,7 +48,7 @@ IMAGE ID, CREATED, and SIZE.
 
 The `docker image ls` command takes an optional `[REPOSITORY[:TAG]]` argument
 that restricts the list to images that match the argument. If you specify
-`REPOSITORY`but no `TAG`, the `docker image ls` command lists all images in the
+`REPOSITORY` but no `TAG`, the `docker image ls` command lists all images in the
 given repository.
 
     docker image ls java


### PR DESCRIPTION
Hi, I read the contribution guide and following "Not sure if that typo is worth a pull request? Found a bug and know how to fix it? Do it! We will appreciate it. Any significant improvement should be documented as a GitHub issue before anybody starts working on it." I have not created a bug request for a change this simple, sorry if this is incorrect. This also means I cant follow the convention of naming my branch after a bug number.

I'm also on the road at the moment and making this change via the Github web interface, so I'm not sure how to go about doing "Make sure all your commits include a signature generated with `git commit -s` "