### PR TITLE
Add a restarting check to ContainerAttach

### DIFF
--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -31,7 +31,11 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, c *backend.ContainerA
 		return err
 	}
 	if container.IsPaused() {
-		err := fmt.Errorf("Container %s is paused. Unpause the container before attach", prefixOrName)
+		err := fmt.Errorf("Container %s is paused, unpause the container before attach.", prefixOrName)
+		return errors.NewRequestConflictError(err)
+	}
+	if container.IsRestarting() {
+		err := fmt.Errorf("Container %s is restarting, wait until the container is running.", prefixOrName)
 		return errors.NewRequestConflictError(err)
 	}
 


### PR DESCRIPTION
Signed-off-by: yangshukui <yangshukui@huawei.com>

part carried from https://github.com/moby/moby/pull/32137

**- What I did**
Add a restarting check to ContainerAttach

**- How I did it**

**- How to verify it**
terminal 1,
```
docker run -d --restart=always busybox
3664ae34b27306711b55a4cbf1802d1a027b3ab33ef7fe7789c1aefb0268c928
sleep 5
docker attach 3664ae34b27306711b55a4cbf1802d1a027b3ab33ef7fe7789c1aefb0268c928
```
terminal 2,
```
docker stop 3664ae34b27306711b55a4cbf1802d1a027b3ab33ef7fe7789c1aefb0268c928
```
and then docker attach maybe block.

