### PR TITLE
add swarm get unlock key test for client package

### DIFF
--- a/client/swarm_get_unlock_key_test.go
+++ b/client/swarm_get_unlock_key_test.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func TestSwarmGetUnlockKeyError(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	}
+
+	_, err := client.SwarmGetUnlockKey(context.Background())
+	testutil.ErrorContains(t, err, "Error response from daemon: Server error")
+}
+
+func TestSwarmGetUnlockKey(t *testing.T) {
+	expectedURL := "/swarm/unlockkey"
+	unlockKey := "SWMKEY-1-y6guTZNTwpQeTL5RhUfOsdBdXoQjiB2GADHSRJvbXeE"
+
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			if req.Method != "GET" {
+				return nil, fmt.Errorf("expected GET method, got %s", req.Method)
+			}
+
+			key := types.SwarmUnlockKeyResponse{
+				UnlockKey: unlockKey,
+			}
+
+			b, err := json.Marshal(key)
+			if err != nil {
+				return nil, err
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}),
+	}
+
+	resp, err := client.SwarmGetUnlockKey(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, unlockKey, resp.UnlockKey)
+}


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

add swarm get unlock key test for client package

**- What I did**
1. add swarm get unlock key test for client package

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![timg 1](https://cloud.githubusercontent.com/assets/9465626/25654131/83a35520-3022-11e7-93c7-b815297c32e5.jpeg)



