### PR TITLE
Sort service-names in a human readable way

### DIFF
--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
+	"vbom.ml/util/sortorder"
 )
 
 const (
@@ -57,7 +58,7 @@ type byName []*stack
 
 func (n byName) Len() int           { return len(n) }
 func (n byName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
-func (n byName) Less(i, j int) bool { return n[i].Name < n[j].Name }
+func (n byName) Less(i, j int) bool { return sortorder.NaturalLess(n[i].Name, n[j].Name) }
 
 func printTable(out io.Writer, stacks []*stack) {
 	writer := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)

--- a/integration-cli/docker_cli_stack_test.go
+++ b/integration-cli/docker_cli_stack_test.go
@@ -67,6 +67,31 @@ func (s *DockerSwarmSuite) TestStackDeployComposeFile(c *check.C) {
 	c.Assert(out, check.Equals, "NAME  SERVICES\n")
 }
 
+func (s *DockerSwarmSuite) TestStackDeployServiceNameOrder(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+	testStackNames := []string{"test-10", "test-2"}
+	for _, stackName := range testStackNames {
+		stackArgs := []string{
+			"stack", "deploy",
+			"--compose-file", "fixtures/deploy/default.yaml",
+			stackName,
+		}
+		out, err := d.Cmd(stackArgs...)
+		c.Assert(err, checker.IsNil, check.Commentf(out))
+	}
+
+	out, err := d.Cmd("stack", "ls")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, check.Equals, "NAME     SERVICES\n"+"test-2   2\n"+"test-10  2\n")
+	for _, stackName := range testStackNames {
+		_, err := d.Cmd("stack", "rm", stackName)
+		c.Assert(err, checker.IsNil)
+	}
+	out, err = d.Cmd("stack", "ls")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, check.Equals, "NAME  SERVICES\n")
+}
+
 func (s *DockerSwarmSuite) TestStackDeployWithSecretsTwice(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -12,6 +12,7 @@ github.com/kr/pty 5cf931ef8f
 github.com/mattn/go-shellwords v1.0.0
 github.com/tchap/go-patricia v2.2.6
 github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
+vbom.ml/util/sortorder 928aaa586d7718c70f4090ddf83f2b34c16fdc8d
 # forked golang.org/x/net package includes a patch for lazy loading trace templates
 golang.org/x/net c427ad74c6d7a814201695e9ffde0c5d400a7674
 golang.org/x/sys 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9


### PR DESCRIPTION
**- What I did**
Change the way the service-names are displayed in `docker stack ls`.

**- How I did it**
Implemented `IsLess` that defines "xxx--2" as smaller than "xxx--10".


**- How to verify it**
Run unit-tests and integration-tests:
```sh
$ TESTFLAGS='-check.f DockerSwarmSuite.TestStackDeploy*' hack/make.sh test-integration-cli
$ TESTDIRS='cli/command/stack/' TESTFLAGS='-test.run ^TestIsLess*' hack/make.sh test-unit
```
