### PR TITLE
LCOW: Add environment variable to enable the feature

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -267,6 +267,10 @@ func (cli *DaemonCli) start(opts daemonOptions) (err error) {
 		logrus.Fatalf("Error creating middlewares: %v", err)
 	}
 
+	if system.LCOWSupported() {
+		logrus.Warnln("LCOW support is enabled - this feature is incomplete")
+	}
+
 	d, err := daemon.NewDaemon(cli.Config, registryService, containerdRemote, pluginStore)
 	if err != nil {
 		return fmt.Errorf("Error starting daemon: %v", err)

--- a/distribution/config.go
+++ b/distribution/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/progress"
+	"github.com/docker/docker/pkg/system"
 	refstore "github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 	"github.com/docker/libtrust"
@@ -143,8 +144,8 @@ func (s *imageConfigStore) RootFSFromConfig(c []byte) (*image.RootFS, error) {
 	}
 
 	// fail immediately on Windows when downloading a non-Windows image
-	// and vice versa
-	if runtime.GOOS == "windows" && unmarshalledConfig.OS == "linux" {
+	// and vice versa. Exception on Windows if Linux Containers are enabled.
+	if runtime.GOOS == "windows" && unmarshalledConfig.OS == "linux" && !system.LCOWSupported() {
 		return nil, fmt.Errorf("image operating system %q cannot be used on this platform", unmarshalledConfig.OS)
 	} else if runtime.GOOS != "windows" && unmarshalledConfig.OS == "windows" {
 		return nil, fmt.Errorf("image operating system %q cannot be used on this platform", unmarshalledConfig.OS)

--- a/pkg/system/chtimes.go
+++ b/pkg/system/chtimes.go
@@ -2,25 +2,8 @@ package system
 
 import (
 	"os"
-	"syscall"
 	"time"
-	"unsafe"
 )
-
-var (
-	maxTime time.Time
-)
-
-func init() {
-	if unsafe.Sizeof(syscall.Timespec{}.Nsec) == 8 {
-		// This is a 64 bit timespec
-		// os.Chtimes limits time to the following
-		maxTime = time.Unix(0, 1<<63-1)
-	} else {
-		// This is a 32 bit timespec
-		maxTime = time.Unix(1<<31-1, 0)
-	}
-}
 
 // Chtimes changes the access time and modified time of a file at the given path
 func Chtimes(name string, atime time.Time, mtime time.Time) error {

--- a/pkg/system/init.go
+++ b/pkg/system/init.go
@@ -1,0 +1,37 @@
+package system
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+var (
+	// Used by chtimes
+	maxTime time.Time
+
+	// LCOWSupported determines if Linux Containers on Windows are supported.
+	// Note: This feature is in development (04/17) and enabled through an
+	// environment variable. At a future time, it will be enabled based
+	// on build number. @jhowardmsft
+	lcowSupported = false
+)
+
+func init() {
+	// chtimes initialization
+	if unsafe.Sizeof(syscall.Timespec{}.Nsec) == 8 {
+		// This is a 64 bit timespec
+		// os.Chtimes limits time to the following
+		maxTime = time.Unix(0, 1<<63-1)
+	} else {
+		// This is a 32 bit timespec
+		maxTime = time.Unix(1<<31-1, 0)
+	}
+
+	// LCOW initialization
+	if runtime.GOOS == "windows" && os.Getenv("LCOW_SUPPORTED") != "" {
+		lcowSupported = true
+	}
+}

--- a/pkg/system/lcow.go
+++ b/pkg/system/lcow.go
@@ -1,0 +1,6 @@
+package system
+
+// LCOWSupported returns true if Linux containers on Windows are supported.
+func LCOWSupported() bool {
+	return lcowSupported
+}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This adds the first bit of infrastructure to enable the development of the Linux Containers on Windows feature, as demo'd at the keynote of Dockercon 2017 last week. 

Obviously this feature requires platform support and the enabling environment variable should only currently be used by the Microsoft team developing it.
