### PR TITLE
Pass the same log filename to logging plugins on start/stop requests

### DIFF
--- a/daemon/logger/adapter.go
+++ b/daemon/logger/adapter.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -18,6 +19,7 @@ type pluginAdapter struct {
 	driverName   string
 	id           string
 	plugin       logPlugin
+	basePath     string
 	fifoPath     string
 	capabilities Capability
 	logInfo      Info
@@ -56,7 +58,7 @@ func (a *pluginAdapter) Close() error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	if err := a.plugin.StopLogging(a.fifoPath); err != nil {
+	if err := a.plugin.StopLogging(strings.TrimPrefix(a.fifoPath, a.basePath)); err != nil {
 		return err
 	}
 

--- a/daemon/logger/plugin.go
+++ b/daemon/logger/plugin.go
@@ -59,6 +59,7 @@ func makePluginCreator(name string, l *logPluginProxy, basePath string) Creator 
 			driverName: name,
 			id:         id,
 			plugin:     l,
+			basePath:   basePath,
 			fifoPath:   filepath.Join(root, id),
 			logInfo:    logCtx,
 		}


### PR DESCRIPTION
Signed-off-by: Peter Bücker <peter.buecker@gmail.com>

**- What I did**

Provide a solution for https://github.com/moby/moby/issues/33569.

**- How I did it**

The `/LogDriver.StopLogging` request needs additional context (`basePath`) to provide the correct filename to the logging plugin. This context was added since I found no way to retrieve it from existing data structures at hand.

**- How to verify it**

Rerun the steps given at https://github.com/moby/moby/issues/33569.

**- Description for the changelog**

Pass the same log filename to logging plugins on start/stop requests.