### PR TITLE
Windows: Remove unused SandboxPath

### DIFF
--- a/daemon/start_windows.go
+++ b/daemon/start_windows.go
@@ -45,10 +45,6 @@ func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Contain
 	if err != nil {
 		return nil, fmt.Errorf("failed to get layer metadata - %s", err)
 	}
-	if hvOpts.IsHyperV {
-		hvOpts.SandboxPath = filepath.Dir(m["dir"])
-	}
-
 	layerOpts.LayerFolderPath = m["dir"]
 
 	// Generate the layer paths of the layer options

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -49,7 +49,6 @@ const defaultOwner = "docker"
 // | VolumePath      | \\?\\Volume{GUIDa}                         |                                                   |
 // | LayerFolderPath | %root%\windowsfilter\containerID           | %root%\windowsfilter\containerID (servicing only) |
 // | Layers[]        | ID=GUIDb;Path=%root%\windowsfilter\layerID | ID=GUIDb;Path=%root%\windowsfilter\layerID        |
-// | SandboxPath     |                                            | %root%\windowsfilter                              |
 // | HvRuntime       |                                            | ImagePath=%root%\BaseLayerID\UtilityVM            |
 // +-----------------+--------------------------------------------+---------------------------------------------------+
 //
@@ -88,7 +87,6 @@ const defaultOwner = "docker"
 //	}],
 //	"HostName": "475c2c58933b",
 //	"MappedDirectories": [],
-//	"SandboxPath": "C:\\\\control\\\\windowsfilter",
 //	"HvPartition": true,
 //	"EndpointList": ["e1bb1e61-d56f-405e-b75d-fd520cefa0cb"],
 //	"DNSSearchList": "a.com,b.com,c.com",
@@ -159,7 +157,6 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 		}
 		if h, ok := option.(*HyperVIsolationOption); ok {
 			configuration.HvPartition = h.IsHyperV
-			configuration.SandboxPath = h.SandboxPath
 			continue
 		}
 		if l, ok := option.(*LayerOption); ok {

--- a/libcontainerd/types_windows.go
+++ b/libcontainerd/types_windows.go
@@ -39,10 +39,9 @@ type FlushOption struct {
 }
 
 // HyperVIsolationOption is a CreateOption that indicates whether the runtime
-// should start the container as a Hyper-V container, and if so, the sandbox path.
+// should start the container as a Hyper-V container.
 type HyperVIsolationOption struct {
-	IsHyperV    bool
-	SandboxPath string `json:",omitempty"`
+	IsHyperV bool
 }
 
 // LayerOption is a CreateOption that indicates to the runtime the layer folder


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Removes passing the unused (TP5 hang-over, pre RTM) sandboxpath into HCS as HCS calculates it as long as the layerfolderpath is set, which it always is. Associated with https://github.com/opencontainers/runtime-spec/pull/849

@johnstep @swernli @darrenstahlmsft PTAL.