### PR TITLE
oci: re-add /sys/firmware to masked paths

### DIFF
--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -119,6 +119,7 @@ func DefaultLinuxSpec() specs.Spec {
 			"/proc/timer_list",
 			"/proc/timer_stats",
 			"/proc/sched_debug",
+			"/sys/firmware",
 			"/proc/scsi",
 		},
 		ReadonlyPaths: []string{


### PR DESCRIPTION
f1545882264e ("LCOW: OCI Spec and Environment for container start")
appears to have accidentially removed this masked path from the list.
Re-add it, because we don't want containers to be able to see bits of
the firwmare (such as EFI variables).

I noticed this while backporting a21ecdf3c8a3 ("Add /proc/scsi to masked
paths").

[![Very pregnant orange cat](https://farm9.staticflickr.com/8174/8060198556_e9f65bf4f1_h.jpg)](https://flic.kr/p/dhfCdC)

###### [Very pregnant orange cat](https://flic.kr/p/dhfCdC) by [Alexandra Zakharova](https://www.flickr.com/photos/zalexandra/).

Fixes: f1545882264e ("LCOW: OCI Spec and Environment for container start")
Signed-off-by: Aleksa Sarai <asarai@suse.de>