### PR TITLE
Add no-new-privileg flag

### DIFF
--- a/cmd/dockerd/config_unix.go
+++ b/cmd/dockerd/config_unix.go
@@ -46,6 +46,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.Int64Var(&conf.CPURealtimeRuntime, "cpu-rt-runtime", 0, "Limit the CPU real-time runtime in microseconds")
 	flags.StringVar(&conf.SeccompProfile, "seccomp-profile", "", "Path to seccomp profile")
 	flags.Var(&conf.ShmSize, "default-shm-size", "Default shm size for containers")
+	flags.BoolVar(&conf.NoNewPrivileges, "no-new-privileges", false, "Set no-new-privileges by default for new containers")
 
 	attachExperimentalFlags(conf, flags)
 }

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -71,6 +71,7 @@ Options:
       --max-concurrent-uploads int            Set the max concurrent uploads for each push (default 5)
       --metrics-addr string                   Set default address and port to serve the metrics api on
       --mtu int                               Set the containers network MTU
+      --no-new-privileges                     Set no-new-privileges by default for new containers
       --oom-score-adjust int                  Set the oom_score_adj for the daemon (default -500)
   -p, --pidfile string                        Path to use for daemon PID file (default "/var/run/docker.pid")
       --raw-logs                              Full timestamps without ANSI coloring


### PR DESCRIPTION
The daemon config for defaulting to no-new-privileges for containers was
added in d7fda019bb7e24f42f8ae1ddecb3fd52df3c48bf (https://github.com/moby/moby/pull/29984), but somehow we
managed to omit the flag itself, but also documented the flag.
This just adds the actual flag.

![image](https://cloud.githubusercontent.com/assets/799078/25581755/aae23f1a-2e57-11e7-87d1-18ca7d73b7b3.png)
