### PR TITLE
[Builder] Move dispatch state to a new struct

### DIFF
--- a/builder/dockerfile/buildargs.go
+++ b/builder/dockerfile/buildargs.go
@@ -1,5 +1,10 @@
 package dockerfile
 
+import (
+	"fmt"
+	"github.com/docker/docker/runconfig/opts"
+)
+
 // builtinAllowedBuildArgs is list of built-in allowed build args
 // these args are considered transparent and are excluded from the image history.
 // Filtering from history is implemented in dispatchers.go
@@ -94,6 +99,19 @@ func (b *buildArgs) getAllFromMapping(source map[string]*string) map[string]stri
 		}
 	}
 	return m
+}
+
+// FilterAllowed returns all allowed args without the filtered args
+func (b *buildArgs) FilterAllowed(filter []string) []string {
+	envs := []string{}
+	configEnv := opts.ConvertKVStringsToMap(filter)
+
+	for key, val := range b.GetAllAllowed() {
+		if _, ok := configEnv[key]; !ok {
+			envs = append(envs, fmt.Sprintf("%s=%s", key, val))
+		}
+	}
+	return envs
 }
 
 func (b *buildArgs) getBuildArg(key string, mapping map[string]*string) (string, bool) {

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -47,6 +47,7 @@ func env(req dispatchRequest) error {
 		return err
 	}
 
+	runConfig := req.state.runConfig
 	commitMessage := bytes.NewBufferString("ENV")
 
 	for j := 0; j < len(req.args); j += 2 {
@@ -59,21 +60,21 @@ func env(req dispatchRequest) error {
 		commitMessage.WriteString(" " + newVar)
 
 		gotOne := false
-		for i, envVar := range req.runConfig.Env {
+		for i, envVar := range runConfig.Env {
 			envParts := strings.SplitN(envVar, "=", 2)
 			compareFrom := envParts[0]
 			if equalEnvKeys(compareFrom, name) {
-				req.runConfig.Env[i] = newVar
+				runConfig.Env[i] = newVar
 				gotOne = true
 				break
 			}
 		}
 		if !gotOne {
-			req.runConfig.Env = append(req.runConfig.Env, newVar)
+			runConfig.Env = append(runConfig.Env, newVar)
 		}
 	}
 
-	return req.builder.commit(commitMessage.String())
+	return req.builder.commit(req.state, commitMessage.String())
 }
 
 // MAINTAINER some text <maybe@an.email.address>
@@ -89,8 +90,8 @@ func maintainer(req dispatchRequest) error {
 	}
 
 	maintainer := req.args[0]
-	req.builder.maintainer = maintainer
-	return req.builder.commit("MAINTAINER " + maintainer)
+	req.state.maintainer = maintainer
+	return req.builder.commit(req.state, "MAINTAINER "+maintainer)
 }
 
 // LABEL some json data describing the image
@@ -111,26 +112,25 @@ func label(req dispatchRequest) error {
 	}
 
 	commitStr := "LABEL"
+	runConfig := req.state.runConfig
 
-	if req.runConfig.Labels == nil {
-		req.runConfig.Labels = map[string]string{}
+	if runConfig.Labels == nil {
+		runConfig.Labels = map[string]string{}
 	}
 
 	for j := 0; j < len(req.args); j++ {
-		// name  ==> req.args[j]
-		// value ==> req.args[j+1]
-
-		if len(req.args[j]) == 0 {
+		name := req.args[j]
+		if name == "" {
 			return errBlankCommandNames("LABEL")
 		}
 
-		newVar := req.args[j] + "=" + req.args[j+1] + ""
-		commitStr += " " + newVar
+		value := req.args[j+1]
+		commitStr += " " + name + "=" + value
 
-		req.runConfig.Labels[req.args[j]] = req.args[j+1]
+		runConfig.Labels[name] = value
 		j++
 	}
-	return req.builder.commit(commitStr)
+	return req.builder.commit(req.state, commitStr)
 }
 
 // ADD foo /path
@@ -147,7 +147,7 @@ func add(req dispatchRequest) error {
 		return err
 	}
 
-	return req.builder.runContextCommand(req.args, true, true, "ADD", nil)
+	return req.builder.runContextCommand(req, true, true, "ADD", nil)
 }
 
 // COPY foo /path
@@ -174,13 +174,13 @@ func dispatchCopy(req dispatchRequest) error {
 		}
 	}
 
