### PR TITLE
Eliminate authz plugin disable race

### DIFF
--- a/pkg/authorization/middleware.go
+++ b/pkg/authorization/middleware.go
@@ -25,18 +25,10 @@ func NewMiddleware(names []string, pg plugingetter.PluginGetter) *Middleware {
 	}
 }
 
-// GetAuthzPlugins gets authorization plugins
-func (m *Middleware) GetAuthzPlugins() []Plugin {
+func (m *Middleware) getAuthzPlugins() []Plugin {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.plugins
-}
-
-// SetAuthzPlugins sets authorization plugins
-func (m *Middleware) SetAuthzPlugins(plugins []Plugin) {
-	m.mu.Lock()
-	m.plugins = plugins
-	m.mu.Unlock()
 }
 
 // SetPlugins sets the plugin used for authorization
@@ -62,7 +54,7 @@ func (m *Middleware) RemovePlugin(name string) {
 // WrapHandler returns a new handler function wrapping the previous one in the request chain.
 func (m *Middleware) WrapHandler(handler func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error) func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-		plugins := m.GetAuthzPlugins()
+		plugins := m.getAuthzPlugins()
 		if len(plugins) == 0 {
 			return handler(ctx, w, r, vars)
 		}
@@ -96,7 +88,7 @@ func (m *Middleware) WrapHandler(handler func(ctx context.Context, w http.Respon
 
 		// There's a chance that the authCtx.plugins was updated. One of the reasons
 		// this can happen is when an authzplugin is disabled.
-		plugins = m.GetAuthzPlugins()
+		plugins = m.getAuthzPlugins()
 		if len(plugins) == 0 {
 			logrus.Debug("There are no authz plugins in the chain")
 			return nil

--- a/pkg/authorization/middleware.go
+++ b/pkg/authorization/middleware.go
@@ -46,6 +46,19 @@ func (m *Middleware) SetPlugins(names []string) {
 	m.mu.Unlock()
 }
 
+// RemovePlugin removes a single plugin from this authz middleware chain
+func (m *Middleware) RemovePlugin(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	plugins := m.plugins[:0]
+	for _, authPlugin := range m.plugins {
+		if authPlugin.Name() != name {
+			plugins = append(plugins, authPlugin)
+		}
+	}
+	m.plugins = plugins
+}
+
 // WrapHandler returns a new handler function wrapping the previous one in the request chain.
 func (m *Middleware) WrapHandler(handler func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error) func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -60,14 +60,7 @@ func (pm *Manager) Disable(refOrID string, config *types.PluginDisableConfig) er
 
 	for _, typ := range p.GetTypes() {
 		if typ.Capability == authorization.AuthZApiImplements {
-			authzList := pm.config.AuthzMiddleware.GetAuthzPlugins()
-			for i, authPlugin := range authzList {
-				if authPlugin.Name() == p.Name() {
-					// Remove plugin from authzmiddleware chain
-					authzList = append(authzList[:i], authzList[i+1:]...)
-					pm.config.AuthzMiddleware.SetAuthzPlugins(authzList)
-				}
-			}
+			pm.config.AuthzMiddleware.RemovePlugin(p.Name())
 		}
 	}
 


### PR DESCRIPTION
**- What I did**

I eliminated a race during authz plugin removal from the middleware chain. Previously, it was possible for multiple authz plugin disable requests to interleave with some authz plugins marked disabled but still present in the middleware chain (due to overwrites).

**- How I did it**

I moved the entirety of the authz middleware chain filter into a critical section in an authz middleware chain method. I also simplified the filter operation, removed the now unused `SetAuthzPlugins` method, and made `GetAuthzPlugins` private `getAuthzPlugins`.

**- How to verify it**

The race is hard to trigger and basically impossible to write a reliable and efficient automated test for. The best way to confirm this is correct is careful reasoning and continued test suite success.

**- Description for the changelog**

I don't think this change is particularly changelog worthy but if you want to mention it:

"Eliminated authz plugin disable race that could result in authz plugins not being actually disabled"

**- A picture of a cute animal (not mandatory but encouraged)**

![Madame Berthe's mouse lemur](http://www.toptenz.net/wp-content/uploads/2014/05/Madame-Berthe-Mouse-Lemur.jpg)

[*Microcebus berthae*](https://en.wikipedia.org/wiki/Madame_Berthe%27s_mouse_lemur), Madame Berthe's mouse lemur, is the smallest primate in the world with an average body length of 9.2cm and seasonal weight of 30g. It's only found in one forest in Madagascar and is currently endangered.