### PR TITLE
Set the alias to the service name instead of the network name

### DIFF
--- a/cli/command/stack/deploy_bundlefile.go
+++ b/cli/command/stack/deploy_bundlefile.go
@@ -54,7 +54,7 @@ func deployBundle(ctx context.Context, dockerCli *command.DockerCli, opts deploy
 		for _, networkName := range service.Networks {
 			nets = append(nets, swarm.NetworkAttachmentConfig{
 				Target:  namespace.Scope(networkName),
-				Aliases: []string{networkName},
+				Aliases: []string{internalName},
 			})
 		}
 


### PR DESCRIPTION
This makes it work a little closer to compose part and it is more
correct 👼

Fixes #30836

/cc @thaJeztah @dnephin @mavenugo @icecrime @cpuguy83 @AkihiroSuda 

🦁

Signed-off-by: Vincent Demeester <vincent@sbr.pm>