### PR TITLE
Fix install.sh of get.docker.com for debian-sudo

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -482,7 +482,7 @@ do_install() {
 
 			(
 			set -x
-			echo "$docker_key" | apt-key add -
+			echo "$docker_key" | $sh_c 'apt-key add -'
 			$sh_c "mkdir -p /etc/apt/sources.list.d"
 			$sh_c "echo deb \[arch=$(dpkg --print-architecture)\] ${apt_url}/repo ${lsb_dist}-${dist_version} ${repo} > /etc/apt/sources.list.d/docker.list"
 			$sh_c 'sleep 3; apt-get update; apt-get install -y -q docker-engine'


### PR DESCRIPTION
**- What I did**
repair sudo call on key-add for install / https://get.docker.com/
fixes #32424

**- How I did it**
readd `$sh_c` in the call

**- How to verify it**
follow issue #32424

**- Description for the changelog**
Fix key-add when installing from an unprivileged user by wrapping it back into `$sh_c`