### PR TITLE
Windows: named pipe mounts

### DIFF
--- a/api/types/mount/mount.go
+++ b/api/types/mount/mount.go
@@ -15,6 +15,8 @@ const (
 	TypeVolume Type = "volume"
 	// TypeTmpfs is the type for mounting tmpfs
 	TypeTmpfs Type = "tmpfs"
+	// TypeNamedPipe is the type for mounting Windows named pipes
+	TypeNamedPipe Type = "npipe"
 )
 
 // Mount represents a mount (volume).

--- a/integration-cli/docker_api_containers_windows_test.go
+++ b/integration-cli/docker_api_containers_windows_test.go
@@ -1,0 +1,71 @@
+// +build windows
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"strings"
+
+	winio "github.com/Microsoft/go-winio"
+	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/request"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestContainersAPICreateMountsBindNamedPipe(c *check.C) {
+	testRequires(c, SameHostDaemon, DaemonIsWindowsAtLeastBuild(16210)) // Named pipe support was added in RS3
+
+	// Create a host pipe to map into the container
+	hostPipeName := fmt.Sprintf(`\\.\pipe\docker-cli-test-pipe-%x`, rand.Uint64())
+	pc := &winio.PipeConfig{
+		SecurityDescriptor: "D:P(A;;GA;;;AU)", // Allow all users access to the pipe
+	}
+	l, err := winio.ListenPipe(hostPipeName, pc)
+	if err != nil {
+		c.Fatal(err)
+	}
+	defer l.Close()
+
+	// Asynchronously read data that the container writes to the mapped pipe.
+	var b []byte
+	ch := make(chan error)
+	go func() {
+		conn, err := l.Accept()
+		if err == nil {
+			b, err = ioutil.ReadAll(conn)
+			conn.Close()
+		}
+		ch <- err
+	}()
+
+	containerPipeName := `\\.\pipe\docker-cli-test-pipe`
+	text := "hello from a pipe"
+	cmd := fmt.Sprintf("echo %s > %s", text, containerPipeName)
+
+	name := "test-bind-npipe"
+	data := map[string]interface{}{
+		"Image":      testEnv.MinimalBaseImage(),
+		"Cmd":        []string{"cmd", "/c", cmd},
+		"HostConfig": map[string]interface{}{"Mounts": []map[string]interface{}{{"Type": "npipe", "Source": hostPipeName, "Target": containerPipeName}}},
+	}
+
+	status, resp, err := request.SockRequest("POST", "/containers/create?name="+name, data, daemonHost())
+	c.Assert(err, checker.IsNil, check.Commentf(string(resp)))
+	c.Assert(status, checker.Equals, http.StatusCreated, check.Commentf(string(resp)))
+
+	status, _, err = request.SockRequest("POST", "/containers/"+name+"/start", nil, daemonHost())
+	c.Assert(err, checker.IsNil)
+	c.Assert(status, checker.Equals, http.StatusNoContent)
+
+	err = <-ch
+	if err != nil {
+		c.Fatal(err)
+	}
+	result := strings.TrimSpace(string(b))
+	if result != text {
+		c.Errorf("expected pipe to contain %s, got %s", text, result)
+	}
+}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4610,10 +4610,7 @@ func (s *DockerSuite) TestRunAddDeviceCgroupRule(c *check.C) {
 
 // Verifies that running as local system is operating correctly on Windows
 func (s *DockerSuite) TestWindowsRunAsSystem(c *check.C) {
-	testRequires(c, DaemonIsWindows)
-	if testEnv.DaemonKernelVersionNumeric() < 15000 {
-		c.Skip("Requires build 15000 or later")
-	}
+	testRequires(c, DaemonIsWindowsAtLeastBuild(15000))
 	out, _ := dockerCmd(c, "run", "--net=none", `--user=nt authority\system`, "--hostname=XYZZY", minimalBaseImage(), "cmd", "/c", `@echo %USERNAME%`)
 	c.Assert(strings.TrimSpace(out), checker.Equals, "XYZZY$")
 }

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -37,6 +37,12 @@ func DaemonIsWindows() bool {
 	return PlatformIs("windows")
 }
 
+func DaemonIsWindowsAtLeastBuild(buildNumber int) func() bool {
+	return func() bool {
+		return DaemonIsWindows() && testEnv.DaemonKernelVersionNumeric() >= buildNumber
+	}
+}
+
 func DaemonIsLinux() bool {
 	return PlatformIs("linux")
 }

--- a/volume/validate.go
+++ b/volume/validate.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
+	"runtime"
 
 	"github.com/docker/docker/api/types/mount"
 )
