### PR TITLE
Refactor builder dispatch state

### DIFF
--- a/builder/dockerfile/bflag.go
+++ b/builder/dockerfile/bflag.go
@@ -37,6 +37,13 @@ func NewBFlags() *BFlags {
 	}
 }
 
+// NewBFlagsWithArgs returns the new BFlags struct with Args set to args
+func NewBFlagsWithArgs(args []string) *BFlags {
+	flags := NewBFlags()
+	flags.Args = args
+	return flags
+}
+
 // AddBool adds a bool flag to BFlags
 // Note, any error will be generated when Parse() is called (see Parse).
 func (bf *BFlags) AddBool(name string, def bool) *Flag {

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -52,20 +52,20 @@ type Builder struct {
 	clientCtx context.Context
 
 	runConfig     *container.Config // runconfig for cmd, run, entrypoint etc.
-	flags         *BFlags
 	tmpContainers map[string]struct{}
-	image         string         // imageID
 	imageContexts *imageContexts // helper for storing contexts from builds
-	noBaseImage   bool           // A flag to track the use of `scratch` as the base image
-	maintainer    string
-	cmdSet        bool
 	disableCommit bool
 	cacheBusted   bool
 	buildArgs     *buildArgs
-	escapeToken   rune
+	imageCache    builder.ImageCache
 
-	imageCache builder.ImageCache
-	from       builder.Image
+	// TODO: these move to DispatchState
+	escapeToken rune
+	maintainer  string
+	cmdSet      bool
+	noBaseImage bool   // A flag to track the use of `scratch` as the base image
+	image       string // imageID
+	from        builder.Image
 }
 
 // BuildManager implements builder.Backend and is shared across all Builder objects.
@@ -304,6 +304,7 @@ func (b *Builder) tagImages(repoAndTags []reference.Named) error {
 }
 
 // hasFromImage returns true if the builder has processed a `FROM <image>` line
+// TODO: move to DispatchState
 func (b *Builder) hasFromImage() bool {
 	return b.image != "" || b.noBaseImage
 }

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -314,7 +314,6 @@ func workdir(req dispatchRequest) error {
 		// We've already updated the runConfig and that's enough.
 		return nil
 	}
-	req.runConfig.Image = req.builder.image
 
 	cmd := req.runConfig.Cmd
 	comment := "WORKDIR " + req.runConfig.WorkingDir

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/builder"
+	"github.com/docker/docker/pkg/testutil"
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/docker/docker/pkg/testutil"
 )
 
 type commandWithFunction struct {

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -3,7 +3,6 @@ package dockerfile
 import (
 	"fmt"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -12,6 +11,8 @@ import (
 	"github.com/docker/docker/builder"
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/docker/docker/pkg/testutil"
 )
 
 type commandWithFunction struct {
@@ -19,161 +20,142 @@ type commandWithFunction struct {
 	function func(args []string) error
 }
 
+func withArgs(f dispatcher) func([]string) error {
+	return func(args []string) error {
+		return f(dispatchRequest{args: args, runConfig: &container.Config{}})
+	}
+}
+
+func withBuilderAndArgs(builder *Builder, f dispatcher) func([]string) error {
+	return func(args []string) error {
+		return f(defaultDispatchReq(builder, args...))
+	}
+}
+
+func defaultDispatchReq(builder *Builder, args ...string) dispatchRequest {
+	return dispatchRequest{
+		builder:   builder,
+		args:      args,
+		flags:     NewBFlags(),
+		runConfig: &container.Config{},
+	}
+}
+
+func newBuilderWithMockBackend() *Builder {
+	b := &Builder{
+		runConfig:     &container.Config{},
+		options:       &types.ImageBuildOptions{},
+		docker:        &MockBackend{},
+		buildArgs:     newBuildArgs(make(map[string]*string)),
+		disableCommit: true,
+	}
+	b.imageContexts = &imageContexts{b: b}
+	return b
+}
+
 func TestCommandsExactlyOneArgument(t *testing.T) {
 	commands := []commandWithFunction{
-		{"MAINTAINER", func(args []string) error { return maintainer(nil, args, nil, "") }},
-		{"WORKDIR", func(args []string) error { return workdir(nil, args, nil, "") }},
-		{"USER", func(args []string) error { return user(nil, args, nil, "") }},
-		{"STOPSIGNAL", func(args []string) error { return stopSignal(nil, args, nil, "") }}}
+		{"MAINTAINER", withArgs(maintainer)},
+		{"WORKDIR", withArgs(workdir)},
+		{"USER", withArgs(user)},
+		{"STOPSIGNAL", withArgs(stopSignal)},
+	}
 
 	for _, command := range commands {
 		err := command.function([]string{})
-
-		if err == nil {
-			t.Fatalf("Error should be present for %s command", command.name)
-		}
-
-		expectedError := errExactlyOneArgument(command.name)
-
-		if err.Error() != expectedError.Error() {
-			t.Fatalf("Wrong error message for %s. Got: %s. Should be: %s", command.name, err.Error(), expectedError)
-		}
+		assert.EqualError(t, err, errExactlyOneArgument(command.name).Error())
 	}
 }
 
 func TestCommandsAtLeastOneArgument(t *testing.T) {
 	commands := []commandWithFunction{
-		{"ENV", func(args []string) error { return env(nil, args, nil, "") }},
-		{"LABEL", func(args []string) error { return label(nil, args, nil, "") }},
-		{"ONBUILD", func(args []string) error { return onbuild(nil, args, nil, "") }},
-		{"HEALTHCHECK", func(args []string) error { return healthcheck(nil, args, nil, "") }},
-		{"EXPOSE", func(args []string) error { return expose(nil, args, nil, "") }},
-		{"VOLUME", func(args []string) error { return volume(nil, args, nil, "") }}}
+		{"ENV", withArgs(env)},
+		{"LABEL", withArgs(label)},
+		{"ONBUILD", withArgs(onbuild)},
+		{"HEALTHCHECK", withArgs(healthcheck)},
+		{"EXPOSE", withArgs(expose)},
+		{"VOLUME", withArgs(volume)},
+	}
 
 	for _, command := range commands {
 		err := command.function([]string{})
-
-		if err == nil {
-			t.Fatalf("Error should be present for %s command", command.name)
-		}
-
-		expectedError := errAtLeastOneArgument(command.name)
-
-		if err.Error() != expectedError.Error() {
-			t.Fatalf("Wrong error message for %s. Got: %s. Should be: %s", command.name, err.Error(), expectedError)
-		}
+		assert.EqualError(t, err, errAtLeastOneArgument(command.name).Error())
 	}
 }
 
 func TestCommandsAtLeastTwoArguments(t *testing.T) {
 	commands := []commandWithFunction{
-		{"ADD", func(args []string) error { return add(nil, args, nil, "") }},
-		{"COPY", func(args []string) error { return dispatchCopy(nil, args, nil, "") }}}
+		{"ADD", withArgs(add)},
+		{"COPY", withArgs(dispatchCopy)}}
 
 	for _, command := range commands {
 		err := command.function([]string{"arg1"})
-
-		if err == nil {
-			t.Fatalf("Error should be present for %s command", command.name)
-		}
-
-		expectedError := errAtLeastTwoArguments(command.name)
-
-		if err.Error() != expectedError.Error() {
-			t.Fatalf("Wrong error message for %s. Got: %s. Should be: %s", command.name, err.Error(), expectedError)
-		}
+		assert.EqualError(t, err, errAtLeastTwoArguments(command.name).Error())
 	}
 }
 
 func TestCommandsTooManyArguments(t *testing.T) {
 	commands := []commandWithFunction{
-		{"ENV", func(args []string) error { return env(nil, args, nil, "") }},
-		{"LABEL", func(args []string) error { return label(nil, args, nil, "") }}}
+		{"ENV", withArgs(env)},
+		{"LABEL", withArgs(label)}}
 
 	for _, command := range commands {
 		err := command.function([]string{"arg1", "arg2", "arg3"})
-
-		if err == nil {
-			t.Fatalf("Error should be present for %s command", command.name)
-		}
-
-		expectedError := errTooManyArguments(command.name)
-
-		if err.Error() != expectedError.Error() {
-			t.Fatalf("Wrong error message for %s. Got: %s. Should be: %s", command.name, err.Error(), expectedError)
-		}
+		assert.EqualError(t, err, errTooManyArguments(command.name).Error())
 	}
 }
 
