### PR TITLE
Warn about unknown options in the config file 

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -320,7 +320,10 @@ func getConflictFreeConfiguration(configFile string, flags *pflag.FlagSet) (*Con
 			return nil, err
 		}
 
-		configSet := configValuesSet(jsonConfig)
+		configSet, unnecessaryKeys := configValuesSet(jsonConfig)
+		if len(unnecessaryKeys) > 0 {
+			logrus.Warnf("The following configuration keys are unnecessary: %s", strings.Join(unnecessaryKeys, ","))
+		}
 
 		if err := findConfigurationConflicts(configSet, flags); err != nil {
 			return nil, err
@@ -377,11 +380,26 @@ func getConflictFreeConfiguration(configFile string, flags *pflag.FlagSet) (*Con
 	return &config, nil
 }
 
-// configValuesSet returns the configuration values explicitly set in the file.
-func configValuesSet(config map[string]interface{}) map[string]interface{} {
+// configValuesSet returns the configuration values explicitly set in the file alongside with
+// unnecessary keys which are in the file but are empty and are not options.
+func configValuesSet(config map[string]interface{}) (map[string]interface{}, []string) {
 	flatten := make(map[string]interface{})
+	// The reason we return unnecessary keys is to detect unnecessary conifgurations.
+	// For example, the following will alert the user that "tls" is not
+	// necessary because it is empty and is not a flat option such as "default-ulimits".
+	//
+	// {
+	// ...
+	//    "tls": {}
+	// }
+	//
+	// This will make the configuration file both easy to read and easy to maintain.
+	unnecessaryKeys := []string{}
 	for k, v := range config {
 		if m, isMap := v.(map[string]interface{}); isMap && !flatOptions[k] {
+			if len(m) == 0 {
+				unnecessaryKeys = append(unnecessaryKeys, k)
+			}
 			for km, vm := range m {
 				flatten[km] = vm
 			}
@@ -390,7 +408,7 @@ func configValuesSet(config map[string]interface{}) map[string]interface{} {
 
 		flatten[k] = v
 	}
-	return flatten
+	return flatten, unnecessaryKeys
 }
 
 // findConfigurationConflicts iterates over the provided flags searching for


### PR DESCRIPTION
**- What I did**

I would like to have a consistent behavior when loading the configuration file.
When I have a key in daemon.json that is not an option and is empty, I rather the daemon to warn me about it than continue running without knowing that something is ignored.
It is also another way to make sure there are no typos. For example, "default-ulimit" instead of "default-ulimits".

**- How I did it**

* Change `configValueSet` to return `unnecessaryKeys` keys alongside with `configSet`
* Check that `unnecessaryKeys` is empty otherwise print a warning message specifying the ignored options

**- How to verify it**

```
$ TESTDIRS='daemon/config' hack/make.sh test-unit
```