### PR TITLE
Respect tar entries modes when rewriting them on Windows

### DIFF
--- a/builder/remotecontext/tarsum_test.go
+++ b/builder/remotecontext/tarsum_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/docker/docker/builder"
@@ -48,7 +47,7 @@ func TestHashFile(t *testing.T) {
 	contextDir, cleanup := createTestTempDir(t, "", "builder-tarsum-test")
 	defer cleanup()
 
-	createTestTempFile(t, contextDir, filename, contents, 0777)
+	createTestTempFile(t, contextDir, filename, contents, 0755)
 
 	tarSum := makeTestTarsumContext(t, contextDir)
 
@@ -63,9 +62,6 @@ func TestHashFile(t *testing.T) {
 	}
 
 	expected := "1149ab94af7be6cc1da1335e398f24ee1cf4926b720044d229969dfc248ae7ec"
-	if runtime.GOOS == "windows" {
-		expected = "55dfeb344351ab27f59aa60ebb0ed12025a2f2f4677bf77d26ea7a671274a9ca"
-	}
 
 	if actual := sum; expected != actual {
 		t.Fatalf("invalid checksum. expected %s, got %s", expected, actual)
@@ -77,12 +73,12 @@ func TestHashSubdir(t *testing.T) {
 	defer cleanup()
 
 	contextSubdir := filepath.Join(contextDir, "builder-tarsum-test-subdir")
-	err := os.Mkdir(contextSubdir, 0700)
+	err := os.Mkdir(contextSubdir, 0755)
 	if err != nil {
 		t.Fatalf("Failed to make directory: %s", contextSubdir)
 	}
 
-	testFilename := createTestTempFile(t, contextSubdir, filename, contents, 0777)
+	testFilename := createTestTempFile(t, contextSubdir, filename, contents, 0755)
 
 	tarSum := makeTestTarsumContext(t, contextDir)
 
@@ -103,9 +99,6 @@ func TestHashSubdir(t *testing.T) {
 	}
 
 	expected := "d7f8d6353dee4816f9134f4156bf6a9d470fdadfb5d89213721f7e86744a4e69"
-	if runtime.GOOS == "windows" {
-		expected = "74a3326b8e766ce63a8e5232f22e9dd895be647fb3ca7d337e5e0a9b3da8ef28"
-	}
 
 	if actual := sum; expected != actual {
 		t.Fatalf("invalid checksum. expected %s, got %s", expected, actual)

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -42,11 +42,14 @@ func CanonicalTarNameForPath(p string) (string, error) {
 // chmodTarEntry is used to adjust the file permissions used in tar header based
 // on the platform the archival is done.
 func chmodTarEntry(perm os.FileMode) os.FileMode {
-	perm &= 0755
+	//perm &= 0755 // this 0-ed out tar flags (like link, regular file, directory marker etc.)
+	permPart := perm & os.ModePerm
+	noPermPart := perm &^ os.ModePerm
 	// Add the x bit: make everything +x from windows
-	perm |= 0111
+	permPart |= 0111
+	permPart &= 0755
 
-	return perm
+	return noPermPart | permPart
 }
 
 func setHeaderForSpecialDevice(hdr *tar.Header, name string, stat interface{}) (err error) {

--- a/pkg/archive/archive_windows_test.go
+++ b/pkg/archive/archive_windows_test.go
@@ -82,6 +82,8 @@ func TestChmodTarEntry(t *testing.T) {
 		{0644, 0755},
 		{0755, 0755},
 		{0444, 0555},
+		{0755 | os.ModeDir, 0755 | os.ModeDir},
+		{0755 | os.ModeSymlink, 0755 | os.ModeSymlink},
 	}
 	for _, v := range cases {
 		if out := chmodTarEntry(v.in); out != v.expected {


### PR DESCRIPTION
Previously, only perm-related bits where preserved when rewriting
FileMode in tar entries on Windows. This had the nasty side effect of
having tarsum returning different values when executing from a tar filed
produced on Windows or Linux.

This fix the issue, and pave the way for incremental build context
to work in hybrid contexts.

Signed-off-by: Simon Ferquel <simon.ferquel@docker.com>

**- What I did**

Modified the chmodTarEntry function on Windows, to copy without any modification bits not related with file permissions

**- How I did it**

Combination of bitmasks

**- How to verify it**

Unit tests are included:
 - modified TestChmodTarEntry to add cases where the dir flag / symlink flags are present and should be present in the result
 - modified tarsum related tests to make sure Windows computes the same tarsums than on Linux (I made sure to create everything with 755 permissions, so that the chmodTarEntry windows implementation has no effect and should produce the exact same tarentry than on Linux.

**- Description for the changelog**

Fixed an issue in tar packaging on Windows where some entries did not have the correct flags

**- A picture of a cute animal (not mandatory but encouraged)**
![Image of ninjacat](http://files.tested.com/photos/2015/03/12/73969-ninja-cat.jpg)
