### PR TITLE
/dev should be constrained in size just like /dev/shm

### DIFF
--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -91,7 +91,7 @@ func DefaultLinuxSpec() specs.Spec {
 			Destination: "/dev",
 			Type:        "tmpfs",
 			Source:      "tmpfs",
-			Options:     []string{"nosuid", "strictatime", "mode=755"},
+			Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
 		},
 		{
 			Destination: "/dev/pts",


### PR DESCRIPTION
There really is no reason why anyone should create content in /dev
other then device nodes.  Limiting it size to the size limit of
/dev/shm.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

