### PR TITLE
Allow registry_mirrors to apply to unofficial registries.

### DIFF
--- a/api/types/registry/registry.go
+++ b/api/types/registry/registry.go
@@ -9,7 +9,6 @@ import (
 type ServiceConfig struct {
 	InsecureRegistryCIDRs []*NetIPNet           `json:"InsecureRegistryCIDRs"`
 	IndexConfigs          map[string]*IndexInfo `json:"IndexConfigs"`
-	Mirrors               []string
 }
 
 // NetIPNet is the net.IPNet type, which can be marshalled and

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -267,10 +267,12 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 		}
 	}
 
-	if info.RegistryConfig != nil && len(info.RegistryConfig.Mirrors) > 0 {
-		fmt.Fprintln(dockerCli.Out(), "Registry Mirrors:")
-		for _, mirror := range info.RegistryConfig.Mirrors {
-			fmt.Fprintf(dockerCli.Out(), " %s\n", mirror)
+	if info.RegistryConfig != nil {
+		for indexInfo := range info.RegistryConfig.IndexConfigs {
+			fmt.Fprintf(dockerCli.Out(), "Registry Mirrors for %s:", indexInfo)
+			for _, mirror := range info.RegistryConfig.IndexConfigs[indexInfo].Mirrors {
+				fmt.Fprintf(dockerCli.Out(), " %s\n", mirror)
+			}
 		}
 	}
 

--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -145,3 +145,23 @@ func TestLoadDaemonConfigWithRegistryOptions(t *testing.T) {
 	assert.Len(t, loadedConfig.Mirrors, 1)
 	assert.Len(t, loadedConfig.InsecureRegistries, 1)
 }
+
+func TestLoadDaemonConfigWithUnofficialRegistryMirrors(t *testing.T) {
+	content := `{
+        "registry-mirrors": [
+            "https://mirrors.docker.com",
+            "https://private_registry.com->https://local_cache"
+        ],
+		"insecure-registries": ["https://insecure.docker.com"]
+	}`
+	tempFile := tempfile.NewTempFile(t, "config", content)
+	defer tempFile.Remove()
+
+	opts := defaultOptions(tempFile.Name())
+	loadedConfig, err := loadDaemonCliConfig(opts)
+	assert.NoError(t, err)
+	assert.NotNil(t, loadedConfig)
+
+	assert.Equal(t, len(loadedConfig.Mirrors), 2)
+	assert.Equal(t, len(loadedConfig.InsecureRegistries), 1)
+}

--- a/registry/service.go
+++ b/registry/service.go
@@ -58,7 +58,6 @@ func (s *DefaultService) ServiceConfig() *registrytypes.ServiceConfig {
 	servConfig := registrytypes.ServiceConfig{
 		InsecureRegistryCIDRs: make([]*(registrytypes.NetIPNet), 0),
 		IndexConfigs:          make(map[string]*(registrytypes.IndexInfo)),
-		Mirrors:               make([]string, 0),
 	}
 
 	// construct a new ServiceConfig which will not retrieve s.Config directly,
@@ -68,8 +67,6 @@ func (s *DefaultService) ServiceConfig() *registrytypes.ServiceConfig {
 	for key, value := range s.config.ServiceConfig.IndexConfigs {
 		servConfig.IndexConfigs[key] = value
 	}
-
-	servConfig.Mirrors = append(servConfig.Mirrors, s.config.ServiceConfig.Mirrors...)
 
 	return &servConfig
 }

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -9,9 +9,10 @@ import (
 
 func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
 	tlsConfig := tlsconfig.ServerDefault()
-	if hostname == DefaultNamespace || hostname == IndexHostname {
-		// v2 mirrors
-		for _, mirror := range s.config.Mirrors {
+
+	// v2 mirrors
+	if _, ok := s.config.IndexConfigs[hostname]; ok {
+		for _, mirror := range s.config.IndexConfigs[hostname].Mirrors {
 			if !strings.HasPrefix(mirror, "http://") && !strings.HasPrefix(mirror, "https://") {
 				mirror = "https://" + mirror
 			}
@@ -33,14 +34,16 @@ func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 			})
 		}
 		// v2 registry
-		endpoints = append(endpoints, APIEndpoint{
-			URL:          DefaultV2Registry,
-			Version:      APIVersion2,
-			Official:     true,
-			TrimHostname: true,
-			TLSConfig:    tlsConfig,
-		})
-
+		// TODO(amidlash): confirm if needed
+		if hostname == IndexName {
+			endpoints = append(endpoints, APIEndpoint{
+				URL:          DefaultV2Registry,
+				Version:      APIVersion2,
+				Official:     true,
+				TrimHostname: true,
+				TLSConfig:    tlsConfig,
+			})
+		}
 		return endpoints, nil
 	}
 


### PR DESCRIPTION
Tested with unit tests, and ran locally:
registry_mirrors="someregistry.com->index.docker.io", and docker pull
someregistry.com/library/ubuntu succeeded.

Signed-off-by: Alexander Midlash <amidlash@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Allow registry_mirrors flag to additionally set mirrors for unofficial registries.

**- How I did it**
For backwards compatibility, registry_mirrors entries can either be old-style ("some-host"), or new style ("original-host->new-mirror"). All mirroring information is stored in the IndexConfig, so that we can set mirrors per index.

**- How to verify it**
Besides unit tests, try setting registry_mirrors="somedomain.com->index.docker.io"
You can then `docker pull somedomain.com/library/ubuntu" and receive the image from the official registry.
In practice, this would be used to redirect from an organizations private registry, to per-datacenter caches.

**- Description for the changelog**
Allow registry_mirrors to apply to unofficial registries.

**- A picture of a cute animal (not mandatory but encouraged)**

