### PR TITLE
Windows: Enable TestAPIImagesSaveAndLoad

### DIFF
--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -53,9 +53,7 @@ func (s *DockerSuite) TestAPIImagesFilter(c *check.C) {
 }
 
 func (s *DockerSuite) TestAPIImagesSaveAndLoad(c *check.C) {
-	// TODO Windows to Windows CI: Investigate further why this test fails.
 	testRequires(c, Network)
-	testRequires(c, DaemonIsLinux)
 	buildImageSuccessfully(c, "saveandload", build.WithDockerfile("FROM busybox\nENV FOO bar"))
 	id := getIDByName(c, "saveandload")
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Enabling this test on Windows. It works locally at least (was debugging docker save for LCOW when was accidentally running in Windows mode and discovered this). Let's see if CI agrees 🙈 