### PR TITLE
Remove undeeded and broken selinux relabel call

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/volume"
 	"github.com/docker/docker/volume/drivers"
-	"github.com/opencontainers/runc/libcontainer/label"
 )
 
 var (
@@ -193,9 +192,6 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 				return err
 			}
 
-			if err := label.Relabel(mp.Source, container.MountLabel, false); err != nil {
-				return err
-			}
 			mp.Volume = v
 			mp.Name = v.Name()
 			mp.Driver = v.DriverName()


### PR DESCRIPTION
The call is not needed here and wouldn't really work since `Source` in
this case is a volume name.
Further we don't neccessarily even have a volume path at this time since
the volume hasn't been mounted yet.

The volume will be relabled either:

1. When data gets copied to it from the image (if applicable) -- https://github.com/docker/docker/blob/master/container/container_unix.go#L196
2. When the container is started -- https://github.com/docker/docker/blob/master/daemon/oci_linux.go#L737

Fixes #31255 (last part, the first part is done)

**- A picture of a cute animal (not mandatory but encouraged)**
![cute-kittens-30-57b30ad41bc90__605](https://cloud.githubusercontent.com/assets/799078/24215501/5813b6ae-0f0f-11e7-982a-22be27c7242c.jpg)

