### PR TITLE
[Builder] Cleanup unnecessary mutate then revert of b.runConfig

### DIFF
--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 )
 
 // ContainerAttachConfig holds the streams to use when connecting to a container to view logs.
@@ -97,4 +98,7 @@ type ExecProcessConfig struct {
 type ContainerCommitConfig struct {
 	types.ContainerCommitConfig
 	Changes []string
+	// TODO: ContainerConfig is only used by the dockerfile Builder, so remove it
+	// once the Builder has been updated to use a different interface
+	ContainerConfig *container.Config
 }

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -243,6 +243,10 @@ func (b *Builder) hasFromImage() bool {
 //
 // TODO: Remove?
 func BuildFromConfig(config *container.Config, changes []string) (*container.Config, error) {
+	if len(changes) == 0 {
+		return config, nil
+	}
+
 	b := newBuilder(context.Background(), builderOptions{})
 
 	result, err := parser.Parse(bytes.NewBufferString(strings.Join(changes, "\n")))

--- a/builder/dockerfile/mockbackend_test.go
+++ b/builder/dockerfile/mockbackend_test.go
@@ -15,12 +15,18 @@ import (
 
 // MockBackend implements the builder.Backend interface for unit testing
 type MockBackend struct {
-	getImageOnBuildFunc func(string) (builder.Image, error)
+	getImageOnBuildFunc  func(string) (builder.Image, error)
+	getImageOnBuildImage *mockImage
+	containerCreateFunc  func(config types.ContainerCreateConfig) (container.ContainerCreateCreatedBody, error)
+	commitFunc           func(string, *backend.ContainerCommitConfig) (string, error)
 }
 
 func (m *MockBackend) GetImageOnBuild(name string) (builder.Image, error) {
 	if m.getImageOnBuildFunc != nil {
 		return m.getImageOnBuildFunc(name)
+	}
+	if m.getImageOnBuildImage != nil {
+		return m.getImageOnBuildImage, nil
 	}
 	return &mockImage{id: "theid"}, nil
 }
@@ -38,6 +44,9 @@ func (m *MockBackend) ContainerAttachRaw(cID string, stdin io.ReadCloser, stdout
 }
 
 func (m *MockBackend) ContainerCreate(config types.ContainerCreateConfig) (container.ContainerCreateCreatedBody, error) {
+	if m.containerCreateFunc != nil {
+		return m.containerCreateFunc(config)
+	}
 	return container.ContainerCreateCreatedBody{}, nil
 }
 
@@ -45,7 +54,10 @@ func (m *MockBackend) ContainerRm(name string, config *types.ContainerRmConfig) 
 	return nil
 }
 
-func (m *MockBackend) Commit(string, *backend.ContainerCommitConfig) (string, error) {
+func (m *MockBackend) Commit(cID string, cfg *backend.ContainerCommitConfig) (string, error) {
+	if m.commitFunc != nil {
+		return m.commitFunc(cID, cfg)
+	}
 	return "", nil
 }
 
@@ -96,4 +108,15 @@ func (i *mockImage) ImageID() string {
 
 func (i *mockImage) RunConfig() *container.Config {
 	return i.config
+}
+
+type mockImageCache struct {
+	getCacheFunc func(parentID string, cfg *container.Config) (string, error)
+}
+
+func (mic *mockImageCache) GetCache(parentID string, cfg *container.Config) (string, error) {
+	if mic.getCacheFunc != nil {
+		return mic.getCacheFunc(parentID, cfg)
+	}
+	return "", nil
 }

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -129,6 +129,11 @@ func (daemon *Daemon) Commit(name string, c *backend.ContainerCommitConfig) (str
 		return "", err
 	}
 
+	containerConfig := c.ContainerConfig
+	if containerConfig == nil {
+		containerConfig = container.Config
+	}
+
 	// It is not possible to commit a running container on Windows and on Solaris.
 	if (runtime.GOOS == "windows" || runtime.GOOS == "solaris") && container.IsRunning() {
 		return "", errors.Errorf("%+v does not support commit of a running container", runtime.GOOS)
@@ -185,7 +190,7 @@ func (daemon *Daemon) Commit(name string, c *backend.ContainerCommitConfig) (str
 	h := image.History{
 		Author:     c.Author,
 		Created:    time.Now().UTC(),
-		CreatedBy:  strings.Join(container.Config.Cmd, " "),
+		CreatedBy:  strings.Join(containerConfig.Cmd, " "),
 		Comment:    c.Comment,
 		EmptyLayer: true,
 	}
@@ -204,7 +209,7 @@ func (daemon *Daemon) Commit(name string, c *backend.ContainerCommitConfig) (str
 			Architecture:    runtime.GOARCH,
 			OS:              runtime.GOOS,
 			Container:       container.ID,
-			ContainerConfig: *container.Config,
+			ContainerConfig: *containerConfig,
 			Author:          c.Author,
 			Created:         h.Created,
 		},

--- a/image/cache/compare.go
+++ b/image/cache/compare.go
@@ -1,6 +1,8 @@
 package cache
 
-import "github.com/docker/docker/api/types/container"
+import (
+	"github.com/docker/docker/api/types/container"
+)
 
 // compare two Config struct. Do not compare the "Image" nor "Hostname" fields
 // If OpenStdin is set, then it differs


### PR DESCRIPTION
This PR changes how runConfig is modified by the builder dispatchers. Previously a single runConfig reference was passed around everywhere. This made it possible for the builder to modify (either accidentally or intentionally) the config of an already created container without using the established interface.

Instead of passing around a single reference, copies of runConfig are created when the dispatcher needs to make a temporary modification to runConfig. Creating a copy removes the need to setup a defer to revert the temporary modification. It also avoids any accidental modification of a container configuration.

`ContainerConfig` was added to the commit options to support the existing behaviour of `dispatchers.run()`. `Cmd` was modified after the container was created, and this change was picked up by `commit()` because of the shared reference. With this API change the behaviour is a lot more obvious.

I think this changes makes the dispatchers and builder internals much easier to understand. It also removes some dead code from `run()` which wasn't obvious because of the clutter.