### PR TITLE
[17.03] Vendor swarmkit e680722

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -101,7 +101,7 @@ github.com/docker/containerd 4ab9917febca54791c5f071a9d1f404867857fcc
 github.com/tonistiigi/fifo 1405643975692217d6720f8b54aeee1bf2cd5cf4
 
 # cluster
-github.com/docker/swarmkit 17756457ad6dc4d8a639a1f0b7a85d1b65a617bb
+github.com/docker/swarmkit e68072200ebbba6ce9745b3a3e49fdba3eb71ff8
 github.com/golang/mock bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 github.com/gogo/protobuf v0.3
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a

--- a/vendor/github.com/docker/swarmkit/agent/agent.go
+++ b/vendor/github.com/docker/swarmkit/agent/agent.go
@@ -264,8 +264,8 @@ func (a *Agent) run(ctx context.Context) {
 			sessionq = a.sessionq
 		case err := <-session.errs:
 			// TODO(stevvooe): This may actually block if a session is closed
-			// but no error was sent. Session.close must only be called here
-			// for this to work.
+			// but no error was sent. This must be the only place
+			// session.close is called in response to errors, for this to work.
 			if err != nil {
 				log.G(ctx).WithError(err).Error("agent: session failed")
 				backoff = initialSessionFailureBackoff + 2*backoff
@@ -315,7 +315,11 @@ func (a *Agent) run(ctx context.Context) {
 				nodeDescription = newNodeDescription
 				// close the session
 				log.G(ctx).Info("agent: found node update")
-				session.sendError(nil)
+				if err := session.close(); err != nil {
+					log.G(ctx).WithError(err).Error("agent: closing session failed")
+				}
+				sessionq = nil
+				registered = nil
 			}
 		case <-a.stopped:
 			// TODO(stevvooe): Wait on shutdown and cleanup. May need to pump

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/global/global.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/global/global.go
@@ -243,8 +243,9 @@ func (g *Orchestrator) reconcileServices(ctx context.Context, serviceIDs []strin
 	updates := make(map[*api.Service][]orchestrator.Slot)
 
 	_, err := g.store.Batch(func(batch *store.Batch) error {
-		var updateTasks []orchestrator.Slot
 		for _, serviceID := range serviceIDs {
+			var updateTasks []orchestrator.Slot
+
 			if _, exists := nodeTasks[serviceID]; !exists {
 				continue
 			}
@@ -298,7 +299,6 @@ func (g *Orchestrator) reconcileServices(ctx context.Context, serviceIDs []strin
 	for service, updateTasks := range updates {
 		g.updater.Update(ctx, g.cluster, service, updateTasks)
 	}
-
 }
 
 // updateNode updates g.nodes based on the current node value

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/update/updater.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/update/updater.go
@@ -406,7 +406,11 @@ func (u *Updater) updateTask(ctx context.Context, slot orchestrator.Slot, update
 	}
 
 	if delayStartCh != nil {
-		<-delayStartCh
+		select {
+		case <-delayStartCh:
+		case <-u.stopChan:
+			return nil
+		}
 	}
 
 	// Wait for the new task to come up.
@@ -456,7 +460,11 @@ func (u *Updater) useExistingTask(ctx context.Context, slot orchestrator.Slot, e
 		}
 
 		if delayStartCh != nil {
-			<-delayStartCh
+			select {
+			case <-delayStartCh:
+			case <-u.stopChan:
+				return nil
+			}
 		}
 	}
 


### PR DESCRIPTION
This vendors the relevant branch of swarmkit for 17.03.2. It brings in the following fixes:

- Fix GetRemoteSignedCertificate retry (https://github.com/docker/swarmkit/pull/2069)
- Add a 5-second timeout to an external CA signing request (https://github.com/docker/swarmkit/pull/2068)
- orchestrator/global: Fix incorrectly assembled parameters to updater.Update (https://github.com/docker/swarmkit/pull/2113)
- agent: Resolve deadlock in run (https://github.com/docker/swarmkit/pull/2166)

Fixes #32218