### PR TITLE
Dropped hyphen in bind mount where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2284,7 +2284,7 @@ by another client (#15489)
 - Use mock for search tests.
 - Update to double-dash everywhere.
 - Move .dockerenv parsing to lxc driver.
-- Move all bind-mounts in the container inside the namespace.
+- Move all bind mounts in the container inside the namespace.
 - Don't use separate bind mount for container.
 - Always symlink /dev/ptmx for libcontainer.
 - Don't kill by pid for other drivers.
@@ -2719,7 +2719,7 @@ With the ongoing changes to the networking and execution subsystems of docker te
 + Implement `docker log -f` to stream logs
 + Add env variable to disable kernel version warning
 + Add -format to `docker inspect`
-+ Support bind-mount for files
++ Support bind mount for files
 - Fix bridge creation on RHEL
 - Fix image size calculation
 - Make sure iptables are called even if the bridge already exists

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -132,8 +132,8 @@
 # Important notes:
 # ---------------
 #
-# Don't attempt to use a bind-mount to pass a local directory as the bundles target
-# directory. It does not work (golang attempts for follow a mapped folder incorrectly). 
+# Don't attempt to use a bind mount to pass a local directory as the bundles target
+# directory. It does not work (golang attempts for follow a mapped folder incorrectly).
 # Instead, use docker cp as per the example.
 #
 # go.zip is not removed from the image as it is used by the Windows CI servers

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -577,7 +577,7 @@ definitions:
               A list of volume bindings for this container. Each volume binding is a string in one of these forms:
 
               - `host-src:container-dest` to bind-mount a host path into the container. Both `host-src`, and `container-dest` must be an _absolute_ path.
-              - `host-src:container-dest:ro` to make the bind-mount read-only inside the container. Both `host-src`, and `container-dest` must be an _absolute_ path.
+              - `host-src:container-dest:ro` to make the bind mount read-only inside the container. Both `host-src`, and `container-dest` must be an _absolute_ path.
               - `volume-name:container-dest` to bind-mount a volume managed by a volume driver into the container. `container-dest` must be an _absolute_ path.
               - `volume-name:container-dest:ro` to mount the volume read-only inside the container.  `container-dest` must be an _absolute_ path.
             items:

--- a/api/types/mount/mount.go
+++ b/api/types/mount/mount.go
@@ -67,7 +67,7 @@ var Propagations = []Propagation{
 type Consistency string
 
 const (
-	// ConsistencyFull guarantees bind-mount-like consistency
+	// ConsistencyFull guarantees bind mount-like consistency
 	ConsistencyFull Consistency = "consistent"
 	// ConsistencyCached mounts can cache read data and FS structure
 	ConsistencyCached Consistency = "cached"

--- a/docs/api/v1.18.md
+++ b/docs/api/v1.18.md
@@ -232,11 +232,11 @@ Create a container
 -   **ExposedPorts** - An object mapping ports to an empty object in the form of:
       `"ExposedPorts": { "<port>/<tcp|udp>: {}" }`
 -   **HostConfig**
-    -   **Binds** – A list of bind-mounts for this container. Each item is a string in one of these forms:
+    -   **Binds** – A list of bind mounts for this container. Each item is a string in one of these forms:
            + `host-src:container-dest` to bind-mount a host path into the
              container. Both `host-src`, and `container-dest` must be an
              _absolute_ path.
-           + `host-src:container-dest:ro` to make the bind-mount read-only
+           + `host-src:container-dest:ro` to make the bind mount read-only
              inside the container. Both `host-src`, and `container-dest` must be
              an _absolute_ path.
     -   **Links** - A list of links for the container. Each link entry should be

--- a/docs/api/v1.19.md
+++ b/docs/api/v1.19.md
@@ -239,11 +239,11 @@ Create a container
 -   **ExposedPorts** - An object mapping ports to an empty object in the form of:
       `"ExposedPorts": { "<port>/<tcp|udp>: {}" }`
 -   **HostConfig**
-    -   **Binds** – A list of bind-mounts for this container. Each item is a string in one of these forms:
+    -   **Binds** – A list of bind mounts for this container. Each item is a string in one of these forms:
            + `host-src:container-dest` to bind-mount a host path into the
              container. Both `host-src`, and `container-dest` must be an
              _absolute_ path.
-           + `host-src:container-dest:ro` to make the bind-mount read-only
+           + `host-src:container-dest:ro` to make the bind mount read-only
              inside the container. Both `host-src`, and `container-dest` must be
              an _absolute_ path.
     -   **Links** - A list of links for the container. Each link entry should be

--- a/docs/api/v1.20.md
+++ b/docs/api/v1.20.md
@@ -239,11 +239,11 @@ Create a container
 -   **ExposedPorts** - An object mapping ports to an empty object in the form of:
       `"ExposedPorts": { "<port>/<tcp|udp>: {}" }`
 -   **HostConfig**
-    -   **Binds** – A list of bind-mounts for this container. Each item is a string in one of these forms:
+    -   **Binds** – A list of bind mounts for this container. Each item is a string in one of these forms:
            + `host-src:container-dest` to bind-mount a host path into the
              container. Both `host-src`, and `container-dest` must be an
              _absolute_ path.
-           + `host-src:container-dest:ro` to make the bind-mount read-only
+           + `host-src:container-dest:ro` to make the bind mount read-only
              inside the container. Both `host-src`, and `container-dest` must be
              an _absolute_ path.
     -   **Links** - A list of links for the container. Each link entry should be

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -255,7 +255,7 @@ Create a container
            + `host-src:container-dest` to bind-mount a host path into the
              container. Both `host-src`, and `container-dest` must be an
              _absolute_ path.
-           + `host-src:container-dest:ro` to make the bind-mount read-only
+           + `host-src:container-dest:ro` to make the bind mount read-only
              inside the container. Both `host-src`, and `container-dest` must be
              an _absolute_ path.
            + `volume-name:container-dest` to bind-mount a volume managed by a

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -357,7 +357,7 @@ Create a container
            + `host-src:container-dest` to bind-mount a host path into the
              container. Both `host-src`, and `container-dest` must be an
              _absolute_ path.
-           + `host-src:container-dest:ro` to make the bind-mount read-only
+           + `host-src:container-dest:ro` to make the bind mount read-only
              inside the container. Both `host-src`, and `container-dest` must be
              an _absolute_ path.
            + `volume-name:container-dest` to bind-mount a volume managed by a

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -382,7 +382,7 @@ Create a container
            + `host-src:container-dest` to bind-mount a host path into the
              container. Both `host-src`, and `container-dest` must be an
              _absolute_ path.
-           + `host-src:container-dest:ro` to make the bind-mount read-only
+           + `host-src:container-dest:ro` to make the bind mount read-only
              inside the container. Both `host-src`, and `container-dest` must be
              an _absolute_ path.
            + `volume-name:container-dest` to bind-mount a volume managed by a

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -414,7 +414,7 @@ Create a container
            + `host-src:container-dest` to bind-mount a host path into the
              container. Both `host-src`, and `container-dest` must be an
              _absolute_ path.
-           + `host-src:container-dest:ro` to make the bind-mount read-only
+           + `host-src:container-dest:ro` to make the bind mount read-only
              inside the container. Both `host-src`, and `container-dest` must be
              an _absolute_ path.
            + `volume-name:container-dest` to bind-mount a volume managed by a

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2185,7 +2185,7 @@ func (s *DockerSuite) TestVolumesNoCopyData(c *check.C) {
 
 	tmpDir := testutil.RandomTmpDirPath("docker_test_bind_mount_copy_data", testEnv.DaemonPlatform())
 	if out, _, err := dockerCmdWithError("run", "-v", tmpDir+":/foo", "dataimage", "ls", "-lh", "/foo/bar"); err == nil || !strings.Contains(out, "No such file or directory") {
-		c.Fatalf("Data was copied on bind-mount but shouldn't be:\n%q", out)
+		c.Fatalf("Data was copied on bind mount but shouldn't be:\n%q", out)
 	}
 }
 

--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -156,7 +156,7 @@ func DefaultLinuxSpec() specs.Spec {
 		},
 		// Devices implicitly contains the following devices:
 		// null, zero, full, random, urandom, tty, console, and ptmx.
-		// ptmx is a bind-mount or symlink of the container's ptmx.
+		// ptmx is a bind mount or symlink of the container's ptmx.
 		// See also: https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#default-devices
 		Devices: []specs.LinuxDevice{},
 		Resources: &specs.LinuxResources{


### PR DESCRIPTION
Signed-off-by: Christophe Vidal <kriss@krizalys.com>

**- What I did**

Dropped the hyphen in `bind mount` where appropriate (when **not** used as an option, a verb, a past participate, in a dependency repository, etc...).

This was suggested previously by @mstanleyjones in https://github.com/docker/cli/pull/446.

Related to https://github.com/docker/cli/pull/460.

