### PR TITLE
LCOW: Builder platform API

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/docker/docker/pkg/system"
 	units "github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -78,6 +79,24 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 
 	if runtime.GOOS != "windows" && options.SecurityOpt != nil {
 		return nil, fmt.Errorf("The daemon on this platform does not support setting security options on build")
+	}
+
+	if versions.GreaterThanOrEqualTo(version, "1.32") {
+		options.Platform = strings.ToLower(r.FormValue("platform"))
+		platformValid := false
+		platforms := []string{"", runtime.GOOS}
+		if system.LCOWSupported() {
+			platforms = append(platforms, "linux")
+		}
+		for _, p := range platforms {
+			if options.Platform == p {
+				platformValid = true
+				break
+			}
+		}
+		if !platformValid {
+			return nil, fmt.Errorf("unsupported platform %q", options.Platform)
+		}
 	}
 
 	var buildUlimits = []*units.Ulimit{}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4964,6 +4964,11 @@ paths:
 
             Only the registry domain name (and port if not the default 443) are required. However, for legacy reasons, the Docker Hub registry must be specified with both a `https://` prefix and a `/v1/` suffix even though Docker will prefer to use the v2 registry API.
           type: "string"
+        - name: "platform"
+          in: "query"
+          description: "Target platform if daemon supports multiple platforms."
+          type: "string"
+          default: ""
       responses:
         200:
           description: "no error"

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -179,10 +179,7 @@ type ImageBuildOptions struct {
 	ExtraHosts  []string // List of extra hosts
 	Target      string
 	SessionID   string
-
-	// TODO @jhowardmsft LCOW Support: This will require extending to include
-	// `Platform string`, but is ommited for now as it's hard-coded temporarily
-	// to avoid API changes.
+	Platform    string
 }
 
 // ImageBuildResponse holds information

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -94,6 +94,7 @@ type Image interface {
 	ImageID() string
 	RunConfig() *container.Config
 	MarshalJSON() ([]byte, error)
+	Platform() string
 }
 
 // ReleaseableLayer is an image layer that can be mounted and released

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -202,11 +202,7 @@ func TestFromScratch(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, req.state.hasFromImage())
 	assert.Equal(t, "", req.state.imageID)
-	// Windows does not set the default path. TODO @jhowardmsft LCOW support. This will need revisiting as we get further into the implementation
 	expected := "PATH=" + system.DefaultPathEnv(runtime.GOOS)
-	if runtime.GOOS == "windows" {
-		expected = ""
-	}
 	assert.Equal(t, []string{expected}, req.state.runConfig.Env)
 }
 

--- a/builder/dockerfile/imagecontext.go
+++ b/builder/dockerfile/imagecontext.go
@@ -97,8 +97,6 @@ type imageSources struct {
 	cache     pathCache // TODO: remove
 }
 
-// TODO @jhowardmsft LCOW Support: Eventually, platform can be moved to options.Options.Platform,
-// and removed from builderOptions, but that can't be done yet as it would affect the API.
 func newImageSources(ctx context.Context, options builderOptions) *imageSources {
 	getAndMount := func(idOrRef string, localOnly bool) (builder.Image, builder.ReleaseableLayer, error) {
 		pullOption := backend.PullOptionNoPull
@@ -113,7 +111,7 @@ func newImageSources(ctx context.Context, options builderOptions) *imageSources 
 			PullOption: pullOption,
 			AuthConfig: options.Options.AuthConfigs,
 			Output:     options.ProgressWriter.Output,
-			Platform:   options.Platform,
+			Platform:   options.Options.Platform,
 		})
 	}
 

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -25,7 +25,7 @@ func (b *Builder) commit(dispatchState *dispatchState, comment string) error {
 		return errors.New("Please provide a source image with `from` prior to commit")
 	}
 
