### PR TITLE
Windows: Fix startup logging

### DIFF
--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -54,9 +54,10 @@ func (cli *DaemonCli) setupConfigReloadTrap() {
 		sa := windows.SecurityAttributes{
 			Length: 0,
 		}
-		ev, _ := windows.UTF16PtrFromString("Global\\docker-daemon-config-" + fmt.Sprint(os.Getpid()))
+		event := "Global\\docker-daemon-config-" + fmt.Sprint(os.Getpid())
+		ev, _ := windows.UTF16PtrFromString(event)
 		if h, _ := windows.CreateEvent(&sa, 0, 0, ev); h != 0 {
-			logrus.Debugf("Config reload - waiting signal at %s", ev)
+			logrus.Debugf("Config reload - waiting signal at %s", event)
 			for {
 				windows.WaitForSingleObject(h, windows.INFINITE)
 				cli.reloadConfig()

--- a/daemon/debugtrap_windows.go
+++ b/daemon/debugtrap_windows.go
@@ -15,10 +15,11 @@ func (d *Daemon) setupDumpStackTrap(root string) {
 	// Windows does not support signals like *nix systems. So instead of
 	// trapping on SIGUSR1 to dump stacks, we wait on a Win32 event to be
 	// signaled. ACL'd to builtin administrators and local system
-	ev, _ := windows.UTF16PtrFromString("Global\\docker-daemon-" + fmt.Sprint(os.Getpid()))
+	event := "Global\\docker-daemon-" + fmt.Sprint(os.Getpid())
+	ev, _ := windows.UTF16PtrFromString(event)
 	sd, err := winio.SddlToSecurityDescriptor("D:P(A;;GA;;;BA)(A;;GA;;;SY)")
 	if err != nil {
-		logrus.Errorf("failed to get security descriptor for debug stackdump event %s: %s", ev, err.Error())
+		logrus.Errorf("failed to get security descriptor for debug stackdump event %s: %s", event, err.Error())
 		return
 	}
 	var sa windows.SecurityAttributes
@@ -27,11 +28,11 @@ func (d *Daemon) setupDumpStackTrap(root string) {
 	sa.SecurityDescriptor = uintptr(unsafe.Pointer(&sd[0]))
 	h, err := windows.CreateEvent(&sa, 0, 0, ev)
 	if h == 0 || err != nil {
-		logrus.Errorf("failed to create debug stackdump event %s: %s", ev, err.Error())
+		logrus.Errorf("failed to create debug stackdump event %s: %s", event, err.Error())
 		return
 	}
 	go func() {
-		logrus.Debugf("Stackdump - waiting signal at %s", ev)
+		logrus.Debugf("Stackdump - waiting signal at %s", event)
 		for {
 			windows.WaitForSingleObject(h, windows.INFINITE)
 			path, err := signal.DumpStacks(root)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This has been annoying me for ages. Finally putting a fix in.

Startup debug logging before this change:

```
...
DEBU[2017-10-19T11:01:22.116355100-07:00] Stackdump - waiting signal at %!s(*uint16=0xc0423a2940)
...
INFO[2017-10-19T11:01:24.307247800-07:00] API listen on //./pipe/docker_engine
DEBU[2017-10-19T11:01:24.307247800-07:00] Config reload - waiting signal at %!s(*uint16=0xc042c02000)
```

And after

```
...
DEBU[2017-10-19T11:08:25.636352700-07:00] Stackdump - waiting signal at Global\docker-daemon-2696
...
INFO[2017-10-19T11:08:27.653351000-07:00] API listen on //./pipe/docker_engine
DEBU[2017-10-19T11:08:27.653351000-07:00] Config reload - waiting signal at Global\docker-daemon-config-2696
```

@thaJeztah @johnstep PTAL
