### PR TITLE
Disable failfast when checking containerd health

### DIFF
--- a/libcontainerd/remote_unix.go
+++ b/libcontainerd/remote_unix.go
@@ -96,6 +96,8 @@ func New(stateDir string, options ...RemoteOption) (_ Remote, err error) {
 	// don't output the grpc reconnect logging
 	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
 	dialOpts := []grpc.DialOption{
+		grpc.WithBlock(),
+		grpc.WithTimeout(10 * time.Second),
 		grpc.WithInsecure(),
 		grpc.WithBackoffMaxDelay(2 * time.Second),
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {


### PR DESCRIPTION
This should ensure that we properly wait 3 secs on connection failure
before restarting the daemon.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

---

Mostly Fixes #33681. 

I think there's another issue where we lose an exit event somehow when `containerd` gets restarted very fast and a container dies until it stabilizes, but haven't been able to pinpoint the root cause atm.

**- What I did**

- Wait up to 10 secs the first time we start containerd
- Made it so we correctly wait for `containerdHealthCheckTimeout` before restarting containerd

**- How I did it**

- disabled `FailFast` when calling health check against `containerd`
- removed `maxConnectionRetryCount` since 9 secs is a bit long to wait for.

**- How to verify it**

- start `dockerd`
- kill `docker-containerd`
- `docker-containerd` should be restarted within 3.5 secs (500ms to take in account the ticker)

**- Description for the changelog**

Prevent fast restart of `containerd` on busy systems

**- A picture of a cute animal (not mandatory but encouraged)**

:cat: 
