### PR TITLE
Fix checkpoint ls

### DIFF
--- a/daemon/checkpoint.go
+++ b/daemon/checkpoint.go
@@ -103,7 +103,7 @@ func (daemon *Daemon) CheckpointList(name string, config types.CheckpointListOpt
 		return nil, err
 	}
 
-	checkpointDir, err := getCheckpointDir(config.CheckpointDir, "", name, container.ID, container.CheckpointDir(), true)
+	checkpointDir, err := getCheckpointDir(config.CheckpointDir, "", name, container.ID, container.CheckpointDir(), false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use create=false when calling getCheckpointDir
Fix #33263

Signed-off-by: Jacob Wen <jian.w.wen@oracle.com>
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Read the patch :)

**- How I did it**
Read the patch :)

**- How to verify it**
See #33263
```
# docker checkpoint ls looper
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

```
< Happy hacking! >
 ----------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

```