### PR TITLE
[test-integration] convert request.SockRequestRaw to appropriate methods

### DIFF
--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -623,6 +623,7 @@ func (d *Daemon) SockRequest(method, endpoint string, data interface{}) (int, []
 
 // SockRequestRaw executes a socket request on a daemon and returns an http
 // response and a reader for the output data.
+// Deprecated: use request package instead
 func (d *Daemon) SockRequestRaw(method, endpoint string, data io.Reader, ct string) (*http.Response, io.ReadCloser, error) {
 	return request.SockRequestRaw(method, endpoint, data, ct, d.Sock())
 }
@@ -714,7 +715,7 @@ func (d *Daemon) ReloadConfig() error {
 	errCh := make(chan error)
 	started := make(chan struct{})
 	go func() {
-		_, body, err := request.SockRequestRaw("GET", "/events", nil, "", d.Sock())
+		_, body, err := request.Get(d.Sock(), "/events")
 		close(started)
 		if err != nil {
 			errCh <- err

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"archive/tar"
 	"bytes"
+	"io/ioutil"
 	"net/http"
 	"regexp"
 	"strings"
@@ -31,7 +32,7 @@ RUN find /tmp/`
 	server := fakeStorage(c, map[string]string{"testD": testD})
 	defer server.Close()
 
-	res, body, err := request.SockRequestRaw("POST", "/build?dockerfile=baz&remote="+server.URL()+"/testD", nil, "application/json", daemonHost())
+	res, body, err := request.Post(daemonHost(), "/build?dockerfile=baz&remote="+server.URL()+"/testD", request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
@@ -70,7 +71,7 @@ func (s *DockerSuite) TestBuildAPIRemoteTarballContext(c *check.C) {
 	})
 	defer server.Close()
 
-	res, b, err := request.SockRequestRaw("POST", "/build?remote="+server.URL()+"/testT.tar", nil, "application/tar", daemonHost())
+	res, b, err := request.Post(daemonHost(), "/build?remote="+server.URL()+"/testT.tar", request.ContentType("application/tar"))
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 	b.Close()
@@ -118,7 +119,7 @@ RUN echo 'right'
 	defer server.Close()
 
 	url := "/build?dockerfile=custom&remote=" + server.URL() + "/testT.tar"
-	res, body, err := request.SockRequestRaw("POST", url, nil, "application/tar", daemonHost())
+	res, body, err := request.Post(daemonHost(), url, request.ContentType("application/tar"))
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
@@ -137,7 +138,7 @@ RUN echo from dockerfile`,
 	}, false)
 	defer git.Close()
 
-	res, body, err := request.SockRequestRaw("POST", "/build?remote="+git.RepoURL, nil, "application/json", daemonHost())
+	res, body, err := request.Post(daemonHost(), "/build?remote="+git.RepoURL, request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
@@ -158,7 +159,7 @@ RUN echo from Dockerfile`,
 	defer git.Close()
 
 	// Make sure it tries to 'dockerfile' query param value
-	res, body, err := request.SockRequestRaw("POST", "/build?dockerfile=baz&remote="+git.RepoURL, nil, "application/json", daemonHost())
+	res, body, err := request.Post(daemonHost(), "/build?dockerfile=baz&remote="+git.RepoURL, request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
@@ -180,7 +181,7 @@ RUN echo from dockerfile`,
 	defer git.Close()
 
 	// Make sure it tries to 'dockerfile' query param value
-	res, body, err := request.SockRequestRaw("POST", "/build?remote="+git.RepoURL, nil, "application/json", daemonHost())
+	res, body, err := request.Post(daemonHost(), "/build?remote="+git.RepoURL, request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
@@ -227,7 +228,7 @@ func (s *DockerSuite) TestBuildAPIUnnormalizedTarPaths(c *check.C) {
 		// failed to close tar archive
 		c.Assert(tw.Close(), checker.IsNil)
 
-		res, body, err := request.SockRequestRaw("POST", "/build", buffer, "application/x-tar", daemonHost())
+		res, body, err := request.Post(daemonHost(), "/build", request.RawContent(ioutil.NopCloser(buffer)), request.ContentType("application/x-tar"))
 		c.Assert(err, checker.IsNil)
 		c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 

--- a/integration-cli/docker_api_events_test.go
+++ b/integration-cli/docker_api_events_test.go
@@ -22,7 +22,7 @@ func (s *DockerSuite) TestEventsAPIEmptyOutput(c *check.C) {
 	}
 	chResp := make(chan *apiResp)
 	go func() {
-		resp, body, err := request.SockRequestRaw("GET", "/events", nil, "", daemonHost())
+		resp, body, err := request.Get(daemonHost(), "/events")
 		body.Close()
 		chResp <- &apiResp{resp, err}
 	}()
@@ -47,7 +47,7 @@ func (s *DockerSuite) TestEventsAPIBackwardsCompatible(c *check.C) {
 	q := url.Values{}
 	q.Set("since", ts)
 
-	_, body, err := request.SockRequestRaw("GET", "/events?"+q.Encode(), nil, "", daemonHost())
+	_, body, err := request.Get(daemonHost(), "/events?"+q.Encode())
 	c.Assert(err, checker.IsNil)
 	defer body.Close()
 

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -62,7 +62,7 @@ func (s *DockerSuite) TestExecResizeImmediatelyAfterExecStart(c *check.C) {
 		}
 		defer conn.Close()
 
-		_, rc, err := request.SockRequestRaw("POST", fmt.Sprintf("/exec/%s/resize?h=24&w=80", execID), nil, "text/plain", daemonHost())
+		_, rc, err := request.Post(daemonHost(), fmt.Sprintf("/exec/%s/resize?h=24&w=80", execID), request.ContentType("text/plain"))
 		// It's probably a panic of the daemon if io.ErrUnexpectedEOF is returned.
 		if err == io.ErrUnexpectedEOF {
 			return fmt.Errorf("The daemon might have crashed.")

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -56,14 +56,14 @@ func (s *DockerSuite) TestAPIImagesSaveAndLoad(c *check.C) {
 	buildImageSuccessfully(c, "saveandload", withDockerfile("FROM busybox\nENV FOO bar"))
 	id := getIDByName(c, "saveandload")
 
-	res, body, err := request.SockRequestRaw("GET", "/images/"+id+"/get", nil, "", daemonHost())
+	res, body, err := request.Get(daemonHost(), "/images/"+id+"/get")
 	c.Assert(err, checker.IsNil)
 	defer body.Close()
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
 	dockerCmd(c, "rmi", id)
 
-	res, loadBody, err := request.SockRequestRaw("POST", "/images/load", body, "application/x-tar", daemonHost())
+	res, loadBody, err := request.Post(daemonHost(), "/images/load", request.RawContent(body), request.ContentType("application/x-tar"))
 	c.Assert(err, checker.IsNil)
 	defer loadBody.Close()
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
@@ -119,7 +119,7 @@ func (s *DockerSuite) TestAPIImagesHistory(c *check.C) {
 func (s *DockerSuite) TestAPIImagesSearchJSONContentType(c *check.C) {
 	testRequires(c, Network)
 
-	res, b, err := request.SockRequestRaw("GET", "/images/search?term=test", nil, "application/json", daemonHost())
+	res, b, err := request.Get(daemonHost(), "/images/search?term=test", request.JSON)
 	c.Assert(err, check.IsNil)
 	b.Close()
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"net/http"
 	"strings"
@@ -26,7 +25,7 @@ func (s *DockerSuite) TestLogsAPIWithStdout(c *check.C) {
 	chLog := make(chan logOut)
 
 	go func() {
-		res, body, err := request.SockRequestRaw("GET", fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&timestamps=1", id), nil, "", daemonHost())
+		res, body, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&timestamps=1", id))
 		if err != nil {
 			chLog <- logOut{"", nil, err}
 			return
@@ -70,7 +69,7 @@ func (s *DockerSuite) TestLogsAPIFollowEmptyOutput(c *check.C) {
 	t0 := time.Now()
 	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "sleep", "10")
 
-	_, body, err := request.SockRequestRaw("GET", fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&stderr=1&tail=all", name), bytes.NewBuffer(nil), "", daemonHost())
+	_, body, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&stderr=1&tail=all", name))
 	t1 := time.Now()
 	c.Assert(err, checker.IsNil)
 	body.Close()
@@ -82,7 +81,7 @@ func (s *DockerSuite) TestLogsAPIFollowEmptyOutput(c *check.C) {
 
 func (s *DockerSuite) TestLogsAPIContainerNotFound(c *check.C) {
 	name := "nonExistentContainer"
-	resp, _, err := request.SockRequestRaw("GET", fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&stderr=1&tail=all", name), bytes.NewBuffer(nil), "", daemonHost())
+	resp, _, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&stderr=1&tail=all", name))
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusNotFound)
 }

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -26,7 +26,7 @@ func (s *DockerSuite) TestAPIStatsNoStreamGetCpu(c *check.C) {
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), checker.IsNil)
 
-	resp, body, err := request.SockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", id), nil, "", daemonHost())
+	resp, body, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/stats?stream=false", id))
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(resp.Header.Get("Content-Type"), checker.Equals, "application/json")
@@ -65,7 +65,7 @@ func (s *DockerSuite) TestAPIStatsStoppedContainerInGoroutines(c *check.C) {
 	id := strings.TrimSpace(out)
 
 	getGoRoutines := func() int {
-		_, body, err := request.SockRequestRaw("GET", fmt.Sprintf("/info"), nil, "", daemonHost())
+		_, body, err := request.Get(daemonHost(), fmt.Sprintf("/info"))
 		c.Assert(err, checker.IsNil)
 		info := types.Info{}
 		err = json.NewDecoder(body).Decode(&info)
@@ -76,7 +76,7 @@ func (s *DockerSuite) TestAPIStatsStoppedContainerInGoroutines(c *check.C) {
 
 	// When the HTTP connection is closed, the number of goroutines should not increase.
 	routines := getGoRoutines()
-	_, body, err := request.SockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats", id), nil, "", daemonHost())
+	_, body, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/stats", id))
 	c.Assert(err, checker.IsNil)
 	body.Close()
 
@@ -192,7 +192,7 @@ func (s *DockerSuite) TestAPIStatsNetworkStatsVersioning(c *check.C) {
 func getNetworkStats(c *check.C, id string) map[string]types.NetworkStats {
 	var st *types.StatsJSON
 
-	_, body, err := request.SockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", id), nil, "", daemonHost())
+	_, body, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/stats?stream=false", id))
 	c.Assert(err, checker.IsNil)
 
 	err = json.NewDecoder(body).Decode(&st)
@@ -209,7 +209,7 @@ func getNetworkStats(c *check.C, id string) map[string]types.NetworkStats {
 func getVersionedStats(c *check.C, id string, apiVersion string) map[string]interface{} {
 	stats := make(map[string]interface{})
 
-	_, body, err := request.SockRequestRaw("GET", fmt.Sprintf("/%s/containers/%s/stats?stream=false", apiVersion, id), nil, "", daemonHost())
+	_, body, err := request.Get(daemonHost(), fmt.Sprintf("/%s/containers/%s/stats?stream=false", apiVersion, id))
 	c.Assert(err, checker.IsNil)
 	defer body.Close()
 
@@ -284,7 +284,7 @@ func (s *DockerSuite) TestAPIStatsNoStreamConnectedContainers(c *check.C) {
 
 	ch := make(chan error)
 	go func() {
-		resp, body, err := request.SockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", id2), nil, "", daemonHost())
+		resp, body, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/stats?stream=false", id2))
 		defer body.Close()
 		if err != nil {
 			ch <- err

--- a/integration-cli/docker_api_stats_unix_test.go
+++ b/integration-cli/docker_api_stats_unix_test.go
@@ -16,7 +16,7 @@ import (
 func (s *DockerSuite) TestAPIStatsContainerGetMemoryLimit(c *check.C) {
 	testRequires(c, DaemonIsLinux, memoryLimitSupport)
 
-	resp, body, err := request.SockRequestRaw("GET", "/info", nil, "application/json", daemonHost())
+	resp, body, err := request.Get(daemonHost(), "/info", request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	var info types.Info
@@ -29,7 +29,7 @@ func (s *DockerSuite) TestAPIStatsContainerGetMemoryLimit(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", conName, "busybox", "top")
 	c.Assert(waitRun(conName), checker.IsNil)
 
-	resp, body, err = request.SockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", conName), nil, "", daemonHost())
+	resp, body, err = request.Get(daemonHost(), fmt.Sprintf("/containers/%s/stats?stream=false", conName))
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(resp.Header.Get("Content-Type"), checker.Equals, "application/json")

--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -24,7 +24,7 @@ func (s *DockerSuite) TestAPIOptionsRoute(c *check.C) {
 }
 
 func (s *DockerSuite) TestAPIGetEnabledCORS(c *check.C) {
-	res, body, err := request.SockRequestRaw("GET", "/version", nil, "", daemonHost())
+	res, body, err := request.Get(daemonHost(), "/version")
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 	body.Close()

--- a/integration-cli/docker_cli_update_unix_test.go
+++ b/integration-cli/docker_cli_update_unix_test.go
@@ -220,7 +220,7 @@ func (s *DockerSuite) TestUpdateStats(c *check.C) {
 	c.Assert(waitRun(name), checker.IsNil)
 
 	getMemLimit := func(id string) uint64 {
-		resp, body, err := request.SockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", id), nil, "", daemonHost())
+		resp, body, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/stats?stream=false", id))
 		c.Assert(err, checker.IsNil)
 		c.Assert(resp.Header.Get("Content-Type"), checker.Equals, "application/json")
 

--- a/integration-cli/docker_deprecated_api_v124_test.go
+++ b/integration-cli/docker_deprecated_api_v124_test.go
@@ -150,7 +150,7 @@ func (s *DockerSuite) TestDeprecatedStartWithTooLowMemoryLimit(c *check.C) {
                 "Memory":    524287
         }`
 
-	res, body, err := request.SockRequestRaw("POST", formatV123StartAPIURL("/containers/"+containerID+"/start"), strings.NewReader(config), "application/json", daemonHost())
+	res, body, err := request.Post(daemonHost(), formatV123StartAPIURL("/containers/"+containerID+"/start"), request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	b, err2 := testutil.ReadBody(body)
 	c.Assert(err2, checker.IsNil)
@@ -169,7 +169,7 @@ func (s *DockerSuite) TestDeprecatedPostContainersStartWithoutLinksInHostConfig(
 	hc := inspectFieldJSON(c, name, "HostConfig")
 	config := `{"HostConfig":` + hc + `}`
 
-	res, b, err := request.SockRequestRaw("POST", formatV123StartAPIURL("/containers/"+name+"/start"), strings.NewReader(config), "application/json", daemonHost())
+	res, b, err := request.Post(daemonHost(), formatV123StartAPIURL("/containers/"+name+"/start"), request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusNoContent)
 	b.Close()
@@ -187,7 +187,7 @@ func (s *DockerSuite) TestDeprecatedPostContainersStartWithLinksInHostConfig(c *
 	hc := inspectFieldJSON(c, name, "HostConfig")
 	config := `{"HostConfig":` + hc + `}`
 
-	res, b, err := request.SockRequestRaw("POST", formatV123StartAPIURL("/containers/"+name+"/start"), strings.NewReader(config), "application/json", daemonHost())
+	res, b, err := request.Post(daemonHost(), formatV123StartAPIURL("/containers/"+name+"/start"), request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusNoContent)
 	b.Close()
@@ -205,7 +205,7 @@ func (s *DockerSuite) TestDeprecatedPostContainersStartWithLinksInHostConfigIdLi
 	hc := inspectFieldJSON(c, name, "HostConfig")
 	config := `{"HostConfig":` + hc + `}`
 
-	res, b, err := request.SockRequestRaw("POST", formatV123StartAPIURL("/containers/"+name+"/start"), strings.NewReader(config), "application/json", daemonHost())
+	res, b, err := request.Post(daemonHost(), formatV123StartAPIURL("/containers/"+name+"/start"), request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusNoContent)
 	b.Close()
@@ -219,7 +219,7 @@ func (s *DockerSuite) TestDeprecatedStartWithNilDNS(c *check.C) {
 
 	config := `{"HostConfig": {"Dns": null}}`
 
-	res, b, err := request.SockRequestRaw("POST", formatV123StartAPIURL("/containers/"+containerID+"/start"), strings.NewReader(config), "application/json", daemonHost())
+	res, b, err := request.Post(daemonHost(), formatV123StartAPIURL("/containers/"+containerID+"/start"), request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusNoContent)
 	b.Close()

--- a/integration-cli/request/request.go
+++ b/integration-cli/request/request.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	dclient "github.com/docker/docker/client"
@@ -32,10 +33,30 @@ func Method(method string) func(*http.Request) error {
 	}
 }
 
+// RawString sets the specified string as body for the request
+func RawString(content string) func(*http.Request) error {
+	return RawContent(ioutil.NopCloser(strings.NewReader(content)))
+}
+
+// RawContent sets the specified reader as body for the request
+func RawContent(reader io.ReadCloser) func(*http.Request) error {
+	return func(req *http.Request) error {
+		req.Body = reader
+		return nil
+	}
+}
+
+// ContentType sets the specified Content-Type request header
+func ContentType(contentType string) func(*http.Request) error {
+	return func(req *http.Request) error {
+		req.Header.Set("Content-Type", contentType)
+		return nil
+	}
+}
+
 // JSON sets the Content-Type request header to json
 func JSON(req *http.Request) error {
-	req.Header.Set("Content-Type", "application/json")
-	return nil
+	return ContentType("application/json")(req)
 }
 
 // JSONBody creates a modifier that encodes the specified data to a JSON string and set it as request body. It also sets


### PR DESCRIPTION
`request.SockRequestRaw` is deprecated, let's use appropriate methods
for those. This is a first pass, `SockRequest` still needs to be removed.

/cc @thaJeztah @dnephin @icecrime @cpuguy83 @runcom @AkihiroSuda 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>