### PR TITLE
bump API to 1.28

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -21,7 +21,7 @@ import (
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion string = "1.27"
+	DefaultVersion string = "1.28"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -520,9 +520,9 @@ func (s *containerRouter) wsContainersAttach(ctx context.Context, w http.Respons
 		}()
 
 		conn := <-wsChan
-		// In case version is higher than 1.27, a binary frame will be sent.
+		// In case version 1.28 and above, a binary frame will be sent.
 		// See 28176 for details.
-		if versions.GreaterThanOrEqualTo(version, "1.27") {
+		if versions.GreaterThanOrEqualTo(version, "1.28") {
 			conn.PayloadType = websocket.BinaryFrame
 		}
 		return conn, conn, conn, nil

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -255,7 +255,7 @@ func (s *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter, 
 
 	version := httputils.VersionFromContext(ctx)
 	filterParam := r.Form.Get("filter")
-	if versions.LessThan(version, "1.28") && filterParam != "" {
+	if versions.LessThanOrEqualTo(version, "1.28") && filterParam != "" {
 		imageFilters.Add("reference", filterParam)
 	}
 

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -62,11 +62,11 @@ SKIP:
 		}
 
 		var nr *types.NetworkResource
-		// Versions < 1.27 fetches all the containers attached to a network
+		// Versions < 1.28 fetches all the containers attached to a network
 		// in a network list api call. It is a heavy weight operation when
-		// run across all the networks. Starting API version 1.27, this detailed
+		// run across all the networks. Starting API version 1.28, this detailed
 		// info is available for network specific GET API (equivalent to inspect)
-		if versions.LessThan(httputils.VersionFromContext(ctx), "1.27") {
+		if versions.LessThan(httputils.VersionFromContext(ctx), "1.28") {
 			nr = n.buildDetailedNetworkResources(nw, false)
 		} else {
 			nr = n.buildNetworkResource(nw)

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.27"
+basePath: "/v1.28"
 info:
   title: "Docker Engine API"
-  version: "1.27"
+  version: "1.28"
   x-logo:
     url: "https://docs.docker.com/images/logo-docker-main.png"
   description: |
@@ -44,7 +44,7 @@ info:
 
     The API is usually changed in each release of Docker, so API calls are versioned to ensure that clients don't break.
 
-    For Docker Engine 17.04, the API version is 1.27. To lock to this version, you prefix the URL with `/v1.27`. For example, calling `/info` is the same as calling `/v1.27/info`.
+    For Docker Engine 17.04, the API version is 1.28. To lock to this version, you prefix the URL with `/v1.28`. For example, calling `/info` is the same as calling `/v1.28/info`.
 
     Engine releases in the near future should support this version of the API, so your client will continue to work even if it is talking to a newer Engine.
 
@@ -52,11 +52,12 @@ info:
 
     The API uses an open schema model, which means server may add extra properties to responses. Likewise, the server will ignore any extra query parameters and request body properties. When you write clients, you need to ignore additional properties in responses to ensure they do not break when talking to newer Docker daemons.
 
-    This documentation is for version 1.27 of the API, which was introduced with Docker 17.04. Use this table to find documentation for previous versions of the API:
+    This documentation is for version 1.28 of the API, which was introduced with Docker 17.04. Use this table to find documentation for previous versions of the API:
 
     Docker version  | API version | Changes
     ----------------|-------------|---------
-    1.13.1 | [1.26](https://docs.docker.com/engine/api/v1.26/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-26-api-changes)
+    17.03.1 | [1.27](https://docs.docker.com/engine/api/v1.27/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-27-api-changes)
+    1.13.1 & 17.03.0 | [1.26](https://docs.docker.com/engine/api/v1.26/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-26-api-changes)
     1.13.0 | [1.25](https://docs.docker.com/engine/api/v1.25/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-25-api-changes)
     1.12.x | [1.24](https://docs.docker.com/engine/api/v1.24/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-24-api-changes)
     1.11.x | [1.23](https://docs.docker.com/engine/api/v1.23/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-23-api-changes)

--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -38,7 +38,7 @@ func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.Var(&opts.mounts, flagMount, "Attach a filesystem mount to the service")
 	flags.Var(&opts.constraints, flagConstraint, "Placement constraints")
 	flags.Var(&opts.placementPrefs, flagPlacementPref, "Add a placement preference")
-	flags.SetAnnotation(flagPlacementPref, "version", []string{"1.27"})
+	flags.SetAnnotation(flagPlacementPref, "version", []string{"1.28"})
 	flags.Var(&opts.networks, flagNetwork, "Network attachments")
 	flags.Var(&opts.secrets, flagSecret, "Specify secrets to expose to the service")
 	flags.SetAnnotation(flagSecret, "version", []string{"1.25"})

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -498,15 +498,15 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags.SetAnnotation(flagUpdateMaxFailureRatio, "version", []string{"1.25"})
 
 	flags.Uint64Var(&opts.rollback.parallelism, flagRollbackParallelism, 1, "Maximum number of tasks rolled back simultaneously (0 to roll back all at once)")
-	flags.SetAnnotation(flagRollbackParallelism, "version", []string{"1.27"})
+	flags.SetAnnotation(flagRollbackParallelism, "version", []string{"1.28"})
 	flags.DurationVar(&opts.rollback.delay, flagRollbackDelay, time.Duration(0), "Delay between task rollbacks (ns|us|ms|s|m|h) (default 0s)")
-	flags.SetAnnotation(flagRollbackDelay, "version", []string{"1.27"})
+	flags.SetAnnotation(flagRollbackDelay, "version", []string{"1.28"})
 	flags.DurationVar(&opts.rollback.monitor, flagRollbackMonitor, time.Duration(0), "Duration after each task rollback to monitor for failure (ns|us|ms|s|m|h) (default 0s)")
-	flags.SetAnnotation(flagRollbackMonitor, "version", []string{"1.27"})
+	flags.SetAnnotation(flagRollbackMonitor, "version", []string{"1.28"})
 	flags.StringVar(&opts.rollback.onFailure, flagRollbackFailureAction, "pause", `Action on rollback failure ("pause"|"continue")`)
-	flags.SetAnnotation(flagRollbackFailureAction, "version", []string{"1.27"})
+	flags.SetAnnotation(flagRollbackFailureAction, "version", []string{"1.28"})
 	flags.Var(&opts.rollback.maxFailureRatio, flagRollbackMaxFailureRatio, "Failure rate to tolerate during a rollback")
-	flags.SetAnnotation(flagRollbackMaxFailureRatio, "version", []string{"1.27"})
+	flags.SetAnnotation(flagRollbackMaxFailureRatio, "version", []string{"1.28"})
 
 	flags.StringVar(&opts.endpoint.mode, flagEndpointMode, "vip", "Endpoint mode (vip or dnsrr)")
 
@@ -530,10 +530,10 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags.SetAnnotation(flagTTY, "version", []string{"1.25"})
 
 	flags.BoolVar(&opts.readOnly, flagReadOnly, false, "Mount the container's root filesystem as read only")
-	flags.SetAnnotation(flagReadOnly, "version", []string{"1.27"})
+	flags.SetAnnotation(flagReadOnly, "version", []string{"1.28"})
 
 	flags.StringVar(&opts.stopSignal, flagStopSignal, "", "Signal to stop the container")
-	flags.SetAnnotation(flagStopSignal, "version", []string{"1.27"})
+	flags.SetAnnotation(flagStopSignal, "version", []string{"1.28"})
 }
 
 const (

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -72,9 +72,9 @@ func newUpdateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.Var(&serviceOpts.mounts, flagMountAdd, "Add or update a mount on a service")
 	flags.Var(&serviceOpts.constraints, flagConstraintAdd, "Add or update a placement constraint")
 	flags.Var(&serviceOpts.placementPrefs, flagPlacementPrefAdd, "Add a placement preference")
-	flags.SetAnnotation(flagPlacementPrefAdd, "version", []string{"1.27"})
+	flags.SetAnnotation(flagPlacementPrefAdd, "version", []string{"1.28"})
 	flags.Var(&placementPrefOpts{}, flagPlacementPrefRemove, "Remove a placement preference")
-	flags.SetAnnotation(flagPlacementPrefRemove, "version", []string{"1.27"})
+	flags.SetAnnotation(flagPlacementPrefRemove, "version", []string{"1.28"})
 	flags.Var(&serviceOpts.endpoint.publishPorts, flagPublishAdd, "Add or update a published port")
 	flags.Var(&serviceOpts.groups, flagGroupAdd, "Add an additional supplementary user group to the container")
 	flags.SetAnnotation(flagGroupAdd, "version", []string{"1.25"})
@@ -132,7 +132,7 @@ func runUpdate(dockerCli *command.DockerCli, flags *pflag.FlagSet, serviceID str
 			return errors.New("other flags may not be combined with --rollback")
 		}
 
-		if versions.LessThan(dockerCli.Client().ClientVersion(), "1.27") {
+		if versions.LessThan(dockerCli.Client().ClientVersion(), "1.28") {
 			clientSideRollback = true
 			spec = service.PreviousSpec
 			if spec == nil {

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,18 +13,24 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
-## v1.27 API changes
+## v1.28 API changes
 
-[Docker Engine API v1.27](https://docs.docker.com/engine/api/v1.27/) documentation
+[Docker Engine API v1.28](https://docs.docker.com/engine/api/v1.28/) documentation
+
 
 * Optional query parameter `verbose` for `GET /networks/(id or name)` will now list all services with all the tasks, including the non-local tasks on the given network.
-* `GET /containers/(id or name)/attach/ws` now returns WebSocket in binary frame format for API version >= v1.27, and returns WebSocket in text frame format for API version< v1.27, for the purpose of backward-compatibility.
+* `GET /containers/(id or name)/attach/ws` now returns WebSocket in binary frame format for API version >= v1.28, and returns WebSocket in text frame format for API version< v1.28, for the purpose of backward-compatibility.
 * `GET /networks` is optimised only to return list of all networks and network specific information. List of all containers attached to a specific network is removed from this API and is only available using the network specific `GET /networks/{network-id}.
 * `GET /containers/json` now supports `publish` and `expose` filters to filter containers that expose or publish certain ports.
 * `POST /services/create` and `POST /services/(id or name)/update` now accept the `ReadOnly` parameter, which mounts the container's root filesystem as read only.
 * `POST /build` now accepts `extrahosts` parameter to specify a host to ip mapping to use during the build.
 * `POST /services/create` and `POST /services/(id or name)/update` now accept a `rollback` value for `FailureAction`.
 * `POST /services/create` and `POST /services/(id or name)/update` now accept an optional `RollbackConfig` object which specifies rollback options.
+
+## v1.27 API changes
+
+[Docker Engine API v1.27](https://docs.docker.com/engine/api/v1.27/) documentation
+
 * `GET /containers/(id or name)/stats` now includes an `online_cpus` field in both `precpu_stats` and `cpu_stats`. If this field is `nil` then for compatibility with older daemons the length of the corresponding `cpu_usage.percpu_usage` array should be used.
 
 ## v1.26 API changes


### PR DESCRIPTION
1.27 is used in 17.03.1, so bumping master to 1.28