### PR TITLE
Create and send codecov report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ dockerversion/version_autogen.go
 dockerversion/version_autogen_unix.go
 vendor/pkg/
 hack/integration-cli-on-swarm/integration-cli-on-swarm
+coverage.txt
+profile.out

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+comment:
+  layout: header, changes, diff, sunburst
+coverage:
+  status:
+    patch:
+      default:
+        target: 50%
+        only_pulls: true
+    # project will give us the diff in the total code coverage between a commit
+    # and its parent
+    project:
+      default:
+        target: auto
+        threshold: "15%"
+    changes: false
+ignore:
+  - "vendor/*"

--- a/hack/ci/janky
+++ b/hack/ci/janky
@@ -4,6 +4,8 @@ set -eu -o pipefail
 
 hack/validate/default
 hack/test/unit
+bash <(curl -s https://codecov.io/bash) -f coverage.txt || \
+    echo 'Codecov failed to upload'
 
 hack/make.sh \
 	binary-daemon \

--- a/hack/ci/janky
+++ b/hack/ci/janky
@@ -4,7 +4,9 @@ set -eu -o pipefail
 
 hack/validate/default
 hack/test/unit
-bash <(curl -s https://codecov.io/bash) -f coverage.txt || \
+bash <(curl -s https://codecov.io/bash) \
+    -f coverage.txt \
+    -C $GIT_SHA1 || \
     echo 'Codecov failed to upload'
 
 hack/make.sh \

--- a/hack/test/unit
+++ b/hack/test/unit
@@ -19,4 +19,20 @@ TESTDIRS="${TESTDIRS:-"./..."}"
 exclude_paths="/vendor/|/integration"
 pkg_list=$(go list $TESTDIRS | grep -vE "($exclude_paths)")
 
-go test -cover "${BUILDFLAGS[@]}" $TESTFLAGS $pkg_list
+# install test dependencies once before running tests for each package. This
+# significantly reduces the runtime.
+go test -i "${BUILDFLAGS[@]}" $pkg_list
+
+for pkg in $pkg_list; do
+    go test "${BUILDFLAGS[@]}" \
+        -cover \
+        -coverprofile=profile.out \
+        -covermode=atomic \
+        $TESTFLAGS \
+        "${pkg}"
+
+    if test -f profile.out; then
+        cat profile.out >> coverage.txt
+        rm profile.out
+    fi
+done


### PR DESCRIPTION
Branched from #34911

Create a code coverage report while running unit tests, and upload it to codecov.

This TestNewEnvClient was failing locally so I added some doc strings to debug the failures.