### PR TITLE
support cluster events

### DIFF
--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -13,6 +13,12 @@ const (
 	PluginEventType = "plugin"
 	// VolumeEventType is the event type that volumes generate
 	VolumeEventType = "volume"
+	// ServiceEventType is the event type that services generate
+	ServiceEventType = "service"
+	// NodeEventType is the event type that nodes generate
+	NodeEventType = "node"
+	// SecretEventType is the event type that secrets generate
+	SecretEventType = "secret"
 )
 
 // Actor describes something that generates events,
@@ -36,6 +42,8 @@ type Message struct {
 	Type   string
 	Action string
 	Actor  Actor
+	// Engine events are local scope. Cluster events are swarm scope.
+	Scope string `json:"scope,omitempty"`
 
 	Time     int64 `json:"time,omitempty"`
 	TimeNano int64 `json:"timeNano,omitempty"`

--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -105,6 +105,9 @@ type Config struct {
 
 	// path to store runtime state, such as the swarm control socket
 	RuntimeRoot string
+
+	// WatchStream is a channel to pass watch API notifications to daemon
+	WatchStream chan *swarmapi.WatchMessage
 }
 
 // Cluster provides capabilities to participate in a cluster as a worker or a
@@ -118,6 +121,7 @@ type Cluster struct {
 	config       Config
 	configEvent  chan lncluster.ConfigEventType // todo: make this array and goroutine safe
 	attachers    map[string]*attacher
+	watchStream  chan *swarmapi.WatchMessage
 }
 
 // attacher manages the in-memory attachment state of a container
@@ -151,6 +155,7 @@ func New(config Config) (*Cluster, error) {
 		configEvent: make(chan lncluster.ConfigEventType, 10),
 		runtimeRoot: config.RuntimeRoot,
 		attachers:   make(map[string]*attacher),
+		watchStream: config.WatchStream,
 	}
 	return c, nil
 }

--- a/daemon/events.go
+++ b/daemon/events.go
@@ -1,14 +1,27 @@
 package daemon
 
 import (
+	"context"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/container"
 	daemonevents "github.com/docker/docker/daemon/events"
 	"github.com/docker/libnetwork"
+	swarmapi "github.com/docker/swarmkit/api"
+	gogotypes "github.com/gogo/protobuf/types"
+)
+
+var (
+	clusterEventAction = map[swarmapi.WatchActionKind]string{
+		swarmapi.WatchActionKindCreate: "create",
+		swarmapi.WatchActionKindUpdate: "update",
+		swarmapi.WatchActionKindRemove: "remove",
+	}
 )
 
 // LogContainerEvent generates an event related to a container with only the default attributes.
