### PR TITLE
[Builder] Expose GetImage interface for builder

### DIFF
--- a/api/types/backend/build.go
+++ b/api/types/backend/build.go
@@ -23,7 +23,7 @@ type BuildConfig struct {
 	Options        *types.ImageBuildOptions
 }
 
-// GetImageAndLayerOptions are the options supported by GetImageAndLayer
+// GetImageAndLayerOptions are the options supported by GetImageAndReleasableLayer
 type GetImageAndLayerOptions struct {
 	ForcePull  bool
 	AuthConfig map[string]types.AuthConfig

--- a/api/types/backend/build.go
+++ b/api/types/backend/build.go
@@ -22,3 +22,10 @@ type BuildConfig struct {
 	ProgressWriter ProgressWriter
 	Options        *types.ImageBuildOptions
 }
+
+// GetImageAndLayerOptions are the options supported by GetImageAndLayer
+type GetImageAndLayerOptions struct {
+	ForcePull  bool
+	AuthConfig map[string]types.AuthConfig
+	Output     io.Writer
+}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -34,7 +34,7 @@ type Source interface {
 
 // Backend abstracts calls to a Docker Daemon.
 type Backend interface {
-	GetImageAndLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (Image, ReleaseableLayer, error)
+	ImageBackend
 
 	// ContainerAttachRaw attaches to container.
 	ContainerAttachRaw(cID string, stdin io.ReadCloser, stdout, stderr io.Writer, stream bool, attached chan struct{}) error
@@ -58,6 +58,11 @@ type Backend interface {
 	// TODO: extract in the builder instead of passing `decompress`
 	// TODO: use containerd/fs.changestream instead as a source
 	CopyOnBuild(containerID string, destPath string, srcRoot string, srcPath string, decompress bool) error
+}
+
+// ImageBackend are the interface methods required from an image component
+type ImageBackend interface {
+	GetImageAndReleasableLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (Image, ReleaseableLayer, error)
 }
 
 // Result is the output produced by a Builder
@@ -89,5 +94,5 @@ type Image interface {
 // ReleaseableLayer is an image layer that can be mounted and released
 type ReleaseableLayer interface {
 	Release() error
-	Mount(string) (string, error)
+	Mount() (string, error)
 }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -89,5 +89,5 @@ type Image interface {
 // ReleaseableLayer is an image layer that can be mounted and released
 type ReleaseableLayer interface {
 	Release() error
-	Mount() (string, error)
+	Mount(string) (string, error)
 }

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -45,7 +45,10 @@ type BuildManager struct {
 
 // NewBuildManager creates a BuildManager
 func NewBuildManager(b builder.Backend) *BuildManager {
-	return &BuildManager{backend: b, pathCache: &syncmap.Map{}}
+	return &BuildManager{
+		backend:   b,
+		pathCache: &syncmap.Map{},
+	}
 }
 
 // Build starts a new build from a BuildConfig
@@ -122,8 +125,8 @@ func newBuilder(clientCtx context.Context, options builderOptions) *Builder {
 		docker:        options.Backend,
 		tmpContainers: map[string]struct{}{},
 		buildArgs:     newBuildArgs(config.BuildArgs),
+		imageContexts: &imageContexts{},
 	}
-	b.imageContexts = &imageContexts{b: b, cache: options.PathCache}
 	return b
 }
 

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -102,11 +102,12 @@ type Builder struct {
 	clientCtx context.Context
 
 	tmpContainers map[string]struct{}
-	imageContexts *imageContexts // helper for storing contexts from builds
+	buildStages   *buildStages
 	disableCommit bool
 	cacheBusted   bool
 	buildArgs     *buildArgs
 	imageCache    builder.ImageCache
+	imageSources  *imageSources
 }
 
 // newBuilder creates a new Dockerfile builder from an optional dockerfile and a Options.
@@ -125,7 +126,8 @@ func newBuilder(clientCtx context.Context, options builderOptions) *Builder {
 		docker:        options.Backend,
 		tmpContainers: map[string]struct{}{},
 		buildArgs:     newBuildArgs(config.BuildArgs),
-		imageContexts: &imageContexts{},
+		buildStages:   newBuildStages(),
+		imageSources:  newImageSources(clientCtx, options),
 	}
 	return b
 }
@@ -140,7 +142,7 @@ func (b *Builder) resetImageCache() {
 // Build runs the Dockerfile builder by parsing the Dockerfile and executing
 // the instructions from the file.
 func (b *Builder) build(source builder.Source, dockerfile *parser.Result) (*builder.Result, error) {
-	defer b.imageContexts.unmount()
+	defer b.imageSources.Unmount()
 
 	// TODO: Remove source field from Builder
 	b.source = source

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -49,15 +49,20 @@ func defaultDispatchReq(builder *Builder, args ...string) dispatchRequest {
 
 func newBuilderWithMockBackend() *Builder {
 	mockBackend := &MockBackend{}
+	ctx := context.Background()
 	b := &Builder{
 		options:       &types.ImageBuildOptions{},
 		docker:        mockBackend,
 		buildArgs:     newBuildArgs(make(map[string]*string)),
 		tmpContainers: make(map[string]struct{}),
 		Stdout:        new(bytes.Buffer),
-		clientCtx:     context.Background(),
+		clientCtx:     ctx,
 		disableCommit: true,
-		imageContexts: &imageContexts{},
+		imageSources: newImageSources(ctx, builderOptions{
+			Options: &types.ImageBuildOptions{},
+			Backend: mockBackend,
+		}),
+		buildStages: newBuildStages(),
 	}
 	return b
 }

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/dockerfile/parser"
+	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/pkg/testutil"
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/assert"
@@ -192,8 +193,9 @@ func TestFromScratch(t *testing.T) {
 	}
 
 	require.NoError(t, err)
+	assert.True(t, req.state.hasFromImage())
 	assert.Equal(t, "", req.state.imageID)
-	assert.Equal(t, true, req.state.noBaseImage)
+	assert.Equal(t, []string{"PATH=" + system.DefaultPathEnv}, req.state.runConfig.Env)
 }
 
 func TestFromWithArg(t *testing.T) {

--- a/builder/dockerfile/imagecontext.go
+++ b/builder/dockerfile/imagecontext.go
@@ -5,10 +5,12 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/remotecontext"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 type pathCache interface {
@@ -16,35 +18,63 @@ type pathCache interface {
 	Store(key, value interface{})
 }
 
-// imageContexts is a helper for stacking up built image rootfs and reusing
-// them as contexts
-type imageContexts struct {
-	list   []*imageMount
-	byName map[string]*imageMount
-	cache  pathCache
+type buildStage struct {
+	id     string
+	config *container.Config
 }
 
-func (ic *imageContexts) add(name string, im *imageMount) error {
-	if len(name) > 0 {
-		if ic.byName == nil {
-			ic.byName = make(map[string]*imageMount)
+func newBuildStageFromImage(image builder.Image) *buildStage {
+	return &buildStage{id: image.ImageID(), config: image.RunConfig()}
+}
+
+func (b *buildStage) ImageID() string {
+	return b.id
+}
+
+func (b *buildStage) RunConfig() *container.Config {
+	return b.config
+}
+
+func (b *buildStage) update(imageID string, runConfig *container.Config) {
+	b.id = imageID
+	b.config = runConfig
+}
+
+var _ builder.Image = &buildStage{}
+
+// buildStages tracks each stage of a build so they can be retrieved by index
+// or by name.
+type buildStages struct {
+	sequence []*buildStage
+	byName   map[string]*buildStage
+}
+
+func newBuildStages() *buildStages {
+	return &buildStages{byName: make(map[string]*buildStage)}
+}
+
+func (s *buildStages) getByName(name string) (builder.Image, bool) {
+	stage, ok := s.byName[strings.ToLower(name)]
+	return stage, ok
+}
+
+func (s *buildStages) get(indexOrName string) (builder.Image, error) {
+	index, err := strconv.Atoi(indexOrName)
+	if err == nil {
+		if err := s.validateIndex(index); err != nil {
+			return nil, err
 		}
-		if _, ok := ic.byName[name]; ok {
-			return errors.Errorf("duplicate name %s", name)
-		}
-		ic.byName[name] = im
+		return s.sequence[index], nil
 	}
-	ic.list = append(ic.list, im)
-	return nil
+	if im, ok := s.byName[strings.ToLower(indexOrName)]; ok {
+		return im, nil
+	}
+	return nil, nil
 }
 
-func (ic *imageContexts) update(imageID string, runConfig *container.Config) {
-	ic.list[len(ic.list)-1].update(imageID, runConfig)
-}
-
-func (ic *imageContexts) validate(i int) error {
-	if i < 0 || i >= len(ic.list)-1 {
-		if i == len(ic.list)-1 {
+func (s *buildStages) validateIndex(i int) error {
+	if i < 0 || i >= len(s.sequence)-1 {
+		if i == len(s.sequence)-1 {
 			return errors.New("refers to current build stage")
 		}
 		return errors.New("index out of bounds")
@@ -52,30 +82,64 @@ func (ic *imageContexts) validate(i int) error {
 	return nil
 }
 
-func (ic *imageContexts) getMount(indexOrName string) (*imageMount, error) {
-	index, err := strconv.Atoi(indexOrName)
-	if err == nil {
-		if err := ic.validate(index); err != nil {
-			return nil, err
+func (s *buildStages) add(name string, image builder.Image) error {
+	stage := newBuildStageFromImage(image)
+	name = strings.ToLower(name)
+	if len(name) > 0 {
+		if _, ok := s.byName[name]; ok {
+			return errors.Errorf("duplicate name %s", name)
 		}
-		return ic.list[index], nil
+		s.byName[name] = stage
 	}
-	if im, ok := ic.byName[strings.ToLower(indexOrName)]; ok {
-		return im, nil
-	}
-	return nil, nil
+	s.sequence = append(s.sequence, stage)
+	return nil
 }
 
-func (ic *imageContexts) unmount() (retErr error) {
-	for _, iml := range append([][]*imageMount{}, ic.list, ic.implicitMounts) {
-		for _, im := range iml {
-			if err := im.unmount(); err != nil {
-				logrus.Error(err)
-				retErr = err
-			}
-		}
+func (s *buildStages) update(imageID string, runConfig *container.Config) {
+	s.sequence[len(s.sequence)-1].update(imageID, runConfig)
+}
+
+type getAndMountFunc func(string) (builder.Image, builder.ReleaseableLayer, error)
+
+// imageSources mounts images and provides a cache for mounted images. It tracks
+// all images so they can be unmounted at the end of the build.
+type imageSources struct {
+	byImageID map[string]*imageMount
+	getImage  getAndMountFunc
+	cache     pathCache // TODO: remove
+}
+
+func newImageSources(ctx context.Context, options builderOptions) *imageSources {
+	getAndMount := func(idOrRef string) (builder.Image, builder.ReleaseableLayer, error) {
+		return options.Backend.GetImageAndReleasableLayer(ctx, idOrRef, backend.GetImageAndLayerOptions{
+			ForcePull:  options.Options.PullParent,
+			AuthConfig: options.Options.AuthConfigs,
+			Output:     options.ProgressWriter.Output,
+		})
 	}
-	for _, im := range ic.byName {
+
+	return &imageSources{
+		byImageID: make(map[string]*imageMount),
+		getImage:  getAndMount,
+	}
+}
+
+func (m *imageSources) Get(idOrRef string) (*imageMount, error) {
+	if im, ok := m.byImageID[idOrRef]; ok {
+		return im, nil
+	}
+
+	image, layer, err := m.getImage(idOrRef)
+	if err != nil {
+		return nil, err
+	}
+	im := newImageMount(image, layer)
+	m.byImageID[image.ImageID()] = im
+	return im, nil
+}
+
+func (m *imageSources) Unmount() (retErr error) {
+	for _, im := range m.byImageID {
 		if err := im.unmount(); err != nil {
 			logrus.Error(err)
 			retErr = err
@@ -84,47 +148,43 @@ func (ic *imageContexts) unmount() (retErr error) {
 	return
 }
 
-// TODO: remove getCache/setCache from imageContexts
-func (ic *imageContexts) getCache(id, path string) (interface{}, bool) {
-	if ic.cache != nil {
+// TODO: remove getCache/setCache from imageSources
+func (m *imageSources) getCache(id, path string) (interface{}, bool) {
+	if m.cache != nil {
 		if id == "" {
 			return nil, false
 		}
-		return ic.cache.Load(id + path)
+		return m.cache.Load(id + path)
 	}
 	return nil, false
 }
 
-func (ic *imageContexts) setCache(id, path string, v interface{}) {
-	if ic.cache != nil {
-		ic.cache.Store(id+path, v)
+func (m *imageSources) setCache(id, path string, v interface{}) {
+	if m.cache != nil {
+		m.cache.Store(id+path, v)
 	}
 }
 
 // imageMount is a reference to an image that can be used as a builder.Source
 type imageMount struct {
-	id        string
-	source    builder.Source
-	runConfig *container.Config
-	layer     builder.ReleaseableLayer
+	image  builder.Image
+	source builder.Source
+	layer  builder.ReleaseableLayer
 }
 
 func newImageMount(image builder.Image, layer builder.ReleaseableLayer) *imageMount {
-	im := &imageMount{layer: layer}
-	if image != nil {
-		im.update(image.ImageID(), image.RunConfig())
-	}
+	im := &imageMount{image: image, layer: layer}
 	return im
 }
 
-func (im *imageMount) context() (builder.Source, error) {
+func (im *imageMount) Source() (builder.Source, error) {
 	if im.source == nil {
-		if im.id == "" || im.layer == nil {
+		if im.layer == nil {
 			return nil, errors.Errorf("empty context")
 		}
-		mountPath, err := im.layer.Mount(im.id)
+		mountPath, err := im.layer.Mount()
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to mount %s", im.id)
+			return nil, errors.Wrapf(err, "failed to mount %s", im.image.ImageID())
 		}
 		source, err := remotecontext.NewLazyContext(mountPath)
 		if err != nil {
@@ -140,20 +200,11 @@ func (im *imageMount) unmount() error {
 		return nil
 	}
 	if err := im.layer.Release(); err != nil {
-		return errors.Wrapf(err, "failed to unmount previous build image %s", im.id)
+		return errors.Wrapf(err, "failed to unmount previous build image %s", im.image.ImageID())
 	}
 	return nil
 }
 
-func (im *imageMount) update(imageID string, runConfig *container.Config) {
-	im.id = imageID
-	im.runConfig = runConfig
-}
-
-func (im *imageMount) ImageID() string {
-	return im.id
-}
-
-func (im *imageMount) RunConfig() *container.Config {
-	return im.runConfig
+func (im *imageMount) Image() builder.Image {
+	return im.image
 }

--- a/builder/dockerfile/imagecontext.go
+++ b/builder/dockerfile/imagecontext.go
@@ -45,9 +45,9 @@ func (ic *imageContexts) update(imageID string, runConfig *container.Config) {
 func (ic *imageContexts) validate(i int) error {
 	if i < 0 || i >= len(ic.list)-1 {
 		if i == len(ic.list)-1 {
-			return errors.Errorf("%d refers to current build stage", i)
+			return errors.New("refers to current build stage")
 		}
-		return errors.Errorf("index out of bounds")
+		return errors.New("index out of bounds")
 	}
 	return nil
 }
@@ -122,7 +122,7 @@ func (im *imageMount) context() (builder.Source, error) {
 		if im.id == "" || im.layer == nil {
 			return nil, errors.Errorf("empty context")
 		}
-		mountPath, err := im.layer.Mount()
+		mountPath, err := im.layer.Mount(im.id)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to mount %s", im.id)
 		}
@@ -136,6 +136,9 @@ func (im *imageMount) context() (builder.Source, error) {
 }
 
 func (im *imageMount) unmount() error {
+	if im.layer == nil {
+		return nil
+	}
 	if err := im.layer.Release(); err != nil {
 		return errors.Wrapf(err, "failed to unmount previous build image %s", im.id)
 	}

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -372,7 +372,7 @@ func (b *Builder) calcCopyInfo(cmdName, origPath string, allowLocalDecompression
 	if imageSource != nil {
 		source, err = imageSource.context()
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "failed to copy")
 		}
 	}
 

--- a/builder/dockerfile/mockbackend_test.go
+++ b/builder/dockerfile/mockbackend_test.go
@@ -66,15 +66,7 @@ func (m *MockBackend) CopyOnBuild(containerID string, destPath string, srcRoot s
 	return nil
 }
 
-func (m *MockBackend) HasExperimental() bool {
-	return false
-}
-
-func (m *MockBackend) SquashImage(from string, to string) (string, error) {
-	return "", nil
-}
-
-func (m *MockBackend) GetImageAndLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (builder.Image, builder.ReleaseableLayer, error) {
+func (m *MockBackend) GetImageAndReleasableLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (builder.Image, builder.ReleaseableLayer, error) {
 	if m.getImageFunc != nil {
 		return m.getImageFunc(refOrID)
 	}
@@ -112,6 +104,6 @@ func (l *mockLayer) Release() error {
 	return nil
 }
 
-func (l *mockLayer) Mount(_ string) (string, error) {
+func (l *mockLayer) Mount() (string, error) {
 	return "mountPath", nil
 }

--- a/builder/dockerfile/mockbackend_test.go
+++ b/builder/dockerfile/mockbackend_test.go
@@ -112,6 +112,6 @@ func (l *mockLayer) Release() error {
 	return nil
 }
 
-func (l *mockLayer) Mount() (string, error) {
+func (l *mockLayer) Mount(_ string) (string, error) {
 	return "mountPath", nil
 }

--- a/builder/dockerfile/mockbackend_test.go
+++ b/builder/dockerfile/mockbackend_test.go
@@ -15,28 +15,13 @@ import (
 
 // MockBackend implements the builder.Backend interface for unit testing
 type MockBackend struct {
-	getImageOnBuildFunc  func(string) (builder.Image, error)
-	getImageOnBuildImage *mockImage
-	containerCreateFunc  func(config types.ContainerCreateConfig) (container.ContainerCreateCreatedBody, error)
-	commitFunc           func(string, *backend.ContainerCommitConfig) (string, error)
-}
-
-func (m *MockBackend) GetImageOnBuild(name string) (builder.Image, error) {
-	if m.getImageOnBuildFunc != nil {
-		return m.getImageOnBuildFunc(name)
-	}
-	if m.getImageOnBuildImage != nil {
-		return m.getImageOnBuildImage, nil
-	}
-	return &mockImage{id: "theid"}, nil
+	containerCreateFunc func(config types.ContainerCreateConfig) (container.ContainerCreateCreatedBody, error)
+	commitFunc          func(string, *backend.ContainerCommitConfig) (string, error)
+	getImageFunc        func(string) (builder.Image, builder.ReleaseableLayer, error)
 }
 
 func (m *MockBackend) TagImageWithReference(image.ID, reference.Named) error {
 	return nil
-}
-
-func (m *MockBackend) PullOnBuild(ctx context.Context, name string, authConfigs map[string]types.AuthConfig, output io.Writer) (builder.Image, error) {
-	return nil, nil
 }
 
 func (m *MockBackend) ContainerAttachRaw(cID string, stdin io.ReadCloser, stdout, stderr io.Writer, stream bool, attached chan struct{}) error {
@@ -89,8 +74,12 @@ func (m *MockBackend) SquashImage(from string, to string) (string, error) {
 	return "", nil
 }
 
-func (m *MockBackend) MountImage(name string) (string, func() error, error) {
-	return "", func() error { return nil }, nil
+func (m *MockBackend) GetImageAndLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (builder.Image, builder.ReleaseableLayer, error) {
+	if m.getImageFunc != nil {
+		return m.getImageFunc(refOrID)
+	}
+
+	return &mockImage{id: "theid"}, &mockLayer{}, nil
 }
 
 type mockImage struct {
@@ -115,4 +104,14 @@ func (mic *mockImageCache) GetCache(parentID string, cfg *container.Config) (str
 		return mic.getCacheFunc(parentID, cfg)
 	}
 	return "", nil
+}
+
+type mockLayer struct{}
+
+func (l *mockLayer) Release() error {
+	return nil
+}
+
+func (l *mockLayer) Mount() (string, error) {
+	return "mountPath", nil
 }

--- a/daemon/build.go
+++ b/daemon/build.go
@@ -1,0 +1,108 @@
+package daemon
+
+import (
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/builder"
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/layer"
+	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/docker/registry"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+	"io"
+)
+
+type releaseableLayer struct {
+	rwLayer layer.RWLayer
+	release func(layer.RWLayer) error
+	mount   func() (layer.RWLayer, error)
+}
+
+func (rl *releaseableLayer) Release() error {
+	if rl.rwLayer == nil {
+		return nil
+	}
+	rl.rwLayer.Unmount()
+	return rl.release(rl.rwLayer)
+}
+
+func (rl *releaseableLayer) Mount() (string, error) {
+	var err error
+	// daemon.layerStore.CreateRWLayer(mountID, img.RootFS.ChainID(), nil)
+	rl.rwLayer, err = rl.mount()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create rwlayer")
+	}
+
+	mountPath, err := rl.rwLayer.Mount("")
+	if err != nil {
+		releaseErr := rl.release(rl.rwLayer)
+		if releaseErr != nil {
+			err = errors.Wrapf(err, "failed to release rwlayer: %s", releaseErr.Error())
+		}
+		return "", errors.Wrap(err, "failed to mount rwlayer")
+	}
+	return mountPath, err
+}
+
+func (daemon *Daemon) getReleasableLayerForImage(img *image.Image) (*releaseableLayer, error) {
+	mountFunc := func() (layer.RWLayer, error) {
+		mountID := stringid.GenerateRandomID()
+		return daemon.layerStore.CreateRWLayer(mountID, img.RootFS.ChainID(), nil)
+	}
+
+	releaseFunc := func(rwLayer layer.RWLayer) error {
+		metadata, err := daemon.layerStore.ReleaseRWLayer(rwLayer)
+		layer.LogReleaseMetadata(metadata)
+		return err
+	}
+
+	return &releaseableLayer{mount: mountFunc, release: releaseFunc}, nil
+}
+
+// TODO: could this use the regular daemon PullImage ?
+func (daemon *Daemon) pullForBuilder(ctx context.Context, name string, authConfigs map[string]types.AuthConfig, output io.Writer) (*image.Image, error) {
+	ref, err := reference.ParseNormalizedNamed(name)
+	if err != nil {
+		return nil, err
+	}
+	ref = reference.TagNameOnly(ref)
+
+	pullRegistryAuth := &types.AuthConfig{}
+	if len(authConfigs) > 0 {
+		// The request came with a full auth config file, we prefer to use that
+		repoInfo, err := daemon.RegistryService.ResolveRepository(ref)
+		if err != nil {
+			return nil, err
+		}
+
+		resolvedConfig := registry.ResolveAuthConfig(authConfigs, repoInfo.Index)
+		pullRegistryAuth = &resolvedConfig
+	}
+
+	if err := daemon.pullImageWithReference(ctx, ref, nil, pullRegistryAuth, output); err != nil {
+		return nil, err
+	}
+	return daemon.GetImage(name)
+}
+
+// GetImageAndLayer returns an image and releaseable layer for a reference or ID
+func (daemon *Daemon) GetImageAndLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (builder.Image, builder.ReleaseableLayer, error) {
+	if !opts.ForcePull {
+		image, _ := daemon.GetImage(refOrID)
+		// TODO: shouldn't we error out if error is different from "not found" ?
+		if image != nil {
+			layer, err := daemon.getReleasableLayerForImage(image)
+			return image, layer, err
+		}
+	}
+
+	image, err := daemon.pullForBuilder(ctx, refOrID, opts.AuthConfig, opts.Output)
+	if err != nil {
+		return nil, nil, err
+	}
+	layer, err := daemon.getReleasableLayerForImage(image)
+	return image, layer, err
+}

--- a/daemon/image.go
+++ b/daemon/image.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/docker/distribution/reference"
-	"github.com/docker/docker/builder"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/stringid"
 )
@@ -74,13 +73,4 @@ func (daemon *Daemon) GetImage(refOrID string) (*image.Image, error) {
 		return nil, err
 	}
 	return daemon.imageStore.Get(imgID)
-}
-
-// GetImageOnBuild looks up a Docker image referenced by `name`.
-func (daemon *Daemon) GetImageOnBuild(name string) (builder.Image, error) {
-	img, err := daemon.GetImage(name)
-	if err != nil {
-		return nil, err
-	}
-	return img, nil
 }

--- a/daemon/image_pull.go
+++ b/daemon/image_pull.go
@@ -7,7 +7,6 @@ import (
 	dist "github.com/docker/distribution"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/builder"
 	"github.com/docker/docker/distribution"
 	progressutils "github.com/docker/docker/distribution/utils"
 	"github.com/docker/docker/pkg/progress"
@@ -44,35 +43,6 @@ func (daemon *Daemon) PullImage(ctx context.Context, image, tag string, metaHead
 	}
 
 	return daemon.pullImageWithReference(ctx, ref, metaHeaders, authConfig, outStream)
-}
-
-// PullOnBuild tells Docker to pull image referenced by `name`.
-func (daemon *Daemon) PullOnBuild(ctx context.Context, name string, authConfigs map[string]types.AuthConfig, output io.Writer) (builder.Image, error) {
-	ref, err := reference.ParseNormalizedNamed(name)
-	if err != nil {
-		return nil, err
-	}
-	ref = reference.TagNameOnly(ref)
-
-	pullRegistryAuth := &types.AuthConfig{}
-	if len(authConfigs) > 0 {
-		// The request came with a full auth config file, we prefer to use that
-		repoInfo, err := daemon.RegistryService.ResolveRepository(ref)
-		if err != nil {
-			return nil, err
-		}
-
-		resolvedConfig := registry.ResolveAuthConfig(
-			authConfigs,
-			repoInfo.Index,
-		)
-		pullRegistryAuth = &resolvedConfig
-	}
-
-	if err := daemon.pullImageWithReference(ctx, ref, nil, pullRegistryAuth, output); err != nil {
-		return nil, err
-	}
-	return daemon.GetImage(name)
 }
 
 func (daemon *Daemon) pullImageWithReference(ctx context.Context, ref reference.Named, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error {

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5946,7 +5946,7 @@ func (s *DockerSuite) TestBuildCopyFromPreviousRootFSErrors(c *check.C) {
 			dockerfile: `
 		FROM busybox
 		COPY --from=0 foo bar`,
-			expectedError: "invalid from flag value 0 refers current build block",
+			expectedError: "invalid from flag value 0: refers to current build stage",
 		},
 		{
 			dockerfile: `


### PR DESCRIPTION
Implement the second task in #32904

This PR removes the previous 3 Image functions from the builder.Backend interface and replaces them with a single function. Also refactors the interfaces between `imageMount`, `imageContects`, and `dispatchers.from`

