### PR TITLE
Add extra prometheus metrics

### DIFF
--- a/builder/dockerfile/metrics.go
+++ b/builder/dockerfile/metrics.go
@@ -1,0 +1,44 @@
+package dockerfile
+
+import (
+	"github.com/docker/go-metrics"
+)
+
+var (
+	buildsTriggered metrics.Counter
+	buildsFailed    metrics.LabeledCounter
+)
+
+// Build metrics prometheus messages, these values must be initialized before
+// using them. See the example below in the "builds_failed" metric definition.
+const (
+	metricsDockerfileSyntaxError        = "dockerfile_syntax_error"
+	metricsDockerfileEmptyError         = "dockerfile_empty_error"
+	metricsCommandNotSupportedError     = "command_not_supported_error"
+	metricsErrorProcessingCommandsError = "error_processing_commands_error"
+	metricsBuildTargetNotReachableError = "build_target_not_reachable_error"
+	metricsMissingOnbuildArgumentsError = "missing_onbuild_arguments_error"
+	metricsUnknownInstructionError      = "unknown_instruction_error"
+	metricsBuildCanceled                = "build_canceled"
+)
+
+func init() {
+	buildMetrics := metrics.NewNamespace("builder", "", nil)
+
+	buildsTriggered = buildMetrics.NewCounter("builds_triggered", "Number of triggered image builds")
+	buildsFailed = buildMetrics.NewLabeledCounter("builds_failed", "Number of failed image builds", "reason")
+	for _, r := range []string{
+		metricsDockerfileSyntaxError,
+		metricsDockerfileEmptyError,
+		metricsCommandNotSupportedError,
+		metricsErrorProcessingCommandsError,
+		metricsBuildTargetNotReachableError,
+		metricsMissingOnbuildArgumentsError,
+		metricsUnknownInstructionError,
+		metricsBuildCanceled,
+	} {
+		buildsFailed.WithValues(r)
+	}
+
+	metrics.Register(buildMetrics)
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -731,13 +731,15 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 	// FIXME: this method never returns an error
 	info, _ := d.SystemInfo()
 
-	engineVersion.WithValues(
+	engineInfo.WithValues(
 		dockerversion.Version,
 		dockerversion.GitCommit,
 		info.Architecture,
 		info.Driver,
 		info.KernelVersion,
 		info.OperatingSystem,
+		info.OSType,
+		info.ID,
 	).Set(1)
 	engineCpus.Set(float64(info.NCPU))
 	engineMemory.Set(float64(info.MemTotal))

--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -6,7 +6,7 @@ var (
 	containerActions          metrics.LabeledTimer
 	imageActions              metrics.LabeledTimer
 	networkActions            metrics.LabeledTimer
-	engineVersion             metrics.LabeledGauge
+	engineInfo                metrics.LabeledGauge
 	engineCpus                metrics.Gauge
 	engineMemory              metrics.Gauge
 	healthChecksCounter       metrics.Counter
@@ -26,12 +26,14 @@ func init() {
 		containerActions.WithValues(a).Update(0)
 	}
 	networkActions = ns.NewLabeledTimer("network_actions", "The number of seconds it takes to process each network action", "action")
-	engineVersion = ns.NewLabeledGauge("engine", "The version and commit information for the engine process", metrics.Unit("info"),
+	engineInfo = ns.NewLabeledGauge("engine", "The information related to the engine and the OS it is running on", metrics.Unit("info"),
 		"version",
 		"commit",
 		"architecture",
-		"graph_driver", "kernel",
-		"os",
+		"graphdriver",
+		"kernel", "os",
+		"os_type",
+		"daemon_id", // ID is a randomly generated unique identifier (e.g. UUID4)
 	)
 	engineCpus = ns.NewGauge("engine_cpus", "The number of cpus that the host system of the engine has", metrics.Unit("cpus"))
 	engineMemory = ns.NewGauge("engine_memory", "The number of bytes of memory that the host system of the engine has", metrics.Bytes)


### PR DESCRIPTION
Signed-off-by: Roberto Gandolfo Hashioka <roberto.hashioka@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added/updated `prometheus` metrics:
 - `buildsTriggered`: type `Counter `
 - `buildsFailed`: type `LabeledCounter `
     - `dockerfile_syntax`
      - `dockerfile_empty`
      - `command_not_supported`
       - `error_processing_commands`
       - `build_target_not_reachable`
       - `missing_onbuild_arguments` 
       - `unknown_instruction`
       - `build_canceled`
 - `engineInfo`: type `LabeledGauge`

**- How I did it**

Extended the existing `prometheus` metrics using the `docker/go-metrics` package

**- How to verify it**

```
$ make binary
```
replace `docker` binaries with the ones located in `bundles/17.06.0-dev/binary-daemon`

**- Description for the changelog**
- `Added build & engine info prometheus metrics`


**- A picture of a cute animal (not mandatory but encouraged)**
![boo-cute-dog-pomeranian-favim com-452643](https://cloud.githubusercontent.com/assets/4483394/25344487/24141b74-28c7-11e7-8962-6d9d028f4f00.jpg)

