### PR TITLE
"Save our build times" aka Add support for mounts during docker build

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -125,6 +125,15 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 		options.CacheFrom = cacheFrom
 	}
 
+	var volumes = []string{}
+	volumesJSON := r.FormValue("volumes")
+	if volumesJSON != "" {
+		if err := json.Unmarshal([]byte(volumesJSON), &volumes); err != nil {
+			return nil, err
+		}
+		options.Volumes = volumes
+	}
+
 	return options, nil
 }
 

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progress"
@@ -125,13 +126,13 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 		options.CacheFrom = cacheFrom
 	}
 
-	var volumes = []string{}
-	volumesJSON := r.FormValue("volumes")
-	if volumesJSON != "" {
-		if err := json.Unmarshal([]byte(volumesJSON), &volumes); err != nil {
+	var mounts = []mount.Mount{}
+	mountsJSON := r.FormValue("mounts")
+	if mountsJSON != "" {
+		if err := json.Unmarshal([]byte(mountsJSON), &mounts); err != nil {
 			return nil, err
 		}
-		options.Volumes = volumes
+		options.Mounts = mounts
 	}
 
 	return options, nil

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4549,18 +4549,19 @@ paths:
         `container:<name|id>`. Any other value is taken as a custom network's
         name to which this container should connect to."
           type: "string"
-        - name: "volumes"
+        - name: "mounts"
           in: "query"
           description: |
-            A list of volume bindings for this container. Each volume binding is a string in one of these forms:
+            This is a JSON array of mounts to be used during build-time only. For example:
 
-            - `host-src:container-dest` to bind-mount a host path into the container. Both `host-src`, and `container-dest` must be an _absolute_ path.
-            - `host-src:container-dest:ro` to make the bind-mount read-only inside the container. Both `host-src`, and `container-dest` must be an _absolute_ path.
-            - `volume-name:container-dest` to bind-mount a volume managed by a volume driver into the container. `container-dest` must be an _absolute_ path.
-            - `volume-name:container-dest:ro` to mount the volume read-only inside the container.  `container-dest` must be an _absolute_ path.
-          type: "array"
-          items:
-            type: "string"
+            ```
+            [{
+              type: "bind",
+              source: "/path/to/host/folder",
+              target: "/path/to/container/folder"
+            }]
+            ```
+          type: "string"
         - name: "Content-type"
           in: "header"
           type: "string"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4549,6 +4549,18 @@ paths:
         `container:<name|id>`. Any other value is taken as a custom network's
         name to which this container should connect to."
           type: "string"
+        - name: "volumes"
+          in: "query"
+          description: |
+            A list of volume bindings for this container. Each volume binding is a string in one of these forms:
+
+            - `host-src:container-dest` to bind-mount a host path into the container. Both `host-src`, and `container-dest` must be an _absolute_ path.
+            - `host-src:container-dest:ro` to make the bind-mount read-only inside the container. Both `host-src`, and `container-dest` must be an _absolute_ path.
+            - `volume-name:container-dest` to bind-mount a volume managed by a volume driver into the container. `container-dest` must be an _absolute_ path.
+            - `volume-name:container-dest:ro` to mount the volume read-only inside the container.  `container-dest` must be an _absolute_ path.
+          type: "array"
+          items:
+            type: "string"
         - name: "Content-type"
           in: "header"
           type: "string"

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -177,6 +177,7 @@ type ImageBuildOptions struct {
 	CacheFrom   []string
 	SecurityOpt []string
 	ExtraHosts  []string // List of extra hosts
+	Volumes     []string // List of build-time volumes
 }
 
 // ImageBuildResponse holds information

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/go-units"
 )
 
@@ -176,8 +177,8 @@ type ImageBuildOptions struct {
 	// specified here do not need to have a valid parent chain to match cache.
 	CacheFrom   []string
 	SecurityOpt []string
-	ExtraHosts  []string // List of extra hosts
-	Volumes     []string // List of build-time volumes
+	ExtraHosts  []string      // List of extra hosts
+	Mounts      []mount.Mount // List of build-time mounts
 }
 
 // ImageBuildResponse holds information

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -500,6 +500,7 @@ func (b *Builder) create() (string, error) {
 		// Set a log config to override any default value set on the daemon
 		LogConfig:  defaultLogConfig,
 		ExtraHosts: b.options.ExtraHosts,
+		Binds:      b.options.Volumes,
 	}
 
 	config := *b.runConfig

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -500,7 +500,7 @@ func (b *Builder) create() (string, error) {
 		// Set a log config to override any default value set on the daemon
 		LogConfig:  defaultLogConfig,
 		ExtraHosts: b.options.ExtraHosts,
-		Binds:      b.options.Volumes,
+		Mounts:     b.options.Mounts,
 	}
 
 	config := *b.runConfig

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -39,7 +39,7 @@ type buildOptions struct {
 	labels         opts.ListOpts
 	buildArgs      opts.ListOpts
 	extraHosts     opts.ListOpts
-	volumes        opts.ListOpts
+	mounts         opts.MountOpt
 	ulimits        *opts.UlimitOpt
 	memory         string
 	memorySwap     string
@@ -72,7 +72,7 @@ func NewBuildCommand(dockerCli *command.DockerCli) *cobra.Command {
 		ulimits:    opts.NewUlimitOpt(&ulimits),
 		labels:     opts.NewListOpts(opts.ValidateEnv),
 		extraHosts: opts.NewListOpts(opts.ValidateExtraHost),
-		volumes:    opts.NewListOpts(nil),
+		mounts:     opts.NewMountOpt(),
 	}
 
 	cmd := &cobra.Command{
@@ -113,7 +113,7 @@ func NewBuildCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.StringVar(&options.networkMode, "network", "default", "Set the networking mode for the RUN instructions during build")
 	flags.SetAnnotation("network", "version", []string{"1.25"})
 	flags.Var(&options.extraHosts, "add-host", "Add a custom host-to-IP mapping (host:ip)")
-	flags.VarP(&options.volumes, "volume", "v", "Bind mount a volume")
+	flags.Var(&options.mounts, "mount", "Attach a filesystem mount to the service")
 
 	command.AddTrustVerificationFlags(flags)
 
@@ -308,7 +308,7 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 		NetworkMode:    options.networkMode,
 		Squash:         options.squash,
 		ExtraHosts:     options.extraHosts.GetAll(),
-		Volumes:        options.volumes.GetAll(),
+		Mounts:         options.mounts.Value(),
 	}
 
 	response, err := dockerCli.Client().ImageBuild(ctx, body, buildOptions)

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -39,6 +39,7 @@ type buildOptions struct {
 	labels         opts.ListOpts
 	buildArgs      opts.ListOpts
 	extraHosts     opts.ListOpts
+	volumes        opts.ListOpts
 	ulimits        *opts.UlimitOpt
 	memory         string
 	memorySwap     string
@@ -71,6 +72,7 @@ func NewBuildCommand(dockerCli *command.DockerCli) *cobra.Command {
 		ulimits:    opts.NewUlimitOpt(&ulimits),
 		labels:     opts.NewListOpts(opts.ValidateEnv),
 		extraHosts: opts.NewListOpts(opts.ValidateExtraHost),
+		volumes:    opts.NewListOpts(nil),
 	}
 
 	cmd := &cobra.Command{
@@ -111,6 +113,7 @@ func NewBuildCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.StringVar(&options.networkMode, "network", "default", "Set the networking mode for the RUN instructions during build")
 	flags.SetAnnotation("network", "version", []string{"1.25"})
 	flags.Var(&options.extraHosts, "add-host", "Add a custom host-to-IP mapping (host:ip)")
+	flags.VarP(&options.volumes, "volume", "v", "Bind mount a volume")
 
 	command.AddTrustVerificationFlags(flags)
 
@@ -305,6 +308,7 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 		NetworkMode:    options.networkMode,
 		Squash:         options.squash,
 		ExtraHosts:     options.extraHosts.GetAll(),
+		Volumes:        options.volumes.GetAll(),
 	}
 
 	response, err := dockerCli.Client().ImageBuild(ctx, body, buildOptions)

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -120,5 +120,11 @@ func (cli *Client) imageBuildOptionsToQuery(options types.ImageBuildOptions) (ur
 	}
 	query.Set("cachefrom", string(cacheFromJSON))
 
+	volumesJSON, err := json.Marshal(options.Volumes)
+	if err != nil {
+		return query, err
+	}
+	query.Set("volumes", string(volumesJSON))
+
 	return query, nil
 }

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -120,11 +120,11 @@ func (cli *Client) imageBuildOptionsToQuery(options types.ImageBuildOptions) (ur
 	}
 	query.Set("cachefrom", string(cacheFromJSON))
 
-	volumesJSON, err := json.Marshal(options.Volumes)
+	mountsJSON, err := json.Marshal(options.Mounts)
 	if err != nil {
 		return query, err
 	}
-	query.Set("volumes", string(volumesJSON))
+	query.Set("mounts", string(mountsJSON))
 
 	return query, nil
 }

--- a/opts/mount.go
+++ b/opts/mount.go
@@ -16,6 +16,11 @@ type MountOpt struct {
 	values []mounttypes.Mount
 }
 
+// NewMountOpt creates a new MountOpt
+func NewMountOpt() MountOpt {
+	return MountOpt{}
+}
+
 // Set a new mount value
 func (m *MountOpt) Set(value string) error {
 	csvReader := csv.NewReader(strings.NewReader(value))


### PR DESCRIPTION
#### What this does

- Allows `--mount`s to be specified during `docker build`
- Example: `docker build --mount type=bind,source=/hostpath,target=/containerpath ...`
- Various different use cases have been documented in #14080 

#### Checklist

- [ ] Fixes #14080 (eventually)
- [x] Initial barebones commit, adds and passes through mount flags in client & server
- [x] Dockerfile is able to `ls` the mount only while building, and does not exist in image metadata or when running
- [x] Use `--mount` instead of `-v`
- [x] Existing test suite passes, no breakage in any existing behavior
- [ ] Design review and feedback, `/build` api, cli, etc
- [ ] TBD: Add test cases
- [ ] TBD: Add build cache invalidation (equivalent to `--no-cache`) if mount definitions are changed
- [ ] TBD: Add docs, `mount` options are less documented in general, difference between `docker run -v` and `docker build --mount`, general warnings and disclaimers, how to invalidate cache, etc
- [ ] TBD: Edge cases, file permissions when copying from volume, post-build leftovers (ideally none except an empty folder is present), running inside a container with docker.sock bind-mounted, volume drivers, mounts overlapping with `ADD/COPY` inside build context/workdir, etc

Signed-off-by: Subhas Dandapani <rdsubhas@gmail.com>

Obligatory picture of how it feels like in the beginning. Slowly warming up. [Great developer docs](https://docs.docker.com/opensource/project/who-written-for/) 👍 It was really shocking how simple this was to get working though. All these years of orchestrating `docker build` as much as (or sometimes more than) `docker run` for sake of performance and developer productivity feels like a lie. Hope we can move forward...

![that works?](http://i.giphy.com/R1Pb5mAXJ7YEE.gif)
