### PR TITLE
daemon: Ignore nonexistent containers when listing containers

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -162,10 +162,7 @@ func (daemon *Daemon) filterByNameIDMatches(view container.View, ctx *listContex
 	cntrs := make([]container.Snapshot, 0, len(matches))
 	for id := range matches {
 		c, err := view.Get(id)
-		if err != nil {
-			return nil, err
-		}
-		if c != nil {
+		if err == nil {
 			cntrs = append(cntrs, *c)
 		}
 	}


### PR DESCRIPTION
The name/ID relationships are maintained separately from the memdb and can be out of sync from any particular memdb snapshot. If a container does not exist in the memdb, we must accept this as normal and not fail the listing. This is consistent with what the code used to do before memdb was introduced.

In combination with #33882, this fixes #33863

cc @fabiokung