### PR TITLE
Add /proc/scsi to masked paths

### DIFF
--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -119,6 +119,7 @@ func DefaultLinuxSpec() specs.Spec {
 			"/proc/timer_list",
 			"/proc/timer_stats",
 			"/proc/sched_debug",
+			"/proc/scsi",
 		},
 		ReadonlyPaths: []string{
 			"/proc/asound",


### PR DESCRIPTION
This is writeable, and can be used to remove devices. Containers do
not need to know about scsi devices.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![1411-masked-dog](https://user-images.githubusercontent.com/482364/32381041-9f526fe6-c0a9-11e7-927e-c02976445c2a.jpg)
