### PR TITLE
client: compare with current version instead of default

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -267,7 +267,7 @@ func (cli *Client) NegotiateAPIVersionPing(p types.Ping) {
 	}
 
 	// if server version is lower than the maximum version supported by the Client, downgrade
-	if versions.LessThan(p.APIVersion, api.DefaultVersion) {
+	if versions.LessThan(p.APIVersion, cli.version) {
 		cli.version = p.APIVersion
 	}
 }


### PR DESCRIPTION
Per discussion in https://github.com/docker/docker-ce/pull/194#pullrequestreview-56231613

The change in behavior seems to happen when the daemon version is in between default and manually set client version.

@thaJeztah @andrewhsu 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>