### PR TITLE
Fix NewVersionError() for clients using default version

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -228,7 +228,7 @@ func IsErrPluginPermissionDenied(err error) bool {
 // NewVersionError returns an error if the APIVersion required
 // if less than the current supported version
 func (cli *Client) NewVersionError(APIrequired, feature string) error {
-	if versions.LessThan(cli.version, APIrequired) {
+	if cli.version != "" && versions.LessThan(cli.version, APIrequired) {
 		return fmt.Errorf("%q requires API version %s, but the Docker daemon API version is %s", feature, APIrequired, cli.version)
 	}
 	return nil


### PR DESCRIPTION
The NewVersionError checks if the client is using the API version
required for using a specific feature.

If the client is initialized without setting a specific version, an
error would be generated because it was not possible to compare
versions. However, a client without explicit version set is running
the latest supported version.

This patch changes the behavior to only generate an error if a version
was set.

ping @tiborvass @vieux PTAL
