### PR TITLE
services: Add support for Credential Spec and SELinux

### DIFF
--- a/api/types/swarm/container.go
+++ b/api/types/swarm/container.go
@@ -21,6 +21,28 @@ type DNSConfig struct {
 	Options []string `json:",omitempty"`
 }
 
+// SELinuxContext contains the SELinux labels of the container.
+type SELinuxContext struct {
+	Disable bool
+
+	User  string
+	Role  string
+	Type  string
+	Level string
+}
+
+// CredentialSpec for managed service account (Windows only)
+type CredentialSpec struct {
+	File     string
+	Registry string
+}
+
+// Privileges defines the security options for the container.
+type Privileges struct {
+	CredentialSpec *CredentialSpec
+	SELinuxContext *SELinuxContext
+}
+
 // ContainerSpec represents the spec of a container.
 type ContainerSpec struct {
 	Image           string                  `json:",omitempty"`
@@ -32,6 +54,7 @@ type ContainerSpec struct {
 	Dir             string                  `json:",omitempty"`
 	User            string                  `json:",omitempty"`
 	Groups          []string                `json:",omitempty"`
+	Privileges      *Privileges             `json:",omitempty"`
 	StopSignal      string                  `json:",omitempty"`
 	TTY             bool                    `json:",omitempty"`
 	OpenStdin       bool                    `json:",omitempty"`

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -236,6 +236,38 @@ func (r *restartPolicyOptions) ToRestartPolicy() *swarm.RestartPolicy {
 	}
 }
 
+type credentialSpecOpt struct {
+	value  *swarm.CredentialSpec
+	source string
+}
+
+func (c *credentialSpecOpt) Set(value string) error {
+	c.source = value
+	c.value = &swarm.CredentialSpec{}
+	switch {
+	case strings.HasPrefix(value, "file://"):
+		c.value.File = strings.TrimPrefix(value, "file://")
+	case strings.HasPrefix(value, "registry://"):
+		c.value.Registry = strings.TrimPrefix(value, "registry://")
+	default:
+		return errors.New("Invalid credential spec - value must be prefixed file:// or registry:// followed by a value")
+	}
+
+	return nil
+}
+
+func (c *credentialSpecOpt) Type() string {
+	return "credential-spec"
+}
+
+func (c *credentialSpecOpt) String() string {
+	return c.source
+}
+
+func (c *credentialSpecOpt) Value() *swarm.CredentialSpec {
+	return c.value
+}
+
 func convertNetworks(networks []string) []swarm.NetworkAttachmentConfig {
 	nets := []swarm.NetworkAttachmentConfig{}
 	for _, network := range networks {
@@ -353,6 +385,7 @@ type serviceOptions struct {
 	workdir         string
 	user            string
 	groups          opts.ListOpts
+	credentialSpec  credentialSpecOpt
 	stopSignal      string
 	tty             bool
 	readOnly        bool
@@ -498,6 +531,12 @@ func (opts *serviceOptions) ToService() (swarm.ServiceSpec, error) {
 		EndpointSpec:   opts.endpoint.ToEndpointSpec(),
 	}
 
+	if opts.credentialSpec.Value() != nil {
+		service.TaskTemplate.ContainerSpec.Privileges = &swarm.Privileges{
+			CredentialSpec: opts.credentialSpec.Value(),
+		}
+	}
+
 	return service, nil
 }
 
@@ -509,6 +548,8 @@ func addServiceFlags(flags *pflag.FlagSet, opts *serviceOptions) {
 
 	flags.StringVarP(&opts.workdir, flagWorkdir, "w", "", "Working directory inside the container")
 	flags.StringVarP(&opts.user, flagUser, "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
+	flags.Var(&opts.credentialSpec, flagCredentialSpec, "Credential spec for managed service account (Windows only)")
+	flags.SetAnnotation(flagCredentialSpec, "version", []string{"1.29"})
 	flags.StringVar(&opts.hostname, flagHostname, "", "Container hostname")
 	flags.SetAnnotation(flagHostname, "version", []string{"1.25"})
 	flags.Var(&opts.entrypoint, flagEntrypoint, "Overwrite the default ENTRYPOINT of the image")
@@ -576,6 +617,7 @@ func addServiceFlags(flags *pflag.FlagSet, opts *serviceOptions) {
 }
 
 const (
+	flagCredentialSpec          = "credential-spec"
 	flagPlacementPref           = "placement-pref"
 	flagPlacementPrefAdd        = "placement-pref-add"
 	flagPlacementPrefRemove     = "placement-pref-rm"


### PR DESCRIPTION
- Defined "normalized" type for Credential Spec and SELinux
- Added --credential-spec to docker service create & update
- SELinux is API only at the time

This is work in progress and vendors in docker/swarmkit#2075

/cc @ehazlett @johnstep @aaronlehmann @dhiltgen @diogomonica @vieux @friism 