### PR TITLE
Fix markdown in references for Kramdown

### DIFF
--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -74,7 +74,7 @@ The currently supported filters are:
 * id (network's id)
 * label (`label=<key>` or `label=<key>=<value>`)
 * name (network's name)
-* type (custom|builtin)
+* type (`custom|builtin`)
 
 #### Driver
 

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -37,7 +37,7 @@ Options:
                         - network=(<network-id>|<network-name>)
                         - publish=(<port>[/<proto>]|<startport-endport>/[<proto>])
                         - since=(<container-name>|<container-id>)
-                        - status=(created|restarting|removing|running|paused|exited) 
+                        - status=(created|restarting|removing|running|paused|exited)
                         - volume=(<volume name>|<mount point destination>)
       --format string   Pretty-print containers using a Go template
       --help            Print usage
@@ -86,11 +86,11 @@ The currently supported filters are:
 * label (`label=<key>` or `label=<key>=<value>`)
 * name (container's name)
 * exited (int - the code of exited containers. Only useful with `--all`)
-* status (created|restarting|running|removing|paused|exited|dead)
+* status (`created|restarting|running|removing|paused|exited|dead`)
 * ancestor (`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`) - filters containers that were created from the given image or a descendant.
 * before (container's id or name) - filters containers created before given id or name
 * since (container's id or name) - filters containers created since given id or name
-* isolation (default|process|hyperv)   (Windows daemon only)
+* isolation (`default|process|hyperv`)   (Windows daemon only)
 * volume (volume name or mount point) - filters containers that mount volumes.
 * network (network id or name) - filters containers connected to the provided network
 * health (starting|healthy|unhealthy|none) - filters containers based on healthcheck status

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -259,12 +259,69 @@ For more information about named volumes, see
 The following table describes options which apply to both bind-mounts and named
 volumes in a service:
 
-| Option                                   | Required                  | Description
-|:-----------------------------------------|:--------------------------|:-----------------------------------------------------------------------------------------
-| **type**                                 |                           | The type of mount, can be either `volume`, `bind`, or `tmpfs`. Defaults to `volume` if no type is specified.<ul><li>`volume`: mounts a [managed volume](volume_create.md) into the container.</li><li>`bind`: bind-mounts a directory or file from the host into the container.</li><li>`tmpfs`: mount a tmpfs in the container</li></ul>
-| **src** or **source**                    | for `type=bind`&nbsp;only | <ul><li>`type=volume`: `src` is an optional way to specify the name of the volume (for example, `src=my-volume`). If the named volume does not exist, it is automatically created. If no `src` is specified, the volume is assigned a random name which is guaranteed to be unique on the host, but may not be unique cluster-wide. A randomly-named volume has the same lifecycle as its container and is destroyed when the *container* is destroyed (which is upon `service update`, or when scaling or re-balancing the service).</li><li>`type=bind`: `src` is required, and specifies an absolute path to the file or directory to bind-mount (for example, `src=/path/on/host/`).  An error is produced if the file or directory does not exist.</li><li>`type=tmpfs`: `src` is not supported.</li></ul>
-| **dst** or **destination** or **target** | yes                       | Mount path inside the container, for example `/some/path/in/container/`. If the path does not exist in the container's filesystem, the Engine creates a directory at the specified location before mounting the volume or bind-mount.
-| **readonly** or **ro**                   |                           | The Engine mounts binds and volumes `read-write` unless `readonly` option is given when mounting the bind or volume.<br /><br /><ul><li>`true` or `1` or no value: Mounts the bind or volume read-only.</li><li>`false` or `0`: Mounts the bind or volume read-write.</li></ul>
+<table>
+  <tr>
+    <th>Option</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><b>types</b></td>
+    <td></td>
+    <td>
+      <p>The type of mount, can be either <tt>volume</tt>, <tt>bind</tt>, or <tt>tmpfs</tt>. Defaults to <tt>volume</tt> if no type is specified.
+      <ul>
+        <li><tt>volume</tt>: mounts a [managed volume](volume_create.md) into the container.</li>
+        <li><tt>bind</tt>: bind-mounts a directory or file from the host into the container.</li>
+        <li><tt>tmpfs</tt>: mount a tmpfs in the container</li>
+      </ul></p>
+    </td>
+  </tr>
+  <tr>
+    <td><b>src</b> or <b>source</b></td>
+    <td>for <tt>type=bind</tt> only></td>
+    <td>
+      <ul>
+        <li>
+         <tt>type=volume</tt>: <tt>src</tt> is an optional way to specify the name of the volume (for example, <tt>src=my-volume</tt>).
+          If the named volume does not exist, it is automatically created. If no <tt>src</tt> is specified, the volume is
+          assigned a random name which is guaranteed to be unique on the host, but may not be unique cluster-wide.
+          A randomly-named volume has the same lifecycle as its container and is destroyed when the <i>container</i>
+          is destroyed (which is upon <tt>service update</tt>, or when scaling or re-balancing the service)
+        </li>
+        <li>
+          <tt>type=bind</tt>: <tt>src</tt> is required, and specifies an absolute path to the file or directory to bind-mount
+          (for example, <tt>src=/path/on/host/</tt>). An error is produced if the file or directory does not exist.
+        </li>
+        <li>
+          <tt>type=tmpfs</tt>: <tt>src</tt> is not supported.
+        </li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td><p><b>dst</b> or <b>destination</b> or <b>target</b></p></td>
+    <td>yes</td>
+    <td>
+      <p>Mount path inside the container, for example <tt>/some/path/in/container/</tt>.
+      If the path does not exist in the container's filesystem, the Engine creates
+      a directory at the specified location before mounting the volume or bind-mount.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><p><b>readonly</b> or <b>ro</b></p></td>
+    <td></td>
+    <td>
+      <p>The Engine mounts binds and volumes <tt>read-write</tt> unless <tt>readonly</tt> option
+      is given when mounting the bind or volume.
+      <ul>
+        <li><tt>true</tt> or <tt>1</tt> or no value: Mounts the bind or volume read-only.</li>
+        <li><tt>false</tt> or <tt>0</tt>: Mounts the bind or volume read-write.</li>
+      </ul></p>
+    </td>
+  </tr>
+</table>
+
 
 #### Bind Propagation
 
@@ -304,22 +361,84 @@ For more information about bind propagation, see the
 [Linux kernel documentation for shared subtree](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt).
 
 #### Options for Named Volumes
+
 The following options can only be used for named volumes (`type=volume`);
 
-| Option                | Description
-|:----------------------|:--------------------------------------------------------------------------------------------------------------------
-| **volume-driver**     | Name of the volume-driver plugin to use for the volume. Defaults to ``"local"``, to use the local volume driver to create the volume if the volume does not exist.
-| **volume-label**      | One or more custom metadata ("labels") to apply to the volume upon creation. For example, `volume-label=mylabel=hello-world,my-other-label=hello-mars`. For more information about labels, refer to [apply custom metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/).
-| **volume-nocopy**     | By default, if you attach an empty volume to a container, and files or directories already existed at the mount-path in the container (`dst`), the Engine copies those files and directories into the volume, allowing the host to access them. Set `volume-nocopy` to disables copying files from the container's filesystem to the volume and mount the empty volume.<br /><br />A value is optional:<ul><li>`true` or `1`: Default if you do not provide a value. Disables copying.</li><li>`false` or `0`: Enables copying.</li></ul>
-| **volume-opt**        | Options specific to a given volume driver, which will be passed to the driver when creating the volume. Options are provided as a comma-separated list of key/value pairs, for example, `volume-opt=some-option=some-value,some-other-option=some-other-value`. For available options for a given driver, refer to that driver's documentation.
+
+<table>
+  <tr>
+    <th>Option</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><b>volume-driver</b></td>
+    <td>
+      <p>Name of the volume-driver plugin to use for the volume. Defaults to
+      <tt>"local"</tt>, to use the local volume driver to create the volume if the
+      volume does not exist.</p>
+    </td>
+  </tr>
+  <tr>
+    <td><b>volume-label</b></td>
+    <td>
+      One or more custom metadata ("labels") to apply to the volume upon
+      creation. For example,
+      `volume-label=mylabel=hello-world,my-other-label=hello-mars`. For more
+      information about labels, refer to
+      <a href="https://docs.docker.com/engine/userguide/labels-custom-metadata/">apply custom metadata</a>.
+    </td>
+  </tr>
+  <tr>
+    <td><b>volume-nocopy</b></td>
+    <td>
+      By default, if you attach an empty volume to a container, and files or
+      directories already existed at the mount-path in the container (<tt>dst</tt>),
+      the Engine copies those files and directories into the volume, allowing
+      the host to access them. Set `volume-nocopy` to disables copying files
+      from the container's filesystem to the volume and mount the empty volume.
+
+      A value is optional:
+
+      <ul>
+        <li><tt>true</tt> or <tt>1</tt>: Default if you do not provide a value. Disables copying.</li>
+        <li><tt>false</tt> or <tt>0</tt>: Enables copying.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td><b>volume-opt</b></td>
+    <td>
+      Options specific to a given volume driver, which will be passed to the
+      driver when creating the volume. Options are provided as a comma-separated
+      list of key/value pairs, for example,
+      <tt>volume-opt=some-option=some-value,some-other-option=some-other-value</tt>.
+      For available options for a given driver, refer to that driver's
+      documentation.
+    </td>
+  </tr>
+</table>
+
 
 #### Options for tmpfs
+
 The following options can only be used for tmpfs mounts (`type=tmpfs`);
 
-| Option                | Description
-|:----------------------|:--------------------------------------------------------------------------------------------------------------------
-| **tmpfs-size**        | Size of the tmpfs mount in bytes. Unlimited by default in Linux.
-| **tmpfs-mode**        | File mode of the tmpfs in octal. (e.g. `"700"` or `"0700"`.) Defaults to ``"1777"`` in Linux.
+
+<table>
+  <tr>
+    <th>Option</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><b>tmpfs-size</b></td>
+    <td>Size of the tmpfs mount in bytes. Unlimited by default in Linux.</td>
+  </tr>
+  <tr>
+    <td><b>tmpfs-mode</b></td>
+    <td>File mode of the tmpfs in octal. (e.g. <tt>"700"</tt> or <tt>"0700"</tt>.) Defaults to <tt>"1777"</tt> in Linux.</td>
+  </tr>
+</table>
+
 
 #### Differences between "--mount" and "--volume"
 
@@ -422,13 +541,40 @@ constraint expressions. Multiple constraints find nodes that satisfy every
 expression (AND match). Constraints can match node or Docker Engine labels as
 follows:
 
-| node attribute  | matches                   | example                                         |
-|:----------------|:--------------------------|:------------------------------------------------|
-| node.id         | node ID                   | `node.id == 2ivku8v2gvtg4`                      |
-| node.hostname   | node hostname             | `node.hostname != node-2`                       |
-| node.role       | node role: manager        | `node.role == manager`                          |
-| node.labels     | user defined node labels  | `node.labels.security == high`                  |
-| engine.labels   | Docker Engine's labels    | `engine.labels.operatingsystem == ubuntu 14.04` |
+
+<table>
+  <tr>
+    <th>node attribute</th>
+    <th>matches</th>
+    <th>example</th>
+  </tr>
+  <tr>
+    <td><tt>node.id</tt></td>
+    <td>Node ID</td>
+    <td><tt>node.id == 2ivku8v2gvtg4</tt></td>
+  </tr>
+  <tr>
+    <td><tt>node.hostname</tt></td>
+    <td>Node hostname</td>
+    <td><tt>node.hostname != node-2</tt></td>
+  </tr>
+  <tr>
+    <td<tt>node.role</tt></td>
+    <td><tt>node role: manager</tt></td>
+    <td><tt>node.role == manager</tt></td>
+  </tr>
+  <tr>
+    <td><tt>node.labels</tt></td>
+    <td>user defined node labels</td>
+    <td><tt>node.labels.security == high</tt></td>
+  </tr>
+  <tr>
+    <td><tt>engine.labels</tt></td>
+    <td>Docker Engine's labels</td>
+    <td><tt>engine.labels.operatingsystem == ubuntu 14.04</tt></td>
+  </tr>
+</table>
+
 
 `engine.labels` apply to Docker Engine labels like operating system,
 drivers, etc. Swarm administrators add `node.labels` for operational purposes by
@@ -611,15 +757,42 @@ The supported flags are the following :
 
 Valid placeholders for the Go template are listed below:
 
-Placeholder       | Description
------------------ | --------------------------------------------
-`.Service.ID`     | Service ID
-`.Service.Name`   | Service name
-`.Service.Labels` | Service labels
-`.Node.ID`        | Node ID
-`.Task.ID`        | Task ID
-`.Task.Name`      | Task name
-`.Task.Slot`      | Task slot
+
+<table>
+  <tr>
+    <th>Placeholder</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><tt>.Service.ID</tt></td>
+    <td>Service ID</td>
+  </tr>
+  <tr>
+    <td><tt>.Service.Name</tt></td>
+    <td>Service name</td>
+  </tr>
+  <tr>
+    <td><tt>.Service.Labels</tt></td>
+    <td>Service labels</td>
+  </tr>
+  <tr>
+    <td><tt>.Node.ID</tt></td>
+    <td>Node ID</td>
+  </tr>
+  <tr>
+    <td><tt>.Task.ID</tt></td>
+    <td>Task ID</td>
+  </tr>
+  <tr>
+    <td><tt>.Task.Name</tt></td>
+    <td>Task name</td>
+  </tr>
+  <tr>
+    <td><tt>.Task.Slot</tt></td>
+    <td>Task slot</td>
+  </tr>
+</table>
+
 
 #### Template example
 

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -28,12 +28,12 @@ Options:
   -q, --quiet           Only display IDs
 ```
 
-### Description
+## Description
 
 Lists the services that are running as part of the specified stack. This
 command has to be run targeting a manager node.
 
-### Examples
+## Examples
 
 The following command shows all services in the `myapp` stack:
 


### PR DESCRIPTION
Several Markdown changes to fix Kramdown parsing of CLI references. Specifically, Kramdown does not allow block HTML elements within Markdown tables. Also, we need both `Description` and `Examples` sections of these references to be H2-level headings (as in `## Examples`).

There may be more Kramdown problems that were not readily apparent.