### PR TITLE
When authz plugin is disabled, remove from authz middleware chain.

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	daemondiscovery "github.com/docker/docker/daemon/discovery"
 	"github.com/docker/docker/opts"
+	"github.com/docker/docker/pkg/authorization"
 	"github.com/docker/docker/pkg/discovery"
 	"github.com/docker/docker/registry"
 	"github.com/imdario/mergo"
@@ -82,25 +83,26 @@ type CommonTLSOptions struct {
 // It includes json tags to deserialize configuration from a file
 // using the same names that the flags in the command line use.
 type CommonConfig struct {
-	AuthorizationPlugins []string            `json:"authorization-plugins,omitempty"` // AuthorizationPlugins holds list of authorization plugins
-	AutoRestart          bool                `json:"-"`
-	Context              map[string][]string `json:"-"`
-	DisableBridge        bool                `json:"-"`
-	DNS                  []string            `json:"dns,omitempty"`
-	DNSOptions           []string            `json:"dns-opts,omitempty"`
-	DNSSearch            []string            `json:"dns-search,omitempty"`
-	ExecOptions          []string            `json:"exec-opts,omitempty"`
-	GraphDriver          string              `json:"storage-driver,omitempty"`
-	GraphOptions         []string            `json:"storage-opts,omitempty"`
-	Labels               []string            `json:"labels,omitempty"`
-	Mtu                  int                 `json:"mtu,omitempty"`
-	Pidfile              string              `json:"pidfile,omitempty"`
-	RawLogs              bool                `json:"raw-logs,omitempty"`
-	Root                 string              `json:"graph,omitempty"`
-	SocketGroup          string              `json:"group,omitempty"`
-	TrustKeyPath         string              `json:"-"`
-	CorsHeaders          string              `json:"api-cors-header,omitempty"`
-	EnableCors           bool                `json:"api-enable-cors,omitempty"`
+	AuthzMiddleware      *authorization.Middleware `json:"-"`
+	AuthorizationPlugins []string                  `json:"authorization-plugins,omitempty"` // AuthorizationPlugins holds list of authorization plugins
+	AutoRestart          bool                      `json:"-"`
+	Context              map[string][]string       `json:"-"`
+	DisableBridge        bool                      `json:"-"`
+	DNS                  []string                  `json:"dns,omitempty"`
+	DNSOptions           []string                  `json:"dns-opts,omitempty"`
+	DNSSearch            []string                  `json:"dns-search,omitempty"`
+	ExecOptions          []string                  `json:"exec-opts,omitempty"`
+	GraphDriver          string                    `json:"storage-driver,omitempty"`
+	GraphOptions         []string                  `json:"storage-opts,omitempty"`
+	Labels               []string                  `json:"labels,omitempty"`
+	Mtu                  int                       `json:"mtu,omitempty"`
+	Pidfile              string                    `json:"pidfile,omitempty"`
+	RawLogs              bool                      `json:"raw-logs,omitempty"`
+	Root                 string                    `json:"graph,omitempty"`
+	SocketGroup          string                    `json:"group,omitempty"`
+	TrustKeyPath         string                    `json:"-"`
+	CorsHeaders          string                    `json:"api-cors-header,omitempty"`
+	EnableCors           bool                      `json:"api-enable-cors,omitempty"`
 
 	// LiveRestoreEnabled determines whether we should keep containers
 	// alive upon daemon shutdown/start

--- a/pkg/authorization/plugin.go
+++ b/pkg/authorization/plugin.go
@@ -61,6 +61,11 @@ func (a *authorizationPlugin) Name() string {
 	return a.name
 }
 
+// Set the remote for an authz pluginv2
+func (a *authorizationPlugin) SetName(remote string) {
+	a.name = remote
+}
+
 func (a *authorizationPlugin) AuthZRequest(authReq *Request) (*Response, error) {
 	if err := a.initPlugin(); err != nil {
 		return nil, err
@@ -98,6 +103,7 @@ func (a *authorizationPlugin) initPlugin() error {
 
 			if pg := GetPluginGetter(); pg != nil {
 				plugin, e = pg.Get(a.name, AuthZApiImplements, plugingetter.Lookup)
+				a.SetName(plugin.Name())
 			} else {
 				plugin, e = plugins.Get(a.name, AuthZApiImplements)
 			}

--- a/plugin/defs.go
+++ b/plugin/defs.go
@@ -18,7 +18,7 @@ type Store struct {
 }
 
 // NewStore creates a Store.
-func NewStore(libRoot string) *Store {
+func NewStore() *Store {
 	return &Store{
 		plugins:  make(map[string]*v2.Plugin),
 		handlers: make(map[string][]func(string, *plugins.Client)),

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/libcontainerd"
+	"github.com/docker/docker/pkg/authorization"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/plugin/v2"
@@ -49,6 +50,7 @@ type ManagerConfig struct {
 	LogPluginEvent     eventLogger
 	Root               string
 	ExecRoot           string
+	AuthzMiddleware    *authorization.Middleware
 }
 
 // Manager controls the plugin subsystem.


### PR DESCRIPTION
When the daemon is configured to run with an authorization-plugin and if
the plugin is disabled, the daemon continues to send API requests to the
plugin and expect it to respond. But the plugin has been disabled. As a
result, all API requests are blocked. Fix this behavior by removing the
disabled plugin from the authz middleware chain.

Tested using riyaz/authz-no-volume-plugin and observed that after
disabling the plugin, API request/response is functional.

Fixes #31836

Signed-off-by: Anusha Ragunathan <anusha.ragunathan@docker.com>