### PR TITLE
Correcting test-instruction.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # docker run -v `pwd`:/go/src/github.com/docker/docker --privileged -i -t docker bash
 #
 # # Run the test suite:
-# docker run --privileged docker hack/make.sh test-unit test-integration-cli test-docker-py
+# docker run -e DOCKER_GITCOMMIT=foo --privileged docker hack/make.sh test-unit test-integration-cli test-docker-py
 #
 # # Publish a release:
 # docker run --privileged \


### PR DESCRIPTION
Signed-off-by: Per Weijnitz <per.weijnitz@gmail.com>

**- What I did**
While building Docker from source, I followed the instructions in Dockerfile. When I reached the following step:
```  
# # Run the test suite:
# docker run --privileged docker hack/make.sh test-unit test-integration-cli test-docker-py
```
docker complained that it could not find the .git. But as the previous step had succeeded, I derived that the following argument was missing from the test step above: 
```  
    -v `pwd`:/go/src/github.com/docker/docker 
```  
This seemed to fix the problem, as the test step works now.

**- How I did it**
I added the following argument to the test step instruction:
```  
    -v `pwd`:/go/src/github.com/docker/docker 
```  

**- How to verify it**
Follow the build instructions at the top of the Dockerfile, up to the test stage.

**- Description for the changelog**
Fixed the build instruction to make the test step work as expected.
