### PR TITLE
Standardized formatting of CLI reference commands

### DIFF
--- a/docs/reference/commandline/attach.md
+++ b/docs/reference/commandline/attach.md
@@ -18,7 +18,7 @@ keywords: "attach, running, container"
 ```markdown
 Usage: docker attach [OPTIONS] CONTAINER
 
-Attach to a running container
+Attach local standard input, output, and error streams to a running container
 
 Options:
       --detach-keys string   Override the key sequence for detaching a container
@@ -29,10 +29,13 @@ Options:
 
 ## Description
 
-Use `docker attach` to attach to a running container using the container's ID
-or name, either to view its ongoing output or to control it interactively.
+Use `docker attach` to attach your terminal's standard input, output, and error
+(or any combination of the three) to a running container using the container's
+ID or name. This allows you to view its ongoing output or to control it
+interactively, as though the commands were running directly in your terminal.
+
 You can attach to the same contained process multiple times simultaneously,
-screen sharing style, or quickly view the progress of your detached process.
+even as a different user with the appropriate permissions.
 
 To stop a container, use `CTRL-c`. This key sequence sends `SIGKILL` to the
 container. If `--sig-proxy` is true (the default),`CTRL-c` sends a `SIGINT` to

--- a/docs/reference/commandline/container_prune.md
+++ b/docs/reference/commandline/container_prune.md
@@ -70,6 +70,7 @@ fraction of a second no more than nine digits long.
 The following removes containers created more than 5 minutes ago:
 
 ```bash
+{% raw %}
 $ docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}\t{{.Status}}'
 
 CONTAINER ID        IMAGE               COMMAND             CREATED AT                      STATUS
@@ -87,11 +88,13 @@ $ docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}
 
 CONTAINER ID        IMAGE               COMMAND             CREATED AT                      STATUS
 61b9efa71024        busybox             "sh"                2017-01-04 13:23:33 -0800 PST   Exited (0) 44 seconds ago
+{% endraw %}
 ```
 
 The following removes containers created before `2017-01-04T13:10:00`:
 
 ```bash
+{% raw %}
 $ docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}\t{{.Status}}'
 
 CONTAINER ID        IMAGE               COMMAND             CREATED AT                      STATUS
@@ -109,6 +112,7 @@ $ docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}
 
 CONTAINER ID        IMAGE               COMMAND             CREATED AT                      STATUS
 53a9bc23a516        busybox             "sh"                2017-01-04 13:11:59 -0800 PST   Exited (0) 9 minutes ago
+{% endraw %}
 ```
 
 ## Related commands

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -413,7 +413,6 @@ Specifies extra mkfs arguments to be used when creating the base device.
 
 ###### Example
 
->>>>>>> 52df69f00... Standardized formatting of CLI reference commands
 ```bash
 $ sudo dockerd --storage-opt "dm.mkfsarg=-O ^has_journal"
 ```

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -323,7 +323,7 @@ pre-configuration of storage. It is strongly recommended that you do
 not use loopback in production. Ensure your Engine daemon has a
 `--storage-opt dm.thinpooldev` argument provided.
 
-###### Example:
+###### Example
 
 ```bash
 $ sudo dockerd --storage-opt dm.thinpooldev=/dev/mapper/thin-pool
@@ -341,7 +341,7 @@ The base device size can be increased at daemon restart which will allow
 all future images and containers (based on those new images) to be of the
 new base device size.
 
-###### Examples
+###### Example
 
 ```bash
 $ sudo dockerd --storage-opt dm.basesize=50G
@@ -413,6 +413,7 @@ Specifies extra mkfs arguments to be used when creating the base device.
 
 ###### Example
 
+>>>>>>> 52df69f00... Standardized formatting of CLI reference commands
 ```bash
 $ sudo dockerd --storage-opt "dm.mkfsarg=-O ^has_journal"
 ```

--- a/docs/reference/commandline/image_prune.md
+++ b/docs/reference/commandline/image_prune.md
@@ -92,6 +92,7 @@ fraction of a second no more than nine digits long.
 The following removes images created before `2017-01-04T00:00:00`:
 
 ```bash
