### PR TITLE
Templated secrets and configs

### DIFF
--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -372,6 +372,10 @@ func (sr *swarmRouter) createSecret(ctx context.Context, w http.ResponseWriter, 
 	if err := json.NewDecoder(r.Body).Decode(&secret); err != nil {
 		return err
 	}
+	version := httputils.VersionFromContext(ctx)
+	if secret.Templating != nil && versions.LessThan(version, "1.36") {
+		return errdefs.InvalidParameter(errors.Errorf("secret templating is not supported on the specified API version: %s", version))
+	}
 
 	id, err := sr.backend.CreateSecret(secret)
 	if err != nil {
@@ -438,6 +442,11 @@ func (sr *swarmRouter) createConfig(ctx context.Context, w http.ResponseWriter, 
 	var config types.ConfigSpec
 	if err := json.NewDecoder(r.Body).Decode(&config); err != nil {
 		return err
+	}
+
+	version := httputils.VersionFromContext(ctx)
+	if config.Templating != nil && versions.LessThan(version, "1.36") {
+		return errdefs.InvalidParameter(errors.Errorf("config templating is not supported on the specified API version: %s", version))
 	}
 
 	id, err := sr.backend.CreateConfig(config)

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3339,17 +3339,12 @@ definitions:
         description: "Name of the secrets driver used to fetch the secret's value from an external secret store"
         $ref: "#/definitions/Driver"
       Templating:
-        description: "Templating driver, if applicable"
-        type: "object"
-        properties:
-          Name:
-            description: "Name of the templating driver (i.e. 'golang')"
-            type: "string"
-          Options:
-            description: "key/value map of driver specific options."
-            type: "object"
-            additionalProperties:
-              type: "string"
+        description: |
+          Templating driver, if applicable
+
+          Templating controls whether and how to evaluate the config payload as
+          a template. If no driver is set, no templating is used.
+        $ref: "#/definitions/Driver"
 
   Secret:
     type: "object"
@@ -3387,17 +3382,12 @@ definitions:
           config data.
         type: "string"
       Templating:
-        description: "Templating driver, if applicable"
-        type: "object"
-        properties:
-          Name:
-            description: "Name of the templating driver (i.e. 'golang')"
-            type: "string"
-          Options:
-            description: "key/value map of driver specific options."
-            type: "object"
-            additionalProperties:
-              type: "string"
+        description: |
+          Templating driver, if applicable
+
+          Templating controls whether and how to evaluate the config payload as
+          a template. If no driver is set, no templating is used.
+        $ref: "#/definitions/Driver"
 
   Config:
     type: "object"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3338,6 +3338,18 @@ definitions:
       Driver:
         description: "Name of the secrets driver used to fetch the secret's value from an external secret store"
         $ref: "#/definitions/Driver"
+      Templating:
+        description: "Templating driver, if applicable"
+        type: "object"
+        properties:
+          Name:
+            description: "Name of the templating driver (i.e. 'golang')"
+            type: "string"
+          Options:
+            description: "key/value map of driver specific options."
+            type: "object"
+            additionalProperties:
+              type: "string"
 
   Secret:
     type: "object"
@@ -3374,6 +3386,18 @@ definitions:
           Base64-url-safe-encoded ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-3.2))
           config data.
         type: "string"
+      Templating:
+        description: "Templating driver, if applicable"
+        type: "object"
+        properties:
+          Name:
+            description: "Name of the templating driver (i.e. 'golang')"
+            type: "string"
+          Options:
+            description: "key/value map of driver specific options."
+            type: "object"
+            additionalProperties:
+              type: "string"
 
   Config:
     type: "object"

--- a/api/types/swarm/config.go
+++ b/api/types/swarm/config.go
@@ -13,6 +13,10 @@ type Config struct {
 type ConfigSpec struct {
 	Annotations
 	Data []byte `json:",omitempty"`
+
+	// Templating controls whether and how to evaluate the config payload as
+	// a template. If it is not set, no templating is used.
+	Templating *Driver `json:",omitempty"`
 }
 
 // ConfigReferenceFileTarget is a file target in a config reference

--- a/api/types/swarm/secret.go
+++ b/api/types/swarm/secret.go
@@ -14,6 +14,10 @@ type SecretSpec struct {
 	Annotations
 	Data   []byte  `json:",omitempty"`
 	Driver *Driver `json:",omitempty"` // name of the secrets driver used to fetch the secret's value from an external secret store
+
+	// Templating controls whether and how to evaluate the secret payload as
+	// a template. If it is not set, no templating is used.
+	Templating *Driver `json:",omitempty"`
 }
 
 // SecretReferenceFileTarget is a file target in a secret reference

--- a/container/container.go
+++ b/container/container.go
@@ -68,13 +68,6 @@ type ExitStatus struct {
 	ExitedAt time.Time
 }
 
-// ConfigReference wraps swarmtypes.ConfigReference to add a Sensitive flag.
-type ConfigReference struct {
-	*swarmtypes.ConfigReference
-	// Sensitive is set if this config should not be written to disk.
-	Sensitive bool
-}
-
 // Container holds the structure defining a container object.
 type Container struct {
 	StreamConfig *stream.Config
@@ -106,7 +99,7 @@ type Container struct {
 	ExecCommands           *exec.Store                `json:"-"`
 	DependencyStore        agentexec.DependencyGetter `json:"-"`
 	SecretReferences       []*swarmtypes.SecretReference
-	ConfigReferences       []*ConfigReference
+	ConfigReferences       []*swarmtypes.ConfigReference
 	// logDriver for closing
 	LogDriver      logger.Logger  `json:"-"`
 	LogCopier      *logger.Copier `json:"-"`
@@ -1054,31 +1047,6 @@ func getSecretTargetPath(r *swarmtypes.SecretReference) string {
 	}
 
 	return filepath.Join(containerSecretMountPath, r.File.Name)
-}
-
-// ConfigsDirPath returns the path to the directory where configs are stored on
-// disk.
-func (container *Container) ConfigsDirPath() (string, error) {
-	return container.GetRootResourcePath("configs")
-}
-
-// ConfigFilePath returns the path to the on-disk location of a config.
-func (container *Container) ConfigFilePath(configRef swarmtypes.ConfigReference) (string, error) {
-	configs, err := container.ConfigsDirPath()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(configs, configRef.ConfigID), nil
-}
-
-// SensitiveConfigFilePath returns the path to the location of a config mounted
-// as a secret.
-func (container *Container) SensitiveConfigFilePath(configRef swarmtypes.ConfigReference) (string, error) {
-	secretMountPath, err := container.SecretMountPath()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(secretMountPath, configRef.ConfigID+"c"), nil
 }
 
 // CreateDaemonEnvironment creates a new environment variable slice for this container.

--- a/daemon/cluster/convert/config.go
+++ b/daemon/cluster/convert/config.go
@@ -2,6 +2,7 @@ package convert // import "github.com/docker/docker/daemon/cluster/convert"
 
 import (
 	swarmtypes "github.com/docker/docker/api/types/swarm"
+	types "github.com/docker/docker/api/types/swarm"
 	swarmapi "github.com/docker/swarmkit/api"
 	gogotypes "github.com/gogo/protobuf/types"
 )
@@ -21,18 +22,34 @@ func ConfigFromGRPC(s *swarmapi.Config) swarmtypes.Config {
 	config.CreatedAt, _ = gogotypes.TimestampFromProto(s.Meta.CreatedAt)
 	config.UpdatedAt, _ = gogotypes.TimestampFromProto(s.Meta.UpdatedAt)
 
+	if s.Spec.Templating != nil {
+		config.Spec.Templating = &types.Driver{
+			Name:    s.Spec.Templating.Name,
+			Options: s.Spec.Templating.Options,
+		}
+	}
+
 	return config
 }
 
 // ConfigSpecToGRPC converts Config to a grpc Config.
 func ConfigSpecToGRPC(s swarmtypes.ConfigSpec) swarmapi.ConfigSpec {
-	return swarmapi.ConfigSpec{
+	spec := swarmapi.ConfigSpec{
 		Annotations: swarmapi.Annotations{
 			Name:   s.Name,
 			Labels: s.Labels,
 		},
 		Data: s.Data,
 	}
+
+	if s.Templating != nil {
+		spec.Templating = &swarmapi.Driver{
+			Name:    s.Templating.Name,
+			Options: s.Templating.Options,
+		}
+	}
+
+	return spec
 }
 
 // ConfigReferencesFromGRPC converts a slice of grpc ConfigReference to ConfigReference

--- a/daemon/cluster/convert/secret.go
+++ b/daemon/cluster/convert/secret.go
@@ -2,6 +2,7 @@ package convert // import "github.com/docker/docker/daemon/cluster/convert"
 
 import (
 	swarmtypes "github.com/docker/docker/api/types/swarm"
+	types "github.com/docker/docker/api/types/swarm"
 	swarmapi "github.com/docker/swarmkit/api"
 	gogotypes "github.com/gogo/protobuf/types"
 )
@@ -22,12 +23,19 @@ func SecretFromGRPC(s *swarmapi.Secret) swarmtypes.Secret {
 	secret.CreatedAt, _ = gogotypes.TimestampFromProto(s.Meta.CreatedAt)
 	secret.UpdatedAt, _ = gogotypes.TimestampFromProto(s.Meta.UpdatedAt)
 
+	if s.Spec.Templating != nil {
+		secret.Spec.Templating = &types.Driver{
+			Name:    s.Spec.Templating.Name,
+			Options: s.Spec.Templating.Options,
+		}
+	}
+
 	return secret
 }
 
 // SecretSpecToGRPC converts Secret to a grpc Secret.
 func SecretSpecToGRPC(s swarmtypes.SecretSpec) swarmapi.SecretSpec {
-	return swarmapi.SecretSpec{
+	spec := swarmapi.SecretSpec{
 		Annotations: swarmapi.Annotations{
 			Name:   s.Name,
 			Labels: s.Labels,
@@ -35,6 +43,15 @@ func SecretSpecToGRPC(s swarmtypes.SecretSpec) swarmapi.SecretSpec {
 		Data:   s.Data,
 		Driver: driverToGRPC(s.Driver),
 	}
+
+	if s.Templating != nil {
+		spec.Templating = &swarmapi.Driver{
+			Name:    s.Templating.Name,
+			Options: s.Templating.Options,
+		}
+	}
+
+	return spec
 }
 
 // SecretReferencesFromGRPC converts a slice of grpc SecretReference to SecretReference

--- a/daemon/cluster/executor/container/executor.go
+++ b/daemon/cluster/executor/container/executor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/api/naming"
+	"github.com/docker/swarmkit/template"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
@@ -191,7 +192,7 @@ func (e *executor) Configure(ctx context.Context, node *api.Node) error {
 
 // Controller returns a docker container runner.
 func (e *executor) Controller(t *api.Task) (exec.Controller, error) {
-	dependencyGetter := agent.Restrict(e.dependencies, t)
+	dependencyGetter := template.NewTemplatedDependencyGetter(agent.Restrict(e.dependencies, t), t, nil)
 
 	// Get the node description from the executor field
 	e.mutex.Lock()

--- a/daemon/configs.go
+++ b/daemon/configs.go
@@ -2,6 +2,7 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	swarmtypes "github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/container"
 	"github.com/sirupsen/logrus"
 )
 
@@ -17,7 +18,9 @@ func (daemon *Daemon) SetContainerConfigReferences(name string, refs []*swarmtyp
 		return err
 	}
 
-	c.ConfigReferences = refs
+	for _, ref := range refs {
+		c.ConfigReferences = append(c.ConfigReferences, &container.ConfigReference{ConfigReference: ref})
+	}
 
 	return nil
 }

--- a/daemon/configs.go
+++ b/daemon/configs.go
@@ -2,7 +2,6 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	swarmtypes "github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/container"
 	"github.com/sirupsen/logrus"
 )
 
@@ -17,10 +16,6 @@ func (daemon *Daemon) SetContainerConfigReferences(name string, refs []*swarmtyp
 	if err != nil {
 		return err
 	}
-
-	for _, ref := range refs {
-		c.ConfigReferences = append(c.ConfigReferences, &container.ConfigReference{ConfigReference: ref})
-	}
-
+	c.ConfigReferences = append(c.ConfigReferences, refs...)
 	return nil
 }

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -167,7 +167,9 @@ func (daemon *Daemon) setupSecretDir(c *container.Container, hasSecretDir *bool)
 	}
 
 	if !*hasSecretDir {
-		daemon.createSecretDir(c)
+		if err := daemon.createSecretDir(c); err != nil {
+			return err
+		}
 		*hasSecretDir = true
 	}
 
@@ -329,7 +331,9 @@ func (daemon *Daemon) setupConfigDir(c *container.Container, hasSecretDir *bool)
 			configRef.Sensitive = true
 			fPath, err = c.SensitiveConfigFilePath(*configRef.ConfigReference)
 			if !*hasSecretDir {
-				daemon.createSecretDir(c)
+				if err := daemon.createSecretDir(c); err != nil {
+					return err
+				}
 				*hasSecretDir = true
 			}
 		} else {

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -51,7 +51,7 @@ func (daemon *Daemon) setupConfigDir(c *container.Container) (setupErr error) {
 			continue
 		}
 
-		fPath, err := c.ConfigFilePath(*configRef)
+		fPath, err := c.ConfigFilePath(*configRef.ConfigReference)
 		if err != nil {
 			return err
 		}

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -21,10 +21,7 @@ func (daemon *Daemon) setupConfigDir(c *container.Container) (setupErr error) {
 		return nil
 	}
 
-	localPath, err := c.ConfigsDirPath()
-	if err != nil {
-		return err
-	}
+	localPath := c.ConfigsDirPath()
 	logrus.Debugf("configs: setting up config dir: %s", localPath)
 
 	// create local config root
@@ -51,11 +48,7 @@ func (daemon *Daemon) setupConfigDir(c *container.Container) (setupErr error) {
 			continue
 		}
 
-		fPath, err := c.ConfigFilePath(*configRef.ConfigReference)
-		if err != nil {
-			return err
-		}
-
+		fPath := c.ConfigFilePath(*configRef)
 		log := logrus.WithFields(logrus.Fields{"name": configRef.File.Name, "path": fPath})
 
 		log.Debug("injecting config")

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -842,26 +842,13 @@ func (daemon *Daemon) createSpec(c *container.Container) (retSpec *specs.Spec, e
 		return nil, err
 	}
 
-	secretMountPath, err := c.SecretMountPath()
-	if err != nil {
-		return nil, err
-	}
-	configsMountPath, err := c.ConfigsDirPath()
-	if err != nil {
-		return nil, err
-	}
 	defer func() {
 		if err != nil {
-			daemon.cleanupSecretDir(secretMountPath)
-			daemon.cleanupSecretDir(configsMountPath)
+			daemon.cleanupSecretDir(c)
 		}
 	}()
 
 	if err := daemon.setupSecretDir(c); err != nil {
-		return nil, err
-	}
-
-	if err := daemon.setupConfigDir(c); err != nil {
 		return nil, err
 	}
 
@@ -885,12 +872,6 @@ func (daemon *Daemon) createSpec(c *container.Container) (retSpec *specs.Spec, e
 		return nil, err
 	}
 	ms = append(ms, secretMounts...)
-
-	configMounts, err := c.ConfigMounts()
-	if err != nil {
-		return nil, err
-	}
-	ms = append(ms, configMounts...)
 
 	sort.Sort(mounts(ms))
 	if err := setMounts(daemon, &s, c, ms); err != nil {

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -102,10 +102,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 		mounts = append(mounts, secretMounts...)
 	}
 
-	configMounts, err := c.ConfigMounts()
-	if err != nil {
-		return nil, err
-	}
+	configMounts := c.ConfigMounts()
 	if configMounts != nil {
 		mounts = append(mounts, configMounts...)
 	}

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"bytes"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -10,6 +12,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/swarm"
 	"github.com/docker/docker/internal/testutil"
+	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/gotestyourself/gotestyourself/skip"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -187,4 +190,131 @@ func TestConfigsUpdate(t *testing.T) {
 	insp.Spec.Data = []byte("TESTINGDATA2")
 	err = client.ConfigUpdate(ctx, configID, insp.Version, insp.Spec)
 	testutil.ErrorContains(t, err, "only updates to Labels are allowed")
+}
+
+func TestTemplatedConfig(t *testing.T) {
+	d := swarm.NewSwarm(t, testEnv)
+	defer d.Stop(t)
+
+	ctx := context.Background()
+	client := swarm.GetClient(t, d)
+
+	referencedSecretSpec := swarmtypes.SecretSpec{
+		Annotations: swarmtypes.Annotations{
+			Name: "referencedsecret",
+		},
+		Data: []byte("this is a secret"),
+	}
+	referencedSecret, err := client.SecretCreate(ctx, referencedSecretSpec)
+	assert.NoError(t, err)
+
+	referencedConfigSpec := swarmtypes.ConfigSpec{
+		Annotations: swarmtypes.Annotations{
+			Name: "referencedconfig",
+		},
+		Data: []byte("this is a config"),
+	}
+	referencedConfig, err := client.ConfigCreate(ctx, referencedConfigSpec)
+	assert.NoError(t, err)
+
+	configSpec := swarmtypes.ConfigSpec{
+		Annotations: swarmtypes.Annotations{
+			Name: "templated_config",
+		},
+		Templating: &swarmtypes.Driver{
+			Name: "golang",
+		},
+		Data: []byte("SERVICE_NAME={{.Service.Name}}\n" +
+			"{{secret \"referencedsecrettarget\"}}\n" +
+			"{{config \"referencedconfigtarget\"}}\n"),
+	}
+
+	templatedConfig, err := client.ConfigCreate(ctx, configSpec)
+	assert.NoError(t, err)
+
+	serviceID := swarm.CreateService(t, d,
+		swarm.ServiceWithConfig(
+			&swarmtypes.ConfigReference{
+				File: &swarmtypes.ConfigReferenceFileTarget{
+					Name: "/templated_config",
+					UID:  "0",
+					GID:  "0",
+					Mode: 0600,
+				},
+				ConfigID:   templatedConfig.ID,
+				ConfigName: "templated_config",
+			},
+		),
+		swarm.ServiceWithConfig(
+			&swarmtypes.ConfigReference{
+				File: &swarmtypes.ConfigReferenceFileTarget{
+					Name: "referencedconfigtarget",
+					UID:  "0",
+					GID:  "0",
+					Mode: 0600,
+				},
+				ConfigID:   referencedConfig.ID,
+				ConfigName: "referencedconfig",
+			},
+		),
+		swarm.ServiceWithSecret(
+			&swarmtypes.SecretReference{
+				File: &swarmtypes.SecretReferenceFileTarget{
+					Name: "referencedsecrettarget",
+					UID:  "0",
+					GID:  "0",
+					Mode: 0600,
+				},
+				SecretID:   referencedSecret.ID,
+				SecretName: "referencedsecret",
+			},
+		),
+		swarm.ServiceWithName("svc"),
+	)
+
+	var tasks []swarmtypes.Task
+	waitAndAssert(t, 60*time.Second, func(t *testing.T) bool {
+		tasks = swarm.GetRunningTasks(t, d, serviceID)
+		return len(tasks) > 0
+	})
+
+	task := tasks[0]
+	waitAndAssert(t, 60*time.Second, func(t *testing.T) bool {
+		if task.NodeID == "" || (task.Status.ContainerStatus == nil || task.Status.ContainerStatus.ContainerID == "") {
+			task, _, _ = client.TaskInspectWithRaw(context.Background(), task.ID)
+		}
+		return task.NodeID != "" && task.Status.ContainerStatus != nil && task.Status.ContainerStatus.ContainerID != ""
+	})
+
+	attach := swarm.ExecTask(t, d, task, types.ExecConfig{
+		Cmd:          []string{"/bin/cat", "/templated_config"},
+		AttachStdout: true,
+		AttachStderr: true,
+	})
+
+	buf := bytes.NewBuffer(nil)
+	_, err = stdcopy.StdCopy(buf, buf, attach.Reader)
+	require.NoError(t, err)
+
+	expect := "SERVICE_NAME=svc\n" +
+		"this is a secret\n" +
+		"this is a config\n"
+
+	assert.Equal(t, expect, buf.String())
+}
+
+func waitAndAssert(t *testing.T, timeout time.Duration, f func(*testing.T) bool) {
+	t.Helper()
+	after := time.After(timeout)
+	for {
+		select {
+		case <-after:
+			t.Fatalf("timed out waiting for condition")
+		default:
+		}
+		if f(t) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 }

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -292,15 +292,24 @@ func TestTemplatedConfig(t *testing.T) {
 		AttachStderr: true,
 	})
 
-	buf := bytes.NewBuffer(nil)
-	_, err = stdcopy.StdCopy(buf, buf, attach.Reader)
-	require.NoError(t, err)
-
 	expect := "SERVICE_NAME=svc\n" +
 		"this is a secret\n" +
 		"this is a config\n"
+	assertAttachedStream(t, attach, expect)
 
-	assert.Equal(t, expect, buf.String())
+	attach = swarm.ExecTask(t, d, task, types.ExecConfig{
+		Cmd:          []string{"mount"},
+		AttachStdout: true,
+		AttachStderr: true,
+	})
+	assertAttachedStream(t, attach, "tmpfs on /templated_config type tmpfs")
+}
+
+func assertAttachedStream(t *testing.T, attach types.HijackedResponse, expect string) {
+	buf := bytes.NewBuffer(nil)
+	_, err := stdcopy.StdCopy(buf, buf, attach.Reader)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), expect)
 }
 
 func waitAndAssert(t *testing.T, timeout time.Duration, f func(*testing.T) bool) {

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -1,10 +1,14 @@
 package swarm
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/internal/test/environment"
 	"github.com/stretchr/testify/require"
@@ -33,4 +37,122 @@ func NewSwarm(t *testing.T, testEnv *environment.Execution) *daemon.Swarm {
 
 	require.NoError(t, d.Init(swarmtypes.InitRequest{}))
 	return d
+}
+
+// ServiceSpecOpt is used with `CreateService` to pass in service spec modifiers
+type ServiceSpecOpt func(*swarmtypes.ServiceSpec)
+
+// CreateService creates a service on the passed in swarm daemon.
+func CreateService(t *testing.T, d *daemon.Swarm, opts ...ServiceSpecOpt) string {
+	spec := defaultServiceSpec()
+	for _, o := range opts {
+		o(&spec)
+	}
+
+	client := GetClient(t, d)
+
+	resp, err := client.ServiceCreate(context.Background(), spec, types.ServiceCreateOptions{})
+	require.NoError(t, err, "error creating service")
+	return resp.ID
+}
+
+func defaultServiceSpec() swarmtypes.ServiceSpec {
+	var spec swarmtypes.ServiceSpec
+	ServiceWithImage("busybox:latest")(&spec)
+	ServiceWithCommand([]string{"/bin/top"})(&spec)
+	ServiceWithReplicas(1)(&spec)
+	return spec
+}
+
+// ServiceWithImage sets the image to use for the service
+func ServiceWithImage(image string) func(*swarmtypes.ServiceSpec) {
+	return func(spec *swarmtypes.ServiceSpec) {
+		ensureContainerSpec(spec)
+		spec.TaskTemplate.ContainerSpec.Image = image
+	}
+}
+
+// ServiceWithCommand sets the command to use for the service
+func ServiceWithCommand(cmd []string) ServiceSpecOpt {
+	return func(spec *swarmtypes.ServiceSpec) {
+		ensureContainerSpec(spec)
+		spec.TaskTemplate.ContainerSpec.Command = cmd
+	}
+}
+
+// ServiceWithConfig adds the config reference to the service
+func ServiceWithConfig(configRef *swarmtypes.ConfigReference) ServiceSpecOpt {
+	return func(spec *swarmtypes.ServiceSpec) {
+		ensureContainerSpec(spec)
+		spec.TaskTemplate.ContainerSpec.Configs = append(spec.TaskTemplate.ContainerSpec.Configs, configRef)
+	}
+}
+
+// ServiceWithSecret adds the secret reference to the service
+func ServiceWithSecret(secretRef *swarmtypes.SecretReference) ServiceSpecOpt {
+	return func(spec *swarmtypes.ServiceSpec) {
+		ensureContainerSpec(spec)
+		spec.TaskTemplate.ContainerSpec.Secrets = append(spec.TaskTemplate.ContainerSpec.Secrets, secretRef)
+	}
+}
+
+// ServiceWithReplicas sets the replicas for the service
+func ServiceWithReplicas(n uint64) ServiceSpecOpt {
+	return func(spec *swarmtypes.ServiceSpec) {
+		spec.Mode = swarmtypes.ServiceMode{
+			Replicated: &swarmtypes.ReplicatedService{
+				Replicas: &n,
+			},
+		}
+	}
+}
+
+// ServiceWithName sets the name of the service
+func ServiceWithName(name string) ServiceSpecOpt {
+	return func(spec *swarmtypes.ServiceSpec) {
+		spec.Annotations.Name = name
+	}
+}
+
+// GetRunningTasks gets the list of running tasks for a service
+func GetRunningTasks(t *testing.T, d *daemon.Swarm, serviceID string) []swarmtypes.Task {
+	client := GetClient(t, d)
+
+	filterArgs := filters.NewArgs()
+	filterArgs.Add("desired-state", "running")
+	filterArgs.Add("service", serviceID)
+
+	options := types.TaskListOptions{
+		Filters: filterArgs,
+	}
+	tasks, err := client.TaskList(context.Background(), options)
+	require.NoError(t, err)
+	return tasks
+}
+
+// ExecTask runs the passed in exec config on the given task
+func ExecTask(t *testing.T, d *daemon.Swarm, task swarmtypes.Task, config types.ExecConfig) types.HijackedResponse {
+	client := GetClient(t, d)
+
+	ctx := context.Background()
+	resp, err := client.ContainerExecCreate(ctx, task.Status.ContainerStatus.ContainerID, config)
+	require.NoError(t, err, "error creating exec")
+
+	startCheck := types.ExecStartCheck{}
+	attach, err := client.ContainerExecAttach(ctx, resp.ID, startCheck)
+	require.NoError(t, err, "error attaching to exec")
+	return attach
+}
+
+func ensureContainerSpec(spec *swarmtypes.ServiceSpec) {
+	if spec.TaskTemplate.ContainerSpec == nil {
+		spec.TaskTemplate.ContainerSpec = &swarmtypes.ContainerSpec{}
+	}
+}
+
+// GetClient creates a new client for the passed in swarm daemon.
+func GetClient(t *testing.T, d *daemon.Swarm) client.APIClient {
+	client, err := client.NewClientWithOpts(client.WithHost((d.Sock())))
+	require.NoError(t, err)
+	return client
 }

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -1,8 +1,10 @@
 package secret
 
 import (
+	"bytes"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -10,6 +12,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/swarm"
 	"github.com/docker/docker/internal/testutil"
+	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/gotestyourself/gotestyourself/skip"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -231,4 +234,131 @@ func TestSecretsUpdate(t *testing.T) {
 	insp.Spec.Data = []byte("TESTINGDATA2")
 	err = client.SecretUpdate(ctx, secretID, insp.Version, insp.Spec)
 	testutil.ErrorContains(t, err, "only updates to Labels are allowed")
+}
+
+func TestTemplatedSecret(t *testing.T) {
+	d := swarm.NewSwarm(t, testEnv)
+	defer d.Stop(t)
+
+	ctx := context.Background()
+	client := swarm.GetClient(t, d)
+
+	referencedSecretSpec := swarmtypes.SecretSpec{
+		Annotations: swarmtypes.Annotations{
+			Name: "referencedsecret",
+		},
+		Data: []byte("this is a secret"),
+	}
+	referencedSecret, err := client.SecretCreate(ctx, referencedSecretSpec)
+	assert.NoError(t, err)
+
+	referencedConfigSpec := swarmtypes.ConfigSpec{
+		Annotations: swarmtypes.Annotations{
+			Name: "referencedconfig",
+		},
+		Data: []byte("this is a config"),
+	}
+	referencedConfig, err := client.ConfigCreate(ctx, referencedConfigSpec)
+	assert.NoError(t, err)
+
+	secretSpec := swarmtypes.SecretSpec{
+		Annotations: swarmtypes.Annotations{
+			Name: "templated_secret",
+		},
+		Templating: &swarmtypes.Driver{
+			Name: "golang",
+		},
+		Data: []byte("SERVICE_NAME={{.Service.Name}}\n" +
+			"{{secret \"referencedsecrettarget\"}}\n" +
+			"{{config \"referencedconfigtarget\"}}\n"),
+	}
+
+	templatedSecret, err := client.SecretCreate(ctx, secretSpec)
+	assert.NoError(t, err)
+
+	serviceID := swarm.CreateService(t, d,
+		swarm.ServiceWithSecret(
+			&swarmtypes.SecretReference{
+				File: &swarmtypes.SecretReferenceFileTarget{
+					Name: "templated_secret",
+					UID:  "0",
+					GID:  "0",
+					Mode: 0600,
+				},
+				SecretID:   templatedSecret.ID,
+				SecretName: "templated_secret",
+			},
+		),
+		swarm.ServiceWithConfig(
+			&swarmtypes.ConfigReference{
+				File: &swarmtypes.ConfigReferenceFileTarget{
+					Name: "referencedconfigtarget",
+					UID:  "0",
+					GID:  "0",
+					Mode: 0600,
+				},
+				ConfigID:   referencedConfig.ID,
+				ConfigName: "referencedconfig",
+			},
+		),
+		swarm.ServiceWithSecret(
+			&swarmtypes.SecretReference{
+				File: &swarmtypes.SecretReferenceFileTarget{
+					Name: "referencedsecrettarget",
+					UID:  "0",
+					GID:  "0",
+					Mode: 0600,
+				},
+				SecretID:   referencedSecret.ID,
+				SecretName: "referencedsecret",
+			},
+		),
+		swarm.ServiceWithName("svc"),
+	)
+
+	var tasks []swarmtypes.Task
+	waitAndAssert(t, 60*time.Second, func(t *testing.T) bool {
+		tasks = swarm.GetRunningTasks(t, d, serviceID)
+		return len(tasks) > 0
+	})
+
+	task := tasks[0]
+	waitAndAssert(t, 60*time.Second, func(t *testing.T) bool {
+		if task.NodeID == "" || (task.Status.ContainerStatus == nil || task.Status.ContainerStatus.ContainerID == "") {
+			task, _, _ = client.TaskInspectWithRaw(context.Background(), task.ID)
+		}
+		return task.NodeID != "" && task.Status.ContainerStatus != nil && task.Status.ContainerStatus.ContainerID != ""
+	})
+
+	attach := swarm.ExecTask(t, d, task, types.ExecConfig{
+		Cmd:          []string{"/bin/cat", "/run/secrets/templated_secret"},
+		AttachStdout: true,
+		AttachStderr: true,
+	})
+
+	buf := bytes.NewBuffer(nil)
+	_, err = stdcopy.StdCopy(buf, buf, attach.Reader)
+	require.NoError(t, err)
+
+	expect := "SERVICE_NAME=svc\n" +
+		"this is a secret\n" +
+		"this is a config\n"
+
+	assert.Equal(t, expect, buf.String())
+}
+
+func waitAndAssert(t *testing.T, timeout time.Duration, f func(*testing.T) bool) {
+	t.Helper()
+	after := time.After(timeout)
+	for {
+		select {
+		case <-after:
+			t.Fatalf("timed out waiting for condition")
+		default:
+		}
+		if f(t) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 }


### PR DESCRIPTION
This adds support for template expansion in secrets and configs, as added up stream in https://github.com/docker/swarmkit/pull/2133.

`SecretSpec` and `ConfigSpec` have a new optional `Templating` field. Currently, the only supported value is `golang` for go-style templates, but I imagine supporting other templating engines in the future, as Go-style templating is not especially familiar to Docker's target audience.

When templating is enabled, it's possible to expand information about the task and service (examples: `{{.Task.ID}}`, `{{env "VAR"}}`), and other secrets and configs available to the service (example: `{{secret "sometarget"}}`).

A few areas where this can be useful:

- Fill in information in a configuration file based on the task, service, or environment.
- Insert a secret such as a password into a configuration file, so the configuration file template can be managed separatly from the actual credential.
- Compose a secret from multiple secrets.

cc @diogomonica