### PR TITLE
Change GetRemoteAddress to return an IP list

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -280,27 +280,29 @@ func (c *Cluster) GetDataPathAddress() string {
 	return ""
 }
 
-// GetRemoteAddress returns a known advertise address of a remote manager if
+// GetRemoteAddressList returns the advertise address for each of the remote managers if
 // available.
-// todo: change to array/connect with info
-func (c *Cluster) GetRemoteAddress() string {
+func (c *Cluster) GetRemoteAddressList() []string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.getRemoteAddress()
+	return c.getRemoteAddressList()
 }
 
-func (c *Cluster) getRemoteAddress() string {
+func (c *Cluster) getRemoteAddressList() []string {
 	state := c.currentNodeState()
 	if state.swarmNode == nil {
-		return ""
+		return []string{}
 	}
+
 	nodeID := state.swarmNode.NodeID()
-	for _, r := range state.swarmNode.Remotes() {
+	remotes := state.swarmNode.Remotes()
+	addressList := make([]string, 0, len(remotes))
+	for _, r := range remotes {
 		if r.NodeID != nodeID {
-			return r.Addr
+			addressList = append(addressList, r.Addr)
 		}
 	}
-	return ""
+	return addressList
 }
 
 // ListenClusterEvents returns a channel that receives messages on cluster

--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -271,7 +271,13 @@ func (n *nodeRunner) enableReconnectWatcher() {
 		if n.stopping {
 			return
 		}
-		config.RemoteAddr = n.cluster.getRemoteAddress()
+		remotes := n.cluster.getRemoteAddressList()
+		if len(remotes) > 0 {
+			config.RemoteAddr = remotes[0]
+		} else {
+			config.RemoteAddr = ""
+		}
+
 		config.joinAddr = config.RemoteAddr
 		if err := n.start(config); err != nil {
 			n.err = err

--- a/vendor.conf
+++ b/vendor.conf
@@ -24,7 +24,7 @@ github.com/RackSec/srslog 456df3a81436d29ba874f3590eeeee25d666f8a5
 github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-github.com/docker/libnetwork 5dc95a3f9ce4b70bf08492ca37ec55c5b6d84975
+github.com/docker/libnetwork cace103704768d39bd88a23d0df76df125a0e39a
 github.com/docker/go-events 18b43f1bc85d9cdd42c05a6cd2d444c7a200a894
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/cluster/provider.go
+++ b/vendor/github.com/docker/libnetwork/cluster/provider.go
@@ -13,7 +13,7 @@ type Provider interface {
 	GetListenAddress() string
 	GetAdvertiseAddress() string
 	GetDataPathAddress() string
-	GetRemoteAddress() string
+	GetRemoteAddressList() []string
 	ListenClusterEvents() <-chan struct{}
 	AttachNetwork(string, string, []string) (*network.NetworkingConfig, error)
 	DetachNetwork(string, string) error


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Changed the method ``GetRemoteAddress`` to ``GetRemoteAddressList``
This will allow the cluster provider to return the list of all known managers available.
Today the user of this is libnetwork that uses them to initialize the network DB.
Before if the daemon on the IP returned by the function was crashing or being unresponsive or unreachable the worker/manager that was initializing the network db was remaining isolated from the gossip cluster.
The new approach is more fault resilient also because the network db is already able to accept a list of IP to join.

Relates to: https://github.com/docker/libnetwork/issues/1734
Fixes the libnetwork side of the issue

**- How I did it**
Just return the whole list of IP (keeping the filtering of local IP)

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Change GetRemoteAddress to return an IP list

**- A picture of a cute animal (not mandatory but encouraged)**
![augusta-has-reached-one-million-views](https://cloud.githubusercontent.com/assets/1823625/25538654/6468315e-2bf8-11e7-9c45-d82503e19ca3.jpg)


