### PR TITLE
Host-mode IPC sharing not possible in a userns

### DIFF
--- a/integration-cli/docker_api_ipcmode_test.go
+++ b/integration-cli/docker_api_ipcmode_test.go
@@ -188,7 +188,7 @@ func (s *DockerSuite) TestAPIIpcModePrivateAndContainer(c *check.C) {
  * can use IPC of the host system.
  */
 func (s *DockerSuite) TestAPIIpcModeHost(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, NotUserNamespace)
 
 	cfg := container.Config{
 		Image: "busybox",


### PR DESCRIPTION
This test is the API version of a docker_cli_run_test that was already
disabled from userns, but when ported to API didn't retain the same test
requirements. Specifically, a user namespaced process will not have
access to the host namespace's IPC devices and is already documented as
such in the user namespace restrictions docs.

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

- This fixes one of the failures noted in #34599