### PR TITLE
Use `assert` in `image` package unit tests

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -287,18 +287,7 @@ func (b *Builder) build(stdout io.Writer, stderr io.Writer, out io.Writer) (stri
 		}
 	}
 
-	// check if there are any leftover build-args that were passed but not
-	// consumed during build. Return a warning, if there are any.
-	leftoverArgs := []string{}
-	for arg := range b.options.BuildArgs {
-		if !b.isBuildArgAllowed(arg) {
-			leftoverArgs = append(leftoverArgs, arg)
-		}
-	}
-
-	if len(leftoverArgs) > 0 {
-		fmt.Fprintf(b.Stderr, "[Warning] One or more build-args %v were not consumed\n", leftoverArgs)
-	}
+	b.warnOnUnusedBuildArgs()
 
 	if b.image == "" {
 		return "", errors.New("No image was generated. Is your Dockerfile empty?")
@@ -324,6 +313,21 @@ func (b *Builder) build(stdout io.Writer, stderr io.Writer, out io.Writer) (stri
 
 	fmt.Fprintf(b.Stdout, "Successfully built %s\n", shortImgID)
 	return b.image, nil
+}
+
+// check if there are any leftover build-args that were passed but not
+// consumed during build. Print a warning, if there are any.
+func (b *Builder) warnOnUnusedBuildArgs() {
+	leftoverArgs := []string{}
+	for arg := range b.options.BuildArgs {
+		if !b.isBuildArgAllowed(arg) {
+			leftoverArgs = append(leftoverArgs, arg)
+		}
+	}
+
+	if len(leftoverArgs) > 0 {
+		fmt.Fprintf(b.Stderr, "[Warning] One or more build-args %v were not consumed\n", leftoverArgs)
+	}
 }
 
 // Cancel cancels an ongoing Dockerfile build.

--- a/image/fs.go
+++ b/image/fs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
 )
 
 // DigestWalkFunc is function called by StoreBackend.Walk
@@ -47,10 +48,10 @@ func newFSStore(root string) (*fs, error) {
 		root: root,
 	}
 	if err := os.MkdirAll(filepath.Join(root, contentDirName, string(digest.Canonical)), 0700); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to create storage backend")
 	}
 	if err := os.MkdirAll(filepath.Join(root, metadataDirName, string(digest.Canonical)), 0700); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to create storage backend")
 	}
 	return s, nil
 }
@@ -96,7 +97,7 @@ func (s *fs) Get(dgst digest.Digest) ([]byte, error) {
 func (s *fs) get(dgst digest.Digest) ([]byte, error) {
 	content, err := ioutil.ReadFile(s.contentFile(dgst))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to get digest %s", dgst)
 	}
 
 	// todo: maybe optional
@@ -118,7 +119,7 @@ func (s *fs) Set(data []byte) (digest.Digest, error) {
 
 	dgst := digest.FromBytes(data)
 	if err := ioutils.AtomicWriteFile(s.contentFile(dgst), data, 0600); err != nil {
-		return "", err
+		return "", errors.Wrap(err, "failed to write digest data")
 	}
 
 	return dgst, nil
@@ -161,7 +162,11 @@ func (s *fs) GetMetadata(dgst digest.Digest, key string) ([]byte, error) {
 	if _, err := s.get(dgst); err != nil {
 		return nil, err
 	}
-	return ioutil.ReadFile(filepath.Join(s.metadataDir(dgst), key))
+	bytes, err := ioutil.ReadFile(filepath.Join(s.metadataDir(dgst), key))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read metadata")
+	}
+	return bytes, nil
 }
 
 // DeleteMetadata removes the metadata associated with a digest.

--- a/image/fs_test.go
+++ b/image/fs_test.go
@@ -11,79 +11,51 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/docker/docker/pkg/testutil/assert"
 	"github.com/opencontainers/go-digest"
 )
 
