### PR TITLE
Small build client cleanup handling `-`

### DIFF
--- a/cli/command/image/build/context.go
+++ b/cli/command/image/build/context.go
@@ -143,7 +143,7 @@ func GetContextFromGitURL(gitURL, dockerfileName string) (string, string, error)
 		return "", "", errors.Wrapf(err, "unable to 'git clone' to temporary context directory")
 	}
 
-	absContextDir, err = resolveAndValidateContextPath(absContextDir)
+	absContextDir, err = ResolveAndValidateContextPath(absContextDir)
 	if err != nil {
 		return "", "", err
 	}
@@ -173,7 +173,7 @@ func GetContextFromURL(out io.Writer, remoteURL, dockerfileName string) (io.Read
 // the relative path of the dockerfile in that context directory, and a non-nil
 // error on success.
 func GetContextFromLocalDir(localDir, dockerfileName string) (string, string, error) {
-	localDir, err := resolveAndValidateContextPath(localDir)
+	localDir, err := ResolveAndValidateContextPath(localDir)
 	if err != nil {
 		return "", "", err
 	}
@@ -191,9 +191,9 @@ func GetContextFromLocalDir(localDir, dockerfileName string) (string, string, er
 	return localDir, relDockerfile, err
 }
 
-// resolveAndValidateContextPath uses the given context directory for a `docker build`
+// ResolveAndValidateContextPath uses the given context directory for a `docker build`
 // and returns the absolute path to the context directory.
-func resolveAndValidateContextPath(givenContextDir string) (string, error) {
+func ResolveAndValidateContextPath(givenContextDir string) (string, error) {
 	absContextDir, err := filepath.Abs(givenContextDir)
 	if err != nil {
 		return "", errors.Errorf("unable to get absolute context directory of given context directory %q: %v", givenContextDir, err)

--- a/cli/command/image/build/dockerignore.go
+++ b/cli/command/image/build/dockerignore.go
@@ -1,0 +1,39 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/builder/dockerignore"
+	"github.com/docker/docker/pkg/fileutils"
+)
+
+// ReadDockerignore reads the .dockerignore file in the context directory and
+// returns the list of paths to exclude
+func ReadDockerignore(contextDir string) ([]string, error) {
+	var excludes []string
+
+	f, err := os.Open(filepath.Join(contextDir, ".dockerignore"))
+	switch {
+	case os.IsNotExist(err):
+		return excludes, nil
+	case err != nil:
+		return nil, err
+	}
+	defer f.Close()
+
+	return dockerignore.ReadAll(f)
+}
+
+// TrimBuildFilesFromExcludes removes the named Dockerfile and .dockerignore from
+// the list of excluded files. The daemon will remove them from the final context
+// but they must be in available in the context when passed to the API.
+func TrimBuildFilesFromExcludes(excludes []string, dockerfile string, dockerfileFromStdin bool) []string {
+	if keep, _ := fileutils.Matches(".dockerignore", excludes); keep {
+		excludes = append(excludes, "!.dockerignore")
+	}
+	if keep, _ := fileutils.Matches(dockerfile, excludes); keep && !dockerfileFromStdin {
+		excludes = append(excludes, "!"+dockerfile)
+	}
+	return excludes
+}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -3689,7 +3689,7 @@ func (s *DockerSuite) TestBuildRenamedDockerfile(c *check.C) {
 	}
 	cli.Docker(cli.Args("build", fmt.Sprintf("--file=%s", nonDockerfileFile), "-t", "test5", "."), cli.InDir(ctx.Dir)).Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err:      fmt.Sprintf("The Dockerfile (%s) must be within the build context (.)", nonDockerfileFile),
+		Err:      fmt.Sprintf("the Dockerfile (%s) must be within the build context", nonDockerfileFile),
 	})
 
 	cli.Docker(cli.Args("build", "-f", filepath.Join("..", "Dockerfile"), "-t", "test6", ".."), cli.InDir(filepath.Join(ctx.Dir, "files"))).Assert(c, icmd.Expected{


### PR DESCRIPTION
Some small improvements I made while I was working on #31236. 

* create some helpers for checking if an option is "from stdin"
* split `getDockerfileRelPath()` into two functions, one for validating the Dockerfile, and one for validating the context path
* short circuit `getDockerfileRelPath()` when the dockerfile is from stdin, since there is no relative path