### PR TITLE
LCOW: Adds platform to the layer store

### DIFF
--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -26,6 +26,7 @@ type mockLayer struct {
 	diffID    layer.DiffID
 	chainID   layer.ChainID
 	parent    layer.Layer
+	platform  layer.Platform
 }
 
 func (ml *mockLayer) TarStream() (io.ReadCloser, error) {
@@ -54,6 +55,10 @@ func (ml *mockLayer) Size() (size int64, err error) {
 
 func (ml *mockLayer) DiffSize() (size int64, err error) {
 	return 0, nil
+}
+
+func (ml *mockLayer) Platform() layer.Platform {
+	return ml.platform
 }
 
 func (ml *mockLayer) Metadata() (map[string]string, error) {

--- a/layer/empty.go
+++ b/layer/empty.go
@@ -54,3 +54,7 @@ func (el *emptyLayer) DiffSize() (size int64, err error) {
 func (el *emptyLayer) Metadata() (map[string]string, error) {
 	return make(map[string]string), nil
 }
+
+func (el *emptyLayer) Platform() Platform {
+	return ""
+}

--- a/layer/filestore_unix.go
+++ b/layer/filestore_unix.go
@@ -1,0 +1,13 @@
+// +build !windows
+
+package layer
+
+// SetPlatform writes the "platform" file to the layer filestore
+func (fm *fileMetadataTransaction) SetPlatform(platform Platform) error {
+	return nil
+}
+
+// GetPlatform reads the "platform" file from the layer filestore
+func (fms *fileMetadataStore) GetPlatform(layer ChainID) (Platform, error) {
+	return "", nil
+}

--- a/layer/filestore_windows.go
+++ b/layer/filestore_windows.go
@@ -1,0 +1,35 @@
+package layer
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+// SetPlatform writes the "platform" file to the layer filestore
+func (fm *fileMetadataTransaction) SetPlatform(platform Platform) error {
+	if platform == "" {
+		return nil
+	}
+	return fm.ws.WriteFile("platform", []byte(platform), 0644)
+}
+
+// GetPlatform reads the "platform" file from the layer filestore
+func (fms *fileMetadataStore) GetPlatform(layer ChainID) (Platform, error) {
+	contentBytes, err := ioutil.ReadFile(fms.getLayerFilename(layer, "platform"))
+	if err != nil {
+		// For backwards compatibility, the platform file may not exist. Default to "windows" if missing.
+		if os.IsNotExist(err) {
+			return "windows", nil
+		}
+		return "", err
+	}
+	content := strings.TrimSpace(string(contentBytes))
+
+	if content != "windows" && content != "linux" {
+		return "", fmt.Errorf("invalid platform value: %s", content)
+	}
+
+	return Platform(content), nil
+}

--- a/layer/layer.go
+++ b/layer/layer.go
@@ -64,6 +64,14 @@ func (id ChainID) String() string {
 	return string(id)
 }
 
+// Platform is the platform of a layer
+type Platform string
+
+// String returns a string rendition of layers target platform
+func (id Platform) String() string {
+	return string(id)
+}
+
 // DiffID is the hash of an individual layer tar.
 type DiffID digest.Digest
 
@@ -98,6 +106,9 @@ type Layer interface {
 
 	// Parent returns the next layer in the layer chain.
 	Parent() Layer
+
+	// Platform returns the platform of the layer
+	Platform() Platform
 
 	// Size returns the size of the entire layer chain. The size
 	// is calculated from the total size of all files in the layers.
@@ -208,6 +219,7 @@ type MetadataTransaction interface {
 	SetDiffID(DiffID) error
 	SetCacheID(string) error
 	SetDescriptor(distribution.Descriptor) error
+	SetPlatform(Platform) error
 	TarSplitWriter(compressInput bool) (io.WriteCloser, error)
 
 	Commit(ChainID) error
@@ -228,6 +240,7 @@ type MetadataStore interface {
 	GetDiffID(ChainID) (DiffID, error)
 	GetCacheID(ChainID) (string, error)
 	GetDescriptor(ChainID) (distribution.Descriptor, error)
+	GetPlatform(ChainID) (Platform, error)
 	TarSplitReader(ChainID) (io.ReadCloser, error)
 
 	SetMountID(string, string) error

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -145,6 +145,11 @@ func (ls *layerStore) loadLayer(layer ChainID) (*roLayer, error) {
 		return nil, fmt.Errorf("failed to get descriptor for %s: %s", layer, err)
 	}
 
+	platform, err := ls.store.GetPlatform(layer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get platform for %s: %s", layer, err)
+	}
+
 	cl = &roLayer{
 		chainID:    layer,
 		diffID:     diff,
@@ -153,6 +158,7 @@ func (ls *layerStore) loadLayer(layer ChainID) (*roLayer, error) {
 		layerStore: ls,
 		references: map[Layer]struct{}{},
 		descriptor: descriptor,
+		platform:   platform,
 	}
 
 	if parent != "" {

--- a/layer/ro_layer.go
+++ b/layer/ro_layer.go
@@ -16,6 +16,7 @@ type roLayer struct {
 	size       int64
 	layerStore *layerStore
 	descriptor distribution.Descriptor
+	platform   Platform
 
 	referenceCount int
 	references     map[Layer]struct{}
@@ -141,6 +142,9 @@ func storeLayer(tx MetadataTransaction, layer *roLayer) error {
 		if err := tx.SetParent(layer.parent.chainID); err != nil {
 			return err
 		}
+	}
+	if err := tx.SetPlatform(layer.platform); err != nil {
+		return err
 	}
 
 	return nil

--- a/layer/ro_layer_unix.go
+++ b/layer/ro_layer_unix.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package layer
+
+func (rl *roLayer) Platform() Platform {
+	return ""
+}

--- a/layer/ro_layer_windows.go
+++ b/layer/ro_layer_windows.go
@@ -7,3 +7,10 @@ var _ distribution.Describable = &roLayer{}
 func (rl *roLayer) Descriptor() distribution.Descriptor {
 	return rl.descriptor
 }
+
+func (rl *roLayer) Platform() Platform {
+	if rl.platform == "" {
+		return "windows"
+	}
+	return rl.platform
+}

--- a/migrate/v1/migratev1_test.go
+++ b/migrate/v1/migratev1_test.go
@@ -433,6 +433,10 @@ func (l *mockLayer) DiffSize() (int64, error) {
 	return 0, nil
 }
 
+func (l *mockLayer) Platform() layer.Platform {
+	return ""
+}
+
 func (l *mockLayer) Metadata() (map[string]string, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@stevvooe @dmcgowan PTAL.

This PR is a building-block for adding support for Linux containers on Windows (LCOW). It adds `platform` to the layer filestore and the RO layer, along with appropriate getters and setters. The overall flow follows the same pattern as for how the `cache-id`, `diff`, `parent` etc are stored.

On Unix platforms, the getters/setters are effectively no-ops

For backwards compatibility on Windows, if the platform is not known, it defaults to `windows`.

