### PR TITLE
Fix a names-generator binary

### DIFF
--- a/pkg/namesgenerator/cmd/names-generator/main.go
+++ b/pkg/namesgenerator/cmd/names-generator/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
+	"time"
 
 	"github.com/docker/docker/pkg/namesgenerator"
 )
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
 	fmt.Println(namesgenerator.GetRandomName(0))
 }


### PR DESCRIPTION
To ensure that namesgenerator binary outputs random name
by initializing Seed.

Signed-off-by: Mizuki Urushida <z11111001011@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes `pkg/namesgenerator/cmd/names-generator/main.go` for outputting random name.

**- How I did it**

Adds init function of initializing `math/rand`'s Seed.

**- How to verify it**

Install.

```
go get github.com/moby/moby/pkg/namesgenerator/cmd/names-generator
```

Before this PR.

```
$ names-generator
xenodochial_fermat
$ names-generator
xenodochial_fermat
$ names-generator
xenodochial_fermat
...
```

After.

```
$ names-generator
vigorous_turing
$ names-generator
cocky_poincare
$ names-generator
heuristic_hawking
...
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Ensures that namesgenerator binary outputs random name
by initializing Seed.
