### PR TITLE
improve semantics of utility function in cli/command/service

### DIFF
--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -29,7 +29,7 @@ func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.StringVar(&opts.mode, flagMode, "replicated", "Service mode (replicated or global)")
 	flags.StringVar(&opts.name, flagName, "", "Service name")
 
-	addServiceFlags(cmd, opts)
+	addServiceFlags(flags, opts)
 
 	flags.VarP(&opts.labels, flagLabel, "l", "Service labels")
 	flags.Var(&opts.containerLabels, flagContainerLabel, "Container labels")

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/opts"
 	runconfigopts "github.com/docker/docker/runconfig/opts"
-	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type int64Value interface {
@@ -468,9 +468,7 @@ func (opts *serviceOptions) ToService() (swarm.ServiceSpec, error) {
 
 // addServiceFlags adds all flags that are common to both `create` and `update`.
 // Any flags that are not common are added separately in the individual command
-func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
-	flags := cmd.Flags()
-
+func addServiceFlags(flags *pflag.FlagSet, opts *serviceOptions) {
 	flags.StringVarP(&opts.workdir, flagWorkdir, "w", "", "Working directory inside the container")
 	flags.StringVarP(&opts.user, flagUser, "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
 	flags.StringVar(&opts.hostname, flagHostname, "", "Container hostname")

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -43,7 +43,7 @@ func newUpdateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.SetAnnotation("rollback", "version", []string{"1.25"})
 	flags.Bool("force", false, "Force update even if no changes require it")
 	flags.SetAnnotation("force", "version", []string{"1.25"})
-	addServiceFlags(cmd, serviceOpts)
+	addServiceFlags(flags, serviceOpts)
 
 	flags.Var(newListOptsVar(), flagEnvRemove, "Remove an environment variable")
 	flags.Var(newListOptsVar(), flagGroupRemove, "Remove a previously added supplementary user group from the container")


### PR DESCRIPTION
Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>

**- What I did**

I changed the signature of the `addServiceFlags` function in `cli/command/service/opts.go`

I replaced the `*cobra.Command` param by a `*pflag.FlagSet` param, as the function doesn't need a cobra.Command struct. This makes it more "reusable", IMO.

🐨