### PR TITLE
Fixed `raw` mode splunk logger

### DIFF
--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -363,6 +364,11 @@ func (l *splunkLoggerJSON) Log(msg *logger.Message) error {
 }
 
 func (l *splunkLoggerRaw) Log(msg *logger.Message) error {
+	// empty or whitespace-only messages are not accepted by HEC
+	if strings.TrimSpace(string(msg.Line)) == "" {
+		return nil
+	}
+
 	message := l.createSplunkMessage(msg)
 
 	message.Event = string(append(l.prefix, msg.Line...))

--- a/daemon/logger/splunk/splunk_test.go
+++ b/daemon/logger/splunk/splunk_test.go
@@ -716,12 +716,19 @@ func TestRawFormatWithoutTag(t *testing.T) {
 	if err := loggerDriver.Log(&logger.Message{Line: []byte("notjson"), Source: "stdout", Timestamp: message2Time}); err != nil {
 		t.Fatal(err)
 	}
+	message3Time := time.Now()
+	if err := loggerDriver.Log(&logger.Message{Line: []byte(" "), Source: "stdout", Timestamp: message3Time}); err != nil {
+		t.Fatal(err)
+	}
 
 	err = loggerDriver.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	// message3 would have an empty or whitespace only string in the "event" field
+	// both of which are not acceptable to HEC
+	// thus here we must expect 2 messages, not 3
 	if len(hec.messages) != 2 {
 		t.Fatal("Expected two messages")
 	}


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/34749

**- What I did**
I tried to use the Splunk logger with the raw format without a tag. I noticed that my logs stopped appearing in Splunk, after an empty line was produced by my docker containers. Since the splunk log driver will repeatedly try to submit the invalid log event, no more logs will be accepted by Splunk.

Here's a minimal sample of my configuration:
```
docker run \
	--rm \
	-it \
	--log-driver splunk \
	--log-opt splunk-token=${SPLUNK_TOKEN} \
	--log-opt splunk-url=http://127.0.0.1:8088 \
	--log-opt splunk-format=raw \
	--log-opt tag="" \
	--hostname ${HOSTNAME} \
	alpine \
	/bin/sh -c "for i in \`seq 10\`; do echo \"hello world from docker \${i}\"; sleep 1; done; echo \"empty line will follow\"; echo \"\"; echo \"    \"; echo \"done\"; "
```

The first few `echo` commands will succeed, but the one with the empty or whitespace only lines will break the logging to Splunk.

**- How I did it**

First checked the behaviour of Splunk: Events with empty or whitespace-only event's are rejected by Splunk HEC. So I've added a check to the Splunk logger, that skips whitespace-only events in raw mode.

**- How to verify it**

See above. I've also extended the unit tests for the Splunk log driver

**- Description for the changelog**

Fixed raw mode Splunk logger when used without a tag