### PR TITLE
Don't treat comment-only lines in Dockerfiles as empty continuation lines.

### DIFF
--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -332,7 +332,7 @@ func trimWhitespace(src []byte) []byte {
 }
 
 func isEmptyContinuationLine(line []byte) bool {
-	return len(trimComments(trimWhitespace(line))) == 0
+	return len(trimWhitespace(line)) == 0
 }
 
 var utf8bom = []byte{0xEF, 0xBB, 0xBF}


### PR DESCRIPTION
Signed-off-by: Robert Rollins <rrollins@caltech.edu>

**- What I did**
Changed the Dockerfile parser to make it treat lines that contain only a comment between two lines of a multi-line RUN command as non-empty continuation lines.

**- Why I did it**
Disallowing comments between lines not only makes it that much harder to accurately document long, complicated RUN commands, it also doesn't match how Bash handles this. This bash script works just fine:
```
true && \
    # comment
    echo 'hi';
```
Echoing 'hi' with no errors. So why disallow this in Dockerfiles?

**- How to verify it**
I dunno. Looks pretty straightforward.

**- Description for the changelog**
Lines in Dockerfiles containing only a comment are no longer treated as empty continuation lines.

**- A picture of a cute animal (not mandatory but encouraged)**
Here's my cat Rita, being a total goof.
![fullsizerender](https://user-images.githubusercontent.com/413571/28793743-da07f7e8-75e8-11e7-9917-dc96c6f4e5e4.jpg)

