### PR TITLE
Update description for patch-releases and backporting

### DIFF
--- a/project/PATCH-RELEASES.md
+++ b/project/PATCH-RELEASES.md
@@ -66,3 +66,32 @@ Any code delivered as part of a patch release should make life easier for a
 significant amount of users with zero chance of degrading anybody's experience.
 A good rule of thumb for that is to limit cherry-picking to small patches, which
 fix well-understood issues, and which come with verifiable tests.
+
+## Backporting fixes to "stable" (quarterly) releases
+
+Quarterly releases (17.03, 17.06 and so on) of Docker CE are maintained for four
+months. During this period they receive critical bugfixes (P0, P1), and security
+fixes. The process for releasing patch-releases on the "stable" channel is similar
+to the process described above. Some additional details are explained below.
+
+It's important that users are able to upgrade from the stable (quarterly) release
+channel to the "edge" (monthly) release channel, without regressions. For that
+reason, fixes for stable releases should always be included in the current "edge"
+release before being _backported_ to the stable release. In rare cases this can
+imply that both an "edge" and a "stable" patch release must take place.
+
+If needed, a separate pull request / patch must be created if a fix cannot be
+backported as-is to the stable release.
+
+To guarantee stability of the quarterly releases, and to not introduce regressions;
+
+- Only P0 and P1 issues can be backported to stable releases (which includes security fixes).
+- Fixes that should be considered for backporting must be labeled with the
+  `process/backport` label. The release captain, together with relevant
+  maintainers decides if a fix will be included in the patch release.
+- Cosmetic changes, and minor usability issues should not be considered.
+- Release candidates (if needed, multiple) are published for patch releases
+  before a patch release is made generally available on the "stable" channel.
+
+Documentation changes are an exception to the above, and can be cherry-picked
+into the release branch, even if no patch-release is planned.

--- a/project/REVIEWING.md
+++ b/project/REVIEWING.md
@@ -43,6 +43,8 @@ Process labels are to assist in preparing (patch) releases. These labels should 
 
 Label                           | Use for
 ------------------------------- | -------------------------------------------------------------------------
+`process/cherry-pick-stable`    | PRs that should be considered for backporting to a patch-release on the "stable" (quarterly) release.
+`process/cherry-picked-stable`  | PRs that have been backported to to a patch-release on the "stable" (quarterly) release. Given that GitHub does not allow setting multiple milestones, it's important to refer to them from the cherry-pick PR for future reference.
 `process/cherry-pick`           | PRs that should be cherry-picked in the bump/release branch. These pull-requests must also be assigned to a milestone.
 `process/cherry-picked`         | PRs that have been cherry-picked. This label is helpful to find PR's that have been added to release-candidates, and to update the change log
 `process/docs-cherry-pick`      | PRs that should be cherry-picked in the docs branch. Only apply this label for changes that apply to the *current* release, and generic documentation fixes, such as Markdown and spelling fixes.


### PR DESCRIPTION
Add additional process information for patch releases for the stable branch.

There was some discussion if we should, or should not consider P1's for these, so perhaps we should leave P1 out of the description, and leave it to a per-case to "bump" P1's to P0


ping @icecrime @aaronlehmann @vieux PTAL