### PR TITLE
Add missing bash completion for `docker attach`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4478,6 +4478,7 @@ _docker() {
 	)
 
 	local legacy_commands=(
+		attach
 		commit
 		cp
 		create


### PR DESCRIPTION
`attach` was missing in the completed commands after `docker <tab>`.