### PR TITLE
Delete extraneous H1 title

### DIFF
--- a/docs/extend/legacy_plugins.md
+++ b/docs/extend/legacy_plugins.md
@@ -15,8 +15,6 @@ keywords: "Examples, Usage, plugins, docker, documentation, user guide"
      will be rejected.
 -->
 
-# Use Docker Engine plugins
-
 This document describes the Docker Engine plugins generally available in Docker
 Engine. To view information on plugins managed by Docker,
 refer to [Docker Engine plugin system](index.md).
@@ -76,7 +74,7 @@ Plugin                                                                          
 [Local Persist Plugin](https://github.com/CWSpear/local-persist)                    | A volume plugin that extends the default `local` driver's functionality by allowing you specify a mountpoint anywhere on the host, which enables the files to *always persist*, even if the volume is removed via `docker volume rm`.
 [NetApp Plugin](https://github.com/NetApp/netappdvp) (nDVP)                         | A volume plugin that provides direct integration with the Docker ecosystem for the NetApp storage portfolio. The nDVP package supports the provisioning and management of storage resources from the storage platform to Docker hosts, with a robust framework for adding additional platforms in the future.
 [Netshare plugin](https://github.com/ContainX/docker-volume-netshare)                 | A volume plugin that provides volume management for NFS 3/4, AWS EFS and CIFS file systems.
-[Nimble Storage Volume Plugin](https://connect.nimblestorage.com/community/app-integration/docker)| A volume plug-in that integrates with Nimble Storage Unified Flash Fabric arrays. The plug-in abstracts array volume capabilities to the Docker administrator to allow self-provisioning of secure multi-tenant volumes and clones. 
+[Nimble Storage Volume Plugin](https://connect.nimblestorage.com/community/app-integration/docker)| A volume plug-in that integrates with Nimble Storage Unified Flash Fabric arrays. The plug-in abstracts array volume capabilities to the Docker administrator to allow self-provisioning of secure multi-tenant volumes and clones.
 [OpenStorage Plugin](https://github.com/libopenstorage/openstorage)                 | A cluster-aware volume plugin that provides volume management for file and block storage solutions.  It implements a vendor neutral specification for implementing extensions such as CoS, encryption, and snapshots. It has example drivers based on FUSE, NFS, NBD and EBS to name a few.
 [Portworx Volume Plugin](https://github.com/portworx/px-dev)                        | A volume plugin that turns any server into a scale-out converged compute/storage node, providing container granular storage and highly available volumes across any node, using a shared-nothing storage backend that works with any docker scheduler.
 [Quobyte Volume Plugin](https://github.com/quobyte/docker-volume)                   | A volume plugin that connects Docker to [Quobyte](http://www.quobyte.com/containers)'s data center file system, a general-purpose scalable and fault-tolerant storage platform.


### PR DESCRIPTION
**- What I did**
Removed the hard-coded H1 title, because our doc build generates the title from metadata.
**- How I did it**
Deleted H1 text.
**- How to verify it**
View page at https://docs.docker.com/engine/extend/legacy_plugins/.
**- Description for the changelog**
Removed the hard-coded H1 title, because our doc build generates titles from metadata.
**- A picture of a cute animal (not mandatory but encouraged)**

