### PR TITLE
Bump go connections for 17.04 and use either system pool or custom CA pool when connecting from client->daemon [17.04]

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -250,8 +250,9 @@ func newHTTPClient(host string, tlsOptions *tlsconfig.Options) (*http.Client, er
 		// let the api client configure the default transport.
 		return nil, nil
 	}
-
-	config, err := tlsconfig.Client(*tlsOptions)
+	opts := *tlsOptions
+	opts.ExclusiveRootPools = true
+	config, err := tlsconfig.Client(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor.conf
+++ b/vendor.conf
@@ -16,7 +16,7 @@ github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 golang.org/x/net c427ad74c6d7a814201695e9ffde0c5d400a7674
 golang.org/x/sys 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
 github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
-github.com/docker/go-connections 7da10c8c50cad14494ec818dcdfb6506265c0086
+github.com/docker/go-connections d217f8e36aba4dbc397981e692a65d3f13b9a46d
 golang.org/x/text f72d8390a633d5dfb0cc84043294db9f6c935756
 
 github.com/RackSec/srslog 456df3a81436d29ba874f3590eeeee25d666f8a5

--- a/vendor/github.com/docker/go-connections/tlsconfig/config.go
+++ b/vendor/github.com/docker/go-connections/tlsconfig/config.go
@@ -29,6 +29,11 @@ type Options struct {
 	InsecureSkipVerify bool
 	// server-only option
 	ClientAuth tls.ClientAuthType
+
+	// If ExclusiveRootPools is set, then if a CA file is provided, the root pool used for TLS
+	// creds will include exclusively the roots in that CA file.  If no CA file is provided,
+	// the system pool will be used.
+	ExclusiveRootPools bool
 }
 
 // Extra (server-side) accepted CBC cipher suites - will phase out in the future
@@ -66,11 +71,19 @@ func ClientDefault() *tls.Config {
 }
 
 // certPool returns an X.509 certificate pool from `caFile`, the certificate file.
-func certPool(caFile string) (*x509.CertPool, error) {
+func certPool(caFile string, exclusivePool bool) (*x509.CertPool, error) {
 	// If we should verify the server, we need to load a trusted ca
-	certPool, err := SystemCertPool()
-	if err != nil {
-		return nil, fmt.Errorf("failed to read system certificates: %v", err)
+	var (
+		certPool *x509.CertPool
+		err      error
+	)
+	if exclusivePool {
+		certPool = x509.NewCertPool()
+	} else {
+		certPool, err = SystemCertPool()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read system certificates: %v", err)
+		}
 	}
 	pem, err := ioutil.ReadFile(caFile)
 	if err != nil {
@@ -88,7 +101,7 @@ func Client(options Options) (*tls.Config, error) {
 	tlsConfig := ClientDefault()
 	tlsConfig.InsecureSkipVerify = options.InsecureSkipVerify
 	if !options.InsecureSkipVerify && options.CAFile != "" {
-		CAs, err := certPool(options.CAFile)
+		CAs, err := certPool(options.CAFile, options.ExclusiveRootPools)
 		if err != nil {
 			return nil, err
 		}
@@ -119,7 +132,7 @@ func Server(options Options) (*tls.Config, error) {
 	}
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	if options.ClientAuth >= tls.VerifyClientCertIfGiven && options.CAFile != "" {
-		CAs, err := certPool(options.CAFile)
+		CAs, err := certPool(options.CAFile, options.ExclusiveRootPools)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When connecting to a daemon from the client, if custom CA certs are provided for a daemon, trust ONLY those CA certs and not the system cert pool.  If no custom CA certs are provided, then trust the system cert pool.

This bumps the go-connections dependency to a version that supports a flag that specifies that the cert pools should be exclusive.  (Differs from https://github.com/docker/docker/pull/31705 in that this version of go-connections contains ONLY the exclusive pool flag change, so is not the latest go-connections change).

Should also address https://github.com/docker/docker/issues/30450 for the case where a windows client is connecting to a remote docker via mTLS (for example when using `docker-machine`):

```
PS C:\Users\cyli> .\Desktop\docker-17.04.0-ce-rc1.exe ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS
NAMES
PS C:\Users\cyli> docker ps
time="2017-03-21T10:54:08-07:00" level=info msg="Unable to use system certificate pool: crypto/x509: system root pool is
 not available on Windows"
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS
NAMES
PS C:\Users\cyli>
```

![picture](https://s-media-cache-ak0.pinimg.com/originals/10/4c/e1/104ce1cf5a37dca6a64e20c2a2d44d27.jpg)

cc @vieux 