### PR TITLE
Moving docker service digest pinning to client side

### DIFF
--- a/api/server/router/swarm/backend.go
+++ b/api/server/router/swarm/backend.go
@@ -19,8 +19,8 @@ type Backend interface {
 
 	GetServices(basictypes.ServiceListOptions) ([]types.Service, error)
 	GetService(idOrName string, insertDefaults bool) (types.Service, error)
-	CreateService(types.ServiceSpec, string) (*basictypes.ServiceCreateResponse, error)
-	UpdateService(string, uint64, types.ServiceSpec, basictypes.ServiceUpdateOptions) (*basictypes.ServiceUpdateResponse, error)
+	CreateService(types.ServiceSpec, string, bool) (*basictypes.ServiceCreateResponse, error)
+	UpdateService(string, uint64, types.ServiceSpec, basictypes.ServiceUpdateOptions, bool) (*basictypes.ServiceUpdateResponse, error)
 	RemoveService(string) error
 
 	ServiceLogs(context.Context, *backend.LogSelector, *basictypes.ContainerLogsOptions) (<-chan *backend.LogMessage, error)

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -276,6 +276,12 @@ type ServiceCreateOptions struct {
 	//
 	// This field follows the format of the X-Registry-Auth header.
 	EncodedRegistryAuth string
+
+	// QueryRegistry indicates whether the service update requires
+	// contacting a registry. A registry may be contacted to retrieve
+	// the image digest and manifest, which in turn can be used to update
+	// platform or other information about the service.
+	QueryRegistry bool
 }
 
 // ServiceCreateResponse contains the information returned to a client
@@ -315,6 +321,12 @@ type ServiceUpdateOptions struct {
 	// The valid values are "previous" and "none". An empty value is the
 	// same as "none".
 	Rollback string
+
+	// QueryRegistry indicates whether the service update requires
+	// contacting a registry. A registry may be contacted to retrieve
+	// the image digest and manifest, which in turn can be used to update
+	// platform or other information about the service.
+	QueryRegistry bool
 }
 
 // ServiceListOptions holds parameters to list services with.

--- a/client/distribution_inspect.go
+++ b/client/distribution_inspect.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+
+	registrytypes "github.com/docker/docker/api/types/registry"
+	"golang.org/x/net/context"
+)
+
+// DistributionInspect returns the image digest with full Manifest
+func (cli *Client) DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registrytypes.DistributionInspect, error) {
+	var headers map[string][]string
+
+	if encodedRegistryAuth != "" {
+		headers = map[string][]string{
+			"X-Registry-Auth": {encodedRegistryAuth},
+		}
+	}
+
+	// Contact the registry to retrieve digest and platform information
+	var distributionInspect registrytypes.DistributionInspect
+	resp, err := cli.get(ctx, "/distribution/"+image+"/json", url.Values{}, headers)
+	if err != nil {
+		return distributionInspect, err
+	}
+
+	err = json.NewDecoder(resp.body).Decode(&distributionInspect)
+	ensureReaderClosed(resp)
+	return distributionInspect, err
+}

