### PR TITLE
Fix `request.SockRequestRaw` error check

### DIFF
--- a/integration-cli/request/request.go
+++ b/integration-cli/request/request.go
@@ -217,13 +217,14 @@ func SockRequestRaw(method, endpoint string, data io.Reader, ct, daemon string, 
 	}
 
 	resp, err := client.Do(req)
+	if err != nil {
+		client.Close()
+		return resp, nil, err
+	}
 	body := ioutils.NewReadCloserWrapper(resp.Body, func() error {
 		defer resp.Body.Close()
 		return client.Close()
 	})
-	if err != nil {
-		client.Close()
-	}
 
 	return resp, body, err
 }


### PR DESCRIPTION
We should check for error before reading the response (response can be
nil, and thus this would panic)

🦁

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
