### PR TITLE
builder: Make builtin arg pruning work with > 1 arg

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -438,12 +438,11 @@ func run(req dispatchRequest) error {
 	// these args are transparent so resulting image should be the same regardless of the value
 	if len(cmdBuildEnv) > 0 {
 		saveCmd = config.Cmd
-		tmpBuildEnv := make([]string, len(cmdBuildEnv))
-		copy(tmpBuildEnv, cmdBuildEnv)
-		for i, env := range tmpBuildEnv {
+		var tmpBuildEnv []string
+		for _, env := range cmdBuildEnv {
 			key := strings.SplitN(env, "=", 2)[0]
-			if req.builder.buildArgs.IsUnreferencedBuiltin(key) {
-				tmpBuildEnv = append(tmpBuildEnv[:i], tmpBuildEnv[i+1:]...)
+			if !req.builder.buildArgs.IsUnreferencedBuiltin(key) {
+				tmpBuildEnv = append(tmpBuildEnv, env)
 			}
 		}
 		sort.Strings(tmpBuildEnv)

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4355,7 +4355,8 @@ func (s *DockerSuite) TestBuildTimeArgHistoryExclusions(c *check.C) {
 		ARG %s
 		RUN echo "Testing Build Args!"`, envKey, explicitProxyKey)
 	buildImage(imgName,
-		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal),
+		cli.WithFlags("--build-arg", "https_proxy=https://proxy.example.com",
+			"--build-arg", fmt.Sprintf("%s=%s", envKey, envVal),
 			"--build-arg", fmt.Sprintf("%s=%s", explicitProxyKey, explicitProxyVal),
 			"--build-arg", proxy),
 		build.WithDockerfile(dockerfile),
@@ -4363,6 +4364,9 @@ func (s *DockerSuite) TestBuildTimeArgHistoryExclusions(c *check.C) {
 
 	out, _ := dockerCmd(c, "history", "--no-trunc", imgName)
 	if strings.Contains(out, proxy) {
+		c.Fatalf("failed to exclude proxy settings from history!")
+	}
+	if strings.Contains(out, "https_proxy") {
 		c.Fatalf("failed to exclude proxy settings from history!")
 	}
 	if !strings.Contains(out, fmt.Sprintf("%s=%s", envKey, envVal)) {


### PR DESCRIPTION
The previous implementation would error out with "Unexpected EOF" which
was caused by an underlying "array index out-of-bounds" error.
The root cause was deleting items from the same array that was being
iterated over. The iteration was unaware that the array size had
changed, resulting in an error.

The new implementation builds a new array instead of mutating a copy of
the old one.

Fixes: #32744

Signed-off-by: Dave Tucker <dt@docker.com>