### PR TITLE
Fix default socket group regression

### DIFF
--- a/pkg/listeners/group_unix.go
+++ b/pkg/listeners/group_unix.go
@@ -10,6 +10,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const defaultSocketGroup = "docker"
+
 func lookupGID(name string) (int, error) {
 	groupFile, err := user.GetGroupPath()
 	if err != nil {

--- a/pkg/listeners/listeners_solaris.go
+++ b/pkg/listeners/listeners_solaris.go
@@ -4,7 +4,9 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/go-connections/sockets"
 )
 
@@ -20,7 +22,11 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) (ls []net.List
 	case "unix":
 		gid, err := lookupGID(socketGroup)
 		if err != nil {
-			return nil, err
+			if socketGroup != defaultSocketGroup {
+				return nil, err
+			}
+			logrus.Warnf("could not change group %s to %s: %v", addr, defaultSocketGroup, err)
+			gid = os.Getgid()
 		}
 		l, err := sockets.NewUnixSocket(addr, gid)
 		if err != nil {

--- a/pkg/listeners/listeners_unix.go
+++ b/pkg/listeners/listeners_unix.go
@@ -6,8 +6,10 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/coreos/go-systemd/activation"
 	"github.com/docker/go-connections/sockets"
 )
@@ -33,7 +35,11 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) ([]net.Listene
 	case "unix":
 		gid, err := lookupGID(socketGroup)
 		if err != nil {
-			return nil, err
+			if socketGroup != defaultSocketGroup {
+				return nil, err
+			}
+			logrus.Warnf("could not change group %s to %s: %v", addr, defaultSocketGroup, err)
+			gid = os.Getgid()
 		}
 		l, err := sockets.NewUnixSocket(addr, gid)
 		if err != nil {


### PR DESCRIPTION
fixes #31788

This is an ugly patch to fix the regression where daemon does not start anymore if there is no `docker` group in the host.

Before this used to be handled in https://github.com/docker/go-connections/pull/26/files#diff-db2f28fb2088d62113489c6a960cfebdL43 . Normally, we would avoid these constants in `pkg` packages but only other way I see to fix it would be to have different signatures for `listeners.Init()` for unix and windows, as I can't change the group input in windows to an integer. It isn't worse than before where we had this constant hardcoded in `go-connections`.

@dongluochen @dmcgowan @cpuguy83 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>

