### PR TITLE
LCOW: Fixed lcow scratch location

### DIFF
--- a/daemon/graphdriver/lcow/lcow.go
+++ b/daemon/graphdriver/lcow/lcow.go
@@ -61,7 +61,7 @@ const (
 	// toolsScratchPath is a location in a service utility VM that the tools can use as a
 	// scratch space to avoid running out of memory.
 	// TODO @jhowardmsft. I really dislike this path! But needs a platform change or passing parameters to the tools.
-	toolsScratchPath = "/mnt/gcs/LinuxServiceVM/scratch"
+	toolsScratchPath = "/tmp/gcs/LinuxServiceVM/scratch"
 
 	// svmGlobalID is the ID used in the serviceVMs map for the global service VM when running in "global" mode.
 	svmGlobalID = "_lcow_global_svm_"


### PR DESCRIPTION
Signed-off-by: Akash Gupta <akagup@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed the location for the scratch VHDX in the lcow driver. In the current master, pulling the nodejs image fails, because the scratch was not attached to the right place, so it was writing to ramdisk.

**- How I did it**

Change `/mnt/...` -> `/tmp/...`

**- How to verify it**

`docker run node`  fails on the master branch but succeeds with this PR

**- Description for the changelog**

Fixed the location for the scratch VHDX in the lcow driver to support large images.

**- A picture of a cute animal (not mandatory but encouraged)**

