### PR TITLE
Handle https proxy's CONNECT response

### DIFF
--- a/contrib/download-frozen-image-v2.sh
+++ b/contrib/download-frozen-image-v2.sh
@@ -64,7 +64,7 @@ fetch_blob() {
 			-D-
 	)"
 	curlHeaders="$(echo "$curlHeaders" | tr -d '\r')"
-	if [ "$(echo "$curlHeaders" | awk 'NR == 1 { print $2; exit }')" != '200' ]; then
+	if echo "$curlHeaders" | grep -qE "^HTTP/[0-9].[0-9] 3"; then
 		rm -f "$targetFile"
 
 		local blobRedirect="$(echo "$curlHeaders" | awk -F ': ' 'tolower($1) == "location" { print $2; exit }')"


### PR DESCRIPTION
When using a https proxy, an extra HTTP 200 header will be generated.
So we can't rely on detecting the first http header.

$curlHeaders with https proxy:
"HTTP/1.0 200 Connection established  <-- the https proxy's response

HTTP/1.1 307 Temporary Redirect
...
"

See https://stackoverflow.com/a/34537988/889429

Fixes #34131

Signed-off-by: Jacob Wen <jian.w.wen@oracle.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

