### PR TITLE
Dockerfile*: bump devmapper library version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,21 +72,21 @@ RUN apt-get update && apt-get install -y \
 	zip \
 	--no-install-recommends \
 	&& pip install awscli==1.10.15
-# Get lvm2 source for compiling statically
-ENV LVM2_VERSION 2.02.103
+
+# Get lvm2 sources to build statically linked devmapper library
+ENV LVM2_VERSION 2.02.173
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1
-# See https://git.fedorahosted.org/cgit/lvm2.git/refs/tags for release tags
 
-# Compile and install lvm2
+# Compile and install (only the needed library)
 RUN cd /usr/local/lvm2 \
 	&& ./configure \
 		--build="$(gcc -print-multiarch)" \
 		--enable-static_link \
-	&& make device-mapper \
-	&& make install_device-mapper
-# See https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
+		--enable-pkgconfig \
+	&& make -C include \
+	&& make -C libdm install_device-mapper
 
 # Install seccomp: the version shipped upstream is too old
 ENV SECCOMP_VERSION 2.3.2

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -54,28 +54,20 @@ RUN apt-get update && apt-get install -y \
 	vim-common \
 	--no-install-recommends
 
-# Get lvm2 source for compiling statically
-ENV LVM2_VERSION 2.02.103
+# Get lvm2 sources to build statically linked devmapper library
+ENV LVM2_VERSION 2.02.173
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1
-# See https://git.fedorahosted.org/cgit/lvm2.git/refs/tags for release tags
 
-# Fix platform enablement in lvm2 to support aarch64 properly
-RUN set -e \
-	&& for f in config.guess config.sub; do \
-		curl -fsSL -o "/usr/local/lvm2/autoconf/$f" "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=$f;hb=HEAD"; \
-	done
-# "arch.c:78:2: error: #error the arch code needs to know about your machine type"
-
-# Compile and install lvm2
+# Compile and install (only the needed library)
 RUN cd /usr/local/lvm2 \
 	&& ./configure \
 		--build="$(gcc -print-multiarch)" \
 		--enable-static_link \
-	&& make device-mapper \
-	&& make install_device-mapper
-# See https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
+		--enable-pkgconfig \
+	&& make -C include \
+	&& make -C libdm install_device-mapper
 
 # Install seccomp: the version shipped upstream is too old
 ENV SECCOMP_VERSION 2.3.2

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -53,21 +53,21 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends \
 	&& pip install awscli==1.10.15
 
-# Get lvm2 source for compiling statically
-ENV LVM2_VERSION 2.02.103
+# Get lvm2 sources to build statically linked devmapper library
+ENV LVM2_VERSION 2.02.173
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1
-# See https://git.fedorahosted.org/cgit/lvm2.git/refs/tags for release tags
 
-# Compile and install lvm2
+# Compile and install (only the needed library)
 RUN cd /usr/local/lvm2 \
 	&& ./configure \
 		--build="$(gcc -print-multiarch)" \
 		--enable-static_link \
-	&& make device-mapper \
-	&& make install_device-mapper
-# See https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
+		--enable-pkgconfig \
+	&& make -C include \
+	&& make -C libdm install_device-mapper
+
 
 # Install Go
 # IMPORTANT: When updating this please note that stdlib archive/tar pkg is vendored

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -53,28 +53,20 @@ RUN apt-get update && apt-get install -y \
 	vim-common \
 	--no-install-recommends
 
-# Get lvm2 source for compiling statically
-ENV LVM2_VERSION 2.02.103
+# Get lvm2 sources to build statically linked devmapper library
+ENV LVM2_VERSION 2.02.173
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1
-# See https://git.fedorahosted.org/cgit/lvm2.git/refs/tags for release tags
 
-# Fix platform enablement in lvm2 to support ppc64le properly
-RUN set -e \
-	&& for f in config.guess config.sub; do \
-		curl -fsSL -o "/usr/local/lvm2/autoconf/$f" "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=$f;hb=HEAD"; \
-	done
-# "arch.c:78:2: error: #error the arch code needs to know about your machine type"
-
-# Compile and install lvm2
+# Compile and install (only the needed library)
 RUN cd /usr/local/lvm2 \
 	&& ./configure \
 		--build="$(gcc -print-multiarch)" \
 		--enable-static_link \
-	&& make device-mapper \
-	&& make install_device-mapper
-# See https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
+		--enable-pkgconfig \
+	&& make -C include \
+	&& make -C libdm install_device-mapper
 
 # Install seccomp: the version shipped upstream is too old
 ENV SECCOMP_VERSION 2.3.2

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -64,28 +64,20 @@ RUN set -x \
 	) \
 	&& rm -rf "$SECCOMP_PATH"
 
