### PR TITLE
Use correct type for ContainerExecAttach

### DIFF
--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -35,7 +35,7 @@ func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config
 // It returns a types.HijackedConnection with the hijacked connection
 // and the a reader to get output. It's up to the called to close
 // the hijacked connection by calling types.HijackedResponse.Close.
-func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, config types.ExecConfig) (types.HijackedResponse, error) {
+func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, config types.ExecStartCheck) (types.HijackedResponse, error) {
 	headers := map[string][]string{"Content-Type": {"application/json"}}
 	return cli.postHijacked(ctx, "/exec/"+execID+"/start", nil, config, headers)
 }

--- a/client/interface.go
+++ b/client/interface.go
@@ -45,7 +45,7 @@ type ContainerAPIClient interface {
 	ContainerCommit(ctx context.Context, container string, options types.ContainerCommitOptions) (types.IDResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (container.ContainerCreateCreatedBody, error)
 	ContainerDiff(ctx context.Context, container string) ([]container.ContainerChangeResponseItem, error)
-	ContainerExecAttach(ctx context.Context, execID string, config types.ExecConfig) (types.HijackedResponse, error)
+	ContainerExecAttach(ctx context.Context, execID string, config types.ExecStartCheck) (types.HijackedResponse, error)
 	ContainerExecCreate(ctx context.Context, container string, config types.ExecConfig) (types.IDResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error)
 	ContainerExecResize(ctx context.Context, execID string, options types.ResizeOptions) error


### PR DESCRIPTION
Fixes https://github.com/docker/engine-api/issues/381 (nice catch @vikstrous !)

`ContainerExecAttach()` used `types.ExecConfig` instead of `types.ExecStartCheck`, which is the type that's expected by the `/exec/execid/start` API endpoint.

Investigating when this inconsistency was introduced, I found that the client has sent the additional properties since its first imlpementation in https://github.com/moby/moby/commit/c786a8ee5e9db8f5f609cf8721bd1e1513fb0043 (https://github.com/moby/moby/pull/8062). The `postContainerExecStart()` at that time used the "jobs" package, which only took the information from the body that was needed (`Detach` and `Tty`).

Commit https://github.com/moby/moby/commit/24425021d26f29a475702064181e6c99fb6bd1c5 (https://github.com/moby/moby/pull/12650) refactored the Exec commands to remove the "jobs", and introduced the `ExecStartCheck` type, but forgot to update the `cli.hijack()` call with the new type.

The change in this patch should not affect compatibility with older clients, as the additional information from the `ExecConfig` type is not used (the API server already decodes to the `ExecStartCheck` type).

Also, no changes are needed in the API documentation, as the documentation has always correctly documented the type: https://docs.docker.com/v1.4/reference/api/docker_remote_api_v1.15/#execstart

**- What I did**

Updated `ContainerExecAttach` to use the correct type

**- Description for the changelog**

```markdown
* Update API client to send the correct body for `/exec/<exec-id>/start` [moby/moby#35128](https://github.com/moby/moby/pull/35128)
```


**- A picture of a cute animal (not mandatory but encouraged)**

![may-17-2012-17-03-31-thgrth](https://user-images.githubusercontent.com/1804568/31322163-c88f00ac-ac92-11e7-83e5-0c837ef9e63a.jpg)


Image: [Grey Goose](http://attackofthecute.com/on/?i=8438)