### PR TITLE
remove Jekyll tags from CLI reference

### DIFF
--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -195,7 +195,6 @@ attach`, `docker exec`, `docker run` or `docker start` command.
 Following is a sample `config.json` file:
 
 ```json
-{% raw %}
 {
   "HttpHeaders": {
     "MyHeader": "MyValue"
@@ -213,7 +212,6 @@ Following is a sample `config.json` file:
     "unicorn.example.com": "vcbait"
   }
 }
-{% endraw %}
 ```
 
 ### Notary

--- a/docs/reference/commandline/commit.md
+++ b/docs/reference/commandline/commit.md
@@ -72,7 +72,6 @@ svendowideit/testimage            version3            f5283438590d        16 sec
 ### Commit a container with new configurations
 
 ```bash
-{% raw %}
 $ docker ps
 
 ICONTAINER ID       IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
@@ -90,7 +89,6 @@ f5283438590d
 $ docker inspect -f "{{ .Config.Env }}" f5283438590d
 
 [HOME=/ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin DEBUG=true]
-{% endraw %}
 ```
 
 ### Commit a container with new `CMD` and `EXPOSE` instructions

--- a/docs/reference/commandline/container_prune.md
+++ b/docs/reference/commandline/container_prune.md
@@ -70,7 +70,6 @@ fraction of a second no more than nine digits long.
 The following removes containers created more than 5 minutes ago:
 
 ```bash
-{% raw %}
 $ docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}\t{{.Status}}'
 
 CONTAINER ID        IMAGE               COMMAND             CREATED AT                      STATUS
@@ -88,13 +87,11 @@ $ docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}
 
 CONTAINER ID        IMAGE               COMMAND             CREATED AT                      STATUS
 61b9efa71024        busybox             "sh"                2017-01-04 13:23:33 -0800 PST   Exited (0) 44 seconds ago
-{% endraw %}
 ```
 
 The following removes containers created before `2017-01-04T13:10:00`:
 
 ```bash
-{% raw %}
 $ docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}\t{{.Status}}'
 
 CONTAINER ID        IMAGE               COMMAND             CREATED AT                      STATUS
@@ -112,7 +109,6 @@ $ docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}
 
 CONTAINER ID        IMAGE               COMMAND             CREATED AT                      STATUS
 53a9bc23a516        busybox             "sh"                2017-01-04 13:11:59 -0800 PST   Exited (0) 9 minutes ago
-{% endraw %}
 ```
 
 ## Related commands

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -326,7 +326,6 @@ $ docker events --filter 'type=plugin'
 ### Format the output
 
 ```bash
-{% raw %}
 $ docker events --filter 'type=container' --format 'Type={{.Type}}  Status={{.Status}}  ID={{.ID}}'
 
 Type=container  Status=create  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
@@ -335,13 +334,11 @@ Type=container  Status=start  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c1
 Type=container  Status=resize  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
 Type=container  Status=die  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
 Type=container  Status=destroy  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
-{% endraw %}
 ```
 
 #### Format as JSON
 
 ```none
