### PR TITLE
Use formatter in docker port

### DIFF
--- a/cli/command/formatter/port.go
+++ b/cli/command/formatter/port.go
@@ -1,0 +1,27 @@
+package formatter
+
+import "github.com/docker/go-connections/nat"
+
+// PortWrite writes the context
+func PortWrite(ctx Context, frontends []nat.PortBinding) error {
+	render := func(format func(subContext subContext) error) error {
+		for _, frontend := range frontends {
+			pCtx := &portContext{PortBinding: frontend}
+			if err := format(pCtx); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	subCtx := &portContext{}
+	return ctx.Write(subCtx, render)
+}
+
+type portContext struct {
+	HeaderContext
+	nat.PortBinding
+}
+
+func (p *portContext) MarshalJSON() ([]byte, error) {
+	return marshalJSON(p)
+}


### PR DESCRIPTION
**- What I did**
Used formatter to print port list
related to #30431

**- How I did it**
* Add cli/command/formatter/port.go
* Replace fmt.Println with formatter.PortWrite

**- How to verify it**
```bash
$ TESTFLAGS='-check.f DockerSuite.TestPort*' hack/make.sh test-integration-cli
$ TESTFLAGS='-check.f DockerSuite.TestUnpublishedPort*' hack/make.sh test-integration-cli
```
