### PR TITLE
Update Erica in mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -131,7 +131,8 @@ Francisco Carriedo <fcarriedo@gmail.com>
 <baloo@gandi.net> <superbaloo+registrations.github@superbaloo.net>
 Brian Goff <cpuguy83@gmail.com>
 <cpuguy83@gmail.com> <bgoff@cpuguy83-mbp.home>
-<eric@windisch.us> <ewindisch@docker.com>
+Erica Windisch <erica@windisch.us> <ewindisch@docker.com>
+Erica Windisch <erica@windisch.us> <eric@windisch.us>
 <frank.rosquin+github@gmail.com> <frank.rosquin@gmail.com>
 Hollie Teal <hollie@docker.com>
 <hollie@docker.com> <hollie.teal@docker.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -486,7 +486,7 @@ Eric Paris <eparis@redhat.com>
 Eric Rafaloff <erafaloff@gmail.com>
 Eric Rosenberg <ehaydenr@users.noreply.github.com>
 Eric Sage <eric.david.sage@gmail.com>
-Eric Windisch <eric@windisch.us>
+Erica Windisch <erica@windisch.us>
 Eric Yang <windfarer@gmail.com>
 Eric-Olivier Lamey <eo@lamey.me>
 Erik Bray <erik.m.bray@gmail.com>


### PR DESCRIPTION
Fix my name and email address.

Signed-off-by: Erica Windisch <erica@windisch.us>

![Deal with it](https://media.giphy.com/media/3oEduVNNr7Oyb2hIU8/giphy.gif)