### PR TITLE
Redact swarm spec CA signing cert for usability reasons

### DIFF
--- a/daemon/cluster/convert/swarm.go
+++ b/daemon/cluster/convert/swarm.go
@@ -31,9 +31,10 @@ func SwarmFromGRPC(c swarmapi.Cluster) types.Swarm {
 					AutoLockManagers: c.Spec.EncryptionConfig.AutoLockManagers,
 				},
 				CAConfig: types.CAConfig{
-					// do not include the signing CA key (it should already be redacted via the swarm APIs)
-					SigningCACert: string(c.Spec.CAConfig.SigningCACert),
-					ForceRotate:   c.Spec.CAConfig.ForceRotate,
+					// do not include the signing CA cert or key (it should already be redacted via the swarm APIs) -
+					// the key because it's secret, and the cert because otherwise doing a get + update on the spec
+					// can cause issues because the key would be missing and the cert wouldn't
+					ForceRotate: c.Spec.CAConfig.ForceRotate,
 				},
 			},
 			TLSInfo: types.TLSInfo{


### PR DESCRIPTION
We currently redact the signing key for security reasons, but due to the general API usage flow of getting the swarm info, changing one piece of the spec, and then updating the whole spec as it was returned by the engine, this can cause issues because, since there is no signing key, swarm may think that the API client is trying to remove the key from the swarm.

If we redact the signing key, it makes sense for usability to redact the signing cert as well, which if `ForceRotate` also doesn't change, basically tells swarm "I'm ok with whatever the current root CA is, just leave it".

![cute](http://naldzgraphics.net/wp-content/uploads/2009/12/baby17.jpg)

(note that this isn't actually redacted in the vendored version of swarm yet, but https://github.com/docker/swarmkit/pull/2263 will do so - regardless, this redacts it in the info returned by the engine)

cc @aaronlehmann @jlhawn @diogomonica @andrewhsu @thaJeztah 