### PR TITLE
Dockerfile: move comments to fix build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -192,13 +192,13 @@ RUN set -x \
 
 # Get the "docker-py" source so we can run their integration tests
 ENV DOCKER_PY_COMMIT 4a08d04aef0595322e1b5ac7c52f28a931da85a5
+# To run integration tests docker-pycreds is required.
+# Before running the integration tests conftest.py is
+# loaded which results in loads auth.py that
+# imports the docker-pycreds module.
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \
-	# To run integration tests docker-pycreds is required.
-	# Before running the integration tests conftest.py is
-	# loaded which results in loads auth.py that
-	# imports the docker-pycreds module.
 	&& pip install docker-pycreds==0.2.1 \
 	&& pip install -r test-requirements.txt
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -143,13 +143,13 @@ RUN set -x \
 
 # Get the "docker-py" source so we can run their integration tests
 ENV DOCKER_PY_COMMIT 4a08d04aef0595322e1b5ac7c52f28a931da85a5
+# Before running the integration tests conftest.py is
+# loaded which results in loads auth.py that
+# imports the docker-pycreds module.
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \
 	&& pip install wheel \
-	# Before running the integration tests conftest.py is
-	# loaded which results in loads auth.py that
-	# imports the docker-pycreds module.
 	&& pip install docker-pycreds==0.2.1 \
 	&& pip install -r test-requirements.txt
 


### PR DESCRIPTION
**- What I did**
I've moved a block of comments out of a group of shell commands.
I was getting an error message which said "unknown instruction &&".

**- How to verify it**
Use an older Docker version to check if you run into build errors
without this patch.

**- Description for the changelog**
Dockerfile: move comments to fix build error
