### PR TITLE
Fix service logs API to be able to specify stream

### DIFF
--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -277,12 +277,22 @@ func (c *Cluster) ServiceLogs(ctx context.Context, input string, config *backend
 		return err
 	}
 
+	// set the streams we'll use
+	stdStreams := []swarmapi.LogStream{}
+	if config.ContainerLogsOptions.ShowStdout {
+		stdStreams = append(stdStreams, swarmapi.LogStreamStdout)
+	}
+	if config.ContainerLogsOptions.ShowStderr {
+		stdStreams = append(stdStreams, swarmapi.LogStreamStderr)
+	}
+
 	stream, err := state.logsClient.SubscribeLogs(ctx, &swarmapi.SubscribeLogsRequest{
 		Selector: &swarmapi.LogSelector{
 			ServiceIDs: []string{service.ID},
 		},
 		Options: &swarmapi.LogSubscriptionOptions{
-			Follow: config.Follow,
+			Follow:  config.Follow,
+			Streams: stdStreams,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes #31306

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed a bug in the API where the user's choice of log streams was being ignored, #31306 

**- How I did it**
Added a check and changed the API call to swarmkit to include the user's desires.

**- How to verify it**

curl wth various permutations of stdout and stderr `/v1.27/services/{serviceid}/logs?stdout=true&stderr=false`. Note you only get back the requested logs.

**- Description for the changelog**
Fix service logs API to bea ble to specify stream.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
my girlfriend saw these puppies for sale on the tuscaloosa, alabama buy and sell group.
![image](https://cloud.githubusercontent.com/assets/2367858/23283487/02bb756e-f9db-11e6-9aa8-5f3e1bb80df3.png)
