### PR TITLE
[client] Enable TCP Keep-Alive in Default Client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -44,12 +44,14 @@ package client // import "github.com/docker/docker/client"
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
@@ -130,6 +132,10 @@ func FromEnv(c *Client) error {
 		httpClient = &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: tlsc,
+				DialContext: (&net.Dialer{
+					KeepAlive: 30 * time.Second,
+					Timeout:   30 * time.Second,
+				}).DialContext,
 			},
 			CheckRedirect: CheckRedirect,
 		}


### PR DESCRIPTION
Some network environments may have NATs, proxies, or gateways which
kill idle connections. There are many Docker API operations which may
be idle for long periods of time (such as ContainerWait and ContainerAttach)
and may result in unexpected connection closures or hangs if TCP keepalives
are not used.

This patch updates the default HTTP transport used by the Docker client
package to enable TCP Keep-Alive with a keep-alive interval of 30 seconds.
It also sets a connect timeout of 30 seconds.

**- What I did**

Updated the creating of the default HTTP client used by the client package to enable TCP keep-alive.

**- How I did it**

By adding a few lines of code.

**- How to verify it**

This error showed up when testing on AWS EC2 in a VPC where a Docker CLI on a machine communicates to a Docker daemon over the internet through a NAT gateway. These NAT gateways will mark a connection as timed-out (it will stop sending data to a Docker client behind the gateway, it does not send a FIN packet) if it is idle for 5 minutes. A `docker run ...` which takes longer than that will hang forever, even when the container has exited. This is because it will never receive a response from the `ContainerWait` API request.

Using a Docker CLI built with this patch will not hang.

**- Description for the changelog**

Enable TCP Keep-Alive by default for API client connections.


