### PR TITLE
update 3 old docs about secret in docs/reference/commandline/

### DIFF
--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -36,11 +36,13 @@ command on a manager node.
 
 ```bash
 $ echo <secret> | docker secret create my_secret -
-mhv17xfe3gh6xc4rij5orpfds
+
+onakdyv307se2tl7nl20anokv
 
 $ docker secret ls
-ID                          NAME                    CREATED                                   UPDATED                                   SIZE
-mhv17xfe3gh6xc4rij5orpfds   my_secret               2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC   1679
+
+ID                          NAME                CREATED             UPDATED
+onakdyv307se2tl7nl20anokv   my_secret           6 seconds ago       6 seconds ago
 ```
 
 ### Create a secret with a file
@@ -48,22 +50,22 @@ mhv17xfe3gh6xc4rij5orpfds   my_secret               2016-10-27 23:25:43.90918108
 ```bash
 $ docker secret create my_secret ./secret.json
 
-mhv17xfe3gh6xc4rij5orpfds
+dg426haahpi5ezmkkj5kyl3sn
 
 $ docker secret ls
 
-ID                          NAME                    CREATED                                   UPDATED                                   SIZE
-mhv17xfe3gh6xc4rij5orpfds   my_secret               2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC   1679
+ID                          NAME                CREATED             UPDATED
+dg426haahpi5ezmkkj5kyl3sn   my_secret           7 seconds ago       7 seconds ago
 ```
 
 ### Create a secret with labels
 
 ```bash
 $ docker secret create --label env=dev \
-                       --label rev=20161102 \
+                       --label rev=20170324 \
                        my_secret ./secret.json
 
-jtn7g6aukl5ky7nr9gvwafoxh
+eo7jnzguqgtpdah3cm5srfb97
 ```
 
 ```none
@@ -71,22 +73,19 @@ $ docker secret inspect my_secret
 
 [
     {
-        "ID": "jtn7g6aukl5ky7nr9gvwafoxh",
+        "ID": "eo7jnzguqgtpdah3cm5srfb97",
         "Version": {
-            "Index": 541
+            "Index": 17
         },
-        "CreatedAt": "2016-11-03T20:54:12.924766548Z",
-        "UpdatedAt": "2016-11-03T20:54:12.924766548Z",
+        "CreatedAt": "2017-03-24T08:15:09.735271783Z",
+        "UpdatedAt": "2017-03-24T08:15:09.735271783Z",
         "Spec": {
             "Name": "my_secret",
             "Labels": {
                 "env": "dev",
-                "rev": "20161102"
-            },
-            "Data": null
-        },
-        "Digest": "sha256:4212a44b14e94154359569333d3fc6a80f6b9959dfdaff26412f4b2796b1f387",
-        "SecretSize": 1679
+                "rev": "20170324"
+            }
+        }
     }
 ]
 ```

--- a/docs/reference/commandline/secret_inspect.md
+++ b/docs/reference/commandline/secret_inspect.md
@@ -46,8 +46,9 @@ For example, given the following secret:
 
 ```bash
 $ docker secret ls
-ID                          NAME                    CREATED                                   UPDATED
-mhv17xfe3gh6xc4rij5orpfds   secret.json             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC
+
+ID                          NAME                CREATED             UPDATED
+eo7jnzguqgtpdah3cm5srfb97   my_secret           3 minutes ago       3 minutes ago
 ```
 
 ```none
@@ -55,14 +56,18 @@ $ docker secret inspect secret.json
 
 [
     {
-        "ID": "mhv17xfe3gh6xc4rij5orpfds",
-            "Version": {
-            "Index": 1198
+        "ID": "eo7jnzguqgtpdah3cm5srfb97",
+        "Version": {
+            "Index": 17
         },
-        "CreatedAt": "2016-10-27T23:25:43.909181089Z",
-        "UpdatedAt": "2016-10-27T23:25:43.909181089Z",
+        "CreatedAt": "2017-03-24T08:15:09.735271783Z",
+        "UpdatedAt": "2017-03-24T08:15:09.735271783Z",
         "Spec": {
-            "Name": "secret.json"
+            "Name": "my_secret",
+            "Labels": {
+                "env": "dev",
+                "rev": "20170324"
+            }
         }
     }
 ]
@@ -75,9 +80,9 @@ secret. The following example command outputs the creation time of the
 secret.
 
 ```bash
-$ docker secret inspect --format='{{.CreatedAt}}' mhv17xfe3gh6xc4rij5orpfds
+$ docker secret inspect --format='{{.CreatedAt}}' eo7jnzguqgtpdah3cm5srfb97
 
-2016-10-27 23:25:43.909181089 +0000 UTC
+2017-03-24 08:15:09.735271783 +0000 UTC
 ```
 
 

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -36,8 +36,8 @@ Run this command on a manager node to list the secrets in the swarm.
 ```bash
 $ docker secret ls
 
-ID                          NAME                    CREATED                                   UPDATED
-mhv17xfe3gh6xc4rij5orpfds   secret.json             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC
+ID                          NAME                CREATED             UPDATED
+eo7jnzguqgtpdah3cm5srfb97   my_secret           11 minutes ago      11 minutes ago
 ```
 
 ## Related commands


### PR DESCRIPTION
When I browse the document about `docker secret`, I found that some of these three documents out of date, they are:
docs/reference/commandline/secret_create.md,
docs/reference/commandline/secret_inspect.md,
docs/reference/commandline/secret_ls.md.

In the latest version, `docker secret ls`, `docker secret create`, `docker secret inspect` prints out the results at the console have changed, but the old document did not synchronize these changes.

Signed-off-by: uhayate <uhayate.gong@daocloud.io>
