### PR TITLE
Spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,7 +190,7 @@ be found.
 * Update runc to 54296cf40ad8143b62dbcaa1d90e520a2136ddfe [#31666](https://github.com/docker/docker/pull/31666)
  * Ignore cgroup2 mountpoints [opencontainers/runc#1266](https://github.com/opencontainers/runc/pull/1266)
 * Update containerd to 4ab9917febca54791c5f071a9d1f404867857fcc [#31662](https://github.com/docker/docker/pull/31662) [#31852](https://github.com/docker/docker/pull/31852)
- * Register healtcheck service before calling restore() [docker/containerd#609](https://github.com/docker/containerd/pull/609)
+ * Register healthcheck service before calling restore() [docker/containerd#609](https://github.com/docker/containerd/pull/609)
 * Fix `docker exec` not working after unattended upgrades that reload apparmor profiles [#31773](https://github.com/docker/docker/pull/31773)
 * Fix unmounting layer without merge dir with Overlay2 [#31069](https://github.com/docker/docker/pull/31069)
 * Do not ignore "volume in use" errors when force-delete [#31450](https://github.com/docker/docker/pull/31450)
@@ -1087,12 +1087,12 @@ installing docker, please make sure to update them accordingly.
 + Add security options to `docker info` output [#21172](https://github.com/docker/docker/pull/21172) [#23520](https://github.com/docker/docker/pull/23520)
 + Add insecure registries to `docker info` output [#20410](https://github.com/docker/docker/pull/20410)
 + Extend Docker authorization with TLS user information [#21556](https://github.com/docker/docker/pull/21556)
-+ devicemapper: expose Mininum Thin Pool Free Space through `docker info` [#21945](https://github.com/docker/docker/pull/21945)
++ devicemapper: expose Minimum Thin Pool Free Space through `docker info` [#21945](https://github.com/docker/docker/pull/21945)
 * API now returns a JSON object when an error occurs making it more consistent [#22880](https://github.com/docker/docker/pull/22880)
 - Prevent `docker run -i --restart` from hanging on exit [#22777](https://github.com/docker/docker/pull/22777)
 - Fix API/CLI discrepancy on hostname validation [#21641](https://github.com/docker/docker/pull/21641)
 - Fix discrepancy in the format of sizes in `stats` from HumanSize to BytesSize [#21773](https://github.com/docker/docker/pull/21773)
-- authz: when request is denied return forbbiden exit code (403) [#22448](https://github.com/docker/docker/pull/22448)
+- authz: when request is denied return forbidden exit code (403) [#22448](https://github.com/docker/docker/pull/22448)
 - Windows: fix tty-related displaying issues [#23878](https://github.com/docker/docker/pull/23878)
 
 ### Runtime
@@ -1887,7 +1887,7 @@ by another client (#15489)
 
 #### Remote API
 
-- Fix unmarshalling of Command and Entrypoint
+- Fix unmarshaling of Command and Entrypoint
 - Set limit for minimum client version supported
 - Validate port specification
 - Return proper errors when attach/reattach fail
@@ -2572,7 +2572,7 @@ With the ongoing changes to the networking and execution subsystems of docker te
 - Fix ADD caching issue with . prefixed path
 - Fix docker build on devicemapper by reverting sparse file tar option
 - Fix issue with file caching and prevent wrong cache hit
-* Use same error handling while unmarshalling CMD and ENTRYPOINT
+* Use same error handling while unmarshaling CMD and ENTRYPOINT
 
 #### Documentation
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -93,7 +93,7 @@ RUN set -x \
 	&& rm -rf "$SECCOMP_PATH"
 
 # Install Go
-# We don't have official binary golang 1.7.5 tarballs for ARM64, eigher for Go or
+# We don't have official binary golang 1.7.5 tarballs for ARM64, either for Go or
 # bootstrap, so we use golang-go (1.6) as bootstrap to build Go from source code.
 # We don't use the official ARMv6 released binaries as a GOROOT_BOOTSTRAP, because
 # not all ARM64 platforms support 32-bit mode. 32-bit mode is optional for ARMv8.

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -102,7 +102,7 @@ func (s *containerRouter) getContainersLogs(ctx context.Context, w http.Response
 	}
 
 	// doesn't matter what version the client is on, we're using this internally only
-	// also do we need size? i'm thinkin no we don't
+	// also do we need size? i'm thinking no we don't
 	raw, err := s.backend.ContainerInspect(containerName, false, api.DefaultVersion)
 	if err != nil {
 		return err

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1637,7 +1637,7 @@ definitions:
       may not be applied if the version number has changed from the last read. In other words,
       if two update requests specify the same base version, only one of the requests can succeed.
       As a result, two separate update requests that happen at the same time will not
-      unintentially overwrite each other.
+      unintentionally overwrite each other.
     type: "object"
     properties:
       Index:

--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -228,7 +228,7 @@ func TestArgsMatch(t *testing.T) {
 			"created": {"tod": true}},
 		}: "created",
 		{map[string]map[string]bool{
-			"created": {"anyting": true, "to*": true}},
+			"created": {"anything": true, "to*": true}},
 		}: "created",
 	}
 

--- a/api/types/swarm/swarm.go
+++ b/api/types/swarm/swarm.go
@@ -2,7 +2,7 @@ package swarm
 
 import "time"
 
-// ClusterInfo represents info about the cluster for outputing in "info"
+// ClusterInfo represents info about the cluster for outputting in "info"
 // it contains the same information as "Swarm", but without the JoinTokens
 type ClusterInfo struct {
 	ID string

--- a/builder/dockerfile/buildargs_test.go
+++ b/builder/dockerfile/buildargs_test.go
@@ -20,7 +20,7 @@ func TestGetAllAllowed(t *testing.T) {
 	})
 
 	buildArgs.AddMetaArg("ArgFromMeta", strPtr("frommeta1"))
-	buildArgs.AddMetaArg("ArgFromMetaOverriden", strPtr("frommeta2"))
+	buildArgs.AddMetaArg("ArgFromMetaOverridden", strPtr("frommeta2"))
 	buildArgs.AddMetaArg("ArgFromMetaNotUsed", strPtr("frommeta3"))
 
 	buildArgs.AddArg("ArgOverriddenByOptions", strPtr("fromdockerfile2"))
@@ -28,7 +28,7 @@ func TestGetAllAllowed(t *testing.T) {
 	buildArgs.AddArg("ArgNoDefaultInDockerfile", nil)
 	buildArgs.AddArg("ArgNoDefaultInDockerfileFromOptions", nil)
 	buildArgs.AddArg("ArgFromMeta", nil)
-	buildArgs.AddArg("ArgFromMetaOverriden", strPtr("fromdockerfile3"))
+	buildArgs.AddArg("ArgFromMetaOverridden", strPtr("fromdockerfile3"))
 
 	all := buildArgs.GetAllAllowed()
 	expected := map[string]string{
@@ -37,7 +37,7 @@ func TestGetAllAllowed(t *testing.T) {
 		"ArgWithDefaultInDockerfile":          "fromdockerfile1",
 		"ArgNoDefaultInDockerfileFromOptions": "fromopt3",
 		"ArgFromMeta":                         "frommeta1",
-		"ArgFromMetaOverriden":                "fromdockerfile3",
+		"ArgFromMetaOverridden":               "fromdockerfile3",
 	}
 	assert.Equal(t, expected, all)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -91,7 +91,7 @@ type Client struct {
 // CheckRedirect specifies the policy for dealing with redirect responses:
 // If the request is non-GET return `ErrRedirect`. Otherwise use the last response.
 //
-// Go 1.8 changes behavior for HTTP redirects (specificlaly 301, 307, and 308) in the client .
+// Go 1.8 changes behavior for HTTP redirects (specifically 301, 307, and 308) in the client .
 // The Docker client (and by extension docker API client) can be made to to send a request
 // like POST /containers//start where what would normally be in the name section of the URL is empty.
 // This triggers an HTTP 301 from the daemon.

--- a/client/container_wait.go
+++ b/client/container_wait.go
@@ -14,7 +14,7 @@ import (
 // indicated by the given condition, either "not-running" (default),
 // "next-exit", or "removed".
 //
-// If this client's API version is beforer 1.30, condition is ignored and
+// If this client's API version is before 1.30, condition is ignored and
 // ContainerWait will return immediately with the two channels, as the server
 // will wait as if the condition were "not-running".
 //
@@ -23,7 +23,7 @@ import (
 // then returns two channels on which the caller can wait for the exit status
 // of the container or an error if there was a problem either beginning the
 // wait request or in getting the response. This allows the caller to
-// sychronize ContainerWait with other calls, such as specifying a
+// synchronize ContainerWait with other calls, such as specifying a
 // "next-exit" condition before issuing a ContainerStart request.
 func (cli *Client) ContainerWait(ctx context.Context, containerID string, condition container.WaitCondition) (<-chan container.ContainerWaitOKBody, <-chan error) {
 	if versions.LessThan(cli.ClientVersion(), "1.30") {

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -269,7 +269,7 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 	cResources := &container.HostConfig.Resources
 
 	// validate NanoCPUs, CPUPeriod, and CPUQuota
-	// Becuase NanoCPU effectively updates CPUPeriod/CPUQuota,
+	// Because NanoCPU effectively updates CPUPeriod/CPUQuota,
 	// once NanoCPU is already set, updating CPUPeriod/CPUQuota will be blocked, and vice versa.
 	// In the following we make sure the intended update (resources) does not conflict with the existing (cResource).
 	if resources.NanoCPUs > 0 && cResources.CPUPeriod > 0 {

--- a/container/state.go
+++ b/container/state.go
@@ -185,7 +185,7 @@ const (
 // timeouts, and avoiding goroutine leaks. Wait must be called without holding
 // the state lock. Returns a channel from which the caller will receive the
 // result. If the container exited on its own, the result's Err() method will
-// be nil and its ExitCode() method will return the conatiners exit code,
+// be nil and its ExitCode() method will return the container's exit code,
 // otherwise, the results Err() method will return an error indicating why the
 // wait operation failed.
 func (s *State) Wait(ctx context.Context, condition WaitCondition) <-chan StateStatus {

--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -343,7 +343,7 @@ func (r *controller) Shutdown(ctx context.Context) error {
 		}
 
 		// add a delay for gossip converge
-		// TODO(dongluochen): this delay shoud be configurable to fit different cluster size and network delay.
+		// TODO(dongluochen): this delay should be configurable to fit different cluster size and network delay.
 		time.Sleep(defaultGossipConvergeDelay)
 	}
 

--- a/daemon/discovery/discovery_test.go
+++ b/daemon/discovery/discovery_test.go
@@ -87,8 +87,8 @@ func TestDiscoveryOpts(t *testing.T) {
 		t.Fatalf("Heartbeat - Expected : %v, Actual : %v", expected, heartbeat)
 	}
 
-	discaveryTTL := fmt.Sprintf("%d", defaultDiscoveryTTLFactor-1)
-	clusterOpts = map[string]string{"discovery.ttl": discaveryTTL}
+	discoveryTTL := fmt.Sprintf("%d", defaultDiscoveryTTLFactor-1)
+	clusterOpts = map[string]string{"discovery.ttl": discoveryTTL}
 	heartbeat, ttl, err = discoveryOpts(clusterOpts)
 	if err == nil && heartbeat == 0 {
 		t.Fatal("discovery.heartbeat must be positive")

--- a/daemon/events/events_test.go
+++ b/daemon/events/events_test.go
@@ -247,7 +247,7 @@ func TestLoadBufferedEventsOnlyFromPast(t *testing.T) {
 }
 
 // #13753
-func TestIngoreBufferedWhenNoTimes(t *testing.T) {
+func TestIgnoreBufferedWhenNoTimes(t *testing.T) {
 	m1, err := eventstestutils.Scan("2016-03-07T17:28:03.022433271+02:00 container die 0b863f2a26c18557fc6cdadda007c459f9ec81b874780808138aea78a3595079 (image=ubuntu, name=small_hoover)")
 	if err != nil {
 		t.Fatal(err)

--- a/daemon/graphdriver/devmapper/device_setup.go
+++ b/daemon/graphdriver/devmapper/device_setup.go
@@ -174,27 +174,27 @@ func writeLVMConfig(root string, cfg directLVMConfig) error {
 func setupDirectLVM(cfg directLVMConfig) error {
 	pvCreate, err := exec.LookPath("pvcreate")
 	if err != nil {
-		return errors.Wrap(err, "error lookuping up command `pvcreate` while setting up direct lvm")
+		return errors.Wrap(err, "error looking up command `pvcreate` while setting up direct lvm")
 	}
 
 	vgCreate, err := exec.LookPath("vgcreate")
 	if err != nil {
-		return errors.Wrap(err, "error lookuping up command `vgcreate` while setting up direct lvm")
+		return errors.Wrap(err, "error looking up command `vgcreate` while setting up direct lvm")
 	}
 
 	lvCreate, err := exec.LookPath("lvcreate")
 	if err != nil {
-		return errors.Wrap(err, "error lookuping up command `lvcreate` while setting up direct lvm")
+		return errors.Wrap(err, "error looking up command `lvcreate` while setting up direct lvm")
 	}
 
 	lvConvert, err := exec.LookPath("lvconvert")
 	if err != nil {
-		return errors.Wrap(err, "error lookuping up command `lvconvert` while setting up direct lvm")
+		return errors.Wrap(err, "error looking up command `lvconvert` while setting up direct lvm")
 	}
 
 	lvChange, err := exec.LookPath("lvchange")
 	if err != nil {
-		return errors.Wrap(err, "error lookuping up command `lvchange` while setting up direct lvm")
+		return errors.Wrap(err, "error looking up command `lvchange` while setting up direct lvm")
 	}
 
 	if cfg.AutoExtendPercent == 0 {

--- a/daemon/graphdriver/driver_linux.go
+++ b/daemon/graphdriver/driver_linux.go
@@ -95,7 +95,7 @@ func GetFSMagic(rootpath string) (FsMagic, error) {
 	return FsMagic(buf.Type), nil
 }
 
-// NewFsChecker returns a checker configured for the provied FsMagic
+// NewFsChecker returns a checker configured for the provided FsMagic
 func NewFsChecker(t FsMagic) Checker {
 	return &fsChecker{
 		t: t,

--- a/daemon/graphdriver/driver_solaris.go
+++ b/daemon/graphdriver/driver_solaris.go
@@ -54,7 +54,7 @@ func (c *fsChecker) IsMounted(path string) bool {
 	return m
 }
 
-// NewFsChecker returns a checker configured for the provied FsMagic
+// NewFsChecker returns a checker configured for the provided FsMagic
 func NewFsChecker(t FsMagic) Checker {
 	return &fsChecker{
 		t: t,

--- a/daemon/graphdriver/quota/projectquota.go
+++ b/daemon/graphdriver/quota/projectquota.go
@@ -328,7 +328,7 @@ func makeBackingFsDev(home string) (string, error) {
 	}
 
 	backingFsBlockDev := path.Join(home, "backingFsBlockDev")
-	// Re-create just in case comeone copied the home directory over to a new device
+	// Re-create just in case someone copied the home directory over to a new device
 	syscall.Unlink(backingFsBlockDev)
 	stat := fileinfo.Sys().(*syscall.Stat_t)
 	if err := syscall.Mknod(backingFsBlockDev, syscall.S_IFBLK|0600, int(stat.Dev)); err != nil {

--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -300,7 +300,7 @@ func (d *Driver) Remove(id string) error {
 		//
 		// TODO @jhowardmsft - For RS3, we can remove the retries. Also consider
 		// using platform APIs (if available) to get this more succinctly. Also
-		// consider enlighting the Remove() interface to have context of why
+		// consider enhancing the Remove() interface to have context of why
 		// the remove is being called - that could improve efficiency by not
 		// enumerating compute systems during a remove of a container as it's
 		// not required.

--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -363,7 +363,7 @@ var newTicker = func(freq time.Duration) *time.Ticker {
 // awslogs-datetime-format options have been configured, multiline processing
 // is enabled, where log messages are stored in an event buffer until a multiline
 // pattern match is found, at which point the messages in the event buffer are
-// pushed to CloudWatch logs as a single log event.  Multline messages are processed
+// pushed to CloudWatch logs as a single log event.  Multiline messages are processed
 // according to the maximumBytesPerPut constraint, and the implementation only
 // allows for messages to be buffered for a maximum of 2*batchPublishFrequency
 // seconds.  When events are ready to be processed for submission to CloudWatch

--- a/daemon/logger/ring.go
+++ b/daemon/logger/ring.go
@@ -121,7 +121,7 @@ func (r *RingLogger) run() {
 
 type messageRing struct {
 	mu sync.Mutex
-	// singals callers of `Dequeue` to wake up either on `Close` or when a new `Message` is added
+	// signals callers of `Dequeue` to wake up either on `Close` or when a new `Message` is added
 	wait *sync.Cond
 
 	sizeBytes int64 // current buffer size

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -55,7 +55,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 	}
 
 	// If the container has not been started, and has configs or secrets
-	// secrets, create symlinks to each confing and secret. If it has been
+	// secrets, create symlinks to each config and secret. If it has been
 	// started before, the symlinks should have already been created. Also, it
 	// is important to not mount a Hyper-V  container that has been started
 	// before, to protect the host from the container; for example, from

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -39,7 +39,7 @@ func (daemon *Daemon) Reload(conf *config.Config) (err error) {
 
 	daemon.reloadPlatform(conf, attributes)
 	daemon.reloadDebug(conf, attributes)
-	daemon.reloadMaxConcurrentDowloadsAndUploads(conf, attributes)
+	daemon.reloadMaxConcurrentDownloadsAndUploads(conf, attributes)
 	daemon.reloadShutdownTimeout(conf, attributes)
 
 	if err := daemon.reloadClusterDiscovery(conf, attributes); err != nil {
@@ -74,9 +74,9 @@ func (daemon *Daemon) reloadDebug(conf *config.Config, attributes map[string]str
 	attributes["debug"] = fmt.Sprintf("%t", daemon.configStore.Debug)
 }
 
-// reloadMaxConcurrentDowloadsAndUploads updates configuration with max concurrent
+// reloadMaxConcurrentDownloadsAndUploads updates configuration with max concurrent
 // download and upload options and updates the passed attributes
-func (daemon *Daemon) reloadMaxConcurrentDowloadsAndUploads(conf *config.Config, attributes map[string]string) {
+func (daemon *Daemon) reloadMaxConcurrentDownloadsAndUploads(conf *config.Config, attributes map[string]string) {
 	// If no value is set for max-concurrent-downloads we assume it is the default value
 	// We always "reset" as the cost is lightweight and easy to maintain.
 	if conf.IsValueSet("max-concurrent-downloads") && conf.MaxConcurrentDownloads != nil {

--- a/daemon/volumes_unix_test.go
+++ b/daemon/volumes_unix_test.go
@@ -206,7 +206,7 @@ func TestBackportMountSpec(t *testing.T) {
 					BindOptions: &mounttypes.BindOptions{Propagation: "shared"},
 				},
 			},
-			comment: "bind mount with read/write + shared propgation",
+			comment: "bind mount with read/write + shared propagation",
 		},
 		{
 			mp: &volume.MountPoint{

--- a/distribution/metadata/v2_metadata_service.go
+++ b/distribution/metadata/v2_metadata_service.go
@@ -203,7 +203,7 @@ func (serv *v2MetadataService) TagAndAdd(diffID layer.DiffID, hmacKey []byte, me
 	return serv.Add(diffID, meta)
 }
 
-// Remove unassociates a metadata entry from a layer DiffID.
+// Remove disassociates a metadata entry from a layer DiffID.
 func (serv *v2MetadataService) Remove(metadata V2Metadata) error {
 	if serv.store == nil {
 		// Support a service which has no backend storage, in this case

--- a/distribution/push_v2_test.go
+++ b/distribution/push_v2_test.go
@@ -185,7 +185,7 @@ func TestLayerAlreadyExists(t *testing.T) {
 			expectedRequests:   []string{"apple"},
 		},
 		{
-			name:               "not matching reposies",
+			name:               "not matching repositories",
 			targetRepo:         "busybox",
 			maxExistenceChecks: 3,
 			metadata: []metadata.V2Metadata{

--- a/dockerversion/useragent.go
+++ b/dockerversion/useragent.go
@@ -52,8 +52,8 @@ func escapeStr(s string, charsToEscape string) string {
 	var ret string
 	for _, currRune := range s {
 		appended := false
-		for _, escapeableRune := range charsToEscape {
-			if currRune == escapeableRune {
+		for _, escapableRune := range charsToEscape {
+			if currRune == escapableRune {
 				ret += `\` + string(currRune)
 				appended = true
 				break

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -826,7 +826,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Query parameters**:
 
--   **details** - 1/True/true or 0/False/flase, Show extra details provided to logs. Default `false`.
+-   **details** - 1/True/true or 0/False/false, Show extra details provided to logs. Default `false`.
 -   **follow** – 1/True/true or 0/False/false, return stream. Default `false`.
 -   **stdout** – 1/True/true or 0/False/false, show `stdout` log. Default `false`.
 -   **stderr** – 1/True/true or 0/False/false, show `stderr` log. Default `false`.

--- a/hack/Jenkins/W2L/setup.sh
+++ b/hack/Jenkins/W2L/setup.sh
@@ -13,7 +13,7 @@ SCRIPT_VER="Wed Apr 20 18:30:19 UTC 2016"
 #  - Error if running 32-bit posix tools. Probably can take from bash --version and check contains "x86_64"
 #  - Warn if the CI directory cannot be deleted afterwards. Otherwise turdlets are left behind
 #  - Use %systemdrive% ($SYSTEMDRIVE) rather than hard code to c: for TEMP
-#  - Consider cross builing the Windows binary and copy across. That's a bit of a heavy lift. Only reason
+#  - Consider cross building the Windows binary and copy across. That's a bit of a heavy lift. Only reason
 #    for doing that is that it mirrors the actual release process for docker.exe which is cross-built.
 #    However, should absolutely not be a problem if built natively, so nit-picking.
 #  - Tidy up of images and containers. Either here, or in the teardown script.
@@ -116,7 +116,7 @@ fi
 # Get the commit has and verify we have something
 if [ $ec -eq 0 ]; then
 	export COMMITHASH=$(git rev-parse --short HEAD)
-	echo INFO: Commmit hash is $COMMITHASH
+	echo INFO: Commit hash is $COMMITHASH
 	if [ -z $COMMITHASH ]; then
 		echo "ERROR: Failed to get commit hash. Are you sure this is a docker repository?"
 		ec=1

--- a/hack/integration-cli-on-swarm/host/enumerate.go
+++ b/hack/integration-cli-on-swarm/host/enumerate.go
@@ -24,7 +24,7 @@ func enumerateTestsForBytes(b []byte) ([]string, error) {
 	return tests, nil
 }
 
-// enumareteTests enumerates valid `-check.f` strings for all the test functions.
+// enumerateTests enumerates valid `-check.f` strings for all the test functions.
 // Note that we use regexp rather than parsing Go files for performance reason.
 // (Try `TESTFLAGS=-check.list make test-integration-cli` to see the slowness of parsing)
 // The files needs to be `gofmt`-ed

--- a/hack/integration-cli-on-swarm/host/host.go
+++ b/hack/integration-cli-on-swarm/host/host.go
@@ -36,10 +36,10 @@ func xmain() (int, error) {
 	// Should we use cobra maybe?
 	replicas := flag.Int("replicas", 1, "Number of worker service replica")
 	chunks := flag.Int("chunks", 0, "Number of test chunks executed in batch (0 == replicas)")
-	pushWorkerImage := flag.String("push-worker-image", "", "Push the worker image to the registry. Required for distribuetd execution. (empty == not to push)")
+	pushWorkerImage := flag.String("push-worker-image", "", "Push the worker image to the registry. Required for distributed execution. (empty == not to push)")
 	shuffle := flag.Bool("shuffle", false, "Shuffle the input so as to mitigate makespan nonuniformity")
 	// flags below are rarely used
-	randSeed := flag.Int64("rand-seed", int64(0), "Random seed used for shuffling (0 == curent time)")
+	randSeed := flag.Int64("rand-seed", int64(0), "Random seed used for shuffling (0 == current time)")
 	filtersFile := flag.String("filters-file", "", "Path to optional file composed of `-check.f` filter strings")
 	dryRun := flag.Bool("dry-run", false, "Dry run")
 	keepExecutor := flag.Bool("keep-executor", false, "Do not auto-remove executor containers, which is used for running privileged programs on Swarm")

--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -175,7 +175,7 @@ Function Execute-Build($type, $additionalBuildTags, $directory) {
     if ($Race)                      { Write-Warning "Using race detector"; $raceParm=" -race"}
     if ($ForceBuildAll)             { $allParm=" -a" }
     if ($NoOpt)                     { $optParm=" -gcflags "+""""+"-N -l"+"""" }
-    if ($addtionalBuildTags -ne "") { $buildTags += $(" " + $additionalBuildTags) }
+    if ($additionalBuildTags -ne "") { $buildTags += $(" " + $additionalBuildTags) }
 
     # Do the go build in the appropriate directory
     # Note -linkmode=internal is required to be able to debug on Windows.

--- a/hack/make/generate-index-listing
+++ b/hack/make/generate-index-listing
@@ -40,7 +40,7 @@ create_index() {
 	# change IFS locally within subshell so the for loop saves line correctly to L var
 	IFS=$'\n';
 
-	# pretty sweet, will mimick the normal apache output. skipping "index" and hidden files
+	# pretty sweet, will mimic the normal apache output. skipping "index" and hidden files
 	for L in $(find -L . -mount -depth -maxdepth 1 -type f ! -name 'index' ! -name '.*' -prune -printf "<a href=\"%f\">%f|@_@%Td-%Tb-%TY %Tk:%TM  @%f@\n"|sort|column -t -s '|' | sed 's,\([\ ]\+\)@_@,</a>\1,g');
 	do
 		# file

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -985,7 +985,7 @@ func (s *DockerSwarmSuite) TestSwarmRepeatedRootRotation(c *check.C) {
 		if cert != nil {
 			c.Assert(clusterTLSInfo.TrustRoot, checker.Equals, expectedCert)
 		}
-		// could take another second or two for the nodes to trust the new roots after the've all gotten
+		// could take another second or two for the nodes to trust the new roots after they've all gotten
 		// new TLS certificates
 		for j := 0; j < 18; j++ {
 			mInfo := m.GetNode(c, m.NodeID).Description.TLSInfo

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -1712,7 +1712,7 @@ func (s *DockerSuite) TestBuildEntrypoint(c *check.C) {
 }
 
 // #6445 ensure ONBUILD triggers aren't committed to grandchildren
-func (s *DockerSuite) TestBuildOnBuildLimitedInheritence(c *check.C) {
+func (s *DockerSuite) TestBuildOnBuildLimitedInheritance(c *check.C) {
 	buildImageSuccessfully(c, "testonbuildtrigger1", build.WithDockerfile(`
 		FROM busybox
 		RUN echo "GRANDPARENT"
@@ -3063,7 +3063,7 @@ func (s *DockerSuite) TestBuildFromGitWithContext(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestBuildFromGitwithF(c *check.C) {
+func (s *DockerSuite) TestBuildFromGitWithF(c *check.C) {
 	name := "testbuildfromgitwithf"
 	git := fakegit.New(c, "repo", map[string]string{
 		"myApp/myDockerfile": `FROM busybox
@@ -3225,7 +3225,7 @@ func (s *DockerSuite) TestBuildCmdJSONNoShDashC(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestBuildEntrypointCanBeOverridenByChild(c *check.C) {
+func (s *DockerSuite) TestBuildEntrypointCanBeOverriddenByChild(c *check.C) {
 	buildImageSuccessfully(c, "parent", build.WithDockerfile(`
     FROM busybox
     ENTRYPOINT exit 130
@@ -3245,7 +3245,7 @@ func (s *DockerSuite) TestBuildEntrypointCanBeOverridenByChild(c *check.C) {
 	})
 }
 
-func (s *DockerSuite) TestBuildEntrypointCanBeOverridenByChildInspect(c *check.C) {
+func (s *DockerSuite) TestBuildEntrypointCanBeOverriddenByChildInspect(c *check.C) {
 	var (
 		name     = "testbuildepinherit"
 		name2    = "testbuildepinherit2"
@@ -4472,26 +4472,26 @@ func (s *DockerSuite) TestBuildBuildTimeArgOverrideArgDefinedBeforeEnv(c *check.
 	imgName := "bldargtest"
 	envKey := "foo"
 	envVal := "bar"
-	envValOveride := "barOverride"
+	envValOverride := "barOverride"
 	dockerfile := fmt.Sprintf(`FROM busybox
 		ARG %s
 		ENV %s %s
 		RUN echo $%s
 		CMD echo $%s
-        `, envKey, envKey, envValOveride, envKey, envKey)
+        `, envKey, envKey, envValOverride, envKey, envKey)
 
 	result := buildImage(imgName,
 		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
 		build.WithDockerfile(dockerfile),
 	)
 	result.Assert(c, icmd.Success)
-	if strings.Count(result.Combined(), envValOveride) != 2 {
-		c.Fatalf("failed to access environment variable in output: %q expected: %q", result.Combined(), envValOveride)
+	if strings.Count(result.Combined(), envValOverride) != 2 {
+		c.Fatalf("failed to access environment variable in output: %q expected: %q", result.Combined(), envValOverride)
 	}
 
 	containerName := "bldargCont"
-	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); !strings.Contains(out, envValOveride) {
-		c.Fatalf("run produced invalid output: %q, expected %q", out, envValOveride)
+	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); !strings.Contains(out, envValOverride) {
+		c.Fatalf("run produced invalid output: %q, expected %q", out, envValOverride)
 	}
 }
 
@@ -4501,25 +4501,25 @@ func (s *DockerSuite) TestBuildBuildTimeArgOverrideEnvDefinedBeforeArg(c *check.
 	imgName := "bldargtest"
 	envKey := "foo"
 	envVal := "bar"
-	envValOveride := "barOverride"
+	envValOverride := "barOverride"
 	dockerfile := fmt.Sprintf(`FROM busybox
 		ENV %s %s
 		ARG %s
 		RUN echo $%s
 		CMD echo $%s
-        `, envKey, envValOveride, envKey, envKey, envKey)
+        `, envKey, envValOverride, envKey, envKey, envKey)
 	result := buildImage(imgName,
 		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
 		build.WithDockerfile(dockerfile),
 	)
 	result.Assert(c, icmd.Success)
-	if strings.Count(result.Combined(), envValOveride) != 2 {
-		c.Fatalf("failed to access environment variable in output: %q expected: %q", result.Combined(), envValOveride)
+	if strings.Count(result.Combined(), envValOverride) != 2 {
+		c.Fatalf("failed to access environment variable in output: %q expected: %q", result.Combined(), envValOverride)
 	}
 
 	containerName := "bldargCont"
-	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); !strings.Contains(out, envValOveride) {
-		c.Fatalf("run produced invalid output: %q, expected %q", out, envValOveride)
+	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); !strings.Contains(out, envValOverride) {
+		c.Fatalf("run produced invalid output: %q, expected %q", out, envValOverride)
 	}
 }
 
@@ -4616,25 +4616,25 @@ func (s *DockerSuite) TestBuildBuildTimeArgExpansionOverride(c *check.C) {
 	envKey := "foo"
 	envVal := "bar"
 	envKey1 := "foo1"
-	envValOveride := "barOverride"
+	envValOverride := "barOverride"
 	dockerfile := fmt.Sprintf(`FROM busybox
 		ARG %s
 		ENV %s %s
 		ENV %s ${%s}
 		RUN echo $%s
-		CMD echo $%s`, envKey, envKey, envValOveride, envKey1, envKey, envKey1, envKey1)
+		CMD echo $%s`, envKey, envKey, envValOverride, envKey1, envKey, envKey1, envKey1)
 	result := buildImage(imgName,
 		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
 		build.WithDockerfile(dockerfile),
 	)
 	result.Assert(c, icmd.Success)
-	if strings.Count(result.Combined(), envValOveride) != 2 {
-		c.Fatalf("failed to access environment variable in output: %q expected: %q", result.Combined(), envValOveride)
+	if strings.Count(result.Combined(), envValOverride) != 2 {
+		c.Fatalf("failed to access environment variable in output: %q expected: %q", result.Combined(), envValOverride)
 	}
 
 	containerName := "bldargCont"
-	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); !strings.Contains(out, envValOveride) {
-		c.Fatalf("run produced invalid output: %q, expected %q", out, envValOveride)
+	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); !strings.Contains(out, envValOverride) {
+		c.Fatalf("run produced invalid output: %q, expected %q", out, envValOverride)
 	}
 }
 
@@ -4690,24 +4690,24 @@ func (s *DockerSuite) TestBuildBuildTimeArgDefaultOverride(c *check.C) {
 	imgName := "bldargtest"
 	envKey := "foo"
 	envVal := "bar"
-	envValOveride := "barOverride"
+	envValOverride := "barOverride"
 	dockerfile := fmt.Sprintf(`FROM busybox
 		ARG %s=%s
 		ENV %s $%s
 		RUN echo $%s
 		CMD echo $%s`, envKey, envVal, envKey, envKey, envKey, envKey)
 	result := buildImage(imgName,
-		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envValOveride)),
+		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envValOverride)),
 		build.WithDockerfile(dockerfile),
 	)
 	result.Assert(c, icmd.Success)
-	if strings.Count(result.Combined(), envValOveride) != 1 {
-		c.Fatalf("failed to access environment variable in output: %q expected: %q", result.Combined(), envValOveride)
+	if strings.Count(result.Combined(), envValOverride) != 1 {
+		c.Fatalf("failed to access environment variable in output: %q expected: %q", result.Combined(), envValOverride)
 	}
 
 	containerName := "bldargCont"
-	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); !strings.Contains(out, envValOveride) {
-		c.Fatalf("run produced invalid output: %q, expected %q", out, envValOveride)
+	if out, _ := dockerCmd(c, "run", "--name", containerName, imgName); !strings.Contains(out, envValOverride) {
+		c.Fatalf("run produced invalid output: %q, expected %q", out, envValOverride)
 	}
 }
 
@@ -4824,7 +4824,7 @@ func (s *DockerSuite) TestBuildBuildTimeArgEmptyValVariants(c *check.C) {
 	buildImageSuccessfully(c, imgName, build.WithDockerfile(dockerfile))
 }
 
-func (s *DockerSuite) TestBuildBuildTimeArgDefintionWithNoEnvInjection(c *check.C) {
+func (s *DockerSuite) TestBuildBuildTimeArgDefinitionWithNoEnvInjection(c *check.C) {
 	imgName := "bldargtest"
 	envKey := "foo"
 	dockerfile := fmt.Sprintf(`FROM busybox
@@ -5785,7 +5785,7 @@ func (s *DockerSuite) TestBuildWithExtraHostInvalidFormat(c *check.C) {
 		buildFlag  string
 	}{
 		{"extra_host_missing_ip", dockerfile, "--add-host=foo"},
-		{"extra_host_missing_ip_with_delimeter", dockerfile, "--add-host=foo:"},
+		{"extra_host_missing_ip_with_delimiter", dockerfile, "--add-host=foo:"},
 		{"extra_host_missing_hostname", dockerfile, "--add-host=:127.0.0.1"},
 		{"extra_host_invalid_ipv4", dockerfile, "--add-host=foo:101.10.2"},
 		{"extra_host_invalid_ipv6", dockerfile, "--add-host=foo:2001::1::3F"},

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -54,9 +54,9 @@ func (s *DockerSuite) TestCommitPausedContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestCommitNewFile(c *check.C) {
-	dockerCmd(c, "run", "--name", "commiter", "busybox", "/bin/sh", "-c", "echo koye > /foo")
+	dockerCmd(c, "run", "--name", "committer", "busybox", "/bin/sh", "-c", "echo koye > /foo")
 
-	imageID, _ := dockerCmd(c, "commit", "commiter")
+	imageID, _ := dockerCmd(c, "commit", "committer")
 	imageID = strings.TrimSpace(imageID)
 
 	out, _ := dockerCmd(c, "run", imageID, "cat", "/foo")

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -965,7 +965,7 @@ func (s *DockerDaemonSuite) TestDaemonUlimitDefaults(c *check.C) {
 		c.Fatalf("expected `ulimit -n` to be `42`, got: %s", nofile)
 	}
 	if nproc != "2048" {
-		c.Fatalf("exepcted `ulimit -p` to be 2048, got: %s", nproc)
+		c.Fatalf("expected `ulimit -p` to be 2048, got: %s", nproc)
 	}
 
 	// Now restart daemon with a new default
@@ -987,7 +987,7 @@ func (s *DockerDaemonSuite) TestDaemonUlimitDefaults(c *check.C) {
 		c.Fatalf("expected `ulimit -n` to be `43`, got: %s", nofile)
 	}
 	if nproc != "2048" {
-		c.Fatalf("exepcted `ulimit -p` to be 2048, got: %s", nproc)
+		c.Fatalf("expected `ulimit -p` to be 2048, got: %s", nproc)
 	}
 }
 
@@ -1408,7 +1408,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithSocketAsVolume(c *check.C) {
 }
 
 // os.Kill should kill daemon ungracefully, leaving behind container mounts.
-// A subsequent daemon restart shoud clean up said mounts.
+// A subsequent daemon restart should clean up said mounts.
 func (s *DockerDaemonSuite) TestCleanupMountsAfterDaemonAndContainerKill(c *check.C) {
 	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
 		Experimental: testEnv.ExperimentalDaemon(),

--- a/integration-cli/docker_cli_external_graphdriver_unix_test.go
+++ b/integration-cli/docker_cli_external_graphdriver_unix_test.go
@@ -111,7 +111,7 @@ func (s *DockerExternalGraphdriverSuite) setUpPlugin(c *check.C, name string, ex
 	}
 
 	respond := func(w http.ResponseWriter, data interface{}) {
-		w.Header().Set("Content-Type", "appplication/vnd.docker.plugins.v1+json")
+		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
 		switch t := data.(type) {
 		case error:
 			fmt.Fprintln(w, fmt.Sprintf(`{"Err": %q}`, t.Error()))

--- a/integration-cli/docker_cli_login_test.go
+++ b/integration-cli/docker_cli_login_test.go
@@ -16,7 +16,7 @@ func (s *DockerSuite) TestLoginWithoutTTY(c *check.C) {
 
 	// run the command and block until it's done
 	err := cmd.Run()
-	c.Assert(err, checker.NotNil) //"Expected non nil err when loginning in & TTY not available"
+	c.Assert(err, checker.NotNil) //"Expected non nil err when logging in & TTY not available"
 }
 
 func (s *DockerRegistryAuthHtpasswdSuite) TestLoginToPrivateRegistry(c *check.C) {

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1151,7 +1151,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkHostModeUngracefulDaemonRestart(c 
 		out, err := s.d.Cmd("run", "-d", "--name", cName, "--net=host", "--restart=always", "busybox", "top")
 		c.Assert(err, checker.IsNil, check.Commentf(out))
 
-		// verfiy container has finished starting before killing daemon
+		// verify container has finished starting before killing daemon
 		err = s.d.WaitRun(cName)
 		c.Assert(err, checker.IsNil)
 	}

--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -475,6 +475,6 @@ func (s *DockerSuite) TestPluginMetricsCollector(c *check.C) {
 
 	b, err := ioutil.ReadAll(resp.Body)
 	c.Assert(err, checker.IsNil)
-	// check that a known metric is there... don't epect this metric to change over time.. probably safe
+	// check that a known metric is there... don't expect this metric to change over time.. probably safe
 	c.Assert(string(b), checker.Contains, "container_actions")
 }

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -746,7 +746,7 @@ func (s *DockerSuite) TestPsShowMounts(c *check.C) {
 	fields = strings.Fields(lines[1])
 	c.Assert(fields, checker.HasLen, 2)
 
-	annonymounsVolumeID := fields[1]
+	anonymousVolumeID := fields[1]
 
 	fields = strings.Fields(lines[2])
 	c.Assert(fields[1], checker.Equals, "ps-volume-test")
@@ -771,7 +771,7 @@ func (s *DockerSuite) TestPsShowMounts(c *check.C) {
 	c.Assert(lines, checker.HasLen, 2)
 
 	fields = strings.Fields(lines[0])
-	c.Assert(fields[1], checker.Equals, annonymounsVolumeID)
+	c.Assert(fields[1], checker.Equals, anonymousVolumeID)
 	fields = strings.Fields(lines[1])
 	c.Assert(fields[1], checker.Equals, "ps-volume-test")
 

--- a/integration-cli/docker_cli_service_logs_test.go
+++ b/integration-cli/docker_cli_service_logs_test.go
@@ -212,7 +212,7 @@ func (s *DockerSwarmSuite) TestServiceLogsTaskLogs(c *check.C) {
 		fmt.Sprintf("--replicas=%v", replicas),
 		// which has this the task id as an environment variable templated in
 		"--env", "TASK={{.Task.ID}}",
-		// and runs this command to print exaclty 6 logs lines
+		// and runs this command to print exactly 6 logs lines
 		"busybox", "sh", "-c", "for line in $(seq 0 5); do echo $TASK log test $line; done; sleep 100000",
 	))
 	result.Assert(c, icmd.Expected{})

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1887,7 +1887,7 @@ func (s *DockerSwarmSuite) TestNetworkInspectWithDuplicateNames(c *check.C) {
 	out, err = d.Cmd("network", "rm", n2.ID)
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 
-	// Dupliates with name but with different driver
+	// Duplicates with name but with different driver
 	networkCreateRequest.NetworkCreate.Driver = "overlay"
 
 	status, body, err = d.SockRequest("POST", "/networks/create", networkCreateRequest)

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -34,7 +34,7 @@ func (s *DockerSuite) TestVolumeCLICreate(c *check.C) {
 
 func (s *DockerSuite) TestVolumeCLIInspect(c *check.C) {
 	c.Assert(
-		exec.Command(dockerBinary, "volume", "inspect", "doesntexist").Run(),
+		exec.Command(dockerBinary, "volume", "inspect", "doesnotexist").Run(),
 		check.Not(check.IsNil),
 		check.Commentf("volume inspect should error on non-existent volume"),
 	)
@@ -54,10 +54,10 @@ func (s *DockerSuite) TestVolumeCLIInspectMulti(c *check.C) {
 	dockerCmd(c, "volume", "create", "test2")
 	dockerCmd(c, "volume", "create", "test3")
 
-	result := dockerCmdWithResult("volume", "inspect", "--format={{ .Name }}", "test1", "test2", "doesntexist", "test3")
+	result := dockerCmdWithResult("volume", "inspect", "--format={{ .Name }}", "test1", "test2", "doesnotexist", "test3")
 	c.Assert(result, icmd.Matches, icmd.Expected{
 		ExitCode: 1,
-		Err:      "No such volume: doesntexist",
+		Err:      "No such volume: doesnotexist",
 	})
 
 	out := result.Stdout()
@@ -185,7 +185,7 @@ func (s *DockerSuite) TestVolumeCLILsFilterDangling(c *check.C) {
 
 	out, _ = dockerCmd(c, "volume", "ls", "--filter", "name=testisin")
 	c.Assert(out, check.Not(checker.Contains), "testnotinuse1\n", check.Commentf("expected volume 'testnotinuse1' in output"))
-	c.Assert(out, checker.Contains, "testisinuse1\n", check.Commentf("execpeted volume 'testisinuse1' in output"))
+	c.Assert(out, checker.Contains, "testisinuse1\n", check.Commentf("expected volume 'testisinuse1' in output"))
 	c.Assert(out, checker.Contains, "testisinuse2\n", check.Commentf("expected volume 'testisinuse2' in output"))
 }
 
@@ -234,7 +234,7 @@ func (s *DockerSuite) TestVolumeCLIRm(c *check.C) {
 
 	dockerCmd(c, "volume", "rm", volumeID)
 	c.Assert(
-		exec.Command("volume", "rm", "doesntexist").Run(),
+		exec.Command("volume", "rm", "doesnotexist").Run(),
 		check.Not(check.IsNil),
 		check.Commentf("volume rm should fail with non-existent volume"),
 	)

--- a/integration-cli/docker_experimental_network_test.go
+++ b/integration-cli/docker_experimental_network_test.go
@@ -155,7 +155,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkMacvlanMultiSubnet(c *check.C) {
 	_, _, err := dockerCmdWithError("exec", "second", "ping", "-c", "1", strings.TrimSpace(ip))
 	c.Assert(err, check.IsNil)
 	// verify ipv6 connectivity to the explicit --ipv6 address second to first
-	c.Skip("Temporarily skipping while invesitigating sporadic v6 CI issues")
+	c.Skip("Temporarily skipping while investigating sporadic v6 CI issues")
 	_, _, err = dockerCmdWithError("exec", "second", "ping6", "-c", "1", strings.TrimSpace(ip6))
 	c.Assert(err, check.IsNil)
 

--- a/opts/ip.go
+++ b/opts/ip.go
@@ -22,7 +22,7 @@ func NewIPOpt(ref *net.IP, defaultVal string) *IPOpt {
 }
 
 // Set sets an IPv4 or IPv6 address from a given string. If the given
-// string is not parseable as an IP address it returns an error.
+// string is not parsable as an IP address it returns an error.
 func (o *IPOpt) Set(val string) error {
 	ip := net.ParseIP(val)
 	if ip == nil {

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -157,7 +157,7 @@ func TestValidateDNSSearch(t *testing.T) {
 		`foo.bar-.baz`,
 		`foo.-bar`,
 		`foo.-bar.baz`,
-		`foo.bar.baz.this.should.fail.on.long.name.beause.it.is.longer.thanisshouldbethis.should.fail.on.long.name.beause.it.is.longer.thanisshouldbethis.should.fail.on.long.name.beause.it.is.longer.thanisshouldbethis.should.fail.on.long.name.beause.it.is.longer.thanisshouldbe`,
+		`foo.bar.baz.this.should.fail.on.long.name.because.it.is.longer.thanitshouldbethis.should.fail.on.long.name.because.it.is.longer.thanitshouldbethis.should.fail.on.long.name.because.it.is.longer.thanitshouldbethis.should.fail.on.long.name.because.it.is.longer.thanitshouldbe`,
 	}
 
 	for _, domain := range valid {

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -180,7 +180,7 @@ func DecompressStream(archive io.Reader) (io.ReadCloser, error) {
 	}
 }
 
-// CompressStream compresseses the dest with specified compression algorithm.
+// CompressStream compresses the dest with specified compression algorithm.
 func CompressStream(dest io.Writer, compression Compression) (io.WriteCloser, error) {
 	p := pools.BufioWriter32KPool
 	buf := p.Get(dest)

--- a/pkg/archive/changes_test.go
+++ b/pkg/archive/changes_test.go
@@ -102,10 +102,10 @@ func createSampleDir(t *testing.T, root string) {
 }
 
 func TestChangeString(t *testing.T) {
-	modifiyChange := Change{"change", ChangeModify}
-	toString := modifiyChange.String()
+	modifyChange := Change{"change", ChangeModify}
+	toString := modifyChange.String()
 	if toString != "C change" {
-		t.Fatalf("String() of a change with ChangeModifiy Kind should have been %s but was %s", "C change", toString)
+		t.Fatalf("String() of a change with ChangeModify Kind should have been %s but was %s", "C change", toString)
 	}
 	addChange := Change{"change", ChangeAdd}
 	toString = addChange.String()

--- a/pkg/authorization/authz_unix_test.go
+++ b/pkg/authorization/authz_unix_test.go
@@ -99,7 +99,7 @@ func TestAuthZResponsePlugin(t *testing.T) {
 
 	request := Request{
 		User:        "user",
-		RequestURI:  "someting.com/auth",
+		RequestURI:  "something.com/auth",
 		RequestBody: []byte("sample body"),
 	}
 	server.replayResponse = Response{

--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -373,7 +373,7 @@ func RemoveDeviceDeferred(name string) error {
 	// semaphores created in `task.setCookie` will be cleaned up in `UdevWait`.
 	// So these two function call must come in pairs, otherwise semaphores will
 	// be leaked, and the  limit of number of semaphores defined in `/proc/sys/kernel/sem`
-	// will be reached, which will eventually make all follwing calls to 'task.SetCookie'
+	// will be reached, which will eventually make all following calls to 'task.SetCookie'
 	// fail.
 	// this call will not wait for the deferred removal's final executing, since no
 	// udev event will be generated, and the semaphore's value will not be incremented

--- a/pkg/filenotify/fsnotify.go
+++ b/pkg/filenotify/fsnotify.go
@@ -2,7 +2,7 @@ package filenotify
 
 import "github.com/fsnotify/fsnotify"
 
-// fsNotifyWatcher wraps the fsnotify package to satisfy the FileNotifer interface
+// fsNotifyWatcher wraps the fsnotify package to satisfy the FileNotifier interface
 type fsNotifyWatcher struct {
 	*fsnotify.Watcher
 }

--- a/pkg/plugins/pluginrpc-gen/parser_test.go
+++ b/pkg/plugins/pluginrpc-gen/parser_test.go
@@ -136,7 +136,7 @@ func TestParseWithMultipleFuncs(t *testing.T) {
 	}
 }
 
-func TestParseWithUnamedReturn(t *testing.T) {
+func TestParseWithUnnamedReturn(t *testing.T) {
 	_, err := Parse(testFixture, "Fooer4")
 	if !strings.HasSuffix(err.Error(), errBadReturn.Error()) {
 		t.Fatalf("expected ErrBadReturn, got %v", err)

--- a/pkg/registrar/registrar_test.go
+++ b/pkg/registrar/registrar_test.go
@@ -60,7 +60,7 @@ func TestGetNames(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(names, names2) {
-		t.Fatalf("Exepected: %v, Got: %v", names, names2)
+		t.Fatalf("Expected: %v, Got: %v", names, names2)
 	}
 }
 

--- a/pkg/stdcopy/stdcopy_test.go
+++ b/pkg/stdcopy/stdcopy_test.go
@@ -16,7 +16,7 @@ func TestNewStdWriter(t *testing.T) {
 	}
 }
 
-func TestWriteWithUnitializedStdWriter(t *testing.T) {
+func TestWriteWithUninitializedStdWriter(t *testing.T) {
 	writer := stdWriter{
 		Writer: nil,
 		prefix: byte(Stdout),

--- a/pkg/symlink/fs.go
+++ b/pkg/symlink/fs.go
@@ -40,7 +40,7 @@ func FollowSymlinkInScope(path, root string) (string, error) {
 //
 // Example:
 //   If /foo/bar -> /outside,
-//   FollowSymlinkInScope("/foo/bar", "/foo") == "/foo/outside" instead of "/oustide"
+//   FollowSymlinkInScope("/foo/bar", "/foo") == "/foo/outside" instead of "/outside"
 //
 // IMPORTANT: it is the caller's responsibility to call evalSymlinksInScope *after* relevant symlinks
 // are created and not to create subsequently, additional symlinks that could potentially make a

--- a/pkg/system/path_windows.go
+++ b/pkg/system/path_windows.go
@@ -12,7 +12,7 @@ import (
 // This is used, for example, when validating a user provided path in docker cp.
 // If a drive letter is supplied, it must be the system drive. The drive letter
 // is always removed. Also, it translates it to OS semantics (IOW / to \). We
-// need the path in this syntax so that it can ultimately be contatenated with
+// need the path in this syntax so that it can ultimately be concatenated with
 // a Windows long-path which doesn't support drive-letters. Examples:
 // C:			--> Fail
 // C:\			--> \

--- a/pkg/system/rm.go
+++ b/pkg/system/rm.go
@@ -20,7 +20,7 @@ import (
 // These types of errors do not need to be returned since it's ok for the dir to
 // be gone we can just retry the remove operation.
 //
-// This should not return a `os.ErrNotExist` kind of error under any cirucmstances
+// This should not return a `os.ErrNotExist` kind of error under any circumstances
 func EnsureRemoveAll(dir string) error {
 	notExistErr := make(map[string]bool)
 

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -30,7 +30,7 @@ var basicFunctions = template.FuncMap{
 // HeaderFunctions are used to created headers of a table.
 // This is a replacement of basicFunctions for header generation
 // because we want the header to remain intact.
-// Some functions like `split` are irrevelant so not added.
+// Some functions like `split` are irrelevant so not added.
 var HeaderFunctions = template.FuncMap{
 	"json": func(v string) string {
 		return v

--- a/pkg/testutil/cmd/command.go
+++ b/pkg/testutil/cmd/command.go
@@ -53,7 +53,7 @@ type Result struct {
 }
 
 // Assert compares the Result against the Expected struct, and fails the test if
-// any of the expcetations are not met.
+// any of the expectations are not met.
 func (r *Result) Assert(t testingT, exp Expected) *Result {
 	err := r.Compare(exp)
 	if err == nil {

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -271,7 +271,7 @@ func (pm *Manager) save(p *v2.Plugin) error {
 	return nil
 }
 
-// GC cleans up unrefrenced blobs. This is recommended to run in a goroutine
+// GC cleans up unreferenced blobs. This is recommended to run in a goroutine
 func (pm *Manager) GC() {
 	pm.muGC.Lock()
 	defer pm.muGC.Unlock()

--- a/plugin/v2/settable_test.go
+++ b/plugin/v2/settable_test.go
@@ -68,7 +68,7 @@ func TestIsSettable(t *testing.T) {
 	}
 }
 
-func TestUpdateSettinsEnv(t *testing.T) {
+func TestUpdateSettingsEnv(t *testing.T) {
 	contexts := []struct {
 		env    []string
 		set    settable

--- a/reference/store.go
+++ b/reference/store.go
@@ -221,7 +221,7 @@ func (store *store) Delete(ref reference.Named) (bool, error) {
 func (store *store) Get(ref reference.Named) (digest.Digest, error) {
 	if canonical, ok := ref.(reference.Canonical); ok {
 		// If reference contains both tag and digest, only
-		// lookup by digest as it takes precendent over
+		// lookup by digest as it takes precedence over
 		// tag, until tag/digest combos are stored.
 		if _, ok := ref.(reference.Tagged); ok {
 			var err error

--- a/registry/config.go
+++ b/registry/config.go
@@ -252,7 +252,7 @@ skip:
 	return nil
 }
 
-// allowNondistributableArtifacts returns true if the provided hostname is part of the list of regsitries
+// allowNondistributableArtifacts returns true if the provided hostname is part of the list of registries
 // that allow push of nondistributable artifacts.
 //
 // The list can contain elements with CIDR notation to specify a whole subnet. If the subnet contains an IP

--- a/registry/endpoint_v1.go
+++ b/registry/endpoint_v1.go
@@ -175,7 +175,7 @@ func (e *V1Endpoint) Ping() (PingResult, error) {
 		Standalone: true,
 	}
 	if err := json.Unmarshal(jsonString, &info); err != nil {
-		logrus.Debugf("Error unmarshalling the _ping PingResult: %s", err)
+		logrus.Debugf("Error unmarshaling the _ping PingResult: %s", err)
 		// don't stop here. Just assume sane defaults
 	}
 	if hdr := resp.Header.Get("X-Docker-Registry-Version"); hdr != "" {

--- a/reports/2017-05-08.md
+++ b/reports/2017-05-08.md
@@ -9,7 +9,7 @@ During this meeting, we are talking about the [tasks](https://github.com/moby/mo
 
 ### The CLI split
 
-The Docker CLI was succesfully moved to [https://github.com/docker/cli](https://github.com/docker/cli) last week thanks to @tiborvass
+The Docker CLI was successfully moved to [https://github.com/docker/cli](https://github.com/docker/cli) last week thanks to @tiborvass
 The Docker CLI is now compiled from the [Dockerfile](https://github.com/moby/moby/blob/a762ceace4e8c1c7ce4fb582789af9d8074be3e1/Dockerfile#L248)
 
 ### Mailing list

--- a/reports/2017-05-15.md
+++ b/reports/2017-05-15.md
@@ -27,7 +27,7 @@ breaking up / removing existing packages that likely are not good candidates to 
 
 With the removal of the CLI from the moby repository, new pull requests will have to be tested using API tests instead
 of using the CLI. Discussion took place whether or not these tests should use the API `client` package, or be completely
-independend, and make raw HTTP calls.
+independent, and make raw HTTP calls.
 
 A topic was created on the forum to discuss options: [evolution of testing](https://forums.mobyproject.org/t/evolution-of-testing-moby/38)
 

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -102,7 +102,7 @@ func (a *volumeDriverAdapter) getCapabilities() volume.Capability {
 	if err != nil {
 		// `GetCapabilities` is a not a required endpoint.
 		// On error assume it's a local-only driver
-		logrus.Warnf("Volume driver %s returned an error while trying to query its capabilities, using default capabilties: %v", a.name, err)
+		logrus.Warnf("Volume driver %s returned an error while trying to query its capabilities, using default capabilities: %v", a.name, err)
 		return volume.Capability{Scope: volume.LocalScope}
 	}
 

--- a/volume/testutils/testutils.go
+++ b/volume/testutils/testutils.go
@@ -25,7 +25,7 @@ func (NoopVolume) Mount(_ string) (string, error) { return "noop", nil }
 // Unmount unmounts the volume from the container
 func (NoopVolume) Unmount(_ string) error { return nil }
 
-// Status proivdes low-level details about the volume
+// Status provides low-level details about the volume
 func (NoopVolume) Status() map[string]interface{} { return nil }
 
 // CreatedAt provides the time the volume (directory) was created at
@@ -57,7 +57,7 @@ func (FakeVolume) Mount(_ string) (string, error) { return "fake", nil }
 // Unmount unmounts the volume from the container
 func (FakeVolume) Unmount(_ string) error { return nil }
 
-// Status proivdes low-level details about the volume
+// Status provides low-level details about the volume
 func (FakeVolume) Status() map[string]interface{} { return nil }
 
 // CreatedAt provides the time the volume (directory) was created at

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -125,7 +125,7 @@ type MountPoint struct {
 	Spec mounttypes.Mount
 
 	// Track usage of this mountpoint
-	// Specicially needed for containers which are running and calls to `docker cp`
+	// Specifically needed for containers which are running and calls to `docker cp`
 	// because both these actions require mounting the volumes.
 	active int
 }

--- a/volume/volume_linux.go
+++ b/volume/volume_linux.go
@@ -26,7 +26,7 @@ func ConvertTmpfsOptions(opt *mounttypes.TmpfsOptions, readOnly bool) (string, e
 		// okay, since API is that way anyways.
 
 		// we do this by finding the suffix that divides evenly into the
-		// value, returing the value itself, with no suffix, if it fails.
+		// value, returning the value itself, with no suffix, if it fails.
 		//
 		// For the most part, we don't enforce any semantic to this values.
 		// The operating system will usually align this and enforce minimum


### PR DESCRIPTION
I'm going to actively ignore your submission guidelines.
As a general rule, whenever I submit large changesets to large projects, people insist on changes. As such, there's no point in me signing a submission at this time.
The current summary of each changeset represents a distinct word family misspelling. Sometimes projects have a preferred language family (en-US/en-GB being the most common), as such it's handy to be able to easily drop changesets. It's also not uncommon for some changes to need to be split out into special PRs (e.g. if they would constitute an API change).

**- What I did**
I spellchecked the docker/docker repository (and then dealt with the fact that it became moby/moby)

**- How I did it**
I used my own personal tool to generate a list of tokens not found in `/usr/share/dict/words` -- I then manually consider each remaining token. Typically I'll let Google Suggest suggest replacement words.

**- How to verify it**
Review the diff.

**- Description for the changelog**
86 word families
85 files changed, 148 insertions(+), 148 deletions(-)


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://cloud.githubusercontent.com/assets/2119212/26288409/c30602da-3e5f-11e7-87e4-f571c5de29a4.png)
