### PR TITLE
Vendor package update github.com/mattn/go-shellwords

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -10,7 +10,7 @@ github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://githu
 github.com/gorilla/context v1.1
 github.com/gorilla/mux v1.1
 github.com/kr/pty 5cf931ef8f
-github.com/mattn/go-shellwords v1.0.0
+github.com/mattn/go-shellwords v1.0.3
 github.com/tchap/go-patricia v2.2.6
 github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 # forked golang.org/x/net package includes a patch for lazy loading trace templates

--- a/vendor/github.com/mattn/go-shellwords/LICENSE
+++ b/vendor/github.com/mattn/go-shellwords/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Yasuhiro Matsumoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/mattn/go-shellwords/README.md
+++ b/vendor/github.com/mattn/go-shellwords/README.md
@@ -40,7 +40,7 @@ This is based on cpan module [Parse::CommandLine](https://metacpan.org/pod/Parse
 
 # License
 
-under the MIT License: http://mattn.mit-license.org/2014
+under the MIT License: http://mattn.mit-license.org/2017
 
 # Author
 


### PR DESCRIPTION
Signed-off-by: Manjunath A Kumatagi <mkumatag@in.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
`./hack/validate/all` script is shows warning message like below:

```
[manjunath@localhost docker]$ ./hack/validate/all 
0 adds, 0 deletions; nothing to validate! :)
Congratulations!  All Go source files are properly formatted.
Congratulations!  All Go source files have been linted.
Congratulations!  "./pkg/..." is safely isolated from internal code.
No api/types/ or api/swagger.yaml changes in diff.
Congratulations!  No testing.T found.
Congratulations!  All toml source files changed here have valid syntax.
Congratulations!  All Go source files have been vetted.
Congratulations!  Changelog CHANGELOG.md is well-formed.
Congratulations!  Changelog CHANGELOG.md dates are in descending order.
No cli/compose/schema/data changes in diff.
No vendor changes in diff.
WARNING: could not find copyright information for github.com/mattn/go-shellwords
[manjunath@localhost docker]$ 
```

The reason for above warning message is because `go-shellwords` project did not had LICENCE file. The issue got fixed part of https://github.com/mattn/go-shellwords/issues/6, so this PR is updating this package to latest released version which got a proper LICENCE file.

**- How I did it**
vndr github.com/mattn/go-shellwords
**- How to verify it**
./hack/validate/all
Above command shouldn't throw any warning message
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![277630_530707513622520_931707833_o](https://cloud.githubusercontent.com/assets/12646029/24910415/52c4a47a-1ee5-11e7-8e22-4ca38228c0a0.jpg)

