### PR TITLE
Enable update to unlimited swap

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -316,7 +316,7 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 	if resources.Memory != 0 {
 		// if memory limit smaller than already set memoryswap limit and doesn't
 		// update the memoryswap limit, then error out.
-		if resources.Memory > cResources.MemorySwap && resources.MemorySwap == 0 {
+		if cResources.MemorySwap > 0 && resources.Memory > cResources.MemorySwap && resources.MemorySwap == 0 {
 			return conflictingUpdateOptions("Memory limit should be smaller than already set memoryswap limit, update the memoryswap at the same time")
 		}
 		cResources.Memory = resources.Memory

--- a/daemon/daemon_solaris.go
+++ b/daemon/daemon_solaris.go
@@ -150,12 +150,12 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 		warnings = append(warnings, "Your kernel does not support memory limit capabilities. Limitation discarded.")
 		logrus.Warnf("Your kernel does not support memory limit capabilities. Limitation discarded.")
 		hostConfig.Memory = 0
-		hostConfig.MemorySwap = -1
+		hostConfig.MemorySwap = 0
 	}
 	if hostConfig.Memory > 0 && hostConfig.MemorySwap != -1 && !sysInfo.SwapLimit {
 		warnings = append(warnings, "Your kernel does not support swap limit capabilities, memory limited without swap.")
 		logrus.Warnf("Your kernel does not support swap limit capabilities, memory limited without swap.")
-		hostConfig.MemorySwap = -1
+		hostConfig.MemorySwap = 0
 	}
 	if hostConfig.Memory > 0 && hostConfig.MemorySwap > 0 && hostConfig.MemorySwap < hostConfig.Memory {
 		return warnings, fmt.Errorf("Minimum memoryswap limit should be larger than memory limit, see usage.")

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -311,12 +311,12 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 		warnings = append(warnings, "Your kernel does not support memory limit capabilities or the cgroup is not mounted. Limitation discarded.")
 		logrus.Warn("Your kernel does not support memory limit capabilities or the cgroup is not mounted. Limitation discarded.")
 		resources.Memory = 0
-		resources.MemorySwap = -1
+		resources.MemorySwap = 0
 	}
 	if resources.Memory > 0 && resources.MemorySwap != -1 && !sysInfo.SwapLimit {
 		warnings = append(warnings, "Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.")
 		logrus.Warn("Your kernel does not support swap limit capabilities,or the cgroup is not mounted. Memory limited without swap.")
-		resources.MemorySwap = -1
+		resources.MemorySwap = 0
 	}
 	if resources.Memory > 0 && resources.MemorySwap > 0 && resources.MemorySwap < resources.Memory {
 		return warnings, fmt.Errorf("Minimum memoryswap limit should be larger than memory limit, see usage")

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -315,7 +315,7 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 		resources.Memory = 0
 		resources.MemorySwap = 0
 	}
-	if resources.Memory > 0 && resources.MemorySwap != -1 && !sysInfo.SwapLimit {
+	if resources.Memory > 0 && resources.MemorySwap != 0 && !sysInfo.SwapLimit {
 		warnings = append(warnings, "Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.")
 		logrus.Warn("Your kernel does not support swap limit capabilities,or the cgroup is not mounted. Memory limited without swap.")
 		resources.MemorySwap = 0

--- a/daemon/update_linux.go
+++ b/daemon/update_linux.go
@@ -23,7 +23,7 @@ func toContainerdResources(resources container.Resources) libcontainerd.Resource
 	r.CpusetCpus = resources.CpusetCpus
 	r.CpusetMems = resources.CpusetMems
 	r.MemoryLimit = uint64(resources.Memory)
-	if resources.MemorySwap > 0 {
+	if resources.MemorySwap != 0 {
 		r.MemorySwap = uint64(resources.MemorySwap)
 	}
 	r.MemoryReservation = uint64(resources.MemoryReservation)

--- a/integration-cli/docker_cli_build_unix_test.go
+++ b/integration-cli/docker_cli_build_unix_test.go
@@ -26,6 +26,7 @@ import (
 
 func (s *DockerSuite) TestBuildResourceConstraintsAreUsed(c *check.C) {
 	testRequires(c, cpuCfsQuota)
+	testRequires(c, swapMemorySupport)
 	name := "testbuildresourceconstraints"
 
 	ctx := fakecontext.New(c, "", fakecontext.WithDockerfile(`

--- a/integration-cli/docker_cli_update_unix_test.go
+++ b/integration-cli/docker_cli_update_unix_test.go
@@ -183,6 +183,16 @@ func (s *DockerSuite) TestUpdateSwapMemoryOnly(c *check.C) {
 	file := "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes"
 	out, _ := dockerCmd(c, "exec", name, "cat", file)
 	c.Assert(strings.TrimSpace(out), checker.Equals, "629145600")
+
+	// Update swap memory to unlimited
+	dockerCmd(c, "update", "--memory-swap", "-1", name)
+
+	c.Assert(inspectField(c, name, "HostConfig.MemorySwap"), checker.Equals, "-1")
+	out, _ = dockerCmd(c, "exec", name, "cat", file)
+	// It is difficult to find out the long bit on the machine and check the
+	// unlimited value is 18446744073709551615 or 9223372036854771712 or other
+	// possible values, so just check it to be greater than the original value.
+	c.Assert(len(strings.TrimSpace(out)), checker.GreaterThan, len("629145600"))
 }
 
 func (s *DockerSuite) TestUpdateInvalidSwapMemory(c *check.C) {


### PR DESCRIPTION
We actually have this feature in help doc:
$ docker update --help | grep swap
      --memory-swap bytes          Swap limit equal to memory plus swap: '-1' to enable unlimited swap

And almost have this support, just needs a small
fix to enable it.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix `docker update --memory-swap -1 <cnt1>`

**- How I did it**
Make negative valid value in toContainerdResources.

**- How to verify it**
```
Terminal 1:
$ docker run -ti -m 300M --memory-swap 500M ubuntu bash

Terminal 2:
$ docker ps
got the container id
$ docker update --memory-swap -1 <id>

Terminal 1:
# cat /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes
see if it's 18446744073709551615
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

