### PR TITLE
Changes error check from NotNil to IsNil

### DIFF
--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -152,7 +152,7 @@ func (s *DockerSuite) TestRmiImageIDForceWithRunningContainersAndMultipleTags(c 
 
 	out, _, err := dockerCmdWithError("rmi", "-f", imgID)
 	// rmi -f should not delete image with running containers
-	c.Assert(err, checker.NotNil)
+	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, "(cannot be forced) - image is being used by running container")
 }
 
@@ -245,7 +245,7 @@ func (s *DockerSuite) TestRmiContainerImageNotFound(c *check.C) {
 	// Try to remove the image of the running container and see if it fails as expected.
 	out, _, err := dockerCmdWithError("rmi", "-f", imageIds[0])
 	// The image of the running container should not be removed.
-	c.Assert(err, checker.NotNil)
+	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, "image is being used by running container", check.Commentf("out: %s", out))
 }
 


### PR DESCRIPTION
# Overview:
rmi -f always returns a 0 exit code so these tests needed to be changed
accordingly.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Changed the assertions from NotNil to IsNil for the `rmi -f` tests

**- How I did it**
```diff
diff --git a/integration-cli/docker_cli_rmi_test.go b/integration-cli/docker_cli_rmi_test.go
index 52c8837d2..2c6829925 100644
--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -152,7 +152,7 @@ func (s *DockerSuite) TestRmiImageIDForceWithRunningContainersAndMultipleTags(c

        out, _, err := dockerCmdWithError("rmi", "-f", imgID)
        // rmi -f should not delete image with running containers
-       c.Assert(err, checker.NotNil)
+       c.Assert(err, checker.IsNil)
        c.Assert(out, checker.Contains, "(cannot be forced) - image is being used by running container")
 }

@@ -245,7 +245,7 @@ func (s *DockerSuite) TestRmiContainerImageNotFound(c *check.C) {
        // Try to remove the image of the running container and see if it fails as expected.
        out, _, err := dockerCmdWithError("rmi", "-f", imageIds[0])
        // The image of the running container should not be removed.
-       c.Assert(err, checker.NotNil)
+       c.Assert(err, checker.IsNil)
        c.Assert(out, checker.Contains, "image is being used by running container", check.Commentf("out: %s", out))
 }
```

**- How to verify it**
* We've had this fix in for Docker CE 17.09 and it remedies the test failures we see when testing against a Docker CLI that's greater than 17.06.0-ce.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Changed `rmi` tests to be more up to date with the current Docker CLI

**- A picture of a cute animal (not mandatory but encouraged)**
![Bird with arms](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTkp6Qr4VOUgSMpE197U6P52eztwHvR6aWIALHn4W9lRKIbNWgY)
