### PR TITLE
Fix mem leak in libcontainerd/queue/append

### DIFF
--- a/libcontainerd/queue_unix.go
+++ b/libcontainerd/queue_unix.go
@@ -27,5 +27,11 @@ func (q *queue) append(id string, f func()) {
 		}
 		f()
 		close(done)
+
+		q.Lock()
+		if q.fns[id] == done {
+			delete(q.fns, id)
+		}
+		q.Unlock()
 	}()
 }

--- a/libcontainerd/queue_unix_test.go
+++ b/libcontainerd/queue_unix_test.go
@@ -1,0 +1,33 @@
+// +build linux solaris
+
+package libcontainerd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerialization(t *testing.T) {
+	var (
+		q             queue
+		serialization = 1
+	)
+
+	q.append("aaa", func() {
+		//simulate a long time task
+		time.Sleep(10 * time.Millisecond)
+		require.EqualValues(t, serialization, 1)
+		serialization = 2
+	})
+	q.append("aaa", func() {
+		require.EqualValues(t, serialization, 2)
+		serialization = 3
+	})
+	q.append("aaa", func() {
+		require.EqualValues(t, serialization, 3)
+		serialization = 4
+	})
+	time.Sleep(20 * time.Millisecond)
+}


### PR DESCRIPTION
For every container,  queue' append interface add a element to q.fns,and it will never be removed.
this pr will  fix it ,and with the following code ,we can see the approach.
```
package main

import (
	"fmt"
	"os/exec"
	"time"
	"runtime/debug"
	"crypto/rand"
)

//copy code from libcontainerd/queue_unix.go
typedef queue{
	...
}

func (q *queue) append(id string, f func()) {
    ...
}

func randID(n int) string{
    b := make([]byte, n)
    if _, err := rand.Read(b); err != nil {
        return "369027c8aaa7b671214abfda8a3ac34b434f27c0bb33d35c4c25b9468bc1fc43"
    }
    return fmt.Sprintf("%x", b)
}

func main(){
	const (
		NUM = 1000000
	)
	var (
	
		q queue
		count = 0	
	)
	for i:= 0; i< NUM; i++{
		q.Append(randID(32), func(){
			count++
		})
	}
	for done:= false; done != false; {
		select {
			case <-time.After(time.Millisecond):
				if count == NUM{
					done = true
			}
		}
	}
	debug.FreeOSMemory()
	
	argv := []string{"-c", "smem|grep queue",}
	c := exec.Command("/bin/bash", argv...)
	d, _ := c.Output()
	fmt.Println(string(d)) 	
}
```
### Before this pr,
![1](https://user-images.githubusercontent.com/11223367/27374877-f4d5e5b6-569f-11e7-9d74-3a418e4f4a1d.JPG)

### After this pr,
![2](https://user-images.githubusercontent.com/11223367/27374896-0120dd30-56a0-11e7-995c-584ab4f47b0a.JPG)


Signed-off-by: yangshukui <yangshukui@huawei.com>