### PR TITLE
validate extraHosts in daemon side

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -256,6 +256,12 @@ func (daemon *Daemon) verifyContainerSettings(hostConfig *containertypes.HostCon
 		return nil, fmt.Errorf("can't create 'AutoRemove' container with restart policy")
 	}
 
+	for _, extraHost := range hostConfig.ExtraHosts {
+		if _, err := opts.ValidateExtraHost(extraHost); err != nil {
+			return nil, err
+		}
+	}
+
 	for port := range hostConfig.PortBindings {
 		_, portStr := nat.SplitProtoPort(string(port))
 		if _, err := nat.ParsePort(portStr); err != nil {

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -16,6 +16,7 @@ import (
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/network"
+	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/go-connections/nat"
@@ -117,6 +118,9 @@ func (daemon *Daemon) buildSandboxOptions(container *container.Container) ([]lib
 
 	for _, extraHost := range container.HostConfig.ExtraHosts {
 		// allow IPv6 addresses in extra hosts; only split on first ":"
+		if _, err := opts.ValidateExtraHost(extraHost); err != nil {
+			return nil, err
+		}
 		parts := strings.SplitN(extraHost, ":", 2)
 		sboxOptions = append(sboxOptions, libnetwork.OptionExtraHost(parts[0], parts[1]))
 	}


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

fixes https://github.com/docker/docker/issues/31378

**- What I did**
1. add validation for extraHosts in daemon side when creating a container;
2  add validation for extraHosts in buildSandboxOptions to prevent the remaining container with run extraHost from being started again 

I think the extraHost has already covered in UNIT test of https://github.com/docker/docker/blob/master/opts/hosts_test.go#L151-L164 , then no integration test added.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

