### PR TITLE
DO NOT MERGE YET: Return a typed error when container not found in libcontainerd

### DIFF
--- a/libcontainerd/client.go
+++ b/libcontainerd/client.go
@@ -7,6 +7,16 @@ import (
 	"github.com/docker/docker/pkg/locker"
 )
 
+type containerNotFoundError struct {
+	containerID string
+}
+
+func (e containerNotFoundError) Error() string {
+	return fmt.Sprintf("invalid container: %s", e.containerID)
+}
+
+func (containerNotFoundError) NotFound() {}
+
 // clientCommon contains the platform agnostic fields used in the client structure
 type clientCommon struct {
 	backend    Backend
@@ -40,7 +50,9 @@ func (clnt *client) getContainer(containerID string) (*container, error) {
 	container, ok := clnt.containers[containerID]
 	defer clnt.mapMutex.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("invalid container: %s", containerID) // fixme: typed error
+		return nil, &containerNotFoundError{
+			containerID: containerID,
+		}
 	}
 	return container, nil
 }

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -537,6 +537,8 @@ func (clnt *client) Signal(containerID string, sig int) error {
 		err  error
 	)
 
+	time.Sleep(time.Second * 30)
+
 	// Get the container as we need it to get the container handle.
 	clnt.lock(containerID)
 	defer clnt.unlock(containerID)
@@ -620,6 +622,8 @@ func (clnt *client) Resize(containerID, processFriendlyName string, width, heigh
 func (clnt *client) Pause(containerID string) error {
 	unlockContainer := true
 	// Get the libcontainerd container object
+	time.Sleep(time.Second * 30)
+
 	clnt.lock(containerID)
 	defer func() {
 		if unlockContainer {


### PR DESCRIPTION
Signed-off-by: Darren Stahl <darst@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This is an attempt to fix the CI errors about invalid container in windowsRS1. I am not able to repro this locally in the same way it is being seen in CI, but I know that the cause is that a shutting down container removes itself from the map stored in libcontainerd. This causes it to become out of sync with the daemon container store

**- How I did it**

Return a typed error when container not found in libcontainerd. I can't tell where all this error is handled in the daemon and if it is correctly wrapped. If not, there will be more work here to follow it through.

**- How to verify it**

I'll be running windowsRS1 CI against this change multiple times, as it seems like the machines are in a state where the repro very often.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A

