### PR TITLE
Add `reference` filter to the list of available filters

### DIFF
--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -158,6 +158,7 @@ The currently supported filters are:
 * label (`label=<key>` or `label=<key>=<value>`)
 * before (`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`) - filter images created before given id or references
 * since (`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`) - filter images created since given id or references
+* reference (pattern of an image reference) - filter images whose reference matches the specified pattern
 
 #### Show untagged images (dangling)
 

--- a/man/src/image/ls.md
+++ b/man/src/image/ls.md
@@ -21,6 +21,7 @@ Filters the output based on these conditions:
    - label=<key> or label=<key>=<value>
    - before=(<image-name>[:tag]|<image-id>|<image@digest>)
    - since=(<image-name>[:tag]|<image-id>|<image@digest>)
+   - reference=(pattern of an image reference)
 
 ## Format
 


### PR DESCRIPTION
The `reference` filter is documented in the file, but is not present
in the list of available filters.

/cc @thaJeztah @mstanleyjones 

🐯

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
