### PR TITLE
Stop trying to load images on an incompatible OS

### DIFF
--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -79,6 +79,9 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 		if err != nil {
 			return err
 		}
+		if err := checkCompatibleOS(img.OS); err != nil {
+			return err
+		}
 		var rootFS image.RootFS
 		rootFS = *img.RootFS
 		rootFS.DiffIDs = nil
@@ -292,8 +295,15 @@ func (l *tarexporter) legacyLoadImage(oldID, sourceDir string, loadedMap map[str
 		return err
 	}
 
-	var img struct{ Parent string }
+	var img struct {
+		OS     string
+		Parent string
+	}
 	if err := json.Unmarshal(imageJSON, &img); err != nil {
+		return err
+	}
+
+	if err := checkCompatibleOS(img.OS); err != nil {
 		return err
 	}
 
@@ -401,4 +411,21 @@ func checkValidParent(img, parent *image.Image) bool {
 		}
 	}
 	return true
+}
+
+func checkCompatibleOS(os string) error {
+	// TODO @jhowardmsft LCOW - revisit for simultaneous platforms
+	platform := runtime.GOOS
+	if system.LCOWSupported() {
+		platform = "linux"
+	}
+	// always compatible if the OS matches; also match an empty OS
+	if os == platform || os == "" {
+		return nil
+	}
+	// for compatibility, only fail if the image or runtime OS is Windows
+	if os == "windows" || platform == "windows" {
+		return fmt.Errorf("cannot load %s image on %s", os, platform)
+	}
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: John Stephens <johnstep@docker.com>

This improves the error message when attempting to load an image on an incompatible OS.

Before:
```
Windows:
$ docker load -i alpine.tar
3fb66f713c9f: Loading layer [==================================================>]  4.221MB/4.221MB
re-exec error: exit status 1: output: ProcessBaseLayer C:\ProgramData\Docker\windowsfilter\0bd532c7245dab3d348403edae359732fa64bb2d5bd3ffad62e0240853db5477: The system cannot find the path specified.

Linux:
$ docker load -i nanoserver.tar
open /var/lib/docker/tmp/docker-import-911583298/932e9fb6732a2d14dee02c92a450e6adb13a9f14488a74e71a0fe3b48d16cab9\layer.tar: no such file or directory
```

After:
```
Windows:
$ docker load -i alpine.tar
cannot load linux image on windows

Linux:
$ docker load -i nanoserver.tar
cannot load windows image on linux
```

@dhiltgen @friism @jhowardmsft