### PR TITLE
Improvement of TestCopier

### DIFF
--- a/daemon/logger/copier_test.go
+++ b/daemon/logger/copier_test.go
@@ -77,6 +77,11 @@ func TestCopier(t *testing.T) {
 		t.Fatal("Copier failed to do its work in 1 second")
 	case <-wait:
 	}
+
+	if c.err != nil {
+		t.Fatal(c.err)
+	}
+
 	dec := json.NewDecoder(&jsonBuf)
 	for {
 		var msg Message


### PR DESCRIPTION
Since `Copier.Run()` won't return any error, it would be confusing to
users if an error is returned when `Decode` in `TestCopier()` but it
actually comes from `Copier.Run()`. So it's better to check if an
error occurred during the process of `Copier.Run()` before `Decode`.

Signed-off-by: Yuanhong Peng <pengyuanhong@huawei.com>