### PR TITLE
Minor fixups for history CLI reference

### DIFF
--- a/docs/reference/commandline/history.md
+++ b/docs/reference/commandline/history.md
@@ -58,19 +58,19 @@ c69cab00d6ef        5 months ago        /bin/sh -c #(nop) MAINTAINER Lokesh Mand
 
 ### Format the output
 
-The formatting option (`--format`) will pretty print history output
+The formatting option (`--format`) will pretty-prints history output
 using a Go template.
 
 Valid placeholders for the Go template are listed below:
 
-| Placeholder | Description|
-| ---- | ---- |
-| `.ID` | Image ID |
-| `.CreatedSince` | Elapsed time since the image was created if --human=true, otherwise timestamp of when image was created |
-| `.CreatedAt` | Timestamp of when image was created |
-| `.CreatedBy` | Command that was used to create the image |
-| `.Size` | Image disk size |
-| `.Comment` | Comment for image |
+| Placeholder     | Description |
+| --------------- | ----------- |
+| `.ID`           | Image ID    |
+| `.CreatedSince` | Elapsed time since the image was created if `--human=true`, otherwise timestamp of when image was created |
+| `.CreatedAt`    | Timestamp of when image was created |
+| `.CreatedBy`    | Command that was used to create the image |
+| `.Size`         | Image disk size |
+| `.Comment`      | Comment for image |
 
 When using the `--format` option, the `history` command will either
 output the data exactly as the template declares or, when using the
@@ -80,7 +80,6 @@ The following example uses a template without headers and outputs the
 `ID` and `CreatedSince` entries separated by a colon for all images:
 
 ```bash
-{% raw %}
 $ docker images --format "{{.ID}}: {{.Created}} ago"
 
 cc1b61406712: 2 weeks ago
@@ -91,6 +90,4 @@ cc1b61406712: 2 weeks ago
 <missing>: 3 weeks ago
 <missing>: 3 weeks ago
 <missing>: 3 weeks ago
-
-{% endraw %}
 ```

--- a/man/src/image/history.md
+++ b/man/src/image/history.md
@@ -16,3 +16,39 @@ The `docker commit` command has a **-m** flag for adding comments to the image. 
     88b42ffd1f7c        5 months ago        /bin/sh -c #(nop) ADD file:1fd8d7f9f6557cafc7   373.7 MB            
     c69cab00d6ef        5 months ago        /bin/sh -c #(nop) MAINTAINER Lokesh Mandvekar   0 B                 
     511136ea3c5a        19 months ago                                                       0 B                 Imported from -
+
+### Format the output
+
+The formatting option (`--format`) will pretty-prints history output
+using a Go template.
+
+Valid placeholders for the Go template are listed below:
+
+| Placeholder     | Description |
+| --------------- | ----------- |
+| `.ID`           | Image ID    |
+| `.CreatedSince` | Elapsed time since the image was created if `--human=true`, otherwise timestamp of when image was created |
+| `.CreatedAt`    | Timestamp of when image was created |
+| `.CreatedBy`    | Command that was used to create the image |
+| `.Size`         | Image disk size |
+| `.Comment`      | Comment for image |
+
+When using the `--format` option, the `history` command will either
+output the data exactly as the template declares or, when using the
+`table` directive, will include column headers as well.
+
+The following example uses a template without headers and outputs the
+`ID` and `CreatedSince` entries separated by a colon for all images:
+
+```bash
+$ docker images --format "{{.ID}}: {{.Created}} ago"
+
+cc1b61406712: 2 weeks ago
+<missing>: 2 weeks ago
+<missing>: 2 weeks ago
+<missing>: 2 weeks ago
+<missing>: 2 weeks ago
+<missing>: 3 weeks ago
+<missing>: 3 weeks ago
+<missing>: 3 weeks ago
+```


### PR DESCRIPTION
This does some minor fix-ups in the CLI reference
for "history", and copies the formattting section to
the man-pages.

follow-up to https://github.com/docker/docker/pull/30962