### PR TITLE
Remove RuntimeData from cluster and types

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2174,9 +2174,6 @@ definitions:
       Runtime:
         description: "Runtime is the type of runtime specified for the task executor."
         type: "string"
-      RuntimeData:
-        description: "RuntimeData is the payload sent to be used with the runtime for the executor."
-        type: "array"
       Networks:
         type: "array"
         items:

--- a/api/types/swarm/task.go
+++ b/api/types/swarm/task.go
@@ -67,9 +67,6 @@ type TaskSpec struct {
 	ForceUpdate uint64
 
 	Runtime RuntimeType `json:",omitempty"`
-	// TODO (ehazlett): this should be removed and instead
-	// use struct tags (proto) for the runtimes
-	RuntimeData []byte `json:",omitempty"`
 }
 
 // Resources represents resources (CPU/Memory).

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -100,7 +100,6 @@ func serviceSpecFromGRPC(spec *swarmapi.ServiceSpec) (*types.ServiceSpec, error)
 			return nil, fmt.Errorf("unknown task runtime type: %s", t.Generic.Payload.TypeUrl)
 		}
 
-		taskTemplate.RuntimeData = t.Generic.Payload.Value
 	default:
 		return nil, fmt.Errorf("error creating service; unsupported runtime %T", t)
 	}
@@ -176,7 +175,6 @@ func ServiceSpecToGRPC(s types.ServiceSpec) (swarmapi.ServiceSpec, error) {
 				Kind: string(types.RuntimePlugin),
 				Payload: &gogotypes.Any{
 					TypeUrl: string(types.RuntimeURLPlugin),
-					Value:   s.TaskTemplate.RuntimeData,
 				},
 			},
 		}


### PR DESCRIPTION
This removes the temporary `RuntimeData` field.  Addresses https://github.com/moby/moby/pull/32030#discussion_r117573017