### PR TITLE
Fix fish autocompletion with custom ps output

### DIFF
--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -26,20 +26,20 @@ end
 function __fish_print_docker_containers --description 'Print a list of docker containers' -a select
     switch $select
         case running
-            docker ps -a --no-trunc | command awk 'NR>1' | command awk 'BEGIN {FS="  +"}; $5 ~ "^Up" {print $1 "\n" $(NF)}' | tr ',' '\n'
+            docker ps -a --no-trunc --filter status=running --format "{{.ID}}\n{{.Names}}" | tr ',' '\n'
         case stopped
-            docker ps -a --no-trunc | command awk 'NR>1' | command awk 'BEGIN {FS="  +"}; $5 ~ "^Exit" {print $1 "\n" $(NF)}' | tr ',' '\n'
+            docker ps -a --no-trunc --filter status=exited --format "{{.ID}}\n{{.Names}}" | tr ',' '\n'
         case all
-            docker ps -a --no-trunc | command awk 'NR>1' | command awk 'BEGIN {FS="  +"}; {print $1 "\n" $(NF)}' | tr ',' '\n'
+            docker ps -a --no-trunc --format "{{.ID}}\n{{.Names}}" | tr ',' '\n'
     end
 end
 
 function __fish_print_docker_images --description 'Print a list of docker images'
-    docker images | command awk 'NR>1' | command grep -v '<none>' | command awk '{print $1":"$2}'
+    docker images --format "{{.Repository}}:{{.Tag}}" | command grep -v '<none>'
 end
 
 function __fish_print_docker_repositories --description 'Print a list of docker repositories'
-    docker images | command awk 'NR>1' | command grep -v '<none>' | command awk '{print $1}' | command sort | command uniq
+    docker images --format "{{.Repository}}" | command grep -v '<none>' | command sort | command uniq
 end
 
 # common options


### PR DESCRIPTION
**- What I did**
Fix an issue in the fish shell with autocomplete not working when using a custom formats in config.json.

**- How I did it**
Use a custom format for `docker ps` and `docker images` to guarantee correct items and to replace parsing with `awk`.

**- How to verify it**
Set a custom format in `~/.docker/config.json`:

```
{
  "psFormat": "table {{.Image}}\t{{.ID}}\t{{.Names}}\t{{.Status}}",
  "imagesFormat": "table {{.ID}}\t{{.Tag}}\t{{.Repository}}\t{{.Size}}"
}
```
Test docker autocompletion commands for containers, images, and repositories.



**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Chris Gibson <chris@chrisg.io>