### PR TITLE
[test-integration] Move FakeContext to `integration-cli/cli/build/fakecontext` package…

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	cliconfig "github.com/docker/docker/cli/config"
 	"github.com/docker/docker/integration-cli/cli"
+	"github.com/docker/docker/integration-cli/cli/build/fakestorage"
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/integration-cli/environment"
 	"github.com/docker/docker/integration-cli/registry"
@@ -65,6 +66,7 @@ func TestMain(m *testing.M) {
 
 func Test(t *testing.T) {
 	cli.EnsureTestEnvIsLoaded(t)
+	fakestorage.EnsureTestEnvIsLoaded(t)
 	cmd := exec.Command(dockerBinary, "images", "-f", "dangling=false", "--format", "{{.Repository}}:{{.Tag}}")
 	cmd.Env = appendBaseEnv(true)
 	out, err := cmd.CombinedOutput()

--- a/integration-cli/cli/build/build.go
+++ b/integration-cli/cli/build/build.go
@@ -1,10 +1,29 @@
 package build
 
 import (
+	"io"
 	"strings"
 
+	"github.com/docker/docker/integration-cli/cli/build/fakecontext"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 )
+
+type testingT interface {
+	Fatal(args ...interface{})
+	Fatalf(string, ...interface{})
+}
+
+// WithStdinContext sets the build context from the standard input with the specified reader
+func WithStdinContext(closer io.ReadCloser) func(*icmd.Cmd) func() {
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Command = append(cmd.Command, "-")
+		cmd.Stdin = closer
+		return func() {
+			// FIXME(vdemeester) we should not ignore the error here…
+			closer.Close()
+		}
+	}
+}
 
 // WithDockerfile creates / returns a CmdOperator to set the Dockerfile for a build operation
 func WithDockerfile(dockerfile string) func(*icmd.Cmd) func() {
@@ -26,5 +45,38 @@ func WithContextPath(path string) func(*icmd.Cmd) func() {
 	return func(cmd *icmd.Cmd) func() {
 		cmd.Command = append(cmd.Command, path)
 		return nil
+	}
+}
+
+// WithExternalBuildContext use the specified context as build context
+func WithExternalBuildContext(ctx *fakecontext.Fake) func(*icmd.Cmd) func() {
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Dir = ctx.Dir
+		cmd.Command = append(cmd.Command, ".")
+		return nil
+	}
+}
+
+// WithBuildContext sets up the build context
+func WithBuildContext(t testingT, contextOperators ...func(*fakecontext.Fake) error) func(*icmd.Cmd) func() {
+	// FIXME(vdemeester) de-duplicate that
+	ctx := fakecontext.New(t, "", contextOperators...)
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Dir = ctx.Dir
+		cmd.Command = append(cmd.Command, ".")
+		return closeBuildContext(t, ctx)
+	}
+}
+
+// WithFile adds the specified file (with content) in the build context
+func WithFile(name, content string) func(*fakecontext.Fake) error {
+	return fakecontext.WithFile(name, content)
+}
+
+func closeBuildContext(t testingT, ctx *fakecontext.Fake) func() {
+	return func() {
+		if err := ctx.Close(); err != nil {
+			t.Fatal(err)
+		}
 	}
 }

