### PR TITLE
Support for upgrading to docker-ce channels

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -24,99 +24,7 @@ set -e
 #
 
 url="https://get.docker.com/"
-apt_url="https://apt.dockerproject.org"
-yum_url="https://yum.dockerproject.org"
-
-docker_key="-----BEGIN PGP PUBLIC KEY BLOCK-----
-Version: GnuPG v1
-
-mQINBFWln24BEADrBl5p99uKh8+rpvqJ48u4eTtjeXAWbslJotmC/CakbNSqOb9o
-ddfzRvGVeJVERt/Q/mlvEqgnyTQy+e6oEYN2Y2kqXceUhXagThnqCoxcEJ3+KM4R
-mYdoe/BJ/J/6rHOjq7Omk24z2qB3RU1uAv57iY5VGw5p45uZB4C4pNNsBJXoCvPn
-TGAs/7IrekFZDDgVraPx/hdiwopQ8NltSfZCyu/jPpWFK28TR8yfVlzYFwibj5WK
-dHM7ZTqlA1tHIG+agyPf3Rae0jPMsHR6q+arXVwMccyOi+ULU0z8mHUJ3iEMIrpT
-X+80KaN/ZjibfsBOCjcfiJSB/acn4nxQQgNZigna32velafhQivsNREFeJpzENiG
-HOoyC6qVeOgKrRiKxzymj0FIMLru/iFF5pSWcBQB7PYlt8J0G80lAcPr6VCiN+4c
-NKv03SdvA69dCOj79PuO9IIvQsJXsSq96HB+TeEmmL+xSdpGtGdCJHHM1fDeCqkZ
-hT+RtBGQL2SEdWjxbF43oQopocT8cHvyX6Zaltn0svoGs+wX3Z/H6/8P5anog43U
-65c0A+64Jj00rNDr8j31izhtQMRo892kGeQAaaxg4Pz6HnS7hRC+cOMHUU4HA7iM
-zHrouAdYeTZeZEQOA7SxtCME9ZnGwe2grxPXh/U/80WJGkzLFNcTKdv+rwARAQAB
-tDdEb2NrZXIgUmVsZWFzZSBUb29sIChyZWxlYXNlZG9ja2VyKSA8ZG9ja2VyQGRv
-Y2tlci5jb20+iQIcBBABCgAGBQJWw7vdAAoJEFyzYeVS+w0QHysP/i37m4SyoOCV
-cnybl18vzwBEcp4VCRbXvHvOXty1gccVIV8/aJqNKgBV97lY3vrpOyiIeB8ETQeg
-srxFE7t/Gz0rsLObqfLEHdmn5iBJRkhLfCpzjeOnyB3Z0IJB6UogO/msQVYe5CXJ
-l6uwr0AmoiCBLrVlDAktxVh9RWch0l0KZRX2FpHu8h+uM0/zySqIidlYfLa3y5oH
-scU+nGU1i6ImwDTD3ysZC5jp9aVfvUmcESyAb4vvdcAHR+bXhA/RW8QHeeMFliWw
-7Z2jYHyuHmDnWG2yUrnCqAJTrWV+OfKRIzzJFBs4e88ru5h2ZIXdRepw/+COYj34
-LyzxR2cxr2u/xvxwXCkSMe7F4KZAphD+1ws61FhnUMi/PERMYfTFuvPrCkq4gyBj
-t3fFpZ2NR/fKW87QOeVcn1ivXl9id3MMs9KXJsg7QasT7mCsee2VIFsxrkFQ2jNp
-D+JAERRn9Fj4ArHL5TbwkkFbZZvSi6fr5h2GbCAXIGhIXKnjjorPY/YDX6X8AaHO
-W1zblWy/CFr6VFl963jrjJgag0G6tNtBZLrclZgWhOQpeZZ5Lbvz2ZA5CqRrfAVc
-wPNW1fObFIRtqV6vuVluFOPCMAAnOnqR02w9t17iVQjO3oVN0mbQi9vjuExXh1Yo
-ScVetiO6LSmlQfVEVRTqHLMgXyR/EMo7iQIcBBABCgAGBQJXSWBlAAoJEFyzYeVS
-+w0QeH0QAI6btAfYwYPuAjfRUy9qlnPhZ+xt1rnwsUzsbmo8K3XTNh+l/R08nu0d
-sczw30Q1wju28fh1N8ay223+69f0+yICaXqR18AbGgFGKX7vo0gfEVaxdItUN3eH
-NydGFzmeOKbAlrxIMECnSTG/TkFVYO9Ntlv9vSN2BupmTagTRErxLZKnVsWRzp+X
-elwlgU5BCZ6U6Ze8+bIc6F1bZstf17X8i6XNV/rOCLx2yP0hn1osoljoLPpW8nzk
-wvqYsYbCA28lMt1aqe0UWvRCqR0zxlKn17NZQqjbxcajEMCajoQ01MshmO5GWePV
-iv2abCZ/iaC5zKqVT3deMJHLq7lum6qhA41E9gJH9QoqT+qgadheeFfoC1QP7cke
-+tXmYg2R39p3l5Hmm+JQbP4f9V5mpWExvHGCSbcatr35tnakIJZugq2ogzsm1djC
-Sz9222RXl9OoFqsm1bNzA78+/cOt5N2cyhU0bM2T/zgh42YbDD+JDU/HSmxUIpU+
-wrGvZGM2FU/up0DRxOC4U1fL6HHlj8liNJWfEg3vhougOh66gGF9ik5j4eIlNoz6
-lst+gmvlZQ9/9hRDeoG+AbhZeIlQ4CCw+Y1j/+fUxIzKHPVK+aFJd+oJVNvbojJW
-/SgDdSMtFwqOvXyYcHl30Ws0gZUeDyAmNGZeJ3kFklnApDmeKK+OiQIiBBABCgAM
-BQJXe5zTBYMHhh+AAAoJEDG4FaMBBnSp7YMQAJqrXoBonZAq07B6qUaT3aBCgnY4
-JshbXmFb/XrrS75f7YJDPx2fJJdqrbYDIHHgOjzxvp3ngPpOpJzI5sYmkaugeoCO
-/KHu/+39XqgTB7fguzapRfbvuWp+qzPcHSdb9opnagfzKAze3DQnnLiwCPlsyvGp
-zC4KzXgV2ze/4raaOye1kK7O0cHyapmn/q/TR3S8YapyXq5VpLThwJAw1SRDu0Yx
-eXIAQiIfaSxT79EktoioW2CSV8/djt+gBjXnKYJJA8P1zzX7GNt/Rc2YG0Ot4v6t
-BW16xqFTg+n5JzbeK5cZ1jbIXXfCcaZJyiM2MzYGhSJ9+EV7JYF05OAIWE4SGTRj
-XMquQ2oMLSwMCPQHm+FCD9PXQ0tHYx6tKT34wksdmoWsdejl/n3NS+178mG1WI/l
-N079h3im2gRwOykMou/QWs3vGw/xDoOYHPV2gJ7To9BLVnVK/hROgdFLZFeyRScN
-zwKm57HmYMFA74tX601OiHhk1ymP2UUc25oDWpLXlfcRULJJlo/KfZZF3pmKwIq3
-CilGayFUi1NNwuavG76EcAVtVFUVFFIITwkhkuRbBHIytzEHYosFgD5/acK0Pauq
-JnwrwKv0nWq3aK7nKiALAD+iZvPNjFZau3/APqLEmvmRnAElmugcHsWREFxMMjMM
-VgYFiYKUAJO8u46eiQI4BBMBAgAiBQJVpZ9uAhsvBgsJCAcDAgYVCAIJCgsEFgID
-AQIeAQIXgAAKCRD3YiFXLFJgnbRfEAC9Uai7Rv20QIDlDogRzd+Vebg4ahyoUdj0
-CH+nAk40RIoq6G26u1e+sdgjpCa8jF6vrx+smpgd1HeJdmpahUX0XN3X9f9qU9oj
-9A4I1WDalRWJh+tP5WNv2ySy6AwcP9QnjuBMRTnTK27pk1sEMg9oJHK5p+ts8hlS
-C4SluyMKH5NMVy9c+A9yqq9NF6M6d6/ehKfBFFLG9BX+XLBATvf1ZemGVHQusCQe
-bTGv0C0V9yqtdPdRWVIEhHxyNHATaVYOafTj/EF0lDxLl6zDT6trRV5n9F1VCEh4
-Aal8L5MxVPcIZVO7NHT2EkQgn8CvWjV3oKl2GopZF8V4XdJRl90U/WDv/6cmfI08
-GkzDYBHhS8ULWRFwGKobsSTyIvnbk4NtKdnTGyTJCQ8+6i52s+C54PiNgfj2ieNn
-6oOR7d+bNCcG1CdOYY+ZXVOcsjl73UYvtJrO0Rl/NpYERkZ5d/tzw4jZ6FCXgggA
-/Zxcjk6Y1ZvIm8Mt8wLRFH9Nww+FVsCtaCXJLP8DlJLASMD9rl5QS9Ku3u7ZNrr5
-HWXPHXITX660jglyshch6CWeiUATqjIAzkEQom/kEnOrvJAtkypRJ59vYQOedZ1s
-FVELMXg2UCkD/FwojfnVtjzYaTCeGwFQeqzHmM241iuOmBYPeyTY5veF49aBJA1g
-EJOQTvBR8Q==
-=Yhur
------END PGP PUBLIC KEY BLOCK-----
-"
-
-mirror=''
-while [ $# -gt 0 ]; do
-	case "$1" in
-		--mirror)
-			mirror="$2"
-			shift
-			;;
-		*)
-			echo "Illegal option $1"
-			;;
-	esac
-	shift $(( $# > 0 ? 1 : 0 ))
-done
-
-case "$mirror" in
-	AzureChinaCloud)
-		apt_url="https://mirror.azure.cn/docker-engine/apt"
-		yum_url="https://mirror.azure.cn/docker-engine/yum"
-		;;
-	Aliyun)
-		apt_url="https://mirrors.aliyun.com/docker-engine/apt"
-		yum_url="https://mirrors.aliyun.com/docker-engine/yum"
-		;;
-esac
+download_url="https://download.docker.com/linux"
 
 command_exists() {
 	command -v "$@" > /dev/null 2>&1
@@ -308,12 +216,12 @@ do_install() {
 	fi
 
 	# check to see which repo they are trying to install from
-	if [ -z "$repo" ]; then
-		repo='main'
+	if [ -z "$channel" ]; then
+		channel='stable'
 		if [ "https://test.docker.com/" = "$url" ]; then
-			repo='testing'
+			channel='test'
 		elif [ "https://experimental.docker.com/" = "$url" ]; then
-			repo='experimental'
+			channel='edge'
 		fi
 	fi
 
@@ -482,10 +390,10 @@ do_install() {
 
 			(
 			set -x
-			echo "$docker_key" | $sh_c 'apt-key add -'
+			curl -sSL "${download_url}/${lsb_dist}/gpg" | $sh_c 'apt-key add -'
 			$sh_c "mkdir -p /etc/apt/sources.list.d"
-			$sh_c "echo deb \[arch=$(dpkg --print-architecture)\] ${apt_url}/repo ${lsb_dist}-${dist_version} ${repo} > /etc/apt/sources.list.d/docker.list"
-			$sh_c 'sleep 3; apt-get update; apt-get install -y -q docker-engine'
+			$sh_c "echo deb \[arch=$(dpkg --print-architecture)\] ${download_url}/${lsb_dist} ${dist_version} ${channel} > /etc/apt/sources.list.d/docker.list"
+			$sh_c 'sleep 3; apt-get update; apt-get install -y -q docker-ce'
 			)
 			echo_docker_as_nonroot
 			exit 0
@@ -496,28 +404,23 @@ do_install() {
 				# we use the centos repository for both redhat and centos releases
 				lsb_dist='centos'
 			fi
-			$sh_c "cat >/etc/yum.repos.d/docker-${repo}.repo" <<-EOF
-			[docker-${repo}-repo]
-			name=Docker ${repo} Repository
-			baseurl=${yum_url}/repo/${repo}/${lsb_dist}/${dist_version}
-			enabled=1
-			gpgcheck=1
-			gpgkey=${yum_url}/gpg
-			EOF
-			if [ "$lsb_dist" = "fedora" ] && [ "$dist_version" -ge "22" ]; then
+
+			curl -sSL "${download_url}/${lsb_dist}/docker-ce.repo" > /etc/yum.repos.d/docker-ce-${channel}.repo
+
+			if [ "$lsb_dist" = "fedora" ] && [ "$dist_version" -ge "24" ]; then
 				(
 					set -x
-					$sh_c 'sleep 3; dnf -y -q install docker-engine'
+					$sh_c 'sleep 3; dnf -y -q install docker-ce'
 				)
 			elif [ "$lsb_dist" = "photon" ]; then
 				(
 					set -x
-					$sh_c 'sleep 3; tdnf -y install docker-engine'
+					$sh_c 'sleep 3; tdnf -y install docker-ce'
 				)
 			else
 				(
 					set -x
-					$sh_c 'sleep 3; yum -y -q install docker-engine'
+					$sh_c 'sleep 3; yum -y -q install docker-ce'
 				)
 			fi
 			echo_docker_as_nonroot


### PR DESCRIPTION
package name renamed after Docker Community Edition announced, and              
according to the setup guide, repositories have changed as well, but            
the helper scripts didn't reflect these changes.                                
                                                                                
if user setup his/her Docker environment with __https://get.docker.com__,       
it was originally to have "docker-engine" releases during upgrade,              
v1.12.6 -> v1.13.0 -> v1.13.1                                                   
                                                                                
but with "docker-ce" announced, it will now getting alised "docker-ce",         
1.12.6 -> 1.13.0 -> 1.13.1 -> 17.03.0 -> 17.03.1 -> 17.04.0,                    
which is **Docker-CE Edge** release                                             
                                                                                
but it was expected to have **Docker-CE Stable** release                        
                                                                                
with this commit,                                                               
it is possible to switch between channels via corresponding URLs                
- https://experimental.docker.com for edge channel releases                     
- https://get.docker.com for stable channel releases                            
- https://test.docker.com for test channel releases                             
                                                                                
References:                                                                     
- https://www.docker.com/community-edition                                      
- https://download.docker.com/linux/


**- What I did**

partial rewrite hack/install.sh for setting up different channal of docker-ce build
- docker-ce[stable] via get.docker.com
- docker-ce[edge] via experimental.docker.com
- docker-ce[test] via test.docker.com


**- How I did it**

partial rewrite hack/install.sh


**- How to verify it**

verify if the /etc/apt/sources.list.d/docker.list or /etc/yum.repos.d/docker-ce-${channel}.repo is pointed to correct channel


**- Description for the changelog**

enable support for docker-ce installation