### PR TITLE
Tags may not be uppercase

### DIFF
--- a/docs/reference/commandline/tag.md
+++ b/docs/reference/commandline/tag.md
@@ -35,7 +35,7 @@ components may contain lowercase letters, digits and separators. A separator
 is defined as a period, one or two underscores, or one or more dashes. A name
 component may not start or end with a separator.
 
-A tag name must be valid ASCII and may contain lowercase and uppercase letters,
+A tag name must be valid ASCII and may contain lowercase letters,
 digits, underscores, periods and dashes. A tag name may not start with a
 period or a dash and may contain a maximum of 128 characters.
 


### PR DESCRIPTION
The code does not allow uppercase tags, the documentation should reflect that. 
	alphaNumericRegexp = match(`[a-z0-9]+`)
https://github.com/docker/distribution/blob/master/reference/regexp.go#L6

Signed-off-by: Matt Ray <matthewhray@gmail.com>