### PR TITLE
Use lazy unmount for local volume driver unmount

### DIFF
--- a/pkg/mount/flags_freebsd.go
+++ b/pkg/mount/flags_freebsd.go
@@ -45,4 +45,5 @@ const (
 	RELATIME    = 0
 	REMOUNT     = 0
 	STRICTATIME = 0
+	mntDetach   = 0
 )

--- a/pkg/mount/flags_linux.go
+++ b/pkg/mount/flags_linux.go
@@ -82,4 +82,6 @@ const (
 	// it possible for the kernel to default to relatime or noatime but still
 	// allow userspace to override it.
 	STRICTATIME = syscall.MS_STRICTATIME
+
+	mntDetach = syscall.MNT_DETACH
 )

--- a/pkg/mount/flags_unsupported.go
+++ b/pkg/mount/flags_unsupported.go
@@ -27,4 +27,5 @@ const (
 	STRICTATIME = 0
 	SYNCHRONOUS = 0
 	RDONLY      = 0
+	mntDetach   = 0
 )

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -1,9 +1,5 @@
 package mount
 
-import (
-	"time"
-)
-
 // GetMounts retrieves a list of mounts for the current running process.
 func GetMounts() ([]*Info, error) {
 	return parseMountTable()
@@ -49,23 +45,11 @@ func ForceMount(device, target, mType, options string) error {
 	return mount(device, target, mType, uintptr(flag), data)
 }
 
-// Unmount will unmount the target filesystem, so long as it is mounted.
+// Unmount lazily unmounts a filesystem on supported platforms, otherwise
+// does a normal unmount.
 func Unmount(target string) error {
 	if mounted, err := Mounted(target); err != nil || !mounted {
 		return err
 	}
-	return ForceUnmount(target)
-}
-
-// ForceUnmount will force an unmount of the target filesystem, regardless if
-// it is mounted or not.
-func ForceUnmount(target string) (err error) {
-	// Simple retry logic for unmount
-	for i := 0; i < 10; i++ {
-		if err = unmount(target, 0); err == nil {
-			return nil
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	return
+	return unmount(target, mntDetach)
 }


### PR DESCRIPTION
This fixes issues where the underlying filesystem may be disconnected and
attempting to unmount may cause a hang.

Fixes part of #31390