### PR TITLE
Windows: Fix Docker hanging with named pipes and stdin

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,7 +1,8 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm 388960b655244e76e24c75f48631564eaefade62
 github.com/Microsoft/hcsshim v0.5.12
-github.com/Microsoft/go-winio v0.3.8
+# TODO: get rid of this fork once PR https://github.com/Microsoft/go-winio/pull/43 is merged
+github.com/Microsoft/go-winio 7c7d6b461cb10872c1138a0d7f3acf9a41b5c353 https://github.com/dgageot/go-winio.git
 github.com/Sirupsen/logrus v0.11.0
 github.com/davecgh/go-spew 6d212800a42e8ab5c146b8ace3490ee17e5225f9
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a

--- a/vendor/github.com/Microsoft/go-winio/file.go
+++ b/vendor/github.com/Microsoft/go-winio/file.go
@@ -219,3 +219,7 @@ func (f *win32File) SetWriteDeadline(t time.Time) error {
 	f.writeDeadline = t
 	return nil
 }
+
+func (f *win32File) Flush() error {
+	return syscall.FlushFileBuffers(f.handle)
+}

--- a/vendor/github.com/Microsoft/go-winio/pipe.go
+++ b/vendor/github.com/Microsoft/go-winio/pipe.go
@@ -87,7 +87,11 @@ func (f *win32MessageBytePipe) CloseWrite() error {
 	if f.writeClosed {
 		return errPipeWriteClosed
 	}
-	_, err := f.win32File.Write(nil)
+	err := f.win32File.Flush()
+	if err != nil {
+		return err
+	}
+	_, err = f.win32File.Write(nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #31922

Vendor a fork of Microsoft/go-winio that has this PR (https://github.com/Microsoft/go-winio/pull/43) merged.

Using this fork makes it possible to include the fix soon in docker cli and battle test it in Docker for Windows where it fixes https://github.com/docker/pinata/issues/6770.

Signed-off-by: David Gageot <david@gageot.net>