### PR TITLE
Support overlay2 on btrfs

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -150,9 +150,19 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 
 	// check if they are running over btrfs, aufs, zfs, overlay, or ecryptfs
 	switch fsMagic {
-	case graphdriver.FsMagicBtrfs, graphdriver.FsMagicAufs, graphdriver.FsMagicZfs, graphdriver.FsMagicOverlay, graphdriver.FsMagicEcryptfs:
+	case graphdriver.FsMagicAufs, graphdriver.FsMagicZfs, graphdriver.FsMagicOverlay, graphdriver.FsMagicEcryptfs:
 		logrus.Errorf("'overlay2' is not supported over %s", backingFs)
 		return nil, graphdriver.ErrIncompatibleFS
+	case graphdriver.FsMagicBtrfs:
+		// Support for OverlayFS on BTRFS was added in kernel 4.7
+		// See https://btrfs.wiki.kernel.org/index.php/Changelog
+		if kernel.CompareKernelVersion(*v, kernel.VersionInfo{Kernel: 4, Major: 7, Minor: 0}) < 0 {
+			if !opts.overrideKernelCheck {
+				logrus.Errorf("'overlay2' requires kernel 4.7 to use on %s", backingFs)
+				return nil, graphdriver.ErrIncompatibleFS
+			}
+			logrus.Warn("Using pre-4.7.0 kernel for overlay2 on btrfs, may require kernel update")
+		}
 	}
 
 	rootUID, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)


### PR DESCRIPTION
OverlayFS is supported on top of btrfs as of Linux Kernel 4.7. Skip the hard enforcement when on kernel 4.7 or newer and respect the kernel check override flag on older kernels.

https://btrfs.wiki.kernel.org/index.php/Changelog#By_feature
> Add support for RENAME_EXCHANGE and RENAME_WHITEOUT to renameat2 syscall. This also means that overlayfs is now supported on top of btrfs.

#### Why would you want to run overlay2 on btrfs when you can use btrfs driver?

Btrfs has support for reflinking on copy up allowing better disk utilization and faster copy-up time than overlayfs on ext4. All the advantages related to shared page caching with overlayfs still apply on btrfs.