### PR TITLE
Ignore no such container in testEnv.Clean

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1261,7 +1261,7 @@ func (s *DockerSuite) TestPutContainerArchiveErrSymlinkInVolumeToReadOnlyRootfs(
 		readOnly: true,
 		volumes:  defaultVolumes(testVol), // Our bind mount is at /vol2
 	})
-	defer deleteContainer(false, cID)
+	defer deleteContainer(cID)
 
 	// Attempt to extract to a symlink in the volume which points to a
 	// directory outside the volume. This should cause an error because the

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -42,7 +42,7 @@ func setupImageWithTag(c *check.C, tag string) (digest.Digest, error) {
 	c.Assert(err, checker.IsNil, check.Commentf("image tagging failed: %s", out))
 
 	// delete the container as we don't need it any more
-	err = deleteContainer(false, containerName)
+	err = deleteContainer(containerName)
 	c.Assert(err, checker.IsNil)
 
 	// push the image

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2029,7 +2029,7 @@ func (s *DockerSuite) TestRunDeallocatePortOnMissingIptablesRule(c *check.C) {
 	icmd.RunCommand("iptables", "-D", "DOCKER", "-d", fmt.Sprintf("%s/32", ip),
 		"!", "-i", "docker0", "-o", "docker0", "-p", "tcp", "-m", "tcp", "--dport", "23", "-j", "ACCEPT").Assert(c, icmd.Success)
 
-	if err := deleteContainer(false, id); err != nil {
+	if err := deleteContainer(id); err != nil {
 		c.Fatal(err)
 	}
 

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -36,16 +36,8 @@ func daemonHost() string {
 }
 
 // FIXME(vdemeester) move this away are remove ignoreNoSuchContainer bool
-func deleteContainer(ignoreNoSuchContainer bool, container ...string) error {
-	result := icmd.RunCommand(dockerBinary, append([]string{"rm", "-fv"}, container...)...)
-	if ignoreNoSuchContainer && result.Error != nil {
-		// If the error is "No such container: ..." this means the container doesn't exists anymore,
-		// we can safely ignore that one.
-		if strings.Contains(result.Stderr(), "No such container") {
-			return nil
-		}
-	}
-	return result.Compare(icmd.Success)
+func deleteContainer(container ...string) error {
+	return icmd.RunCommand(dockerBinary, append([]string{"rm", "-fv"}, container...)...).Compare(icmd.Success)
 }
 
 func getAllContainers(c *check.C) string {
@@ -58,7 +50,7 @@ func getAllContainers(c *check.C) string {
 func deleteAllContainers(c *check.C) {
 	containers := getAllContainers(c)
 	if containers != "" {
-		err := deleteContainer(true, strings.Split(strings.TrimSpace(containers), "\n")...)
+		err := deleteContainer(strings.Split(strings.TrimSpace(containers), "\n")...)
 		c.Assert(err, checker.IsNil)
 	}
 }
@@ -346,7 +338,7 @@ func (f *remoteFileServer) Close() error {
 	if f.container == "" {
 		return nil
 	}
-	return deleteContainer(false, f.container)
+	return deleteContainer(f.container)
 }
 
 func newRemoteFileServer(c *check.C, ctx *FakeContext) *remoteFileServer {


### PR DESCRIPTION
When moving the clean function there, this check was not ported and
generated some errors on the CI. `deleteContainer` now fail if any
error but the clean function won't if "no such container" (because of
some races -_-).

/cc @dnephin @cpuguy83 @thaJeztah @tonistiigi 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
