### PR TITLE
Plugin save and load.

### DIFF
--- a/api/server/router/plugin/backend.go
+++ b/api/server/router/plugin/backend.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/distribution/reference"
 	enginetypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/pkg/ioutils"
 	"golang.org/x/net/context"
 )
 
@@ -23,4 +24,6 @@ type Backend interface {
 	Push(ctx context.Context, name string, metaHeaders http.Header, authConfig *enginetypes.AuthConfig, outStream io.Writer) error
 	Upgrade(ctx context.Context, ref reference.Named, name string, metaHeaders http.Header, authConfig *enginetypes.AuthConfig, privileges enginetypes.PluginPrivileges, outStream io.Writer) error
 	CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, options *enginetypes.PluginCreateOptions) error
+	SavePlugin(plugin string, output *ioutils.WriteFlusher) error
+	LoadPlugin(input io.ReadCloser, outStream io.Writer, quiet bool) error
 }

--- a/api/server/router/plugin/backend.go
+++ b/api/server/router/plugin/backend.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/distribution/reference"
 	enginetypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/pkg/ioutils"
 	"golang.org/x/net/context"
 )
 
@@ -24,6 +23,6 @@ type Backend interface {
 	Push(ctx context.Context, name string, metaHeaders http.Header, authConfig *enginetypes.AuthConfig, outStream io.Writer) error
 	Upgrade(ctx context.Context, ref reference.Named, name string, metaHeaders http.Header, authConfig *enginetypes.AuthConfig, privileges enginetypes.PluginPrivileges, outStream io.Writer) error
 	CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, options *enginetypes.PluginCreateOptions) error
-	SavePlugin(plugin string, output *ioutils.WriteFlusher) error
+	SavePlugin(plugin string, output io.Writer) error
 	LoadPlugin(input io.ReadCloser, outStream io.Writer, quiet bool) error
 }

--- a/api/server/router/plugin/backend.go
+++ b/api/server/router/plugin/backend.go
@@ -23,6 +23,6 @@ type Backend interface {
 	Push(ctx context.Context, name string, metaHeaders http.Header, authConfig *enginetypes.AuthConfig, outStream io.Writer) error
 	Upgrade(ctx context.Context, ref reference.Named, name string, metaHeaders http.Header, authConfig *enginetypes.AuthConfig, privileges enginetypes.PluginPrivileges, outStream io.Writer) error
 	CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, options *enginetypes.PluginCreateOptions) error
-	SavePlugin(plugin string, output io.Writer) error
-	LoadPlugin(input io.ReadCloser, outStream io.Writer, quiet bool) error
+	SavePlugin(ctx context.Context, plugin string, output io.Writer) error
+	LoadPlugin(ctx context.Context, input io.ReadCloser, outStream io.Writer) error
 }

--- a/api/server/router/plugin/plugin.go
+++ b/api/server/router/plugin/plugin.go
@@ -35,7 +35,7 @@ func (r *pluginRouter) initRoutes() {
 		router.NewPostRoute("/plugins/{name:.*}/upgrade", r.upgradePlugin, router.WithCancel),
 		router.NewPostRoute("/plugins/{name:.*}/set", r.setPlugin),
 		router.NewPostRoute("/plugins/create", r.createPlugin),
-		router.NewPostRoute("/plugins/load", r.loadPlugin),
-		router.NewGetRoute("/plugins/save", r.savePlugin),
+		router.NewPostRoute("/plugins/load", r.loadPlugin, router.WithCancel),
+		router.NewGetRoute("/plugins/save", r.savePlugin, router.WithCancel),
 	}
 }

--- a/api/server/router/plugin/plugin.go
+++ b/api/server/router/plugin/plugin.go
@@ -35,5 +35,7 @@ func (r *pluginRouter) initRoutes() {
 		router.NewPostRoute("/plugins/{name:.*}/upgrade", r.upgradePlugin, router.WithCancel),
 		router.NewPostRoute("/plugins/{name:.*}/set", r.setPlugin),
 		router.NewPostRoute("/plugins/create", r.createPlugin),
+		router.NewPostRoute("/plugins/load", r.loadPlugin),
+		router.NewGetRoute("/plugins/save", r.savePlugin),
 	}
 }

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -334,11 +334,7 @@ type TaskListOptions struct {
 }
 
 // PluginLoadResponse returns information to the client about a load process.
-type PluginLoadResponse struct {
-	// Body must be closed to avoid a resource leak
-	Body io.ReadCloser
-	JSON bool
-}
+type PluginLoadResponse ImageLoadResponse
 
 // PluginRemoveOptions holds parameters to remove plugins.
 type PluginRemoveOptions struct {

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -333,6 +333,13 @@ type TaskListOptions struct {
 	Filters filters.Args
 }
 
+// PluginLoadResponse returns information to the client about a load process.
+type PluginLoadResponse struct {
+	// Body must be closed to avoid a resource leak
+	Body io.ReadCloser
+	JSON bool
+}
+
 // PluginRemoveOptions holds parameters to remove plugins.
 type PluginRemoveOptions struct {
 	Force bool

--- a/client/interface.go
+++ b/client/interface.go
@@ -119,6 +119,8 @@ type PluginAPIClient interface {
 	PluginSet(ctx context.Context, name string, args []string) error
 	PluginInspectWithRaw(ctx context.Context, name string) (*types.Plugin, []byte, error)
 	PluginCreate(ctx context.Context, createContext io.Reader, options types.PluginCreateOptions) error
+	PluginLoad(ctx context.Context, input io.Reader) (types.PluginLoadResponse, error)
+	PluginSave(ctx context.Context, plugin string) (io.ReadCloser, error)
 }
 
 // ServiceAPIClient defines API client methods for the services

--- a/client/plugin_load.go
+++ b/client/plugin_load.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"io"
+	"net/url"
+
+	"github.com/docker/docker/api/types"
+	"golang.org/x/net/context"
+)
+
+// PluginLoad loads a plugin
+func (cli *Client) PluginLoad(ctx context.Context, input io.Reader) (types.PluginLoadResponse, error) {
+	v := url.Values{}
+
+	// set the type of the data request
+	headers := map[string][]string{"Content-Type": {"application/x-tar"}}
+
+	resp, err := cli.postRaw(ctx, "/plugins/load", v, input, headers)
+	if err != nil {
+		return types.PluginLoadResponse{}, err
+	}
+
+	return types.PluginLoadResponse{
+		Body: resp.body,
+		JSON: resp.header.Get("Content-Type") == "application/json",
+	}, nil
+}

--- a/client/plugin_save.go
+++ b/client/plugin_save.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+
+	"golang.org/x/net/context"
+)
+
+// PluginSave retreives a plugin from docker as an io.ReadCloser.
+// The caller is expected to store the plugin and close the stream.
+func (cli *Client) PluginSave(ctx context.Context, plugin string) (io.ReadCloser, error) {
+	query := url.Values{}
+	query.Set("plugin", plugin)
+
+	resp, err := cli.get(ctx, "/plugins/save", query, nil)
+	if err != nil {
+		if resp.statusCode == http.StatusNotFound {
+			return nil, pluginNotFoundError{plugin}
+		}
+		return nil, err
+	}
+	return resp.body, err
+}

