### PR TITLE
Fix RestartPolicy default value

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -322,7 +322,6 @@ definitions:
       MaximumRetryCount:
         type: "integer"
         description: "If `on-failure` is used, the number of times to retry before giving up"
-    default: {}
 
   Resources:
     description: "A container's resources (cgroups config, ulimits, etc)"


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/32649

to verify; this no longer produces a validation error; https://online.swagger.io/validator/debug?url=https://raw.githubusercontent.com/thaJeztah/docker/fc48b5529dca3907ade273921a14906be796e333/api/swagger.yaml

ping @dnephin PTAL