### PR TITLE
Windows: Balk on --privileged

### DIFF
--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -55,24 +55,30 @@ func DecodeContainerConfig(src io.Reader) (*container.Config, *container.HostCon
 
 	// Certain parameters need daemon-side validation that cannot be done
 	// on the client, as only the daemon knows what is valid for the platform.
-	if err := ValidateNetMode(w.Config, hc); err != nil {
+	if err := validateNetMode(w.Config, hc); err != nil {
 		return nil, nil, nil, err
 	}
 
 	// Validate isolation
-	if err := ValidateIsolation(hc); err != nil {
+	if err := validateIsolation(hc); err != nil {
 		return nil, nil, nil, err
 	}
 
 	// Validate QoS
-	if err := ValidateQoS(hc); err != nil {
+	if err := validateQoS(hc); err != nil {
 		return nil, nil, nil, err
 	}
 
 	// Validate Resources
-	if err := ValidateResources(hc, sysinfo.New(true)); err != nil {
+	if err := validateResources(hc, sysinfo.New(true)); err != nil {
 		return nil, nil, nil, err
 	}
+
+	// Validate Privileged
+	if err := validatePrivileged(hc); err != nil {
+		return nil, nil, nil, err
+	}
+
 	return w.Config, hc, w.NetworkingConfig, nil
 }
 

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -35,9 +35,9 @@ func SetDefaultNetModeIfBlank(hc *container.HostConfig) {
 	}
 }
 
-// ValidateNetContainerMode ensures that the various combinations of requested
+// validateNetContainerMode ensures that the various combinations of requested
 // network settings wrt container mode are valid.
-func ValidateNetContainerMode(c *container.Config, hc *container.HostConfig) error {
+func validateNetContainerMode(c *container.Config, hc *container.HostConfig) error {
 	// We may not be passed a host config, such as in the case of docker commit
 	if hc == nil {
 		return nil

--- a/runconfig/hostconfig_solaris.go
+++ b/runconfig/hostconfig_solaris.go
@@ -16,26 +16,31 @@ func IsPreDefinedNetwork(network string) bool {
 	return false
 }
 
-// ValidateNetMode ensures that the various combinations of requested
+// validateNetMode ensures that the various combinations of requested
 // network settings are valid.
-func ValidateNetMode(c *container.Config, hc *container.HostConfig) error {
+func validateNetMode(c *container.Config, hc *container.HostConfig) error {
 	// We may not be passed a host config, such as in the case of docker commit
 	return nil
 }
 
-// ValidateIsolation performs platform specific validation of the
+// validateIsolation performs platform specific validation of the
 // isolation level in the hostconfig structure.
 // This setting is currently discarded for Solaris so this is a no-op.
-func ValidateIsolation(hc *container.HostConfig) error {
+func validateIsolation(hc *container.HostConfig) error {
 	return nil
 }
 
-// ValidateQoS performs platform specific validation of the QoS settings
-func ValidateQoS(hc *container.HostConfig) error {
+// validateQoS performs platform specific validation of the QoS settings
+func validateQoS(hc *container.HostConfig) error {
 	return nil
 }
 
-// ValidateResources performs platform specific validation of the resource settings
-func ValidateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
+// validateResources performs platform specific validation of the resource settings
+func validateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
+	return nil
+}
+
+// validatePrivileged performs platform specific validation of the Privileged setting
+func validatePrivileged(hc *container.HostConfig) error {
 	return nil
 }

--- a/runconfig/hostconfig_test.go
+++ b/runconfig/hostconfig_test.go
@@ -276,7 +276,7 @@ func TestValidateResources(t *testing.T) {
 		si.CPURealtimePeriod = rt.SysInfoCPURealtimePeriod
 		si.CPURealtimeRuntime = rt.SysInfoCPURealtimeRuntime
 
-		if err := ValidateResources(&hc, &si); (err != nil) != rt.ErrorExpected {
+		if err := validateResources(&hc, &si); (err != nil) != rt.ErrorExpected {
 			t.Fatal(rt.FailureMsg, err)
 		}
 	}

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -22,15 +22,15 @@ func IsPreDefinedNetwork(network string) bool {
 	return n.IsBridge() || n.IsHost() || n.IsNone() || n.IsDefault() || network == "ingress"
 }
 
-// ValidateNetMode ensures that the various combinations of requested
+// validateNetMode ensures that the various combinations of requested
 // network settings are valid.
-func ValidateNetMode(c *container.Config, hc *container.HostConfig) error {
+func validateNetMode(c *container.Config, hc *container.HostConfig) error {
 	// We may not be passed a host config, such as in the case of docker commit
 	if hc == nil {
 		return nil
 	}
 
-	err := ValidateNetContainerMode(c, hc)
+	err := validateNetContainerMode(c, hc)
 	if err != nil {
 		return err
 	}
@@ -46,10 +46,10 @@ func ValidateNetMode(c *container.Config, hc *container.HostConfig) error {
 	return nil
 }
 
-// ValidateIsolation performs platform specific validation of
+// validateIsolation performs platform specific validation of
 // isolation in the hostconfig structure. Linux only supports "default"
 // which is LXC container isolation
-func ValidateIsolation(hc *container.HostConfig) error {
+func validateIsolation(hc *container.HostConfig) error {
 	// We may not be passed a host config, such as in the case of docker commit
 	if hc == nil {
 		return nil
@@ -60,8 +60,8 @@ func ValidateIsolation(hc *container.HostConfig) error {
 	return nil
 }
 
-// ValidateQoS performs platform specific validation of the QoS settings
-func ValidateQoS(hc *container.HostConfig) error {
+// validateQoS performs platform specific validation of the QoS settings
+func validateQoS(hc *container.HostConfig) error {
 	// We may not be passed a host config, such as in the case of docker commit
 	if hc == nil {
 		return nil
@@ -77,9 +77,9 @@ func ValidateQoS(hc *container.HostConfig) error {
 	return nil
 }
 
-// ValidateResources performs platform specific validation of the resource settings
+// validateResources performs platform specific validation of the resource settings
 // cpu-rt-runtime and cpu-rt-period can not be greater than their parent, cpu-rt-runtime requires sys_nice
-func ValidateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
+func validateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
 	// We may not be passed a host config, such as in the case of docker commit
 	if hc == nil {
 		return nil
@@ -96,5 +96,10 @@ func ValidateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
 	if hc.Resources.CPURealtimePeriod != 0 && hc.Resources.CPURealtimeRuntime != 0 && hc.Resources.CPURealtimeRuntime > hc.Resources.CPURealtimePeriod {
 		return fmt.Errorf("invalid --cpu-rt-runtime: rt runtime cannot be higher than rt period")
 	}
+	return nil
+}
+
+// validatePrivileged performs platform specific validation of the Privileged setting
+func validatePrivileged(hc *container.HostConfig) error {
 	return nil
 }

--- a/runconfig/hostconfig_windows.go
+++ b/runconfig/hostconfig_windows.go
@@ -18,14 +18,14 @@ func IsPreDefinedNetwork(network string) bool {
 	return !container.NetworkMode(network).IsUserDefined()
 }
 
-// ValidateNetMode ensures that the various combinations of requested
+// validateNetMode ensures that the various combinations of requested
 // network settings are valid.
-func ValidateNetMode(c *container.Config, hc *container.HostConfig) error {
+func validateNetMode(c *container.Config, hc *container.HostConfig) error {
 	if hc == nil {
 		return nil
 	}
 
-	err := ValidateNetContainerMode(c, hc)
+	err := validateNetContainerMode(c, hc)
 	if err != nil {
 		return err
 	}
@@ -37,10 +37,10 @@ func ValidateNetMode(c *container.Config, hc *container.HostConfig) error {
 	return nil
 }
 
-// ValidateIsolation performs platform specific validation of the
+// validateIsolation performs platform specific validation of the
 // isolation in the hostconfig structure. Windows supports 'default' (or
 // blank), 'process', or 'hyperv'.
-func ValidateIsolation(hc *container.HostConfig) error {
+func validateIsolation(hc *container.HostConfig) error {
 	// We may not be passed a host config, such as in the case of docker commit
 	if hc == nil {
 		return nil
@@ -51,23 +51,34 @@ func ValidateIsolation(hc *container.HostConfig) error {
 	return nil
 }
 
-// ValidateQoS performs platform specific validation of the Qos settings
-func ValidateQoS(hc *container.HostConfig) error {
+// validateQoS performs platform specific validation of the Qos settings
+func validateQoS(hc *container.HostConfig) error {
 	return nil
 }
 
-// ValidateResources performs platform specific validation of the resource settings
-func ValidateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
+// validateResources performs platform specific validation of the resource settings
+func validateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
 	// We may not be passed a host config, such as in the case of docker commit
 	if hc == nil {
 		return nil
 	}
-
 	if hc.Resources.CPURealtimePeriod != 0 {
 		return fmt.Errorf("invalid --cpu-rt-period: Windows does not support this feature")
 	}
 	if hc.Resources.CPURealtimeRuntime != 0 {
 		return fmt.Errorf("invalid --cpu-rt-runtime: Windows does not support this feature")
+	}
+	return nil
+}
+
+// validatePrivileged performs platform specific validation of the Privileged setting
+func validatePrivileged(hc *container.HostConfig) error {
+	// We may not be passed a host config, such as in the case of docker commit
+	if hc == nil {
+		return nil
+	}
+	if hc.Privileged {
+		return fmt.Errorf("invalid --privileged: Windows does not support this feature")
 	}
 	return nil
 }

--- a/runconfig/hostconfig_windows_test.go
+++ b/runconfig/hostconfig_windows_test.go
@@ -1,0 +1,17 @@
+// +build windows
+
+package runconfig
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+)
+
+func TestValidatePrivileged(t *testing.T) {
+	expected := "invalid --privileged: Windows does not support this feature"
+	err := validatePrivileged(&container.HostConfig{Privileged: true})
+	if err == nil || err.Error() != expected {
+		t.Fatalf("Expected %s", expected)
+	}
+}


### PR DESCRIPTION
Signed-off-by: John Howard (VM) <jhoward@ntdev.microsoft.com>

Throws an error if privileged mode is attempted on Windows where the platform does not support it. Fixes https://github.com/docker/docker/issues/31059 @thaJeztah 

It also updates the `Validate*` functions to not be exported - they are now `validate*`