### PR TITLE
Fix TestTrustedIsolatedCreate – clean trust folder at the end of the test

### DIFF
--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -321,6 +321,7 @@ func (s *DockerTrustSuite) TestTrustedIsolatedCreate(c *check.C) {
 
 	// Try create
 	icmd.RunCmd(icmd.Command(dockerBinary, "--config", "/tmp/docker-isolated-create", "create", repoName), trustedCmd).Assert(c, SuccessTagging)
+	defer os.RemoveAll("/tmp/docker-isolated-create")
 
 	dockerCmd(c, "rmi", repoName)
 }


### PR DESCRIPTION
This test doesn't clean the folder where it stores its config (and
the trust folder), and thus, it fails if we run it more than
once (could also affect other tests at some point).

Closes #30201 

/cc @AkihiroSuda @thaJeztah @cpuguy83 @dnephin @icecrime 

🦁 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>