### PR TITLE
Improve the description of "docker -v" & "docker version"

### DIFF
--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -42,7 +42,7 @@ func NewVersionCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "version [OPTIONS]",
-		Short: "Show the Docker version information",
+		Short: "Show the summary information of client and server",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runVersion(dockerCli, &opts)

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -55,7 +55,7 @@ func newDockerCommand(dockerCli *command.DockerCli) *cobra.Command {
 	cli.SetupRootCommand(cmd)
 
 	flags = cmd.Flags()
-	flags.BoolVarP(&opts.Version, "version", "v", false, "Print version information and quit")
+	flags.BoolVarP(&opts.Version, "version", "v", false, "Show version information")
 	flags.StringVar(&opts.ConfigDir, "config", cliconfig.Dir(), "Location of client config files")
 	opts.Common.InstallFlags(flags)
 

--- a/cmd/dockerd/docker.go
+++ b/cmd/dockerd/docker.go
@@ -45,7 +45,7 @@ func newDaemonCommand() *cobra.Command {
 	cli.SetupRootCommand(cmd)
 
 	flags := cmd.Flags()
-	flags.BoolVarP(&opts.version, "version", "v", false, "Print version information and quit")
+	flags.BoolVarP(&opts.version, "version", "v", false, "Show version information")
 	flags.StringVar(&opts.configFile, flagDaemonConfigFile, defaultDaemonConfigFile, "Daemon configuration file")
 	opts.common.InstallFlags(flags)
 	installConfigFlags(opts.daemonConfig, flags)

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -36,7 +36,7 @@ Options:
       --tlscert string     Path to TLS certificate file (default "/root/.docker/cert.pem")
       --tlskey string      Path to TLS key file (default "/root/.docker/key.pem")
       --tlsverify          Use TLS and verify the remote
-  -v, --version            Print version information and quit
+  -v, --version            Show version information
 
 Commands:
     attach    Attach to a running container

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -89,7 +89,7 @@ Options:
       --userland-proxy                        Use userland proxy for loopback traffic (default true)
       --userland-proxy-path string            Path to the userland proxy binary
       --userns-remap string                   User/Group setting for user namespaces
-  -v, --version                               Print version information and quit
+  -v, --version                               Show version information
 ```
 
 Options with [] may be specified multiple times.

--- a/docs/reference/commandline/version.md
+++ b/docs/reference/commandline/version.md
@@ -18,7 +18,7 @@ keywords: "version, architecture, api"
 ```markdown
 Usage:  docker version [OPTIONS]
 
-Show the Docker version information
+Show the summary information of client and server
 
 Options:
   -f, --format string   Format the output using the given Go template

--- a/man/docker.1.md
+++ b/man/docker.1.md
@@ -54,7 +54,7 @@ unix://[/path/to/socket] to use.
   Default is false.
 
 **-v**, **--version**=*true*|*false*
-  Print version information and quit. Default is false.
+  Show version information. Default is false.
 
 # COMMANDS
 


### PR DESCRIPTION
Signed-off-by: yupengzte <yu.peng36@zte.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Delete "and quit" of "docker -v"
2. Distinguish the description between "docker -v" and “docker version”
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
Before:
docker version
![image](https://cloud.githubusercontent.com/assets/20062886/23118538/774012b2-f78f-11e6-8db3-654d8aac43e1.png)
docker -v
![image](https://cloud.githubusercontent.com/assets/20062886/23118570/982f5bcc-f78f-11e6-80f0-33df819c401e.png)
![image](https://cloud.githubusercontent.com/assets/20062886/23118596/b24e4c8e-f78f-11e6-96c4-696e94db4837.png)

