### PR TITLE
graphdriver: promote overlay2 over aufs

### DIFF
--- a/daemon/graphdriver/driver_linux.go
+++ b/daemon/graphdriver/driver_linux.go
@@ -53,10 +53,10 @@ const (
 var (
 	// Slice of drivers that should be used in an order
 	priority = []string{
-		"aufs",
 		"btrfs",
 		"zfs",
 		"overlay2",
+		"aufs",
 		"overlay",
 		"devicemapper",
 		"vfs",


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Promote `overlay2` over `aufs`, as `overlay2` recently became matured, although it is not perfect.


**- How I did it**
By updating `daemon/graphdriver/driver_linux.go`

**- How to verify it**

Make sure `overlay2` is preferred over `aufs` by default

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
promote overlay2 over aufs

**- A picture of a cute animal (not mandatory but encouraged)**
![penguins](https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/SGI-2016-South_Georgia_%28Fortuna_Bay%29–King_penguin_%28Aptenodytes_patagonicus%29_04.jpg/655px-SGI-2016-South_Georgia_%28Fortuna_Bay%29–King_penguin_%28Aptenodytes_patagonicus%29_04.jpg)


TODO: update https://github.com/docker/docker.github.io/blob/b12ec60faa9612f2b37e09e34faf882e8c3efad7/engine/userguide/storagedriver/selectadriver.md