### PR TITLE
Move service runtime filter to server

### DIFF
--- a/cli/command/service/list.go
+++ b/cli/command/service/list.go
@@ -46,7 +46,6 @@ func runList(dockerCli *command.DockerCli, opts listOptions) error {
 	client := dockerCli.Client()
 
 	serviceFilters := opts.filter.Value()
-	serviceFilters.Add("runtime", string(swarm.RuntimeContainer))
 	services, err := client.ServiceList(ctx, types.ServiceListOptions{Filters: serviceFilters})
 	if err != nil {
 		return err

--- a/cli/command/service/ps.go
+++ b/cli/command/service/ps.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/cli/command/formatter"
@@ -59,11 +58,8 @@ func runPS(dockerCli *command.DockerCli, opts psOptions) error {
 	serviceIDFilter := filters.NewArgs()
 	serviceNameFilter := filters.NewArgs()
 	for _, service := range opts.services {
-		// default to container runtime
 		serviceIDFilter.Add("id", service)
-		serviceIDFilter.Add("runtime", string(swarmtypes.RuntimeContainer))
 		serviceNameFilter.Add("name", service)
-		serviceNameFilter.Add("runtime", string(swarmtypes.RuntimeContainer))
 	}
 	serviceByIDList, err := client.ServiceList(ctx, types.ServiceListOptions{Filters: serviceIDFilter})
 	if err != nil {

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -54,7 +54,10 @@ func (c *Cluster) GetServices(options apitypes.ServiceListOptions) ([]types.Serv
 		NamePrefixes: options.Filters.Get("name"),
 		IDPrefixes:   options.Filters.Get("id"),
 		Labels:       runconfigopts.ConvertKVStringsToMap(options.Filters.Get("label")),
-		Runtimes:     options.Filters.Get("runtime"),
+		// (ehazlett): hardcode runtime for now. eventually we will
+		// be able to filter for the desired runtimes once more
+		// are supported.
+		Runtimes: []string{string(types.RuntimeContainer)},
 	}
 
 	ctx, cancel := c.getRequestContext()


### PR DESCRIPTION
This moves the runtime filter to the server.  

The current behavior breaks 17.04 clients talking to a < 17.04 daemon as the "runtime" filter is not supported.  This moves it to the server so the downgrade from the client works.