### PR TITLE
fix the possible ports leak after abnormal restart

### DIFF
--- a/vendor/github.com/docker/libnetwork/controller.go
+++ b/vendor/github.com/docker/libnetwork/controller.go
@@ -205,6 +205,7 @@ func New(cfgOptions ...config.Option) (NetworkController, error) {
 			dcfg = c.makeDriverConfig(i.ntype)
 		}
 
+		// in i.fn, bridge drivers restore the port mapping and proxy based on stored endpoint
 		if err := drvRegistry.AddDriver(i.ntype, i.fn, dcfg); err != nil {
 			return nil, err
 		}
@@ -232,6 +233,8 @@ func New(cfgOptions ...config.Option) (NetworkController, error) {
 	c.reservePools()
 
 	// Cleanup resources
+	// clean up the sandbox and the related endpoints( including release port mapping and proxy), however, if endpoint updated but
+	// process exited abnormally before update the sandbox store, then after the process restart, there would be ports leak.
 	c.sandboxCleanup(c.cfg.ActiveSandboxes)
 	c.cleanupLocalEndpoints()
 	c.networkCleanup()

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -1311,10 +1311,12 @@ func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string
 			endpoint.portMapping = nil
 		}
 	}()
-
-	if err = d.storeUpdate(endpoint); err != nil {
-		return fmt.Errorf("failed to update bridge endpoint %s to store: %v", endpoint.id[0:7], err)
-	}
+	/*
+		// the endpoint should be updated after sandbox
+		if err = d.storeUpdate(endpoint); err != nil {
+			return fmt.Errorf("failed to update bridge endpoint %s to store: %v", endpoint.id[0:7], err)
+		}
+	*/
 
 	if !network.config.EnableICC {
 		return d.link(network, endpoint, true)

--- a/vendor/github.com/docker/libnetwork/sandbox.go
+++ b/vendor/github.com/docker/libnetwork/sandbox.go
@@ -663,6 +663,15 @@ func (sb *sandbox) SetKey(basePath string) error {
 		if err = sb.populateNetworkResources(ep); err != nil {
 			return err
 		}
+		// update the endpoint after sandbox
+		n, err := ep.getNetworkFromStore()
+		if err != nil {
+			return fmt.Errorf("failed to get network from store during join: %v", err)
+		}
+		if err = n.getController().updateToStore(ep); err != nil {
+			return err
+		}
+
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix the possible ports leak after process abnormally restarts.

**- How I did it**
Update the endpoint store after updating sandbox store when use port mapping.

**- How to verify it**
Panic the program after updating the endpoint store but before updating the sandbox store when do port mapping. After the program restarts under supervisor or something similar, there will be ports leak.
After fixing, there would be no ports leak under the same situation.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix the possible ports leak after process abnormally restarts.

**- A picture of a cute animal (not mandatory but encouraged)**

