### PR TITLE
Added "Provides: docker-engine"

### DIFF
--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -100,6 +100,9 @@ Conflicts: docker
 Conflicts: docker-io
 Conflicts: docker-engine-cs
 
+# provides package
+Provides: docker-engine
+
 %description
 Docker is an open source project to build, ship and run any application as a
 lightweight container.


### PR DESCRIPTION
Added "Provides: docker-engine" so that it can be referred to by other packages to ensure the docker-engine capability is provided.
More detail at: http://rpm.org/user_doc/dependencies.html

fixes #31463