### PR TITLE
docker_api_ipcmode_test: add SameHostDaemon req

### DIFF
--- a/integration-cli/docker_api_ipcmode_test.go
+++ b/integration-cli/docker_api_ipcmode_test.go
@@ -104,7 +104,7 @@ func (s *DockerSuite) TestAPIIpcModeNone(c *check.C) {
  * such pair on the host.
  */
 func (s *DockerSuite) TestAPIIpcModePrivate(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	testIpcNonePrivateShareable(c, "private", true, false)
 }
 
@@ -114,7 +114,7 @@ func (s *DockerSuite) TestAPIIpcModePrivate(c *check.C) {
  * also exists on the host.
  */
 func (s *DockerSuite) TestAPIIpcModeShareable(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	testIpcNonePrivateShareable(c, "shareable", true, true)
 }
 
@@ -188,7 +188,7 @@ func (s *DockerSuite) TestAPIIpcModePrivateAndContainer(c *check.C) {
  * can use IPC of the host system.
  */
 func (s *DockerSuite) TestAPIIpcModeHost(c *check.C) {
-	testRequires(c, DaemonIsLinux, NotUserNamespace)
+	testRequires(c, DaemonIsLinux, SameHostDaemon, NotUserNamespace)
 
 	cfg := container.Config{
 		Image: "busybox",

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -3022,7 +3022,7 @@ func testDaemonIpcPrivateShareable(d *daemon.Daemon, c *check.C, mustExist bool)
 
 // TestDaemonIpcModeShareable checks that --default-ipc-mode shareable works as intended.
 func (s *DockerDaemonSuite) TestDaemonIpcModeShareable(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 
 	s.d.StartWithBusybox(c, "--default-ipc-mode", "shareable")
 	testDaemonIpcPrivateShareable(s.d, c, true)
@@ -3030,7 +3030,7 @@ func (s *DockerDaemonSuite) TestDaemonIpcModeShareable(c *check.C) {
 
 // TestDaemonIpcModePrivate checks that --default-ipc-mode private works as intended.
 func (s *DockerDaemonSuite) TestDaemonIpcModePrivate(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 
 	s.d.StartWithBusybox(c, "--default-ipc-mode", "private")
 	testDaemonIpcPrivateShareable(s.d, c, false)
@@ -3053,17 +3053,17 @@ func testDaemonIpcFromConfig(s *DockerDaemonSuite, c *check.C, mode string, must
 
 // TestDaemonIpcModePrivateFromConfig checks that "default-ipc-mode: private" config works as intended.
 func (s *DockerDaemonSuite) TestDaemonIpcModePrivateFromConfig(c *check.C) {
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	testDaemonIpcFromConfig(s, c, "private", false)
 }
 
 // TestDaemonIpcModeShareableFromConfig checks that "default-ipc-mode: shareable" config works as intended.
 func (s *DockerDaemonSuite) TestDaemonIpcModeShareableFromConfig(c *check.C) {
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	testDaemonIpcFromConfig(s, c, "shareable", true)
 }
 
 func testDaemonStartIpcMode(c *check.C, from, mode string, valid bool) {
-	testRequires(c, DaemonIsLinux)
-
 	d := daemon.New(c, dockerBinary, dockerdBinary, daemon.Config{
 		Experimental: testEnv.ExperimentalDaemon(),
 	})
@@ -3101,6 +3101,8 @@ func testDaemonStartIpcMode(c *check.C, from, mode string, valid bool) {
 // arguments for default IPC mode, and bails out with incorrect ones.
 // Both CLI option (--default-ipc-mode) and config parameter are tested.
 func (s *DockerDaemonSuite) TestDaemonStartWithIpcModes(c *check.C) {
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
+
 	ipcModes := []struct {
 		mode  string
 		valid bool


### PR DESCRIPTION
This is needed for tests that do some checks and/or create files
on the host system. Inspired by commit d9f3548a9.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

