### PR TITLE
Ignore `layer does not exist` error from `docker images`

### DIFF
--- a/daemon/images.go
+++ b/daemon/images.go
@@ -118,6 +118,11 @@ func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs
 		if layerID != "" {
 			l, err := daemon.layerStore.Get(layerID)
 			if err != nil {
+				// The layer may have been deleted between the call to `Map()` or
+				// `Heads()` and the call to `Get()`, so we just ignore this error
+				if err == layer.ErrLayerDoesNotExist {
+					continue
+				}
 				return nil, err
 			}
 


### PR DESCRIPTION
Fix #31350

As we can see in `daemon.Images()`, there is a gap between
`allImages = daemon.imageStore.Map()` and `l, err :=
daemon.layerStore.Get(layerID)`, so images which still exist when we hit
`allImages = daemon.imageStore.Map()` may have already been deleted when we hit
`l, err := daemon.layerStore.Get(layerID)`.

```
	if danglingOnly {
        	allImages = daemon.imageStore.Heads()
	} else {
        	allImages = daemon.imageStore.Map()
	}

	...

	for id, img := range allImages {
		...

		layerID := img.RootFS.ChainID()
        	var size int64
	        if layerID != "" {
        	        l, err := daemon.layerStore.Get(layerID)
                	if err != nil {
                        	return nil, err
                	}
```
ping @coolljt0725 

Signed-off-by: Yuanhong Peng <pengyuanhong@huawei.com>

