### PR TITLE
Fix stop/start/restart of detached container

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -546,6 +546,28 @@ func (daemon *Daemon) allocateNetwork(container *container.Container) error {
 		}
 	}
 
+	// If the container is not to be connected to any network,
+	// create its network sandbox now if not present
+	if len(networks) == 0 {
+		if nil == daemon.getNetworkSandbox(container) {
+			options, err := daemon.buildSandboxOptions(container)
+			if err != nil {
+				return err
+			}
+			sb, err := daemon.netController.NewSandbox(container.ID, options...)
+			if err != nil {
+				return err
+			}
+			container.UpdateSandboxNetworkSettings(sb)
+			defer func() {
+				if err != nil {
+					sb.Delete()
+				}
+			}()
+		}
+
+	}
+
 	if err := container.WriteHostConfig(); err != nil {
 		return err
 	}

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -916,7 +916,7 @@ func (daemon *Daemon) releaseNetwork(container *container.Container) {
 	settings := container.NetworkSettings.Networks
 	container.NetworkSettings.Ports = nil
 
-	if sid == "" || len(settings) == 0 {
+	if sid == "" {
 		return
 	}
 


### PR DESCRIPTION
This PR fixes the issue where

- Stopping a container which is not connected to any network does not remove its network namespace
- Attempting to start or restart a container which is not connected to any network will fail with

```
Error response from daemon: Cannot restart container 9f0b96: oci runtime error: container_linux.go:247: starting container process caused "process_linux.go:334: running prestart hook 0 caused \"error running hook: exit status 1, stdout: , stderr: time=\\\"2017-03-21T17:46:07Z\\\" level=fatal msg=\\\"no sandbox present for 9f0b96b0acc44208160e73504fc4a504c21842e9384f510382057ef759fae364\\\" \\n\""
```


Fixes #31597


**- A picture of a cute animal (not mandatory but encouraged)**
![canebrutto](https://cloud.githubusercontent.com/assets/10080882/24186244/a9b3a0e4-0e94-11e7-9e76-00ea924c5973.jpg)


