### PR TITLE
Remove go-winio fork - move to v0.3.9

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,8 +1,7 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm 388960b655244e76e24c75f48631564eaefade62
 github.com/Microsoft/hcsshim v0.5.13
-# TODO: get rid of this fork once PR https://github.com/Microsoft/go-winio/pull/43 is merged
-github.com/Microsoft/go-winio 7c7d6b461cb10872c1138a0d7f3acf9a41b5c353 https://github.com/dgageot/go-winio.git
+github.com/Microsoft/go-winio v0.3.9
 github.com/Sirupsen/logrus v0.11.0
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@vdemeester @thaJeztah Removes the fork of go-winio now the deadlock PR (#43) has been merged. Back to the mainline....