### PR TITLE
fix unless-stopped unexpected behavior

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -87,6 +87,7 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, sig int)
 
 	if !daemon.IsShuttingDown() {
 		container.HasBeenManuallyStopped = true
+		container.CheckpointTo(daemon.containersReplica)
 	}
 
 	// if the container is currently restarting we do not need to send the signal

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -158,6 +158,7 @@ func (daemon *Daemon) containerStart(container *container.Container, checkpoint 
 
 	if resetRestartManager {
 		container.ResetRestartManager(true)
+		container.HasBeenManuallyStopped = false
 	}
 
 	if daemon.saveApparmorConfig(container); err != nil {
@@ -194,7 +195,6 @@ func (daemon *Daemon) containerStart(container *container.Container, checkpoint 
 	}
 
 	container.SetRunning(pid, true)
-	container.HasBeenManuallyStopped = false
 	container.HasBeenStartedBefore = true
 	daemon.setStateCounter(container)
 


### PR DESCRIPTION
fix https://github.com/moby/moby/issues/35304 `restart=unless-stopped` not working as expected

Signed-off-by: Deng Guangxing <dengguangxing@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
