### PR TITLE
Fix dropped field in task translation from GRPC to REST

### DIFF
--- a/daemon/cluster/convert/task.go
+++ b/daemon/cluster/convert/task.go
@@ -13,12 +13,7 @@ func TaskFromGRPC(t swarmapi.Task) types.Task {
 	if t.Spec.GetAttachment() != nil {
 		return types.Task{}
 	}
-	containerConfig := t.Spec.Runtime.(*swarmapi.TaskSpec_Container).Container
 	containerStatus := t.Status.GetContainer()
-	networks := make([]types.NetworkAttachmentConfig, 0, len(t.Spec.Networks))
-	for _, n := range t.Spec.Networks {
-		networks = append(networks, types.NetworkAttachmentConfig{Target: n.Target, Aliases: n.Aliases})
-	}
 
 	task := types.Task{
 		ID:          t.ID,
@@ -26,14 +21,7 @@ func TaskFromGRPC(t swarmapi.Task) types.Task {
 		ServiceID:   t.ServiceID,
 		Slot:        int(t.Slot),
 		NodeID:      t.NodeID,
-		Spec: types.TaskSpec{
-			ContainerSpec: containerSpecFromGRPC(containerConfig),
-			Resources:     resourcesFromGRPC(t.Spec.Resources),
-			RestartPolicy: restartPolicyFromGRPC(t.Spec.Restart),
-			Placement:     placementFromGRPC(t.Spec.Placement),
-			LogDriver:     driverFromGRPC(t.Spec.LogDriver),
-			Networks:      networks,
-		},
+		Spec:        taskSpecFromGRPC(t.Spec),
 		Status: types.TaskStatus{
 			State:   types.TaskState(strings.ToLower(t.Status.State.String())),
 			Message: t.Status.Message,


### PR DESCRIPTION
Split off from #31144.

This fixes the `ForceUpdate` field being omitted from the JSON representation of a `TaskSpec` returned by the REST API. It also reorganizes the code to reduce duplication.