### PR TITLE
Update gitdm domain-map

### DIFF
--- a/contrib/gitdm/domain-map
+++ b/contrib/gitdm/domain-map
@@ -23,7 +23,14 @@ github@hollensbe.org            Docker      < 2015-01-01
 github@hollensbe.org            Cisco
 
 david.calavera@gmail.com        Docker      < 2016-04-01
-david.calavera@gmail.com        Netlify
+david.calavera@gmail.com        (Unknown)
+
+madhu@socketplane.io            Docker
+ejhazlett@gmail.com             Docker
+ben@firshman.co.uk              Docker
+
+vincent@sbr.pm                  (Unknown)   < 2016-10-24
+vincent@sbr.pm                  Docker
 
 #
 # Others
@@ -37,3 +44,4 @@ microsoft.com                   Microsoft
 
 redhat.com                      Red Hat
 mrunalp@gmail.com               Red Hat
+antonio.murdaca@gmail.com       Red Hat


### PR DESCRIPTION
Signed-off-by: Arnaud Porterie (icecrime) <arnaud.porterie@docker.com>
