### PR TITLE
example of ADD and COPY with special characters file name

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -803,6 +803,14 @@ the source will be copied inside the destination container.
     ADD test relativeDir/          # adds "test" to `WORKDIR`/relativeDir/
     ADD test /absoluteDir/         # adds "test" to /absoluteDir/
 
+When adding files or directories that contain special characters (such as `[`
+and `]`), you need to escape those paths following the Golang rules to prevent
+them from being treated as a matching pattern. For example, to add a file
+named `arr[0].txt`, use the following;
+
+    ADD arr[[]0].txt /mydir/    # copy a file named "arr[0].txt" to /mydir/
+
+
 All new files and directories are created with a UID and GID of 0.
 
 In the case where `<src>` is a remote file URL, the destination will
@@ -914,6 +922,14 @@ the source will be copied inside the destination container.
 
     COPY test relativeDir/   # adds "test" to `WORKDIR`/relativeDir/
     COPY test /absoluteDir/  # adds "test" to /absoluteDir/
+
+
+When copying files or directories that contain special characters (such as `[`
+and `]`), you need to escape those paths following the Golang rules to prevent
+them from being treated as a matching pattern. For example, to copy a file
+named `arr[0].txt`, use the following;
+
+    COPY arr[[]0].txt /mydir/    # copy a file named "arr[0].txt" to /mydir/
 
 All new files and directories are created with a UID and GID of 0.
 


### PR DESCRIPTION
Signed-off-by: Foysal Iqbal <foysal.iqbal.fb@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add an example for COPY and ADD command in the docs
**- How I did it**
Modify the docs/reference/builder.md file
**- How to verify it**
Created a docker image with the following exmaple

FROM docker/whalesay:latest
COPY "arr[[]0].txt" /
ADD ar2[[]1].txt /
CMD ["bash", "-c", "ls -la *.txt"]

And verified these two files are coped into the container
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

