### PR TITLE
Adding csv format parameters to network option in service create/update

### DIFF
--- a/opts/network.go
+++ b/opts/network.go
@@ -1,0 +1,77 @@
+package opts
+
+import (
+	"encoding/csv"
+	"fmt"
+	"github.com/docker/docker/api/types/swarm"
+	"strings"
+)
+
+const (
+	networkOptName  = "name"
+	networkOptAlias = "alias"
+	networkOptIP    = "ip"
+	networkOptIPv6  = "ipv6"
+)
+
+// NetworkOpt represents a network config in swarm mode.
+type NetworkOpt struct {
+	networkAttachments []swarm.NetworkAttachmentConfig
+}
+
+// Set networkopts value
+func (n *NetworkOpt) Set(value string) error {
+	csvReader := csv.NewReader(strings.NewReader(value))
+	fields, err := csvReader.Read()
+	if err != nil {
+		return err
+	}
+	var netAttach swarm.NetworkAttachmentConfig
+	for _, field := range fields {
+		parts := strings.SplitN(field, "=", 2)
+		//Support legacy non csv format
+		if len(parts) == 1 {
+			netAttach.Target = parts[0]
+			break
+		}
+
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid field %s", field)
+		}
+
+		key := strings.TrimSpace(strings.ToLower(parts[0]))
+		value := strings.TrimSpace(strings.ToLower(parts[1]))
+
+		switch key {
+		case networkOptName:
+			netAttach.Target = value
+		case networkOptAlias:
+			netAttach.Aliases = append(netAttach.Aliases, value)
+		default:
+			return fmt.Errorf("invalid field key %s", key)
+		}
+	}
+	n.networkAttachments = append(n.networkAttachments, netAttach)
+
+	return nil
+}
+
+// Type returns the type of this option
+func (n *NetworkOpt) Type() string {
+	return "network"
+}
+
+// Value returns the networkopts
+func (n *NetworkOpt) Value() []swarm.NetworkAttachmentConfig {
+	return n.networkAttachments
+}
+
+// String returns the network opts as a string
+func (n *NetworkOpt) String() string {
+	networks := []string{}
+	for _, network := range n.networkAttachments {
+		str := fmt.Sprintf("%s:%s", network.Target, strings.Join(network.Aliases, "/"))
+		networks = append(networks, str)
+	}
+	return strings.Join(networks, ",")
+}

--- a/opts/network_test.go
+++ b/opts/network_test.go
@@ -1,0 +1,111 @@
+package opts
+
+import (
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestNetworkOptLegacySyntax(t *testing.T) {
+	testCases := []struct {
+		value    string
+		expected []swarm.NetworkAttachmentConfig
+	}{
+		{
+			value: "docknet1",
+			expected: []swarm.NetworkAttachmentConfig{
+				{
+					Target: "docknet1",
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		var network NetworkOpt
+		assert.NoError(t, network.Set(tc.value))
+		assert.Len(t, network.Value(), len(tc.expected))
+		for _, expectedNetConfig := range tc.expected {
+			verifyNetworkOpt(t, network.Value(), expectedNetConfig)
+		}
+	}
+}
+
+func TestNetworkOptCompleteSyntax(t *testing.T) {
+	testCases := []struct {
+		value    string
+		expected []swarm.NetworkAttachmentConfig
+	}{
+		{
+			value: "name=docknet1,alias=web",
+			expected: []swarm.NetworkAttachmentConfig{
+				{
+					Target:  "docknet1",
+					Aliases: []string{"web"},
+				},
+			},
+		},
+		{
+			value: "name=docknet1,alias=web1,alias=web2",
+			expected: []swarm.NetworkAttachmentConfig{
+				{
+					Target:  "docknet1",
+					Aliases: []string{"web1", "web2"},
+				},
+			},
+		},
+		{
+			value: "name=docknet1",
+			expected: []swarm.NetworkAttachmentConfig{
+				{
+					Target:  "docknet1",
+					Aliases: []string{},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		var network NetworkOpt
+		assert.NoError(t, network.Set(tc.value))
+		assert.Len(t, network.Value(), len(tc.expected))
+		for _, expectedNetConfig := range tc.expected {
+			verifyNetworkOpt(t, network.Value(), expectedNetConfig)
+		}
+	}
+}
+
+func TestNetworkOptInvalidSyntax(t *testing.T) {
+	testCases := []struct {
+		value         string
+		expectedError string
+	}{
+		{
+			value:         "invalidField=docknet1",
+			expectedError: "invalid field",
+		},
+		{
+			value:         "network=docknet1,invalid=web",
+			expectedError: "invalid field",
+		},
+	}
+	for _, tc := range testCases {
+		var network NetworkOpt
+		testutil.ErrorContains(t, network.Set(tc.value), tc.expectedError)
+	}
+}
+
+func verifyNetworkOpt(t *testing.T, netConfigs []swarm.NetworkAttachmentConfig, expected swarm.NetworkAttachmentConfig) {
+	var contains = false
+	for _, netConfig := range netConfigs {
+		if netConfig.Target == expected.Target {
+			if strings.Join(netConfig.Aliases, ",") == strings.Join(expected.Aliases, ",") {
+				contains = true
+				break
+			}
+		}
+	}
+	if !contains {
+		t.Errorf("expected %v to contain %v, did not", netConfigs, expected)
+	}
+}


### PR DESCRIPTION
**- What I did**
Added capability to service create/update  to accept network option in csv format and add test case to verify the same.

**- How I did it**
Changed `--network` , `--network-add` options to accept csv format key/value by create a new network option type. 

**- How to verify it**

```
docker service create --name web --network name=docknet,alias=web1,alias=web2 nginx
docker service create --name web --network docknet nginx
docker service update web --network-add name=docknet,alias=web1
docker service update web --network-rm docknet
```

**- A picture of a cute animal (not mandatory but encouraged)**

![polar-bear](https://cloud.githubusercontent.com/assets/784144/25640747/acccb80c-2f45-11e7-8dc5-188ee564964e.jpg)
