### PR TITLE
devicemapper: protect mounts against volume leaks

### DIFF
--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -41,7 +41,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 
-	if err := mount.MakePrivate(home); err != nil {
+	if err := mount.MakeUnbindable(home); err != nil {
 		return nil, err
 	}
 

--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -154,6 +154,10 @@ func DefaultLinuxSpec() specs.Spec {
 			{Type: "pid"},
 			{Type: "ipc"},
 		},
+		// Always use MS_PRIVATE for rootfs propagation to make sure that we
+		// don't leak any MS_UNBINDABLE mounts into the container's namespace
+		// while its resolving volume bindmounts.
+		RootfsPropagation: "private",
 		// Devices implicitly contains the following devices:
 		// null, zero, full, random, urandom, tty, console, and ptmx.
 		// ptmx is a bind-mount or symlink of the container's ptmx.


### PR DESCRIPTION
This is necessary to make sure that setups which include things like `-v
/:/rootfs` won't accidentally include the libdm mounts inside
/var/lib/docker. libdm does not react well to operations on a device
which has live mounts, and leaking mounts to other containers easily
will cause many issues.

By default, runc uses MS_SHARED as the rootfsPropagation, which can
exacerbate problems with mountpoint leaks (the recursive relabeling will
cause all MS_UNBINDABLE mounts to become MS_SHARED). This is necessary
to ensure that libdm mounts don't leak into containers that have
bindmounts containing /var/lib/docker.

In addition, make the daemonRepo (/var/lib/docker/containers)
MS_UNBINDABLE for similar reasons, to avoid /dev/shm mounts from being
leaked into containers.

You can reproduce this issue by doing something like this on a `-s devicemapper`
box:

```
% docker run -d --name testA busybox top
% docker run -d --name testB -v /var/lib/docker:/docker busybox top
% docker rm -f testA
Error response from daemon: Driver devicemapper failed to remove root filesystem 8f3f1a40cda5f464839f356efa8c48447afc3408688921475c353e4ea08d0d58: failed to remove device cf0aadfb11388690d91af3bdb16634c38e24951266b1939aebe7d7cdab08b4c4: devicemapper: Error running RemoveDevice dm_task_run failed
```

I"ve added a test for this too.

[![Cute by Behzad No](https://farm8.staticflickr.com/7145/6752966059_4a6cba753d_b.jpg)](https://flic.kr/p/bhJHxi)

###### [Cute](https://flic.kr/p/bhJHxi) by [Behzad No](https://www.flickr.com/photos/behzad_noorifard/).

Signed-off-by: Aleksa Sarai <asarai@suse.de>