### PR TITLE
[1.13] update client/client.go DefaultVersion

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -58,7 +58,7 @@ import (
 )
 
 // DefaultVersion is the version of the current stable API
-const DefaultVersion string = "1.25"
+const DefaultVersion string = "1.26"
 
 // Client is the API client that performs all operations
 // against a docker server.


### PR DESCRIPTION
it's only used in tests, to just an update for consistency. (I forgot to update it in https://github.com/docker/docker/pull/30806)

see https://github.com/docker/docker/pull/31164 in master to avoid the duplcation

/cc @vdemeester @thaJeztah 

