### PR TITLE
docs: remove outdated reference to updating /etc/hosts

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -458,10 +458,6 @@ If a container is connected to the default bridge network and `linked`
 with other containers, then the container's `/etc/hosts` file is updated
 with the linked container's name.
 
-If the container is connected to user-defined network, the container's
-`/etc/hosts` file is updated with names of all other containers in that
-user-defined network.
-
 > **Note** Since Docker may live update the container’s `/etc/hosts` file, there
 may be situations when processes inside the container can end up reading an
 empty or incomplete `/etc/hosts` file. In most cases, retrying the read again


### PR DESCRIPTION
Starting with docker 1.10, docker no longer uses `/etc/hosts` for service discovery, but uses an embedded DNS server. This patch removes a reference to the old (pre 1.10) behavior. This one was missed in https://github.com/docker/docker/issues/19221 :smile:

fixes https://github.com/docker/docker/issues/31835

**- A picture of a cute animal (not mandatory but encouraged)**

![58c9e86c04cb775daeab4b9fa69178a3](https://cloud.githubusercontent.com/assets/1804568/23946610/5e9a6174-097b-11e7-9dad-bd3b21ea32c5.jpg)