### PR TITLE
[test-integration] Migrate some more tests to `cli` package

### DIFF
--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/pkg/testutil"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
@@ -71,10 +72,7 @@ func (s *DockerSuite) TestAPIDockerAPIVersion(c *check.C) {
 	defer server.Close()
 
 	// Test using the env var first
-	result := icmd.RunCmd(icmd.Cmd{
-		Command: binaryWithArgs("-H="+server.URL[7:], "version"),
-		Env:     appendBaseEnv(false, "DOCKER_API_VERSION=xxx"),
-	})
+	result := cli.Docker(cli.Args("-H="+server.URL[7:], "version"), cli.WithEnvironmentVariables("DOCKER_API_VERSION=xxx"))
 	c.Assert(result, icmd.Matches, icmd.Expected{Out: "API version:  xxx", ExitCode: 1})
 	c.Assert(svrVersion, check.Equals, "/vxxx/version", check.Commentf("%s", result.Compare(icmd.Success)))
 }

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -49,19 +49,19 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithRunningContainersPorts(c *check
 	s.d.StartWithBusybox(c)
 
 	cli.Docker(
-		cli.Cmd("run", "-d", "--name", "top1", "-p", "1234:80", "--restart", "always", "busybox:latest", "top"),
+		cli.Args("run", "-d", "--name", "top1", "-p", "1234:80", "--restart", "always", "busybox:latest", "top"),
 		cli.Daemon(s.d),
 	).Assert(c, icmd.Success)
 
 	cli.Docker(
-		cli.Cmd("run", "-d", "--name", "top2", "-p", "80", "busybox:latest", "top"),
+		cli.Args("run", "-d", "--name", "top2", "-p", "80", "busybox:latest", "top"),
 		cli.Daemon(s.d),
 	).Assert(c, icmd.Success)
 
 	testRun := func(m map[string]bool, prefix string) {
 		var format string
 		for cont, shouldRun := range m {
-			out := cli.Docker(cli.Cmd("ps"), cli.Daemon(s.d)).Assert(c, icmd.Success).Combined()
+			out := cli.Docker(cli.Args("ps"), cli.Daemon(s.d)).Assert(c, icmd.Success).Combined()
 			if shouldRun {
 				format = "%scontainer %q is not running"
 			} else {

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -7,6 +7,7 @@ import (
 	"unicode"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/pkg/homedir"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
@@ -149,29 +150,29 @@ func (s *DockerSuite) TestHelpExitCodesHelpOutput(c *check.C) {
 	// various good and bad cases are what we expect
 
 	// docker : stdout=all, stderr=empty, rc=0
-	out, _ := dockerCmd(c)
+	out := cli.DockerCmd(c).Combined()
 	// Be really pick
 	c.Assert(out, checker.Not(checker.HasSuffix), "\n\n", check.Commentf("Should not have a blank line at the end of 'docker'\n"))
 
 	// docker help: stdout=all, stderr=empty, rc=0
-	out, _ = dockerCmd(c, "help")
+	out = cli.DockerCmd(c, "help").Combined()
 	// Be really pick
 	c.Assert(out, checker.Not(checker.HasSuffix), "\n\n", check.Commentf("Should not have a blank line at the end of 'docker help'\n"))
 
 	// docker --help: stdout=all, stderr=empty, rc=0
-	out, _ = dockerCmd(c, "--help")
+	out = cli.DockerCmd(c, "--help").Combined()
 	// Be really pick
 	c.Assert(out, checker.Not(checker.HasSuffix), "\n\n", check.Commentf("Should not have a blank line at the end of 'docker --help'\n"))
 
 	// docker inspect busybox: stdout=all, stderr=empty, rc=0
 	// Just making sure stderr is empty on valid cmd
-	out, _ = dockerCmd(c, "inspect", "busybox")
+	out = cli.DockerCmd(c, "inspect", "busybox").Combined()
 	// Be really pick
 	c.Assert(out, checker.Not(checker.HasSuffix), "\n\n", check.Commentf("Should not have a blank line at the end of 'docker inspect busyBox'\n"))
 
 	// docker rm: stdout=empty, stderr=all, rc!=0
 	// testing the min arg error msg
-	icmd.RunCommand(dockerBinary, "rm").Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("rm")).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Error:    "exit status 1",
 		Out:      "",
@@ -182,8 +183,7 @@ func (s *DockerSuite) TestHelpExitCodesHelpOutput(c *check.C) {
 
 	// docker rm NoSuchContainer: stdout=empty, stderr=all, rc=0
 	// testing to make sure no blank line on error
-	result := icmd.RunCommand(dockerBinary, "rm", "NoSuchContainer")
-	result.Assert(c, icmd.Expected{
+	result := cli.Docker(cli.Args("rm", "NoSuchContainer")).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Error:    "exit status 1",
 		Out:      "",
@@ -193,7 +193,7 @@ func (s *DockerSuite) TestHelpExitCodesHelpOutput(c *check.C) {
 	c.Assert(result.Stderr(), checker.Not(checker.HasSuffix), "\n\n", check.Commentf("Should not have a blank line at the end of 'docker rm'\n"))
 
 	// docker BadCmd: stdout=empty, stderr=all, rc=0
-	icmd.RunCommand(dockerBinary, "BadCmd").Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("BadCmd")).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Error:    "exit status 1",
 		Out:      "",

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/pkg/jsonlog"
 	"github.com/docker/docker/pkg/testutil"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
@@ -65,18 +66,13 @@ func (s *DockerSuite) TestLogsTimestamps(c *check.C) {
 
 func (s *DockerSuite) TestLogsSeparateStderr(c *check.C) {
 	msg := "stderr_log"
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg))
-
+	out := cli.DockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg)).Combined()
 	id := strings.TrimSpace(out)
-	dockerCmd(c, "wait", id)
-
-	stdout, stderr, _ := dockerCmdWithStdoutStderr(c, "logs", id)
-
-	c.Assert(stdout, checker.Equals, "")
-
-	stderr = strings.TrimSpace(stderr)
-
-	c.Assert(stderr, checker.Equals, msg)
+	cli.DockerCmd(c, "wait", id)
+	cli.DockerCmd(c, "logs", id).Assert(c, icmd.Expected{
+		Out: "",
+		Err: msg,
+	})
 }
 
 func (s *DockerSuite) TestLogsStderrInStdout(c *check.C) {
@@ -84,46 +80,44 @@ func (s *DockerSuite) TestLogsStderrInStdout(c *check.C) {
 	// a bunch of ANSI escape sequences before the "stderr_log" message.
 	testRequires(c, DaemonIsLinux)
 	msg := "stderr_log"
-	out, _ := dockerCmd(c, "run", "-d", "-t", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg))
-
+	out := cli.DockerCmd(c, "run", "-d", "-t", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg)).Combined()
 	id := strings.TrimSpace(out)
-	dockerCmd(c, "wait", id)
+	cli.DockerCmd(c, "wait", id)
 
-	stdout, stderr, _ := dockerCmdWithStdoutStderr(c, "logs", id)
-	c.Assert(stderr, checker.Equals, "")
-
-	stdout = strings.TrimSpace(stdout)
-	c.Assert(stdout, checker.Equals, msg)
+	cli.DockerCmd(c, "logs", id).Assert(c, icmd.Expected{
+		Out: msg,
+		Err: "",
+	})
 }
 
 func (s *DockerSuite) TestLogsTail(c *check.C) {
 	testLen := 100
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo =; done;", testLen))
+	out := cli.DockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo =; done;", testLen)).Combined()
 
 	id := strings.TrimSpace(out)
-	dockerCmd(c, "wait", id)
+	cli.DockerCmd(c, "wait", id)
 
-	out, _ = dockerCmd(c, "logs", "--tail", "0", id)
+	out = cli.DockerCmd(c, "logs", "--tail", "0", id).Combined()
 	lines := strings.Split(out, "\n")
 	c.Assert(lines, checker.HasLen, 1)
 
-	out, _ = dockerCmd(c, "logs", "--tail", "5", id)
+	out = cli.DockerCmd(c, "logs", "--tail", "5", id).Combined()
 	lines = strings.Split(out, "\n")
 	c.Assert(lines, checker.HasLen, 6)
 
-	out, _ = dockerCmd(c, "logs", "--tail", "99", id)
+	out = cli.DockerCmd(c, "logs", "--tail", "99", id).Combined()
 	lines = strings.Split(out, "\n")
 	c.Assert(lines, checker.HasLen, 100)
 
-	out, _ = dockerCmd(c, "logs", "--tail", "all", id)
+	out = cli.DockerCmd(c, "logs", "--tail", "all", id).Combined()
 	lines = strings.Split(out, "\n")
 	c.Assert(lines, checker.HasLen, testLen+1)
 
-	out, _ = dockerCmd(c, "logs", "--tail", "-1", id)
+	out = cli.DockerCmd(c, "logs", "--tail", "-1", id).Combined()
 	lines = strings.Split(out, "\n")
 	c.Assert(lines, checker.HasLen, testLen+1)
 
-	out, _, _ = dockerCmdWithStdoutStderr(c, "logs", "--tail", "random", id)
+	out = cli.DockerCmd(c, "logs", "--tail", "random", id).Combined()
 	lines = strings.Split(out, "\n")
 	c.Assert(lines, checker.HasLen, testLen+1)
 }

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/docker/docker/pkg/mount"
@@ -495,11 +496,13 @@ func (s *DockerSuite) TestRunWithKernelMemory(c *check.C) {
 	testRequires(c, kernelMemorySupport)
 
 	file := "/sys/fs/cgroup/memory/memory.kmem.limit_in_bytes"
-	stdout, _, _ := dockerCmdWithStdoutStderr(c, "run", "--kernel-memory", "50M", "--name", "test1", "busybox", "cat", file)
-	c.Assert(strings.TrimSpace(stdout), checker.Equals, "52428800")
+	cli.DockerCmd(c, "run", "--kernel-memory", "50M", "--name", "test1", "busybox", "cat", file).Assert(c, icmd.Expected{
+		Out: "52428800",
+	})
 
-	out := inspectField(c, "test1", "HostConfig.KernelMemory")
-	c.Assert(out, check.Equals, "52428800")
+	cli.InspectCmd(c, "test1", cli.Format(".HostConfig.KernelMemory")).Assert(c, icmd.Expected{
+		Out: "52428800",
+	})
 }
 
 func (s *DockerSuite) TestRunWithInvalidKernelMemory(c *check.C) {
@@ -531,8 +534,9 @@ func (s *DockerSuite) TestRunWithCPUShares(c *check.C) {
 func (s *DockerSuite) TestRunEchoStdoutWithCPUSharesAndMemoryLimit(c *check.C) {
 	testRequires(c, cpuShare)
 	testRequires(c, memoryLimitSupport)
-	out, _, _ := dockerCmdWithStdoutStderr(c, "run", "--cpu-shares", "1000", "-m", "32m", "busybox", "echo", "test")
-	c.Assert(out, checker.Equals, "test\n", check.Commentf("container should've printed 'test'"))
+	cli.DockerCmd(c, "run", "--cpu-shares", "1000", "-m", "32m", "busybox", "echo", "test").Assert(c, icmd.Expected{
+		Out: "test\n",
+	})
 }
 
 func (s *DockerSuite) TestRunWithCpusetCpus(c *check.C) {
@@ -629,11 +633,12 @@ func (s *DockerSuite) TestRunWithMemoryLimit(c *check.C) {
 	testRequires(c, memoryLimitSupport)
 
 	file := "/sys/fs/cgroup/memory/memory.limit_in_bytes"
-	stdout, _, _ := dockerCmdWithStdoutStderr(c, "run", "-m", "32M", "--name", "test", "busybox", "cat", file)
-	c.Assert(strings.TrimSpace(stdout), checker.Equals, "33554432")
-
-	out := inspectField(c, "test", "HostConfig.Memory")
-	c.Assert(out, check.Equals, "33554432")
+	cli.DockerCmd(c, "run", "-m", "32M", "--name", "test", "busybox", "cat", file).Assert(c, icmd.Expected{
+		Out: "33554432",
+	})
+	cli.InspectCmd(c, "test", cli.Format(".HostConfig.Memory")).Assert(c, icmd.Expected{
+		Out: "33554432",
+	})
 }
 
 // TestRunWithoutMemoryswapLimit sets memory limit and disables swap

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -58,7 +58,7 @@ func (s *DockerSwarmSuite) TestSwarmInit(c *check.C) {
 		return sw.Spec
 	}
 
-	cli.Docker(cli.Cmd("swarm", "init", "--cert-expiry", "30h", "--dispatcher-heartbeat", "11s"),
+	cli.Docker(cli.Args("swarm", "init", "--cert-expiry", "30h", "--dispatcher-heartbeat", "11s"),
 		cli.Daemon(d.Daemon)).Assert(c, icmd.Success)
 
 	spec := getSpec()
@@ -67,7 +67,7 @@ func (s *DockerSwarmSuite) TestSwarmInit(c *check.C) {
 
 	c.Assert(d.Leave(true), checker.IsNil)
 	time.Sleep(500 * time.Millisecond) // https://github.com/docker/swarmkit/issues/1421
-	cli.Docker(cli.Cmd("swarm", "init"), cli.Daemon(d.Daemon)).Assert(c, icmd.Success)
+	cli.Docker(cli.Args("swarm", "init"), cli.Daemon(d.Daemon)).Assert(c, icmd.Success)
 
 	spec = getSpec()
 	c.Assert(spec.CAConfig.NodeCertExpiry, checker.Equals, 90*24*time.Hour)
@@ -77,12 +77,12 @@ func (s *DockerSwarmSuite) TestSwarmInit(c *check.C) {
 func (s *DockerSwarmSuite) TestSwarmInitIPv6(c *check.C) {
 	testRequires(c, IPv6)
 	d1 := s.AddDaemon(c, false, false)
-	cli.Docker(cli.Cmd("swarm", "init", "--listen-add", "::1"), cli.Daemon(d1.Daemon)).Assert(c, icmd.Success)
+	cli.Docker(cli.Args("swarm", "init", "--listen-add", "::1"), cli.Daemon(d1.Daemon)).Assert(c, icmd.Success)
 
 	d2 := s.AddDaemon(c, false, false)
-	cli.Docker(cli.Cmd("swarm", "join", "::1"), cli.Daemon(d2.Daemon)).Assert(c, icmd.Success)
+	cli.Docker(cli.Args("swarm", "join", "::1"), cli.Daemon(d2.Daemon)).Assert(c, icmd.Success)
 
-	out := cli.Docker(cli.Cmd("info"), cli.Daemon(d2.Daemon)).Assert(c, icmd.Success).Combined()
+	out := cli.Docker(cli.Args("info"), cli.Daemon(d2.Daemon)).Assert(c, icmd.Success).Combined()
 	c.Assert(out, checker.Contains, "Swarm: active")
 }
 

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -79,77 +79,24 @@ func deleteImages(images ...string) error {
 	return icmd.RunCmd(icmd.Cmd{Command: append(args, images...)}).Error
 }
 
+// Deprecated: use cli.Docker or cli.DockerCmd
 func dockerCmdWithError(args ...string) (string, int, error) {
-	if err := validateArgs(args...); err != nil {
-		return "", 0, err
-	}
-	result := icmd.RunCommand(dockerBinary, args...)
+	result := cli.Docker(cli.Args(args...))
 	if result.Error != nil {
 		return result.Combined(), result.ExitCode, result.Compare(icmd.Success)
 	}
 	return result.Combined(), result.ExitCode, result.Error
 }
 
-func dockerCmdWithStdoutStderr(c *check.C, args ...string) (string, string, int) {
-	if err := validateArgs(args...); err != nil {
-		c.Fatalf(err.Error())
-	}
-
-	result := icmd.RunCommand(dockerBinary, args...)
-	c.Assert(result, icmd.Matches, icmd.Success)
-	return result.Stdout(), result.Stderr(), result.ExitCode
-}
-
+// Deprecated: use cli.Docker or cli.DockerCmd
 func dockerCmd(c *check.C, args ...string) (string, int) {
-	if err := validateArgs(args...); err != nil {
-		c.Fatalf(err.Error())
-	}
-	result := icmd.RunCommand(dockerBinary, args...)
-	c.Assert(result, icmd.Matches, icmd.Success)
+	result := cli.DockerCmd(c, args...)
 	return result.Combined(), result.ExitCode
 }
 
+// Deprecated: use cli.Docker or cli.DockerCmd
 func dockerCmdWithResult(args ...string) *icmd.Result {
-	return icmd.RunCommand(dockerBinary, args...)
-}
-
-func binaryWithArgs(args ...string) []string {
-	return append([]string{dockerBinary}, args...)
-}
-
-// execute a docker command with a timeout
-func dockerCmdWithTimeout(timeout time.Duration, args ...string) *icmd.Result {
-	if err := validateArgs(args...); err != nil {
-		return &icmd.Result{Error: err}
-	}
-	return icmd.RunCmd(icmd.Cmd{Command: binaryWithArgs(args...), Timeout: timeout})
-}
-
-// execute a docker command in a directory
-func dockerCmdInDir(c *check.C, path string, args ...string) (string, int, error) {
-	if err := validateArgs(args...); err != nil {
-		c.Fatalf(err.Error())
-	}
-	result := icmd.RunCmd(icmd.Cmd{Command: binaryWithArgs(args...), Dir: path})
-	return result.Combined(), result.ExitCode, result.Error
-}
-
-// validateArgs is a checker to ensure tests are not running commands which are
-// not supported on platforms. Specifically on Windows this is 'busybox top'.
-func validateArgs(args ...string) error {
-	if testEnv.DaemonPlatform() != "windows" {
-		return nil
-	}
-	foundBusybox := -1
-	for key, value := range args {
-		if strings.ToLower(value) == "busybox" {
-			foundBusybox = key
-		}
-		if (foundBusybox != -1) && (key == foundBusybox+1) && (strings.ToLower(value) == "top") {
-			return errors.New("cannot use 'busybox top' in tests on Windows. Use runSleepingContainer()")
-		}
-	}
-	return nil
+	return cli.Docker(cli.Args(args...))
 }
 
 func findContainerIP(c *check.C, id string, network string) string {
@@ -391,6 +338,7 @@ func inspectFieldAndUnmarshall(c *check.C, name, field string, output interface{
 	}
 }
 
+// Deprecated: use cli.Inspect
 func inspectFilter(name, filter string) (string, error) {
 	format := fmt.Sprintf("{{%s}}", filter)
 	result := icmd.RunCommand(dockerBinary, "inspect", "-f", format, name)
@@ -400,10 +348,12 @@ func inspectFilter(name, filter string) (string, error) {
 	return strings.TrimSpace(result.Combined()), nil
 }
 
+// Deprecated: use cli.Inspect
 func inspectFieldWithError(name, field string) (string, error) {
 	return inspectFilter(name, fmt.Sprintf(".%s", field))
 }
 
+// Deprecated: use cli.Inspect
 func inspectField(c *check.C, name, field string) string {
 	out, err := inspectFilter(name, fmt.Sprintf(".%s", field))
 	if c != nil {
@@ -412,6 +362,7 @@ func inspectField(c *check.C, name, field string) string {
 	return out
 }
 
+// Deprecated: use cli.Inspect
 func inspectFieldJSON(c *check.C, name, field string) string {
 	out, err := inspectFilter(name, fmt.Sprintf("json .%s", field))
 	if c != nil {
@@ -420,6 +371,7 @@ func inspectFieldJSON(c *check.C, name, field string) string {
 	return out
 }
 
+// Deprecated: use cli.Inspect
 func inspectFieldMap(c *check.C, name, path, field string) string {
 	out, err := inspectFilter(name, fmt.Sprintf("index .%s %q", path, field))
 	if c != nil {
@@ -428,6 +380,7 @@ func inspectFieldMap(c *check.C, name, path, field string) string {
 	return out
 }
 
+// Deprecated: use cli.Inspect
 func inspectMountSourceField(name, destination string) (string, error) {
 	m, err := inspectMountPoint(name, destination)
 	if err != nil {
@@ -436,6 +389,7 @@ func inspectMountSourceField(name, destination string) (string, error) {
 	return m.Source, nil
 }
 
+// Deprecated: use cli.Inspect
 func inspectMountPoint(name, destination string) (types.MountPoint, error) {
 	out, err := inspectFilter(name, "json .Mounts")
 	if err != nil {
@@ -447,6 +401,7 @@ func inspectMountPoint(name, destination string) (types.MountPoint, error) {
 
 var errMountNotFound = errors.New("mount point not found")
 
+// Deprecated: use cli.Inspect
 func inspectMountPointJSON(j, destination string) (types.MountPoint, error) {
 	var mp []types.MountPoint
 	if err := json.Unmarshal([]byte(j), &mp); err != nil {
@@ -468,6 +423,7 @@ func inspectMountPointJSON(j, destination string) (types.MountPoint, error) {
 	return *m, nil
 }
 
+// Deprecated: use cli.Inspect
 func inspectImage(c *check.C, name, filter string) string {
 	args := []string{"inspect", "--type", "image"}
 	if filter != "" {


### PR DESCRIPTION
Add some required command operators to the `cli` package, and update some tests to use this package, in order to remove a few functions from `docker_utils_test.go`.

/cc @thaJeztah @dnephin @icecrime @cpuguy83 

🦁

Signed-off-by: Vincent Demeester <vincent@sbr.pm>