### PR TITLE
Fix: when commit a container, should check if the container is in removing progress

### DIFF
--- a/container/state.go
+++ b/container/state.go
@@ -328,6 +328,13 @@ func (s *State) ResetRemovalInProgress() {
 	s.Unlock()
 }
 
+// IsRemovalInProgress returns whether the container is in removing progress
+func (s *State) IsRemovalInProgress() bool {
+	s.Lock()
+	defer s.Unlock()
+	return s.RemovalInProgress
+}
+
 // SetDead sets the container state to "dead"
 func (s *State) SetDead() {
 	s.Lock()

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -131,6 +131,10 @@ func (daemon *Daemon) Commit(name string, c *backend.ContainerCommitConfig) (str
 		return "", errors.Errorf("%+v does not support commit of a running container", runtime.GOOS)
 	}
 
+	if container.IsRemovalInProgress() {
+		return "", fmt.Errorf("can't commit a container in removal progress")
+	}
+
 	if c.Pause && !container.IsPaused() {
 		daemon.containerPause(container)
 		defer daemon.containerUnpause(container)


### PR DESCRIPTION


Signed-off-by: Wentao Zhang <zhangwentao234@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix a bug:
Reproduce:
```
root@localhost:~/temp/test# cat a.sh
#!/bin/bash
NEW=hello
IMG=ubuntu
docker run --name abc -d $IMG bash -c "echo babc >id; sleep 100"
docker rm -f abc  &
docker commit abc $NEW
```
When commit a container while the container is in removal progress, will fail to commit, and docker will report an error like this: 
`Handler for POST /v1.23/commit returned error: lstat /mnt /docker/devicemapper/mnt/a25dc9d183dbddcdf9abfec0f1e11a705ba26dcb9d5c5b804467687803bc68be/rootfs: no such file or directory"`

**- How I did it**

When commit the container, check if the container is in removal progress. if so, just returns.

**- How to verify it**

Using this script could verify it:
```
root@localhost:~/temp/test# cat a.sh
#!/bin/bash
NEW=hello
IMG=ubuntu
docker run --name abc -d $IMG bash -c "echo babc >id; sleep 100"
docker rm -f abc  &
docker commit abc $NEW
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix a bug which when commit a container, should check if the container is in removing progress

**- A picture of a cute animal (not mandatory but encouraged)**

