### PR TITLE
Fix inline schema definition issue in swagger.yaml

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -159,6 +159,293 @@ tags:
     x-displayName: "System"
 
 definitions:
+  ServiceUpdateBody:
+    allOf:
+      - $ref: "#/definitions/ServiceSpec"
+      - type: "object"
+        example:
+          Name: "top"
+          TaskTemplate:
+            ContainerSpec:
+              Image: "busybox"
+              Args:
+                - "top"
+            Resources:
+              Limits: {}
+              Reservations: {}
+            RestartPolicy:
+              Condition: "any"
+              MaxAttempts: 0
+            Placement: {}
+            ForceUpdate: 0
+          Mode:
+            Replicated:
+              Replicas: 1
+          UpdateConfig:
+            Parallelism: 2
+            Delay: 1000000000
+            FailureAction: "pause"
+            Monitor: 15000000000
+            MaxFailureRatio: 0.15
+          RollbackConfig:
+            Parallelism: 1
+            Delay: 1000000000
+            FailureAction: "pause"
+            Monitor: 15000000000
+            MaxFailureRatio: 0.15
+          EndpointSpec:
+            Mode: "vip"
+  ServiceCreateBody:
+    allOf:
+      - $ref: "#/definitions/ServiceSpec"
+      - type: "object"
+        example:
+          Name: "web"
+          TaskTemplate:
+            ContainerSpec:
+              Image: "nginx:alpine"
+              Mounts:
+                -
+                  ReadOnly: true
+                  Source: "web-data"
+                  Target: "/usr/share/nginx/html"
+                  Type: "volume"
+                  VolumeOptions:
+                    DriverConfig: {}
+                    Labels:
+                      com.example.something: "something-value"
+              Hosts: ["10.10.10.10 host1", "ABCD:EF01:2345:6789:ABCD:EF01:2345:6789 host2"]
+              User: "33"
+              DNSConfig:
+                Nameservers: ["8.8.8.8"]
+                Search: ["example.org"]
+                Options: ["timeout:3"]
+              Secrets:
+                -
+                  File:
+                    Name: "www.example.org.key"
+                    UID: "33"
+                    GID: "33"
+                    Mode: 384
+                  SecretID: "fpjqlhnwb19zds35k8wn80lq9"
+                  SecretName: "example_org_domain_key"
+            LogDriver:
+              Name: "json-file"
+              Options:
+                max-file: "3"
+                max-size: "10M"
+            Placement: {}
+            Resources:
+              Limits:
+                MemoryBytes: 104857600
+              Reservations: {}
+            RestartPolicy:
+              Condition: "on-failure"
+              Delay: 10000000000
+              MaxAttempts: 10
+          Mode:
+            Replicated:
+              Replicas: 4
+          UpdateConfig:
+            Parallelism: 2
+            Delay: 1000000000
+            FailureAction: "pause"
+            Monitor: 15000000000
+            MaxFailureRatio: 0.15
+          RollbackConfig:
+            Parallelism: 1
+            Delay: 1000000000
+            FailureAction: "pause"
+            Monitor: 15000000000
+            MaxFailureRatio: 0.15
+          EndpointSpec:
+            Ports:
+              -
+                Protocol: "tcp"
+                PublishedPort: 8080
+                TargetPort: 80
+          Labels:
+            foo: "bar"
+  SecretCreateBody:
+    allOf:
+      - $ref: "#/definitions/SecretSpec"
+      - type: "object"
+        example:
+          Name: "app-key.crt"
+          Labels:
+            foo: "bar"
+          Data: "VEhJUyBJUyBOT1QgQSBSRUFMIENFUlRJRklDQVRFCg=="
+          Driver:
+            Name: "secret-bucket"
+            Options:
+              OptionA: "value for driver option A"
+              OptionB: "value for driver option B"
+  ConfigCreateBody:
+    allOf:
+      - $ref: "#/definitions/ConfigSpec"
+      - type: "object"
+        example:
+          Name: "server.conf"
+          Labels:
+            foo: "bar"
+          Data: "VEhJUyBJUyBOT1QgQSBSRUFMIENFUlRJRklDQVRFCg=="
+  ContainerUpdateUpdate:
+    allOf:
+      - $ref: "#/definitions/Resources"
+      - type: "object"
+        properties:
+          RestartPolicy:
+            $ref: "#/definitions/RestartPolicy"
+    example:
+      BlkioWeight: 300
+      CpuShares: 512
+      CpuPeriod: 100000
+      CpuQuota: 50000
+      CpuRealtimePeriod: 1000000
+      CpuRealtimeRuntime: 10000
+      CpusetCpus: "0,1"
+      CpusetMems: "0"
+      Memory: 314572800
+      MemorySwap: 514288000
+      MemoryReservation: 209715200
+      KernelMemory: 52428800
+      RestartPolicy:
+        MaximumRetryCount: 4
+        Name: "on-failure"
+  ContainerCreateBody:
+    allOf:
+      - $ref: "#/definitions/ContainerConfig"
+      - type: "object"
+        properties:
+          HostConfig:
+            $ref: "#/definitions/HostConfig"
+          NetworkingConfig:
+            description: "This container's networking configuration."
+            type: "object"
+            properties:
+              EndpointsConfig:
+                description: "A mapping of network name to endpoint configuration for that network."
+                type: "object"
+                additionalProperties:
+                  $ref: "#/definitions/EndpointSettings"
+    example:
+      Hostname: ""
+      Domainname: ""
+      User: ""
+      AttachStdin: false
+      AttachStdout: true
+      AttachStderr: true
+      Tty: false
+      OpenStdin: false
+      StdinOnce: false
+      Env:
+        - "FOO=bar"
+        - "BAZ=quux"
+      Cmd:
+        - "date"
+      Entrypoint: ""
+      Image: "ubuntu"
+      Labels:
+        com.example.vendor: "Acme"
+        com.example.license: "GPL"
+        com.example.version: "1.0"
+      Volumes:
+        /volumes/data: {}
+      WorkingDir: ""
+      NetworkDisabled: false
+      MacAddress: "12:34:56:78:9a:bc"
+      ExposedPorts:
+        22/tcp: {}
+      StopSignal: "SIGTERM"
+      StopTimeout: 10
+      HostConfig:
+        Binds:
+          - "/tmp:/tmp"
+        Links:
+          - "redis3:redis"
+        Memory: 0
+        MemorySwap: 0
+        MemoryReservation: 0
+        KernelMemory: 0
+        NanoCPUs: 500000
+        CpuPercent: 80
+        CpuShares: 512
+        CpuPeriod: 100000
+        CpuRealtimePeriod: 1000000
+        CpuRealtimeRuntime: 10000
+        CpuQuota: 50000
+        CpusetCpus: "0,1"
+        CpusetMems: "0,1"
+        MaximumIOps: 0
+        MaximumIOBps: 0
+        BlkioWeight: 300
+        BlkioWeightDevice:
+          - {}
+        BlkioDeviceReadBps:
+          - {}
+        BlkioDeviceReadIOps:
+          - {}
+        BlkioDeviceWriteBps:
+          - {}
+        BlkioDeviceWriteIOps:
+          - {}
+        MemorySwappiness: 60
+        OomKillDisable: false
+        OomScoreAdj: 500
+        PidMode: ""
+        PidsLimit: -1
+        PortBindings:
+          22/tcp:
+            - HostPort: "11022"
+        PublishAllPorts: false
+        Privileged: false
+        ReadonlyRootfs: false
+        Dns:
+          - "8.8.8.8"
+        DnsOptions:
+          - ""
+        DnsSearch:
+          - ""
+        VolumesFrom:
+          - "parent"
+          - "other:ro"
+        CapAdd:
+          - "NET_ADMIN"
+        CapDrop:
+          - "MKNOD"
+        GroupAdd:
+          - "newgroup"
+        RestartPolicy:
+          Name: ""
+          MaximumRetryCount: 0
+        AutoRemove: true
+        NetworkMode: "bridge"
+        Devices: []
+        Ulimits:
+          - {}
+        LogConfig:
+          Type: "json-file"
+          Config: {}
+        SecurityOpt: []
+        StorageOpt: {}
+        CgroupParent: ""
+        VolumeDriver: ""
+        ShmSize: 67108864
+      NetworkingConfig:
+        EndpointsConfig:
+          isolated_nw:
+            IPAMConfig:
+              IPv4Address: "172.20.30.33"
+              IPv6Address: "2001:db8:abcd::3033"
+              LinkLocalIPs:
+                - "169.254.34.68"
+                - "fe80::3468"
+            Links:
+              - "container_1"
+              - "container_2"
+            Aliases:
+              - "server_x"
+              - "server_y"
   Port:
     type: "object"
     description: "An open port on a container"
