### PR TITLE
rmLink: fix parsing name with /

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -509,7 +509,20 @@ func (daemon *Daemon) parents(c *container.Container) map[string]*container.Cont
 	return daemon.linkIndex.parents(c)
 }
 
+func validateAlias(alias string, c *container.Container) error {
+	if !validContainerNamePattern.MatchString(alias) {
+		return fmt.Errorf("Invalid alias name (%s), only %s are allowed", alias, validContainerNameChars)
+	}
+	if alias == c.Config.Hostname {
+		return fmt.Errorf("Invalid alias name (%s), alias is the same to current container's hostname", alias)
+	}
+	return nil
+}
+
 func (daemon *Daemon) registerLink(parent, child *container.Container, alias string) error {
+	if err := validateAlias(alias, parent); err != nil {
+		return err
+	}
 	fullName := path.Join(parent.Name, alias)
 	if err := daemon.containersReplica.ReserveName(fullName, child.ID); err != nil {
 		if err == container.ErrNameReserved {

--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -119,7 +119,7 @@ func (s *DockerSuite) TestRenameContainerWithLinkedContainer(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 
 	db1, _ := dockerCmd(c, "run", "--name", "db1", "-d", "busybox", "top")
-	dockerCmd(c, "run", "--name", "app1", "-d", "--link", "db1:/mysql", "busybox", "top")
+	dockerCmd(c, "run", "--name", "app1", "-d", "--link", "db1:mysql", "busybox", "top")
 	dockerCmd(c, "rename", "app1", "app2")
 	out, _, err := dockerCmdWithError("inspect", "--format={{ .Id }}", "app2/mysql")
 	c.Assert(err, checker.IsNil)

--- a/integration/container/links_test.go
+++ b/integration/container/links_test.go
@@ -1,0 +1,57 @@
+package container
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/strslice"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/integration/util/request"
+	"github.com/docker/docker/internal/testutil"
+)
+
+func runContainerLinks(ctx context.Context, t *testing.T, client client.APIClient, cntCfg *container.Config, hstCfg *container.HostConfig, nwkCfg *network.NetworkingConfig, cntName string) (string, error) {
+	cnt, err := client.ContainerCreate(ctx, cntCfg, hstCfg, nwkCfg, cntName)
+	if err != nil {
+		return "", err
+	}
+
+	err = client.ContainerStart(ctx, cnt.ID, types.ContainerStartOptions{})
+	return cnt.ID, err
+}
+
+func TestLinkedContainerAliasWithSeparator(t *testing.T) {
+	defer setupTest(t)()
+	ctx := context.Background()
+	client := request.NewAPIClient(t)
+
+	cntConfig := &container.Config{
+		Image: "busybox",
+		Tty:   true,
+		Cmd:   strslice.StrSlice([]string{"top"}),
+	}
+
+	var (
+		err error
+	)
+
+	runContainer(ctx, t, client,
+		cntConfig,
+		&container.HostConfig{},
+		&network.NetworkingConfig{},
+		"a0",
+	)
+
+	_, err = runContainerLinks(ctx, t, client,
+		cntConfig,
+		&container.HostConfig{
+			Links: []string{"a0:links/sep"},
+		},
+		&network.NetworkingConfig{},
+		"b0",
+	)
+	testutil.ErrorContains(t, err, "Invalid alias name")
+}


### PR DESCRIPTION
Run a container with "--link container:somethingA/somethingB", then rm the link, we will see a err like this,
```
Error response from daemon: Cannot get parent **for name ***
```

### How to reproduce
```
# runc two containers
docker run -d -ti --name aaa busybox sleep 10000000   
docker run -d -ti --name bbb --link aaa:linka/hello busybox sleep 1000000

[root@localhost ~]# docker ps  --no-trunc 
CONTAINER ID                                                       IMAGE               COMMAND             CREATED             STATUS                  PORTS               NAMES
d4065c5608f24a6ff9e7633d5aca27771a05b40cfee79036b8179848f5993308   busybox             "ash"               2 seconds ago       Up Less than a second                       bbb
f996150fa7597d4bb142626e058259435728ebfb1889710e6d679eb72ed52c79   busybox             "ash"               10 seconds ago      Up 7 seconds                                aaa,bbb/linka/hello
[root@localhost ~]# docker rm -l bbb/linka/hello
Error response from daemon: Cannot get parent linka for name /bbb/linka/hello
```

### Why
With "--link container:somethingA/somethingB", docker should parse "parent"( parent, n := path.Split(name)) to "/container", not "/container/somethingA".

### After this pr
```
[root@localhost ~]# docker ps --no-trunc 
CONTAINER ID                                                       IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
74376ac54f93a114f7f835061a1d5b15d13f01c41b8cc51043133944b20aed0c   busybox             "ash"               4 seconds ago        Up 2 seconds                            bbb
6ab1881806a0ac4e293b0cc049d0bc5f6f6b0f646099c6cb747589d2103c7479   busybox             "ash"               11 seconds ago       Up 9 seconds                            aaa,bbb/linka/hello
[root@localhost ~]# docker rm -l bbb/linka/hello
bbb/linka/hello
[root@localhost ~]# docker ps --no-trunc        
CONTAINER ID                                                       IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
74376ac54f93a114f7f835061a1d5b15d13f01c41b8cc51043133944b20aed0c   busybox             "ash"               15 seconds ago       Up 13 seconds                           bbb
6ab1881806a0ac4e293b0cc049d0bc5f6f6b0f646099c6cb747589d2103c7479   busybox             "ash"               22 seconds ago       Up 20 seconds                           aaa
```
Signed-off-by: yangshukui <yangshukui@huawei.com>
