### PR TITLE
Remove redundant Mounts when start docker daemon

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -270,6 +270,13 @@ func (daemon *Daemon) restore() error {
 		}(c)
 	}
 	wg.Wait()
+
+	err = daemon.removeRedundantMounts(containers)
+	if err != nil {
+		// just print error info
+		logrus.Errorf("removeRedundantMounts failed %v", err)
+	}
+
 	daemon.netController, err = daemon.initNetworkController(daemon.configStore, activeSandboxes)
 	if err != nil {
 		return fmt.Errorf("Error initializing network controller: %v", err)

--- a/daemon/daemon_unix_test.go
+++ b/daemon/daemon_unix_test.go
@@ -311,3 +311,33 @@ func TestMigratePre17Volumes(t *testing.T) {
 		}
 	}
 }
+
+func TestGetContainerMountId(t *testing.T) {
+	id := "56e143922c405419a38b23bfbccc92284f35525e3f2ad7011ea904501ccd1219"
+
+	id1 := getContainerMountId("/var/lib/docker/aufs/mnt/" + id)
+	if id1 != id {
+		t.Fatalf("Expected container mount id [%s], but got [%s]", id, id1)
+	}
+
+	id1 = getContainerMountId("/var/lib/docker/devicemapper/mnt/" + id)
+	if id1 != id {
+		t.Fatalf("Expected container mount id [%s], but got [%s]", id, id1)
+	}
+
+	id1 = getContainerMountId("/var/lib/docker/overlay/" + id + "/merged")
+	if id1 != id {
+		t.Fatalf("Expected container mount id [%s], but got [%s]", id, id1)
+	}
+
+	id1 = getContainerMountId("/var/lib/docker/zfs/graph/" + id)
+	if id1 != id {
+		t.Fatalf("Expected container mount id [%s], but got [%s]", id, id1)
+	}
+
+	id1 = getContainerMountId("/var/lib/docker/devicemapper_err/mnt" + id)
+
+	if id1 != "" {
+		t.Fatalf("Expected a empty container mount id, but got [%s]", id1)
+	}
+}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -616,3 +616,7 @@ func (daemon *Daemon) verifyVolumesInfo(container *container.Container) error {
 func (daemon *Daemon) setupSeccompProfile() error {
 	return nil
 }
+
+func (daemon *Daemon) removeRedundantMounts(containers map[string]*container.Container) error {
+	return nil
+}

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -145,6 +145,10 @@ func (ls *mockLayerStore) Cleanup() error {
 	return nil
 }
 
+func (ls *mockLayerStore) DriverPut(id string) error {
+	return nil
+}
+
 func (ls *mockLayerStore) DriverStatus() [][2]string {
 	return [][2]string{}
 }

--- a/layer/layer.go
+++ b/layer/layer.go
@@ -190,6 +190,7 @@ type Store interface {
 	ReleaseRWLayer(RWLayer) ([]Metadata, error)
 
 	Cleanup() error
+	DriverPut(id string) error
 	DriverStatus() [][2]string
 	DriverName() string
 }

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -665,6 +665,10 @@ func (ls *layerStore) Cleanup() error {
 	return ls.driver.Cleanup()
 }
 
+func (ls *layerStore) DriverPut(id string) error {
+	return ls.driver.Put(id)
+}
+
 func (ls *layerStore) DriverStatus() [][2]string {
 	return ls.driver.Status()
 }


### PR DESCRIPTION
Signed-off-by: yangshukui <yangshukui@huawei.com>

If you have one or more container running in your host and restart docker daemon when docker save is in progress, then  you use docker save again, the docker save operation will not be successful again.

**- Why**
1. with container ruuning, docker daemon will not invoke Cleanup in the graphdriver when daemon exit.
2. docker daemon exit with exception when docker save operation is running,the procedure of saving will have mount/umount operation , if docker daemon exit with exception, it maybe has something not umount.

**- How I did it**
when restart docker daemon, remove the redundant mounts which are not used by docker container.

**- How to verify it**
before the pr,
```
docker run -d ubuntu:15.04 sleep 100000
docker save ubuntu:15.04>test.tar         #(kill docker daemon at the same time and restart it)
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
docker save rnd-dockerhub.huawei.com/official/ubuntu:15.04>test.tar
Error response from daemon: open /var/lib/docker/devicemapper/mnt/b49e7f17506fc456afc1936ddadc570ff9861f86af5c157b10b07057b7a31535/rootfs/bin/bash: no such file or directory
docker save rnd-dockerhub.huawei.com/official/ubuntu:15.04>test.tar
Error response from daemon: open /var/lib/docker/devicemapper/mnt/b49e7f17506fc456afc1936ddadc570ff9861f86af5c157b10b07057b7a31535/rootfs/bin/bash: no such file or directory
 ......
```
