### PR TITLE
fix wrong type print and wrong type param passing

### DIFF
--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -460,7 +460,7 @@ func TestStopSignal(t *testing.T) {
 }
 
 func TestArg(t *testing.T) {
-	buildOptions := &types.ImageBuildOptions{BuildArgs: make(map[string]*string)}
+	buildOptions := &types.ImageBuildOptions{BuildArgs: make(map[string]string)}
 
 	b := &Builder{flags: &BFlags{}, runConfig: &container.Config{}, disableCommit: true, allowedBuildArgs: make(map[string]bool), options: buildOptions}
 
@@ -488,7 +488,7 @@ func TestArg(t *testing.T) {
 		t.Fatalf("%s argument should be a build arg", argName)
 	}
 
-	if *val != "bar" {
+	if val != "bar" {
 		t.Fatalf("%s argument should have default value 'bar', got %s", argName, val)
 	}
 }

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -492,7 +492,7 @@ func TestParseHealth(t *testing.T) {
 		t.Fatalf("--health-cmd: got %#v", health.Test)
 	}
 	if health.Timeout != 0 {
-		t.Fatalf("--health-cmd: timeout = %f", health.Timeout)
+		t.Fatalf("--health-cmd: timeout = %s", health.Timeout)
 	}
 
 	checkError("--no-healthcheck conflicts with --health-* options",


### PR DESCRIPTION
Signed-off-by: Reficul <xuzhenglun@gmail.com>

hi:

I updated Golang 1.8. When I executed `go vet` in my project, I found some issue about docker. So I try to fix it. :D 

And I humbly suggest that adding `go vet` checking before merging PR if it's possible. 

Have a nice day.