### PR TITLE
daemon: also ensureDefaultApparmorProfile in exec path

### DIFF
--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -5,6 +5,7 @@ import (
 	"github.com/docker/docker/daemon/caps"
 	"github.com/docker/docker/daemon/exec"
 	"github.com/docker/docker/libcontainerd"
+	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -22,6 +23,28 @@ func execSetPlatformOpt(c *container.Container, ec *exec.Config, p *libcontainer
 	}
 	if ec.Privileged {
 		p.Capabilities = caps.GetAllCapabilities()
+	}
+	if apparmor.IsEnabled() {
+		var appArmorProfile string
+		if c.AppArmorProfile != "" {
+			appArmorProfile = c.AppArmorProfile
+		} else if c.HostConfig.Privileged {
+			appArmorProfile = "unconfined"
+		} else {
+			appArmorProfile = "docker-default"
+		}
+
+		if appArmorProfile == "docker-default" {
+			// Unattended upgrades and other fun services can unload AppArmor
+			// profiles inadvertently. Since we cannot store our profile in
+			// /etc/apparmor.d, nor can we practically add other ways of
+			// telling the system to keep our profile loaded, in order to make
+			// sure that we keep the default profile enabled we dynamically
+			// reload it if necessary.
+			if err := ensureDefaultAppArmorProfile(); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
When 567ef8e7858c ("daemon: switch to 'ensure' workflow for AppArmor
profiles") was merged, it didn't correctly handle the exec path if
AppArmor profiles were deleted. Fix this by duplicating the
ensureDefaultApparmorProfile code in the exec code.

[![Mikey's Window](https://c1.staticflickr.com/6/5442/9326091343_ce2ec46200_k.jpg)](https://flic.kr/p/fd7E3k)

Fixes #31733
Fixes: 567ef8e7858c ("daemon: switch to 'ensure' workflow for AppArmor profiles")
Signed-off-by: Aleksa Sarai <asarai@suse.de>

###### [Mikey's Window](https://flic.kr/p/fd7E3k) by [Jessica Nichole](https://www.flickr.com/photos/95831741@N06/), on Flickr