### PR TITLE
Add `PidsLimit` in swarm Resources.

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2108,6 +2108,10 @@ definitions:
                 description: "Memory limit in Bytes."
                 type: "integer"
                 format: "int64"
+              PidsLimit:
+                description: "PIDs limit in integers. Set to -1 for unlimited PIDs."
+                type: "integer"
+                format: "int64"
           Reservation:
             description: "Define resources reservation."
             properties:

--- a/api/types/swarm/task.go
+++ b/api/types/swarm/task.go
@@ -73,6 +73,7 @@ type TaskSpec struct {
 type Resources struct {
 	NanoCPUs    int64 `json:",omitempty"`
 	MemoryBytes int64 `json:",omitempty"`
+	PidsLimit   int64 `json:",omitempty"`
 }
 
 // ResourceRequirements represents resources requirements.

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -289,6 +289,7 @@ func resourcesFromGRPC(res *swarmapi.ResourceRequirements) *types.ResourceRequir
 			resources.Limits = &types.Resources{
 				NanoCPUs:    res.Limits.NanoCPUs,
 				MemoryBytes: res.Limits.MemoryBytes,
+				PidsLimit:   res.Limits.PidsLimit,
 			}
 		}
 		if res.Reservations != nil {
@@ -310,6 +311,7 @@ func resourcesToGRPC(res *types.ResourceRequirements) *swarmapi.ResourceRequirem
 			reqs.Limits = &swarmapi.Resources{
 				NanoCPUs:    res.Limits.NanoCPUs,
 				MemoryBytes: res.Limits.MemoryBytes,
+				PidsLimit:   res.Limits.PidsLimit,
 			}
 		}
 		if res.Reservations != nil {

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -435,6 +435,10 @@ func (c *containerConfig) resources() enginecontainer.Resources {
 		resources.CPUQuota = r.Limits.NanoCPUs * resources.CPUPeriod / 1e9
 	}
 
+	if r.Limits.PidsLimit > -1 {
+		resources.PidsLimit = r.Limits.PidsLimit
+	}
+
 	return resources
 }
 


### PR DESCRIPTION
Refer [docker/cli#181](https://github.com/docker/cli/pull/181)

Adds `PidsLimit` in:
  - `swarm.Resources` struct
  - swagger.yaml for swarm resources
  - `resourcesFromGRPC()` and `resourcesToGRPC()`
  - daemon cluster executor `containerConfig.resources()`

Signed-off-by: Sunny Gogoi <indiasuny000@gmail.com>

**- What I did**

Added `PidsLimit` to swarm Resources.

**- How I did it**

Refer commit message.

**- Description for the changelog**

Add `PidsLimit` to swarm Resources.