### PR TITLE
Fix docker logs a dead container

### DIFF
--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -29,6 +29,10 @@ func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, c
 		return err
 	}
 
+	if container.RemovalInProgress || container.Dead {
+		return errors.New("can not get logs from container which is dead or marked for removal")
+	}
+
 	if container.HostConfig.LogConfig.Type == "none" {
 		return logger.ErrReadLogsNotSupported
 	}


### PR DESCRIPTION
If a container is dead or marked for removal, the json log
file could have been removed, so docker logs will return
`<id>-json.log: no such file or directory`.

Signed-off-by: Lei Jitang <leijitang@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

