### PR TITLE
Some cleanup of container run command

### DIFF
--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -51,7 +51,12 @@ func parseRun(args []string) (*container.Config, *container.HostConfig, *network
 	if err := flags.Parse(args); err != nil {
 		return nil, nil, nil, err
 	}
-	return parse(flags, copts)
+	// TODO: fix tests to accept ContainerConfig
+	containerConfig, err := parse(flags, copts)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return containerConfig.Config, containerConfig.HostConfig, containerConfig.NetworkingConfig, err
 }
 
 func parsetest(t *testing.T, args string) (*container.Config, *container.HostConfig, error) {

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
-	opttypes "github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/promise"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/libnetwork/resolvconf/dns"
@@ -66,40 +66,44 @@ func NewRunCommand(dockerCli *command.DockerCli) *cobra.Command {
 	return cmd
 }
 
-func runRun(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *runOptions, copts *containerOptions) error {
-	stdout, stderr, stdin := dockerCli.Out(), dockerCli.Err(), dockerCli.In()
-	client := dockerCli.Client()
-	// TODO: pass this as an argument
-	cmdPath := "run"
-
-	var (
-		flAttach                *opttypes.ListOpts
-		ErrConflictAttachDetach = errors.New("Conflicting options: -a and -d")
-	)
-
-	config, hostConfig, networkingConfig, err := parse(flags, copts)
-
-	// just in case the parse does not exit
-	if err != nil {
-		reportError(stderr, cmdPath, err.Error(), true)
-		return cli.StatusError{StatusCode: 125}
-	}
-
+func warnOnOomKillDisable(hostConfig container.HostConfig, stderr io.Writer) {
 	if hostConfig.OomKillDisable != nil && *hostConfig.OomKillDisable && hostConfig.Memory == 0 {
 		fmt.Fprintln(stderr, "WARNING: Disabling the OOM killer on containers without setting a '-m/--memory' limit may be dangerous.")
 	}
+}
 
-	if len(hostConfig.DNS) > 0 {
-		// check the DNS settings passed via --dns against
-		// localhost regexp to warn if they are trying to
-		// set a DNS to a localhost address
-		for _, dnsIP := range hostConfig.DNS {
-			if dns.IsLocalhost(dnsIP) {
-				fmt.Fprintf(stderr, "WARNING: Localhost DNS setting (--dns=%s) may fail in containers.\n", dnsIP)
-				break
-			}
+// check the DNS settings passed via --dns against localhost regexp to warn if
+// they are trying to set a DNS to a localhost address
+func warnOnLocalhostDNS(hostConfig container.HostConfig, stderr io.Writer) {
+	for _, dnsIP := range hostConfig.DNS {
+		if dns.IsLocalhost(dnsIP) {
+			fmt.Fprintf(stderr, "WARNING: Localhost DNS setting (--dns=%s) may fail in containers.\n", dnsIP)
+			return
 		}
 	}
+}
+
+func runRun(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *runOptions, copts *containerOptions) error {
+	containerConfig, err := parse(flags, copts)
+	// just in case the parse does not exit
+	if err != nil {
+		reportError(dockerCli.Err(), "run", err.Error(), true)
+		return cli.StatusError{StatusCode: 125}
+	}
+	return runContainer(dockerCli, opts, copts, containerConfig)
+}
+
+func runContainer(dockerCli *command.DockerCli, opts *runOptions, copts *containerOptions, containerConfig *containerConfig) error {
+	config := containerConfig.Config
+	hostConfig := containerConfig.HostConfig
+	stdout, stderr := dockerCli.Out(), dockerCli.Err()
+	client := dockerCli.Client()
+
+	// TODO: pass this as an argument
+	cmdPath := "run"
+
+	warnOnOomKillDisable(*hostConfig, stderr)
+	warnOnLocalhostDNS(*hostConfig, stderr)
 
 	config.ArgsEscaped = false
 
@@ -108,11 +112,8 @@ func runRun(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *runOptions
 			return err
 		}
 	} else {
-		if fl := flags.Lookup("attach"); fl != nil {
-			flAttach = fl.Value.(*opttypes.ListOpts)
-			if flAttach.Len() != 0 {
-				return ErrConflictAttachDetach
-			}
+		if copts.attach.Len() != 0 {
+			return errors.New("Conflicting options: -a and -d")
 		}
 
 		config.AttachStdin = false
@@ -135,7 +136,7 @@ func runRun(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *runOptions
 
 	ctx, cancelFun := context.WithCancel(context.Background())
 
-	createResponse, err := createContainer(ctx, dockerCli, config, hostConfig, networkingConfig, hostConfig.ContainerIDFile, opts.name)
+	createResponse, err := createContainer(ctx, dockerCli, containerConfig, opts.name)
 	if err != nil {
 		reportError(stderr, cmdPath, err.Error(), true)
 		return runStartContainerErr(err)
@@ -158,51 +159,15 @@ func runRun(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *runOptions
 	}
 	attach := config.AttachStdin || config.AttachStdout || config.AttachStderr
 	if attach {
-		var (
-			out, cerr io.Writer
-			in        io.ReadCloser
-		)
-		if config.AttachStdin {
-			in = stdin
-		}
-		if config.AttachStdout {
-			out = stdout
-		}
-		if config.AttachStderr {
-			if config.Tty {
-				cerr = stdout
-			} else {
-				cerr = stderr
-			}
-		}
-
 		if opts.detachKeys != "" {
 			dockerCli.ConfigFile().DetachKeys = opts.detachKeys
 		}
 
-		options := types.ContainerAttachOptions{
-			Stream:     true,
-			Stdin:      config.AttachStdin,
-			Stdout:     config.AttachStdout,
-			Stderr:     config.AttachStderr,
-			DetachKeys: dockerCli.ConfigFile().DetachKeys,
+		close, err := attachContainer(ctx, dockerCli, &errCh, config, createResponse.ID)
+		defer close()
+		if err != nil {
+			return err
 		}
-
-		resp, errAttach := client.ContainerAttach(ctx, createResponse.ID, options)
-		if errAttach != nil && errAttach != httputil.ErrPersistEOF {
-			// ContainerAttach returns an ErrPersistEOF (connection closed)
-			// means server met an error and put it in Hijacked connection
-			// keep the error and read detailed error message from hijacked connection later
-			return errAttach
-		}
-		defer resp.Close()
-
-		errCh = promise.Go(func() error {
-			if errHijack := holdHijackedConnection(ctx, dockerCli, config.Tty, in, out, cerr, resp); errHijack != nil {
-				return errHijack
-			}
-			return errAttach
-		})
 	}
 
 	statusChan := waitExitOrRemoved(ctx, dockerCli, createResponse.ID, copts.autoRemove)
@@ -250,6 +215,57 @@ func runRun(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *runOptions
 		return cli.StatusError{StatusCode: status}
 	}
 	return nil
+}
+
+func attachContainer(
+	ctx context.Context,
+	dockerCli *command.DockerCli,
+	errCh *chan error,
+	config *container.Config,
+	containerID string,
+) (func(), error) {
+	stdout, stderr := dockerCli.Out(), dockerCli.Err()
+	var (
+		out, cerr io.Writer
+		in        io.ReadCloser
+	)
+	if config.AttachStdin {
+		in = dockerCli.In()
+	}
+	if config.AttachStdout {
+		out = stdout
+	}
+	if config.AttachStderr {
+		if config.Tty {
+			cerr = stdout
+		} else {
+			cerr = stderr
+		}
+	}
+
+	options := types.ContainerAttachOptions{
+		Stream:     true,
+		Stdin:      config.AttachStdin,
+		Stdout:     config.AttachStdout,
+		Stderr:     config.AttachStderr,
+		DetachKeys: dockerCli.ConfigFile().DetachKeys,
+	}
+
+	resp, errAttach := dockerCli.Client().ContainerAttach(ctx, containerID, options)
+	if errAttach != nil && errAttach != httputil.ErrPersistEOF {
+		// ContainerAttach returns an ErrPersistEOF (connection closed)
+		// means server met an error and put it in Hijacked connection
+		// keep the error and read detailed error message from hijacked connection later
+		return nil, errAttach
+	}
+
+	*errCh = promise.Go(func() error {
+		if errHijack := holdHijackedConnection(ctx, dockerCli, config.Tty, in, out, cerr, resp); errHijack != nil {
+			return errHijack
+		}
+		return errAttach
+	})
+	return resp.Close, nil
 }
 
 // reportError is a utility method that prints a user-friendly message


### PR DESCRIPTION
Extract a few functions from a massive function.
A new `containerConfig` option for passing around the three config structs.
Use the `containerOptions` object instead of `flags` for checking attach.