### PR TITLE
Fix autogen vars

### DIFF
--- a/hack/make/build-integration-test-binary
+++ b/hack/make/build-integration-test-binary
@@ -4,6 +4,8 @@ set -e
 rm -rf "$DEST"
 DEST="$ABS_DEST/../test-integration-cli"
 
+source "$SCRIPTDIR/make/.go-autogen"
+
 if [ -z $DOCKER_INTEGRATION_TESTS_VERIFIED ]; then
 	source ${MAKEDIR}/.integration-test-helpers
 	ensure_test_dir integration-cli "$DEST/test.main"


### PR DESCRIPTION
commit ea2e4d73c4c753cdc99966e4dfe35143e79564ce removed the autogen
script, but if you happen to do a fresh clone of the repo you can't
build the integration-cli tests.

Signed-off-by: Christy Perez <christy@linux.vnet.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

clone the moby dir into a brand new dir, and run `make binary test-integration-cli`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Failure seen: 

```
06:38:09 ---> Making bundle: build-integration-test-binary (in bundles/17.06.0-dev/build-integration-test-binary)
06:38:09 Building test dir: integration-cli
06:38:09 ++ cd integration-cli
06:38:09 ++ go test -c -o /go/src/github.com/docker/docker/bundles/17.06.0-dev/build-integration-test-binary/../test-integration-cli/test.main -ldflags -w -tags 'autogen netgo static_build apparmor seccomp selinux journald libdm_no_deferred_remove' -installsuffix netgo -i
06:38:15 # github.com/docker/docker/dockerversion
06:38:15 ../dockerversion/useragent.go:20:83: undefined: Version
06:38:15 ../dockerversion/useragent.go:22:87: undefined: GitCommit
```

**- A picture of a cute animal (not mandatory but encouraged)**

