### PR TITLE
GCP Logs: send log text as jsonPayload.message instead of jsonPayload.data

### DIFF
--- a/daemon/logger/gcplogs/gcplogging.go
+++ b/daemon/logger/gcplogs/gcplogging.go
@@ -61,7 +61,7 @@ type gcplogs struct {
 type dockerLogEntry struct {
 	Instance  *instanceInfo  `json:"instance,omitempty"`
 	Container *containerInfo `json:"container,omitempty"`
-	Data      string         `json:"data,omitempty"`
+	Message   string         `json:"message,omitempty"`
 }
 
 type instanceInfo struct {
@@ -219,7 +219,7 @@ func ValidateLogOpts(cfg map[string]string) error {
 }
 
 func (l *gcplogs) Log(m *logger.Message) error {
-	data := string(m.Line)
+	message := string(m.Line)
 	ts := m.Timestamp
 	logger.PutMessage(m)
 
@@ -228,7 +228,7 @@ func (l *gcplogs) Log(m *logger.Message) error {
 		Payload: &dockerLogEntry{
 			Instance:  l.instance,
 			Container: l.container,
-			Data:      data,
+			Message:   message,
 		},
 	})
 	return nil


### PR DESCRIPTION
* **What I did**
  Change the log line field name from `jsonPayload.data` to `jsonPayload.message` in the GCP Stackdriver logging driver

* **How I did it**
  * Change `Data` field to `Message` field in the `dockerLogEntry`
  * Change `data` variable inside the `Log()` function as well, for consistency

* **How to verify it**
  * Ran a simple test inside the development container where I built a container `FROM debian:jessie` with `CMD ["echo", "test"]` (with proper GCP authentication set up in the form of a JSON key file) and it showed up in the GCP Logs Viewer web UI

* **Description for the changelog**

* **A picture of a cute animal (not mandatory but encouraged)**

I believe this addresses part of https://github.com/moby/moby/issues/28555 as well.