### PR TITLE
Use `cli` for trusted related command

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4199,21 +4199,20 @@ func (s *DockerTrustSuite) TestTrustedBuildTagFromReleasesRole(c *check.C) {
 
 	// push a different tag to the releases role
 	otherTag := fmt.Sprintf("%s:other", repoName)
-	dockerCmd(c, "tag", "busybox", otherTag)
+	cli.DockerCmd(c, "tag", "busybox", otherTag)
 
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", otherTag), trustedCmd).Assert(c, icmd.Success)
+	cli.Docker(cli.Args("push", otherTag), trustedCmd).Assert(c, icmd.Success)
 	s.assertTargetInRoles(c, repoName, "other", "targets/releases")
 	s.assertTargetNotInRoles(c, repoName, "other", "targets")
 
-	out, status := dockerCmd(c, "rmi", otherTag)
-	c.Assert(status, check.Equals, 0, check.Commentf("docker rmi failed: %s", out))
+	cli.DockerCmd(c, "rmi", otherTag)
 
 	dockerFile := fmt.Sprintf(`
   FROM %s
   RUN []
     `, otherTag)
 	name := "testtrustedbuildreleasesrole"
-	buildImage(name, trustedBuild, build.WithDockerfile(dockerFile)).Assert(c, icmd.Expected{
+	cli.BuildCmd(c, name, trustedCmd, build.WithDockerfile(dockerFile)).Assert(c, icmd.Expected{
 		Out: fmt.Sprintf("FROM %s@sha", repoName),
 	})
 }
@@ -4231,14 +4230,13 @@ func (s *DockerTrustSuite) TestTrustedBuildTagIgnoresOtherDelegationRoles(c *che
 
 	// push a different tag to the other role
 	otherTag := fmt.Sprintf("%s:other", repoName)
-	dockerCmd(c, "tag", "busybox", otherTag)
+	cli.DockerCmd(c, "tag", "busybox", otherTag)
 
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", otherTag), trustedCmd).Assert(c, icmd.Success)
+	cli.Docker(cli.Args("push", otherTag), trustedCmd).Assert(c, icmd.Success)
 	s.assertTargetInRoles(c, repoName, "other", "targets/other")
 	s.assertTargetNotInRoles(c, repoName, "other", "targets")
 
-	out, status := dockerCmd(c, "rmi", otherTag)
-	c.Assert(status, check.Equals, 0, check.Commentf("docker rmi failed: %s", out))
+	cli.DockerCmd(c, "rmi", otherTag)
 
 	dockerFile := fmt.Sprintf(`
   FROM %s
@@ -4246,7 +4244,7 @@ func (s *DockerTrustSuite) TestTrustedBuildTagIgnoresOtherDelegationRoles(c *che
     `, otherTag)
 
 	name := "testtrustedbuildotherrole"
-	buildImage(name, trustedBuild, build.WithDockerfile(dockerFile)).Assert(c, icmd.Expected{
+	cli.Docker(cli.Build(name), trustedCmd, build.WithDockerfile(dockerFile)).Assert(c, icmd.Expected{
 		ExitCode: 1,
 	})
 }

--- a/integration-cli/docker_cli_pull_trusted_test.go
+++ b/integration-cli/docker_cli_pull_trusted_test.go
@@ -3,11 +3,10 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"time"
 
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
-	"github.com/docker/docker/pkg/testutil"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
 	"github.com/go-check/check"
 )
@@ -16,58 +15,33 @@ func (s *DockerTrustSuite) TestTrustedPull(c *check.C) {
 	repoName := s.setupTrustedImage(c, "trusted-pull")
 
 	// Try pull
-	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd).Assert(c, SuccessTagging)
+	cli.Docker(cli.Args("pull", repoName), trustedCmd).Assert(c, SuccessTagging)
 
-	dockerCmd(c, "rmi", repoName)
+	cli.DockerCmd(c, "rmi", repoName)
 	// Try untrusted pull to ensure we pushed the tag to the registry
-	icmd.RunCmd(icmd.Command(dockerBinary, "pull", "--disable-content-trust=true", repoName), trustedCmd).Assert(c, SuccessDownloaded)
+	cli.Docker(cli.Args("pull", "--disable-content-trust=true", repoName), trustedCmd).Assert(c, SuccessDownloaded)
 }
 
 func (s *DockerTrustSuite) TestTrustedIsolatedPull(c *check.C) {
 	repoName := s.setupTrustedImage(c, "trusted-isolated-pull")
 
 	// Try pull (run from isolated directory without trust information)
-	icmd.RunCmd(icmd.Command(dockerBinary, "--config", "/tmp/docker-isolated", "pull", repoName), trustedCmd).Assert(c, SuccessTagging)
+	cli.Docker(cli.Args("--config", "/tmp/docker-isolated", "pull", repoName), trustedCmd).Assert(c, SuccessTagging)
 
-	dockerCmd(c, "rmi", repoName)
+	cli.DockerCmd(c, "rmi", repoName)
 }
 
 func (s *DockerTrustSuite) TestUntrustedPull(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockercliuntrusted/pulltest:latest", privateRegistryURL)
 	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoName)
-	dockerCmd(c, "push", repoName)
-	dockerCmd(c, "rmi", repoName)
+	cli.DockerCmd(c, "tag", "busybox", repoName)
+	cli.DockerCmd(c, "push", repoName)
+	cli.DockerCmd(c, "rmi", repoName)
 
 	// Try trusted pull on untrusted tag
-	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("pull", repoName), trustedCmd).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "Error: remote trust data does not exist",
-	})
-}
-
-func (s *DockerTrustSuite) TestPullWhenCertExpired(c *check.C) {
-	c.Skip("Currently changes system time, causing instability")
-	repoName := s.setupTrustedImage(c, "trusted-cert-expired")
-
-	// Certificates have 10 years of expiration
-	elevenYearsFromNow := time.Now().Add(time.Hour * 24 * 365 * 11)
-
-	testutil.RunAtDifferentDate(elevenYearsFromNow, func() {
-		// Try pull
-		icmd.RunCmd(icmd.Cmd{
-			Command: []string{dockerBinary, "pull", repoName},
-		}, trustedCmd).Assert(c, icmd.Expected{
-			ExitCode: 1,
-			Err:      "could not validate the path to a trusted root",
-		})
-	})
-
-	testutil.RunAtDifferentDate(elevenYearsFromNow, func() {
-		// Try pull
-		icmd.RunCmd(icmd.Cmd{
-			Command: []string{dockerBinary, "pull", "--disable-content-trust", repoName},
-		}, trustedCmd).Assert(c, SuccessDownloaded)
 	})
 }
 
