### PR TITLE
Update tmLanguage file to not be case sensitive

### DIFF
--- a/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
+++ b/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
@@ -25,7 +25,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*\b(FROM)\b.*?\b(AS)\b</string>
+			<string>^\s*\b(?i:(FROM))\b.*?\b(?i:(AS))\b</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -42,7 +42,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(?:(ONBUILD)\s+)?(ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL|MAINTAINER|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR)\s</string>
+			<string>^\s*(?i:(ONBUILD)\s+)?(?i:(ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL|MAINTAINER|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR))\s</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -59,7 +59,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(?:(ONBUILD)\s+)?(CMD|ENTRYPOINT)\s</string>
+			<string>^\s*(?i:(ONBUILD)\s+)?(?i:(CMD|ENTRYPOINT))\s</string>
 		</dict>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
**- What I did**
Updated the `Dockerfile.tmLanguage` file so that it is case insensitive and highlights instructions regardless of whether they are written in uppercase or lowercase.

**- How I did it**
Used the `?i` flag as indicated in [TextMate's documentation](https://manual.macromates.com/en/regular_expressions) so that the regexp would be case insensitive.

**- How to verify it**
I tested that this worked by modifying a JSON variant of this file for use in VS Code and then testing a Dockerfile with various instructions written in it.

```Dockerfile
FROM node AS setup
FROM node As setup
FROM node as setup
from node aS setup

ADD x y
EXPOSE 808
expOSE 8081

ONBUILD ADD y
onbuild AdD y
onbuild add y

ONBUILD CMD ls
ONBUILD ENTRYPOINT ls
OnBUILD cmD ls
OnBUILD entrYpoint ls
```

**- Description for the changelog**
Modified Dockerfile.tmLanguage file so that instructions will be highlighted even if they are not written in uppercase.