### PR TITLE
Fix make test-unit printing deprecation warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ test-integration: build ## run the integration tests
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary test-integration
 
 test-unit: build ## run the unit tests
-	$(DOCKER_RUN_DOCKER) hack/make.sh test-unit
+	$(DOCKER_RUN_DOCKER) hack/test/unit
 
 tgz: build ## build the archives (.zip on windows and .tgz\notherwise) containing the binaries
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary binary cross tgz


### PR DESCRIPTION
Commit https://github.com/moby/moby/commit/1fb615599a83f41b449529df24f7e833c727e0ed (https://github.com/moby/moby/pull/33987) moved the unit tests out
of `hack/make.sh`, however the Makefile still used the old path, resulting
in a warning being printed when the unit tests were run:

    ---> Making bundle: test-unit (in bundles/17.06.0-dev/test-unit)
    DEPRECATED: use hack/test/unit instead of hack/make.sh test-unit

This patch updates the Makefile to use the new command.

**- How to verify it**

Run a unit test, and check that no warning is printed, e.g.:

```bash
$ make TESTDIRS='github.com/docker/docker/daemon/cluster/executor' test-unit
```

**- Description for the changelog**

    Fix deprecation warning being printed when unit tests are run
