### PR TITLE
[17.04.x] Remove unused filter param from Swagger

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6147,14 +6147,6 @@ paths:
       produces:
         - "application/json"
       operationId: "VolumePrune"
-      parameters:
-        - name: "filters"
-          in: "query"
-          description: |
-            Filters to process on the prune list, encoded as JSON (a `map[string][]string`).
-
-            Available filters:
-          type: "string"
       responses:
         200:
           description: "No error"


### PR DESCRIPTION
Commit 745795ef2e0089c5001e5a2fc7ba8c1ab0234857 added a `filter`
query-parameter to all "prune" endpoints, however the parameter was only used
when pruning images.

This patch removes the filter parameter from the volume-prune endpoint, given
that it is not used there, so there is no reason documenting it.

relates to https://github.com/moby/moby/issues/33026