### PR TITLE
seccomp: Allow personality with UNAME26 bit set.

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -406,6 +406,40 @@
 			"args": [
 				{
 					"index": 0,
+					"value": 131072,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 131080,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
 					"value": 4294967295,
 					"valueTwo": 0,
 					"op": "SCMP_CMP_EQ"

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -383,6 +383,28 @@ func DefaultProfile() *types.Seccomp {
 			Args: []*types.Arg{
 				{
 					Index: 0,
+					Value: 0x20000,
+					Op:    types.OpEqualTo,
+				},
+			},
+		},
+		{
+			Names:  []string{"personality"},
+			Action: types.ActAllow,
+			Args: []*types.Arg{
+				{
+					Index: 0,
+					Value: 0x20008,
+					Op:    types.OpEqualTo,
+				},
+			},
+		},
+		{
+			Names:  []string{"personality"},
+			Action: types.ActAllow,
+			Args: []*types.Arg{
+				{
+					Index: 0,
 					Value: 0xffffffff,
 					Op:    types.OpEqualTo,
 				},


### PR DESCRIPTION
From personality(2):

    Have uname(2) report a 2.6.40+ version number rather than a 3.x version
    number.  Added as a stopgap measure to support broken applications that
    could not handle the  kernel  version-numbering  switch  from 2.6.x to 3.x.

This allows both "`UNAME26|PER_LINUX`" and "`UNAME26|PER_LINUX32`".

Fixes: #32839

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added `UNAME26` to allowable calls to `personality(2)`

**- How I did it**

Editing the seccomp profile then running `go generate github.com/moby/moby/profiles/seccomp`

**- How to verify it**

`docker run -t --rm debian setarch $(arch) --uname-2.6 uname -a` should return a `2.6.X` instead of `4.x`. For me it returns `2.6.69-2-amd64` rather than `4.9.0-2-amd64`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Support use of `setarch --uname-2.6` in containers.


**- A picture of a cute animal (not mandatory but encouraged)**
Spider Kitten:
![Spider Kitten](http://www.metal-archives.com/images/1/1/2/1/112185_photo.jpg?2230)
