### PR TITLE
Reworded push message

### DIFF
--- a/distribution/push.go
+++ b/distribution/push.go
@@ -69,7 +69,7 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
 		return err
 	}
 
-	progress.Messagef(imagePushConfig.ProgressOutput, "", "The push refers to a repository [%s]", repoInfo.Name.Name())
+	progress.Messagef(imagePushConfig.ProgressOutput, "", "The push refers to repository [%s]", repoInfo.Name.Name())
 
 	associations := imagePushConfig.ReferenceStore.ReferencesByName(repoInfo.Name)
 	if len(associations) == 0 {


### PR DESCRIPTION
<sup>Disclaimer: I only created this pull request due to the section in your contribution guideline: "Not sure if that typo is worth a pull request? Found a bug and know how to fix it? Do it! We will appreciate it.", please just close it if you don't see any merit.</sup>

Changed push message from "The push refers to a repository" to "The push refers to the repository" to make it clearer that this is just an information about the local source and not a distinction between pushing single images or whole repositories.

See this thread: https://stackoverflow.com/questions/46229467/does-the-push-refers-to-a-repository-actually-mean-refers-to-a-registry