### PR TITLE
Devicemapper: ignore Nodata errors when delete thin device

### DIFF
--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -67,12 +67,14 @@ var (
 	ErrBusy                 = errors.New("Device is Busy")
 	ErrDeviceIDExists       = errors.New("Device Id Exists")
 	ErrEnxio                = errors.New("No such device or address")
+	ErrEnoData              = errors.New("No data available")
 )
 
 var (
-	dmSawBusy  bool
-	dmSawExist bool
-	dmSawEnxio bool // No Such Device or Address
+	dmSawBusy    bool
+	dmSawExist   bool
+	dmSawEnxio   bool // No Such Device or Address
+	dmSawEnoData bool // No data available
 )
 
 type (
@@ -708,9 +710,14 @@ func DeleteDevice(poolName string, deviceID int) error {
 	}
 
 	dmSawBusy = false
+	dmSawEnoData = false
 	if err := task.run(); err != nil {
 		if dmSawBusy {
 			return ErrBusy
+		}
+		if dmSawEnoData {
+			logrus.Debugf("devicemapper: Device(id: %d) from pool(%s) does not exist", deviceID, poolName)
+			return nil
 		}
 		return fmt.Errorf("devicemapper: Error running DeleteDevice %s", err)
 	}

--- a/pkg/devicemapper/devmapper_log.go
+++ b/pkg/devicemapper/devmapper_log.go
@@ -55,6 +55,9 @@ func DevmapperLogCallback(level C.int, file *C.char, line, dmErrnoOrClass C.int,
 		if strings.Contains(msg, "No such device or address") {
 			dmSawEnxio = true
 		}
+		if strings.Contains(msg, "No data available") {
+			dmSawEnoData = true
+		}
 	}
 
 	if dmLogger != nil {


### PR DESCRIPTION
if thin device is deteled and the metadata exists, you can not
delete related containers. This patch ignore Nodata errors for
thin device deletion

Signed-off-by: Liu Hua <sdu.liu@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
When we killed docker with 9 when we delete containers.  We maybe get the following issue
"Driver devicemapper failed to remove root filesystem 090f22f17fa1ca1ff4fab4e19e16ca1b0bfd88df43db5567298e3cecc846af03: devicemapper: Error running DeleteDevice dm_task_run failed" #34463 ?
**- How I did it**
In the container-deleteing process, we delete the thin device first and then delete the metadata. So if docker is killing between these two actions. we can reproduce this issue.  This patch ignore this type of errors.
**- How to verify it**
Because the time windows is very small, so we can remove device of a existed container. And remove it,
* create a container
```
docker run  -tid  --name=test ubuntu  bash
```

*  Get `device id` and  stop container
```
# docker inspect --format="{{.GraphDriver.Data.DeviceId}}" test
10
 # docker stop test
test
```
* delete device and container

```
# docker stop test
test
# dmsetup message  /dev/mapper/docker-8:2-400468-pool 0 "delete 10"
# docker rm -f test
Error response from daemon: Driver devicemapper failed to remove root filesystem 2ba68a882c7c744fcf046aa46cd0190b2c362e07296341071a914234a66fa53c: devicemapper: Error running deviceCreate (ActivateDevice) dm_task_run failed

```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:


**- A picture of a cute animal (not mandatory but encouraged)**

