### PR TITLE
plugin/store.Get: return a specific error if plugin is disabled

### DIFF
--- a/plugin/store.go
+++ b/plugin/store.go
@@ -29,7 +29,7 @@ type ErrNotFound string
 
 func (name ErrNotFound) Error() string { return fmt.Sprintf("plugin %q not found", string(name)) }
 
-// ErrAmbiguous indicates that a plugin was not found locally.
+// ErrAmbiguous indicates that more than one plugin was found
 type ErrAmbiguous string
 
 func (name ErrAmbiguous) Error() string {

--- a/plugin/store.go
+++ b/plugin/store.go
@@ -36,6 +36,13 @@ func (name ErrAmbiguous) Error() string {
 	return fmt.Sprintf("multiple plugins found for %q", string(name))
 }
 
+// ErrDisabled indicates that a plugin was found but it is disabled
+type ErrDisabled string
+
+func (name ErrDisabled) Error() string {
+	return fmt.Sprintf("plugin %s found but disabled", string(name))
+}
+
 // GetV2Plugin retrieves a plugin by name, id or partial ID.
 func (ps *Store) GetV2Plugin(refOrID string) (*v2.Plugin, error) {
 	ps.RLock()
@@ -138,7 +145,7 @@ func (ps *Store) Get(name, capability string, mode int) (plugingetter.CompatPlug
 			}
 			// Plugin was found but it is disabled, so we should not fall back to legacy plugins
 			// but we should error out right away
-			return nil, ErrNotFound(name)
+			return nil, ErrDisabled(name)
 		}
 		if _, ok := errors.Cause(err).(ErrNotFound); !ok {
 			return nil, err


### PR DESCRIPTION
**- What I did**

Previously, a 'plugin not found' error would be returned if a plugin to be retrieved was found but disabled. This was misleading and incorrect. Now, a new error `plugin.ErrDisabled` is returned in this case. This makes the error message when trying to statically start plugins (from `daemon.json` or `dockerd` command line) accurate.

**- How I did it**

I created a new type alias `ErrDisabled` to mirror `ErrNotFound` and `ErrAmbiguous`. It satisfies the `error` interface.

**- How to verify it**

```
docker plugin install --grant-all-permissions riyaz/authz-no-volume-plugin
docker plugin disable riyaz/authz-no-volume-plugin
```

then restart `dockerd` and add `--authorization-plugin=riyaz/authz-no-volume-plugin` to the command line. `docker.log` will then have the "found but disabled" message instead of the "not found" message.

I tried to write a test for this but I couldn't figure out how to match on the daemon log error.

**- Description for the changelog**

Probably does not deserve a changelog entry but if you add one:

"Improved error message when trying to start daemon with installed but disabled plugin"

**- A picture of a cute animal (not mandatory but encouraged)**

![Suncus etruscus](https://upload.wikimedia.org/wikipedia/commons/thumb/f/ff/Suncus_etruscus.jpg/640px-Suncus_etruscus.jpg)
By Trebol-a - Own work, CC BY-SA 3.0, https://commons.wikimedia.org/w/index.php?curid=4607913

[*Suncus etruscus*](https://en.wikipedia.org/wiki/Etruscan_shrew), the Etruscan shrew, is the smallest known mammal by mass and consumes 1.5-2x its own body weight in food per day. It has a very high heart rate of up to 1511 beats/minute.