### PR TITLE
Fix api server null pointer def on inspect/ls null ipam-driver networks

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -409,7 +409,9 @@ func buildIpamResources(r *types.NetworkResource, nwInfo libnetwork.NetworkInfo)
 		for _, ip4Info := range ipv4Info {
 			iData := network.IPAMConfig{}
 			iData.Subnet = ip4Info.IPAMData.Pool.String()
-			iData.Gateway = ip4Info.IPAMData.Gateway.IP.String()
+			if ip4Info.IPAMData.Gateway != nil {
+				iData.Gateway = ip4Info.IPAMData.Gateway.IP.String()
+			}
 			r.IPAM.Config = append(r.IPAM.Config, iData)
 		}
 	}

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -690,6 +690,21 @@ func (s *DockerNetworkSuite) TestDockerNetworkIPAMOptions(c *check.C) {
 	c.Assert(opts["opt2"], checker.Equals, "drv2")
 }
 
+func (s *DockerNetworkSuite) TestDockerNetworkNullIPAMDriver(c *check.C) {
+	// Create a network with null ipam driver
+	_, _, err := dockerCmdWithError("network", "create", "-d", dummyNetworkDriver, "--ipam-driver", "null", "test000")
+	c.Assert(err, check.IsNil)
+	assertNwIsAvailable(c, "test000")
+
+	// Verify the inspect data contains the default subnet provided by the null
+	// ipam driver and no gateway, as the null ipam driver does not provide one
+	nr := getNetworkResource(c, "test000")
+	c.Assert(nr.IPAM.Driver, checker.Equals, "null")
+	c.Assert(len(nr.IPAM.Config), checker.Equals, 1)
+	c.Assert(nr.IPAM.Config[0].Subnet, checker.Equals, "0.0.0.0/0")
+	c.Assert(nr.IPAM.Config[0].Gateway, checker.Equals, "")
+}
+
 func (s *DockerNetworkSuite) TestDockerNetworkInspectDefault(c *check.C) {
 	nr := getNetworkResource(c, "none")
 	c.Assert(nr.Driver, checker.Equals, "null")


### PR DESCRIPTION
- When a network is created with the null ipam driver, docker api server
  thread will deference a nil pointer on `docker network ls` and on
  `docker network inspect <nw>`. This because buildIpamResource()
  assumes a gateway address is always present, which is not correct.

```
# docker version | grep 'ersion\|commit'
 Version:      17.06.0-ce
 API version:  1.30
 Go version:   go1.8.3
 Git commit:   02c1d87
 Version:      17.06.0-ce
 API version:  1.30 (minimum version 1.12)
 Go version:   go1.8.3
 Git commit:   02c1d87
#
# docker network create -d mynw-driver --ipam-driver null nw3
112f14f0955e1aa51722b3962f794ba91439357d3f21c1972ff411309a5c0c14
#
# docker network ls
error during connect: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.30/networks: EOF
# docker network inspect nw3
[]
error during connect: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.30/networks/nw3: EOF
#
```

From daemon logs:

```
Aug 03 22:22:59 localhost.localdomain dockerd[5338]: http: panic serving @: runtime error: invalid memory address or nil pointer dereference
 goroutine 299 [running]:
 net/http.(*conn).serve.func1(0xc4203f6140)
         /usr/local/go/src/net/http/server.go:1721 +0xd0
 panic(0x17a1fa0, 0x25eb1d0)
         /usr/local/go/src/runtime/panic.go:489 +0x2cf
 github.com/docker/docker/api/server/router/network.buildIpamResources(0xc4208ff3b0, 0x2634880, 0xc420a2f860)
         /root/rpmbuild/BUILD/src/engine/.gopath/src/github.com/docker/docker/api/server/router/network/network_routes.go:392 +0x44a
 github.com/docker/docker/api/server/router/network.(*networkRouter).buildNetworkResource(0xc4207c6570, 0x2632d80, 0xc420a2f860, 0xc400000036)
         /root/rpmbuild/BUILD/src/engine/.gopath/src/github.com/docker/docker/api/server/router/network/network_routes.go:293 +0x2d7
 github.com/docker/docker/api/server/router/network.(*networkRouter).buildDetailedNetworkResources(0xc4207c6570, 0x2632d80, 0xc420a2f860, 0x0, 0xc420d37001)
         /root/rpmbuild/BUILD/src/engine/.gopath/src/github.com/docker/docker/api/server/router/network/network_routes.go:314 +0x66
 github.com/docker/docker/api/server/router/network.(*networkRouter).getNetwork(0xc4207c6570, 0x7f6243e43128, 0xc420d36f30, 0x2627cc0, 0xc4200f5a40, 0xc42000bd00, 0xc420d36e70, 0x19fae7a, 0x5)
         /root/rpmbuild/BUILD/src/engine/.gopath/src/github.com/docker/docker/api/server/router/network/network_routes.go:121 +0xf9d
 github.com/docker/docker/api/server/router/network.(*networkRouter).(github.com/docker/docker/api/server/router/network.getNetwork)-fm(0x7f6243e43128, 0xc420d36f30, 0x2627cc0, 0xc4200f5a40, 0xc42000bd00, 0xc420d36e70, 0x7f6243e43128, 0xc420d36f30)
         /root/rpmbuild/BUILD/src/engine/.gopath/src/github.com/docker/docker/api/server/router/network/network.go:35 +0x69
 github.com/docker/docker/api/server/middleware.ExperimentalMiddleware.WrapHandler.func1(0x7f6243e43128, 0xc420d36f30, 0x2627cc0, 0xc4200f5a40, 0xc42000bd00, 0xc420d36e70, 0x7f6243e43128, 0xc420d36f30)
         /root/rpmbuild/BUILD/src/engine/.gopath/src/github.com/docker/docker/api/server/middleware/experimental.go:27 +0xd8
 github.com/docker/docker/api/server/middleware.VersionMiddleware.WrapHandler.func1(0x7f6243e43128, 0xc420d36f00, 0x2627cc0, 0xc4200f5a40, 0xc42000bd00, 0xc420d36e70, 0xc4208cd400, 0xc42022fa00)
         /root/rpmbuild/BUILD/src/engine/.gopath/src/github.com/docker/docker/api/server/middleware/version.go:48 +0x55d
 github.com/docker/docker/pkg/authorization.(*Middleware).WrapHandler.func1(0x7f6243e43128, 0xc420d36f00, 0x2627cc0, 0xc4200f5a40, 0xc42000bd00, 0xc420d36e70, 0x7f6243e43128, 0xc420d36f00)
         /root/rpmbuild/BUILD/src/engine/.gopath/src/github.com/docker/docker/pkg/authorization/middleware.go:54 +0x871
 github.com/docker/docker/api/server.(*Server).makeHTTPHandler.func1(0x2627cc0, 0xc4200f5a40, 0xc42000bd00)
         /root/rpmbuild/BUILD/src/engine/.gopath/src/github.com/docker/docker/api/server/server.go:139 +0x21a
 net/http.HandlerFunc.ServeHTTP(0xc420bfd200, 0x2627cc0, 0xc4200f5a40, 0xc42000bd00)
         /usr/local/go/src/net/http/server.go:1942 +0x44
 github.com/docker/docker/vendor/github.com/gorilla/mux.(*Router).ServeHTTP(0xc42095de00, 0x2627cc0, 0xc4200f5a40, 0xc42000bd00)
         /root/rpmbuild/BUILD/src/engine/.gopath/src/github.com/docker/docker/vendor/github.com/gorilla/mux/mux.go:103 +0x255
 github.com/docker/docker/api/server.(*routerSwapper).ServeHTTP(0xc420c2f920, 0x2627cc0, 0xc4200f5a40, 0xc42000bd00)
         /root/rpmbuild/BUILD/src/engine/.gopath/src/github.com/docker/docker/api/server/router_swapper.go:29 +0x70
 net/http.serverHandler.ServeHTTP(0xc4204222c0, 0x2627cc0, 0xc4200f5a40, 0xc42000bd00)
         /usr/local/go/src/net/http/server.go:2568 +0x92
 net/http.(*conn).serve(0xc4203f6140, 0x2629840, 0xc4208cd200)
         /usr/local/go/src/net/http/server.go:1825 +0x612
 created by net/http.(*Server).Serve
         /usr/local/go/src/net/http/server.go:2668 +0x2ce
```

**- A picture of a cute animal (not mandatory but encouraged)**

![volpi](https://user-images.githubusercontent.com/10080882/28942442-385a994a-7850-11e7-9f72-a791acb7f6ea.jpg)
