### PR TITLE
Replaces fluentd-address string by constant

### DIFF
--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -189,7 +189,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		}
 	}
 
-	_, err := parseAddress(cfg["fluentd-address"])
+	_, err := parseAddress(cfg[addressKey])
 	return err
 }
 


### PR DESCRIPTION
**- What I did**

Replaced the use of a string in a map lookup by its constant equivalent. 

**- How I did it**

Replacing `"fluentd-address"` by `addressKey`

**- How to verify it**

Configuring a fluentd logger and specifying the `fluentd-address` option will still work.

**- Description for the changelog**

Replacing `"fluentd-address"` by `addressKey` constant.

**- A picture of a cute animal (not mandatory but encouraged)**

![b0ad5940781fb0316f31d3fc18ef5a5e](https://user-images.githubusercontent.com/27320/28256892-439cab64-6a7b-11e7-9fbb-2ec39a766b95.jpg)

