### PR TITLE
LCOW: Additional flags for VHD boot

### DIFF
--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -331,7 +331,9 @@ func (clnt *client) createLinux(containerID string, checkpoint string, checkpoin
 
 	if lcowOpt.Config.ActualMode == opengcs.ModeActualVhdx {
 		configuration.HvRuntime = &hcsshim.HvRuntime{
-			ImagePath: lcowOpt.Config.Vhdx,
+			ImagePath:          lcowOpt.Config.Vhdx,
+			BootSource:         "Vhd",
+			WritableBootSource: true,
 		}
 	} else {
 		configuration.HvRuntime = &hcsshim.HvRuntime{


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@johnstep Turns out two additional flags are needed for VHD boot in the HCS call.