### PR TITLE
Devmapper fixes for cookie generation and error reporting (fixes  #33050)

### DIFF
--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -328,11 +328,11 @@ func RemoveDevice(name string) error {
 		return err
 	}
 
-	var cookie uint
-	if err := task.setCookie(&cookie, 0); err != nil {
+	cookie := new(uint)
+	if err := task.setCookie(cookie, 0); err != nil {
 		return fmt.Errorf("devicemapper: Can not set cookie: %s", err)
 	}
-	defer UdevWait(&cookie)
+	defer UdevWait(cookie)
 
 	dmSawBusy = false // reset before the task is run
 	if err = task.run(); err != nil {
@@ -361,10 +361,10 @@ func RemoveDeviceDeferred(name string) error {
 	// set a task cookie and disable library fallback, or else libdevmapper will
 	// disable udev dm rules and delete the symlink under /dev/mapper by itself,
 	// even if the removal is deferred by the kernel.
-	var cookie uint
+	cookie := new(uint)
 	var flags uint16
 	flags = DmUdevDisableLibraryFallback
-	if err := task.setCookie(&cookie, flags); err != nil {
+	if err := task.setCookie(cookie, flags); err != nil {
 		return fmt.Errorf("devicemapper: Can not set cookie: %s", err)
 	}
 
@@ -377,7 +377,7 @@ func RemoveDeviceDeferred(name string) error {
 	// this call will not wait for the deferred removal's final executing, since no
 	// udev event will be generated, and the semaphore's value will not be incremented
 	// by udev, what UdevWait is just cleaning up the semaphore.
-	defer UdevWait(&cookie)
+	defer UdevWait(cookie)
 
 	if err = task.run(); err != nil {
 		return fmt.Errorf("devicemapper: Error running RemoveDeviceDeferred %s", err)
@@ -471,13 +471,13 @@ func CreatePool(poolName string, dataFile, metadataFile *os.File, poolBlockSize 
 		return fmt.Errorf("devicemapper: Can't add target %s", err)
 	}
 
-	var cookie uint
+	cookie := new(uint)
 	var flags uint16
 	flags = DmUdevDisableSubsystemRulesFlag | DmUdevDisableDiskRulesFlag | DmUdevDisableOtherRulesFlag
-	if err := task.setCookie(&cookie, flags); err != nil {
+	if err := task.setCookie(cookie, flags); err != nil {
 		return fmt.Errorf("devicemapper: Can't set cookie %s", err)
 	}
-	defer UdevWait(&cookie)
+	defer UdevWait(cookie)
 
 	if err := task.run(); err != nil {
 		return fmt.Errorf("devicemapper: Error running deviceCreate (CreatePool) %s", err)
@@ -659,11 +659,11 @@ func ResumeDevice(name string) error {
 		return err
 	}
 
-	var cookie uint
-	if err := task.setCookie(&cookie, 0); err != nil {
+	cookie := new(uint)
+	if err := task.setCookie(cookie, 0); err != nil {
 		return fmt.Errorf("devicemapper: Can't set cookie %s", err)
 	}
-	defer UdevWait(&cookie)
+	defer UdevWait(cookie)
 
 	if err := task.run(); err != nil {
 		return fmt.Errorf("devicemapper: Error running deviceResume %s", err)
@@ -757,12 +757,12 @@ func activateDevice(poolName string, name string, deviceID int, size uint64, ext
 		return fmt.Errorf("devicemapper: Can't add node %s", err)
 	}
 
-	var cookie uint
-	if err := task.setCookie(&cookie, 0); err != nil {
+	cookie := new(uint)
+	if err := task.setCookie(cookie, 0); err != nil {
 		return fmt.Errorf("devicemapper: Can't set cookie %s", err)
 	}
 
-	defer UdevWait(&cookie)
+	defer UdevWait(cookie)
 
 	if err := task.run(); err != nil {
 		return fmt.Errorf("devicemapper: Error running deviceCreate (ActivateDevice) %s", err)

--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -332,7 +332,6 @@ func RemoveDevice(name string) error {
 	if err := task.setCookie(cookie, 0); err != nil {
 		return fmt.Errorf("devicemapper: Can not set cookie: %s", err)
 	}
-	defer UdevWait(cookie)
 
 	dmSawBusy = false // reset before the task is run
 	if err = task.run(); err != nil {
@@ -342,7 +341,7 @@ func RemoveDevice(name string) error {
 		return fmt.Errorf("devicemapper: Error running RemoveDevice %s", err)
 	}
 
-	return nil
+	return UdevWait(cookie)
 }
 
 // RemoveDeviceDeferred is a useful helper for cleaning up a device, but deferred.
@@ -368,6 +367,10 @@ func RemoveDeviceDeferred(name string) error {
 		return fmt.Errorf("devicemapper: Can not set cookie: %s", err)
 	}
 
+	if err = task.run(); err != nil {
+		return fmt.Errorf("devicemapper: Error running RemoveDeviceDeferred %s", err)
+	}
+
 	// libdevmapper and udev relies on System V semaphore for synchronization,
 	// semaphores created in `task.setCookie` will be cleaned up in `UdevWait`.
 	// So these two function call must come in pairs, otherwise semaphores will
@@ -377,13 +380,8 @@ func RemoveDeviceDeferred(name string) error {
 	// this call will not wait for the deferred removal's final executing, since no
 	// udev event will be generated, and the semaphore's value will not be incremented
 	// by udev, what UdevWait is just cleaning up the semaphore.
-	defer UdevWait(cookie)
 
-	if err = task.run(); err != nil {
-		return fmt.Errorf("devicemapper: Error running RemoveDeviceDeferred %s", err)
-	}
-
-	return nil
+	return UdevWait(cookie)
 }
 
 // CancelDeferredRemove cancels a deferred remove for a device.
@@ -477,13 +475,12 @@ func CreatePool(poolName string, dataFile, metadataFile *os.File, poolBlockSize 
 	if err := task.setCookie(cookie, flags); err != nil {
 		return fmt.Errorf("devicemapper: Can't set cookie %s", err)
 	}
-	defer UdevWait(cookie)
 
 	if err := task.run(); err != nil {
 		return fmt.Errorf("devicemapper: Error running deviceCreate (CreatePool) %s", err)
 	}
 
-	return nil
+	return UdevWait(cookie)
 }
 
 // ReloadPool is the programmatic example of "dmsetup reload".
@@ -663,13 +660,12 @@ func ResumeDevice(name string) error {
 	if err := task.setCookie(cookie, 0); err != nil {
 		return fmt.Errorf("devicemapper: Can't set cookie %s", err)
 	}
-	defer UdevWait(cookie)
 
 	if err := task.run(); err != nil {
 		return fmt.Errorf("devicemapper: Error running deviceResume %s", err)
 	}
 
-	return nil
+	return UdevWait(cookie)
 }
 
 // CreateDevice creates a device with the specified poolName with the specified device id.
@@ -762,13 +758,11 @@ func activateDevice(poolName string, name string, deviceID int, size uint64, ext
 		return fmt.Errorf("devicemapper: Can't set cookie %s", err)
 	}
 
-	defer UdevWait(cookie)
-
 	if err := task.run(); err != nil {
 		return fmt.Errorf("devicemapper: Error running deviceCreate (ActivateDevice) %s", err)
 	}
 
-	return nil
+	return UdevWait(cookie)
 }
 
 // CreateSnapDeviceRaw creates a snapshot device. Caller needs to suspend and resume the origin device if it is active.

--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -257,7 +257,7 @@ func (t *Task) getNextTarget(next unsafe.Pointer) (nextPtr unsafe.Pointer, start
 // UdevWait waits for any processes that are waiting for udev to complete the specified cookie.
 func UdevWait(cookie *uint) error {
 	if res := DmUdevWait(*cookie); res != 1 {
-		logrus.Debugf("devicemapper: Failed to wait on udev cookie %d", *cookie)
+		logrus.Debugf("devicemapper: Failed to wait on udev cookie %d, %d", *cookie, res)
 		return ErrUdevWait
 	}
 	return nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- In attempting to run openshift on power I continually ran into the segmentation violation described in issue 33050**

**- Just run openshift on power.  Normal operation was enough to quickly trigger a set of lvm operations that resulted in the crash mentioned in issue 33050**

**- No exact steps, typically booting openshift on power was enough to trigger the error**

**- Ensure that cookie generation for dm_task_run is unique, and error reporting is robust**
<!--
-->


**- A picture of a cute animal (not mandatory but encouraged)**

