### PR TITLE
Use octal values for file mode in filenotify poller and sysinfo_linux tests

### DIFF
--- a/pkg/filenotify/poller_test.go
+++ b/pkg/filenotify/poller_test.go
@@ -61,7 +61,7 @@ func TestPollerEvent(t *testing.T) {
 	default:
 	}
 
-	if err := ioutil.WriteFile(f.Name(), []byte("hello"), 644); err != nil {
+	if err := ioutil.WriteFile(f.Name(), []byte("hello"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	if err := assertEvent(w, fsnotify.Write); err != nil {

--- a/pkg/sysinfo/sysinfo_linux_test.go
+++ b/pkg/sysinfo/sysinfo_linux_test.go
@@ -16,7 +16,7 @@ func TestReadProcBool(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	procFile := filepath.Join(tmpDir, "read-proc-bool")
-	if err := ioutil.WriteFile(procFile, []byte("1"), 644); err != nil {
+	if err := ioutil.WriteFile(procFile, []byte("1"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -24,7 +24,7 @@ func TestReadProcBool(t *testing.T) {
 		t.Fatal("expected proc bool to be true, got false")
 	}
 
-	if err := ioutil.WriteFile(procFile, []byte("0"), 644); err != nil {
+	if err := ioutil.WriteFile(procFile, []byte("0"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	if readProcBool(procFile) {
@@ -48,7 +48,7 @@ func TestCgroupEnabled(t *testing.T) {
 		t.Fatal("cgroupEnabled should be false")
 	}
 
-	if err := ioutil.WriteFile(path.Join(cgroupDir, "test"), []byte{}, 644); err != nil {
+	if err := ioutil.WriteFile(path.Join(cgroupDir, "test"), []byte{}, 0644); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Closes #33484.

Signed-off-by: Tim Potter <tpot@hpe.com>

**- What I did**

Replaced incorrect file mode values 644 with 0644 in a few places.

**- How I did it**

vi

**- How to verify it**

TestReadProcBool was failing in my build environment and is working now. I suspect this test has always been working in the auto build environments due to permissive umask setting.

**- Description for the changelog**

Fix incorrect file mode values in file notify poller and sysinfo_linux tests

**- A picture of a cute animal (not mandatory but encouraged)**

      /\ ___ /\
     (  o   o  ) 
      \  >#<  /
      /       \  
     /         \       ^
    |           |     //
     \         /    //
      ///  ///   --