### PR TITLE
cmd: docker: fix TestDaemonCommand

### DIFF
--- a/cmd/docker/daemon_none.go
+++ b/cmd/docker/daemon_none.go
@@ -12,8 +12,10 @@ import (
 
 func newDaemonCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:    "daemon",
-		Hidden: true,
+		Use:                "daemon",
+		Hidden:             true,
+		Args:               cobra.ArbitraryArgs,
+		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDaemon()
 		},

--- a/cmd/docker/daemon_none_test.go
+++ b/cmd/docker/daemon_none_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestDaemonCommand(t *testing.T) {
 	cmd := newDaemonCommand()
-	cmd.SetArgs([]string{"--help"})
+	cmd.SetArgs([]string{"--version"})
 	err := cmd.Execute()
 
 	assert.Error(t, err, "Please run `dockerd`")


### PR DESCRIPTION
In more recent versions of Cobra, `--help` parsing is done before
anything else resulting in TestDaemonCommand not actually passing. I'm
actually unsure if this test ever passed since it appears that !daemon
is not being run as part of the test suite.

You can check it by just running `go test -v github.com/docker/docker/cmd/docker` inside `make shell`.

[![kitteh](https://c1.staticflickr.com/9/8376/8592095141_1d495012db_k.jpg)](https://flic.kr/p/e6fJxp) [1]

Signed-off-by: Aleksa Sarai <asarai@suse.de>

<small>[1]: [Trolli II](https://flic.kr/p/e6fJxp) by [Christian Skubich](https://www.flickr.com/photos/chaosbastler/).</small>