### PR TITLE
Move TearDownTest cleaning to environment package

### DIFF
--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -20,23 +20,19 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
-	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/daemon"
+	"github.com/docker/docker/integration-cli/environment"
 	"github.com/docker/docker/integration-cli/registry"
 	"github.com/docker/docker/integration-cli/request"
-	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/stringutils"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
 
+// Deprecated
 func daemonHost() string {
-	daemonURLStr := "unix://" + opts.DefaultUnixSocket
-	if daemonHostVar := os.Getenv("DOCKER_HOST"); daemonHostVar != "" {
-		daemonURLStr = daemonHostVar
-	}
-	return daemonURLStr
+	return environment.DaemonHost()
 }
 
 // FIXME(vdemeester) move this away are remove ignoreNoSuchContainer bool
@@ -58,141 +54,12 @@ func getAllContainers(c *check.C) string {
 	return result.Combined()
 }
 
+// Deprecated
 func deleteAllContainers(c *check.C) {
 	containers := getAllContainers(c)
 	if containers != "" {
 		err := deleteContainer(true, strings.Split(strings.TrimSpace(containers), "\n")...)
 		c.Assert(err, checker.IsNil)
-	}
-}
-
-func deleteAllNetworks(c *check.C) {
-	networks, err := getAllNetworks()
-	c.Assert(err, check.IsNil)
-	var errs []string
-	for _, n := range networks {
-		if n.Name == "bridge" || n.Name == "none" || n.Name == "host" {
-			continue
-		}
-		if testEnv.DaemonPlatform() == "windows" && strings.ToLower(n.Name) == "nat" {
-			// nat is a pre-defined network on Windows and cannot be removed
-			continue
-		}
-		status, b, err := request.SockRequest("DELETE", "/networks/"+n.Name, nil, daemonHost())
-		if err != nil {
-			errs = append(errs, err.Error())
-			continue
-		}
-		if status != http.StatusNoContent {
-			errs = append(errs, fmt.Sprintf("error deleting network %s: %s", n.Name, string(b)))
-		}
-	}
-	c.Assert(errs, checker.HasLen, 0, check.Commentf(strings.Join(errs, "\n")))
-}
-
-func getAllNetworks() ([]types.NetworkResource, error) {
-	var networks []types.NetworkResource
-	_, b, err := request.SockRequest("GET", "/networks", nil, daemonHost())
-	if err != nil {
-		return nil, err
-	}
-	if err := json.Unmarshal(b, &networks); err != nil {
-		return nil, err
-	}
-	return networks, nil
-}
-
-func deleteAllPlugins(c *check.C) {
-	plugins, err := getAllPlugins()
-	c.Assert(err, checker.IsNil)
-	var errs []string
-	for _, p := range plugins {
-		pluginName := p.Name
-		status, b, err := request.SockRequest("DELETE", "/plugins/"+pluginName+"?force=1", nil, daemonHost())
-		if err != nil {
-			errs = append(errs, err.Error())
-			continue
-		}
-		if status != http.StatusOK {
-			errs = append(errs, fmt.Sprintf("error deleting plugin %s: %s", p.Name, string(b)))
-		}
-	}
-	c.Assert(errs, checker.HasLen, 0, check.Commentf(strings.Join(errs, "\n")))
-}
-
-func getAllPlugins() (types.PluginsListResponse, error) {
-	var plugins types.PluginsListResponse
-	_, b, err := request.SockRequest("GET", "/plugins", nil, daemonHost())
-	if err != nil {
-		return nil, err
-	}
-	if err := json.Unmarshal(b, &plugins); err != nil {
-		return nil, err
-	}
-	return plugins, nil
-}
-
-func deleteAllVolumes(c *check.C) {
-	volumes, err := getAllVolumes()
-	c.Assert(err, checker.IsNil)
-	var errs []string
-	for _, v := range volumes {
-		status, b, err := request.SockRequest("DELETE", "/volumes/"+v.Name, nil, daemonHost())
-		if err != nil {
-			errs = append(errs, err.Error())
-			continue
-		}
-		if status != http.StatusNoContent {
-			errs = append(errs, fmt.Sprintf("error deleting volume %s: %s", v.Name, string(b)))
-		}
-	}
-	c.Assert(errs, checker.HasLen, 0, check.Commentf(strings.Join(errs, "\n")))
-}
-
-func getAllVolumes() ([]*types.Volume, error) {
-	var volumes volumetypes.VolumesListOKBody
-	_, b, err := request.SockRequest("GET", "/volumes", nil, daemonHost())
-	if err != nil {
-		return nil, err
-	}
-	if err := json.Unmarshal(b, &volumes); err != nil {
-		return nil, err
-	}
-	return volumes.Volumes, nil
-}
-
-func deleteAllImages(c *check.C) {
-	cmd := exec.Command(dockerBinary, "images", "--digests")
-	cmd.Env = appendBaseEnv(true)
-	out, err := cmd.CombinedOutput()
-	c.Assert(err, checker.IsNil)
-	lines := strings.Split(string(out), "\n")[1:]
-	imgMap := map[string]struct{}{}
-	for _, l := range lines {
-		if l == "" {
-			continue
-		}
-		fields := strings.Fields(l)
-		imgTag := fields[0] + ":" + fields[1]
-		if _, ok := protectedImages[imgTag]; !ok {
-			if fields[0] == "<none>" || fields[1] == "<none>" {
-				if fields[2] != "<none>" {
-					imgMap[fields[0]+"@"+fields[2]] = struct{}{}
-				} else {
-					imgMap[fields[3]] = struct{}{}
-				}
-				// continue
-			} else {
-				imgMap[imgTag] = struct{}{}
-			}
-		}
-	}
-	if len(imgMap) != 0 {
-		imgs := make([]string, 0, len(imgMap))
-		for k := range imgMap {
-			imgs = append(imgs, k)
-		}
-		dockerCmd(c, append([]string{"rmi", "-f"}, imgs...)...)
 	}
 }
 
