### PR TITLE
Move to a single tag-store

### DIFF
--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -20,7 +20,7 @@ func (daemon *Daemon) getLayerRefs(platform string) map[layer.ChainID]int {
 	layerRefs := map[layer.ChainID]int{}
 	for id, img := range tmpImages {
 		dgst := digest.Digest(id)
-		if len(daemon.stores[platform].referenceStore.References(dgst)) == 0 && len(daemon.stores[platform].imageStore.Children(id)) != 0 {
+		if len(daemon.referenceStore.References(dgst)) == 0 && len(daemon.stores[platform].imageStore.Children(id)) != 0 {
 			continue
 		}
 

--- a/daemon/image_exporter.go
+++ b/daemon/image_exporter.go
@@ -19,7 +19,7 @@ func (daemon *Daemon) ExportImage(names []string, outStream io.Writer) error {
 	if system.LCOWSupported() {
 		platform = "linux"
 	}
-	imageExporter := tarexport.NewTarExporter(daemon.stores[platform].imageStore, daemon.stores[platform].layerStore, daemon.stores[platform].referenceStore, daemon)
+	imageExporter := tarexport.NewTarExporter(daemon.stores[platform].imageStore, daemon.stores[platform].layerStore, daemon.referenceStore, daemon)
 	return imageExporter.Save(names, outStream)
 }
 
@@ -32,6 +32,6 @@ func (daemon *Daemon) LoadImage(inTar io.ReadCloser, outStream io.Writer, quiet 
 	if system.LCOWSupported() {
 		platform = "linux"
 	}
-	imageExporter := tarexport.NewTarExporter(daemon.stores[platform].imageStore, daemon.stores[platform].layerStore, daemon.stores[platform].referenceStore, daemon)
+	imageExporter := tarexport.NewTarExporter(daemon.stores[platform].imageStore, daemon.stores[platform].layerStore, daemon.referenceStore, daemon)
 	return imageExporter.Load(inTar, outStream, quiet)
 }

--- a/daemon/image_history.go
+++ b/daemon/image_history.go
@@ -69,7 +69,7 @@ func (daemon *Daemon) ImageHistory(name string) ([]*image.HistoryResponseItem, e
 		h.ID = id.String()
 
 		var tags []string
-		for _, r := range daemon.stores[platform].referenceStore.References(id.Digest()) {
+		for _, r := range daemon.referenceStore.References(id.Digest()) {
 			if _, ok := r.(reference.NamedTagged); ok {
 				tags = append(tags, reference.FamiliarString(r))
 			}

--- a/daemon/image_inspect.go
+++ b/daemon/image_inspect.go
@@ -24,7 +24,7 @@ func (daemon *Daemon) LookupImage(name string) (*types.ImageInspect, error) {
 		platform = runtime.GOOS
 	}
 
-	refs := daemon.stores[platform].referenceStore.References(img.ID().Digest())
+	refs := daemon.referenceStore.References(img.ID().Digest())
 	repoTags := []string{}
 	repoDigests := []string{}
 	for _, ref := range refs {

--- a/daemon/image_pull.go
+++ b/daemon/image_pull.go
@@ -74,7 +74,7 @@ func (daemon *Daemon) pullImageWithReference(ctx context.Context, ref reference.
 			ImageEventLogger: daemon.LogImageEvent,
 			MetadataStore:    daemon.stores[platform].distributionMetadataStore,
 			ImageStore:       distribution.NewImageConfigStoreFromStore(daemon.stores[platform].imageStore),
-			ReferenceStore:   daemon.stores[platform].referenceStore,
+			ReferenceStore:   daemon.referenceStore,
 		},
 		DownloadManager: daemon.downloadManager,
 		Schema2Types:    distribution.ImageTypes,

--- a/daemon/image_push.go
+++ b/daemon/image_push.go
@@ -56,7 +56,7 @@ func (daemon *Daemon) PushImage(ctx context.Context, image, tag string, metaHead
 			ImageEventLogger: daemon.LogImageEvent,
 			MetadataStore:    daemon.stores[platform].distributionMetadataStore,
 			ImageStore:       distribution.NewImageConfigStoreFromStore(daemon.stores[platform].imageStore),
-			ReferenceStore:   daemon.stores[platform].referenceStore,
+			ReferenceStore:   daemon.referenceStore,
 		},
 		ConfigMediaType: schema2.MediaTypeImageConfig,
 		LayerStore:      distribution.NewLayerProviderFromStore(daemon.stores[platform].layerStore),

--- a/daemon/image_tag.go
+++ b/daemon/image_tag.go
@@ -28,7 +28,7 @@ func (daemon *Daemon) TagImage(imageName, repository, tag string) error {
 
 // TagImageWithReference adds the given reference to the image ID provided.
 func (daemon *Daemon) TagImageWithReference(imageID image.ID, platform string, newTag reference.Named) error {
-	if err := daemon.stores[platform].referenceStore.AddTag(newTag, imageID.Digest(), true); err != nil {
+	if err := daemon.referenceStore.AddTag(newTag, imageID.Digest(), true); err != nil {
 		return err
 	}
 

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -149,7 +149,7 @@ func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs
 
 		newImage := newImage(img, size)
 
-		for _, ref := range daemon.stores[platform].referenceStore.References(id.Digest()) {
+		for _, ref := range daemon.referenceStore.References(id.Digest()) {
 			if imageFilters.Include("reference") {
 				var found bool
 				var matchErr error

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -221,7 +221,7 @@ func (daemon *Daemon) ImagesPrune(ctx context.Context, pruneFilters filters.Args
 			return nil, ctx.Err()
 		default:
 			dgst := digest.Digest(id)
-			if len(daemon.stores[platform].referenceStore.References(dgst)) == 0 && len(daemon.stores[platform].imageStore.Children(id)) != 0 {
+			if len(daemon.referenceStore.References(dgst)) == 0 && len(daemon.stores[platform].imageStore.Children(id)) != 0 {
 				continue
 			}
 			if !until.IsZero() && img.Created.After(until) {
@@ -252,7 +252,7 @@ deleteImagesLoop:
 		}
 
 		deletedImages := []types.ImageDeleteResponseItem{}
-		refs := daemon.stores[platform].referenceStore.References(dgst)
+		refs := daemon.referenceStore.References(dgst)
 		if len(refs) > 0 {
 			shouldDelete := !danglingOnly
 			if !shouldDelete {

--- a/reference/store.go
+++ b/reference/store.go
@@ -26,7 +26,7 @@ type Association struct {
 	ID  digest.Digest
 }
 
-// Store provides the set of methods which can operate on a tag store.
+// Store provides the set of methods which can operate on a reference store.
 type Store interface {
 	References(id digest.Digest) []reference.Named
 	ReferencesByName(ref reference.Named) []Association
@@ -46,9 +46,6 @@ type store struct {
 	// referencesByIDCache is a cache of references indexed by ID, to speed
 	// up References.
 	referencesByIDCache map[digest.Digest]map[string]reference.Named
-	// platform is the container target platform for this store (which may be
-	// different to the host operating system
-	platform string
 }
 
 // Repository maps tags to digests. The key is a stringified Reference,
@@ -73,7 +70,7 @@ func (a lexicalAssociations) Less(i, j int) bool {
 
 // NewReferenceStore creates a new reference store, tied to a file path where
 // the set of references are serialized in JSON format.
-func NewReferenceStore(jsonPath, platform string) (Store, error) {
+func NewReferenceStore(jsonPath string) (Store, error) {
 	abspath, err := filepath.Abs(jsonPath)
 	if err != nil {
 		return nil, err
@@ -83,7 +80,6 @@ func NewReferenceStore(jsonPath, platform string) (Store, error) {
 		jsonPath:            abspath,
 		Repositories:        make(map[string]repository),
 		referencesByIDCache: make(map[digest.Digest]map[string]reference.Named),
-		platform:            platform,
 	}
 	// Load the json file if it exists, otherwise create it.
 	if err := store.reload(); os.IsNotExist(err) {

--- a/reference/store_test.go
+++ b/reference/store_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -41,7 +40,7 @@ func TestLoad(t *testing.T) {
 	}
 	jsonFile.Close()
 
-	store, err := NewReferenceStore(jsonFile.Name(), runtime.GOOS)
+	store, err := NewReferenceStore(jsonFile.Name())
 	if err != nil {
 		t.Fatalf("error creating tag store: %v", err)
 	}
@@ -70,7 +69,7 @@ func TestSave(t *testing.T) {
 	jsonFile.Close()
 	defer os.RemoveAll(jsonFile.Name())
 
-	store, err := NewReferenceStore(jsonFile.Name(), runtime.GOOS)
+	store, err := NewReferenceStore(jsonFile.Name())
 	if err != nil {
 		t.Fatalf("error creating tag store: %v", err)
 	}
@@ -112,7 +111,7 @@ func TestAddDeleteGet(t *testing.T) {
 	jsonFile.Close()
 	defer os.RemoveAll(jsonFile.Name())
 
-	store, err := NewReferenceStore(jsonFile.Name(), runtime.GOOS)
+	store, err := NewReferenceStore(jsonFile.Name())
 	if err != nil {
 		t.Fatalf("error creating tag store: %v", err)
 	}
@@ -329,7 +328,7 @@ func TestInvalidTags(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "tag-store-test")
 	defer os.RemoveAll(tmpDir)
 
-	store, err := NewReferenceStore(filepath.Join(tmpDir, "repositories.json"), runtime.GOOS)
+	store, err := NewReferenceStore(filepath.Join(tmpDir, "repositories.json"))
 	if err != nil {
 		t.Fatalf("error creating tag store: %v", err)
 	}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@tonistiigi @stevvooe @dmcgowan @mlaventure As per offline discussion (larger doc to follow, but this is one of the easier non-contentious pieces), this restructures the daemon back to how it was so that the reference (tag) store is global. This means that once the Windows daemon is able to run in dual LCOW/WCOW mode again, it will not be possible to have `image:tag` as both a Windows and a Linux image. 