@@ -4359,140 +4646,7 @@ paths:
           in: "body"
           description: "Container to create"
           schema:
-            allOf:
-              - $ref: "#/definitions/ContainerConfig"
-              - type: "object"
-                properties:
-                  HostConfig:
-                    $ref: "#/definitions/HostConfig"
-                  NetworkingConfig:
-                    description: "This container's networking configuration."
-                    type: "object"
-                    properties:
-                      EndpointsConfig:
-                        description: "A mapping of network name to endpoint configuration for that network."
-                        type: "object"
-                        additionalProperties:
-                          $ref: "#/definitions/EndpointSettings"
-            example:
-              Hostname: ""
-              Domainname: ""
-              User: ""
-              AttachStdin: false
-              AttachStdout: true
-              AttachStderr: true
-              Tty: false
-              OpenStdin: false
-              StdinOnce: false
-              Env:
-                - "FOO=bar"
-                - "BAZ=quux"
-              Cmd:
-                - "date"
-              Entrypoint: ""
-              Image: "ubuntu"
-              Labels:
-                com.example.vendor: "Acme"
-                com.example.license: "GPL"
-                com.example.version: "1.0"
-              Volumes:
-                /volumes/data: {}
-              WorkingDir: ""
-              NetworkDisabled: false
-              MacAddress: "12:34:56:78:9a:bc"
-              ExposedPorts:
-                22/tcp: {}
-              StopSignal: "SIGTERM"
-              StopTimeout: 10
-              HostConfig:
-                Binds:
-                  - "/tmp:/tmp"
-                Links:
-                  - "redis3:redis"
-                Memory: 0
-                MemorySwap: 0
-                MemoryReservation: 0
-                KernelMemory: 0
-                NanoCPUs: 500000
-                CpuPercent: 80
-                CpuShares: 512
-                CpuPeriod: 100000
-                CpuRealtimePeriod: 1000000
-                CpuRealtimeRuntime: 10000
-                CpuQuota: 50000
-                CpusetCpus: "0,1"
-                CpusetMems: "0,1"
-                MaximumIOps: 0
-                MaximumIOBps: 0
-                BlkioWeight: 300
-                BlkioWeightDevice:
-                  - {}
-                BlkioDeviceReadBps:
-                  - {}
-                BlkioDeviceReadIOps:
-                  - {}
-                BlkioDeviceWriteBps:
-                  - {}
-                BlkioDeviceWriteIOps:
-                  - {}
-                MemorySwappiness: 60
-                OomKillDisable: false
-                OomScoreAdj: 500
-                PidMode: ""
-                PidsLimit: -1
-                PortBindings:
-                  22/tcp:
-                    - HostPort: "11022"
-                PublishAllPorts: false
-                Privileged: false
-                ReadonlyRootfs: false
-                Dns:
-                  - "8.8.8.8"
-                DnsOptions:
-                  - ""
-                DnsSearch:
-                  - ""
-                VolumesFrom:
-                  - "parent"
-                  - "other:ro"
-                CapAdd:
-                  - "NET_ADMIN"
-                CapDrop:
-                  - "MKNOD"
-                GroupAdd:
-                  - "newgroup"
-                RestartPolicy:
-                  Name: ""
-                  MaximumRetryCount: 0
-                AutoRemove: true
-                NetworkMode: "bridge"
-                Devices: []
-                Ulimits:
-                  - {}
-                LogConfig:
-                  Type: "json-file"
-                  Config: {}
-                SecurityOpt: []
-                StorageOpt: {}
-                CgroupParent: ""
-                VolumeDriver: ""
-                ShmSize: 67108864
-              NetworkingConfig:
-                EndpointsConfig:
-                  isolated_nw:
-                    IPAMConfig:
-                      IPv4Address: "172.20.30.33"
-                      IPv6Address: "2001:db8:abcd::3033"
-                      LinkLocalIPs:
-                        - "169.254.34.68"
-                        - "fe80::3468"
-                    Links:
-                      - "container_1"
-                      - "container_2"
-                    Aliases:
-                      - "server_x"
-                      - "server_y"
-
+            $ref: "#/definitions/ContainerCreateBody"
           required: true
       responses:
         201:
