### PR TITLE
Add myself to CODEOWNERS for integration suite

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,8 @@ daemon/graphdriver/windows/**           @johnstep @jhowardmsft
 daemon/logger/awslogs/**                @samuelkarp  
 hack/**                                 @dnephin @tianon
 hack/integration-cli-on-swarm/**        @AkihiroSuda
+integration-cli/**                      @dnephin @vdemeester
+integration/**                          @dnephin @vdemeester
 pkg/testutil/**                         @dnephin
 plugin/**                               @cpuguy83
 project/**                              @thaJeztah


### PR DESCRIPTION
Adding myself to CODEOWNERS for `integration[-cli]` so that I can point people at the new suite.

@vdemeester do you have any interest in being added to these as well? I don't want to flood you with notifications.