### PR TITLE
Hide zero-valued timestamps from service JSON

### DIFF
--- a/cli/command/formatter/service.go
+++ b/cli/command/formatter/service.go
@@ -224,7 +224,7 @@ func (ctx *serviceInspectContext) HasUpdateStatusStarted() bool {
 }
 
 func (ctx *serviceInspectContext) UpdateStatusStarted() string {
-	return units.HumanDuration(time.Since(*ctx.Service.UpdateStatus.StartedAt))
+	return units.HumanDuration(time.Since(*ctx.Service.UpdateStatus.StartedAt)) + " ago"
 }
 
 func (ctx *serviceInspectContext) UpdateIsCompleted() bool {
@@ -232,7 +232,7 @@ func (ctx *serviceInspectContext) UpdateIsCompleted() bool {
 }
 
 func (ctx *serviceInspectContext) UpdateStatusCompleted() string {
-	return units.HumanDuration(time.Since(*ctx.Service.UpdateStatus.CompletedAt))
+	return units.HumanDuration(time.Since(*ctx.Service.UpdateStatus.CompletedAt)) + " ago"
 }
 
 func (ctx *serviceInspectContext) UpdateStatusMessage() string {

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -58,12 +58,12 @@ func ServiceFromGRPC(s swarmapi.Service) (types.Service, error) {
 		}
 
 		startedAt, _ := gogotypes.TimestampFromProto(s.UpdateStatus.StartedAt)
-		if !startedAt.IsZero() {
+		if !startedAt.IsZero() && startedAt.Unix() != 0 {
 			service.UpdateStatus.StartedAt = &startedAt
 		}
 
 		completedAt, _ := gogotypes.TimestampFromProto(s.UpdateStatus.CompletedAt)
-		if !completedAt.IsZero() {
+		if !completedAt.IsZero() && completedAt.Unix() != 0 {
 			service.UpdateStatus.CompletedAt = &completedAt
 		}
 


### PR DESCRIPTION
It was possible to see output like this:

        "UpdateStatus": {
            "State": "updating",
            "StartedAt": "2017-04-14T17:10:03.226607162Z",
            "CompletedAt": "1970-01-01T00:00:00Z",
            "Message": "update in progress"
        }

The timestamp fields were already changed to pointers, and left nil if
the timestamp value was zero. However the zero-value of a timestamp from
gRPC is different from the value Go considers to be zero. gRPC uses the
Unix epoch instead of Go's epoch. Therefore, check that the timestamp
does not match the Unix epoch.

Also, add " ago" to the timestamps as shown in "docker service inspect
--pretty", as they are shown as relative times.

Fixes #32625