### PR TITLE
[carry 33883] daemon: Ignore nonexistent containers when listing containers

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -162,11 +162,13 @@ func (daemon *Daemon) filterByNameIDMatches(view container.View, ctx *listContex
 	cntrs := make([]container.Snapshot, 0, len(matches))
 	for id := range matches {
 		c, err := view.Get(id)
-		if err != nil {
-			return nil, err
-		}
-		if c != nil {
+		switch err.(type) {
+		case nil:
 			cntrs = append(cntrs, *c)
+		case container.NoSuchContainerError:
+			// ignore error
+		default:
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
The name/ID relationships are maintained separately from the memdb and
can be out of sync from any particular memdb snapshot. If a container
does not exist in the memdb, we must accept this as normal and not fail
the listing. This is consistent with what the code used to do before
memdb was introduced.

carry of https://github.com/moby/moby/pull/33883

closes https://github.com/moby/moby/pull/33883
fixes https://github.com/moby/moby/issues/33863