### PR TITLE
security: Chmod config.v2.json to 0600

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -167,7 +167,7 @@ func (container *Container) toDisk() (*Container, error) {
 	}
 
 	// Save container settings
-	f, err := ioutils.NewAtomicFileWriter(pth, 0644)
+	f, err := ioutils.NewAtomicFileWriter(pth, 0600)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
partially addresses https://github.com/moby/moby/issues/17310

There may be some secret info in container's evn, like http_proxy(with accounts).

```
[root@localhost docker-bin]# docker run --rm -ti -e https_proxy=https://xxxxxx:xxxx@proxy.com:8080 busybox ash                                                 
/ # 
....
[root@localhost docker-bin]#  ls -l /var/lib/docker/containers/fc06e2d8fdc072099818758e8d584f3b8e4543be84e0e66429ea9ace9bcf4133/config.v2.json                  
-rw-r--r--. 1 root root 2487 Aug  7 06:00 /var/lib/docker/containers/fc06e2d8fdc072099818758e8d584f3b8e4543be84e0e66429ea9ace9bcf4133/config.v2.json
[root@localhost docker-bin]# cat /var/lib/docker/containers/fc06e2d8fdc072099818758e8d584f3b8e4543be84e0e66429ea9ace9bcf4133/config.v2.json |python -mjson.tool|grep https_proxy
            "https_proxy=https://xxxxxx:xxxx@proxy.com:8080",
```

On the other hand, 0600 is also ok for config.v2.json, in order to reduce the attack surface，can we change the permit mode to  0600?

Signed-off-by: yangshukui <yangshukui@huawei.com>

