### PR TITLE
Add clarification to --privileged error message

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -550,7 +550,7 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 	// check for various conflicting options with user namespaces
 	if daemon.configStore.RemappedRoot != "" && hostConfig.UsernsMode.IsPrivate() {
 		if hostConfig.Privileged {
-			return warnings, fmt.Errorf("Privileged mode is incompatible with user namespaces")
+			return warnings, fmt.Errorf("Privileged mode is incompatible with user namespaces.  You must run the container in the host namespace when running privileged mode.")
 		}
 		if hostConfig.NetworkMode.IsHost() && !hostConfig.UsernsMode.IsHost() {
 			return warnings, fmt.Errorf("Cannot share the host's network namespace when user namespaces are enabled")


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added additional error message verbiage to --privilege error when user namespace is in play.  This will hopefully allow the user to figure out how to disable namespace usage.  Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1461573.

**- How I did it**
Added a second sentence to the error message.

**- How to verify it**
Enable user namespace and then issue 'docker run --privileged centos date' from the command line to see the new message.

**- Description for the changelog**
<!--
Added clarification to --privileged error message
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![cute_animal](https://user-images.githubusercontent.com/25613829/27255531-79239cae-536d-11e7-8a6d-9d2712df3484.jpg)


