### PR TITLE
Fix seccomp JSON format

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1483,7 +1483,7 @@ func (s *DockerDaemonSuite) TestRunSeccompJSONNoNameAndNames(c *check.C) {
 
 	out, err := s.d.Cmd("run", "--security-opt", "seccomp="+tmpFile.Name(), "busybox", "chmod", "777", ".")
 	c.Assert(err, check.NotNil)
-	c.Assert(out, checker.Contains, "'name' and 'names' were specified in the seccomp profile, use either 'name' or 'names'")
+	c.Assert(out, checker.Contains, "either one (not both) of 'name' or 'names' must be specified in the seccomp profile: ")
 }
 
 func (s *DockerDaemonSuite) TestRunSeccompJSONNoArchAndArchMap(c *check.C) {
@@ -1520,7 +1520,7 @@ func (s *DockerDaemonSuite) TestRunSeccompJSONNoArchAndArchMap(c *check.C) {
 
 	out, err := s.d.Cmd("run", "--security-opt", "seccomp="+tmpFile.Name(), "busybox", "chmod", "777", ".")
 	c.Assert(err, check.NotNil)
-	c.Assert(out, checker.Contains, "'architectures' and 'archMap' were specified in the seccomp profile, use either 'architectures' or 'archMap'")
+	c.Assert(out, checker.Contains, "either one (not both) of 'architectures' or 'archMap' must be specified in the seccomp profile")
 }
 
 func (s *DockerDaemonSuite) TestRunWithDaemonDefaultSeccompProfile(c *check.C) {

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -461,7 +461,7 @@
 			"comment": "",
 			"includes": {
 				"arches": [
-					"ppc64le"
+					"SCMP_ARCH_PPC64LE"
 				]
 			},
 			"excludes": {}
@@ -480,8 +480,8 @@
 			"comment": "",
 			"includes": {
 				"arches": [
-					"arm",
-					"arm64"
+					"SCMP_ARCH_ARM",
+					"SCMP_ARCH_AARCH64"
 				]
 			},
 			"excludes": {}
@@ -495,8 +495,8 @@
 			"comment": "",
 			"includes": {
 				"arches": [
-					"amd64",
-					"x32"
+					"SCMP_ARCH_X86_64",
+					"SCMP_ARCH_X32"
 				]
 			},
 			"excludes": {}
@@ -510,9 +510,9 @@
 			"comment": "",
 			"includes": {
 				"arches": [
-					"amd64",
-					"x32",
-					"x86"
+					"SCMP_ARCH_X86_64",
+					"SCMP_ARCH_X32",
+					"SCMP_ARCH_X86"
 				]
 			},
 			"excludes": {}
@@ -528,8 +528,8 @@
 			"comment": "",
 			"includes": {
 				"arches": [
-					"s390",
-					"s390x"
+					"SCMP_ARCH_S390",
+					"SCMP_ARCH_S390X"
 				]
 			},
 			"excludes": {}
@@ -594,8 +594,8 @@
 					"CAP_SYS_ADMIN"
 				],
 				"arches": [
-					"s390",
-					"s390x"
+					"SCMP_ARCH_S390",
+					"SCMP_ARCH_S390X"
 				]
 			}
 		},
