### PR TITLE
improve error of `docker network create -d overlay` on non-Swarm node

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -335,6 +335,9 @@ func (daemon *Daemon) createNetwork(create types.NetworkCreateRequest, id string
 
 	n, err := c.NewNetwork(driver, create.Name, id, nwOptions...)
 	if err != nil {
+		if _, ok := err.(libnetwork.ErrDataStoreNotInitialized); ok {
+			return nil, errors.New("This node is not a swarm manager. Use \"docker swarm init\" or \"docker swarm join\" to connect this node to swarm and try again.")
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Improved the error of `docker network create -d overlay` on non-Swarm node.

before: `Error response from daemon: datastore for scope "global" is not initialized`
after: `Error response from daemon: This node is not a swarm manager. Use "docker swarm init" or "docker swarm join" to connect this node to swarm and try again.`

This PR also vendors docker/libnetwork@f6ce0ce8bfc5e3f0c96835b10949cf13591a1708 (for https://github.com/docker/libnetwork/pull/1707)

**- How I did it**

Check `daemon.clusterProvider` during `createNetwork()`.
Also, added`pkg/errorutils` for deduplicating error literals.

**- How to verify it**

`docker network create -d overlay` on non-Swarm node

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![penguin](https://upload.wikimedia.org/wikipedia/commons/6/6b/Emperor_Penguin_chicks_moulting.jpg)


Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>