### PR TITLE
Remove constant for "config-file" flag

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -27,7 +27,6 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.StringVarP(&conf.GraphDriver, "storage-driver", "s", "", "Storage driver to use")
 	flags.IntVar(&conf.Mtu, "mtu", 0, "Set the containers network MTU")
 	flags.BoolVar(&conf.RawLogs, "raw-logs", false, "Full timestamps without ANSI coloring")
-	// FIXME: why the inconsistency between "hosts" and "sockets"?
 	flags.Var(opts.NewListOptsRef(&conf.DNS, opts.ValidateIPAddress), "dns", "DNS server to use")
 	flags.Var(opts.NewNamedListOptsRef("dns-opts", &conf.DNSOptions, nil), "dns-opt", "DNS options to use")
 	flags.Var(opts.NewListOptsRef(&conf.DNSSearch, opts.ValidateDNSSearch), "dns-search", "DNS search domains to use")

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -50,10 +50,6 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const (
-	flagDaemonConfigFile = "config-file"
-)
-
 // DaemonCli represents the daemon CLI.
 type DaemonCli struct {
 	*config.Config
@@ -426,7 +422,7 @@ func loadDaemonCliConfig(opts daemonOptions) (*config.Config, error) {
 	if opts.configFile != "" {
 		c, err := config.MergeDaemonConfigurations(conf, flags, opts.configFile)
 		if err != nil {
-			if flags.Changed(flagDaemonConfigFile) || !os.IsNotExist(err) {
+			if flags.Changed("config-file") || !os.IsNotExist(err) {
 				return nil, fmt.Errorf("unable to configure the Docker daemon with file %s: %v\n", opts.configFile, err)
 			}
 		}

--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -19,7 +19,7 @@ func defaultOptions(configFile string) daemonOptions {
 	}
 	opts.common.InstallFlags(opts.flags)
 	installConfigFlags(opts.daemonConfig, opts.flags)
-	opts.flags.StringVar(&opts.configFile, flagDaemonConfigFile, defaultDaemonConfigFile, "")
+	opts.flags.StringVar(&opts.configFile, "config-file", defaultDaemonConfigFile, "")
 	opts.configFile = configFile
 	return opts
 }
@@ -55,7 +55,7 @@ func TestLoadDaemonCliConfigWithConflicts(t *testing.T) {
 	opts := defaultOptions(configFile)
 	flags := opts.flags
 
-	assert.NilError(t, flags.Set(flagDaemonConfigFile, configFile))
+	assert.NilError(t, flags.Set("config-file", configFile))
 	assert.NilError(t, flags.Set("label", "l1=bar"))
 	assert.NilError(t, flags.Set("label", "l2=baz"))
 

--- a/cmd/dockerd/docker.go
+++ b/cmd/dockerd/docker.go
@@ -46,7 +46,7 @@ func newDaemonCommand() *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.version, "version", "v", false, "Print version information and quit")
-	flags.StringVar(&opts.configFile, flagDaemonConfigFile, defaultDaemonConfigFile, "Daemon configuration file")
+	flags.StringVar(&opts.configFile, "config-file", defaultDaemonConfigFile, "Daemon configuration file")
 	opts.common.InstallFlags(flags)
 	installConfigFlags(opts.daemonConfig, flags)
 	installServiceFlags(flags)


### PR DESCRIPTION
None of the daemon flags use a constant for the flag name. This patch removes the constant for consistency

Also removes a FIXME, that was now in the wrong location, and added a long time ago in
353b7c8ec77b30fa83dac5ec0778193f6de8b437 (https://github.com/docker/docker/pull/7506), without a lot of context (and probably no longer really relevant).
