### PR TITLE
Fix make.ps1 client build for Windows

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -411,7 +411,7 @@ Try {
             $saveGOPATH = $env:GOPATH
             Try {
                 $env:GOPATH = $tempLocation
-                $dockerCliRoot = "$env:GOPATH\src\$($dockerCliRepo.Split("/", 3)[2])"
+                $dockerCliRoot = "$env:GOPATH\src\github.com\docker\cli"
                 Write-Host "INFO: Cloning client repository..."
                 Invoke-Expression "git clone -q $dockerCliRepo $dockerCliRoot"
                 if ($LASTEXITCODE -ne 0) { Throw "Failed to clone client repository $dockerCliRepo" }


### PR DESCRIPTION
Always clone the client to the docker directory, even if the specified
client repository is a fork. This is simpler than modifying the build
command to specify the package path of the fork.

Signed-off-by: John Stephens <johnstep@docker.com>