### PR TITLE
add check for local volume option

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1835,14 +1835,62 @@ func (s *DockerSuite) TestContainersAPICreateMountsValidation(c *check.C) {
 					Image: "busybox",
 				},
 				hostConfig: containertypes.HostConfig{
-					Mounts: []mounttypes.Mount{{
-						Type:   "volume",
-						Source: "hello3",
-						Target: destPath,
-						VolumeOptions: &mounttypes.VolumeOptions{
-							DriverConfig: &mounttypes.Driver{
-								Name:    "local",
-								Options: map[string]string{"o": "size=1"}}}}}},
+					Mounts: []mounttypes.Mount{
+						{
+							Type:   "volume",
+							Source: "missing-device-opt",
+							Target: destPath,
+							VolumeOptions: &mounttypes.VolumeOptions{
+								DriverConfig: &mounttypes.Driver{
+									Name:    "local",
+									Options: map[string]string{"type": "tmpfs"},
+								},
+							},
+						},
+					},
+				},
+				msg: `missing required option: "device"`,
+			},
+			{
+				config: containertypes.Config{
+					Image: "busybox",
+				},
+				hostConfig: containertypes.HostConfig{
+					Mounts: []mounttypes.Mount{
+						{
+							Type:   "volume",
+							Source: "missing-type-opt",
+							Target: destPath,
+							VolumeOptions: &mounttypes.VolumeOptions{
+								DriverConfig: &mounttypes.Driver{
+									Name:    "local",
+									Options: map[string]string{"device": "tmpfs"},
+								},
+							},
+						},
+					},
+				},
+				msg: `missing required option: "type"`,
+			},
+			{
+				config: containertypes.Config{
+					Image: "busybox",
+				},
+				hostConfig: containertypes.HostConfig{
+					Mounts: []mounttypes.Mount{
+						{
+							Type:   "volume",
+							Source: "hello4",
+							Target: destPath,
+							VolumeOptions: &mounttypes.VolumeOptions{
+								DriverConfig: &mounttypes.Driver{
+									Name:    "local",
+									Options: map[string]string{"o": "size=1", "type": "tmpfs", "device": "tmpfs"},
+								},
+							},
+						},
+					},
+				},
 				msg: "",
 			},
 			{
@@ -1869,7 +1917,6 @@ func (s *DockerSuite) TestContainersAPICreateMountsValidation(c *check.C) {
 						}}}},
 				msg: "",
 			},
-
 			{
 				config: containertypes.Config{
 					Image: "busybox",

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -353,9 +353,17 @@ func (v *localVolume) unmount() error {
 }
 
 func validateOpts(opts map[string]string) error {
+	if len(opts) == 0 {
+		return nil
+	}
 	for opt := range opts {
 		if !validOpts[opt] {
 			return validationError(fmt.Sprintf("invalid option key: %q", opt))
+		}
+	}
+	for opt := range mandatoryOpts {
+		if _, ok := opts[opt]; !ok {
+			return errdefs.InvalidParameter(errors.Errorf("missing required option: %q", opt))
 		}
 	}
 	return nil

--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -27,6 +27,10 @@ var (
 		"o":      true, // generic mount options
 		"device": true, // device to mount from
 	}
+	mandatoryOpts = map[string]struct{}{
+		"device": {},
+		"type":   {},
+	}
 )
 
 type optsConfig struct {

--- a/volume/local/local_windows.go
+++ b/volume/local/local_windows.go
@@ -14,7 +14,10 @@ import (
 
 type optsConfig struct{}
 
-var validOpts map[string]bool
+var (
+	validOpts     map[string]bool
+	mandatoryOpts map[string]struct{}
+)
 
 // scopedPath verifies that the path where the volume is located
 // is under Docker's root and the valid local paths.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add check for creating local volume

Fix issue:
```
root@localhost:~# docker volume create -d local --name test -o type=tmpfs
test
root@localhost:~# docker run -tid -v test:/tmp ubuntu
docker: Error response from daemon: missing device in volume options.
See 'docker run --help'.
root@localhost:~#
```

I think it should fail at creating it.
```
root@localhost:~# docker volume create -d local --name test2 -o type=tmpfs
Error response from daemon: create test2: option device must be specified
root@localhost:~#
```

**- How I did it**

add check flag when creating local volume

**- How to verify it**

docker volume create -d local --name test -o type=tmpfs
It should fail to create local volume when provide wrong options.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Signed-off-by: Wentao Zhang <zhangwentao234@huawei.com>

**- A picture of a cute animal (not mandatory but encouraged)**

