### PR TITLE
Add gelf log driver plugin to Windows build

### DIFF
--- a/daemon/logdrivers_windows.go
+++ b/daemon/logdrivers_windows.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/docker/docker/daemon/logger/awslogs"
 	_ "github.com/docker/docker/daemon/logger/etwlogs"
 	_ "github.com/docker/docker/daemon/logger/fluentd"
+	_ "github.com/docker/docker/daemon/logger/gelf"
 	_ "github.com/docker/docker/daemon/logger/jsonfilelog"
 	_ "github.com/docker/docker/daemon/logger/logentries"
 	_ "github.com/docker/docker/daemon/logger/splunk"

--- a/daemon/logger/gelf/gelf.go
+++ b/daemon/logger/gelf/gelf.go
@@ -1,5 +1,3 @@
-// +build linux
-
 // Package gelf provides the log driver for forwarding server logs to
 // endpoints that support the Graylog Extended Log Format.
 package gelf

--- a/daemon/logger/gelf/gelf_unsupported.go
+++ b/daemon/logger/gelf/gelf_unsupported.go
@@ -1,3 +1,0 @@
-// +build !linux
-
-package gelf


### PR DESCRIPTION
Fix for #35062

Added gelf log plugin to the Windows version of the Moby build.

New to Go and Moby so please make sure the changes I made make sense.  Looked at the other log plugins that are in the Windows version and they seemed to be similar to how I changed the config for the gelf plugin.

As per the issue I did verify that it does indeed log to our server that takes the gelf formatted log data.