### PR TITLE
[17.05] Add `CACert` object to swarm type ExternalCA (WIP - needs test)

### DIFF
--- a/api/types/swarm/swarm.go
+++ b/api/types/swarm/swarm.go
@@ -126,6 +126,9 @@ type ExternalCA struct {
 	// Options is a set of additional key/value pairs whose interpretation
 	// depends on the specified CA type.
 	Options map[string]string `json:",omitempty"`
+
+	// CACert specifies which root CA is used by this external CA
+	CACert []byte
 }
 
 // InitRequest is the request used to init a swarm.

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -212,7 +212,7 @@ func (c *Cluster) Update(version uint64, spec types.Spec, flags types.UpdateFlag
 		// In update, client should provide the complete spec of the swarm, including
 		// Name and Labels. If a field is specified with 0 or nil, then the default value
 		// will be used to swarmkit.
-		clusterSpec, err := convert.SwarmSpecToGRPC(spec)
+		clusterSpec, err := convert.SwarmSpecToGRPC(spec, swarm.RootCA.CACert)
 		if err != nil {
 			return apierrors.NewBadRequestError(err)
 		}
@@ -506,7 +506,7 @@ func initClusterSpec(node *swarmnode.Node, spec types.Spec) error {
 			// Note that this is different from Update(), as in Update() we expect
 			// user to specify the complete spec of the cluster (as they already know
 			// the existing one and knows which field to update)
-			clusterSpec, err := convert.MergeSwarmSpecToGRPC(spec, cluster.Spec)
+			clusterSpec, err := convert.MergeSwarmSpecToGRPC(spec, cluster.RootCA.CACert, cluster.Spec)
 			if err != nil {
 				return fmt.Errorf("error updating cluster settings: %v", err)
 			}

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -50,6 +50,14 @@ func (s *DockerSwarmSuite) TestSwarmUpdate(c *check.C) {
 	c.Assert(out, checker.Contains, "minimum certificate expiry time")
 	spec = getSpec()
 	c.Assert(spec.CAConfig.NodeCertExpiry, checker.Equals, 30*time.Hour)
+
+	// passing an external CA (this is without starting a root rotation) correctly sets the default root CA
+	out, err = d.Cmd("swarm", "update", "--external-ca", "protocol=cfssl,url=https://something.org")
+	c.Assert(err, checker.IsNil, check.Commentf("out: %v", out))
+
+	spec = getSpec()
+	c.Assert(spec.CAConfig.ExternalCAs, checker.HasLen, 1)
+	c.Assert(spec.CAConfig.ExternalCAs[0].CACert, checker.NotNil)
 }
 
 func (s *DockerSwarmSuite) TestSwarmInit(c *check.C) {
@@ -60,12 +68,15 @@ func (s *DockerSwarmSuite) TestSwarmInit(c *check.C) {
 		return sw.Spec
 	}
 
-	cli.Docker(cli.Args("swarm", "init", "--cert-expiry", "30h", "--dispatcher-heartbeat", "11s"),
+	cli.Docker(cli.Args("swarm", "init", "--cert-expiry", "30h", "--dispatcher-heartbeat", "11s",
+		"--external-ca", "protocol=cfssl,url=https://something.org"),
 		cli.Daemon(d.Daemon)).Assert(c, icmd.Success)
 
 	spec := getSpec()
 	c.Assert(spec.CAConfig.NodeCertExpiry, checker.Equals, 30*time.Hour)
 	c.Assert(spec.Dispatcher.HeartbeatPeriod, checker.Equals, 11*time.Second)
+	c.Assert(spec.CAConfig.ExternalCAs, checker.HasLen, 1)
+	c.Assert(spec.CAConfig.ExternalCAs[0].CACert, checker.NotNil)
 
 	c.Assert(d.Leave(true), checker.IsNil)
 	time.Sleep(500 * time.Millisecond) // https://github.com/docker/swarmkit/issues/1421


### PR DESCRIPTION
This would make it consistent with swarmkit.  This is required when updating the spec of a cluster, else swarmkit will reject the update when the user attempts to add an external CA.

It doesn't add any new command line flags, but just fills out the `swarmapi.ExternalCA` object's `CACert` field with the cluster's current root certificate on update and init cluster if the external CA is not already provided.

This is a bugfix for 17.05.