### PR TITLE
Remove bogus statement from bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3018,8 +3018,6 @@ _docker_service_update() {
 # _docker_service_update_and_create is the combined completion for `docker service create`
 # and `docker service update`
 _docker_service_update_and_create() {
-	local $subcommand="${words[$subcommand_pos]}"
-
 	local options_with_args="
 		--endpoint-mode
 		--env -e


### PR DESCRIPTION
https://github.com/docker/docker/pull/32678/files#r111887622 found strange code that this PR fixes.
The original code sets either the variable `update` to `update` or `create` to `create`, depending on which subcommand was used.
The desired outcome was to set `subcommand` to either `create` or `update`.

The code did work in spite of this error because `subcommand` is set before in `__docker_subcommands` (https://github.com/docker/docker/blob/master/contrib/completion/bash/docker#L617).
Therefore the wrong assignment can be removed safely.

See `_docker_container_run_and_create` for the same usecase: a shared completion function which makes use of `$subcommand` without redefining it.
