### PR TITLE
Update libseccomp-golang

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -63,7 +63,7 @@ github.com/miekg/pkcs11 df8ae6ca730422dba20c768ff38ef7d79077a59f
 github.com/opencontainers/runc b6b70e53451794e8333e9b602cc096b47a20bd0f
 github.com/opencontainers/runtime-spec v1.0.0-rc5 # specs
 
-github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
+github.com/seccomp/libseccomp-golang 84e90a91acea0f4e51e62bc1a75de18b1fc0790f
 
 # libcontainer deps (see src/github.com/opencontainers/runc/Godeps/Godeps.json)
 github.com/coreos/go-systemd v4

--- a/vendor/github.com/seccomp/libseccomp-golang/README
+++ b/vendor/github.com/seccomp/libseccomp-golang/README
@@ -24,3 +24,28 @@ please note that a Google account is not required to subscribe to the mailing
 list.
 
 	-> https://groups.google.com/d/forum/libseccomp
+
+Documentation is also available at:
+
+	-> https://godoc.org/github.com/seccomp/libseccomp-golang
+
+* Installing the package
+
+The libseccomp-golang bindings require at least Go v1.2.1 and GCC v4.8.4;
+earlier versions may yield unpredictable results.  If you meet these
+requirements you can install this package using the command below:
+
+	$ go get github.com/seccomp/libseccomp-golang
+
+* Testing the Library
+
+A number of tests and lint related recipes are provided in the Makefile, if
+you want to run the standard regression tests, you can excute the following:
+
+	$ make check
+
+In order to execute the 'make lint' recipe the 'golint' tool is needed, it
+can be found at:
+
+	-> https://github.com/golang/lint
+


### PR DESCRIPTION
Fix #32714

This fixes a bug in handling of multiple arguments specifed together.

We no longer have these in the default profile, but users may in their
profiles.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![heron_chick](https://cloud.githubusercontent.com/assets/482364/26007838/1f5832c4-373a-11e7-919d-6a01cf1ceff1.jpg)

