### PR TITLE
Improved aarch64 build

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -15,7 +15,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM aarch64/ubuntu:wily
+FROM aarch64/ubuntu:xenial
 
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get install -y \
 	libcap-dev \
 	libltdl-dev \
 	libsystemd-dev \
+	libyaml-dev \
 	mercurial \
 	net-tools \
 	parallel \
@@ -101,8 +102,19 @@ RUN mkdir /usr/src/go && curl -fsSL https://golang.org/dl/go${GO_VERSION}.src.ta
 	&& cd /usr/src/go/src \
 	&& GOOS=linux GOARCH=arm64 GOROOT_BOOTSTRAP="$(go env GOROOT)" ./make.bash
 
-ENV PATH /usr/src/go/bin:$PATH
+ENV PATH /go/bin:/usr/src/go/bin:$PATH
 ENV GOPATH /go
+
+# Dependency for golint
+ENV GO_TOOLS_COMMIT 823804e1ae08dbb14eb807afc7db9993bc9e3cc3
+RUN git clone https://github.com/golang/tools.git /go/src/golang.org/x/tools \
+	&& (cd /go/src/golang.org/x/tools && git checkout -q $GO_TOOLS_COMMIT)
+
+# Grab Go's lint tool
+ENV GO_LINT_COMMIT 32a87160691b3c96046c0c678fe57c5bef761456
+RUN git clone https://github.com/golang/lint.git /go/src/github.com/golang/lint \
+	&& (cd /go/src/github.com/golang/lint && git checkout -q $GO_LINT_COMMIT) \
+	&& go install -v github.com/golang/lint/golint
 
 # Only install one version of the registry, because old version which support
 # schema1 manifests is not working on ARM64, we should skip integration-cli
@@ -134,6 +146,15 @@ RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \
 	&& pip install -r test-requirements.txt
+
+# Install yamllint for validating swagger.yaml
+RUN pip install yamllint==1.5.0
+
+# Install go-swagger for validating swagger.yaml
+ENV GO_SWAGGER_COMMIT c28258affb0b6251755d92489ef685af8d4ff3eb
+RUN git clone https://github.com/go-swagger/go-swagger.git /go/src/github.com/go-swagger/go-swagger \
+	&& (cd /go/src/github.com/go-swagger/go-swagger && git checkout -q $GO_SWAGGER_COMMIT) \
+	&& go install -v github.com/go-swagger/go-swagger/cmd/swagger
 
 # Set user.email so crosbymichael's in-container merge commits go smoothly
 RUN git config --global user.email 'docker-dummy@example.com'

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -47,8 +47,9 @@ RUN apt-get update && apt-get install -y \
 	python-dev \
 	python-mock \
 	python-pip \
+	python-setuptools \
 	python-websocket \
-	gccgo \
+	golang-go \
 	iproute2 \
 	iputils-ping \
 	vim-common \
@@ -93,8 +94,8 @@ RUN set -x \
 	&& rm -rf "$SECCOMP_PATH"
 
 # Install Go
-# We don't have official binary tarballs for ARM64, eigher for Go or bootstrap,
-# so we use gccgo as bootstrap to build Go from source code.
+# We don't have official binary golang 1.7.5 tarballs for ARM64, eigher for Go or
+# bootstrap, so we use golang-go (1.6) as bootstrap to build Go from source code.
 # We don't use the official ARMv6 released binaries as a GOROOT_BOOTSTRAP, because
 # not all ARM64 platforms support 32-bit mode. 32-bit mode is optional for ARMv8.
 ENV GO_VERSION 1.7.5
@@ -145,6 +146,7 @@ ENV DOCKER_PY_COMMIT e2655f658408f9ad1f62abdef3eb6ed43c0cf324
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \
+	&& pip install wheel \
 	&& pip install -r test-requirements.txt
 
 # Install yamllint for validating swagger.yaml

--- a/man/Dockerfile.aarch64
+++ b/man/Dockerfile.aarch64
@@ -1,16 +1,6 @@
 FROM    aarch64/ubuntu:xenial
 
-# allow replacing httpredir or deb mirror
-ARG     APT_MIRROR=deb.debian.org
-RUN     sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
-
-RUN     apt-get update && apt-get install -y \
-          git \
-          bash \
-          curl \
-          gcc \
-          gccgo \
-          make
+RUN     apt-get update && apt-get install -y git golang-go curl
 
 ENV     GO_VERSION 1.7.5
 ENV     GOARCH arm64

--- a/man/Dockerfile.aarch64
+++ b/man/Dockerfile.aarch64
@@ -1,6 +1,25 @@
 FROM    aarch64/ubuntu:xenial
 
-RUN     apt-get update && apt-get install -y git golang-go
+# allow replacing httpredir or deb mirror
+ARG     APT_MIRROR=deb.debian.org
+RUN     sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
+
+RUN     apt-get update && apt-get install -y \
+          git \
+          bash \
+          curl \
+          gcc \
+          gccgo \
+          make
+
+ENV     GO_VERSION 1.7.5
+ENV     GOARCH arm64
+ENV     PATH /go/bin:/usr/src/go/bin:$PATH
+
+RUN     mkdir /usr/src/go && \
+        curl -fsSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/src/go -xz --strip-components=1 && \
+        cd /usr/src/go/src && \
+        GOOS=linux GOARCH=arm64 GOROOT_BOOTSTRAP="$(go env GOROOT)" ./make.bash
 
 RUN     mkdir -p /go/src /go/bin /go/pkg
 ENV     GOPATH=/go


### PR DESCRIPTION
**- What I did**
Fixed some issue that prevented me from running `make all` on aarch64.

**- How I did it**
Updated `Dockerfile.aarch64`to include a few things that are included in the files for other platforms:

- `golint`
- `yamllint`
- `swagger`

I've also updated `man/Dockerfile.aarch64` so that it bootstraps its own Go 1.7.5. Go 1.6.x is not sufficient anymore due to the fact that context was moved out of experimental.

**- How to verify it**
Run `make all` on an aarch64 platform should work except for a few unrelated test issues.

**- Description for the changelog**
Fixed issues that prevented `make all` to run properly on aarch64.