### PR TITLE
Permit a broader range of errors from mirror endpoints when determining whether to fall back

### DIFF
--- a/distribution/errors_test.go
+++ b/distribution/errors_test.go
@@ -1,0 +1,85 @@
+package distribution
+
+import (
+	"errors"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/docker/distribution/registry/api/errcode"
+	"github.com/docker/distribution/registry/api/v2"
+	"github.com/docker/distribution/registry/client"
+)
+
+var always_continue = []error{
+	&client.UnexpectedHTTPResponseError{},
+
+	// Some errcode.Errors that don't disprove the existence of a V1 image
+	errcode.Error{Code: errcode.ErrorCodeUnauthorized},
+	errcode.Error{Code: v2.ErrorCodeManifestUnknown},
+	errcode.Error{Code: v2.ErrorCodeNameUnknown},
+
+	errors.New("some totally unexpected error"),
+}
+
+var continue_from_mirror_endpoint = []error{
+	ImageConfigPullError{},
+
+	// Some other errcode.Error that doesn't indicate we should search for a V1 image.
+	errcode.Error{Code: errcode.ErrorCodeTooManyRequests},
+}
+
+var never_continue = []error{
+	errors.New(strings.ToLower(syscall.ESRCH.Error())), // No such process
+}
+
+func TestContinueOnError_NonMirrorEndpoint(t *testing.T) {
+	for _, err := range always_continue {
+		if !continueOnError(err, false) {
+			t.Errorf("Should continue from non-mirror endpoint: %T: '%s'", err, err.Error())
+		}
+	}
+
+	for _, err := range continue_from_mirror_endpoint {
+		if continueOnError(err, false) {
+			t.Errorf("Should only continue from mirror endpoint: %T: '%s'", err, err.Error())
+		}
+	}
+}
+
+func TestContinueOnError_MirrorEndpoint(t *testing.T) {
+	errs := []error{}
+	errs = append(errs, always_continue...)
+	errs = append(errs, continue_from_mirror_endpoint...)
+	for _, err := range errs {
+		if !continueOnError(err, true) {
+			t.Errorf("Should continue from mirror endpoint: %T: '%s'", err, err.Error())
+		}
+	}
+}
+
+func TestContinueOnError_NeverContinue(t *testing.T) {
+	for _, is_mirror_endpoint := range []bool{true, false} {
+		for _, err := range never_continue {
+			if continueOnError(err, is_mirror_endpoint) {
+				t.Errorf("Should never continue: %T: '%s'", err, err.Error())
+			}
+		}
+	}
+}
+
+func TestContinueOnError_UnnestsErrors(t *testing.T) {
+	// ContinueOnError should evaluate nested errcode.Errors.
+
+	// Assumes that v2.ErrorCodeNameUnknown is a continueable error code.
+	err := errcode.Errors{errcode.Error{Code: v2.ErrorCodeNameUnknown}}
+	if !continueOnError(err, false) {
+		t.Fatal("ContinueOnError should unnest, base return value on errcode.Errors")
+	}
+
+	// Assumes that errcode.ErrorCodeTooManyRequests is not a V1-fallback indication
+	err = errcode.Errors{errcode.Error{Code: errcode.ErrorCodeTooManyRequests}}
+	if continueOnError(err, false) {
+		t.Fatal("ContinueOnError should unnest, base return value on errcode.Errors")
+	}
+}

--- a/distribution/errors_test.go
+++ b/distribution/errors_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/distribution/registry/client"
 )
 
-var always_continue = []error{
+var alwaysContinue = []error{
 	&client.UnexpectedHTTPResponseError{},
 
 	// Some errcode.Errors that don't disprove the existence of a V1 image
@@ -22,25 +22,25 @@ var always_continue = []error{
 	errors.New("some totally unexpected error"),
 }
 
-var continue_from_mirror_endpoint = []error{
+var continueFromMirrorEndpoint = []error{
 	ImageConfigPullError{},
 
 	// Some other errcode.Error that doesn't indicate we should search for a V1 image.
 	errcode.Error{Code: errcode.ErrorCodeTooManyRequests},
 }
 
-var never_continue = []error{
+var neverContinue = []error{
 	errors.New(strings.ToLower(syscall.ESRCH.Error())), // No such process
 }
 
 func TestContinueOnError_NonMirrorEndpoint(t *testing.T) {
-	for _, err := range always_continue {
+	for _, err := range alwaysContinue {
 		if !continueOnError(err, false) {
 			t.Errorf("Should continue from non-mirror endpoint: %T: '%s'", err, err.Error())
 		}
 	}
 
-	for _, err := range continue_from_mirror_endpoint {
+	for _, err := range continueFromMirrorEndpoint {
 		if continueOnError(err, false) {
 			t.Errorf("Should only continue from mirror endpoint: %T: '%s'", err, err.Error())
 		}
@@ -49,8 +49,8 @@ func TestContinueOnError_NonMirrorEndpoint(t *testing.T) {
 
 func TestContinueOnError_MirrorEndpoint(t *testing.T) {
 	errs := []error{}
-	errs = append(errs, always_continue...)
-	errs = append(errs, continue_from_mirror_endpoint...)
+	errs = append(errs, alwaysContinue...)
+	errs = append(errs, continueFromMirrorEndpoint...)
 	for _, err := range errs {
 		if !continueOnError(err, true) {
 			t.Errorf("Should continue from mirror endpoint: %T: '%s'", err, err.Error())
@@ -59,9 +59,9 @@ func TestContinueOnError_MirrorEndpoint(t *testing.T) {
 }
 
 func TestContinueOnError_NeverContinue(t *testing.T) {
-	for _, is_mirror_endpoint := range []bool{true, false} {
-		for _, err := range never_continue {
-			if continueOnError(err, is_mirror_endpoint) {
+	for _, isMirrorEndpoint := range []bool{true, false} {
+		for _, err := range neverContinue {
+			if continueOnError(err, isMirrorEndpoint) {
 				t.Errorf("Should never continue: %T: '%s'", err, err.Error())
 			}
 		}

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -74,7 +74,7 @@ func (p *v2Puller) Pull(ctx context.Context, ref reference.Named, platform strin
 		if _, ok := err.(fallbackError); ok {
 			return err
 		}
-		if continueOnError(err) {
+		if continueOnError(err, p.endpoint.Mirror) {
 			return fallbackError{
 				err:         err,
 				confirmedV2: p.confirmedV2,

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -67,7 +67,7 @@ func (p *v2Pusher) Push(ctx context.Context) (err error) {
 	}
 
 	if err = p.pushV2Repository(ctx); err != nil {
-		if continueOnError(err) {
+		if continueOnError(err, p.endpoint.Mirror) {
 			return fallbackError{
 				err:         err,
 				confirmedV2: p.pushState.confirmedV2,


### PR DESCRIPTION
This change has 2 primary effects:
* Allow for continueOnError to disambiguate mirror -> other endpoint fallbacks from V2 -> V1 fallbacks.
* Begin allowing for a wider range of failures from mirror endpoints to result in fallbacks

The goal is to allow for higher pull availability.

Signed-off-by: Jake Sanders <jsand@google.com>

![what kind of fruit is this](https://i.redd.it/45qkgqs53avz.jpg)