### PR TITLE
[docs] Fix incorrect `docker inspect` example

### DIFF
--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -63,7 +63,7 @@ $ docker inspect --format='{{.LogPath}}' $INSTANCE_ID
 ### Get an instance's image name
 
 ```bash
-$ docker inspect --format='{{.Container.Spec.Image}}' $INSTANCE_ID
+$ docker inspect --format='{{.Config.Image}}' $INSTANCE_ID
 ```
 
 ### List all port bindings


### PR DESCRIPTION
Fixed incorrect `docker inspect` example in docs.
Verify by running the old and new commands.

fixes #31900

Signed-off-by: David Xia <dxia@spotify.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed incorrect `docker inspect` example in docs.

**- How I did it**
By editing the doc

**- How to verify it**
Verify by running the old and new commands.

**- Description for the changelog**
Fixed incorrect `docker inspect` example in docs.

**- A picture of a cute animal (not mandatory but encouraged)**


![amuoycn](https://cloud.githubusercontent.com/assets/480621/24018116/fd3a8d52-0a68-11e7-8c4c-fd6c4b6c3c08.jpg)
