### PR TITLE
Use actual cli version for TestConfigHTTPHeader

### DIFF
--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -17,6 +17,8 @@ if ! command -v "$TEST_CLIENT_BINARY" &> /dev/null; then
 	false
 fi
 
+export DOCKER_CLI_VERSION=$(${TEST_CLIENT_BINARY} --version | awk '{ gsub(",", " "); print $3 }')
+
 # This is a temporary hack for split-binary mode. It can be removed once
 # https://github.com/docker/docker/pull/22134 is merged into docker master
 if [ "$(go env GOOS)" = 'windows' ]; then

--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -60,6 +60,7 @@ test_env() {
 		# use "env -i" to tightly control the environment variables that bleed into the tests
 		env -i \
 			DEST="$DEST" \
+			DOCKER_CLI_VERSION="$DOCKER_CLI_VERSION" \
 			DOCKER_API_VERSION="$DOCKER_API_VERSION" \
 			DOCKER_INTEGRATION_DAEMON_DEST="$DOCKER_INTEGRATION_DAEMON_DEST" \
 			DOCKER_TLS_VERIFY="$DOCKER_TEST_TLS_VERIFY" \

--- a/integration-cli/docker_cli_config_test.go
+++ b/integration-cli/docker_cli_config_test.go
@@ -58,8 +58,7 @@ func (s *DockerSuite) TestConfigHTTPHeader(c *check.C) {
 
 	c.Assert(headers["User-Agent"], checker.NotNil, check.Commentf("Missing User-Agent"))
 
-	//TODO(tiborvass): restore dockerversion.Version instead of library-import
-	c.Assert(headers["User-Agent"][0], checker.Equals, "Docker-Client/unknown-version ("+runtime.GOOS+")", check.Commentf("Badly formatted User-Agent,out:%v", result.Combined()))
+	c.Assert(headers["User-Agent"][0], checker.Equals, "Docker-Client/"+os.Getenv("DOCKER_CLI_VERSION")+" ("+runtime.GOOS+")", check.Commentf("Badly formatted User-Agent,out:%v", result.Combined()))
 
 	c.Assert(headers["Myheader"], checker.NotNil)
 	c.Assert(headers["Myheader"][0], checker.Equals, "MyValue", check.Commentf("Missing/bad header,out:%v", result.Combined()))


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

--- 

This solve a false positive when testing with the actual release candidate within docker-ce.

ping @tiborvass 
