### PR TITLE
[17.04.x] cherry-pick 32425 - fix install.sh of get.docker.com for debian-sudo

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -478,7 +478,7 @@ do_install() {
 
 			(
 			set -x
-			echo "$docker_key" | apt-key add -
+			echo "$docker_key" | $sh_c 'apt-key add -'
 			$sh_c "mkdir -p /etc/apt/sources.list.d"
 			$sh_c "echo deb \[arch=$(dpkg --print-architecture)\] ${apt_url}/repo ${lsb_dist}-${dist_version} ${repo} > /etc/apt/sources.list.d/docker.list"
 			$sh_c 'sleep 3; apt-get update; apt-get install -y -q docker-engine'


### PR DESCRIPTION
Fix install.sh of get.docker.com for debian-sudo
(cherry picked from commit daaf9ddfa9a53fb82511accb8ad0fed381670a54)


This cherry-picks the change to the install.sh into the 17.04.x branch

ping @vieux @andrewhsu PTAL
