### PR TITLE
specify max size for secret in doc

### DIFF
--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -27,8 +27,9 @@ Options:
 
 ## Description
 
-Creates a secret using standard input or from a file for the secret content. You must run this
-command on a manager node.
+Creates a secret using standard input or from a file for the secret content. You must run this command on a manager node. 
+
+For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
 
 ## Examples
 

--- a/docs/reference/commandline/secret_inspect.md
+++ b/docs/reference/commandline/secret_inspect.md
@@ -36,6 +36,8 @@ the given template will be executed for each result.
 Go's [text/template](http://golang.org/pkg/text/template/) package
 describes all the details of the format.
 
+For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
+
 ## Examples
 
 ### Inspect a secret by name or ID

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -32,6 +32,8 @@ Options:
 
 Run this command on a manager node to list the secrets in the swarm.
 
+For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
+
 ## Examples
 
 ```bash

--- a/docs/reference/commandline/secret_rm.md
+++ b/docs/reference/commandline/secret_rm.md
@@ -32,6 +32,8 @@ Options:
 Removes the specified secrets from the swarm. This command has to be run
 targeting a manager node.
 
+For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
+
 ## Examples
 
 This example removes a secret:


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I think we should explain the max size for secret in docs, since it has been specified in https://github.com/docker/swarmkit/blob/master/manager/controlapi/secret.go#L21

**- What I did**
1. specify max size for secret in doc

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

