### PR TITLE
[docs] Add missing Name field to NetworkContainer object

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1193,6 +1193,8 @@ definitions:
   NetworkContainer:
     type: "object"
     properties:
+      Name:
+        type: "string"
       EndpointID:
         type: "string"
       MacAddress:


### PR DESCRIPTION
See https://github.com/spotify/docker-client/issues/730

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Saw that Docker API 1.28 returns a `Name` field in `NetworkContainer`.
So I updated the API docs.

**- How I did it**

```
/usr/local/opt/curl/bin/curl 'https://192.168.99.100:2376/networks/6f379c8a21f855a22fe0569d4b8a37bf633e19d8ce09bdeec4e0ff67460ad736' \
     --cert $DOCKER_CERT_PATH/cert.pem \
     --key $DOCKER_CERT_PATH/key.pem \
     --cacert $DOCKER_CERT_PATH/ca.pem -k | jq .

{
  "Name": "b3ec48a467e51b76-2e56018a86df5dea",
  "Id": "6f379c8a21f855a22fe0569d4b8a37bf633e19d8ce09bdeec4e0ff67460ad736",
  "Created": "2017-04-27T14:12:56.210363111Z",
  "Scope": "local",
  "Driver": "bridge",
  "EnableIPv6": false,
  "IPAM": {
    "Driver": "default",
    "Options": null,
    "Config": [
      {
        "Subnet": "172.21.0.0/16",
        "Gateway": "172.21.0.1"
      }
    ]
  },
  "Internal": false,
  "Attachable": false,
  "Containers": {
    "3c81c7719587ed3aa7d3ef7a8639c20bf2d61faf67d2363daffcf3c591900b2c": {
      "Name": "b3ec48a467e51b76-999904893e18034f",
      "EndpointID": "e3011415c9791bca387cee1c10c8e5ef1f5f16891007310ec8c53afbeacb77f2",
      "MacAddress": "02:42:ac:15:00:02",
      "IPv4Address": "172.21.0.2/16",
      "IPv6Address": ""
    }
  },
  "Options": {},
  "Labels": {}
}
```

**- How to verify it**

See above.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[docs] Add missing Name field to NetworkContainer object

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://cloud.githubusercontent.com/assets/480621/25488641/8753dfd8-2b35-11e7-9938-c1a54a667ef4.png)
