### PR TITLE
api: Don't include stack traces with errors

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -139,11 +139,9 @@ func (s *Server) makeHTTPHandler(handler httputils.APIFunc) http.HandlerFunc {
 
 		if err := handlerFunc(ctx, w, r, vars); err != nil {
 			statusCode := httputils.GetHTTPErrorStatusCode(err)
-			errFormat := "%v"
-			if statusCode == http.StatusInternalServerError {
-				errFormat = "%+v"
+			if statusCode >= 500 {
+				logrus.Errorf("Handler for %s %s returned error: %v", r.Method, r.URL.Path, err)
 			}
-			logrus.Errorf("Handler for %s %s returned error: "+errFormat, r.Method, r.URL.Path, err)
 			httputils.MakeErrorHandler(err)(w, r)
 		}
 	}


### PR DESCRIPTION
I know we agreed in #30615 on a compromise to only show stack traces on 500 errors, but... it's not working out.

Everything produced with `errors.New` from `github.com/pkg/errors` that bubbles up to the API will result in a stack trace. Have a look at https://github.com/docker/docker/blob/master/daemon/cluster/swarm.go. Everything from bad input parameters to trying to unlock a swarm that's not locked to supplying the wrong unlock key to removing a manager without demoting it will dump an illegible stack trace in the log.

This is what the output looks like:

```
Apr  5 17:25:06 ip-172-31-112-181 dockerd[31430]: time="2017-04-05T17:25:06.994419730Z" level=error msg="Handler for POST /v1.28/swarm/leave returned error: You are attempting to leave the swarm on a node that is participating as a manager. The only way to restore a swarm that has lost consensus is to reinitialize it with `--force-new-cluster`. Use `--force` to suppress this message.\ngithub.com/docker/docker/daemon/cluster.(*Cluster).Leave\n\t/usr/src/docker/.gopath/src/github.com/docker/docker/daemon/cluster/swarm.go:354\ngithub.com/docker/docker/api/server/router/swarm.(*swarmRouter).leaveCluster\n\t/usr/src/docker/.gopath/src/github.com/docker/docker/api/server/router/swarm/cluster_routes.go:47\ngithub.com/docker/docker/api/server/router/swarm.(*swarmRouter).(github.com/docker/docker/api/server/router/swarm.leaveCluster)-fm\n\t/usr/src/docker/.gopath/src/github.com/docker/docker/api/server/router/swarm/cluster.go:29\ngithub.com/docker/docker/api/server/middleware.ExperimentalMiddleware.WrapHandler.func1\n\t/usr/src/docker/.gopath/src/github.com/docker/docker/api/server/middleware/experimental.go:27\ngithub.com/docker/docker/api/server/middleware.VersionMiddleware.WrapHandler.func1\n\t/usr/src/docker/.gopath/src/github.com/docker/docker/api/server/middleware/version.go:48\ngithub.com/docker/docker/pkg/authorization.(*Middleware).WrapHandler.func1\n\t/usr/src/docker/.gopath/src/github.com/docker/docker/pkg/authorization/middleware.go:43\ngithub.com/docker/docker/api/server.(*Server).makeHTTPHandler.func1\n\t/usr/src/docker/.gopath/src/github.com/docker/docker/api/server/server.go:140\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:1726\ngithub.com/docker/docker/vendor/github.com/gorilla/mux.(*Router).ServeHTTP\n\t/usr/src/docker/.gopath/src/github.com/docker/docker/vendor/github.com/gorilla/mux/mux.go:103\ngithub.com/docker/docker/api/server.(*routerSwapper).ServeHTTP\n\t/usr/src/docker/.gopath/src/github.com/docker/docker/api/server/router_swapper.go:29\nnet/http.serverHandler.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2202\nnet
Apr  5 17:25:06 ip-172-31-112-181 dockerd[31430]: /http.(*conn).serve\n\t/usr/local/go/src/net/http/server.go:1579\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:2086"
```

I feel strongly that logs are not the right place to put stack traces. They either appear on a single line, so are completely illegible, or they break the line-delimited format of the log. Either way, they scare users and make it look like something is broken. If we must capture stack traces, we should save them to individual files, like we do with the SIGUSR1 dump.

Ideally we would convert the swarm errors to typed errors, as described in #32144, so they wouldn't be affected by this. But we're not there yet. In the mean time, I think the best thing to do is never output stack traces in logs.

cc @tiborvass @anusha-ragunathan @cpuguy83