### PR TITLE
fix documentation error: volume-opt in service create

### DIFF
--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -424,7 +424,7 @@ The following options can only be used for named volumes (`type=volume`);
       Options specific to a given volume driver, which will be passed to the
       driver when creating the volume. Options are provided as a comma-separated
       list of key/value pairs, for example,
-      <tt>volume-opt=some-option=some-value,some-other-option=some-other-value</tt>.
+      <tt>volume-opt=some-option=some-value,volume-opt=some-other-option=some-other-value</tt>.
       For available options for a given driver, refer to that driver's
       documentation.
     </td>


### PR DESCRIPTION
> docker service create --replicas 1 --mount type=volume,source=test2,target=/tmp,volume-driver=rexray,volume-nocopy=true,volume-opt=size=8,volume-opt=volume-type=defaultSP,volume-opt=size=24 --mount  type=volume,source=test4,target=/tmp1,volume-driver=rexray  --env MYVAR=foo daocloud.io/daocloud/dao-2048:latest

As the example above shows, correct opts for volume are like 'volume-opt=volume-type=defaultSP,volume-opt=size=24'.