### PR TITLE
Bump up nproc in TestExecUlimits

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -490,12 +490,12 @@ func (s *DockerSuite) TestExecOnReadonlyContainer(c *check.C) {
 func (s *DockerSuite) TestExecUlimits(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testexeculimits"
-	runSleepingContainer(c, "-d", "--ulimit", "nproc=21", "--name", name)
+	runSleepingContainer(c, "-d", "--ulimit", "nofile=511:511", "--name", name)
 	c.Assert(waitRun(name), checker.IsNil)
 
-	out, _, err := dockerCmdWithError("exec", name, "sh", "-c", "ulimit -p")
+	out, _, err := dockerCmdWithError("exec", name, "sh", "-c", "ulimit -n")
 	c.Assert(err, checker.IsNil)
-	c.Assert(strings.TrimSpace(out), checker.Equals, "21")
+	c.Assert(strings.TrimSpace(out), checker.Equals, "511")
 }
 
 // #15750


### PR DESCRIPTION
Bump up nproc from 21 to 121, because in some environments, such as
inside Virtuozzo Containers, number of processes is higher and testcase
fails.

Signed-off-by: Vitaly Ostrosablin <vostrosablin@virtuozzo.com>