### PR TITLE
Don't special case /sys/firmware in masked paths

### DIFF
--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -120,6 +120,7 @@ func DefaultLinuxSpec() specs.Spec {
 			"/proc/timer_stats",
 			"/proc/sched_debug",
 			"/proc/scsi",
+			"/sys/firmware",
 		},
 		ReadonlyPaths: []string{
 			"/proc/asound",
@@ -203,11 +204,6 @@ func DefaultLinuxSpec() specs.Spec {
 	// For LCOW support, populate a blank Windows spec
 	if runtime.GOOS == "windows" {
 		s.Windows = &specs.Windows{}
-	}
-
-	// For LCOW support, don't mask /sys/firmware
-	if runtime.GOOS != "windows" {
-		s.Linux.MaskedPaths = append(s.Linux.MaskedPaths, "/sys/firmware")
 	}
 
 	return s


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Follow-up from https://github.com/moby/moby/pull/35421#issuecomment-342939558. This isn't an issue for LCOW any more, so removing the special case.

@thaJeztah @cyphar @gupta-ak @johnstep 