### PR TITLE
Windows: Stop holding client container lock during shutdown

### DIFF
--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -201,8 +201,17 @@ func (ctr *container) waitExit(process *process, isFirstProcessToStart bool) err
 	logrus.Debugln("libcontainerd: waitExit() on pid", process.systemPid)
 
 	exitCode := ctr.waitProcessExitCode(process)
-	// Lock the container while shutting down
+	// Lock the container while removing the process/container from the list
 	ctr.client.lock(ctr.containerID)
+
+	if !isFirstProcessToStart {
+		ctr.cleanProcess(process.friendlyName)
+	} else {
+		ctr.client.deleteContainer(ctr.containerID)
+	}
+
+	// Unlock here so other threads are unblocked
+	ctr.client.unlock(ctr.containerID)
 
 	// Assume the container has exited
 	si := StateInfo{
@@ -218,7 +227,6 @@ func (ctr *container) waitExit(process *process, isFirstProcessToStart bool) err
 	// But it could have been an exec'd process which exited
 	if !isFirstProcessToStart {
 		si.State = StateExitProcess
-		ctr.cleanProcess(process.friendlyName)
 	} else {
 		updatePending, err := ctr.hcsContainer.HasPendingUpdates()
 		if err != nil {
@@ -236,19 +244,11 @@ func (ctr *container) waitExit(process *process, isFirstProcessToStart bool) err
 		if err := ctr.hcsContainer.Close(); err != nil {
 			logrus.Error(err)
 		}
-
-		// Remove process from list if we have exited
-		if si.State == StateExit {
-			ctr.client.deleteContainer(ctr.containerID)
-		}
 	}
 
 	if err := process.hcsProcess.Close(); err != nil {
 		logrus.Errorf("libcontainerd: hcsProcess.Close(): %v", err)
 	}
-
-	// Unlock here before we call back into the daemon to update state
-	ctr.client.unlock(ctr.containerID)
 
 	// Call into the backend to notify it of the state change.
 	logrus.Debugf("libcontainerd: waitExit() calling backend.StateChanged %+v", si)


### PR DESCRIPTION
Signed-off-by: Darren Stahl <darst@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #31624

**- What I did**

Prevent the container exit thread from holding the client lock while waiting for the container to shut down. This prevents temporary hangs in the case of a container failing to terminate.

**- How I did it**

Hold the client lock only while removing the container/process from the respective list, and release it before shutting the container down.

**- How to verify it**

Manual verification, only affects timing, not correctness.

/cc @jhowardmsft @jstarks 
