### PR TITLE
[WIP] [RFC] Docker runtime plug-in infrastructure

### DIFF
--- a/api/server/router/runtime/backend.go
+++ b/api/server/router/runtime/backend.go
@@ -1,0 +1,12 @@
+package runtime
+
+import (
+	"github.com/docker/docker/api/types/runtime"
+)
+
+// Backend is all the methods that need to be implemented by
+// a runtime manager
+type Backend interface {
+	ListRuntimes() (runtime.GetRuntimesResponse, error)
+	SetDefaultRuntime(runtime string) error
+}

--- a/api/server/router/runtime/runtime.go
+++ b/api/server/router/runtime/runtime.go
@@ -1,0 +1,33 @@
+package runtime
+
+import "github.com/docker/docker/api/server/router"
+
+// runtimeRouter is a router to talk with the runtime controller
+type runtimeRouter struct {
+	backend Backend
+	routes  []router.Route
+}
+
+// NewRouter initializes a new runtime router
+func NewRouter(b Backend) router.Router {
+	r := &runtimeRouter{
+		backend: b,
+	}
+	r.initRoutes()
+	return r
+}
+
+// Routes returns the available routers to the runtime controller
+func (rr *runtimeRouter) Routes() []router.Route {
+	return rr.routes
+}
+
+func (rr *runtimeRouter) initRoutes() {
+	rr.routes = []router.Route{
+		// GET
+		router.NewGetRoute("/runtimes", rr.getRuntimes),
+
+		// POST
+		router.NewPostRoute("/runtimes/{id}/default", rr.postRuntimeDefault),
+	}
+}

--- a/api/server/router/runtime/runtime_routes.go
+++ b/api/server/router/runtime/runtime_routes.go
@@ -1,0 +1,36 @@
+package runtime
+
+import (
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/server/httputils"
+	"golang.org/x/net/context"
+)
+
+func (rr *runtimeRouter) getRuntimes(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+
+	runtimes, err := rr.backend.ListRuntimes()
+	if err != nil {
+		logrus.Errorf("Error getting runtimes: %v", err)
+		return err
+	}
+
+	return httputils.WriteJSON(w, http.StatusOK, runtimes)
+}
+
+func (rr *runtimeRouter) postRuntimeDefault(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+
+	if err := rr.backend.SetDefaultRuntime(r.Form.Get("runtime")); err != nil {
+		return err
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	return nil
+}

--- a/api/types/runtime/runtime.go
+++ b/api/types/runtime/runtime.go
@@ -1,0 +1,30 @@
+package runtime
+
+// Runtime describes an OCI runtime configuration
+type Runtime struct {
+	Path string   `json:"path"`
+	Args []string `json:"runtimeArgs,omitempty"`
+}
+
+type Info struct {
+	Name           string
+	DefaultRuntime bool
+	Runtime        Runtime
+}
+
+const (
+	GetPath = "RuntimeDriver.Path"
+	GetArgs = "RuntimeDriver.Args"
+)
+
+type GetRuntimesResponse struct {
+	Runtimes []Info `json:"runtimes"`
+}
+
+type PluginPathResponse struct {
+	Path string `json:"path"`
+}
+
+type PluginArgsResponse struct {
+	Args []string `json:"args,omitempty"`
+}

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/api/types/runtime"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/go-connections/nat"
 )
