### PR TITLE
Fix stringer in Result (pkg\testutil\cmd)

### DIFF
--- a/pkg/testutil/cmd/command.go
+++ b/pkg/testutil/cmd/command.go
@@ -59,9 +59,12 @@ func (r *Result) Assert(t testingT, exp Expected) {
 	if err == nil {
 		return
 	}
-
-	_, file, line, _ := runtime.Caller(1)
-	t.Fatalf("at %s:%d\n%s", filepath.Base(file), line, err.Error())
+	_, file, line, ok := runtime.Caller(1)
+	if ok {
+		t.Fatalf("at %s:%d - %s", filepath.Base(file), line, err.Error())
+	} else {
+		t.Fatalf("(no file/line info) - %s", err.Error())
+	}
 }
 
 // Compare returns a formatted error with the command, stdout, stderr, exit
@@ -123,10 +126,11 @@ func (r *Result) String() string {
 	}
 
 	return fmt.Sprintf(`
-Command: %s
-ExitCode: %d%s, Error: %s
-Stdout: %v
-Stderr: %v
+Command:  %s
+ExitCode: %d%s
+Error:    %v
+Stdout:   %v
+Stderr:   %v
 `,
 		strings.Join(r.Cmd.Args, " "),
 		r.ExitCode,


### PR DESCRIPTION
Signed-off-by: John Howard (VM) <jhoward@ntdev.microsoft.com>

@vdemeester Fixes the error output [and aligns (I'm just like that 😇)]. The `%s` for error should have been a `%v`.

Before:

```
00:14:51.046 Command: d:\CI\CI-0b8f46bb6\binary\docker.exe ps -f status=paused -q -a
00:14:51.046 ExitCode: 0, Error: %!s(<nil>)
00:14:51.046 Stdout: 
00:14:51.046 Stderr: 
```

After:

```
Command:  e:\go\src\github.com\docker\docker\bundles\docker.exe ps -f status=paused -q -a
ExitCode: 0
Error:    <nil>
Stdout:
Stderr:
```
