### PR TITLE
fix when rpc reports "transport is closing" error, health check go routine will exit

### DIFF
--- a/libcontainerd/remote_unix.go
+++ b/libcontainerd/remote_unix.go
@@ -154,7 +154,7 @@ func (r *remote) handleConnectionChange() {
 		logrus.Debugf("libcontainerd: containerd health check returned error: %v", err)
 
 		if r.daemonPid != -1 {
-			if strings.Contains(err.Error(), "is closing") {
+			if r.closeManually {
 				// Well, we asked for it to stop, just return
 				return
 			}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix a bug:
Description:
Kill docker-containerd continuously, and use kill -SIGUSR1 <dockerpid> to check docker callstacks. And we will find that event handler: `handleConnectionChange` exit.

I wrote a script: each 10 seconds I killed containerd, and run about 15 minutes, this condition appears.

looks like PR:
  https://github.com/moby/moby/pull/32590

**- How I did it**

Analysis:
When grpc connection is fall, the error maybe like this: 
```
2017-05-03T14:18:30.163173+00:00|info|docker[-]|time="2017-05-03T14:18:30.161475751Z" level=debug msg="libcontainerd: containerd health check returned error: rpc error: code = 14 desc = grpc: the connection is unavailable"
2017-05-03T14:18:38.185628+00:00|info|docker[-]|time="2017-05-03T14:18:38.185044385Z" level=debug msg="libcontainerd: containerd health check returned error: rpc error: code = 13 desc = transport is closing"
```

And the second error will make the go routine `handleConnectionChange` returned.

I think we should use `r.closeManually` not `is closing` to determine if it should return or not.

**- How to verify it**

use the script, run a long time, the go routine will not appear.

**- Description for the changelog**

Signed-off-by: Wentao Zhang <zhangwentao234@huawei.com>

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

