### PR TITLE
Update changelog 17.03.0 ce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Upgrading from Docker 1.13.1 to 17.03.0 is expected to be simple and low-risk.
 ### Contrib
 
 * Update various `bash` and `zsh` completion scripts [#30823](https://github.com/docker/docker/pull/30823), [#30945](https://github.com/docker/docker/pull/30945) and more...
+* Block obsolete socket families in default seccomp profile - mitigates unpatched kernels' CVE-2017-6074 [#29076](https://github.com/docker/docker/pull/29076)
 
 ### Networking
 
@@ -36,6 +37,14 @@ Upgrading from Docker 1.13.1 to 17.03.0 is expected to be simple and low-risk.
 
 * Fix a deadlock in docker logs [#30223](https://github.com/docker/docker/pull/30223)
 * Fix cpu spin waiting for log write events [#31070](https://github.com/docker/docker/pull/31070)
+* Fix a possible crash when using journald [#31231](https://github.com/docker/docker/pull/31231) [#31263](https://github.com/docker/docker/pull/31231)
+* Fix a panic on close of nil channel [#31274](https://github.com/docker/docker/pull/31274)
+* Fix duplicate mount point for `--volumes-from` in `docker run` [#29563](https://github.com/docker/docker/pull/29563)
+* Fix `--cache-from` does not cache last step [#31189](https://github.com/docker/docker/pull/31189)
+
+### Swarm Mode
+
+* Shutdown leaks an error when the container was never started [#31279](https://github.com/docker/docker/pull/31279)
 
 ### Swarm Mode
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ information on the list of deprecated flags and APIs please have a look at
 https://docs.docker.com/engine/deprecated/ where target removal dates can also
 be found.
 
-## 17.03.0-ce (2017-02-01)
+## 17.03.0-ce (2017-03-01)
 
 ### Client
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ be found.
 
 ## 17.03.0-ce (2017-03-01)
 
+**IMPORTANT**: Starting with this release, Docker is on a monthly release cycle and uses a
+new YY.MM versioning scheme to reflect this. Two channels are available: monthly and quarterly.
+Any given monthly release will only receive security and bugfixes until the next monthly
+release is available. Quarterly releases receive security and bugfixes for 4 months after
+initial release. This release includes bugfixes for 1.13.1 but
+there are no major feature additions and the API version stays the same.
+Upgrading from Docker 1.13.1 to 17.03.0 is expected to be simple and low-risk.
+
 ### Client
 
-* Fix panic in `docker stats --format`
+* Fix panic in `docker stats --format` [#30776](https://github.com/docker/docker/pull/30776)
 
 ### Contrib
 
@@ -17,13 +25,24 @@ be found.
 
 ### Networking
 
+* Fix bug on overlay encryption keys rotation in cross-datacenter swarm [#30727](https://github.com/docker/docker/pull/30727)
+* Fix side effect panic in overlay encryption and network control plane communication failure ("No installed keys could decrypt the message") on frequent swarm leader re-election [#25608](https://github.com/docker/docker/pull/25608)
+* Several fixes around system responsiveness and datapath programming when using overlay network with external kv-store [docker/libnetwork#1639](https://github.com/docker/libnetwork/pull/1639), [docker/libnetwork#1632](https://github.com/docker/libnetwork/pull/1632) and more...
 * Discard incoming plain vxlan packets for encrypted overlay network [#31170](https://github.com/docker/docker/pull/31170)
 * Release the network attachment on allocation failure [#31073](https://github.com/docker/docker/pull/31073)
+* Fix port allocation when multiple published ports map to the same target port [docker/swarmkit#1835](https://github.com/docker/swarmkit/pull/1835)
 
 ### Runtime
 
 * Fix a deadlock in docker logs [#30223](https://github.com/docker/docker/pull/30223)
 * Fix cpu spin waiting for log write events [#31070](https://github.com/docker/docker/pull/31070)
+
+### Swarm Mode
+
+* Fix possibility of tasks getting stuck in the "NEW" state during a leader failover [docker/swarmkit#1938](https://github.com/docker/swarmkit/pull/1938)
+* Fix extraneous task creations for global services that led to confusing replica counts in `docker service ls` [docker/swarmkit#1957](https://github.com/docker/swarmkit/pull/1957)
+* Fix problem that made rolling updates slow when `task-history-limit` was set to 1 [docker/swarmkit#1948](https://github.com/docker/swarmkit/pull/1948)
+* Restart tasks elsewhere, if appropriate, when they are shut down as a result of nodes no longer satisfying constraints [docker/swarmkit#1958](https://github.com/docker/swarmkit/pull/1958)
 
 ## 1.13.1 (2017-02-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ information on the list of deprecated flags and APIs please have a look at
 https://docs.docker.com/engine/deprecated/ where target removal dates can also
 be found.
 
+## 17.03.0-ce (2017-02-01)
+
+### Client
+
+* Fix panic in `docker stats --format`
+
+### Contrib
+
+* Update various `bash` and `zsh` completion scripts [#30823](https://github.com/docker/docker/pull/30823), [#30945](https://github.com/docker/docker/pull/30945) and more...
+
+### Networking
+
+* Discard incoming plain vxlan packets for encrypted overlay network [#31170](https://github.com/docker/docker/pull/31170)
+* Release the network attachment on allocation failure [#31073](https://github.com/docker/docker/pull/31073)
+
+### Runtime
+
+* Fix a deadlock in docker logs [#30223](https://github.com/docker/docker/pull/30223)
+* Fix cpu spin waiting for log write events [#31070](https://github.com/docker/docker/pull/31070)
+
 ## 1.13.1 (2017-02-08)
 
 **IMPORTANT**: On Linux distributions where `devicemapper` was the default storage driver,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,6 @@ Upgrading from Docker 1.13.1 to 17.03.0 is expected to be simple and low-risk.
 ### Swarm Mode
 
 * Shutdown leaks an error when the container was never started [#31279](https://github.com/docker/docker/pull/31279)
-
-### Swarm Mode
-
 * Fix possibility of tasks getting stuck in the "NEW" state during a leader failover [docker/swarmkit#1938](https://github.com/docker/swarmkit/pull/1938)
 * Fix extraneous task creations for global services that led to confusing replica counts in `docker service ls` [docker/swarmkit#1957](https://github.com/docker/swarmkit/pull/1957)
 * Fix problem that made rolling updates slow when `task-history-limit` was set to 1 [docker/swarmkit#1948](https://github.com/docker/swarmkit/pull/1948)

--- a/hack/validate/changelog-well-formed
+++ b/hack/validate/changelog-well-formed
@@ -10,7 +10,7 @@ fi
 changelogWellFormed=1
 
 # e.g. "## 1.12.3 (2016-10-26)"
-VER_LINE_REGEX='^## [0-9]+\.[0-9]+\.[0-9]+ \([0-9]+-[0-9]+-[0-9]+\)$'
+VER_LINE_REGEX='^## [0-9]+\.[0-9]+\.[0-9]+(-ce)? \([0-9]+-[0-9]+-[0-9]+\)$'
 while read -r line; do
   if ! [[ "$line" =~ $VER_LINE_REGEX ]]; then
     echo "Malformed changelog $changelogFile line \"$line\"" >&2


### PR DESCRIPTION
This cherry-picks some commits from the 17.03.x branch back to master;

1c44f35eb1f593839eec00f9ce810913e7309ef2
ce07fb6b0f1b8765b92022e45f96bd4349812e06
9fb5c83df051fc2c2335fad0d3738539d1b4c264 (https://github.com/docker/docker/pull/31205)
4fa77953f8d51149afbead5dfe5930580f2cc022 (https://github.com/docker/docker/pull/31266)
44aec1b69261e8cee0dd416adbbe7a2443f759d6

