### PR TITLE
Fix docker cp dir with hard link

### DIFF
--- a/pkg/archive/copy.go
+++ b/pkg/archive/copy.go
@@ -332,6 +332,9 @@ func RebaseArchiveEntries(srcContent io.Reader, oldBase, newBase string) io.Read
 			}
 
 			hdr.Name = strings.Replace(hdr.Name, oldBase, newBase, 1)
+			if hdr.Typeflag == tar.TypeLink {
+				hdr.Linkname = strings.Replace(hdr.Linkname, oldBase, newBase, 1)
+			}
 
 			if err = rebasedTar.WriteHeader(hdr); err != nil {
 				w.CloseWithError(err)


### PR DESCRIPTION
Use docker cp command to copy dir from container, if the path in container is not the same to the path on the host, docker cp will fail, this pr will fix it.

This bug need docker/cli update vendor for docker.

Signed-off-by: yangshukui <yangshukui@huawei.com>

**- What I did**
Adjust targetPath with hard link.

**- How to verify it**

***before this pr
![1](https://user-images.githubusercontent.com/11223367/27851423-31354bda-618d-11e7-9b40-d282b81c2728.JPG)

***after this pr
![2](https://user-images.githubusercontent.com/11223367/27851437-3c2b5214-618d-11e7-8dcf-fd7a840f010e.JPG)



