### PR TITLE
Fix prefix-matching for service ps

### DIFF
--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1654,17 +1654,23 @@ func (s *DockerSwarmSuite) TestSwarmNetworkCreateDup(c *check.C) {
 func (s *DockerSwarmSuite) TestSwarmServicePsMultipleServiceIDs(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
-	name1 := "top1"
-	out, err := d.Cmd("service", "create", "--detach=true", "--name", name1, "--replicas=3", "busybox", "top")
+	name1 := "top"
+	out, err := d.Cmd("service", "create", "--detach=true", "--name", name1, "--replicas=2", "busybox", "top")
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
 	id1 := strings.TrimSpace(out)
 
 	name2 := "top2"
-	out, err = d.Cmd("service", "create", "--detach=true", "--name", name2, "--replicas=3", "busybox", "top")
+	out, err = d.Cmd("service", "create", "--detach=true", "--name", name2, "--replicas=2", "busybox", "top")
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
 	id2 := strings.TrimSpace(out)
+
+	name3 := id1
+	out, err = d.Cmd("service", "create", "--detach=true", "--name", name3, "--replicas=2", "busybox", "top")
+	c.Assert(err, checker.IsNil)
+	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
+	id3 := strings.TrimSpace(out)
 
 	// make sure task has been deployed.
 	waitAndAssert(c, defaultReconciliationTimeout, d.CheckActiveContainerCount, checker.Equals, 6)
@@ -1673,52 +1679,51 @@ func (s *DockerSwarmSuite) TestSwarmServicePsMultipleServiceIDs(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, name1+".1")
 	c.Assert(out, checker.Contains, name1+".2")
-	c.Assert(out, checker.Contains, name1+".3")
 	c.Assert(out, checker.Not(checker.Contains), name2+".1")
 	c.Assert(out, checker.Not(checker.Contains), name2+".2")
-	c.Assert(out, checker.Not(checker.Contains), name2+".3")
 
 	out, err = d.Cmd("service", "ps", name1, name2)
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, name1+".1")
 	c.Assert(out, checker.Contains, name1+".2")
-	c.Assert(out, checker.Contains, name1+".3")
 	c.Assert(out, checker.Contains, name2+".1")
 	c.Assert(out, checker.Contains, name2+".2")
-	c.Assert(out, checker.Contains, name2+".3")
-
-	// Name Prefix
-	out, err = d.Cmd("service", "ps", "to")
-	c.Assert(err, checker.IsNil)
-	c.Assert(out, checker.Contains, name1+".1")
-	c.Assert(out, checker.Contains, name1+".2")
-	c.Assert(out, checker.Contains, name1+".3")
-	c.Assert(out, checker.Contains, name2+".1")
-	c.Assert(out, checker.Contains, name2+".2")
-	c.Assert(out, checker.Contains, name2+".3")
 
 	// Name Prefix (no hit)
-	out, err = d.Cmd("service", "ps", "noname")
+	out, err = d.Cmd("service", "ps", name1, "nosuchservice")
 	c.Assert(err, checker.NotNil)
-	c.Assert(out, checker.Contains, "no such services: noname")
+	c.Assert(out, checker.Contains, name1+".1")
+	c.Assert(out, checker.Contains, name1+".2")
+	c.Assert(out, checker.Contains, "no such service: nosuchservice")
 
+	// service ps using "service 1's" ID should not return "service 2", nor "service 3" (which uses "service 1"'s ID as name)
 	out, err = d.Cmd("service", "ps", id1)
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, name1+".1")
 	c.Assert(out, checker.Contains, name1+".2")
-	c.Assert(out, checker.Contains, name1+".3")
 	c.Assert(out, checker.Not(checker.Contains), name2+".1")
 	c.Assert(out, checker.Not(checker.Contains), name2+".2")
-	c.Assert(out, checker.Not(checker.Contains), name2+".3")
+	c.Assert(out, checker.Not(checker.Contains), name3+".1")
+	c.Assert(out, checker.Not(checker.Contains), name3+".2")
 
