### PR TITLE
Initial omslogs logging driver

### DIFF
--- a/daemon/logdrivers_linux.go
+++ b/daemon/logdrivers_linux.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/docker/docker/daemon/logger/journald"
 	_ "github.com/docker/docker/daemon/logger/jsonfilelog"
 	_ "github.com/docker/docker/daemon/logger/logentries"
+	_ "github.com/docker/docker/daemon/logger/omslogs"
 	_ "github.com/docker/docker/daemon/logger/splunk"
 	_ "github.com/docker/docker/daemon/logger/syslog"
 )

--- a/daemon/logdrivers_windows.go
+++ b/daemon/logdrivers_windows.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/docker/docker/daemon/logger/fluentd"
 	_ "github.com/docker/docker/daemon/logger/jsonfilelog"
 	_ "github.com/docker/docker/daemon/logger/logentries"
+	_ "github.com/docker/docker/daemon/logger/omslogs"
 	_ "github.com/docker/docker/daemon/logger/splunk"
 	_ "github.com/docker/docker/daemon/logger/syslog"
 )

--- a/daemon/logger/omslogs/omsclient/omsclient.go
+++ b/daemon/logger/omslogs/omsclient/omsclient.go
@@ -1,0 +1,105 @@
+// Package omsclient adapted from https://github.com/Azure/oms-log-analytics-firehose-nozzle
+package omsclient
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+//OmsLogClient interface
+type OmsLogClient interface {
+	PostData(*[]byte, string) error
+}
+
+// OmsLogClient posts messages to OMS
+type omslogclient struct {
+	customerID      string
+	sharedKey       string
+	url             string
+	httpPostTimeout time.Duration
+	client          *http.Client
+}
+
+const (
+	method      = "POST"
+	contentType = "application/json"
+	resource    = "/api/logs"
+)
+
+func init() {
+	http.DefaultClient.Timeout = time.Second * 30
+}
+
+// NewOmsLogClient creates a new instance of OmsLogClient
+func NewOmsLogClient(domain string, customerID string, sharedKey string, postTimeout time.Duration) OmsLogClient {
+	if domain == "" {
+		domain = "ods.opinsights.azure.com"
+	}
+
+	return &omslogclient{
+		customerID:      customerID,
+		sharedKey:       sharedKey,
+		url:             "https://" + customerID + "." + domain + resource + "?api-version=2016-04-01",
+		httpPostTimeout: postTimeout,
+		client:          &http.Client{Timeout: postTimeout},
+	}
+}
+
+// PostData posts message to OMS
+func (c *omslogclient) PostData(msg *[]byte, logType string) error {
+	// Headers
+	contentLength := len(*msg)
+	rfc1123date := time.Now().UTC().Format(time.RFC1123)
+	// rfc1123 date should have UTC offset
+	rfc1123date = strings.Replace(rfc1123date, "UTC", "GMT", 1)
+
+	// Signature
+	signature, err := c.buildSignature(rfc1123date, contentLength, method, contentType, resource)
+	if err != nil {
+		return err
+	}
+
+	// Create request
+	req, err := http.NewRequest("POST", c.url, bytes.NewBuffer(*msg))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", signature)
+	req.Header.Set("Log-Type", logType)
+	// Headers should be case insentitive
+	req.Header["x-ms-date"] = []string{rfc1123date}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 || resp.StatusCode < 200 {
+		return fmt.Errorf("Post Error. HTTP response code:%d message:%s", resp.StatusCode, resp.Status)
+	}
+	return nil
+}
+
+func (c *omslogclient) buildSignature(date string, contentLength int, method string, contentType string, resource string) (string, error) {
+	xHeaders := "x-ms-date:" + date
+	stringToHash := method + "\n" + strconv.Itoa(contentLength) + "\n" + contentType + "\n" + xHeaders + "\n" + resource
+	bytesToHash := []byte(stringToHash)
+	keyBytes, err := base64.StdEncoding.DecodeString(c.sharedKey)
+	if err != nil {
+		return "", err
+	}
+	hasher := hmac.New(sha256.New, keyBytes)
+	hasher.Write(bytesToHash)
+	encodedHash := base64.StdEncoding.EncodeToString(hasher.Sum(nil))
+	authorization := fmt.Sprintf("SharedKey %s:%s", c.customerID, encodedHash)
+	return authorization, err
+}

