### PR TITLE
[17.03.x] Remove unused filter params from Swagger

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4261,14 +4261,6 @@ paths:
       produces:
         - "application/json"
       operationId: "ContainerPrune"
-      parameters:
-        - name: "filters"
-          in: "query"
-          description: |
-            Filters to process on the prune list, encoded as JSON (a `map[string][]string`).
-
-            Available filters:
-          type: "string"
       responses:
         200:
           description: "No error"
@@ -6036,14 +6028,6 @@ paths:
       produces:
         - "application/json"
       operationId: "VolumePrune"
-      parameters:
-        - name: "filters"
-          in: "query"
-          description: |
-            Filters to process on the prune list, encoded as JSON (a `map[string][]string`).
-
-            Available filters:
-          type: "string"
       responses:
         200:
           description: "No error"
@@ -6392,14 +6376,6 @@ paths:
       produces:
         - "application/json"
       operationId: "NetworkPrune"
-      parameters:
-        - name: "filters"
-          in: "query"
-          description: |
-            Filters to process on the prune list, encoded as JSON (a `map[string][]string`).
-
-            Available filters:
-          type: "string"
       responses:
         200:
           description: "No error"


### PR DESCRIPTION
Commit 745795ef2e0089c5001e5a2fc7ba8c1ab0234857 added
a `filter` query-parameter to all "prune" endpoints,
however the parameter was only used when pruning
images.

This patch removes the filter parameter from the other
endpoints, given that it is not used for those, so
there is no reason documenting it.

relates to https://github.com/moby/moby/issues/33026
