### PR TITLE
Remove use of deprecated filter functions

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -28,7 +28,7 @@ func (s *containerRouter) getContainersJSON(ctx context.Context, w http.Response
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
-	filter, err := filters.FromParam(r.Form.Get("filters"))
+	filter, err := filters.FromJSON(r.Form.Get("filters"))
 	if err != nil {
 		return err
 	}
@@ -588,7 +588,7 @@ func (s *containerRouter) postContainersPrune(ctx context.Context, w http.Respon
 		return err
 	}
 
-	pruneFilters, err := filters.FromParam(r.Form.Get("filters"))
+	pruneFilters, err := filters.FromJSON(r.Form.Get("filters"))
 	if err != nil {
 		return validationError{err}
 	}

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -302,7 +302,7 @@ func (s *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter, 
 		return err
 	}
 
-	imageFilters, err := filters.FromParam(r.Form.Get("filters"))
+	imageFilters, err := filters.FromJSON(r.Form.Get("filters"))
 	if err != nil {
 		return err
 	}
@@ -385,7 +385,7 @@ func (s *imageRouter) postImagesPrune(ctx context.Context, w http.ResponseWriter
 		return err
 	}
 
-	pruneFilters, err := filters.FromParam(r.Form.Get("filters"))
+	pruneFilters, err := filters.FromJSON(r.Form.Get("filters"))
 	if err != nil {
 		return err
 	}

--- a/api/server/router/network/filter.go
+++ b/api/server/router/network/filter.go
@@ -45,27 +45,27 @@ func filterNetworks(nws []types.NetworkResource, filter filters.Args) ([]types.N
 
 	displayNet := []types.NetworkResource{}
 	for _, nw := range nws {
-		if filter.Include("driver") {
+		if filter.Contains("driver") {
 			if !filter.ExactMatch("driver", nw.Driver) {
 				continue
 			}
 		}
-		if filter.Include("name") {
+		if filter.Contains("name") {
 			if !filter.Match("name", nw.Name) {
 				continue
 			}
 		}
-		if filter.Include("id") {
+		if filter.Contains("id") {
 			if !filter.Match("id", nw.ID) {
 				continue
 			}
 		}
-		if filter.Include("label") {
+		if filter.Contains("label") {
 			if !filter.MatchKVList("label", nw.Labels) {
 				continue
 			}
 		}
-		if filter.Include("scope") {
+		if filter.Contains("scope") {
 			if !filter.ExactMatch("scope", nw.Scope) {
 				continue
 			}
@@ -73,7 +73,7 @@ func filterNetworks(nws []types.NetworkResource, filter filters.Args) ([]types.N
 		displayNet = append(displayNet, nw)
 	}
 
-	if filter.Include("type") {
+	if filter.Contains("type") {
 		typeNet := []types.NetworkResource{}
 		errFilter := filter.WalkValues("type", func(fval string) error {
 			passList, err := filterNetworkByType(displayNet, fval)

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -37,7 +37,7 @@ func (n *networkRouter) getNetworksList(ctx context.Context, w http.ResponseWrit
 	}
 
 	filter := r.Form.Get("filters")
-	netFilters, err := filters.FromParam(filter)
+	netFilters, err := filters.FromJSON(filter)
 	if err != nil {
 		return err
 	}
@@ -489,7 +489,7 @@ func (n *networkRouter) postNetworksPrune(ctx context.Context, w http.ResponseWr
 		return err
 	}
 
-	pruneFilters, err := filters.FromParam(r.Form.Get("filters"))
+	pruneFilters, err := filters.FromJSON(r.Form.Get("filters"))
 	if err != nil {
 		return err
 	}

--- a/api/server/router/plugin/plugin_routes.go
+++ b/api/server/router/plugin/plugin_routes.go
@@ -290,7 +290,7 @@ func (pr *pluginRouter) listPlugins(ctx context.Context, w http.ResponseWriter, 
 		return err
 	}
 
-	pluginFilters, err := filters.FromParam(r.Form.Get("filters"))
+	pluginFilters, err := filters.FromJSON(r.Form.Get("filters"))
 	if err != nil {
 		return err
 	}

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -151,7 +151,7 @@ func (sr *swarmRouter) getServices(ctx context.Context, w http.ResponseWriter, r
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
-	filter, err := filters.FromParam(r.Form.Get("filters"))
+	filter, err := filters.FromJSON(r.Form.Get("filters"))
 	if err != nil {
 		return invalidRequestError{err}
 	}
@@ -277,7 +277,7 @@ func (sr *swarmRouter) getNodes(ctx context.Context, w http.ResponseWriter, r *h
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
-	filter, err := filters.FromParam(r.Form.Get("filters"))
+	filter, err := filters.FromJSON(r.Form.Get("filters"))
 	if err != nil {
 		return err
 	}
@@ -339,7 +339,7 @@ func (sr *swarmRouter) getTasks(ctx context.Context, w http.ResponseWriter, r *h
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
-	filter, err := filters.FromParam(r.Form.Get("filters"))
+	filter, err := filters.FromJSON(r.Form.Get("filters"))
 	if err != nil {
 		return err
 	}
@@ -367,7 +367,7 @@ func (sr *swarmRouter) getSecrets(ctx context.Context, w http.ResponseWriter, r 
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
-	filters, err := filters.FromParam(r.Form.Get("filters"))
+	filters, err := filters.FromJSON(r.Form.Get("filters"))
 	if err != nil {
 		return err
 	}
@@ -434,7 +434,7 @@ func (sr *swarmRouter) getConfigs(ctx context.Context, w http.ResponseWriter, r 
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
-	filters, err := filters.FromParam(r.Form.Get("filters"))
+	filters, err := filters.FromJSON(r.Form.Get("filters"))
 	if err != nil {
 		return err
 	}

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -127,7 +127,7 @@ func (s *systemRouter) getEvents(ctx context.Context, w http.ResponseWriter, r *
 		}
 	}
 
-	ef, err := filters.FromParam(r.Form.Get("filters"))
+	ef, err := filters.FromJSON(r.Form.Get("filters"))
 	if err != nil {
 		return err
 	}

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -72,7 +72,7 @@ func (v *volumeRouter) postVolumesPrune(ctx context.Context, w http.ResponseWrit
 		return err
 	}
 
-	pruneFilters, err := filters.FromParam(r.Form.Get("filters"))
+	pruneFilters, err := filters.FromJSON(r.Form.Get("filters"))
 	if err != nil {
 		return err
 	}

--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -337,6 +337,17 @@ func TestOnlyOneExactMatch(t *testing.T) {
 	}
 }
 
+func TestContains(t *testing.T) {
+	f := NewArgs()
+	if f.Contains("status") {
+		t.Fatal("Expected to not contain a status key, got true")
+	}
+	f.Add("status", "running")
+	if !f.Contains("status") {
+		t.Fatal("Expected to contain a status key, got false")
+	}
+}
+
 func TestInclude(t *testing.T) {
 	f := NewArgs()
 	if f.Include("status") {

--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -42,14 +42,14 @@ func TestParseArgsEdgeCase(t *testing.T) {
 	}
 }
 
-func TestToParam(t *testing.T) {
+func TestToJSON(t *testing.T) {
 	fields := map[string]map[string]bool{
 		"created":    {"today": true},
 		"image.name": {"ubuntu*": true, "*untu": true},
 	}
 	a := Args{fields: fields}
 
-	_, err := ToParam(a)
+	_, err := ToJSON(a)
 	if err != nil {
 		t.Errorf("failed to marshal the filters: %s", err)
 	}
@@ -80,7 +80,7 @@ func TestToParamWithVersion(t *testing.T) {
 	}
 }
 
-func TestFromParam(t *testing.T) {
+func TestFromJSON(t *testing.T) {
 	invalids := []string{
 		"anything",
 		"['a','list']",
@@ -103,14 +103,14 @@ func TestFromParam(t *testing.T) {
 	}
 
 	for _, invalid := range invalids {
-		if _, err := FromParam(invalid); err == nil {
+		if _, err := FromJSON(invalid); err == nil {
 			t.Fatalf("Expected an error with %v, got nothing", invalid)
 		}
 	}
 
 	for expectedArgs, matchers := range valid {
 		for _, json := range matchers {
-			args, err := FromParam(json)
+			args, err := FromJSON(json)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -136,11 +136,11 @@ func TestFromParam(t *testing.T) {
 
 func TestEmpty(t *testing.T) {
 	a := Args{}
-	v, err := ToParam(a)
+	v, err := ToJSON(a)
 	if err != nil {
 		t.Errorf("failed to marshal the filters: %s", err)
 	}
-	v1, err := FromParam(v)
+	v1, err := FromJSON(v)
 	if err != nil {
 		t.Errorf("%s", err)
 	}

--- a/client/config_list.go
+++ b/client/config_list.go
@@ -18,7 +18,7 @@ func (cli *Client) ConfigList(ctx context.Context, options types.ConfigListOptio
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filters)
+		filterJSON, err := filters.ToJSON(options.Filters)
 		if err != nil {
 			return nil, err
 		}

--- a/client/image_search.go
+++ b/client/image_search.go
@@ -21,7 +21,7 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options types.I
 	query.Set("limit", fmt.Sprintf("%d", options.Limit))
 
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filters)
+		filterJSON, err := filters.ToJSON(options.Filters)
 		if err != nil {
 			return results, err
 		}

--- a/client/node_list.go
+++ b/client/node_list.go
@@ -15,7 +15,7 @@ func (cli *Client) NodeList(ctx context.Context, options types.NodeListOptions) 
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filters)
+		filterJSON, err := filters.ToJSON(options.Filters)
 
 		if err != nil {
 			return nil, err

--- a/client/secret_list.go
+++ b/client/secret_list.go
@@ -18,7 +18,7 @@ func (cli *Client) SecretList(ctx context.Context, options types.SecretListOptio
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filters)
+		filterJSON, err := filters.ToJSON(options.Filters)
 		if err != nil {
 			return nil, err
 		}

--- a/client/service_list.go
+++ b/client/service_list.go
@@ -15,7 +15,7 @@ func (cli *Client) ServiceList(ctx context.Context, options types.ServiceListOpt
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filters)
+		filterJSON, err := filters.ToJSON(options.Filters)
 		if err != nil {
 			return nil, err
 		}

--- a/client/task_list.go
+++ b/client/task_list.go
@@ -15,7 +15,7 @@ func (cli *Client) TaskList(ctx context.Context, options types.TaskListOptions) 
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filters)
+		filterJSON, err := filters.ToJSON(options.Filters)
 		if err != nil {
 			return nil, err
 		}

--- a/client/utils.go
+++ b/client/utils.go
@@ -24,7 +24,7 @@ func getDockerOS(serverHeader string) string {
 func getFiltersQuery(f filters.Args) (url.Values, error) {
 	query := url.Values{}
 	if f.Len() > 0 {
-		filterJSON, err := filters.ToParam(f)
+		filterJSON, err := filters.ToJSON(f)
 		if err != nil {
 			return query, err
 		}

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -74,7 +74,7 @@ func (c *Cluster) GetServices(options apitypes.ServiceListOptions) ([]types.Serv
 	services := make([]types.Service, 0, len(r.Services))
 
 	for _, service := range r.Services {
-		if options.Filters.Include("mode") {
+		if options.Filters.Contains("mode") {
 			var mode string
 			switch service.Spec.GetMode().(type) {
 			case *swarmapi.ServiceSpec_Global:

--- a/daemon/cluster/tasks.go
+++ b/daemon/cluster/tasks.go
@@ -15,7 +15,7 @@ func (c *Cluster) GetTasks(options apitypes.TaskListOptions) ([]types.Task, erro
 
 	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
 		filterTransform := func(filter filters.Args) error {
-			if filter.Include("service") {
+			if filter.Contains("service") {
 				serviceFilters := filter.Get("service")
 				for _, serviceFilter := range serviceFilters {
 					service, err := getService(ctx, state.controlClient, serviceFilter, false)
@@ -26,7 +26,7 @@ func (c *Cluster) GetTasks(options apitypes.TaskListOptions) ([]types.Task, erro
 					filter.Add("service", service.ID)
 				}
 			}
-			if filter.Include("node") {
+			if filter.Contains("node") {
 				nodeFilters := filter.Get("node")
 				for _, nodeFilter := range nodeFilters {
 					node, err := getNode(ctx, state.controlClient, nodeFilter)
@@ -37,7 +37,7 @@ func (c *Cluster) GetTasks(options apitypes.TaskListOptions) ([]types.Task, erro
 					filter.Add("node", node.ID)
 				}
 			}
-			if !filter.Include("runtime") {
+			if !filter.Contains("runtime") {
 				// default to only showing container tasks
 				filter.Add("runtime", "container")
 				filter.Add("runtime", "")

--- a/daemon/events/filter.go
+++ b/daemon/events/filter.go
@@ -49,14 +49,14 @@ func (ef *Filter) filterContains(field string, values map[string]struct{}) bool 
 }
 
 func (ef *Filter) matchScope(scope string) bool {
-	if !ef.filter.Include("scope") {
+	if !ef.filter.Contains("scope") {
 		return true
 	}
 	return ef.filter.ExactMatch("scope", scope)
 }
 
 func (ef *Filter) matchLabels(attributes map[string]string) bool {
-	if !ef.filter.Include("label") {
+	if !ef.filter.Contains("label") {
 		return true
 	}
 	return ef.filter.MatchKVList("label", attributes)

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -67,7 +67,7 @@ func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs
 		return nil, err
 	}
 
-	if imageFilters.Include("dangling") {
+	if imageFilters.Contains("dangling") {
 		if imageFilters.ExactMatch("dangling", "true") {
 			danglingOnly = true
 		} else if !imageFilters.ExactMatch("dangling", "false") {
@@ -116,7 +116,7 @@ func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs
 			}
 		}
 
-		if imageFilters.Include("label") {
+		if imageFilters.Contains("label") {
 			// Very old image that do not have image.Config (or even labels)
 			if img.Config == nil {
 				continue
@@ -150,7 +150,7 @@ func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs
 		newImage := newImage(img, size)
 
 		for _, ref := range daemon.referenceStore.References(id.Digest()) {
-			if imageFilters.Include("reference") {
+			if imageFilters.Contains("reference") {
 				var found bool
 				var matchErr error
 				for _, pattern := range imageFilters.Get("reference") {
@@ -173,11 +173,11 @@ func (daemon *Daemon) Images(imageFilters filters.Args, all bool, withExtraAttrs
 		if newImage.RepoDigests == nil && newImage.RepoTags == nil {
 			if all || len(daemon.stores[platform].imageStore.Children(id)) == 0 {
 
-				if imageFilters.Include("dangling") && !danglingOnly {
+				if imageFilters.Contains("dangling") && !danglingOnly {
 					//dangling=false case, so dangling image is not needed
 					continue
 				}
-				if imageFilters.Include("reference") { // skip images with no references if filtering by reference
+				if imageFilters.Contains("reference") { // skip images with no references if filtering by reference
 					continue
 				}
 				newImage.RepoDigests = []string{"<none>@<none>"}

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -585,7 +585,7 @@ func (daemon *Daemon) Volumes(filter string) ([]*types.Volume, []string, error) 
 	var (
 		volumesOut []*types.Volume
 	)
-	volFilters, err := filters.FromParam(filter)
+	volFilters, err := filters.FromJSON(filter)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -276,7 +276,7 @@ func (daemon *Daemon) foldFilter(view container.View, config *types.ContainerLis
 	}
 
 	var taskFilter, isTask bool
-	if psFilters.Include("is-task") {
+	if psFilters.Contains("is-task") {
 		if psFilters.ExactMatch("is-task", "true") {
 			taskFilter = true
 			isTask = true
@@ -319,7 +319,7 @@ func (daemon *Daemon) foldFilter(view container.View, config *types.ContainerLis
 
 	imagesFilter := map[image.ID]bool{}
 	var ancestorFilter bool
-	if psFilters.Include("ancestor") {
+	if psFilters.Contains("ancestor") {
 		ancestorFilter = true
 		psFilters.WalkValues("ancestor", func(ancestor string) error {
 			id, platform, err := daemon.GetImageIDAndPlatform(ancestor)
@@ -465,7 +465,7 @@ func includeContainerInList(container *container.Snapshot, ctx *listContext) ite
 		return excludeContainer
 	}
 
-	if ctx.filters.Include("volume") {
+	if ctx.filters.Contains("volume") {
 		volumesByName := make(map[string]types.MountPoint)
 		for _, m := range container.Mounts {
 			if m.Name != "" {
@@ -509,7 +509,7 @@ func includeContainerInList(container *container.Snapshot, ctx *listContext) ite
 		networkExist = errors.New("container part of network")
 		noNetworks   = errors.New("container is not part of any networks")
 	)
-	if ctx.filters.Include("network") {
+	if ctx.filters.Contains("network") {
 		err := ctx.filters.WalkValues("network", func(value string) error {
 			if container.NetworkSettings == nil {
 				return noNetworks
@@ -627,17 +627,17 @@ func (daemon *Daemon) filterVolumes(vols []volume.Volume, filter filters.Args) (
 
 	var retVols []volume.Volume
 	for _, vol := range vols {
-		if filter.Include("name") {
+		if filter.Contains("name") {
 			if !filter.Match("name", vol.Name()) {
 				continue
 			}
 		}
-		if filter.Include("driver") {
+		if filter.Contains("driver") {
 			if !filter.ExactMatch("driver", vol.DriverName()) {
 				continue
 			}
 		}
-		if filter.Include("label") {
+		if filter.Contains("label") {
 			v, ok := vol.(volume.DetailedVolume)
 			if !ok {
 				continue
@@ -649,7 +649,7 @@ func (daemon *Daemon) filterVolumes(vols []volume.Volume, filter filters.Args) (
 		retVols = append(retVols, vol)
 	}
 	danglingOnly := false
-	if filter.Include("dangling") {
+	if filter.Contains("dangling") {
 		if filter.ExactMatch("dangling", "true") || filter.ExactMatch("dangling", "1") {
 			danglingOnly = true
 		} else if !filter.ExactMatch("dangling", "false") && !filter.ExactMatch("dangling", "0") {

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -182,7 +182,7 @@ func (daemon *Daemon) ImagesPrune(ctx context.Context, pruneFilters filters.Args
 	rep := &types.ImagesPruneReport{}
 
 	danglingOnly := true
-	if pruneFilters.Include("dangling") {
+	if pruneFilters.Contains("dangling") {
 		if pruneFilters.ExactMatch("dangling", "false") || pruneFilters.ExactMatch("dangling", "0") {
 			danglingOnly = false
 		} else if !pruneFilters.ExactMatch("dangling", "true") && !pruneFilters.ExactMatch("dangling", "1") {
@@ -440,7 +440,7 @@ func (daemon *Daemon) NetworksPrune(ctx context.Context, pruneFilters filters.Ar
 
 func getUntilFromPruneFilters(pruneFilters filters.Args) (time.Time, error) {
 	until := time.Time{}
-	if !pruneFilters.Include("until") {
+	if !pruneFilters.Contains("until") {
 		return until, nil
 	}
 	untilFilters := pruneFilters.Get("until")
@@ -464,8 +464,8 @@ func matchLabels(pruneFilters filters.Args, labels map[string]string) bool {
 		return false
 	}
 	// By default MatchKVList will return true if field (like 'label!') does not exist
-	// So we have to add additional Include("label!") check
-	if pruneFilters.Include("label!") {
+	// So we have to add additional Contains("label!") check
+	if pruneFilters.Contains("label!") {
 		if pruneFilters.MatchKVList("label!", labels) {
 			return false
 		}

--- a/daemon/search.go
+++ b/daemon/search.go
@@ -23,7 +23,7 @@ func (daemon *Daemon) SearchRegistryForImages(ctx context.Context, filtersArgs s
 	authConfig *types.AuthConfig,
 	headers map[string][]string) (*registrytypes.SearchResults, error) {
 
-	searchFilters, err := filters.FromParam(filtersArgs)
+	searchFilters, err := filters.FromJSON(filtersArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/search.go
+++ b/daemon/search.go
@@ -33,21 +33,21 @@ func (daemon *Daemon) SearchRegistryForImages(ctx context.Context, filtersArgs s
 
 	var isAutomated, isOfficial bool
 	var hasStarFilter = 0
-	if searchFilters.Include("is-automated") {
+	if searchFilters.Contains("is-automated") {
 		if searchFilters.UniqueExactMatch("is-automated", "true") {
 			isAutomated = true
 		} else if !searchFilters.UniqueExactMatch("is-automated", "false") {
 			return nil, invalidFilter{"is-automated", searchFilters.Get("is-automated")}
 		}
 	}
-	if searchFilters.Include("is-official") {
+	if searchFilters.Contains("is-official") {
 		if searchFilters.UniqueExactMatch("is-official", "true") {
 			isOfficial = true
 		} else if !searchFilters.UniqueExactMatch("is-official", "false") {
 			return nil, invalidFilter{"is-official", searchFilters.Get("is-official")}
 		}
 	}
-	if searchFilters.Include("stars") {
+	if searchFilters.Contains("stars") {
 		hasStars := searchFilters.Get("stars")
 		for _, hasStar := range hasStars {
 			iHasStar, err := strconv.Atoi(hasStar)
@@ -67,17 +67,17 @@ func (daemon *Daemon) SearchRegistryForImages(ctx context.Context, filtersArgs s
 
 	filteredResults := []registrytypes.SearchResult{}
 	for _, result := range unfilteredResult.Results {
-		if searchFilters.Include("is-automated") {
+		if searchFilters.Contains("is-automated") {
 			if isAutomated != result.IsAutomated {
 				continue
 			}
 		}
-		if searchFilters.Include("is-official") {
+		if searchFilters.Contains("is-official") {
 			if isOfficial != result.IsOfficial {
 				continue
 			}
 		}
-		if searchFilters.Include("stars") {
+		if searchFilters.Contains("stars") {
 			if result.StarCount < hasStarFilter {
 				continue
 			}

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -282,7 +282,7 @@ func getNetworkIDByName(c *check.C, name string) string {
 		filterArgs = filters.NewArgs()
 	)
 	filterArgs.Add("name", name)
-	filterJSON, err := filters.ToParam(filterArgs)
+	filterJSON, err := filters.ToJSON(filterArgs)
 	c.Assert(err, checker.IsNil)
 	v.Set("filters", filterJSON)
 

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -365,7 +365,7 @@ func (pm *Manager) List(pluginFilters filters.Args) ([]types.Plugin, error) {
 
 	enabledOnly := false
 	disabledOnly := false
-	if pluginFilters.Include("enabled") {
+	if pluginFilters.Contains("enabled") {
 		if pluginFilters.ExactMatch("enabled", "true") {
 			enabledOnly = true
 		} else if pluginFilters.ExactMatch("enabled", "false") {
@@ -386,7 +386,7 @@ next:
 		if disabledOnly && p.PluginObj.Enabled {
 			continue
 		}
-		if pluginFilters.Include("capability") {
+		if pluginFilters.Contains("capability") {
 			for _, f := range p.GetTypes() {
 				if !pluginFilters.Match("capability", f.Capability) {
 					continue next


### PR DESCRIPTION
Commit https://github.com/moby/moby/commit/065118390a3ecaf0dbd2fa752d54d43f8f1e8ec6 (https://github.com/moby/moby/pull/34756) deprecated various filter functions in favor of new ones.

This PR replaces:

- `filters.Include()` with `filters.Contains()`
- `filters.ToParam()`, `filters.FromParam()` with `ToJSON()`, `FromJSON()`


ping @vdemeester @dnephin 