### PR TITLE
Stop referring CLI flags in error messages if API client is unknown

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -77,7 +77,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	}
 
 	if runtime.GOOS != "windows" && options.SecurityOpt != nil {
-		return nil, fmt.Errorf("the daemon on this platform does not support --security-opt to build")
+		return nil, fmt.Errorf("The daemon on this platform does not support setting security options on build")
 	}
 
 	var buildUlimits = []*units.Ulimit{}

--- a/api/server/router/experimental.go
+++ b/api/server/router/experimental.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	errExperimentalFeature = errors.New("This experimental feature is disabled by default. Start the Docker daemon with --experimental in order to enable it.")
+	errExperimentalFeature = errors.New("This experimental feature is disabled by default. Start the Docker daemon in experimental mode in order to enable it.")
 )
 
 // ExperimentalRoute defines an experimental API route that can be enabled or disabled.

--- a/integration-cli/docker_cli_netmode_test.go
+++ b/integration-cli/docker_cli_netmode_test.go
@@ -44,7 +44,7 @@ func (s *DockerSuite) TestNetHostname(c *check.C) {
 	c.Assert(out, checker.Contains, runconfig.ErrConflictNetworkHostname.Error())
 
 	out, _ = dockerCmdWithFail(c, "run", "--net=container", "busybox", "ps")
-	c.Assert(out, checker.Contains, "--net: invalid net mode: invalid container format container:<name|id>")
+	c.Assert(out, checker.Contains, "Invalid network mode: invalid container format container:<name|id>")
 
 	out, _ = dockerCmdWithFail(c, "run", "--net=weird", "busybox", "ps")
 	c.Assert(out, checker.Contains, "network weird not found")

--- a/runconfig/config_test.go
+++ b/runconfig/config_test.go
@@ -75,9 +75,9 @@ func TestDecodeContainerConfig(t *testing.T) {
 // as to what level of container isolation is supported.
 func TestDecodeContainerConfigIsolation(t *testing.T) {
 
-	// An invalid isolation level
+	// An Invalid isolation level
 	if _, _, _, err := callDecodeContainerConfigIsolation("invalid"); err != nil {
-		if !strings.Contains(err.Error(), `invalid --isolation: "invalid"`) {
+		if !strings.Contains(err.Error(), `Invalid isolation: "invalid"`) {
 			t.Fatal(err)
 		}
 	}
@@ -99,7 +99,7 @@ func TestDecodeContainerConfigIsolation(t *testing.T) {
 		}
 	} else {
 		if _, _, _, err := callDecodeContainerConfigIsolation("process"); err != nil {
-			if !strings.Contains(err.Error(), `invalid --isolation: "process"`) {
+			if !strings.Contains(err.Error(), `Invalid isolation: "process"`) {
 				t.Fatal(err)
 			}
 		}
@@ -112,7 +112,7 @@ func TestDecodeContainerConfigIsolation(t *testing.T) {
 		}
 	} else {
 		if _, _, _, err := callDecodeContainerConfigIsolation("hyperv"); err != nil {
-			if !strings.Contains(err.Error(), `invalid --isolation: "hyperv"`) {
+			if !strings.Contains(err.Error(), `Invalid isolation: "hyperv"`) {
 				t.Fatal(err)
 			}
 		}

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -45,7 +45,7 @@ func validateNetContainerMode(c *container.Config, hc *container.HostConfig) err
 	parts := strings.Split(string(hc.NetworkMode), ":")
 	if parts[0] == "container" {
 		if len(parts) < 2 || parts[1] == "" {
-			return fmt.Errorf("--net: invalid net mode: invalid container format container:<name|id>")
+			return fmt.Errorf("Invalid network mode: invalid container format container:<name|id>")
 		}
 	}
 

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -55,7 +55,7 @@ func validateIsolation(hc *container.HostConfig) error {
 		return nil
 	}
 	if !hc.Isolation.IsValid() {
-		return fmt.Errorf("invalid --isolation: %q - %s only supports 'default'", hc.Isolation, runtime.GOOS)
+		return fmt.Errorf("Invalid isolation: %q - %s only supports 'default'", hc.Isolation, runtime.GOOS)
 	}
 	return nil
 }
@@ -68,11 +68,11 @@ func validateQoS(hc *container.HostConfig) error {
 	}
 
 	if hc.IOMaximumBandwidth != 0 {
-		return fmt.Errorf("invalid QoS settings: %s does not support --io-maxbandwidth", runtime.GOOS)
+		return fmt.Errorf("Invalid QoS settings: %s does not support configuration of maximum bandwidth", runtime.GOOS)
 	}
 
 	if hc.IOMaximumIOps != 0 {
-		return fmt.Errorf("invalid QoS settings: %s does not support --io-maxiops", runtime.GOOS)
+		return fmt.Errorf("Invalid QoS settings: %s does not support configuration of maximum IOPs", runtime.GOOS)
 	}
 	return nil
 }
@@ -86,15 +86,15 @@ func validateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
 	}
 
 	if hc.Resources.CPURealtimePeriod > 0 && !si.CPURealtimePeriod {
-		return fmt.Errorf("invalid --cpu-rt-period: Your kernel does not support cgroup rt period")
+		return fmt.Errorf("Your kernel does not support cgroup cpu real-time period")
 	}
 
 	if hc.Resources.CPURealtimeRuntime > 0 && !si.CPURealtimeRuntime {
-		return fmt.Errorf("invalid --cpu-rt-runtime: Your kernel does not support cgroup rt runtime")
+		return fmt.Errorf("Your kernel does not support cgroup cpu real-time runtime")
 	}
 
 	if hc.Resources.CPURealtimePeriod != 0 && hc.Resources.CPURealtimeRuntime != 0 && hc.Resources.CPURealtimeRuntime > hc.Resources.CPURealtimePeriod {
-		return fmt.Errorf("invalid --cpu-rt-runtime: rt runtime cannot be higher than rt period")
+		return fmt.Errorf("cpu real-time runtime cannot be higher than cpu real-time period")
 	}
 	return nil
 }

--- a/runconfig/hostconfig_windows.go
+++ b/runconfig/hostconfig_windows.go
@@ -31,7 +31,7 @@ func validateNetMode(c *container.Config, hc *container.HostConfig) error {
 	}
 
 	if hc.NetworkMode.IsContainer() && hc.Isolation.IsHyperV() {
-		return fmt.Errorf("net mode --net=container:<NameOrId> unsupported for hyperv isolation")
+		return fmt.Errorf("Using the network stack of another container is not supported while using Hyper-V Containers")
 	}
 
 	return nil
@@ -46,7 +46,7 @@ func validateIsolation(hc *container.HostConfig) error {
 		return nil
 	}
 	if !hc.Isolation.IsValid() {
-		return fmt.Errorf("invalid --isolation: %q. Windows supports 'default', 'process', or 'hyperv'", hc.Isolation)
+		return fmt.Errorf("Invalid isolation: %q. Windows supports 'default', 'process', or 'hyperv'", hc.Isolation)
 	}
 	return nil
 }
@@ -63,10 +63,10 @@ func validateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
 		return nil
 	}
 	if hc.Resources.CPURealtimePeriod != 0 {
-		return fmt.Errorf("invalid --cpu-rt-period: Windows does not support this feature")
+		return fmt.Errorf("Windows does not support CPU real-time period")
 	}
 	if hc.Resources.CPURealtimeRuntime != 0 {
-		return fmt.Errorf("invalid --cpu-rt-runtime: Windows does not support this feature")
+		return fmt.Errorf("Windows does not support CPU real-time runtime")
 	}
 	return nil
 }
@@ -78,7 +78,7 @@ func validatePrivileged(hc *container.HostConfig) error {
 		return nil
 	}
 	if hc.Privileged {
-		return fmt.Errorf("invalid --privileged: Windows does not support this feature")
+		return fmt.Errorf("Windows does not support privileged mode")
 	}
 	return nil
 }
@@ -90,7 +90,7 @@ func validateReadonlyRootfs(hc *container.HostConfig) error {
 		return nil
 	}
 	if hc.ReadonlyRootfs {
-		return fmt.Errorf("invalid --read-only: Windows does not support this feature")
+		return fmt.Errorf("Windows does not support root filesystem in read-only mode")
 	}
 	return nil
 }

--- a/runconfig/hostconfig_windows_test.go
+++ b/runconfig/hostconfig_windows_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestValidatePrivileged(t *testing.T) {
-	expected := "invalid --privileged: Windows does not support this feature"
+	expected := "Windows does not support privileged mode"
 	err := validatePrivileged(&container.HostConfig{Privileged: true})
 	if err == nil || err.Error() != expected {
 		t.Fatalf("Expected %s", expected)


### PR DESCRIPTION
Made error messages more generic. 

Fixes #33138