### PR TITLE
AppArmor: use pipe for loading default profile

### DIFF
--- a/profiles/apparmor/apparmor.go
+++ b/profiles/apparmor/apparmor.go
@@ -5,8 +5,8 @@ package apparmor
 import (
 	"bufio"
 	"io"
-	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"strings"
 
@@ -70,21 +70,23 @@ func InstallDefault(name string) error {
 		Name: name,
 	}
 
-	// Install to a temporary directory.
-	f, err := ioutil.TempFile("", name)
+	cmd := exec.Command("apparmor_parser", "-Kr")
+	pipe, err := cmd.StdinPipe()
 	if err != nil {
 		return err
 	}
-	profilePath := f.Name()
-
-	defer f.Close()
-	defer os.Remove(profilePath)
-
-	if err := p.generateDefault(f); err != nil {
+	if err := cmd.Start(); err != nil {
+		pipe.Close()
+		return err
+	}
+	if err := p.generateDefault(pipe); err != nil {
+		pipe.Close()
+		cmd.Wait()
 		return err
 	}
 
-	return aaparser.LoadProfile(profilePath)
+	pipe.Close()
+	return cmd.Wait()
 }
 
 // IsLoaded checks if a profile with the given name has been loaded into the

--- a/profiles/apparmor/apparmor_test.go
+++ b/profiles/apparmor/apparmor_test.go
@@ -1,0 +1,58 @@
+// +build linux
+
+package apparmor
+
+import (
+	"os"
+	"testing"
+)
+
+func TestInstallDefault(t *testing.T) {
+	const profile = "test-apparmor-default"
+	const aapath = "/sys/kernel/security/apparmor/"
+
+	if _, err := os.Stat(aapath); err != nil {
+		t.Skip("AppArmor isn't available in this environment")
+	}
+
+	// removes `profile`
+	removeProfile := func() error {
+		path := aapath + ".remove"
+
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		_, err = f.WriteString(profile)
+		return err
+	}
+
+	// makes sure `profile` is loaded according to `state`
+	checkLoaded := func(state bool) {
+		loaded, err := IsLoaded(profile)
+		if err != nil {
+			t.Fatalf("Error searching AppArmor profile '%s': %v", profile, err)
+		}
+		if state != loaded {
+			if state {
+				t.Fatalf("AppArmor profile '%s' isn't loaded but should", profile)
+			} else {
+				t.Fatalf("AppArmor profile '%s' is loaded but shouldn't", profile)
+			}
+		}
+	}
+
+	// test installing the profile
+	if err := InstallDefault(profile); err != nil {
+		t.Fatalf("Couldn't install AppArmor profile '%s': %v", profile, err)
+	}
+	checkLoaded(true)
+
+	// remove the profile and check again
+	if err := removeProfile(); err != nil {
+		t.Fatalf("Couldn't remove AppArmor profile '%s': %v", profile, err)
+	}
+	checkLoaded(false)
+}


### PR DESCRIPTION
Use a pipe to load/install the default AppArmor profile instead of using a temporary file. A pipe is faster, more generic and can be useful for future changes.

Add an additional test case to test and demonstrate the functionality.

**- What I did**
Use a pipe instead of a tmp file for loading the default AppArmor profile.

**- How I did it**
Write to the stdin pipe of `apparmor_parser`.

**- How to verify it**
I added a test case which loads and removes a default profile and checks for its presence before and after.

**- Description for the changelog**
AppArmor: use pipe for loading default profile