### PR TITLE
Network: add support for 'dangling' filter

### DIFF
--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -112,12 +112,13 @@ type ConfigReference struct {
 }
 
 var acceptedFilters = map[string]bool{
-	"driver": true,
-	"type":   true,
-	"name":   true,
-	"id":     true,
-	"label":  true,
-	"scope":  true,
+	"driver":   true,
+	"type":     true,
+	"name":     true,
+	"id":       true,
+	"label":    true,
+	"scope":    true,
+	"dangling": true,
 }
 
 // ValidateFilters validates the list of filter args with the available filters.


### PR DESCRIPTION
Closes #30825

Like its counterpart in images and volumes, introduce the dangling
filter while listing networks. When the filter value is set to true,
only networks which aren't attached to containers and aren't builtin
networks are shown. When set to false, all builtin networks and
networks which are attached to containers are shown.

Signed-off-by: Karthik Nayak <Karthik.188@gmail.com>

---

**- How I did it**

Mostly by mimicking the existing code, and writing new code for supporting this feature. 

**- How to verify it**

Either by running the unit test included, or by simply building and running
`docker network ls --filter dangling=true` and `docker network ls --filter dangling=false`

**- Description for the changelog**

Network: add support for 'dangling' filter

**- A picture of a cute animal (not mandatory but encouraged)**

<a data-flickr-embed="true"  href="https://www.flickr.com/photos/stys19850129/32571697242/in/photolist-R6Fcn3-RQjeYY-QXDLYx-RLUhEq-RCfsNW-Si72qN-RKjMKd-Sheb8e-RUY1kf-dDwovw-SsJbxz-oKG6TJ-RTRjBU-Sa2HfK-qbac9i-RJycyQ-RRwvDo-dVup61-Srj1YH-RZUnrk-QC16S4-QN1VQP-QPKwbd-RXjkut-r1iML3-QMaLtG-RM4oCQ-RTRjQu-RMrZqA-RRGYww-4irz6w-QZqTQx-qVN3pe-mJ6aTa-RMrZtw-Srj2N8-RZ2v5Z-S6KY4Q-nqm9TN-RhuARE-Sdy74x-7EKwGg-RQkBPJ-S5n1rX-oHRcJa-QyxPn1-R5fBh3-SfoWa6-RSGKFg-ReHBMn/" title="cat"><img src="https://c1.staticflickr.com/1/533/32571697242_78d0f82020.jpg" width="500" height="333" alt="cat"></a>
Credits: Flickr/NEKOFighter
