### PR TITLE
Remove assertions that were testing CLI behaviour

### DIFF
--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -69,24 +69,13 @@ func (s *DockerSuite) TestRenameCheckNames(c *check.C) {
 	})
 }
 
+// TODO: move to unit test
 func (s *DockerSuite) TestRenameInvalidName(c *check.C) {
 	runSleepingContainer(c, "--name", "myname")
 
 	out, _, err := dockerCmdWithError("rename", "myname", "new:invalid")
 	c.Assert(err, checker.NotNil, check.Commentf("Renaming container to invalid name should have failed: %s", out))
 	c.Assert(out, checker.Contains, "Invalid container name", check.Commentf("%v", err))
-
-	out, _, err = dockerCmdWithError("rename", "myname")
-	c.Assert(err, checker.NotNil, check.Commentf("Renaming container to invalid name should have failed: %s", out))
-	c.Assert(out, checker.Contains, "requires exactly 2 argument(s).", check.Commentf("%v", err))
-
-	out, _, err = dockerCmdWithError("rename", "myname", "")
-	c.Assert(err, checker.NotNil, check.Commentf("Renaming container to invalid name should have failed: %s", out))
-	c.Assert(out, checker.Contains, "may be empty", check.Commentf("%v", err))
-
-	out, _, err = dockerCmdWithError("rename", "", "newname")
-	c.Assert(err, checker.NotNil, check.Commentf("Renaming container with empty name should have failed: %s", out))
-	c.Assert(out, checker.Contains, "may be empty", check.Commentf("%v", err))
 
 	out, _ = dockerCmd(c, "ps", "-a")
 	c.Assert(out, checker.Contains, "myname", check.Commentf("Output of docker ps should have included 'myname': %s", out))


### PR DESCRIPTION
Related to https://github.com/moby/moby/issues/34623#issuecomment-326378333

Remove assertions of cli output that are no long valid. These cases will be covered in the docker/cli repo.