### PR TITLE
docs: fix Makefile for yaml docs generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ shell: build ## start a shell inside the build env
 	$(DOCKER_RUN_DOCKER) bash
 
 yaml-docs-gen: build ## generate documentation YAML files consumed by docs repo
-	$(DOCKER_RUN_DOCKER) sh -c 'hack/make.sh yaml-docs-generator && ( cd bundles/latest/yaml-docs-generator; mkdir docs; ./yaml-docs-generator --target $$(pwd)/docs )'
+	$(DOCKER_RUN_DOCKER) sh -c 'hack/make.sh yaml-docs-generator && ( root=$$(pwd); cd bundles/latest/yaml-docs-generator; mkdir docs; ./yaml-docs-generator --root $${root} --target $$(pwd)/docs )'
 
 test: build ## run the unit, integration and docker-py tests
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary cross test-unit test-integration-cli test-docker-py


### PR DESCRIPTION
This commit is already in master, 17.05.x, 17.03.x, but somehow missed 17.04.x. Without it, you can't actually generate the YAML files correctly.