### PR TITLE
LCOW: Graphdriver - don't create scratch

### DIFF
--- a/daemon/graphdriver/lcow/lcow.go
+++ b/daemon/graphdriver/lcow/lcow.go
@@ -190,11 +190,6 @@ func InitDriver(dataRoot string, options []string, _, _ []idtools.IDMap) (graphd
 		return nil, fmt.Errorf("%s failed to create '%s': %v", title, cd, err)
 	}
 
-	// Make sure the scratch directory is created under dataRoot
-	if err := idtools.MkdirAllAs(sd, 0700, 0, 0); err != nil {
-		return nil, fmt.Errorf("%s failed to create '%s': %v", title, sd, err)
-	}
-
 	// Delete any items in the scratch directory
 	filepath.Walk(sd, deletefiles)
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@johnstep This should have been removed ages ago - this directory hasn't been used since almost the inception of LCOW (was part of the early prototype). Only noticed when examining the main directory from the command line.