### PR TITLE
[WIP] Add new driver option to enable IPv6

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -841,6 +841,7 @@ func driverOptions(config *config.Config) []nwconfig.Option {
 		"EnableIPForwarding":  config.BridgeConfig.EnableIPForward,
 		"EnableIPTables":      config.BridgeConfig.EnableIPTables,
 		"EnableUserlandProxy": config.BridgeConfig.EnableUserlandProxy,
+		"EnableIPv6":          config.BridgeConfig.EnableIPv6,
 		"UserlandProxyPath":   config.BridgeConfig.UserlandProxyPath}
 	bridgeOption := options.Generic{netlabel.GenericData: bridgeConfig}
 


### PR DESCRIPTION
Fixes issue 25407

This pull request is linked with https://github.com/docker/libnetwork/pull/1992 to enable NAT functionality for IPv6. The issue can be found https://github.com/moby/moby/issues/25407

This pull request just adds the EnableIPv6 flag to the bridgeConfig options to allow parts of libnetwork to identify that IPv6 is enabled.

When combined with the libnetwork pull request, the fix can be verified after starting a container in bridge mode with port forwarding and IPv6 enabled:
1. Compare the `iptables -t nat -L` command with the `ip6tables -t nat -L` command 
2. Compare `iptables -t filter -L` command with `ip6tables -t filter -L` command
3. Ping6 from within a running container to an outside device.