### PR TITLE
integration-cli-on-swarm: print detailed error

### DIFF
--- a/hack/integration-cli-on-swarm/host/dockercmd.go
+++ b/hack/integration-cli-on-swarm/host/dockercmd.go
@@ -43,7 +43,7 @@ func deployStack(unusedCli *client.Client, stackName, composeFilePath string) er
 
 func hasStack(unusedCli *client.Client, stackName string) bool {
 	// FIXME: eliminate os/exec (but stack is implemented in CLI ...)
-	out, err := exec.Command("docker", "stack", "ls").Output()
+	out, err := exec.Command("docker", "stack", "ls").CombinedOutput()
 	if err != nil {
 		panic(fmt.Errorf("`docker stack ls` failed with: %s", string(out)))
 	}


### PR DESCRIPTION
e.g. 
```
panic: `docker stack ls` failed with: Error response from daemon: This node is not a swarm manager. Use "docker swarm init" or "docker swarm join" to connect this node to swarm and try again.
````
 when swarm is not configured.

Previously, the error message was just empty.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>