### PR TITLE
Fix missing "--version" argument

### DIFF
--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -38,7 +38,7 @@ func (daemon *Daemon) FillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) 
 
 	v.RuncCommit.Expected = dockerversion.RuncCommitID
 	defaultRuntimeBinary := daemon.configStore.GetRuntime(daemon.configStore.GetDefaultRuntimeName()).Path
-	if rv, err := exec.Command(defaultRuntimeBinary).Output(); err == nil {
+	if rv, err := exec.Command(defaultRuntimeBinary, "--version").Output(); err == nil {
 		parts := strings.Split(strings.TrimSpace(string(rv)), "\n")
 		if len(parts) == 3 {
 			parts = strings.Split(parts[1], ": ")

--- a/integration-cli/docker_api_info_test.go
+++ b/integration-cli/docker_api_info_test.go
@@ -3,8 +3,11 @@ package main
 import (
 	"net/http"
 
+	"encoding/json"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/request"
+	"github.com/docker/docker/pkg/testutil"
 	"github.com/go-check/check"
 )
 
@@ -38,6 +41,25 @@ func (s *DockerSuite) TestInfoAPI(c *check.C) {
 	for _, linePrefix := range stringsToCheck {
 		c.Assert(out, checker.Contains, linePrefix)
 	}
+}
+
+// TestInfoAPIRuncCommit tests that dockerd is able to obtain RunC version
+// information, and that the version matches the expected version
+func (s *DockerSuite) TestInfoAPIRuncCommit(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Windows does not have RunC version information
+
+	res, body, err := request.Get("/v1.30/info")
+	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
+	c.Assert(err, checker.IsNil)
+
+	b, err := testutil.ReadBody(body)
+	c.Assert(err, checker.IsNil)
+
+	var i types.Info
+
+	c.Assert(json.Unmarshal(b, &i), checker.IsNil)
+	c.Assert(i.RuncCommit.ID, checker.Not(checker.Equals), "N/A")
+	c.Assert(i.RuncCommit.ID, checker.Equals, i.RuncCommit.Expected)
 }
 
 func (s *DockerSuite) TestInfoAPIVersioned(c *check.C) {


### PR DESCRIPTION
Commit 858b4b44c8172eb2c92767c8f624f4138db5212b (https://github.com/moby/moby/pull/33546) added support for obtaining the runtime version
if a custom path was set, but accidentally removed the `"--version"` flag.

This patch restores the flag.


fixes https://github.com/moby/moby/issues/33617
