### PR TITLE
WIP: Move networking settings from createOption to oci runtime-spec

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -1,12 +1,14 @@
 package daemon
 
 import (
+	"fmt"
 	"syscall"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/oci"
 	"github.com/docker/docker/pkg/sysinfo"
+	"github.com/docker/docker/pkg/system"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -154,6 +156,69 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 			Iops: &c.HostConfig.IOMaximumIOps,
 		},
 	}
+
+	dnsSearch := daemon.getDNSSearchSettings(c)
+	if dnsSearch != nil {
+		osv := system.GetOSVersion()
+		if osv.Build < 14997 {
+			return nil, fmt.Errorf("dns-search option is not supported on the current platform")
+		}
+	}
+
+	// Get endpoints for the libnetwork allocated networks to the container
+	var epList []string
+	AllowUnqualifiedDNSQuery := false
+	gwHNSID := ""
+	if c.NetworkSettings != nil {
+		for n := range c.NetworkSettings.Networks {
+			sn, err := daemon.FindNetwork(n)
+			if err != nil {
+				continue
+			}
+
+			ep, err := c.GetEndpointInNetwork(sn)
+			if err != nil {
+				continue
+			}
+
+			data, err := ep.DriverInfo()
+			if err != nil {
+				continue
+			}
+
+			if data["GW_INFO"] != nil {
+				gwInfo := data["GW_INFO"].(map[string]interface{})
+				if gwInfo["hnsid"] != nil {
+					gwHNSID = gwInfo["hnsid"].(string)
+				}
+			}
+
+			if data["hnsid"] != nil {
+				epList = append(epList, data["hnsid"].(string))
+			}
+
+			if data["AllowUnqualifiedDNSQuery"] != nil {
+				AllowUnqualifiedDNSQuery = true
+			}
+		}
+	}
+
+	var networkSharedContainerID string
+	if c.HostConfig.NetworkMode.IsContainer() {
+		networkSharedContainerID = c.NetworkSharedContainerID
+	}
+
+	if gwHNSID != "" {
+		epList = append(epList, gwHNSID)
+	}
+
+	s.Windows.Network = &specs.WindowsNetwork{
+		EndpointList:               epList,
+		AllowUnqualifiedDNSQuery:   AllowUnqualifiedDNSQuery,
+		DNSSearchList:              dnsSearch,
+		NetworkSharedContainerName: networkSharedContainerID,
+	}
+
 	return (*specs.Spec)(&s), nil
 }
 

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -147,6 +147,15 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 		}
 	}
 
+	if spec.Windows.Network != nil {
+		configuration.EndpointList = spec.Windows.Network.EndpointList
+		configuration.AllowUnqualifiedDNSQuery = spec.Windows.Network.AllowUnqualifiedDNSQuery
+		if spec.Windows.Network.DNSSearchList != nil {
+			configuration.DNSSearchList = strings.Join(spec.Windows.Network.DNSSearchList, ",")
+		}
+		configuration.NetworkSharedContainerName = spec.Windows.Network.NetworkSharedContainerName
+	}
+
 	var layerOpt *LayerOption
 	for _, option := range options {
 		if s, ok := option.(*ServicingOption); ok {
@@ -164,15 +173,6 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 		}
 		if l, ok := option.(*LayerOption); ok {
 			layerOpt = l
-		}
-		if n, ok := option.(*NetworkEndpointsOption); ok {
-			configuration.EndpointList = n.Endpoints
-			configuration.AllowUnqualifiedDNSQuery = n.AllowUnqualifiedDNSQuery
-			if n.DNSSearchList != nil {
-				configuration.DNSSearchList = strings.Join(n.DNSSearchList, ",")
-			}
-			configuration.NetworkSharedContainerName = n.NetworkSharedContainerID
-			continue
 		}
 		if c, ok := option.(*CredentialsOption); ok {
 			configuration.Credentials = c.Credentials

--- a/libcontainerd/types_windows.go
+++ b/libcontainerd/types_windows.go
@@ -54,15 +54,6 @@ type LayerOption struct {
 	LayerPaths []string
 }
 
-// NetworkEndpointsOption is a CreateOption that provides the runtime list
-// of network endpoints to which a container should be attached during its creation.
-type NetworkEndpointsOption struct {
-	Endpoints                []string
-	AllowUnqualifiedDNSQuery bool
-	DNSSearchList            []string
-	NetworkSharedContainerID string
-}
-
 // CredentialsOption is a CreateOption that indicates the credentials from
 // a credential spec to be used to the runtime
 type CredentialsOption struct {

--- a/libcontainerd/utils_windows.go
+++ b/libcontainerd/utils_windows.go
@@ -35,11 +35,6 @@ func (h *LayerOption) Apply(interface{}) error {
 	return nil
 }
 
-// Apply for the network endpoints option is a no-op.
-func (s *NetworkEndpointsOption) Apply(interface{}) error {
-	return nil
-}
-
 // Apply for the credentials option is a no-op.
 func (s *CredentialsOption) Apply(interface{}) error {
 	return nil

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -429,6 +429,8 @@ type SolarisAnet struct {
 type Windows struct {
 	// Resources contains information for handling resource constraints for the container.
 	Resources *WindowsResources `json:"resources,omitempty"`
+	// Network restriction configuration.
+	Network *WindowsNetwork `json:"network,omitempty"`
 }
 
 // WindowsResources has container runtime resource constraints for containers running on Windows.
@@ -439,8 +441,6 @@ type WindowsResources struct {
 	CPU *WindowsCPUResources `json:"cpu,omitempty"`
 	// Storage restriction configuration.
 	Storage *WindowsStorageResources `json:"storage,omitempty"`
-	// Network restriction configuration.
-	Network *WindowsNetworkResources `json:"network,omitempty"`
 }
 
 // WindowsMemoryResources contains memory resource management settings.
@@ -471,10 +471,16 @@ type WindowsStorageResources struct {
 	SandboxSize *uint64 `json:"sandboxSize,omitempty"`
 }
 
-// WindowsNetworkResources contains network resource management settings.
-type WindowsNetworkResources struct {
-	// EgressBandwidth is the maximum egress bandwidth in bytes per second.
-	EgressBandwidth *uint64 `json:"egressBandwidth,omitempty"`
+// WindowsNetwork contains network settings for Windows containers.
+type WindowsNetwork struct {
+	// List of HNS endpoints that the container should connect to.
+	EndpointList []string `json:"endpointList,omitempty"`
+	// Specifies if unqualified DNS name resolution is allowed.
+	AllowUnqualifiedDNSQuery bool `json:"allowUnqualifiedDNSQuery,omitempty"`
+	// Comma seperated list of DNS suffixes to use for name resolution.
+	DNSSearchList []string `json:"DNSSearchList,omitempty"`
+	// Name (ID) of the container that we will share with the network stack.
+	NetworkSharedContainerName string `json:"networkSharedContainerName,omitempty"`
 }
 
 // LinuxSeccomp represents syscall restrictions


### PR DESCRIPTION
Signed-off-by: Darren Stahl <darst@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Moved networking options from libcontainerd createOption to OCI runtime-spec

**- How to verify it**

Networking still works. Existing CI tests.

See https://github.com/opencontainers/runtime-spec/pull/801 for runtime-spec PR

/cc @jhowardmsft @jstarks 
