### PR TITLE
Bugfix: Remove links when remove container

### DIFF
--- a/daemon/links.go
+++ b/daemon/links.go
@@ -76,12 +76,16 @@ func (l *linkIndex) parents(child *container.Container) map[string]*container.Co
 }
 
 // delete deletes all link relationships referencing this container
-func (l *linkIndex) delete(container *container.Container) {
+func (l *linkIndex) delete(container *container.Container) []string {
 	l.mu.Lock()
-	for _, child := range l.idx[container] {
+
+	var aliases []string
+	for alias, child := range l.idx[container] {
+		aliases = append(aliases, alias)
 		delete(l.childIdx[child], container)
 	}
 	delete(l.idx, container)
 	delete(l.childIdx, container)
 	l.mu.Unlock()
+	return aliases
 }


### PR DESCRIPTION
Steps to reproduce:
```
# docker run -tid --name aaa ubuntu
57bfd00ac5559f72eec8c1b32a01fe38427d66687940f74611e65137414f0ada
# docker run -tid --name bbb --link aaa ubuntu
23ad18362950f39b638206ab4d1885fd4f50cbd1d16aac9cab8e97e0c8363471
# docker ps --no-trunc
CONTAINER ID                                                       IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
23ad18362950f39b638206ab4d1885fd4f50cbd1d16aac9cab8e97e0c8363471   ubuntu              "/bin/bash"         4 seconds ago       Up 3 seconds                            bbb
57bfd00ac5559f72eec8c1b32a01fe38427d66687940f74611e65137414f0ada   ubuntu              "/bin/bash"         14 seconds ago      Up 14 seconds                           aaa,bbb/aaa
# docker rm -f bbb
bbb
# docker ps --no-trunc
CONTAINER ID                                                       IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
57bfd00ac5559f72eec8c1b32a01fe38427d66687940f74611e65137414f0ada   ubuntu              "/bin/bash"         29 seconds ago      Up 28 seconds                           aaa,bbb/aaa
# docker rm --link bbb/aaa
Error response from daemon: Cannot get parent /bbb for name /bbb/aaa
```

When we rm container `bbb`, we can still see `bbb/aaa` in `docker ps --no-trunc`. And this link cannot be deleted since container `bbb` has already been removed.

So, we should remove links of a container when it is deleted.

**after this PR:**
```
# docker run -tid --name aaa ubuntu
123ee6c52ba5fe61f1da468ea7c67c2a3c97d5220e49c867c1ca7c643343f34c
# docker run -tid --name bbb --link aaa ubuntu
ee0c046a8268518b165468f47fcba1d68c490ec035179023256d547823d79c2b
# docker ps --no-trunc
CONTAINER ID                                                       IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
ee0c046a8268518b165468f47fcba1d68c490ec035179023256d547823d79c2b   ubuntu              "/bin/bash"         5 seconds ago       Up 3 seconds                            bbb
123ee6c52ba5fe61f1da468ea7c67c2a3c97d5220e49c867c1ca7c643343f34c   ubuntu              "/bin/bash"         9 seconds ago       Up 8 seconds                            aaa,bbb/aaa
# docker rm -f bbb
bbb
# docker ps --no-trunc
CONTAINER ID                                                       IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
123ee6c52ba5fe61f1da468ea7c67c2a3c97d5220e49c867c1ca7c643343f34c   ubuntu              "/bin/bash"         18 seconds ago      Up 17 seconds                           aaa
```

Signed-off-by: Yuanhong Peng <pengyuanhong@huawei.com>
