### PR TITLE
Fix honoring tmpfs-size for user /dev/shm mount

### DIFF
--- a/daemon/daemon_linux_test.go
+++ b/daemon/daemon_linux_test.go
@@ -5,6 +5,13 @@ package daemon
 import (
 	"strings"
 	"testing"
+
+	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/oci"
+	"github.com/docker/docker/pkg/idtools"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const mountsFixture = `142 78 0:38 / / rw,relatime - aufs none rw,si=573b861da0b3a05b,dio
@@ -100,5 +107,53 @@ func TestNotCleanupMounts(t *testing.T) {
 	d.cleanupMountsFromReaderByID(strings.NewReader(mountInfo), "", unmount)
 	if unmounted {
 		t.Fatal("Expected not to clean up /dev/shm")
+	}
+}
+
+// TestTmpfsDevShmSizeOverride checks that user-specified /dev/tmpfs mount
+// size is not overriden by the default shmsize (that should only be used
+// for default /dev/shm (as in "shareable" and "private" ipc modes).
+// https://github.com/moby/moby/issues/35271
+func TestTmpfsDevShmSizeOverride(t *testing.T) {
+	size := "777m"
+	mnt := "/dev/shm"
+
+	d := Daemon{
+		idMappings: &idtools.IDMappings{},
+	}
+	c := &container.Container{
+		HostConfig: &containertypes.HostConfig{
+			ShmSize: 48 * 1024, // size we should NOT end up with
+		},
+	}
+	ms := []container.Mount{
+		{
+			Source:      "tmpfs",
+			Destination: mnt,
+			Data:        "size=" + size,
+		},
+	}
+
+	// convert ms to spec
+	spec := oci.DefaultSpec()
+	err := setMounts(&d, &spec, c, ms)
+	assert.NoError(t, err)
+
+	// Check the resulting spec for the correct size
+	found := false
+	for _, m := range spec.Mounts {
+		if m.Destination == mnt {
+			for _, o := range m.Options {
+				if !strings.HasPrefix(o, "size=") {
+					continue
+				}
+				t.Logf("%+v\n", m.Options)
+				assert.Equal(t, "size="+size, o)
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("/dev/shm not found in spec, or size option missing")
 	}
 }

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -528,23 +528,35 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 		userMounts[m.Destination] = struct{}{}
 	}
 
-	// Filter out mounts from spec
-	noIpc := c.HostConfig.IpcMode.IsNone()
-	// Filter out mounts that are overridden by user supplied mounts
+	// Copy all mounts from spec to defaultMounts, except for
+	//  - mounts overriden by a user supplied mount;
+	//  - all mounts under /dev if a user supplied /dev is present;
+	//  - /dev/shm, in case IpcMode is none.
+	// While at it, also
+	//  - set size for /dev/shm from shmsize.
 	var defaultMounts []specs.Mount
 	_, mountDev := userMounts["/dev"]
 	for _, m := range s.Mounts {
-		// filter out /dev/shm mount if case IpcMode is none
-		if noIpc && m.Destination == "/dev/shm" {
+		if _, ok := userMounts[m.Destination]; ok {
+			// filter out mount overridden by a user supplied mount
 			continue
 		}
-		// filter out mount overridden by a user supplied mount
-		if _, ok := userMounts[m.Destination]; !ok {
-			if mountDev && strings.HasPrefix(m.Destination, "/dev/") {
+		if mountDev && strings.HasPrefix(m.Destination, "/dev/") {
+			// filter out everything under /dev if /dev is user-mounted
+			continue
+		}
+
+		if m.Destination == "/dev/shm" {
+			if c.HostConfig.IpcMode.IsNone() {
+				// filter out /dev/shm for "none" IpcMode
 				continue
 			}
-			defaultMounts = append(defaultMounts, m)
+			// set size for /dev/shm mount from spec
+			sizeOpt := "size=" + strconv.FormatInt(c.HostConfig.ShmSize, 10)
+			m.Options = append(m.Options, sizeOpt)
 		}
+
+		defaultMounts = append(defaultMounts, m)
 	}
 
 	s.Mounts = defaultMounts
@@ -650,14 +662,6 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 		}
 		s.Linux.ReadonlyPaths = nil
 		s.Linux.MaskedPaths = nil
-	}
-
-	// Set size for /dev/shm mount that comes from spec (IpcMode: private only)
-	for i, m := range s.Mounts {
-		if m.Destination == "/dev/shm" {
-			sizeOpt := "size=" + strconv.FormatInt(c.HostConfig.ShmSize, 10)
-			s.Mounts[i].Options = append(s.Mounts[i].Options, sizeOpt)
-		}
 	}
 
 	// TODO: until a kernel/mount solution exists for handling remount in a user namespace,


### PR DESCRIPTION
**- What I did**
Commit 7120976d74195 ("Implement none, private, and shareable ipc modes") introduces a bug: if a user-specified mount for /dev/shm is provided, its size is overridden by value of ShmSize. This was reported in https://github.com/moby/moby/issues/35271.

This commit is an attempt to fix this, as well as optimize things a but and make the code easier to read.

**- How I did it**
Appending the 'size' argument to /dev/shm mount options moved to an earlier place in the function, where we deal with the mounts that came from spec, therefore a user mount is left intact.

**- How to verify it**

There is a test case included in this PR. In addition, it can easily be checked manually:
```
 docker run --rm \
	--mount type=tmpfs,dst=/dev/shm,tmpfs-size=100K \
	alpine df /dev/shm
```

Expected output (i.e. if there is no bug):
```
Filesystem           1K-blocks      Used Available Use% Mounted on
tmpfs                      100         0       100   0% /dev/shm
```

(i.e. `100` should be shown under the "1K-blocks" header)

**- Description for the changelog**
Fix honoring tmpfs-size for user /dev/shm mount

**- A picture of a cute animal (not mandatory but encouraged)**
![shy-beaver](https://user-images.githubusercontent.com/4522509/32094987-6e3c1806-bab6-11e7-89e8-062d0e4821a0.jpg)
*Shy beaver | Minnesota zoo ([source](https://www.flickr.com/photos/nouqraz/198455748))*