+{% raw %}
 $ docker images --format 'table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedAt}}\t{{.Size}}'
 REPOSITORY          TAG                 IMAGE ID            CREATED AT                      SIZE
 foo                 latest              2f287ac753da        2017-01-04 13:42:23 -0800 PST   3.98 MB
@@ -114,6 +115,7 @@ $ docker images --format 'table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedAt
 
 REPOSITORY          TAG                 IMAGE ID            CREATED AT                      SIZE
 foo                 latest              2f287ac753da        2017-01-04 13:42:23 -0800 PST   3.98 MB
+{% endraw %}
 ```
 
 The following removes images created more than 10 days (`240h`) ago:

--- a/docs/reference/commandline/load.md
+++ b/docs/reference/commandline/load.md
@@ -26,6 +26,7 @@ Options:
                        The tarball may be compressed with gzip, bzip, or xz
   -q, --quiet          Suppress the load output but still outputs the imported images
 ```
+
 ## Description
 
 `docker load` loads a tarred repository from a file or the standard input stream.

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -148,9 +148,11 @@ $ docker plugin inspect tiborvass/sample-volume-plugin:latest
 ### Formatting the output
 
 ```bash
+{% raw %}
 $ docker plugin inspect -f '{{.Id}}' tiborvass/sample-volume-plugin:latest
 
 8c74c978c434745c3ade82f1bc0acf38d04990eaf494fa507c16d9f1daa99c21
+{% endraw %}
 ```
 
 

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -101,9 +101,11 @@ The following example uses a template without headers and outputs the
 `ID` and `Name` entries separated by a colon for all plugins:
 
 ```bash
+{% raw %}
 $ docker plugin ls --format "{{.ID}}: {{.Name}}"
 
 4be01827a72e: tiborvass/no-remove
+{% endraw %}
 ```
 
 

--- a/docs/reference/commandline/plugin_set.md
+++ b/docs/reference/commandline/plugin_set.md
@@ -42,6 +42,7 @@ The following example change the env variable `DEBUG` on the
 `sample-volume-plugin` plugin.
 
 ```bash
+{% raw %}
 $ docker plugin inspect -f {{.Settings.Env}} tiborvass/sample-volume-plugin
 
 [DEBUG=0]
@@ -50,6 +51,7 @@ $ docker plugin set tiborvass/sample-volume-plugin DEBUG=1
 
 $ docker plugin inspect -f {{.Settings.Env}} tiborvass/sample-volume-plugin
 [DEBUG=1]
+{% endraw %}
 ```
 
 ### Change the source of a mount
@@ -58,6 +60,7 @@ The following example change the source of the `mymount` mount on
 the `myplugin` plugin.
 
 ```bash
+{% raw %}
 $ docker plugin inspect -f '{{with $mount := index .Settings.Mounts 0}}{{$mount.Source}}{{end}}' myplugin
 /foo
 
@@ -65,6 +68,7 @@ $ docker plugins set myplugin mymount.source=/bar
 
 $ docker plugin inspect -f '{{with $mount := index .Settings.Mounts 0}}{{$mount.Source}}{{end}}' myplugin
 /bar
+{% endraw %}
 ```
 
 > **Note**: Since only `source` is settable in `mymount`,
@@ -76,6 +80,7 @@ The following example change the path of the `mydevice` device on
 the `myplugin` plugin.
 
 ```bash
+{% raw %}
 $ docker plugin inspect -f '{{with $device := index .Settings.Devices 0}}{{$device.Path}}{{end}}' myplugin
 /dev/foo
 
@@ -83,6 +88,7 @@ $ docker plugins set myplugin mydevice.path=/dev/bar
 
 $ docker plugin inspect -f '{{with $device := index .Settings.Devices 0}}{{$device.Path}}{{end}}' myplugin
 /dev/bar
+{% endraw %}
 ```
 
 > **Note**: Since only `path` is settable in `mydevice`,
