### PR TITLE
daemon: correctly try to retrieve init/runtime versions

### DIFF
--- a/daemon/config/config_common_unix.go
+++ b/daemon/config/config_common_unix.go
@@ -59,7 +59,7 @@ func (conf *Config) GetExecRoot() string {
 	return conf.ExecRoot
 }
 
-// GetInitPath returns the configure docker-init path
+// GetInitPath returns the configured docker-init path
 func (conf *Config) GetInitPath() string {
 	conf.Lock()
 	defer conf.Unlock()


### PR DESCRIPTION
Since paths for default runtime and init can be configured it's silly to spam logs with:
```
[root@7pvelk01 ~]# grep -c 'failed to retrieve docker-init version' /var/log/messages
9696
```
same goes for `docker-runc`

Signed-off-by: Antonio Murdaca <runcom@redhat.com>