@@ -5390,28 +5544,7 @@ paths:
           in: "body"
           required: true
           schema:
-            allOf:
-              - $ref: "#/definitions/Resources"
-              - type: "object"
-                properties:
-                  RestartPolicy:
-                    $ref: "#/definitions/RestartPolicy"
-            example:
-              BlkioWeight: 300
-              CpuShares: 512
-              CpuPeriod: 100000
-              CpuQuota: 50000
-              CpuRealtimePeriod: 1000000
-              CpuRealtimeRuntime: 10000
-              CpusetCpus: "0,1"
-              CpusetMems: "0"
-              Memory: 314572800
-              MemorySwap: 514288000
-              MemoryReservation: 209715200
-              KernelMemory: 52428800
-              RestartPolicy:
-                MaximumRetryCount: 4
-                Name: "on-failure"
+            $ref: "#/definitions/ContainerUpdateUpdate"
       tags: ["Container"]
   /containers/{id}/rename:
     post:
@@ -8858,76 +8991,7 @@ paths:
           in: "body"
           required: true
           schema:
-            allOf:
-              - $ref: "#/definitions/ServiceSpec"
-              - type: "object"
-                example:
-                  Name: "web"
-                  TaskTemplate:
-                    ContainerSpec:
-                      Image: "nginx:alpine"
-                      Mounts:
-                        -
-                          ReadOnly: true
-                          Source: "web-data"
-                          Target: "/usr/share/nginx/html"
-                          Type: "volume"
-                          VolumeOptions:
-                            DriverConfig: {}
-                            Labels:
-                              com.example.something: "something-value"
-                      Hosts: ["10.10.10.10 host1", "ABCD:EF01:2345:6789:ABCD:EF01:2345:6789 host2"]
-                      User: "33"
-                      DNSConfig:
-                        Nameservers: ["8.8.8.8"]
-                        Search: ["example.org"]
-                        Options: ["timeout:3"]
-                      Secrets:
-                        -
-                          File:
-                            Name: "www.example.org.key"
-                            UID: "33"
-                            GID: "33"
-                            Mode: 384
-                          SecretID: "fpjqlhnwb19zds35k8wn80lq9"
-                          SecretName: "example_org_domain_key"
-                    LogDriver:
-                      Name: "json-file"
-                      Options:
-                        max-file: "3"
-                        max-size: "10M"
-                    Placement: {}
-                    Resources:
-                      Limits:
-                        MemoryBytes: 104857600
-                      Reservations: {}
-                    RestartPolicy:
-                      Condition: "on-failure"
-                      Delay: 10000000000
-                      MaxAttempts: 10
-                  Mode:
-                    Replicated:
-                      Replicas: 4
-                  UpdateConfig:
-                    Parallelism: 2
-                    Delay: 1000000000
-                    FailureAction: "pause"
-                    Monitor: 15000000000
-                    MaxFailureRatio: 0.15
-                  RollbackConfig:
-                    Parallelism: 1
-                    Delay: 1000000000
-                    FailureAction: "pause"
-                    Monitor: 15000000000
-                    MaxFailureRatio: 0.15
-                  EndpointSpec:
-                    Ports:
-                      -
-                        Protocol: "tcp"
-                        PublishedPort: 8080
-                        TargetPort: 80
-                  Labels:
-                    foo: "bar"
+            $ref: "#/definitions/ServiceCreateBody"
         - name: "X-Registry-Auth"
           in: "header"
           description: "A base64-encoded auth configuration for pulling from private registries. [See the authentication section for details.](#section/Authentication)"
