### PR TITLE
CI cleanup - only unpause if platform supports it

### DIFF
--- a/integration-cli/environment/clean.go
+++ b/integration-cli/environment/clean.go
@@ -25,7 +25,9 @@ type logT interface {
 // and removing everything else. It's meant to run after any tests so that they don't
 // depend on each others.
 func (e *Execution) Clean(t testingT, dockerBinary string) {
-	unpauseAllContainers(t, dockerBinary)
+	if (e.DaemonPlatform() != "windows") || (e.DaemonPlatform() == "windows" && e.Isolation() == "hyperv") {
+		unpauseAllContainers(t, dockerBinary)
+	}
 	deleteAllContainers(t, dockerBinary)
 	deleteAllImages(t, dockerBinary, e.protectedElements.images)
 	deleteAllVolumes(t, dockerBinary)


### PR DESCRIPTION
Signed-off-by: John Howard (VM) <jhoward@ntdev.microsoft.com>

This PR is for Windows CI reliability. There have been occasional instances of CI failures due to below, also seen in internal Microsoft runs. I still don't fully understand the underlying cause, but is as much for correctness as anything else. During cleanup, with this PR, we only unpause containers if the platform supports it. (Between this and https://github.com/docker/docker/pull/31752, specifically the OK check, I think this should fix it). 🤞 

```
01:03:22.339 ----------------------------------------------------------------------
01:03:22.339 FAIL: check_test.go:101: DockerSuite.TearDownTest
01:03:22.339 
01:03:22.339 check_test.go:102:
01:03:22.339     testEnv.Clean(c, dockerBinary)
01:03:22.339 c:/gopath/src/github.com/docker/docker/pkg/testutil/cmd/command.go:64:
01:03:22.340     t.Fatalf("at %s:%d\n%s", filepath.Base(file), line, err.Error())
01:03:22.340 ... Error: at clean.go:41
01:03:22.340 
01:03:22.340 Command: d:\CI\CI-6f733c006\binary\docker.exe unpause runtime: failed to create new OS thread (have 6 already; errno=5) fatal error: runtime.newosproc
01:03:22.340 ExitCode: 1, Error: exit status 1
01:03:22.340 Stdout: 
01:03:22.340 Stderr: Error response from daemon: No such container: runtime:

```

https://jenkins.dockerproject.org/job/Docker-PRs-WoW-RS1/11230/console (but the logs will roll over soon).