### PR TITLE
IGNORE: Investigating an intermittent CI testing panic

### DIFF
--- a/integration-cli/environment/clean.go
+++ b/integration-cli/environment/clean.go
@@ -43,8 +43,12 @@ func unpauseAllContainers(t testingT, dockerBinary string) {
 }
 
 func getPausedContainers(t testingT, dockerBinary string) []string {
+	fmt.Println("--> getPausedContainers")
 	result := icmd.RunCommand(dockerBinary, "ps", "-f", "status=paused", "-q", "-a")
+	fmt.Println("result ", result)
 	result.Assert(t, icmd.Success)
+
+	// Is the bug that result.Assert doesn't return???
 	return strings.Fields(result.Combined())
 }
 

--- a/pkg/testutil/cmd/command.go
+++ b/pkg/testutil/cmd/command.go
@@ -59,9 +59,13 @@ func (r *Result) Assert(t testingT, exp Expected) {
 	if err == nil {
 		return
 	}
-
-	_, file, line, _ := runtime.Caller(1)
-	t.Fatalf("at %s:%d\n%s", filepath.Base(file), line, err.Error())
+	fmt.Println("**** Assert failed")
+	_, file, line, ok := runtime.Caller(1)
+	if ok {
+		t.Fatalf("at %s:%d\n%s", filepath.Base(file), line, err.Error())
+	} else {
+		t.Fatalf("Error (no file/line info)\n%s", err.Error())
+	}
 }
 
 // Compare returns a formatted error with the command, stdout, stderr, exit


### PR DESCRIPTION
Signed-off-by: John Howard (VM) <jhoward@ntdev.microsoft.com>

IGNORE IGNORE IGNORE. Trying to get to the bottom of very occasional CI errors which have outputs similar to below

```
01:03:21.964 SKIP: docker_cli_run_test.go:2362: DockerSuite.TestRunModeIpcContainerNotRunning (unmatched requirement DaemonIsLinux)
01:03:22.098 SKIP: docker_cli_run_test.go:2289: DockerSuite.TestRunModeIpcHost (unmatched requirement DaemonIsLinux)
01:03:22.235 SKIP: docker_cli_run_test.go:3541: DockerSuite.TestRunModeNetContainerHostname (unmatched requirement DaemonIsLinux)
01:03:22.339 
01:03:22.339 ----------------------------------------------------------------------
01:03:22.339 FAIL: check_test.go:101: DockerSuite.TearDownTest
01:03:22.339 
01:03:22.339 check_test.go:102:
01:03:22.339     testEnv.Clean(c, dockerBinary)
01:03:22.339 c:/gopath/src/github.com/docker/docker/pkg/testutil/cmd/command.go:64:
01:03:22.340     t.Fatalf("at %s:%d\n%s", filepath.Base(file), line, err.Error())
01:03:22.340 ... Error: at clean.go:41
01:03:22.340 
01:03:22.340 Command: d:\CI\CI-6f733c006\binary\docker.exe unpause runtime: failed to create new OS thread (have 6 already; errno=5) fatal error: runtime.newosproc
01:03:22.340 ExitCode: 1, Error: exit status 1
01:03:22.340 Stdout: 
01:03:22.340 Stderr: Error response from daemon: No such container: runtime:
01:03:22.340 Error response from daemon: No such container: failed
01:03:22.340 Error response from daemon: No such container: to
01:03:22.340 Error response from daemon: No such container: create
01:03:22.341 Error response from daemon: No such container: new
01:03:22.341 Error response from daemon: No such container: OS
01:03:22.341 Error response from daemon: No such container: thread
01:03:22.341 Error response from daemon: No such container: (have
01:03:22.341 Error response from daemon: No such container: 6
01:03:22.341 Error response from daemon: No such container: already;
01:03:22.341 Error response from daemon: No such container: errno=5)
01:03:22.341 Error response from daemon: No such container: fatal
01:03:22.341 Error response from daemon: No such container: error:
01:03:22.341 Error response from daemon: No such container: runtime.newosproc
01:03:22.342 
01:03:22.342 
01:03:22.342 Failures:
01:03:22.342 ExitCode was 1 expected 0
01:03:22.342 Expected no error
01:03:22.342 
01:03:22.342 
01:03:22.342 
01:03:22.342 ----------------------------------------------------------------------
01:03:22.342 PANIC: docker_cli_run_test.go:2375: DockerSuite.TestRunModePIDContainer
01:03:22.342 
01:03:22.342 ... Panic: Fixture has panicked (see related PANIC)
01:03:22.342 
01:03:22.342 ----------------------------------------------------------------------
01:03:22.342 MISS: docker_cli_run_test.go:2400: DockerSuite.TestRunModePIDContainerNotExists
01:03:22.343 MISS: docker_cli_run_test.go:2409: DockerSuite.TestRunModePIDContainerNotRunning
01:03:22.343 MISS: docker_cli_run_test.go:2467: DockerSuite.TestRunModePIDHost

```