### PR TITLE
Prevent a goroutine leak when healthcheck gets stopped

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -186,7 +186,7 @@ func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe)
 			logrus.Debugf("Running health check for container %s ...", c.ID)
 			startTime := time.Now()
 			ctx, cancelProbe := context.WithTimeout(context.Background(), probeTimeout)
-			results := make(chan *types.HealthcheckResult)
+			results := make(chan *types.HealthcheckResult, 1)
 			go func() {
 				healthChecksCounter.Inc()
 				result, err := probe.run(ctx, d, c)
@@ -209,8 +209,10 @@ func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe)
 			select {
 			case <-stop:
 				logrus.Debugf("Stop healthcheck monitoring for container %s (received while probing)", c.ID)
-				// Stop timeout and kill probe, but don't wait for probe to exit.
 				cancelProbe()
+				// Wait for probe to exit (it might take a while to respond to the TERM
+				// signal and we don't want dying probes to pile up).
+				<-results
 				return
 			case result := <-results:
 				handleProbeResult(d, c, result, stop)


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

--- 

ping @talex5 I couldn't understand why we don't want to wait for the probe to exit here, so I just put it in a go routine. However, the code is waiting if the context is cancelled a few lines below, can the same be done here?

**- What I did**

Prevent a go routine leak when a probe has been started and we're asked to stop healthchecks

**- How I did it**

Started a goroutine that will wait on the channel

**- How to verify it**

**- Description for the changelog**

Fix a case were healthcheck could leak a goroutine

**- A picture of a cute animal (not mandatory but encouraged)**

:dog: 
