### PR TITLE
Do not error out on serv bind deactivation if no sbox is found

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -1072,7 +1072,9 @@ func (daemon *Daemon) DeactivateContainerServiceBinding(containerName string) er
 	}
 	sb := daemon.getNetworkSandbox(container)
 	if sb == nil {
-		return fmt.Errorf("network sandbox does not exist for container %s", containerName)
+		// If the network sandbox is not found, then there is nothing to deactivate
+		logrus.Debugf("Could not find network sandbox for container %s on service binding deactivation request", containerName)
+		return nil
 	}
 	return sb.DisableService()
 }


### PR DESCRIPTION
- If the nw sbox is not there, then there is nothing to deactivate.
- This will silence unnecessary error/warning logs which divert the attention from the problem root cause