### PR TITLE
[ppc64le] add ppc64le to default seccomp profile

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -43,6 +43,10 @@
 			]
 		},
 		{
+			"architecture": "SCMP_ARCH_PPC64LE",
+			"subArchitectures": []
+		},
+		{
 			"architecture": "SCMP_ARCH_S390X",
 			"subArchitectures": [
 				"SCMP_ARCH_S390"

--- a/profiles/seccomp/seccomp.go
+++ b/profiles/seccomp/seccomp.go
@@ -36,6 +36,7 @@ var nativeToSeccomp = map[string]types.Arch{
 	"mips64n32":   types.ArchMIPS64N32,
 	"mipsel64":    types.ArchMIPSEL64,
 	"mipsel64n32": types.ArchMIPSEL64N32,
+	"ppc64le":     types.ArchPPC64LE,
 	"s390x":       types.ArchS390X,
 }
 

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -35,6 +35,10 @@ func arches() []types.Architecture {
 			SubArches: []types.Arch{types.ArchMIPSEL, types.ArchMIPSEL64},
 		},
 		{
+			Arch:      types.ArchPPC64LE,
+			SubArches: []types.Arch{},
+		},
+		{
 			Arch:      types.ArchS390X,
 			SubArches: []types.Arch{types.ArchS390},
 		},


### PR DESCRIPTION
This PR explicitly adds ppc64le to the default seccomp profile. 

ppc64le was already running the default profile because of libseccomp https://github.com/docker/docker/blob/master/profiles/seccomp/seccomp.go#L64,
but this explicitly adds it to the profile.

Note: I've gone through all the calls again, and compared to the linux kernel to look for ppc64le specific ones that needed to be added, and I didn't find any. I was also suggested looking at QEMU's seccomp list just to see if there were any power specific ones I was missing, and didn't find any that needed to be added.

Test results, first without the profile, the second with it: 
```sh
$ docker run -it --security-opt seccomp=unconfined ppc64le/ubuntu:latest  unshare --map-root-user --user sh -c whoami
root

$ docker run -it ppc64le/ubuntu:latest  unshare --map-root-user --user sh -c whoami
unshare: unshare failed: Operation not permitted
```

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>

cc @justincormack 

![dog doing thing](http://cdn.playbuzz.com/cdn/8d6e563b-4d1a-448a-8b7a-441c6b516deb/8370245b-b306-4d0f-969f-f10c0b90ea1b.jpg)