### PR TITLE
Fix inefficient file paths filter

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2403,7 +2403,7 @@ func (s *DockerSuite) TestBuildDockerignoringBadExclusion(c *check.C) {
 		withFile(".dockerignore", "!\n"),
 	)).Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err:      "Error checking context: 'Illegal exclusion pattern: !",
+		Err:      "Error checking context: 'illegal exclusion pattern: \"!\"",
 	})
 }
 


### PR DESCRIPTION
Previous version compiled `patterns*files*2` regexps to process `.dockerignore`. This version caches reused patterns. 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>

