### PR TITLE
Disable HTML escaping for JSON in formatter

### DIFF
--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 	"text/template"
@@ -10,8 +11,12 @@ import (
 // functions provided to every template.
 var basicFunctions = template.FuncMap{
 	"json": func(v interface{}) string {
-		a, _ := json.Marshal(v)
-		return string(a)
+		buf := &bytes.Buffer{}
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		enc.Encode(v)
+		// Remove the trailing new line added by the encoder
+		return strings.TrimSpace(buf.String())
 	},
 	"split":    strings.Split,
 	"join":     strings.Join,

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -7,6 +7,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Github #32120
+func TestParseJSONFunctions(t *testing.T) {
+	tm, err := Parse(`{{json .Ports}}`)
+	assert.NoError(t, err)
+
+	var b bytes.Buffer
+	assert.NoError(t, tm.Execute(&b, map[string]string{"Ports": "0.0.0.0:2->8/udp"}))
+	want := "\"0.0.0.0:2->8/udp\""
+	assert.Equal(t, want, b.String())
+}
+
 func TestParseStringFunctions(t *testing.T) {
 	tm, err := Parse(`{{join (split . ":") "/"}}`)
 	assert.NoError(t, err)


### PR DESCRIPTION
closes #32120 

**- What I did**
Marshal values to JSON without HTML escaping characters such as `<` and `>`. 

**- How I did it**
I set HTML escaping in the JSON encoder to `false` using `SetEscapeHTML`.

This is very similar to https://github.com/docker/docker/pull/27139/commits/d1d505fa701bfe28a59afee8158994cf33ef043c and https://github.com/docker/docker/pull/27060/commits/0fa20ad13b0b5c6d1bf8a8285717c07697d079ba.

**- How to verify it**
```bash
$ TESTDIRS='pkg/templates' TESTFLAGS='-test.run ^TestParseJSONFunctions$' hack/make.sh test-unit
```