### PR TITLE
doc: Update 2017-06-12.md

### DIFF
--- a/reports/2017-06-12.md
+++ b/reports/2017-06-12.md
@@ -22,7 +22,7 @@ We should expect to do those changes after the moby summit. We contacted github 
 
 ### Custom golang URLs
 
-More discussions on the [forums]https://forums.mobyproject.org/t/cutoms-golang-urls), no agreement for now.
+More discussions on the [forums](https://forums.mobyproject.org/t/cutoms-golang-urls), no agreement for now.
 
 ### Buildkit
 


### PR DESCRIPTION
fix broken markdown. i hope this is primary source of the file not auto-copied from elsewhere.