### PR TITLE
Windows - fix panic and stderr output when service

### DIFF
--- a/cmd/dockerd/docker.go
+++ b/cmd/dockerd/docker.go
@@ -104,7 +104,14 @@ func main() {
 
 	// Set terminal emulation based on platform as required.
 	_, stdout, stderr := term.StdStreams()
-	logrus.SetOutput(stderr)
+
+	// @jhowardmsft - maybe there is a historic reason why on non-Windows, stderr is used
+	// here. However, on Windows it makes no sense and there is no need.
+	if runtime.GOOS == "windows" {
+		logrus.SetOutput(stdout)
+	} else {
+		logrus.SetOutput(stderr)
+	}
 
 	cmd := newDaemonCommand()
 	cmd.SetOutput(stdout)

--- a/cmd/dockerd/service_windows.go
+++ b/cmd/dockerd/service_windows.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -408,6 +409,12 @@ func initPanicFile(path string) error {
 	if r == 0 && err != nil {
 		return err
 	}
+
+	// Reset os.Stderr to the panic file (so fmt.Fprintf(os.Stderr,...) actually gets redirected)
+	os.Stderr = os.NewFile(uintptr(panicFile.Fd()), "/dev/stderr")
+
+	// Force threads that panic to write to stderr (the panicFile handle now), otherwise it will go into the ether
+	log.SetOutput(os.Stderr)
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jstarks FYI.

There are three tiny fixes here:

When running as a Windows service, writes to stderr (eg `fmt.Fprintf(os.Stderr,...)` were being thrown away. This is because os.Stderr wasn't being reset to the panicfile FD.

Second, if a goroutine does panic when running as a service, as the built-in golangs handlers stderr handle wasn't being set to the panic file, it would also be thrown away.

Verified both the above by temporarily adding a null-pointer deference and a `fmt.FPrintf(os.stderr)`, and checking the contents of `panic.log` are populated in both cases.

Third - @thaJeztah @darrenstahlmsft  Fixes https://github.com/docker/docker/issues/31927. Without wanting to rat-hole over whether the same fix is right for non-Windows (can be addressed in a follow-up, no reason to delay this one), I've updated it so that on Windows at least, the daemon uses stdout for log messages rather than stderr, and done manual verification that it does the expected thing.

The first two fixes are critical for investigating some issues such as https://github.com/docker/docker/issues/30605#issuecomment-290556243 and it would be great to get this cherry-picked into a formal release ASAP so that @georgyturevich could continue to provide valuable debugging logs for issues on his production system with an official release, while still running as a Windows service and not resorting to the use of command-line file redirection.  @thaJeztah @vieux 


