### PR TITLE
Fixes #29901 digest output when using filter

### DIFF
--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"fmt"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
@@ -56,41 +55,6 @@ func (s *DockerSuite) TestAPIImagesFilter(c *check.C) {
 
 	images = getImages("*5000*/*")
 	c.Assert(images[0].RepoTags, checker.HasLen, 1)
-}
-
-func (s *DockerRegistrySuite) TestAPIImagesFilterHasDigest(c *check.C) {
-	repoName := fmt.Sprintf("%v/busybox:mytag", privateRegistryURL)
-	repoName2 := fmt.Sprintf("%v/busybox:mytag2", privateRegistryURL)
-	repoName3 := fmt.Sprintf("%v/utest:tag1", privateRegistryURL)
-	for _, n := range []string{repoName, repoName2, repoName3} {
-		dockerCmd(c, "tag", "busybox", n)
-	}
-
-	// Push only some images to compute the digest
-	dockerCmd(c, "push", repoName)
-	dockerCmd(c, "push", repoName2)
-
-	type image types.ImageSummary
-	getImages := func(filter string) []image {
-		v := url.Values{}
-		v.Set("filter", filter)
-		status, b, err := request.SockRequest("GET", "/images/json?"+v.Encode(), nil, daemonHost())
-		c.Assert(err, checker.IsNil)
-		c.Assert(status, checker.Equals, http.StatusOK)
-
-		var images []image
-		err = json.Unmarshal(b, &images)
-		c.Assert(err, checker.IsNil)
-
-		return images
-	}
-
-	images := getImages(privateRegistryURL + "/utest")
-	c.Assert(images[0].RepoDigests, checker.HasLen, 0)
-
-	images = getImages(privateRegistryURL + "/busybox")
-	c.Assert(images[0].RepoDigests, checker.HasLen, 1)
-	c.Assert(images[0].RepoTags, checker.HasLen, 2)
 }
 
 func (s *DockerSuite) TestAPIImagesSaveAndLoad(c *check.C) {

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"fmt"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
@@ -17,7 +18,6 @@ import (
 	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/go-check/check"
-	"fmt"
 )
 
 func (s *DockerSuite) TestAPIImagesFilter(c *check.C) {
@@ -66,7 +66,7 @@ func (s *DockerRegistrySuite) TestAPIImagesFilterHasDigest(c *check.C) {
 		dockerCmd(c, "tag", "busybox", n)
 	}
 
-	// Push only one image to compute the digest
+	// Push only some images to compute the digest
 	dockerCmd(c, "push", repoName)
 	dockerCmd(c, "push", repoName2)
 

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -47,3 +47,37 @@ func TestImagesFilterMultiReference(t *testing.T) {
 		}
 	}
 }
