### PR TITLE
exported add. cli compose loader parsing methods

### DIFF
--- a/cli/compose/loader/loader.go
+++ b/cli/compose/loader/loader.go
@@ -75,7 +75,7 @@ func Load(configDetails types.ConfigDetails) (*types.Config, error) {
 			return nil, err
 		}
 
-		servicesList, err := loadServices(servicesConfig, configDetails.WorkingDir)
+		servicesList, err := LoadServices(servicesConfig, configDetails.WorkingDir)
 		if err != nil {
 			return nil, err
 		}
@@ -89,7 +89,7 @@ func Load(configDetails types.ConfigDetails) (*types.Config, error) {
 			return nil, err
 		}
 
-		networksMapping, err := loadNetworks(networksConfig)
+		networksMapping, err := LoadNetworks(networksConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -103,7 +103,7 @@ func Load(configDetails types.ConfigDetails) (*types.Config, error) {
 			return nil, err
 		}
 
-		volumesMapping, err := loadVolumes(volumesConfig)
+		volumesMapping, err := LoadVolumes(volumesConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -117,7 +117,7 @@ func Load(configDetails types.ConfigDetails) (*types.Config, error) {
 			return nil, err
 		}
 
-		secretsMapping, err := loadSecrets(secretsConfig, configDetails.WorkingDir)
+		secretsMapping, err := LoadSecrets(secretsConfig, configDetails.WorkingDir)
 		if err != nil {
 			return nil, err
 		}
@@ -304,11 +304,13 @@ func formatInvalidKeyError(keyPrefix string, key interface{}) error {
 	return fmt.Errorf("Non-string key %s: %#v", location, key)
 }
 
-func loadServices(servicesDict types.Dict, workingDir string) ([]types.ServiceConfig, error) {
+// LoadServices produces a ServiceConfig map from a compose file Dict
+// the servicesDict is not validated if directly used. Use Load() to enable validation
+func LoadServices(servicesDict types.Dict, workingDir string) ([]types.ServiceConfig, error) {
 	var services []types.ServiceConfig
 
 	for name, serviceDef := range servicesDict {
-		serviceConfig, err := loadService(name, serviceDef.(types.Dict), workingDir)
+		serviceConfig, err := LoadService(name, serviceDef.(types.Dict), workingDir)
 		if err != nil {
 			return nil, err
 		}
@@ -318,7 +320,9 @@ func loadServices(servicesDict types.Dict, workingDir string) ([]types.ServiceCo
 	return services, nil
 }
 
-func loadService(name string, serviceDict types.Dict, workingDir string) (*types.ServiceConfig, error) {
+// LoadService produces a single ServiceConfig from a compose file Dict
+// the serviceDict is not validated if directly used. Use Load() to enable validation
+func LoadService(name string, serviceDict types.Dict, workingDir string) (*types.ServiceConfig, error) {
 	serviceConfig := &types.ServiceConfig{}
 	if err := transform(serviceDict, serviceConfig); err != nil {
 		return nil, err
@@ -405,7 +409,9 @@ func transformUlimits(data interface{}) (interface{}, error) {
 	}
 }
 
-func loadNetworks(source types.Dict) (map[string]types.NetworkConfig, error) {
+// LoadNetworks produces a NetworkConfig map from a compose file Dict
+// the source Dict is not validated if directly used. Use Load() to enable validation
+func LoadNetworks(source types.Dict) (map[string]types.NetworkConfig, error) {
 	networks := make(map[string]types.NetworkConfig)
 	err := transform(source, &networks)
 	if err != nil {
@@ -420,7 +426,9 @@ func loadNetworks(source types.Dict) (map[string]types.NetworkConfig, error) {
 	return networks, nil
 }
 
-func loadVolumes(source types.Dict) (map[string]types.VolumeConfig, error) {
+// LoadVolumes produces a VolumeConfig map from a compose file Dict
+// the source Dict is not validated if directly used. Use Load() to enable validation
+func LoadVolumes(source types.Dict) (map[string]types.VolumeConfig, error) {
 	volumes := make(map[string]types.VolumeConfig)
 	err := transform(source, &volumes)
 	if err != nil {
@@ -435,7 +443,9 @@ func loadVolumes(source types.Dict) (map[string]types.VolumeConfig, error) {
 	return volumes, nil
 }
 
-func loadSecrets(source types.Dict, workingDir string) (map[string]types.SecretConfig, error) {
+// LoadSecrets produces a SecretConfig map from a compose file Dict
+// the source Dict is not validated if directly used. Use Load() to enable validation
+func LoadSecrets(source types.Dict, workingDir string) (map[string]types.SecretConfig, error) {
 	secrets := make(map[string]types.SecretConfig)
 	if err := transform(source, &secrets); err != nil {
 		return secrets, err


### PR DESCRIPTION
Signed-off-by: James Nesbitt <james.nesbitt@wunderkraut.com>

Relates to https://github.com/docker/docker/issues/31440

**- What I did**

I exported some of the loadX methods found in the cli/compose/loader system, to make it possible for others to reuse the core functionality to parse services/networks etc from custom yml config.
This is meant to allow re-using of the core code for parsing compose config, regardless of where it is used.

The changes are all internal to the docker/cli/compose/loader package, and no external impact should be felt.

THIS INTRODUCES THE RISK OF MAINTENANCE OF NEWLY EXPORTED FUNCTIONS
(people are going to expect them to be reliable - but technically they may start to use Load() anyway)

**- How I did it**

The following functions in cli/compose/loader/loader.go were affected:

```
loadServices()
loadService()
loadNetworks()
loadVolumes()
loadSecrets()
```

1. I exported the functions (turned loadX into LoadX) and added a doc line to each
2. Then I updated all calls of those functions

**- How to verify it**

This should produce no external changes, but allows use of the loader as a library.


**- Description for the changelog**

exported more cli/compose/load marshalling functions for re-use
