### PR TITLE
add status code 400 for update endpoints in swagger.yml

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7095,6 +7095,10 @@ paths:
       responses:
         200:
           description: "no error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "no such node"
           schema:
@@ -8201,6 +8205,10 @@ paths:
       responses:
         200:
           description: "no error"
+        400:
+          description: "bad parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         404:
           description: "no such secret"
           schema:


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I think in docker/master we should add status code 400 for endpoint node update and secret update.

First pic is for node update.
![wechatimg1](https://cloud.githubusercontent.com/assets/9465626/24850099/425df788-1e01-11e7-86de-429e353ed1a2.jpeg)
I test docker 1.12.x, 

Second pic is for secret update:
![wechatimg2](https://cloud.githubusercontent.com/assets/9465626/24850100/425e4616-1e01-11e7-8f29-931d45dd5cb8.jpeg)

**- What I did**
1. add status code 400 for endpoint `POST /node/{id}/update`;
2. add status code 400 for endpoint `POST /secret/{id}/update`;

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

