### PR TITLE
Force to use default volume driver to handle volume requests

### DIFF
--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -46,7 +46,8 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 			return fmt.Errorf("cannot mount volume over existing file, file exists %s", path)
 		}
 
-		v, err := daemon.volumes.CreateWithRef(name, hostConfig.VolumeDriver, container.ID, nil, nil)
+		// Force to use default driver to handle the request
+		v, err := daemon.volumes.CreateWithRef(name, "", container.ID, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/daemon/create_windows.go
+++ b/daemon/create_windows.go
@@ -16,9 +16,10 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 		hostConfig.Isolation = daemon.defaultIsolation
 	}
 
+	// Force to use default driver to handle the request
 	for spec := range config.Volumes {
 
-		mp, err := volume.ParseMountRaw(spec, hostConfig.VolumeDriver)
+		mp, err := volume.ParseMountRaw(spec, "")
 		if err != nil {
 			return fmt.Errorf("Unrecognised volume spec: %v", err)
 		}
@@ -34,11 +35,9 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 			continue
 		}
 
-		volumeDriver := hostConfig.VolumeDriver
-
 		// Create the volume in the volume driver. If it doesn't exist,
 		// a new one will be created.
-		v, err := daemon.volumes.CreateWithRef(mp.Name, volumeDriver, container.ID, nil, nil)
+		v, err := daemon.volumes.CreateWithRef(mp.Name, "", container.ID, nil, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Force to use default volume driver to handle volume requests
specified by VOLUME commands in Dockerfile.

Fixes #33553

Signed-off-by: Yang Honggang joseph.yang@xtaotech.com
