### PR TITLE
[test] remove prefix v from apiVersion

### DIFF
--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -175,14 +175,14 @@ func (s *DockerSuite) TestAPIStatsNetworkStatsVersioning(c *check.C) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			apiVersion := fmt.Sprintf("v1.%d", i)
+			apiVersion := fmt.Sprintf("1.%d", i)
 			statsJSONBlob := getVersionedStats(c, id, apiVersion)
-			if versions.LessThan(apiVersion, "v1.21") {
+			if versions.LessThan(apiVersion, "1.21") {
 				c.Assert(jsonBlobHasLTv121NetworkStats(statsJSONBlob), checker.Equals, true,
-					check.Commentf("Stats JSON blob from API %s %#v does not look like a <v1.21 API stats structure", apiVersion, statsJSONBlob))
+					check.Commentf("Stats JSON blob from API %s %#v does not look like a < 1.21 API stats structure", apiVersion, statsJSONBlob))
 			} else {
 				c.Assert(jsonBlobHasGTE121NetworkStats(statsJSONBlob), checker.Equals, true,
-					check.Commentf("Stats JSON blob from API %s %#v does not look like a >=v1.21 API stats structure", apiVersion, statsJSONBlob))
+					check.Commentf("Stats JSON blob from API %s %#v does not look like a >= 1.21 API stats structure", apiVersion, statsJSONBlob))
 			}
 		}(i)
 	}


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

**- What I did**
In integration test, I found that apiVersion has a prefix `v`, while I think it is redundant. This PR tries to remove that.

**- How I did it**
1. remove v from apiVersion in integration test.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

