### PR TITLE
Short explanation corrected

### DIFF
--- a/cli/command/image/prune.go
+++ b/cli/command/image/prune.go
@@ -23,7 +23,7 @@ func NewPruneCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "prune [OPTIONS]",
-		Short: "Remove unused images",
+		Short: "Remove dangling images",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			spaceReclaimed, output, err := runPrune(dockerCli, opts)


### PR DESCRIPTION
The parameter removes dangling images by default, not unused ones, unused images are removed in case with -a parameter

This is important as docs.docker.com is generated referring those.

Signed-off-by: Derya SEZEN <derya.sezen@gmail.com>