### PR TITLE
Return 400 error if API client is too new

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -50,6 +50,8 @@ info:
 
     In previous versions of Docker, it was possible to access the API without providing a version. This behaviour is now deprecated will be removed in a future version of Docker.
 
+    If the API version specified in the URL is not supported by the daemon, a HTTP `400 Bad Request` error message is returned.
+
     The API uses an open schema model, which means server may add extra properties to responses. Likewise, the server will ignore any extra query parameters and request body properties. When you write clients, you need to ignore additional properties in responses to ensure they do not break when talking to newer Docker daemons.
 
     This documentation is for version 1.34 of the API. Use this table to find documentation for previous versions of the API:

--- a/docs/api/v1.18.md
+++ b/docs/api/v1.18.md
@@ -25,6 +25,11 @@ redirect_from:
    `stdin` and `stderr`.
  - A `Content-Length` header should be present in `POST` requests to endpoints
    that expect a body.
+ - To lock to a specific version of the API, you prefix the URL with the version
+   of the API to use. For example, `/v1.18/info`. If no version is included in
+   the URL, the maximum supported API version is used.
+ - If the API version specified in the URL is not supported by the daemon, a HTTP
+   `400 Bad Request` error message is returned.
 
 ## 2. Endpoints
 

--- a/docs/api/v1.19.md
+++ b/docs/api/v1.19.md
@@ -23,10 +23,13 @@ redirect_from:
  - The API tends to be REST. However, for some complex commands, like `attach`
    or `pull`, the HTTP connection is hijacked to transport `stdout`,
    `stdin` and `stderr`.
- - When the client API version is newer than the daemon's, these calls return an HTTP
-   `400 Bad Request` error message.
  - A `Content-Length` header should be present in `POST` requests to endpoints
    that expect a body.
+ - To lock to a specific version of the API, you prefix the URL with the version
+   of the API to use. For example, `/v1.18/info`. If no version is included in
+   the URL, the maximum supported API version is used.
+ - If the API version specified in the URL is not supported by the daemon, a HTTP
+   `400 Bad Request` error message is returned.
 
 ## 2. Endpoints
 

--- a/docs/api/v1.20.md
+++ b/docs/api/v1.20.md
@@ -23,10 +23,13 @@ redirect_from:
  - The API tends to be REST. However, for some complex commands, like `attach`
    or `pull`, the HTTP connection is hijacked to transport `stdout`,
    `stdin` and `stderr`.
- - When the client API version is newer than the daemon's, these calls return an HTTP
-   `400 Bad Request` error message.
  - A `Content-Length` header should be present in `POST` requests to endpoints
    that expect a body.
+ - To lock to a specific version of the API, you prefix the URL with the version
+   of the API to use. For example, `/v1.18/info`. If no version is included in
+   the URL, the maximum supported API version is used.
+ - If the API version specified in the URL is not supported by the daemon, a HTTP
+   `400 Bad Request` error message is returned.
 
 ## 2. Endpoints
 

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -23,10 +23,13 @@ redirect_from:
  - The API tends to be REST. However, for some complex commands, like `attach`
    or `pull`, the HTTP connection is hijacked to transport `stdout`,
    `stdin` and `stderr`.
- - When the client API version is newer than the daemon's, these calls return an HTTP
-   `400 Bad Request` error message.
  - A `Content-Length` header should be present in `POST` requests to endpoints
    that expect a body.
+ - To lock to a specific version of the API, you prefix the URL with the version
+   of the API to use. For example, `/v1.18/info`. If no version is included in
+   the URL, the maximum supported API version is used.
+ - If the API version specified in the URL is not supported by the daemon, a HTTP
+   `400 Bad Request` error message is returned.
 
 ## 2. Endpoints
 

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -23,10 +23,13 @@ redirect_from:
  - The API tends to be REST. However, for some complex commands, like `attach`
    or `pull`, the HTTP connection is hijacked to transport `stdout`,
    `stdin` and `stderr`.
- - When the client API version is newer than the daemon's, these calls return an HTTP
-   `400 Bad Request` error message.
  - A `Content-Length` header should be present in `POST` requests to endpoints
    that expect a body.
+ - To lock to a specific version of the API, you prefix the URL with the version
+   of the API to use. For example, `/v1.18/info`. If no version is included in
+   the URL, the maximum supported API version is used.
+ - If the API version specified in the URL is not supported by the daemon, a HTTP
+   `400 Bad Request` error message is returned.
 
 ## 2. Endpoints
 

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -23,10 +23,13 @@ redirect_from:
  - The API tends to be REST. However, for some complex commands, like `attach`
    or `pull`, the HTTP connection is hijacked to transport `stdout`,
    `stdin` and `stderr`.
