### PR TITLE
Add checking stop/restart timeout is not negative

### DIFF
--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -18,7 +18,7 @@ func (daemon *Daemon) ContainerRestart(name string, seconds *int) error {
 	if err != nil {
 		return err
 	}
-	if seconds == nil {
+	if seconds == nil || *seconds < 0 {
 		stopTimeout := container.StopTimeout()
 		seconds = &stopTimeout
 	}

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -26,7 +26,7 @@ func (daemon *Daemon) ContainerStop(name string, seconds *int) error {
 		err := fmt.Errorf("Container %s is already stopped", name)
 		return errors.NewErrorWithStatusCode(err, http.StatusNotModified)
 	}
-	if seconds == nil {
+	if seconds == nil || *seconds < 0 {
 		stopTimeout := container.StopTimeout()
 		seconds = &stopTimeout
 	}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix a bug:
 When stop/restart container using -t flag and give an negative number, some time the operation will block.

To reproduce:
 1. docker run --name test -d ubuntu sleep 1000
 2. docker stop -t -1 test

sleep may be ignore stop signal, and can not exit, and `WaitForStop` will only wait the `stopChan` without timeout, and the stop operation will  never finish.


**- How I did it**

Add an check for negative number, if negative just use default timeout value.

**- How to verify it**

 1. docker run --name test -d ubuntu sleep 1000
 2. docker stop -t -1 test
stop won't block.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Signed-off-by: Wentao Zhang <zhangwentao234@huawei.com>

**- A picture of a cute animal (not mandatory but encouraged)**

