### PR TITLE
Fix wrong filemode for rotate log files

### DIFF
--- a/daemon/logger/loggerutils/rotatefilewriter.go
+++ b/daemon/logger/loggerutils/rotatefilewriter.go
@@ -74,7 +74,7 @@ func (w *RotateFileWriter) checkCapacityAndRotate() error {
 		if err := rotate(name, w.maxFiles); err != nil {
 			return err
 		}
-		file, err := os.OpenFile(name, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 06400)
+		file, err := os.OpenFile(name, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0640)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
the filemode should be 0640 but not 06400

Signed-off-by: Lei Jitang <leijitang@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

