### PR TITLE
Fix `plugin set` missing field panic

### DIFF
--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -303,6 +303,7 @@ func (pm *Manager) save(p *v2.Plugin) error {
 	if err := ioutils.AtomicWriteFile(filepath.Join(pm.config.Root, p.GetID(), configFileName), pluginJSON, 0600); err != nil {
 		return errors.Wrap(err, "failed to write atomically plugin json")
 	}
+	pm.config.Store.plugins[p.GetID()] = p
 	return nil
 }
 

--- a/plugin/v2/plugin.go
+++ b/plugin/v2/plugin.go
@@ -131,7 +131,7 @@ next:
 		}
 
 		// range over all the mounts in the config
-		for _, mount := range p.PluginObj.Config.Mounts {
+		for i, mount := range p.PluginObj.Config.Mounts {
 			// found the mount in the config
 			if mount.Name == s.name {
 				// is it settable ?
@@ -142,13 +142,13 @@ next:
 				}
 
 				// it is, so lets update the settings in memory
-				*mount.Source = s.value
+				p.PluginObj.Settings.Mounts[i].Source = &s.value
 				continue next
 			}
 		}
 
 		// range over all the devices in the config
-		for _, device := range p.PluginObj.Config.Linux.Devices {
+		for i, device := range p.PluginObj.Config.Linux.Devices {
 			// found the device in the config
 			if device.Name == s.name {
 				// is it settable ?
@@ -159,7 +159,7 @@ next:
 				}
 
 				// it is, so lets update the settings in memory
-				*device.Path = s.value
+				p.PluginObj.Settings.Devices[i].Path = &s.value
 				continue next
 			}
 		}

--- a/plugin/v2/plugin_linux.go
+++ b/plugin/v2/plugin_linux.go
@@ -33,7 +33,7 @@ func (p *Plugin) InitSpec(execRoot string) (*specs.Spec, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	mounts := append(p.PluginObj.Config.Mounts, types.PluginMount{
+	mounts := append(p.PluginObj.Settings.Mounts, types.PluginMount{
 		Source:      &execRoot,
 		Destination: defaultPluginRuntimeDestination,
 		Type:        "bind",


### PR DESCRIPTION
**- What I did**

I fixed a bug in `plugin set` for mount sources and device paths that are not specified in the plugin config file.

**- How I did it**

I removed inappropriate and unchecked pointer dereferencing which mutated the plugin config values (rather than just the runtime plugin settings values) through aliasing. I replaced this with normal mutation of the settings values.

**- How to verify it**

I wrote a test that used to fail and now passes.

**- Description for the changelog**

Probably not changelog worthy. If you want to include it:

> Fixed a bug in `plugin set` for mount sources and device paths that are not specified in the plugin config file

**- A picture of a cute animal (not mandatory but encouraged)**

![African pygmy mouse](https://upload.wikimedia.org/wikipedia/commons/2/23/Mus_musculoides_hirse_fressend.jpg)

[*Mus minutoides*](https://en.wikipedia.org/wiki/African_pygmy_mouse), or the African pygmy mouse, is one of the smallest rodent species on Earth. Adults are between 30 and 80 mm (1.2 and 3.1 in) long, with a 20 to 40 mm (0.79 to 1.57 in) tail, and weigh from 3 to 12 g (0.11 to 0.42 oz). Its method of sex determination has also been found to differ from most mammals in that rearrangements of the X chromosome have led to many XY individuals actually being female.