### PR TITLE
Creates a manifest store for caching canonically to disk.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -38,6 +38,7 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/libcontainerd"
+	"github.com/docker/docker/manifest"
 	"github.com/docker/docker/migrate/v1"
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/idtools"
@@ -76,6 +77,7 @@ type Daemon struct {
 	containers                container.Store
 	execCommands              *exec.Store
 	referenceStore            refstore.Store
+	manifestStore             manifest.Store
 	downloadManager           *xfer.LayerDownloadManager
 	uploadManager             *xfer.LayerUploadManager
 	distributionMetadataStore dmetadata.Store
@@ -637,6 +639,11 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 	}
 
 	d.imageStore, err = image.NewImageStore(ifs, d.layerStore)
+	if err != nil {
+		return nil, err
+	}
+
+	d.manifestStore, err = manifest.NewManifestStore(filepath.Join(imageRoot, "manifestdb"))
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/image.go
+++ b/daemon/image.go
@@ -42,6 +42,15 @@ func (daemon *Daemon) GetImageID(refOrID string) (image.ID, error) {
 		return id, nil
 	}
 
+	// For a canonical reference, use the manifest store to ensure integrity.
+	if canonical, ok := ref.(reference.Canonical); ok {
+		id, err := daemon.manifestStore.GetImageID(canonical)
+		if err != nil {
+			return "", ErrImageDoesNotExist{ref}
+		}
+		return id, nil
+	}
+
 	if id, err := daemon.referenceStore.Get(namedRef); err == nil {
 		return image.IDFromDigest(id), nil
 	}

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -256,6 +256,10 @@ func (daemon *Daemon) removeAllReferencesToImageID(imgID image.ID, records *[]ty
 			return err
 		}
 
+		if canonical, ok := imageRef.(reference.Canonical); ok {
+			daemon.manifestStore.Delete(canonical)
+		}
+
 		untaggedRecord := types.ImageDeleteResponseItem{Untagged: reference.FamiliarString(parsedRef)}
 
 		daemon.LogImageEvent(imgID.String(), imgID.String(), "untag")

--- a/daemon/image_pull.go
+++ b/daemon/image_pull.go
@@ -99,6 +99,7 @@ func (daemon *Daemon) pullImageWithReference(ctx context.Context, ref reference.
 			MetadataStore:    daemon.distributionMetadataStore,
 			ImageStore:       distribution.NewImageConfigStoreFromStore(daemon.imageStore),
 			ReferenceStore:   daemon.referenceStore,
+			ManifestStore:    daemon.manifestStore,
 		},
 		DownloadManager: daemon.downloadManager,
 		Schema2Types:    distribution.ImageTypes,

--- a/distribution/config.go
+++ b/distribution/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/distribution/xfer"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
+	"github.com/docker/docker/manifest"
 	"github.com/docker/docker/pkg/progress"
 	refstore "github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
@@ -47,6 +48,9 @@ type Config struct {
 	ReferenceStore refstore.Store
 	// RequireSchema2 ensures that only schema2 manifests are used.
 	RequireSchema2 bool
+	// ManifestStore caches manifests and ensures integrity of the data
+	// when requested canonically.
+	ManifestStore manifest.Store
 }
 
 // ImagePullConfig stores pull configuration.

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -367,6 +367,13 @@ func (p *v2Puller) pullV2Tag(ctx context.Context, ref reference.Named) (tagUpdat
 		}
 	}
 
+	// Cache manifests, so integrity can be verified when executed canonically.
+	if p.config.ManifestStore != nil {
+		if _, err2 := p.config.ManifestStore.Set(ref.Name(), manifest); err2 != nil {
+			return false, err2
+		}
+	}
+
 	// If manSvc.Get succeeded, we can be confident that the registry on
 	// the other side speaks the v2 protocol.
 	p.confirmedV2 = true
