### PR TITLE
Do not panic on redundant UpdateAttachment

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -126,6 +126,7 @@ type Cluster struct {
 type attacher struct {
 	taskID           string
 	config           *network.NetworkingConfig
+	inProgress       bool
 	attachWaitCh     chan *network.NetworkingConfig
 	attachCompleteCh chan struct{}
 	detachWaitCh     chan struct{}


### PR DESCRIPTION
The following panic has been reported. Most likely due to a redundant call to `(*Cluster).UpdateAttachment()`. There is no reason to panic for this, because the `(c *Cluster) AttachNetwork()` has already moved on and nobody is going to listen on that channel anymore. 

```
Mar 12 18:22:15 docker-node docker[1171]: time="2017-03-12T18:22:15.934724419+01:00" level=warning msg="found leaked image layer sha256:b5ab2e5864ce03da8fecace65286b57 
Mar 12 18:22:15 docker-node docker[1171]: time="2017-03-12T18:22:15.934762606+01:00" level=warning msg="found leaked image layer sha256:49343f722d11e921873ba136d7f3644 
Mar 12 18:22:25 docker-node docker[1171]: panic: send on closed channel 
Mar 12 18:22:25 docker-node docker[1171]: goroutine 1292550 [running]: 
Mar 12 18:22:25 docker-node docker[1171]: panic(0x16d5240, 0xc42137b090) 
Mar 12 18:22:25 docker-node docker[1171]: /usr/local/go/src/runtime/panic.go:500 +0x1a1 
Mar 12 18:22:25 docker-node docker[1171]: github.com/docker/docker/daemon/cluster.(*Cluster).UpdateAttachment(0xc4211de690, 0xc425e68240, 0x13, 0xc422669500, 0x40, 0xc 
Mar 12 18:22:25 docker-node docker[1171]: /root/rpmbuild/BUILD/docker-engine/.gopath/src/github.com/docker/docker/daemon/cluster/cluster.go:1616 +0x291 
Mar 12 18:22:25 docker-node docker[1171]: github.com/docker/docker/daemon.(*Daemon).UpdateAttachment(0xc4203fec00, 0xc425e68240, 0x13, 0xc425e68200, 0x19, 0xc422669500 
Mar 12 18:22:25 docker-node docker[1171]: /root/rpmbuild/BUILD/docker-engine/.gopath/src/github.com/docker/docker/daemon/network.go:206 +0x7f 
Mar 12 18:22:25 docker-node docker[1171]: github.com/docker/docker/daemon/cluster/executor/container.(*containerAdapter).networkAttach(0xc425494840, 0x2443520, 0xc4228 
Mar 12 18:22:25 docker-node docker[1171]: /root/rpmbuild/BUILD/docker-engine/.gopath/src/github.com/docker/docker/daemon/cluster/executor/container/adapter.go:192 +0xe 
Mar 12 18:22:25 docker-node docker[1171]: github.com/docker/docker/daemon/cluster/executor/container.(*networkAttacherController).Start(0xc425494870, 0x2443520, 0xc422 
Mar 12 18:22:25 docker-node docker[1171]: /root/rpmbuild/BUILD/docker-engine/.gopath/src/github.com/docker/docker/daemon/cluster/executor/container/attachment.go:51 +0 
Mar 12 18:22:25 docker-node docker[1171]: github.com/docker/docker/vendor/github.com/docker/swarmkit/agent/exec.Do(0x2443520, 0xc4228ec040, 0xc420c991e0, 0x2448880, 0x 
Mar 12 18:22:25 docker-node docker[1171]: /root/rpmbuild/BUILD/docker-engine/.gopath/src/github.com/docker/docker/vendor/github.com/docker/swarmkit/agent/exec/controll 
Mar 12 18:22:25 docker-node docker[1171]: github.com/docker/docker/vendor/github.com/docker/swarmkit/agent.(*taskManager).run.func2(0x24435e0, 0xc423a880c0, 0x0, 0x0) 
Mar 12 18:22:25 docker-node docker[1171]: /root/rpmbuild/BUILD/docker-engine/.gopath/src/github.com/docker/docker/vendor/github.com/docker/swarmkit/agent/task.go:134 + 
Mar 12 18:22:25 docker-node docker[1171]: github.com/docker/docker/vendor/github.com/docker/swarmkit/agent.runctx(0x24435e0, 0xc423a880c0, 0xc4234868a0, 0xc424390360, 
Mar 12 18:22:25 docker-node docker[1171]: /root/rpmbuild/BUILD/docker-engine/.gopath/src/github.com/docker/docker/vendor/github.com/docker/swarmkit/agent/helpers.go:9 
Mar 12 18:22:25 docker-node docker[1171]: created by github.com/docker/docker/vendor/github.com/docker/swarmkit/agent.(*taskManager).run 
Mar 12 18:22:25 docker-node docker[1171]: /root/rpmbuild/BUILD/docker-engine/.gopath/src/github.com/docker/docker/vendor/github.com/docker/swarmkit/agent/task.go:150 + 
Mar 12 18:22:26 docker-node systemd[1]: docker.service: main process exited, code=exited, status=2/INVALIDARGUMENT 
Mar 12 18:22:26 docker-node systemd[1]: Unit docker.service entered failed state. 
Mar 12 18:22:26 docker-node systemd[1]: docker.service failed.
```

**- A picture of a cute animal (not mandatory but encouraged)**

![orsetto](https://cloud.githubusercontent.com/assets/10080882/24298506/6d90cdaa-1063-11e7-9ef8-13e98739d9b2.jpg)
