### PR TITLE
LCOW: Change directory from lcow to "Linux Containers"

### DIFF
--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -299,7 +299,7 @@ func (clnt *client) createLinux(containerID string, checkpoint string, checkpoin
 		Owner:         defaultOwner,
 		TerminateOnLastHandleClosed: true,
 		HvRuntime: &hcsshim.HvRuntime{
-			ImagePath:       `c:\program files\lcow`,
+			ImagePath:       `c:\Program Files\Linux Containers`,
 			LinuxKernelFile: `bootx64.efi`,
 			LinuxInitrdFile: `initrd.img`,
 		},

--- a/vendor.conf
+++ b/vendor.conf
@@ -8,7 +8,7 @@ github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git
 github.com/gorilla/context v1.1
 github.com/gorilla/mux v1.1
-github.com/jhowardmsft/opengcs v0.0.4
+github.com/jhowardmsft/opengcs v0.0.7
 github.com/kr/pty 5cf931ef8f
 github.com/mattn/go-shellwords v1.0.3
 github.com/tchap/go-patricia v2.2.6

--- a/vendor/github.com/jhowardmsft/opengcs/gogcs/client/createsandbox.go
+++ b/vendor/github.com/jhowardmsft/opengcs/gogcs/client/createsandbox.go
@@ -25,7 +25,7 @@ func (config *Config) CreateSandbox(destFile string, maxSizeInMB uint32, cacheFi
 	logrus.Debugf("opengcs: CreateSandbox: %s size:%dMB cache:%s", destFile, maxSizeInMB, cacheFile)
 
 	// Retrieve from cache if the default size and already on disk
-	if maxSizeInMB == DefaultSandboxSizeMB {
+	if cacheFile != "" && maxSizeInMB == DefaultSandboxSizeMB {
 		sandboxCacheLock.Lock()
 		if _, err := os.Stat(cacheFile); err == nil {
 			if err := copyFile(cacheFile, destFile); err != nil {
@@ -61,7 +61,7 @@ func (config *Config) CreateSandbox(destFile string, maxSizeInMB uint32, cacheFi
 	}
 
 	// Populate the cache
-	if maxSizeInMB == DefaultSandboxSizeMB {
+	if cacheFile != "" && maxSizeInMB == DefaultSandboxSizeMB {
 		sandboxCacheLock.Lock()
 		// It may already exist due to being created on another thread, in which case no copy back needed.
 		if _, err := os.Stat(cacheFile); os.IsNotExist(err) {

--- a/vendor/github.com/jhowardmsft/opengcs/gogcs/client/tartovhd.go
+++ b/vendor/github.com/jhowardmsft/opengcs/gogcs/client/tartovhd.go
@@ -31,7 +31,9 @@ func (config *Config) TarToVhd(targetVHDFile string, reader io.Reader) (int64, e
 	}
 
 	// Don't need stdin now we've sent everything. This signals GCS that we are finished sending data.
-	process.Process.CloseStdin()
+	if err := process.Process.CloseStdin(); err != nil {
+		return 0, fmt.Errorf("opengcs: TarToVhd: %s: failed closing stdin handle: %s", targetVHDFile, err)
+	}
 
 	// Write stdout contents of `tar2vhd` to the VHD file
 	payloadSize, err := writeFileFromReader(targetVHDFile, process.Stdout, config.UvmTimeoutSeconds, fmt.Sprintf("output of tar2vhd to %s", targetVHDFile))

--- a/vendor/github.com/jhowardmsft/opengcs/gogcs/client/utilities.go
+++ b/vendor/github.com/jhowardmsft/opengcs/gogcs/client/utilities.go
@@ -41,20 +41,9 @@ func copyWithTimeout(dst io.Writer, src io.Reader, size int64, timeoutSeconds in
 
 	done := make(chan resultType, 1)
 	go func() {
-		// TODO @jhowardmsft. Needs platform fix. Improve reliability by
-		// chunking the data. Ultimately can just use io.Copy instead with no loop
 		result := resultType{}
-		var copied int64
-		for {
-			copied, result.err = io.CopyN(dst, src, 1024)
-			result.bytes += copied
-			if copied == 0 {
-				done <- result
-				break
-			}
-			// TODO @jhowardmsft - next line is debugging only. Remove
-			//logrus.Debugf("%s: copied so far %d\n", context, result.bytes)
-		}
+		result.bytes, result.err = io.Copy(dst, src)
+		done <- result
 	}()
 
 	var result resultType


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Updates the default kernel/initrd location from pf\lcow to `pf\Linux Containers`. Don't ask.

@johnstep 