### PR TITLE
Fixes #10824. Adjusted docker stats memory output

### DIFF
--- a/cli/command/container/stats_helpers_test.go
+++ b/cli/command/container/stats_helpers_test.go
@@ -1,0 +1,42 @@
+package container
+
+import (
+	"github.com/docker/docker/api/types"
+	"testing"
+)
+
+func TestCalculateMemUsageUnixNoCache(t *testing.T) {
+	// Given
+	stats := types.MemoryStats{Usage: 500, Stats: map[string]uint64{"cache": 400}}
+
+	// When
+	result := calculateMemUsageUnixNoCache(stats)
+
+	// Then
+	if result != 100 {
+		t.Errorf("mem = %d, want 100", result)
+	}
+}
+
+func TestCalculateMemPercentUnixNoCache(t *testing.T) {
+	// Given
+	someLimit := float64(100.0)
+	noLimit := float64(0.0)
+	used := float64(70.0)
+
+	// When and Then
+	t.Run("Limit is set", func(t *testing.T) {
+		result := calculateMemPercentUnixNoCache(someLimit, used)
+		expected := float64(70.0)
+		if result != expected {
+			t.Errorf("percent = %f, want %f", result, expected)
+		}
+	})
+	t.Run("No limit, no cgroup data", func(t *testing.T) {
+		result := calculateMemPercentUnixNoCache(noLimit, used)
+		expected := float64(0.0)
+		if result != expected {
+			t.Errorf("percent = %f, want %f", result, expected)
+		}
+	})
+}

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -105,7 +105,7 @@ Placeholder  | Description
 `.Name`      | Container name
 `.ID`        | Container ID
 `.CPUPerc`   | CPU percentage
-`.MemUsage`  | Memory usage
+`.MemUsage`  | Memory usage (page cache is excluded)
 `.NetIO`     | Network IO
 `.BlockIO`   | Block IO
 `.MemPerc`   | Memory percentage (Not available on Windows)


### PR DESCRIPTION
Signed-off-by: Sergey Tryuber <Sergeant007@users.noreply.github.com>

### **- What I did**
"docker stats" CLI command now outputs memory usage without page cache. Fixes #10824.

### **- How I did it**
Followed to the solution suggested by @crosbymichael in #10824 - "just subtract the cache from the usage value before displaying it to the user". 

### **- How to verify it**
#10824 contains the debug steps to prove that "docker stats" used to include page cache in its output. This PR corrects the behavior. 

Experiment (Docker version 17.06.0-dev, build 1eec7b5). The steps are done inside [development container](https://docs.docker.com/opensource/project/set-up-dev-env/#task-2-start-a-development-container), you would need to open several terminals to the development container.

_Step 0. [build the binaries](https://docs.docker.com/opensource/project/set-up-dev-env/#task-2-start-a-development-container) and then start docker daemon listening on tcp_
```bash
// start with tcp since curl in development container cannot work with file sockets
$dockerd -D -H tcp://0.0.0.0:2375
```

_Step 1. start a container with bash_
```bash
docker -H localhost:2375 run --name mem_stats_test --interactive --tty ubuntu:14.04 /bin/bash
```

_Step 2. open a new terminal window and ensure that memory consumption in stats is low_
```bash
$ docker -H localhost:2375 stats mem_stats_test --no-stream
CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
mem_stats_test      0.00%               1.699MiB / 15.58GiB   0.01%               648B / 0B           0B / 0B             1
$
$curl http://localhost:2375/containers/mem_stats_test/stats?stream=false | python -m json.tool
...
    "memory_stats": {
        "limit": 16724922368,
        "max_usage": 2629632,
        "stats": {
            "active_anon": 507904,
            "active_file": 0,
            "cache": 20480,                  <-- CACHE
            "dirty": 0,
            "hierarchical_memory_limit": 9223372036854771712,
            "inactive_anon": 4096,
            "inactive_file": 0,
            "mapped_file": 0,
            "pgfault": 1377,
            "pgmajfault": 0,
            "pgpgin": 754,
            "pgpgout": 629,
            "rss": 491520,
            "rss_huge": 0,
            "total_active_anon": 507904,
            "total_active_file": 0,
            "total_cache": 20480,
            "total_dirty": 0,
            "total_inactive_anon": 4096,
            "total_inactive_file": 0,
            "total_mapped_file": 0,
            "total_pgfault": 1377,
            "total_pgmajfault": 0,
            "total_pgpgin": 754,
            "total_pgpgout": 629,
            "total_rss": 491520,
            "total_rss_huge": 0,
            "total_unevictable": 0,
            "total_writeback": 0,
            "unevictable": 0,
            "writeback": 0
        },
        "usage": 1802240                     <-- OVERALL USAGE
    },
...
```

_Step 3. Let is work for several hours to ensure that memory doesn't grow significanly (or believe me ans skip this step)_

_Step 4. Do some heavy file operations that grow page cache (in docker container console from Step 1)_
```bash
# # Once following operation is finished, page cache will grow, but no additional "real" memory consumption is added
# dd if=/dev/urandom of=/tmp/1GB.bin bs=64M count=16 iflag=fullblock
16+0 records in
16+0 records out
1073741824 bytes (1.1 GB) copied, 10.9137 s, 98.4 MB/s
```

_Step 5. Check docker stats again to see that **there is no page cache included in the output**_
```bash
$ # reported memoty DID NOT grew up (significantly)!!!
$ docker -H localhost:2375 stats mem_stats_test --no-stream
CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
mem_stats_test      0.00%               4.039MiB / 15.58GiB   0.03%               648B / 0B           0B / 0B             1
$curl http://localhost:2375/containers/mem_stats_test/stats?stream=false | python -m json.tool
...
"memory_stats": {
        "limit": 16724922368,
        "max_usage": 1145520128,
        "stats": {
            "active_anon": 520192,
            "active_file": 0,
            "cache": 1073766400,                          <-- OUR PAGE CACHE
            "dirty": 0,
            "hierarchical_memory_limit": 9223372036854771712,
            "inactive_anon": 0,
            "inactive_file": 1073741824,
            "mapped_file": 0,
            "pgfault": 2050,
            "pgmajfault": 0,
            "pgpgin": 263492,
            "pgpgout": 1221,
            "rss": 495616,
            "rss_huge": 0,
            "total_active_anon": 520192,
            "total_active_file": 0,
            "total_cache": 1073766400,
            "total_dirty": 0,
            "total_inactive_anon": 0,
            "total_inactive_file": 1073741824,
            "total_mapped_file": 0,
            "total_pgfault": 2050,
            "total_pgmajfault": 0,
            "total_pgpgin": 263492,
            "total_pgpgout": 1221,
            "total_rss": 495616,
            "total_rss_huge": 0,
            "total_unevictable": 0,
            "total_writeback": 0,
            "unevictable": 0,
            "writeback": 0
        },
        "usage": 1078001664                                  <-- THIS INCLUDES PAGE CACHE !!!!
...
```
_Step 6. Conclusion_
**With this PR docker stats outputs reasonable amount of used memory (no page cache included)**

### **- Description for the changelog**
"docker stats" command outputs memory usage with no page cache memory included.

### **- A picture of a cute animal (not mandatory but encouraged)**
My cat Tom.
![tom](https://cloud.githubusercontent.com/assets/6276040/25304000/3de373e6-276f-11e7-886f-a5e5240b5f64.jpg)

