### PR TITLE
builder: fix build cache hash for broken symlink

### DIFF
--- a/builder/remotecontext/archive.go
+++ b/builder/remotecontext/archive.go
@@ -122,8 +122,5 @@ func normalize(path string, root containerfs.ContainerFS) (cleanPath, fullPath s
 	if err != nil {
 		return "", "", errors.Wrapf(err, "forbidden path outside the build context: %s (%s)", path, cleanPath)
 	}
-	if _, err := root.Lstat(fullPath); err != nil {
-		return "", "", errors.WithStack(convertPathError(err, path))
-	}
 	return
 }

--- a/builder/remotecontext/lazycontext.go
+++ b/builder/remotecontext/lazycontext.go
@@ -40,14 +40,14 @@ func (c *lazySource) Hash(path string) (string, error) {
 		return "", err
 	}
 
-	fi, err := c.root.Lstat(fullPath)
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-
 	relPath, err := Rel(c.root, fullPath)
 	if err != nil {
 		return "", errors.WithStack(convertPathError(err, cleanPath))
+	}
+
+	fi, err := os.Lstat(fullPath)
+	if err != nil {
+		return relPath, nil
 	}
 
 	sum, ok := c.sums[relPath]

--- a/builder/remotecontext/lazycontext.go
+++ b/builder/remotecontext/lazycontext.go
@@ -47,6 +47,8 @@ func (c *lazySource) Hash(path string) (string, error) {
 
 	fi, err := os.Lstat(fullPath)
 	if err != nil {
+		// Backwards compatibility: a missing file returns a path as hash.
+		// This is reached in the case of a broken symlink.
 		return relPath, nil
 	}
 

--- a/builder/remotecontext/tarsum_test.go
+++ b/builder/remotecontext/tarsum_test.go
@@ -104,17 +104,6 @@ func TestHashSubdir(t *testing.T) {
 	}
 }
 
-func TestStatNotExisting(t *testing.T) {
-	contextDir, cleanup := createTestTempDir(t, "", "builder-tarsum-test")
-	defer cleanup()
-
-	src := makeTestArchiveContext(t, contextDir)
-	_, err := src.Hash("not-existing")
-	if !os.IsNotExist(errors.Cause(err)) {
-		t.Fatalf("This file should not exist: %s", err)
-	}
-}
-
 func TestRemoveDirectory(t *testing.T) {
 	contextDir, cleanup := createTestTempDir(t, "", "builder-tarsum-test")
 	defer cleanup()
@@ -129,17 +118,20 @@ func TestRemoveDirectory(t *testing.T) {
 
 	src := makeTestArchiveContext(t, contextDir)
 
-	tarSum := src.(modifiableContext)
+	_, err = src.Root().Stat(src.Root().Join(src.Root().Path(), relativePath))
+	if err != nil {
+		t.Fatalf("Statting %s shouldn't fail: %+v", relativePath, err)
+	}
 
+	tarSum := src.(modifiableContext)
 	err = tarSum.Remove(relativePath)
 	if err != nil {
 		t.Fatalf("Error when executing Remove: %s", err)
 	}
 
-	_, err = src.Hash(contextSubdir)
-
+	_, err = src.Root().Stat(src.Root().Join(src.Root().Path(), relativePath))
 	if !os.IsNotExist(errors.Cause(err)) {
-		t.Fatal("Directory should not exist at this point")
+		t.Fatalf("Directory should not exist at this point: %+v ", err)
 	}
 }
 


### PR DESCRIPTION
fixes #34260

This makes build cache hash for broken symlink in a directory to match the path of resolved path like it appears in the original tarsum version https://github.com/moby/moby/blob/8c72417b51a4998caae9f44eaf2f5a654ffcd839/builder/remotecontext/archive.go#L113-L115 . There are still plenty of cases where this isn't quite correct, some are described in https://github.com/moby/buildkit/issues/38 . I think we need to rethink what exact data to hash in there. The current is an accidental combination of some tar headers and automatic symlink following because of the `ADD/COPY` semantics.

@justincormack @dnephin 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
