### PR TITLE
Add completion for `--filter desired-state=shutdown`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2906,7 +2906,7 @@ _docker_service_ps() {
 	local key=$(__docker_map_key_of_current_option '--filter|-f')
 	case "$key" in
 		desired-state)
-			COMPREPLY=( $( compgen -W "accepted running" -- "${cur##*=}" ) )
+			COMPREPLY=( $( compgen -W "accepted running shutdown" -- "${cur##*=}" ) )
 			return
 			;;
 		name)
@@ -3391,7 +3391,7 @@ _docker_node_ps() {
 	local key=$(__docker_map_key_of_current_option '--filter|-f')
 	case "$key" in
 		desired-state)
-			COMPREPLY=( $( compgen -W "accepted running" -- "${cur##*=}" ) )
+			COMPREPLY=( $( compgen -W "accepted running shutdown" -- "${cur##*=}" ) )
 			return
 			;;
 		name)
@@ -3880,7 +3880,7 @@ _docker_stack_ps() {
 	local key=$(__docker_map_key_of_current_option '--filter|-f')
 	case "$key" in
 		desired-state)
-			COMPREPLY=( $( compgen -W "accepted running" -- "${cur##*=}" ) )
+			COMPREPLY=( $( compgen -W "accepted running shutdown" -- "${cur##*=}" ) )
 			return
 			;;
 		id)

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1344,7 +1344,7 @@ __docker_node_complete_ps_filters() {
     if compset -P '*='; then
         case "${${words[-1]%=*}#*=}" in
             (desired-state)
-                state_opts=('accepted' 'running')
+                state_opts=('accepted' 'running' 'shutdown')
                 _describe -t state-opts "desired state options" state_opts && ret=0
                 ;;
             *)
@@ -1784,7 +1784,7 @@ __docker_service_complete_ps_filters() {
     if compset -P '*='; then
         case "${${words[-1]%=*}#*=}" in
             (desired-state)
-                state_opts=('accepted' 'running')
+                state_opts=('accepted' 'running' 'shutdown')
                 _describe -t state-opts "desired state options" state_opts && ret=0
                 ;;
             *)
@@ -2040,7 +2040,7 @@ __docker_stack_complete_ps_filters() {
     if compset -P '*='; then
         case "${${words[-1]%=*}#*=}" in
             (desired-state)
-                state_opts=('accepted' 'running')
+                state_opts=('accepted' 'running' 'shutdown')
                 _describe -t state-opts "desired state options" state_opts && ret=0
                 ;;
             *)


### PR DESCRIPTION
There was a missing value for the `desired-state` filter.
This PR adds it to bash and zsh completion of `docker service|node|stack ps`.