### PR TITLE
[Builder] Remove ContainerUpdateCmdOnBuild

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -54,8 +54,6 @@ type Backend interface {
 	ContainerStart(containerID string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error
 	// ContainerWait stops processing until the given container is stopped.
 	ContainerWait(containerID string, timeout time.Duration) (int, error)
-	// ContainerUpdateCmdOnBuild updates container.Path and container.Args
-	ContainerUpdateCmdOnBuild(containerID string, cmd []string) error
 	// ContainerCreateWorkdir creates the workdir
 	ContainerCreateWorkdir(containerID string) error
 

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -383,6 +383,11 @@ func run(req dispatchRequest) error {
 
 	logrus.Debugf("[BUILDER] Command to be executed: %v", runConfig.Cmd)
 
+	// Set blank entrypoint to cancel the entrypoint from the parent image
+	if len(runConfig.Cmd) > 0 {
+		runConfig.Entrypoint = strslice.StrSlice{""}
+	}
+
 	cID, err := req.builder.create(runConfig)
 	if err != nil {
 		return err

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -315,10 +315,6 @@ func workdir(req dispatchRequest) error {
 		return nil
 	}
 
-	// TODO: why is this done here. This seems to be done at random places all over
-	// the builder
-	req.runConfig.Image = req.builder.image
-
 	comment := "WORKDIR " + req.runConfig.WorkingDir
 	runConfigWithCommentCmd := copyRunConfig(req.runConfig, withCmdCommentString(comment))
 	if hit, err := req.builder.probeCache(req.builder.image, runConfigWithCommentCmd); err != nil || hit {
@@ -371,9 +367,6 @@ func run(req dispatchRequest) error {
 	if len(buildArgs) > 0 {
 		saveCmd = prependEnvOnCmd(req.builder.buildArgs, buildArgs, cmdFromArgs)
 	}
-
-	// TODO: this was previously in b.create(), why is it necessary?
-	req.runConfig.Image = req.builder.image
 
 	runConfigForCacheProbe := copyRunConfig(req.runConfig, withCmd(saveCmd))
 	hit, err := req.builder.probeCache(req.builder.image, runConfigForCacheProbe)

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -448,6 +448,7 @@ func TestRunWithBuildArgs(t *testing.T) {
 		getCacheFunc: func(parentID string, cfg *container.Config) (string, error) {
 			// Check the runConfig.Cmd sent to probeCache()
 			assert.Equal(t, cachedCmd, cfg.Cmd)
+			assert.Equal(t, strslice.StrSlice(nil), cfg.Entrypoint)
 			return "", nil
 		},
 	}
@@ -462,12 +463,14 @@ func TestRunWithBuildArgs(t *testing.T) {
 		// Check the runConfig.Cmd sent to create()
 		assert.Equal(t, cmdWithShell, config.Config.Cmd)
 		assert.Contains(t, config.Config.Env, "one=two")
+		assert.Equal(t, strslice.StrSlice{""}, config.Config.Entrypoint)
 		return container.ContainerCreateCreatedBody{ID: "12345"}, nil
 	}
 	mockBackend.commitFunc = func(cID string, cfg *backend.ContainerCommitConfig) (string, error) {
 		// Check the runConfig.Cmd sent to commit()
 		assert.Equal(t, origCmd, cfg.Config.Cmd)
 		assert.Equal(t, cachedCmd, cfg.ContainerConfig.Cmd)
+		assert.Equal(t, strslice.StrSlice(nil), cfg.Config.Entrypoint)
 		return "", nil
 	}
 

--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -173,7 +173,14 @@ func (b *Builder) dispatch(stepN int, stepTotal int, node *parser.Node, shlex *S
 	// XXX yes, we skip any cmds that are not valid; the parser should have
 	// picked these out already.
 	if f, ok := evaluateTable[cmd]; ok {
-		return f(newDispatchRequestFromNode(node, b, strList, shlex))
+		if err := f(newDispatchRequestFromNode(node, b, strList, shlex)); err != nil {
+			return err
+		}
+		// TODO: return an object instead of setting things on builder
+		// If the step created a new image set it as the imageID for the
+		// current runConfig
+		b.runConfig.Image = b.image
+		return nil
 	}
 
 	return fmt.Errorf("Unknown instruction: %s", upperCasedCmd)

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -42,8 +42,6 @@ func (b *Builder) commit(comment string) error {
 	if !b.hasFromImage() {
 		return errors.New("Please provide a source image with `from` prior to commit")
 	}
-	// TODO: why is this set here?
-	b.runConfig.Image = b.image
 
 	runConfigWithCommentCmd := copyRunConfig(b.runConfig, withCmdComment(comment))
 	hit, err := b.probeCache(b.image, runConfigWithCommentCmd)
@@ -99,10 +97,6 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowLocalD
 
 	// Work in daemon-specific filepath semantics
 	dest := filepath.FromSlash(args[len(args)-1]) // last one is always the dest
-
-	// TODO: why is this done here. This seems to be done at random places all over
-	// the builder
-	b.runConfig.Image = b.image
 
 	var infos []copyInfo
 
@@ -542,12 +536,12 @@ func (b *Builder) processImageFrom(img builder.Image) error {
 // If an image is found, probeCache returns `(true, nil)`.
 // If no image is found, it returns `(false, nil)`.
 // If there is any error, it returns `(false, err)`.
-func (b *Builder) probeCache(imageID string, runConfig *container.Config) (bool, error) {
+func (b *Builder) probeCache(parentID string, runConfig *container.Config) (bool, error) {
 	c := b.imageCache
 	if c == nil || b.options.NoCache || b.cacheBusted {
 		return false, nil
 	}
-	cache, err := c.GetCache(imageID, runConfig)
+	cache, err := c.GetCache(parentID, runConfig)
 	if err != nil {
 		return false, err
 	}

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -601,12 +601,6 @@ func (b *Builder) create(runConfig *container.Config) (string, error) {
 
 	b.tmpContainers[c.ID] = struct{}{}
 	fmt.Fprintf(b.Stdout, " ---> Running in %s\n", stringid.TruncateID(c.ID))
-
-	// override the entry point that may have been picked up from the base image
-	if err := b.docker.ContainerUpdateCmdOnBuild(c.ID, runConfig.Cmd); err != nil {
-		return "", err
-	}
-
 	return c.ID, nil
 }
 

--- a/builder/dockerfile/mockbackend_test.go
+++ b/builder/dockerfile/mockbackend_test.go
@@ -73,10 +73,6 @@ func (m *MockBackend) ContainerWait(containerID string, timeout time.Duration) (
 	return 0, nil
 }
 
-func (m *MockBackend) ContainerUpdateCmdOnBuild(containerID string, cmd []string) error {
-	return nil
-}
-
 func (m *MockBackend) ContainerCreateWorkdir(containerID string) error {
 	return nil
 }

--- a/daemon/update.go
+++ b/daemon/update.go
@@ -22,20 +22,6 @@ func (daemon *Daemon) ContainerUpdate(name string, hostConfig *container.HostCon
 	return container.ContainerUpdateOKBody{Warnings: warnings}, nil
 }
 
-// ContainerUpdateCmdOnBuild updates Path and Args for the container with ID cID.
-func (daemon *Daemon) ContainerUpdateCmdOnBuild(cID string, cmd []string) error {
-	if len(cmd) == 0 {
-		return nil
-	}
-	c, err := daemon.GetContainer(cID)
-	if err != nil {
-		return err
-	}
-	c.Path = cmd[0]
-	c.Args = cmd[1:]
-	return nil
-}
-
 func (daemon *Daemon) update(name string, hostConfig *container.HostConfig) error {
 	if hostConfig == nil {
 		return nil

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -337,13 +337,13 @@ func (s *DockerSuite) TestBuildOnBuildCmdEntrypointJSON(c *check.C) {
 	name1 := "onbuildcmd"
 	name2 := "onbuildgenerated"
 
-	buildImageSuccessfully(c, name1, build.WithDockerfile(`
+	cli.BuildCmd(c, name1, build.WithDockerfile(`
 FROM busybox
 ONBUILD CMD ["hello world"]
 ONBUILD ENTRYPOINT ["echo"]
 ONBUILD RUN ["true"]`))
 
-	buildImageSuccessfully(c, name2, build.WithDockerfile(fmt.Sprintf(`FROM %s`, name1)))
+	cli.BuildCmd(c, name2, build.WithDockerfile(fmt.Sprintf(`FROM %s`, name1)))
 
 	result := cli.DockerCmd(c, "run", name2)
 	result.Assert(c, icmd.Expected{Out: "hello world"})


### PR DESCRIPTION
`ContainerUpdateCmdOnBuild` is an unnecessary extra method on the `builder.Backend` interface. It seems to have been added (39343b86182b4e997dc991645729ae130bd0f5f2) as a way to deal with really old code in the builder that messed with container config after creating the container.

Instead we can set the entrypoint to the `{""}` token, which maybe didn't exist when this code was first written.

Also cleans up setting of `b.runConfig.Image = b.image`, which was does at random places. I believe the correct place for this operation is between dispatch steps. With further refactoring there should be a bunch of other similar operations that happen at this time, as fields are removed from the `Builder` struct.