### PR TITLE
use t.Fatal() to output the err message and fix typo

### DIFF
--- a/api/common_test.go
+++ b/api/common_test.go
@@ -286,7 +286,7 @@ func TestLoadOrCreateTrustKeyInvalidKeyFile(t *testing.T) {
 	}
 
 	if _, err := LoadOrCreateTrustKey(tmpKeyFile.Name()); err == nil {
-		t.Fatalf("expected an error, got nothing.")
+		t.Fatal("expected an error, got nothing.")
 	}
 
 }

--- a/api/server/httputils/form_test.go
+++ b/api/server/httputils/form_test.go
@@ -100,6 +100,6 @@ func TestInt64ValueOrDefaultWithError(t *testing.T) {
 
 	_, err := Int64ValueOrDefault(r, "test", -1)
 	if err == nil {
-		t.Fatalf("Expected an error.")
+		t.Fatal("Expected an error.")
 	}
 }

--- a/api/server/middleware/version_test.go
+++ b/api/server/middleware/version_test.go
@@ -13,7 +13,7 @@ import (
 func TestVersionMiddleware(t *testing.T) {
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 		if httputils.VersionFromContext(ctx) == "" {
-			t.Fatalf("Expected version, got empty string")
+			t.Fatal("Expected version, got empty string")
 		}
 		return nil
 	}
@@ -34,7 +34,7 @@ func TestVersionMiddleware(t *testing.T) {
 func TestVersionMiddlewareWithErrors(t *testing.T) {
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 		if httputils.VersionFromContext(ctx) == "" {
-			t.Fatalf("Expected version, got empty string")
+			t.Fatal("Expected version, got empty string")
 		}
 		return nil
 	}

--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -1,7 +1,7 @@
 package filters
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 )
 
@@ -284,18 +284,18 @@ func TestDel(t *testing.T) {
 	f.Del("status", "running")
 	v := f.fields["status"]
 	if v["running"] {
-		t.Fatalf("Expected to not include a running status filter, got true")
+		t.Fatal("Expected to not include a running status filter, got true")
 	}
 }
 
 func TestLen(t *testing.T) {
 	f := NewArgs()
 	if f.Len() != 0 {
-		t.Fatalf("Expected to not include any field")
+		t.Fatal("Expected to not include any field")
 	}
 	f.Add("status", "running")
 	if f.Len() != 1 {
-		t.Fatalf("Expected to include one field")
+		t.Fatal("Expected to include one field")
 	}
 }
 
@@ -303,18 +303,18 @@ func TestExactMatch(t *testing.T) {
 	f := NewArgs()
 
 	if !f.ExactMatch("status", "running") {
-		t.Fatalf("Expected to match `running` when there are no filters, got false")
+		t.Fatal("Expected to match `running` when there are no filters, got false")
 	}
 
 	f.Add("status", "running")
 	f.Add("status", "pause*")
 
 	if !f.ExactMatch("status", "running") {
-		t.Fatalf("Expected to match `running` with one of the filters, got false")
+		t.Fatal("Expected to match `running` with one of the filters, got false")
 	}
 
 	if f.ExactMatch("status", "paused") {
-		t.Fatalf("Expected to not match `paused` with one of the filters, got true")
+		t.Fatal("Expected to not match `paused` with one of the filters, got true")
 	}
 }
 
@@ -322,33 +322,33 @@ func TestOnlyOneExactMatch(t *testing.T) {
 	f := NewArgs()
 
 	if !f.UniqueExactMatch("status", "running") {
-		t.Fatalf("Expected to match `running` when there are no filters, got false")
+		t.Fatal("Expected to match `running` when there are no filters, got false")
 	}
 
 	f.Add("status", "running")
 
 	if !f.UniqueExactMatch("status", "running") {
-		t.Fatalf("Expected to match `running` with one of the filters, got false")
+		t.Fatal("Expected to match `running` with one of the filters, got false")
 	}
 
 	if f.UniqueExactMatch("status", "paused") {
-		t.Fatalf("Expected to not match `paused` with one of the filters, got true")
+		t.Fatal("Expected to not match `paused` with one of the filters, got true")
 	}
 
 	f.Add("status", "pause")
 	if f.UniqueExactMatch("status", "running") {
-		t.Fatalf("Expected to not match only `running` with two filters, got true")
+		t.Fatal("Expected to not match only `running` with two filters, got true")
 	}
 }
 
 func TestInclude(t *testing.T) {
 	f := NewArgs()
 	if f.Include("status") {
-		t.Fatalf("Expected to not include a status key, got true")
+		t.Fatal("Expected to not include a status key, got true")
 	}
 	f.Add("status", "running")
 	if !f.Include("status") {
-		t.Fatalf("Expected to include a status key, got false")
+		t.Fatal("Expected to include a status key, got false")
 	}
 }
 
@@ -367,7 +367,7 @@ func TestValidate(t *testing.T) {
 
 	f.Add("bogus", "running")
 	if err := f.Validate(valid); err == nil {
-		t.Fatalf("Expected to return an error, got nil")
+		t.Fatal("Expected to return an error, got nil")
 	}
 }
 
@@ -384,14 +384,14 @@ func TestWalkValues(t *testing.T) {
 	})
 
 	err := f.WalkValues("status", func(value string) error {
-		return fmt.Errorf("return")
+		return errors.New("return")
 	})
 	if err == nil {
-		t.Fatalf("Expected to get an error, got nil")
+		t.Fatal("Expected to get an error, got nil")
 	}
 
 	err = f.WalkValues("foo", func(value string) error {
-		return fmt.Errorf("return")
+		return errors.New("return")
 	})
 	if err != nil {
 		t.Fatalf("Expected to not iterate when the field doesn't exist, got %v", err)

--- a/builder/dockerfile/bflag_test.go
+++ b/builder/dockerfile/bflag_test.go
@@ -130,7 +130,7 @@ func TestBuilderFlags(t *testing.T) {
 	}
 
 	if !flBool1.IsTrue() {
-		t.Fatalf("Test-b2 Bool1 was supposed to be true")
+		t.Fatal("Test-b2 Bool1 was supposed to be true")
 	}
 
 	// ---

--- a/builder/dockerfile/dispatchers_unix.go
+++ b/builder/dockerfile/dispatchers_unix.go
@@ -3,16 +3,17 @@
 package dockerfile
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 )
 
 // normaliseWorkdir normalises a user requested working directory in a