-	runConfigWithCommentCmd := copyRunConfig(dispatchState.runConfig, withCmdComment(comment, b.platform))
+	runConfigWithCommentCmd := copyRunConfig(dispatchState.runConfig, withCmdComment(comment, b.options.Platform))
 	hit, err := b.probeCache(dispatchState, runConfigWithCommentCmd)
 	if err != nil || hit {
 		return err
@@ -65,7 +65,7 @@ func (b *Builder) commitContainer(dispatchState *dispatchState, id string, conta
 }
 
 func (b *Builder) exportImage(state *dispatchState, imageMount *imageMount, runConfig *container.Config) error {
-	newLayer, err := imageMount.Layer().Commit(b.platform)
+	newLayer, err := imageMount.Layer().Commit(b.options.Platform)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func (b *Builder) performCopy(state *dispatchState, inst copyInstruction) error 
 	// TODO: should this have been using origPaths instead of srcHash in the comment?
 	runConfigWithCommentCmd := copyRunConfig(
 		state.runConfig,
-		withCmdCommentString(fmt.Sprintf("%s %s in %s ", inst.cmdName, srcHash, inst.dest), b.platform))
+		withCmdCommentString(fmt.Sprintf("%s %s in %s ", inst.cmdName, srcHash, inst.dest), b.options.Platform))
 	hit, err := b.probeCache(state, runConfigWithCommentCmd)
 	if err != nil || hit {
 		return err
@@ -256,13 +256,13 @@ func (b *Builder) probeAndCreate(dispatchState *dispatchState, runConfig *contai
 	}
 	// Set a log config to override any default value set on the daemon
 	hostConfig := &container.HostConfig{LogConfig: defaultLogConfig}
-	container, err := b.containerManager.Create(runConfig, hostConfig, b.platform)
+	container, err := b.containerManager.Create(runConfig, hostConfig, b.options.Platform)
 	return container.ID, err
 }
 
 func (b *Builder) create(runConfig *container.Config) (string, error) {
 	hostConfig := hostConfigFromOptions(b.options)
-	container, err := b.containerManager.Create(runConfig, hostConfig, b.platform)
+	container, err := b.containerManager.Create(runConfig, hostConfig, b.options.Platform)
 	if err != nil {
 		return "", err
 	}

--- a/builder/dockerfile/mockbackend_test.go
+++ b/builder/dockerfile/mockbackend_test.go
@@ -3,6 +3,7 @@ package dockerfile
 import (
 	"encoding/json"
 	"io"
+	"runtime"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
@@ -93,6 +94,10 @@ func (i *mockImage) ImageID() string {
 
 func (i *mockImage) RunConfig() *container.Config {
 	return i.config
+}
+
+func (i *mockImage) Platform() string {
+	return runtime.GOOS
 }
 
 func (i *mockImage) MarshalJSON() ([]byte, error) {

--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -91,9 +91,6 @@ var (
 // DefaultEscapeToken is the default escape token
 const DefaultEscapeToken = '\\'
 
-// defaultPlatformToken is the platform assumed for the build if not explicitly provided
-var defaultPlatformToken = runtime.GOOS
-
 // Directive is the structure used during a build run to hold the state of
 // parsing directives.
 type Directive struct {
@@ -152,8 +149,7 @@ func (d *Directive) possibleParserDirective(line string) error {
 		}
 	}
 
-	// TODO @jhowardmsft LCOW Support: Eventually this check can be removed,
-	// but only recognise a platform token if running in LCOW mode.
+	// Only recognise a platform token if LCOW is supported
 	if system.LCOWSupported() {
 		tpcMatch := tokenPlatformCommand.FindStringSubmatch(strings.ToLower(line))
 		if len(tpcMatch) != 0 {
@@ -177,7 +173,6 @@ func (d *Directive) possibleParserDirective(line string) error {
 func NewDefaultDirective() *Directive {
 	directive := Directive{}
 	directive.setEscapeToken(string(DefaultEscapeToken))
-	directive.setPlatformToken(defaultPlatformToken)
 	return &directive
 }
 

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -124,5 +124,12 @@ func (cli *Client) imageBuildOptionsToQuery(options types.ImageBuildOptions) (ur
 		query.Set("session", options.SessionID)
 	}
 
+	if options.Platform != "" {
+		if err := cli.NewVersionError("1.32", "platform"); err != nil {
+			return query, err
+		}
+		query.Set("platform", options.Platform)
+	}
+
 	return query, nil
 }

--- a/pkg/system/path.go
+++ b/pkg/system/path.go
@@ -9,7 +9,7 @@ const defaultUnixPathEnv = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/s
 // ':' character .
 func DefaultPathEnv(platform string) string {
 	if runtime.GOOS == "windows" {
-		if platform != runtime.GOOS && LCOWSupported() {
+		if platform != runtime.GOOS {
 			return defaultUnixPathEnv
 		}
 		// Deliberately empty on Windows containers on Windows as the default path will be set by


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This removes all the `// TODO @jhowardmsft LCOW Support:....` from the builder. It adds `platform` to the build API as per the epic at https://github.com/moby/moby/issues/33850. Will open the client API to match this shortly.

```PowerShell
PS E:\docker\build\lcow> docker build --no-cache -f test3 --platform=linux .
Sending build context to Docker daemon   5.12kB
Step 1/3 : FROM busybox
 ---> efe10ee6727f
Step 2/3 : RUN mkdir /foo
 ---> Running in b77c17688016
 ---> 27efb69d2070
Removing intermediate container b77c17688016
Step 3/3 : RUN ls -l /
 ---> Running in e1e791738de1
total 40
drwxr-xr-x    2 root     root         12288 Jul 19 20:56 bin
drwxr-xr-x    4 root     root           320 Aug  4 00:55 dev
drwxr-xr-x    1 root     root          4096 Jul 19 20:56 etc
drwxr-xr-x    2 root     root          4096 Aug  4 00:55 foo
drwxr-xr-x    2 nobody   nogroup       4096 Jul 19 20:56 home
dr-xr-xr-x  105 root     root             0 Aug  4 00:55 proc
drwxr-xr-x    2 root     root          4096 Jul 19 20:56 root
dr-xr-xr-x   12 root     root             0 Aug  4 00:55 sys
drwxrwxrwt    2 root     root          4096 Jul 19 20:56 tmp
drwxr-xr-x    3 root     root          4096 Jul 19 20:56 usr
drwxr-xr-x    4 root     root          4096 Jul 19 20:56 var
 ---> 2fc0de70c186
Removing intermediate container e1e791738de1
Successfully built 2fc0de70c186
PS E:\docker\build\lcow>
```
