### PR TITLE
[17.03.3] Bump go version to 1.7.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,7 @@ RUN set -x \
 # IMPORTANT: If the version of Go is updated, the Windows to Linux CI machines
 #            will need updating, to avoid errors. Ping #docker-maintainers on IRC
 #            with a heads-up.
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
 	| tar -xzC /usr/local
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -97,7 +97,7 @@ RUN set -x \
 # so we use gccgo as bootstrap to build Go from source code.
 # We don't use the official ARMv6 released binaries as a GOROOT_BOOTSTRAP, because
 # not all ARM64 platforms support 32-bit mode. 32-bit mode is optional for ARMv8.
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN mkdir /usr/src/go && curl -fsSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/src/go -xz --strip-components=1 \
 	&& cd /usr/src/go/src \
 	&& GOOS=linux GOARCH=arm64 GOROOT_BOOTSTRAP="$(go env GOROOT)" ./make.bash

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -72,7 +72,7 @@ RUN cd /usr/local/lvm2 \
 # See https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
 # Install Go
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" \
 	| tar -xzC /usr/local
 ENV PATH /go/bin:/usr/local/go/bin:$PATH

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -95,7 +95,7 @@ RUN set -x \
 
 # Install Go
 # NOTE: official ppc64le go binaries weren't available until go 1.6.4 and 1.7.4
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" \
 	| tar -xzC /usr/local
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -97,7 +97,7 @@ RUN cd /usr/local/lvm2 \
 	&& make install_device-mapper
 # See https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" \
 	| tar -xzC /usr/local
 

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -55,7 +55,7 @@ RUN set -x \
 # IMPORTANT: If the version of Go is updated, the Windows to Linux CI machines
 #            will need updating, to avoid errors. Ping #docker-maintainers on IRC
 #            with a heads-up.
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
 	| tar -xzC /usr/local
 ENV PATH /go/bin:/usr/local/go/bin:$PATH

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -165,7 +165,7 @@ SHELL ["powershell", "-command"]
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
-ENV GO_VERSION=1.7.5 `
+ENV GO_VERSION=1.7.6 `
     GIT_VERSION=2.11.0 `
     GOPATH=C:\go `
     FROM_DOCKERFILE=1

--- a/contrib/builder/deb/aarch64/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/aarch64/ubuntu-trusty/Dockerfile
@@ -11,7 +11,7 @@ RUN update-alternatives --install /usr/bin/go go /usr/lib/go-1.6/bin/go 100
 # Install Go
 # aarch64 doesn't have official go binaries, so use the version of go installed from
 # the image to build go from source.
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN mkdir /usr/src/go && curl -fsSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/src/go -xz --strip-components=1 \
 	&& cd /usr/src/go/src \
 	&& GOOS=linux GOARCH=arm64 GOROOT_BOOTSTRAP="$(go env GOROOT)" ./make.bash

--- a/contrib/builder/deb/aarch64/ubuntu-xenial/Dockerfile
+++ b/contrib/builder/deb/aarch64/ubuntu-xenial/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools bu
 # Install Go
 # aarch64 doesn't have official go binaries, so use the version of go installed from
 # the image to build go from source.
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN mkdir /usr/src/go && curl -fsSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/src/go -xz --strip-components=1 \
 	&& cd /usr/src/go/src \
 	&& GOOS=linux GOARCH=arm64 GOROOT_BOOTSTRAP="$(go env GOROOT)" ./make.bash

--- a/contrib/builder/deb/amd64/debian-jessie/Dockerfile
+++ b/contrib/builder/deb/amd64/debian-jessie/Dockerfile
@@ -10,7 +10,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/amd64/debian-stretch/Dockerfile
+++ b/contrib/builder/deb/amd64/debian-stretch/Dockerfile
@@ -10,7 +10,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev libsqlite3-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/amd64/debian-wheezy/Dockerfile
+++ b/contrib/builder/deb/amd64/debian-wheezy/Dockerfile
@@ -12,7 +12,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list.d
 RUN apt-get update && apt-get install -y -t wheezy-backports btrfs-tools --no-install-recommends && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install -y apparmor bash-completion  build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config vim-common --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/amd64/ubuntu-precise/Dockerfile
+++ b/contrib/builder/deb/amd64/ubuntu-precise/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:precise
 
 RUN apt-get update && apt-get install -y apparmor bash-completion  build-essential cmake curl ca-certificates debhelper dh-apparmor  git libapparmor-dev  libltdl-dev  libsqlite3-dev pkg-config vim-common --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/amd64/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/amd64/ubuntu-trusty/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:trusty
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/amd64/ubuntu-xenial/Dockerfile
+++ b/contrib/builder/deb/amd64/ubuntu-xenial/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev libsqlite3-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/amd64/ubuntu-yakkety/Dockerfile
+++ b/contrib/builder/deb/amd64/ubuntu-yakkety/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:yakkety
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev libsqlite3-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/armhf/debian-jessie/Dockerfile
+++ b/contrib/builder/deb/armhf/debian-jessie/Dockerfile
@@ -10,7 +10,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/armhf/raspbian-jessie/Dockerfile
+++ b/contrib/builder/deb/armhf/raspbian-jessie/Dockerfile
@@ -10,7 +10,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 # GOARM is the ARM architecture version which is unrelated to the above Golang version
 ENV GOARM 6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/deb/armhf/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/armhf/ubuntu-trusty/Dockerfile
