### PR TITLE
Added Test Case Coverage for PKG/REEXEC

### DIFF
--- a/pkg/reexec/reexec_test.go
+++ b/pkg/reexec/reexec_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/assert"
-	"path/filepath"
 )
 
 func init() {

--- a/pkg/reexec/reexec_test.go
+++ b/pkg/reexec/reexec_test.go
@@ -1,0 +1,55 @@
+package reexec
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"path/filepath"
+)
+
+func init() {
+	Register("reexec", func() {
+		panic("Return Error")
+	})
+	Init()
+}
+
+func TestRegister(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			require.Equal(t, `reexec func already registered under name "reexec"`, r)
+		}
+	}()
+	Register("reexec", func() {})
+}
+
+func TestCommand(t *testing.T) {
+	cmd := Command("reexec")
+	w, err := cmd.StdinPipe()
+	require.NoError(t, err, fmt.Sprintf("Error on pipe creation: %v", err))
+	defer w.Close()
+
+	err = cmd.Start()
+	require.NoError(t, err, fmt.Sprintf("Error on re-exec cmd: %v", err))
+	err = cmd.Wait()
+	require.EqualError(t, err, "exit status 2")
+}
+
+func TestNaiveSelf(t *testing.T) {
+	if os.Getenv("TEST_CHECK") == "1" {
+		os.Exit(2)
+	}
+	cmd := exec.Command(naiveSelf(), "-test.run=TestNaiveSelf")
+	cmd.Env = append(os.Environ(), "TEST_CHECK=1")
+	err := cmd.Start()
+	require.NoError(t, err, "Unable to start command")
+	err = cmd.Wait()
+	require.EqualError(t, err, "exit status 2")
+
+	os.Args[0] = "mkdir"
+	assert.NotEqual(t, naiveSelf(), os.Args[0])
+}


### PR DESCRIPTION
Signed-off-by: Naveed Jamil <naveed.jamil@tenpearls.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added test coverage for the package pkg/reexec. Previously it had no test coverage.