### PR TITLE
cli: Wrong error message from "node ps" outside swarm mode

### DIFF
--- a/cli/command/node/cmd.go
+++ b/cli/command/node/cmd.go
@@ -1,6 +1,9 @@
 package node
 
 import (
+	"errors"
+
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	apiclient "github.com/docker/docker/client"
@@ -37,6 +40,16 @@ func Reference(ctx context.Context, client apiclient.APIClient, ref string) (str
 		info, err := client.Info(ctx)
 		if err != nil {
 			return "", err
+		}
+		if info.Swarm.NodeID == "" {
+			// If there's no node ID in /info, the node probably
+			// isn't a manager. Call a swarm-specific endpoint to
+			// get a more specific error message.
+			_, err = client.NodeList(ctx, types.NodeListOptions{})
+			if err != nil {
+				return "", err
+			}
+			return "", errors.New("node ID not found in /info")
 		}
 		return info.Swarm.NodeID, nil
 	}

--- a/cli/command/node/inspect_test.go
+++ b/cli/command/node/inspect_test.go
@@ -49,7 +49,7 @@ func TestNodeInspectErrors(t *testing.T) {
 				return swarm.Node{}, []byte{}, fmt.Errorf("error inspecting the node")
 			},
 			infoFunc: func() (types.Info, error) {
-				return types.Info{}, nil
+				return types.Info{Swarm: swarm.Info{NodeID: "abc"}}, nil
 			},
 			expectedError: "error inspecting the node",
 		},

--- a/cli/command/node/ps.go
+++ b/cli/command/node/ps.go
@@ -95,8 +95,10 @@ func runPs(dockerCli command.Cli, opts psOptions) error {
 		}
 	}
 
-	if err := task.Print(dockerCli, ctx, tasks, idresolver.New(client, opts.noResolve), !opts.noTrunc, opts.quiet, format); err != nil {
-		errs = append(errs, err.Error())
+	if len(errs) == 0 || len(tasks) != 0 {
+		if err := task.Print(dockerCli, ctx, tasks, idresolver.New(client, opts.noResolve), !opts.noTrunc, opts.quiet, format); err != nil {
+			errs = append(errs, err.Error())
+		}
 	}
 
 	if len(errs) > 0 {


### PR DESCRIPTION
`docker node ps` behaves strangely outside swarm mode:

    $ docker node ps
    ID                  NAME                IMAGE               NODE                DESIRED STATE       CURRENT STATE       ERROR               PORTS
    Error: No such node:

It should explain that the node is not a swarm manager.

The reason this happens is that the argument to `docker node ps` defaults
to "self". The first thing the command does is try to resolve "self" to
a node ID using the /info endpoint. If there is no node ID, it tries to
use the empty string as an ID, and tries to `GET /nodes/`, which is not a
valid endpoint.

Change the command to check if the node ID is present in the /info
response. If it isn't, a swarm API endpoint can supply a useful error
message.

Also, avoid printing the column headers if the only following text is an
error.

Fixes #31879