### PR TITLE
Do not log the CA config CA signing key in debug mode.

### DIFF
--- a/api/server/middleware/debug.go
+++ b/api/server/middleware/debug.go
@@ -64,7 +64,7 @@ func maskSecretKeys(inp interface{}) {
 	if form, ok := inp.(map[string]interface{}); ok {
 	loop0:
 		for k, v := range form {
-			for _, m := range []string{"password", "secret", "jointoken", "unlockkey"} {
+			for _, m := range []string{"password", "secret", "jointoken", "unlockkey", "signingcakey"} {
 				if strings.EqualFold(m, k) {
 					form[k] = "*****"
 					continue loop0


### PR DESCRIPTION
In debug mode, some form data when updating a swarm gets logged on the daemon.  We want to mask the `CAConfig.SigningCAKey` and not log it.

Signed-off-by: Ying Li <ying.li@docker.com>

This is a fix for 17.06.

![cute](https://s-media-cache-ak0.pinimg.com/736x/d4/26/0c/d4260c4c7a50d949e13291b7864d3a03.jpg)