### PR TITLE
Ignore HNS networks with type `Private`

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -327,6 +327,9 @@ func (daemon *Daemon) initNetworkController(config *config.Config, activeSandbox
 	// discover and add HNS networks to windows
 	// network that exist are removed and added again
 	for _, v := range hnsresponse {
+		if strings.ToLower(v.Type) == "private" {
+			continue // workaround for HNS reporting unsupported networks
+		}
 		var n libnetwork.Network
 		s := func(current libnetwork.Network) bool {
 			options := current.Info().DriverOptions()


### PR DESCRIPTION
Fix #33052 (workaround style)

**- What I did**

HNS reports networks that don't have anything to do with the Daemon, and for which no networking plugin is available. This make the Daemon start sequence pause for 15 secs, as the plugin resolving logic has a wait & retry logic

**- How I did it**

Just after retrieving the HNS networks, I filter out those with type `Private`

**- How to verify it**

Replace dockerd coming with Docker for Windows from one built from this PR. Windows containers daemon should now launch pretty quickly


