### PR TITLE
Fix TestRunEnvironment

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -824,7 +824,7 @@ func (s *DockerSuite) TestRunEnvironment(c *check.C) {
 	})
 	result.Assert(c, icmd.Success)
 
-	actualEnv := strings.Split(strings.TrimSpace(result.Combined()), "\n")
+	actualEnv := strings.Split(strings.TrimSuffix(result.Stdout(), "\n"), "\n")
 	sort.Strings(actualEnv)
 
 	goodEnv := []string{


### PR DESCRIPTION
If the empty variable happens to be sorted to the end of the list then TrimSpace()
would remove it. Instead only strip the single trailing newline.

```
FAIL: docker_cli_run_test.go:814: DockerSuite.TestRunEnvironment

docker_cli_run_test.go:844:
    c.Fatalf("Wrong environment: should be %d variables, not %d: %q", len(goodEnv), len(actualEnv), strings.Join(actualEnv, ", "))
... Error: Wrong environment: should be 8 variables, not 7: "FALSE=true, HOME=/root, HOSTNAME=testing, PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin, TRICKY=tri, TRUE=false, cky"
```