### PR TITLE
Hide aliases in bash completion of `docker node|service`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2764,7 +2764,11 @@ _docker_network() {
 		prune
 		rm
 	"
-	__docker_subcommands "$subcommands" && return
+	local aliases="
+		list
+		remove
+	"
+	__docker_subcommands "$subcommands $aliases" && return
 
 	case "$cur" in
 		-*)
@@ -2780,15 +2784,19 @@ _docker_service() {
 	local subcommands="
 		create
 		inspect
-		ls list
-		rm remove
+		ls
+		rm
 		scale
 		ps
 		update
 	"
 	__docker_daemon_is_experimental && subcommands+="logs"
 
-	__docker_subcommands "$subcommands" && return
+	local aliases="
+		list
+		remove
+	"
+	__docker_subcommands "$subcommands $aliases" && return
 
 	case "$cur" in
 		-*)
@@ -3287,13 +3295,17 @@ _docker_node() {
 	local subcommands="
 		demote
 		inspect
-		ls list
+		ls
 		promote
-		rm remove
+		rm
 		ps
 		update
 	"
-	__docker_subcommands "$subcommands" && return
+	local aliases="
+		list
+		remove
+	"
+	__docker_subcommands "$subcommands $aliases" && return
 
 	case "$cur" in
 		-*)


### PR DESCRIPTION
Background: Docker CLI hides aliases of subcommands in its help output. The aliases only appear in the help message of such subcommands. Example: `docker volume list`:
```bash
$ docker volume --help
[...]
Commands:
  create      Create a volume
  inspect     Display detailed information on one or more volumes
  ls          List volumes
  prune       Remove all unused volumes
  rm          Remove one or more volumes
[...]
$ docker volume ls --help
[...]
Aliases:
  ls, list
[...]
```
To be consistent with the CLI, bash completion of such commands does not offer subcommand aliases. This means that `docker volume l<tab>` directly expands to `docker volume ls` (without the potential match `list` interfering, same for `rm` and `remove`).
Note that the aliases are still honored once you manually typed them: `docker volume list --<tab>` will complete the available options.

There are some historical deviations from this rule that this PR starts to resolve.