### PR TITLE
[1.13.x/17.03.x] Vendoring libnetwork @ce28404

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -23,7 +23,7 @@ github.com/RackSec/srslog 456df3a81436d29ba874f3590eeeee25d666f8a5
 github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-github.com/docker/libnetwork bba65e5e191eccfbc8e2f6455c527b407c2be5ff
+github.com/docker/libnetwork ce28404512e8fac9b8103b9072e75cf8d4339302
 github.com/docker/go-events 18b43f1bc85d9cdd42c05a6cd2d444c7a200a894
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/drivers/overlay/ov_network.go
+++ b/vendor/github.com/docker/libnetwork/drivers/overlay/ov_network.go
@@ -154,6 +154,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 	if !n.secure {
 		for _, vni := range vnis {
 			programMangle(vni, false)
+			programInput(vni, false)
 		}
 	}
 
@@ -204,6 +205,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 	if n.secure {
 		for _, vni := range vnis {
 			programMangle(vni, false)
+			programInput(vni, false)
 		}
 	}
 


### PR DESCRIPTION
Once an overlay network is encrypted, a participating host should not accept clear packets for it.
