### PR TITLE
Minor grammatical fix

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -14,8 +14,8 @@ It consists of various components in this repository:
 
 The API is defined by the [Swagger](http://swagger.io/specification/) definition in `api/swagger.yaml`. This definition can be used to:
 
-1. To automatically generate documentation.
-2. To automatically generate the Go server and client. (A work-in-progress.)
+1. Automatically generate documentation.
+2. Automatically generate the Go server and client. (A work-in-progress.)
 3. Provide a machine readable version of the API for introspecting what it can do, automatically generating clients for other languages, etc.
 
 ## Updating the API documentation


### PR DESCRIPTION
Just a small grammatical correction, but it is unnecessary to repeat "to," after the colon, and deleting it makes the format of the list more consistent and readable.

Signed-off-by: Ryan Cooper <ryan.cooper7@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

