### PR TITLE
container: update real-time resources

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -332,6 +332,12 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 	if resources.KernelMemory != 0 {
 		cResources.KernelMemory = resources.KernelMemory
 	}
+	if resources.CPURealtimePeriod != 0 {
+		cResources.CPURealtimePeriod = resources.CPURealtimePeriod
+	}
+	if resources.CPURealtimeRuntime != 0 {
+		cResources.CPURealtimeRuntime = resources.CPURealtimeRuntime
+	}
 
 	// update HostConfig of container
 	if hostConfig.RestartPolicy.Name != "" {


### PR DESCRIPTION
CPU real-time period and runtime are actually sent as part of an update
command via the cli:

https://github.com/docker/cli/blob/master/cli/command/container/update.go#L20-L21

This patch makes update effective because, until now, those settings
weren't actually updated in a container.

Tested in on a real-time kernel, this fixes the issue. Can't add a test
though as I don't think CI has rt kernels enabled.

Reproducer on a rt kernel:

```
root@xxx ~]# docker run -p 9090:9090 -itd --cpu-rt-runtime=790000
--ulimit rtprio=99 --cap-add=sys_nice mytest
[root@xxx ~]# docker exec -it awesome_edison /bin/bash
[root@451a1aa4fd46 /]# cat /sys/fs/cgroup/cpu/cpu.rt_runtime_us
790000

[root@xxx ~]# docker update --cpu-rt-runtime=810000 awesome_edison
awesome_edison
[root@xxx ~]# docker exec -it awesome_edison /bin/bash
[root@451a1aa4fd46 /]# cat /sys/fs/cgroup/cpu/cpu.rt_runtime_us
790000

[root@xxx ~]# echo 811000 >
/sys/fs/cgroup/cpu/system.slice/docker-451a1aa4fd468f3b67783c23d00e70558183456c775119484319c3f17d49e409.scope/cpu.rt_runtime_us
[root@xxx ~]# docker exec -it awesome_edison /bin/bash
[root@451a1aa4fd46 /]# cat /sys/fs/cgroup/cpu/cpu.rt_runtime_us
811000
```

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

