### PR TITLE
Allow plugins to share ipc namespace with host

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1506,8 +1506,11 @@ definitions:
           Linux:
             type: "object"
             x-nullable: false
-            required: [Capabilities, AllowAllDevices, Devices]
+            required: [Capabilities, AllowAllDevices, Devices, Ipc]
             properties:
+              Ipc:
+                type: "string"
+                x-nullable: false
               Capabilities:
                 type: "array"
                 items:

--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -145,6 +145,10 @@ type PluginConfigLinux struct {
 	// devices
 	// Required: true
 	Devices []PluginDevice `json:"Devices"`
+
+	// ipc
+	// Required: true
+	Ipc string `json:"Ipc"`
 }
 
 // PluginConfigNetwork plugin config network

--- a/docs/extend/config.md
+++ b/docs/extend/config.md
@@ -168,6 +168,10 @@ Config provides the base accessible fields for working with V0 plugin format
 
 	If `/dev` is bind mounted from the host, and allowAllDevices is set to true, the plugin will have `rwm` access to all devices on the host.
 
+    - **`ipc`** *string*
+
+	If `ipc` is `host`, the plugin will use the host's IPC namespace.
+
     - **`devices`** *PluginDevice array*
 
           device of the plugin, (*Linux only*), struct consisting of the following fields, see [`DEVICES`](https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#devices)

--- a/plugin/v2/plugin_linux.go
+++ b/plugin/v2/plugin_linux.go
@@ -22,6 +22,10 @@ func (p *Plugin) InitSpec(execRoot string) (*specs.Spec, error) {
 		Readonly: false, // TODO: all plugins should be readonly? settable in config?
 	}
 
+	if p.PluginObj.Config.Linux.Ipc == "host" {
+		oci.RemoveNamespace(&s, specs.NamespaceType("ipc"))
+	}
+
 	userMounts := make(map[string]struct{}, len(p.PluginObj.Settings.Mounts))
 	for _, m := range p.PluginObj.Settings.Mounts {
 		userMounts[m.Destination] = struct{}{}


### PR DESCRIPTION
Adds an "ipc" entry to the linux config so that plugins can be
configured to share the host's ipc namespace.

Signed-off-by: Alfred Landrum <alfred.landrum@docker.com>
