### PR TITLE
Let graphdrivers declare diff stream fidelity

### DIFF
--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -112,6 +112,23 @@ type Driver interface {
 	DiffDriver
 }
 
+// Capabilities defines a list of capabilities a driver may implement.
+// These capabilities are not required; however, they do determine how a
+// graphdriver can be used.
+type Capabilities struct {
+	// Flags that this driver is capable of reproducing exactly equivalent
+	// diffs for read-only layers. If set, clients can rely on the driver
+	// for consistent tar streams, and avoid extra processing to account
+	// for potential differences (eg: the layer store's use of tar-split).
+	ReproducesExactDiffs bool
+}
+
+// CapabilityDriver is the interface for layered file system drivers that
+// can report on their Capabilities.
+type CapabilityDriver interface {
+	Capabilities() Capabilities
+}
+
 // DiffGetterDriver is the interface for layered file system drivers that
 // provide a specialized function for getting file contents for tar-split.
 type DiffGetterDriver interface {

--- a/daemon/graphdriver/plugin.go
+++ b/daemon/graphdriver/plugin.go
@@ -38,6 +38,6 @@ func newPluginDriver(name string, pl plugingetter.CompatPlugin, config Options) 
 			}
 		}
 	}
-	proxy := &graphDriverProxy{name, pl}
+	proxy := &graphDriverProxy{name, pl, Capabilities{}}
 	return proxy, proxy.Init(filepath.Join(home, name), config.DriverOptions, config.UIDMaps, config.GIDMaps)
 }

--- a/docs/extend/plugins_graphdriver.md
+++ b/docs/extend/plugins_graphdriver.md
@@ -84,6 +84,29 @@ The request also includes a list of UID and GID mappings, structed as follows:
 Respond with a non-empty string error if an error occurred.
 
 
+### /GraphDriver.Capabilities
+
+**Request**:
+```json
+{}
+```
+
+Get behavioral characteristics of the graph driver. If a plugin does not handle
+this request, the engine will use default values for all capabilities.
+
+**Response**:
+```json
+{
+  "ReproducesExactDiffs": false,
+}
+```
+
+Respond with values of capabilities:
+
+* **ReproducesExactDiffs** Defaults to false. Flags that this driver is capable
+of reproducing exactly equivalent diffs for read-only filesystem layers.
+
+
 ### /GraphDriver.Create
 
 **Request**:

--- a/layer/ro_layer.go
+++ b/layer/ro_layer.go
@@ -24,25 +24,16 @@ type roLayer struct {
 // TarStream for roLayer guarantees that the data that is produced is the exact
 // data that the layer was registered with.
 func (rl *roLayer) TarStream() (io.ReadCloser, error) {
-	r, err := rl.layerStore.store.TarSplitReader(rl.chainID)
+	rc, err := rl.layerStore.getTarStream(rl)
 	if err != nil {
 		return nil, err
 	}
 
-	pr, pw := io.Pipe()
-	go func() {
-		err := rl.layerStore.assembleTarTo(rl.cacheID, r, nil, pw)
-		if err != nil {
-			pw.CloseWithError(err)
-		} else {
-			pw.Close()
-		}
-	}()
-	rc, err := newVerifiedReadCloser(pr, digest.Digest(rl.diffID))
+	vrc, err := newVerifiedReadCloser(rc, digest.Digest(rl.diffID))
 	if err != nil {
 		return nil, err
 	}
-	return rc, nil
+	return vrc, nil
 }
 
 // TarStreamFrom does not make any guarantees to the correctness of the produced


### PR DESCRIPTION
This allows graphdrivers to declare that they can reproduce the original
diff stream for a layer. If they do so, the layer store will not use
tar-split processing, but will still verify the digest on layer export.
This makes it easier to experiment with non-default diff formats.

Signed-off-by: Alfred Landrum <alfred.landrum@docker.com>