### PR TITLE
Stop using deprecated SockRequest

### DIFF
--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -14,8 +14,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/opts"
@@ -750,6 +752,16 @@ func (d *Daemon) ReloadConfig() error {
 		return errors.New("timeout waiting for daemon reload event")
 	}
 	return nil
+}
+
+// NewClient creates new client based on daemon's socket path
+func (d *Daemon) NewClient() (*client.Client, error) {
+	httpClient, err := request.NewHTTPClient(d.Sock())
+	if err != nil {
+		return nil, err
+	}
+
+	return client.NewClient(d.Sock(), api.DefaultVersion, httpClient, nil)
 }
 
 // WaitInspectWithArgs waits for the specified expression to be equals to the specified expected string in the given time.

--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -86,11 +86,13 @@ func (s *DockerSuite) TestPostContainersAttachContainerNotFound(c *check.C) {
 }
 
 func (s *DockerSuite) TestGetContainersWsAttachContainerNotFound(c *check.C) {
-	status, body, err := request.SockRequest("GET", "/containers/doesnotexist/attach/ws", nil, daemonHost())
-	c.Assert(status, checker.Equals, http.StatusNotFound)
+	res, body, err := request.Get("/containers/doesnotexist/attach/ws")
+	c.Assert(res.StatusCode, checker.Equals, http.StatusNotFound)
+	c.Assert(err, checker.IsNil)
+	b, err := request.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 	expected := "No such container: doesnotexist"
-	c.Assert(getErrorMessage(c, body), checker.Contains, expected)
+	c.Assert(getErrorMessage(c, b), checker.Contains, expected)
 }
 
 func (s *DockerSuite) TestPostContainersAttach(c *check.C) {
@@ -177,6 +179,7 @@ func (s *DockerSuite) TestPostContainersAttach(c *check.C) {
 	// Make sure we don't see "hello" if Logs is false
 	client, err := client.NewEnvClient()
 	c.Assert(err, checker.IsNil)
+	defer client.Close()
 
 	cid, _ = dockerCmd(c, "run", "-di", "busybox", "/bin/sh", "-c", "echo hello; cat")
 	cid = strings.TrimSpace(cid)

--- a/integration-cli/docker_api_create_test.go
+++ b/integration-cli/docker_api_create_test.go
@@ -23,11 +23,15 @@ func (s *DockerSuite) TestAPICreateWithInvalidHealthcheckParams(c *check.C) {
 		},
 	}
 
-	status, body, err := request.SockRequest("POST", "/containers/create?name="+name, config, daemonHost())
+	res, body, err := request.Post("/containers/create?name="+name, request.JSONBody(config))
 	c.Assert(err, check.IsNil)
-	c.Assert(status, check.Equals, http.StatusBadRequest)
+	c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
+
+	buf, err := request.ReadBody(body)
+	c.Assert(err, checker.IsNil)
+
 	expected := fmt.Sprintf("Interval in Healthcheck cannot be less than %s", container.MinimumDuration)
-	c.Assert(getErrorMessage(c, body), checker.Contains, expected)
+	c.Assert(getErrorMessage(c, buf), checker.Contains, expected)
 
 	// test invalid Interval in Healthcheck: larger than 0s but less than 1ms
 	name = "test2"
@@ -39,10 +43,14 @@ func (s *DockerSuite) TestAPICreateWithInvalidHealthcheckParams(c *check.C) {
 			"Retries":  int(1000),
 		},
 	}
-	status, body, err = request.SockRequest("POST", "/containers/create?name="+name, config, daemonHost())
+	res, body, err = request.Post("/containers/create?name="+name, request.JSONBody(config))
 	c.Assert(err, check.IsNil)
-	c.Assert(status, check.Equals, http.StatusBadRequest)
-	c.Assert(getErrorMessage(c, body), checker.Contains, expected)
+
+	buf, err = request.ReadBody(body)
+	c.Assert(err, checker.IsNil)
+
+	c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
+	c.Assert(getErrorMessage(c, buf), checker.Contains, expected)
 
 	// test invalid Timeout in Healthcheck: less than 1ms
 	name = "test3"
@@ -54,11 +62,15 @@ func (s *DockerSuite) TestAPICreateWithInvalidHealthcheckParams(c *check.C) {
 			"Retries":  int(1000),
 		},
 	}
-	status, body, err = request.SockRequest("POST", "/containers/create?name="+name, config, daemonHost())
+	res, body, err = request.Post("/containers/create?name="+name, request.JSONBody(config))
 	c.Assert(err, check.IsNil)
-	c.Assert(status, check.Equals, http.StatusBadRequest)
+	c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
+
+	buf, err = request.ReadBody(body)
+	c.Assert(err, checker.IsNil)
+
 	expected = fmt.Sprintf("Timeout in Healthcheck cannot be less than %s", container.MinimumDuration)
-	c.Assert(getErrorMessage(c, body), checker.Contains, expected)
+	c.Assert(getErrorMessage(c, buf), checker.Contains, expected)
 
 	// test invalid Retries in Healthcheck: less than 0
 	name = "test4"
@@ -70,11 +82,15 @@ func (s *DockerSuite) TestAPICreateWithInvalidHealthcheckParams(c *check.C) {
 			"Retries":  int(-10),
 		},
 	}
-	status, body, err = request.SockRequest("POST", "/containers/create?name="+name, config, daemonHost())
+	res, body, err = request.Post("/containers/create?name="+name, request.JSONBody(config))
 	c.Assert(err, check.IsNil)
-	c.Assert(status, check.Equals, http.StatusBadRequest)
+	c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
+
+	buf, err = request.ReadBody(body)
+	c.Assert(err, checker.IsNil)
+
 	expected = "Retries in Healthcheck cannot be negative"
