### PR TITLE
Don't error with empty group

### DIFF
--- a/pkg/listeners/listeners_solaris.go
+++ b/pkg/listeners/listeners_solaris.go
@@ -22,10 +22,12 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) (ls []net.List
 	case "unix":
 		gid, err := lookupGID(socketGroup)
 		if err != nil {
-			if socketGroup != defaultSocketGroup {
-				return nil, err
+			if socketGroup != "" {
+				if socketGroup != defaultSocketGroup {
+					return nil, err
+				}
+				logrus.Warnf("could not change group %s to %s: %v", addr, defaultSocketGroup, err)
 			}
-			logrus.Warnf("could not change group %s to %s: %v", addr, defaultSocketGroup, err)
 			gid = os.Getgid()
 		}
 		l, err := sockets.NewUnixSocket(addr, gid)

--- a/pkg/listeners/listeners_unix.go
+++ b/pkg/listeners/listeners_unix.go
@@ -35,10 +35,12 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) ([]net.Listene
 	case "unix":
 		gid, err := lookupGID(socketGroup)
 		if err != nil {
-			if socketGroup != defaultSocketGroup {
-				return nil, err
+			if socketGroup != "" {
+				if socketGroup != defaultSocketGroup {
+					return nil, err
+				}
+				logrus.Warnf("could not change group %s to %s: %v", addr, defaultSocketGroup, err)
 			}
-			logrus.Warnf("could not change group %s to %s: %v", addr, defaultSocketGroup, err)
 			gid = os.Getgid()
 		}
 		l, err := sockets.NewUnixSocket(addr, gid)


### PR DESCRIPTION
Don't error if no group is specified, as this was the prior API.  Also
don't return a docker specific error message as this is in `/pkg` and
used by other projects.  Just set the default group for the current
user/group consuming the package.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>