### PR TITLE
Remove the logrus from pkg/signal

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -205,7 +205,7 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	signal.Trap(func() {
 		cli.stop()
 		<-stopc // wait for daemonCli.start() to return
-	})
+	}, logrus.StandardLogger())
 
 	// Notify that the API is active, but before daemon is set up.
 	preNotifySystem()

--- a/pkg/signal/trap.go
+++ b/pkg/signal/trap.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // Trap sets up a simplified signal "trap", appropriate for common
@@ -27,7 +26,9 @@ import (
 //   the docker daemon is not restarted and also running under systemd.
 //   Fixes https://github.com/docker/docker/issues/19728
 //
-func Trap(cleanup func()) {
+func Trap(cleanup func(), logger interface {
+	Info(args ...interface{})
+}) {
 	c := make(chan os.Signal, 1)
 	// we will handle INT, TERM, QUIT, SIGPIPE here
 	signals := []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGPIPE}
@@ -40,7 +41,7 @@ func Trap(cleanup func()) {
 			}
 
 			go func(sig os.Signal) {
-				logrus.Infof("Processing signal '%v'", sig)
+				logger.Info(fmt.Sprintf("Processing signal '%v'", sig))
 				switch sig {
 				case os.Interrupt, syscall.SIGTERM:
 					if atomic.LoadUint32(&interruptCount) < 3 {
@@ -54,11 +55,11 @@ func Trap(cleanup func()) {
 						}
 					} else {
 						// 3 SIGTERM/INT signals received; force exit without cleanup
-						logrus.Info("Forcing docker daemon shutdown without cleanup; 3 interrupts received")
+						logger.Info("Forcing docker daemon shutdown without cleanup; 3 interrupts received")
 					}
 				case syscall.SIGQUIT:
 					DumpStacks("")
-					logrus.Info("Forcing docker daemon shutdown without cleanup on SIGQUIT")
+					logger.Info("Forcing docker daemon shutdown without cleanup on SIGQUIT")
 				}
 				//for the SIGINT/TERM, and SIGQUIT non-clean shutdown case, exit with 128 + signal #
 				os.Exit(128 + int(sig.(syscall.Signal)))


### PR DESCRIPTION
Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>

fixes #34334

**- What I did**
Remove the logrus from pkg/signal/trap.go which should not be specific to docker/moby and should not import the logger.

**- How I did it**
Use fmt.Println or fmt.Printf instead of logrus.Info



