### PR TITLE
ServiceConfig: log errors when loading config

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -82,9 +82,15 @@ func newServiceConfig(options ServiceOptions) *serviceConfig {
 		V2Only: options.V2Only,
 	}
 
-	config.LoadAllowNondistributableArtifacts(options.AllowNondistributableArtifacts)
-	config.LoadMirrors(options.Mirrors)
-	config.LoadInsecureRegistries(options.InsecureRegistries)
+	if err := config.LoadAllowNondistributableArtifacts(options.AllowNondistributableArtifacts); err != nil {
+		logrus.Warnf("error loading non-distributable artifacts: %v", err)
+	}
+	if err := config.LoadMirrors(options.Mirrors); err != nil {
+		logrus.Warnf("error loading mirrors: %v", err)
+	}
+	if err := config.LoadInsecureRegistries(options.InsecureRegistries); err != nil {
+		logrus.Warnf("error loading insecure registries: %v", err)
+	}
 
 	return config
 }


### PR DESCRIPTION
Log errors when the config is loaded to notify the user of any errors,
for instance, when a specified mirror has an invalid URL.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>

**- What I did / How I did it**

Catch and log errors when loading the config in `newServiceConfig()`.

**- How to verify it**

Start the daemon for instance with `--registry-mirrors "in@valid:url"`. The daemon starts successfully, but now we can see the following log: `level=warning msg="error loading mirrors: invalid mirror: \"in@valid:url\" is not a valid URI"`

**- Description for the changelog**

Log errors when the config is loaded.

