### PR TITLE
Enable inspect exec if container is pause/restarting/non-running

### DIFF
--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -196,9 +196,13 @@ func (daemon *Daemon) getInspectData(container *container.Container) (*types.Con
 // ContainerExecInspect returns low-level information about the exec
 // command. An error is returned if the exec cannot be found.
 func (daemon *Daemon) ContainerExecInspect(id string) (*backend.ExecInspect, error) {
-	e, err := daemon.getExecConfig(id)
-	if err != nil {
-		return nil, err
+	e := daemon.execCommands.Get(id)
+	if e == nil {
+		return nil, errExecNotFound(id)
+	}
+
+	if container := daemon.containers.Get(e.ContainerID); container == nil {
+		return nil, errExecNotFound(id)
 	}
 
 	pc := inspectExecProcessConfig(e)


### PR DESCRIPTION
if docker exec exit and at the same the the container is pause,
there could be a chance the `docker exec exit` will fail
```
$ docker exec -ti 388c7f47a06c sh
/ # exit
Error response from daemon: Container 388c7f47a06cce0856266ffd56a2ce2901689ca7a6b9cd741b37652418448f2b is paused, unpause the container before exec
```
To reproduce this error easilly, we can add a sleep in `containerPause`
```
--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -2,6 +2,7 @@ package daemon

 import (
        "fmt"
+       "time"

        "github.com/docker/docker/container"
 )
@@ -25,7 +26,7 @@ func (daemon *Daemon) ContainerPause(name string) error {
 func (daemon *Daemon) containerPause(container *container.Container) error {
        container.Lock()
        defer container.Unlock()
-
+       time.Sleep(time.Second * 5)
        // We cannot Pause the container which is not running
        if !container.Running {
                return errNotRunning{container.ID}
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

