### PR TITLE
[Builder] Fix Cache with ONBUILD

### DIFF
--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -171,11 +171,9 @@ func (b *Builder) dispatch(options dispatchOptions) (*dispatchState, error) {
 		buildsFailed.WithValues(metricsUnknownInstructionError).Inc()
 		return nil, fmt.Errorf("unknown instruction: %s", upperCasedCmd)
 	}
-	if err := f(newDispatchRequestFromOptions(options, b, args)); err != nil {
-		return nil, err
-	}
 	options.state.updateRunConfig()
-	return options.state, nil
+	err = f(newDispatchRequestFromOptions(options, b, args))
+	return options.state, err
 }
 
 type dispatchOptions struct {

--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -74,7 +74,7 @@ func (s *DockerSuite) TestGetContainersAttachWebsocket(c *check.C) {
 
 // regression gh14320
 func (s *DockerSuite) TestPostContainersAttachContainerNotFound(c *check.C) {
-	client, err := request.NewClient(daemonHost())
+	client, err := request.NewHTTPClient(daemonHost())
 	c.Assert(err, checker.IsNil)
 	req, err := request.New(daemonHost(), "/containers/doesnotexist/attach", request.Method(http.MethodPost))
 	resp, err := client.Do(req)

--- a/integration-cli/request/request.go
+++ b/integration-cli/request/request.go
@@ -100,7 +100,7 @@ func DoOnHost(host, endpoint string, modifiers ...func(*http.Request) error) (*h
 	if err != nil {
 		return nil, nil, err
 	}
-	client, err := NewClient(host)
+	client, err := NewHTTPClient(host)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -140,8 +140,8 @@ func New(host, endpoint string, modifiers ...func(*http.Request) error) (*http.R
 	return req, nil
 }
 
-// NewClient creates an http client for the specific host
-func NewClient(host string) (*http.Client, error) {
+// NewHTTPClient creates an http client for the specific host
+func NewHTTPClient(host string) (*http.Client, error) {
 	// FIXME(vdemeester) 10*time.Second timeout of SockRequest… ?
 	proto, addr, _, err := dclient.ParseHost(host)
 	if err != nil {
@@ -161,6 +161,16 @@ func NewClient(host string) (*http.Client, error) {
 	return &http.Client{
 		Transport: transport,
 	}, err
+}
+
+// NewClient returns a new Docker API client
+func NewClient() (dclient.APIClient, error) {
+	host := DaemonHost()
+	httpClient, err := NewHTTPClient(host)
+	if err != nil {
+		return nil, err
+	}
+	return dclient.NewClient(host, "", httpClient, nil)
 }
 
 // FIXME(vdemeester) httputil.ClientConn is deprecated, use http.Client instead (closer to actual client)


### PR DESCRIPTION
Caching with ONBUILD was broken because `runConfig.Image` had the wrong value in the inner dispatch performed by `processOnBuild()`.

By setting `runConfig.Image` before starting dispatch the value should always be correct during dispatch.