### PR TITLE
Added tag log option to json-logger

### DIFF
--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -31,6 +31,7 @@ type JSONFileLogger struct {
 	closed  bool
 	writer  *loggerutils.RotateFileWriter
 	readers map[*logger.LogWatcher]struct{} // stores the active log followers
+	tag     string                          // tag values requested by the user to log
 }
 
 func init() {
@@ -65,6 +66,12 @@ func New(info logger.Info) (logger.Logger, error) {
 		}
 	}
 
+	// no default template. only use a tag if the user asked for it
+	tag, err := loggerutils.ParseLogTag(info, "")
+	if err != nil {
+		return nil, err
+	}
+
 	writer, err := loggerutils.NewRotateFileWriter(info.LogPath, capval, maxFiles)
 	if err != nil {
 		return nil, err
@@ -88,20 +95,21 @@ func New(info logger.Info) (logger.Logger, error) {
 		writer:  writer,
 		readers: make(map[*logger.LogWatcher]struct{}),
 		extra:   extra,
+		tag:     tag,
 	}, nil
 }
 
 // Log converts logger.Message to jsonlog.JSONLog and serializes it to file.
 func (l *JSONFileLogger) Log(msg *logger.Message) error {
 	l.mu.Lock()
-	err := writeMessageBuf(l.writer, msg, l.extra, l.buf)
+	err := writeMessageBuf(l.writer, msg, l.extra, l.buf, l.tag)
 	l.buf.Reset()
 	l.mu.Unlock()
 	return err
 }
 
