### PR TITLE
builder: Emit a BuildResult after squashing.

### DIFF
--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -55,6 +55,11 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 		if imageID, err = squashBuild(build, b.imageComponent); err != nil {
 			return "", err
 		}
+		if config.ProgressWriter.AuxFormatter != nil {
+			if err = config.ProgressWriter.AuxFormatter.Emit(types.BuildResult{ID: imageID}); err != nil {
+				return "", err
+			}
+		}
 	}
 
 	stdout := config.ProgressWriter.StdoutFormatter


### PR DESCRIPTION
This ensures that the final BuildResult is the actual tagged image.

Fixes #33822.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Ensured that a new `BuildResult` is emitted into the build log stream when squashing, added a test case for this scenario.

**- How I did it**

Added a suitable call to `AuxFormatter.Emit` after squashing. I considered pushing this down into `squashBuild` but decided not to mess with its parameter list. It might also be possible to push this whole functionality into the Builder, but that was more than I wanted to do.

**- How to verify it**

Build a `Dockerfile` with `docker build --iidfile=foo --squash`. The contents of `foo` should be the squashed image and not the final unsquashed one.

**- Description for the changelog**

`docker build` now correctly supports simultaneous use of `--iidfile` and `--squash`

**- A picture of a cute animal (not mandatory but encouraged)**
[![](https://s-media-cache-ak0.pinimg.com/originals/d5/78/31/d57831ead16139ab2a76568a9550941b.jpg "Goat")](https://en.wikipedia.org/wiki/Goat_(band))

/cc @tonistiigi 