### PR TITLE
"docker swarm init --force-new-cluster" use limit

### DIFF
--- a/daemon/cluster/errors.go
+++ b/daemon/cluster/errors.go
@@ -15,6 +15,9 @@ const (
 
 	// errSwarmCertificatesExpired is returned if docker was not started for the whole validity period and they had no chance to renew automatically.
 	errSwarmCertificatesExpired notAvailableError = "Swarm certificates have expired. To replace them, leave the swarm and join again."
+
+	// errSwarmNotManager is returned if the node is not a swarm manager.
+	errSwarmNotManager notAvailableError = "This node is not a swarm manager. Worker nodes can't be used to view or modify cluster state. Please run this command on a manager node or promote the current node to a manager."
 )
 
 type notFoundError struct {

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -26,9 +26,13 @@ func (c *Cluster) Init(req types.InitRequest) (string, error) {
 	defer c.controlMutex.Unlock()
 	if c.nr != nil {
 		if req.ForceNewCluster {
+
 			// Take c.mu temporarily to wait for presently running
 			// API handlers to finish before shutting down the node.
 			c.mu.Lock()
+			if !c.nr.nodeState.IsManager() {
+				return "", errSwarmNotManager
+			}
 			c.mu.Unlock()
 
 			if err := c.nr.Stop(); err != nil {


### PR DESCRIPTION
Signed-off-by: yangchenliang <yangchenliang@huawei.com>

When worker executes  `docker swarm init
--force-new-cluster`,docker would hang.So only manager can process it.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

