### PR TITLE
Fix integration-cli tests for updated notary behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary and notary-server
-ENV NOTARY_VERSION v0.5.0
+ENV NOTARY_VERSION v0.5.1
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -98,7 +98,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary and notary-server
-ENV NOTARY_VERSION v0.5.0
+ENV NOTARY_VERSION v0.5.1
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -91,7 +91,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary and notary-server
-ENV NOTARY_VERSION v0.5.0
+ENV NOTARY_VERSION v0.5.1
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -89,7 +89,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary and notary-server
-ENV NOTARY_VERSION v0.5.0
+ENV NOTARY_VERSION v0.5.1
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -83,7 +83,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary and notary-server
-ENV NOTARY_VERSION v0.5.0
+ENV NOTARY_VERSION v0.5.1
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/hack/dockerfile/install-binaries.sh
+++ b/hack/dockerfile/install-binaries.sh
@@ -53,25 +53,12 @@ install_dockercli() {
 
 	arch=$(uname -m)
 	# No official release of these platforms
-	if [[ "$arch" != "x86_64" ]] && [[ "$arch" != "s390x" ]]; then
-		build_dockercli
-		return
-	fi
-
-	url=https://download.docker.com/linux/static
-	curl -Ls $url/$DOCKERCLI_CHANNEL/$arch/docker-$DOCKERCLI_VERSION.tgz | \
-	tar -xz docker/docker
-	mv docker/docker /usr/local/bin/
-	rmdir docker
+	build_dockercli
 }
 
 build_dockercli() {
 	DOCKERCLI_VERSION=${DOCKERCLI_VERSION:-17.06.0-ce}
-	git clone https://github.com/docker/docker-ce "$GOPATH/tmp/docker-ce"
-	cd "$GOPATH/tmp/docker-ce"
-	git checkout -q "v$DOCKERCLI_VERSION"
-	mkdir -p "$GOPATH/src/github.com/docker"
-	mv components/cli "$GOPATH/src/github.com/docker/cli"
+	git clone https://github.com/docker/cli "$GOPATH/src/github.com/docker/cli"
 	go build -o /usr/local/bin/docker github.com/docker/cli/cmd/docker
 }
 

--- a/integration-cli/docker_cli_pull_trusted_test.go
+++ b/integration-cli/docker_cli_pull_trusted_test.go
@@ -144,7 +144,7 @@ func (s *DockerTrustSuite) TestTrustedPullReadsFromReleasesRole(c *check.C) {
 
 	// Try pull, check we retrieve from targets role
 	cli.Docker(cli.Args("-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
-		Err: "retrieving target for targets role",
+		Err: "successfully verified cached targets",
 	})
 
 	// Now we'll create the releases role, and try pushing and pulling
@@ -155,7 +155,7 @@ func (s *DockerTrustSuite) TestTrustedPullReadsFromReleasesRole(c *check.C) {
 	// try a pull, check that we can still pull because we can still read the
 	// old tag in the targets role
 	cli.Docker(cli.Args("-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
-		Err: "retrieving target for targets role",
+		Err: "successfully verified downloaded targets",
 	})
 
 	// try a pull -a, check that it succeeds because we can still pull from the
@@ -169,7 +169,7 @@ func (s *DockerTrustSuite) TestTrustedPullReadsFromReleasesRole(c *check.C) {
 
 	// Try pull, check we retrieve from targets/releases role
 	cli.Docker(cli.Args("-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
-		Err: "retrieving target for targets/releases role",
+		Err: "successfully verified cached targets/releases",
 	})
 
 	// Create another delegation that we'll sign with
@@ -183,7 +183,7 @@ func (s *DockerTrustSuite) TestTrustedPullReadsFromReleasesRole(c *check.C) {
 
 	// Try pull, check we retrieve from targets/releases role
 	cli.Docker(cli.Args("-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
-		Err: "retrieving target for targets/releases role",
+		Err: "successfully verified cached targets/releases",
 	})
 }
 
@@ -210,7 +210,7 @@ func (s *DockerTrustSuite) TestTrustedPullIgnoresOtherDelegationRoles(c *check.C
 	cli.DockerCmd(c, "tag", "busybox", targetName)
 	cli.Docker(cli.Args("-D", "pull", repoName), trustedCmd).Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err:      "No trust data for",
+		Err:      "No trusted tags for",
 	})
 
 	// try a pull -a: we should fail since pull will only pull from the targets/releases

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -373,8 +373,12 @@ func (s *DockerTrustSuite) TestTrustedPushWithIncorrectPassphraseForNonRoot(c *c
 	// Push with default passphrases
 	cli.Docker(cli.Args("push", repoName), trustedCmd).Assert(c, SuccessSigningAndPushing)
 
+	repoName2 := fmt.Sprintf("%v/dockercliincorretpwd/trusted:blue", privateRegistryURL)
+	// tag the image and upload it to the private registry
+	cli.DockerCmd(c, "tag", "busybox", repoName2)
+
 	// Push with wrong passphrases
-	cli.Docker(cli.Args("push", repoName), trustedCmdWithPassphrases("12345678", "87654321")).Assert(c, icmd.Expected{
+	cli.Docker(cli.Args("push", repoName2), trustedCmdWithPassphrases("12345678", "87654321")).Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "could not find necessary signing keys",
 	})

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -294,10 +294,10 @@ func (s *DockerTrustSuite) TestTrustedPush(c *check.C) {
 	})
 
 	// Assert that we rotated the snapshot key to the server by checking our local keystore
-	contents, err := ioutil.ReadDir(filepath.Join(config.Dir(), "trust/private/tuf_keys", privateRegistryURL, "dockerclitrusted/pushtest"))
+	contents, err := ioutil.ReadDir(filepath.Join(config.Dir(), "trust/private"))
 	c.Assert(err, check.IsNil, check.Commentf("Unable to read local tuf key files"))
-	// Check that we only have 1 key (targets key)
-	c.Assert(contents, checker.HasLen, 1)
+	// Check that we only have 2 keys (root, targets key)
+	c.Assert(contents, checker.HasLen, 2)
 }
 
 func (s *DockerTrustSuite) TestTrustedPushWithEnvPasswords(c *check.C) {


### PR DESCRIPTION
Notary has updated to pkcs8 keys and has updated its debug logs, which has necessitated the need for updating our whitebox tests.  Also bumped Notary to 0.5.1 in testing for good measure.

Most importantly: the changes necessitated in these tests are in the newer Notary versions (0.5.0+) but not in previous ones, so I've added a commit to always build from `docker/cli` master to demonstrate success.
I'm not sure what is desired here, please advise what you think makes most sense cc @andrewhsu @vieux @endophage 