### PR TITLE
Fix dockerfile parser failing silently on long tokens

### DIFF
--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -321,7 +321,7 @@ func Parse(rwc io.Reader) (*Result, error) {
 		Warnings:    warnings,
 		EscapeToken: d.escapeToken,
 		OS:          d.platformToken,
-	}, nil
+	}, handleScannerError(scanner.Err())
 }
 
 func trimComments(src []byte) []byte {
@@ -357,4 +357,13 @@ func processLine(d *Directive, token []byte, stripLeftWhitespace bool) ([]byte, 
 		token = trimWhitespace(token)
 	}
 	return trimComments(token), d.possibleParserDirective(string(token))
+}
+
+func handleScannerError(err error) error {
+	switch err {
+	case bufio.ErrTooLong:
+		return errors.Errorf("dockerfile line greater than max allowed size of %d", bufio.MaxScanTokenSize-1)
+	default:
+		return err
+	}
 }

--- a/builder/dockerfile/parser/parser_test.go
+++ b/builder/dockerfile/parser/parser_test.go
@@ -1,12 +1,14 @@
 package parser
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -158,4 +160,15 @@ RUN indented \
 	assert.Contains(t, warnings[0], "RUN something     following     more")
 	assert.Contains(t, warnings[1], "RUN another     thing")
 	assert.Contains(t, warnings[2], "will become errors in a future release")
+}
+
+func TestParseReturnsScannerErrors(t *testing.T) {
+	label := strings.Repeat("a", bufio.MaxScanTokenSize)
+
+	dockerfile := strings.NewReader(fmt.Sprintf(`
+		FROM image
+		LABEL test=%s
+`, label))
+	_, err := Parse(dockerfile)
+	assert.EqualError(t, err, "dockerfile line greater than max allowed size of 65535")
 }

--- a/builder/remotecontext/archive.go
+++ b/builder/remotecontext/archive.go
@@ -79,7 +79,6 @@ func FromArchive(tarStream io.Reader) (builder.Source, error) {
 	}
 
 	tsc.sums = sum.GetSums()
-
 	return tsc, nil
 }
 

--- a/builder/remotecontext/remote_test.go
+++ b/builder/remotecontext/remote_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/internal/testutil"
-	"github.com/docker/docker/pkg/archive"
+	"github.com/gotestyourself/gotestyourself/fs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -174,11 +174,10 @@ func TestUnknownContentLength(t *testing.T) {
 	}
 }
 
-func TestMakeRemoteContext(t *testing.T) {
-	contextDir, cleanup := createTestTempDir(t, "", "builder-tarsum-test")
-	defer cleanup()
-
-	createTestTempFile(t, contextDir, builder.DefaultDockerfileName, dockerfileContents, 0777)
+func TestDownloadRemote(t *testing.T) {
+	contextDir := fs.NewDir(t, "test-builder-download-remote",
+		fs.WithFile(builder.DefaultDockerfileName, dockerfileContents))
+	defer contextDir.Remove()
 
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
@@ -187,39 +186,15 @@ func TestMakeRemoteContext(t *testing.T) {
 	serverURL.Path = "/" + builder.DefaultDockerfileName
 	remoteURL := serverURL.String()
 
-	mux.Handle("/", http.FileServer(http.Dir(contextDir)))
+	mux.Handle("/", http.FileServer(http.Dir(contextDir.Path())))
 
-	remoteContext, err := MakeRemoteContext(remoteURL, map[string]func(io.ReadCloser) (io.ReadCloser, error){
-		mimeTypes.TextPlain: func(rc io.ReadCloser) (io.ReadCloser, error) {
-			dockerfile, err := ioutil.ReadAll(rc)
-			if err != nil {
-				return nil, err
-			}
+	contentType, content, err := downloadRemote(remoteURL)
+	require.NoError(t, err)
 
-			r, err := archive.Generate(builder.DefaultDockerfileName, string(dockerfile))
-			if err != nil {
-				return nil, err
-			}
-			return ioutil.NopCloser(r), nil
-		},
-	})
-
-	if err != nil {
-		t.Fatalf("Error when executing DetectContextFromRemoteURL: %s", err)
-	}
-
-	if remoteContext == nil {
-		t.Fatal("Remote context should not be nil")
-	}
-
-	h, err := remoteContext.Hash(builder.DefaultDockerfileName)
-	if err != nil {
-		t.Fatalf("failed to compute hash %s", err)
-	}
-
-	if expected, actual := "7b6b6b66bee9e2102fbdc2228be6c980a2a23adf371962a37286a49f7de0f7cc", h; expected != actual {
-		t.Fatalf("There should be file named %s %s in fileInfoSums", expected, actual)
-	}
+	assert.Equal(t, mimeTypes.TextPlain, contentType)
+	raw, err := ioutil.ReadAll(content)
+	require.NoError(t, err)
+	assert.Equal(t, dockerfileContents, string(raw))
 }
 
 func TestGetWithStatusError(t *testing.T) {


### PR DESCRIPTION
Fixes docker/for-linux#157
Fixes docker/for-mac#2208

Report errors when the scanner fails. The error message should include enough details for the user to fix the problem.

Fixing the first problem revealed another problem with handling remote urls that point at Dockerfiles, which is fixed in the second and third commits.