### PR TITLE
api: Only return a Platform when relevant information is available

### DIFF
--- a/api/server/router/distribution/distribution_routes.go
+++ b/api/server/router/distribution/distribution_routes.go
@@ -122,7 +122,7 @@ func (s *distributionRouter) getDistributionInfo(ctx context.Context, w http.Res
 		var platform v1.Platform
 		if err == nil {
 			err := json.Unmarshal(configJSON, &platform)
-			if err == nil {
+			if err == nil && (platform.OS != "" || platform.Architecture != "") {
 				distributionInspect.Platforms = append(distributionInspect.Platforms, platform)
 			}
 		}


### PR DESCRIPTION
I noticed that we could return a `Platform` that has no information filled in. This doesn't look like it would cause any problems, but it would be confusing. Fix the handler to only append to this slice when the `Platform` is not empty.

cc @nishanttotla