### PR TITLE
set plugin v1 active timeout

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -152,7 +152,7 @@ func (p *Plugin) activated() bool {
 }
 
 func (p *Plugin) activateWithLock() error {
-	c, err := NewClient(p.Addr, p.TLSConfig)
+	c, err := NewClientWithTimeout(p.Addr, p.TLSConfig, 30*time.Second)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: bingshen.wbs <bingshen.wbs@alibaba-inc.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix #33871  , Dockerd can not restart when use containerize v1 plugins.
**- How I did it**
Set plugin check http client timeout.
**- How to verify it**
Restart the docker daemon with v1 plugin.
**- Description for the changelog**

In the `pkg/plugins/plugins.go activateWithLock` . Use the timeout http client with 30 seconds.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/3598874/28354570-f8048c20-6c92-11e7-9019-d33ca11717e0.png)
