### PR TITLE
[WIP] Refactor Container Logs and support TTY for Service Logs

### DIFF
--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -67,6 +67,7 @@ func runLogs(dockerCli *command.DockerCli, opts *logsOptions) error {
 		Timestamps: opts.timestamps,
 		Follow:     opts.follow,
 		Tail:       opts.tail,
+		Details:    true,
 	}
 
 	client := dockerCli.Client()
@@ -75,12 +76,25 @@ func runLogs(dockerCli *command.DockerCli, opts *logsOptions) error {
 	if err != nil {
 		return err
 	}
+	// TODO(dperny) nil checks
+	tty := service.Spec.TaskTemplate.ContainerSpec.TTY
+
+	// TODO(dperny) hot fix until we get a nice details system squared away,
+	// ignores details (including task context) if we have a TTY log
+	if tty {
+		options.Details = false
+	}
 
 	responseBody, err := client.ServiceLogs(ctx, opts.service, options)
 	if err != nil {
 		return err
 	}
 	defer responseBody.Close()
+
+	if tty {
+		_, err = io.Copy(dockerCli.Out(), responseBody)
+		return err
+	}
 
 	var replicas uint64
 	padding := 1

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -20,6 +20,9 @@ import (
 	networktypes "github.com/docker/libnetwork/types"
 	"github.com/docker/swarmkit/agent/exec"
 	"golang.org/x/net/context"
+
+	// TODO(dperny) fix this to avoid this import
+	"github.com/docker/docker/daemon/logger"
 )
 
 // Backend defines the executor component for a swarm agent.
@@ -33,6 +36,7 @@ type Backend interface {
 	ContainerStart(name string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error
 	ContainerStop(name string, seconds *int) error
 	ContainerLogs(context.Context, string, *backend.ContainerLogsConfig, chan struct{}) error
+	ContainerLogsRawChan(context.Context, string, *backend.ContainerLogsConfig, chan *logger.Message) error
 	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error
 	ActivateContainerServiceBinding(containerName string) error
 	DeactivateContainerServiceBinding(containerName string) error


### PR DESCRIPTION
This PR is two commits. The first commit is an almost-substantial refactoring of container logs that needs **design review** before I proceed. It's the main focus of this change.

The second commit is an example of what this refactoring is useful for.

Before merging, there may be further work to support `Details` in service logs, and all of the work will be rebased to 1 commit.

/cc @aluzzardi 

**- What I did**
Support TTY logs in `docker service logs`, facilitated through internal refactoring.

**- How I did it**
I refactored the daemon to expose a new method, `ContainerLogsRawChan`, which sends over a passed-in channel log messages as structs straight from the container logger. I refactored `ContainerLogs` to use this new, lower-level method. I expanded the backend interface that the exec package uses to expose `ContainerLogsRawChan` instead of `ContainerLogs`. I refactored `ServiceLogs` to use this new, lower-level method and avoid having to parse a barely-structured ambiguous byte string.

In a second commit, I made small changes to show how TTY logs would be supported through this change.

**- How to verify it**
Things build, run, and work, but I'm not making guarantees about correctness or passing tests at this time, because I'm anticipating people asking me to make substantial changes to this design (because it involves changing internal APIs). When the design looks good, I'll clean things up, address my own TODOs, and fix the tests.

**- A picture of a cute animal (not mandatory but encouraged)**
this blurry dog should not be driving, because i do not think he has a license.
![image](https://cloud.githubusercontent.com/assets/2367858/24116395/e1559b2e-0d63-11e7-8486-b04922963704.png)

