### PR TITLE
client to return imageNotFound error if API returns 404 status code

### DIFF
--- a/client/image_remove.go
+++ b/client/image_remove.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"net/http"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
@@ -21,6 +22,9 @@ func (cli *Client) ImageRemove(ctx context.Context, imageID string, options type
 
 	resp, err := cli.delete(ctx, "/images/"+imageID, query, nil)
 	if err != nil {
+		if resp.statusCode == http.StatusNotFound {
+			return nil, imageNotFoundError{imageID}
+		}
 		return nil, err
 	}
 

--- a/client/image_remove_test.go
+++ b/client/image_remove_test.go
@@ -24,6 +24,17 @@ func TestImageRemoveError(t *testing.T) {
 	}
 }
 
+func TestImageRemoveImageNotFound(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusNotFound, "Server error")),
+	}
+
+	_, err := client.ImageRemove(context.Background(), "unknown", types.ImageRemoveOptions{})
+	if err == nil || !IsErrNotFound(err) {
+		t.Fatalf("expected an imageNotFoundError error, got %v", err)
+	}
+}
+
 func TestImageRemove(t *testing.T) {
 	expectedURL := "/images/image_id"
 	removeCases := []struct {


### PR DESCRIPTION
This PR changes the client to return an imageNotFound error when the API returns a 404 status code. Part of work on docker/cli#394

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**- What I did**
The client now returns 'imageNotFoundError' error if the API returns status code 404.

**- How I did it**
- Used the error type imageNotFoundError in client/image_remove.go in response to 404 status code.
- Added a unit test for the behavior

**- How to verify it**
Run the unit tests

**- Description for the changelog**
Client returns an imageNotFound error if the API response was status code 404.

**- A picture of a cute animal (not mandatory but encouraged)**

