### PR TITLE
Stop container when error occured.

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2790,6 +2790,10 @@ func (s *DockerDaemonSuite) TestExecWithUserAfterLiveRestore(c *check.C) {
 
 	out, err := s.d.Cmd("run", "-d", "--name=top", "busybox", "sh", "-c", "addgroup -S test && adduser -S -G test test -D -s /bin/sh && top")
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
+	defer func() {
+		out, err = s.d.Cmd("stop", "top")
+		c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
+	}()
 
 	s.d.WaitRun("top")
 
@@ -2803,9 +2807,6 @@ func (s *DockerDaemonSuite) TestExecWithUserAfterLiveRestore(c *check.C) {
 	out2, err := s.d.Cmd("exec", "-u", "test", "top", "id")
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out2))
 	c.Assert(out1, check.Equals, out2, check.Commentf("Output: before restart '%s', after restart '%s'", out1, out2))
-
-	out, err = s.d.Cmd("stop", "top")
-	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
 }
 
 func (s *DockerDaemonSuite) TestRemoveContainerAfterLiveRestore(c *check.C) {


### PR DESCRIPTION
We should stop container even if test case execute failed, or
CI's stuck when exit.

Signed-off-by: Fengtu Wang <wangfengtu@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Ensure container is stopped even if test case TestExecWithUserAfterLiveRestore failed.

**- How I did it**
Use 'defer' to stop the container if it started, so it can be stopped even if test failed.

**- How to verify it**
I add some code to let it fail definitely:

```
diff --git a/integration-cli/docker_cli_daemon_test.go b/integration-cli/docker_cli_daemon_test.go
index 53bc45e..a9425ce 100644
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2802,6 +2802,7 @@ func (s *DockerDaemonSuite) TestExecWithUserAfterLiveRestore(c *check.C) {
 
        out2, err := s.d.Cmd("exec", "-u", "test", "top", "id")
        c.Assert(err, check.IsNil, check.Commentf("Output: %s", out2))
+       out1 = ""
        c.Assert(out1, check.Equals, out2, check.Commentf("Output: before restart '%s', after restart '%s'", out1, out2))
 
        out, err = s.d.Cmd("stop", "top")
```
Then i execute shell command in terminal:
```
TESTFLAGS='-check.f TestExecWithUserAfterLiveRestore' make test-integration-cli
```
Before the change, shell can't exit after test.
After the change, shell can exit normally.

By the way, this PR is same as #32035. It was closed as 'not bug' and i delete the branch. 
But after i test it again, i found it's a bug, so i post it again. I think we should stop
container in code if it's started with parameter '--live-restore'. Sorry for the noise if i made a mistake.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

