### PR TITLE
Fix .go-autogen warnings

### DIFF
--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -5,8 +5,10 @@
 #
 #     TESTFLAGS='-check.f DockerSuite.TestBuild*' ./hack/make.sh binary test-integration
 #
-
-source "$SCRIPTDIR/make/.go-autogen"
+if [ -z $MAKEDIR ]; then
+	export MAKEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+fi
+source "$MAKEDIR/.go-autogen"
 
 # Set defaults
 : ${TEST_REPEAT:=1}

--- a/hack/make/build-integration-test-binary
+++ b/hack/make/build-integration-test-binary
@@ -2,7 +2,6 @@
 # required by `make build-integration-cli-on-swarm`
 set -e
 
-source "${MAKEDIR}/.go-autogen"
 source hack/make/.integration-test-helpers
 
 build_test_suite_binaries

--- a/hack/make/test-integration
+++ b/hack/make/test-integration
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -e -o pipefail
 
-source "${MAKEDIR}/.go-autogen"
 source hack/make/.integration-test-helpers
 
 (


### PR DESCRIPTION
The `.integration-test-helpers` script was sourced by `/etc/bash/bash.rc`.
However, the `$SCRIPTDIR` environment variable is set through `hack/make.sh`,
so will not be set when calling the `.integration-test-helpers` script directly.

Before this patch;

    make BIND_DIR=. shell
    ...
    bash: /make/.go-autogen: No such file or directory

After this patch, the warning is no longer printed

Also removed sourcing `.go-autogen` from test-integration and build-integration-test-binary,
as they already sourced `.integration-test-helpers` (which sources
`.go-autogen`).

ping @dnephin @vdemeester PTAL

