### PR TITLE
Fix typo in sample output

### DIFF
--- a/docs/reference/commandline/commit.md
+++ b/docs/reference/commandline/commit.md
@@ -74,7 +74,7 @@ svendowideit/testimage            version3            f5283438590d        16 sec
 ```bash
 $ docker ps
 
-ICONTAINER ID       IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
+CONTAINER ID       IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
 c3f279d17e0a        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
 197387f1b436        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
 


### PR DESCRIPTION
For some reasons, the `bash` output has the first column as `ICONTAINER ID` instead of `CONTAINER ID`. This should fix (part of?) [docker.github.io #2165](https://github.com/docker/docker.github.io/issues/2165).