### PR TITLE
Net dial to the plugin socket during enable.

### DIFF
--- a/client/plugin_install.go
+++ b/client/plugin_install.go
@@ -60,8 +60,8 @@ func (cli *Client) PluginInstall(ctx context.Context, name string, options types
 			return
 		}
 
-		err = cli.PluginEnable(ctx, name, types.PluginEnableOptions{Timeout: 0})
-		pw.CloseWithError(err)
+		enableErr := cli.PluginEnable(ctx, name, types.PluginEnableOptions{Timeout: 0})
+		pw.CloseWithError(enableErr)
 	}()
 	return pr, nil
 }


### PR DESCRIPTION
When a plugin fails to start, we still incorrectly mark it as enabled.
This change verifies that we can dial to the plugin socket to confirm that
the plugin is functional and only then mark the plugin as enabled. Also,
dont delete the plugin on install, if only the enable fails.

Signed-off-by: Anusha Ragunathan <anusha.ragunathan@docker.com>