### PR TITLE
Fix tmp deletion

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -955,7 +955,7 @@ func prepareTempDir(rootDir string, rootUID, rootGID int) (string, error) {
 	if tmpDir = os.Getenv("DOCKER_TMPDIR"); tmpDir == "" {
 		tmpDir = filepath.Join(rootDir, "tmp")
 		newName := tmpDir + "-old"
-		if err := os.Rename(tmpDir, newName); err != nil {
+		if err := os.Rename(tmpDir, newName); err == nil {
 			go func() {
 				if err := os.RemoveAll(newName); err != nil {
 					logrus.Warnf("failed to delete old tmp directory: %s", newName)


### PR DESCRIPTION
Signed-off-by: Darren Stahl <darst@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Tmp deletion was only deleting the tmp-old folder when it failed to rename the tmp folder. This fixes it.

**- How I did it**

Delete tmp-old on rename success, not failure.

**- How to verify it**

Daemon no longer throws warnings on every other start.

/cc @mlaventure FYI 👼 