### PR TITLE
Adding Platforms field to TaskSpec Placement

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2158,6 +2158,16 @@ definitions:
                     SpreadDescriptor:
                       description: "label descriptor, such as engine.labels.az"
                       type: "string"
+          Platforms:
+            description: "An array of supported platforms."
+            type: "array"
+            items:
+              type: "object"
+              properties:
+                Architecture:
+                  type: "string"
+                OS:
+                  type: "string"
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"

--- a/api/types/swarm/task.go
+++ b/api/types/swarm/task.go
@@ -88,6 +88,11 @@ type ResourceRequirements struct {
 type Placement struct {
 	Constraints []string              `json:",omitempty"`
 	Preferences []PlacementPreference `json:",omitempty"`
+
+	// Platforms stores all the platforms that the image can run on.
+	// This field is used in the platform filter for scheduling. If empty,
+	// then the platform filter is off, meaning there are no scheduling restrictions.
+	Platforms []Platform `json:",omitempty"`
 }
 
 // PlacementPreference provides a way to make the scheduler aware of factors

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -198,9 +198,17 @@ func ServiceSpecToGRPC(s types.ServiceSpec) (swarmapi.ServiceSpec, error) {
 				})
 			}
 		}
+		var platforms []*swarmapi.Platform
+		for _, plat := range s.TaskTemplate.Placement.Platforms {
+			platforms = append(platforms, &swarmapi.Platform{
+				Architecture: plat.Architecture,
+				OS:           plat.OS,
+			})
+		}
 		spec.Task.Placement = &swarmapi.Placement{
 			Constraints: s.TaskTemplate.Placement.Constraints,
 			Preferences: preferences,
+			Platforms:   platforms,
 		}
 	}
 
@@ -391,6 +399,13 @@ func placementFromGRPC(p *swarmapi.Placement) *types.Placement {
 				},
 			})
 		}
+	}
+
+	for _, plat := range p.Platforms {
+		r.Platforms = append(r.Platforms, types.Platform{
+			Architecture: plat.Architecture,
+			OS:           plat.OS,
+		})
 	}
 
 	return r

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -27,6 +27,7 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /swarm/update` now accepts 3 additional parameters as part of the swarm spec's CA configuration; the desired CA certificate for
  the swarm, the desired CA key for the swarm (if not using an external certificate), and an optional parameter to force swarm to
  generate and rotate to a new CA certificate/key pair.
+* `POST /service/create` and `POST /services/(id or name)/update` now take the field `Platforms` as part of the service `Placement`, allowing to specify platforms supported by the service.
 
 ## v1.29 API changes
 
@@ -37,7 +38,7 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /networks/(name)` now returns an `Ingress` field showing whether the network is the ingress one.
 * `GET /networks/` now supports a `scope` filter to filter networks based on the network mode (`swarm`, `global`, or `local`).
 * `POST /containers/create`, `POST /service/create` and `POST /services/(id or name)/update` now takes the field `StartPeriod` as a part of the `HealthConfig` allowing for specification of a period during which the container should not be considered unhealthy even if health checks do not pass.
-* `GET /services/(id)` now accepts an `insertDefaults` query-parameter to merge default values into the service inspect output. 
+* `GET /services/(id)` now accepts an `insertDefaults` query-parameter to merge default values into the service inspect output.
 * `POST /containers/prune`, `POST /images/prune`, `POST /volumes/prune`, and `POST /networks/prune` now support a `label` filter to filter containers, images, volumes, or networks based on the label. The format of the label filter could be `label=<key>`/`label=<key>=<value>` to remove those with the specified labels, or `label!=<key>`/`label!=<key>=<value>` to remove those without the specified labels.
 
 ## v1.28 API changes


### PR DESCRIPTION
The Platforms field contains an array of all platforms supported by the Task. This PR is part of adding multi-arch support for Swarm Mode (https://github.com/moby/moby/issues/31348).

The platform filter was introduced in SwarmKit in https://github.com/docker/swarmkit/pull/1981 and vendored into `moby/moby` with https://github.com/moby/moby/pull/33059.
```
// Placement represents orchestration parameters.
type Placement struct {
	Constraints []string              `json:",omitempty"`
	Preferences []PlacementPreference `json:",omitempty"`

	// Platforms stores all the platforms that the image can run on.
	// This field is used in the platform filter for scheduling. If empty,
	// then the platform filter is off, meaning there are no scheduling restrictions.
	Platforms []Platform `json:",omitempty"`
}
```

The follow-up for this PR will actually add the platform information to the Spec when a service is created. That part depends on #32388.