### PR TITLE
Show what cross-build is executing

### DIFF
--- a/hack/make/cross
+++ b/hack/make/cross
@@ -29,6 +29,7 @@ for platform in $DOCKER_CROSSPLATFORMS; do
 		if [ "$GOOS" != "solaris" ]; then
 			# TODO. Solaris cannot be cross build because of CGO calls.
 
+			echo "Cross building: $DEST"
 			# go install docker/docker/pkg packages to ensure that
 			# they build cross platform.
 			go install github.com/docker/docker/pkg/...


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@tianon @crosbymichael - While working on https://github.com/moby/moby/pull/33241, I have been tearing my hair out trying to figure out what exactly was being executed when I was seeing CI failures on janky/experimental. It turned out that it was during the cross-compilation step of client binaries, but there was nothing to indicate in the output that was being done.

Hence added a simple echo to help anyone else who might hit this.