### PR TITLE
[integration] add setupTest to integration test

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestBuildWithRemoveAndForceRemove(t *testing.T) {
+	defer setupTest(t)()
 	t.Parallel()
 	cases := []struct {
 		name                           string

--- a/integration/build/main_test.go
+++ b/integration/build/main_test.go
@@ -17,6 +17,11 @@ func TestMain(m *testing.M) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	err = environment.EnsureFrozenImagesLinux(testEnv)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	testEnv.Print()
 	os.Exit(m.Run())

--- a/integration/container/main_test.go
+++ b/integration/container/main_test.go
@@ -17,6 +17,11 @@ func TestMain(m *testing.M) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	err = environment.EnsureFrozenImagesLinux(testEnv)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	testEnv.Print()
 	os.Exit(m.Run())

--- a/integration/network/main_test.go
+++ b/integration/network/main_test.go
@@ -17,6 +17,11 @@ func TestMain(m *testing.M) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	err = environment.EnsureFrozenImagesLinux(testEnv)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	testEnv.Print()
 	os.Exit(m.Run())

--- a/integration/plugin/authz/main_test.go
+++ b/integration/plugin/authz/main_test.go
@@ -33,6 +33,11 @@ func TestMain(m *testing.M) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	err = environment.EnsureFrozenImagesLinux(testEnv)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	testEnv.Print()
 	setupSuite()

--- a/integration/service/main_test.go
+++ b/integration/service/main_test.go
@@ -19,6 +19,11 @@ func TestMain(m *testing.M) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	err = environment.EnsureFrozenImagesLinux(testEnv)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	testEnv.Print()
 	os.Exit(m.Run())

--- a/integration/system/main_test.go
+++ b/integration/system/main_test.go
@@ -17,6 +17,11 @@ func TestMain(m *testing.M) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	err = environment.EnsureFrozenImagesLinux(testEnv)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	testEnv.Print()
 	os.Exit(m.Run())

--- a/internal/test/environment/environment.go
+++ b/internal/test/environment/environment.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/integration-cli/fixtures/load"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -127,4 +128,16 @@ func (e *Execution) Print() {
 // APIClient returns an APIClient connected to the daemon under test
 func (e *Execution) APIClient() client.APIClient {
 	return e.client
+}
+
+// EnsureFrozenImagesLinux loads frozen test images into the daemon
+// if they aren't already loaded
+func EnsureFrozenImagesLinux(testEnv *Execution) error {
+	if testEnv.OSType == "linux" {
+		err := load.FrozenImagesLinux(testEnv.APIClient(), frozenImages...)
+		if err != nil {
+			return errors.Wrap(err, "error loading frozen images")
+		}
+	}
+	return nil
 }

--- a/internal/test/environment/protect.go
+++ b/internal/test/environment/protect.go
@@ -6,9 +6,10 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	dclient "github.com/docker/docker/client"
-	"github.com/docker/docker/integration-cli/fixtures/load"
 	"github.com/stretchr/testify/require"
 )
+
+var frozenImages = []string{"busybox:latest", "hello-world:frozen", "debian:jessie"}
 
 type protectedElements struct {
 	containers map[string]struct{}
@@ -83,7 +84,7 @@ func ProtectImages(t testingT, testEnv *Execution) {
 	images := getExistingImages(t, testEnv)
 
 	if testEnv.OSType == "linux" {
-		images = append(images, ensureFrozenImagesLinux(t, testEnv)...)
+		images = append(images, frozenImages...)
 	}
 	testEnv.ProtectImage(t, images...)
 }
@@ -118,15 +119,6 @@ func tagsFromImageSummary(image types.ImageSummary) []string {
 		}
 	}
 	return result
-}
-
-func ensureFrozenImagesLinux(t testingT, testEnv *Execution) []string {
-	images := []string{"busybox:latest", "hello-world:frozen", "debian:jessie"}
-	err := load.FrozenImagesLinux(testEnv.APIClient(), images...)
-	if err != nil {
-		t.Fatalf("Failed to load frozen images: %s", err)
-	}
-	return images
 }
 
 // ProtectNetwork adds the specified network(s) to be protected in case of


### PR DESCRIPTION
fixes #35215

setupTest() calls protectAll() which calls ensureFrozenImagesLinux().
If this isn't called before a test is run, if that test uses an image,
in this case busybox:latest, that image is pulled.

If that image is already pulled, when ensureFrozenImagesLinux() is
called, it sees that busybox is already in the daemon, and doesn't load it
which causes problems with tests later on because frozen is different from latest.

On non-x86 architectures, this would also cause architecture specific images
from being retagged, and because they aren't in the frozen images protected list,
were then removed.

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>
