### PR TITLE
devicemapper: Fix suspend a removed device

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -858,6 +858,7 @@ func (devices *DeviceSet) takeSnapshot(hash string, baseInfo *devInfo, size uint
 				if err != devicemapper.ErrEnxio {
 					return err
 				}
+				devinfo = nil
 			} else {
 				defer devices.deactivateDevice(baseInfo)
 			}


### PR DESCRIPTION
when doing `devices.cancelDeferredRemoval`, the device could have been removed
and return `ErrEnxio`, but it continue to check if it is need to do suspend.
`doSuspend := devinfo != nil && devinfo.Exists != 0` uses a devinfo which is
get before `devices.cancelDeferredRemoval(baseInfo)`, it is outdate, the device
has been removed and there is no need to do suspend. If do suspend it will return
`devicemapper: Error running deviceSuspend dm_task_run failed`.

Signed-off-by: Lei Jitang <leijitang@huawei.com>

This issue is not easy to reproduce but we have encountered this several times.

To reproduce easily, I add this code
```
diff --git a/daemon/graphdriver/devmapper/deviceset.go b/daemon/graphdriver/devmapper/deviceset.go
index 8b92400..7d08f1b 100644
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -851,12 +851,31 @@ func (devices *DeviceSet) takeSnapshot(hash string, baseInfo *devInfo, size uint
                if err != nil {
                        return err
                }
+               doDebug := strings.Contains(baseInfo.Name(), "init")
+               if doDebug {
+                       logrus.Infof("1 devinfo is: %+v", devinfo)
+                       logrus.Infof("Sleep 10s, please umount the device to make OpenCount to 0 and the kernel will remove the device")
+                       time.Sleep(10 * time.Second)
+                       logrus.Infof("Sleep over, you must umount the device before you see this log")
+
+                       // sleep another 2 second to make sure the kernel has removed the device
+                       time.Sleep(2 * time.Second)
+               }
                if devinfo != nil && devinfo.DeferredRemove != 0 {
+                       if doDebug {
+                               newdevinfo, err := devicemapper.GetInfoWithDeferred(baseInfo.Name())
+                               if err != nil {
+                                       return err
+                               }
+                               logrus.Infof("2 devinfo is: %+v", newdevinfo)
+                       }
                        err = devices.cancelDeferredRemoval(baseInfo)
                        if err != nil {
                                // If Error is ErrEnxio. Device is probably already gone. Continue.
                                if err != devicemapper.ErrEnxio {
                                        return err
+                               } else {
+                                       logrus.Infof("Err is %v", err)
                                }
                        } else {
                                defer devices.deactivateDevice(baseInfo)
@@ -882,6 +901,7 @@ func (devices *DeviceSet) takeSnapshot(hash string, baseInfo *devInfo, size uint
                return err
        }
 
+       time.Sleep(2 * time.Second)
        return nil
 }
``` 
* step 1:  start the docker daemon on terminal 1
```
dockerd -s devicemapper  --storage-opt dm.use_deferred_removal=true --storage-opt dm.use_deferred_deletion=true
INFO[0000] libcontainerd: new containerd process, pid: 23090 
WARN[0000] containerd: low RLIMIT_NOFILE changing to max  current=1024 max=4096
WARN[0001] devmapper: Usage of loopback devices is strongly discouraged for production use. Please use `--storage-opt dm.thinpooldev` or use `man docker` to refer to dm.thinpooldev section. 
WARN[0001] devmapper: Base device already exists and has filesystem xfs on it. User specified filesystem  will be ignored. 
INFO[0001] Graph migration to content-addressability took 0.00 seconds 
INFO[0001] Loading containers: start.                   
INFO[0002] Firewalld running: true                      
INFO[0002] Default bridge (docker0) is assigned with an IP address 172.17.0.0/16. Daemon option --bip can be used to set a preferred IP address 
INFO[0003] Loading containers: done.                    
INFO[0003] Daemon has completed initialization          
INFO[0003] Docker daemon                                 commit=55fcd6f-unsupported graphdriver=devicemapper version=17.04.0-dev
INFO[0003] API listen on /var/run/docker.sock  
```
* step 2:  on terminal 2, run a script under `/dev/mapper/` to make the ` docker-xxxxxx-init` ref count > 1 once it exist on container creation.
the script is: 
```
# !/bin/bash

while true; do
     DEV=$(ls -l /dev/mapper | grep init | awk {'print $9'})
     if [ -n "$DEV" ]; then
        echo $DEV
        mount "${DEV}" /mnt
        exit
     fi
done
``` 
This script is to mount the `docker-xxxxx-init` to `/mnt`, it just to make the refcount of `docker-xxxxx-init` > 1, so defer removal will triggered when docker try to remove the device.
```
[root@centos mapper]# ./test.sh
```
* step 3: run a container 

open terminal 3,  run a container
`[lei@centos docker]$ docker run -tid busybox`

After we see log ` Sleep 10s, please umount the device to make OpenCount to 0 and the kernel will remove the device `  from daemon log on terminal 1. 

do `umount /mnt` to make kernel remove the device on terminal 2
```
[root@centos mapper]# ./test.sh
docker-253:0-135201377-6b74d2a57c37678c6fe6c734d892ba0b06053d9816c2b4e0f8111dadf2bd1d6f-init
[root@centos mapper]# umount /mnt
```
and then we can see docker run fail with 
```
$ docker run -tid busybox
docker: Error response from daemon: devicemapper: Error running deviceSuspend dm_task_run failed.
```

Then daemon log is 
```
INFO[0019] 1 devinfo is: &{Exists:1 Suspended:0 LiveTable:1 InactiveTable:0 OpenCount:1 EventNr:0 Major:253 Minor:4 ReadOnly:0 TargetCount:1 DeferredRemove:131072} 
INFO[0019] Sleep 10s, please umount the device to make OpenCount to 0 and the kernel will remove the device 
INFO[0029] Sleep over, you must umount the device before you see this log 
INFO[0031] 2 devinfo is: &{Exists:0 Suspended:0 LiveTable:0 InactiveTable:0 OpenCount:0 EventNr:0 Major:0 Minor:0 ReadOnly:0 TargetCount:0 DeferredRemove:0} 
INFO[0031] Err is No such device or address             
ERRO[0031] Handler for POST /v1.27/containers/create returned error: devicemapper: Error running deviceSuspend dm_task_run failed
```




ping @rhvgoyal @shishir-a412ed  

