### PR TITLE
Remove docs for `dockerd --no-new-privileges`

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -70,7 +70,6 @@ Options:
       --max-concurrent-uploads int            Set the max concurrent uploads for each push (default 5)
       --metrics-addr string                   Set address and port to serve the metrics api (default "")
       --mtu int                               Set the containers network MTU
-      --no-new-privileges                     Disable container processes from gaining new privileges
       --oom-score-adjust int                  Set the oom_score_adj for the daemon (default -500)
   -p, --pidfile string                        Path to use for daemon PID file (default "/var/run/docker.pid")
       --raw-logs                              Full timestamps without ANSI coloring


### PR DESCRIPTION
In #29984, the daemon option `--no-new-privileges` was added to the docs.
This option does not exist:
```bash
dockerd --no-new-privileges 2>&1 | head -1
Status: unknown flag: --no-new-privileges
```
This was executed on current master:
```bash
docker --version
Docker version 17.04.0-dev, build 4744b01
```
The feature exists as `docker run --security-opt no-new-privileges`.