### PR TITLE
do not show errors on make install

### DIFF
--- a/hack/make/.detect-daemon-osarch
+++ b/hack/make/.detect-daemon-osarch
@@ -2,6 +2,10 @@
 set -e
 
 docker-version-osarch() {
+	if ! type docker &>/dev/null; then
+		# docker is not installed
+		return
+	fi
 	local target="$1" # "Client" or "Server"
 	local fmtStr="{{.${target}.Os}}/{{.${target}.Arch}}"
 	if docker version -f "$fmtStr" 2>/dev/null; then


### PR DESCRIPTION
When running "make install" in a build container, docker is not installed the first time it's run, causing these errors to appear;

    $ make install
    hack/make/.detect-daemon-osarch: line 11: docker: command not found
    hack/make/.detect-daemon-osarch: line 11: docker: command not found
    hack/make/.detect-daemon-osarch: line 11: docker: command not found
    hack/make/.detect-daemon-osarch: line 11: docker: command not found
    KEEPBUNDLE=1 hack/make.sh install-binary

This patch checks if docker exists, and if not just continues silently :)

ping @cpuguy83 @tianon PTAL 😇 
