### PR TITLE
Fix API version

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion string = "1.34"
+	DefaultVersion string = "1.35"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.


### PR DESCRIPTION
Commit https://github.com/moby/moby/commit/3ba1dda1914fa7d380d9d3220c3b158a41f90cba (https://github.com/moby/moby/pull/35343) bumped the API version, but forgot to actually bump the version in code.

This patch fixes the version to match those changes :-)

thanks @simonferquel for spotting this; I messed that one up 😅 