### PR TITLE
cli: Preserve order of environment variables

### DIFF
--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -524,20 +524,21 @@ func updateLabels(flags *pflag.FlagSet, field *map[string]string) {
 }
 
 func updateEnvironment(flags *pflag.FlagSet, field *[]string) {
-	envSet := map[string]string{}
-	for _, v := range *field {
-		envSet[envKey(v)] = v
-	}
 	if flags.Changed(flagEnvAdd) {
+		envSet := map[string]string{}
+		for _, v := range *field {
+			envSet[envKey(v)] = v
+		}
+
 		value := flags.Lookup(flagEnvAdd).Value.(*opts.ListOpts)
 		for _, v := range value.GetAll() {
 			envSet[envKey(v)] = v
 		}
-	}
 
-	*field = []string{}
-	for _, v := range envSet {
-		*field = append(*field, v)
+		*field = []string{}
+		for _, v := range envSet {
+			*field = append(*field, v)
+		}
 	}
 
 	toRemove := buildToRemoveSet(flags, flagEnvRemove)


### PR DESCRIPTION
Unless we are adding or removing environment variables, their order
shouldn't be changed. This makes it look like the service's TaskSpec has
changed relative to the old version of the service, and containers need
to be redeployed.

The existing code always rebuilds the list of environment variables by
converting them to a map and back, but there's no reason to do this if
no environment variables are being added.

Fixes #32344