### PR TITLE
Improve bash completion for `docker rm`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -101,6 +101,10 @@ __docker_complete_containers_all() {
 	__docker_complete_containers "$@" --all
 }
 
+__docker_complete_containers_removable() {
+	__docker_complete_containers "$@" --filter status=created --filter status=exited
+}
+
 __docker_complete_containers_running() {
 	__docker_complete_containers "$@" --filter status=running
 }
@@ -1430,7 +1434,7 @@ _docker_container_rm() {
 						;;
 				esac
 			done
-			__docker_complete_containers_stopped
+			__docker_complete_containers_removable
 			;;
 	esac
 }


### PR DESCRIPTION
This PR applies the idea behind #31891 to bash completion:
`docker rm` can delete containers in state=created, too.
Thus, bash completion for `docker rm` should complete created containers as well.

Thanks @ngaro for catching this.