### PR TITLE
Fix negative time out policy when stop the container

### DIFF
--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -70,8 +70,15 @@ func (daemon *Daemon) containerStop(container *containerpkg.Container, seconds i
 	}
 
 	// 2. Wait for the process to exit on its own
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(seconds)*time.Second)
-	defer cancel()
+	var (
+		ctx    context.Context = context.Context
+	)
+
+	if seconds >= 0 {
+		cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(seconds)*time.Second)
+		defer cancel
+	}
 
 	if status := <-container.Wait(ctx, containerpkg.WaitConditionNotRunning); status.Err() != nil {
 		logrus.Infof("Container %v failed to exit within %d seconds of signal %d - using the force", container.ID, seconds, stopSignal)


### PR DESCRIPTION
This patch fix the policy when stop timeout value is negative.

The realize before was wait channel and now we use context.
Context will return immediately and the behavior will be different.

Fix it by using different cancel func when timeout is negative.

Signed-off-by: Haomini Tsai <caihaomin@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
When negative timeout is set， docker will behave differently after PR #32237.
This patch fix the difference between wait channel and `context.WithTimeout`.
fix #35311 

**- How I did it**
Considering the negative timeout,use `context.WithCancel` to generate the cancel func
And point to positive timeout ,just using `context.WithTimeout` as before

**- How to verify it**
1. `docker run -itd busybox top`
2. `docker stop -t -1 $containerID`
3. `docker` will wait until the process exit elegantly.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
This patch fix the policy when stop timeout value is negative.

**- A picture of a cute animal (not mandatory but encouraged)**

