### PR TITLE
Fix indenting in deprecated engine features toc

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -40,7 +40,7 @@ docker 1.9, but kept around for backward compatibility.
 Refer to [#17538](https://github.com/docker/docker/pull/17538) for further
 information.
 
-## `filter` param for `/images/json` endpoint
+### `filter` param for `/images/json` endpoint
 **Deprecated In Release: [v1.13.0](https://github.com/docker/docker/releases/tag/v1.13.0)**
 
 **Target For Removal In Release: v17.12**


### PR DESCRIPTION
Fixes #30841. The "filter" section had the wrong header size, which
caused sections following it to have the wrong indentation in the
right-side table of contents.

**- What I did**
Changed one H2 heading to H3.

**- How to verify it**
View the right-side table of contents at https://docs.docker.com/engine/deprecated/. Everything in that list should be at the same level, no indenting.

I attempted to test by building the doc, “docker-compose up” in docker.github.io, but opening the User Guide > Deprecated Engine Features link causes “ERROR `/engine/deprecated/' not found.” My change was not included in that build, so it did not cause that failure.

I did view the the page as rendered by GitHub in my repo, which looked ok but not the same as it will look after it is consumed by the doc build.

**- Description for the changelog**
Fix indenting in table of contents for deprecated engine features.

