### PR TITLE
client: Allow hex strings as source references for ImageTag

### DIFF
--- a/client/image_tag.go
+++ b/client/image_tag.go
@@ -10,7 +10,7 @@ import (
 
 // ImageTag tags an image in the docker host
 func (cli *Client) ImageTag(ctx context.Context, source, target string) error {
-	if _, err := reference.ParseNormalizedNamed(source); err != nil {
+	if _, err := reference.ParseAnyReference(source); err != nil {
 		return errors.Wrapf(err, "Error parsing reference: %q is not a valid repository/tag", source)
 	}
 

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -46,6 +46,17 @@ func TestImageTagInvalidSourceImageName(t *testing.T) {
 	}
 }
 
+func TestImageTagHexSource(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusOK, "OK")),
+	}
+
+	err := client.ImageTag(context.Background(), "0d409d33b27e47423b049f7f863faa08655a8c901749c2b25b93ca67d01a470d", "repo:tag")
+	if err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+}
+
 func TestImageTag(t *testing.T) {
 	expectedURL := "/images/image_id/tag"
 	tagCases := []struct {


### PR DESCRIPTION
The source of a tag operation is allowed to be a 64-character hex string. This means it should use `ParseAnyReference` for validation instead of `ParseNormalizedNamed`.

This fixes a regression that happened in 17.04.

Fixes #32517

ping @dmcgowan