### PR TITLE
Fix variable shadowing causing LayersSize to be reported as 0

### DIFF
--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -99,7 +99,6 @@ func (daemon *Daemon) SystemDiskUsage(ctx context.Context) (*types.DiskUsage, er
 	for platform := range daemon.stores {
 		layerRefs := daemon.getLayerRefs(platform)
 		allLayers := daemon.stores[platform].layerStore.Map()
-		var allLayersSize int64
 		for _, l := range allLayers {
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
**- What I did**

Fix variable shadowing causing LayersSize to be reported as 0 in `/system/df` (`docker system df`) calls.

**- How I did it**

This is a simple one-line fix removing duplicated declaration of `allLayersSize`.

**- Description for the changelog**
Fix layers size reported as 0 in `docker system df`.


