### PR TITLE
Fix run `docker rename <container-id> new_name` concurrently, the container will have multi names

### DIFF
--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -32,15 +32,15 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 		return err
 	}
 
+	container.Lock()
+	defer container.Unlock()
+
 	oldName = container.Name
 	oldIsAnonymousEndpoint := container.NetworkSettings.IsAnonymousEndpoint
 
 	if oldName == newName {
 		return errors.New("Renaming a container with the same name as its current name")
 	}
-
-	container.Lock()
-	defer container.Unlock()
 
 	links := map[string]*dockercontainer.Container{}
 	for k, v := range daemon.linkIndex.children(container) {


### PR DESCRIPTION
When run `docker rename <container-id> new_name` concurrently, every operation will release old
container name. So container will have multi new names reserve in nameIndex.

**- What I did**
Fix a bug:
Description:

1. start a container
    `docker run busybox`
2. run `docker rename` command concurrently
    ```
    #!/bin/bash
    for((i=0;i<10;i++))
    do
    docker rename efbf7ff32533 name${i} &
    done
    ```
3. container has multi names
    ```
    # docker ps --no-trunc -a
    CONTAINER ID                                                       IMAGE           COMMAND             CREATED             STATUS                       PORTS               NAMES                                                           
    efbf7ff32533151babb878769e47fc5c33cd85b2afbfa52ef29f4cb16929e64c   busybox         "/bin/sh"           7 minutes ago       Exited (0) 7 minutes ago                         name2,name4,name1,name8,name5,name6,name3,name7,name9                                     
    ```
4. run `docker ps` and `docker inspect`, container name is different
    ```
    # docker ps --format "table {{.Names}}" -a
    NAMES
    name2
    # docker inspect --format {{.Name}} name2
    /name9
    ```
**- How I did it**
Every `docker rename` operation should release newest container name,  so container should get locked before get container name.
**- How to verify it**
1. start a container
2. run `docker rename` command concurrently
3. run `docker ps` and `docker inspect`, container name is the same

Signed-off-by: Yang Pengfei <yangpengfei4@huawei.com>

