### PR TITLE
MacVlan internal Gateway support

### DIFF
--- a/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan.go
+++ b/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan.go
@@ -22,6 +22,7 @@ const (
 	modePassthru        = "passthru" // macvlan mode passthrough
 	parentOpt           = "parent"   // parent interface -o parent
 	modeOpt             = "_mode"    // macvlan mode ux opt suffix
+	internal_gw         = "internal_gateway" // gateway for 10.0.0.0/8 networks
 )
 
 var driverModeOpt = macvlanType + modeOpt // mode --option macvlan_mode

--- a/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_network.go
@@ -227,6 +227,8 @@ func (config *configuration) fromOptions(labels map[string]string) error {
 		case driverModeOpt:
 			// parse driver option '-o macvlan_mode'
 			config.MacvlanMode = value
+		case internal_gw:
+			config.InternalGw = value
 		}
 	}
 

--- a/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_store.go
+++ b/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_store.go
@@ -30,6 +30,7 @@ type configuration struct {
 	CreatedSlaveLink bool
 	Ipv4Subnets      []*ipv4Subnet
 	Ipv6Subnets      []*ipv6Subnet
+	InternalGw       string
 }
 
 type ipv4Subnet struct {
@@ -150,6 +151,11 @@ func (config *configuration) MarshalJSON() ([]byte, error) {
 	nMap["MacvlanMode"] = config.MacvlanMode
 	nMap["Internal"] = config.Internal
 	nMap["CreatedSubIface"] = config.CreatedSlaveLink
+
+	if len(config.InternalGw) > 0 {
+		nMap["InternalGw"] = config.InternalGw
+	}
+
 	if len(config.Ipv4Subnets) > 0 {
 		iis, err := json.Marshal(config.Ipv4Subnets)
 		if err != nil {
@@ -180,9 +186,16 @@ func (config *configuration) UnmarshalJSON(b []byte) error {
 	config.ID = nMap["ID"].(string)
 	config.Mtu = int(nMap["Mtu"].(float64))
 	config.Parent = nMap["Parent"].(string)
+	config.InternalGw = nMap["InternalGw"].(string)
 	config.MacvlanMode = nMap["MacvlanMode"].(string)
 	config.Internal = nMap["Internal"].(bool)
 	config.CreatedSlaveLink = nMap["CreatedSubIface"].(bool)
+
+	// Optional internal_gateway
+	if v, ok := nMap["InternalGw"]; ok {
+		config.InternalGw = v.(string)
+	}
+
 	if v, ok := nMap["Ipv4Subnets"]; ok {
 		if err := json.Unmarshal([]byte(v.(string)), &config.Ipv4Subnets); err != nil {
 			return err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Feature allows to use Alternative Gateway for internal networks with MacVlan libnetwork driver**

**- How I did it:** by my hands && Go ;)

**- How to verify it:**
Create network macvlan with option *internal_gateway* set to alternative gateway IP address.
run container && check routes table, one route should be added for networks with cidr 10.0.0.0/8:

`root@weisshorn:~# docker run --rm -v /bin/ip:/bin/ip  --net  mesos_crowd_dev --entrypoint ip centos r `

`default via 172.20.10.11 dev eth0`
`10.0.0.0/8 via 172.20.0.9 dev eth0 `
`172.20.0.0/16 dev eth0  proto kernel  scope link  src 172.20.10.0 
`

**- Description for the changelog**:
Macvlan: ability to add secondary gateway to use for internal networks routing
Option: internal_gateway


**- A picture of a cute animal**: 
Here is it! - https://kittenrescue.org/wp-content/uploads/2017/03/KittenRescue_KittenCareHandbook.jpg

