### PR TITLE
Ignore exist/not-exist errors on plugin remove

### DIFF
--- a/plugin/backend_linux_test.go
+++ b/plugin/backend_linux_test.go
@@ -1,0 +1,81 @@
+package plugin
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAtomicRemoveAllNormal(t *testing.T) {
+	dir, err := ioutil.TempDir("", "atomic-remove-with-normal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir) // just try to make sure this gets cleaned up
+
+	if err := atomicRemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("dir should be gone: %v", err)
+	}
+	if _, err := os.Stat(dir + "-removing"); !os.IsNotExist(err) {
+		t.Fatalf("dir should be gone: %v", err)
+	}
+}
+
+func TestAtomicRemoveAllAlreadyExists(t *testing.T) {
+	dir, err := ioutil.TempDir("", "atomic-remove-already-exists")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir) // just try to make sure this gets cleaned up
+
+	if err := os.MkdirAll(dir+"-removing", 0755); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir + "-removing")
+
+	if err := atomicRemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("dir should be gone: %v", err)
+	}
+	if _, err := os.Stat(dir + "-removing"); !os.IsNotExist(err) {
+		t.Fatalf("dir should be gone: %v", err)
+	}
+}
+
+func TestAtomicRemoveAllNotExist(t *testing.T) {
+	if err := atomicRemoveAll("/not-exist"); err != nil {
+		t.Fatal(err)
+	}
+
+	dir, err := ioutil.TempDir("", "atomic-remove-already-exists")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir) // just try to make sure this gets cleaned up
+
+	// create the removing dir, but not the "real" one
+	foo := filepath.Join(dir, "foo")
+	removing := dir + "-removing"
+	if err := os.MkdirAll(removing, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := atomicRemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(foo); !os.IsNotExist(err) {
+		t.Fatalf("dir should be gone: %v", err)
+	}
+	if _, err := os.Stat(removing); !os.IsNotExist(err) {
+		t.Fatalf("dir should be gone: %v", err)
+	}
+}


### PR DESCRIPTION
During a plugin remove, docker performs an `os.Rename` to move the
plugin data dir to a new location before removing to acheive an atomic
removal.

`os.Rename` can return either a `NotExist` error if the source path
doesn't exist, or an `Exist` error if the target path already exists.
Both these cases can happen when there is an error on the final
`os.Remove` call, which is common on older kernels (`device or resource
busy`).

When calling rename, we can safely ignore these error types and proceed
to try and remove the plugin.

ping @rogaha @andrewhsu 