### PR TITLE
Fix directive example to match description

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -199,8 +199,8 @@ directive:
 
 ```Dockerfile
 # About my dockerfile
-FROM ImageName
 # directive=value
+FROM ImageName
 ```
 
 The unknown directive is treated as a comment due to not being recognized. In


### PR DESCRIPTION
The Dockerfile reference has an example in the parser directives' section with a description that doesn't match the example. I've reordered the lines to make it match.