### PR TITLE
[test-integration] Introduce a `cli` package for test-integration

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/docker/api/types/swarm"
 	cliconfig "github.com/docker/docker/cli/config"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/integration-cli/environment"
 	"github.com/docker/docker/integration-cli/registry"
@@ -51,15 +52,7 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
-	var err error
-	if dockerBin := os.Getenv("DOCKER_BINARY"); dockerBin != "" {
-		dockerBinary = dockerBin
-	}
-	dockerBinary, err = exec.LookPath(dockerBinary)
-	if err != nil {
-		fmt.Printf("ERROR: couldn't resolve full path to the Docker binary (%v)\n", err)
-		os.Exit(1)
-	}
+	dockerBinary = testEnv.DockerBinary()
 
 	if testEnv.LocalDaemon() {
 		fmt.Println("INFO: Testing against a local daemon")
@@ -71,6 +64,7 @@ func TestMain(m *testing.M) {
 }
 
 func Test(t *testing.T) {
+	cli.EnsureTestEnvIsLoaded(t)
 	cmd := exec.Command(dockerBinary, "images", "-f", "dangling=false", "--format", "{{.Repository}}:{{.Tag}}")
 	cmd.Env = appendBaseEnv(true)
 	out, err := cmd.CombinedOutput()

--- a/integration-cli/cli/build/build.go
+++ b/integration-cli/cli/build/build.go
@@ -1,0 +1,31 @@
+package build
+
+import (
+	"strings"
+
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
+)
+
+// WithDockerfile creates / returns a CmdOperator to set the Dockerfile for a build operation
+func WithDockerfile(dockerfile string) func(*icmd.Cmd) func() {
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Command = append(cmd.Command, "-")
+		cmd.Stdin = strings.NewReader(dockerfile)
+		return nil
+	}
+}
+
+// WithoutCache makes the build ignore cache
+func WithoutCache(cmd *icmd.Cmd) func() {
+	cmd.Command = append(cmd.Command, "--no-cache")
+	return nil
+}
+
+// WithContextPath set the build context path
+func WithContextPath(path string) func(*icmd.Cmd) func() {
+	// WithContextPath sets the build context path
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Command = append(cmd.Command, path)
+		return nil
+	}
+}

