### PR TITLE
add hosts example for serviceSpec in swagger.yml

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7509,6 +7509,7 @@ paths:
                             DriverConfig: {}
                             Labels:
                               com.example.something: "something-value"
+                      Hosts: ["10.10.10.10 host1", "ABCD:EF01:2345:6789:ABCD:EF01:2345:6789 host2"]
                       User: "33"
                       DNSConfig:
                         Nameservers: ["8.8.8.8"]


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

first, I think the parameter extraHost in /containers/create and hosts in /services/create have the same format. However they are different.

Here are the description in swagger.yml:
```
ExtraHosts:
            type: "array"
            description: |
              A list of hostnames/IP mappings to add to the container's `/etc/hosts` file. Specified in the form `["hostname:IP"]`.
            items:
              type: "string"
```
and 
```
          Hosts:
            type: "array"
            description: |
              A list of hostnames/IP mappings to add to the container's `/etc/hosts` file.
              The format of extra hosts on swarmkit is specified in:
              http://man7.org/linux/man-pages/man5/hosts.5.html
                IP_address canonical_hostname [aliases...]
            items:
              type: "string"
```

So I think it is better to add a specific example of hosts in ServiceSpec.

**- What I did**
1. add hosts example for serviceSpec in swagger.yml

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

