### PR TITLE
cli: Correct command/image tests for testify

### DIFF
--- a/cli/command/image/history_test.go
+++ b/cli/command/image/history_test.go
@@ -102,7 +102,7 @@ func TestNewHistoryCommandSuccess(t *testing.T) {
 			testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, expected)
 		} else {
 			match, _ := regexp.MatchString(tc.outputRegex, actual)
-			assert.Equal(t, match, true)
+			assert.True(t, match)
 		}
 	}
 }

--- a/cli/command/image/import_test.go
+++ b/cli/command/image/import_test.go
@@ -69,7 +69,7 @@ func TestNewImportCommandSuccess(t *testing.T) {
 			name: "double",
 			args: []string{"-", "image:local"},
 			imageImportFunc: func(source types.ImageImportSource, ref string, options types.ImageImportOptions) (io.ReadCloser, error) {
-				assert.Equal(t, ref, "image:local")
+				assert.Equal(t, "image:local", ref)
 				return ioutil.NopCloser(strings.NewReader("")), nil
 			},
 		},
@@ -77,7 +77,7 @@ func TestNewImportCommandSuccess(t *testing.T) {
 			name: "message",
 			args: []string{"--message", "test message", "-"},
 			imageImportFunc: func(source types.ImageImportSource, ref string, options types.ImageImportOptions) (io.ReadCloser, error) {
-				assert.Equal(t, options.Message, "test message")
+				assert.Equal(t, "test message", options.Message)
 				return ioutil.NopCloser(strings.NewReader("")), nil
 			},
 		},
@@ -85,7 +85,7 @@ func TestNewImportCommandSuccess(t *testing.T) {
 			name: "change",
 			args: []string{"--change", "ENV DEBUG true", "-"},
 			imageImportFunc: func(source types.ImageImportSource, ref string, options types.ImageImportOptions) (io.ReadCloser, error) {
-				assert.Equal(t, options.Changes[0], "ENV DEBUG true")
+				assert.Equal(t, "ENV DEBUG true", options.Changes[0])
 				return ioutil.NopCloser(strings.NewReader("")), nil
 			},
 		},

--- a/cli/command/image/inspect_test.go
+++ b/cli/command/image/inspect_test.go
@@ -48,7 +48,7 @@ func TestNewInspectCommandSuccess(t *testing.T) {
 			imageCount: 1,
 			imageInspectFunc: func(image string) (types.ImageInspect, []byte, error) {
 				imageInspectInvocationCount++
-				assert.Equal(t, image, "image")
+				assert.Equal(t, "image", image)
 				return types.ImageInspect{}, nil, nil
 			},
 		},
@@ -68,9 +68,9 @@ func TestNewInspectCommandSuccess(t *testing.T) {
 			imageInspectFunc: func(image string) (types.ImageInspect, []byte, error) {
 				imageInspectInvocationCount++
 				if imageInspectInvocationCount == 1 {
-					assert.Equal(t, image, "image1")
+					assert.Equal(t, "image1", image)
 				} else {
-					assert.Equal(t, image, "image2")
+					assert.Equal(t, "image2", image)
 				}
 				return types.ImageInspect{}, nil, nil
 			},
@@ -87,6 +87,6 @@ func TestNewInspectCommandSuccess(t *testing.T) {
 		actual := buf.String()
 		expected := string(golden.Get(t, []byte(actual), fmt.Sprintf("inspect-command-success.%s.golden", tc.name))[:])
 		testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, expected)
-		assert.Equal(t, tc.imageCount, imageInspectInvocationCount)
+		assert.Equal(t, imageInspectInvocationCount, tc.imageCount)
 	}
 }

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -39,7 +39,7 @@ func TestNewImagesCommandErrors(t *testing.T) {
 		cmd := NewImagesCommand(test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc}, new(bytes.Buffer)))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
-		assert.Error(t, cmd.Execute(), tc.expectedError)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
 
@@ -66,7 +66,7 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 			name: "match-name",
 			args: []string{"image"},
 			imageListFunc: func(options types.ImageListOptions) ([]types.ImageSummary, error) {
-				assert.Equal(t, options.Filters.Get("reference")[0], "image")
+				assert.Equal(t, "image", options.Filters.Get("reference")[0])
 				return []types.ImageSummary{{}}, nil
 			},
 		},
@@ -74,7 +74,7 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 			name: "filters",
 			args: []string{"--filter", "name=value"},
 			imageListFunc: func(options types.ImageListOptions) ([]types.ImageSummary, error) {
-				assert.Equal(t, options.Filters.Get("name")[0], "value")
+				assert.Equal(t, "value", options.Filters.Get("name")[0])
 				return []types.ImageSummary{{}}, nil
 			},
 		},
