### PR TITLE
Improve documentation on the -e flag to the 'run' cli command. 

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1408,13 +1408,17 @@ The following environment variables are set for Linux containers:
 
 Additionally, the operator can **set any environment variable** in the
 container by using one or more `-e` flags, even overriding those mentioned
-above, or already defined by the developer with a Dockerfile `ENV`:
+above, or already defined by the developer with a Dockerfile `ENV`. If the
+operator names an environment variable without specifying a value, then the
+current value of the named variable is propagated into the container's environment:
 
 ```bash
-$ docker run -e "deep=purple" --rm alpine env
+$ export today=Wednesday
+$ docker run -e "deep=purple" -e today --rm alpine env
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 HOSTNAME=d2219b854598
 deep=purple
+today=Wednesday
 HOME=/root
 ```
 


### PR DESCRIPTION

**- What I did**
I added a sentence to the run command documentation explicitly informing users of the option to simply name an environment variable and have its value be imported into the container. I then expanded the code example below to show how this would look.

**- How I did it**
With vi  :)

**- How to verify it**
Not sure how you verify documentation: but you can see the code in opts/env.go where the value is fetched from the environment if the -e flag is used without the "=value" part.

**- Description for the changelog**
Enhanced the documentation of the -e flag of the run command to describe how to import the current value of an environment variable into a container.