-func writeMessageBuf(w io.Writer, m *logger.Message, extra json.RawMessage, buf *bytes.Buffer) error {
-	if err := marshalMessage(m, extra, buf); err != nil {
+func writeMessageBuf(w io.Writer, m *logger.Message, extra json.RawMessage, buf *bytes.Buffer, tag string) error {
+	if err := marshalMessage(m, extra, buf, tag); err != nil {
 		logger.PutMessage(m)
 		return err
 	}
@@ -110,7 +118,7 @@ func writeMessageBuf(w io.Writer, m *logger.Message, extra json.RawMessage, buf 
 	return errors.Wrap(err, "error writing log entry")
 }
 
-func marshalMessage(msg *logger.Message, extra json.RawMessage, buf *bytes.Buffer) error {
+func marshalMessage(msg *logger.Message, extra json.RawMessage, buf *bytes.Buffer, tag string) error {
 	logLine := msg.Line
 	if !msg.Partial {
 		logLine = append(msg.Line, '\n')
@@ -120,6 +128,7 @@ func marshalMessage(msg *logger.Message, extra json.RawMessage, buf *bytes.Buffe
 		Stream:   msg.Source,
 		Created:  msg.Timestamp,
 		RawAttrs: extra,
+		Tag:      tag,
 	}).MarshalJSONBuf(buf)
 	if err != nil {
 		return errors.Wrap(err, "error writing log message to buffer")
@@ -137,6 +146,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case "labels":
 		case "env":
 		case "env-regex":
+		case "tag":
 		default:
 			return fmt.Errorf("unknown log opt '%s' for json-file log driver", key)
 		}

--- a/daemon/logger/jsonfilelog/jsonfilelog_test.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog_test.go
@@ -57,6 +57,49 @@ func TestJSONFileLogger(t *testing.T) {
 	}
 }
 
+func TestJSONFileLoggerWithTags(t *testing.T) {
+	cid := "a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"
+	cname := "test-container"
+	tmp, err := ioutil.TempDir("", "docker-logger-")
+
+	require.NoError(t, err)
+
+	defer os.RemoveAll(tmp)
+	filename := filepath.Join(tmp, "container.log")
+	l, err := New(logger.Info{
+		Config: map[string]string{
+			"tag": "{{.ID}}/{{.Name}}", // first 12 characters of ContainerID and full ContainerName
+		},
+		ContainerID:   cid,
+		ContainerName: cname,
+		LogPath:       filename,
+	})
+
+	require.NoError(t, err)
+	defer l.Close()
+
+	err = l.Log(&logger.Message{Line: []byte("line1"), Source: "src1"})
+	require.NoError(t, err)
+
+	err = l.Log(&logger.Message{Line: []byte("line2"), Source: "src2"})
+	require.NoError(t, err)
+
+	err = l.Log(&logger.Message{Line: []byte("line3"), Source: "src3"})
+	require.NoError(t, err)
+
+	res, err := ioutil.ReadFile(filename)
+	require.NoError(t, err)
+
+	expected := `{"log":"line1\n","stream":"src1","tag":"a7317399f3f8/test-container","time":"0001-01-01T00:00:00Z"}
+{"log":"line2\n","stream":"src2","tag":"a7317399f3f8/test-container","time":"0001-01-01T00:00:00Z"}
+{"log":"line3\n","stream":"src3","tag":"a7317399f3f8/test-container","time":"0001-01-01T00:00:00Z"}
+`
+
+	if string(res) != expected {
+		t.Fatalf("Wrong log content: %q, expected %q", res, expected)
+	}
+}
+
 func BenchmarkJSONFileLoggerLog(b *testing.B) {
 	tmp := fs.NewDir(b, "bench-jsonfilelog")
 	defer tmp.Remove()
@@ -82,7 +125,7 @@ func BenchmarkJSONFileLoggerLog(b *testing.B) {
 	}
 
 	buf := bytes.NewBuffer(nil)
-	require.NoError(b, marshalMessage(msg, jsonlogger.(*JSONFileLogger).extra, buf))
+	require.NoError(b, marshalMessage(msg, jsonlogger.(*JSONFileLogger).extra, buf, ""))
 	b.SetBytes(int64(buf.Len()))
 
 	b.ResetTimer()

--- a/daemon/logger/jsonfilelog/jsonlog/jsonlog.go
+++ b/daemon/logger/jsonfilelog/jsonlog/jsonlog.go
@@ -14,6 +14,8 @@ type JSONLog struct {
 	Created time.Time `json:"time"`
 	// Attrs is the list of extra attributes provided by the user
 	Attrs map[string]string `json:"attrs,omitempty"`
+	// Tags requested the operator
+	Tag string `json:"tag,omitempty"`
 }
 
 // Reset all fields to their zero value.
@@ -22,4 +24,5 @@ func (jl *JSONLog) Reset() {
 	jl.Stream = ""
 	jl.Created = time.Time{}
 	jl.Attrs = make(map[string]string)
+	jl.Tag = ""
 }

--- a/daemon/logger/jsonfilelog/jsonlog/jsonlogbytes.go
+++ b/daemon/logger/jsonfilelog/jsonlog/jsonlogbytes.go
@@ -12,6 +12,7 @@ type JSONLogs struct {
 	Log     []byte    `json:"log,omitempty"`
 	Stream  string    `json:"stream,omitempty"`
 	Created time.Time `json:"time"`
+	Tag     string    `json:"tag,omitempty"`
 
 	// json-encoded bytes
 	RawAttrs json.RawMessage `json:"attrs,omitempty"`
@@ -36,6 +37,15 @@ func (mj *JSONLogs) MarshalJSONBuf(buf *bytes.Buffer) error {
 		}
 		buf.WriteString(`"stream":`)
 		ffjsonWriteJSONBytesAsString(buf, []byte(mj.Stream))
+	}
+	if len(mj.Tag) > 0 {
+		if first {
+			first = false
+		} else {
+			buf.WriteString(`,`)
+		}
+		buf.WriteString(`"tag":`)
+		ffjsonWriteJSONBytesAsString(buf, []byte(mj.Tag))
 	}
 	if len(mj.RawAttrs) > 0 {
 		if first {

--- a/daemon/logger/jsonfilelog/jsonlog/jsonlogbytes_test.go
+++ b/daemon/logger/jsonfilelog/jsonlog/jsonlogbytes_test.go
@@ -29,6 +29,8 @@ func TestJSONLogsMarshalJSONBuf(t *testing.T) {
 		{Log: []byte{0x7F}}:            `^{\"log\":\"\x7f\",\"time\":`,
 		// with raw attributes
 		{Log: []byte("A log line"), RawAttrs: []byte(`{"hello":"world","value":1234}`)}: `^{\"log\":\"A log line\",\"attrs\":{\"hello\":\"world\",\"value\":1234},\"time\":`,
+		// with Tag set
+		{Log: []byte("A log line with tag"), Tag: "test-tag"}: `^{\"log\":\"A log line with tag\",\"tag\":\"test-tag\",\"time\":`,
 	}
 	for jsonLog, expression := range logs {
 		var buf bytes.Buffer

--- a/daemon/logger/jsonfilelog/read_test.go
+++ b/daemon/logger/jsonfilelog/read_test.go
@@ -35,7 +35,7 @@ func BenchmarkJSONFileLoggerReadLogs(b *testing.B) {
 	}
 
 	buf := bytes.NewBuffer(nil)
-	require.NoError(b, marshalMessage(msg, jsonlogger.(*JSONFileLogger).extra, buf))
+	require.NoError(b, marshalMessage(msg, jsonlogger.(*JSONFileLogger).extra, buf, ""))
 	b.SetBytes(int64(buf.Len()))
 
 	b.ResetTimer()


### PR DESCRIPTION
Fixes #19803
Updated the json-logger to utilize the common log option
'tag' that can define container/image information to include
as part of logging.

When the 'tag' log option is not included, there is no change
to the log content via the json-logger. When the 'tag' log option
is included, the tag will be parsed as a template and the result
will be stored within each log entry as the attribute 'tag'.

Signed-off-by: bonczj <josh.bonczkowski@gmail.com>

**- What I did**
Enabled the --log-opt tag= for the json-logger to allow operators to also log variables from https://docs.docker.com/engine/admin/logging/log_tags/.

**Note**: This is a continuation from #34088. The new PR is due to my botched rebase on the original. I'm not sure the best way to clean up it, so instead I created a new branch from my changes plus the code review change and rebased a bit more correctly.

**- How I did it**
Enabled the 'tag' option on json-logger. Utilized the existing loggerutils.ParseLogTag method to parse the tag template while providing an empty default template. Updated the jsonlog-marshaling routines in pkg/jsonlog/ to allow writing the tag string if it was specified.

**- How to verify it**
Use --log-driver json-logger --log-opt tag="[tag template]" either through 'docker run' or through dockerd.

**- Description for the changelog**
Added tag log option to json-logger

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![cute animal](http://cuteanimalpicturesandvideos.com/wp-content/uploads/lizard.jpg)
