### PR TITLE
Update Dockerfiles to use Debian Stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN apt-get update && apt-get install -y \
 	less \
 	libapparmor-dev \
 	libcap-dev \
+	libdevmapper-dev \
 	libnl-3-dev \
 	libprotobuf-c0-dev \
 	libprotobuf-dev \
@@ -75,22 +76,6 @@ RUN apt-get update && apt-get install -y \
 	zip \
 	--no-install-recommends \
 	&& pip install awscli==1.10.15
-
-# Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.168
-RUN mkdir -p /usr/local/lvm2 \
-	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
-		| tar -xzC /usr/local/lvm2 --strip-components=1
-
-# Compile and install (only the needed library)
-RUN cd /usr/local/lvm2 \
-	&& ./configure \
-		--build="$(gcc -print-multiarch)" \
-		--enable-static_link \
-		--enable-pkgconfig \
-		--enable-udev_sync \
-	&& make -C include \
-	&& make -C libdm install_device-mapper
 
 # Install seccomp: the version shipped upstream is too old
 ENV SECCOMP_VERSION 2.3.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,9 +149,6 @@ RUN set -x \
 # Get the "docker-py" source so we can run their integration tests
 ENV DOCKER_PY_COMMIT a962578e515185cf06506050b2200c0b81aa84ef
 # To run integration tests docker-pycreds is required.
-# Before running the integration tests conftest.py is
-# loaded which results in loads auth.py that
-# imports the docker-pycreds module.
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,11 +63,14 @@ RUN apt-get update && apt-get install -y \
 	pkg-config \
 	protobuf-compiler \
 	protobuf-c-compiler \
+	python-backports.ssl-match-hostname \
 	python-dev \
 	python-mock \
 	python-pip \
+	python-requests \
 	python-setuptools \
 	python-websocket \
+	python-wheel \
 	tar \
 	thin-provisioning-tools \
 	vim \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM debian:jessie
+FROM debian:stretch
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org
@@ -54,8 +54,9 @@ RUN apt-get update && apt-get install -y \
 	libnl-3-dev \
 	libprotobuf-c0-dev \
 	libprotobuf-dev \
-	libsystemd-journal-dev \
+	libsystemd-dev \
 	libtool \
+	libudev-dev \
 	mercurial \
 	net-tools \
 	pkg-config \
@@ -64,8 +65,10 @@ RUN apt-get update && apt-get install -y \
 	python-dev \
 	python-mock \
 	python-pip \
+	python-setuptools \
 	python-websocket \
 	tar \
+	thin-provisioning-tools \
 	vim \
 	vim-common \
 	xfsprogs \
@@ -85,6 +88,7 @@ RUN cd /usr/local/lvm2 \
 		--build="$(gcc -print-multiarch)" \
 		--enable-static_link \
 		--enable-pkgconfig \
+		--enable-udev_sync \
 	&& make -C include \
 	&& make -C libdm install_device-mapper
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -44,6 +44,7 @@ RUN apt-get update && apt-get install -y \
 	less \
 	libapparmor-dev \
 	libcap-dev \
+	libdevmapper-dev \
 	libnl-3-dev \
 	libprotobuf-c0-dev \
 	libprotobuf-dev \
@@ -67,22 +68,6 @@ RUN apt-get update && apt-get install -y \
 	xfsprogs \
 	zip \
 	--no-install-recommends
-
-# Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.168
-RUN mkdir -p /usr/local/lvm2 \
-	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
-		| tar -xzC /usr/local/lvm2 --strip-components=1
-
-# Compile and install (only the needed library)
-RUN cd /usr/local/lvm2 \
-	&& ./configure \
-		--build="$(gcc -print-multiarch)" \
-		--enable-static_link \
-		--enable-pkgconfig \
-		--enable-udev_sync \
-	&& make -C include \
-	&& make -C libdm install_device-mapper
 
 # Install seccomp: the version shipped upstream is too old
 ENV SECCOMP_VERSION 2.3.2

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -56,11 +56,14 @@ RUN apt-get update && apt-get install -y \
 	pkg-config \
 	protobuf-compiler \
 	protobuf-c-compiler \