@@ -206,6 +73,7 @@ func unpauseContainer(c *check.C, container string) {
 	dockerCmd(c, "unpause", container)
 }
 
+// Deprecated
 func unpauseAllContainers(c *check.C) {
 	containers := getPausedContainers(c)
 	for _, value := range containers {
@@ -487,7 +355,7 @@ func newRemoteFileServer(c *check.C, ctx *FakeContext) *remoteFileServer {
 		container = fmt.Sprintf("fileserver-cnt-%s", strings.ToLower(stringutils.GenerateRandomAlphaOnlyString(10)))
 	)
 
-	c.Assert(ensureHTTPServerImage(), checker.IsNil)
+	ensureHTTPServerImage(c)
 
 	// Build the image
 	fakeContextAddDockerfile(c, ctx, `FROM httpserver

--- a/integration-cli/environment/clean.go
+++ b/integration-cli/environment/clean.go
@@ -1,0 +1,213 @@
+package environment
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/docker/docker/api/types"
+	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/integration-cli/request"
+	"github.com/docker/docker/opts"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
+)
+
+type testingT interface {
+	logT
+	Fatalf(string, ...interface{})
+}
+
+type logT interface {
+	Logf(string, ...interface{})
+}
+
+// Clean the environment, preserving protected objects (images, containers, ...)
+// and removing everything else. It's meant to run after any tests so that they don't
+// depend on each others.
+func (e *Execution) Clean(t testingT, dockerBinary string) {
+	unpauseAllContainers(t, dockerBinary)
+	deleteAllContainers(t, dockerBinary)
+	deleteAllImages(t, dockerBinary, e.protectedElements.images)
+	deleteAllVolumes(t, dockerBinary)
+	deleteAllNetworks(t, dockerBinary, e.DaemonPlatform())
+	if e.DaemonPlatform() == "linux" {
+		deleteAllPlugins(t, dockerBinary)
+	}
+}
+
+func unpauseAllContainers(t testingT, dockerBinary string) {
+	containers := getPausedContainers(t, dockerBinary)
+	if len(containers) > 0 {
+		icmd.RunCommand(dockerBinary, append([]string{"unpause"}, containers...)...).Assert(t, icmd.Success)
+	}
+}
+
+func getPausedContainers(t testingT, dockerBinary string) []string {
+	result := icmd.RunCommand(dockerBinary, "ps", "-f", "status=paused", "-q", "-a")
+	result.Assert(t, icmd.Success)
+	return strings.Fields(result.Combined())
+}
+
+func deleteAllContainers(t testingT, dockerBinary string) {
+	containers := getAllContainers(t, dockerBinary)
+	if len(containers) > 0 {
+		icmd.RunCommand(dockerBinary, append([]string{"rm", "-fv"}, containers...)...).Assert(t, icmd.Success)
+	}
+}
+
+func getAllContainers(t testingT, dockerBinary string) []string {
+	result := icmd.RunCommand(dockerBinary, "ps", "-q", "-a")
+	result.Assert(t, icmd.Success)
+	return strings.Fields(result.Combined())
+}
+
+func deleteAllImages(t testingT, dockerBinary string, protectedImages map[string]struct{}) {
+	result := icmd.RunCommand(dockerBinary, "images", "--digests")
+	result.Assert(t, icmd.Success)
+	lines := strings.Split(string(result.Combined()), "\n")[1:]
+	imgMap := map[string]struct{}{}
+	for _, l := range lines {
+		if l == "" {
+			continue
+		}
+		fields := strings.Fields(l)
+		imgTag := fields[0] + ":" + fields[1]
+		if _, ok := protectedImages[imgTag]; !ok {
+			if fields[0] == "<none>" || fields[1] == "<none>" {
+				if fields[2] != "<none>" {
+					imgMap[fields[0]+"@"+fields[2]] = struct{}{}
+				} else {
+					imgMap[fields[3]] = struct{}{}
+				}
+				// continue
+			} else {
+				imgMap[imgTag] = struct{}{}
+			}
+		}
+	}
+	if len(imgMap) != 0 {
+		imgs := make([]string, 0, len(imgMap))
+		for k := range imgMap {
+			imgs = append(imgs, k)
+		}
+		icmd.RunCommand(dockerBinary, append([]string{"rmi", "-f"}, imgs...)...).Assert(t, icmd.Success)
+	}
+}
+
+func deleteAllVolumes(t testingT, dockerBinary string) {
+	volumes, err := getAllVolumes()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	var errs []string
+	for _, v := range volumes {
+		status, b, err := request.SockRequest("DELETE", "/volumes/"+v.Name, nil, DaemonHost())
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+		if status != http.StatusNoContent {
+			errs = append(errs, fmt.Sprintf("error deleting volume %s: %s", v.Name, string(b)))
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("%v", strings.Join(errs, "\n"))
+	}
+}
+
+func getAllVolumes() ([]*types.Volume, error) {
+	var volumes volumetypes.VolumesListOKBody
+	_, b, err := request.SockRequest("GET", "/volumes", nil, DaemonHost())
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(b, &volumes); err != nil {
+		return nil, err
+	}
+	return volumes.Volumes, nil
+}
+
+func deleteAllNetworks(t testingT, dockerBinary string, daemonPlatform string) {
+	networks, err := getAllNetworks()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	var errs []string
+	for _, n := range networks {
+		if n.Name == "bridge" || n.Name == "none" || n.Name == "host" {
+			continue
+		}
+		if daemonPlatform == "windows" && strings.ToLower(n.Name) == "nat" {
+			// nat is a pre-defined network on Windows and cannot be removed
+			continue
+		}
+		status, b, err := request.SockRequest("DELETE", "/networks/"+n.Name, nil, DaemonHost())
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+		if status != http.StatusNoContent {
+			errs = append(errs, fmt.Sprintf("error deleting network %s: %s", n.Name, string(b)))
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("%v", strings.Join(errs, "\n"))
+	}
+}
+
+func getAllNetworks() ([]types.NetworkResource, error) {
+	var networks []types.NetworkResource
+	_, b, err := request.SockRequest("GET", "/networks", nil, DaemonHost())
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(b, &networks); err != nil {
+		return nil, err
+	}
+	return networks, nil
+}
+
+func deleteAllPlugins(t testingT, dockerBinary string) {
+	plugins, err := getAllPlugins()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	var errs []string
+	for _, p := range plugins {
+		pluginName := p.Name
+		status, b, err := request.SockRequest("DELETE", "/plugins/"+pluginName+"?force=1", nil, DaemonHost())
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+		if status != http.StatusOK {
+			errs = append(errs, fmt.Sprintf("error deleting plugin %s: %s", p.Name, string(b)))
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("%v", strings.Join(errs, "\n"))
+	}
+}
+
+func getAllPlugins() (types.PluginsListResponse, error) {
+	var plugins types.PluginsListResponse
+	_, b, err := request.SockRequest("GET", "/plugins", nil, DaemonHost())
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(b, &plugins); err != nil {
+		return nil, err
+	}
+	return plugins, nil
+}
+
+// DaemonHost return the daemon host string for this test execution
+func DaemonHost() string {
+	daemonURLStr := "unix://" + opts.DefaultUnixSocket
+	if daemonHostVar := os.Getenv("DOCKER_HOST"); daemonHostVar != "" {
+		daemonURLStr = daemonHostVar
+	}
+	return daemonURLStr
+}

--- a/integration-cli/environment/environment.go
+++ b/integration-cli/environment/environment.go
@@ -32,6 +32,8 @@ type Execution struct {
 	// baseImage is the name of the base image for testing
 	// Environment variable WINDOWS_BASE_IMAGE can override this
 	baseImage string
+
+	protectedElements protectedElements
 }
 
 // New creates a new Execution struct
@@ -100,6 +102,9 @@ func New() (*Execution, error) {
 		daemonPid:            daemonPid,
 		experimentalDaemon:   info.ExperimentalBuild,
 		baseImage:            baseImage,
+		protectedElements: protectedElements{
+			images: map[string]struct{}{},
+		},
 	}, nil
 }
 func getDaemonDockerInfo() (types.Info, error) {

--- a/integration-cli/environment/protect.go
+++ b/integration-cli/environment/protect.go
@@ -1,0 +1,12 @@
+package environment
+
+// ProtectImage adds the specified image(s) to be protected in case of clean
+func (e *Execution) ProtectImage(t testingT, images ...string) {
+	for _, image := range images {
+		e.protectedElements.images[image] = struct{}{}
+	}
+}
+
+type protectedElements struct {
+	images map[string]struct{}
+}

--- a/integration-cli/fixtures_linux_daemon_test.go
+++ b/integration-cli/fixtures_linux_daemon_test.go
@@ -31,9 +31,7 @@ func ensureFrozenImagesLinux(t testingT) {
 		t.Logf(dockerCmdWithError("images"))
 		t.Fatalf("%+v", err)
 	}
-	for _, img := range images {
-		protectedImages[img] = struct{}{}
-	}
+	defer testEnv.ProtectImage(t, images...)
 }
 
 var ensureSyscallTestOnce sync.Once
@@ -46,7 +44,7 @@ func ensureSyscallTest(c *check.C) {
 	if !doIt {
 		return
 	}
-	protectedImages["syscall-test:latest"] = struct{}{}
+	defer testEnv.ProtectImage(c, "syscall-test:latest")
 
 	// if no match, must build in docker, which is significantly slower
 	// (slower mostly because of the vfs graphdriver)
@@ -104,7 +102,7 @@ func ensureSyscallTestBuild(c *check.C) {
 }
 
 func ensureNNPTest(c *check.C) {
-	protectedImages["nnp-test:latest"] = struct{}{}
+	defer testEnv.ProtectImage(c, "nnp-test:latest")
 	if testEnv.DaemonPlatform() != runtime.GOOS {
 		ensureNNPTestBuild(c)
 		return


### PR DESCRIPTION
Move the clean functions of integration-cli in the `environment` package (and mainly in `testEnv.Clean(…)` function).

It just move the function to the package with the smallest change possible 👼 . First part of #30759 which I'll close.

/cc @thaJeztah @tonistiigi @tiborvass @dnephin @icecrime @cpuguy83 @LK4D4 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>