### PR TITLE
cluster: Proceed with startup if cluster component can't be created

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -39,7 +39,6 @@ package cluster
 //
 
 import (
-	"crypto/x509"
 	"fmt"
 	"net"
 	"os"
@@ -171,13 +170,8 @@ func New(config Config) (*Cluster, error) {
 		logrus.Error("swarm component could not be started before timeout was reached")
 	case err := <-nr.Ready():
 		if err != nil {
-			if errors.Cause(err) == errSwarmLocked {
-				return c, nil
-			}
-			if err, ok := errors.Cause(c.nr.err).(x509.CertificateInvalidError); ok && err.Reason == x509.Expired {
-				return c, nil
-			}
-			return nil, errors.Wrap(err, "swarm component could not be started")
+			logrus.WithError(err).Error("swarm component could not be started")
+			return c, nil
 		}
 	}
 	return c, nil


### PR DESCRIPTION
The current behavior is for dockerd to fail to start if the swarm component can't be started for some reason. This can be difficult to debug remotely because the daemon won't be running at all, so it's not possible to hit endpoints like /info to see what's going on. It's also very difficult to recover from the situation, since commands like "docker swarm leave" are unavailable.

Change the behavior to allow startup to proceed.

Note this is a change we'll have to communicate well. People may expect they can rely on successful daemon startup as an indicator that swarm mode is functioning (though frankly I expect that in most cases people are surprised when dockerd suddenly fails to start). I'm not sure where this change needs to be documented.

Fixes #29580

cc @tonistiigi @aluzzardi