### PR TITLE
Move Isolation API changes to the correct version

### DIFF
--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -15,6 +15,13 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 ## v1.35 API changes
 
+[Docker Engine API v1.35](https://docs.docker.com/engine/api/v1.35/) documentation
+
+* `POST /services/create` and `POST /services/(id)/update` now accepts an
+  `Isolation` field on container spec to set the Isolation technology of the
+  containers running the service (`default`, `process`, or `hyperv`). This
+  configuration is only used for Windows containers.
+
 
 ## v1.34 API changes
 
@@ -26,7 +33,6 @@ keywords: "API, Docker, rcli, REST, documentation"
   If `Error` is `null`, container removal has succeeded, otherwise
   the test of an error message indicating why container removal has failed
   is available from `Error.Message` field.
-* `POST /services/create` and `POST /services/(id)/update` now accept an `Isolation` field on container spec
 
 ## v1.33 API changes
 


### PR DESCRIPTION
Commit https://github.com/moby/moby/commit/d91c5f42eb37c6f88cec4021c10c0a1ded1785c3 (https://github.com/moby/moby/pull/34424) added support for "Isolation" mode for services, but didn't get merged before API 1.34.

This patch moves the description in the API version history to the correct API version (1.35), and does a slight rewording of the functionality.


ping @vieux @cpuguy83 @simonferquel 
