### PR TITLE
LCOW (and generic): Add Supported-Platforms to _ping API endpoint

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -15,6 +15,7 @@ import (
 	timetypes "github.com/docker/docker/api/types/time"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/pkg/system"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -26,7 +27,13 @@ func optionsHandler(ctx context.Context, w http.ResponseWriter, r *http.Request,
 }
 
 func pingHandler(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	_, err := w.Write([]byte{'O', 'K'})
+	platforms := system.SupportedPlatforms()
+	platformsJSON, err := json.Marshal(platforms)
+	if err != nil {
+		return err
+	}
+	w.Header().Add("Supported-Platforms", string(platformsJSON[:]))
+	_, err = w.Write([]byte{'O', 'K'})
 	return err
 }
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6779,6 +6779,9 @@ paths:
             Docker-Experimental:
               type: "boolean"
               description: "If the server is running with experimental mode enabled"
+            Supported-Platforms:
+              type: "string"
+              description: "JSON encoded list of supported platforms"
         500:
           description: "server error"
           schema:

--- a/pkg/system/lcow.go
+++ b/pkg/system/lcow.go
@@ -1,0 +1,28 @@
+package system
+
+import (
+	"runtime"
+
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// SupportedPlatforms is a helper function which returns an array of
+// supported platforms. This is so that an API client can query the daemon
+// via a _ping to determine whether a request is valid or not.
+func SupportedPlatforms() []*specs.Platform {
+	var platforms []*specs.Platform
+
+	platforms = append(platforms, &specs.Platform{
+		Architecture: runtime.GOARCH,
+		OS:           runtime.GOOS,
+	})
+
+	if LCOWSupported() {
+		platforms = append(platforms, &specs.Platform{
+			Architecture: runtime.GOARCH,
+			OS:           "linux",
+		})
+	}
+
+	return platforms
+}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This is part of the LCOW discussion issue, specifically for https://github.com/moby/moby/issues/34617#issuecomment-324730147. It adds an HTTP header to the _ping API endpoint so that a client can determine whether the daemon is multi-platform capable, and the list of possible values. As HTTP headers can't be structured, it passes this as a string. 

For a Linux daemon, it would return something like `Supported-Platforms: linux/amd64`. For a dual-mode LCOW/WCOW daemon on Windows, it would return `Supported-Platforms: windows/amd64,linux/amd64`.

@dnephin @johnstep 

EDIT: Updated to use JSON encode the OCI Image-Spec platform structure instead of a comma-separated list.