### PR TITLE
Remove double defined alarm in seccomp list.

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -57,7 +57,6 @@
 				"access",
 				"adjtimex",
 				"alarm",
-				"alarm",
 				"bind",
 				"brk",
 				"capget",

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -50,7 +50,6 @@ func DefaultProfile() *types.Seccomp {
 				"access",
 				"adjtimex",
 				"alarm",
-				"alarm",
 				"bind",
 				"brk",
 				"capget",


### PR DESCRIPTION
Small fix that removes the double listed "alarm" syscall in the seccomp list.

