### PR TITLE
[WIP] Configurable layer compression during push

### DIFF
--- a/daemon/image_push.go
+++ b/daemon/image_push.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"compress/gzip"
 	"io"
 	"runtime"
 
@@ -60,6 +61,7 @@ func (daemon *Daemon) PushImage(ctx context.Context, image, tag string, metaHead
 		},
 		ConfigMediaType: schema2.MediaTypeImageConfig,
 		LayerStore:      distribution.NewLayerProviderFromStore(daemon.stores[platform].layerStore),
+		LayerCompressor: distribution.NewGzipCompressor(gzip.DefaultCompression),
 		TrustKey:        daemon.trustKey,
 		UploadManager:   daemon.uploadManager,
 	}

--- a/distribution/config.go
+++ b/distribution/config.go
@@ -73,6 +73,8 @@ type ImagePushConfig struct {
 	ConfigMediaType string
 	// LayerStore manages layers.
 	LayerStore PushLayerProvider
+	// LayerCompressor manages compression of layers prior of uploading.
+	LayerCompressor Compressor
 	// TrustKey is the private key for legacy signatures. This is typically
 	// an ephemeral key, since these signatures are no longer verified.
 	TrustKey libtrust.PrivateKey


### PR DESCRIPTION
Initial work to fix #1266 by making compression configurable. This PR is far from complete, but I'd like to collect feedback before investing any more time in the wrong direction. I'm far from a docker internals or go expert, so I can use guidance on all levels (testing, documentation, code style, design,...).

This PR currently just extracts the configuration of the compressor from the push internals up to the `Daemon.PushImage` method; additional plumbing is needed to pull it out of that method and into the API request handler.

As stated in the original issue, there are some open points:

> 1. Do we want to handle just the levels which can be passed to the gzip writer (https://golang.org/pkg/compress/gzip/#pkg-constants) or do we want to support other compression algorithms altogether?

I'm leaning towards just allowing gzip levels, but without excluding a future evolution to support custom algorithms altogether. Also, I did not check what is needed on the metadata/pull level to be able to support other algorithms during pull. This works transparently as long as we stick to gzip, but I can imagine we need additional support if we want to use a different algorithm.

> 2. Where should the level/algorithm be specified? Via the CLI (which then also requires changes to the API) or in the configuration? In the latter case, would it be per daemon or per registry (more appropriate)?

Would passing the compression algo/options using the HTTP headers of the push API endpoint be a viable solution? It looks like the easiest and least intrusive at the API level.

A third point is: if a layer is already uploaded to a registry with a different compression scheme, then any new pushes of that layer would be skipped, even if the compression would be different. This is not an issue per-se, but it is something to be aware of.