### PR TITLE
Implement private registry mirror support

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -471,6 +471,10 @@ func findConfigurationConflicts(config map[string]interface{}, flags *pflag.Flag
 	unknownKeys := make(map[string]interface{})
 	for key, value := range config {
 		if flag := flags.Lookup(key); flag == nil && !skipValidateOptions[key] {
+			// skip config-only flags
+			if key == "registries" {
+				continue
+			}
 			unknownKeys[key] = value
 		}
 	}

--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -100,7 +100,7 @@ func (i *ImageService) GetRepository(ctx context.Context, ref reference.Named, a
 	}
 
 	// get endpoints
-	endpoints, err := i.registryService.LookupPullEndpoints(reference.Domain(repoInfo.Name))
+	endpoints, err := i.registryService.LookupPullEndpoints(ref)
 	if err != nil {
 		return nil, false, err
 	}
@@ -116,7 +116,6 @@ func (i *ImageService) GetRepository(ctx context.Context, ref reference.Named, a
 		if endpoint.Version == registry.APIVersion1 {
 			continue
 		}
-
 		repository, confirmedV2, lastError = distribution.NewV2Repository(ctx, repoInfo, endpoint, nil, authConfig, "pull")
 		if lastError == nil && confirmedV2 {
 			break

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -23,6 +23,14 @@ import (
 // - Registry mirrors
 // - Daemon live restore
 func (daemon *Daemon) Reload(conf *config.Config) (err error) {
+	if conf == nil {
+		return fmt.Errorf("prodived config is nil")
+	}
+	// check for incompatible options
+	if err := conf.ServiceOptions.CompatCheck(); err != nil {
+		return nil
+	}
+
 	daemon.configStore.Lock()
 	attributes := map[string]string{}
 
@@ -60,6 +68,9 @@ func (daemon *Daemon) Reload(conf *config.Config) (err error) {
 		return err
 	}
 	if err := daemon.reloadRegistryMirrors(conf, attributes); err != nil {
+		return err
+	}
+	if err := daemon.reloadRegistries(conf, attributes); err != nil {
 		return err
 	}
 	if err := daemon.reloadLiveRestore(conf, attributes); err != nil {
@@ -292,6 +303,29 @@ func (daemon *Daemon) reloadRegistryMirrors(conf *config.Config, attributes map[
 		attributes["registry-mirrors"] = "[]"
 	}
 
+	return nil
+}
+
+// reloadRegistries updates the registries configuration and the passed attributes
+func (daemon *Daemon) reloadRegistries(conf *config.Config, attributes map[string]string) error {
+	// update corresponding configuration
+	if conf.IsValueSet("registries") {
+		daemon.configStore.Registries = conf.Registries
+		if err := daemon.RegistryService.LoadRegistries(conf.Registries); err != nil {
+			return err
+		}
+	}
+
+	// prepare reload event attributes with updatable configurations
+	if daemon.configStore.Registries != nil {
+		registries, err := json.Marshal(daemon.configStore.Registries)
+		if err != nil {
+			return err
+		}
+		attributes["registries"] = string(registries)
+	} else {
+		attributes["registries"] = "[]"
+	}
 	return nil
 }
 

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -63,7 +63,7 @@ func Pull(ctx context.Context, ref reference.Named, imagePullConfig *ImagePullCo
 		return err
 	}
 
-	endpoints, err := imagePullConfig.RegistryService.LookupPullEndpoints(reference.Domain(repoInfo.Name))
+	endpoints, err := imagePullConfig.RegistryService.LookupPullEndpoints(ref)
 	if err != nil {
 		return err
 	}

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -64,7 +64,7 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
 		return err
 	}
 
-	endpoints, err := imagePushConfig.RegistryService.LookupPushEndpoints(reference.Domain(repoInfo.Name))
+	endpoints, err := imagePushConfig.RegistryService.LookupPushEndpoints(ref)
 	if err != nil {
 		return err
 	}

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/client"
 	apitypes "github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/distribution/xfer"
 	"github.com/docker/docker/layer"
@@ -113,6 +114,16 @@ func (p *v2Pusher) pushV2Repository(ctx context.Context) (err error) {
 }
 
 func (p *v2Pusher) pushV2Tag(ctx context.Context, ref reference.NamedTagged, id digest.Digest) error {
+	newRef, err := registrytypes.RewriteReference(ref, p.endpoint.Prefix, p.endpoint.URL)
+	if err != nil {
+		return err
+	}
+	logrus.Infof("rewriting %q to %q", ref.String(), newRef.String())
+	ref, err = reference.WithTag(newRef, ref.Tag())
+	if err != nil {
+		return err
+	}
+
 	logrus.Debugf("Pushing repository: %s", reference.FamiliarString(ref))
 
 	imgConfig, err := p.config.ImageStore.Get(id)

--- a/registry/config.go
+++ b/registry/config.go
@@ -14,11 +14,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// ServiceOptions holds command line options.
+// ServiceOptions holds user-specified configuration and command line options.
 type ServiceOptions struct {
 	AllowNondistributableArtifacts []string `json:"allow-nondistributable-artifacts,omitempty"`
 	Mirrors                        []string `json:"registry-mirrors,omitempty"`
 	InsecureRegistries             []string `json:"insecure-registries,omitempty"`
+
+	// Registries holds information associated with registries and their
+	// push and pull mirrors.
+	Registries registrytypes.Registries `json:"registries,omitempty"`
 
 	// V2Only controls access to legacy registries.  If it is set to true via the
 	// command line flag the daemon will not attempt to contact v1 legacy registries
@@ -67,8 +71,24 @@ var (
 // for mocking in unit tests
 var lookupIP = net.LookupIP
 
+// CompatCheck performs some compatibility checks among the config options and
+// returns an error in case of conflicts.
+func (options *ServiceOptions) CompatCheck() error {
+	if len(options.Registries) > 0 && len(options.InsecureRegistries) > 0 {
+		return fmt.Errorf("usage of 'registries' with deprecated option 'insecure-registries' is not supported")
+	}
+	if len(options.Registries) > 0 && len(options.Mirrors) > 0 {
+		return fmt.Errorf("usage of 'registries' with deprecated option 'registry-mirrors' is not supported")
+	}
+	return nil
+}
+
 // newServiceConfig returns a new instance of ServiceConfig
 func newServiceConfig(options ServiceOptions) (*serviceConfig, error) {
+	if err := options.CompatCheck(); err != nil {
+		return nil, fmt.Errorf("error loading config: %v", err)
+	}
+
 	config := &serviceConfig{
 		ServiceConfig: registrytypes.ServiceConfig{
 			InsecureRegistryCIDRs: make([]*registrytypes.NetIPNet, 0),
@@ -85,6 +105,9 @@ func newServiceConfig(options ServiceOptions) (*serviceConfig, error) {
 		return nil, err
 	}
 	if err := config.LoadInsecureRegistries(options.InsecureRegistries); err != nil {
+		return nil, err
+	}
+	if err := config.LoadRegistries(options.Registries); err != nil {
 		return nil, err
 	}
 
@@ -131,6 +154,10 @@ func (config *serviceConfig) LoadAllowNondistributableArtifacts(registries []str
 // LoadMirrors loads mirrors to config, after removing duplicates.
 // Returns an error if mirrors contains an invalid mirror.
 func (config *serviceConfig) LoadMirrors(mirrors []string) error {
+	if len(mirrors) > 0 {
+		logrus.Infof("usage of deprecated 'registry-mirrors' option: please use 'registries' instead")
+	}
+
 	mMap := map[string]struct{}{}
 	unique := []string{}
 
@@ -165,6 +192,10 @@ func (config *serviceConfig) LoadInsecureRegistries(registries []string) error {
 	//
 	// TODO: should we deprecate this once it is easier for people to set up a TLS registry or change
 	// daemon flags on boot2docker?
+	if len(registries) > 0 {
+		logrus.Info("usage of deprecated 'insecure-registries' option: please use 'registries' instead")
+	}
+
 	registries = append(registries, "127.0.0.0/8")
 
 	// Store original InsecureRegistryCIDRs and IndexConfigs
@@ -235,6 +266,30 @@ skip:
 		Official: true,
 	}
 
+	return nil
+}
+
+// LoadRegistries loads the user-specified configuration options for registries
+func (config *serviceConfig) LoadRegistries(registries registrytypes.Registries) error {
+	for _, registry := range registries {
+		if err := registry.Prepare(); err != nil {
+			return err
+		}
+		config.Registries = append(config.Registries, registry)
+	}
+
+	// Make sure there's a default registry for "docker.io"
+	if reg := config.Registries.FindRegistry("docker.io/"); reg == nil {
+		defaultReg := registrytypes.Registry{Prefix: "docker.io/"}
+		if err := defaultReg.Prepare(); err != nil {
+			return err
+		}
+		config.Registries = append(config.Registries, defaultReg)
+	}
+
+	for i, r := range config.Registries {
+		logrus.Infof("REGISTRY %d: %v", i, r)
+	}
 	return nil
 }
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -684,7 +684,7 @@ func TestMirrorEndpointLookup(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	pushAPIEndpoints, err := s.LookupPushEndpoints(reference.Domain(imageName))
+	pushAPIEndpoints, err := s.LookupPushEndpoints(imageName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -692,12 +692,12 @@ func TestMirrorEndpointLookup(t *testing.T) {
 		t.Fatal("Push endpoint should not contain mirror")
 	}
 
-	pullAPIEndpoints, err := s.LookupPullEndpoints(reference.Domain(imageName))
+	pullAPIEndpoints, err := s.LookupPullEndpoints(imageName)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !containsMirror(pullAPIEndpoints) {
-		t.Fatal("Pull endpoint should contain mirror")
+	if containsMirror(pullAPIEndpoints) {
+		t.Fatal("Pull endpoint should not contain mirror")
 	}
 }
 


### PR DESCRIPTION
Add private-registry mirror support

Add support for mirroring private registries.  The daemon.json config
can now be configured as exemplified below:

```json
{
"registries": [
        {
	"Prefix": "docker.io/alpine",
	"Mirrors": [
		{
			"URL": "http://local-alpine-mirror.lan",
		}
	]
        },
        {
        "Prefix": "registry.suse.com",
        "Mirrors": [
                {
                        "URL": "https://remote.suse.mirror.com"
                }
        ]
        },
        {
        "Prefix": "http://insecure.registry.org:5000"
        }
],
"registry-mirrors": ["https://deprecated-mirror.com"]
}
```

With the new semantics, a mirror will be selected as an endpoint if the
specified prefix matches the prefix of the requested resource (e.g., an
image reference).  In the upper example, "local-alpine-mirror" will only
serve as a mirror for docker.io if the requested resource matches the
"alpine" prefix, such as "alpine:latest" or "alpine-foo/bar".

Furthermore, private registries can now be mirrored as well.  In the
example above, "remote.suse.mirror.com" will serve as a mirror for all
requests to "registry.suse.com".  Notice that if no http{s,} scheme is
specified, the URI will always default to https without fallback to
http.  An insecure registry can now be specified by adding the "http://"
scheme to the corresponding prefix.

Note that the configuration is sanity checked, so that a given mirror
can serve multiple prefixes if they all point to the same registry,
while a registry cannot simultaneously serve as a mirror.  The daemon
will warn in case the URI schemes of a registry and one of its mirrors
do not correspond.

This change deprecates the "insecure-regestries" and "registry-mirrors"
options, while the "insecure-registries" cannot be used simultaneously
with the new "registries", which doesn't allow a fallback from https to
http for security reasons.

Signed-off-by: Flavio Castelli <fcastelli@suse.com>
Signed-off-by: Valentin Rothberg <vrothberg@suse.com>