-	c.Assert(getErrorMessage(c, body), checker.Contains, expected)
+	c.Assert(getErrorMessage(c, buf), checker.Contains, expected)
 
 	// test invalid StartPeriod in Healthcheck: not 0 and less than 1ms
 	name = "test3"
@@ -87,9 +103,13 @@ func (s *DockerSuite) TestAPICreateWithInvalidHealthcheckParams(c *check.C) {
 			"StartPeriod": 100 * time.Microsecond,
 		},
 	}
-	status, body, err = request.SockRequest("POST", "/containers/create?name="+name, config, daemonHost())
+	res, body, err = request.Post("/containers/create?name="+name, request.JSONBody(config))
 	c.Assert(err, check.IsNil)
-	c.Assert(status, check.Equals, http.StatusBadRequest)
+	c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
+
+	buf, err = request.ReadBody(body)
+	c.Assert(err, checker.IsNil)
+
 	expected = fmt.Sprintf("StartPeriod in Healthcheck cannot be less than %s", container.MinimumDuration)
-	c.Assert(getErrorMessage(c, body), checker.Contains, expected)
+	c.Assert(getErrorMessage(c, buf), checker.Contains, expected)
 }

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -20,9 +20,9 @@ func (s *DockerSuite) TestExecResizeAPIHeightWidthNoInt(c *check.C) {
 	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/exec/" + cleanedContainerID + "/resize?h=foo&w=bar"
-	status, _, err := request.SockRequest("POST", endpoint, nil, daemonHost())
+	res, _, err := request.Post(endpoint)
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusBadRequest)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusBadRequest)
 }
 
 // Part of #14845
@@ -36,16 +36,19 @@ func (s *DockerSuite) TestExecResizeImmediatelyAfterExecStart(c *check.C) {
 			"Cmd":         []string{"/bin/sh"},
 		}
 		uri := fmt.Sprintf("/containers/%s/exec", name)
-		status, body, err := request.SockRequest("POST", uri, data, daemonHost())
+		res, body, err := request.Post(uri, request.JSONBody(data))
 		if err != nil {
 			return err
 		}
-		if status != http.StatusCreated {
-			return fmt.Errorf("POST %s is expected to return %d, got %d", uri, http.StatusCreated, status)
+		if res.StatusCode != http.StatusCreated {
+			return fmt.Errorf("POST %s is expected to return %d, got %d", uri, http.StatusCreated, res.StatusCode)
 		}
 
+		buf, err := request.ReadBody(body)
+		c.Assert(err, checker.IsNil)
+
 		out := map[string]string{}
-		err = json.Unmarshal(body, &out)
+		err = json.Unmarshal(buf, &out)
 		if err != nil {
 			return fmt.Errorf("ExecCreate returned invalid json. Error: %q", err.Error())
 		}

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -10,9 +10,12 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
+	"golang.org/x/net/context"
 )
 
 // Regression test for #9414
@@ -20,12 +23,15 @@ func (s *DockerSuite) TestExecAPICreateNoCmd(c *check.C) {
 	name := "exec_test"
 	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
-	status, body, err := request.SockRequest("POST", fmt.Sprintf("/containers/%s/exec", name), map[string]interface{}{"Cmd": nil}, daemonHost())
+	res, body, err := request.Post(fmt.Sprintf("/containers/%s/exec", name), request.JSONBody(map[string]interface{}{"Cmd": nil}))
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusBadRequest)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusBadRequest)
+
+	b, err := request.ReadBody(body)
+	c.Assert(err, checker.IsNil)
 
 	comment := check.Commentf("Expected message when creating exec command with no Cmd specified")
