### PR TITLE
Updated push.md with progress bar info

### DIFF
--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -36,6 +36,10 @@ image and tag names.
 Killing the `docker push` process, for example by pressing `CTRL-c` while it is
 running in a terminal, terminates the push operation.
 
+Progress bars are shown during docker push, which show the uncompressed size. The 
+actual amount of data that's pushed will be compressed before sending, so the uploaded
+ size will not be reflected by the progress bar. 
+
 Registry credentials are managed by [docker login](login.md).
 
 ### Concurrent uploads


### PR DESCRIPTION
Updated doc push.md and closes #32000 with VSCode > Markdown > wordwrap at 80. Please review push.md.

Changelog:
Added to doc that progress bar on push shows uncompressed size.

^  ^
 o 0
   *

Signed-off-by: Ian Philpot <ian.philpot@microsoft.com>