### PR TITLE
Remove compose types.Dict alias

### DIFF
--- a/cli/compose/interpolation/interpolation.go
+++ b/cli/compose/interpolation/interpolation.go
@@ -4,19 +4,18 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/cli/compose/template"
-	"github.com/docker/docker/cli/compose/types"
 )
 
 // Interpolate replaces variables in a string with the values from a mapping
-func Interpolate(config types.Dict, section string, mapping template.Mapping) (types.Dict, error) {
-	out := types.Dict{}
+func Interpolate(config map[string]interface{}, section string, mapping template.Mapping) (map[string]interface{}, error) {
+	out := map[string]interface{}{}
 
 	for name, item := range config {
 		if item == nil {
 			out[name] = nil
 			continue
 		}
-		interpolatedItem, err := interpolateSectionItem(name, item.(types.Dict), section, mapping)
+		interpolatedItem, err := interpolateSectionItem(name, item.(map[string]interface{}), section, mapping)
 		if err != nil {
 			return nil, err
 		}
@@ -28,12 +27,12 @@ func Interpolate(config types.Dict, section string, mapping template.Mapping) (t
 
 func interpolateSectionItem(
 	name string,
-	item types.Dict,
+	item map[string]interface{},
 	section string,
 	mapping template.Mapping,
-) (types.Dict, error) {
+) (map[string]interface{}, error) {
 
-	out := types.Dict{}
+	out := map[string]interface{}{}
 
 	for key, value := range item {
 		interpolatedValue, err := recursiveInterpolate(value, mapping)
@@ -60,8 +59,8 @@ func recursiveInterpolate(
 	case string:
 		return template.Substitute(value, mapping)
 
-	case types.Dict:
-		out := types.Dict{}
+	case map[string]interface{}:
+		out := map[string]interface{}{}
 		for key, elem := range value {
 			interpolatedElem, err := recursiveInterpolate(elem, mapping)
 			if err != nil {

--- a/cli/compose/interpolation/interpolation_test.go
+++ b/cli/compose/interpolation/interpolation_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/docker/docker/cli/compose/types"
 )
 
 var defaults = map[string]string{
@@ -19,25 +17,25 @@ func defaultMapping(name string) (string, bool) {
 }
 
 func TestInterpolate(t *testing.T) {
-	services := types.Dict{
-		"servicea": types.Dict{
+	services := map[string]interface{}{
+		"servicea": map[string]interface{}{
 			"image":   "example:${USER}",
 			"volumes": []interface{}{"$FOO:/target"},
-			"logging": types.Dict{
+			"logging": map[string]interface{}{
 				"driver": "${FOO}",
-				"options": types.Dict{
+				"options": map[string]interface{}{
 					"user": "$USER",
 				},
 			},
 		},
 	}
-	expected := types.Dict{
-		"servicea": types.Dict{
+	expected := map[string]interface{}{
+		"servicea": map[string]interface{}{
 			"image":   "example:jenny",
 			"volumes": []interface{}{"bar:/target"},
-			"logging": types.Dict{
+			"logging": map[string]interface{}{
 				"driver": "bar",
-				"options": types.Dict{
+				"options": map[string]interface{}{
 					"user": "jenny",
 				},
 			},
@@ -49,8 +47,8 @@ func TestInterpolate(t *testing.T) {
 }
 
 func TestInvalidInterpolation(t *testing.T) {
-	services := types.Dict{
-		"servicea": types.Dict{
+	services := map[string]interface{}{
+		"servicea": map[string]interface{}{
 			"image": "${",
 		},
 	}

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func buildConfigDetails(source types.Dict, env map[string]string) types.ConfigDetails {
+func buildConfigDetails(source map[string]interface{}, env map[string]string) types.ConfigDetails {
 	workingDir, err := os.Getwd()
 	if err != nil {
 		panic(err)
@@ -70,39 +70,39 @@ networks:
         - subnet: 172.28.0.0/16
 `
 
-var sampleDict = types.Dict{
+var sampleDict = map[string]interface{}{
 	"version": "3",
-	"services": types.Dict{
-		"foo": types.Dict{
+	"services": map[string]interface{}{
+		"foo": map[string]interface{}{
 			"image":    "busybox",
-			"networks": types.Dict{"with_me": nil},
+			"networks": map[string]interface{}{"with_me": nil},
 		},
-		"bar": types.Dict{
+		"bar": map[string]interface{}{
 			"image":       "busybox",
 			"environment": []interface{}{"FOO=1"},
 			"networks":    []interface{}{"with_ipam"},
 		},
 	},
-	"volumes": types.Dict{
-		"hello": types.Dict{
+	"volumes": map[string]interface{}{
+		"hello": map[string]interface{}{
 			"driver": "default",
-			"driver_opts": types.Dict{
+			"driver_opts": map[string]interface{}{
 				"beep": "boop",
 			},
 		},
 	},
-	"networks": types.Dict{
-		"default": types.Dict{
+	"networks": map[string]interface{}{
+		"default": map[string]interface{}{
 			"driver": "bridge",
-			"driver_opts": types.Dict{
+			"driver_opts": map[string]interface{}{
 				"beep": "boop",
 			},
 		},
-		"with_ipam": types.Dict{
-			"ipam": types.Dict{
+		"with_ipam": map[string]interface{}{
+			"ipam": map[string]interface{}{
 				"driver": "default",
 				"config": []interface{}{
-					types.Dict{
+					map[string]interface{}{
 						"subnet": "172.28.0.0/16",
 					},
 				},

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -50,13 +50,10 @@ var ForbiddenProperties = map[string]string{
 	"memswap_limit": "Set resource limits using deploy.resources",
 }
 
-// Dict is a mapping of strings to interface{}
-type Dict map[string]interface{}
-
 // ConfigFile is a filename and the contents of the file as a Dict
 type ConfigFile struct {
 	Filename string
-	Config   Dict
+	Config   map[string]interface{}
 }
 
 // ConfigDetails are the details about a group of ConfigFiles


### PR DESCRIPTION
It is just an alias type and make the code a little bit more complex and hard to use from outside `compose` package. It makes the `compose/interpolation` package indenpendent of the `compose/types` package (which is a good thing 👼)

/cc @dnephin @AkihiroSuda @thaJeztah @cpuguy83 

🦁

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
