### PR TITLE
[Builder] Refactor builder probe cache and container backend

### DIFF
--- a/builder/dockerfile/buildargs.go
+++ b/builder/dockerfile/buildargs.go
@@ -2,8 +2,9 @@ package dockerfile
 
 import (
 	"fmt"
-	"github.com/docker/docker/runconfig/opts"
 	"io"
+
+	"github.com/docker/docker/runconfig/opts"
 )
 
 // builtinAllowedBuildArgs is list of built-in allowed build args

--- a/builder/dockerfile/buildargs_test.go
+++ b/builder/dockerfile/buildargs_test.go
@@ -1,9 +1,9 @@
 package dockerfile
 
 import (
+	"bytes"
 	"testing"
 
-	"bytes"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/builder/dockerfile/containerbackend.go
+++ b/builder/dockerfile/containerbackend.go
@@ -1,0 +1,143 @@
+package dockerfile
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/builder"
+	containerpkg "github.com/docker/docker/container"
+	"github.com/docker/docker/pkg/stringid"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+)
+
+type containerManager struct {
+	tmpContainers map[string]struct{}
+	backend       builder.ExecBackend
+}
+
+// newContainerManager creates a new container backend
+func newContainerManager(docker builder.ExecBackend) *containerManager {
+	return &containerManager{
+		backend:       docker,
+		tmpContainers: make(map[string]struct{}),
+	}
+}
+
+// Create a container
+func (c *containerManager) Create(runConfig *container.Config, hostConfig *container.HostConfig) (container.ContainerCreateCreatedBody, error) {
+	container, err := c.backend.ContainerCreate(types.ContainerCreateConfig{
+		Config:     runConfig,
+		HostConfig: hostConfig,
+	})
+	if err != nil {
+		return container, err
+	}
+	c.tmpContainers[container.ID] = struct{}{}
+	return container, nil
+}
+
+var errCancelled = errors.New("build cancelled")
+
+// Run a container by ID
+func (c *containerManager) Run(ctx context.Context, cID string, stdout, stderr io.Writer) (err error) {
+	attached := make(chan struct{})
+	errCh := make(chan error)
+	go func() {
+		errCh <- c.backend.ContainerAttachRaw(cID, nil, stdout, stderr, true, attached)
+	}()
+	select {
+	case err := <-errCh:
+		return err
+	case <-attached:
+	}
+
+	finished := make(chan struct{})
+	cancelErrCh := make(chan error, 1)
+	go func() {
+		select {
+		case <-ctx.Done():
+			logrus.Debugln("Build cancelled, killing and removing container:", cID)
+			c.backend.ContainerKill(cID, 0)
+			c.removeContainer(cID, stdout)
+			cancelErrCh <- errCancelled
+		case <-finished:
+			cancelErrCh <- nil
+		}
+	}()
+
+	if err := c.backend.ContainerStart(cID, nil, "", ""); err != nil {
+		close(finished)
+		logCancellationError(cancelErrCh, "error from ContainerStart: "+err.Error())
+		return err
+	}
+
+	// Block on reading output from container, stop on err or chan closed
+	if err := <-errCh; err != nil {
+		close(finished)
+		logCancellationError(cancelErrCh, "error from errCh: "+err.Error())
+		return err
+	}
+
+	waitC, err := c.backend.ContainerWait(ctx, cID, containerpkg.WaitConditionNotRunning)
+	if err != nil {
+		close(finished)
+		logCancellationError(cancelErrCh, fmt.Sprintf("unable to begin ContainerWait: %s", err))
+		return err
+	}
+
+	if status := <-waitC; status.ExitCode() != 0 {
+		close(finished)
+		logCancellationError(cancelErrCh,
+			fmt.Sprintf("a non-zero code from ContainerWait: %d", status.ExitCode()))
+		return &statusCodeError{code: status.ExitCode(), err: err}
+	}
+
+	close(finished)
+	return <-cancelErrCh
+}
+
+func logCancellationError(cancelErrCh chan error, msg string) {
+	if cancelErr := <-cancelErrCh; cancelErr != nil {
+		logrus.Debugf("Build cancelled (%v): ", cancelErr, msg)
+	}
+}
+
+type statusCodeError struct {
+	code int
+	err  error
+}
+
+func (e *statusCodeError) Error() string {
+	return e.err.Error()
+}
+
+func (e *statusCodeError) StatusCode() int {
+	return e.code
+}
+
+func (c *containerManager) removeContainer(containerID string, stdout io.Writer) error {
+	rmConfig := &types.ContainerRmConfig{
+		ForceRemove:  true,
+		RemoveVolume: true,
+	}
+	if err := c.backend.ContainerRm(containerID, rmConfig); err != nil {
+		fmt.Fprintf(stdout, "Error removing intermediate container %s: %v\n", stringid.TruncateID(containerID), err)
+		return err
+	}
+	return nil
+}
+
+// RemoveAll containers managed by this container manager
+func (c *containerManager) RemoveAll(stdout io.Writer) {
+	for containerID := range c.tmpContainers {
+		if err := c.removeContainer(containerID, stdout); err != nil {
+			return
+		}
+		delete(c.tmpContainers, containerID)
+		fmt.Fprintf(stdout, "Removing intermediate container %s\n", stringid.TruncateID(containerID))
+	}
+}

