### PR TITLE
seccomp: whitelist quotactl with CAP_SYS_ADMIN

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -557,6 +557,7 @@
 				"mount",
 				"name_to_handle_at",
 				"perf_event_open",
+				"quotactl",
 				"setdomainname",
 				"sethostname",
 				"setns",

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -488,6 +488,7 @@ func DefaultProfile() *types.Seccomp {
 				"mount",
 				"name_to_handle_at",
 				"perf_event_open",
+				"quotactl",
 				"setdomainname",
 				"sethostname",
 				"setns",


### PR DESCRIPTION
The quotactl syscall is being whitelisted in default seccomp profile,
gated by CAP_SYS_ADMIN.

Signed-off-by: Panagiotis Moustafellos <pmoust@elastic.co>

Fixes: #34444

