### PR TITLE
Unexport api.SecurityOpt and api.KeyValue

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -194,28 +194,28 @@ type Info struct {
 	SecurityOptions    []string
 }
 
-// KeyValue holds a key/value pair
-type KeyValue struct {
+// keyValue holds a key/value pair
+type keyValue struct {
 	Key, Value string
 }
 
-// SecurityOpt contains the name and options of a security option
-type SecurityOpt struct {
+// securityOpt contains the name and options of a security option
+type securityOpt struct {
 	Name    string
-	Options []KeyValue
+	Options []keyValue
 }
 
 // DecodeSecurityOptions decodes a security options string slice to a type safe
-// SecurityOpt
-func DecodeSecurityOptions(opts []string) ([]SecurityOpt, error) {
-	so := []SecurityOpt{}
+// securityOpt
+func DecodeSecurityOptions(opts []string) ([]securityOpt, error) {
+	so := []securityOpt{}
 	for _, opt := range opts {
 		// support output from a < 1.13 docker daemon
 		if !strings.Contains(opt, "=") {
-			so = append(so, SecurityOpt{Name: opt})
+			so = append(so, securityOpt{Name: opt})
 			continue
 		}
-		secopt := SecurityOpt{}
+		secopt := securityOpt{}
 		split := strings.Split(opt, ",")
 		for _, s := range split {
 			kv := strings.SplitN(s, "=", 2)
@@ -229,7 +229,7 @@ func DecodeSecurityOptions(opts []string) ([]SecurityOpt, error) {
 				secopt.Name = kv[1]
 				continue
 			}
-			secopt.Options = append(secopt.Options, KeyValue{Key: kv[0], Value: kv[1]})
+			secopt.Options = append(secopt.Options, keyValue{Key: kv[0], Value: kv[1]})
 		}
 		so = append(so, secopt)
 	}


### PR DESCRIPTION
These fields are only used by the `DecodeSecurityOptions` and don't have to be accessed directly.

Looks like these were added as part of https://github.com/moby/moby/pull/28504/commits/514ca09426e5d023753101ffa6ac3a21b0e0efb5 (https://github.com/moby/moby/pull/28504)

ping @runcom @cpuguy83 PTAL
