### PR TITLE
Fix message line in journald when Tty enabled

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -6,6 +6,7 @@ package journald
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"unicode"
 
@@ -114,6 +115,11 @@ func (s *journald) Log(msg *logger.Message) error {
 	line := string(msg.Line)
 	source := msg.Source
 	logger.PutMessage(msg)
+
+	// when Tty is enabled on a container "\r" is appended to each line
+	// and is causing journald message to show blob data instead
+	// of the string message.
+	line = strings.Replace(line, "\r", "\\r", -1)
 
 	if source == "stderr" {
 		return journal.Send(line, journal.PriErr, vars)


### PR DESCRIPTION
**- What I did**

When Tty is enabled a trailing `\r` is added to the line.
This makes the message data to be corrupted when sent to journald
ending with `[<text size>B blob data]` messages in journalctl -u docker.

**- How I did it**

To fix this, replace all `\r` with `\\r`.

**- How to verify it**

I used Vagrant to install binaries on CentOS 7 that comes with systemd and journald out of the box.
Then ran `docker run -dit --log-driver journald busybox sh -c "while true;do echo hello; sleep 1s;done"` and then checked that "hello\r" is diplayed and not "[6B blob data]" in `journalctl -u docker`
