### PR TITLE
Fix container no ipv6 when run container on --network=host

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -428,6 +428,22 @@ func (s *DockerDaemonSuite) TestDaemonIPv6FixedCIDRAndMac(c *check.C) {
 	c.Assert(strings.Trim(out, " \r\n'"), checker.Equals, "2001:db8:1::aabb:ccdd:eeff")
 }
 
+// TestDaemonIPv6HostMode checks that when the running a container with
+// network=host the host ipv6 addresses are not removed
+func (s *DockerDaemonSuite) TestDaemonIPv6HostMode(c *check.C) {
+	testRequires(c, SameHostDaemon)
+	deleteInterface(c, "docker0")
+
+	s.d.StartWithBusybox(c, "--ipv6", "--fixed-cidr-v6=2001:db8:2::/64")
+	out, err := s.d.Cmd("run", "-itd", "--name=hostcnt", "--network=host", "busybox:latest")
+	c.Assert(err, checker.IsNil, check.Commentf("Could not run container: %s, %v", out, err))
+
+	out, err = s.d.Cmd("exec", "hostcnt", "ip", "-6", "addr", "show", "docker0")
+	out = strings.Trim(out, " \r\n'")
+
+	c.Assert(out, checker.Contains, "2001:db8:2::1")
+}
+
 func (s *DockerDaemonSuite) TestDaemonLogLevelWrong(c *check.C) {
 	c.Assert(s.d.StartWithError("--log-level=bogus"), check.NotNil, check.Commentf("Daemon shouldn't start with wrong log level"))
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -24,7 +24,7 @@ github.com/RackSec/srslog 456df3a81436d29ba874f3590eeeee25d666f8a5
 github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-github.com/docker/libnetwork f3c4ca8ce5c128e071bab198c4ed9fd0d08384eb
+github.com/docker/libnetwork ab8f7e61743aa7e54c5d0dad0551543adadc33cf
 github.com/docker/go-events 18b43f1bc85d9cdd42c05a6cd2d444c7a200a894
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/iptables/firewalld.go
+++ b/vendor/github.com/docker/libnetwork/iptables/firewalld.go
@@ -151,7 +151,6 @@ func checkRunning() bool {
 
 	if connection != nil {
 		err = connection.sysobj.Call(dbusInterface+".getDefaultZone", 0).Store(&zone)
-		logrus.Infof("Firewalld running: %t", err == nil)
 		return err == nil
 	}
 	return false

--- a/vendor/github.com/docker/libnetwork/osl/namespace_linux.go
+++ b/vendor/github.com/docker/libnetwork/osl/namespace_linux.go
@@ -222,9 +222,11 @@ func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error) {
 	}
 
 	// As starting point, disable IPv6 on all interfaces
-	err = setIPv6(n.path, "all", false)
-	if err != nil {
-		logrus.Warnf("Failed to disable IPv6 on all interfaces on network namespace %q: %v", n.path, err)
+	if !n.isDefault {
+		err = setIPv6(n.path, "all", false)
+		if err != nil {
+			logrus.Warnf("Failed to disable IPv6 on all interfaces on network namespace %q: %v", n.path, err)
+		}
 	}
 
 	if err = n.loopbackUp(); err != nil {


### PR DESCRIPTION
Fixes #32433
Fixes #31473

Fixes regression where running a container on network=host will disable ipv6 on the host.