### PR TITLE
Fix build error for `make test-unit`

### DIFF
--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -26,6 +26,8 @@ bundle_test_unit() {
 		TEST_PATH=./${TESTDIRS}
 	fi
 
+	source "${MAKEDIR}/.go-autogen"
+
 	if [ "$(go env GOHOSTOS)" = 'solaris' ]; then
 		pkg_list=$(go list -e \
 			-f '{{if ne .Name "github.com/docker/docker"}}


### PR DESCRIPTION
**- What I did**

This fix tries to address the issue raised by #33856 where
`make test-unit` will result in the failure:
```
...
...
dockerversion/useragent.go:20: undefined: Version
dockerversion/useragent.go:22: undefined: GitCommit
ok  	github.com/docker/docker/api	0.026s	coverage: 68.0% of statements
ok  	github.com/docker/docker/api/errors	0.003s	coverage: 100.0% of statements
FAIL	github.com/docker/docker/api/server [build failed]
make: *** [test-unit] Error 2
```

The issue is because in case of `make test-unit`, `source "${MAKEDIR}/.go-autogen"`
is missing.

This caused the `make test-unit` failure.


**- How I did it**

This fix adds `source "${MAKEDIR}/.go-autogen"` in `hack/make/test-unit`

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #33856.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
