### PR TITLE
Increase health check timeout for TestAPISwarmServicesUpdateStartFirst

### DIFF
--- a/integration-cli/docker_api_swarm_service_test.go
+++ b/integration-cli/docker_api_swarm_service_test.go
@@ -196,7 +196,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesUpdateStartFirst(c *check.C) {
 	// service started from this image won't pass health check
 	_, _, err := d.BuildImageWithOut(image2,
 		`FROM busybox
-		HEALTHCHECK --interval=1s --timeout=1s --retries=1024\
+		HEALTHCHECK --interval=1s --timeout=30s --retries=1024 \
 		  CMD cat /status`,
 		true)
 	c.Check(err, check.IsNil)


### PR DESCRIPTION
For some reason, the health check (catting a file) consistently takes longer than 1s to run on a slow ARM CI machine. Increase the timeout so the test can succeed.