### PR TITLE
Fix #34953 how volumes are pruned from daemon

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/system"
+	"github.com/docker/docker/volume"
 	volumestore "github.com/docker/docker/volume/store"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -148,10 +149,19 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 // If the volume is referenced by a container it is not removed
 // This is called directly from the Engine API
 func (daemon *Daemon) VolumeRm(name string, force bool) error {
-	err := daemon.volumeRm(name)
+	v, err := daemon.volumes.Get(name)
+	if err != nil {
+		if force && volumestore.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	err = daemon.volumeRm(v)
 	if err != nil && volumestore.IsInUse(err) {
 		return stateConflictError{err}
 	}
+
 	if err == nil || force {
 		daemon.volumes.Purge(name)
 		return nil
@@ -159,12 +169,7 @@ func (daemon *Daemon) VolumeRm(name string, force bool) error {
 	return err
 }
 
-func (daemon *Daemon) volumeRm(name string) error {
-	v, err := daemon.volumes.Get(name)
-	if err != nil {
-		return err
-	}
-
+func (daemon *Daemon) volumeRm(v volume.Volume) error {
 	if err := daemon.volumes.Remove(v); err != nil {
 		return errors.Wrap(err, "unable to remove volume")
 	}

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -140,7 +140,7 @@ func (daemon *Daemon) VolumesPrune(ctx context.Context, pruneFilters filters.Arg
 			if err != nil {
 				logrus.Warnf("could not determine size of volume %s: %v", name, err)
 			}
-			err = daemon.volumes.Remove(v)
+			err = daemon.volumeRm(v)
 			if err != nil {
 				logrus.Warnf("could not remove volume %s: %v", name, err)
 				return nil


### PR DESCRIPTION
- Call the function that create an event entry while volumes are pruning.

Signed-off-by: Nicolas Sterchele <sterchele.nicolas@gmail.com>

**- What I did**
From `daemon/prune.go` file, function `VolumesPrune` line `143`, I replaced the following call `daemon.volumes.Remove' by this one `daemon.VolumeRm.

**- How to verify it**
Listen the events by calling `docker events`, then remove volumes with the following command `docker volume prune`. Now you should see an event entry.
**- Description for the changelog**
Replace volumes pruning call by the one that create an event entry.