### PR TITLE
profiles: seccomp: fix !seccomp build

### DIFF
--- a/profiles/seccomp/seccomp_unsupported.go
+++ b/profiles/seccomp/seccomp_unsupported.go
@@ -8,6 +8,6 @@ import (
 )
 
 // DefaultProfile returns a nil pointer on unsupported systems.
-func DefaultProfile(rs *specs.Spec) *types.Seccomp {
+func DefaultProfile() *types.Seccomp {
 	return nil
 }


### PR DESCRIPTION
Previously building with seccomp disabled would cause build failures
because of a mismatch in the type signatures of DefaultProfile().

[![kitteh](https://c2.staticflickr.com/4/3147/2567501805_17ee8fd947_z.jpg)](https://flic.kr/p/4UT7Qv) [1]

[1]: [Yvonne Lin on Flickr](https://www.flickr.com/photos/birdcantfly/)

Signed-off-by: Aleksa Sarai <asarai@suse.de>