### PR TITLE
Add a log message when storage driver is overriden through environment

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -620,6 +620,8 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 		driverName := os.Getenv("DOCKER_DRIVER")
 		if driverName == "" {
 			driverName = config.GraphDriver
+		} else {
+			logrus.Infof("Setting the storage driver from the $DOCKER_DRIVER environment variable (%s)", driverName)
 		}
 		d.stores[runtime.GOOS] = daemonStore{graphDriver: driverName} // May still be empty. Layerstore init determines instead.
 	}


### PR DESCRIPTION
Signed-off-by: Jérôme Petazzoni <jerome.petazzoni@gmail.com>

**- Description for the changelog**

Overriding the storage driver with the DOCKER_DRIVER env var now prints a log message

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/171481/28426276-fe1e0baa-6d72-11e7-9a80-b9a6ab37f533.png)
Majestic doggo says "no pictures please"
