### PR TITLE
Move cli.Configdir away (in `flags`).

### DIFF
--- a/cli/flags/common.go
+++ b/cli/flags/common.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/cli"
 	"github.com/docker/docker/opts"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/spf13/pflag"
@@ -46,7 +45,7 @@ func NewCommonOptions() *CommonOptions {
 // InstallFlags adds flags for the common options on the FlagSet
 func (commonOpts *CommonOptions) InstallFlags(flags *pflag.FlagSet) {
 	if dockerCertPath == "" {
-		dockerCertPath = cli.ConfigurationDir()
+		dockerCertPath = ConfigurationDir()
 	}
 
 	flags.BoolVarP(&commonOpts.Debug, "debug", "D", false, "Enable debug mode")

--- a/cli/flags/common_test.go
+++ b/cli/flags/common_test.go
@@ -4,7 +4,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/docker/docker/cli"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 )
@@ -26,7 +25,7 @@ func TestCommonOptionsInstallFlags(t *testing.T) {
 }
 
 func defaultPath(filename string) string {
-	return filepath.Join(cli.ConfigurationDir(), filename)
+	return filepath.Join(ConfigurationDir(), filename)
 }
 
 func TestCommonOptionsInstallFlagsWithDefaults(t *testing.T) {

--- a/cli/flags/configdir.go
+++ b/cli/flags/configdir.go
@@ -1,4 +1,4 @@
-package cli
+package flags
 
 import (
 	"os"

--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
-	dcli "github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/flags"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build/fakestorage"
 	"github.com/docker/docker/integration-cli/daemon"
@@ -406,7 +406,7 @@ func (s *DockerTrustSuite) TearDownTest(c *check.C) {
 	}
 
 	// Remove trusted keys and metadata after test
-	os.RemoveAll(filepath.Join(dcli.ConfigurationDir(), "trust"))
+	os.RemoveAll(filepath.Join(flags.ConfigurationDir(), "trust"))
 	s.ds.TearDownTest(c)
 }
 

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 
 	"github.com/docker/distribution/reference"
-	dcli "github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/flags"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
@@ -294,7 +294,7 @@ func (s *DockerTrustSuite) TestTrustedPush(c *check.C) {
 	})
 
 	// Assert that we rotated the snapshot key to the server by checking our local keystore
-	contents, err := ioutil.ReadDir(filepath.Join(dcli.ConfigurationDir(), "trust/private/tuf_keys", privateRegistryURL, "dockerclitrusted/pushtest"))
+	contents, err := ioutil.ReadDir(filepath.Join(flags.ConfigurationDir(), "trust/private/tuf_keys", privateRegistryURL, "dockerclitrusted/pushtest"))
 	c.Assert(err, check.IsNil, check.Commentf("Unable to read local tuf key files"))
 	// Check that we only have 1 key (targets key)
 	c.Assert(contents, checker.HasLen, 1)
@@ -399,7 +399,7 @@ func (s *DockerTrustSuite) TestTrustedPushWithReleasesDelegationOnly(c *check.C)
 	s.assertTargetNotInRoles(c, repoName, "latest", "targets")
 
 	// Try pull after push
-	os.RemoveAll(filepath.Join(dcli.ConfigurationDir(), "trust"))
+	os.RemoveAll(filepath.Join(flags.ConfigurationDir(), "trust"))
 
 	cli.Docker(cli.Args("pull", targetName), trustedCmd).Assert(c, icmd.Expected{
 		Out: "Status: Image is up to date",
@@ -436,7 +436,7 @@ func (s *DockerTrustSuite) TestTrustedPushSignsAllFirstLevelRolesWeHaveKeysFor(c
 	s.assertTargetNotInRoles(c, repoName, "latest", "targets")
 
 	// Try pull after push
-	os.RemoveAll(filepath.Join(dcli.ConfigurationDir(), "trust"))
+	os.RemoveAll(filepath.Join(flags.ConfigurationDir(), "trust"))
 
 	// pull should fail because none of these are the releases role
 	cli.Docker(cli.Args("pull", targetName), trustedCmd).Assert(c, icmd.Expected{
@@ -472,7 +472,7 @@ func (s *DockerTrustSuite) TestTrustedPushSignsForRolesWithKeysAndValidPaths(c *
 	s.assertTargetNotInRoles(c, repoName, "latest", "targets")
 
 	// Try pull after push
-	os.RemoveAll(filepath.Join(dcli.ConfigurationDir(), "trust"))
+	os.RemoveAll(filepath.Join(flags.ConfigurationDir(), "trust"))
 
 	// pull should fail because none of these are the releases role
 	cli.Docker(cli.Args("pull", targetName), trustedCmd).Assert(c, icmd.Expected{

--- a/integration-cli/trust_server_test.go
+++ b/integration-cli/trust_server_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	dcli "github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/flags"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/cli"
 	icmd "github.com/docker/docker/pkg/testutil/cmd"
@@ -108,7 +108,7 @@ func newTestNotary(c *check.C) (*testNotary, error) {
 		"skipTLSVerify": true
 	}
 }`
-	if _, err = fmt.Fprintf(clientConfig, template, filepath.Join(dcli.ConfigurationDir(), "trust"), notaryURL); err != nil {
+	if _, err = fmt.Fprintf(clientConfig, template, filepath.Join(flags.ConfigurationDir(), "trust"), notaryURL); err != nil {
 		os.RemoveAll(tmp)
 		return nil, err
 	}


### PR DESCRIPTION
This makes integration not depend anymore of `cli` and thus not
require `cobra` and other packages to compile.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
