### PR TITLE
daemon: relabel secrets path

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -214,6 +214,8 @@ func (daemon *Daemon) setupSecretDir(c *container.Container) (setupErr error) {
 		}
 	}
 
+	label.Relabel(localMountPath, c.MountLabel, false)
+
 	// remount secrets ro
 	if err := mount.Mount("tmpfs", localMountPath, "tmpfs", "remount,ro,"+tmpfsOwnership); err != nil {
 		return errors.Wrap(err, "unable to remount secret dir as readonly")


### PR DESCRIPTION
We need to relabel the secrets path so that containers running with selinux enabled can access secrets. It won't be allowed otherwise, with Permission denied.

@cpuguy83 @cyphar @rhatdan PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>