### PR TITLE
demonstration of failing file match

### DIFF
--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -77,6 +77,13 @@ func (pm *PatternMatcher) Matches(file string) (bool, error) {
 			return false, err
 		}
 
+		if !match {
+			match, err = pattern.match(parentPath)
+			if err != nil {
+				return false, err
+			}
+		}
+
 		if !match && parentPath != "." {
 			// Check to see if the pattern matches one of our parent dirs.
 			if len(pattern.dirs) <= len(parentPathDirs) {

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -211,6 +211,13 @@ func TestReadSymlinkedDirectoryToFile(t *testing.T) {
 }
 
 func TestWildcardMatches(t *testing.T) {
+	match, _ := Matches("/tmp/dir1/dir2/dir3/file.txt", []string{"**/dir3"})
+	if !match {
+		t.Errorf("failed to get nested dir match, got %v", match)
+	}
+}
+
+func TestDirMatches(t *testing.T) {
 	match, _ := Matches("fileutils.go", []string{"*"})
 	if !match {
 		t.Errorf("failed to get a wildcard match, got %v", match)


### PR DESCRIPTION
The test introduced by this PR currently fails because i think the Matches() implementation is broken.