### PR TITLE
syntax highlighting: support FROM...AS for multi stage build

### DIFF
--- a/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
+++ b/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
@@ -16,6 +16,23 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
+					<string>keyword.other.special-method.dockerfile</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.special-method.dockerfile</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>^\s*\b(FROM)\b.*?\b(AS)\b</string>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
 					<string>keyword.control.dockerfile</string>
 				</dict>
 				<key>2</key>


### PR DESCRIPTION

**- What I did**
Added support for `AS` for multi stage builds, as in `FROM node AS base`

**- How I did it**
Added new a capture to the `dockerfile.tmLanguage` file

**- How to verify it**
I tested that this works in VS Code. I added the `tmLanguage` file to the `vscode-docker` extension and it looks good.

**- Description for the changelog**
Add a new capture group to support `FROM...AS` in the Dockerfile syntax



