### PR TITLE
[integration-cli] Only attempt to find pid with local daemon

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -79,6 +79,9 @@ type DockerSuite struct {
 }
 
 func (s *DockerSuite) OnTimeout(c *check.C) {
+	if !testEnv.IsLocalDaemon() {
+		return
+	}
 	path := filepath.Join(os.Getenv("DEST"), "docker.pid")
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -91,7 +94,7 @@ func (s *DockerSuite) OnTimeout(c *check.C) {
 	}
 
 	daemonPid := int(rawPid)
-	if daemonPid > 0 && testEnv.IsLocalDaemon() {
+	if daemonPid > 0 {
 		daemon.SignalDaemonDump(daemonPid)
 	}
 }


### PR DESCRIPTION
Follow up fix from #34656

I noticed there was an error in a jenkins log on a timeout, and it's because this shouldn't look for a pid file if the daemon is remote.