### PR TITLE
Show more specific reason why the pull failed in the task's error field

### DIFF
--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -155,6 +155,9 @@ func (r *controller) Prepare(ctx context.Context) error {
 			return exec.ErrTaskPrepared
 		}
 
+		if r.pullErr != nil {
+			return errors.Wrap(err, r.pullErr.Error())
+		}
 		return err
 	}
 


### PR DESCRIPTION
Related issue: #33521

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Display more specific error message in task's error field about image pull failure.




**- How I did it**
Currently, docker daemon discards the error message about pulling failure. I wrapped original message(`No such image`) with pulling failure message. 

**- How to verify it**
##### AS-IS
```bash
$ docker service ps --no-trunc t1
ID                          NAME                IMAGE                                         NODE                  DESIRED STATE       CURRENT STATE             ERROR                                                          PORTS
spcc2shfohcxvql1j7pq1hzre   t1.1                registry.navercorp.com/albamc/stress:latest   dev-dcluster002.ncl   Ready               Rejected 3 seconds ago    "No such image: registry.navercorp.com/albamc/stress:latest"
```

##### TO-BE
```bash
$ docker service ps --no-trunc shyr1
ID                          NAME                IMAGE                                          NODE                  DESIRED STATE       CURRENT STATE             ERROR                                                                                                                                PORTS
73llybw8c1i5ffg94yh6fii27   shyr1.1             registry.navercorp.com/albamc/stress1:latest   dev-dcluster001.ncl   Ready               Rejected 1 second ago     "manifest for registry.navercorp.com/albamc/stress1:latest not found: No such image: registry.navercorp.com/albamc/stress1:latest"
```

```bash
$ docker service ps --no-trunc shyr2
ID                          NAME                IMAGE                                         NODE                  DESIRED STATE       CURRENT STATE                     ERROR                                                                                                                          PORTS
nc2ljq67hj5fwnfxjdepmebj7   shyr2.1             registry.navercorp.com/albamc/stress:latest   dev-dcluster001.ncl   Ready               Rejected less than a second ago   "unauthorized: The client does not have permission for manifest: No such image: registry.navercorp.com/albamc/stress:latest"
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/7446428/31996168-5ead3b9e-b9c2-11e7-8ce9-ebe7df9c1224.png)

