### PR TITLE
pkg/term: use IoctlGetWinsize/IoctlSetWinsize from golang.org/x/sys/unix

### DIFF
--- a/pkg/term/winsize.go
+++ b/pkg/term/winsize.go
@@ -3,28 +3,18 @@
 package term
 
 import (
-	"unsafe"
-
 	"golang.org/x/sys/unix"
 )
 
 // GetWinsize returns the window size based on the specified file descriptor.
 func GetWinsize(fd uintptr) (*Winsize, error) {
-	ws := &Winsize{}
-	_, _, err := unix.Syscall(unix.SYS_IOCTL, fd, uintptr(unix.TIOCGWINSZ), uintptr(unsafe.Pointer(ws)))
-	// Skipp errno = 0
-	if err == 0 {
-		return ws, nil
-	}
+	uws, err := unix.IoctlGetWinsize(int(fd), unix.TIOCGWINSZ)
+	ws := &Winsize{Height: uws.Row, Width: uws.Col, x: uws.Xpixel, y: uws.Ypixel}
 	return ws, err
 }
 
 // SetWinsize tries to set the specified window size for the specified file descriptor.
 func SetWinsize(fd uintptr, ws *Winsize) error {
-	_, _, err := unix.Syscall(unix.SYS_IOCTL, fd, uintptr(unix.TIOCSWINSZ), uintptr(unsafe.Pointer(ws)))
-	// Skipp errno = 0
-	if err == 0 {
-		return nil
-	}
-	return err
+	uws := &unix.Winsize{Row: ws.Height, Col: ws.Width, Xpixel: ws.x, Ypixel: ws.y}
+	return unix.IoctlSetWinsize(int(fd), unix.TIOCSWINSZ, uws)
 }


### PR DESCRIPTION
Use unix.IoctlGetWinsize and unix.IoctlSetWinsize instead of manually
reimplementing them.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

