### PR TITLE
Reset the positions for all readers of multireader before reading the data

### DIFF
--- a/pkg/ioutils/multireader.go
+++ b/pkg/ioutils/multireader.go
@@ -152,7 +152,8 @@ func (r *multiReadSeeker) getOffsetToReader(rdr io.ReadSeeker) (int64, error) {
 
 func (r *multiReadSeeker) Read(b []byte) (int, error) {
 	if r.pos == nil {
-		r.pos = &pos{0, 0}
+		// make sure all readers are at 0
+		r.Seek(0, os.SEEK_SET)
 	}
 
 	bLen := int64(len(b))

--- a/pkg/ioutils/multireader_test.go
+++ b/pkg/ioutils/multireader_test.go
@@ -55,6 +55,20 @@ func TestMultiReadSeekerReadAll(t *testing.T) {
 	if string(b) != expected {
 		t.Fatalf("ReadAll failed, got: %q, expected %q", string(b), expected)
 	}
+
+	// The positions of some readers are not 0
+	s1.Seek(0, os.SEEK_SET)
+	s2.Seek(0, os.SEEK_END)
+	s3.Seek(0, os.SEEK_SET)
+	mr = MultiReadSeeker(s1, s2, s3)
+	b, err = ioutil.ReadAll(mr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(b) != expected {
+		t.Fatalf("ReadAll failed, got: %q, expected %q", string(b), expected)
+	}
 }
 
 func TestMultiReadSeekerReadEach(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>

Some data will be losed when reading data via `multireader.read()`, if some readers in multireader are't at `0`.