--- a/integration-cli/cli/build/fakecontext/context.go
+++ b/integration-cli/cli/build/fakecontext/context.go
@@ -1,0 +1,112 @@
+package fakecontext
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+type testingT interface {
+	Fatal(args ...interface{})
+	Fatalf(string, ...interface{})
+}
+
+// New creates a fake build context
+func New(t testingT, dir string, modifiers ...func(*Fake) error) *Fake {
+	fakeContext := &Fake{Dir: dir}
+	if dir == "" {
+		if err := newDir(fakeContext); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, modifier := range modifiers {
+		if err := modifier(fakeContext); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return fakeContext
+}
+
+func newDir(fake *Fake) error {
+	tmp, err := ioutil.TempDir("", "fake-context")
+	if err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp, 0755); err != nil {
+		return err
+	}
+	fake.Dir = tmp
+	return nil
+}
+
+// WithFile adds the specified file (with content) in the build context
+func WithFile(name, content string) func(*Fake) error {
+	return func(ctx *Fake) error {
+		return ctx.Add(name, content)
+	}
+}
+
+// WithDockerfile adds the specified content as Dockerfile in the build context
+func WithDockerfile(content string) func(*Fake) error {
+	return WithFile("Dockerfile", content)
+}
+
+// WithFiles adds the specified files in the build context, content is a string
+func WithFiles(files map[string]string) func(*Fake) error {
+	return func(fakeContext *Fake) error {
+		for file, content := range files {
+			if err := fakeContext.Add(file, content); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// WithBinaryFiles adds the specified files in the build context, content is binary
+func WithBinaryFiles(files map[string]*bytes.Buffer) func(*Fake) error {
+	return func(fakeContext *Fake) error {
+		for file, content := range files {
+			if err := fakeContext.Add(file, string(content.Bytes())); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// Fake creates directories that can be used as a build context
+type Fake struct {
+	Dir string
+}
+
+// Add a file at a path, creating directories where necessary
+func (f *Fake) Add(file, content string) error {
+	return f.addFile(file, []byte(content))
+}
+
+func (f *Fake) addFile(file string, content []byte) error {
+	fp := filepath.Join(f.Dir, filepath.FromSlash(file))
+	dirpath := filepath.Dir(fp)
+	if dirpath != "." {
+		if err := os.MkdirAll(dirpath, 0755); err != nil {
+			return err
+		}
+	}
+	return ioutil.WriteFile(fp, content, 0644)
+
+}
+
+// Delete a file at a path
+func (f *Fake) Delete(file string) error {
+	fp := filepath.Join(f.Dir, filepath.FromSlash(file))
+	return os.RemoveAll(fp)
+}
+
+// Close deletes the context
+func (f *Fake) Close() error {
+	return os.RemoveAll(f.Dir)
+}

--- a/integration-cli/cli/build/fakestorage/fixtures.go
+++ b/integration-cli/cli/build/fakestorage/fixtures.go
@@ -1,4 +1,4 @@
-package main
+package fakestorage
 
 import (
 	"io/ioutil"
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sync"
+
+	"github.com/docker/docker/integration-cli/cli"
 )
 
 var ensureHTTPServerOnce sync.Once
@@ -61,7 +63,5 @@ func ensureHTTPServerImage(t testingT) {
 		t.Fatalf("could not build http server: %v", string(out))
 	}
 
-	if out, err = exec.Command(dockerBinary, "build", "-q", "-t", "httpserver", tmp).CombinedOutput(); err != nil {
-		t.Fatalf("could not build http server: %v", string(out))
-	}
+	cli.DockerCmd(t, "build", "-q", "-t", "httpserver", tmp)
 }

--- a/integration-cli/cli/build/fakestorage/storage.go
+++ b/integration-cli/cli/build/fakestorage/storage.go
@@ -1,0 +1,176 @@
+package fakestorage
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/docker/docker/integration-cli/cli"
+	"github.com/docker/docker/integration-cli/cli/build"
+	"github.com/docker/docker/integration-cli/cli/build/fakecontext"
+	"github.com/docker/docker/integration-cli/environment"
+	"github.com/docker/docker/integration-cli/request"
+	"github.com/docker/docker/pkg/stringutils"
+)
+
+var (
+	testEnv  *environment.Execution
+	onlyOnce sync.Once
+)
+
+// EnsureTestEnvIsLoaded make sure the test environment is loaded for this package
+func EnsureTestEnvIsLoaded(t testingT) {
+	var doIt bool
+	var err error
+	onlyOnce.Do(func() {
+		doIt = true
+	})
+
+	if !doIt {
+		return
+	}
+	testEnv, err = environment.New()
+	if err != nil {
+		t.Fatalf("error loading testenv : %v", err)
+	}
+}
+
+type testingT interface {
+	logT
+	Fatal(args ...interface{})
+	Fatalf(string, ...interface{})
+}
+
+type logT interface {
+	Logf(string, ...interface{})
+}
+
+// Fake is a static file server. It might be running locally or remotely
+// on test host.
+type Fake interface {
+	Close() error
+	URL() string
+	CtxDir() string
+}
+
+// New returns a static file server that will be use as build context.
+func New(t testingT, dir string, modifiers ...func(*fakecontext.Fake) error) Fake {
+	ctx := fakecontext.New(t, dir, modifiers...)
+	if testEnv.LocalDaemon() {
+		return newLocalFakeStorage(t, ctx)
+	}
+	return newRemoteFileServer(t, ctx)
+}
+
+// localFileStorage is a file storage on the running machine
+type localFileStorage struct {
+	*fakecontext.Fake
+	*httptest.Server
+}
+
+func (s *localFileStorage) URL() string {
+	return s.Server.URL
+}
+
+func (s *localFileStorage) CtxDir() string {
+	return s.Fake.Dir
+}
+
+func (s *localFileStorage) Close() error {
+	defer s.Server.Close()
+	return s.Fake.Close()
+}
+
+func newLocalFakeStorage(t testingT, ctx *fakecontext.Fake) *localFileStorage {
+	handler := http.FileServer(http.Dir(ctx.Dir))
+	server := httptest.NewServer(handler)
+	return &localFileStorage{
+		Fake:   ctx,
+		Server: server,
+	}
+}
+
+// remoteFileServer is a containerized static file server started on the remote
+// testing machine to be used in URL-accepting docker build functionality.
+type remoteFileServer struct {
+	host      string // hostname/port web server is listening to on docker host e.g. 0.0.0.0:43712
+	container string
+	image     string
+	ctx       *fakecontext.Fake
+}
+
+func (f *remoteFileServer) URL() string {
+	u := url.URL{
+		Scheme: "http",
+		Host:   f.host}
+	return u.String()
+}
+
+func (f *remoteFileServer) CtxDir() string {
+	return f.ctx.Dir
+}
+
+func (f *remoteFileServer) Close() error {
+	defer func() {
+		if f.ctx != nil {
+			f.ctx.Close()
+		}
+		if f.image != "" {
+			if err := cli.Docker(cli.Args("rmi", "-f", f.image)).Error; err != nil {
+				fmt.Fprintf(os.Stderr, "Error closing remote file server : %v\n", err)
+			}
+		}
+	}()
+	if f.container == "" {
+		return nil
+	}
+	return cli.Docker(cli.Args("rm", "-fv", f.container)).Error
+}
+
+func newRemoteFileServer(t testingT, ctx *fakecontext.Fake) *remoteFileServer {
+	var (
+		image     = fmt.Sprintf("fileserver-img-%s", strings.ToLower(stringutils.GenerateRandomAlphaOnlyString(10)))
+		container = fmt.Sprintf("fileserver-cnt-%s", strings.ToLower(stringutils.GenerateRandomAlphaOnlyString(10)))
+	)
+
+	ensureHTTPServerImage(t)
+
+	// Build the image
+	if err := ctx.Add("Dockerfile", `FROM httpserver
+COPY . /static`); err != nil {
+		t.Fatal(err)
+	}
+	cli.BuildCmd(t, image, build.WithoutCache, build.WithExternalBuildContext(ctx))
+
+	// Start the container
+	cli.DockerCmd(t, "run", "-d", "-P", "--name", container, image)
+
+	// Find out the system assigned port
+	out := cli.DockerCmd(t, "port", container, "80/tcp").Combined()
+	fileserverHostPort := strings.Trim(out, "\n")
+	_, port, err := net.SplitHostPort(fileserverHostPort)
+	if err != nil {
+		t.Fatalf("unable to parse file server host:port: %v", err)
+	}
+
+	dockerHostURL, err := url.Parse(request.DaemonHost())
+	if err != nil {
+		t.Fatalf("unable to parse daemon host URL: %v", err)
+	}
+
+	host, _, err := net.SplitHostPort(dockerHostURL.Host)
+	if err != nil {
+		t.Fatalf("unable to parse docker daemon host:port: %v", err)
+	}
+
+	return &remoteFileServer{
+		container: container,
+		image:     image,
+		host:      fmt.Sprintf("%s:%s", host, port),
+		ctx:       ctx}
+}

--- a/integration-cli/cli/cli.go
+++ b/integration-cli/cli/cli.go
@@ -39,6 +39,7 @@ func EnsureTestEnvIsLoaded(t testingT) {
 type CmdOperator func(*icmd.Cmd) func()
 
 type testingT interface {
+	Fatal(args ...interface{})
 	Fatalf(string, ...interface{})
 }
 

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli/build/fakecontext"
+	"github.com/docker/docker/integration-cli/cli/build/fakestorage"
 	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/pkg/testutil"
 	"github.com/go-check/check"
@@ -29,7 +31,7 @@ COPY * /tmp/
 RUN find / -xdev -name ba*
 RUN find /tmp/`
 	}
-	server := fakeStorage(c, map[string]string{"testD": testD})
+	server := fakestorage.New(c, "", fakecontext.WithFiles(map[string]string{"testD": testD}))
 	defer server.Close()
 
 	res, body, err := request.Post("/build?dockerfile=baz&remote="+server.URL()+"/testD", request.JSON)
@@ -66,9 +68,9 @@ func (s *DockerSuite) TestBuildAPIRemoteTarballContext(c *check.C) {
 	// failed to close tar archive
 	c.Assert(tw.Close(), checker.IsNil)
 
-	server := fakeBinaryStorage(c, map[string]*bytes.Buffer{
+	server := fakestorage.New(c, "", fakecontext.WithBinaryFiles(map[string]*bytes.Buffer{
 		"testT.tar": buffer,
-	})
+	}))
 	defer server.Close()
 
 	res, b, err := request.Post("/build?remote="+server.URL()+"/testT.tar", request.ContentType("application/tar"))
@@ -113,9 +115,9 @@ RUN echo 'right'
 	// failed to close tar archive
 	c.Assert(tw.Close(), checker.IsNil)
 
-	server := fakeBinaryStorage(c, map[string]*bytes.Buffer{
+	server := fakestorage.New(c, "", fakecontext.WithBinaryFiles(map[string]*bytes.Buffer{
 		"testT.tar": buffer,
-	})
+	}))
 	defer server.Close()
 
 	url := "/build?dockerfile=custom&remote=" + server.URL() + "/testT.tar"

--- a/integration-cli/trust_server_test.go
+++ b/integration-cli/trust_server_test.go
@@ -190,12 +190,6 @@ func (t *testNotary) Close() {
 	os.RemoveAll(t.dir)
 }
 
-// Deprecated: used trustedCmd instead
-func trustedExecCmd(cmd *exec.Cmd) {
-	pwd := "12345678"
-	cmd.Env = append(cmd.Env, trustEnv(notaryURL, pwd, pwd)...)
-}
-
 func trustedCmd(cmd *icmd.Cmd) {
 	pwd := "12345678"
 	cmd.Env = append(cmd.Env, trustEnv(notaryURL, pwd, pwd)...)


### PR DESCRIPTION
… and continue emptying `docker_utils_test.go` from build related function. Cleans some more stuff in `docker_utils_test.go` and move them in specific `integration-cli` packages.

/cc @icecrime @vieux @thaJeztah @dnephin @tonistiigi @aaronlehmann 

Part of #31410

🦁

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
