### PR TITLE
drop useless apparmor denies

### DIFF
--- a/profiles/apparmor/template.go
+++ b/profiles/apparmor/template.go
@@ -24,8 +24,6 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
   deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
   deny @{PROC}/sysrq-trigger rwklx,
-  deny @{PROC}/mem rwklx,
-  deny @{PROC}/kmem rwklx,
   deny @{PROC}/kcore rwklx,
 
   deny mount,


### PR DESCRIPTION
These files don't exist under proc so this rule does nothing.

They are protected against by docker's default cgroup devices since they're
both character devices and not explicitly allowed.

Signed-off-by: Tycho Andersen <tycho@docker.com>