### PR TITLE
LCOW: Remove CommonContainer - just Container

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -58,9 +58,8 @@ var (
 	errInvalidNetwork  = fmt.Errorf("invalid network settings while building port map info")
 )
 
-// CommonContainer holds the fields for a container which are
-// applicable across all platforms supported by the daemon.
-type CommonContainer struct {
+// Container holds the structure defining a container object.
+type Container struct {
 	StreamConfig *stream.Config
 	// embed for Container to support states directly.
 	*State          `json:"State"` // Needed for Engine API version <= 1.11
@@ -94,21 +93,31 @@ type CommonContainer struct {
 	LogCopier      *logger.Copier `json:"-"`
 	restartManager restartmanager.RestartManager
 	attachContext  *attachContext
+
+	// Fields here are specific to Unix platforms
+	AppArmorProfile string
+	HostnamePath    string
+	HostsPath       string
+	ShmPath         string
+	ResolvConfPath  string
+	SeccompProfile  string
+	NoNewPrivileges bool
+
+	// Fields here are specific to Windows
+	NetworkSharedContainerID string
 }
 
 // NewBaseContainer creates a new container with its
 // basic configuration.
 func NewBaseContainer(id, root string) *Container {
 	return &Container{
-		CommonContainer: CommonContainer{
-			ID:            id,
-			State:         NewState(),
-			ExecCommands:  exec.NewStore(),
-			Root:          root,
-			MountPoints:   make(map[string]*volume.MountPoint),
-			StreamConfig:  stream.NewConfig(),
-			attachContext: &attachContext{},
-		},
+		ID:            id,
+		State:         NewState(),
+		ExecCommands:  exec.NewStore(),
+		Root:          root,
+		MountPoints:   make(map[string]*volume.MountPoint),
+		StreamConfig:  stream.NewConfig(),
+		attachContext: &attachContext{},
 	}
 }
 

--- a/container/container_unit_test.go
+++ b/container/container_unit_test.go
@@ -9,9 +9,7 @@ import (
 
 func TestContainerStopSignal(t *testing.T) {
 	c := &Container{
-		CommonContainer: CommonContainer{
-			Config: &container.Config{},
-		},
+		Config: &container.Config{},
 	}
 
 	def, err := signal.ParseSignal(signal.DefaultStopSignal)
@@ -25,9 +23,7 @@ func TestContainerStopSignal(t *testing.T) {
 	}
 
 	c = &Container{
-		CommonContainer: CommonContainer{
-			Config: &container.Config{StopSignal: "SIGKILL"},
-		},
+		Config: &container.Config{StopSignal: "SIGKILL"},
 	}
 	s = c.StopSignal()
 	if s != 9 {
@@ -37,9 +33,7 @@ func TestContainerStopSignal(t *testing.T) {
 
 func TestContainerStopTimeout(t *testing.T) {
 	c := &Container{
-		CommonContainer: CommonContainer{
-			Config: &container.Config{},
-		},
+		Config: &container.Config{},
 	}
 
 	s := c.StopTimeout()
@@ -49,9 +43,7 @@ func TestContainerStopTimeout(t *testing.T) {
 
 	stopTimeout := 15
 	c = &Container{
-		CommonContainer: CommonContainer{
-			Config: &container.Config{StopTimeout: &stopTimeout},
-		},
+		Config: &container.Config{StopTimeout: &stopTimeout},
 	}
 	s = c.StopSignal()
 	if s != 15 {

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -25,21 +25,6 @@ const (
 	containerSecretMountPath = "/run/secrets"
 )
 
-// Container holds the fields specific to unixen implementations.
-// See CommonContainer for standard fields common to all containers.
-type Container struct {
-	CommonContainer
-
-	// Fields below here are platform specific.
-	AppArmorProfile string
-	HostnamePath    string
-	HostsPath       string
-	ShmPath         string
-	ResolvConfPath  string
-	SeccompProfile  string
-	NoNewPrivileges bool
-}
-
 // ExitStatus provides exit reasons for a container.
 type ExitStatus struct {
 	// The exit code with which the container exited.

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -10,15 +10,6 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 )
 
-// Container holds fields specific to the Windows implementation. See
-// CommonContainer for standard fields common to all containers.
-type Container struct {
-	CommonContainer
-
-	// Fields below here are platform specific.
-	NetworkSharedContainerID string
-}
-
 // ExitStatus provides exit reasons for a container.
 type ExitStatus struct {
 	// The exit code with which the container exited.

--- a/daemon/cluster/executor/container/health_test.go
+++ b/daemon/cluster/executor/container/health_test.go
@@ -38,14 +38,12 @@ func TestHealthStates(t *testing.T) {
 	}
 
 	c := &container.Container{
-		CommonContainer: container.CommonContainer{
-			ID:   "id",
-			Name: "name",
-			Config: &containertypes.Config{
-				Image: "image_name",
-				Labels: map[string]string{
-					"com.docker.swarm.task.id": "id",
-				},
+		ID:   "id",
+		Name: "name",
+		Config: &containertypes.Config{
+			Image: "image_name",
+			Labels: map[string]string{
+				"com.docker.swarm.task.id": "id",
 			},
 		},
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -26,38 +26,28 @@ import (
 
 func TestGetContainer(t *testing.T) {
 	c1 := &container.Container{
-		CommonContainer: container.CommonContainer{
-			ID:   "5a4ff6a163ad4533d22d69a2b8960bf7fafdcba06e72d2febdba229008b0bf57",
-			Name: "tender_bardeen",
-		},
+		ID:   "5a4ff6a163ad4533d22d69a2b8960bf7fafdcba06e72d2febdba229008b0bf57",
+		Name: "tender_bardeen",
 	}
 
 	c2 := &container.Container{
-		CommonContainer: container.CommonContainer{
-			ID:   "3cdbd1aa394fd68559fd1441d6eff2ab7c1e6363582c82febfaa8045df3bd8de",
-			Name: "drunk_hawking",
-		},
+		ID:   "3cdbd1aa394fd68559fd1441d6eff2ab7c1e6363582c82febfaa8045df3bd8de",
+		Name: "drunk_hawking",
 	}
 
 	c3 := &container.Container{
-		CommonContainer: container.CommonContainer{
-			ID:   "3cdbd1aa394fd68559fd1441d6eff2abfafdcba06e72d2febdba229008b0bf57",
-			Name: "3cdbd1aa",
-		},
+		ID:   "3cdbd1aa394fd68559fd1441d6eff2abfafdcba06e72d2febdba229008b0bf57",
+		Name: "3cdbd1aa",
 	}
 
 	c4 := &container.Container{
-		CommonContainer: container.CommonContainer{
-			ID:   "75fb0b800922abdbef2d27e60abcdfaf7fb0698b2a96d22d3354da361a6ff4a5",
-			Name: "5a4ff6a163ad4533d22d69a2b8960bf7fafdcba06e72d2febdba229008b0bf57",
-		},
+		ID:   "75fb0b800922abdbef2d27e60abcdfaf7fb0698b2a96d22d3354da361a6ff4a5",
+		Name: "5a4ff6a163ad4533d22d69a2b8960bf7fafdcba06e72d2febdba229008b0bf57",
 	}
 
 	c5 := &container.Container{
-		CommonContainer: container.CommonContainer{
-			ID:   "d22d69a2b8960bf7fafdcba06e72d2febdba960bf7fafdcba06e72d2f9008b060b",
-			Name: "d22d69a2b896",
-		},
+		ID:   "d22d69a2b8960bf7fafdcba06e72d2febdba960bf7fafdcba06e72d2f9008b060b",
+		Name: "d22d69a2b896",
 	}
 
 	store := container.NewMemoryStore()
@@ -183,7 +173,7 @@ func TestContainerInitDNS(t *testing.T) {
 "UpdateDns":false,"Volumes":{},"VolumesRW":{},"AppliedVolumesFrom":null}`
 
 	// Container struct only used to retrieve path to config file
-	container := &container.Container{CommonContainer: container.CommonContainer{Root: containerPath}}
+	container := &container.Container{Root: containerPath}
 	configPath, err := container.ConfigPath()
 	if err != nil {
 		t.Fatal(err)

--- a/daemon/delete_test.go
+++ b/daemon/delete_test.go
@@ -26,11 +26,9 @@ func newDaemonWithTmpRoot(t *testing.T) (*Daemon, func()) {
 
 func newContainerWithState(state *container.State) *container.Container {
 	return &container.Container{
-		CommonContainer: container.CommonContainer{
-			ID:     "test",
-			State:  state,
-			Config: &containertypes.Config{},
-		},
+		ID:     "test",
+		State:  state,
+		Config: &containertypes.Config{},
 	}
 
 }

--- a/daemon/events_test.go
+++ b/daemon/events_test.go
@@ -16,15 +16,13 @@ func TestLogContainerEventCopyLabels(t *testing.T) {
 	defer e.Evict(l)
 
 	container := &container.Container{
-		CommonContainer: container.CommonContainer{
-			ID:   "container_id",
-			Name: "container_name",
-			Config: &containertypes.Config{
-				Image: "image_name",
-				Labels: map[string]string{
-					"node": "1",
-					"os":   "alpine",
-				},
+		ID:   "container_id",
+		Name: "container_name",
+		Config: &containertypes.Config{
+			Image: "image_name",
+			Labels: map[string]string{
+				"node": "1",
+				"os":   "alpine",
 			},
 		},
 	}
@@ -49,14 +47,12 @@ func TestLogContainerEventWithAttributes(t *testing.T) {
 	defer e.Evict(l)
 
 	container := &container.Container{
-		CommonContainer: container.CommonContainer{
-			ID:   "container_id",
-			Name: "container_name",
-			Config: &containertypes.Config{
-				Labels: map[string]string{
-					"node": "1",
-					"os":   "alpine",
-				},
+		ID:   "container_id",
+		Name: "container_name",
+		Config: &containertypes.Config{
+			Labels: map[string]string{
+				"node": "1",
+				"os":   "alpine",
 			},
 		},
 	}

--- a/daemon/health_test.go
+++ b/daemon/health_test.go
@@ -19,17 +19,15 @@ func reset(c *container.Container) {
 
 func TestNoneHealthcheck(t *testing.T) {
 	c := &container.Container{
-		CommonContainer: container.CommonContainer{
-			ID:   "container_id",
-			Name: "container_name",
-			Config: &containertypes.Config{
-				Image: "image_name",
-				Healthcheck: &containertypes.HealthConfig{
-					Test: []string{"NONE"},
-				},
+		ID:   "container_id",
+		Name: "container_name",
+		Config: &containertypes.Config{
+			Image: "image_name",
+			Healthcheck: &containertypes.HealthConfig{
+				Test: []string{"NONE"},
 			},
-			State: &container.State{},
 		},
+		State: &container.State{},
 	}
 	daemon := &Daemon{}
 
@@ -58,12 +56,10 @@ func TestHealthStates(t *testing.T) {
 	}
 
 	c := &container.Container{
-		CommonContainer: container.CommonContainer{
-			ID:   "container_id",
-			Name: "container_name",
-			Config: &containertypes.Config{
-				Image: "image_name",
-			},
+		ID:   "container_id",
+		Name: "container_name",
+		Config: &containertypes.Config{
+			Image: "image_name",
 		},
 	}
 	daemon := &Daemon{


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Think I got everything - CI will tell for sure. For Linux Containers on Windows, I need to re-combine the `Container` structure into a single structure encompassing all fields. Hence this removes `CommonContainer` and updates the unit tests plus associated code in the daemon.

@thaJeztah PTAL.  @Gupta-ak FYI

Relates to https://github.com/moby/moby/pull/32793