### PR TITLE
Fix build with `ADD` urls without any sub path

### DIFF
--- a/builder/dockerfile/copy_test.go
+++ b/builder/dockerfile/copy_test.go
@@ -1,6 +1,7 @@
 package dockerfile
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/gotestyourself/gotestyourself/fs"
@@ -41,5 +42,105 @@ func TestIsExistingDirectory(t *testing.T) {
 			continue
 		}
 		assert.Equal(t, testcase.expected, result, testcase.doc)
+	}
+}
+
+func TestGetFilenameForDownload(t *testing.T) {
+	var testcases = []struct {
+		path        string
+		disposition string
+		expected    string
+	}{
+		{
+			path:     "http://www.example.com/",
+			expected: "",
+		},
+		{
+			path:     "http://www.example.com/xyz",
+			expected: "xyz",
+		},
+		{
+			path:     "http://www.example.com/xyz.html",
+			expected: "xyz.html",
+		},
+		{
+			path:     "http://www.example.com/xyz/",
+			expected: "",
+		},
+		{
+			path:     "http://www.example.com/xyz/uvw",
+			expected: "uvw",
+		},
+		{
+			path:     "http://www.example.com/xyz/uvw.html",
+			expected: "uvw.html",
+		},
+		{
+			path:     "http://www.example.com/xyz/uvw/",
+			expected: "",
+		},
+		{
+			path:     "/",
+			expected: "",
+		},
+		{
+			path:     "/xyz",
+			expected: "xyz",
+		},
+		{
+			path:     "/xyz.html",
+			expected: "xyz.html",
+		},
+		{
+			path:     "/xyz/",
+			expected: "",
+		},
+		{
+			path:        "/xyz/",
+			disposition: "attachment; filename=xyz.html",
+			expected:    "xyz.html",
+		},
+		{
+			disposition: "",
+			expected:    "",
+		},
+		{
+			disposition: "attachment; filename=xyz",
+			expected:    "xyz",
+		},
+		{
+			disposition: "attachment; filename=xyz.html",
+			expected:    "xyz.html",
+		},
+		{
+			disposition: "attachment; filename=\"xyz\"",
+			expected:    "xyz",
+		},
+		{
+			disposition: "attachment; filename=\"xyz.html\"",
+			expected:    "xyz.html",
+		},
+		{
+			disposition: "attachment; filename=\"/xyz.html\"",
+			expected:    "xyz.html",
+		},
+		{
+			disposition: "attachment; filename=\"/xyz/uvw\"",
+			expected:    "uvw",
+		},
+		{
+			disposition: "attachment; filename=\"Naïve file.txt\"",
+			expected:    "Naïve file.txt",
+		},
+	}
+	for _, testcase := range testcases {
+		resp := http.Response{
+			Header: make(map[string][]string),
+		}
+		if testcase.disposition != "" {
+			resp.Header.Add("Content-Disposition", testcase.disposition)
+		}
+		filename := getFilenameForDownload(testcase.path, &resp)
+		assert.Equal(t, testcase.expected, filename)
 	}
 }

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6506,19 +6506,3 @@ RUN touch /foop
 	c.Assert(err, check.IsNil)
 	c.Assert(d.String(), checker.Equals, getIDByName(c, name))
 }
-
-// Test case for #34208
-func (s *DockerSuite) TestBuildAddHTTPRoot(c *check.C) {
-	testRequires(c, Network, DaemonIsLinux)
-	buildImageSuccessfully(c, "buildaddhttproot", build.WithDockerfile(`
-                FROM scratch
-                ADD http://example.com/index.html /example1
-                ADD http://example.com /example2
-                ADD http://example.com /example3`))
-	buildImage("buildaddhttprootfailure", build.WithDockerfile(`
-                FROM scratch
-                ADD http://example.com/ /`)).Assert(c, icmd.Expected{
-		ExitCode: 1,
-		Err:      "cannot determine filename for source http://example.com/",
-	})
-}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6506,3 +6506,19 @@ RUN touch /foop
 	c.Assert(err, check.IsNil)
 	c.Assert(d.String(), checker.Equals, getIDByName(c, name))
 }
+
+// Test case for #34208
+func (s *DockerSuite) TestBuildAddHTTPRoot(c *check.C) {
+	testRequires(c, Network, DaemonIsLinux)
+	buildImageSuccessfully(c, "buildaddhttproot", build.WithDockerfile(`
+                FROM scratch
+                ADD http://example.com/index.html /example1
+                ADD http://example.com /example2
+                ADD http://example.com /example3`))
+	buildImage("buildaddhttprootfailure", build.WithDockerfile(`
+                FROM scratch
+                ADD http://example.com/ /`)).Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err:      "cannot determine filename for source http://example.com/",
+	})
+}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This fix tries to address the issue raised in #34208 where in Dockerfile an `ADD` followed by an url without any sub path will cause an error.

The issue is because the temporary filename relies on the sub path.


**- How I did it**
This fix fixes this issue by having `index.html` as the filename if no sub path exists.


**- How to verify it**
An integration test has been added.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![5vznpa4dkmk](https://user-images.githubusercontent.com/6932348/28486415-6272f840-6e36-11e7-9376-188030487908.jpg)

This fix fixes #34208.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
