### PR TITLE
LCOW - Change platform parser directive to FROM statement flag

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"runtime"
 	"strings"
 	"time"
 
@@ -104,7 +103,7 @@ func (bm *BuildManager) Build(ctx context.Context, config backend.BuildConfig) (
 		source = src
 	}
 
-	os := runtime.GOOS
+	os := ""
 	apiPlatform := system.ParsePlatform(config.Options.Platform)
 	if apiPlatform.OS != "" {
 		os = apiPlatform.OS

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -105,17 +105,11 @@ func (bm *BuildManager) Build(ctx context.Context, config backend.BuildConfig) (
 	}
 
 	os := runtime.GOOS
-	optionsPlatform := system.ParsePlatform(config.Options.Platform)
-	if dockerfile.OS != "" {
-		if optionsPlatform.OS != "" && optionsPlatform.OS != dockerfile.OS {
-			return nil, fmt.Errorf("invalid platform")
-		}
-		os = dockerfile.OS
-	} else if optionsPlatform.OS != "" {
-		os = optionsPlatform.OS
+	apiPlatform := system.ParsePlatform(config.Options.Platform)
+	if apiPlatform.OS != "" {
+		os = apiPlatform.OS
 	}
 	config.Options.Platform = os
-	dockerfile.OS = os
 
 	builderOptions := builderOptions{
 		Options:        config.Options,

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -148,7 +148,7 @@ func (d *dispatchRequest) getImageMount(imageRefOrID string) (*imageMount, error
 	return d.builder.imageSources.Get(imageRefOrID, localOnly)
 }
 
-// FROM imagename[:tag | @digest] [AS build-stage-name]
+// FROM [--platform=platform] imagename[:tag | @digest] [AS build-stage-name]
 //
 func initializeStage(d dispatchRequest, cmd *instructions.Stage) error {
 	d.builder.imageProber.Reset()

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -208,6 +208,7 @@ func TestOnbuild(t *testing.T) {
 func TestWorkdir(t *testing.T) {
 	b := newBuilderWithMockBackend()
 	sb := newDispatchRequest(b, '`', nil, newBuildArgs(make(map[string]*string)), newStagesBuildResults())
+	sb.state.baseImage = &mockImage{}
 	workingDir := "/app"
 	if runtime.GOOS == "windows" {
 		workingDir = "C:\\app"

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -225,6 +225,7 @@ func TestWorkdir(t *testing.T) {
 func TestCmd(t *testing.T) {
 	b := newBuilderWithMockBackend()
 	sb := newDispatchRequest(b, '`', nil, newBuildArgs(make(map[string]*string)), newStagesBuildResults())
+	sb.state.baseImage = &mockImage{}
 	command := "./executable"
 
 	cmd := &instructions.CmdCommand{
@@ -282,6 +283,7 @@ func TestHealthcheckCmd(t *testing.T) {
 func TestEntrypoint(t *testing.T) {
 	b := newBuilderWithMockBackend()
 	sb := newDispatchRequest(b, '`', nil, newBuildArgs(make(map[string]*string)), newStagesBuildResults())
+	sb.state.baseImage = &mockImage{}
 	entrypointCmd := "/usr/sbin/nginx"
 
 	cmd := &instructions.EntrypointCommand{
@@ -357,6 +359,7 @@ func TestStopSignal(t *testing.T) {
 	}
 	b := newBuilderWithMockBackend()
 	sb := newDispatchRequest(b, '`', nil, newBuildArgs(make(map[string]*string)), newStagesBuildResults())
+	sb.state.baseImage = &mockImage{}
 	signal := "SIGKILL"
 
 	cmd := &instructions.StopSignalCommand{

--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -37,7 +37,7 @@ import (
 
 func dispatch(d dispatchRequest, cmd instructions.Command) (err error) {
 	if c, ok := cmd.(instructions.PlatformSpecific); ok {
-		err := c.CheckPlatform(d.state.baseImage.OperatingSystem())
+		err := c.CheckPlatform(d.state.operatingSystem)
 		if err != nil {
 			return errdefs.InvalidParameter(err)
 		}

--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -37,8 +37,7 @@ import (
 
 func dispatch(d dispatchRequest, cmd instructions.Command) (err error) {
 	if c, ok := cmd.(instructions.PlatformSpecific); ok {
-		optionsOS := system.ParsePlatform(d.builder.options.Platform).OS
-		err := c.CheckPlatform(optionsOS)
+		err := c.CheckPlatform(d.state.baseImage.OperatingSystem())
 		if err != nil {
 			return errdefs.InvalidParameter(err)
 		}

--- a/builder/dockerfile/instructions/commands.go
+++ b/builder/dockerfile/instructions/commands.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // KeyValuePair represent an arbitrary named value (useful in slice instead of map[string] string to preserve ordering)
@@ -357,11 +358,11 @@ type ShellCommand struct {
 
 // Stage represents a single stage in a multi-stage build
 type Stage struct {
-	Name            string
-	Commands        []Command
-	BaseName        string
-	SourceCode      string
-	OperatingSystem string
+	Name       string
+	Commands   []Command
+	BaseName   string
+	SourceCode string
+	Platform   specs.Platform
 }
 
 // AddCommand to the stage

--- a/builder/dockerfile/instructions/commands.go
+++ b/builder/dockerfile/instructions/commands.go
@@ -357,10 +357,11 @@ type ShellCommand struct {
 
 // Stage represents a single stage in a multi-stage build
 type Stage struct {
-	Name       string
-	Commands   []Command
-	BaseName   string
-	SourceCode string
+	Name            string
+	Commands        []Command
+	BaseName        string
+	SourceCode      string
+	OperatingSystem string
 }
 
 // AddCommand to the stage

--- a/builder/dockerfile/instructions/parse.go
+++ b/builder/dockerfile/instructions/parse.go
@@ -276,23 +276,13 @@ func parseFrom(req parseRequest) (*Stage, error) {
 	if err := req.flags.Parse(); err != nil {
 		return nil, err
 	}
-	specPlatform := system.ParsePlatform(flPlatform.Value)
-	if err := system.ValidatePlatform(specPlatform); err != nil {
-		return nil, fmt.Errorf("invalid platform %q on FROM", flPlatform.Value)
-	}
-	if specPlatform.OS != "" && !system.IsOSSupported(specPlatform.OS) {
-		return nil, fmt.Errorf("unsupported platform %q on FROM", flPlatform.Value)
-	}
-	if err != nil {
-		return nil, err
-	}
 	code := strings.TrimSpace(req.original)
 	return &Stage{
-		BaseName:        req.args[0],
-		Name:            stageName,
-		SourceCode:      code,
-		Commands:        []Command{},
-		OperatingSystem: specPlatform.OS,
+		BaseName:   req.args[0],
+		Name:       stageName,
+		SourceCode: code,
+		Commands:   []Command{},
+		Platform:   *system.ParsePlatform(flPlatform.Value),
 	}, nil
 
 }

--- a/builder/dockerfile/instructions/parse.go
+++ b/builder/dockerfile/instructions/parse.go
@@ -3,7 +3,6 @@ package instructions // import "github.com/docker/docker/builder/dockerfile/inst
 import (
 	"fmt"
 	"regexp"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -278,20 +277,16 @@ func parseFrom(req parseRequest) (*Stage, error) {
 		return nil, err
 	}
 	specPlatform := system.ParsePlatform(flPlatform.Value)
-	if specPlatform.OS == "" {
-		specPlatform.OS = runtime.GOOS
-	}
 	if err := system.ValidatePlatform(specPlatform); err != nil {
 		return nil, fmt.Errorf("invalid platform %q on FROM", flPlatform.Value)
 	}
-	if !system.IsOSSupported(specPlatform.OS) {
+	if specPlatform.OS != "" && !system.IsOSSupported(specPlatform.OS) {
 		return nil, fmt.Errorf("unsupported platform %q on FROM", flPlatform.Value)
 	}
 	if err != nil {
 		return nil, err
 	}
 	code := strings.TrimSpace(req.original)
-	fmt.Println("JJH", specPlatform.OS)
 	return &Stage{
 		BaseName:        req.args[0],
 		Name:            stageName,

--- a/builder/dockerfile/instructions/parse_test.go
+++ b/builder/dockerfile/instructions/parse_test.go
@@ -1,8 +1,6 @@
 package instructions // import "github.com/docker/docker/builder/dockerfile/instructions"
 
 import (
-	"fmt"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -185,16 +183,6 @@ func TestErrorCases(t *testing.T) {
 			name:          "Invalid instruction",
 			dockerfile:    `foo bar`,
 			expectedError: "unknown instruction: FOO",
-		},
-		{
-			name:          "Invalid platform",
-			dockerfile:    `FROM --platform=invalid busybox`,
-			expectedError: `invalid platform "invalid"`,
-		},
-		{
-			name:          "Only OS",
-			dockerfile:    fmt.Sprintf(`FROM --platform=%s/%s busybox`, runtime.GOOS, runtime.GOARCH),
-			expectedError: `invalid platform`,
 		},
 	}
 	for _, c := range cases {

--- a/builder/dockerfile/instructions/parse_test.go
+++ b/builder/dockerfile/instructions/parse_test.go
@@ -1,6 +1,8 @@
 package instructions // import "github.com/docker/docker/builder/dockerfile/instructions"
 
 import (
+	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -184,6 +186,16 @@ func TestErrorCases(t *testing.T) {
 			dockerfile:    `foo bar`,
 			expectedError: "unknown instruction: FOO",
 		},
+		{
+			name:          "Invalid platform",
+			dockerfile:    `FROM --platform=invalid busybox`,
+			expectedError: `invalid platform "invalid"`,
+		},
+		{
+			name:          "Only OS",
+			dockerfile:    fmt.Sprintf(`FROM --platform=%s/%s busybox`, runtime.GOOS, runtime.GOARCH),
+			expectedError: `invalid platform`,
+		},
 	}
 	for _, c := range cases {
 		r := strings.NewReader(c.dockerfile)
@@ -196,5 +208,4 @@ func TestErrorCases(t *testing.T) {
 		_, err = ParseInstruction(n)
 		testutil.ErrorContains(t, err, c.expectedError)
 	}
-
 }

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -83,8 +83,7 @@ func (b *Builder) commit(dispatchState *dispatchState, comment string) error {
 		return errors.New("Please provide a source image with `from` prior to commit")
 	}
 
-	optionsPlatform := system.ParsePlatform(b.options.Platform)
-	runConfigWithCommentCmd := copyRunConfig(dispatchState.runConfig, withCmdComment(comment, optionsPlatform.OS))
+	runConfigWithCommentCmd := copyRunConfig(dispatchState.runConfig, withCmdComment(comment, dispatchState.baseImage.OperatingSystem()))
 	hit, err := b.probeCache(dispatchState, runConfigWithCommentCmd)
 	if err != nil || hit {
 		return err
@@ -164,16 +163,15 @@ func (b *Builder) performCopy(state *dispatchState, inst copyInstruction) error 
 	commentStr := fmt.Sprintf("%s %s%s in %s ", inst.cmdName, chownComment, srcHash, inst.dest)
 
 	// TODO: should this have been using origPaths instead of srcHash in the comment?
-	optionsPlatform := system.ParsePlatform(b.options.Platform)
 	runConfigWithCommentCmd := copyRunConfig(
 		state.runConfig,
-		withCmdCommentString(commentStr, optionsPlatform.OS))
+		withCmdCommentString(commentStr, state.baseImage.OperatingSystem()))
 	hit, err := b.probeCache(state, runConfigWithCommentCmd)
 	if err != nil || hit {
 		return err
 	}
 
-	imageMount, err := b.imageSources.Get(state.imageID, true)
+	imageMount, err := b.imageSources.Get(state.imageID, true, state.baseImage.OperatingSystem())
 	if err != nil {
 		return errors.Wrapf(err, "failed to get destination image %q", state.imageID)
 	}
@@ -184,7 +182,7 @@ func (b *Builder) performCopy(state *dispatchState, inst copyInstruction) error 
 	}
 	defer rwLayer.Release()
 
-	destInfo, err := createDestInfo(state.runConfig.WorkingDir, inst, rwLayer, b.options.Platform)
+	destInfo, err := createDestInfo(state.runConfig.WorkingDir, inst, rwLayer, state.baseImage.OperatingSystem())
 	if err != nil {
 		return err
 	}

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -83,7 +83,7 @@ func (b *Builder) commit(dispatchState *dispatchState, comment string) error {
 		return errors.New("Please provide a source image with `from` prior to commit")
 	}
 
-	runConfigWithCommentCmd := copyRunConfig(dispatchState.runConfig, withCmdComment(comment, dispatchState.baseImage.OperatingSystem()))
+	runConfigWithCommentCmd := copyRunConfig(dispatchState.runConfig, withCmdComment(comment, dispatchState.operatingSystem))
 	hit, err := b.probeCache(dispatchState, runConfigWithCommentCmd)
 	if err != nil || hit {
 		return err
@@ -165,13 +165,13 @@ func (b *Builder) performCopy(state *dispatchState, inst copyInstruction) error 
 	// TODO: should this have been using origPaths instead of srcHash in the comment?
 	runConfigWithCommentCmd := copyRunConfig(
 		state.runConfig,
-		withCmdCommentString(commentStr, state.baseImage.OperatingSystem()))
+		withCmdCommentString(commentStr, state.operatingSystem))
 	hit, err := b.probeCache(state, runConfigWithCommentCmd)
 	if err != nil || hit {
 		return err
 	}
 
-	imageMount, err := b.imageSources.Get(state.imageID, true, state.baseImage.OperatingSystem())
+	imageMount, err := b.imageSources.Get(state.imageID, true, state.operatingSystem)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get destination image %q", state.imageID)
 	}
@@ -182,7 +182,7 @@ func (b *Builder) performCopy(state *dispatchState, inst copyInstruction) error 
 	}
 	defer rwLayer.Release()
 
-	destInfo, err := createDestInfo(state.runConfig.WorkingDir, inst, rwLayer, state.baseImage.OperatingSystem())
+	destInfo, err := createDestInfo(state.runConfig.WorkingDir, inst, rwLayer, state.operatingSystem)
 	if err != nil {
 		return err
 	}

--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -237,10 +237,7 @@ func newNodeFromLine(line string, directive *Directive) (*Node, error) {
 type Result struct {
 	AST         *Node
 	EscapeToken rune
-	// TODO @jhowardmsft - see https://github.com/moby/moby/issues/34617
-	// This next field will be removed in a future update for LCOW support.
-	OS       string
-	Warnings []string
+	Warnings    []string
 }
 
 // PrintWarnings to the writer
@@ -320,7 +317,6 @@ func Parse(rwc io.Reader) (*Result, error) {
 		AST:         root,
 		Warnings:    warnings,
 		EscapeToken: d.escapeToken,
-		OS:          d.platformToken,
 	}, handleScannerError(scanner.Err())
 }
 

--- a/daemon/images/image_history.go
+++ b/daemon/images/image_history.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/layer"
+	"github.com/docker/docker/pkg/system"
 )
 
 // ImageHistory returns a slice of ImageHistory structures for the specified image
@@ -31,7 +32,9 @@ func (i *ImageService) ImageHistory(name string) ([]*image.HistoryResponseItem, 
 			if len(img.RootFS.DiffIDs) <= layerCounter {
 				return nil, fmt.Errorf("too many non-empty layers in History section")
 			}
-
+			if !system.IsOSSupported(img.OperatingSystem()) {
+				return nil, system.ErrNotSupportedOperatingSystem
+			}
 			rootFS.Append(img.RootFS.DiffIDs[layerCounter])
 			l, err := i.layerStores[img.OperatingSystem()].Get(rootFS.ChainID())
 			if err != nil {

--- a/daemon/images/images.go
+++ b/daemon/images/images.go
@@ -271,7 +271,9 @@ func (i *ImageService) SquashImage(id, parent string) (string, error) {
 		rootFS := image.NewRootFS()
 		parentImg = &image.Image{RootFS: rootFS}
 	}
-
+	if !system.IsOSSupported(img.OperatingSystem()) {
+		return "", errors.Wrap(err, system.ErrNotSupportedOperatingSystem.Error())
+	}
 	l, err := i.layerStores[img.OperatingSystem()].Get(img.RootFS.ChainID())
 	if err != nil {
 		return "", errors.Wrap(err, "error getting image layer")


### PR DESCRIPTION
This removes the `# platform=....` parser directive, and adds `--platform` as a flag to the `FROM` statement instead. This is one of the action items from the F2F in SF in August 2017, and the document described in #34617. It's a direct follow-on to https://github.com/moby/moby/pull/34859 which is now merged in master

![image](https://user-images.githubusercontent.com/10522484/35169611-00abf6aa-fd12-11e7-9413-719747f4e60e.png)
