### PR TITLE
client: Expose ClientHost to client users

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -247,6 +247,12 @@ func (cli *Client) UpdateClientVersion(v string) {
 
 }
 
+// DaemonHost returns the host associated with this instance of the Client.
+// This operation doesn't acquire a mutex.
+func (cli *Client) DaemonHost() string {
+	return cli.host
+}
+
 // ParseHost verifies that the given host strings is valid.
 func ParseHost(host string) (string, string, string, error) {
 	protoAddrParts := strings.SplitN(host, "://", 2)

--- a/client/interface.go
+++ b/client/interface.go
@@ -31,6 +31,7 @@ type CommonAPIClient interface {
 	SystemAPIClient
 	VolumeAPIClient
 	ClientVersion() string
+	DaemonHost() string
 	ServerVersion(ctx context.Context) (types.Version, error)
 	UpdateClientVersion(v string)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added a new `ClientHost()` function to the `Client` interface to return the host that the client is communicating with.

**- How I did it**

This exposes the private `host` field that was already a part of the Client struct

**- How to verify it**

It was verified as working in https://github.com/moby/moby/pull/32966
I've now re-opened this against as https://github.com/docker/cli/pull/93 - this is the moby-side portion of the changes.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://cloud.githubusercontent.com/assets/3781777/26160343/eb817dba-3b18-11e7-8b5d-5233028d5ce7.png)

