### PR TITLE
Add support for `--type=secret` in `docker inspect`

### DIFF
--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/cli/command/inspect"
 	apiclient "github.com/docker/docker/client"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type inspectOptions struct {
@@ -45,7 +44,7 @@ func NewInspectCommand(dockerCli *command.DockerCli) *cobra.Command {
 func runInspect(dockerCli *command.DockerCli, opts inspectOptions) error {
 	var elementSearcher inspect.GetRefFunc
 	switch opts.inspectType {
-	case "", "container", "image", "node", "network", "service", "volume", "task", "plugin":
+	case "", "container", "image", "node", "network", "service", "volume", "task", "plugin", "secret":
 		elementSearcher = inspectAll(context.Background(), dockerCli, opts.size, opts.inspectType)
 	default:
 		return fmt.Errorf("%q is not a valid value for --type", opts.inspectType)
@@ -101,6 +100,12 @@ func inspectPlugin(ctx context.Context, dockerCli *command.DockerCli) inspect.Ge
 	}
 }
 
+func inspectSecret(ctx context.Context, dockerCli *command.DockerCli) inspect.GetRefFunc {
+	return func(ref string) (interface{}, []byte, error) {
+		return dockerCli.Client().SecretInspectWithRaw(ctx, ref)
+	}
+}
+
 func inspectAll(ctx context.Context, dockerCli *command.DockerCli, getSize bool, typeConstraint string) inspect.GetRefFunc {
 	var inspectAutodetect = []struct {
 		objectType      string
@@ -143,6 +148,11 @@ func inspectAll(ctx context.Context, dockerCli *command.DockerCli, getSize bool,
 		{
 			objectType:      "plugin",
 			objectInspector: inspectPlugin(ctx, dockerCli),
+		},
+		{
+			objectType:      "secret",
+			isSwarmObject:   true,
+			objectInspector: inspectSecret(ctx, dockerCli),
 		},
 	}
 

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2511,7 +2511,7 @@ _docker_inspect() {
 			;;
 		--type)
 			if [ -z "$preselected_type" ] ; then
-				COMPREPLY=( $( compgen -W "container image network node plugin service volume" -- "$cur" ) )
+				COMPREPLY=( $( compgen -W "container image network node plugin secret service volume" -- "$cur" ) )
 				return
 			fi
 			;;
@@ -2534,6 +2534,7 @@ _docker_inspect() {
 						$(__docker_networks)
 						$(__docker_nodes)
 						$(__docker_plugins_installed)
+						$(__docker_secrets)
 						$(__docker_services)
 						$(__docker_volumes)
 					" -- "$cur" ) )
@@ -2552,6 +2553,9 @@ _docker_inspect() {
 					;;
 				plugin)
 					__docker_complete_plugins_installed
+					;;
+				secret)
+					__docker_complete_secrets
 					;;
 				service)
 					__docker_complete_services

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2713,6 +2713,8 @@ __docker_subcommand() {
                         __docker_complete_nodes && ret=0
                     elif [[ ${words[(r)--type=plugin]} == --type=plugin ]]; then
                         __docker_complete_plugins && ret=0
+                    elif [[ ${words[(r)--type=service]} == --type=secrets ]]; then
+                        __docker_complete_secrets && ret=0
                     elif [[ ${words[(r)--type=service]} == --type=service ]]; then
                         __docker_complete_services && ret=0
                     elif [[ ${words[(r)--type=volume]} == --type=volume ]]; then
@@ -2723,6 +2725,7 @@ __docker_subcommand() {
                         __docker_complete_networks
                         __docker_complete_nodes
                         __docker_complete_plugins
+                        __docker_complete_secrets
                         __docker_complete_services
                         __docker_complete_volumes && ret=0
                     fi


### PR DESCRIPTION
Taking into account @allencloud, add support for `docker inspect --type=secret` because, why not 👼.

/cc @icecrime :trollface: @thaJeztah @cpuguy83 @AkihiroSuda @dnephin @tiborvass @vieux 

🦁

Signed-off-by: Vincent Demeester <vincent@sbr.pm>