### PR TITLE
Re-enable some conversion for darwin-amd64 platform

### DIFF
--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -50,8 +50,8 @@ func setHeaderForSpecialDevice(hdr *tar.Header, name string, stat interface{}) (
 		// Currently go does not fill in the major/minors
 		if s.Mode&unix.S_IFBLK != 0 ||
 			s.Mode&unix.S_IFCHR != 0 {
-			hdr.Devmajor = int64(major(s.Rdev))
-			hdr.Devminor = int64(minor(s.Rdev))
+			hdr.Devmajor = int64(major(uint64(s.Rdev))) // nolint: unconvert
+			hdr.Devminor = int64(minor(uint64(s.Rdev))) // nolint: unconvert
 		}
 	}
 


### PR DESCRIPTION
With introduction of the convert linter, some convertion that are mandatory for some platforms supported by the cli (but not the daemon) have been erronously removed. Especially, on darwin-amd64, stat_t.Rdev is an int32 and cannot be converted implicitly to uint64.
**- What I did**
Re-enabled convertion for this case
**- How I did it**
Very simple code change
**- How to verify it**
Vendor this PR in the CLI project and cross compile
