### PR TITLE
return prune data when context canceled

### DIFF
--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -70,7 +70,7 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 
 // PruneCache removes all cached build sources
 func (b *Backend) PruneCache(ctx context.Context) (*types.BuildCachePruneReport, error) {
-	size, err := b.fsCache.Prune()
+	size, err := b.fsCache.Prune(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to prune build cache")
 	}

--- a/builder/fscache/fscache_test.go
+++ b/builder/fscache/fscache_test.go
@@ -97,7 +97,7 @@ func TestFSCache(t *testing.T) {
 	assert.Equal(t, s, int64(8))
 
 	// prune deletes everything
-	released, err := fscache.Prune()
+	released, err := fscache.Prune(context.TODO())
 	assert.Nil(t, err)
 	assert.Equal(t, released, uint64(8))
 


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

This PR takes into user's cancel request when prune data into consideration. When context is canceled, docker daemon still returns the data which is already pruned. 

Prune Object includes: container, network, image, volume, and build cache.

fixes https://github.com/moby/moby/issues/33957

**- What I did**
1. make engine return prune data even if context is canceled.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


/cc @mlaventure 