### PR TITLE
Fix flaky TestStackRemove test

### DIFF
--- a/integration-cli/fixtures/deploy/remove.yaml
+++ b/integration-cli/fixtures/deploy/remove.yaml
@@ -2,7 +2,7 @@
 version: "3.1"
 services:
   web:
-    image: busybox@sha256:e4f93f6ed15a0cdd342f5aae387886fba0ab98af0a102da6276eaf24d6e6ade0
+    image: busybox:latest
     command: top
     secrets:
       - special


### PR DESCRIPTION
Fixes #30604

For some reason the service was failing to start with the old busybox image (even though I can pull that image without any problem).

Instead of looking for containers, look for the service to exist.