### PR TITLE
DO NOT MERGE integration-cli/docker_cli_logs_test.go: Wait()

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN apt-get update && apt-get install -y \
 	&& pip install awscli==1.10.15
 
 # Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.173
+ENV LVM2_VERSION 2.02.168
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -55,7 +55,7 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends
 
 # Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.173
+ENV LVM2_VERSION 2.02.168
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install -y \
 	&& pip install awscli==1.10.15
 
 # Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.173
+ENV LVM2_VERSION 2.02.168
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends
 
 # Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.173
+ENV LVM2_VERSION 2.02.168
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -65,7 +65,7 @@ RUN set -x \
 	&& rm -rf "$SECCOMP_PATH"
 
 # Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.173
+ENV LVM2_VERSION 2.02.168
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1

--- a/daemon/graphdriver/overlay/copy.go
+++ b/daemon/graphdriver/overlay/copy.go
@@ -157,9 +157,10 @@ func copyDir(srcDir, dstDir string, flags copyFlags) error {
 		}
 
 		// system.Chtimes doesn't support a NOFOLLOW flag atm
+		// nolint: unconvert
 		if !isSymlink {
-			aTime := time.Unix(stat.Atim.Sec, stat.Atim.Nsec)
-			mTime := time.Unix(stat.Mtim.Sec, stat.Mtim.Nsec)
+			aTime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+			mTime := time.Unix(int64(stat.Mtim.Sec), int64(stat.Mtim.Nsec))
 			if err := system.Chtimes(dstPath, aTime, mTime); err != nil {
 				return err
 			}

--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -25,7 +25,7 @@ run_test_integration() {
 	done
 
 	(
-		flags="-check.v -check.timeout=${TIMEOUT} -test.timeout=360m $TESTFLAGS"
+		flags="-check.v -check.timeout=${TIMEOUT} -test.timeout=360m -check.f TestLogsFollowSlow $TESTFLAGS"
 		cd integration-cli
 		echo "Running $PWD"
 		test_env ./test.main $flags

--- a/hack/test/unit
+++ b/hack/test/unit
@@ -10,6 +10,8 @@
 #
 #    TESTDIRS="./pkg/term" hack/test/unit
 #
+echo 'Skipped ;)'
+exit 0
 set -eu -o pipefail
 
 TESTFLAGS+=" -test.timeout=${TIMEOUT:-5m}"

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -242,6 +242,7 @@ func (s *DockerSuite) TestLogsFollowSlowStdoutConsumer(c *check.C) {
 
 	actual := bytes1 + bytes2
 	expected := 200000
+	c.Logf("read %d+%d=%d bytes", bytes1, bytes2, actual)
 	c.Assert(actual, checker.Equals, expected)
 }
 

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -238,6 +238,8 @@ func (s *DockerSuite) TestLogsFollowSlowStdoutConsumer(c *check.C) {
 	bytes2, err := ConsumeWithSpeed(stdout, 32*1024, 0, nil)
 	c.Assert(err, checker.IsNil)
 
+	c.Assert(logCmd.Wait(), checker.IsNil)
+
 	actual := bytes1 + bytes2
 	expected := 200000
 	c.Assert(actual, checker.Equals, expected)
@@ -288,6 +290,7 @@ func (s *DockerSuite) TestLogsFollowGoroutinesWithStdout(c *check.C) {
 	c.Assert(<-chErr, checker.IsNil)
 	c.Assert(cmd.Process.Kill(), checker.IsNil)
 	r.Close()
+	cmd.Wait()
 	// NGoroutines is not updated right away, so we need to wait before failing
 	c.Assert(waitForGoroutines(nroutines), checker.IsNil)
 }
@@ -303,6 +306,7 @@ func (s *DockerSuite) TestLogsFollowGoroutinesNoOutput(c *check.C) {
 	c.Assert(cmd.Start(), checker.IsNil)
 	time.Sleep(200 * time.Millisecond)
 	c.Assert(cmd.Process.Kill(), checker.IsNil)
+	cmd.Wait()
 
 	// NGoroutines is not updated right away, so we need to wait before failing
 	c.Assert(waitForGoroutines(nroutines), checker.IsNil)


### PR DESCRIPTION
To avoid a zombie apocalyplse, use cmd.Wait() to properly finish
the processes we spawn with Start().

Found while investigating DockerSuite.TestLogsFollowSlowStdoutConsumer
failure on ARM (see https://github.com/moby/moby/pull/34550#issuecomment-324937936).