### PR TITLE
Don't json marshal then immediately unmarshal

### DIFF
--- a/libcontainerd/client_unix.go
+++ b/libcontainerd/client_unix.go
@@ -83,8 +83,7 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 	if err := json.NewEncoder(f).Encode(spec); err != nil {
 		return err
 	}
-
-	return container.start(checkpoint, checkpointDir, attachStdio)
+	return container.start(&spec, checkpoint, checkpointDir, attachStdio)
 }
 
 func (clnt *client) Signal(containerID string, sig int) error {

--- a/libcontainerd/container_unix.go
+++ b/libcontainerd/container_unix.go
@@ -90,12 +90,7 @@ func (ctr *container) spec() (*specs.Spec, error) {
 	return &spec, nil
 }
 
-func (ctr *container) start(checkpoint string, checkpointDir string, attachStdio StdioCallback) (err error) {
-	spec, err := ctr.spec()
-	if err != nil {
-		return nil
-	}
-
+func (ctr *container) start(spec *specs.Spec, checkpoint, checkpointDir string, attachStdio StdioCallback) (err error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ready := make(chan struct{})
@@ -172,6 +167,7 @@ func (ctr *container) start(checkpoint string, checkpointDir string, attachStdio
 			State: StateStart,
 			Pid:   ctr.systemPid,
 		}})
+
 }
 
 func (ctr *container) newProcess(friendlyName string) *process {


### PR DESCRIPTION
During container startup we end up spending a fair amount of time
encoding/decoding json.
This cuts out some of that since we already have the decoded object in
memory.

The old flow looked like:

1. Start container request
2. Create file
3. Encode container spec to json
4. Write to file
5. Close file
6. Open file
7. Read file
8. Decode container spec
9. Close file
10. Send to containerd.

The new flow cuts out steps 6-9 completely, and with it a lot of time
spent in reflect and file IO.