### PR TITLE
[test-integration] Update request.* signature to remove the host

### DIFF
--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -718,7 +718,7 @@ func (d *Daemon) ReloadConfig() error {
 	errCh := make(chan error)
 	started := make(chan struct{})
 	go func() {
-		_, body, err := request.Get(d.Sock(), "/events")
+		_, body, err := request.DoOnHost(d.Sock(), "/events", request.Method(http.MethodGet))
 		close(started)
 		if err != nil {
 			errCh <- err

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -32,7 +32,7 @@ RUN find /tmp/`
 	server := fakeStorage(c, map[string]string{"testD": testD})
 	defer server.Close()
 
-	res, body, err := request.Post(daemonHost(), "/build?dockerfile=baz&remote="+server.URL()+"/testD", request.JSON)
+	res, body, err := request.Post("/build?dockerfile=baz&remote="+server.URL()+"/testD", request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
@@ -71,7 +71,7 @@ func (s *DockerSuite) TestBuildAPIRemoteTarballContext(c *check.C) {
 	})
 	defer server.Close()
 
-	res, b, err := request.Post(daemonHost(), "/build?remote="+server.URL()+"/testT.tar", request.ContentType("application/tar"))
+	res, b, err := request.Post("/build?remote="+server.URL()+"/testT.tar", request.ContentType("application/tar"))
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 	b.Close()
@@ -119,7 +119,7 @@ RUN echo 'right'
 	defer server.Close()
 
 	url := "/build?dockerfile=custom&remote=" + server.URL() + "/testT.tar"
-	res, body, err := request.Post(daemonHost(), url, request.ContentType("application/tar"))
+	res, body, err := request.Post(url, request.ContentType("application/tar"))
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
@@ -138,7 +138,7 @@ RUN echo from dockerfile`,
 	}, false)
 	defer git.Close()
 
-	res, body, err := request.Post(daemonHost(), "/build?remote="+git.RepoURL, request.JSON)
+	res, body, err := request.Post("/build?remote="+git.RepoURL, request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
@@ -159,7 +159,7 @@ RUN echo from Dockerfile`,
 	defer git.Close()
 
 	// Make sure it tries to 'dockerfile' query param value
-	res, body, err := request.Post(daemonHost(), "/build?dockerfile=baz&remote="+git.RepoURL, request.JSON)
+	res, body, err := request.Post("/build?dockerfile=baz&remote="+git.RepoURL, request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
@@ -181,7 +181,7 @@ RUN echo from dockerfile`,
 	defer git.Close()
 
 	// Make sure it tries to 'dockerfile' query param value
-	res, body, err := request.Post(daemonHost(), "/build?remote="+git.RepoURL, request.JSON)
+	res, body, err := request.Post("/build?remote="+git.RepoURL, request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
@@ -228,7 +228,7 @@ func (s *DockerSuite) TestBuildAPIUnnormalizedTarPaths(c *check.C) {
 		// failed to close tar archive
 		c.Assert(tw.Close(), checker.IsNil)
 
-		res, body, err := request.Post(daemonHost(), "/build", request.RawContent(ioutil.NopCloser(buffer)), request.ContentType("application/x-tar"))
+		res, body, err := request.Post("/build", request.RawContent(ioutil.NopCloser(buffer)), request.ContentType("application/x-tar"))
 		c.Assert(err, checker.IsNil)
 		c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -216,7 +216,7 @@ func (s *DockerSuite) TestGetContainerStatsRmRunning(c *check.C) {
 	buf := &testutil.ChannelBuffer{C: make(chan []byte, 1)}
 	defer buf.Close()
 
-	_, body, err := request.Get(daemonHost(), "/containers/"+id+"/stats?stream=1", request.JSON)
+	_, body, err := request.Get("/containers/"+id+"/stats?stream=1", request.JSON)
 	c.Assert(err, checker.IsNil)
 	defer body.Close()
 
@@ -255,7 +255,7 @@ func (s *DockerSuite) TestGetContainerStatsStream(c *check.C) {
 	}
 	bc := make(chan b, 1)
 	go func() {
-		status, body, err := request.Get(daemonHost(), "/containers/"+name+"/stats")
+		status, body, err := request.Get("/containers/" + name + "/stats")
 		bc <- b{status.StatusCode, body, err}
 	}()
 
@@ -329,7 +329,7 @@ func (s *DockerSuite) TestGetStoppedContainerStats(c *check.C) {
 	// We expect an immediate response, but if it's not immediate, the test would hang, so put it in a goroutine
 	// below we'll check this on a timeout.
 	go func() {
-		resp, body, err := request.Get(daemonHost(), "/containers/"+name+"/stats")
+		resp, body, err := request.Get("/containers/" + name + "/stats")
 		body.Close()
 		chResp <- stats{resp.StatusCode, err}
 	}()
@@ -661,7 +661,7 @@ func (s *DockerSuite) TestContainerAPIVerifyHeader(c *check.C) {
 	create := func(ct string) (*http.Response, io.ReadCloser, error) {
 		jsonData := bytes.NewBuffer(nil)
 		c.Assert(json.NewEncoder(jsonData).Encode(config), checker.IsNil)
-		return request.Post(daemonHost(), "/containers/create", request.RawContent(ioutil.NopCloser(jsonData)), request.ContentType(ct))
+		return request.Post("/containers/create", request.RawContent(ioutil.NopCloser(jsonData)), request.ContentType(ct))
 	}
 
 	// Try with no content-type
@@ -697,7 +697,7 @@ func (s *DockerSuite) TestContainerAPIInvalidPortSyntax(c *check.C) {
 				  }
 				}`
 
-	res, body, err := request.Post(daemonHost(), "/containers/create", request.RawString(config), request.JSON)
+	res, body, err := request.Post("/containers/create", request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusInternalServerError)
 
@@ -717,7 +717,7 @@ func (s *DockerSuite) TestContainerAPIRestartPolicyInvalidPolicyName(c *check.C)
 		}
 	}`
 
-	res, body, err := request.Post(daemonHost(), "/containers/create", request.RawString(config), request.JSON)
+	res, body, err := request.Post("/containers/create", request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusInternalServerError)
 
@@ -737,7 +737,7 @@ func (s *DockerSuite) TestContainerAPIRestartPolicyRetryMismatch(c *check.C) {
 		}
 	}`
 
-	res, body, err := request.Post(daemonHost(), "/containers/create", request.RawString(config), request.JSON)
+	res, body, err := request.Post("/containers/create", request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusInternalServerError)
 
@@ -757,7 +757,7 @@ func (s *DockerSuite) TestContainerAPIRestartPolicyNegativeRetryCount(c *check.C
 		}
 	}`
 
-	res, body, err := request.Post(daemonHost(), "/containers/create", request.RawString(config), request.JSON)
+	res, body, err := request.Post("/containers/create", request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusInternalServerError)
 
@@ -777,7 +777,7 @@ func (s *DockerSuite) TestContainerAPIRestartPolicyDefaultRetryCount(c *check.C)
 		}
 	}`
 
-	res, _, err := request.Post(daemonHost(), "/containers/create", request.RawString(config), request.JSON)
+	res, _, err := request.Post("/containers/create", request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusCreated)
 }
@@ -808,7 +808,7 @@ func (s *DockerSuite) TestContainerAPIPostCreateNull(c *check.C) {
 		"NetworkDisabled":false,
 		"OnBuild":null}`
 
-	res, body, err := request.Post(daemonHost(), "/containers/create", request.RawString(config), request.JSON)
+	res, body, err := request.Post("/containers/create", request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusCreated)
 
@@ -839,7 +839,7 @@ func (s *DockerSuite) TestCreateWithTooLowMemoryLimit(c *check.C) {
 		"Memory":    524287
 	}`
 
-	res, body, err := request.Post(daemonHost(), "/containers/create", request.RawString(config), request.JSON)
+	res, body, err := request.Post("/containers/create", request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	b, err2 := testutil.ReadBody(body)
 	c.Assert(err2, checker.IsNil)
@@ -1139,7 +1139,7 @@ func (s *DockerSuite) TestContainerAPIChunkedEncoding(c *check.C) {
 		"OpenStdin": true,
 	}
 
-	resp, _, err := request.Post(daemonHost(), "/containers/create", request.JSONBody(config), func(req *http.Request) error {
+	resp, _, err := request.Post("/containers/create", request.JSONBody(config), func(req *http.Request) error {
 		// This is a cheat to make the http request do chunked encoding
 		// Otherwise (just setting the Content-Encoding to chunked) net/http will overwrite
 		// https://golang.org/src/pkg/net/http/request.go?s=11980:12172

--- a/integration-cli/docker_api_events_test.go
+++ b/integration-cli/docker_api_events_test.go
@@ -22,7 +22,7 @@ func (s *DockerSuite) TestEventsAPIEmptyOutput(c *check.C) {
 	}
 	chResp := make(chan *apiResp)
 	go func() {
-		resp, body, err := request.Get(daemonHost(), "/events")
+		resp, body, err := request.Get("/events")
 		body.Close()
 		chResp <- &apiResp{resp, err}
 	}()
@@ -47,7 +47,7 @@ func (s *DockerSuite) TestEventsAPIBackwardsCompatible(c *check.C) {
 	q := url.Values{}
 	q.Set("since", ts)
 
-	_, body, err := request.Get(daemonHost(), "/events?"+q.Encode())
+	_, body, err := request.Get("/events?" + q.Encode())
 	c.Assert(err, checker.IsNil)
 	defer body.Close()
 

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -62,7 +62,7 @@ func (s *DockerSuite) TestExecResizeImmediatelyAfterExecStart(c *check.C) {
 		}
 		defer conn.Close()
 
-		_, rc, err := request.Post(daemonHost(), fmt.Sprintf("/exec/%s/resize?h=24&w=80", execID), request.ContentType("text/plain"))
+		_, rc, err := request.Post(fmt.Sprintf("/exec/%s/resize?h=24&w=80", execID), request.ContentType("text/plain"))
 		// It's probably a panic of the daemon if io.ErrUnexpectedEOF is returned.
 		if err == io.ErrUnexpectedEOF {
 			return fmt.Errorf("The daemon might have crashed.")

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -38,7 +38,7 @@ func (s *DockerSuite) TestExecAPICreateNoValidContentType(c *check.C) {
 		c.Fatalf("Can not encode data to json %s", err)
 	}
 
-	res, body, err := request.Post(daemonHost(), fmt.Sprintf("/containers/%s/exec", name), request.RawContent(ioutil.NopCloser(jsonData)), request.ContentType("test/plain"))
+	res, body, err := request.Post(fmt.Sprintf("/containers/%s/exec", name), request.RawContent(ioutil.NopCloser(jsonData)), request.ContentType("test/plain"))
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusInternalServerError)
 
@@ -96,7 +96,7 @@ func (s *DockerSuite) TestExecAPIStartEnsureHeaders(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", "test", "busybox", "top")
 
 	id := createExec(c, "test")
-	resp, _, err := request.Post(daemonHost(), fmt.Sprintf("/exec/%s/start", id), request.RawString(`{"Detach": true}`), request.JSON)
+	resp, _, err := request.Post(fmt.Sprintf("/exec/%s/start", id), request.RawString(`{"Detach": true}`), request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.Header.Get("Server"), checker.Not(checker.Equals), "")
 }
@@ -106,7 +106,7 @@ func (s *DockerSuite) TestExecAPIStartBackwardsCompatible(c *check.C) {
 	runSleepingContainer(c, "-d", "--name", "test")
 	id := createExec(c, "test")
 
-	resp, body, err := request.Post(daemonHost(), fmt.Sprintf("/v1.20/exec/%s/start", id), request.RawString(`{"Detach": true}`), request.ContentType("text/plain"))
+	resp, body, err := request.Post(fmt.Sprintf("/v1.20/exec/%s/start", id), request.RawString(`{"Detach": true}`), request.ContentType("text/plain"))
 	c.Assert(err, checker.IsNil)
 
 	b, err := testutil.ReadBody(body)
@@ -141,14 +141,14 @@ func (s *DockerSuite) TestExecAPIStartWithDetach(c *check.C) {
 	}{}
 	c.Assert(json.Unmarshal(b, &createResp), checker.IsNil, check.Commentf(string(b)))
 
-	_, body, err := request.Post(daemonHost(), fmt.Sprintf("/exec/%s/start", createResp.ID), request.RawString(`{"Detach": true}`), request.JSON)
+	_, body, err := request.Post(fmt.Sprintf("/exec/%s/start", createResp.ID), request.RawString(`{"Detach": true}`), request.JSON)
 	c.Assert(err, checker.IsNil)
 
 	b, err = testutil.ReadBody(body)
 	comment := check.Commentf("response body: %s", b)
 	c.Assert(err, checker.IsNil, comment)
 
-	resp, _, err := request.Get(daemonHost(), "/_ping")
+	resp, _, err := request.Get("/_ping")
 	c.Assert(err, checker.IsNil)
 	if resp.StatusCode != http.StatusOK {
 		c.Fatal("daemon is down, it should alive")
@@ -191,7 +191,7 @@ func createExec(c *check.C, name string) string {
 }
 
 func createExecCmd(c *check.C, name string, cmd string) string {
-	_, reader, err := request.Post(daemonHost(), fmt.Sprintf("/containers/%s/exec", name), request.JSONBody(map[string]interface{}{"Cmd": []string{cmd}}))
+	_, reader, err := request.Post(fmt.Sprintf("/containers/%s/exec", name), request.JSONBody(map[string]interface{}{"Cmd": []string{cmd}}))
 	c.Assert(err, checker.IsNil)
 	b, err := ioutil.ReadAll(reader)
 	c.Assert(err, checker.IsNil)
@@ -204,7 +204,7 @@ func createExecCmd(c *check.C, name string, cmd string) string {
 }
 
 func startExec(c *check.C, id string, code int) {
-	resp, body, err := request.Post(daemonHost(), fmt.Sprintf("/exec/%s/start", id), request.RawString(`{"Detach": true}`), request.JSON)
+	resp, body, err := request.Post(fmt.Sprintf("/exec/%s/start", id), request.RawString(`{"Detach": true}`), request.JSON)
 	c.Assert(err, checker.IsNil)
 
 	b, err := testutil.ReadBody(body)
@@ -214,7 +214,7 @@ func startExec(c *check.C, id string, code int) {
 }
 
 func inspectExec(c *check.C, id string, out interface{}) {
-	resp, body, err := request.Get(daemonHost(), fmt.Sprintf("/exec/%s/json", id))
+	resp, body, err := request.Get(fmt.Sprintf("/exec/%s/json", id))
 	c.Assert(err, checker.IsNil)
 	defer body.Close()
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
@@ -240,7 +240,7 @@ func waitForExec(c *check.C, id string) {
 }
 
 func inspectContainer(c *check.C, id string, out interface{}) {
-	resp, body, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/json", id))
+	resp, body, err := request.Get(fmt.Sprintf("/containers/%s/json", id))
 	c.Assert(err, checker.IsNil)
 	defer body.Close()
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -56,14 +56,14 @@ func (s *DockerSuite) TestAPIImagesSaveAndLoad(c *check.C) {
 	buildImageSuccessfully(c, "saveandload", withDockerfile("FROM busybox\nENV FOO bar"))
 	id := getIDByName(c, "saveandload")
 
-	res, body, err := request.Get(daemonHost(), "/images/"+id+"/get")
+	res, body, err := request.Get("/images/" + id + "/get")
 	c.Assert(err, checker.IsNil)
 	defer body.Close()
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
 	dockerCmd(c, "rmi", id)
 
-	res, loadBody, err := request.Post(daemonHost(), "/images/load", request.RawContent(body), request.ContentType("application/x-tar"))
+	res, loadBody, err := request.Post("/images/load", request.RawContent(body), request.ContentType("application/x-tar"))
 	c.Assert(err, checker.IsNil)
 	defer loadBody.Close()
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
@@ -119,7 +119,7 @@ func (s *DockerSuite) TestAPIImagesHistory(c *check.C) {
 func (s *DockerSuite) TestAPIImagesSearchJSONContentType(c *check.C) {
 	testRequires(c, Network)
 
-	res, b, err := request.Get(daemonHost(), "/images/search?term=test", request.JSON)
+	res, b, err := request.Get("/images/search?term=test", request.JSON)
 	c.Assert(err, check.IsNil)
 	b.Close()
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -25,7 +25,7 @@ func (s *DockerSuite) TestLogsAPIWithStdout(c *check.C) {
 	chLog := make(chan logOut)
 
 	go func() {
-		res, body, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&timestamps=1", id))
+		res, body, err := request.Get(fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&timestamps=1", id))
 		if err != nil {
 			chLog <- logOut{"", nil, err}
 			return
@@ -69,7 +69,7 @@ func (s *DockerSuite) TestLogsAPIFollowEmptyOutput(c *check.C) {
 	t0 := time.Now()
 	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "sleep", "10")
 
-	_, body, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&stderr=1&tail=all", name))
+	_, body, err := request.Get(fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&stderr=1&tail=all", name))
 	t1 := time.Now()
 	c.Assert(err, checker.IsNil)
 	body.Close()
@@ -81,7 +81,7 @@ func (s *DockerSuite) TestLogsAPIFollowEmptyOutput(c *check.C) {
 
 func (s *DockerSuite) TestLogsAPIContainerNotFound(c *check.C) {
 	name := "nonExistentContainer"
-	resp, _, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&stderr=1&tail=all", name))
+	resp, _, err := request.Get(fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&stderr=1&tail=all", name))
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusNotFound)
 }

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -257,7 +257,7 @@ func createDeletePredefinedNetwork(c *check.C, name string) {
 }
 
 func isNetworkAvailable(c *check.C, name string) bool {
-	resp, body, err := request.Get(daemonHost(), "/networks")
+	resp, body, err := request.Get("/networks")
 	c.Assert(err, checker.IsNil)
 	defer resp.Body.Close()
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
@@ -284,7 +284,7 @@ func getNetworkIDByName(c *check.C, name string) string {
 	c.Assert(err, checker.IsNil)
 	v.Set("filters", filterJSON)
 
-	resp, body, err := request.Get(daemonHost(), "/networks?"+v.Encode())
+	resp, body, err := request.Get("/networks?" + v.Encode())
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(err, checker.IsNil)
 
@@ -297,7 +297,7 @@ func getNetworkIDByName(c *check.C, name string) string {
 }
 
 func getNetworkResource(c *check.C, id string) *types.NetworkResource {
-	_, obj, err := request.Get(daemonHost(), "/networks/"+id)
+	_, obj, err := request.Get("/networks/" + id)
 	c.Assert(err, checker.IsNil)
 
 	nr := types.NetworkResource{}
@@ -308,7 +308,7 @@ func getNetworkResource(c *check.C, id string) *types.NetworkResource {
 }
 
 func createNetwork(c *check.C, config types.NetworkCreateRequest, shouldSucceed bool) string {
-	resp, body, err := request.Post(daemonHost(), "/networks/create", request.JSONBody(config))
+	resp, body, err := request.Post("/networks/create", request.JSONBody(config))
 	c.Assert(err, checker.IsNil)
 	defer resp.Body.Close()
 	if !shouldSucceed {
@@ -330,7 +330,7 @@ func connectNetwork(c *check.C, nid, cid string) {
 		Container: cid,
 	}
 
-	resp, _, err := request.Post(daemonHost(), "/networks/"+nid+"/connect", request.JSONBody(config))
+	resp, _, err := request.Post("/networks/"+nid+"/connect", request.JSONBody(config))
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(err, checker.IsNil)
 }
@@ -340,13 +340,13 @@ func disconnectNetwork(c *check.C, nid, cid string) {
 		Container: cid,
 	}
 
-	resp, _, err := request.Post(daemonHost(), "/networks/"+nid+"/disconnect", request.JSONBody(config))
+	resp, _, err := request.Post("/networks/"+nid+"/disconnect", request.JSONBody(config))
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(err, checker.IsNil)
 }
 
 func deleteNetwork(c *check.C, id string, shouldSucceed bool) {
-	resp, _, err := request.Delete(daemonHost(), "/networks/"+id)
+	resp, _, err := request.Delete("/networks/" + id)
 	c.Assert(err, checker.IsNil)
 	defer resp.Body.Close()
 	if !shouldSucceed {

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -26,7 +26,7 @@ func (s *DockerSuite) TestAPIStatsNoStreamGetCpu(c *check.C) {
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), checker.IsNil)
 
-	resp, body, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/stats?stream=false", id))
+	resp, body, err := request.Get(fmt.Sprintf("/containers/%s/stats?stream=false", id))
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(resp.Header.Get("Content-Type"), checker.Equals, "application/json")
@@ -65,7 +65,7 @@ func (s *DockerSuite) TestAPIStatsStoppedContainerInGoroutines(c *check.C) {
 	id := strings.TrimSpace(out)
 
 	getGoRoutines := func() int {
-		_, body, err := request.Get(daemonHost(), fmt.Sprintf("/info"))
+		_, body, err := request.Get(fmt.Sprintf("/info"))
 		c.Assert(err, checker.IsNil)
 		info := types.Info{}
 		err = json.NewDecoder(body).Decode(&info)
@@ -76,7 +76,7 @@ func (s *DockerSuite) TestAPIStatsStoppedContainerInGoroutines(c *check.C) {
 
 	// When the HTTP connection is closed, the number of goroutines should not increase.
 	routines := getGoRoutines()
-	_, body, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/stats", id))
+	_, body, err := request.Get(fmt.Sprintf("/containers/%s/stats", id))
 	c.Assert(err, checker.IsNil)
 	body.Close()
 
@@ -192,7 +192,7 @@ func (s *DockerSuite) TestAPIStatsNetworkStatsVersioning(c *check.C) {
 func getNetworkStats(c *check.C, id string) map[string]types.NetworkStats {
 	var st *types.StatsJSON
 
-	_, body, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/stats?stream=false", id))
+	_, body, err := request.Get(fmt.Sprintf("/containers/%s/stats?stream=false", id))
 	c.Assert(err, checker.IsNil)
 
 	err = json.NewDecoder(body).Decode(&st)
@@ -209,7 +209,7 @@ func getNetworkStats(c *check.C, id string) map[string]types.NetworkStats {
 func getVersionedStats(c *check.C, id string, apiVersion string) map[string]interface{} {
 	stats := make(map[string]interface{})
 
-	_, body, err := request.Get(daemonHost(), fmt.Sprintf("/%s/containers/%s/stats?stream=false", apiVersion, id))
+	_, body, err := request.Get(fmt.Sprintf("/%s/containers/%s/stats?stream=false", apiVersion, id))
 	c.Assert(err, checker.IsNil)
 	defer body.Close()
 
@@ -284,7 +284,7 @@ func (s *DockerSuite) TestAPIStatsNoStreamConnectedContainers(c *check.C) {
 
 	ch := make(chan error)
 	go func() {
-		resp, body, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/stats?stream=false", id2))
+		resp, body, err := request.Get(fmt.Sprintf("/containers/%s/stats?stream=false", id2))
 		defer body.Close()
 		if err != nil {
 			ch <- err

--- a/integration-cli/docker_api_stats_unix_test.go
+++ b/integration-cli/docker_api_stats_unix_test.go
@@ -16,7 +16,7 @@ import (
 func (s *DockerSuite) TestAPIStatsContainerGetMemoryLimit(c *check.C) {
 	testRequires(c, DaemonIsLinux, memoryLimitSupport)
 
-	resp, body, err := request.Get(daemonHost(), "/info", request.JSON)
+	resp, body, err := request.Get("/info", request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	var info types.Info
@@ -29,7 +29,7 @@ func (s *DockerSuite) TestAPIStatsContainerGetMemoryLimit(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", conName, "busybox", "top")
 	c.Assert(waitRun(conName), checker.IsNil)
 
-	resp, body, err = request.Get(daemonHost(), fmt.Sprintf("/containers/%s/stats?stream=false", conName))
+	resp, body, err = request.Get(fmt.Sprintf("/containers/%s/stats?stream=false", conName))
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(resp.Header.Get("Content-Type"), checker.Equals, "application/json")

--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -18,13 +18,13 @@ import (
 )
 
 func (s *DockerSuite) TestAPIOptionsRoute(c *check.C) {
-	resp, _, err := request.Do(daemonHost(), "/", request.Method(http.MethodOptions))
+	resp, _, err := request.Do("/", request.Method(http.MethodOptions))
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 }
 
 func (s *DockerSuite) TestAPIGetEnabledCORS(c *check.C) {
-	res, body, err := request.Get(daemonHost(), "/version")
+	res, body, err := request.Get("/version")
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 	body.Close()
@@ -49,7 +49,7 @@ func (s *DockerSuite) TestAPIClientVersionOldNotSupported(c *check.C) {
 	v[1] = strconv.Itoa(vMinInt)
 	version := strings.Join(v, ".")
 
-	resp, body, err := request.Get(daemonHost(), "/v"+version+"/version")
+	resp, body, err := request.Get("/v" + version + "/version")
 	c.Assert(err, checker.IsNil)
 	defer body.Close()
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusBadRequest)
@@ -80,7 +80,7 @@ func (s *DockerSuite) TestAPIDockerAPIVersion(c *check.C) {
 }
 
 func (s *DockerSuite) TestAPIErrorJSON(c *check.C) {
-	httpResp, body, err := request.Post(daemonHost(), "/containers/create", request.JSONBody(struct{}{}))
+	httpResp, body, err := request.Post("/containers/create", request.JSONBody(struct{}{}))
 	c.Assert(err, checker.IsNil)
 	c.Assert(httpResp.StatusCode, checker.Equals, http.StatusInternalServerError)
 	c.Assert(httpResp.Header.Get("Content-Type"), checker.Equals, "application/json")
@@ -93,7 +93,7 @@ func (s *DockerSuite) TestAPIErrorPlainText(c *check.C) {
 	// Windows requires API 1.25 or later. This test is validating a behaviour which was present
 	// in v1.23, but changed in 1.24, hence not applicable on Windows. See apiVersionSupportsJSONErrors
 	testRequires(c, DaemonIsLinux)
-	httpResp, body, err := request.Post(daemonHost(), "/v1.23/containers/create", request.JSONBody(struct{}{}))
+	httpResp, body, err := request.Post("/v1.23/containers/create", request.JSONBody(struct{}{}))
 	c.Assert(err, checker.IsNil)
 	c.Assert(httpResp.StatusCode, checker.Equals, http.StatusInternalServerError)
 	c.Assert(httpResp.Header.Get("Content-Type"), checker.Contains, "text/plain")
@@ -104,7 +104,7 @@ func (s *DockerSuite) TestAPIErrorPlainText(c *check.C) {
 
 func (s *DockerSuite) TestAPIErrorNotFoundJSON(c *check.C) {
 	// 404 is a different code path to normal errors, so test separately
-	httpResp, body, err := request.Get(daemonHost(), "/notfound", request.JSON)
+	httpResp, body, err := request.Get("/notfound", request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(httpResp.StatusCode, checker.Equals, http.StatusNotFound)
 	c.Assert(httpResp.Header.Get("Content-Type"), checker.Equals, "application/json")
@@ -114,7 +114,7 @@ func (s *DockerSuite) TestAPIErrorNotFoundJSON(c *check.C) {
 }
 
 func (s *DockerSuite) TestAPIErrorNotFoundPlainText(c *check.C) {
-	httpResp, body, err := request.Get(daemonHost(), "/v1.23/notfound", request.JSON)
+	httpResp, body, err := request.Get("/v1.23/notfound", request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(httpResp.StatusCode, checker.Equals, http.StatusNotFound)
 	c.Assert(httpResp.Header.Get("Content-Type"), checker.Contains, "text/plain")

--- a/integration-cli/docker_cli_update_unix_test.go
+++ b/integration-cli/docker_cli_update_unix_test.go
@@ -220,7 +220,7 @@ func (s *DockerSuite) TestUpdateStats(c *check.C) {
 	c.Assert(waitRun(name), checker.IsNil)
 
 	getMemLimit := func(id string) uint64 {
-		resp, body, err := request.Get(daemonHost(), fmt.Sprintf("/containers/%s/stats?stream=false", id))
+		resp, body, err := request.Get(fmt.Sprintf("/containers/%s/stats?stream=false", id))
 		c.Assert(err, checker.IsNil)
 		c.Assert(resp.Header.Get("Content-Type"), checker.Equals, "application/json")
 

--- a/integration-cli/docker_deprecated_api_v124_test.go
+++ b/integration-cli/docker_deprecated_api_v124_test.go
@@ -150,7 +150,7 @@ func (s *DockerSuite) TestDeprecatedStartWithTooLowMemoryLimit(c *check.C) {
                 "Memory":    524287
         }`
 
-	res, body, err := request.Post(daemonHost(), formatV123StartAPIURL("/containers/"+containerID+"/start"), request.RawString(config), request.JSON)
+	res, body, err := request.Post(formatV123StartAPIURL("/containers/"+containerID+"/start"), request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	b, err2 := testutil.ReadBody(body)
 	c.Assert(err2, checker.IsNil)
@@ -169,7 +169,7 @@ func (s *DockerSuite) TestDeprecatedPostContainersStartWithoutLinksInHostConfig(
 	hc := inspectFieldJSON(c, name, "HostConfig")
 	config := `{"HostConfig":` + hc + `}`
 
-	res, b, err := request.Post(daemonHost(), formatV123StartAPIURL("/containers/"+name+"/start"), request.RawString(config), request.JSON)
+	res, b, err := request.Post(formatV123StartAPIURL("/containers/"+name+"/start"), request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusNoContent)
 	b.Close()
@@ -187,7 +187,7 @@ func (s *DockerSuite) TestDeprecatedPostContainersStartWithLinksInHostConfig(c *
 	hc := inspectFieldJSON(c, name, "HostConfig")
 	config := `{"HostConfig":` + hc + `}`
 
-	res, b, err := request.Post(daemonHost(), formatV123StartAPIURL("/containers/"+name+"/start"), request.RawString(config), request.JSON)
+	res, b, err := request.Post(formatV123StartAPIURL("/containers/"+name+"/start"), request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusNoContent)
 	b.Close()
@@ -205,7 +205,7 @@ func (s *DockerSuite) TestDeprecatedPostContainersStartWithLinksInHostConfigIdLi
 	hc := inspectFieldJSON(c, name, "HostConfig")
 	config := `{"HostConfig":` + hc + `}`
 
-	res, b, err := request.Post(daemonHost(), formatV123StartAPIURL("/containers/"+name+"/start"), request.RawString(config), request.JSON)
+	res, b, err := request.Post(formatV123StartAPIURL("/containers/"+name+"/start"), request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusNoContent)
 	b.Close()
@@ -219,7 +219,7 @@ func (s *DockerSuite) TestDeprecatedStartWithNilDNS(c *check.C) {
 
 	config := `{"HostConfig": {"Dns": null}}`
 
-	res, b, err := request.Post(daemonHost(), formatV123StartAPIURL("/containers/"+containerID+"/start"), request.RawString(config), request.JSON)
+	res, b, err := request.Post(formatV123StartAPIURL("/containers/"+containerID+"/start"), request.RawString(config), request.JSON)
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusNoContent)
 	b.Close()

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/daemon"
-	"github.com/docker/docker/integration-cli/environment"
 	"github.com/docker/docker/integration-cli/registry"
 	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/pkg/stringutils"
@@ -32,7 +31,7 @@ import (
 
 // Deprecated
 func daemonHost() string {
-	return environment.DaemonHost()
+	return request.DaemonHost()
 }
 
 // FIXME(vdemeester) move this away are remove ignoreNoSuchContainer bool

--- a/integration-cli/environment/clean.go
+++ b/integration-cli/environment/clean.go
@@ -4,13 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/docker/docker/api/types"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/integration-cli/request"
-	"github.com/docker/docker/opts"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 )
 
@@ -111,7 +109,7 @@ func deleteAllVolumes(t testingT, dockerBinary string) {
 	}
 	var errs []string
 	for _, v := range volumes {
-		status, b, err := request.SockRequest("DELETE", "/volumes/"+v.Name, nil, DaemonHost())
+		status, b, err := request.SockRequest("DELETE", "/volumes/"+v.Name, nil, request.DaemonHost())
 		if err != nil {
 			errs = append(errs, err.Error())
 			continue
@@ -127,7 +125,7 @@ func deleteAllVolumes(t testingT, dockerBinary string) {
 
 func getAllVolumes() ([]*types.Volume, error) {
 	var volumes volumetypes.VolumesListOKBody
-	_, b, err := request.SockRequest("GET", "/volumes", nil, DaemonHost())
+	_, b, err := request.SockRequest("GET", "/volumes", nil, request.DaemonHost())
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +149,7 @@ func deleteAllNetworks(t testingT, dockerBinary string, daemonPlatform string) {
 			// nat is a pre-defined network on Windows and cannot be removed
 			continue
 		}
-		status, b, err := request.SockRequest("DELETE", "/networks/"+n.Name, nil, DaemonHost())
+		status, b, err := request.SockRequest("DELETE", "/networks/"+n.Name, nil, request.DaemonHost())
 		if err != nil {
 			errs = append(errs, err.Error())
 			continue
@@ -167,7 +165,7 @@ func deleteAllNetworks(t testingT, dockerBinary string, daemonPlatform string) {
 
 func getAllNetworks() ([]types.NetworkResource, error) {
 	var networks []types.NetworkResource
-	_, b, err := request.SockRequest("GET", "/networks", nil, DaemonHost())
+	_, b, err := request.SockRequest("GET", "/networks", nil, request.DaemonHost())
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +183,7 @@ func deleteAllPlugins(t testingT, dockerBinary string) {
 	var errs []string
 	for _, p := range plugins {
 		pluginName := p.Name
-		status, b, err := request.SockRequest("DELETE", "/plugins/"+pluginName+"?force=1", nil, DaemonHost())
+		status, b, err := request.SockRequest("DELETE", "/plugins/"+pluginName+"?force=1", nil, request.DaemonHost())
 		if err != nil {
 			errs = append(errs, err.Error())
 			continue
@@ -201,7 +199,7 @@ func deleteAllPlugins(t testingT, dockerBinary string) {
 
 func getAllPlugins() (types.PluginsListResponse, error) {
 	var plugins types.PluginsListResponse
-	_, b, err := request.SockRequest("GET", "/plugins", nil, DaemonHost())
+	_, b, err := request.SockRequest("GET", "/plugins", nil, request.DaemonHost())
 	if err != nil {
 		return nil, err
 	}
@@ -209,13 +207,4 @@ func getAllPlugins() (types.PluginsListResponse, error) {
 		return nil, err
 	}
 	return plugins, nil
-}
-
-// DaemonHost return the daemon host string for this test execution
-func DaemonHost() string {
-	daemonURLStr := "unix://" + opts.DefaultUnixSocket
-	if daemonHostVar := os.Getenv("DOCKER_HOST"); daemonHostVar != "" {
-		daemonURLStr = daemonHostVar
-	}
-	return daemonURLStr
 }

--- a/integration-cli/request/request.go
+++ b/integration-cli/request/request.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	dclient "github.com/docker/docker/client"
+	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/testutil"
 	"github.com/docker/go-connections/sockets"
@@ -74,22 +75,27 @@ func JSONBody(data interface{}) func(*http.Request) error {
 }
 
 // Post creates and execute a POST request on the specified host and endpoint, with the specified request modifiers
-func Post(host, endpoint string, modifiers ...func(*http.Request) error) (*http.Response, io.ReadCloser, error) {
-	return Do(host, endpoint, append(modifiers, Method(http.MethodPost))...)
+func Post(endpoint string, modifiers ...func(*http.Request) error) (*http.Response, io.ReadCloser, error) {
+	return Do(endpoint, append(modifiers, Method(http.MethodPost))...)
 }
 
 // Delete creates and execute a DELETE request on the specified host and endpoint, with the specified request modifiers
-func Delete(host, endpoint string, modifiers ...func(*http.Request) error) (*http.Response, io.ReadCloser, error) {
-	return Do(host, endpoint, append(modifiers, Method(http.MethodDelete))...)
+func Delete(endpoint string, modifiers ...func(*http.Request) error) (*http.Response, io.ReadCloser, error) {
+	return Do(endpoint, append(modifiers, Method(http.MethodDelete))...)
 }
 
 // Get creates and execute a GET request on the specified host and endpoint, with the specified request modifiers
-func Get(host, endpoint string, modifiers ...func(*http.Request) error) (*http.Response, io.ReadCloser, error) {
-	return Do(host, endpoint, modifiers...)
+func Get(endpoint string, modifiers ...func(*http.Request) error) (*http.Response, io.ReadCloser, error) {
+	return Do(endpoint, modifiers...)
 }
 
-// Do creates and execute a request on the specified host and endpoint, with the specified request modifiers
-func Do(host, endpoint string, modifiers ...func(*http.Request) error) (*http.Response, io.ReadCloser, error) {
+// Do creates and execute a request on the specified endpoint, with the specified request modifiers
+func Do(endpoint string, modifiers ...func(*http.Request) error) (*http.Response, io.ReadCloser, error) {
+	return DoOnHost(DaemonHost(), endpoint, modifiers...)
+}
+
+// DoOnHost creates and execute a request on the specified host and endpoint, with the specified request modifiers
+func DoOnHost(host, endpoint string, modifiers ...func(*http.Request) error) (*http.Response, io.ReadCloser, error) {
 	req, err := New(host, endpoint, modifiers...)
 	if err != nil {
 		return nil, nil, err
@@ -282,4 +288,13 @@ func getTLSConfig() (*tls.Config, error) {
 	}
 
 	return tlsConfig, nil
+}
+
+// DaemonHost return the daemon host string for this test execution
+func DaemonHost() string {
+	daemonURLStr := "unix://" + opts.DefaultUnixSocket
+	if daemonHostVar := os.Getenv("DOCKER_HOST"); daemonHostVar != "" {
+		daemonURLStr = daemonHostVar
+	}
+	return daemonURLStr
 }


### PR DESCRIPTION
99.9% of use case for request call are using daemonHost. This makes it
default and adds a `request.DoOnHost` function to be able to specify
the host for specific, more complex use cases.

/cc @thaJeztah @dnephin @aaronlehmann @cpuguy83 @AkihiroSuda @icecrime 

🦁

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
