### PR TITLE
"back port" #29083

### DIFF
--- a/volume/store/store_test.go
+++ b/volume/store/store_test.go
@@ -212,7 +212,7 @@ func TestDerefMultipleOfSameRef(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	defer os.RemoveAll(dir)
 	s, err := New(dir)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
I was looking if https://github.com/moby/moby/pull/29083 had to be backported to master, but it looks like that was covered by 6ef1060 (#29042)

While doing this, I noticed that a defer was not present on master, so adding this :smile: