### PR TITLE
CPU hotplug integration in Docker

### DIFF
--- a/daemon/cpuhotplug.go
+++ b/daemon/cpuhotplug.go
@@ -1,0 +1,259 @@
+// +build linux
+
+package daemon
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/daemon/cpuhotplug"
+	"github.com/sirupsen/logrus"
+)
+
+const cpusetDir = "/sys/fs/cgroup/cpuset"
+
+type containerUpdate struct {
+	cparent string     // Cgroup parent to update
+	done    chan error // Channel for synch
+}
+
+type CpuHotPlug struct {
+	UdevChan chan struct{}        // Channel for  cpu events
+	ContChan chan containerUpdate // Channel for started containers
+}
+
+func (cpuhotplug *CpuHotPlug) Close() {
+	close(cpuhotplug.ContChan)
+}
+
+func (daemon *Daemon) updateRecCgroup(path, cpuset string) error {
+
+	file := filepath.Join(path, "cpuset.cpus")
+
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		//If the parent does not exist nothing to update
+		return nil
+	}
+
+	if err := ioutil.WriteFile(file, []byte(cpuset), 0777); err != nil {
+		logrus.Warnf("Error update cgroup in %s", file)
+		return err
+	}
+	entries, err := ioutil.ReadDir(path)
+
+	if err != nil {
+		logrus.Warnf("Error update recursively cgroup parent %s", err)
+	}
+
+	if entries == nil {
+		return nil
+	}
+
+	// We update recursively until we find that the directory belongs
+	// to a container or the cgroup parent branch is finshed
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+
+		// The directory belongs to a container.
+		// We don't update at this point in time the container.
+		if daemon.Exists(e.Name()) {
+			continue
+		}
+
+		if err := daemon.updateRecCgroup(filepath.Join(path, e.Name()), cpuset); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// updateParentCgroups updates the cgroup parent
+func (daemon *Daemon) updateParentCgroups(parent string) error {
+	cpuset, err := cpuhotplug.ReadCurrentCpuset()
+	if err != nil {
+		return err
+	}
+	//Default parent cgroup name is docker
+	if parent == "" {
+		parent = "docker"
+	}
+	logrus.Debugf("cpuhotplug: updated parent cgroup %s", parent)
+
+	return daemon.updateRecCgroup(filepath.Join(cpusetDir, parent), cpuset)
+}
+
+// updateContainerCpuset updates the cpuset of a container
+func (daemon *Daemon) updateContainerCpuset(id, cpuset string) error {
+	resources := container.Resources{
+		CpusetCpus: cpuset,
+	}
+	return daemon.containerd.UpdateResources(id, toContainerdResources(resources))
+}
+
+// syncUpdateParentCgroup synchronizes the update for the cgroup parent when a container
+// is started. When a container is started its cgroup parent needs to be update as well.
+// If the cgroup parent was already created but no containers were presented, it may not be
+// correctly updated.
+func (daemon *Daemon) syncUpdateParentCgroup(cparent string) error {
+	done := make(chan error, 1)
+	c := strings.Split(cparent, "/")[0]
+	daemon.cpuHotplug.ContChan <- containerUpdate{
+		cparent: c,
+		done:    done,
+	}
+	err := <-done
+	if err != nil {
+		logrus.Errorf("Cgroup parent error %s", err)
+	}
+
+	return err
+
+}
+
+// performCpuHotplug listens to the cpu events and update the cpuset accordingly
+func (daemon *Daemon) performCpuHotplug() {
+	//Enable CPU event filter
+	daemon.cpuHotplug.UdevChan = make(chan struct{})
+	cpuhotplug.ListenToCpuEvent(daemon.cpuHotplug.UdevChan)
+	logrus.Infof("Started cpuhotplug")
+
+	//Initialize channel for incoming started container
+	daemon.cpuHotplug.ContChan = make(chan containerUpdate)
+	var oldCgroup = " "
+
+	go func() {
+		for {
+			// Priority queue high to a started container over a cpu event
+			// High priority queue: started container
+			select {
+			case w := <-daemon.cpuHotplug.ContChan:
+				// if no cpu went online and we have already update in a
+				// previous iteration the cgroup parent tree
+				// we just skip it
+				if oldCgroup != w.cparent {
+					err := daemon.updateParentCgroups(w.cparent)
+					oldCgroup = w.cparent
+					w.done <- err
+				}
+				w.done <- nil
+			default:
+			}
+
+			// Check if a cpu went online or a container is started
+			select {
+			// Cgroup parent update for started container
+			case w := <-daemon.cpuHotplug.ContChan:
+				if oldCgroup != w.cparent {
+					err := daemon.updateParentCgroups(w.cparent)
+					oldCgroup = w.cparent
+					w.done <- err
+				}
+				w.done <- nil
+			// CPU events
+			case <-daemon.cpuHotplug.UdevChan:
+				daemon.updateCpusetContainers()
+				oldCgroup = " "
+			}
+		}
+	}()
+
+}
+
+// updateRestrictedCpuset updates the cpuset of a restricted container.
+func (daemon *Daemon) updateRestrictedCpuset(id, originalCpuset string) error {
+	//Read which cpus are online
+	currentCpusSet, err := cpuhotplug.ReadCurrentCpuset()
+	if err != nil {
+		return err
+	}
+
+	return daemon.updateContainerCpuset(id, cpuhotplug.NewCpusetRestrictedCont(currentCpusSet, originalCpuset))
+}
+
+// updateCpusetContainers updates all Docker containers and their cgroup
+// parent.
+func (daemon *Daemon) updateCpusetContainers() {
+
+	// List of cgroup parent to update
+	var listParentCgroup []string
+	for _, c := range daemon.containers.List() {
+
+		if !c.IsRunning() {
+			continue
+		}
+
+		containerJson, err := daemon.ContainerInspectCurrent(c.Name, false)
+		if err != nil {
+			continue
+		}
+		cgroupParent := containerJson.ContainerJSONBase.HostConfig.CgroupParent
+		// Find all the Parent cgroup of the container
+		// Avoid duplicate
+		// We just need the first directory then the cgroup parent tree will be
+		// recursively updated
+		s := strings.Split(cgroupParent, "/")[0]
+
+		found := false
+		// Check if the cgroup parent needs to be inserted
+		for _, e := range listParentCgroup {
+			if e == s {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			listParentCgroup = append(listParentCgroup, s)
+		}
+
+	}
+
+	// Update cgroup parent
+	for _, e := range listParentCgroup {
+		if err := daemon.updateParentCgroups(e); err != nil {
+			logrus.Errorf("Error %s updating cgroup parent %s", err, e)
+		}
+	}
+
+	// Update the running containers
+	for _, c := range daemon.containers.List() {
+
+		if !c.IsRunning() {
+			continue
+		}
+		//Get original cpuset
+		containerJson, err := daemon.ContainerInspectCurrent(c.Name, false)
+		if err != nil {
+			logrus.Warnf("A problem has occured with container %s: %s\n", err, c.ID)
+			continue
+		}
+
+		cpuset := containerJson.ContainerJSONBase.HostConfig.Resources.CpusetCpus
+
+		//Unrestricted container
+		if cpuset == "" {
+			updatedCpuset, err := cpuhotplug.ReadCurrentCpuset()
+			if err != nil {
+				logrus.Warnf("Container %s  err: %s", c.ID, err)
+			}
+			if err := daemon.updateContainerCpuset(c.ID, updatedCpuset); err == nil {
+				logrus.Debugf("Container %s updated succesfully", c.ID)
+			} else {
+				logrus.Warnf("Container %s  err: %s", c.ID, err)
+			}
+			continue
+		}
+
+		//Restricted container
+		if err := daemon.updateRestrictedCpuset(c.ID, cpuset); err == nil {
+			logrus.Debugf("Container %s updated succesfully", c.ID)
+		} else {
+			logrus.Warnf("Restricted container %s  err: %s", c.ID, err)
+		}
+	}
+}

--- a/daemon/cpuhotplug/README.md
+++ b/daemon/cpuhotplug/README.md
@@ -1,0 +1,42 @@
+# Docker Cpuhotplug extention
+
+Docker uses *cgroups* in order to achieve isolation and limits container resources.
+
+However, the Docker cpuset.cpus is not automatically updated when a cpu is set offline and online again. The goal of this docker extention is to update the cpuset of the docker daemon and each Docker container.
+
+A container is defined *restricted*, if it was started with the flag `--cpuset-cpus`, otherwise is called *unrestricted*. A restricted container mantains the initial cpuset restriction and it is update consequently.
+
+In linux system the updated cpuset can be find in `/sys/fs/cgroup/cpuset/cpuset.cpus` and it holds the information or the currently online cpus.
+The each cgroup and subcgroup has its own cpuset.cpus. *Cgroup parent* is a cgroup that contains another cgroup. Subcgroups can have only a subset or the entire subset of their cgroup parent cpuset.
+
+The docker daemon has an additional option `--exec-opt native.cgroupdriver`. The default value is *cgroupdriver* and the name structure looks like these in the following example.
+However, the cgroup manage could be handles also by *systemd* using this option. The name cgroup strcture is different from that used by the *cgroupdriver*.
+For a first prototype we just consider the default option. Hence, the cgroup are managed by the *cgroupdriver*.
+
+The default cgroup parent for docker is called *docker* and the its path is `/sys/fs/cgroup/cpuset/docker/cpuset.cpus`. Each container has a subfolder in `/sys/fs/cgroup/cpuset/docker/` that holds its own cpuset.
+
+Additionally, a container can create another cgroup parent with the option `--cgroup-parent string`. The cgroup-parent can be an entire path and each folder of the path has its own cpuset.
+
+Example
+```sh
+docker run -td s390x/ubuntu bash
+docker run -td  --cgroup-parent level1/level2 s390x/ubuntu bash
+```
+The cgroup structure looks like:
+
+```sh
+                /sys/fs/cgroup/cpuset/
+ DEFAULT                              cpuset.cpus
+    ____________  / ___________              \
+   |             /             |              \
+   |    /docker                |                /level1
+   |            cpuset.cpus    |                        cpuset.cpus
+   |        /                  |                              \
+   |       /                   |                               \
+   |  /7e2..a12                |                             /level2
+   |            cpuset.cpus    |                                    cpuset.cpus
+   |                           |                                        \
+   |___________________________|                                         \
+                                                                        /2f9..a45
+                                                                                  cpuset.cpus
+```

--- a/daemon/cpuhotplug/cpu_event_test.go
+++ b/daemon/cpuhotplug/cpu_event_test.go
@@ -1,0 +1,47 @@
+// +build linux
+package cpuhotplug
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+const numEvent = 15
+
+func TestListenToCpuEvent(t *testing.T) {
+
+	test := make(chan struct{})
+	done := make(chan struct{})
+	ListenToCpuEvent(test)
+
+	// Catch the cpu event
+	go func(done chan struct{}) {
+		i := numEvent - 1
+		for range test {
+			fmt.Printf("Waiting for %d events\n", i-1)
+			i--
+			if i == 0 {
+				done <- struct{}{}
+			}
+		}
+	}(done)
+
+	// Trigger the cpu events
+	go func() {
+		for i := 0; i < numEvent; i++ {
+			//trigger cpu events
+			if err := exec.Command("chcpu", "-d", "1").Run(); err != nil {
+				fmt.Printf("Error %d offnline cpu\n", err)
+			}
+			time.Sleep(100 * time.Millisecond)
+			if err := exec.Command("chcpu", "-e", " 1").Run(); err != nil {
+				fmt.Printf("Error %d online cpu\n", err)
+			}
+			fmt.Printf("CPU event %d\n", i)
+		}
+	}()
+	<-done
+	close(test)
+}

--- a/daemon/cpuhotplug/cpuhotplug.go
+++ b/daemon/cpuhotplug/cpuhotplug.go
@@ -1,0 +1,155 @@
+// Package cpuhotplug provieds methods to update cpuset of a restricted
+// container
+package cpuhotplug
+
+import (
+	"io/ioutil"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Path to the cpuset correctly update by the kernel
+const PathCpusetCpus = "/sys/fs/cgroup/cpuset/cpuset.cpus"
+
+// ReadCurrentCpuset reads the current cpuset.
+func ReadCurrentCpuset() (string, error) {
+	b, err := ioutil.ReadFile(PathCpusetCpus)
+	return strings.TrimSpace(string(b)), err
+}
+
+// getMaxCpuNumber retrieves the maximum number of possible cpus in the
+// system.
+func getMaxCpuNumber() int {
+
+	b, err := ioutil.ReadFile("/sys/devices/system/cpu/possible")
+	if err != nil {
+		logrus.Fatalf("%s", err)
+	}
+
+	split := strings.Split(strings.TrimSpace(string(b)), "-")
+
+	maxCpu, err := strconv.Atoi(split[1])
+	if err != nil {
+		return 1024
+	}
+	//It starts from 0
+	return maxCpu + 1
+}
+
+// cpusetToSlice converts the cpuset string into a slice of 0s and 1s.
+// A 0 indicates that the i-th cpus is offline, otherwise the cpu is online
+// represented by a 1.
+// The cpuset is represented by a string. A "-" stands for a continuous interval,
+// of online cpus, a "," for a discontinuous.
+// Example:
+//	max number of cpus:12
+//	cpuset 1-3,5-8n => [0 1 1 1 0 1 1 1 1 0 0 0]
+func cpusetToSlice(cpuset string) []int {
+	cpu := make([]int, getMaxCpuNumber())
+	for _, s := range strings.Split(cpuset, ",") {
+		arr := strings.Split(s, "-")
+		if len(arr) == 1 {
+			// single cpu
+			i, _ := strconv.Atoi(s)
+			cpu[i] = 1
+			continue
+		}
+		// cpu range  2-4
+		a, _ := strconv.Atoi(arr[0])
+		b, _ := strconv.Atoi(arr[1])
+		for i := a; i <= b; i++ {
+			cpu[i] = 1
+		}
+	}
+	return cpu
+}
+
+// sliceToString converts a slice into a string for the cpuset.
+// See comment for cpusetToSlice.
+func sliceToString(cpu []int) string {
+	// [0, 1, 1, 1, 0, 1, 0] => 1-3,5
+	var res string
+	for i := range cpu {
+		switch {
+		case cpu[i] == 0: // ignore if cpu is not set
+		case i == 0 && cpu[i+1] == 0: // ^ x 0
+			res += strconv.Itoa(i) + ","
+		case i == 0 && cpu[i+1] == 1: // ^ x 1
+			res += strconv.Itoa(i)
+		case cpu[i-1] == 0 && cpu[i+1] == 0: // 0 x 0
+			res += strconv.Itoa(i) + ","
+		case cpu[i-1] == 0 && cpu[i+1] == 1: // 0 x 1
+			res += strconv.Itoa(i)
+		case cpu[i-1] == 1 && cpu[i+1] == 0: // 1 x 0
+			res += "-" + strconv.Itoa(i) + ","
+		case cpu[i-1] == 1 && cpu[i+1] == 1: // 1 x 1
+
+		default:
+			logrus.Debugf("Error in parsing cpu %d res: %s", i, res)
+			for _, c := range cpu {
+				logrus.Debugf("CPU:%d", c)
+			}
+		}
+	}
+	res = strings.TrimRight(res, ",") // remove trailing ,
+	return res
+}
+
+// NewCpusetRestrictedCont merges the current cpuset according with the container
+// cpuset restrictions.
+func NewCpusetRestrictedCont(currentCpusset, containerCpuset string) string {
+	currSlice := cpusetToSlice(currentCpusset)
+	contSlice := cpusetToSlice(containerCpuset)
+
+	// merge
+	//  currSlice	    contSlice	       new
+	// a)	0		0		0
+	// b)	0		1		0
+	// c)	1		0		0
+	// d)	1		1		1
+	for i := range currSlice {
+		// b case
+		if currSlice[i] == 0 && contSlice[i] == 1 {
+			contSlice[i] = 0
+		}
+	}
+	return sliceToString(contSlice)
+}
+
+// ListenToCpuEvent triggers the channel ch when a online
+// cpu event occurs
+func ListenToCpuEvent(ch chan struct{}) {
+
+	//udevam command monitors the cpu events
+	//stdbuf avoids the buffering of the output stream of udevadm command
+	cmd := exec.Command("stdbuf", "-o0", "-i0", "udevadm", "monitor", "--subsystem-match=cpu", "--kernel")
+	stdout, err := cmd.StdoutPipe()
+	buf := make([]byte, 10000)
+
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	// Start the monitor for cpu events
+	go func() {
+		if err := cmd.Start(); err != nil {
+			logrus.Fatal(err)
+		}
+	}()
+
+	// Filter the output to catch the cpu event and trigger ch
+	go func() {
+		for {
+			if _, err := stdout.Read(buf); err != nil {
+				break
+			}
+			event := string(buf)
+			if strings.Contains(event, "online") {
+				ch <- struct{}{}
+			}
+		}
+	}()
+
+}

--- a/daemon/cpuhotplug/cpuhotplug_test.go
+++ b/daemon/cpuhotplug/cpuhotplug_test.go
@@ -1,0 +1,45 @@
+// +build linux
+package cpuhotplug
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestNewCpuset(t *testing.T) {
+
+	tables := []struct {
+		currentCpusset  string
+		containerCpuset string
+		expectedResult  string
+	}{
+		{"0-5", "0-5", "0-5"},
+		{"1,3", "3", "3"},
+		{"1,3,5", "2,4", ""},
+		{"1-3,5-8", "0-9", "1-3,5-8"},
+		{"1", "9", ""},
+		{"0-6", "1,3,5", "1,3,5"},
+		{"0-3,5-7,9-13", "0-3,5-7,9-13", "0-3,5-7,9-13"},
+		{"0,2-4", "0-2", "0,2"},
+		{"0-3", "0-3", "0-3"},
+	}
+	maxCpu := getMaxCpuNumber() - 1
+	for _, table := range tables {
+		var cpusetMax, contMax int
+		tmp1 := strings.Split(strings.TrimSpace(string(table.currentCpusset)), "-")
+		tmp2 := strings.Split(strings.TrimSpace(string(table.containerCpuset)), "-")
+		split1 := strings.Split(tmp1[len(tmp1)-1], ",")
+		split2 := strings.Split(tmp2[len(tmp2)-1], ",")
+		cpusetMax, _ = strconv.Atoi(split1[len(split1)-1])
+		contMax, _ = strconv.Atoi(split2[len(split2)-1])
+
+		if cpusetMax >= maxCpu || contMax >= maxCpu {
+			continue
+		}
+		result := NewCpusetRestrictedCont(table.currentCpusset, table.containerCpuset)
+		if result != table.expectedResult {
+			t.Errorf("NewCpuset of (%s+%s) was incorrect, got: %s, want: %s.", table.currentCpusset, table.containerCpuset, result, table.expectedResult)
+		}
+	}
+}

--- a/daemon/cpuhotplug_unsupported.go
+++ b/daemon/cpuhotplug_unsupported.go
@@ -1,0 +1,18 @@
+// +build !linux
+
+package daemon
+
+func (cpuhotplug *CpuHotPlug) Close() {
+}
+
+func (daemon *Daemon) updateRecCgroup(path, cpuset string) error {
+	return nil
+}
+
+func (daemon *Daemon) updateParentCgroups(parent string) error {
+	return nil
+}
+
+func (daemon *Daemon) updateCpusetContainers() {
+
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -123,6 +123,8 @@ type Daemon struct {
 	pruneRunning     int32
 	hosts            map[string]bool // hosts stores the addresses the daemon is listening on
 	startupDone      chan struct{}
+
+	cpuHotplug	 CpuHotPlug
 }
 
 // StoreHosts stores the addresses the daemon is listening on
@@ -833,6 +835,7 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 		"graphdriver(s)": gd,
 	}).Info("Docker daemon")
 
+	d.performCpuHotplug()
 	return d, nil
 }
 