@@ -93,6 +99,7 @@ $ docker plugin inspect -f '{{with $device := index .Settings.Devices 0}}{{$devi
 The following example change the source of the args on the `myplugin` plugin.
 
 ```bash
+{% raw %}
 $ docker plugin inspect -f '{{.Settings.Args}}' myplugin
 ["foo", "bar"]
 
@@ -100,6 +107,7 @@ $ docker plugins set myplugin args="foo bar baz"
 
 $ docker plugin inspect -f '{{.Settings.Args}}' myplugin
 ["foo", "bar", "baz"]
+{% endraw %}
 ```
 
 ## Related commands

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -827,6 +827,7 @@ wo41w8hg8qan  hosttempl.1  busybox:latest@sha256:29f5d56d12684887bdfa50dcd29fc31
 $ docker inspect --format="{{.Config.Hostname}}" hosttempl.1.wo41w8hg8qanxwjwsg4kxpprj
 
 x3ti0erg11rjpg64m75kej2mz-hosttempl
+{% endraw %}
 ```
 
 ## Related commands

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -133,10 +133,12 @@ The following example uses a template without headers and outputs the
 `ID`, `Mode`, and `Replicas` entries separated by a colon for all services:
 
 ```bash
+{% raw %}
 $ docker service ls --format "{{.ID}}: {{.Mode}} {{.Replicas}}"
 
 0zmvwuiu3vue: replicated 10/10
 fm6uf97exkul: global 5/5
+{% endraw %}
 ```
 
 ## Related commands

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -166,7 +166,7 @@ myservice
 
 ### Rolling back to the previous version of a service 
 
-Use the `--rollback` option to roll back to the previous version of the service. 
+Use the `--rollback` option to roll back to the previous version of the service.
 
 This will revert the service to the configuration that was in place before the most recent `docker service update` command.
 
@@ -183,7 +183,7 @@ ID            NAME  MODE        REPLICAS  IMAGE
 80bvrzp6vxf3  web   replicated  0/5       nginx:alpine
 
 ```
-Roll back the `web` service... 
+Roll back the `web` service...
 
 ```bash
 $ docker service update --rollback web

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -90,10 +90,12 @@ The following example uses a template without headers and outputs the
 `ID`, `Mode`, and `Replicas` entries separated by a colon for all services:
 
 ```bash
+{% raw %}
 $ docker stack services --format "{{.ID}}: {{.Mode}} {{.Replicas}}"
 
 0zmvwuiu3vue: replicated 10/10
 fm6uf97exkul: global 5/5
+{% endraw %}
 ```
 
 

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -120,21 +120,25 @@ The following example uses a template without headers and outputs the
 `Container` and `CPUPerc` entries separated by a colon for all images:
 
 ```bash
+{% raw %}
 $ docker stats --format "{{.Container}}: {{.CPUPerc}}"
 
 09d3bb5b1604: 6.61%
 9db7aa4d986d: 9.19%
 3f214c61ad1d: 0.00%
+{% endraw %}
 ```
 
 To list all containers statistics with their name, CPU percentage and memory
 usage in a table format you can use:
 
 ```bash
+{% raw %}
 $ docker stats --format "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}"
 
 CONTAINER           CPU %               PRIV WORKING SET
 1285939c1fd3        0.07%               796 KiB / 64 MiB
 9c76f7834ae2        0.07%               2.746 MiB / 64 MiB
 d1ea048f04e4        0.03%               4.583 MiB / 64 MiB
+{% endraw %}
 ```

--- a/docs/reference/commandline/volume_ls.md
+++ b/docs/reference/commandline/volume_ls.md
@@ -183,11 +183,13 @@ The following example uses a template without headers and outputs the
 `Name` and `Driver` entries separated by a colon for all volumes:
 
 ```bash
+{% raw %}
 $ docker volume ls --format "{{.Name}}: {{.Driver}}"
 
 vol1: local
 vol2: local
 vol3: local
+{% endraw %}
 ```
 
 ## Related commands


### PR DESCRIPTION
**- What I did**

Cherry-picked CLI improvements back to 17.04 branch, where they seem to be missing.

![armadillo with babies](https://s-media-cache-ak0.pinimg.com/564x/3c/1f/10/3c1f10aa7f2f109d56d233227db16a49.jpg)

