### PR TITLE
api: Remove SecretRequestOption type

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"io"
 	"net"
-	"os"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -362,15 +361,6 @@ type PluginInstallOptions struct {
 	PrivilegeFunc         RequestPrivilegeFunc
 	AcceptPermissionsFunc func(PluginPrivileges) (bool, error)
 	Args                  []string
-}
-
-// SecretRequestOption is a type for requesting secrets
-type SecretRequestOption struct {
-	Source string
-	Target string
-	UID    string
-	GID    string
-	Mode   os.FileMode
 }
 
 // SwarmUnlockKeyResponse contains the response for Engine API:

--- a/cli/command/service/parse.go
+++ b/cli/command/service/parse.go
@@ -10,27 +10,19 @@ import (
 	"golang.org/x/net/context"
 )
 
-// ParseSecrets retrieves the secrets from the requested names and converts
-// them to secret references to use with the spec
-func ParseSecrets(client client.SecretAPIClient, requestedSecrets []*types.SecretRequestOption) ([]*swarmtypes.SecretReference, error) {
+// ParseSecrets retrieves the secrets with the requested names and fills
+// secret IDs into the secret references.
+func ParseSecrets(client client.SecretAPIClient, requestedSecrets []*swarmtypes.SecretReference) ([]*swarmtypes.SecretReference, error) {
 	secretRefs := make(map[string]*swarmtypes.SecretReference)
 	ctx := context.Background()
 
 	for _, secret := range requestedSecrets {
-		if _, exists := secretRefs[secret.Target]; exists {
-			return nil, fmt.Errorf("duplicate secret target for %s not allowed", secret.Source)
+		if _, exists := secretRefs[secret.File.Name]; exists {
+			return nil, fmt.Errorf("duplicate secret target for %s not allowed", secret.SecretName)
 		}
-		secretRef := &swarmtypes.SecretReference{
-			File: &swarmtypes.SecretReferenceFileTarget{
-				Name: secret.Target,
-				UID:  secret.UID,
-				GID:  secret.GID,
-				Mode: secret.Mode,
-			},
-			SecretName: secret.Source,
-		}
-
-		secretRefs[secret.Target] = secretRef
+		secretRef := new(swarmtypes.SecretReference)
+		*secretRef = *secret
+		secretRefs[secret.File.Name] = secretRef
 	}
 
 	args := filters.NewArgs()

--- a/opts/secret_test.go
+++ b/opts/secret_test.go
@@ -16,10 +16,10 @@ func TestSecretOptionsSimple(t *testing.T) {
 	reqs := opt.Value()
 	assert.Equal(t, len(reqs), 1)
 	req := reqs[0]
-	assert.Equal(t, req.Source, "app-secret")
-	assert.Equal(t, req.Target, "app-secret")
-	assert.Equal(t, req.UID, "0")
-	assert.Equal(t, req.GID, "0")
+	assert.Equal(t, req.SecretName, "app-secret")
+	assert.Equal(t, req.File.Name, "app-secret")
+	assert.Equal(t, req.File.UID, "0")
+	assert.Equal(t, req.File.GID, "0")
 }
 
 func TestSecretOptionsSourceTarget(t *testing.T) {
@@ -31,8 +31,8 @@ func TestSecretOptionsSourceTarget(t *testing.T) {
 	reqs := opt.Value()
 	assert.Equal(t, len(reqs), 1)
 	req := reqs[0]
-	assert.Equal(t, req.Source, "foo")
-	assert.Equal(t, req.Target, "testing")
+	assert.Equal(t, req.SecretName, "foo")
+	assert.Equal(t, req.File.Name, "testing")
 }
 
 func TestSecretOptionsShorthand(t *testing.T) {
@@ -44,7 +44,7 @@ func TestSecretOptionsShorthand(t *testing.T) {
 	reqs := opt.Value()
 	assert.Equal(t, len(reqs), 1)
 	req := reqs[0]
-	assert.Equal(t, req.Source, "foo")
+	assert.Equal(t, req.SecretName, "foo")
 }
 
 func TestSecretOptionsCustomUidGid(t *testing.T) {
@@ -56,10 +56,10 @@ func TestSecretOptionsCustomUidGid(t *testing.T) {
 	reqs := opt.Value()
 	assert.Equal(t, len(reqs), 1)
 	req := reqs[0]
-	assert.Equal(t, req.Source, "foo")
-	assert.Equal(t, req.Target, "testing")
-	assert.Equal(t, req.UID, "1000")
-	assert.Equal(t, req.GID, "1001")
+	assert.Equal(t, req.SecretName, "foo")
+	assert.Equal(t, req.File.Name, "testing")
+	assert.Equal(t, req.File.UID, "1000")
+	assert.Equal(t, req.File.GID, "1001")
 }
 
 func TestSecretOptionsCustomMode(t *testing.T) {
@@ -71,9 +71,9 @@ func TestSecretOptionsCustomMode(t *testing.T) {
 	reqs := opt.Value()
 	assert.Equal(t, len(reqs), 1)
 	req := reqs[0]
-	assert.Equal(t, req.Source, "foo")
-	assert.Equal(t, req.Target, "testing")
-	assert.Equal(t, req.UID, "1000")
-	assert.Equal(t, req.GID, "1001")
-	assert.Equal(t, req.Mode, os.FileMode(0444))
+	assert.Equal(t, req.SecretName, "foo")
+	assert.Equal(t, req.File.Name, "testing")
+	assert.Equal(t, req.File.UID, "1000")
+	assert.Equal(t, req.File.GID, "1001")
+	assert.Equal(t, req.File.Mode, os.FileMode(0444))
 }


### PR DESCRIPTION
This type is only used by CLI code. It duplicates `SecretReference` in the types/swarm package. Change the CLI code to use that type instead.

cc @dnephin @ehazlett @vdemeester