### PR TITLE
client: Allow Proxy Configuration in config.json

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -40,6 +40,15 @@ type ConfigFile struct {
 	SecretFormat         string                      `json:"secretFormat,omitempty"`
 	NodesFormat          string                      `json:"nodesFormat,omitempty"`
 	PruneFilters         []string                    `json:"pruneFilters,omitempty"`
+	Proxies              map[string]ProxyConfig      `json:"proxies,omitempty"`
+}
+
+// ProxyConfig contains proxy configuration settings
+type ProxyConfig struct {
+	HTTPProxy  string `json:"httpProxy,omitempty"`
+	HTTPSProxy string `json:"httpsProxy,omitempty"`
+	NoProxy    string `json:"noProxy,omitempty"`
+	FTPProxy   string `json:"ftpProxy,omitempty"`
 }
 
 // LegacyLoadFromReader reads the non-nested configuration data given and sets up the

--- a/client/client.go
+++ b/client/client.go
@@ -224,6 +224,12 @@ func (cli *Client) UpdateClientVersion(v string) {
 
 }
 
+// ClientHost returns the host associated with this instance of the Client.
+// This operation doesn't acquire a mutex.
+func (cli *Client) ClientHost() string {
+	return cli.host
+}
+
 // ParseHost verifies that the given host strings is valid.
 func ParseHost(host string) (string, string, string, error) {
 	protoAddrParts := strings.SplitN(host, "://", 2)

--- a/client/interface.go
+++ b/client/interface.go
@@ -28,6 +28,7 @@ type CommonAPIClient interface {
 	SecretAPIClient
 	SystemAPIClient
 	VolumeAPIClient
+	ClientHost() string
 	ClientVersion() string
 	ServerVersion(ctx context.Context) (types.Version, error)
 	UpdateClientVersion(v string)

--- a/integration-cli/cli/cli.go
+++ b/integration-cli/cli/cli.go
@@ -229,3 +229,14 @@ func WithStdout(writer io.Writer) func(*icmd.Cmd) func() {
 		return nil
 	}
 }
+
+// WithConfigFile sets the location of the client config file
+func WithConfigFile(dir string) func(*icmd.Cmd) func() {
+	return func(cmd *icmd.Cmd) func() {
+		cmd.Command = append(
+			[]string{"--config", dir},
+			cmd.Command...,
+		)
+		return nil
+	}
+}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -917,6 +917,57 @@ func (s *DockerSuite) TestRunEnvironmentOverride(c *check.C) {
 	}
 }
 
+func (s *DockerSuite) TestRunEnvironmentFromConfig(c *check.C) {
+	// TODO Windows: Environment handling is different between Linux and
+	// Windows and this test relies currently on unix functionality.
+	testRequires(c, DaemonIsLinux)
+
+	tmp, err := ioutil.TempDir("", "integration-cli-")
+	c.Assert(err, checker.IsNil)
+	config := `{ "proxies": { "default": { "httpProxy": "http://127.0.0.1:9000" }}}`
+	configPath := filepath.Join(tmp, "config.json")
+	err = ioutil.WriteFile(configPath, []byte(config), 0644)
+	c.Assert(err, checker.IsNil)
+
+	result := icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "--config", tmp, "run", "busybox", "env"},
+	})
+	result.Assert(c, icmd.Success)
+
+	if !strings.Contains(result.Combined(), "http://127.0.0.1:9000") {
+		c.Fatalf("Proxy config missing from output! %s", result.Combined())
+	}
+}
+
+func (s *DockerSuite) TestRunEnvironmentFromConfigOverride(c *check.C) {
+	// TODO Windows: Environment handling is different between Linux and
+	// Windows and this test relies currently on unix functionality.
+	testRequires(c, DaemonIsLinux)
+
+	expected := "http://proxy.example.com"
+	tmp, err := ioutil.TempDir("", "integration-cli-")
+	c.Assert(err, checker.IsNil)
+	config := `{ "proxies": { "default": { "httpProxy": "http://127.0.0.1:9000" }}}`
+	configPath := filepath.Join(tmp, "config.json")
+	err = ioutil.WriteFile(configPath, []byte(config), 0644)
+	c.Assert(err, checker.IsNil)
+
+	result := icmd.RunCmd(icmd.Cmd{
+		Command: []string{dockerBinary, "--config", tmp, "run",
+			"-e", fmt.Sprintf("HTTP_PROXY=%s", expected),
+			"-e", fmt.Sprintf("http_proxy=%s", expected),
+			"busybox", "env"},
+	})
+	result.Assert(c, icmd.Success)
+
+	if strings.Contains(result.Combined(), "http://127.0.0.1:9000") {
+		c.Fatalf("Wrong Proxy config in the output! %s", result.Combined())
+	}
+	if !strings.ContainsAny(result.Combined(), expected) {
+		c.Fatalf("Expected proxy config %s, missing from output: %s", expected, result.Combined())
+	}
+}
+
 func (s *DockerSuite) TestRunContainerNetwork(c *check.C) {
 	if testEnv.DaemonPlatform() == "windows" {
 		// Windows busybox does not have ping. Use built in ping instead.


### PR DESCRIPTION
This is a redux of #30588 rebased and after the repo move!

**- What I did**

Added a mechanism to allow HTTP/HTTPS/FTP/NO proxy variables to be configured in `config.json`. These are then automatically populated in a `docker run` command as environment variables or as `build-args` in `docker build`!

This makes it easier for users suffering behind an HTTP Proxy as they only need to configure this once as opposed to creating custom aliases or forgetting the args and being denied buildage/runnage.

Updates #30323

**- How I did it**

Extended the `configfile` with some new proxy related variables.

These are scoped per Docker Host with a `default` catchall.

The config file is then read by the `build` or `run` command and the necessary variables are exported.

A `-e` flag or `--build-arg` provided on the CLI will override these default settings.

**- How to verify it**

There are integration tests! But manually, you may:

1. Create a `config.json` with `{ "proxies" : { "httpProxy" : "http://127.0.0.1:3001" }`
2. Create a Dockerfile
```
FROM busybox
RUN echo $HTTP_PROXY
CMD echo $HTTP_PROXY
```
3. `docker --config /path/to/config build -t configtest .`
4. Verify that the `HTTP_PROXY` variable is as configured
5. `docker run --rm configtest env`
6. Verify that the HTTP_PROXY variable is as configured

**- Description for the changelog**

Added HTTP/HTTPS/FTP proxy configuration to `config.json`

**- A picture of a cute animal (not mandatory but encouraged)**

![](http://media-cache-ec0.pinimg.com/736x/e1/8c/21/e18c21aedb909d3553d4eae6e9c8961b.jpg)