### PR TITLE
Bash completion for `docker service ps` completes only one service

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2928,7 +2928,10 @@ _docker_service_ps() {
 			COMPREPLY=( $( compgen -W "--filter -f --help --no-resolve --no-trunc --quiet -q" -- "$cur" ) )
 			;;
 		*)
-			__docker_complete_services
+			local counter=$(__docker_pos_first_nonflag '--filter|-f')
+			if [ $cword -eq $counter ]; then
+				__docker_complete_services
+			fi
 			;;
 	esac
 }


### PR DESCRIPTION
`docker service ps` does not accept more than one service:
```bash
$ docker service ps proxy swarm-listener
"docker service ps" requires exactly 1 argument(s).
See 'docker service ps --help'.

Usage:  docker service ps [OPTIONS] SERVICE
```
Bash completion would complete multiple services, though.