### PR TITLE
image/spec: tags are 128 characters

### DIFF
--- a/image/spec/v1.1.md
+++ b/image/spec/v1.1.md
@@ -88,7 +88,7 @@ This specification uses the following terms:
         A tag serves to map a descriptive, user-given name to any single image
         ID. Tag values are limited to the set of characters
         <code>[a-zA-Z0-9_.-]</code>, except they may not start with a <code>.</code>
-        or <code>-</code> character. Tags are limited to 127 characters.
+        or <code>-</code> character. Tags are limited to 128 characters.
     </dd>
     <dt>
         Repository

--- a/image/spec/v1.2.md
+++ b/image/spec/v1.2.md
@@ -88,7 +88,7 @@ This specification uses the following terms:
         A tag serves to map a descriptive, user-given name to any single image
         ID. Tag values are limited to the set of characters
         <code>[a-zA-Z0-9_.-]</code>, except they may not start with a <code>.</code>
-        or <code>-</code> character. Tags are limited to 127 characters.
+        or <code>-</code> character. Tags are limited to 128 characters.
     </dd>
     <dt>
         Repository


### PR DESCRIPTION
Mostly, they always have been. Most regular expressions were implemented
as `[\w][\w.-]{0,127]`, which actually allows 128 characters, since we
start with a character in the first expression.

This "fact" has been backported to the existing specifications where
length is mentioned. For the most part, no ill-effects should come of
this, unless someone has optimized to hold the length of a tag in a 7
bit integer.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

This was reported in https://github.com/docker/distribution/issues/2248.