+
+// func TestImagesFilterContainsDigest(t *testing.T) {
+// 	defer setupTest(t)()
+// 	client := testEnv.APIClient()
+// 	ctx := context.Background()
+
+// 	name := "images_filter_contains_digest"
+// 	repoTags := []string{
+// 		name + ":v1",
+// 		name + ":v2",
+// 		name + ":v3",
+// 		name + ":v4",
+// 	}
+
+// 	for _, repoTag := range repoTags {
+// 		err := client.ImageTag(ctx, "busybox:latest", repoTag)
+// 		assert.NilError(t, err)
+// 		err = client.ImagePush(ctx, repoTag, types.ImagePushOptions{RegistryAuth: "{}"})
+// 		assert.NilError(t, err)
+// 	}
+
+// 	filter := filters.NewArgs()
+// 	filter.Add("reference", repoTags[0])
+// 	filter.Add("reference", repoTags[1])
+// 	filter.Add("reference", repoTags[2])
+// 	options := types.ImageListOptions{
+// 		All:     false,
+// 		Filters: filter,
+// 	}
+// 	images, err := client.ImageList(ctx, options)
+// 	assert.NilError(t, err)
+
+// 	assert.Check(t, is.Equal(len(images[0].RepoDigests), 3))
+// }

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -81,3 +81,45 @@ func TestImagesFilterMultiReference(t *testing.T) {
 
 // 	assert.Check(t, is.Equal(len(images[0].RepoDigests), 3))
 // }
+
+// func TestImagesFilterHasDigest(t *testing.T) {
+// 	defer setupTest(t)()
+// 	client := testEnv.APIClient()
+// 	ctx := context.Background()
+
+// 	reg := registry.NewV2(t)
+// 	defer reg.Close()
+
+// 	name := "images_filter_has_digest"
+// 	repoTags := []string{
+// 		name + ":v1",
+// 		name + ":1-v2",
+// 		name + ":1-v3",
+// 		name + ":v4",
+// 	}
+
+// 	for _, repoTag := range repoTags {
+// 		err := client.ImageTag(ctx, "busybox:latest", repoTag)
+// 		assert.NilError(t, err)
+// 		_, err = client.ImagePush(ctx, path.Join(registry.DefaultURL, "busybox"+repoTag), types.ImagePushOptions{})
+// 		assert.NilError(t, err)
+// 	}
+
+// 	filter := filters.NewArgs()
+// 	//filter.Add("reference", repoTags[0])
+// 	//filter.Add("reference", repoTags[1])
+// 	filter.Add("reference", "v*")
+// 	options := types.ImageListOptions{
+// 		All:     false,
+// 		Filters: filter,
+// 	}
+// 	images, err := client.ImageList(ctx, options)
+// 	assert.NilError(t, err)
+
+// 	assert.Check(t, is.Equal(len(images[0].RepoTags), 2))
+// 	for _, repoTag := range images[0].RepoTags {
+// 		if repoTag != repoTags[0] && repoTag != repoTags[1] && repoTag != repoTags[2] {
+// 			t.Errorf("list images doesn't match any repoTag we expected, repoTag: %s", repoTag)
+// 		}
+// 	}
+// }


### PR DESCRIPTION
Fixes #29901

**- What I did**
~Added digest information to the `/images` endpoint when a filter is used.~
Added digest information to the `/images` endpoint when filtering by tag. Additionally a tag is attached when filtering by digest


**- How I did it**
~Aggregate and store digests when filter matches a reference using `FamiliarName` as key (as it's done in the CLI)~
Checking the code deeper made me realize that Tags & Digests are stored within a dictionary as such their iteration order was unrealiable. The new approach utilized the `id` and keeps track of the last Tag & Digests encountered and if a match was made in the process and one or the other is missing, it uses the last tracked values.

**- How to verify it**
~I've added a integration test to go with the changes.~
Integration tests would be added according to the new format

Before:
```
$ docker images --filter="reference=busybox:*"  --digests
REPOSITORY          TAG                 DIGEST              IMAGE ID            CREATED             SIZE
busybox             latest              <none>              efe10ee6727f        2 weeks ago         1.13 MB
busybox             mytag               <none>              efe10ee6727f        2 weeks ago         1.13 MB
```

```
$ docker images --filter="reference=busybox@sha256:2605*"  --digests
REPOSITORY          TAG                 DIGEST              IMAGE ID            CREATED             SIZE
busybox             <none>              sha256:2605a2c4875ce5eb27a9f7403263190cd1af31e48a2044d400320548356251c4              efe10ee6727f        2 weeks ago         1.13 MB
```

After:
```
$ docker images --filter="reference=busybox:*"  --digests
REPOSITORY          TAG                 DIGEST                                                                    IMAGE ID            CREATED             SIZE
busybox             latest              sha256:2605a2c4875ce5eb27a9f7403263190cd1af31e48a2044d400320548356251c4   efe10ee6727f        2 weeks ago         1.13 MB
busybox             mytag               sha256:2605a2c4875ce5eb27a9f7403263190cd1af31e48a2044d400320548356251c4   efe10ee6727f        2 weeks ago         1.13 MB
```

```
$ docker images --filter="reference=busybox@sha256:2605*"  --digests
REPOSITORY          TAG                 DIGEST              IMAGE ID            CREATED             SIZE
busybox             latest              sha256:2605a2c4875ce5eb27a9f7403263190cd1af31e48a2044d400320548356251c4              efe10ee6727f        2 weeks ago         1.13 MB
```

**- Description for the changelog**
Fixes missing digest references when requesting images with a tag filter and missing tag names when filter reference was a digest.


**- A picture of a cute animal (not mandatory but encouraged)**
[Mia](http://i.imgur.com/HF8NMCO.jpg?1)