@@ -699,6 +706,13 @@ func (p *v2Puller) pullManifestList(ctx context.Context, ref reference.Named, mf
 	manifest, err := manSvc.Get(ctx, manifestDigest)
 	if err != nil {
 		return "", "", err
+	}
+
+	// Cache manifests, so integrity can be verified when executed canonically.
+	if p.config.ManifestStore != nil {
+		if _, err2 := p.config.ManifestStore.Set(ref.Name(), manifest); err2 != nil {
+			return "", "", err2
+		}
 	}
 
 	manifestRef, err := reference.WithDigest(reference.TrimNamed(ref), manifestDigest)

--- a/manifest/store.go
+++ b/manifest/store.go
@@ -1,0 +1,227 @@
+package manifest
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/pkg/ioutils"
+	"github.com/opencontainers/go-digest"
+)
+
+// Store provides methods which can operate on a manifest store.
+type Store interface {
+	Get(reference.Canonical) (*distribution.Manifest, error)
+	GetImageID(reference.Canonical) (image.ID, error)
+	Set(string, distribution.Manifest) (digest.Digest, error)
+	Delete(reference.Canonical) error
+	DeleteByImageID(image.ID) error
+}
+
+// store implements a Store on the filesystem.
+type store struct {
+	sync.RWMutex
+	// root is the directory under which manifests are cached.
+	root string
+}
+
+var (
+	// ErrNotFound indicates an entity was not found in the store.
+	ErrNotFound = errors.New("Not found")
+)
+
+const (
+	contentDirName = "content"
+)
+
+// NewManifestStore returns a new filesystem backed Store.
+func NewManifestStore(root string) (Store, error) {
+	abspath, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &store{root: abspath}
+	if err := os.MkdirAll(s.contentPath(), 0700); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *store) contentPath() string {
+	return filepath.Join(s.root, contentDirName, string(digest.Canonical))
+}
+
+func (s *store) contentFile(ref reference.Canonical) string {
+	base46Ref := base64.StdEncoding.EncodeToString([]byte(ref.String()))
+	return filepath.Join(s.contentPath(), base46Ref)
+}
+
+func newReference(str string) (reference.Canonical, error) {
+	ref, err := reference.Parse(str)
+	if err != nil {
+		return nil, err
+	}
+
+	canonical, ok := ref.(reference.Canonical)
+	if !ok {
+		return nil, errors.New("Expected reference to be canonical")
+	}
+	return canonical, nil
+}
+
+// Get returns the content stored under a given canonical reference.
+// The content is verified to match the digest in the lookup reference.
+func (s *store) Get(ref reference.Canonical) (*distribution.Manifest, error) {
+	s.RLock()
+	defer s.RUnlock()
+
+	data, err := ioutil.ReadFile(s.contentFile(ref))
+	if err != nil {
+		return nil, err
+	}
+
+	dgst := ref.Digest()
+	if digest.FromBytes(data) != dgst {
+		return nil, fmt.Errorf("failed to verify cached manifest: %v", dgst)
+	}
+
+	var version manifest.Versioned
+	if err := json.Unmarshal(data, &version); err != nil {
+		return nil, err
+	}
+
+	m, _, err := distribution.UnmarshalManifest(version.MediaType, data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &m, nil
+}
+
+// GetImageID retrieves the content stored under a given canonical reference and extracts the image ID.
+// The content is verified to match the digest in the lookup reference.
+func (s *store) GetImageID(ref reference.Canonical) (image.ID, error) {
+	m, err := s.Get(ref)
+	if err != nil {
+		return "", ErrNotFound
+	}
+	return s.toImageID(ref, m)
+}
+
+// Set stores content by canonical reference.
+func (s *store) Set(name string, manifest distribution.Manifest) (digest.Digest, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	_, data, err := manifest.Payload()
+	if err != nil {
+		return "", err
+	}
+
+	ref, err := newReference(fmt.Sprintf("%s@%s", name, digest.FromBytes(data)))
+	if err != nil {
+		return "", err
+	}
+	if err := ioutils.AtomicWriteFile(s.contentFile(ref), data, 0600); err != nil {
+		return "", err
+	}
+
+	return ref.Digest(), nil
+}
+
+// Delete removes the content identified by the canonical reference.
+func (s *store) Delete(ref reference.Canonical) error {
+	s.Lock()
+	defer s.Unlock()
+
+	return os.Remove(s.contentFile(ref))
+}
+
+// DeleteByImageID removes any content containing the given image ID.
+func (s *store) DeleteByImageID(imageID image.ID) error {
+	files, err := ioutil.ReadDir(s.contentPath())
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		decoded, err := base64.StdEncoding.DecodeString(f.Name())
+		if err != nil {
+			return err
+		}
+
+		ref, err := newReference(string(decoded))
+		if err != nil {
+			return err
+		}
+
+		m, err := s.Get(ref)
+		if err != nil {
+			return err
+		}
+
+		id, err := s.toImageID(ref, m)
+		if err != nil {
+			return err
+		}
+
+		if imageID == id {
+			err = s.Delete(ref)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *store) toImageID(ref reference.Canonical, m *distribution.Manifest) (image.ID, error) {
+	switch v := (*m).(type) {
+	case *schema2.DeserializedManifest:
+		return image.IDFromDigest(v.Target().Digest), nil
+	case *manifestlist.DeserializedManifestList:
+		subManifestDigest := subManifestForRuntime(v.Manifests)
+		if subManifestDigest == "" {
+			return "", ErrNotFound
+		}
+
+		subRef, err := newReference(fmt.Sprintf("%s@%s", ref.Name(), subManifestDigest))
+		if err != nil {
+			return "", ErrNotFound
+		}
+
+		subManifest, err := s.Get(subRef)
+		if err != nil {
+			return "", ErrNotFound
+		}
+
+		if v2, ok := (*subManifest).(*schema2.DeserializedManifest); ok {
+			return image.IDFromDigest(v2.Target().Digest), nil
+		}
+	}
+	return "", ErrNotFound
+}
+
+// subManifestForRuntime is a helper to find the appropriate manifest for the current runtime.
+func subManifestForRuntime(descriptors []manifestlist.ManifestDescriptor) digest.Digest {
+	for _, descriptor := range descriptors {
+		// Look for digest for this system.
+		if descriptor.Platform.Architecture == runtime.GOARCH && descriptor.Platform.OS == runtime.GOOS {
+			return descriptor.Digest
+		}
+	}
+	return ""
+}

--- a/manifest/store_test.go
+++ b/manifest/store_test.go
@@ -1,0 +1,166 @@
+package manifest
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/docker/image"
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreGetSet(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "manifest-store")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	store, err := NewManifestStore(tmpdir)
+	require.NoError(t, err)
+
+	type tcase struct {
+		input []byte
+		ref   string
+	}
+	tcases := []tcase{
+		{[]byte(`{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","layers":[],"config":{}}`),
+			"sha256:d5f0a331a44afef0062260bb42d0488b0e3bf9d3639ae963369cfd6a2908c483"},
+	}
+
+	for _, tc := range tcases {
+		id, err := store.Set("img", manifestFromBytes(tc.input))
+		require.NoError(t, err)
+		require.Equal(t, tc.ref, id.String(), "Expected ID %q, got %q.", tc.ref, id)
+	}
+
+	for _, tc := range tcases {
+		ref, err := newReference("img@" + tc.ref)
+		require.NoError(t, err)
+		m, err := store.Get(ref)
+		require.NoError(t, err)
+		_, data, err := (*m).Payload()
+		require.NoError(t, err)
+
+		if !bytes.Equal(data, tc.input) {
+			t.Fatalf("Expected data %q, got %q", tc.input, data)
+		}
+	}
+
+	for _, badDigest := range []string{"img@foobar:abc", "img@sha256:abc", "img@sha256:d5f0a331a44afef0062260bb42d0488b0e3bf9d3639ae963369cfd6a2908c483a"} {
+		ref, err := newReference(badDigest)
+		require.Error(t, err, "Expected error for ID %q.", ref)
+	}
+}
+
+func TestStoreGetInvalidData(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "manifest-store")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	store, err := NewManifestStore(tmpdir)
+	require.NoError(t, err)
+
+	mBytes := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","layers":[],"config":{}}`)
+	id, err := store.Set("img", manifestFromBytes(mBytes))
+	require.NoError(t, err)
+
+	ref, err := newReference(fmt.Sprintf("img@%s", id))
+	require.NoError(t, err)
+
+	mBytes2 := []byte(`{"schemaVersion":2,   "mediaType":"application/vnd.docker.distribution.manifest.v2+json","layers":[],"config":{}}`)
+	base46Ref := base64.StdEncoding.EncodeToString([]byte(ref.String()))
+	if err := ioutil.WriteFile(filepath.Join(tmpdir, contentDirName, string(digest.Canonical), base46Ref), mBytes2, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.Get(ref)
+	require.Error(t, err, "Expected get to fail after data modification.")
+}
+
+func TestStoreInvalidRoot(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "manifest-store")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	tcases := []struct {
+		root, invalidFile string
+	}{
+		{"root", "root"},
+		{"root", "root/content"},
+	}
+
+	for _, tc := range tcases {
+		root := filepath.Join(tmpdir, tc.root)
+		filePath := filepath.Join(tmpdir, tc.invalidFile)
+		err := os.MkdirAll(filepath.Dir(filePath), 0700)
+		require.NoError(t, err)
+		f, err := os.Create(filePath)
+		require.NoError(t, err)
+		f.Close()
+
+		_, err = NewManifestStore(root)
+		require.Error(t, err, "Expected error from root %q and invalid file %q.", tc.root, tc.invalidFile)
+
+		os.RemoveAll(root)
+	}
+}
+
+func TestStoreDelete(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "manifest-store")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	store, err := NewManifestStore(tmpdir)
+	require.NoError(t, err)
+
+	mBytes := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","layers":[],"config":{}}`)
+	id, err := store.Set("img", manifestFromBytes(mBytes))
+	require.NoError(t, err)
+
+	ref, _ := newReference(fmt.Sprintf("img@%s", id))
+	_, err = store.Get(ref)
+	require.NoError(t, err)
+
+	err = store.Delete(ref)
+	require.NoError(t, err)
+
+	_, err = store.Get(ref)
+	require.Error(t, err, "Expected error for retrieving an image after pruning.")
+}
+
+func TestStoreGetDeleteByImageID(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "manifest-store")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	store, err := NewManifestStore(tmpdir)
+	require.NoError(t, err)
+
+	mBytes := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","layers":[],
+	"config":{"digest":"sha256:d5f0a331a44afef0062260bb42d0488b0e3bf9d3639ae963369cfd6a2908c483"}}`)
+	expectedImageID := image.ID("sha256:d5f0a331a44afef0062260bb42d0488b0e3bf9d3639ae963369cfd6a2908c483")
+	id, err := store.Set("img", manifestFromBytes(mBytes))
+	require.NoError(t, err)
+
+	ref, _ := newReference(fmt.Sprintf("img@%s", id))
+	imageID, err := store.GetImageID(ref)
+	require.NoError(t, err)
+	require.Equal(t, expectedImageID, imageID)
+
+	err = store.DeleteByImageID(imageID)
+	require.NoError(t, err)
+
+	_, err = store.Get(ref)
+	require.Error(t, err, "Expected error for retrieving an image after pruning.")
+}
+
+func manifestFromBytes(data []byte) schema2.DeserializedManifest {
+	m := new(schema2.DeserializedManifest)
+	m.UnmarshalJSON(data)
+	return *m
+}


### PR DESCRIPTION
When an image is run with a canonical reference (e.g. [1]),
The manifest matching that digest may be retrieved from cache,
verified against the digest, and used to resolve the proper image
config (image.ID). Previously, just the reference.Store was used,
which leaves room for on disk modification. This patch ensure that
a canonical reference executes on a manifest matching the reference.

The manifest store may be useful for other purposes, but this is the
initial use-case.

[1]: `docker run -i -t alpine@sha256:58e1a1bb75db1b5a24a462dd5e2915277ea06438c3f105138f97eb53149673c4 /bin/sh`