### PR TITLE
skip plugin test on non x86 architectures

### DIFF
--- a/integration-cli/docker_cli_swarm_unix_test.go
+++ b/integration-cli/docker_cli_swarm_unix_test.go
@@ -54,6 +54,7 @@ func (s *DockerSwarmSuite) TestSwarmVolumePlugin(c *check.C) {
 
 // Test network plugin filter in swarm
 func (s *DockerSwarmSuite) TestSwarmNetworkPluginV2(c *check.C) {
+	testRequires(c, IsAmd64)
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, true, false)
 


### PR DESCRIPTION
Because the plugins in dockerhub aren't multi-arch, they will
fail on non x86-64 platforms. Comment this test out like we do with
the others.

should fix the p, z and an issue on the arm CI

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>