### PR TITLE
Always perform version-negotiation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -260,8 +260,13 @@ func (cli *Client) NegotiateAPIVersionPing(p types.Ping) {
 		p.APIVersion = "1.24"
 	}
 
-	// if server version is lower than the current cli, downgrade
-	if versions.LessThan(p.APIVersion, cli.ClientVersion()) {
+	// if the client is not initialized with a version, start with the latest supported version
+	if cli.version == "" {
+		cli.version = api.DefaultVersion
+	}
+
+	// if server version is lower than the maximum version supported by the Client, downgrade
+	if versions.LessThan(p.APIVersion, api.DefaultVersion) {
 		cli.version = p.APIVersion
 	}
 }


### PR DESCRIPTION
If a client is initialized without a specific version set, version negotiation would not be functional.

This patch changes the behavior to always perform version negotation (if called), in which case the "current" (maximum supported API version) is used as a default.

Although I don't think this should be an issue, the [`NewClient()` documentation mentions](https://github.com/moby/moby/blob/5f1d94e569592fc2680f8661e16d0e5b02e82492/client/client.go#L158-L160):

```
// It won't send any version information if the version number is empty. It is
// highly recommended that you set a version or your client may break if the
// server is upgraded.
```

This behavior remains unchanged, as the version is only updated if `NegotiateAPIVersionPing()` is explicitly called

ping @tiborvass @vdemeester @dnephin 