### PR TITLE
apparmor: make pkg/aaparser work on read-only root

### DIFF
--- a/daemon/apparmor_default.go
+++ b/daemon/apparmor_default.go
@@ -28,7 +28,7 @@ func ensureDefaultAppArmorProfile() error {
 
 		// Load the profile.
 		if err := aaprofile.InstallDefault(defaultApparmorProfile); err != nil {
-			return fmt.Errorf("AppArmor enabled on system but the %s profile could not be loaded.", defaultApparmorProfile)
+			return fmt.Errorf("AppArmor enabled on system but the %s profile could not be loaded: %s", defaultApparmorProfile, err)
 		}
 	}
 

--- a/pkg/aaparser/aaparser.go
+++ b/pkg/aaparser/aaparser.go
@@ -22,10 +22,11 @@ func GetVersion() (int, error) {
 	return parseVersion(output)
 }
 
-// LoadProfile runs `apparmor_parser -r` on a specified apparmor profile to
-// replace the profile.
+// LoadProfile runs `apparmor_parser -Kr` on a specified apparmor profile to
+// replace the profile. The `-K` is necessary to make sure that apparmor_parser
+// doesn't try to write to a read-only filesystem.
 func LoadProfile(profilePath string) error {
-	_, err := cmd("", "-r", profilePath)
+	_, err := cmd("", "-Kr", profilePath)
 	return err
 }
 


### PR DESCRIPTION
This is necessary because normally `apparmor_parser -r` will try to
create a temporary directory on the host (which is not allowed if the
host has a rootfs). However, the -K option bypasses saving things to the
cache (which avoids this issue).

```
% apparmor_parser -r /tmp/docker-profile
mkstemp: Read-only file system
% apparmor_parser -Kr /tmp/docker-profile
%
```

In addition, add extra information to the ensureDefaultAppArmorProfile
errors so that problems like this are easier to debug.

[![nikonfinal4 by Brittany Westveer](https://c1.staticflickr.com/8/7305/8721017831_07314bac69_z.jpg)](https://flic.kr/p/ehDuLp)

Fixes: 2f7596aaef3a ("apparmor: do not save profile to /etc/apparmor.d")
Signed-off-by: Aleksa Sarai <asarai@suse.de>

###### [nikonfinal4](https://flic.kr/p/ehDuLp) by [Brittany Westveer](https://www.flickr.com/photos/bwestveer/) on Flickr