### PR TITLE
Filter credentials sent by the native cred store on Build

### DIFF
--- a/cli/config/credentials/native_store_test.go
+++ b/cli/config/credentials/native_store_test.go
@@ -82,8 +82,73 @@ func (m *mockCommand) Input(in io.Reader) {
 	m.input = in
 }
 
+// desktopMockCommand simulates interactions between the docker client and a desktop
+// credentials helper.
+// Unit tests inject this mocked command into the remote to control execution.
+type desktopMockCommand struct {
+	arg   string
+	input io.Reader
+}
+
+// Output returns responses from the desktop credentials helper.
+// It mocks those responses based in the input in the mock.
+func (m *desktopMockCommand) Output() ([]byte, error) {
+	in, err := ioutil.ReadAll(m.input)
+	if err != nil {
+		return nil, err
+	}
+	inS := string(in)
+
+	switch m.arg {
+	case "erase":
+		switch inS {
+		case validServerAddress:
+			return nil, nil
+		default:
+			return []byte("program failed"), errCommandExited
+		}
+	case "get":
+		switch inS {
+		case validServerAddress:
+			return []byte(`{"Username": "foo", "Secret": "bar"}`), nil
+		case validServerAddress2:
+			return []byte(`{"Username": "<token>", "Secret": "abcd1234"}`), nil
+		case missingCredsAddress:
+			return []byte(credentials.NewErrCredentialsNotFound().Error()), errCommandExited
+		case invalidServerAddress:
+			return []byte("program failed"), errCommandExited
+		}
+	case "store":
+		var c credentials.Credentials
+		err := json.NewDecoder(strings.NewReader(inS)).Decode(&c)
+		if err != nil {
+			return []byte("program failed"), errCommandExited
+		}
+		switch c.ServerURL {
+		case validServerAddress:
+			return nil, nil
+		default:
+			return []byte("program failed"), errCommandExited
+		}
+	case "list":
+		return []byte("{}"), nil
+	}
+
+	return []byte(fmt.Sprintf("unknown argument %q with %q", m.arg, inS)), errCommandExited
+}
+
+// Input sets the input to send to a desktop credentials helper.
+func (m *desktopMockCommand) Input(in io.Reader) {
+	m.input = in
+}
+
 func mockCommandFn(args ...string) client.Program {
 	return &mockCommand{
+		arg: args[0],
+	}
+}
+func desktopMockCommandFn(args ...string) client.Program {
+	return &desktopMockCommand{
 		arg: args[0],
 	}
 }
@@ -266,6 +331,35 @@ func TestNativeStoreGetAll(t *testing.T) {
 	}
 	if as[validServerAddress2].Email != "" {
 		t.Fatalf("expected no email for %s, got %s", validServerAddress2, as[validServerAddress2].Email)
+	}
+}
+
+func TestNativeStoreGetAllDesktopByConfigFile(t *testing.T) {
+	f := newConfigFile(map[string]types.AuthConfig{
+		validServerAddress2: {},
+	})
+	f.CredentialsStore = "mock"
+
+	s := &nativeStore{
+		programFunc: desktopMockCommandFn,
+		fileStore:   NewFileStore(f),
+	}
+	as, err := s.GetAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(as) != 1 {
+		t.Fatalf("wanted 1, got %d", len(as))
+	}
+
+	_, ok := as[validServerAddress]
+	if ok {
+		t.Fatalf("should not get credentials for %s", validServerAddress)
+	}
+	_, ok = as[validServerAddress2]
+	if !ok {
+		t.Fatalf("should get credentials for %s", validServerAddress2)
 	}
 }
 


### PR DESCRIPTION
Previously, this used to fetch all credentials from the cred store
without any filtering. So if the underlying native credstore contained credentials
for things not related to Docker (which was the case with the mac and
windows credential helpers), this would send much more credentials to
the daemon than required.

Additionaly, if the user uses multiple config files for different
environments, credentials for every environment would be sent without
filtering to every targeted daemon.

Now, instead of asking the credential store a list of credentials, we
list all authenticated registries from the current config file, and we
ask the credential store if it has credentials for them.

fixes #31517 

**- What I did**

Filter which credentials are sent to the daemon on `docker build` from auths referenced in the config file

**- How I did it**

I removed the listCredentialsInStore method, and used the credentials list in the current config file to know which credentials should be sent

**- How to verify it**

Use Docker for mac or windows, patch docker cli with the one from this PR, 
- login to a private registry, 
- create a docker file with a FROM `something in this private registry`
- make sure docker build success
- edit the docker.config file and remove the corresponding auth entry
- make sure docker build fails

**- Description for the changelog**
Fixes an issue with credential helpers where too many credentials were sent to the daemon


