### PR TITLE
Use generic handler for pprof profile lookups

### DIFF
--- a/api/server/profiler.go
+++ b/api/server/profiler.go
@@ -19,10 +19,15 @@ func profilerSetup(mainRouter *mux.Router) {
 	r.HandleFunc("/pprof/profile", pprof.Profile)
 	r.HandleFunc("/pprof/symbol", pprof.Symbol)
 	r.HandleFunc("/pprof/trace", pprof.Trace)
-	r.HandleFunc("/pprof/block", pprof.Handler("block").ServeHTTP)
-	r.HandleFunc("/pprof/heap", pprof.Handler("heap").ServeHTTP)
-	r.HandleFunc("/pprof/goroutine", pprof.Handler("goroutine").ServeHTTP)
-	r.HandleFunc("/pprof/threadcreate", pprof.Handler("threadcreate").ServeHTTP)
+	r.HandleFunc("/pprof/{name}", handlePprof)
+}
+
+func handlePprof(w http.ResponseWriter, r *http.Request) {
+	var name string
+	if vars := mux.Vars(r); vars != nil {
+		name = vars["name"]
+	}
+	pprof.Handler(name).ServeHTTP(w, r)
 }
 
 // Replicated from expvar.go as not public.


### PR DESCRIPTION
This more (in spirit) mimics the handler usage in net/http/pprof.
It also makes sure that any new profiles that are added are
automatically supported (e.g. `mutex` profiles in go1.8).

Signed-off-by: Brian Goff <cpuguy83@gmail.com>