--- a/docs/reference/commandline/plugin_load.md
+++ b/docs/reference/commandline/plugin_load.md
@@ -1,0 +1,55 @@
+---
+title: "plugin load"
+description: "the plugin load command description and usage"
+keywords: "plugin, load"
+---
+
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
+# plugin load
+
+```markdown
+Usage:  docker plugin load [OPTIONS]
+
+Load a plugin from a tar archive or STDIN
+
+Options:
+      --help           Print usage
+  -i, --input string   Read from tar archive file, instead of STDIN
+  -q, --quiet          Suppress the load output
+
+```
+
+## Description
+
+Loads a plugin from the tarstream generated from `docker plugin save`.
+
+## Examples
+
+The following example loads a saved tarstream of the plugin `tiborvass/sample-volume-plugin`
+
+```bash
+$ docker plugin load < /tmp/volplugin.tar
+Loaded plugin ID: 792e00e0251b114f44dfd4e855cba43d92de94b1517e29b430a68e00614e9f38
+```
+
+## Related commands
+
+* [plugin install](plugin_install.md)
+* [plugin create](plugin_create.md)
+* [plugin disable](plugin_disable.md)
+* [plugin enable](plugin_enable.md)
+* [plugin inspect](plugin_inspect.md)
+* [plugin ls](plugin_ls.md)
+* [plugin push](plugin_push.md)
+* [plugin rm](plugin_rm.md)
+* [plugin set](plugin_set.md)
+* [plugin upgrade](plugin_upgrade.md)
+* [plugin save](plugin_save.md)

--- a/docs/reference/commandline/plugin_save.md
+++ b/docs/reference/commandline/plugin_save.md
@@ -1,0 +1,57 @@
+---
+title: "plugin save"
+description: "the plugin save command description and usage"
+keywords: "plugin, save"
+---
+
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
+# plugin save
+
+```markdown
+Usage:  docker plugin save [OPTIONS] PLUGIN
+
+Save a plugin to a tar archive (streamed to STDOUT by default)
+
+Options:
+      --help            Print usage
+  -o, --output string   Write to a file, instead of STDOUT
+
+```
+
+## Description
+
+Saves a plugin to a tar stream.
+
+## Examples
+
+The following example saves the installed`tiborvass/sample-volume-plugin` to a tar stream.
+
+```bash
+
+$ docker plugin save tiborvass/sample-volume-plugin > /tmp/volplugin.tar
+
+```
+
+After the plugin is saved, it can be distributed and loaded using `docker plugin load` 
+
+## Related commands
+
+* [plugin install](plugin_install.md)
+* [plugin create](plugin_create.md)
+* [plugin disable](plugin_disable.md)
+* [plugin enable](plugin_enable.md)
+* [plugin inspect](plugin_inspect.md)
+* [plugin ls](plugin_ls.md)
+* [plugin push](plugin_push.md)
+* [plugin rm](plugin_rm.md)
+* [plugin set](plugin_set.md)
+* [plugin upgrade](plugin_upgrade.md)
+* [plugin load](plugin_load.md)

--- a/integration-cli/docker_api_plugin_test.go
+++ b/integration-cli/docker_api_plugin_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
+	"github.com/docker/docker/integration-cli/request"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestPluginLoadSave(c *check.C) {
+	testRequires(c, DaemonIsLinux, IsAmd64, Network)
+	cli.DockerCmd(c, "plugin", "install", "--grant-all-permissions", pName)
+	defer cli.DockerCmd(c, "plugin", "rm", "-f", pName)
+
+	resp, _, err := request.Get("/plugins/save?plugin=" + pName)
+	c.Assert(err, checker.IsNil)
+	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
+	defer resp.Body.Close()
+
+	dir, err := ioutil.TempDir("", "plugin-save")
+	c.Assert(err, checker.IsNil)
+	defer os.RemoveAll(dir)
+
+	pluginPath := filepath.Join(dir, "plugin.tar")
+	f, err := os.Create(pluginPath)
+	c.Assert(err, checker.IsNil)
+	defer f.Close()
+
+	_, err = io.Copy(f, resp.Body)
+	c.Assert(err, checker.IsNil)
+
+	f, err = os.Open(pluginPath)
+	c.Assert(err, checker.IsNil)
+	defer f.Close()
+
+	resp, _, err = request.Post("/plugins/load", request.ContentType("application/x-tar"), request.RawContent(f))
+	c.Assert(err, checker.IsNil)
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	c.Assert(string(b), checker.Contains, "already exists")
+
+	cli.Docker(cli.Args("plugin", "rm", "-f", pName))
+
+	f, err = os.Open(pluginPath)
+	c.Assert(err, checker.IsNil)
+	defer f.Close()
+
+	resp, _, err = request.Post("/plugins/load", request.ContentType("application/x-tar"), request.RawContent(f))
+	c.Assert(err, checker.IsNil)
+	defer resp.Body.Close()
+	b, err = ioutil.ReadAll(resp.Body)
+	c.Assert(string(b), checker.Contains, "Loaded")
+}

