### PR TITLE
gcplogging driver MRPB for VM set

### DIFF
--- a/daemon/logger/gcplogs/gcplogging.go
+++ b/daemon/logger/gcplogs/gcplogging.go
@@ -12,6 +12,7 @@ import (
 	"cloud.google.com/go/logging"
 	"github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
+	mrpb "google.golang.org/genproto/googleapis/api/monitoredres"
 )
 
 const (
@@ -128,7 +129,35 @@ func New(info logger.Info) (logger.Logger, error) {
 	if err != nil {
 		return nil, err
 	}
-	lg := c.Logger("gcplogs-docker-driver")
+	var instanceResource *instanceInfo
+	if onGCE {
+		instanceResource = &instanceInfo{
+			Zone: zone,
+			Name: instanceName,
+			ID:   instanceID,
+		}
+	} else if info.Config[logZoneKey] != "" || info.Config[logNameKey] != "" || info.Config[logIDKey] != "" {
+		instanceResource = &instanceInfo{
+			Zone: info.Config[logZoneKey],
+			Name: info.Config[logNameKey],
+			ID:   info.Config[logIDKey],
+		}
+	}
+
+	options := []logging.LoggerOption{}
+	if instanceResource != nil {
+		vmMrpb := logging.CommonResource(
+			&mrpb.MonitoredResource{
+				Type: "gce_instance",
+				Labels: map[string]string{
+					"instance_id": instanceResource.ID,
+					"zone":        instanceResource.Zone,
+				},
+			},
+		)
+		options = []logging.LoggerOption{vmMrpb}
+	}
+	lg := c.Logger("gcplogs-docker-driver", options...)
 
 	if err := c.Ping(context.Background()); err != nil {
 		return nil, fmt.Errorf("unable to connect or authenticate with Google Cloud Logging: %v", err)
@@ -155,18 +184,8 @@ func New(info logger.Info) (logger.Logger, error) {
 		l.container.Command = info.Command()
 	}
 
-	if onGCE {
-		l.instance = &instanceInfo{
-			Zone: zone,
-			Name: instanceName,
-			ID:   instanceID,
-		}
-	} else if info.Config[logZoneKey] != "" || info.Config[logNameKey] != "" || info.Config[logIDKey] != "" {
-		l.instance = &instanceInfo{
-			Zone: info.Config[logZoneKey],
-			Name: info.Config[logNameKey],
-			ID:   info.Config[logIDKey],
-		}
+	if instanceResource != nil {
+		l.instance = instanceResource
 	}
 
 	// The logger "overflows" at a rate of 10,000 logs per second and this


### PR DESCRIPTION
Signed-off-by: Grzegorz Jaśkiewicz <gj.jaskiewicz@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added metadata about monitored resource type for GCP logging driver.

**- How I did it**

I used GCP logging SDK.

**- How to verify it**

Run a docker container using GCP logging driver on GCE VM and go to GCE VM logs, observe that logs are attributed to VM rather than being logged to global sink. Example to run a command could be
`docker run --log-driver=gcplogs docker.io/tomcat`

Before this change:
![gcplogging-before](https://cloud.githubusercontent.com/assets/2766140/25552033/903b2b50-2c8f-11e7-9140-82c74ae4d956.png)

After this change:
![gcplogging-after](https://cloud.githubusercontent.com/assets/2766140/25552034/978e1dae-2c8f-11e7-9d25-9a58d8c1ee2c.png)

**- Description for the changelog**
Add monitored resource type metadata for GCP logging driver

**- A picture of a cute animal (not mandatory but encouraged)**
![hamster2](https://cloud.githubusercontent.com/assets/2766140/25552039/b8c01aea-2c8f-11e7-9569-6aace25c2b14.jpg)

