### PR TITLE
[WIP] Moving docker service digest pinning to client side

### DIFF
--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -80,10 +80,6 @@ func runCreate(dockerCli *command.DockerCli, opts *serviceOptions) error {
 
 	ctx := context.Background()
 
-	if err := resolveServiceImageDigest(dockerCli, &service); err != nil {
-		return err
-	}
-
 	// only send auth if flag was set
 	if opts.registryAuth {
 		// Retrieve encoded auth token from the image reference
@@ -92,6 +88,10 @@ func runCreate(dockerCli *command.DockerCli, opts *serviceOptions) error {
 			return err
 		}
 		createOpts.EncodedRegistryAuth = encodedAuth
+	}
+
+	if err := resolveServiceImageDigest(dockerCli, &service, createOpts.EncodedRegistryAuth); err != nil {
+		return err
 	}
 
 	response, err := apiClient.ServiceCreate(ctx, service, createOpts)

--- a/cli/command/service/manifest.go
+++ b/cli/command/service/manifest.go
@@ -1,0 +1,54 @@
+package service
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/cli/command"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+)
+
+func resolveServiceImageDigest(dockerCli *command.DockerCli, service *swarm.ServiceSpec, encodedRegistryAuth string) error {
+	if !command.IsTrusted() {
+		// Contact registry to get manifest
+		apiClient := dockerCli.Client()
+		manifestInspect, err := apiClient.ImageManifest(context.Background(), service.TaskTemplate.ContainerSpec.Image, encodedRegistryAuth)
+		if err != nil {
+			return err
+		}
+
+		service.TaskTemplate.ContainerSpec.Image = string(manifestInspect.Digest)
+		// TODO(nishanttotla): Refactoring to update platform information
+
+		return nil
+	}
+
+	ref, err := reference.ParseAnyReference(service.TaskTemplate.ContainerSpec.Image)
+	if err != nil {
+		return errors.Wrapf(err, "invalid reference %s", service.TaskTemplate.ContainerSpec.Image)
+	}
+
+	// If reference does not have digest (is not canonical nor image id)
+	if _, ok := ref.(reference.Digested); !ok {
+		namedRef, ok := ref.(reference.Named)
+		if !ok {
+			return errors.New("failed to resolve image digest using content trust: reference is not named")
+		}
+		namedRef = reference.TagNameOnly(namedRef)
+		taggedRef, ok := namedRef.(reference.NamedTagged)
+		if !ok {
+			return errors.New("failed to resolve image digest using content trust: reference is not tagged")
+		}
+
+		resolvedImage, err := trustedResolveDigest(context.Background(), dockerCli, taggedRef)
+		if err != nil {
+			return errors.Wrap(err, "failed to resolve image digest using content trust")
+		}
+		resolvedFamiliar := reference.FamiliarString(resolvedImage)
+		logrus.Debugf("resolved image tag to %s using content trust", resolvedFamiliar)
+		service.TaskTemplate.ContainerSpec.Image = resolvedFamiliar
+	}
+
+	return nil
+}

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -152,12 +152,6 @@ func runUpdate(dockerCli *command.DockerCli, flags *pflag.FlagSet, serviceID str
 		return err
 	}
 
-	if flags.Changed("image") {
-		if err := resolveServiceImageDigest(dockerCli, spec); err != nil {
-			return err
-		}
-	}
-
 	updatedSecrets, err := getUpdatedSecrets(apiClient, flags, spec.TaskTemplate.ContainerSpec.Secrets)
 	if err != nil {
 		return err
@@ -183,6 +177,13 @@ func runUpdate(dockerCli *command.DockerCli, flags *pflag.FlagSet, serviceID str
 		updateOpts.RegistryAuthFrom = types.RegistryAuthFromPreviousSpec
 	} else {
 		updateOpts.RegistryAuthFrom = types.RegistryAuthFromSpec
+	}
+
+	// TODO(nishanttotla): Figure out correct registry auth to pass here
+	if flags.Changed("image") {
+		if err := resolveServiceImageDigest(dockerCli, spec, updateOpts.EncodedRegistryAuth); err != nil {
+			return err
+		}
 	}
 
 	response, err := apiClient.ServiceUpdate(ctx, service.ID, service.Version, *spec, updateOpts)

--- a/client/image_manifest.go
+++ b/client/image_manifest.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+
+	registrytypes "github.com/docker/docker/api/types/registry"
+	"golang.org/x/net/context"
+)
+
+// ImageManifest returns .
+func (cli *Client) ImageManifest(ctx context.Context, image, encodedRegistryAuth string) (registrytypes.ManifestInspect, error) {
+	var headers map[string][]string
+
+	if encodedRegistryAuth != "" {
+		headers = map[string][]string{
+			"X-Registry-Auth": {encodedRegistryAuth},
+		}
+	}
+
+	// Call the /manifest endpoint to retrieve manifest information
+	var manifestInspect registrytypes.ManifestInspect
+	resp, err := cli.get(ctx, "/images/"+image+"/manifest", url.Values{}, headers)
+	if err != nil {
+		return manifestInspect, err
+	}
+
+	err = json.NewDecoder(resp.body).Decode(&manifestInspect)
+	ensureReaderClosed(resp)
+	return manifestInspect, err
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Digest pinning was introduced for Docker services in #28173, and it was performed on the daemon. After #32061, I moved digest pinning to the client, simplifying it.

**- How I did it**
The client makes a call to `/images/image_name/manifest` to retrieve manifest information, which contains the image digest.

**- How to verify it**
`docker service create --name test alpine sleep 1000` then `docker service inspect test` should contain an image with the digest.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Docker service image pin by digest moved to client side.

**- WIP**
- [ ] Disable daemon side digest pinning for new API versions
- [ ] Return warning when pinning fails
- [ ] Merge #32061

**- A picture of a cute animal (not mandatory but encouraged)**
![goshi](https://cloud.githubusercontent.com/assets/1872537/24725003/22d41800-1a02-11e7-8d73-b81a4af06214.jpg)

This is Gosha, the friendliest cat in Berkeley.

cc @aaronlehmann @aluzzardi @vieux @tonistiigi 