### PR TITLE
Update Container Wait

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -44,7 +44,7 @@ type stateBackend interface {
 	ContainerStop(name string, seconds *int) error
 	ContainerUnpause(name string) error
 	ContainerUpdate(name string, hostConfig *container.HostConfig) (container.ContainerUpdateOKBody, error)
-	ContainerWait(ctx context.Context, name string, untilRemoved bool) (<-chan *containerpkg.StateStatus, error)
+	ContainerWait(ctx context.Context, name string, condition containerpkg.WaitCondition) (<-chan containerpkg.StateStatus, error)
 }
 
 // monitorBackend includes functions to implement to provide containers monitoring functionality.

--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -2,7 +2,6 @@ package container
 
 import (
 	"io"
-	"time"
 
 	"golang.org/x/net/context"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+	containerpkg "github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/archive"
 )
 
@@ -44,7 +44,7 @@ type stateBackend interface {
 	ContainerStop(name string, seconds *int) error
 	ContainerUnpause(name string) error
 	ContainerUpdate(name string, hostConfig *container.HostConfig) (container.ContainerUpdateOKBody, error)
-	ContainerWait(name string, timeout time.Duration) (int, error)
+	ContainerWait(ctx context.Context, name string, untilRemoved bool) (<-chan *containerpkg.StateStatus, error)
 }
 
 // monitorBackend includes functions to implement to provide containers monitoring functionality.

