### PR TITLE
Dockerd: enable CORS when only `--api-cors-header` is used

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -511,7 +511,7 @@ func (cli *DaemonCli) initMiddlewares(s *apiserver.Server, cfg *apiserver.Config
 	vm := middleware.NewVersionMiddleware(v, api.DefaultVersion, api.MinVersion)
 	s.UseMiddleware(vm)
 
-	if cfg.EnableCors {
+	if cfg.EnableCors || cfg.CorsHeaders != "" {
 		c := middleware.NewCORSMiddleware(cfg.CorsHeaders)
 		s.UseMiddleware(c)
 	}


### PR DESCRIPTION
Even though the flag `--api-enable-cors` is deprecated in favor of
`--api-cors-header`. Using only `--api-cors-header` does not enable
CORS.

Make changes to 'cmd/dockerd/daemon.go' to enable CORS if either of
the above flags is set.

Signed-off-by: Karthik Nayak <Karthik.188@gmail.com>

This PR closes the issue https://github.com/docker/docker/issues/32113

**- What I did**

Fixed the issue mentioned above.

**- How I did it**

Allowed CORS to be enabled even if `--api-enable-cors` is not used but `--api-cors-header` is set, by changing the `if` condition in `cmd/dockerd/daemon.go`.

**- How to verify it**

Check issue for steps to reproduce and test.

**- Description for the changelog**

Fix an issue where CORS (`--api-cors-header`) was ignored if `--api-enable-cors` was not set

**- A picture of a cute animal (not mandatory but encouraged)**

![10e9721ebeb269bdd1c434f08572d81d](https://cloud.githubusercontent.com/assets/1786334/24405336/2a406a42-13e2-11e7-94c5-5a2c6bb276a2.jpg)

[Img Credit](https://s-media-cache-ak0.pinimg.com/originals/10/e9/72/10e9721ebeb269bdd1c434f08572d81d.jpg)