### PR TITLE
Properly identify ingress network created with older swarm

### DIFF
--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -29,7 +29,7 @@ func networkFromGRPC(n *swarmapi.Network) types.Network {
 				IPv6Enabled: n.Spec.Ipv6Enabled,
 				Internal:    n.Spec.Internal,
 				Attachable:  n.Spec.Attachable,
-				Ingress:     n.Spec.Ingress,
+				Ingress:     IsIngressNetwork(n),
 				IPAMOptions: ipamFromGRPC(n.Spec.IPAM),
 				Scope:       netconst.SwarmScope,
 			},
@@ -165,7 +165,7 @@ func BasicNetworkFromGRPC(n swarmapi.Network) basictypes.NetworkResource {
 		IPAM:       ipam,
 		Internal:   spec.Internal,
 		Attachable: spec.Attachable,
-		Ingress:    spec.Ingress,
+		Ingress:    IsIngressNetwork(&n),
 		Labels:     n.Spec.Annotations.Labels,
 	}
 
@@ -224,4 +224,14 @@ func BasicNetworkCreateToGRPC(create basictypes.NetworkCreateRequest) swarmapi.N
 		ns.ConfigFrom = create.ConfigFrom.Network
 	}
 	return ns
+}
+
+// IsIngressNetwork check if the swarm network is an ingress network
+func IsIngressNetwork(n *swarmapi.Network) bool {
+	if n.Spec.Ingress {
+		return true
+	}
+	// Check if legacy defined ingress network
+	_, ok := n.Spec.Annotations.Labels["com.docker.swarm.internal"]
+	return ok && n.Spec.Annotations.Name == "ingress"
 }

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -18,6 +18,7 @@ import (
 	enginemount "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/daemon/cluster/convert"
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
 	clustertypes "github.com/docker/docker/daemon/cluster/provider"
 	"github.com/docker/go-connections/nat"
@@ -590,7 +591,7 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 		Labels:         na.Network.Spec.Annotations.Labels,
 		Internal:       na.Network.Spec.Internal,
 		Attachable:     na.Network.Spec.Attachable,
-		Ingress:        na.Network.Spec.Ingress,
+		Ingress:        convert.IsIngressNetwork(na.Network),
 		EnableIPv6:     na.Network.Spec.Ipv6Enabled,
 		CheckDuplicate: true,
 		Scope:          netconst.SwarmScope,


### PR DESCRIPTION
- otherwise docker network prune will remove it

Fixes #33259