@@ -944,6 +947,10 @@ func (daemon *Daemon) Shutdown() error {
 	if err := daemon.cleanupMounts(); err != nil {
 		return err
 	}
+
+	//Close the channel
+	logrus.Debugf("Closing channel for cpuhotplug")
+	daemon.cpuHotplug.Close()
 
 	return nil
 }

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -95,6 +95,11 @@ func (daemon *Daemon) containerStart(container *container.Container, checkpoint 
 	container.Lock()
 	defer container.Unlock()
 
+	// Update parent cgroup
+	if err = daemon.syncUpdateParentCgroup(container.HostConfig.CgroupParent); err != nil {
+		return err
+	}
+
 	if resetRestartManager && container.Running { // skip this check if already in restarting step and resetRestartManager==false
 		return nil
 	}


### PR DESCRIPTION
In some virtual environments (and some physical environments), it is common to add CPUs on the fly. This is true for s390x for density reasons, but also is a topic when trying to increase resource utilization on x86.

Today, cgroups does not react to environmental changes when CPUs are added to a system. From a cgroups perspective the kernel folks claim they don't know what the right reaction could be.
However, Docker as a user of cgroups has got that insight and knows, whether containers are restricted to specific CPUs, or are started without any CPU constraints.

This PR allows to hotplug new CPUs and make them available for already-running and new containers.

It resolves various issues like:
  - https://github.com/moby/moby/issues/27453
  - https://github.com/opencontainers/runc/issues/1119
and some others dealing with this problem.

The extention can be used with the flags *--cgroup-parent* and *--cpuset-cpus*.
With the flag *--cgroup-parent "level1/level2"* the cgroup structure looks like:
```
+---------------------------cgroup-parent -----------------------------+
|     +-----------------+          +-----------------+                 |
|     | docker          |          |   level1        |                 |
|     |                 |          |                 |                 |
|     +-----------+-----+          +--+--------------+----+            |
|     |           |                   |                   |            |
|     |           |                   |                   |            |
|     |           |                   |          +--------v--------+   |
|     |           |                   |          |   level2        |   |
|     |           |                   |          |                 |   |
|     |           |                   |          +-----------------+   |
+----------------------------------------------------------------------+
      |           |                   |               |          |
  +---v---+  +----v--+            +---v---+       +---v---+  +---v---+
  |       |  |       |            |       |       |       |  |       |
  |       |  |       |            |       |       |       |  |       |     containers
  |       |  |       |            |       |       |       |  |       |
  |       |  |       |            |       |       |       |  |       |
  +-------+  +-------+            +-------+       +-------+  +-------+

```

The code has been tested on a s390 and x86 Ubuntu 16.10 VM guest with 4 virtual cpus.

This PR is fully functional and tested code (on s390x and x86 platforms), but will probably have to get agreement on the design first. A couple of alternatives have been looked at (using jochenvg/go-udev, but that does not work when linking statically; having a standalone daemon that talks to dockerd;
having a standalone daemon that acts without dockerd's awareness) and this appears to be the most desireable approach.

Signed-off-by: Alice Frosi <alice@linux.vnet.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added update of cgroup-parent and container cgroups when a cpu is hotplugged
**- How I did it**
A routine listens to CPU online events and triggers containers' cgroups and containers updates.

The *cpuhotplug routine* is triggered when a cpu online event occurs
```
               +
               | start
               +--------------------------+
               |                          |
       +-------v------+          +--------v-----+
       |              |          |              |
       |              |          |              |
       |  Docker      |    +-----+  cpuhotplug  |
       |  daemon      |    |     |  routine    <-----------+
       |              |    |     |              |          |
       |              |  update  |              |          |
       +--------------+  running +-------+------+          |
                         containers      | start           |
+-----+ +-----+ +-----+    |             |                 |
|     | |     | |     |    |      +------v-----------+-----+
|cont | |cont | |cont | <--+      |  udevam monitor  |
|     | |     | |     |           |                  | <----+  CPU online
+-----+ +-----+ +-----+           +------------------+         events
```

and when a new container is started:
```
docker run+---------------+          +---------------+
new cont  |               |  new cont|               |
          |               |          |               |
  +------->  Docker       +---------->  cpuhotplug   |
          |  daemon       |     +----+  routine      |
          |               |     |    |               |
          |               |     |    |               |
          +---------------+     |    +---------------+
                             update cgroup
                             parent of new cont
       +-----------+   +--------v---+
       |not default|   |docker      |
       +----+------+   +---+--------+
            |              |
            |              |
            |              |
         +--v--+         +-v---+
         |     |         | new |
         | cont|         |cont |
         |     |         |     |
         +-----+         +-----+
```
**- How to verify it**
Execute the following commands

```sh
docker run -td ubuntu bash
docker run -td  --cgroup-parent level1/level2 --cpuset-cpus 0-2  ubuntu bash
chcpu -d 1
cat $(find /sys/fs/cgroup/cpuset/docker | grep cpuset.cpus)
cat $(find /sys/fs/cgroup/cpuset/level1 | grep cpuset.cpus)
chcpu -e 1
cat $(find /sys/fs/cgroup/cpuset/docker | grep cpuset.cpus)
cat $(find /sys/fs/cgroup/cpuset/level1 | grep cpuset.cpus)
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Dynamically adapt cgroups in case of CPU hotplug events.

**- A picture of a cute animal (not mandatory but encouraged)**

