### PR TITLE
Prevent a non-zero NanoCPUs from setting a zero CPU.Count

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -92,6 +92,11 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 			}
 		} else {
 			cpuPercent = uint8(c.HostConfig.NanoCPUs * 100 / int64(sysinfo.NumCPU()) / 1e9)
+
+			if cpuPercent < 1 {
+				// The requested NanoCPUs is so small that we rounded to 0, use 1 instead
+				cpuPercent = 1
+			}
 		}
 	}
 	memoryLimit := uint64(c.HostConfig.Memory)


### PR DESCRIPTION
Signed-off-by: Darren Stahl <darst@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Prevent a non-zero NanoCPUs from setting a zero CPU.Count

fixes https://github.com/moby/moby/issues/32014

**- How I did it**

If calculated cpuPercent is 0, set to 1.

**- How to verify it**

Create a container with `--cpus 0.01`. Inspect the JSON blob sent to HCS, ensure that CpuMaximum is not 0.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Windows: Fix rounding error on small values of NanoCPUs