### PR TITLE
Allows environment variables to be lazily expanded on container run

### DIFF
--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	OpenStdin       bool                // Open stdin
 	StdinOnce       bool                // If true, close stdin after the 1 attached client disconnects.
 	Env             []string            // List of environment variable to set in the container
+	LazyEnvVarNames []string            `json:",omitempty"` // List of environment variable names that should be expanded at runtime
 	Cmd             strslice.StrSlice   // Command to run when starting the container
 	Healthcheck     *HealthConfig       `json:",omitempty"` // Healthcheck describes how to check the container is healthy
 	ArgsEscaped     bool                `json:",omitempty"` // True if command is already escaped (Windows specific)

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -105,7 +105,7 @@ func TestCommandsTooManyArguments(t *testing.T) {
 }
 
 func TestCommandseBlankNames(t *testing.T) {
-	bflags := &BFlags{}
+	bflags := &BFlags{flags: make(map[string]*Flag)}
 	config := &container.Config{}
 
 	b := &Builder{flags: bflags, runConfig: config, disableCommit: true}
@@ -133,7 +133,7 @@ func TestCommandseBlankNames(t *testing.T) {
 func TestEnv2Variables(t *testing.T) {
 	variables := []string{"var1", "val1", "var2", "val2"}
 
-	bflags := &BFlags{}
+	bflags := &BFlags{flags: make(map[string]*Flag)}
 	config := &container.Config{}
 
 	b := &Builder{flags: bflags, runConfig: config, disableCommit: true}

--- a/builder/dockerfile/shell_parser_test.go
+++ b/builder/dockerfile/shell_parser_test.go
@@ -51,7 +51,7 @@ func TestShellParser4EnvVars(t *testing.T) {
 
 		if ((words[0] == "W" || words[0] == "A") && runtime.GOOS == "windows") ||
 			((words[0] == "U" || words[0] == "A") && runtime.GOOS != "windows") {
-			newWord, err := ProcessWord(words[1], envs, '\\')
+			newWord, _, err := ProcessWord(words[1], envs, make([]string, 0), '\\', false)
 
 			if err != nil {
 				newWord = "error"
@@ -95,7 +95,7 @@ func TestShellParser4Words(t *testing.T) {
 		test := strings.TrimSpace(words[0])
 		expected := strings.Split(strings.TrimLeft(words[1], " "), ",")
 
-		result, err := ProcessWords(test, envs, '\\')
+		result, _, err := ProcessWords(test, envs, make([]string, 0), '\\', false)
 
 		if err != nil {
 			result = []string{"error"}
@@ -120,36 +120,36 @@ func TestGetEnv(t *testing.T) {
 	}
 
 	sw.envs = []string{}
-	if sw.getEnv("foo") != "" {
+	if sw.getEnv("foo").value != "" {
 		t.Fatal("2 - 'foo' should map to ''")
 	}
 
 	sw.envs = []string{"foo"}
-	if sw.getEnv("foo") != "" {
+	if sw.getEnv("foo").value != "" {
 		t.Fatal("3 - 'foo' should map to ''")
 	}
 
 	sw.envs = []string{"foo="}
-	if sw.getEnv("foo") != "" {
+	if sw.getEnv("foo").value != "" {
 		t.Fatal("4 - 'foo' should map to ''")
 	}
 
 	sw.envs = []string{"foo=bar"}
-	if sw.getEnv("foo") != "bar" {
+	if sw.getEnv("foo").value != "bar" {
 		t.Fatal("5 - 'foo' should map to 'bar'")
 	}
 
 	sw.envs = []string{"foo=bar", "car=hat"}
-	if sw.getEnv("foo") != "bar" {
+	if sw.getEnv("foo").value != "bar" {
 		t.Fatal("6 - 'foo' should map to 'bar'")
 	}
-	if sw.getEnv("car") != "hat" {
+	if sw.getEnv("car").value != "hat" {
 		t.Fatal("7 - 'car' should map to 'hat'")
 	}
 
 	// Make sure we grab the first 'car' in the list
 	sw.envs = []string{"foo=bar", "car=hat", "car=bike"}
-	if sw.getEnv("car") != "hat" {
+	if sw.getEnv("car").value != "hat" {
 		t.Fatal("8 - 'car' should map to 'hat'")
 	}
 }

--- a/builder/dockerfile/shell_parser_unix.go
+++ b/builder/dockerfile/shell_parser_unix.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package dockerfile
+
+func (sw *shellWord) lazyExpandedVariableReference(varName string) string {
+	return "${" + varName + "}"
+}

--- a/builder/dockerfile/shell_parser_windows.go
+++ b/builder/dockerfile/shell_parser_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package dockerfile
+
+func (sw *shellWord) lazyExpandedVariableReference(varName string) string {
+	return "${env:" + varName + "}"
+}

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -62,6 +62,28 @@ func merge(userConf, imageConf *containertypes.Config) error {
 		}
 	}
 
+	if len(userConf.LazyEnvVarNames) == 0 {
+		userConf.LazyEnvVarNames = imageConf.LazyEnvVarNames
+	} else {
+		for _, imageEnvKey := range imageConf.LazyEnvVarNames {
+			found := false
+			for _, userEnvKey := range userConf.LazyEnvVarNames {
+				if runtime.GOOS == "windows" {
+					// Case insensitive environment variables on Windows
+					imageEnvKey = strings.ToUpper(imageEnvKey)
+					userEnvKey = strings.ToUpper(userEnvKey)
+				}
+				if imageEnvKey == userEnvKey {
+					found = true
+					break
+				}
+			}
+			if !found {
+				userConf.LazyEnvVarNames = append(userConf.LazyEnvVarNames, imageEnvKey)
+			}
+		}
+	}
+
 	if userConf.Labels == nil {
 		userConf.Labels = map[string]string{}
 	}


### PR DESCRIPTION
Context:
On Windows, environment variables can be either volatile (scoped to a
process and its children, like on Linux), or persisted (stored in
registry, shared accross sessions, even sometimes accross users).

The current ENV dockerfile command does not consider that a particular
variable can have a living value stored in the container registry simply
because persisted variables does not exist on *nix platforms.

This is a problem, very well illustrated by a simple file:
```
FROM microsoft/nanoserver
ADD .\\bin c:\\myapp
ENV PATH ${PATH};c:\\myapp
RUN echo %PATH%
```
In this example, the builder does not consider that PATH can have a
living value in the stored base image and overrides its value with
`;c:\\myapp`. this breaks basically the whole Windows

The way I solved this, is by introducing a flag to the ENV command
telling the variable should be expanded at runtime:
```
ENV --lazy-expand PATH ${PATH};c:\\myapp
```

The lazy-expandiness of a variable is stored in the image configuration,
and when running a container for an image with such parameters, the
processStart info is modified to expand these variables in powershell
before invoking the previously defined processStart.

Signed-off-by: Simon Ferquel <simon.ferquel@docker.com>
