### PR TITLE
Add a new entrypoint for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all binary dynbinary build cross deb help init-go-pkg-cache install manpages rpm run shell test test-docker-py test-integration test-unit tgz validate win
+.PHONY: all binary dynbinary build cross deb help init-go-pkg-cache install manpages rpm run shell test test-docker-py test-integration test-unit validate win
 
 # set the graph driver as the current graphdriver if not set
 DOCKER_GRAPHDRIVER := $(if $(DOCKER_GRAPHDRIVER),$(DOCKER_GRAPHDRIVER),$(shell docker info 2>&1 | grep "Storage Driver" | sed 's/.*: //'))
@@ -163,9 +163,6 @@ test-integration: build ## run the integration tests
 
 test-unit: build ## run the unit tests
 	$(DOCKER_RUN_DOCKER) hack/test/unit
-
-tgz: build ## build the archives (.zip on windows and .tgz\notherwise) containing the binaries
-	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary binary cross tgz
 
 validate: build ## validate DCO, Seccomp profile generation, gofmt,\n./pkg/ isolation, golint, tests, tomls, go vet and vendor
 	$(DOCKER_RUN_DOCKER) hack/validate/all

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -140,10 +140,7 @@ func (daemon *Daemon) StoreHosts(hosts []string) {
 
 // HasExperimental returns whether the experimental features of the daemon are enabled or not
 func (daemon *Daemon) HasExperimental() bool {
-	if daemon.configStore != nil && daemon.configStore.Experimental {
-		return true
-	}
-	return false
+	return daemon.configStore != nil && daemon.configStore.Experimental
 }
 
 func (daemon *Daemon) restore() error {

--- a/hack/ci/arm
+++ b/hack/ci/arm
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Entrypoint for jenkins arm CI build
+set -eu -o pipefail
+
+hack/test/unit
+
+hack/make.sh \
+	binary-daemon \
+	dynbinary \
+	test-integration

--- a/hack/ci/experimental
+++ b/hack/ci/experimental
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Entrypoint for jenkins experimental CI
+set -eu -o pipefail
+
+export DOCKER_EXPERIMENTAL=y
+
+hack/make.sh \
+	binary-daemon \
+	test-integration

--- a/hack/ci/janky
+++ b/hack/ci/janky
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Entrypoint for jenkins janky CI build
+set -eu -o pipefail
+
+hack/validate/default
+hack/test/unit
+
+hack/make.sh \
+	binary-daemon \
+	dynbinary \
+	test-integration \
+	test-docker-py \
+	cross

--- a/hack/ci/powerpc
+++ b/hack/ci/powerpc
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Entrypoint for jenkins powerpc CI build
+set -eu -o pipefail
+
+hack/test/unit
+hack/make.sh dynbinary test-integration

--- a/hack/ci/z
+++ b/hack/ci/z
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Entrypoint for jenkins s390x (z) CI build
+set -eu -o pipefail
+
+hack/test/unit
+hack/make.sh dynbinary test-integration

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -59,12 +59,10 @@ DEFAULT_BUNDLES=(
 	binary-daemon
 	dynbinary
 
-	test-unit
 	test-integration
 	test-docker-py
 
 	cross
-	tgz
 )
 
 VERSION=${VERSION:-$(< ./VERSION)}

--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-echo "DEPRECATED: use hack/test/unit instead of hack/make.sh test-unit" >&2
-
-$SCRIPTDIR/test/unit 2>&1 | tee -a "$DEST/test.log"

--- a/hack/make/tgz
+++ b/hack/make/tgz
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-echo "tgz is deprecated"

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -56,10 +56,6 @@ func ExperimentalDaemon() bool {
 	return testEnv.DaemonInfo.ExperimentalBuild
 }
 
-func NotExperimentalDaemon() bool {
-	return !testEnv.DaemonInfo.ExperimentalBuild
-}
-
 func IsAmd64() bool {
 	return os.Getenv("DOCKER_ENGINE_GOARCH") == "amd64"
 }


### PR DESCRIPTION
We've slowly been moving away from `hack/make.sh` as the in-container entrypoint for everything (#33987, #27964). This PR adds a new `hack/ci` directory which acts as the entrypoint for all the CI builds.

This setup has the following advantages:
* allow us to support #34900 (uploading codecov) which we only want to run as part of CI
* removes more configuration from jenkins (easier to maintain from the source repo)
* allows us to run different tasks for each build (ex: we don't need `cross` on z/powerpc/arm)
* should allow us to move more CI settings out of the `Dockerfile` (which is used for both CI and development) and into these entrypoint scripts, so we can provide better defaults for development
* should allow us to being the windows CI inline with our linux CI (the entrypoint would be a powershell script at `hack/ci/windows-RS1` instead of hundreds of lines in the jenkins config)

