### PR TITLE
daemon: relabel config files.

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -307,6 +307,8 @@ func (daemon *Daemon) setupConfigDir(c *container.Container) (setupErr error) {
 		if err := os.Chown(fPath, rootIDs.UID+uid, rootIDs.GID+gid); err != nil {
 			return errors.Wrap(err, "error setting ownership for config")
 		}
+
+		label.Relabel(fPath, c.MountLabel, false)
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Similar to #32529, without relabel these files, SELinux-enabled containers will show
"permission denied" errors for configuration files mounted with
`docker service create ... --config ... ...`.

**- How I did it**

Relabel the config files when they are created.

They may be relabelled just before they mounted, but I follow the same logic as #32529 did.
I may also relabel the directory when config directory gets setup, however only config files in the directory are mounted to the containers, thus relabelling the directory is not necessary. Moreover, other files may (?) add to the config directory in the future. So that's why I choose this implementation.

**- How to verify it**

I compiled CentOS 7 version of rpm for `docker-17.07.1-ce`, and installed on my server.
The "permission denied" issue is gone, and no more AVC in `audit.log`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Relabel config files.

<!--
**- A picture of a cute animal (not mandatory but encouraged)**
-->

Signed-off-by: Wenxuan Zhao <viz@linux.com>
