### PR TITLE
Fix a rare case where using FROM scratch as NAME would fail

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -200,7 +200,11 @@ func from(req dispatchRequest) error {
 	if err != nil {
 		return err
 	}
-	if image != nil {
+	switch image {
+	case nil:
+		req.state.imageID = ""
+		req.state.noBaseImage = true
+	default:
 		req.builder.imageContexts.update(image.ImageID(), image.RunConfig())
 	}
 	req.state.baseImage = image
@@ -248,8 +252,6 @@ func (b *Builder) getFromImage(dispatchState *dispatchState, shlex *ShellLex, na
 		if runtime.GOOS == "windows" {
 			return nil, errors.New("Windows does not support FROM scratch")
 		}
-		dispatchState.imageID = ""
-		dispatchState.noBaseImage = true
 		return nil, nil
 	}
 	return pullOrGetImage(b, name)

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -233,6 +233,21 @@ func TestFromWithUndefinedArg(t *testing.T) {
 	assert.Equal(t, expected, req.state.imageID)
 }
 
+func TestFromMultiStageWithScratchNamedStage(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not support scratch")
+	}
+	b := newBuilderWithMockBackend()
+	req := defaultDispatchReq(b, "scratch", "AS", "base")
+
+	require.NoError(t, from(req))
+	assert.True(t, req.state.hasFromImage())
+
+	req.args = []string{"base"}
+	require.NoError(t, from(req))
+	assert.True(t, req.state.hasFromImage())
+}
+
 func TestOnbuildIllegalTriggers(t *testing.T) {
 	triggers := []struct{ command, expectedError string }{
 		{"ONBUILD", "Chaining ONBUILD via `ONBUILD ONBUILD` isn't allowed"},


### PR DESCRIPTION
I think this is pretty rare, but still worth fixing. Below is an integration test that shows the failure from a Dockerfile. I don't think it's really worth adding this integration test because it's such a rare case, and we can cover it with a unit test.

The test would fail because `getFromImage()` was not setting `noBaseImage` when it received an image from `imageContexts.byName`

```go
func (s *DockerSuite) TestBuildMultiStageFromScratchBase(c *check.C) {
	name := "test_build_multi_stage_from_scratch_base"
	result := cli.Docker(cli.Build(name), build.WithDockerfile(`
		FROM scratch as base

		FROM base
		ENV  This_is_still_fine=ok
	`))
	result.Assert(c, icmd.Expected{
		Out: "This_is_still_fine",
	})
}
```