### PR TITLE
Error on attempting services logs on TTY container

### DIFF
--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -397,6 +397,12 @@ func (c *containerAdapter) deactivateServiceBinding() error {
 }
 
 func (c *containerAdapter) logs(ctx context.Context, options api.LogSubscriptionOptions) (io.ReadCloser, error) {
+	// we can't handle the peculiarities of a TTY-attached container yet
+	conf := c.container.config()
+	if conf != nil && conf.Tty {
+		return nil, errors.New("logs not supported on containers with a TTY attached")
+	}
+
 	reader, writer := io.Pipe()
 
 	apiOptions := &backend.ContainerLogsConfig{

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -262,6 +262,13 @@ func (c *Cluster) ServiceLogs(ctx context.Context, input string, config *backend
 		c.mu.RUnlock()
 		return err
 	}
+	container := service.Spec.Task.GetContainer()
+	if container == nil {
+		return errors.New("service logs only supported for container tasks")
+	}
+	if container.TTY {
+		return errors.New("service logs not supported on tasks with a TTY attached")
+	}
 
 	// set the streams we'll use
 	stdStreams := []swarmapi.LogStream{}


### PR DESCRIPTION

Signed-off-by: Drew Erny <drew.erny@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Errors are better than undefined behavior.

**- What I did**
Error on attempting to do `docker service logs` on a service with TTY-attached containers.

Right now getting service logs from a container with an attached TTY does not work. The behavior was undefined and caused the command to hang and strange messages to occur in the daemon logs.

**- How I did it**
This returns errors, both deep in the swarmkit adapter (to guard against undefined behavior, which is Bad) and in the daemon (to tell users that the thing they're asking for is not possible) by checking if the requested service/container is TTY-attached and returning an error if it is.

**- How to verify it**
Create a service with a TTY attached, try to do logs, see how errors are returned

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://cloud.githubusercontent.com/assets/2367858/23732833/508199be-042a-11e7-93b1-f237ac08918f.png)