--- a/daemon/logger/omslogs/omsclient/omsclient_test.go
+++ b/daemon/logger/omslogs/omsclient/omsclient_test.go
@@ -1,0 +1,190 @@
+package omsclient
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	idStr       = "customerID string"
+	keyStr      = "sharedKey string"
+	postTimeout = 30 * time.Second
+)
+
+//date string, contentLength int, method string, contentType string, resource string
+func TestNewOmsClient(t *testing.T) {
+	client := NewOmsLogClient("", idStr, keyStr, postTimeout)
+
+	omsclient, ok := client.(*omslogclient)
+	if !ok {
+		t.Fatal("Expected omsclient pointer type")
+	}
+	if omsclient == nil {
+		t.Fatal("Did not Create a new Client")
+	}
+
+	if omsclient.url != "https://"+idStr+".ods.opinsights.azure.com/api/logs?api-version=2016-04-01" {
+		t.Fatal("Default URL domain not correct")
+	}
+}
+
+func TestNewOmsClientCustomDomain(t *testing.T) {
+	client := NewOmsLogClient("ods.opinsights.azure.us", idStr, keyStr, postTimeout)
+
+	omsclient, ok := client.(*omslogclient)
+	if !ok {
+		t.Fatal("Expected omsclient pointer type")
+	}
+	if omsclient == nil {
+		t.Fatal("Did not Create a new Client")
+	}
+
+	if omsclient.url != "https://"+idStr+".ods.opinsights.azure.us/api/logs?api-version=2016-04-01" {
+		t.Fatal("Custom URL domain not correct")
+	}
+}
+
+// mock transport - taken from Docker client mock
+type transportFunc func(*http.Request) (*http.Response, error)
+
+func (tf transportFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return tf(req)
+}
+
+// mock http client - take from Docker client mock
+func newMockClient(doer func(*http.Request) (*http.Response, error)) *http.Client {
+	return &http.Client{
+		Transport: transportFunc(doer),
+	}
+}
+
+// mock response body
+type mockBody struct {
+	body []byte
+}
+
+func newMockBody(body []byte) *mockBody {
+	return &mockBody{body}
+}
+
+func (b *mockBody) Read(p []byte) (n int, err error) {
+	return len(b.body), nil
+}
+
+func (b *mockBody) Close() error {
+	return nil
+}
+
+// taken from Docker client mock.
+func plainTextErrorMock(statusCode int, message string) func(req *http.Request) (*http.Response, error) {
+	return func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: statusCode,
+			Body:       newMockBody([]byte(message)),
+		}, nil
+	}
+}
+
+func doerErrorMock(text string) func(req *http.Request) (*http.Response, error) {
+	return func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New(text)
+	}
+}
+
+func TestPostDataSuccess(t *testing.T) {
+
+	omsclient := &omslogclient{
+		customerID:      idStr,
+		sharedKey:       base64.StdEncoding.EncodeToString([]byte(keyStr)),
+		url:             "Big Fancy URL string",
+		httpPostTimeout: postTimeout,
+		client:          newMockClient(plainTextErrorMock(http.StatusOK, "This is a response string")),
+	}
+
+	line := []byte("This is a log line")
+	logType := "warning"
+
+	if err := omsclient.PostData(&line, logType); err != nil {
+		t.Fatal("Received an error from PostData")
+	}
+}
+
+func TestPostDatasignatureFailure(t *testing.T) {
+	omsclient := &omslogclient{
+		customerID:      idStr,
+		sharedKey:       keyStr, // invalid base64 key
+		url:             "Big Fancy URL string",
+		httpPostTimeout: postTimeout,
+		client:          newMockClient(plainTextErrorMock(http.StatusProcessing, "This is a response string")),
+	}
+
+	line := []byte("This is a log line")
+	logType := "warning"
+
+	if err := omsclient.PostData(&line, logType); err == nil {
+		t.Fatal("Did not receive an error from PostData")
+	}
+}
+
+func TestPostDataDoerError(t *testing.T) {
+	errText := "error text"
+	omsclient := &omslogclient{
+		customerID:      idStr,
+		sharedKey:       base64.StdEncoding.EncodeToString([]byte(keyStr)),
+		url:             "thisurl",
+		httpPostTimeout: postTimeout,
+		client:          newMockClient(doerErrorMock(errText)),
+	}
+
+	line := []byte("This is a log line")
+	logType := "warning"
+
+	if err := omsclient.PostData(&line, logType); err == nil {
+		t.Fatal("Did not receive an error from PostData")
+	} else {
+		netError := err.Error()
+		if !strings.Contains(netError, errText) {
+			t.Fatal("Did not receive expected error (text)")
+		}
+		if !strings.Contains(netError, omsclient.url) {
+			t.Fatal("Did not receive expected error (url)")
+		}
+	}
+}
+func TestPostDataStatus1XXError(t *testing.T) {
+	omsclient := &omslogclient{
+		customerID:      idStr,
+		sharedKey:       base64.StdEncoding.EncodeToString([]byte(keyStr)),
+		url:             "Big Fancy URL string",
+		httpPostTimeout: postTimeout,
+		client:          newMockClient(plainTextErrorMock(http.StatusProcessing, "This is a response string")),
+	}
+
+	line := []byte("This is a log line")
+	logType := "warning"
+
+	if err := omsclient.PostData(&line, logType); err == nil {
+		t.Fatal("Did not receive an error from PostData")
+	}
+}
+
+func TestPostDataStatus3XXError(t *testing.T) {
+	omsclient := &omslogclient{
+		customerID:      idStr,
+		sharedKey:       base64.StdEncoding.EncodeToString([]byte(keyStr)),
+		url:             "Big Fancy URL string",
+		httpPostTimeout: postTimeout,
+		client:          newMockClient(plainTextErrorMock(http.StatusForbidden, "This is a response string")),
+	}
+
+	line := []byte("This is a log line")
+	logType := "warning"
+
+	if err := omsclient.PostData(&line, logType); err == nil {
+		t.Fatal("Did not receive an error from PostData")
+	}
+}

