### PR TITLE
Healthchecks should inherit environment

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -78,6 +78,7 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, container *container.Cont
 	execConfig.Tty = false
 	execConfig.Privileged = false
 	execConfig.User = container.Config.User
+	execConfig.Env = container.Config.Env
 
 	d.registerExecCommand(container, execConfig)
 	d.LogContainerEvent(container, "exec_create: "+execConfig.Entrypoint+" "+strings.Join(execConfig.Args, " "))


### PR DESCRIPTION
Signed-off-by: David McKay <david@rawkode.com>

I was adding a `HEALTHCHECK` to a container and noticed that I couldn't utilise environment variables; meaning I had to duplicate some variables:

```yaml
healthcheck:
  test: ["CMD-SHELL", "mysql --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} -e 'SHOW TABLES' ${MYSQL_DATABASE}"]
```
**- What I did**
Assigning the containers `Env` to the healthcheck environment

**- Description for the changelog**
Making a containers environment variables available to the healthcheck command

![image](https://cloud.githubusercontent.com/assets/145816/23516402/0465c3e4-ff65-11e6-95c1-f5155356fa97.png)

