### PR TITLE
Fixes LCOW after containerd 1.0 introduced regressions

### DIFF
--- a/libcontainerd/client_local_windows.go
+++ b/libcontainerd/client_local_windows.go
@@ -513,7 +513,7 @@ func (c *client) createLinux(id string, spec *specs.Spec, runtimeOptions interfa
 	ctr := &container{
 		id:           id,
 		execs:        make(map[string]*process),
-		isWindows:    true,
+		isWindows:    false,
 		ociSpec:      spec,
 		hcsContainer: hcsContainer,
 		status:       StatusCreated,

--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -65,6 +65,7 @@ func DefaultLinuxSpec() specs.Spec {
 				Effective:   defaultCapabilities(),
 			},
 		},
+		Root: &specs.Root{},
 	}
 	s.Mounts = []specs.Mount{
 		{


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@mlaventure @johnstep PTAL (would be good to get this merged ASAP).

Fixes https://github.com/moby/moby/issues/35302

https://github.com/moby/moby/pull/34895 regressed LCOW functionality. Two small spot fixes in this PR. Verified locally.