### PR TITLE
Add PortConfig.PublishMode to API documentation

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3042,6 +3042,24 @@ definitions:
       PublishedPort:
         description: "The port on the swarm hosts."
         type: "integer"
+      PublishMode:
+        description: |
+          The mode in which port is published.
+
+          <p><br /></p>
+
+          - "ingress" makes the target port accessible on on every node,
+            regardless of whether there is a task for the service running on
+            that node or not.
+          - "host" bypasses the routing mesh and publish the port directly on
+            the swarm node where that service is running.
+
+        type: "string"
+        enum:
+          - "ingress"
+          - "host"
+        default: "ingress"
+        example: "ingress"
 
   EndpointSpec:
     description: "Properties that can be configured to access and load balance a service."


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/33708

ping @joaofnfernandes 

**- How to verify it**

run `make swagger-docs` and visit http://localhost:9000 in your browser

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```markdown
* Add `PortConfig.PublishMode` to API documentation [moby/moby#35085](https://github.com/moby/moby/pull/35085)
```