### PR TITLE
Add swagger spec for /info Log plugins

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5215,6 +5215,10 @@ paths:
                     type: "array"
                     items:
                       type: "string"
+                  Log:
+                    type: "array"
+                    items:
+                      type: "string"
               ExperimentalBuild:
                 type: "boolean"
               HttpProxy:

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,6 +17,8 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.30](https://docs.docker.com/engine/api/v1.30/) documentation
 
+* `GET /info` now returns the list of supported logging drivers, including plugins.
+
 ## v1.29 API changes
 
 [Docker Engine API v1.29](https://docs.docker.com/engine/api/v1.29/) documentation


### PR DESCRIPTION
The `Log` field for plugins was added to `/info` in
17abacb8946ed89496fcbf07a0288fafe24cb7b0 but the swagger spec was not
updated.
This just updates the spec to match reality.