### PR TITLE
In the case of remounting with changed data, need to call mount

### DIFF
--- a/pkg/mount/mounter_linux.go
+++ b/pkg/mount/mounter_linux.go
@@ -29,8 +29,9 @@ func isremount(device string, flags uintptr) bool {
 
 func mount(device, target, mType string, flags uintptr, data string) error {
 	oflags := flags &^ ptypes
-	if !isremount(device, flags) {
-		// Initial call applying all non-propagation flags.
+	if !isremount(device, flags) || data != "" {
+		// Initial call applying all non-propagation flags for mount
+		// or remount with changed data
 		if err := unix.Mount(device, target, mType, oflags, data); err != nil {
 			return err
 		}


### PR DESCRIPTION
The case where we are trying to do a remount with changed filesystem specific options was missing,
we need to call `mount` as well here to change those options.

See #33844 for where we need this, as we change `tmpfs` options.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>
