### PR TITLE
ContainerWait on remove: don't stuck on rm fail

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5723,6 +5723,13 @@ paths:
                 description: "Exit code of the container"
                 type: "integer"
                 x-nullable: false
+              Error:
+                description: "container waiting error, if any"
+                type: "object"
+                properties:
+                  Message:
+                    description: "Details of an error"
+                    type: "string"
         404:
           description: "no such container"
           schema:

--- a/api/types/container/container_wait.go
+++ b/api/types/container/container_wait.go
@@ -7,9 +7,21 @@ package container
 // See hack/generate-swagger-api.sh
 // ----------------------------------------------------------------------------
 
+// ContainerWaitOKBodyError container waiting error, if any
+// swagger:model ContainerWaitOKBodyError
+type ContainerWaitOKBodyError struct {
+
+	// Details of an error
+	Message string `json:"Message,omitempty"`
+}
+
 // ContainerWaitOKBody container wait o k body
 // swagger:model ContainerWaitOKBody
 type ContainerWaitOKBody struct {
+
+	// error
+	// Required: true
+	Error *ContainerWaitOKBodyError `json:"Error"`
 
 	// Exit code of the container
 	// Required: true

--- a/container/state.go
+++ b/container/state.go
@@ -29,7 +29,7 @@ type State struct {
 	Dead              bool
 	Pid               int
 	ExitCodeValue     int    `json:"ExitCode"`
-	ErrorMsg          string `json:"Error"` // contains last known error when starting the container
+	ErrorMsg          string `json:"Error"` // contains last known error during container start or remove
 	StartedAt         time.Time
 	FinishedAt        time.Time
 	Health            *Health
@@ -319,7 +319,10 @@ func (s *State) SetRestarting(exitStatus *ExitStatus) {
 // know the error that occurred when container transits to another state
 // when inspecting it
 func (s *State) SetError(err error) {
-	s.ErrorMsg = err.Error()
+	s.ErrorMsg = ""
+	if err != nil {
+		s.ErrorMsg = err.Error()
+	}
 }
 
 // IsPaused returns whether the container is paused or not.
@@ -385,8 +388,18 @@ func (s *State) IsDead() bool {
 // closes the internal waitRemove channel to unblock callers waiting for a
 // container to be removed.
 func (s *State) SetRemoved() {
+	s.SetRemovalError(nil)
+}
+
+// SetRemovalError is to be called in case a container remove failed.
+// It sets an error and closes the internal waitRemove channel to unblock
+// callers waiting for the container to be removed.
+func (s *State) SetRemovalError(err error) {
+	s.SetError(err)
 	s.Lock()
 	close(s.waitRemove) // Unblock those waiting on remove.
+	// Recreate the channel so next ContainerWait will work
+	s.waitRemove = make(chan struct{})
 	s.Unlock()
 }
 

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,12 +17,19 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.34](https://docs.docker.com/engine/api/v1.34/) documentation
 
+* `POST /containers/(name)/wait?condition=removed` now also also returns
+  in case of container removal failure. A pointer to a structure named
+  `Error` added to the response JSON in order to indicate a failure.
+  If `Error` is `null`, container removal has succeeded, otherwise
+  the test of an error message indicating why container removal has failed
+  is available from `Error.Message` field.
+
 ## v1.33 API changes
 
 [Docker Engine API v1.33](https://docs.docker.com/engine/api/v1.33/) documentation
 
 * `GET /events` now supports filtering 4 more kinds of events: `config`, `node`,
-`secret` and `service`. 
+`secret` and `service`.
 
 ## v1.32 API changes
 


### PR DESCRIPTION
Currently, if a container removal has failed for some reason, any client waiting for removal (e.g. `docker run --rm`) is stuck, waiting for removal to succeed while it has failed already. For more details and the reproducer, please check https://github.com/moby/moby/issues/34945

This commit addresses that by allowing `ContainerWait()` with `container.WaitCondition == "removed"` argument to return an error in case of removal failure. The `ContainerWaitOKBody` response returned to a client is amended with an error message, and the `Client.ContainerWait()` is modified to return the error, if any, to the client.

Note that this feature is only available for API version >= 1.34. The old behavior (i.e. do not return from wait on removal error) is being kept for current and older clients, except for the added empty `Error` string field in returned JSON, which to my best knowledge should not cause any compatibility problems.

Now, docker-cli would need a separate commit to bump the API to 1.34 and to show an error returned, if any. The current version of docker-cli will work as is.

* [v2: recreate the waitRemove channel after closing]
* [v3: document new api; keep legacy behavior for older clients]