### PR TITLE
Remove Dockerfile.solaris reference

### DIFF
--- a/hack/make/.detect-daemon-osarch
+++ b/hack/make/.detect-daemon-osarch
@@ -60,9 +60,6 @@ case "$PACKAGE_ARCH" in
 			windows)
 				DOCKERFILE='Dockerfile.windows'
 				;;
-			solaris)
-				DOCKERFILE='Dockerfile.solaris'
-				;;
 		esac
 		;;
 	*)


### PR DESCRIPTION
This is a small fix that removes Dockerfile.solaris reference in `hack/make/.detect-daemon-osarch` as `Dockerfile.solaris` has been removed.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
