### PR TITLE
Clarify relationship between Moby and Docker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+### Docker users, see [Moby and Docker](https://mobyproject.org/#moby-and-docker) to clarify the relationship between the projects
+
 ### Docker maintainers and contributors, see [Transitioning to Moby](#transitioning-to-moby) for more details
 
 The Moby Project


### PR DESCRIPTION
As discussed yesterday with @shykes @chanezon @tiborvass & others, here is (belatedly) a PR which links the `moby/moby` README to the clarificatory text we drafted collaboratively for _Docker users looking at the repo_.