### PR TITLE
Replace manually written wrappers by functions from x/sys/unix

### DIFF
--- a/pkg/loopback/ioctl.go
+++ b/pkg/loopback/ioctl.go
@@ -9,15 +9,15 @@ import (
 )
 
 func ioctlLoopCtlGetFree(fd uintptr) (int, error) {
-	index, _, err := unix.Syscall(unix.SYS_IOCTL, fd, LoopCtlGetFree, 0)
-	if err != 0 {
+	index, err := unix.IoctlGetInt(int(fd), LoopCtlGetFree)
+	if err != nil {
 		return 0, err
 	}
-	return int(index), nil
+	return index, nil
 }
 
 func ioctlLoopSetFd(loopFd, sparseFd uintptr) error {
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, loopFd, LoopSetFd, sparseFd); err != 0 {
+	if err := unix.IoctlSetInt(int(loopFd), LoopSetFd, int(sparseFd)); err != nil {
 		return err
 	}
 	return nil
@@ -47,7 +47,7 @@ func ioctlLoopGetStatus64(loopFd uintptr) (*loopInfo64, error) {
 }
 
 func ioctlLoopSetCapacity(loopFd uintptr, value int) error {
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, loopFd, LoopSetCapacity, uintptr(value)); err != 0 {
+	if err := unix.IoctlSetInt(int(loopFd), LoopSetCapacity, value); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -12,11 +12,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const (
-	// SeccompModeFilter refers to the syscall argument SECCOMP_MODE_FILTER.
-	SeccompModeFilter = uintptr(2)
-)
-
 func findCgroupMountpoints() (map[string]string, error) {
 	cgMounts, err := cgroups.GetCgroupMounts(false)
 	if err != nil {
@@ -60,9 +55,9 @@ func New(quiet bool) *SysInfo {
 	}
 
 	// Check if Seccomp is supported, via CONFIG_SECCOMP.
-	if _, _, err := unix.RawSyscall(unix.SYS_PRCTL, unix.PR_GET_SECCOMP, 0, 0); err != unix.EINVAL {
+	if err := unix.Prctl(unix.PR_GET_SECCOMP, 0, 0, 0, 0); err != unix.EINVAL {
 		// Make sure the kernel has CONFIG_SECCOMP_FILTER.
-		if _, _, err := unix.RawSyscall(unix.SYS_PRCTL, unix.PR_SET_SECCOMP, SeccompModeFilter, 0); err != unix.EINVAL {
+		if err := unix.Prctl(unix.PR_SET_SECCOMP, unix.SECCOMP_MODE_FILTER, 0, 0, 0); err != unix.EINVAL {
 			sysInfo.Seccomp = true
 		}
 	}

--- a/pkg/sysinfo/sysinfo_linux_test.go
+++ b/pkg/sysinfo/sysinfo_linux_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func TestReadProcBool(t *testing.T) {
@@ -66,9 +66,9 @@ func TestNew(t *testing.T) {
 
 func checkSysInfo(t *testing.T, sysInfo *SysInfo) {
 	// Check if Seccomp is supported, via CONFIG_SECCOMP.then sysInfo.Seccomp must be TRUE , else FALSE
-	if _, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_GET_SECCOMP, 0, 0); err != syscall.EINVAL {
+	if err := unix.Prctl(unix.PR_GET_SECCOMP, 0, 0, 0, 0); err != unix.EINVAL {
 		// Make sure the kernel has CONFIG_SECCOMP_FILTER.
-		if _, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_SET_SECCOMP, SeccompModeFilter, 0); err != syscall.EINVAL {
+		if err := unix.Prctl(unix.PR_SET_SECCOMP, unix.SECCOMP_MODE_FILTER, 0, 0, 0); err != unix.EINVAL {
 			require.True(t, sysInfo.Seccomp)
 		}
 	} else {

--- a/pkg/term/termios_linux.go
+++ b/pkg/term/termios_linux.go
@@ -1,8 +1,6 @@
 package term
 
 import (
-	"unsafe"
-
 	"golang.org/x/sys/unix"
 )
 
@@ -18,20 +16,21 @@ type Termios unix.Termios
 // mode and returns the previous state of the terminal so that it can be
 // restored.
 func MakeRaw(fd uintptr) (*State, error) {
-	var oldState State
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, getTermios, uintptr(unsafe.Pointer(&oldState.termios))); err != 0 {
+	termios, err := unix.IoctlGetTermios(int(fd), getTermios)
+	if err != nil {
 		return nil, err
 	}
 
-	newState := oldState.termios
+	var oldState State
+	oldState.termios = Termios(*termios)
 
-	newState.Iflag &^= (unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON)
-	newState.Oflag &^= unix.OPOST
-	newState.Lflag &^= (unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)
-	newState.Cflag &^= (unix.CSIZE | unix.PARENB)
-	newState.Cflag |= unix.CS8
+	termios.Iflag &^= (unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON)
+	termios.Oflag &^= unix.OPOST
+	termios.Lflag &^= (unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)
+	termios.Cflag &^= (unix.CSIZE | unix.PARENB)
+	termios.Cflag |= unix.CS8
 
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, setTermios, uintptr(unsafe.Pointer(&newState))); err != 0 {
+	if err := unix.IoctlSetTermios(int(fd), setTermios, termios); err != nil {
 		return nil, err
 	}
 	return &oldState, nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Replaced manually written wrappers for functions from golang.org/x/sys/unix.

**- How I did it**

Manually checked for obvious candiates (unix.Syscall, unix.RawSyscall) to replace by corresponding function from x/sys/unix.

**- How to verify it**

Unit, integration and docker-py tests still run through.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
n/a

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/539708/28260850-2d243bb0-6add-11e7-9f16-70570a6d0625.png)
