### PR TITLE
Add ResourceReference to task spec

### DIFF
--- a/api/types/swarm/task.go
+++ b/api/types/swarm/task.go
@@ -61,10 +61,11 @@ type TaskSpec struct {
 	ContainerSpec *ContainerSpec      `json:",omitempty"`
 	PluginSpec    *runtime.PluginSpec `json:",omitempty"`
 
-	Resources     *ResourceRequirements     `json:",omitempty"`
-	RestartPolicy *RestartPolicy            `json:",omitempty"`
-	Placement     *Placement                `json:",omitempty"`
-	Networks      []NetworkAttachmentConfig `json:",omitempty"`
+	Resources          *ResourceRequirements     `json:",omitempty"`
+	ResourceReferences []ResourceReference       `json:",omitempty"`
+	RestartPolicy      *RestartPolicy            `json:",omitempty"`
+	Placement          *Placement                `json:",omitempty"`
+	Networks           []NetworkAttachmentConfig `json:",omitempty"`
 
 	// LogDriver specifies the LogDriver to use for tasks created from this
 	// spec. If not present, the one on cluster default on swarm.Spec will be
@@ -114,6 +115,24 @@ type DiscreteGenericResource struct {
 type ResourceRequirements struct {
 	Limits       *Resources `json:",omitempty"`
 	Reservations *Resources `json:",omitempty"`
+}
+
+// ResourceType represent the resource type
+type ResourceType string
+
+const (
+	// ResourceTypeTask is the task resource type
+	ResourceTypeTask ResourceType = "task"
+	// ResourceTypeSecret is the secret resource type
+	ResourceTypeSecret ResourceType = "secret"
+	// ResourceTypeConfig is the config resource type
+	ResourceTypeConfig ResourceType = "config"
+)
+
+// ResourceReference represents resources references by a task.
+type ResourceReference struct {
+	ResourceID   string       `json:",omitempty"`
+	ResourceType ResourceType `json:",omitempty"`
 }
 
 // Placement represents orchestration parameters.


### PR DESCRIPTION
Add missing `ResourceReference` as part of the swarmapi conversion

This is required for populating the secret reference to swarm plugins.

docker/swarmkit#2380

Signed-off-by: Liron Levin <liron@twistlock.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

