### PR TITLE
Set unpaused state when receiving 'stateExit' event

### DIFF
--- a/container/state.go
+++ b/container/state.go
@@ -278,6 +278,7 @@ func (s *State) SetRunning(pid int, initial bool) {
 	s.ErrorMsg = ""
 	s.Running = true
 	s.Restarting = false
+	s.Paused = false
 	s.ExitCodeValue = 0
 	s.Pid = pid
 	if initial {
@@ -304,6 +305,7 @@ func (s *State) SetRestarting(exitStatus *ExitStatus) {
 	// all the checks in docker around rm/stop/etc
 	s.Running = true
 	s.Restarting = true
+	s.Paused = false
 	s.Pid = 0
 	s.FinishedAt = time.Now().UTC()
 	s.setFromExitStatus(exitStatus)


### PR DESCRIPTION





<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix a bug:
Description:
 1. start a container with restart=always, e.g.
    `docker run -d --restart=always ubuntu sleep 3`
 2. container init process exits at sometime.
 3. use `docker pause <id>` to pause this container.

Try some times, we will find the container is running with Paused，and but docker-runc list cannot show it.  Later it will startup. ( not paused actually)


if the pause action is before cgroup data is removed and after the init process died.
`Pause` operation will success to write cgroup data, but actually do not freeze any process.

And then docker received pause event and stateExit event from
containerd, the docker state will be Running(paused), but the container
is free running.

Then we can not remove it, stop it , pause it  and unpause it.

**- How I did it**

When receiving `StateExit` event from containerd, set the container to be unpaused.

I think if an container is exiting, it should not be paused.

**- How to verify it**
 1. start a container with restart=always, e.g.
    `docker run -d --restart=always ubuntu sleep 3`
 2. use `docker pause <id>` to pause this container.
   do not see the
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Signed-off-by: Wentao Zhang <zhangwentao234@huawei.com>

**- A picture of a cute animal (not mandatory but encouraged)**

