### PR TITLE
should use bytes.Equal() instead of bytes.Compare()

### DIFF
--- a/daemon/graphdriver/graphtest/testutil.go
+++ b/daemon/graphdriver/graphtest/testutil.go
@@ -61,7 +61,7 @@ func checkFile(drv graphdriver.Driver, layer, filename string, content []byte) e
 		return err
 	}
 
-	if bytes.Compare(fileContent, content) != 0 {
+	if !bytes.Equal(fileContent, content) {
 		return fmt.Errorf("mismatched file content %v, expecting %v", fileContent, content)
 	}
 
@@ -211,7 +211,7 @@ func checkManyFiles(drv graphdriver.Driver, layer string, count int, seed int64)
 
 			content := randomContent(64, seed+int64(i+j))
 
-			if bytes.Compare(fileContent, content) != 0 {
+			if !bytes.Equal(fileContent, content) {
 				return fmt.Errorf("mismatched file content %v, expecting %v", fileContent, content)
 			}
 		}
@@ -300,7 +300,7 @@ func checkManyLayers(drv graphdriver.Driver, layer string, count int) error {
 		return err
 	}
 
-	if bytes.Compare(layerIDBytes, []byte(layer)) != 0 {
+	if !bytes.Equal(layerIDBytes, []byte(layer)) {
 		return fmt.Errorf("mismatched file content %v, expecting %v", layerIDBytes, []byte(layer))
 	}
 
@@ -311,7 +311,7 @@ func checkManyLayers(drv graphdriver.Driver, layer string, count int) error {
 		if err != nil {
 			return err
 		}
-		if bytes.Compare(thisLayerIDBytes, layerIDBytes) != 0 {
+		if !bytes.Equal(thisLayerIDBytes, layerIDBytes) {
 			return fmt.Errorf("mismatched file content %v, expecting %v", thisLayerIDBytes, layerIDBytes)
 		}
 		layerIDBytes, err = ioutil.ReadFile(path.Join(layerDir, "parent-id"))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
should use bytes.Equal() instead of bytes.Compare()
**- How I did it**
should use bytes.Equal() instead of bytes.Compare()
**- How to verify it**
NONE
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

