### PR TITLE
Move test-unit out of hack/make

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -132,7 +132,7 @@ if \
 	command -v gcc &> /dev/null \
 	&& ! ( echo -e  '#include <libdevmapper.h>\nint main() { dm_task_deferred_remove(NULL); }'| gcc -xc - -o /dev/null -ldevmapper &> /dev/null ) \
 ; then
-    DOCKER_BUILDTAGS+=' libdm_no_deferred_remove'
+	DOCKER_BUILDTAGS+=' libdm_no_deferred_remove'
 fi
 
 # Use these flags when compiling the tests and final binary
@@ -158,8 +158,8 @@ fi
 ORIG_BUILDFLAGS+=( $REBUILD_FLAG )
 
 BUILDFLAGS=( $BUILDFLAGS "${ORIG_BUILDFLAGS[@]}" )
-# Test timeout.
 
+# Test timeout.
 if [ "${DOCKER_ENGINE_GOARCH}" == "arm" ]; then
 	: ${TIMEOUT:=10m}
 elif [ "${DOCKER_ENGINE_GOARCH}" == "windows" ]; then

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -132,7 +132,7 @@ if \
 	command -v gcc &> /dev/null \
 	&& ! ( echo -e  '#include <libdevmapper.h>\nint main() { dm_task_deferred_remove(NULL); }'| gcc -xc - -o /dev/null -ldevmapper &> /dev/null ) \
 ; then
-       DOCKER_BUILDTAGS+=' libdm_no_deferred_remove'
+    DOCKER_BUILDTAGS+=' libdm_no_deferred_remove'
 fi
 
 # Use these flags when compiling the tests and final binary
@@ -183,77 +183,10 @@ if [ "$(uname -s)" = 'FreeBSD' ]; then
 	LDFLAGS="$LDFLAGS -extld clang"
 fi
 
