### PR TITLE
backport #29418 "Fix buildIpamResources()" to master

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -410,6 +410,9 @@ func buildIpamResources(r *types.NetworkResource, nwInfo libnetwork.NetworkInfo)
 
 	if !hasIpv6Conf {
 		for _, ip6Info := range ipv6Info {
+			if ip6Info.IPAMData.Pool == nil {
+				continue
+			}
 			iData := network.IPAMConfig{}
 			iData.Subnet = ip6Info.IPAMData.Pool.String()
 			iData.Gateway = ip6Info.IPAMData.Gateway.String()


### PR DESCRIPTION
[1.13.x] Fix buildIpamResources()
(cherry picked from commit 4d2be03b68dd54d8f2307e8b4178ad8ed8d5d343)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

Looks like this PR (https://github.com/moby/moby/pull/29418) never found it's way back to master; fixes https://github.com/moby/moby/issues/29411, which involves a possible panic


ping @mavenugo @fcrisciani PTAL