### PR TITLE
Fix incorrect assert message in TestReadProcBool

### DIFF
--- a/pkg/sysinfo/sysinfo_linux_test.go
+++ b/pkg/sysinfo/sysinfo_linux_test.go
@@ -28,7 +28,7 @@ func TestReadProcBool(t *testing.T) {
 		t.Fatal(err)
 	}
 	if readProcBool(procFile) {
-		t.Fatal("expected proc bool to be false, got false")
+		t.Fatal("expected proc bool to be false, got true")
 	}
 
 	if readProcBool(path.Join(tmpDir, "no-exist")) {


### PR DESCRIPTION
Signed-off-by: Tim Potter <tpot@hpe.com>

**- What I did**

Fixed incorrect assert message in a unit test.

**- How I did it**

vi

**- How to verify it**

By inspection.

**- Description for the changelog**

Fixed incorrect assert message in Linux sysinfo unit test.

**- A picture of a cute animal (not mandatory but encouraged)**

      )\_/(
      'o.o'
     =(_ _)=
        U
