### PR TITLE
Returned type conversion of Rdev to uint64.

### DIFF
--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -50,8 +50,8 @@ func setHeaderForSpecialDevice(hdr *tar.Header, name string, stat interface{}) (
 		// Currently go does not fill in the major/minors
 		if s.Mode&unix.S_IFBLK != 0 ||
 			s.Mode&unix.S_IFCHR != 0 {
-			hdr.Devmajor = int64(major(s.Rdev))
-			hdr.Devminor = int64(minor(s.Rdev))
+			hdr.Devmajor = int64(major(uint64(s.Rdev)))
+			hdr.Devminor = int64(minor(uint64(s.Rdev)))
 		}
 	}
 


### PR DESCRIPTION
Closes #34726

Signed-off-by: Andrew Nee <ndrewnee@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed bug when building of package `pkg/archive` is failed on MacOS

**- How I did it**

Added type conversion of `s.Rdev` to `uint64`. Function `setHeaderForSpecialDevice` in file `pkg/archive/archive_unix.go`

**- How to verify it**

Run `go build` in package `pkg/archive` on MacOS. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed bug when building of package `pkg/archive` is failed on MacOS

**- A picture of a cute animal (not mandatory but encouraged)**