--- a/api/server/router/container/container.go
+++ b/api/server/router/container/container.go
@@ -59,7 +59,7 @@ func (r *containerRouter) initRoutes() {
 		router.NewPostRoute("/containers/{name:.*}/restart", r.postContainersRestart),
 		router.NewPostRoute("/containers/{name:.*}/start", r.postContainersStart),
 		router.NewPostRoute("/containers/{name:.*}/stop", r.postContainersStop),
-		router.NewPostRoute("/containers/{name:.*}/wait", r.postContainersWait),
+		router.NewPostRoute("/containers/{name:.*}/wait", r.postContainersWait, router.WithCancel),
 		router.NewPostRoute("/containers/{name:.*}/resize", r.postContainersResize),
 		router.NewPostRoute("/containers/{name:.*}/attach", r.postContainersAttach),
 		router.NewPostRoute("/containers/{name:.*}/copy", r.postContainersCopy), // Deprecated since 1.8, Errors out since 1.12

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strconv"
 	"syscall"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api"
@@ -284,13 +283,15 @@ func (s *containerRouter) postContainersUnpause(ctx context.Context, w http.Resp
 }
 
 func (s *containerRouter) postContainersWait(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	status, err := s.backend.ContainerWait(vars["name"], -1*time.Second)
+	waitC, err := s.backend.ContainerWait(ctx, vars["name"], false)
 	if err != nil {
 		return err
 	}
 
+	status := <-waitC
+
 	return httputils.WriteJSON(w, http.StatusOK, &container.ContainerWaitOKBody{
-		StatusCode: int64(status),
+		StatusCode: int64(status.ExitCode()),
 	})
 }
 

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/versions"
+	containerpkg "github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/signal"
 	"golang.org/x/net/context"
@@ -283,14 +284,47 @@ func (s *containerRouter) postContainersUnpause(ctx context.Context, w http.Resp
 }
 
 func (s *containerRouter) postContainersWait(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	waitC, err := s.backend.ContainerWait(ctx, vars["name"], false)
+	// Behavior changed in version 1.30 to handle wait condition and to
+	// return headers immediately.
+	version := httputils.VersionFromContext(ctx)
+	legacyBehavior := versions.LessThan(version, "1.30")
+
+	// The wait condition defaults to "not-running".
+	waitCondition := containerpkg.WaitConditionNotRunning
+	if !legacyBehavior {
+		if err := httputils.ParseForm(r); err != nil {
+			return err
+		}
+		switch container.WaitCondition(r.Form.Get("condition")) {
+		case container.WaitConditionNextExit:
+			waitCondition = containerpkg.WaitConditionNextExit
+		case container.WaitConditionRemoved:
+			waitCondition = containerpkg.WaitConditionRemoved
+		}
+	}
+
+	// Note: the context should get canceled if the client closes the
+	// connection since this handler has been wrapped by the
+	// router.WithCancel() wrapper.
+	waitC, err := s.backend.ContainerWait(ctx, vars["name"], waitCondition)
 	if err != nil {
 		return err
 	}
 
+	w.Header().Set("Content-Type", "application/json")
+
+	if !legacyBehavior {
+		// Write response header immediately.
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}
+
+	// Block on the result of the wait operation.
 	status := <-waitC
 
-	return httputils.WriteJSON(w, http.StatusOK, &container.ContainerWaitOKBody{
+	return json.NewEncoder(w).Encode(&container.ContainerWaitOKBody{
 		StatusCode: int64(status.ExitCode()),
 	})
 }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4270,6 +4270,11 @@ paths:
           required: true
           description: "ID or name of the container"
           type: "string"
+        - name: "condition"
+          in: "query"
+          description: "Wait until a container state reaches the given condition, either 'not-running' (default), 'next-exit', or 'removed'."
+          type: "string"
+          default: "not-running"
       tags: ["Container"]
   /containers/{id}:
     delete:

--- a/api/types/container/waitcondition.go
+++ b/api/types/container/waitcondition.go
@@ -1,0 +1,22 @@
+package container
+
+// WaitCondition is a type used to specify a container state for which
+// to wait.
+type WaitCondition string
+
+// Possible WaitCondition Values.
+//
+// WaitConditionNotRunning (default) is used to wait for any of the non-running
+// states: "created", "exited", "dead", "removing", or "removed".
+//
+// WaitConditionNextExit is used to wait for the next time the state changes
+// to a non-running state. If the state is currently "created" or "exited",
+// this would cause Wait() to block until either the container runs and exits
+// or is removed.
+//
+// WaitConditionRemoved is used to wait for the container to be removed.
+const (
+	WaitConditionNotRunning WaitCondition = "not-running"
+	WaitConditionNextExit   WaitCondition = "next-exit"
+	WaitConditionRemoved    WaitCondition = "removed"
+)

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -6,12 +6,13 @@ package builder
 
 import (
 	"io"
-	"time"
+
+	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
-	"golang.org/x/net/context"
+	containerpkg "github.com/docker/docker/container"
 )
 
 const (
@@ -49,7 +50,7 @@ type Backend interface {
 	// ContainerStart starts a new container
 	ContainerStart(containerID string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error
 	// ContainerWait stops processing until the given container is stopped.
-	ContainerWait(containerID string, timeout time.Duration) (int, error)
+	ContainerWait(ctx context.Context, name string, untilRemoved bool) (<-chan *containerpkg.StateStatus, error)
 	// ContainerCreateWorkdir creates the workdir
 	ContainerCreateWorkdir(containerID string) error
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -50,7 +50,7 @@ type Backend interface {
 	// ContainerStart starts a new container
 	ContainerStart(containerID string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error
 	// ContainerWait stops processing until the given container is stopped.
-	ContainerWait(ctx context.Context, name string, untilRemoved bool) (<-chan *containerpkg.StateStatus, error)
+	ContainerWait(ctx context.Context, name string, condition containerpkg.WaitCondition) (<-chan containerpkg.StateStatus, error)
 	// ContainerCreateWorkdir creates the workdir
 	ContainerCreateWorkdir(containerID string) error
 

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -4,7 +4,6 @@ package dockerfile
 // non-contiguous functionality. Please read the comments.
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -24,6 +23,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/remotecontext"
+	containerpkg "github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/httputils"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -597,7 +597,7 @@ func (b *Builder) run(cID string, cmd []string) (err error) {
 		return err
 	}
 
-	waitC, err := b.docker.ContainerWait(context.Background(), cID, false)
+	waitC, err := b.docker.ContainerWait(b.clientCtx, cID, containerpkg.WaitConditionNotRunning)
 	if err != nil {
 		// Unable to begin waiting for container.
 		close(finished)

--- a/builder/dockerfile/mockbackend_test.go
+++ b/builder/dockerfile/mockbackend_test.go
@@ -2,13 +2,13 @@ package dockerfile
 
 import (
 	"io"
-	"time"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
+	containerpkg "github.com/docker/docker/container"
 	"github.com/docker/docker/image"
 	"golang.org/x/net/context"
 )
@@ -54,8 +54,8 @@ func (m *MockBackend) ContainerStart(containerID string, hostConfig *container.H
 	return nil
 }
 
-func (m *MockBackend) ContainerWait(containerID string, timeout time.Duration) (int, error) {
-	return 0, nil
+func (m *MockBackend) ContainerWait(ctx context.Context, containerID string, condition containerpkg.WaitCondition) (<-chan containerpkg.StateStatus, error) {
+	return nil, nil
 }
 
 func (m *MockBackend) ContainerCreateWorkdir(containerID string) error {

--- a/client/container_wait.go
+++ b/client/container_wait.go
@@ -2,25 +2,83 @@ package client
 
 import (
 	"encoding/json"
+	"net/url"
 
 	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/versions"
 )
 
-// ContainerWait pauses execution until a container exits.
-// It returns the API status code as response of its readiness.
-func (cli *Client) ContainerWait(ctx context.Context, containerID string) (int64, error) {
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/wait", nil, nil, nil)
+// ContainerWait waits until the specified continer is in a certain state
+// indicated by the given condition, either "not-running" (default),
+// "next-exit", or "removed".
+//
+// If this client's API version is beforer 1.30, condition is ignored and
+// ContainerWait will return immediately with the two channels, as the server
+// will wait as if the condition were "not-running".
+//
+// If this client's API version is at least 1.30, ContainerWait blocks until
+// the request has been acknowledged by the server (with a response header),
+// then returns two channels on which the caller can wait for the exit status
+// of the container or an error if there was a problem either beginning the
+// wait request or in getting the response. This allows the caller to
+// sychronize ContainerWait with other calls, such as specifying a
+// "next-exit" condition before issuing a ContainerStart request.
+func (cli *Client) ContainerWait(ctx context.Context, containerID string, condition container.WaitCondition) (<-chan container.ContainerWaitOKBody, <-chan error) {
+	if versions.LessThan(cli.ClientVersion(), "1.30") {
+		return cli.legacyContainerWait(ctx, containerID)
+	}
+
+	resultC := make(chan container.ContainerWaitOKBody)
+	errC := make(chan error)
+
+	query := url.Values{}
+	query.Set("condition", string(condition))
+
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/wait", query, nil, nil)
 	if err != nil {
-		return -1, err
-	}
-	defer ensureReaderClosed(resp)
-
-	var res container.ContainerWaitOKBody
-	if err := json.NewDecoder(resp.body).Decode(&res); err != nil {
-		return -1, err
+		defer ensureReaderClosed(resp)
+		errC <- err
+		return resultC, errC
 	}
 
-	return res.StatusCode, nil
+	go func() {
+		defer ensureReaderClosed(resp)
+		var res container.ContainerWaitOKBody
+		if err := json.NewDecoder(resp.body).Decode(&res); err != nil {
+			errC <- err
+			return
+		}
+
+		resultC <- res
+	}()
+
+	return resultC, errC
+}
+
+// legacyContainerWait returns immediately and doesn't have an option to wait
+// until the container is removed.
+func (cli *Client) legacyContainerWait(ctx context.Context, containerID string) (<-chan container.ContainerWaitOKBody, <-chan error) {
+	resultC := make(chan container.ContainerWaitOKBody)
+	errC := make(chan error)
+
+	go func() {
+		resp, err := cli.post(ctx, "/containers/"+containerID+"/wait", nil, nil, nil)
+		if err != nil {
+			errC <- err
+			return
+		}
+		defer ensureReaderClosed(resp)
+
+		var res container.ContainerWaitOKBody
+		if err := json.NewDecoder(resp.body).Decode(&res); err != nil {
+			errC <- err
+			return
+		}
+
+		resultC <- res
+	}()
+
+	return resultC, errC
 }

--- a/client/interface.go
+++ b/client/interface.go
@@ -63,7 +63,7 @@ type ContainerAPIClient interface {
 	ContainerTop(ctx context.Context, container string, arguments []string) (container.ContainerTopOKBody, error)
 	ContainerUnpause(ctx context.Context, container string) error
 	ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) (container.ContainerUpdateOKBody, error)
-	ContainerWait(ctx context.Context, container string) (int64, error)
+	ContainerWait(ctx context.Context, container string, condition container.WaitCondition) (<-chan container.ContainerWaitOKBody, <-chan error)
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
 	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (types.ContainersPruneReport, error)

--- a/container/state_test.go
+++ b/container/state_test.go
@@ -1,7 +1,7 @@
 package container
 
 import (
-	"sync/atomic"
+	"context"
 	"testing"
 	"time"
 
@@ -30,31 +30,49 @@ func TestIsValidHealthString(t *testing.T) {
 
 func TestStateRunStop(t *testing.T) {
 	s := NewState()
-	for i := 1; i < 3; i++ { // full lifecycle two times
+
+	// An initial wait (in "created" state) should block until the
+	// container has started and exited. It shouldn't take more than 100
+	// milliseconds.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	initialWait := s.Wait(ctx, false)
+
+	// Begin another wait for the final removed state. It should complete
+	// within 200 milliseconds.
+	ctx, cancel = context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	removalWait := s.Wait(ctx, true)
+
+	// Full lifecycle two times.
+	for i := 1; i <= 2; i++ {
+		// Set the state to "Running".
 		s.Lock()
-		s.SetRunning(i+100, false)
+		s.SetRunning(i, true)
 		s.Unlock()
 
+		// Assert desired state.
 		if !s.IsRunning() {
 			t.Fatal("State not running")
 		}
-		if s.Pid != i+100 {
-			t.Fatalf("Pid %v, expected %v", s.Pid, i+100)
+		if s.Pid != i {
+			t.Fatalf("Pid %v, expected %v", s.Pid, i)
 		}
 		if s.ExitCode() != 0 {
 			t.Fatalf("ExitCode %v, expected 0", s.ExitCode())
 		}
 
-		stopped := make(chan struct{})
-		var exit int64
-		go func() {
-			exitCode, _ := s.WaitStop(-1 * time.Second)
-			atomic.StoreInt64(&exit, int64(exitCode))
-			close(stopped)
-		}()
+		// Async wait up to 50 milliseconds for the exit status.
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		exitWait := s.Wait(ctx, false)
+
+		// Set the state to "Exited".
 		s.Lock()
 		s.SetStopped(&ExitStatus{ExitCode: i})
 		s.Unlock()
+
+		// Assert desired state.
 		if s.IsRunning() {
 			t.Fatal("State is running")
 		}
@@ -64,50 +82,86 @@ func TestStateRunStop(t *testing.T) {
 		if s.Pid != 0 {
 			t.Fatalf("Pid %v, expected 0", s.Pid)
 		}
-		select {
-		case <-time.After(100 * time.Millisecond):
-			t.Fatal("Stop callback doesn't fire in 100 milliseconds")
-		case <-stopped:
-			t.Log("Stop callback fired")
+
+		// Receive the exitWait result.
+		status := <-exitWait
+		if status.ExitCode() != i {
+			t.Fatalf("ExitCode %v, expected %v, err %q", status.ExitCode(), i, status.Err())
 		}
-		exitCode := int(atomic.LoadInt64(&exit))
-		if exitCode != i {
-			t.Fatalf("ExitCode %v, expected %v", exitCode, i)
+
+		// A repeated call to Wait() should not block at this point.
+		ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		exitWait = s.Wait(ctx, false)
+
+		status = <-exitWait
+		if status.ExitCode() != i {
+			t.Fatalf("ExitCode %v, expected %v, err %q", status.ExitCode(), i, status.Err())
 		}
-		if exitCode, err := s.WaitStop(-1 * time.Second); err != nil || exitCode != i {
-			t.Fatalf("WaitStop returned exitCode: %v, err: %v, expected exitCode: %v, err: %v", exitCode, err, i, nil)
+
+		if i == 1 {
+			// Make sure our initial wait also succeeds.
+			status = <-initialWait
+			if status.ExitCode() != i {
+				// Should have the exit code from this first loop.
+				t.Fatalf("Initial wait exitCode %v, expected %v, err %q", status.ExitCode(), i, status.Err())
+			}
 		}
+	}
+
+	// Set the state to dead and removed.
+	s.SetDead()
+	s.SetRemoved()
+
+	// Wait for removed status or timeout.
+	status := <-removalWait
+	if status.ExitCode() != 2 {
+		// Should have the final exit code from the loop.
+		t.Fatalf("Removal wait exitCode %v, expected %v, err %q", status.ExitCode(), 2, status.Err())
 	}
 }
 
 func TestStateTimeoutWait(t *testing.T) {
 	s := NewState()
-	stopped := make(chan struct{})
-	go func() {
-		s.WaitStop(100 * time.Millisecond)
-		close(stopped)
-	}()
+
+	// Start a wait with a timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	waitC := s.Wait(ctx, false)
+
+	// It should timeout *before* this 200ms timer does.
 	select {
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("Stop callback doesn't fire in 200 milliseconds")
-	case <-stopped:
+	case status := <-waitC:
 		t.Log("Stop callback fired")
+		// Should be a timeout error.
+		if status.Err() == nil {
+			t.Fatal("expected timeout error, got nil")
+		}
+		if status.ExitCode() != -1 {
+			t.Fatalf("expected exit code %v, got %v", -1, status.ExitCode())
+		}
 	}
 
 	s.Lock()
-	s.SetStopped(&ExitStatus{ExitCode: 1})
+	s.SetRunning(0, true)
+	s.SetStopped(&ExitStatus{ExitCode: 0})
 	s.Unlock()
 
-	stopped = make(chan struct{})
-	go func() {
-		s.WaitStop(100 * time.Millisecond)
-		close(stopped)
-	}()
+	// Start another wait with a timeout. This one should return
+	// immediately.
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	waitC = s.Wait(ctx, false)
+
 	select {
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("Stop callback doesn't fire in 200 milliseconds")
-	case <-stopped:
+	case status := <-waitC:
 		t.Log("Stop callback fired")
+		if status.ExitCode() != 0 {
+			t.Fatalf("expected exit code %v, got %v, err %q", 0, status.ExitCode(), status.Err())
+		}
 	}
-
 }

--- a/container/stream/attach.go
+++ b/container/stream/attach.go
@@ -8,16 +8,10 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/promise"
+	"github.com/docker/docker/pkg/term"
 )
 
 var defaultEscapeSequence = []byte{16, 17} // ctrl-p, ctrl-q
-
-// DetachError is special error which returned in case of container detach.
-type DetachError struct{}
-
-func (DetachError) Error() string {
-	return "detached from container"
-}
 
 // AttachConfig is the config struct used to attach a client to a stream's stdio
 type AttachConfig struct {
@@ -173,62 +167,11 @@ func (c *Config) CopyStreams(ctx context.Context, cfg *AttachConfig) chan error 
 	})
 }
 
-// ttyProxy is used only for attaches with a TTY. It is used to proxy
-// stdin keypresses from the underlying reader and look for the passed in
-// escape key sequence to signal a detach.
-type ttyProxy struct {
-	escapeKeys   []byte
-	escapeKeyPos int
-	r            io.Reader
-}
-
-func (r *ttyProxy) Read(buf []byte) (int, error) {
-	nr, err := r.r.Read(buf)
-
-	preserve := func() {
-		// this preserves the original key presses in the passed in buffer
-		nr += r.escapeKeyPos
-		preserve := make([]byte, 0, r.escapeKeyPos+len(buf))
-		preserve = append(preserve, r.escapeKeys[:r.escapeKeyPos]...)
-		preserve = append(preserve, buf...)
-		r.escapeKeyPos = 0
-		copy(buf[0:nr], preserve)
-	}
-
-	if nr != 1 || err != nil {
-		if r.escapeKeyPos > 0 {
-			preserve()
-		}
-		return nr, err
-	}
-
-	if buf[0] != r.escapeKeys[r.escapeKeyPos] {
-		if r.escapeKeyPos > 0 {
-			preserve()
-		}
-		return nr, nil
-	}
-
-	if r.escapeKeyPos == len(r.escapeKeys)-1 {
-		return 0, DetachError{}
-	}
-
-	// Looks like we've got an escape key, but we need to match again on the next
-	// read.
-	// Store the current escape key we found so we can look for the next one on
-	// the next read.
-	// Since this is an escape key, make sure we don't let the caller read it
-	// If later on we find that this is not the escape sequence, we'll add the
-	// keys back
-	r.escapeKeyPos++
-	return nr - r.escapeKeyPos, nil
-}
-
 func copyEscapable(dst io.Writer, src io.ReadCloser, keys []byte) (written int64, err error) {
 	if len(keys) == 0 {
 		keys = defaultEscapeSequence
 	}
-	pr := &ttyProxy{escapeKeys: keys, r: src}
+	pr := term.NewEscapeProxy(src, keys)
 	defer src.Close()
 
 	return io.Copy(dst, pr)

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -162,7 +162,7 @@ func (daemon *Daemon) containerAttach(c *container.Container, cfg *stream.Attach
 
 	if c.Config.StdinOnce && !c.Config.Tty {
 		// Wait for the container to stop before returning.
-		waitChan := c.Wait(context.Background(), false)
+		waitChan := c.Wait(context.Background(), container.WaitConditionNotRunning)
 		defer func() {
 			_ = <-waitChan // Ignore returned exit code.
 		}()
@@ -171,7 +171,7 @@ func (daemon *Daemon) containerAttach(c *container.Container, cfg *stream.Attach
 	ctx := c.InitAttachContext()
 	err := <-c.StreamConfig.CopyStreams(ctx, cfg)
 	if err != nil {
-		if _, ok := err.(stream.DetachError); ok {
+		if _, ok := err.(term.EscapeError); ok {
 			daemon.LogContainerEvent(c, "detach")
 		} else {
 			logrus.Errorf("attach failed with error: %v", err)

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -40,7 +40,7 @@ type Backend interface {
 	DeactivateContainerServiceBinding(containerName string) error
 	UpdateContainerServiceConfig(containerName string, serviceConfig *clustertypes.ServiceConfig) error
 	ContainerInspectCurrent(name string, size bool) (*types.ContainerJSON, error)
-	ContainerWait(ctx context.Context, name string, untilRemoved bool) (<-chan *containerpkg.StateStatus, error)
+	ContainerWait(ctx context.Context, name string, condition containerpkg.WaitCondition) (<-chan containerpkg.StateStatus, error)
 	ContainerRm(name string, config *types.ContainerRmConfig) error
 	ContainerKill(name string, sig uint64) error
 	SetContainerDependencyStore(name string, store exec.DependencyGetter) error

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
+	containerpkg "github.com/docker/docker/container"
 	clustertypes "github.com/docker/docker/daemon/cluster/provider"
 	"github.com/docker/docker/plugin"
 	"github.com/docker/libnetwork"
@@ -39,7 +40,7 @@ type Backend interface {
 	DeactivateContainerServiceBinding(containerName string) error
 	UpdateContainerServiceConfig(containerName string, serviceConfig *clustertypes.ServiceConfig) error
 	ContainerInspectCurrent(name string, size bool) (*types.ContainerJSON, error)
-	ContainerWaitWithContext(ctx context.Context, name string) error
+	ContainerWait(ctx context.Context, name string, untilRemoved bool) (<-chan *containerpkg.StateStatus, error)
 	ContainerRm(name string, config *types.ContainerRmConfig) error
 	ContainerKill(name string, sig uint64) error
 	SetContainerDependencyStore(name string, store exec.DependencyGetter) error

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
+	containerpkg "github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/cluster/convert"
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
 	"github.com/docker/libnetwork"
@@ -337,8 +338,8 @@ func (c *containerAdapter) events(ctx context.Context) <-chan events.Message {
 	return eventsq
 }
 
-func (c *containerAdapter) wait(ctx context.Context) error {
-	return c.backend.ContainerWaitWithContext(ctx, c.container.nameOrID())
+func (c *containerAdapter) wait(ctx context.Context) (<-chan *containerpkg.StateStatus, error) {
+	return c.backend.ContainerWait(ctx, c.container.nameOrID(), false)
 }
 
 func (c *containerAdapter) shutdown(ctx context.Context) error {

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -338,8 +338,8 @@ func (c *containerAdapter) events(ctx context.Context) <-chan events.Message {
 	return eventsq
 }
 
-func (c *containerAdapter) wait(ctx context.Context) (<-chan *containerpkg.StateStatus, error) {
-	return c.backend.ContainerWait(ctx, c.container.nameOrID(), false)
+func (c *containerAdapter) wait(ctx context.Context) (<-chan containerpkg.StateStatus, error) {
+	return c.backend.ContainerWait(ctx, c.container.nameOrID(), containerpkg.WaitConditionNotRunning)
 }
 
 func (c *containerAdapter) shutdown(ctx context.Context) error {

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -291,16 +291,16 @@ func (daemon *Daemon) setupConfigDir(c *container.Container) (setupErr error) {
 	return nil
 }
 
-func killProcessDirectly(container *container.Container) error {
+func killProcessDirectly(cntr *container.Container) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	// Block until the container to stops or timeout.
-	status := <-container.Wait(ctx, false)
+	status := <-cntr.Wait(ctx, container.WaitConditionNotRunning)
 	if status.Err() != nil {
 		// Ensure that we don't kill ourselves
-		if pid := container.GetPID(); pid != 0 {
-			logrus.Infof("Container %s failed to exit within 10 seconds of kill - trying direct SIGKILL", stringid.TruncateID(container.ID))
+		if pid := cntr.GetPID(); pid != 0 {
+			logrus.Infof("Container %s failed to exit within 10 seconds of kill - trying direct SIGKILL", stringid.TruncateID(cntr.ID))
 			if err := syscall.Kill(pid, 9); err != nil {
 				if err != syscall.ESRCH {
 					return err

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -779,7 +779,7 @@ func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 		defer cancel()
 
 		// Wait with timeout for container to exit.
-		if status := <-c.Wait(ctx, false); status.Err() != nil {
+		if status := <-c.Wait(ctx, container.WaitConditionNotRunning); status.Err() != nil {
 			logrus.Debugf("container %s failed to exit in %d second of SIGTERM, sending SIGKILL to force", c.ID, stopTimeout)
 			sig, ok := signal.SignalMap["KILL"]
 			if !ok {
@@ -790,7 +790,7 @@ func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 			}
 			// Wait for exit again without a timeout.
 			// Explicitly ignore the result.
-			_ = <-c.Wait(context.Background(), false)
+			_ = <-c.Wait(context.Background(), container.WaitConditionNotRunning)
 			return status.Err()
 		}
 	}
@@ -801,7 +801,7 @@ func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 
 	// Wait without timeout for the container to exit.
 	// Ignore the result.
-	_ = <-c.Wait(context.Background(), false)
+	_ = <-c.Wait(context.Background(), container.WaitConditionNotRunning)
 	return nil
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -6,6 +6,7 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -773,7 +774,12 @@ func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 		if err := daemon.containerUnpause(c); err != nil {
 			return fmt.Errorf("Failed to unpause container %s with error: %v", c.ID, err)
 		}
-		if _, err := c.WaitStop(time.Duration(stopTimeout) * time.Second); err != nil {
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(stopTimeout)*time.Second)
+		defer cancel()
+
+		// Wait with timeout for container to exit.
+		if status := <-c.Wait(ctx, false); status.Err() != nil {
 			logrus.Debugf("container %s failed to exit in %d second of SIGTERM, sending SIGKILL to force", c.ID, stopTimeout)
 			sig, ok := signal.SignalMap["KILL"]
 			if !ok {
@@ -782,8 +788,10 @@ func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 			if err := daemon.kill(c, int(sig)); err != nil {
 				logrus.Errorf("Failed to SIGKILL container %s", c.ID)
 			}
-			c.WaitStop(-1 * time.Second)
-			return err
+			// Wait for exit again without a timeout.
+			// Explicitly ignore the result.
+			_ = <-c.Wait(context.Background(), false)
+			return status.Err()
 		}
 	}
 	// If container failed to exit in stopTimeout seconds of SIGTERM, then using the force
@@ -791,7 +799,9 @@ func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 		return fmt.Errorf("Failed to stop container %s with error: %v", c.ID, err)
 	}
 
-	c.WaitStop(-1 * time.Second)
+	// Wait without timeout for the container to exit.
+	// Ignore the result.
+	_ = <-c.Wait(context.Background(), false)
 	return nil
 }
 

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -134,6 +134,7 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 	if e := daemon.removeMountPoints(container, removeVolume); e != nil {
 		logrus.Error(e)
 	}
+	container.SetRemoved()
 	stateCtr.del(container.ID)
 	daemon.LogContainerEvent(container, "destroy")
 	return nil

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -253,7 +253,7 @@ func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.R
 		return fmt.Errorf("context cancelled")
 	case err := <-attachErr:
 		if err != nil {
-			if _, ok := err.(stream.DetachError); !ok {
+			if _, ok := err.(term.EscapeError); !ok {
 				return fmt.Errorf("exec attach failed with error: %v", err)
 			}
 			d.LogContainerEvent(c, "exec_detach")

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -153,7 +153,7 @@ func (daemon *Daemon) getInspectData(container *container.Container) (*types.Con
 		Dead:       container.State.Dead,
 		Pid:        container.State.Pid,
 		ExitCode:   container.State.ExitCode(),
-		Error:      container.State.Error(),
+		Error:      container.State.ErrorMsg,
 		StartedAt:  container.State.StartedAt.Format(time.RFC3339Nano),
 		FinishedAt: container.State.FinishedAt.Format(time.RFC3339Nano),
 		Health:     containerHealth,

--- a/daemon/wait.go
+++ b/daemon/wait.go
@@ -5,18 +5,18 @@ import (
 	"golang.org/x/net/context"
 )
 
-// ContainerWait stops processing until the given container is stopped or
-// removed (if untilRemoved is true). If the container is not found, a nil
+// ContainerWait waits until the given container is in a certain state
+// indicated by the given condition. If the container is not found, a nil
 // channel and non-nil error is returned immediately. If the container is
 // found, a status result will be sent on the returned channel once the wait
 // condition is met or if an error occurs waiting for the container (such as a
-// context timeout or cancellation). On a successful stop, the exit code of the
+// context timeout or cancellation). On a successful wait, the exit code of the
 // container is returned in the status with a non-nil Err() value.
-func (daemon *Daemon) ContainerWait(ctx context.Context, name string, untilRemoved bool) (<-chan *container.StateStatus, error) {
-	container, err := daemon.GetContainer(name)
+func (daemon *Daemon) ContainerWait(ctx context.Context, name string, condition container.WaitCondition) (<-chan container.StateStatus, error) {
+	cntr, err := daemon.GetContainer(name)
 	if err != nil {
 		return nil, err
 	}
 
-	return container.Wait(ctx, untilRemoved), nil
+	return cntr.Wait(ctx, condition), nil
 }

--- a/daemon/wait.go
+++ b/daemon/wait.go
@@ -1,32 +1,22 @@
 package daemon
 
 import (
-	"time"
-
+	"github.com/docker/docker/container"
 	"golang.org/x/net/context"
 )
 
-// ContainerWait stops processing until the given container is
-// stopped. If the container is not found, an error is returned. On a
-// successful stop, the exit code of the container is returned. On a
-// timeout, an error is returned. If you want to wait forever, supply
-// a negative duration for the timeout.
-func (daemon *Daemon) ContainerWait(name string, timeout time.Duration) (int, error) {
+// ContainerWait stops processing until the given container is stopped or
+// removed (if untilRemoved is true). If the container is not found, a nil
+// channel and non-nil error is returned immediately. If the container is
+// found, a status result will be sent on the returned channel once the wait
+// condition is met or if an error occurs waiting for the container (such as a
+// context timeout or cancellation). On a successful stop, the exit code of the
+// container is returned in the status with a non-nil Err() value.
+func (daemon *Daemon) ContainerWait(ctx context.Context, name string, untilRemoved bool) (<-chan *container.StateStatus, error) {
 	container, err := daemon.GetContainer(name)
 	if err != nil {
-		return -1, err
+		return nil, err
 	}
 
-	return container.WaitStop(timeout)
-}
-
-// ContainerWaitWithContext returns a channel where exit code is sent
-// when container stops. Channel can be cancelled with a context.
-func (daemon *Daemon) ContainerWaitWithContext(ctx context.Context, name string) error {
-	container, err := daemon.GetContainer(name)
-	if err != nil {
-		return err
-	}
-
-	return container.WaitWithContext(ctx)
+	return container.Wait(ctx, untilRemoved), nil
 }

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -28,6 +28,7 @@ keywords: "API, Docker, rcli, REST, documentation"
  the swarm, the desired CA key for the swarm (if not using an external certificate), and an optional parameter to force swarm to
  generate and rotate to a new CA certificate/key pair.
 * `POST /service/create` and `POST /services/(id or name)/update` now take the field `Platforms` as part of the service `Placement`, allowing to specify platforms supported by the service.
+* `POST /containers/(name)/wait` now accepts a `condition` query parameter to indicate which state change condition to wait for. Also, response headers are now returned immediately to acknowledge that the server has registered a wait callback for the client.
 
 ## v1.29 API changes
 

--- a/docs/reference/commandline/wait.md
+++ b/docs/reference/commandline/wait.md
@@ -21,7 +21,7 @@ Usage:  docker wait CONTAINER [CONTAINER...]
 Block until one or more containers stop, then print their exit codes
 
 Options:
-      --help   Print usage
+      --help        Print usage
 ```
 
 > **Note**: `docker wait` returns `0` when run against a container which had

--- a/hack/integration-cli-on-swarm/agent/worker/executor.go
+++ b/hack/integration-cli-on-swarm/agent/worker/executor.go
@@ -83,11 +83,13 @@ func privilegedTestChunkExecutor(autoRemove bool) testChunkExecutor {
 		}
 		var b bytes.Buffer
 		teeContainerStream(&b, os.Stdout, os.Stderr, stream)
-		rc, err := cli.ContainerWait(context.Background(), id)
-		if err != nil {
+		resultC, errC := cli.ContainerWait(context.Background(), id, "")
+		select {
+		case err := <-errC:
 			return 0, "", err
+		case result := <-resultC:
+			return result.StatusCode, b.String(), nil
 		}
-		return rc, b.String(), nil
 	}
 }
 

--- a/hack/integration-cli-on-swarm/host/host.go
+++ b/hack/integration-cli-on-swarm/host/host.go
@@ -188,5 +188,11 @@ func waitForContainerCompletion(cli *client.Client, stdout, stderr io.Writer, co
 	}
 	stdcopy.StdCopy(stdout, stderr, stream)
 	stream.Close()
-	return cli.ContainerWait(context.Background(), containerID)
+	resultC, errC := cli.ContainerWait(context.Background(), containerID, "")
+	select {
+	case err := <-errC:
+		return 1, err
+	case result := <-resultC:
+		return result.StatusCode, nil
+	}
 }

--- a/pkg/term/proxy.go
+++ b/pkg/term/proxy.go
@@ -1,0 +1,74 @@
+package term
+
+import (
+	"io"
+)
+
+// EscapeError is special error which returned by a TTY proxy reader's Read()
+// method in case its detach escape sequence is read.
+type EscapeError struct{}
+
+func (EscapeError) Error() string {
+	return "read escape sequence"
+}
+
+// escapeProxy is used only for attaches with a TTY. It is used to proxy
+// stdin keypresses from the underlying reader and look for the passed in
+// escape key sequence to signal a detach.
+type escapeProxy struct {
+	escapeKeys   []byte
+	escapeKeyPos int
+	r            io.Reader
+}
+
+// NewEscapeProxy returns a new TTY proxy reader which wraps the given reader
+// and detects when the specified escape keys are read, in which case the Read
+// method will return an error of type EscapeError.
+func NewEscapeProxy(r io.Reader, escapeKeys []byte) io.Reader {
+	return &escapeProxy{
+		escapeKeys: escapeKeys,
+		r:          r,
+	}
+}
+
+func (r *escapeProxy) Read(buf []byte) (int, error) {
+	nr, err := r.r.Read(buf)
+
+	preserve := func() {
+		// this preserves the original key presses in the passed in buffer
+		nr += r.escapeKeyPos
+		preserve := make([]byte, 0, r.escapeKeyPos+len(buf))
+		preserve = append(preserve, r.escapeKeys[:r.escapeKeyPos]...)
+		preserve = append(preserve, buf...)
+		r.escapeKeyPos = 0
+		copy(buf[0:nr], preserve)
+	}
+
+	if nr != 1 || err != nil {
+		if r.escapeKeyPos > 0 {
+			preserve()
+		}
+		return nr, err
+	}
+
+	if buf[0] != r.escapeKeys[r.escapeKeyPos] {
+		if r.escapeKeyPos > 0 {
+			preserve()
+		}
+		return nr, nil
+	}
+
+	if r.escapeKeyPos == len(r.escapeKeys)-1 {
+		return 0, EscapeError{}
+	}
+
+	// Looks like we've got an escape key, but we need to match again on the next
+	// read.
+	// Store the current escape key we found so we can look for the next one on
+	// the next read.
+	// Since this is an escape key, make sure we don't let the caller read it
+	// If later on we find that this is not the escape sequence, we'll add the
+	// keys back
+	r.escapeKeyPos++
+	return nr - r.escapeKeyPos, nil
+}


### PR DESCRIPTION
**Summary**

The goal for this PR is to be able to use the `POST /containers/{name}/wait` API in order to no longer rely on the Events API when doing `docker run ...` and `docker start` in attached mode. Here is the set of behavioral changes in the API and CLI:

- The wait API now has on optional query parameter, `condition`, which specifies the state of the container which the client would like to wait for:

    - **`not-running`**

        This is the default value which maintains the existing behavior of the Wait API. It blocks if the container is in a state which is considered to be *running*, i.e., any of *running*, *paused*, or *restarting*. If it is already not in any of those states, then it would not block at all and return immediately with the current exit code.

    - **`next-exit`**

        This condition allows the client to wait for the container's state to *change* to a not-running state or to be removed. This is different from the *not-running* option because it will block if the container is in the *created*, *exited*, *dead*, or *removing* state, blocking through a transition to one of the running states and back to one of *exited* states or until the container is removed, whichever comes first. It is similar to waiting for a *die* or *destroy* event. This option is very useful to use before issuing a container start API request.

    - **`removed`**

        This condition allows the client to wait for the container to be removed. It is similar to waiting for a *destroy* event.

- The Wait API will now return HTTP response headers immediately. This serves an an acknowledgement that a wait has been registered. The JSON response body will not be returned until the wait condition is met.

- The Wait API's request context is extended to wait for a `http.CloseNotifier` event in the case that the client closes the connection while the server is blocked on the wait condition. This prevents leaked goroutines but should only be necessary until we switch to using Go 1.8's request context which cancels automatically if the client disconnects.

- ~~To handle a manual detach (when the user enters the detach keys sequence when attached in TTY mode), the CLI now detects this key sequence, stops sending stdin, and causes the CLI to exit immediately. This is done as an alternative to waiting for a *detach* event.~~ The rug has been pulled out from under this bullet point. This will have to be done in the github.com/docker/cli repo along with the other CLI changes.

Follow-up to #31794

Fixes #32242