### PR TITLE
Split homedir files by operating system

### DIFF
--- a/pkg/homedir/homedir_unix.go
+++ b/pkg/homedir/homedir_unix.go
@@ -1,8 +1,9 @@
+// +build !windows
+
 package homedir
 
 import (
 	"os"
-	"runtime"
 
 	"github.com/opencontainers/runc/libcontainer/user"
 )
@@ -10,9 +11,6 @@ import (
 // Key returns the env var name for the user's home dir based on
 // the platform being run on
 func Key() string {
-	if runtime.GOOS == "windows" {
-		return "USERPROFILE"
-	}
 	return "HOME"
 }
 
@@ -21,7 +19,7 @@ func Key() string {
 // Returned path should be used with "path/filepath" to form new paths.
 func Get() string {
 	home := os.Getenv(Key())
-	if home == "" && runtime.GOOS != "windows" {
+	if home == "" {
 		if u, err := user.CurrentUser(); err == nil {
 			return u.Home
 		}
@@ -32,8 +30,5 @@ func Get() string {
 // GetShortcutString returns the string that is shortcut to user's home directory
 // in the native shell of the platform running on.
 func GetShortcutString() string {
-	if runtime.GOOS == "windows" {
-		return "%USERPROFILE%" // be careful while using in format functions
-	}
 	return "~"
 }

--- a/pkg/homedir/homedir_windows.go
+++ b/pkg/homedir/homedir_windows.go
@@ -1,0 +1,24 @@
+package homedir
+
+import (
+	"os"
+)
+
+// Key returns the env var name for the user's home dir based on
+// the platform being run on
+func Key() string {
+	return "USERPROFILE"
+}
+
+// Get returns the home directory of the current user with the help of
+// environment variables depending on the target operating system.
+// Returned path should be used with "path/filepath" to form new paths.
+func Get() string {
+	return os.Getenv(Key())
+}
+
+// GetShortcutString returns the string that is shortcut to user's home directory
+// in the native shell of the platform running on.
+func GetShortcutString() string {
+	return "%USERPROFILE%" // be careful while using in format functions
+}


### PR DESCRIPTION
libcontainer/user does not build at all on Windows any more, and
this was breaking the client on Windows with upstream `runc`. As
these functions are not used anyway, just split out and stop
checking `runtime`.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![dog-looking-in-window](https://user-images.githubusercontent.com/482364/28019769-ff86cabe-6579-11e7-8fb8-98f06596e644.jpg)
