### PR TITLE
unexport error errPruneRunning

### DIFF
--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -22,9 +22,9 @@ import (
 )
 
 var (
-	// ErrPruneRunning is returned when a prune request is received while
+	// errPruneRunning is returned when a prune request is received while
 	// one is in progress
-	ErrPruneRunning = fmt.Errorf("a prune operation is already running")
+	errPruneRunning = fmt.Errorf("a prune operation is already running")
 
 	containersAcceptedFilters = map[string]bool{
 		"label":  true,
@@ -51,7 +51,7 @@ var (
 // ContainersPrune removes unused containers
 func (daemon *Daemon) ContainersPrune(ctx context.Context, pruneFilters filters.Args) (*types.ContainersPruneReport, error) {
 	if !atomic.CompareAndSwapInt32(&daemon.pruneRunning, 0, 1) {
-		return nil, ErrPruneRunning
+		return nil, errPruneRunning
 	}
 	defer atomic.StoreInt32(&daemon.pruneRunning, 0)
 
@@ -104,7 +104,7 @@ func (daemon *Daemon) ContainersPrune(ctx context.Context, pruneFilters filters.
 // VolumesPrune removes unused local volumes
 func (daemon *Daemon) VolumesPrune(ctx context.Context, pruneFilters filters.Args) (*types.VolumesPruneReport, error) {
 	if !atomic.CompareAndSwapInt32(&daemon.pruneRunning, 0, 1) {
-		return nil, ErrPruneRunning
+		return nil, errPruneRunning
 	}
 	defer atomic.StoreInt32(&daemon.pruneRunning, 0)
 
@@ -158,7 +158,7 @@ func (daemon *Daemon) VolumesPrune(ctx context.Context, pruneFilters filters.Arg
 // ImagesPrune removes unused images
 func (daemon *Daemon) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error) {
 	if !atomic.CompareAndSwapInt32(&daemon.pruneRunning, 0, 1) {
-		return nil, ErrPruneRunning
+		return nil, errPruneRunning
 	}
 	defer atomic.StoreInt32(&daemon.pruneRunning, 0)
 
@@ -392,7 +392,7 @@ func (daemon *Daemon) clusterNetworksPrune(ctx context.Context, pruneFilters fil
 // NetworksPrune removes unused networks
 func (daemon *Daemon) NetworksPrune(ctx context.Context, pruneFilters filters.Args) (*types.NetworksPruneReport, error) {
 	if !atomic.CompareAndSwapInt32(&daemon.pruneRunning, 0, 1) {
-		return nil, ErrPruneRunning
+		return nil, errPruneRunning
 	}
 	defer atomic.StoreInt32(&daemon.pruneRunning, 0)
 


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

This is PR tries to not export the error errPruneRunning, since I think it will not be used out of the package's scope.

And ping @gdevillele . This is a thought come from your PR. Thanks ☀️ 

**- What I did**
1. unexport error errPruneRunning

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

