### PR TITLE
Fix missing Init Binary in docker info output

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -41,6 +41,8 @@ const (
 	DefaultNetworkMtu = 1500
 	// DisableNetworkBridge is the default value of the option to disable network bridge
 	DisableNetworkBridge = "none"
+	// DefaultInitBinary is the name of the default init binary
+	DefaultInitBinary = "docker-init"
 )
 
 // flatOptions contains configuration keys

--- a/daemon/config/config_common_unix.go
+++ b/daemon/config/config_common_unix.go
@@ -66,5 +66,8 @@ func (conf *Config) GetInitPath() string {
 	if conf.InitPath != "" {
 		return conf.InitPath
 	}
-	return conf.DefaultInitBinary
+	if conf.DefaultInitBinary != "" {
+		return conf.DefaultInitBinary
+	}
+	return DefaultInitBinary
 }

--- a/daemon/config/config_common_unix_test.go
+++ b/daemon/config/config_common_unix_test.go
@@ -41,3 +41,44 @@ func TestCommonUnixValidateConfigurationErrors(t *testing.T) {
 		}
 	}
 }
+
+func TestCommonUnixGetInitPath(t *testing.T) {
+	testCases := []struct {
+		config           *Config
+		expectedInitPath string
+	}{
+		{
+			config: &Config{
+				InitPath: "some-init-path",
+			},
+			expectedInitPath: "some-init-path",
+		},
+		{
+			config: &Config{
+				CommonUnixConfig: CommonUnixConfig{
+					DefaultInitBinary: "foo-init-bin",
+				},
+			},
+			expectedInitPath: "foo-init-bin",
+		},
+		{
+			config: &Config{
+				InitPath: "init-path-A",
+				CommonUnixConfig: CommonUnixConfig{
+					DefaultInitBinary: "init-path-B",
+				},
+			},
+			expectedInitPath: "init-path-A",
+		},
+		{
+			config:           &Config{},
+			expectedInitPath: "docker-init",
+		},
+	}
+	for _, tc := range testCases {
+		initPath := tc.config.GetInitPath()
+		if initPath != tc.expectedInitPath {
+			t.Fatalf("expected initPath to be %v, got %v", tc.expectedInitPath, initPath)
+		}
+	}
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -65,9 +65,6 @@ var (
 	// containerd if none is specified
 	DefaultRuntimeBinary = "docker-runc"
 
-	// DefaultInitBinary is the name of the default init binary
-	DefaultInitBinary = "docker-init"
-
 	errSystemNotSupported = errors.New("The Docker daemon is not supported on this platform.")
 )
 

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
+	daemonconfig "github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/pkg/errors"
@@ -55,15 +56,15 @@ func (daemon *Daemon) FillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) 
 		v.RuncCommit.ID = "N/A"
 	}
 
-	if rv, err := exec.Command(DefaultInitBinary, "--version").Output(); err == nil {
+	if rv, err := exec.Command(daemonconfig.DefaultInitBinary, "--version").Output(); err == nil {
 		ver, err := parseInitVersion(string(rv))
 
 		if err != nil {
-			logrus.Warnf("failed to retrieve %s version: %s", DefaultInitBinary, err)
+			logrus.Warnf("failed to retrieve %s version: %s", daemonconfig.DefaultInitBinary, err)
 		}
 		v.InitCommit = ver
 	} else {
-		logrus.Warnf("failed to retrieve %s version: %s", DefaultInitBinary, err)
+		logrus.Warnf("failed to retrieve %s version: %s", daemonconfig.DefaultInitBinary, err)
 		v.InitCommit.ID = "N/A"
 	}
 }

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -15,6 +15,7 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/caps"
+	daemonconfig "github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/oci"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/mount"
@@ -624,7 +625,7 @@ func (daemon *Daemon) populateCommonSpec(s *specs.Spec, c *container.Container) 
 			s.Process.Args = append([]string{"/dev/init", "--", c.Path}, c.Args...)
 			var path string
 			if daemon.configStore.InitPath == "" && c.HostConfig.InitPath == "" {
-				path, err = exec.LookPath(DefaultInitBinary)
+				path, err = exec.LookPath(daemonconfig.DefaultInitBinary)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
- Moved DefaultInitBinary from daemon/daemon.go to
daemon/config/config.go since it's a daemon config and is referred in
config package files.
- Added condition in GetInitPath to check for any explicitly configured
DefaultInitBinary. If not, the default value of DefaultInitBinary is
returned.
- Changed all references of DefaultInitBinary to refer to the variable
from new location.
- Added TestCommonUnixGetInitPath to test for the values of
DefaultInitBinary.

Fixes #32314

Signed-off-by: Sunny Gogoi <indiasuny000@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added the missing Init Binary info in `docker info` output.

**- How I did it**

Details are in commit body.

**- How to verify it**

Verify by running `docker info` and checking the value of `Init Binary` in the output.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix missing Init Binary in docker info output.

**- A picture of a cute animal (not mandatory but encouraged)**

![cute animal](https://img0.etsystatic.com/005/0/6220876/il_570xN.373873960_2exh.jpg)