@@ -129,4 +142,181 @@ func copyAttributes(attributes, labels map[string]string) {
 	for k, v := range labels {
 		attributes[k] = v
 	}
+}
+
+// ProcessClusterNotifications gets changes from store and add them to event list
+func (daemon *Daemon) ProcessClusterNotifications(ctx context.Context, watchStream chan *swarmapi.WatchMessage) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case message, ok := <-watchStream:
+			if !ok {
+				logrus.Debug("cluster event channel has stopped")
+				return
+			}
+			daemon.generateClusterEvent(message)
+		}
+	}
+}
+
+func (daemon *Daemon) generateClusterEvent(msg *swarmapi.WatchMessage) {
+	for _, event := range msg.Events {
+		if event.Object == nil {
+			logrus.Errorf("event without object: %v", event)
+			continue
+		}
+		switch v := event.Object.GetObject().(type) {
+		case *swarmapi.Object_Node:
+			daemon.logNodeEvent(event.Action, v.Node, event.OldObject.GetNode())
+		case *swarmapi.Object_Service:
+			daemon.logServiceEvent(event.Action, v.Service, event.OldObject.GetService())
+		case *swarmapi.Object_Network:
+			daemon.logNetworkEvent(event.Action, v.Network, event.OldObject.GetNetwork())
+		case *swarmapi.Object_Secret:
+			daemon.logSecretEvent(event.Action, v.Secret, event.OldObject.GetSecret())
+		default:
+			logrus.Warnf("unrecognized event: %v", event)
+		}
+	}
+}
+
+func (daemon *Daemon) logNetworkEvent(action swarmapi.WatchActionKind, net *swarmapi.Network, oldNet *swarmapi.Network) {
+	attributes := map[string]string{
+		"name": net.Spec.Annotations.Name,
+	}
+	eventTime := eventTimestamp(net.Meta, action)
+	daemon.logClusterEvent(action, net.ID, "network", attributes, eventTime)
+}
+
+func (daemon *Daemon) logSecretEvent(action swarmapi.WatchActionKind, secret *swarmapi.Secret, oldSecret *swarmapi.Secret) {
+	attributes := map[string]string{
+		"name": secret.Spec.Annotations.Name,
+	}
+	eventTime := eventTimestamp(secret.Meta, action)
+	daemon.logClusterEvent(action, secret.ID, "secret", attributes, eventTime)
+}
+
+func (daemon *Daemon) logNodeEvent(action swarmapi.WatchActionKind, node *swarmapi.Node, oldNode *swarmapi.Node) {
+	name := node.Spec.Annotations.Name
+	if name == "" && node.Description != nil {
+		name = node.Description.Hostname
+	}
+	attributes := map[string]string{
+		"name": name,
+	}
+	eventTime := eventTimestamp(node.Meta, action)
+	// In an update event, display the changes in attributes
+	if action == swarmapi.WatchActionKindUpdate && oldNode != nil {
+		if node.Spec.Availability != oldNode.Spec.Availability {
+			attributes["availability.old"] = strings.ToLower(oldNode.Spec.Availability.String())
+			attributes["availability.new"] = strings.ToLower(node.Spec.Availability.String())
+		}
+		if node.Role != oldNode.Role {
+			attributes["role.old"] = strings.ToLower(oldNode.Role.String())
+			attributes["role.new"] = strings.ToLower(node.Role.String())
+		}
+		if node.Status.State != oldNode.Status.State {
+			attributes["state.old"] = strings.ToLower(oldNode.Status.State.String())
+			attributes["state.new"] = strings.ToLower(node.Status.State.String())
+		}
+		// This handles change within manager role
+		if node.ManagerStatus != nil && oldNode.ManagerStatus != nil {
+			// leader change
+			if node.ManagerStatus.Leader != oldNode.ManagerStatus.Leader {
+				if node.ManagerStatus.Leader {
+					attributes["leader.old"] = "false"
+					attributes["leader.new"] = "true"
+				} else {
+					attributes["leader.old"] = "true"
+					attributes["leader.new"] = "false"
+				}
+			}
+			if node.ManagerStatus.Reachability != oldNode.ManagerStatus.Reachability {
+				attributes["reachability.old"] = strings.ToLower(oldNode.ManagerStatus.Reachability.String())
+				attributes["reachability.new"] = strings.ToLower(node.ManagerStatus.Reachability.String())
+			}
+		}
+	}
+
+	daemon.logClusterEvent(action, node.ID, "node", attributes, eventTime)
+}
+
+func (daemon *Daemon) logServiceEvent(action swarmapi.WatchActionKind, service *swarmapi.Service, oldService *swarmapi.Service) {
+	attributes := map[string]string{
+		"name": service.Spec.Annotations.Name,
+	}
+	eventTime := eventTimestamp(service.Meta, action)
+
+	if action == swarmapi.WatchActionKindUpdate && oldService != nil {
+		// check image
+		if x, ok := service.Spec.Task.GetRuntime().(*swarmapi.TaskSpec_Container); ok {
+			containerSpec := x.Container
+			if y, ok := oldService.Spec.Task.GetRuntime().(*swarmapi.TaskSpec_Container); ok {
+				oldContainerSpec := y.Container
+				if containerSpec.Image != oldContainerSpec.Image {
+					attributes["image.old"] = oldContainerSpec.Image
+					attributes["image.new"] = containerSpec.Image
+				}
+			} else {
+				// This should not happen.
+				logrus.Errorf("service %s runtime changed from %T to %T", service.Spec.Annotations.Name, oldService.Spec.Task.GetRuntime(), service.Spec.Task.GetRuntime())
+			}
+		}
+		// check replicated count change
+		if x, ok := service.Spec.GetMode().(*swarmapi.ServiceSpec_Replicated); ok {
+			replicas := x.Replicated.Replicas
+			if y, ok := oldService.Spec.GetMode().(*swarmapi.ServiceSpec_Replicated); ok {
+				oldReplicas := y.Replicated.Replicas
+				if replicas != oldReplicas {
+					attributes["replicas.old"] = strconv.FormatUint(oldReplicas, 10)
+					attributes["replicas.new"] = strconv.FormatUint(replicas, 10)
+				}
+			} else {
+				// This should not happen.
+				logrus.Errorf("service %s mode changed from %T to %T", service.Spec.Annotations.Name, oldService.Spec.GetMode(), service.Spec.GetMode())
+			}
+		}
+		if service.UpdateStatus != nil {
+			if oldService.UpdateStatus == nil {
+				attributes["updatestate.new"] = strings.ToLower(service.UpdateStatus.State.String())
+			} else if service.UpdateStatus.State != oldService.UpdateStatus.State {
+				attributes["updatestate.old"] = strings.ToLower(oldService.UpdateStatus.State.String())
+				attributes["updatestate.new"] = strings.ToLower(service.UpdateStatus.State.String())
+			}
+		}
+	}
+	daemon.logClusterEvent(action, service.ID, "service", attributes, eventTime)
+}
+
+func (daemon *Daemon) logClusterEvent(action swarmapi.WatchActionKind, id, eventType string, attributes map[string]string, eventTime time.Time) {
+	actor := events.Actor{
+		ID:         id,
+		Attributes: attributes,
+	}
+
+	jm := events.Message{
+		Action:   clusterEventAction[action],
+		Type:     eventType,
+		Actor:    actor,
+		Scope:    "swarm",
+		Time:     eventTime.UTC().Unix(),
+		TimeNano: eventTime.UTC().UnixNano(),
+	}
+	daemon.EventsService.PublishMessage(jm)
+}
+
+func eventTimestamp(meta swarmapi.Meta, action swarmapi.WatchActionKind) time.Time {
+	var eventTime time.Time
+	switch action {
+	case swarmapi.WatchActionKindCreate:
+		eventTime, _ = gogotypes.TimestampFromProto(meta.CreatedAt)
+	case swarmapi.WatchActionKindUpdate:
+		eventTime, _ = gogotypes.TimestampFromProto(meta.UpdatedAt)
+	case swarmapi.WatchActionKindRemove:
+		// There is no timestamp from store message for remove operations.
+		// Use current time.
+		eventTime = time.Now()
+	}
+	return eventTime
 }

