### PR TITLE
Fix bash completion for service constraints

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2967,7 +2967,6 @@ _docker_service_update_and_create() {
 	local $subcommand="${words[$subcommand_pos]}"
 
 	local options_with_args="
-		--constraint
 		--endpoint-mode
 		--env -e
 		--force
@@ -3018,6 +3017,7 @@ _docker_service_update_and_create() {
 
 	if [ "$subcommand" = "create" ] ; then
 		options_with_args="$options_with_args
+			--constraint
 			--container-label
 			--dns
 			--dns-option
@@ -3061,6 +3061,8 @@ _docker_service_update_and_create() {
 	if [ "$subcommand" = "update" ] ; then
 		options_with_args="$options_with_args
 			--arg
+			--constraint-add
+			--constraint-rm
 			--container-label-add
 			--container-label-rm
 			--dns-add


### PR DESCRIPTION
- Remove bash completion for `service update --constraint` (only exists for `service create`)
- Add bash completion for `service update --constraint-{add,rm}`