-func TestFSGetSet(t *testing.T) {
+func defaultFSStoreBackend(t *testing.T) (StoreBackend, func()) {
 	tmpdir, err := ioutil.TempDir("", "images-fs-store")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-	fs, err := NewFSStoreBackend(tmpdir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
-	testGetSet(t, fs)
+	fsBackend, err := NewFSStoreBackend(tmpdir)
+	assert.NilError(t, err)
+
+	return fsBackend, func() { os.RemoveAll(tmpdir) }
 }
 
 func TestFSGetInvalidData(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "images-fs-store")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-	fs, err := NewFSStoreBackend(tmpdir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	store, cleanup := defaultFSStoreBackend(t)
+	defer cleanup()
 
-	id, err := fs.Set([]byte("foobar"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	id, err := store.Set([]byte("foobar"))
+	assert.NilError(t, err)
 
 	dgst := digest.Digest(id)
 
-	if err := ioutil.WriteFile(filepath.Join(tmpdir, contentDirName, string(dgst.Algorithm()), dgst.Hex()), []byte("foobar2"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	err = ioutil.WriteFile(filepath.Join(store.(*fs).root, contentDirName, string(dgst.Algorithm()), dgst.Hex()), []byte("foobar2"), 0600)
+	assert.NilError(t, err)
 
-	_, err = fs.Get(id)
-	if err == nil {
-		t.Fatal("expected get to fail after data modification.")
-	}
+	_, err = store.Get(id)
+	assert.Error(t, err, "failed to verify")
 }
 
 func TestFSInvalidSet(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "images-fs-store")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-	fs, err := NewFSStoreBackend(tmpdir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	store, cleanup := defaultFSStoreBackend(t)
+	defer cleanup()
 
 	id := digest.FromBytes([]byte("foobar"))
-	err = os.Mkdir(filepath.Join(tmpdir, contentDirName, string(id.Algorithm()), id.Hex()), 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err := os.Mkdir(filepath.Join(store.(*fs).root, contentDirName, string(id.Algorithm()), id.Hex()), 0700)
+	assert.NilError(t, err)
 
-	_, err = fs.Set([]byte("foobar"))
-	if err == nil {
-		t.Fatal("expected error from invalid filesystem data.")
-	}
+	_, err = store.Set([]byte("foobar"))
+	assert.Error(t, err, "is a directory")
 }
 
 func TestFSInvalidRoot(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "images-fs-store")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	defer os.RemoveAll(tmpdir)
 
 	tcases := []struct {
@@ -98,34 +70,29 @@ func TestFSInvalidRoot(t *testing.T) {
 		root := filepath.Join(tmpdir, tc.root)
 		filePath := filepath.Join(tmpdir, tc.invalidFile)
 		err := os.MkdirAll(filepath.Dir(filePath), 0700)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
+
 		f, err := os.Create(filePath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		f.Close()
+		defer f.Close()
+		assert.NilError(t, err)
 
 		_, err = NewFSStoreBackend(root)
-		if err == nil {
-			t.Fatalf("expected error from root %q and invalid file %q", tc.root, tc.invalidFile)
-		}
+		assert.Error(t, err, "not a directory")
 
 		os.RemoveAll(root)
 	}
 
 }
 
-func testMetadataGetSet(t *testing.T, store StoreBackend) {
+func TestFSMetadataGetSet(t *testing.T) {
+	store, cleanup := defaultFSStoreBackend(t)
+	defer cleanup()
+
 	id, err := store.Set([]byte("foo"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
+
 	id2, err := store.Set([]byte("bar"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	tcases := []struct {
 		id    digest.Digest
@@ -139,115 +106,51 @@ func testMetadataGetSet(t *testing.T, store StoreBackend) {
 
 	for _, tc := range tcases {
 		err = store.SetMetadata(tc.id, tc.key, tc.value)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 
 		actual, err := store.GetMetadata(tc.id, tc.key)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
+
 		if bytes.Compare(actual, tc.value) != 0 {
 			t.Fatalf("Metadata expected %q, got %q", tc.value, actual)
 		}
 	}
 
 	_, err = store.GetMetadata(id2, "tkey2")
-	if err == nil {
-		t.Fatal("expected error for getting metadata for unknown key")
-	}
+	assert.Error(t, err, "no such file or directory")
 
 	id3 := digest.FromBytes([]byte("baz"))
 	err = store.SetMetadata(id3, "tkey", []byte("tval"))
-	if err == nil {
-		t.Fatal("expected error for setting metadata for unknown ID.")
-	}
+	assert.Error(t, err, "no such file or directory")
 
 	_, err = store.GetMetadata(id3, "tkey")
-	if err == nil {
-		t.Fatal("expected error for getting metadata for unknown ID.")
-	}
-}
-
-func TestFSMetadataGetSet(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "images-fs-store")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-	fs, err := NewFSStoreBackend(tmpdir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testMetadataGetSet(t, fs)
-}
-
-func TestFSDelete(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "images-fs-store")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-	fs, err := NewFSStoreBackend(tmpdir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testDelete(t, fs)
-}
-
-func TestFSWalker(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "images-fs-store")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-	fs, err := NewFSStoreBackend(tmpdir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testWalker(t, fs)
+	assert.Error(t, err, "no such file or directory")
 }
 
 func TestFSInvalidWalker(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "images-fs-store")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-	fs, err := NewFSStoreBackend(tmpdir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	store, cleanup := defaultFSStoreBackend(t)
+	defer cleanup()
 
-	fooID, err := fs.Set([]byte("foo"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	fooID, err := store.Set([]byte("foo"))
+	assert.NilError(t, err)
 
-	if err := ioutil.WriteFile(filepath.Join(tmpdir, contentDirName, "sha256/foobar"), []byte("foobar"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	err = ioutil.WriteFile(filepath.Join(store.(*fs).root, contentDirName, "sha256/foobar"), []byte("foobar"), 0600)
+	assert.NilError(t, err)
 
 	n := 0
-	err = fs.Walk(func(id digest.Digest) error {
-		if id != fooID {
-			t.Fatalf("invalid walker ID %q, expected %q", id, fooID)
-		}
+	err = store.Walk(func(id digest.Digest) error {
+		assert.Equal(t, id, fooID)
 		n++
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("invalid data should not have caused walker error, got %v", err)
-	}
-	if n != 1 {
-		t.Fatalf("expected 1 walk initialization, got %d", n)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, n, 1)
 }
 
-func testGetSet(t *testing.T, store StoreBackend) {
+func TestFSGetSet(t *testing.T) {
+	store, cleanup := defaultFSStoreBackend(t)
+	defer cleanup()
+
 	type tcase struct {
 		input    []byte
 		expected digest.Digest
@@ -258,15 +161,13 @@ func testGetSet(t *testing.T, store StoreBackend) {
 
 	randomInput := make([]byte, 8*1024)
 	_, err := rand.Read(randomInput)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
+
 	// skipping use of digest pkg because it is used by the implementation
 	h := sha256.New()
 	_, err = h.Write(randomInput)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
+
 	tcases = append(tcases, tcase{
 		input:    randomInput,
 		expected: digest.Digest("sha256:" + hex.EncodeToString(h.Sum(nil))),
@@ -274,83 +175,74 @@ func testGetSet(t *testing.T, store StoreBackend) {
 
 	for _, tc := range tcases {
 		id, err := store.Set([]byte(tc.input))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if id != tc.expected {
-			t.Fatalf("expected ID %q, got %q", tc.expected, id)
-		}
-	}
-
-	for _, emptyData := range [][]byte{nil, {}} {
-		_, err := store.Set(emptyData)
-		if err == nil {
-			t.Fatal("expected error for nil input.")
-		}
+		assert.NilError(t, err)
+		assert.Equal(t, id, tc.expected)
 	}
 
 	for _, tc := range tcases {
 		data, err := store.Get(tc.expected)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 		if bytes.Compare(data, tc.input) != 0 {
 			t.Fatalf("expected data %q, got %q", tc.input, data)
 		}
 	}
+}
+
+func TestFSGetUnsetKey(t *testing.T) {
+	store, cleanup := defaultFSStoreBackend(t)
+	defer cleanup()
 
 	for _, key := range []digest.Digest{"foobar:abc", "sha256:abc", "sha256:c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2a"} {
 		_, err := store.Get(key)
-		if err == nil {
-			t.Fatalf("expected error for ID %q.", key)
-		}
+		assert.Error(t, err, "no such file or directory")
 	}
-
 }
 
-func testDelete(t *testing.T, store StoreBackend) {
+func TestFSGetEmptyData(t *testing.T) {
+	store, cleanup := defaultFSStoreBackend(t)
+	defer cleanup()
+
+	for _, emptyData := range [][]byte{nil, {}} {
+		_, err := store.Set(emptyData)
+		assert.Error(t, err, "invalid empty data")
+	}
+}
+
+func TestFSDelete(t *testing.T) {
+	store, cleanup := defaultFSStoreBackend(t)
+	defer cleanup()
+
 	id, err := store.Set([]byte("foo"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
+
 	id2, err := store.Set([]byte("bar"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	err = store.Delete(id)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	_, err = store.Get(id)
-	if err == nil {
-		t.Fatalf("expected getting deleted item %q to fail", id)
-	}
+	assert.Error(t, err, "no such file or directory")
+
 	_, err = store.Get(id2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	err = store.Delete(id2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
+
 	_, err = store.Get(id2)
-	if err == nil {
-		t.Fatalf("expected getting deleted item %q to fail", id2)
-	}
+	assert.Error(t, err, "no such file or directory")
 }
 
-func testWalker(t *testing.T, store StoreBackend) {
+func TestFSWalker(t *testing.T) {
+	store, cleanup := defaultFSStoreBackend(t)
+	defer cleanup()
+
 	id, err := store.Set([]byte("foo"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
+
 	id2, err := store.Set([]byte("bar"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	tcases := make(map[digest.Digest]struct{})
 	tcases[id] = struct{}{}
@@ -361,24 +253,22 @@ func testWalker(t *testing.T, store StoreBackend) {
 		n++
 		return nil
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, n, 2)
+	assert.Equal(t, len(tcases), 0)
+}
 
-	if n != 2 {
-		t.Fatalf("expected 2 walk initializations, got %d", n)
-	}
-	if len(tcases) != 0 {
-		t.Fatalf("expected empty unwalked set, got %+v", tcases)
-	}
+func TestFSWalkerStopOnError(t *testing.T) {
+	store, cleanup := defaultFSStoreBackend(t)
+	defer cleanup()
 
-	// stop on error
-	tcases = make(map[digest.Digest]struct{})
+	id, err := store.Set([]byte("foo"))
+	assert.NilError(t, err)
+
+	tcases := make(map[digest.Digest]struct{})
 	tcases[id] = struct{}{}
 	err = store.Walk(func(id digest.Digest) error {
-		return errors.New("")
+		return errors.New("what")
 	})
-	if err == nil {
-		t.Fatalf("expected error from walker.")
-	}
+	assert.Error(t, err, "what")
 }

--- a/image/fs_test.go
+++ b/image/fs_test.go
@@ -50,7 +50,7 @@ func TestFSInvalidSet(t *testing.T) {
 	assert.NilError(t, err)
 
 	_, err = store.Set([]byte("foobar"))
-	assert.Error(t, err, "is a directory")
+	assert.Error(t, err, "failed to write digest data")
 }
 
 func TestFSInvalidRoot(t *testing.T) {
@@ -73,11 +73,11 @@ func TestFSInvalidRoot(t *testing.T) {
 		assert.NilError(t, err)
 
 		f, err := os.Create(filePath)
-		defer f.Close()
 		assert.NilError(t, err)
+		f.Close()
 
 		_, err = NewFSStoreBackend(root)
-		assert.Error(t, err, "not a directory")
+		assert.Error(t, err, "failed to create storage backend")
 
 		os.RemoveAll(root)
 	}
@@ -117,14 +117,14 @@ func TestFSMetadataGetSet(t *testing.T) {
 	}
 
 	_, err = store.GetMetadata(id2, "tkey2")
-	assert.Error(t, err, "no such file or directory")
+	assert.Error(t, err, "failed to read metadata")
 
 	id3 := digest.FromBytes([]byte("baz"))
 	err = store.SetMetadata(id3, "tkey", []byte("tval"))
-	assert.Error(t, err, "no such file or directory")
+	assert.Error(t, err, "failed to get digest")
 
 	_, err = store.GetMetadata(id3, "tkey")
-	assert.Error(t, err, "no such file or directory")
+	assert.Error(t, err, "failed to get digest")
 }
 
 func TestFSInvalidWalker(t *testing.T) {
@@ -194,7 +194,7 @@ func TestFSGetUnsetKey(t *testing.T) {
 
 	for _, key := range []digest.Digest{"foobar:abc", "sha256:abc", "sha256:c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2a"} {
 		_, err := store.Get(key)
-		assert.Error(t, err, "no such file or directory")
+		assert.Error(t, err, "failed to get digest")
 	}
 }
 
@@ -222,7 +222,7 @@ func TestFSDelete(t *testing.T) {
 	assert.NilError(t, err)
 
 	_, err = store.Get(id)
-	assert.Error(t, err, "no such file or directory")
+	assert.Error(t, err, "failed to get digest")
 
 	_, err = store.Get(id2)
 	assert.NilError(t, err)
@@ -231,7 +231,7 @@ func TestFSDelete(t *testing.T) {
 	assert.NilError(t, err)
 
 	_, err = store.Get(id2)
-	assert.Error(t, err, "no such file or directory")
+	assert.Error(t, err, "failed to get digest")
 }
 
 func TestFSWalker(t *testing.T) {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/pkg/testutil/assert"
 )
 
 const sampleImageJSON = `{
@@ -17,22 +19,15 @@ const sampleImageJSON = `{
 	}
 }`
 
-func TestJSON(t *testing.T) {
+func TestNewFromJSON(t *testing.T) {
 	img, err := NewFromJSON([]byte(sampleImageJSON))
-	if err != nil {
-		t.Fatal(err)
-	}
-	rawJSON := img.RawJSON()
-	if string(rawJSON) != sampleImageJSON {
-		t.Fatalf("raw JSON of config didn't match: expected %+v, got %v", sampleImageJSON, rawJSON)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, string(img.RawJSON()), sampleImageJSON)
 }
 
-func TestInvalidJSON(t *testing.T) {
+func TestNewFromJSONWithInvalidJSON(t *testing.T) {
 	_, err := NewFromJSON([]byte("{}"))
-	if err == nil {
-		t.Fatal("expected JSON parse error")
-	}
+	assert.Error(t, err, "invalid image JSON, no RootFS key")
 }
 
 func TestMarshalKeyOrder(t *testing.T) {
@@ -43,9 +38,7 @@ func TestMarshalKeyOrder(t *testing.T) {
 			Architecture: "c",
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	expectedOrder := []string{"architecture", "author", "comment"}
 	var indexes []int

--- a/image/store_test.go
+++ b/image/store_test.go
@@ -40,7 +40,7 @@ func TestRestore(t *testing.T) {
 	assert.Equal(t, img2.Comment, "def")
 
 	p, err := is.GetParent(ID(id1))
-	assert.Error(t, err, "no such file")
+	assert.Error(t, err, "failed to read metadata")
 
 	p, err = is.GetParent(ID(id2))
 	assert.NilError(t, err)
@@ -90,13 +90,13 @@ func TestAddDelete(t *testing.T) {
 	assert.NilError(t, err)
 
 	_, err = is.Get(id1)
-	assert.Error(t, err, "no such file or directory")
+	assert.Error(t, err, "failed to get digest")
 
 	_, err = is.Get(id2)
 	assert.NilError(t, err)
 
 	_, err = is.GetParent(id2)
-	assert.Error(t, err, "no such file or directory")
+	assert.Error(t, err, "failed to read metadata")
 }
 
 func TestSearchAfterDelete(t *testing.T) {

--- a/image/store_test.go
+++ b/image/store_test.go
@@ -1,292 +1,150 @@
 package image
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/docker/docker/layer"
+	"github.com/docker/docker/pkg/testutil/assert"
 	"github.com/opencontainers/go-digest"
 )
 
 func TestRestore(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "images-fs-store")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-	fs, err := NewFSStoreBackend(tmpdir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	fs, cleanup := defaultFSStoreBackend(t)
+	defer cleanup()
 
 	id1, err := fs.Set([]byte(`{"comment": "abc", "rootfs": {"type": "layers"}}`))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
+
 	_, err = fs.Set([]byte(`invalid`))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
+
 	id2, err := fs.Set([]byte(`{"comment": "def", "rootfs": {"type": "layers", "diff_ids": ["2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"]}}`))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
+
 	err = fs.SetMetadata(id2, "parent", []byte(id1))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	is, err := NewImageStore(fs, &mockLayerGetReleaser{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
-	imgs := is.Map()
-	if actual, expected := len(imgs), 2; actual != expected {
-		t.Fatalf("invalid images length, expected 2, got %q", len(imgs))
-	}
+	assert.Equal(t, len(is.Map()), 2)
 
 	img1, err := is.Get(ID(id1))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if actual, expected := img1.computedID, ID(id1); actual != expected {
-		t.Fatalf("invalid image ID: expected %q, got %q", expected, actual)
-	}
-
-	if actual, expected := img1.computedID.String(), string(id1); actual != expected {
-		t.Fatalf("invalid image ID string: expected %q, got %q", expected, actual)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, img1.computedID, ID(id1))
+	assert.Equal(t, img1.computedID.String(), string(id1))
 
 	img2, err := is.Get(ID(id2))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if actual, expected := img1.Comment, "abc"; actual != expected {
-		t.Fatalf("invalid comment for image1: expected %q, got %q", expected, actual)
-	}
-
-	if actual, expected := img2.Comment, "def"; actual != expected {
-		t.Fatalf("invalid comment for image2: expected %q, got %q", expected, actual)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, img1.Comment, "abc")
+	assert.Equal(t, img2.Comment, "def")
 
 	p, err := is.GetParent(ID(id1))
-	if err == nil {
-		t.Fatal("expected error for getting parent")
-	}
+	assert.Error(t, err, "no such file")
 
 	p, err = is.GetParent(ID(id2))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if actual, expected := p, ID(id1); actual != expected {
-		t.Fatalf("invalid parent: expected %q, got %q", expected, actual)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, p, ID(id1))
 
 	children := is.Children(ID(id1))
-	if len(children) != 1 {
-		t.Fatalf("invalid children length: %q", len(children))
-	}
-	if actual, expected := children[0], ID(id2); actual != expected {
-		t.Fatalf("invalid child for id1: expected %q, got %q", expected, actual)
-	}
-
-	heads := is.Heads()
-	if actual, expected := len(heads), 1; actual != expected {
-		t.Fatalf("invalid images length: expected %q, got %q", expected, actual)
-	}
+	assert.Equal(t, len(children), 1)
+	assert.Equal(t, children[0], ID(id2))
+	assert.Equal(t, len(is.Heads()), 1)
 
 	sid1, err := is.Search(string(id1)[:10])
-	if err != nil {
-		t.Fatal(err)
-	}
-	if actual, expected := sid1, ID(id1); actual != expected {
-		t.Fatalf("searched ID mismatch: expected %q, got %q", expected, actual)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, sid1, ID(id1))
 
 	sid1, err = is.Search(digest.Digest(id1).Hex()[:6])
-	if err != nil {
-		t.Fatal(err)
-	}
-	if actual, expected := sid1, ID(id1); actual != expected {
-		t.Fatalf("searched ID mismatch: expected %q, got %q", expected, actual)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, sid1, ID(id1))
 
 	invalidPattern := digest.Digest(id1).Hex()[1:6]
 	_, err = is.Search(invalidPattern)
-	if err == nil {
-		t.Fatalf("expected search for %q to fail", invalidPattern)
-	}
-
+	assert.Error(t, err, "No such image")
 }
 
 func TestAddDelete(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "images-fs-store")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-	fs, err := NewFSStoreBackend(tmpdir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	is, err := NewImageStore(fs, &mockLayerGetReleaser{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	is, cleanup := defaultImageStore(t)
+	defer cleanup()
 
 	id1, err := is.Create([]byte(`{"comment": "abc", "rootfs": {"type": "layers", "diff_ids": ["2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"]}}`))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if actual, expected := id1, ID("sha256:8d25a9c45df515f9d0fe8e4a6b1c64dd3b965a84790ddbcc7954bb9bc89eb993"); actual != expected {
-		t.Fatalf("create ID mismatch: expected %q, got %q", expected, actual)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, id1, ID("sha256:8d25a9c45df515f9d0fe8e4a6b1c64dd3b965a84790ddbcc7954bb9bc89eb993"))
 
 	img, err := is.Get(id1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if actual, expected := img.Comment, "abc"; actual != expected {
-		t.Fatalf("invalid comment in image: expected %q, got %q", expected, actual)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, img.Comment, "abc")
 
 	id2, err := is.Create([]byte(`{"comment": "def", "rootfs": {"type": "layers", "diff_ids": ["2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"]}}`))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	err = is.SetParent(id2, id1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	pid1, err := is.GetParent(id2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if actual, expected := pid1, id1; actual != expected {
-		t.Fatalf("invalid parent for image: expected %q, got %q", expected, actual)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, pid1, id1)
 
 	_, err = is.Delete(id1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = is.Get(id1)
-	if err == nil {
-		t.Fatalf("expected get for deleted image %q to fail", id1)
-	}
-	_, err = is.Get(id2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pid1, err = is.GetParent(id2)
-	if err == nil {
-		t.Fatalf("expected parent check for image %q to fail, got %q", id2, pid1)
-	}
+	assert.NilError(t, err)
 
+	_, err = is.Get(id1)
+	assert.Error(t, err, "no such file or directory")
+
+	_, err = is.Get(id2)
+	assert.NilError(t, err)
+
+	_, err = is.GetParent(id2)
+	assert.Error(t, err, "no such file or directory")
 }
 
 func TestSearchAfterDelete(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "images-fs-store")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-	fs, err := NewFSStoreBackend(tmpdir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	is, err := NewImageStore(fs, &mockLayerGetReleaser{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	is, cleanup := defaultImageStore(t)
+	defer cleanup()
 
 	id, err := is.Create([]byte(`{"comment": "abc", "rootfs": {"type": "layers"}}`))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	id1, err := is.Search(string(id)[:15])
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, id1, id)
 
-	if actual, expected := id1, id; expected != actual {
-		t.Fatalf("wrong id returned from search: expected %q, got %q", expected, actual)
-	}
+	_, err = is.Delete(id)
+	assert.NilError(t, err)
 
-	if _, err := is.Delete(id); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := is.Search(string(id)[:15]); err == nil {
-		t.Fatal("expected search after deletion to fail")
-	}
+	_, err = is.Search(string(id)[:15])
+	assert.Error(t, err, "No such image")
 }
 
 func TestParentReset(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "images-fs-store")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-	fs, err := NewFSStoreBackend(tmpdir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	is, err := NewImageStore(fs, &mockLayerGetReleaser{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	is, cleanup := defaultImageStore(t)
+	defer cleanup()
 
 	id, err := is.Create([]byte(`{"comment": "abc1", "rootfs": {"type": "layers"}}`))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	id2, err := is.Create([]byte(`{"comment": "abc2", "rootfs": {"type": "layers"}}`))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	id3, err := is.Create([]byte(`{"comment": "abc3", "rootfs": {"type": "layers"}}`))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
-	if err := is.SetParent(id, id2); err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, is.SetParent(id, id2))
+	assert.Equal(t, len(is.Children(id2)), 1)
 
-	ids := is.Children(id2)
-	if actual, expected := len(ids), 1; expected != actual {
-		t.Fatalf("wrong number of children: %d, got %d", expected, actual)
-	}
+	assert.NilError(t, is.SetParent(id, id3))
+	assert.Equal(t, len(is.Children(id2)), 0)
+	assert.Equal(t, len(is.Children(id3)), 1)
+}
 
-	if err := is.SetParent(id, id3); err != nil {
-		t.Fatal(err)
-	}
+func defaultImageStore(t *testing.T) (Store, func()) {
+	fsBackend, cleanup := defaultFSStoreBackend(t)
 
-	ids = is.Children(id2)
-	if actual, expected := len(ids), 0; expected != actual {
-		t.Fatalf("wrong number of children after parent reset: %d, got %d", expected, actual)
-	}
+	store, err := NewImageStore(fsBackend, &mockLayerGetReleaser{})
+	assert.NilError(t, err)
 
-	ids = is.Children(id3)
-	if actual, expected := len(ids), 1; expected != actual {
-		t.Fatalf("wrong number of children after parent reset: %d, got %d", expected, actual)
-	}
-
+	return store, cleanup
 }
 
 type mockLayerGetReleaser struct{}


### PR DESCRIPTION
Some misc cleanup

* extract a function from a rather large function in the builder
* remove setup duplication from the tests in `image/`
* use `assert.*` in the tests to make them more readable, and also for better assertions when an error is expected. Now a specific error message is expected.