### PR TITLE
Do not clear swarm directory on `swarm init` and `swarm join`

### DIFF
--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -88,10 +88,6 @@ func (c *Cluster) Init(req types.InitRequest) (string, error) {
 		}
 	}
 
-	if !req.ForceNewCluster {
-		clearPersistentState(c.root)
-	}
-
 	nr, err := c.newNodeRunner(nodeStartConfig{
 		forceNewCluster: req.ForceNewCluster,
 		autolock:        req.AutoLockManagers,
@@ -109,15 +105,13 @@ func (c *Cluster) Init(req types.InitRequest) (string, error) {
 	c.mu.Unlock()
 
 	if err := <-nr.Ready(); err != nil {
+		c.mu.Lock()
+		c.nr = nil
+		c.mu.Unlock()
 		if !req.ForceNewCluster { // if failure on first attempt don't keep state
 			if err := clearPersistentState(c.root); err != nil {
 				return "", err
 			}
-		}
-		if err != nil {
-			c.mu.Lock()
-			c.nr = nil
-			c.mu.Unlock()
 		}
 		return "", err
 	}
@@ -166,8 +160,6 @@ func (c *Cluster) Join(req types.JoinRequest) error {
 		return err
 	}
 
-	clearPersistentState(c.root)
-
 	nr, err := c.newNodeRunner(nodeStartConfig{
 		RemoteAddr:    req.RemoteAddrs[0],
 		ListenAddr:    net.JoinHostPort(listenHost, listenPort),
@@ -193,6 +185,9 @@ func (c *Cluster) Join(req types.JoinRequest) error {
 			c.mu.Lock()
 			c.nr = nil
 			c.mu.Unlock()
+			if err := clearPersistentState(c.root); err != nil {
+				return err
+			}
 		}
 		return err
 	}


### PR DESCRIPTION
However, this [continues to clear the directory if init fails](https://github.com/moby/moby/compare/master...cyli:do-not-clear-state-on-swarm-init-join?expand=1#diff-12d2a05186062a2b8f2fb8c09adac4a1L112), because we don't want to leave it in a half-finished state.

This would fix https://github.com/moby/moby/issues/33216 to be compatible with the method for pre-generating external CA certs that was in 17.03.

After some discussion with @aaronlehmann and @tonistiigi, this is probably the correct behavior (unless the state dir can get corrupted?) either way.

This would also allow the extra flags as suggested in https://github.com/moby/moby/issues/33216 to be added after 17.06 if necessary.