### PR TITLE
Readme grammer fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This is usually difficult for several reasons:
     of them handle it differently.
 
 
-Docker solves the problem of dependency hell by giving the developer a simple
+Docker solves the problem of dependency hell by giving developers a simple
 way to express *all* their application's dependencies in one place, while
 streamlining the process of assembling them. If this makes you think of
 [XKCD 927](https://xkcd.com/927/), don't worry. Docker doesn't


### PR DESCRIPTION
"Giving THE developer...." -> "to express all THEIR application's.."
A developer is single so it can't be followed by "their" which refers to plural (developers).

So, adjusted to plural ("developers") so that the two will match.
 * The alternative would be to use "the developer....his / her application's" but that leads to gender reference issues, so the former alternative works better

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Changed "the developer" to "developers"

**- How I did it**
Plural / singular matching with gender consideration

**- How to verify it**
http://www.ef.com/english-resources/english-grammar/singular-and-plural-nouns/
**- Description for the changelog**
<!-- Readme grammer single to plural developers fix
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
--> Changed "the developer" to "developers" to match plural / singular grammer


**- A picture of a cute animal (not mandatory but encouraged)**
https://s-media-cache-ak0.pinimg.com/originals/1a/f3/37/1af33760a821e18bb6e7bd3457c55aa2.jpg
Wierd, but cute :)

Signed-off-by: Jonathan Saring (Joni Sar) <yoni@cocycles.com>