@@ -79,14 +53,14 @@ func (s *DockerTrustSuite) TestTrustedPullFromBadTrustServer(c *check.C) {
 	}
 
 	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoName)
+	cli.DockerCmd(c, "tag", "busybox", repoName)
 
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
-	dockerCmd(c, "rmi", repoName)
+	cli.Docker(cli.Args("push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
+	cli.DockerCmd(c, "rmi", repoName)
 
 	// Try pull
-	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd).Assert(c, SuccessTagging)
-	dockerCmd(c, "rmi", repoName)
+	cli.Docker(cli.Args("pull", repoName), trustedCmd).Assert(c, SuccessTagging)
+	cli.DockerCmd(c, "rmi", repoName)
 
 	// Kill the notary server, start a new "evil" one.
 	s.not.Close()
@@ -96,71 +70,46 @@ func (s *DockerTrustSuite) TestTrustedPullFromBadTrustServer(c *check.C) {
 
 	// In order to make an evil server, lets re-init a client (with a different trust dir) and push new data.
 	// tag an image and upload it to the private registry
-	dockerCmd(c, "--config", evilLocalConfigDir, "tag", "busybox", repoName)
+	cli.DockerCmd(c, "--config", evilLocalConfigDir, "tag", "busybox", repoName)
 
 	// Push up to the new server
-	icmd.RunCmd(icmd.Command(dockerBinary, "--config", evilLocalConfigDir, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
+	cli.Docker(cli.Args("--config", evilLocalConfigDir, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 
 	// Now, try pulling with the original client from this new trust server. This should fail because the new root is invalid.
-	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("pull", repoName), trustedCmd).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "could not rotate trust to a new trusted root",
-	})
-}
-
-func (s *DockerTrustSuite) TestTrustedPullWithExpiredSnapshot(c *check.C) {
-	c.Skip("Currently changes system time, causing instability")
-	repoName := fmt.Sprintf("%v/dockercliexpiredtimestamppull/trusted:latest", privateRegistryURL)
-	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoName)
-
-	// Push with default passphrases
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
-	dockerCmd(c, "rmi", repoName)
-
-	// Snapshots last for three years. This should be expired
-	fourYearsLater := time.Now().Add(time.Hour * 24 * 365 * 4)
-
-	testutil.RunAtDifferentDate(fourYearsLater, func() {
-		// Try pull
-		icmd.RunCmd(icmd.Cmd{
-			Command: []string{dockerBinary, "pull", repoName},
-		}, trustedCmd).Assert(c, icmd.Expected{
-			ExitCode: 1,
-			Err:      "repository out-of-date",
-		})
 	})
 }
 
 func (s *DockerTrustSuite) TestTrustedOfflinePull(c *check.C) {
 	repoName := s.setupTrustedImage(c, "trusted-offline-pull")
 
-	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmdWithServer("https://invalidnotaryserver")).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("pull", repoName), trustedCmdWithServer("https://invalidnotaryserver")).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "error contacting notary server",
 	})
 	// Do valid trusted pull to warm cache
