### PR TITLE
builder: add an option for specifying build target

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -56,6 +56,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	options.ExtraHosts = r.Form["extrahosts"]
 	options.SecurityOpt = r.Form["securityopt"]
 	options.Squash = httputils.BoolValue(r, "squash")
+	options.Target = r.FormValue("target")
 
 	if r.Form.Get("shmsize") != "" {
 		shmSize, err := strconv.ParseInt(r.Form.Get("shmsize"), 10, 64)

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -176,6 +176,7 @@ type ImageBuildOptions struct {
 	CacheFrom   []string
 	SecurityOpt []string
 	ExtraHosts  []string // List of extra hosts
+	Target      string
 }
 
 // ImageBuildResponse holds information

--- a/builder/dockerfile/imagecontext.go
+++ b/builder/dockerfile/imagecontext.go
@@ -15,10 +15,11 @@ import (
 // imageContexts is a helper for stacking up built image rootfs and reusing
 // them as contexts
 type imageContexts struct {
-	b      *Builder
-	list   []*imageMount
-	byName map[string]*imageMount
-	cache  *pathCache
+	b           *Builder
+	list        []*imageMount
+	byName      map[string]*imageMount
+	cache       *pathCache
+	currentName string
 }
 
 func (ic *imageContexts) new(name string, increment bool) (*imageMount, error) {
@@ -35,6 +36,7 @@ func (ic *imageContexts) new(name string, increment bool) (*imageMount, error) {
 	if increment {
 		ic.list = append(ic.list, im)
 	}
+	ic.currentName = name
 	return im, nil
 }
 
@@ -86,6 +88,13 @@ func (ic *imageContexts) unmount() (retErr error) {
 		}
 	}
 	return
+}
+
+func (ic *imageContexts) isCurrentTarget(target string) bool {
+	if target == "" {
+		return false
+	}
+	return strings.EqualFold(ic.currentName, target)
 }
 
 func (ic *imageContexts) getCache(id, path string) (interface{}, bool) {

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -64,6 +64,7 @@ type buildOptions struct {
 	securityOpt    []string
 	networkMode    string
 	squash         bool
+	target         string
 }
 
 // NewBuildCommand creates a new `docker build` command
@@ -115,6 +116,7 @@ func NewBuildCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.StringVar(&options.networkMode, "network", "default", "Set the networking mode for the RUN instructions during build")
 	flags.SetAnnotation("network", "version", []string{"1.25"})
 	flags.Var(&options.extraHosts, "add-host", "Add a custom host-to-IP mapping (host:ip)")
+	flags.StringVar(&options.target, "target", "", "Set the target build stage to build.")
 
 	command.AddTrustVerificationFlags(flags)
 
@@ -302,6 +304,7 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 		NetworkMode:    options.networkMode,
 		Squash:         options.squash,
 		ExtraHosts:     options.extraHosts.GetAll(),
+		Target:         options.target,
 	}
 
 	response, err := dockerCli.Client().ImageBuild(ctx, body, buildOptions)

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -95,6 +95,7 @@ func (cli *Client) imageBuildOptionsToQuery(options types.ImageBuildOptions) (ur
 	query.Set("cgroupparent", options.CgroupParent)
 	query.Set("shmsize", strconv.FormatInt(options.ShmSize, 10))
 	query.Set("dockerfile", options.Dockerfile)
+	query.Set("target", options.Target)
 
 	ulimitsJSON, err := json.Marshal(options.Ulimits)
 	if err != nil {


### PR DESCRIPTION
fixes #32104

This is a first pass of `docker build --target` that lets you specify an intermediate build stage that you wish to build/tag instead of the last one. The stages are still executed sequentially and only skipped from the end of the file if possible. Skipping other stages that do not have dependencies should be a future optimization that doesn't change the UI(cc @AkihiroSuda).

@dnephin @vdemeester 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>