### PR TITLE
Gracefully stop containers during system reboot/halt

### DIFF
--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -1,7 +1,7 @@
 description "Docker daemon"
 
 start on (filesystem and net-device-up IFACE!=lo)
-stop on runlevel [!2345]
+stop on starting rc RUNLEVEL=[06]
 
 limit nofile 524288 1048576
 
@@ -69,4 +69,11 @@ post-start script
 		done
 		echo "$DOCKER_SOCKET is up"
 	fi
+end script
+
+pre-stop script
+        SHUTDOWN_RUNLEVELS='06'
+        if runlevel | cut -d' ' -f2 | grep -q [$SHUTDOWN_RUNLEVELS]; then
+                docker stop $(docker ps -q)
+        fi
 end script


### PR DESCRIPTION
The current upstart init tries to gracefully kill containers
as is, but doesn't if configured with option 'live-restore'.
This change will run a post-stop script that will only execute
if the runlevel is either 0 (halt) or 6 (reboot).

Fixes #31547



