### PR TITLE
Add missing fields in Swagger docs

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -469,6 +469,31 @@ definitions:
         type: "integer"
         format: "int64"
 
+  HealthConfig:
+    description: "A test to perform to check that the container is healthy."
+    type: "object"
+    properties:
+      Test:
+        description: |
+          The test to perform. Possible values are:
+
+          - `{}` inherit healthcheck from image or parent image
+          - `{"NONE"}` disable healthcheck
+          - `{"CMD", args...}` exec arguments directly
+          - `{"CMD-SHELL", command}` run command with system's default shell
+        type: "array"
+        items:
+          type: "string"
+      Interval:
+        description: "The time to wait between checks in nanoseconds. It should be 0 or not less than 1000000000(1s). 0 means inherit."
+        type: "integer"
+      Timeout:
+        description: "The time to wait before considering the check to have hung. It should be 0 or not less than 1000000000(1s). 0 means inherit."
+        type: "integer"
+      Retries:
+        description: "The number of consecutive failures needed to consider a container as unhealthy. 0 means inherit."
+        type: "integer"
+
   HostConfig:
     description: "Container configuration that depends on the host we are running on"
     allOf:
@@ -728,29 +753,7 @@ definitions:
         items:
           type: "string"
       Healthcheck:
-        description: "A test to perform to check that the container is healthy."
-        type: "object"
-        properties:
-          Test:
-            description: |
-              The test to perform. Possible values are:
-
-              - `{}` inherit healthcheck from image or parent image
-              - `{"NONE"}` disable healthcheck
-              - `{"CMD", args...}` exec arguments directly
-              - `{"CMD-SHELL", command}` run command with system's default shell
-            type: "array"
-            items:
-              type: "string"
-          Interval:
-            description: "The time to wait between checks in nanoseconds. It should be 0 or not less than 1000000000(1s). 0 means inherit."
-            type: "integer"
-          Timeout:
-            description: "The time to wait before considering the check to have hung. It should be 0 or not less than 1000000000(1s). 0 means inherit."
-            type: "integer"
-          Retries:
-            description: "The number of consecutive failures needed to consider a container as unhealthy. 0 means inherit."
-            type: "integer"
+        $ref: "#/definitions/HealthConfig"
       ArgsEscaped:
         description: "Command is already escaped (Windows only)"
         type: "boolean"
@@ -1863,6 +1866,11 @@ definitions:
           Image:
             description: "The image name to use for the container."
             type: "string"
+          Labels:
+            description: "User-defined key/value data."
+            type: "object"
+            additionalProperties:
+              type: "string"
           Command:
             description: "The command to be run in the image."
             type: "array"
@@ -1873,6 +1881,9 @@ definitions:
             type: "array"
             items:
               type: "string"
+          Hostname:
+            description: "The hostname to use for the container, as a valid RFC 1123 hostname."
+            type: "string"
           Env:
             description: "A list of environment variables in the form `VAR=value`."
             type: "array"
@@ -1884,13 +1895,16 @@ definitions:
           User:
             description: "The user inside the container."
             type: "string"
-          Labels:
-            description: "User-defined key/value data."
-            type: "object"
-            additionalProperties:
+          Groups:
+            type: "array"
+            description: "A list of additional groups that the container process will run as."
+            items:
               type: "string"
           TTY:
             description: "Whether a pseudo-TTY should be allocated."
+            type: "boolean"
+          OpenStdin:
+            description: "Open `stdin`"
             type: "boolean"
           ReadOnly:
             description: "Mount the container's root filesystem as read only."
@@ -1904,6 +1918,17 @@ definitions:
             description: "Amount of time to wait for the container to terminate before forcefully killing it."
             type: "integer"
             format: "int64"
+          HealthCheck:
+            $ref: "#/definitions/HealthConfig"
+          Hosts:
+            type: "array"
+            description: |
+              A list of hostnames/IP mappings to add to the container's `/etc/hosts` file.
+              The format of extra hosts on swarmkit is specified in:
+              http://man7.org/linux/man-pages/man5/hosts.5.html
+                IP_address canonical_hostname [aliases...]
+            items:
+              type: "string"
           DNSConfig:
             description: "Specification for DNS related configurations in resolver configuration file (`resolv.conf`)."
             type: "object"


### PR DESCRIPTION
This fix adds the missing fields of `Hostname`, `OpenStdin`, `Hosts`, `Groups`, and `Healthcheck` to `ContainerSpec`.
This fix also moves the `Label` around in `ContainerSpec` to align with the definition order.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>