### PR TITLE
builder: Fix setting command with custom shell

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -827,7 +827,7 @@ func errTooManyArguments(command string) error {
 // shell-form of RUN, ENTRYPOINT and CMD instructions
 func getShell(c *container.Config) []string {
 	if 0 == len(c.Shell) {
-		return defaultShell[:]
+		return append([]string{}, defaultShell[:]...)
 	}
-	return c.Shell[:]
+	return append([]string{}, c.Shell[:]...)
 }


### PR DESCRIPTION
- fixes #31957

`getShell` returned a static array that is appended multiple times. Second append overrides the values for the previous one.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
