### PR TITLE
Add support for git+ssh:// URLs for docker build

### DIFF
--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -155,5 +155,5 @@ func git(args ...string) ([]byte, error) {
 // isGitTransport returns true if the provided str is a git transport by inspecting
 // the prefix of the string for known protocols used in git.
 func isGitTransport(str string) bool {
-	return urlutil.IsURL(str) || strings.HasPrefix(str, "git://") || strings.HasPrefix(str, "git@")
+	return urlutil.IsURL(str) || strings.HasPrefix(str, "git://") || strings.HasPrefix(str, "git+ssh://") || strings.HasPrefix(str, "git@")
 }

--- a/pkg/urlutil/urlutil.go
+++ b/pkg/urlutil/urlutil.go
@@ -10,7 +10,7 @@ import (
 var (
 	validPrefixes = map[string][]string{
 		"url":       {"http://", "https://"},
-		"git":       {"git://", "github.com/", "git@"},
+		"git":       {"git://", "git+ssh://", "github.com/", "git@"},
 		"transport": {"tcp://", "tcp+tls://", "udp://", "unix://", "unixgram://"},
 	}
 	urlPathWithFragmentSuffix = regexp.MustCompile(".git(?:#.+)?$")

--- a/pkg/urlutil/urlutil_test.go
+++ b/pkg/urlutil/urlutil_test.go
@@ -6,11 +6,14 @@ var (
 	gitUrls = []string{
 		"git://github.com/docker/docker",
 		"git@github.com:docker/docker.git",
-		"git@bitbucket.org:atlassianlabs/atlassian-docker.git",
+		"git@bitbucket.org:atlassianlabs/atlassian-docker",
 		"https://github.com/docker/docker.git",
 		"http://github.com/docker/docker.git",
 		"http://github.com/docker/docker.git#branch",
 		"http://github.com/docker/docker.git#:dir",
+		"git+ssh://github.com/docker/docker",
+		"git+ssh://github.com/docker/docker.git#branch",
+		"git+ssh://github.com/docker/docker.git#:dir",
 	}
 	incompleteGitUrls = []string{
 		"github.com/docker/docker",


### PR DESCRIPTION
Support `git+ssh://address/path/to/repo.git` URLs (such as `git+ssh://github.com/moby/moby`), which makes ssh easier and more general (right now, there is some silly URL magic that only supports `git@foo:bar/repo.git`).

Fixes #29919 
Fixes #23932

After merging, we need to update https://github.com/docker/cli and the documentation.

