### PR TITLE
[integration-cli] fix s390x flaky test

### DIFF
--- a/integration-cli/docker_cli_update_unix_test.go
+++ b/integration-cli/docker_cli_update_unix_test.go
@@ -180,7 +180,7 @@ func GetKernelVersion() *kernel.VersionInfo {
 // CheckKernelVersion checks if current kernel is newer than (or equal to)
 // the given version.
 func CheckKernelVersion(k, major, minor int) bool {
-	return kernel.CompareKernelVersion(*GetKernelVersion(), kernel.VersionInfo{Kernel: k, Major: major, Minor: minor}) > 0
+	return kernel.CompareKernelVersion(*GetKernelVersion(), kernel.VersionInfo{Kernel: k, Major: major, Minor: minor}) >= 0
 }
 
 func (s *DockerSuite) TestUpdateSwapMemoryOnly(c *check.C) {


### PR DESCRIPTION
Fixes #34938

s390x node-1 has kernel 4.6.0, kernel.CompareKernelVersion()
returns 0 if the kernels are equal, so include that.

Full logic for CompareKernelVersion() is
a > b ret 1,
a == b ret 0,
a < b ret -1

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>