### PR TITLE
integration-cli-on-swarm/README.md: add a note about Docker->Moby

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ swagger-docs: ## preview the API documentation
 		bfirsh/redoc:1.6.2
 
 build-integration-cli-on-swarm: build ## build images and binary for running integration-cli on Swarm in parallel
-	@echo "Building hack/integration-cli-on-swarm"
+	@echo "Building hack/integration-cli-on-swarm (if build fails, please refer to hack/integration-cli-on-swarm/README.md)"
 	go build -o ./hack/integration-cli-on-swarm/integration-cli-on-swarm ./hack/integration-cli-on-swarm/host
 	@echo "Building $(INTEGRATION_CLI_MASTER_IMAGE)"
 	docker build -t $(INTEGRATION_CLI_MASTER_IMAGE) hack/integration-cli-on-swarm/agent

--- a/hack/integration-cli-on-swarm/README.md
+++ b/hack/integration-cli-on-swarm/README.md
@@ -38,6 +38,8 @@ Following environment variables are known to work in this step:
  - `BUILDFLAGS`
  - `DOCKER_INCREMENTAL_BINARY`
 
+Note: during the transition into Moby Project, you might need to create a symbolic link `$GOPATH/src/github.com/docker/docker` to `$GOPATH/src/github.com/moby/moby`. 
+
 ### Step 2: Execute tests
 
     $ ./hack/integration-cli-on-swarm/integration-cli-on-swarm -replicas 40 -push-worker-image YOUR_REGISTRY.EXAMPLE.COM/integration-cli-worker:latest 


### PR DESCRIPTION
`make build-integration-cli-on-swarm` still expects the repo name to be `docker/docker`.

Probably, we have similar issues for other things as well.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
