### PR TITLE
Implement filesystem quota for overlay2 over ext4 if it support

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -576,6 +576,25 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 		}
 	}
 
+	if hostConfig.StorageOpt != nil && daemon.GraphDriverName(runtime.GOOS) == "overlay2" {
+		_, exist := hostConfig.StorageOpt["size"]
+		if exist {
+			status := daemon.stores[runtime.GOOS].layerStore.DriverStatus()
+			if status[0][0] == "Backing Filesystem" && status[0][1] != "xfs" {
+				if hostConfig.Privileged {
+					warnings = append(warnings, fmt.Sprintf("filesystem quota for overlay2 over %s can't take affect with privileged container", status[0][1]))
+				} else {
+					for _, cap := range hostConfig.CapAdd {
+						if cap == "SYS_RESOURCE" {
+							warnings = append(warnings, fmt.Sprintf("filesystem quota for overlay2 over %s can't take affect with CAP_SYS_RESOURCE", status[0][1]))
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
 	return warnings, nil
 }
 

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -199,16 +199,11 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 
 	d.naiveDiff = graphdriver.NewNaiveDiffDriver(d, uidMaps, gidMaps)
 
-	if backingFs == "xfs" {
-		// Try to enable project quota support over xfs.
-		if d.quotaCtl, err = quota.NewControl(home); err == nil {
-			projectQuotaSupported = true
-		} else if opts.quota.Size > 0 {
-			return nil, fmt.Errorf("Storage option overlay2.size not supported. Filesystem does not support Project Quota: %v", err)
-		}
+	// Try to enable project quota.
+	if d.quotaCtl, err = quota.NewControl(home, backingFs); err == nil {
+		projectQuotaSupported = true
 	} else if opts.quota.Size > 0 {
-		// if xfs is not the backing fs then error out if the storage-opt overlay2.size is used.
-		return nil, fmt.Errorf("Storage Option overlay2.size only supported for backingFS XFS. Found %v", backingFs)
+		return nil, fmt.Errorf("Storage option overlay2.size not supported. Filesystem %s does not support Project Quota: %v", backingFs, err)
 	}
 
 	logrus.Debugf("backingFs=%s,  projectQuotaSupported=%v", backingFs, projectQuotaSupported)
@@ -324,7 +319,7 @@ func (d *Driver) Cleanup() error {
 // file system.
 func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts) error {
 	if opts != nil && len(opts.StorageOpt) != 0 && !projectQuotaSupported {
-		return fmt.Errorf("--storage-opt is supported only for overlay over xfs with 'pquota' mount option")
+		return fmt.Errorf("--storage-opt is not supported for overlay on your system, make sure your backingFs %s support quota or mounted with 'prjquota' option", backingFs)
 	}
 
 	if opts == nil {


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/29364

Signed-off-by: Lei Jitang <leijitang@huawei.com>

/cc @dmcgowan  @amir73il 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This pr adds support for --storage-opt size=xx to overlay2 over
ext4 if kernel support and mount with `-o prjquota` option.
**- How I did it**

**- How to verify it**

First we need enable the quota during mkfs with
```
mkfs.ext4 -O quota,project /dev/mapper/vg--docker-ext4
```
or you can update the old filsystem with
```
tune2fs -O quota,project /dev/mapper/vg--docker-ext4
```

Then mount the disk with `-o prjquota`
```
/dev/mapper/vg--docker-ext4 on /mnt type ext4 (rw,relatime,seclabel,prjquota,data=ordered)
```

Then start the docker and use `-g` to specify the root to `/mnt`.

Run a container and check whether the quota works.
```
$ docker run -ti --storage-opt size=10M busybox
/ # df -h
Filesystem                Size      Used Available Use% Mounted on
overlay                  10.0M     24.0K     10.0M   0% /
tmpfs                     7.8G         0      7.8G   0% /dev
tmpfs                     7.8G         0      7.8G   0% /sys/fs/cgroup
/dev/mapper/vg--docker-ext4
                         29.4G     82.4M     27.8G   0% /etc/resolv.conf
/dev/mapper/vg--docker-ext4
                         29.4G     82.4M     27.8G   0% /etc/hostname
/dev/mapper/vg--docker-ext4
                         29.4G     82.4M     27.8G   0% /etc/hosts
shm                      64.0M         0     64.0M   0% /dev/shm
tmpfs                     7.8G         0      7.8G   0% /proc/kcore
tmpfs                     7.8G         0      7.8G   0% /proc/sched_debug
/ # dd if=/dev/zero of=/home/img bs=2M count=6 && sync
dm-3: write failed, project block limit reached.
dd: writing '/home/img': Disk quota exceeded
6+0 records in
4+1 records out
10444800 bytes (10.0MB) copied, 0.022292 seconds, 446.8MB/s
/ # df -h
Filesystem                Size      Used Available Use% Mounted on
overlay                  10.0M     10.0M         0 100% /
tmpfs                     7.8G         0      7.8G   0% /dev
tmpfs                     7.8G         0      7.8G   0% /sys/fs/cgroup
/dev/mapper/vg--docker-ext4
                         29.4G     92.4M     27.8G   0% /etc/resolv.conf
/dev/mapper/vg--docker-ext4
                         29.4G     92.4M     27.8G   0% /etc/hostname
/dev/mapper/vg--docker-ext4
                         29.4G     92.4M     27.8G   0% /etc/hosts
shm                      64.0M         0     64.0M   0% /dev/shm
tmpfs                     7.8G         0      7.8G   0% /proc/kcore
tmpfs                     7.8G         0      7.8G   0% /proc/sched_debug

```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

