### PR TITLE
Fixed:go vetting warning unkeyed fields

### DIFF
--- a/cli/command/container/stats_unit_test.go
+++ b/cli/command/container/stats_unit_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestCalculateBlockIO(t *testing.T) {
 	blkio := types.BlkioStats{
-		IoServiceBytesRecursive: []types.BlkioStatEntry{{8, 0, "read", 1234}, {8, 1, "read", 4567}, {8, 0, "write", 123}, {8, 1, "write", 456}},
+		IoServiceBytesRecursive: []types.BlkioStatEntry{{Major: 8, Minor: 0, Op: "read", Value: 1234}, {Major: 8, Minor: 1, Op: "read", Value: 4567}, {Major: 8, Minor: 0, Op: "write", Value: 123}, {Major: 8, Minor: 1, Op: "write", Value: 456}},
 	}
 	blkRead, blkWrite := calculateBlockIO(blkio)
 	if blkRead != 5801 {

--- a/integration-cli/docker_api_swarm_secret_test.go
+++ b/integration-cli/docker_api_swarm_secret_test.go
@@ -24,10 +24,10 @@ func (s *DockerSwarmSuite) TestAPISwarmSecretsCreate(c *check.C) {
 
 	testName := "test_secret"
 	id := d.CreateSecret(c, swarm.SecretSpec{
-		swarm.Annotations{
+		Annotations: swarm.Annotations{
 			Name: testName,
 		},
-		[]byte("TESTINGDATA"),
+		Data: []byte("TESTINGDATA"),
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 
@@ -41,11 +41,10 @@ func (s *DockerSwarmSuite) TestAPISwarmSecretsDelete(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	testName := "test_secret"
-	id := d.CreateSecret(c, swarm.SecretSpec{
-		swarm.Annotations{
-			Name: testName,
-		},
-		[]byte("TESTINGDATA"),
+	id := d.CreateSecret(c, swarm.SecretSpec{Annotations: swarm.Annotations{
+		Name: testName,
+	},
+		Data: []byte("TESTINGDATA"),
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 
@@ -63,13 +62,13 @@ func (s *DockerSwarmSuite) TestAPISwarmSecretsUpdate(c *check.C) {
 
 	testName := "test_secret"
 	id := d.CreateSecret(c, swarm.SecretSpec{
-		swarm.Annotations{
+		Annotations: swarm.Annotations{
 			Name: testName,
 			Labels: map[string]string{
 				"test": "test1",
 			},
 		},
-		[]byte("TESTINGDATA"),
+		Data: []byte("TESTINGDATA"),
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 

--- a/integration-cli/docker_cli_secret_create_test.go
+++ b/integration-cli/docker_cli_secret_create_test.go
@@ -17,10 +17,10 @@ func (s *DockerSwarmSuite) TestSecretCreate(c *check.C) {
 
 	testName := "test_secret"
 	id := d.CreateSecret(c, swarm.SecretSpec{
-		swarm.Annotations{
+		Annotations: swarm.Annotations{
 			Name: testName,
 		},
-		[]byte("TESTINGDATA"),
+		Data: []byte("TESTINGDATA"),
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 
@@ -33,14 +33,14 @@ func (s *DockerSwarmSuite) TestSecretCreateWithLabels(c *check.C) {
 
 	testName := "test_secret"
 	id := d.CreateSecret(c, swarm.SecretSpec{
-		swarm.Annotations{
+		Annotations: swarm.Annotations{
 			Name: testName,
 			Labels: map[string]string{
 				"key1": "value1",
 				"key2": "value2",
 			},
 		},
-		[]byte("TESTINGDATA"),
+		Data: []byte("TESTINGDATA"),
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 
@@ -57,18 +57,18 @@ func (s *DockerSwarmSuite) TestSecretCreateResolve(c *check.C) {
 
 	name := "test_secret"
 	id := d.CreateSecret(c, swarm.SecretSpec{
-		swarm.Annotations{
+		Annotations: swarm.Annotations{
 			Name: name,
 		},
-		[]byte("foo"),
+		Data: []byte("foo"),
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 
 	fake := d.CreateSecret(c, swarm.SecretSpec{
-		swarm.Annotations{
+		Annotations: swarm.Annotations{
 			Name: id,
 		},
-		[]byte("fake foo"),
+		Data: []byte("fake foo"),
 	})
 	c.Assert(fake, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", fake))
 

--- a/integration-cli/docker_cli_secret_inspect_test.go
+++ b/integration-cli/docker_cli_secret_inspect_test.go
@@ -15,10 +15,10 @@ func (s *DockerSwarmSuite) TestSecretInspect(c *check.C) {
 
 	testName := "test_secret"
 	id := d.CreateSecret(c, swarm.SecretSpec{
-		swarm.Annotations{
+		Annotations: swarm.Annotations{
 			Name: testName,
 		},
-		[]byte("TESTINGDATA"),
+		Data: []byte("TESTINGDATA"),
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 
@@ -42,10 +42,10 @@ func (s *DockerSwarmSuite) TestSecretInspectMultiple(c *check.C) {
 	}
 	for _, n := range testNames {
 		id := d.CreateSecret(c, swarm.SecretSpec{
-			swarm.Annotations{
+			Annotations: swarm.Annotations{
 				Name: n,
 			},
-			[]byte("TESTINGDATA"),
+			Data: []byte("TESTINGDATA"),
 		})
 		c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 

--- a/integration-cli/docker_cli_service_create_test.go
+++ b/integration-cli/docker_cli_service_create_test.go
@@ -68,10 +68,10 @@ func (s *DockerSwarmSuite) TestServiceCreateWithSecretSimple(c *check.C) {
 	serviceName := "test-service-secret"
 	testName := "test_secret"
 	id := d.CreateSecret(c, swarm.SecretSpec{
-		swarm.Annotations{
+		Annotations: swarm.Annotations{
 			Name: testName,
 		},
-		[]byte("TESTINGDATA"),
+		Data: []byte("TESTINGDATA"),
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 
@@ -98,10 +98,10 @@ func (s *DockerSwarmSuite) TestServiceCreateWithSecretSourceTarget(c *check.C) {
 	serviceName := "test-service-secret"
 	testName := "test_secret"
 	id := d.CreateSecret(c, swarm.SecretSpec{
-		swarm.Annotations{
+		Annotations: swarm.Annotations{
 			Name: testName,
 		},
-		[]byte("TESTINGDATA"),
+		Data: []byte("TESTINGDATA"),
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 	testTarget := "testing"

--- a/integration-cli/docker_cli_service_update_test.go
+++ b/integration-cli/docker_cli_service_update_test.go
@@ -91,10 +91,10 @@ func (s *DockerSwarmSuite) TestServiceUpdateSecrets(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 	testName := "test_secret"
 	id := d.CreateSecret(c, swarm.SecretSpec{
-		swarm.Annotations{
+		Annotations: swarm.Annotations{
 			Name: testName,
 		},
-		[]byte("TESTINGDATA"),
+		Data: []byte("TESTINGDATA"),
 	})
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 	testTarget := "testing"

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -14,33 +14,33 @@ func TestValidatePrivileges(t *testing.T) {
 	}{
 		"diff-len": {
 			requiredPrivileges: []types.PluginPrivilege{
-				{"Privilege1", "Description", []string{"abc", "def", "ghi"}},
+				{Name: "Privilege1", Description: "Description", Value: []string{"abc", "def", "ghi"}},
 			},
 			privileges: []types.PluginPrivilege{
-				{"Privilege1", "Description", []string{"abc", "def", "ghi"}},
-				{"Privilege2", "Description", []string{"123", "456", "789"}},
+				{Name: "Privilege1", Description: "Description", Value: []string{"abc", "def", "ghi"}},
+				{Name: "Privilege2", Description: "Description", Value: []string{"123", "456", "789"}},
 			},
 			result: false,
 		},
 		"diff-value": {
 			requiredPrivileges: []types.PluginPrivilege{
-				{"Privilege1", "Description", []string{"abc", "def", "GHI"}},
-				{"Privilege2", "Description", []string{"123", "456", "***"}},
+				{Name: "Privilege1", Description: "Description", Value: []string{"abc", "def", "GHI"}},
+				{Name: "Privilege2", Description: "Description", Value: []string{"123", "456", "***"}},
 			},
 			privileges: []types.PluginPrivilege{
-				{"Privilege1", "Description", []string{"abc", "def", "ghi"}},
-				{"Privilege2", "Description", []string{"123", "456", "789"}},
+				{Name: "Privilege1", Description: "Description", Value: []string{"abc", "def", "ghi"}},
+				{Name: "Privilege2", Description: "Description", Value: []string{"123", "456", "789"}},
 			},
 			result: false,
 		},
 		"diff-order-but-same-value": {
 			requiredPrivileges: []types.PluginPrivilege{
-				{"Privilege1", "Description", []string{"abc", "def", "GHI"}},
-				{"Privilege2", "Description", []string{"123", "456", "789"}},
+				{Name: "Privilege1", Description: "Description", Value: []string{"abc", "def", "GHI"}},
+				{Name: "Privilege2", Description: "Description", Value: []string{"123", "456", "789"}},
 			},
 			privileges: []types.PluginPrivilege{
-				{"Privilege2", "Description", []string{"123", "456", "789"}},
-				{"Privilege1", "Description", []string{"GHI", "abc", "def"}},
+				{Name: "Privilege2", Description: "Description", Value: []string{"123", "456", "789"}},
+				{Name: "Privilege1", Description: "Description", Value: []string{"GHI", "abc", "def"}},
 			},
 			result: true,
 		},

--- a/plugin/store_test.go
+++ b/plugin/store_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestFilterByCapNeg(t *testing.T) {
 	p := v2.Plugin{PluginObj: types.Plugin{Name: "test:latest"}}
-	iType := types.PluginInterfaceType{"volumedriver", "docker", "1.0"}
-	i := types.PluginConfigInterface{"plugins.sock", []types.PluginInterfaceType{iType}}
+	iType := types.PluginInterfaceType{Capability: "volumedriver", Prefix: "docker", Version: "1.0"}
+	i := types.PluginConfigInterface{Socket: "plugins.sock", Types: []types.PluginInterfaceType{iType}}
 	p.PluginObj.Config.Interface = i
 
 	_, err := p.FilterByCap("foobar")
@@ -22,8 +22,8 @@ func TestFilterByCapNeg(t *testing.T) {
 func TestFilterByCapPos(t *testing.T) {
 	p := v2.Plugin{PluginObj: types.Plugin{Name: "test:latest"}}
 
-	iType := types.PluginInterfaceType{"volumedriver", "docker", "1.0"}
-	i := types.PluginConfigInterface{"plugins.sock", []types.PluginInterfaceType{iType}}
+	iType := types.PluginInterfaceType{Capability: "volumedriver", Prefix: "docker", Version: "1.0"}
+	i := types.PluginConfigInterface{Socket: "plugins.sock", Types: []types.PluginInterfaceType{iType}}
 	p.PluginObj.Config.Interface = i
 
 	_, err := p.FilterByCap("volumedriver")

--- a/runconfig/hostconfig_test.go
+++ b/runconfig/hostconfig_test.go
@@ -167,11 +167,11 @@ func TestPidModeTest(t *testing.T) {
 func TestRestartPolicy(t *testing.T) {
 	restartPolicies := map[container.RestartPolicy][]bool{
 		// none, always, failure
-		container.RestartPolicy{}:                {true, false, false},
-		container.RestartPolicy{"something", 0}:  {false, false, false},
-		container.RestartPolicy{"no", 0}:         {true, false, false},
-		container.RestartPolicy{"always", 0}:     {false, true, false},
-		container.RestartPolicy{"on-failure", 0}: {false, false, true},
+		container.RestartPolicy{}:                                         {true, false, false},
+		container.RestartPolicy{Name: "something", MaximumRetryCount: 0}:  {false, false, false},
+		container.RestartPolicy{Name: "no", MaximumRetryCount: 0}:         {true, false, false},
+		container.RestartPolicy{Name: "always", MaximumRetryCount: 0}:     {false, true, false},
+		container.RestartPolicy{Name: "on-failure", MaximumRetryCount: 0}: {false, false, true},
 	}
 	for restartPolicy, state := range restartPolicies {
 		if restartPolicy.IsNone() != state[0] {


### PR DESCRIPTION
Signed-off-by: Aaron.L.Xu <liker.xu@foxmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

Introducing "go tool vet"

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

