### PR TITLE
[RFC] Make MountFlags=slave for RPM based distros

### DIFF
--- a/contrib/init/systemd/docker.service.rpm-centos
+++ b/contrib/init/systemd/docker.service.rpm-centos
@@ -1,0 +1,36 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network-online.target firewalld.service
+Wants=network-online.target
+
+[Service]
+Type=notify
+# the default is not to use systemd for cgroups because the delegate issues still
+# exists and systemd currently does not support the cgroup feature set required
+# for containers run by docker
+ExecStart=/usr/bin/dockerd
+ExecReload=/bin/kill -s HUP $MAINPID
+
+# MountFlags "slave" is needed on RHEL/CentOS 7.3 kernels to prevent device busy error
+MountFlags=slave
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=infinity
+LimitNPROC=infinity
+LimitCORE=infinity
+# Uncomment TasksMax if your systemd version supports it.
+# Only systemd 226 and above support this version.
+#TasksMax=infinity
+TimeoutStartSec=0
+# set delegate yes so that systemd does not reset the cgroups of docker containers
+Delegate=yes
+# kill only the docker process, not all processes in the cgroup
+KillMode=process
+# restart the docker process if it exits prematurely
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
+
+[Install]
+WantedBy=multi-user.target

--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -161,7 +161,14 @@ install -d $RPM_BUILD_ROOT/%{_initddir}
 
 %if 0%{?is_systemd}
 install -d $RPM_BUILD_ROOT/%{_unitdir}
+
+%if 0%{?centos} || 0%{?rhel}
+# rhel/centos 7.3 kernels need MountFlags=slave (TODO remove once 7.4 is released with an updated kernel)
+install -p -m 644 contrib/init/systemd/docker.service.rpm-centos $RPM_BUILD_ROOT/%{_unitdir}/docker.service
+%else
 install -p -m 644 contrib/init/systemd/docker.service.rpm $RPM_BUILD_ROOT/%{_unitdir}/docker.service
+%endif
+
 %else
 install -p -m 644 contrib/init/sysvinit-redhat/docker.sysconfig $RPM_BUILD_ROOT/etc/sysconfig/docker
 install -p -m 755 contrib/init/sysvinit-redhat/docker $RPM_BUILD_ROOT/%{_initddir}/docker


### PR DESCRIPTION
Commit 791f98290e0e88c76cb916d6e1d211467f36e230 removed MountFlags=slave to allow shared mount propagation.

However, it turns out this is causing issues with installations running devicemapper, which may be resolved in RHEL7.4.

This patch reverts the change, and adds MountFlags=slave back for rpm-based distros (e.g., RHEL, CentOS, Fedora)

relates to https://github.com/docker/docker/pull/22806, https://github.com/docker/docker/issues/31489, https://github.com/docker/docker/issues/27381


Alternatively, we can add instructions to the documentation for users that use device mapper, and explain how to add a drop-in file to make this configuration.

/cc @rhvgoyal @rhatdan @cpuguy83 