### PR TITLE
Fix link in dev report

### DIFF
--- a/reports/2017-05-01.md
+++ b/reports/2017-05-01.md
@@ -4,7 +4,7 @@ This is the 1st report, since the Moby project was announced at DockerCon. Thank
 
 ## Daily Meeting
 
-A daily meeting is hosted on [slack](dockercommunity.slack.com) every business day at 9am PST on the channel `#moby-project`.
+A daily meeting is hosted on [slack](https://dockercommunity.slack.com/) every business day at 9am PST on the channel `#moby-project`.
 During this meeting, we are talking about the [tasks](https://github.com/moby/moby/issues/32867) needed to be done for splitting moby and docker.
 
 ## Topics discussed last week


### PR DESCRIPTION
Without this fix, the link is rendered as `https://github.com/moby/moby/blob/master/reports/2017-05-01.md` in github.