+	python-backports.ssl-match-hostname \
 	python-dev \
 	python-mock \
 	python-pip \
+	python-requests \
 	python-setuptools \
 	python-websocket \
+	python-wheel \
 	tar \
 	thin-provisioning-tools \
 	vim \
@@ -128,7 +131,6 @@ ENV DOCKER_PY_COMMIT a962578e515185cf06506050b2200c0b81aa84ef
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \
-	&& pip install wheel \
 	&& pip install docker-pycreds==0.2.1 \
 	&& pip install -r test-requirements.txt
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -15,14 +15,20 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM aarch64/ubuntu:xenial
+FROM arm64v8/debian:stretch
+
+# allow replacing httpredir or deb mirror
+ARG APT_MIRROR=deb.debian.org
+RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \
 	apparmor \
+	apt-utils \
 	aufs-tools \
 	automake \
 	bash-completion \
+	bsdmainutils \
 	btrfs-tools \
 	build-essential \
 	cmake \
@@ -32,26 +38,34 @@ RUN apt-get update && apt-get install -y \
 	g++ \
 	gcc \
 	git \
+	golang \
 	iptables \
 	jq \
+	less \
 	libapparmor-dev \
-	libc6-dev \
 	libcap-dev \
+	libnl-3-dev \
+	libprotobuf-c0-dev \
+	libprotobuf-dev \
 	libsystemd-dev \
-	libyaml-dev \
+	libtool \
+	libudev-dev \
 	mercurial \
 	net-tools \
-	parallel \
 	pkg-config \
+	protobuf-compiler \
+	protobuf-c-compiler \
 	python-dev \
 	python-mock \
 	python-pip \
 	python-setuptools \
 	python-websocket \
-	golang-go \
-	iproute2 \
-	iputils-ping \
+	tar \
+	thin-provisioning-tools \
+	vim \
 	vim-common \
+	xfsprogs \
+	zip \
 	--no-install-recommends
 
 # Get lvm2 sources to build statically linked devmapper library
@@ -66,6 +80,7 @@ RUN cd /usr/local/lvm2 \
 		--build="$(gcc -print-multiarch)" \
 		--enable-static_link \
 		--enable-pkgconfig \
+		--enable-udev_sync \
 	&& make -C include \
 	&& make -C libdm install_device-mapper
 
@@ -86,9 +101,7 @@ RUN set -x \
 
 # Install Go
 # We don't have official binary golang 1.7.5 tarballs for ARM64, either for Go or
-# bootstrap, so we use golang-go (1.6) as bootstrap to build Go from source code.
-# We don't use the official ARMv6 released binaries as a GOROOT_BOOTSTRAP, because
-# not all ARM64 platforms support 32-bit mode. 32-bit mode is optional for ARMv8.
+# bootstrap, so we use Debian golang (1.7) as bootstrap to build Go from source code.
 # IMPORTANT: When updating this please note that stdlib archive/tar pkg is vendored
 ENV GO_VERSION 1.8.3
 RUN mkdir /usr/src/go && curl -fsSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/src/go -xz --strip-components=1 \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -125,9 +125,7 @@ RUN set -x \
 
 # Get the "docker-py" source so we can run their integration tests
 ENV DOCKER_PY_COMMIT a962578e515185cf06506050b2200c0b81aa84ef
-# Before running the integration tests conftest.py is
-# loaded which results in loads auth.py that
-# imports the docker-pycreds module.
+# To run integration tests docker-pycreds is required.
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -15,7 +15,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM armhf/debian:jessie
+FROM arm32v7/debian:stretch
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org
@@ -39,16 +39,19 @@ RUN apt-get update && apt-get install -y \
 	net-tools \
 	libapparmor-dev \
 	libcap-dev \
-	libsystemd-journal-dev \
+	libsystemd-dev \
 	libtool \
+	libudev-dev \
 	mercurial \
 	pkg-config \
 	python-dev \
 	python-mock \
 	python-pip \
+	python-setuptools \
 	python-websocket \
 	xfsprogs \
 	tar \
