### PR TITLE
do not ignore "volume in use" errors when force-delete

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/api/errors"
+	apierrors "github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/layer"
 	volumestore "github.com/docker/docker/volume/store"
+	"github.com/pkg/errors"
 )
 
 // ContainerRm removes the container id from the filesystem. An error
@@ -29,7 +30,7 @@ func (daemon *Daemon) ContainerRm(name string, config *types.ContainerRmConfig) 
 	// Container state RemovalInProgress should be used to avoid races.
 	if inProgress := container.SetRemovalInProgress(); inProgress {
 		err := fmt.Errorf("removal of container %s is already in progress", name)
-		return errors.NewBadRequestError(err)
+		return apierrors.NewBadRequestError(err)
 	}
 	defer container.ResetRemovalInProgress()
 
@@ -80,7 +81,7 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 	if container.IsRunning() {
 		if !forceRemove {
 			err := fmt.Errorf("You cannot remove a running container %s. Stop the container before attempting removal or use -f", container.ID)
-			return errors.NewRequestConflictError(err)
+			return apierrors.NewRequestConflictError(err)
 		}
 		if err := daemon.Kill(container); err != nil {
 			return fmt.Errorf("Could not kill running container %s, cannot remove - %v", container.ID, err)
@@ -143,6 +144,9 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 // This is called directly from the Engine API
 func (daemon *Daemon) VolumeRm(name string, force bool) error {
 	err := daemon.volumeRm(name)
+	if err != nil && volumestore.IsInUse(err) {
+		return apierrors.NewRequestConflictError(err)
+	}
 	if err == nil || force {
 		daemon.volumes.Purge(name)
 		return nil
@@ -157,11 +161,7 @@ func (daemon *Daemon) volumeRm(name string) error {
 	}
 
 	if err := daemon.volumes.Remove(v); err != nil {
-		if volumestore.IsInUse(err) {
-			err := fmt.Errorf("Unable to remove volume, volume still in use: %v", err)
-			return errors.NewRequestConflictError(err)
-		}
-		return fmt.Errorf("Error while removing volume %s: %v", name, err)
+		return errors.Wrap(err, "unable to remove volume")
 	}
 	daemon.LogVolumeEvent(v.Name(), "destroy", map[string]string{"driver": v.DriverName()})
 	return nil


### PR DESCRIPTION
fixes https://github.com/docker/docker/issues/31446

When using `docker volume rm -f`, all errors were ignored, and volumes where Purged, even if they were still in use by a container. As a result, repeated calls to `docker volume rm -f` actually removed the volume.

The `-f` option was implemented to ignore errors in case a volume was already removed out-of-band by a volume driver plugin.

This patch changes the remove function to not ignore "volume in use" errors if `-f` is used. Other errors are still ignored as before.

**- How to verify it**

```
$ docker volume create my-volume
my-volume

$ docker create -v my-volume:/volume busybox

# then run `docker volume rm -f` multiple times; it should produce an error each time
$ docker volume rm my-volume
$ docker volume rm my-volume

# the volume should still be present
$ docker volume ls
```

**- Description for the changelog**

Fix a bug where `docker volume rm -f` was removing volumes that were still in use by a container.

**- A picture of a cute animal (not mandatory but encouraged)**

![loving-mother-cow-and-calf1](https://cloud.githubusercontent.com/assets/1804568/23462230/42be466c-fe8d-11e6-9c04-ba557706cbe0.jpg)