### PR TITLE
[DONOT MERGE] improve test for config file to show incorrect config merge logic

### DIFF
--- a/daemon/config/config_unix_test.go
+++ b/daemon/config/config_unix_test.go
@@ -5,8 +5,11 @@ package config
 import (
 	"io/ioutil"
 	"runtime"
-
 	"testing"
+
+	"github.com/docker/docker/opts"
+	units "github.com/docker/go-units"
+	"github.com/spf13/pflag"
 )
 
 func TestDaemonConfigurationMerge(t *testing.T) {
@@ -44,7 +47,16 @@ func TestDaemonConfigurationMerge(t *testing.T) {
 		},
 	}
 
-	cc, err := MergeDaemonConfigurations(c, nil, configFile)
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+	var debug bool
+	ulimit := make(map[string]*units.Ulimit)
+
+	flags.BoolVarP(&debug, "debug", "D", false, "")
+	flags.Var(opts.NewUlimitOpt(&ulimit), "default-ulimit", "Default ulimits for containers")
+	flags.Var(opts.NewNamedMapOpts("log-opts", nil, nil), "log-opt", "")
+
+	cc, err := MergeDaemonConfigurations(c, flags, configFile)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

This PR is used to show that one test case in merging flag configs and file config is incorrect.  
And this PR is only used for https://github.com/moby/moby/pull/32547,  when PR https://github.com/moby/moby/pull/32547 is merged, we can immediatelly close this.

**What I did**:
1. pass a non-nil value to `MergeDaemonConfigurations` to make test more sufficient.

With this PR, the unit test will show error:
```
--- FAIL: TestDaemonConfigurationMerge (0.00s)
	config_unix_test.go:61: the following directives don't match any configuration option: default-ulimits
FAIL
```


