### PR TITLE
Copy Inslice() to those parts that use it

### DIFF
--- a/daemon/caps/utils_unix.go
+++ b/daemon/caps/utils_unix.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/docker/pkg/stringutils"
 	"github.com/syndtr/gocapability/capability"
 )
 
@@ -69,6 +68,17 @@ func GetAllCapabilities() []string {
 	return output
 }
 
+// inSlice tests whether a string is contained in a slice of strings or not.
+// Comparison is case insensitive
+func inSlice(slice []string, s string) bool {
+	for _, ss := range slice {
+		if strings.ToLower(s) == strings.ToLower(ss) {
+			return true
+		}
+	}
+	return false
+}
+
 // TweakCapabilities can tweak capabilities by adding or dropping capabilities
 // based on the basics capabilities.
 func TweakCapabilities(basics, adds, drops []string) ([]string, error) {
@@ -86,17 +96,17 @@ func TweakCapabilities(basics, adds, drops []string) ([]string, error) {
 			continue
 		}
 
-		if !stringutils.InSlice(allCaps, "CAP_"+cap) {
+		if !inSlice(allCaps, "CAP_"+cap) {
 			return nil, fmt.Errorf("Unknown capability drop: %q", cap)
 		}
 	}
 
 	// handle --cap-add=all
-	if stringutils.InSlice(adds, "all") {
+	if inSlice(adds, "all") {
 		basics = allCaps
 	}
 
-	if !stringutils.InSlice(drops, "all") {
+	if !inSlice(drops, "all") {
 		for _, cap := range basics {
 			// skip `all` already handled above
 			if strings.ToLower(cap) == "all" {
@@ -104,7 +114,7 @@ func TweakCapabilities(basics, adds, drops []string) ([]string, error) {
 			}
 
 			// if we don't drop `all`, add back all the non-dropped caps
-			if !stringutils.InSlice(drops, cap[4:]) {
+			if !inSlice(drops, cap[4:]) {
 				newCaps = append(newCaps, strings.ToUpper(cap))
 			}
 		}
@@ -118,12 +128,12 @@ func TweakCapabilities(basics, adds, drops []string) ([]string, error) {
 
 		cap = "CAP_" + cap
 
-		if !stringutils.InSlice(allCaps, cap) {
+		if !inSlice(allCaps, cap) {
 			return nil, fmt.Errorf("Unknown capability to add: %q", cap)
 		}
 
 		// add cap if not already in the list
-		if !stringutils.InSlice(newCaps, cap) {
+		if !inSlice(newCaps, cap) {
 			newCaps = append(newCaps, strings.ToUpper(cap))
 		}
 	}

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -18,7 +18,6 @@ import (
 	"github.com/docker/docker/oci"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/mount"
-	"github.com/docker/docker/pkg/stringutils"
 	"github.com/docker/docker/volume"
 	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -522,6 +521,17 @@ var (
 	}
 )
 
+// inSlice tests whether a string is contained in a slice of strings or not.
+// Comparison is case sensitive
+func inSlice(slice []string, s string) bool {
+	for _, ss := range slice {
+		if s == ss {
+			return true
+		}
+	}
+	return false
+}
+
 func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []container.Mount) error {
 	userMounts := make(map[string]struct{})
 	for _, m := range mounts {
@@ -632,7 +642,7 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 				continue
 			}
 			if _, ok := userMounts[m.Destination]; !ok {
-				if !stringutils.InSlice(m.Options, "ro") {
+				if !inSlice(m.Options, "ro") {
 					s.Mounts[i].Options = append(s.Mounts[i].Options, "ro")
 				}
 			}

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/docker/docker/api/types/versions/v1p20"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/checker"
-	"github.com/docker/docker/pkg/stringutils"
 	"github.com/go-check/check"
+	"github.com/stretchr/testify/assert"
 )
 
 func (s *DockerSuite) TestInspectAPIContainerResponse(c *check.C) {
@@ -115,8 +115,8 @@ func (s *DockerSuite) TestInspectAPIImageResponse(c *check.C) {
 	c.Assert(err, checker.IsNil)
 
 	c.Assert(imageJSON.RepoTags, checker.HasLen, 2)
-	c.Assert(stringutils.InSlice(imageJSON.RepoTags, "busybox:latest"), checker.Equals, true)
-	c.Assert(stringutils.InSlice(imageJSON.RepoTags, "busybox:mytag"), checker.Equals, true)
+	assert.Contains(c, imageJSON.RepoTags, "busybox:latest")
+	assert.Contains(c, imageJSON.RepoTags, "busybox:mytag")
 }
 
 // #17131, #17139, #17173

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
-	"github.com/docker/docker/pkg/stringutils"
 	"github.com/go-check/check"
 	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -403,7 +403,7 @@ func (s *DockerRegistrySuite) TestInspectImageWithDigests(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(imageJSON, checker.HasLen, 1)
 	c.Assert(imageJSON[0].RepoDigests, checker.HasLen, 1)
-	c.Assert(stringutils.InSlice(imageJSON[0].RepoDigests, imageReference), checker.Equals, true)
+	assert.Contains(c, imageJSON[0].RepoDigests, imageReference)
 }
 
 func (s *DockerRegistrySuite) TestPsListContainersFilterAncestorImageByDigest(c *check.C) {

--- a/pkg/stringutils/stringutils.go
+++ b/pkg/stringutils/stringutils.go
@@ -41,17 +41,6 @@ func Truncate(s string, maxlen int) string {
 	return string(r[:maxlen])
 }
 
-// InSlice tests whether a string is contained in a slice of strings or not.
-// Comparison is case insensitive
-func InSlice(slice []string, s string) bool {
-	for _, ss := range slice {
-		if strings.ToLower(s) == strings.ToLower(ss) {
-			return true
-		}
-	}
-	return false
-}
-
 func quote(word string, buf *bytes.Buffer) {
 	// Bail out early for "simple" strings
 	if word != "" && !strings.ContainsAny(word, "\\'\"`${[|&;<>()~*?! \t\n") {

--- a/pkg/stringutils/stringutils_test.go
+++ b/pkg/stringutils/stringutils_test.go
@@ -77,23 +77,6 @@ func TestTruncate(t *testing.T) {
 	}
 }
 
-func TestInSlice(t *testing.T) {
-	slice := []string{"t🐳st", "in", "slice"}
-
-	test := InSlice(slice, "t🐳st")
-	if !test {
-		t.Fatalf("Expected string t🐳st to be in slice")
-	}
-	test = InSlice(slice, "SLICE")
-	if !test {
-		t.Fatalf("Expected string SLICE to be in slice")
-	}
-	test = InSlice(slice, "notinslice")
-	if test {
-		t.Fatalf("Expected string notinslice not to be in slice")
-	}
-}
-
 func TestShellQuoteArgumentsEmpty(t *testing.T) {
 	actual := ShellQuoteArguments([]string{})
 	expected := ""

--- a/profiles/seccomp/seccomp.go
+++ b/profiles/seccomp/seccomp.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/pkg/stringutils"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	libseccomp "github.com/seccomp/libseccomp-golang"
 )
@@ -37,6 +36,17 @@ var nativeToSeccomp = map[string]types.Arch{
 	"mipsel64":    types.ArchMIPSEL64,
 	"mipsel64n32": types.ArchMIPSEL64N32,
 	"s390x":       types.ArchS390X,
+}
+
+// inSlice tests whether a string is contained in a slice of strings or not.
+// Comparison is case sensitive
+func inSlice(slice []string, s string) bool {
+	for _, ss := range slice {
+		if s == ss {
+			return true
+		}
+	}
+	return false
 }
 
 func setupSeccomp(config *types.Seccomp, rs *specs.Spec) (*specs.LinuxSeccomp, error) {
@@ -89,25 +99,25 @@ Loop:
 	// Loop through all syscall blocks and convert them to libcontainer format after filtering them
 	for _, call := range config.Syscalls {
 		if len(call.Excludes.Arches) > 0 {
-			if stringutils.InSlice(call.Excludes.Arches, arch) {
+			if inSlice(call.Excludes.Arches, arch) {
 				continue Loop
 			}
 		}
 		if len(call.Excludes.Caps) > 0 {
 			for _, c := range call.Excludes.Caps {
-				if stringutils.InSlice(rs.Process.Capabilities.Effective, c) {
+				if inSlice(rs.Process.Capabilities.Effective, c) {
 					continue Loop
 				}
 			}
 		}
 		if len(call.Includes.Arches) > 0 {
-			if !stringutils.InSlice(call.Includes.Arches, arch) {
+			if !inSlice(call.Includes.Arches, arch) {
 				continue Loop
 			}
 		}
 		if len(call.Includes.Caps) > 0 {
 			for _, c := range call.Includes.Caps {
-				if !stringutils.InSlice(rs.Process.Capabilities.Effective, c) {
+				if !inSlice(rs.Process.Capabilities.Effective, c) {
 					continue Loop
 				}
 			}


### PR DESCRIPTION
Signed-off-by: Chao Wang <wangchao.fnst@cn.fujitsu.com>

**- What I did**
Copy Inslice() to those parts that use it.
**- How I did it**
According to @thaJeztah 's suggestion at [/moby/moby/pull/35034(closed)](https://github.com/moby/moby/pull/35034#pullrequestreview-68582683)
Accordance with the tasklist at [Separate the GenerateRandomAlphaOnlyString function from stringutils #35313](https://github.com/moby/moby/pull/35313)
**- A picture of a cute animal (not mandatory but encouraged)**
![hahaha](https://github.com/charrywanganthony/MarkdownPhotos/blob/master/Photos/2017-10-31_18-13-35.jpg?raw=true)
