### PR TITLE
Provide daemon config to enable/disable pprof

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -33,11 +33,12 @@ type Config struct {
 
 // Server contains instance details for the server
 type Server struct {
-	cfg           *Config
-	servers       []*HTTPServer
-	routers       []router.Router
-	routerSwapper *routerSwapper
-	middlewares   []middleware.Middleware
+	cfg             *Config
+	servers         []*HTTPServer
+	routers         []router.Router
+	routerSwapper   *routerSwapper
+	middlewares     []middleware.Middleware
+	profilerEnabled bool
 }
 
 // New returns a new instance of the server based on the specified configuration.
@@ -151,13 +152,10 @@ func (s *Server) makeHTTPHandler(handler httputils.APIFunc) http.HandlerFunc {
 
 // InitRouter initializes the list of routers for the server.
 // This method also enables the Go profiler if enableProfiler is true.
-func (s *Server) InitRouter(enableProfiler bool, routers ...router.Router) {
+func (s *Server) InitRouter(routers ...router.Router) {
 	s.routers = append(s.routers, routers...)
 
 	m := s.createMux()
-	if enableProfiler {
-		profilerSetup(m)
-	}
 	s.routerSwapper = &routerSwapper{
 		router: m,
 	}
@@ -200,12 +198,23 @@ func (s *Server) Wait(waitChan chan error) {
 
 // DisableProfiler reloads the server mux without adding the profiler routes.
 func (s *Server) DisableProfiler() {
+	if !s.profilerEnabled {
+		return
+	}
+	logrus.Debug("disabling profiler endpoint")
 	s.routerSwapper.Swap(s.createMux())
+	s.profilerEnabled = false
 }
 
 // EnableProfiler reloads the server mux adding the profiler routes.
 func (s *Server) EnableProfiler() {
+	if s.profilerEnabled {
+		return
+	}
+	logrus.Debug("enabling profiler endpoint")
+
 	m := s.createMux()
 	profilerSetup(m)
 	s.routerSwapper.Swap(m)
+	s.profilerEnabled = true
 }

--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -46,6 +46,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.BoolVar(&conf.Experimental, "experimental", false, "Enable experimental features")
 
 	flags.StringVar(&conf.MetricsAddress, "metrics-addr", "", "Set default address and port to serve the metrics api on")
+	flags.BoolVar(&conf.EnableProfilerEndpoints, "enable-profiler-endpoints", false, "Enables the profiler endpoints")
 
 	conf.MaxConcurrentDownloads = &maxConcurrentDownloads
 	conf.MaxConcurrentUploads = &maxConcurrentUploads

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -159,6 +159,9 @@ type CommonConfig struct {
 	ValuesSet map[string]interface{}
 
 	Experimental bool `json:"experimental"` // Experimental indicates whether experimental features should be exposed or not
+
+	// enables the pprof http endpoints
+	EnableProfilerEndpoints bool `json:"enable-profiler-endpoints"`
 }
 
 // IsValueSet returns true if a configuration value


### PR DESCRIPTION
Currently the only way to enable the profiler is to enable debug mode.
It's nice that this can be enabled/disabled with a config reload,
however users may not want to run debug logging and whatever else might
mean "debug" but still be able access things like CPU profiles.

This breaks out the the toggle for the profiler separately from debug
mode.
Debug mode will still enable the profiler, but is not required for it.
The new config is able to be reloaded from `SIGHUP`.

For now, if debug mode is enabled the profiler is always enabled
regardless if the profiler flag is set (to false), this is similar to
the log-level setting always being `debug` when debug mode is enabled
regardless of the `--log-level` setting.