### PR TITLE
Fix flaky test TestPushMisconfiguredTokenServiceResponseError

### DIFF
--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -605,7 +605,7 @@ func (s *DockerRegistryAuthTokenSuite) TestPushMisconfiguredTokenServiceResponse
 }
 
 func (s *DockerRegistryAuthTokenSuite) TestPushMisconfiguredTokenServiceResponseError(c *check.C) {
-	ts := getTestTokenService(http.StatusTooManyRequests, `{"errors": [{"code":"TOOMANYREQUESTS","message":"out of tokens"}]}`, 4)
+	ts := getTestTokenService(http.StatusTooManyRequests, `{"errors": [{"code":"TOOMANYREQUESTS","message":"out of tokens"}]}`, 10)
 	defer ts.Close()
 	s.setupRegistryWithTokenService(c, ts.URL)
 	repoName := fmt.Sprintf("%s/busybox", privateRegistryURL)


### PR DESCRIPTION
This should "fix" the CI, but IMO there is something wrong and this still needs more investigating.

This value shouldn't need to be higher than 1 to work (less than 4 running with the DockerRegistrySuite* should fail on x86_64 as well), and seems to indicate a race condition somewhere in the test that I didn't see, or the push code. 

Ping @dmcgowan because you seem to have encountered this issue initially when redoing this test in #26219. Not sure if you have any ideas now about what root cause might be. 

FYI made this as a PR to give you all the option of fixing the CI first, then solving the issue (I know, rebuilding is a pain)

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>
