### PR TITLE
Set OPOST on bsd

### DIFF
--- a/pkg/term/termios_bsd.go
+++ b/pkg/term/termios_bsd.go
@@ -27,7 +27,7 @@ func MakeRaw(fd uintptr) (*State, error) {
 
 	newState := oldState.termios
 	newState.Iflag &^= (unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON)
-	newState.Oflag &^= unix.OPOST
+	newState.Oflag |= unix.OPOST
 	newState.Lflag &^= (unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)
 	newState.Cflag &^= (unix.CSIZE | unix.PARENB)
 	newState.Cflag |= unix.CS8


### PR DESCRIPTION
This syncs up the terminal raw handling for bsd(OSX) and linux.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>