### PR TITLE
should use time.Since instead of time.Now().Sub

### DIFF
--- a/hack/integration-cli-on-swarm/agent/worker/worker.go
+++ b/hack/integration-cli-on-swarm/agent/worker/worker.go
@@ -58,7 +58,7 @@ func handle(workerImageDigest string, executor testChunkExecutor) error {
 				RawLog:  rawLog,
 			}
 		}
-		elapsed := time.Now().Sub(begin)
+		elapsed := time.Since(begin)
 		log.Printf("Finished chunk %d, code=%d, elapsed=%v", args.ChunkID, code, elapsed)
 		return types.Result{
 			ChunkID: args.ChunkID,


### PR DESCRIPTION
should use time.Since instead of time.Now().Sub

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
should use time.Since instead of time.Now().Sub
**- How I did it**
should use time.Since instead of time.Now().Sub
**- How to verify it**
NONE
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

