### PR TITLE
Fix Devmapper issue: Power off the VM while loading a image, couldn't load it after the VM bootup

### DIFF
--- a/image/store.go
+++ b/image/store.go
@@ -72,6 +72,11 @@ func (is *store) restore() error {
 		if chainID := img.RootFS.ChainID(); chainID != "" {
 			l, err = is.ls.Get(chainID)
 			if err != nil {
+				logrus.Errorf("Failed to restore layer %s for image %s: %v", chainID, dgst, err)
+				// If the layer doesn't exist, return nil to ignore this image.
+				if err == layer.ErrLayerDoesNotExist {
+					return nil
+				}
 				return err
 			}
 		}


### PR DESCRIPTION
    Issue Description:
    While running loading image test, power off or restart the VM, and then there are
    some chances that we can not load the image. And "Error running
    deviceCreate (createSnapDevice) dm_task_run failed" will be reported.

    Reproduce Steps:
    > 1. run  `docker load -i xxx.tar`
    > 2. virsh restart VM; # restart the VM.
    > 3. After startup, run `docker load -i xxx.tar`, will fail to import the image

    Analysis:
    From syslog, we found that docker was executing "Umount Device" then VM powered restart. And found
    two failure reasons:
    > 1. Rollback operation only remove the device on DM thin pool, not remove the device in memory
    > 2. TransactionData or metadata not flushed to Disk.

    Solution:
    > 1. Rollback operation for DM, should remove the devices cache in DM driver.
    > 2. When restore layers and images, check whether the device exists in graphdriver.
         If desen't, remove the layer( and the metadata) and do not load the image.

    Signed-off-by: Wentao Zhang <zhangwentao234@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix a devicemapper issue:
 when loading a image, restart the VM, when the system bootup, there are some chances to fail to load the image again.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