-	c.Assert(getErrorMessage(c, body), checker.Contains, "No exec command specified", comment)
+	c.Assert(getErrorMessage(c, b), checker.Contains, "No exec command specified", comment)
 }
 
 func (s *DockerSuite) TestExecAPICreateNoValidContentType(c *check.C) {
@@ -55,12 +61,18 @@ func (s *DockerSuite) TestExecAPICreateContainerPaused(c *check.C) {
 	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
 	dockerCmd(c, "pause", name)
-	status, body, err := request.SockRequest("POST", fmt.Sprintf("/containers/%s/exec", name), map[string]interface{}{"Cmd": []string{"true"}}, daemonHost())
+
+	cli, err := client.NewEnvClient()
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusConflict)
+	defer cli.Close()
+
+	config := types.ExecConfig{
+		Cmd: []string{"true"},
+	}
+	_, err = cli.ContainerExecCreate(context.Background(), name, config)
 
 	comment := check.Commentf("Expected message when creating exec command with Container %s is paused", name)
-	c.Assert(getErrorMessage(c, body), checker.Contains, "Container "+name+" is paused, unpause the container before exec", comment)
+	c.Assert(err.Error(), checker.Contains, "Container "+name+" is paused, unpause the container before exec", comment)
 }
 
 func (s *DockerSuite) TestExecAPIStart(c *check.C) {
@@ -128,22 +140,23 @@ func (s *DockerSuite) TestExecAPIStartMultipleTimesError(c *check.C) {
 func (s *DockerSuite) TestExecAPIStartWithDetach(c *check.C) {
 	name := "foo"
 	runSleepingContainer(c, "-d", "-t", "--name", name)
-	data := map[string]interface{}{
-		"cmd":         []string{"true"},
-		"AttachStdin": true,
-	}
-	_, b, err := request.SockRequest("POST", fmt.Sprintf("/containers/%s/exec", name), data, daemonHost())
-	c.Assert(err, checker.IsNil, check.Commentf(string(b)))
 
-	createResp := struct {
-		ID string `json:"Id"`
-	}{}
-	c.Assert(json.Unmarshal(b, &createResp), checker.IsNil, check.Commentf(string(b)))
+	config := types.ExecConfig{
+		Cmd:          []string{"true"},
+		AttachStderr: true,
+	}
+
+	cli, err := client.NewEnvClient()
+	c.Assert(err, checker.IsNil)
+	defer cli.Close()
+
+	createResp, err := cli.ContainerExecCreate(context.Background(), name, config)
+	c.Assert(err, checker.IsNil)
 
 	_, body, err := request.Post(fmt.Sprintf("/exec/%s/start", createResp.ID), request.RawString(`{"Detach": true}`), request.JSON)
 	c.Assert(err, checker.IsNil)
 
-	b, err = request.ReadBody(body)
+	b, err := request.ReadBody(body)
 	comment := check.Commentf("response body: %s", b)
 	c.Assert(err, checker.IsNil, comment)
 

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -1,38 +1,40 @@
 package main
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
+	"golang.org/x/net/context"
 )
 
 func (s *DockerSuite) TestAPIImagesFilter(c *check.C) {
+	cli, err := client.NewEnvClient()
+	c.Assert(err, checker.IsNil)
+	defer cli.Close()
+
 	name := "utest:tag1"
 	name2 := "utest/docker:tag2"
 	name3 := "utest:5000/docker:tag3"
 	for _, n := range []string{name, name2, name3} {
 		dockerCmd(c, "tag", "busybox", n)
 	}
-	type image types.ImageSummary
-	getImages := func(filter string) []image {
-		v := url.Values{}
-		v.Set("filter", filter)
-		status, b, err := request.SockRequest("GET", "/images/json?"+v.Encode(), nil, daemonHost())
-		c.Assert(err, checker.IsNil)
-		c.Assert(status, checker.Equals, http.StatusOK)
-
-		var images []image
-		err = json.Unmarshal(b, &images)
+	getImages := func(filter string) []types.ImageSummary {
+		filters := filters.NewArgs()
+		filters.Add("reference", filter)
+		options := types.ImageListOptions{
+			All:     false,
+			Filters: filters,
+		}
+		images, err := cli.ImageList(context.Background(), options)
 		c.Assert(err, checker.IsNil)
 
 		return images
@@ -74,6 +76,10 @@ func (s *DockerSuite) TestAPIImagesSaveAndLoad(c *check.C) {
 }
 
 func (s *DockerSuite) TestAPIImagesDelete(c *check.C) {
+	cli, err := client.NewEnvClient()
+	c.Assert(err, checker.IsNil)
+	defer cli.Close()
+
 	if testEnv.DaemonPlatform() != "windows" {
 		testRequires(c, Network)
 	}
@@ -83,20 +89,21 @@ func (s *DockerSuite) TestAPIImagesDelete(c *check.C) {
 
 	dockerCmd(c, "tag", name, "test:tag1")
 
-	status, _, err := request.SockRequest("DELETE", "/images/"+id, nil, daemonHost())
-	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusConflict)
+	_, err = cli.ImageRemove(context.Background(), id, types.ImageRemoveOptions{})
+	c.Assert(err.Error(), checker.Contains, "unable to delete")
 
-	status, _, err = request.SockRequest("DELETE", "/images/test:noexist", nil, daemonHost())
-	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusNotFound) //Status Codes:404 – no such image
+	_, err = cli.ImageRemove(context.Background(), "test:noexist", types.ImageRemoveOptions{})
+	c.Assert(err.Error(), checker.Contains, "No such image")
 
-	status, _, err = request.SockRequest("DELETE", "/images/test:tag1", nil, daemonHost())
+	_, err = cli.ImageRemove(context.Background(), "test:tag1", types.ImageRemoveOptions{})
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusOK)
 }
 
 func (s *DockerSuite) TestAPIImagesHistory(c *check.C) {
+	cli, err := client.NewEnvClient()
+	c.Assert(err, checker.IsNil)
+	defer cli.Close()
+
 	if testEnv.DaemonPlatform() != "windows" {
 		testRequires(c, Network)
 	}
@@ -104,13 +111,8 @@ func (s *DockerSuite) TestAPIImagesHistory(c *check.C) {
 	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nENV FOO bar"))
 	id := getIDByName(c, name)
 
-	status, body, err := request.SockRequest("GET", "/images/"+id+"/history", nil, daemonHost())
+	historydata, err := cli.ImageHistory(context.Background(), id)
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusOK)
-
-	var historydata []image.HistoryResponseItem
-	err = json.Unmarshal(body, &historydata)
-	c.Assert(err, checker.IsNil, check.Commentf("Error on unmarshal"))
 
 	c.Assert(historydata, checker.Not(checker.HasLen), 0)
 	c.Assert(historydata[0].Tags[0], checker.Equals, "test-api-images-history:latest")
@@ -133,9 +135,8 @@ func (s *DockerSuite) TestAPIImagesImportBadSrc(c *check.C) {
 	}
 
 	for _, te := range tt {
-		res, b, err := request.SockRequestRaw("POST", strings.Join([]string{"/images/create?fromSrc=", te.fromSrc}, ""), nil, "application/json", daemonHost())
+		res, _, err := request.Post(strings.Join([]string{"/images/create?fromSrc=", te.fromSrc}, ""), request.JSON)
 		c.Assert(err, check.IsNil)
-		b.Close()
 		c.Assert(res.StatusCode, checker.Equals, te.statusExp)
 		c.Assert(res.Header.Get("Content-Type"), checker.Equals, "application/json")
 	}
@@ -156,11 +157,11 @@ func (s *DockerSuite) TestAPIImagesSearchJSONContentType(c *check.C) {
 // Test case for 30027: image size reported as -1 in v1.12 client against v1.13 daemon.
 // This test checks to make sure both v1.12 and v1.13 client against v1.13 daemon get correct `Size` after the fix.
 func (s *DockerSuite) TestAPIImagesSizeCompatibility(c *check.C) {
-	status, b, err := request.SockRequest("GET", "/images/json", nil, daemonHost())
+	cli, err := client.NewEnvClient()
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusOK)
-	var images []types.ImageSummary
-	err = json.Unmarshal(b, &images)
+	defer cli.Close()
+
+	images, err := cli.ImageList(context.Background(), types.ImageListOptions{})
 	c.Assert(err, checker.IsNil)
 	c.Assert(len(images), checker.Not(checker.Equals), 0)
 	for _, image := range images {
@@ -177,11 +178,13 @@ func (s *DockerSuite) TestAPIImagesSizeCompatibility(c *check.C) {
 		VirtualSize int64
 		Labels      map[string]string
 	}
-	status, b, err = request.SockRequest("GET", "/v1.24/images/json", nil, daemonHost())
+
+	var httpClient *http.Client
+	cli, err = client.NewClient(daemonHost(), "v1.24", httpClient, nil)
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusOK)
-	var v124Images []v124Image
-	err = json.Unmarshal(b, &v124Images)
+	defer cli.Close()
+
+	v124Images, err := cli.ImageList(context.Background(), types.ImageListOptions{})
 	c.Assert(err, checker.IsNil)
 	c.Assert(len(v124Images), checker.Not(checker.Equals), 0)
 	for _, image := range v124Images {

--- a/integration-cli/docker_api_info_test.go
+++ b/integration-cli/docker_api_info_test.go
@@ -4,17 +4,23 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"fmt"
+
 	"github.com/docker/docker/api/types"
+
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
+	"golang.org/x/net/context"
 )
 
 func (s *DockerSuite) TestInfoAPI(c *check.C) {
-	endpoint := "/info"
+	cli, err := client.NewEnvClient()
+	c.Assert(err, checker.IsNil)
+	defer cli.Close()
 
-	status, body, err := request.SockRequest("GET", endpoint, nil, daemonHost())
-	c.Assert(status, checker.Equals, http.StatusOK)
+	info, err := cli.Info(context.Background())
 	c.Assert(err, checker.IsNil)
 
 	// always shown fields
@@ -36,7 +42,7 @@ func (s *DockerSuite) TestInfoAPI(c *check.C) {
 		"ServerVersion",
 		"SecurityOptions"}
 
-	out := string(body)
+	out := fmt.Sprintf("%+v", info)
 	for _, linePrefix := range stringsToCheck {
 		c.Assert(out, checker.Contains, linePrefix)
 	}
@@ -63,13 +69,15 @@ func (s *DockerSuite) TestInfoAPIRuncCommit(c *check.C) {
 
 func (s *DockerSuite) TestInfoAPIVersioned(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Windows only supports 1.25 or later
-	endpoint := "/v1.20/info"
 
-	status, body, err := request.SockRequest("GET", endpoint, nil, daemonHost())
-	c.Assert(status, checker.Equals, http.StatusOK)
+	res, body, err := request.Get("/v1.20/info")
+	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(err, checker.IsNil)
 
-	out := string(body)
+	b, err := request.ReadBody(body)
+	c.Assert(err, checker.IsNil)
+
+	out := string(b)
 	c.Assert(out, checker.Contains, "ExecutionDriver")
 	c.Assert(out, checker.Contains, "not supported")
 }

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"encoding/json"
-	"net/http"
 	"strings"
+
+	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions/v1p20"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/checker"
-	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/pkg/stringutils"
 	"github.com/go-check/check"
 )
@@ -106,18 +107,14 @@ func (s *DockerSuite) TestInspectAPIContainerVolumeDriver(c *check.C) {
 
 func (s *DockerSuite) TestInspectAPIImageResponse(c *check.C) {
 	dockerCmd(c, "tag", "busybox:latest", "busybox:mytag")
-
-	endpoint := "/images/busybox/json"
-	status, body, err := request.SockRequest("GET", endpoint, nil, daemonHost())
-
+	cli, err := client.NewEnvClient()
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusOK)
+	defer cli.Close()
 
-	var imageJSON types.ImageInspect
-	err = json.Unmarshal(body, &imageJSON)
-	c.Assert(err, checker.IsNil, check.Commentf("Unable to unmarshal body for latest version"))
+	imageJSON, _, err := cli.ImageInspectWithRaw(context.Background(), "busybox")
+	c.Assert(err, checker.IsNil)
+
 	c.Assert(imageJSON.RepoTags, checker.HasLen, 2)
-
 	c.Assert(stringutils.InSlice(imageJSON.RepoTags, "busybox:latest"), checker.Equals, true)
 	c.Assert(stringutils.InSlice(imageJSON.RepoTags, "busybox:mytag"), checker.Equals, true)
 }

--- a/integration-cli/docker_api_inspect_unix_test.go
+++ b/integration-cli/docker_api_inspect_unix_test.go
@@ -4,12 +4,12 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/checker"
-	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
+	"golang.org/x/net/context"
 )
 
 // #16665
@@ -19,9 +19,11 @@ func (s *DockerSuite) TestInspectAPICpusetInConfigPre120(c *check.C) {
 
 	name := "cpusetinconfig-pre120"
 	dockerCmd(c, "run", "--name", name, "--cpuset-cpus", "0", "busybox", "true")
-
-	status, body, err := request.SockRequest("GET", fmt.Sprintf("/v1.19/containers/%s/json", name), nil, daemonHost())
-	c.Assert(status, check.Equals, http.StatusOK)
+	var httpClient *http.Client
+	cli, err := client.NewClient(daemonHost(), "v1.19", httpClient, nil)
+	c.Assert(err, checker.IsNil)
+	defer cli.Close()
+	_, body, err := cli.ContainerInspectWithRaw(context.Background(), name, false)
 	c.Assert(err, check.IsNil)
 
 	var inspectJSON map[string]interface{}

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -7,9 +7,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
+	"golang.org/x/net/context"
 )
 
 func (s *DockerSuite) TestLogsAPIWithStdout(c *check.C) {
@@ -51,13 +54,13 @@ func (s *DockerSuite) TestLogsAPIWithStdout(c *check.C) {
 func (s *DockerSuite) TestLogsAPINoStdoutNorStderr(c *check.C) {
 	name := "logs_test"
 	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
-
-	status, body, err := request.SockRequest("GET", fmt.Sprintf("/containers/%s/logs", name), nil, daemonHost())
-	c.Assert(status, checker.Equals, http.StatusBadRequest)
+	cli, err := client.NewEnvClient()
 	c.Assert(err, checker.IsNil)
+	defer cli.Close()
 
+	_, err = cli.ContainerLogs(context.Background(), name, types.ContainerLogsOptions{})
 	expected := "Bad parameters: you must choose at least one stream"
-	c.Assert(getErrorMessage(c, body), checker.Contains, expected)
+	c.Assert(err.Error(), checker.Contains, expected)
 }
 
 // Regression test for #12704

--- a/integration-cli/docker_api_resize_test.go
+++ b/integration-cli/docker_api_resize_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
@@ -12,10 +15,15 @@ import (
 func (s *DockerSuite) TestResizeAPIResponse(c *check.C) {
 	out := runSleepingContainer(c, "-d")
 	cleanedContainerID := strings.TrimSpace(out)
+	cli, err := client.NewEnvClient()
+	c.Assert(err, checker.IsNil)
+	defer cli.Close()
 
-	endpoint := "/containers/" + cleanedContainerID + "/resize?h=40&w=40"
-	status, _, err := request.SockRequest("POST", endpoint, nil, daemonHost())
-	c.Assert(status, check.Equals, http.StatusOK)
+	options := types.ResizeOptions{
+		Height: 40,
+		Width:  40,
+	}
+	err = cli.ContainerResize(context.Background(), cleanedContainerID, options)
 	c.Assert(err, check.IsNil)
 }
 
@@ -24,8 +32,8 @@ func (s *DockerSuite) TestResizeAPIHeightWidthNoInt(c *check.C) {
 	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/containers/" + cleanedContainerID + "/resize?h=foo&w=bar"
-	status, _, err := request.SockRequest("POST", endpoint, nil, daemonHost())
-	c.Assert(status, check.Equals, http.StatusBadRequest)
+	res, _, err := request.Post(endpoint)
+	c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
 	c.Assert(err, check.IsNil)
 }
 
@@ -36,10 +44,15 @@ func (s *DockerSuite) TestResizeAPIResponseWhenContainerNotStarted(c *check.C) {
 	// make sure the exited container is not running
 	dockerCmd(c, "wait", cleanedContainerID)
 
-	endpoint := "/containers/" + cleanedContainerID + "/resize?h=40&w=40"
-	status, body, err := request.SockRequest("POST", endpoint, nil, daemonHost())
-	c.Assert(status, check.Equals, http.StatusConflict)
-	c.Assert(err, check.IsNil)
+	cli, err := client.NewEnvClient()
+	c.Assert(err, checker.IsNil)
+	defer cli.Close()
 
-	c.Assert(getErrorMessage(c, body), checker.Contains, "is not running", check.Commentf("resize should fail with message 'Container is not running'"))
+	options := types.ResizeOptions{
+		Height: 40,
+		Width:  40,
+	}
+
+	err = cli.ContainerResize(context.Background(), cleanedContainerID, options)
+	c.Assert(err.Error(), checker.Contains, "is not running")
 }

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -13,9 +13,11 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
+	"golang.org/x/net/context"
 )
 
 var expectedNetworkInterfaceStats = strings.Split("rx_bytes rx_dropped rx_errors rx_packets tx_bytes tx_dropped tx_errors tx_packets", " ")
@@ -260,14 +262,16 @@ func jsonBlobHasGTE121NetworkStats(blob map[string]interface{}) bool {
 
 func (s *DockerSuite) TestAPIStatsContainerNotFound(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-
-	status, _, err := request.SockRequest("GET", "/containers/nonexistent/stats", nil, daemonHost())
+	cli, err := client.NewEnvClient()
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusNotFound)
+	defer cli.Close()
 
-	status, _, err = request.SockRequest("GET", "/containers/nonexistent/stats?stream=0", nil, daemonHost())
-	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusNotFound)
+	expected := "No such container: nonexistent"
+
+	_, err = cli.ContainerStats(context.Background(), "nonexistent", true)
+	c.Assert(err.Error(), checker.Contains, expected)
+	_, err = cli.ContainerStats(context.Background(), "nonexistent", false)
+	c.Assert(err.Error(), checker.Contains, expected)
 }
 
 func (s *DockerSuite) TestAPIStatsNoStreamConnectedContainers(c *check.C) {

--- a/integration-cli/docker_api_swarm_config_test.go
+++ b/integration-cli/docker_api_swarm_config_test.go
@@ -3,12 +3,10 @@
 package main
 
 import (
-	"fmt"
-	"net/http"
-
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/go-check/check"
+	"golang.org/x/net/context"
 )
 
 func (s *DockerSwarmSuite) TestAPISwarmConfigsEmptyList(c *check.C) {
@@ -52,9 +50,15 @@ func (s *DockerSwarmSuite) TestAPISwarmConfigsDelete(c *check.C) {
 	c.Assert(config.ID, checker.Equals, id, check.Commentf("config: %v", config))
 
 	d.DeleteConfig(c, config.ID)
-	status, out, err := d.SockRequest("GET", "/configs/"+id, nil)
+
+	cli, err := d.NewClient()
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusNotFound, check.Commentf("config delete: %s", string(out)))
+	defer cli.Close()
+
+	expected := "no such config"
+
+	_, _, err = cli.ConfigInspectWithRaw(context.Background(), id)
+	c.Assert(err.Error(), checker.Contains, expected)
 }
 
 func (s *DockerSwarmSuite) TestAPISwarmConfigsUpdate(c *check.C) {
@@ -110,9 +114,12 @@ func (s *DockerSwarmSuite) TestAPISwarmConfigsUpdate(c *check.C) {
 	config = d.GetConfig(c, id)
 	config.Spec.Data = []byte("TESTINGDATA2")
 
-	url := fmt.Sprintf("/configs/%s/update?version=%d", config.ID, config.Version.Index)
-	status, out, err := d.SockRequest("POST", url, config.Spec)
+	cli, err := d.NewClient()
+	c.Assert(err, checker.IsNil)
+	defer cli.Close()
 
-	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
-	c.Assert(status, checker.Equals, http.StatusBadRequest, check.Commentf("output: %q", string(out)))
+	expected := "only updates to Labels are allowed"
+
+	err = cli.ConfigUpdate(context.Background(), config.ID, config.Version, config.Spec)
+	c.Assert(err.Error(), checker.Contains, expected)
 }

--- a/integration-cli/docker_api_swarm_secret_test.go
+++ b/integration-cli/docker_api_swarm_secret_test.go
@@ -3,12 +3,12 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/go-check/check"
+	"golang.org/x/net/context"
 )
 
 func (s *DockerSwarmSuite) TestAPISwarmSecretsEmptyList(c *check.C) {
@@ -59,16 +59,19 @@ func (s *DockerSwarmSuite) TestAPISwarmSecretsDelete(c *check.C) {
 	c.Assert(secret.ID, checker.Equals, id, check.Commentf("secret: %v", secret))
 
 	d.DeleteSecret(c, secret.ID)
-	status, out, err := d.SockRequest("GET", "/secrets/"+id, nil)
-	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusNotFound, check.Commentf("secret delete: %s", string(out)))
 
-	// delete non-existing secret, daemon should return a status code of 404
+	cli, err := d.NewClient()
+	c.Assert(err, checker.IsNil)
+	defer cli.Close()
+
+	expected := "no such secret"
+	_, _, err = cli.SecretInspectWithRaw(context.Background(), id)
+	c.Assert(err.Error(), checker.Contains, expected)
+
 	id = "non-existing"
-	status, out, err = d.SockRequest("DELETE", "/secrets/"+id, nil)
-	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusNotFound, check.Commentf("secret delete: %s", string(out)))
-
+	expected = "secret non-existing not found"
+	err = cli.SecretRemove(context.Background(), id)
+	c.Assert(err.Error(), checker.Contains, expected)
 }
 
 func (s *DockerSwarmSuite) TestAPISwarmSecretsUpdate(c *check.C) {
@@ -124,9 +127,12 @@ func (s *DockerSwarmSuite) TestAPISwarmSecretsUpdate(c *check.C) {
 	secret = d.GetSecret(c, id)
 	secret.Spec.Data = []byte("TESTINGDATA2")
 
-	url := fmt.Sprintf("/secrets/%s/update?version=%d", secret.ID, secret.Version.Index)
-	status, out, err := d.SockRequest("POST", url, secret.Spec)
+	cli, err := d.NewClient()
+	c.Assert(err, checker.IsNil)
+	defer cli.Close()
 
-	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
-	c.Assert(status, checker.Equals, http.StatusBadRequest, check.Commentf("output: %q", string(out)))
+	expected := "only updates to Labels are allowed"
+
+	err = cli.SecretUpdate(context.Background(), secret.ID, secret.Version, secret.Spec)
+	c.Assert(err.Error(), checker.Contains, expected)
 }

--- a/integration-cli/docker_api_version_test.go
+++ b/integration-cli/docker_api_version_test.go
@@ -1,24 +1,18 @@
 package main
 
 import (
-	"encoding/json"
-	"net/http"
-
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/integration-cli/checker"
-	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
+	"golang.org/x/net/context"
 )
 
 func (s *DockerSuite) TestGetVersion(c *check.C) {
-	status, body, err := request.SockRequest("GET", "/version", nil, daemonHost())
-	c.Assert(status, checker.Equals, http.StatusOK)
+	cli, err := client.NewEnvClient()
 	c.Assert(err, checker.IsNil)
+	defer cli.Close()
 
-	var v types.Version
-
-	c.Assert(json.Unmarshal(body, &v), checker.IsNil)
-
+	v, err := cli.ServerVersion(context.Background())
 	c.Assert(v.Version, checker.Equals, dockerversion.Version, check.Commentf("Version mismatch"))
 }

--- a/integration-cli/docker_api_volumes_test.go
+++ b/integration-cli/docker_api_volumes_test.go
@@ -1,30 +1,29 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/checker"
-	"github.com/docker/docker/integration-cli/request"
 	"github.com/go-check/check"
+	"golang.org/x/net/context"
 )
 
 func (s *DockerSuite) TestVolumesAPIList(c *check.C) {
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 	dockerCmd(c, "run", "-v", prefix+"/foo", "busybox")
 
-	status, b, err := request.SockRequest("GET", "/volumes", nil, daemonHost())
+	cli, err := client.NewEnvClient()
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusOK)
+	defer cli.Close()
 
-	var volumes volumetypes.VolumesListOKBody
-	c.Assert(json.Unmarshal(b, &volumes), checker.IsNil)
+	volumes, err := cli.VolumeList(context.Background(), filters.Args{})
+	c.Assert(err, checker.IsNil)
 
 	c.Assert(len(volumes.Volumes), checker.Equals, 1, check.Commentf("\n%v", volumes.Volumes))
 }
@@ -33,13 +32,13 @@ func (s *DockerSuite) TestVolumesAPICreate(c *check.C) {
 	config := volumetypes.VolumesCreateBody{
 		Name: "test",
 	}
-	status, b, err := request.SockRequest("POST", "/volumes/create", config, daemonHost())
-	c.Assert(err, check.IsNil)
-	c.Assert(status, check.Equals, http.StatusCreated, check.Commentf(string(b)))
 
-	var vol types.Volume
-	err = json.Unmarshal(b, &vol)
+	cli, err := client.NewEnvClient()
 	c.Assert(err, checker.IsNil)
+	defer cli.Close()
+
+	vol, err := cli.VolumeCreate(context.Background(), config)
+	c.Assert(err, check.IsNil)
 
 	c.Assert(filepath.Base(filepath.Dir(vol.Mountpoint)), checker.Equals, config.Name)
 }
@@ -48,49 +47,43 @@ func (s *DockerSuite) TestVolumesAPIRemove(c *check.C) {
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 	dockerCmd(c, "run", "-v", prefix+"/foo", "--name=test", "busybox")
 
-	status, b, err := request.SockRequest("GET", "/volumes", nil, daemonHost())
+	cli, err := client.NewEnvClient()
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusOK)
+	defer cli.Close()
 
-	var volumes volumetypes.VolumesListOKBody
-	c.Assert(json.Unmarshal(b, &volumes), checker.IsNil)
-	c.Assert(len(volumes.Volumes), checker.Equals, 1, check.Commentf("\n%v", volumes.Volumes))
+	volumes, err := cli.VolumeList(context.Background(), filters.Args{})
+	c.Assert(err, checker.IsNil)
 
 	v := volumes.Volumes[0]
-	status, _, err = request.SockRequest("DELETE", "/volumes/"+v.Name, nil, daemonHost())
-	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusConflict, check.Commentf("Should not be able to remove a volume that is in use"))
+	err = cli.VolumeRemove(context.Background(), v.Name, false)
+	c.Assert(err.Error(), checker.Contains, "volume is in use")
 
 	dockerCmd(c, "rm", "-f", "test")
-	status, data, err := request.SockRequest("DELETE", "/volumes/"+v.Name, nil, daemonHost())
+	err = cli.VolumeRemove(context.Background(), v.Name, false)
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusNoContent, check.Commentf(string(data)))
-
 }
 
 func (s *DockerSuite) TestVolumesAPIInspect(c *check.C) {
 	config := volumetypes.VolumesCreateBody{
 		Name: "test",
 	}
+
 	// sampling current time minus a minute so to now have false positive in case of delays
 	now := time.Now().Truncate(time.Minute)
-	status, b, err := request.SockRequest("POST", "/volumes/create", config, daemonHost())
-	c.Assert(err, check.IsNil)
-	c.Assert(status, check.Equals, http.StatusCreated, check.Commentf(string(b)))
 
-	status, b, err = request.SockRequest("GET", "/volumes", nil, daemonHost())
+	cli, err := client.NewEnvClient()
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf(string(b)))
+	defer cli.Close()
 
-	var volumes volumetypes.VolumesListOKBody
-	c.Assert(json.Unmarshal(b, &volumes), checker.IsNil)
+	_, err = cli.VolumeCreate(context.Background(), config)
+	c.Assert(err, check.IsNil)
+
+	volumes, err := cli.VolumeList(context.Background(), filters.Args{})
+	c.Assert(err, checker.IsNil)
 	c.Assert(len(volumes.Volumes), checker.Equals, 1, check.Commentf("\n%v", volumes.Volumes))
 
-	var vol types.Volume
-	status, b, err = request.SockRequest("GET", "/volumes/"+config.Name, nil, daemonHost())
+	vol, err := cli.VolumeInspect(context.Background(), config.Name)
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf(string(b)))
-	c.Assert(json.Unmarshal(b, &vol), checker.IsNil)
 	c.Assert(vol.Name, checker.Equals, config.Name)
 
 	// comparing CreatedAt field time for the new volume to now. Removing a minute from both to avoid false positive

--- a/integration-cli/docker_deprecated_api_v124_test.go
+++ b/integration-cli/docker_deprecated_api_v124_test.go
@@ -22,9 +22,14 @@ func (s *DockerSuite) TestDeprecatedContainerAPIStartHostConfig(c *check.C) {
 	config := map[string]interface{}{
 		"Binds": []string{"/aa:/bb"},
 	}
-	status, _, err := request.SockRequest("POST", "/containers/"+name+"/start", config, daemonHost())
+	res, body, err := request.Post("/containers/"+name+"/start", request.JSONBody(config))
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusBadRequest)
+
+	buf, err := request.ReadBody(body)
+	c.Assert(err, checker.IsNil)
+
+	c.Assert(res.StatusCode, checker.Equals, http.StatusBadRequest)
+	c.Assert(string(buf), checker.Contains, "was deprecated since API v1.22")
 }
 
 func (s *DockerSuite) TestDeprecatedContainerAPIStartVolumeBinds(c *check.C) {
@@ -40,17 +45,17 @@ func (s *DockerSuite) TestDeprecatedContainerAPIStartVolumeBinds(c *check.C) {
 		"Volumes": map[string]struct{}{path: {}},
 	}
 
-	status, _, err := request.SockRequest("POST", formatV123StartAPIURL("/containers/create?name="+name), config, daemonHost())
+	res, _, err := request.Post(formatV123StartAPIURL("/containers/create?name="+name), request.JSONBody(config))
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusCreated)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusCreated)
 
 	bindPath := RandomTmpDirPath("test", testEnv.DaemonPlatform())
 	config = map[string]interface{}{
 		"Binds": []string{bindPath + ":" + path},
 	}
