### PR TITLE
Make log timestamp configurable using timezone

### DIFF
--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -279,8 +279,9 @@ const (
 
 // LogConfig represents the logging configuration of the container.
 type LogConfig struct {
-	Type   string
-	Config map[string]string
+	Type     string
+	Timezone string
+	Config   map[string]string
 }
 
 // Resources contains container's resources (cgroups config, ulimits...)

--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -49,6 +49,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.Var(opts.NewListOptsRef(&conf.DNSSearch, opts.ValidateDNSSearch), "dns-search", "DNS search domains to use")
 	flags.Var(opts.NewNamedListOptsRef("labels", &conf.Labels, opts.ValidateLabel), "label", "Set key=value labels to the daemon")
 	flags.StringVar(&conf.LogConfig.Type, "log-driver", "json-file", "Default driver for container logs")
+	flags.StringVar(&conf.LogConfig.Timezone, "log-timezone", "", "Default log driver timestamp for containers")
 	flags.Var(opts.NewNamedMapOpts("log-opts", conf.LogConfig.Config, nil), "log-opt", "Default log driver options for containers")
 	flags.StringVar(&conf.ClusterAdvertise, "cluster-advertise", "", "Address or interface name to advertise")
 	flags.StringVar(&conf.ClusterStore, "cluster-store", "", "URL of the distributed storage backend")

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -105,8 +105,8 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 		return fmt.Errorf("Failed to set umask: %v", err)
 	}
 
-	if len(cli.LogConfig.Config) > 0 {
-		if err := logger.ValidateLogOpts(cli.LogConfig.Type, cli.LogConfig.Config); err != nil {
+	if len(cli.LogConfig.Config) > 0 || cli.LogConfig.Timezone != "" {
+		if err := logger.ValidateLogOpts(cli.LogConfig.Type, cli.LogConfig.Config, cli.LogConfig.Timezone); err != nil {
 			return fmt.Errorf("Failed to set log opts: %v", err)
 		}
 	}

--- a/container/container.go
+++ b/container/container.go
@@ -962,7 +962,16 @@ func (container *Container) startLogging() error {
 		return fmt.Errorf("failed to initialize logging driver: %v", err)
 	}
 
-	copier := logger.NewCopier(map[string]io.Reader{"stdout": container.StdoutPipe(), "stderr": container.StderrPipe()}, l)
+	loc := time.UTC
+	if container.HostConfig.LogConfig.Timezone != "" {
+		var err error
+		loc, err = time.LoadLocation(container.HostConfig.LogConfig.Timezone)
+		if err != nil {
+			return err
+		}
+	}
+
+	copier := logger.NewCopier(map[string]io.Reader{"stdout": container.StdoutPipe(), "stderr": container.StderrPipe()}, l, loc)
 	container.LogCopier = copier
 	copier.Run()
 	container.LogDriver = l

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -59,8 +59,9 @@ var flatOptions = map[string]bool{
 // It includes json tags to deserialize configuration from a file
 // using the same names that the flags in the command line use.
 type LogConfig struct {
-	Type   string            `json:"log-driver,omitempty"`
-	Config map[string]string `json:"log-opts,omitempty"`
+	Type     string            `json:"log-driver,omitempty"`
+	Timezone string            `json:"log-timezone,omitempty"`
+	Config   map[string]string `json:"log-opts,omitempty"`
 }
 
 // commonBridgeConfig stores all the platform-common bridge driver specific

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -793,8 +793,9 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 	d.idIndex = truncindex.NewTruncIndex([]string{})
 	d.statsCollector = d.newStatsCollector(1 * time.Second)
 	d.defaultLogConfig = containertypes.LogConfig{
-		Type:   config.LogConfig.Type,
-		Config: config.LogConfig.Config,
+		Type:     config.LogConfig.Type,
+		Timezone: config.LogConfig.Timezone,
+		Config:   config.LogConfig.Config,
 	}
 	d.EventsService = eventsService
 	d.volumes = volStore

--- a/daemon/logger/factory.go
+++ b/daemon/logger/factory.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"time"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/plugingetter"
@@ -123,11 +124,13 @@ var builtInLogOpts = map[string]bool{
 
 // ValidateLogOpts checks the options for the given log driver. The
 // options supported are specific to the LogDriver implementation.
-func ValidateLogOpts(name string, cfg map[string]string) error {
+func ValidateLogOpts(name string, cfg map[string]string, timezone string) error {
 	if name == "none" {
 		return nil
 	}
-
+	if _, err := time.LoadLocation(timezone); timezone != "" && err != nil {
+		return err
+	}
 	switch containertypes.LogMode(cfg["mode"]) {
 	case containertypes.LogModeBlocking, containertypes.LogModeNonBlock, containertypes.LogModeUnset:
 	default:
@@ -158,5 +161,6 @@ func ValidateLogOpts(name string, cfg map[string]string) error {
 	if validator != nil {
 		return validator(filteredOpts)
 	}
+
 	return nil
 }

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -159,6 +159,10 @@ func (daemon *Daemon) mergeAndVerifyLogConfig(cfg *containertypes.LogConfig) err
 		cfg.Type = daemon.defaultLogConfig.Type
 	}
 
+	if cfg.Timezone == "" {
+		cfg.Timezone = daemon.defaultLogConfig.Timezone
+	}
+
 	if cfg.Config == nil {
 		cfg.Config = make(map[string]string)
 	}
@@ -171,5 +175,5 @@ func (daemon *Daemon) mergeAndVerifyLogConfig(cfg *containertypes.LogConfig) err
 		}
 	}
 
-	return logger.ValidateLogOpts(cfg.Type, cfg.Config)
+	return logger.ValidateLogOpts(cfg.Type, cfg.Config, cfg.Timezone)
 }

--- a/daemon/logs_test.go
+++ b/daemon/logs_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMergeAndVerifyLogConfigNilConfig(t *testing.T) {
@@ -12,4 +13,16 @@ func TestMergeAndVerifyLogConfigNilConfig(t *testing.T) {
 	if err := d.mergeAndVerifyLogConfig(&cfg); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestMergeAndVerifyLogConfig(t *testing.T) {
+	timezone := "Asia/Jerusalem"
+	logType := "json-file"
+	d := &Daemon{defaultLogConfig: containertypes.LogConfig{Type: logType, Timezone: timezone}}
+	cfg := containertypes.LogConfig{}
+	if err := d.mergeAndVerifyLogConfig(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, timezone, cfg.Timezone)
+	assert.Equal(t, logType, cfg.Type)
 }


### PR DESCRIPTION
**- What I did**

closes #33778 

This commit adds the capability to setup the log timestamp according to the timezone given.
The default value, however, is still set to UTC.

To setup this, run `dockerd` with `--log-timezone`.
For example, the following will set the time of the log according to Berlin time.
```
$ dockerd --log-timezone Europe/Berlin
```

Signed-off-by: Boaz Shuster <ripcurld.github@gmail.com>

**- How I did it**

* Added `Timezone` to `LogConfig`
* Added a flag to set it + validation that it's set correctly
* Add an argument to `NewCopier` - a function that returns `time.Time`
* Added unit tests

**- How to verify it**

Run unit tests:

```
$ hack/test/unit
```

**- Description for the changelog**
