### PR TITLE
[multi-arch] skip more plugin tests on non-x86

### DIFF
--- a/integration-cli/docker_cli_daemon_plugins_test.go
+++ b/integration-cli/docker_cli_daemon_plugins_test.go
@@ -287,7 +287,7 @@ func existsMountpointWithPrefix(mountpointPrefix string) (bool, error) {
 }
 
 func (s *DockerDaemonSuite) TestPluginListFilterEnabled(c *check.C) {
-	testRequires(c, Network)
+	testRequires(c, IsAmd64, Network)
 
 	s.d.Start(c)
 
@@ -315,7 +315,7 @@ func (s *DockerDaemonSuite) TestPluginListFilterEnabled(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestPluginListFilterCapability(c *check.C) {
-	testRequires(c, Network)
+	testRequires(c, IsAmd64, Network)
 
 	s.d.Start(c)
 

--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -350,7 +350,7 @@ func (s *DockerTrustSuite) TestPluginUntrustedInstall(c *check.C) {
 }
 
 func (s *DockerSuite) TestPluginIDPrefix(c *check.C) {
-	testRequires(c, DaemonIsLinux, Network)
+	testRequires(c, DaemonIsLinux, IsAmd64, Network)
 	_, _, err := dockerCmdWithError("plugin", "install", "--disable", "--grant-all-permissions", pNameWithTag)
 	c.Assert(err, checker.IsNil)
 


### PR DESCRIPTION
Until the plugins are multi-arch plugins, or built on runtime,
skip these tests like we do with the remainder of the plugin tests.

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>