### PR TITLE
LCOW: Add UVM debugability by grabbing logs before tear-down

### DIFF
--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -440,9 +440,7 @@ func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendly
 		return -1, err
 	}
 
-	defer func() {
-		container.debugGCS()
-	}()
+	defer container.debugGCS()
 
 	// Note we always tell HCS to
 	// create stdout as it's required regardless of '-i' or '-t' options, so that

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -439,6 +439,11 @@ func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendly
 	if err != nil {
 		return -1, err
 	}
+
+	defer func() {
+		container.debugGCS()
+	}()
+
 	// Note we always tell HCS to
 	// create stdout as it's required regardless of '-i' or '-t' options, so that
 	// docker can always grab the output through logs. We also tell HCS to always

--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -59,9 +59,7 @@ func (ctr *container) start(attachStdio StdioCallback) error {
 		return err
 	}
 
-	defer func() {
-		ctr.debugGCS()
-	}()
+	defer ctr.debugGCS()
 
 	// Note we always tell HCS to
 	// create stdout as it's required regardless of '-i' or '-t' options, so that

--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -50,6 +50,7 @@ func (ctr *container) start(attachStdio StdioCallback) error {
 	logrus.Debugln("libcontainerd: starting container ", ctr.containerID)
 	if err = ctr.hcsContainer.Start(); err != nil {
 		logrus.Errorf("libcontainerd: failed to start container: %s", err)
+		ctr.debugGCS() // Before terminating!
 		if err := ctr.terminate(); err != nil {
 			logrus.Errorf("libcontainerd: failed to cleanup after a failed Start. %s", err)
 		} else {
@@ -57,6 +58,10 @@ func (ctr *container) start(attachStdio StdioCallback) error {
 		}
 		return err
 	}
+
+	defer func() {
+		ctr.debugGCS()
+	}()
 
 	// Note we always tell HCS to
 	// create stdout as it's required regardless of '-i' or '-t' options, so that

--- a/libcontainerd/utils_windows.go
+++ b/libcontainerd/utils_windows.go
@@ -1,6 +1,10 @@
 package libcontainerd
 
-import "strings"
+import (
+	"strings"
+
+	opengcs "github.com/Microsoft/opengcs/client"
+)
 
 // setupEnvironmentVariables converts a string array of environment variables
 // into a map as required by the HCS. Source array is in format [v1=k1] [v2=k2] etc.
@@ -18,4 +22,17 @@ func setupEnvironmentVariables(a []string) map[string]string {
 // Apply for the LCOW option is a no-op.
 func (s *LCOWOption) Apply(interface{}) error {
 	return nil
+}
+
+// DebugGCS is a dirty hack for debugging for Linux Utility VMs. It simply
+// runs a bunch of commands inside the UVM, but seriously aides in advanced debugging.
+func (c *container) debugGCS() {
+	if c == nil || c.isWindows || c.hcsContainer == nil {
+		return
+	}
+	cfg := opengcs.Config{
+		Uvm:               c.hcsContainer,
+		UvmTimeoutSeconds: 600,
+	}
+	cfg.DebugGCS()
 }

--- a/libcontainerd/utils_windows.go
+++ b/libcontainerd/utils_windows.go
@@ -24,7 +24,7 @@ func (s *LCOWOption) Apply(interface{}) error {
 	return nil
 }
 
-// DebugGCS is a dirty hack for debugging for Linux Utility VMs. It simply
+// debugGCS is a dirty hack for debugging for Linux Utility VMs. It simply
 // runs a bunch of commands inside the UVM, but seriously aides in advanced debugging.
 func (c *container) debugGCS() {
 	if c == nil || c.isWindows || c.hcsContainer == nil {

--- a/vendor.conf
+++ b/vendor.conf
@@ -8,7 +8,7 @@ github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git
 github.com/gorilla/context v1.1
 github.com/gorilla/mux v1.1
-github.com/Microsoft/opengcs v0.3.3
+github.com/Microsoft/opengcs v0.3.4
 github.com/kr/pty 5cf931ef8f
 github.com/mattn/go-shellwords v1.0.3
 github.com/sirupsen/logrus v1.0.1

--- a/vendor/github.com/Microsoft/opengcs/client/createext4vhdx.go
+++ b/vendor/github.com/Microsoft/opengcs/client/createext4vhdx.go
@@ -57,6 +57,8 @@ func (config *Config) CreateExt4Vhdx(destFile string, sizeGB uint32, cacheFile s
 		return fmt.Errorf("failed to create VHDx %s: %s", destFile, err)
 	}
 
+	defer config.DebugGCS()
+
 	// Attach it to the utility VM, but don't mount it (as there's no filesystem on it)
 	if err := config.HotAddVhd(destFile, "", false, false); err != nil {
 		return fmt.Errorf("opengcs: CreateExt4Vhdx: failed to hot-add %s to utility VM: %s", cacheFile, err)

--- a/vendor/github.com/Microsoft/opengcs/client/hotaddvhd.go
+++ b/vendor/github.com/Microsoft/opengcs/client/hotaddvhd.go
@@ -20,6 +20,8 @@ func (config *Config) HotAddVhd(hostPath string, containerPath string, readOnly 
 		return fmt.Errorf("cannot hot-add VHD as no utility VM is in configuration")
 	}
 
+	defer config.DebugGCS()
+
 	modification := &hcsshim.ResourceModificationRequestResponse{
 		Resource: "MappedVirtualDisk",
 		Data: hcsshim.MappedVirtualDisk{

--- a/vendor/github.com/Microsoft/opengcs/client/hotremovevhd.go
+++ b/vendor/github.com/Microsoft/opengcs/client/hotremovevhd.go
@@ -18,6 +18,8 @@ func (config *Config) HotRemoveVhd(hostPath string) error {
 		return fmt.Errorf("cannot hot-add VHD as no utility VM is in configuration")
 	}
 
+	defer config.DebugGCS()
+
 	modification := &hcsshim.ResourceModificationRequestResponse{
 		Resource: "MappedVirtualDisk",
 		Data: hcsshim.MappedVirtualDisk{

--- a/vendor/github.com/Microsoft/opengcs/client/tartovhd.go
+++ b/vendor/github.com/Microsoft/opengcs/client/tartovhd.go
@@ -17,6 +17,8 @@ func (config *Config) TarToVhd(targetVHDFile string, reader io.Reader) (int64, e
 		return 0, fmt.Errorf("cannot Tar2Vhd as no utility VM is in configuration")
 	}
 
+	defer config.DebugGCS()
+
 	process, err := config.createUtilsProcess("tar2vhd")
 	if err != nil {
 		return 0, fmt.Errorf("failed to start tar2vhd for %s: %s", targetVHDFile, err)

--- a/vendor/github.com/Microsoft/opengcs/client/vhdtotar.go
+++ b/vendor/github.com/Microsoft/opengcs/client/vhdtotar.go
@@ -20,6 +20,8 @@ func (config *Config) VhdToTar(vhdFile string, uvmMountPath string, isSandbox bo
 		return nil, fmt.Errorf("cannot VhdToTar as no utility VM is in configuration")
 	}
 
+	defer config.DebugGCS()
+
 	vhdHandle, err := os.Open(vhdFile)
 	if err != nil {
 		return nil, fmt.Errorf("opengcs: VhdToTar: failed to open %s: %s", vhdFile, err)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@rn @johnstep - Adds the ability for docker to grab logs from the utility VM before it is torn down in advanced debugging mode (the daemon must be in debug mode itself, plus "OPENGCS_DEBUG_ENABLE" must be set in its environment.)

You can see an example of what it looks like from https://github.com/Microsoft/opengcs/pull/134.

It's a far-from-perfect solution, but pretty much the best that is possible in the RS3 release.