--- a/daemon/events/events_test.go
+++ b/daemon/events/events_test.go
@@ -139,17 +139,17 @@ func TestLogEvents(t *testing.T) {
 		t.Fatalf("First action is %s, must be action_16", first.Status)
 	}
 	last := current[len(current)-1]
-	if last.Status != "action_79" {
-		t.Fatalf("Last action is %s, must be action_79", last.Status)
+	if last.Status != "action_271" {
+		t.Fatalf("Last action is %s, must be action_271", last.Status)
 	}
 
 	firstC := msgs[0]
-	if firstC.Status != "action_80" {
-		t.Fatalf("First action is %s, must be action_80", firstC.Status)
+	if firstC.Status != "action_272" {
+		t.Fatalf("First action is %s, must be action_272", firstC.Status)
 	}
 	lastC := msgs[len(msgs)-1]
-	if lastC.Status != "action_89" {
-		t.Fatalf("Last action is %s, must be action_89", lastC.Status)
+	if lastC.Status != "action_281" {
+		t.Fatalf("Last action is %s, must be action_281", lastC.Status)
 	}
 }
 

--- a/daemon/events/filter.go
+++ b/daemon/events/filter.go
@@ -20,6 +20,7 @@ func NewFilter(filter filters.Args) *Filter {
 func (ef *Filter) Include(ev events.Message) bool {
 	return ef.matchEvent(ev) &&
 		ef.filter.ExactMatch("type", ev.Type) &&
+		ef.matchScope(ev.Scope) &&
 		ef.matchDaemon(ev) &&
 		ef.matchContainer(ev) &&
 		ef.matchPlugin(ev) &&
@@ -47,6 +48,13 @@ func (ef *Filter) filterContains(field string, values map[string]struct{}) bool 
 	return false
 }
 
+func (ef *Filter) matchScope(scope string) bool {
+	if !ef.filter.Include("scope") {
+		return true
+	}
+	return ef.filter.ExactMatch("scope", scope)
+}
+
 func (ef *Filter) matchLabels(attributes map[string]string) bool {
 	if !ef.filter.Include("label") {
 		return true
@@ -72,6 +80,18 @@ func (ef *Filter) matchVolume(ev events.Message) bool {
 
 func (ef *Filter) matchNetwork(ev events.Message) bool {
 	return ef.fuzzyMatchName(ev, events.NetworkEventType)
+}
+
+func (ef *Filter) matchService(ev events.Message) bool {
+	return ef.fuzzyMatchName(ev, events.ServiceEventType)
+}
+
+func (ef *Filter) matchNode(ev events.Message) bool {
+	return ef.fuzzyMatchName(ev, events.NodeEventType)
+}
+
+func (ef *Filter) matchSecret(ev events.Message) bool {
+	return ef.fuzzyMatchName(ev, events.SecretEventType)
 }
 
 func (ef *Filter) fuzzyMatchName(ev events.Message, eventType string) bool {

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -119,7 +119,7 @@ func (s *DockerSuite) TestEventsLimit(c *check.C) {
 	out, _ := dockerCmd(c, "events", "--since=0", "--until", daemonUnixTime(c))
 	events := strings.Split(out, "\n")
 	nEvents := len(events) - 1
-	c.Assert(nEvents, checker.Equals, 64, check.Commentf("events should be limited to 64, but received %d", nEvents))
+	c.Assert(nEvents, checker.Equals, 256, check.Commentf("events should be limited to 256, but received %d", nEvents))
 }
 
 func (s *DockerSuite) TestEventsContainerEvents(c *check.C) {


### PR DESCRIPTION
This PR is ready for review.

===
This is a work item in progress. Test needs to be added. It also needs a change in Swarmkit Watch API https://github.com/docker/swarmkit/pull/2099. Initial design discussion is at https://github.com/docker/swarmkit/issues/491. I'd like to get design feedback. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>

**- What I did**
Add swarm events to docker event stream. 

**- How I did it**
Use Swarm Store Watch API to get change notification from Raft store. Translate that into Docker event format and push it into Docker event structure. 

**- How to verify it**
On a manager node, `docker events` includes node's local events and cluster events. Cluster events have a global scope while node's local events are local. Existing event filters apply to cluster events. A new `scope` filter is added. 

```
#run this on a manager node
$ docker events -f scope=global

# a node joins a cluster
2017-04-06T18:03:46.551104594Z node create s0ugk1wi0vgxnspxx0ptmon47 (name=)
2017-04-06T18:03:46.553642227Z node update s0ugk1wi0vgxnspxx0ptmon47 (name=)
2017-04-06T18:03:46.556070184Z node update s0ugk1wi0vgxnspxx0ptmon47 (name=)
2017-04-06T18:03:46.562025609Z node update s0ugk1wi0vgxnspxx0ptmon47 (name=)
2017-04-06T18:03:46.689608127Z node update s0ugk1wi0vgxnspxx0ptmon47 (name=ip-172-19-71-145, state.new=ready, state.old=unknown)
# a node goes down
2017-04-06T18:04:32.705082118Z node update 0urgktyobae3etk5e4n4331es (name=ip-172-19-147-51, state.new=down, state.old=ready)
# a node is back up
2017-04-06T18:05:06.288643169Z node update 0urgktyobae3etk5e4n4331es (name=ip-172-19-147-51, state.new=ready, state.old=down)
# promote a node
2017-04-06T18:05:29.965972204Z node update 0urgktyobae3etk5e4n4331es (desiredrole.new=manager, desiredrole.old=worker, name=ip-172-19-147-51)
2017-04-06T18:05:29.972791974Z node update 0urgktyobae3etk5e4n4331es (name=ip-172-19-147-51)
2017-04-06T18:05:29.992599632Z node update 0urgktyobae3etk5e4n4331es (name=ip-172-19-147-51)
2017-04-06T18:05:30.007889135Z node update 0urgktyobae3etk5e4n4331es (name=ip-172-19-147-51)
2017-04-06T18:05:30.084421029Z node update 0urgktyobae3etk5e4n4331es (name=ip-172-19-147-51)
2017-04-06T18:05:30.088454689Z node update 0urgktyobae3etk5e4n4331es (name=ip-172-19-147-51)
# demote a node
2017-04-06T18:06:15.004097376Z node update 0urgktyobae3etk5e4n4331es (desiredrole.new=worker, desiredrole.old=manager, name=ip-172-19-147-51)
2017-04-06T18:06:20.015726988Z node update 0urgktyobae3etk5e4n4331es (name=ip-172-19-147-51)
2017-04-06T18:06:20.035951960Z node update 0urgktyobae3etk5e4n4331es (name=ip-172-19-147-51)
2017-04-06T18:06:20.048380156Z node update 0urgktyobae3etk5e4n4331es (name=ip-172-19-147-51)
2017-04-06T18:06:20.068198599Z node update 0urgktyobae3etk5e4n4331es (name=ip-172-19-147-51)
2017-04-06T18:06:20.072033661Z node update 0urgktyobae3etk5e4n4331es (name=ip-172-19-147-51)
# change a node's availability to pause
2017-04-06T18:07:01.620569322Z node update 0urgktyobae3etk5e4n4331es (availability.new=pause, availability.old=active, name=ip-172-19-147-51)
# change a node's availability to active
2017-04-06T18:07:35.825859057Z node update 0urgktyobae3etk5e4n4331es (availability.new=active, availability.old=pause, name=ip-172-19-147-51)

# create a service
2017-04-06T18:08:43.303340796Z service create 9vvofszhb6iv4k3tmphras96u (name=nginx)
2017-04-06T18:08:43.307625739Z service update 9vvofszhb6iv4k3tmphras96u (name=nginx)
# scale a service
2017-04-06T18:09:37.018798236Z service update 9vvofszhb6iv4k3tmphras96u (name=nginx, replicas.new=3, replicas.old=2)
# update image of a service
2017-04-06T18:11:19.122732546Z service update 9vvofszhb6iv4k3tmphras96u (image.new=nginx:1.10.3@sha256:6202beb06ea61f44179e02ca965e8e13b961d12640101fca213efbfd145d7575, image.old=nginx:latest@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582, name=nginx)
2017-04-06T18:11:19.126619069Z service update 9vvofszhb6iv4k3tmphras96u (name=nginx, updatestate.new=updating, updatestate.old=nil)
2017-04-06T18:11:41.552581741Z service update 9vvofszhb6iv4k3tmphras96u (name=nginx, updatestate.new=completed, updatestate.old=updating)
# remove a service
2017-04-06T18:12:23.466026101Z service remove 9vvofszhb6iv4k3tmphras96u (name=nginx)

# create a network
2017-04-06T18:12:45.047497468Z network create qew8jjh6riv75r8tj4wf0imfw (name=tnet)
2017-04-06T18:12:45.053957928Z network update qew8jjh6riv75r8tj4wf0imfw (name=tnet)
# create a container associtated with this network
# create a service associated with this network
2017-04-06T18:14:38.161988206Z service create v6md2fr205au7c6wq5zdo6sz1 (name=nginx)
2017-04-06T18:14:38.166951070Z service update v6md2fr205au7c6wq5zdo6sz1 (name=nginx)
# remove the service
2017-04-06T18:15:29.441350106Z service remove v6md2fr205au7c6wq5zdo6sz1 (name=nginx)
# remove a network
2017-04-06T18:15:43.558832104Z network remove qew8jjh6riv75r8tj4wf0imfw (name=tnet)

# create a secret
2017-04-06T18:16:27.127307662Z secret create p3z8b3f2q40fun94yq3vd2g9y (name=mysecret)
# remove a secret
2017-04-06T18:16:55.393649748Z secret remove p3z8b3f2q40fun94yq3vd2g9y (name=mysecret)
```

**- Description for the changelog**
Add cluster events to Docker event stream. 