### PR TITLE
Windows Daemon should respect DOCKER_TMPDIR

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -555,7 +555,17 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 	if err != nil {
 		return nil, fmt.Errorf("Unable to get the full path to the TempDir (%s): %s", tmp, err)
 	}
-	os.Setenv("TMPDIR", realTmp)
+	if runtime.GOOS == "windows" {
+		if _, err := os.Stat(realTmp); err != nil && os.IsNotExist(err) {
+			if err := system.MkdirAll(realTmp, 0700, ""); err != nil {
+				return nil, fmt.Errorf("Unable to create the TempDir (%s): %s", realTmp, err)
+			}
+		}
+		os.Setenv("TEMP", realTmp)
+		os.Setenv("TMP", realTmp)
+	} else {
+		os.Setenv("TMPDIR", realTmp)
+	}
 
 	d := &Daemon{
 		configStore: config,


### PR DESCRIPTION
**- What I did**
Fixes #35076 by instructing the windows daemon to utilize the tmp directory under data-root and respect DOCKER_TMPDIR if it exists.

**- How I did it**
Leveraged Windows TMP and TEMP environment variables.

**- How to verify it**
1. Install Docker for Windows
2. Pull a large image
3. Observe disk activity via Resource Monitor

**- Description for the changelog**
Bug fix: Windows Daemon will now utilize the tmp directory under data-root and respect DOCKER_TMPDIR if it exists instead of leveraging the Temp directory under C:\Windows.