### PR TITLE
Misc fixes for devmapper

### DIFF
--- a/daemon/graphdriver/devmapper/device_setup.go
+++ b/daemon/graphdriver/devmapper/device_setup.go
@@ -173,33 +173,15 @@ func writeLVMConfig(root string, cfg directLVMConfig) error {
 
 func setupDirectLVM(cfg directLVMConfig) error {
 	lvmProfileDir := "/etc/lvm/profile"
+	binaries := []string{"pvcreate", "vgcreate", "lvcreate", "lvconvert", "lvchange", "thin_check"}
 
-	pvCreate, err := exec.LookPath("pvcreate")
-	if err != nil {
-		return errors.Wrap(err, "error looking up command `pvcreate` while setting up direct lvm")
+	for _, bin := range binaries {
+		if _, err := exec.LookPath(bin); err != nil {
+			return errors.Wrap(err, "error looking up command `"+bin+"` while setting up direct lvm")
+		}
 	}
 
-	vgCreate, err := exec.LookPath("vgcreate")
-	if err != nil {
-		return errors.Wrap(err, "error looking up command `vgcreate` while setting up direct lvm")
-	}
-
-	lvCreate, err := exec.LookPath("lvcreate")
-	if err != nil {
-		return errors.Wrap(err, "error looking up command `lvcreate` while setting up direct lvm")
-	}
-
-	lvConvert, err := exec.LookPath("lvconvert")
-	if err != nil {
-		return errors.Wrap(err, "error looking up command `lvconvert` while setting up direct lvm")
-	}
-
-	lvChange, err := exec.LookPath("lvchange")
-	if err != nil {
-		return errors.Wrap(err, "error looking up command `lvchange` while setting up direct lvm")
-	}
-
-	err = os.MkdirAll(lvmProfileDir, 0755)
+	err := os.MkdirAll(lvmProfileDir, 0755)
 	if err != nil {
 		return errors.Wrap(err, "error creating lvm profile directory")
 	}
@@ -219,26 +201,26 @@ func setupDirectLVM(cfg directLVMConfig) error {
 		cfg.ThinpMetaPercent = 1
 	}
 
-	out, err := exec.Command(pvCreate, "-f", cfg.Device).CombinedOutput()
+	out, err := exec.Command("pvcreate", "-f", cfg.Device).CombinedOutput()
 	if err != nil {
 		return errors.Wrap(err, string(out))
 	}
 
-	out, err = exec.Command(vgCreate, "docker", cfg.Device).CombinedOutput()
+	out, err = exec.Command("vgcreate", "docker", cfg.Device).CombinedOutput()
 	if err != nil {
 		return errors.Wrap(err, string(out))
 	}
 
-	out, err = exec.Command(lvCreate, "--wipesignatures", "y", "-n", "thinpool", "docker", "--extents", fmt.Sprintf("%d%%VG", cfg.ThinpPercent)).CombinedOutput()
+	out, err = exec.Command("lvcreate", "--wipesignatures", "y", "-n", "thinpool", "docker", "--extents", fmt.Sprintf("%d%%VG", cfg.ThinpPercent)).CombinedOutput()
 	if err != nil {
 		return errors.Wrap(err, string(out))
 	}
-	out, err = exec.Command(lvCreate, "--wipesignatures", "y", "-n", "thinpoolmeta", "docker", "--extents", fmt.Sprintf("%d%%VG", cfg.ThinpMetaPercent)).CombinedOutput()
+	out, err = exec.Command("lvcreate", "--wipesignatures", "y", "-n", "thinpoolmeta", "docker", "--extents", fmt.Sprintf("%d%%VG", cfg.ThinpMetaPercent)).CombinedOutput()
 	if err != nil {
 		return errors.Wrap(err, string(out))
 	}
 
-	out, err = exec.Command(lvConvert, "-y", "--zero", "n", "-c", "512K", "--thinpool", "docker/thinpool", "--poolmetadata", "docker/thinpoolmeta").CombinedOutput()
+	out, err = exec.Command("lvconvert", "-y", "--zero", "n", "-c", "512K", "--thinpool", "docker/thinpool", "--poolmetadata", "docker/thinpoolmeta").CombinedOutput()
 	if err != nil {
 		return errors.Wrap(err, string(out))
 	}
@@ -249,6 +231,6 @@ func setupDirectLVM(cfg directLVMConfig) error {
 		return errors.Wrap(err, "error writing docker thinp autoextend profile")
 	}
 
-	out, err = exec.Command(lvChange, "--metadataprofile", "docker-thinpool", "docker/thinpool").CombinedOutput()
+	out, err = exec.Command("lvchange", "--metadataprofile", "docker-thinpool", "docker/thinpool").CombinedOutput()
 	return errors.Wrap(err, string(out))
 }

--- a/daemon/graphdriver/devmapper/device_setup.go
+++ b/daemon/graphdriver/devmapper/device_setup.go
@@ -172,6 +172,8 @@ func writeLVMConfig(root string, cfg directLVMConfig) error {
 }
 
 func setupDirectLVM(cfg directLVMConfig) error {
+	lvmProfileDir := "/etc/lvm/profile"
+
 	pvCreate, err := exec.LookPath("pvcreate")
 	if err != nil {
 		return errors.Wrap(err, "error looking up command `pvcreate` while setting up direct lvm")
@@ -195,6 +197,11 @@ func setupDirectLVM(cfg directLVMConfig) error {
 	lvChange, err := exec.LookPath("lvchange")
 	if err != nil {
 		return errors.Wrap(err, "error looking up command `lvchange` while setting up direct lvm")
+	}
+
+	err = os.MkdirAll(lvmProfileDir, 0755)
+	if err != nil {
+		return errors.Wrap(err, "error creating lvm profile directory")
 	}
 
 	if cfg.AutoExtendPercent == 0 {
@@ -237,7 +244,7 @@ func setupDirectLVM(cfg directLVMConfig) error {
 	}
 
 	profile := fmt.Sprintf("activation{\nthin_pool_autoextend_threshold=%d\nthin_pool_autoextend_percent=%d\n}", cfg.AutoExtendThreshold, cfg.AutoExtendPercent)
-	err = ioutil.WriteFile("/etc/lvm/profile/docker-thinpool.profile", []byte(profile), 0600)
+	err = ioutil.WriteFile(lvmProfileDir+"/docker-thinpool.profile", []byte(profile), 0600)
 	if err != nil {
 		return errors.Wrap(err, "error writing docker thinp autoextend profile")
 	}

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1860,7 +1860,7 @@ func (devices *DeviceSet) initDevmapper(doInit bool) (retErr error) {
 
 	if devices.thinPoolDevice == "" {
 		if devices.metadataLoopFile != "" || devices.dataLoopFile != "" {
-			logrus.Warn("devmapper: Usage of loopback devices is strongly discouraged for production use. Please use `--storage-opt dm.thinpooldev` or use `man docker` to refer to dm.thinpooldev section.")
+			logrus.Warn("devmapper: Usage of loopback devices is strongly discouraged for production use. Please use `--storage-opt dm.thinpooldev` or use `man dockerd` to refer to dm.thinpooldev section.")
 		}
 	}
 


### PR DESCRIPTION
1. Add mkdir to devmapper autoconfiguration so it won't fail because of absent directory.
2. Refer to correct man page in dockerd warning message.
3. dm autosetup: add check for thin_check binary