### PR TITLE
Use environment variable from shell when empty

### DIFF
--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -394,6 +394,9 @@ func convertEnvironment(source map[string]string) []string {
 	var output []string
 
 	for name, value := range source {
+		if value == "" {
+			value = os.Getenv(name)
+		}
 		output = append(output, fmt.Sprintf("%s=%s", name, value))
 	}
 


### PR DESCRIPTION
This makes `docker stack deploy --compose-file` act more like docker-compose when environment variables are define empty. @dnephin not sure if this was by design or not :angel:.

Fix #31319 

/cc @dnephin @thaJeztah @cpuguy83 @icecrime 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
