### PR TITLE
Update Dockerfiles to use Debian stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM debian:jessie
+FROM debian:stretch
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org
@@ -54,8 +54,9 @@ RUN apt-get update && apt-get install -y \
 	libnl-3-dev \
 	libprotobuf-c0-dev \
 	libprotobuf-dev \
-	libsystemd-journal-dev \
+	libsystemd-dev \
 	libtool \
+	libudev-dev \
 	mercurial \
 	net-tools \
 	pkg-config \
@@ -64,8 +65,10 @@ RUN apt-get update && apt-get install -y \
 	python-dev \
 	python-mock \
 	python-pip \
+	python-setuptools \
 	python-websocket \
 	tar \
+	thin-provisioning-tools \
 	vim \
 	vim-common \
 	xfsprogs \
@@ -85,6 +88,7 @@ RUN cd /usr/local/lvm2 \
 		--build="$(gcc -print-multiarch)" \
 		--enable-static_link \
 		--enable-pkgconfig \
+		--enable-udev_sync \
 	&& make -C include \
 	&& make -C libdm install_device-mapper
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -15,14 +15,20 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM aarch64/ubuntu:xenial
+FROM arm64v8/debian:stretch
+
+# allow replacing httpredir or deb mirror
+ARG APT_MIRROR=deb.debian.org
+RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \
 	apparmor \
+	apt-utils \
 	aufs-tools \
 	automake \
 	bash-completion \
+	bsdmainutils \
 	btrfs-tools \
 	build-essential \
 	cmake \
@@ -32,26 +38,34 @@ RUN apt-get update && apt-get install -y \
 	g++ \
 	gcc \
 	git \
+	golang \
 	iptables \
 	jq \
+	less \
 	libapparmor-dev \
-	libc6-dev \
 	libcap-dev \
+	libnl-3-dev \
+	libprotobuf-c0-dev \
+	libprotobuf-dev \
 	libsystemd-dev \
-	libyaml-dev \
+	libtool \
+	libudev-dev \
 	mercurial \
 	net-tools \
-	parallel \
 	pkg-config \
+	protobuf-compiler \
+	protobuf-c-compiler \
 	python-dev \
 	python-mock \
 	python-pip \
 	python-setuptools \
 	python-websocket \
-	golang-go \
-	iproute2 \
-	iputils-ping \
+	tar \
+	thin-provisioning-tools \
+	vim \
 	vim-common \
+	xfsprogs \
+	zip \
 	--no-install-recommends
 
 # Get lvm2 sources to build statically linked devmapper library
@@ -66,6 +80,7 @@ RUN cd /usr/local/lvm2 \
 		--build="$(gcc -print-multiarch)" \
 		--enable-static_link \
 		--enable-pkgconfig \
+		--enable-udev_sync \
 	&& make -C include \
 	&& make -C libdm install_device-mapper
 
@@ -86,9 +101,7 @@ RUN set -x \
 
 # Install Go
 # We don't have official binary golang 1.7.5 tarballs for ARM64, either for Go or
-# bootstrap, so we use golang-go (1.6) as bootstrap to build Go from source code.
-# We don't use the official ARMv6 released binaries as a GOROOT_BOOTSTRAP, because
-# not all ARM64 platforms support 32-bit mode. 32-bit mode is optional for ARMv8.
+# bootstrap, so we use Debian golang (1.7) as bootstrap to build Go from source code.
 # IMPORTANT: When updating this please note that stdlib archive/tar pkg is vendored
 ENV GO_VERSION 1.8.3
 RUN mkdir /usr/src/go && curl -fsSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/src/go -xz --strip-components=1 \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -15,7 +15,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM armhf/debian:jessie
+FROM arm32v7/debian:stretch
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org
@@ -39,16 +39,19 @@ RUN apt-get update && apt-get install -y \
 	net-tools \
 	libapparmor-dev \
 	libcap-dev \
-	libsystemd-journal-dev \
+	libsystemd-dev \
 	libtool \
+	libudev-dev \
 	mercurial \
 	pkg-config \
 	python-dev \
 	python-mock \
 	python-pip \
+	python-setuptools \
 	python-websocket \
 	xfsprogs \
 	tar \
+	thin-provisioning-tools \
 	vim-common \
 	--no-install-recommends \
 	&& pip install awscli==1.10.15
@@ -65,6 +68,7 @@ RUN cd /usr/local/lvm2 \
 		--build="$(gcc -print-multiarch)" \
 		--enable-static_link \
 		--enable-pkgconfig \
+		--enable-udev_sync \
 	&& make -C include \
 	&& make -C libdm install_device-mapper
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -15,7 +15,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM ppc64le/debian:jessie
+FROM ppc64le/debian:stretch
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org
@@ -40,16 +40,19 @@ RUN apt-get update && apt-get install -y \
 	net-tools \
 	libapparmor-dev \
 	libcap-dev \
-	libsystemd-journal-dev \
+	libsystemd-dev \
 	libtool \
+	libudev-dev \
 	mercurial \
 	pkg-config \
 	python-dev \
 	python-mock \
 	python-pip \
+	python-setuptools \
 	python-websocket \
 	xfsprogs \
 	tar \
+	thin-provisioning-tools \
 	vim-common \
 	--no-install-recommends
 
@@ -65,6 +68,7 @@ RUN cd /usr/local/lvm2 \
 		--build="$(gcc -print-multiarch)" \
 		--enable-static_link \
 		--enable-pkgconfig \
+		--enable-udev_sync \
 	&& make -C include \
 	&& make -C libdm install_device-mapper
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -15,7 +15,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM s390x/debian:jessie
+FROM s390x/debian:stretch
 
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \
@@ -36,16 +36,19 @@ RUN apt-get update && apt-get install -y \
 	net-tools \
 	libapparmor-dev \
 	libcap-dev \
-	libsystemd-journal-dev \
+	libsystemd-dev \
 	libtool \
+	libudev-dev \
 	mercurial \
 	pkg-config \
 	python-dev \
 	python-mock \
 	python-pip \
+	python-setuptools \
 	python-websocket \
 	xfsprogs \
 	tar \
+	thin-provisioning-tools \
 	vim-common \
 	--no-install-recommends
 
@@ -76,6 +79,7 @@ RUN cd /usr/local/lvm2 \
 		--build="$(gcc -print-multiarch)" \
 		--enable-static_link \
 		--enable-pkgconfig \
+		--enable-udev_sync \
 	&& make -C include \
 	&& make -C libdm install_device-mapper
 

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-FROM debian:jessie
+FROM debian:stretch
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org


### PR DESCRIPTION
The main gain here is that they all use exactly the same distro; previously
arm64 was using Ubuntu Xenial because Debian jessie was too old.

Does not seem that we can change any of the downloaded dependencies still,
as eg libseccomp is still not the version we are using.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

Tested on amd64 and arm64, will see if anything comes up in the other builds.

![stretch-cat](https://user-images.githubusercontent.com/482364/28827594-fff29b74-76c5-11e7-826a-a903bf0256c7.jpg)
