### PR TITLE
LCOW: API: Add `platform` to /images/create and /build

### DIFF
--- a/api/server/httputils/httputils.go
+++ b/api/server/httputils/httputils.go
@@ -1,17 +1,11 @@
 package httputils
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 	"mime"
 	"net/http"
-	"runtime"
 	"strings"
 
-	"github.com/docker/docker/api/types/versions"
-	"github.com/docker/docker/pkg/system"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -114,28 +108,4 @@ func matchesContentType(contentType, expectedType string) bool {
 		logrus.Errorf("Error parsing media type: %s error: %v", contentType, err)
 	}
 	return err == nil && mimetype == expectedType
-}
-
-// GetRequestedPlatform extracts an optional platform structure from an HTTP request header
-func GetRequestedPlatform(ctx context.Context, r *http.Request) (*specs.Platform, error) {
-	platform := &specs.Platform{}
-	version := VersionFromContext(ctx)
-	if versions.GreaterThanOrEqualTo(version, "1.32") {
-		requestedPlatform := r.Header.Get("X-Requested-Platform")
-		if requestedPlatform != "" {
-			if err := json.Unmarshal([]byte(requestedPlatform), platform); err != nil {
-				return nil, fmt.Errorf("invalid X-Requested-Platform header: %s", err)
-			}
-		}
-		if err := system.ValidatePlatform(platform); err != nil {
-			return nil, err
-		}
-	}
-	if platform.OS == "" {
-		platform.OS = runtime.GOOS
-	}
-	if platform.Architecture == "" {
-		platform.Architecture = runtime.GOARCH
-	}
-	return platform, nil
 }

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -87,6 +87,12 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 		return nil, validationError{fmt.Errorf("The daemon on this platform does not support setting security options on build")}
 	}
 
