### PR TITLE
docs/dockerd: correct authz plugin chain semantics

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -901,10 +901,10 @@ file. The plugin's implementation determines whether you can specify a name or
 path. Consult with your Docker administrator to get information about the
 plugins available to you.
 
-Once a plugin is installed, requests made to the `daemon` through the command
-line or Docker's Engine API are allowed or denied by the plugin.  If you have
-multiple plugins installed, at least one must allow the request for it to
-complete.
+Once a plugin is installed, requests made to the `daemon` through the
+command line or Docker's Engine API are allowed or denied by the plugin.
+If you have multiple plugins installed, each plugin, in order, must
+allow the request for it to complete.
 
 For information about how to create an authorization plugin, see [authorization
 plugin](../../extend/plugins_authorization.md) section in the Docker extend section of this documentation.

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -701,10 +701,10 @@ specification file. The plugin's implementation determines whether you can
 specify a name or path. Consult with your Docker administrator to get
 information about the plugins available to you.
 
-Once a plugin is installed, requests made to the `daemon` through the command
-line or Docker's Engine API are allowed or denied by the plugin.  If you have
-multiple plugins installed, at least one must allow the request for it to
-complete.
+Once a plugin is installed, requests made to the `daemon` through the
+command line or Docker's Engine API are allowed or denied by the plugin.
+If you have multiple plugins installed, each plugin, in order, must
+allow the request for it to complete.
 
 For information about how to create an authorization plugin, see [authorization
 plugin](https://docs.docker.com/engine/extend/authorization/) section in the


### PR DESCRIPTION
**- What I did**

I edited `docs/reference/commandline/dockerd.md` (and `man/dockerd.8.md`) to bring its description of authorization plugin chain semantics ("at least one" i.e. OR) in line with `docs/extend/plugins_authorization.md` and the implementation in `pkg/authorization/authz.go` ("for all" i.e. AND).

**- How I did it**

N/A

**- How to verify it**

Read <https://github.com/moby/moby/blob/master/pkg/authorization/authz.go#L86-L97> and <https://github.com/moby/moby/blob/master/pkg/authorization/authz.go#L111-L122>.

**- Description for the changelog**

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

<img src="http://photos1.blogger.com/hello/265/947/1024/Paedocypris_micromegethes.jpg">

*Paedocypris progenetica*, the world's smallest vertebrate