### PR TITLE
Only set DOCKER_CROSSPLATFORMS from env if it's set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ export DOCKER_GITCOMMIT
 # to allow things like `make KEEPBUNDLE=1 binary` easily
 # `project/PACKAGERS.md` have some limited documentation of some of these
 DOCKER_ENVS := \
+	$(if $(DOCKER_CROSSPLATFORMS), -e DOCKER_CROSSPLATFORMS) \
 	-e BUILD_APT_MIRROR \
 	-e BUILDFLAGS \
 	-e KEEPBUNDLE \
 	-e DOCKER_BUILD_ARGS \
 	-e DOCKER_BUILD_GOGC \
 	-e DOCKER_BUILD_PKGS \
-	-e DOCKER_CROSSPLATFORMS \
 	-e DOCKER_DEBUG \
 	-e DOCKER_EXPERIMENTAL \
 	-e DOCKER_GITCOMMIT \


### PR DESCRIPTION
This allows for the default to come from the image/`Dockerfile` rather than being unconditionally overwritten by the environment.

(See #31425, especially https://github.com/moby/moby/pull/31425#commitcomment-21597029.)

cc @vieux @xylnao @tiborvass

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://cloud.githubusercontent.com/assets/161631/25708127/6cced428-309a-11e7-808d-d3e5bd30c690.png)