### PR TITLE
libcontainerd: remove fifos on docker exec failed

### DIFF
--- a/libcontainerd/client_linux.go
+++ b/libcontainerd/client_linux.go
@@ -117,6 +117,13 @@ func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendly
 		return -1, err
 	}
 
+	// clean up fifos if failed to add process
+	defer func() {
+		if err != nil {
+			p.cleanFifos(processFriendlyName)
+		}
+	}()
+
 	resp, err := clnt.remote.apiClient.AddProcess(ctx, r)
 	if err != nil {
 		p.closeFifos(iopipe)

--- a/libcontainerd/container_unix.go
+++ b/libcontainerd/container_unix.go
@@ -69,11 +69,7 @@ func (ctr *container) clean() error {
 // Caller needs to lock container ID before calling this method.
 func (ctr *container) cleanProcess(id string) {
 	if p, ok := ctr.processes[id]; ok {
-		for _, i := range []int{syscall.Stdin, syscall.Stdout, syscall.Stderr} {
-			if err := os.Remove(p.fifo(i)); err != nil && !os.IsNotExist(err) {
-				logrus.Warnf("libcontainerd: failed to remove %v for process %v: %v", p.fifo(i), id, err)
-			}
-		}
+		p.cleanFifos(id)
 	}
 	delete(ctr.processes, id)
 }

--- a/libcontainerd/process_unix.go
+++ b/libcontainerd/process_unix.go
@@ -9,7 +9,9 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"strings"
+	"syscall"
 
+	"github.com/Sirupsen/logrus"
 	containerd "github.com/containerd/containerd/api/grpc/types"
 	"github.com/tonistiigi/fifo"
 	"golang.org/x/net/context"
@@ -104,4 +106,13 @@ func (r emptyReader) Read(b []byte) (int, error) {
 
 func (p *process) fifo(index int) string {
 	return filepath.Join(p.dir, p.friendlyName+"-"+fdNames[index])
+}
+
+func (p *process) cleanFifos(id string) {
+	for _, i := range []int{syscall.Stdin, syscall.Stdout, syscall.Stderr} {
+		if err := os.Remove(p.fifo(i)); err != nil && !os.IsNotExist(err) {
+			logrus.Warnf("failed to remove %v for process %v: %v", p.fifo(i), id, err)
+		}
+	}
+
 }


### PR DESCRIPTION
if docker exec failed to start, the fifo for exec will
left on system.
```
[root@centos-220 bcc8bc6a080eb859ecd193dc32ea4e1cd0080b070afb2a0259b3ed004aae155e]# docker exec -ti bcc8bc6a080e bash
rpc error: code = 2 desc = oci runtime error: exec failed: container_linux.go:247: starting container process caused "exec: \"bash\": executable file not found in $PATH"

[root@centos-220 bcc8bc6a080eb859ecd193dc32ea4e1cd0080b070afb2a0259b3ed004aae155e]# ls -l
total 4
prwx------. 1 root root    0 Apr 10 11:29 46889b0713827f708949af4f6b30315181e1d96e75ce179c949935ab02db2bd1-stdin
prwx------. 1 root root    0 Apr 10 11:29 46889b0713827f708949af4f6b30315181e1d96e75ce179c949935ab02db2bd1-stdout
prwx------. 1 root root    0 Apr  6 13:15 4dfc9806a2aef53f72a5d2854ff235714b5f064d10e29b5e59ff67d48a924462-stdin
prwx------. 1 root root    0 Apr  6 13:15 4dfc9806a2aef53f72a5d2854ff235714b5f064d10e29b5e59ff67d48a924462-stdout
prwx------. 1 root root    0 Apr  6 13:15 cc3af6845394cc60007b49242acd990b28988ef4ddaaa217a26caba1075ab343-stdin
prwx------. 1 root root    0 Apr  6 13:15 cc3af6845394cc60007b49242acd990b28988ef4ddaaa217a26caba1075ab343-stdout
-rw-r--r--. 1 root root 3353 Apr  6 13:12 config.json
prwx------. 1 root root    0 Apr  6 13:14 d35e637104991052261e3afeba96a86b3cc6392dae6bd2226812407c0b92a20c-stdin
prwx------. 1 root root    0 Apr  6 13:14 d35e637104991052261e3afeba96a86b3cc6392dae6bd2226812407c0b92a20c-stdout
prwx------. 1 root root    0 Apr  6 13:12 init-stdin
prwx------. 1 root root    0 Apr  6 13:12 init-stdout
```

Signed-off-by: Lei Jitang <leijitang@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

ping @tonistiigi 