### PR TITLE
Return proper exit code on builder panic

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -305,6 +305,7 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 			}
 			return cli.StatusError{Status: jerr.Message, StatusCode: jerr.Code}
 		}
+		return err
 	}
 
 	// Windows: show error message about modified file permissions if the


### PR DESCRIPTION
Error was ignored if it wasn't in expected json format. Now returns `unexpected EOF` like the rest of the disconnect errors and sets exit code to 1.

fixes #31990

@nathanleclaire 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>

