### PR TITLE
Fix requests for docker host ending with slash

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -51,6 +51,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -219,9 +220,9 @@ func (cli *Client) getAPIPath(p string, query url.Values) string {
 	var apiPath string
 	if cli.version != "" {
 		v := strings.TrimPrefix(cli.version, "v")
-		apiPath = cli.basePath + "/v" + v + p
+		apiPath = path.Join(cli.basePath, "/v"+v+p)
 	} else {
-		apiPath = cli.basePath + p
+		apiPath = path.Join(cli.basePath, p)
 	}
 
 	u := &url.URL{

--- a/client/ping.go
+++ b/client/ping.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"path"
+
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
 )
@@ -8,7 +10,7 @@ import (
 // Ping pings the server and returns the value of the "Docker-Experimental", "OS-Type" & "API-Version" headers
 func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 	var ping types.Ping
-	req, err := cli.buildRequest("GET", cli.basePath+"/_ping", nil, nil)
+	req, err := cli.buildRequest("GET", path.Join(cli.basePath, "/_ping"), nil, nil)
 	if err != nil {
 		return ping, err
 	}


### PR DESCRIPTION
relates to https://github.com/docker-library/docker/issues/71

`DOCKER_HOST` ending with `/` would cause the first component of a request to be skipped. Resulting invalid `ping` results and skipping manually set version.

@dnephin @thaJeztah 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
