### PR TITLE
Do not treat C.sysconf(C._SC_NPROCESSORS_ONLN) non-zero errno as error

### DIFF
--- a/daemon/stats/collector_unix.go
+++ b/daemon/stats/collector_unix.go
@@ -72,7 +72,11 @@ func (s *Collector) getSystemCPUUsage() (uint64, error) {
 
 func (s *Collector) getNumberOnlineCPUs() (uint32, error) {
 	i, err := C.sysconf(C._SC_NPROCESSORS_ONLN)
-	if err != nil {
+	// According to POSIX - errno is undefined after successful
+	// sysconf, and can be non-zero in several cases, so look for
+	// error in returned value not in errno.
+	// (https://sourceware.org/bugzilla/show_bug.cgi?id=21536)
+	if i == -1 {
 		return 0, err
 	}
 	return uint32(i), nil


### PR DESCRIPTION
Treat return code -1 as error instead.

People from glibc say that errno is undefined in case of successful
sysconf call according to POSIX standard:
Glibc bug: https://sourceware.org/bugzilla/show_bug.cgi?id=21536

More over in sysconf man it is wrongly said that "errno is not changed"
on success. So I've created a bug to man-pages:
https://bugzilla.kernel.org/show_bug.cgi?id=195955

Background: Glibc's sysconf(_SC_NPROCESSORS_ONLN) changes errno to
ENOENT, if there is no /sys/devices/system/cpu/online file, while
the call itself is successful. In Virtuozzo containers we prohibit
most of sysfs files for security reasons. So we have Run():daemon
/stats/collector.go infinitely loop never actualy collecting stats
from publisher pairs.

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>