### PR TITLE
Bash completion for `docker node update` completes only one node

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3522,7 +3522,11 @@ _docker_node_update() {
 			COMPREPLY=( $( compgen -W "--availability --help --label-add --label-rm --role" -- "$cur" ) )
 			;;
 		*)
-			__docker_complete_nodes
+			local counter=$(__docker_pos_first_nonflag '--availability|--label-add|--label-rm|--role')
+			if [ $cword -eq $counter ]; then
+				__docker_complete_nodes
+			fi
+			;;
 	esac
 }
 


### PR DESCRIPTION
`docker node update` accepts only one node:
```bash
$ docker node update --help | grep Usage
Usage:  docker node update [OPTIONS] NODE
```
Before this change, bash completion would complete additional nodes.