### PR TITLE
plugins: Rename plugins_linux.go to plugins_unix.go and use build tags

### DIFF
--- a/hack/make/cross
+++ b/hack/make/cross
@@ -31,6 +31,11 @@ for platform in $DOCKER_CROSSPLATFORMS; do
 
 		if [ "$GOOS" != "solaris" ]; then
 			# TODO. Solaris cannot be cross build because of CGO calls.
+
+			# go install docker/docker/pkg packages to ensure that
+			# they build cross platform.
+			go install github.com/docker/docker/pkg/...
+
 			if [ -z "${daemonSupporting[$platform]}" ]; then
 				# we just need a simple client for these platforms
 				export LDFLAGS_STATIC_DOCKER=""

--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,cgo
 
 package devicemapper
 

--- a/pkg/devicemapper/devmapper_log.go
+++ b/pkg/devicemapper/devmapper_log.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,cgo
 
 package devicemapper
 

--- a/pkg/devicemapper/devmapper_wrapper.go
+++ b/pkg/devicemapper/devmapper_wrapper.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,cgo
 
 package devicemapper
 

--- a/pkg/devicemapper/devmapper_wrapper_deferred_remove.go
+++ b/pkg/devicemapper/devmapper_wrapper_deferred_remove.go
@@ -1,4 +1,4 @@
-// +build linux,!libdm_no_deferred_remove
+// +build linux,cgo,!libdm_no_deferred_remove
 
 package devicemapper
 

--- a/pkg/devicemapper/devmapper_wrapper_no_deferred_remove.go
+++ b/pkg/devicemapper/devmapper_wrapper_no_deferred_remove.go
@@ -1,4 +1,4 @@
-// +build linux,libdm_no_deferred_remove
+// +build linux,cgo,libdm_no_deferred_remove
 
 package devicemapper
 

--- a/pkg/devicemapper/ioctl.go
+++ b/pkg/devicemapper/ioctl.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,cgo
 
 package devicemapper
 

--- a/pkg/loopback/attach_loopback.go
+++ b/pkg/loopback/attach_loopback.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,cgo
 
 package loopback
 

--- a/pkg/loopback/ioctl.go
+++ b/pkg/loopback/ioctl.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,cgo
 
 package loopback
 

--- a/pkg/loopback/loop_wrapper.go
+++ b/pkg/loopback/loop_wrapper.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,cgo
 
 package loopback
 

--- a/pkg/loopback/loopback.go
+++ b/pkg/loopback/loopback.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,cgo
 
 package loopback
 

--- a/pkg/plugins/plugins_unix.go
+++ b/pkg/plugins/plugins_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package plugins
 
 // BasePath returns the path to which all paths returned by the plugin are relative to.


### PR DESCRIPTION
This allows pkg/authorization to build on OS X.

Fixes #32192

cc @anusha-ragunathan