### PR TITLE
Add bash completion for `service create|update --stop-signal`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1704,6 +1704,10 @@ _docker_container_run_and_create() {
 			fi
 			return
 			;;
+		--stop-signal)
+			__docker_complete_signals
+			return
+			;;
 		--storage-opt)
 			COMPREPLY=( $( compgen -W "size" -S = -- "$cur") )
 			__docker_nospace

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2993,6 +2993,7 @@ _docker_service_update_and_create() {
 		--rollback-monitor
 		--rollback-parallelism
 		--stop-grace-period
+		--stop-signal
 		--update-delay
 		--update-failure-action
 		--update-max-failure-ratio
@@ -3129,6 +3130,10 @@ _docker_service_update_and_create() {
 			;;
 		--rollback-failure-action)
 			COMPREPLY=( $( compgen -W "continue pause" -- "$cur" ) )
+			return
+			;;
+		--stop-signal)
+			__docker_complete_signals
 			return
 			;;
 		--update-failure-action)


### PR DESCRIPTION
Ref: #30754
- adds the new option to bash completion of `docker service create|update` using the same completion of signals as `docker container kill --signal` has
- also adds completion of signals to `docker create|run --stop-signal`

Ping @sdurrheimer for zsh completion