@@ -9028,42 +9092,7 @@ paths:
           in: "body"
           required: true
           schema:
-            allOf:
-              - $ref: "#/definitions/ServiceSpec"
-              - type: "object"
-                example:
-                  Name: "top"
-                  TaskTemplate:
-                    ContainerSpec:
-                      Image: "busybox"
-                      Args:
-                        - "top"
-                    Resources:
-                      Limits: {}
-                      Reservations: {}
-                    RestartPolicy:
-                      Condition: "any"
-                      MaxAttempts: 0
-                    Placement: {}
-                    ForceUpdate: 0
-                  Mode:
-                    Replicated:
-                      Replicas: 1
-                  UpdateConfig:
-                    Parallelism: 2
-                    Delay: 1000000000
-                    FailureAction: "pause"
-                    Monitor: 15000000000
-                    MaxFailureRatio: 0.15
-                  RollbackConfig:
-                    Parallelism: 1
-                    Delay: 1000000000
-                    FailureAction: "pause"
-                    Monitor: 15000000000
-                    MaxFailureRatio: 0.15
-                  EndpointSpec:
-                    Mode: "vip"
-
+            $ref: "#/definitions/ServiceUpdateBody"
         - name: "version"
           in: "query"
           description: "The version number of the service object being updated. This is required to avoid conflicting writes."
