### PR TITLE
Setting predefined network name in service spec

### DIFF
--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -311,7 +311,11 @@ func (c *Cluster) populateNetworkID(ctx context.Context, client swarmapi.Control
 			return err
 		}
 	setid:
-		networks[i].Target = apiNetwork.ID
+		if runconfig.IsPreDefinedNetwork(n.Target) {
+			networks[i].Target = n.Target
+		} else {
+			networks[i].Target = apiNetwork.ID
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
From 17.06 we started supporting service creation on host and bridge
predefined networks in addition to user defined local scope networks.
Since the task allocation involves creation of networks in the swarm
manager. A network id is generated on the manager to create predefined networks.
But this network id is not visible with the api to fetch networks. Since
the tasktemplate which is part of a servicespec holds this networkid
its hard to correlate the network id to network name by the api consumer.
For this reason the service spec is created to support network target as
ID,host or bridge.

Signed-off-by: Abhinandan Prativadi <abhi@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

