### PR TITLE
add node/service/secret/config specific event filter

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6941,16 +6941,20 @@ paths:
           description: |
             A JSON encoded value of filters (a `map[string][]string`) to process on the event list. Available filters:
 
+            - `config=<string>` config name or ID
             - `container=<string>` container name or ID
             - `daemon=<string>` daemon name or ID
             - `event=<string>` event type
             - `image=<string>` image name or ID
             - `label=<string>` image or container label
             - `network=<string>` network name or ID
+            - `node=<string>` node ID
             - `plugin`=<string> plugin name or ID
             - `scope`＝<string> local or swarm
-            - `type=<string>` object to filter by, one of `container`, `image`, `volume`, `network`, `daemon`, `plugin`, `node`, `service` or `secret`
-            - `volume=<string>` volume name or ID
+            - `secret=<string>` secret name or ID
+            - `service=<string>` service name or ID
+            - `type=<string>` object to filter by, one of `container`, `image`, `volume`, `network`, `daemon`, `plugin`, `node`, `service`, `secret` or `config`
+            - `volume=<string>` volume name
           type: "string"
       tags: ["System"]
   /system/df:

--- a/daemon/events/filter.go
+++ b/daemon/events/filter.go
@@ -27,6 +27,10 @@ func (ef *Filter) Include(ev events.Message) bool {
 		ef.matchVolume(ev) &&
 		ef.matchNetwork(ev) &&
 		ef.matchImage(ev) &&
+		ef.matchNode(ev) &&
+		ef.matchService(ev) &&
+		ef.matchSecret(ev) &&
+		ef.matchConfig(ev) &&
 		ef.matchLabels(ev.Actor.Attributes)
 }
 

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -18,7 +18,8 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.33](https://docs.docker.com/engine/api/v1.33/) documentation
 
-
+* `GET /events` now supports filtering 4 more kinds of events: `config`, `node`,
+`secret` and `service`. 
 
 ## v1.32 API changes
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

fixes #34951 

**- What I did**
1. add four specific event filters, so that we can use `docker events --filter config=allen` to filter only config events whose name is allen.
2. update swagger.yml including remove volume ID since volume has only name. can see PR https://github.com/docker/cli/pull/552
3. add a missing type `config` in type event filter.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

ping @thaJeztah @vdemeester @dnephin 