### PR TITLE
add environment configs to systemd init file

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -10,7 +10,11 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd -H fd://
+
+# environment file for Debian/Ubuntu
+EnvironmentFile=-/etc/default/docker
+
+ExecStart=/usr/bin/dockerd -H fd:// $DOCKER_OPTS
 ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/contrib/init/systemd/docker.service.rpm
+++ b/contrib/init/systemd/docker.service.rpm
@@ -9,7 +9,17 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd
+
+# environment file for CentOS 7.x, RHEL 7.x
+EnvironmentFile=-/etc/sysconfig/docker
+EnvironmentFile=-/etc/sysconfig/docker-storage
+EnvironmentFile=-/etc/sysconfig/docker-network
+
+ExecStart=/usr/bin/dockerd $OPTIONS \
+          $DOCKER_STORAGE_OPTIONS \
+          $DOCKER_NETWORK_OPTIONS \
+          $BLOCK_REGISTRY \
+          $INSECURE_REGISTRY
 ExecReload=/bin/kill -s HUP $MAINPID
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.


### PR DESCRIPTION
Signed-off-by: qudongfang <qudongfang@gmail.com>

fixes #31589 

**- What I did**
    add environment configs to systemd init file

**- How I did it**

**- How to verify it**

**- Description for the changelog**
    add environment configs to systemd init file
