### PR TITLE
[vim] support *.Dockerfile

### DIFF
--- a/contrib/syntax/vim/ftdetect/dockerfile.vim
+++ b/contrib/syntax/vim/ftdetect/dockerfile.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead [Dd]ockerfile,Dockerfile.* set filetype=dockerfile
+au BufNewFile,BufRead [Dd]ockerfile,Dockerfile.*,*.Dockerfile set filetype=dockerfile


### PR DESCRIPTION
Probably a good idea to treat `*.Dockerfile` as dockerfile format as well. In general, it's better to use the `Dockerfile` part as an extension rather than a basename.

**- A picture of a cute animal (not mandatory but encouraged)**

🐱 