### PR TITLE
expose ContainerConfigWrapper.getHostConfig

### DIFF
--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -101,3 +101,8 @@ func validateMountSettings(c *container.Config, hc *container.HostConfig) error 
 
 	return nil
 }
+
+// GetHostConfig gets the HostConfig of the Config
+func (w *ContainerConfigWrapper) GetHostConfig() *container.HostConfig {
+	return w.getHostConfig()
+}


### PR DESCRIPTION
**- What I did**

add an exposed version of the `runconfig/ContainerConfigWrapper.getHostConfig()` function.
This function has 2 implementations (`unix` and `windows`).

**- Why I did it**

So this "host config" can be accessed. This is useful for writing docker-related components and tools.

**- A picture of a cute animal (not mandatory but encouraged)**

![images](https://cloud.githubusercontent.com/assets/939999/25876220/afd7af30-34d0-11e7-8c10-ad5449d4e5d9.jpeg)

Thanks.

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>