### PR TITLE
31358: Add warning in document and docker info for nproc

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/cli/debug"
 	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/templates"
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
@@ -280,6 +281,9 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 	if info.OSType != "windows" {
 		printStorageDriverWarnings(dockerCli, info)
 
+		if kernel.CheckKernelVersionNproc() {
+			fmt.Fprintln(dockerCli.Err(), "WARNING: nproc is only available in Linux kernel 4.3+")
+		}
 		if !info.MemoryLimit {
 			fmt.Fprintln(dockerCli.Err(), "WARNING: No memory limit support")
 		}

--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -14,6 +14,12 @@ respawn
 kill timeout 20
 
 pre-start script
+        if ! printf "%s" "$DOCKER_OPTS" | grep -qE -e '-H|--host'; then
+		DOCKER_SOCKET=/var/run/docker.sock
+	else
+                DOCKER_SOCKET=$(printf "%s" "$DOCKER_OPTS" | grep -oP -e '(-H|--host)\W*unix://\K(\S+)' | sed 1q)
+        fi
+        test -d "$DOCKER_SOCKET" && rmdir "$DOCKER_SOCKET"`
 	# see also https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
 	if grep -v '^#' /etc/fstab | grep -q cgroup \
 		|| [ ! -e /proc/cgroups ] \

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -685,6 +685,7 @@ $ docker run -d -u daemon --ulimit nproc=3 busybox top
 The 4th container fails and reports "[8] System error: resource temporarily unavailable" error.
 This fails because the caller set `nproc=3` resulting in the first three containers using up
 the three processes quota set for the `daemon` user.
+WARNING: Feature nproc limit is only available in Linux kernel 4.3+
 
 ### Stop container with signal (--stop-signal)
 

--- a/pkg/parsers/kernel/kernel.go
+++ b/pkg/parsers/kernel/kernel.go
@@ -7,6 +7,8 @@ package kernel
 import (
 	"errors"
 	"fmt"
+
+	"github.com/Sirupsen/logrus"
 )
 
 // VersionInfo holds information about the kernel.
@@ -43,6 +45,24 @@ func CompareKernelVersion(a, b VersionInfo) int {
 	}
 
 	return 0
+}
+
+// CompareKernelVersionNproc checks if current is 4.10+ to check nproc feature
+func CompareKernelVersionNproc(a VersionInfo) bool {
+	if a.Kernel <= 3 || (a.Kernel >= 4 && a.Major < 3) {
+		return true
+	}
+	return false
+}
+
+// CheckKernelVersionNproc checks if current kernel is 4.10+.
+func CheckKernelVersionNproc() bool {
+	if v, err := GetKernelVersion(); err != nil {
+		logrus.Warnf("error getting kernel version: %s", err)
+	} else if CompareKernelVersionNproc(*v) {
+		return true
+	}
+	return false
 }
 
 // ParseRelease parses a string and creates a VersionInfo based on it.

--- a/pkg/parsers/kernel/kernel_windows.go
+++ b/pkg/parsers/kernel/kernel_windows.go
@@ -67,3 +67,8 @@ func GetKernelVersion() (*VersionInfo, error) {
 
 	return KVI, nil
 }
+
+// CheckKernelVersionNproc checks if current kernel is 4.10+.
+func CheckKernelVersionNproc() bool {
+	return false
+}


### PR DESCRIPTION
Signed-off-by: dattatrayakumbhar <dattatraya.kumbhar@gslab.com>
"closes #31358"

**- What I did**
Added warning for nproc in document and docker info command output as nproc feature support is only available in Linux kernel 4.3+

**- How I did it**
Added changes in cli/command/system/info.go for docker info command.
Added changes in docs/reference/commandline/run.md for document.

**- How to verify it**
1. Clone latest repository and take this PR.
2. Run dockerd service and verify docker info command.
   It should have warning that nproc feature is only available for Linux kernel 4.3+.