### PR TITLE
Dev environment path and docs of docs.docker.com don't correspond

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -158,7 +158,7 @@ RUN groupadd -r docker
 RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
-WORKDIR /go/src/github.com/docker/docker
+WORKDIR /go/src/github.com/moby/moby
 ENV DOCKER_BUILDTAGS apparmor seccomp selinux
 
 # Let us use a .bashrc file
@@ -189,8 +189,8 @@ RUN ln -s /usr/local/completion/bash/docker /etc/bash_completion.d/docker
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]
 
-# Upload docker source
-COPY . /go/src/github.com/docker/docker
+# Upload moby source
+COPY . /go/src/github.com/moby/moby
 
 # Options for hack/validate/gometalinter
 ENV GOMETALINTER_OPTS="--deadline 2m"


### PR DESCRIPTION
The doc says dev working directory is `/go/src/github.com/moby/moby`, but actually it is `/go/src/github.com/docker/docker`. I think the doc is right.

[doc from docs.docker.com](https://docs.docker.com/opensource/project/set-up-dev-env/#task-2-start-a-development-container)

Signed-off-by: michaelyou <michaelseu2011@gmail.com>

