### PR TITLE
[17.03.x] Vendor swarmkit 1775645

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -101,7 +101,7 @@ github.com/docker/containerd 595e75c212d19a81d2b808a518fe1afc1391dad5
 github.com/tonistiigi/fifo 1405643975692217d6720f8b54aeee1bf2cd5cf4
 
 # cluster
-github.com/docker/swarmkit f93948cb430facd540e3c65c606384a89b3ac40f
+github.com/docker/swarmkit 17756457ad6dc4d8a639a1f0b7a85d1b65a617bb
 github.com/golang/mock bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 github.com/gogo/protobuf v0.3
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a


### PR DESCRIPTION
This brings in a scheduler fix for 17.03:

- scheduler: Fix accounting when task ends up in multiple groups https://github.com/docker/swarmkit/pull/2031

It fixes a problem where resource accounting could become incorrect due to duplicate tasks going through the scheduler (part of #31694).

Thanks @kleptog for finding the bug.