@@ -9517,19 +9546,7 @@ paths:
         - name: "body"
           in: "body"
           schema:
-            allOf:
-              - $ref: "#/definitions/SecretSpec"
-              - type: "object"
-                example:
-                  Name: "app-key.crt"
-                  Labels:
-                    foo: "bar"
-                  Data: "VEhJUyBJUyBOT1QgQSBSRUFMIENFUlRJRklDQVRFCg=="
-                  Driver:
-                    Name: "secret-bucket"
-                    Options:
-                      OptionA: "value for driver option A"
-                      OptionB: "value for driver option B"
+            $ref: "#/definitions/SecretCreateBody"
       tags: ["Secret"]
   /secrets/{id}:
     get:
@@ -9722,14 +9739,7 @@ paths:
         - name: "body"
           in: "body"
           schema:
-            allOf:
-              - $ref: "#/definitions/ConfigSpec"
-              - type: "object"
-                example:
-                  Name: "server.conf"
-                  Labels:
-                    foo: "bar"
-                  Data: "VEhJUyBJUyBOT1QgQSBSRUFMIENFUlRJRklDQVRFCg=="
+            $ref: "#/definitions/ConfigCreateBody"
       tags: ["Config"]
   /configs/{id}:
     get:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -159,77 +159,6 @@ tags:
     x-displayName: "System"
 
 definitions:
-  ServiceCreateBody:
-    allOf:
-      - $ref: "#/definitions/ServiceSpec"
-      - type: "object"
-        example:
-          Name: "web"
-          TaskTemplate:
-            ContainerSpec:
-              Image: "nginx:alpine"
-              Mounts:
-                -
-                  ReadOnly: true
-                  Source: "web-data"
-                  Target: "/usr/share/nginx/html"
-                  Type: "volume"
-                  VolumeOptions:
-                    DriverConfig: {}
-                    Labels:
-                      com.example.something: "something-value"
-              Hosts: ["10.10.10.10 host1", "ABCD:EF01:2345:6789:ABCD:EF01:2345:6789 host2"]
-              User: "33"
-              DNSConfig:
-                Nameservers: ["8.8.8.8"]
-                Search: ["example.org"]
-                Options: ["timeout:3"]
-              Secrets:
-                -
-                  File:
-                    Name: "www.example.org.key"
-                    UID: "33"
-                    GID: "33"
-                    Mode: 384
-                  SecretID: "fpjqlhnwb19zds35k8wn80lq9"
-                  SecretName: "example_org_domain_key"
-            LogDriver:
-              Name: "json-file"
-              Options:
-                max-file: "3"
-                max-size: "10M"
-            Placement: {}
-            Resources:
-              Limits:
-                MemoryBytes: 104857600
-              Reservations: {}
-            RestartPolicy:
-              Condition: "on-failure"
-              Delay: 10000000000
-              MaxAttempts: 10
-          Mode:
-            Replicated:
-              Replicas: 4
-          UpdateConfig:
-            Parallelism: 2
-            Delay: 1000000000
-            FailureAction: "pause"
-            Monitor: 15000000000
-            MaxFailureRatio: 0.15
-          RollbackConfig:
-            Parallelism: 1
-            Delay: 1000000000
-            FailureAction: "pause"
-            Monitor: 15000000000
-            MaxFailureRatio: 0.15
-          EndpointSpec:
-            Ports:
-              -
-                Protocol: "tcp"
-                PublishedPort: 8080
-                TargetPort: 80
-          Labels:
-            foo: "bar"
   SecretCreateBody:
     allOf:
       - $ref: "#/definitions/SecretSpec"