-# Get lvm2 source for compiling statically
-ENV LVM2_VERSION 2.02.103
+# Get lvm2 sources to build statically linked devmapper library
+ENV LVM2_VERSION 2.02.173
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1
-# See https://git.fedorahosted.org/cgit/lvm2.git/refs/tags for release tags
 
-# Fix platform enablement in lvm2 to support s390x properly
-RUN set -e \
-	&& for f in config.guess config.sub; do \
-		curl -fsSL -o "/usr/local/lvm2/autoconf/$f" "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=$f;hb=HEAD"; \
-	done
-# "arch.c:78:2: error: #error the arch code needs to know about your machine type"
-
-# Compile and install lvm2
+# Compile and install (only the needed library)
 RUN cd /usr/local/lvm2 \
 	&& ./configure \
 		--build="$(gcc -print-multiarch)" \
 		--enable-static_link \
-	&& make device-mapper \
-	&& make install_device-mapper
-# See https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
+		--enable-pkgconfig \
+	&& make -C include \
+	&& make -C libdm install_device-mapper
 
 # IMPORTANT: When updating this please note that stdlib archive/tar pkg is vendored
 ENV GO_VERSION 1.8.3

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -130,7 +130,7 @@ fi
 # functionality.
 if \
 	command -v gcc &> /dev/null \
-	&& ! ( echo -e  '#include <libdevmapper.h>\nint main() { dm_task_deferred_remove(NULL); }'| gcc -xc - -o /dev/null -ldevmapper &> /dev/null ) \
+	&& ! ( echo -e  '#include <libdevmapper.h>\nint main() { dm_task_deferred_remove(NULL); }'| gcc -xc - -o /dev/null $(pkg-config --libs devmapper) &> /dev/null ) \
 ; then
 	DOCKER_BUILDTAGS+=' libdm_no_deferred_remove'
 fi

--- a/pkg/devicemapper/devmapper_wrapper.go
+++ b/pkg/devicemapper/devmapper_wrapper.go
@@ -3,7 +3,6 @@
 package devicemapper
 
 /*
-#cgo LDFLAGS: -L. -ldevmapper
 #define _GNU_SOURCE
 #include <libdevmapper.h>
 #include <linux/fs.h>   // FIXME: present only for BLKGETSIZE64, maybe we can remove it?

--- a/pkg/devicemapper/devmapper_wrapper_deferred_remove.go
+++ b/pkg/devicemapper/devmapper_wrapper_deferred_remove.go
@@ -2,10 +2,7 @@
 
 package devicemapper
 
-/*
-#cgo LDFLAGS: -L. -ldevmapper
-#include <libdevmapper.h>
-*/
+// #include <libdevmapper.h>
 import "C"
 
 // LibraryDeferredRemovalSupport tells if the feature is enabled in the build

--- a/pkg/devicemapper/devmapper_wrapper_dynamic.go
+++ b/pkg/devicemapper/devmapper_wrapper_dynamic.go
@@ -1,0 +1,6 @@
+// +build linux,cgo,!static_build
+
+package devicemapper
+
+// #cgo pkg-config: devmapper
+import "C"

--- a/pkg/devicemapper/devmapper_wrapper_static.go
+++ b/pkg/devicemapper/devmapper_wrapper_static.go
@@ -1,0 +1,6 @@
+// +build linux,cgo,static_build
+
+package devicemapper
+
+// #cgo pkg-config: --static devmapper
+import "C"


### PR DESCRIPTION
Let's use latest lvm2 sources to compile the libdevmapper library.

Initial reason for compiling devmapper lib from sources was a need to
have the static version of the library at hand, in order to build
the static dockerd, but note that the same headers/solib are used
for dynamic build (dynbinary) as well.

The reason for this patch is to enable the deferral removal feature.
The supplied devmapper library (and headers) are too old, lacking the
needed functions, so the daemon is built with 'libdm_no_deferred_remove'
build tag (see the check in hack/make.sh). Because of this, even if the
kernel dm driver is perfectly able to support the feature, it can not
be used. For more details and background story, see https://github.com/moby/moby/issues/34298

Surely, one can't just change the version number. While at it:
 - improve the comments;
 - remove obsoleted URLs;
 - remove s390 and ppc configure updates that are no longer needed;
 - use pkg-config instead of hardcoding the flags (newer lib added
   some more dependencies).

PS the version chosen is the one that is supposed to be bundled in RHEL7u4