### PR TITLE
Add pids-limit support in docker update

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -460,9 +460,10 @@ definitions:
         type: "boolean"
         x-nullable: true
       PidsLimit:
-        description: "Tune a container's pids limit. Set -1 for unlimited."
+        description: "Tune a container's pids limit. Set 0 or -1 for unlimited. Leave null to not change"
         type: "integer"
         format: "int64"
+        x-nullable: true
       Ulimits:
         description: |
           A list of resource limits to set in the container. For example: `{"Name": "nofile", "Soft": 1024, "Hard": 2048}`"
@@ -3689,6 +3690,10 @@ definitions:
           See [cpuset(7)](https://www.kernel.org/doc/Documentation/cgroup-v1/cpusets.txt)
         type: "boolean"
         example: true
+      PidsLimit:
+        description: "Indicates if the host kernel has PID limit support enabled."
+        type: "boolean"
+        example: true
       OomKillDisable:
         description: "Indicates if OOM killer disable is supported on the host."
         type: "boolean"
@@ -4625,7 +4630,7 @@ paths:
                 OomKillDisable: false
                 OomScoreAdj: 500
                 PidMode: ""
-                PidsLimit: -1
+                PidsLimit: 0
                 PortBindings:
                   22/tcp:
                     - HostPort: "11022"

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -334,7 +334,7 @@ type Resources struct {
 	MemorySwap           int64           // Total memory usage (memory + swap); set `-1` to enable unlimited swap
 	MemorySwappiness     *int64          // Tuning container memory swappiness behaviour
 	OomKillDisable       *bool           // Whether to disable OOM Killer or not
-	PidsLimit            int64           // Setting pids limit for a container
+	PidsLimit            *int64          // Setting pids limit for a container
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
 
 	// Applicable to Windows

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -164,6 +164,7 @@ type Info struct {
 	CPUCfsQuota        bool `json:"CpuCfsQuota"`
 	CPUShares          bool
 	CPUSet             bool
+	PidsLimit          bool
 	IPv4Forwarding     bool
 	BridgeNfIptables   bool
 	BridgeNfIP6tables  bool `json:"BridgeNfIp6tables"`

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -342,6 +342,9 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 	if resources.CPURealtimeRuntime != 0 {
 		cResources.CPURealtimeRuntime = resources.CPURealtimeRuntime
 	}
+	if resources.PidsLimit != nil {
+		cResources.PidsLimit = resources.PidsLimit
+	}
 
 	// update HostConfig of container
 	if hostConfig.RestartPolicy.Name != "" {

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -159,7 +159,7 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 		resources.MemorySwap != 0 ||
 		resources.MemorySwappiness != nil ||
 		resources.OomKillDisable != nil ||
-		resources.PidsLimit != 0 ||
+		(resources.PidsLimit != nil && *resources.PidsLimit != 0) ||
 		len(resources.Ulimits) != 0 ||
 		resources.CPUCount != 0 ||
 		resources.CPUPercent != 0 ||

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -181,7 +181,7 @@ func verifyPlatformContainerResources(resources *containertypes.Resources, isHyp
 	if resources.OomKillDisable != nil && *resources.OomKillDisable {
 		return warnings, fmt.Errorf("invalid option: Windows does not support OomKillDisable")
 	}
-	if resources.PidsLimit != 0 {
+	if resources.PidsLimit != nil && *resources.PidsLimit != 0 {
 		return warnings, fmt.Errorf("invalid option: Windows does not support PidsLimit")
 	}
 	if len(resources.Ulimits) != 0 {

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -27,6 +27,7 @@ func (daemon *Daemon) fillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) 
 	v.CPUCfsQuota = sysInfo.CPUCfsQuota
 	v.CPUShares = sysInfo.CPUShares
 	v.CPUSet = sysInfo.Cpuset
+	v.PidsLimit = sysInfo.PidsLimit
 	v.Runtimes = daemon.configStore.GetAllRuntimes()
 	v.DefaultRuntime = daemon.configStore.GetDefaultRuntimeName()
 	v.InitBinary = daemon.configStore.GetInitPath()

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -72,9 +72,7 @@ func setResources(s *specs.Spec, r containertypes.Resources) error {
 			ThrottleReadIOPSDevice:  readIOpsDevice,
 			ThrottleWriteIOPSDevice: writeIOpsDevice,
 		},
-		Pids: &specs.LinuxPids{
-			Limit: r.PidsLimit,
-		},
+		Pids: getPidsLimit(r),
 	}
 
 	if s.Linux.Resources != nil && len(s.Linux.Resources.Devices) > 0 {

--- a/daemon/update_linux.go
+++ b/daemon/update_linux.go
@@ -50,5 +50,6 @@ func toContainerdResources(resources container.Resources) *libcontainerd.Resourc
 		r.Memory.Swap = &resources.MemorySwap
 	}
 
+	r.Pids = getPidsLimit(resources)
 	return &r
 }

--- a/integration/container/update_linux_test.go
+++ b/integration/container/update_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/assert"
@@ -99,5 +100,69 @@ func TestUpdateCPUQuota(t *testing.T) {
 		assert.Equal(t, 0, res.ExitCode)
 
 		assert.Check(t, is.Equal(strconv.FormatInt(test.update, 10), strings.TrimSpace(res.Stdout())))
+	}
+}
+
+func TestUpdatePidsLimit(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	skip.If(t, !testEnv.DaemonInfo.PidsLimit)
+
+	defer setupTest(t)()
+	client := testEnv.APIClient()
+	ctx := context.Background()
+
+	cID := container.Run(t, ctx, client)
+
+	intPtr := func(i int64) *int64 {
+		return &i
+	}
+
+	for _, test := range []struct {
+		desc     string
+		update   *int64
+		expect   int64
+		expectCg string
+	}{
+		{desc: "update from none", update: intPtr(32), expect: 32, expectCg: "32"},
+		{desc: "no change", update: nil, expectCg: "32"},
+		{desc: "update lower", update: intPtr(16), expect: 16, expectCg: "16"},
+		{desc: "unset limit", update: intPtr(0), expect: 0, expectCg: "max"},
+	} {
+		var before types.ContainerJSON
+		if test.update == nil {
+			var err error
+			before, err = client.ContainerInspect(ctx, cID)
+			assert.NilError(t, err)
+		}
+
+		t.Run(test.desc, func(t *testing.T) {
+			_, err := client.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
+				Resources: containertypes.Resources{
+					PidsLimit: test.update,
+				},
+			})
+			assert.NilError(t, err)
+
+			inspect, err := client.ContainerInspect(ctx, cID)
+			assert.NilError(t, err)
+			assert.Assert(t, inspect.HostConfig.Resources.PidsLimit != nil)
+
+			if test.update == nil {
+				assert.Assert(t, before.HostConfig.Resources.PidsLimit != nil)
+				assert.Equal(t, *before.HostConfig.Resources.PidsLimit, *inspect.HostConfig.Resources.PidsLimit)
+			} else {
+				assert.Equal(t, *inspect.HostConfig.Resources.PidsLimit, test.expect)
+			}
+
+			ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+			defer cancel()
+
+			res, err := container.Exec(ctx, client, cID, []string{"cat", "/sys/fs/cgroup/pids/pids.max"})
+			assert.NilError(t, err)
+			assert.Assert(t, is.Len(res.Stderr(), 0))
+
+			out := strings.TrimSpace(res.Stdout())
+			assert.Equal(t, out, test.expectCg)
+		})
 	}
 }


### PR DESCRIPTION
- Added a new flag `--pids-limit` in `docker update` command.
- Value of the `pidsLimit` flag variable is set as `PidsLimit` in
`containertypes.Resources`, which is used to apply the update in
hostConfig and the real world (running containers).
- Added `TestUpdatePIDsLimit` integration test for the new flag.

Fixes #32443

Signed-off-by: Sunny Gogoi <indiasuny000@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added a new flag, `--pids-limit` , in the command `docker update`.

**- How I did it**

Details are in commit body.

**- How to verify it**

Verify by starting a container with `--pids-limit=4` and then updating pids-limit of the container
to a new value with `docker update --pids-limit=<newValue> <containerName>`.
Once updated, the result can be seen in `docker inspect <containerName>` and in the file
`/sys/fs/cgroup/pids/pids.max` within the container.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add pids-limit support in docker update

**- A picture of a cute animal (not mandatory but encouraged)**

![cute animal](https://s-media-cache-ak0.pinimg.com/736x/fd/48/67/fd48674fda8c9054ec1a766a5d896b9e--no-drama-baby-llama.jpg)