### PR TITLE
Add a restarting check to ContainerAttach

### DIFF
--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -60,6 +60,10 @@ func runAttach(dockerCli *command.DockerCli, opts *attachOptions) error {
 		return errors.New("You cannot attach to a paused container, unpause it first")
 	}
 
+	if c.State.Restarting {
+		return errors.New("You cannot attach to a restarting container, wait until it is running")
+	}
+
 	if err := dockerCli.In().CheckTty(!opts.noStdin, c.Config.Tty); err != nil {
 		return err
 	}

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -35,6 +35,10 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, c *backend.ContainerA
 		return errors.NewRequestConflictError(err)
 	}
 
+	if container.IsRestarting() {
+		err := fmt.Errorf("Container %s is restarting. Wait until the container is running", prefixOrName)
+		return errors.NewRequestConflictError(err)
+	}
 	cfg := stream.AttachConfig{
 		UseStdin:   c.UseStdin,
 		UseStdout:  c.UseStdout,


### PR DESCRIPTION
Signed-off-by: yangshukui <yangshukui@huawei.com>

**- What I did**
Add a restarting check to ContainerAttach

**- How I did it**

**- How to verify it**
terminal 1,
```
docker run -d --restart=always busybox
3664ae34b27306711b55a4cbf1802d1a027b3ab33ef7fe7789c1aefb0268c928
sleep 5
docker attach 3664ae34b27306711b55a4cbf1802d1a027b3ab33ef7fe7789c1aefb0268c928
```
terminal 2,
```
docker stop 3664ae34b27306711b55a4cbf1802d1a027b3ab33ef7fe7789c1aefb0268c928
```
and then docker attach will very likely block.

**- Description for the changelog**


