### PR TITLE
do not allow sub second in healthcheck options in Dockerfile

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -475,7 +475,7 @@ func cmd(b *Builder, args []string, attributes map[string]bool, original string)
 }
 
 // parseOptInterval(flag) is the duration of flag.Value, or 0 if
-// empty. An error is reported if the value is given and is not positive.
+// empty. An error is reported if the value is given and less than 1 second.
 func parseOptInterval(f *Flag) (time.Duration, error) {
 	s := f.Value
 	if s == "" {
@@ -485,8 +485,8 @@ func parseOptInterval(f *Flag) (time.Duration, error) {
 	if err != nil {
 		return 0, err
 	}
-	if d <= 0 {
-		return 0, fmt.Errorf("Interval %#v must be positive", f.name)
+	if d < time.Duration(time.Second) {
+		return 0, fmt.Errorf("Interval %#v cannot be less than 1 second", f.name)
 	}
 	return d, nil
 }


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

This is a follow-up for https://github.com/docker/docker/pull/30203

Since in docker/master, we do not allow docker daemon to validate healthcheck parameter `Timeout` and `Interval` to be not less than 1 second. We discussed about that we should not support `sub second validation`.

Without this PR, if a user specifies `Timeout` in Dockerfile to be 0.5s(sub second), then the `docker build` will be OK, and let us call the built image to be `built-image`. However, the `docker run built-image` will report error, since PR https://github.com/docker/docker/pull/30203.

**- What I did**
1. validate healthcheck parameters `Timeout` and `Interval` in Dockerfile options.

ping @cpuguy83 @LK4D4 
