### PR TITLE
don't log v2 pull as error when retrying

### DIFF
--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -140,7 +140,7 @@ func Pull(ctx context.Context, ref reference.Named, imagePullConfig *ImagePullCo
 					// append subsequent errors
 					lastErr = err
 				}
-				logrus.Errorf("Attempting next endpoint for pull after error: %v", err)
+				logrus.Infof("Attempting next endpoint for pull after error: %v", err)
 				continue
 			}
 			logrus.Errorf("Not continuing with pull after error: %v", err)

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -73,7 +73,6 @@ func (p *v2Puller) Pull(ctx context.Context, ref reference.Named) (err error) {
 			return err
 		}
 		if continueOnError(err) {
-			logrus.Errorf("Error trying v2 registry: %v", err)
 			return fallbackError{
 				err:         err,
 				confirmedV2: p.confirmedV2,

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -126,7 +126,7 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
 					}
 					err = fallbackErr.err
 					lastErr = err
-					logrus.Errorf("Attempting next endpoint for push after error: %v", err)
+					logrus.Infof("Attempting next endpoint for push after error: %v", err)
 					continue
 				}
 			}


### PR DESCRIPTION
When looking at https://github.com/docker/docker/pull/31113/files#diff-50d5ae90ec0b4ef64c7aaa299532bcf7R76, I noticed that the current code logged this as an _error_, but the actual error is handled, and followed by a retry / fallback. For that reason, logging as an "informational" message seems more appropriate.

This changes those errors to be logged as "Info" instead of "Error".

After this patch, debug logs look like this;

    DEBU[0050] Calling GET /_ping
    DEBU[0050] Calling POST /v1.27/images/create?fromImage=localhost%3A5000%2Ffoo&tag=latest
    DEBU[0050] Trying to pull localhost:5000/foo from https://localhost:5000 v2
    WARN[0050] Error getting v2 registry: Get https://localhost:5000/v2/: http: server gave HTTP response to HTTPS client
    INFO[0050] Attempting next endpoint for pull after error: Get https://localhost:5000/v2/: http: server gave HTTP response to HTTPS client
    DEBU[0050] Trying to pull localhost:5000/foo from http://localhost:5000 v2
    INFO[0050] Attempting next endpoint for pull after error: manifest unknown: manifest unknown
    DEBU[0050] Trying to pull localhost:5000/foo from https://localhost:5000 v1
    DEBU[0050] attempting v1 ping for registry endpoint https://localhost:5000/v1/
    DEBU[0050] Fallback from error: Get https://localhost:5000/v1/_ping: http: server gave HTTP response to HTTPS client
    INFO[0050] Attempting next endpoint for pull after error: Get https://localhost:5000/v1/_ping: http: server gave HTTP response to HTTPS client
    DEBU[0050] Trying to pull localhost:5000/foo from http://localhost:5000 v1
    DEBU[0050] [registry] Calling GET http://localhost:5000/v1/repositories/foo/images
    ERRO[0050] Not continuing with pull after error: Error: image foo:latest not found



ping @aaronlehmann @dmcgowan ptal