### PR TITLE
add disk usage test for client package

### DIFF
--- a/client/disk_usage_test.go
+++ b/client/disk_usage_test.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"golang.org/x/net/context"
+)
+
+func TestDiskUsageError(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	}
+	_, err := client.DiskUsage(context.Background())
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestDiskUsage(t *testing.T) {
+	expectedURL := "/system/df"
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+
+			du := types.DiskUsage{
+				LayersSize: int64(100),
+				Images:     nil,
+				Containers: nil,
+				Volumes:    nil,
+			}
+
+			b, err := json.Marshal(du)
+			if err != nil {
+				return nil, err
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}),
+	}
+	if _, err := client.DiskUsage(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I found that in moby/moby there is a package client. while in docker/cli, there is another package cli. And they are almost the same. Then for a contributor, what is the better choice to contribute, push 2 PRs, one for one repo? 

ping @thaJeztah @dnephin 

**- What I did**
1. add disk usage test for client package

**- How I did it**

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

