### PR TITLE
Fix bash-completion script.

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2258,7 +2258,7 @@ _docker_image_build() {
 					__docker_complete_containers_all --cur "${cur#*:}"
 					;;
 				*)
-					COMPREPLY=( $( compgen -W "$(__docker_plugins --type Network) $(__docker_networks) container:" -- "$cur") )
+					COMPREPLY=( $( compgen -W "$(__docker_plugins_bundled --type Network) $(__docker_networks) container:" -- "$cur") )
 					if [ "${COMPREPLY[*]}" = "container:" ] ; then
 						__docker_nospace
 					fi


### PR DESCRIPTION
bash-completion script for 'docker build --network' calls
__docker_plugins, the correct name for this function is
__docker_plugins_bundled.

Closes #32588

Signed-off-by: Corey Farrell <git@cfware.com>

**- Description for the changelog**
Fix bash completion for `docker build --network`.