### PR TITLE
Improved poor memory efficiency of awslogs

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -590,9 +590,9 @@ func (slice byTimestamp) Swap(i, j int) {
 }
 
 func unwrapEvents(events []wrappedEvent) []*cloudwatchlogs.InputLogEvent {
-	cwEvents := []*cloudwatchlogs.InputLogEvent{}
-	for _, input := range events {
-		cwEvents = append(cwEvents, input.inputLogEvent)
+	cwEvents := make([]*cloudwatchlogs.InputLogEvent, len(events))
+	for i, input := range events {
+		cwEvents[i] = input.inputLogEvent
 	}
 	return cwEvents
 }

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -1034,3 +1034,20 @@ func TestCreateTagSuccess(t *testing.T) {
 		t.Errorf("Expected LogStreamName to be %s", "test-container/container-abcdefghijklmnopqrstuvwxyz01234567890")
 	}
 }
+
+func BenchmarkUnwrapEvents(b *testing.B) {
+	events := make([]wrappedEvent, maximumLogEventsPerPut)
+	for i := 0; i < maximumLogEventsPerPut; i++ {
+		mes := strings.Repeat("0", maximumBytesPerEvent)
+		events[i].inputLogEvent = &cloudwatchlogs.InputLogEvent{
+			Message: &mes,
+		}
+	}
+
+	as := assert.New(b)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res := unwrapEvents(events)
+		as.Len(res, maximumLogEventsPerPut)
+	}
+}


### PR DESCRIPTION
Signed-off-by: YAMASAKI Masahide <masahide.y@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I fixed it because I found an inefficient code to repeat append to slice.

**- How I did it**
Make slice secured by make () beforehand.

**- How to verify it**

```
$ go test -v -bench . -benchmem
BenchmarkUnwrapEvents-32                           10000            298710 ns/op          386328 B/op         21 allocs/op
BenchmarkUnwrapEventsNew-32                        50000             39756 ns/op           81952 B/op          2 allocs/op
PASS
ok      github.com/moby/moby/daemon/logger/awslogs      20.450s
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
