### PR TITLE
hide emptyfs error

### DIFF
--- a/hack/make/.ensure-emptyfs
+++ b/hack/make/.ensure-emptyfs
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-set -e
 
-if ! docker image inspect emptyfs > /dev/null; then
+inspect_err="$(docker image inspect emptyfs 2>&1 > /dev/null)"
+
+set -e
+if [ "$inspect_err" == "Error: No such image: emptyfs" ]; then
 	# build a "docker save" tarball for "emptyfs"
 	# see https://github.com/docker/docker/pull/5262
 	# and also https://github.com/docker/docker/issues/4242
@@ -20,4 +22,6 @@ if ! docker image inspect emptyfs > /dev/null; then
 		tar -cC "$dir" . | docker load
 	)
 	rm -rf "$dir"
+else
+	echo "$inspect_err"
 fi


### PR DESCRIPTION
This was confusing:

```
09:18:06 ---> Making bundle: .integration-daemon-setup (in bundles/test-integration)
09:18:06 ---> Making bundle: .ensure-emptyfs (in bundles/test-integration)
09:18:06 Error: No such image: emptyfs
09:18:06 Running integration-test (iteration 1)
```

It looks like a problem, but this script builds the image if it doesn't exist so let's hide it.

Signed-off-by: Christy Perez <christy@linux.vnet.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

Easy recreate: 
`TESTFLAGS="-check.f=DockerSuite.TestInspectImage" make test-integration`
