### PR TITLE
profiles: seccomp: allow clock_settime when CAP_SYS_TIME is added

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -900,7 +900,8 @@
 			"names": [
 				"settimeofday",
 				"stime",
-				"adjtimex"
+				"adjtimex",
+				"clock_settime"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [],

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -735,6 +735,7 @@ func DefaultProfile() *types.Seccomp {
 				"settimeofday",
 				"stime",
 				"adjtimex",
+				"clock_settime",
 			},
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},


### PR DESCRIPTION
This will allow commands like:
```bash
$ docker run --rm --cap-add sys_time registry.access.redhat.com/rhel7 date 03201000
```

/cc @justincormack 

Signed-off-by: Antonio Murdaca <runcom@redhat.com>