### PR TITLE
[pkg/term] switch more syscalls to /x/sys/

### DIFF
--- a/pkg/term/tc_solaris_cgo.go
+++ b/pkg/term/tc_solaris_cgo.go
@@ -13,7 +13,7 @@ import (
 import "C"
 
 // Termios is the Unix API for terminal I/O.
-// It is passthrough for syscall.Termios in order to make it portable with
+// It is passthrough for unix.Termios in order to make it portable with
 // other platforms where it is not available or handled differently.
 type Termios unix.Termios
 
@@ -28,11 +28,11 @@ func MakeRaw(fd uintptr) (*State, error) {
 
 	newState := oldState.termios
 
-	newState.Iflag &^= (syscall.IGNBRK | syscall.BRKINT | syscall.PARMRK | syscall.ISTRIP | syscall.INLCR | syscall.IGNCR | syscall.ICRNL | syscall.IXON | syscall.IXANY)
-	newState.Oflag &^= syscall.OPOST
-	newState.Lflag &^= (syscall.ECHO | syscall.ECHONL | syscall.ICANON | syscall.ISIG | syscall.IEXTEN)
-	newState.Cflag &^= (syscall.CSIZE | syscall.PARENB)
-	newState.Cflag |= syscall.CS8
+	newState.Iflag &^= (unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON | unix.IXANY)
+	newState.Oflag &^= unix.OPOST
+	newState.Lflag &^= (unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)
+	newState.Cflag &^= (unix.CSIZE | unix.PARENB)
+	newState.Cflag |= unix.CS8
 
 	/*
 		VMIN is the minimum number of characters that needs to be read in non-canonical mode for it to be returned


### PR DESCRIPTION
Switches the remaining syscalls in pkg/term except Errno to /x/sys/.
This was supposed to be part of #33180

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>
