### PR TITLE
Revert change to TestPushMisconfiguredTokenServiceResponseError

### DIFF
--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -606,15 +606,16 @@ func (s *DockerRegistryAuthTokenSuite) TestPushMisconfiguredTokenServiceResponse
 }
 
 func (s *DockerRegistryAuthTokenSuite) TestPushMisconfiguredTokenServiceResponseError(c *check.C) {
-	ts := getTestTokenService(http.StatusTooManyRequests, `{"errors": [{"code":"TOOMANYREQUESTS","message":"out of tokens"}]}`, 10)
+	ts := getTestTokenService(http.StatusTooManyRequests, `{"errors": [{"code":"TOOMANYREQUESTS","message":"out of tokens"}]}`, 3)
 	defer ts.Close()
 	s.setupRegistryWithTokenService(c, ts.URL)
 	repoName := fmt.Sprintf("%s/busybox", privateRegistryURL)
 	dockerCmd(c, "tag", "busybox", repoName)
 	out, _, err := dockerCmdWithError("push", repoName)
 	c.Assert(err, check.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Retrying")
-	c.Assert(out, checker.Not(checker.Contains), "Retrying in 15")
+	// TODO: isolate test so that it can be guaranteed that the 503 will trigger xfer retries
+	//c.Assert(out, checker.Contains, "Retrying")
+	//c.Assert(out, checker.Not(checker.Contains), "Retrying in 15")
 	split := strings.Split(out, "\n")
 	c.Assert(split[len(split)-2], check.Equals, "toomanyrequests: out of tokens")
 }


### PR DESCRIPTION
Allowing the retries to go up to 10 causes the test to always hit the check against ensuring the retry wait went up to 15 seconds. Additionally we have the max download attempts in the code set to 5. This change did not protect against using this test to expose a problem in the underlying code.

Do not merge this test yet, I want to run it a few times to see if I can expose the flakiness and figure out which error condition is getting hit. If you have an error log from the previous flakiness please post.



