### PR TITLE
Allow to override build date

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -68,7 +68,7 @@ DEFAULT_BUNDLES=(
 )
 
 VERSION=$(< ./VERSION)
-! BUILDTIME=$(date --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
+! BUILDTIME=$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
 if [ "$DOCKER_GITCOMMIT" ]; then
 	GITCOMMIT="$DOCKER_GITCOMMIT"
 elif command -v git &> /dev/null && [ -d .git ] && git rev-parse &> /dev/null; then


### PR DESCRIPTION


in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Signed-off-by: Bernhard M. Wiedemann <bwiedemann@suse.de>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Enable reproducible builds

**- How I did it**
by allowing to have a fixed BUILDTIME for different builds

**- How to verify it**
build docker packages twice (e.g. for openSUSE) without debuginfo
and verify that /usr/bin/docker has the same md5sum across builds

**- Description for the changelog**
It is now possible for docker to be built reproducibly.

**- A picture of a cute animal (not mandatory but encouraged)**
[cute one](https://www.zq1.de/~bernhard/images/family/tobi201706.jpg)