### PR TITLE
Add hostname to DNS service discovery

### DIFF
--- a/vendor/github.com/docker/libnetwork/agent.go
+++ b/vendor/github.com/docker/libnetwork/agent.go
@@ -638,6 +638,11 @@ func (ep *endpoint) addServiceInfoToCluster(sb *sandbox) error {
 		}
 	}
 
+	// In any case, add the container hostName to the service discovery DNS
+	if err := c.addContainerNameResolution(n.ID(), ep.ID(), sb.config.hostName, ep.myAliases, ep.Iface().Address().IP, "addServiceInfoToCluster"); err != nil {
+		return err
+	}
+
 	buf, err := proto.Marshal(&EndpointRecord{
 		Name:         name,
 		ServiceName:  ep.svcName,
@@ -709,6 +714,11 @@ func (ep *endpoint) deleteServiceInfoFromCluster(sb *sandbox, method string) err
 				return err
 			}
 		}
+	}
+
+	// In any case, delete the container hostName to the service discovery DNS
+	if err := c.delContainerNameResolution(n.ID(), ep.ID(), sb.config.hostName, ep.myAliases, ep.Iface().Address().IP, "deleteServiceInfoFromCluster"); err != nil {
+		return err
 	}
 
 	logrus.Debugf("deleteServiceInfoFromCluster from %s END for %s %s", method, ep.svcName, ep.ID())


### PR DESCRIPTION
This Closes #34239, closes docker/swarmkit#2325,
closes docker/libnetwork#1854

Signed-off-by: Mario Kleinsasser <mario.kleinsasser@gmail.com>

**- What I did**
As mentioned in docker/swarmkit#2325 and in #34239 it is sometimes neccessary to
resolve the hostnames of the containers from within a service. This is usful as
it provides the posibility for the service software running inside the containers
to resolve each other through DNS. I've looked into the source code and found out,
that some minor changes must be made to vendor/github.com/docker/libnetwork/agent.go.

**- How I did it**
I've looked at the mentioned file and there are two functions which are
responsible for the creation of the DNS entries in the service discovery.
Therefore I've patched these two functions that in any case, regardless if it
is a service task or a simple container that joined a network, the hostname
will be added to the DNS service discovery. For the hostname of the container
I use the sandbox struct which is available in the context of the code.

**- How to verify it**
- Wrong
```
[09:27 mario@ ~/reg]$ docker exec registry_app.1.oc3eudiz86attr7kktjk0jjdl hostname
registry_app-1
[09:28 mario@ ~/reg]$ docker exec registry_app.2.w4mjpo46ikov2xkero552r6if hostname
registry_app-2
[09:28 mario@ ~/reg]$ docker exec registry_app.1.oc3eudiz86attr7kktjk0jjdl ping registry_app-2
ping: bad address 'registry_app-2'
```

- As it should be (PR):
```
root@b31f5a9da046: # docker service create --network test_net --name test_srv --hostname={{.Service.Name}}-{{.Task.Slot}} --replicas 2 n0r1skcom/echo
root@b31f5a9da046:/go/src/github.com/docker/docker# docker exec test_srv.1.0f9x9a0x46xi7fi81qi57ntyy hostname
test_srv-1
root@b31f5a9da046:/go/src/github.com/docker/docker# docker exec test_srv.2.jttdg37ra8hh3yx7gl2nnff42 hostname
test_srv-2
root@b31f5a9da046:/go/src/github.com/docker/docker# docker exec test_srv.1.0f9x9a0x46xi7fi81qi57ntyy ping test_srv-1
PING test_srv-1 (10.0.0.3): 56 data bytes
64 bytes from 10.0.0.3: icmp_seq=0 ttl=64 time=0.075 ms
64 bytes from 10.0.0.3: icmp_seq=1 ttl=64 time=0.119 ms
```

**-Impact**

Even if the hostname of all containers would be the same, this would not be a
problem, because the result is DNS entry like ```test_srv``` that will be
resolved to all ip adresses (multiple A-records) like te ```tasks.servicename```
entry is resolved. The benefit is, that all containers can reach each other container
of the same or other service on the same network due to knowing the hostname
pattern, which is deterministic and predictable. Therefore, configuration possibilites
for clusterservices are given -> see #34239 for details.

**- Description for the changelog**
Add container hostname to DNS service discovery
