### PR TITLE
no need to re-fetch the nameIndex during `docker ps` queries

### DIFF
--- a/container/view.go
+++ b/container/view.go
@@ -50,6 +50,7 @@ type ViewDB interface {
 
 // View can be used by readers to avoid locking
 type View interface {
+	Names() map[string][]string
 	All() ([]Snapshot, error)
 	Get(id string) (*Snapshot, error)
 }
@@ -108,6 +109,10 @@ func (db *memDB) Delete(c *Container) error {
 type memdbView struct {
 	txn       *memdb.Txn
 	nameIndex map[string][]string
+}
+
+func (v *memdbView) Names() map[string][]string {
+	return v.nameIndex
 }
 
 // All returns a all items in this snapshot. Returned objects must never be modified.

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -359,7 +359,7 @@ func (daemon *Daemon) foldFilter(view container.View, config *types.ContainerLis
 		publish:              publishFilter,
 		expose:               exposeFilter,
 		ContainerListOptions: config,
-		names:                daemon.nameIndex.GetAll(),
+		names:                view.Names(),
 	}, nil
 }
 func portOp(key string, filter map[nat.Port]bool) func(value string) error {


### PR DESCRIPTION
... by always using the one that has been snapshotted for each query.

Related to #33863

Signed-off-by: Fabio Kung <fabio.kung@gmail.com>

/cc @aaronlehmann @thaJeztah 