### PR TITLE
Fix flaky TestAPIStatsNoStreamGetCpu

### DIFF
--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -21,11 +21,10 @@ import (
 var expectedNetworkInterfaceStats = strings.Split("rx_bytes rx_dropped rx_errors rx_packets tx_bytes tx_dropped tx_errors tx_packets", " ")
 
 func (s *DockerSuite) TestAPIStatsNoStreamGetCpu(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true;do echo 'Hello'; usleep 100000; done")
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true;usleep 100; do echo 'Hello'; done")
 
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), checker.IsNil)
-
 	resp, body, err := request.Get(fmt.Sprintf("/containers/%s/stats?stream=false", id))
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

I've seen this test fail on Windows occasionally in CI, and reliably fail CI when using the nanoserver base image and finally got round to looking at it. It's simply a case that on Windows, it's not always crossing the threshold of CPU usage to register something, so we end up with showing zero CPU and hence failing the test. Reducing the usleep time (hence more CPU load) seems to make this reliable now (as in I haven't managed to make it fail yet, where I was hitting it 100% before using nanoserver).

@johnstep @thaJeztah 