@@ -12,8 +12,7 @@ import (
 var errBindNotExist = errors.New("bind source path does not exist")
 
 type validateOpts struct {
-	skipBindSourceCheck   bool
-	skipAbsolutePathCheck bool
+	skipBindSourceCheck bool
 }
 
 func validateMountConfig(mnt *mount.Mount, options ...func(*validateOpts)) error {
@@ -30,10 +29,8 @@ func validateMountConfig(mnt *mount.Mount, options ...func(*validateOpts)) error
 		return &errMountConfig{mnt, err}
 	}
 
-	if !opts.skipAbsolutePathCheck {
-		if err := validateAbsolute(mnt.Target); err != nil {
-			return &errMountConfig{mnt, err}
-		}
+	if err := validateAbsolute(mnt.Target); err != nil {
+		return &errMountConfig{mnt, err}
 	}
 
 	switch mnt.Type {
@@ -97,6 +94,31 @@ func validateMountConfig(mnt *mount.Mount, options ...func(*validateOpts)) error
 		if _, err := ConvertTmpfsOptions(mnt.TmpfsOptions, mnt.ReadOnly); err != nil {
 			return &errMountConfig{mnt, err}
 		}
+	case mount.TypeNamedPipe:
+		if runtime.GOOS != "windows" {
+			return &errMountConfig{mnt, errors.New("named pipe bind mounts are not supported on this OS")}
+		}
+
+		if len(mnt.Source) == 0 {
+			return &errMountConfig{mnt, errMissingField("Source")}
+		}
+
+		if mnt.BindOptions != nil {
+			return &errMountConfig{mnt, errExtraField("BindOptions")}
+		}
+
+		if mnt.ReadOnly {
+			return &errMountConfig{mnt, errExtraField("ReadOnly")}
+		}
+
+		if detectMountType(mnt.Source) != mount.TypeNamedPipe {
+			return &errMountConfig{mnt, fmt.Errorf("'%s' is not a valid pipe path", mnt.Source)}
+		}
+
+		if detectMountType(mnt.Target) != mount.TypeNamedPipe {
+			return &errMountConfig{mnt, fmt.Errorf("'%s' is not a valid pipe path", mnt.Target)}
+		}
+
 	default:
 		return &errMountConfig{mnt, errors.New("mount type unknown")}
 	}
@@ -121,7 +143,7 @@ func errMissingField(name string) error {
 
 func validateAbsolute(p string) error {
 	p = convertSlash(p)
-	if filepath.IsAbs(p) {
+	if isAbsPath(p) {
 		return nil
 	}
 	return fmt.Errorf("invalid mount path: '%s' mount path must be absolute", p)

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -3,7 +3,6 @@ package volume
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -284,12 +283,7 @@ func ParseMountRaw(raw, volumeDriver string) (*MountPoint, error) {
 		return nil, errInvalidMode(mode)
 	}
 
-	if filepath.IsAbs(spec.Source) {
-		spec.Type = mounttypes.TypeBind
-	} else {
-		spec.Type = mounttypes.TypeVolume
-	}
-
+	spec.Type = detectMountType(spec.Source)
 	spec.ReadOnly = !ReadWrite(mode)
 
 	// cannot assume that if a volume driver is passed in that we should set it
@@ -350,7 +344,7 @@ func ParseMountSpec(cfg mounttypes.Mount, options ...func(*validateOpts)) (*Moun
 				mp.CopyData = false
 			}
 		}
-	case mounttypes.TypeBind:
+	case mounttypes.TypeBind, mounttypes.TypeNamedPipe:
 		mp.Source = clean(convertSlash(cfg.Source))
 		if cfg.BindOptions != nil && len(cfg.BindOptions.Propagation) > 0 {
 			mp.Propagation = cfg.BindOptions.Propagation

--- a/volume/volume_unix.go
+++ b/volume/volume_unix.go
@@ -124,7 +124,12 @@ func validateCopyMode(mode bool) error {
 }
 
 func convertSlash(p string) string {
-	return filepath.ToSlash(p)
+	return p
+}
+
+// isAbsPath reports whether the path is absolute.
+func isAbsPath(p string) bool {
+	return filepath.IsAbs(p)
 }
 
 func splitRawSpec(raw string) ([]string, error) {
@@ -137,6 +142,13 @@ func splitRawSpec(raw string) ([]string, error) {
 		return nil, errInvalidSpec(raw)
 	}
 	return arr, nil
+}
+
+func detectMountType(p string) mounttypes.Type {
+	if filepath.IsAbs(p) {
+		return mounttypes.TypeBind
+	}
+	return mounttypes.TypeVolume
 }
 
 func clean(p string) string {


### PR DESCRIPTION
Current insider builds of Windows have support for mounting individual
named pipe servers from the host to the guest. This allows, for example,
exposing the docker engine's named pipe to a container.

This change allows the user to request such a mount via the normal bind
mount syntax in the CLI:

```
docker run -v \\.\pipe\docker_engine:\\.\pipe\docker_engine <args>
```