### PR TITLE
Add note to CopyToContainer documentation

### DIFF
--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -30,6 +30,7 @@ func (cli *Client) ContainerStatPath(ctx context.Context, containerID, path stri
 }
 
 // CopyToContainer copies content into the container filesystem.
+// Note that `content` must be a Reader for a TAR
 func (cli *Client) CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error {
 	query := url.Values{}
 	query.Set("path", filepath.ToSlash(path)) // Normalize the paths used in the API.


### PR DESCRIPTION
The documentation for CopyToContainer doesn't mention that the content it expects is actually a TAR file. Hopefully this will save future developers a few hours of their time.

Signed-off-by: Brian Schwind <brianmschwind@gmail.com>

**- A picture of a cute animal (not mandatory but encouraged)**

![okay](http://i.imgur.com/o28jzDt.jpg)