### PR TITLE
Clarify --env-file usage with names without values

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -393,17 +393,20 @@ If no `=` is provided and that variable is not exported in your local
 environment, the variable won't be set in the container.
 
 You can also load the environment variables from a file. This file should use
-the syntax `<variable>= value`, and `#` for comments.
+the syntax `<variable>=value` (which sets the variable to the given value) or
+`<variable>` (which takes the value from the local environment), and `#` for comments.
 
 ```bash
 $ cat env.list
 # This is a comment
 VAR1=value1
 VAR2=value2
+USER
 
 $ docker run --env-file env.list ubuntu env | grep VAR
 VAR1=value1
 VAR2=value2
+USER=denis
 ```
 
 ### Set metadata on container (-l, --label, --label-file)


### PR DESCRIPTION
This extends the documentation for `run --env-file` to also mention the possibility of specifying env var names without values (e.g. `USER`), which will let `docker run` take the value of the env var from the host environment.

This is supported and documented for `-e/--env`, but it also works for `--env-file`, which isn’t documented.