### PR TITLE
Shutdown leaks an error when the container was never started

### DIFF
--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -317,8 +317,10 @@ func (r *controller) Shutdown(ctx context.Context) error {
 
 	// remove container from service binding
 	if err := r.adapter.deactivateServiceBinding(); err != nil {
-		log.G(ctx).WithError(err).Errorf("failed to deactivate service binding for container %s", r.adapter.container.name())
-		return err
+		log.G(ctx).WithError(err).Warningf("failed to deactivate service binding for container %s", r.adapter.container.name())
+		// Don't return an error here, because failure to deactivate
+		// the service binding is expected if the container was never
+		// started.
 	}
 
 	if err := r.adapter.shutdown(ctx); err != nil {


### PR DESCRIPTION
I found that sometimes tasks would end up in a rejected state when trying to update them quickly. The problem was that `Shutdown` could fail if called before the container was started. Instead of returning an error in this case, `Shutdown` should succeed. This allows tasks to progress to the "shutdown" state as expected.

This was part of #31108 that I'm extracting into its own PR.