### PR TITLE
Use containerd API to get version

### DIFF
--- a/libcontainerd/client_daemon.go
+++ b/libcontainerd/client_daemon.go
@@ -60,6 +60,10 @@ type client struct {
 	containers map[string]*container
 }
 
+func (c *client) Version(ctx context.Context) (containerd.Version, error) {
+	return c.remote.Version(ctx)
+}
+
 func (c *client) Restore(ctx context.Context, id string, attachStdio StdioCallback) (alive bool, pid int, err error) {
 	c.Lock()
 	defer c.Unlock()

--- a/libcontainerd/client_local_windows.go
+++ b/libcontainerd/client_local_windows.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Microsoft/hcsshim"
 	opengcs "github.com/Microsoft/opengcs/client"
+	"github.com/containerd/containerd"
 	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/docker/docker/pkg/system"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -69,6 +70,10 @@ const (
 // container creator management stacks. We hard code "docker" in the case
 // of docker.
 const defaultOwner = "docker"
+
+func (c *client) Version(ctx context.Context) (containerd.Version, error) {
+	return containerd.Version{}, errors.New("not implemented on Windows")
+}
 
 // Create is the entrypoint to create a container from a spec.
 // Table below shows the fields required for HCS JSON calling parameters,

--- a/libcontainerd/types.go
+++ b/libcontainerd/types.go
@@ -82,6 +82,8 @@ type Backend interface {
 
 // Client provides access to containerd features.
 type Client interface {
+	Version(ctx context.Context) (containerd.Version, error)
+
 	Restore(ctx context.Context, containerID string, attachStdio StdioCallback) (alive bool, pid int, err error)
 
 	Create(ctx context.Context, containerID string, spec *specs.Spec, runtimeOptions interface{}) error


### PR DESCRIPTION
The `docker info` code was shelling out to obtain the version of containerd (using the `--version` flag).

Parsing the output of this version string is error-prone, and not needed, as the containerd API can return the version.

This patch adds a `Version()` method to the containerd Client interface, and uses this to get the containerd version.

ping @mlaventure @stevvooe PTAL

