### PR TITLE
Windows: Add missing HostConfig fields to update block

### DIFF
--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -70,13 +70,39 @@ func (container *Container) TmpfsMounts() ([]Mount, error) {
 func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfig) error {
 	container.Lock()
 	defer container.Unlock()
+
 	resources := hostConfig.Resources
-	if resources.BlkioWeight != 0 || resources.CPUShares != 0 ||
-		resources.CPUPeriod != 0 || resources.CPUQuota != 0 ||
-		resources.CpusetCpus != "" || resources.CpusetMems != "" ||
-		resources.Memory != 0 || resources.MemorySwap != 0 ||
-		resources.MemoryReservation != 0 || resources.KernelMemory != 0 {
-		return fmt.Errorf("Resource updating isn't supported on Windows")
+	if resources.CPUShares != 0 ||
+		resources.Memory != 0 ||
+		resources.NanoCPUs != 0 ||
+		resources.CgroupParent != "" ||
+		resources.BlkioWeight != 0 ||
+		len(resources.BlkioWeightDevice) != 0 ||
+		len(resources.BlkioDeviceReadBps) != 0 ||
+		len(resources.BlkioDeviceWriteBps) != 0 ||
+		len(resources.BlkioDeviceReadIOps) != 0 ||
+		len(resources.BlkioDeviceWriteIOps) != 0 ||
+		resources.CPUPeriod != 0 ||
+		resources.CPUQuota != 0 ||
+		resources.CPURealtimePeriod != 0 ||
+		resources.CPURealtimeRuntime != 0 ||
+		resources.CpusetCpus != "" ||
+		resources.CpusetMems != "" ||
+		len(resources.Devices) != 0 ||
+		len(resources.DeviceCgroupRules) != 0 ||
+		resources.DiskQuota != 0 ||
+		resources.KernelMemory != 0 ||
+		resources.MemoryReservation != 0 ||
+		resources.MemorySwap != 0 ||
+		resources.MemorySwappiness != nil ||
+		resources.OomKillDisable != nil ||
+		resources.PidsLimit != 0 ||
+		len(resources.Ulimits) != 0 ||
+		resources.CPUCount != 0 ||
+		resources.CPUPercent != 0 ||
+		resources.IOMaximumIOps != 0 ||
+		resources.IOMaximumBandwidth != 0 {
+		return fmt.Errorf("resource updating isn't supported on Windows")
 	}
 	// update HostConfig of container
 	if hostConfig.RestartPolicy.Name != "" {


### PR DESCRIPTION
Signed-off-by: Darren Stahl <darst@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes #31575 

Some values (CpuCount and CpuPercent, among others) were not being checked during container update. This resulted in returning success when using the Update Container API with resources set to be updated, even though they were not updated.

**- How I did it**

Ensure all fields in the Resources field of HostConfig are not set when updating containers on Windows daemons.

**- How to verify it**

See https://github.com/docker/docker/issues/31575 for repro steps:

Proof of fix:
![image](https://cloud.githubusercontent.com/assets/14114019/23683126/2a3588da-034c-11e7-8666-3ea5f545be7f.png)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Block resource updating on Windows containers instead of silently failing in some cases

/cc @jhowardmsft @jstarks FYI

