### PR TITLE
api: clarify that Env var without `=` is removed from the environment

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -741,7 +741,7 @@ definitions:
         default: false
       Env:
         description: |
-          A list of environment variables to set inside the container in the form `["VAR=value", ...]`
+          A list of environment variables to set inside the container in the form `["VAR=value", ...]`. A variable without `=` is removed from the environment, rather than to have an empty value.
         type: "array"
         items:
           type: "string"

--- a/container/env_test.go
+++ b/container/env_test.go
@@ -4,11 +4,14 @@ import "testing"
 
 func TestReplaceAndAppendEnvVars(t *testing.T) {
 	var (
-		d = []string{"HOME=/"}
-		o = []string{"HOME=/root", "TERM=xterm"}
+		d = []string{"HOME=/", "FOO=foo_default"}
+		// remove FOO from env
+		// remove BAR from env (nop)
+		o = []string{"HOME=/root", "TERM=xterm", "FOO", "BAR"}
 	)
 
 	env := ReplaceOrAppendEnvValues(d, o)
+	t.Logf("default=%v, override=%v, result=%v", d, o, env)
 	if len(env) != 2 {
 		t.Fatalf("expected len of 2 got %d", len(env))
 	}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Clarified that Env var without `=` is removed from the environment.

**- How I did it**

Updated `swagger.yaml` and `env_test.go`

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![](https://upload.wikimedia.org/wikipedia/commons/7/7a/Antarctic,_adelie_penguin_(js)_57.jpg)

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>