### PR TITLE
Fix CString memory leaks

### DIFF
--- a/daemon/graphdriver/driver_solaris.go
+++ b/daemon/graphdriver/driver_solaris.go
@@ -81,17 +81,16 @@ func (c *defaultChecker) IsMounted(path string) bool {
 func Mounted(fsType FsMagic, mountPath string) (bool, error) {
 
 	cs := C.CString(filepath.Dir(mountPath))
+	defer C.free(unsafe.Pointer(cs))
 	buf := C.getstatfs(cs)
+	defer C.free(unsafe.Pointer(buf))
 
 	// on Solaris buf.f_basetype contains ['z', 'f', 's', 0 ... ]
 	if (buf.f_basetype[0] != 122) || (buf.f_basetype[1] != 102) || (buf.f_basetype[2] != 115) ||
 		(buf.f_basetype[3] != 0) {
 		logrus.Debugf("[zfs] no zfs dataset found for rootdir '%s'", mountPath)
-		C.free(unsafe.Pointer(buf))
 		return false, ErrPrerequisites
 	}
 
-	C.free(unsafe.Pointer(buf))
-	C.free(unsafe.Pointer(cs))
 	return true, nil
 }

--- a/daemon/graphdriver/zfs/zfs_solaris.go
+++ b/daemon/graphdriver/zfs/zfs_solaris.go
@@ -27,18 +27,17 @@ import (
 func checkRootdirFs(rootdir string) error {
 
 	cs := C.CString(filepath.Dir(rootdir))
+	defer C.free(unsafe.Pointer(cs))
 	buf := C.getstatfs(cs)
+	defer C.free(unsafe.Pointer(buf))
 
 	// on Solaris buf.f_basetype contains ['z', 'f', 's', 0 ... ]
 	if (buf.f_basetype[0] != 122) || (buf.f_basetype[1] != 102) || (buf.f_basetype[2] != 115) ||
 		(buf.f_basetype[3] != 0) {
 		logrus.Debugf("[zfs] no zfs dataset found for rootdir '%s'", rootdir)
-		C.free(unsafe.Pointer(buf))
 		return graphdriver.ErrPrerequisites
 	}
 
-	C.free(unsafe.Pointer(buf))
-	C.free(unsafe.Pointer(cs))
 	return nil
 }
 

--- a/pkg/mount/mountinfo_solaris.go
+++ b/pkg/mount/mountinfo_solaris.go
@@ -4,16 +4,23 @@ package mount
 
 /*
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/mnttab.h>
 */
 import "C"
 
 import (
 	"fmt"
+	"unsafe"
 )
 
 func parseMountTable() ([]*Info, error) {
-	mnttab := C.fopen(C.CString(C.MNTTAB), C.CString("r"))
+	path := C.CString(C.MNTTAB)
+	defer C.free(unsafe.Pointer(path))
+	mode := C.CString("r")
+	defer C.free(unsafe.Pointer(mode))
+
+	mnttab := C.fopen(path, mode)
 	if mnttab == nil {
 		return nil, fmt.Errorf("Failed to open %s", C.MNTTAB)
 	}


### PR DESCRIPTION
Make sure to call C.free on C string allocated using C.CString in every
exit path.

C.CString allocates memory in the C heap using malloc. It is the callers
responsibility to free them. See
https://golang.org/cmd/cgo/#hdr-Go_references_to_C for details.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>