-	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd).Assert(c, SuccessTagging)
-	dockerCmd(c, "rmi", repoName)
+	cli.Docker(cli.Args("pull", repoName), trustedCmd).Assert(c, SuccessTagging)
+	cli.DockerCmd(c, "rmi", repoName)
 
 	// Try pull again with invalid notary server, should use cache
-	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmdWithServer("https://invalidnotaryserver")).Assert(c, SuccessTagging)
+	cli.Docker(cli.Args("pull", repoName), trustedCmdWithServer("https://invalidnotaryserver")).Assert(c, SuccessTagging)
 }
 
 func (s *DockerTrustSuite) TestTrustedPullDelete(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockercli/%s:latest", privateRegistryURL, "trusted-pull-delete")
 	// tag the image and upload it to the private registry
-	buildImageSuccessfully(c, repoName, build.WithDockerfile(`
+	cli.BuildCmd(c, repoName, build.WithDockerfile(`
                     FROM busybox
                     CMD echo trustedpulldelete
                 `))
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
+	cli.Docker(cli.Args("push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 
-	dockerCmd(c, "rmi", repoName)
+	cli.DockerCmd(c, "rmi", repoName)
 
 	// Try pull
-	result := icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd)
-	result.Assert(c, icmd.Success)
+	result := cli.Docker(cli.Args("pull", repoName), trustedCmd).Assert(c, icmd.Success)
 
 	matches := digestRegex.FindStringSubmatch(result.Combined())
 	c.Assert(matches, checker.HasLen, 2, check.Commentf("unable to parse digest from pull output: %s", result.Combined()))
@@ -174,7 +123,7 @@ func (s *DockerTrustSuite) TestTrustedPullDelete(c *check.C) {
 	c.Assert(byDigestID, checker.Equals, imageID)
 
 	// rmi of tag should also remove the digest reference
-	dockerCmd(c, "rmi", repoName)
+	cli.DockerCmd(c, "rmi", repoName)
 
 	_, err := inspectFieldWithError(imageByDigest, "Id")
 	c.Assert(err, checker.NotNil, check.Commentf("digest reference should have been removed"))
@@ -189,12 +138,12 @@ func (s *DockerTrustSuite) TestTrustedPullReadsFromReleasesRole(c *check.C) {
 	targetName := fmt.Sprintf("%s:latest", repoName)
 
 	// Push with targets first, initializing the repo
-	dockerCmd(c, "tag", "busybox", targetName)
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", targetName), trustedCmd).Assert(c, icmd.Success)
+	cli.DockerCmd(c, "tag", "busybox", targetName)
+	cli.Docker(cli.Args("push", targetName), trustedCmd).Assert(c, icmd.Success)
 	s.assertTargetInRoles(c, repoName, "latest", "targets")
 
 	// Try pull, check we retrieve from targets role
-	icmd.RunCmd(icmd.Command(dockerBinary, "-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
 		Err: "retrieving target for targets role",
 	})
 
@@ -205,21 +154,21 @@ func (s *DockerTrustSuite) TestTrustedPullReadsFromReleasesRole(c *check.C) {
 
 	// try a pull, check that we can still pull because we can still read the
 	// old tag in the targets role
-	icmd.RunCmd(icmd.Command(dockerBinary, "-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
 		Err: "retrieving target for targets role",
 	})
 
 	// try a pull -a, check that it succeeds because we can still pull from the
 	// targets role
-	icmd.RunCmd(icmd.Command(dockerBinary, "-D", "pull", "-a", repoName), trustedCmd).Assert(c, icmd.Success)
+	cli.Docker(cli.Args("-D", "pull", "-a", repoName), trustedCmd).Assert(c, icmd.Success)
 
 	// Push, should sign with targets/releases
-	dockerCmd(c, "tag", "busybox", targetName)
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", targetName), trustedCmd).Assert(c, icmd.Success)
+	cli.DockerCmd(c, "tag", "busybox", targetName)
+	cli.Docker(cli.Args("push", targetName), trustedCmd).Assert(c, icmd.Success)
 	s.assertTargetInRoles(c, repoName, "latest", "targets", "targets/releases")
 
 	// Try pull, check we retrieve from targets/releases role
-	icmd.RunCmd(icmd.Command(dockerBinary, "-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
 		Err: "retrieving target for targets/releases role",
 	})
 
@@ -228,12 +177,12 @@ func (s *DockerTrustSuite) TestTrustedPullReadsFromReleasesRole(c *check.C) {
 	s.notaryImportKey(c, repoName, "targets/other", s.not.keys[1].Private)
 	s.notaryPublish(c, repoName)
 
-	dockerCmd(c, "tag", "busybox", targetName)
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", targetName), trustedCmd).Assert(c, icmd.Success)
+	cli.DockerCmd(c, "tag", "busybox", targetName)
+	cli.Docker(cli.Args("push", targetName), trustedCmd).Assert(c, icmd.Success)
 	s.assertTargetInRoles(c, repoName, "latest", "targets", "targets/releases", "targets/other")
 
 	// Try pull, check we retrieve from targets/releases role
-	icmd.RunCmd(icmd.Command(dockerBinary, "-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
 		Err: "retrieving target for targets/releases role",
 	})
 }
@@ -251,22 +200,22 @@ func (s *DockerTrustSuite) TestTrustedPullIgnoresOtherDelegationRoles(c *check.C
 	s.notaryPublish(c, repoName)
 
 	// Push should write to the delegation role, not targets
-	dockerCmd(c, "tag", "busybox", targetName)
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", targetName), trustedCmd).Assert(c, icmd.Success)
+	cli.DockerCmd(c, "tag", "busybox", targetName)
+	cli.Docker(cli.Args("push", targetName), trustedCmd).Assert(c, icmd.Success)
 	s.assertTargetInRoles(c, repoName, "latest", "targets/other")
 	s.assertTargetNotInRoles(c, repoName, "latest", "targets")
 
 	// Try pull - we should fail, since pull will only pull from the targets/releases
 	// role or the targets role
-	dockerCmd(c, "tag", "busybox", targetName)
-	icmd.RunCmd(icmd.Command(dockerBinary, "-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+	cli.DockerCmd(c, "tag", "busybox", targetName)
+	cli.Docker(cli.Args("-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "No trust data for",
 	})
 
 	// try a pull -a: we should fail since pull will only pull from the targets/releases
 	// role or the targets role
-	icmd.RunCmd(icmd.Command(dockerBinary, "-D", "pull", "-a", repoName), trustedCmd).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("-D", "pull", "-a", repoName), trustedCmd).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "No trusted tags for",
 	})

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -3,6 +3,13 @@ package main
 import (
 	"archive/tar"
 	"fmt"
+	"github.com/docker/distribution/reference"
+	cliconfig "github.com/docker/docker/cli/config"
+	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
+	"github.com/docker/docker/integration-cli/cli/build"
+	icmd "github.com/docker/docker/pkg/testutil/cmd"
+	"github.com/go-check/check"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -10,15 +17,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
-
-	"github.com/docker/distribution/reference"
-	cliconfig "github.com/docker/docker/cli/config"
-	"github.com/docker/docker/integration-cli/checker"
-	"github.com/docker/docker/integration-cli/cli/build"
-	"github.com/docker/docker/pkg/testutil"
-	icmd "github.com/docker/docker/pkg/testutil/cmd"
-	"github.com/go-check/check"
 )
 
 // Pushing an image to a private registry.
@@ -285,12 +283,12 @@ func (s *DockerSchema1RegistrySuite) TestCrossRepositoryLayerPushNotSupported(c 
 func (s *DockerTrustSuite) TestTrustedPush(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockerclitrusted/pushtest:latest", privateRegistryURL)
 	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoName)
+	cli.DockerCmd(c, "tag", "busybox", repoName)
 
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
+	cli.Docker(cli.Args("push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 
 	// Try pull after push
-	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("pull", repoName), trustedCmd).Assert(c, icmd.Expected{
 		Out: "Status: Image is up to date",
 	})
 
@@ -304,12 +302,12 @@ func (s *DockerTrustSuite) TestTrustedPush(c *check.C) {
 func (s *DockerTrustSuite) TestTrustedPushWithEnvPasswords(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockerclienv/trusted:latest", privateRegistryURL)
 	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoName)
+	cli.DockerCmd(c, "tag", "busybox", repoName)
 
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmdWithPassphrases("12345678", "12345678")).Assert(c, SuccessSigningAndPushing)
+	cli.Docker(cli.Args("push", repoName), trustedCmdWithPassphrases("12345678", "12345678")).Assert(c, SuccessSigningAndPushing)
 
 	// Try pull after push
-	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("pull", repoName), trustedCmd).Assert(c, icmd.Expected{
 		Out: "Status: Image is up to date",
 	})
 }
@@ -317,10 +315,10 @@ func (s *DockerTrustSuite) TestTrustedPushWithEnvPasswords(c *check.C) {
 func (s *DockerTrustSuite) TestTrustedPushWithFailingServer(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockerclitrusted/failingserver:latest", privateRegistryURL)
 	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoName)
+	cli.DockerCmd(c, "tag", "busybox", repoName)
 
 	// Using a name that doesn't resolve to an address makes this test faster
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmdWithServer("https://server.invalid:81/")).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("push", repoName), trustedCmdWithServer("https://server.invalid:81/")).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "error contacting notary server",
 	})
@@ -329,9 +327,9 @@ func (s *DockerTrustSuite) TestTrustedPushWithFailingServer(c *check.C) {
 func (s *DockerTrustSuite) TestTrustedPushWithoutServerAndUntrusted(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockerclitrusted/trustedandnot:latest", privateRegistryURL)
 	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoName)
+	cli.DockerCmd(c, "tag", "busybox", repoName)
 
-	result := icmd.RunCmd(icmd.Command(dockerBinary, "push", "--disable-content-trust", repoName), trustedCmdWithServer("https://server.invalid:81/"))
+	result := cli.Docker(cli.Args("push", "--disable-content-trust", repoName), trustedCmdWithServer("https://server.invalid:81/"))
 	result.Assert(c, icmd.Success)
 	c.Assert(result.Combined(), check.Not(checker.Contains), "Error establishing connection to notary repository", check.Commentf("Missing expected output on trusted push with --disable-content-trust:"))
 }
@@ -339,13 +337,13 @@ func (s *DockerTrustSuite) TestTrustedPushWithoutServerAndUntrusted(c *check.C) 
 func (s *DockerTrustSuite) TestTrustedPushWithExistingTag(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockerclitag/trusted:latest", privateRegistryURL)
 	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoName)
-	dockerCmd(c, "push", repoName)
+	cli.DockerCmd(c, "tag", "busybox", repoName)
+	cli.DockerCmd(c, "push", repoName)
 
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
+	cli.Docker(cli.Args("push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 
 	// Try pull after push
-	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("pull", repoName), trustedCmd).Assert(c, icmd.Expected{
 		Out: "Status: Image is up to date",
 	})
 }
@@ -353,73 +351,31 @@ func (s *DockerTrustSuite) TestTrustedPushWithExistingTag(c *check.C) {
 func (s *DockerTrustSuite) TestTrustedPushWithExistingSignedTag(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockerclipushpush/trusted:latest", privateRegistryURL)
 	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoName)
+	cli.DockerCmd(c, "tag", "busybox", repoName)
 
 	// Do a trusted push
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
+	cli.Docker(cli.Args("push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 
 	// Do another trusted push
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
-	dockerCmd(c, "rmi", repoName)
+	cli.Docker(cli.Args("push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
+	cli.DockerCmd(c, "rmi", repoName)
 
 	// Try pull to ensure the double push did not break our ability to pull
-	icmd.RunCmd(icmd.Command(dockerBinary, "pull", repoName), trustedCmd).Assert(c, SuccessDownloaded)
+	cli.Docker(cli.Args("pull", repoName), trustedCmd).Assert(c, SuccessDownloaded)
 }
 
 func (s *DockerTrustSuite) TestTrustedPushWithIncorrectPassphraseForNonRoot(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockercliincorretpwd/trusted:latest", privateRegistryURL)
 	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoName)
+	cli.DockerCmd(c, "tag", "busybox", repoName)
 
 	// Push with default passphrases
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
+	cli.Docker(cli.Args("push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 
 	// Push with wrong passphrases
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmdWithPassphrases("12345678", "87654321")).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("push", repoName), trustedCmdWithPassphrases("12345678", "87654321")).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "could not find necessary signing keys",
-	})
-}
-
-func (s *DockerTrustSuite) TestTrustedPushWithExpiredSnapshot(c *check.C) {
-	c.Skip("Currently changes system time, causing instability")
-	repoName := fmt.Sprintf("%v/dockercliexpiredsnapshot/trusted:latest", privateRegistryURL)
-	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoName)
-
-	// Push with default passphrases
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
-
-	// Snapshots last for three years. This should be expired
-	fourYearsLater := time.Now().Add(time.Hour * 24 * 365 * 4)
-
-	testutil.RunAtDifferentDate(fourYearsLater, func() {
-		// Push with wrong passphrases
-		icmd.RunCmd(icmd.Cmd{
-			Command: []string{dockerBinary, "push", repoName},
-		}, trustedCmd).Assert(c, icmd.Expected{
-			ExitCode: 1,
-			Err:      "repository out-of-date",
-		})
-	})
-}
-
-func (s *DockerTrustSuite) TestTrustedPushWithExpiredTimestamp(c *check.C) {
-	c.Skip("Currently changes system time, causing instability")
-	repoName := fmt.Sprintf("%v/dockercliexpiredtimestamppush/trusted:latest", privateRegistryURL)
-	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoName)
-
-	// Push with default passphrases
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
-
-	// The timestamps expire in two weeks. Lets check three
-	threeWeeksLater := time.Now().Add(time.Hour * 24 * 21)
-
-	// Should succeed because the server transparently re-signs one
-	testutil.RunAtDifferentDate(threeWeeksLater, func() {
-		icmd.RunCmd(icmd.Command(dockerBinary, "push", repoName),
-			trustedCmd).Assert(c, SuccessSigningAndPushing)
 	})
 }
 
@@ -434,9 +390,9 @@ func (s *DockerTrustSuite) TestTrustedPushWithReleasesDelegationOnly(c *check.C)
 	s.notaryImportKey(c, repoName, "targets/releases", s.not.keys[0].Private)
 
 	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", targetName)
+	cli.DockerCmd(c, "tag", "busybox", targetName)
 
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", targetName), trustedCmd).Assert(c, SuccessSigningAndPushing)
+	cli.Docker(cli.Args("push", targetName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 	// check to make sure that the target has been added to targets/releases and not targets
 	s.assertTargetInRoles(c, repoName, "latest", "targets/releases")
 	s.assertTargetNotInRoles(c, repoName, "latest", "targets")
@@ -444,7 +400,7 @@ func (s *DockerTrustSuite) TestTrustedPushWithReleasesDelegationOnly(c *check.C)
 	// Try pull after push
 	os.RemoveAll(filepath.Join(cliconfig.Dir(), "trust"))
 
-	icmd.RunCmd(icmd.Command(dockerBinary, "pull", targetName), trustedCmd).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("pull", targetName), trustedCmd).Assert(c, icmd.Expected{
 		Out: "Status: Image is up to date",
 	})
 }
@@ -468,9 +424,9 @@ func (s *DockerTrustSuite) TestTrustedPushSignsAllFirstLevelRolesWeHaveKeysFor(c
 	s.notaryPublish(c, repoName)
 
 	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", targetName)
+	cli.DockerCmd(c, "tag", "busybox", targetName)
 
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", targetName), trustedCmd).Assert(c, SuccessSigningAndPushing)
+	cli.Docker(cli.Args("push", targetName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 
 	// check to make sure that the target has been added to targets/role1 and targets/role2, and
 	// not targets (because there are delegations) or targets/role3 (due to missing key) or
@@ -482,7 +438,7 @@ func (s *DockerTrustSuite) TestTrustedPushSignsAllFirstLevelRolesWeHaveKeysFor(c
 	os.RemoveAll(filepath.Join(cliconfig.Dir(), "trust"))
 
 	// pull should fail because none of these are the releases role
-	icmd.RunCmd(icmd.Command(dockerBinary, "pull", targetName), trustedCmd).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("pull", targetName), trustedCmd).Assert(c, icmd.Expected{
 		ExitCode: 1,
 	})
 }
@@ -504,9 +460,9 @@ func (s *DockerTrustSuite) TestTrustedPushSignsForRolesWithKeysAndValidPaths(c *
 	s.notaryPublish(c, repoName)
 
 	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", targetName)
+	cli.DockerCmd(c, "tag", "busybox", targetName)
 
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", targetName), trustedCmd).Assert(c, SuccessSigningAndPushing)
+	cli.Docker(cli.Args("push", targetName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 
 	// check to make sure that the target has been added to targets/role1 and targets/role4, and
 	// not targets (because there are delegations) or targets/role2 (due to path restrictions) or
@@ -518,7 +474,7 @@ func (s *DockerTrustSuite) TestTrustedPushSignsForRolesWithKeysAndValidPaths(c *
 	os.RemoveAll(filepath.Join(cliconfig.Dir(), "trust"))
 
 	// pull should fail because none of these are the releases role
-	icmd.RunCmd(icmd.Command(dockerBinary, "pull", targetName), trustedCmd).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("pull", targetName), trustedCmd).Assert(c, icmd.Expected{
 		ExitCode: 1,
 	})
 }
@@ -534,9 +490,9 @@ func (s *DockerTrustSuite) TestTrustedPushDoesntSignTargetsIfDelegationsExist(c 
 	// do not import any delegations key
 
 	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", targetName)
+	cli.DockerCmd(c, "tag", "busybox", targetName)
 
-	icmd.RunCmd(icmd.Command(dockerBinary, "push", targetName), trustedCmd).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("push", targetName), trustedCmd).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "no valid signing keys",
 	})

--- a/pkg/testutil/utils.go
+++ b/pkg/testutil/utils.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/docker/docker/pkg/stringutils"
 	"github.com/docker/docker/pkg/system"
-	icmd "github.com/docker/docker/pkg/testutil/cmd"
 )
 
 // IsKilled process the specified error and returns whether the process was killed or not.
@@ -210,20 +209,6 @@ func (c *ChannelBuffer) ReadTimeout(p []byte, n time.Duration) (int, error) {
 	case <-time.After(n):
 		return -1, fmt.Errorf("timeout reading from channel")
 	}
-}
-
-// RunAtDifferentDate runs the specified function with the given time.
-// It changes the date of the system, which can led to weird behaviors.
-func RunAtDifferentDate(date time.Time, block func()) {
-	// Layout for date. MMDDhhmmYYYY
-	const timeLayout = "010203042006"
-	// Ensure we bring time back to now
-	now := time.Now().Format(timeLayout)
-	defer icmd.RunCommand("date", now)
-
-	icmd.RunCommand("date", date.Format(timeLayout))
-	block()
-	return
 }
 
 // ReadBody read the specified ReadCloser content and returns it

--- a/pkg/testutil/utils_test.go
+++ b/pkg/testutil/utils_test.go
@@ -339,25 +339,3 @@ func TestChannelBuffer(t *testing.T) {
 		t.Fatalf("Expected '%s', got '%s'", expected, string(b))
 	}
 }
-
-// FIXME doesn't work
-// func TestRunAtDifferentDate(t *testing.T) {
-// 	var date string
-
-// 	// Layout for date. MMDDhhmmYYYY
-// 	const timeLayout = "20060102"
-// 	expectedDate := "20100201"
-// 	theDate, err := time.Parse(timeLayout, expectedDate)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-
-// 	RunAtDifferentDate(theDate, func() {
-// 		cmd := exec.Command("date", "+%Y%M%d")
-// 		out, err := cmd.Output()
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		date = string(out)
-// 	})
-// }


### PR DESCRIPTION
This also removed some skipped test (that are skipped for a long while).

🦁

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
