### PR TITLE
Add container state count metrics

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -34,7 +34,6 @@ import (
 	"github.com/docker/docker/daemon/stats"
 	dmetadata "github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/distribution/xfer"
-	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/libcontainerd"
@@ -728,19 +727,7 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 		return nil, err
 	}
 
-	// FIXME: this method never returns an error
-	info, _ := d.SystemInfo()
-
-	engineVersion.WithValues(
-		dockerversion.Version,
-		dockerversion.GitCommit,
-		info.Architecture,
-		info.Driver,
-		info.KernelVersion,
-		info.OperatingSystem,
-	).Set(1)
-	engineCpus.Set(float64(info.NCPU))
-	engineMemory.Set(float64(info.MemTotal))
+	d.setupMetrics()
 
 	return d, nil
 }

--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -1,8 +1,17 @@
 package daemon
 
-import "github.com/docker/go-metrics"
+import (
+	"sync"
+
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/dockerversion"
+	"github.com/docker/go-metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 var (
+	daemonMetrics *metrics.Namespace
+
 	containerActions          metrics.LabeledTimer
 	imageActions              metrics.LabeledTimer
 	networkActions            metrics.LabeledTimer
@@ -14,8 +23,8 @@ var (
 )
 
 func init() {
-	ns := metrics.NewNamespace("engine", "daemon", nil)
-	containerActions = ns.NewLabeledTimer("container_actions", "The number of seconds it takes to process each container action", "action")
+	daemonMetrics = metrics.NewNamespace("engine", "daemon", nil)
+	containerActions = daemonMetrics.NewLabeledTimer("container_actions", "The number of seconds it takes to process each container action", "action")
 	for _, a := range []string{
 		"start",
 		"changes",
@@ -25,18 +34,64 @@ func init() {
 	} {
 		containerActions.WithValues(a).Update(0)
 	}
-	networkActions = ns.NewLabeledTimer("network_actions", "The number of seconds it takes to process each network action", "action")
-	engineVersion = ns.NewLabeledGauge("engine", "The version and commit information for the engine process", metrics.Unit("info"),
+	networkActions = daemonMetrics.NewLabeledTimer("network_actions", "The number of seconds it takes to process each network action", "action")
+	engineVersion = daemonMetrics.NewLabeledGauge("engine", "The version and commit information for the engine process", metrics.Unit("info"),
 		"version",
 		"commit",
 		"architecture",
-		"graph_driver", "kernel",
+		"graph_driver",
+		"kernel",
 		"os",
 	)
-	engineCpus = ns.NewGauge("engine_cpus", "The number of cpus that the host system of the engine has", metrics.Unit("cpus"))
-	engineMemory = ns.NewGauge("engine_memory", "The number of bytes of memory that the host system of the engine has", metrics.Bytes)
-	healthChecksCounter = ns.NewCounter("health_checks", "The total number of health checks")
-	healthChecksFailedCounter = ns.NewCounter("health_checks_failed", "The total number of failed health checks")
-	imageActions = ns.NewLabeledTimer("image_actions", "The number of seconds it takes to process each image action", "action")
-	metrics.Register(ns)
+	engineCpus = daemonMetrics.NewGauge("engine_cpus", "The number of cpus that the host system of the engine has", metrics.Unit("cpus"))
+	engineMemory = daemonMetrics.NewGauge("engine_memory", "The number of bytes of memory that the host system of the engine has", metrics.Bytes)
+	healthChecksCounter = daemonMetrics.NewCounter("health_checks", "The total number of health checks")
+	healthChecksFailedCounter = daemonMetrics.NewCounter("health_checks_failed", "The total number of failed health checks")
+	imageActions = daemonMetrics.NewLabeledTimer("image_actions", "The number of seconds it takes to process each image action", "action")
+	metrics.Register(daemonMetrics)
+}
+
+type storeMetrics struct {
+	d                *Daemon
+	containerByState *prometheus.Desc
+}
+
+func (m *storeMetrics) Describe(ch chan<- *prometheus.Desc) {
+	ch <- m.containerByState
+}
+
+func (m *storeMetrics) Collect(ch chan<- prometheus.Metric) {
+	var mu sync.Mutex
+	states := make(map[string]int)
+	m.d.containers.ApplyAll(func(c *container.Container) {
+		mu.Lock()
+		states[c.StateString()]++
+		mu.Unlock()
+	})
+
+	for state, count := range states {
+		ch <- prometheus.MustNewConstMetric(m.containerByState, prometheus.GaugeValue, float64(count), state)
+	}
+}
+
+func (daemon *Daemon) setupMetrics() {
+	sm := &storeMetrics{
+		d:                daemon,
+		containerByState: daemonMetrics.NewDesc("container_by_state", "Number of containers by state", metrics.Total, "state"),
+	}
+	daemonMetrics.Add(sm)
+
+	// FIXME: this method never returns an error
+	info, _ := daemon.SystemInfo()
+
+	engineVersion.WithValues(
+		dockerversion.Version,
+		dockerversion.GitCommit,
+		info.Architecture,
+		info.Driver,
+		info.KernelVersion,
+		info.OperatingSystem,
+	).Set(1)
+	engineCpus.Set(float64(info.NCPU))
+	engineMemory.Set(float64(info.MemTotal))
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -136,7 +136,7 @@ github.com/flynn-archive/go-shlex 3f9db97f856818214da2e1057f8ad84803971cff
 github.com/Nvveen/Gotty a8b993ba6abdb0e0c12b0125c603323a71c7790c https://github.com/ijc25/Gotty
 
 # metrics
-github.com/docker/go-metrics 86138d05f285fd9737a99bee2d9be30866b59d72
+github.com/docker/go-metrics 8fd5772bf1584597834c6f7961a530f06cbfbb87
 
 # composefile
 github.com/mitchellh/mapstructure f3009df150dadf309fdee4a54ed65c124afad715

--- a/vendor/github.com/docker/go-metrics/README.md
+++ b/vendor/github.com/docker/go-metrics/README.md
@@ -2,10 +2,67 @@
 
 This package is small wrapper around the prometheus go client to help enforce convention and best practices for metrics collection in Docker projects.
 
-## Status
+## Best Practices
 
-This project is a work in progress.
-It is under heavy development and not intended to be used.
+This packages is meant to be used for collecting metrics in Docker projects.
+It is not meant to be used as a replacement for the prometheus client but to help enforce consistent naming across metrics collected.
+If you have not already read the prometheus best practices around naming and labels you can read the page [here](https://prometheus.io/docs/practices/naming/).
+
+The following are a few Docker specific rules that will help you name and work with metrics in your project.
+
+1. Namespace and Subsystem
+
+This package provides you with a namespace type that allows you to specify the same namespace and subsystem for your metrics.
+
+```go
+ns := metrics.NewNamespace("engine", "daemon", metrics.Labels{
+        "version": dockerversion.Version,
+        "commit":  dockerversion.GitCommit,
+})
+```
+
+In the example above we are creating metrics for the Docker engine's daemon package.
+`engine` would be the namespace in this example where `daemon` is the subsystem or package where we are collecting the metrics.
+
+A namespace also allows you to attach constant labels to the metrics such as the git commit and version that it is collecting.
+
+2. Declaring your Metrics
+
+Try to keep all your metric declarations in one file.
+This makes it easy for others to see what constant labels are defined on the namespace and what labels are defined on the metrics when they are created.
+
+3. Use labels instead of multiple metrics
+
+Labels allow you to define one metric such as the time it takes to perform a certain action on an object.
+If we wanted to collect timings on various container actions such as create, start, and delete then we can define one metric called `container_actions` and use labels to specify the type of action.
+
+
+```go
+containerActions = ns.NewLabeledTimer("container_actions", "The number of milliseconds it takes to process each container action", "action")
+```
+
+The last parameter is the label name or key.
+When adding a data point to the metric you will use the `WithValues` function to specify the `action` that you are collecting for.
+
+```go
+containerActions.WithValues("create").UpdateSince(start)
+```
+
+4. Always use a unit
+
+The metric name should describe what you are measuring but you also need to provide the unit that it is being measured with.
+For a timer, the standard unit is seconds and a counter's standard unit is a total.
+For gauges you must provide the unit.
+This package provides a standard set of units for use within the Docker projects.
+
+```go
+Nanoseconds Unit = "nanoseconds"
+Seconds     Unit = "seconds"
+Bytes       Unit = "bytes"
+Total       Unit = "total"
+```
+
+If you need to use a unit but it is not defined in the package please open a PR to add it but first try to see if one of the already created units will work for your metric, i.e. seconds or nanoseconds vs adding milliseconds.
 
 ## Docs
 

--- a/vendor/github.com/docker/go-metrics/namespace.go
+++ b/vendor/github.com/docker/go-metrics/namespace.go
@@ -40,21 +40,25 @@ type Namespace struct {
 //  Only metrics created with the returned namespace will get the new constant
 //  labels.  The returned namespace must be registered separately.
 func (n *Namespace) WithConstLabels(labels Labels) *Namespace {
-	ns := *n
-	ns.metrics = nil // blank this out
-	ns.labels = mergeLabels(ns.labels, labels)
-	return &ns
+	n.mu.Lock()
+	ns := &Namespace{
+		name:      n.name,
+		subsystem: n.subsystem,
+		labels:    mergeLabels(n.labels, labels),
+	}
+	n.mu.Unlock()
+	return ns
 }
 
 func (n *Namespace) NewCounter(name, help string) Counter {
 	c := &counter{pc: prometheus.NewCounter(n.newCounterOpts(name, help))}
-	n.addMetric(c)
+	n.Add(c)
 	return c
 }
 
 func (n *Namespace) NewLabeledCounter(name, help string, labels ...string) LabeledCounter {
 	c := &labeledCounter{pc: prometheus.NewCounterVec(n.newCounterOpts(name, help), labels)}
-	n.addMetric(c)
+	n.Add(c)
 	return c
 }
 
@@ -72,7 +76,7 @@ func (n *Namespace) NewTimer(name, help string) Timer {
 	t := &timer{
 		m: prometheus.NewHistogram(n.newTimerOpts(name, help)),
 	}
-	n.addMetric(t)
+	n.Add(t)
 	return t
 }
 
@@ -80,7 +84,7 @@ func (n *Namespace) NewLabeledTimer(name, help string, labels ...string) Labeled
 	t := &labeledTimer{
 		m: prometheus.NewHistogramVec(n.newTimerOpts(name, help), labels),
 	}
-	n.addMetric(t)
+	n.Add(t)
 	return t
 }
 
@@ -98,7 +102,7 @@ func (n *Namespace) NewGauge(name, help string, unit Unit) Gauge {
 	g := &gauge{
 		pg: prometheus.NewGauge(n.newGaugeOpts(name, help, unit)),
 	}
-	n.addMetric(g)
+	n.Add(g)
 	return g
 }
 
@@ -106,7 +110,7 @@ func (n *Namespace) NewLabeledGauge(name, help string, unit Unit, labels ...stri
 	g := &labeledGauge{
 		pg: prometheus.NewGaugeVec(n.newGaugeOpts(name, help, unit), labels),
 	}
-	n.addMetric(g)
+	n.Add(g)
 	return g
 }
 
@@ -138,10 +142,22 @@ func (n *Namespace) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-func (n *Namespace) addMetric(collector prometheus.Collector) {
+func (n *Namespace) Add(collector prometheus.Collector) {
 	n.mu.Lock()
 	n.metrics = append(n.metrics, collector)
 	n.mu.Unlock()
+}
+
+func (n *Namespace) NewDesc(name, help string, unit Unit, labels ...string) *prometheus.Desc {
+	if string(unit) != "" {
+		name = fmt.Sprintf("%s_%s", name, unit)
+	}
+	namespace := n.name
+	if n.subsystem != "" {
+		namespace = fmt.Sprintf("%s_%s", namespace, n.subsystem)
+	}
+	name = fmt.Sprintf("%s_%s", namespace, name)
+	return prometheus.NewDesc(name, help, labels, prometheus.Labels(n.labels))
 }
 
 // mergeLabels merges two or more labels objects into a single map, favoring


### PR DESCRIPTION
This adds a new labeled gauge metric that records the current count of
containers by their state: engine_daemon_container_by_state_total.

After talking with @rogaha , we decided to pull this out of his existing PR https://github.com/moby/moby/pull/32792 .
