### PR TITLE
Make Project ID Quotas Safer

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -302,6 +302,11 @@ func (d *Driver) GetMetadata(id string) (map[string]string, error) {
 		"UpperDir":  path.Join(dir, "diff"),
 	}
 
+	projectID, err := d.quotaCtl.GetProjectID(dir)
+	if err == nil {
+		metadata["ProjectID"] = strconv.FormatInt(int64(projectID), 10)
+	}
+
 	lowerDirs, err := d.getLowerDirs(id)
 	if err != nil {
 		return nil, err

--- a/daemon/graphdriver/quota/projectquota.go
+++ b/daemon/graphdriver/quota/projectquota.go
@@ -58,7 +58,10 @@ import (
 	"path/filepath"
 	"unsafe"
 
+	"encoding/json"
 	"errors"
+
+	"math"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -66,6 +69,17 @@ import (
 
 // ErrQuotaNotSupported indicates if were found the FS didn't have projects quotas available
 var ErrQuotaNotSupported = errors.New("Filesystem does not support, or has not enabled quotas")
+
+// ErrQuotasExhausted indicates that all project IDs are used on the filesystem
+var ErrQuotasExhausted = errors.New("All project IDs have been exhausted")
+
+var errNotOurProjectID = errors.New("Project ID set, but not by Docker")
+
+const quotaXattr = "user.dockerprojectquota"
+
+// currently this is empty, but we can populate it with quota metadata
+type quotaStorage struct {
+}
 
 // Quota limit params - currently we only control blocks hard limit
 type Quota struct {
@@ -77,7 +91,6 @@ type Quota struct {
 type Control struct {
 	backingFsBlockDev string
 	nextProjectID     uint32
-	quotas            map[string]uint32
 }
 
 // NewControl - initialize project quota support.
@@ -137,14 +150,14 @@ func NewControl(basePath string) (*Control, error) {
 	quota := Quota{
 		Size: 0,
 	}
-	if err := setProjectQuota(backingFsBlockDev, minProjectID, quota); err != nil {
+	err = setProjectQuota(backingFsBlockDev, minProjectID, quota)
+	if err != nil {
 		return nil, err
 	}
 
 	q := Control{
 		backingFsBlockDev: backingFsBlockDev,
 		nextProjectID:     minProjectID + 1,
-		quotas:            make(map[string]uint32),
 	}
 
 	//
@@ -162,21 +175,43 @@ func NewControl(basePath string) (*Control, error) {
 // SetQuota - assign a unique project id to directory and set the quota limits
 // for that project id
 func (q *Control) SetQuota(targetPath string, quota Quota) error {
+	projectID, err := getProjectID(targetPath)
+	if err != nil {
+		return err
+	}
 
-	projectID, ok := q.quotas[targetPath]
-	if !ok {
-		projectID = q.nextProjectID
-
+	if projectID == 0 {
+		projectID, err = q.getNextProjectID()
+		if err != nil {
+			return err
+		}
 		//
 		// assign project id to new container directory
 		//
-		err := setProjectID(targetPath, projectID)
+		err = setProjectID(targetPath, projectID)
 		if err != nil {
 			return err
 		}
 
-		q.quotas[targetPath] = projectID
-		q.nextProjectID++
+		// Add requisite metadata to mark it as owned by Docker
+		buf, err := json.Marshal(quotaStorage{})
+		if err != nil {
+			return err
+		}
+		err = unix.Setxattr(targetPath, quotaXattr, buf, 0)
+		if err != nil {
+			return err
+		}
+
+		q.nextProjectID = projectID + 1
+	} else {
+		dockerSet, err := isDockerSetProjectID(targetPath)
+		if err != nil {
+			return err
+		}
+		if !dockerSet {
+			return errNotOurProjectID
+		}
 	}
 
 	//
@@ -184,6 +219,26 @@ func (q *Control) SetQuota(targetPath string, quota Quota) error {
 	//
 	logrus.Debugf("SetQuota(%s, %d): projectID=%d", targetPath, quota.Size, projectID)
 	return setProjectQuota(q.backingFsBlockDev, projectID, quota)
+}
+
+func (q *Control) getNextProjectID() (uint32, error) {
+	// Verify that this project ID has no limit set on it before using it
+	checkedProjectIDs := 0
+	projectIDToCheck := q.nextProjectID
+	// TODO: Have a mechanism by which to determine whether 32-bit project IDs are safe
+	for checkedProjectIDs < math.MaxUint16 {
+		lim, err := getLimit(projectIDToCheck, q.backingFsBlockDev)
+		// Alternatively, if there is no current files owned by this project ID, let's recycle it
+		if err == unix.ESRCH || err == unix.ENOENT || lim.dIcount == 0 {
+			return projectIDToCheck, nil
+		}
+		if err != nil {
+			return 0, err
+		}
+		projectIDToCheck = (projectIDToCheck + 1) % math.MaxUint16
+		checkedProjectIDs++
+	}
+	return 0, ErrQuotasExhausted
 }
 
 // setProjectQuota - set the quota for project id on xfs block device
@@ -213,30 +268,65 @@ func setProjectQuota(backingFsBlockDev string, projectID uint32, quota Quota) er
 
 // GetQuota - get the quota limits of a directory that was configured with SetQuota
 func (q *Control) GetQuota(targetPath string, quota *Quota) error {
-
-	projectID, ok := q.quotas[targetPath]
-	if !ok {
+	projectID, err := getProjectID(targetPath)
+	if err != nil {
+		return err
+	}
+	if projectID == 0 {
 		return fmt.Errorf("quota not found for path : %s", targetPath)
 	}
 
+	dockerSet, err := isDockerSetProjectID(targetPath)
+	if err != nil {
+		return err
+	}
+	if !dockerSet {
+		return errNotOurProjectID
+	}
+
+	lim, err := getLimit(projectID, q.backingFsBlockDev)
+	quota.Size = lim.dBlkHardlimit * 512
+	if err != nil {
+		return fmt.Errorf("Failed to get quota limit for projid %d on %s: %v",
+			projectID, q.backingFsBlockDev, err.Error())
+	}
+
+	return nil
+}
+
+type limit struct {
+	dBlkHardlimit uint64 // absolute limit on disk blks
+	dBlkSoftlimit uint64 // preferred limit on disk blks
+	dInoHardlimit uint64 // maximum # allocated inodes
+	dInoSoftlimit uint64 // preferred inode limit
+	dBcount       uint64 // # disk blocks owned by the user
+	dIcount       uint64 // # inodes owned by the user
+}
+
+func getLimit(projectID uint32, backingFsBlockDev string) (limit, error) {
 	//
 	// get the quota limit for the container's project id
 	//
 	var d C.fs_disk_quota_t
 
-	var cs = C.CString(q.backingFsBlockDev)
+	var cs = C.CString(backingFsBlockDev)
 	defer C.free(unsafe.Pointer(cs))
 
 	_, _, errno := unix.Syscall6(unix.SYS_QUOTACTL, C.Q_XGETPQUOTA,
 		uintptr(unsafe.Pointer(cs)), uintptr(C.__u32(projectID)),
 		uintptr(unsafe.Pointer(&d)), 0, 0)
 	if errno != 0 {
-		return fmt.Errorf("Failed to get quota limit for projid %d on %s: %v",
-			projectID, q.backingFsBlockDev, errno.Error())
+		return limit{}, errno
 	}
-	quota.Size = uint64(d.d_blk_hardlimit) * 512
-
-	return nil
+	lim := limit{
+		dBlkHardlimit: uint64(d.d_blk_hardlimit),
+		dBlkSoftlimit: uint64(d.d_blk_softlimit),
+		dInoHardlimit: uint64(d.d_ino_hardlimit),
+		dInoSoftlimit: uint64(d.d_ino_softlimit),
+		dBcount:       uint64(d.d_bcount),
+		dIcount:       uint64(d.d_icount),
+	}
+	return lim, nil
 }
 
 // getProjectID - get the project id of path on xfs
@@ -257,6 +347,18 @@ func getProjectID(targetPath string) (uint32, error) {
 	return uint32(fsx.fsx_projid), nil
 }
 
+func isDockerSetProjectID(targetPath string) (bool, error) {
+	buf := make([]byte, 4096)
+	_, err := unix.Getxattr(targetPath, quotaXattr, buf)
+	if err == unix.ENODATA {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // setProjectID - set the project id of path on xfs
 func setProjectID(targetPath string, projectID uint32) error {
 	dir, err := openDir(targetPath)
@@ -271,6 +373,17 @@ func setProjectID(targetPath string, projectID uint32) error {
 	if errno != 0 {
 		return fmt.Errorf("Failed to get projid for %s: %v", targetPath, errno.Error())
 	}
+
+	if fsx.fsx_projid != 0 {
+		dockerSet, err := isDockerSetProjectID(targetPath)
+		if err != nil {
+			return err
+		}
+		if !dockerSet {
+			return errNotOurProjectID
+		}
+	}
+
 	fsx.fsx_projid = C.__u32(projectID)
 	fsx.fsx_xflags |= C.FS_XFLAG_PROJINHERIT
 	_, _, errno = unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.FS_IOC_FSSETXATTR,
@@ -297,9 +410,6 @@ func (q *Control) findNextProjectID(home string) error {
 		projid, err := getProjectID(path)
 		if err != nil {
 			return err
-		}
-		if projid > 0 {
-			q.quotas[path] = projid
 		}
 		if q.nextProjectID <= projid {
 			q.nextProjectID = projid + 1
@@ -364,8 +474,8 @@ func hasQuotaSupport(backingFsBlockDev string) (bool, error) {
 	}
 
 	switch errno {
+	// For this class of errors, return them directly to the user
 	case unix.EFAULT:
-	case unix.EINVAL:
 	case unix.ENOENT:
 	case unix.ENOTBLK:
 	case unix.EPERM:

--- a/daemon/graphdriver/quota/projectquota.go
+++ b/daemon/graphdriver/quota/projectquota.go
@@ -294,6 +294,27 @@ func (q *Control) GetQuota(targetPath string, quota *Quota) error {
 	return nil
 }
 
+// GetProjectID - Get the project ID for a given path
+func (q *Control) GetProjectID(targetPath string) (uint32, error) {
+	projectID, err := getProjectID(targetPath)
+	if err != nil {
+		return 0, err
+	}
+	if projectID == 0 {
+		return 0, fmt.Errorf("quota not found for path : %s", targetPath)
+	}
+
+	dockerSet, err := isDockerSetProjectID(targetPath)
+	if err != nil {
+		return 0, err
+	}
+	if !dockerSet {
+		return 0, errNotOurProjectID
+	}
+
+	return projectID, nil
+}
+
 type limit struct {
 	dBlkHardlimit uint64 // absolute limit on disk blks
 	dBlkSoftlimit uint64 // preferred limit on disk blks

--- a/daemon/graphdriver/quota/projectquota_test.go
+++ b/daemon/graphdriver/quota/projectquota_test.go
@@ -1,0 +1,87 @@
+// +build linux
+
+package quota
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 10MB
+const testQuotaSize = 10 * 1024 * 1024
+
+func TestQuota(t *testing.T) {
+	var err error
+	homeDir, err := ioutil.TempDir("", "docker-copy-check")
+	require.NoError(t, err)
+	defer os.RemoveAll(homeDir)
+
+	backingFsDev, err := makeBackingFsDev(homeDir)
+	require.NoError(t, err)
+
+	hasSupport, err := hasQuotaSupport(backingFsDev)
+	require.NoError(t, err)
+
+	if !hasSupport {
+		// Do some minimal tests here, but point out to the user
+		// that we weren't able to test fully (skip)
+		ctrl, err := NewControl(homeDir)
+		require.Nil(t, ctrl)
+		require.EqualError(t, err, ErrQuotaNotSupported.Error())
+		t.Skip("Quota not supported")
+	}
+
+	t.Run("testSmallerThanQuota", wrapTest(homeDir, testSmallerThanQuota))
+	t.Run("testBiggerThanQuota", wrapTest(homeDir, testBiggerThanQuota))
+	t.Run("testRetrieveQuota", wrapTest(homeDir, testRetrieveQuota))
+}
+
+func wrapTest(homeDir string, testFunc func(t *testing.T, ctrl *Control, homeDir, testDir, testSubDir string)) func(*testing.T) {
+	return func(t *testing.T) {
+		var err error
+		testDir, err := ioutil.TempDir(homeDir, "per-test")
+		defer os.RemoveAll(testDir)
+		require.NoError(t, err)
+		ctrl, err := NewControl(testDir)
+		require.NoError(t, err)
+		testSubDir, err := ioutil.TempDir(testDir, "quota-test")
+		require.NoError(t, err)
+		testFunc(t, ctrl, homeDir, testDir, testSubDir)
+	}
+}
+
+func testSmallerThanQuota(t *testing.T, ctrl *Control, homeDir, testDir, testSubDir string) {
+	require.NoError(t, ctrl.SetQuota(testSubDir, Quota{testQuotaSize}))
+	smallerThanQuotaFile := filepath.Join(testSubDir, "smaller-than-quota")
+	require.NoError(t, ioutil.WriteFile(smallerThanQuotaFile, make([]byte, testQuotaSize/2), 0644))
+	require.NoError(t, os.Remove(smallerThanQuotaFile))
+}
+
+func testBiggerThanQuota(t *testing.T, ctrl *Control, homeDir, testDir, testSubDir string) {
+	// Make sure the quota is being enforced
+	// TODO: When we implement this under EXT4, we need to shed CAP_SYS_RESOURCE, otherwise
+	// we're able to violate quota without issue
+	require.NoError(t, ctrl.SetQuota(testSubDir, Quota{testQuotaSize}))
+
+	biggerThanQuotaFile := filepath.Join(testSubDir, "bigger-than-quota")
+	err := ioutil.WriteFile(biggerThanQuotaFile, make([]byte, testQuotaSize+1), 0644)
+	require.Error(t, err)
+	if err == io.ErrShortWrite {
+		require.NoError(t, os.Remove(biggerThanQuotaFile))
+	}
+}
+
+func testRetrieveQuota(t *testing.T, ctrl *Control, homeDir, testDir, testSubDir string) {
+	// Validate that we can retrieve quota
+	require.NoError(t, ctrl.SetQuota(testSubDir, Quota{testQuotaSize}))
+
+	var q Quota
+	require.NoError(t, ctrl.GetQuota(testSubDir, &q))
+	assert.EqualValues(t, testQuotaSize, q.Size)
+}


### PR DESCRIPTION
**- What I did**
I made project ID quotas stateless. This changeset allows us to work safely inside an isolated project ID quota range, without risk of colliding with another system. Previously, it required the user to set the base number of their quota space. We now detect whether a given project ID is in use or not.

**- How I did it**
I added a mechanism that probes whether there are inodes in use for an existing project ID.

**- How to verify it**
I added unit tests to the code. Currently there does not exist a specific test ensuring reuse, but that's hard to do in a non-isolated environment. A simple way to verify is by using quotactl tools to see if new project IDs are being allocated.

**- Description for the changelog**
Ensure that Project ID-based quotas do not collide with others on the system.