### PR TITLE
logrus use full timestamp

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -96,6 +96,7 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	logrus.SetFormatter(&logrus.TextFormatter{
 		TimestampFormat: jsonlog.RFC3339NanoFixed,
 		DisableColors:   cli.Config.RawLogs,
+		FullTimestamp:   true,
 	})
 
 	if err := setDefaultUmask(); err != nil {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@dmcgowan Puts logrus back to the full timestamp after moving to logrus 1.x

Before this change (on Windows)
```
DEBU[42985] opengcs: StartUtilityVM: uvm created, starting...
DEBU[42985] HCSShim::Container::Start id=cbc13747439811c14bd1615e15cc096f930e8ff12b9a45e431e364bad96a644b_svm
DEBU[42985] HCSShim::Container::Start succeeded id=cbc13747439811c14bd1615e15cc096f930e8ff12b9a45e431e364bad96a644b_svm
DEBU[42985] opengcs StartUtilityVM: uvm cbc13747439811c14bd1615e15cc096f930e8ff12b9a45e431e364bad96a644b_svm is running
DEBU[42985] lcowdriver: startservicevmifnotrunning cbc13747439811c14bd1615e15cc096f930e8ff12b9a45e431e364bad96a644b: locking serviceVmsMutex for insertion
DEBU[42985] lcowdriver: startservicevmifnotrunning cbc13747439811c14bd1615e15cc096f930e8ff12b9a45e431e364bad96a644b: releasing serviceVmsMutex after insertion
DEBU[42985] lcowdriver: startservicevmifnotrunning cbc13747439811c14bd1615e15cc096f930e8ff12b9a45e431e364bad96a644b: locking cachedScratchMutex
DEBU[42985] lcowdriver: startservicevmifnotrunning cbc13747439811c14bd1615e15cc096f930e8ff12b9a45e431e364bad96a644b: (applydiff cbc13747439811c14bd1615e15cc096f930e8ff12b9a45e431e364bad96a644b): releasing cachedScratchMutex
DEBU[42985] lcowdriver: startServiceVmIfNotRunning: (applydiff cbc13747439811c14bd1615e15cc096f930e8ff12b9a45e431e364bad96a644b) success
```

After this change
```
DEBU[2017-08-02T10:28:49.718217600-07:00] Listener created for HTTP on npipe (//./pipe/docker_engine)
WARN[2017-08-02T10:28:49.720220600-07:00] LCOW support is enabled - this feature is incomplete
INFO[2017-08-02T10:28:49.724223400-07:00] Windows default isolation mode: process
DEBU[2017-08-02T10:28:49.725218800-07:00] Using default logging driver json-file
DEBU[2017-08-02T10:28:49.725218800-07:00] Stackdump - waiting signal at Global\docker-daemon-6856
DEBU[2017-08-02T10:28:49.725218800-07:00] [graphdriver] trying provided driver: windowsfilter
DEBU[2017-08-02T10:28:49.726212600-07:00] WindowsGraphDriver InitFilter at C:\lcow\windowsfilter
DEBU[2017-08-02T10:28:49.726212600-07:00] Using graph driver windowsfilter
DEBU[2017-08-02T10:28:49.727215600-07:00] [graphdriver] trying provided driver: lcow
INFO[2017-08-02T10:28:49.727215600-07:00] lcowdriver: init: dataRoot: C:\lcow\lcow globalMode: false
DEBU[2017-08-02T10:28:49.727215600-07:00] Using graph driver lcow
```

