### PR TITLE
Windows: Remove --credentialspec flag

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -115,7 +115,6 @@ type containerOptions struct {
 	autoRemove         bool
 	init               bool
 	initPath           string
-	credentialSpec     string
 
 	Image string
 	Args  []string
@@ -188,8 +187,6 @@ func addFlags(flags *pflag.FlagSet) *containerOptions {
 	flags.BoolVar(&copts.privileged, "privileged", false, "Give extended privileges to this container")
 	flags.Var(&copts.securityOpt, "security-opt", "Security Options")
 	flags.StringVar(&copts.usernsMode, "userns", "", "User namespace to use")
-	flags.StringVar(&copts.credentialSpec, "credentialspec", "", "Credential spec for managed service account (Windows only)")
-	flags.SetAnnotation("credentialspec", "ostype", []string{"windows"})
 
 	// Network and port publishing flag
 	flags.Var(&copts.extraHosts, "add-host", "Add a custom host-to-IP mapping (host:ip)")

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1522,7 +1522,6 @@ _docker_container_run_and_create() {
 	__docker_daemon_os_is windows && options_with_args+="
 		--cpu-count
 		--cpu-percent
-		--credentialspec
 		--io-maxbandwidth
 		--io-maxiops
 		--isolation


### PR DESCRIPTION
Signed-off-by: John Howard (VM) <jhoward@ntdev.microsoft.com>

@johnstep As per offline discussion.

https://github.com/docker/docker/pull/23389#issuecomment-249317778 - this flag was supposed to have been removed from the CLI, but wasn't. Specifically runconfig/opts/parse.go in that PR (it's moved in the codebase now).  This flag isn't wired up to anything and never has been. 