### PR TITLE
Fix incorrect assumption in TestAPISwarmRaftQuorum

### DIFF
--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -350,9 +350,6 @@ func (s *DockerSwarmSuite) TestAPISwarmRaftQuorum(c *check.C) {
 
 	d3.Stop(c)
 
-	// make sure there is a leader
-	waitAndAssert(c, defaultReconciliationTimeout, d1.CheckLeader, checker.IsNil)
-
 	var service swarm.Service
 	simpleTestService(&service)
 	service.Spec.Name = "top2"


### PR DESCRIPTION
This test shuts down two out of three managers and then asserts that the swarm has a leader. A swarm that lost quorum won't necessarily have a leader, and in this case only has one because the old leader is still around. Soon SwarmKit will be changed so the leader gives up leadership when quorum is lost. This will avoid confusing situations, like read-only APIs succeeding, while ones that write to Raft hang.