### PR TITLE
add cluster events details in swagger.yml

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5662,15 +5662,21 @@ paths:
 
         Various objects within Docker report events when something happens to them.
 
-        Containers report these events: `attach, commit, copy, create, destroy, detach, die, exec_create, exec_detach, exec_start, export, health_status, kill, oom, pause, rename, resize, restart, start, stop, top, unpause, update`
+        Containers report these events: `attach`, `commit`, `copy`, `create`, `destroy`, `detach`, `die`, `exec_create`, `exec_detach`, `exec_start`, `export`, `health_status`, `kill`, `oom`, `pause`, `rename`, `resize`, `restart`, `start`, `stop`, `top`, `unpause`, and `update`
 
-        Images report these events: `delete, import, load, pull, push, save, tag, untag`
+        Images report these events: `delete`, `import`, `load`, `pull`, `push`, `save`, `tag`, and `untag`
 
-        Volumes report these events: `create, mount, unmount, destroy`
+        Volumes report these events: `create`, `mount`, `unmount`, and `destroy`
 
-        Networks report these events: `create, connect, disconnect, destroy`
+        Networks report these events: `create`, `connect`, `disconnect`, `destroy`, `update`, and `remove`
 
         The Docker daemon reports these events: `reload`
+
+        Services report these events: `create`, `update`, and `remove`
+
+        Nodes report these events: `create`, `update`, and `remove`
+
+        Secrets report these events: `create`, `update`, and `remove`
 
       operationId: "SystemEvents"
       produces:
@@ -5745,7 +5751,8 @@ paths:
             - `label=<string>` image or container label
             - `network=<string>` network name or ID
             - `plugin`=<string> plugin name or ID
-            - `type=<string>` object to filter by, one of `container`, `image`, `volume`, `network`, or `daemon`
+            - `scope`＝<string> local or swarm
+            - `type=<string>` object to filter by, one of `container`, `image`, `volume`, `network`, `daemon`, `plugin`, `node`, `service` or `secret`
             - `volume=<string>` volume name or ID
           type: "string"
       tags: ["System"]


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

PR https://github.com/moby/moby/pull/32421 introduces the cluster events. While this part has not updated in the docs and swagger.

**- What I did**
1. add cluster events details in swagger.yml

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

