### PR TITLE
make: add dynbinary target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all binary build cross deb help init-go-pkg-cache install manpages rpm run shell test test-docker-py test-integration-cli test-unit tgz validate win
+.PHONY: all binary dynbinary build cross deb help init-go-pkg-cache install manpages rpm run shell test test-docker-py test-integration-cli test-unit tgz validate win
 
 # set the graph driver as the current graphdriver if not set
 DOCKER_GRAPHDRIVER := $(if $(DOCKER_GRAPHDRIVER),$(DOCKER_GRAPHDRIVER),$(shell docker info 2>&1 | grep "Storage Driver" | sed 's/.*: //'))
@@ -105,6 +105,9 @@ all: build ## validate all checks, build linux binaries, run all tests\ncross bu
 
 binary: build ## build the linux binaries
 	$(DOCKER_RUN_DOCKER) hack/make.sh binary
+
+dynbinary: build ## build the linux dynbinaries
+	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary
 
 build: bundles init-go-pkg-cache
 	$(warning The docker client CLI has moved to github.com/docker/cli. By default, it is built from the git sha specified in hack/dockerfile/binaries-commits. For a dev-test cycle involving the CLI, run:${\n} DOCKER_CLI_PATH=/host/path/to/cli/binary make shell ${\n} then change the cli and compile into a binary at the same location.${\n})


### PR DESCRIPTION
Recently, it's become necessary to build dynbinaries on certain
distributions, so make it easier for users to build dynbinaries. It
looks like this was just an oversight when we added dynbinary builds.

[![kitteh](https://farm8.staticflickr.com/7413/9158637229_b235f50695_k.jpg)](https://flic.kr/p/eXjpLr)

Signed-off-by: Aleksa Sarai <asarai@suse.de>

###### [Kitten](https://flic.kr/p/eXjpLr) by [Jennifer C.](https://www.flickr.com/photos/29638108@N06/), on Flickr.