### PR TITLE
Ensure health probe is stopped when a container exits

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -45,7 +45,7 @@ func (daemon *Daemon) StateChanged(id string, e libcontainerd.StateInfo) error {
 		c.StreamConfig.Wait()
 		c.Reset(false)
 
-		restart, wait, err := c.RestartManager().ShouldRestart(e.ExitCode, false, time.Since(c.StartedAt))
+		restart, wait, err := c.RestartManager().ShouldRestart(e.ExitCode, c.HasBeenManuallyStopped, time.Since(c.StartedAt))
 		if err == nil && restart {
 			c.RestartCount++
 			c.SetRestarting(platformConstructExitStatus(e))
@@ -54,7 +54,9 @@ func (daemon *Daemon) StateChanged(id string, e libcontainerd.StateInfo) error {
 			defer autoRemove()
 		}
 
-		daemon.updateHealthMonitor(c)
+		// cancel healthcheck here, they will be automatically
+		// restarted if/when the container is started again
+		daemon.stopHealthchecks(c)
 		attributes := map[string]string{
 			"exitCode": strconv.Itoa(int(e.ExitCode)),
 		}


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

-- 

**- What I did**

Fixes #30107 by preventing an health check to keep on running after a container has been removed

**- How I did it**

By **always** stopping health checks on container exits. Health checks are always started if present on container start (see [`daemon.StateChanged()`](https://github.com/docker/docker/blob/9518a71ceff0f1aa9abada5b51cbac40f8e8c80e/daemon/monitor.go#L114)), so there's no fear of missing any and it avoid unneeded exec while the container is still down.

**- How to verify it**

Given it's a race, it has to be manually testing unfortunately. Instructions provided by @esbite were used (https://gist.github.com/esbite/d0c639e72435b4721d44445b0972dff8)

**- Description for the changelog**

Ensure health probe is stopped when a container exits

**- A picture of a cute animal (not mandatory but encouraged)**

Not Today :scream_cat: 
