### PR TITLE
Fix fetching LVM2 sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN apt-get update && apt-get install -y \
 	&& pip install awscli==1.10.15
 
 # Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.173
+ENV LVM2_VERSION 2.02.168
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -55,7 +55,7 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends
 
 # Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.173
+ENV LVM2_VERSION 2.02.168
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install -y \
 	&& pip install awscli==1.10.15
 
 # Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.173
+ENV LVM2_VERSION 2.02.168
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends
 
 # Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.173
+ENV LVM2_VERSION 2.02.168
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -65,7 +65,7 @@ RUN set -x \
 	&& rm -rf "$SECCOMP_PATH"
 
 # Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.173
+ENV LVM2_VERSION 2.02.168
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1


### PR DESCRIPTION
Version 2.02.173 has disappeared, meaning moby build is failing:



Let's revert back to latest stable one for the time being.
A proper fix would be to merge https://github.com/moby/moby/pull/34550

Original bug report: https://github.com/moby/moby/issues/34843