### PR TITLE
fix wrong print format

### DIFF
--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -489,7 +489,7 @@ func TestArg(t *testing.T) {
 	}
 
 	if *val != "bar" {
-		t.Fatalf("%s argument should have default value 'bar', got %s", argName, val)
+		t.Fatalf("%s argument should have default value 'bar', got %s", argName, *val)
 	}
 }
 

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -492,7 +492,7 @@ func TestParseHealth(t *testing.T) {
 		t.Fatalf("--health-cmd: got %#v", health.Test)
 	}
 	if health.Timeout != 0 {
-		t.Fatalf("--health-cmd: timeout = %f", health.Timeout)
+		t.Fatalf("--health-cmd: timeout = %s", health.Timeout)
 	}
 
 	checkError("--no-healthcheck conflicts with --health-* options",


### PR DESCRIPTION
Signed-off-by: Reficul <xuzhenglun@gmail.com>

hi:

in #31197, I misunderstood the purpose of the code, and now it should be fine. 


**- Description for the changelog**
`val` is a Pointer of String type and `%s` is not suitable for Pointer, it should change to `*val`

`health.Timeout` is a type of `time.Duration` which should be format as `%s` or `%d`, and I think `%s` will be more readable.

