### PR TITLE
Output network attachment task information

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2449,7 +2449,15 @@ definitions:
     properties:
       PluginSpec:
         type: "object"
-        description: "Invalid when specified with `ContainerSpec`. *(Experimental release only.)*"
+        description: |
+          Plugin spec for the service.  *(Experimental release only.)*
+
+          <p><br /></p>
+
+          > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are
+          > mutually exclusive. PluginSpec is only used when the Runtime field
+          > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime
+          > field is set to `attachment`.
         properties:
           Name:
             description: "The name or 'alias' to use for the plugin."
@@ -2476,7 +2484,15 @@ definitions:
                     type: "string"
       ContainerSpec:
         type: "object"
-        description: "Invalid when specified with `PluginSpec`."
+        description: |
+          Container spec for the service.
+
+          <p><br /></p>
+
+          > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are
+          > mutually exclusive. PluginSpec is only used when the Runtime field
+          > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime
+          > field is set to `attachment`.
         properties:
           Image:
             description: "The image name to use for the container"
@@ -2689,7 +2705,16 @@ definitions:
               - "process"
               - "hyperv"
       NetworkAttachmentSpec:
-        description: "Read-only spec type for non-swarm containers attached to swarm overlay networks"
+        description: |
+          Read-only spec type for non-swarm containers attached to swarm overlay
+          networks.
+
+          <p><br /></p>
+
+          > **Note**: ContainerSpec, NetworkAttachmentSpec, and PluginSpec are
+          > mutually exclusive. PluginSpec is only used when the Runtime field
+          > is set to `plugin`. NetworkAttachmentSpec is used when the Runtime
+          > field is set to `attachment`.
         type: "object"
         properties:
           ContainerID:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2688,6 +2688,13 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+      NetworkAttachmentSpec:
+        description: "Read-only spec type for non-swarm containers attached to swarm overlay networks"
+        type: "object"
+        properties:
+          ContainerID:
+            description: "ID of the container represented by this task"
+            type: "string"
       Resources:
         description: "Resource requirements which apply to each individual container created as part of the service."
         type: "object"

--- a/api/types/swarm/runtime.go
+++ b/api/types/swarm/runtime.go
@@ -11,9 +11,17 @@ const (
 	RuntimeContainer RuntimeType = "container"
 	// RuntimePlugin is the plugin based runtime
 	RuntimePlugin RuntimeType = "plugin"
+	// RuntimeNetworkAttachment is the network attachment runtime
+	RuntimeNetworkAttachment RuntimeType = "attachment"
 
 	// RuntimeURLContainer is the proto url for the container type
 	RuntimeURLContainer RuntimeURL = "types.docker.com/RuntimeContainer"
 	// RuntimeURLPlugin is the proto url for the plugin type
 	RuntimeURLPlugin RuntimeURL = "types.docker.com/RuntimePlugin"
 )
+
+// NetworkAttachmentSpec represents the runtime spec type for network
+// attachment tasks
+type NetworkAttachmentSpec struct {
+	ContainerID string
+}

--- a/api/types/swarm/task.go
+++ b/api/types/swarm/task.go
@@ -60,10 +60,13 @@ type Task struct {
 
 // TaskSpec represents the spec of a task.
 type TaskSpec struct {
-	// ContainerSpec and PluginSpec are mutually exclusive.
-	// PluginSpec will only be used when the `Runtime` field is set to `plugin`
-	ContainerSpec *ContainerSpec      `json:",omitempty"`
-	PluginSpec    *runtime.PluginSpec `json:",omitempty"`
+	// ContainerSpec, NetworkAttachmentSpec, and PluginSpec are mutually exclusive.
+	// PluginSpec is only used when the `Runtime` field is set to `plugin`
+	// NetworkAttachmentSpec is used if the `Runtime` field is set to
+	// `attachment`.
+	ContainerSpec         *ContainerSpec         `json:",omitempty"`
+	PluginSpec            *runtime.PluginSpec    `json:",omitempty"`
+	NetworkAttachmentSpec *NetworkAttachmentSpec `json:",omitempty"`
 
 	Resources     *ResourceRequirements     `json:",omitempty"`
 	RestartPolicy *RestartPolicy            `json:",omitempty"`

--- a/daemon/cluster/convert/task.go
+++ b/daemon/cluster/convert/task.go
@@ -10,9 +10,6 @@ import (
 
 // TaskFromGRPC converts a grpc Task to a Task.
 func TaskFromGRPC(t swarmapi.Task) (types.Task, error) {
-	if t.Spec.GetAttachment() != nil {
-		return types.Task{}, nil
-	}
 	containerStatus := t.Status.GetContainer()
 	taskSpec, err := taskSpecFromGRPC(t.Spec)
 	if err != nil {

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -135,6 +135,8 @@ func (c *Cluster) CreateService(s types.ServiceSpec, encodedAuth string, queryRe
 		resp = &apitypes.ServiceCreateResponse{}
 
 		switch serviceSpec.Task.Runtime.(type) {
+		case *swarmapi.TaskSpec_Attachment:
+			return fmt.Errorf("invalid task spec: spec type %q not supported", types.RuntimeNetworkAttachment)
 		// handle other runtimes here
 		case *swarmapi.TaskSpec_Generic:
 			switch serviceSpec.Task.GetGeneric().Kind {
@@ -244,6 +246,8 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec typ
 		resp = &apitypes.ServiceUpdateResponse{}
 
 		switch serviceSpec.Task.Runtime.(type) {
+		case *swarmapi.TaskSpec_Attachment:
+			return fmt.Errorf("invalid task spec: spec type %q not supported", types.RuntimeNetworkAttachment)
 		case *swarmapi.TaskSpec_Generic:
 			switch serviceSpec.Task.GetGeneric().Kind {
 			case string(types.RuntimePlugin):

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,12 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## V1.38 API changes
+
+* `GET /tasks` and `GET /tasks/{id}` now return a `NetworkAttachmentSpec` field,
+  containing the `ContainerID` for non-service containers connected to "attachable"
+  swarm-scoped networks.
+
 ## v1.37 API changes
 
 [Docker Engine API v1.37](https://docs.docker.com/engine/api/v1.37/) documentation


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Network attachment tasks are phony tasks created in swarmkit to deal with unmanaged containers attached to swarmkit. Before this change, attempting `docker inspect` on the task id of a network attachment task would result in an empty task object. After this change, a full task object is returned

Fixes #26548 the correct way.
Fixes https://github.com/moby/moby/issues/36498

**- How I did it**
Adds functionality to parse and return network attachment spec information.

**- How to verify it**
1. Create a network like `docker network create --driver overlay --attachable testnet`
1. Attach a container like `docker run -d --network testnet nginx`
1. Try to delete the network `docker network rm testnet`. Note that it will return an error because the network is in use, and that error will include a task id.
1. `docker inspect` the task id from the previous spec.

Before this change, the output of the inspect will be an empty task.
After this change, the output will be a full task object, including the ID of the container that this task represents.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Running `docker inspect` on network attachment tasks now returns a full task object