### PR TITLE
Remove duplicate redundant setting of OOMScoreAdj in OCI spec

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -755,7 +755,6 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 	if err := setResources(&s, c.HostConfig.Resources); err != nil {
 		return nil, fmt.Errorf("linux runtime spec resources: %v", err)
 	}
-	s.Process.OOMScoreAdj = &c.HostConfig.OomScoreAdj
 	s.Linux.Sysctl = c.HostConfig.Sysctls
 
 	p := s.Linux.CgroupsPath


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

`OOMScoreAdj` is set to the same value twice in the `createSpec` function in daemon\oci_linux.go. Removed the duplicate. (Also set on L882)