-HAVE_GO_TEST_COVER=
-if \
-	go help testflag | grep -- -cover > /dev/null \
-	&& go tool -n cover > /dev/null 2>&1 \
-; then
-	HAVE_GO_TEST_COVER=1
-fi
-
-# a helper to provide ".exe" when it's appropriate
-binary_extension() {
-	if [ "$(go env GOOS)" = 'windows' ]; then
-		echo -n '.exe'
-	fi
-}
-
-hash_files() {
-	while [ $# -gt 0 ]; do
-		f="$1"
-		shift
-		dir="$(dirname "$f")"
-		base="$(basename "$f")"
-		for hashAlgo in md5 sha256; do
-			if command -v "${hashAlgo}sum" &> /dev/null; then
-				(
-					# subshell and cd so that we get output files like:
-					#   $HASH docker-$VERSION
-					# instead of:
-					#   $HASH /go/src/github.com/.../$VERSION/binary/docker-$VERSION
-					cd "$dir"
-					"${hashAlgo}sum" "$base" > "$base.$hashAlgo"
-				)
-			fi
-		done
-	done
-}
-
 bundle() {
 	local bundle="$1"; shift
 	echo "---> Making bundle: $(basename "$bundle") (in $DEST)"
 	source "$SCRIPTDIR/make/$bundle" "$@"
-}
-
-copy_binaries() {
-	dir="$1"
-	# Add nested executables to bundle dir so we have complete set of
-	# them available, but only if the native OS/ARCH is the same as the
-	# OS/ARCH of the build target
-	if [ "$(go env GOOS)/$(go env GOARCH)" == "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
-		if [ -x /usr/local/bin/docker-runc ]; then
-			echo "Copying nested executables into $dir"
-			for file in containerd containerd-shim containerd-ctr runc init proxy; do
-				cp -f `which "docker-$file"` "$dir/"
-				if [ "$2" == "hash" ]; then
-					hash_files "$dir/docker-$file"
-				fi
-			done
-		fi
-	fi
-}
-
-install_binary() {
-	file="$1"
-	target="${DOCKER_MAKE_INSTALL_PREFIX:=/usr/local}/bin/"
-	if [ "$(go env GOOS)" == "linux" ]; then
-		echo "Installing $(basename $file) to ${target}"
-		mkdir -p "$target"
-		cp -f -L "$file" "$target"
-	else
-		echo "Install is only supported on linux"
-		return 1
-	fi
 }
 
 main() {

--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
+# a helper to provide ".exe" when it's appropriate
+binary_extension() {
+	if [ "$(go env GOOS)" = 'windows' ]; then
+		echo -n '.exe'
+	fi
+}
+
 GO_PACKAGE='github.com/docker/docker/cmd/dockerd'
 BINARY_SHORT_NAME='dockerd'
 BINARY_NAME="$BINARY_SHORT_NAME-$VERSION"
@@ -8,6 +15,27 @@ BINARY_EXTENSION="$(binary_extension)"
 BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
 
 source "${MAKEDIR}/.go-autogen"
+
+hash_files() {
+	while [ $# -gt 0 ]; do
+		f="$1"
+		shift
+		dir="$(dirname "$f")"
+		base="$(basename "$f")"
+		for hashAlgo in md5 sha256; do
+			if command -v "${hashAlgo}sum" &> /dev/null; then
+				(
+					# subshell and cd so that we get output files like:
+					#   $HASH docker-$VERSION
+					# instead of:
+					#   $HASH /go/src/github.com/.../$VERSION/binary/docker-$VERSION
+					cd "$dir"
+					"${hashAlgo}sum" "$base" > "$base.$hashAlgo"
+				)
+			fi
+		done
+	done
+}
 
 (
 export GOGC=${DOCKER_BUILD_GOGC:-1000}

--- a/hack/make/README.md
+++ b/hack/make/README.md
@@ -4,10 +4,9 @@ Each script is named after the bundle it creates.
 They should not be called directly - instead, pass it as argument to make.sh, for example:
 
 ```
-./hack/make.sh test
 ./hack/make.sh binary ubuntu
 
-# Or to run all bundles:
+# Or to run all default bundles:
 ./hack/make.sh
 ```
 

--- a/hack/make/binary-daemon
+++ b/hack/make/binary-daemon
@@ -1,9 +1,27 @@
 #!/usr/bin/env bash
 set -e
 
-[ -z "$KEEPDEST" ] && rm -rf "$DEST"
+copy_binaries() {
+	local dir="$1"
+	local hash="$2"
+	# Add nested executables to bundle dir so we have complete set of
+	# them available, but only if the native OS/ARCH is the same as the
+	# OS/ARCH of the build target
+	if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
+		return
+	fi
+	if [ ! -x /usr/local/bin/docker-runc ]; then
+		return
+	fi
+	echo "Copying nested executables into $dir"
+	for file in containerd containerd-shim containerd-ctr runc init proxy; do
+		cp -f `which "docker-$file"` "$dir/"
+		if [ "$hash" == "hash" ]; then
+			hash_files "$dir/docker-$file"
+		fi
+	done
+}
 
-(
-	source "${MAKEDIR}/.binary"
-	copy_binaries "$DEST" 'hash'
-)
+[ -z "$KEEPDEST" ] && rm -rf "$DEST"
+source "${MAKEDIR}/.binary"
+copy_binaries "$DEST" 'hash'

--- a/hack/make/install-binary-daemon
+++ b/hack/make/install-binary-daemon
@@ -3,6 +3,19 @@
 set -e
 rm -rf "$DEST"
 
+install_binary() {
+	local file="$1"
+	local target="${DOCKER_MAKE_INSTALL_PREFIX:=/usr/local}/bin/"
+	if [ "$(go env GOOS)" == "linux" ]; then
+		echo "Installing $(basename $file) to ${target}"
+		mkdir -p "$target"
+		cp -f -L "$file" "$target"
+	else
+		echo "Install is only supported on linux"
+		return 1
+	fi
+}
+
 (
 	DEST="$(dirname $DEST)/binary-daemon"
 	source "${MAKEDIR}/.binary-setup"

--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -1,58 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# Run Docker's test suite, including sub-packages, and store their output as a bundle
-# If $TESTFLAGS is set in the environment, it is passed as extra arguments to 'go test'.
-# You can use this to select certain tests to run, e.g.
-#
-#   TESTFLAGS='-test.run ^TestBuild$' ./hack/make.sh test-unit
-#
-bundle_test_unit() {
-	TESTFLAGS+=" -test.timeout=${TIMEOUT}"
-	INCBUILD="-i"
-	count=0
-	for flag in "${BUILDFLAGS[@]}"; do
-		if [ "${flag}" == ${INCBUILD} ]; then
-			unset BUILDFLAGS[${count}]
-			break
-		fi
-		count=$[ ${count} + 1 ]
-	done
+echo "DEPRECATED: use hack/test/unit instead of hack/make.sh test-unit" >&2
 
-	date
-	if [ -z "$TESTDIRS" ]; then
-		TEST_PATH=./...
-	else
-		TEST_PATH=./${TESTDIRS}
-	fi
-
-	source "${MAKEDIR}/.go-autogen"
-
-	if [ "$(go env GOHOSTOS)" = 'solaris' ]; then
-		pkg_list=$(go list -e \
-			-f '{{if ne .Name "github.com/docker/docker"}}
-				{{.ImportPath}}
-			    {{end}}' \
-			"${BUILDFLAGS[@]}" $TEST_PATH \
-			| grep github.com/docker/docker \
-			| grep -v github.com/docker/docker/vendor \
-			| grep -v github.com/docker/docker/daemon/graphdriver \
-			| grep -v github.com/docker/docker/man \
-			| grep -v github.com/docker/docker/integration-cli)
-	else
-		pkg_list=$(go list -e \
-			-f '{{if ne .Name "github.com/docker/docker"}}
-				{{.ImportPath}}
-			    {{end}}' \
-			"${BUILDFLAGS[@]}" $TEST_PATH \
-			| grep github.com/docker/docker \
-			| grep -v github.com/docker/docker/vendor \
-			| grep -v github.com/docker/docker/man \
-			| grep -v github.com/docker/docker/integration-cli)
-	fi
-
-	go test -cover -ldflags "$LDFLAGS" "${BUILDFLAGS[@]}" $TESTFLAGS $pkg_list
-	go test -cover -ldflags "$LDFLAGS" "${BUILDFLAGS[@]}" $TESTFLAGS github.com/docker/docker/pkg/term -test.root
-}
-
-bundle_test_unit 2>&1 | tee -a "$DEST/test.log"
+$SCRIPTDIR/test/unit 2>&1 | tee -a "$DEST/test.log"

--- a/hack/test/unit
+++ b/hack/test/unit
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Run unit tests
+#
+# TESTFLAGS - add additional test flags. Ex:
+#
+#   TESTFLAGS="-v -run TestBuild" hack/test/unit
+#
+# TESTDIRS - run tests for specified packages. Ex:
+#
+#    TESTDIRS="./pkg/term" hack/test/unit
+#
+set -eu -o pipefail
+
+TESTFLAGS+=" -test.timeout=${TIMEOUT:-5m}"
+BUILDFLAGS=( -tags "netgo seccomp libdm_no_deferred_remove" )
+TESTDIRS="${TESTDIRS:-"./..."}"
+
+exclude_paths="/vendor/|/integration-cli"
+if [ "$(go env GOHOSTOS)" = 'solaris' ]; then
+	exclude_paths="$exclude_paths|/daemon/graphdriver"
+fi
+pkg_list=$(go list $TESTDIRS | grep -vE "($exclude_paths)")
+
+go test -cover "${BUILDFLAGS[@]}" $TESTFLAGS $pkg_list


### PR DESCRIPTION
This is similar to the changes we made to `hack/validate`. Running tests shouldn't require `hack/make.sh`. Moving them to `hack/test/` will allow us to run them directly with less overhead.  It also makes the scripts much easier to read because there's no hidden state provided by a "runner" (hack/make.sh).

Also:
* Fixed a couple problems I found in #33520 (tests leaving the terminal broken, and remove the test flag)
* Moved some functions out of `hack/make.sh` to where they are used. The less global state provided by `hack/make.sh` the easier these scripts are to read.
* remove `HAVE_GO_TEST_COVER` which was dead code.

I'll address test-integration and test-docker-py as part of carrying #33344