### PR TITLE
Add test coverage to signal/trap.go

### DIFF
--- a/pkg/signal/testfiles/main.go
+++ b/pkg/signal/testfiles/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/docker/docker/pkg/signal"
+	"github.com/sirupsen/logrus"
+)
+
+func main() {
+	sigmap := map[string]os.Signal{
+		"TERM": syscall.SIGTERM,
+		"QUIT": syscall.SIGQUIT,
+		"INT":  os.Interrupt,
+	}
+	signal.Trap(func() {
+		time.Sleep(time.Second)
+		os.Exit(99)
+	}, logrus.StandardLogger())
+	go func() {
+		p, err := os.FindProcess(os.Getpid())
+		if err != nil {
+			panic(err)
+		}
+		s := os.Getenv("SIGNAL_TYPE")
+		multiple := os.Getenv("IF_MULTIPLE")
+		switch s {
+		case "TERM", "INT":
+			if multiple == "1" {
+				for {
+					p.Signal(sigmap[s])
+				}
+			} else {
+				p.Signal(sigmap[s])
+			}
+		case "QUIT":
+			p.Signal(sigmap[s])
+		}
+	}()
+	time.Sleep(2 * time.Second)
+}

--- a/pkg/signal/trap_linux_test.go
+++ b/pkg/signal/trap_linux_test.go
@@ -1,0 +1,82 @@
+// +build linux
+
+package signal
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildTestBinary(t *testing.T, tmpdir string, prefix string) (string, string) {
+	tmpDir, err := ioutil.TempDir(tmpdir, prefix)
+	require.NoError(t, err)
+	exePath := tmpDir + "/" + prefix
+	wd, _ := os.Getwd()
+	testHelperCode := wd + "/testfiles/main.go"
+	cmd := exec.Command("go", "build", "-o", exePath, testHelperCode)
+	err = cmd.Run()
+	require.NoError(t, err)
+	return exePath, tmpDir
+}
+
+func TestTrap(t *testing.T) {
+	var sigmap = []struct {
+		name     string
+		signal   os.Signal
+		multiple bool
+	}{
+		{"TERM", syscall.SIGTERM, false},
+		{"QUIT", syscall.SIGQUIT, true},
+		{"INT", os.Interrupt, false},
+		{"TERM", syscall.SIGTERM, true},
+		{"INT", os.Interrupt, true},
+	}
+	exePath, tmpDir := buildTestBinary(t, "", "main")
+	defer os.RemoveAll(tmpDir)
+
+	for _, v := range sigmap {
+		cmd := exec.Command(exePath)
+		cmd.Env = append(os.Environ(), fmt.Sprintf("SIGNAL_TYPE=%s", v.name))
+		if v.multiple {
+			cmd.Env = append(cmd.Env, "IF_MULTIPLE=1")
+		}
+		err := cmd.Start()
+		require.NoError(t, err)
+		err = cmd.Wait()
+		if e, ok := err.(*exec.ExitError); ok {
+			code := e.Sys().(syscall.WaitStatus).ExitStatus()
+			if v.multiple {
+				assert.Equal(t, 128+int(v.signal.(syscall.Signal)), code)
+			} else {
+				assert.Equal(t, 99, code)
+			}
+			continue
+		}
+		t.Fatal("process didn't end with any error")
+	}
+
+}
+
+func TestDumpStacks(t *testing.T) {
+	directory, err := ioutil.TempDir("", "test-dump-tasks")
+	assert.NoError(t, err)
+	defer os.RemoveAll(directory)
+	dumpPath, err := DumpStacks(directory)
+	assert.NoError(t, err)
+	readFile, _ := ioutil.ReadFile(dumpPath)
+	fileData := string(readFile)
+	assert.Contains(t, fileData, "goroutine")
+}
+
+func TestDumpStacksWithEmptyInput(t *testing.T) {
+	path, err := DumpStacks("")
+	assert.NoError(t, err)
+	assert.Equal(t, os.Stderr.Name(), path)
+}


### PR DESCRIPTION
Signed-off-by: Naveed Jamil <naveed.jamil@tenpearls.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added complete test coverage to the file trap.go preset in pkg/signal.
**- Why I did**
There was no test coverage present in for this file.
**- How I did it**
The function TestTrap calls itself as a separate process with an additional flag which allows us to check the functionality of a trap and also enables us to verify is cleanup() is being called as expected.
**- How to verify it**
Run `go test`. 
**- Additional Information**
The coverage tools shows that trap function is not being covered that is because it is being run in a separate process which is not being monitored by test coverage.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