@@ -615,8 +615,8 @@
 			"comment": "s390 parameter ordering for clone is different",
 			"includes": {
 				"arches": [
-					"s390",
-					"s390x"
+					"SCMP_ARCH_S390",
+					"SCMP_ARCH_S390X"
 				]
 			},
 			"excludes": {

--- a/profiles/seccomp/seccomp.go
+++ b/profiles/seccomp/seccomp.go
@@ -31,12 +31,21 @@ func LoadProfile(body string, rs *specs.Spec) (*specs.LinuxSeccomp, error) {
 }
 
 var nativeToSeccomp = map[string]types.Arch{
+	"x86":         types.ArchX86,
 	"amd64":       types.ArchX86_64,
+	"x32":         types.ArchX32,
+	"arm":         types.ArchARM,
 	"arm64":       types.ArchAARCH64,
+	"mips":        types.ArchMIPS,
 	"mips64":      types.ArchMIPS64,
 	"mips64n32":   types.ArchMIPS64N32,
+	"mipsel":      types.ArchMIPSEL,
 	"mipsel64":    types.ArchMIPSEL64,
 	"mipsel64n32": types.ArchMIPSEL64N32,
+	"ppc":         types.ArchPPC,
+	"ppc64":       types.ArchPPC64,
+	"ppc64le":     types.ArchPPC64LE,
+	"s390":        types.ArchS390,
 	"s390x":       types.ArchS390X,
 }
 

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -420,7 +420,7 @@ func DefaultProfile() *types.Seccomp {
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},
 			Includes: types.Filter{
-				Arches: []string{"ppc64le"},
+				Arches: []string{string(types.ArchPPC64LE)},
 			},
 		},
 		{
@@ -435,7 +435,7 @@ func DefaultProfile() *types.Seccomp {
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},
 			Includes: types.Filter{
-				Arches: []string{"arm", "arm64"},
+				Arches: []string{string(types.ArchARM), string(types.ArchAARCH64)},
 			},
 		},
 		{
@@ -445,7 +445,7 @@ func DefaultProfile() *types.Seccomp {
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},
 			Includes: types.Filter{
-				Arches: []string{"amd64", "x32"},
+				Arches: []string{string(types.ArchX86_64), string(types.ArchX32)},
 			},
 		},
 		{
@@ -455,7 +455,7 @@ func DefaultProfile() *types.Seccomp {
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},
 			Includes: types.Filter{
-				Arches: []string{"amd64", "x32", "x86"},
+				Arches: []string{string(types.ArchX86_64), string(types.ArchX32), string(types.ArchX86)},
 			},
 		},
 		{
@@ -467,7 +467,7 @@ func DefaultProfile() *types.Seccomp {
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},
 			Includes: types.Filter{
-				Arches: []string{"s390", "s390x"},
+				Arches: []string{string(types.ArchS390), string(types.ArchS390X)},
 			},
 		},
 		{
@@ -517,7 +517,7 @@ func DefaultProfile() *types.Seccomp {
 			},
 			Excludes: types.Filter{
 				Caps:   []string{"CAP_SYS_ADMIN"},
-				Arches: []string{"s390", "s390x"},
+				Arches: []string{string(types.ArchS390), string(types.ArchS390X)},
 			},
 		},
 		{
@@ -535,7 +535,7 @@ func DefaultProfile() *types.Seccomp {
 			},
 			Comment: "s390 parameter ordering for clone is different",
 			Includes: types.Filter{
-				Arches: []string{"s390", "s390x"},
+				Arches: []string{string(types.ArchS390), string(types.ArchS390X)},
 			},
 			Excludes: types.Filter{
 				Caps: []string{"CAP_SYS_ADMIN"},

--- a/profiles/seccomp/seccomp_test.go
+++ b/profiles/seccomp/seccomp_test.go
@@ -4,6 +4,7 @@ package seccomp
 
 import (
 	"io/ioutil"
+	"reflect"
 	"testing"
 
 	"github.com/docker/docker/oci"
@@ -29,4 +30,31 @@ func TestLoadDefaultProfile(t *testing.T) {
 	if _, err := LoadProfile(string(f), &rs); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestGetSeccompArch(t *testing.T) {
+	if _, err := getSeccompArch(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestSupportLegacyArchID(t *testing.T) {
+	f := func(input, expected []string) {
+		output := supportLegacyArchID(input)
+		if !reflect.DeepEqual(expected, output) {
+			t.Errorf("%v != %v <= %v", expected, output, input)
+		}
+	}
+
+	f([]string{"SCMP_ARCH_X86", "SCMP_ARCH_X86_64"},
+		[]string{"SCMP_ARCH_X86", "SCMP_ARCH_X86_64"})
+	f([]string{}, []string{})
+	f([]string{"arm64", "SCMP_ARCH_X86", "SCMP_ARCH_X86_64"},
+		[]string{"SCMP_ARCH_AARCH64", "SCMP_ARCH_X86", "SCMP_ARCH_X86_64"})
+	f([]string{"SCMP_ARCH_X86", "arm64", "SCMP_ARCH_X86_64"},
+		[]string{"SCMP_ARCH_X86", "SCMP_ARCH_AARCH64", "SCMP_ARCH_X86_64"})
+	f([]string{"SCMP_ARCH_X86", "SCMP_ARCH_X86_64", "arm64"},
+		[]string{"SCMP_ARCH_X86", "SCMP_ARCH_X86_64", "SCMP_ARCH_AARCH64"})
+	f([]string{"SCMP_ARCH_X86", "SCMP_ARCH_X86_64", "arm64", "s390"},
+		[]string{"SCMP_ARCH_X86", "SCMP_ARCH_X86_64", "SCMP_ARCH_AARCH64", "SCMP_ARCH_S390"})
 }


### PR DESCRIPTION
**- What I did**

Changed the architecture ID format accepted by part of seccomp JSON config so that it is consistent with another, more often-used part of the same config

**- How I did it**

Modified `profile/seccomp/*.go` (see individual commit messages for more details)

**- How to verify it**

`make test-integration-cli`

**- Description for the changelog**

Use the libseccomp architecture ID format throughout the seccomp config (corrects #24510)