### PR TITLE
fix a typo

### DIFF
--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -52,7 +52,7 @@ func NewSearchCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.BoolVar(&opts.automated, "automated", false, "Only show automated builds")
 	flags.UintVarP(&opts.stars, "stars", "s", 0, "Only displays with at least x stars")
 
-	flags.MarkDeprecated("automated", "use --filter=automated=true instead")
+	flags.MarkDeprecated("automated", "use --filter=is-automated=true instead")
 	flags.MarkDeprecated("stars", "use --filter=stars=3 instead")
 
 	return cmd


### PR DESCRIPTION
when i was using:
docker search --automated -s 3 nginx
told me:
Flag --automated has been deprecated, use --filter=automated=true instead
Flag --stars has been deprecated, use --filter=stars=3 instead
and when i use:
docker search --filter=automated=true --filter=stars=3 nginx
told me:
Error response from daemon: Invalid filter 'automated'
and i found out that the correct command should be:
docker search --filter=is-automated=true --filter=stars=3 nginx

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

