### PR TITLE
Fix ONBUILD COPY

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -274,7 +274,7 @@ func BuildFromConfig(config *container.Config, changes []string) (*container.Con
 	}
 	dispatchState := newDispatchState()
 	dispatchState.runConfig = config
-	return dispatchFromDockerfile(b, dockerfile, dispatchState)
+	return dispatchFromDockerfile(b, dockerfile, dispatchState, nil)
 }
 
 func checkDispatchDockerfile(dockerfile *parser.Node) error {
@@ -286,7 +286,7 @@ func checkDispatchDockerfile(dockerfile *parser.Node) error {
 	return nil
 }
 
-func dispatchFromDockerfile(b *Builder, result *parser.Result, dispatchState *dispatchState) (*container.Config, error) {
+func dispatchFromDockerfile(b *Builder, result *parser.Result, dispatchState *dispatchState, source builder.Source) (*container.Config, error) {
 	shlex := NewShellLex(result.EscapeToken)
 	ast := result.AST
 	total := len(ast.Children)
@@ -297,6 +297,7 @@ func dispatchFromDockerfile(b *Builder, result *parser.Result, dispatchState *di
 			stepMsg: formatStep(i, total),
 			node:    n,
 			shlex:   shlex,
+			source:  source,
 		}
 		if _, err := b.dispatch(opts); err != nil {
 			return nil, err

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -325,7 +325,7 @@ func processOnBuild(req dispatchRequest) error {
 			}
 		}
 
-		if _, err := dispatchFromDockerfile(req.builder, dockerfile, dispatchState); err != nil {
+		if _, err := dispatchFromDockerfile(req.builder, dockerfile, dispatchState, req.source); err != nil {
 			return err
 		}
 	}

--- a/integration-cli/cli/build/fakecontext/context.go
+++ b/integration-cli/cli/build/fakecontext/context.go
@@ -2,9 +2,12 @@ package fakecontext
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/docker/docker/pkg/archive"
 )
 
 type testingT interface {
@@ -109,4 +112,13 @@ func (f *Fake) Delete(file string) error {
 // Close deletes the context
 func (f *Fake) Close() error {
 	return os.RemoveAll(f.Dir)
+}
+
+// AsTarReader returns a ReadCloser with the contents of Dir as a tar archive.
+func (f *Fake) AsTarReader(t testingT) io.ReadCloser {
+	reader, err := archive.TarWithOptions(f.Dir, &archive.TarOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create tar from %s: %s", f.Dir, err)
+	}
+	return reader
 }


### PR DESCRIPTION
Fixes #33493

Source was removed from `Builder` and wasn't being passed to the second `ONBUILD` dispatch.