### PR TITLE
add cluster events change in version_history.md

### DIFF
--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -46,6 +46,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /containers/(name)/wait` now accepts a `condition` query parameter to indicate which state change condition to wait for. Also, response headers are now returned immediately to acknowledge that the server has registered a wait callback for the client.
 * `POST /swarm/init` now accepts a `DataPathAddr` property to set the IP-address or network interface to use for data traffic
 * `POST /swarm/join` now accepts a `DataPathAddr` property to set the IP-address or network interface to use for data traffic
+* `GET /events` now supports service, node and secret events which are emmited when users create, update and remove service, node and secret 
+* `GET /events` now supports network remove event which is emmitted when users remove a swarm scoped network
+* `GET /events` now supports a filter type `scope` in which supported value could be swarm and local
 
 ## v1.29 API changes
 


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

docker 17.06-ce has released and uses api version 1.30. While there is something missing in version_history.md with api 1.30. Cluster events is supported in 1.30, and I think we should support this.

**- What I did**
1. add cluster events change in version_history.md

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