--- a/integration-cli/cli/cli.go
+++ b/integration-cli/cli/cli.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/docker/docker/integration-cli/daemon"
+	"github.com/docker/docker/integration-cli/environment"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
+)
+
+var (
+	testEnv  *environment.Execution
+	onlyOnce sync.Once
+)
+
+// EnsureTestEnvIsLoaded make sure the test environment is loaded for this package
+func EnsureTestEnvIsLoaded(t testingT) {
+	var doIt bool
+	var err error
+	onlyOnce.Do(func() {
+		doIt = true
+	})
+
+	if !doIt {
+		return
+	}
+	testEnv, err = environment.New()
+	if err != nil {
+		t.Fatalf("error loading testenv : %v", err)
+	}
+}
+
+// CmdOperator defines functions that can modify a command
+type CmdOperator func(*icmd.Cmd) func()
+
+type testingT interface {
+	Fatalf(string, ...interface{})
+}
+
+// DockerCmd executes the specified docker command and expect a success
+func DockerCmd(t testingT, command string, args ...string) *icmd.Result {
+	return Docker(Cmd(command, args...)).Assert(t, icmd.Success)
+}
+
+// BuildCmd executes the specified docker build command and expect a success
+func BuildCmd(t testingT, name string, cmdOperators ...CmdOperator) *icmd.Result {
+	return Docker(Build(name), cmdOperators...).Assert(t, icmd.Success)
+}
+
+// InspectCmd executes the specified docker inspect command and expect a success
+func InspectCmd(t testingT, name string, cmdOperators ...CmdOperator) *icmd.Result {
+	return Docker(Inspect(name), cmdOperators...).Assert(t, icmd.Success)
+}
+
+// Docker executes the specified docker command
+func Docker(cmd icmd.Cmd, cmdOperators ...CmdOperator) *icmd.Result {
+	for _, op := range cmdOperators {
+		deferFn := op(&cmd)
+		if deferFn != nil {
+			defer deferFn()
+		}
+	}
+	appendDocker(&cmd)
+	return icmd.RunCmd(cmd)
+}
+
+// Build executes the specified docker build command
+func Build(name string) icmd.Cmd {
+	return icmd.Command("build", "-t", name)
+}
+
+// Inspect executes the specified docker inspect command
+func Inspect(name string) icmd.Cmd {
+	return icmd.Command("inspect", name)
+}
+
+// Format sets the specified format with --format flag
+func Format(format string) func(*icmd.Cmd) func() {
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Command = append(
+			[]string{cmd.Command[0]},
+			append([]string{"--format", fmt.Sprintf("{{%s}}", format)}, cmd.Command[1:]...)...,
+		)
+		return nil
+	}
+}
+
+func appendDocker(cmd *icmd.Cmd) {
+	cmd.Command = append([]string{testEnv.DockerBinary()}, cmd.Command...)
+}
+
+// Cmd build an icmd.Cmd struct from the specified command and arguments
+func Cmd(command string, args ...string) icmd.Cmd {
+	return icmd.Command(command, args...)
+}
+
+// Daemon points to the specified daemon
+func Daemon(d *daemon.Daemon) func(*icmd.Cmd) func() {
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Command = append([]string{"--host", d.Sock()}, cmd.Command...)
+		return nil
+	}
+}
+
+// WithTimeout sets the timeout for the command to run
+func WithTimeout(timeout time.Duration) func(cmd *icmd.Cmd) func() {
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Timeout = timeout
+		return nil
+	}
+}
+
+// WithEnvironmentVariables sets the specified environment variables for the command to run
+func WithEnvironmentVariables(envs ...string) func(cmd *icmd.Cmd) func() {
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Env = envs
+		return nil
+	}
+}
+
+// WithFlags sets the specified flags for the command to run
+func WithFlags(flags ...string) func(*icmd.Cmd) func() {
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Command = append(cmd.Command, flags...)
+		return nil
+	}
+}

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -21,6 +21,7 @@ import (
 	mounttypes "github.com/docker/docker/api/types/mount"
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/mount"
@@ -1768,7 +1769,7 @@ func (s *DockerSuite) TestContainersAPICreateMountsCreate(c *check.C) {
 	)
 	if testEnv.DaemonPlatform() != "windows" {
 		testImg = "test-mount-config"
-		buildImageSuccessfully(c, testImg, withDockerfile(`
+		buildImageSuccessfully(c, testImg, build.WithDockerfile(`
 	FROM busybox
 	RUN mkdir `+destPath+` && touch `+destPath+slash+`bar
 	CMD cat `+destPath+slash+`bar

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
 )
@@ -53,7 +55,7 @@ func (s *DockerSuite) TestAPIImagesSaveAndLoad(c *check.C) {
 	// TODO Windows to Windows CI: Investigate further why this test fails.
 	testRequires(c, Network)
 	testRequires(c, DaemonIsLinux)
-	buildImageSuccessfully(c, "saveandload", withDockerfile("FROM busybox\nENV FOO bar"))
+	buildImageSuccessfully(c, "saveandload", build.WithDockerfile("FROM busybox\nENV FOO bar"))
 	id := getIDByName(c, "saveandload")
 
 	res, body, err := request.Get("/images/" + id + "/get")
@@ -68,7 +70,7 @@ func (s *DockerSuite) TestAPIImagesSaveAndLoad(c *check.C) {
 	defer loadBody.Close()
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
-	inspectOut := inspectField(c, id, "Id")
+	inspectOut := cli.InspectCmd(c, id, cli.Format(".Id")).Combined()
 	c.Assert(strings.TrimSpace(string(inspectOut)), checker.Equals, id, check.Commentf("load did not work properly"))
 }
 
@@ -77,7 +79,7 @@ func (s *DockerSuite) TestAPIImagesDelete(c *check.C) {
 		testRequires(c, Network)
 	}
 	name := "test-api-images-delete"
-	buildImageSuccessfully(c, name, withDockerfile("FROM busybox\nENV FOO bar"))
+	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nENV FOO bar"))
 	id := getIDByName(c, name)
 
 	dockerCmd(c, "tag", name, "test:tag1")
@@ -100,7 +102,7 @@ func (s *DockerSuite) TestAPIImagesHistory(c *check.C) {
 		testRequires(c, Network)
 	}
 	name := "test-api-images-history"
-	buildImageSuccessfully(c, name, withDockerfile("FROM busybox\nENV FOO bar"))
+	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nENV FOO bar"))
 	id := getIDByName(c, name)
 
 	status, body, err := request.SockRequest("GET", "/images/"+id+"/history", nil, daemonHost())

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/docker/docker/builder/dockerfile/command"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/stringutils"
 	"github.com/docker/docker/pkg/testutil"
@@ -26,7 +28,7 @@ import (
 )
 
 func (s *DockerSuite) TestBuildJSONEmptyRun(c *check.C) {
-	buildImageSuccessfully(c, "testbuildjsonemptyrun", withDockerfile(`
+	cli.BuildCmd(c, "testbuildjsonemptyrun", build.WithDockerfile(`
     FROM busybox
     RUN []
     `))
@@ -39,7 +41,7 @@ func (s *DockerSuite) TestBuildShCmdJSONEntrypoint(c *check.C) {
 		expected = "cmd /S /C echo test"
 	}
 
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
     FROM busybox
     ENTRYPOINT ["echo"]
     CMD echo test
@@ -56,7 +58,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementUser(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvironmentreplacement"
 
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
   FROM scratch
   ENV user foo
   USER ${user}
@@ -79,7 +81,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementVolume(c *check.C) {
 		volumePath = "/quux"
 	}
 
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
   FROM `+minimalBaseImage()+`
   ENV volume `+volumePath+`
   VOLUME ${volume}
@@ -98,7 +100,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementExpose(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvironmentreplacement"
 
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
   FROM scratch
   ENV port 80
   EXPOSE ${port}
@@ -121,7 +123,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementExpose(c *check.C) {
 func (s *DockerSuite) TestBuildEnvironmentReplacementWorkdir(c *check.C) {
 	name := "testbuildenvironmentreplacement"
 
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
   FROM busybox
   ENV MYWORKDIR /work
   RUN mkdir ${MYWORKDIR}
@@ -167,7 +169,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementEnv(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvironmentreplacement"
 
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
   FROM busybox
   ENV foo zzz
   ENV bar ${foo}
@@ -244,7 +246,7 @@ func (s *DockerSuite) TestBuildHandleEscapesInVolume(c *check.C) {
 	}
 
 	for _, tc := range testCases {
-		buildImageSuccessfully(c, name, withDockerfile(fmt.Sprintf(`
+		buildImageSuccessfully(c, name, build.WithDockerfile(fmt.Sprintf(`
   FROM scratch
   ENV FOO bar
   VOLUME %s
@@ -265,12 +267,12 @@ func (s *DockerSuite) TestBuildOnBuildLowercase(c *check.C) {
 	name := "testbuildonbuildlowercase"
 	name2 := "testbuildonbuildlowercase2"
 
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
   FROM busybox
   onbuild run echo quux
   `))
 
-	result := buildImage(name2, withDockerfile(fmt.Sprintf(`
+	result := buildImage(name2, build.WithDockerfile(fmt.Sprintf(`
   FROM %s
   `, name)))
 	result.Assert(c, icmd.Success)
@@ -289,7 +291,7 @@ func (s *DockerSuite) TestBuildEnvEscapes(c *check.C) {
 	// ENV expansions work differently in Windows
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvescapes"
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
     FROM busybox
     ENV TEST foo
     CMD echo \$
@@ -306,7 +308,7 @@ func (s *DockerSuite) TestBuildEnvOverwrite(c *check.C) {
 	// ENV expansions work differently in Windows
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvoverwrite"
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
     FROM busybox
     ENV TEST foo
     CMD echo ${TEST}
@@ -324,13 +326,13 @@ func (s *DockerSuite) TestBuildOnBuildCmdEntrypointJSON(c *check.C) {
 	name1 := "onbuildcmd"
 	name2 := "onbuildgenerated"
 
-	buildImageSuccessfully(c, name1, withDockerfile(`
+	buildImageSuccessfully(c, name1, build.WithDockerfile(`
 FROM busybox
 ONBUILD CMD ["hello world"]
 ONBUILD ENTRYPOINT ["echo"]
 ONBUILD RUN ["true"]`))
 
-	buildImageSuccessfully(c, name2, withDockerfile(fmt.Sprintf(`FROM %s`, name1)))
+	buildImageSuccessfully(c, name2, build.WithDockerfile(fmt.Sprintf(`FROM %s`, name1)))
 
 	out, _ := dockerCmd(c, "run", name2)
 	if !regexp.MustCompile(`(?m)^hello world`).MatchString(out) {
@@ -344,11 +346,11 @@ func (s *DockerSuite) TestBuildOnBuildEntrypointJSON(c *check.C) {
 	name1 := "onbuildcmd"
 	name2 := "onbuildgenerated"
 
-	buildImageSuccessfully(c, name1, withDockerfile(`
+	buildImageSuccessfully(c, name1, build.WithDockerfile(`
 FROM busybox
 ONBUILD ENTRYPOINT ["echo"]`))
 
-	buildImageSuccessfully(c, name2, withDockerfile(fmt.Sprintf("FROM %s\nCMD [\"hello world\"]\n", name1)))
+	buildImageSuccessfully(c, name2, build.WithDockerfile(fmt.Sprintf("FROM %s\nCMD [\"hello world\"]\n", name1)))
 
 	out, _ := dockerCmd(c, "run", name2)
 	if !regexp.MustCompile(`(?m)^hello world`).MatchString(out) {
@@ -366,10 +368,10 @@ func (s *DockerSuite) TestBuildCacheAdd(c *check.C) {
 	})
 	defer server.Close()
 
-	buildImageSuccessfully(c, name, withDockerfile(fmt.Sprintf(`FROM scratch
+	cli.BuildCmd(c, name, build.WithDockerfile(fmt.Sprintf(`FROM scratch
 		ADD %s/robots.txt /`, server.URL())))
 
-	result := buildImage(name, withDockerfile(fmt.Sprintf(`FROM scratch
+	result := cli.Docker(cli.Build(name), build.WithDockerfile(fmt.Sprintf(`FROM scratch
 		ADD %s/index.html /`, server.URL())))
 	result.Assert(c, icmd.Success)
 	if strings.Contains(result.Combined(), "Using cache") {
@@ -395,14 +397,14 @@ func (s *DockerSuite) TestBuildLastModified(c *check.C) {
 ADD %s/file /`
 	dockerfile := fmt.Sprintf(dFmt, server.URL())
 
-	buildImageSuccessfully(c, name, withoutCache, withDockerfile(dockerfile))
+	buildImageSuccessfully(c, name, build.WithoutCache, build.WithDockerfile(dockerfile))
 	out, _ = dockerCmd(c, "run", name, "ls", "-le", "/file")
 
 	// Build it again and make sure the mtime of the file didn't change.
 	// Wait a few seconds to make sure the time changed enough to notice
 	time.Sleep(2 * time.Second)
 
-	buildImageSuccessfully(c, name, withoutCache, withDockerfile(dockerfile))
+	buildImageSuccessfully(c, name, build.WithoutCache, build.WithDockerfile(dockerfile))
 	out2, _ = dockerCmd(c, "run", name, "ls", "-le", "/file")
 
 	if out != out2 {
@@ -417,7 +419,7 @@ ADD %s/file /`
 	defer server.Close()
 
 	dockerfile = fmt.Sprintf(dFmt, server.URL())
-	buildImageSuccessfully(c, name, withoutCache, withDockerfile(dockerfile))
+	buildImageSuccessfully(c, name, build.WithoutCache, build.WithDockerfile(dockerfile))
 	out2, _ = dockerCmd(c, "run", name, "ls", "-le", "/file")
 
 	if out == out2 {
@@ -1155,7 +1157,7 @@ func (s *DockerSuite) TestBuildForceRm(c *check.C) {
 	containerCountBefore := getContainerCount(c)
 	name := "testbuildforcerm"
 
-	buildImage(name, withBuildFlags("--force-rm"), withBuildContext(c,
+	buildImage(name, cli.WithFlags("--force-rm"), withBuildContext(c,
 		withFile("Dockerfile", `FROM `+minimalBaseImage()+`
 	RUN true
 	RUN thiswillfail`))).Assert(c, icmd.Expected{
@@ -1194,7 +1196,7 @@ func (s *DockerSuite) TestBuildRm(c *check.C) {
 	for _, tc := range testCases {
 		containerCountBefore := getContainerCount(c)
 
-		buildImageSuccessfully(c, name, withBuildFlags(tc.buildflags...), withDockerfile(`FROM busybox
+		buildImageSuccessfully(c, name, cli.WithFlags(tc.buildflags...), build.WithDockerfile(`FROM busybox
 	RUN echo hello world`))
 
 		containerCountAfter := getContainerCount(c)
@@ -1230,7 +1232,7 @@ func (s *DockerSuite) TestBuildWithVolumes(c *check.C) {
 		}
 	)
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM scratch
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM scratch
 		VOLUME /test1
 		VOLUME /test2
     VOLUME /test3 /test4
@@ -1250,7 +1252,7 @@ func (s *DockerSuite) TestBuildWithVolumes(c *check.C) {
 func (s *DockerSuite) TestBuildMaintainer(c *check.C) {
 	name := "testbuildmaintainer"
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         MAINTAINER dockerio`))
 
 	expected := "dockerio"
@@ -1264,7 +1266,7 @@ func (s *DockerSuite) TestBuildUser(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuilduser"
 	expected := "dockerio"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 		USER dockerio
 		RUN [ $(whoami) = 'dockerio' ]`))
@@ -1299,7 +1301,7 @@ func (s *DockerSuite) TestBuildRelativeWorkdir(c *check.C) {
 		expectedFinal = `/test2/test3`
 	}
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		RUN sh -c "[ "$PWD" = "`+expected1+`" ]"
 		WORKDIR test1
 		RUN sh -c "[ "$PWD" = "`+expected2+`" ]"
@@ -1318,7 +1320,7 @@ func (s *DockerSuite) TestBuildRelativeWorkdir(c *check.C) {
 // Windows semantics. Most path handling verifications are in unit tests
 func (s *DockerSuite) TestBuildWindowsWorkdirProcessing(c *check.C) {
 	testRequires(c, DaemonIsWindows)
-	buildImageSuccessfully(c, "testbuildwindowsworkdirprocessing", withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, "testbuildwindowsworkdirprocessing", build.WithDockerfile(`FROM busybox
 		WORKDIR C:\\foo
 		WORKDIR bar
 		RUN sh -c "[ "$PWD" = "C:/foo/bar" ]"
@@ -1370,7 +1372,7 @@ func (s *DockerSuite) TestBuildWorkdirWithEnvVariables(c *check.C) {
 		expected = `/test1/test2`
 	}
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		ENV DIRPATH /test1
 		ENV SUBDIRNAME test2
 		WORKDIR $DIRPATH
@@ -1440,7 +1442,7 @@ func (s *DockerSuite) TestBuildBlankName(c *check.C) {
 	}
 
 	for _, tc := range testCases {
-		buildImage(name, withDockerfile(fmt.Sprintf(`FROM busybox
+		buildImage(name, build.WithDockerfile(fmt.Sprintf(`FROM busybox
 		%s`, tc.expression))).Assert(c, icmd.Expected{
 			ExitCode: 1,
 			Err:      tc.expectedStderr,
@@ -1452,7 +1454,7 @@ func (s *DockerSuite) TestBuildEnv(c *check.C) {
 	testRequires(c, DaemonIsLinux) // ENV expansion is different in Windows
 	name := "testbuildenv"
 	expected := "[PATH=/test:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PORT=2375]"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		ENV PATH /test:$PATH
 		ENV PORT 2375
 		RUN [ $(env | grep PORT) = 'PORT=2375' ]`))
@@ -1468,7 +1470,7 @@ func (s *DockerSuite) TestBuildPATH(c *check.C) {
 	defPath := "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 	fn := func(dockerfile string, expected string) {
-		buildImageSuccessfully(c, "testbldpath", withDockerfile(dockerfile))
+		buildImageSuccessfully(c, "testbldpath", build.WithDockerfile(dockerfile))
 		res := inspectField(c, "testbldpath", "Config.Env")
 		if res != expected {
 			c.Fatalf("Env %q, expected %q for dockerfile:%q", res, expected, dockerfile)
@@ -1500,7 +1502,7 @@ func (s *DockerSuite) TestBuildContextCleanup(c *check.C) {
 		c.Fatalf("failed to list contents of tmp dir: %s", err)
 	}
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         ENTRYPOINT ["/bin/echo"]`))
 
 	entriesFinal, err := ioutil.ReadDir(filepath.Join(testEnv.DockerBasePath(), "tmp"))
@@ -1522,7 +1524,7 @@ func (s *DockerSuite) TestBuildContextCleanupFailedBuild(c *check.C) {
 		c.Fatalf("failed to list contents of tmp dir: %s", err)
 	}
 
-	buildImage(name, withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImage(name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
 	RUN /non/existing/command`)).Assert(c, icmd.Expected{
 		ExitCode: 1,
 	})
@@ -1541,7 +1543,7 @@ func (s *DockerSuite) TestBuildCmd(c *check.C) {
 	name := "testbuildcmd"
 	expected := "[/bin/echo Hello World]"
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         CMD ["/bin/echo", "Hello World"]`))
 
 	res := inspectField(c, name, "Config.Cmd")
@@ -1555,7 +1557,7 @@ func (s *DockerSuite) TestBuildExpose(c *check.C) {
 	name := "testbuildexpose"
 	expected := "map[2375/tcp:{}]"
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM scratch
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM scratch
         EXPOSE 2375`))
 
 	res := inspectField(c, name, "Config.ExposedPorts")
@@ -1591,7 +1593,7 @@ func (s *DockerSuite) TestBuildExposeMorePorts(c *check.C) {
 	tmpl.Execute(buf, portList)
 
 	name := "testbuildexpose"
-	buildImageSuccessfully(c, name, withDockerfile(buf.String()))
+	buildImageSuccessfully(c, name, build.WithDockerfile(buf.String()))
 
 	// check if all the ports are saved inside Config.ExposedPorts
 	res := inspectFieldJSON(c, name, "Config.ExposedPorts")
@@ -1616,7 +1618,7 @@ func (s *DockerSuite) TestBuildExposeMorePorts(c *check.C) {
 func (s *DockerSuite) TestBuildExposeOrder(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Expose not implemented on Windows
 	buildID := func(name, exposed string) string {
-		buildImageSuccessfully(c, name, withDockerfile(fmt.Sprintf(`FROM scratch
+		buildImageSuccessfully(c, name, build.WithDockerfile(fmt.Sprintf(`FROM scratch
 		EXPOSE %s`, exposed)))
 		id := inspectField(c, name, "Id")
 		return id
@@ -1633,7 +1635,7 @@ func (s *DockerSuite) TestBuildExposeUpperCaseProto(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Expose not implemented on Windows
 	name := "testbuildexposeuppercaseproto"
 	expected := "map[5678/udp:{}]"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM scratch
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM scratch
         EXPOSE 5678/UDP`))
 	res := inspectField(c, name, "Config.ExposedPorts")
 	if res != expected {
@@ -1645,7 +1647,7 @@ func (s *DockerSuite) TestBuildEmptyEntrypointInheritance(c *check.C) {
 	name := "testbuildentrypointinheritance"
 	name2 := "testbuildentrypointinheritance2"
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
         ENTRYPOINT ["/bin/echo"]`))
 	res := inspectField(c, name, "Config.Entrypoint")
 
@@ -1654,7 +1656,7 @@ func (s *DockerSuite) TestBuildEmptyEntrypointInheritance(c *check.C) {
 		c.Fatalf("Entrypoint %s, expected %s", res, expected)
 	}
 
-	buildImageSuccessfully(c, name2, withDockerfile(fmt.Sprintf(`FROM %s
+	buildImageSuccessfully(c, name2, build.WithDockerfile(fmt.Sprintf(`FROM %s
         ENTRYPOINT []`, name)))
 	res = inspectField(c, name2, "Config.Entrypoint")
 
@@ -1668,7 +1670,7 @@ func (s *DockerSuite) TestBuildEmptyEntrypoint(c *check.C) {
 	name := "testbuildentrypoint"
 	expected := "[]"
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
         ENTRYPOINT []`))
 
 	res := inspectField(c, name, "Config.Entrypoint")
@@ -1682,7 +1684,7 @@ func (s *DockerSuite) TestBuildEntrypoint(c *check.C) {
 	name := "testbuildentrypoint"
 
 	expected := "[/bin/echo]"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         ENTRYPOINT ["/bin/echo"]`))
 
 	res := inspectField(c, name, "Config.Entrypoint")
@@ -1694,17 +1696,17 @@ func (s *DockerSuite) TestBuildEntrypoint(c *check.C) {
 
 // #6445 ensure ONBUILD triggers aren't committed to grandchildren
 func (s *DockerSuite) TestBuildOnBuildLimitedInheritence(c *check.C) {
-	buildImageSuccessfully(c, "testonbuildtrigger1", withDockerfile(`
+	buildImageSuccessfully(c, "testonbuildtrigger1", build.WithDockerfile(`
 		FROM busybox
 		RUN echo "GRANDPARENT"
 		ONBUILD RUN echo "ONBUILD PARENT"
 		`))
 	// ONBUILD should be run in second build.
-	buildImage("testonbuildtrigger2", withDockerfile("FROM testonbuildtrigger1")).Assert(c, icmd.Expected{
+	buildImage("testonbuildtrigger2", build.WithDockerfile("FROM testonbuildtrigger1")).Assert(c, icmd.Expected{
 		Out: "ONBUILD PARENT",
 	})
 	// ONBUILD should *not* be run in third build.
-	result := buildImage("testonbuildtrigger3", withDockerfile("FROM testonbuildtrigger2"))
+	result := buildImage("testonbuildtrigger3", build.WithDockerfile("FROM testonbuildtrigger2"))
 	result.Assert(c, icmd.Success)
 	if strings.Contains(result.Combined(), "ONBUILD PARENT") {
 		c.Fatalf("ONBUILD instruction ran in grandchild of ONBUILD parent")
@@ -1718,11 +1720,11 @@ func (s *DockerSuite) TestBuildSameDockerfileWithAndWithoutCache(c *check.C) {
 		MAINTAINER dockerio
 		EXPOSE 5432
         ENTRYPOINT ["/bin/echo"]`
-	buildImageSuccessfully(c, name, withDockerfile(dockerfile))
+	buildImageSuccessfully(c, name, build.WithDockerfile(dockerfile))
 	id1 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, withDockerfile(dockerfile))
+	buildImageSuccessfully(c, name, build.WithDockerfile(dockerfile))
 	id2 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, withoutCache, withDockerfile(dockerfile))
+	buildImageSuccessfully(c, name, build.WithoutCache, build.WithDockerfile(dockerfile))
 	id3 := getIDByName(c, name)
 	if id1 != id2 {
 		c.Fatal("The cache should have been used but hasn't.")
@@ -1781,7 +1783,7 @@ func (s *DockerSuite) TestBuildAddMultipleLocalFileWithAndWithoutCache(c *check.
 	id1 := getIDByName(c, name)
 	buildImageSuccessfully(c, name, withExternalBuildContext(ctx))
 	id2 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, withoutCache, withExternalBuildContext(ctx))
+	buildImageSuccessfully(c, name, build.WithoutCache, withExternalBuildContext(ctx))
 	id3 := getIDByName(c, name)
 	if id1 != id2 {
 		c.Fatal("The cache should have been used but hasn't.")
@@ -1874,7 +1876,7 @@ func (s *DockerSuite) TestBuildAddCurrentDirWithoutCache(c *check.C) {
 	defer ctx.Close()
 	buildImageSuccessfully(c, name, withExternalBuildContext(ctx))
 	id1 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, withoutCache, withExternalBuildContext(ctx))
+	buildImageSuccessfully(c, name, build.WithoutCache, withExternalBuildContext(ctx))
 	id2 := getIDByName(c, name)
 	if id1 == id2 {
 		c.Fatal("The cache should have been invalided but hasn't.")
@@ -1891,11 +1893,11 @@ func (s *DockerSuite) TestBuildAddRemoteFileWithAndWithoutCache(c *check.C) {
 	dockerfile := fmt.Sprintf(`FROM `+minimalBaseImage()+`
         MAINTAINER dockerio
         ADD %s/baz /usr/lib/baz/quux`, server.URL())
-	buildImageSuccessfully(c, name, withDockerfile(dockerfile))
+	buildImageSuccessfully(c, name, build.WithDockerfile(dockerfile))
 	id1 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, withDockerfile(dockerfile))
+	buildImageSuccessfully(c, name, build.WithDockerfile(dockerfile))
 	id2 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, withoutCache, withDockerfile(dockerfile))
+	buildImageSuccessfully(c, name, build.WithoutCache, build.WithDockerfile(dockerfile))
 	id3 := getIDByName(c, name)
 
 	if id1 != id2 {
@@ -1968,7 +1970,7 @@ func (s *DockerSuite) TestBuildAddLocalAndRemoteFilesWithAndWithoutCache(c *chec
 	id1 := getIDByName(c, name)
 	buildImageSuccessfully(c, name, withExternalBuildContext(ctx))
 	id2 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, withoutCache, withExternalBuildContext(ctx))
+	buildImageSuccessfully(c, name, build.WithoutCache, withExternalBuildContext(ctx))
 	id3 := getIDByName(c, name)
 	if id1 != id2 {
 		c.Fatal("The cache should have been used but hasn't.")
@@ -2026,7 +2028,7 @@ func (s *DockerSuite) TestBuildWithVolumeOwnership(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildimg"
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox:latest
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox:latest
         RUN mkdir /test && chown daemon:daemon /test && chmod 0600 /test
         VOLUME /test`))
 
@@ -2044,7 +2046,7 @@ func (s *DockerSuite) TestBuildWithVolumeOwnership(c *check.C) {
 // utilizing cache
 func (s *DockerSuite) TestBuildEntrypointRunCleanup(c *check.C) {
 	name := "testbuildcmdcleanup"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
         RUN echo "hello"`))
 
 	buildImageSuccessfully(c, name, withBuildContext(c,
@@ -2082,11 +2084,11 @@ func (s *DockerSuite) TestBuildInheritance(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildinheritance"
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM scratch
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM scratch
 		EXPOSE 2375`))
 	ports1 := inspectField(c, name, "Config.ExposedPorts")
 
-	buildImageSuccessfully(c, name, withDockerfile(fmt.Sprintf(`FROM %s
+	buildImageSuccessfully(c, name, build.WithDockerfile(fmt.Sprintf(`FROM %s
 		ENTRYPOINT ["/bin/echo"]`, name)))
 
 	res := inspectField(c, name, "Config.Entrypoint")
@@ -2101,7 +2103,7 @@ func (s *DockerSuite) TestBuildInheritance(c *check.C) {
 
 func (s *DockerSuite) TestBuildFails(c *check.C) {
 	name := "testbuildfails"
-	buildImage(name, withDockerfile(`FROM busybox
+	buildImage(name, build.WithDockerfile(`FROM busybox
 		RUN sh -c "exit 23"`)).Assert(c, icmd.Expected{
 		ExitCode: 23,
 		Err:      "returned a non-zero code: 23",
@@ -2110,9 +2112,9 @@ func (s *DockerSuite) TestBuildFails(c *check.C) {
 
 func (s *DockerSuite) TestBuildOnBuild(c *check.C) {
 	name := "testbuildonbuild"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		ONBUILD RUN touch foobar`))
-	buildImageSuccessfully(c, name, withDockerfile(fmt.Sprintf(`FROM %s
+	buildImageSuccessfully(c, name, build.WithDockerfile(fmt.Sprintf(`FROM %s
 		RUN [ -f foobar ]`, name)))
 }
 
@@ -2138,7 +2140,7 @@ func (s *DockerSuite) TestBuildAddToSymlinkDest(c *check.C) {
 func (s *DockerSuite) TestBuildEscapeWhitespace(c *check.C) {
 	name := "testbuildescapewhitespace"
 
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
   # ESCAPE=\
   FROM busybox
   MAINTAINER "Docker \
@@ -2157,7 +2159,7 @@ func (s *DockerSuite) TestBuildVerifyIntString(c *check.C) {
 	// Verify that strings that look like ints are still passed as strings
 	name := "testbuildstringing"
 
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
 	FROM busybox
 	MAINTAINER 123`))
 
@@ -2290,12 +2292,12 @@ func (s *DockerSuite) TestBuildDockerignoringRenamedDockerfile(c *check.C) {
 		RUN ls /tmp/Dockerfile
 		RUN sh -c "! ls /tmp/MyDockerfile"
 		RUN ls /tmp/.dockerignore`
-	buildImageSuccessfully(c, name, withBuildFlags("-f", "MyDockerfile"), withBuildContext(c,
+	buildImageSuccessfully(c, name, cli.WithFlags("-f", "MyDockerfile"), withBuildContext(c,
 		withFile("Dockerfile", "Should not use me"),
 		withFile("MyDockerfile", dockerfile),
 		withFile(".dockerignore", "MyDockerfile\n"),
 	))
-	buildImageSuccessfully(c, name, withBuildFlags("-f", "MyDockerfile"), withBuildContext(c,
+	buildImageSuccessfully(c, name, cli.WithFlags("-f", "MyDockerfile"), withBuildContext(c,
 		withFile("Dockerfile", "Should not use me"),
 		withFile("MyDockerfile", dockerfile),
 		withFile(".dockerignore", "./MyDockerfile\n"),
@@ -2495,7 +2497,7 @@ dir1/dir3/**
 func (s *DockerSuite) TestBuildLineBreak(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildlinebreak"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM  busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM  busybox
 RUN    sh -c 'echo root:testpass \
 	> /tmp/passwd'
 RUN    mkdir -p /var/run/sshd
@@ -2506,7 +2508,7 @@ RUN    sh -c "[ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]"`))
 func (s *DockerSuite) TestBuildEOLInLine(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildeolinline"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM   busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM   busybox
 RUN    sh -c 'echo root:testpass > /tmp/passwd'
 RUN    echo "foo \n bar"; echo "baz"
 RUN    mkdir -p /var/run/sshd
@@ -2517,7 +2519,7 @@ RUN    sh -c "[ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]"`))
 func (s *DockerSuite) TestBuildCommentsShebangs(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildcomments"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 # This is an ordinary comment.
 RUN { echo '#!/bin/sh'; echo 'echo hello world'; } > /hello.sh
 RUN [ ! -x /hello.sh ]
@@ -2531,7 +2533,7 @@ RUN [ "$(/hello.sh)" = "hello world" ]`))
 func (s *DockerSuite) TestBuildUsersAndGroups(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildusers"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 
 # Make sure our defaults work
 RUN [ "$(id -u):$(id -g)/$(id -un):$(id -gn)" = '0:0/root:root' ]
@@ -2930,7 +2932,7 @@ func (s *DockerSuite) TestBuildFromGit(c *check.C) {
 	}, true)
 	defer git.Close()
 
-	buildImageSuccessfully(c, name, withBuildContextPath(git.RepoURL))
+	buildImageSuccessfully(c, name, build.WithContextPath(git.RepoURL))
 
 	res := inspectField(c, name, "Author")
 	if res != "docker" {
@@ -2949,7 +2951,7 @@ func (s *DockerSuite) TestBuildFromGitWithContext(c *check.C) {
 	}, true)
 	defer git.Close()
 
-	buildImageSuccessfully(c, name, withBuildContextPath(fmt.Sprintf("%s#master:docker", git.RepoURL)))
+	buildImageSuccessfully(c, name, build.WithContextPath(fmt.Sprintf("%s#master:docker", git.RepoURL)))
 
 	res := inspectField(c, name, "Author")
 	if res != "docker" {
@@ -2965,7 +2967,7 @@ func (s *DockerSuite) TestBuildFromGitwithF(c *check.C) {
 	}, true)
 	defer git.Close()
 
-	buildImage(name, withBuildFlags("-f", "myApp/myDockerfile"), withBuildContextPath(git.RepoURL)).Assert(c, icmd.Expected{
+	buildImage(name, cli.WithFlags("-f", "myApp/myDockerfile"), build.WithContextPath(git.RepoURL)).Assert(c, icmd.Expected{
 		Out: "hi from Dockerfile",
 	})
 }
@@ -2997,7 +2999,7 @@ func (s *DockerSuite) TestBuildFromRemoteTarball(c *check.C) {
 	})
 	defer server.Close()
 
-	buildImageSuccessfully(c, name, withBuildContextPath(server.URL()+"/testT.tar"))
+	buildImageSuccessfully(c, name, build.WithContextPath(server.URL()+"/testT.tar"))
 
 	res := inspectField(c, name, "Author")
 	if res != "docker" {
@@ -3008,10 +3010,10 @@ func (s *DockerSuite) TestBuildFromRemoteTarball(c *check.C) {
 func (s *DockerSuite) TestBuildCleanupCmdOnEntrypoint(c *check.C) {
 	name := "testbuildcmdcleanuponentrypoint"
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
 		CMD ["test"]
 		ENTRYPOINT ["echo"]`))
-	buildImageSuccessfully(c, name, withDockerfile(fmt.Sprintf(`FROM %s
+	buildImageSuccessfully(c, name, build.WithDockerfile(fmt.Sprintf(`FROM %s
 		ENTRYPOINT ["cat"]`, name)))
 
 	res := inspectField(c, name, "Config.Cmd")
@@ -3026,7 +3028,7 @@ func (s *DockerSuite) TestBuildCleanupCmdOnEntrypoint(c *check.C) {
 
 func (s *DockerSuite) TestBuildClearCmd(c *check.C) {
 	name := "testbuildclearcmd"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
    ENTRYPOINT ["/bin/bash"]
    CMD []`))
 
@@ -3041,7 +3043,7 @@ func (s *DockerSuite) TestBuildEmptyCmd(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 
 	name := "testbuildemptycmd"
-	buildImageSuccessfully(c, name, withDockerfile("FROM "+minimalBaseImage()+"\nMAINTAINER quux\n"))
+	buildImageSuccessfully(c, name, build.WithDockerfile("FROM "+minimalBaseImage()+"\nMAINTAINER quux\n"))
 
 	res := inspectFieldJSON(c, name, "Config.Cmd")
 	if res != "null" {
@@ -3051,9 +3053,9 @@ func (s *DockerSuite) TestBuildEmptyCmd(c *check.C) {
 
 func (s *DockerSuite) TestBuildOnBuildOutput(c *check.C) {
 	name := "testbuildonbuildparent"
-	buildImageSuccessfully(c, name, withDockerfile("FROM busybox\nONBUILD RUN echo foo\n"))
+	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nONBUILD RUN echo foo\n"))
 
-	buildImage(name, withDockerfile("FROM "+name+"\nMAINTAINER quux\n")).Assert(c, icmd.Expected{
+	buildImage(name, build.WithDockerfile("FROM "+name+"\nMAINTAINER quux\n")).Assert(c, icmd.Expected{
 		Out: "# Executing 1 build trigger",
 	})
 }
@@ -3061,7 +3063,7 @@ func (s *DockerSuite) TestBuildOnBuildOutput(c *check.C) {
 // FIXME(vdemeester) should be a unit test
 func (s *DockerSuite) TestBuildInvalidTag(c *check.C) {
 	name := "abcd:" + stringutils.GenerateRandomAlphaOnlyString(200)
-	buildImage(name, withDockerfile("FROM "+minimalBaseImage()+"\nMAINTAINER quux\n")).Assert(c, icmd.Expected{
+	buildImage(name, build.WithDockerfile("FROM "+minimalBaseImage()+"\nMAINTAINER quux\n")).Assert(c, icmd.Expected{
 		ExitCode: 125,
 		Err:      "invalid reference format",
 	})
@@ -3069,7 +3071,7 @@ func (s *DockerSuite) TestBuildInvalidTag(c *check.C) {
 
 func (s *DockerSuite) TestBuildCmdShDashC(c *check.C) {
 	name := "testbuildcmdshc"
-	buildImageSuccessfully(c, name, withDockerfile("FROM busybox\nCMD echo cmd\n"))
+	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nCMD echo cmd\n"))
 
 	res := inspectFieldJSON(c, name, "Config.Cmd")
 	expected := `["/bin/sh","-c","echo cmd"]`
@@ -3088,9 +3090,9 @@ func (s *DockerSuite) TestBuildCmdSpaces(c *check.C) {
 	// look the same
 	name := "testbuildcmdspaces"
 
-	buildImageSuccessfully(c, name, withDockerfile("FROM busybox\nCMD [\"echo hi\"]\n"))
+	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nCMD [\"echo hi\"]\n"))
 	id1 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, withDockerfile("FROM busybox\nCMD [\"echo\", \"hi\"]\n"))
+	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nCMD [\"echo\", \"hi\"]\n"))
 	id2 := getIDByName(c, name)
 
 	if id1 == id2 {
@@ -3098,9 +3100,9 @@ func (s *DockerSuite) TestBuildCmdSpaces(c *check.C) {
 	}
 
 	// Now do the same with ENTRYPOINT
-	buildImageSuccessfully(c, name, withDockerfile("FROM busybox\nENTRYPOINT [\"echo hi\"]\n"))
+	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nENTRYPOINT [\"echo hi\"]\n"))
 	id1 = getIDByName(c, name)
-	buildImageSuccessfully(c, name, withDockerfile("FROM busybox\nENTRYPOINT [\"echo\", \"hi\"]\n"))
+	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nENTRYPOINT [\"echo\", \"hi\"]\n"))
 	id2 = getIDByName(c, name)
 
 	if id1 == id2 {
@@ -3110,7 +3112,7 @@ func (s *DockerSuite) TestBuildCmdSpaces(c *check.C) {
 
 func (s *DockerSuite) TestBuildCmdJSONNoShDashC(c *check.C) {
 	name := "testbuildcmdjson"
-	buildImageSuccessfully(c, name, withDockerfile("FROM busybox\nCMD [\"echo\", \"cmd\"]"))
+	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nCMD [\"echo\", \"cmd\"]"))
 
 	res := inspectFieldJSON(c, name, "Config.Cmd")
 	expected := `["echo","cmd"]`
@@ -3120,7 +3122,7 @@ func (s *DockerSuite) TestBuildCmdJSONNoShDashC(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEntrypointCanBeOverridenByChild(c *check.C) {
-	buildImageSuccessfully(c, "parent", withDockerfile(`
+	buildImageSuccessfully(c, "parent", build.WithDockerfile(`
     FROM busybox
     ENTRYPOINT exit 130
     `))
@@ -3129,7 +3131,7 @@ func (s *DockerSuite) TestBuildEntrypointCanBeOverridenByChild(c *check.C) {
 		ExitCode: 130,
 	})
 
-	buildImageSuccessfully(c, "child", withDockerfile(`
+	buildImageSuccessfully(c, "child", build.WithDockerfile(`
     FROM parent
     ENTRYPOINT exit 5
     `))
@@ -3150,8 +3152,8 @@ func (s *DockerSuite) TestBuildEntrypointCanBeOverridenByChildInspect(c *check.C
 		expected = `["cmd","/S","/C","echo quux"]`
 	}
 
-	buildImageSuccessfully(c, name, withDockerfile("FROM busybox\nENTRYPOINT /foo/bar"))
-	buildImageSuccessfully(c, name2, withDockerfile(fmt.Sprintf("FROM %s\nENTRYPOINT echo quux", name)))
+	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nENTRYPOINT /foo/bar"))
+	buildImageSuccessfully(c, name2, build.WithDockerfile(fmt.Sprintf("FROM %s\nENTRYPOINT echo quux", name)))
 
 	res := inspectFieldJSON(c, name2, "Config.Entrypoint")
 	if res != expected {
@@ -3165,7 +3167,7 @@ func (s *DockerSuite) TestBuildEntrypointCanBeOverridenByChildInspect(c *check.C
 
 func (s *DockerSuite) TestBuildRunShEntrypoint(c *check.C) {
 	name := "testbuildentrypoint"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
                                 ENTRYPOINT echo`))
 	dockerCmd(c, "run", "--rm", name)
 }
@@ -3174,7 +3176,7 @@ func (s *DockerSuite) TestBuildExoticShellInterpolation(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildexoticshellinterpolation"
 
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
 		FROM busybox
 
 		ENV SOME_VAR a.b.c
@@ -3207,7 +3209,7 @@ func (s *DockerSuite) TestBuildVerifySingleQuoteFails(c *check.C) {
 		expectedExitCode = 127
 	}
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		CMD [ '/bin/sh', '-c', 'echo hi' ]`))
 
 	icmd.RunCommand(dockerBinary, "run", "--rm", name).Assert(c, icmd.Expected{
@@ -3223,7 +3225,7 @@ func (s *DockerSuite) TestBuildVerboseOut(c *check.C) {
 		expected = "\n123\r\n"
 	}
 
-	buildImage(name, withDockerfile(`FROM busybox
+	buildImage(name, build.WithDockerfile(`FROM busybox
 RUN echo 123`)).Assert(c, icmd.Expected{
 		Out: expected,
 	})
@@ -3231,7 +3233,7 @@ RUN echo 123`)).Assert(c, icmd.Expected{
 
 func (s *DockerSuite) TestBuildWithTabs(c *check.C) {
 	name := "testbuildwithtabs"
-	buildImageSuccessfully(c, name, withDockerfile("FROM busybox\nRUN echo\tone\t\ttwo"))
+	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nRUN echo\tone\t\ttwo"))
 	res := inspectFieldJSON(c, name, "ContainerConfig.Cmd")
 	expected1 := `["/bin/sh","-c","echo\tone\t\ttwo"]`
 	expected2 := `["/bin/sh","-c","echo\u0009one\u0009\u0009two"]` // syntactically equivalent, and what Go 1.3 generates
@@ -3247,7 +3249,7 @@ func (s *DockerSuite) TestBuildWithTabs(c *check.C) {
 func (s *DockerSuite) TestBuildLabels(c *check.C) {
 	name := "testbuildlabel"
 	expected := `{"License":"GPL","Vendor":"Acme"}`
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		LABEL Vendor=Acme
                 LABEL License GPL`))
 	res := inspectFieldJSON(c, name, "Config.Labels")
@@ -3259,24 +3261,24 @@ func (s *DockerSuite) TestBuildLabels(c *check.C) {
 func (s *DockerSuite) TestBuildLabelsCache(c *check.C) {
 	name := "testbuildlabelcache"
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		LABEL Vendor=Acme`))
 	id1 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		LABEL Vendor=Acme`))
 	id2 := getIDByName(c, name)
 	if id1 != id2 {
 		c.Fatalf("Build 2 should have worked & used cache(%s,%s)", id1, id2)
 	}
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		LABEL Vendor=Acme1`))
 	id2 = getIDByName(c, name)
 	if id1 == id2 {
 		c.Fatalf("Build 3 should have worked & NOT used cache(%s,%s)", id1, id2)
 	}
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		LABEL Vendor Acme`))
 	id2 = getIDByName(c, name)
 	if id1 != id2 {
@@ -3284,10 +3286,10 @@ func (s *DockerSuite) TestBuildLabelsCache(c *check.C) {
 	}
 
 	// Now make sure the cache isn't used by mistake
-	buildImageSuccessfully(c, name, withoutCache, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithoutCache, build.WithDockerfile(`FROM busybox
        LABEL f1=b1 f2=b2`))
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
        LABEL f1=b1 f2=b2`))
 	id2 = getIDByName(c, name)
 	if id1 == id2 {
@@ -3300,7 +3302,7 @@ func (s *DockerSuite) TestBuildNotVerboseSuccess(c *check.C) {
 	// This test makes sure that -q works correctly when build is successful:
 	// stdout has only the image ID (long image ID) and stderr is empty.
 	outRegexp := regexp.MustCompile("^(sha256:|)[a-z0-9]{64}\\n$")
-	buildFlags := withBuildFlags("-q")
+	buildFlags := cli.WithFlags("-q")
 
 	tt := []struct {
 		Name      string
@@ -3309,7 +3311,7 @@ func (s *DockerSuite) TestBuildNotVerboseSuccess(c *check.C) {
 		{
 			Name: "quiet_build_stdin_success",
 			BuildFunc: func(name string) *icmd.Result {
-				return buildImage(name, buildFlags, withDockerfile("FROM busybox"))
+				return buildImage(name, buildFlags, build.WithDockerfile("FROM busybox"))
 			},
 		},
 		{
@@ -3327,7 +3329,7 @@ func (s *DockerSuite) TestBuildNotVerboseSuccess(c *check.C) {
 				git := newFakeGit(c, "repo", map[string]string{
 					"Dockerfile": "FROM busybox",
 				}, true)
-				return buildImage(name, buildFlags, withBuildContextPath(git.RepoURL))
+				return buildImage(name, buildFlags, build.WithContextPath(git.RepoURL))
 			},
 		},
 	}
@@ -3353,11 +3355,11 @@ func (s *DockerSuite) TestBuildNotVerboseFailureWithNonExistImage(c *check.C) {
 	testRequires(c, Network)
 	testName := "quiet_build_not_exists_image"
 	dockerfile := "FROM busybox11"
-	quietResult := buildImage(testName, withBuildFlags("-q"), withDockerfile(dockerfile))
+	quietResult := buildImage(testName, cli.WithFlags("-q"), build.WithDockerfile(dockerfile))
 	quietResult.Assert(c, icmd.Expected{
 		ExitCode: 1,
 	})
-	result := buildImage(testName, withDockerfile(dockerfile))
+	result := buildImage(testName, build.WithDockerfile(dockerfile))
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
 	})
@@ -3379,11 +3381,11 @@ func (s *DockerSuite) TestBuildNotVerboseFailure(c *check.C) {
 	}
 
 	for _, tc := range testCases {
-		quietResult := buildImage(tc.testName, withBuildFlags("-q"), withDockerfile(tc.dockerfile))
+		quietResult := buildImage(tc.testName, cli.WithFlags("-q"), build.WithDockerfile(tc.dockerfile))
 		quietResult.Assert(c, icmd.Expected{
 			ExitCode: 1,
 		})
-		result := buildImage(tc.testName, withDockerfile(tc.dockerfile))
+		result := buildImage(tc.testName, build.WithDockerfile(tc.dockerfile))
 		result.Assert(c, icmd.Expected{
 			ExitCode: 1,
 		})
@@ -3399,11 +3401,11 @@ func (s *DockerSuite) TestBuildNotVerboseFailureRemote(c *check.C) {
 	// TODO(vdemeester) with cobra, stdout has a carriage return too much so this test should not check stdout
 	URL := "http://something.invalid"
 	name := "quiet_build_wrong_remote"
-	quietResult := buildImage(name, withBuildFlags("-q"), withBuildContextPath(URL))
+	quietResult := buildImage(name, cli.WithFlags("-q"), build.WithContextPath(URL))
 	quietResult.Assert(c, icmd.Expected{
 		ExitCode: 1,
 	})
-	result := buildImage(name, withBuildContextPath(URL))
+	result := buildImage(name, build.WithContextPath(URL))
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
 	})
@@ -3416,7 +3418,7 @@ func (s *DockerSuite) TestBuildStderr(c *check.C) {
 	// This test just makes sure that no non-error output goes
 	// to stderr
 	name := "testbuildstderr"
-	result := buildImage(name, withDockerfile("FROM busybox\nRUN echo one"))
+	result := buildImage(name, build.WithDockerfile("FROM busybox\nRUN echo one"))
 	result.Assert(c, icmd.Success)
 
 	// Windows to non-Windows should have a security warning
@@ -3494,7 +3496,7 @@ func (s *DockerSuite) TestBuildSymlinkBreakout(c *check.C) {
 	w.Close()
 	f.Close()
 
-	buildImageSuccessfully(c, name, withoutCache, withExternalBuildContext(fakeContextFromDir(ctx)))
+	buildImageSuccessfully(c, name, build.WithoutCache, withExternalBuildContext(fakeContextFromDir(ctx)))
 	if _, err := os.Lstat(filepath.Join(tmpdir, "inject")); err == nil {
 		c.Fatal("symlink breakout - inject")
 	} else if !os.IsNotExist(err) {
@@ -3515,9 +3517,7 @@ ADD xz /usr/local/sbin/
 RUN chmod 755 /usr/local/sbin/xz
 ADD test.xz /
 RUN [ ! -e /injected ]`),
-		withFile("test.xz", "\xfd\x37\x7a\x58\x5a\x00\x00\x04\xe6\xd6\xb4\x46\x02\x00"+
-			"\x21\x01\x16\x00\x00\x00\x74\x2f\xe5\xa3\x01\x00\x3f\xfd"+
-			"\x37\x7a\x58\x5a\x00\x00\x04\xe6\xd6\xb4\x46\x02\x00\x21"),
+		withFile("test.xz", "\xfd\x37\x7a\x58\x5a\x00\x00\x04\xe6\xd6\xb4\x46\x02\x00"+"\x21\x01\x16\x00\x00\x00\x74\x2f\xe5\xa3\x01\x00\x3f\xfd"+"\x37\x7a\x58\x5a\x00\x00\x04\xe6\xd6\xb4\x46\x02\x00\x21"),
 		withFile("xz", "#!/bin/sh\ntouch /injected"),
 	))
 }
@@ -3690,7 +3690,7 @@ RUN echo from Dockerfile`,
 
 	// Make sure that -f is ignored and that we don't use the Dockerfile
 	// that's in the current dir
-	result := buildImage("test1", withBuildFlags("-f", "baz", server.URL()+"/baz"), func(cmd *icmd.Cmd) func() {
+	result := buildImage("test1", cli.WithFlags("-f", "baz", server.URL()+"/baz"), func(cmd *icmd.Cmd) func() {
 		cmd.Dir = ctx.Dir
 		return nil
 	})
@@ -3713,7 +3713,7 @@ RUN echo "from Dockerfile"`,
 
 	// Make sure that -f is ignored and that we don't use the Dockerfile
 	// that's in the current dir
-	result := buildImage("test1", withBuildFlags("-f", "baz", "-"), func(cmd *icmd.Cmd) func() {
+	result := buildImage("test1", cli.WithFlags("-f", "baz", "-"), func(cmd *icmd.Cmd) func() {
 		cmd.Dir = ctx.Dir
 		cmd.Stdin = strings.NewReader(`FROM busybox
 RUN echo "from baz"
@@ -3743,7 +3743,7 @@ func (s *DockerSuite) TestBuildFromOfficialNames(c *check.C) {
 	}
 	for idx, fromName := range fromNames {
 		imgName := fmt.Sprintf("%s%d", name, idx)
-		buildImageSuccessfully(c, imgName, withDockerfile("FROM "+fromName))
+		buildImageSuccessfully(c, imgName, build.WithDockerfile("FROM "+fromName))
 		dockerCmd(c, "rmi", imgName)
 	}
 }
@@ -3839,7 +3839,7 @@ func (s *DockerSuite) TestBuildSpaces(c *check.C) {
 	}
 
 	ctx.Add("Dockerfile", "FROM busybox\n   COPY")
-	result2 = buildImage(name, withoutCache, withExternalBuildContext(ctx))
+	result2 = buildImage(name, build.WithoutCache, withExternalBuildContext(ctx))
 	result2.Assert(c, icmd.Expected{
 		ExitCode: 1,
 	})
@@ -3854,7 +3854,7 @@ func (s *DockerSuite) TestBuildSpaces(c *check.C) {
 	}
 
 	ctx.Add("Dockerfile", "FROM busybox\n   COPY    ")
-	result2 = buildImage(name, withoutCache, withExternalBuildContext(ctx))
+	result2 = buildImage(name, build.WithoutCache, withExternalBuildContext(ctx))
 	result2.Assert(c, icmd.Expected{
 		ExitCode: 1,
 	})
@@ -3884,7 +3884,7 @@ RUN echo "  \
 		expected = "\"    foo  \""
 	}
 
-	buildImage(name, withDockerfile(dockerfile)).Assert(c, icmd.Expected{
+	buildImage(name, build.WithDockerfile(dockerfile)).Assert(c, icmd.Expected{
 		Out: expected,
 	})
 }
@@ -3892,7 +3892,7 @@ RUN echo "  \
 // #4393
 func (s *DockerSuite) TestBuildVolumeFileExistsinContainer(c *check.C) {
 	testRequires(c, DaemonIsLinux) // TODO Windows: This should error out
-	buildImage("docker-test-errcreatevolumewithfile", withDockerfile(`
+	buildImage("docker-test-errcreatevolumewithfile", build.WithDockerfile(`
 	FROM busybox
 	RUN touch /foo
 	VOLUME /foo
@@ -3940,7 +3940,7 @@ func (s *DockerSuite) TestBuildMissingArgs(c *check.C) {
 			dockerfile = "FROM busybox\n" + cmd
 		}
 
-		buildImage("args", withDockerfile(dockerfile)).Assert(c, icmd.Expected{
+		buildImage("args", build.WithDockerfile(dockerfile)).Assert(c, icmd.Expected{
 			ExitCode: 1,
 			Err:      cmd + " requires",
 		})
@@ -3950,7 +3950,7 @@ func (s *DockerSuite) TestBuildMissingArgs(c *check.C) {
 
 func (s *DockerSuite) TestBuildEmptyScratch(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	buildImage("sc", withDockerfile("FROM scratch")).Assert(c, icmd.Expected{
+	buildImage("sc", build.WithDockerfile("FROM scratch")).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "No image was generated",
 	})
@@ -3967,7 +3967,7 @@ func (s *DockerSuite) TestBuildRUNoneJSON(c *check.C) {
 	testRequires(c, DaemonIsLinux) // No hello-world Windows image
 	name := "testbuildrunonejson"
 
-	buildImage(name, withDockerfile(`FROM hello-world:frozen
+	buildImage(name, build.WithDockerfile(`FROM hello-world:frozen
 RUN [ "/hello" ]`)).Assert(c, icmd.Expected{
 		Out: "Hello from Docker",
 	})
@@ -3976,7 +3976,7 @@ RUN [ "/hello" ]`)).Assert(c, icmd.Expected{
 func (s *DockerSuite) TestBuildEmptyStringVolume(c *check.C) {
 	name := "testbuildemptystringvolume"
 
-	buildImage(name, withDockerfile(`
+	buildImage(name, build.WithDockerfile(`
   FROM busybox
   ENV foo=""
   VOLUME $foo
@@ -3999,8 +3999,8 @@ func (s *DockerSuite) TestBuildContainerWithCgroupParent(c *check.C) {
 		c.Fatalf("unable to find self memory cgroup path. CgroupsPath: %v", selfCgroupPaths)
 	}
 	result := buildImage("buildcgroupparent",
-		withBuildFlags("--cgroup-parent", cgroupParent),
-		withDockerfile(`
+		cli.WithFlags("--cgroup-parent", cgroupParent),
+		build.WithDockerfile(`
 FROM busybox
 RUN cat /proc/self/cgroup
 `))
@@ -4018,7 +4018,7 @@ func (s *DockerSuite) TestBuildNoDupOutput(c *check.C) {
 	// property - there was a bug that caused it to be duplicated on the
 	// Step X  line
 	name := "testbuildnodupoutput"
-	result := buildImage(name, withDockerfile(`
+	result := buildImage(name, build.WithDockerfile(`
   FROM busybox
   RUN env`))
 	result.Assert(c, icmd.Success)
@@ -4033,7 +4033,7 @@ func (s *DockerSuite) TestBuildNoDupOutput(c *check.C) {
 func (s *DockerSuite) TestBuildStartsFromOne(c *check.C) {
 	// Explicit check to ensure that build starts from step 1 rather than 0
 	name := "testbuildstartsfromone"
-	result := buildImage(name, withDockerfile(`FROM busybox`))
+	result := buildImage(name, build.WithDockerfile(`FROM busybox`))
 	result.Assert(c, icmd.Success)
 	exp := "\nStep 1/1 : FROM busybox\n"
 	if !strings.Contains(result.Combined(), exp) {
@@ -4054,7 +4054,7 @@ func (s *DockerSuite) TestBuildRUNErrMsg(c *check.C) {
 	}
 	exp := fmt.Sprintf(`The command '%s badEXE a1 \& a2	a3' returned a non-zero code: %d`, shell, exitCode)
 
-	buildImage(name, withDockerfile(`
+	buildImage(name, build.WithDockerfile(`
   FROM busybox
   RUN badEXE a1 \& a2	a3`)).Assert(c, icmd.Expected{
 		ExitCode: exitCode,
@@ -4071,7 +4071,7 @@ func (s *DockerTrustSuite) TestTrustedBuild(c *check.C) {
 
 	name := "testtrustedbuild"
 
-	buildImage(name, trustedBuild, withDockerfile(dockerFile)).Assert(c, icmd.Expected{
+	buildImage(name, trustedBuild, build.WithDockerfile(dockerFile)).Assert(c, icmd.Expected{
 		Out: fmt.Sprintf("FROM %s@sha", repoName[:len(repoName)-7]),
 	})
 
@@ -4091,7 +4091,7 @@ func (s *DockerTrustSuite) TestTrustedBuildUntrustedTag(c *check.C) {
 
 	name := "testtrustedbuilduntrustedtag"
 
-	buildImage(name, trustedBuild, withDockerfile(dockerFile)).Assert(c, icmd.Expected{
+	buildImage(name, trustedBuild, build.WithDockerfile(dockerFile)).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "does not have trust data for",
 	})
@@ -4159,7 +4159,7 @@ func (s *DockerTrustSuite) TestTrustedBuildTagFromReleasesRole(c *check.C) {
   RUN []
     `, otherTag)
 	name := "testtrustedbuildreleasesrole"
-	buildImage(name, trustedBuild, withDockerfile(dockerFile)).Assert(c, icmd.Expected{
+	buildImage(name, trustedBuild, build.WithDockerfile(dockerFile)).Assert(c, icmd.Expected{
 		Out: fmt.Sprintf("FROM %s@sha", repoName),
 	})
 }
@@ -4192,7 +4192,7 @@ func (s *DockerTrustSuite) TestTrustedBuildTagIgnoresOtherDelegationRoles(c *che
     `, otherTag)
 
 	name := "testtrustedbuildotherrole"
-	buildImage(name, trustedBuild, withDockerfile(dockerFile)).Assert(c, icmd.Expected{
+	buildImage(name, trustedBuild, build.WithDockerfile(dockerFile)).Assert(c, icmd.Expected{
 		ExitCode: 1,
 	})
 }
@@ -4221,7 +4221,7 @@ func (s *DockerSuite) TestBuildNullStringInAddCopyVolume(c *check.C) {
 func (s *DockerSuite) TestBuildStopSignal(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Windows does not support STOPSIGNAL yet
 	imgName := "test_build_stop_signal"
-	buildImageSuccessfully(c, imgName, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, imgName, build.WithDockerfile(`FROM busybox
 		 STOPSIGNAL SIGKILL`))
 	res := inspectFieldJSON(c, imgName, "Config.StopSignal")
 	if res != `"SIGKILL"` {
@@ -4255,8 +4255,8 @@ func (s *DockerSuite) TestBuildBuildTimeArg(c *check.C) {
 
 	}
 	buildImage(imgName,
-		withBuildFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
-		withDockerfile(dockerfile),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
+		build.WithDockerfile(dockerfile),
 	).Assert(c, icmd.Expected{
 		Out: envVal,
 	})
@@ -4277,8 +4277,8 @@ func (s *DockerSuite) TestBuildBuildTimeArgHistory(c *check.C) {
 	dockerfile := fmt.Sprintf(`FROM busybox
 		ARG %s=%s`, envKey, envDef)
 	buildImage(imgName,
-		withBuildFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
-		withDockerfile(dockerfile),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
+		build.WithDockerfile(dockerfile),
 	).Assert(c, icmd.Expected{
 		Out: envVal,
 	})
@@ -4302,10 +4302,10 @@ func (s *DockerSuite) TestBuildTimeArgHistoryExclusions(c *check.C) {
 		ARG %s
 		RUN echo "Testing Build Args!"`, envKey, explicitProxyKey)
 	buildImage(imgName,
-		withBuildFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal),
 			"--build-arg", fmt.Sprintf("%s=%s", explicitProxyKey, explicitProxyVal),
 			"--build-arg", proxy),
-		withDockerfile(dockerfile),
+		build.WithDockerfile(dockerfile),
 	).Assert(c, icmd.Success)
 
 	out, _ := dockerCmd(c, "history", "--no-trunc", imgName)
@@ -4328,15 +4328,15 @@ func (s *DockerSuite) TestBuildBuildTimeArgCacheHit(c *check.C) {
 		ARG %s
 		RUN echo $%s`, envKey, envKey)
 	buildImageSuccessfully(c, imgName,
-		withBuildFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
-		withDockerfile(dockerfile),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
+		build.WithDockerfile(dockerfile),
 	)
 	origImgID := getIDByName(c, imgName)
 
 	imgNameCache := "bldargtestcachehit"
 	buildImageSuccessfully(c, imgNameCache,
-		withBuildFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
-		withDockerfile(dockerfile),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
+		build.WithDockerfile(dockerfile),
 	)
 	newImgID := getIDByName(c, imgName)
 	if newImgID != origImgID {
@@ -4355,18 +4355,18 @@ func (s *DockerSuite) TestBuildBuildTimeArgCacheMissExtraArg(c *check.C) {
 		ARG %s
 		RUN echo $%s`, envKey, extraEnvKey, envKey)
 	buildImageSuccessfully(c, imgName,
-		withBuildFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
-		withDockerfile(dockerfile),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
+		build.WithDockerfile(dockerfile),
 	)
 	origImgID := getIDByName(c, imgName)
 
 	imgNameCache := "bldargtestcachemiss"
 	buildImageSuccessfully(c, imgNameCache,
-		withBuildFlags(
+		cli.WithFlags(
 			"--build-arg", fmt.Sprintf("%s=%s", envKey, envVal),
 			"--build-arg", fmt.Sprintf("%s=%s", extraEnvKey, extraEnvVal),
 		),
-		withDockerfile(dockerfile),
+		build.WithDockerfile(dockerfile),
 	)
 	newImgID := getIDByName(c, imgNameCache)
 
@@ -4384,15 +4384,15 @@ func (s *DockerSuite) TestBuildBuildTimeArgCacheMissSameArgDiffVal(c *check.C) {
 		ARG %s
 		RUN echo $%s`, envKey, envKey)
 	buildImageSuccessfully(c, imgName,
-		withBuildFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
-		withDockerfile(dockerfile),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
+		build.WithDockerfile(dockerfile),
 	)
 	origImgID := getIDByName(c, imgName)
 
 	imgNameCache := "bldargtestcachemiss"
 	buildImageSuccessfully(c, imgNameCache,
-		withBuildFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, newEnvVal)),
-		withDockerfile(dockerfile),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, newEnvVal)),
+		build.WithDockerfile(dockerfile),
 	)
 	newImgID := getIDByName(c, imgNameCache)
 	if newImgID == origImgID {
@@ -4414,8 +4414,8 @@ func (s *DockerSuite) TestBuildBuildTimeArgOverrideArgDefinedBeforeEnv(c *check.
         `, envKey, envKey, envValOveride, envKey, envKey)
 
 	result := buildImage(imgName,
-		withBuildFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
-		withDockerfile(dockerfile),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
+		build.WithDockerfile(dockerfile),
 	)
 	result.Assert(c, icmd.Success)
 	if strings.Count(result.Combined(), envValOveride) != 2 {
@@ -4442,8 +4442,8 @@ func (s *DockerSuite) TestBuildBuildTimeArgOverrideEnvDefinedBeforeArg(c *check.
 		CMD echo $%s
         `, envKey, envValOveride, envKey, envKey, envKey)
 	result := buildImage(imgName,
-		withBuildFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
-		withDockerfile(dockerfile),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
+		build.WithDockerfile(dockerfile),
 	)
 	result.Assert(c, icmd.Success)
 	if strings.Count(result.Combined(), envValOveride) != 2 {
@@ -4476,7 +4476,7 @@ func (s *DockerSuite) TestBuildBuildTimeArgExpansion(c *check.C) {
 	volVal := "/testVol/"
 
 	buildImageSuccessfully(c, imgName,
-		withBuildFlags(
+		cli.WithFlags(
 			"--build-arg", fmt.Sprintf("%s=%s", wdVar, wdVal),
 			"--build-arg", fmt.Sprintf("%s=%s", addVar, addVal),
 			"--build-arg", fmt.Sprintf("%s=%s", copyVar, copyVal),
@@ -4559,8 +4559,8 @@ func (s *DockerSuite) TestBuildBuildTimeArgExpansionOverride(c *check.C) {
 		RUN echo $%s
 		CMD echo $%s`, envKey, envKey, envValOveride, envKey1, envKey, envKey1, envKey1)
 	result := buildImage(imgName,
-		withBuildFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
-		withDockerfile(dockerfile),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
+		build.WithDockerfile(dockerfile),
 	)
 	result.Assert(c, icmd.Success)
 	if strings.Count(result.Combined(), envValOveride) != 2 {
@@ -4583,8 +4583,8 @@ func (s *DockerSuite) TestBuildBuildTimeArgUntrustedDefinedAfterUse(c *check.C) 
 		ARG %s
 		CMD echo $%s`, envKey, envKey, envKey)
 	result := buildImage(imgName,
-		withBuildFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
-		withDockerfile(dockerfile),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
+		build.WithDockerfile(dockerfile),
 	)
 	result.Assert(c, icmd.Success)
 	if strings.Contains(result.Combined(), envVal) {
@@ -4607,8 +4607,8 @@ func (s *DockerSuite) TestBuildBuildTimeArgBuiltinArg(c *check.C) {
 		CMD echo $%s`, envKey, envKey)
 
 	result := buildImage(imgName,
-		withBuildFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
-		withDockerfile(dockerfile),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
+		build.WithDockerfile(dockerfile),
 	)
 	result.Assert(c, icmd.Success)
 	if !strings.Contains(result.Combined(), envVal) {
@@ -4632,8 +4632,8 @@ func (s *DockerSuite) TestBuildBuildTimeArgDefaultOverride(c *check.C) {
 		RUN echo $%s
 		CMD echo $%s`, envKey, envVal, envKey, envKey, envKey, envKey)
 	result := buildImage(imgName,
-		withBuildFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envValOveride)),
-		withDockerfile(dockerfile),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envValOveride)),
+		build.WithDockerfile(dockerfile),
 	)
 	result.Assert(c, icmd.Success)
 	if strings.Count(result.Combined(), envValOveride) != 1 {
@@ -4655,8 +4655,8 @@ func (s *DockerSuite) TestBuildBuildTimeArgUnconsumedArg(c *check.C) {
 		CMD echo $%s`, envKey, envKey)
 	warnStr := "[Warning] One or more build-args"
 	buildImage(imgName,
-		withBuildFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
-		withDockerfile(dockerfile),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
+		build.WithDockerfile(dockerfile),
 	).Assert(c, icmd.Expected{
 		Out: warnStr,
 	})
@@ -4686,7 +4686,7 @@ func (s *DockerSuite) TestBuildBuildTimeArgEnv(c *check.C) {
 		RUN [ "$FO10" == "" ]
 	    `
 	result := buildImage("testbuildtimeargenv",
-		withBuildFlags(
+		cli.WithFlags(
 			"--build-arg", fmt.Sprintf("FOO1=fromcmd"),
 			"--build-arg", fmt.Sprintf("FOO2="),
 			"--build-arg", fmt.Sprintf("FOO3"), // set in env
@@ -4698,7 +4698,7 @@ func (s *DockerSuite) TestBuildBuildTimeArgEnv(c *check.C) {
 			"--build-arg", fmt.Sprintf("FOO9"), // should produce a warning
 			"--build-arg", fmt.Sprintf("FO10"), // not set in env, empty value
 		),
-		withEnvironmentVariales(append(os.Environ(),
+		cli.WithEnvironmentVariables(append(os.Environ(),
 			"FOO1=fromenv",
 			"FOO2=fromenv",
 			"FOO3=fromenv")...),
@@ -4740,7 +4740,7 @@ func (s *DockerSuite) TestBuildBuildTimeArgQuotedValVariants(c *check.C) {
 		RUN [ "$%s" != "$%s" ]`, envKey, envKey1, envKey2, envKey3,
 		envKey, envKey2, envKey, envKey3, envKey1, envKey2, envKey1, envKey3,
 		envKey2, envKey3)
-	buildImageSuccessfully(c, imgName, withDockerfile(dockerfile))
+	buildImageSuccessfully(c, imgName, build.WithDockerfile(dockerfile))
 }
 
 func (s *DockerSuite) TestBuildBuildTimeArgEmptyValVariants(c *check.C) {
@@ -4756,7 +4756,7 @@ func (s *DockerSuite) TestBuildBuildTimeArgEmptyValVariants(c *check.C) {
 		RUN [ "$%s" == "$%s" ]
 		RUN [ "$%s" == "$%s" ]
 		RUN [ "$%s" == "$%s" ]`, envKey, envKey1, envKey2, envKey, envKey1, envKey1, envKey2, envKey, envKey2)
-	buildImageSuccessfully(c, imgName, withDockerfile(dockerfile))
+	buildImageSuccessfully(c, imgName, build.WithDockerfile(dockerfile))
 }
 
 func (s *DockerSuite) TestBuildBuildTimeArgDefintionWithNoEnvInjection(c *check.C) {
@@ -4766,7 +4766,7 @@ func (s *DockerSuite) TestBuildBuildTimeArgDefintionWithNoEnvInjection(c *check.
 		ARG %s
 		RUN env`, envKey)
 
-	result := buildImage(imgName, withDockerfile(dockerfile))
+	result := buildImage(imgName, build.WithDockerfile(dockerfile))
 	result.Assert(c, icmd.Success)
 	if strings.Count(result.Combined(), envKey) != 1 {
 		c.Fatalf("unexpected number of occurrences of the arg in output: %q expected: 1", result.Combined())
@@ -4785,7 +4785,7 @@ func (s *DockerSuite) TestBuildNoNamedVolume(c *check.C) {
 	VOLUME ` + volName + `
 	RUN ls /foo/oops
 	`
-	buildImage("test", withDockerfile(dockerFile)).Assert(c, icmd.Expected{
+	buildImage("test", build.WithDockerfile(dockerFile)).Assert(c, icmd.Expected{
 		ExitCode: 1,
 	})
 }
@@ -4796,7 +4796,7 @@ func (s *DockerSuite) TestBuildTagEvent(c *check.C) {
 	dockerFile := `FROM busybox
 	RUN echo events
 	`
-	buildImageSuccessfully(c, "test", withDockerfile(dockerFile))
+	buildImageSuccessfully(c, "test", build.WithDockerfile(dockerFile))
 
 	until := daemonUnixTime(c)
 	out, _ := dockerCmd(c, "events", "--since", since, "--until", until, "--filter", "type=image")
@@ -4819,7 +4819,7 @@ func (s *DockerSuite) TestBuildMultipleTags(c *check.C) {
 	FROM busybox
 	MAINTAINER test-15780
 	`
-	buildImageSuccessfully(c, "tag1", withBuildFlags("-t", "tag2:v2", "-t", "tag1:latest", "-t", "tag1"), withDockerfile(dockerfile))
+	buildImageSuccessfully(c, "tag1", cli.WithFlags("-t", "tag2:v2", "-t", "tag1:latest", "-t", "tag1"), build.WithDockerfile(dockerfile))
 
 	id1 := getIDByName(c, "tag1")
 	id2 := getIDByName(c, "tag2:v2")
@@ -4963,14 +4963,14 @@ func (s *DockerSuite) TestBuildCacheRootSource(c *check.C) {
 
 // #19375
 func (s *DockerSuite) TestBuildFailsGitNotCallable(c *check.C) {
-	buildImage("gitnotcallable", withEnvironmentVariales("PATH="),
-		withBuildContextPath("github.com/docker/v1.10-migrator.git")).Assert(c, icmd.Expected{
+	buildImage("gitnotcallable", cli.WithEnvironmentVariables("PATH="),
+		build.WithContextPath("github.com/docker/v1.10-migrator.git")).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "unable to prepare context: unable to find 'git': ",
 	})
 
-	buildImage("gitnotcallable", withEnvironmentVariales("PATH="),
-		withBuildContextPath("https://github.com/docker/v1.10-migrator.git")).Assert(c, icmd.Expected{
+	buildImage("gitnotcallable", cli.WithEnvironmentVariables("PATH="),
+		build.WithContextPath("https://github.com/docker/v1.10-migrator.git")).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "unable to prepare context: unable to find 'git': ",
 	})
@@ -4980,7 +4980,7 @@ func (s *DockerSuite) TestBuildFailsGitNotCallable(c *check.C) {
 func (s *DockerSuite) TestBuildWorkdirWindowsPath(c *check.C) {
 	testRequires(c, DaemonIsWindows)
 	name := "testbuildworkdirwindowspath"
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
 	FROM `+testEnv.MinimalBaseImage()+`
 	RUN mkdir C:\\work
 	WORKDIR C:\\work
@@ -4992,8 +4992,8 @@ func (s *DockerSuite) TestBuildLabel(c *check.C) {
 	name := "testbuildlabel"
 	testLabel := "foo"
 
-	buildImageSuccessfully(c, name, withBuildFlags("--label", testLabel),
-		withDockerfile(`
+	buildImageSuccessfully(c, name, cli.WithFlags("--label", testLabel),
+		build.WithDockerfile(`
   FROM `+minimalBaseImage()+`
   LABEL default foo
 `))
@@ -5007,8 +5007,8 @@ func (s *DockerSuite) TestBuildLabel(c *check.C) {
 
 func (s *DockerSuite) TestBuildLabelOneNode(c *check.C) {
 	name := "testbuildlabel"
-	buildImageSuccessfully(c, name, withBuildFlags("--label", "foo=bar"),
-		withDockerfile("FROM busybox"))
+	buildImageSuccessfully(c, name, cli.WithFlags("--label", "foo=bar"),
+		build.WithDockerfile("FROM busybox"))
 
 	var labels map[string]string
 	inspectFieldAndUnmarshall(c, name, "Config.Labels", &labels)
@@ -5023,12 +5023,12 @@ func (s *DockerSuite) TestBuildLabelCacheCommit(c *check.C) {
 	name := "testbuildlabelcachecommit"
 	testLabel := "foo"
 
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
   FROM `+minimalBaseImage()+`
   LABEL default foo
   `))
-	buildImageSuccessfully(c, name, withBuildFlags("--label", testLabel),
-		withDockerfile(`
+	buildImageSuccessfully(c, name, cli.WithFlags("--label", testLabel),
+		build.WithDockerfile(`
   FROM `+minimalBaseImage()+`
   LABEL default foo
   `))
@@ -5051,8 +5051,8 @@ func (s *DockerSuite) TestBuildLabelMultiple(c *check.C) {
 		labelArgs = append(labelArgs, "--label", k+"="+v)
 	}
 
-	buildImageSuccessfully(c, name, withBuildFlags(labelArgs...),
-		withDockerfile(`
+	buildImageSuccessfully(c, name, cli.WithFlags(labelArgs...),
+		build.WithDockerfile(`
   FROM `+minimalBaseImage()+`
   LABEL default foo
 `))
@@ -5070,7 +5070,7 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestBuildFromAuthenticatedRegistry(c *
 	dockerCmd(c, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), privateRegistryURL)
 	baseImage := privateRegistryURL + "/baseimage"
 
-	buildImageSuccessfully(c, baseImage, withDockerfile(`
+	buildImageSuccessfully(c, baseImage, build.WithDockerfile(`
 	FROM busybox
 	ENV env1 val1
 	`))
@@ -5078,7 +5078,7 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestBuildFromAuthenticatedRegistry(c *
 	dockerCmd(c, "push", baseImage)
 	dockerCmd(c, "rmi", baseImage)
 
-	buildImageSuccessfully(c, baseImage, withDockerfile(fmt.Sprintf(`
+	buildImageSuccessfully(c, baseImage, build.WithDockerfile(fmt.Sprintf(`
 	FROM %s
 	ENV env2 val2
 	`, baseImage)))
@@ -5130,8 +5130,8 @@ func (s *DockerSuite) TestBuildLabelsOverride(c *check.C) {
 	// Command line option labels will always override
 	name := "scratchy"
 	expected := `{"bar":"from-flag","foo":"from-flag"}`
-	buildImageSuccessfully(c, name, withBuildFlags("--label", "foo=from-flag", "--label", "bar=from-flag"),
-		withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImageSuccessfully(c, name, cli.WithFlags("--label", "foo=from-flag", "--label", "bar=from-flag"),
+		build.WithDockerfile(`FROM `+minimalBaseImage()+`
                 LABEL foo=from-dockerfile`))
 	res := inspectFieldJSON(c, name, "Config.Labels")
 	if res != expected {
@@ -5140,7 +5140,7 @@ func (s *DockerSuite) TestBuildLabelsOverride(c *check.C) {
 
 	name = "from"
 	expected = `{"foo":"from-dockerfile"}`
-	buildImageSuccessfully(c, name, withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
                 LABEL foo from-dockerfile`))
 	res = inspectFieldJSON(c, name, "Config.Labels")
 	if res != expected {
@@ -5150,8 +5150,8 @@ func (s *DockerSuite) TestBuildLabelsOverride(c *check.C) {
 	// Command line option label will override even via `FROM`
 	name = "new"
 	expected = `{"bar":"from-dockerfile2","foo":"new"}`
-	buildImageSuccessfully(c, name, withBuildFlags("--label", "foo=new"),
-		withDockerfile(`FROM from
+	buildImageSuccessfully(c, name, cli.WithFlags("--label", "foo=new"),
+		build.WithDockerfile(`FROM from
                 LABEL bar from-dockerfile2`))
 	res = inspectFieldJSON(c, name, "Config.Labels")
 	if res != expected {
@@ -5162,8 +5162,8 @@ func (s *DockerSuite) TestBuildLabelsOverride(c *check.C) {
 	// will be treated as --label foo="", --label bar=""
 	name = "scratchy2"
 	expected = `{"bar":"","foo":""}`
-	buildImageSuccessfully(c, name, withBuildFlags("--label", "foo", "--label", "bar="),
-		withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImageSuccessfully(c, name, cli.WithFlags("--label", "foo", "--label", "bar="),
+		build.WithDockerfile(`FROM `+minimalBaseImage()+`
                 LABEL foo=from-dockerfile`))
 	res = inspectFieldJSON(c, name, "Config.Labels")
 	if res != expected {
@@ -5175,8 +5175,8 @@ func (s *DockerSuite) TestBuildLabelsOverride(c *check.C) {
 	// This time is for inherited images
 	name = "new2"
 	expected = `{"bar":"","foo":""}`
-	buildImageSuccessfully(c, name, withBuildFlags("--label", "foo=", "--label", "bar"),
-		withDockerfile(`FROM from
+	buildImageSuccessfully(c, name, cli.WithFlags("--label", "foo=", "--label", "bar"),
+		build.WithDockerfile(`FROM from
                 LABEL bar from-dockerfile2`))
 	res = inspectFieldJSON(c, name, "Config.Labels")
 	if res != expected {
@@ -5186,8 +5186,8 @@ func (s *DockerSuite) TestBuildLabelsOverride(c *check.C) {
 	// Command line option labels with only `FROM`
 	name = "scratchy"
 	expected = `{"bar":"from-flag","foo":"from-flag"}`
-	buildImageSuccessfully(c, name, withBuildFlags("--label", "foo=from-flag", "--label", "bar=from-flag"),
-		withDockerfile(`FROM `+minimalBaseImage()))
+	buildImageSuccessfully(c, name, cli.WithFlags("--label", "foo=from-flag", "--label", "bar=from-flag"),
+		build.WithDockerfile(`FROM `+minimalBaseImage()))
 	res = inspectFieldJSON(c, name, "Config.Labels")
 	if res != expected {
 		c.Fatalf("Labels %s, expected %s", res, expected)
@@ -5196,8 +5196,8 @@ func (s *DockerSuite) TestBuildLabelsOverride(c *check.C) {
 	// Command line option labels with env var
 	name = "scratchz"
 	expected = `{"bar":"$PATH"}`
-	buildImageSuccessfully(c, name, withBuildFlags("--label", "bar=$PATH"),
-		withDockerfile(`FROM `+minimalBaseImage()))
+	buildImageSuccessfully(c, name, cli.WithFlags("--label", "bar=$PATH"),
+		build.WithDockerfile(`FROM `+minimalBaseImage()))
 	res = inspectFieldJSON(c, name, "Config.Labels")
 	if res != expected {
 		c.Fatalf("Labels %s, expected %s", res, expected)
@@ -5207,7 +5207,7 @@ func (s *DockerSuite) TestBuildLabelsOverride(c *check.C) {
 // Test case for #22855
 func (s *DockerSuite) TestBuildDeleteCommittedFile(c *check.C) {
 	name := "test-delete-committed-file"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		RUN echo test > file
 		RUN test -e file
 		RUN rm file
@@ -5279,7 +5279,7 @@ func (s *DockerSuite) TestBuildWithUTF8BOMDockerignore(c *check.C) {
 func (s *DockerSuite) TestBuildShellUpdatesConfig(c *check.C) {
 	name := "testbuildshellupdatesconfig"
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         SHELL ["foo", "-bar"]`))
 	expected := `["foo","-bar","#(nop) ","SHELL [foo -bar]"]`
 	res := inspectFieldJSON(c, name, "ContainerConfig.Cmd")
@@ -5296,7 +5296,7 @@ func (s *DockerSuite) TestBuildShellUpdatesConfig(c *check.C) {
 func (s *DockerSuite) TestBuildShellMultiple(c *check.C) {
 	name := "testbuildshellmultiple"
 
-	result := buildImage(name, withDockerfile(`FROM busybox
+	result := buildImage(name, build.WithDockerfile(`FROM busybox
 		RUN echo defaultshell
 		SHELL ["echo"]
 		RUN echoshell
@@ -5332,7 +5332,7 @@ func (s *DockerSuite) TestBuildShellMultiple(c *check.C) {
 func (s *DockerSuite) TestBuildShellEntrypoint(c *check.C) {
 	name := "testbuildshellentrypoint"
 
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		SHELL ["ls"]
 		ENTRYPOINT -l`))
 	// A container started from the image uses the shell-form ENTRYPOINT.
@@ -5346,10 +5346,10 @@ func (s *DockerSuite) TestBuildShellEntrypoint(c *check.C) {
 // #22489 Shell test to confirm shell is inherited in a subsequent build
 func (s *DockerSuite) TestBuildShellInherited(c *check.C) {
 	name1 := "testbuildshellinherited1"
-	buildImageSuccessfully(c, name1, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name1, build.WithDockerfile(`FROM busybox
         SHELL ["ls"]`))
 	name2 := "testbuildshellinherited2"
-	buildImage(name2, withDockerfile(`FROM `+name1+`
+	buildImage(name2, build.WithDockerfile(`FROM `+name1+`
         RUN -l`)).Assert(c, icmd.Expected{
 		// ls -l has "total " followed by some number in it, ls without -l does not.
 		Out: "total ",
@@ -5360,7 +5360,7 @@ func (s *DockerSuite) TestBuildShellInherited(c *check.C) {
 func (s *DockerSuite) TestBuildShellNotJSON(c *check.C) {
 	name := "testbuildshellnotjson"
 
-	buildImage(name, withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImage(name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         sHeLl exec -form`, // Casing explicit to ensure error is upper-cased.
 	)).Assert(c, icmd.Expected{
 		ExitCode: 1,
@@ -5373,7 +5373,7 @@ func (s *DockerSuite) TestBuildShellNotJSON(c *check.C) {
 func (s *DockerSuite) TestBuildShellWindowsPowershell(c *check.C) {
 	testRequires(c, DaemonIsWindows)
 	name := "testbuildshellpowershell"
-	buildImage(name, withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImage(name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         SHELL ["powershell", "-command"]
 		RUN Write-Host John`)).Assert(c, icmd.Expected{
 		Out: "\nJohn\n",
@@ -5385,7 +5385,7 @@ func (s *DockerSuite) TestBuildShellWindowsPowershell(c *check.C) {
 func (s *DockerSuite) TestBuildEscapeNotBackslashWordTest(c *check.C) {
 	testRequires(c, DaemonIsWindows)
 	name := "testbuildescapenotbackslashwordtesta"
-	buildImage(name, withDockerfile(`# escape= `+"`"+`
+	buildImage(name, build.WithDockerfile(`# escape= `+"`"+`
 		FROM `+minimalBaseImage()+`
         WORKDIR c:\windows
 		RUN dir /w`)).Assert(c, icmd.Expected{
@@ -5393,7 +5393,7 @@ func (s *DockerSuite) TestBuildEscapeNotBackslashWordTest(c *check.C) {
 	})
 
 	name = "testbuildescapenotbackslashwordtestb"
-	buildImage(name, withDockerfile(`# escape= `+"`"+`
+	buildImage(name, build.WithDockerfile(`# escape= `+"`"+`
 		FROM `+minimalBaseImage()+`
 		SHELL ["powershell.exe"]
         WORKDIR c:\foo
@@ -5407,7 +5407,7 @@ func (s *DockerSuite) TestBuildEscapeNotBackslashWordTest(c *check.C) {
 func (s *DockerSuite) TestBuildCmdShellArgsEscaped(c *check.C) {
 	testRequires(c, DaemonIsWindows)
 	name := "testbuildcmdshellescaped"
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
   FROM `+minimalBaseImage()+`
   CMD "ipconfig"
   `))
@@ -5428,7 +5428,7 @@ func (s *DockerSuite) TestBuildCmdShellArgsEscaped(c *check.C) {
 func (s *DockerSuite) TestBuildStepsWithProgress(c *check.C) {
 	name := "testbuildstepswithprogress"
 	totalRun := 5
-	result := buildImage(name, withDockerfile("FROM busybox\n"+strings.Repeat("RUN echo foo\n", totalRun)))
+	result := buildImage(name, build.WithDockerfile("FROM busybox\n"+strings.Repeat("RUN echo foo\n", totalRun)))
 	result.Assert(c, icmd.Success)
 	c.Assert(result.Combined(), checker.Contains, fmt.Sprintf("Step 1/%d : FROM busybox", 1+totalRun))
 	for i := 2; i <= 1+totalRun; i++ {
@@ -5441,14 +5441,14 @@ func (s *DockerSuite) TestBuildWithFailure(c *check.C) {
 
 	// First test case can only detect `nobody` in runtime so all steps will show up
 	dockerfile := "FROM busybox\nRUN nobody"
-	result := buildImage(name, withDockerfile(dockerfile))
+	result := buildImage(name, build.WithDockerfile(dockerfile))
 	c.Assert(result.Error, checker.NotNil)
 	c.Assert(result.Stdout(), checker.Contains, "Step 1/2 : FROM busybox")
 	c.Assert(result.Stdout(), checker.Contains, "Step 2/2 : RUN nobody")
 
 	// Second test case `FFOM` should have been detected before build runs so no steps
 	dockerfile = "FFOM nobody\nRUN nobody"
-	result = buildImage(name, withDockerfile(dockerfile))
+	result = buildImage(name, build.WithDockerfile(dockerfile))
 	c.Assert(result.Error, checker.NotNil)
 	c.Assert(result.Stdout(), checker.Not(checker.Contains), "Step 1/2 : FROM busybox")
 	c.Assert(result.Stdout(), checker.Not(checker.Contains), "Step 2/2 : RUN nobody")
@@ -5468,7 +5468,7 @@ func (s *DockerSuite) TestBuildCacheFromEqualDiffIDsLength(c *check.C) {
 	id1 := getIDByName(c, "build1")
 
 	// rebuild with cache-from
-	result := buildImage("build2", withBuildFlags("--cache-from=build1"), withExternalBuildContext(ctx))
+	result := buildImage("build2", cli.WithFlags("--cache-from=build1"), withExternalBuildContext(ctx))
 	result.Assert(c, icmd.Success)
 	id2 := getIDByName(c, "build2")
 	c.Assert(id1, checker.Equals, id2)
@@ -5492,7 +5492,7 @@ func (s *DockerSuite) TestBuildCacheFrom(c *check.C) {
 	id1 := getIDByName(c, "build1")
 
 	// rebuild with cache-from
-	result := buildImage("build2", withBuildFlags("--cache-from=build1"), withExternalBuildContext(ctx))
+	result := buildImage("build2", cli.WithFlags("--cache-from=build1"), withExternalBuildContext(ctx))
 	result.Assert(c, icmd.Success)
 	id2 := getIDByName(c, "build2")
 	c.Assert(id1, checker.Equals, id2)
@@ -5500,7 +5500,7 @@ func (s *DockerSuite) TestBuildCacheFrom(c *check.C) {
 	dockerCmd(c, "rmi", "build2")
 
 	// no cache match with unknown source
-	result = buildImage("build2", withBuildFlags("--cache-from=nosuchtag"), withExternalBuildContext(ctx))
+	result = buildImage("build2", cli.WithFlags("--cache-from=nosuchtag"), withExternalBuildContext(ctx))
 	result.Assert(c, icmd.Success)
 	id2 = getIDByName(c, "build2")
 	c.Assert(id1, checker.Not(checker.Equals), id2)
@@ -5521,7 +5521,7 @@ func (s *DockerSuite) TestBuildCacheFrom(c *check.C) {
 	c.Assert(strings.TrimSpace(parentID), checker.Equals, "")
 
 	// cache still applies without parents
-	result = buildImage("build2", withBuildFlags("--cache-from=build1"), withExternalBuildContext(ctx))
+	result = buildImage("build2", cli.WithFlags("--cache-from=build1"), withExternalBuildContext(ctx))
 	result.Assert(c, icmd.Success)
 	id2 = getIDByName(c, "build2")
 	c.Assert(id1, checker.Equals, id2)
@@ -5529,7 +5529,7 @@ func (s *DockerSuite) TestBuildCacheFrom(c *check.C) {
 	history1, _ := dockerCmd(c, "history", "-q", "build2")
 
 	// Retry, no new intermediate images
-	result = buildImage("build3", withBuildFlags("--cache-from=build1"), withExternalBuildContext(ctx))
+	result = buildImage("build3", cli.WithFlags("--cache-from=build1"), withExternalBuildContext(ctx))
 	result.Assert(c, icmd.Success)
 	id3 := getIDByName(c, "build3")
 	c.Assert(id1, checker.Equals, id3)
@@ -5551,7 +5551,7 @@ func (s *DockerSuite) TestBuildCacheFrom(c *check.C) {
 	err = ioutil.WriteFile(filepath.Join(ctx.Dir, "Dockerfile"), []byte(dockerfile), 0644)
 	c.Assert(err, checker.IsNil)
 
-	result = buildImage("build2", withBuildFlags("--cache-from=build1"), withExternalBuildContext(ctx))
+	result = buildImage("build2", cli.WithFlags("--cache-from=build1"), withExternalBuildContext(ctx))
 	result.Assert(c, icmd.Success)
 	id2 = getIDByName(c, "build2")
 	c.Assert(id1, checker.Not(checker.Equals), id2)
@@ -5575,7 +5575,7 @@ func (s *DockerSuite) TestBuildCacheFrom(c *check.C) {
 func (s *DockerSuite) TestBuildNetNone(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildnetnone"
-	buildImage(name, withBuildFlags("--network=none"), withDockerfile(`
+	buildImage(name, cli.WithFlags("--network=none"), build.WithDockerfile(`
   FROM busybox
   RUN ping -c 1 8.8.8.8
   `)).Assert(c, icmd.Expected{
@@ -5590,8 +5590,8 @@ func (s *DockerSuite) TestBuildNetContainer(c *check.C) {
 	id, _ := dockerCmd(c, "run", "--hostname", "foobar", "-d", "busybox", "nc", "-ll", "-p", "1234", "-e", "hostname")
 
 	name := "testbuildnetcontainer"
-	buildImageSuccessfully(c, name, withBuildFlags("--network=container:"+strings.TrimSpace(id)),
-		withDockerfile(`
+	buildImageSuccessfully(c, name, cli.WithFlags("--network=container:"+strings.TrimSpace(id)),
+		build.WithDockerfile(`
   FROM busybox
   RUN nc localhost 1234 > /otherhost
   `))
@@ -5605,11 +5605,11 @@ func (s *DockerSuite) TestBuildWithExtraHost(c *check.C) {
 
 	name := "testbuildwithextrahost"
 	buildImageSuccessfully(c, name,
-		withBuildFlags(
+		cli.WithFlags(
 			"--add-host", "foo:127.0.0.1",
 			"--add-host", "bar:127.0.0.1",
 		),
-		withDockerfile(`
+		build.WithDockerfile(`
   FROM busybox
   RUN ping -c 1 foo
   RUN ping -c 1 bar
@@ -5635,7 +5635,7 @@ func (s *DockerSuite) TestBuildWithExtraHostInvalidFormat(c *check.C) {
 	}
 
 	for _, tc := range testCases {
-		result := buildImage(tc.testName, withBuildFlags(tc.buildFlag), withDockerfile(tc.dockerfile))
+		result := buildImage(tc.testName, cli.WithFlags(tc.buildFlag), build.WithDockerfile(tc.dockerfile))
 		result.Assert(c, icmd.Expected{
 			ExitCode: 125,
 		})
@@ -5655,11 +5655,11 @@ func (s *DockerSuite) TestBuildSquashParent(c *check.C) {
 		`
 	// build and get the ID that we can use later for history comparison
 	name := "test"
-	buildImageSuccessfully(c, name, withDockerfile(dockerFile))
+	buildImageSuccessfully(c, name, build.WithDockerfile(dockerFile))
 	origID := getIDByName(c, name)
 
 	// build with squash
-	buildImageSuccessfully(c, name, withBuildFlags("--squash"), withDockerfile(dockerFile))
+	buildImageSuccessfully(c, name, cli.WithFlags("--squash"), build.WithDockerfile(dockerFile))
 	id := getIDByName(c, name)
 
 	out, _ := dockerCmd(c, "run", "--rm", id, "/bin/sh", "-c", "cat /hello")
@@ -5686,23 +5686,23 @@ func (s *DockerSuite) TestBuildSquashParent(c *check.C) {
 func (s *DockerSuite) TestBuildContChar(c *check.C) {
 	name := "testbuildcontchar"
 
-	buildImage(name, withDockerfile(`FROM busybox\`)).Assert(c, icmd.Expected{
+	buildImage(name, build.WithDockerfile(`FROM busybox\`)).Assert(c, icmd.Expected{
 		Out: "Step 1/1 : FROM busybox",
 	})
 
-	result := buildImage(name, withDockerfile(`FROM busybox
+	result := buildImage(name, build.WithDockerfile(`FROM busybox
 		 RUN echo hi \`))
 	result.Assert(c, icmd.Success)
 	c.Assert(result.Combined(), checker.Contains, "Step 1/2 : FROM busybox")
 	c.Assert(result.Combined(), checker.Contains, "Step 2/2 : RUN echo hi\n")
 
-	result = buildImage(name, withDockerfile(`FROM busybox
+	result = buildImage(name, build.WithDockerfile(`FROM busybox
 		 RUN echo hi \\`))
 	result.Assert(c, icmd.Success)
 	c.Assert(result.Combined(), checker.Contains, "Step 1/2 : FROM busybox")
 	c.Assert(result.Combined(), checker.Contains, "Step 2/2 : RUN echo hi \\\n")
 
-	result = buildImage(name, withDockerfile(`FROM busybox
+	result = buildImage(name, build.WithDockerfile(`FROM busybox
 		 RUN echo hi \\\`))
 	result.Assert(c, icmd.Success)
 	c.Assert(result.Combined(), checker.Contains, "Step 1/2 : FROM busybox")
@@ -5723,14 +5723,14 @@ func (s *DockerSuite) TestBuildOpaqueDirectory(c *check.C) {
 		`
 	// Test that build succeeds, last command fails if opaque directory
 	// was not handled correctly
-	buildImageSuccessfully(c, "testopaquedirectory", withDockerfile(dockerFile))
+	buildImageSuccessfully(c, "testopaquedirectory", build.WithDockerfile(dockerFile))
 }
 
 // Windows test for USER in dockerfile
 func (s *DockerSuite) TestBuildWindowsUser(c *check.C) {
 	testRequires(c, DaemonIsWindows)
 	name := "testbuildwindowsuser"
-	buildImage(name, withDockerfile(`FROM `+testEnv.MinimalBaseImage()+`
+	buildImage(name, build.WithDockerfile(`FROM `+testEnv.MinimalBaseImage()+`
 		RUN net user user /add
 		USER user
 		RUN set username
@@ -5760,7 +5760,7 @@ RUN ["cat", "/foo/file"]
 func (s *DockerSuite) TestBuildWindowsEnvCaseInsensitive(c *check.C) {
 	testRequires(c, DaemonIsWindows)
 	name := "testbuildwindowsenvcaseinsensitive"
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
 		FROM `+testEnv.MinimalBaseImage()+`
 		ENV FOO=bar foo=baz
   `))
@@ -5773,7 +5773,7 @@ func (s *DockerSuite) TestBuildWindowsEnvCaseInsensitive(c *check.C) {
 // Test case for 29667
 func (s *DockerSuite) TestBuildWorkdirImageCmd(c *check.C) {
 	image := "testworkdirimagecmd"
-	buildImageSuccessfully(c, image, withDockerfile(`
+	buildImageSuccessfully(c, image, build.WithDockerfile(`
 FROM busybox
 WORKDIR /foo/bar
 `))
@@ -5787,7 +5787,7 @@ WORKDIR /foo/bar
 	c.Assert(strings.TrimSpace(out), checker.Equals, lookingFor)
 
 	image = "testworkdirlabelimagecmd"
-	buildImageSuccessfully(c, image, withDockerfile(`
+	buildImageSuccessfully(c, image, build.WithDockerfile(`
 FROM busybox
 WORKDIR /foo/bar
 LABEL a=b
@@ -5805,8 +5805,8 @@ func (s *DockerSuite) TestBuildWorkdirCmd(c *check.C) {
                 FROM busybox
                 WORKDIR /
                 `
-	buildImageSuccessfully(c, name, withDockerfile(dockerFile))
-	result := buildImage(name, withDockerfile(dockerFile))
+	buildImageSuccessfully(c, name, build.WithDockerfile(dockerFile))
+	result := buildImage(name, build.WithDockerfile(dockerFile))
 	result.Assert(c, icmd.Success)
 	c.Assert(strings.Count(result.Combined(), "Using cache"), checker.Equals, 1)
 }
@@ -5814,7 +5814,7 @@ func (s *DockerSuite) TestBuildWorkdirCmd(c *check.C) {
 // FIXME(vdemeester) should be a unit test
 func (s *DockerSuite) TestBuildLineErrorOnBuild(c *check.C) {
 	name := "test_build_line_error_onbuild"
-	buildImage(name, withDockerfile(`FROM busybox
+	buildImage(name, build.WithDockerfile(`FROM busybox
   ONBUILD
   `)).Assert(c, icmd.Expected{
 		ExitCode: 1,
@@ -5825,7 +5825,7 @@ func (s *DockerSuite) TestBuildLineErrorOnBuild(c *check.C) {
 // FIXME(vdemeester) should be a unit test
 func (s *DockerSuite) TestBuildLineErrorUknownInstruction(c *check.C) {
 	name := "test_build_line_error_unknown_instruction"
-	buildImage(name, withDockerfile(`FROM busybox
+	buildImage(name, build.WithDockerfile(`FROM busybox
   RUN echo hello world
   NOINSTRUCTION echo ba
   RUN echo hello
@@ -5839,7 +5839,7 @@ func (s *DockerSuite) TestBuildLineErrorUknownInstruction(c *check.C) {
 // FIXME(vdemeester) should be a unit test
 func (s *DockerSuite) TestBuildLineErrorWithEmptyLines(c *check.C) {
 	name := "test_build_line_error_with_empty_lines"
-	buildImage(name, withDockerfile(`
+	buildImage(name, build.WithDockerfile(`
   FROM busybox
 
   RUN echo hello world
@@ -5856,7 +5856,7 @@ func (s *DockerSuite) TestBuildLineErrorWithEmptyLines(c *check.C) {
 // FIXME(vdemeester) should be a unit test
 func (s *DockerSuite) TestBuildLineErrorWithComments(c *check.C) {
 	name := "test_build_line_error_with_comments"
-	buildImage(name, withDockerfile(`FROM busybox
+	buildImage(name, build.WithDockerfile(`FROM busybox
   # This will print hello world
   # and then ba
   RUN echo hello world

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/stringutils"
 	"github.com/go-check/check"
 	"github.com/opencontainers/go-digest"
@@ -196,7 +197,7 @@ func (s *DockerRegistrySuite) TestBuildByDigest(c *check.C) {
 
 	// do the build
 	name := "buildbydigest"
-	buildImageSuccessfully(c, name, withDockerfile(fmt.Sprintf(
+	buildImageSuccessfully(c, name, build.WithDockerfile(fmt.Sprintf(
 		`FROM %s
      CMD ["/bin/echo", "Hello World"]`, imageReference)))
 	c.Assert(err, checker.IsNil)
@@ -419,7 +420,7 @@ func (s *DockerRegistrySuite) TestPsListContainersFilterAncestorImageByDigest(c 
 
 	// build an image from it
 	imageName1 := "images_ps_filter_test"
-	buildImageSuccessfully(c, imageName1, withDockerfile(fmt.Sprintf(
+	buildImageSuccessfully(c, imageName1, build.WithDockerfile(fmt.Sprintf(
 		`FROM %s
 		 LABEL match me 1`, imageReference)))
 

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -4,21 +4,22 @@ import (
 	"strings"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestCommitAfterContainerIsDone(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
+	out := cli.DockerCmd(c, "run", "-i", "-a", "stdin", "busybox", "echo", "foo").Combined()
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	dockerCmd(c, "wait", cleanedContainerID)
+	cli.DockerCmd(c, "wait", cleanedContainerID)
 
-	out, _ = dockerCmd(c, "commit", cleanedContainerID)
+	out = cli.DockerCmd(c, "commit", cleanedContainerID).Combined()
 
 	cleanedImageID := strings.TrimSpace(out)
 
-	dockerCmd(c, "inspect", cleanedImageID)
+	cli.DockerCmd(c, "inspect", cleanedImageID)
 }
 
 func (s *DockerSuite) TestCommitWithoutPause(c *check.C) {

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/testutil"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
@@ -204,7 +205,7 @@ func (s *DockerSuite) TestCreateLabels(c *check.C) {
 
 func (s *DockerSuite) TestCreateLabelFromImage(c *check.C) {
 	imageName := "testcreatebuildlabel"
-	buildImageSuccessfully(c, imageName, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, imageName, build.WithDockerfile(`FROM busybox
 		LABEL k1=v1 k2=v2`))
 
 	name := "test_create_labels_from_image"
@@ -259,7 +260,7 @@ func (s *DockerSuite) TestCreateModeIpcContainer(c *check.C) {
 
 func (s *DockerSuite) TestCreateByImageID(c *check.C) {
 	imageName := "testcreatebyimageid"
-	buildImageSuccessfully(c, imageName, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, imageName, build.WithDockerfile(`FROM busybox
 		MAINTAINER dockerio`))
 	imageID := getIDByName(c, imageName)
 	truncatedImageID := stringid.TruncateID(imageID)

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -15,6 +15,7 @@ import (
 	eventtypes "github.com/docker/docker/api/types/events"
 	eventstestutils "github.com/docker/docker/daemon/events/testutils"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/pkg/testutil"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
@@ -384,7 +385,7 @@ func (s *DockerSuite) TestEventsFilterImageLabels(c *check.C) {
 	label := "io.docker.testing=image"
 
 	// Build a test image.
-	buildImageSuccessfully(c, name, withDockerfile(fmt.Sprintf(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(fmt.Sprintf(`
 		FROM busybox:latest
 		LABEL %s`, label)))
 	dockerCmd(c, "tag", name, "labelfiltertest:tag1")
@@ -465,7 +466,7 @@ func (s *DockerSuite) TestEventsCommit(c *check.C) {
 
 func (s *DockerSuite) TestEventsCopy(c *check.C) {
 	// Build a test image.
-	buildImageSuccessfully(c, "cpimg", withDockerfile(`
+	buildImageSuccessfully(c, "cpimg", build.WithDockerfile(`
 		  FROM busybox
 		  RUN echo HI > /file`))
 	id := getIDByName(c, "cpimg")
@@ -598,7 +599,7 @@ func (s *DockerSuite) TestEventsFilterType(c *check.C) {
 	label := "io.docker.testing=image"
 
 	// Build a test image.
-	buildImageSuccessfully(c, name, withDockerfile(fmt.Sprintf(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(fmt.Sprintf(`
 		FROM busybox:latest
 		LABEL %s`, label)))
 	dockerCmd(c, "tag", name, "labelfiltertest:tag1")

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -15,6 +15,7 @@ import (
 	"unicode"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/go-check/check"
 	"github.com/kr/pty"
 )
@@ -111,7 +112,7 @@ func (s *DockerSuite) TestEventsOOMDisableTrue(c *check.C) {
 	case <-time.After(20 * time.Second):
 		observer.CheckEventError(c, containerID, "oom", matcher)
 	case <-testActions["oom"]:
-		// ignore, done
+	// ignore, done
 	case errRun := <-errChan:
 		if errRun != nil {
 			c.Fatalf("%v", errRun)
@@ -310,7 +311,7 @@ func (s *DockerSuite) TestEventsImageUntagDelete(c *check.C) {
 	defer observer.Stop()
 
 	name := "testimageevents"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM scratch
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM scratch
 		MAINTAINER "docker"`))
 	imageID := getIDByName(c, name)
 	c.Assert(deleteImages(name), checker.IsNil)

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/integration-cli/request"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
@@ -470,7 +471,7 @@ func (s *DockerSuite) TestExecWithImageUser(c *check.C) {
 	// Not applicable on Windows
 	testRequires(c, DaemonIsLinux)
 	name := "testbuilduser"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 		USER dockerio`))
 	dockerCmd(c, "run", "-d", "--name", "dockerioexec", name, "top")

--- a/integration-cli/docker_cli_health_test.go
+++ b/integration-cli/docker_cli_health_test.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"encoding/json"
-
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/go-check/check"
 )
 
@@ -40,7 +40,7 @@ func (s *DockerSuite) TestHealth(c *check.C) {
 	testRequires(c, DaemonIsLinux) // busybox doesn't work on Windows
 
 	imageName := "testhealth"
-	buildImageSuccessfully(c, imageName, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, imageName, build.WithDockerfile(`FROM busybox
 		RUN echo OK > /status
 		CMD ["/bin/sleep", "120"]
 		STOPSIGNAL SIGKILL
@@ -55,10 +55,7 @@ func (s *DockerSuite) TestHealth(c *check.C) {
 
 	// Inspect the options
 	out, _ = dockerCmd(c, "inspect",
-		"--format=timeout={{.Config.Healthcheck.Timeout}} "+
-			"interval={{.Config.Healthcheck.Interval}} "+
-			"retries={{.Config.Healthcheck.Retries}} "+
-			"test={{.Config.Healthcheck.Test}}", name)
+		"--format=timeout={{.Config.Healthcheck.Timeout}} interval={{.Config.Healthcheck.Interval}} retries={{.Config.Healthcheck.Retries}} test={{.Config.Healthcheck.Test}}", name)
 	c.Check(out, checker.Equals, "timeout=30s interval=1s retries=0 test=[CMD-SHELL cat /status]\n")
 
 	// Start
@@ -87,7 +84,7 @@ func (s *DockerSuite) TestHealth(c *check.C) {
 	dockerCmd(c, "rm", "noh")
 
 	// Disable the check with a new build
-	buildImageSuccessfully(c, "no_healthcheck", withDockerfile(`FROM testhealth
+	buildImageSuccessfully(c, "no_healthcheck", build.WithDockerfile(`FROM testhealth
 		HEALTHCHECK NONE`))
 
 	out, _ = dockerCmd(c, "inspect", "--format={{.ContainerConfig.Healthcheck.Test}}", "no_healthcheck")
@@ -131,7 +128,7 @@ func (s *DockerSuite) TestHealth(c *check.C) {
 	dockerCmd(c, "rm", "-f", "test")
 
 	// Check JSON-format
-	buildImageSuccessfully(c, imageName, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, imageName, build.WithDockerfile(`FROM busybox
 		RUN echo OK > /status
 		CMD ["/bin/sleep", "120"]
 		STOPSIGNAL SIGKILL

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/go-check/check"
 )
 
@@ -14,7 +15,7 @@ import (
 // sort is not predictable it doesn't always fail.
 func (s *DockerSuite) TestBuildHistory(c *check.C) {
 	name := "testbuildhistory"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
 LABEL label.A="A"
 LABEL label.B="B"
 LABEL label.C="C"

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/stringid"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
@@ -46,15 +47,15 @@ func (s *DockerSuite) TestImagesEnsureImageWithBadTagIsNotListed(c *check.C) {
 }
 
 func (s *DockerSuite) TestImagesOrderedByCreationDate(c *check.C) {
-	buildImageSuccessfully(c, "order:test_a", withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, "order:test_a", build.WithDockerfile(`FROM busybox
                 MAINTAINER dockerio1`))
 	id1 := getIDByName(c, "order:test_a")
 	time.Sleep(1 * time.Second)
-	buildImageSuccessfully(c, "order:test_c", withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, "order:test_c", build.WithDockerfile(`FROM busybox
                 MAINTAINER dockerio2`))
 	id2 := getIDByName(c, "order:test_c")
 	time.Sleep(1 * time.Second)
-	buildImageSuccessfully(c, "order:test_b", withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, "order:test_b", build.WithDockerfile(`FROM busybox
                 MAINTAINER dockerio3`))
 	id3 := getIDByName(c, "order:test_b")
 
@@ -75,15 +76,15 @@ func (s *DockerSuite) TestImagesFilterLabelMatch(c *check.C) {
 	imageName1 := "images_filter_test1"
 	imageName2 := "images_filter_test2"
 	imageName3 := "images_filter_test3"
-	buildImageSuccessfully(c, imageName1, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, imageName1, build.WithDockerfile(`FROM busybox
                  LABEL match me`))
 	image1ID := getIDByName(c, imageName1)
 
-	buildImageSuccessfully(c, imageName2, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, imageName2, build.WithDockerfile(`FROM busybox
                  LABEL match="me too"`))
 	image2ID := getIDByName(c, imageName2)
 
-	buildImageSuccessfully(c, imageName3, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, imageName3, build.WithDockerfile(`FROM busybox
                  LABEL nomatch me`))
 	image3ID := getIDByName(c, imageName3)
 
@@ -112,13 +113,13 @@ func (s *DockerSuite) TestImagesFilterLabelWithCommit(c *check.C) {
 }
 
 func (s *DockerSuite) TestImagesFilterSinceAndBefore(c *check.C) {
-	buildImageSuccessfully(c, "image:1", withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImageSuccessfully(c, "image:1", build.WithDockerfile(`FROM `+minimalBaseImage()+`
 LABEL number=1`))
 	imageID1 := getIDByName(c, "image:1")
-	buildImageSuccessfully(c, "image:2", withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImageSuccessfully(c, "image:2", build.WithDockerfile(`FROM `+minimalBaseImage()+`
 LABEL number=2`))
 	imageID2 := getIDByName(c, "image:2")
-	buildImageSuccessfully(c, "image:3", withDockerfile(`FROM `+minimalBaseImage()+`
+	buildImageSuccessfully(c, "image:3", build.WithDockerfile(`FROM `+minimalBaseImage()+`
 LABEL number=3`))
 	imageID3 := getIDByName(c, "image:3")
 
@@ -184,7 +185,7 @@ func assertImageList(out string, expected []string) bool {
 func (s *DockerSuite) TestImagesFilterSpaceTrimCase(c *check.C) {
 	imageName := "images_filter_test"
 	// Build a image and fail to build so that we have dangling images ?
-	buildImage(imageName, withDockerfile(`FROM busybox
+	buildImage(imageName, build.WithDockerfile(`FROM busybox
                  RUN touch /test/foo
                  RUN touch /test/bar
                  RUN touch /test/baz`)).Assert(c, icmd.Expected{
@@ -261,7 +262,7 @@ func (s *DockerSuite) TestImagesEnsureOnlyHeadsImagesShown(c *check.C) {
         MAINTAINER docker
         ENV foo bar`
 	name := "scratch-image"
-	result := buildImage(name, withDockerfile(dockerfile))
+	result := buildImage(name, build.WithDockerfile(dockerfile))
 	result.Assert(c, icmd.Success)
 	id := getIDByName(c, name)
 
@@ -285,7 +286,7 @@ func (s *DockerSuite) TestImagesEnsureImagesFromScratchShown(c *check.C) {
         MAINTAINER docker`
 
 	name := "scratch-image"
-	buildImageSuccessfully(c, name, withDockerfile(dockerfile))
+	buildImageSuccessfully(c, name, build.WithDockerfile(dockerfile))
 	id := getIDByName(c, name)
 
 	out, _ := dockerCmd(c, "images")
@@ -301,7 +302,7 @@ func (s *DockerSuite) TestImagesEnsureImagesFromBusyboxShown(c *check.C) {
         MAINTAINER docker`
 	name := "busybox-image"
 
-	buildImageSuccessfully(c, name, withDockerfile(dockerfile))
+	buildImageSuccessfully(c, name, build.WithDockerfile(dockerfile))
 	id := getIDByName(c, name)
 
 	out, _ := dockerCmd(c, "images")

--- a/integration-cli/docker_cli_nat_test.go
+++ b/integration-cli/docker_cli_nat_test.go
@@ -38,16 +38,6 @@ func getExternalAddress(c *check.C) net.IP {
 	return ifaceIP
 }
 
-func getContainerLogs(c *check.C, containerID string) string {
-	out, _ := dockerCmd(c, "logs", containerID)
-	return strings.Trim(out, "\r\n")
-}
-
-func getContainerStatus(c *check.C, containerID string) string {
-	out := inspectField(c, containerID, "State.Running")
-	return out
-}
-
 func (s *DockerSuite) TestNetworkNat(c *check.C) {
 	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	msg := "it works"

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/stringid"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
@@ -305,17 +306,17 @@ func (s *DockerSuite) TestPsListContainersFilterName(c *check.C) {
 func (s *DockerSuite) TestPsListContainersFilterAncestorImage(c *check.C) {
 	// Build images
 	imageName1 := "images_ps_filter_test1"
-	buildImageSuccessfully(c, imageName1, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, imageName1, build.WithDockerfile(`FROM busybox
 		 LABEL match me 1`))
 	imageID1 := getIDByName(c, imageName1)
 
 	imageName1Tagged := "images_ps_filter_test1:tag"
-	buildImageSuccessfully(c, imageName1Tagged, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, imageName1Tagged, build.WithDockerfile(`FROM busybox
 		 LABEL match me 1 tagged`))
 	imageID1Tagged := getIDByName(c, imageName1Tagged)
 
 	imageName2 := "images_ps_filter_test2"
-	buildImageSuccessfully(c, imageName2, withDockerfile(fmt.Sprintf(`FROM %s
+	buildImageSuccessfully(c, imageName2, build.WithDockerfile(fmt.Sprintf(`FROM %s
 		 LABEL match me 2`, imageName1)))
 	imageID2 := getIDByName(c, imageName2)
 

--- a/integration-cli/docker_cli_pull_local_test.go
+++ b/integration-cli/docker_cli_pull_local_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 	"github.com/opencontainers/go-digest"
@@ -65,7 +66,7 @@ func testConcurrentPullWholeRepo(c *check.C) {
 	repos := []string{}
 	for _, tag := range []string{"recent", "fresh", "todays"} {
 		repo := fmt.Sprintf("%v:%v", repoName, tag)
-		buildImageSuccessfully(c, repo, withDockerfile(fmt.Sprintf(`
+		buildImageSuccessfully(c, repo, build.WithDockerfile(fmt.Sprintf(`
 		    FROM busybox
 		    ENTRYPOINT ["/bin/echo"]
 		    ENV FOO foo
@@ -153,7 +154,7 @@ func testConcurrentPullMultipleTags(c *check.C) {
 	repos := []string{}
 	for _, tag := range []string{"recent", "fresh", "todays"} {
 		repo := fmt.Sprintf("%v:%v", repoName, tag)
-		buildImageSuccessfully(c, repo, withDockerfile(fmt.Sprintf(`
+		buildImageSuccessfully(c, repo, build.WithDockerfile(fmt.Sprintf(`
 		    FROM busybox
 		    ENTRYPOINT ["/bin/echo"]
 		    ENV FOO foo
@@ -207,7 +208,7 @@ func testPullIDStability(c *check.C) {
 	derivedImage := privateRegistryURL + "/dockercli/id-stability"
 	baseImage := "busybox"
 
-	buildImageSuccessfully(c, derivedImage, withDockerfile(fmt.Sprintf(`
+	buildImageSuccessfully(c, derivedImage, build.WithDockerfile(fmt.Sprintf(`
 	    FROM %s
 	    ENV derived true
 	    ENV asdf true
@@ -266,7 +267,7 @@ func (s *DockerSchema1RegistrySuite) TestPullIDStability(c *check.C) {
 func testPullNoLayers(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockercli/scratch", privateRegistryURL)
 
-	buildImageSuccessfully(c, repoName, withDockerfile(`
+	buildImageSuccessfully(c, repoName, build.WithDockerfile(`
 	FROM scratch
 	ENV foo bar`))
 	dockerCmd(c, "push", repoName)

--- a/integration-cli/docker_cli_pull_trusted_test.go
+++ b/integration-cli/docker_cli_pull_trusted_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/testutil"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
@@ -149,7 +150,7 @@ func (s *DockerTrustSuite) TestTrustedOfflinePull(c *check.C) {
 func (s *DockerTrustSuite) TestTrustedPullDelete(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockercli/%s:latest", privateRegistryURL, "trusted-pull-delete")
 	// tag the image and upload it to the private registry
-	buildImageSuccessfully(c, repoName, withDockerfile(`
+	buildImageSuccessfully(c, repoName, build.WithDockerfile(`
                     FROM busybox
                     CMD echo trustedpulldelete
                 `))

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/distribution/reference"
 	cliconfig "github.com/docker/docker/cli/config"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/testutil"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
@@ -161,7 +162,7 @@ func testConcurrentPush(c *check.C) {
 	repos := []string{}
 	for _, tag := range []string{"push1", "push2", "push3"} {
 		repo := fmt.Sprintf("%v:%v", repoName, tag)
-		buildImageSuccessfully(c, repo, withDockerfile(fmt.Sprintf(`
+		buildImageSuccessfully(c, repo, build.WithDockerfile(fmt.Sprintf(`
 	FROM busybox
 	ENTRYPOINT ["/bin/echo"]
 	ENV FOO foo

--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/go-check/check"
 )
 
@@ -60,12 +61,12 @@ func (s *DockerSuite) TestRmContainerOrphaning(c *check.C) {
 	MAINTAINER Integration Tests`
 
 	// build first dockerfile
-	buildImageSuccessfully(c, img, withDockerfile(dockerfile1))
+	buildImageSuccessfully(c, img, build.WithDockerfile(dockerfile1))
 	img1 := getIDByName(c, img)
 	// run container on first image
 	dockerCmd(c, "run", img)
 	// rebuild dockerfile with a small addition at the end
-	buildImageSuccessfully(c, img, withDockerfile(dockerfile2))
+	buildImageSuccessfully(c, img, build.WithDockerfile(dockerfile2))
 	// try to remove the image, should not error out.
 	out, _, err := dockerCmdWithError("rmi", img)
 	c.Assert(err, check.IsNil, check.Commentf("Expected to removing the image, but failed: %s", out))

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/stringid"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
@@ -147,7 +148,7 @@ func (s *DockerSuite) TestRmiImgIDForce(c *check.C) {
 // See https://github.com/docker/docker/issues/14116
 func (s *DockerSuite) TestRmiImageIDForceWithRunningContainersAndMultipleTags(c *check.C) {
 	dockerfile := "FROM busybox\nRUN echo test 14116\n"
-	buildImageSuccessfully(c, "test-14116", withDockerfile(dockerfile))
+	buildImageSuccessfully(c, "test-14116", build.WithDockerfile(dockerfile))
 	imgID := getIDByName(c, "test-14116")
 
 	newTag := "newtag"
@@ -205,7 +206,7 @@ func (s *DockerSuite) TestRmiForceWithMultipleRepositories(c *check.C) {
 	tag1 := imageName + ":tag1"
 	tag2 := imageName + ":tag2"
 
-	buildImageSuccessfully(c, tag1, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, tag1, build.WithDockerfile(`FROM busybox
 		MAINTAINER "docker"`))
 	dockerCmd(c, "tag", tag1, tag2)
 
@@ -234,7 +235,7 @@ func (s *DockerSuite) TestRmiContainerImageNotFound(c *check.C) {
 	imageIds := make([]string, 2)
 	for i, name := range imageNames {
 		dockerfile := fmt.Sprintf("FROM busybox\nMAINTAINER %s\nRUN echo %s\n", name, name)
-		buildImageSuccessfully(c, name, withoutCache, withDockerfile(dockerfile))
+		buildImageSuccessfully(c, name, build.WithoutCache, build.WithDockerfile(dockerfile))
 		id := getIDByName(c, name)
 		imageIds[i] = id
 	}
@@ -263,7 +264,7 @@ RUN echo 0 #layer0
 RUN echo 1 #layer1
 RUN echo 2 #layer2
 `
-	buildImageSuccessfully(c, image, withoutCache, withDockerfile(dockerfile))
+	buildImageSuccessfully(c, image, build.WithoutCache, build.WithDockerfile(dockerfile))
 	out, _ := dockerCmd(c, "history", "-q", image)
 	ids := strings.Split(out, "\n")
 	idToTag := ids[2]
@@ -299,7 +300,7 @@ RUN echo 2 #layer2
 }
 
 func (*DockerSuite) TestRmiParentImageFail(c *check.C) {
-	buildImageSuccessfully(c, "test", withDockerfile(`
+	buildImageSuccessfully(c, "test", build.WithDockerfile(`
 	FROM busybox
 	RUN echo hello`))
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/stringutils"
@@ -410,7 +411,7 @@ func (s *DockerSuite) TestRunCreateVolumesInSymlinkDir(c *check.C) {
 		containerPath = "/test/test"
 		cmd = "true"
 	}
-	buildImageSuccessfully(c, name, withDockerfile(dockerFile))
+	buildImageSuccessfully(c, name, build.WithDockerfile(dockerFile))
 	dockerCmd(c, "run", "-v", containerPath, name, cmd)
 }
 
@@ -435,7 +436,7 @@ func (s *DockerSuite) TestRunCreateVolumesInSymlinkDir2(c *check.C) {
 		containerPath = "/test/test"
 		cmd = "true"
 	}
-	buildImageSuccessfully(c, name, withDockerfile(dockerFile))
+	buildImageSuccessfully(c, name, build.WithDockerfile(dockerFile))
 	dockerCmd(c, "run", "-v", containerPath, name, cmd)
 }
 
@@ -1658,7 +1659,7 @@ func (s *DockerSuite) TestRunCopyVolumeUIDGID(c *check.C) {
 	// Not applicable on Windows as it does not support uid or gid in this way
 	testRequires(c, DaemonIsLinux)
 	name := "testrunvolumesuidgid"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 		RUN echo 'dockerio:x:1001:' >> /etc/group
 		RUN mkdir -p /hello && touch /hello/test && chown dockerio.dockerio /hello`))
@@ -1677,7 +1678,7 @@ func (s *DockerSuite) TestRunCopyVolumeContent(c *check.C) {
 	// that copies from the image to the volume.
 	testRequires(c, DaemonIsLinux)
 	name := "testruncopyvolumecontent"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		RUN mkdir -p /hello/local && echo hello > /hello/local/world`))
 
 	// Test that the content is copied from the image to the volume
@@ -1689,7 +1690,7 @@ func (s *DockerSuite) TestRunCopyVolumeContent(c *check.C) {
 
 func (s *DockerSuite) TestRunCleanupCmdOnEntrypoint(c *check.C) {
 	name := "testrunmdcleanuponentrypoint"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		ENTRYPOINT ["echo"]
 		CMD ["testingpoint"]`))
 
@@ -2173,7 +2174,7 @@ func (s *DockerSuite) TestVolumesNoCopyData(c *check.C) {
 	// are pre-populated such as is built in the dockerfile used in this test.
 	testRequires(c, DaemonIsLinux)
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-	buildImageSuccessfully(c, "dataimage", withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, "dataimage", build.WithDockerfile(`FROM busybox
 		RUN ["mkdir", "-p", "/foo"]
 		RUN ["touch", "/foo/bar"]`))
 	dockerCmd(c, "run", "--name", "test", "-v", prefix+slash+"foo", "busybox")
@@ -2204,7 +2205,7 @@ func (s *DockerSuite) TestRunNoOutputFromPullInStdout(c *check.C) {
 func (s *DockerSuite) TestRunVolumesCleanPaths(c *check.C) {
 	testRequires(c, SameHostDaemon)
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-	buildImageSuccessfully(c, "run_volumes_clean_paths", withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, "run_volumes_clean_paths", build.WithDockerfile(`FROM busybox
 		VOLUME `+prefix+`/foo/`))
 	dockerCmd(c, "run", "-v", prefix+"/foo", "-v", prefix+"/bar/", "--name", "dark_helmet", "run_volumes_clean_paths")
 
@@ -3843,7 +3844,7 @@ func (s *DockerSuite) TestRunInitLayerPathOwnership(c *check.C) {
 	// Not applicable on Windows as it does not support Linux uid/gid ownership
 	testRequires(c, DaemonIsLinux)
 	name := "testetcfileownership"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 		RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 		RUN echo 'dockerio:x:1001:' >> /etc/group
 		RUN chown dockerio:dockerio /etc`))
@@ -3975,7 +3976,7 @@ func (s *DockerSuite) TestRunNamedVolumeCopyImageData(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 
 	testImg := "testvolumecopy"
-	buildImageSuccessfully(c, testImg, withDockerfile(`
+	buildImageSuccessfully(c, testImg, build.WithDockerfile(`
 	FROM busybox
 	RUN mkdir -p /foo && echo hello > /foo/hello
 	`))
@@ -4054,7 +4055,7 @@ func (s *DockerSuite) TestRunVolumeWithOneCharacter(c *check.C) {
 
 func (s *DockerSuite) TestRunVolumeCopyFlag(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Windows does not support copying data from image to the volume
-	buildImageSuccessfully(c, "volumecopy", withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, "volumecopy", build.WithDockerfile(`FROM busybox
 		RUN mkdir /foo && echo hello > /foo/bar
 		CMD cat /foo/bar`))
 	dockerCmd(c, "volume", "create", "test")

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/parsers"
@@ -828,7 +829,7 @@ func (s *DockerSuite) TestRunTmpfsMounts(c *check.C) {
 
 func (s *DockerSuite) TestRunTmpfsMountsOverrideImageVolumes(c *check.C) {
 	name := "img-with-volumes"
-	buildImageSuccessfully(c, name, withDockerfile(`
+	buildImageSuccessfully(c, name, build.WithDockerfile(`
     FROM busybox
     VOLUME /run
     RUN touch /run/stuff

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/testutil"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
@@ -265,7 +266,7 @@ func (s *DockerSuite) TestSaveDirectoryPermissions(c *check.C) {
 	os.Mkdir(extractionDirectory, 0777)
 
 	defer os.RemoveAll(tmpDir)
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 	RUN adduser -D user && mkdir -p /opt/a/b && chown -R user:user /opt/a
 	RUN touch /opt/a/b/c && chown user:user /opt/a/b/c`))
 
@@ -360,7 +361,7 @@ func (s *DockerSuite) TestSaveLoadNoTag(c *check.C) {
 
 	name := "saveloadnotag"
 
-	buildImageSuccessfully(c, name, withDockerfile("FROM busybox\nENV foo=bar"))
+	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nENV foo=bar"))
 	id := inspectField(c, name, "Id")
 
 	// Test to make sure that save w/o name just shows imageID during load

--- a/integration-cli/docker_cli_save_load_unix_test.go
+++ b/integration-cli/docker_cli_save_load_unix_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 	"github.com/kr/pty"
@@ -71,7 +72,7 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 
 func (s *DockerSuite) TestSaveAndLoadWithProgressBar(c *check.C) {
 	name := "test-load"
-	buildImageSuccessfully(c, name, withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
 	RUN touch aa
 	`))
 

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/stringutils"
 	"github.com/go-check/check"
@@ -142,7 +143,7 @@ func (s *DockerSuite) TestTagInvalidRepoName(c *check.C) {
 
 // ensure tags cannot create ambiguity with image ids
 func (s *DockerSuite) TestTagTruncationAmbiguity(c *check.C) {
-	buildImageSuccessfully(c, "notbusybox:latest", withDockerfile(`FROM busybox
+	buildImageSuccessfully(c, "notbusybox:latest", build.WithDockerfile(`FROM busybox
 		MAINTAINER dockerio`))
 	imageID := getIDByName(c, "notbusybox:latest")
 	truncatedImageID := stringid.TruncateID(imageID)

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/integration-cli/request"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
@@ -497,7 +498,7 @@ func (s *DockerSuite) TestDuplicateMountpointsForVolumesFrom(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 
 	image := "vimage"
-	buildImageSuccessfully(c, image, withDockerfile(`
+	buildImageSuccessfully(c, image, build.WithDockerfile(`
 		FROM busybox
 		VOLUME ["/tmp/data"]`))
 
@@ -539,7 +540,7 @@ func (s *DockerSuite) TestDuplicateMountpointsForVolumesFromAndBind(c *check.C) 
 	testRequires(c, DaemonIsLinux)
 
 	image := "vimage"
-	buildImageSuccessfully(c, image, withDockerfile(`
+	buildImageSuccessfully(c, image, build.WithDockerfile(`
                 FROM busybox
                 VOLUME ["/tmp/data"]`))
 
@@ -583,7 +584,7 @@ func (s *DockerSuite) TestDuplicateMountpointsForVolumesFromAndMounts(c *check.C
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	image := "vimage"
-	buildImageSuccessfully(c, image, withDockerfile(`
+	buildImageSuccessfully(c, image, build.WithDockerfile(`
                 FROM busybox
                 VOLUME ["/tmp/data"]`))
 

--- a/integration-cli/environment/environment.go
+++ b/integration-cli/environment/environment.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -11,7 +12,13 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/opts"
 	"golang.org/x/net/context"
+)
+
+const (
+	// DefaultDockerBinary is the name of the docker binary
+	DefaultDockerBinary = "docker"
 )
 
 // Execution holds informations about the test execution environment.
@@ -31,7 +38,8 @@ type Execution struct {
 	containerStoragePath string
 	// baseImage is the name of the base image for testing
 	// Environment variable WINDOWS_BASE_IMAGE can override this
-	baseImage string
+	baseImage    string
+	dockerBinary string
 
 	protectedElements protectedElements
 }
@@ -90,6 +98,16 @@ func New() (*Execution, error) {
 			daemonPid = int(p)
 		}
 	}
+
+	var dockerBinary = DefaultDockerBinary
+	if dockerBin := os.Getenv("DOCKER_BINARY"); dockerBin != "" {
+		dockerBinary = dockerBin
+	}
+	dockerBinary, err = exec.LookPath(dockerBinary)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Execution{
 		localDaemon:          localDaemon,
 		daemonPlatform:       daemonPlatform,
@@ -102,6 +120,7 @@ func New() (*Execution, error) {
 		daemonPid:            daemonPid,
 		experimentalDaemon:   info.ExperimentalBuild,
 		baseImage:            baseImage,
+		dockerBinary:         dockerBinary,
 		protectedElements: protectedElements{
 			images: map[string]struct{}{},
 		},
@@ -189,4 +208,18 @@ func (e *Execution) DaemonKernelVersionNumeric() int {
 	}
 	v, _ := strconv.Atoi(strings.Split(e.daemonKernelVersion, " ")[1])
 	return v
+}
+
+// DockerBinary returns the docker binary for this testing environment
+func (e *Execution) DockerBinary() string {
+	return e.dockerBinary
+}
+
+// DaemonHost return the daemon host string for this test execution
+func DaemonHost() string {
+	daemonURLStr := "unix://" + opts.DefaultUnixSocket
+	if daemonHostVar := os.Getenv("DOCKER_HOST"); daemonHostVar != "" {
+		daemonURLStr = daemonHostVar
+	}
+	return daemonURLStr
 }

--- a/pkg/testutil/cmd/command.go
+++ b/pkg/testutil/cmd/command.go
@@ -54,10 +54,10 @@ type Result struct {
 
 // Assert compares the Result against the Expected struct, and fails the test if
 // any of the expcetations are not met.
-func (r *Result) Assert(t testingT, exp Expected) {
+func (r *Result) Assert(t testingT, exp Expected) *Result {
 	err := r.Compare(exp)
 	if err == nil {
-		return
+		return r
 	}
 	_, file, line, ok := runtime.Caller(1)
 	if ok {
@@ -65,6 +65,7 @@ func (r *Result) Assert(t testingT, exp Expected) {
 	} else {
 		t.Fatalf("(no file/line info) - %s", err.Error())
 	}
+	return nil
 }
 
 // Compare returns a formatted error with the command, stdout, stderr, exit


### PR DESCRIPTION
This is an attempt to extract `dockerCmd*`, `inspect*` and `build*` code from `docker_utils_test.go` to package(s) (here `cli` and `cli/build`). The idea is to make what's done for `buildImage` but for any `docker` command and make it so that a test suite that wants to target a daemon use the same command as the default one (with just a *modifier*).

Some code examples 🐻.

```go
// dockerCmd functions
out := cli.DockerCmd(c, "ps", "-q").Combined() // equilvalent to `dockerCmd("ps", "-q")`
cli.Docker(cli.Cmd("ps", "-q"), cli.On(s.d)) // ~equivalent to `d.Cmd("ps", "-q")`
cli.Docker(cli.Cmd("ps", "-q"), cli.WithTimeout(5 * time.Second)).Assert(c, icmd.Success)
// Showing chaining asserts and using result
out := cli.Docker(cli.Cmd("ps", "-q")).Assert(c, icmd.Success).Combined()

// build* functions
cli.BuildCmd("imageName", build.WithDockerfile(…))
cli.BuildCmd("imageName", build.WithoutCache, withBuildContext(…))
// Or the common / hard way for specific stuff
cli.Docker(cli.Build("imageName"), build.WithDockerfile(…), cli.WithFlag("-q"))

// inspect* functions
id := cli.InspectCmd(c, "id", cli.Format(".Id")).Combined()
// Or the common / hard way for specific stuff ?
cli.Docker(cli.Inspect("id"), cli.Format(".Id")).Combined()
```

It also comes with a small change in `pkg/testutil/cmd` package to be able to chain multiple `Assert` and thus use `Result` after asserts if needed 🐯. 

It's a wip because I want to get some feedback on that 👼 and because I didn't migrate all function (will be in follow-up PRs anyway because it would be too much to review in one pass) and didn't mark old function as deprecated either. Not sure about the name either 😅. It might not pass validation too at first because I didn't comment all exported function 😝 

/cc @thaJeztah @aaronlehmann @dnephin @icecrime @cpuguy83 @vieux 

🦁

Signed-off-by: Vincent Demeester <vincent@sbr.pm>