### PR TITLE
add NamedUlimitOpt to implement NamedOption to fix 32528

### DIFF
--- a/cmd/dockerd/config_unix.go
+++ b/cmd/dockerd/config_unix.go
@@ -24,7 +24,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 
 	// Then platform-specific install flags
 	flags.BoolVar(&conf.EnableSelinuxSupport, "selinux-enabled", false, "Enable selinux support")
-	flags.Var(opts.NewUlimitOpt(&conf.Ulimits), "default-ulimit", "Default ulimits for containers")
+	flags.Var(opts.NewNamedUlimitOpt("default-ulimits", &conf.Ulimits), "default-ulimit", "Default ulimits for containers")
 	flags.BoolVar(&conf.BridgeConfig.EnableIPTables, "iptables", true, "Enable addition of iptables rules")
 	flags.BoolVar(&conf.BridgeConfig.EnableIPForward, "ip-forward", true, "Enable net.ipv4.ip_forward")
 	flags.BoolVar(&conf.BridgeConfig.EnableIPMasq, "ip-masq", true, "Enable IP masquerading")

--- a/opts/ulimit.go
+++ b/opts/ulimit.go
@@ -55,3 +55,27 @@ func (o *UlimitOpt) GetList() []*units.Ulimit {
 func (o *UlimitOpt) Type() string {
 	return "ulimit"
 }
+
+// NamedUlimitOpt defines a named map of Ulimits
+type NamedUlimitOpt struct {
+	name string
+	UlimitOpt
+}
+
+var _ NamedOption = &NamedUlimitOpt{}
+
+// NewNamedUlimitOpt creates a new NamedUlimitOpt
+func NewNamedUlimitOpt(name string, ref *map[string]*units.Ulimit) *NamedUlimitOpt {
+	if ref == nil {
+		ref = &map[string]*units.Ulimit{}
+	}
+	return &NamedUlimitOpt{
+		name:      name,
+		UlimitOpt: *NewUlimitOpt(ref),
+	}
+}
+
+// Name returns the option name
+func (o *NamedUlimitOpt) Name() string {
+	return o.name
+}


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

fixes https://github.com/docker/docker/issues/32528

I think @dsheets described the issue in details. 

**- What I did**
1. add NamedUlimitOpt implement NamedOption, so we can read config `default-ulimits` from json file and reload `default-ulimits` as well.

Why is this in WIP?
Since I am confused that the test here https://github.com/docker/docker/blob/f3a8886d8890d6797a568ab316baf9400ee2e1e1/daemon/config/config_unix_test.go#L23-L29 still work without this PR. Keep digging.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

