### PR TITLE
Fixing issue with driver opt not passed to drivers

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -745,6 +745,9 @@ func (container *Container) BuildCreateEndpointOptions(n libnetwork.Network, epC
 		for _, alias := range epConfig.Aliases {
 			createOptions = append(createOptions, libnetwork.CreateOptionMyAlias(alias))
 		}
+		for k, v := range epConfig.DriverOpts {
+			createOptions = append(createOptions, libnetwork.EndpointOptionGeneric(options.Generic{k: v}))
+		}
 	}
 
 	if container.NetworkSettings.Service != nil {
@@ -789,9 +792,6 @@ func (container *Container) BuildCreateEndpointOptions(n libnetwork.Network, epC
 			}
 
 			createOptions = append(createOptions, libnetwork.EndpointOptionGeneric(genericOption))
-		}
-		for k, v := range epConfig.DriverOpts {
-			createOptions = append(createOptions, libnetwork.EndpointOptionGeneric(options.Generic{k: v}))
 		}
 
 	}


### PR DESCRIPTION
Please provide the following information:

PR docker/cli#62 and moby/moby#33130 introduced per network options which were passed all the way to the network driver. However as a part of this update the driver options were not passed all the way to network drivers. The issue was that the options were being populated for non swarm endpoints. The PR fixes the issue to attach driver options for all applicable endpoints. 

**- A picture of a cute animal (not mandatory but encouraged)**

