### PR TITLE
bugfix issue 31200 - Import variables from /etc/default/docker to docker.service

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -10,7 +10,8 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd -H fd://
+EnvironmentFile=/etc/default/docker
+ExecStart=/usr/bin/dockerd -H fd:// $DOCKER_OPTS
 ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576
 # Having non-zero Limit*s causes performance problems due to accounting overhead


### PR DESCRIPTION
Just added _EnvironmentFile_ parameter and added _$DOCKER_OPTS_ variable in the _ExecStart_ into _docker.service_ file.

Signed-off-by: Fernando Ike <fike@midstorm.org>
