### PR TITLE
Add a proper type to the Source field in Mount

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -231,6 +231,7 @@ definitions:
         type: "string"
       Source:
         description: "Mount source (e.g. a volume name, a host path)."
+        type: "string"
       Type:
         description: |
           The mount type. Available types:


### PR DESCRIPTION
This field was missing a type, which meant that the example objects that Swagger tools generate did not work.
