### PR TITLE
Bring "Lego set" back in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Moby Project
 
 Moby is an open-source project created by Docker to enable and accelerate software containerization.
 
-It provides a comprehensive toolkit of components, the framework for assembling them into custom container-based systems, and a place for all container enthusiasts and professionals to experiment and exchange ideas.
+It provides a "Lego set" of toolkit components, the framework for assembling them into custom container-based systems, and a place for all container enthusiasts and professionals to experiment and exchange ideas.
 Components include container build tools, a container registry, orchestration tools, a runtime and more, and these can be used as building blocks in conjunction with other tools and projects.
 
 ## Principles


### PR DESCRIPTION
This PR brings the nice concept of "Lego set" back in README.md. (See comment https://github.com/moby/moby/pull/35141#discussion_r143726091)

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

/cc @justincormack @tiborvass @shykes @AkihiroSuda @thaJeztah 

![killer-whale-dreams](https://user-images.githubusercontent.com/6932348/31391268-e71e3a94-ad8a-11e7-825a-b1618a8dbf81.jpg)