### PR TITLE
Windows: Disable TestAttachTTYWithoutStdin

### DIFF
--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -88,6 +88,14 @@ func (s *DockerSuite) TestAttachMultipleAndRestart(c *check.C) {
 }
 
 func (s *DockerSuite) TestAttachTTYWithoutStdin(c *check.C) {
+	// TODO @jhowardmsft. Figure out how to get this running again reliable on Windows.
+	// It works by accident at the moment. Sometimes. I've gone back to v1.13.0 and see the same.
+	// On Windows, docker run -d -ti busybox causes the container to exit immediately.
+	// Obviously a year back when I updated the test, that was not the case. However,
+	// with this, and the test racing with the tear-down which panic's, sometimes CI
+	// will just fail and `MISS` all the other tests. For now, disabling it. Will
+	// open an issue to track re-enabling this and root-causing the problem.
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "-ti", "busybox")
 
 	id := strings.TrimSpace(out)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

As per the comment:

	// TODO @jhowardmsft. Figure out how to get this running again reliable on Windows.
	// It works by accident at the moment. Sometimes. I've gone back to v1.13.0 and see the same.
	// On Windows, docker run -d -ti busybox causes the container to exit immediately.
	// Obviously a year back when I updated the test, that was not the case. However,
	// with this, and the test racing with the tear-down which panic's, sometimes CI
	// will just fail and `MISS` all the other tests. For now, disabling it. Will
	// open an issue to track re-enabling this and root-causing the problem.

@johnstep