### PR TITLE
builder: add a test for `ENV name` (without `=value`)

### DIFF
--- a/builder/dockerfile/parser/line_parsers_test.go
+++ b/builder/dockerfile/parser/line_parsers_test.go
@@ -64,3 +64,11 @@ func TestNodeFromLabels(t *testing.T) {
 	assert.Equal(t, expected, node)
 
 }
+
+func TestParseNameValWithoutVal(t *testing.T) {
+	directive := Directive{}
+	// In Config.Env, a variable without `=` is removed from the environment. (#31634)
+	// However, in Dockerfile, we don't allow "unsetting" an environment variable. (#11922)
+	_, err := parseNameVal("foo", "ENV", &directive)
+	assert.Error(t, err, "ENV must have two arguments")
+}


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>


