### PR TITLE
Refactor logs and support service logs with TTY 

### DIFF
--- a/api/server/httputils/write_log_stream.go
+++ b/api/server/httputils/write_log_stream.go
@@ -1,0 +1,92 @@
+package httputils
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"golang.org/x/net/context"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/pkg/jsonlog"
+	"github.com/docker/docker/pkg/stdcopy"
+)
+
+// WriteLogStream writes an encoded byte stream of log messages from the
+// messages channel, multiplexing them with a stdcopy.Writer if mux is true
+func WriteLogStream(ctx context.Context, w io.Writer, msgs <-chan *backend.LogMessage, config *types.ContainerLogsOptions, mux bool) {
+	wf := ioutils.NewWriteFlusher(w)
+	defer wf.Close()
+
+	wf.Flush()
+
+	// this might seem like doing below is clear:
+	//   var outStream io.Writer = wf
+	// however, this GREATLY DISPLEASES golint, and if you do that, it will
+	// fail CI. we need outstream to be type writer because if we mux streams,
+	// we will need to reassign all of the streams to be stdwriters, which only
+	// conforms to the io.Writer interface.
+	var outStream io.Writer
+	outStream = wf
+	errStream := outStream
+	sysErrStream := errStream
+	if mux {
+		sysErrStream = stdcopy.NewStdWriter(outStream, stdcopy.Systemerr)
+		errStream = stdcopy.NewStdWriter(outStream, stdcopy.Stderr)
+		outStream = stdcopy.NewStdWriter(outStream, stdcopy.Stdout)
+	}
+
+	for {
+		msg, ok := <-msgs
+		if !ok {
+			return
+		}
+		// check if the message contains an error. if so, write that error
+		// and exit
+		if msg.Err != nil {
+			fmt.Fprintf(sysErrStream, "Error grabbing logs: %v\n", msg.Err)
+			continue
+		}
+		logLine := msg.Line
+		if config.Details {
+			logLine = append([]byte(stringAttrs(msg.Attrs)+" "), logLine...)
+		}
+		if config.Timestamps {
+			// TODO(dperny) the format is defined in
+			// daemon/logger/logger.go as logger.TimeFormat. importing
+			// logger is verboten (not part of backend) so idk if just
+			// importing the same thing from jsonlog is good enough
+			logLine = append([]byte(msg.Timestamp.Format(jsonlog.RFC3339NanoFixed)+" "), logLine...)
+		}
+		if msg.Source == "stdout" && config.ShowStdout {
+			outStream.Write(logLine)
+		}
+		if msg.Source == "stderr" && config.ShowStderr {
+			errStream.Write(logLine)
+		}
+	}
+}
+
+type byKey []string
+
+func (s byKey) Len() int { return len(s) }
+func (s byKey) Less(i, j int) bool {
+	keyI := strings.Split(s[i], "=")
+	keyJ := strings.Split(s[j], "=")
+	return keyI[0] < keyJ[0]
+}
+func (s byKey) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func stringAttrs(a backend.LogAttributes) string {
+	var ss byKey
+	for k, v := range a {
+		ss = append(ss, k+"="+v)
+	}
+	sort.Sort(ss)
+	return strings.Join(ss, ",")
+}

