### PR TITLE
Bump API version

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -21,7 +21,7 @@ import (
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion string = "1.30"
+	DefaultVersion string = "1.31"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.30"
+basePath: "/v1.31"
 info:
   title: "Docker Engine API"
-  version: "1.30"
+  version: "1.31"
   x-logo:
     url: "https://docs.docker.com/images/logo-docker-main.png"
   description: |
@@ -52,10 +52,11 @@ info:
 
     The API uses an open schema model, which means server may add extra properties to responses. Likewise, the server will ignore any extra query parameters and request body properties. When you write clients, you need to ignore additional properties in responses to ensure they do not break when talking to newer Docker daemons.
 
-    This documentation is for version 1.30 of the API, which was introduced with Docker 17.06. Use this table to find documentation for previous versions of the API:
+    This documentation is for version 1.31 of the API. Use this table to find documentation for previous versions of the API:
 
     Docker version  | API version | Changes
     ----------------|-------------|---------
+    17.06.x | [1.30](https://docs.docker.com/engine/api/v1.30/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-30-api-changes)
     17.05.x | [1.29](https://docs.docker.com/engine/api/v1.29/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-29-api-changes)
     17.04.x | [1.28](https://docs.docker.com/engine/api/v1.28/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-28-api-changes)
     17.03.1 | [1.27](https://docs.docker.com/engine/api/v1.27/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-27-api-changes)

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,15 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.31 API changes
+
+[Docker Engine API v1.31](https://docs.docker.com/engine/api/v1.31/) documentation
+
+* `DELETE /secrets/(name)` now returns status code 404 instead of 500 when the secret does not exist.
+* `POST /secrets/create` now returns status code 409 instead of 500 when creating an already existing secret.
+* `POST /secrets/(name)/update` now returns status code 400 instead of 500 when updating a secret's content which is not the labels.
+* `POST /nodes/(name)/update` now returns status code 400 instead of 500 when demoting last node fails.
+
 ## v1.30 API changes
 
 [Docker Engine API v1.30](https://docs.docker.com/engine/api/v1.30/) documentation
@@ -29,10 +38,6 @@ keywords: "API, Docker, rcli, REST, documentation"
  generate and rotate to a new CA certificate/key pair.
 * `POST /service/create` and `POST /services/(id or name)/update` now take the field `Platforms` as part of the service `Placement`, allowing to specify platforms supported by the service.
 * `POST /containers/(name)/wait` now accepts a `condition` query parameter to indicate which state change condition to wait for. Also, response headers are now returned immediately to acknowledge that the server has registered a wait callback for the client.
-* `DELETE /secrets/(name)` now returns status code 404 instead of 500 when the secret does not exist.
-* `POST /secrets/create` now returns status code 409 instead of 500 when creating an already existing secret.
-* `POST /secrets/(name)/update` now returns status code 400 instead of 500 when updating a secret's content which is not the labels.
-* `POST /nodes/(name)/update` now returns status code 400 instead of 500 when demoting last node fails.
 
 ## v1.29 API changes
 

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -6,6 +6,10 @@ base="$ABS_DEST/.."
 export PATH="$base/binary-daemon:$base/dynbinary-daemon:$PATH"
 
 export TEST_CLIENT_BINARY=docker
+
+# Do not bump this version! Integration tests should no longer rely on the docker cli, they should be
+# API tests instead. For the existing tests the scripts will use a frozen version of the docker cli
+# with a DOCKER_API_VERSION frozen to 1.30, which should ensure that the CI remains green at all times.
 export DOCKER_API_VERSION=1.30
 if [ -n "$DOCKER_CLI_PATH" ]; then
 	export TEST_CLIENT_BINARY=/usr/local/cli/$(basename "$DOCKER_CLI_PATH")


### PR DESCRIPTION
With the Moby/Docker split, no decisions have been made yet how, and when to bump the API version.

Although these decisions should not be lead by Docker releases, I'm bumping the API version to not complicate things for now; after this bump we should make a plan how to handle this in future (for example, using SemVer for the REST api, and bump with every change).


ping @vieux @mlaventure PTAL