+	thin-provisioning-tools \
 	vim-common \
 	--no-install-recommends \
 	&& pip install awscli==1.10.15
@@ -65,6 +68,7 @@ RUN cd /usr/local/lvm2 \
 		--build="$(gcc -print-multiarch)" \
 		--enable-static_link \
 		--enable-pkgconfig \
+		--enable-udev_sync \
 	&& make -C include \
 	&& make -C libdm install_device-mapper
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -45,11 +45,14 @@ RUN apt-get update && apt-get install -y \
 	libudev-dev \
 	mercurial \
 	pkg-config \
+	python-backports.ssl-match-hostname \
 	python-dev \
 	python-mock \
 	python-pip \
+	python-requests \
 	python-setuptools \
 	python-websocket \
+	python-wheel \
 	xfsprogs \
 	tar \
 	thin-provisioning-tools \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get install -y \
 	net-tools \
 	libapparmor-dev \
 	libcap-dev \
+	libdevmapper-dev \
 	libsystemd-dev \
 	libtool \
 	libudev-dev \
@@ -55,23 +56,6 @@ RUN apt-get update && apt-get install -y \
 	vim-common \
 	--no-install-recommends \
 	&& pip install awscli==1.10.15
-
-# Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.168
-RUN mkdir -p /usr/local/lvm2 \
-	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
-		| tar -xzC /usr/local/lvm2 --strip-components=1
-
-# Compile and install (only the needed library)
-RUN cd /usr/local/lvm2 \
-	&& ./configure \
-		--build="$(gcc -print-multiarch)" \
-		--enable-static_link \
-		--enable-pkgconfig \
-		--enable-udev_sync \
-	&& make -C include \
-	&& make -C libdm install_device-mapper
-
 
 # Install Go
 # IMPORTANT: When updating this please note that stdlib archive/tar pkg is vendored

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -118,9 +118,11 @@ RUN set -x \
 
 # Get the "docker-py" source so we can run their integration tests
 ENV DOCKER_PY_COMMIT a962578e515185cf06506050b2200c0b81aa84ef
+# To run integration tests docker-pycreds is required.
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \
+	&& pip install docker-pycreds==0.2.1 \
 	&& pip install -r test-requirements.txt
 
 # Set user.email so crosbymichael's in-container merge commits go smoothly

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -40,6 +40,7 @@ RUN apt-get update && apt-get install -y \
 	net-tools \
 	libapparmor-dev \
 	libcap-dev \
+	libdevmapper-dev \
 	libsystemd-dev \
 	libtool \
 	libudev-dev \
@@ -55,22 +56,6 @@ RUN apt-get update && apt-get install -y \
 	thin-provisioning-tools \
 	vim-common \
 	--no-install-recommends
-
-# Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.168
-RUN mkdir -p /usr/local/lvm2 \
-	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
-		| tar -xzC /usr/local/lvm2 --strip-components=1
-
-# Compile and install (only the needed library)
-RUN cd /usr/local/lvm2 \
-	&& ./configure \
-		--build="$(gcc -print-multiarch)" \
-		--enable-static_link \
-		--enable-pkgconfig \
-		--enable-udev_sync \
-	&& make -C include \
-	&& make -C libdm install_device-mapper
 
 # Install seccomp: the version shipped upstream is too old
 ENV SECCOMP_VERSION 2.3.2

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -46,11 +46,14 @@ RUN apt-get update && apt-get install -y \
 	libudev-dev \
 	mercurial \
 	pkg-config \
+	python-backports.ssl-match-hostname \
 	python-dev \
 	python-mock \
 	python-pip \
+	python-requests \
 	python-setuptools \
 	python-websocket \
+	python-wheel \
 	xfsprogs \
 	tar \
 	thin-provisioning-tools \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -117,9 +117,11 @@ RUN set -x \
 
 # Get the "docker-py" source so we can run their integration tests
 ENV DOCKER_PY_COMMIT a962578e515185cf06506050b2200c0b81aa84ef
