### PR TITLE
should use bytes.Equal() instead of bytes.Compare()

### DIFF
--- a/image/fs_test.go
+++ b/image/fs_test.go
@@ -112,7 +112,7 @@ func TestFSMetadataGetSet(t *testing.T) {
 		actual, err := store.GetMetadata(tc.id, tc.key)
 		assert.NoError(t, err)
 
-		if bytes.Compare(actual, tc.value) != 0 {
+		if !bytes.Equal(actual, tc.value) {
 			t.Fatalf("Metadata expected %q, got %q", tc.value, actual)
 		}
 	}
@@ -183,7 +183,7 @@ func TestFSGetSet(t *testing.T) {
 	for _, tc := range tcases {
 		data, err := store.Get(tc.expected)
 		assert.NoError(t, err)
-		if bytes.Compare(data, tc.input) != 0 {
+		if !bytes.Equal(data, tc.input) {
 			t.Fatalf("expected data %q, got %q", tc.input, data)
 		}
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
use bytes.Equal() instead of bytes.Compare()
**- How I did it**
NONE
**- How to verify it**
NONE
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

