### PR TITLE
Return an empty stats if "container not found"

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1165,6 +1165,9 @@ func (daemon *Daemon) stats(c *container.Container) (*types.StatsJSON, error) {
 	}
 	stats, err := daemon.containerd.Stats(c.ID)
 	if err != nil {
+		if strings.Contains(err.Error(), "container not found") {
+			return nil, errNotFound{c.ID}
+		}
 		return nil, err
 	}
 	s := &types.StatsJSON{}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -525,6 +525,9 @@ func (daemon *Daemon) stats(c *container.Container) (*types.StatsJSON, error) {
 	// Obtain the stats from HCS via libcontainerd
 	stats, err := daemon.containerd.Stats(c.ID)
 	if err != nil {
+		if strings.Contains(err.Error(), "container not found") {
+			return nil, errNotFound{c.ID}
+		}
 		return nil, err
 	}
 

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -39,3 +39,15 @@ func errExecPaused(id string) error {
 	err := fmt.Errorf("Container %s is paused, unpause the container before exec", id)
 	return errors.NewRequestConflictError(err)
 }
+
+type errNotFound struct {
+	containerID string
+}
+
+func (e errNotFound) Error() string {
+	return fmt.Sprintf("Container %s is not found", e.containerID)
+}
+
+func (e errNotFound) ContainerNotFound() bool {
+	return true
+}


### PR DESCRIPTION
If we get "container not found" error from containerd, it's possibly
because that this container has already been stopped. It will be ok to
ignore this error and just return an empty stats.

**Steps to reproduce:**
```
# docker run -tid --name tmp --restart=always ubuntu true && docker stats --no-stream
48d3344f404a2b4a28538af857dedab5bca7f3939667f51509c61dd9f150bf5c


(hangs...)



^C
#
```

It's a duplicate of #27772 which has already been closed by https://github.com/moby/moby/pull/28026, but https://github.com/moby/moby/pull/28026 is not a complete fix because if `docker stats --no-stream` comes faster after `docker run`, the container is still running when the code hits https://github.com/moby/moby/blob/master/daemon/stats.go#L35. Then I can see a lot of error logs from daemon:
```
time="2017-07-07T14:54:41.210577988+08:00" level=error msg="collecting stats for 48d3344f404a2b4a28538af857dedab5bca7f3939667f51509c61dd9f150bf5c: rpc error: code = Unknown desc = containerd: container not found"
time="2017-07-07T14:54:42.210686973+08:00" level=error msg="collecting stats for 48d3344f404a2b4a28538af857dedab5bca7f3939667f51509c61dd9f150bf5c: rpc error: code = Unknown desc = containerd: container not found"
time="2017-07-07T14:54:43.210721305+08:00" level=error msg="collecting stats for 48d3344f404a2b4a28538af857dedab5bca7f3939667f51509c61dd9f150bf5c: rpc error: code = Unknown desc = containerd: container not found"
time="2017-07-07T14:54:44.210637074+08:00" level=error msg="collecting stats for 48d3344f404a2b4a28538af857dedab5bca7f3939667f51509c61dd9f150bf5c: rpc error: code = Unknown desc = containerd: container not found"
time="2017-07-07T14:54:45.210742374+08:00" level=error msg="collecting stats for 48d3344f404a2b4a28538af857dedab5bca7f3939667f51509c61dd9f150bf5c: rpc error: code = Unknown desc = containerd: container not found"
time="2017-07-07T14:54:46.210928003+08:00" level=error msg="collecting stats for 48d3344f404a2b4a28538af857dedab5bca7f3939667f51509c61dd9f150bf5c: rpc error: code = Unknown desc = containerd: container not found"
time="2017-07-07T14:54:47.210899239+08:00" level=error msg="collecting stats for 48d3344f404a2b4a28538af857dedab5bca7f3939667f51509c61dd9f150bf5c: rpc error: code = Unknown desc = containerd: container not found"
time="2017-07-07T14:54:48.210914277+08:00" level=error msg="collecting stats for 48d3344f404a2b4a28538af857dedab5bca7f3939667f51509c61dd9f150bf5c: rpc error: code = Unknown desc = containerd: container not found"
time="2017-07-07T14:54:49.210748399+08:00" level=error msg="collecting stats for 48d3344f404a2b4a28538af857dedab5bca7f3939667f51509c61dd9f150bf5c: rpc error: code = Unknown desc = containerd: container not found"
time="2017-07-07T14:54:50.210818936+08:00" level=error msg="collecting stats for 48d3344f404a2b4a28538af857dedab5bca7f3939667f51509c61dd9f150bf5c: rpc error: code = Unknown desc = containerd: container not found"
time="2017-07-07T14:54:51.210596037+08:00" level=error msg="collecting stats for 48d3344f404a2b4a28538af857dedab5bca7f3939667f51509c61dd9f150bf5c: rpc error: code = Unknown desc = containerd: container not found"
```
This pr will ignore this error and just return an empty stats. So that client will not hang forever.

**after this pr:**
```
# docker run -tid --name tmp --restart=always ubuntu true && docker stats --no-stream
0c93066033730361fb296af0e3b07e4b264169535353aecd9121159b81dfa101
CONTAINER           CPU %               MEM USAGE / LIMIT   MEM %               NET I/O             BLOCK I/O           PIDS
```

Signed-off-by: Yuanhong Peng <pengyuanhong@huawei.com>

**- A picture of a cute animal (not mandatory but encouraged)**
![images](https://user-images.githubusercontent.com/20569488/27949550-a51ea9fc-6330-11e7-92d6-1fd3f0df0fd8.jpg)