### PR TITLE
cluster: Fix shadowed resp variable

### DIFF
--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -193,7 +193,7 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec typ
 			}
 		}
 
-		resp := &apitypes.ServiceUpdateResponse{}
+		resp = &apitypes.ServiceUpdateResponse{}
 
 		// pin image by digest
 		if os.Getenv("DOCKER_SERVICE_PREFER_OFFLINE_IMAGE") != "1" {


### PR DESCRIPTION
The response would never reach the client because it was being redeclared in the current scope.

Related to #30843

Fixes #31716

cc @nishanttotla @vdemeester