### PR TITLE
Don't abort when setting may_detach_mounts

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1300,7 +1300,10 @@ func setupDaemonProcess(config *config.Config) error {
 	if err := setupOOMScoreAdj(config.OOMScoreAdjust); err != nil {
 		return err
 	}
-	return setMayDetachMounts()
+	if err := setMayDetachMounts(); err != nil {
+		logrus.WithError(err).Warn("Could not set may_detach_mounts kernel parameter")
+	}
+	return nil
 }
 
 // This is used to allow removal of mountpoints that may be mounted in other


### PR DESCRIPTION
83c2152de503012195bd26069fd8fbd2dea4b32f sets the kernel param for
fs.may_detach_mounts, but this is not necessary for the daemon to
operate. Instead of erroring out (and thus aborting startup) just log
the error.

Fixes docker/for-linux#126