@@ -96,7 +96,7 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 
 func TestNewListCommandAlias(t *testing.T) {
 	cmd := newListCommand(test.NewFakeCli(&fakeClient{}, new(bytes.Buffer)))
-	assert.Equal(t, cmd.HasAlias("images"), true)
-	assert.Equal(t, cmd.HasAlias("list"), true)
-	assert.Equal(t, cmd.HasAlias("other"), false)
+	assert.True(t, cmd.HasAlias("images"))
+	assert.True(t, cmd.HasAlias("list"))
+	assert.False(t, cmd.HasAlias("other"))
 }

--- a/cli/command/image/load_test.go
+++ b/cli/command/image/load_test.go
@@ -48,7 +48,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 		cmd := NewLoadCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
-		assert.Error(t, cmd.Execute(), tc.expectedError)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
 
@@ -58,8 +58,7 @@ func TestNewLoadCommandInvalidInput(t *testing.T) {
 	cmd.SetOutput(ioutil.Discard)
 	cmd.SetArgs([]string{"--input", "*"})
 	err := cmd.Execute()
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), expectedError)
+	testutil.ErrorContains(t, err, expectedError)
 }
 
 func TestNewLoadCommandSuccess(t *testing.T) {

--- a/cli/command/image/prune_test.go
+++ b/cli/command/image/prune_test.go
@@ -43,7 +43,7 @@ func TestNewPruneCommandErrors(t *testing.T) {
 		}, buf))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
-		assert.Error(t, cmd.Execute(), tc.expectedError)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
 
@@ -57,7 +57,7 @@ func TestNewPruneCommandSuccess(t *testing.T) {
 			name: "all",
 			args: []string{"--all"},
 			imagesPruneFunc: func(pruneFilter filters.Args) (types.ImagesPruneReport, error) {
-				assert.Equal(t, pruneFilter.Get("dangling")[0], "false")
+				assert.Equal(t, "false", pruneFilter.Get("dangling")[0])
 				return types.ImagesPruneReport{}, nil
 			},
 		},
