### PR TITLE
Improve POSIX compatibility of bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -581,7 +581,7 @@ __docker_subcommands() {
 			$(__docker_to_extglob "$subcommands") )
 				subcommand_pos=$counter
 				local subcommand=${words[$counter]}
-				local completions_func=_docker_${command}_${subcommand}
+				local completions_func=_docker_${command}_${subcommand//-/_}
 				declare -F $completions_func >/dev/null && $completions_func
 				return 0
 				;;
@@ -671,7 +671,7 @@ __docker_complete_capabilities_droppable() {
 	" -- "$cur" ) )
 }
 
-__docker_complete_detach-keys() {
+__docker_complete_detach_keys() {
 	case "$prev" in
 		--detach-keys)
 			case "$cur" in
@@ -1074,7 +1074,7 @@ _docker_container() {
 }
 
 _docker_container_attach() {
-	__docker_complete_detach-keys && return
+	__docker_complete_detach_keys && return
 
 	case "$cur" in
 		-*)
@@ -1181,7 +1181,7 @@ _docker_container_diff() {
 }
 
 _docker_container_exec() {
-	__docker_complete_detach-keys && return
+	__docker_complete_detach_keys && return
 
 	case "$prev" in
 		--env|-e)
@@ -1550,7 +1550,7 @@ _docker_container_run_and_create() {
 			--rm
 			--sig-proxy=false
 		"
-		__docker_complete_detach-keys && return
+		__docker_complete_detach_keys && return
 	fi
 
 	local all_options="$options_with_args $boolean_options"
@@ -1744,7 +1744,7 @@ _docker_container_run_and_create() {
 }
 
 _docker_container_start() {
-	__docker_complete_detach-keys && return
+	__docker_complete_detach_keys && return
 
 	case "$prev" in
 		--checkpoint)
@@ -3247,7 +3247,7 @@ _docker_swarm_join() {
 	esac
 }
 
-_docker_swarm_join-token() {
+_docker_swarm_join_token() {
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "--help --quiet -q --rotate" -- "$cur" ) )
@@ -3277,7 +3277,7 @@ _docker_swarm_unlock() {
 	esac
 }
 
-_docker_swarm_unlock-key() {
+_docker_swarm_unlock_key() {
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "--help --quiet -q --rotate" -- "$cur" ) )
@@ -4441,7 +4441,7 @@ _docker() {
 		command_pos=0
 	fi
 
-	local completions_func=_docker_${command}
+	local completions_func=_docker_${command//-/_}
 	declare -F $completions_func >/dev/null && $completions_func
 
 	eval "$previous_extglob_setting"


### PR DESCRIPTION
Fixes #31504
See also https://github.com/docker/compose/pull/1170

Some systems out there run bash in POSIX mode by default. In POSIX mode, bash does not accept function names that contain dashes:
```bash
$ bash /usr/share/bash-completion/completions/docker
$ bash --posix /usr/share/bash-completion/completions/docker
/usr/share/bash-completion/completions/docker: line 670: `__docker_complete_detach-keys': not a valid identifier
```
This PR changes several function names to `s/-/_/` and the logic to compute the functions from command and subcommand names. The same logic already exists in bash completion for Compose.

@tianon PTAL