### PR TITLE
Add "slot" label to task containers

### DIFF
--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -232,6 +232,11 @@ func (c *containerConfig) labels() map[string]string {
 		labels = make(map[string]string)
 	)
 
+	if c.task.Slot > 0 {
+		// Tasks for services in "global" mode do not use slots as part of their name
+		system["task.slot"] = strconv.FormatUint(c.task.Slot, 10)
+	}
+
 	// base labels are those defined in the spec.
 	for k, v := range c.spec().Labels {
 		labels[k] = v

--- a/daemon/cluster/executor/container/container_test.go
+++ b/daemon/cluster/executor/container/container_test.go
@@ -1,0 +1,104 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainerLabels(t *testing.T) {
+	c := &containerConfig{
+		task: &api.Task{
+			ID: "real-task.id",
+			Spec: api.TaskSpec{
+				Runtime: &api.TaskSpec_Container{
+					Container: &api.ContainerSpec{
+						Labels: map[string]string{
+							"com.docker.swarm.task":         "user-specified-task",
+							"com.docker.swarm.task.id":      "user-specified-task.id",
+							"com.docker.swarm.task.name":    "user-specified-task.name",
+							"com.docker.swarm.task.slot":    "user-specified-task.slot",
+							"com.docker.swarm.node.id":      "user-specified-node.id",
+							"com.docker.swarm.service.id":   "user-specified-service.id",
+							"com.docker.swarm.service.name": "user-specified-service.name",
+							"this-is-a-user-label":          "this is a user label's value",
+						},
+					},
+				},
+			},
+			ServiceID: "real-service.id",
+			Slot:      123,
+			NodeID:    "real-node.id",
+			Annotations: api.Annotations{
+				Name: "real-service.name.123.real-task.id",
+			},
+			ServiceAnnotations: api.Annotations{
+				Name: "real-service.name",
+			},
+		},
+	}
+
+	expected := map[string]string{
+		"com.docker.swarm.task":         "",
+		"com.docker.swarm.task.id":      "real-task.id",
+		"com.docker.swarm.task.name":    "real-service.name.123.real-task.id",
+		"com.docker.swarm.task.slot":    "123",
+		"com.docker.swarm.node.id":      "real-node.id",
+		"com.docker.swarm.service.id":   "real-service.id",
+		"com.docker.swarm.service.name": "real-service.name",
+		"this-is-a-user-label":          "this is a user label's value",
+	}
+
+	labels := c.labels()
+	assert.Len(t, labels, 8)
+	assert.Equal(t, expected, labels)
+}
+
+func TestContainerLabelsGlobalService(t *testing.T) {
+	c := &containerConfig{
+		task: &api.Task{
+			ID: "real-task.id",
+			Spec: api.TaskSpec{
+				Runtime: &api.TaskSpec_Container{
+					Container: &api.ContainerSpec{
+						Labels: map[string]string{
+							"com.docker.swarm.task":         "user-specified-task",
+							"com.docker.swarm.task.id":      "user-specified-task.id",
+							"com.docker.swarm.task.name":    "user-specified-task.name",
+							"com.docker.swarm.task.slot":    "user-specified-task.slot",
+							"com.docker.swarm.node.id":      "user-specified-node.id",
+							"com.docker.swarm.service.id":   "user-specified-service.id",
+							"com.docker.swarm.service.name": "user-specified-service.name",
+							"this-is-a-user-label":          "this is a user label's value",
+						},
+					},
+				},
+			},
+			ServiceID: "real-service.id",
+			Slot:      0,
+			NodeID:    "real-node.id",
+			Annotations: api.Annotations{
+				Name: "real-service.name.real-task.id",
+			},
+			ServiceAnnotations: api.Annotations{
+				Name: "real-service.name",
+			},
+		},
+	}
+
+	expected := map[string]string{
+		"com.docker.swarm.task":         "",
+		"com.docker.swarm.task.id":      "real-task.id",
+		"com.docker.swarm.task.name":    "real-service.name.real-task.id",
+		"com.docker.swarm.task.slot":    "user-specified-task.slot",
+		"com.docker.swarm.node.id":      "real-node.id",
+		"com.docker.swarm.service.id":   "real-service.id",
+		"com.docker.swarm.service.name": "real-service.name",
+		"this-is-a-user-label":          "this is a user label's value",
+	}
+
+	labels := c.labels()
+	assert.Len(t, labels, 8)
+	assert.Equal(t, expected, labels)
+}


### PR DESCRIPTION
Relates to https://github.com/moby/moby/issues/28806 (https://github.com/moby/moby/issues/28806#issuecomment-322743077), and slightly related to https://github.com/moby/moby/issues/25365, https://github.com/moby/moby/issues/34658

Task names consist of three elements;

- Service name
- Slot number
- Task ID

Currently, "Service name" and "Task ID" are stored as metadata (labels)
on the container (`com.docker.swarm.service.name`, `com.docker.swarm.task.id`),
however Slot number is not.

This patch adds a new `com.docker.swarm.task.slot` label to containers,
to provide the missing information.


**- How to verify it**

Run the unit test;

```bash
$ make TESTDIRS='github.com/docker/docker/daemon/cluster/executor/container' test-unit
```

Create a service and verify that the `com.docker.swarm.task.slot` label is set:

```bash
$ docker service create --name test --replicas=2 nginx:alpine
$ docker service update --container-label-add foo=bar test
$ docker inspect --format '{{json .Config.Labels}}' $(docker ps -aq)

{"com.docker.swarm.node.id":"uotlie6hcl04lte3uz57y0f7s","com.docker.swarm.service.id":"p5ix2vx5rzvt1sj89oib57q8z","com.docker.swarm.service.name":"test","com.docker.swarm.task":"","com.docker.swarm.task.id":"2z8fu2grp7gczo8izvxnq26bq","com.docker.swarm.task.name":"test.1.2z8fu2grp7gczo8izvxnq26bq","com.docker.swarm.task.slot":"1","foo":"bar"}
{"com.docker.swarm.node.id":"uotlie6hcl04lte3uz57y0f7s","com.docker.swarm.service.id":"p5ix2vx5rzvt1sj89oib57q8z","com.docker.swarm.service.name":"test","com.docker.swarm.task":"","com.docker.swarm.task.id":"n14w5a2l4wgag80aw3zs6m0xe","com.docker.swarm.task.name":"test.2.n14w5a2l4wgag80aw3zs6m0xe","com.docker.swarm.task.slot":"2","foo":"bar"}
{"com.docker.swarm.node.id":"uotlie6hcl04lte3uz57y0f7s","com.docker.swarm.service.id":"p5ix2vx5rzvt1sj89oib57q8z","com.docker.swarm.service.name":"test","com.docker.swarm.task":"","com.docker.swarm.task.id":"hkntjorbtippjw0j72d335vxa","com.docker.swarm.task.name":"test.1.hkntjorbtippjw0j72d335vxa","com.docker.swarm.task.slot":"1"}
{"com.docker.swarm.node.id":"uotlie6hcl04lte3uz57y0f7s","com.docker.swarm.service.id":"p5ix2vx5rzvt1sj89oib57q8z","com.docker.swarm.service.name":"test","com.docker.swarm.task":"","com.docker.swarm.task.id":"694ndvyp8s3vo1zz3avk5mkmb","com.docker.swarm.task.name":"test.2.694ndvyp8s3vo1zz3avk5mkmb","com.docker.swarm.task.slot":"2"}
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

    Add `com.docker.swarm.task.slot` label to tasks, containing the task's slot
