### PR TITLE
Add the format option to the docker stack ls command

### DIFF
--- a/cli/command/formatter/stack.go
+++ b/cli/command/formatter/stack.go
@@ -1,0 +1,67 @@
+package formatter
+
+import (
+	"strconv"
+)
+
+const (
+	defaultStackTableFormat = "table {{.Name}}\t{{.Services}}"
+
+	stackServicesHeader = "SERVICES"
+)
+
+// Stack contains deployed stack information.
+type Stack struct {
+	// Name is the name of the stack
+	Name string
+	// Services is the number of the services
+	Services int
+}
+
+// NewStackFormat returns a format for use with a stack Context
+func NewStackFormat(source string) Format {
+	switch source {
+	case TableFormatKey:
+		return defaultStackTableFormat
+	}
+	return Format(source)
+}
+
+// StackWrite writes formatted stacks using the Context
+func StackWrite(ctx Context, stacks []*Stack) error {
+	render := func(format func(subContext subContext) error) error {
+		for _, stack := range stacks {
+			if err := format(&stackContext{s: stack}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return ctx.Write(newStackContext(), render)
+}
+
+type stackContext struct {
+	HeaderContext
+	s *Stack
+}
+
+func newStackContext() *stackContext {
+	stackCtx := stackContext{}
+	stackCtx.header = map[string]string{
+		"Name":     nameHeader,
+		"Services": stackServicesHeader,
+	}
+	return &stackCtx
+}
+
+func (s *stackContext) MarshalJSON() ([]byte, error) {
+	return marshalJSON(s)
+}
+
+func (s *stackContext) Name() string {
+	return s.s.Name
+}
+
+func (s *stackContext) Services() string {
+	return strconv.Itoa(s.s.Services)
+}

--- a/cli/command/formatter/stack_test.go
+++ b/cli/command/formatter/stack_test.go
@@ -1,0 +1,64 @@
+package formatter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStackContextWrite(t *testing.T) {
+	cases := []struct {
+		context  Context
+		expected string
+	}{
+		// Errors
+		{
+			Context{Format: "{{InvalidFunction}}"},
+			`Template parsing error: template: :1: function "InvalidFunction" not defined
+`,
+		},
+		{
+			Context{Format: "{{nil}}"},
+			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
+`,
+		},
+		// Table format
+		{
+			Context{Format: NewStackFormat("table")},
+			`NAME                SERVICES
+baz                 2
+bar                 1
+`,
+		},
+		{
+			Context{Format: NewStackFormat("table {{.Name}}")},
+			`NAME
+baz
+bar
+`,
+		},
+		// Custom Format
+		{
+			Context{Format: NewStackFormat("{{.Name}}")},
+			`baz
+bar
+`,
+		},
+	}
+
+	stacks := []*Stack{
+		{Name: "baz", Services: 2},
+		{Name: "bar", Services: 1},
+	}
+	for _, testcase := range cases {
+		out := bytes.NewBufferString("")
+		testcase.context.Output = out
+		err := StackWrite(testcase.context, stacks)
+		if err != nil {
+			assert.Error(t, err, testcase.expected)
+		} else {
+			assert.Equal(t, out.String(), testcase.expected)
+		}
+	}
+}

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -24,7 +24,8 @@ Aliases:
   ls, list
 
 Options:
-      --help   Print usage
+      --help            Print usage
+      --format string   Pretty-print stacks using a Go template
 ```
 
 ## Description
@@ -41,6 +42,30 @@ $ docker stack ls
 ID                 SERVICES
 vossibility-stack  6
 myapp              2
+```
+
+### Formatting
+
+The formatting option (`--format`) pretty-prints stacks using a Go template.
+
+Valid placeholders for the Go template are listed below:
+
+| Placeholder | Description        |
+| ----------- | ------------------ |
+| `.Name`     | Stack name         |
+| `.Services` | Number of services |
+
+When using the `--format` option, the `stack ls` command either outputs
+the data exactly as the template declares or, when using the
+`table` directive, includes column headers as well.
+
+The following example uses a template without headers and outputs the
+`Name` and `Services` entries separated by a colon for all stacks:
+
+```bash
+$ docker stack ls --format "{{.Name}}: {{.Services}}"
+web-server: 1
+web-cache: 4
 ```
 
 ## Related commands

--- a/integration-cli/docker_cli_stack_test.go
+++ b/integration-cli/docker_cli_stack_test.go
@@ -15,6 +15,17 @@ import (
 	"github.com/go-check/check"
 )
 
+var cleanSpaces = func(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		spaceIx := strings.Index(line, " ")
+		if spaceIx > 0 {
+			lines[i] = line[:spaceIx+1] + strings.TrimLeft(line[spaceIx:], " ")
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
 func (s *DockerSwarmSuite) TestStackRemoveUnknown(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
@@ -59,13 +70,13 @@ func (s *DockerSwarmSuite) TestStackDeployComposeFile(c *check.C) {
 
 	out, err = d.Cmd("stack", "ls")
 	c.Assert(err, checker.IsNil)
-	c.Assert(out, check.Equals, "NAME        SERVICES\n"+"testdeploy  2\n")
+	c.Assert(cleanSpaces(out), check.Equals, "NAME SERVICES\n"+"testdeploy 2\n")
 
 	out, err = d.Cmd("stack", "rm", testStackName)
 	c.Assert(err, checker.IsNil)
 	out, err = d.Cmd("stack", "ls")
 	c.Assert(err, checker.IsNil)
-	c.Assert(out, check.Equals, "NAME  SERVICES\n")
+	c.Assert(cleanSpaces(out), check.Equals, "NAME SERVICES\n")
 }
 
 func (s *DockerSwarmSuite) TestStackDeployWithSecretsTwice(c *check.C) {
@@ -180,7 +191,7 @@ func (s *DockerSwarmSuite) TestStackDeployWithDAB(c *check.C) {
 	stackArgs = []string{"stack", "ls"}
 	out, err = d.Cmd(stackArgs...)
 	c.Assert(err, checker.IsNil)
-	c.Assert(out, check.Equals, "NAME  SERVICES\n"+"test  2\n")
+	c.Assert(cleanSpaces(out), check.Equals, "NAME SERVICES\n"+"test 2\n")
 	// rm
 	stackArgs = []string{"stack", "rm", testStackName}
 	out, err = d.Cmd(stackArgs...)
@@ -191,5 +202,5 @@ func (s *DockerSwarmSuite) TestStackDeployWithDAB(c *check.C) {
 	stackArgs = []string{"stack", "ls"}
 	out, err = d.Cmd(stackArgs...)
 	c.Assert(err, checker.IsNil)
-	c.Assert(out, check.Equals, "NAME  SERVICES\n")
+	c.Assert(cleanSpaces(out), check.Equals, "NAME SERVICES\n")
 }


### PR DESCRIPTION
**- What I did**
Add the format option to the docker-stack-ls command
related to #30431

**- How I did it**
* Add the format option to the cli/command/stack/ls.go
* Create cli/command/formatter/stack.go
* Move stack.stack to api.types.Stack
* Add unit tests

**- How to verify it**
` TESTDIRS='cli/command/formatter/' TESTFLAGS='-test.run ^TestStack*' hack/make.sh test-unit`

