### PR TITLE
Creates formatter for docker search, Adds tests, Updates docker searc…

### DIFF
--- a/cli/command/formatter/search.go
+++ b/cli/command/formatter/search.go
@@ -1,0 +1,112 @@
+package formatter
+
+import (
+	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/pkg/stringutils"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultSearchTableFormat = "table {{.Name}}\t{{.Description}}\t{{.StarCount}}\t{{.IsOfficial}}\t{{.IsAutomated}}"
+
+	starsHeader     = "STARS"
+	officialHeader  = "OFFICIAL"
+	automatedHeader = "AUTOMATED"
+)
+
+// NewSearchFormat returns a Format for rendering using a network Context
+func NewSearchFormat(source string) Format {
+	switch source {
+	case TableFormatKey:
+		return defaultSearchTableFormat
+	}
+	return Format(source)
+}
+
+// SearchWrite writes the context
+func SearchWrite(ctx Context, results []registrytypes.SearchResult, auto bool, stars int) error {
+	render := func(format func(subContext subContext) error) error {
+		for _, result := range results {
+			// --automated and -s, --stars are deprecated since Docker 1.12
+			if (auto && !result.IsAutomated) || (stars > result.StarCount) {
+				continue
+			}
+			searchCtx := &searchContext{trunc: ctx.Trunc, s: result}
+			if err := format(searchCtx); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	searchCtx := searchContext{}
+	searchCtx.header = map[string]string{
+		"Name":        nameHeader,
+		"Description": descriptionHeader,
+		"StarCount":   starsHeader,
+		"IsOfficial":  officialHeader,
+		"IsAutomated": automatedHeader,
+	}
+	return ctx.Write(&searchCtx, render)
+}
+
+type searchContext struct {
+	HeaderContext
+	trunc bool
+	json  bool
+	s     registrytypes.SearchResult
+}
+
+func (c *searchContext) MarshalJSON() ([]byte, error) {
+	c.json = true
+	return marshalJSON(c)
+}
+
+func (c *searchContext) Name() string {
+	return c.s.Name
+}
+
+func (c *searchContext) Description() string {
+	desc := strings.Replace(c.s.Description, "\n", " ", -1)
+	desc = strings.Replace(desc, "\r", " ", -1)
+	if c.trunc {
+		desc = stringutils.Ellipsis(desc, 45)
+	}
+	return desc
+}
+
+func (c *searchContext) StarCount() string {
+	return strconv.Itoa(c.s.StarCount)
+}
+
+func (c *searchContext) IsOfficial() string {
+	official := ""
+	if c.s.IsOfficial {
+		if c.json {
+			official = "true"
+		} else {
+			official = "[OK]"
+		}
+	} else {
+		if c.json {
+			official = "false"
+		}
+	}
+	return official
+}
+
+func (c *searchContext) IsAutomated() string {
+	auto := ""
+	if c.s.IsAutomated {
+		if c.json {
+			auto = "true"
+		} else {
+			auto = "[OK]"
+		}
+	} else {
+		if c.json {
+			auto = "false"
+		}
+	}
+	return auto
+}

--- a/cli/command/formatter/search_test.go
+++ b/cli/command/formatter/search_test.go
@@ -1,0 +1,284 @@
+package formatter
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/pkg/stringutils"
+	"github.com/docker/docker/pkg/testutil/assert"
+)
+
+func TestSearchContext(t *testing.T) {
+	name := "nginx"
+	starCount := 5000
+
+	var ctx searchContext
+	cases := []struct {
+		searchCtx searchContext
+		expValue  string
+		call      func() string
+	}{
+		{searchContext{
+			s: registrytypes.SearchResult{Name: name},
+		}, name, ctx.Name},
+		{searchContext{
+			s: registrytypes.SearchResult{StarCount: starCount},
+		}, "5000", ctx.StarCount},
+		{searchContext{
+			s: registrytypes.SearchResult{IsOfficial: true},
+		}, "[OK]", ctx.IsOfficial},
+		{searchContext{
+			s: registrytypes.SearchResult{IsOfficial: false},
+		}, "", ctx.IsOfficial},
+		{searchContext{
+			s: registrytypes.SearchResult{IsAutomated: true},
+		}, "[OK]", ctx.IsAutomated},
+		{searchContext{
+			s: registrytypes.SearchResult{IsAutomated: false},
+		}, "", ctx.IsAutomated},
+	}
+
+	for _, c := range cases {
+		ctx = c.searchCtx
+		v := c.call()
+		if strings.Contains(v, ",") {
+			compareMultipleValues(t, v, c.expValue)
+		} else if v != c.expValue {
+			t.Fatalf("Expected %s, was %s\n", c.expValue, v)
+		}
+	}
+}
+
+func TestSearchContext_Description(t *testing.T) {
+	shortDescription := "Official build of Nginx."
+	longDescription := "Automated Nginx reverse proxy for docker containers"
+	descriptionWReturns := "Automated\nNginx reverse\rproxy\rfor docker\ncontainers"
+
+	var ctx searchContext
+	cases := []struct {
+		searchCtx searchContext
+		expValue  string
+		call      func() string
+	}{
+		{searchContext{
+			s:     registrytypes.SearchResult{Description: shortDescription},
+			trunc: true,
+		}, shortDescription, ctx.Description},
+		{searchContext{
+			s:     registrytypes.SearchResult{Description: shortDescription},
+			trunc: false,
+		}, shortDescription, ctx.Description},
+		{searchContext{
+			s:     registrytypes.SearchResult{Description: longDescription},
+			trunc: false,
+		}, longDescription, ctx.Description},
+		{searchContext{
+			s:     registrytypes.SearchResult{Description: longDescription},
+			trunc: true,
+		}, stringutils.Ellipsis(longDescription, 45), ctx.Description},
+		{searchContext{
+			s:     registrytypes.SearchResult{Description: descriptionWReturns},
+			trunc: false,
+		}, longDescription, ctx.Description},
+		{searchContext{
+			s:     registrytypes.SearchResult{Description: descriptionWReturns},
+			trunc: true,
+		}, stringutils.Ellipsis(longDescription, 45), ctx.Description},
+	}
+
+	for _, c := range cases {
+		ctx = c.searchCtx
+		v := c.call()
+		if strings.Contains(v, ",") {
+			compareMultipleValues(t, v, c.expValue)
+		} else if v != c.expValue {
+			t.Fatalf("Expected %s, was %s\n", c.expValue, v)
+		}
+	}
+}
+
+func TestSearchContextWrite(t *testing.T) {
+	cases := []struct {
+		context  Context
+		expected string
+	}{
+
+		// Errors
+		{
+			Context{Format: "{{InvalidFunction}}"},
+			`Template parsing error: template: :1: function "InvalidFunction" not defined
+`,
+		},
+		{
+			Context{Format: "{{nil}}"},
+			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
+`,
+		},
+		// Table format
+		{
+			Context{Format: NewSearchFormat("table")},
+			`NAME                DESCRIPTION         STARS               OFFICIAL            AUTOMATED
+result1             Official build      5000                [OK]                
+result2             Not official        5                                       [OK]
+`,
+		},
+		{
+			Context{Format: NewSearchFormat("table {{.Name}}")},
+			`NAME
+result1
+result2
+`,
+		},
+		// Custom Format
+		{
+			Context{Format: NewSearchFormat("{{.Name}}")},
+			`result1
+result2
+`,
+		},
+		// Custom Format with CreatedAt
+		{
+			Context{Format: NewSearchFormat("{{.Name}} {{.StarCount}}")},
+			`result1 5000
+result2 5
+`,
+		},
+	}
+
+	for _, testcase := range cases {
+		results := []registrytypes.SearchResult{
+			{Name: "result1", Description: "Official build", StarCount: 5000, IsOfficial: true, IsAutomated: false},
+			{Name: "result2", Description: "Not official", StarCount: 5, IsOfficial: false, IsAutomated: true},
+		}
+		out := bytes.NewBufferString("")
+		testcase.context.Output = out
+		err := SearchWrite(testcase.context, results, false, 0)
+		if err != nil {
+			assert.Error(t, err, testcase.expected)
+		} else {
+			assert.Equal(t, out.String(), testcase.expected)
+		}
+	}
+}
+
+func TestSearchContextWrite_Automated(t *testing.T) {
+	cases := []struct {
+		context  Context
+		expected string
+	}{
+
+		// Table format
+		{
+			Context{Format: NewSearchFormat("table")},
+			`NAME                DESCRIPTION         STARS               OFFICIAL            AUTOMATED
+result2             Not official        5                                       [OK]
+`,
+		},
+		{
+			Context{Format: NewSearchFormat("table {{.Name}}")},
+			`NAME
+result2
+`,
+		},
+	}
+
+	for _, testcase := range cases {
+		results := []registrytypes.SearchResult{
+			{Name: "result1", Description: "Official build", StarCount: 5000, IsOfficial: true, IsAutomated: false},
+			{Name: "result2", Description: "Not official", StarCount: 5, IsOfficial: false, IsAutomated: true},
+		}
+		out := bytes.NewBufferString("")
+		testcase.context.Output = out
+		err := SearchWrite(testcase.context, results, true, 0)
+		if err != nil {
+			assert.Error(t, err, testcase.expected)
+		} else {
+			assert.Equal(t, out.String(), testcase.expected)
+		}
+	}
+}
+
+func TestSearchContextWrite_Stars(t *testing.T) {
+	cases := []struct {
+		context  Context
+		expected string
+	}{
+
+		// Table format
+		{
+			Context{Format: NewSearchFormat("table")},
+			`NAME                DESCRIPTION         STARS               OFFICIAL            AUTOMATED
+result1             Official build      5000                [OK]                
+`,
+		},
+		{
+			Context{Format: NewSearchFormat("table {{.Name}}")},
+			`NAME
+result1
+`,
+		},
+	}
+
+	for _, testcase := range cases {
+		results := []registrytypes.SearchResult{
+			{Name: "result1", Description: "Official build", StarCount: 5000, IsOfficial: true, IsAutomated: false},
+			{Name: "result2", Description: "Not official", StarCount: 5, IsOfficial: false, IsAutomated: true},
+		}
+		out := bytes.NewBufferString("")
+		testcase.context.Output = out
+		err := SearchWrite(testcase.context, results, false, 6)
+		if err != nil {
+			assert.Error(t, err, testcase.expected)
+		} else {
+			assert.Equal(t, out.String(), testcase.expected)
+		}
+	}
+}
+
+func TestSearchContextWriteJSON(t *testing.T) {
+	results := []registrytypes.SearchResult{
+		{Name: "result1", Description: "Official build", StarCount: 5000, IsOfficial: true, IsAutomated: false},
+		{Name: "result2", Description: "Not official", StarCount: 5, IsOfficial: false, IsAutomated: true},
+	}
+	expectedJSONs := []map[string]interface{}{
+		{"Name": "result1", "Description": "Official build", "StarCount": "5000", "IsOfficial": "true", "IsAutomated": "false"},
+		{"Name": "result2", "Description": "Not official", "StarCount": "5", "IsOfficial": "false", "IsAutomated": "true"},
+	}
+
+	out := bytes.NewBufferString("")
+	err := SearchWrite(Context{Format: "{{json .}}", Output: out}, results, false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		t.Logf("Output: line %d: %s", i, line)
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatal(err)
+		}
+		assert.DeepEqual(t, m, expectedJSONs[i])
+	}
+}
+
+func TestSearchContextWriteJSONField(t *testing.T) {
+	results := []registrytypes.SearchResult{
+		{Name: "result1", Description: "Official build", StarCount: 5000, IsOfficial: true, IsAutomated: false},
+		{Name: "result2", Description: "Not official", StarCount: 5, IsOfficial: false, IsAutomated: true},
+	}
+	out := bytes.NewBufferString("")
+	err := SearchWrite(Context{Format: "{{json .Name}}", Output: out}, results, false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		t.Logf("Output: line %d: %s", i, line)
+		var s string
+		if err := json.Unmarshal([]byte(line), &s); err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, s, results[i].Name)
+	}
+}

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -25,6 +25,7 @@ Options:
                        - is-automated=(true|false)
                        - is-official=(true|false)
                        - stars=<number> - image has at least 'number' stars
+      --format string  Pretty-print images using a Go template
       --help           Print usage
       --limit int      Max number of search results (default 25)
       --no-trunc       Don't truncate output
@@ -146,4 +147,59 @@ $ docker search --filter "is-official=true" --filter "stars=3" busybox
 NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
 progrium/busybox                                                     50                   [OK]
 radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8                    [OK]
+```
+
+### Format the output
+
+The formatting option (`--format`) will pretty print container output
+using a Go template.
+
+Valid placeholders for the Go template are listed below:
+
+| Placeholder | Description|
+| ---- | ---- |
+| `.Name` | Image Name |
+| `.Description` | Image description |
+| `.StarCount` | Number of stars for the image |
+| `.IsOfficial` | "OK" if image is official |
+| `.IsAutomated` | "OK" if image build was automated |
+
+When using the `--format` option, the `search` command will either
+output the data exactly as the template declares or, when using the
+`table` directive, will include column headers as well.
+
+The following example uses a template without headers and outputs the
+`Name` and `StarCount` entries separated by a colon for all images:
+
+```bash
+{% raw %}
+$ docker search --format "{{.Name}}: {{.StarCount}}" nginx
+
+nginx: 5441
+jwilder/nginx-proxy: 953
+richarvey/nginx-php-fpm: 353
+million12/nginx-php: 75
+webdevops/php-nginx: 70
+h3nrik/nginx-ldap: 35
+bitnami/nginx: 23
+evild/alpine-nginx: 14
+million12/nginx: 9
+maxexcloo/nginx: 7
+{% endraw %}
+```
+
+To search for images in a table format youcan use:
+
+```bash
+{% raw %}
+$ docker search --format "table {{.Name}}\t{{.IsAutomated}}\t{{.IsOfficial}}" nginx
+
+NAME                                     AUTOMATED           OFFICIAL
+nginx                                                        [OK]
+jwilder/nginx-proxy                      [OK]                
+richarvey/nginx-php-fpm                  [OK]                
+jrcs/letsencrypt-nginx-proxy-companion   [OK]                
+million12/nginx-php                      [OK]                
+webdevops/php-nginx                      [OK]                
+{% endraw %}
 ```


### PR DESCRIPTION
…h to use formatter and supports --format option, Updates docker search docs to include --format

Signed-off-by: Jeremy Chambers <jeremy@thehipbot.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added the `--format` to `docker search`. Part of #30431 

**- How I did it**

Refactored `docker search` to use a newly created search formatter, added the format flag

**- How to verify it**

Wrote tests to verify formatter works correctly

**- Description for the changelog**

Adds `--format` flag to `docker search` command
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