@@ -172,7 +173,7 @@ type Info struct {
 	ServerVersion      string
 	ClusterStore       string
 	ClusterAdvertise   string
-	Runtimes           map[string]Runtime
+	Runtimes           map[string]runtime.Runtime
 	DefaultRuntime     string
 	Swarm              swarm.Info
 	// LiveRestoreEnabled determines whether containers should be kept
@@ -464,12 +465,6 @@ type NetworkDisconnect struct {
 // Checkpoint represents the details of a checkpoint
 type Checkpoint struct {
 	Name string // Name is the name of the checkpoint
-}
-
-// Runtime describes an OCI runtime
-type Runtime struct {
-	Path string   `json:"path"`
-	Args []string `json:"runtimeArgs,omitempty"`
 }
 
 // DiskUsage contains response of Engine API:

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/cli/command/node"
 	"github.com/docker/docker/cli/command/plugin"
 	"github.com/docker/docker/cli/command/registry"
+	"github.com/docker/docker/cli/command/runtime"
 	"github.com/docker/docker/cli/command/secret"
 	"github.com/docker/docker/cli/command/service"
 	"github.com/docker/docker/cli/command/stack"
@@ -47,6 +48,9 @@ func AddCommands(cmd *cobra.Command, dockerCli *command.DockerCli) {
 		registry.NewLoginCommand(dockerCli),
 		registry.NewLogoutCommand(dockerCli),
 		registry.NewSearchCommand(dockerCli),
+
+		// runtime
+		runtime.NewRuntimeCommand(dockerCli),
 
 		// secret
 		secret.NewSecretCommand(dockerCli),

--- a/cli/command/formatter/runtime.go
+++ b/cli/command/formatter/runtime.go
@@ -1,0 +1,81 @@
+package formatter
+
+import (
+	"strings"
+
+	"github.com/docker/docker/api/types/runtime"
+)
+
+const (
+	defaultRuntimeTableFormat = "table {{.Name}}\t{{.Path}}\t{{.Args}}\t{{.Default}}"
+	runtimeNameHeader         = "NAME"
+	runtimePathHeader         = "PATH"
+	runtimeArgsHeader         = "ARGS"
+	runtimeDefaultHeader      = "DEFAULT"
+)
+
+// NewRuntimeFormat returns a Format for rendering
+func NewRuntimeFormat(source string, quiet bool) Format {
+	switch source {
+	case TableFormatKey:
+		if quiet {
+			return defaultQuietFormat
+		}
+		return defaultRuntimeTableFormat
+	}
+	return Format(source)
+}
+
+// RuntimeWrite writes the context
+func RuntimeWrite(ctx Context, runtimes []runtime.Info) error {
+	render := func(format func(subContext subContext) error) error {
+		for _, runtime := range runtimes {
+			if err := format(&runtimeContext{r: runtime}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return ctx.Write(newRuntimeContext(), render)
+}
+
+func newRuntimeContext() *runtimeContext {
+	rCtx := &runtimeContext{}
+
+	rCtx.header = map[string]string{
+		"Name":    runtimeNameHeader,
+		"Path":    runtimePathHeader,
+		"Args":    runtimeArgsHeader,
+		"Default": runtimeDefaultHeader,
+	}
+	return rCtx
+}
+
+type runtimeContext struct {
+	HeaderContext
+	r runtime.Info
+}
+
+func (c *runtimeContext) MarshalJSON() ([]byte, error) {
+	return marshalJSON(c)
+}
+
+func (c *runtimeContext) Name() string {
+	return c.r.Name
+}
+
+func (c *runtimeContext) Path() string {
+	return c.r.Runtime.Path
+}
+
+func (c *runtimeContext) Args() string {
+	return strings.Join(c.r.Runtime.Args, " ")
+}
+
+func (c *runtimeContext) Default() string {
+	if c.r.DefaultRuntime {
+		return "*"
+	}
+
+	return ""
+}

--- a/cli/command/runtime/cmd.go
+++ b/cli/command/runtime/cmd.go
@@ -1,0 +1,23 @@
+package runtime
+
+import (
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/command"
+	"github.com/spf13/cobra"
+)
+
+// NewRuntimeCommand returns a cobra command for `runtime` subcommands
+func NewRuntimeCommand(dockerCli *command.DockerCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "runtime COMMAND",
+		Short: "Manage runtimes",
+		Args:  cli.NoArgs,
+		RunE:  dockerCli.ShowHelp,
+		Tags:  map[string]string{"version": "1.21"},
+	}
+	cmd.AddCommand(
+		newListCommand(dockerCli),
+		newDefaultCommand(dockerCli),
+	)
+	return cmd
+}

--- a/cli/command/runtime/default.go
+++ b/cli/command/runtime/default.go
@@ -1,0 +1,39 @@
+package runtime
+
+import (
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/command"
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
+)
+
+func newDefaultCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "default RUNTIME [VOLUME...]",
+		Aliases: []string{"default"},
+		Short:   "Select a default runtime",
+		Long:    defaultDescription,
+		Example: defaultExample,
+		Args:    cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDefault(dockerCli, args[0])
+		},
+	}
+
+	return cmd
+}
+
+func runDefault(dockerCli command.Cli, runtime string) error {
+	client := dockerCli.Client()
+
+	return client.RuntimeDefault(context.Background(), runtime)
+}
+
+var defaultDescription = `
+Set the default runtime. This overrides the default runtime selection done through the dockerd command line.
+`
+
+var defaultExample = `
+$ docker runtime default clearcontainers/runtime:2.1.3
+clearcontainers/runtime:2.1.3
+`

--- a/cli/command/runtime/list.go
+++ b/cli/command/runtime/list.go
@@ -1,0 +1,74 @@
+package runtime
+
+import (
+	"sort"
+
+	"github.com/docker/docker/api/types/runtime"
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/command"
+	"github.com/docker/docker/cli/command/formatter"
+	"github.com/docker/docker/opts"
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
+)
+
+type byRuntimeName []runtime.Info
+
+func (r byRuntimeName) Len() int      { return len(r) }
+func (r byRuntimeName) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
+func (r byRuntimeName) Less(i, j int) bool {
+	return r[i].Name < r[j].Name
+}
+
+type listOptions struct {
+	quiet  bool
+	format string
+	filter opts.FilterOpt
+}
+
+func newListCommand(dockerCli command.Cli) *cobra.Command {
+	opts := listOptions{filter: opts.NewFilterOpt()}
+
+	cmd := &cobra.Command{
+		Use:     "ls [OPTIONS]",
+		Aliases: []string{"list"},
+		Short:   "List runtimes",
+		Args:    cli.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(dockerCli, opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Only display runtime names")
+	flags.StringVar(&opts.format, "format", "", "Pretty-print runtimes using a Go template")
+	flags.VarP(&opts.filter, "filter", "f", "Provide filter values (e.g. 'dangling=true')")
+
+	return cmd
+}
+
+func runList(dockerCli command.Cli, opts listOptions) error {
+	client := dockerCli.Client()
+	runtimes, err := client.RuntimeList(context.Background(), opts.filter.Value())
+	if err != nil {
+		return err
+	}
+
+	format := opts.format
+	if len(format) == 0 {
+		if len(dockerCli.ConfigFile().RuntimesFormat) > 0 && !opts.quiet {
+			format = dockerCli.ConfigFile().RuntimesFormat
+		} else {
+			format = formatter.TableFormatKey
+		}
+	}
+
+	sort.Sort(byRuntimeName(runtimes))
+
+	runtimeCtx := formatter.Context{
+		Output: dockerCli.Out(),
+		Format: formatter.NewRuntimeFormat(format, opts.quiet),
+	}
+
+	return formatter.RuntimeWrite(runtimeCtx, runtimes)
+}

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -37,6 +37,7 @@ type ConfigFile struct {
 	ServiceInspectFormat string                      `json:"serviceInspectFormat,omitempty"`
 	ServicesFormat       string                      `json:"servicesFormat,omitempty"`
 	TasksFormat          string                      `json:"tasksFormat,omitempty"`
+	RuntimesFormat       string                      `json:"runtimesFormat,omitempty"`
 	SecretFormat         string                      `json:"secretFormat,omitempty"`
 	NodesFormat          string                      `json:"nodesFormat,omitempty"`
 	PruneFilters         []string                    `json:"pruneFilters,omitempty"`

--- a/client/interface.go
+++ b/client/interface.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/api/types/runtime"
 	"github.com/docker/docker/api/types/swarm"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"golang.org/x/net/context"
@@ -23,6 +24,7 @@ type CommonAPIClient interface {
 	NodeAPIClient
 	NetworkAPIClient
 	PluginAPIClient
+	RuntimeAPIClient
 	ServiceAPIClient
 	SwarmAPIClient
 	SecretAPIClient
@@ -161,6 +163,12 @@ type VolumeAPIClient interface {
 	VolumeList(ctx context.Context, filter filters.Args) (volumetypes.VolumesListOKBody, error)
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
 	VolumesPrune(ctx context.Context, pruneFilter filters.Args) (types.VolumesPruneReport, error)
+}
+
+// RuntimeAPIClient defines API client methods for runtimes
+type RuntimeAPIClient interface {
+	RuntimeList(ctx context.Context, filter filters.Args) ([]runtime.Info, error)
+	RuntimeDefault(ctx context.Context, runtime string) error
 }
 
 // SecretAPIClient defines API client methods for secrets

--- a/client/runtime_default.go
+++ b/client/runtime_default.go
@@ -1,0 +1,17 @@
+package client
+
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+)
+
+// RuntimeDefault sets the default runtime
+func (cli *Client) RuntimeDefault(ctx context.Context, runtime string) error {
+	query := url.Values{}
+	query.Set("runtime", runtime)
+
+	resp, err := cli.post(ctx, "/runtimes/"+runtime+"/default", query, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/client/runtime_list.go
+++ b/client/runtime_list.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/runtime"
+	"golang.org/x/net/context"
+)
+
+// RuntimeList returns the list of managed runtimes in the Docker host.
+func (cli *Client) RuntimeList(ctx context.Context, filter filters.Args) ([]runtime.Info, error) {
+	var runtimes runtime.GetRuntimesResponse
+	query := url.Values{}
+
+	if filter.Len() > 0 {
+		filterJSON, err := filters.ToParamWithVersion(cli.version, filter)
+		if err != nil {
+			return []runtime.Info{}, err
+		}
+		query.Set("filters", filterJSON)
+	}
+	resp, err := cli.get(ctx, "/runtimes", query, nil)
+	if err != nil {
+		return []runtime.Info{}, err
+	}
+
+	err = json.NewDecoder(resp.body).Decode(&runtimes)
+	ensureReaderClosed(resp)
+
+	return runtimes.Runtimes, err
+}

--- a/cmd/dockerd/config_common_unix.go
+++ b/cmd/dockerd/config_common_unix.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/runtime"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/opts"
 	"github.com/spf13/pflag"
@@ -18,7 +18,7 @@ var (
 // installUnixConfigFlags adds command-line options to the top-level flag parser for
 // the current process that are common across Unix platforms.
 func installUnixConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
-	conf.Runtimes = make(map[string]types.Runtime)
+	conf.Runtimes = make(map[string]runtime.Runtime)
 
 	flags.StringVarP(&conf.SocketGroup, "group", "G", "docker", "Group for the unix socket")
 	flags.StringVar(&conf.BridgeConfig.IP, "bip", "", "Specify network bridge IP")

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -24,6 +24,7 @@ import (
 	pluginrouter "github.com/docker/docker/api/server/router/plugin"
 	swarmrouter "github.com/docker/docker/api/server/router/swarm"
 	systemrouter "github.com/docker/docker/api/server/router/system"
+	runtimerouter "github.com/docker/docker/api/server/router/runtime"
 	"github.com/docker/docker/api/server/router/volume"
 	"github.com/docker/docker/builder/dockerfile"
 	cliconfig "github.com/docker/docker/cli/config"
@@ -487,6 +488,7 @@ func initRouter(s *apiserver.Server, d *daemon.Daemon, c *cluster.Cluster) {
 		build.NewRouter(dockerfile.NewBuildManager(d)),
 		swarmrouter.NewRouter(c),
 		pluginrouter.NewRouter(d.PluginManager()),
+		runtimerouter.NewRouter(d),
 	}
 
 	if d.NetworkControllerEnabled() {

--- a/daemon/config/config_common_unix.go
+++ b/daemon/config/config_common_unix.go
@@ -5,17 +5,17 @@ package config
 import (
 	"net"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/runtime"
 )
 
 // CommonUnixConfig defines configuration of a docker daemon that is
 // common across Unix platforms.
 type CommonUnixConfig struct {
-	ExecRoot          string                   `json:"exec-root,omitempty"`
-	ContainerdAddr    string                   `json:"containerd,omitempty"`
-	Runtimes          map[string]types.Runtime `json:"runtimes,omitempty"`
-	DefaultRuntime    string                   `json:"default-runtime,omitempty"`
-	DefaultInitBinary string                   `json:"default-init,omitempty"`
+	ExecRoot          string                     `json:"exec-root,omitempty"`
+	ContainerdAddr    string                     `json:"containerd,omitempty"`
+	Runtimes          map[string]runtime.Runtime `json:"runtimes,omitempty"`
+	DefaultRuntime    string                     `json:"default-runtime,omitempty"`
+	DefaultInitBinary string                     `json:"default-init,omitempty"`
 }
 
 type commonUnixBridgeConfig struct {
@@ -28,7 +28,7 @@ type commonUnixBridgeConfig struct {
 
 // GetRuntime returns the runtime path and arguments for a given
 // runtime name
-func (conf *Config) GetRuntime(name string) *types.Runtime {
+func (conf *Config) GetRuntime(name string) *runtime.Runtime {
 	conf.Lock()
 	defer conf.Unlock()
 	if rt, ok := conf.Runtimes[name]; ok {
@@ -47,7 +47,7 @@ func (conf *Config) GetDefaultRuntimeName() string {
 }
 
 // GetAllRuntimes returns a copy of the runtimes map
-func (conf *Config) GetAllRuntimes() map[string]types.Runtime {
+func (conf *Config) GetAllRuntimes() map[string]runtime.Runtime {
 	conf.Lock()
 	rts := conf.Runtimes
 	conf.Unlock()

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/docker/api/types/blkiodev"
 	pblkiodev "github.com/docker/docker/api/types/blkiodev"
 	containertypes "github.com/docker/docker/api/types/container"
+	runtimetypes "github.com/docker/docker/api/types/runtime"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/image"
@@ -585,7 +586,7 @@ func (daemon *Daemon) reloadPlatform(conf *config.Config, attributes map[string]
 	if conf.IsValueSet("runtimes") {
 		daemon.configStore.Runtimes = conf.Runtimes
 		// Always set the default one
-		daemon.configStore.Runtimes[config.StockRuntimeName] = types.Runtime{Path: DefaultRuntimeBinary}
+		daemon.configStore.Runtimes[config.StockRuntimeName] = runtimetypes.Runtime{Path: DefaultRuntimeBinary}
 	}
 
 	if conf.DefaultRuntime != "" {
@@ -635,9 +636,9 @@ func verifyDaemonSettings(conf *config.Config) error {
 		conf.DefaultRuntime = config.StockRuntimeName
 	}
 	if conf.Runtimes == nil {
-		conf.Runtimes = make(map[string]types.Runtime)
+		conf.Runtimes = make(map[string]runtimetypes.Runtime)
 	}
-	conf.Runtimes[config.StockRuntimeName] = types.Runtime{Path: DefaultRuntimeBinary}
+	conf.Runtimes[config.StockRuntimeName] = runtimetypes.Runtime{Path: DefaultRuntimeBinary}
 
 	return nil
 }

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -564,11 +564,12 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 		}
 	}
 	if hostConfig.Runtime == "" {
-		hostConfig.Runtime = daemon.configStore.GetDefaultRuntimeName()
+		hostConfig.Runtime = daemon.runtimeManager.GetDefaultRuntimeName()
 	}
 
-	if rt := daemon.configStore.GetRuntime(hostConfig.Runtime); rt == nil {
-		return warnings, fmt.Errorf("Unknown runtime specified %s", hostConfig.Runtime)
+	_, err = daemon.runtimeManager.Lookup(hostConfig.Runtime)
+	if err != nil {
+		return warnings, err
 	}
 
 	for dest := range hostConfig.Tmpfs {

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -26,7 +26,7 @@ func (daemon *Daemon) FillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) 
 	v.CPUShares = sysInfo.CPUShares
 	v.CPUSet = sysInfo.Cpuset
 	v.Runtimes = daemon.configStore.GetAllRuntimes()
-	v.DefaultRuntime = daemon.configStore.GetDefaultRuntimeName()
+	v.DefaultRuntime = daemon.runtimeManager.GetDefaultRuntimeName()
 	v.InitBinary = daemon.configStore.GetInitPath()
 
 	v.ContainerdCommit.Expected = dockerversion.ContainerdCommitID

--- a/daemon/runtime.go
+++ b/daemon/runtime.go
@@ -1,0 +1,21 @@
+package daemon
+
+import (
+	"github.com/docker/docker/api/types/runtime"
+)
+
+func (daemon *Daemon) ListRuntimes() (runtime.GetRuntimesResponse, error) {
+	var resp runtime.GetRuntimesResponse
+
+	runtimes := daemon.runtimeManager.GetAllRuntimes()
+
+	for _, r := range runtimes {
+		resp.Runtimes = append(resp.Runtimes, r.Info())
+	}
+
+	return resp, nil
+
+}
+func (daemon *Daemon) SetDefaultRuntime(runtime string) error {
+	return daemon.runtimeManager.SetDefaultRuntime(runtime)
+}

--- a/opts/runtime.go
+++ b/opts/runtime.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/docker/api/types"
+	types "github.com/docker/docker/api/types/runtime"
 )
 
 // RuntimeOpt defines a map of Runtimes

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -1,0 +1,32 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrRuntimeNotFound indicates that a runtime was not found locally.
+type ErrRuntimeNotFound string
+
+func (name ErrRuntimeNotFound) Error() string {
+	return fmt.Sprintf("runtime %q not found", string(name))
+}
+
+// ErrRuntimeExists indicates that a runtime already exists.
+type ErrRuntimeExists string
+
+func (name ErrRuntimeExists) Error() string {
+	return fmt.Sprintf("runtime %q already exists", string(name))
+}
+
+// ErrRuntimeDeleted indicates that a runtime was locally deleted.
+type ErrRuntimeDeleted string
+
+func (name ErrRuntimeDeleted) Error() string {
+	return fmt.Sprintf("runtime %q was deleted", string(name))
+}
+
+var (
+	ErrRuntimeMissingPlugin       = errors.New("missing plugin")
+	ErrRuntimeMissingPluginGetter = errors.New("missing plugin getter")
+)

--- a/runtime/manager.go
+++ b/runtime/manager.go
@@ -1,0 +1,240 @@
+package runtime
+
+import (
+	"sync"
+
+	"github.com/docker/docker/api/types/runtime"
+	getter "github.com/docker/docker/pkg/plugingetter"
+)
+
+const RuntimeDriverName = "RuntimeDriver"
+
+type RuntimeManager struct {
+	sync.RWMutex
+	cache          map[string]*RuntimeDriver
+	defaultRuntime string
+	plugingetter   getter.PluginGetter
+}
+
+func NewRuntimeManager() *RuntimeManager {
+	return &RuntimeManager{
+		cache: make(map[string]*RuntimeDriver),
+	}
+}
+
+func (rtmgr *RuntimeManager) RegisterPluginGetter(plugingetter getter.PluginGetter) {
+	rtmgr.plugingetter = plugingetter
+}
+
+// FillCache populates the runtime manager cache with the managed runtimes.
+func (rtmgr *RuntimeManager) FillCache() error {
+	if rtmgr.plugingetter == nil {
+		return ErrRuntimeMissingPluginGetter
+	}
+
+	runtimePlugins := rtmgr.plugingetter.GetAllManagedPluginsByCap(RuntimeDriverName)
+
+	for _, plugin := range runtimePlugins {
+		runtime, err := runtimeDriverFromPlugin(plugin)
+		if err != nil {
+			continue
+		}
+
+		_, err = rtmgr.GetRuntime(runtime.name())
+		if err != nil {
+			continue
+		}
+	}
+
+	return nil
+}
+
+func (rtmgr *RuntimeManager) RegisterConfiguredRuntime(name string, rt runtime.Runtime) error {
+	rtmgr.Lock()
+	defer rtmgr.Unlock()
+
+	if _, ok := rtmgr.cache[name]; ok {
+		return ErrRuntimeExists(name)
+	}
+
+	rtmgr.cache[name] = newRuntimeDriver(name, rt, nil)
+
+	return nil
+}
+
+func (rtmgr *RuntimeManager) Lookup(name string) (*RuntimeDriver, error) {
+	rtmgr.RLock()
+	defer rtmgr.RUnlock()
+	if rt, ok := rtmgr.cache[name]; ok {
+		if rt.plugin == nil {
+			// This is a configured runtime
+			return rt, nil
+		}
+
+		// Verify from the plugin store that it is still there
+		_, err := rtmgr.plugingetter.Get(name, RuntimeDriverName, getter.Lookup)
+		if err != nil {
+			rtmgr.ReleaseRuntime(name)
+			return nil, ErrRuntimeNotFound(name)
+		}
+
+		return rt, nil
+	}
+
+	return nil, ErrRuntimeNotFound(name)
+}
+
+
+func (rtmgr *RuntimeManager) GetRuntime(name string) (*RuntimeDriver, error) {
+	rtmgr.RLock()
+	defer rtmgr.RUnlock()
+	if rt, ok := rtmgr.cache[name]; ok {
+		if rt.plugin == nil {
+			// This is a configured runtime
+			return rt, nil
+		}
+
+		// Verify from the plugin store that it is still there
+		_, err := rtmgr.plugingetter.Get(name, RuntimeDriverName, getter.Lookup)
+		if err != nil {
+			rtmgr.ReleaseRuntime(name)
+			return nil, ErrRuntimeNotFound(name)
+		}
+
+		return rt, nil
+	}
+
+	// This is not a cached runtime, let's search through the plugin store
+	rtplugin, err := rtmgr.plugingetter.Get(name, RuntimeDriverName, getter.Acquire)
+	if err != nil {
+		return nil, ErrRuntimeNotFound(name)
+	}
+
+	// Create and initialize a new runtime driver
+	newRuntimeDriver, err := runtimeDriverFromPlugin(rtplugin)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add the runtime to our cache
+	rtmgr.cache[name] = newRuntimeDriver
+
+	return newRuntimeDriver, nil
+}
+
+func (rtmgr *RuntimeManager) ReleaseRuntime(name string) error {
+	rtmgr.RLock()
+	defer rtmgr.RUnlock()
+	rt, ok := rtmgr.cache[name]
+	if !ok {
+		return ErrRuntimeNotFound(name)
+	}
+
+	delete(rtmgr.cache, rt.info.Name)
+
+	if rt.plugin != nil {
+		// Releasethe plugin store
+		_, _ = rtmgr.plugingetter.Get(name, RuntimeDriverName, getter.Release)
+	}
+
+	return nil
+}
+
+// GetRuntimePathAndArgs returns the runtime path and arguments for a given
+// runtime name
+func (rtmgr *RuntimeManager) GetRuntimePathAndArgs(name string) (string, []string, error) {
+	rt, err := rtmgr.GetRuntime(name)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return rt.info.Runtime.Path, rt.info.Runtime.Args, nil
+}
+
+// GetDefaultRuntimeName returns the current default runtime
+func (rtmgr *RuntimeManager) GetDefaultRuntimeName() string {
+	rtmgr.RLock()
+	rt := rtmgr.defaultRuntime
+	rtmgr.RUnlock()
+
+	return rt
+}
+
+func (rtmgr *RuntimeManager) GetAllRuntimes() []RuntimeDriver {
+	rtmgr.Lock()
+	defer rtmgr.Unlock()
+
+	var runtimes []RuntimeDriver
+
+	for name, r := range rtmgr.cache {
+		if r.plugin != nil {
+			_, err := rtmgr.plugingetter.Get(name, RuntimeDriverName, getter.Lookup)
+			if err != nil {
+				// This cache entry is missing, let's delete it
+				if name == rtmgr.defaultRuntime {
+					rtmgr.defaultRuntime = ""
+				}
+
+				delete(rtmgr.cache, name)
+
+				continue
+			}
+		}
+
+		runtimes = append(runtimes, *r)
+	}
+
+	return runtimes
+}
+
+func (rtmgr *RuntimeManager) SetDefaultRuntime(name string) error {
+	rtmgr.Lock()
+	defer rtmgr.Unlock()
+
+	if name == rtmgr.defaultRuntime {
+		return nil
+	}
+
+	if _, ok := rtmgr.cache[name]; !ok {
+		plugin, err := rtmgr.plugingetter.Get(name, RuntimeDriverName, getter.Lookup)
+		if err != nil {
+			return ErrRuntimeNotFound(name)
+		}
+
+		// We cache the new runtime
+		driver, err := runtimeDriverFromPlugin(plugin)
+		if err != nil {
+			return err
+		}
+
+		rtmgr.cache[name] = driver
+	}
+
+	// TODO verify that the default runtime is still there.
+	defaultRuntime, ok := rtmgr.cache[rtmgr.defaultRuntime]
+	if ok {
+		defaultRuntime.setDefaultRuntime(false)
+	}
+
+	// New default
+	rtmgr.defaultRuntime = name
+	rtmgr.cache[rtmgr.defaultRuntime].setDefaultRuntime(true)
+
+	return nil
+}
+
+func (rtmgr *RuntimeManager) GetPluginList() []string {
+	if rtmgr.plugingetter == nil {
+		return nil
+	}
+
+	var pluginList []string
+
+	runtimePlugins := rtmgr.plugingetter.GetAllManagedPluginsByCap(RuntimeDriverName)
+
+	for _, plugin := range runtimePlugins {
+		pluginList = append(pluginList, plugin.Name())
+	}
+
+	return pluginList
+}

--- a/runtime/proxy.go
+++ b/runtime/proxy.go
@@ -1,0 +1,99 @@
+package runtime
+
+import (
+	"github.com/docker/docker/api/types/runtime"
+	getter "github.com/docker/docker/pkg/plugingetter"
+)
+
+type RuntimeDriver struct {
+	info   runtime.Info
+	plugin getter.CompatPlugin
+}
+
+func runtimeDriverFromPlugin(plugin getter.CompatPlugin) (*RuntimeDriver, error) {
+	r := &RuntimeDriver{
+		info: runtime.Info{
+			DefaultRuntime: false,
+		},
+		plugin: plugin,
+	}
+
+	if err := r.init(); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func newRuntimeDriver(name string, rt runtime.Runtime, plugin getter.CompatPlugin) *RuntimeDriver {
+	return &RuntimeDriver{
+		info: runtime.Info{
+			Name:           name,
+			Runtime:        rt,
+			DefaultRuntime: false,
+		},
+		plugin: plugin,
+	}
+}
+
+func (r RuntimeDriver) name() string {
+	return r.info.Name
+}
+
+func (r *RuntimeDriver) init() error {
+	if r.plugin == nil {
+		return ErrRuntimeMissingPlugin
+	}
+
+	r.info.Name = r.plugin.Name()
+
+	// Fetch the runtime path and arguments
+	path, err := r.Path()
+	if err != nil {
+		return err
+	}
+
+	args, err := r.Args()
+	if err != nil {
+		return err
+	}
+
+	r.info.Runtime = runtime.Runtime{
+		Path: path,
+		Args: args,
+	}
+
+	return nil
+}
+
+func (r *RuntimeDriver) setDefaultRuntime(d bool) {
+	r.info.DefaultRuntime = d
+}
+
+func (r RuntimeDriver) Info() runtime.Info {
+	return r.info
+}
+
+func (r RuntimeDriver) Path() (string, error) {
+	if r.plugin == nil {
+		return "", ErrRuntimeMissingPlugin
+	}
+
+	var resp runtime.PluginPathResponse
+
+	if err := r.plugin.Client().Call(runtime.GetPath, nil, &resp); err != nil {
+		return "", err
+	}
+
+	return resp.Path, nil
+}
+
+func (r RuntimeDriver) Args() ([]string, error) {
+	var resp runtime.PluginArgsResponse
+
+	if err := r.plugin.Client().Call(runtime.GetArgs, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Args, nil
+}


### PR DESCRIPTION
**NOTE** This PR is intended to be both an initial implementation and an architecture proposal. There are still some opens that we'd like to discuss here, please see the *Opens* section.

-----------------------------------------------

This is a pull request for supporting container runtimes as Docker plugins.

### Problem statement
Not all OCI compatible runtimes are equal and some can be relatively complex pieces of software made of several components. For example the [Clear Containers](https://github.com/01org/cc-oci-runtime) runtime for running hardware virtualized containers is made of mostly 4 components:

1. The runtime binary itself: `cc-oci-runtime`
2. A container proxy: `cc-proxy`
3. A specific shim that leaves between `containerd-shim` and `cc-proxy`
4. An optimized QEMU hypervisor

Shipping, installing and distributing this kind of runtimes can be challenging for several reasons:

* Distribution specific artifacts (RPMs, debs) need to be generated and maintained for each supported distribution and each supported runtime release. Maintaining such a matrix is error prone, time consuming and a resource burden.
* Some components may have dynamic libraries dependencies and depending on the targeted host distribution, building and packaging new runtimes can be intrusive (i.e. it may need additional libraries or more recent versions of the already installed ones) and error prone.
* Dockerd needs to be configured to use this new runtime as its default which is typically done through systemd configuration files. Adding or modifying those on already provisioned systems can range from being fragile (post installation systemd files could be garbage collected or disabled for security reasons) to impossible (read-only systems).

### Goal
The goal of this proposal is to provide OCI compatible runtimes as a new type of Docker plugins.
Installing a new Docker runtime would become as simple as:

```
# docker plugin install clearcontainers/runtime:2.1.2
```

By hosting and distributing container runtimes as Docker plugins, we'd significantly simplify their distribution and installation steps for using them as Docker runtimes.

Additionally, we want to be able to dynamically switch between default runtimes without having to restart `dockerd`

### Proposed design
Today Docker runtimes are managed through configuration settings, either from the command line or from dockerd `daemon.json`. Here we are adding a runtime management layer to control and manage both configured and plugin based runtimes. This runtime manager becomes the interface between the dockerd daemon and all supported runtimes.

To keep the same simple integration path with `containerd`, runtime plugins should provide a host absolute path to the runtime binary and a list of arguments. The runtime manager provides those 2 pieces of data to the docker daemon, which then passes that down to containerd. This approach is basically using runtime plugins as runtime installers on the host as opposed to running containers fully containerized within the plugin container. The pros and cons of each approaches (runtime plugins as installers vs runtime plugins as fully containerized runtimes) is discussed further in the *Opens* section below.

With this proposal, the runtime manager is responsible for 2 things:

- Caching all installed runtimes together with their path and arguments values, and save a few RPC calls whenever we switch between runtimes. The runtime cache is updated everytime the daemon runtime client API is hit.
- Selecting and enabling the default runtime.

**Client API**
In order to interact with the new runtime manager entity, we add a new docker command: `docker runtime` for:

- Listing all installed runtimes:

```
$ docker runtime ls
NAME                                PATH                ARGS                DEFAULT
runc                                docker-runc                             *
sameo/clear-containers-plugin:1.0   /foo/bar            foo bar
```

- Selecting the default runtime:

```
$ docker runtime default runc
```

**Plugin API**
A runtime plugin must provide the following endpoints:

- `/RuntimeDriver.Path` for fetching the runtime binary path.
- `/RuntimeDriver.Args` for fetching the runtime command arguments.

The runtime manager calls into these endpoints whenever it detects a new installed runtime.

### Opens

The main open here is about how the runtime plugin is used, and more specifically how and where the runtime binary is called and run.

We have 2 main options:
- Using the runtime plugin as a runtime installer. The plugin basically copies the runtime components into a host visible path and this is where it gets called from containerd
  - Pros
    - Interface between containerd and runtimes kept unchanged
  - Cons
    - Difficult to run dynamically linked runtimes
    - Runtime uninstallation must be handled from the plugin implementation

- Using the runtime plugin as a runtime container and actually launching the runtime as a fully privileged but containerized binary
  - Pros
    - Fixes runtime dependencies issues
  - Cons
    - New RPC interface between `containerd` and runtimes.
    - Runtime manager to act as a `containerd` proxy for configured runtimes (That can't implement the new containerd RPC interface), or to treat configured runtimes and plugin ones from very different code paths.
    - Full host filesystem access for reaching all container resources.
    - Runtime modification for accessing host filesystem paths through a container volume (e.g. 

Our preference goes to the first option (runtime installer) as it's simpler, shorter and more importantly does not require `containerd` changes.

### TODO

* [x] docker runtime manager
* [x] runtime manager integration with `dockerd`
* [x] `docker runtime` CLI implementation
* [ ] Unit tests
* [ ] Documentation
* [ ] Dynamic switching between runtimes
* [ ] Default runtime storage

![bunnies](http://happyvalentineimages.com/wp-content/uploads/2017/04/cute-easter-bunny-images-3.jpg)

cc @mcastelino @jodh-intel @NathanMcCauley 