### PR TITLE
return pruned size even when error occurs

### DIFF
--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -72,7 +72,7 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 func (b *Backend) PruneCache(ctx context.Context) (*types.BuildCachePruneReport, error) {
 	size, err := b.fsCache.Prune()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to prune build cache")
+		return &types.BuildCachePruneReport{SpaceReclaimed: size}, errors.Wrap(err, "failed to prune build cache")
 	}
 	return &types.BuildCachePruneReport{SpaceReclaimed: size}, nil
 }

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -304,7 +304,7 @@ deleteImagesLoop:
 
 	if canceled {
 		logrus.Warnf("ImagesPrune operation cancelled: %#v", *rep)
-		return nil, ctx.Err()
+		return rep, ctx.Err()
 	}
 
 	return rep, nil
@@ -428,7 +428,7 @@ func (daemon *Daemon) NetworksPrune(ctx context.Context, pruneFilters filters.Ar
 	select {
 	case <-ctx.Done():
 		logrus.Warnf("NetworksPrune operation cancelled: %#v", *rep)
-		return nil, ctx.Err()
+		return rep, ctx.Err()
 	default:
 	}
 


### PR DESCRIPTION
#Signed-off-by: allencloud <allen.sun@daocloud.io>

This PR takes one situation into consideration that when user hopes to prune unused data in docker daemon side, we know that docker daemon need a while to finish this.  But when an error occurs during the whole prune process, daemon will return an error, but the unused data is already pruned
maybe 50%. Thus I think we need to return the pruned data size even when an error occurs.

Currently, we take volume prune as an example, here is the corresponding handler:
```
func (v *volumeRouter) postVolumesPrune(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
	if err := httputils.ParseForm(r); err != nil {
		return err
	}

	pruneFilters, err := filters.FromParam(r.Form.Get("filters"))
	if err != nil {
		return err
	}

	pruneReport, err := v.backend.VolumesPrune(ctx, pruneFilters)
	if err != nil {
// Here we did not return the pruned data.
		return err
	}
	return httputils.WriteJSON(w, http.StatusOK, pruneReport)
}
```

So I think there should be somewhere to tell user the exact thing what has happened, such returning data to client, or just a line of daemon log. Otherwise these message seems ignored by default.

**- What I did**
1. return pruned size even when error occurs rather than nil

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

