### PR TITLE
make engine support cluster config event

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5678,6 +5678,8 @@ paths:
 
         Secrets report these events: `create`, `update`, and `remove`
 
+        Configs report these events: `create`, `update`, and `remove`
+
       operationId: "SystemEvents"
       produces:
         - "application/json"

--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -19,6 +19,8 @@ const (
 	NodeEventType = "node"
 	// SecretEventType is the event type that secrets generate
 	SecretEventType = "secret"
+	// ConfigEventType is the event type that configs generate
+	ConfigEventType = "config"
 )
 
 // Actor describes something that generates events,

--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -202,6 +202,10 @@ func (n *nodeRunner) watchClusterEvents(ctx context.Context, conn *grpc.ClientCo
 				Kind:   "secret",
 				Action: swarmapi.WatchActionKindCreate | swarmapi.WatchActionKindUpdate | swarmapi.WatchActionKindRemove,
 			},
+			{
+				Kind:   "config",
+				Action: swarmapi.WatchActionKindCreate | swarmapi.WatchActionKindUpdate | swarmapi.WatchActionKindRemove,
+			},
 		},
 		IncludeOldObject: true,
 	})

--- a/daemon/events.go
+++ b/daemon/events.go
@@ -175,6 +175,8 @@ func (daemon *Daemon) generateClusterEvent(msg *swarmapi.WatchMessage) {
 			daemon.logNetworkEvent(event.Action, v.Network, event.OldObject.GetNetwork())
 		case *swarmapi.Object_Secret:
 			daemon.logSecretEvent(event.Action, v.Secret, event.OldObject.GetSecret())
+		case *swarmapi.Object_Config:
+			daemon.logConfigEvent(event.Action, v.Config, event.OldObject.GetConfig())
 		default:
 			logrus.Warnf("unrecognized event: %v", event)
 		}
@@ -195,6 +197,14 @@ func (daemon *Daemon) logSecretEvent(action swarmapi.WatchActionKind, secret *sw
 	}
 	eventTime := eventTimestamp(secret.Meta, action)
 	daemon.logClusterEvent(action, secret.ID, "secret", attributes, eventTime)
+}
+
+func (daemon *Daemon) logConfigEvent(action swarmapi.WatchActionKind, config *swarmapi.Config, oldConfig *swarmapi.Config) {
+	attributes := map[string]string{
+		"name": config.Spec.Annotations.Name,
+	}
+	eventTime := eventTimestamp(config.Meta, action)
+	daemon.logClusterEvent(action, config.ID, "config", attributes, eventTime)
 }
 
 func (daemon *Daemon) logNodeEvent(action swarmapi.WatchActionKind, node *swarmapi.Node, oldNode *swarmapi.Node) {

--- a/daemon/events/filter.go
+++ b/daemon/events/filter.go
@@ -94,6 +94,10 @@ func (ef *Filter) matchSecret(ev events.Message) bool {
 	return ef.fuzzyMatchName(ev, events.SecretEventType)
 }
 
+func (ef *Filter) matchConfig(ev events.Message) bool {
+	return ef.fuzzyMatchName(ev, events.ConfigEventType)
+}
+
 func (ef *Filter) fuzzyMatchName(ev events.Message, eventType string) bool {
 	return ef.filter.FuzzyMatch(eventType, ev.Actor.ID) ||
 		ef.filter.FuzzyMatch(eventType, ev.Actor.Attributes["name"])

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -27,6 +27,7 @@ keywords: "API, Docker, rcli, REST, documentation"
   enabled.
 * `GET /images/(name)/get` now includes an `ImageMetadata` field which contains image metadata that is local to the engine and not part of the image config.
 * `POST /services/create` now accepts a `PluginSpec` when `TaskTemplate.Runtime` is set to `plugin`
+* `GET /events` now supports config events `create`, `update` and `remove` that are emitted when users create, update or remove a config
 
 ## v1.30 API changes
 

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -2208,3 +2208,23 @@ func (s *DockerSwarmSuite) TestSwarmClusterEventsSecret(c *check.C) {
 	// filtered by secret
 	waitForEvent(c, d, t1, "-f type=secret", "secret remove "+id, defaultRetryCount)
 }
+
+func (s *DockerSwarmSuite) TestSwarmClusterEventsConfig(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	testName := "test_config"
+	id := d.CreateConfig(c, swarm.ConfigSpec{
+		Annotations: swarm.Annotations{
+			Name: testName,
+		},
+		Data: []byte("TESTINGDATA"),
+	})
+	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("configs: %s", id))
+
+	waitForEvent(c, d, "0", "-f scope=swarm", "config create "+id, defaultRetryCount)
+
+	t1 := daemonUnixTime(c)
+	d.DeleteConfig(c, id)
+	// filtered by config
+	waitForEvent(c, d, t1, "-f type=config", "config remove "+id, defaultRetryCount)
+}


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I found that docker-ce 17.06.0-ce has already supported cluster events, such as node, service, secret and so on. While I think there is still config events missing.

ping @dongluochen @aaronlehmann 

**- What I did**
1. make engine support cluster config event
2. add a test case for config event
3. update swagger.yml to add configs event

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

