### PR TITLE
Change multi-type parameters to single type

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -836,9 +836,7 @@ definitions:
           type: "string"
       Cmd:
         description: "Command to run specified as a string or an array of strings."
-        type:
-          - "array"
-          - "string"
+        type: "array"
         items:
           type: "string"
       Healthcheck:
@@ -866,9 +864,7 @@ definitions:
           The entry point for the container as a string or an array of strings.
 
           If the array consists of exactly one empty string (`[""]`) then the entry point is reset to system default (i.e., the entry point used by docker when there is no `ENTRYPOINT` instruction in the `Dockerfile`).
-        type:
-          - "array"
-          - "string"
+        type: "array"
         items:
           type: "string"
       NetworkDisabled:


### PR DESCRIPTION
**- What I did**
Remove multi-type parameter definitions from swagger.yaml. While these are valid in JSON-schema, they are not valid in the extended subset that Swagger employs. See https://github.com/moby/moby/issues/27919#issuecomment-335067510 and subsequent discussion.

**- How to verify it**
Existing `swagger.yaml` chokes when validated with https://editor.swagger.io. Updated version does not.

**- Description for the changelog**

Remove invalid multi-type parameter definitions in swagger.yaml

**- A picture of a cute animal (not mandatory but encouraged)**
🐶 
