### PR TITLE
Add support in plugin config for accessing host ipc and pid namespace.

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1452,6 +1452,10 @@ definitions:
           - Env
           - Args
         properties:
+          DockerVersion:
+            description: "Docker Version used to create the plugin"
+            type: "string"
+            x-nullable: false
           Description:
             type: "string"
             x-nullable: false

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1446,6 +1446,7 @@ definitions:
           - Network
           - Linux
           - PropagatedMount
+          - IpcHost
           - Mounts
           - Env
           - Args
@@ -1512,6 +1513,9 @@ definitions:
                   $ref: "#/definitions/PluginDevice"
           PropagatedMount:
             type: "string"
+            x-nullable: false
+          IpcHost:
+            type: "boolean"
             x-nullable: false
           Mounts:
             type: "array"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1445,6 +1445,7 @@ definitions:
           - WorkDir
           - Network
           - Linux
+          - PidHost
           - PropagatedMount
           - IpcHost
           - Mounts
@@ -1515,6 +1516,9 @@ definitions:
             type: "string"
             x-nullable: false
           IpcHost:
+            type: "boolean"
+            x-nullable: false
+          PidHost:
             type: "boolean"
             x-nullable: false
           Mounts:

--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -42,6 +42,9 @@ type PluginConfig struct {
 	// Required: true
 	Description string `json:"Description"`
 
+	// Docker Version used to create the plugin
+	DockerVersion string `json:"DockerVersion,omitempty"`
+
 	// documentation
 	// Required: true
 	Documentation string `json:"Documentation"`

--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -58,6 +58,10 @@ type PluginConfig struct {
 	// Required: true
 	Interface PluginConfigInterface `json:"Interface"`
 
+	// ipc host
+	// Required: true
+	IpcHost bool `json:"IpcHost"`
+
 	// linux
 	// Required: true
 	Linux PluginConfigLinux `json:"Linux"`

--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -74,6 +74,10 @@ type PluginConfig struct {
 	// Required: true
 	Network PluginConfigNetwork `json:"Network"`
 
+	// pid host
+	// Required: true
+	PidHost bool `json:"PidHost"`
+
 	// propagated mount
 	// Required: true
 	PropagatedMount string `json:"PropagatedMount"`

--- a/docs/extend/config.md
+++ b/docs/extend/config.md
@@ -115,6 +115,9 @@ Config provides the base accessible fields for working with V0 plugin format
 
 	  options of the mount.
 
+- **`ipchost`** *boolean*
+   Access to host ipc namespace.
+
 - **`propagatedMount`** *string*
 
    path to be mounted as rshared, so that mounts under that path are visible to docker. This is useful for volume plugins.

--- a/docs/extend/config.md
+++ b/docs/extend/config.md
@@ -117,6 +117,8 @@ Config provides the base accessible fields for working with V0 plugin format
 
 - **`ipchost`** *boolean*
    Access to host ipc namespace.
+- **`pidhost`** *boolean*
+   Access to host pid namespace.
 
 - **`propagatedMount`** *string*
 

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -150,6 +150,13 @@ func computePrivileges(c types.PluginConfig) (types.PluginPrivileges, error) {
 			Value:       []string{c.Network.Type},
 		})
 	}
+	if c.IpcHost {
+		privileges = append(privileges, types.PluginPrivilege{
+			Name:        "host ipc namespace",
+			Description: "allow access to host ipc namespace",
+			Value:       []string{"true"},
+		})
+	}
 	for _, mount := range c.Mounts {
 		if mount.Source != nil {
 			privileges = append(privileges, types.PluginPrivilege{

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/docker/distribution"
 	progressutils "github.com/docker/docker/distribution/utils"
 	"github.com/docker/docker/distribution/xfer"
+	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/chrootarchive"
@@ -757,6 +758,8 @@ func (pm *Manager) CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, 
 		Type:    "layers",
 		DiffIds: []string{layerDigester.Digest().String()},
 	}
+
+	config.DockerVersion = dockerversion.Version
 
 	configBlob, err := pm.blobStore.New()
 	if err != nil {

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -157,6 +157,13 @@ func computePrivileges(c types.PluginConfig) (types.PluginPrivileges, error) {
 			Value:       []string{"true"},
 		})
 	}
+	if c.PidHost {
+		privileges = append(privileges, types.PluginPrivilege{
+			Name:        "host pid namespace",
+			Description: "allow access to host pid namespace",
+			Value:       []string{"true"},
+		})
+	}
 	for _, mount := range c.Mounts {
 		if mount.Source != nil {
 			privileges = append(privileges, types.PluginPrivilege{

--- a/plugin/v2/plugin_linux.go
+++ b/plugin/v2/plugin_linux.go
@@ -61,6 +61,10 @@ func (p *Plugin) InitSpec(execRoot string) (*specs.Spec, error) {
 			})
 	}
 
+	if p.PluginObj.Config.IpcHost {
+		oci.RemoveNamespace(&s, specs.NamespaceType("ipc"))
+	}
+
 	for _, mnt := range mounts {
 		m := specs.Mount{
 			Destination: mnt.Destination,

--- a/plugin/v2/plugin_linux.go
+++ b/plugin/v2/plugin_linux.go
@@ -60,6 +60,9 @@ func (p *Plugin) InitSpec(execRoot string) (*specs.Spec, error) {
 				Options:     []string{"rbind", "ro"},
 			})
 	}
+	if p.PluginObj.Config.PidHost {
+		oci.RemoveNamespace(&s, specs.NamespaceType("pid"))
+	}
 
 	if p.PluginObj.Config.IpcHost {
 		oci.RemoveNamespace(&s, specs.NamespaceType("ipc"))


### PR DESCRIPTION
Plugins might need access to host ipc and pid namespaces. A good usecase is
a volume plugin running iscsi multipath commands that need access to
host kernel locks.
Tested with a custom plugin (aragunathan/global-net-plugin-full) that's
built with `"ipchost" : true` and `"pidhost": true` in config.json. Observed using
`readlink /proc/self/ns/ipc` and `readlink /proc/self/ns/pid`that plugin and host 
have the same ns.

Signed-off-by: Anusha Ragunathan <anusha.ragunathan@docker.com>