### PR TITLE
Fix typo in docs/api/version-history.md

### DIFF
--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -70,8 +70,8 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /containers/(name)/wait` now accepts a `condition` query parameter to indicate which state change condition to wait for. Also, response headers are now returned immediately to acknowledge that the server has registered a wait callback for the client.
 * `POST /swarm/init` now accepts a `DataPathAddr` property to set the IP-address or network interface to use for data traffic
 * `POST /swarm/join` now accepts a `DataPathAddr` property to set the IP-address or network interface to use for data traffic
-* `GET /events` now supports service, node and secret events which are emmited when users create, update and remove service, node and secret 
-* `GET /events` now supports network remove event which is emmitted when users remove a swarm scoped network
+* `GET /events` now supports service, node and secret events which are emitted when users create, update and remove service, node and secret 
+* `GET /events` now supports network remove event which is emitted when users remove a swarm scoped network
 * `GET /events` now supports a filter type `scope` in which supported value could be swarm and local
 
 ## v1.29 API changes


### PR DESCRIPTION
Signed-off-by: Ti Zhou <tizhou1986@gmail.com>

**- What I did**
Fixed typo in docs/api/version-history.md.

**- How I did it**
Modified file.

**- How to verify it**
Check modified file.

**- Description for the changelog**
Fixed several typos.

**- A picture of a cute animal (not mandatory but encouraged)**
Hmmm...maybe next time...