### PR TITLE
add support for dns nameservers and search domains in stack files

### DIFF
--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -93,6 +93,11 @@ func convertService(
 		return swarm.ServiceSpec{}, err
 	}
 
+	dnsConfig, err := convertDNSConfig(service.DNS, service.DNSSearch)
+	if err != nil {
+		return swarm.ServiceSpec{}, err
+	}
+
 	var logDriver *swarm.Driver
 	if service.Logging != nil {
 		logDriver = &swarm.Driver{
@@ -113,6 +118,7 @@ func convertService(
 				Args:            service.Command,
 				Hostname:        service.Hostname,
 				Hosts:           sortStrings(convertExtraHosts(service.ExtraHosts)),
+				DNSConfig:       dnsConfig,
 				Healthcheck:     healthcheck,
 				Env:             sortStrings(convertEnvironment(service.Environment)),
 				Labels:          AddStackLabel(namespace, service.Labels),
@@ -424,4 +430,14 @@ func convertDeployMode(mode string, replicas *uint64) (swarm.ServiceMode, error)
 		return serviceMode, fmt.Errorf("Unknown mode: %s", mode)
 	}
 	return serviceMode, nil
+}
+
+func convertDNSConfig(DNS []string, DNSSearch []string) (*swarm.DNSConfig, error) {
+	if DNS != nil || DNSSearch != nil {
+		return &swarm.DNSConfig{
+			Nameservers: DNS,
+			Search:      DNSSearch,
+		}, nil
+	}
+	return nil, nil
 }

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -277,3 +277,42 @@ func (s byTargetSort) Less(i, j int) bool {
 func (s byTargetSort) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
+
+func TestConvertDNSConfigEmpty(t *testing.T) {
+	dnsConfig, err := convertDNSConfig(nil, nil)
+
+	assert.NilError(t, err)
+	assert.Equal(t, dnsConfig, (*swarm.DNSConfig)(nil))
+}
+
+var (
+	nameservers = []string{"8.8.8.8", "9.9.9.9"}
+	search      = []string{"dc1.example.com", "dc2.example.com"}
+)
+
+func TestConvertDNSConfigAll(t *testing.T) {
+	dnsConfig, err := convertDNSConfig(nameservers, search)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, dnsConfig, &swarm.DNSConfig{
+		Nameservers: nameservers,
+		Search:      search,
+	})
+}
+
+func TestConvertDNSConfigNameservers(t *testing.T) {
+	dnsConfig, err := convertDNSConfig(nameservers, nil)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, dnsConfig, &swarm.DNSConfig{
+		Nameservers: nameservers,
+		Search:      nil,
+	})
+}
+
+func TestConvertDNSConfigSearch(t *testing.T) {
+	dnsConfig, err := convertDNSConfig(nil, search)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, dnsConfig, &swarm.DNSConfig{
+		Nameservers: nil,
+		Search:      search,
+	})
+}

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -11,8 +11,6 @@ var UnsupportedProperties = []string{
 	"cap_drop",
 	"cgroup_parent",
 	"devices",
-	"dns",
-	"dns_search",
 	"domainname",
 	"external_links",
 	"ipc",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added support for dns config flags in stack files. (only nameservers and search domain)

```yml
version: '3'

services:
  busybox:
    image: busybox:latest
    dns:
      ### 8.8.8.8 is an example
      - 8.8.8.8
```

**- How I did it**

`docker service create --dns x.x.x.x ...` is supported right now but stack files do not support it. 
I just simply hooked the `ServiceConfig` with the `ContainerSpec` used in `ServiceSpec`

**- How to verify it**

1. docker swarm init

2. stack deploy behaviour *before this PR*

```console
$ docker stack deploy -c docker-compose.yml test
Ignoring unsupported options: dns

Creating network testing_default
Creating service testing_busybox
```

3. stack inspect

```console
$ docker service inspect testing_busybox
[
    {
        "ID": "lp97yfpg5mnljpaqn67eu8sys",
        "Version": {
            "Index": 1311
        },
        "CreatedAt": "2017-03-23T23:56:10.907936203Z",
        "UpdatedAt": "2017-03-23T23:56:10.921987465Z",
        "Spec": {
            "Name": "testing_busybox",
            "Labels": {
                "com.docker.stack.namespace": "testing"
            },
            "TaskTemplate": {
                "ContainerSpec": {
                    "Image": "busybox:latest@sha256:32f093055929dbc23dec4d03e09dfe971f5973a9ca5cf059cbfb644c206aa83f",
                    "Labels": {
                        "com.docker.stack.namespace": "testing"
                    }
                },
                ...
            },
            ...
        }
    }
]
```

4. stack deploy behaviour *with this PR*

```console
$ docker stack deploy -c docker-compose-test.yml testing
Creating network testing_default
Creating service testing_busybox
```

5. stack inspect

Notice the `DNSConfig` is passed in correctly.

```console
$ docker service inspect testing_busybox
[
    {
        "ID": "93mp786llsintm6i8ua6eix0w",
        "Spec": {
            "Name": "testing_busybox",
            "Labels": {
                "com.docker.stack.namespace": "testing"
            },
            "TaskTemplate": {
                "ContainerSpec": {
                    "Image": "busybox:latest@sha256:32f093055929dbc23dec4d03e09dfe971f5973a9ca5cf059cbfb644c206aa83f",
                    "Labels": {
                        "com.docker.stack.namespace": "testing"
                    },
                    #
                    # DNSConfig are created correctly
                    #
                    "DNSConfig": {
                        "Nameservers": [
                            "8.8.8.8"
                        ]
                    }
                    #
                    #
                },
                ...
              },
           ...
        }
    }
]
```

**- Description for the changelog**

add support for dns nameservers and search domains in stack files

**- A picture of a cute animal (not mandatory but encouraged)**

![landseer](https://cloud.githubusercontent.com/assets/6145422/24274707/67035718-1000-11e7-8a8a-eec7947e726f.jpeg)

Fixes #29685