### PR TITLE
Stop container when error occured.

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2785,6 +2785,10 @@ func (s *DockerDaemonSuite) TestExecWithUserAfterLiveRestore(c *check.C) {
 
 	out, err := s.d.Cmd("run", "-d", "--name=top", "busybox", "sh", "-c", "addgroup -S test && adduser -S -G test test -D -s /bin/sh && top")
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
+	defer func() {
+		out, err = s.d.Cmd("stop", "top")
+		c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
+	}()
 
 	s.d.WaitRun("top")
 
@@ -2798,9 +2802,6 @@ func (s *DockerDaemonSuite) TestExecWithUserAfterLiveRestore(c *check.C) {
 	out2, err := s.d.Cmd("exec", "-u", "test", "top", "id")
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out2))
 	c.Assert(out1, check.Equals, out2, check.Commentf("Output: before restart '%s', after restart '%s'", out1, out2))
-
-	out, err = s.d.Cmd("stop", "top")
-	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
 }
 
 func (s *DockerDaemonSuite) TestRemoveContainerAfterLiveRestore(c *check.C) {


### PR DESCRIPTION
We should stop container even if test case execution failed, or
CI's stuck when exit.

Signed-off-by: Fengtu Wang <wangfengtu@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

