### PR TITLE
Add interfacer and unconvert linters

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -18,7 +18,7 @@ type execBackend interface {
 	ContainerExecCreate(name string, config *types.ExecConfig) (string, error)
 	ContainerExecInspect(id string) (*backend.ExecInspect, error)
 	ContainerExecResize(name string, height, width int) error
-	ContainerExecStart(ctx context.Context, name string, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer) error
+	ContainerExecStart(ctx context.Context, name string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error
 	ExecExists(name string) (bool, error)
 }
 

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -70,7 +70,7 @@ func (s *containerRouter) getContainersStats(ctx context.Context, w http.Respons
 	config := &backend.ContainerStatsConfig{
 		Stream:    stream,
 		OutStream: w,
-		Version:   string(httputils.VersionFromContext(ctx)),
+		Version:   httputils.VersionFromContext(ctx),
 	}
 
 	return s.backend.ContainerStats(ctx, vars["name"], config)

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -66,9 +66,7 @@ func (s *imageRouter) postCommit(ctx context.Context, w http.ResponseWriter, r *
 		return err
 	}
 
-	return httputils.WriteJSON(w, http.StatusCreated, &types.IDResponse{
-		ID: string(imgID),
-	})
+	return httputils.WriteJSON(w, http.StatusCreated, &types.IDResponse{ID: imgID})
 }
 
 // Creates an image from Pull or from Import

--- a/api/server/router/swarm/helpers.go
+++ b/api/server/router/swarm/helpers.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/docker/docker/api/server/httputils"
@@ -12,7 +13,7 @@ import (
 
 // swarmLogs takes an http response, request, and selector, and writes the logs
 // specified by the selector to the response
-func (sr *swarmRouter) swarmLogs(ctx context.Context, w http.ResponseWriter, r *http.Request, selector *backend.LogSelector) error {
+func (sr *swarmRouter) swarmLogs(ctx context.Context, w io.Writer, r *http.Request, selector *backend.LogSelector) error {
 	// Args are validated before the stream starts because when it starts we're
 	// sending HTTP 200 by writing an empty chunk of data to tell the client that
 	// daemon is going to stream. By sending this initial HTTP 200 we can't report

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -551,7 +551,7 @@ func parseOptInterval(f *Flag) (time.Duration, error) {
 	if err != nil {
 		return 0, err
 	}
-	if d < time.Duration(container.MinimumDuration) {
+	if d < container.MinimumDuration {
 		return 0, fmt.Errorf("Interval %#v cannot be less than %s", f.name, container.MinimumDuration)
 	}
 	return d, nil

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -243,7 +243,7 @@ func (b *Builder) probeCache(dispatchState *dispatchState, runConfig *container.
 	}
 	fmt.Fprint(b.Stdout, " ---> Using cache\n")
 
-	dispatchState.imageID = string(cachedID)
+	dispatchState.imageID = cachedID
 	b.buildStages.update(dispatchState.imageID)
 	return true, nil
 }

--- a/builder/remotecontext/remote.go
+++ b/builder/remotecontext/remote.go
@@ -110,7 +110,7 @@ func GetWithStatusError(address string) (resp *http.Response, err error) {
 //    - an io.Reader for the response body
 //    - an error value which will be non-nil either when something goes wrong while
 //      reading bytes from r or when the detected content-type is not acceptable.
-func inspectResponse(ct string, r io.ReadCloser, clen int64) (string, io.ReadCloser, error) {
+func inspectResponse(ct string, r io.Reader, clen int64) (string, io.ReadCloser, error) {
 	plen := clen
 	if plen <= 0 || plen > maxPreambleLength {
 		plen = maxPreambleLength
@@ -119,10 +119,10 @@ func inspectResponse(ct string, r io.ReadCloser, clen int64) (string, io.ReadClo
 	preamble := make([]byte, plen, plen)
 	rlen, err := r.Read(preamble)
 	if rlen == 0 {
-		return ct, r, errors.New("empty response")
+		return ct, ioutil.NopCloser(r), errors.New("empty response")
 	}
 	if err != nil && err != io.EOF {
-		return ct, r, err
+		return ct, ioutil.NopCloser(r), err
 	}
 
 	preambleR := bytes.NewReader(preamble[:rlen])

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -85,7 +85,7 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 	return response, err
 }
 
-func imageDigestAndPlatforms(ctx context.Context, cli *Client, image, encodedAuth string) (string, []swarm.Platform, error) {
+func imageDigestAndPlatforms(ctx context.Context, cli DistributionAPIClient, image, encodedAuth string) (string, []swarm.Platform, error) {
 	distributionInspect, err := cli.DistributionInspect(ctx, image, encodedAuth)
 	imageWithDigest := image
 	var platforms []swarm.Platform

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -539,7 +539,7 @@ func initRouter(opts routerOptions) {
 }
 
 // TODO: remove this from cli and return the authzMiddleware
-func (cli *DaemonCli) initMiddlewares(s *apiserver.Server, cfg *apiserver.Config, pluginStore *plugin.Store) error {
+func (cli *DaemonCli) initMiddlewares(s *apiserver.Server, cfg *apiserver.Config, pluginStore plugingetter.PluginGetter) error {
 	v := cfg.Version
 
 	exp := middleware.NewExperimentalMiddleware(cli.Config.Experimental)

--- a/container/container.go
+++ b/container/container.go
@@ -655,8 +655,12 @@ func (container *Container) BuildEndpointInfo(n libnetwork.Network, ep libnetwor
 	return nil
 }
 
+type named interface {
+	Name() string
+}
+
 // UpdateJoinInfo updates network settings when container joins network n with endpoint ep.
-func (container *Container) UpdateJoinInfo(n libnetwork.Network, ep libnetwork.Endpoint) error {
+func (container *Container) UpdateJoinInfo(n named, ep libnetwork.Endpoint) error {
 	if err := container.buildPortMapInfo(ep); err != nil {
 		return err
 	}
@@ -684,7 +688,7 @@ func (container *Container) UpdateSandboxNetworkSettings(sb libnetwork.Sandbox) 
 }
 
 // BuildJoinOptions builds endpoint Join options from a given network.
-func (container *Container) BuildJoinOptions(n libnetwork.Network) ([]libnetwork.EndpointOption, error) {
+func (container *Container) BuildJoinOptions(n named) ([]libnetwork.EndpointOption, error) {
 	var joinOptions []libnetwork.EndpointOption
 	if epConfig, ok := container.NetworkSettings.Networks[n.Name()]; ok {
 		for _, str := range epConfig.Links {

--- a/daemon/cluster/convert/swarm.go
+++ b/daemon/cluster/convert/swarm.go
@@ -3,7 +3,6 @@ package convert
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	types "github.com/docker/docker/api/types/swarm"
 	swarmapi "github.com/docker/swarmkit/api"
@@ -115,7 +114,7 @@ func MergeSwarmSpecToGRPC(s types.Spec, spec swarmapi.ClusterSpec) (swarmapi.Clu
 		spec.Raft.ElectionTick = uint32(s.Raft.ElectionTick)
 	}
 	if s.Dispatcher.HeartbeatPeriod != 0 {
-		spec.Dispatcher.HeartbeatPeriod = gogotypes.DurationProto(time.Duration(s.Dispatcher.HeartbeatPeriod))
+		spec.Dispatcher.HeartbeatPeriod = gogotypes.DurationProto(s.Dispatcher.HeartbeatPeriod)
 	}
 	if s.CAConfig.NodeCertExpiry != 0 {
 		spec.CAConfig.NodeCertExpiry = gogotypes.DurationProto(s.CAConfig.NodeCertExpiry)

--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -659,7 +659,7 @@ func (e *exitError) Error() string {
 }
 
 func (e *exitError) ExitCode() int {
-	return int(e.code)
+	return e.code
 }
 
 func (e *exitError) Cause() error {

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -142,7 +142,7 @@ func (d *Daemon) ContainerExecCreate(name string, config *types.ExecConfig) (str
 // ContainerExecStart starts a previously set up exec instance. The
 // std streams are set up.
 // If ctx is cancelled, the process is terminated.
-func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer) (err error) {
+func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.Reader, stdout io.Writer, stderr io.Writer) (err error) {
 	var (
 		cStdin           io.ReadCloser
 		cStdout, cStderr io.Writer

--- a/daemon/graphdriver/overlay/copy.go
+++ b/daemon/graphdriver/overlay/copy.go
@@ -158,8 +158,8 @@ func copyDir(srcDir, dstDir string, flags copyFlags) error {
 
 		// system.Chtimes doesn't support a NOFOLLOW flag atm
 		if !isSymlink {
-			aTime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
-			mTime := time.Unix(int64(stat.Mtim.Sec), int64(stat.Mtim.Nsec))
+			aTime := time.Unix(stat.Atim.Sec, stat.Atim.Nsec)
+			mTime := time.Unix(stat.Mtim.Sec, stat.Mtim.Nsec)
 			if err := system.Chtimes(dstPath, aTime, mTime); err != nil {
 				return err
 			}

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -97,10 +97,10 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 	drivers = strings.TrimSpace(drivers)
 	v := &types.Info{
 		ID:                 daemon.ID,
-		Containers:         int(cRunning + cPaused + cStopped),
-		ContainersRunning:  int(cRunning),
-		ContainersPaused:   int(cPaused),
-		ContainersStopped:  int(cStopped),
+		Containers:         cRunning + cPaused + cStopped,
+		ContainersRunning:  cRunning,
+		ContainersPaused:   cPaused,
+		ContainersStopped:  cStopped,
 		Images:             imageCount,
 		Driver:             drivers,
 		DriverStatus:       daemon.stores[p].layerStore.DriverStatus(),

--- a/daemon/listeners/listeners_unix.go
+++ b/daemon/listeners/listeners_unix.go
@@ -86,7 +86,7 @@ func listenFD(addr string, tlsConfig *tls.Config) ([]net.Listener, error) {
 		return nil, fmt.Errorf("failed to parse systemd fd address: should be a number: %v", addr)
 	}
 	fdOffset := fdNum - 3
-	if len(listeners) < int(fdOffset)+1 {
+	if len(listeners) < fdOffset+1 {
 		return nil, fmt.Errorf("too few socket activated files passed in by systemd")
 	}
 	if listeners[fdOffset] == nil {

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -834,7 +834,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 	s.Process.NoNewPrivileges = c.NoNewPrivileges
 	s.Linux.MountLabel = c.MountLabel
 
-	return (*specs.Spec)(&s), nil
+	return &s, nil
 }
 
 func clearReadOnly(m *specs.Mount) {

--- a/distribution/metadata/v2_metadata_service.go
+++ b/distribution/metadata/v2_metadata_service.go
@@ -84,7 +84,7 @@ func ComputeV2MetadataHMACKey(authConfig *types.AuthConfig) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return []byte(digest.FromBytes([]byte(buf))), nil
+	return []byte(digest.FromBytes(buf)), nil
 }
 
 // authConfigKeyInput is a reduced AuthConfig structure holding just relevant credential data eligible for

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -28,7 +28,7 @@ import (
 	"github.com/docker/docker/pkg/system"
 	refstore "github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -435,7 +435,7 @@ func (p *v2Puller) pullV2Tag(ctx context.Context, ref reference.Named) (tagUpdat
 	return true, nil
 }
 
-func (p *v2Puller) pullSchema1(ctx context.Context, ref reference.Named, unverifiedManifest *schema1.SignedManifest) (id digest.Digest, manifestDigest digest.Digest, err error) {
+func (p *v2Puller) pullSchema1(ctx context.Context, ref reference.Reference, unverifiedManifest *schema1.SignedManifest) (id digest.Digest, manifestDigest digest.Digest, err error) {
 	var verifiedManifest *schema1.Manifest
 	verifiedManifest, err = verifySchema1Manifest(unverifiedManifest, ref)
 	if err != nil {
@@ -838,7 +838,7 @@ func allowV1Fallback(err error) error {
 	return err
 }
 
-func verifySchema1Manifest(signedManifest *schema1.SignedManifest, ref reference.Named) (m *schema1.Manifest, err error) {
+func verifySchema1Manifest(signedManifest *schema1.SignedManifest, ref reference.Reference) (m *schema1.Manifest, err error) {
 	// If pull by digest, then verify the manifest digest. NOTE: It is
 	// important to do this first, before any other content validation. If the
 	// digest cannot be verified, don't even bother with those other things.

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -24,7 +24,7 @@ import (
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/registry"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
 )
 
@@ -651,6 +651,7 @@ func (bla byLikeness) Swap(i, j int) {
 }
 func (bla byLikeness) Len() int { return len(bla.arr) }
 
+// nolint: interfacer
 func sortV2MetadataByLikenessAndAge(repoInfo reference.Named, hmacKey []byte, marr []metadata.V2Metadata) {
 	// reverse the metadata array to shift the newest entries to the beginning
 	for i := 0; i < len(marr)/2; i++ {

--- a/hack/validate/gometalinter.json
+++ b/hack/validate/gometalinter.json
@@ -15,6 +15,7 @@
     "goimports",
     "golint",
     "interfacer",
+    "unconvert",
     "vet"
   ],
 

--- a/hack/validate/gometalinter.json
+++ b/hack/validate/gometalinter.json
@@ -14,6 +14,7 @@
     "gofmt",
     "goimports",
     "golint",
+    "interfacer",
     "vet"
   ],
 

--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -23,7 +23,7 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/docker/docker/pkg/system"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
 )
 
@@ -212,15 +212,12 @@ func (l *tarexporter) loadLayer(filename string, rootFS image.RootFS, id string,
 	return l.ls.Register(inflatedLayerData, rootFS.ChainID(), platform)
 }
 
-func (l *tarexporter) setLoadedTag(ref reference.NamedTagged, imgID digest.Digest, outStream io.Writer) error {
+func (l *tarexporter) setLoadedTag(ref reference.Named, imgID digest.Digest, outStream io.Writer) error {
 	if prevID, err := l.rs.Get(ref); err == nil && prevID != imgID {
 		fmt.Fprintf(outStream, "The image %s already exists, renaming the old one with ID %s to empty string\n", reference.FamiliarString(ref), string(prevID)) // todo: this message is wrong in case of multiple tags
 	}
 
-	if err := l.rs.AddTag(ref, imgID, true); err != nil {
-		return err
-	}
-	return nil
+	return l.rs.AddTag(ref, imgID, true)
 }
 
 func (l *tarexporter) legacyLoad(tmpDir string, outStream io.Writer, progressOutput progress.Output) error {

--- a/libcontainerd/client_unix.go
+++ b/libcontainerd/client_unix.go
@@ -50,7 +50,7 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 		return fmt.Errorf("Container %s is already active", containerID)
 	}
 
-	uid, gid, err := getRootIDs(specs.Spec(spec))
+	uid, gid, err := getRootIDs(spec)
 	if err != nil {
 		return err
 	}

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -180,7 +180,7 @@ func (opts *MapOpts) GetAll() map[string]string {
 }
 
 func (opts *MapOpts) String() string {
-	return fmt.Sprintf("%v", map[string]string((opts.values)))
+	return fmt.Sprintf("%v", opts.values)
 }
 
 // Type returns a string name for this Option type

--- a/opts/quotedstring.go
+++ b/opts/quotedstring.go
@@ -18,7 +18,7 @@ func (s *QuotedString) Type() string {
 }
 
 func (s *QuotedString) String() string {
-	return string(*s.value)
+	return *s.value
 }
 
 func trimQuotes(value string) string {

--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -50,8 +50,8 @@ func setHeaderForSpecialDevice(hdr *tar.Header, name string, stat interface{}) (
 		// Currently go does not fill in the major/minors
 		if s.Mode&unix.S_IFBLK != 0 ||
 			s.Mode&unix.S_IFCHR != 0 {
-			hdr.Devmajor = int64(major(uint64(s.Rdev)))
-			hdr.Devminor = int64(minor(uint64(s.Rdev)))
+			hdr.Devmajor = int64(major(s.Rdev))
+			hdr.Devminor = int64(minor(s.Rdev))
 		}
 	}
 
@@ -62,7 +62,7 @@ func getInodeFromStat(stat interface{}) (inode uint64, err error) {
 	s, ok := stat.(*syscall.Stat_t)
 
 	if ok {
-		inode = uint64(s.Ino)
+		inode = s.Ino
 	}
 
 	return

--- a/pkg/archive/changes_linux.go
+++ b/pkg/archive/changes_linux.go
@@ -294,7 +294,7 @@ func OverlayChanges(layers []string, rw string) ([]Change, error) {
 func overlayDeletedFile(root, path string, fi os.FileInfo) (string, error) {
 	if fi.Mode()&os.ModeCharDevice != 0 {
 		s := fi.Sys().(*syscall.Stat_t)
-		if major(uint64(s.Rdev)) == 0 && minor(uint64(s.Rdev)) == 0 {
+		if major(s.Rdev) == 0 && minor(s.Rdev) == 0 {
 			return path, nil
 		}
 	}

--- a/pkg/archive/changes_unix.go
+++ b/pkg/archive/changes_unix.go
@@ -29,7 +29,7 @@ func (info *FileInfo) isDir() bool {
 }
 
 func getIno(fi os.FileInfo) uint64 {
-	return uint64(fi.Sys().(*syscall.Stat_t).Ino)
+	return fi.Sys().(*syscall.Stat_t).Ino
 }
 
 func hasHardlinks(fi os.FileInfo) bool {

--- a/pkg/devicemapper/devmapper_log.go
+++ b/pkg/devicemapper/devmapper_log.go
@@ -74,7 +74,7 @@ type DefaultLogger struct {
 // DMLog is the logging callback containing all of the information from
 // devicemapper. The interface is identical to the C libdm counterpart.
 func (l DefaultLogger) DMLog(level int, file string, line, dmError int, message string) {
-	if int(level) <= l.Level {
+	if level <= l.Level {
 		// Forward the log to the correct logrus level, if allowed by dmLogLevel.
 		logMsg := fmt.Sprintf("libdevmapper(%d): %s:%d (%d) %s", level, file, line, dmError, message)
 		switch level {

--- a/pkg/directory/directory_unix.go
+++ b/pkg/directory/directory_unix.go
@@ -34,11 +34,11 @@ func Size(dir string) (size int64, err error) {
 		// Check inode to handle hard links correctly
 		inode := fileInfo.Sys().(*syscall.Stat_t).Ino
 		// inode is not a uint64 on all platforms. Cast it to avoid issues.
-		if _, exists := data[uint64(inode)]; exists {
+		if _, exists := data[inode]; exists {
 			return nil
 		}
 		// inode is not a uint64 on all platforms. Cast it to avoid issues.
-		data[uint64(inode)] = struct{}{}
+		data[inode] = struct{}{}
 
 		size += s
 

--- a/pkg/system/stat_linux.go
+++ b/pkg/system/stat_linux.go
@@ -5,10 +5,10 @@ import "syscall"
 // fromStatT converts a syscall.Stat_t type to a system.Stat_t type
 func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 	return &StatT{size: s.Size,
-		mode: uint32(s.Mode),
+		mode: s.Mode,
 		uid:  s.Uid,
 		gid:  s.Gid,
-		rdev: uint64(s.Rdev),
+		rdev: s.Rdev,
 		mtim: s.Mtim}, nil
 }
 

--- a/pkg/term/ascii.go
+++ b/pkg/term/ascii.go
@@ -59,7 +59,7 @@ next:
 				return nil, fmt.Errorf("Unknown character: '%s'", key)
 			}
 		} else {
-			codes = append(codes, byte(key[0]))
+			codes = append(codes, key[0])
 		}
 	}
 	return codes, nil

--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -18,7 +18,6 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/plugin/v2"
 	"github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -62,7 +61,7 @@ func (pm *Manager) enable(p *v2.Plugin, c *controller, force bool) error {
 		return errors.WithStack(err)
 	}
 
-	if err := pm.containerdClient.Create(p.GetID(), "", "", specs.Spec(*spec), attachToLog(p.GetID())); err != nil {
+	if err := pm.containerdClient.Create(p.GetID(), "", "", *spec, attachToLog(p.GetID())); err != nil {
 		if p.PropagatedMount != "" {
 			if err := mount.Unmount(p.PropagatedMount); err != nil {
 				logrus.Warnf("Could not unmount %s: %v", p.PropagatedMount, err)

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -247,6 +247,7 @@ func (err PingResponseError) Error() string {
 // challenge manager for the supported authentication types and
 // whether v2 was confirmed by the response. If a response is received but
 // cannot be interpreted a PingResponseError will be returned.
+// nolint: interfacer
 func PingV2Registry(endpoint *url.URL, transport http.RoundTripper) (challenge.Manager, bool, error) {
 	var (
 		foundV2   = false


### PR DESCRIPTION
`interfacer` checks function arguments for types that could use a smaller interface
`unconvert` finds unnecessary type convertions