### PR TITLE
NegotiateAPIVersionPing should set version when ping returns default version

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -265,8 +265,8 @@ func (cli *Client) NegotiateAPIVersionPing(p types.Ping) {
 		cli.version = api.DefaultVersion
 	}
 
-	// if server version is lower than the maximum version supported by the Client, downgrade
-	if versions.LessThan(p.APIVersion, api.DefaultVersion) {
+	// if server version is less than or equal to the maximum version supported by the Client, downgrade
+	if versions.LessThanOrEqualTo(p.APIVersion, api.DefaultVersion) {
 		cli.version = p.APIVersion
 	}
 }


### PR DESCRIPTION
There's an edge case which we hit recently on Swarm classic that this PR fixes.

Consider the case when a client was created with some old version (say 1.20). This means `cli.version` is set to 1.20.

Suppose also that `api.DefaultVersion` is 1.30 and the server ping also returns that version, i.e. `p.APIVersion` is 1.30 as well. When this happens, then this following condition is skipped.

```
// if server version is lower than the maximum version supported by the Client, downgrade
if versions.LessThan(p.APIVersion, api.DefaultVersion) {
  cli.version = p.APIVersion
}
```
That results in `cli.version` staying put at 1.20, even though it should have been updated.

While nobody should be creating clients with old versions, I don't think there are any other side effects of making this change.

cc @thaJeztah (last updater for this piece of code)
cc @wsong (who discovered the bug)