### PR TITLE
Windows: no pidfile when service

### DIFF
--- a/cmd/dockerd/docker.go
+++ b/cmd/dockerd/docker.go
@@ -74,13 +74,18 @@ func runDaemon(opts daemonOptions) error {
 
 	// On Windows, this may be launching as a service or with an option to
 	// register the service.
-	stop, err := initService(daemonCli)
+	stop, runAsService, err := initService(daemonCli)
 	if err != nil {
 		logrus.Fatal(err)
 	}
 
 	if stop {
 		return nil
+	}
+
+	// If Windows SCM manages the service - no need for PID files
+	if runAsService {
+		opts.daemonConfig.Pidfile = ""
 	}
 
 	err = daemonCli.start(opts)

--- a/cmd/dockerd/service_unsupported.go
+++ b/cmd/dockerd/service_unsupported.go
@@ -6,8 +6,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func initService(daemonCli *DaemonCli) (bool, error) {
-	return false, nil
+func initService(daemonCli *DaemonCli) (bool, bool, error) {
+	return false, false, nil
 }
 
 func installServiceFlags(flags *pflag.FlagSet) {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes https://github.com/docker/docker/issues/30240. 

Fixes https://github.com/docker/docker/pull/31668

@friism @johnstep @thaJeztah 

With this change, the pidfile mechanism is disabled when the daemon is running as a service on Windows. SCM will ensure that only one instance is running at a time.