### PR TITLE
Ensure the correct Windows client is built

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -418,8 +418,10 @@ Try {
                 Invoke-Expression "git -C $dockerCliRoot  checkout -q $dockerCliCommit"
                 if ($LASTEXITCODE -ne 0) { Throw "Failed to checkout client commit $dockerCliCommit" }
                 Write-Host "INFO: Building client..."
-                Invoke-Expression "go build -o $root\bundles\docker.exe github.com/docker/cli/cmd/docker"
+                Push-Location "$dockerCliRoot\cmd\docker"; $global:pushed=$True
+                Invoke-Expression "go build -o $root\bundles\docker.exe"
                 if ($LASTEXITCODE -ne 0) { Throw "Failed to compile client" }
+                Pop-Location; $global:pushed=$False
             }
             Catch [Exception] {
                 Throw $_


### PR DESCRIPTION
This script builds the client by cloning the repository to a temporary
location and building from there by temporarily changing GOPATH.
However, it was previously building by package name, and a package with
the same name in GOROOT overrides. This update changes the current
directory, and builds from there, instead of specifying a package name.

Signed-off-by: John Stephens <johnstep@docker.com>