### PR TITLE
Add daemon option to push foreign layers

### DIFF
--- a/api/types/registry/registry.go
+++ b/api/types/registry/registry.go
@@ -7,9 +7,11 @@ import (
 
 // ServiceConfig stores daemon registry services configuration.
 type ServiceConfig struct {
-	InsecureRegistryCIDRs []*NetIPNet           `json:"InsecureRegistryCIDRs"`
-	IndexConfigs          map[string]*IndexInfo `json:"IndexConfigs"`
-	Mirrors               []string
+	AllowNondistributableArtifactsCIDRs     []*NetIPNet
+	AllowNondistributableArtifactsHostnames []string
+	InsecureRegistryCIDRs                   []*NetIPNet           `json:"InsecureRegistryCIDRs"`
+	IndexConfigs                            map[string]*IndexInfo `json:"IndexConfigs"`
+	Mirrors                                 []string
 }
 
 // NetIPNet is the net.IPNet type, which can be marshalled and

--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -131,6 +131,7 @@ func TestLoadDaemonConfigWithEmbeddedOptions(t *testing.T) {
 
 func TestLoadDaemonConfigWithRegistryOptions(t *testing.T) {
 	content := `{
+		"allow-nondistributable-artifacts": ["allow-nondistributable-artifacts.com"],
 		"registry-mirrors": ["https://mirrors.docker.com"],
 		"insecure-registries": ["https://insecure.docker.com"]
 	}`
@@ -142,6 +143,7 @@ func TestLoadDaemonConfigWithRegistryOptions(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, loadedConfig)
 
+	assert.Len(t, loadedConfig.AllowNondistributableArtifacts, 1)
 	assert.Len(t, loadedConfig.Mirrors, 1)
 	assert.Len(t, loadedConfig.InsecureRegistries, 1)
 }

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1962,6 +1962,7 @@ _docker_daemon() {
 	local options_with_args="
 		$global_options_with_args
 		--add-runtime
+		--allow-nondistributable-artifacts
 		--api-cors-header
 		--authorization-plugin
 		--bip

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2603,6 +2603,7 @@ __docker_subcommand() {
             _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help)*--add-runtime=[Register an additional OCI compatible runtime]:runtime:__docker_complete_runtimes" \
+                "($help)*--allow-nondistributable-artifacts=[Push nondistributable artifacts to specified registries]:registry: " \
                 "($help)--api-cors-header=[CORS headers in the Engine API]:CORS headers: " \
                 "($help)*--authorization-plugin=[Authorization plugins to load]" \
                 "($help -b --bridge)"{-b=,--bridge=}"[Attach containers to a network bridge]:bridge:_net_interfaces" \

--- a/distribution/pull_v2_windows.go
+++ b/distribution/pull_v2_windows.go
@@ -23,20 +23,28 @@ func (ld *v2LayerDescriptor) Descriptor() distribution.Descriptor {
 }
 
 func (ld *v2LayerDescriptor) open(ctx context.Context) (distribution.ReadSeekCloser, error) {
+	blobs := ld.repo.Blobs(ctx)
+	rsc, err := blobs.Open(ctx, ld.digest)
+
 	if len(ld.src.URLs) == 0 {
-		blobs := ld.repo.Blobs(ctx)
-		return blobs.Open(ctx, ld.digest)
+		return rsc, err
 	}
 
-	var (
-		err error
-		rsc distribution.ReadSeekCloser
-	)
+	// We're done if the registry has this blob.
+	if err == nil {
+		// Seek does an HTTP GET.  If it succeeds, the blob really is accessible.
+		if _, err = rsc.Seek(0, os.SEEK_SET); err == nil {
+			return rsc, nil
+		}
+		rsc.Close()
+	}
 
 	// Find the first URL that results in a 200 result code.
 	for _, url := range ld.src.URLs {
 		logrus.Debugf("Pulling %v from foreign URL %v", ld.digest, url)
 		rsc = transport.NewHTTPReadSeeker(http.DefaultClient, url, nil)
+
+		// Seek does an HTTP GET.  If it succeeds, the blob really is accessible.
 		_, err = rsc.Seek(0, os.SEEK_SET)
 		if err == nil {
 			break

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -23,6 +23,7 @@ A self-sufficient runtime for containers.
 
 Options:
       --add-runtime runtime                   Register an additional OCI compatible runtime (default [])
+      --allow-nondistributable-artifacts list Push nondistributable artifacts to specified registries (default [])
       --api-cors-header string                Set CORS headers in the Engine API
       --authorization-plugin list             Authorization plugins to load (default [])
       --bip string                            Specify network bridge IP
@@ -828,6 +829,32 @@ To set the DNS search domain for all Docker containers, use:
 $ sudo dockerd --dns-search example.com
 ```
 
+#### Allow push of nondistributable artifacts
+
+Some images (e.g., Windows base images) contain artifacts whose distribution is
+restricted by license. When these images are pushed to a registry, restricted
+artifacts are not included.
+
+To override this behavior for specific registries, use the
+`--allow-nondistributable-artifacts` option in one of the following forms:
+
+* `--allow-nondistributable-artifacts myregistry:5000` tells the Docker daemon
+  to push nondistributable artifacts to myregistry:5000.
+* `--allow-nondistributable-artifacts 10.1.0.0/16` tells the Docker daemon to
+  push nondistributable artifacts to all registries whose resolved IP address
+  is within the subnet described by the CIDR syntax.
+
+This option can be used multiple times.
+
+This option is useful when pushing images containing nondistributable artifacts
+to a registry on an air-gapped network so hosts on that network can pull the
+images without connecting to another server.
+
+> **Warning**: Nondistributable artifacts typically have restrictions on how
+> and where they can be distributed and shared. Only use this feature to push
+> artifacts to private registries and ensure that you are in compliance with
+> any terms that cover redistributing nondistributable artifacts.
+
 #### Insecure registries
 
 Docker considers a private registry either secure or insecure. In the rest of
@@ -1261,6 +1288,7 @@ This is a full example of the allowed configuration options on Linux:
 	"default-gateway-v6": "",
 	"icc": false,
 	"raw-logs": false,
+	"allow-nondistributable-artifacts": [],
 	"registry-mirrors": [],
 	"seccomp-profile": "",
 	"insecure-registries": [],
@@ -1330,6 +1358,7 @@ This is a full example of the allowed configuration options on Windows:
     "bridge": "",
     "fixed-cidr": "",
     "raw-logs": false,
+    "allow-nondistributable-artifacts": [],
     "registry-mirrors": [],
     "insecure-registries": [],
     "disable-legacy-registry": false
@@ -1361,6 +1390,7 @@ The list of currently supported options that can be reconfigured is this:
 - `runtimes`: it updates the list of available OCI runtimes that can
   be used to run containers
 - `authorization-plugin`: specifies the authorization plugins to use.
+- `allow-nondistributable-artifacts`: Replaces the set of registries to which the daemon will push nondistributable artifacts with a new set of registries.
 - `insecure-registries`: it replaces the daemon insecure registries with a new set of insecure registries. If some existing insecure registries in daemon's configuration are not in newly reloaded insecure resgitries, these existing ones will be removed from daemon's config.
 - `registry-mirrors`: it replaces the daemon registry mirrors with a new set of registry mirrors. If some existing registry mirrors in daemon's configuration are not in newly reloaded registry mirrors, these existing ones will be removed from daemon's config.
 

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -428,7 +428,7 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *check.C) {
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c))
 	c.Assert(err, checker.IsNil)
 
-	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s (cluster-advertise=, cluster-store=, cluster-store-opts={}, debug=true, default-runtime=runc, default-shm-size=67108864, insecure-registries=[], labels=[\"bar=foo\"], live-restore=false, max-concurrent-downloads=1, max-concurrent-uploads=5, name=%s, registry-mirrors=[], runtimes=runc:{docker-runc []}, shutdown-timeout=10)", daemonID, daemonName))
+	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s (allow-nondistributable-artifacts=[], cluster-advertise=, cluster-store=, cluster-store-opts={}, debug=true, default-runtime=runc, default-shm-size=67108864, insecure-registries=[], labels=[\"bar=foo\"], live-restore=false, max-concurrent-downloads=1, max-concurrent-uploads=5, name=%s, registry-mirrors=[], runtimes=runc:{docker-runc []}, shutdown-timeout=10)", daemonID, daemonName))
 }
 
 func (s *DockerDaemonSuite) TestDaemonEventsWithFilters(c *check.C) {

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -7,6 +7,7 @@ dockerd - Enable daemon mode
 # SYNOPSIS
 **dockerd**
 [**--add-runtime**[=*[]*]]
+[**--allow-nondistributable-artifacts**[=*[]*]]
 [**--api-cors-header**=[=*API-CORS-HEADER*]]
 [**--authorization-plugin**[=*[]*]]
 [**-b**|**--bridge**[=*BRIDGE*]]
@@ -115,6 +116,20 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 ```
 
   **Note**: defining runtime arguments via the command line is not supported.
+
+**--allow-nondistributable-artifacts**=[]
+  Push nondistributable artifacts to the specified registries.
+
+  List can contain elements with CIDR notation to specify a whole subnet.
+
+  This option is useful when pushing images containing nondistributable
+  artifacts to a registry on an air-gapped network so hosts on that network can
+  pull the images without connecting to another server.
+
+  **Warning**: Nondistributable artifacts typically have restrictions on how
+  and where they can be distributed and shared. Only use this feature to push
+  artifacts to private registries and ensure that you are in compliance with
+  any terms that cover redistributing nondistributable artifacts.
 
 **--api-cors-header**=""
   Set CORS headers in the Engine API. Default is cors disabled. Give urls like

--- a/registry/config_test.go
+++ b/registry/config_test.go
@@ -1,9 +1,128 @@
 package registry
 
 import (
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 )
+
+func TestLoadAllowNondistributableArtifacts(t *testing.T) {
+	testCases := []struct {
+		registries []string
+		cidrStrs   []string
+		hostnames  []string
+		err        string
+	}{
+		{
+			registries: []string{"1.2.3.0/24"},
+			cidrStrs:   []string{"1.2.3.0/24"},
+		},
+		{
+			registries: []string{"2001:db8::/120"},
+			cidrStrs:   []string{"2001:db8::/120"},
+		},
+		{
+			registries: []string{"127.0.0.1"},
+			hostnames:  []string{"127.0.0.1"},
+		},
+		{
+			registries: []string{"127.0.0.1:8080"},
+			hostnames:  []string{"127.0.0.1:8080"},
+		},
+		{
+			registries: []string{"2001:db8::1"},
+			hostnames:  []string{"2001:db8::1"},
+		},
+		{
+			registries: []string{"[2001:db8::1]:80"},
+			hostnames:  []string{"[2001:db8::1]:80"},
+		},
+		{
+			registries: []string{"[2001:db8::1]:80"},
+			hostnames:  []string{"[2001:db8::1]:80"},
+		},
+		{
+			registries: []string{"1.2.3.0/24", "2001:db8::/120", "127.0.0.1", "127.0.0.1:8080"},
+			cidrStrs:   []string{"1.2.3.0/24", "2001:db8::/120"},
+			hostnames:  []string{"127.0.0.1", "127.0.0.1:8080"},
+		},
+
+		{
+			registries: []string{"http://mytest.com"},
+			err:        "allow-nondistributable-artifacts registry http://mytest.com should not contain '://'",
+		},
+		{
+			registries: []string{"https://mytest.com"},
+			err:        "allow-nondistributable-artifacts registry https://mytest.com should not contain '://'",
+		},
+		{
+			registries: []string{"HTTP://mytest.com"},
+			err:        "allow-nondistributable-artifacts registry HTTP://mytest.com should not contain '://'",
+		},
+		{
+			registries: []string{"svn://mytest.com"},
+			err:        "allow-nondistributable-artifacts registry svn://mytest.com should not contain '://'",
+		},
+		{
+			registries: []string{"-invalid-registry"},
+			err:        "Cannot begin or end with a hyphen",
+		},
+		{
+			registries: []string{`mytest-.com`},
+			err:        `allow-nondistributable-artifacts registry mytest-.com is not valid: invalid host "mytest-.com"`,
+		},
+		{
+			registries: []string{`1200:0000:AB00:1234:0000:2552:7777:1313:8080`},
+			err:        `allow-nondistributable-artifacts registry 1200:0000:AB00:1234:0000:2552:7777:1313:8080 is not valid: invalid host "1200:0000:AB00:1234:0000:2552:7777:1313:8080"`,
+		},
+		{
+			registries: []string{`mytest.com:500000`},
+			err:        `allow-nondistributable-artifacts registry mytest.com:500000 is not valid: invalid port "500000"`,
+		},
+		{
+			registries: []string{`"mytest.com"`},
+			err:        `allow-nondistributable-artifacts registry "mytest.com" is not valid: invalid host "\"mytest.com\""`,
+		},
+		{
+			registries: []string{`"mytest.com:5000"`},
+			err:        `allow-nondistributable-artifacts registry "mytest.com:5000" is not valid: invalid host "\"mytest.com"`,
+		},
+	}
+	for _, testCase := range testCases {
+		config := newServiceConfig(ServiceOptions{})
+		err := config.LoadAllowNondistributableArtifacts(testCase.registries)
+		if testCase.err == "" {
+			if err != nil {
+				t.Fatalf("expect no error, got '%s'", err)
+			}
+
+			cidrStrs := []string{}
+			for _, c := range config.AllowNondistributableArtifactsCIDRs {
+				cidrStrs = append(cidrStrs, c.String())
+			}
+
+			sort.Strings(testCase.cidrStrs)
+			sort.Strings(cidrStrs)
+			if (len(testCase.cidrStrs) > 0 || len(cidrStrs) > 0) && !reflect.DeepEqual(testCase.cidrStrs, cidrStrs) {
+				t.Fatalf("expect AllowNondistributableArtifactsCIDRs to be '%+v', got '%+v'", testCase.cidrStrs, cidrStrs)
+			}
+
+			sort.Strings(testCase.hostnames)
+			sort.Strings(config.AllowNondistributableArtifactsHostnames)
+			if (len(testCase.hostnames) > 0 || len(config.AllowNondistributableArtifactsHostnames) > 0) && !reflect.DeepEqual(testCase.hostnames, config.AllowNondistributableArtifactsHostnames) {
+				t.Fatalf("expect AllowNondistributableArtifactsHostnames to be '%+v', got '%+v'", testCase.hostnames, config.AllowNondistributableArtifactsHostnames)
+			}
+		} else {
+			if err == nil {
+				t.Fatalf("expect error '%s', got no error", testCase.err)
+			}
+			if !strings.Contains(err.Error(), testCase.err) {
+				t.Fatalf("expect error '%s', got '%s'", testCase.err, err)
+			}
+		}
+	}
+}
 
 func TestValidateMirror(t *testing.T) {
 	valid := []string{

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -44,6 +44,8 @@ func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 		return endpoints, nil
 	}
 
+	ana := allowNondistributableArtifacts(s.config, hostname)
+
 	tlsConfig, err = s.tlsConfig(hostname)
 	if err != nil {
 		return nil, err
@@ -55,9 +57,10 @@ func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 				Scheme: "https",
 				Host:   hostname,
 			},
-			Version:      APIVersion2,
-			TrimHostname: true,
-			TLSConfig:    tlsConfig,
+			Version: APIVersion2,
+			AllowNondistributableArtifacts: ana,
+			TrimHostname:                   true,
+			TLSConfig:                      tlsConfig,
 		},
 	}
 
@@ -67,8 +70,9 @@ func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 				Scheme: "http",
 				Host:   hostname,
 			},
-			Version:      APIVersion2,
-			TrimHostname: true,
+			Version: APIVersion2,
+			AllowNondistributableArtifacts: ana,
+			TrimHostname:                   true,
 			// used to check if supposed to be secure via InsecureSkipVerify
 			TLSConfig: tlsConfig,
 		})


### PR DESCRIPTION
The ~~--air-gapped-registry~~ *--allow-nondistributable-artifacts* daemon option specifies registries to which foreign layers should be pushed.  (By default, foreign layers are not pushed to registries.)

Additionally, to make this option effective, foreign layers are now pulled from the registry if possible, falling back to the URLs in the image manifest otherwise.

This option is useful when pushing images containing foreign layers to ~~an air-gapped registry so that air-gapped hosts~~ *a registry on an air-gapped network so hosts on that network* can pull the images without connecting to another server.

Caveats:
1. "Air-gapped" might not be the right terminology for this.
2. distribution/pull_v2_windows.go, distribution/push_v2.go, ~~isAirGappedRegistry~~, and isCIDRMatch have no tests.