### PR TITLE
Add ReferenceCount for Image to solve image operation competition

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -85,6 +85,10 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig, managed bool) (
 			return nil, errors.New("Platform on which parent image was created is not Solaris")
 		}
 		imgID = img.ID()
+		if err := daemon.HoldOnImageByID(string(imgID)); err != nil {
+			return nil, err
+		}
+		defer daemon.HoldOffImageByID(string(imgID))
 	}
 
 	if err := daemon.mergeAndVerifyConfig(params.Config, img); err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -974,6 +974,16 @@ func (daemon *Daemon) GetRemappedUIDGID() (int, int) {
 	return uid, gid
 }
 
+// HoldOnImageByID will increase the image reference count
+func (daemon *Daemon) HoldOnImageByID(id string) error {
+	return daemon.imageStore.HoldOn(image.ID(id))
+}
+
+// HoldOffImageByID will decrease the image reference count
+func (daemon *Daemon) HoldOffImageByID(id string) error {
+	return daemon.imageStore.HoldOff(image.ID(id))
+}
+
 // prepareTempDir prepares and returns the default directory to use
 // for temporary files.
 // If it doesn't exist, it is created. If it exists, its content is removed.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixed issue: 
  1.  https://github.com/moby/moby/issues/29653
        Not using the solution in https://github.com/moby/moby/pull/32293
  2.  protect build image & rmi operation competition.
  3. protect push & rmi operation competition. (like saving operation).
  4. protect create container & rmi competition.

**- What I did**
Fix image operation competition.
Just lots of issues mentioned, image operation need to pretect. especially build, save, push & rmi operations.

**- How I did it**

Add an `ReferenceCount` for each image, when we need to protect our image, we just use
```
  imageStore.HoldOn(imageID)   // increase  the refcount of the image.
  ... do something ....
  imageStore.HoldOff(imageID)  // decrease the refcount.
```

**- How to verify it**
1.  Saving image follow  https://github.com/moby/moby/issues/29653
2.  write a script for example create container & rmi operation:
    the container may not be startup.
```
#!/bin/bash
docker run -d ubuntu sleep 2000 &
docker rmi ubuntu
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Signed-off-by: Wentao Zhang <zhangwentao234@huawei.com>

**- A picture of a cute animal (not mandatory but encouraged)**

