### PR TITLE
Refactor Dockerfile.parser and directive

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -62,7 +62,7 @@ type Builder struct {
 	disableCommit bool
 	cacheBusted   bool
 	buildArgs     *buildArgs
-	directive     parser.Directive
+	directive     *parser.Directive
 
 	imageCache builder.ImageCache
 	from       builder.Image
@@ -122,14 +122,9 @@ func NewBuilder(clientCtx context.Context, config *types.ImageBuildOptions, back
 		runConfig:     new(container.Config),
 		tmpContainers: map[string]struct{}{},
 		buildArgs:     newBuildArgs(config.BuildArgs),
-		directive: parser.Directive{
-			EscapeSeen:           false,
-			LookingForDirectives: true,
-		},
+		directive:     parser.NewDefaultDirective(),
 	}
 	b.imageContexts = &imageContexts{b: b}
-
-	parser.SetEscapeToken(parser.DefaultEscapeToken, &b.directive) // Assume the default token for escape
 	return b, nil
 }
 
@@ -325,7 +320,7 @@ func BuildFromConfig(config *container.Config, changes []string) (*container.Con
 		return nil, err
 	}
 
-	ast, err := parser.Parse(bytes.NewBufferString(strings.Join(changes, "\n")), &b.directive)
+	ast, err := parser.Parse(bytes.NewBufferString(strings.Join(changes, "\n")), b.directive)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/dockerfile/builder_test.go
+++ b/builder/dockerfile/builder_test.go
@@ -10,9 +10,8 @@ import (
 
 func TestAddNodesForLabelOption(t *testing.T) {
 	dockerfile := "FROM scratch"
-	d := parser.Directive{}
-	parser.SetEscapeToken(parser.DefaultEscapeToken, &d)
-	nodes, err := parser.Parse(strings.NewReader(dockerfile), &d)
+	d := parser.NewDefaultDirective()
+	nodes, err := parser.Parse(strings.NewReader(dockerfile), d)
 	assert.NilError(t, err)
 
 	labels := map[string]string{

--- a/builder/dockerfile/builder_test.go
+++ b/builder/dockerfile/builder_test.go
@@ -10,8 +10,7 @@ import (
 
 func TestAddNodesForLabelOption(t *testing.T) {
 	dockerfile := "FROM scratch"
-	d := parser.NewDefaultDirective()
-	nodes, err := parser.Parse(strings.NewReader(dockerfile), d)
+	result, err := parser.Parse(strings.NewReader(dockerfile))
 	assert.NilError(t, err)
 
 	labels := map[string]string{
@@ -21,6 +20,7 @@ func TestAddNodesForLabelOption(t *testing.T) {
 		"org.b": "cli-b",
 		"org.a": "cli-a",
 	}
+	nodes := result.AST
 	addNodesForLabelOption(nodes, labels)
 
 	expected := []string{

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -200,7 +200,7 @@ func from(b *Builder, args []string, attributes map[string]bool, original string
 		substituionArgs = append(substituionArgs, key+"="+value)
 	}
 
-	name, err := ProcessWord(args[0], substituionArgs, b.directive.EscapeToken)
+	name, err := ProcessWord(args[0], substituionArgs, b.directive.EscapeToken())
 	if err != nil {
 		return err
 	}

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -200,7 +200,7 @@ func from(b *Builder, args []string, attributes map[string]bool, original string
 		substituionArgs = append(substituionArgs, key+"="+value)
 	}
 
-	name, err := ProcessWord(args[0], substituionArgs, b.directive.EscapeToken())
+	name, err := ProcessWord(args[0], substituionArgs, b.escapeToken)
 	if err != nil {
 		return err
 	}

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/builder"
+	"github.com/docker/docker/builder/dockerfile/parser"
 	"github.com/docker/docker/pkg/testutil/assert"
 	"github.com/docker/go-connections/nat"
 )
@@ -204,6 +205,7 @@ func newBuilderWithMockBackend() *Builder {
 		options:   &types.ImageBuildOptions{},
 		docker:    &MockBackend{},
 		buildArgs: newBuildArgs(make(map[string]*string)),
+		directive: parser.NewDefaultDirective(),
 	}
 	b.imageContexts = &imageContexts{b: b}
 	return b

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/builder"
-	"github.com/docker/docker/builder/dockerfile/parser"
 	"github.com/docker/docker/pkg/testutil/assert"
 	"github.com/docker/go-connections/nat"
 )
@@ -205,7 +204,6 @@ func newBuilderWithMockBackend() *Builder {
 		options:   &types.ImageBuildOptions{},
 		docker:    &MockBackend{},
 		buildArgs: newBuildArgs(make(map[string]*string)),
-		directive: parser.NewDefaultDirective(),
 	}
 	b.imageContexts = &imageContexts{b: b}
 	return b

--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -180,7 +180,7 @@ func (b *Builder) evaluateEnv(cmd string, str string, envs []string) ([]string, 
 			return []string{word}, err
 		}
 	}
-	return processFunc(str, envs, b.directive.EscapeToken())
+	return processFunc(str, envs, b.escapeToken)
 }
 
 // buildArgsWithoutConfigEnv returns a list of key=value pairs for all the build

--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -180,7 +180,7 @@ func (b *Builder) evaluateEnv(cmd string, str string, envs []string) ([]string, 
 			return []string{word}, err
 		}
 	}
-	return processFunc(str, envs, b.directive.EscapeToken)
+	return processFunc(str, envs, b.directive.EscapeToken())
 }
 
 // buildArgsWithoutConfigEnv returns a list of key=value pairs for all the build

--- a/builder/dockerfile/evaluator_test.go
+++ b/builder/dockerfile/evaluator_test.go
@@ -171,9 +171,7 @@ func executeTestCase(t *testing.T, testCase dispatchTestCase) {
 	}()
 
 	r := strings.NewReader(testCase.dockerfile)
-	d := parser.Directive{}
-	parser.SetEscapeToken(parser.DefaultEscapeToken, &d)
-	n, err := parser.Parse(r, &d)
+	n, err := parser.Parse(r, parser.NewDefaultDirective())
 
 	if err != nil {
 		t.Fatalf("Error when parsing Dockerfile: %s", err)
@@ -190,6 +188,7 @@ func executeTestCase(t *testing.T, testCase dispatchTestCase) {
 		Stdout:    ioutil.Discard,
 		context:   context,
 		buildArgs: newBuildArgs(options.BuildArgs),
+		directive: parser.NewDefaultDirective(),
 	}
 
 	err = b.dispatch(0, len(n.Children), n.Children[0])

--- a/builder/dockerfile/evaluator_test.go
+++ b/builder/dockerfile/evaluator_test.go
@@ -171,7 +171,7 @@ func executeTestCase(t *testing.T, testCase dispatchTestCase) {
 	}()
 
 	r := strings.NewReader(testCase.dockerfile)
-	n, err := parser.Parse(r, parser.NewDefaultDirective())
+	result, err := parser.Parse(r)
 
 	if err != nil {
 		t.Fatalf("Error when parsing Dockerfile: %s", err)
@@ -188,9 +188,9 @@ func executeTestCase(t *testing.T, testCase dispatchTestCase) {
 		Stdout:    ioutil.Discard,
 		context:   context,
 		buildArgs: newBuildArgs(options.BuildArgs),
-		directive: parser.NewDefaultDirective(),
 	}
 
+	n := result.AST
 	err = b.dispatch(0, len(n.Children), n.Children[0])
 
 	if err == nil {

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -462,7 +462,7 @@ func (b *Builder) processImageFrom(img builder.Image) error {
 
 	// parse the ONBUILD triggers by invoking the parser
 	for _, step := range onBuildTriggers {
-		ast, err := parser.Parse(strings.NewReader(step), &b.directive)
+		ast, err := parser.Parse(strings.NewReader(step), b.directive)
 		if err != nil {
 			return err
 		}
@@ -702,5 +702,5 @@ func (b *Builder) parseDockerfile() (*parser.Node, error) {
 			return nil, fmt.Errorf("The Dockerfile (%s) cannot be empty", b.options.Dockerfile)
 		}
 	}
-	return parser.Parse(f, &b.directive)
+	return parser.Parse(f, b.directive)
 }

--- a/builder/dockerfile/parser/dumper/main.go
+++ b/builder/dockerfile/parser/dumper/main.go
@@ -23,10 +23,8 @@ func main() {
 		}
 		defer f.Close()
 
-		d := parser.Directive{LookingForDirectives: true}
-		parser.SetEscapeToken(parser.DefaultEscapeToken, &d)
-
-		ast, err := parser.Parse(f, &d)
+		d := parser.NewDefaultDirective()
+		ast, err := parser.Parse(f, d)
 		if err != nil {
 			panic(err)
 		} else {

--- a/builder/dockerfile/parser/dumper/main.go
+++ b/builder/dockerfile/parser/dumper/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/docker/docker/builder/dockerfile/parser"
+	"go/ast"
 )
 
 func main() {
@@ -23,12 +24,10 @@ func main() {
 		}
 		defer f.Close()
 
-		d := parser.NewDefaultDirective()
-		ast, err := parser.Parse(f, d)
+		result, err := parser.Parse(f)
 		if err != nil {
 			panic(err)
-		} else {
-			fmt.Println(ast.Dump())
 		}
+		fmt.Println(result.AST.Dump())
 	}
 }

--- a/builder/dockerfile/parser/dumper/main.go
+++ b/builder/dockerfile/parser/dumper/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/docker/docker/builder/dockerfile/parser"
-	"go/ast"
 )
 
 func main() {

--- a/builder/dockerfile/parser/json_test.go
+++ b/builder/dockerfile/parser/json_test.go
@@ -29,7 +29,7 @@ var validJSONArraysOfStrings = map[string][]string{
 func TestJSONArraysOfStrings(t *testing.T) {
 	for json, expected := range validJSONArraysOfStrings {
 		d := Directive{}
-		SetEscapeToken(DefaultEscapeToken, &d)
+		d.SetEscapeToken(DefaultEscapeToken)
 
 		if node, _, err := parseJSON(json, &d); err != nil {
 			t.Fatalf("%q should be a valid JSON array of strings, but wasn't! (err: %q)", json, err)
@@ -52,7 +52,7 @@ func TestJSONArraysOfStrings(t *testing.T) {
 	}
 	for _, json := range invalidJSONArraysOfStrings {
 		d := Directive{}
-		SetEscapeToken(DefaultEscapeToken, &d)
+		d.SetEscapeToken(DefaultEscapeToken)
 
 		if _, _, err := parseJSON(json, &d); err != errDockerfileNotStringArray {
 			t.Fatalf("%q should be an invalid JSON array of strings, but wasn't!", json)

--- a/builder/dockerfile/parser/json_test.go
+++ b/builder/dockerfile/parser/json_test.go
@@ -28,10 +28,9 @@ var validJSONArraysOfStrings = map[string][]string{
 
 func TestJSONArraysOfStrings(t *testing.T) {
 	for json, expected := range validJSONArraysOfStrings {
-		d := Directive{}
-		d.SetEscapeToken(DefaultEscapeToken)
+		d := NewDefaultDirective()
 
-		if node, _, err := parseJSON(json, &d); err != nil {
+		if node, _, err := parseJSON(json, d); err != nil {
 			t.Fatalf("%q should be a valid JSON array of strings, but wasn't! (err: %q)", json, err)
 		} else {
 			i := 0
@@ -51,10 +50,9 @@ func TestJSONArraysOfStrings(t *testing.T) {
 		}
 	}
 	for _, json := range invalidJSONArraysOfStrings {
-		d := Directive{}
-		d.SetEscapeToken(DefaultEscapeToken)
+		d := NewDefaultDirective()
 
-		if _, _, err := parseJSON(json, &d); err != errDockerfileNotStringArray {
+		if _, _, err := parseJSON(json, d); err != errDockerfileNotStringArray {
 			t.Fatalf("%q should be an invalid JSON array of strings, but wasn't!", json)
 		}
 	}

--- a/builder/dockerfile/parser/line_parsers.go
+++ b/builder/dockerfile/parser/line_parsers.go
@@ -103,7 +103,7 @@ func parseWords(rest string, d *Directive) []string {
 				blankOK = true
 				phase = inQuote
 			}
-			if ch == d.EscapeToken {
+			if ch == d.escapeToken {
 				if pos+chWidth == len(rest) {
 					continue // just skip an escape token at end of line
 				}
@@ -122,7 +122,7 @@ func parseWords(rest string, d *Directive) []string {
 				phase = inWord
 			}
 			// The escape token is special except for ' quotes - can't escape anything for '
-			if ch == d.EscapeToken && quote != '\'' {
+			if ch == d.escapeToken && quote != '\'' {
 				if pos+chWidth == len(rest) {
 					phase = inWord
 					continue // just skip the escape token at end

--- a/builder/dockerfile/parser/line_parsers.go
+++ b/builder/dockerfile/parser/line_parsers.go
@@ -42,7 +42,7 @@ func parseSubCommand(rest string, d *Directive) (*Node, map[string]bool, error) 
 		return nil, nil, nil
 	}
 
-	_, child, err := ParseLine(rest, d, false)
+	child, err := newNodeFromLine(rest, d)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/builder/dockerfile/parser/parser_test.go
+++ b/builder/dockerfile/parser/parser_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/docker/docker/pkg/testutil/assert"
 )
 
 const testDir = "testfiles"
@@ -16,17 +18,11 @@ const testFileLineInfo = "testfile-line/Dockerfile"
 
 func getDirs(t *testing.T, dir string) []string {
 	f, err := os.Open(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	assert.NilError(t, err)
 	defer f.Close()
 
 	dirs, err := f.Readdirnames(0)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	assert.NilError(t, err)
 	return dirs
 }
 
@@ -35,15 +31,11 @@ func TestTestNegative(t *testing.T) {
 		dockerfile := filepath.Join(negativeTestDir, dir, "Dockerfile")
 
 		df, err := os.Open(dockerfile)
-		if err != nil {
-			t.Fatalf("Dockerfile missing for %s: %v", dir, err)
-		}
+		assert.NilError(t, err)
 		defer df.Close()
 
-		_, err = Parse(df, NewDefaultDirective())
-		if err == nil {
-			t.Fatalf("No error parsing broken dockerfile for %s", dir)
-		}
+		_, err = Parse(df)
+		assert.Error(t, err, "")
 	}
 }
 
@@ -53,31 +45,21 @@ func TestTestData(t *testing.T) {
 		resultfile := filepath.Join(testDir, dir, "result")
 
 		df, err := os.Open(dockerfile)
-		if err != nil {
-			t.Fatalf("Dockerfile missing for %s: %v", dir, err)
-		}
+		assert.NilError(t, err)
 		defer df.Close()
 
-		ast, err := Parse(df, NewDefaultDirective())
-		if err != nil {
-			t.Fatalf("Error parsing %s's dockerfile: %v", dir, err)
-		}
+		result, err := Parse(df)
+		assert.NilError(t, err)
 
 		content, err := ioutil.ReadFile(resultfile)
-		if err != nil {
-			t.Fatalf("Error reading %s's result file: %v", dir, err)
-		}
+		assert.NilError(t, err)
 
 		if runtime.GOOS == "windows" {
 			// CRLF --> CR to match Unix behavior
 			content = bytes.Replace(content, []byte{'\x0d', '\x0a'}, []byte{'\x0a'}, -1)
 		}
 
-		if ast.Dump()+"\n" != string(content) {
-			fmt.Fprintln(os.Stderr, "Result:\n"+ast.Dump())
-			fmt.Fprintln(os.Stderr, "Expected:\n"+string(content))
-			t.Fatalf("%s: AST dump of dockerfile does not match result", dir)
-		}
+		assert.Equal(t, result.AST.Dump()+"\n", string(content))
 	}
 }
 
@@ -119,46 +101,33 @@ func TestParseWords(t *testing.T) {
 
 	for _, test := range tests {
 		words := parseWords(test["input"][0], NewDefaultDirective())
-		if len(words) != len(test["expect"]) {
-			t.Fatalf("length check failed. input: %v, expect: %q, output: %q", test["input"][0], test["expect"], words)
-		}
-		for i, word := range words {
-			if word != test["expect"][i] {
-				t.Fatalf("word check failed for word: %q. input: %q, expect: %q, output: %q", word, test["input"][0], test["expect"], words)
-			}
-		}
+		assert.DeepEqual(t, words, test["expect"])
 	}
 }
 
 func TestLineInformation(t *testing.T) {
 	df, err := os.Open(testFileLineInfo)
-	if err != nil {
-		t.Fatalf("Dockerfile missing for %s: %v", testFileLineInfo, err)
-	}
+	assert.NilError(t, err)
 	defer df.Close()
 
-	ast, err := Parse(df, NewDefaultDirective())
-	if err != nil {
-		t.Fatalf("Error parsing dockerfile %s: %v", testFileLineInfo, err)
-	}
+	result, err := Parse(df)
+	assert.NilError(t, err)
 
-	if ast.StartLine != 5 || ast.EndLine != 31 {
-		fmt.Fprintf(os.Stderr, "Wrong root line information: expected(%d-%d), actual(%d-%d)\n", 5, 31, ast.StartLine, ast.EndLine)
+	ast := result.AST
+	if ast.StartLine != 5 || ast.endLine != 31 {
+		fmt.Fprintf(os.Stderr, "Wrong root line information: expected(%d-%d), actual(%d-%d)\n", 5, 31, ast.StartLine, ast.endLine)
 		t.Fatal("Root line information doesn't match result.")
 	}
-	if len(ast.Children) != 3 {
-		fmt.Fprintf(os.Stderr, "Wrong number of child: expected(%d), actual(%d)\n", 3, len(ast.Children))
-		t.Fatalf("Root line information doesn't match result for %s", testFileLineInfo)
-	}
+	assert.Equal(t, len(ast.Children), 3)
 	expected := [][]int{
 		{5, 5},
 		{11, 12},
 		{17, 31},
 	}
 	for i, child := range ast.Children {
-		if child.StartLine != expected[i][0] || child.EndLine != expected[i][1] {
+		if child.StartLine != expected[i][0] || child.endLine != expected[i][1] {
 			t.Logf("Wrong line information for child %d: expected(%d-%d), actual(%d-%d)\n",
-				i, expected[i][0], expected[i][1], child.StartLine, child.EndLine)
+				i, expected[i][0], expected[i][1], child.StartLine, child.endLine)
 			t.Fatal("Root line information doesn't match result.")
 		}
 	}

--- a/builder/dockerfile/parser/parser_test.go
+++ b/builder/dockerfile/parser/parser_test.go
@@ -59,7 +59,7 @@ func TestTestData(t *testing.T) {
 			content = bytes.Replace(content, []byte{'\x0d', '\x0a'}, []byte{'\x0a'}, -1)
 		}
 
-		assert.Equal(t, result.AST.Dump()+"\n", string(content))
+		assert.Equal(t, result.AST.Dump()+"\n", string(content), "In "+dockerfile)
 	}
 }
 

--- a/builder/dockerfile/parser/parser_test.go
+++ b/builder/dockerfile/parser/parser_test.go
@@ -40,9 +40,7 @@ func TestTestNegative(t *testing.T) {
 		}
 		defer df.Close()
 
-		d := Directive{LookingForDirectives: true}
-		SetEscapeToken(DefaultEscapeToken, &d)
-		_, err = Parse(df, &d)
+		_, err = Parse(df, NewDefaultDirective())
 		if err == nil {
 			t.Fatalf("No error parsing broken dockerfile for %s", dir)
 		}
@@ -60,9 +58,7 @@ func TestTestData(t *testing.T) {
 		}
 		defer df.Close()
 
-		d := Directive{LookingForDirectives: true}
-		SetEscapeToken(DefaultEscapeToken, &d)
-		ast, err := Parse(df, &d)
+		ast, err := Parse(df, NewDefaultDirective())
 		if err != nil {
 			t.Fatalf("Error parsing %s's dockerfile: %v", dir, err)
 		}
@@ -122,9 +118,7 @@ func TestParseWords(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		d := Directive{LookingForDirectives: true}
-		SetEscapeToken(DefaultEscapeToken, &d)
-		words := parseWords(test["input"][0], &d)
+		words := parseWords(test["input"][0], NewDefaultDirective())
 		if len(words) != len(test["expect"]) {
 			t.Fatalf("length check failed. input: %v, expect: %q, output: %q", test["input"][0], test["expect"], words)
 		}
@@ -143,9 +137,7 @@ func TestLineInformation(t *testing.T) {
 	}
 	defer df.Close()
 
-	d := Directive{LookingForDirectives: true}
-	SetEscapeToken(DefaultEscapeToken, &d)
-	ast, err := Parse(df, &d)
+	ast, err := Parse(df, NewDefaultDirective())
 	if err != nil {
 		t.Fatalf("Error parsing dockerfile %s: %v", testFileLineInfo, err)
 	}

--- a/builder/dockerfile/parser/testfiles/continue-at-eof/Dockerfile
+++ b/builder/dockerfile/parser/testfiles/continue-at-eof/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.5
+
+RUN something \

--- a/builder/dockerfile/parser/testfiles/continue-at-eof/result
+++ b/builder/dockerfile/parser/testfiles/continue-at-eof/result
@@ -1,0 +1,2 @@
+(from "alpine:3.5")
+(run "something")


### PR DESCRIPTION
Don't expose parser.Directive outside of the parser package
Remove duplication in `parser.Parse()` and make it easier to support #29161