### PR TITLE
integration-cli-on-swarm: new CLI flag: -keep-executor

### DIFF
--- a/hack/integration-cli-on-swarm/README.md
+++ b/hack/integration-cli-on-swarm/README.md
@@ -64,3 +64,4 @@ Flags for debugging IT on Swarm itself:
  - `-rand-seed N`: the random seed. This flag is useful for deterministic replaying. By default(0), the timestamp is used.
  - `-filters-file FILE`: the file contains `-check.f` strings. By default, the file is automatically generated.
  - `-dry-run`: skip the actual workload
+ - `keep-executor`: do not auto-remove executor containers, which is used for running privileged programs on Swarm

--- a/hack/integration-cli-on-swarm/agent/worker/worker.go
+++ b/hack/integration-cli-on-swarm/agent/worker/worker.go
@@ -24,6 +24,7 @@ func validImageDigest(s string) bool {
 func xmain() error {
 	workerImageDigest := flag.String("worker-image-digest", "", "Needs to be the digest of this worker image itself")
 	dryRun := flag.Bool("dry-run", false, "Dry run")
+	keepExecutor := flag.Bool("keep-executor", false, "Do not auto-remove executor containers, which is used for running privileged programs on Swarm")
 	flag.Parse()
 	if !validImageDigest(*workerImageDigest) {
 		// Because of issue #29582.
@@ -31,9 +32,9 @@ func xmain() error {
 		// So, `docker run localregistry.example.com/blahblah:latest` fails: `Unable to find image 'localregistry.example.com/blahblah:latest' locally`
 		return fmt.Errorf("worker-image-digest must be a digest, got %q", *workerImageDigest)
 	}
-	executor := privilegedTestChunkExecutor
+	executor := privilegedTestChunkExecutor(!*keepExecutor)
 	if *dryRun {
-		executor = dryTestChunkExecutor
+		executor = dryTestChunkExecutor()
 	}
 	return handle(*workerImageDigest, executor)
 }

--- a/hack/integration-cli-on-swarm/host/compose.go
+++ b/hack/integration-cli-on-swarm/host/compose.go
@@ -16,7 +16,7 @@ version: "3"
 services:
   worker:
     image: "{{.WorkerImage}}"
-    command: ["-worker-image-digest={{.WorkerImageDigest}}", "-dry-run={{.DryRun}}"]
+    command: ["-worker-image-digest={{.WorkerImageDigest}}", "-dry-run={{.DryRun}}", "-keep-executor={{.KeepExecutor}}"]
     networks:
       - net
     volumes:
@@ -57,14 +57,15 @@ volumes:
 `
 
 type composeOptions struct {
-	Replicas    int
-	Chunks      int
-	MasterImage string
-	WorkerImage string
-	Volume      string
-	Shuffle     bool
-	RandSeed    int64
-	DryRun      bool
+	Replicas     int
+	Chunks       int
+	MasterImage  string
+	WorkerImage  string
+	Volume       string
+	Shuffle      bool
+	RandSeed     int64
+	DryRun       bool
+	KeepExecutor bool
 }
 
 type composeTemplateOptions struct {

--- a/hack/integration-cli-on-swarm/host/host.go
+++ b/hack/integration-cli-on-swarm/host/host.go
@@ -41,6 +41,7 @@ func xmain() error {
 	randSeed := flag.Int64("rand-seed", int64(0), "Random seed used for shuffling (0 == curent time)")
 	filtersFile := flag.String("filters-file", "", "Path to optional file composed of `-check.f` filter strings")
 	dryRun := flag.Bool("dry-run", false, "Dry run")
+	keepExecutor := flag.Bool("keep-executor", false, "Do not auto-remove executor containers, which is used for running privileged programs on Swarm")
 	flag.Parse()
 	if *chunks == 0 {
 		*chunks = *replicas
@@ -72,14 +73,15 @@ func xmain() error {
 		workerImageForStack = *pushWorkerImage
 	}
 	compose, err := createCompose("", cli, composeOptions{
-		Replicas:    *replicas,
-		Chunks:      *chunks,
-		MasterImage: defaultMasterImageName,
-		WorkerImage: workerImageForStack,
-		Volume:      defaultVolumeName,
-		Shuffle:     *shuffle,
-		RandSeed:    *randSeed,
-		DryRun:      *dryRun,
+		Replicas:     *replicas,
+		Chunks:       *chunks,
+		MasterImage:  defaultMasterImageName,
+		WorkerImage:  workerImageForStack,
+		Volume:       defaultVolumeName,
+		Shuffle:      *shuffle,
+		RandSeed:     *randSeed,
+		DryRun:       *dryRun,
+		KeepExecutor: *keepExecutor,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

`integration-cli-on-swarm` executes `integration-cli` across Swarm-mode, by running `docker run --privileged --rm -e TESTFLAGS=\"-check.f TestFooBar\" ... hack/make.sh test-integration-cli` from the service, with the bind-mounted socket.

This PR adds a new CLI flag `-keep-executor` to `integration-cli-on-swarm`, which disables `-rm` of `docker run` for debugging purpose.

**- How I did it**



**- How to verify it**

```console
$ make build-integration-cli-on-swarm
$ hack/integration-cli-on-swarm/integration-cli-on-swarm \
  -replicas 30 \
  -shuffle \
  -push-worker-image your-registry.example.com/integration-cli-worker:latest \
  -keep-executor
$ docker ps -a -f label=org.dockerproject.integration-cli-on-swarm                            
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                     PORTS               NAMES
48119bf29e82        e751b3c38d20        "hack/dind hack/ma..."   4 minutes ago       Exited (1) 4 minutes ago                       epic_lumiere
...
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
