### PR TITLE
Add validation for '--network-control-plane-mtu' flag

### DIFF
--- a/cmd/dockerd/docker.go
+++ b/cmd/dockerd/docker.go
@@ -85,7 +85,7 @@ func main() {
 	initLogging(stdout, stderr)
 
 	onError := func(err error) {
-		fmt.Fprintf(stderr, "%s\n", err)
+		logrus.Error(err)
 		os.Exit(1)
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -476,7 +476,7 @@ func (daemon *Daemon) restore() error {
 
 	daemon.netController, err = daemon.initNetworkController(daemon.configStore, activeSandboxes)
 	if err != nil {
-		return fmt.Errorf("Error initializing network controller: %v", err)
+		return errors.Wrap(err, "Error initializing network controller")
 	}
 
 	// Now that all the containers are registered, register the links
@@ -1459,7 +1459,12 @@ func (daemon *Daemon) networkOptions(dconfig *config.Config, pg plugingetter.Plu
 		options = append(options, nwconfig.OptionPluginGetter(pg))
 	}
 
-	options = append(options, nwconfig.OptionNetworkControlPlaneMTU(dconfig.NetworkControlPlaneMTU))
+	if dconfig.NetworkControlPlaneMTU != 0 {
+		if dconfig.NetworkControlPlaneMTU < 500 {
+			return nil, errors.Errorf("Network Control plane MTU (%d) out of range. Minimum value is 500", dconfig.NetworkControlPlaneMTU)
+		}
+		options = append(options, nwconfig.OptionNetworkControlPlaneMTU(dconfig.NetworkControlPlaneMTU))
+	}
 
 	return options, nil
 }


### PR DESCRIPTION
The `--network-control-plane-mtu` daemon flag did not have validation
in the daemon, causing invalid values to be silently ignored.

This patch adds validation of the specified value; any non-zero value
lower than 500 produces an error, both in the logs, and on `stderr`.

Other errors during initialization of the Network Controller (errors
returned by `daemon.initNetworkController()` are now also written to
the daemon logs, which may help in debugging daemon startup issues.

Before this change:

    $ dockerd --network-control-plane-mtu=480

    INFO[2019-07-16T11:48:18.533128294Z] Starting up
    INFO[2019-07-16T11:48:18.535302135Z] libcontainerd: started new containerd process  pid=280
    ...

    WARN[2019-07-16T11:51:25.143486074Z] Received a MTU of 480, this value is very low, the network control plane can misbehave, defaulting to minimum value (500)
    WARN[2019-07-16T11:51:25.143688661Z] Running modprobe bridge br_netfilter failed with message: , error: exec: "modprobe": executable file not found in $PATH
    WARN[2019-07-16T11:51:25.143740923Z] Running modprobe nf_nat failed with message: ``, error: exec: "modprobe": executable file not found in $PATH
    WARN[2019-07-16T11:51:25.143759220Z] Running modprobe xt_conntrack failed with message: ``, error: exec: "modprobe": executable file not found in $PATH
    ...
    INFO[2019-07-16T11:48:19.338019445Z] Daemon has completed initialization
    INFO[2019-07-16T11:48:19.411229968Z] API listen on /var/run/docker.sock


    $ dockerd --network-control-plane-mtu=-1234

    INFO[2019-07-16T11:48:18.533128294Z] Starting up
    INFO[2019-07-16T11:48:18.535302135Z] libcontainerd: started new containerd process  pid=280
    ...

    INFO[2019-07-16T11:48:19.204058323Z] Loading containers: start.
    WARN[2019-07-16T11:48:19.204146378Z] Received a MTU of -1234, this value is very low, the network control plane can misbehave, defaulting to minimum value (500)
    WARN[2019-07-16T11:48:19.204335714Z] Running modprobe bridge br_netfilter failed with message: , error: exec: "modprobe": executable file not found in $PATH
    WARN[2019-07-16T11:48:19.204367262Z] Running modprobe nf_nat failed with message: ``, error: exec: "modprobe": executable file not found in $PATH
    WARN[2019-07-16T11:48:19.204450049Z] Running modprobe xt_conntrack failed with message: ``, error: exec: "modprobe": executable file not found in $PATH
    ...
    INFO[2019-07-16T11:48:19.338019445Z] Daemon has completed initialization
    INFO[2019-07-16T11:48:19.411229968Z] API listen on /var/run/docker.sock

With this patch applied:

    $ dockerd --network-control-plane-mtu=480
    INFO[2017-08-05T17:13:58.202466154Z] libcontainerd: new containerd process, pid: 988
    INFO[2017-08-05T17:13:59.215554306Z] [graphdriver] using prior storage driver: aufs
    ...
    ERRO[2017-08-05T17:13:59.224865695Z] Error initializing network controller:Network Control plane MTU (1480) out of range. Minimum value is 500

    Error starting daemon: Error initializing network controller: Network Control plane MTU (480) out of range. Minimum value is 500

    $ dockerd --network-control-plane-mtu=-1234
    INFO[2017-08-05T17:13:58.202466154Z] libcontainerd: new containerd process, pid: 988
    INFO[2017-08-05T17:13:59.215554306Z] [graphdriver] using prior storage driver: aufs
    ...
    ERRO[2017-08-05T17:13:59.224865695Z] Error initializing network controller:Network Control plane MTU (-1234) out of range. Minimum value is 500

    Error starting daemon: Error initializing network controller: Network Control plane MTU (-1234) out of range. Minimum value is 500

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add validation for '--network-control-plane-mtu' daemon flag