@@ -490,9 +419,11 @@ definitions:
       Target:
         description: "Container path."
         type: "string"
+        example: "/usr/share/nginx/html"
       Source:
         description: "Mount source (e.g. a volume name, a host path)."
         type: "string"
+        example: "web-data"
       Type:
         description: |
           The mount type. Available types:
@@ -505,9 +436,11 @@ definitions:
           - "bind"
           - "volume"
           - "tmpfs"
+        example: "volume"
       ReadOnly:
         description: "Whether the mount should be read-only."
         type: "boolean"
+        example: true
       Consistency:
         description: "The consistency requirement for the mount: `default`, `consistent`, `cached`, or `delegated`."
         type: "string"
@@ -537,6 +470,8 @@ definitions:
             type: "object"
             additionalProperties:
               type: "string"
+            example:
+              com.example.something: "something-value"
           DriverConfig:
             description: "Map of driver specific options"
             type: "object"
@@ -2762,6 +2697,7 @@ definitions:
           User:
             description: "The user inside the container."
             type: "string"
+            example: "33"
           Groups:
             type: "array"
             description: "A list of additional groups that the container process will run as."
@@ -2852,6 +2788,7 @@ definitions:
                   IP_address canonical_hostname [aliases...]
             items:
               type: "string"
+            example: ["10.10.10.10 host1", "ABCD:EF01:2345:6789:ABCD:EF01:2345:6789 host2"]
           DNSConfig:
             description: "Specification for DNS related configurations in resolver configuration file (`resolv.conf`)."
             type: "object"
@@ -2861,16 +2798,19 @@ definitions:
                 type: "array"
                 items:
                   type: "string"
+                example: ["8.8.8.8"]
               Search:
                 description: "A search list for host-name lookup."
                 type: "array"
                 items:
                   type: "string"
+                example: ["example.org"]
               Options:
                 description: "A list of internal resolver variables to be modified (e.g., `debug`, `ndots:3`, etc.)."
                 type: "array"
                 items:
                   type: "string"
+                example: ["timeout:3"]
           Secrets:
             description: "Secrets contains references to zero or more secrets that will be exposed to the service."
             type: "array"
@@ -2884,24 +2824,30 @@ definitions:
                     Name:
                       description: "Name represents the final filename in the filesystem."
                       type: "string"
+                      example: "www.example.org.key"
                     UID:
                       description: "UID represents the file UID."
                       type: "string"
+                      example: "33"
                     GID:
                       description: "GID represents the file GID."
                       type: "string"
+                      example: "33"
                     Mode:
                       description: "Mode represents the FileMode of the file."
                       type: "integer"
                       format: "uint32"
+                      example: 384
                 SecretID:
                   description: "SecretID represents the ID of the specific secret that we're referencing."
                   type: "string"
+                  example: "fpjqlhnwb19zds35k8wn80lq9"
                 SecretName:
                   description: |
                     SecretName is the name of the secret that this references, but this is just provided for
                     lookup/display purposes. The secret in the reference will be identified by its ID.
                   type: "string"
