### PR TITLE
Use CpuMaximum instead of CpuPercent for more precision

### DIFF
--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -128,8 +128,8 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 			if spec.Windows.Resources.CPU.Shares != nil {
 				configuration.ProcessorWeight = uint64(*spec.Windows.Resources.CPU.Shares)
 			}
-			if spec.Windows.Resources.CPU.Percent != nil {
-				configuration.ProcessorMaximum = int64(*spec.Windows.Resources.CPU.Percent) * 100 // ProcessorMaximum is a value between 1 and 10000
+			if spec.Windows.Resources.CPU.Maximum != nil {
+				configuration.ProcessorMaximum = int64(*spec.Windows.Resources.CPU.Maximum)
 			}
 		}
 		if spec.Windows.Resources.Memory != nil {

--- a/vendor.conf
+++ b/vendor.conf
@@ -62,8 +62,8 @@ github.com/miekg/pkcs11 df8ae6ca730422dba20c768ff38ef7d79077a59f
 
 # When updating, also update RUNC_COMMIT in hack/dockerfile/binaries-commits accordingly
 github.com/opencontainers/runc 992a5be178a62e026f4069f443c6164912adbf09
-github.com/opencontainers/runtime-spec v1.0.0-rc5 # specs
 github.com/opencontainers/image-spec f03dbe35d449c54915d235f1a3cf8f585a24babe
+github.com/opencontainers/runtime-spec d42f1eb741e6361e858d83fc75aa6893b66292c4 # specs
 
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
 

--- a/vendor/github.com/opencontainers/runtime-spec/README.md
+++ b/vendor/github.com/opencontainers/runtime-spec/README.md
@@ -60,10 +60,16 @@ When in doubt, start on the [mailing-list](#mailing-list).
 
 ### Weekly Call
 
-The contributors and maintainers of all OCI projects have a weekly meeting Wednesdays at 2:00 PM (USA Pacific).
-Everyone is welcome to participate via [UberConference web][uberconference] or audio-only: 415-968-0849 (no PIN needed.)
+The contributors and maintainers of all OCI projects have a weekly meeting on Wednesdays at:
+
+* 8:00 AM (USA Pacific), during [odd weeks][iso-week].
+* 5:00 PM (USA Pacific), during [even weeks][iso-week].
+
+There is an [iCalendar][rfc5545] format for the meetings [here](meeting.ics).
+
+Everyone is welcome to participate via [UberConference web][uberconference] or audio-only: +1 415 968 0849 (no PIN needed).
 An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
-Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived to the [wiki][runtime-wiki].
+Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived [here][minutes], with minutes from especially old meetings (September 2015 and earlier) archived [here][runtime-wiki].
 
 ### Mailing List
 
@@ -148,7 +154,10 @@ Read more on [How to Write a Git Commit Message][how-to-git-commit] or the Discu
 [dev-list]: https://groups.google.com/a/opencontainers.org/forum/#!forum/dev
 [how-to-git-commit]: http://chris.beams.io/posts/git-commit
 [irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/
+[iso-week]: https://en.wikipedia.org/wiki/ISO_week_date#Calculating_the_week_number_of_a_given_date
+[minutes]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/
 [oci]: https://www.opencontainers.org
+[rfc5545]: https://tools.ietf.org/html/rfc5545
 [runtime-wiki]: https://github.com/opencontainers/runtime-spec/wiki
 [uberconference]: https://www.uberconference.com/opencontainers
 

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -169,6 +169,9 @@ type Linux struct {
 	ReadonlyPaths []string `json:"readonlyPaths,omitempty"`
 	// MountLabel specifies the selinux context for the mounts in the container.
 	MountLabel string `json:"mountLabel,omitempty"`
+	// IntelRdt contains Intel Resource Director Technology (RDT) information
+	// for handling resource constraints (e.g., L3 cache) for the container
+	IntelRdt *LinuxIntelRdt `json:"intelRdt,omitempty"`
 }
 
 // LinuxNamespace is the configuration for a Linux namespace
@@ -247,9 +250,9 @@ type linuxBlockIODevice struct {
 // LinuxWeightDevice struct holds a `major:minor weight` pair for blkioWeightDevice
 type LinuxWeightDevice struct {
 	linuxBlockIODevice
-	// Weight is the bandwidth rate for the device, range is from 10 to 1000
+	// Weight is the bandwidth rate for the device.
 	Weight *uint16 `json:"weight,omitempty"`
-	// LeafWeight is the bandwidth rate for the device while competing with the cgroup's child cgroups, range is from 10 to 1000, CFQ scheduler only
+	// LeafWeight is the bandwidth rate for the device while competing with the cgroup's child cgroups, CFQ scheduler only
 	LeafWeight *uint16 `json:"leafWeight,omitempty"`
 }
 
@@ -262,9 +265,9 @@ type LinuxThrottleDevice struct {
 
 // LinuxBlockIO for Linux cgroup 'blkio' resource management
 type LinuxBlockIO struct {
-	// Specifies per cgroup weight, range is from 10 to 1000
+	// Specifies per cgroup weight
 	Weight *uint16 `json:"blkioWeight,omitempty"`
-	// Specifies tasks' weight in the given cgroup while competing with the cgroup's child cgroups, range is from 10 to 1000, CFQ scheduler only
+	// Specifies tasks' weight in the given cgroup while competing with the cgroup's child cgroups, CFQ scheduler only
 	LeafWeight *uint16 `json:"blkioLeafWeight,omitempty"`
 	// Weight per cgroup per device, can override BlkioWeight
 	WeightDevice []LinuxWeightDevice `json:"blkioWeightDevice,omitempty"`
@@ -457,8 +460,8 @@ type WindowsCPUResources struct {
 	Count *uint64 `json:"count,omitempty"`
 	// CPU shares (relative weight to other containers with cpu shares). Range is from 1 to 10000.
 	Shares *uint16 `json:"shares,omitempty"`
-	// Percent of available CPUs usable by the container.
-	Percent *uint8 `json:"percent,omitempty"`
+	// Specifies the portion of processor cycles that this container can use as a percentage times 100.
+	Maximum *uint16 `json:"maximum,omitempty"`
 }
 
 // WindowsStorageResources contains storage resource management settings.
@@ -481,7 +484,7 @@ type WindowsNetworkResources struct {
 type LinuxSeccomp struct {
 	DefaultAction LinuxSeccompAction `json:"defaultAction"`
 	Architectures []Arch             `json:"architectures,omitempty"`
-	Syscalls      []LinuxSyscall     `json:"syscalls"`
+	Syscalls      []LinuxSyscall     `json:"syscalls,omitempty"`
 }
 
 // Arch used for additional architectures
@@ -546,8 +549,15 @@ type LinuxSeccompArg struct {
 
 // LinuxSyscall is used to match a syscall in Seccomp
 type LinuxSyscall struct {
-	Names   []string           `json:"names"`
-	Action  LinuxSeccompAction `json:"action"`
-	Args    []LinuxSeccompArg  `json:"args"`
-	Comment string             `json:"comment"`
+	Names  []string           `json:"names"`
+	Action LinuxSeccompAction `json:"action"`
+	Args   []LinuxSeccompArg  `json:"args,omitempty"`
+}
+
+// LinuxIntelRdt has container runtime resource constraints
+// for Intel RDT/CAT which introduced in Linux 4.10 kernel
+type LinuxIntelRdt struct {
+	// The schema for L3 cache id and capacity bitmask (CBM)
+	// Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
+	L3CacheSchema string `json:"l3CacheSchema,omitempty"`
 }

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc5"
+	VersionDev = "-rc5-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
Signed-off-by: Darren Stahl <darst@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

In order to allow for more fine tuned control of CPU resources on Windows, this extends the ProcessorMaximum setting from the HCS API into the daemon through the oci runtime spec (See https://github.com/opencontainers/runtime-spec/pull/777).

Related to https://github.com/moby/moby/pull/32608 and https://github.com/moby/moby/pull/32727 and https://github.com/moby/moby/issues/32014

**- How I did it**

Change OCI runtime spec to use Maximum instead of Percent. Update NanoCpus and Percent calculations to use the new type.

**- How to verify it**

Manual.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A (Unless we want to also update the HostConfig to use Maximum instead of Percent)

/cc @jhowardmsft 