-{% raw %}
     $ docker events --format '{{json .}}'
 
     {"status":"create","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
@@ -349,5 +346,4 @@ Type=container  Status=destroy  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299
     {"Type":"network","Action":"connect","Actor":{"ID":"1b50a5bf755f6021dfa78e..
     {"status":"start","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f42..
     {"status":"resize","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
-{% endraw %}
 ```

--- a/docs/reference/commandline/image_prune.md
+++ b/docs/reference/commandline/image_prune.md
@@ -92,7 +92,6 @@ fraction of a second no more than nine digits long.
 The following removes images created before `2017-01-04T00:00:00`:
 
 ```bash
-{% raw %}
 $ docker images --format 'table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedAt}}\t{{.Size}}'
 REPOSITORY          TAG                 IMAGE ID            CREATED AT                      SIZE
 foo                 latest              2f287ac753da        2017-01-04 13:42:23 -0800 PST   3.98 MB
@@ -115,7 +114,6 @@ $ docker images --format 'table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedAt
 
 REPOSITORY          TAG                 IMAGE ID            CREATED AT                      SIZE
 foo                 latest              2f287ac753da        2017-01-04 13:42:23 -0800 PST   3.98 MB
-{% endraw %}
 ```
 
 The following removes images created more than 10 days (`240h`) ago:

--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -309,7 +309,6 @@ The following example uses a template without headers and outputs the
 `ID` and `Repository` entries separated by a colon for all images:
 
 ```bash
-{% raw %}
 $ docker images --format "{{.ID}}: {{.Repository}}"
 
 77af4d6b9913: <none>
@@ -321,14 +320,12 @@ b6fa739cedf5: committ
 746b819f315e: postgres
 746b819f315e: postgres
 746b819f315e: postgres
-{% endraw %}
 ```
 
 To list all images with their repository and tag in a table format you
 can use:
 
 ```bash
-{% raw %}
 $ docker images --format "table {{.ID}}\t{{.Repository}}\t{{.Tag}}"
 
 IMAGE ID            REPOSITORY                TAG
@@ -341,5 +338,4 @@ b6fa739cedf5        committ                   latest
 746b819f315e        postgres                  9.3
 746b819f315e        postgres                  9.3.5
 746b819f315e        postgres                  latest
-{% endraw %}
 ```

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -197,7 +197,6 @@ The global `-D` option causes all `docker` commands to output debug information.
 You can also specify the output format:
 
 ```bash
-{% raw %}
 $ docker info --format '{{json .}}'
 
 {"ID":"I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S","Containers":14, ...}

--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -45,33 +45,25 @@ For the most part, you can pick out any field from the JSON in a fairly
 straightforward manner.
 
 ```bash
-{% raw %}
 $ docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $INSTANCE_ID
-{% endraw %}
 ```
 
 ### Get an instance's MAC address
 
 ```bash
-{% raw %}
 $ docker inspect --format='{{range .NetworkSettings.Networks}}{{.MacAddress}}{{end}}' $INSTANCE_ID
-{% endraw %}
 ```
 
 ### Get an instance's log path
 
 ```bash
-{% raw %}
 $ docker inspect --format='{{.LogPath}}' $INSTANCE_ID
-{% endraw %}
 ```
 
 ### Get an instance's image name
 
 ```bash
-{% raw %}
 $ docker inspect --format='{{.Container.Spec.Image}}' $INSTANCE_ID
-{% endraw %}
 ```
 
 ### List all port bindings
@@ -80,9 +72,7 @@ You can loop over arrays and maps in the results to produce simple text
 output:
 
 ```bash
-{% raw %}
 $ docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' $INSTANCE_ID
-{% endraw %}
 ```
 
 ### Find a specific port mapping
@@ -96,9 +86,7 @@ then `index` 0 contains the first object inside of that. Then we ask for
 the `HostPort` field to get the public address.
 
 ```bash
-{% raw %}
 $ docker inspect --format='{{(index (index .NetworkSettings.Ports "8787/tcp") 0).HostPort}}' $INSTANCE_ID
-{% endraw %}
 ```
 
 ### Get a subsection in JSON format
@@ -109,7 +97,5 @@ Docker adds a template function, `json`, which can be applied to get
 results in JSON format.
 
 ```bash
-{% raw %}
 $ docker inspect --format='{{json .Config}}' $INSTANCE_ID
-{% endraw %}
 ```

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -109,7 +109,6 @@ $ docker node inspect swarm-manager
 ### Specify an output format
 
 ```none
-{% raw %}
 $ docker node inspect --format '{{ .ManagerStatus.Leader }}' self
 
 false
@@ -136,7 +135,6 @@ Plugins:
   Network:              overlay, bridge, null, host, overlay
   Volume:               local
 Engine Version:         1.12.0
-{% endraw %}
 ```
 
 ## Related commands

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -148,11 +148,9 @@ $ docker plugin inspect tiborvass/sample-volume-plugin:latest
 ### Formatting the output
 
 ```bash
-{% raw %}
 $ docker plugin inspect -f '{{.Id}}' tiborvass/sample-volume-plugin:latest
 
 8c74c978c434745c3ade82f1bc0acf38d04990eaf494fa507c16d9f1daa99c21
-{% endraw %}
 ```
 
 

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -101,11 +101,9 @@ The following example uses a template without headers and outputs the
 `ID` and `Name` entries separated by a colon for all plugins:
 
 ```bash
-{% raw %}
 $ docker plugin ls --format "{{.ID}}: {{.Name}}"
 
 4be01827a72e: tiborvass/no-remove
-{% endraw %}
 ```
 
 

--- a/docs/reference/commandline/plugin_set.md
+++ b/docs/reference/commandline/plugin_set.md
@@ -42,7 +42,6 @@ The following example change the env variable `DEBUG` on the
 `sample-volume-plugin` plugin.
 
 ```bash
-{% raw %}
 $ docker plugin inspect -f {{.Settings.Env}} tiborvass/sample-volume-plugin
 
 [DEBUG=0]
@@ -51,7 +50,6 @@ $ docker plugin set tiborvass/sample-volume-plugin DEBUG=1
 
 $ docker plugin inspect -f {{.Settings.Env}} tiborvass/sample-volume-plugin
 [DEBUG=1]
-{% endraw %}
 ```
 
 ### Change the source of a mount
@@ -60,7 +58,6 @@ The following example change the source of the `mymount` mount on
 the `myplugin` plugin.
 
 ```bash
-{% raw %}
 $ docker plugin inspect -f '{{with $mount := index .Settings.Mounts 0}}{{$mount.Source}}{{end}}' myplugin
 /foo
 
@@ -68,7 +65,6 @@ $ docker plugins set myplugin mymount.source=/bar
 
 $ docker plugin inspect -f '{{with $mount := index .Settings.Mounts 0}}{{$mount.Source}}{{end}}' myplugin
 /bar
-{% endraw %}
 ```
 
 > **Note**: Since only `source` is settable in `mymount`,
@@ -80,7 +76,6 @@ The following example change the path of the `mydevice` device on
 the `myplugin` plugin.
 
 ```bash
-{% raw %}
 $ docker plugin inspect -f '{{with $device := index .Settings.Devices 0}}{{$device.Path}}{{end}}' myplugin
 /dev/foo
 
@@ -88,7 +83,6 @@ $ docker plugins set myplugin mydevice.path=/dev/bar
 
 $ docker plugin inspect -f '{{with $device := index .Settings.Devices 0}}{{$device.Path}}{{end}}' myplugin
 /dev/bar
-{% endraw %}
 ```
 
 > **Note**: Since only `path` is settable in `mydevice`,
@@ -99,7 +93,6 @@ $ docker plugin inspect -f '{{with $device := index .Settings.Devices 0}}{{$devi
 The following example change the source of the args on the `myplugin` plugin.
 
 ```bash
-{% raw %}
 $ docker plugin inspect -f '{{.Settings.Args}}' myplugin
 ["foo", "bar"]
 
@@ -107,7 +100,6 @@ $ docker plugins set myplugin args="foo bar baz"
 
 $ docker plugin inspect -f '{{.Settings.Args}}' myplugin
 ["foo", "bar", "baz"]
-{% endraw %}
 ```
 
 ## Related commands

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -300,7 +300,6 @@ The `volume` filter shows only containers that mount a specific volume or have
 a volume mounted in a specific path:
 
 ```bash
-{% raw %}
 $ docker ps --filter volume=remote-volume --format "table {{.ID}}\t{{.Mounts}}"
 CONTAINER ID        MOUNTS
 9c3527ed70ce        remote-volume
@@ -308,7 +307,6 @@ CONTAINER ID        MOUNTS
 $ docker ps --filter volume=/data --format "table {{.ID}}\t{{.Mounts}}"
 CONTAINER ID        MOUNTS
 9c3527ed70ce        remote-volume
-{% endraw %}
 ```
 
 #### network
@@ -334,9 +332,7 @@ example shows all containers that are attached to the `net1` network, using
 the network id as a filter;
 
 ```bash
-{% raw %}
 $ docker network inspect --format "{{.ID}}" net1
-{% endraw %}
 
 8c0b4110ae930dbe26b258de9bc34a03f98056ed6f27f991d32919bfe401d7c5
 
@@ -403,7 +399,7 @@ Placeholder   | Description
 `.Size`       | Container disk size.
 `.Names`      | Container names.
 `.Labels`     | All labels assigned to the container.
-`.Label`      | Value of a specific label for this container. For example `'{% raw %}{{.Label "com.docker.swarm.cpu"}}{% endraw %}'`
+`.Label`      | Value of a specific label for this container. For example `'{{.Label "com.docker.swarm.cpu"}}'`
 `.Mounts`     | Names of the volumes mounted in this container.
 `.Networks`   | Names of the networks attached to this container.
 
@@ -415,9 +411,7 @@ The following example uses a template without headers and outputs the `ID` and
 `Command` entries separated by a colon for all running containers:
 
 ```bash
-{% raw %}
 $ docker ps --format "{{.ID}}: {{.Command}}"
-{% endraw %}
 
 a87ecb4f327c: /bin/sh -c #(nop) MA
 01946d9d34d8: /bin/sh -c #(nop) MA
@@ -428,9 +422,7 @@ c1d3b0166030: /bin/sh -c yum -y up
 To list all running containers with their labels in a table format you can use:
 
 ```bash
-{% raw %}
 $ docker ps --format "table {{.ID}}\t{{.Labels}}"
-{% endraw %}
 
 CONTAINER ID        LABELS
 a87ecb4f327c        com.docker.swarm.node=ubuntu,com.docker.swarm.storage=ssd

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -543,7 +543,6 @@ retrieve the container's ID once the container has finished running.
 ### Add host device to container (--device)
 
 ```bash
-{% raw %}
 $ docker run --device=/dev/sdc:/dev/xvdc \
              --device=/dev/sdd --device=/dev/zero:/dev/nulo \
              -i -t \
@@ -552,7 +551,6 @@ $ docker run --device=/dev/sdc:/dev/xvdc \
 brw-rw---- 1 root disk 8, 2 Feb  9 16:05 /dev/xvdc
 brw-rw---- 1 root disk 8, 3 Feb  9 16:05 /dev/sdd
 crw-rw-rw- 1 root root 1, 5 Feb  9 16:05 /dev/nulo
-{% endraw %}
 ```
 
 It is often necessary to directly expose devices to a container. The `--device`
@@ -636,10 +634,8 @@ using IPv4 or IPv6 networking in your containers. Use the following
 flags for IPv4 address retrieval for a network device named `eth0`:
 
 ```bash
-{% raw %}
 $ HOSTIP=`ip -4 addr show scope global dev eth0 | grep inet | awk '{print \$2}' | cut -d / -f 1`
 $ docker run  --add-host=docker:${HOSTIP} --rm -it debian
-{% endraw %}
 ```
 
 For IPv6 use the `-6` flag instead of the `-4` flag. For other network

--- a/docs/reference/commandline/secret_inspect.md
+++ b/docs/reference/commandline/secret_inspect.md
@@ -75,11 +75,9 @@ secret. The following example command outputs the creation time of the
 secret.
 
 ```bash
-{% raw %}
 $ docker secret inspect --format='{{.CreatedAt}}' mhv17xfe3gh6xc4rij5orpfds
 
 2016-10-27 23:25:43.909181089 +0000 UTC
-{% endraw %}
 ```
 
 

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -548,9 +548,8 @@ In this example, we are going to set the template of the created containers base
 service's name and the node's ID where it sits.
 
 ```bash
-{% raw %}
 $ docker service create --name hosttempl \
-                        --hostname={% raw %}"{{.Node.ID}}-{{.Service.Name}}"\
+                        --hostname="{{.Node.ID}}-{{.Service.Name}}"\
                          busybox top
 
 va8ew30grofhjoychbr6iot8c
@@ -563,7 +562,6 @@ wo41w8hg8qan  hosttempl.1  busybox:latest@sha256:29f5d56d12684887bdfa50dcd29fc31
 $ docker inspect --format="{{.Config.Hostname}}" hosttempl.1.wo41w8hg8qanxwjwsg4kxpprj
 
 x3ti0erg11rjpg64m75kej2mz-hosttempl
-{% endraw %}
 ```
 
 ## Related commands

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -153,11 +153,9 @@ service. For example, the following command outputs the number of replicas
 of the "redis" service.
 
 ```bash
-{% raw %}
 $ docker service inspect --format='{{.Spec.Mode.Replicated.Replicas}}' redis
 
 10
-{% endraw %}
 ```
 
 

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -133,12 +133,10 @@ The following example uses a template without headers and outputs the
 `ID`, `Mode`, and `Replicas` entries separated by a colon for all services:
 
 ```bash
-{% raw %}
 $ docker service ls --format "{{.ID}}: {{.Mode}} {{.Replicas}}"
 
 0zmvwuiu3vue: replicated 10/10
 fm6uf97exkul: global 5/5
-{% endraw %}
 ```
 
 ## Related commands

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -90,12 +90,10 @@ The following example uses a template without headers and outputs the
 `ID`, `Mode`, and `Replicas` entries separated by a colon for all services:
 
 ```bash
-{% raw %}
 $ docker stack services --format "{{.ID}}: {{.Mode}} {{.Replicas}}"
 
 0zmvwuiu3vue: replicated 10/10
 fm6uf97exkul: global 5/5
-{% endraw %}
 ```
 
 

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -120,25 +120,21 @@ The following example uses a template without headers and outputs the
 `Container` and `CPUPerc` entries separated by a colon for all images:
 
 ```bash
-{% raw %}
 $ docker stats --format "{{.Container}}: {{.CPUPerc}}"
 
 09d3bb5b1604: 6.61%
 9db7aa4d986d: 9.19%
 3f214c61ad1d: 0.00%
-{% endraw %}
 ```
 
 To list all containers statistics with their name, CPU percentage and memory
 usage in a table format you can use:
 
 ```bash
-{% raw %}
 $ docker stats --format "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}"
 
 CONTAINER           CPU %               PRIV WORKING SET
 1285939c1fd3        0.07%               796 KiB / 64 MiB
 9c76f7834ae2        0.07%               2.746 MiB / 64 MiB
 d1ea048f04e4        0.03%               4.583 MiB / 64 MiB
-{% endraw %}
 ```

--- a/docs/reference/commandline/version.md
+++ b/docs/reference/commandline/version.md
@@ -60,19 +60,15 @@ OS/Arch:      linux/amd64
 ### Get the server version
 
 ```bash
-{% raw %}
 $ docker version --format '{{.Server.Version}}'
 
 1.8.0
-{% endraw %}
 ```
 
 ### Dump raw JSON data
 
 ```bash
-{% raw %}
 $ docker version --format '{{json .}}'
 
 {"Client":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"},"ServerOK":true,"Server":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","KernelVersion":"3.13.2-gentoo","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"}}
-{% endraw %}
 ```

--- a/docs/reference/commandline/volume_inspect.md
+++ b/docs/reference/commandline/volume_inspect.md
@@ -48,10 +48,8 @@ $ docker volume inspect 85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443
   }
 ]
 
-{% raw %}
 $ docker volume inspect --format '{{ .Mountpoint }}' 85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d
 /var/lib/docker/volumes/85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d/_data
-{% endraw %}
 ```
 
 ## Related commands

--- a/docs/reference/commandline/volume_ls.md
+++ b/docs/reference/commandline/volume_ls.md
@@ -183,13 +183,11 @@ The following example uses a template without headers and outputs the
 `Name` and `Driver` entries separated by a colon for all volumes:
 
 ```bash
-{% raw %}
 $ docker volume ls --format "{{.Name}}: {{.Driver}}"
 
 vol1: local
 vol2: local
 vol3: local
-{% endraw %}
 ```
 
 ## Related commands


### PR DESCRIPTION
These Markdown files are now embedded in a YAML file for templating in the documentation, and these special markers are no longer needed.

