### PR TITLE
Perform first healthcheck on startup without waiting the specified interval

### DIFF
--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -32,6 +32,9 @@ type HealthConfig struct {
 	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
 	// Zero means inherit.
 	Retries int `json:",omitempty"`
+
+	// True means to perform first healthcheck on startup without waiting the specified interval
+	NoWait bool `json:",omitempty"`
 }
 
 // Config contains the configuration data about a container.

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -591,6 +591,7 @@ func healthcheck(req dispatchRequest) error {
 		flTimeout := req.flags.AddString("timeout", "")
 		flStartPeriod := req.flags.AddString("start-period", "")
 		flRetries := req.flags.AddString("retries", "")
+		flNoWait := req.flags.AddBool("no-wait", false)
 
 		if err := req.flags.Parse(); err != nil {
 			return err
@@ -642,6 +643,8 @@ func healthcheck(req dispatchRequest) error {
 		} else {
 			healthcheck.Retries = 0
 		}
+
+		healthcheck.NoWait = flNoWait.IsTrue()
 
 		runConfig.Healthcheck = &healthcheck
 	}

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -99,6 +99,9 @@ func merge(userConf, imageConf *containertypes.Config) error {
 			if userConf.Healthcheck.Retries == 0 {
 				userConf.Healthcheck.Retries = imageConf.Healthcheck.Retries
 			}
+			if !userConf.Healthcheck.NoWait {
+				userConf.Healthcheck.NoWait = imageConf.Healthcheck.NoWait
+			}
 		}
 	}
 


### PR DESCRIPTION
**- What I did**
This fix tries to address the issue raised in #33410 where the first healthcheck was only performed after the specified interval.

That might be problematic in case the interval is long yet, as is specified in #33410.

**- How I did it**

This fix make the following changes:
1. The first healthcheck is performed on startup (at time 0)
2. The first healthcheck is only valid when start-period < 0

The changes allows the backward-compatibility while at the same
time it is possbile to address the issue raised in #33410.

**- How to verify it**

Additional test cases have been added.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![cute-kitten-kittens-22438020-480-360](https://user-images.githubusercontent.com/6932348/27765938-e1de92b4-5e74-11e7-8d12-5a21f4add2ea.jpg)


This fix fixes #33410.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>