### PR TITLE
Docs back ports to master

### DIFF
--- a/docs/extend/legacy_plugins.md
+++ b/docs/extend/legacy_plugins.md
@@ -87,8 +87,9 @@ Plugin                                                                          
 
  Plugin                                                       | Description
 ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [Twistlock AuthZ Broker](https://github.com/twistlock/authz) | A basic extendable authorization plugin that runs directly on the host or inside a container. This plugin allows you to define user policies that it evaluates during authorization. Basic authorization is provided if Docker daemon is started with the --tlsverify flag (username is extracted from the certificate common name).
- [HBM plugin](https://github.com/kassisol/hbm)                | An authorization plugin that prevents from executing commands with certains parameters.
+[Casbin AuthZ Plugin](https://github.com/casbin/casbin-authz-plugin) | An authorization plugin based on [Casbin](https://github.com/casbin/casbin), which supports access control models like ACL, RBAC, ABAC. The access control model can be customized. The policy can be persisted into file or DB.
+[HBM plugin](https://github.com/kassisol/hbm)                 | An authorization plugin that prevents from executing commands with certains parameters.
+[Twistlock AuthZ Broker](https://github.com/twistlock/authz)  | A basic extendable authorization plugin that runs directly on the host or inside a container. This plugin allows you to define user policies that it evaluates during authorization. Basic authorization is provided if Docker daemon is started with the --tlsverify flag (username is extracted from the certificate common name).
 
 ## Troubleshooting a plugin
 

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -94,8 +94,8 @@ instructions.
 Whenever possible, Docker will re-use the intermediate images (cache),
 to accelerate the `docker build` process significantly. This is indicated by
 the `Using cache` message in the console output.
-(For more information, see the [Build cache section](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache)) in the
-`Dockerfile` best practices guide:
+(For more information, see the [Build cache section](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#build-cache) in the
+`Dockerfile` best practices guide):
 
     $ docker build -t svendowideit/ambassador .
     Sending build context to Docker daemon 15.36 kB

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1281,18 +1281,28 @@ This Dockerfile results in an image that causes `docker run`, to
 create a new mount point at `/myvol` and copy the  `greeting` file
 into the newly created volume.
 
-> **Note**:
-> When using Windows-based containers, the destination of a volume inside the
-> container must be one of: a non-existing or empty directory; or a drive other
-> than C:.
+### Notes about specifying volumes
 
-> **Note**:
-> If any build steps change the data within the volume after it has been
-> declared, those changes will be discarded.
+Keep the following things in mind about volumes in the `Dockerfile`.
 
-> **Note**:
-> The list is parsed as a JSON array, which means that
-> you must use double-quotes (") around words not single-quotes (').
+- **Volumes on Windows-based containers**: When using Windows-based containers,
+  the destination of a volume inside the container must be one of:
+  
+  - a non-existing or empty directory
+  - a drive other than `C:`
+
+- **Changing the volume from within the Dockerfile**: If any build steps change the
+  data within the volume after it has been declared, those changes will be discarded.
+
+- **JSON formatting**: The list is parsed as a JSON array.
+  You must enclose words with double quotes (`"`)rather than single quotes (`'`).
+
+- **The host directory is declared at container run-time**: The host directory
+  (the mountpoint) is, by its nature, host-dependent. This is to preserve image
+  portability. since a given host directory can't be guaranteed to be available
+  on all hosts.For this reason, you can't mount a host directory from
+  within the Dockerfile. The `VOLUME` instruction does not support specifying a `host-dir`
+  parameter.  You must specify the mountpoint when you create or run the container.
 
 ## USER
 

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -89,7 +89,7 @@ ID                         HOSTNAME       STATUS  AVAILABILITY  MANAGER STATUS
 1bcef6utixb0l0ca7gxuivsj0  swarm-worker2  Ready   Active
 ```
 
-#### membersip
+#### membership
 
 The `membership` filter matches nodes based on the presence of a `membership` and a value
 `accepted` or `pending`.

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -745,6 +745,41 @@ PS C:\> docker run -d --isolation default microsoft/nanoserver powershell echo h
 PS C:\> docker run -d --isolation hyperv microsoft/nanoserver powershell echo hyperv
 ```
 
+### Specify hard limits on memory available to containers (-m, --memory)
+
+These parameters always set an upper limit on the memory available to the container. On Linux, this
+is set on the cgroup and applications in a container can query it at `/sys/fs/cgroup/memory/memory.limit_in_bytes`.
+
+On Windows, this will affect containers differently depending on what type of isolation is used.
+
+- With `process` isolation, Windows will report the full memory of the host system, not the limit to applications running inside the container
+    ```powershell
+    docker run -it -m 2GB --isolation=process microsoft/nanoserver powershell Get-ComputerInfo *memory*
+
+    CsTotalPhysicalMemory      : 17064509440
+    CsPhyicallyInstalledMemory : 16777216
+    OsTotalVisibleMemorySize   : 16664560
+    OsFreePhysicalMemory       : 14646720
+    OsTotalVirtualMemorySize   : 19154928
+    OsFreeVirtualMemory        : 17197440
+    OsInUseVirtualMemory       : 1957488
+    OsMaxProcessMemorySize     : 137438953344
+    ```
+- With `hyperv` isolation, Windows will create a utility VM that is big enough to hold the memory limit, plus the minimal OS needed to host the container. That size is reported as "Total Physical Memory."
+    ```powershell
+    docker run -it -m 2GB --isolation=hyperv microsoft/nanoserver powershell Get-ComputerInfo *memory*
+
+    CsTotalPhysicalMemory      : 2683355136
+    CsPhyicallyInstalledMemory :
+    OsTotalVisibleMemorySize   : 2620464
+    OsFreePhysicalMemory       : 2306552
+    OsTotalVirtualMemorySize   : 2620464
+    OsFreeVirtualMemory        : 2356692
+    OsInUseVirtualMemory       : 263772
+    OsMaxProcessMemorySize     : 137438953344
+    ```
+
+
 ### Configure namespaced kernel parameters (sysctls) at runtime
 
 The `--sysctl` sets namespaced kernel parameters (sysctls) in the

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1123,7 +1123,7 @@ by default a container is not allowed to access any devices, but a
 the documentation on [cgroups devices](https://www.kernel.org/doc/Documentation/cgroup-v1/devices.txt)).
 
 When the operator executes `docker run --privileged`, Docker will enable
-to access to all devices on the host as well as set some configuration
+access to all devices on the host as well as set some configuration
 in AppArmor or SELinux to allow the container nearly all the same access to the
 host as processes running outside containers on the host. Additional
 information about running with `--privileged` is available on the


### PR DESCRIPTION
Backports of the following commits/PR's to master:

https://github.com/moby/moby/commit/831066337743fc29ff122fce51afe44b8b3b3ba9 (https://github.com/moby/moby/pull/32684)
https://github.com/moby/moby/commit/c3fbca106552f2dadcb89510ff87945b50f36419 (https://github.com/moby/moby/pull/32724)
https://github.com/moby/moby/commit/f2fff9d913a8ab0436dd56033189a7c3713a59a2 (https://github.com/moby/moby/pull/32735)
https://github.com/moby/moby/commit/32a52716b964373b4ac464052e73ea5da79856c6 (https://github.com/moby/moby/pull/32791)
https://github.com/moby/moby/commit/9db03bd8cdad3c8804105cb5794ebad5e728f48f (https://github.com/moby/moby/pull/32804)
https://github.com/moby/moby/commit/220831d541bfe9bf566c1038773198d431560dd3 (https://github.com/moby/moby/pull/33572)

Last commit, I fixed up some tiny things I noticed (order of plugins, leading space)