### PR TITLE
Remove comment about forked golang.org/x/net

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -13,7 +13,6 @@ github.com/kr/pty 5cf931ef8f
 github.com/mattn/go-shellwords v1.0.3
 github.com/tchap/go-patricia v2.2.6
 github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
-# forked golang.org/x/net package includes a patch for lazy loading trace templates
 golang.org/x/net 7dcfb8076726a3fdd9353b6b8a1f1b6be6811bd6
 golang.org/x/sys 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
 github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1


### PR DESCRIPTION
This dependency was temporarily forked, but
the fork was removed in db37a86d37431a1d82505cf6adc91a5d91dad146 (https://github.com/moby/moby/pull/30146).

This patch removes the comment


ping @tonistiigi @vdemeester PTAL