--- a/builder/dockerfile/imageprobe.go
+++ b/builder/dockerfile/imageprobe.go
@@ -1,0 +1,63 @@
+package dockerfile
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/builder"
+)
+
+// ImageProber exposes an Image cache to the Builder. It supports resetting a
+// cache.
+type ImageProber interface {
+	Reset()
+	Probe(parentID string, runConfig *container.Config) (string, error)
+}
+
+type imageProber struct {
+	cache       builder.ImageCache
+	reset       func() builder.ImageCache
+	cacheBusted bool
+}
+
+func newImageProber(cacheBuilder builder.ImageCacheBuilder, cacheFrom []string, noCache bool) ImageProber {
+	if noCache {
+		return &nopProber{}
+	}
+
+	reset := func() builder.ImageCache {
+		return cacheBuilder.MakeImageCache(cacheFrom)
+	}
+	return &imageProber{cache: reset(), reset: reset}
+}
+
+func (c *imageProber) Reset() {
+	c.cache = c.reset()
+	c.cacheBusted = false
+}
+
+// Probe checks if cache match can be found for current build instruction.
+// It returns the cachedID if there is a hit, and the empty string on miss
+func (c *imageProber) Probe(parentID string, runConfig *container.Config) (string, error) {
+	if c.cacheBusted {
+		return "", nil
+	}
+	cacheID, err := c.cache.GetCache(parentID, runConfig)
+	if err != nil {
+		return "", err
+	}
+	if len(cacheID) == 0 {
+		logrus.Debugf("[BUILDER] Cache miss: %s", runConfig.Cmd)
+		c.cacheBusted = true
+		return "", nil
+	}
+	logrus.Debugf("[BUILDER] Use cached version: %s", runConfig.Cmd)
+	return cacheID, nil
+}
+
+type nopProber struct{}
+
+func (c *nopProber) Reset() {}
+
+func (c *nopProber) Probe(_ string, _ *container.Config) (string, error) {
+	return "", nil
+}

--- a/builder/dockerfile/mockbackend_test.go
+++ b/builder/dockerfile/mockbackend_test.go
@@ -3,13 +3,11 @@ package dockerfile
 import (
 	"io"
 
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
 	containerpkg "github.com/docker/docker/container"
-	"github.com/docker/docker/image"
 	"golang.org/x/net/context"
 )
 
@@ -18,10 +16,7 @@ type MockBackend struct {
 	containerCreateFunc func(config types.ContainerCreateConfig) (container.ContainerCreateCreatedBody, error)
 	commitFunc          func(string, *backend.ContainerCommitConfig) (string, error)
 	getImageFunc        func(string) (builder.Image, builder.ReleaseableLayer, error)
-}
-
-func (m *MockBackend) TagImageWithReference(image.ID, reference.Named) error {
-	return nil
+	makeImageCacheFunc  func(cacheFrom []string) builder.ImageCache
 }
 
 func (m *MockBackend) ContainerAttachRaw(cID string, stdin io.ReadCloser, stdout, stderr io.Writer, stream bool, attached chan struct{}) error {
@@ -72,6 +67,13 @@ func (m *MockBackend) GetImageAndReleasableLayer(ctx context.Context, refOrID st
 	}
 
 	return &mockImage{id: "theid"}, &mockLayer{}, nil
+}
+
+func (m *MockBackend) MakeImageCache(cacheFrom []string) builder.ImageCache {
+	if m.makeImageCacheFunc != nil {
+		return m.makeImageCacheFunc(cacheFrom)
+	}
+	return nil
 }
 
 type mockImage struct {

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -100,7 +100,7 @@ func (s *DockerSuite) TestImagesFilterLabelMatch(c *check.C) {
 }
 
 // Regression : #15659
-func (s *DockerSuite) TestImagesFilterLabelWithCommit(c *check.C) {
+func (s *DockerSuite) TestCommitWithFilterLabel(c *check.C) {
 	// Create a container
 	dockerCmd(c, "run", "--name", "bar", "busybox", "/bin/sh")
 	// Commit with labels "using changes"


### PR DESCRIPTION
Part of the first task in #32904

Remove `tmpContainers` from `Builder` and 6 container methods from `builder.Backend`. Replaced with `ContainerBackend` which has 3 methods.

Remove `cacheBusted` and `imageCache` from `Builder`, replaced with an `imageProber` which exposes the cache to `Builder`.