### PR TITLE
Bump opencontainers/image-spec to v1.0.0

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -67,7 +67,7 @@ google.golang.org/grpc v1.3.0
 # When updating, also update RUNC_COMMIT in hack/dockerfile/binaries-commits accordingly
 github.com/opencontainers/runc 0351df1c5a66838d0c392b4ac4cf9450de844e2d
 github.com/opencontainers/runtime-spec v1.0.0
-github.com/opencontainers/image-spec 372ad780f63454fbbbbcc7cf80e5b90245c13e13
+github.com/opencontainers/image-spec v1.0.0
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
 
 # libcontainer deps (see src/github.com/opencontainers/runc/Godeps/Godeps.json)

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
@@ -37,7 +37,7 @@ type ImageConfig struct {
 	// Cmd defines the default arguments to the entrypoint of the container.
 	Cmd []string `json:"Cmd,omitempty"`
 
-	// Volumes is a set of directories which should be created as data volumes in a container running this image.
+	// Volumes is a set of directories describing where the process is likely write data specific to a container instance.
 	Volumes map[string]struct{} `json:"Volumes,omitempty"`
 
 	// WorkingDir sets the current working directory of the entrypoint process in the container.

--- a/vendor/github.com/opencontainers/image-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc6-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
looks like there's no code changes for this repository, but this matches what's used by containerd

ping @mlaventure