### PR TITLE
Fix syslog to set the correct priority

### DIFF
--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -133,8 +133,9 @@ func New(info logger.Info) (logger.Logger, error) {
 
 func (s *syslogger) Log(msg *logger.Message) error {
 	line := string(msg.Line)
+	isError := (msg.Source == "stderr")
 	logger.PutMessage(msg)
-	if msg.Source == "stderr" {
+	if isError {
 		return s.writer.Err(line)
 	}
 	return s.writer.Info(line)


### PR DESCRIPTION
fixes #33834

**- What I did**

When using the syslog log-driver, if the log line came from `stderr` it is supposed to be prioritize as `3` or as `LOG_ERR`. However, in the current state this is not happening.

According to this code, we are expecting to work correctly:
```
func (s *syslogger) Log(msg *logger.Message) error {
	line := string(msg.Line)
	logger.PutMessage(msg)
	if msg.Source == "stderr" {
		return s.writer.Err(line)
	}
	return s.writer.Info(line)
}
```

However, when calling `logger.PutMessage` the `msg` is being reset even though we are using it later in the if condition (`msg.Source == "stderr"`).

**- How I did it**

I created a new variable `isError` which stores true or false. If the log line came from `stderr` then `isError` is true otherwise false. Then, changed the if condition to `if isError`.

**- How to verify it**
