### PR TITLE
Set integration test OSType with environment variable

### DIFF
--- a/integration-cli/cli/build/fakestorage/fixtures.go
+++ b/integration-cli/cli/build/fakestorage/fixtures.go
@@ -30,7 +30,7 @@ func ensureHTTPServerImage(t testingT) {
 	}
 	defer os.RemoveAll(tmp)
 
-	goos := testEnv.DaemonInfo.OSType
+	goos := testEnv.OSType
 	if goos == "" {
 		goos = "linux"
 	}

--- a/integration-cli/cli/cli.go
+++ b/integration-cli/cli/cli.go
@@ -115,7 +115,7 @@ func Docker(cmd icmd.Cmd, cmdOperators ...CmdOperator) *icmd.Result {
 // validateArgs is a checker to ensure tests are not running commands which are
 // not supported on platforms. Specifically on Windows this is 'busybox top'.
 func validateArgs(args ...string) error {
-	if testEnv.DaemonInfo.OSType != "windows" {
+	if testEnv.OSType != "windows" {
 		return nil
 	}
 	foundBusybox := -1

--- a/integration-cli/environment/environment.go
+++ b/integration-cli/environment/environment.go
@@ -67,9 +67,9 @@ func (e *Execution) ExperimentalDaemon() bool {
 // decisions on how to configure themselves according to the platform
 // of the daemon. This is initialized in docker_utils by sending
 // a version call to the daemon and examining the response header.
-// Deprecated: use Execution.DaemonInfo.OSType
+// Deprecated: use Execution.OSType
 func (e *Execution) DaemonPlatform() string {
-	return e.DaemonInfo.OSType
+	return e.OSType
 }
 
 // MinimalBaseImage is the image used for minimal builds (it depends on the platform)

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -21,12 +21,12 @@ func ArchitectureIsNot(arch string) bool {
 }
 
 func DaemonIsWindows() bool {
-	return testEnv.DaemonInfo.OSType == "windows"
+	return testEnv.OSType == "windows"
 }
 
 func DaemonIsWindowsAtLeastBuild(buildNumber int) func() bool {
 	return func() bool {
-		if testEnv.DaemonInfo.OSType != "windows" {
+		if testEnv.OSType != "windows" {
 			return false
 		}
 		version := testEnv.DaemonInfo.KernelVersion
@@ -36,7 +36,7 @@ func DaemonIsWindowsAtLeastBuild(buildNumber int) func() bool {
 }
 
 func DaemonIsLinux() bool {
-	return testEnv.DaemonInfo.OSType == "linux"
+	return testEnv.OSType == "linux"
 }
 
 func OnlyDefaultNetworks() bool {
@@ -178,21 +178,21 @@ func UserNamespaceInKernel() bool {
 }
 
 func IsPausable() bool {
-	if testEnv.DaemonInfo.OSType == "windows" {
+	if testEnv.OSType == "windows" {
 		return testEnv.DaemonInfo.Isolation == "hyperv"
 	}
 	return true
 }
 
 func NotPausable() bool {
-	if testEnv.DaemonInfo.OSType == "windows" {
+	if testEnv.OSType == "windows" {
 		return testEnv.DaemonInfo.Isolation == "process"
 	}
 	return false
 }
 
 func IsolationIs(expectedIsolation string) bool {
-	return testEnv.DaemonInfo.OSType == "windows" && string(testEnv.DaemonInfo.Isolation) == expectedIsolation
+	return testEnv.OSType == "windows" && string(testEnv.DaemonInfo.Isolation) == expectedIsolation
 }
 
 func IsolationIsHyperv() bool {

--- a/integration/system/version_test.go
+++ b/integration/system/version_test.go
@@ -20,5 +20,5 @@ func TestVersion(t *testing.T) {
 	assert.NotNil(t, version.Version)
 	assert.NotNil(t, version.MinAPIVersion)
 	assert.Equal(t, testEnv.DaemonInfo.ExperimentalBuild, version.Experimental)
-	assert.Equal(t, testEnv.DaemonInfo.OSType, version.Os)
+	assert.Equal(t, testEnv.OSType, version.Os)
 }

--- a/internal/test/environment/clean.go
+++ b/internal/test/environment/clean.go
@@ -28,7 +28,7 @@ type logT interface {
 func (e *Execution) Clean(t testingT) {
 	client := e.APIClient()
 
-	platform := e.DaemonInfo.OSType
+	platform := e.OSType
 	if (platform != "windows") || (platform == "windows" && e.DaemonInfo.Isolation == "hyperv") {
 		unpauseAllContainers(t, client)
 	}

--- a/internal/test/environment/protect.go
+++ b/internal/test/environment/protect.go
@@ -35,7 +35,7 @@ func ProtectAll(t testingT, testEnv *Execution) {
 	ProtectImages(t, testEnv)
 	ProtectNetworks(t, testEnv)
 	ProtectVolumes(t, testEnv)
-	if testEnv.DaemonInfo.OSType == "linux" {
+	if testEnv.OSType == "linux" {
 		ProtectPlugins(t, testEnv)
 	}
 }
@@ -81,7 +81,7 @@ func (e *Execution) ProtectImage(t testingT, images ...string) {
 func ProtectImages(t testingT, testEnv *Execution) {
 	images := getExistingImages(t, testEnv)
 
-	if testEnv.DaemonInfo.OSType == "linux" {
+	if testEnv.OSType == "linux" {
 		images = append(images, ensureFrozenImagesLinux(t, testEnv)...)
 	}
 	testEnv.ProtectImage(t, images...)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add the ability to set the daemon `OSType`  for integration tests.

**- How I did it**
Set the `TEST_OSTYPE` environment variable to override that from daemon info.

**- How to verify it**
Run integration tests with `TEST_OSTYPE` set.
