### PR TITLE
Service alias should not be copied to task alias

### DIFF
--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -495,7 +495,6 @@ func getEndpointConfig(na *api.NetworkAttachment, b executorpkg.Backend) *networ
 			IPv4Address: ipv4,
 			IPv6Address: ipv6,
 		},
-		Aliases:    na.Aliases,
 		DriverOpts: na.DriverAttachmentOpts,
 	}
 	if v, ok := na.Network.Spec.Annotations.Labels["com.docker.swarm.predefined"]; ok && v == "true" {


### PR DESCRIPTION
If a service alias is copied to task, then the DNS resolution on the
service name will resolve to service VIP and all of Task-IPs and that
will break the concept of vip based load-balancing resulting in all the
dns-rr caching issues.

This is a regression introduced by #33130

Fixes #33576 

Signed-off-by: Madhu Venugopal <madhu@docker.com>