### PR TITLE
arg filter for printf verb %s of wrong type

### DIFF
--- a/daemon/cluster/filters_test.go
+++ b/daemon/cluster/filters_test.go
@@ -51,7 +51,7 @@ func TestNewListSecretsFilters(t *testing.T) {
 
 	for _, filter := range invalidFilters {
 		if _, err := newListSecretsFilters(filter); err == nil {
-			t.Fatalf("Should get an error for filter %s, while got nil", filter)
+			t.Fatalf("Should get an error for filter %v, while got nil", filter)
 		}
 	}
 }
@@ -96,7 +96,7 @@ func TestNewListConfigsFilters(t *testing.T) {
 
 	for _, filter := range invalidFilters {
 		if _, err := newListConfigsFilters(filter); err == nil {
-			t.Fatalf("Should get an error for filter %s, while got nil", filter)
+			t.Fatalf("Should get an error for filter %v, while got nil", filter)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: yupengzte <yu.peng36@zte.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Change "%s" to "%v", fix ***arg filter for printf verb %s of wrong type***.
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![view_7](https://cloud.githubusercontent.com/assets/20062886/26234864/3c4eac72-3c9a-11e7-91e8-f32dcbb22e1b.jpg)

