### PR TITLE
Fix TestMount under a selinux system

### DIFF
--- a/pkg/mount/mounter_linux_test.go
+++ b/pkg/mount/mounter_linux_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	selinux "github.com/opencontainers/selinux/go-selinux"
 )
 
 func TestMount(t *testing.T) {
@@ -101,7 +103,11 @@ func TestMount(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer ensureUnmount(t, target)
-			validateMount(t, target, tc.expectedOpts, tc.expectedOptional, tc.expectedVFS)
+			expectedVFS := tc.expectedVFS
+			if selinux.GetEnabled() && expectedVFS != "" {
+				expectedVFS = expectedVFS + ",seclabel"
+			}
+			validateMount(t, target, tc.expectedOpts, tc.expectedOptional, expectedVFS)
 		})
 	}
 }


### PR DESCRIPTION
`master` builds are red under `Fedora` and `Centos` since.. a lot while (~4months) :scream: 
The reason is :

```
19:09:52 --- FAIL: TestMount (0.14s)
19:09:52     --- FAIL: TestMount/none-remount,size=128k (0.01s)
19:09:52     	mounter_linux_test.go:203: unexpected mount option "seclabel" expected "rw,size=128k"
19:09:52     --- FAIL: TestMount/none-remount,ro,size=128k (0.01s)
19:09:52     	mounter_linux_test.go:203: unexpected mount option "seclabel" expected "ro,size=128k"
19:09:52 FAIL
19:09:52 coverage: 69.3% of statements
```

This fixes that by taking into account if `SELinux` is activated or not.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
