### PR TITLE
fix TestExecWithUserAfterLiveRestore

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2788,10 +2788,14 @@ func (s *DockerDaemonSuite) TestExecWithUserAfterLiveRestore(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	s.d.StartWithBusybox(c, "--live-restore")
 
-	out, err := s.d.Cmd("run", "-d", "--name=top", "busybox", "sh", "-c", "addgroup -S test && adduser -S -G test test -D -s /bin/sh && top")
+	out, err := s.d.Cmd("run", "-d", "--name=top", "busybox", "sh", "-c", "addgroup -S test && adduser -S -G test test -D -s /bin/sh && touch /adduser_end && top")
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
 
 	s.d.WaitRun("top")
+
+	// Wait for shell command to be completed
+	_, err = s.d.Cmd("exec", "top", "sh", "-c", `for i in $(seq 1 5); do if [ -e /adduser_end ]; then rm -f /adduser_end && break; else sleep 1 && false; fi; done`)
+	c.Assert(err, check.IsNil, check.Commentf("Timeout waiting for shell command to be completed"))
 
 	out1, err := s.d.Cmd("exec", "-u", "test", "top", "id")
 	// uid=100(test) gid=101(test) groups=101(test)


### PR DESCRIPTION
When container's status is running, shell command may have not
executed end. So if we use 'docker exec -u test' to execute
command, it may fail since user 'test' have not be added yet.

Signed-off-by: Fengtu Wang <wangfengtu@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Test case TestExecWithUserAfterLiveRestore failed in our jenkins, like:
```
----------------------------------------------------------------------
FAIL: docker_cli_daemon_test.go:2787: DockerDaemonSuite.TestExecWithUserAfterLiveRestore

[d3d00aa382f7f] waiting for daemon to start
[d3d00aa382f7f] daemon started

docker_cli_daemon_test.go:2798:
    // uid=100(test) gid=101(test) groups=101(test)
    c.Assert(err, check.IsNil, check.Commentf("Output: %s", out1))
... value *exec.ExitError = &exec.ExitError{ProcessState:(*os.ProcessState)(0xc42043a000), Stderr:[]uint8(nil)} ("exit status 126")
... Output: unable to find user test: no matching entries in passwd file
```
I think it's because shell command may have not be executed end when container's status is running.
I use following command to simulate the situation:
```
# docker run -d busybox sh -c 'sleep 1000 && addgroup -S test && adduser -S -G test test -D -s /bin/sh && top'
d161c908aba183472337b0d44053e638881d6dfaf9b6974a876ea4fd505a7644
# docker inspect -f '{{.State.Running}}' d161c908aba183472337b0d44053e638881d6dfaf9b6974a876ea4fd505a7644
true
# docker exec -u test d161c908aba183472337b0d44053e638881d6dfaf9b6974a876ea4fd505a7644 id
unable to find user test: no matching entries in passwd file
```
Or we can add some sleep at the begining of the shell, then this test case
will fail:
```
diff --git a/integration-cli/docker_cli_daemon_test.go b/integration-cli/docker_cli_daemon_test.go
index 53bc45e..f1fc5e7 100644
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2788,7 +2788,7 @@ func (s *DockerDaemonSuite) TestExecWithUserAfterLiveRestore(c *check.C) {
        testRequires(c, DaemonIsLinux)
        s.d.StartWithBusybox(c, "--live-restore")
 
-       out, err := s.d.Cmd("run", "-d", "--name=top", "busybox", "sh", "-c", "addgroup -S test && adduser -S -G test test -D -s /bin/sh && top")
+       out, err := s.d.Cmd("run", "-d", "--name=top", "busybox", "sh", "-c", "sleep 5 && addgroup -S test && adduser -S -G test test -D -s /bin/sh && top")
        c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
 
        s.d.WaitRun("top")
```
I try to correct it by this PR.

**- How I did it**
Wait until a file is created to ensure shell command is exectued end.  Please see code for detail.

**- How to verify it**
Run this test case many times and it have not failed again.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

