### PR TITLE
Close readclosers returned by DecompressStream

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -127,6 +127,7 @@ func IsArchivePath(path string) bool {
 	if err != nil {
 		return false
 	}
+	defer rdr.Close()
 	r := tar.NewReader(rdr)
 	_, err = r.Next()
 	return err == nil

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -247,10 +247,12 @@ func applyLayerHandler(dest string, layer io.Reader, options *TarOptions, decomp
 	defer system.Umask(oldmask) // ignore err, ErrNotSupportedPlatform
 
 	if decompress {
-		layer, err = DecompressStream(layer)
+		decompLayer, err := DecompressStream(layer)
 		if err != nil {
 			return 0, err
 		}
+		defer decompLayer.Close()
+		layer = decompLayer
 	}
 	return UnpackLayer(dest, layer, options)
 }

--- a/plugin/blobstore.go
+++ b/plugin/blobstore.go
@@ -145,6 +145,7 @@ func (dm *downloadManager) Download(ctx context.Context, initialRootFS image.Roo
 		if err != nil {
 			return initialRootFS, nil, err
 		}
+		defer inflatedLayerData.Close()
 		digester := digest.Canonical.Digester()
 		if _, err := chrootarchive.ApplyLayer(dm.tmpDir, io.TeeReader(inflatedLayerData, digester.Hash())); err != nil {
 			return initialRootFS, nil, err


### PR DESCRIPTION
**- What I did**

@tianon mentioned that he has seen this for quite a while, but never bothered to find the root cause. I build many images on my local machine (every Linux amd64 image in the official images) and, over time, docker leaves many `xz` processes waiting.

```console
$ ps aux | grep xz | grep -V grep
root       981  0.0  0.0  76052   884 ?        S    Jul19   0:00 xz -d -c -q
root      2973  0.0  0.0  76052   852 ?        S    Jul20   0:00 xz -d -c -q
root      7361  0.0  0.0  76052   840 ?        S    Jul20   0:00 xz -d -c -q
root      8006  0.0  0.0  76052   944 ?        S    Jul20   0:00 xz -d -c -q
root     17969  0.0  0.0  76052   856 ?        S    Jul18   0:00 xz -d -c -q
root     18836  0.0  0.0  76052   848 ?        S    Jul18   0:00 xz -d -c -q
root     19855  0.0  0.0  76052   860 ?        S    Jul18   0:00 xz -d -c -q
root     20062  0.0  0.0  18708   856 ?        S    Jul20   0:00 xz -d -c -q
root     27810  0.0  0.0  76052   864 ?        S    Jul20   0:00 xz -d -c -q
root     28826  0.0  0.0  18708   896 ?        S    Jul19   0:00 xz -d -c -q
root     32101  0.0  0.0  76052   912 ?        S    Jul19   0:00 xz -d -c -q
root     32759  0.0  0.0  76052   860 ?        S    Jul19   0:00 xz -d -c -q
```

You can reproduce it by building an image that uses an `ADD` with an `xz` file:
```console
$ # get count of current xz processes
$ pidof xz | wc -w
12
$ docker build --no-cache https://github.com/debuerreotype/docker-debian-artifacts.git#dist-amd64:jessie/slim
Sending build context to Docker daemon  16.25MB
Step 1/3 : FROM scratch
 ---> 
Step 2/3 : ADD rootfs.tar.xz /
 ---> cab71017cf4e
Removing intermediate container a37f42abdd32
Step 3/3 : CMD bash
 ---> Running in d5a8f1e3d97b
 ---> 36f80bc07497
Removing intermediate container d5a8f1e3d97b
Successfully built 36f80bc07497
$ pidof xz | wc -w
13
```

**- How I did it**
Found out who calls `xz -d -c -q` and found it in `pkg/archive/archive.go`, walked up the chain and found who receives a `ReadCloser` and doesn't `Close`.  This is the same pattern applied in these files:

- [pkg/chrootarchive/archive.go](https://github.com/moby/moby/blob/4ac4c8ef4b06ffa8ccd4fd3ae0f76e4ca820c1bc/pkg/chrootarchive/archive.go#L61-L66)
- [pkg/chrootarchive/diff_unix.go](https://github.com/moby/moby/blob/4ac4c8ef4b06ffa8ccd4fd3ae0f76e4ca820c1bc/pkg/chrootarchive/diff_unix.go#L88-L94)
- [pkg/chrootarchive/diff_windows.go](https://github.com/moby/moby/blob/4ac4c8ef4b06ffa8ccd4fd3ae0f76e4ca820c1bc/pkg/chrootarchive/diff_windows.go#L24-L30)
- [pkg/archive/archive_test.go](https://github.com/moby/moby/blob/4ac4c8ef4b06ffa8ccd4fd3ae0f76e4ca820c1bc/pkg/archive/archive_test.go#L108-L117)

**- How to verify it**
I tried applying this diff, restarted docker, and then ran the same `docker build` from above and it hangs on `ADD rootfs.tar.xz /`.

I'd love some help to find where I am going wrong.  Feel free to push onto my branch if you'd like to help! 

**- Description for the changelog**
Close ReadClosers to prevent `xz` zombies

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://media.giphy.com/media/sueyjcZ4vSnQc/giphy.gif)