@@ -6,7 +6,7 @@ FROM armhf/ubuntu:trusty
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/armhf/ubuntu-xenial/Dockerfile
+++ b/contrib/builder/deb/armhf/ubuntu-xenial/Dockerfile
@@ -6,7 +6,7 @@ FROM armhf/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev libsqlite3-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/armhf/ubuntu-yakkety/Dockerfile
+++ b/contrib/builder/deb/armhf/ubuntu-yakkety/Dockerfile
@@ -6,7 +6,7 @@ FROM armhf/ubuntu:yakkety
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev libsqlite3-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/ppc64le/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/ppc64le/ubuntu-trusty/Dockerfile
@@ -6,7 +6,7 @@ FROM ppc64le/ubuntu:trusty
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/ppc64le/ubuntu-xenial/Dockerfile
+++ b/contrib/builder/deb/ppc64le/ubuntu-xenial/Dockerfile
@@ -6,7 +6,7 @@ FROM ppc64le/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config vim-common libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/ppc64le/ubuntu-yakkety/Dockerfile
+++ b/contrib/builder/deb/ppc64le/ubuntu-yakkety/Dockerfile
@@ -6,7 +6,7 @@ FROM ppc64le/ubuntu:yakkety
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config vim-common libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/s390x/ubuntu-xenial/Dockerfile
+++ b/contrib/builder/deb/s390x/ubuntu-xenial/Dockerfile
@@ -6,7 +6,7 @@ FROM s390x/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev libsqlite3-dev pkg-config libsystemd-dev vim-common --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/amd64/centos-7/Dockerfile
+++ b/contrib/builder/rpm/amd64/centos-7/Dockerfile
@@ -8,7 +8,7 @@ RUN yum groupinstall -y "Development Tools"
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
 RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/amd64/fedora-24/Dockerfile
+++ b/contrib/builder/rpm/amd64/fedora-24/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/amd64/fedora-25/Dockerfile
+++ b/contrib/builder/rpm/amd64/fedora-25/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/amd64/opensuse-13.2/Dockerfile
+++ b/contrib/builder/rpm/amd64/opensuse-13.2/Dockerfile
@@ -7,7 +7,7 @@ FROM opensuse:13.2
 RUN zypper --non-interactive install ca-certificates* curl gzip rpm-build
 RUN zypper --non-interactive install libbtrfs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel pkg-config selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim systemd-rpm-macros
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/amd64/oraclelinux-6/Dockerfile
+++ b/contrib/builder/rpm/amd64/oraclelinux-6/Dockerfile
@@ -10,7 +10,7 @@ RUN yum install -y kernel-uek-devel-4.1.12-32.el6uek
 RUN yum groupinstall -y "Development Tools"
 RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel  tar git cmake vim-common
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/amd64/oraclelinux-7/Dockerfile
+++ b/contrib/builder/rpm/amd64/oraclelinux-7/Dockerfile
@@ -7,7 +7,7 @@ FROM oraclelinux:7
 RUN yum groupinstall -y "Development Tools"
 RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/amd64/photon-1.0/Dockerfile
+++ b/contrib/builder/rpm/amd64/photon-1.0/Dockerfile
@@ -7,7 +7,7 @@ FROM photon:1.0
 RUN tdnf install -y wget curl ca-certificates gzip make rpm-build sed gcc linux-api-headers glibc-devel binutils libseccomp libltdl-devel elfutils
 RUN tdnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkg-config selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/man/Dockerfile
+++ b/man/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.7.5-alpine
+FROM    golang:1.7.6-alpine
 
 RUN     apk add -U git bash curl gcc musl-dev make
 

--- a/man/Dockerfile.armhf
+++ b/man/Dockerfile.armhf
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
   gcc \
   make
 
-ENV GO_VERSION 1.7.5
+ENV GO_VERSION 1.7.6
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" \
   | tar -xzC /usr/local
 ENV PATH /go/bin:/usr/local/go/bin:$PATH

--- a/man/Dockerfile.ppc64le
+++ b/man/Dockerfile.ppc64le
@@ -7,7 +7,7 @@ RUN     apt-get update && apt-get install -y \
         make \
         tar
 
-ENV     GO_VERSION 1.7.5
+ENV     GO_VERSION 1.7.6
 RUN     curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" \
         | tar -xzC /usr/local
 ENV     PATH /usr/local/go/bin:$PATH

--- a/man/Dockerfile.s390x
+++ b/man/Dockerfile.s390x
@@ -7,7 +7,7 @@ RUN     apt-get update && apt-get install -y \
         make \
         tar
 
-ENV     GO_VERSION 1.7.5
+ENV     GO_VERSION 1.7.6
 RUN     curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" \
         | tar -xzC /usr/local
 ENV     PATH /usr/local/go/bin:$PATH


### PR DESCRIPTION
This addresses a security issue in go (CVE-2017-8932).

ping @mlaventure @mavenugo @thaJeztah @andrewhsu 