### PR TITLE
Do not calculate size for local volumes with mount

### DIFF
--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -65,6 +65,13 @@ func (daemon *Daemon) SystemDiskUsage(ctx context.Context) (*types.DiskUsage, er
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
+			if d, ok := v.(volume.DetailedVolume); ok {
+				// skip local volumes with mount options since these could have external
+				// mounted filesystems that will be slow to enumerate.
+				if len(d.Options()) > 0 {
+					return nil
+				}
+			}
 			name := v.Name()
 			refs := daemon.volumes.Refs(v)
 


### PR DESCRIPTION
Local volumes support mount options which, when in use, can mount
external file systems. We don't really need to enumerate these external
filesystems which may be a very slow process.