### PR TITLE
move multireader out of /pkg

### DIFF
--- a/daemon/logger/jsonfilelog/multireader/multireader.go
+++ b/daemon/logger/jsonfilelog/multireader/multireader.go
@@ -1,4 +1,4 @@
-package ioutils
+package multireader
 
 import (
 	"bytes"

--- a/daemon/logger/jsonfilelog/multireader/multireader_test.go
+++ b/daemon/logger/jsonfilelog/multireader/multireader_test.go
@@ -1,4 +1,4 @@
-package ioutils
+package multireader
 
 import (
 	"bytes"

--- a/daemon/logger/jsonfilelog/read.go
+++ b/daemon/logger/jsonfilelog/read.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/daemon/logger"
+	"github.com/docker/docker/daemon/logger/jsonfilelog/multireader"
 	"github.com/docker/docker/pkg/filenotify"
-	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/jsonlog"
 	"github.com/docker/docker/pkg/tailfile"
 )
@@ -77,7 +77,7 @@ func (l *JSONFileLogger) readLogs(logWatcher *logger.LogWatcher, config logger.R
 	defer latestFile.Close()
 
 	if config.Tail != 0 {
-		tailer := ioutils.MultiReadSeeker(append(files, latestFile)...)
+		tailer := multireader.MultiReadSeeker(append(files, latestFile)...)
 		tailFile(tailer, logWatcher, config.Tail, config.Since)
 	}
 


### PR DESCRIPTION
See #32989 

Moves `pkg/ioutils/multireader.*` to `daemon/logger/jsonfilelog/multireader`where it is used.