### PR TITLE
Windows: Do not clean empty windowsfilter folder

### DIFF
--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -427,6 +427,9 @@ func (d *Driver) Cleanup() error {
 
 	items, err := ioutil.ReadDir(d.info.HomeDir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Darren Stahl <darst@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Stop attempting to cleanup partially removed images on Windows if the windowsfilter folder does not exist.

**- How I did it**

Ignore error if folder does not exist.

**- How to verify it**

Create a new install of Docker. Prior to installing any images, stop the daemon.

Before change:
```
C:\Users\Administrator>dockerd
time="2017-04-17T11:37:07.919651300-07:00" level=info msg="Windows default isolation mode: process"
time="2017-04-17T11:37:07.930581700-07:00" level=info msg="Graph migration to content-addressability took 0.00 seconds"
time="2017-04-17T11:37:07.930581700-07:00" level=info msg="Loading containers: start."
time="2017-04-17T11:37:07.930581700-07:00" level=info msg="Restoring existing overlay networks from HNS into docker"
time="2017-04-17T11:37:08.023527700-07:00" level=info msg="Loading containers: done."
time="2017-04-17T11:37:08.025834000-07:00" level=info msg="Daemon has completed initialization"
time="2017-04-17T11:37:08.026517700-07:00" level=info msg="Docker daemon" commit=3b5af0a28-unsupported graphdriver=windowsfilter version=17.06.0-dev
time="2017-04-17T11:37:08.037110600-07:00" level=info msg="API listen on //./pipe/docker_engine"
time="2017-04-17T11:37:12.028290000-07:00" level=info msg="Processing signal 'interrupt'"
time="2017-04-17T11:37:12.028290000-07:00" level=error msg="Error during layer Store.Cleanup(): open C:\\ProgramData\\docker\\windowsfilter: The system cannot find the file specified."
```

After change:
```
C:\Users\Administrator>dockerd
time="2017-04-17T11:40:33.871805100-07:00" level=info msg="Windows default isolation mode: process"
time="2017-04-17T11:40:33.887811900-07:00" level=info msg="Graph migration to content-addressability took 0.00 seconds"
time="2017-04-17T11:40:33.887811900-07:00" level=info msg="Loading containers: start."
time="2017-04-17T11:40:33.890372800-07:00" level=info msg="Restoring existing overlay networks from HNS into docker"
time="2017-04-17T11:40:33.977470700-07:00" level=info msg="Loading containers: done."
time="2017-04-17T11:40:33.979406600-07:00" level=info msg="Daemon has completed initialization"
time="2017-04-17T11:40:33.981438200-07:00" level=info msg="Docker daemon" commit=1eec7b558-unsupported graphdriver=windowsfilter version=17.06.0-dev
time="2017-04-17T11:40:33.991014500-07:00" level=info msg="API listen on //./pipe/docker_engine"
time="2017-04-17T11:40:35.157865600-07:00" level=info msg="Processing signal 'interrupt'"
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Windows bugfix: Do not clean empty windowsfilter folder

/cc @jhowardmsft @jstarks
