### PR TITLE
Update API history and example response for volume CreatedAt

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1058,7 +1058,7 @@ definitions:
       CreatedAt:
         type: "string"
         format: "dateTime"
-        description: "Time volume was created."
+        description: "Date/Time the volume was created."
       Status:
         type: "object"
         description: |
@@ -6257,7 +6257,8 @@ paths:
           examples:
             application/json:
               Volumes:
-                - Name: "tardis"
+                - CreatedAt: "2017-07-19T12:00:26Z"
+                  Name: "tardis"
                   Driver: "local"
                   Mountpoint: "/var/lib/docker/volumes/tardis"
                   Labels:

--- a/api/types/volume.go
+++ b/api/types/volume.go
@@ -7,7 +7,7 @@ package types
 // swagger:model Volume
 type Volume struct {
 
-	// Time volume was created.
+	// Date/Time the volume was created.
 	CreatedAt string `json:"CreatedAt,omitempty"`
 
 	// Name of the volume driver used by the volume.

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -28,6 +28,13 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /images/(name)/get` now includes an `ImageMetadata` field which contains image metadata that is local to the engine and not part of the image config.
 * `POST /services/create` now accepts a `PluginSpec` when `TaskTemplate.Runtime` is set to `plugin`
 * `GET /events` now supports config events `create`, `update` and `remove` that are emitted when users create, update or remove a config
+* `GET /volumes/` and `GET /volumes/{name}` now return a `CreatedAt` field,
+  containing the date/time the volume was created. This field is omitted if the
+  creation date/time for the volume is unknown. For volumes with scope "global",
+  this field represents the creation date/time of the local _instance_ of the
+  volume, which may differ from instances of the same volume on different nodes.
+* `GET /system/df` now returns a `CreatedAt` field for `Volumes`. Refer to the
+  `/volumes/` endpoint for a description of this field.
 
 ## v1.30 API changes
 


### PR DESCRIPTION
This adds the new `CreatedAt` field to the API version history
and updates some examples to show this information.

The `CreatedAt` field was implemented in a46f757c4043031379362c5d6b3bad7562ab9fed (https://github.com/moby/moby/pull/33257)
