### PR TITLE
Explictly set state of a disabled plugin.

### DIFF
--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -97,6 +97,8 @@ func (pm *Manager) pluginPostStart(p *v2.Plugin, c *controller) error {
 		if retries > maxRetries {
 			logrus.Debugf("error net dialing plugin: %v", err)
 			c.restart = false
+			// While restoring plugins, we need to explicitly set the state to disabled
+			pm.config.Store.SetState(p, false)
 			shutdownPlugin(p, c, pm.containerdClient)
 			return err
 		}


### PR DESCRIPTION
While restoring plugins during daemon restart, some plugins can fail to
respond to net.Dial. These plugins should be explicitly set to disabled,
else they will retain their original state of enabled, which is
incorrect.

Tested with a plugin that fails to restart and observed that the state
was set to disabled.

Signed-off-by: Anusha Ragunathan <anusha.ragunathan@docker.com>