### PR TITLE
Fix validation of namespace mode

### DIFF
--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -44,6 +44,9 @@ func (n IpcMode) Valid() bool {
 	parts := strings.Split(string(n), ":")
 	switch mode := parts[0]; mode {
 	case "", "host":
+		if len(parts) != 1 {
+			return false
+		}
 	case "container":
 		if len(parts) != 2 || parts[1] == "" {
 			return false
@@ -122,6 +125,9 @@ func (n UsernsMode) Valid() bool {
 	parts := strings.Split(string(n), ":")
 	switch mode := parts[0]; mode {
 	case "", "host":
+		if len(parts) != 1 {
+			return false
+		}
 	default:
 		return false
 	}
@@ -169,6 +175,9 @@ func (n UTSMode) Valid() bool {
 	parts := strings.Split(string(n), ":")
 	switch mode := parts[0]; mode {
 	case "", "host":
+		if len(parts) != 1 {
+			return false
+		}
 	default:
 		return false
 	}
@@ -199,6 +208,9 @@ func (n PidMode) Valid() bool {
 	parts := strings.Split(string(n), ":")
 	switch mode := parts[0]; mode {
 	case "", "host":
+		if len(parts) != 1 {
+			return false
+		}
 	case "container":
 		if len(parts) != 2 || parts[1] == "" {
 			return false


### PR DESCRIPTION
Current validation of namespace mode is too loose. The `Valid()` func
looks like this:
```
func (n IpcMode) Valid() bool {
        parts := strings.Split(string(n), ":")
        switch mode := parts[0]; mode {
        case "", "host":
        case "container":
                if len(parts) != 2 || parts[1] == "" {
                        return false
                }
        default:
                return false
        }
        return true
}
```

Valid parameters for `--ipc` are "", "host" and "container:id". But this
func will also return `true` for the following invalid parameters:
```
    --ipc :
    --ipc host:abc
```

We should add a check of `len(parts)` when `parts[0] == ""|"host"`.

Signed-off-by: Yuanhong Peng <pengyuanhong@huawei.com>