### PR TITLE
LCOW: WORKDIR correct handling

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -387,7 +387,7 @@ func workdir(req dispatchRequest) error {
 	runConfig := req.state.runConfig
 	// This is from the Dockerfile and will not necessarily be in platform
 	// specific semantics, hence ensure it is converted.
-	runConfig.WorkingDir, err = normaliseWorkdir(runConfig.WorkingDir, req.args[0])
+	runConfig.WorkingDir, err = normaliseWorkdir(req.builder.platform, runConfig.WorkingDir, req.args[0])
 	if err != nil {
 		return err
 	}

--- a/builder/dockerfile/dispatchers_unix.go
+++ b/builder/dockerfile/dispatchers_unix.go
@@ -11,7 +11,7 @@ import (
 
 // normaliseWorkdir normalises a user requested working directory in a
 // platform semantically consistent way.
-func normaliseWorkdir(current string, requested string) (string, error) {
+func normaliseWorkdir(_ string, current string, requested string) (string, error) {
 	if requested == "" {
 		return "", errors.New("cannot normalise nothing")
 	}

--- a/builder/dockerfile/dispatchers_unix_test.go
+++ b/builder/dockerfile/dispatchers_unix_test.go
@@ -3,6 +3,7 @@
 package dockerfile
 
 import (
+	"runtime"
 	"testing"
 )
 
@@ -16,7 +17,7 @@ func TestNormaliseWorkdir(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		normalised, err := normaliseWorkdir(test.current, test.requested)
+		normalised, err := normaliseWorkdir(runtime.GOOS, test.current, test.requested)
 
 		if test.expectedError != "" && err == nil {
 			t.Fatalf("NormaliseWorkdir should return an error %s, got nil", test.expectedError)

--- a/builder/dockerfile/dispatchers_windows.go
+++ b/builder/dockerfile/dispatchers_windows.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -15,7 +16,33 @@ var pattern = regexp.MustCompile(`^[a-zA-Z]:\.$`)
 
 // normaliseWorkdir normalises a user requested working directory in a
 // platform semantically consistent way.
-func normaliseWorkdir(current string, requested string) (string, error) {
+func normaliseWorkdir(platform string, current string, requested string) (string, error) {
+	if platform == "" {
+		platform = "windows"
+	}
+	if platform == "windows" {
+		return normaliseWorkdirWindows(current, requested)
+	}
+	return normaliseWorkdirUnix(current, requested)
+}
+
+// normaliseWorkdirUnix normalises a user requested working directory in a
+// platform semantically consistent way.
+func normaliseWorkdirUnix(current string, requested string) (string, error) {
+	if requested == "" {
+		return "", errors.New("cannot normalise nothing")
+	}
+	current = strings.Replace(current, string(os.PathSeparator), "/", -1)
+	requested = strings.Replace(requested, string(os.PathSeparator), "/", -1)
+	if !path.IsAbs(requested) {
+		return path.Join(`/`, current, requested), nil
+	}
+	return requested, nil
+}
+
+// normaliseWorkdirWindows normalises a user requested working directory in a
+// platform semantically consistent way.
+func normaliseWorkdirWindows(current string, requested string) (string, error) {
 	if requested == "" {
 		return "", errors.New("cannot normalise nothing")
 	}

--- a/builder/dockerfile/dispatchers_windows_test.go
+++ b/builder/dockerfile/dispatchers_windows_test.go
@@ -5,25 +5,31 @@ package dockerfile
 import "testing"
 
 func TestNormaliseWorkdir(t *testing.T) {
-	tests := []struct{ current, requested, expected, etext string }{
-		{``, ``, ``, `cannot normalise nothing`},
-		{``, `C:`, ``, `C:. is not a directory. If you are specifying a drive letter, please add a trailing '\'`},
-		{``, `C:.`, ``, `C:. is not a directory. If you are specifying a drive letter, please add a trailing '\'`},
-		{`c:`, `\a`, ``, `c:. is not a directory. If you are specifying a drive letter, please add a trailing '\'`},
-		{`c:.`, `\a`, ``, `c:. is not a directory. If you are specifying a drive letter, please add a trailing '\'`},
-		{``, `a`, `C:\a`, ``},
-		{``, `c:\foo`, `C:\foo`, ``},
-		{``, `c:\\foo`, `C:\foo`, ``},
-		{``, `\foo`, `C:\foo`, ``},
-		{``, `\\foo`, `C:\foo`, ``},
-		{``, `/foo`, `C:\foo`, ``},
-		{``, `C:/foo`, `C:\foo`, ``},
-		{`C:\foo`, `bar`, `C:\foo\bar`, ``},
-		{`C:\foo`, `/bar`, `C:\bar`, ``},
-		{`C:\foo`, `\bar`, `C:\bar`, ``},
+	tests := []struct{ platform, current, requested, expected, etext string }{
+		{"windows", ``, ``, ``, `cannot normalise nothing`},
+		{"windows", ``, `C:`, ``, `C:. is not a directory. If you are specifying a drive letter, please add a trailing '\'`},
+		{"windows", ``, `C:.`, ``, `C:. is not a directory. If you are specifying a drive letter, please add a trailing '\'`},
+		{"windows", `c:`, `\a`, ``, `c:. is not a directory. If you are specifying a drive letter, please add a trailing '\'`},
+		{"windows", `c:.`, `\a`, ``, `c:. is not a directory. If you are specifying a drive letter, please add a trailing '\'`},
+		{"windows", ``, `a`, `C:\a`, ``},
+		{"windows", ``, `c:\foo`, `C:\foo`, ``},
+		{"windows", ``, `c:\\foo`, `C:\foo`, ``},
+		{"windows", ``, `\foo`, `C:\foo`, ``},
+		{"windows", ``, `\\foo`, `C:\foo`, ``},
+		{"windows", ``, `/foo`, `C:\foo`, ``},
+		{"windows", ``, `C:/foo`, `C:\foo`, ``},
+		{"windows", `C:\foo`, `bar`, `C:\foo\bar`, ``},
+		{"windows", `C:\foo`, `/bar`, `C:\bar`, ``},
+		{"windows", `C:\foo`, `\bar`, `C:\bar`, ``},
+		{"linux", ``, ``, ``, `cannot normalise nothing`},
+		{"linux", ``, `foo`, `/foo`, ``},
+		{"linux", ``, `/foo`, `/foo`, ``},
+		{"linux", `/foo`, `bar`, `/foo/bar`, ``},
+		{"linux", `/foo`, `/bar`, `/bar`, ``},
+		{"linux", `\a`, `b\c`, `/a/b/c`, ``},
 	}
 	for _, i := range tests {
-		r, e := normaliseWorkdir(i.current, i.requested)
+		r, e := normaliseWorkdir(i.platform, i.current, i.requested)
 
 		if i.etext != "" && e == nil {
 			t.Fatalf("TestNormaliseWorkingDir Expected error %s for '%s' '%s', got no error", i.etext, i.current, i.requested)

--- a/container/container.go
+++ b/container/container.go
@@ -261,12 +261,17 @@ func (container *Container) WriteHostConfig() (*containertypes.HostConfig, error
 
 // SetupWorkingDirectory sets up the container's working directory as set in container.Config.WorkingDir
 func (container *Container) SetupWorkingDirectory(rootIDs idtools.IDPair) error {
+	// TODO @jhowardmsft, @gupta-ak LCOW Support. This will need revisiting.
+	// We will need to do remote filesystem operations here.
+	if container.Platform != runtime.GOOS {
+		return nil
+	}
+
 	if container.Config.WorkingDir == "" {
 		return nil
 	}
 
 	container.Config.WorkingDir = filepath.Clean(container.Config.WorkingDir)
-
 	pth, err := container.GetResourcePath(container.Config.WorkingDir)
 	if err != nil {
 		return err

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -79,7 +79,7 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *containertypes.Hos
 
 	// check if hostConfig is in line with the current system settings.
 	// It may happen cgroups are umounted or the like.
-	if _, err = daemon.verifyContainerSettings(container.HostConfig, nil, false); err != nil {
+	if _, err = daemon.verifyContainerSettings(container.Platform, container.HostConfig, nil, false); err != nil {
 		return validationError{err}
 	}
 	// Adapt for old containers in case we have updates in this function and

--- a/daemon/update.go
+++ b/daemon/update.go
@@ -11,7 +11,12 @@ import (
 func (daemon *Daemon) ContainerUpdate(name string, hostConfig *container.HostConfig) (container.ContainerUpdateOKBody, error) {
 	var warnings []string
 
-	warnings, err := daemon.verifyContainerSettings(hostConfig, nil, true)
+	c, err := daemon.GetContainer(name)
+	if err != nil {
+		return container.ContainerUpdateOKBody{Warnings: warnings}, err
+	}
+
+	warnings, err = daemon.verifyContainerSettings(c.Platform, hostConfig, nil, true)
 	if err != nil {
 		return container.ContainerUpdateOKBody{Warnings: warnings}, validationError{err}
 	}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

WORKDIR in LCOW mode was being treated as a Windows path and not working - `/bin` was being translated to `C:\bin`. This fixes it to use Unix semantics.

```PowerShell
PS E:\docker\build\lcow> docker build -f workdir --no-cache .
Sending build context to Docker daemon  6.144kB
Step 1/2 : FROM busybox
 ---> efe10ee6727f
Step 2/2 : WORKDIR /bin
 ---> 29731c1d2cbd
Removing intermediate container 7425c28fb858
Successfully built 29731c1d2cbd
PS E:\docker\build\lcow> docker inspect -f "{{.ContainerConfig.Cmd}} -- {{.Config.WorkingDir}}" 297
[/bin/sh -c #(nop) WORKDIR /bin] -- /bin
PS E:\docker\build\lcow> docker run --rm 297 pwd
/bin
PS E:\docker\build\lcow> docker run --rm 297 ls -l ./sh
-rwxr-xr-x  385 root     root       1049592 Aug  4 18:44 ./sh
PS E:\docker\build\lcow>
```

@johnstep @dnephin PTAL

@Gupta-ak - I left a `TODO` in there for the remote filesystem operation.