--- a/plugin/backend_unsupported.go
+++ b/plugin/backend_unsupported.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/pkg/ioutils"
 	"golang.org/x/net/context"
 )
 
@@ -68,5 +69,15 @@ func (pm *Manager) Set(name string, args []string) error {
 // CreateFromContext creates a plugin from the given pluginDir which contains
 // both the rootfs and the config.json and a repoName with optional tag.
 func (pm *Manager) CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, options *types.PluginCreateOptions) error {
+	return errNotSupported
+}
+
+// LoadPlugin loads a plugin from a tar stream
+func (pm *Manager) LoadPlugin(input io.ReadCloser, outStream io.Writer, quiet bool) error {
+	return errNotSupported
+}
+
+// SavePlugin saves a plugin into a tar stream
+func (pm *Manager) SavePlugin(plugin string, output *ioutils.WriteFlusher) error {
 	return errNotSupported
 }

--- a/plugin/backend_unsupported.go
+++ b/plugin/backend_unsupported.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/pkg/ioutils"
 	"golang.org/x/net/context"
 )
 
@@ -73,11 +72,11 @@ func (pm *Manager) CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, 
 }
 
 // LoadPlugin loads a plugin from a tar stream
-func (pm *Manager) LoadPlugin(input io.ReadCloser, outStream io.Writer, quiet bool) error {
+func (pm *Manager) LoadPlugin(ctx context.Context, input io.ReadCloser, outStream io.Writer) error {
 	return errNotSupported
 }
 
 // SavePlugin saves a plugin into a tar stream
-func (pm *Manager) SavePlugin(plugin string, output *ioutils.WriteFlusher) error {
+func (pm *Manager) SavePlugin(ctx context.Context, plugin string, output io.Writer) error {
 	return errNotSupported
 }

--- a/plugin/blobstore.go
+++ b/plugin/blobstore.go
@@ -76,6 +76,11 @@ func (b *basicBlobStore) gc(whitelist map[digest.Digest]struct{}) {
 // WriteCommitCloser defines object that can be committed to blobstore.
 type WriteCommitCloser interface {
 	io.WriteCloser
+	Commiter
+}
+
+// Commiter is an object that can commit a blob and return it's digest
+type Commiter interface {
 	Commit() (digest.Digest, error)
 }
 

--- a/plugin/blobstore.go
+++ b/plugin/blobstore.go
@@ -12,14 +12,22 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progress"
+	"github.com/docker/docker/pkg/symlink"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
+var errDigestMismatch = errors.New("digest does not match")
+
 type blobstore interface {
 	New() (WriteCommitCloser, error)
+	readOnlyBlobstore
+}
+
+type readOnlyBlobstore interface {
 	Get(dgst digest.Digest) (io.ReadCloser, error)
 	Size(dgst digest.Digest) (int64, error)
 }
@@ -37,7 +45,11 @@ func newBasicBlobStore(p string) (*basicBlobStore, error) {
 }
 
 func (b *basicBlobStore) New() (WriteCommitCloser, error) {
-	f, err := ioutil.TempFile(filepath.Join(b.path, "tmp"), ".insertion")
+	tmpPath := filepath.Join(b.path, "tmp")
+	if err := os.MkdirAll(tmpPath, 0755); err != nil {
+		return nil, errors.Wrap(err, "failed to create tmp dir")
+	}
+	f, err := ioutil.TempFile(tmpPath, ".insertion")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create temp file")
 	}
@@ -45,7 +57,12 @@ func (b *basicBlobStore) New() (WriteCommitCloser, error) {
 }
 
 func (b *basicBlobStore) Get(dgst digest.Digest) (io.ReadCloser, error) {
-	return os.Open(filepath.Join(b.path, string(dgst.Algorithm()), dgst.Hex()))
+	p := filepath.Join(b.path, string(dgst.Algorithm()), dgst.Hex())
+	p, err := symlink.FollowSymlinkInScope(p, b.path)
+	if err != nil {
+		return nil, errors.Wrap(err, "error in blob path")
+	}
+	return os.Open(p)
 }
 
 func (b *basicBlobStore) Size(dgst digest.Digest) (int64, error) {
@@ -76,11 +93,11 @@ func (b *basicBlobStore) gc(whitelist map[digest.Digest]struct{}) {
 // WriteCommitCloser defines object that can be committed to blobstore.
 type WriteCommitCloser interface {
 	io.WriteCloser
-	Commiter
+	Committer
 }
 
-// Commiter is an object that can commit a blob and return it's digest
-type Commiter interface {
+// Committer is an object that can commit a blob and return it's digest
+type Committer interface {
 	Commit() (digest.Digest, error)
 }
 
@@ -109,7 +126,9 @@ func (i *insertion) Commit() (digest.Digest, error) {
 	if err := os.MkdirAll(filepath.Join(d, string(dgst.Algorithm())), 0700); err != nil {
 		return "", errors.Wrapf(err, "failed to mkdir %v", d)
 	}
-	if err := os.Rename(p, filepath.Join(d, string(dgst.Algorithm()), dgst.Hex())); err != nil {
+
+	blobPath := filepath.Join(d, string(dgst.Algorithm()), dgst.Hex())
+	if err := os.Rename(p, blobPath); err != nil {
 		return "", errors.Wrapf(err, "failed to rename %v", p)
 	}
 	return dgst, nil
@@ -184,4 +203,40 @@ func (dm *downloadManager) Get(d digest.Digest) ([]byte, error) {
 }
 func (dm *downloadManager) RootFSFromConfig(c []byte) (*image.RootFS, error) {
 	return configToRootFS(c)
+}
+
+// getBlob looks for a blob in the passed in local blob store, then the remote store
+// If the blob is in the remote store it sets up the blob to be imported into the
+// local store once read, and returns a function to verifiy the imported digest
+// against the passed in digest.
+func getBlob(local blobstore, remote readOnlyBlobstore, dgst digest.Digest) (io.ReadCloser, func() error, error) {
+	if f, err := local.Get(dgst); err == nil {
+		return f, func() error { return nil }, nil
+	}
+
+	f, err := remote.Get(dgst)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	committer, err := local.New()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	verifier := func() error {
+		d, err := committer.Commit()
+		if err != nil {
+			return err
+		}
+		if d != dgst {
+			return errDigestMismatch
+		}
+		return nil
+	}
+
+	return ioutils.NewReadCloserWrapper(io.TeeReader(f, committer), func() error {
+		committer.Close()
+		return f.Close()
+	}), verifier, nil
 }

--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -273,16 +273,14 @@ func (pm *Manager) setupNewPlugin(configDigest digest.Digest, privileges *types.
 }
 
 // createPlugin creates a new plugin. take lock before calling.
-func (pm *Manager) createPlugin(name string, configDigest digest.Digest, blobsums []digest.Digest, rootFSDir string, privileges *types.PluginPrivileges, config *types.PluginConfig) (p *v2.Plugin, err error) {
+func (pm *Manager) createPlugin(name string, configDigest digest.Digest, blobsums []digest.Digest, rootFSDir string, privileges *types.PluginPrivileges) (p *v2.Plugin, err error) {
 	if err := pm.config.Store.validateName(name); err != nil { // todo: this check is wrong. remove store
 		return nil, err
 	}
 
-	if config == nil {
-		config, err = pm.setupNewPlugin(configDigest, privileges)
-		if err != nil {
-			return nil, err
-		}
+	config, err := pm.setupNewPlugin(configDigest, privileges)
+	if err != nil {
+		return nil, err
 	}
 
 	p = &v2.Plugin{

--- a/plugin/oci.go
+++ b/plugin/oci.go
@@ -8,100 +8,55 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/docker/pkg/symlink"
 	"github.com/docker/docker/pkg/system"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 const ociPluginNameKey = "com.docker.plugin.ref.name"
-
-func ociNewManifest() ocispecv1.Manifest {
-	return ocispecv1.Manifest{
-		Versioned: specs.Versioned{SchemaVersion: 2},
-		Config: ocispecv1.Descriptor{
-			MediaType: schema2.MediaTypePluginConfig,
-		},
-	}
-}
-
-func ociWriteBlob(root string, dgst digest.Digest, r io.Reader) (int64, error) {
-	base := filepath.Join(root, "blobs", dgst.Algorithm().String())
-	if err := os.MkdirAll(base, 0755); err != nil {
-		return 0, errors.Wrap(err, "error creating blob tree")
-	}
-
-	fileName := filepath.Join(base, dgst.Hex())
-	f, err := os.Create(fileName)
-	if err != nil {
-		return 0, errors.Wrap(err, "error creating blob file")
-	}
-	defer f.Close()
-
-	size, err := io.Copy(f, r)
-	if err != nil {
-		return 0, errors.Wrap(err, "error writing blob to file")
-	}
-
-	if err := system.Chtimes(fileName, time.Unix(0, 0), time.Unix(0, 0)); err != nil {
-		return 0, errors.Wrap(err, "error resseting times file mod times")
-	}
-	return size, nil
-}
-
-func ociWriteLayout(root string) error {
-	layout := &ocispecv1.ImageLayout{
-		Version: ocispecv1.ImageLayoutVersion,
-	}
-
-	fileName := filepath.Join(root, ocispecv1.ImageLayoutFile)
-	data, err := json.Marshal(layout)
-	if err != nil {
-		return errors.Wrap(err, "error marshaling oci layout")
-	}
-
-	if err := ioutil.WriteFile(fileName, data, 644); err != nil {
-		return errors.Wrap(err, "error writing oci layout file")
-	}
-
-	if err := system.Chtimes(fileName, time.Unix(0, 0), time.Unix(0, 0)); err != nil {
-		return errors.Wrap(err, "error resetting mod times on oci layout file")
-	}
-	return nil
-}
-
-func ociWriteIndex(root string, manifests []ocispecv1.Descriptor) error {
-	fileName := filepath.Join(root, "index.json")
-	index := &ocispecv1.Index{
-		Versioned: specs.Versioned{SchemaVersion: 2},
-		Manifests: manifests,
-	}
-
-	f, err := os.Create(fileName)
-	if err != nil {
-		return errors.Wrap(err, "error creating oci index file")
-	}
-	defer f.Close()
-	if err := json.NewEncoder(f).Encode(index); err != nil {
-		return errors.Wrap(err, "error writing oci index")
-	}
-
-	if err := system.Chtimes(fileName, time.Unix(0, 0), time.Unix(0, 0)); err != nil {
-		return errors.Wrap(err, "error resetting mod times on oci index file")
-	}
-	return nil
-}
 
 type ociImageBundleV1 struct {
 	root string
 }
 
+type ociWalkFn func(ocispecv1.Manifest, map[string]string) error
+
+func (b *ociImageBundleV1) Walk(ctx context.Context, fn ociWalkFn) error {
+	idx, err := b.GetIndex()
+	if err != nil {
+		return err
+	}
+
+	for _, md := range idx.Manifests {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		m, err := b.ReadManifest(md)
+		if err != nil {
+			return err
+		}
+		if err := fn(m, md.Annotations); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (b *ociImageBundleV1) GetIndex() (ocispecv1.Index, error) {
 	var index ocispecv1.Index
 
-	f, err := os.Open(filepath.Join(b.root, "index.json"))
+	p, err := symlink.FollowSymlinkInScope(filepath.Join(b.root, "index.json"), b.root)
+	if err != nil {
+		return index, errors.Wrap(err, "error in index path")
+	}
+	f, err := os.Open(p)
 	if err != nil {
 		return index, errors.Wrap(err, "error opening oci index")
 	}
@@ -116,7 +71,7 @@ func (b *ociImageBundleV1) GetIndex() (ocispecv1.Index, error) {
 func (b *ociImageBundleV1) ReadManifest(d ocispecv1.Descriptor) (ocispecv1.Manifest, error) {
 	var m ocispecv1.Manifest
 
-	f, err := b.openBlob(d.Digest)
+	f, err := b.Store().Get(d.Digest)
 	if err != nil {
 		return m, errors.Wrap(err, "error reading manifest")
 	}
@@ -135,10 +90,74 @@ func (b *ociImageBundleV1) ReadManifest(d ocispecv1.Descriptor) (ocispecv1.Manif
 	return m, nil
 }
 
-func (b *ociImageBundleV1) openBlob(d digest.Digest) (io.ReadCloser, error) {
-	f, err := os.Open(filepath.Join(b.root, "blobs", d.Algorithm().String(), d.Hex()))
+func (b *ociImageBundleV1) Store() blobstore {
+	return &basicBlobStore{filepath.Join(b.root, "blobs")}
+}
+
+func (b *ociImageBundleV1) AddBlob(r io.Reader) (ocispecv1.Descriptor, error) {
+	blob, err := b.Store().New()
 	if err != nil {
-		return nil, errors.Wrap(err, "error opening blob")
+		return ocispecv1.Descriptor{}, errors.Wrap(err, "error creating blob")
 	}
-	return f, nil
+	defer blob.Close()
+
+	size, err := io.Copy(blob, r)
+	if err != nil {
+		return ocispecv1.Descriptor{}, errors.Wrap(err, "error writing blob")
+	}
+
+	dgst, err := blob.Commit()
+	if err != nil {
+		return ocispecv1.Descriptor{}, errors.Wrap(err, "error committing blob")
+	}
+
+	return ocispecv1.Descriptor{
+		Digest: dgst,
+		Size:   size,
+	}, nil
+}
+
+func (b *ociImageBundleV1) Commit(manifests []ocispecv1.Descriptor) error {
+	index := &ocispecv1.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		Manifests: manifests,
+	}
+
+	fileName := filepath.Join(b.root, "index.json")
+	f, err := os.Create(fileName)
+	if err != nil {
+		return errors.Wrap(err, "error creating oci index file")
+	}
+	defer f.Close()
+	if err := json.NewEncoder(f).Encode(index); err != nil {
+		return errors.Wrap(err, "error writing oci index")
+	}
+
+	layout := &ocispecv1.ImageLayout{
+		Version: ocispecv1.ImageLayoutVersion,
+	}
+
+	fileName = filepath.Join(b.root, ocispecv1.ImageLayoutFile)
+	data, err := json.Marshal(layout)
+	if err != nil {
+		return errors.Wrap(err, "error marshaling oci layout")
+	}
+
+	if err := ioutil.WriteFile(fileName, data, 644); err != nil {
+		return errors.Wrap(err, "error writing oci layout file")
+	}
+
+	os.RemoveAll(filepath.Join(b.root, "blobs", "tmp"))
+
+	// change all mod times to unix epoch for consistent hashing
+	err = filepath.Walk(b.root, func(p string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if err := system.Chtimes(p, time.Unix(0, 0), time.Unix(0, 0)); err != nil {
+			return errors.Wrapf(err, "error resetting mod times on %s", p)
+		}
+		return nil
+	})
+	return err
 }

--- a/plugin/oci.go
+++ b/plugin/oci.go
@@ -1,0 +1,93 @@
+package plugin
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/docker/pkg/system"
+	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
+	ocispecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+func ociNewManifest() ocispecv1.Manifest {
+	return ocispecv1.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		Config: ocispecv1.Descriptor{
+			MediaType: schema2.MediaTypePluginConfig,
+		},
+	}
+}
+
+func ociWriteBlob(root string, dgst digest.Digest, r io.Reader) (int64, error) {
+	base := filepath.Join(root, "blobs", dgst.Algorithm().String())
+	if err := os.MkdirAll(base, 0755); err != nil {
+		return 0, errors.Wrap(err, "error creating blob tree")
+	}
+
+	fileName := filepath.Join(base, dgst.Hex())
+	f, err := os.Create(fileName)
+	if err != nil {
+		return 0, errors.Wrap(err, "error creating blob file")
+	}
+	defer f.Close()
+
+	size, err := io.Copy(f, r)
+	if err != nil {
+		return 0, errors.Wrap(err, "error writing blob to file")
+	}
+
+	if err := system.Chtimes(fileName, time.Unix(0, 0), time.Unix(0, 0)); err != nil {
+		return 0, errors.Wrap(err, "error resseting times file mod times")
+	}
+	return size, nil
+}
+
+func ociWriteLayout(root string) error {
+	layout := &ocispecv1.ImageLayout{
+		Version: ocispecv1.ImageLayoutVersion,
+	}
+
+	fileName := filepath.Join(root, ocispecv1.ImageLayoutFile)
+	data, err := json.Marshal(layout)
+	if err != nil {
+		return errors.Wrap(err, "error marshaling oci layout")
+	}
+
+	if err := ioutil.WriteFile(fileName, data, 644); err != nil {
+		return errors.Wrap(err, "error writing oci layout file")
+	}
+
+	if err := system.Chtimes(fileName, time.Unix(0, 0), time.Unix(0, 0)); err != nil {
+		return errors.Wrap(err, "error resetting mod times on oci layout file")
+	}
+	return nil
+}
+
+func ociWriteIndex(root string, manifests []ocispecv1.Descriptor) error {
+	fileName := filepath.Join(root, "index.json")
+	index := &ocispecv1.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		Manifests: manifests,
+	}
+
+	f, err := os.Create(fileName)
+	if err != nil {
+		return errors.Wrap(err, "error creating oci index file")
+	}
+	defer f.Close()
+	if err := json.NewEncoder(f).Encode(index); err != nil {
+		return errors.Wrap(err, "error writing oci index")
+	}
+
+	if err := system.Chtimes(fileName, time.Unix(0, 0), time.Unix(0, 0)); err != nil {
+		return errors.Wrap(err, "error resetting mod times on oci index file")
+	}
+	return nil
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -135,3 +135,5 @@ github.com/Nvveen/Gotty a8b993ba6abdb0e0c12b0125c603323a71c7790c https://github.
 github.com/docker/go-metrics d466d4f6fd960e01820085bd7e1a24426ee7ef18
 
 github.com/opencontainers/selinux v1.0.0-rc1
+
+github.com/opencontainers/image-spec 40075dd9067146ebd6b0e1a3d3a1e9021fc2e47f

--- a/vendor/github.com/opencontainers/image-spec/LICENSE
+++ b/vendor/github.com/opencontainers/image-spec/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2016 The Linux Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/opencontainers/image-spec/README.md
+++ b/vendor/github.com/opencontainers/image-spec/README.md
@@ -1,0 +1,167 @@
+# OCI Image Format Specification
+<div>
+<a href="https://travis-ci.org/opencontainers/image-spec">
+<img src="https://travis-ci.org/opencontainers/image-spec.svg?branch=master"></img>
+</a>
+</div>
+
+The OCI Image Format project creates and maintains the software shipping container image format spec (OCI Image Format).
+
+**[The specification can be found here](spec.md).**
+
+This repository also provides [Go types](specs-go), [intra-blob validation tooling, and JSON Schema](schema).
+The Go types and validation should be compatible with the current Go release; earlier Go releases are not supported.
+
+Additional documentation about how this group operates:
+
+- [Code of Conduct](https://github.com/opencontainers/tob/blob/d2f9d68c1332870e40693fe077d311e0742bc73d/code-of-conduct.md)
+- [Roadmap](#roadmap)
+- [Releases](RELEASES.md)
+- [Project Documentation](project.md)
+
+The _optional_ and _base_ layers of all OCI projects are tracked in the [OCI Scope Table](https://www.opencontainers.org/about/oci-scope-table).
+
+## Running an OCI Image
+
+The OCI Image Format partner project is the [OCI Runtime Spec project](https://github.com/opencontainers/runtime-spec).
+The Runtime Specification outlines how to run a "[filesystem bundle](https://github.com/opencontainers/runtime-spec/blob/master/bundle.md)" that is unpacked on disk.
+At a high-level an OCI implementation would download an OCI Image then unpack that image into an OCI Runtime filesystem bundle.
+At this point the OCI Runtime Bundle would be run by an OCI Runtime.
+
+This entire workflow supports the UX that users have come to expect from container engines like Docker and rkt: primarily, the ability to run an image with no additional arguments:
+
+* docker run example.com/org/app:v1.0.0
+* rkt run example.com/org/app,version=v1.0.0
+
+To support this UX the OCI Image Format contains sufficient information to launch the application on the target platform (e.g. command, arguments, environment variables, etc).
+
+## FAQ
+
+**Q: Why doesn't this project mention distribution?**
+
+A: Distribution, for example using HTTP as both Docker v2.2 and AppC do today, is currently out of scope on the [OCI Scope Table](https://www.opencontainers.org/about/oci-scope-table).
+There has been [some discussion on the TOB mailing list](https://groups.google.com/a/opencontainers.org/d/msg/tob/A3JnmI-D-6Y/tLuptPDHAgAJ) to make distribution an optional layer, but this topic is a work in progress.
+
+**Q: What happens to AppC or Docker Image Formats?**
+
+A: Existing formats can continue to be a proving ground for technologies, as needed.
+The OCI Image Format project strives to provide a dependable open specification that can be shared between different tools and be evolved for years or decades of compatibility; as the deb and rpm format have.
+
+Find more [FAQ on the OCI site](https://www.opencontainers.org/faq).
+
+## Roadmap
+
+The [GitHub milestones](https://github.com/opencontainers/image-spec/milestones) lay out the path to the OCI v1.0.0 release in late 2016.
+
+# Contributing
+
+Development happens on GitHub for the spec.
+Issues are used for bugs and actionable items and longer discussions can happen on the [mailing list](#mailing-list).
+
+The specification and code is licensed under the Apache 2.0 license found in the `LICENSE` file of this repository.
+
+## Discuss your design
+
+The project welcomes submissions, but please let everyone know what you are working on.
+
+Before undertaking a nontrivial change to this specification, send mail to the [mailing list](#mailing-list) to discuss what you plan to do.
+This gives everyone a chance to validate the design, helps prevent duplication of effort, and ensures that the idea fits.
+It also guarantees that the design is sound before code is written; a GitHub pull-request is not the place for high-level discussions.
+
+Typos and grammatical errors can go straight to a pull-request.
+When in doubt, start on the [mailing-list](#mailing-list).
+
+## Weekly Call
+
+The contributors and maintainers of all OCI projects have a weekly meeting Wednesdays at 2:00 PM (USA Pacific).
+Everyone is welcome to participate via [UberConference web][UberConference] or audio-only: +1-415-968-0849 (no PIN needed).
+An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
+Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived [here][minutes].
+
+## Mailing List
+
+You can subscribe and join the mailing list on [Google Groups](https://groups.google.com/a/opencontainers.org/forum/#!forum/dev).
+
+## IRC
+
+OCI discussion happens on #opencontainers on Freenode ([logs][irc-logs]).
+
+## Markdown style
+
+To keep consistency throughout the Markdown files in the Open Container spec all files should be formatted one sentence per line.
+This fixes two things: it makes diffing easier with git and it resolves fights about line wrapping length.
+For example, this paragraph will span three lines in the Markdown source.
+
+## Git commit
+
+### Sign your work
+
+The sign-off is a simple line at the end of the explanation for the patch, which certifies that you wrote it or otherwise have the right to pass it on as an open-source patch.
+The rules are pretty simple: if you can certify the below (from [developercertificate.org](http://developercertificate.org/)):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe@gmail.com>
+
+using your real name (sorry, no pseudonyms or anonymous contributions.)
+
+You can add the sign off when creating the git commit via `git commit -s`.
+
+### Commit Style
+
+Simple house-keeping for clean git history.
+Read more on [How to Write a Git Commit Message](http://chris.beams.io/posts/git-commit/) or the Discussion section of [`git-commit(1)`](http://git-scm.com/docs/git-commit).
+
+1. Separate the subject from body with a blank line
+2. Limit the subject line to 50 characters
+3. Capitalize the subject line
+4. Do not end the subject line with a period
+5. Use the imperative mood in the subject line
+6. Wrap the body at 72 characters
+7. Use the body to explain what and why vs. how
+  * If there was important/useful/essential conversation or information, copy or include a reference
+8. When possible, one keyword to scope the change in the subject (i.e. "README: ...", "runtime: ...")
+
+
+[UberConference]: https://www.uberconference.com/opencontainers
+[irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/
+[minutes]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
@@ -1,0 +1,103 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"time"
+
+	digest "github.com/opencontainers/go-digest"
+)
+
+// ImageConfig defines the execution parameters which should be used as a base when running a container using an image.
+type ImageConfig struct {
+	// User defines the username or UID which the process in the container should run as.
+	User string `json:"User,omitempty"`
+
+	// ExposedPorts a set of ports to expose from a container running this image.
+	ExposedPorts map[string]struct{} `json:"ExposedPorts,omitempty"`
+
+	// Env is a list of environment variables to be used in a container.
+	Env []string `json:"Env,omitempty"`
+
+	// Entrypoint defines a list of arguments to use as the command to execute when the container starts.
+	Entrypoint []string `json:"Entrypoint,omitempty"`
+
+	// Cmd defines the default arguments to the entrypoint of the container.
+	Cmd []string `json:"Cmd,omitempty"`
+
+	// Volumes is a set of directories which should be created as data volumes in a container running this image.
+	Volumes map[string]struct{} `json:"Volumes,omitempty"`
+
+	// WorkingDir sets the current working directory of the entrypoint process in the container.
+	WorkingDir string `json:"WorkingDir,omitempty"`
+
+	// Labels contains arbitrary metadata for the container.
+	Labels map[string]string `json:"Labels,omitempty"`
+
+	// StopSignal contains the system call signal that will be sent to the container to exit.
+	StopSignal string `json:"StopSignal,omitempty"`
+}
+
+// RootFS describes a layer content addresses
+type RootFS struct {
+	// Type is the type of the rootfs.
+	Type string `json:"type"`
+
+	// DiffIDs is an array of layer content hashes (DiffIDs), in order from bottom-most to top-most.
+	DiffIDs []digest.Digest `json:"diff_ids"`
+}
+
+// History describes the history of a layer.
+type History struct {
+	// Created is the combined date and time at which the layer was created, formatted as defined by RFC 3339, section 5.6.
+	Created *time.Time `json:"created,omitempty"`
+
+	// CreatedBy is the command which created the layer.
+	CreatedBy string `json:"created_by,omitempty"`
+
+	// Author is the author of the build point.
+	Author string `json:"author,omitempty"`
+
+	// Comment is a custom message set when creating the layer.
+	Comment string `json:"comment,omitempty"`
+
+	// EmptyLayer is used to mark if the history item created a filesystem diff.
+	EmptyLayer bool `json:"empty_layer,omitempty"`
+}
+
+// Image is the JSON structure which describes some basic information about the image.
+// This provides the `application/vnd.oci.image.config.v1+json` mediatype when marshalled to JSON.
+type Image struct {
+	// Created is the combined date and time at which the image was created, formatted as defined by RFC 3339, section 5.6.
+	Created *time.Time `json:"created,omitempty"`
+
+	// Author defines the name and/or email address of the person or entity which created and is responsible for maintaining the image.
+	Author string `json:"author,omitempty"`
+
+	// Architecture is the CPU architecture which the binaries in this image are built to run on.
+	Architecture string `json:"architecture"`
+
+	// OS is the name of the operating system which the image is built to run on.
+	OS string `json:"os"`
+
+	// Config defines the execution parameters which should be used as a base when running a container using the image.
+	Config ImageConfig `json:"config,omitempty"`
+
+	// RootFS references the layer content addresses used by the image.
+	RootFS RootFS `json:"rootfs"`
+
+	// History describes the history of each layer.
+	History []History `json:"history,omitempty"`
+}

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
@@ -1,0 +1,68 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import digest "github.com/opencontainers/go-digest"
+
+// Descriptor describes the disposition of targeted content.
+// This structure provides `application/vnd.oci.descriptor.v1+json` mediatype
+// when marshalled to JSON.
+type Descriptor struct {
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType,omitempty"`
+
+	// Digest is the digest of the targeted content.
+	Digest digest.Digest `json:"digest"`
+
+	// Size specifies the size in bytes of the blob.
+	Size int64 `json:"size"`
+
+	// URLs specifies a list of URLs from which this object MAY be downloaded
+	URLs []string `json:"urls,omitempty"`
+
+	// Annotations contains arbitrary metadata relating to the targeted content.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Platform describes the platform which the image in the manifest runs on.
+	//
+	// This should only be used when referring to a manifest.
+	Platform *Platform `json:"platform,omitempty"`
+}
+
+// Platform describes the platform which the image in the manifest runs on.
+type Platform struct {
+	// Architecture field specifies the CPU architecture, for example
+	// `amd64` or `ppc64`.
+	Architecture string `json:"architecture"`
+
+	// OS specifies the operating system, for example `linux` or `windows`.
+	OS string `json:"os"`
+
+	// OSVersion is an optional field specifying the operating system
+	// version, for example `10.0.10586`.
+	OSVersion string `json:"os.version,omitempty"`
+
+	// OSFeatures is an optional field specifying an array of strings,
+	// each listing a required OS feature (for example on Windows `win32k`).
+	OSFeatures []string `json:"os.features,omitempty"`
+
+	// Variant is an optional field specifying a variant of the CPU, for
+	// example `ppc64le` to specify a little-endian version of a PowerPC CPU.
+	Variant string `json:"variant,omitempty"`
+
+	// Features is an optional field specifying an array of strings, each
+	// listing a required CPU feature (for example `sse4` or `aes`).
+	Features []string `json:"features,omitempty"`
+}

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/index.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/index.go
@@ -1,0 +1,29 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import "github.com/opencontainers/image-spec/specs-go"
+
+// Index references manifests for various platforms.
+// This structure provides `application/vnd.oci.image.index.v1+json` mediatype when marshalled to JSON.
+type Index struct {
+	specs.Versioned
+
+	// Manifests references platform specific manifests.
+	Manifests []Descriptor `json:"manifests"`
+
+	// Annotations contains arbitrary metadata for the image index.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/layout.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/layout.go
@@ -1,0 +1,28 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+const (
+	// ImageLayoutFile is the file name of oci image layout file
+	ImageLayoutFile = "oci-layout"
+	// ImageLayoutVersion is the version of ImageLayout
+	ImageLayoutVersion = "1.0.0"
+)
+
+// ImageLayout is the structure in the "oci-layout" file, found in the root
+// of an OCI Image-layout directory.
+type ImageLayout struct {
+	Version string `json:"imageLayoutVersion"`
+}

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
@@ -1,0 +1,32 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import "github.com/opencontainers/image-spec/specs-go"
+
+// Manifest provides `application/vnd.oci.image.manifest.v1+json` mediatype structure when marshalled to JSON.
+type Manifest struct {
+	specs.Versioned
+
+	// Config references a configuration object for a container, by digest.
+	// The referenced configuration object is a JSON blob that the runtime uses to set up the container.
+	Config Descriptor `json:"config"`
+
+	// Layers is an indexed list of layers referenced by the manifest.
+	Layers []Descriptor `json:"layers"`
+
+	// Annotations contains arbitrary metadata for the image manifest.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
@@ -1,0 +1,48 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+const (
+	// MediaTypeDescriptor specifies the media type for a content descriptor.
+	MediaTypeDescriptor = "application/vnd.oci.descriptor.v1+json"
+
+	// MediaTypeLayoutHeader specifies the media type for the oci-layout.
+	MediaTypeLayoutHeader = "application/vnd.oci.layout.header.v1+json"
+
+	// MediaTypeImageManifest specifies the media type for an image manifest.
+	MediaTypeImageManifest = "application/vnd.oci.image.manifest.v1+json"
+
+	// MediaTypeImageIndex specifies the media type for an image index.
+	MediaTypeImageIndex = "application/vnd.oci.image.index.v1+json"
+
+	// MediaTypeImageLayer is the media type used for layers referenced by the manifest.
+	MediaTypeImageLayer = "application/vnd.oci.image.layer.v1.tar"
+
+	// MediaTypeImageLayerGzip is the media type used for gzipped layers
+	// referenced by the manifest.
+	MediaTypeImageLayerGzip = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+	// MediaTypeImageLayerNonDistributable is the media type for layers referenced by
+	// the manifest but with distribution restrictions.
+	MediaTypeImageLayerNonDistributable = "application/vnd.oci.image.layer.nondistributable.v1.tar"
+
+	// MediaTypeImageLayerNonDistributableGzip is the media type for
+	// gzipped layers referenced by the manifest but with distribution
+	// restrictions.
+	MediaTypeImageLayerNonDistributableGzip = "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip"
+
+	// MediaTypeImageConfig specifies the media type for the image configuration.
+	MediaTypeImageConfig = "application/vnd.oci.image.config.v1+json"
+)

--- a/vendor/github.com/opencontainers/image-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/version.go
@@ -1,0 +1,32 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package specs
+
+import "fmt"
+
+const (
+	// VersionMajor is for an API incompatible changes
+	VersionMajor = 1
+	// VersionMinor is for functionality in a backwards-compatible manner
+	VersionMinor = 0
+	// VersionPatch is for backwards-compatible bug fixes
+	VersionPatch = 0
+
+	// VersionDev indicates development branch. Releases will be empty string.
+	VersionDev = "-rc5-dev"
+)
+
+// Version is the specification version that the package types support.
+var Version = fmt.Sprintf("%d.%d.%d%s", VersionMajor, VersionMinor, VersionPatch, VersionDev)

--- a/vendor/github.com/opencontainers/image-spec/specs-go/versioned.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/versioned.go
@@ -1,0 +1,23 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package specs
+
+// Versioned provides a struct with the manifest schemaVersion and mediaType.
+// Incoming content with unknown schema version can be decoded against this
+// struct to check the version.
+type Versioned struct {
+	// SchemaVersion is the image manifest schema that this image follows
+	SchemaVersion int `json:"schemaVersion"`
+}


### PR DESCRIPTION
Implement plugin save and load to handle the offline distribution
usecase. Save a tar of the plugin in the following layout:
--- sha256ofconfig.json
--- sha256ofrootfs.tar.gz
--- manifest.json containing metadata of the form:
{
	"Name"  : pluginName
	"Config": sha256config.json
	"Layers": [
		"sha256rootfs.tar.gz"
	]
}
Load loads such a tar stream into the plugin inventory.

Signed-off-by: Anusha Ragunathan <anusha.ragunathan@docker.com>