### PR TITLE
Remove deprecated error checks

### DIFF
--- a/client/checkpoint_list_test.go
+++ b/client/checkpoint_list_test.go
@@ -62,7 +62,7 @@ func TestCheckpointListContainerNotFound(t *testing.T) {
 	}
 
 	_, err := client.CheckpointList(context.Background(), "unknown", types.CheckpointListOptions{})
-	if err == nil || !IsErrContainerNotFound(err) {
+	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected a containerNotFound error, got %v", err)
 	}
 }

--- a/client/config_inspect_test.go
+++ b/client/config_inspect_test.go
@@ -42,7 +42,7 @@ func TestConfigInspectConfigNotFound(t *testing.T) {
 	}
 
 	_, _, err := client.ConfigInspectWithRaw(context.Background(), "unknown")
-	if err == nil || !IsErrConfigNotFound(err) {
+	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected a configNotFoundError error, got %v", err)
 	}
 }
@@ -53,7 +53,7 @@ func TestConfigInspect(t *testing.T) {
 		version: "1.30",
 		client: newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+				return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
 			content, err := json.Marshal(swarm.Config{
 				ID: "config_id",

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -37,7 +37,7 @@ func TestContainerCreateImageNotFound(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusNotFound, "No such image")),
 	}
 	_, err := client.ContainerCreate(context.Background(), &container.Config{Image: "unknown_image"}, nil, nil, "unknown")
-	if err == nil || !IsErrImageNotFound(err) {
+	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected an imageNotFound error, got %v", err)
 	}
 }

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -30,7 +30,7 @@ func TestContainerInspectContainerNotFound(t *testing.T) {
 	}
 
 	_, err := client.ContainerInspect(context.Background(), "unknown")
-	if err == nil || !IsErrContainerNotFound(err) {
+	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected a containerNotFound error, got %v", err)
 	}
 }

--- a/client/errors.go
+++ b/client/errors.go
@@ -71,38 +71,6 @@ func wrapResponseError(err error, resp serverResponse, object, id string) error 
 	}
 }
 
-// IsErrImageNotFound returns true if the error is caused
-// when an image is not found in the docker host.
-//
-// Deprecated: Use IsErrNotFound
-func IsErrImageNotFound(err error) bool {
-	return IsErrNotFound(err)
-}
-
-// IsErrContainerNotFound returns true if the error is caused
-// when a container is not found in the docker host.
-//
-// Deprecated: Use IsErrNotFound
-func IsErrContainerNotFound(err error) bool {
-	return IsErrNotFound(err)
-}
-
-// IsErrNetworkNotFound returns true if the error is caused
-// when a network is not found in the docker host.
-//
-// Deprecated: Use IsErrNotFound
-func IsErrNetworkNotFound(err error) bool {
-	return IsErrNotFound(err)
-}
-
-// IsErrVolumeNotFound returns true if the error is caused
-// when a volume is not found in the docker host.
-//
-// Deprecated: Use IsErrNotFound
-func IsErrVolumeNotFound(err error) bool {
-	return IsErrNotFound(err)
-}
-
 // unauthorizedError represents an authorization error in a remote registry.
 type unauthorizedError struct {
 	cause error
@@ -118,30 +86,6 @@ func (u unauthorizedError) Error() string {
 func IsErrUnauthorized(err error) bool {
 	_, ok := err.(unauthorizedError)
 	return ok
-}
-
-// IsErrNodeNotFound returns true if the error is caused
-// when a node is not found.
-//
-// Deprecated: Use IsErrNotFound
-func IsErrNodeNotFound(err error) bool {
-	return IsErrNotFound(err)
-}
-
-// IsErrServiceNotFound returns true if the error is caused
-// when a service is not found.
-//
-// Deprecated: Use IsErrNotFound
-func IsErrServiceNotFound(err error) bool {
-	return IsErrNotFound(err)
-}
-
-// IsErrTaskNotFound returns true if the error is caused
-// when a task is not found.
-//
-// Deprecated: Use IsErrNotFound
-func IsErrTaskNotFound(err error) bool {
-	return IsErrNotFound(err)
 }
 
 type pluginPermissionDenied struct {
@@ -186,28 +130,4 @@ func (cli *Client) NewVersionError(APIrequired, feature string) error {
 		return fmt.Errorf("%q requires API version %s, but the Docker daemon API version is %s", feature, APIrequired, cli.version)
 	}
 	return nil
-}
-
-// IsErrSecretNotFound returns true if the error is caused
-// when a secret is not found.
-//
-// Deprecated: Use IsErrNotFound
-func IsErrSecretNotFound(err error) bool {
-	return IsErrNotFound(err)
-}
-
-// IsErrConfigNotFound returns true if the error is caused
-// when a config is not found.
-//
-// Deprecated: Use IsErrNotFound
-func IsErrConfigNotFound(err error) bool {
-	return IsErrNotFound(err)
-}
-
-// IsErrPluginNotFound returns true if the error is caused
-// when a plugin is not found in the docker host.
-//
-// Deprecated: Use IsErrNotFound
-func IsErrPluginNotFound(err error) bool {
-	return IsErrNotFound(err)
 }

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -31,7 +31,7 @@ func TestImageInspectImageNotFound(t *testing.T) {
 	}
 
 	_, _, err := client.ImageInspectWithRaw(context.Background(), "unknown")
-	if err == nil || !IsErrImageNotFound(err) {
+	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected an imageNotFound error, got %v", err)
 	}
 }

--- a/client/node_inspect_test.go
+++ b/client/node_inspect_test.go
@@ -30,7 +30,7 @@ func TestNodeInspectNodeNotFound(t *testing.T) {
 	}
 
 	_, _, err := client.NodeInspectWithRaw(context.Background(), "unknown")
-	if err == nil || !IsErrNodeNotFound(err) {
+	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected a nodeNotFoundError error, got %v", err)
 	}
 }

--- a/client/secret_inspect_test.go
+++ b/client/secret_inspect_test.go
@@ -42,7 +42,7 @@ func TestSecretInspectSecretNotFound(t *testing.T) {
 	}
 
 	_, _, err := client.SecretInspectWithRaw(context.Background(), "unknown")
-	if err == nil || !IsErrSecretNotFound(err) {
+	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected a secretNotFoundError error, got %v", err)
 	}
 }

--- a/client/service_inspect_test.go
+++ b/client/service_inspect_test.go
@@ -31,7 +31,7 @@ func TestServiceInspectServiceNotFound(t *testing.T) {
 	}
 
 	_, _, err := client.ServiceInspectWithRaw(context.Background(), "unknown", types.ServiceInspectOptions{})
-	if err == nil || !IsErrServiceNotFound(err) {
+	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected a serviceNotFoundError error, got %v", err)
 	}
 }


### PR DESCRIPTION
These were deprecated in favor of `IsErrNotFound()`

Also see https://github.com/docker/cli/pull/594, which removes these from the docker cli