### PR TITLE
Memory related limit should be able to update to 0

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -306,13 +306,18 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 	if resources.CpusetMems != "" {
 		cResources.CpusetMems = resources.CpusetMems
 	}
-	if resources.Memory != 0 {
+	if resources.Memory == -1 || resources.Memory > 0 {
 		// if memory limit smaller than already set memoryswap limit and doesn't
 		// update the memoryswap limit, then error out.
 		if resources.Memory > cResources.MemorySwap && resources.MemorySwap == 0 {
 			return fmt.Errorf("Memory limit should be smaller than already set memoryswap limit, update the memoryswap at the same time")
 		}
-		cResources.Memory = resources.Memory
+
+		if resources.Memory > 0 {
+			cResources.Memory = resources.Memory
+		} else {
+			cResources.Memory = 0
+		}
 	}
 	if resources.MemorySwap != 0 {
 		cResources.MemorySwap = resources.MemorySwap

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -295,7 +295,7 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 	fixMemorySwappiness(resources)
 
 	// memory subsystem checks and adjustments
-	if resources.Memory != 0 && resources.Memory < linuxMinMemory {
+	if resources.Memory > 0 && resources.Memory < linuxMinMemory {
 		return warnings, fmt.Errorf("Minimum memory limit allowed is 4MB")
 	}
 	if resources.Memory > 0 && !sysInfo.MemoryLimit {


### PR DESCRIPTION
**- Description**
The dafault value of Memory,  KernelMemory, MemoryReservation, MemorySwap is 0 in default. However, the `docker update` command is not able to set them back to 0.

For example
1. create a container with memory limit 512 MB
```
docker run -dit -m 536870912 --name test ubuntu /bin/bash
docker inspect test | grep \"Memory\"
            "Memory": 536870912,
```
2. change the memory limit to 0 MB (default)
```
docker update -m 0 test
test
```
3. the memory limit remain the same as follows
```
docker inspect test | grep \"Memory\"
            "Memory": 536870912,
```

**- How I did it**
change the condition from `!= 0` to `>= 0`

**- How to verify it**
1. create a container with memory limit 512 MB
```
docker run -dit -m 536870912 --name test ubuntu /bin/bash
docker inspect test | grep \"Memory\"
            "Memory": 536870912,
```
2. change the memory limit to 0 MB (default)
```
docker update -m 0 test
test
```
3. the memory limit will be 0
```
docker inspect test | grep \"Memory\"
            "Memory": 0,
```