### PR TITLE
Ensure Host Network Service exists

### DIFF
--- a/daemon/daemon_windows_test.go
+++ b/daemon/daemon_windows_test.go
@@ -1,0 +1,72 @@
+// +build windows
+
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+const existingService = "Power"
+
+func TestEnsureServicesExist(t *testing.T) {
+	m, err := mgr.Connect()
+	if err != nil {
+		t.Fatal("failed to connect to service manager, this test needs admin")
+	}
+	defer m.Disconnect()
+	s, err := m.OpenService(existingService)
+	if err != nil {
+		t.Fatalf("expected to find known inbox service %q, this test needs a known inbox service to run correctly", existingService)
+	}
+	defer s.Close()
+
+	input := []string{existingService}
+	err = ensureServicesInstalled(input)
+	if err != nil {
+		t.Fatalf("unexpected error for input %q: %q", input, err)
+	}
+}
+
+func TestEnsureServicesExistErrors(t *testing.T) {
+	m, err := mgr.Connect()
+	if err != nil {
+		t.Fatal("failed to connect to service manager, this test needs admin")
+	}
+	defer m.Disconnect()
+	s, err := m.OpenService(existingService)
+	if err != nil {
+		t.Fatalf("expected to find known inbox service %q, this test needs a known inbox service to run correctly", existingService)
+	}
+	defer s.Close()
+
+	for _, testcase := range []struct {
+		input         []string
+		expectedError string
+	}{
+		{
+			input:         []string{"daemon_windows_test_fakeservice"},
+			expectedError: "failed to open service daemon_windows_test_fakeservice",
+		},
+		{
+			input:         []string{"daemon_windows_test_fakeservice1", "daemon_windows_test_fakeservice2"},
+			expectedError: "failed to open service daemon_windows_test_fakeservice1",
+		},
+		{
+			input:         []string{existingService, "daemon_windows_test_fakeservice"},
+			expectedError: "failed to open service daemon_windows_test_fakeservice",
+		},
+	} {
+		t.Run(strings.Join(testcase.input, ";"), func(t *testing.T) {
+			err := ensureServicesInstalled(testcase.input)
+			if err == nil {
+				t.Fatalf("expected error for input %v", testcase.input)
+			}
+			if !strings.Contains(err.Error(), testcase.expectedError) {
+				t.Fatalf("expected error %q to contain %q", err.Error(), testcase.expectedError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**- What I did**

Fixes https://github.com/moby/moby/issues/34920

The HNS service is the host network service required for container networking. If the service does not exist, the daemon will fail when trying to restore existing networks. This moves the failure earlier in the daemon start to provide a better error message.

**- How I did it**

Prevent daemon from starting if Host Network Service does not exist.

**- How to verify it**

Due to the global state required to test this, it is not tested in CI, but the unit test tests the added ensureServicesInstalled function.

Tested manually on RS1 and RS3 with all combinations of installed roles Hyper-V and Containers. The only change is in RS3, if Hyper-V role is installed, but Containers role is not, the daemon now fails with the new error:

```
PS C:\Windows\system32> dockerd
Error starting daemon: a required service is not installed, ensure the Containers role is installed: failed to open service hns: The specified service does not exist as an installed service.
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A


@andrewhsu I think this should be considered for backporting to 17.06. If a currently working Docker host has the Hyper-V role installed, but not the containers role installed (an unsupported configuration that happens to work on current (pre-RS3) versions of Windows), the upgrade to RS3 may cause the daemon to fail to start with a generic sounding HNS error (see https://github.com/moby/moby/issues/34920). This fix would provide a proper error message so that they can install the Containers role to fix the issue.

