### PR TITLE
fix c.spec() == nil cause nil point panic

### DIFF
--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -133,6 +133,9 @@ func (c *containerConfig) name() string {
 }
 
 func (c *containerConfig) image() string {
+	if c.spec() == nil {
+		return ""
+	}
 	raw := c.spec().Image
 	ref, err := reference.ParseNormalizedNamed(raw)
 	if err != nil {
@@ -187,25 +190,28 @@ func (c *containerConfig) exposedPorts() map[nat.Port]struct{} {
 func (c *containerConfig) config() *enginecontainer.Config {
 	config := &enginecontainer.Config{
 		Labels:       c.labels(),
-		StopSignal:   c.spec().StopSignal,
-		Tty:          c.spec().TTY,
-		OpenStdin:    c.spec().OpenStdin,
-		User:         c.spec().User,
-		Env:          c.spec().Env,
-		Hostname:     c.spec().Hostname,
-		WorkingDir:   c.spec().Dir,
 		Image:        c.image(),
 		ExposedPorts: c.exposedPorts(),
 		Healthcheck:  c.healthcheck(),
 	}
 
-	if len(c.spec().Command) > 0 {
+	if c.spec() != nil {
+		config.StopSignal = c.spec().StopSignal
+		config.Tty = c.spec().TTY
+		config.OpenStdin = c.spec().OpenStdin
+		config.User = c.spec().User
+		config.Env = c.spec().Env
+		config.Hostname = c.spec().Hostname
+		config.WorkingDir = c.spec().Dir
+	}
+
+	if c.spec() != nil && len(c.spec().Command) > 0 {
 		// If Command is provided, we replace the whole invocation with Command
 		// by replacing Entrypoint and specifying Cmd. Args is ignored in this
 		// case.
 		config.Entrypoint = append(config.Entrypoint, c.spec().Command...)
 		config.Cmd = append(config.Cmd, c.spec().Args...)
-	} else if len(c.spec().Args) > 0 {
+	} else if c.spec() != nil && len(c.spec().Args) > 0 {
 		// In this case, we assume the image has an Entrypoint and Args
 		// specifies the arguments for that entrypoint.
 		config.Cmd = c.spec().Args
@@ -228,8 +234,10 @@ func (c *containerConfig) labels() map[string]string {
 	)
 
 	// base labels are those defined in the spec.
-	for k, v := range c.spec().Labels {
-		labels[k] = v
+	if c.spec() != nil {
+		for k, v := range c.spec().Labels {
+			labels[k] = v
+		}
 	}
 
 	// we then apply the overrides from the task, which may be set via the
@@ -248,8 +256,10 @@ func (c *containerConfig) labels() map[string]string {
 
 func (c *containerConfig) mounts() []enginemount.Mount {
 	var r []enginemount.Mount
-	for _, mount := range c.spec().Mounts {
-		r = append(r, convertMount(mount))
+	if c.spec() != nil {
+		for _, mount := range c.spec().Mounts {
+			r = append(r, convertMount(mount))
+		}
 	}
 	return r
 }
@@ -322,6 +332,9 @@ func convertMount(m api.Mount) enginemount.Mount {
 }
 
 func (c *containerConfig) healthcheck() *enginecontainer.HealthConfig {
+	if c.spec() == nil {
+		return nil
+	}
 	hcSpec := c.spec().Healthcheck
 	if hcSpec == nil {
 		return nil
@@ -340,32 +353,35 @@ func (c *containerConfig) healthcheck() *enginecontainer.HealthConfig {
 
 func (c *containerConfig) hostConfig() *enginecontainer.HostConfig {
 	hc := &enginecontainer.HostConfig{
-		Resources:      c.resources(),
-		GroupAdd:       c.spec().Groups,
-		PortBindings:   c.portBindings(),
-		Mounts:         c.mounts(),
-		ReadonlyRootfs: c.spec().ReadOnly,
+		Resources:    c.resources(),
+		PortBindings: c.portBindings(),
+		Mounts:       c.mounts(),
 	}
 
-	if c.spec().DNSConfig != nil {
-		hc.DNS = c.spec().DNSConfig.Nameservers
-		hc.DNSSearch = c.spec().DNSConfig.Search
-		hc.DNSOptions = c.spec().DNSConfig.Options
-	}
+	if c.spec() != nil {
+		hc.GroupAdd = c.spec().Groups
+		hc.ReadonlyRootfs = c.spec().ReadOnly
 
-	c.applyPrivileges(hc)
+		if c.spec().DNSConfig != nil {
+			hc.DNS = c.spec().DNSConfig.Nameservers
+			hc.DNSSearch = c.spec().DNSConfig.Search
+			hc.DNSOptions = c.spec().DNSConfig.Options
+		}
 
-	// The format of extra hosts on swarmkit is specified in:
-	// http://man7.org/linux/man-pages/man5/hosts.5.html
-	//    IP_address canonical_hostname [aliases...]
-	// However, the format of ExtraHosts in HostConfig is
-	//    <host>:<ip>
-	// We need to do the conversion here
-	// (Alias is ignored for now)
-	for _, entry := range c.spec().Hosts {
-		parts := strings.Fields(entry)
-		if len(parts) > 1 {
-			hc.ExtraHosts = append(hc.ExtraHosts, fmt.Sprintf("%s:%s", parts[1], parts[0]))
+		c.applyPrivileges(hc)
+
+		// The format of extra hosts on swarmkit is specified in:
+		// http://man7.org/linux/man-pages/man5/hosts.5.html
+		//    IP_address canonical_hostname [aliases...]
+		// However, the format of ExtraHosts in HostConfig is
+		//    <host>:<ip>
+		// We need to do the conversion here
+		// (Alias is ignored for now)
+		for _, entry := range c.spec().Hosts {
+			parts := strings.Fields(entry)
+			if len(parts) > 1 {
+				hc.ExtraHosts = append(hc.ExtraHosts, fmt.Sprintf("%s:%s", parts[1], parts[0]))
+			}
 		}
 	}
 


### PR DESCRIPTION
fix c.spec() == nil cause nil point panic on `docker run --net` at attachable network

Signed-off-by: bingshen.wbs <bingshen.wbs@alibaba-inc.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

