### PR TITLE
Fix zsh-completion for containers in status 'created'

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -78,7 +78,7 @@ __docker_get_containers() {
             s="${${line[${begin[CONTAINER ID]},${end[CONTAINER ID]}]%% ##}[0,12]}"
             s="$s:${(l:15:: :::)${${line[${begin[CREATED]},${end[CREATED]}]/ ago/}%% ##}}"
             s="$s, ${${${line[${begin[IMAGE]},${end[IMAGE]}]}/:/\\:}%% ##}"
-            if [[ ${line[${begin[STATUS]},${end[STATUS]}]} = Exit* ]]; then
+            if [[ ${line[${begin[STATUS]},${end[STATUS]}]} = (Exit*|Created*) ]]; then
                 stopped=($stopped $s)
             else
                 running=($running $s)
@@ -100,7 +100,7 @@ __docker_get_containers() {
             (( $#s != 0 )) || continue
             s="$s:${(l:15:: :::)${${line[${begin[CREATED]},${end[CREATED]}]/ ago/}%% ##}}"
             s="$s, ${${${line[${begin[IMAGE]},${end[IMAGE]}]}/:/\\:}%% ##}"
-            if [[ ${line[${begin[STATUS]},${end[STATUS]}]} = Exit* ]]; then
+            if [[ ${line[${begin[STATUS]},${end[STATUS]}]} = (Exit*|Created*) ]]; then
                 stopped=($stopped $s)
             else
                 running=($running $s)


### PR DESCRIPTION
This patch makes sure that containers in the created-stated are
counted as stopped containers. Otherwise if you create a container,
don't run it and type: "docker rm ", followed by pressing tab in zsh, it won't show up.

Signed-off-by: Nikolas Garofil <nikolas.garofil@uantwerpen.be>

