### PR TITLE
Allows VERSION to be overwritten by env variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ DOCKER_ENVS := \
 	-e NO_PROXY \
 	-e http_proxy \
 	-e https_proxy \
-	-e no_proxy
+	-e no_proxy \
+	-e VERSION
 # note: we _cannot_ add "-e DOCKER_BUILDTAGS" here because even if it's unset in the shell, that would shadow the "ENV DOCKER_BUILDTAGS" set in our Dockerfile, which is very important for our official builds
 
 # to allow `make BIND_DIR=. shell` or `make BIND_DIR= test`

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -67,7 +67,7 @@ DEFAULT_BUNDLES=(
 	tgz
 )
 
-VERSION=$(< ./VERSION)
+VERSION=${VERSION:-$(< ./VERSION)}
 ! BUILDTIME=$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
 if [ "$DOCKER_GITCOMMIT" ]; then
 	GITCOMMIT="$DOCKER_GITCOMMIT"


### PR DESCRIPTION

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
VERSION was hardcoded to be used as the `VERSION` file from the root
directory, this makes it so that you have the option to overwrite this.

**- How I did it**
```diff
+VERSION=${VERSION:-$(< ./VERSION)}
```

Also adding it to the Makefile as a passable environment variable

**- How to verify it**
Build a package using `docker-ce-packaging` verify the tail ends of the binaries match the version that you overwrote with.

or

From the root directory
`make VERSION=bleh-version dynbinary` produces `dockerd-bleh-version`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Allowed VERSION to be overwritten at build time

**- A picture of a cute animal (not mandatory but encouraged)**
![Bird with arms](http://i.imgur.com/5ZIyHIh.jpg)
