### PR TITLE
Fix 'Specify a Dockerfile (-f)' heading in Engine CLI Docs.

### DIFF
--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -334,6 +334,7 @@ For example, to tag an image both as `whenry/fedora-jboss:latest` and
 ```bash
 $ docker build -t whenry/fedora-jboss:latest -t whenry/fedora-jboss:v2.1 .
 ```
+
 ### Specify a Dockerfile (-f)
 
 ```bash


### PR DESCRIPTION
**- What I did**
Fixed broken Markdown header in Engine > CLI > Build doc.

**- How I did it**
Added a newline above the header.

**- How to verify it**
Look at the generated docs. :)

**- Description for the changelog**
Fix broken Markdown header for Engine > CLI > Build doc.

Here's what the broken heading looks like right now:
![docker-doc-broken-header](https://cloud.githubusercontent.com/assets/6017470/24085247/c4ccc4b8-0cce-11e7-9859-1afba56930a9.png)
