### PR TITLE
Output `docker swarm join` command on a single line when running `docker swarm init`

### DIFF
--- a/cli/command/swarm/join_token.go
+++ b/cli/command/swarm/join_token.go
@@ -108,10 +108,10 @@ func printJoinCommand(ctx context.Context, dockerCli command.Cli, nodeID string,
 
 	if node.ManagerStatus != nil {
 		if worker {
-			fmt.Fprintf(dockerCli.Out(), "To add a worker to this swarm, run the following command:\n\n    docker swarm join \\\n    --token %s \\\n    %s\n\n", sw.JoinTokens.Worker, node.ManagerStatus.Addr)
+			fmt.Fprintf(dockerCli.Out(), "To add a worker to this swarm, run the following command:\n\n    docker swarm join --token %s %s\n\n", sw.JoinTokens.Worker, node.ManagerStatus.Addr)
 		}
 		if manager {
-			fmt.Fprintf(dockerCli.Out(), "To add a manager to this swarm, run the following command:\n\n    docker swarm join \\\n    --token %s \\\n    %s\n\n", sw.JoinTokens.Manager, node.ManagerStatus.Addr)
+			fmt.Fprintf(dockerCli.Out(), "To add a manager to this swarm, run the following command:\n\n    docker swarm join --token %s %s\n\n", sw.JoinTokens.Manager, node.ManagerStatus.Addr)
 		}
 	}
 

--- a/cli/command/swarm/testdata/jointoken-manager-rotate.golden
+++ b/cli/command/swarm/testdata/jointoken-manager-rotate.golden
@@ -2,7 +2,4 @@ Successfully rotated manager join token.
 
 To add a manager to this swarm, run the following command:
 
-    docker swarm join \
-    --token manager-join-token \
-    127.0.0.1
-
+    docker swarm join --token manager-join-token 127.0.0.1

--- a/cli/command/swarm/testdata/jointoken-manager.golden
+++ b/cli/command/swarm/testdata/jointoken-manager.golden
@@ -1,6 +1,3 @@
 To add a manager to this swarm, run the following command:
 
-    docker swarm join \
-    --token manager-join-token \
-    127.0.0.1
-
+    docker swarm join --token manager-join-token 127.0.0.1

--- a/cli/command/swarm/testdata/jointoken-worker.golden
+++ b/cli/command/swarm/testdata/jointoken-worker.golden
@@ -1,6 +1,3 @@
 To add a worker to this swarm, run the following command:
 
-    docker swarm join \
-    --token worker-join-token \
-    127.0.0.1
-
+    docker swarm join --token worker-join-token 127.0.0.1


### PR DESCRIPTION
This avoids issues when copy/pasting between different shells on
different OSes, which may not all support `\` as a continuation
character.

Fixes #32725

**- What I did**

Changed the string being printed in `printJoinCommand`

**- How to verify it**

Run `docker swarm init` and make sure the `docker swarm join` command is printed on a single line.

**- Description for the changelog**

Output `docker swarm join` command on a single line when running `docker swarm init`

**- A picture of a cute animal (not mandatory but encouraged)**

![cute-baby-beaver](https://cloud.githubusercontent.com/assets/2037086/25211213/ba224e8c-2549-11e7-978c-87cd35a4a1d3.jpg)

Signed-off-by: Dave Henderson <dhenderson@gmail.com>
