### PR TITLE
Add support for `--force` in `network rm`

### DIFF
--- a/api/server/router/network/backend.go
+++ b/api/server/router/network/backend.go
@@ -15,6 +15,6 @@ type Backend interface {
 	CreateNetwork(nc types.NetworkCreateRequest) (*types.NetworkCreateResponse, error)
 	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error
 	DisconnectContainerFromNetwork(containerName string, networkName string, force bool) error
-	DeleteNetwork(name string) error
+	DeleteNetwork(name string, force bool) error
 	NetworksPrune(pruneFilters filters.Args) (*types.NetworksPruneReport, error)
 }

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -258,14 +258,15 @@ func (n *networkRouter) deleteNetwork(ctx context.Context, w http.ResponseWriter
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
+	force := httputils.BoolValue(r, "force")
 	if _, err := n.cluster.GetNetwork(vars["id"]); err == nil {
-		if err = n.cluster.RemoveNetwork(vars["id"]); err != nil {
+		if err = n.cluster.RemoveNetwork(vars["id"], force); err != nil {
 			return err
 		}
 		w.WriteHeader(http.StatusNoContent)
 		return nil
 	}
-	if err := n.backend.DeleteNetwork(vars["id"]); err != nil {
+	if err := n.backend.DeleteNetwork(vars["id"], force); err != nil {
 		return err
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/cli/command/network/remove.go
+++ b/cli/command/network/remove.go
@@ -3,32 +3,46 @@ package network
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
+type removeOptions struct {
+	force bool
+
+	networks []string
+}
+
 func newRemoveCommand(dockerCli *command.DockerCli) *cobra.Command {
-	return &cobra.Command{
+	var opts removeOptions
+
+	cmd := &cobra.Command{
 		Use:     "rm NETWORK [NETWORK...]",
 		Aliases: []string{"remove"},
 		Short:   "Remove one or more networks",
 		Args:    cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRemove(dockerCli, args)
+			opts.networks = args
+			return runRemove(dockerCli, &opts)
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&opts.force, "force", "f", false, "Force the removal of one or more networks")
+	flags.SetAnnotation("force", "version", []string{"1.28"})
+
+	return cmd
 }
 
-func runRemove(dockerCli *command.DockerCli, networks []string) error {
+func runRemove(dockerCli *command.DockerCli, opts *removeOptions) error {
 	client := dockerCli.Client()
 	ctx := context.Background()
 	status := 0
 
-	for _, name := range networks {
-		if err := client.NetworkRemove(ctx, name); err != nil {
+	for _, name := range opts.networks {
+		if err := client.NetworkRemove(ctx, name, opts.force); err != nil {
 			fmt.Fprintf(dockerCli.Err(), "%s\n", err)
 			status = 1
 			continue

--- a/cli/command/stack/remove.go
+++ b/cli/command/stack/remove.go
@@ -89,7 +89,7 @@ func removeNetworks(
 	var err error
 	for _, network := range networks {
 		fmt.Fprintf(dockerCli.Err(), "Removing network %s\n", network.Name)
-		if err = dockerCli.Client().NetworkRemove(ctx, network.ID); err != nil {
+		if err = dockerCli.Client().NetworkRemove(ctx, network.ID, false); err != nil {
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove network %s: %s", network.ID, err)
 		}
 	}

--- a/client/interface.go
+++ b/client/interface.go
@@ -94,7 +94,7 @@ type NetworkAPIClient interface {
 	NetworkInspect(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, error)
 	NetworkInspectWithRaw(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, []byte, error)
 	NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error)
-	NetworkRemove(ctx context.Context, networkID string) error
+	NetworkRemove(ctx context.Context, networkID string, force bool) error
 	NetworksPrune(ctx context.Context, pruneFilter filters.Args) (types.NetworksPruneReport, error)
 }
 

--- a/client/network_remove.go
+++ b/client/network_remove.go
@@ -1,10 +1,21 @@
 package client
 
-import "golang.org/x/net/context"
+import (
+	"net/url"
+
+	"github.com/docker/docker/api/types/versions"
+	"golang.org/x/net/context"
+)
 
 // NetworkRemove removes an existent network from the docker host.
-func (cli *Client) NetworkRemove(ctx context.Context, networkID string) error {
-	resp, err := cli.delete(ctx, "/networks/"+networkID, nil, nil)
+func (cli *Client) NetworkRemove(ctx context.Context, networkID string, force bool) error {
+	query := url.Values{}
+	if versions.GreaterThanOrEqualTo(cli.version, "1.28") {
+		if force {
+			query.Set("force", "1")
+		}
+	}
+	resp, err := cli.delete(ctx, "/networks/"+networkID, query, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/network_remove_test.go
+++ b/client/network_remove_test.go
@@ -16,7 +16,7 @@ func TestNetworkRemoveError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.NetworkRemove(context.Background(), "network_id")
+	err := client.NetworkRemove(context.Background(), "network_id", false)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -40,7 +40,7 @@ func TestNetworkRemove(t *testing.T) {
 		}),
 	}
 
-	err := client.NetworkRemove(context.Background(), "network_id")
+	err := client.NetworkRemove(context.Background(), "network_id", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/cluster.go
+++ b/daemon/cluster.go
@@ -8,5 +8,5 @@ import (
 type Cluster interface {
 	GetNetwork(input string) (apitypes.NetworkResource, error)
 	GetNetworks() ([]apitypes.NetworkResource, error)
-	RemoveNetwork(input string) error
+	RemoveNetwork(input string, force bool) error
 }

--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -243,7 +243,7 @@ func (c *Cluster) CreateNetwork(s apitypes.NetworkCreateRequest) (string, error)
 }
 
 // RemoveNetwork removes a cluster network.
-func (c *Cluster) RemoveNetwork(input string) error {
+func (c *Cluster) RemoveNetwork(input string, force bool) error {
 	return c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
 		network, err := getNetwork(ctx, state.controlClient, input)
 		if err != nil {

--- a/daemon/daemon_solaris.go
+++ b/daemon/daemon_solaris.go
@@ -384,7 +384,7 @@ func (daemon *Daemon) initNetworkController(config *Config, activeSandboxes map[
 
 func initBridgeDriver(controller libnetwork.NetworkController, config *Config) error {
 	if n, err := controller.NetworkByName("bridge"); err == nil {
-		if err = n.Delete(); err != nil {
+		if err = n.Delete(false); err != nil {
 			return fmt.Errorf("could not delete the default bridge network: %v", err)
 		}
 	}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -756,7 +756,7 @@ func (daemon *Daemon) initNetworkController(config *config.Config, activeSandbox
 
 	// Clear stale bridge network
 	if n, err := controller.NetworkByName("bridge"); err == nil {
-		if err = n.Delete(); err != nil {
+		if err = n.Delete(false); err != nil {
 			return nil, fmt.Errorf("could not delete the default bridge network: %v", err)
 		}
 	}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -289,7 +289,7 @@ func (daemon *Daemon) initNetworkController(config *config.Config, activeSandbox
 		if !found {
 			// global networks should not be deleted by local HNS
 			if v.Info().Scope() != datastore.GlobalScope {
-				err = v.Delete()
+				err = v.Delete(false)
 				if err != nil {
 					logrus.Errorf("Error occurred when removing network %v", err)
 				}
@@ -336,7 +336,7 @@ func (daemon *Daemon) initNetworkController(config *config.Config, activeSandbox
 			v.Name = n.Name()
 			// This will not cause network delete from HNS as the network
 			// is not yet populated in the libnetwork windows driver
-			n.Delete()
+			n.Delete(false)
 		}
 
 		netOption := map[string]string{

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -135,7 +135,7 @@ func (daemon *Daemon) SetupIngress(create clustertypes.NetworkCreateRequest, nod
 				}
 			}
 
-			if err := n.Delete(); err != nil {
+			if err := n.Delete(false); err != nil {
 				logrus.Errorf("Failed to delete stale ingress network %s: %v", n.ID(), err)
 				return
 			}
@@ -429,15 +429,15 @@ func (daemon *Daemon) GetNetworkDriverList() []string {
 
 // DeleteManagedNetwork deletes an agent network.
 func (daemon *Daemon) DeleteManagedNetwork(networkID string) error {
-	return daemon.deleteNetwork(networkID, true)
+	return daemon.deleteNetwork(networkID, true, false)
 }
 
 // DeleteNetwork destroys a network unless it's one of docker's predefined networks.
-func (daemon *Daemon) DeleteNetwork(networkID string) error {
-	return daemon.deleteNetwork(networkID, false)
+func (daemon *Daemon) DeleteNetwork(networkID string, force bool) error {
+	return daemon.deleteNetwork(networkID, false, force)
 }
 
-func (daemon *Daemon) deleteNetwork(networkID string, dynamic bool) error {
+func (daemon *Daemon) deleteNetwork(networkID string, dynamic bool, force bool) error {
 	nw, err := daemon.FindNetwork(networkID)
 	if err != nil {
 		return err
@@ -448,7 +448,7 @@ func (daemon *Daemon) deleteNetwork(networkID string, dynamic bool) error {
 		return apierrors.NewRequestForbiddenError(err)
 	}
 
-	if err := nw.Delete(); err != nil {
+	if err := nw.Delete(force); err != nil {
 		return err
 	}
 	daemon.pluginRefCount(nw.Type(), driverapi.NetworkPluginEndpointType, plugingetter.Release)

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -207,7 +207,7 @@ func (daemon *Daemon) localNetworksPrune(pruneFilters filters.Args) *types.Netwo
 		if len(nw.Endpoints()) > 0 {
 			return false
 		}
-		if err := daemon.DeleteNetwork(nw.ID()); err != nil {
+		if err := daemon.DeleteNetwork(nw.ID(), false); err != nil {
 			logrus.Warnf("could not remove local network %s: %v", nwName, err)
 			return false
 		}
@@ -240,7 +240,7 @@ func (daemon *Daemon) clusterNetworksPrune(pruneFilters filters.Args) (*types.Ne
 		// https://github.com/docker/docker/issues/24186
 		// `docker network inspect` unfortunately displays ONLY those containers that are local to that node.
 		// So we try to remove it anyway and check the error
-		err = cluster.RemoveNetwork(nw.ID)
+		err = cluster.RemoveNetwork(nw.ID, false)
 		if err != nil {
 			// we can safely ignore the "network .. is in use" error
 			match := networkIsInUse.FindStringSubmatch(err.Error())

--- a/vendor/github.com/docker/libnetwork/controller.go
+++ b/vendor/github.com/docker/libnetwork/controller.go
@@ -1173,7 +1173,7 @@ func (c *controller) clearIngress(clusterLeave bool) {
 	}
 
 	if n != nil {
-		if err := n.Delete(); err != nil {
+		if err := n.Delete(false); err != nil {
 			logrus.Warnf("Could not delete ingress network while leaving: %v", err)
 		}
 	}

--- a/vendor/github.com/docker/libnetwork/network.go
+++ b/vendor/github.com/docker/libnetwork/network.go
@@ -39,7 +39,7 @@ type Network interface {
 	CreateEndpoint(name string, options ...EndpointOption) (Endpoint, error)
 
 	// Delete the network.
-	Delete() error
+	Delete(force bool) error
 
 	// Endpoints returns the list of Endpoint(s) in this network.
 	Endpoints() []Endpoint
@@ -779,8 +779,8 @@ func (n *network) driver(load bool) (driverapi.Driver, error) {
 	return d, nil
 }
 
-func (n *network) Delete() error {
-	return n.delete(false)
+func (n *network) Delete(force bool) error {
+	return n.delete(force)
 }
 
 func (n *network) delete(force bool) error {


### PR DESCRIPTION
Add the possibility to force remove a network (to have cli/api more consistent with other object rm methods). Taking into account @mavenugo comment : https://github.com/docker/docker/pull/31714#issuecomment-289343757 .

/cc @mavenugo @aboch @thaJeztah @icecrime @cpuguy83 @AkihiroSuda @aaronlehmann 

🦁

Signed-off-by: Vincent Demeester <vincent@sbr.pm>