### PR TITLE
Exit if service config is loaded unsuccessfully on startup

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -198,7 +198,11 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 		cli.api.Accept(addr, ls...)
 	}
 
-	registryService := registry.NewService(cli.Config.ServiceOptions)
+	registryService, err := registry.NewService(cli.Config.ServiceOptions)
+	if err != nil {
+		return err
+	}
+
 	containerdRemote, err := libcontainerd.New(cli.getLibcontainerdRoot(), cli.getPlatformRemoteOptions()...)
 	if err != nil {
 		return err

--- a/daemon/reload_test.go
+++ b/daemon/reload_test.go
@@ -46,8 +46,9 @@ func TestDaemonReloadAllowNondistributableArtifacts(t *testing.T) {
 		configStore: &config.Config{},
 	}
 
+	var err error
 	// Initialize daemon with some registries.
-	daemon.RegistryService = registry.NewService(registry.ServiceOptions{
+	daemon.RegistryService, err = registry.NewService(registry.ServiceOptions{
 		AllowNondistributableArtifacts: []string{
 			"127.0.0.0/8",
 			"10.10.1.11:5000",
@@ -56,6 +57,9 @@ func TestDaemonReloadAllowNondistributableArtifacts(t *testing.T) {
 			"docker2.com", // This will be removed during reload.
 		},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	registries := []string{
 		"127.0.0.0/8",
@@ -98,7 +102,8 @@ func TestDaemonReloadAllowNondistributableArtifacts(t *testing.T) {
 
 func TestDaemonReloadMirrors(t *testing.T) {
 	daemon := &Daemon{}
-	daemon.RegistryService = registry.NewService(registry.ServiceOptions{
+	var err error
+	daemon.RegistryService, err = registry.NewService(registry.ServiceOptions{
 		InsecureRegistries: []string{},
 		Mirrors: []string{
 			"https://mirror.test1.com",
@@ -106,6 +111,9 @@ func TestDaemonReloadMirrors(t *testing.T) {
 			"https://mirror.test3.com", // this will be removed when reloading
 		},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	daemon.configStore = &config.Config{}
 
@@ -191,8 +199,9 @@ func TestDaemonReloadMirrors(t *testing.T) {
 
 func TestDaemonReloadInsecureRegistries(t *testing.T) {
 	daemon := &Daemon{}
+	var err error
 	// initialize daemon with existing insecure registries: "127.0.0.0/8", "10.10.1.11:5000", "10.10.1.22:5000"
-	daemon.RegistryService = registry.NewService(registry.ServiceOptions{
+	daemon.RegistryService, err = registry.NewService(registry.ServiceOptions{
 		InsecureRegistries: []string{
 			"127.0.0.0/8",
 			"10.10.1.11:5000",
@@ -201,6 +210,9 @@ func TestDaemonReloadInsecureRegistries(t *testing.T) {
 			"docker2.com", // this will be removed when reloading
 		},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	daemon.configStore = &config.Config{}
 

--- a/integration-cli/fixtures/plugin/plugin_linux.go
+++ b/integration-cli/fixtures/plugin/plugin_linux.go
@@ -71,9 +71,14 @@ func CreateInRegistry(ctx context.Context, repo string, auth *types.AuthConfig, 
 	}
 	defer tar.Close()
 
+	regService, err := registry.NewService(registry.ServiceOptions{V2Only: true})
+	if err != nil {
+		return err
+	}
+
 	managerConfig := plugin.ManagerConfig{
 		Store:           plugin.NewStore(),
-		RegistryService: registry.NewService(registry.ServiceOptions{V2Only: true}),
+		RegistryService: regService,
 		Root:            filepath.Join(tmpDir, "root"),
 		ExecRoot:        "/run/docker", // manager init fails if not set
 		Executor:        dummyExecutor{},

--- a/registry/config.go
+++ b/registry/config.go
@@ -60,7 +60,7 @@ var (
 	// not have the correct form
 	ErrInvalidRepositoryName = errors.New("Invalid repository name (ex: \"registry.domain.tld/myrepos\")")
 
-	emptyServiceConfig = newServiceConfig(ServiceOptions{})
+	emptyServiceConfig, _ = newServiceConfig(ServiceOptions{})
 )
 
 var (
@@ -71,7 +71,7 @@ var (
 var lookupIP = net.LookupIP
 
 // newServiceConfig returns a new instance of ServiceConfig
-func newServiceConfig(options ServiceOptions) *serviceConfig {
+func newServiceConfig(options ServiceOptions) (*serviceConfig, error) {
 	config := &serviceConfig{
 		ServiceConfig: registrytypes.ServiceConfig{
 			InsecureRegistryCIDRs: make([]*registrytypes.NetIPNet, 0),
@@ -81,12 +81,17 @@ func newServiceConfig(options ServiceOptions) *serviceConfig {
 		},
 		V2Only: options.V2Only,
 	}
+	if err := config.LoadAllowNondistributableArtifacts(options.AllowNondistributableArtifacts); err != nil {
+		return nil, err
+	}
+	if err := config.LoadMirrors(options.Mirrors); err != nil {
+		return nil, err
+	}
+	if err := config.LoadInsecureRegistries(options.InsecureRegistries); err != nil {
+		return nil, err
+	}
 
-	config.LoadAllowNondistributableArtifacts(options.AllowNondistributableArtifacts)
-	config.LoadMirrors(options.Mirrors)
-	config.LoadInsecureRegistries(options.InsecureRegistries)
-
-	return config
+	return config, nil
 }
 
 // LoadAllowNondistributableArtifacts loads allow-nondistributable-artifacts registries into config.

--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -175,7 +175,7 @@ func makePublicIndex() *registrytypes.IndexInfo {
 	return index
 }
 
-func makeServiceConfig(mirrors []string, insecureRegistries []string) *serviceConfig {
+func makeServiceConfig(mirrors []string, insecureRegistries []string) (*serviceConfig, error) {
 	options := ServiceOptions{
 		Mirrors:            mirrors,
 		InsecureRegistries: insecureRegistries,

--- a/registry/service.go
+++ b/registry/service.go
@@ -45,10 +45,10 @@ type DefaultService struct {
 
 // NewService returns a new instance of DefaultService ready to be
 // installed into an engine.
-func NewService(options ServiceOptions) *DefaultService {
-	return &DefaultService{
-		config: newServiceConfig(options),
-	}
+func NewService(options ServiceOptions) (*DefaultService, error) {
+	config, err := newServiceConfig(options)
+
+	return &DefaultService{config: config}, err
 }
 
 // ServiceConfig returns the public registry service configuration.

--- a/registry/service_v1_test.go
+++ b/registry/service_v1_test.go
@@ -3,7 +3,10 @@ package registry
 import "testing"
 
 func TestLookupV1Endpoints(t *testing.T) {
-	s := NewService(ServiceOptions{})
+	s, err := NewService(ServiceOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	cases := []struct {
 		hostname    string


### PR DESCRIPTION
**- What I did**

This PR closes #34476

In `registry/config.go` at `newServiceConfig` the error returned by `config.LoadMirrors` and `config.LoadInsecureRegistries` weren't checked and by that caused the service configurations error to be silently ignored.

**- How I did it**

Check whether `config.LoadMirrors`/`config.LoadInsecureRegistries` returns an error. If it does, the daemon will print it and exit.

**- How to verify it**

```
$ mkdir -p /etc/docker/ && echo '{"registry-mirrors": ["example.com:5000"]}' > /etc/docker/daemon.json
$ dockerd
```
Should exit and print:
```
invalid registry mirror configurations: invalid mirror: unsupported scheme "example.com" in "example.com:5000
```

**- Description for the changelog**

Fix #34476: invalid registry mirrors configuration isn't being silently ignored

**- A picture of a cute animal (not mandatory but encouraged)**

