### PR TITLE
Remove bash completion for `run|create --init-path`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1512,7 +1512,6 @@ _docker_container_run_and_create() {
 		--expose
 		--group-add
 		--hostname -h
-		--init-path
 		--ip
 		--ip6
 		--ipc
@@ -1636,7 +1635,7 @@ _docker_container_run_and_create() {
 			__docker_complete_capabilities_droppable
 			return
 			;;
-		--cidfile|--env-file|--init-path|--label-file)
+		--cidfile|--env-file|--label-file)
 			_filedir
 			return
 			;;


### PR DESCRIPTION
Amends #32470 for bash completion.
Ping @sdurrheimer for zsh completion