### PR TITLE
pull client API version negotiation out of the CLI and into the client

### DIFF
--- a/client/interface.go
+++ b/client/interface.go
@@ -33,7 +33,8 @@ type CommonAPIClient interface {
 	ClientVersion() string
 	DaemonHost() string
 	ServerVersion(ctx context.Context) (types.Version, error)
-	UpdateClientVersion(v string)
+	NegotiateAPIVersion(ctx context.Context)
+	NegotiateAPIVersionPing(types.Ping)
 }
 
 // ContainerAPIClient defines API client methods for the containers


### PR DESCRIPTION
**- What I did**

Added some tests for client version discovery, and moved that logic out of the CLI and into the client.

The drive here is that I was using the go docker client, and had to call UpdateVersion with a string I needed to get from the server. I noticed that the CLI never had to do this, and sure enough there was some server version negotiation going on in the CLI. At this commit, the CLI just implements a normal client, and the client owns the logic for server version negotiation (so folks consuming the client library can enjoy that same functionality).

**- How I did it**

Added a new conditional statement in client/client.go UpdateClientVersion(str). If the string is empty, it will trigger DowngradeClientVersion() and step into some cut/paste logic that already existed in cli/command/cli.go for pinging the server, grabbing the APIVersion string, and updating that.

**- How to verify it**

```sh
docker run --privileged -e DOCKER_GITCOMMIT=eebfdd0 docker hack/make.sh test-unit test-integration-cli test-docker-py
```

or 
```sh
cd client
go test
```

The manual/functional verification for the CLI built against this commit:
1) start a daemon of an older version
2) docker info

The test cases cover a few more edges than that:
* if the server doesn't return an APIVersion
* if the environment of the CLI specifically pins DOCKER_API_VERSION

**- Description for the changelog**

UpdateClientVersion can auto-downgrade to the server APIVersion

**- A picture of a cute animal (not mandatory but encouraged)**

![shibs](https://i.imgur.com/zKP7aXH.jpg)