@@ -65,7 +65,7 @@ func TestNewPruneCommandSuccess(t *testing.T) {
 			name: "force-deleted",
 			args: []string{"--force"},
 			imagesPruneFunc: func(pruneFilter filters.Args) (types.ImagesPruneReport, error) {
-				assert.Equal(t, pruneFilter.Get("dangling")[0], "true")
+				assert.Equal(t, "true", pruneFilter.Get("dangling")[0])
 				return types.ImagesPruneReport{
 					ImagesDeleted:  []types.ImageDeleteResponseItem{{Deleted: "image1"}},
 					SpaceReclaimed: 1,
@@ -76,7 +76,7 @@ func TestNewPruneCommandSuccess(t *testing.T) {
 			name: "force-untagged",
 			args: []string{"--force"},
 			imagesPruneFunc: func(pruneFilter filters.Args) (types.ImagesPruneReport, error) {
-				assert.Equal(t, pruneFilter.Get("dangling")[0], "true")
+				assert.Equal(t, "true", pruneFilter.Get("dangling")[0])
 				return types.ImagesPruneReport{
 					ImagesDeleted:  []types.ImageDeleteResponseItem{{Untagged: "image1"}},
 					SpaceReclaimed: 2,

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -51,7 +51,7 @@ func TestNewPullCommandErrors(t *testing.T) {
 		cmd := NewPullCommand(test.NewFakeCli(&fakeClient{}, buf))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
-		assert.Error(t, cmd.Execute(), tc.expectedError)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
 

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/cli/internal/test"
+	"github.com/docker/docker/pkg/testutil"
 	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -53,7 +54,7 @@ func TestNewPushCommandErrors(t *testing.T) {
 		cmd := NewPushCommand(test.NewFakeCli(&fakeClient{imagePushFunc: tc.imagePushFunc}, buf))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
-		assert.Error(t, cmd.Execute(), tc.expectedError)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
 

--- a/cli/command/image/remove_test.go
+++ b/cli/command/image/remove_test.go
@@ -16,9 +16,9 @@ import (
 
 func TestNewRemoveCommandAlias(t *testing.T) {
 	cmd := newRemoveCommand(test.NewFakeCli(&fakeClient{}, new(bytes.Buffer)))
-	assert.Equal(t, cmd.HasAlias("rmi"), true)
-	assert.Equal(t, cmd.HasAlias("remove"), true)
-	assert.Equal(t, cmd.HasAlias("other"), false)
+	assert.True(t, cmd.HasAlias("rmi"))
+	assert.True(t, cmd.HasAlias("remove"))
+	assert.False(t, cmd.HasAlias("other"))
 }
 
 func TestNewRemoveCommandErrors(t *testing.T) {
@@ -37,8 +37,8 @@ func TestNewRemoveCommandErrors(t *testing.T) {
 			args:          []string{"arg1"},
 			expectedError: "error removing image",
 			imageRemoveFunc: func(image string, options types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error) {
-				assert.Equal(t, options.Force, false)
-				assert.Equal(t, options.PruneChildren, true)
+				assert.False(t, options.Force)
+				assert.True(t, options.PruneChildren)
 				return []types.ImageDeleteResponseItem{}, errors.Errorf("error removing image")
 			},
 		},
@@ -49,7 +49,7 @@ func TestNewRemoveCommandErrors(t *testing.T) {
 		}, new(bytes.Buffer)))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
-		assert.Error(t, cmd.Execute(), tc.expectedError)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
 
@@ -63,7 +63,7 @@ func TestNewRemoveCommandSuccess(t *testing.T) {
 			name: "Image Deleted",
 			args: []string{"image1"},
 			imageRemoveFunc: func(image string, options types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error) {
-				assert.Equal(t, image, "image1")
+				assert.Equal(t, "image1", image)
 				return []types.ImageDeleteResponseItem{{Deleted: image}}, nil
 			},
 		},
@@ -71,7 +71,7 @@ func TestNewRemoveCommandSuccess(t *testing.T) {
 			name: "Image Untagged",
 			args: []string{"image1"},
 			imageRemoveFunc: func(image string, options types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error) {
-				assert.Equal(t, image, "image1")
+				assert.Equal(t, "image1", image)
 				return []types.ImageDeleteResponseItem{{Untagged: image}}, nil
 			},
 		},

--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -9,8 +9,10 @@ import (
 	"testing"
 
 	"github.com/docker/docker/cli/internal/test"
+	"github.com/docker/docker/pkg/testutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewSaveCommandErrors(t *testing.T) {
@@ -48,7 +50,7 @@ func TestNewSaveCommandErrors(t *testing.T) {
 		cmd := NewSaveCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
-		assert.Error(t, cmd.Execute(), tc.expectedError)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
 
@@ -63,8 +65,8 @@ func TestNewSaveCommandSuccess(t *testing.T) {
 			args:       []string{"-o", "save_tmp_file", "arg1"},
 			isTerminal: true,
 			imageSaveFunc: func(images []string) (io.ReadCloser, error) {
-				assert.Equal(t, len(images), 1)
-				assert.Equal(t, images[0], "arg1")
+				require.Len(t, images, 1)
+				assert.Equal(t, "arg1", images[0])
 				return ioutil.NopCloser(strings.NewReader("")), nil
 			},
 			deferredFunc: func() {
@@ -75,9 +77,9 @@ func TestNewSaveCommandSuccess(t *testing.T) {
 			args:       []string{"arg1", "arg2"},
 			isTerminal: false,
 			imageSaveFunc: func(images []string) (io.ReadCloser, error) {
-				assert.Equal(t, len(images), 2)
-				assert.Equal(t, images[0], "arg1")
-				assert.Equal(t, images[1], "arg2")
+				require.Len(t, images, 2)
+				assert.Equal(t, "arg1", images[0])
+				assert.Equal(t, "arg2", images[1])
 				return ioutil.NopCloser(strings.NewReader("")), nil
 			},
 		},

--- a/cli/command/image/tag_test.go
+++ b/cli/command/image/tag_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/cli/internal/test"
+	"github.com/docker/docker/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,7 +22,7 @@ func TestCliNewTagCommandErrors(t *testing.T) {
 		cmd := NewTagCommand(test.NewFakeCli(&fakeClient{}, buf))
 		cmd.SetArgs(args)
 		cmd.SetOutput(ioutil.Discard)
-		assert.Error(t, cmd.Execute(), expectedError)
+		testutil.ErrorContains(t, cmd.Execute(), expectedError)
 	}
 }
 
@@ -30,8 +31,8 @@ func TestCliNewTagCommand(t *testing.T) {
 	cmd := NewTagCommand(
 		test.NewFakeCli(&fakeClient{
 			imageTagFunc: func(image string, ref string) error {
-				assert.Equal(t, image, "image1")
-				assert.Equal(t, ref, "image2")
+				assert.Equal(t, "image1", image)
+				assert.Equal(t, "image2", ref)
 				return nil
 			},
 		}, buf))
@@ -39,5 +40,5 @@ func TestCliNewTagCommand(t *testing.T) {
 	cmd.SetOutput(ioutil.Discard)
 	assert.NoError(t, cmd.Execute())
 	value, _ := cmd.Flags().GetBool("interspersed")
-	assert.Equal(t, value, false)
+	assert.False(t, value)
 }


### PR DESCRIPTION
These tests were caught in the crossfire of the transition to testify.
testify has a few subtle differences from the similar custom framework
it replaced:

- `Error` behaves differently
- `Equal` takes its arguments in a different order

This PR also takes the opportunity to use a few shorthands from testify,
such as `Len`, `True`, and `False`.