### PR TITLE
contrib/init/openrc: allow separate logs for stdout and stderr

### DIFF
--- a/contrib/init/openrc/docker.confd
+++ b/contrib/init/openrc/docker.confd
@@ -1,7 +1,17 @@
 # /etc/conf.d/docker: config file for /etc/init.d/docker
 
 # where the docker daemon output gets piped
+# this contains both stdout and stderr. If  you need to separate them,
+# see the settings below
 #DOCKER_LOGFILE="/var/log/docker.log"
+
+# where the docker daemon stdout gets piped
+# if this is not set, DOCKER_LOGFILE is used
+#DOCKER_OUTFILE="/var/log/docker-out.log"
+
+# where the docker daemon stderr gets piped
+# if this is not set, DOCKER_LOGFILE is used
+#DOCKER_ERRFILE="/var/log/docker-err.log"
 
 # where docker's pid get stored
 #DOCKER_PIDFILE="/run/docker.pid"

--- a/contrib/init/openrc/docker.initd
+++ b/contrib/init/openrc/docker.initd
@@ -6,8 +6,10 @@ command="${DOCKERD_BINARY:-/usr/bin/dockerd}"
 pidfile="${DOCKER_PIDFILE:-/run/${RC_SVCNAME}.pid}"
 command_args="-p \"${pidfile}\" ${DOCKER_OPTS}"
 DOCKER_LOGFILE="${DOCKER_LOGFILE:-/var/log/${RC_SVCNAME}.log}"
+DOCKER_ERRFILE="${DOCKER_ERRFILE:-${DOCKER_LOGFILE}}"
+DOCKER_OUTFILE="${DOCKER_OUTFILE:-${DOCKER_LOGFILE}}"
 start_stop_daemon_args="--background \
-	--stderr \"${DOCKER_LOGFILE}\" --stdout \"${DOCKER_LOGFILE}\""
+	--stderr \"${DOCKER_ERRFILE}\" --stdout \"${DOCKER_OUTFILE}\""
 
 start_pre() {
 	checkpath -f -m 0644 -o root:docker "$DOCKER_LOGFILE"


### PR DESCRIPTION
**- What I did**

Allow separate log files for stdout and stderr in the OpenRC scripts.

**- How I did it**

This was done by creating two new configuration variables, DOCKER_ERRFILE and DOCKER_OUTFILE in the conf.d file. If either of these is set when docker is started, they will be used to log stdout and stderr instead of using DOCKER_LOGFILE. If either or both of them is not set, DOCKER_LOGFILE will be used.

**- How to verify it**

If you change either of the mentioned settings before starting docker, you will find that the respective files are used for logging stdout and stderr instead of DOCKER_LOGFILE.

**- Description for the changelog**

Allow stdout and stderr to be logged separately if Docker is started with the OpenRC script.
