### PR TITLE
Update bash completion for `docker service logs`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2846,7 +2846,7 @@ _docker_service_logs() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--details --follow -f --help --no-resolve --since --tail --timestamps -t" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--follow -f --help --no-resolve --no-task-ids --no-trunc --since --tail --timestamps -t" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag '--since|--tail')


### PR DESCRIPTION
Bash completion for #31672, which is scheduled for 17.04.0 (see #31811 for bump PR).
Ping @sdurrheimer for zsh completion