### PR TITLE
Fix building client on OpenBSD

### DIFF
--- a/pkg/parsers/kernel/kernel_unix.go
+++ b/pkg/parsers/kernel/kernel_unix.go
@@ -1,4 +1,4 @@
-// +build linux freebsd solaris
+// +build linux freebsd solaris openbsd
 
 // Package kernel provides helper function to get, parse and compare kernel
 // versions for different platforms.

--- a/pkg/system/stat_openbsd.go
+++ b/pkg/system/stat_openbsd.go
@@ -13,3 +13,15 @@ func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 		rdev: uint64(s.Rdev),
 		mtim: s.Mtim}, nil
 }
+
+// Stat takes a path to a file and returns
+// a system.Stat_t type pertaining to that file.
+//
+// Throws an error if the file does not exist
+func Stat(path string) (*StatT, error) {
+	s := &syscall.Stat_t{}
+	if err := syscall.Stat(path, s); err != nil {
+		return nil, err
+	}
+	return fromStatT(s)
+}


### PR DESCRIPTION
It seems to be that this got lost along the way after #21325. The patch makes client building  on OpenBSD work (again?).