### PR TITLE
delete generated rpm "changelog"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ autogen/
 bundles/
 cmd/dockerd/dockerd
 cmd/docker/docker
+contrib/builder/rpm/*/changelog
 dockerversion/version_autogen.go
 dockerversion/version_autogen_unix.go
 docs/AWS_S3_BUCKET

--- a/hack/make/build-rpm
+++ b/hack/make/build-rpm
@@ -54,6 +54,7 @@ set -e
 	make manpages
 
 	# Convert the CHANGELOG.md file into RPM changelog format
+	rm -f contrib/builder/rpm/${PACKAGE_ARCH}/changelog
 	VERSION_REGEX="^\W\W (.*) \((.*)\)$"
 	ENTRY_REGEX="^[-+*] (.*)$"
 	while read -r line || [[ -n "$line" ]]; do


### PR DESCRIPTION
The generated "changelog" was not removed before re-generating, causing the changelog to be added twice on repeated runs of "make rpm" (when bind-mounting the local source).

As a result, rpms failed to build, because the resulting file had entries in non-chronological order.

This change removes the generated file before re-generating, and adds the file to `.gitignore`, to prevent it from accidentally being added to source control.

**- A picture of a cute animal (not mandatory but encouraged)**

![raccoon-in-garbage](https://cloud.githubusercontent.com/assets/1804568/24464669/d4ce9d12-14aa-11e7-9451-f0dfa442c331.jpg)
