### PR TITLE
Activate bash completion for Windows executable

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4423,4 +4423,4 @@ _docker() {
 eval "$__docker_previous_extglob_setting"
 unset __docker_previous_extglob_setting
 
-complete -F _docker docker dockerd
+complete -F _docker docker docker.exe dockerd dockerd.exe


### PR DESCRIPTION
On Unix shells running on Windows (cygwin, Docker Toolbox), command completion will expand the name of the Docker binary to `docker.exe`. If you manually installed bash completion, it will not trigger unless you   remove `.exe`.
This PR makes bash completion work for binaries named `docker` _and_ `docker.exe` (same for `dockerd` _and_ `dockerd.exe`).

See also the corresponding PRs for [Compose](https://github.com/docker/compose/pull/4533) and [Machine](https://github.com/docker/machine/pull/4003)