### PR TITLE
The variable heartbeat might be 0

### DIFF
--- a/daemon/discovery/discovery.go
+++ b/daemon/discovery/discovery.go
@@ -81,8 +81,7 @@ func discoveryOpts(clusterOpts map[string]string) (time.Duration, time.Duration,
 		ttl = time.Duration(t) * time.Second
 
 		if _, ok := clusterOpts["discovery.heartbeat"]; !ok {
-			h := int(t / defaultDiscoveryTTLFactor)
-			heartbeat = time.Duration(h) * time.Second
+			heartbeat = time.Duration(t) * time.Second / time.Duration(defaultDiscoveryTTLFactor)
 		}
 
 		if ttl <= heartbeat {

--- a/daemon/discovery/discovery_test.go
+++ b/daemon/discovery/discovery_test.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -84,6 +85,13 @@ func TestDiscoveryOpts(t *testing.T) {
 	expected = 30 * time.Second / defaultDiscoveryTTLFactor
 	if heartbeat != expected {
 		t.Fatalf("Heartbeat - Expected : %v, Actual : %v", expected, heartbeat)
+	}
+
+	discaveryTTL := fmt.Sprintf("%d", defaultDiscoveryTTLFactor-1)
+	clusterOpts = map[string]string{"discovery.ttl": discaveryTTL}
+	heartbeat, ttl, err = discoveryOpts(clusterOpts)
+	if err == nil && heartbeat == 0 {
+		t.Fatal("discovery.heartbeat must be positive")
 	}
 
 	clusterOpts = map[string]string{}


### PR DESCRIPTION
Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>

if we don't set `discovery.heartbeat`, and set `discovery.ttl` < `defaultDiscoveryTTLFactor`, then heartbeat wil be 0.
For example, `int(2/3)` = 0 