### PR TITLE
Whitelisting adjtimex get time operation and requiring CAP_SYS_TIME only in case of adjustment

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -55,6 +55,7 @@
 				"accept",
 				"accept4",
 				"access",
+				"adjtimex",
 				"alarm",
 				"alarm",
 				"bind",
@@ -719,7 +720,6 @@
 			"names": [
 				"settimeofday",
 				"stime",
-				"adjtimex",
 				"clock_settime"
 			],
 			"action": "SCMP_ACT_ALLOW",

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -49,6 +49,7 @@ func DefaultProfile() *types.Seccomp {
 				"accept",
 				"accept4",
 				"access",
+				"adjtimex",
 				"alarm",
 				"alarm",
 				"bind",
@@ -611,7 +612,6 @@ func DefaultProfile() *types.Seccomp {
 			Names: []string{
 				"settimeofday",
 				"stime",
-				"adjtimex",
 				"clock_settime",
 			},
 			Action: types.ActAllow,


### PR DESCRIPTION
…

Signed-off-by: Miklos Szegedi <miklos.szegedi@cloudera.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixes #33126 . Enabled getting the time without CAP_SYS_TIME

**- How I did it**
Enabled adjtimex in the default profile without requiring CAP_SYS_TIME privilege. The kernel will check CAP_SYS_TIME and won't allow setting the time.

**- How to verify it**
docker run -t -i centos:7
yum install -y ntp
ntptime
Returns: ntp_gettime() returns code 0 (OK)
ntpdate -v time.nist.gov
Returns: ntpdate[84]: Can't adjust the time of day: Operation not permitted

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Whitelisting adjtimex get time operation and requiring CAP_SYS_TIME only in case of adjustment

