### PR TITLE
pkg/archive/diff.go: avoid redundant options init

### DIFF
--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -41,9 +41,6 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 	aufsTempdir := ""
 	aufsHardlinks := make(map[string]*tar.Header)
 
-	if options == nil {
-		options = &TarOptions{}
-	}
 	// Iterate through the files in the archive.
 	for {
 		hdr, err := tr.Next()


### PR DESCRIPTION


**- What I did**
I've removed one redundant initialization of TarOptions. It was already initialized above.

**- How I did it**
I've deleted three lines of code.

**- How to verify it**
The code above already initializes TarOptions. There's nothing which resets it to make it nil again.

**- Description for the changelog**
pkg/archive/diff.go: avoid redundant options init