### PR TITLE
Events CLI tests: fix flakyness of TestEventsOOMDisableTrue

### DIFF
--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -97,7 +97,7 @@ func (s *DockerSuite) TestEventsOOMDisableTrue(c *check.C) {
 	}()
 
 	c.Assert(waitRun("oomTrue"), checker.IsNil)
-	defer dockerCmd(c, "kill", "oomTrue")
+	defer dockerCmdWithResult("kill", "oomTrue")
 	containerID := inspectField(c, "oomTrue", "Id")
 
 	testActions := map[string]chan bool{


### PR DESCRIPTION
**- What I did**
I changed the cleanup code of TestEventsOOMDisableTrue, so that if the container is already removed by the time the defer call is triggered, it does not fail the test
**- How I did it**
I used `dockerCmdWithResult` (which let client code choose what to do with the potential command line error) instead of `dockerCmd` (which fails the test if the command line does not succeed)
**- How to verify it**
Run the CI :)

