### PR TITLE
[17.05] Vendor swarmkit 78685cf

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -105,7 +105,7 @@ github.com/docker/containerd 9048e5e50717ea4497b757314bad98ea3763c145
 github.com/tonistiigi/fifo 1405643975692217d6720f8b54aeee1bf2cd5cf4
 
 # cluster
-github.com/docker/swarmkit 6a6f38c02f1c96b1d3c548e45927349656ae37a1
+github.com/docker/swarmkit 78685cfc94de06f21d65d0d30b6f61e80d250c45
 github.com/gogo/protobuf 8d70fb3182befc465c4a1eac8ad4d38ff49778e2
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a
 github.com/google/certificate-transparency d90e65c3a07988180c5b1ece71791c0b6506826e


### PR DESCRIPTION
This brings in https://github.com/docker/swarmkit/pull/2127. It fixes a regression when a current version of Docker joins a cluster that had managers running older versions. In that case, the new node might not join successfully, and it could end up in a certificate rotation loop.

This is backport of the fix for #32385

ping @vieux