### PR TITLE
[17.03.x] Backport lazy unmount volume

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -94,8 +94,8 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithVolumesRefs(c *check.C) {
 		c.Fatal(err)
 	}
 
-	if _, err := s.d.Cmd("run", "-d", "--volumes-from", "volrestarttest1", "--name", "volrestarttest2", "busybox", "top"); err != nil {
-		c.Fatal(err)
+	if out, err := s.d.Cmd("run", "-d", "--volumes-from", "volrestarttest1", "--name", "volrestarttest2", "busybox", "top"); err != nil {
+		c.Fatal(err, out)
 	}
 
 	if out, err := s.d.Cmd("rm", "-fv", "volrestarttest2"); err != nil {

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -353,7 +353,7 @@ func (v *localVolume) Unmount(id string) error {
 
 func (v *localVolume) unmount() error {
 	if v.opts != nil {
-		if err := mount.Unmount(v.path); err != nil {
+		if err := unmount(v.path); err != nil {
 			if mounted, mErr := mount.Mounted(v.path); mounted || mErr != nil {
 				return errors.Wrapf(err, "error while unmounting volume path '%s'", v.path)
 			}

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -218,6 +218,14 @@ func (r *Root) Remove(v volume.Volume) error {
 		return fmt.Errorf("unknown volume type %T", v)
 	}
 
+	if lv.active.count > 0 {
+		return fmt.Errorf("volume has active mounts")
+	}
+
+	if err := lv.unmount(); err != nil {
+		return err
+	}
+
 	realPath, err := filepath.EvalSymlinks(lv.path)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -306,6 +314,7 @@ func (v *localVolume) Path() string {
 }
 
 // Mount implements the localVolume interface, returning the data location.
+// If there are any provided mount options, the resources will be mounted at this point
 func (v *localVolume) Mount(id string) (string, error) {
 	v.m.Lock()
 	defer v.m.Unlock()
@@ -321,19 +330,35 @@ func (v *localVolume) Mount(id string) (string, error) {
 	return v.path, nil
 }
 
-// Umount is for satisfying the localVolume interface and does not do anything in this driver.
+// Unmount dereferences the id, and if it is the last reference will unmount any resources
+// that were previously mounted.
 func (v *localVolume) Unmount(id string) error {
 	v.m.Lock()
 	defer v.m.Unlock()
+
+	// Always decrement the count, even if the unmount fails
+	// Essentially docker doesn't care if this fails, it will send an error, but
+	// ultimately there's nothing that can be done. If we don't decrement the count
+	// this volume can never be removed until a daemon restart occurs.
 	if v.opts != nil {
 		v.active.count--
-		if v.active.count == 0 {
-			if err := mount.Unmount(v.path); err != nil {
-				v.active.count++
+	}
+
+	if v.active.count > 0 {
+		return nil
+	}
+
+	return v.unmount()
+}
+
+func (v *localVolume) unmount() error {
+	if v.opts != nil {
+		if err := mount.Unmount(v.path); err != nil {
+			if mounted, mErr := mount.Mounted(v.path); mounted || mErr != nil {
 				return errors.Wrapf(err, "error while unmounting volume path '%s'", v.path)
 			}
-			v.active.mounted = false
 		}
+		v.active.mounted = false
 	}
 	return nil
 }

--- a/volume/local/unmount_linux.go
+++ b/volume/local/unmount_linux.go
@@ -1,0 +1,7 @@
+package local
+
+import "golang.org/x/sys/unix"
+
+func unmount(path string) error {
+	return unix.Unmount(path, unix.MNT_DETACH)
+}

--- a/volume/local/unmount_unix.go
+++ b/volume/local/unmount_unix.go
@@ -1,0 +1,9 @@
+// +build !linux,!windows
+
+package local
+
+import "golang.org/x/sys/unix"
+
+func unmount(path string) error {
+	return unix.Unmount(path, 0)
+}

--- a/volume/local/unmount_windows.go
+++ b/volume/local/unmount_windows.go
@@ -1,0 +1,5 @@
+package local
+
+func unmount(_ string) error {
+	return nil
+}


### PR DESCRIPTION
Cherry-picks db3576f8a08ca70287bd3fdf9b21e162537f9d3a
Then converts the local volume unmount to use a lazy unmount on Linux.
This is the equivalent of acbfe6bc56b9357d40a452f6b3901cb2c2d40404 but localized to the local volume driver rather than affecting the entire codebase.

ping @mlaventure @thaJeztah 