### PR TITLE
Restrict secret view to node level in controller

### DIFF
--- a/daemon/cluster/executor/container/executor.go
+++ b/daemon/cluster/executor/container/executor.go
@@ -152,7 +152,7 @@ func (e *executor) Controller(t *api.Task) (exec.Controller, error) {
 		return newNetworkAttacherController(e.backend, t, e.secrets)
 	}
 
-	ctlr, err := newController(e.backend, t, e.secrets)
+	ctlr, err := newController(e.backend, t, secrets.Restrict(e.secrets, t))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This restricts access to the secrets at the node level.

Signed-off-by: Evan Hazlett <ejhazlett@gmail.com>