### PR TITLE
Add support for command aliases to bash completion of `docker volume`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4203,6 +4203,10 @@ _docker_volume_inspect() {
 	esac
 }
 
+_docker_volume_list() {
+	_docker_volume_ls
+}
+
 _docker_volume_ls() {
 	local key=$(__docker_map_key_of_current_option '--filter|-f')
 	case "$key" in
@@ -4246,6 +4250,10 @@ _docker_volume_prune() {
 	esac
 }
 
+_docker_volume_remove() {
+	_docker_volume_rm
+}
+
 _docker_volume_rm() {
 	case "$cur" in
 		-*)
@@ -4265,7 +4273,11 @@ _docker_volume() {
 		prune
 		rm
 	"
-	__docker_subcommands "$subcommands" && return
+	local aliases="
+		list
+		remove
+	"
+	__docker_subcommands "$subcommands $aliases" && return
 
 	case "$cur" in
 		-*)


### PR DESCRIPTION
When bash completion for `docker volume` was created, there were no command aliases.
This PR adds support for the aliases `docker volume list` and `docker volume remove`.
Like in the other command families this means that the aliases are **not** completed at command level (`docker volume <tab>`). They are, however, considered if the user types a command alias manually (e.g. `docker volume list --<tab>`).

Related: #31190