### PR TITLE
LCOW: CI enablement

### DIFF
--- a/integration-cli/requirement/requirement.go
+++ b/integration-cli/requirement/requirement.go
@@ -27,6 +27,20 @@ func Is(s skipT, requirements ...Test) {
 	}
 }
 
+// IsOneOf checks if the environment satisfies the requirements
+// for the test to run or skips the tests.
+func IsOneOf(s skipT, requirements ...Test) {
+	list := ""
+	for _, r := range requirements {
+		requirementFunc := runtime.FuncForPC(reflect.ValueOf(r).Pointer()).Name()
+		list = list + extractRequirement(requirementFunc) + " "
+		if r() {
+			return
+		}
+	}
+	s.Skip(fmt.Sprintf("no matched requirement %s", strings.TrimSpace(list)))
+}
+
 func extractRequirement(requirementFunc string) string {
 	requirement := path.Base(requirementFunc)
 	return strings.SplitN(requirement, ".", 2)[1]

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -41,6 +41,9 @@ func DaemonIsLinux() bool {
 	return PlatformIs("linux")
 }
 
+func DaemonIsLCOW() bool {
+	return testEnv.DaemonIsLCOW()
+}
 func ExperimentalDaemon() bool {
 	return testEnv.ExperimentalDaemon()
 }
@@ -200,4 +203,10 @@ func IsolationIsProcess() bool {
 // for the test to run or skips the tests.
 func testRequires(c *check.C, requirements ...requirement.Test) {
 	requirement.Is(c, requirements...)
+}
+
+// testRequiresOneOf checks if the environment satisfies the requirements
+// for the test to run or skips the tests.
+func testRequiresOneOf(c *check.C, requirements ...requirement.Test) {
+	requirement.IsOneOf(c, requirements...)
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@vdemeester - I think this is your area?

This puts some infrastructure plumbing in so that tests can use (in addition to the current `testRequires(c, check1, check2, ...)` which are `AND`), a new `OR` operator.

In other words, tests can be updated with the following constraint `testRequiresOneOf(c, DaemonIsLinux, DaemonIsLCOW)`.

It doesn't actually enable any tests, this is just the `or` infrastructure.

@johnstep PTAL.