### PR TITLE
[Builder] Warn on empty continuation lines

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -255,6 +255,7 @@ func (b *Builder) build(source builder.Source, dockerfile *parser.Result) (*buil
 		return nil, errors.Errorf("failed to reach build target %s in Dockerfile", b.options.Target)
 	}
 
+	dockerfile.PrintWarnings(b.Stderr)
 	b.buildArgs.WarnOnUnusedBuildArgs(b.Stderr)
 
 	if dispatchState.imageID == "" {

--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -246,6 +246,14 @@ type Result struct {
 	Warnings    []string
 }
 
+// PrintWarnings to the writer
+func (r *Result) PrintWarnings(out io.Writer) {
+	if len(r.Warnings) == 0 {
+		return
+	}
+	fmt.Fprintf(out, strings.Join(r.Warnings, "\n")+"\n")
+}
+
 // Parse reads lines from a Reader, parses the lines into an AST and returns
 // the AST and escape token
 func Parse(rwc io.Reader) (*Result, error) {
@@ -311,7 +319,7 @@ func Parse(rwc io.Reader) (*Result, error) {
 		AST:         root,
 		Warnings:    warnings,
 		EscapeToken: d.escapeToken,
-		Platform: d.platformToken,
+		Platform:    d.platformToken,
 	}, nil
 }
 

--- a/builder/remotecontext/detect.go
+++ b/builder/remotecontext/detect.go
@@ -110,17 +110,13 @@ func newURLRemote(url string, dockerfilePath string, progressReader func(in io.R
 			return progressReader(rc), nil
 		},
 	})
-	if err != nil {
-		if err == dockerfileFoundErr {
-			res, err := parser.Parse(dockerfile)
-			if err != nil {
-				return nil, nil, err
-			}
-			return nil, res, nil
-		}
+	switch {
+	case err == dockerfileFoundErr:
+		res, err := parser.Parse(dockerfile)
+		return nil, res, err
+	case err != nil:
 		return nil, nil, err
 	}
-
 	return withDockerfileFromContext(c.(modifiableContext), dockerfilePath)
 }
 


### PR DESCRIPTION
Carry #29161
Related issues #29005 and #24693

Add a warning that support for empty continuation lines will be removed in a future release.