-// platform sematically consistent way.
+// platform semantically consistent way.
 func normaliseWorkdir(current string, requested string) (string, error) {
 	if requested == "" {
-		return "", fmt.Errorf("cannot normalise nothing")
+		return "", errors.New("cannot normalise nothing")
 	}
 	current = filepath.FromSlash(current)
 	requested = filepath.FromSlash(requested)

--- a/builder/dockerfile/dispatchers_windows.go
+++ b/builder/dockerfile/dispatchers_windows.go
@@ -1,6 +1,7 @@
 package dockerfile
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,10 +14,10 @@ import (
 var pattern = regexp.MustCompile(`^[a-zA-Z]:\.$`)
 
 // normaliseWorkdir normalises a user requested working directory in a
-// platform sematically consistent way.
+// platform semantically consistent way.
 func normaliseWorkdir(current string, requested string) (string, error) {
 	if requested == "" {
-		return "", fmt.Errorf("cannot normalise nothing")
+		return "", errors.New("cannot normalise nothing")
 	}
 
 	// `filepath.Clean` will replace "" with "." so skip in that case

--- a/builder/dockerfile/parser/line_parsers.go
+++ b/builder/dockerfile/parser/line_parsers.go
@@ -252,7 +252,7 @@ func parseStringsWhitespaceDelimited(rest string, d *Directive) (*Node, map[stri
 	return rootnode, nil, nil
 }
 
-// parsestring just wraps the string in quotes and returns a working node.
+// parseString just wraps the string in quotes and returns a working node.
 func parseString(rest string, d *Directive) (*Node, map[string]bool, error) {
 	if rest == "" {
 		return nil, nil, nil

--- a/builder/dockerfile/parser/parser_test.go
+++ b/builder/dockerfile/parser/parser_test.go
@@ -152,7 +152,7 @@ func TestLineInformation(t *testing.T) {
 
 	if ast.StartLine != 5 || ast.EndLine != 31 {
 		fmt.Fprintf(os.Stderr, "Wrong root line information: expected(%d-%d), actual(%d-%d)\n", 5, 31, ast.StartLine, ast.EndLine)
-		t.Fatalf("Root line information doesn't match result.")
+		t.Fatal("Root line information doesn't match result.")
 	}
 	if len(ast.Children) != 3 {
 		fmt.Fprintf(os.Stderr, "Wrong number of child: expected(%d), actual(%d)\n", 3, len(ast.Children))
@@ -167,7 +167,7 @@ func TestLineInformation(t *testing.T) {
 		if child.StartLine != expected[i][0] || child.EndLine != expected[i][1] {
 			t.Logf("Wrong line information for child %d: expected(%d-%d), actual(%d-%d)\n",
 				i, expected[i][0], expected[i][1], child.StartLine, child.EndLine)
-			t.Fatalf("Root line information doesn't match result.")
+			t.Fatal("Root line information doesn't match result.")
 		}
 	}
 }

--- a/builder/dockerignore/dockerignore_test.go
+++ b/builder/dockerignore/dockerignore_test.go
@@ -43,15 +43,15 @@ func TestReadAll(t *testing.T) {
 	}
 
 	if di[0] != "test1" {
-		t.Fatalf("First element is not test1")
+		t.Fatal("First element is not test1")
 	}
 	if di[1] != "/test2" {
-		t.Fatalf("Second element is not /test2")
+		t.Fatal("Second element is not /test2")
 	}
 	if di[2] != "/a/file/here" {
-		t.Fatalf("Third element is not /a/file/here")
+		t.Fatal("Third element is not /a/file/here")
 	}
 	if di[3] != "lastfile" {
-		t.Fatalf("Fourth element is not lastfile")
+		t.Fatal("Fourth element is not lastfile")
 	}
 }

--- a/builder/remote_test.go
+++ b/builder/remote_test.go
@@ -53,7 +53,7 @@ func TestInspectEmptyResponse(t *testing.T) {
 	br := ioutil.NopCloser(bytes.NewReader([]byte("")))
 	contentType, bReader, err := inspectResponse(ct, br, 0)
 	if err == nil {
-		t.Fatalf("Should have generated an error for an empty response")
+		t.Fatal("Should have generated an error for an empty response")
 	}
 	if contentType != "application/octet-stream" {
 		t.Fatalf("Content type should be 'application/octet-stream' but is %q", contentType)
@@ -206,13 +206,13 @@ func TestMakeRemoteContext(t *testing.T) {
 	}
 
 	if remoteContext == nil {
-		t.Fatalf("Remote context should not be nil")
+		t.Fatal("Remote context should not be nil")
 	}
 
 	tarSumCtx, ok := remoteContext.(*tarSumContext)
 
 	if !ok {
-		t.Fatalf("Cast error, remote context should be casted to tarSumContext")
+		t.Fatal("Cast error, remote context should be casted to tarSumContext")
 	}
 
 	fileInfoSums := tarSumCtx.sums

--- a/builder/tarsum_test.go
+++ b/builder/tarsum_test.go
@@ -39,7 +39,7 @@ func TestCloseRootDirectory(t *testing.T) {
 	_, err = os.Stat(contextDir)
 
 	if !os.IsNotExist(err) {
-		t.Fatalf("Directory should not exist at this point")
+		t.Fatal("Directory should not exist at this point")
 		defer os.RemoveAll(contextDir)
 	}
 }
@@ -157,7 +157,7 @@ func TestStatNotExisting(t *testing.T) {
 	}
 
 	if fileInfo != nil {
-		t.Fatalf("File info should be nil")
+		t.Fatal("File info should be nil")
 	}
 
 	if !os.IsNotExist(err) {
@@ -188,7 +188,7 @@ func TestRemoveDirectory(t *testing.T) {
 	_, err = os.Stat(contextSubdir)
 
 	if !os.IsNotExist(err) {
-		t.Fatalf("Directory should not exist at this point")
+		t.Fatal("Directory should not exist at this point")
 	}
 }
 
@@ -213,7 +213,7 @@ func TestMakeTarSumContext(t *testing.T) {
 	}
 
 	if tarSum == nil {
-		t.Fatalf("Tar sum context should not be nil")
+		t.Fatal("Tar sum context should not be nil")
 	}
 }
 
@@ -260,6 +260,6 @@ func TestWalkWithError(t *testing.T) {
 	err := tarSum.Walk(contextSubdir, walkFun)
 
 	if err == nil {
-		t.Fatalf("Error should not be nil")
+		t.Fatal("Error should not be nil")
 	}
 }

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -28,7 +28,7 @@ func TestValidateAttach(t *testing.T) {
 		"STDERR",
 	}
 	if _, err := validateAttach("invalid"); err == nil {
-		t.Fatalf("Expected error with [valid streams are STDIN, STDOUT and STDERR], got nothing")
+		t.Fatal("Expected error with [valid streams are STDIN, STDOUT and STDERR], got nothing")
 	}
 
 	for _, attach := range valid {
@@ -96,28 +96,28 @@ func TestParseRunAttach(t *testing.T) {
 	}
 
 	if _, _, err := parsetest(t, "-a"); err == nil {
-		t.Fatalf("Error parsing attach flags, `-a` should be an error but is not")
+		t.Fatal("Error parsing attach flags, `-a` should be an error but is not")
 	}
 	if _, _, err := parsetest(t, "-a invalid"); err == nil {
-		t.Fatalf("Error parsing attach flags, `-a invalid` should be an error but is not")
+		t.Fatal("Error parsing attach flags, `-a invalid` should be an error but is not")
 	}
 	if _, _, err := parsetest(t, "-a invalid -a stdout"); err == nil {
-		t.Fatalf("Error parsing attach flags, `-a stdout -a invalid` should be an error but is not")
+		t.Fatal("Error parsing attach flags, `-a stdout -a invalid` should be an error but is not")
 	}
 	if _, _, err := parsetest(t, "-a stdout -a stderr -d"); err == nil {
-		t.Fatalf("Error parsing attach flags, `-a stdout -a stderr -d` should be an error but is not")
+		t.Fatal("Error parsing attach flags, `-a stdout -a stderr -d` should be an error but is not")
 	}
 	if _, _, err := parsetest(t, "-a stdin -d"); err == nil {
-		t.Fatalf("Error parsing attach flags, `-a stdin -d` should be an error but is not")
+		t.Fatal("Error parsing attach flags, `-a stdin -d` should be an error but is not")
 	}
 	if _, _, err := parsetest(t, "-a stdout -d"); err == nil {
-		t.Fatalf("Error parsing attach flags, `-a stdout -d` should be an error but is not")
+		t.Fatal("Error parsing attach flags, `-a stdout -d` should be an error but is not")
 	}
 	if _, _, err := parsetest(t, "-a stderr -d"); err == nil {
-		t.Fatalf("Error parsing attach flags, `-a stderr -d` should be an error but is not")
+		t.Fatal("Error parsing attach flags, `-a stderr -d` should be an error but is not")
 	}
 	if _, _, err := parsetest(t, "-d --rm"); err == nil {
-		t.Fatalf("Error parsing attach flags, `-d --rm` should be an error but is not")
+		t.Fatal("Error parsing attach flags, `-d --rm` should be an error but is not")
 	}
 }
 

--- a/daemon/daemon_linux_test.go
+++ b/daemon/daemon_linux_test.go
@@ -62,7 +62,7 @@ func TestCleanupMounts(t *testing.T) {
 	d.cleanupMountsFromReaderByID(strings.NewReader(mountsFixture), "", unmount)
 
 	if unmounted != 1 {
-		t.Fatalf("Expected to unmount the shm (and the shm only)")
+		t.Fatal("Expected to unmount the shm (and the shm only)")
 	}
 }
 
@@ -83,7 +83,7 @@ func TestCleanupMountsByID(t *testing.T) {
 	d.cleanupMountsFromReaderByID(strings.NewReader(mountsFixture), "03ca4b49e71f1e49a41108829f4d5c70ac95934526e2af8984a1f65f1de0715d", unmount)
 
 	if unmounted != 1 {
-		t.Fatalf("Expected to unmount the auf root (and that only)")
+		t.Fatal("Expected to unmount the auf root (and that only)")
 	}
 }
 
@@ -99,6 +99,6 @@ func TestNotCleanupMounts(t *testing.T) {
 	mountInfo := `234 232 0:59 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k`
 	d.cleanupMountsFromReaderByID(strings.NewReader(mountInfo), "", unmount)
 	if unmounted {
-		t.Fatalf("Expected not to clean up /dev/shm")
+		t.Fatal("Expected not to clean up /dev/shm")
 	}
 }

--- a/daemon/daemon_unix_test.go
+++ b/daemon/daemon_unix_test.go
@@ -229,7 +229,7 @@ func TestNetworkOptions(t *testing.T) {
 	}
 
 	if _, err := daemon.networkOptions(dconfigWrong, nil, nil); err == nil {
-		t.Fatalf("Expected networkOptions error, got nil")
+		t.Fatal("Expected networkOptions error, got nil")
 	}
 }
 

--- a/daemon/discovery/discovery_test.go
+++ b/daemon/discovery/discovery_test.go
@@ -9,37 +9,37 @@ func TestDiscoveryOpts(t *testing.T) {
 	clusterOpts := map[string]string{"discovery.heartbeat": "10", "discovery.ttl": "5"}
 	heartbeat, ttl, err := discoveryOpts(clusterOpts)
 	if err == nil {
-		t.Fatalf("discovery.ttl < discovery.heartbeat must fail")
+		t.Fatal("discovery.ttl < discovery.heartbeat must fail")
 	}
 
 	clusterOpts = map[string]string{"discovery.heartbeat": "10", "discovery.ttl": "10"}
 	heartbeat, ttl, err = discoveryOpts(clusterOpts)
 	if err == nil {
-		t.Fatalf("discovery.ttl == discovery.heartbeat must fail")
+		t.Fatal("discovery.ttl == discovery.heartbeat must fail")
 	}
 
 	clusterOpts = map[string]string{"discovery.heartbeat": "-10", "discovery.ttl": "10"}
 	heartbeat, ttl, err = discoveryOpts(clusterOpts)
 	if err == nil {
-		t.Fatalf("negative discovery.heartbeat must fail")
+		t.Fatal("negative discovery.heartbeat must fail")
 	}
 
 	clusterOpts = map[string]string{"discovery.heartbeat": "10", "discovery.ttl": "-10"}
 	heartbeat, ttl, err = discoveryOpts(clusterOpts)
 	if err == nil {
-		t.Fatalf("negative discovery.ttl must fail")
+		t.Fatal("negative discovery.ttl must fail")
 	}
 
 	clusterOpts = map[string]string{"discovery.heartbeat": "invalid"}
 	heartbeat, ttl, err = discoveryOpts(clusterOpts)
 	if err == nil {
-		t.Fatalf("invalid discovery.heartbeat must fail")
+		t.Fatal("invalid discovery.heartbeat must fail")
 	}
 
 	clusterOpts = map[string]string{"discovery.ttl": "invalid"}
 	heartbeat, ttl, err = discoveryOpts(clusterOpts)
 	if err == nil {
-		t.Fatalf("invalid discovery.ttl must fail")
+		t.Fatal("invalid discovery.ttl must fail")
 	}
 
 	clusterOpts = map[string]string{"discovery.heartbeat": "10", "discovery.ttl": "20"}

--- a/daemon/events_test.go
+++ b/daemon/events_test.go
@@ -89,6 +89,6 @@ func validateTestAttributes(t *testing.T, l chan interface{}, expectedAttributes
 			}
 		}
 	case <-time.After(10 * time.Second):
-		t.Fatalf("LogEvent test timed out")
+		t.Fatal("LogEvent test timed out")
 	}
 }

--- a/daemon/graphdriver/aufs/aufs_test.go
+++ b/daemon/graphdriver/aufs/aufs_test.go
@@ -56,7 +56,7 @@ func TestNewDriver(t *testing.T) {
 	d := testInit(tmp, t)
 	defer os.RemoveAll(tmp)
 	if d == nil {
-		t.Fatalf("Driver should not be nil")
+		t.Fatal("Driver should not be nil")
 	}
 }
 
@@ -206,7 +206,7 @@ func TestMountedFalseResponse(t *testing.T) {
 	}
 
 	if response != false {
-		t.Fatalf("Response if dir id 1 is mounted should be false")
+		t.Fatal("Response if dir id 1 is mounted should be false")
 	}
 }
 
@@ -233,7 +233,7 @@ func TestMountedTrueResponse(t *testing.T) {
 	}
 
 	if response != true {
-		t.Fatalf("Response if dir id 2 is mounted should be true")
+		t.Fatal("Response if dir id 2 is mounted should be true")
 	}
 }
 
@@ -299,7 +299,7 @@ func TestRemoveMountedDir(t *testing.T) {
 	}
 
 	if !mounted {
-		t.Fatalf("Dir id 2 should be mounted")
+		t.Fatal("Dir id 2 should be mounted")
 	}
 
 	if err := d.Remove("2"); err != nil {
@@ -312,7 +312,7 @@ func TestCreateWithInvalidParent(t *testing.T) {
 	defer os.RemoveAll(tmp)
 
 	if err := d.Create("1", "docker", nil); err == nil {
-		t.Fatalf("Error should not be nil with parent does not exist")
+		t.Fatal("Error should not be nil with parent does not exist")
 	}
 }
 
@@ -346,7 +346,7 @@ func TestGetDiff(t *testing.T) {
 		t.Fatal(err)
 	}
 	if a == nil {
-		t.Fatalf("Archive should not be nil")
+		t.Fatal("Archive should not be nil")
 	}
 }
 

--- a/daemon/graphdriver/devmapper/devmapper_test.go
+++ b/daemon/graphdriver/devmapper/devmapper_test.go
@@ -59,7 +59,7 @@ func testChangeLoopBackSize(t *testing.T, delta, expectDataSize, expectMetaDataS
 	defer graphtest.PutDriver(t)
 	// make sure data or metadata loopback size are the default size
 	if s := driver.DeviceSet.Status(); s.Data.Total != uint64(defaultDataLoopbackSize) || s.Metadata.Total != uint64(defaultMetaDataLoopbackSize) {
-		t.Fatalf("data or metadata loop back size is incorrect")
+		t.Fatal("data or metadata loop back size is incorrect")
 	}
 	if err := driver.Cleanup(); err != nil {
 		t.Fatal(err)
@@ -74,7 +74,7 @@ func testChangeLoopBackSize(t *testing.T, delta, expectDataSize, expectMetaDataS
 	}
 	driver = d.(*graphdriver.NaiveDiffDriver).ProtoDriver.(*Driver)
 	if s := driver.DeviceSet.Status(); s.Data.Total != uint64(expectDataSize) || s.Metadata.Total != uint64(expectMetaDataSize) {
-		t.Fatalf("data or metadata loop back size is incorrect")
+		t.Fatal("data or metadata loop back size is incorrect")
 	}
 	if err := driver.Cleanup(); err != nil {
 		t.Fatal(err)
@@ -104,7 +104,7 @@ func TestDevmapperLockReleasedDeviceDeletion(t *testing.T) {
 		// function return and we are deadlocked. Release lock
 		// here so that cleanup could succeed and fail the test.
 		driver.DeviceSet.Unlock()
-		t.Fatalf("Could not acquire devices lock after call to cleanupDeletedDevices()")
+		t.Fatal("Could not acquire devices lock after call to cleanupDeletedDevices()")
 	case <-doneChan:
 	}
 }

--- a/daemon/links/links_test.go
+++ b/daemon/links/links_test.go
@@ -33,7 +33,7 @@ func TestLinkNaming(t *testing.T) {
 	value, ok := env["DOCKER_1_PORT"]
 
 	if !ok {
-		t.Fatalf("DOCKER_1_PORT not found in env")
+		t.Fatal("DOCKER_1_PORT not found in env")
 	}
 
 	if value != "tcp://172.0.17.2:6379" {

--- a/daemon/logger/copier_test.go
+++ b/daemon/logger/copier_test.go
@@ -200,7 +200,7 @@ func TestCopierSlow(t *testing.T) {
 	c.Close()
 	select {
 	case <-time.After(200 * time.Millisecond):
-		t.Fatalf("failed to exit in time after the copier is closed")
+		t.Fatal("failed to exit in time after the copier is closed")
 	case <-wait:
 	}
 }

--- a/daemon/reload_test.go
+++ b/daemon/reload_test.go
@@ -247,7 +247,7 @@ func TestDaemonReloadNotAffectOthers(t *testing.T) {
 	}
 	debug := daemon.configStore.Debug
 	if !debug {
-		t.Fatalf("Expected debug 'enabled', got 'disabled'")
+		t.Fatal("Expected debug 'enabled', got 'disabled'")
 	}
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1.use t.Fatal() to output the err message where the values used for formatting text does not appear to contain a placeholder
2.use errors.New() to return err message
3.fix misspell "semantically"
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

