### PR TITLE
client: Use string concatenation instead of Sprintf

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -216,9 +216,9 @@ func (cli *Client) getAPIPath(p string, query url.Values) string {
 	var apiPath string
 	if cli.version != "" {
 		v := strings.TrimPrefix(cli.version, "v")
-		apiPath = fmt.Sprintf("%s/v%s%s", cli.basePath, v, p)
+		apiPath = cli.basePath + "/v" + v + p
 	} else {
-		apiPath = fmt.Sprintf("%s%s", cli.basePath, p)
+		apiPath = cli.basePath + p
 	}
 
 	u := &url.URL{

--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -20,7 +20,7 @@ func (cli *Client) ContainerStatPath(ctx context.Context, containerID, path stri
 	query := url.Values{}
 	query.Set("path", filepath.ToSlash(path)) // Normalize the paths used in the API.
 
-	urlStr := fmt.Sprintf("/containers/%s/archive", containerID)
+	urlStr := "/containers/" + containerID + "/archive"
 	response, err := cli.head(ctx, urlStr, query, nil)
 	if err != nil {
 		return types.ContainerPathStat{}, err
@@ -42,7 +42,7 @@ func (cli *Client) CopyToContainer(ctx context.Context, container, path string, 
 		query.Set("copyUIDGID", "true")
 	}
 
-	apiPath := fmt.Sprintf("/containers/%s/archive", container)
+	apiPath := "/containers/" + container + "/archive"
 
 	response, err := cli.putRaw(ctx, apiPath, query, content, nil)
 	if err != nil {
@@ -63,7 +63,7 @@ func (cli *Client) CopyFromContainer(ctx context.Context, container, srcPath str
 	query := make(url.Values, 1)
 	query.Set("path", filepath.ToSlash(srcPath)) // Normalize the paths used in the API.
 
-	apiPath := fmt.Sprintf("/containers/%s/archive", container)
+	apiPath := "/containers/" + container + "/archive"
 	response, err := cli.get(ctx, apiPath, query, nil)
 	if err != nil {
 		return nil, types.ContainerPathStat{}, err

--- a/client/ping.go
+++ b/client/ping.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"fmt"
-
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
 )
@@ -10,7 +8,7 @@ import (
 // Ping pings the server and returns the value of the "Docker-Experimental", "OS-Type" & "API-Version" headers
 func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 	var ping types.Ping
-	req, err := cli.buildRequest("GET", fmt.Sprintf("%s/_ping", cli.basePath), nil, nil)
+	req, err := cli.buildRequest("GET", cli.basePath+"/_ping", nil, nil)
 	if err != nil {
 		return ping, err
 	}

--- a/client/plugin_upgrade.go
+++ b/client/plugin_upgrade.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"fmt"
 	"io"
 	"net/url"
 
@@ -33,5 +32,5 @@ func (cli *Client) PluginUpgrade(ctx context.Context, name string, options types
 
 func (cli *Client) tryPluginUpgrade(ctx context.Context, query url.Values, privileges types.PluginPrivileges, name, registryAuth string) (serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
-	return cli.post(ctx, fmt.Sprintf("/plugins/%s/upgrade", name), query, privileges, headers)
+	return cli.post(ctx, "/plugins/"+name+"/upgrade", query, privileges, headers)
 }


### PR DESCRIPTION
Despite my C background, I dislike `Sprintf` and try to avoid it when I can. I've seen too many printf format string bugs. I tolerate it when it's used for actual formatting, but for simple string concatenation, I much prefer the `+` operator. It makes code easier to read and allows more compile-time checking.