### PR TITLE
Revendor github.com/Nvveen/Gotty for github.com/Nvveen/Gotty#2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -131,7 +131,7 @@ github.com/spf13/cobra v1.5.1 https://github.com/dnephin/cobra.git
 github.com/spf13/pflag 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 github.com/flynn-archive/go-shlex 3f9db97f856818214da2e1057f8ad84803971cff
-github.com/Nvveen/Gotty 6018b68f96b839edfbe3fb48668853f5dbad88a3 https://github.com/ijc25/Gotty
+github.com/Nvveen/Gotty a8b993ba6abdb0e0c12b0125c603323a71c7790c https://github.com/ijc25/Gotty
 
 # metrics
 github.com/docker/go-metrics 86138d05f285fd9737a99bee2d9be30866b59d72

--- a/vendor/github.com/Nvveen/Gotty/gotty.go
+++ b/vendor/github.com/Nvveen/Gotty/gotty.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"reflect"
 	"strings"
 	"sync"
@@ -22,33 +23,30 @@ import (
 // If something went wrong reading the terminfo database file, an error is
 // returned.
 func OpenTermInfo(termName string) (*TermInfo, error) {
-	var term *TermInfo
-	var err error
+	if len(termName) == 0 {
+		return nil, errors.New("No termname given")
+	}
 	// Find the environment variables
-	termloc := os.Getenv("TERMINFO")
-	if len(termloc) == 0 {
+	if termloc := os.Getenv("TERMINFO"); len(termloc) > 0 {
+		return readTermInfo(path.Join(termloc, string(termName[0]), termName))
+	} else {
 		// Search like ncurses
-		locations := []string{os.Getenv("HOME") + "/.terminfo/", "/etc/terminfo/",
-			"/lib/terminfo/", "/usr/share/terminfo/"}
-		var path string
+		locations := []string{}
+		if h := os.Getenv("HOME"); len(h) > 0 {
+			locations = append(locations, path.Join(h, ".terminfo"))
+		}
+		locations = append(locations,
+			"/etc/terminfo/",
+			"/lib/terminfo/",
+			"/usr/share/terminfo/")
 		for _, str := range locations {
-			// Construct path
-			path = str + string(termName[0]) + "/" + termName
-			// Check if path can be opened
-			file, _ := os.Open(path)
-			if file != nil {
-				// Path can open, fall out and use current path
-				file.Close()
-				break
+			term, err := readTermInfo(path.Join(str, string(termName[0]), termName))
+			if err == nil {
+				return term, nil
 			}
 		}
-		if len(path) > 0 {
-			term, err = readTermInfo(path)
-		} else {
-			err = errors.New(fmt.Sprintf("No terminfo file(-location) found"))
-		}
+		return nil, errors.New("No terminfo file(-location) found")
 	}
-	return term, err
 }
 
 // Open a terminfo file from the environment variable containing the current


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Revendored https://github.com/Nvveen/Gotty in order to pickup the fixes in https://github.com/Nvveen/Gotty/pull/2 which fixes 32400, a panic when `TERMINFO` is set during `docker pull`.

**- How I did it**

The handling for this case was just missing, so I added it and cleaned up a few things at the same time.

I merged the new PR into my master branch which now contains https://github.com/Nvveen/Gotty/pull/1 and https://github.com/Nvveen/Gotty/pull/2.

**- How to verify it**

Previously only the first of these examples would work, the others all panic. Now they all work.

```
$ docker rmi alpine:3.3 >/dev/null ; TERM=xterm-16color strace -f -o pull.str -e openat ./bundles/latest/binary-client/docker pull alpine:3.3 && grep xterm-16color pull.str
3.3: Pulling from library/alpine
53ebc9bfbcc0: Pull complete 
Digest: sha256:8d366db868cba704e3f86823106390201887de958b19f01e2daa4f178fe604e3
Status: Downloaded newer image for alpine:3.3
6448  openat(AT_FDCWD, "/home/ijc/.terminfo/x/xterm-16color", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
6448  openat(AT_FDCWD, "/etc/terminfo/x/xterm-16color", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
6448  openat(AT_FDCWD, "/lib/terminfo/x/xterm-16color", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
6448  openat(AT_FDCWD, "/usr/share/terminfo/x/xterm-16color", O_RDONLY|O_CLOEXEC) = 5
```

```
$ docker rmi alpine:3.3 >/dev/null ; TERMINFO=/usr/share/terminfo TERM=xterm-16color strace -f -o pull.str -e openat ./bundles/latest/binary-client/docker pull alpine:3.3 && grep xterm-16color pull.str
3.3: Pulling from library/alpine
53ebc9bfbcc0: Pull complete 
Digest: sha256:8d366db868cba704e3f86823106390201887de958b19f01e2daa4f178fe604e3
Status: Downloaded newer image for alpine:3.3
6551  openat(AT_FDCWD, "/usr/share/terminfo/x/xterm-16color", O_RDONLY|O_CLOEXEC) = 5
```

```
$ rm -rf $HOME/tmp/terminfo
$ docker rmi alpine:3.3 >/dev/null ; TERMINFO=$HOME/tmp/terminfo TERM=xterm-16color strace -f -o pull.str -e openat ./bundles/latest/binary-client/docker pull alpine:3.3 && grep xterm-16color pull.str
3.3: Pulling from library/alpine
53ebc9bfbcc0: Pull complete 
Digest: sha256:8d366db868cba704e3f86823106390201887de958b19f01e2daa4f178fe604e3
Status: Downloaded newer image for alpine:3.3
6645  openat(AT_FDCWD, "/home/ijc/tmp/terminfo/x/xterm-16color", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
```

```
$ cp -r /usr/share/terminfo $HOME/tmp/terminfo/
$ docker rmi alpine:3.3 >/dev/null ; TERMINFO=$HOME/tmp/terminfo TERM=xterm-16color strace -f -o pull.str -e openat ./bundles/latest/binary-client/docker pull alpine:3.3 && grep xterm-16color pull.str
3.3: Pulling from library/alpine
53ebc9bfbcc0: Pull complete 
Digest: sha256:8d366db868cba704e3f86823106390201887de958b19f01e2daa4f178fe604e3
Status: Downloaded newer image for alpine:3.3
6766  openat(AT_FDCWD, "/home/ijc/tmp/terminfo/x/xterm-16color", O_RDONLY|O_CLOEXEC) = 5
```


**- Description for the changelog**

Fix `docker pull` when `$TERMINFO` is set

**- A picture of a cute animal (not mandatory but encouraged)**

![Blue Öyster Cult](https://upload.wikimedia.org/wikipedia/commons/thumb/6/64/Blue_Oyster_Cult_1977_publicity_photo.jpg/320px-Blue_Oyster_Cult_1977_publicity_photo.jpg)
