### PR TITLE
Dockerfile: use seccomp provided by stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update && apt-get install -y \
 	libnl-3-dev \
 	libprotobuf-c0-dev \
 	libprotobuf-dev \
+	libseccomp-dev \
 	libsystemd-dev \
 	libtool \
 	libudev-dev \
@@ -79,21 +80,6 @@ RUN apt-get update && apt-get install -y \
 	zip \
 	--no-install-recommends \
 	&& pip install awscli==1.10.15
-
-# Install seccomp: the version shipped upstream is too old
-ENV SECCOMP_VERSION 2.3.2
-RUN set -x \
-	&& export SECCOMP_PATH="$(mktemp -d)" \
-	&& curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" \
-		| tar -xzC "$SECCOMP_PATH" --strip-components=1 \
-	&& ( \
-		cd "$SECCOMP_PATH" \
-		&& ./configure --prefix=/usr/local \
-		&& make \
-		&& make install \
-		&& ldconfig \
-	) \
-	&& rm -rf "$SECCOMP_PATH"
 
 # Install Go
 # IMPORTANT: If the version of Go is updated, the Windows to Linux CI machines

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -48,6 +48,7 @@ RUN apt-get update && apt-get install -y \
 	libnl-3-dev \
 	libprotobuf-c0-dev \
 	libprotobuf-dev \
+	libseccomp-dev \
 	libsystemd-dev \
 	libtool \
 	libudev-dev \
@@ -71,21 +72,6 @@ RUN apt-get update && apt-get install -y \
 	xfsprogs \
 	zip \
 	--no-install-recommends
-
-# Install seccomp: the version shipped upstream is too old
-ENV SECCOMP_VERSION 2.3.2
-RUN set -x \
-	&& export SECCOMP_PATH="$(mktemp -d)" \
-	&& curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" \
-		| tar -xzC "$SECCOMP_PATH" --strip-components=1 \
-	&& ( \
-		cd "$SECCOMP_PATH" \
-		&& ./configure --prefix=/usr/local \
-		&& make \
-		&& make install \
-		&& ldconfig \
-	) \
-	&& rm -rf "$SECCOMP_PATH"
 
 # Install Go
 # We don't have official binary golang 1.7.5 tarballs for ARM64, either for Go or

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -40,6 +40,7 @@ RUN apt-get update && apt-get install -y \
 	libapparmor-dev \
 	libcap-dev \
 	libdevmapper-dev \
+	libseccomp-dev \
 	libsystemd-dev \
 	libtool \
 	libudev-dev \
@@ -71,21 +72,6 @@ ENV GOPATH /go
 # We're building for armhf, which is ARMv7, so let's be explicit about that
 ENV GOARCH arm
 ENV GOARM 7
-
-# Install seccomp: the version shipped upstream is too old
-ENV SECCOMP_VERSION 2.3.2
-RUN set -x \
-	&& export SECCOMP_PATH="$(mktemp -d)" \
-	&& curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" \
-		| tar -xzC "$SECCOMP_PATH" --strip-components=1 \
-	&& ( \
-		cd "$SECCOMP_PATH" \
-		&& ./configure --prefix=/usr/local \
-		&& make \
-		&& make install \
-		&& ldconfig \
-	) \
-	&& rm -rf "$SECCOMP_PATH"
 
 # Install two versions of the registry. The first is an older version that
 # only supports schema1 manifests. The second is a newer version that supports

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get install -y \
 	libapparmor-dev \
 	libcap-dev \
 	libdevmapper-dev \
+	libseccomp-dev \
 	libsystemd-dev \
 	libtool \
 	libudev-dev \
@@ -59,22 +60,6 @@ RUN apt-get update && apt-get install -y \
 	thin-provisioning-tools \
 	vim-common \
 	--no-install-recommends
-
-# Install seccomp: the version shipped upstream is too old
-ENV SECCOMP_VERSION 2.3.2
-RUN set -x \
-        && export SECCOMP_PATH="$(mktemp -d)" \
-        && curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" \
-                | tar -xzC "$SECCOMP_PATH" --strip-components=1 \
-        && ( \
-                cd "$SECCOMP_PATH" \
-                && ./configure --prefix=/usr/local \
-                && make \
-                && make install \
-                && ldconfig \
-        ) \
-        && rm -rf "$SECCOMP_PATH"
-
 
 # Install Go
 # NOTE: official ppc64le go binaries weren't available until go 1.6.4 and 1.7.4

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get install -y \
 	libapparmor-dev \
 	libcap-dev \
 	libdevmapper-dev \
+	libseccomp-dev \
 	libsystemd-dev \
 	libtool \
 	libudev-dev \
@@ -55,21 +56,6 @@ RUN apt-get update && apt-get install -y \
 	thin-provisioning-tools \
 	vim-common \
 	--no-install-recommends
-
-# Install seccomp: the version shipped upstream is too old
-ENV SECCOMP_VERSION 2.3.2
-RUN set -x \
-	&& export SECCOMP_PATH="$(mktemp -d)" \
-	&& curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" \
-		| tar -xzC "$SECCOMP_PATH" --strip-components=1 \
-	&& ( \
-		cd "$SECCOMP_PATH" \
-		&& ./configure --prefix=/usr/local \
-		&& make \
-		&& make install \
-		&& ldconfig \
-	) \
-	&& rm -rf "$SECCOMP_PATH"
 
 # IMPORTANT: When updating this please note that stdlib archive/tar pkg is vendored
 ENV GO_VERSION 1.8.3

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		git \
 		libapparmor-dev \
 		libdevmapper-dev \
+		libseccomp-dev \
 		ca-certificates \
 		e2fsprogs \
 		iptables \
@@ -33,21 +34,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		aufs-tools \
 		vim-common \
 	&& rm -rf /var/lib/apt/lists/*
-
-# Install seccomp: the version shipped upstream is too old
-ENV SECCOMP_VERSION 2.3.2
-RUN set -x \
-	&& export SECCOMP_PATH="$(mktemp -d)" \
-	&& curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" \
-		| tar -xzC "$SECCOMP_PATH" --strip-components=1 \
-	&& ( \
-		cd "$SECCOMP_PATH" \
-		&& ./configure --prefix=/usr/local \
-		&& make \
-		&& make install \
-		&& ldconfig \
-	) \
-	&& rm -rf "$SECCOMP_PATH"
 
 # Install Go
 # IMPORTANT: If the version of Go is updated, the Windows to Linux CI machines


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Use seccomp provided by stretch (2.3.1 as of writing: https://packages.debian.org/en/stretch/seccomp)

This downgrades seccomp from 2.3.2 to 2.3.1, but the changes seems trivial: https://github.com/seccomp/libseccomp/blob/master/CHANGELOG


**- How I did it**

Modified Dockerfiles

Past commits to related lines:
https://github.com/moby/moby/commit/9067ef0e32c6a85384dad2a30ac3a49e2f9fe393
https://github.com/moby/moby/commit/9b8d328666a6cd5313208cdf5f116825f06dccdc
https://github.com/moby/moby/commit/4357ed4a7363a1032edf93cf03232953c805184f

**- How to verify it**

Observe CI result.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
https://www.youtube.com/watch?v=uCgS9rN1M84