### PR TITLE
Keep pause state when restoring container's status

### DIFF
--- a/container/state.go
+++ b/container/state.go
@@ -278,7 +278,9 @@ func (s *State) SetRunning(pid int, initial bool) {
 	s.ErrorMsg = ""
 	s.Running = true
 	s.Restarting = false
-	s.Paused = false
+	if initial {
+		s.Paused = false
+	}
 	s.ExitCodeValue = 0
 	s.Pid = pid
 	if initial {


### PR DESCRIPTION
Do not change pause state when restoring container's
status, or status in docker will be different with
status in runc.

Signed-off-by: Fengtu Wang <wangfengtu@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
 When restoring containers, it will first change state to StateRestore in 
https://github.com/moby/moby/blob/c0e6da7637491886904725c2fcec9db6ec261af4/libcontainerd/client_linux.go#L377
and then change state according event in https://github.com/moby/moby/blob/c0e6da7637491886904725c2fcec9db6ec261af4/libcontainerd/client_linux.go#L391
So if no event found(it may occur after a long time running, because events.log can only contain about 500 events), state will only changed to StateRestore.

 StateRestore will call SetRunning in https://github.com/moby/moby/blob/c0e6da7637491886904725c2fcec9db6ec261af4/daemon/monitor.go#L120
But s.Paused is set to false no matter container is paused or not in https://github.com/moby/moby/blob/c0e6da7637491886904725c2fcec9db6ec261af4/container/state.go#L281

So when restoring a container which is paused, if past event can not found in events.log, container will in
a wrong state of unpaused in docker daemon, but paused in runc.

**- How I did it**
Do not set state s.Paused to false if is is restoring container.

**- How to verify it**
1. Start docker daemon with parameter --live-restore
2. Start a container and pause it 
```
root@SZV1000164744:~# docker run -td busybox top
48953a3164d0d5d780e160a07d292a7fedf0fc078b065b568485d0d00cdb5cd6
root@SZV1000164744:~# docker pause 48953a3164d0d5d780e160a07d292a7fedf0fc078b065b568485d0d00cdb5cd6
48953a3164d0d5d780e160a07d292a7fedf0fc078b065b568485d0d00cdb5cd6
root@SZV1000164744:~#
```
3. Do many operations on other containers until events.log does not contain any event of container
    48953a316  which is paused above. Or just delete events.log in /var/run/docker/libcontainerd/containerd/events.log. This operation imitate that after long time running , events.log may not contain any event of paused container.

4. restart docker daemon

5. Check status in docker daemon and status in runc, following is the result before this PR.
```
root@SZV1000164744:~# docker-runc list
ID                                                                 PID         STATUS      BUNDLE                                                                                       CREATED                          OWNER
48953a3164d0d5d780e160a07d292a7fedf0fc078b065b568485d0d00cdb5cd6   72344       paused      /run/docker/libcontainerd/48953a3164d0d5d780e160a07d292a7fedf0fc078b065b568485d0d00cdb5cd6   2017-07-12T08:18:27.790590618Z   root
root@SZV1000164744:~# docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
48953a3164d0        busybox             "top"               2 minutes ago       Up 2 minutes                            dazzling_williams
root@SZV1000164744:~#
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