--- a/daemon/logger/omslogs/omslogs.go
+++ b/daemon/logger/omslogs/omslogs.go
@@ -1,0 +1,350 @@
+package omslogs
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/docker/docker/daemon/logger"
+	client "github.com/docker/docker/daemon/logger/omslogs/omsclient"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	name = "omslogs"
+
+	// Command line options
+	optDomain      = "omslogs-domain"
+	optWorkspaceID = "omslogs-workspaceID"
+	optSharedKey   = "omslogs-sharedKey"
+	optTimeout     = "omslogs-timeout"
+
+	// Environment variables
+	envDomain                = "OMS_LOGGING_DOMAIN"
+	envTimeout               = "OMS_LOGGING_DRIVER_TIMEOUT"
+	envPostMessagesFrequency = "OMS_LOGGING_DRIVER_POST_MESSAGES_FREQUENCY"
+	envPostMessagesBatchSize = "OMS_LOGGING_DRIVER_POST_MESSAGES_BATCH_SIZE"
+	envBufferSize            = "OMS_LOGGING_DRIVER_BUFFER_SIZE"
+	envStreamChannelSize     = "OMS_LOGGING_DRIVER_CHANNEL_SIZE"
+
+	// Default option values
+	defaultTimeout               = time.Duration(5 * time.Second)
+	defaultPostMessagesFrequency = time.Duration(5 * time.Second)
+	defaultPostMessagesBatchSize = 100
+	defaultBufferSize            = 10 * defaultPostMessagesBatchSize
+	defaultStreamChannelSize     = 4 * defaultPostMessagesBatchSize
+
+	// Errors
+	errOptRequired = "must specify a value for log opt '%s'"
+)
+
+type omsLogger struct {
+	// Initial container data
+	containerID   string
+	containerName string
+	imageID       string
+	imageName     string
+
+	// Client options
+	timeout               time.Duration
+	postMessagesFrequency time.Duration
+	postMessagesBatchSize int
+	bufferSize            int
+	streamChannelSize     int
+	client                client.OmsLogClient
+
+	// Synchronization
+	stream    chan *omsMessage
+	lock      sync.RWMutex
+	closed    bool
+	closedSig *sync.Cond
+}
+
+type omsMessage struct {
+	ContainerID    string `json:"containerId"`
+	ContainerName  string `json:"containerName"`
+	ImageID        string `json:"imageId"`
+	ImageName      string `json:"imageName"`
+	TimeGenerated  string `json:"timeGenerated"`
+	LogEntrySource string `json:"logEntrySource"`
+	LogEntry       string `json:"logEntry"`
+}
+
+func init() {
+	if err := logger.RegisterLogDriver(name, New); err != nil {
+		logrus.Fatal(err)
+	}
+
+	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+// ValidateLogOpt looks for workspaceID and sharedKey.
+func ValidateLogOpt(cfg map[string]string) error {
+	for key := range cfg {
+		switch key {
+		case optDomain:
+		case optWorkspaceID:
+		case optSharedKey:
+		case optTimeout:
+			if duration, err := getOptionDuration(cfg[key], defaultTimeout); err != nil {
+				return err
+			} else if duration.Nanoseconds() <= 0 {
+				return fmt.Errorf("negative log opt '%s' value for %s log driver", key, name)
+			}
+
+			return nil
+		default:
+			return fmt.Errorf("unknown log opt '%s' for %s log driver", key, name)
+		}
+	}
+
+	return nil
+}
+
+// New creates a new instance of the logging driver using configuration options passed in via the context.
+func New(info logger.Info) (logger.Logger, error) {
+	domain := info.Config[optDomain]
+	workspaceID := info.Config[optWorkspaceID]
+	sharedKey := info.Config[optSharedKey]
+
+	if workspaceID == "" {
+		return nil, fmt.Errorf(errOptRequired, workspaceID)
+	}
+
+	if sharedKey == "" {
+		return nil, fmt.Errorf(errOptRequired, sharedKey)
+	}
+
+	l := &omsLogger{
+		containerID:   info.ContainerID,
+		containerName: info.ContainerName,
+		imageID:       info.ContainerImageID,
+		imageName:     info.ContainerImageName,
+	}
+
+	if domain == "" {
+		domain = os.Getenv(envDomain)
+	}
+
+	l.timeout = defaultTimeout
+	if timeoutStr, ok := info.Config[optTimeout]; ok {
+		timeout, err := getOptionDuration(timeoutStr, defaultTimeout)
+		if err != nil {
+			logrus.Error(err)
+		}
+
+		l.timeout = timeout
+	} else {
+		l.timeout = getEnvOptionDuration(envTimeout, defaultTimeout)
+	}
+
+	l.postMessagesFrequency = getEnvOptionDuration(envPostMessagesFrequency, defaultPostMessagesFrequency)
+	l.postMessagesBatchSize = getEnvOptionInt(envPostMessagesBatchSize, defaultPostMessagesBatchSize)
+	l.bufferSize = getEnvOptionInt(envBufferSize, defaultBufferSize)
+	l.streamChannelSize = getEnvOptionInt(envStreamChannelSize, defaultStreamChannelSize)
+
+	l.client = client.NewOmsLogClient(domain, workspaceID, sharedKey, l.timeout)
+	l.stream = make(chan *omsMessage, l.streamChannelSize)
+
+	go l.work()
+	return l, nil
+}
+
+// Log logs a message to the logging driver.
+func (l *omsLogger) Log(message *logger.Message) error {
+	msg := l.createMessage(message)
+
+	logger.PutMessage(message)
+	return l.queueMessage(msg)
+}
+
+// Name gets the name of the logging driver.
+func (l *omsLogger) Name() string {
+	return name
+}
+
+// Close closes the logging driver.
+func (l *omsLogger) Close() error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	if l.closedSig == nil {
+		l.closedSig = sync.NewCond(&l.lock)
+
+		close(l.stream)
+		for !l.closed {
+			l.closedSig.Wait()
+		}
+	}
+
+	return nil
+}
+
+func (l *omsLogger) createMessage(m *logger.Message) *omsMessage {
+	return &omsMessage{
+		ContainerID:    l.containerID,
+		ContainerName:  l.containerName,
+		ImageID:        l.imageID,
+		ImageName:      l.imageName,
+		TimeGenerated:  m.Timestamp.Format(time.RFC3339),
+		LogEntrySource: m.Source,
+		LogEntry:       string(m.Line),
+	}
+}
+
+func (l *omsLogger) processMessages(messages []*omsMessage, final bool) []*omsMessage {
+	len := len(messages)
+	for i := 0; i < len; i += l.postMessagesBatchSize {
+		upper := i + l.postMessagesBatchSize
+		if upper > len {
+			upper = len
+		}
+
+		if err := l.sendMessages(messages[i:upper]); err != nil {
+			logrus.Error(err)
+
+			if len-1 >= l.bufferSize || final {
+				// Send any remaining messages to daemon log.
+				if final {
+					upper = len
+				}
+
+				for j := 0; i < upper; j++ {
+					if buffer, err := json.Marshal(messages[j]); err != nil {
+						logrus.Error(err)
+					} else {
+						logrus.Errorf("Failed to send message: %s", string(buffer))
+					}
+				}
+
+				return messages[upper:len]
+			}
+
+			// Return remaining buffer.
+			return messages[i:len]
+		}
+	}
+
+	// Return empty buffer when all messages sent.
+	return messages[:0]
+}
+
+func (l *omsLogger) queueMessage(m *omsMessage) error {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
+	if l.closedSig != nil {
+		return fmt.Errorf("%s driver is closed", name)
+	}
+
+	l.stream <- m
+	return nil
+}
+
+func (l *omsLogger) sendMessages(messages []*omsMessage) error {
+	// TODO: Send messages as a JSON array. Double check its supported.
+
+	buffer, err := json.Marshal(messages)
+	if err != nil {
+		return err
+	}
+
+	// TODO: support setting mock client.OmsLogClient for testing.
+	if err := l.client.PostData(&buffer, "ContainerLog"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (l *omsLogger) setClient(c client.OmsLogClient) {
+	l.client = c
+}
+
+func (l *omsLogger) work() {
+	timer := time.NewTicker(l.postMessagesFrequency)
+	var messages []*omsMessage
+
+	for {
+		select {
+		case message, open := <-l.stream:
+			if !open {
+				l.processMessages(messages, true)
+
+				l.lock.Lock()
+				defer l.lock.Unlock()
+
+				l.closed = true
+				l.closedSig.Signal()
+
+				return
+			}
+
+			messages = append(messages, message)
+			if len(messages)%l.postMessagesBatchSize == 0 {
+				messages = l.processMessages(messages, false)
+			}
+
+		case <-timer.C:
+			messages = l.processMessages(messages, false)
+		}
+	}
+}
+
+func getOptionDuration(valueStr string, defaultValue time.Duration) (time.Duration, error) {
+	if valueStr == "" {
+		return defaultValue, nil
+	}
+
+	value, err := time.ParseDuration(valueStr)
+	if err != nil {
+		return defaultValue, fmt.Errorf("invalid duration: %s. Using default value: %v", valueStr, defaultValue)
+	}
+
+	return value, nil
+}
+
+func getEnvOptionDuration(envName string, defaultValue time.Duration) time.Duration {
+	value, err := getOptionDuration(os.Getenv(envName), defaultValue)
+	if err != nil {
+		logrus.Errorf("Failed to parse environment variable '%s': %s", envName, err.Error())
+	}
+
+	return value
+}
+
+func getOptionInt(valueStr string, defaultValue int) (int, error) {
+	if valueStr == "" {
+		return defaultValue, nil
+	}
+
+	value, err := strconv.ParseInt(valueStr, 10, 32)
+	if err != nil {
+		return defaultValue, fmt.Errorf("invalid integer: %s. Using default value: %v", valueStr, defaultValue)
+	}
+
+	if value < 0 {
+		return defaultValue, fmt.Errorf("negative integer not supported: %s. Using default value %v", valueStr, defaultValue)
+	}
+
+	if value > math.MaxInt32 {
+		return defaultValue, fmt.Errorf("integer overflow: %s. Using default value %v", valueStr, defaultValue)
+	}
+
+	return int(value), nil
+}
+
+func getEnvOptionInt(envName string, defaultValue int) int {
+	value, err := getOptionInt(os.Getenv(envName), defaultValue)
+	if err != nil {
+		logrus.Errorf("Failed to parse environment variable '%s': %s", envName, err.Error())
+	}
+
+	return value
+}

--- a/daemon/logger/omslogs/omslogs.go
+++ b/daemon/logger/omslogs/omslogs.go
@@ -32,8 +32,8 @@ const (
 	envStreamChannelSize     = "OMS_LOGGING_DRIVER_CHANNEL_SIZE"
 
 	// Default option values
-	defaultTimeout               = time.Duration(5 * time.Second)
-	defaultPostMessagesFrequency = time.Duration(5 * time.Second)
+	defaultTimeout               = 5 * time.Second
+	defaultPostMessagesFrequency = 5 * time.Second
 	defaultPostMessagesBatchSize = 100
 	defaultBufferSize            = 10 * defaultPostMessagesBatchSize
 	defaultStreamChannelSize     = 4 * defaultPostMessagesBatchSize

--- a/daemon/logger/omslogs/omslogs_test.go
+++ b/daemon/logger/omslogs/omslogs_test.go
@@ -1,0 +1,123 @@
+package omslogs
+
+import (
+	"testing"
+
+	"bytes"
+	"fmt"
+	"github.com/docker/docker/daemon/logger"
+)
+
+func TestValidateLogOpt(t *testing.T) {
+	if err := ValidateLogOpt(map[string]string{
+		"omslogs-workspaceID": "56fcb3e3-8309-4989-befd-17ddf7462181",
+		"omslogs-sharedKey":   "LjdZpLJL1bhDFB4/coTPumo6rmc5CImAyfxjMklDDNc=",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ValidateLogOpt(map[string]string{
+		"unknown": "unknown",
+	}); err == nil {
+		t.Fatal("expected error for unsupported option")
+	}
+}
+
+func TestValidateLogOptTimeoutInvalid(t *testing.T) {
+	if err := ValidateLogOpt(map[string]string{
+		"omslogs-timeout": "invalid",
+	}); err == nil {
+		t.Fatalf("expected error for invalid value for option '%s'", optTimeout)
+	}
+}
+
+func TestValidateLogOptTimeoutNegative(t *testing.T) {
+	if err := ValidateLogOpt(map[string]string{
+		"omslogs-timeout": "-1ms",
+	}); err == nil {
+		t.Fatalf("expected error for negative option '%s'", optTimeout)
+	}
+}
+
+func TestValidateLogOptTimeout(t *testing.T) {
+	if err := ValidateLogOpt(map[string]string{
+		"omslogs-timeout": "5s",
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewMissedConfig(t *testing.T) {
+	info := logger.Info{
+		Config: map[string]string{},
+	}
+
+	if _, err := New(info); err == nil {
+		t.Fatal("expected failure when missing required options")
+	}
+}
+
+func TestNewMissedWorkspaceID(t *testing.T) {
+	info := logger.Info{
+		Config: map[string]string{
+			"omslogs-sharedKey": "LjdZpLJL1bhDFB4/coTPumo6rmc5CImAyfxjMklDDNc=",
+		},
+	}
+
+	if _, err := New(info); err == nil {
+		t.Fatalf("expected failure when missing required '%s'", optWorkspaceID)
+	}
+}
+
+func TestNewMissedSharedKey(t *testing.T) {
+	info := logger.Info{
+		Config: map[string]string{
+			"omslogs-workspaceID": "56fcb3e3-8309-4989-befd-17ddf7462181",
+		},
+	}
+
+	if _, err := New(info); err == nil {
+		t.Fatalf("expected failure when missing required '%s'", optSharedKey)
+	}
+}
+
+func TestLog(t *testing.T) {
+	info := logger.Info{
+		Config: map[string]string{
+			"omslogs-workspaceID": "56fcb3e3-8309-4989-befd-17ddf7462181",
+			"omslogs-sharedKey":   "LjdZpLJL1bhDFB4/coTPumo6rmc5CImAyfxjMklDDNc=",
+		},
+		ContainerID:        "containerID",
+		ContainerName:      "containerName",
+		ContainerImageID:   "imageID",
+		ContainerImageName: "imageName",
+	}
+
+	l, err := New(info)
+	if err != nil {
+		t.Error(err)
+	}
+
+	mock := &OmsLogClientMock{}
+
+	sut := l.(*omsLogger)
+	sut.setClient(mock)
+
+	for i := 0; i < 2*sut.postMessagesBatchSize; i++ {
+		message := &logger.Message{
+			Source: "stdout",
+			Line:   bytes.NewBufferString(fmt.Sprintf("message %d\n", i)).Bytes(),
+		}
+
+		if err := sut.Log(message); err != nil {
+			t.Error(err)
+		}
+	}
+
+	l.Close()
+
+	messages := mock.getMessages()
+	if len(messages) != 2 {
+		t.Fatal("expected 2 batches of log messages")
+	}
+}

--- a/daemon/logger/omslogs/omslogs_test.go
+++ b/daemon/logger/omslogs/omslogs_test.go
@@ -1,10 +1,10 @@
 package omslogs
 
 import (
-	"testing"
-
 	"bytes"
 	"fmt"
+	"testing"
+
 	"github.com/docker/docker/daemon/logger"
 )
 

--- a/daemon/logger/omslogs/omslogsmock.go
+++ b/daemon/logger/omslogs/omslogsmock.go
@@ -1,0 +1,33 @@
+package omslogs
+
+import (
+	"bytes"
+	"sync"
+)
+
+// OmsLogClientMock mocks an OmsLogClient.
+type OmsLogClientMock struct {
+	lock     sync.RWMutex
+	messages []string
+}
+
+// PostData saves the buffer for later analysis.
+func (l *OmsLogClientMock) PostData(data *[]byte, name string) error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	buffer := bytes.NewBuffer(*data)
+	l.messages = append(l.messages, buffer.String())
+
+	return nil
+}
+
+func (l *OmsLogClientMock) getMessages() []string {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	messages := l.messages[0:]
+	l.messages = l.messages[:0]
+
+	return messages
+}


### PR DESCRIPTION
Created a client for the Azure Operations Management Suite (OMS) and a
logging driver to pass stdout/stderr log messages to OMS.

Resolves issue #34257

Signed-off-by: Heath Stewart <heaths@microsoft.com>

**- What I did**

@darobs, @dtzar, @radu-matei, and I created an Azure OMS client and use that in a Docker logging driver to send docker container messages to OMS.

**- How I did it**

Based somewhat on the design of the splunk driver of batching messages we wrote an OMS driver that would queue messages and send in a batch to OMS. Using OMS documentation we allow for logging driver options and some environment variables (for finer-grained customization) to set the workspace ID (sometimes called the customer ID) and the shared key.

**- How to verify it**

1. Build docker with these changes.
2. Create an OMS workspace in Azure and copy the workspaceID and sharedKey.
3. Start a container using the `omslogs` driver:
```
docker run --log-driver omslogs --log-opt "omslogs-workspaceID=$workspaceID" --log-opt "omslogs-sharedKey=$sharedKey" hello-world
```
4. Check the OMS driver logs (may take a couple of minutes to process and appear).

**- Description for the changelog**

> Added built-in logging driver for Azure Operations Management Suite

**- A picture of a cute animal (not mandatory but encouraged)**

![waiting squirrel](https://jasonsprojects.wikispaces.com/file/view/04_cute_animals_squirrel01.jpg/303461432/04_cute_animals_squirrel01.jpg)