### PR TITLE
LCOW: Updates necessary due to platform schema change

### DIFF
--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -299,7 +299,9 @@ func (clnt *client) createLinux(containerID string, checkpoint string, checkpoin
 		Owner:         defaultOwner,
 		TerminateOnLastHandleClosed: true,
 		HvRuntime: &hcsshim.HvRuntime{
-			ImagePath: `c:\program files\lcow`,
+			ImagePath:       `c:\program files\lcow`,
+			LinuxKernelFile: `bootx64.efi`,
+			LinuxInitrdFile: `initrd.img`,
 		},
 	}
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -8,7 +8,7 @@ github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git
 github.com/gorilla/context v1.1
 github.com/gorilla/mux v1.1
-github.com/jhowardmsft/opengcs v0.0.3
+github.com/jhowardmsft/opengcs v0.0.4
 github.com/kr/pty 5cf931ef8f
 github.com/mattn/go-shellwords v1.0.3
 github.com/tchap/go-patricia v2.2.6

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,6 +1,6 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm 388960b655244e76e24c75f48631564eaefade62
-github.com/Microsoft/hcsshim v0.5.23
+github.com/Microsoft/hcsshim v0.5.25
 github.com/Microsoft/go-winio v0.4.2
 github.com/Sirupsen/logrus v0.11.0
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76

--- a/vendor/github.com/Microsoft/hcsshim/interface.go
+++ b/vendor/github.com/Microsoft/hcsshim/interface.go
@@ -11,6 +11,7 @@ import (
 type ProcessConfig struct {
 	ApplicationName   string            `json:",omitempty"`
 	CommandLine       string            `json:",omitempty"`
+	CommandArgs       []string          `json:",omitempty"` // Used by Linux Containers on Windows
 	User              string            `json:",omitempty"`
 	WorkingDirectory  string            `json:",omitempty"`
 	Environment       map[string]string `json:",omitempty"`
@@ -39,8 +40,8 @@ type MappedDir struct {
 type HvRuntime struct {
 	ImagePath       string `json:",omitempty"`
 	SkipTemplate    bool   `json:",omitempty"`
-	LinuxInitrdPath string `json:",omitempty"` // Host path to an initrd image for starting a Linux utility VM
-	LinuxKernelPath string `json:",omitempty"` // Host path to kernel for starting a Linux utility VM
+	LinuxInitrdFile string `json:",omitempty"` // File under ImagePath on host containing an initrd image for starting a Linux utility VM
+	LinuxKernelFile string `json:",omitempty"` // File under ImagePath on host containing a kernel for starting a Linux utility VM
 }
 
 type MappedVirtualDisk struct {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

The HCS API in the platform has just been updated. This revendors HCSShim and opengcs with the updated schema, and updates libcontainerd in docker to match. Manually verified internally (there are no public builds which are available)

@johnstep 