### PR TITLE
download-frozen-image-v2.sh: follow redirects

### DIFF
--- a/contrib/download-frozen-image-v2.sh
+++ b/contrib/download-frozen-image-v2.sh
@@ -57,7 +57,7 @@ fetch_blob() {
 	local curlArgs=( "$@" )
 
 	local curlHeaders="$(
-		curl -S "${curlArgs[@]}" \
+		curl -SL "${curlArgs[@]}" \
 			-H "Authorization: Bearer $token" \
 			"$registryBase/v2/$image/blobs/$digest" \
 			-o "$targetFile" \


### PR DESCRIPTION
If we don't follow the redirects, a redirect url instead of a json
object will be saved in $targetFile when the server returns HTTP 307.

Signed-off-by: Jacob Wen <jian.w.wen@oracle.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

