### PR TITLE
Add path filtering to build session client

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -140,8 +140,7 @@ func (bm *BuildManager) initializeClientSession(ctx context.Context, cancel func
 	}()
 	if options.RemoteContext == remotecontext.ClientSessionRemote {
 		st := time.Now()
-		csi, err := NewClientSessionSourceIdentifier(ctx, bm.sg,
-			options.SessionID, []string{"/"})
+		csi, err := NewClientSessionSourceIdentifier(ctx, bm.sg, options.SessionID)
 		if err != nil {
 			return nil, err
 		}

--- a/builder/dockerfile/clientsession.go
+++ b/builder/dockerfile/clientsession.go
@@ -30,26 +30,25 @@ func (cst *ClientSessionTransport) Copy(ctx context.Context, id fscache.RemoteId
 	}
 
 	return filesync.FSSync(ctx, csi.caller, filesync.FSSendRequestOpt{
-		SrcPaths:     csi.srcPaths,
-		DestDir:      dest,
-		CacheUpdater: cu,
+		IncludePatterns: csi.includePatterns,
+		DestDir:         dest,
+		CacheUpdater:    cu,
 	})
 }
 
 // ClientSessionSourceIdentifier is an identifier that can be used for requesting
 // files from remote client
 type ClientSessionSourceIdentifier struct {
-	srcPaths  []string
-	caller    session.Caller
-	sharedKey string
-	uuid      string
+	includePatterns []string
+	caller          session.Caller
+	sharedKey       string
+	uuid            string
 }
 
 // NewClientSessionSourceIdentifier returns new ClientSessionSourceIdentifier instance
-func NewClientSessionSourceIdentifier(ctx context.Context, sg SessionGetter, uuid string, sources []string) (*ClientSessionSourceIdentifier, error) {
+func NewClientSessionSourceIdentifier(ctx context.Context, sg SessionGetter, uuid string) (*ClientSessionSourceIdentifier, error) {
 	csi := &ClientSessionSourceIdentifier{
-		uuid:     uuid,
-		srcPaths: sources,
+		uuid: uuid,
 	}
 	caller, err := sg.Get(ctx, uuid)
 	if err != nil {

--- a/client/session/filesync/diffcopy.go
+++ b/client/session/filesync/diffcopy.go
@@ -9,9 +9,10 @@ import (
 	"github.com/tonistiigi/fsutil"
 )
 
-func sendDiffCopy(stream grpc.Stream, dir string, excludes []string, progress progressCb) error {
+func sendDiffCopy(stream grpc.Stream, dir string, includes, excludes []string, progress progressCb) error {
 	return fsutil.Send(stream.Context(), stream, dir, &fsutil.WalkOpt{
 		ExcludePatterns: excludes,
+		IncludePaths:    includes, // TODO: rename IncludePatterns
 	}, progress)
 }
 

--- a/client/session/filesync/filesync_test.go
+++ b/client/session/filesync/filesync_test.go
@@ -1,0 +1,71 @@
+package filesync
+
+import (
+	"context"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/docker/client/session"
+	"github.com/docker/docker/client/session/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestFileSyncIncludePatterns(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "fsynctest")
+	require.NoError(t, err)
+
+	destDir, err := ioutil.TempDir("", "fsynctest")
+	require.NoError(t, err)
+
+	err = ioutil.WriteFile(filepath.Join(tmpDir, "foo"), []byte("content1"), 0600)
+	require.NoError(t, err)
+
+	err = ioutil.WriteFile(filepath.Join(tmpDir, "bar"), []byte("content2"), 0600)
+	require.NoError(t, err)
+
+	s, err := session.NewSession("foo", "bar")
+	require.NoError(t, err)
+
+	m, err := session.NewManager()
+	require.NoError(t, err)
+
+	fs := NewFSSyncProvider(tmpDir, nil)
+	s.Allow(fs)
+
+	dialer := session.Dialer(testutil.TestStream(testutil.Handler(m.HandleConn)))
+
+	g, ctx := errgroup.WithContext(context.Background())
+
+	g.Go(func() error {
+		return s.Run(ctx, dialer)
+	})
+
+	g.Go(func() (reterr error) {
+		c, err := m.Get(ctx, s.UUID())
+		if err != nil {
+			return err
+		}
+		if err := FSSync(ctx, c, FSSendRequestOpt{
+			DestDir:         destDir,
+			IncludePatterns: []string{"ba*"},
+		}); err != nil {
+			return err
+		}
+
+		_, err = ioutil.ReadFile(filepath.Join(destDir, "foo"))
+		assert.Error(t, err)
+
+		dt, err := ioutil.ReadFile(filepath.Join(destDir, "bar"))
+		if err != nil {
+			return err
+		}
+		assert.Equal(t, "content2", string(dt))
+		return s.Close()
+	})
+
+	err = g.Wait()
+	require.NoError(t, err)
+}

--- a/client/session/filesync/tarstream.go
+++ b/client/session/filesync/tarstream.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-func sendTarStream(stream grpc.Stream, dir string, excludes []string, progress progressCb) error {
+func sendTarStream(stream grpc.Stream, dir string, includes, excludes []string, progress progressCb) error {
 	a, err := archive.TarWithOptions(dir, &archive.TarOptions{
 		ExcludePatterns: excludes,
 	})

--- a/client/session/testutil/testutil.go
+++ b/client/session/testutil/testutil.go
@@ -1,0 +1,70 @@
+package testutil
+
+import (
+	"io"
+	"net"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+// Handler is function called to handle incoming connection
+type Handler func(ctx context.Context, conn net.Conn, meta map[string][]string) error
+
+// Dialer is a function for dialing an outgoing connection
+type Dialer func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error)
+
+// TestStream creates an in memory session dialer for a handler function
+func TestStream(handler Handler) Dialer {
+	s1, s2 := sockPair()
+	return func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error) {
+		go func() {
+			err := handler(context.TODO(), s1, meta)
+			if err != nil {
+				logrus.Error(err)
+			}
+			s1.Close()
+		}()
+		return s2, nil
+	}
+}
+
+func sockPair() (*sock, *sock) {
+	pr1, pw1 := io.Pipe()
+	pr2, pw2 := io.Pipe()
+	return &sock{pw1, pr2, pw1}, &sock{pw2, pr1, pw2}
+}
+
+type sock struct {
+	io.Writer
+	io.Reader
+	io.Closer
+}
+
+func (s *sock) LocalAddr() net.Addr {
+	return dummyAddr{}
+}
+func (s *sock) RemoteAddr() net.Addr {
+	return dummyAddr{}
+}
+func (s *sock) SetDeadline(t time.Time) error {
+	return nil
+}
+func (s *sock) SetReadDeadline(t time.Time) error {
+	return nil
+}
+func (s *sock) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+type dummyAddr struct {
+}
+
+func (d dummyAddr) Network() string {
+	return "tcp"
+}
+
+func (d dummyAddr) String() string {
+	return "localhost"
+}


### PR DESCRIPTION
This PR enables path filtering capabilities to the file send stream so that it can be used in the future for the builder to only ask the paths that are actually needed or for transferring individual files(for example Dockerfile). This was described as follow-up in #32677 as optional but it occurred to me that if a client doesn't have support for this then future daemons would need to detect if clients have support for this or not(possible but harder to maintain). The `fsutil` package already had support for this but it was not enabled in `session/filesync`.

As there isn't a daemon feature that uses it yet I added a test helper that can be used to test the full lifecycle of the session in another commit. Hopefully this will become useful in the future for testing other similar features as well.

@thaJeztah @tiborvass 
