### PR TITLE
Fix API docs for GET /secrets/{id}, GET /secrets

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2779,7 +2779,7 @@ definitions:
         type: "string"
         format: "dateTime"
       Spec:
-        $ref: "#/definitions/ServiceSpec"
+        $ref: "#/definitions/SecretSpec"
 paths:
   /containers/json:
     get:


### PR DESCRIPTION
The swagger.yml defined these endpoints to return
a "ServiceSpec" instead of a "SecretSpec".

**- How to verify it**

run:

```
make swagger-docs
```

And visit http://localhost:9000 (or http://localhost:9000/#operation/SecretInspect) in your browser

**- Description for the changelog**

```markdown
Fix API reference for `GET /secrets` and `GET /secrets/{id}` endpoints
```
**- A picture of a cute animal (not mandatory but encouraged)**
