### PR TITLE
container: Fix Delete on nonexistent container

### DIFF
--- a/container/view.go
+++ b/container/view.go
@@ -168,9 +168,9 @@ func (db *memDB) Delete(c *Container) error {
 			txn.Delete(memdbNamesTable, nameAssociation{name: name})
 		}
 
-		if err := txn.Delete(memdbContainersTable, NewBaseContainer(c.ID, c.Root)); err != nil {
-			return err
-		}
+		// Ignore error - the container may not actually exist in the
+		// db, but we still need to clean up associated names.
+		txn.Delete(memdbContainersTable, NewBaseContainer(c.ID, c.Root))
 		return nil
 	})
 }

--- a/container/view_test.go
+++ b/container/view_test.go
@@ -150,4 +150,12 @@ func TestNames(t *testing.T) {
 
 	view = db.Snapshot()
 	assert.Equal(t, map[string][]string{"containerid1": {"name1", "name3", "name4"}, "containerid4": {"name2"}}, view.GetAllNames())
+
+	// Release containerid1's names with Delete even though no container exists
+	assert.NoError(t, db.Delete(&Container{ID: "containerid1"}))
+
+	// Reusing one of those names should work
+	assert.NoError(t, db.ReserveName("name1", "containerid4"))
+	view = db.Snapshot()
+	assert.Equal(t, map[string][]string{"containerid4": {"name1", "name2"}}, view.GetAllNames())
 }


### PR DESCRIPTION
`Delete` needs to release names related to a container even if that
container isn't present in the db. However, slightly overzealous error
checking causes the transaction to get rolled back. Ignore the error
from `Delete` on the container itself, since it may not be present.

Fixes #34270