### PR TITLE
Avoid using "example.com" in integration test

### DIFF
--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 
@@ -120,13 +121,16 @@ func (s *DockerSuite) TestAPIImagesHistory(c *check.C) {
 func (s *DockerSuite) TestAPIImagesImportBadSrc(c *check.C) {
 	testRequires(c, Network)
 
+	server := httptest.NewServer(http.NewServeMux())
+	defer server.Close()
+
 	tt := []struct {
 		statusExp int
 		fromSrc   string
 	}{
-		{http.StatusNotFound, "http://example.com/nofile.tar"},
-		{http.StatusNotFound, "example.com/nofile.tar"},
-		{http.StatusNotFound, "example.com%2Fdata%2Ffile.tar"},
+		{http.StatusNotFound, server.URL + "/nofile.tar"},
+		{http.StatusNotFound, strings.TrimPrefix(server.URL, "http://") + "/nofile.tar"},
+		{http.StatusNotFound, strings.TrimPrefix(server.URL, "http://") + "%2Fdata%2Ffile.tar"},
 		{http.StatusInternalServerError, "%2Fdata%2Ffile.tar"},
 	}
 


### PR DESCRIPTION
This test appears to trigger HTTP requests to "example.com", which may
explain why it is not behaving consistently. This changes it to use an
internal HTTP server to avoid unexpected behavior caused by firewalls or
proxies.

Attempts to fix #32267

cc @vdemeester @tophj-ibm @michael-holzheu