### PR TITLE
Replace 'precpu' with 'percpu' in API docs.

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5095,9 +5095,9 @@ paths:
         This endpoint returns a live stream of a container’s resource usage
         statistics.
 
-        The `precpu_stats` is the CPU statistic of last read, which is used
-        for calculating the CPU usage percentage. It is not the same as the
-        `cpu_stats` field.
+        The `precpu_stats` is the CPU statistic of the *previous* read, and is
+        used to calculate the CPU usage percentage. It is not an exact copy
+        of the `cpu_stats` field.
 
         If either `precpu_stats.online_cpus` or `cpu_stats.online_cpus` is
         nil then for compatibility with older daemons the length of the

--- a/docs/api/v1.19.md
+++ b/docs/api/v1.19.md
@@ -739,7 +739,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
          }
       }
 
-The `precpu_stats` is the cpu statistic of last read, which is used for calculating the cpu usage percent. It is not the exact copy of the `cpu_stats` field.
+The `precpu_stats` is the cpu statistic of *previous* read, which is used for calculating the cpu usage percent. It is not the exact copy of the `cpu_stats` field.
 
 **Query parameters**:
 

--- a/docs/api/v1.20.md
+++ b/docs/api/v1.20.md
@@ -748,7 +748,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
          }
       }
 
-The `precpu_stats` is the cpu statistic of last read, which is used for calculating the cpu usage percent. It is not the exact copy of the `cpu_stats` field.
+The `precpu_stats` is the cpu statistic of *previous* read, which is used for calculating the cpu usage percent. It is not the exact copy of the `cpu_stats` field.
 
 **Query parameters**:
 

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -829,7 +829,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
          }
       }
 
-The `precpu_stats` is the cpu statistic of last read, which is used for calculating the cpu usage percent. It is not the exact copy of the `cpu_stats` field.
+The `precpu_stats` is the cpu statistic of *previous* read, which is used for calculating the cpu usage percent. It is not the exact copy of the `cpu_stats` field.
 
 **Query parameters**:
 

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -957,7 +957,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
          }
       }
 
-The `precpu_stats` is the cpu statistic of last read, which is used for calculating the cpu usage percent. It is not the exact copy of the `cpu_stats` field.
+The `precpu_stats` is the cpu statistic of *previous* read, which is used for calculating the cpu usage percent. It is not the exact copy of the `cpu_stats` field.
 
 **Query parameters**:
 

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -986,7 +986,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
          }
       }
 
-The `precpu_stats` is the cpu statistic of last read, which is used for calculating the cpu usage percent. It is not the exact copy of the `cpu_stats` field.
+The `precpu_stats` is the cpu statistic of *previous* read, which is used for calculating the cpu usage percent. It is not the exact copy of the `cpu_stats` field.
 
 **Query parameters**:
 

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -1036,7 +1036,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
          }
       }
 
-The `precpu_stats` is the cpu statistic of last read, which is used for calculating the cpu usage percent. It is not the exact copy of the `cpu_stats` field.
+The `precpu_stats` is the cpu statistic of *previous* read, which is used for calculating the cpu usage percent. It is not the exact copy of the `cpu_stats` field.
 
 **Query parameters**:
 


### PR DESCRIPTION
**- What I did**

Replace `precpu` with `percpu` in `docs/api/*.md`.

**- How to verify it**

Compare output of:

- `curl "localhost:4243/containers/$CID/stats?stream=false" | jq .cpu_stats.cpu_usage.precpu_usage`
- `curl "localhost:4243/containers/$CID/stats?stream=false" | jq .cpu_stats.cpu_usage.precpu_usage`

**- Description for the changelog**

Docs should refer to `percpu_stats`, not `precpu_stats`.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1585815/32417398-0e309dec-c20e-11e7-857d-a577c20091f2.png)