-func TestCommandseBlankNames(t *testing.T) {
-	bflags := &BFlags{}
-	config := &container.Config{}
-
-	b := &Builder{flags: bflags, runConfig: config, disableCommit: true}
-
+func TestCommandsBlankNames(t *testing.T) {
+	builder := newBuilderWithMockBackend()
 	commands := []commandWithFunction{
-		{"ENV", func(args []string) error { return env(b, args, nil, "") }},
-		{"LABEL", func(args []string) error { return label(b, args, nil, "") }},
+		{"ENV", withBuilderAndArgs(builder, env)},
+		{"LABEL", withBuilderAndArgs(builder, label)},
 	}
 
 	for _, command := range commands {
 		err := command.function([]string{"", ""})
-
-		if err == nil {
-			t.Fatalf("Error should be present for %s command", command.name)
-		}
-
-		expectedError := errBlankCommandNames(command.name)
-
-		if err.Error() != expectedError.Error() {
-			t.Fatalf("Wrong error message for %s. Got: %s. Should be: %s", command.name, err.Error(), expectedError)
-		}
+		assert.EqualError(t, err, errBlankCommandNames(command.name).Error())
 	}
 }
 
 func TestEnv2Variables(t *testing.T) {
 	b := newBuilderWithMockBackend()
-	b.disableCommit = true
 
 	args := []string{"var1", "val1", "var2", "val2"}
-	err := env(b, args, nil, "")
-	assert.NoError(t, err)
+	req := defaultDispatchReq(b, args...)
+	err := env(req)
+	require.NoError(t, err)
 
 	expected := []string{
 		fmt.Sprintf("%s=%s", args[0], args[1]),
 		fmt.Sprintf("%s=%s", args[2], args[3]),
 	}
-	assert.Equal(t, expected, b.runConfig.Env)
+	assert.Equal(t, expected, req.runConfig.Env)
 }
 
 func TestEnvValueWithExistingRunConfigEnv(t *testing.T) {
 	b := newBuilderWithMockBackend()
-	b.disableCommit = true
-	b.runConfig.Env = []string{"var1=old", "var2=fromenv"}
 
 	args := []string{"var1", "val1"}
-	err := env(b, args, nil, "")
-	assert.NoError(t, err)
+	req := defaultDispatchReq(b, args...)
+	req.runConfig.Env = []string{"var1=old", "var2=fromenv"}
+	err := env(req)
+	require.NoError(t, err)
 
 	expected := []string{
 		fmt.Sprintf("%s=%s", args[0], args[1]),
 		"var2=fromenv",
 	}
-	assert.Equal(t, expected, b.runConfig.Env)
+	assert.Equal(t, expected, req.runConfig.Env)
 }
 
 func TestMaintainer(t *testing.T) {
 	maintainerEntry := "Some Maintainer <maintainer@example.com>"
 
-	b := &Builder{flags: &BFlags{}, runConfig: &container.Config{}, disableCommit: true}
-
-	if err := maintainer(b, []string{maintainerEntry}, nil, ""); err != nil {
-		t.Fatalf("Error when executing maintainer: %s", err.Error())
-	}
-
-	if b.maintainer != maintainerEntry {
-		t.Fatalf("Maintainer in builder should be set to %s. Got: %s", maintainerEntry, b.maintainer)
-	}
+	b := newBuilderWithMockBackend()
+	err := maintainer(defaultDispatchReq(b, maintainerEntry))
+	require.NoError(t, err)
+	assert.Equal(t, maintainerEntry, b.maintainer)
 }
 
 func TestLabel(t *testing.T) {
@@ -181,45 +163,25 @@ func TestLabel(t *testing.T) {
 	labelValue := "value"
 
 	labelEntry := []string{labelName, labelValue}
+	b := newBuilderWithMockBackend()
+	req := defaultDispatchReq(b, labelEntry...)
+	err := label(req)
+	require.NoError(t, err)
 
-	b := &Builder{flags: &BFlags{}, runConfig: &container.Config{}, disableCommit: true}
-
-	if err := label(b, labelEntry, nil, ""); err != nil {
-		t.Fatalf("Error when executing label: %s", err.Error())
-	}
-
-	if val, ok := b.runConfig.Labels[labelName]; ok {
-		if val != labelValue {
-			t.Fatalf("Label %s should have value %s, had %s instead", labelName, labelValue, val)
-		}
-	} else {
-		t.Fatalf("Label %s should be present but it is not", labelName)
-	}
-}
-
-func newBuilderWithMockBackend() *Builder {
-	b := &Builder{
-		flags:     &BFlags{},
-		runConfig: &container.Config{},
-		options:   &types.ImageBuildOptions{},
-		docker:    &MockBackend{},
-		buildArgs: newBuildArgs(make(map[string]*string)),
-	}
-	b.imageContexts = &imageContexts{b: b}
-	return b
+	require.Contains(t, req.runConfig.Labels, labelName)
+	assert.Equal(t, req.runConfig.Labels[labelName], labelValue)
 }
 
 func TestFromScratch(t *testing.T) {
 	b := newBuilderWithMockBackend()
-
-	err := from(b, []string{"scratch"}, nil, "")
+	err := from(defaultDispatchReq(b, "scratch"))
 
 	if runtime.GOOS == "windows" {
 		assert.EqualError(t, err, "Windows does not support FROM scratch")
 		return
 	}
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "", b.image)
 	assert.Equal(t, true, b.noBaseImage)
 }
@@ -234,10 +196,10 @@ func TestFromWithArg(t *testing.T) {
 	b := newBuilderWithMockBackend()
 	b.docker.(*MockBackend).getImageOnBuildFunc = getImage
 
-	assert.NoError(t, arg(b, []string{"THETAG=" + tag}, nil, ""))
-	err := from(b, []string{"alpine${THETAG}"}, nil, "")
+	require.NoError(t, arg(defaultDispatchReq(b, "THETAG="+tag)))
+	err := from(defaultDispatchReq(b, "alpine${THETAG}"))
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, b.image)
 	assert.Equal(t, expected, b.from.ImageID())
 	assert.Len(t, b.buildArgs.GetAllAllowed(), 0)
@@ -255,8 +217,8 @@ func TestFromWithUndefinedArg(t *testing.T) {
 	b.docker.(*MockBackend).getImageOnBuildFunc = getImage
 	b.options.BuildArgs = map[string]*string{"THETAG": &tag}
 
-	err := from(b, []string{"alpine${THETAG}"}, nil, "")
-	assert.NoError(t, err)
+	err := from(defaultDispatchReq(b, "alpine${THETAG}"))
+	require.NoError(t, err)
 	assert.Equal(t, expected, b.image)
 }
 
@@ -267,237 +229,147 @@ func TestOnbuildIllegalTriggers(t *testing.T) {
 		{"FROM", "FROM isn't allowed as an ONBUILD trigger"}}
 
 	for _, trigger := range triggers {
-		b := &Builder{flags: &BFlags{}, runConfig: &container.Config{}, disableCommit: true}
+		b := newBuilderWithMockBackend()
 
-		err := onbuild(b, []string{trigger.command}, nil, "")
-
-		if err == nil {
-			t.Fatal("Error should not be nil")
-		}
-
-		if !strings.Contains(err.Error(), trigger.expectedError) {
-			t.Fatalf("Error message not correct. Should be: %s, got: %s", trigger.expectedError, err.Error())
-		}
+		err := onbuild(defaultDispatchReq(b, trigger.command))
+		testutil.ErrorContains(t, err, trigger.expectedError)
 	}
 }
 
 func TestOnbuild(t *testing.T) {
-	b := &Builder{flags: &BFlags{}, runConfig: &container.Config{}, disableCommit: true}
+	b := newBuilderWithMockBackend()
 
-	err := onbuild(b, []string{"ADD", ".", "/app/src"}, nil, "ONBUILD ADD . /app/src")
+	req := defaultDispatchReq(b, "ADD", ".", "/app/src")
+	req.original = "ONBUILD ADD . /app/src"
+	req.runConfig = &container.Config{}
 
-	if err != nil {
-		t.Fatalf("Error should be empty, got: %s", err.Error())
-	}
-
-	expectedOnbuild := "ADD . /app/src"
-
-	if b.runConfig.OnBuild[0] != expectedOnbuild {
-		t.Fatalf("Wrong ONBUILD command. Expected: %s, got: %s", expectedOnbuild, b.runConfig.OnBuild[0])
-	}
+	err := onbuild(req)
+	require.NoError(t, err)
+	assert.Equal(t, "ADD . /app/src", req.runConfig.OnBuild[0])
 }
 
 func TestWorkdir(t *testing.T) {
-	b := &Builder{flags: &BFlags{}, runConfig: &container.Config{}, disableCommit: true}
-
+	b := newBuilderWithMockBackend()
 	workingDir := "/app"
-
 	if runtime.GOOS == "windows" {
 		workingDir = "C:\app"
 	}
 
-	err := workdir(b, []string{workingDir}, nil, "")
-
-	if err != nil {
-		t.Fatalf("Error should be empty, got: %s", err.Error())
-	}
-
-	if b.runConfig.WorkingDir != workingDir {
-		t.Fatalf("WorkingDir should be set to %s, got %s", workingDir, b.runConfig.WorkingDir)
-	}
-
+	req := defaultDispatchReq(b, workingDir)
+	err := workdir(req)
+	require.NoError(t, err)
+	assert.Equal(t, workingDir, req.runConfig.WorkingDir)
 }
 
 func TestCmd(t *testing.T) {
-	b := &Builder{flags: &BFlags{}, runConfig: &container.Config{}, disableCommit: true}
-
+	b := newBuilderWithMockBackend()
 	command := "./executable"
 
-	err := cmd(b, []string{command}, nil, "")
-
-	if err != nil {
-		t.Fatalf("Error should be empty, got: %s", err.Error())
-	}
+	req := defaultDispatchReq(b, command)
+	err := cmd(req)
+	require.NoError(t, err)
 
 	var expectedCommand strslice.StrSlice
-
 	if runtime.GOOS == "windows" {
 		expectedCommand = strslice.StrSlice(append([]string{"cmd"}, "/S", "/C", command))
 	} else {
 		expectedCommand = strslice.StrSlice(append([]string{"/bin/sh"}, "-c", command))
 	}
 
-	if !compareStrSlice(b.runConfig.Cmd, expectedCommand) {
-		t.Fatalf("Command should be set to %s, got %s", command, b.runConfig.Cmd)
-	}
-
-	if !b.cmdSet {
-		t.Fatal("Command should be marked as set")
-	}
-}
-
-func compareStrSlice(slice1, slice2 strslice.StrSlice) bool {
-	if len(slice1) != len(slice2) {
-		return false
-	}
-
-	for i := range slice1 {
-		if slice1[i] != slice2[i] {
-			return false
-		}
-	}
-
-	return true
+	assert.Equal(t, expectedCommand, req.runConfig.Cmd)
+	assert.True(t, b.cmdSet)
 }
 
 func TestHealthcheckNone(t *testing.T) {
-	b := &Builder{flags: &BFlags{}, runConfig: &container.Config{}, disableCommit: true}
+	b := newBuilderWithMockBackend()
 
-	if err := healthcheck(b, []string{"NONE"}, nil, ""); err != nil {
-		t.Fatalf("Error should be empty, got: %s", err.Error())
-	}
+	req := defaultDispatchReq(b, "NONE")
+	err := healthcheck(req)
+	require.NoError(t, err)
 
-	if b.runConfig.Healthcheck == nil {
-		t.Fatal("Healthcheck should be set, got nil")
-	}
-
-	expectedTest := strslice.StrSlice(append([]string{"NONE"}))
-
-	if !compareStrSlice(expectedTest, b.runConfig.Healthcheck.Test) {
-		t.Fatalf("Command should be set to %s, got %s", expectedTest, b.runConfig.Healthcheck.Test)
-	}
+	require.NotNil(t, req.runConfig.Healthcheck)
+	assert.Equal(t, []string{"NONE"}, req.runConfig.Healthcheck.Test)
 }
 
 func TestHealthcheckCmd(t *testing.T) {
-	b := &Builder{flags: &BFlags{flags: make(map[string]*Flag)}, runConfig: &container.Config{}, disableCommit: true}
+	b := newBuilderWithMockBackend()
 
-	if err := healthcheck(b, []string{"CMD", "curl", "-f", "http://localhost/", "||", "exit", "1"}, nil, ""); err != nil {
-		t.Fatalf("Error should be empty, got: %s", err.Error())
-	}
+	args := []string{"CMD", "curl", "-f", "http://localhost/", "||", "exit", "1"}
+	req := defaultDispatchReq(b, args...)
+	err := healthcheck(req)
+	require.NoError(t, err)
 
-	if b.runConfig.Healthcheck == nil {
-		t.Fatal("Healthcheck should be set, got nil")
-	}
-
-	expectedTest := strslice.StrSlice(append([]string{"CMD-SHELL"}, "curl -f http://localhost/ || exit 1"))
-
-	if !compareStrSlice(expectedTest, b.runConfig.Healthcheck.Test) {
-		t.Fatalf("Command should be set to %s, got %s", expectedTest, b.runConfig.Healthcheck.Test)
-	}
+	require.NotNil(t, req.runConfig.Healthcheck)
+	expectedTest := []string{"CMD-SHELL", "curl -f http://localhost/ || exit 1"}
+	assert.Equal(t, expectedTest, req.runConfig.Healthcheck.Test)
 }
 
 func TestEntrypoint(t *testing.T) {
-	b := &Builder{flags: &BFlags{}, runConfig: &container.Config{}, disableCommit: true}
-
+	b := newBuilderWithMockBackend()
 	entrypointCmd := "/usr/sbin/nginx"
 
-	if err := entrypoint(b, []string{entrypointCmd}, nil, ""); err != nil {
-		t.Fatalf("Error should be empty, got: %s", err.Error())
-	}
-
-	if b.runConfig.Entrypoint == nil {
-		t.Fatal("Entrypoint should be set")
-	}
+	req := defaultDispatchReq(b, entrypointCmd)
+	err := entrypoint(req)
+	require.NoError(t, err)
+	require.NotNil(t, req.runConfig.Entrypoint)
 
 	var expectedEntrypoint strslice.StrSlice
-
 	if runtime.GOOS == "windows" {
 		expectedEntrypoint = strslice.StrSlice(append([]string{"cmd"}, "/S", "/C", entrypointCmd))
 	} else {
 		expectedEntrypoint = strslice.StrSlice(append([]string{"/bin/sh"}, "-c", entrypointCmd))
 	}
-
-	if !compareStrSlice(expectedEntrypoint, b.runConfig.Entrypoint) {
-		t.Fatalf("Entrypoint command should be set to %s, got %s", expectedEntrypoint, b.runConfig.Entrypoint)
-	}
+	assert.Equal(t, expectedEntrypoint, req.runConfig.Entrypoint)
 }
 
 func TestExpose(t *testing.T) {
-	b := &Builder{flags: &BFlags{}, runConfig: &container.Config{}, disableCommit: true}
+	b := newBuilderWithMockBackend()
 
 	exposedPort := "80"
+	req := defaultDispatchReq(b, exposedPort)
+	err := expose(req)
+	require.NoError(t, err)
 
-	if err := expose(b, []string{exposedPort}, nil, ""); err != nil {
-		t.Fatalf("Error should be empty, got: %s", err.Error())
-	}
-
-	if b.runConfig.ExposedPorts == nil {
-		t.Fatal("ExposedPorts should be set")
-	}
-
-	if len(b.runConfig.ExposedPorts) != 1 {
-		t.Fatalf("ExposedPorts should contain only 1 element. Got %s", b.runConfig.ExposedPorts)
-	}
+	require.NotNil(t, req.runConfig.ExposedPorts)
+	require.Len(t, req.runConfig.ExposedPorts, 1)
 
 	portsMapping, err := nat.ParsePortSpec(exposedPort)
-
-	if err != nil {
-		t.Fatalf("Error when parsing port spec: %s", err.Error())
-	}
-
-	if _, ok := b.runConfig.ExposedPorts[portsMapping[0].Port]; !ok {
-		t.Fatalf("Port %s should be present. Got %s", exposedPort, b.runConfig.ExposedPorts)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, req.runConfig.ExposedPorts, portsMapping[0].Port)
 }
 
 func TestUser(t *testing.T) {
-	b := &Builder{flags: &BFlags{}, runConfig: &container.Config{}, disableCommit: true}
-
+	b := newBuilderWithMockBackend()
 	userCommand := "foo"
 
-	if err := user(b, []string{userCommand}, nil, ""); err != nil {
-		t.Fatalf("Error should be empty, got: %s", err.Error())
-	}
-
-	if b.runConfig.User != userCommand {
-		t.Fatalf("User should be set to %s, got %s", userCommand, b.runConfig.User)
-	}
+	req := defaultDispatchReq(b, userCommand)
+	err := user(req)
+	require.NoError(t, err)
+	assert.Equal(t, userCommand, req.runConfig.User)
 }
 
 func TestVolume(t *testing.T) {
-	b := &Builder{flags: &BFlags{}, runConfig: &container.Config{}, disableCommit: true}
+	b := newBuilderWithMockBackend()
 
 	exposedVolume := "/foo"
 
-	if err := volume(b, []string{exposedVolume}, nil, ""); err != nil {
-		t.Fatalf("Error should be empty, got: %s", err.Error())
-	}
+	req := defaultDispatchReq(b, exposedVolume)
+	err := volume(req)
+	require.NoError(t, err)
 
-	if b.runConfig.Volumes == nil {
-		t.Fatal("Volumes should be set")
-	}
-
-	if len(b.runConfig.Volumes) != 1 {
-		t.Fatalf("Volumes should contain only 1 element. Got %s", b.runConfig.Volumes)
-	}
-
-	if _, ok := b.runConfig.Volumes[exposedVolume]; !ok {
-		t.Fatalf("Volume %s should be present. Got %s", exposedVolume, b.runConfig.Volumes)
-	}
+	require.NotNil(t, req.runConfig.Volumes)
+	assert.Len(t, req.runConfig.Volumes, 1)
+	assert.Contains(t, req.runConfig.Volumes, exposedVolume)
 }
 
 func TestStopSignal(t *testing.T) {
-	b := &Builder{flags: &BFlags{}, runConfig: &container.Config{}, disableCommit: true}
-
+	b := newBuilderWithMockBackend()
 	signal := "SIGKILL"
 
-	if err := stopSignal(b, []string{signal}, nil, ""); err != nil {
-		t.Fatalf("Error should be empty, got: %s", err.Error())
-	}
-
-	if b.runConfig.StopSignal != signal {
-		t.Fatalf("StopSignal should be set to %s, got %s", signal, b.runConfig.StopSignal)
-	}
+	req := defaultDispatchReq(b, signal)
+	err := stopSignal(req)
+	require.NoError(t, err)
+	assert.Equal(t, signal, req.runConfig.StopSignal)
 }
 
 func TestArg(t *testing.T) {
@@ -507,33 +379,23 @@ func TestArg(t *testing.T) {
 	argVal := "bar"
 	argDef := fmt.Sprintf("%s=%s", argName, argVal)
 
-	err := arg(b, []string{argDef}, nil, "")
-	assert.NoError(t, err)
+	err := arg(defaultDispatchReq(b, argDef))
+	require.NoError(t, err)
 
 	expected := map[string]string{argName: argVal}
-	allowed := b.buildArgs.GetAllAllowed()
-	assert.Equal(t, expected, allowed)
+	assert.Equal(t, expected, b.buildArgs.GetAllAllowed())
 }
 
 func TestShell(t *testing.T) {
-	b := &Builder{flags: &BFlags{}, runConfig: &container.Config{}, disableCommit: true}
+	b := newBuilderWithMockBackend()
 
 	shellCmd := "powershell"
+	req := defaultDispatchReq(b, shellCmd)
+	req.attributes = map[string]bool{"json": true}
 
-	attrs := make(map[string]bool)
-	attrs["json"] = true
-
-	if err := shell(b, []string{shellCmd}, attrs, ""); err != nil {
-		t.Fatalf("Error should be empty, got: %s", err.Error())
-	}
-
-	if b.runConfig.Shell == nil {
-		t.Fatal("Shell should be set")
-	}
+	err := shell(req)
+	require.NoError(t, err)
 
 	expectedShell := strslice.StrSlice([]string{shellCmd})
-
-	if !compareStrSlice(expectedShell, b.runConfig.Shell) {
-		t.Fatalf("Shell should be set to %s, got %s", expectedShell, b.runConfig.Shell)
-	}
+	assert.Equal(t, expectedShell, req.runConfig.Shell)
 }

--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -20,9 +20,9 @@
 package dockerfile
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
-	"bytes"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder/dockerfile/command"

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -505,7 +505,7 @@ func (s *DockerSuite) TestBuildAddSingleFileToWorkdir(c *check.C) {
 
 func (s *DockerSuite) TestBuildAddSingleFileToExistDir(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
-	buildImageSuccessfully(c, "testaddsinglefiletoexistdir", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testaddsinglefiletoexistdir", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 RUN echo 'dockerio:x:1001:' >> /etc/group
@@ -561,13 +561,13 @@ func (s *DockerSuite) TestBuildUsernamespaceValidateRemappedRoot(c *check.C) {
 	}
 	name := "testbuildusernamespacevalidateremappedroot"
 	for _, tc := range testCases {
-		buildImageSuccessfully(c, name, build.WithBuildContext(c,
+		cli.BuildCmd(c, name, build.WithBuildContext(c,
 			build.WithFile("Dockerfile", fmt.Sprintf(`FROM busybox
 %s
 RUN [ $(ls -l / | grep new_dir | awk '{print $3":"$4}') = 'root:root' ]`, tc)),
 			build.WithFile("test_dir/test_file", "test file")))
 
-		dockerCmd(c, "rmi", name)
+		cli.DockerCmd(c, "rmi", name)
 	}
 }
 
@@ -576,7 +576,7 @@ func (s *DockerSuite) TestBuildAddAndCopyFileWithWhitespace(c *check.C) {
 	name := "testaddfilewithwhitespace"
 
 	for _, command := range []string{"ADD", "COPY"} {
-		buildImageSuccessfully(c, name, build.WithBuildContext(c,
+		cli.BuildCmd(c, name, build.WithBuildContext(c,
 			build.WithFile("Dockerfile", fmt.Sprintf(`FROM busybox
 RUN mkdir "/test dir"
 RUN mkdir "/test_dir"
@@ -600,7 +600,7 @@ RUN [ $(cat "/test dir/test_file6") = 'test6' ]`, command, command, command, com
 			build.WithFile("test dir/test_file6", "test6"),
 		))
 
-		dockerCmd(c, "rmi", name)
+		cli.DockerCmd(c, "rmi", name)
 	}
 }
 
@@ -623,7 +623,7 @@ RUN find "test5" "C:/test dir/test_file5"
 RUN find "test6" "C:/test dir/test_file6"`
 
 	name := "testcopyfilewithwhitespace"
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", dockerfile),
 		build.WithFile("test file1", "test1"),
 		build.WithFile("test_file2", "test2"),


### PR DESCRIPTION
The `dockerfile.Builder` struct has many responsibilities, one of which is a bunch of shared state for the dispatchers. This PR starts the process of removing the shared state from the `Builder` and moving into smaller structs that don't need to be shared with everything.

* Removes the `Builder.flags` field.
* Creates a new `dispatchRequest` struct which should contain all the data required by a dispatcher. Currently it still has to include a reference to the builder, but as we continue to refactor this will eventually be removed.