+                  example: "example_org_domain_key"
           Configs:
             description: "Configs contains references to zero or more configs that will be exposed to the service."
             type: "array"
@@ -2960,6 +2906,7 @@ definitions:
             description: "Delay between restart attempts."
             type: "integer"
             format: "int64"
+            example: 10000000000
           MaxAttempts:
             description: "Maximum attempts to restart a given container before giving up (default value is 0, which is ignored)."
             type: "integer"
@@ -3033,10 +2980,14 @@ definitions:
         properties:
           Name:
             type: "string"
+            example: "json-file"
           Options:
             type: "object"
             additionalProperties:
               type: "string"
+            example:
+              max-file: "3"
+              max-size: "10M"
 
   TaskState:
     type: "string"
@@ -3306,12 +3257,15 @@ definitions:
         enum:
           - "tcp"
           - "udp"
+        example: "tcp"
       TargetPort:
         description: "The port inside the container."
         type: "integer"
+        example: 80
       PublishedPort:
         description: "The port on the swarm hosts."
         type: "integer"
+        example: 8080
       PublishMode:
         description: |
           The mode in which port is published.
@@ -8973,7 +8927,7 @@ paths:
           in: "body"
           required: true
           schema:
-            $ref: "#/definitions/ServiceCreateBody"
+            $ref: "#/definitions/ServiceSpec"
         - name: "X-Registry-Auth"
           in: "header"
           description: "A base64-encoded auth configuration for pulling from private registries. [See the authentication section for details.](#section/Authentication)"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -159,42 +159,6 @@ tags:
     x-displayName: "System"
 
 definitions:
-  ServiceUpdateBody:
-    allOf:
-      - $ref: "#/definitions/ServiceSpec"
-      - type: "object"
-        example:
-          Name: "top"
-          TaskTemplate:
-            ContainerSpec:
-              Image: "busybox"
-              Args:
-                - "top"
-            Resources:
-              Limits: {}
-              Reservations: {}
-            RestartPolicy:
-              Condition: "any"
-              MaxAttempts: 0
-            Placement: {}
-            ForceUpdate: 0
-          Mode:
-            Replicated:
-              Replicas: 1
-          UpdateConfig:
-            Parallelism: 2
-            Delay: 1000000000
-            FailureAction: "pause"
-            Monitor: 15000000000
-            MaxFailureRatio: 0.15
-          RollbackConfig:
-            Parallelism: 1
-            Delay: 1000000000
-            FailureAction: "pause"
-            Monitor: 15000000000
-            MaxFailureRatio: 0.15
-          EndpointSpec:
-            Mode: "vip"
   ServiceCreateBody:
     allOf:
       - $ref: "#/definitions/ServiceSpec"
@@ -2767,6 +2731,7 @@ definitions:
           Image:
             description: "The image name to use for the container"
             type: "string"
+            example: "busybox"
           Labels:
             description: "User-defined key/value data."
             type: "object"
@@ -2782,6 +2747,7 @@ definitions:
             type: "array"
             items:
               type: "string"
+            example: ["top"]
           Hostname:
             description: "The hostname to use for the container, as a valid RFC 1123 hostname."
             type: "string"
@@ -2989,6 +2955,7 @@ definitions:
               - "none"
               - "on-failure"
               - "any"
+            example: "any"
           Delay:
             description: "Delay between restart attempts."
             type: "integer"
@@ -2998,6 +2965,7 @@ definitions:
             type: "integer"
             format: "int64"
             default: 0
+            example: 0
           Window:
             description: "Windows is the time window used to evaluate the restart policy (default value is 0, which is unbounded)."
             type: "integer"
@@ -3044,6 +3012,7 @@ definitions:
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"
+        example: 0
       Runtime:
         description: "Runtime is the type of runtime specified for the task executor."
         type: "string"
@@ -3216,6 +3185,7 @@ definitions:
       Name:
         description: "Name of the service."
         type: "string"
+        example: "top"
       Labels:
         description: "User-defined key/value metadata."
         type: "object"
@@ -3233,6 +3203,7 @@ definitions:
               Replicas:
                 type: "integer"
                 format: "int64"
