### PR TITLE
Support `--filter mode=global|replicated` for `docker service ls`

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7398,6 +7398,7 @@ paths:
 
             - `id=<service id>`
             - `label=<service label>`
+            - `mode=["replicated"|"global"]`
             - `name=<service name>`
       tags: ["Service"]
   /services/create:

--- a/daemon/cluster/filters.go
+++ b/daemon/cluster/filters.go
@@ -45,22 +45,6 @@ func newListNodesFilters(filter filters.Args) (*swarmapi.ListNodesRequest_Filter
 	return f, nil
 }
 
-func newListServicesFilters(filter filters.Args) (*swarmapi.ListServicesRequest_Filters, error) {
-	accepted := map[string]bool{
-		"name":  true,
-		"id":    true,
-		"label": true,
-	}
-	if err := filter.Validate(accepted); err != nil {
-		return nil, err
-	}
-	return &swarmapi.ListServicesRequest_Filters{
-		NamePrefixes: filter.Get("name"),
-		IDPrefixes:   filter.Get("id"),
-		Labels:       runconfigopts.ConvertKVStringsToMap(filter.Get("label")),
-	}, nil
-}
-
 func newListTasksFilters(filter filters.Args, transformFunc func(filters.Args) error) (*swarmapi.ListTasksRequest_Filters, error) {
 	accepted := map[string]bool{
 		"name":          true,

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -27,6 +27,7 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /build` now accepts `extrahosts` parameter to specify a host to ip mapping to use during the build.
 * `POST /services/create` and `POST /services/(id or name)/update` now accept a `rollback` value for `FailureAction`.
 * `POST /services/create` and `POST /services/(id or name)/update` now accept an optional `RollbackConfig` object which specifies rollback options.
+* `GET /services` now supports a `mode` filter to filter services based on the service mode (either `global` or `replicated`).
 
 ## v1.27 API changes
 

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -60,6 +60,7 @@ The currently supported filters are:
 
 * [id](service_ls.md#id)
 * [label](service_ls.md#label)
+* [mode](service_ls.md#mode)
 * [name](service_ls.md#name)
 
 #### id
@@ -96,6 +97,18 @@ $ docker service ls --filter label=project=project-a
 ID            NAME      MODE        REPLICAS  IMAGE
 36xvvwwauej0  frontend  replicated  5/5       nginx:alpine
 74nzcxxjv6fq  backend   replicated  3/3       redis:3.0.6
+```
+
+#### mode
+
+The `mode` filter matches on the mode (either `replicated` or `global`) of a service.
+
+The following filter matches only `global` services.
+
+```bash
+$ docker service ls --filter mode=global
+ID                  NAME                MODE                REPLICAS            IMAGE
+w7y0v2yrn620        top                 global              1/1                 busybox
 ```
 
 #### name


### PR DESCRIPTION
**- What I did**
This fix tries to address the request in #31325 by adding `--filter mode=global|replicated` to `docker service ls`.

As `docker service ls` has a `MODE` column by default, it is natural to support `--filter mode=global|replicated` for `docker service ls`.

**- How I did it**

There are multiple ways to address the issue. One way is to pass the filter of mode to SwarmKit, another way is to process the filter of mode in the daemon.

This fix process the filter in the daemon.

*NOTE: Alternatively, we could update SwarmKit to add the mode filter as well. Suggestion is welcomed if other way is preferred.*

Related docs has been updated.

**- How to verify it**

An integration test has been added.

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

![siberian-freestyle-list-photo-u1](https://cloud.githubusercontent.com/assets/6932348/23575576/ad2591d8-0043-11e7-9147-798b33bebe49.jpg)


This fix fixes #31325.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>