### PR TITLE
Add Windows configs support

### DIFF
--- a/daemon/configs_windows.go
+++ b/daemon/configs_windows.go
@@ -1,7 +1,7 @@
-// +build !linux,!windows
+// +build windows
 
 package daemon
 
 func configsSupported() bool {
-	return false
+	return true
 }


### PR DESCRIPTION
Signed-off-by: John Stephens <johnstep@docker.com>

This change implements configs support for Windows by writing all configs to a single container directory, mounted at `C:\ProgramData\Docker\internal\configs`, and creating symlinks from the target to these files.