### PR TITLE
Describe the differences between container-inspect and container-list

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2698,6 +2698,11 @@ paths:
   /containers/json:
     get:
       summary: "List containers"
+      description: |
+        Returns a list of containers. For details on the format, see [the inspect endpoint](#operation/ContainerInspect).
+
+        Note that it uses a different, smaller representation of a container than inspecting a single container. For example,
+        the list of linked containers is not propagated .
       operationId: "ContainerList"
       produces:
         - "application/json"


### PR DESCRIPTION
closes #32338

**- What I did**

Update swagger.yaml

**- How I did it**

Add a description paragraph under `/containers/json` explaining the differences in representation between container list and container inspect.