+                example: 1
           Global:
             type: "object"
       UpdateConfig:
@@ -3243,10 +3214,12 @@ definitions:
             description: "Maximum number of tasks to be updated in one iteration (0 means unlimited parallelism)."
             type: "integer"
             format: "int64"
+            example: 2
           Delay:
             description: "Amount of time between updates, in nanoseconds."
             type: "integer"
             format: "int64"
+            example: 1000000000
           FailureAction:
             description: "Action to take if an updated task fails to run, or stops running during the update."
             type: "string"
@@ -3254,14 +3227,17 @@ definitions:
               - "continue"
               - "pause"
               - "rollback"
+            example: "pause"
           Monitor:
             description: "Amount of time to monitor each updated task for failures, in nanoseconds."
             type: "integer"
             format: "int64"
+            example: 15000000000
           MaxFailureRatio:
             description: "The fraction of tasks that may fail during an update before the failure action is invoked, specified as a floating point number between 0 and 1."
             type: "number"
             default: 0
+            example: 0.15
           Order:
             description: "The order of operations when rolling out an updated task. Either the old task is shut down before the new task is started, or the new task is started before the old task is shut down."
             type: "string"
@@ -3276,24 +3252,29 @@ definitions:
             description: "Maximum number of tasks to be rolled back in one iteration (0 means unlimited parallelism)."
             type: "integer"
             format: "int64"
+            example: 1
           Delay:
             description: "Amount of time between rollback iterations, in nanoseconds."
             type: "integer"
             format: "int64"
+            example: 1000000000
           FailureAction:
             description: "Action to take if an rolled back task fails to run, or stops running during the rollback."
             type: "string"
             enum:
               - "continue"
               - "pause"
+            example: "pause"
           Monitor:
             description: "Amount of time to monitor each rolled back task for failures, in nanoseconds."
             type: "integer"
             format: "int64"
+            example: 15000000000
           MaxFailureRatio:
             description: "The fraction of tasks that may fail during a rollback before the failure action is invoked, specified as a floating point number between 0 and 1."
             type: "number"
             default: 0
+            example: 0.15
           Order:
             description: "The order of operations when rolling back a task. Either the old task is shut down before the new task is started, or the new task is started before the old task is shut down."
             type: "string"
@@ -3362,6 +3343,7 @@ definitions:
           - "vip"
           - "dnsrr"
         default: "vip"
+        example: "vip"
       Ports:
         description: "List of exposed ports that this service is accessible on from the outside. Ports can only be provided if `vip` resolution mode is used."
         type: "array"
@@ -9092,7 +9074,7 @@ paths:
           in: "body"
           required: true
           schema:
-            $ref: "#/definitions/ServiceUpdateBody"
+            $ref: "#/definitions/ServiceSpec"
         - name: "version"
           in: "query"
           description: "The version number of the service object being updated. This is required to avoid conflicting writes."


### PR DESCRIPTION
**- What I did**
Worked around swagger-api/swagger-codegen#3225, which renders the current swagger.yaml invalid and prevents generating API clients.

See #27919, and in particular https://github.com/moby/moby/issues/27919#issuecomment-284520682.

**- How I did it**
Move all inline `allOf` schema declarations to definitions section.

**- How to verify it**
Start a container for performing swagger codegen:

```
docker run -it --rm --entrypoint sh swaggerapi/swagger-codegen-cli
```

Run the following to generate the API client:

```
java -jar /opt/swagger-codegen-cli/swagger-codegen-cli.jar generate --verbose -i <url> -l typescript-node -o /local >log.txt 2>&1
```

Where `<url>` should be substituted with:

 - `https://raw.githubusercontent.com/moby/moby/master/api/swagger.yaml`
 - `https://raw.githubusercontent.com/masaeedu/moby/27919-fixswagger/api/swagger.yaml`

Examine the `/local` folder to see the difference in generated clients before and after the change. Due to swagger-api/swagger-codegen#3225, a client generated from `swagger.yaml` on master will be missing doc comments and type declarations for several parameters.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix swagger codegen issue.

**- A picture of a cute animal (not mandatory but encouraged)**
🐱 