-	status, _, err = request.SockRequest("POST", formatV123StartAPIURL("/containers/"+name+"/start"), config, daemonHost())
+	res, _, err = request.Post(formatV123StartAPIURL("/containers/"+name+"/start"), request.JSONBody(config))
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusNoContent)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusNoContent)
 
 	pth, err := inspectMountSourceField(name, path)
 	c.Assert(err, checker.IsNil)
@@ -67,9 +72,9 @@ func (s *DockerSuite) TestDeprecatedContainerAPIStartDupVolumeBinds(c *check.C) 
 		"Volumes": map[string]struct{}{"/tmp": {}},
 	}
 
-	status, _, err := request.SockRequest("POST", formatV123StartAPIURL("/containers/create?name="+name), config, daemonHost())
+	res, _, err := request.Post(formatV123StartAPIURL("/containers/create?name="+name), request.JSONBody(config))
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusCreated)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusCreated)
 
 	bindPath1 := RandomTmpDirPath("test1", testEnv.DaemonPlatform())
 	bindPath2 := RandomTmpDirPath("test2", testEnv.DaemonPlatform())
@@ -77,10 +82,14 @@ func (s *DockerSuite) TestDeprecatedContainerAPIStartDupVolumeBinds(c *check.C) 
 	config = map[string]interface{}{
 		"Binds": []string{bindPath1 + ":/tmp", bindPath2 + ":/tmp"},
 	}
