### PR TITLE
Use In-kernel File Copy for Overlayfs and VFS on Linux

### DIFF
--- a/daemon/graphdriver/copy/copy_test.go
+++ b/daemon/graphdriver/copy/copy_test.go
@@ -1,0 +1,67 @@
+// +build linux
+
+package copy
+
+import (
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/docker/pkg/parsers/kernel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsCopyFileRangeSyscallAvailable(t *testing.T) {
+	// Verifies:
+	// 1. That copyFileRangeEnabled is being set to true when copy_file_range syscall is available
+	// 2. That isCopyFileRangeSyscallAvailable() works on "new" kernels
+	v, err := kernel.GetKernelVersion()
+	require.NoError(t, err)
+
+	copyWithFileRange := true
+	copyWithFileClone := false
+	doCopyTest(t, &copyWithFileRange, &copyWithFileClone)
+
+	if kernel.CompareKernelVersion(*v, kernel.VersionInfo{Kernel: 4, Major: 5, Minor: 0}) < 0 {
+		assert.False(t, copyWithFileRange)
+	} else {
+		assert.True(t, copyWithFileRange)
+	}
+
+}
+
+func TestCopy(t *testing.T) {
+	copyWithFileRange := true
+	copyWithFileClone := true
+	doCopyTest(t, &copyWithFileRange, &copyWithFileClone)
+}
+
+func TestCopyWithoutRange(t *testing.T) {
+	copyWithFileRange := false
+	copyWithFileClone := false
+	doCopyTest(t, &copyWithFileRange, &copyWithFileClone)
+}
+
+func doCopyTest(t *testing.T, copyWithFileRange, copyWithFileClone *bool) {
+	dir, err := ioutil.TempDir("", "docker-copy-check")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	srcFilename := filepath.Join(dir, "srcFilename")
+	dstFilename := filepath.Join(dir, "dstilename")
+
+	r := rand.New(rand.NewSource(0))
+	buf := make([]byte, 1024)
+	_, err = r.Read(buf)
+	require.NoError(t, err)
+	require.NoError(t, ioutil.WriteFile(srcFilename, buf, 0777))
+	fileinfo, err := os.Stat(srcFilename)
+	require.NoError(t, err)
+
+	require.NoError(t, copyRegular(srcFilename, dstFilename, fileinfo, copyWithFileRange, copyWithFileClone))
+	readBuf, err := ioutil.ReadFile(dstFilename)
+	require.NoError(t, err)
+	assert.Equal(t, buf, readBuf)
+}

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 
 	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/daemon/graphdriver/copy"
 	"github.com/docker/docker/daemon/graphdriver/overlayutils"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/containerfs"
@@ -327,7 +328,7 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) (retErr
 		return err
 	}
 
-	return copyDir(parentUpperDir, upperDir, 0)
+	return copy.DirCopy(parentUpperDir, upperDir, copy.Content)
 }
 
 func (d *Driver) dir(id string) string {
@@ -443,7 +444,7 @@ func (d *Driver) ApplyDiff(id string, parent string, diff io.Reader) (size int64
 		}
 	}()
 
-	if err = copyDir(parentRootDir, tmpRootDir, copyHardlink); err != nil {
+	if err = copy.DirCopy(parentRootDir, tmpRootDir, copy.Hardlink); err != nil {
 		return 0, err
 	}
 


### PR DESCRIPTION
**- What I did**
Broke out the copy code from overlayfs into its own module, and added support for in-kernel copying of data, as opposed to having to pass all data back through userspace.

Eventually, I'd like to use this copy code in the VFS graphdriver code, but I'd like to work out any worries here before changing the VFS driver.

My end-game, over perhaps 5 different PRs is:
1) Use copy_file_range for copy code, and modularize it so it can be reused [This PR]
2) Switch VFS to use the shared copy code for Linux systems
3) Speed up copy code a bit by parallelizing metadata and copy operations
4) Switch to the quotactl API for project quotas for XFS and EXT4
5) Add project quota support to the VFS driver

Then, I can use XFS / EXT4 with the VFS driver, and be done with life. Not mucking with the VFS and mount stacking code every time a container spins up, or spins down would be great. I tested a slightly more optimized version of the copy that I posted in the PR, and it runs on the ubuntu container with modern reflinking XFS in < 600 ms on ubuntu:latest. For my test, I simply commented out the xattr and mtime-related code, which turns out to have a significant speed up. See step (3) -- we should be able to get similar performance benefits by performing listxattr in parallel. Otherwise, we're paying a 200-1000 microsecond cost for listxattr, which most of the time will be a no-op, while we could be spending that precious time doing real work.

I’d also like to use this as a bouncing-off step for per-container user namespaces.

**- How I did it**
It now checks the kernel version, and uses that to determine if it can use the `copy_file_range` (introduced in Kernel 4.5). If not, it falls back to what it did previously, and copies the data through Go. It limits each copy to a built-in kernel constant of MAX_RW_COUNT (http://elixir.free-electrons.com/linux/latest/source/include/linux/fs.h#L2138). This also prevents us from accidentally overflowing on 32-bit platforms since the constant is smaller than 2GB.

**- How to verify it**
There are already unit tests in the overlay that leverage the copy module. The copy module also has an associated test to ensure that the logic to verify that the copy is using copy_file_range on newer kernels, and it is not on older kernels. 

**- Description for the changelog**
Use in-kernel file copy helper for overlayfs layers on new Kernels
