### PR TITLE
daemon/info: don't sort authorization plugins as order matters

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"reflect"
 	"runtime"
-	"sort"
 	"strings"
 	"sync"
 
@@ -501,19 +500,6 @@ func Validate(config *Config) error {
 	}
 
 	return nil
-}
-
-// GetAuthorizationPlugins returns daemon's sorted authorization plugins
-func (conf *Config) GetAuthorizationPlugins() []string {
-	conf.Lock()
-	defer conf.Unlock()
-
-	authPlugins := make([]string, 0, len(conf.AuthorizationPlugins))
-	for _, p := range conf.AuthorizationPlugins {
-		authPlugins = append(authPlugins, p)
-	}
-	sort.Strings(authPlugins)
-	return authPlugins
 }
 
 // ModifiedDiscoverySettings returns whether the discovery configuration has been modified or not.

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -175,7 +175,9 @@ func (daemon *Daemon) showPluginsInfo() types.PluginsInfo {
 
 	pluginsInfo.Volume = volumedrivers.GetDriverList()
 	pluginsInfo.Network = daemon.GetNetworkDriverList()
-	pluginsInfo.Authorization = daemon.configStore.GetAuthorizationPlugins()
+	// The authorization plugins are returned in the order they are
+	// used as they constitute a request/response modification chain.
+	pluginsInfo.Authorization = daemon.configStore.AuthorizationPlugins
 	pluginsInfo.Log = logger.ListDrivers()
 
 	return pluginsInfo


### PR DESCRIPTION
#30474 started sorting authorization plugins in `/info` responses but AuthZ plugins exist in a chain that composes potentially mutating requests and responses. This simply reverts the sorting of AuthZ plugins so that the `/info` API endpoint returns the internal ordering used for AuthZ composition.

Volume driver plugins are not affected because they are just a set.

**- What I did**

Removed the sorting of AuthZ plugins reported on the `/info` endpoint.

**- How I did it**

Returned the implementation to its state before #30474 with respect to AuthZ plugins.

**- How to verify it**

AuthZ plugins are now reported via `/info` in the order they are used.

**- Description for the changelog**

This probably doesn't need a mention? Unless you think it is a bugfix worth mentioning?

**- A picture of a cute animal (not mandatory but encouraged)**

<img src="https://userscontent2.emaze.com/images/07526565-6061-4434-89ee-5973d18971a9/d746e06bec5611061409ee31d3899649.jpeg">