### PR TITLE
fixed special character

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6995,7 +6995,7 @@ paths:
             - `network=<string>` network name or ID
             - `node=<string>` node ID
             - `plugin`=<string> plugin name or ID
-            - `scope`＝<string> local or swarm
+            - `scope`=<string> local or swarm
             - `secret=<string>` secret name or ID
             - `service=<string>` service name or ID
             - `type=<string>` object to filter by, one of `container`, `image`, `volume`, `network`, `daemon`, `plugin`, `node`, `service`, `secret` or `config`


### PR DESCRIPTION
`scope`=<string> local or swarm had special character, which was breaking the Swagger UI

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

