### PR TITLE
add empty string for restart policy in swagger.yml

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -308,10 +308,12 @@ definitions:
       Name:
         type: "string"
         description: |
+          - Empty string means not to restart
           - `always` Always restart
           - `unless-stopped` Restart always except when the user has manually stopped the container
           - `on-failure` Restart only when the container exit code is non-zero
         enum:
+          - ""
           - "always"
           - "unless-stopped"
           - "on-failure"


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I think when we create a container, we can set the restart policy to be empty string to mean that we take no action when container stops.

While in swagger.yml, I think we missed the empty string. This PR tries to add such case.

**- What I did**
1. add empty string for restart policy in swagger.yml

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

