### PR TITLE
LCOW: Spot fix for multi-os image pulling

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -709,11 +709,16 @@ func (p *v2Puller) pullManifestList(ctx context.Context, ref reference.Named, mf
 
 	logrus.Debugf("%s resolved to a manifestList object with %d entries; looking for a os/arch match", ref, len(mfstList.Manifests))
 	var manifestDigest digest.Digest
+	// TODO @jhowardmsft LCOW Support: Need to remove the hard coding in LCOW mode.
+	lookingForOS := runtime.GOOS
+	if system.LCOWSupported() {
+		lookingForOS = "linux"
+	}
 	for _, manifestDescriptor := range mfstList.Manifests {
 		// TODO(aaronl): The manifest list spec supports optional
 		// "features" and "variant" fields. These are not yet used.
 		// Once they are, their values should be interpreted here.
-		if manifestDescriptor.Platform.Architecture == runtime.GOARCH && manifestDescriptor.Platform.OS == runtime.GOOS {
+		if manifestDescriptor.Platform.Architecture == runtime.GOARCH && manifestDescriptor.Platform.OS == lookingForOS {
 			manifestDigest = manifestDescriptor.Digest
 			logrus.Debugf("found match for %s/%s with media type %s, digest %s", runtime.GOOS, runtime.GOARCH, manifestDescriptor.MediaType, manifestDigest.String())
 			break

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -211,7 +212,12 @@ func (s *DockerHubPullSuite) TestPullAllTagsFromCentralRegistry(c *check.C) {
 			break
 		}
 	}
-	c.Assert(latestLine, checker.Not(checker.Equals), "", check.Commentf("no entry for busybox:latest found after pulling all tags"))
+
+	if runtime.GOARCH == "amd64" {
+		c.Assert(latestLine, checker.Not(checker.Equals), "", check.Commentf("no entry for busybox:latest found after pulling all tags"))
+	} else {
+		c.Assert(latestLine, checker.Not(checker.Contains), "", check.Commentf("no matching manifest"))
+	}
 	splitLatest := strings.Fields(latestLine)
 	splitCurrent := strings.Fields(splitOutImageCmd[1])
 
@@ -273,7 +279,7 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestPullNoCredentialsNotFound(c *check
 func (s *DockerSuite) TestPullLinuxImageFailsOnWindows(c *check.C) {
 	testRequires(c, DaemonIsWindows, Network)
 	_, _, err := dockerCmdWithError("pull", "ubuntu")
-	c.Assert(err.Error(), checker.Contains, "cannot be used on this platform")
+	c.Assert(err.Error(), checker.Contains, "no matching manifest")
 }
 
 // Regression test for https://github.com/docker/docker/issues/28892


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@johnstep @tianon @friism As per slack discussion, quick spot fix for multi-arch images pulling in LCOW. Verified busybox and Ubuntu pull just fine with the multi-arch manifests now - eg

```
PS C:\lcow2> docker pull ubuntu
Using default tag: latest
latest: Pulling from library/ubuntu
d5c6f90da05d: Pull complete
1300883d87d5: Pull complete
c220aa3cfc1b: Pull complete
2e9398f099dc: Pull complete
dc27a084064f: Pull complete
Digest: sha256:9c24600e5c4b09a51c933e1a1bd4748c2e4a639787421132db8f42fb3448d66b
Status: Downloaded newer image for ubuntu:latest
PS C:\lcow2>
```