### PR TITLE
Add ability to pass wildcard pattern for env vars

### DIFF
--- a/opts/env.go
+++ b/opts/env.go
@@ -39,13 +39,12 @@ func ExpandEnvWildcard(pattern string) []string {
 	for _, entry := range os.Environ() {
 		parts := strings.SplitN(entry, "=", 2)
 		name := parts[0]
-		val := parts[1]
 		matched, err := filepath.Match(pattern, name)
 		if err != nil {
 			break
 		}
 		if matched {
-			opts = append(opts, fmt.Sprintf("%s=%s", name, val))
+			opts = append(opts, entry)
 		}
 	}
 

--- a/opts/env.go
+++ b/opts/env.go
@@ -3,6 +3,7 @@ package opts
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -27,6 +28,28 @@ func ValidateEnv(val string) (string, error) {
 		return val, nil
 	}
 	return fmt.Sprintf("%s=%s", val, os.Getenv(val)), nil
+}
+
+// ExpandEnvWildcard takes a glob pattern and then returns a slice of strings
+// of the form KEY=VALUE with environment variables where KEY matches the glob
+// pattern.
+func ExpandEnvWildcard(pattern string) []string {
+	var opts []string
+
+	for _, entry := range os.Environ() {
+		parts := strings.SplitN(entry, "=", 2)
+		name := parts[0]
+		val := parts[1]
+		matched, err := filepath.Match(pattern, name)
+		if err != nil {
+			break
+		}
+		if matched {
+			opts = append(opts, fmt.Sprintf("%s=%s", name, val))
+		}
+	}
+
+	return opts
 }
 
 func doesEnvExist(name string) bool {


### PR DESCRIPTION
E.g.:

```
$ docker run --env-wildcard='GO_*' -it bash -c 'env | sort | grep ^GO_'
GO_LINT_COMMIT=32a87160691b3c96046c0c678fe57c5bef761456
GO_SWAGGER_COMMIT=c28258affb0b6251755d92489ef685af8d4ff3eb
GO_TOOLS_COMMIT=823804e1ae08dbb14eb807afc7db9993bc9e3cc3
GO_VERSION=1.7.5
```

This is useful because if you have an app named "foobar" and it reads its config from many environment variables that all start with `FOOBAR_`, then you can simply use `--env-wildcard 'FOOBAR_*'` instead of listing each environment variable, which is ugly and error-prone (it's easy to add a new environment variable and to forget to add it to the list of variables to pass through).

**- How to verify it**

```
$ docker run --env-wildcard='GO_*' -it bash -c 'env | sort | grep ^GO_'
GO_LINT_COMMIT=32a87160691b3c96046c0c678fe57c5bef761456
GO_SWAGGER_COMMIT=c28258affb0b6251755d92489ef685af8d4ff3eb
GO_TOOLS_COMMIT=823804e1ae08dbb14eb807afc7db9993bc9e3cc3
GO_VERSION=1.7.5
```

**- Description for the changelog**

Add ability to pass wildcard pattern for env vars (e.g.: `docker run --env-wildcard MY_APP_* ...`)

**- A picture of a cute animal (not mandatory but encouraged)**

![cute bunny](http://wallpapercave.com/wp/QkzwVSB.jpg)