### PR TITLE
 Reload daemon even if "/etc/docker/daemon.json" does not exist

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"reflect"
 	"runtime"
 	"strings"
@@ -244,7 +245,10 @@ func Reload(configFile string, flags *pflag.FlagSet, reload func(*Config)) error
 	logrus.Infof("Got signal to reload configuration, reloading from: %s", configFile)
 	newConfig, err := getConflictFreeConfiguration(configFile, flags)
 	if err != nil {
-		return err
+		if flags.Changed("config-file") || !os.IsNotExist(err) {
+			return fmt.Errorf("unable to configure the Docker daemon with file %s: %v", configFile, err)
+		}
+		newConfig = New()
 	}
 
 	if err := Validate(newConfig); err != nil {

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -389,3 +389,49 @@ func discoveryConfig(backendAddr, advertiseAddr string, opts map[string]string) 
 		},
 	}
 }
+
+// TestReloadSetConfigFileNotExist tests that when `--config-file` is set
+// and it doesn't exist the `Reload` function returns an error.
+func TestReloadSetConfigFileNotExist(t *testing.T) {
+	configFile := "/tmp/blabla/not/exists/config.json"
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("config-file", "", "")
+	flags.Set("config-file", configFile)
+
+	err := Reload(configFile, flags, func(c *Config) {})
+	assert.Error(t, err)
+	testutil.ErrorContains(t, err, "unable to configure the Docker daemon with file")
+}
+
+// TestReloadDefaultConfigNotExist tests that if the default configuration file
+// doesn't exist the daemon still will be reloaded.
+func TestReloadDefaultConfigNotExist(t *testing.T) {
+	reloaded := false
+	configFile := "/etc/docker/daemon.json"
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("config-file", configFile, "")
+	err := Reload(configFile, flags, func(c *Config) {
+		reloaded = true
+	})
+	assert.Nil(t, err)
+	assert.True(t, reloaded)
+}
+
+// TestReloadBadDefaultConfig tests that when `--config-file` is not set
+// and the default configuration file exists and is bad return an error
+func TestReloadBadDefaultConfig(t *testing.T) {
+	f, err := ioutil.TempFile("", "docker-config-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configFile := f.Name()
+	f.Write([]byte(`{wrong: "configuration"}`))
+	f.Close()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("config-file", configFile, "")
+	err = Reload(configFile, flags, func(c *Config) {})
+	assert.Error(t, err)
+	testutil.ErrorContains(t, err, "unable to configure the Docker daemon with file")
+}


### PR DESCRIPTION
**- What I did**

closes #35114

Before this commit if `--config-file` wasn't set the daemon would use the default configuration file which is `/etc/docker/daemon.json`.

When attempting to reload the daemon if that file didn't exist and error message would display.

This behaviour is changed in a way that if the default configuration file does not exist, the daemon will use an empty configuration which later will be reloaded using the `reload` function given as an
argument in `Reload`.

However, if the `--config-file` flag was set and the file was removed or renamed an error message
will be displayed and no reload will be done.

**- How I did it**

* Add a check when `err != nil` in the `Reload` function.
* Add unit tests in `daemon/config/config_test.go`

**- How to verify it**

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

