### PR TITLE
Added Test Case Coverage for PKG/REEXEC

### DIFF
--- a/pkg/reexec/reexec_test.go
+++ b/pkg/reexec/reexec_test.go
@@ -1,0 +1,53 @@
+package reexec
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	Register("reexec", func() {
+		panic("Return Error")
+	})
+	Init()
+}
+
+func TestRegister(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			require.Equal(t, `reexec func already registered under name "reexec"`, r)
+		}
+	}()
+	Register("reexec", func() {})
+}
+
+func TestCommand(t *testing.T) {
+	cmd := Command("reexec")
+	w, err := cmd.StdinPipe()
+	require.NoError(t, err, "Error on pipe creation: %v", err)
+	defer w.Close()
+
+	err = cmd.Start()
+	require.NoError(t, err, "Error on re-exec cmd: %v", err)
+	err = cmd.Wait()
+	require.EqualError(t, err, "exit status 2")
+}
+
+func TestNaiveSelf(t *testing.T) {
+	if os.Getenv("TEST_CHECK") == "1" {
+		os.Exit(2)
+	}
+	cmd := exec.Command(naiveSelf(), "-test.run=TestNaiveSelf")
+	cmd.Env = append(os.Environ(), "TEST_CHECK=1")
+	err := cmd.Start()
+	require.NoError(t, err, "Unable to start command")
+	err = cmd.Wait()
+	require.EqualError(t, err, "exit status 2")
+
+	os.Args[0] = "mkdir"
+	assert.NotEqual(t, naiveSelf(), os.Args[0])
+}


### PR DESCRIPTION
Signed-off-by: Naveed Jamil <naveed.jamil@tenpearls.com>

**- What I did**
Added test coverage for the package pkg/reexec, previously it had no unit tests written in it.
**- How to verify it**
Run `go test`