### PR TITLE
Add CreatedAt filed to volume. Display when volume is inspected.

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1047,6 +1047,10 @@ definitions:
         type: "string"
         description: "Mount path of the volume on the host."
         x-nullable: false
+      CreatedAt:
+        type: "string"
+        format: "dateTime"
+        description: "Time volume was created."
       Status:
         type: "object"
         description: |
@@ -1100,6 +1104,7 @@ definitions:
         com.example.some-label: "some-value"
         com.example.some-other-label: "some-other-value"
       Scope: "local"
+      CreatedAt: "2016-06-07T20:31:11.853781916Z"
 
   Network:
     type: "object"

--- a/api/types/volume.go
+++ b/api/types/volume.go
@@ -7,6 +7,9 @@ package types
 // swagger:model Volume
 type Volume struct {
 
+	// Time volume was created.
+	CreatedAt string `json:"CreatedAt,omitempty"`
+
 	// Name of the volume driver used by the volume.
 	// Required: true
 	Driver string `json:"Driver"`

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	dockererrors "github.com/docker/docker/api/errors"
@@ -27,9 +28,11 @@ type mounts []container.Mount
 
 // volumeToAPIType converts a volume.Volume to the type used by the Engine API
 func volumeToAPIType(v volume.Volume) *types.Volume {
+	createdAt, _ := v.CreatedAt()
 	tv := &types.Volume{
-		Name:   v.Name(),
-		Driver: v.DriverName(),
+		Name:      v.Name(),
+		Driver:    v.DriverName(),
+		CreatedAt: createdAt.Format(time.RFC3339),
 	}
 	if v, ok := v.(volume.DetailedVolume); ok {
 		tv.Labels = v.Labels()

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/volume"
@@ -82,6 +83,7 @@ func (a *volumeDriverAdapter) Get(name string) (volume.Volume, error) {
 		name:         v.Name,
 		driverName:   a.Name(),
 		eMount:       v.Mountpoint,
+		createdAt:    v.CreatedAt,
 		status:       v.Status,
 		baseHostPath: a.baseHostPath,
 	}, nil
@@ -124,13 +126,15 @@ type volumeAdapter struct {
 	name         string
 	baseHostPath string
 	driverName   string
-	eMount       string // ephemeral host volume path
+	eMount       string    // ephemeral host volume path
+	createdAt    time.Time // time the directory was created
 	status       map[string]interface{}
 }
 
 type proxyVolume struct {
 	Name       string
 	Mountpoint string
+	CreatedAt  time.Time
 	Status     map[string]interface{}
 }
 
@@ -168,6 +172,9 @@ func (a *volumeAdapter) Unmount(id string) error {
 	return err
 }
 
+func (a *volumeAdapter) CreatedAt() (time.Time, error) {
+	return a.createdAt, nil
+}
 func (a *volumeAdapter) Status() map[string]interface{} {
 	out := make(map[string]interface{}, len(a.status))
 	for k, v := range a.status {

--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -8,8 +8,11 @@ package local
 import (
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -84,4 +87,13 @@ func (v *localVolume) mount() error {
 	}
 	err := mount.Mount(v.opts.MountDevice, v.path, v.opts.MountType, mountOpts)
 	return errors.Wrapf(err, "error while mounting volume with options: %s", v.opts)
+}
+
+func (v *localVolume) CreatedAt() (time.Time, error) {
+	fileInfo, err := os.Stat(v.path)
+	if err != nil {
+		return time.Time{}, err
+	}
+	sec, nsec := fileInfo.Sys().(*syscall.Stat_t).Ctim.Unix()
+	return time.Unix(sec, nsec), nil
 }

--- a/volume/local/local_windows.go
+++ b/volume/local/local_windows.go
@@ -5,8 +5,11 @@ package local
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 )
 
 type optsConfig struct{}
@@ -31,4 +34,13 @@ func setOpts(v *localVolume, opts map[string]string) error {
 
 func (v *localVolume) mount() error {
 	return nil
+}
+
+func (v *localVolume) CreatedAt() (time.Time, error) {
+	fileInfo, err := os.Stat(v.path)
+	if err != nil {
+		return time.Time{}, err
+	}
+	ft := fileInfo.Sys().(*syscall.Win32FileAttributeData).CreationTime
+	return time.Unix(0, ft.Nanoseconds()), nil
 }

--- a/volume/testutils/testutils.go
+++ b/volume/testutils/testutils.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/docker/docker/volume"
 )
@@ -26,6 +27,9 @@ func (NoopVolume) Unmount(_ string) error { return nil }
 
 // Status proivdes low-level details about the volume
 func (NoopVolume) Status() map[string]interface{} { return nil }
+
+// CreatedAt provides the time the volume (directory) was created at
+func (NoopVolume) CreatedAt() (time.Time, error) { return time.Now(), nil }
 
 // FakeVolume is a fake volume with a random name
 type FakeVolume struct {
@@ -55,6 +59,9 @@ func (FakeVolume) Unmount(_ string) error { return nil }
 
 // Status proivdes low-level details about the volume
 func (FakeVolume) Status() map[string]interface{} { return nil }
+
+// CreatedAt provides the time the volume (directory) was created at
+func (FakeVolume) CreatedAt() (time.Time, error) { return time.Now(), nil }
 
 // FakeDriver is a driver that generates fake volumes
 type FakeDriver struct {

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/pkg/idtools"
@@ -64,6 +65,8 @@ type Volume interface {
 	Mount(id string) (string, error)
 	// Unmount unmounts the volume when it is no longer in use.
 	Unmount(id string) error
+	// CreatedAt returns Volume Creation time
+	CreatedAt() (time.Time, error)
 	// Status returns low-level status information about a volume
 	Status() map[string]interface{}
 }


### PR DESCRIPTION
Closes #32663 by adding CreatedAt field when volume is created.
Displaying CreatedAt value when volume is inspected
Adding tests to verify the new field is correctly populated

Signed-off-by: Marianna <mtesselh@gmail.com>
