### PR TITLE
LCOW: pass command arguments without extra quoting

### DIFF
--- a/daemon/exec_windows.go
+++ b/daemon/exec_windows.go
@@ -8,7 +8,9 @@ import (
 
 func execSetPlatformOpt(c *container.Container, ec *exec.Config, p *libcontainerd.Process) error {
 	// Process arguments need to be escaped before sending to OCI.
-	p.Args = escapeArgs(p.Args)
-	p.User.Username = ec.User
+	if c.Platform == "windows" {
+		p.Args = escapeArgs(p.Args)
+		p.User.Username = ec.User
+	}
 	return nil
 }

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -98,7 +98,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 
 	// In s.Process
 	s.Process.Args = append([]string{c.Path}, c.Args...)
-	if !c.Config.ArgsEscaped {
+	if !c.Config.ArgsEscaped && img.OS == "windows" {
 		s.Process.Args = escapeArgs(s.Process.Args)
 	}
 

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -420,7 +420,11 @@ func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendly
 
 	// Configure the environment for the process
 	createProcessParms.Environment = setupEnvironmentVariables(procToAdd.Env)
-	createProcessParms.CommandLine = strings.Join(procToAdd.Args, " ")
+	if container.ociSpec.Platform.OS == "windows" {
+		createProcessParms.CommandLine = strings.Join(procToAdd.Args, " ")
+	} else {
+		createProcessParms.CommandArgs = procToAdd.Args
+	}
 	createProcessParms.User = procToAdd.User.Username
 
 	logrus.Debugf("libcontainerd: commandLine: %s", createProcessParms.CommandLine)

--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -82,7 +82,11 @@ func (ctr *container) start(attachStdio StdioCallback) error {
 
 	// Configure the environment for the process
 	createProcessParms.Environment = setupEnvironmentVariables(ctr.ociSpec.Process.Env)
-	createProcessParms.CommandLine = strings.Join(ctr.ociSpec.Process.Args, " ")
+	if ctr.ociSpec.Platform.OS == "windows" {
+		createProcessParms.CommandLine = strings.Join(ctr.ociSpec.Process.Args, " ")
+	} else {
+		createProcessParms.CommandArgs = ctr.ociSpec.Process.Args
+	}
 	createProcessParms.User = ctr.ociSpec.Process.User.Username
 
 	// LCOW requires the raw OCI spec passed through HCS and onwards to GCS for the utility VM.


### PR DESCRIPTION
Right now, LCOW processes do not work with arguments that need to be quoted. E.g. this does not work:

`docker run busybox sh -c "echo hello world"`

because it ends up double-quoting "echo hello world", so sh tries to find a binary with that name.

This change fixes this by removing the extra quoting for LCOW processes and passing the argument list to hcsshim as a JSON array instead of a single string, which is the more natural interface for Linux processes.

Signed-off-by: John Starks <jostarks@microsoft.com>
