### PR TITLE
[PoC / DO NOT MERGE] Demo for Notary & Registry mirrors

### DIFF
--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -102,7 +102,7 @@ func PushTrustedReference(cli *command.DockerCli, repoInfo *registry.RepositoryI
 
 	fmt.Fprintln(cli.Out(), "Signing and pushing trust metadata")
 
-	repo, err := trust.GetNotaryRepository(cli, repoInfo, authConfig, "push", "pull")
+	repo, err := trust.GetMirroredNotaryRepository(cli, repoInfo, authConfig, "push", "pull")
 	if err != nil {
 		fmt.Fprintf(cli.Out(), "Error establishing connection to notary repository: %s\n", err)
 		return err
@@ -219,7 +219,7 @@ func imagePushPrivileged(ctx context.Context, cli *command.DockerCli, authConfig
 func trustedPull(ctx context.Context, cli *command.DockerCli, repoInfo *registry.RepositoryInfo, ref reference.Named, authConfig types.AuthConfig, requestPrivilege types.RequestPrivilegeFunc) error {
 	var refs []target
 
-	notaryRepo, err := trust.GetNotaryRepository(cli, repoInfo, authConfig, "pull")
+	notaryRepo, err := trust.GetMirroredNotaryRepository(cli, repoInfo, authConfig, "pull")
 	if err != nil {
 		fmt.Fprintf(cli.Out(), "Error establishing connection to trust repository: %s\n", err)
 		return err
@@ -334,7 +334,7 @@ func TrustedReference(ctx context.Context, cli *command.DockerCli, ref reference
 	// Resolve the Auth config relevant for this server
 	authConfig := command.ResolveAuthConfig(ctx, cli, repoInfo.Index)
 
-	notaryRepo, err := trust.GetNotaryRepository(cli, repoInfo, authConfig, "pull")
+	notaryRepo, err := trust.GetMirroredNotaryRepository(cli, repoInfo, authConfig, "pull")
 	if err != nil {
 		fmt.Fprintf(cli.Out(), "Error establishing connection to trust repository: %s\n", err)
 		return nil, err

--- a/cli/command/service/trust.go
+++ b/cli/command/service/trust.go
@@ -59,7 +59,7 @@ func trustedResolveDigest(ctx context.Context, cli *command.DockerCli, ref refer
 
 	authConfig := command.ResolveAuthConfig(ctx, cli, repoInfo.Index)
 
-	notaryRepo, err := trust.GetNotaryRepository(cli, repoInfo, authConfig, "pull")
+	notaryRepo, err := trust.GetMirroredNotaryRepository(cli, repoInfo, authConfig, "pull")
 	if err != nil {
 		return nil, errors.Wrap(err, "error establishing connection to trust repository")
 	}


### PR DESCRIPTION
Just requesting feedback at this point from the security perspective.
Before merging, I plan on making a change to distribution, so that
registries in proxy mode provide metadata about their upstream(perhaps a
/v2/mirrorinfo endpoint), so we might obtain this information automatically.

Example usage:
root@d92f17ec9f21:/go/src/github.com/docker/docker# DOCKER_CONTENT_TRUST=1 docker pull some-mirror.mydomain.com/library/ubuntu
DEBU[0144] Calling GET /_ping
Using default tag: latest
The repository some-mirror.mydomain.com/library/ubuntu claims to be a mirror of docker.io/library/ubuntu Do you trust docker.io/library/ubuntu to validate this data? [Y/n]Y

Using upstream docker.io/library/ubuntu to validate mirror data
Pull (1 of 1): some-mirror.mydomain.com/library/ubuntu:latest@sha256:dd7808d8792c9841d0b460122f1acf0a2dd1f56404f8d1e56298048885e45535

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
 Enabled docker-content-trust for proxy registries without running another notary. This works as long as the upstream has its own notary.

**- How I did it**
Modified GetNotaryRepository, so that we use the Notary server from the upstream if pulling from a registry that acts as a pr
**- How to verify it**
TODO: Given a general lg, I'll make the change to distribution, and add to the integration tests for docker/docker to demonstrate that the pull works. I've tested by bringing up another registry configured to mirror index.docker.io, and pulled ubuntu. I confirmed that it results in pulling the pinned manifest, as expected.
**- Description for the changelog**
<!--
Lookup notary instance of upstream when pulling from proxy registries, to enable docker-content-trust without creating new notary instances.
-->


**- A picture of a cute animal (not mandatory but encouraged)**

