### PR TITLE
refactor some code in libcontainerd to be more readable

### DIFF
--- a/libcontainerd/client_linux.go
+++ b/libcontainerd/client_linux.go
@@ -466,11 +466,18 @@ func (clnt *client) Restore(containerID string, attachStdio StdioCallback, optio
 	// events will do is change the state of the container to be
 	// exactly the same.
 	cont, err := clnt.getContainerdContainer(containerID)
-	// Get its last event
-	ev, eerr := clnt.getContainerLastEvent(containerID)
-	if err != nil || containerd_runtime_types.State(cont.Status) == containerd_runtime_types.Stopped {
-		if err != nil {
-			logrus.Warnf("libcontainerd: failed to retrieve container %s state: %v", containerID, err)
+	if err != nil {
+		logrus.Warnf("libcontainerd: failed to retrieve container %s state: %v", containerID, err)
+		return nil
+	}
+
+	var ev *containerd.Event
+	if containerd_runtime_types.State(cont.Status) == containerd_runtime_types.Stopped {
+		// Get its last event
+		ev, eerr := clnt.getContainerLastEvent(containerID)
+		if eerr != nil {
+			// if we don't have one exit status, indicate an error
+			return clnt.setExited(containerID, uint32(255))
 		}
 		if ev != nil && (ev.Pid != InitFriendlyName || ev.Type != StateExit) {
 			// Wait a while for the exit event


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

**- What I did**
When I read code in libcontainerd about the restore logic. I found it is really hard to understand one part of the code like what this changes.
So I try to make it more readable to utilize "return fast".

While although I did this, I still hope get more other eyes on this, after all the consistent logic is the most important,

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

