### PR TITLE
btrfs: make all new btrfs storage drivers a subvolume

### DIFF
--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -157,6 +157,9 @@ func (d *Driver) Status() [][2]string {
 	if lv := btrfsLibVersion(); lv != -1 {
 		status = append(status, [2]string{"Library Version", fmt.Sprintf("%d", lv)})
 	}
+	if sv, err := isSubvolume(d.home); err == nil {
+		status = append(status, [2]string{"Root Subvolume", fmt.Sprintf("%v", sv)})
+	}
 	return status
 }
 


### PR DESCRIPTION
Each time that / is snapshotted, by default /var/lib/docker/btrfs will
be included in the snapshot (because /var/lib/docker/btrfs is just a
directory and not a subvolume) which results in lots of disk wastage
(since the old data is generally not useful).

Fix this by making all new /var/lib/docker/btrfs setups use btrfs
subvolumes. Migration would not be practical, so this is only done on
new setups (with old setups still supported).

The main purpose of this is to make it easier to debug cases where the
userbase is bifoccated on old and new btrfs storage driver setups. New
setups will have the output:

```
% docker info | grep 'Root Subvolume'
  Root Subvolume: true
```

While old setups will have:

```
% docker info | grep 'Root Subvolume'
  Root Subvolume: false
```

Fixes #33226
Signed-off-by: Aleksa Sarai <asarai@suse.de>