### PR TITLE
Suggest login on pull denial

### DIFF
--- a/api/server/httputils/errors.go
+++ b/api/server/httputils/errors.go
@@ -73,6 +73,7 @@ func GetHTTPErrorStatusCode(err error) int {
 			{"this node", http.StatusServiceUnavailable},
 			{"needs to be unlocked", http.StatusServiceUnavailable},
 			{"certificates have expired", http.StatusServiceUnavailable},
+			{"repository does not exist", http.StatusNotFound},
 		} {
 			if strings.Contains(errStr, status.keyword) {
 				statusCode = status.code

--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -78,7 +78,7 @@ func TranslatePullError(err error, ref reference.Named) error {
 		switch v.Code {
 		case errcode.ErrorCodeDenied:
 			// ErrorCodeDenied is used when access to the repository was denied
-			newErr = errors.Errorf("repository %s not found: does not exist or no pull access", reference.FamiliarName(ref))
+			newErr = errors.Errorf("pull access denied for %s, repository does not exist or may require 'docker login'", reference.FamiliarName(ref))
 		case v2.ErrorCodeManifestUnknown:
 			newErr = errors.Errorf("manifest for %s not found", reference.FamiliarString(ref))
 		case v2.ErrorCodeNameUnknown:

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -98,11 +98,11 @@ func (s *DockerHubPullSuite) TestPullNonExistingImage(c *check.C) {
 	for record := range recordChan {
 		if len(record.option) == 0 {
 			c.Assert(record.err, checker.NotNil, check.Commentf("expected non-zero exit status when pulling non-existing image: %s", record.out))
-			c.Assert(record.out, checker.Contains, fmt.Sprintf("repository %s not found: does not exist or no pull access", record.e.repo), check.Commentf("expected image not found error messages"))
+			c.Assert(record.out, checker.Contains, fmt.Sprintf("pull access denied for %s, repository does not exist or may require 'docker login'", record.e.repo), check.Commentf("expected image not found error messages"))
 		} else {
 			// pull -a on a nonexistent registry should fall back as well
 			c.Assert(record.err, checker.NotNil, check.Commentf("expected non-zero exit status when pulling non-existing image: %s", record.out))
-			c.Assert(record.out, checker.Contains, fmt.Sprintf("repository %s not found", record.e.repo), check.Commentf("expected image not found error messages"))
+			c.Assert(record.out, checker.Contains, fmt.Sprintf("pull access denied for %s, repository does not exist or may require 'docker login'", record.e.repo), check.Commentf("expected image not found error messages"))
 			c.Assert(record.out, checker.Not(checker.Contains), "unauthorized", check.Commentf(`message should not contain "unauthorized"`))
 		}
 	}


### PR DESCRIPTION
**- What I did**
We've seen a few new users of Docker Store subscriptions see the "no pull access" message when they try to pull content for the first time, as they don't realize they need to login first.

To improve their experience with Store, or any other registry, make the returned error suggest that `docker login` may be needed.

**- How to verify it**
Use `docker pull` with any non-existent repository, or to a known repository that requires credentials w/o providing them first.

**- Description for the changelog**
Suggest login on pull denial

