### PR TITLE
17.03.2 cherry picks

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -898,7 +898,8 @@
 			"names": [
 				"settimeofday",
 				"stime",
-				"adjtimex"
+				"adjtimex",
+				"clock_settime"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [],

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -733,6 +733,7 @@ func DefaultProfile() *types.Seccomp {
 				"settimeofday",
 				"stime",
 				"adjtimex",
+				"clock_settime",
 			},
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},


### PR DESCRIPTION
Cherry pick for 17.03.2:
 - profiles: seccomp: allow clock_settime when CAP_SYS_TIME is added [#31966](https://github.com/moby/moby/pull/31966)
 - ~Refactor to remove duplicate code around BuildArgs [#31351](https://github.com/moby/moby/pull/31351)~
 - ~Add testcase for build arg without value [#31991](https://github.com/moby/moby/pull/31991)~