### PR TITLE
LCOW: VHDX boot to readonly.

### DIFF
--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -343,7 +343,7 @@ func (clnt *client) createLinux(containerID string, checkpoint string, checkpoin
 		configuration.HvRuntime = &hcsshim.HvRuntime{
 			ImagePath:          lcowOpt.Config.Vhdx,
 			BootSource:         "Vhd",
-			WritableBootSource: true,
+			WritableBootSource: false,
 		}
 	} else {
 		configuration.HvRuntime = &hcsshim.HvRuntime{

--- a/vendor.conf
+++ b/vendor.conf
@@ -8,7 +8,7 @@ github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git
 github.com/gorilla/context v1.1
 github.com/gorilla/mux v1.1
-github.com/Microsoft/opengcs v0.3.2
+github.com/Microsoft/opengcs v0.3.3
 github.com/kr/pty 5cf931ef8f
 github.com/mattn/go-shellwords v1.0.3
 github.com/sirupsen/logrus v1.0.1

--- a/vendor/github.com/Microsoft/opengcs/client/config.go
+++ b/vendor/github.com/Microsoft/opengcs/client/config.go
@@ -93,10 +93,10 @@ func ParseOptions(options []string) (Options, error) {
 			case "lcow.timeout":
 				var err error
 				if rOpts.TimeoutSeconds, err = strconv.Atoi(opt[1]); err != nil {
-					return rOpts, fmt.Errorf("opengcstimeoutsecs option could not be interpreted as an integer")
+					return rOpts, fmt.Errorf("lcow.timeout option could not be interpreted as an integer")
 				}
 				if rOpts.TimeoutSeconds < 0 {
-					return rOpts, fmt.Errorf("opengcstimeoutsecs option cannot be negative")
+					return rOpts, fmt.Errorf("lcow.timeout option cannot be negative")
 				}
 			}
 		}
@@ -242,7 +242,7 @@ func (config *Config) StartUtilityVM() error {
 		configuration.HvRuntime = &hcsshim.HvRuntime{
 			ImagePath:          config.Vhdx,
 			BootSource:         "Vhd",
-			WritableBootSource: true,
+			WritableBootSource: false,
 		}
 	} else {
 		configuration.HvRuntime = &hcsshim.HvRuntime{


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes internal VSO bug 12969254. Makes the VHDX boot read-only to avoid file sharing violation running 2nd container.  @beweedon, @jstarks @patricklang  FYI.

@johnstep PTAL.