+	platform, err := httputils.GetRequestedPlatform(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	options.Platform = *platform
+
 	var buildUlimits = []*units.Ulimit{}
 	ulimitsJSON := r.FormValue("ulimits")
 	if ulimitsJSON != "" {

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/docker/docker/pkg/system"
 	units "github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -67,6 +69,24 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	options.Squash = httputils.BoolValue(r, "squash")
 	options.Target = r.FormValue("target")
 	options.RemoteContext = r.FormValue("remote")
+	if versions.GreaterThanOrEqualTo(version, "1.32") {
+		// TODO @jhowardmsft. The following environment variable is an interim
+		// measure to allow the daemon to have a default platform if omitted by
+		// the client. This allows LCOW and WCOW to work with a down-level CLI
+		// for a short period of time, as the CLI changes can't be merged
+		// until after the daemon changes have been merged. Once the CLI is
+		// updated, this can be removed. PR for CLI is currently in
+		// https://github.com/docker/cli/pull/474.
+		apiPlatform := r.FormValue("platform")
+		if system.LCOWSupported() && apiPlatform == "" {
+			apiPlatform = os.Getenv("LCOW_API_PLATFORM_IF_OMITTED")
+		}
+		p := system.ParsePlatform(apiPlatform)
+		if err := system.ValidatePlatform(p); err != nil {
+			return nil, validationError{fmt.Errorf("invalid platform: %s", err)}
+		}
+		options.Platform = p.OS
+	}
 
 	if r.Form.Get("shmsize") != "" {
 		shmSize, err := strconv.ParseInt(r.Form.Get("shmsize"), 10, 64)
@@ -86,12 +106,6 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	if runtime.GOOS != "windows" && options.SecurityOpt != nil {
 		return nil, validationError{fmt.Errorf("The daemon on this platform does not support setting security options on build")}
 	}
-
-	platform, err := httputils.GetRequestedPlatform(ctx, r)
-	if err != nil {
-		return nil, err
-	}
-	options.Platform = *platform
 
 	var buildUlimits = []*units.Ulimit{}
 	ulimitsJSON := r.FormValue("ulimits")

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -3,8 +3,10 @@ package image
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
@@ -16,6 +18,7 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/registry"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -70,6 +73,7 @@ func (s *imageRouter) postCommit(ctx context.Context, w http.ResponseWriter, r *
 
 // Creates an image from Pull or from Import
 func (s *imageRouter) postImagesCreate(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
@@ -87,7 +91,25 @@ func (s *imageRouter) postImagesCreate(ctx context.Context, w http.ResponseWrite
 
 	w.Header().Set("Content-Type", "application/json")
 
-	platform, err = httputils.GetRequestedPlatform(ctx, r)
+	version := httputils.VersionFromContext(ctx)
+	if versions.GreaterThanOrEqualTo(version, "1.32") {
+		// TODO @jhowardmsft. The following environment variable is an interim
+		// measure to allow the daemon to have a default platform if omitted by
+		// the client. This allows LCOW and WCOW to work with a down-level CLI
+		// for a short period of time, as the CLI changes can't be merged
+		// until after the daemon changes have been merged. Once the CLI is
+		// updated, this can be removed. PR for CLI is currently in
+		// https://github.com/docker/cli/pull/474.
+		apiPlatform := r.FormValue("platform")
+		if system.LCOWSupported() && apiPlatform == "" {
+			apiPlatform = os.Getenv("LCOW_API_PLATFORM_IF_OMITTED")
+		}
+		platform = system.ParsePlatform(apiPlatform)
+		if err = system.ValidatePlatform(platform); err != nil {
+			err = fmt.Errorf("invalid platform: %s", err)
+		}
+	}
+
 	if err == nil {
 		if image != "" { //pull
 			metaHeaders := map[string][]string{}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6181,6 +6181,19 @@ paths:
 
             Only the registry domain name (and port if not the default 443) are required. However, for legacy reasons, the Docker Hub registry must be specified with both a `https://` prefix and a `/v1/` suffix even though Docker will prefer to use the v2 registry API.
           type: "string"
+        - name: "X-Requested-Platform"
+          in: "header"
+          description: |
+            This is a JSON object representing an OCI image-spec `Platform` object. It is used to request a platform in the case that the engine supports multiple platforms. For example:
+
+            ```
+            {
+              "architecture": "amd64",
+              "os": "linux"
+            }
+            ```
+          type: "string"
+          default: ""
       responses:
         200:
           description: "no error"
@@ -6262,6 +6275,19 @@ paths:
           in: "header"
           description: "A base64-encoded auth configuration. [See the authentication section for details.](#section/Authentication)"
           type: "string"
+        - name: "X-Requested-Platform"
+          in: "header"
+          description: |
+            This is a JSON object representing an OCI image-spec `Platform` object. It is used to request a platform in the case that the engine supports multiple platforms. For example:
+
+            ```
+            {
+              "architecture": "amd64",
+              "os": "linux"
+            }
+            ```
+          type: "string"
+          default: ""
       tags: ["Image"]
   /images/{name}/json:
     get:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6181,17 +6181,9 @@ paths:
 
             Only the registry domain name (and port if not the default 443) are required. However, for legacy reasons, the Docker Hub registry must be specified with both a `https://` prefix and a `/v1/` suffix even though Docker will prefer to use the v2 registry API.
           type: "string"
-        - name: "X-Requested-Platform"
-          in: "header"
-          description: |
-            This is a JSON object representing an OCI image-spec `Platform` object. It is used to request a platform in the case that the engine supports multiple platforms. For example:
-
-            ```
-            {
-              "architecture": "amd64",
-              "os": "linux"
-            }
-            ```
+        - name: "platform"
+          in: "query"
+          description: "Platform in the format os[/arch[/variant]]"
           type: "string"
           default: ""
       responses:
@@ -6275,17 +6267,9 @@ paths:
           in: "header"
           description: "A base64-encoded auth configuration. [See the authentication section for details.](#section/Authentication)"
           type: "string"
-        - name: "X-Requested-Platform"
-          in: "header"
-          description: |
-            This is a JSON object representing an OCI image-spec `Platform` object. It is used to request a platform in the case that the engine supports multiple platforms. For example:
-
-            ```
-            {
-              "architecture": "amd64",
-              "os": "linux"
-            }
-            ```
+        - name: "platform"
+          in: "query"
+          description: "Platform in the format os[/arch[/variant]]"
           type: "string"
           default: ""
       tags: ["Image"]

--- a/api/types/backend/build.go
+++ b/api/types/backend/build.go
@@ -40,5 +40,5 @@ type GetImageAndLayerOptions struct {
 	PullOption PullOption
 	AuthConfig map[string]types.AuthConfig
 	Output     io.Writer
-	Platform   string
+	OS         string
 }

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	units "github.com/docker/go-units"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // CheckpointCreateOptions holds parameters to create a checkpoint from a container
@@ -180,7 +179,7 @@ type ImageBuildOptions struct {
 	ExtraHosts  []string // List of extra hosts
 	Target      string
 	SessionID   string
-	Platform    specs.Platform
+	Platform    string
 }
 
 // ImageBuildResponse holds information
@@ -193,8 +192,8 @@ type ImageBuildResponse struct {
 
 // ImageCreateOptions holds information to create images.
 type ImageCreateOptions struct {
-	RegistryAuth string         // RegistryAuth is the base64 encoded credentials for the registry.
-	Platform     specs.Platform // Platform is the target platform of the image if it needs to be pulled from the registry.
+	RegistryAuth string // RegistryAuth is the base64 encoded credentials for the registry.
+	Platform     string // Platform is the target platform of the image if it needs to be pulled from the registry.
 }
 
 // ImageImportSource holds source information for ImageImport
@@ -205,9 +204,10 @@ type ImageImportSource struct {
 
 // ImageImportOptions holds information to import images from the client host.
 type ImageImportOptions struct {
-	Tag     string   // Tag is the name to tag this image with. This attribute is deprecated.
-	Message string   // Message is the message to tag the image with
-	Changes []string // Changes are the raw changes to apply to this image
+	Tag      string   // Tag is the name to tag this image with. This attribute is deprecated.
+	Message  string   // Message is the message to tag the image with
+	Changes  []string // Changes are the raw changes to apply to this image
+	Platform string   // Platform is the target platform of the image
 }
 
 // ImageListOptions holds parameters to filter the list of images with.
@@ -228,7 +228,7 @@ type ImagePullOptions struct {
 	All           bool
 	RegistryAuth  string // RegistryAuth is the base64 encoded credentials for the registry
 	PrivilegeFunc RequestPrivilegeFunc
-	Platform      specs.Platform
+	Platform      string
 }
 
 // RequestPrivilegeFunc is a function interface that

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	units "github.com/docker/go-units"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // CheckpointCreateOptions holds parameters to create a checkpoint from a container
@@ -179,10 +180,7 @@ type ImageBuildOptions struct {
 	ExtraHosts  []string // List of extra hosts
 	Target      string
 	SessionID   string
-
-	// TODO @jhowardmsft LCOW Support: This will require extending to include
-	// `Platform string`, but is omitted for now as it's hard-coded temporarily
-	// to avoid API changes.
+	Platform    specs.Platform
 }
 
 // ImageBuildResponse holds information
@@ -195,7 +193,8 @@ type ImageBuildResponse struct {
 
 // ImageCreateOptions holds information to create images.
 type ImageCreateOptions struct {
-	RegistryAuth string // RegistryAuth is the base64 encoded credentials for the registry
+	RegistryAuth string         // RegistryAuth is the base64 encoded credentials for the registry.
+	Platform     specs.Platform // Platform is the target platform of the image if it needs to be pulled from the registry.
 }
 
 // ImageImportSource holds source information for ImageImport
@@ -229,6 +228,7 @@ type ImagePullOptions struct {
 	All           bool
 	RegistryAuth  string // RegistryAuth is the base64 encoded credentials for the registry
 	PrivilegeFunc RequestPrivilegeFunc
+	Platform      specs.Platform
 }
 
 // RequestPrivilegeFunc is a function interface that

--- a/api/types/configs.go
+++ b/api/types/configs.go
@@ -16,7 +16,6 @@ type ContainerCreateConfig struct {
 	HostConfig       *container.HostConfig
 	NetworkingConfig *network.NetworkingConfig
 	AdjustCPUShares  bool
-	Platform         string
 }
 
 // ContainerRmConfig holds arguments for the container remove

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -327,7 +327,7 @@ type ContainerJSONBase struct {
 	Name            string
 	RestartCount    int
 	Driver          string
-	Platform        string
+	OS              string
 	MountLabel      string
 	ProcessLabel    string
 	AppArmorProfile string

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/go-connections/nat"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // RootFS returns Image's RootFS description including the layer IDs.
@@ -327,7 +328,7 @@ type ContainerJSONBase struct {
 	Name            string
 	RestartCount    int
 	Driver          string
-	OS              string
+	Platform        specs.Platform
 	MountLabel      string
 	ProcessLabel    string
 	AppArmorProfile string

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -95,6 +95,7 @@ type Image interface {
 	ImageID() string
 	RunConfig() *container.Config
 	MarshalJSON() ([]byte, error)
+	OperatingSystem() string
 }
 
 // ReleaseableLayer is an image layer that can be mounted and released

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -20,7 +20,6 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/docker/docker/pkg/system"
 	"github.com/moby/buildkit/session"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -93,15 +92,6 @@ func (bm *BuildManager) Build(ctx context.Context, config backend.BuildConfig) (
 		}
 	}()
 
-	// TODO @jhowardmsft LCOW support - this will require rework to allow both linux and Windows simultaneously.
-	// This is an interim solution to hardcode to linux if LCOW is turned on.
-	if dockerfile.Platform == "" {
-		dockerfile.Platform = runtime.GOOS
-		if dockerfile.Platform == "windows" && system.LCOWSupported() {
-			dockerfile.Platform = "linux"
-		}
-	}
-
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -111,16 +101,26 @@ func (bm *BuildManager) Build(ctx context.Context, config backend.BuildConfig) (
 		source = src
 	}
 
+	os := runtime.GOOS
+	if dockerfile.OS != "" {
+		if config.Options.Platform.OS != "" && config.Options.Platform.OS != dockerfile.OS {
+			return nil, fmt.Errorf("invalid platform")
+		}
+		os = dockerfile.OS
+	} else if config.Options.Platform.OS != "" {
+		os = config.Options.Platform.OS
+	}
+	config.Options.Platform.OS = os
+	dockerfile.OS = os
+
 	builderOptions := builderOptions{
 		Options:        config.Options,
 		ProgressWriter: config.ProgressWriter,
 		Backend:        bm.backend,
 		PathCache:      bm.pathCache,
 		IDMappings:     bm.idMappings,
-		Platform:       dockerfile.Platform,
 	}
-
-	return newBuilder(ctx, builderOptions).build(source, dockerfile)
+	return newBuilder(ctx, builderOptions, os).build(source, dockerfile)
 }
 
 func (bm *BuildManager) initializeClientSession(ctx context.Context, cancel func(), options *types.ImageBuildOptions) (builder.Source, error) {
@@ -163,7 +163,6 @@ type builderOptions struct {
 	ProgressWriter backend.ProgressWriter
 	PathCache      pathCache
 	IDMappings     *idtools.IDMappings
-	Platform       string
 }
 
 // Builder is a Dockerfile builder
@@ -185,30 +184,13 @@ type Builder struct {
 	pathCache        pathCache
 	containerManager *containerManager
 	imageProber      ImageProber
-
-	// TODO @jhowardmft LCOW Support. This will be moved to options at a later
-	// stage, however that cannot be done now as it affects the public API
-	// if it were.
-	platform string
 }
 
 // newBuilder creates a new Dockerfile builder from an optional dockerfile and a Options.
-// TODO @jhowardmsft LCOW support: Eventually platform can be moved into the builder
-// options, however, that would be an API change as it shares types.ImageBuildOptions.
-func newBuilder(clientCtx context.Context, options builderOptions) *Builder {
+func newBuilder(clientCtx context.Context, options builderOptions, os string) *Builder {
 	config := options.Options
 	if config == nil {
 		config = new(types.ImageBuildOptions)
-	}
-
-	// @jhowardmsft LCOW Support. For the time being, this is interim. Eventually
-	// will be moved to types.ImageBuildOptions, but it can't for now as that would
-	// be an API change.
-	if options.Platform == "" {
-		options.Platform = runtime.GOOS
-	}
-	if options.Platform == "windows" && system.LCOWSupported() {
-		options.Platform = "linux"
 	}
 
 	b := &Builder{
@@ -222,9 +204,8 @@ func newBuilder(clientCtx context.Context, options builderOptions) *Builder {
 		idMappings:       options.IDMappings,
 		imageSources:     newImageSources(clientCtx, options),
 		pathCache:        options.PathCache,
-		imageProber:      newImageProber(options.Backend, config.CacheFrom, options.Platform, config.NoCache),
+		imageProber:      newImageProber(options.Backend, config.CacheFrom, os, config.NoCache),
 		containerManager: newContainerManager(options.Backend),
-		platform:         options.Platform,
 	}
 
 	return b
@@ -382,25 +363,19 @@ func BuildFromConfig(config *container.Config, changes []string) (*container.Con
 		return config, nil
 	}
 
-	b := newBuilder(context.Background(), builderOptions{
-		Options: &types.ImageBuildOptions{NoCache: true},
-	})
-
 	dockerfile, err := parser.Parse(bytes.NewBufferString(strings.Join(changes, "\n")))
 	if err != nil {
 		return nil, validationError{err}
 	}
 
-	// TODO @jhowardmsft LCOW support. For now, if LCOW enabled, switch to linux.
-	// Also explicitly set the platform. Ultimately this will be in the builder
-	// options, but we can't do that yet as it would change the API.
-	if dockerfile.Platform == "" {
-		dockerfile.Platform = runtime.GOOS
+	os := runtime.GOOS
+	if dockerfile.OS != "" {
+		os = dockerfile.OS
 	}
-	if dockerfile.Platform == "windows" && system.LCOWSupported() {
-		dockerfile.Platform = "linux"
-	}
-	b.platform = dockerfile.Platform
+
+	b := newBuilder(context.Background(), builderOptions{
+		Options: &types.ImageBuildOptions{NoCache: true},
+	}, os)
 
 	// ensure that the commands are valid
 	for _, n := range dockerfile.AST.Children {

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/docker/pkg/system"
 	"github.com/moby/buildkit/session"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -102,15 +103,16 @@ func (bm *BuildManager) Build(ctx context.Context, config backend.BuildConfig) (
 	}
 
 	os := runtime.GOOS
+	optionsPlatform := system.ParsePlatform(config.Options.Platform)
 	if dockerfile.OS != "" {
-		if config.Options.Platform.OS != "" && config.Options.Platform.OS != dockerfile.OS {
+		if optionsPlatform.OS != "" && optionsPlatform.OS != dockerfile.OS {
 			return nil, fmt.Errorf("invalid platform")
 		}
 		os = dockerfile.OS
-	} else if config.Options.Platform.OS != "" {
-		os = config.Options.Platform.OS
+	} else if optionsPlatform.OS != "" {
+		os = optionsPlatform.OS
 	}
-	config.Options.Platform.OS = os
+	config.Options.Platform = os
 	dockerfile.OS = os
 
 	builderOptions := builderOptions{

--- a/builder/dockerfile/builder_unix.go
+++ b/builder/dockerfile/builder_unix.go
@@ -2,6 +2,6 @@
 
 package dockerfile
 
-func defaultShellForPlatform(platform string) []string {
+func defaultShellForOS(os string) []string {
 	return []string{"/bin/sh", "-c"}
 }

--- a/builder/dockerfile/builder_windows.go
+++ b/builder/dockerfile/builder_windows.go
@@ -1,7 +1,7 @@
 package dockerfile
 
-func defaultShellForPlatform(platform string) []string {
-	if platform == "linux" {
+func defaultShellForOS(os string) []string {
+	if os == "linux" {
 		return []string{"/bin/sh", "-c"}
 	}
 	return []string{"cmd", "/S", "/C"}

--- a/builder/dockerfile/containerbackend.go
+++ b/builder/dockerfile/containerbackend.go
@@ -32,7 +32,6 @@ func (c *containerManager) Create(runConfig *container.Config, hostConfig *conta
 	container, err := c.backend.ContainerCreate(types.ContainerCreateConfig{
 		Config:     runConfig,
 		HostConfig: hostConfig,
-		Platform:   platform,
 	})
 	if err != nil {
 		return container, err

--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -82,7 +82,7 @@ func copierFromDispatchRequest(req dispatchRequest, download sourceDownloader, i
 		pathCache:   req.builder.pathCache,
 		download:    download,
 		imageSource: imageSource,
-		platform:    req.builder.options.Platform.OS,
+		platform:    req.builder.options.Platform,
 	}
 }
 

--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -82,7 +82,7 @@ func copierFromDispatchRequest(req dispatchRequest, download sourceDownloader, i
 		pathCache:   req.builder.pathCache,
 		download:    download,
 		imageSource: imageSource,
-		platform:    req.builder.platform,
+		platform:    req.builder.options.Platform.OS,
 	}
 }
 

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/docker/builder/dockerfile/instructions"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/go-connections/nat"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,13 +22,13 @@ func newBuilderWithMockBackend() *Builder {
 	mockBackend := &MockBackend{}
 	ctx := context.Background()
 	b := &Builder{
-		options:       &types.ImageBuildOptions{Platform: specs.Platform{OS: runtime.GOOS}},
+		options:       &types.ImageBuildOptions{Platform: runtime.GOOS},
 		docker:        mockBackend,
 		Stdout:        new(bytes.Buffer),
 		clientCtx:     ctx,
 		disableCommit: true,
 		imageSources: newImageSources(ctx, builderOptions{
-			Options: &types.ImageBuildOptions{Platform: specs.Platform{OS: runtime.GOOS}},
+			Options: &types.ImageBuildOptions{Platform: runtime.GOOS},
 			Backend: mockBackend,
 		}),
 		imageProber:      newImageProber(mockBackend, nil, runtime.GOOS, false),

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/builder/dockerfile/instructions"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/go-connections/nat"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,13 +23,13 @@ func newBuilderWithMockBackend() *Builder {
 	mockBackend := &MockBackend{}
 	ctx := context.Background()
 	b := &Builder{
-		options:       &types.ImageBuildOptions{},
+		options:       &types.ImageBuildOptions{Platform: specs.Platform{OS: runtime.GOOS}},
 		docker:        mockBackend,
 		Stdout:        new(bytes.Buffer),
 		clientCtx:     ctx,
 		disableCommit: true,
 		imageSources: newImageSources(ctx, builderOptions{
-			Options: &types.ImageBuildOptions{},
+			Options: &types.ImageBuildOptions{Platform: specs.Platform{OS: runtime.GOOS}},
 			Backend: mockBackend,
 		}),
 		imageProber:      newImageProber(mockBackend, nil, runtime.GOOS, false),
@@ -118,11 +119,7 @@ func TestFromScratch(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, sb.state.hasFromImage())
 	assert.Equal(t, "", sb.state.imageID)
-	// Windows does not set the default path. TODO @jhowardmsft LCOW support. This will need revisiting as we get further into the implementation
 	expected := "PATH=" + system.DefaultPathEnv(runtime.GOOS)
-	if runtime.GOOS == "windows" {
-		expected = ""
-	}
 	assert.Equal(t, []string{expected}, sb.state.runConfig.Env)
 }
 

--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -21,7 +21,6 @@ package dockerfile
 
 import (
 	"reflect"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -35,7 +34,7 @@ import (
 
 func dispatch(d dispatchRequest, cmd instructions.Command) error {
 	if c, ok := cmd.(instructions.PlatformSpecific); ok {
-		err := c.CheckPlatform(d.builder.platform)
+		err := c.CheckPlatform(d.builder.options.Platform.OS)
 		if err != nil {
 			return validationError{err}
 		}
@@ -218,19 +217,15 @@ func (s *dispatchState) beginStage(stageName string, image builder.Image) {
 	s.runConfig.StdinOnce = false
 }
 
-// Add the default PATH to runConfig.ENV if one exists for the platform and there
+// Add the default PATH to runConfig.ENV if one exists for the operating system and there
 // is no PATH set. Note that Windows containers on Windows won't have one as it's set by HCS
 func (s *dispatchState) setDefaultPath() {
-	// TODO @jhowardmsft LCOW Support - This will need revisiting later
-	platform := runtime.GOOS
-	if system.LCOWSupported() {
-		platform = "linux"
-	}
-	if system.DefaultPathEnv(platform) == "" {
+	defaultPath := system.DefaultPathEnv(s.baseImage.OperatingSystem())
+	if defaultPath == "" {
 		return
 	}
 	envMap := opts.ConvertKVStringsToMap(s.runConfig.Env)
 	if _, ok := envMap["PATH"]; !ok {
-		s.runConfig.Env = append(s.runConfig.Env, "PATH="+system.DefaultPathEnv(platform))
+		s.runConfig.Env = append(s.runConfig.Env, "PATH="+defaultPath)
 	}
 }

--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -34,7 +34,8 @@ import (
 
 func dispatch(d dispatchRequest, cmd instructions.Command) error {
 	if c, ok := cmd.(instructions.PlatformSpecific); ok {
-		err := c.CheckPlatform(d.builder.options.Platform.OS)
+		optionsOS := system.ParsePlatform(d.builder.options.Platform).OS
+		err := c.CheckPlatform(optionsOS)
 		if err != nil {
 			return validationError{err}
 		}

--- a/builder/dockerfile/imagecontext.go
+++ b/builder/dockerfile/imagecontext.go
@@ -5,6 +5,7 @@ import (
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/remotecontext"
 	dockerimage "github.com/docker/docker/image"
+	"github.com/docker/docker/pkg/system"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -30,11 +31,12 @@ func newImageSources(ctx context.Context, options builderOptions) *imageSources 
 				pullOption = backend.PullOptionPreferLocal
 			}
 		}
+		optionsPlatform := system.ParsePlatform(options.Options.Platform)
 		return options.Backend.GetImageAndReleasableLayer(ctx, idOrRef, backend.GetImageAndLayerOptions{
 			PullOption: pullOption,
 			AuthConfig: options.Options.AuthConfigs,
 			Output:     options.ProgressWriter.Output,
-			OS:         options.Options.Platform.OS,
+			OS:         optionsPlatform.OS,
 		})
 	}
 

--- a/builder/dockerfile/imagecontext.go
+++ b/builder/dockerfile/imagecontext.go
@@ -20,8 +20,6 @@ type imageSources struct {
 	getImage  getAndMountFunc
 }
 
-// TODO @jhowardmsft LCOW Support: Eventually, platform can be moved to options.Options.Platform,
-// and removed from builderOptions, but that can't be done yet as it would affect the API.
 func newImageSources(ctx context.Context, options builderOptions) *imageSources {
 	getAndMount := func(idOrRef string, localOnly bool) (builder.Image, builder.ReleaseableLayer, error) {
 		pullOption := backend.PullOptionNoPull
@@ -36,7 +34,7 @@ func newImageSources(ctx context.Context, options builderOptions) *imageSources 
 			PullOption: pullOption,
 			AuthConfig: options.Options.AuthConfigs,
 			Output:     options.ProgressWriter.Output,
-			Platform:   options.Platform,
+			OS:         options.Options.Platform.OS,
 		})
 	}
 

--- a/builder/dockerfile/internals_test.go
+++ b/builder/dockerfile/internals_test.go
@@ -103,7 +103,7 @@ func TestCopyRunConfig(t *testing.T) {
 			doc:       "Set the command to a comment",
 			modifiers: []runConfigModifier{withCmdComment("comment", runtime.GOOS)},
 			expected: &container.Config{
-				Cmd: append(defaultShellForPlatform(runtime.GOOS), "#(nop) ", "comment"),
+				Cmd: append(defaultShellForOS(runtime.GOOS), "#(nop) ", "comment"),
 				Env: defaultEnv,
 			},
 		},

--- a/builder/dockerfile/mockbackend_test.go
+++ b/builder/dockerfile/mockbackend_test.go
@@ -3,6 +3,7 @@ package dockerfile
 import (
 	"encoding/json"
 	"io"
+	"runtime"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
@@ -94,6 +95,10 @@ func (i *mockImage) ImageID() string {
 
 func (i *mockImage) RunConfig() *container.Config {
 	return i.config
+}
+
+func (i *mockImage) OperatingSystem() string {
+	return runtime.GOOS
 }
 
 func (i *mockImage) MarshalJSON() ([]byte, error) {

--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -91,9 +91,6 @@ var (
 // DefaultEscapeToken is the default escape token
 const DefaultEscapeToken = '\\'
 
-// defaultPlatformToken is the platform assumed for the build if not explicitly provided
-var defaultPlatformToken = runtime.GOOS
-
 // Directive is the structure used during a build run to hold the state of
 // parsing directives.
 type Directive struct {
@@ -152,8 +149,7 @@ func (d *Directive) possibleParserDirective(line string) error {
 		}
 	}
 
-	// TODO @jhowardmsft LCOW Support: Eventually this check can be removed,
-	// but only recognise a platform token if running in LCOW mode.
+	// Only recognise a platform token if LCOW is supported
 	if system.LCOWSupported() {
 		tpcMatch := tokenPlatformCommand.FindStringSubmatch(strings.ToLower(line))
 		if len(tpcMatch) != 0 {
@@ -177,7 +173,6 @@ func (d *Directive) possibleParserDirective(line string) error {
 func NewDefaultDirective() *Directive {
 	directive := Directive{}
 	directive.setEscapeToken(string(DefaultEscapeToken))
-	directive.setPlatformToken(defaultPlatformToken)
 	return &directive
 }
 
@@ -242,8 +237,10 @@ func newNodeFromLine(line string, directive *Directive) (*Node, error) {
 type Result struct {
 	AST         *Node
 	EscapeToken rune
-	Platform    string
-	Warnings    []string
+	// TODO @jhowardmsft - see https://github.com/moby/moby/issues/34617
+	// This next field will be removed in a future update for LCOW support.
+	OS       string
+	Warnings []string
 }
 
 // PrintWarnings to the writer
@@ -323,7 +320,7 @@ func Parse(rwc io.Reader) (*Result, error) {
 		AST:         root,
 		Warnings:    warnings,
 		EscapeToken: d.escapeToken,
-		Platform:    d.platformToken,
+		OS:          d.platformToken,
 	}, nil
 }
 

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/system"
 )
 
 // ImageBuild sends request to the daemon to build images.
@@ -29,6 +30,20 @@ func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, optio
 		return types.ImageBuildResponse{}, err
 	}
 	headers.Add("X-Registry-Config", base64.URLEncoding.EncodeToString(buf))
+
+	// TODO @jhowardmsft: system.IsPlatformEmpty is a temporary function. We need to move
+	// (in the reasonably short future) to a package which supports all the platform
+	// validation such as is proposed in https://github.com/containerd/containerd/pull/1403
+	if !system.IsPlatformEmpty(options.Platform) {
+		if err := cli.NewVersionError("1.32", "platform"); err != nil {
+			return types.ImageBuildResponse{}, err
+		}
+		platformJSON, err := json.Marshal(options.Platform)
+		if err != nil {
+			return types.ImageBuildResponse{}, err
+		}
+		headers.Add("X-Requested-Platform", string(platformJSON[:]))
+	}
 	headers.Set("Content-Type", "application/x-tar")
 
 	serverResp, err := cli.postRaw(ctx, "/build", query, buildContext, headers)
@@ -123,6 +138,5 @@ func (cli *Client) imageBuildOptionsToQuery(options types.ImageBuildOptions) (ur
 	if options.SessionID != "" {
 		query.Set("session", options.SessionID)
 	}
-
 	return query, nil
 }

--- a/client/image_create.go
+++ b/client/image_create.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"io"
 	"net/url"
 
@@ -8,6 +9,8 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/system"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ImageCreate creates a new image based in the parent options.
@@ -21,14 +24,25 @@ func (cli *Client) ImageCreate(ctx context.Context, parentReference string, opti
 	query := url.Values{}
 	query.Set("fromImage", reference.FamiliarName(ref))
 	query.Set("tag", getAPITagFromNamedRef(ref))
-	resp, err := cli.tryImageCreate(ctx, query, options.RegistryAuth)
+	resp, err := cli.tryImageCreate(ctx, query, options.RegistryAuth, options.Platform)
 	if err != nil {
 		return nil, err
 	}
 	return resp.body, nil
 }
 
-func (cli *Client) tryImageCreate(ctx context.Context, query url.Values, registryAuth string) (serverResponse, error) {
+func (cli *Client) tryImageCreate(ctx context.Context, query url.Values, registryAuth string, platform specs.Platform) (serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
+
+	// TODO @jhowardmsft: system.IsPlatformEmpty is a temporary function. We need to move
+	// (in the reasonably short future) to a package which supports all the platform
+	// validation such as is proposed in https://github.com/containerd/containerd/pull/1403
+	if !system.IsPlatformEmpty(platform) {
+		platformJSON, err := json.Marshal(platform)
+		if err != nil {
+			return serverResponse{}, err
+		}
+		headers["X-Requested-Platform"] = []string{string(platformJSON[:])}
+	}
 	return cli.post(ctx, "/images/create", query, nil, headers)
 }

--- a/client/image_create.go
+++ b/client/image_create.go
@@ -1,16 +1,14 @@
 package client
 
 import (
-	"encoding/json"
 	"io"
 	"net/url"
+	"strings"
 
 	"golang.org/x/net/context"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/pkg/system"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ImageCreate creates a new image based in the parent options.
@@ -24,25 +22,17 @@ func (cli *Client) ImageCreate(ctx context.Context, parentReference string, opti
 	query := url.Values{}
 	query.Set("fromImage", reference.FamiliarName(ref))
 	query.Set("tag", getAPITagFromNamedRef(ref))
-	resp, err := cli.tryImageCreate(ctx, query, options.RegistryAuth, options.Platform)
+	if options.Platform != "" {
+		query.Set("platform", strings.ToLower(options.Platform))
+	}
+	resp, err := cli.tryImageCreate(ctx, query, options.RegistryAuth)
 	if err != nil {
 		return nil, err
 	}
 	return resp.body, nil
 }
 
-func (cli *Client) tryImageCreate(ctx context.Context, query url.Values, registryAuth string, platform specs.Platform) (serverResponse, error) {
+func (cli *Client) tryImageCreate(ctx context.Context, query url.Values, registryAuth string) (serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
-
-	// TODO @jhowardmsft: system.IsPlatformEmpty is a temporary function. We need to move
-	// (in the reasonably short future) to a package which supports all the platform
-	// validation such as is proposed in https://github.com/containerd/containerd/pull/1403
-	if !system.IsPlatformEmpty(platform) {
-		platformJSON, err := json.Marshal(platform)
-		if err != nil {
-			return serverResponse{}, err
-		}
-		headers["X-Requested-Platform"] = []string{string(platformJSON[:])}
-	}
 	return cli.post(ctx, "/images/create", query, nil, headers)
 }

--- a/client/image_import.go
+++ b/client/image_import.go
@@ -3,6 +3,7 @@ package client
 import (
 	"io"
 	"net/url"
+	"strings"
 
 	"golang.org/x/net/context"
 
@@ -25,6 +26,9 @@ func (cli *Client) ImageImport(ctx context.Context, source types.ImageImportSour
 	query.Set("repo", ref)
 	query.Set("tag", options.Tag)
 	query.Set("message", options.Message)
+	if options.Platform != "" {
+		query.Set("platform", strings.ToLower(options.Platform))
+	}
 	for _, change := range options.Changes {
 		query.Add("changes", change)
 	}

--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -4,12 +4,12 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"golang.org/x/net/context"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/pkg/system"
 )
 
 // ImagePull requests the docker host to pull an image from a remote registry.
@@ -31,30 +31,17 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options types.I
 	if !options.All {
 		query.Set("tag", getAPITagFromNamedRef(ref))
 	}
-
-	// TODO 1: Extend to include "and the platform is supported by the daemon".
-	// This is dependent on https://github.com/moby/moby/pull/34628 though,
-	// and the daemon returning the set of platforms it supports via the _ping
-	// API endpoint.
-	//
-	// TODO 2: system.IsPlatformEmpty is a temporary function. We need to move
-	// (in the reasonably short future) to a package which supports all the platform
-	// validation such as is proposed in https://github.com/containerd/containerd/pull/1403
-	//
-	// @jhowardmsft.
-	if !system.IsPlatformEmpty(options.Platform) {
-		if err := cli.NewVersionError("1.32", "platform"); err != nil {
-			return nil, err
-		}
+	if options.Platform != "" {
+		query.Set("platform", strings.ToLower(options.Platform))
 	}
 
-	resp, err := cli.tryImageCreate(ctx, query, options.RegistryAuth, options.Platform)
+	resp, err := cli.tryImageCreate(ctx, query, options.RegistryAuth)
 	if resp.statusCode == http.StatusUnauthorized && options.PrivilegeFunc != nil {
 		newAuthHeader, privilegeErr := options.PrivilegeFunc()
 		if privilegeErr != nil {
 			return nil, privilegeErr
 		}
-		resp, err = cli.tryImageCreate(ctx, query, newAuthHeader, options.Platform)
+		resp, err = cli.tryImageCreate(ctx, query, newAuthHeader)
 	}
 	if err != nil {
 		return nil, err

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -222,10 +222,6 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 		logrus.Fatalf("Error creating middlewares: %v", err)
 	}
 
-	if system.LCOWSupported() {
-		logrus.Warnln("LCOW support is enabled - this feature is incomplete")
-	}
-
 	d, err := daemon.NewDaemon(cli.Config, registryService, containerdRemote, pluginStore)
 	if err != nil {
 		return fmt.Errorf("Error starting daemon: %v", err)

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -66,7 +66,7 @@ func (container *Container) BuildHostnameFile() error {
 func (container *Container) NetworkMounts() []Mount {
 	var mounts []Mount
 	shared := container.HostConfig.NetworkMode.IsContainer()
-	parser := volume.NewParser(container.Platform)
+	parser := volume.NewParser(container.OS)
 	if container.ResolvConfPath != "" {
 		if _, err := os.Stat(container.ResolvConfPath); err != nil {
 			logrus.Warnf("ResolvConfPath set to %q, but can't stat this filename (err = %v); skipping", container.ResolvConfPath, err)
@@ -195,7 +195,7 @@ func (container *Container) UnmountIpcMount(unmount func(pth string) error) erro
 // IpcMounts returns the list of IPC mounts
 func (container *Container) IpcMounts() []Mount {
 	var mounts []Mount
-	parser := volume.NewParser(container.Platform)
+	parser := volume.NewParser(container.OS)
 
 	if container.HasMountFor("/dev/shm") {
 		return mounts
@@ -429,7 +429,7 @@ func copyOwnership(source, destination string) error {
 
 // TmpfsMounts returns the list of tmpfs mounts
 func (container *Container) TmpfsMounts() ([]Mount, error) {
-	parser := volume.NewParser(container.Platform)
+	parser := volume.NewParser(container.OS)
 	var mounts []Mount
 	for dest, data := range container.HostConfig.Tmpfs {
 		mounts = append(mounts, Mount{

--- a/daemon/archive_unix.go
+++ b/daemon/archive_unix.go
@@ -12,7 +12,7 @@ import (
 // cannot be configured with a read-only rootfs.
 func checkIfPathIsInAVolume(container *container.Container, absPath string) (bool, error) {
 	var toVolume bool
-	parser := volume.NewParser(container.Platform)
+	parser := volume.NewParser(container.OS)
 	for _, mnt := range container.MountPoints {
 		if toVolume = parser.HasResource(mnt, absPath); toVolume {
 			if mnt.RW {

--- a/daemon/build.go
+++ b/daemon/build.go
@@ -55,7 +55,7 @@ func (rl *releaseableLayer) Mount() (containerfs.ContainerFS, error) {
 	return mountPath, nil
 }
 
-func (rl *releaseableLayer) Commit(platform string) (builder.ReleaseableLayer, error) {
+func (rl *releaseableLayer) Commit(os string) (builder.ReleaseableLayer, error) {
 	var chainID layer.ChainID
 	if rl.roLayer != nil {
 		chainID = rl.roLayer.ChainID()
@@ -67,7 +67,7 @@ func (rl *releaseableLayer) Commit(platform string) (builder.ReleaseableLayer, e
 	}
 	defer stream.Close()
 
-	newLayer, err := rl.layerStore.Register(stream, chainID, layer.Platform(platform))
+	newLayer, err := rl.layerStore.Register(stream, chainID, layer.OS(os))
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func (daemon *Daemon) pullForBuilder(ctx context.Context, name string, authConfi
 // leaking of layers.
 func (daemon *Daemon) GetImageAndReleasableLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (builder.Image, builder.ReleaseableLayer, error) {
 	if refOrID == "" {
-		layer, err := newReleasableLayerForImage(nil, daemon.stores[opts.Platform].layerStore)
+		layer, err := newReleasableLayerForImage(nil, daemon.stores[opts.OS].layerStore)
 		return nil, layer, err
 	}
 
@@ -187,16 +187,16 @@ func (daemon *Daemon) GetImageAndReleasableLayer(ctx context.Context, refOrID st
 		}
 		// TODO: shouldn't we error out if error is different from "not found" ?
 		if image != nil {
-			layer, err := newReleasableLayerForImage(image, daemon.stores[opts.Platform].layerStore)
+			layer, err := newReleasableLayerForImage(image, daemon.stores[opts.OS].layerStore)
 			return image, layer, err
 		}
 	}
 
-	image, err := daemon.pullForBuilder(ctx, refOrID, opts.AuthConfig, opts.Output, opts.Platform)
+	image, err := daemon.pullForBuilder(ctx, refOrID, opts.AuthConfig, opts.Output, opts.OS)
 	if err != nil {
 		return nil, nil, err
 	}
-	layer, err := newReleasableLayerForImage(image, daemon.stores[opts.Platform].layerStore)
+	layer, err := newReleasableLayerForImage(image, daemon.stores[opts.OS].layerStore)
 	return image, layer, err
 }
 

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -20,7 +20,6 @@ import (
 	containerpkg "github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/cluster/convert"
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
-	"github.com/docker/docker/pkg/system"
 	"github.com/docker/libnetwork"
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
@@ -93,9 +92,6 @@ func (c *containerAdapter) pullImage(ctx context.Context) error {
 		// TODO @jhowardmsft LCOW Support: This will need revisiting as
 		// the stack is built up to include LCOW support for swarm.
 		platform := runtime.GOOS
-		if system.LCOWSupported() {
-			platform = "linux"
-		}
 		err := c.backend.PullImage(ctx, c.container.image(), "", platform, metaHeaders, authConfig, pw)
 		pw.CloseWithError(err)
 	}()

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -123,7 +123,7 @@ func (daemon *Daemon) Register(c *container.Container) error {
 	return c.CheckpointTo(daemon.containersReplica)
 }
 
-func (daemon *Daemon) newContainer(name string, platform string, config *containertypes.Config, hostConfig *containertypes.HostConfig, imgID image.ID, managed bool) (*container.Container, error) {
+func (daemon *Daemon) newContainer(name string, operatingSystem string, config *containertypes.Config, hostConfig *containertypes.HostConfig, imgID image.ID, managed bool) (*container.Container, error) {
 	var (
 		id             string
 		err            error
@@ -156,8 +156,8 @@ func (daemon *Daemon) newContainer(name string, platform string, config *contain
 	base.ImageID = imgID
 	base.NetworkSettings = &network.Settings{IsAnonymousEndpoint: noExplicitName}
 	base.Name = name
-	base.Driver = daemon.GraphDriverName(platform)
-	base.Platform = platform
+	base.Driver = daemon.GraphDriverName(operatingSystem)
+	base.OS = operatingSystem
 	return base, err
 }
 

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -39,17 +39,21 @@ func (daemon *Daemon) containerCreate(params types.ContainerCreateConfig, manage
 		return containertypes.ContainerCreateCreatedBody{}, validationError{errors.New("Config cannot be empty in order to create a container")}
 	}
 
-	// TODO: @jhowardmsft LCOW support - at a later point, can remove the hard-coding
-	// to force the platform to be linux.
-	// Default the platform if not supplied
-	if params.Platform == "" {
-		params.Platform = runtime.GOOS
-	}
-	if system.LCOWSupported() {
-		params.Platform = "linux"
+	os := runtime.GOOS
+	if params.Config.Image != "" {
+		img, err := daemon.GetImage(params.Config.Image)
+		if err == nil {
+			os = img.OS
+		}
+	} else {
+		// This mean scratch. On Windows, we can safely assume that this is a linux
+		// container. On other platforms, it's the host OS (which it already is)
+		if runtime.GOOS == "windows" && system.LCOWSupported() {
+			os = "linux"
+		}
 	}
 
-	warnings, err := daemon.verifyContainerSettings(params.Platform, params.HostConfig, params.Config, false)
+	warnings, err := daemon.verifyContainerSettings(os, params.HostConfig, params.Config, false)
 	if err != nil {
 		return containertypes.ContainerCreateCreatedBody{Warnings: warnings}, validationError{err}
 	}
@@ -85,29 +89,25 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig, managed bool) (
 		err       error
 	)
 
+	os := runtime.GOOS
 	if params.Config.Image != "" {
 		img, err = daemon.GetImage(params.Config.Image)
 		if err != nil {
 			return nil, err
 		}
+		os = img.OS
 
 		if runtime.GOOS == "solaris" && img.OS != "solaris " {
-			return nil, errors.New("platform on which parent image was created is not Solaris")
+			return nil, errors.New("operating system on which parent image was created is not Solaris")
 		}
 		imgID = img.ID()
 
 		if runtime.GOOS == "windows" && img.OS == "linux" && !system.LCOWSupported() {
-			return nil, errors.New("platform on which parent image was created is not Windows")
+			return nil, errors.New("operating system on which parent image was created is not Windows")
 		}
-	}
-
-	// Make sure the platform requested matches the image
-	if img != nil {
-		if params.Platform != img.Platform() {
-			// Ignore this in LCOW mode. @jhowardmsft TODO - This will need revisiting later.
-			if !system.LCOWSupported() {
-				return nil, fmt.Errorf("cannot create a %s container from a %s image", params.Platform, img.Platform())
-			}
+	} else {
+		if runtime.GOOS == "windows" {
+			os = "linux" // 'scratch' case.
 		}
 	}
 
@@ -119,7 +119,7 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig, managed bool) (
 		return nil, validationError{err}
 	}
 
-	if container, err = daemon.newContainer(params.Name, params.Platform, params.Config, params.HostConfig, imgID, managed); err != nil {
+	if container, err = daemon.newContainer(params.Name, os, params.Config, params.HostConfig, imgID, managed); err != nil {
 		return nil, err
 	}
 	defer func() {
@@ -170,7 +170,7 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig, managed bool) (
 		return nil, err
 	}
 
-	if err := daemon.createContainerPlatformSpecificSettings(container, params.Config, params.HostConfig); err != nil {
+	if err := daemon.createContainerOSSpecificSettings(container, params.Config, params.HostConfig); err != nil {
 		return nil, err
 	}
 
@@ -253,7 +253,7 @@ func (daemon *Daemon) generateSecurityOpt(hostConfig *containertypes.HostConfig)
 func (daemon *Daemon) setRWLayer(container *container.Container) error {
 	var layerID layer.ChainID
 	if container.ImageID != "" {
-		img, err := daemon.stores[container.Platform].imageStore.Get(container.ImageID)
+		img, err := daemon.stores[container.OS].imageStore.Get(container.ImageID)
 		if err != nil {
 			return err
 		}
@@ -266,7 +266,7 @@ func (daemon *Daemon) setRWLayer(container *container.Container) error {
 		StorageOpt: container.HostConfig.StorageOpt,
 	}
 
-	rwLayer, err := daemon.stores[container.Platform].layerStore.CreateRWLayer(container.ID, layerID, rwLayerOpts)
+	rwLayer, err := daemon.stores[container.OS].layerStore.CreateRWLayer(container.ID, layerID, rwLayerOpts)
 	if err != nil {
 		return err
 	}

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -15,8 +15,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// createContainerPlatformSpecificSettings performs platform specific container create functionality
-func (daemon *Daemon) createContainerPlatformSpecificSettings(container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
+// createContainerOSSpecificSettings performs host-OS specific container create functionality
+func (daemon *Daemon) createContainerOSSpecificSettings(container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
 	if err := daemon.Mount(container); err != nil {
 		return err
 	}

--- a/daemon/create_windows.go
+++ b/daemon/create_windows.go
@@ -10,10 +10,10 @@ import (
 	"github.com/docker/docker/volume"
 )
 
-// createContainerPlatformSpecificSettings performs platform specific container create functionality
-func (daemon *Daemon) createContainerPlatformSpecificSettings(container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
+// createContainerOSSpecificSettings performs host-OS specific container create functionality
+func (daemon *Daemon) createContainerOSSpecificSettings(container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
 
-	if container.Platform == runtime.GOOS {
+	if container.OS == runtime.GOOS {
 		// Make sure the host config has the default daemon isolation if not specified by caller.
 		if containertypes.Isolation.IsDefault(containertypes.Isolation(hostConfig.Isolation)) {
 			hostConfig.Isolation = daemon.defaultIsolation
@@ -26,7 +26,7 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 		}
 		hostConfig.Isolation = "hyperv"
 	}
-	parser := volume.NewParser(container.Platform)
+	parser := volume.NewParser(container.OS)
 	for spec := range config.Volumes {
 
 		mp, err := parser.ParseMountRaw(spec, hostConfig.VolumeDriver)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -162,9 +162,9 @@ func (daemon *Daemon) restore() error {
 		}
 
 		// Ignore the container if it does not support the current driver being used by the graph
-		currentDriverForContainerPlatform := daemon.stores[container.Platform].graphDriver
-		if (container.Driver == "" && currentDriverForContainerPlatform == "aufs") || container.Driver == currentDriverForContainerPlatform {
-			rwlayer, err := daemon.stores[container.Platform].layerStore.GetRWLayer(container.ID)
+		currentDriverForContainerOS := daemon.stores[container.OS].graphDriver
+		if (container.Driver == "" && currentDriverForContainerOS == "aufs") || container.Driver == currentDriverForContainerOS {
+			rwlayer, err := daemon.stores[container.OS].layerStore.GetRWLayer(container.ID)
 			if err != nil {
 				logrus.Errorf("Failed to load container mount %v: %v", id, err)
 				continue
@@ -664,7 +664,7 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 	}
 
 	var graphDrivers []string
-	for platform, ds := range d.stores {
+	for operatingSystem, ds := range d.stores {
 		ls, err := layer.NewStoreFromOptions(layer.StoreOptions{
 			StorePath:                 config.Root,
 			MetadataStorePathTemplate: filepath.Join(config.Root, "image", "%s", "layerdb"),
@@ -673,14 +673,14 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 			IDMappings:                idMappings,
 			PluginGetter:              d.PluginStore,
 			ExperimentalEnabled:       config.Experimental,
-			Platform:                  platform,
+			OS:                        operatingSystem,
 		})
 		if err != nil {
 			return nil, err
 		}
 		ds.graphDriver = ls.DriverName() // As layerstore may set the driver
 		ds.layerStore = ls
-		d.stores[platform] = ds
+		d.stores[operatingSystem] = ds
 		graphDrivers = append(graphDrivers, ls.DriverName())
 	}
 
@@ -691,13 +691,13 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 
 	logrus.Debugf("Max Concurrent Downloads: %d", *config.MaxConcurrentDownloads)
 	lsMap := make(map[string]layer.Store)
-	for platform, ds := range d.stores {
-		lsMap[platform] = ds.layerStore
+	for operatingSystem, ds := range d.stores {
+		lsMap[operatingSystem] = ds.layerStore
 	}
 	d.downloadManager = xfer.NewLayerDownloadManager(lsMap, *config.MaxConcurrentDownloads)
 	logrus.Debugf("Max Concurrent Uploads: %d", *config.MaxConcurrentUploads)
 	d.uploadManager = xfer.NewLayerUploadManager(*config.MaxConcurrentUploads)
-	for platform, ds := range d.stores {
+	for operatingSystem, ds := range d.stores {
 		imageRoot := filepath.Join(config.Root, "image", ds.graphDriver)
 		ifs, err := image.NewFSStoreBackend(filepath.Join(imageRoot, "imagedb"))
 		if err != nil {
@@ -705,13 +705,13 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 		}
 
 		var is image.Store
-		is, err = image.NewImageStore(ifs, platform, ds.layerStore)
+		is, err = image.NewImageStore(ifs, operatingSystem, ds.layerStore)
 		if err != nil {
 			return nil, err
 		}
 		ds.imageRoot = imageRoot
 		ds.imageStore = is
-		d.stores[platform] = ds
+		d.stores[operatingSystem] = ds
 	}
 
 	// Configure the volumes driver
@@ -921,7 +921,7 @@ func (daemon *Daemon) Shutdown() error {
 				logrus.Errorf("Stop container error: %v", err)
 				return
 			}
-			if mountid, err := daemon.stores[c.Platform].layerStore.GetMountID(c.ID); err == nil {
+			if mountid, err := daemon.stores[c.OS].layerStore.GetMountID(c.ID); err == nil {
 				daemon.cleanupMountsByID(mountid)
 			}
 			logrus.Debugf("container stopped %s", c.ID)
@@ -981,7 +981,7 @@ func (daemon *Daemon) Mount(container *container.Container) error {
 		if runtime.GOOS != "windows" {
 			daemon.Unmount(container)
 			return fmt.Errorf("Error: driver %s is returning inconsistent paths for container %s ('%s' then '%s')",
-				daemon.GraphDriverName(container.Platform), container.ID, container.BaseFS, dir)
+				daemon.GraphDriverName(container.OS), container.ID, container.BaseFS, dir)
 		}
 	}
 	container.BaseFS = dir // TODO: combine these fields

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -493,12 +493,14 @@ func (daemon *Daemon) runAsHyperVContainer(hostConfig *containertypes.HostConfig
 // conditionalMountOnStart is a platform specific helper function during the
 // container start to call mount.
 func (daemon *Daemon) conditionalMountOnStart(container *container.Container) error {
-	// Bail out now for Linux containers
-	if system.LCOWSupported() && container.Platform != "windows" {
+	// Bail out now for Linux containers. We cannot mount the containers filesystem on the
+	// host as it is a non-Windows filesystem.
+	if system.LCOWSupported() && container.OS != "windows" {
 		return nil
 	}
 
-	// We do not mount if a Hyper-V container
+	// We do not mount if a Hyper-V container as it needs to be mounted inside the
+	// utility VM, not the host.
 	if !daemon.runAsHyperVContainer(container.HostConfig) {
 		return daemon.Mount(container)
 	}
@@ -509,7 +511,7 @@ func (daemon *Daemon) conditionalMountOnStart(container *container.Container) er
 // during the cleanup of a container to unmount.
 func (daemon *Daemon) conditionalUnmountOnCleanup(container *container.Container) error {
 	// Bail out now for Linux containers
-	if system.LCOWSupported() && container.Platform != "windows" {
+	if system.LCOWSupported() && container.OS != "windows" {
 		return nil
 	}
 

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -116,10 +116,10 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 	// When container creation fails and `RWLayer` has not been created yet, we
 	// do not call `ReleaseRWLayer`
 	if container.RWLayer != nil {
-		metadata, err := daemon.stores[container.Platform].layerStore.ReleaseRWLayer(container.RWLayer)
+		metadata, err := daemon.stores[container.OS].layerStore.ReleaseRWLayer(container.RWLayer)
 		layer.LogReleaseMetadata(metadata)
 		if err != nil && err != layer.ErrMountDoesNotExist && !os.IsNotExist(errors.Cause(err)) {
-			return errors.Wrapf(err, "driver %q failed to remove root filesystem for %s", daemon.GraphDriverName(container.Platform), container.ID)
+			return errors.Wrapf(err, "driver %q failed to remove root filesystem for %s", daemon.GraphDriverName(container.OS), container.ID)
 		}
 	}
 

--- a/daemon/exec_windows.go
+++ b/daemon/exec_windows.go
@@ -8,7 +8,7 @@ import (
 
 func execSetPlatformOpt(c *container.Container, ec *exec.Config, p *libcontainerd.Process) error {
 	// Process arguments need to be escaped before sending to OCI.
-	if c.Platform == "windows" {
+	if c.OS == "windows" {
 		p.Args = escapeArgs(p.Args)
 		p.User.Username = ec.User
 	}

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -18,8 +18,8 @@ func (daemon *Daemon) ContainerExport(name string, out io.Writer) error {
 		return err
 	}
 
-	if runtime.GOOS == "windows" && container.Platform == "windows" {
-		return fmt.Errorf("the daemon on this platform does not support exporting Windows containers")
+	if runtime.GOOS == "windows" && container.OS == "windows" {
+		return fmt.Errorf("the daemon on this operating system does not support exporting Windows containers")
 	}
 
 	if container.IsDead() {
@@ -46,13 +46,13 @@ func (daemon *Daemon) ContainerExport(name string, out io.Writer) error {
 }
 
 func (daemon *Daemon) containerExport(container *container.Container) (arch io.ReadCloser, err error) {
-	rwlayer, err := daemon.stores[container.Platform].layerStore.GetRWLayer(container.ID)
+	rwlayer, err := daemon.stores[container.OS].layerStore.GetRWLayer(container.ID)
 	if err != nil {
 		return nil, err
 	}
 	defer func() {
 		if err != nil {
-			daemon.stores[container.Platform].layerStore.ReleaseRWLayer(rwlayer)
+			daemon.stores[container.OS].layerStore.ReleaseRWLayer(rwlayer)
 		}
 	}()
 
@@ -73,7 +73,7 @@ func (daemon *Daemon) containerExport(container *container.Container) (arch io.R
 	arch = ioutils.NewReadCloserWrapper(archive, func() error {
 		err := archive.Close()
 		rwlayer.Unmount()
-		daemon.stores[container.Platform].layerStore.ReleaseRWLayer(rwlayer)
+		daemon.stores[container.OS].layerStore.ReleaseRWLayer(rwlayer)
 		return err
 	})
 	daemon.LogContainerEvent(container, "export")

--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -154,19 +154,8 @@ func (d *Driver) Status() [][2]string {
 	}
 }
 
-// panicIfUsedByLcow does exactly what it says.
-// TODO @jhowardmsft - this is a temporary measure for the bring-up of
-// Linux containers on Windows. It is a failsafe to ensure that the right
-// graphdriver is used.
-func panicIfUsedByLcow() {
-	if system.LCOWSupported() {
-		panic("inconsistency - windowsfilter graphdriver should not be used when in LCOW mode")
-	}
-}
-
 // Exists returns true if the given id is registered with this driver.
 func (d *Driver) Exists(id string) bool {
-	panicIfUsedByLcow()
 	rID, err := d.resolveID(id)
 	if err != nil {
 		return false
@@ -181,7 +170,6 @@ func (d *Driver) Exists(id string) bool {
 // CreateReadWrite creates a layer that is writable for use as a container
 // file system.
 func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts) error {
-	panicIfUsedByLcow()
 	if opts != nil {
 		return d.create(id, parent, opts.MountLabel, false, opts.StorageOpt)
 	}
@@ -190,7 +178,6 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 
 // Create creates a new read-only layer with the given id.
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
-	panicIfUsedByLcow()
 	if opts != nil {
 		return d.create(id, parent, opts.MountLabel, true, opts.StorageOpt)
 	}
@@ -274,7 +261,6 @@ func (d *Driver) dir(id string) string {
 
 // Remove unmounts and removes the dir information.
 func (d *Driver) Remove(id string) error {
-	panicIfUsedByLcow()
 	rID, err := d.resolveID(id)
 	if err != nil {
 		return err
@@ -356,7 +342,6 @@ func (d *Driver) Remove(id string) error {
 
 // Get returns the rootfs path for the id. This will mount the dir at its given path.
 func (d *Driver) Get(id, mountLabel string) (containerfs.ContainerFS, error) {
-	panicIfUsedByLcow()
 	logrus.Debugf("WindowsGraphDriver Get() id %s mountLabel %s", id, mountLabel)
 	var dir string
 
@@ -415,7 +400,6 @@ func (d *Driver) Get(id, mountLabel string) (containerfs.ContainerFS, error) {
 
 // Put adds a new layer to the driver.
 func (d *Driver) Put(id string) error {
-	panicIfUsedByLcow()
 	logrus.Debugf("WindowsGraphDriver Put() id %s", id)
 
 	rID, err := d.resolveID(id)
@@ -474,7 +458,6 @@ func (d *Driver) Cleanup() error {
 // layer and its parent layer which may be "".
 // The layer should be mounted when calling this function
 func (d *Driver) Diff(id, parent string) (_ io.ReadCloser, err error) {
-	panicIfUsedByLcow()
 	rID, err := d.resolveID(id)
 	if err != nil {
 		return
@@ -511,7 +494,6 @@ func (d *Driver) Diff(id, parent string) (_ io.ReadCloser, err error) {
 // and its parent layer. If parent is "", then all changes will be ADD changes.
 // The layer should not be mounted when calling this function.
 func (d *Driver) Changes(id, parent string) ([]archive.Change, error) {
-	panicIfUsedByLcow()
 	rID, err := d.resolveID(id)
 	if err != nil {
 		return nil, err
@@ -567,7 +549,6 @@ func (d *Driver) Changes(id, parent string) ([]archive.Change, error) {
 // new layer in bytes.
 // The layer should not be mounted when calling this function
 func (d *Driver) ApplyDiff(id, parent string, diff io.Reader) (int64, error) {
-	panicIfUsedByLcow()
 	var layerChain []string
 	if parent != "" {
 		rPId, err := d.resolveID(parent)
@@ -602,7 +583,6 @@ func (d *Driver) ApplyDiff(id, parent string, diff io.Reader) (int64, error) {
 // and its parent and returns the size in bytes of the changes
 // relative to its base filesystem directory.
 func (d *Driver) DiffSize(id, parent string) (size int64, err error) {
-	panicIfUsedByLcow()
 	rPId, err := d.resolveID(parent)
 	if err != nil {
 		return
@@ -624,7 +604,6 @@ func (d *Driver) DiffSize(id, parent string) (size int64, err error) {
 
 // GetMetadata returns custom driver information.
 func (d *Driver) GetMetadata(id string) (map[string]string, error) {
-	panicIfUsedByLcow()
 	m := make(map[string]string)
 	m["dir"] = d.dir(id)
 	return m, nil
@@ -927,7 +906,6 @@ func (fg *fileGetCloserWithBackupPrivileges) Close() error {
 // DiffGetter returns a FileGetCloser that can read files from the directory that
 // contains files for the layer differences. Used for direct access for tar-split.
 func (d *Driver) DiffGetter(id string) (graphdriver.FileGetCloser, error) {
-	panicIfUsedByLcow()
 	id, err := d.resolveID(id)
 	if err != nil {
 		return nil, err

--- a/daemon/image.go
+++ b/daemon/image.go
@@ -24,9 +24,9 @@ func (e errImageDoesNotExist) Error() string {
 
 func (e errImageDoesNotExist) NotFound() {}
 
-// GetImageIDAndPlatform returns an image ID and platform corresponding to the image referred to by
+// GetImageIDAndOS returns an image ID and operating system corresponding to the image referred to by
 // refOrID.
-func (daemon *Daemon) GetImageIDAndPlatform(refOrID string) (image.ID, string, error) {
+func (daemon *Daemon) GetImageIDAndOS(refOrID string) (image.ID, string, error) {
 	ref, err := reference.ParseAnyReference(refOrID)
 	if err != nil {
 		return "", "", validationError{err}
@@ -47,16 +47,16 @@ func (daemon *Daemon) GetImageIDAndPlatform(refOrID string) (image.ID, string, e
 	}
 
 	if digest, err := daemon.referenceStore.Get(namedRef); err == nil {
-		// Search the image stores to get the platform, defaulting to host OS.
-		imagePlatform := runtime.GOOS
+		// Search the image stores to get the operating system, defaulting to host OS.
+		imageOS := runtime.GOOS
 		id := image.IDFromDigest(digest)
-		for platform := range daemon.stores {
-			if img, err := daemon.stores[platform].imageStore.Get(id); err == nil {
-				imagePlatform = img.Platform()
+		for os := range daemon.stores {
+			if img, err := daemon.stores[os].imageStore.Get(id); err == nil {
+				imageOS = img.OperatingSystem()
 				break
 			}
 		}
-		return id, imagePlatform, nil
+		return id, imageOS, nil
 	}
 
 	// deprecated: repo:shortid https://github.com/docker/docker/pull/799
@@ -75,9 +75,9 @@ func (daemon *Daemon) GetImageIDAndPlatform(refOrID string) (image.ID, string, e
 	}
 
 	// Search based on ID
-	for platform := range daemon.stores {
-		if id, err := daemon.stores[platform].imageStore.Search(refOrID); err == nil {
-			return id, platform, nil
+	for os := range daemon.stores {
+		if id, err := daemon.stores[os].imageStore.Search(refOrID); err == nil {
+			return id, os, nil
 		}
 	}
 
@@ -86,9 +86,9 @@ func (daemon *Daemon) GetImageIDAndPlatform(refOrID string) (image.ID, string, e
 
 // GetImage returns an image corresponding to the image referred to by refOrID.
 func (daemon *Daemon) GetImage(refOrID string) (*image.Image, error) {
-	imgID, platform, err := daemon.GetImageIDAndPlatform(refOrID)
+	imgID, os, err := daemon.GetImageIDAndOS(refOrID)
 	if err != nil {
 		return nil, err
 	}
-	return daemon.stores[platform].imageStore.Get(imgID)
+	return daemon.stores[os].imageStore.Get(imgID)
 }

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -65,7 +65,7 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 	start := time.Now()
 	records := []types.ImageDeleteResponseItem{}
 
-	imgID, platform, err := daemon.GetImageIDAndPlatform(imageRef)
+	imgID, os, err := daemon.GetImageIDAndOS(imageRef)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 			return nil, err
 		}
 
-		parsedRef, err = daemon.removeImageRef(platform, parsedRef)
+		parsedRef, err = daemon.removeImageRef(os, parsedRef)
 		if err != nil {
 			return nil, err
 		}
@@ -122,7 +122,7 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 				remainingRefs := []reference.Named{}
 				for _, repoRef := range repoRefs {
 					if _, repoRefIsCanonical := repoRef.(reference.Canonical); repoRefIsCanonical && parsedRef.Name() == repoRef.Name() {
-						if _, err := daemon.removeImageRef(platform, repoRef); err != nil {
+						if _, err := daemon.removeImageRef(os, repoRef); err != nil {
 							return records, err
 						}
 
@@ -152,12 +152,12 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 			if !force {
 				c |= conflictSoft &^ conflictActiveReference
 			}
-			if conflict := daemon.checkImageDeleteConflict(imgID, platform, c); conflict != nil {
+			if conflict := daemon.checkImageDeleteConflict(imgID, os, c); conflict != nil {
 				return nil, conflict
 			}
 
 			for _, repoRef := range repoRefs {
-				parsedRef, err := daemon.removeImageRef(platform, repoRef)
+				parsedRef, err := daemon.removeImageRef(os, repoRef)
 				if err != nil {
 					return nil, err
 				}
@@ -170,7 +170,7 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 		}
 	}
 
-	if err := daemon.imageDeleteHelper(imgID, platform, &records, force, prune, removedRepositoryRef); err != nil {
+	if err := daemon.imageDeleteHelper(imgID, os, &records, force, prune, removedRepositoryRef); err != nil {
 		return nil, err
 	}
 

--- a/daemon/image_tag.go
+++ b/daemon/image_tag.go
@@ -8,7 +8,7 @@ import (
 // TagImage creates the tag specified by newTag, pointing to the image named
 // imageName (alternatively, imageName can also be an image ID).
 func (daemon *Daemon) TagImage(imageName, repository, tag string) error {
-	imageID, platform, err := daemon.GetImageIDAndPlatform(imageName)
+	imageID, os, err := daemon.GetImageIDAndOS(imageName)
 	if err != nil {
 		return err
 	}
@@ -23,16 +23,16 @@ func (daemon *Daemon) TagImage(imageName, repository, tag string) error {
 		}
 	}
 
-	return daemon.TagImageWithReference(imageID, platform, newTag)
+	return daemon.TagImageWithReference(imageID, os, newTag)
 }
 
 // TagImageWithReference adds the given reference to the image ID provided.
-func (daemon *Daemon) TagImageWithReference(imageID image.ID, platform string, newTag reference.Named) error {
+func (daemon *Daemon) TagImageWithReference(imageID image.ID, os string, newTag reference.Named) error {
 	if err := daemon.referenceStore.AddTag(newTag, imageID.Digest(), true); err != nil {
 		return err
 	}
 
-	if err := daemon.stores[platform].imageStore.SetLastUpdated(imageID); err != nil {
+	if err := daemon.stores[os].imageStore.SetLastUpdated(imageID); err != nil {
 		return err
 	}
 	daemon.LogImageEvent(imageID.String(), reference.FamiliarString(newTag), "tag")

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -36,7 +36,7 @@ func (r byCreated) Less(i, j int) bool { return r[i].Created < r[j].Created }
 
 // Map returns a map of all images in the ImageStore
 func (daemon *Daemon) Map() map[image.ID]*image.Image {
-	// TODO @jhowardmsft LCOW. This will need  work to enumerate the stores for all platforms.
+	// TODO @jhowardmsft LCOW. This can be removed when imagestores are coalesced
 	platform := runtime.GOOS
 	if system.LCOWSupported() {
 		platform = "linux"
@@ -51,7 +51,7 @@ func (daemon *Daemon) Map() map[image.ID]*image.Image {
 // the heads.
 func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs bool) ([]*types.ImageSummary, error) {
 
-	// TODO @jhowardmsft LCOW. This will need  work to enumerate the stores for all platforms.
+	// TODO @jhowardmsft LCOW. This can be removed when imagestores are coalesced
 	platform := runtime.GOOS
 	if system.LCOWSupported() {
 		platform = "linux"
@@ -273,7 +273,7 @@ func (daemon *Daemon) SquashImage(id, parent string) (string, error) {
 	var parentImg *image.Image
 	var parentChainID layer.ChainID
 	if len(parent) != 0 {
-		parentImg, err = daemon.stores[img.Platform()].imageStore.Get(image.ID(parent))
+		parentImg, err = daemon.stores[img.OperatingSystem()].imageStore.Get(image.ID(parent))
 		if err != nil {
 			return "", errors.Wrap(err, "error getting specified parent layer")
 		}
@@ -283,11 +283,11 @@ func (daemon *Daemon) SquashImage(id, parent string) (string, error) {
 		parentImg = &image.Image{RootFS: rootFS}
 	}
 
-	l, err := daemon.stores[img.Platform()].layerStore.Get(img.RootFS.ChainID())
+	l, err := daemon.stores[img.OperatingSystem()].layerStore.Get(img.RootFS.ChainID())
 	if err != nil {
 		return "", errors.Wrap(err, "error getting image layer")
 	}
-	defer daemon.stores[img.Platform()].layerStore.Release(l)
+	defer daemon.stores[img.OperatingSystem()].layerStore.Release(l)
 
 	ts, err := l.TarStreamFrom(parentChainID)
 	if err != nil {
@@ -295,11 +295,11 @@ func (daemon *Daemon) SquashImage(id, parent string) (string, error) {
 	}
 	defer ts.Close()
 
-	newL, err := daemon.stores[img.Platform()].layerStore.Register(ts, parentChainID, layer.Platform(img.Platform()))
+	newL, err := daemon.stores[img.OperatingSystem()].layerStore.Register(ts, parentChainID, layer.OS(img.OperatingSystem()))
 	if err != nil {
 		return "", errors.Wrap(err, "error registering layer")
 	}
-	defer daemon.stores[img.Platform()].layerStore.Release(newL)
+	defer daemon.stores[img.OperatingSystem()].layerStore.Release(newL)
 
 	newImage := *img
 	newImage.RootFS = nil
@@ -334,7 +334,7 @@ func (daemon *Daemon) SquashImage(id, parent string) (string, error) {
 		return "", errors.Wrap(err, "error marshalling image config")
 	}
 
-	newImgID, err := daemon.stores[img.Platform()].imageStore.Create(b)
+	newImgID, err := daemon.stores[img.OperatingSystem()].imageStore.Create(b)
 	if err != nil {
 		return "", errors.Wrap(err, "error creating new image after squash")
 	}

--- a/daemon/import.go
+++ b/daemon/import.go
@@ -26,16 +26,16 @@ import (
 // inConfig (if src is "-"), or from a URI specified in src. Progress output is
 // written to outStream. Repository and tag names can optionally be given in
 // the repo and tag arguments, respectively.
-func (daemon *Daemon) ImportImage(src string, repository, platform string, tag string, msg string, inConfig io.ReadCloser, outStream io.Writer, changes []string) error {
+func (daemon *Daemon) ImportImage(src string, repository, os string, tag string, msg string, inConfig io.ReadCloser, outStream io.Writer, changes []string) error {
 	var (
 		rc     io.ReadCloser
 		resp   *http.Response
 		newRef reference.Named
 	)
 
-	// Default the platform if not supplied.
-	if platform == "" {
-		platform = runtime.GOOS
+	// Default the operating system if not supplied.
+	if os == "" {
+		os = runtime.GOOS
 	}
 
 	if repository != "" {
@@ -90,11 +90,11 @@ func (daemon *Daemon) ImportImage(src string, repository, platform string, tag s
 	if err != nil {
 		return err
 	}
-	l, err := daemon.stores[platform].layerStore.Register(inflatedLayerData, "", layer.Platform(platform))
+	l, err := daemon.stores[os].layerStore.Register(inflatedLayerData, "", layer.OS(os))
 	if err != nil {
 		return err
 	}
-	defer layer.ReleaseAndLog(daemon.stores[platform].layerStore, l)
+	defer layer.ReleaseAndLog(daemon.stores[os].layerStore, l)
 
 	created := time.Now().UTC()
 	imgConfig, err := json.Marshal(&image.Image{
@@ -102,7 +102,7 @@ func (daemon *Daemon) ImportImage(src string, repository, platform string, tag s
 			DockerVersion: dockerversion.Version,
 			Config:        config,
 			Architecture:  runtime.GOARCH,
-			OS:            platform,
+			OS:            os,
 			Created:       created,
 			Comment:       msg,
 		},
@@ -119,14 +119,14 @@ func (daemon *Daemon) ImportImage(src string, repository, platform string, tag s
 		return err
 	}
 
-	id, err := daemon.stores[platform].imageStore.Create(imgConfig)
+	id, err := daemon.stores[os].imageStore.Create(imgConfig)
 	if err != nil {
 		return err
 	}
 
 	// FIXME: connect with commit code and call refstore directly
 	if newRef != nil {
-		if err := daemon.TagImageWithReference(id, platform, newRef); err != nil {
+		if err := daemon.TagImageWithReference(id, os, newRef); err != nil {
 			return err
 		}
 	}

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -171,7 +171,7 @@ func (daemon *Daemon) getInspectData(container *container.Container) (*types.Con
 		Name:         container.Name,
 		RestartCount: container.RestartCount,
 		Driver:       container.Driver,
-		Platform:     container.Platform,
+		OS:           container.OS,
 		MountLabel:   container.MountLabel,
 		ProcessLabel: container.ProcessLabel,
 		ExecIDs:      container.GetExecIDs(),

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/daemon/network"
 	volumestore "github.com/docker/docker/volume/store"
 	"github.com/docker/go-connections/nat"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ContainerInspect returns low-level information about a
@@ -171,7 +172,7 @@ func (daemon *Daemon) getInspectData(container *container.Container) (*types.Con
 		Name:         container.Name,
 		RestartCount: container.RestartCount,
 		Driver:       container.Driver,
-		OS:           container.OS,
+		Platform:     specs.Platform{OS: container.OS},
 		MountLabel:   container.MountLabel,
 		ProcessLabel: container.ProcessLabel,
 		ExecIDs:      container.GetExecIDs(),

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -322,7 +322,7 @@ func (daemon *Daemon) foldFilter(view container.View, config *types.ContainerLis
 	if psFilters.Contains("ancestor") {
 		ancestorFilter = true
 		psFilters.WalkValues("ancestor", func(ancestor string) error {
-			id, platform, err := daemon.GetImageIDAndPlatform(ancestor)
+			id, os, err := daemon.GetImageIDAndOS(ancestor)
 			if err != nil {
 				logrus.Warnf("Error while looking up for image %v", ancestor)
 				return nil
@@ -332,7 +332,7 @@ func (daemon *Daemon) foldFilter(view container.View, config *types.ContainerLis
 				return nil
 			}
 			// Then walk down the graph and put the imageIds in imagesFilter
-			populateImageFilterByParents(imagesFilter, id, daemon.stores[platform].imageStore.Children)
+			populateImageFilterByParents(imagesFilter, id, daemon.stores[os].imageStore.Children)
 			return nil
 		})
 	}
@@ -566,7 +566,7 @@ func (daemon *Daemon) refreshImage(s *container.Snapshot, ctx *listContext) (*ty
 	c := s.Container
 	image := s.Image // keep the original ref if still valid (hasn't changed)
 	if image != s.ImageID {
-		id, _, err := daemon.GetImageIDAndPlatform(image)
+		id, _, err := daemon.GetImageIDAndOS(image)
 		if _, isDNE := err.(errImageDoesNotExist); err != nil && !isDNE {
 			return nil, err
 		}

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -138,9 +138,9 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 	max := len(img.RootFS.DiffIDs)
 	for i := 1; i <= max; i++ {
 		img.RootFS.DiffIDs = img.RootFS.DiffIDs[:i]
-		layerPath, err := layer.GetLayerPath(daemon.stores[c.Platform].layerStore, img.RootFS.ChainID())
+		layerPath, err := layer.GetLayerPath(daemon.stores[c.OS].layerStore, img.RootFS.ChainID())
 		if err != nil {
-			return nil, fmt.Errorf("failed to get layer path from graphdriver %s for ImageID %s - %s", daemon.stores[c.Platform].layerStore, img.RootFS.ChainID(), err)
+			return nil, fmt.Errorf("failed to get layer path from graphdriver %s for ImageID %s - %s", daemon.stores[c.OS].layerStore, img.RootFS.ChainID(), err)
 		}
 		// Reverse order, expecting parent most first
 		s.Windows.LayerFolders = append([]string{layerPath}, s.Windows.LayerFolders...)

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -79,7 +79,7 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *containertypes.Hos
 
 	// check if hostConfig is in line with the current system settings.
 	// It may happen cgroups are umounted or the like.
-	if _, err = daemon.verifyContainerSettings(container.Platform, container.HostConfig, nil, false); err != nil {
+	if _, err = daemon.verifyContainerSettings(container.OS, container.HostConfig, nil, false); err != nil {
 		return validationError{err}
 	}
 	// Adapt for old containers in case we have updates in this function and
@@ -191,7 +191,7 @@ func (daemon *Daemon) Cleanup(container *container.Container) {
 	if err := daemon.conditionalUnmountOnCleanup(container); err != nil {
 		// FIXME: remove once reference counting for graphdrivers has been refactored
 		// Ensure that all the mounts are gone
-		if mountid, err := daemon.stores[container.Platform].layerStore.GetMountID(container.ID); err == nil {
+		if mountid, err := daemon.stores[container.OS].layerStore.GetMountID(container.ID); err == nil {
 			daemon.cleanupMountsByID(mountid)
 		}
 	}

--- a/daemon/start_windows.go
+++ b/daemon/start_windows.go
@@ -10,7 +10,7 @@ func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Contain
 	createOptions := []libcontainerd.CreateOption{}
 
 	// LCOW options.
-	if container.Platform == "linux" {
+	if container.OS == "linux" {
 		config := &client.Config{}
 		if err := config.GenerateDefault(daemon.configStore.GraphOptions); err != nil {
 			return nil, err

--- a/daemon/update.go
+++ b/daemon/update.go
@@ -16,7 +16,7 @@ func (daemon *Daemon) ContainerUpdate(name string, hostConfig *container.HostCon
 		return container.ContainerUpdateOKBody{Warnings: warnings}, err
 	}
 
-	warnings, err = daemon.verifyContainerSettings(c.Platform, hostConfig, nil, true)
+	warnings, err = daemon.verifyContainerSettings(c.OS, hostConfig, nil, true)
 	if err != nil {
 		return container.ContainerUpdateOKBody{Warnings: warnings}, validationError{err}
 	}

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -75,7 +75,7 @@ func (m mounts) parts(i int) int {
 func (daemon *Daemon) registerMountPoints(container *container.Container, hostConfig *containertypes.HostConfig) (retErr error) {
 	binds := map[string]bool{}
 	mountPoints := map[string]*volume.MountPoint{}
-	parser := volume.NewParser(container.Platform)
+	parser := volume.NewParser(container.OS)
 	defer func() {
 		// clean up the container mountpoints once return with error
 		if retErr != nil {
@@ -256,7 +256,7 @@ func (daemon *Daemon) backportMountSpec(container *container.Container) {
 	container.Lock()
 	defer container.Unlock()
 
-	parser := volume.NewParser(container.Platform)
+	parser := volume.NewParser(container.OS)
 
 	maybeUpdate := make(map[string]bool)
 	for _, mp := range container.MountPoints {

--- a/distribution/config.go
+++ b/distribution/config.go
@@ -86,7 +86,7 @@ type ImagePushConfig struct {
 type ImageConfigStore interface {
 	Put([]byte) (digest.Digest, error)
 	Get(digest.Digest) ([]byte, error)
-	RootFSAndPlatformFromConfig([]byte) (*image.RootFS, layer.Platform, error)
+	RootFSAndOSFromConfig([]byte) (*image.RootFS, layer.OS, error)
 }
 
 // PushLayerProvider provides layers to be pushed by ChainID.
@@ -112,7 +112,7 @@ type RootFSDownloadManager interface {
 	// returns the final rootfs.
 	// Given progress output to track download progress
 	// Returns function to release download resources
-	Download(ctx context.Context, initialRootFS image.RootFS, platform layer.Platform, layers []xfer.DownloadDescriptor, progressOutput progress.Output) (image.RootFS, func(), error)
+	Download(ctx context.Context, initialRootFS image.RootFS, os layer.OS, layers []xfer.DownloadDescriptor, progressOutput progress.Output) (image.RootFS, func(), error)
 }
 
 type imageConfigStore struct {
@@ -140,7 +140,7 @@ func (s *imageConfigStore) Get(d digest.Digest) ([]byte, error) {
 	return img.RawJSON(), nil
 }
 
-func (s *imageConfigStore) RootFSAndPlatformFromConfig(c []byte) (*image.RootFS, layer.Platform, error) {
+func (s *imageConfigStore) RootFSAndOSFromConfig(c []byte) (*image.RootFS, layer.OS, error) {
 	var unmarshalledConfig image.Image
 	if err := json.Unmarshal(c, &unmarshalledConfig); err != nil {
 		return nil, "", err
@@ -154,11 +154,11 @@ func (s *imageConfigStore) RootFSAndPlatformFromConfig(c []byte) (*image.RootFS,
 		return nil, "", fmt.Errorf("image operating system %q cannot be used on this platform", unmarshalledConfig.OS)
 	}
 
-	platform := ""
+	os := ""
 	if runtime.GOOS == "windows" {
-		platform = unmarshalledConfig.OS
+		os = unmarshalledConfig.OS
 	}
-	return unmarshalledConfig.RootFS, layer.Platform(platform), nil
+	return unmarshalledConfig.RootFS, layer.OS(os), nil
 }
 
 type storeLayerProvider struct {

--- a/distribution/pull_v1.go
+++ b/distribution/pull_v1.go
@@ -35,7 +35,7 @@ type v1Puller struct {
 	session     *registry.Session
 }
 
-func (p *v1Puller) Pull(ctx context.Context, ref reference.Named) error {
+func (p *v1Puller) Pull(ctx context.Context, ref reference.Named, platform string) error {
 	if _, isCanonical := ref.(reference.Canonical); isCanonical {
 		// Allowing fallback, because HTTPS v1 is before HTTP v2
 		return fallbackError{err: ErrNoSupport{Err: errors.New("Cannot pull by digest with v1 registry")}}

--- a/distribution/pull_v1.go
+++ b/distribution/pull_v1.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/docker/distribution/reference"
+	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/distribution/xfer"
@@ -68,7 +69,9 @@ func (p *v1Puller) Pull(ctx context.Context, ref reference.Named, platform strin
 	return nil
 }
 
-func (p *v1Puller) pullRepository(ctx context.Context, ref reference.Named) error {
+// Note use auth.Scope rather than reference.Named due to this warning causing Jenkins CI to fail:
+// warning: ref can be github.com/docker/docker/vendor/github.com/docker/distribution/registry/client/auth.Scope (interfacer)
+func (p *v1Puller) pullRepository(ctx context.Context, ref auth.Scope) error {
 	progress.Message(p.config.ProgressOutput, "", "Pulling repository "+p.repoInfo.Name.Name())
 
 	tagged, isTagged := ref.(reference.NamedTagged)

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -510,7 +510,7 @@ func (p *v2Puller) pullSchema1(ctx context.Context, ref reference.Reference, unv
 
 	// Early bath if the requested OS doesn't match that of the configuration.
 	// This avoids doing the download, only to potentially fail later.
-	if !strings.EqualFold(string(configOS), requestedOS) {
+	if !strings.EqualFold(configOS, requestedOS) {
 		return "", "", fmt.Errorf("cannot download image with operating system %q when requesting %q", configOS, requestedOS)
 	}
 
@@ -651,7 +651,7 @@ func (p *v2Puller) pullSchema2(ctx context.Context, ref reference.Named, mfst *s
 	}
 
 	if configJSON == nil {
-		configJSON, configRootFS, configOS, err = receiveConfig(p.config.ImageStore, configChan, configErrChan)
+		configJSON, configRootFS, _, err = receiveConfig(p.config.ImageStore, configChan, configErrChan)
 		if err == nil && configRootFS == nil {
 			err = errRootFSInvalid
 		}
@@ -723,7 +723,7 @@ func (p *v2Puller) pullManifestList(ctx context.Context, ref reference.Named, mf
 
 	logrus.Debugf("%s resolved to a manifestList object with %d entries; looking for a %s/%s match", ref, len(mfstList.Manifests), os, runtime.GOARCH)
 
-	manifestMatches := filterManifests(mfstList.Manifests)
+	manifestMatches := filterManifests(mfstList.Manifests, os)
 
 	if len(manifestMatches) == 0 {
 		errMsg := fmt.Sprintf("no matching manifest for %s/%s in the manifest list entries", os, runtime.GOARCH)

--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -16,13 +16,13 @@ func (ld *v2LayerDescriptor) open(ctx context.Context) (distribution.ReadSeekClo
 	return blobs.Open(ctx, ld.digest)
 }
 
-func filterManifests(manifests []manifestlist.ManifestDescriptor) []manifestlist.ManifestDescriptor {
+func filterManifests(manifests []manifestlist.ManifestDescriptor, os string) []manifestlist.ManifestDescriptor {
 	var matches []manifestlist.ManifestDescriptor
 	for _, manifestDescriptor := range manifests {
-		if manifestDescriptor.Platform.Architecture == runtime.GOARCH && manifestDescriptor.Platform.OS == runtime.GOOS {
+		if manifestDescriptor.Platform.Architecture == runtime.GOARCH && manifestDescriptor.Platform.OS == os {
 			matches = append(matches, manifestDescriptor)
 
-			logrus.Debugf("found match for %s/%s with media type %s, digest %s", runtime.GOOS, runtime.GOARCH, manifestDescriptor.MediaType, manifestDescriptor.Digest.String())
+			logrus.Debugf("found match for %s/%s with media type %s, digest %s", os, runtime.GOARCH, manifestDescriptor.MediaType, manifestDescriptor.Digest.String())
 		}
 	}
 	return matches

--- a/distribution/pull_v2_windows.go
+++ b/distribution/pull_v2_windows.go
@@ -76,12 +76,12 @@ func filterManifests(manifests []manifestlist.ManifestDescriptor) []manifestlist
 	var matches []manifestlist.ManifestDescriptor
 	for _, manifestDescriptor := range manifests {
 		if manifestDescriptor.Platform.Architecture == runtime.GOARCH && manifestDescriptor.Platform.OS == lookingForOS {
-			if !versionMatch(manifestDescriptor.Platform.OSVersion, osVersion) {
+			if lookingForOS == "windows" && !versionMatch(manifestDescriptor.Platform.OSVersion, osVersion) {
 				continue
 			}
 			matches = append(matches, manifestDescriptor)
 
-			logrus.Debugf("found match for %s/%s with media type %s, digest %s", runtime.GOOS, runtime.GOARCH, manifestDescriptor.MediaType, manifestDescriptor.Digest.String())
+			logrus.Debugf("found match for %s/%s with media type %s, digest %s", lookingForOS, runtime.GOARCH, manifestDescriptor.MediaType, manifestDescriptor.Digest.String())
 		}
 	}
 	sort.Stable(manifestsByVersion(matches))

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -118,7 +118,7 @@ func (p *v2Pusher) pushV2Tag(ctx context.Context, ref reference.NamedTagged, id 
 		return fmt.Errorf("could not find image from tag %s: %v", reference.FamiliarString(ref), err)
 	}
 
-	rootfs, _, err := p.config.ImageStore.RootFSAndPlatformFromConfig(imgConfig)
+	rootfs, _, err := p.config.ImageStore.RootFSAndOSFromConfig(imgConfig)
 	if err != nil {
 		return fmt.Errorf("unable to get rootfs for image %s: %s", reference.FamiliarString(ref), err)
 	}

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"runtime"
 	"strings"
 	"testing"
 

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -83,7 +83,7 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 	logrus.Debug("About to pull")
 	// We expect it to fail, since we haven't mock'd the full registry exchange in our handler above
 	tag, _ := reference.WithTag(n, "tag_goes_here")
-	_ = p.pullV2Repository(ctx, tag)
+	_ = p.pullV2Repository(ctx, tag, runtime.GOOS)
 }
 
 func TestTokenPassThru(t *testing.T) {

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -95,7 +95,7 @@ type DownloadDescriptorWithRegistered interface {
 // Download method is called to get the layer tar data. Layers are then
 // registered in the appropriate order.  The caller must call the returned
 // release function once it is done with the returned RootFS object.
-func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS image.RootFS, platform layer.Platform, layers []DownloadDescriptor, progressOutput progress.Output) (image.RootFS, func(), error) {
+func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS image.RootFS, os layer.OS, layers []DownloadDescriptor, progressOutput progress.Output) (image.RootFS, func(), error) {
 	var (
 		topLayer       layer.Layer
 		topDownload    *downloadTransfer
@@ -105,9 +105,9 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 		downloadsByKey = make(map[string]*downloadTransfer)
 	)
 
-	// Assume that the platform is the host OS if blank
-	if platform == "" {
-		platform = layer.Platform(runtime.GOOS)
+	// Assume that the operating system is the host OS if blank
+	if os == "" {
+		os = layer.OS(runtime.GOOS)
 	}
 
 	rootFS := initialRootFS
@@ -121,13 +121,13 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 			if err == nil {
 				getRootFS := rootFS
 				getRootFS.Append(diffID)
-				l, err := ldm.layerStores[string(platform)].Get(getRootFS.ChainID())
+				l, err := ldm.layerStores[string(os)].Get(getRootFS.ChainID())
 				if err == nil {
 					// Layer already exists.
 					logrus.Debugf("Layer already exists: %s", descriptor.ID())
 					progress.Update(progressOutput, descriptor.ID(), "Already exists")
 					if topLayer != nil {
-						layer.ReleaseAndLog(ldm.layerStores[string(platform)], topLayer)
+						layer.ReleaseAndLog(ldm.layerStores[string(os)], topLayer)
 					}
 					topLayer = l
 					missingLayer = false
@@ -146,7 +146,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 		// the stack? If so, avoid downloading it more than once.
 		var topDownloadUncasted Transfer
 		if existingDownload, ok := downloadsByKey[key]; ok {
-			xferFunc := ldm.makeDownloadFuncFromDownload(descriptor, existingDownload, topDownload, platform)
+			xferFunc := ldm.makeDownloadFuncFromDownload(descriptor, existingDownload, topDownload, os)
 			defer topDownload.Transfer.Release(watcher)
 			topDownloadUncasted, watcher = ldm.tm.Transfer(transferKey, xferFunc, progressOutput)
 			topDownload = topDownloadUncasted.(*downloadTransfer)
@@ -158,10 +158,10 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 
 		var xferFunc DoFunc
 		if topDownload != nil {
-			xferFunc = ldm.makeDownloadFunc(descriptor, "", topDownload, platform)
+			xferFunc = ldm.makeDownloadFunc(descriptor, "", topDownload, os)
 			defer topDownload.Transfer.Release(watcher)
 		} else {
-			xferFunc = ldm.makeDownloadFunc(descriptor, rootFS.ChainID(), nil, platform)
+			xferFunc = ldm.makeDownloadFunc(descriptor, rootFS.ChainID(), nil, os)
 		}
 		topDownloadUncasted, watcher = ldm.tm.Transfer(transferKey, xferFunc, progressOutput)
 		topDownload = topDownloadUncasted.(*downloadTransfer)
@@ -171,7 +171,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 	if topDownload == nil {
 		return rootFS, func() {
 			if topLayer != nil {
-				layer.ReleaseAndLog(ldm.layerStores[string(platform)], topLayer)
+				layer.ReleaseAndLog(ldm.layerStores[string(os)], topLayer)
 			}
 		}, nil
 	}
@@ -182,7 +182,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 
 	defer func() {
 		if topLayer != nil {
-			layer.ReleaseAndLog(ldm.layerStores[string(platform)], topLayer)
+			layer.ReleaseAndLog(ldm.layerStores[string(os)], topLayer)
 		}
 	}()
 
@@ -218,11 +218,11 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 // complete before the registration step, and registers the downloaded data
 // on top of parentDownload's resulting layer. Otherwise, it registers the
 // layer on top of the ChainID given by parentLayer.
-func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor, parentLayer layer.ChainID, parentDownload *downloadTransfer, platform layer.Platform) DoFunc {
+func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor, parentLayer layer.ChainID, parentDownload *downloadTransfer, os layer.OS) DoFunc {
 	return func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) Transfer {
 		d := &downloadTransfer{
 			Transfer:   NewTransfer(),
-			layerStore: ldm.layerStores[string(platform)],
+			layerStore: ldm.layerStores[string(os)],
 		}
 
 		go func() {
@@ -341,9 +341,9 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				src = fs.Descriptor()
 			}
 			if ds, ok := d.layerStore.(layer.DescribableStore); ok {
-				d.layer, err = ds.RegisterWithDescriptor(inflatedLayerData, parentLayer, platform, src)
+				d.layer, err = ds.RegisterWithDescriptor(inflatedLayerData, parentLayer, os, src)
 			} else {
-				d.layer, err = d.layerStore.Register(inflatedLayerData, parentLayer, platform)
+				d.layer, err = d.layerStore.Register(inflatedLayerData, parentLayer, os)
 			}
 			if err != nil {
 				select {
@@ -382,11 +382,11 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 // parentDownload. This function does not log progress output because it would
 // interfere with the progress reporting for sourceDownload, which has the same
 // Key.
-func (ldm *LayerDownloadManager) makeDownloadFuncFromDownload(descriptor DownloadDescriptor, sourceDownload *downloadTransfer, parentDownload *downloadTransfer, platform layer.Platform) DoFunc {
+func (ldm *LayerDownloadManager) makeDownloadFuncFromDownload(descriptor DownloadDescriptor, sourceDownload *downloadTransfer, parentDownload *downloadTransfer, os layer.OS) DoFunc {
 	return func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) Transfer {
 		d := &downloadTransfer{
 			Transfer:   NewTransfer(),
-			layerStore: ldm.layerStores[string(platform)],
+			layerStore: ldm.layerStores[string(os)],
 		}
 
 		go func() {
@@ -440,9 +440,9 @@ func (ldm *LayerDownloadManager) makeDownloadFuncFromDownload(descriptor Downloa
 				src = fs.Descriptor()
 			}
 			if ds, ok := d.layerStore.(layer.DescribableStore); ok {
-				d.layer, err = ds.RegisterWithDescriptor(layerReader, parentLayer, platform, src)
+				d.layer, err = ds.RegisterWithDescriptor(layerReader, parentLayer, os, src)
 			} else {
-				d.layer, err = d.layerStore.Register(layerReader, parentLayer, platform)
+				d.layer, err = d.layerStore.Register(layerReader, parentLayer, os)
 			}
 			if err != nil {
 				d.err = fmt.Errorf("failed to register layer: %v", err)

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -26,7 +26,7 @@ type mockLayer struct {
 	diffID    layer.DiffID
 	chainID   layer.ChainID
 	parent    layer.Layer
-	platform  layer.Platform
+	os        layer.OS
 }
 
 func (ml *mockLayer) TarStream() (io.ReadCloser, error) {
@@ -57,8 +57,8 @@ func (ml *mockLayer) DiffSize() (size int64, err error) {
 	return 0, nil
 }
 
-func (ml *mockLayer) Platform() layer.Platform {
-	return ml.platform
+func (ml *mockLayer) OS() layer.OS {
+	return ml.os
 }
 
 func (ml *mockLayer) Metadata() (map[string]string, error) {
@@ -91,7 +91,7 @@ func (ls *mockLayerStore) Map() map[layer.ChainID]layer.Layer {
 	return layers
 }
 
-func (ls *mockLayerStore) Register(reader io.Reader, parentID layer.ChainID, platform layer.Platform) (layer.Layer, error) {
+func (ls *mockLayerStore) Register(reader io.Reader, parentID layer.ChainID, os layer.OS) (layer.Layer, error) {
 	return ls.RegisterWithDescriptor(reader, parentID, distribution.Descriptor{})
 }
 
@@ -293,13 +293,13 @@ func TestSuccessfulDownload(t *testing.T) {
 	firstDescriptor := descriptors[0].(*mockDownloadDescriptor)
 
 	// Pre-register the first layer to simulate an already-existing layer
-	l, err := layerStore.Register(firstDescriptor.mockTarStream(), "", layer.Platform(runtime.GOOS))
+	l, err := layerStore.Register(firstDescriptor.mockTarStream(), "", layer.OS(runtime.GOOS))
 	if err != nil {
 		t.Fatal(err)
 	}
 	firstDescriptor.diffID = l.DiffID()
 
-	rootFS, releaseFunc, err := ldm.Download(context.Background(), *image.NewRootFS(), layer.Platform(runtime.GOOS), descriptors, progress.ChanOutput(progressChan))
+	rootFS, releaseFunc, err := ldm.Download(context.Background(), *image.NewRootFS(), layer.OS(runtime.GOOS), descriptors, progress.ChanOutput(progressChan))
 	if err != nil {
 		t.Fatalf("download error: %v", err)
 	}
@@ -357,7 +357,7 @@ func TestCancelledDownload(t *testing.T) {
 	}()
 
 	descriptors := downloadDescriptors(nil)
-	_, _, err := ldm.Download(ctx, *image.NewRootFS(), layer.Platform(runtime.GOOS), descriptors, progress.ChanOutput(progressChan))
+	_, _, err := ldm.Download(ctx, *image.NewRootFS(), layer.OS(runtime.GOOS), descriptors, progress.ChanOutput(progressChan))
 	if err != context.Canceled {
 		t.Fatal("expected download to be cancelled")
 	}

--- a/image/image.go
+++ b/image/image.go
@@ -96,8 +96,8 @@ func (img *Image) RunConfig() *container.Config {
 	return img.Config
 }
 
-// Platform returns the image's operating system. If not populated, defaults to the host runtime OS.
-func (img *Image) Platform() string {
+// OperatingSystem returns the image's operating system. If not populated, defaults to the host runtime OS.
+func (img *Image) OperatingSystem() string {
 	os := img.OS
 	if os == "" {
 		os = runtime.GOOS

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -62,7 +62,7 @@ func TestImage(t *testing.T) {
 		Domainname: "domain",
 		User:       "root",
 	}
-	platform := runtime.GOOS
+	os := runtime.GOOS
 
 	img := &Image{
 		V1Image: V1Image{
@@ -73,19 +73,19 @@ func TestImage(t *testing.T) {
 
 	assert.Equal(t, cid, img.ImageID())
 	assert.Equal(t, cid, img.ID().String())
-	assert.Equal(t, platform, img.Platform())
+	assert.Equal(t, os, img.OperatingSystem())
 	assert.Equal(t, config, img.RunConfig())
 }
 
-func TestImagePlatformNotEmpty(t *testing.T) {
-	platform := "platform"
+func TestImageOSNotEmpty(t *testing.T) {
+	os := "os"
 	img := &Image{
 		V1Image: V1Image{
-			OS: platform,
+			OS: os,
 		},
 		OSVersion: "osversion",
 	}
-	assert.Equal(t, platform, img.Platform())
+	assert.Equal(t, os, img.OperatingSystem())
 }
 
 func TestNewChildImageFromImageWithRootFS(t *testing.T) {

--- a/image/store.go
+++ b/image/store.go
@@ -47,17 +47,17 @@ type store struct {
 	images    map[ID]*imageMeta
 	fs        StoreBackend
 	digestSet *digestset.Set
-	platform  string
+	os        string
 }
 
 // NewImageStore returns new store object for given layer store
-func NewImageStore(fs StoreBackend, platform string, ls LayerGetReleaser) (Store, error) {
+func NewImageStore(fs StoreBackend, os string, ls LayerGetReleaser) (Store, error) {
 	is := &store{
 		ls:        ls,
 		images:    make(map[ID]*imageMeta),
 		fs:        fs,
 		digestSet: digestset.NewSet(),
-		platform:  platform,
+		os:        os,
 	}
 
 	// load all current images and retain layers
@@ -118,11 +118,11 @@ func (is *store) Create(config []byte) (ID, error) {
 		return "", err
 	}
 
-	// TODO @jhowardmsft - LCOW Support. This will need revisiting.
+	// TODO @jhowardmsft - LCOW Support. This will need revisiting when coalescing the image stores.
 	// Integrity check - ensure we are creating something for the correct platform
 	if system.LCOWSupported() {
-		if strings.ToLower(img.Platform()) != strings.ToLower(is.platform) {
-			return "", fmt.Errorf("cannot create entry for platform %q in image store for platform %q", img.Platform(), is.platform)
+		if strings.ToLower(img.OperatingSystem()) != strings.ToLower(is.os) {
+			return "", fmt.Errorf("cannot create entry for operating system %q in image store for operating system %q", img.OperatingSystem(), is.os)
 		}
 	}
 

--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -90,13 +90,13 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 		}
 
 		// On Windows, validate the platform, defaulting to windows if not present.
-		platform := layer.Platform(img.OS)
+		os := layer.OS(img.OS)
 		if runtime.GOOS == "windows" {
-			if platform == "" {
-				platform = "windows"
+			if os == "" {
+				os = "windows"
 			}
-			if (platform != "windows") && (platform != "linux") {
-				return fmt.Errorf("configuration for this image has an unsupported platform: %s", platform)
+			if (os != "windows") && (os != "linux") {
+				return fmt.Errorf("configuration for this image has an unsupported operating system: %s", os)
 			}
 		}
 
@@ -109,7 +109,7 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 			r.Append(diffID)
 			newLayer, err := l.ls.Get(r.ChainID())
 			if err != nil {
-				newLayer, err = l.loadLayer(layerPath, rootFS, diffID.String(), platform, m.LayerSources[diffID], progressOutput)
+				newLayer, err = l.loadLayer(layerPath, rootFS, diffID.String(), os, m.LayerSources[diffID], progressOutput)
 				if err != nil {
 					return err
 				}
@@ -176,7 +176,7 @@ func (l *tarexporter) setParentID(id, parentID image.ID) error {
 	return l.is.SetParent(id, parentID)
 }
 
-func (l *tarexporter) loadLayer(filename string, rootFS image.RootFS, id string, platform layer.Platform, foreignSrc distribution.Descriptor, progressOutput progress.Output) (layer.Layer, error) {
+func (l *tarexporter) loadLayer(filename string, rootFS image.RootFS, id string, os layer.OS, foreignSrc distribution.Descriptor, progressOutput progress.Output) (layer.Layer, error) {
 	// We use system.OpenSequential to use sequential file access on Windows, avoiding
 	// depleting the standby list. On Linux, this equates to a regular os.Open.
 	rawTar, err := system.OpenSequential(filename)
@@ -206,9 +206,9 @@ func (l *tarexporter) loadLayer(filename string, rootFS image.RootFS, id string,
 	defer inflatedLayerData.Close()
 
 	if ds, ok := l.ls.(layer.DescribableStore); ok {
-		return ds.RegisterWithDescriptor(inflatedLayerData, rootFS.ChainID(), platform, foreignSrc)
+		return ds.RegisterWithDescriptor(inflatedLayerData, rootFS.ChainID(), os, foreignSrc)
 	}
-	return l.ls.Register(inflatedLayerData, rootFS.ChainID(), platform)
+	return l.ls.Register(inflatedLayerData, rootFS.ChainID(), os)
 }
 
 func (l *tarexporter) setLoadedTag(ref reference.Named, imgID digest.Digest, outStream io.Writer) error {

--- a/layer/empty.go
+++ b/layer/empty.go
@@ -55,7 +55,7 @@ func (el *emptyLayer) Metadata() (map[string]string, error) {
 	return make(map[string]string), nil
 }
 
-func (el *emptyLayer) Platform() Platform {
+func (el *emptyLayer) OS() OS {
 	return ""
 }
 

--- a/layer/filestore_unix.go
+++ b/layer/filestore_unix.go
@@ -2,12 +2,12 @@
 
 package layer
 
-// SetPlatform writes the "platform" file to the layer filestore
-func (fm *fileMetadataTransaction) SetPlatform(platform Platform) error {
+// SetOS writes the "os" file to the layer filestore
+func (fm *fileMetadataTransaction) SetOS(os OS) error {
 	return nil
 }
 
-// GetPlatform reads the "platform" file from the layer filestore
-func (fms *fileMetadataStore) GetPlatform(layer ChainID) (Platform, error) {
+// GetOS reads the "os" file from the layer filestore
+func (fms *fileMetadataStore) GetOS(layer ChainID) (OS, error) {
 	return "", nil
 }

--- a/layer/filestore_windows.go
+++ b/layer/filestore_windows.go
@@ -7,19 +7,19 @@ import (
 	"strings"
 )
 
-// SetPlatform writes the "platform" file to the layer filestore
-func (fm *fileMetadataTransaction) SetPlatform(platform Platform) error {
-	if platform == "" {
+// SetOS writes the "os" file to the layer filestore
+func (fm *fileMetadataTransaction) SetOS(os OS) error {
+	if os == "" {
 		return nil
 	}
-	return fm.ws.WriteFile("platform", []byte(platform), 0644)
+	return fm.ws.WriteFile("os", []byte(os), 0644)
 }
 
-// GetPlatform reads the "platform" file from the layer filestore
-func (fms *fileMetadataStore) GetPlatform(layer ChainID) (Platform, error) {
-	contentBytes, err := ioutil.ReadFile(fms.getLayerFilename(layer, "platform"))
+// GetOS reads the "os" file from the layer filestore
+func (fms *fileMetadataStore) GetOS(layer ChainID) (OS, error) {
+	contentBytes, err := ioutil.ReadFile(fms.getLayerFilename(layer, "os"))
 	if err != nil {
-		// For backwards compatibility, the platform file may not exist. Default to "windows" if missing.
+		// For backwards compatibility, the os file may not exist. Default to "windows" if missing.
 		if os.IsNotExist(err) {
 			return "windows", nil
 		}
@@ -28,8 +28,8 @@ func (fms *fileMetadataStore) GetPlatform(layer ChainID) (Platform, error) {
 	content := strings.TrimSpace(string(contentBytes))
 
 	if content != "windows" && content != "linux" {
-		return "", fmt.Errorf("invalid platform value: %s", content)
+		return "", fmt.Errorf("invalid operating system value: %s", content)
 	}
 
-	return Platform(content), nil
+	return OS(content), nil
 }

--- a/layer/layer.go
+++ b/layer/layer.go
@@ -53,8 +53,8 @@ var (
 	ErrMaxDepthExceeded = errors.New("max depth exceeded")
 
 	// ErrNotSupported is used when the action is not supported
-	// on the current platform
-	ErrNotSupported = errors.New("not support on this platform")
+	// on the current host operating system.
+	ErrNotSupported = errors.New("not support on this host operating system")
 )
 
 // ChainID is the content-addressable ID of a layer.
@@ -65,11 +65,11 @@ func (id ChainID) String() string {
 	return string(id)
 }
 
-// Platform is the platform of a layer
-type Platform string
+// OS is the operating system of a layer
+type OS string
 
-// String returns a string rendition of layers target platform
-func (id Platform) String() string {
+// String returns a string rendition of layers target operating system
+func (id OS) String() string {
 	return string(id)
 }
 
@@ -108,8 +108,8 @@ type Layer interface {
 	// Parent returns the next layer in the layer chain.
 	Parent() Layer
 
-	// Platform returns the platform of the layer
-	Platform() Platform
+	// OS returns the operating system of the layer
+	OS() OS
 
 	// Size returns the size of the entire layer chain. The size
 	// is calculated from the total size of all files in the layers.
@@ -191,7 +191,7 @@ type CreateRWLayerOpts struct {
 // Store represents a backend for managing both
 // read-only and read-write layers.
 type Store interface {
-	Register(io.Reader, ChainID, Platform) (Layer, error)
+	Register(io.Reader, ChainID, OS) (Layer, error)
 	Get(ChainID) (Layer, error)
 	Map() map[ChainID]Layer
 	Release(Layer) ([]Metadata, error)
@@ -209,7 +209,7 @@ type Store interface {
 // DescribableStore represents a layer store capable of storing
 // descriptors for layers.
 type DescribableStore interface {
-	RegisterWithDescriptor(io.Reader, ChainID, Platform, distribution.Descriptor) (Layer, error)
+	RegisterWithDescriptor(io.Reader, ChainID, OS, distribution.Descriptor) (Layer, error)
 }
 
 // MetadataTransaction represents functions for setting layer metadata
@@ -220,7 +220,7 @@ type MetadataTransaction interface {
 	SetDiffID(DiffID) error
 	SetCacheID(string) error
 	SetDescriptor(distribution.Descriptor) error
-	SetPlatform(Platform) error
+	SetOS(OS) error
 	TarSplitWriter(compressInput bool) (io.WriteCloser, error)
 
 	Commit(ChainID) error
@@ -241,7 +241,7 @@ type MetadataStore interface {
 	GetDiffID(ChainID) (DiffID, error)
 	GetCacheID(ChainID) (string, error)
 	GetDescriptor(ChainID) (distribution.Descriptor, error)
-	GetPlatform(ChainID) (Platform, error)
+	GetOS(ChainID) (OS, error)
 	TarSplitReader(ChainID) (io.ReadCloser, error)
 
 	SetMountID(string, string) error

--- a/layer/layer_store_windows.go
+++ b/layer/layer_store_windows.go
@@ -6,6 +6,6 @@ import (
 	"github.com/docker/distribution"
 )
 
-func (ls *layerStore) RegisterWithDescriptor(ts io.Reader, parent ChainID, platform Platform, descriptor distribution.Descriptor) (Layer, error) {
-	return ls.registerWithDescriptor(ts, parent, platform, descriptor)
+func (ls *layerStore) RegisterWithDescriptor(ts io.Reader, parent ChainID, os OS, descriptor distribution.Descriptor) (Layer, error) {
+	return ls.registerWithDescriptor(ts, parent, os, descriptor)
 }

--- a/layer/layer_test.go
+++ b/layer/layer_test.go
@@ -108,7 +108,7 @@ func createLayer(ls Store, parent ChainID, layerFunc layerInit) (Layer, error) {
 	}
 	defer ts.Close()
 
-	layer, err := ls.Register(ts, parent, Platform(runtime.GOOS))
+	layer, err := ls.Register(ts, parent, OS(runtime.GOOS))
 	if err != nil {
 		return nil, err
 	}
@@ -501,7 +501,7 @@ func TestTarStreamStability(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	layer1, err := ls.Register(bytes.NewReader(tar1), "", Platform(runtime.GOOS))
+	layer1, err := ls.Register(bytes.NewReader(tar1), "", OS(runtime.GOOS))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -520,7 +520,7 @@ func TestTarStreamStability(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	layer2, err := ls.Register(bytes.NewReader(tar2), layer1.ChainID(), Platform(runtime.GOOS))
+	layer2, err := ls.Register(bytes.NewReader(tar2), layer1.ChainID(), OS(runtime.GOOS))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -688,12 +688,12 @@ func TestRegisterExistingLayer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	layer2a, err := ls.Register(bytes.NewReader(tar1), layer1.ChainID(), Platform(runtime.GOOS))
+	layer2a, err := ls.Register(bytes.NewReader(tar1), layer1.ChainID(), OS(runtime.GOOS))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	layer2b, err := ls.Register(bytes.NewReader(tar1), layer1.ChainID(), Platform(runtime.GOOS))
+	layer2b, err := ls.Register(bytes.NewReader(tar1), layer1.ChainID(), OS(runtime.GOOS))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -728,12 +728,12 @@ func TestTarStreamVerification(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	layer1, err := ls.Register(bytes.NewReader(tar1), "", Platform(runtime.GOOS))
+	layer1, err := ls.Register(bytes.NewReader(tar1), "", OS(runtime.GOOS))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	layer2, err := ls.Register(bytes.NewReader(tar2), "", Platform(runtime.GOOS))
+	layer2, err := ls.Register(bytes.NewReader(tar2), "", OS(runtime.GOOS))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/layer/migration_test.go
+++ b/layer/migration_test.go
@@ -110,14 +110,14 @@ func TestLayerMigration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	layer1b, err := ls.Register(bytes.NewReader(tar1), "", Platform(runtime.GOOS))
+	layer1b, err := ls.Register(bytes.NewReader(tar1), "", OS(runtime.GOOS))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	assertReferences(t, layer1a, layer1b)
 	// Attempt register, should be same
-	layer2a, err := ls.Register(bytes.NewReader(tar2), layer1a.ChainID(), Platform(runtime.GOOS))
+	layer2a, err := ls.Register(bytes.NewReader(tar2), layer1a.ChainID(), OS(runtime.GOOS))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +238,7 @@ func TestLayerMigrationNoTarsplit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	layer1b, err := ls.Register(bytes.NewReader(tar1), "", Platform(runtime.GOOS))
+	layer1b, err := ls.Register(bytes.NewReader(tar1), "", OS(runtime.GOOS))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,7 +246,7 @@ func TestLayerMigrationNoTarsplit(t *testing.T) {
 	assertReferences(t, layer1a, layer1b)
 
 	// Attempt register, should be same
-	layer2a, err := ls.Register(bytes.NewReader(tar2), layer1a.ChainID(), Platform(runtime.GOOS))
+	layer2a, err := ls.Register(bytes.NewReader(tar2), layer1a.ChainID(), OS(runtime.GOOS))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/layer/ro_layer.go
+++ b/layer/ro_layer.go
@@ -16,7 +16,7 @@ type roLayer struct {
 	size       int64
 	layerStore *layerStore
 	descriptor distribution.Descriptor
-	platform   Platform
+	os         OS
 
 	referenceCount int
 	references     map[Layer]struct{}
@@ -143,7 +143,7 @@ func storeLayer(tx MetadataTransaction, layer *roLayer) error {
 			return err
 		}
 	}
-	if err := tx.SetPlatform(layer.platform); err != nil {
+	if err := tx.SetOS(layer.os); err != nil {
 		return err
 	}
 

--- a/layer/ro_layer_unix.go
+++ b/layer/ro_layer_unix.go
@@ -2,6 +2,6 @@
 
 package layer
 
-func (rl *roLayer) Platform() Platform {
+func (rl *roLayer) OS() OS {
 	return ""
 }

--- a/layer/ro_layer_windows.go
+++ b/layer/ro_layer_windows.go
@@ -8,9 +8,9 @@ func (rl *roLayer) Descriptor() distribution.Descriptor {
 	return rl.descriptor
 }
 
-func (rl *roLayer) Platform() Platform {
-	if rl.platform == "" {
+func (rl *roLayer) OS() OS {
+	if rl.os == "" {
 		return "windows"
 	}
-	return rl.platform
+	return rl.os
 }

--- a/migrate/v1/migratev1_test.go
+++ b/migrate/v1/migratev1_test.go
@@ -433,7 +433,7 @@ func (l *mockLayer) DiffSize() (int64, error) {
 	return 0, nil
 }
 
-func (l *mockLayer) Platform() layer.Platform {
+func (l *mockLayer) OS() layer.OS {
 	return ""
 }
 

--- a/pkg/system/init_windows.go
+++ b/pkg/system/init_windows.go
@@ -2,17 +2,16 @@ package system
 
 import "os"
 
-// LCOWSupported determines if Linux Containers on Windows are supported.
-// Note: This feature is in development (06/17) and enabled through an
-// environment variable. At a future time, it will be enabled based
-// on build number. @jhowardmsft
+// lcowSupported determines if Linux Containers on Windows are supported.
 var lcowSupported = false
 
 // InitLCOW sets whether LCOW is supported or not
+// TODO @jhowardmsft.
+// 1. Replace with RS3 RTM build number.
+// 2. Remove the getenv check when image-store is coalesced as shouldn't be needed anymore.
 func InitLCOW(experimental bool) {
-	// LCOW initialization
-	if experimental && os.Getenv("LCOW_SUPPORTED") != "" {
+	v := GetOSVersion()
+	if experimental && v.Build > 16270 && os.Getenv("LCOW_SUPPORTED") != "" {
 		lcowSupported = true
 	}
-
 }

--- a/pkg/system/lcow.go
+++ b/pkg/system/lcow.go
@@ -1,0 +1,71 @@
+package system
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// IsPlatformEmpty determines if an OCI image-spec platform structure is not populated.
+// TODO This is a temporary function - can be replaced by parsing from
+// https://github.com/containerd/containerd/pull/1403/files at a later date.
+// @jhowardmsft
+func IsPlatformEmpty(platform specs.Platform) bool {
+	if platform.Architecture == "" &&
+		platform.OS == "" &&
+		len(platform.OSFeatures) == 0 &&
+		platform.OSVersion == "" &&
+		platform.Variant == "" {
+		return true
+	}
+	return false
+}
+
+// ValidatePlatform determines if a platform structure is valid.
+// TODO This is a temporary function - can be replaced by parsing from
+// https://github.com/containerd/containerd/pull/1403/files at a later date.
+// @jhowardmsft
+func ValidatePlatform(platform *specs.Platform) error {
+	platform.Architecture = strings.ToLower(platform.Architecture)
+	platform.OS = strings.ToLower(platform.OS)
+	if platform.Architecture != "" && platform.Architecture != runtime.GOARCH {
+		return fmt.Errorf("invalid platform architecture %q", platform.Architecture)
+	}
+	if platform.OS != "" {
+		if !(platform.OS == runtime.GOOS || (LCOWSupported() && platform.OS == "linux")) {
+			return fmt.Errorf("invalid platform os %q", platform.OS)
+		}
+	}
+	if len(platform.OSFeatures) != 0 {
+		return fmt.Errorf("invalid platform osfeatures %q", platform.OSFeatures)
+	}
+	if platform.OSVersion != "" {
+		return fmt.Errorf("invalid platform osversion %q", platform.OSVersion)
+	}
+	if platform.Variant != "" {
+		return fmt.Errorf("invalid platform variant %q", platform.Variant)
+	}
+	return nil
+}
+
+// ParsePlatform parses a platform string in the format os[/arch[/variant]
+// into an OCI image-spec platform structure.
+// TODO This is a temporary function - can be replaced by parsing from
+// https://github.com/containerd/containerd/pull/1403/files at a later date.
+// @jhowardmsft
+func ParsePlatform(in string) *specs.Platform {
+	p := &specs.Platform{}
+	elements := strings.SplitN(strings.ToLower(in), "/", 3)
+	if len(elements) == 3 {
+		p.Variant = elements[2]
+	}
+	if len(elements) >= 2 {
+		p.Architecture = elements[1]
+	}
+	if len(elements) >= 1 {
+		p.OS = elements[0]
+	}
+	return p
+}

--- a/pkg/system/lcow.go
+++ b/pkg/system/lcow.go
@@ -8,21 +8,6 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// IsPlatformEmpty determines if an OCI image-spec platform structure is not populated.
-// TODO This is a temporary function - can be replaced by parsing from
-// https://github.com/containerd/containerd/pull/1403/files at a later date.
-// @jhowardmsft
-func IsPlatformEmpty(platform specs.Platform) bool {
-	if platform.Architecture == "" &&
-		platform.OS == "" &&
-		len(platform.OSFeatures) == 0 &&
-		platform.OSVersion == "" &&
-		platform.Variant == "" {
-		return true
-	}
-	return false
-}
-
 // ValidatePlatform determines if a platform structure is valid.
 // TODO This is a temporary function - can be replaced by parsing from
 // https://github.com/containerd/containerd/pull/1403/files at a later date.
@@ -30,7 +15,9 @@ func IsPlatformEmpty(platform specs.Platform) bool {
 func ValidatePlatform(platform *specs.Platform) error {
 	platform.Architecture = strings.ToLower(platform.Architecture)
 	platform.OS = strings.ToLower(platform.OS)
-	if platform.Architecture != "" && platform.Architecture != runtime.GOARCH {
+	// Based on https://github.com/moby/moby/pull/34642#issuecomment-330375350, do
+	// not support anything except operating system.
+	if platform.Architecture != "" {
 		return fmt.Errorf("invalid platform architecture %q", platform.Architecture)
 	}
 	if platform.OS != "" {

--- a/pkg/system/path.go
+++ b/pkg/system/path.go
@@ -14,9 +14,9 @@ const defaultUnixPathEnv = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/s
 // DefaultPathEnv is unix style list of directories to search for
 // executables. Each directory is separated from the next by a colon
 // ':' character .
-func DefaultPathEnv(platform string) string {
+func DefaultPathEnv(os string) string {
 	if runtime.GOOS == "windows" {
-		if platform != runtime.GOOS && LCOWSupported() {
+		if os != runtime.GOOS {
 			return defaultUnixPathEnv
 		}
 		// Deliberately empty on Windows containers on Windows as the default path will be set by

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -146,7 +146,7 @@ func (s *tempConfigStore) Get(d digest.Digest) ([]byte, error) {
 	return s.config, nil
 }
 
-func (s *tempConfigStore) RootFSAndPlatformFromConfig(c []byte) (*image.RootFS, layer.Platform, error) {
+func (s *tempConfigStore) RootFSAndOSFromConfig(c []byte) (*image.RootFS, layer.OS, error) {
 	return configToRootFS(c)
 }
 
@@ -533,7 +533,7 @@ func (s *pluginConfigStore) Get(d digest.Digest) ([]byte, error) {
 	return ioutil.ReadAll(rwc)
 }
 
-func (s *pluginConfigStore) RootFSAndPlatformFromConfig(c []byte) (*image.RootFS, layer.Platform, error) {
+func (s *pluginConfigStore) RootFSAndOSFromConfig(c []byte) (*image.RootFS, layer.OS, error) {
 	return configToRootFS(c)
 }
 

--- a/plugin/blobstore.go
+++ b/plugin/blobstore.go
@@ -126,7 +126,7 @@ type downloadManager struct {
 	configDigest digest.Digest
 }
 
-func (dm *downloadManager) Download(ctx context.Context, initialRootFS image.RootFS, platform layer.Platform, layers []xfer.DownloadDescriptor, progressOutput progress.Output) (image.RootFS, func(), error) {
+func (dm *downloadManager) Download(ctx context.Context, initialRootFS image.RootFS, os layer.OS, layers []xfer.DownloadDescriptor, progressOutput progress.Output) (image.RootFS, func(), error) {
 	// TODO @jhowardmsft LCOW: May need revisiting.
 	for _, l := range layers {
 		b, err := dm.blobStore.New()
@@ -179,6 +179,6 @@ func (dm *downloadManager) Put(dt []byte) (digest.Digest, error) {
 func (dm *downloadManager) Get(d digest.Digest) ([]byte, error) {
 	return nil, fmt.Errorf("digest not found")
 }
-func (dm *downloadManager) RootFSAndPlatformFromConfig(c []byte) (*image.RootFS, layer.Platform, error) {
+func (dm *downloadManager) RootFSAndOSFromConfig(c []byte) (*image.RootFS, layer.OS, error) {
 	return configToRootFS(c)
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -379,11 +379,11 @@ func isEqualPrivilege(a, b types.PluginPrivilege) bool {
 	return reflect.DeepEqual(a.Value, b.Value)
 }
 
-func configToRootFS(c []byte) (*image.RootFS, layer.Platform, error) {
-	// TODO @jhowardmsft LCOW - Will need to revisit this. For now, calculate the platform.
-	platform := layer.Platform(runtime.GOOS)
+func configToRootFS(c []byte) (*image.RootFS, layer.OS, error) {
+	// TODO @jhowardmsft LCOW - Will need to revisit this. For now, calculate the operating system.
+	os := layer.OS(runtime.GOOS)
 	if system.LCOWSupported() {
-		platform = "linux"
+		os = "linux"
 	}
 	var pluginConfig types.PluginConfig
 	if err := json.Unmarshal(c, &pluginConfig); err != nil {
@@ -391,10 +391,10 @@ func configToRootFS(c []byte) (*image.RootFS, layer.Platform, error) {
 	}
 	// validation for empty rootfs is in distribution code
 	if pluginConfig.Rootfs == nil {
-		return nil, platform, nil
+		return nil, os, nil
 	}
 
-	return rootFSFromPlugin(pluginConfig.Rootfs), platform, nil
+	return rootFSFromPlugin(pluginConfig.Rootfs), os, nil
 }
 
 func rootFSFromPlugin(pluginfs *types.PluginConfigRootfs) *image.RootFS {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This PR has the API changes described in https://github.com/moby/moby/issues/34617.

_Update 9/13 based on feedback:_
~~Specifically, it adds an HTTP header "X-Requested-Platform" which is a JSON-encoded
OCI Image-spec `Platform` structure to `/images/create` and `/build`~~
Specifically, it adds a query parameter which is a simple string such as `platform=linux/amd64` to `/images/create` and `/build`.

In addition, it renames (almost all) uses of the string variable `platform` (and associated
methods/functions) to `os`, or `operatingSystem` where it clashes with the `os` import. This makes it much clearer to disambiguate with the swarm "platform" which is really `os/arch`. This is a stepping stone to getting the daemon towards fully multi-platform/arch-aware, and makes it clear when "operating system" is being referred to rather than "platform" which is misleadingly used - sometimes in the swarm
meaning, but more often as just the operating system.