### PR TITLE
Fix regression on inspect

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/go-connections/nat"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // RootFS returns Image's RootFS description including the layer IDs.
@@ -328,7 +327,7 @@ type ContainerJSONBase struct {
 	Name            string
 	RestartCount    int
 	Driver          string
-	Platform        specs.Platform
+	Platform        string
 	MountLabel      string
 	ProcessLabel    string
 	AppArmorProfile string

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/daemon/network"
 	volumestore "github.com/docker/docker/volume/store"
 	"github.com/docker/go-connections/nat"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ContainerInspect returns low-level information about a
@@ -172,7 +171,7 @@ func (daemon *Daemon) getInspectData(container *container.Container) (*types.Con
 		Name:         container.Name,
 		RestartCount: container.RestartCount,
 		Driver:       container.Driver,
-		Platform:     specs.Platform{OS: container.OS},
+		Platform:     container.OS,
 		MountLabel:   container.MountLabel,
 		ProcessLabel: container.ProcessLabel,
 		ExecIDs:      container.GetExecIDs(),


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/35175

Signed-off-by: John Howard <jhoward@microsoft.com>

Unfortunately, I regressed use of a client against docker master daemon in https://github.com/moby/moby/pull/34642 when I changed the `Platform` field to an OCI `specs.Platform`. Changing it back to a string.

Without this change, docker inspect would fail with `json: cannot unmarshal object into Go struct field ContainerJSON.Platform of type string` 

@johnstep As per offline conversation. PTAL. Ping @thaJeztah 