### PR TITLE
use an encrypted client certificate to connect to a docker daemon

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -20,6 +20,7 @@ import (
 	dopts "github.com/docker/docker/opts"
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
+	"github.com/docker/notary/passphrase"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
@@ -153,9 +154,30 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions) error {
 
 	var err error
 	cli.client, err = NewAPIClientFromFlags(opts.Common, cli.configFile)
+	if tlsconfig.IsErrEncryptedKey(err) {
+		var (
+			passwd string
+			giveup bool
+		)
+		passRetriever := passphrase.PromptRetrieverWithInOut(cli.In(), cli.Out(), nil)
+
+		for attempts := 0; tlsconfig.IsErrEncryptedKey(err); attempts++ {
+			// some code and comments borrowed from notary/trustmanager/keystore.go
+			passwd, giveup, err = passRetriever("private", "encrypted TLS private", false, attempts)
+			// Check if the passphrase retriever got an error or if it is telling us to give up
+			if giveup || err != nil {
+				return errors.Wrap(err, "private key is encrypted, but could not get passphrase")
+			}
+
+			opts.Common.TLSOptions.Passphrase = passwd
+			cli.client, err = NewAPIClientFromFlags(opts.Common, cli.configFile)
+		}
+	}
+
 	if err != nil {
 		return err
 	}
+
 	cli.defaultVersion = cli.client.ClientVersion()
 
 	if opts.Common.TrustKey == "" {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -33,7 +33,7 @@ func TestNewEnvClient(t *testing.T) {
 			envs: map[string]string{
 				"DOCKER_CERT_PATH": "invalid/path",
 			},
-			expectedError: "Could not load X509 key pair: open invalid/path/cert.pem: no such file or directory. Make sure the key is not encrypted",
+			expectedError: "Could not load X509 key pair: open invalid/path/cert.pem: no such file or directory",
 		},
 		{
 			envs: map[string]string{

--- a/vendor.conf
+++ b/vendor.conf
@@ -17,7 +17,7 @@ github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 golang.org/x/net c427ad74c6d7a814201695e9ffde0c5d400a7674
 golang.org/x/sys 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
 github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
-github.com/docker/go-connections a2afab9802043837035592f1c24827fb70766de9
+github.com/docker/go-connections e15c02316c12de00874640cd76311849de2aeed5
 golang.org/x/text f72d8390a633d5dfb0cc84043294db9f6c935756
 
 github.com/RackSec/srslog 456df3a81436d29ba874f3590eeeee25d666f8a5


### PR DESCRIPTION
An encrypted client certificate can be used to connect to a docker daemon.

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**- What I did**
This is a first attempt at fixing #30935. As discussed on #30935, the first draft of the PR includes changes to vendor repositories (docker/go-connections and docker/notary), to allow review of all the required changes. These will be submitted as PRs on corresponding repos after the approval of
the changes.

**- How I did it**
- Added code to go-connections repo to make use of existing functionaliy in notary for decrypting private keys.
- Added code for passing function for getting password from the client to the go-connections (and to notary)
        - added this as an option in tlsconfig options.
- Added code for the functionality to be enabled only if a client-specific flag is present (named it 'tlsgetpass' for now)

**- How to verify it**
- To reproduce, as shown in #30935, follow the tutorial here : https://docs.docker.com/engine/security/https/   , but generate an encrypted private key: 
$ openssl genrsa -aes256 -out key.pem 4096

- Current behavior: running a docker command (include -H ) will result in an error, e.g.:
$ docker --tlsverify --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem version
Could not load X509 key pair: tls: failed to parse private key. Make sure the key is not encrypted

- With this PR (include -H for host/port)
$ docker --tlsverify --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem version
Enter passphrase for  key with ID private:  ********   (passphrase for the private key should be entered)
Client:
 Version:      17.04.0-dev
 API version:  1.26 (downgraded from 1.27)
 Go version:   go1.7.5
 Git commit:   ffc70d2
 Built:        Sat Feb 25 20:14:54 2017
 OS/Arch:      linux/amd64

Server:
 Version:      1.14.0-dev
 API version:  1.26 (minimum version 1.12)
 Go version:   go1.7.3
 Git commit:   1b63529
 Built:        Wed Nov 30 08:16:55 2016
 OS/Arch:      linux/amd64
 Experimental: false


**- Description for the changelog**
Encrypted client certificate can be used to connect to a docker daemon.

**- A picture of a cute animal (not mandatory but encouraged)**

