### PR TITLE
[test-integration] more clean on `docker_utils_test.go`, wait* functions

### DIFF
--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -758,7 +758,7 @@ func (d *Daemon) ReloadConfig() error {
 }
 
 // WaitInspectWithArgs waits for the specified expression to be equals to the specified expected string in the given time.
-// FIXME(vdemeester) Attach this to the Daemon struct
+// Deprecated: use cli.WaitCmd instead
 func WaitInspectWithArgs(dockerBinary, name, expr, expected string, timeout time.Duration, arg ...string) error {
 	after := time.After(timeout)
 

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -155,7 +155,6 @@ func (s *DockerSuite) TestAttachDisconnect(c *check.C) {
 
 func (s *DockerSuite) TestAttachPausedContainer(c *check.C) {
 	testRequires(c, IsPausable)
-	defer unpauseAllContainers(c)
 	runSleepingContainer(c, "-d", "--name=test")
 	dockerCmd(c, "pause", "test")
 

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/docker/integration-cli/cli"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
@@ -22,8 +23,8 @@ func (s *DockerSuite) TestAttachMultipleAndRestart(c *check.C) {
 	endGroup.Add(3)
 	startGroup.Add(3)
 
-	err := waitForContainer("attacher", "-d", "busybox", "/bin/sh", "-c", "while true; do sleep 1; echo hello; done")
-	c.Assert(err, check.IsNil)
+	cli.DockerCmd(c, "run", "--name", "attacher", "-d", "busybox", "/bin/sh", "-c", "while true; do sleep 1; echo hello; done")
+	cli.WaitRun(c, "attacher")
 
 	startDone := make(chan struct{})
 	endDone := make(chan struct{})
@@ -77,7 +78,7 @@ func (s *DockerSuite) TestAttachMultipleAndRestart(c *check.C) {
 		c.Fatalf("Attaches did not initialize properly")
 	}
 
-	dockerCmd(c, "kill", "attacher")
+	cli.DockerCmd(c, "kill", "attacher")
 
 	select {
 	case <-endDone:

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -40,7 +40,6 @@ func (s *DockerSuite) TestCommitWithoutPause(c *check.C) {
 //test commit a paused container should not unpause it after commit
 func (s *DockerSuite) TestCommitPausedContainer(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	defer unpauseAllContainers(c)
 	out, _ := dockerCmd(c, "run", "-i", "-d", "busybox")
 
 	cleanedContainerID := strings.TrimSpace(out)

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -15,6 +15,7 @@ import (
 	eventtypes "github.com/docker/docker/api/types/events"
 	eventstestutils "github.com/docker/docker/daemon/events/testutils"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/pkg/testutil"
@@ -453,14 +454,14 @@ func (s *DockerSuite) TestEventsCommit(c *check.C) {
 
 	out, _ := runSleepingContainer(c)
 	cID := strings.TrimSpace(out)
-	c.Assert(waitRun(cID), checker.IsNil)
+	cli.WaitRun(c, cID)
 
-	dockerCmd(c, "commit", "-m", "test", cID)
-	dockerCmd(c, "stop", cID)
-	c.Assert(waitExited(cID, 5*time.Second), checker.IsNil)
+	cli.DockerCmd(c, "commit", "-m", "test", cID)
+	cli.DockerCmd(c, "stop", cID)
+	cli.WaitExited(c, cID, 5*time.Second)
 
 	until := daemonUnixTime(c)
-	out, _ = dockerCmd(c, "events", "-f", "container="+cID, "--until="+until)
+	out = cli.DockerCmd(c, "events", "-f", "container="+cID, "--until="+until).Combined()
 	c.Assert(out, checker.Contains, "commit", check.Commentf("Missing 'commit' log event"))
 }
 
@@ -514,9 +515,9 @@ func (s *DockerSuite) TestEventsAttach(c *check.C) {
 	// TODO Windows CI: Figure out why this test fails intermittently (TP5).
 	testRequires(c, DaemonIsLinux)
 
-	out, _ := dockerCmd(c, "run", "-di", "busybox", "cat")
+	out := cli.DockerCmd(c, "run", "-di", "busybox", "cat").Combined()
 	cID := strings.TrimSpace(out)
-	c.Assert(waitRun(cID), checker.IsNil)
+	cli.WaitRun(c, cID)
 
 	cmd := exec.Command(dockerBinary, "attach", cID)
 	stdin, err := cmd.StdinPipe()
@@ -537,11 +538,11 @@ func (s *DockerSuite) TestEventsAttach(c *check.C) {
 
 	c.Assert(stdin.Close(), checker.IsNil)
 
-	dockerCmd(c, "kill", cID)
-	c.Assert(waitExited(cID, 5*time.Second), checker.IsNil)
+	cli.DockerCmd(c, "kill", cID)
+	cli.WaitExited(c, cID, 5*time.Second)
 
 	until := daemonUnixTime(c)
-	out, _ = dockerCmd(c, "events", "-f", "container="+cID, "--until="+until)
+	out = cli.DockerCmd(c, "events", "-f", "container="+cID, "--until="+until).Combined()
 	c.Assert(out, checker.Contains, "attach", check.Commentf("Missing 'attach' log event"))
 }
 

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/integration-cli/request"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
+	"github.com/docker/docker/integration-cli/cli"
 )
 
 func (s *DockerSuite) TestExec(c *check.C) {
@@ -137,7 +138,6 @@ func (s *DockerSuite) TestExecExitStatus(c *check.C) {
 
 func (s *DockerSuite) TestExecPausedContainer(c *check.C) {
 	testRequires(c, IsPausable)
-	defer unpauseAllContainers(c)
 
 	out, _ := runSleepingContainer(c, "-d", "--name", "testing")
 	ContainerID := strings.TrimSpace(out)
@@ -389,7 +389,10 @@ func (s *DockerSuite) TestRunMutableNetworkFiles(c *check.C) {
 	// Not applicable on Windows to Windows CI.
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 	for _, fn := range []string{"resolv.conf", "hosts"} {
-		deleteAllContainers(c)
+		containers := cli.DockerCmd(c, "ps", "-q", "-a").Combined()
+		if containers != "" {
+			cli.DockerCmd(c, append([]string{"rm", "-fv"}, strings.Split(strings.TrimSpace(containers), "\n")...)...)
+		}
 
 		content := runCommandAndReadContainerFile(c, fn, dockerBinary, "run", "-d", "--name", "c1", "busybox", "sh", "-c", fmt.Sprintf("echo success >/etc/%s && top", fn))
 

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -16,11 +16,11 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/integration-cli/request"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
-	"github.com/docker/docker/integration-cli/cli"
 )
 
 func (s *DockerSuite) TestExec(c *check.C) {

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -53,9 +53,6 @@ func (s *DockerSuite) TestInspectDefault(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectStatus(c *check.C) {
-	if testEnv.DaemonPlatform() != "windows" {
-		defer unpauseAllContainers(c)
-	}
 	out, _ := runSleepingContainer(c, "-d")
 	out = strings.TrimSpace(out)
 

--- a/integration-cli/docker_cli_kill_test.go
+++ b/integration-cli/docker_cli_kill_test.go
@@ -7,19 +7,21 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/request"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestKillContainer(c *check.C) {
 	out, _ := runSleepingContainer(c, "-d")
 	cleanedContainerID := strings.TrimSpace(out)
-	c.Assert(waitRun(cleanedContainerID), check.IsNil)
+	cli.WaitRun(c, cleanedContainerID)
 
-	dockerCmd(c, "kill", cleanedContainerID)
-	c.Assert(waitExited(cleanedContainerID, 10*time.Second), check.IsNil)
+	cli.DockerCmd(c, "kill", cleanedContainerID)
+	cli.WaitExited(c, cleanedContainerID, 10*time.Second)
 
-	out, _ = dockerCmd(c, "ps", "-q")
+	out = cli.DockerCmd(c, "ps", "-q").Combined()
 	c.Assert(out, checker.Not(checker.Contains), cleanedContainerID, check.Commentf("killed container is still running"))
 
 }
@@ -28,24 +30,25 @@ func (s *DockerSuite) TestKillOffStoppedContainer(c *check.C) {
 	out, _ := runSleepingContainer(c, "-d")
 	cleanedContainerID := strings.TrimSpace(out)
 
-	dockerCmd(c, "stop", cleanedContainerID)
-	c.Assert(waitExited(cleanedContainerID, 10*time.Second), check.IsNil)
+	cli.DockerCmd(c, "stop", cleanedContainerID)
+	cli.WaitExited(c, cleanedContainerID, 10*time.Second)
 
-	_, _, err := dockerCmdWithError("kill", "-s", "30", cleanedContainerID)
-	c.Assert(err, check.Not(check.IsNil), check.Commentf("Container %s is not running", cleanedContainerID))
+	cli.Docker(cli.Args("kill", "-s", "30", cleanedContainerID)).Assert(c, icmd.Expected{
+		ExitCode: 1,
+	})
 }
 
 func (s *DockerSuite) TestKillDifferentUserContainer(c *check.C) {
 	// TODO Windows: Windows does not yet support -u (Feb 2016).
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-u", "daemon", "-d", "busybox", "top")
+	out := cli.DockerCmd(c, "run", "-u", "daemon", "-d", "busybox", "top").Combined()
 	cleanedContainerID := strings.TrimSpace(out)
-	c.Assert(waitRun(cleanedContainerID), check.IsNil)
+	cli.WaitRun(c, cleanedContainerID)
 
-	dockerCmd(c, "kill", cleanedContainerID)
-	c.Assert(waitExited(cleanedContainerID, 10*time.Second), check.IsNil)
+	cli.DockerCmd(c, "kill", cleanedContainerID)
+	cli.WaitExited(c, cleanedContainerID, 10*time.Second)
 
-	out, _ = dockerCmd(c, "ps", "-q")
+	out = cli.DockerCmd(c, "ps", "-q").Combined()
 	c.Assert(out, checker.Not(checker.Contains), cleanedContainerID, check.Commentf("killed container is still running"))
 
 }
@@ -69,33 +72,33 @@ func (s *DockerSuite) TestKillWithSignal(c *check.C) {
 func (s *DockerSuite) TestKillWithStopSignalWithSameSignalShouldDisableRestartPolicy(c *check.C) {
 	// Cannot port to Windows - does not support signals int the same way as Linux does
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "--stop-signal=TERM", "--restart=always", "busybox", "top")
+	out := cli.DockerCmd(c, "run", "-d", "--stop-signal=TERM", "--restart=always", "busybox", "top").Combined()
 	cid := strings.TrimSpace(out)
-	c.Assert(waitRun(cid), check.IsNil)
+	cli.WaitRun(c, cid)
 
 	// Let docker send a TERM signal to the container
 	// It will kill the process and disable the restart policy
-	dockerCmd(c, "kill", "-s", "TERM", cid)
-	c.Assert(waitExited(cid, 10*time.Second), check.IsNil)
+	cli.DockerCmd(c, "kill", "-s", "TERM", cid)
+	cli.WaitExited(c, cid, 10*time.Second)
 
-	out, _ = dockerCmd(c, "ps", "-q")
+	out = cli.DockerCmd(c, "ps", "-q").Combined()
 	c.Assert(out, checker.Not(checker.Contains), cid, check.Commentf("killed container is still running"))
 }
 
 func (s *DockerSuite) TestKillWithStopSignalWithDifferentSignalShouldKeepRestartPolicy(c *check.C) {
 	// Cannot port to Windows - does not support signals int the same way as Linux does
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "--stop-signal=CONT", "--restart=always", "busybox", "top")
+	out := cli.DockerCmd(c, "run", "-d", "--stop-signal=CONT", "--restart=always", "busybox", "top").Combined()
 	cid := strings.TrimSpace(out)
-	c.Assert(waitRun(cid), check.IsNil)
+	cli.WaitRun(c, cid)
 
 	// Let docker send a TERM signal to the container
 	// It will kill the process, but not disable the restart policy
-	dockerCmd(c, "kill", "-s", "TERM", cid)
-	c.Assert(waitRestart(cid, 10*time.Second), check.IsNil)
+	cli.DockerCmd(c, "kill", "-s", "TERM", cid)
+	cli.WaitRestart(c, cid, 10*time.Second)
 
 	// Restart policy should still be in place, so it should be still running
-	c.Assert(waitRun(cid), check.IsNil)
+	cli.WaitRun(c, cid)
 }
 
 // FIXME(vdemeester) should be a unit test

--- a/integration-cli/docker_cli_nat_test.go
+++ b/integration-cli/docker_cli_nat_test.go
@@ -7,18 +7,23 @@ import (
 	"strings"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/go-check/check"
 )
 
 func startServerContainer(c *check.C, msg string, port int) string {
 	name := "server"
 	cmd := []string{
+		"run",
+		"--name",
+		name,
 		"-d",
 		"-p", fmt.Sprintf("%d:%d", port, port),
 		"busybox",
 		"sh", "-c", fmt.Sprintf("echo %q | nc -lp %d", msg, port),
 	}
-	c.Assert(waitForContainer(name, cmd...), check.IsNil)
+	cli.DockerCmd(c, cmd...)
+	cli.WaitRun(c, name)
 	return name
 }
 

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -231,9 +231,9 @@ func (s *DockerSuite) TestPsListContainersFilterHealth(c *check.C) {
 	out, _ := runSleepingContainer(c, "--name=none_legacy")
 	containerID := strings.TrimSpace(out)
 
-	waitForContainer(containerID)
+	cli.WaitRun(c, containerID)
 
-	out, _ = dockerCmd(c, "ps", "-q", "-l", "--no-trunc", "--filter=health=none")
+	out = cli.DockerCmd(c, "ps", "-q", "-l", "--no-trunc", "--filter=health=none").Combined()
 	containerOut := strings.TrimSpace(out)
 	c.Assert(containerOut, checker.Equals, containerID, check.Commentf("Expected id %s, got %s for legacy none filter, output: %q", containerID, containerOut, out))
 
@@ -241,9 +241,9 @@ func (s *DockerSuite) TestPsListContainersFilterHealth(c *check.C) {
 	out, _ = runSleepingContainer(c, "--name=none", "--no-healthcheck")
 	containerID = strings.TrimSpace(out)
 
-	waitForContainer(containerID)
+	cli.WaitRun(c, containerID)
 
-	out, _ = dockerCmd(c, "ps", "-q", "-l", "--no-trunc", "--filter=health=none")
+	out = cli.DockerCmd(c, "ps", "-q", "-l", "--no-trunc", "--filter=health=none").Combined()
 	containerOut = strings.TrimSpace(out)
 	c.Assert(containerOut, checker.Equals, containerID, check.Commentf("Expected id %s, got %s for none filter, output: %q", containerID, containerOut, out))
 
@@ -253,7 +253,7 @@ func (s *DockerSuite) TestPsListContainersFilterHealth(c *check.C) {
 
 	waitForHealthStatus(c, "failing_container", "starting", "unhealthy")
 
-	out, _ = dockerCmd(c, "ps", "-q", "--no-trunc", "--filter=health=unhealthy")
+	out = cli.DockerCmd(c, "ps", "-q", "--no-trunc", "--filter=health=unhealthy").Combined()
 	containerOut = strings.TrimSpace(out)
 	c.Assert(containerOut, checker.Equals, containerID, check.Commentf("Expected containerID %s, got %s for unhealthy filter, output: %q", containerID, containerOut, out))
 
@@ -263,7 +263,7 @@ func (s *DockerSuite) TestPsListContainersFilterHealth(c *check.C) {
 
 	waitForHealthStatus(c, "passing_container", "starting", "healthy")
 
-	out, _ = dockerCmd(c, "ps", "-q", "--no-trunc", "--filter=health=healthy")
+	out = cli.DockerCmd(c, "ps", "-q", "--no-trunc", "--filter=health=healthy").Combined()
 	containerOut = strings.TrimSpace(out)
 	c.Assert(containerOut, checker.Equals, containerID, check.Commentf("Expected containerID %s, got %s for healthy filter, output: %q", containerID, containerOut, out))
 }

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/stringid"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
@@ -62,24 +63,22 @@ func (s *DockerSuite) TestRmiTag(c *check.C) {
 }
 
 func (s *DockerSuite) TestRmiImgIDMultipleTag(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir '/busybox-one'")
-
+	out := cli.DockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir '/busybox-one'").Combined()
 	containerID := strings.TrimSpace(out)
 
 	// Wait for it to exit as cannot commit a running container on Windows, and
 	// it will take a few seconds to exit
 	if testEnv.DaemonPlatform() == "windows" {
-		err := waitExited(containerID, 60*time.Second)
-		c.Assert(err, check.IsNil)
+		cli.WaitExited(c, containerID, 60*time.Second)
 	}
 
-	dockerCmd(c, "commit", containerID, "busybox-one")
+	cli.DockerCmd(c, "commit", containerID, "busybox-one")
 
-	imagesBefore, _ := dockerCmd(c, "images", "-a")
-	dockerCmd(c, "tag", "busybox-one", "busybox-one:tag1")
-	dockerCmd(c, "tag", "busybox-one", "busybox-one:tag2")
+	imagesBefore := cli.DockerCmd(c, "images", "-a").Combined()
+	cli.DockerCmd(c, "tag", "busybox-one", "busybox-one:tag1")
+	cli.DockerCmd(c, "tag", "busybox-one", "busybox-one:tag2")
 
-	imagesAfter, _ := dockerCmd(c, "images", "-a")
+	imagesAfter := cli.DockerCmd(c, "images", "-a").Combined()
 	// tag busybox to create 2 more images with same imageID
 	c.Assert(strings.Count(imagesAfter, "\n"), checker.Equals, strings.Count(imagesBefore, "\n")+2, check.Commentf("docker images shows: %q\n", imagesAfter))
 
@@ -87,59 +86,55 @@ func (s *DockerSuite) TestRmiImgIDMultipleTag(c *check.C) {
 
 	// run a container with the image
 	out, _ = runSleepingContainerInImage(c, "busybox-one")
-
 	containerID = strings.TrimSpace(out)
 
 	// first checkout without force it fails
-	out, _, err := dockerCmdWithError("rmi", imgID)
-	expected := fmt.Sprintf("conflict: unable to delete %s (cannot be forced) - image is being used by running container %s", stringid.TruncateID(imgID), stringid.TruncateID(containerID))
 	// rmi tagged in multiple repos should have failed without force
-	c.Assert(err, checker.NotNil)
-	c.Assert(out, checker.Contains, expected)
+	cli.Docker(cli.Args("rmi", imgID)).Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err:      fmt.Sprintf("conflict: unable to delete %s (cannot be forced) - image is being used by running container %s", stringid.TruncateID(imgID), stringid.TruncateID(containerID)),
+	})
 
-	dockerCmd(c, "stop", containerID)
-	dockerCmd(c, "rmi", "-f", imgID)
+	cli.DockerCmd(c, "stop", containerID)
+	cli.DockerCmd(c, "rmi", "-f", imgID)
 
-	imagesAfter, _ = dockerCmd(c, "images", "-a")
+	imagesAfter = cli.DockerCmd(c, "images", "-a").Combined()
 	// rmi -f failed, image still exists
 	c.Assert(imagesAfter, checker.Not(checker.Contains), imgID[:12], check.Commentf("ImageID:%q; ImagesAfter: %q", imgID, imagesAfter))
 }
 
 func (s *DockerSuite) TestRmiImgIDForce(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir '/busybox-test'")
-
+	out := cli.DockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir '/busybox-test'").Combined()
 	containerID := strings.TrimSpace(out)
 
 	// Wait for it to exit as cannot commit a running container on Windows, and
 	// it will take a few seconds to exit
 	if testEnv.DaemonPlatform() == "windows" {
-		err := waitExited(containerID, 60*time.Second)
-		c.Assert(err, check.IsNil)
+		cli.WaitExited(c, containerID, 60*time.Second)
 	}
 
-	dockerCmd(c, "commit", containerID, "busybox-test")
+	cli.DockerCmd(c, "commit", containerID, "busybox-test")
 
-	imagesBefore, _ := dockerCmd(c, "images", "-a")
-	dockerCmd(c, "tag", "busybox-test", "utest:tag1")
-	dockerCmd(c, "tag", "busybox-test", "utest:tag2")
-	dockerCmd(c, "tag", "busybox-test", "utest/docker:tag3")
-	dockerCmd(c, "tag", "busybox-test", "utest:5000/docker:tag4")
+	imagesBefore := cli.DockerCmd(c, "images", "-a").Combined()
+	cli.DockerCmd(c, "tag", "busybox-test", "utest:tag1")
+	cli.DockerCmd(c, "tag", "busybox-test", "utest:tag2")
+	cli.DockerCmd(c, "tag", "busybox-test", "utest/docker:tag3")
+	cli.DockerCmd(c, "tag", "busybox-test", "utest:5000/docker:tag4")
 	{
-		imagesAfter, _ := dockerCmd(c, "images", "-a")
+		imagesAfter := cli.DockerCmd(c, "images", "-a").Combined()
 		c.Assert(strings.Count(imagesAfter, "\n"), checker.Equals, strings.Count(imagesBefore, "\n")+4, check.Commentf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter))
 	}
 	imgID := inspectField(c, "busybox-test", "Id")
 
 	// first checkout without force it fails
-	out, _, err := dockerCmdWithError("rmi", imgID)
-	// rmi tagged in multiple repos should have failed without force
-	c.Assert(err, checker.NotNil)
-	// rmi tagged in multiple repos should have failed without force
-	c.Assert(out, checker.Contains, "(must be forced) - image is referenced in multiple repositories", check.Commentf("out: %s; err: %v;", out, err))
+	cli.Docker(cli.Args("rmi", imgID)).Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err:      "(must be forced) - image is referenced in multiple repositories",
+	})
 
-	dockerCmd(c, "rmi", "-f", imgID)
+	cli.DockerCmd(c, "rmi", "-f", imgID)
 	{
-		imagesAfter, _ := dockerCmd(c, "images", "-a")
+		imagesAfter := cli.DockerCmd(c, "images", "-a").Combined()
 		// rmi failed, image still exists
 		c.Assert(imagesAfter, checker.Not(checker.Contains), imgID[:12])
 	}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4260,10 +4260,9 @@ func (s *DockerSuite) TestRunCredentialSpecWellFormed(c *check.C) {
 func (s *DockerSuite) TestRunServicingContainer(c *check.C) {
 	testRequires(c, DaemonIsWindows, SameHostDaemon)
 
-	out, _ := dockerCmd(c, "run", "-d", testEnv.MinimalBaseImage(), "cmd", "/c", "mkdir c:\\programdata\\Microsoft\\Windows\\ContainerUpdates\\000_000_d99f45d0-ffc8-4af7-bd9c-ea6a62e035c9_200 && sc control cexecsvc 255")
+	out := cli.DockerCmd(c, "run", "-d", testEnv.MinimalBaseImage(), "cmd", "/c", "mkdir c:\\programdata\\Microsoft\\Windows\\ContainerUpdates\\000_000_d99f45d0-ffc8-4af7-bd9c-ea6a62e035c9_200 && sc control cexecsvc 255").Combined()
 	containerID := strings.TrimSpace(out)
-	err := waitExited(containerID, 60*time.Second)
-	c.Assert(err, checker.IsNil)
+	cli.WaitExited(c, containerID, 60*time.Second)
 
 	result := icmd.RunCommand("powershell", "echo", `(Get-WinEvent -ProviderName "Microsoft-Windows-Hyper-V-Compute" -FilterXPath 'Event[System[EventID=2010]]' -MaxEvents 1).Message`)
 	result.Assert(c, icmd.Success)

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -173,17 +173,15 @@ func (s *DockerSuite) TestStartAttachMultipleContainers(c *check.C) {
 // Test case for #23716
 func (s *DockerSuite) TestStartAttachWithRename(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "create", "-t", "--name", "before", "busybox")
+	cli.DockerCmd(c, "create", "-t", "--name", "before", "busybox")
 	go func() {
-		c.Assert(waitRun("before"), checker.IsNil)
-		dockerCmd(c, "rename", "before", "after")
-		dockerCmd(c, "stop", "--time=2", "after")
+		cli.WaitRun(c, "before")
+		cli.DockerCmd(c, "rename", "before", "after")
+		cli.DockerCmd(c, "stop", "--time=2", "after")
 	}()
 	// FIXME(vdemeester) the intent is not clear and potentially racey
-	result := icmd.RunCommand(dockerBinary, "start", "-a", "before")
-	result.Assert(c, icmd.Expected{
+	result := cli.Docker(cli.Args("start", "-a", "before")).Assert(c, icmd.Expected{
 		ExitCode: 137,
-		Error:    "exit status 137",
 	})
 	c.Assert(result.Stderr(), checker.Not(checker.Contains), "No such container")
 }

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -94,7 +94,6 @@ func (s *DockerSuite) TestStartRecordError(c *check.C) {
 func (s *DockerSuite) TestStartPausedContainer(c *check.C) {
 	// Windows does not support pausing containers
 	testRequires(c, IsPausable)
-	defer unpauseAllContainers(c)
 
 	runSleepingContainer(c, "-d", "--name", "testing")
 

--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/go-check/check"
 )
 
@@ -162,17 +163,17 @@ func (s *DockerSuite) TestStatsFormatAll(c *check.C) {
 	// Windows does not support stats
 	testRequires(c, DaemonIsLinux)
 
-	dockerCmd(c, "run", "-d", "--name=RunningOne", "busybox", "top")
-	c.Assert(waitRun("RunningOne"), check.IsNil)
-	dockerCmd(c, "run", "-d", "--name=ExitedOne", "busybox", "top")
-	dockerCmd(c, "stop", "ExitedOne")
-	c.Assert(waitExited("ExitedOne", 5*time.Second), check.IsNil)
+	cli.DockerCmd(c, "run", "-d", "--name=RunningOne", "busybox", "top")
+	cli.WaitRun(c, "RunningOne")
+	cli.DockerCmd(c, "run", "-d", "--name=ExitedOne", "busybox", "top")
+	cli.DockerCmd(c, "stop", "ExitedOne")
+	cli.WaitExited(c, "ExitedOne", 5*time.Second)
 
-	out, _ := dockerCmd(c, "stats", "--no-stream", "--format", "{{.Name}}")
+	out := cli.DockerCmd(c, "stats", "--no-stream", "--format", "{{.Name}}").Combined()
 	c.Assert(out, checker.Contains, "RunningOne")
 	c.Assert(out, checker.Not(checker.Contains), "ExitedOne")
 
-	out, _ = dockerCmd(c, "stats", "--all", "--no-stream", "--format", "{{.Name}}")
+	out = cli.DockerCmd(c, "stats", "--all", "--no-stream", "--format", "{{.Name}}").Combined()
 	c.Assert(out, checker.Contains, "RunningOne")
 	c.Assert(out, checker.Contains, "ExitedOne")
 }

--- a/integration-cli/docker_cli_update_test.go
+++ b/integration-cli/docker_cli_update_test.go
@@ -5,11 +5,13 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestUpdateRestartPolicy(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "sh", "-c", "sleep 1 && false")
+	out := cli.DockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "sh", "-c", "sleep 1 && false").Combined()
 	timeout := 60 * time.Second
 	if testEnv.DaemonPlatform() == "windows" {
 		timeout = 180 * time.Second
@@ -18,10 +20,9 @@ func (s *DockerSuite) TestUpdateRestartPolicy(c *check.C) {
 	id := strings.TrimSpace(string(out))
 
 	// update restart policy to on-failure:5
-	dockerCmd(c, "update", "--restart=on-failure:5", id)
+	cli.DockerCmd(c, "update", "--restart=on-failure:5", id)
 
-	err := waitExited(id, timeout)
-	c.Assert(err, checker.IsNil)
+	cli.WaitExited(c, id, timeout)
 
 	count := inspectField(c, id, "RestartCount")
 	c.Assert(count, checker.Equals, "5")
@@ -35,7 +36,8 @@ func (s *DockerSuite) TestUpdateRestartWithAutoRemoveFlag(c *check.C) {
 	id := strings.TrimSpace(out)
 
 	// update restart policy for an AutoRemove container
-	out, _, err := dockerCmdWithError("update", "--restart=always", id)
-	c.Assert(err, checker.NotNil)
-	c.Assert(out, checker.Contains, "Restart policy cannot be updated because AutoRemove is enabled for the container")
+	cli.Docker(cli.Args("update", "--restart=always", id)).Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err:      "Restart policy cannot be updated because AutoRemove is enabled for the container",
+	})
 }

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -33,44 +33,6 @@ func daemonHost() string {
 	return request.DaemonHost()
 }
 
-// FIXME(vdemeester) move this away are remove ignoreNoSuchContainer bool
-func deleteContainer(container ...string) error {
-	return icmd.RunCommand(dockerBinary, append([]string{"rm", "-fv"}, container...)...).Compare(icmd.Success)
-}
-
-func getAllContainers(c *check.C) string {
-	result := icmd.RunCommand(dockerBinary, "ps", "-q", "-a")
-	result.Assert(c, icmd.Success)
-	return result.Combined()
-}
-
-// Deprecated
-func deleteAllContainers(c *check.C) {
-	containers := getAllContainers(c)
-	if containers != "" {
-		err := deleteContainer(strings.Split(strings.TrimSpace(containers), "\n")...)
-		c.Assert(err, checker.IsNil)
-	}
-}
-
-func getPausedContainers(c *check.C) []string {
-	result := icmd.RunCommand(dockerBinary, "ps", "-f", "status=paused", "-q", "-a")
-	result.Assert(c, icmd.Success)
-	return strings.Fields(result.Combined())
-}
-
-func unpauseContainer(c *check.C, container string) {
-	dockerCmd(c, "unpause", container)
-}
-
-// Deprecated
-func unpauseAllContainers(c *check.C) {
-	containers := getPausedContainers(c)
-	for _, value := range containers {
-		unpauseContainer(c, value)
-	}
-}
-
 func deleteImages(images ...string) error {
 	args := []string{dockerBinary, "rmi", "-f"}
 	return icmd.RunCmd(icmd.Cmd{Command: append(args, images...)}).Error

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -458,38 +458,21 @@ func createTmpFile(c *check.C, content string) string {
 	return filename
 }
 
-func waitForContainer(contID string, args ...string) error {
-	args = append([]string{dockerBinary, "run", "--name", contID}, args...)
-	result := icmd.RunCmd(icmd.Cmd{Command: args})
-	if result.Error != nil {
-		return result.Error
-	}
-	return waitRun(contID)
-}
-
-// waitRestart will wait for the specified container to restart once
-func waitRestart(contID string, duration time.Duration) error {
-	return waitInspect(contID, "{{.RestartCount}}", "1", duration)
-}
-
 // waitRun will wait for the specified container to be running, maximum 5 seconds.
+// Deprecated: use cli.WaitFor
 func waitRun(contID string) error {
 	return waitInspect(contID, "{{.State.Running}}", "true", 5*time.Second)
-}
-
-// waitExited will wait for the specified container to state exit, subject
-// to a maximum time limit in seconds supplied by the caller
-func waitExited(contID string, duration time.Duration) error {
-	return waitInspect(contID, "{{.State.Status}}", "exited", duration)
 }
 
 // waitInspect will wait for the specified container to have the specified string
 // in the inspect output. It will wait until the specified timeout (in seconds)
 // is reached.
+// Deprecated: use cli.WaitFor
 func waitInspect(name, expr, expected string, timeout time.Duration) error {
 	return waitInspectWithArgs(name, expr, expected, timeout)
 }
 
+// Deprecated: use cli.WaitFor
 func waitInspectWithArgs(name, expr, expected string, timeout time.Duration, arg ...string) error {
 	return daemon.WaitInspectWithArgs(dockerBinary, name, expr, expected, timeout, arg...)
 }


### PR DESCRIPTION
- CLean some functions in `docker_utils_test.go` (that were not really useful)
- Introduce `cli.Wait*` fuctions. These replace `wait*` functions from `docker_utils_test.go` and work more or less like other `cli` functions.

/cc @thaJeztah @dnephin @aaronlehmann @AkihiroSuda @cpuguy83 

🦁 