### PR TITLE
Fix description of `docker run|create --stop-signal` in help message

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -173,7 +173,7 @@ func addFlags(flags *pflag.FlagSet) *containerOptions {
 	flags.Var(&copts.labelsFile, "label-file", "Read in a line delimited file of labels")
 	flags.BoolVar(&copts.readonlyRootfs, "read-only", false, "Mount the container's root filesystem as read only")
 	flags.StringVar(&copts.restartPolicy, "restart", "no", "Restart policy to apply when a container exits")
-	flags.StringVar(&copts.stopSignal, "stop-signal", signal.DefaultStopSignal, fmt.Sprintf("Signal to stop a container, %v by default", signal.DefaultStopSignal))
+	flags.StringVar(&copts.stopSignal, "stop-signal", signal.DefaultStopSignal, "Signal to stop a container")
 	flags.IntVar(&copts.stopTimeout, "stop-timeout", 0, "Timeout (in seconds) to stop a container")
 	flags.SetAnnotation("stop-timeout", "version", []string{"1.25"})
 	flags.Var(copts.sysctls, "sysctl", "Sysctl options")

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -111,7 +111,7 @@ Options:
                                     The format is `<number><unit>`. `number` must be greater than `0`.
                                     Unit is optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes),
                                     or `g` (gigabytes). If you omit the unit, the system uses bytes.
-      --stop-signal string          Signal to stop a container, SIGTERM by default (default "SIGTERM")
+      --stop-signal string          Signal to stop a container (default "SIGTERM")
       --stop-timeout=10             Timeout (in seconds) to stop a container
       --storage-opt value           Storage driver options for the container (default [])
       --sysctl value                Sysctl options (default map[])

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -122,7 +122,7 @@ Options:
                                     Unit is optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes),
                                     or `g` (gigabytes). If you omit the unit, the system uses bytes.
       --sig-proxy                   Proxy received signals to the process (default true)
-      --stop-signal string          Signal to stop a container, SIGTERM by default (default "SIGTERM")
+      --stop-signal string          Signal to stop a container (default "SIGTERM")
       --stop-timeout=10             Timeout (in seconds) to stop a container
       --storage-opt value           Storage driver options for the container (default [])
       --sysctl value                Sysctl options (default map[])


### PR DESCRIPTION
`docker run` and `docker create` have a strange description for `--stop-signal` in the usage message:

```bash
$ docker create --help | grep stop-signal
      --stop-signal string                    Signal to stop a container, SIGTERM by default (default "SIGTERM")
```
This PR removes the redundant "_, SIGTERM by default_".