### PR TITLE
Rather than remove the swarm directory and re-create, remove the subdirs

### DIFF
--- a/daemon/cluster/utils.go
+++ b/daemon/cluster/utils.go
@@ -38,12 +38,19 @@ func savePersistentState(root string, config nodeStartConfig) error {
 
 func clearPersistentState(root string) error {
 	// todo: backup this data instead of removing?
-	if err := os.RemoveAll(root); err != nil {
+	// rather than delete the entire swarm directory, delete the contents in order to preserve the inode
+	// (for example, allowing it to be bind-mounted)
+	files, err := ioutil.ReadDir(root)
+	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(root, 0700); err != nil {
-		return err
+
+	for _, f := range files {
+		if err := os.RemoveAll(filepath.Join(root, f.Name())); err != nil {
+			return err
+		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
**- What I did**

Bind-mounted the `/var/lib/docker/swarm` directory in a running container (for instance to monitor current peers and the expiry of the cert), then ran `docker swarm init`.

**- How I did it**

In one terminal:
```
docker run -it -v /var/lib/docker/swarm:/swarm ubuntu bash -c "apt-get update && apt-get install -y -q openssl && watch -n 10 -d openssl x509 -text -in /swarm/certificates/swarm-node.crt"
```

In another: 
```
docker swarm init
```

**- How to verify it**

This gets printed in the window monitoring the cert:

```
Every 10.0s: openssl x509 -text -in /swarm/certificates/swarm-node.crt                                                                                                              Wed Feb 22 21:18:57 2017

Error opening Certificate /swarm/certificates/swarm-node.crt
140504176608920:error:02001002:system library:fopen:No such file or directory:bss_file.c:398:fopen('/swarm/certificates/swarm-node.crt','r')
140504176608920:error:20074002:BIO routines:FILE_CTRL:system lib:bss_file.c:400:
unable to load certificate
```

Even though if you start another docker container, the cert is present.  This is because the bind mounted folder was deleted and re-created.

**- Description for the changelog**

Updated the utility function which removes the swarm persistent data to remove the subdirectories and files rather than delete the whole swarm subdirectory and recreate.  This is so that any plugins etc. that need to bind-mount the swarm directory will still be able to access the subdirectory after `docker swarm init`, without having to bind-mount the whole docker directory, since it seems like bind-mounting the whole docker directory may cause device busy issues:

- https://github.com/docker/docker/issues/21704
- https://github.com/docker/docker/issues/22260#issuecomment-263035087
- https://github.com/docker/docker/issues/9665#issuecomment-137440333

**- A picture of a cute animal (not mandatory but encouraged)**

![horse](https://www.neatorama.com/images/posts/731/67/67731/1386925813-0.jpg)