### PR TITLE
[integration-cli] ensureFrozenImages here too

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -60,6 +60,12 @@ func init() {
 
 func TestMain(m *testing.M) {
 	dockerBinary = testEnv.DockerBinary()
+	err := ienv.EnsureFrozenImagesLinux(&testEnv.Execution)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	testEnv.Print()
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
Checks + pulls down the frozen images in the integration-cli
tests too. Fixes an issue where they wouldn't be pulled if running
against just integration-cli tests, e.g. through TESTFLAGS

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>