### PR TITLE
Make client.ContainerWait easier and safer to use

### DIFF
--- a/client/interface.go
+++ b/client/interface.go
@@ -68,7 +68,7 @@ type ContainerAPIClient interface {
 	ContainerTop(ctx context.Context, container string, arguments []string) (container.ContainerTopOKBody, error)
 	ContainerUnpause(ctx context.Context, container string) error
 	ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) (container.ContainerUpdateOKBody, error)
-	ContainerWait(ctx context.Context, container string, condition container.WaitCondition) (<-chan container.ContainerWaitOKBody, <-chan error)
+	ContainerWait(ctx context.Context, container string, condition container.WaitCondition, ackChan chan<- struct{}) (container.ContainerWaitOKBody, error)
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
 	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (types.ContainersPruneReport, error)

--- a/hack/integration-cli-on-swarm/agent/worker/executor.go
+++ b/hack/integration-cli-on-swarm/agent/worker/executor.go
@@ -83,13 +83,8 @@ func privilegedTestChunkExecutor(autoRemove bool) testChunkExecutor {
 		}
 		var b bytes.Buffer
 		teeContainerStream(&b, os.Stdout, os.Stderr, stream)
-		resultC, errC := cli.ContainerWait(context.Background(), id, "")
-		select {
-		case err := <-errC:
-			return 0, "", err
-		case result := <-resultC:
-			return result.StatusCode, b.String(), nil
-		}
+		result, err := cli.ContainerWait(context.Background(), id, "", nil)
+		return result.StatusCode, b.String(), err
 	}
 }
 

--- a/hack/integration-cli-on-swarm/host/host.go
+++ b/hack/integration-cli-on-swarm/host/host.go
@@ -188,11 +188,9 @@ func waitForContainerCompletion(cli *client.Client, stdout, stderr io.Writer, co
 	}
 	stdcopy.StdCopy(stdout, stderr, stream)
 	stream.Close()
-	resultC, errC := cli.ContainerWait(context.Background(), containerID, "")
-	select {
-	case err := <-errC:
+	result, err := cli.ContainerWait(context.Background(), containerID, "", nil)
+	if err != nil {
 		return 1, err
-	case result := <-resultC:
-		return result.StatusCode, nil
 	}
+	return result.StatusCode, nil
 }

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1025,14 +1025,10 @@ func (s *DockerSuite) TestContainerAPIWait(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cli.Close()
 
-	waitresC, errC := cli.ContainerWait(context.Background(), name, "")
+	waitres, err := cli.ContainerWait(context.Background(), name, "", nil)
 
-	select {
-	case err = <-errC:
-		c.Assert(err, checker.IsNil)
-	case waitres := <-waitresC:
-		c.Assert(waitres.StatusCode, checker.Equals, int64(0))
-	}
+	c.Assert(err, checker.IsNil)
+	c.Assert(waitres.StatusCode, checker.Equals, int64(0))
 }
 
 func (s *DockerSuite) TestContainerAPICopyNotExistsAnyMore(c *check.C) {


### PR DESCRIPTION
The caller of this function needed to be extra careful
by making sure they are draining all the return channels
in a specific order to avoid leaking goroutines.

This commit introduces ackChan as a parameter to allow
for the same behavior the previous signature was designed for.

Signed-off-by: Tibor Vass <tibor@docker.com>
