### PR TITLE
Make max log line length configurable for all log drivers

### DIFF
--- a/daemon/logger/copier_test.go
+++ b/daemon/logger/copier_test.go
@@ -65,7 +65,8 @@ func TestCopier(t *testing.T) {
 			"stdout": &stdout,
 			"stderr": &stderr,
 		},
-		jsonLog)
+		jsonLog,
+		DefaultCopierBufferSize)
 	c.Run()
 	wait := make(chan struct{})
 	go func() {
@@ -105,7 +106,7 @@ func TestCopier(t *testing.T) {
 // TestCopierLongLines tests long lines without line breaks
 func TestCopierLongLines(t *testing.T) {
 	// Long lines (should be split at "bufSize")
-	const bufSize = 16 * 1024
+	bufSize := int(DefaultCopierBufferSize)
 	stdoutLongLine := strings.Repeat("a", bufSize)
 	stderrLongLine := strings.Repeat("b", bufSize)
 	stdoutTrailingLine := "stdout trailing line"
@@ -139,7 +140,8 @@ func TestCopierLongLines(t *testing.T) {
 			"stdout": &stdout,
 			"stderr": &stderr,
 		},
-		jsonLog)
+		jsonLog,
+		DefaultCopierBufferSize)
 	c.Run()
 	wait := make(chan struct{})
 	go func() {
@@ -189,7 +191,7 @@ func TestCopierSlow(t *testing.T) {
 	//encoder := &encodeCloser{Encoder: json.NewEncoder(&jsonBuf)}
 	jsonLog := &TestLoggerJSON{Encoder: json.NewEncoder(&jsonBuf), delay: 100 * time.Millisecond}
 
-	c := NewCopier(map[string]io.Reader{"stdout": &stdout}, jsonLog)
+	c := NewCopier(map[string]io.Reader{"stdout": &stdout}, jsonLog, DefaultCopierBufferSize)
 	c.Run()
 	wait := make(chan struct{})
 	go func() {
@@ -288,7 +290,8 @@ func benchmarkCopier(b *testing.B, length int) {
 			map[string]io.Reader{
 				"buffer": piped(b, 10, time.Nanosecond, buf),
 			},
-			&BenchmarkLoggerDummy{})
+			&BenchmarkLoggerDummy{},
+			DefaultCopierBufferSize)
 		c.Run()
 		c.Wait()
 		c.Close()

--- a/daemon/logger/factory.go
+++ b/daemon/logger/factory.go
@@ -119,6 +119,7 @@ func GetLogDriver(name string) (Creator, error) {
 var builtInLogOpts = map[string]bool{
 	"mode":            true,
 	"max-buffer-size": true,
+	"max-line-length": true,
 }
 
 // ValidateLogOpts checks the options for the given log driver. The
@@ -140,6 +141,12 @@ func ValidateLogOpts(name string, cfg map[string]string) error {
 		}
 		if _, err := units.RAMInBytes(s); err != nil {
 			return errors.Wrap(err, "error parsing option max-buffer-size")
+		}
+	}
+
+	if s, ok := cfg["max-line-length"]; ok {
+		if _, err := units.RAMInBytes(s); err != nil {
+			return errors.Wrap(err, "error parsing option max-line-length")
 		}
 	}
 


### PR DESCRIPTION
/cc @piosz @fgrzadkowski @cpuguy83

**- What I did**

Introduced a built-in log-opt `max-line-length` for all logging drivers that sets the limit on the length of a log entry passed to the log driver.

**- How I did it**

Replaced constant buffer size in `daemon/logger.Copier` with the field, populated from the constructor parameters. Added `max-line-length` to the list of well-known log-opts and used it in the container logging initialization function to initialize `daemon/logger.Copier` instance.

**- How to verify it**

Run 

```
CONTAINER_ID=`docker run -d --log-opt max-line-length=10 debian perl -le 'print "A" x 100'`
```

And then check the log file. It should contain several JSON objects

```
cat `docker inspect --format='{{.LogPath}}' $CONTAINER_ID` | wc -l
```

The printed value should be `11`

**- Description for the changelog**

Add a built-in log-opt `max-line-length` for all logging drivers that controls the max log line length. Closes #34855.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1756505/30666336-3c4e9c3e-9e54-11e7-9ee2-a4b3215b72e6.png)
