### PR TITLE
pkg/term: set termios VMIN and VTIME in MakeRaw on Linux

### DIFF
--- a/pkg/term/termios_linux.go
+++ b/pkg/term/termios_linux.go
@@ -29,6 +29,8 @@ func MakeRaw(fd uintptr) (*State, error) {
 	termios.Lflag &^= (unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)
 	termios.Cflag &^= (unix.CSIZE | unix.PARENB)
 	termios.Cflag |= unix.CS8
+	termios.Cc[unix.VMIN] = 1
+	termios.Cc[unix.VTIME] = 0
 
 	if err := unix.IoctlSetTermios(int(fd), setTermios, termios); err != nil {
 		return nil, err


### PR DESCRIPTION
The BSD and Solaris versions of term.MakeRaw already set VMIN and VTIME
explicitly such that a read returns when one character is available.
cfmakeraw (which was previously used) in glibc also sets these values
explicitly, so it should be done in the Linux version of MakeRaw as well
to be consistent.