--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -51,7 +51,7 @@ type stateBackend interface {
 type monitorBackend interface {
 	ContainerChanges(name string) ([]archive.Change, error)
 	ContainerInspect(name string, size bool, version string) (interface{}, error)
-	ContainerLogs(ctx context.Context, name string, config *backend.ContainerLogsConfig, started chan struct{}) error
+	ContainerLogs(ctx context.Context, name string, config *types.ContainerLogsOptions) (<-chan *backend.LogMessage, error)
 	ContainerStats(ctx context.Context, name string, config *backend.ContainerStatsConfig) error
 	ContainerTop(name string, psArgs string) (*container.ContainerTopOKBody, error)
 

--- a/api/server/router/swarm/backend.go
+++ b/api/server/router/swarm/backend.go
@@ -21,7 +21,7 @@ type Backend interface {
 	CreateService(types.ServiceSpec, string) (*basictypes.ServiceCreateResponse, error)
 	UpdateService(string, uint64, types.ServiceSpec, basictypes.ServiceUpdateOptions) (*basictypes.ServiceUpdateResponse, error)
 	RemoveService(string) error
-	ServiceLogs(context.Context, *backend.LogSelector, *backend.ContainerLogsConfig, chan struct{}) error
+	ServiceLogs(context.Context, *backend.LogSelector, *basictypes.ContainerLogsOptions) (<-chan *backend.LogMessage, error)
 	GetNodes(basictypes.NodeListOptions) ([]types.Node, error)
 	GetNode(string) (types.Node, error)
 	UpdateNode(string, uint64, types.NodeSpec) error

--- a/api/server/router/swarm/helpers.go
+++ b/api/server/router/swarm/helpers.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	basictypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
-	"github.com/docker/docker/pkg/stdcopy"
 	"golang.org/x/net/context"
 )
 
@@ -24,32 +23,43 @@ func (sr *swarmRouter) swarmLogs(ctx context.Context, w http.ResponseWriter, r *
 		return fmt.Errorf("Bad parameters: you must choose at least one stream")
 	}
 
-	logsConfig := &backend.ContainerLogsConfig{
-		ContainerLogsOptions: basictypes.ContainerLogsOptions{
-			Follow:     httputils.BoolValue(r, "follow"),
-			Timestamps: httputils.BoolValue(r, "timestamps"),
-			Since:      r.Form.Get("since"),
-			Tail:       r.Form.Get("tail"),
-			ShowStdout: stdout,
-			ShowStderr: stderr,
-			Details:    httputils.BoolValue(r, "details"),
-		},
-		OutStream: w,
+	// there is probably a neater way to manufacture the ContainerLogsOptions
+	// struct, probably in the caller, to eliminate the dependency on net/http
+	logsConfig := &basictypes.ContainerLogsOptions{
+		Follow:     httputils.BoolValue(r, "follow"),
+		Timestamps: httputils.BoolValue(r, "timestamps"),
+		Since:      r.Form.Get("since"),
+		Tail:       r.Form.Get("tail"),
+		ShowStdout: stdout,
+		ShowStderr: stderr,
+		Details:    httputils.BoolValue(r, "details"),
 	}
 
-	chStarted := make(chan struct{})
-	if err := sr.backend.ServiceLogs(ctx, selector, logsConfig, chStarted); err != nil {
-		select {
-		case <-chStarted:
-			// The client may be expecting all of the data we're sending to
-			// be multiplexed, so send it through OutStream, which will
-			// have been set up to handle that if needed.
-			stdwriter := stdcopy.NewStdWriter(w, stdcopy.Systemerr)
-			fmt.Fprintf(stdwriter, "Error grabbing service logs: %v\n", err)
-		default:
+	tty := false
+	// checking for whether logs are TTY involves iterating over every service
+	// and task. idk if there is a better way
+	for _, service := range selector.Services {
+		s, err := sr.backend.GetService(service)
+		if err != nil {
+			// maybe should return some context with this error?
 			return err
 		}
+		tty = s.Spec.TaskTemplate.ContainerSpec.TTY || tty
+	}
+	for _, task := range selector.Tasks {
+		t, err := sr.backend.GetTask(task)
+		if err != nil {
+			// as above
+			return err
+		}
+		tty = t.Spec.ContainerSpec.TTY || tty
 	}
 
+	msgs, err := sr.backend.ServiceLogs(ctx, selector, logsConfig)
+	if err != nil {
+		return err
+	}
+
+	httputils.WriteLogStream(ctx, w, msgs, logsConfig, !tty)
 	return nil
 }

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -3,6 +3,7 @@ package backend
 
 import (
 	"io"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/streamformatter"
@@ -25,12 +26,27 @@ type ContainerAttachConfig struct {
 	MuxStreams bool
 }
 
-// ContainerLogsConfig holds configs for logging operations. Exists
-// for users of the backend to to pass it a logging configuration.
-type ContainerLogsConfig struct {
-	types.ContainerLogsOptions
-	OutStream io.Writer
+// LogMessage is datastructure that represents piece of output produced by some
+// container.  The Line member is a slice of an array whose contents can be
+// changed after a log driver's Log() method returns.
+// changes to this struct need to be reflect in the reset method in
+// daemon/logger/logger.go
+type LogMessage struct {
+	Line      []byte
+	Source    string
+	Timestamp time.Time
+	Attrs     LogAttributes
+	Partial   bool
+
+	// Err is an error associated with a message. Completeness of a message
+	// with Err is not expected, tho it may be partially complete (fields may
+	// be missing, gibberish, or nil)
+	Err error
 }
+
+// LogAttributes is used to hold the extra attributes available in the log message
+// Primarily used for converting the map type to string and sorting.
+type LogAttributes map[string]string
 
 // LogSelector is a list of services and tasks that should be returned as part
 // of a log stream. It is similar to swarmapi.LogSelector, with the difference

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -33,7 +33,7 @@ type Backend interface {
 	CreateManagedContainer(config types.ContainerCreateConfig) (container.ContainerCreateCreatedBody, error)
 	ContainerStart(name string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error
 	ContainerStop(name string, seconds *int) error
-	ContainerLogs(context.Context, string, *backend.ContainerLogsConfig, chan struct{}) error
+	ContainerLogs(context.Context, string, *types.ContainerLogsOptions) (<-chan *backend.LogMessage, error)
 	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error
 	ActivateContainerServiceBinding(containerName string) error
 	DeactivateContainerServiceBinding(containerName string) error

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -2,48 +2,57 @@ package daemon
 
 import (
 	"errors"
-	"io"
 	"strconv"
 	"time"
 
 	"golang.org/x/net/context"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
 	timetypes "github.com/docker/docker/api/types/time"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/logger"
-	"github.com/docker/docker/pkg/ioutils"
-	"github.com/docker/docker/pkg/stdcopy"
 )
 
-// ContainerLogs hooks up a container's stdout and stderr streams
-// configured with the given struct.
-func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, config *backend.ContainerLogsConfig, started chan struct{}) error {
+// ContainerLogs copies the container's log channel to the channel provided in
+// the config. If ContainerLogs returns an error, no messages have been copied.
+// and the channel will be closed without data.
+//
+// if it returns nil, the config channel will be active and return log
+// messages until it runs out or the context is canceled.
+func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, config *types.ContainerLogsOptions) (<-chan *backend.LogMessage, error) {
+	lg := logrus.WithFields(logrus.Fields{
+		"module":    "daemon",
+		"method":    "(*Daemon).ContainerLogs",
+		"container": containerName,
+	})
+
 	if !(config.ShowStdout || config.ShowStderr) {
-		return errors.New("You must choose at least one stream")
+		return nil, errors.New("You must choose at least one stream")
 	}
 	container, err := daemon.GetContainer(containerName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if container.RemovalInProgress || container.Dead {
-		return errors.New("can not get logs from container which is dead or marked for removal")
+		return nil, errors.New("can not get logs from container which is dead or marked for removal")
 	}
 
 	if container.HostConfig.LogConfig.Type == "none" {
-		return logger.ErrReadLogsNotSupported
+		return nil, logger.ErrReadLogsNotSupported
 	}
 
 	cLog, err := daemon.getLogger(container)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
 	logReader, ok := cLog.(logger.LogReader)
 	if !ok {
-		return logger.ErrReadLogsNotSupported
+		return nil, logger.ErrReadLogsNotSupported
 	}
 
 	follow := config.Follow && container.IsRunning()
@@ -52,76 +61,91 @@ func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, c
 		tailLines = -1
 	}
 
-	logrus.Debug("logs: begin stream")
-
 	var since time.Time
 	if config.Since != "" {
 		s, n, err := timetypes.ParseTimestamps(config.Since, 0)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		since = time.Unix(s, n)
 	}
+
 	readConfig := logger.ReadConfig{
 		Since:  since,
 		Tail:   tailLines,
 		Follow: follow,
 	}
+
 	logs := logReader.ReadLogs(readConfig)
-	// Close logWatcher on exit
-	defer func() {
-		logs.Close()
-		if cLog != container.LogDriver {
-			// Since the logger isn't cached in the container, which
-			// occurs if it is running, it must get explicitly closed
-			// here to avoid leaking it and any file handles it has.
-			if err := cLog.Close(); err != nil {
-				logrus.Errorf("Error closing logger: %v", err)
+
+	// past this point, we can't possibly return any errors, so we can just
+	// start a goroutine and return to tell the caller not to expect errors
+	// (if the caller wants to give up on logs, they have to cancel the context)
+	// this goroutine functions as a shim between the logger and the caller.
+	messageChan := make(chan *backend.LogMessage, 1)
+	go func() {
+		// set up some defers
+		defer func() {
+			// ok so this function, originally, was placed right after that
+			// logger.ReadLogs call above. I THINK that means it sets off the
+			// chain of events that results in the logger needing to be closed.
+			// i do not know if an error in time parsing above causing an early
+			// return will result in leaking the logger. if that is the case,
+			// it would also have been a bug in the original code
+			logs.Close()
+			if cLog != container.LogDriver {
+				// Since the logger isn't cached in the container, which
+				// occurs if it is running, it must get explicitly closed
+				// here to avoid leaking it and any file handles it has.
+				if err := cLog.Close(); err != nil {
+					logrus.Errorf("Error closing logger: %v", err)
+				}
+			}
+		}()
+		// close the messages channel. closing is the only way to signal above
+		// that we're doing with logs (other than context cancel i guess).
+		defer close(messageChan)
+
+		lg.Debug("begin logs")
+		for {
+			select {
+			// i do not believe as the system is currently designed any error
+			// is possible, but we should be prepared to handle it anyway. if
+			// we do get an error, copy only the error field to a new object so
+			// we don't end up with partial data in the other fields
+			case err := <-logs.Err:
+				lg.Errorf("Error streaming logs: %v", err)
+				select {
+				case <-ctx.Done():
+				case messageChan <- &backend.LogMessage{Err: err}:
+				}
+				return
+			case <-ctx.Done():
+				lg.Debug("logs: end stream, ctx is done: %v", ctx.Err())
+				return
+			case msg, ok := <-logs.Msg:
+				// there is some kind of pool or ring buffer in the logger that
+				// produces these messages, and a possible future optimization
+				// might be to use that pool and reuse message objects
+				if !ok {
+					lg.Debug("end logs")
+					return
+				}
+				m := msg.AsLogMessage() // just a pointer conversion, does not copy data
+
+				// there could be a case where the reader stops accepting
+				// messages and the context is canceled. we need to check that
+				// here, or otherwise we risk blocking forever on the message
+				// send.
+				select {
+				case <-ctx.Done():
+					return
+				case messageChan <- m:
+				}
 			}
 		}
 	}()
-
-	wf := ioutils.NewWriteFlusher(config.OutStream)
-	defer wf.Close()
-	close(started)
-	wf.Flush()
-
-	var outStream io.Writer
-	outStream = wf
-	errStream := outStream
-	if !container.Config.Tty {
-		errStream = stdcopy.NewStdWriter(outStream, stdcopy.Stderr)
-		outStream = stdcopy.NewStdWriter(outStream, stdcopy.Stdout)
-	}
-
-	for {
-		select {
-		case err := <-logs.Err:
-			logrus.Errorf("Error streaming logs: %v", err)
-			return nil
-		case <-ctx.Done():
-			logrus.Debugf("logs: end stream, ctx is done: %v", ctx.Err())
-			return nil
-		case msg, ok := <-logs.Msg:
-			if !ok {
-				logrus.Debug("logs: end stream")
-				return nil
-			}
-			logLine := msg.Line
-			if config.Details {
-				logLine = append([]byte(msg.Attrs.String()+" "), logLine...)
-			}
-			if config.Timestamps {
-				logLine = append([]byte(msg.Timestamp.Format(logger.TimeFormat)+" "), logLine...)
-			}
-			if msg.Source == "stdout" && config.ShowStdout {
-				outStream.Write(logLine)
-			}
-			if msg.Source == "stderr" && config.ShowStderr {
-				errStream.Write(logLine)
-			}
-		}
-	}
+	return messageChan, nil
 }
 
 func (daemon *Daemon) getLogger(container *container.Container) (logger.Logger, error) {


### PR DESCRIPTION
**- What I did**

This PR supersedes #31952 and either depends on or supersedes #32015 (your choice). 

Refactoring the internal logs APIs, both for services and containers. Moved marshalling into the REST server, changed APIs to communicate internally with a channel instead of a byte stream, and avoided making the dependency tree more complicated. 

Added support for TTY logs.

Paved the way to support details in service logs (which will be a follow-up PR). Paved the way to fix the [broken logs format](https://github.com/docker/docker/issues/31956). Opened up opportunities to change the log stream type.

This refactoring was necessary because trying to work with the existing byte stream API for swarm was fragile and complicated. This simplifies internal communication substantially, as well as reducing code duplication between container and service logs. Support for TTY logs was added because it was half of the motivation for this change, and trivially easy after. 

**- How I did it**

1. Refactored the `daemon/logger/Message` struct to be originally defined in `api/types/backend/LogMessage`.
1. Refactored `daemon.ContainerLogs` to write to a `chan *LogMessage` instead of a byte stream
1. Refactored `api/types/backend/ContainerLogsConfig` to contain  `chan *LogMessage` instead of an `io.Writer`
1. `daemon.ContainerLogs` is now async, and starts a goroutine if it encounters no errors. 
1. Refactored `daemon.ServiceLogs` to have the same API.
1. Added `api/server/httputils/write_log_stream.go`, with `WriteLogStream` function, to centralize the responsibility for writing and returning log streams to the client.
1. Refactored `api/types/server/container/container_routes`.`getContainerLogs` and `.../swarm/cluster_routes`.`getSwarmLogs` to send the logs config (with Messages channel) to the backend for reading and to `WriteLogStream` for writing.
1. Refactored `daemon/cluster/executor/container` to use the new API.
1. Added support for TTY logs, which is trivially easy with the new API. 
1. Wrote a LOT of comments so nobody should be scratching their head on what does what, what belongs where, and how things work.

**- How to verify it**

All of the tests pass, and there has been no change to external APIs (except the fact that logs for service with TTYs is now supported). 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added support for TTY services in `docker service logs`

**- A picture of a cute animal (not mandatory but encouraged)**
This hummingbird's beak is almost as long as this diff.
![image](https://cloud.githubusercontent.com/assets/2367858/24382458/41552c36-130b-11e7-8988-364f0fa3be4e.png)
