### PR TITLE
Update mkimage-yum.sh

### DIFF
--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -81,13 +81,13 @@ fi
 if [[ -n "$install_groups" ]];
 then
     yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs \
-        --setopt=group_package_types=mandatory -y groupinstall $install_groups
+        --setopt=group_package_types=mandatory -y groupinstall "$install_groups"
 fi
 
 if [[ -n "$install_packages" ]];
 then
     yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs \
-        --setopt=group_package_types=mandatory -y install $install_packages
+        --setopt=group_package_types=mandatory -y install "$install_packages"
 fi
 
 yum -c "$yum_config" --installroot="$target" -y clean all


### PR DESCRIPTION
If you want to makeimage using the group "Compute Node" and so on, you must add “ ” to include the $install_groups, or it will format the text as below:
`yum -c /etc/yum.conf --installroot=/tmp/makeimage.sh.zOLs8y --releasever=/ --setopt=tsflags=nodocs --setopt=group_package_types=mandatory -y groupinstall Compute Node`
That's absolutely incorrect, and the right command is like this:
`yum -c /etc/yum.conf --installroot=/tmp/makeimage.sh.zOLs8y --releasever=/ --setopt=tsflags=nodocs --setopt=group_package_types=mandatory -y groupinstall "Compute Node"`

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->