### PR TITLE
Add log option max-log-size which applies to all log drivers.  Fixes #32923

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -897,7 +897,17 @@ func (container *Container) startLogging() error {
 		return fmt.Errorf("failed to initialize logging driver: %v", err)
 	}
 
-	copier := logger.NewCopier(map[string]io.Reader{"stdout": container.StdoutPipe(), "stderr": container.StderrPipe()}, l)
+	bufSize := int64(-1)
+	if s, exists := container.HostConfig.LogConfig.Config["max-log-size"]; exists {
+		bufSize, err = units.RAMInBytes(s)
+		if err != nil {
+			return err
+		}
+	} else {
+		bufSize = 16 * 1024
+	}
+
+	copier := logger.NewCopier(map[string]io.Reader{"stdout": container.StdoutPipe(), "stderr": container.StderrPipe()}, l, bufSize)
 	container.LogCopier = copier
 	copier.Run()
 	container.LogDriver = l

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -746,7 +746,7 @@ __docker_complete_log_drivers() {
 
 __docker_complete_log_options() {
 	# see repository docker/docker.github.io/engine/admin/logging/
-	local common_options="max-buffer-size mode"
+	local common_options="max-buffer-size mode max-log-size"
 
 	local awslogs_options="$common_options awslogs-create-group awslogs-group awslogs-region awslogs-stream"
 	local fluentd_options="$common_options env fluentd-address fluentd-async-connect fluentd-buffer-limit fluentd-retry-wait fluentd-max-retries labels tag"

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -223,7 +223,7 @@ __docker_get_log_options() {
     local log_driver=${opt_args[--log-driver]:-"all"}
     local -a common_options awslogs_options fluentd_options gelf_options journald_options json_file_options logentries_options syslog_options splunk_options
 
-    common_options=("max-buffer-size" "mode")
+    common_options=("max-buffer-size" "mode" "max-log-size")
     awslogs_options=($common_options "awslogs-region" "awslogs-group" "awslogs-stream" "awslogs-create-group")
     fluentd_options=($common_options "env" "fluentd-address" "fluentd-async-connect" "fluentd-buffer-limit" "fluentd-retry-wait" "fluentd-max-retries" "labels" "tag")
     gcplogs_options=($common_options "env" "gcp-log-cmd" "gcp-project" "labels")

--- a/daemon/logger/copier.go
+++ b/daemon/logger/copier.go
@@ -10,7 +10,6 @@ import (
 )
 
 const (
-	bufSize  = 16 * 1024
 	readSize = 2 * 1024
 )
 
@@ -23,14 +22,16 @@ type Copier struct {
 	copyJobs  sync.WaitGroup
 	closeOnce sync.Once
 	closed    chan struct{}
+	bufSize   int64
 }
 
 // NewCopier creates a new Copier
-func NewCopier(srcs map[string]io.Reader, dst Logger) *Copier {
+func NewCopier(srcs map[string]io.Reader, dst Logger, bufSize int64) *Copier {
 	return &Copier{
-		srcs:   srcs,
-		dst:    dst,
-		closed: make(chan struct{}),
+		srcs:    srcs,
+		dst:     dst,
+		closed:  make(chan struct{}),
+		bufSize: bufSize,
 	}
 }
 
@@ -44,7 +45,7 @@ func (c *Copier) Run() {
 
 func (c *Copier) copySrc(name string, src io.Reader) {
 	defer c.copyJobs.Done()
-	buf := make([]byte, bufSize)
+	buf := make([]byte, c.bufSize)
 	n := 0
 	eof := false
 

--- a/daemon/logger/copier_test.go
+++ b/daemon/logger/copier_test.go
@@ -12,6 +12,10 @@ import (
 	"time"
 )
 
+const (
+	bufSize = 16 * 1024
+)
+
 type TestLoggerJSON struct {
 	*json.Encoder
 	mu    sync.Mutex
@@ -65,7 +69,8 @@ func TestCopier(t *testing.T) {
 			"stdout": &stdout,
 			"stderr": &stderr,
 		},
-		jsonLog)
+		jsonLog,
+		bufSize)
 	c.Run()
 	wait := make(chan struct{})
 	go func() {
@@ -139,7 +144,8 @@ func TestCopierLongLines(t *testing.T) {
 			"stdout": &stdout,
 			"stderr": &stderr,
 		},
-		jsonLog)
+		jsonLog,
+		bufSize)
 	c.Run()
 	wait := make(chan struct{})
 	go func() {
@@ -189,7 +195,7 @@ func TestCopierSlow(t *testing.T) {
 	//encoder := &encodeCloser{Encoder: json.NewEncoder(&jsonBuf)}
 	jsonLog := &TestLoggerJSON{Encoder: json.NewEncoder(&jsonBuf), delay: 100 * time.Millisecond}
 
-	c := NewCopier(map[string]io.Reader{"stdout": &stdout}, jsonLog)
+	c := NewCopier(map[string]io.Reader{"stdout": &stdout}, jsonLog, bufSize)
 	c.Run()
 	wait := make(chan struct{})
 	go func() {
@@ -288,7 +294,8 @@ func benchmarkCopier(b *testing.B, length int) {
 			map[string]io.Reader{
 				"buffer": piped(b, 10, time.Nanosecond, buf),
 			},
-			&BenchmarkLoggerDummy{})
+			&BenchmarkLoggerDummy{},
+			bufSize)
 		c.Run()
 		c.Wait()
 		c.Close()

--- a/daemon/logger/factory.go
+++ b/daemon/logger/factory.go
@@ -119,6 +119,7 @@ func GetLogDriver(name string) (Creator, error) {
 var builtInLogOpts = map[string]bool{
 	"mode":            true,
 	"max-buffer-size": true,
+	"max-log-size":    true,
 }
 
 // ValidateLogOpts checks the options for the given log driver. The
@@ -140,6 +141,12 @@ func ValidateLogOpts(name string, cfg map[string]string) error {
 		}
 		if _, err := units.RAMInBytes(s); err != nil {
 			return errors.Wrap(err, "error parsing option max-buffer-size")
+		}
+	}
+
+	if s, ok := cfg["max-log-size"]; ok {
+		if _, err := units.RAMInBytes(s); err != nil {
+			return errors.Wrap(err, "error parsing option max-log-size")
 		}
 	}
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added a new daemon option `--log-opt max-log-line=<size>` which set the maximum size of a single container log message.

**- How I did it**
I adjusted the NewCopier function (https://github.com/moby/moby/blob/master/daemon/logger/copier.go#L29) to require an integer argument which sets the maximum.    The default will be remain at the 16k max introduced in 1.13.

**- How to verify it**
Start docker daemon with the argument that increases the max-log-size beyond 16k - for example `--log-opt max-log-size=32k` then run a container that emits a large log line that is greater than 16k but less than the value set in max-log-size.   For example the line below will run a container that prints about a 30K line which have a START and END anchors around alot of X's.

`docker run -d perl perl -e 'print "START" ;print "X" x 30000; print "END\n"'`

Then look at the logs for the container and make sure the above line was logged as 1 single line and not split into multiple parts.   If you are running with the log driver json-file it's easy to look at the container json log and see if the single line contains both the START and END anchors.


 
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add `--log-opt max-log-line=<size>` to determine when a single log line should be split into smaller pieces.

**- A picture of a cute animal (not mandatory but encouraged)**

![cute-baby-animals-10](https://cloud.githubusercontent.com/assets/225537/25593795/0a69a96c-2e73-11e7-8cf8-3dbfa7a55ed8.jpg)
