### PR TITLE
add f.Close()  after dockerignore.ReadAll(f) before return err

### DIFF
--- a/builder/remotecontext/detect.go
+++ b/builder/remotecontext/detect.go
@@ -131,6 +131,7 @@ func removeDockerfile(c modifiableContext, filesToRemove ...string) error {
 	}
 	excludes, err := dockerignore.ReadAll(f)
 	if err != nil {
+		f.Close()
 		return err
 	}
 	f.Close()


### PR DESCRIPTION
add f.Close() after dockerignore.ReadAll(f) before return err.