### PR TITLE
Change uid/gid on 'docker cp' and preserve it on 'docker cp -a'

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -277,7 +277,8 @@ func (daemon *Daemon) containerExtractToDir(container *container.Container, path
 
 	options := daemon.defaultTarCopyOptions(noOverwriteDirNonDir)
 
-	if copyUIDGID {
+	// If we don't want to copy uid/gid, modify tar copy options to use uid/gid of container's main user
+	if !copyUIDGID {
 		var err error
 		// tarCopyOptions will appropriately pull in the right uid/gid for the
 		// user/group and will set the options.


### PR DESCRIPTION
Signed-off-by: Jorge Marin <chipironcin@users.noreply.github.com>
Fixes #34096

**- What I did**
Modified behavior of `docker cp` command to revert it back to the original behavior after https://github.com/moby/moby/pull/28923

**- How I did it**
Negate a variable and add an explanatory comment.

**- How to verify it**
Read https://github.com/moby/moby/issues/34096

**- Description for the changelog**
Revert `docker cp` behavior back to old way of setting uid/gid when copying files from host to a container while preserving `docker cp -a` option for copying all uid/gid information.

**- A picture of a cute animal (not mandatory but encouraged)**

![chamaleon](https://user-images.githubusercontent.com/3980637/28181178-eef8aa2e-6807-11e7-93a7-cdd17d1dbe86.png)
