### PR TITLE
Do not print e2e test logs by default

### DIFF
--- a/hack/test/e2e-run.sh
+++ b/hack/test/e2e-run.sh
@@ -16,7 +16,7 @@ run_test_integration() {
 }
 
 run_test_integration_suites() {
-  local flags="-test.v -test.timeout=${TIMEOUT} $TESTFLAGS"
+  local flags="-test.timeout=${TIMEOUT} $TESTFLAGS"
   for dir in /tests/integration/*; do
     if ! (
       cd $dir
@@ -28,7 +28,7 @@ run_test_integration_suites() {
 
 run_test_integration_legacy_suites() {
   (
-    flags="-check.v -check.timeout=${TIMEOUT} -test.timeout=360m $TESTFLAGS_LEGACY"
+    flags="-check.timeout=${TIMEOUT} -test.timeout=360m $TESTFLAGS_LEGACY"
     cd /tests/integration-cli
     echo "Running $PWD"
     ./test.main $flags


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Turned off test logging by default. This allows users to only activate logs if they would like them.

**- How I did it**
Removed the `-test.v` and `-check.v` flags from the run script.

**- How to verify it**
Run e2e tests

