### PR TITLE
Always HEAD blobs at least once during pushes

### DIFF
--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -283,8 +283,8 @@ func (pd *v2PushDescriptor) Upload(ctx context.Context, progressOutput progress.
 	// Do we have any metadata associated with this layer's DiffID?
 	v2Metadata, err := pd.v2MetadataService.GetMetadata(diffID)
 	if err == nil {
-		// check for blob existence in the target repository if we have a mapping with it
-		descriptor, exists, err := pd.layerAlreadyExists(ctx, progressOutput, diffID, false, 1, v2Metadata)
+		// check for blob existence in the target repository
+		descriptor, exists, err := pd.layerAlreadyExists(ctx, progressOutput, diffID, true, 1, v2Metadata)
 		if exists || err != nil {
 			return descriptor, err
 		}


### PR DESCRIPTION
Signed-off-by: Jon Johnson <jonjohnson@google.com>

**- What I did**

Change push behavior to always HEAD each blob before trying to mount. The docker client used to do this, but that changed in #26564. This causes a lot of unnecessary blob uploads if the blobs already exist in the target repository.

**- How I did it**

Set checkOtherRepositories to true for the first layerAlreadyExists check.

**- How to verify it**

Push an image to a registry, there should be a HEAD request for each blob before trying to mount.

**- Description for the changelog**
Always check to see if blobs exists before pushing.