- - When the client API version is newer than the daemon's, these calls return an HTTP
-   `400 Bad Request` error message.
  - A `Content-Length` header should be present in `POST` requests to endpoints
    that expect a body.
+ - To lock to a specific version of the API, you prefix the URL with the version
+   of the API to use. For example, `/v1.18/info`. If no version is included in
+   the URL, the maximum supported API version is used.
+ - If the API version specified in the URL is not supported by the daemon, a HTTP
+   `400 Bad Request` error message is returned.
 
 ## 2. Endpoints
 

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -25,6 +25,11 @@ redirect_from:
    `stdin` and `stderr`.
  - A `Content-Length` header should be present in `POST` requests to endpoints
    that expect a body.
+ - To lock to a specific version of the API, you prefix the URL with the version
+   of the API to use. For example, `/v1.18/info`. If no version is included in
+   the URL, the maximum supported API version is used.
+ - If the API version specified in the URL is not supported by the daemon, a HTTP
+   `400 Bad Request` error message is returned.
 
 ## 2. Errors
 


### PR DESCRIPTION
Commit e98e4a71110fd33852bb755a9b8b4ebc9df904db (https://github.com/moby/moby/pull/27745) implemented API version negotiation using the `/_ping` endpoint. In that change, URL validation for the maximum supported API version was removed from the API server (validation for the _minimum_ version was kept in place).

With this feature, clients that support version negotiation would negotiate the maximum version supported by the daemon, and downgrade to an older API version if the client's default API version is not supported.

However, clients that do _not_ support version negotiation can call API versions that are higher than the maximum supported version. Due to the missing version check, this is silently ignored, and the daemon's default API version is used.

This is a problem, because the actual API version in use is non-deterministic; for example, calling `/v9999.9999/version` on a daemon that runs API v1.34 will use API v1.34, but calling the same URL on an older daemon may use API version v1.24 (for example).

This patch reverts the removal of the API check for maximum supported versions. The documentation has been updated accordingly

Before this patch is applied, the daemon returns a 200 (success):

    $ curl -v --unix-socket /var/run/docker.sock http://localhost/v9999.9999/version
    *   Trying /var/run/docker.sock...
    * Connected to localhost (/Users/sebastiaan/Library/Containers/com.dock) port 80 (#0)
    > GET /v9999.9999/version HTTP/1.1
    > Host: localhost
    > User-Agent: curl/7.54.0
    > Accept: */*
    >
    < HTTP/1.1 200 OK
    < Api-Version: 1.32
    < Content-Length: 240
    < Content-Type: application/json
    < Date: Tue, 10 Oct 2017 09:11:29 GMT
    < Docker-Experimental: true
    < Ostype: linux
    < Server: Docker/17.09.0-ce (linux)
    <
    {"Version":"17.09.0-ce","ApiVersion":"1.32","MinAPIVersion":"1.12","GitCommit":"afdb6d4","GoVersion":"go1.8.3","Os":"linux","Arch":"amd64","KernelVersion":"4.9.49-moby","Experimental":true,"BuildTime":"2017-09-26T22:45:38.000000000+00:00"}
    * Connection #0 to host localhost left intact

After this patch is applied, a 400 (Bad Request) is returned:

    $ curl -v --unix-socket /var/run/docker.sock http://localhost/v9999.9999/version
    *   Trying /var/run/docker.sock...
    * Connected to localhost (/var/run/docker.sock) port 80 (#0)
    > GET /v9999.9999/info HTTP/1.1
    > Host: localhost
    > User-Agent: curl/7.52.1
    > Accept: */*
    >
    < HTTP/1.1 400 Bad Request
    < Content-Type: application/json
    < Date: Tue, 10 Oct 2017 08:08:34 GMT
    < Content-Length: 89
    <
    {"message":"client version 9999.9999 is too new. Maximim supported API version is 1.34"}
    * Curl_http_done: called premature == 0
    * Connection #0 to host localhost left intact

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```Markdown
* Fix missing version check for API versions that are higher than what's supported. The API now returns a 400 error for those requests [moby/moby#35150](https://github.com/moby/moby/pull/35150)
```

**- A picture of a cute animal (not mandatory but encouraged)**

![baby-goats-5](https://user-images.githubusercontent.com/1804568/31379239-02749e0a-adae-11e7-8aea-e5485fc2012d.jpg)


(Image by [Fearsy4](http://photobucket.com/user/Fearsy4/library/))