### PR TITLE
devmapper_wrapper.go: fix gcc warning

### DIFF
--- a/pkg/devicemapper/devmapper_wrapper.go
+++ b/pkg/devicemapper/devmapper_wrapper.go
@@ -15,10 +15,15 @@ static void	log_cb(int level, const char *file, int line, int dm_errno_or_class,
 {
 	char *buffer = NULL;
 	va_list ap;
+	int ret;
 
 	va_start(ap, f);
-	vasprintf(&buffer, f, ap);
+	ret = vasprintf(&buffer, f, ap);
 	va_end(ap);
+	if (ret < 0) {
+		// memory allocation failed -- should never happen?
+		return;
+	}
 
 	DevmapperLogCallback(level, (char *)file, line, dm_errno_or_class, buffer);
 	free(buffer);


### PR DESCRIPTION
I am getting the following warning from gcc when compiling the daemon:

```
# github.com/docker/docker/pkg/devicemapper
pkg/devicemapper/devmapper_wrapper.go: In function ‘log_cb’: 
pkg/devicemapper/devmapper_wrapper.go:20:2: warning: ignoring return value
of ‘vasprintf’, declared with attribute warn_unused_result [-Wunused-result]
 vasprintf(&buffer, f, ap);
 ^
```
vasprintf(3) man page says if the function returns -1, the buffer is
undefined, so we should not use it. In practice, I assume, this never
happens so we just return.

Introduced by https://github.com/moby/moby/pull/33845 that resulted in
commit 63328c6 ("devicemapper: remove 256 character limit of libdm logs")

Cc: Aleksa Sarai <asarai@suse.de>
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>