### PR TITLE
Remove incorrect duplicate phrase from build.md

### DIFF
--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -112,9 +112,6 @@ Build Syntax Suffix             | Commit Used           | Build Context Used
 
 If you pass an URL to a remote tarball, the URL itself is sent to the daemon:
 
-Instead of specifying a context, you can pass a single Dockerfile in the `URL`
-or pipe the file in via `STDIN`. To pipe a Dockerfile from `STDIN`:
-
 ```bash
 $ docker build http://server/context.tar.gz
 ```


### PR DESCRIPTION
A phrase from the "Text files" section in build.md was incorrectly duplicated under the "Tarball contexts" section.

Signed-off-by: Peter Jaffe <pjaffe@nevo.com>