### PR TITLE
Add a `replace` function for Go templates (fixes #30518)

### DIFF
--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -18,6 +18,7 @@ var basicFunctions = template.FuncMap{
 	"title":    strings.Title,
 	"lower":    strings.ToLower,
 	"upper":    strings.ToUpper,
+	"replace":  strings.Replace,
 	"pad":      padWithSpace,
 	"truncate": truncateWithLength,
 }

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -7,16 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseStringFunctions(t *testing.T) {
-	tm, err := Parse(`{{join (split . ":") "/"}}`)
-	assert.NoError(t, err)
-
-	var b bytes.Buffer
-	assert.NoError(t, tm.Execute(&b, "text:with:colon"))
-	want := "text/with/colon"
-	assert.Equal(t, want, b.String())
-}
-
 func TestNewParse(t *testing.T) {
 	tm, err := NewParse("foo", "this is a {{ . }}")
 	assert.NoError(t, err)
@@ -27,23 +17,60 @@ func TestNewParse(t *testing.T) {
 	assert.Equal(t, want, b.String())
 }
 
-func TestParseTruncateFunction(t *testing.T) {
-	source := "tupx5xzf6hvsrhnruz5cr8gwp"
-
+func TestParseStringTruncateFunction(t *testing.T) {
 	testCases := []struct {
 		template string
+		source   string
 		expected string
 	}{
 		{
+			template: `{{join (split . ":") "/"}}`,
+			source:   "text:with:colon",
+			expected: "text/with/colon",
+		},
+		{
+			template: `{{replace . ":" "/" -1}}`,
+			source:   "text:with:colon",
+			expected: "text/with/colon",
+		},
+		{
+			template: `{{upper . }}`,
+			source:   "abc12",
+			expected: "ABC12",
+		},
+		{
+			template: `{{lower . }}`,
+			source:   "ABC12",
+			expected: "abc12",
+		},
+		{
+			template: `{{title . }}`,
+			source:   "her royal highness",
+			expected: "Her Royal Highness",
+		},
+		{
+			template: `{{pad . 2 3}}`,
+			source:   "",
+			expected: "",
+		},
+		{
+			template: `{{pad . 2 3}}`,
+			source:   "padthis",
+			expected: "  padthis   ",
+		},
+		{
 			template: `{{truncate . 5}}`,
+			source:   "tupx5xzf6hvsrhnruz5cr8gwp",
 			expected: "tupx5",
 		},
 		{
 			template: `{{truncate . 25}}`,
+			source:   "tupx5xzf6hvsrhnruz5cr8gwp",
 			expected: "tupx5xzf6hvsrhnruz5cr8gwp",
 		},
 		{
 			template: `{{truncate . 30}}`,
+			source:   "tupx5xzf6hvsrhnruz5cr8gwp",
 			expected: "tupx5xzf6hvsrhnruz5cr8gwp",
 		},
 	}
@@ -53,7 +80,7 @@ func TestParseTruncateFunction(t *testing.T) {
 		assert.NoError(t, err)
 
 		var b bytes.Buffer
-		assert.NoError(t, tm.Execute(&b, source))
+		assert.NoError(t, tm.Execute(&b, testCase.source))
 		assert.Equal(t, testCase.expected, b.String())
 	}
 }


### PR DESCRIPTION
**- What I did**

Add a replace function for Go Template to work around the limitations of the AWS API that disallow the use of ":" in the logstreams names:

http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogStream.html#API_CreateLogStream_RequestSyntax

**- How I did it**

Added 'replace' alongside the other strings functions.

As well as adding a unit test for replace, added tests cases for upper, lower, title and pad. Refactored template use cases.

Thanks to Colin Hebert <makkhdyn@gmail.com> for his help finding my way around the code and @rwolfson for the initial suggestion in #30518.

**- How to verify it**

With this addition, it is possible to start dockerd with the awslogs log driver as such:

```
--log-driver=awslogs --log-opt awslogs-group=docker-awslogs --log-opt tag='{{ replace .ImageName ":" "_"  -1}}-{{.ID}}'
```

With the `replace` function if you start an image with `docker run XXXXXX.dkr.ecr.YYYYY.amazonaws.com/path/image:mytag` and the above configuration, the logs would successfully appear in the cloudwatch logs under `docker-awslogs/XXXXXX.dkr.ecr.YYYYY.amazonaws.com/path/image_mytag-bf0072049c76`. Running with `XXXXXX.dkr.ecr.YYYYY.amazonaws.com/path/image` would appear under `docker-awslogs/XXXXXX.dkr.ecr.YYYYY.amazonaws.com/path/image-bf0072049c76`.

**- Description for the changelog**
Add a `replace` function for Go templates (fixes #30518)

Signed-off-by: Gildas Le Nadan <gildas@endemic-systems.com>