--- a/client/interface.go
+++ b/client/interface.go
@@ -20,6 +20,7 @@ import (
 type CommonAPIClient interface {
 	ConfigAPIClient
 	ContainerAPIClient
+	DistributionAPIClient
 	ImageAPIClient
 	NodeAPIClient
 	NetworkAPIClient
@@ -67,6 +68,11 @@ type ContainerAPIClient interface {
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
 	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (types.ContainersPruneReport, error)
+}
+
+// DistributionAPIClient defines API client methods for the registry
+type DistributionAPIClient interface {
+	DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registry.DistributionInspect, error)
 }
 
 // ImageAPIClient defines API client methods for the images

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -13,15 +13,14 @@ import (
 
 // ServiceCreate creates a new Service.
 func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options types.ServiceCreateOptions) (types.ServiceCreateResponse, error) {
-	var (
-		headers map[string][]string
-		distErr error
-	)
+	var distErr error
+
+	headers := map[string][]string{
+		"version": {cli.version},
+	}
 
 	if options.EncodedRegistryAuth != "" {
-		headers = map[string][]string{
-			"X-Registry-Auth": {options.EncodedRegistryAuth},
-		}
+		headers["X-Registry-Auth"] = []string{options.EncodedRegistryAuth}
 	}
 
 	// Contact the registry to retrieve digest and platform information

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -2,15 +2,21 @@ package client
 
 import (
 	"encoding/json"
+	"fmt"
 
+	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/opencontainers/go-digest"
 	"golang.org/x/net/context"
 )
 
 // ServiceCreate creates a new Service.
 func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options types.ServiceCreateOptions) (types.ServiceCreateResponse, error) {
-	var headers map[string][]string
+	var (
+		headers map[string][]string
+		distErr error
+	)
 
 	if options.EncodedRegistryAuth != "" {
 		headers = map[string][]string{
@@ -18,6 +24,18 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 		}
 	}
 
+	// Contact the registry to retrieve digest and platform information
+	if options.QueryRegistry {
+		distributionInspect, err := cli.DistributionInspect(ctx, service.TaskTemplate.ContainerSpec.Image, options.EncodedRegistryAuth)
+		distErr = err
+		if err == nil {
+			// now pin by digest if the image doesn't already contain a digest
+			img := imageWithDigestString(service.TaskTemplate.ContainerSpec.Image, distributionInspect.Descriptor.Digest)
+			if img != "" {
+				service.TaskTemplate.ContainerSpec.Image = img
+			}
+		}
+	}
 	var response types.ServiceCreateResponse
 	resp, err := cli.post(ctx, "/services/create", nil, service, headers)
 	if err != nil {
@@ -25,6 +43,38 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 	}
 
 	err = json.NewDecoder(resp.body).Decode(&response)
+
+	if distErr != nil {
+		response.Warnings = append(response.Warnings, digestWarning(service.TaskTemplate.ContainerSpec.Image))
+	}
+
 	ensureReaderClosed(resp)
 	return response, err
+}
+
+// imageWithDigestString takes an image string and a digest, and updates
+// the image string if it didn't originally contain a digest. It assumes
+// that the image string is not an image ID
+func imageWithDigestString(image string, dgst digest.Digest) string {
+	isCanonical := false
+	ref, err := reference.ParseAnyReference(image)
+	if err == nil {
+		_, isCanonical = ref.(reference.Canonical)
+
+		if !isCanonical {
+			namedRef, _ := ref.(reference.Named)
+			img, err := reference.WithDigest(namedRef, dgst)
+			if err == nil {
+				return img.String()
+			}
+		}
+	}
+	return ""
+}
+
+// digestWarning constructs a formatted warning string using the
+// image name that could not be pinned by digest. The formatting
+// is hardcoded, but could me made smarter in the future
+func digestWarning(image string) string {
+	return fmt.Sprintf("image %s could not be accessed on a registry to record\nits digest. Each node will access %s independently,\npossibly leading to different nodes running different\nversions of the image.\n", image, image)
 }

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -13,15 +13,16 @@ import (
 // ServiceUpdate updates a Service.
 func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (types.ServiceUpdateResponse, error) {
 	var (
-		headers map[string][]string
 		query   = url.Values{}
 		distErr error
 	)
 
+	headers := map[string][]string{
+		"version": {cli.version},
+	}
+
 	if options.EncodedRegistryAuth != "" {
-		headers = map[string][]string{
-			"X-Registry-Auth": {options.EncodedRegistryAuth},
-		}
+		headers["X-Registry-Auth"] = []string{options.EncodedRegistryAuth}
 	}
 
 	if options.RegistryAuthFrom != "" {

--- a/client/utils.go
+++ b/client/utils.go
@@ -1,9 +1,10 @@
 package client
 
 import (
-	"github.com/docker/docker/api/types/filters"
 	"net/url"
 	"regexp"
+
+	"github.com/docker/docker/api/types/filters"
 )
 
 var headerRegexp = regexp.MustCompile(`\ADocker/.+\s\((.+)\)\z`)

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -117,7 +117,7 @@ func (c *Cluster) GetService(input string, insertDefaults bool) (types.Service, 
 }
 
 // CreateService creates a new service in a managed swarm cluster.
-func (c *Cluster) CreateService(s types.ServiceSpec, encodedAuth string) (*apitypes.ServiceCreateResponse, error) {
+func (c *Cluster) CreateService(s types.ServiceSpec, encodedAuth string, queryRegistry bool) (*apitypes.ServiceCreateResponse, error) {
 	var resp *apitypes.ServiceCreateResponse
 	err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
 		err := c.populateNetworkID(ctx, state.controlClient, &s)
@@ -151,8 +151,11 @@ func (c *Cluster) CreateService(s types.ServiceSpec, encodedAuth string) (*apity
 				}
 			}
 
-			// pin image by digest
-			if os.Getenv("DOCKER_SERVICE_PREFER_OFFLINE_IMAGE") != "1" {
+			// pin image by digest for API versions < 1.30
+			// TODO(nishanttotla): The check on "DOCKER_SERVICE_PREFER_OFFLINE_IMAGE"
+			// should be removed in the future. Since integration tests only use the
+			// latest API version, so this is no longer required.
+			if os.Getenv("DOCKER_SERVICE_PREFER_OFFLINE_IMAGE") != "1" && queryRegistry {
 				digestImage, err := c.imageWithDigestString(ctx, ctnr.Image, authConfig)
 				if err != nil {
 					logrus.Warnf("unable to pin image %s to digest: %s", ctnr.Image, err.Error())
@@ -193,7 +196,7 @@ func (c *Cluster) CreateService(s types.ServiceSpec, encodedAuth string) (*apity
 }
 
 // UpdateService updates existing service to match new properties.
-func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec types.ServiceSpec, flags apitypes.ServiceUpdateOptions) (*apitypes.ServiceUpdateResponse, error) {
+func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec types.ServiceSpec, flags apitypes.ServiceUpdateOptions, queryRegistry bool) (*apitypes.ServiceUpdateResponse, error) {
 	var resp *apitypes.ServiceUpdateResponse
 
 	err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
@@ -256,8 +259,11 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec typ
 
 		resp = &apitypes.ServiceUpdateResponse{}
 
-		// pin image by digest
-		if os.Getenv("DOCKER_SERVICE_PREFER_OFFLINE_IMAGE") != "1" {
+		// pin image by digest for API versions < 1.30
+		// TODO(nishanttotla): The check on "DOCKER_SERVICE_PREFER_OFFLINE_IMAGE"
+		// should be removed in the future. Since integration tests only use the
+		// latest API version, so this is no longer required.
+		if os.Getenv("DOCKER_SERVICE_PREFER_OFFLINE_IMAGE") != "1" && queryRegistry {
 			digestImage, err := c.imageWithDigestString(ctx, newCtnr.Image, authConfig)
 			if err != nil {
 				logrus.Warnf("unable to pin image %s to digest: %s", newCtnr.Image, err.Error())


### PR DESCRIPTION
This PR is an alternative proposal to #32384, based on discussions with @aluzzardi @dhiltgen @alexmavr. 

The _heavy lifting_ in this case happens in the `client` package, which is easier to use for third-party clients, and they get the benefit of client-side digest pinning without having to do it themselves.

cc @aaronlehmann 

**- What I did**
Digest pinning was introduced for Docker services in #28173, and it was performed on the daemon. After #32061, I moved digest pinning to the client, simplifying it.

**- How I did it**
The client makes a call to `/images/image_name/manifest` to retrieve manifest information, which contains the image digest.

**- How to verify it**
`docker service create --name test alpine sleep 1000` then `docker service inspect test` should contain an image with the digest.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Docker service image pin by digest moved to client side.

**- WIP**
- [x] Merge #32061
- [x] Return warning when pinning fails
- [x] Disable daemon side digest pinning for new API versions (unclear if this is necessary)

**- A picture of a cute animal (not mandatory but encouraged)**
![goshi](https://cloud.githubusercontent.com/assets/1872537/24725003/22d41800-1a02-11e7-8d73-b81a4af06214.jpg)

This is Gosha, the friendliest cat in Berkeley.