### PR TITLE
Add examples of storage-opts and log-opts for the daemon

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -311,12 +311,7 @@ This is an example of the configuration file for devicemapper on Linux:
     "dm.thinpooldev=/dev/mapper/thin-pool",
     "dm.use_deferred_deletion=true",
     "dm.use_deferred_removal=true"
-  ],
-  "log-driver": "json-file",
-  "log-opts": {
-    "max-size": "10m",
-    "max-file": "10"
-  }
+  ]
 }
 ```
 

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -302,6 +302,24 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
 
 #### Devicemapper options
 
+This is an example of the configuration file for devicemapper on Linux:
+
+```json
+{
+  "storage-driver": "devicemapper",
+  "storage-opts": [
+    "dm.thinpooldev=/dev/mapper/thin-pool",
+    "dm.use_deferred_deletion=true",
+    "dm.use_deferred_removal=true"
+  ],
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "10"
+  }
+}
+```
+
 ##### `dm.thinpooldev`
 
 Specifies a custom block storage device to use for the thin pool.


### PR DESCRIPTION
Signed-off-by: Alvin Deng <alvin.q.deng@utexas.edu>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added example JSON for the device mapper documentation

Fixes docker/docker.github.io#967