+# To run integration tests docker-pycreds is required.
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \
+	&& pip install docker-pycreds==0.2.1 \
 	&& pip install -r test-requirements.txt
 
 # Set user.email so crosbymichael's in-container merge commits go smoothly

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -15,7 +15,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM ppc64le/debian:jessie
+FROM ppc64le/debian:stretch
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org
@@ -40,16 +40,19 @@ RUN apt-get update && apt-get install -y \
 	net-tools \
 	libapparmor-dev \
 	libcap-dev \
-	libsystemd-journal-dev \
+	libsystemd-dev \
 	libtool \
+	libudev-dev \
 	mercurial \
 	pkg-config \
 	python-dev \
 	python-mock \
 	python-pip \
+	python-setuptools \
 	python-websocket \
 	xfsprogs \
 	tar \
+	thin-provisioning-tools \
 	vim-common \
 	--no-install-recommends
 
@@ -65,6 +68,7 @@ RUN cd /usr/local/lvm2 \
 		--build="$(gcc -print-multiarch)" \
 		--enable-static_link \
 		--enable-pkgconfig \
+		--enable-udev_sync \
 	&& make -C include \
 	&& make -C libdm install_device-mapper
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -42,11 +42,14 @@ RUN apt-get update && apt-get install -y \
 	libudev-dev \
 	mercurial \
 	pkg-config \
+	python-backports.ssl-match-hostname \
 	python-dev \
 	python-mock \
 	python-pip \
+	python-requests \
 	python-setuptools \
 	python-websocket \
+	python-wheel \
 	xfsprogs \
 	tar \
 	thin-provisioning-tools \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -110,9 +110,11 @@ RUN set -x \
 
 # Get the "docker-py" source so we can run their integration tests
 ENV DOCKER_PY_COMMIT a962578e515185cf06506050b2200c0b81aa84ef
+# To run integration tests docker-pycreds is required.
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \
+	&& pip install docker-pycreds==0.2.1 \
 	&& pip install -r test-requirements.txt
 
 # Set user.email so crosbymichael's in-container merge commits go smoothly

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -15,7 +15,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM s390x/debian:jessie
+FROM s390x/debian:stretch
 
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \
@@ -36,16 +36,19 @@ RUN apt-get update && apt-get install -y \
 	net-tools \
 	libapparmor-dev \
 	libcap-dev \
-	libsystemd-journal-dev \
+	libsystemd-dev \
 	libtool \
+	libudev-dev \
 	mercurial \
 	pkg-config \
 	python-dev \
 	python-mock \
 	python-pip \
+	python-setuptools \
 	python-websocket \
 	xfsprogs \
 	tar \
+	thin-provisioning-tools \
 	vim-common \
 	--no-install-recommends
 
@@ -76,6 +79,7 @@ RUN cd /usr/local/lvm2 \
 		--build="$(gcc -print-multiarch)" \
 		--enable-static_link \
 		--enable-pkgconfig \
+		--enable-udev_sync \
 	&& make -C include \
 	&& make -C libdm install_device-mapper
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -36,6 +36,7 @@ RUN apt-get update && apt-get install -y \
 	net-tools \
 	libapparmor-dev \
 	libcap-dev \
+	libdevmapper-dev \
 	libsystemd-dev \
 	libtool \
 	libudev-dev \
@@ -66,22 +67,6 @@ RUN set -x \
 		&& ldconfig \
 	) \
 	&& rm -rf "$SECCOMP_PATH"
-
-# Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.168
-RUN mkdir -p /usr/local/lvm2 \
-	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
-		| tar -xzC /usr/local/lvm2 --strip-components=1
-
-# Compile and install (only the needed library)
-RUN cd /usr/local/lvm2 \
-	&& ./configure \
-		--build="$(gcc -print-multiarch)" \
-		--enable-static_link \
-		--enable-pkgconfig \
-		--enable-udev_sync \
-	&& make -C include \
-	&& make -C libdm install_device-mapper
 
 # IMPORTANT: When updating this please note that stdlib archive/tar pkg is vendored
 ENV GO_VERSION 1.8.3

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-FROM debian:jessie
+FROM debian:stretch
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/devicemapper"
+	"github.com/docker/docker/pkg/dmesg"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/loopback"
 	"github.com/docker/docker/pkg/mount"
