### PR TITLE
Fix multiple `COPY --from` in multistage builds

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -137,10 +137,13 @@ type ChildConfig struct {
 // NewChildImage creates a new Image as a child of this image.
 func NewChildImage(img *Image, child ChildConfig, platform string) *Image {
 	isEmptyLayer := layer.IsEmpty(child.DiffID)
-	rootFS := img.RootFS
-	if rootFS == nil {
+	var rootFS *RootFS
+	if img.RootFS != nil {
+		rootFS = img.RootFS.Clone()
+	} else {
 		rootFS = NewRootFS()
 	}
+
 	if !isEmptyLayer {
 		rootFS.Append(child.DiffID)
 	}

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/layer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,4 +52,39 @@ func TestMarshalKeyOrder(t *testing.T) {
 	if !sort.IntsAreSorted(indexes) {
 		t.Fatal("invalid key order in JSON: ", string(b))
 	}
+}
+
+func TestNewChildImageFromImageWithRootFS(t *testing.T) {
+	rootFS := NewRootFS()
+	rootFS.Append(layer.DiffID("ba5e"))
+	parent := &Image{
+		RootFS: rootFS,
+		History: []History{
+			NewHistory("a", "c", "r", false),
+		},
+	}
+	childConfig := ChildConfig{
+		DiffID:  layer.DiffID("abcdef"),
+		Author:  "author",
+		Comment: "comment",
+		ContainerConfig: &container.Config{
+			Cmd: []string{"echo", "foo"},
+		},
+		Config: &container.Config{},
+	}
+
+	newImage := NewChildImage(parent, childConfig, "platform")
+	expectedDiffIDs := []layer.DiffID{layer.DiffID("ba5e"), layer.DiffID("abcdef")}
+	assert.Equal(t, expectedDiffIDs, newImage.RootFS.DiffIDs)
+	assert.Equal(t, childConfig.Author, newImage.Author)
+	assert.Equal(t, childConfig.Config, newImage.Config)
+	assert.Equal(t, *childConfig.ContainerConfig, newImage.ContainerConfig)
+	assert.Equal(t, "platform", newImage.OS)
+	assert.Equal(t, childConfig.Config, newImage.Config)
+
+	assert.Len(t, newImage.History, 2)
+	assert.Equal(t, childConfig.Comment, newImage.History[1].Comment)
+
+	// RootFS should be copied not mutated
+	assert.NotEqual(t, parent.RootFS.DiffIDs, newImage.RootFS.DiffIDs)
 }

--- a/image/rootfs.go
+++ b/image/rootfs.go
@@ -34,6 +34,14 @@ func (r *RootFS) Append(id layer.DiffID) {
 	r.DiffIDs = append(r.DiffIDs, id)
 }
 
+// Clone returns a copy of the RootFS
+func (r *RootFS) Clone() *RootFS {
+	newRoot := NewRootFS()
+	newRoot.Type = r.Type
+	newRoot.DiffIDs = append(r.DiffIDs)
+	return newRoot
+}
+
 // ChainID returns the ChainID for the top layer in RootFS.
 func (r *RootFS) ChainID() layer.ChainID {
 	if runtime.GOOS == "windows" && r.Type == typeLayersWithBase {


### PR DESCRIPTION
Fixes #33974

I remember thinking it was strange that this pointer was being re-used, but for some reason it seemed to work with the old code. The RootFS was being mutated, so using the cached image reference was causing it to have the wrong DiffIDs.