### PR TITLE
Set OS on scratch image and prevent panic if empty

### DIFF
--- a/builder/dockerfile/imagecontext.go
+++ b/builder/dockerfile/imagecontext.go
@@ -1,6 +1,8 @@
 package dockerfile
 
 import (
+	"runtime"
+
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/remotecontext"
@@ -73,7 +75,13 @@ func (m *imageSources) Unmount() (retErr error) {
 func (m *imageSources) Add(im *imageMount) {
 	switch im.image {
 	case nil:
-		im.image = &dockerimage.Image{}
+		// set the OS for scratch images
+		os := runtime.GOOS
+		// Windows does not support scratch except for LCOW
+		if runtime.GOOS == "windows" {
+			os = "linux"
+		}
+		im.image = &dockerimage.Image{V1Image: dockerimage.V1Image{OS: os}}
 	default:
 		m.byImageID[im.image.ImageID()] = im
 	}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -95,7 +95,14 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig, managed bool) (
 		if err != nil {
 			return nil, err
 		}
-		os = img.OS
+		if img.OS != "" {
+			os = img.OS
+		} else {
+			// default to the host OS except on Windows with LCOW
+			if runtime.GOOS == "windows" && system.LCOWSupported() {
+				os = "linux"
+			}
+		}
 		imgID = img.ID()
 
 		if runtime.GOOS == "windows" && img.OS == "linux" && !system.LCOWSupported() {


### PR DESCRIPTION
Signed-off-by: John Stephens <johnstep@docker.com>

This change fixes https://github.com/moby/moby/issues/35413 and adds a test. The regression was introduced with https://github.com/moby/moby/commit/0380fbff37922cadf294851b1546f4c212c7f364, which requires an OS from the image. Images built from scratch did not specify an OS, leading to the eventual panic.