### PR TITLE
archive: add ChownOpts support to TarWithOptions

### DIFF
--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -394,7 +394,7 @@ func ChangesSize(newDir string, changes []Change) int64 {
 func ExportChanges(dir string, changes []Change, uidMaps, gidMaps []idtools.IDMap) (io.ReadCloser, error) {
 	reader, writer := io.Pipe()
 	go func() {
-		ta := newTarAppender(idtools.NewIDMappingsFromMaps(uidMaps, gidMaps), writer)
+		ta := newTarAppender(idtools.NewIDMappingsFromMaps(uidMaps, gidMaps), writer, nil)
 
 		// this buffer is needed for the duration of this piped stream
 		defer pools.BufioWriter32KPool.Put(ta.Buffer)


### PR DESCRIPTION
**- What I did**

Added support of ChownOpts to TarWithOptions in pkg/archive. The goal is then to [use this option in cli](https://github.com/docker/cli/blob/0b050a599f04d8401c04493f9c7f787b74fd6511/cli/command/image/build.go#L244) to reset the uid/gid to 0 thus to fix a cache busting issue in the build context as discussed in https://github.com/moby/moby/issues/32816#issuecomment-323805976

**- How I did it**

I've added a `ChownOpts` field into `TarOptions` struct and used it in `TarWithOptions` to override uid/gid when specified.

**- How to verify it**

```shell
cd pkg/archive && go test -v . -run TestTarWithOptionsChownOptsAlwaysOverridesIdPair
```

**- Description for the changelog**

archive: added ChownOpts to TarWithOptions to override idPair

**- A picture of a cute animal (not mandatory but encouraged)**
![cute-cub-with-open-mouth-635747953856576059-14200](https://user-images.githubusercontent.com/54712/29543646-dda5f930-86e2-11e7-8f68-b0cec0e4c732.jpg)
