### PR TITLE
Add note about host-dir in VOLUME

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1222,24 +1222,28 @@ This Dockerfile results in an image that causes `docker run`, to
 create a new mount point at `/myvol` and copy the  `greeting` file
 into the newly created volume.
 
-> **Note**:
-> When using Windows-based containers, the destination of a volume inside the
-> container must be one of: a non-existing or empty directory; or a drive other
-> than C:.
+### Notes about specifying volumes
 
-> **Note**:
-> If any build steps change the data within the volume after it has been
-> declared, those changes will be discarded.
+Keep the following things in mind about volumes in the `Dockerfile`.
 
-> **Note**:
-> The list is parsed as a JSON array, which means that
-> you must use double-quotes (") around words not single-quotes (').
+- **Volumes on Windows-based containers**: When using Windows-based containers,
+  the destination of a volume inside the container must be one of:
+  
+  - a non-existing or empty directory
+  - a drive other than `C:`
 
->**Note**: The host directory is, by its nature, host-dependent. For this
->reason, you can't mount a host directory from `Dockerfile`, the `VOLUME`
-instruction does not support passing a `host-dir`, because built images
->should be portable. A host directory wouldn't be available on all potential
->hosts.
+- **Changing the volume from within the Dockerfile**: If any build steps change the
+  data within the volume after it has been declared, those changes will be discarded.
+
+- **JSON formatting**: The list is parsed as a JSON array.
+  You must enclose words with double quotes (`"`)rather than single quotes (`'`).
+
+- **The host directory is declared at container run-time**: The host directory
+  (the mountpoint) is, by its nature, host-dependent. This is to preserve image
+  portability. since a given host directory can't be guaranteed to be available
+  on all hosts.For this reason, you can't mount a host directory from
+  within the Dockerfile. The `VOLUME` instruction does not support specifying a `host-dir`
+  parameter.  You must specify the mountpoint when you create or run the container.
 
 ## USER
 

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1235,6 +1235,12 @@ into the newly created volume.
 > The list is parsed as a JSON array, which means that
 > you must use double-quotes (") around words not single-quotes (').
 
+>**Note**: The host directory is, by its nature, host-dependent. For this
+>reason, you can't mount a host directory from `Dockerfile`, the `VOLUME`
+instruction does not support passing a `host-dir`, because built images
+>should be portable. A host directory wouldn't be available on all potential
+>hosts.
+
 ## USER
 
     USER daemon


### PR DESCRIPTION
Added the note about VOLUME from [here](https://docs.docker.com/engine/tutorials/dockervolumes/#/mount-a-host-directory-as-a-data-volume)

Fixes https://github.com/docker/docker.github.io/issues/2589

This somewhat makes it clear for people who are reading just this document. 