### PR TITLE
Add Windows secrets support

### DIFF
--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -8,10 +8,12 @@ import (
 	"path/filepath"
 
 	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/system"
 )
 
 const (
-	containerSecretMountPath = `C:\ProgramData\Docker\secrets`
+	containerSecretMountPath         = `C:\ProgramData\Docker\secrets`
+	containerInternalSecretMountPath = `C:\ProgramData\Docker\internal\secrets`
 )
 
 // Container holds fields specific to the Windows implementation. See
@@ -47,14 +49,46 @@ func (container *Container) IpcMounts() []Mount {
 	return nil
 }
 
-// SecretMounts returns the mounts for the secret path
-func (container *Container) SecretMounts() []Mount {
+// CreateSecretSymlinks creates symlinks to files in the secret mount.
+func (container *Container) CreateSecretSymlinks() error {
+	for _, r := range container.SecretReferences {
+		if r.File == nil {
+			continue
+		}
+		resolvedPath, _, err := container.ResolvePath(getSecretTargetPath(r))
+		if err != nil {
+			return err
+		}
+		if err := system.MkdirAll(filepath.Dir(resolvedPath), 0); err != nil {
+			return err
+		}
+		if err := os.Symlink(filepath.Join(containerInternalSecretMountPath, r.SecretID), resolvedPath); err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+// SecretMounts returns the mount for the secret path.
+// All secrets are stored in a single mount on Windows. Target symlinks are
+// created for each secret, pointing to the files in this mount.
+func (container *Container) SecretMounts() []Mount {
+	var mounts []Mount
+	if len(container.SecretReferences) > 0 {
+		mounts = append(mounts, Mount{
+			Source:      container.SecretMountPath(),
+			Destination: containerInternalSecretMountPath,
+			Writable:    false,
+		})
+	}
+
+	return mounts
 }
 
 // UnmountSecrets unmounts the fs for secrets
 func (container *Container) UnmountSecrets() error {
-	return nil
+	return os.RemoveAll(container.SecretMountPath())
 }
 
 // DetachAndUnmount unmounts all volumes.

--- a/daemon/secrets_windows.go
+++ b/daemon/secrets_windows.go
@@ -1,7 +1,7 @@
-// +build !linux,!windows
+// +build windows
 
 package daemon
 
 func secretsSupported() bool {
-	return false
+	return true
 }


### PR DESCRIPTION
Signed-off-by: John Stephens <johnstep@docker.com>

This change implements secrets support for Windows by writing to persistent files on the host, due to the lack of a RAM disk driver built in to Windows. A separate change will add RAM disk support later.

@jhowardmsft @PatrickLang @ehazlett @diogomonica @cyli