### PR TITLE
install: map debian_version 9.X to debian stretch without lsb_release

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -366,6 +366,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
+				9)
+					dist_version="stretch"
+				;;
 				8)
 					dist_version="jessie"
 				;;


### PR DESCRIPTION
related to https://github.com/docker/docker/pull/30480