### PR TITLE
Add --prune to stack deploy

### DIFF
--- a/cli/command/stack/deploy_bundlefile.go
+++ b/cli/command/stack/deploy_bundlefile.go
@@ -21,6 +21,14 @@ func deployBundle(ctx context.Context, dockerCli *command.DockerCli, opts deploy
 
 	namespace := convert.NewNamespace(opts.namespace)
 
+	if opts.prune {
+		services := map[string]struct{}{}
+		for service := range bundle.Services {
+			services[service] = struct{}{}
+		}
+		pruneServices(ctx, dockerCli, namespace, services)
+	}
+
 	networks := make(map[string]types.NetworkCreate)
 	for _, service := range bundle.Services {
 		for _, networkName := range service.Networks {

--- a/cli/command/stack/deploy_composefile.go
+++ b/cli/command/stack/deploy_composefile.go
@@ -52,8 +52,15 @@ func deployCompose(ctx context.Context, dockerCli *command.DockerCli, opts deplo
 
 	namespace := convert.NewNamespace(opts.namespace)
 
-	serviceNetworks := getServicesDeclaredNetworks(config.Services)
+	if opts.prune {
+		services := map[string]struct{}{}
+		for _, service := range config.Services {
+			services[service.Name] = struct{}{}
+		}
+		pruneServices(ctx, dockerCli, namespace, services)
+	}
 
+	serviceNetworks := getServicesDeclaredNetworks(config.Services)
 	networks, externalNetworks := convert.Networks(namespace, config.Networks, serviceNetworks)
 	if err := validateExternalNetworks(ctx, dockerCli, externalNetworks); err != nil {
 		return err

--- a/cli/command/stack/deploy_test.go
+++ b/cli/command/stack/deploy_test.go
@@ -1,0 +1,54 @@
+package stack
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/cli/compose/convert"
+	"github.com/docker/docker/cli/internal/test"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/testutil/assert"
+	"golang.org/x/net/context"
+)
+
+type fakeClient struct {
+	client.Client
+	serviceList []string
+	removedIDs  []string
+}
+
+func (cli *fakeClient) ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
+	services := []swarm.Service{}
+	for _, name := range cli.serviceList {
+		services = append(services, swarm.Service{
+			ID: name,
+			Spec: swarm.ServiceSpec{
+				Annotations: swarm.Annotations{Name: name},
+			},
+		})
+	}
+	return services, nil
+}
+
+func (cli *fakeClient) ServiceRemove(ctx context.Context, serviceID string) error {
+	cli.removedIDs = append(cli.removedIDs, serviceID)
+	return nil
+}
+
+func TestPruneServices(t *testing.T) {
+	ctx := context.Background()
+	namespace := convert.NewNamespace("foo")
+	services := map[string]struct{}{
+		"new":  {},
+		"keep": {},
+	}
+	client := &fakeClient{serviceList: []string{"foo_keep", "foo_remove"}}
+	dockerCli := test.NewFakeCli(client, &bytes.Buffer{})
+	dockerCli.SetErr(&bytes.Buffer{})
+
+	pruneServices(ctx, dockerCli, namespace, services)
+
+	assert.DeepEqual(t, client.removedIDs, []string{"foo_remove"})
+}

--- a/cli/command/stack/remove.go
+++ b/cli/command/stack/remove.go
@@ -68,7 +68,7 @@ func runRemove(dockerCli *command.DockerCli, opts removeOptions) error {
 
 func removeServices(
 	ctx context.Context,
-	dockerCli *command.DockerCli,
+	dockerCli command.Cli,
 	services []swarm.Service,
 ) bool {
 	var err error
@@ -83,7 +83,7 @@ func removeServices(
 
 func removeNetworks(
 	ctx context.Context,
-	dockerCli *command.DockerCli,
+	dockerCli command.Cli,
 	networks []types.NetworkResource,
 ) bool {
 	var err error
@@ -98,7 +98,7 @@ func removeNetworks(
 
 func removeSecrets(
 	ctx context.Context,
-	dockerCli *command.DockerCli,
+	dockerCli command.Cli,
 	secrets []swarm.Secret,
 ) bool {
 	var err error

--- a/cli/compose/convert/compose.go
+++ b/cli/compose/convert/compose.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"io/ioutil"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	networktypes "github.com/docker/docker/api/types/network"
@@ -22,6 +23,11 @@ type Namespace struct {
 // Scope prepends the namespace to a name
 func (n Namespace) Scope(name string) string {
 	return n.name + "_" + name
+}
+
+// Descope returns the name without the namespace prefix
+func (n Namespace) Descope(name string) string {
+	return strings.TrimPrefix(name, n.name+"_")
 }
 
 // Name returns the name of the namespace

--- a/cli/internal/test/cli.go
+++ b/cli/internal/test/cli.go
@@ -35,7 +35,7 @@ func (c *FakeCli) SetIn(in io.ReadCloser) {
 	c.in = in
 }
 
-// SetErr sets the standard error stream th cli should write on
+// SetErr sets the stderr stream for the cli to the specified io.Writer
 func (c *FakeCli) SetErr(err io.Writer) {
 	c.err = err
 }

--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -30,6 +30,7 @@ Options:
       --bundle-file string    Path to a Distributed Application Bundle file
       --compose-file string   Path to a Compose file
       --help                  Print usage
+      --prune                 Prune services that are no longer referenced
       --with-registry-auth    Send registry authentication details to Swarm agents
 ```
 

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -27,6 +27,7 @@ Options:
       --bundle-file string    Path to a Distributed Application Bundle file
   -c, --compose-file string   Path to a Compose file
       --help                  Print usage
+      --prune                 Prune services that are no longer referenced
       --with-registry-auth    Send registry authentication details to Swarm agents
 ```
 


### PR DESCRIPTION
Fixes #29898

cc @vdemeester 

**Description for changelog**

```Markdown
+ Add `--prune` option to `docker stack deploy` [#31302](https://github.com/docker/docker/pull/31302)
```