### PR TITLE
Replace all dashes in version name before building rpm artifact

### DIFF
--- a/hack/make/build-rpm
+++ b/hack/make/build-rpm
@@ -45,7 +45,7 @@ set -e
 	fi
 
 	# Replace any other dashes with periods
-	rpmVersion="${rpmVersion/-/.}"
+	rpmVersion="${rpmVersion//-/.}"
 
 	rpmPackager="$(awk -F ': ' '$1 == "Packager" { print $2; exit }' hack/make/.build-rpm/${rpmName}.spec)"
 	rpmDate="$(date +'%a %b %d %Y')"


### PR DESCRIPTION
Signed-off-by: Mauricio Garavaglia <mauricio@medallia.com>

**- What I did**

fixed the build-rpm script to replace all the dashes in the version, and not just the first one. This allows to correctly build artifacts whose version includes multiple dashes. 

**- How I did it**

changed the bash substitution to include multiple dashes

**- How to verify it**

`echo 17.06.1-dev-1234 > VERSION && make rpm`

**- Description for the changelog**

Fix build rpm to replace all the dashes used in the version 

**- A picture of a cute animal (not mandatory but encouraged)**

![cute animal](https://s-media-cache-ak0.pinimg.com/236x/b0/13/fd/b013fdef09d1180341341e985d967d49--too-cute-cute-cute.jpg)
