### PR TITLE
Disable auto-assigning PR's to milestones

### DIFF
--- a/poule.yml
+++ b/poule.yml
@@ -35,12 +35,6 @@
         }
       - type:       version-label
 
-# When a pull request is closed, attach it to the currently active milestone.
-- triggers:
-      pull_request: [ closed ]
-  operations:
-      - type:       version-milestone
-
 # Labeling a PR with `rebuild/<configuration>` triggers a rebuild job for the associated
 # configuration. The label is automatically removed after the rebuild is initiated. There's no such
 # thing as "templating" in this configuration, so we need one operation for each type of


### PR DESCRIPTION
Moby and Docker are separate projects, so don't assign docker milestones to pull requests in this repository.

/cc @aaronlehmann @vieux 
