### PR TITLE
Fix error string about containers feature

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -235,7 +235,7 @@ func checkSystem() error {
 
 	vmcompute := windows.NewLazySystemDLL("vmcompute.dll")
 	if vmcompute.Load() != nil {
-		return fmt.Errorf("Failed to load vmcompute.dll. Ensure that the Containers role is installed.")
+		return fmt.Errorf("failed to load vmcompute.dll, ensure that the Containers feature is installed")
 	}
 
 	return nil


### PR DESCRIPTION
This is a requested followup from https://github.com/moby/moby/pull/34928

It fixes the error about not having the Containers feature installed to correctly call it a feature instead of a role. It also follows proper Golang error format with no punctuation and errors starting in a lowercase.

/cc @jhowardmsft 