### PR TITLE
[17.04.x] deprecation and changelog updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,17 @@ be found.
 
 ## 17.04.0-ce (2017-04-05)
 
+### Builder
+
+* Disable container logging for build containers [#29552](https://github.com/docker/docker/pull/29552)
+* Fix use of `**/` in `.dockerignore` [#29043](https://github.com/docker/docker/pull/29043)
+
 ### Client
+
 + Sort `docker stack ls` by name [#31085](https://github.com/docker/docker/pull/31085)
 + Flags for specifying bind mount consistency [#31047](https://github.com/docker/docker/pull/31047)
-* Suppressing image digest in docker ps [#30848](https://github.com/docker/docker/pull/30848)
+* Output of docker CLI --help is now wrapped to the terminal width [#28751](https://github.com/docker/docker/pull/28751)
+* Suppress image digest in docker ps [#30848](https://github.com/docker/docker/pull/30848)
 * Hide command options that are related to Windows [#30788](https://github.com/docker/docker/pull/30788)
 * Fix `docker plugin install` prompt to accept "enter" for the "N" default [#30769](https://github.com/docker/docker/pull/30769)
 + Add `truncate` function for Go templates [#30484](https://github.com/docker/docker/pull/30484)
@@ -19,15 +26,22 @@ be found.
 + Add `--add-host` for docker build [#30383](https://github.com/docker/docker/pull/30383)
 + Add `.CreatedAt` placeholder for `docker network ls --format` [#29900](https://github.com/docker/docker/pull/29900)
 * Update order of `--secret-rm` and `--secret-add` [#29802](https://github.com/docker/docker/pull/29802)
-* Fix use of `**/` in `.dockerignore` [#29043](https://github.com/docker/docker/pull/29043)
 + Add `--filter enabled=true` for `docker plugin ls` [#28627](https://github.com/docker/docker/pull/28627)
 + Add `--format` to `docker service ls` [#28199](https://github.com/docker/docker/pull/28199)
 + Add `publish` and `expose` filter for `docker ps --filter` [#27557](https://github.com/docker/docker/pull/27557)
 * Support multiple service IDs on `docker service ps` [#25234](https://github.com/docker/docker/pull/25234)
 + Allow swarm join with `--availability=drain` [#24993](https://github.com/docker/docker/pull/24993)
-* Removal of the email from `docker login` [#26868](https://github.com/docker/docker/pull/26868)
+* Docker inspect now shows "docker-default" when AppArmor is enabled and no other profile was defined [#27083](https://github.com/docker/docker/pull/27083)
+
+### Logging
+
++ Implement optional ring buffer for container logs [#28762](https://github.com/docker/docker/pull/28762)
++ Add `--log-opt awslogs-create-group=<true|false>` for awslogs (CloudWatch) to support creation of log groups as needed [#29504](https://github.com/docker/docker/pull/29504)
+- Fix segfault when using the gcplogs logging driver with a "static" binary [#29478](https://github.com/docker/docker/pull/29478)
+
 
 ### Networking
+
 * Check parameter `--ip`, `--ip6` and `--link-local-ip` in `docker network connect` [#30807](https://github.com/docker/docker/pull/30807)
 + Added support for `dns-search` [#30117](https://github.com/docker/docker/pull/30117)
 + Added --verbose option for docker network inspect to show task details from all swarm nodes [#31710](https://github.com/docker/docker/pull/31710)
@@ -36,8 +50,10 @@ be found.
 * Fix bad order of iptables filter rules [docker/libnetwork#961](https://github.com/docker/libnetwork/pull/961)
 + Add anonymous container alias to service record on attachable network [docker/libnetwork#1651](https://github.com/docker/libnetwork/pull/1651)
 + Support for `com.docker.network.container_interface_prefix` driver label [docker/libnetwork#1667](https://github.com/docker/libnetwork/pull/1667)
++ Improve network list performance by omitting network details that are not used [#30673](https://github.com/docker/docker/pull/30673)
 
 ### Runtime
+
 * Handle paused container when restoring without live-restore set [#31704](https://github.com/docker/docker/pull/31704)
 - Do not allow sub second in healthcheck options in Dockerfile [#31177](https://github.com/docker/docker/pull/31177)
 * Support name and id prefix in  `secret update` [#30856](https://github.com/docker/docker/pull/30856)
@@ -50,10 +66,11 @@ be found.
 + Support registry mirror config reload [#29650](https://github.com/docker/docker/pull/29650)
 - Ignore the daemon log config when building images [#29552](https://github.com/docker/docker/pull/29552)
 * Move secret name or ID prefix resolving from client to daemon [#29218](https://github.com/docker/docker/pull/29218)
-+ Implement optional ring buffer for container logs [#28762](https://github.com/docker/docker/pull/28762)
 + Allow adding rules to `cgroup devices.allow` on container create/run [#22563](https://github.com/docker/docker/pull/22563)
+- Fix `cpu.cfs_quota_us` being reset when running `systemd daemon-reload` [#31736](https://github.com/docker/docker/pull/31736)
 
 ### Swarm Mode
+
 + Topology-aware scheduling [#30725](https://github.com/docker/docker/pull/30725)
 + Automatic service rollback on failure [#31108](https://github.com/docker/docker/pull/31108)
 + Worker and manager on the same node are now connected through a UNIX socket [docker/swarmkit#1828](https://github.com/docker/swarmkit/pull/1828), [docker/swarmkit#1850](https://github.com/docker/swarmkit/pull/1850), [docker/swarmkit#1851](https://github.com/docker/swarmkit/pull/1851)
@@ -66,8 +83,11 @@ be found.
 + Add `--stop-signal` for `service create` and `service update` [#30754](https://github.com/docker/docker/pull/30754)
 + Add `--read-only` for `service create` and `service update` [#30162](https://github.com/docker/docker/pull/30162)
 + Renew the context after communicating with the registry [#31586](https://github.com/docker/docker/pull/31586)
++ (experimental) Add `--tail` and `--since` options to `docker service logs` [#31500](https://github.com/docker/docker/pull/31500)
++ (experimental) Add `--no-task-ids` and `--no-trunc` options to `docker service logs` [#31672](https://github.com/docker/docker/pull/31672)
 
 ### Windows
+
 * Wait for OOBE to prevent crashing during host update [#31054](https://github.com/docker/docker/pull/31054)
 * Block pulling Windows images on non-Windows daemons [#29001](https://github.com/docker/docker/pull/29001)
 
@@ -115,6 +135,7 @@ Upgrading from Docker 1.13.1 to 17.03.0 is expected to be simple and low-risk.
 * Fix extraneous task creations for global services that led to confusing replica counts in `docker service ls` [docker/swarmkit#1957](https://github.com/docker/swarmkit/pull/1957)
 * Fix problem that made rolling updates slow when `task-history-limit` was set to 1 [docker/swarmkit#1948](https://github.com/docker/swarmkit/pull/1948)
 * Restart tasks elsewhere, if appropriate, when they are shut down as a result of nodes no longer satisfying constraints [docker/swarmkit#1958](https://github.com/docker/swarmkit/pull/1958)
+* (experimental)
 
 ## 1.13.1 (2017-02-08)
 
@@ -385,7 +406,7 @@ To manually remove all plugins and resolve this problem, take the following step
 - Fix selinux labeling of volumes shared in a container [#23024](https://github.com/docker/docker/pull/23024)
 - Prohibit `/sys/firmware/**` from being accessed with apparmor [#26618](https://github.com/docker/docker/pull/26618)
 
-### DEPRECATION
+### Deprecation
 
 - Marked the `docker daemon` command as deprecated. The daemon is moved to a separate binary (`dockerd`), and should be used instead [#26834](https://github.com/docker/docker/pull/26834)
 - Deprecate unversioned API endpoints [#28208](https://github.com/docker/docker/pull/28208)
@@ -1008,7 +1029,8 @@ installing docker, please make sure to update them accordingly.
 - Windows: Enable auto-creation of host-path to match Linux [#22094](https://github.com/docker/docker/pull/22094)
 
 
-### DEPRECATION
+### Deprecation
+
 * Environment variables `DOCKER_CONTENT_TRUST_OFFLINE_PASSPHRASE` and `DOCKER_CONTENT_TRUST_TAGGING_PASSPHRASE` have been renamed
   to `DOCKER_CONTENT_TRUST_ROOT_PASSPHRASE` and `DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE` respectively [#22574](https://github.com/docker/docker/pull/22574)
 * Remove deprecated `syslog-tag`, `gelf-tag`, `fluentd-tag` log option in favor of the more generic `tag` one [#22620](https://github.com/docker/docker/pull/22620)

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -266,9 +266,9 @@ of the `--changes` flag that allows to pass `Dockerfile` commands.
 
 ### Interacting with V1 registries
 
-**Disabled By Default In Release: v17.04**
+**Disabled By Default In Release: v17.06**
 
-**Target For Removal In Release: v17.10**
+**Target For Removal In Release: v17.12**
 
 Version 1.9 adds a flag (`--disable-legacy-registry=false`) which prevents the
 docker daemon from `pull`, `push`, and `login` operations against v1


### PR DESCRIPTION
- Interacting with V1 registries is not yet disabled by default, so moving the deprecation version
- Added various entries to the changelog, and moved some to a different section

ping @vieux PTAL

