### PR TITLE
Fix GitHub spelling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Github code owners
+# GitHub code owners
 # See https://help.github.com/articles/about-codeowners/
 #
 # KEEP THIS FILE SORTED. Order is important. Last match takes precedence.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -264,7 +264,7 @@
 	[people.cpuguy83]
 	Name = "Brian Goff"
 	Email = "cpuguy83@gmail.com"
-	Github = "cpuguy83"
+	GitHub = "cpuguy83"
 
 	[people.chanwit]
 	Name = "Chanwit Kaewkasi"

--- a/docs/api/v1.18.md
+++ b/docs/api/v1.18.md
@@ -7,8 +7,8 @@ redirect_from:
 - /reference/api/docker_remote_api_v1.18/
 ---
 
-<!-- This file is maintained within the docker/docker Github
-     repository at https://github.com/docker/docker/. Make all
+<!-- This file is maintained within the moby/moby GitHub
+     repository at https://github.com/moby/moby/. Make all
      pull requests against that repo. If you see this file in
      another repository, consider it read-only there, as it will
      periodically be overwritten by the definitive file. Pull

--- a/docs/api/v1.19.md
+++ b/docs/api/v1.19.md
@@ -7,8 +7,8 @@ redirect_from:
 - /reference/api/docker_remote_api_v1.19/
 ---
 
-<!-- This file is maintained within the docker/docker Github
-     repository at https://github.com/docker/docker/. Make all
+<!-- This file is maintained within the moby/moby GitHub
+     repository at https://github.com/moby/moby/. Make all
      pull requests against that repo. If you see this file in
      another repository, consider it read-only there, as it will
      periodically be overwritten by the definitive file. Pull

--- a/docs/api/v1.20.md
+++ b/docs/api/v1.20.md
@@ -7,8 +7,8 @@ redirect_from:
 - /reference/api/docker_remote_api_v1.20/
 ---
 
-<!-- This file is maintained within the docker/docker Github
-     repository at https://github.com/docker/docker/. Make all
+<!-- This file is maintained within the moby/moby GitHub
+     repository at https://github.com/moby/moby/. Make all
      pull requests against that repo. If you see this file in
      another repository, consider it read-only there, as it will
      periodically be overwritten by the definitive file. Pull

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -7,8 +7,8 @@ redirect_from:
 - /reference/api/docker_remote_api_v1.21/
 ---
 
-<!-- This file is maintained within the docker/docker Github
-     repository at https://github.com/docker/docker/. Make all
+<!-- This file is maintained within the moby/moby GitHub
+     repository at https://github.com/moby/moby/. Make all
      pull requests against that repo. If you see this file in
      another repository, consider it read-only there, as it will
      periodically be overwritten by the definitive file. Pull

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -7,8 +7,8 @@ redirect_from:
 - /reference/api/docker_remote_api_v1.22/
 ---
 
-<!-- This file is maintained within the docker/docker Github
-     repository at https://github.com/docker/docker/. Make all
+<!-- This file is maintained within the moby/moby GitHub
+     repository at https://github.com/moby/moby/. Make all
      pull requests against that repo. If you see this file in
      another repository, consider it read-only there, as it will
      periodically be overwritten by the definitive file. Pull

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -7,8 +7,8 @@ redirect_from:
 - /reference/api/docker_remote_api_v1.23/
 ---
 
-<!-- This file is maintained within the docker/docker Github
-     repository at https://github.com/docker/docker/. Make all
+<!-- This file is maintained within the moby/moby GitHub
+     repository at https://github.com/moby/moby/. Make all
      pull requests against that repo. If you see this file in
      another repository, consider it read-only there, as it will
      periodically be overwritten by the definitive file. Pull

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -7,8 +7,8 @@ redirect_from:
 - /reference/api/docker_remote_api_v1.24/
 ---
 
-<!-- This file is maintained within the docker/docker Github
-     repository at https://github.com/docker/docker/. Make all
+<!-- This file is maintained within the moby/moby GitHub
+     repository at https://github.com/moby/moby/. Make all
      pull requests against that repo. If you see this file in
      another repository, consider it read-only there, as it will
      periodically be overwritten by the definitive file. Pull

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -4,8 +4,8 @@ description: "Documentation of changes that have been made to Engine API."
 keywords: "API, Docker, rcli, REST, documentation"
 ---
 
-<!-- This file is maintained within the docker/docker Github
-     repository at https://github.com/docker/docker/. Make all
+<!-- This file is maintained within the moby/moby GitHub
+     repository at https://github.com/moby/moby/. Make all
      pull requests against that repo. If you see this file in
      another repository, consider it read-only there, as it will
      periodically be overwritten by the definitive file. Pull

--- a/integration-cli/docker_cli_health_test.go
+++ b/integration-cli/docker_cli_health_test.go
@@ -143,7 +143,7 @@ func (s *DockerSuite) TestHealth(c *check.C) {
 
 }
 
-// Github #33021
+// GitHub #33021
 func (s *DockerSuite) TestUnsetEnvVarHealthCheck(c *check.C) {
 	testRequires(c, DaemonIsLinux) // busybox doesn't work on Windows
 

--- a/project/RELEASE-PROCESS.md
+++ b/project/RELEASE-PROCESS.md
@@ -45,7 +45,7 @@ defined by a ROADMAP.md file at the root of the repository).
 - The earlier a PR is opened, the more time the maintainers have to review. For
 example, if a PR is opened the day before the freeze date, it’s very unlikely
 that it will be merged for the release.
-- Constant communication with the maintainers (mailing-list, IRC, Github issues,
+- Constant communication with the maintainers (mailing-list, IRC, GitHub issues,
 etc.) allows to get early feedback on the design before getting into the
 implementation, which usually reduces the time needed to discuss a changeset.
 - If the code is commented, fully tested and by extension follows every single

--- a/project/REVIEWING.md
+++ b/project/REVIEWING.md
@@ -68,7 +68,7 @@ the next appropriate stage:
 
  - Has DCO
  - Contains sufficient justification (e.g., usecases) for the proposed change
- - References the Github issue it fixes (if any) in the commit or the first Github comment
+ - References the GitHub issue it fixes (if any) in the commit or the first GitHub comment
 
 Possible transitions from this state:
 


### PR DESCRIPTION
Just a small typo fix `Github` -> `GitHub`. This also changes a few references to the `docker/docker` repo to `moby/moby` (found on the same line).