### PR TITLE
api: Omit Cluster, Nodes, and Managers from swarm info when unavailable

### DIFF
--- a/api/types/swarm/swarm.go
+++ b/api/types/swarm/swarm.go
@@ -179,10 +179,10 @@ type Info struct {
 	Error            string
 
 	RemoteManagers []Peer
-	Nodes          int
-	Managers       int
+	Nodes          int `json:",omitempty"`
+	Managers       int `json:",omitempty"`
 
-	Cluster ClusterInfo
+	Cluster *ClusterInfo `json:",omitempty"`
 }
 
 // Peer represents a peer.

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -97,7 +97,7 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 			fmt.Fprintf(dockerCli.Out(), " Error: %v\n", info.Swarm.Error)
 		}
 		fmt.Fprintf(dockerCli.Out(), " Is Manager: %v\n", info.Swarm.ControlAvailable)
-		if info.Swarm.ControlAvailable && info.Swarm.Error == "" && info.Swarm.LocalNodeState != swarm.LocalNodeStateError {
+		if info.Swarm.Cluster != nil && info.Swarm.ControlAvailable && info.Swarm.Error == "" && info.Swarm.LocalNodeState != swarm.LocalNodeStateError {
 			fmt.Fprintf(dockerCli.Out(), " ClusterID: %s\n", info.Swarm.Cluster.ID)
 			fmt.Fprintf(dockerCli.Out(), " Managers: %d\n", info.Swarm.Managers)
 			fmt.Fprintf(dockerCli.Out(), " Nodes: %d\n", info.Swarm.Nodes)

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -407,8 +407,7 @@ func (c *Cluster) Info() types.Info {
 			info.Error = err.Error()
 		}
 
-		// Strip JoinTokens
-		info.Cluster = swarm.ClusterInfo
+		info.Cluster = &swarm.ClusterInfo
 
 		if r, err := state.controlClient.ListNodes(ctx, &swarmapi.ListNodesRequest{}); err != nil {
 			info.Error = err.Error()


### PR DESCRIPTION
Currently these fields are included in the response JSON with zero values. It's better not to include them if the information is unavailable (for example, on a worker node).

This turns `Cluster` into a pointer so that it can be left out.

Fixes #32166