### PR TITLE
Small fix and new option for contrib/mkimage_alpine.sh

### DIFF
--- a/contrib/mkimage-alpine.sh
+++ b/contrib/mkimage-alpine.sh
@@ -8,7 +8,7 @@ set -e
 }
 
 usage() {
-	printf >&2 '%s: [-r release] [-m mirror] [-s]  [-c additional repository]\n' "$0"
+	printf >&2 '%s: [-r release] [-m mirror] [-s] [-c additional repository] [-a arch]\n' "$0"
 	exit 1
 }
 
@@ -52,7 +52,7 @@ save() {
 	tar --numeric-owner -C $ROOTFS -c . | xz > rootfs.tar.xz
 }
 
-while getopts "hr:m:sc:" opt; do
+while getopts "hr:m:sc:a:" opt; do
 	case $opt in
 		r)
 			REL=$OPTARG
@@ -65,6 +65,9 @@ while getopts "hr:m:sc:" opt; do
 			;;
 		c)
 			ADDITIONALREPO=$OPTARG
+			;;
+		a)
+			ARCH=$OPTARG
 			;;
 		*)
 			usage

--- a/contrib/mkimage-alpine.sh
+++ b/contrib/mkimage-alpine.sh
@@ -52,7 +52,7 @@ save() {
 	tar --numeric-owner -C $ROOTFS -c . | xz > rootfs.tar.xz
 }
 
-while getopts "hr:m:s" opt; do
+while getopts "hr:m:sc:" opt; do
 	case $opt in
 		r)
 			REL=$OPTARG
@@ -64,7 +64,7 @@ while getopts "hr:m:s" opt; do
 			SAVE=1
 			;;
 		c)
-			ADDITIONALREPO=community
+			ADDITIONALREPO=$OPTARG
 			;;
 		*)
 			usage
@@ -76,7 +76,7 @@ REL=${REL:-edge}
 MIRROR=${MIRROR:-http://nl.alpinelinux.org/alpine}
 SAVE=${SAVE:-0}
 MAINREPO=$MIRROR/$REL/main
-ADDITIONALREPO=$MIRROR/$REL/community
+ADDITIONALREPO=$MIRROR/$REL/${ADDITIONALREPO:-community}
 ARCH=${ARCH:-$(uname -m)}
 
 tmp


### PR DESCRIPTION
With contrib/mkimage-alpine.sh it is now possible to:

1. Use the fixed parameter "-c" to set another additional repository.
2. Set the architecture manually if "uname -m" results in a different architecture string.
