### PR TITLE
Use multiplexed stream format for ws attach

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -625,9 +625,15 @@ func (s *containerRouter) wsContainersAttach(ctx context.Context, w http.Respons
 		UseStdin:   true,
 		UseStdout:  true,
 		UseStderr:  true,
-		MuxStreams: false, // TODO: this should be true since it's a single stream for both stdout and stderr
+		MuxStreams: true,
 	}
 
+	// In prior API versions we were only mixing stdout/stderr streams together
+	// with no way for the client to differentiate. Setting `MuxStreams` to false
+	// keeps this old behavior.
+	if versions.LessThan(version, "1.36") {
+		attachConfig.MuxStreams = false
+	}
 	err = s.backend.ContainerAttach(containerName, attachConfig)
 	close(done)
 	select {

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -18,7 +18,7 @@ keywords: "API, Docker, rcli, REST, documentation"
 [Docker Engine API v1.36](https://docs.docker.com/engine/api/v1.36/) documentation
 
 * `Get /events` now return `exec_die` event when an exec process terminates.  
-
+* `/containers/attach` websocket endpoint now properly multiplexes streams on non-TTY outputs so clients can differentiate stdout and stderr. This uses the same stream format as the normal HTTP endpoint.
 
 ## v1.35 API changes
 
@@ -41,7 +41,6 @@ keywords: "API, Docker, rcli, REST, documentation"
   `Os`, `Arch`, `BuildTime`, `KernelVersion`, and `Experimental` fields. Going
   forward, the information from the `Components` section is preferred over their
   top-level counterparts.
-
 
 ## v1.34 API changes
 


### PR DESCRIPTION
Before this change, there is no way to differentiate stdout/stderr on
the websocket attach endpoint. With this change, the websocket attach
endpoint uses the same stream format as the non-websocket endpoint. This
allows websocket clients to differentiate stdout and stderr streams.

This continues to serve the old format for older clients.

Fixes #33504 