### PR TITLE
LCOW: Don't block export

### DIFF
--- a/daemon/export.go
+++ b/daemon/export.go
@@ -13,13 +13,13 @@ import (
 // ContainerExport writes the contents of the container to the given
 // writer. An error is returned if the container cannot be found.
 func (daemon *Daemon) ContainerExport(name string, out io.Writer) error {
-	if runtime.GOOS == "windows" {
-		return fmt.Errorf("the daemon on this platform does not support export of a container")
-	}
-
 	container, err := daemon.GetContainer(name)
 	if err != nil {
 		return err
+	}
+
+	if runtime.GOOS == "windows" && container.Platform == "windows" {
+		return fmt.Errorf("the daemon on this platform does not support exporting Windows containers")
 	}
 
 	data, err := daemon.containerExport(container)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@johnstep Allows work to continue on supporting export (it needs Akash's remote filesystem work). Just changes the condition under which the command is blocked currently.