-	out, err = d.Cmd("service", "ps", id1, id2)
+	out, err = d.Cmd("service", "ps", id1, id2, id3[:6])
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, name1+".1")
 	c.Assert(out, checker.Contains, name1+".2")
-	c.Assert(out, checker.Contains, name1+".3")
 	c.Assert(out, checker.Contains, name2+".1")
 	c.Assert(out, checker.Contains, name2+".2")
-	c.Assert(out, checker.Contains, name2+".3")
+	c.Assert(out, checker.Contains, name3+".1")
+	c.Assert(out, checker.Contains, name3+".2")
+
+	// filter by partial ID for service 1 and 3
+	out, err = d.Cmd("service", "ps", id1[:6], id3[:6])
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, name1+".1")
+	c.Assert(out, checker.Contains, name1+".2")
+	c.Assert(out, checker.Not(checker.Contains), name2+".1")
+	c.Assert(out, checker.Not(checker.Contains), name2+".2")
+	c.Assert(out, checker.Contains, name3+".1")
+	c.Assert(out, checker.Contains, name3+".2")
 }
 
 func (s *DockerSwarmSuite) TestSwarmPublishDuplicatePorts(c *check.C) {


### PR DESCRIPTION
The docker CLI matches objects either by ID _prefix_
or a full name match, but not partial name matches.

The correct order of resolution is;

- Full ID match (a name should not be able to mask an ID)
- Full name
- ID-prefix

This patch changes the way services are matched.

Also change to use the first matching service, if there's a full match (by ID or Name) instead of continue looking for other possible matches.

Error handling changed;

- Do not error early if multiple services were requested and one or more services were not found. Print the services that were not found after printing those that _were_ found instead
- Print an error if ID-prefix matching is ambiguous

fixes https://github.com/moby/moby/issues/32556


With this patch applied;

Given these services

```
$ docker service ls
ID                  NAME                      MODE                REPLICAS            IMAGE               PORTS
71yo8k34uxd6        db                        replicated          1/1                 busybox:latest
wt6z677fhoou        db2                       replicated          1/1                 busybox:latest
oygr4njb0qxl        71yo8k34uxd6              replicated          1/1                 busybox:latest
l6ps3579zt0u        hopeful_feynman           replicated          1/1                 busybox:latest
l9ehdvyxkyiy        xenodochial_stonebraker   replicated          1/1                 busybox:latest
```

Match by name no longer does a "prefix" match

```bash
$ docker service ps db
ID                  NAME                IMAGE               NODE                DESIRED STATE       CURRENT STATE           ERROR                              PORTS
ygrefa0tph0c        db.1                busybox:latest      9c8f9fbf54e8        Running             Running 2 minutes ago
```

Full name match "trumps" partial ID match;

```bash
$ docker service ps 71yo8k34uxd6
ID                  NAME                 IMAGE               NODE                DESIRED STATE       CURRENT STATE           ERROR                              PORTS
lgq4j24xl54m        71yo8k34uxd6.1       busybox:latest      9c8f9fbf54e8        Running             Running 2 minutes ago
```

Ambiguous ID-prefix produces an error

```bash
$ docker service ps l
multiple services found with provided prefix: l

$ docker service ps l6
ID                  NAME                    IMAGE               NODE                DESIRED STATE       CURRENT STATE            ERROR                              PORTS
ls2ml2jkxlve        hopeful_feynman.1       busybox:latest      9c8f9fbf54e8        Running             Running 25 seconds ago
```

Don't error out on first non-existing service, but print errors at the end

```bash
$ docker service ps db foo bar
ID                  NAME                IMAGE               NODE                DESIRED STATE       CURRENT STATE           ERROR               PORTS
4b3jlca22dho        db.1                busybox:latest      9c8f9fbf54e8        Running             Running 2 minutes ago
no such service: foo
no such service: bar
```
