### PR TITLE
Remove deadlock in ContainerWait

### DIFF
--- a/client/container_wait.go
+++ b/client/container_wait.go
@@ -31,7 +31,7 @@ func (cli *Client) ContainerWait(ctx context.Context, containerID string, condit
 	}
 
 	resultC := make(chan container.ContainerWaitOKBody)
-	errC := make(chan error)
+	errC := make(chan error, 1)
 
 	query := url.Values{}
 	query.Set("condition", string(condition))


### PR DESCRIPTION
when `cli.post(...)` fails `errC <- err` [blocks on line 42][1] because `errC` is unbufferd.

  [1]: https://github.com/moby/moby/pull/33293/files#diff-316ca96dd5834654f8dc1537e5377bc3L42