### PR TITLE
Fix One of the Docker Stats Tests in /integration-cli

### DIFF
--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -34,7 +34,7 @@ func (s *DockerSuite) TestStatsNoStream(c *check.C) {
 	select {
 	case outerr := <-ch:
 		c.Assert(outerr.err, checker.IsNil, check.Commentf("Error running stats: %v", outerr.err))
-		c.Assert(string(outerr.out), checker.Contains, id) //running container wasn't present in output
+		c.Assert(string(outerr.out), checker.Contains, id[:12]) //running container wasn't present in output
 	case <-time.After(3 * time.Second):
 		statsCmd.Process.Kill()
 		c.Fatalf("stats did not return immediately when not streaming")


### PR DESCRIPTION
Use only the first 12 characters of the ID instead of the full thing. The command `docker stats` only contains 12 characters for the different IDs being shown.

Signed-off-by: Corbin <corbin.coleman@docker.com>

![image](https://user-images.githubusercontent.com/18235718/31198874-9a467eea-a90a-11e7-9688-4bde57dca24e.png)
