### PR TITLE
TLS minimum version can be specified through configuration and command line options

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -207,7 +207,12 @@ func LoadDefaultConfigFile(err io.Writer) *configfile.ConfigFile {
 
 // NewAPIClientFromFlags creates a new APIClient from command line flags
 func NewAPIClientFromFlags(opts *cliflags.CommonOptions, configFile *configfile.ConfigFile) (client.APIClient, error) {
-	host, err := getServerHost(opts.Hosts, opts.TLSOptions)
+	tlsOptions, err := tlsConfigFromOptions(opts)
+	if err != nil {
+		return &client.Client{}, err
+	}
+
+	host, err := getServerHost(opts.Hosts, tlsOptions)
 	if err != nil {
 		return &client.Client{}, err
 	}
@@ -223,7 +228,7 @@ func NewAPIClientFromFlags(opts *cliflags.CommonOptions, configFile *configfile.
 		verStr = tmpStr
 	}
 
-	httpClient, err := newHTTPClient(host, opts.TLSOptions)
+	httpClient, err := newHTTPClient(host, tlsOptions)
 	if err != nil {
 		return &client.Client{}, err
 	}
@@ -269,6 +274,27 @@ func newHTTPClient(host string, tlsOptions *tlsconfig.Options) (*http.Client, er
 	return &http.Client{
 		Transport: tr,
 	}, nil
+}
+
+func tlsConfigFromOptions(opts *cliflags.CommonOptions) (*tlsconfig.Options, error) {
+	if opts.TLSOptions == nil {
+		return nil, nil
+	}
+
+	tlsMinVersion, err := dopts.ParseTLSMinVersion(opts.TLSOptions.MinVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsOptions := &tlsconfig.Options{
+		CAFile:             opts.TLSOptions.CAFile,
+		CertFile:           opts.TLSOptions.CertFile,
+		KeyFile:            opts.TLSOptions.KeyFile,
+		InsecureSkipVerify: !opts.TLSVerify,
+		MinVersion:         tlsMinVersion,
+	}
+
+	return tlsOptions, nil
 }
 
 // UserAgent returns the user agent string used for making API requests

--- a/cli/flags/common.go
+++ b/cli/flags/common.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	cliconfig "github.com/docker/docker/cli/config"
+	daemonconfig "github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/opts"
-	"github.com/docker/go-connections/tlsconfig"
 	"github.com/spf13/pflag"
 )
 
@@ -37,7 +37,7 @@ type CommonOptions struct {
 	LogLevel   string
 	TLS        bool
 	TLSVerify  bool
-	TLSOptions *tlsconfig.Options
+	TLSOptions *daemonconfig.CommonTLSOptions
 	TrustKey   string
 }
 
@@ -59,7 +59,7 @@ func (commonOpts *CommonOptions) InstallFlags(flags *pflag.FlagSet) {
 
 	// TODO use flag flags.String("identity"}, "i", "", "Path to libtrust key file")
 
-	commonOpts.TLSOptions = &tlsconfig.Options{
+	commonOpts.TLSOptions = &daemonconfig.CommonTLSOptions{
 		CAFile:   filepath.Join(dockerCertPath, DefaultCaFile),
 		CertFile: filepath.Join(dockerCertPath, DefaultCertFile),
 		KeyFile:  filepath.Join(dockerCertPath, DefaultKeyFile),
@@ -68,6 +68,7 @@ func (commonOpts *CommonOptions) InstallFlags(flags *pflag.FlagSet) {
 	flags.Var(opts.NewQuotedString(&tlsOptions.CAFile), "tlscacert", "Trust certs signed only by this CA")
 	flags.Var(opts.NewQuotedString(&tlsOptions.CertFile), "tlscert", "Path to TLS certificate file")
 	flags.Var(opts.NewQuotedString(&tlsOptions.KeyFile), "tlskey", "Path to TLS key file")
+	flags.Var(opts.NewQuotedString(&tlsOptions.MinVersion), "tlsminversion", "Minimum TLS version")
 
 	hostOpt := opts.NewNamedListOptsRef("hosts", &commonOpts.Hosts, opts.ValidateHost)
 	flags.VarP(hostOpt, "host", "H", "Daemon socket(s) to connect to")
@@ -88,7 +89,6 @@ func (commonOpts *CommonOptions) SetDefaultOptions(flags *pflag.FlagSet) {
 		commonOpts.TLSOptions = nil
 	} else {
 		tlsOptions := commonOpts.TLSOptions
-		tlsOptions.InsecureSkipVerify = !commonOpts.TLSVerify
 
 		// Reset CertFile and KeyFile to empty string if the user did not specify
 		// the respective flags and the respective default files were not found.

--- a/cli/flags/common_test.go
+++ b/cli/flags/common_test.go
@@ -18,11 +18,13 @@ func TestCommonOptionsInstallFlags(t *testing.T) {
 		"--tlscacert=\"/foo/cafile\"",
 		"--tlscert=\"/foo/cert\"",
 		"--tlskey=\"/foo/key\"",
+		"--tlsminversion=\"TLS.TLSV11\"",
 	})
 	assert.NilError(t, err)
 	assert.Equal(t, opts.TLSOptions.CAFile, "/foo/cafile")
 	assert.Equal(t, opts.TLSOptions.CertFile, "/foo/cert")
 	assert.Equal(t, opts.TLSOptions.KeyFile, "/foo/key")
+	assert.Equal(t, opts.TLSOptions.MinVersion, "TLS.TLSV11")
 }
 
 func defaultPath(filename string) string {

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -187,10 +187,17 @@ func (cli *DaemonCli) start(opts daemonOptions) (err error) {
 	}
 
 	if cli.Config.TLS {
+
+		tlsMinVersion, err := dopts.ParseTLSMinVersion(cli.Config.CommonTLSOptions.MinVersion)
+		if err != nil {
+			return err
+		}
+
 		tlsOptions := tlsconfig.Options{
-			CAFile:   cli.Config.CommonTLSOptions.CAFile,
-			CertFile: cli.Config.CommonTLSOptions.CertFile,
-			KeyFile:  cli.Config.CommonTLSOptions.KeyFile,
+			CAFile:     cli.Config.CommonTLSOptions.CAFile,
+			CertFile:   cli.Config.CommonTLSOptions.CertFile,
+			KeyFile:    cli.Config.CommonTLSOptions.KeyFile,
+			MinVersion: tlsMinVersion,
 		}
 
 		if cli.Config.TLSVerify {
@@ -418,9 +425,7 @@ func loadDaemonCliConfig(opts daemonOptions) (*config.Config, error) {
 	conf.CommonTLSOptions = config.CommonTLSOptions{}
 
 	if opts.common.TLSOptions != nil {
-		conf.CommonTLSOptions.CAFile = opts.common.TLSOptions.CAFile
-		conf.CommonTLSOptions.CertFile = opts.common.TLSOptions.CertFile
-		conf.CommonTLSOptions.KeyFile = opts.common.TLSOptions.KeyFile
+		conf.CommonTLSOptions = *opts.common.TLSOptions
 	}
 
 	if opts.configFile != "" {

--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -47,6 +47,18 @@ func TestLoadDaemonCliConfigWithTLS(t *testing.T) {
 	assert.Equal(t, loadedConfig.CommonTLSOptions.CAFile, "/tmp/ca.pem")
 }
 
+func TestLoadDaemonCliConfigWithTLSMinVersion(t *testing.T) {
+	opts := defaultOptions("")
+	opts.common.TLSOptions.CAFile = "/tmp/ca.pem"
+	opts.common.TLS = true
+	opts.common.TLSOptions.MinVersion = "VersionTLS11"
+
+	loadedConfig, err := loadDaemonCliConfig(opts)
+	assert.NilError(t, err)
+	assert.NotNil(t, loadedConfig)
+	assert.Equal(t, loadedConfig.CommonTLSOptions.MinVersion, "VersionTLS11")
+}
+
 func TestLoadDaemonCliConfigWithConflicts(t *testing.T) {
 	tempFile := tempfile.NewTempFile(t, "config", `{"labels": ["l3=foo"]}`)
 	defer tempFile.Remove()

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -73,9 +73,10 @@ type commonBridgeConfig struct {
 // It includes json tags to deserialize configuration from a file
 // using the same names that the flags in the command line use.
 type CommonTLSOptions struct {
-	CAFile   string `json:"tlscacert,omitempty"`
-	CertFile string `json:"tlscert,omitempty"`
-	KeyFile  string `json:"tlskey,omitempty"`
+	CAFile     string `json:"tlscacert,omitempty"`
+	CertFile   string `json:"tlscert,omitempty"`
+	KeyFile    string `json:"tlskey,omitempty"`
+	MinVersion string `json:"tlsminversion,omitempty"`
 }
 
 // CommonConfig defines the configuration of a docker daemon which is

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -1,6 +1,7 @@
 package opts
 
 import (
+	"crypto/tls"
 	"fmt"
 	"math/big"
 	"net"
@@ -396,6 +397,30 @@ func ParseLink(val string) (string, string, error) {
 		return arr[0][1:], alias, nil
 	}
 	return arr[0], arr[1], nil
+}
+
+// ParseTLSMinVersion takes a string and returns:
+//	for an empty version string: 0 (which is ignored by tlsconfig)
+//	for a valid version string: a valid TLS version
+//	for an invalid version string: an error
+func ParseTLSMinVersion(val string) (uint16, error) {
+	allTLSVersions := map[string]uint16{
+		"VERSIONSSL30": tls.VersionSSL30,
+		"VERSIONTLS10": tls.VersionTLS10,
+		"VERSIONTLS11": tls.VersionTLS11,
+		"VERSIONTLS12": tls.VersionTLS12,
+	}
+
+	if val == "" {
+		return 0, nil
+	}
+
+	key := strings.ToUpper(val)
+	if version, ok := allTLSVersions[key]; ok {
+		return version, nil
+	}
+
+	return 0, fmt.Errorf("invalid minimum TLS version string: %q", val)
 }
 
 // ValidateLink validates that the specified string has a valid link format (containerName:alias).

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -1,6 +1,7 @@
 package opts
 
 import (
+	"crypto/tls"
 	"fmt"
 	"strings"
 	"testing"
@@ -303,5 +304,30 @@ func TestParseLink(t *testing.T) {
 	// more than two colons are not allowed
 	if _, _, err := ParseLink("link:alias:wrong"); err == nil || !strings.Contains(err.Error(), "bad format for links: link:alias:wrong") {
 		t.Fatalf("Expected error 'bad format for links: link:alias:wrong' but got: %v", err)
+	}
+}
+
+func TestParseTLSMinVersion(t *testing.T) {
+	// empty minimum version string
+	version, err := ParseTLSMinVersion("")
+	if err != nil {
+		t.Fatalf("Expected not to error out on an empty version string, but got: %v", err)
+	}
+	if version != 0 {
+		t.Fatalf("TLS minimum version should have been 0, got %v instead", version)
+	}
+
+	// valid minimum version strings
+	version, err = ParseTLSMinVersion("versionTLS11")
+	if err != nil {
+		t.Fatalf("Expected not to error out on valid version string 'versionTLS11', but got: %v", err)
+	}
+	if version != tls.VersionTLS11 {
+		t.Fatalf("TLS minimum version should have been %v, got %v instead", tls.VersionTLS11, version)
+	}
+
+	// invalid minimum version string is not allowed
+	if _, err := ParseTLSMinVersion("invalid version"); err == nil || !strings.Contains(err.Error(), "invalid minimum TLS version string") {
+		t.Fatalf("Expected error 'invalid minimum TLS version string' but got: %v", err)
 	}
 }


### PR DESCRIPTION
TLS minimum version can be specified through configuration (for daemon) and command line options (for both daemon and client). Closes #30258

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>


**- What I did**

This is a first attempt at adding functionality that allows specification of minimum TLS version. The PR covers both daemon and client (configuration and command line options for daemon, command-line only for client).

**- How I did it**
- Added support for minimum version in go-connections (it has been vendored)
- Added the following code (and tests when I saw the possibility):
     - client-side flag for minimum TLS version
     - daemon-side configuration option for minimum TLS version
     - translations between specific version strings and TLS minimum version codes

**- How to verify it**

The PR adds a configuration parameter 'tlsminversion' to daemon configuration file, and a command line option with the same name. 
Note that go-connections library rejects minimum versions if it considers them too low (The following example can be used to verify the PR)

$ docker --tlsminversion=versionTLS11 --tlsverify --tlscacert=ca.pem -H=$HOST:2376 version
Requested minimum TLS version is too low. Should be at-least: 303

**- Description for the changelog**
Minimum TLS version can be specified for both daemon (configuration and command-line options) and client (command-line options), through a 'tlsminversion' option.

**- A picture of a cute animal (not mandatory but encouraged)**

