### PR TITLE
Fixing a comment to reflect correct command

### DIFF
--- a/cli/command/image/inspect.go
+++ b/cli/command/image/inspect.go
@@ -14,7 +14,7 @@ type inspectOptions struct {
 	refs   []string
 }
 
-// newInspectCommand creates a new cobra.Command for `docker image inspect`
+// newInspectCommand creates a new cobra.Command for `docker inspect <image>`
 func newInspectCommand(dockerCli *command.DockerCli) *cobra.Command {
 	var opts inspectOptions
 


### PR DESCRIPTION
AFAIK, there is no 'docker image inspect' but rather 'docker inspect <image>'

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixing what seems to be a typo in a comment 

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

