### PR TITLE
pkg/archive: add xattr to archive when use overlay2 graphdriver

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -703,6 +703,8 @@ func (d *Driver) Diff(id, parent string) (io.ReadCloser, error) {
 		UIDMaps:        d.uidMaps,
 		GIDMaps:        d.gidMaps,
 		WhiteoutFormat: archive.OverlayWhiteoutFormat,
+		Xattrs:         true,
+		XattrsInclude:  []string{"trusted.overlay.*"},
 	})
 }
 

--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -423,7 +423,7 @@ func ExportChanges(dir string, changes []Change, uidMaps, gidMaps []idtools.IDMa
 				}
 			} else {
 				path := filepath.Join(dir, change.Path)
-				if err := ta.addTarFile(path, change.Path[1:]); err != nil {
+				if err := ta.addTarFile(path, change.Path[1:], false, nil); err != nil {
 					logrus.Debugf("Can't add file %s to tar: %s", path, err)
 				}
 			}

--- a/pkg/system/xattrs_linux.go
+++ b/pkg/system/xattrs_linux.go
@@ -27,3 +27,35 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 func Lsetxattr(path string, attr string, data []byte, flags int) error {
 	return unix.Lsetxattr(path, attr, data, flags)
 }
+
+// Listxattr retrieves a list of names of extened attributes associated
+// with the given path in the file system
+func Listxattr(path string) ([]string, error) {
+	// Get the size first
+	size, err := unix.Listxattr(path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if size > 0 {
+		buf := make([]byte, size)
+		// Read into buffer of that size.
+		read, err := unix.Listxattr(path, buf)
+		if err != nil {
+			return nil, err
+		}
+		return nullTermToStrings(buf[:read]), nil
+	}
+	return []string{}, nil
+}
+
+// nullTermToStrings converts an array of NULL terminated UTF-8 strings to a []string.
+func nullTermToStrings(buf []byte) (result []string) {
+	offset := 0
+	for index, b := range buf {
+		if b == 0 {
+			result = append(result, string(buf[offset:index]))
+			offset = index + 1
+		}
+	}
+	return
+}


### PR DESCRIPTION
When use overlay2 as the graphdriver and the kernel enable
`CONFIG_OVERLAY_FS_REDIRECT_DIR=y`, the following dockerfile
will miss files after mv dir operation.

```
FROM busybox

RUN mkdir /dir1
RUN touch /dir1/newfile
RUN mv /dir1 /dir2
```
The `newfile` is missing from the `/dir2` in the final image.

This is because `dir2` has a xattr to redirect its dir to `dir1`
when kernel enbale `CONFIG_OVERLAY_FS_REDIRECT_DIR`
```
debugfs:  ea_list dir2/
Extended attributes:
  security.selinux (43)
  trusted.overlay.redirect (4) = "dir1"
```
but this xattr is missing on archiving.
```
debugfs:  ea_list dir2
Extended attributes:
  security.selinux (43)
```

This patch add `Xattrs` and `XattrsInclude` to TarOptions and
enable this two options when using overlay2.

Signed-off-by: Lei Jitang <leijitang@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

