### PR TITLE
Update API docs on image creation

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4619,7 +4619,11 @@ paths:
         200:
           description: "no error"
         404:
-          description: "repository does not exist or no read access"
+          description: "no read access"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        404:
+          description: "repository does not exist"
           schema:
             $ref: "#/definitions/ErrorResponse"
         500:


### PR DESCRIPTION
When pulling images, the Docker daemon returns 401
for unauthorized pulls instead of 404.