### PR TITLE
Remove service runtime filter in stack command

### DIFF
--- a/cli/command/stack/common.go
+++ b/cli/command/stack/common.go
@@ -18,9 +18,7 @@ func getStackFilter(namespace string) filters.Args {
 }
 
 func getServiceFilter(namespace string) filters.Args {
-	filter := getStackFilter(namespace)
-	filter.Add("runtime", string(swarm.RuntimeContainer))
-	return filter
+	return getStackFilter(namespace)
 }
 
 func getStackFilterFromOpt(namespace string, opt opts.FilterOpt) filters.Args {


### PR DESCRIPTION
This is a follow up to #32813 to remove the runtime filtering from the CLI.  This removes it from the stack command.