### PR TITLE
Fix HTTP status-code when loading invalid tar

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -173,6 +173,9 @@ func (s *imageRouter) postImagesLoad(ctx context.Context, w http.ResponseWriter,
 	output := ioutils.NewWriteFlusher(w)
 	defer output.Close()
 	if err := s.backend.LoadImage(r.Body, output, quiet); err != nil {
+		if !output.Flushed() {
+			w.WriteHeader(errdefs.GetHTTPErrorStatusCode(err))
+		}
 		_, _ = output.Write(streamformatter.FormatError(err))
 	}
 	return nil

--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	v1 "github.com/docker/docker/image/v1"
 	"github.com/docker/docker/layer"
@@ -57,7 +58,7 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 
 	var manifest []manifestItem
 	if err := json.NewDecoder(manifestFile).Decode(&manifest); err != nil {
-		return err
+		return errdefs.InvalidParameter(err)
 	}
 
 	if err := validateManifest(manifest); err != nil {
@@ -79,16 +80,16 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 		}
 		img, err := image.NewFromJSON(config)
 		if err != nil {
-			return err
+			return errdefs.InvalidParameter(err)
 		}
 		if !system.IsOSSupported(img.OperatingSystem()) {
-			return fmt.Errorf("cannot load %s image on %s", img.OperatingSystem(), runtime.GOOS)
+			return errdefs.InvalidParameter(fmt.Errorf("cannot load %s image on %s", img.OperatingSystem(), runtime.GOOS))
 		}
 		rootFS := *img.RootFS
 		rootFS.DiffIDs = nil
 
 		if expected, actual := len(m.Layers), len(img.RootFS.DiffIDs); expected != actual {
-			return fmt.Errorf("invalid manifest, layers length mismatch: expected %d, got %d", expected, actual)
+			return errdefs.InvalidParameter(fmt.Errorf("invalid manifest, layers length mismatch: expected %d, got %d", expected, actual))
 		}
 
 		for i, diffID := range img.RootFS.DiffIDs {
@@ -122,11 +123,11 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 		for _, repoTag := range m.RepoTags {
 			named, err := reference.ParseNormalizedNamed(repoTag)
 			if err != nil {
-				return err
+				return errdefs.InvalidParameter(err)
 			}
 			ref, ok := named.(reference.NamedTagged)
 			if !ok {
-				return fmt.Errorf("invalid tag %q", repoTag)
+				return errdefs.InvalidParameter(fmt.Errorf("invalid tag %q", repoTag))
 			}
 			l.setLoadedTag(ref, imgID.Digest(), outStream)
 			outStream.Write([]byte(fmt.Sprintf("Loaded image: %s\n", reference.FamiliarString(ref))))
@@ -238,28 +239,31 @@ func (l *tarexporter) legacyLoad(tmpDir string, outStream io.Writer, progressOut
 	}
 	repositoriesFile, err := os.Open(repositoriesPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return errdefs.InvalidParameter(err)
+		}
 		return err
 	}
 	defer repositoriesFile.Close()
 
 	repositories := make(map[string]map[string]string)
 	if err := json.NewDecoder(repositoriesFile).Decode(&repositories); err != nil {
-		return err
+		return errdefs.InvalidParameter(err)
 	}
 
 	for name, tagMap := range repositories {
 		for tag, oldID := range tagMap {
 			imgID, ok := legacyLoadedMap[oldID]
 			if !ok {
-				return fmt.Errorf("invalid target ID: %v", oldID)
+				return errdefs.InvalidParameter(fmt.Errorf("invalid target ID: %v", oldID))
 			}
 			named, err := reference.ParseNormalizedNamed(name)
 			if err != nil {
-				return err
+				return errdefs.InvalidParameter(err)
 			}
 			ref, err := reference.WithTag(named, tag)
 			if err != nil {
-				return err
+				return errdefs.InvalidParameter(err)
 			}
 			l.setLoadedTag(ref, imgID.Digest(), outStream)
 		}
@@ -279,6 +283,9 @@ func (l *tarexporter) legacyLoadImage(oldID, sourceDir string, loadedMap map[str
 	imageJSON, err := os.ReadFile(configPath)
 	if err != nil {
 		logrus.Debugf("Error reading json: %v", err)
+		if os.IsNotExist(err) {
+			return errdefs.InvalidParameter(err)
+		}
 		return err
 	}
 
@@ -287,14 +294,14 @@ func (l *tarexporter) legacyLoadImage(oldID, sourceDir string, loadedMap map[str
 		Parent string
 	}
 	if err := json.Unmarshal(imageJSON, &img); err != nil {
-		return err
+		return errdefs.InvalidParameter(err)
 	}
 
 	if img.OS == "" {
 		img.OS = runtime.GOOS
 	}
 	if !system.IsOSSupported(img.OS) {
-		return fmt.Errorf("cannot load %s image on %s", img.OS, runtime.GOOS)
+		return errdefs.InvalidParameter(fmt.Errorf("cannot load %s image on %s", img.OS, runtime.GOOS))
 	}
 
 	var parentID image.ID
@@ -337,13 +344,13 @@ func (l *tarexporter) legacyLoadImage(oldID, sourceDir string, loadedMap map[str
 
 	h, err := v1.HistoryFromConfig(imageJSON, false)
 	if err != nil {
-		return err
+		return errdefs.InvalidParameter(err)
 	}
 	history = append(history, h)
 
 	config, err := v1.MakeConfigFromV1Config(imageJSON, rootFS, history)
 	if err != nil {
-		return err
+		return errdefs.InvalidParameter(err)
 	}
 	imgID, err := l.is.Create(config)
 	if err != nil {

--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -1,7 +1,6 @@
 package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
 
 import (
-	"fmt"
 	"io"
 	"net"
 	"os"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -18,6 +18,16 @@ func init() {
 	_, _ = user.Lookup("docker")
 	_, _ = net.LookupHost("localhost")
 }
+
+type invalidArchiveError struct {
+	cause error
+}
+
+func (e invalidArchiveError) Error() string {
+	return e.cause.Error()
+}
+
+func (e invalidArchiveError) InvalidParameter() {}
 
 // NewArchiver returns a new Archiver which uses chrootarchive.Untar
 func NewArchiver(idMapping *idtools.IdentityMapping) *archive.Archiver {
@@ -64,7 +74,7 @@ func UntarUncompressed(tarArchive io.Reader, dest string, options *archive.TarOp
 // Handler for teasing out the automatic decompression
 func untarHandler(tarArchive io.Reader, dest string, options *archive.TarOptions, decompress bool, root string) error {
 	if tarArchive == nil {
-		return fmt.Errorf("Empty archive")
+		return invalidArchiveError{errors.New("empty archive")}
 	}
 	if options == nil {
 		options = &archive.TarOptions{}

--- a/pkg/chrootarchive/archive_unix.go
+++ b/pkg/chrootarchive/archive_unix.go
@@ -113,7 +113,12 @@ func invokeUnpack(decompressedArchive io.Reader, dest string, options *archive.T
 		// pending on write pipe forever
 		io.Copy(io.Discard, decompressedArchive)
 
-		return fmt.Errorf("Error processing tar file(%v): %s", err, output)
+		rerr := fmt.Errorf("Error processing tar file(%v): %s", err, output)
+		if strings.Contains(err.Error(), "peration not permitted") { // "(O|o)eration not permitted"
+			// return EPERM errors as-is, as they unlikely to be a problem with the archive itself
+			return rerr
+		}
+		return invalidArchiveError{rerr}
 	}
 	return nil
 }


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/34416

Opening for discussion, because this changes the `WriteFlusher` interface, which is used in various places; also the error-code may need to be more specific based on the actual error.

Before this change:

    echo "hello world, I am not a tar" | curl -v --unix-socket  /var/run/docker.sock -H "Content-Type: application/x-tar"  --data-binary @- -X POST http://localhost/v1.29/images/load
    *   Trying /var/run/docker.sock...
    * Connected to localhost (/Users/sebastiaan/Library/Containers/com.dock) port 80 (#0)
    > POST /v1.29/images/load HTTP/1.1
    > Host: localhost
    > User-Agent: curl/7.51.0
    > Accept: */*
    > Content-Type: application/x-tar
    > Content-Length: 28
    >
    * upload completely sent off: 28 out of 28 bytes
    < HTTP/1.1 200 OK
    < Api-Version: 1.31
    < Content-Type: application/json
    < Date: Mon, 07 Aug 2017 15:11:35 GMT
    < Docker-Experimental: true
    < Ostype: linux
    < Server: Docker/17.07.0-ce-rc1 (linux)
    < Transfer-Encoding: chunked
    <
    {"errorDetail":{"message":"Error processing tar file(exit status 1): unexpected EOF"},"error":"Error processing tar file(exit status 1): unexpected EOF"}
    * Curl_http_done: called premature == 0
    * Connection #0 to host localhost left intact

After this change:

    / # echo "hello world, I am not a tar" | curl -v --unix-socket  /var/run/docker.sock -H "Content-Type: application/x-tar"  --data-binary @- -X POST http://localhost/v1.29/images/load
       *   Trying /var/run/docker.sock...
    * Connected to localhost (/var/run/docker.sock) port 80 (#0)
    > POST /v1.29/images/load HTTP/1.1
    > Host: localhost
    > User-Agent: curl/7.52.1
    > Accept: */*
    > Content-Type: application/x-tar
    > Content-Length: 28
    > 
    * upload completely sent off: 28 out of 28 bytes
    < HTTP/1.1 400 Bad Request
    < Api-Version: 1.36
    < Content-Type: application/json
    < Docker-Experimental: false
    < Ostype: linux
    < Server: Docker/dev (linux)
    < Date: Fri, 16 Feb 2018 16:21:46 GMT
    < Transfer-Encoding: chunked
    < 
    Api-Version: 1.36
    Content-Type: application/json
    Docker-Experimental: false
    Ostype: linux
    Server: Docker/dev (linux)
    {"errorDetail":{"message":"Error processing tar file(exit status 1): unexpected EOF"},"error":"Error processing tar file(exit status 1): unexpected EOF"}
    * Curl_http_done: called premature == 0
    * Connection #0 to host localhost left intact

