### PR TITLE
fix client.Transport verify

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -165,7 +165,7 @@ func NewClient(host string, version string, client *http.Client, httpHeaders map
 	}
 
 	if client != nil {
-		if _, ok := client.Transport.(*http.Transport); !ok {
+		if _, ok := client.Transport.(http.RoundTripper); !ok {
 			return nil, fmt.Errorf("unable to verify TLS configuration, invalid transport %v", client.Transport)
 		}
 	} else {


### PR DESCRIPTION
`client.Transport` is `http.Client.Transport` just has `RoundTripper()`. Not `http.Transport`. So we cannot convert it here.
 
For a mock test, I can play with this https://play.golang.org/p/gs7_QrL9-Y

**- What I did**
mock a docker client

**- How I did it**
pass a client to `client.NewClient()` with `doer()`

**- How to verify it**
Copy the code from https://play.golang.org/p/gs7_QrL9-Y and run it with docker imported.

![31325_large](https://user-images.githubusercontent.com/7827389/28914431-3735f87a-786e-11e7-9bec-e55a994d1141.png)