-	return req.builder.runContextCommand(req.args, false, false, "COPY", im)
+	return req.builder.runContextCommand(req, false, false, "COPY", im)
 }
 
 // FROM imagename[:tag | @digest] [AS build-stage-name]
 //
 func from(req dispatchRequest) error {
-	ctxName, err := parseBuildStageName(req.args)
+	stageName, err := parseBuildStageName(req.args)
 	if err != nil {
 		return err
 	}
@@ -190,21 +190,23 @@ func from(req dispatchRequest) error {
 	}
 
 	req.builder.resetImageCache()
-	if _, err := req.builder.imageContexts.add(ctxName); err != nil {
+	req.state.noBaseImage = false
+	req.state.stageName = stageName
+	if _, err := req.builder.imageContexts.add(stageName); err != nil {
 		return err
 	}
 
-	image, err := req.builder.getFromImage(req.shlex, req.args[0])
+	image, err := req.builder.getFromImage(req.state, req.shlex, req.args[0])
 	if err != nil {
 		return err
 	}
 	if image != nil {
 		req.builder.imageContexts.update(image.ImageID(), image.RunConfig())
 	}
-	req.builder.from = image
+	req.state.baseImage = image
 
 	req.builder.buildArgs.ResetAllowed()
-	return req.builder.processImageFrom(image)
+	return req.builder.processImageFrom(req.state, image)
 }
 
 func parseBuildStageName(args []string) (string, error) {
@@ -222,7 +224,7 @@ func parseBuildStageName(args []string) (string, error) {
 	return stageName, nil
 }
 
-func (b *Builder) getFromImage(shlex *ShellLex, name string) (builder.Image, error) {
+func (b *Builder) getFromImage(dispatchState *dispatchState, shlex *ShellLex, name string) (builder.Image, error) {
 	substitutionArgs := []string{}
 	for key, value := range b.buildArgs.GetAllMeta() {
 		substitutionArgs = append(substitutionArgs, key+"="+value)
@@ -246,8 +248,8 @@ func (b *Builder) getFromImage(shlex *ShellLex, name string) (builder.Image, err
 		if runtime.GOOS == "windows" {
 			return nil, errors.New("Windows does not support FROM scratch")
 		}
-		b.image = ""
-		b.noBaseImage = true
+		dispatchState.imageID = ""
+		dispatchState.noBaseImage = true
 		return nil, nil
 	}
 	return pullOrGetImage(b, name)
@@ -279,9 +281,10 @@ func onbuild(req dispatchRequest) error {
 		return fmt.Errorf("%s isn't allowed as an ONBUILD trigger", triggerInstruction)
 	}
 
+	runConfig := req.state.runConfig
 	original := regexp.MustCompile(`(?i)^\s*ONBUILD\s*`).ReplaceAllString(req.original, "")
-	req.runConfig.OnBuild = append(req.runConfig.OnBuild, original)
-	return req.builder.commit("ONBUILD " + original)
+	runConfig.OnBuild = append(runConfig.OnBuild, original)
+	return req.builder.commit(req.state, "ONBUILD "+original)
 }
 
 // WORKDIR /tmp
@@ -298,9 +301,10 @@ func workdir(req dispatchRequest) error {
 		return err
 	}
 
+	runConfig := req.state.runConfig
 	// This is from the Dockerfile and will not necessarily be in platform
 	// specific semantics, hence ensure it is converted.
-	req.runConfig.WorkingDir, err = normaliseWorkdir(req.runConfig.WorkingDir, req.args[0])
+	runConfig.WorkingDir, err = normaliseWorkdir(runConfig.WorkingDir, req.args[0])
 	if err != nil {
 		return err
 	}
@@ -315,9 +319,9 @@ func workdir(req dispatchRequest) error {
 		return nil
 	}
 
-	comment := "WORKDIR " + req.runConfig.WorkingDir
-	runConfigWithCommentCmd := copyRunConfig(req.runConfig, withCmdCommentString(comment))
-	if hit, err := req.builder.probeCache(req.builder.image, runConfigWithCommentCmd); err != nil || hit {
+	comment := "WORKDIR " + runConfig.WorkingDir
+	runConfigWithCommentCmd := copyRunConfig(runConfig, withCmdCommentString(comment))
+	if hit, err := req.builder.probeCache(req.state, runConfigWithCommentCmd); err != nil || hit {
 		return err
 	}
 
@@ -334,7 +338,7 @@ func workdir(req dispatchRequest) error {
 		return err
 	}
 
-	return req.builder.commitContainer(container.ID, runConfigWithCommentCmd)
+	return req.builder.commitContainer(req.state, container.ID, runConfigWithCommentCmd)
 }
 
 // RUN some command yo
@@ -348,7 +352,7 @@ func workdir(req dispatchRequest) error {
 // RUN [ "echo", "hi" ] # echo hi
 //
 func run(req dispatchRequest) error {
-	if !req.builder.hasFromImage() {
+	if !req.state.hasFromImage() {
 		return errors.New("Please provide a source image with `from` prior to run")
 	}
 
@@ -356,29 +360,30 @@ func run(req dispatchRequest) error {
 		return err
 	}
 
+	stateRunConfig := req.state.runConfig
 	args := handleJSONArgs(req.args, req.attributes)
 	if !req.attributes["json"] {
-		args = append(getShell(req.runConfig), args...)
+		args = append(getShell(stateRunConfig), args...)
 	}
 	cmdFromArgs := strslice.StrSlice(args)
-	buildArgs := req.builder.buildArgsWithoutConfigEnv()
+	buildArgs := req.builder.buildArgs.FilterAllowed(stateRunConfig.Env)
 
 	saveCmd := cmdFromArgs
 	if len(buildArgs) > 0 {
 		saveCmd = prependEnvOnCmd(req.builder.buildArgs, buildArgs, cmdFromArgs)
 	}
 
-	runConfigForCacheProbe := copyRunConfig(req.runConfig,
+	runConfigForCacheProbe := copyRunConfig(stateRunConfig,
 		withCmd(saveCmd),
 		withEntrypointOverride(saveCmd, nil))
-	hit, err := req.builder.probeCache(req.builder.image, runConfigForCacheProbe)
+	hit, err := req.builder.probeCache(req.state, runConfigForCacheProbe)
 	if err != nil || hit {
 		return err
 	}
 
-	runConfig := copyRunConfig(req.runConfig,
+	runConfig := copyRunConfig(stateRunConfig,
 		withCmd(cmdFromArgs),
-		withEnv(append(req.runConfig.Env, buildArgs...)),
+		withEnv(append(stateRunConfig.Env, buildArgs...)),
 		withEntrypointOverride(saveCmd, strslice.StrSlice{""}))
 
 	// set config as already being escaped, this prevents double escaping on windows
@@ -393,7 +398,7 @@ func run(req dispatchRequest) error {
 		return err
 	}
 
-	return req.builder.commitContainer(cID, runConfigForCacheProbe)
+	return req.builder.commitContainer(req.state, cID, runConfigForCacheProbe)
 }
 
 // Derive the command to use for probeCache() and to commit in this container.
@@ -431,22 +436,22 @@ func cmd(req dispatchRequest) error {
 		return err
 	}
 
+	runConfig := req.state.runConfig
 	cmdSlice := handleJSONArgs(req.args, req.attributes)
-
 	if !req.attributes["json"] {
-		cmdSlice = append(getShell(req.runConfig), cmdSlice...)
+		cmdSlice = append(getShell(runConfig), cmdSlice...)
 	}
 
-	req.runConfig.Cmd = strslice.StrSlice(cmdSlice)
+	runConfig.Cmd = strslice.StrSlice(cmdSlice)
 	// set config as already being escaped, this prevents double escaping on windows
-	req.runConfig.ArgsEscaped = true
+	runConfig.ArgsEscaped = true
 
-	if err := req.builder.commit(fmt.Sprintf("CMD %q", cmdSlice)); err != nil {
+	if err := req.builder.commit(req.state, fmt.Sprintf("CMD %q", cmdSlice)); err != nil {
 		return err
 	}
 
 	if len(req.args) != 0 {
-		req.builder.cmdSet = true
+		req.state.cmdSet = true
 	}
 
 	return nil
@@ -478,6 +483,7 @@ func healthcheck(req dispatchRequest) error {
 	if len(req.args) == 0 {
 		return errAtLeastOneArgument("HEALTHCHECK")
 	}
+	runConfig := req.state.runConfig
 	typ := strings.ToUpper(req.args[0])
 	args := req.args[1:]
 	if typ == "NONE" {
@@ -485,12 +491,12 @@ func healthcheck(req dispatchRequest) error {
 			return errors.New("HEALTHCHECK NONE takes no arguments")
 		}
 		test := strslice.StrSlice{typ}
-		req.runConfig.Healthcheck = &container.HealthConfig{
+		runConfig.Healthcheck = &container.HealthConfig{
 			Test: test,
 		}
 	} else {
-		if req.runConfig.Healthcheck != nil {
-			oldCmd := req.runConfig.Healthcheck.Test
+		if runConfig.Healthcheck != nil {
+			oldCmd := runConfig.Healthcheck.Test
 			if len(oldCmd) > 0 && oldCmd[0] != "NONE" {
 				fmt.Fprintf(req.builder.Stdout, "Note: overriding previous HEALTHCHECK: %v\n", oldCmd)
 			}
@@ -554,10 +560,10 @@ func healthcheck(req dispatchRequest) error {
 			healthcheck.Retries = 0
 		}
 
-		req.runConfig.Healthcheck = &healthcheck
+		runConfig.Healthcheck = &healthcheck
 	}
 
-	return req.builder.commit(fmt.Sprintf("HEALTHCHECK %q", req.runConfig.Healthcheck))
+	return req.builder.commit(req.state, fmt.Sprintf("HEALTHCHECK %q", runConfig.Healthcheck))
 }
 
 // ENTRYPOINT /usr/sbin/nginx
@@ -573,27 +579,28 @@ func entrypoint(req dispatchRequest) error {
 		return err
 	}
 
+	runConfig := req.state.runConfig
 	parsed := handleJSONArgs(req.args, req.attributes)
 
 	switch {
 	case req.attributes["json"]:
 		// ENTRYPOINT ["echo", "hi"]
-		req.runConfig.Entrypoint = strslice.StrSlice(parsed)
+		runConfig.Entrypoint = strslice.StrSlice(parsed)
 	case len(parsed) == 0:
 		// ENTRYPOINT []
-		req.runConfig.Entrypoint = nil
+		runConfig.Entrypoint = nil
 	default:
 		// ENTRYPOINT echo hi
-		req.runConfig.Entrypoint = strslice.StrSlice(append(getShell(req.runConfig), parsed[0]))
+		runConfig.Entrypoint = strslice.StrSlice(append(getShell(runConfig), parsed[0]))
 	}
 
 	// when setting the entrypoint if a CMD was not explicitly set then
 	// set the command to nil
-	if !req.builder.cmdSet {
-		req.runConfig.Cmd = nil
+	if !req.state.cmdSet {
+		runConfig.Cmd = nil
 	}
 
-	return req.builder.commit(fmt.Sprintf("ENTRYPOINT %q", req.runConfig.Entrypoint))
+	return req.builder.commit(req.state, fmt.Sprintf("ENTRYPOINT %q", runConfig.Entrypoint))
 }
 
 // EXPOSE 6667/tcp 7000/tcp
@@ -612,8 +619,9 @@ func expose(req dispatchRequest) error {
 		return err
 	}
 
-	if req.runConfig.ExposedPorts == nil {
-		req.runConfig.ExposedPorts = make(nat.PortSet)
+	runConfig := req.state.runConfig
+	if runConfig.ExposedPorts == nil {
+		runConfig.ExposedPorts = make(nat.PortSet)
 	}
 
 	ports, _, err := nat.ParsePortSpecs(portsTab)
@@ -627,14 +635,14 @@ func expose(req dispatchRequest) error {
 	portList := make([]string, len(ports))
 	var i int
 	for port := range ports {
-		if _, exists := req.runConfig.ExposedPorts[port]; !exists {
-			req.runConfig.ExposedPorts[port] = struct{}{}
+		if _, exists := runConfig.ExposedPorts[port]; !exists {
+			runConfig.ExposedPorts[port] = struct{}{}
 		}
 		portList[i] = string(port)
 		i++
 	}
 	sort.Strings(portList)
-	return req.builder.commit("EXPOSE " + strings.Join(portList, " "))
+	return req.builder.commit(req.state, "EXPOSE "+strings.Join(portList, " "))
 }
 
 // USER foo
@@ -651,8 +659,8 @@ func user(req dispatchRequest) error {
 		return err
 	}
 
-	req.runConfig.User = req.args[0]
-	return req.builder.commit(fmt.Sprintf("USER %v", req.args))
+	req.state.runConfig.User = req.args[0]
+	return req.builder.commit(req.state, fmt.Sprintf("USER %v", req.args))
 }
 
 // VOLUME /foo
@@ -668,17 +676,18 @@ func volume(req dispatchRequest) error {
 		return err
 	}
 
-	if req.runConfig.Volumes == nil {
-		req.runConfig.Volumes = map[string]struct{}{}
+	runConfig := req.state.runConfig
+	if runConfig.Volumes == nil {
+		runConfig.Volumes = map[string]struct{}{}
 	}
 	for _, v := range req.args {
 		v = strings.TrimSpace(v)
 		if v == "" {
 			return errors.New("VOLUME specified can not be an empty string")
 		}
-		req.runConfig.Volumes[v] = struct{}{}
+		runConfig.Volumes[v] = struct{}{}
 	}
-	return req.builder.commit(fmt.Sprintf("VOLUME %v", req.args))
+	return req.builder.commit(req.state, fmt.Sprintf("VOLUME %v", req.args))
 }
 
 // STOPSIGNAL signal
@@ -695,8 +704,8 @@ func stopSignal(req dispatchRequest) error {
 		return err
 	}
 
-	req.runConfig.StopSignal = sig
-	return req.builder.commit(fmt.Sprintf("STOPSIGNAL %v", req.args))
+	req.state.runConfig.StopSignal = sig
+	return req.builder.commit(req.state, fmt.Sprintf("STOPSIGNAL %v", req.args))
 }
 
 // ARG name[=value]
@@ -742,11 +751,11 @@ func arg(req dispatchRequest) error {
 	req.builder.buildArgs.AddArg(name, value)
 
 	// Arg before FROM doesn't add a layer
-	if !req.builder.hasFromImage() {
+	if !req.state.hasFromImage() {
 		req.builder.buildArgs.AddMetaArg(name, value)
 		return nil
 	}
-	return req.builder.commit("ARG " + arg)
+	return req.builder.commit(req.state, "ARG "+arg)
 }
 
 // SHELL powershell -command
@@ -763,12 +772,12 @@ func shell(req dispatchRequest) error {
 		return errAtLeastOneArgument("SHELL")
 	case req.attributes["json"]:
 		// SHELL ["powershell", "-command"]
-		req.runConfig.Shell = strslice.StrSlice(shellSlice)
+		req.state.runConfig.Shell = strslice.StrSlice(shellSlice)
 	default:
 		// SHELL powershell -command - not JSON
 		return errNotJSON("SHELL", req.original)
 	}
-	return req.builder.commit(fmt.Sprintf("SHELL %v", shellSlice))
+	return req.builder.commit(req.state, fmt.Sprintf("SHELL %v", shellSlice))
 }
 
 func errAtLeastOneArgument(command string) error {

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -26,7 +26,7 @@ type commandWithFunction struct {
 
 func withArgs(f dispatcher) func([]string) error {
 	return func(args []string) error {
-		return f(dispatchRequest{args: args, runConfig: &container.Config{}})
+		return f(dispatchRequest{args: args})
 	}
 }
 
@@ -38,17 +38,16 @@ func withBuilderAndArgs(builder *Builder, f dispatcher) func([]string) error {
 
 func defaultDispatchReq(builder *Builder, args ...string) dispatchRequest {
 	return dispatchRequest{
-		builder:   builder,
-		args:      args,
-		flags:     NewBFlags(),
-		runConfig: &container.Config{},
-		shlex:     NewShellLex(parser.DefaultEscapeToken),
+		builder: builder,
+		args:    args,
+		flags:   NewBFlags(),
+		shlex:   NewShellLex(parser.DefaultEscapeToken),
+		state:   &dispatchState{runConfig: &container.Config{}},
 	}
 }
 
 func newBuilderWithMockBackend() *Builder {
 	b := &Builder{
-		runConfig:     &container.Config{},
 		options:       &types.ImageBuildOptions{},
 		docker:        &MockBackend{},
 		buildArgs:     newBuildArgs(make(map[string]*string)),
@@ -138,7 +137,7 @@ func TestEnv2Variables(t *testing.T) {
 		fmt.Sprintf("%s=%s", args[0], args[1]),
 		fmt.Sprintf("%s=%s", args[2], args[3]),
 	}
-	assert.Equal(t, expected, req.runConfig.Env)
+	assert.Equal(t, expected, req.state.runConfig.Env)
 }
 
 func TestEnvValueWithExistingRunConfigEnv(t *testing.T) {
@@ -146,7 +145,7 @@ func TestEnvValueWithExistingRunConfigEnv(t *testing.T) {
 
 	args := []string{"var1", "val1"}
 	req := defaultDispatchReq(b, args...)
-	req.runConfig.Env = []string{"var1=old", "var2=fromenv"}
+	req.state.runConfig.Env = []string{"var1=old", "var2=fromenv"}
 	err := env(req)
 	require.NoError(t, err)
 
@@ -154,16 +153,17 @@ func TestEnvValueWithExistingRunConfigEnv(t *testing.T) {
 		fmt.Sprintf("%s=%s", args[0], args[1]),
 		"var2=fromenv",
 	}
-	assert.Equal(t, expected, req.runConfig.Env)
+	assert.Equal(t, expected, req.state.runConfig.Env)
 }
 
 func TestMaintainer(t *testing.T) {
 	maintainerEntry := "Some Maintainer <maintainer@example.com>"
 
 	b := newBuilderWithMockBackend()
-	err := maintainer(defaultDispatchReq(b, maintainerEntry))
+	req := defaultDispatchReq(b, maintainerEntry)
+	err := maintainer(req)
 	require.NoError(t, err)
-	assert.Equal(t, maintainerEntry, b.maintainer)
+	assert.Equal(t, maintainerEntry, req.state.maintainer)
 }
 
 func TestLabel(t *testing.T) {
@@ -176,13 +176,14 @@ func TestLabel(t *testing.T) {
 	err := label(req)
 	require.NoError(t, err)
 
-	require.Contains(t, req.runConfig.Labels, labelName)
-	assert.Equal(t, req.runConfig.Labels[labelName], labelValue)
+	require.Contains(t, req.state.runConfig.Labels, labelName)
+	assert.Equal(t, req.state.runConfig.Labels[labelName], labelValue)
 }
 
 func TestFromScratch(t *testing.T) {
 	b := newBuilderWithMockBackend()
-	err := from(defaultDispatchReq(b, "scratch"))
+	req := defaultDispatchReq(b, "scratch")
+	err := from(req)
 
 	if runtime.GOOS == "windows" {
 		assert.EqualError(t, err, "Windows does not support FROM scratch")
@@ -190,8 +191,8 @@ func TestFromScratch(t *testing.T) {
 	}
 
 	require.NoError(t, err)
-	assert.Equal(t, "", b.image)
-	assert.Equal(t, true, b.noBaseImage)
+	assert.Equal(t, "", req.state.imageID)
+	assert.Equal(t, true, req.state.noBaseImage)
 }
 
 func TestFromWithArg(t *testing.T) {
@@ -205,11 +206,12 @@ func TestFromWithArg(t *testing.T) {
 	b.docker.(*MockBackend).getImageOnBuildFunc = getImage
 
 	require.NoError(t, arg(defaultDispatchReq(b, "THETAG="+tag)))
-	err := from(defaultDispatchReq(b, "alpine${THETAG}"))
+	req := defaultDispatchReq(b, "alpine${THETAG}")
+	err := from(req)
 
 	require.NoError(t, err)
-	assert.Equal(t, expected, b.image)
-	assert.Equal(t, expected, b.from.ImageID())
+	assert.Equal(t, expected, req.state.imageID)
+	assert.Equal(t, expected, req.state.baseImage.ImageID())
 	assert.Len(t, b.buildArgs.GetAllAllowed(), 0)
 	assert.Len(t, b.buildArgs.GetAllMeta(), 1)
 }
@@ -225,9 +227,10 @@ func TestFromWithUndefinedArg(t *testing.T) {
 	b.docker.(*MockBackend).getImageOnBuildFunc = getImage
 	b.options.BuildArgs = map[string]*string{"THETAG": &tag}
 
-	err := from(defaultDispatchReq(b, "alpine${THETAG}"))
+	req := defaultDispatchReq(b, "alpine${THETAG}")
+	err := from(req)
 	require.NoError(t, err)
-	assert.Equal(t, expected, b.image)
+	assert.Equal(t, expected, req.state.imageID)
 }
 
 func TestOnbuildIllegalTriggers(t *testing.T) {
@@ -249,11 +252,11 @@ func TestOnbuild(t *testing.T) {
 
 	req := defaultDispatchReq(b, "ADD", ".", "/app/src")
 	req.original = "ONBUILD ADD . /app/src"
-	req.runConfig = &container.Config{}
+	req.state.runConfig = &container.Config{}
 
 	err := onbuild(req)
 	require.NoError(t, err)
-	assert.Equal(t, "ADD . /app/src", req.runConfig.OnBuild[0])
+	assert.Equal(t, "ADD . /app/src", req.state.runConfig.OnBuild[0])
 }
 
 func TestWorkdir(t *testing.T) {
@@ -266,7 +269,7 @@ func TestWorkdir(t *testing.T) {
 	req := defaultDispatchReq(b, workingDir)
 	err := workdir(req)
 	require.NoError(t, err)
-	assert.Equal(t, workingDir, req.runConfig.WorkingDir)
+	assert.Equal(t, workingDir, req.state.runConfig.WorkingDir)
 }
 
 func TestCmd(t *testing.T) {
@@ -284,8 +287,8 @@ func TestCmd(t *testing.T) {
 		expectedCommand = strslice.StrSlice(append([]string{"/bin/sh"}, "-c", command))
 	}
 
-	assert.Equal(t, expectedCommand, req.runConfig.Cmd)
-	assert.True(t, b.cmdSet)
+	assert.Equal(t, expectedCommand, req.state.runConfig.Cmd)
+	assert.True(t, req.state.cmdSet)
 }
 
 func TestHealthcheckNone(t *testing.T) {
@@ -295,8 +298,8 @@ func TestHealthcheckNone(t *testing.T) {
 	err := healthcheck(req)
 	require.NoError(t, err)
 
-	require.NotNil(t, req.runConfig.Healthcheck)
-	assert.Equal(t, []string{"NONE"}, req.runConfig.Healthcheck.Test)
+	require.NotNil(t, req.state.runConfig.Healthcheck)
+	assert.Equal(t, []string{"NONE"}, req.state.runConfig.Healthcheck.Test)
 }
 
 func TestHealthcheckCmd(t *testing.T) {
@@ -307,9 +310,9 @@ func TestHealthcheckCmd(t *testing.T) {
 	err := healthcheck(req)
 	require.NoError(t, err)
 
-	require.NotNil(t, req.runConfig.Healthcheck)
+	require.NotNil(t, req.state.runConfig.Healthcheck)
 	expectedTest := []string{"CMD-SHELL", "curl -f http://localhost/ || exit 1"}
-	assert.Equal(t, expectedTest, req.runConfig.Healthcheck.Test)
+	assert.Equal(t, expectedTest, req.state.runConfig.Healthcheck.Test)
 }
 
 func TestEntrypoint(t *testing.T) {
@@ -319,7 +322,7 @@ func TestEntrypoint(t *testing.T) {
 	req := defaultDispatchReq(b, entrypointCmd)
 	err := entrypoint(req)
 	require.NoError(t, err)
-	require.NotNil(t, req.runConfig.Entrypoint)
+	require.NotNil(t, req.state.runConfig.Entrypoint)
 
 	var expectedEntrypoint strslice.StrSlice
 	if runtime.GOOS == "windows" {
@@ -327,7 +330,7 @@ func TestEntrypoint(t *testing.T) {
 	} else {
 		expectedEntrypoint = strslice.StrSlice(append([]string{"/bin/sh"}, "-c", entrypointCmd))
 	}
-	assert.Equal(t, expectedEntrypoint, req.runConfig.Entrypoint)
+	assert.Equal(t, expectedEntrypoint, req.state.runConfig.Entrypoint)
 }
 
 func TestExpose(t *testing.T) {
@@ -338,12 +341,12 @@ func TestExpose(t *testing.T) {
 	err := expose(req)
 	require.NoError(t, err)
 
-	require.NotNil(t, req.runConfig.ExposedPorts)
-	require.Len(t, req.runConfig.ExposedPorts, 1)
+	require.NotNil(t, req.state.runConfig.ExposedPorts)
+	require.Len(t, req.state.runConfig.ExposedPorts, 1)
 
 	portsMapping, err := nat.ParsePortSpec(exposedPort)
 	require.NoError(t, err)
-	assert.Contains(t, req.runConfig.ExposedPorts, portsMapping[0].Port)
+	assert.Contains(t, req.state.runConfig.ExposedPorts, portsMapping[0].Port)
 }
 
 func TestUser(t *testing.T) {
@@ -353,7 +356,7 @@ func TestUser(t *testing.T) {
 	req := defaultDispatchReq(b, userCommand)
 	err := user(req)
 	require.NoError(t, err)
-	assert.Equal(t, userCommand, req.runConfig.User)
+	assert.Equal(t, userCommand, req.state.runConfig.User)
 }
 
 func TestVolume(t *testing.T) {
@@ -365,9 +368,9 @@ func TestVolume(t *testing.T) {
 	err := volume(req)
 	require.NoError(t, err)
 
-	require.NotNil(t, req.runConfig.Volumes)
-	assert.Len(t, req.runConfig.Volumes, 1)
-	assert.Contains(t, req.runConfig.Volumes, exposedVolume)
+	require.NotNil(t, req.state.runConfig.Volumes)
+	assert.Len(t, req.state.runConfig.Volumes, 1)
+	assert.Contains(t, req.state.runConfig.Volumes, exposedVolume)
 }
 
 func TestStopSignal(t *testing.T) {
@@ -377,7 +380,7 @@ func TestStopSignal(t *testing.T) {
 	req := defaultDispatchReq(b, signal)
 	err := stopSignal(req)
 	require.NoError(t, err)
-	assert.Equal(t, signal, req.runConfig.StopSignal)
+	assert.Equal(t, signal, req.state.runConfig.StopSignal)
 }
 
 func TestArg(t *testing.T) {
@@ -405,7 +408,7 @@ func TestShell(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedShell := strslice.StrSlice([]string{shellCmd})
-	assert.Equal(t, expectedShell, req.runConfig.Shell)
+	assert.Equal(t, expectedShell, req.state.runConfig.Shell)
 }
 
 func TestParseOptInterval(t *testing.T) {
@@ -439,8 +442,9 @@ func TestRunWithBuildArgs(t *testing.T) {
 	b.buildArgs.argsFromOptions["HTTP_PROXY"] = strPtr("FOO")
 	b.disableCommit = false
 
+	runConfig := &container.Config{}
 	origCmd := strslice.StrSlice([]string{"cmd", "in", "from", "image"})
-	cmdWithShell := strslice.StrSlice(append(getShell(b.runConfig), "echo foo"))
+	cmdWithShell := strslice.StrSlice(append(getShell(runConfig), "echo foo"))
 	envVars := []string{"|1", "one=two"}
 	cachedCmd := strslice.StrSlice(append(envVars, cmdWithShell...))
 
@@ -477,12 +481,10 @@ func TestRunWithBuildArgs(t *testing.T) {
 	req := defaultDispatchReq(b, "abcdef")
 	require.NoError(t, from(req))
 	b.buildArgs.AddArg("one", strPtr("two"))
-	// TODO: this can be removed with b.runConfig
-	req.runConfig.Cmd = origCmd
 
 	req.args = []string{"echo foo"}
 	require.NoError(t, run(req))
 
 	// Check that runConfig.Cmd has not been modified by run
-	assert.Equal(t, origCmd, b.runConfig.Cmd)
+	assert.Equal(t, origCmd, req.state.runConfig.Cmd)
 }

--- a/builder/dockerfile/imagecontext.go
+++ b/builder/dockerfile/imagecontext.go
@@ -19,11 +19,10 @@ type pathCache interface {
 // imageContexts is a helper for stacking up built image rootfs and reusing
 // them as contexts
 type imageContexts struct {
-	b           *Builder
-	list        []*imageMount
-	byName      map[string]*imageMount
-	cache       pathCache
-	currentName string
+	b      *Builder
+	list   []*imageMount
+	byName map[string]*imageMount
+	cache  pathCache
 }
 
 func (ic *imageContexts) newImageMount(id string) *imageMount {
@@ -41,7 +40,6 @@ func (ic *imageContexts) add(name string) (*imageMount, error) {
 		}
 		ic.byName[name] = im
 	}
-	ic.currentName = name
 	ic.list = append(ic.list, im)
 	return im, nil
 }
@@ -94,13 +92,6 @@ func (ic *imageContexts) unmount() (retErr error) {
 		}
 	}
 	return
-}
-
-func (ic *imageContexts) isCurrentTarget(target string) bool {
-	if target == "" {
-		return false
-	}
-	return strings.EqualFold(ic.currentName, target)
 }
 
 func (ic *imageContexts) getCache(id, path string) (interface{}, bool) {


### PR DESCRIPTION
Remove dispatch state from `Builder` and move it to a new `dispatchResult` struct. 

With this change we are very close to removing all the dispatch state from the Builder struct, which would let us run multiple build stages using the same Builder. I think the only remaining state is: `buildArgs`, `cacheBusted` and `tmpContainers`.  I'm going to look at those next.