### PR TITLE
Allow setting http headers via environmental variable

### DIFF
--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -75,6 +75,7 @@ by the `docker` command line:
   `docker pull`) in `docker help` output, and only `Management commands` per object-type (e.g., `docker container`) are
   printed. This may become the default in a future release, at which point this environment-variable is removed.
 * `DOCKER_TMPDIR` Location for temporary Docker files.
+* `DOCKER_CUSTOMHEADER` Custom headers that the docker client would include in HTTP requests. This parameter serves the same purpose as the `HttpHeaders` configuration in config.json except the environmental variable would take precedence. The value of the variable should be provided in the format of a JSON object. I.E. `{ "Header" : "value" }`
 
 Because Docker is developed using Go, you can also use any environment
 variables used by the Go runtime. In particular, you may find these useful:


### PR DESCRIPTION
We (Azure Docker Registry/Visual Studio Tooling team) need a way to communicate with each other. Our registry would like to be able to track docker usage initiated from Visual Studio Docker tools.

We are aware of the [HttpHeaders](https://docs.docker.com/engine/reference/commandline/cli/#configuration-files) feature of the `config.json` file. However, to make use of this feature Visual Studio Docker tools would have to maintain a separate copy of `.docker/config.json` which might be flaky.

**- What I did**

Docker cli now reads a new environmental variable `DOCKER_CUSTOMHEADER`. Headers provided by this variable would then be added to the collection of custom headers that the client would include in its Http requests.

**- How I did it**

I simply added some logic to parse the `DOCKER_CUSTOMHEADER` in `cli.go`

**- How to verify it**

A happy path test case is added to the `docker_cli_config_test.go`. I manually tested a few other test cases:

-- No header cases still works fine
-- Using a header called `x-meta-hdr1` results in the HTTP header gets passed all the way to the registry
-- Malformed `DOCKER_CUSTOMHEADER` variable would result in the `docker` command call bailing out and complaining
-- Having the same header key in `config.json` and `DOCKER_CUSTOMHEADER` variable would result in logs generated notifying that the header value in `DOCKER_CUSTOMHEADER` is used

**- Description for the changelog**
--	allow setting http headers via environmental variable
Main changes

**- A picture of a cute animal (not mandatory but encouraged)**

![Free stock photo](http://images.all-free-download.com/images/graphiclarge/cute_dog_03_hd_pictures_168930.jpg)