### PR TITLE
use make slice to store cluster objects to improve efficiency

### DIFF
--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -37,7 +37,7 @@ func (c *Cluster) getNetworks(filters *swarmapi.ListNetworksRequest_Filters) ([]
 		return nil, err
 	}
 
-	var networks []apitypes.NetworkResource
+	networks := make([]apitypes.NetworkResource, 0, len(r.Networks))
 
 	for _, network := range r.Networks {
 		networks = append(networks, convert.BasicNetworkFromGRPC(*network))

--- a/daemon/cluster/nodes.go
+++ b/daemon/cluster/nodes.go
@@ -34,7 +34,7 @@ func (c *Cluster) GetNodes(options apitypes.NodeListOptions) ([]types.Node, erro
 		return nil, err
 	}
 
-	nodes := []types.Node{}
+	nodes := make([]types.Node, 0, len(r.Nodes))
 
 	for _, node := range r.Nodes {
 		nodes = append(nodes, convert.NodeFromGRPC(*node))

--- a/daemon/cluster/secrets.go
+++ b/daemon/cluster/secrets.go
@@ -48,7 +48,7 @@ func (c *Cluster) GetSecrets(options apitypes.SecretListOptions) ([]types.Secret
 		return nil, err
 	}
 
-	secrets := []types.Secret{}
+	secrets := make([]types.Secret, 0, len(r.Secrets))
 
 	for _, secret := range r.Secrets {
 		secrets = append(secrets, convert.SecretFromGRPC(secret))

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -67,7 +67,7 @@ func (c *Cluster) GetServices(options apitypes.ServiceListOptions) ([]types.Serv
 		return nil, err
 	}
 
-	services := []types.Service{}
+	services := make([]types.Service, 0, len(r.Services))
 
 	for _, service := range r.Services {
 		if options.Filters.Include("mode") {

--- a/daemon/cluster/tasks.go
+++ b/daemon/cluster/tasks.go
@@ -60,7 +60,7 @@ func (c *Cluster) GetTasks(options apitypes.TaskListOptions) ([]types.Task, erro
 		return nil, err
 	}
 
-	tasks := []types.Task{}
+	tasks := make([]types.Task, 0, len(r.Tasks))
 
 	for _, task := range r.Tasks {
 		if task.Spec.GetContainer() != nil {


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

we we know the slice length in advance, I think we had better use make to create the specified length of slice. This will improve some kind of performance. Since if we create a slice with `[]type{}`, we did not know how much space runtime should reserve, sine slice implementation should be continuous in memory. While when we make a slice with specified length, runtime would reserve a continuous memory space which will not result in slice movement in case of current space is not enough.

**- What I did**
1. use make slice to store objects to improve efficiency

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

