### PR TITLE
Don't compare API version in the future for `image ls` endpoint

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -253,9 +253,9 @@ func (s *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter, 
 		return err
 	}
 
-	version := httputils.VersionFromContext(ctx)
 	filterParam := r.Form.Get("filter")
-	if versions.LessThanOrEqualTo(version, "1.28") && filterParam != "" {
+	// FIXME(vdemeester) This has been deprecated in 1.13, and is target for removal for v17.12
+	if filterParam != "" {
 		imageFilters.Add("reference", filterParam)
 	}
 


### PR DESCRIPTION
… as we don't know for sure what API version it will be at that time. Added a *sticky* `FIXME` instead 👼 (see `deprecated.md` file for the reason of this if).

/cc @thaJeztah @vieux @icecrime @dnephin @cpuguy83 

🐯

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
