### PR TITLE
Do not error on relabel when relabel not supported

### DIFF
--- a/volume/volume.go
+++ b/volume/volume.go
@@ -156,6 +156,10 @@ func (m *MountPoint) Setup(mountLabel string, rootIDs idtools.IDPair, checkFun f
 		if err == nil {
 			if label.RelabelNeeded(m.Mode) {
 				if err = label.Relabel(m.Source, mountLabel, label.IsShared(m.Mode)); err != nil {
+					if err == syscall.ENOTSUP {
+						err = nil
+						return
+					}
 					path = ""
 					err = errors.Wrapf(err, "error setting label on mount source '%s'", m.Source)
 					return


### PR DESCRIPTION
This is the same as https://github.com/moby/moby/tree/master/container/container_unix.go#L157
Using syscall here instead of `x/sys/unix` since this code path is run on both unix and windows.