### PR TITLE
Always return version and server headers

### DIFF
--- a/api/server/middleware/version_test.go
+++ b/api/server/middleware/version_test.go
@@ -3,10 +3,12 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/server/httputils"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
 
@@ -79,4 +81,32 @@ func TestVersionMiddlewareVersionTooNew(t *testing.T) {
 	if !strings.Contains(err.Error(), "client version 9999.9999 is too new. Maximum supported API version is 1.10.0") {
 		t.Fatalf("Expected too new client error, got %v", err)
 	}
+}
+
+func TestVersionMiddlewareWithErrorsReturnsHeaders(t *testing.T) {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+		if httputils.VersionFromContext(ctx) == "" {
+			t.Fatal("Expected version, got empty string")
+		}
+		return nil
+	}
+
+	defaultVersion := "1.10.0"
+	minVersion := "1.2.0"
+	m := NewVersionMiddleware(defaultVersion, defaultVersion, minVersion)
+	h := m.WrapHandler(handler)
+
+	req, _ := http.NewRequest("GET", "/containers/json", nil)
+	resp := httptest.NewRecorder()
+	ctx := context.Background()
+
+	vars := map[string]string{"version": "0.1"}
+	err := h(ctx, resp, req, vars)
+
+	assert.Error(t, err)
+	hdr := resp.Result().Header
+	assert.Contains(t, hdr.Get("Server"), "Docker/"+defaultVersion)
+	assert.Contains(t, hdr.Get("Server"), runtime.GOOS)
+	assert.Equal(t, hdr.Get("API-Version"), defaultVersion)
+	assert.Equal(t, hdr.Get("OSType"), runtime.GOOS)
 }


### PR DESCRIPTION
Noticed this while working on https://github.com/moby/moby/pull/35150, so opening a PR :smile:

If a 400 error is returned due to an API version mismatch, no version and server-identification headers were returned by the API.

All information in these headers is "static", so there is no reason to omit the information in case of an error being returned.

This patch updates the version middleware to always return the headers.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```Markdown
* Do not omit  `Server`, `API-Version`, and `OSType` headers on 400 API response due to API version mismatch [moby/moby#35151](https://github.com/moby/moby/pull/35151)
```


**- A picture of a cute animal (not mandatory but encouraged)**