### PR TITLE
Do not set -1 for swappiness

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1243,3 +1243,11 @@ func (daemon *Daemon) checkpointAndSave(container *container.Container) error {
 	}
 	return nil
 }
+
+// because the CLI sends a -1 when it wants to unset the swappiness value
+// we need to clear it on the server side
+func fixMemorySwappiness(resources *containertypes.Resources) {
+	if resources.MemorySwappiness != nil && *resources.MemorySwappiness == -1 {
+		resources.MemorySwappiness = nil
+	}
+}

--- a/daemon/daemon_solaris.go
+++ b/daemon/daemon_solaris.go
@@ -143,6 +143,7 @@ func UsingSystemd(config *Config) bool {
 // verifyPlatformContainerSettings performs platform-specific validation of the
 // hostconfig and config structures.
 func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.HostConfig, config *containertypes.Config, update bool) ([]string, error) {
+	fixMemorySwappiness(resources)
 	warnings := []string{}
 	sysInfo := sysinfo.New(true)
 	// NOTE: We do not enforce a minimum value for swap limits for zones on Solaris and
@@ -163,7 +164,7 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 	}
 	// Solaris NOTE: We allow and encourage setting the swap without setting the memory limit.
 
-	if hostConfig.MemorySwappiness != nil && *hostConfig.MemorySwappiness != -1 && !sysInfo.MemorySwappiness {
+	if hostConfig.MemorySwappiness != nil && !sysInfo.MemorySwappiness {
 		warnings = append(warnings, "Your kernel does not support memory swappiness capabilities, memory swappiness discarded.")
 		logrus.Warnf("Your kernel does not support memory swappiness capabilities, memory swappiness discarded.")
 		hostConfig.MemorySwappiness = nil

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -100,7 +100,7 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConf
 
 func verifyContainerResources(resources *containertypes.Resources, isHyperv bool) ([]string, error) {
 	warnings := []string{}
-
+	fixMemorySwappiness(resources)
 	if !isHyperv {
 		// The processor resource controls are mutually exclusive on
 		// Windows Server Containers, the order of precedence is
@@ -197,7 +197,7 @@ func verifyContainerResources(resources *containertypes.Resources, isHyperv bool
 	if resources.MemorySwap != 0 {
 		return warnings, fmt.Errorf("invalid option: Windows does not support MemorySwap")
 	}
-	if resources.MemorySwappiness != nil && *resources.MemorySwappiness != -1 {
+	if resources.MemorySwappiness != nil {
 		return warnings, fmt.Errorf("invalid option: Windows does not support MemorySwappiness")
 	}
 	if resources.OomKillDisable != nil && *resources.OomKillDisable {

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1448,7 +1448,7 @@ func (s *DockerSuite) TestPostContainersCreateMemorySwappinessHostConfigOmitted(
 	var containerJSON types.ContainerJSON
 	c.Assert(json.Unmarshal(body, &containerJSON), check.IsNil)
 
-	c.Assert(*containerJSON.HostConfig.MemorySwappiness, check.Equals, int64(-1))
+	c.Assert(containerJSON.HostConfig.MemorySwappiness, check.IsNil)
 }
 
 // check validation is done daemon side and not only in cli


### PR DESCRIPTION
Do not set a default value for swappiness as the default value should be`nil`.  

This keeps moby from setting invalid values for the OCI and cgroups configs.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>