### PR TITLE
Fix typo in swagger doc

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3119,7 +3119,7 @@ paths:
                       all processes in the container. Freezing the process requires the process to
                       be running. As a result, paused containers are both `Running` _and_ `Paused`.
 
-                      Use the `Status` field instead to determin if a container's state is "running".
+                      Use the `Status` field instead to determine if a container's state is "running".
                     type: "boolean"
                   Paused:
                     description: "Whether this container is paused."


### PR DESCRIPTION
Signed-off-by: Tobias Gesellchen <tobias@gesellix.de>

**- Description for the changelog**

Fix a little typo in the swagger docs.

**- A picture of a cute animal (not mandatory but encouraged)**

![79781427577038480](https://cloud.githubusercontent.com/assets/432791/26524296/f7a12f50-432e-11e7-8991-19afbea59136.jpg)

