### PR TITLE
Remove "-e" / "--email" from integration tests

### DIFF
--- a/integration-cli/docker_cli_login_test.go
+++ b/integration-cli/docker_cli_login_test.go
@@ -28,17 +28,3 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestLoginToPrivateRegistry(c *check.C)
 	// now it's fine
 	dockerCmd(c, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), privateRegistryURL)
 }
-
-func (s *DockerRegistryAuthHtpasswdSuite) TestLoginToPrivateRegistryDeprecatedEmailFlag(c *check.C) {
-	// Test to make sure login still works with the deprecated -e and --email flags
-	// wrong credentials
-	out, _, err := dockerCmdWithError("login", "-u", s.reg.Username(), "-p", "WRONGPASSWORD", "-e", s.reg.Email(), privateRegistryURL)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "401 Unauthorized")
-
-	// now it's fine
-	// -e flag
-	dockerCmd(c, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), "-e", s.reg.Email(), privateRegistryURL)
-	// --email flag
-	dockerCmd(c, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), "--email", s.reg.Email(), privateRegistryURL)
-}

--- a/integration-cli/docker_cli_registry_user_agent_test.go
+++ b/integration-cli/docker_cli_registry_user_agent_test.go
@@ -107,7 +107,7 @@ func (s *DockerRegistrySuite) TestUserAgentPassThrough(c *check.C) {
 	s.d.Cmd("build", "--file", dockerfileName, ".")
 	regexpCheckUA(c, buildUA)
 
-	s.d.Cmd("login", "-u", "richard", "-p", "testtest", "-e", "testuser@testdomain.com", loginReg.URL())
+	s.d.Cmd("login", "-u", "richard", "-p", "testtest", loginReg.URL())
 	regexpCheckUA(c, loginUA)
 
 	s.d.Cmd("pull", pullRepoName)

--- a/integration-cli/docker_cli_v2_only_test.go
+++ b/integration-cli/docker_cli_v2_only_test.go
@@ -60,7 +60,7 @@ func (s *DockerRegistrySuite) TestV2Only(c *check.C) {
 	s.d.Cmd("build", "--file", dockerfileName, ".")
 
 	s.d.Cmd("run", repoName)
-	s.d.Cmd("login", "-u", "richard", "-p", "testtest", "-e", "testuser@testdomain.com", reg.URL())
+	s.d.Cmd("login", "-u", "richard", "-p", "testtest", reg.URL())
 	s.d.Cmd("tag", "busybox", repoName)
 	s.d.Cmd("push", repoName)
 	s.d.Cmd("pull", repoName)


### PR DESCRIPTION
This option is no longer supported in docker 17.06, so should not be used.

Relates to https://github.com/docker/cli/pull/143

CI didn't catch this, because an older version of the CLI is used. Unfortunately, cherry-picking is done in the docker/docker-ce repository, so we cannot bump to the version that 17.06 will use, because it doesn't exist in the docker/cli repository.

ping @vdemeester @andrewhsu @seemethere PTAL