### PR TITLE
Remove command line flag install from registry package

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -10,10 +10,8 @@ import (
 
 	"github.com/docker/distribution/reference"
 	registrytypes "github.com/docker/docker/api/types/registry"
-	"github.com/docker/docker/opts"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/pflag"
 )
 
 // ServiceOptions holds command line options.
@@ -71,20 +69,6 @@ var (
 
 // for mocking in unit tests
 var lookupIP = net.LookupIP
-
-// InstallCliFlags adds command-line options to the top-level flag parser for
-// the current process.
-func (options *ServiceOptions) InstallCliFlags(flags *pflag.FlagSet) {
-	ana := opts.NewNamedListOptsRef("allow-nondistributable-artifacts", &options.AllowNondistributableArtifacts, ValidateIndexName)
-	mirrors := opts.NewNamedListOptsRef("registry-mirrors", &options.Mirrors, ValidateMirror)
-	insecureRegistries := opts.NewNamedListOptsRef("insecure-registries", &options.InsecureRegistries, ValidateIndexName)
-
-	flags.Var(ana, "allow-nondistributable-artifacts", "Allow push of nondistributable artifacts to registry")
-	flags.Var(mirrors, "registry-mirror", "Preferred Docker registry mirror")
-	flags.Var(insecureRegistries, "insecure-registry", "Enable insecure registry communication")
-
-	options.installCliPlatformFlags(flags)
-}
 
 // newServiceConfig returns a new instance of ServiceConfig
 func newServiceConfig(options ServiceOptions) *serviceConfig {

--- a/registry/config_unix.go
+++ b/registry/config_unix.go
@@ -2,10 +2,6 @@
 
 package registry
 
-import (
-	"github.com/spf13/pflag"
-)
-
 var (
 	// CertsDir is the directory where certificates are stored
 	CertsDir = "/etc/docker/certs.d"
@@ -17,9 +13,4 @@ var (
 // which contain those characters (such as : on Windows)
 func cleanPath(s string) string {
 	return s
-}
-
-// installCliPlatformFlags handles any platform specific flags for the service.
-func (options *ServiceOptions) installCliPlatformFlags(flags *pflag.FlagSet) {
-	flags.BoolVar(&options.V2Only, "disable-legacy-registry", true, "Disable contacting legacy registries")
 }

--- a/registry/config_windows.go
+++ b/registry/config_windows.go
@@ -4,8 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/spf13/pflag"
 )
 
 // CertsDir is the directory where certificates are stored
@@ -17,9 +15,4 @@ var CertsDir = os.Getenv("programdata") + `\docker\certs.d`
 // which contain those characters (such as : on Windows)
 func cleanPath(s string) string {
 	return filepath.FromSlash(strings.Replace(s, ":", "", -1))
-}
-
-// installCliPlatformFlags handles any platform specific flags for the service.
-func (options *ServiceOptions) installCliPlatformFlags(flags *pflag.FlagSet) {
-	// No Windows specific flags.
 }


### PR DESCRIPTION
Related to #34668 and https://github.com/docker/cli/pull/424#pullrequestreview-59281521

This is long overdue. The `registry/` package is a client and utils for working with a registry. It shouldn't be responsible for defining command line flags. Move the flags to the file where all the other daemon flags are added.

Moving this code allows us to reduce the dependencies required to use the registry client.