### PR TITLE
Remove comments and unused structures in Windows resources

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -78,7 +78,6 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 	s.Root.Readonly = false // Windows does not support a read-only root filesystem
 
 	// In s.Windows.Resources
-	// @darrenstahlmsft implement these resources
 	cpuShares := uint16(c.HostConfig.CPUShares)
 	cpuPercent := uint8(c.HostConfig.CPUPercent)
 	cpuCount := uint64(c.HostConfig.CPUCount)
@@ -103,10 +102,6 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 		},
 		Memory: &specs.WindowsMemoryResources{
 			Limit: &memoryLimit,
-			//TODO Reservation: ...,
-		},
-		Network: &specs.WindowsNetworkResources{
-		//TODO Bandwidth: ...,
 		},
 		Storage: &specs.WindowsStorageResources{
 			Bps:  &c.HostConfig.IOMaximumBandwidth,


### PR DESCRIPTION
Signed-off-by: Darren Stahl <darst@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Removed a TODO that is finished.

Removed unused network structure, as it was implemented in HNS instead.