-	status, body, err := request.SockRequest("POST", formatV123StartAPIURL("/containers/"+name+"/start"), config, daemonHost())
+	res, body, err := request.Post(formatV123StartAPIURL("/containers/"+name+"/start"), request.JSONBody(config))
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusBadRequest)
-	c.Assert(string(body), checker.Contains, "Duplicate mount point", check.Commentf("Expected failure due to duplicate bind mounts to same path, instead got: %q with error: %v", string(body), err))
+
+	buf, err := request.ReadBody(body)
+	c.Assert(err, checker.IsNil)
+
+	c.Assert(res.StatusCode, checker.Equals, http.StatusBadRequest)
+	c.Assert(string(buf), checker.Contains, "Duplicate mount point", check.Commentf("Expected failure due to duplicate bind mounts to same path, instead got: %q with error: %v", string(buf), err))
 }
 
 func (s *DockerSuite) TestDeprecatedContainerAPIStartVolumesFrom(c *check.C) {
@@ -97,16 +106,16 @@ func (s *DockerSuite) TestDeprecatedContainerAPIStartVolumesFrom(c *check.C) {
 		"Volumes": map[string]struct{}{volPath: {}},
 	}
 
-	status, _, err := request.SockRequest("POST", formatV123StartAPIURL("/containers/create?name="+name), config, daemonHost())
+	res, _, err := request.Post(formatV123StartAPIURL("/containers/create?name="+name), request.JSONBody(config))
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusCreated)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusCreated)
 
 	config = map[string]interface{}{
 		"VolumesFrom": []string{volName},
 	}
