### PR TITLE
Add container resource verifications

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -99,9 +99,6 @@ func getMemoryResources(config containertypes.Resources) *specs.LinuxMemory {
 func getCPUResources(config containertypes.Resources) (*specs.LinuxCPU, error) {
 	cpu := specs.LinuxCPU{}
 
-	if config.CPUShares < 0 {
-		return nil, fmt.Errorf("shares: invalid argument")
-	}
 	if config.CPUShares >= 0 {
 		shares := uint64(config.CPUShares)
 		cpu.Shares = &shares
@@ -391,6 +388,9 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 		warnings = append(warnings, "You specified a kernel memory limit on a kernel older than 4.0. Kernel memory limits are experimental on older kernels, it won't work as expected and can cause your system to be unstable.")
 		logrus.Warn("You specified a kernel memory limit on a kernel older than 4.0. Kernel memory limits are experimental on older kernels, it won't work as expected and can cause your system to be unstable.")
 	}
+	if resources.KernelMemory < 0 {
+		return warnings, fmt.Errorf("Invalid KernelMemory value. Must be nonnegative.")
+	}
 	if resources.OomKillDisable != nil && !sysInfo.OomKillDisable {
 		// only produce warnings if the setting wasn't to *disable* the OOM Kill; no point
 		// warning the caller if they already wanted the feature to be off
@@ -433,6 +433,9 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 		logrus.Warn("Your kernel does not support CPU shares or the cgroup is not mounted. Shares discarded.")
 		resources.CPUShares = 0
 	}
+	if resources.CPUShares < 0 {
+		return warnings, fmt.Errorf("Invalid CPUShares value. Must be nonnegative.")
+	}
 	if resources.CPUPeriod > 0 && !sysInfo.CPUCfsPeriod {
 		warnings = append(warnings, "Your kernel does not support CPU cfs period or the cgroup is not mounted. Period discarded.")
 		logrus.Warn("Your kernel does not support CPU cfs period or the cgroup is not mounted. Period discarded.")
@@ -448,6 +451,9 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 	}
 	if resources.CPUQuota > 0 && resources.CPUQuota < 1000 {
 		return warnings, fmt.Errorf("CPU cfs quota can not be less than 1ms (i.e. 1000)")
+	}
+	if resources.CPUQuota < 0 {
+		return warnings, fmt.Errorf("Invalid CPUQuota value. Must be nonnegative.")
 	}
 	if resources.CPUPercent > 0 {
 		warnings = append(warnings, fmt.Sprintf("%s does not support CPU percent. Percent discarded.", runtime.GOOS))
@@ -514,6 +520,9 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 		warnings = append(warnings, "Your kernel does not support IOPS Block write limit or the cgroup is not mounted. Block I/O IOPS write limit discarded.")
 		logrus.Warn("Your kernel does not support IOPS Block I/O write limit or the cgroup is not mounted. Block I/O IOPS write limit discarded.")
 		resources.BlkioDeviceWriteIOps = []*pblkiodev.ThrottleDevice{}
+	}
+	if resources.CPURealtimeRuntime < 0 {
+		return warnings, fmt.Errorf("Invalid CPURealtimeRuntime value. Must be nonnegative.")
 	}
 
 	return warnings, nil

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -770,7 +770,7 @@ func (s *DockerSuite) TestRunInvalidCPUShares(c *check.C) {
 
 	out, _, err = dockerCmdWithError("run", "--cpu-shares", "-1", "busybox", "echo", "test")
 	c.Assert(err, check.NotNil, check.Commentf(out))
-	expected = "shares: invalid argument"
+	expected = "Invalid CPUShares value. Must be nonnegative."
 	c.Assert(out, checker.Contains, expected)
 
 	out, _, err = dockerCmdWithError("run", "--cpu-shares", "99999999", "busybox", "echo", "test")


### PR DESCRIPTION
Signed-off-by: Jiuyuan Huang <jiuyuan.huang@daocloud.io>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I found that some verification for container creating field are needed in CentOS. It is possible to pass inappropriate values to docker. Also, the user may not get warning of the inappropriate input if the have made unintended mistakes. I have added more verification on `KernelMemory`, `CPUShares`, `CPUQuota`, and `CPURealtimeRuntime`.

**- How I did it**
I added more verification on `KernelMemory`, `CPUShares`, `CPUQuota`, and `CPURealtimeRuntime` in function `verifyContainerResources` under `daemon/daemon_unix.go`.

**- How to verify it**
Run integration test.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
