### PR TITLE
docker/registry: Make CertsDir configurable.

### DIFF
--- a/registry/config_unix.go
+++ b/registry/config_unix.go
@@ -3,22 +3,12 @@
 package registry
 
 import (
-	"os"
-
 	"github.com/spf13/pflag"
 )
 
-func initCertsDir() string {
-	dir := os.Getenv("DOCKER_REGISTRY_CERTS_DIR")
-	if len(dir) == 0 {
-		dir = "/etc/docker/certs.d"
-	}
-	return dir
-}
-
 var (
 	// CertsDir is the directory where certificates are stored
-	CertsDir = initCertsDir()
+	CertsDir = "/etc/docker/certs.d"
 )
 
 // cleanPath is used to ensure that a directory name is valid on the target
@@ -32,4 +22,5 @@ func cleanPath(s string) string {
 // installCliPlatformFlags handles any platform specific flags for the service.
 func (options *ServiceOptions) installCliPlatformFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&options.V2Only, "disable-legacy-registry", false, "Disable contacting legacy registries")
+	flags.StringVar(&CertsDir, "registry-certificate-dir", CertsDir, "The directory where registry certificates are stored")
 }

--- a/registry/config_unix.go
+++ b/registry/config_unix.go
@@ -3,12 +3,22 @@
 package registry
 
 import (
+	"os"
+
 	"github.com/spf13/pflag"
 )
 
+func initCertsDir() string {
+	dir := os.Getenv("DOCKER_REGISTRY_CERTS_DIR")
+	if len(dir) == 0 {
+		dir = "/etc/docker/certs.d"
+	}
+	return dir
+}
+
 var (
 	// CertsDir is the directory where certificates are stored
-	CertsDir = "/etc/docker/certs.d"
+	CertsDir = initCertsDir()
 )
 
 // cleanPath is used to ensure that a directory name is valid on the target


### PR DESCRIPTION
On linux hosts, it would be helpful if certificates for
accessing a remote registry could be configured at runtime
for specific setups. One example are snaps and third-parties
who want to work with their own registries.