-	status, _, err = request.SockRequest("POST", formatV123StartAPIURL("/containers/"+name+"/start"), config, daemonHost())
+	res, _, err = request.Post(formatV123StartAPIURL("/containers/"+name+"/start"), request.JSONBody(config))
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusNoContent)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusNoContent)
 
 	pth, err := inspectMountSourceField(name, volPath)
 	c.Assert(err, checker.IsNil)
@@ -127,9 +136,9 @@ func (s *DockerSuite) TestDeprecatedPostContainerBindNormalVolume(c *check.C) {
 	dockerCmd(c, "create", "-v", "/foo", "--name=two", "busybox")
 
 	bindSpec := map[string][]string{"Binds": {fooDir + ":/foo"}}
-	status, _, err := request.SockRequest("POST", formatV123StartAPIURL("/containers/two/start"), bindSpec, daemonHost())
+	res, _, err := request.Post(formatV123StartAPIURL("/containers/two/start"), request.JSONBody(bindSpec))
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusNoContent)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusNoContent)
 
 	fooDir2, err := inspectMountSourceField("two", "/foo")
 	c.Assert(err, checker.IsNil)

--- a/integration-cli/docker_deprecated_api_v124_unix_test.go
+++ b/integration-cli/docker_deprecated_api_v124_unix_test.go
@@ -22,7 +22,7 @@ func (s *DockerNetworkSuite) TestDeprecatedDockerNetworkStartAPIWithHostconfig(c
 			"NetworkMode": netName,
 		},
 	}
-	_, _, err := request.SockRequest("POST", formatV123StartAPIURL("/containers/"+conName+"/start"), config, daemonHost())
+	_, _, err := request.Post(formatV123StartAPIURL("/containers/"+conName+"/start"), request.JSONBody(config))
 	c.Assert(err, checker.IsNil)
 	c.Assert(waitRun(conName), checker.IsNil)
 	networks := inspectField(c, conName, "NetworkSettings.Networks")


### PR DESCRIPTION
Signed-off-by: Stanislav Bondarenko <stanislav.bondarenko@gmail.com>

per #31410 

Use `client/` package instead of `request `deprecated `SockRequest`. If not viable to use `client/` replace with new `Do`, `Post`, `Get`, ...

**- Description for the changelog**
integration-cli: Use `client/` package instead of deprecated `SockRequest`


