### PR TITLE
Fine control of libdevmapper logging

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1271,7 +1271,7 @@ func setCloseOnExec(name string) {
 }
 
 // DMLog implements logging using DevMapperLogger interface.
-func (devices *DeviceSet) DMLog(level int, file string, line int, dmError int, message string) {
+func (devices *DeviceSet) DMLog(level devicemapper.LogLevel, file string, line int, dmError int, message string) {
 	// By default libdm sends us all the messages including debug ones.
 	// We need to filter out messages here and figure out which one
 	// should be printed.
@@ -1279,15 +1279,7 @@ func (devices *DeviceSet) DMLog(level int, file string, line int, dmError int, m
 		return
 	}
 
-	// FIXME(vbatts) push this back into ./pkg/devicemapper/
-	if level <= devicemapper.LogLevelErr {
-		logrus.Errorf("libdevmapper(%d): %s:%d (%d) %s", level, file, line, dmError, message)
-	} else if level <= devicemapper.LogLevelInfo {
-		logrus.Infof("libdevmapper(%d): %s:%d (%d) %s", level, file, line, dmError, message)
-	} else {
-		// FIXME(vbatts) push this back into ./pkg/devicemapper/
-		logrus.Debugf("libdevmapper(%d): %s:%d (%d) %s", level, file, line, dmError, message)
-	}
+	devicemapper.Logf(level, file, line, dmError, message)
 }
 
 func major(device uint64) uint64 {
@@ -2603,6 +2595,8 @@ func NewDeviceSet(root string, doInit bool, options []string, uidMaps, gidMaps [
 		gidMaps:               gidMaps,
 		minFreeSpacePercent:   defaultMinFreeSpacePercent,
 	}
+
+	logLevel, _ = devicemapper.LogLevelValue(logrus.GetLevel())
 
 	foundBlkDiscard := false
 	for _, option := range options {

--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -15,7 +15,7 @@ import (
 
 // DevmapperLogger defines methods for logging with devicemapper.
 type DevmapperLogger interface {
-	DMLog(level int, file string, line int, dmError int, message string)
+	DMLog(level LogLevel, file string, line int, dmError int, message string)
 }
 
 const (
@@ -264,8 +264,8 @@ func UdevWait(cookie *uint) error {
 }
 
 // LogInitVerbose is an interface to initialize the verbose logger for the device mapper library.
-func LogInitVerbose(level int) {
-	DmLogInitVerbose(level)
+func LogInitVerbose(level LogLevel) {
+	DmLogInitVerbose(int(level))
 }
 
 var dmLogger DevmapperLogger

--- a/pkg/devicemapper/devmapper_log.go
+++ b/pkg/devicemapper/devmapper_log.go
@@ -30,6 +30,6 @@ func DevmapperLogCallback(level C.int, file *C.char, line C.int, dmErrnoOrClass 
 	}
 
 	if dmLogger != nil {
-		dmLogger.DMLog(int(level), C.GoString(file), int(line), int(dmErrnoOrClass), msg)
+		dmLogger.DMLog(LogLevel(level), C.GoString(file), int(line), int(dmErrnoOrClass), msg)
 	}
 }

--- a/pkg/devicemapper/log.go
+++ b/pkg/devicemapper/log.go
@@ -1,11 +1,80 @@
 package devicemapper
 
+import (
+	"fmt"
+
+	"github.com/Sirupsen/logrus"
+)
+
 // definitions from lvm2 lib/log/log.h
 const (
-	LogLevelFatal  = 2 + iota // _LOG_FATAL
-	LogLevelErr               // _LOG_ERR
-	LogLevelWarn              // _LOG_WARN
-	LogLevelNotice            // _LOG_NOTICE
-	LogLevelInfo              // _LOG_INFO
-	LogLevelDebug             // _LOG_DEBUG
+	LogLevelFatal  LogLevel = 2 + iota // _LOG_FATAL
+	LogLevelErr                        // _LOG_ERR
+	LogLevelWarn                       // _LOG_WARN
+	LogLevelNotice                     // _LOG_NOTICE
+	LogLevelInfo                       // _LOG_INFO
+	LogLevelDebug                      // _LOG_DEBUG
 )
+
+// Working "notice" level into mappings as that is not a direct mapping for logrus log levels.
+var logFunc = []func(format string, args ...interface{}){
+	logrus.Infof,
+	logrus.Infof,
+	logrus.Fatalf,
+	logrus.Errorf,
+	logrus.Warnf,
+	logrus.Infof,
+	logrus.Infof,
+	logrus.Debugf,
+}
+
+// LogLevel represents the level of logging to be included from the library
+type LogLevel int
+
+// LogLevelValue takes a logrus.Level and returns the libdevicemapper log level constant.
+func LogLevelValue(lvl logrus.Level) (LogLevel, error) {
+	switch lvl {
+	case logrus.FatalLevel:
+		return LogLevelFatal, nil
+	case logrus.ErrorLevel:
+		return LogLevelErr, nil
+	case logrus.WarnLevel:
+		return LogLevelWarn, nil
+	case logrus.InfoLevel:
+		return LogLevelInfo, nil
+	case logrus.DebugLevel:
+		return LogLevelDebug, nil
+	}
+
+	return LogLevelInfo, fmt.Errorf("not a valid libdevicemapper log level: %q", lvl)
+}
+
+func (lvl LogLevel) String() string {
+	switch lvl {
+	case LogLevelDebug:
+		return "debug"
+	case LogLevelInfo:
+		return "info"
+	case LogLevelNotice:
+		return "notice"
+	case LogLevelWarn:
+		return "warning"
+	case LogLevelErr:
+		return "error"
+	case LogLevelFatal:
+		return "fatal"
+	}
+
+	return "unknown"
+}
+
+// Logf formats and logs a message from libdevmapper
+func Logf(level LogLevel, file string, line int, dmError int, message string) {
+	f := logrus.Debugf
+	if level < LogLevelDebug {
+		f = logFunc[level]
+	}
+
+	// Level included to document the libdevmapper logging level vs. the logrus level
+	f("libdevmapper(%s): %s:%d (%d) %s", level, file, line, dmError, message)
+}


### PR DESCRIPTION
Allow libdevmapper logging to be configured when starting the daemon
    rather than at compile time to better facilitate debugging. The logrus
    log level from the daemon is mapped unto the libdevmapper log entries
    for filtering.
    
The additional libdevmapper levels not included within the logrus
    framework are logged within the text of the log entry.

Chang log:
  Match libdevmapper graphdriver log level  to logrus level within daemon.

Signed-off-by: Jhon Honce <jhonce@redhat.com>

