### PR TITLE
Windows: Block read-only

### DIFF
--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -79,6 +79,11 @@ func DecodeContainerConfig(src io.Reader) (*container.Config, *container.HostCon
 		return nil, nil, nil, err
 	}
 
+	// Validate ReadonlyRootfs
+	if err := validateReadonlyRootfs(hc); err != nil {
+		return nil, nil, nil, err
+	}
+
 	return w.Config, hc, w.NetworkingConfig, nil
 }
 

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -103,3 +103,8 @@ func validateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
 func validatePrivileged(hc *container.HostConfig) error {
 	return nil
 }
+
+// validateReadonlyRootfs performs platform specific validation of the ReadonlyRootfs setting
+func validateReadonlyRootfs(hc *container.HostConfig) error {
+	return nil
+}

--- a/runconfig/hostconfig_windows.go
+++ b/runconfig/hostconfig_windows.go
@@ -82,3 +82,15 @@ func validatePrivileged(hc *container.HostConfig) error {
 	}
 	return nil
 }
+
+// validateReadonlyRootfs performs platform specific validation of the ReadonlyRootfs setting
+func validateReadonlyRootfs(hc *container.HostConfig) error {
+	// We may not be passed a host config, such as in the case of docker commit
+	if hc == nil {
+		return nil
+	}
+	if hc.ReadonlyRootfs {
+		return fmt.Errorf("invalid --read-only: Windows does not support this feature")
+	}
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Windows containers do not (and are unlikely to anytime soon) support a read-only root filesystem. This adds a block if it is attempted. Fixes https://github.com/moby/moby/issues/33065. @sixeyed

```
PS E:\docker\build\scratch> docker run --rm microsoft/windowsservercore cmd /s /c echo hello
hello
PS E:\docker\build\scratch> docker run --read-only --rm microsoft/windowsservercore cmd /s /c echo hello
e:\go\src\github.com\docker\docker\bundles\docker.exe: Error response from daemon: invalid --read-only: Windows does not support this feature.
See 'e:\go\src\github.com\docker\docker\bundles\docker.exe run --help'.
PS E:\docker\build\scratch>
```