### PR TITLE
Add bash completion for `service create|update --rollback-*`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2987,7 +2987,11 @@ _docker_service_update_and_create() {
 		--restart-delay
 		--restart-max-attempts
 		--restart-window
-		--rollback
+		--rollback-delay
+		--rollback-failure-action
+		--rollback-max-failure-ratio
+		--rollback-monitor
+		--rollback-parallelism
 		--stop-grace-period
 		--update-delay
 		--update-failure-action
@@ -3067,6 +3071,7 @@ _docker_service_update_and_create() {
 			--image
 			--publish-add
 			--publish-rm
+			--rollback
 			--secret-add
 			--secret-rm
 		"
@@ -3120,6 +3125,10 @@ _docker_service_update_and_create() {
 			;;
 		--restart-condition)
 			COMPREPLY=( $( compgen -W "any none on-failure" -- "$cur" ) )
+			return
+			;;
+		--rollback-failure-action)
+			COMPREPLY=( $( compgen -W "continue pause" -- "$cur" ) )
 			return
 			;;
 		--user|-u)

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3131,6 +3131,10 @@ _docker_service_update_and_create() {
 			COMPREPLY=( $( compgen -W "continue pause" -- "$cur" ) )
 			return
 			;;
+		--update-failure-action)
+			COMPREPLY=( $( compgen -W "continue pause rollback" -- "$cur" ) )
+			return
+			;;
 		--user|-u)
 			__docker_complete_user_group
 			return


### PR DESCRIPTION
Ref: #31108
This also removes the wrong completion for `docker service create --rollback` (only exists for `update`) and refines completion for `--update-failure-action`.
