### PR TITLE
stack deploy exits with error if both 'external' and other options are specified for a volume

### DIFF
--- a/cli/compose/loader/loader.go
+++ b/cli/compose/loader/loader.go
@@ -427,9 +427,21 @@ func loadVolumes(source types.Dict) (map[string]types.VolumeConfig, error) {
 		return volumes, err
 	}
 	for name, volume := range volumes {
-		if volume.External.External && volume.External.Name == "" {
-			volume.External.Name = name
-			volumes[name] = volume
+		if volume.External.External {
+			template := "conflicting parameters \"external\" and %q specified for volume %q"
+			if volume.Driver != "" {
+				return nil, fmt.Errorf(template, "driver", name)
+			}
+			if len(volume.DriverOpts) > 0 {
+				return nil, fmt.Errorf(template, "driver_opts", name)
+			}
+			if len(volume.Labels) > 0 {
+				return nil, fmt.Errorf(template, "labels", name)
+			}
+			if volume.External.Name == "" {
+				volume.External.Name = name
+				volumes[name] = volume
+			}
 		}
 	}
 	return volumes, nil

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -541,6 +541,50 @@ services:
 	assert.Contains(t, forbidden, "extends")
 }
 
+func TestInvalidExternalAndDriverCombination(t *testing.T) {
+	_, err := loadYAML(`
+version: "3"
+volumes:
+  external_volume:
+    external: true
+    driver: foobar
+`)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicting parameters \"external\" and \"driver\" specified for volume")
+	assert.Contains(t, err.Error(), "external_volume")
+}
+
+func TestInvalidExternalAndDirverOptsCombination(t *testing.T) {
+	_, err := loadYAML(`
+version: "3"
+volumes:
+  external_volume:
+    external: true
+    driver_opts:
+      beep: boop
+`)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicting parameters \"external\" and \"driver_opts\" specified for volume")
+	assert.Contains(t, err.Error(), "external_volume")
+}
+
+func TestInvalidExternalAndLabelsCombination(t *testing.T) {
+	_, err := loadYAML(`
+version: "3"
+volumes:
+  external_volume:
+    external: true
+    labels:
+      - beep=boop
+`)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicting parameters \"external\" and \"labels\" specified for volume")
+	assert.Contains(t, err.Error(), "external_volume")
+}
+
 func durationPtr(value time.Duration) *time.Duration {
 	return &value
 }


### PR DESCRIPTION
stack deploy should exit with error if both 'external' and other options are specified for a volume. Fixes #29662.

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>


**- What I did**
stack deploy command ignores options specified for a volume when the 'external' option is set to true for that volume. This PR makes it an error to specify both 'external' and other options for a volume.

**- How I did it**
Added a check to test whether both 'external' is set and other options are specified for any of the volumes in the yaml compose file.

**- How to verify it**
1. Use a compose file with the following contents:
```
version: '3'
volumes:
  external_volume:
    driver_opts:
      device: =/my-path-on-host
    external: true
```


2. run stack deploy. With this PR included:
$ docker stack deploy --compose-file=./compose.yml s1
both 'external' and options are specified for volume "external_volume". Only one is allowed


**- Description for the changelog**
docker stack deploy exits with error if both 'external' is set and other options are specified for a volume.

**- A picture of a cute animal (not mandatory but encouraged)**

