### PR TITLE
misleading default for --update-monitor duration

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -491,7 +491,7 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 
 	flags.Uint64Var(&opts.update.parallelism, flagUpdateParallelism, 1, "Maximum number of tasks updated simultaneously (0 to update all at once)")
 	flags.DurationVar(&opts.update.delay, flagUpdateDelay, time.Duration(0), "Delay between updates (ns|us|ms|s|m|h) (default 0s)")
-	flags.DurationVar(&opts.update.monitor, flagUpdateMonitor, time.Duration(0), "Duration after each task update to monitor for failure (ns|us|ms|s|m|h) (default 0s)")
+	flags.DurationVar(&opts.update.monitor, flagUpdateMonitor, time.Duration(0), "Duration after each task update to monitor for failure (ns|us|ms|s|m|h)")
 	flags.SetAnnotation(flagUpdateMonitor, "version", []string{"1.25"})
 	flags.StringVar(&opts.update.onFailure, flagUpdateFailureAction, "pause", `Action on update failure ("pause"|"continue"|"rollback")`)
 	flags.Var(&opts.update.maxFailureRatio, flagUpdateMaxFailureRatio, "Failure rate to tolerate during an update")

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -71,7 +71,7 @@ Options:
       --update-delay duration              Delay between updates (ns|us|ms|s|m|h) (default 0s)
       --update-failure-action string       Action on update failure ("pause"|"continue"|"rollback") (default "pause")
       --update-max-failure-ratio float     Failure rate to tolerate during an update
-      --update-monitor duration            Duration after each task update to monitor for failure (ns|us|ms|s|m|h) (default 0s)
+      --update-monitor duration            Duration after each task update to monitor for failure (ns|us|ms|s|m|h)
       --update-parallelism uint            Maximum number of tasks updated simultaneously (0 to update all at once) (default 1)
   -u, --user string                        Username or UID (format: <name|uid>[:<group|gid>])
       --with-registry-auth                 Send registry authentication details to swarm agents

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -84,7 +84,7 @@ Options:
       --update-delay duration              Delay between updates (ns|us|ms|s|m|h) (default 0s)
       --update-failure-action string       Action on update failure ("pause"|"continue"|"rollback") (default "pause")
       --update-max-failure-ratio float     Failure rate to tolerate during an update
-      --update-monitor duration            Duration after each task update to monitor for failure (ns|us|ms|s|m|h) (default 0s)
+      --update-monitor duration            Duration after each task update to monitor for failure (ns|us|ms|s|m|h) 
       --update-parallelism uint            Maximum number of tasks updated simultaneously (0 to update all at once) (default 1)
   -u, --user string                        Username or UID (format: <name|uid>[:<group|gid>])
       --with-registry-auth                 Send registry authentication details to swarm agents


### PR DESCRIPTION
Signed-off-by: erxian <evelynhsu21@gmail.com>

Hi,
This PR aims to correct the default for --update-monitor duration from **0s** to **5s**.

The output of --update-monitor duration default is 0s :

...
      --update-max-failure-ratio float   Failure rate to tolerate during an update
      --update-monitor duration          Duration after each task update to monitor for failure (ns|us|ms|s|m|h) (default 0s)
      --update-parallelism uint          Maximum number of tasks updated simultaneously (0 to update all at once) (default 1)
...

However the actual default is 5s, which locates in https://github.com/docker/docker/blob/master/vendor/github.com/docker/swarmkit/manager/orchestrator/update/updater.go#L24

So I fix the misleading default by changing :

flags.DurationVar(&opts.update.monitor, flagUpdateMonitor, time.Duration(0), "Duration after each task update to monitor for failure (ns|us|ms|s|m|h) (default 0s)")
TO :

flags.DurationVar(&opts.update.monitor, flagUpdateMonitor, 5 * time.Second, "Duration after each task update to monitor for failure (ns|us|ms|s|m|h) (default 30s)")
Besides, the bellowing docs have also been updated.

https://github.com/docker/docker/blob/master/docs/reference/commandline/service_create.md

https://github.com/docker/docker/blob/master/docs/reference/commandline/service_update.md


**- A picture of a cute animal (not mandatory but encouraged)**

