### PR TITLE
Windows: Fail fs ops on running Hyper-V containers gracefully

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -34,6 +34,11 @@ func (daemon *Daemon) ContainerCopy(name string, res string) (io.ReadCloser, err
 		res = res[1:]
 	}
 
+	// Make sure an online file-system operation is permitted.
+	if err := daemon.isOnlineFSOperationPermitted(container); err != nil {
+		return nil, err
+	}
+
 	return daemon.containerCopy(container, res)
 }
 
@@ -42,6 +47,11 @@ func (daemon *Daemon) ContainerCopy(name string, res string) (io.ReadCloser, err
 func (daemon *Daemon) ContainerStatPath(name string, path string) (stat *types.ContainerPathStat, err error) {
 	container, err := daemon.GetContainer(name)
 	if err != nil {
+		return nil, err
+	}
+
+	// Make sure an online file-system operation is permitted.
+	if err := daemon.isOnlineFSOperationPermitted(container); err != nil {
 		return nil, err
 	}
 
@@ -57,6 +67,11 @@ func (daemon *Daemon) ContainerArchivePath(name string, path string) (content io
 		return nil, nil, err
 	}
 
+	// Make sure an online file-system operation is permitted.
+	if err := daemon.isOnlineFSOperationPermitted(container); err != nil {
+		return nil, nil, err
+	}
+
 	return daemon.containerArchivePath(container, path)
 }
 
@@ -69,6 +84,11 @@ func (daemon *Daemon) ContainerArchivePath(name string, path string) (content io
 func (daemon *Daemon) ContainerExtractToDir(name, path string, noOverwriteDirNonDir bool, content io.Reader) error {
 	container, err := daemon.GetContainer(name)
 	if err != nil {
+		return err
+	}
+
+	// Make sure an online file-system operation is permitted.
+	if err := daemon.isOnlineFSOperationPermitted(container); err != nil {
 		return err
 	}
 

--- a/daemon/archive_unix.go
+++ b/daemon/archive_unix.go
@@ -56,3 +56,9 @@ func fixPermissions(source, destination string, uid, gid int, destExisted bool) 
 		return os.Lchown(fullpath, uid, gid)
 	})
 }
+
+// isOnlineFSOperationPermitted returns an error if an online filesystem operation
+// is not permitted.
+func (daemon *Daemon) isOnlineFSOperationPermitted(container *container.Container) error {
+	return nil
+}

--- a/daemon/archive_windows.go
+++ b/daemon/archive_windows.go
@@ -1,6 +1,11 @@
 package daemon
 
-import "github.com/docker/docker/container"
+import (
+	"errors"
+
+	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/container"
+)
 
 // checkIfPathIsInAVolume checks if the path is in a volume. If it is, it
 // cannot be in a read-only volume. If it  is not in a volume, the container
@@ -14,5 +19,26 @@ func checkIfPathIsInAVolume(container *container.Container, absPath string) (boo
 
 func fixPermissions(source, destination string, uid, gid int, destExisted bool) error {
 	// chown is not supported on Windows
+	return nil
+}
+
+// isOnlineFSOperationPermitted returns an error if an online filesystem operation
+// is not permitted (such as stat or for copying). Running Hyper-V containers
+// cannot have their file-system interrogated from the host as the filter is
+// loaded inside the utility VM, not the host.
+// IMPORTANT: The container lock must NOT be held when calling this function.
+func (daemon *Daemon) isOnlineFSOperationPermitted(container *container.Container) error {
+	if !container.IsRunning() {
+		return nil
+	}
+
+	// Determine isolation. If not specified in the hostconfig, use daemon default.
+	actualIsolation := container.HostConfig.Isolation
+	if containertypes.Isolation.IsDefault(containertypes.Isolation(actualIsolation)) {
+		actualIsolation = daemon.defaultIsolation
+	}
+	if containertypes.Isolation.IsHyperV(actualIsolation) {
+		return errors.New("filesystem operations against a running Hyper-V container are not supported")
+	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: John Howard (VM) <jhoward@ntdev.microsoft.com>

@thaJeztah Fixes https://github.com/docker/docker/issues/31606

Note - can't do a CI test for this as CI doesn't support Hyper-V containers on the Azure hosts. Manual verification with the daemon set to run with default isolation of Hyper-V.

```
PS E:\go\src\github.com\docker\docker> docker run -d --rm microsoft/nanoserver ping -t 127.0.0.1
6fdd49a48088cd269a30dfc1873cbc5da3c625bbf2c6d04bc170fd59d94b823d
PS E:\go\src\github.com\docker\docker> docker cp 6fd:c:\dockerfile e:\dockerfile
Error response from daemon: filesystem operations against a running Hyper-V container are not supported
PS E:\go\src\github.com\docker\docker>
```