### PR TITLE
Switch Stat syscalls to x/sys/unix

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -14,7 +14,6 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -46,6 +45,7 @@ import (
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -146,11 +146,11 @@ func getCPUResources(config containertypes.Resources) (*specs.LinuxCPU, error) {
 }
 
 func getBlkioWeightDevices(config containertypes.Resources) ([]specs.LinuxWeightDevice, error) {
-	var stat syscall.Stat_t
+	var stat unix.Stat_t
 	var blkioWeightDevices []specs.LinuxWeightDevice
 
 	for _, weightDevice := range config.BlkioWeightDevice {
-		if err := syscall.Stat(weightDevice.Path, &stat); err != nil {
+		if err := unix.Stat(weightDevice.Path, &stat); err != nil {
 			return nil, err
 		}
 		weight := weightDevice.Weight
@@ -219,10 +219,10 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 
 func getBlkioThrottleDevices(devs []*blkiodev.ThrottleDevice) ([]specs.LinuxThrottleDevice, error) {
 	var throttleDevices []specs.LinuxThrottleDevice
-	var stat syscall.Stat_t
+	var stat unix.Stat_t
 
 	for _, d := range devs {
-		if err := syscall.Stat(d.Path, &stat); err != nil {
+		if err := unix.Stat(d.Path, &stat); err != nil {
 			return nil, err
 		}
 		d := specs.LinuxThrottleDevice{Rate: d.Rate}

--- a/daemon/graphdriver/devmapper/mount.go
+++ b/daemon/graphdriver/devmapper/mount.go
@@ -7,7 +7,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // FIXME: this is copy-pasted from the aufs driver.
@@ -15,19 +16,17 @@ import (
 
 // Mounted returns true if a mount point exists.
 func Mounted(mountpoint string) (bool, error) {
-	mntpoint, err := os.Stat(mountpoint)
-	if err != nil {
+	var mntpointSt unix.Stat_t
+	if err := unix.Stat(mountpoint, &mntpointSt); err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
 		return false, err
 	}
-	parent, err := os.Stat(filepath.Join(mountpoint, ".."))
-	if err != nil {
+	var parentSt unix.Stat_t
+	if err := unix.Stat(filepath.Join(mountpoint, ".."), &parentSt); err != nil {
 		return false, err
 	}
-	mntpointSt := mntpoint.Sys().(*syscall.Stat_t)
-	parentSt := parent.Sys().(*syscall.Stat_t)
 	return mntpointSt.Dev != parentSt.Dev, nil
 }
 

--- a/pkg/idtools/idtools_unix_test.go
+++ b/pkg/idtools/idtools_unix_test.go
@@ -7,10 +7,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 type node struct {
@@ -187,8 +187,8 @@ func readTree(base, root string) (map[string]node, error) {
 	}
 
 	for _, info := range dirInfos {
-		s := &syscall.Stat_t{}
-		if err := syscall.Stat(filepath.Join(base, info.Name()), s); err != nil {
+		s := &unix.Stat_t{}
+		if err := unix.Stat(filepath.Join(base, info.Name()), s); err != nil {
 			return nil, fmt.Errorf("Can't stat file %q: %v", filepath.Join(base, info.Name()), err)
 		}
 		tree[filepath.Join(root, info.Name())] = node{int(s.Uid), int(s.Gid)}

--- a/pkg/loopback/loopback.go
+++ b/pkg/loopback/loopback.go
@@ -5,9 +5,9 @@ package loopback
 import (
 	"fmt"
 	"os"
-	"syscall"
 
 	"github.com/Sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 func getLoopbackBackingFile(file *os.File) (uint64, uint64, error) {
@@ -31,12 +31,13 @@ func SetCapacity(file *os.File) error {
 // FindLoopDeviceFor returns a loopback device file for the specified file which
 // is backing file of a loop back device.
 func FindLoopDeviceFor(file *os.File) *os.File {
-	stat, err := file.Stat()
+	var stat unix.Stat_t
+	err := unix.Stat(file.Name(), &stat)
 	if err != nil {
 		return nil
 	}
-	targetInode := stat.Sys().(*syscall.Stat_t).Ino
-	targetDevice := stat.Sys().(*syscall.Stat_t).Dev
+	targetInode := stat.Ino
+	targetDevice := stat.Dev
 
 	for i := 0; true; i++ {
 		path := fmt.Sprintf("/dev/loop%d", i)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Switch some more usage of the Stat function and the Stat_t type from the
syscall package to golang.org/x/sys - akin to PR #33399 (/cc @tophj-ibm).

**- How I did it**

Manually grep'ed for obvious candidates (syscall.Stat, syscall.Stat_t) to replace by corresponding function/type from x/sys/unix.

**- How to verify it**

Unit, integration and docker-py tests still run through.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
n/a

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/539708/28660723-7355e442-72b4-11e7-9882-86dc6b9f00ac.png)
