### PR TITLE
Improve error handling of commands run against unsupported daemon

### DIFF
--- a/cli/command/node/cmd.go
+++ b/cli/command/node/cmd.go
@@ -15,6 +15,7 @@ func NewNodeCommand(dockerCli *command.DockerCli) *cobra.Command {
 		Short: "Manage Swarm nodes",
 		Args:  cli.NoArgs,
 		RunE:  dockerCli.ShowHelp,
+		Tags:  map[string]string{"version": "1.24"},
 	}
 	cmd.AddCommand(
 		newDemoteCommand(dockerCli),

--- a/cli/command/plugin/cmd.go
+++ b/cli/command/plugin/cmd.go
@@ -13,6 +13,7 @@ func NewPluginCommand(dockerCli *command.DockerCli) *cobra.Command {
 		Short: "Manage plugins",
 		Args:  cli.NoArgs,
 		RunE:  dockerCli.ShowHelp,
+		Tags:  map[string]string{"version": "1.25"},
 	}
 
 	cmd.AddCommand(

--- a/cli/command/plugin/upgrade.go
+++ b/cli/command/plugin/upgrade.go
@@ -26,6 +26,7 @@ func newUpgradeCommand(dockerCli *command.DockerCli) *cobra.Command {
 			}
 			return runUpgrade(dockerCli, options)
 		},
+		Tags: map[string]string{"version": "1.26"},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/secret/cmd.go
+++ b/cli/command/secret/cmd.go
@@ -14,6 +14,7 @@ func NewSecretCommand(dockerCli *command.DockerCli) *cobra.Command {
 		Short: "Manage Docker secrets",
 		Args:  cli.NoArgs,
 		RunE:  dockerCli.ShowHelp,
+		Tags:  map[string]string{"version": "1.25"},
 	}
 	cmd.AddCommand(
 		newSecretListCommand(dockerCli),

--- a/cli/command/service/cmd.go
+++ b/cli/command/service/cmd.go
@@ -14,6 +14,7 @@ func NewServiceCommand(dockerCli *command.DockerCli) *cobra.Command {
 		Short: "Manage services",
 		Args:  cli.NoArgs,
 		RunE:  dockerCli.ShowHelp,
+		Tags:  map[string]string{"version": "1.24"},
 	}
 	cmd.AddCommand(
 		newCreateCommand(dockerCli),

--- a/cli/command/swarm/cmd.go
+++ b/cli/command/swarm/cmd.go
@@ -14,6 +14,7 @@ func NewSwarmCommand(dockerCli *command.DockerCli) *cobra.Command {
 		Short: "Manage Swarm",
 		Args:  cli.NoArgs,
 		RunE:  dockerCli.ShowHelp,
+		Tags:  map[string]string{"version": "1.24"},
 	}
 	cmd.AddCommand(
 		newInitCommand(dockerCli),

--- a/cli/command/volume/cmd.go
+++ b/cli/command/volume/cmd.go
@@ -13,6 +13,7 @@ func NewVolumeCommand(dockerCli *command.DockerCli) *cobra.Command {
 		Short: "Manage volumes",
 		Args:  cli.NoArgs,
 		RunE:  dockerCli.ShowHelp,
+		Tags:  map[string]string{"version": "1.21"},
 	}
 	cmd.AddCommand(
 		newCreateCommand(dockerCli),


### PR DESCRIPTION
The current error-handling only checked for version annotations on the subcommand itself, but did not check the top-level command.

This patch always traverses the command path (parents), and prints an error if the command is not supported.

Before this change:

    $ docker service
    Usage:	docker service COMMAND

    Manage services

    Options:
          --help   Print usage

    Commands:
      create      Create a new service
      inspect     Display detailed information on one or more services
      ls          List services
      ps          List the tasks of one or more services
      rm          Remove one or more services
      scale       Scale one or multiple replicated services
      update      Update a service

    Run 'docker service COMMAND --help' for more information on a command.

    $ docker service ls
    ID                  NAME                MODE                REPLICAS            IMAGE

After this change:

    $ DOCKER_API_VERSION=1.12 docker service
    docker service requires API version 1.24, but the Docker daemon API version is 1.12

    $ DOCKER_API_VERSION=1.12 docker service ls
    docker service ls requires API version 1.24, but the Docker daemon API version is 1.12

    $ DOCKER_API_VERSION=1.24 docker plugin --help
    docker plugin requires API version 1.25, but the Docker daemon API version is 1.24

    $ DOCKER_API_VERSION=1.25 docker plugin upgrade --help
    docker plugin upgrade requires API version 1.26, but the Docker daemon API version is 1.25


**- Description for the changelog**

Improve error handling of commands run against older daemons
