### PR TITLE
Fix secret/{id} response example

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8242,7 +8242,8 @@ paths:
           description: "no error"
           schema:
             $ref: "#/definitions/Secret"
-            example:
+          examples:
+            application/json:
               ID: "ktnbjxoalbkvbvedmg1urrz8h"
               Version:
                 Index: 11


### PR DESCRIPTION
This was bothering me for a while, haha

Fixes a warning that was shown;

    Warning: Other properties are defined at the same level as $ref at
    "#/paths/~1secrets~1{id}/get/responses/200/schema". They are IGNORED according
    to the JsonSchema spec

And resulted in the example values not being shown in the documentation.


ping @vdemeester @ehazlett PTAL :smile:
