### PR TITLE
Fix TestErrorCases to run all tests

### DIFF
--- a/builder/dockerfile/instructions/parse_test.go
+++ b/builder/dockerfile/instructions/parse_test.go
@@ -196,7 +196,7 @@ func TestErrorCases(t *testing.T) {
 		_, err = ParseInstruction(n)
 		if err != nil {
 			testutil.ErrorContains(t, err, c.expectedError)
-			return
+			continue
 		}
 		t.Fatalf("No error when executing test %s", c.name)
 	}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@simonferquel @dnephin @thaJeztah 

`TestErrorCases` has a bug in it :) The `return` causes the loop to terminate after the first case, and doesn't run the remaining cases. Changed to a `continue` and validated all the cases are validated.