### PR TITLE
Suppress warning for renaming missing tmp directory

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1044,7 +1044,7 @@ func prepareTempDir(rootDir string, rootIDs idtools.IDPair) (string, error) {
 					logrus.Warnf("failed to delete old tmp directory: %s", newName)
 				}
 			}()
-		} else {
+		} else if !os.IsNotExist(err) {
 			logrus.Warnf("failed to rename %s for background deletion: %s. Deleting synchronously", tmpDir, err)
 			if err := os.RemoveAll(tmpDir); err != nil {
 				logrus.Warnf("failed to delete old tmp directory: %s", tmpDir)


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/34982

When starting `dockerd` on a host that has no `/var/lib/docker/tmp` directory,
a warning was printed in the logs:

    $ dockerd --data-root=/no-such-directory
    ...
    WARN[2017-09-26T09:37:00.045153377Z] failed to rename /no-such-directory/tmp for background deletion: rename /no-such-directory/tmp /no-such-directory/tmp-old: no such file or directory. Deleting synchronously

Although harmless, the warning does not show any useful information, so can be
skipped.

This patch checks thetype of error, so that warning is not printed.
Other errors will still show up:

    $ touch /i-am-a-file
    $ dockerd --data-root=/i-am-a-file
    Unable to get the full path to root (/i-am-a-file): canonical path points to a file '/i-am-a-file'


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

    Remove warning in daemon logs when starting the daemon on a clean host

