### PR TITLE
Add Init API field documentation to swagger

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -443,6 +443,10 @@ definitions:
       OomKillDisable:
         description: "Disable OOM Killer for the container."
         type: "boolean"
+      Init:
+        description: "Run an init inside the container that forwards signals and reaps processes. This field is omitted if empty, and the default (as configured on the daemon) is used."
+        type: "boolean"
+        x-nullable: true
       PidsLimit:
         description: "Tune a container's pids limit. Set -1 for unlimited."
         type: "integer"


### PR DESCRIPTION
The API documentation is missing a description of the "Init" HostConfig setting. This change corrects that omission. The text of the Init description is copied from the `docker run --help` output's description of the `--init` flag.

Tested with `make swagger-docs`