### PR TITLE
Change order of arguments in assertion to be more logical

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2797,7 +2797,7 @@ func (s *DockerDaemonSuite) TestExecWithUserAfterLiveRestore(c *check.C) {
 
 	out2, err := s.d.Cmd("exec", "-u", "test", "top", "id")
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out2))
-	c.Assert(out1, check.Equals, out2, check.Commentf("Output: before restart '%s', after restart '%s'", out1, out2))
+	c.Assert(out2, check.Equals, out1, check.Commentf("Output: before restart '%s', after restart '%s'", out1, out2))
 
 	out, err = s.d.Cmd("stop", "top")
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))


### PR DESCRIPTION
Because of argument order to assert, in case of fail, we'll get message
like:

... obtained string = "uid=100(test) gid=101(test)\n"
... expected string = "uid=100(test) gid=101(test) groups=101(test)\n"

But obtained string should be second one, not the first one. And
expected string should be first. Here's sample output from test above:

... Output: before restart 'uid=100(test) gid=101(test)
', after restart 'uid=100(test) gid=101(test) groups=101(test)

It's confusing, because expected order of strings in assertion is
reversed. What goes before restart - should be "expected string" and
what goes after - should be "obtained string".

Signed-off-by: Vitaly Ostrosablin <vostrosablin@virtuozzo.com>

**- What I did**

Fixed order of arguments to assertion.

**- How I did it**

Swapped out1 and out2.

**- How to verify it**

make test-integration-cli

In case of assertion failure in this test, strings should be printed in proper order.

**- Description for the changelog**

Fixed string order in assertion in TestExecWithUserAfterLiveRestore testcase.