### PR TITLE
Add missing headers for e2e test image build

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -3,6 +3,7 @@ FROM golang:1.8.5-alpine3.6 as builder
 
 RUN apk add --update \
     bash \
+    btrfs-progs-dev \
     build-base \
     curl \
     lvm2-dev \


### PR DESCRIPTION
When building the e2e image, the following error is seen:
```bash
...
---> Making bundle: build-integration-test-binary (in bundles/build-integration-test-binary)
Building test suite binary ./integration-cli/test.main
# github.com/docker/docker/daemon/graphdriver/btrfs
daemon/graphdriver/btrfs/btrfs.go:8:25: fatal error: btrfs/ioctl.h: No such file or directory
 #include <btrfs/ioctl.h>
                         ^
compilation terminated.
...
```

Install the `btrfs-progs-dev` package to fix this.