### PR TITLE
Make sure daemon is ready for containerd events

### DIFF
--- a/daemon/start.go
+++ b/daemon/start.go
@@ -96,6 +96,8 @@ func (daemon *Daemon) Start(container *container.Container) error {
 // between containers. The container is left waiting for a signal to
 // begin running.
 func (daemon *Daemon) containerStart(container *container.Container, checkpoint string, checkpointDir string, resetRestartManager bool) (err error) {
+	<-daemon.ready
+
 	start := time.Now()
 	container.Lock()
 	defer container.Unlock()


### PR DESCRIPTION
Currently there exists a race condition where when live-restore is
enabled and you have a container with `--restart=always` which dies
while the daemon is offline, when the daemon comes up and tries to
restart the container it may panic if the daemon networking has not yet
been initialized.

The easiest way to reproduce this is to insert a sleep before https://github.com/moby/moby/blob/4480e0417eb01caf29ae285880ec51a0180faf7f/daemon/daemon.go#L271
Then you can run this integration test:

```go
func (s *DockerDaemonSuite) TestDaemonLiveRestoreRestartWithFailedContainers(c *check.C) {
	testRequires(c, DaemonIsLinux, SameHostDaemon)

	s.d.StartWithBusybox(c, "--live-restore")
	out, err := s.d.Cmd("run", "-d", "--name=test", "--restart=always", "busybox", "top")
	c.Assert(err, checker.IsNil, check.Commentf(out))

	hostArgs := []string{"--host", s.d.Sock()}
	err = waitInspectWithArgs("test", "{{.State.Running}} {{.State.Restarting}}", "true false", 10*time.Second, hostArgs...)
	c.Assert(err, checker.IsNil)

	out, err = s.d.Cmd("inspect", "--format={{.State.Pid}}", "test")
	c.Assert(err, checker.IsNil, check.Commentf(out))
	pid := strings.TrimSpace(out)

	err = s.d.Kill()
	c.Assert(err, checker.IsNil)

	result := icmd.RunCommand("kill", "-9", pid)
	c.Assert(result.ExitCode, checker.Equals, 0, check.Commentf(result.Combined()))

	// start daemon again and wait for container to be in running state
	s.d.StartWithBusybox(c, "--live-restore")
	err = waitInspectWithArgs("test", "{{.State.Running}} {{.State.Restarting}}", "true false", 10*time.Second, hostArgs...)
	c.Assert(err, checker.IsNil)
}
```

I have not included the test in code because I could not reproduce
without inserting the sleep.

Fixes #32808 

![cute-animal-pictures-018](https://cloud.githubusercontent.com/assets/799078/25443502/088671b2-2a76-11e7-8a68-16a7c84bac34.jpg)
