### PR TITLE
pkg/system: Set appropriate CFLAGS on Solaris

### DIFF
--- a/pkg/system/meminfo_solaris.go
+++ b/pkg/system/meminfo_solaris.go
@@ -7,6 +7,7 @@ import (
 	"unsafe"
 )
 
+// #cgo CFLAGS: -std=c99
 // #cgo LDFLAGS: -lkstat
 // #include <unistd.h>
 // #include <stdlib.h>


### PR DESCRIPTION
The cgo in `meminfo_solaris.go` initializes variables in for loops, and therefore requires a `-std=c99` `CFLAG` in order to compile (at least on modern SmartOS).

This pull request adds the flag.