### PR TITLE
Fix bad import graph from opts/opts.go

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -502,7 +502,7 @@ func Validate(config *Config) error {
 		}
 	}
 
-	if _, err := opts.ParseGenericResources(config.NodeGenericResources); err != nil {
+	if _, err := ParseGenericResources(config.NodeGenericResources); err != nil {
 		return err
 	}
 

--- a/daemon/config/opts.go
+++ b/daemon/config/opts.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/daemon/cluster/convert"
+	"github.com/docker/swarmkit/api/genericresource"
+)
+
+// ParseGenericResources parses and validates the specified string as a list of GenericResource
+func ParseGenericResources(value string) ([]swarm.GenericResource, error) {
+	if value == "" {
+		return nil, nil
+	}
+
+	resources, err := genericresource.Parse(value)
+	if err != nil {
+		return nil, err
+	}
+
+	obj := convert.GenericResourcesFromGRPC(resources)
+	return obj, nil
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -29,7 +29,6 @@ import (
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/daemon/exec"
 	"github.com/docker/docker/daemon/logger"
-	"github.com/docker/docker/opts"
 	"github.com/sirupsen/logrus"
 	// register graph drivers
 	_ "github.com/docker/docker/daemon/graphdriver/register"
@@ -1053,7 +1052,7 @@ func (daemon *Daemon) setupInitLayer(initPath string) error {
 }
 
 func (daemon *Daemon) setGenericResources(conf *config.Config) error {
-	genericResources, err := opts.ParseGenericResources(conf.NodeGenericResources)
+	genericResources, err := config.ParseGenericResources(conf.NodeGenericResources)
 	if err != nil {
 		return err
 	}

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -7,10 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/daemon/cluster/convert"
 	units "github.com/docker/go-units"
-	"github.com/docker/swarmkit/api/genericresource"
 )
 
 var (
@@ -327,20 +324,4 @@ func (m *MemBytes) UnmarshalJSON(s []byte) error {
 	val, err := units.RAMInBytes(string(s[1 : len(s)-1]))
 	*m = MemBytes(val)
 	return err
-}
-
-// ParseGenericResources parses and validates the specified string as a list of GenericResource
-func ParseGenericResources(value string) ([]swarm.GenericResource, error) {
-	if value == "" {
-		return nil, nil
-	}
-
-	resources, err := genericresource.Parse(value)
-	if err != nil {
-		return nil, err
-	}
-
-	obj := convert.GenericResourcesFromGRPC(resources)
-
-	return obj, nil
 }


### PR DESCRIPTION
This problem was introduced in #33440

Moved `ParseGenericResources` to a more appropriate package.

See https://github.com/docker/cli/pull/424#pullrequestreview-59281521 for a full explanation of  the problem. Importing these packages from `opts` creates a huge dependency tree for no reason.

cc @simonferquel 