@@ -1199,7 +1200,7 @@ func (devices *DeviceSet) growFS(info *devInfo) error {
 	options = joinMountOptions(options, devices.mountOptions)
 
 	if err := mount.Mount(info.DevName(), fsMountPoint, devices.BaseDeviceFilesystem, options); err != nil {
-		return fmt.Errorf("Error mounting '%s' on '%s': %s", info.DevName(), fsMountPoint, err)
+		return fmt.Errorf("Error mounting '%s' on '%s': %s\n%v", info.DevName(), fsMountPoint, err, string(dmesg.Dmesg(256)))
 	}
 
 	defer unix.Unmount(fsMountPoint, unix.MNT_DETACH)
@@ -2390,7 +2391,7 @@ func (devices *DeviceSet) MountDevice(hash, path, mountLabel string) error {
 	options = joinMountOptions(options, label.FormatMountLabel("", mountLabel))
 
 	if err := mount.Mount(info.DevName(), path, fstype, options); err != nil {
-		return fmt.Errorf("devmapper: Error mounting '%s' on '%s': %s", info.DevName(), path, err)
+		return fmt.Errorf("devmapper: Error mounting '%s' on '%s': %s\n%v", info.DevName(), path, err, string(dmesg.Dmesg(256)))
 	}
 
 	if fstype == "xfs" && devices.xfsNospaceRetries != "" {

--- a/daemon/graphdriver/overlay/copy.go
+++ b/daemon/graphdriver/overlay/copy.go
@@ -157,9 +157,10 @@ func copyDir(srcDir, dstDir string, flags copyFlags) error {
 		}
 
 		// system.Chtimes doesn't support a NOFOLLOW flag atm
+		// nolint: unconvert
 		if !isSymlink {
-			aTime := time.Unix(stat.Atim.Sec, stat.Atim.Nsec)
-			mTime := time.Unix(stat.Mtim.Sec, stat.Mtim.Nsec)
+			aTime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+			mTime := time.Unix(int64(stat.Mtim.Sec), int64(stat.Mtim.Nsec))
 			if err := system.Chtimes(dstPath, aTime, mTime); err != nil {
 				return err
 			}

--- a/daemon/graphdriver/register/register_devicemapper.go
+++ b/daemon/graphdriver/register/register_devicemapper.go
@@ -1,4 +1,4 @@
-// +build !exclude_graphdriver_devicemapper,linux
+// +build !exclude_graphdriver_devicemapper,!static_build,linux
 
 package register
 

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -214,14 +214,15 @@ func (s *DockerSuite) TestLogsSinceFutureFollow(c *check.C) {
 func (s *DockerSuite) TestLogsFollowSlowStdoutConsumer(c *check.C) {
 	// TODO Windows: Fix this test for TP5.
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", `usleep 600000;yes X | head -c 200000`)
+	expected := 150000
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", fmt.Sprintf("usleep 600000; yes X | head -c %d", expected))
 
 	id := strings.TrimSpace(out)
 
 	stopSlowRead := make(chan bool)
 
 	go func() {
-		exec.Command(dockerBinary, "wait", id).Run()
+		dockerCmd(c, "wait", id)
 		stopSlowRead <- true
 	}()
 
@@ -239,7 +240,6 @@ func (s *DockerSuite) TestLogsFollowSlowStdoutConsumer(c *check.C) {
 	c.Assert(err, checker.IsNil)
 
 	actual := bytes1 + bytes2
-	expected := 200000
 	c.Assert(actual, checker.Equals, expected)
 }
 

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -239,6 +239,8 @@ func (s *DockerSuite) TestLogsFollowSlowStdoutConsumer(c *check.C) {
 	bytes2, err := ConsumeWithSpeed(stdout, 32*1024, 0, nil)
 	c.Assert(err, checker.IsNil)
 
+	c.Assert(logCmd.Wait(), checker.IsNil)
+
 	actual := bytes1 + bytes2
 	c.Assert(actual, checker.Equals, expected)
 }
@@ -288,6 +290,7 @@ func (s *DockerSuite) TestLogsFollowGoroutinesWithStdout(c *check.C) {
 	c.Assert(<-chErr, checker.IsNil)
 	c.Assert(cmd.Process.Kill(), checker.IsNil)
 	r.Close()
+	cmd.Wait()
 	// NGoroutines is not updated right away, so we need to wait before failing
 	c.Assert(waitForGoroutines(nroutines), checker.IsNil)
 }
@@ -303,6 +306,7 @@ func (s *DockerSuite) TestLogsFollowGoroutinesNoOutput(c *check.C) {
 	c.Assert(cmd.Start(), checker.IsNil)
 	time.Sleep(200 * time.Millisecond)
 	c.Assert(cmd.Process.Kill(), checker.IsNil)
+	cmd.Wait()
 
 	// NGoroutines is not updated right away, so we need to wait before failing
 	c.Assert(waitForGoroutines(nroutines), checker.IsNil)

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1060,7 +1060,7 @@ func (s *DockerSuite) TestRunSeccompProfileAllow32Bit(c *check.C) {
 	testRequires(c, SameHostDaemon, seccompEnabled, IsAmd64)
 	ensureSyscallTest(c)
 
-	icmd.RunCommand(dockerBinary, "run", "syscall-test", "exit32-test", "id").Assert(c, icmd.Success)
+	icmd.RunCommand(dockerBinary, "run", "syscall-test", "exit32-test").Assert(c, icmd.Success)
 }
 
 // TestRunSeccompAllowSetrlimit checks that 'docker run debian:jessie ulimit -v 1048510' succeeds.

--- a/integration-cli/fixtures_linux_daemon_test.go
+++ b/integration-cli/fixtures_linux_daemon_test.go
@@ -57,7 +57,7 @@ func ensureSyscallTest(c *check.C) {
 	}
 
 	if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {
-		out, err := exec.Command(gcc, "-s", "-m32", "-nostdlib", "../contrib/syscall-test/exit32.s", "-o", tmp+"/"+"exit32-test").CombinedOutput()
+		out, err := exec.Command(gcc, "-s", "-m32", "-nostdlib", "-static", "../contrib/syscall-test/exit32.s", "-o", tmp+"/"+"exit32-test").CombinedOutput()
 		c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	}
 

--- a/pkg/devicemapper/devmapper_wrapper_static.go
+++ b/pkg/devicemapper/devmapper_wrapper_static.go
@@ -1,6 +1,0 @@
-// +build linux,cgo,static_build
-
-package devicemapper
-
-// #cgo pkg-config: --static devmapper
-import "C"

--- a/pkg/dmesg/dmesg_linux.go
+++ b/pkg/dmesg/dmesg_linux.go
@@ -1,0 +1,20 @@
+// +build linux
+
+package dmesg
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Dmesg returns last messages from the kernel log, up to size bytes
+func Dmesg(size int) []byte {
+	t := uintptr(3) // SYSLOG_ACTION_READ_ALL
+	b := make([]byte, size)
+	amt, _, err := unix.Syscall(unix.SYS_SYSLOG, t, uintptr(unsafe.Pointer(&b[0])), uintptr(len(b)))
+	if err != 0 {
+		return []byte{}
+	}
+	return b[:amt]
+}

--- a/pkg/dmesg/dmesg_linux_test.go
+++ b/pkg/dmesg/dmesg_linux_test.go
@@ -1,0 +1,9 @@
+package dmesg
+
+import (
+	"testing"
+)
+
+func TestDmesg(t *testing.T) {
+	t.Logf("dmesg output follows:\n%v", string(Dmesg(512)))
+}


### PR DESCRIPTION
A short high-level description of this patch set:
Patch 1: update Dockerfiles to use Debian Stretch as a base
Patch 2: disable devmapper graph driver for static build
Patches 3-5: various CI fixes
Patches 6-7: improve error reporting for devmapper graph driver
Patches 8-10: fix 'make all' on some platforms (unrelated but here for the sake of CI)

I believe this is now ready for inclusion. Here is the description of all patches:

# Update Dockerfiles to use Debian stretch
The main gain here is that they all use exactly the same distro; previously
arm64 was using Ubuntu Xenial because Debian jessie was too old.

Does not seem that we can change any of the downloaded dependencies still,
as eg libseccomp is still not the version we are using.

# devmapper gd: disable for static build
Static build with devmapper is impossible now since libudev is required
and no static version of libudev is available (as static libraries are
not supported by systemd which udev is part of).

This should not hurt anyone as "[t]he primary user of static builds
is the Editions, and docker in docker via the containers, and none
of those use device mapper".

Also, since the need for static libdevmapper is gone, there is no need
to self-compile libdevmapper -- let's use the one from Debian Stretch.

# TestRunSeccompProfileAllow32Bit: fix
Since the update to Debian Stretch, this test fails. The reason is dynamic
binary, which requires i386 ld.so for loading (and apparently it is no longer
installed by default):

> root@09d4b17:/go/src/github.com/docker/docker# file exit32-test
> exit32-test: ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.2, BuildID[sha1]=a0d3d6cb59788453b983f65f8dc6ac52920147b6, stripped
> root@09d4b17:/go/src/github.com/docker/docker# ls -l /lib/ld-linux.so.2
> ls: cannot access '/lib/ld-linux.so.2': No such file or directory

To fix, just add -static.

Interestingly, ldd can'f figure it out.

> root@a324f8e:/go/src/github.com/docker/docker# ldd exit32-test
>	not a dynamic executable

Other tools (e.g. objdump) also show it's a dynamic binary.

While at it, remove the extra "id" argument (a copy-paste error I
guess).

# devmapper: show dmesg if mount fails
If mount fails, the reason might be right there in the kernel log ring buffer.
Let's include it in the error message, it might be of great help.

# Dockerfiles: fix test-docker-py
Presumably after switch to debian-stretch as a base, the following
errors happens in Jenkins:

10:48:03 ---> Making bundle: test-docker-py (in
bundles/17.06.0-dev/test-docker-py)
10:48:03 ---> Making bundle: .integration-daemon-start (in
bundles/17.06.0-dev/test-docker-py)
10:48:03 Using test binary docker
10:48:03 # DOCKER_EXPERIMENTAL is set: starting daemon with experimental
features enabled!
10:48:03 /etc/init.d/apparmor: 130: /etc/init.d/apparmor:
systemd-detect-virt: not found
10:48:03 Starting AppArmor profiles:Warning from stdin (line 1):
/sbin/apparmor_parser: cannot use or update cache, disable, or
force-complain via stdin
10:48:03 Warning failed to create cache: (null)
10:48:03 .
10:48:03 INFO: Waiting for daemon to start...
10:48:03 Starting dockerd
10:48:05 .
10:48:06 Traceback (most recent call last):
10:48:06   File
"/usr/local/lib/python2.7/dist-packages/_pytest/config.py", line 320, in
_importconftest
10:48:06     mod = conftestpath.pyimport()
10:48:06   File
"/usr/local/lib/python2.7/dist-packages/py/_path/local.py", line 662, in
pyimport
10:48:06     __import__(modname)
10:48:06   File "/docker-py/tests/integration/conftest.py", line 6, in
<module>
10:48:06     import docker.errors
10:48:06   File "/docker-py/docker/__init__.py", line 2, in <module>
10:48:06     from .api import APIClient
10:48:06   File "/docker-py/docker/api/__init__.py", line 2, in <module>
10:48:06     from .client import APIClient
10:48:06   File "/docker-py/docker/api/client.py", line 6, in <module>
10:48:06     import requests
10:48:06 ImportError: No module named requests
10:48:06 ERROR: could not load /docker-py/tests/integration/conftest.py
10:48:06

and

00:38:55   File "/docker-py/docker/transport/ssladapter.py", line 21, in
<module>
00:38:55     from backports.ssl_match_hostname import match_hostname
00:38:55 ImportError: No module named backports.ssl_match_hostname
00:38:55 ERROR: could not load /docker-py/tests/integration/conftest.py

To fix, install the missing python modules.

# devmapper: tell why xfs is not supported
Instead of providing a generic message listing all possible reasons
why xfs is not available on the system, let's be specific.

# devmapper: don't create too new xfs
Since the update to Debian Stretch, devmapper unit test fails. One
reason is, the combination of somewhat old (less than 3.16) kernel and
relatively new xfsprogs leads to creating a filesystem which is not supported
by the kernel:

> [12206.467518] XFS (dm-1): Superblock has unknown read-only compatible features (0x1) enabled.
> [12206.472046] XFS (dm-1): Attempted to mount read-only compatible filesystem read-write.
> Filesystem can only be safely mounted read only.
> [12206.472079] XFS (dm-1): SB validate failed with error 22.

Ideally, that would be automatically and implicitly handled by xfsprogs.
In real life, we have to take care about it here. Sigh.

# overlay gd: fix build for 32-bit ARM
This commit reverts a hunk of commit 2f5f0af ("Add unconvert linter")
and adds a hint for unconvert linter to ignore excessive conversion as
it is required on 32-bit platforms (e.g. armhf).

The exact error on armhf is this:

	19:06:45 ---> Making bundle: dynbinary (in bundles/17.06.0-dev/dynbinary)
	19:06:48 Building: bundles/17.06.0-dev/dynbinary-daemon/dockerd-17.06.0-dev
	19:10:58 # github.com/docker/docker/daemon/graphdriver/overlay
	19:10:58 daemon/graphdriver/overlay/copy.go:161: cannot use stat.Atim.Sec (type int32) as type int64 in argument to time.Unix
	19:10:58 daemon/graphdriver/overlay/copy.go:161: cannot use stat.Atim.Nsec (type int32) as type int64 in argument to time.Unix
	19:10:58 daemon/graphdriver/overlay/copy.go:162: cannot use stat.Mtim.Sec (type int32) as type int64 in argument to time.Unix
	19:10:58 daemon/graphdriver/overlay/copy.go:162: cannot use stat.Mtim.Nsec (type int32) as type int64 in argument to time.Unix

# Fix test-docker-py on some arches
When running 'make all' on armhf, I got this:

> ---> Making bundle: .integration-daemon-start (in bundles/17.06.0-dev/test-docker-py)
> Using test binary docker
> INFO: Waiting for daemon to start...
> Starting dockerd
> .
> Traceback (most recent call last):
>   File "/usr/local/lib/python2.7/dist-packages/_pytest/config.py", line
> 320, in _importconftest
>     mod = conftestpath.pyimport()
>   File "/usr/local/lib/python2.7/dist-packages/py/_path/local.py", line
> 662, in pyimport
>     __import__(modname)
>   File "/docker-py/tests/integration/conftest.py", line 6, in <module>
>     import docker.errors
>   File "/docker-py/docker/__init__.py", line 2, in <module>
>     from .api import APIClient
>   File "/docker-py/docker/api/__init__.py", line 2, in <module>
>     from .client import APIClient
>   File "/docker-py/docker/api/client.py", line 11, in <module>
>     from .build import BuildApiMixin
>   File "/docker-py/docker/api/build.py", line 6, in <module>
>     from .. import auth
>   File "/docker-py/docker/auth.py", line 6, in <module>
>     import dockerpycreds
> ImportError: No module named dockerpycreds
> ERROR: could not load /docker-py/tests/integration/conftest.py

The fix for this was already provided by commit 0ec8f56 and
commit c7c9235, but for some reason it did not made its way
to Dockerfiles for all architectures.

While at it, remove excessive comments.

# TestLogsFollowSlowStdoutConsumer: fix for slow ARM
We run our CI on Scaleway C1 machine, which is pretty slow,
including I/O. This test was failing on it, as it tried to
write 100000 lines of log very fast, and the loggerCloseTimeout
(defined and used in container/monitor.go) prevents the
daemon to finish writing it within this time frame,

Reducing the size to 150000 characters (75000 lines) should
help avoiding hitting it, without compromising the test case
itself.

Alternatively, we could have increased the timeout further. It was
originally set to 1s (commit b6a4267) and later increased 10x
(commit c0391bf). Please let me know if you want me to go that way.