### PR TITLE
Forbidden mount container rootfs while daemon is shutting down

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -119,10 +120,11 @@ type Daemon struct {
 	seccompProfile     []byte
 	seccompProfilePath string
 
-	diskUsageRunning int32
-	pruneRunning     int32
-	hosts            map[string]bool // hosts stores the addresses the daemon is listening on
-	startupDone      chan struct{}
+	diskUsageRunning   int32
+	pruneRunning       int32
+	hosts              map[string]bool // hosts stores the addresses the daemon is listening on
+	startupDone        chan struct{}
+	mountingContainers int32
 }
 
 // StoreHosts stores the addresses the daemon is listening on
@@ -785,6 +787,7 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 	d.idMappings = idMappings
 	d.seccompEnabled = sysInfo.Seccomp
 	d.apparmorEnabled = sysInfo.AppArmor
+	d.mountingContainers = 0
 
 	d.linkIndex = newLinkIndex()
 	d.containerdRemote = containerdRemote
@@ -918,6 +921,12 @@ func (daemon *Daemon) Shutdown() error {
 	}
 
 	for platform, ds := range daemon.stores {
+		for {
+			if atomic.CompareAndSwapInt32(&daemon.mountingContainers, 0, 0) {
+				break
+			}
+			<-time.After(10 * time.Millisecond)
+		}
 		if ds.layerStore != nil {
 			if err := ds.layerStore.Cleanup(); err != nil {
 				logrus.Errorf("Error during layer Store.Cleanup(): %v %s", err, platform)
@@ -951,6 +960,13 @@ func (daemon *Daemon) Shutdown() error {
 // Mount sets container.BaseFS
 // (is it not set coming in? why is it unset?)
 func (daemon *Daemon) Mount(container *container.Container) error {
+	atomic.AddInt32(&daemon.mountingContainers, 1)
+	defer func() {
+		atomic.AddInt32(&daemon.mountingContainers, -1)
+	}()
+	if daemon.IsShuttingDown() {
+		return fmt.Errorf("Error: daemon is shutting down")
+	}
 	dir, err := container.RWLayer.Mount(container.GetMountLabel())
 	if err != nil {
 		return err


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix a bug：

Description:
 When daemon is shutting down, it will umount
`/var/lib/docker/devicemapper` (take `devicemapper` as example) in devicemapper graphdriver(both `devicemapper` and `overlay2` has the issue). Then any mount to /var/lib/docker/devicemapper/xx will
become shared mount not private. it will leak to other mnt ns.

Of course if we mount container rootfs after this, may cause mountpoint leak to
sub-mnt namespace (e.g. systemd-udevd process mnt ns)

And more, the docker startup next time, and after docker re-mount
/var/lib/docker/devicemapper, we won't see that mountpoint in new
`/var/lib/docker/devicemapper`, so the rootfs is empty.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


Signed-off-by: Wentao Zhang <zhangwentao234@huawei.com>

**- A picture of a cute animal (not mandatory but encouraged)**

