### PR TITLE
make install script clearer which packages to install for AUFS support

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -442,7 +442,7 @@ do_install() {
 					else
 						echo >&2 'Warning: current kernel is not supported by the linux-image-extra-virtual'
 						echo >&2 ' package.  We have no AUFS support.  Consider installing the packages'
-						echo >&2 ' linux-image-virtual kernel and linux-image-extra-virtual for AUFS support.'
+						echo >&2 ' "linux-image-virtual" and "linux-image-extra-virtual" for AUFS support.'
 						( set -x; sleep 10 )
 					fi
 				fi


### PR DESCRIPTION
**- What I did**

Installing via `curl https://get.docker.com | sh` on a fresh box, I hit the issue of needing to install `linux-image-virtual` and `linux-image-extra-virtual` -- blindly copying and pasting the packages as shown in the existing error message (`sudo apt-get install  linux-image-virtual kernel linux-image-extra-virtual`) led me to the creation of this PR.

**- How I did it**

added quotes around the package names, removed extraneous "kernel"

**- How to verify it**

run the script on a machine without the packages (e.g. default Bash on Windows install)

**- Description for the changelog**

make install script clearer which packages to install for AUFS support

**- A picture of a cute animal (not mandatory but encouraged)**

![](http://vignette4.wikia.nocookie.net/pokemon-revolution/images/4/41/004Charmander_OS_anime_2.png/revision/latest)