### PR TITLE
fixes #19803 - update json-file log driver to always include extra…

### DIFF
--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -66,8 +66,26 @@ func New(ctx logger.Context) (logger.Logger, error) {
 		return nil, err
 	}
 
+	extraAttrs := map[string]string{
+		"_container_id":   ctx.ContainerID,
+		"_container_name": ctx.ContainerName,
+		"_image_id":       ctx.ContainerImageID,
+		"_image_name":     ctx.ContainerImageName,
+	}
+
+	var attrs map[string]string
+	if attrs = ctx.ExtraAttributes(nil); len(attrs) <= 0 {
+		attrs = make(map[string]string)
+	}
+
+	for k, v := range extraAttrs {
+		if len(v) > 0 {
+			attrs[k] = v
+		}
+	}
+
 	var extra []byte
-	if attrs := ctx.ExtraAttributes(nil); len(attrs) > 0 {
+	if len(attrs) > 0 {
 		var err error
 		extra, err = json.Marshal(attrs)
 		if err != nil {

--- a/daemon/logger/jsonfilelog/jsonfilelog_test.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestJSONFileLogger(t *testing.T) {
 	cid := "a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"
+	cname := "json-file-logger-test"
 	tmp, err := ioutil.TempDir("", "docker-logger-")
 	if err != nil {
 		t.Fatal(err)
@@ -23,8 +24,9 @@ func TestJSONFileLogger(t *testing.T) {
 	defer os.RemoveAll(tmp)
 	filename := filepath.Join(tmp, "container.log")
 	l, err := New(logger.Context{
-		ContainerID: cid,
-		LogPath:     filename,
+		ContainerID:   cid,
+		ContainerName: cname,
+		LogPath:       filename,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -44,9 +46,9 @@ func TestJSONFileLogger(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := `{"log":"line1\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line2\n","stream":"src2","time":"0001-01-01T00:00:00Z"}
-{"log":"line3\n","stream":"src3","time":"0001-01-01T00:00:00Z"}
+	expected := `{"log":"line1\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657","_container_name":"json-file-logger-test"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line2\n","stream":"src2","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657","_container_name":"json-file-logger-test"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line3\n","stream":"src3","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657","_container_name":"json-file-logger-test"},"time":"0001-01-01T00:00:00Z"}
 `
 
 	if string(res) != expected {
@@ -96,7 +98,7 @@ func TestJSONFileLoggerWithOpts(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 	filename := filepath.Join(tmp, "container.log")
-	config := map[string]string{"max-file": "2", "max-size": "1k"}
+	config := map[string]string{"max-file": "2", "max-size": "2k"}
 	l, err := New(logger.Context{
 		ContainerID: cid,
 		LogPath:     filename,
@@ -120,27 +122,27 @@ func TestJSONFileLoggerWithOpts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedPenultimate := `{"log":"line0\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line1\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line2\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line3\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line4\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line5\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line6\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line7\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line8\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line9\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line10\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line11\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line12\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line13\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line14\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line15\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+	expectedPenultimate := `{"log":"line0\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line1\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line2\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line3\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line4\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line5\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line6\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line7\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line8\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line9\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line10\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line11\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line12\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
 `
-	expected := `{"log":"line16\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line17\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line18\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
-{"log":"line19\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+	expected := `{"log":"line13\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line14\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line15\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line16\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line17\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line18\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
+{"log":"line19\n","stream":"src1","attrs":{"_container_id":"a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"},"time":"0001-01-01T00:00:00Z"}
 `
 
 	if string(res) != expected {
@@ -189,11 +191,12 @@ func TestJSONFileLoggerWithLabelsEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected := map[string]string{
-		"rack":    "101",
-		"dc":      "lhr",
-		"environ": "production",
-		"debug":   "false",
-		"ssl":     "true",
+		"rack":          "101",
+		"dc":            "lhr",
+		"environ":       "production",
+		"debug":         "false",
+		"ssl":           "true",
+		"_container_id": "a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657",
 	}
 	if !reflect.DeepEqual(extra, expected) {
 		t.Fatalf("Wrong log attrs: %q, expected %q", extra, expected)

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -316,7 +316,17 @@ func (s *DockerSuite) TestLogsWithDetails(c *check.C) {
 	c.Assert(len(logFields), checker.Equals, 3, check.Commentf(out))
 
 	details := strings.Split(logFields[1], ",")
-	c.Assert(details, checker.HasLen, 2)
-	c.Assert(details[0], checker.Equals, "baz=qux")
-	c.Assert(details[1], checker.Equals, "foo=bar")
+	c.Assert(details, checker.HasLen, 6)
+	c.Assert(SliceContains(details, "baz=qux"), checker.True)
+	c.Assert(SliceContains(details, "foo=bar"), checker.True)
+}
+
+func SliceContains(arr []string, target string) bool {
+	for _, v := range arr {
+		if v == target {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
… attributes

Updated json-file log driver to by compatible with other log drivers
in providing ContainerId, ContainerName, ImageId and ImageName data
as extra attributes. This allows the use of 'docker logs' while still
being able to ship the logs to a log aggregation (like ELK stack)
tool and sort by ContainerName. Previously, this was only available
through other log drivers which then prevented the use of the
'docker logs' command for manual debugging.

Updated the unit tests based on the new log file structure with the
extra attributes.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Updated json-file log driver to include extra attributes in the output for ContainerId, ContainerName, ImageId, ImageName so that it mirrors other log drivers.

**- How I did it**
Used the LogContext which contains the container information already and applied as extra attributes when constructing the logger.

**- How to verify it**
1. Check the jsonfilelogger unit test
2. When running a docker container with the json-file log driver, each line in the log file under /var/lib/docker/container/*/*-json.log will contain a new attrs:{} map with each of the attributes listed.

**- Description for the changelog**
update json-file log driver to always include extra attributes
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

