### PR TITLE
'docker daemon' deprecation message doesn't use the new version

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -271,7 +271,7 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 			fmt.Fprintf(dockerCli.Out(), " %s\n", attribute)
 		}
 		// TODO: Engine labels with duplicate keys has been deprecated in 1.13 and will be error out
-		// after 3 release cycles (1.16). For now, a WARNING will be generated. The following will
+		// after 3 release cycles (17.12). For now, a WARNING will be generated. The following will
 		// be removed eventually.
 		labelMap := map[string]string{}
 		for _, label := range info.Labels {

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -437,7 +437,7 @@ func loadDaemonCliConfig(opts daemonOptions) (*config.Config, error) {
 	// This is deprecated in 1.13, and, be removed after 3 release cycles.
 	// The following will check the conflict of labels, and report a warning for deprecation.
 	//
-	// TODO: After 3 release cycles (1.16) an error will be returned, and labels will be
+	// TODO: After 3 release cycles (17.12) an error will be returned, and labels will be
 	// sanitized to consolidate duplicate key-value pairs (config.Labels = newLabels):
 	//
 	// newLabels, err := daemon.GetConflictFreeLabels(config.Labels)

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -242,7 +242,7 @@ func Reload(configFile string, flags *pflag.FlagSet, reload func(*Config)) error
 	// This is deprecated in 1.13, and, be removed after 3 release cycles.
 	// The following will check the conflict of labels, and report a warning for deprecation.
 	//
-	// TODO: After 3 release cycles (1.16) an error will be returned, and labels will be
+	// TODO: After 3 release cycles (17.12) an error will be returned, and labels will be
 	// sanitized to consolidate duplicate key-value pairs (config.Labels = newLabels):
 	//
 	// newLabels, err := GetConflictFreeLabels(newConfig.Labels)

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -146,7 +146,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 	if !supportsDType {
-		// not a fatal error until v1.16 (#27443)
+		// not a fatal error until v17.12 (#27443)
 		logrus.Warn(overlayutils.ErrDTypeNotSupported("overlay", backingFs))
 	}
 

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -172,7 +172,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 	if !supportsDType {
-		// not a fatal error until v1.16 (#27443)
+		// not a fatal error until v17.12 (#27443)
 		logrus.Warn(overlayutils.ErrDTypeNotSupported("overlay2", backingFs))
 	}
 

--- a/daemon/graphdriver/overlayutils/overlayutils.go
+++ b/daemon/graphdriver/overlayutils/overlayutils.go
@@ -13,6 +13,6 @@ func ErrDTypeNotSupported(driver, backingFs string) error {
 	if backingFs == "xfs" {
 		msg += " Reformat the filesystem with ftype=1 to enable d_type support."
 	}
-	msg += " Running without d_type support will no longer be supported in Docker 1.16."
+	msg += " Running without d_type support will no longer be supported in Docker 17.12."
 	return errors.New(msg)
 }


### PR DESCRIPTION
Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>


fixes #31397

**- What I did**
Use the new version for 'docker daemon' deprecation message

**- How I did it**

**- How to verify it**

**- Description for the changelog**
