### PR TITLE
Fix markdown structure of v1.md

### DIFF
--- a/image/spec/v1.md
+++ b/image/spec/v1.md
@@ -10,115 +10,94 @@ runtime and execution tool.
 
 This specification uses the following terms:
 
-<dl>
-    <dt>
-        Layer
-    </dt>
-    <dd>
-        Images are composed of <i>layers</i>. <i>Image layer</i> is a general
-        term which may be used to refer to one or both of the following:
+### Layer
 
-        <ol>
-            <li>The metadata for the layer, described in the JSON format.</li>
-            <li>The filesystem changes described by a layer.</li>
-        </ol>
+Images are composed of <i>layers</i>. <i>Image layer</i> is a general
+term which may be used to refer to one or both of the following:
+        
+1. The metadata for the layer, described in the JSON format.
+2. The filesystem changes described by a layer.
 
-        To refer to the former you may use the term <i>Layer JSON</i> or
-        <i>Layer Metadata</i>. To refer to the latter you may use the term
-        <i>Image Filesystem Changeset</i> or <i>Image Diff</i>.
-    </dd>
-    <dt>
-        Image JSON
-    </dt>
-    <dd>
-        Each layer has an associated JSON structure which describes some
-        basic information about the image such as date created, author, and the
-        ID of its parent image as well as execution/runtime configuration like
-        its entry point, default arguments, CPU/memory shares, networking, and
-        volumes.
-    </dd>
-    <dt>
-        Image Filesystem Changeset
-    </dt>
-    <dd>
-        Each layer has an archive of the files which have been added, changed,
-        or deleted relative to its parent layer. Using a layer-based or union
-        filesystem such as AUFS, or by computing the diff from filesystem
-        snapshots, the filesystem changeset can be used to present a series of
-        image layers as if they were one cohesive filesystem.
-    </dd>
-    <dt>
-        Image ID <a name="id_desc"></a>
-    </dt>
-    <dd>
-        Each layer is given an ID upon its creation. It is 
-        represented as a hexadecimal encoding of 256 bits, e.g.,
-        <code>a9561eb1b190625c9adb5a9513e72c4dedafc1cb2d4c5236c9a6957ec7dfd5a9</code>.
-        Image IDs should be sufficiently random so as to be globally unique.
-        32 bytes read from <code>/dev/urandom</code> is sufficient for all
-        practical purposes. Alternatively, an image ID may be derived as a
-        cryptographic hash of image contents as the result is considered
-        indistinguishable from random. The choice is left up to implementors.
-    </dd>
-    <dt>
-        Image Parent
-    </dt>
-    <dd>
-        Most layer metadata structs contain a <code>parent</code> field which
-        refers to the Image from which another directly descends. An image
-        contains a separate JSON metadata file and set of changes relative to
-        the filesystem of its parent image. <i>Image Ancestor</i> and
-        <i>Image Descendant</i> are also common terms.
-    </dd>
-    <dt>
-        Image Checksum
-    </dt>
-    <dd>
-        Layer metadata structs contain a cryptographic hash of the contents of
-        the layer's filesystem changeset. Though the set of changes exists as a
-        simple Tar archive, two archives with identical filenames and content
-        will have different SHA digests if the last-access or last-modified
-        times of any entries differ. For this reason, image checksums are
-        generated using the TarSum algorithm which produces a cryptographic
-        hash of file contents and selected headers only. Details of this
-        algorithm are described in the separate <a href="https://github.com/docker/docker/blob/master/pkg/tarsum/tarsum_spec.md">TarSum specification</a>.
-    </dd>
-    <dt>
-        Tag
-    </dt>
-    <dd>
-        A tag serves to map a descriptive, user-given name to any single image
-        ID. An image name suffix (the name component after <code>:</code>) is
-        often referred to as a tag as well, though it strictly refers to the
-        full name of an image. Acceptable values for a tag suffix are
-        implementation specific, but they SHOULD be limited to the set of
-        alphanumeric characters <code>[a-zA-Z0-9]</code>, punctuation
-        characters <code>[._-]</code>, and MUST NOT contain a <code>:</code>
-        character.
-    </dd>
-    <dt>
-        Repository
-    </dt>
-    <dd>
-        A collection of tags grouped under a common prefix (the name component
-        before <code>:</code>). For example, in an image tagged with the name
-        <code>my-app:3.1.4</code>, <code>my-app</code> is the <i>Repository</i>
-        component of the name. Acceptable values for repository name are
-        implementation specific, but they SHOULD be limited to the set of
-        alphanumeric characters <code>[a-zA-Z0-9]</code>, and punctuation
-        characters <code>[._-]</code>, however it MAY contain additional
-        <code>/</code> and <code>:</code> characters for organizational
-        purposes, with the last <code>:</code> character being interpreted
-        dividing the repository component of the name from the tag suffix
-        component.
-    </dd>
-</dl>
+To refer to the former you may use the term *Layer JSON* or
+*Layer Metadata*. To refer to the latter you may use the term
+*Image Filesystem Changeset* or *Image Diff*.
+
+### Image JSON
+
+Each layer has an associated JSON structure which describes some
+basic information about the image such as date created, author, and the
+ID of its parent image as well as execution/runtime configuration like
+its entry point, default arguments, CPU/memory shares, networking, and
+volumes.
+
+### Image Filesystem Changeset
+
+Each layer has an archive of the files which have been added, changed,
+or deleted relative to its parent layer. Using a layer-based or union
+filesystem such as AUFS, or by computing the diff from filesystem
+snapshots, the filesystem changeset can be used to present a series of
+image layers as if they were one cohesive filesystem.
+
+### Image ID
+
+Each layer is given an ID upon its creation. It is 
+represented as a hexadecimal encoding of 256 bits, e.g.,
+`a9561eb1b190625c9adb5a9513e72c4dedafc1cb2d4c5236c9a6957ec7dfd5a9`.
+Image IDs should be sufficiently random so as to be globally unique.
+32 bytes read from `/dev/urandom` is sufficient for all
+practical purposes. Alternatively, an image ID may be derived as a
+cryptographic hash of image contents as the result is considered
+indistinguishable from random. The choice is left up to implementors.
+
+### Image Parent
+
+Most layer metadata structs contain a `parent` field which
+refers to the Image from which another directly descends. An image
+contains a separate JSON metadata file and set of changes relative to
+the filesystem of its parent image. *Image Ancestor* and
+*Image Descendant* are also common terms.
+
+### Image Checksum
+
+Layer metadata structs contain a cryptographic hash of the contents of
+the layer's filesystem changeset. Though the set of changes exists as a
+simple Tar archive, two archives with identical filenames and content
+will have different SHA digests if the last-access or last-modified
+times of any entries differ. For this reason, image checksums are
+generated using the TarSum algorithm which produces a cryptographic
+hash of file contents and selected headers only. Details of this
+algorithm are described in the separate [TarSum specification](https://github.com/docker/docker/blob/master/pkg/tarsum/tarsum_spec.md).
+
+### Tag
+
+A tag serves to map a descriptive, user-given name to any single image
+ID. An image name suffix (the name component after `:`) is
+often referred to as a tag as well, though it strictly refers to the
+full name of an image. Acceptable values for a tag suffix are
+implementation specific, but they SHOULD be limited to the set of
+alphanumeric characters `[a-zA-Z0-9]`, punctuation
+characters `[._-]`, and MUST NOT contain a `:`
+character.
+
+### Repository
+
+A collection of tags grouped under a common prefix (the name component
+before `:`). For example, in an image tagged with the name
+`my-app:3.1.4`, `my-app` is the *Repository*
+component of the name. Acceptable values for repository name are
+implementation specific, but they SHOULD be limited to the set of
+alphanumeric characters `[a-zA-Z0-9]`, and punctuation
+characters `[._-]`, however it MAY contain additional
+`/` and `:` characters for organizational
+purposes, with the last `:` character being interpreted
+dividing the repository component of the name from the tag suffix
+component.
 
 ## Image JSON Description
 
 Here is an example image JSON file:
 
-```
+```javascript
 {  
     "id": "a9561eb1b190625c9adb5a9513e72c4dedafc1cb2d4c5236c9a6957ec7dfd5a9",
     "parent": "c6e3cedcda2e3982a1a6760e178355e8e65f7b80e4e5248743fa3549d284e024",
@@ -160,228 +139,157 @@ Here is an example image JSON file:
 
 ### Image JSON Field Descriptions
 
-<dl>
-    <dt>
-        id <code>string</code>
-    </dt>
-    <dd>
-        Randomly generated, 256-bit, hexadecimal encoded. Uniquely identifies
-        the image.
-    </dd>
-    <dt>
-        parent <code>string</code>
-    </dt>
-    <dd>
-        ID of the parent image. If there is no parent image then this field
-        should be omitted. A collection of images may share many of the same
-        ancestor layers. This organizational structure is strictly a tree with
-        any one layer having either no parent or a single parent and zero or
-        more descendant layers. Cycles are not allowed and implementations
-        should be careful to avoid creating them or iterating through a cycle
-        indefinitely.
-    </dd>
-    <dt>
-        created <code>string</code>
-    </dt>
-    <dd>
-        ISO-8601 formatted combined date and time at which the image was
-        created.
-    </dd>
-    <dt>
-        author <code>string</code>
-    </dt>
-    <dd>
-        Gives the name and/or email address of the person or entity which
-        created and is responsible for maintaining the image.
-    </dd>
-    <dt>
-        architecture <code>string</code>
-    </dt>
-    <dd>
-        The CPU architecture which the binaries in this image are built to run
-        on. Possible values include:
-        <ul>
-            <li>386</li>
-            <li>amd64</li>
-            <li>arm</li>
-        </ul>
-        More values may be supported in the future and any of these may or may
-        not be supported by a given container runtime implementation.
-    </dd>
-    <dt>
-        os <code>string</code>
-    </dt>
-    <dd>
-        The name of the operating system which the image is built to run on.
-        Possible values include:
-        <ul>
-            <li>darwin</li>
-            <li>freebsd</li>
-            <li>linux</li>
-        </ul>
-        More values may be supported in the future and any of these may or may
-        not be supported by a given container runtime implementation.
-    </dd>
-    <dt>
-        checksum <code>string</code>
-    </dt>
-    <dd>
-        Image Checksum of the filesystem changeset associated with the image
-        layer.
-    </dd>
-    <dt>
-        Size <code>integer</code>
-    </dt>
-    <dd>
-        The size in bytes of the filesystem changeset associated with the image
-        layer.
-    </dd>
-    <dt>
-        config <code>struct</code>
-    </dt>
-    <dd>
-        The execution parameters which should be used as a base when running a
-        container using the image. This field can be <code>null</code>, in
-        which case any execution parameters should be specified at creation of
-        the container.
+#### id `string`
+Randomly generated, 256-bit, hexadecimal encoded. Uniquely identifies
+the image.
 
-        <h4>Container RunConfig Field Descriptions</h4>
+#### parent `string`
+ID of the parent image. If there is no parent image then this field
+should be omitted. A collection of images may share many of the same
+ancestor layers. This organizational structure is strictly a tree with
+any one layer having either no parent or a single parent and zero or
+more descendant layers. Cycles are not allowed and implementations
+should be careful to avoid creating them or iterating through a cycle
+indefinitely.
 
-        <dl>
-            <dt>
-                User <code>string</code>
-            </dt>
-            <dd>
-                <p>The username or UID which the process in the container should
-                run as. This acts as a default value to use when the value is
-                not specified when creating a container.</p>
+#### created `string`
+ISO-8601 formatted combined date and time at which the image was
+created.
 
-                <p>All of the following are valid:</p>
+#### author `string`
+Gives the name and/or email address of the person or entity which
+created and is responsible for maintaining the image.
 
-                <ul>
-                    <li><code>user</code></li>
-                    <li><code>uid</code></li>
-                    <li><code>user:group</code></li>
-                    <li><code>uid:gid</code></li>
-                    <li><code>uid:group</code></li>
-                    <li><code>user:gid</code></li>
-                </ul>
+#### architecture `string`
+The CPU architecture which the binaries in this image are built to run
+on. Possible values include:
+* 386
+* amd64
+* arm
 
-                <p>If <code>group</code>/<code>gid</code> is not specified, the
-                default group and supplementary groups of the given
-                <code>user</code>/<code>uid</code> in <code>/etc/passwd</code>
-                from the container are applied.</p>
-            </dd>
-            <dt>
-                Memory <code>integer</code>
-            </dt>
-            <dd>
-                Memory limit (in bytes). This acts as a default value to use
-                when the value is not specified when creating a container.
-            </dd>
-            <dt>
-                MemorySwap <code>integer</code>
-            </dt>
-            <dd>
-                Total memory usage (memory + swap); set to <code>-1</code> to
-                disable swap. This acts as a default value to use when the
-                value is not specified when creating a container.
-            </dd>
-            <dt>
-                CpuShares <code>integer</code>
-            </dt>
-            <dd>
-                CPU shares (relative weight vs. other containers). This acts as
-                a default value to use when the value is not specified when
-                creating a container.
-            </dd>
-            <dt>
-                ExposedPorts <code>struct</code>
-            </dt>
-            <dd>
-                A set of ports to expose from a container running this image.
-                This JSON structure value is unusual because it is a direct
-                JSON serialization of the Go type
-                <code>map[string]struct{}</code> and is represented in JSON as
-                an object mapping its keys to an empty object. Here is an
-                example:
+More values may be supported in the future and any of these may or may
+not be supported by a given container runtime implementation.
 
-<pre>{
+#### os `string`
+The name of the operating system which the image is built to run on.
+Possible values include:
+* darwin
+* freebsd
+* linux
+
+More values may be supported in the future and any of these may or may
+not be supported by a given container runtime implementation.
+
+#### checksum `string`
+Image Checksum of the filesystem changeset associated with the image
+layer.
+
+#### Size `integer`
+The size in bytes of the filesystem changeset associated with the image
+layer.
+
+#### config `struct`
+
+The execution parameters which should be used as a base when running a
+container using the image. This field can be `null`, in
+which case any execution parameters should be specified at creation of
+the container.
+
+##### Container RunConfig Field Descriptions
+
+###### User `string`
+The username or UID which the process in the container should
+run as. This acts as a default value to use when the value is
+not specified when creating a container.
+
+All of the following are valid:
+* `user`
+* `uid`
+* `user:group`
+* `uid:gid`
+* `uid:group`
+* `user:gid`
+
+If `group`/`gid` is not specified, the
+default group and supplementary groups of the given
+`user`/`uid` in `/etc/passwd`
+from the container are applied.
+
+###### Memory `integer`
+Memory limit (in bytes). This acts as a default value to use
+when the value is not specified when creating a container.
+
+###### MemorySwap `integer`
+Total memory usage (memory + swap); set to `-1` to
+disable swap. This acts as a default value to use when the
+value is not specified when creating a container.
+
+###### CpuShares `integer`
+CPU shares (relative weight vs. other containers). This acts as
+a default value to use when the value is not specified when
+creating a container.
+
+###### ExposedPorts `struct`
+A set of ports to expose from a container running this image.
+This JSON structure value is unusual because it is a direct
+JSON serialization of the Go type
+`map[string]struct{}` and is represented in JSON as
+an object mapping its keys to an empty object. Here is an
+example:
+
+```javascript
+{
     "8080": {},
     "53/udp": {},
     "2356/tcp": {}
-}</pre>
+}
+```
 
-                Its keys can be in the format of:
-                <ul>
-                    <li>
-                        <code>"port/tcp"</code>
-                    </li>
-                    <li>
-                        <code>"port/udp"</code>
-                    </li>
-                    <li>
-                        <code>"port"</code>
-                    </li>
-                </ul>
-                with the default protocol being <code>"tcp"</code> if not
-                specified.
+Its keys can be in the format of:
+* `"port/tcp"`
+* `"port/udp"`
+* `"port"`
+          
+with the default protocol being `"tcp"` if not
+specified.
 
-                These values act as defaults and are merged with any specified
-                when creating a container.
-            </dd>
-            <dt>
-                Env <code>array of strings</code>
-            </dt>
-            <dd>
-                Entries are in the format of <code>VARNAME="var value"</code>.
-                These values act as defaults and are merged with any specified
-                when creating a container.
-            </dd>
-            <dt>
-                Entrypoint <code>array of strings</code>
-            </dt>
-            <dd>
-                A list of arguments to use as the command to execute when the
-                container starts. This value acts as a  default and is replaced
-                by an entrypoint specified when creating a container.
-            </dd>
-            <dt>
-                Cmd <code>array of strings</code>
-            </dt>
-            <dd>
-                Default arguments to the entry point of the container. These
-                values act as defaults and are replaced with any specified when
-                creating a container. If an <code>Entrypoint</code> value is
-                not specified, then the first entry of the <code>Cmd</code>
-                array should be interpreted as the executable to run.
-            </dd>
-            <dt>
-                Volumes <code>struct</code>
-            </dt>
-            <dd>
-                A set of directories which should be created as data volumes in
-                a container running this image. This JSON structure value is
-                unusual because it is a direct JSON serialization of the Go
-                type <code>map[string]struct{}</code> and is represented in
-                JSON as an object mapping its keys to an empty object. Here is
-                an example:
-<pre>{
+These values act as defaults and are merged with any specified
+when creating a container.
+
+###### Env `array of strings`
+Entries are in the format of `VARNAME="var value"`.
+These values act as defaults and are merged with any specified
+when creating a container.
+
+###### Entrypoint `array of strings`
+A list of arguments to use as the command to execute when the
+container starts. This value acts as a  default and is replaced
+by an entrypoint specified when creating a container.
+
+###### Cmd `array of strings`
+Default arguments to the entry point of the container. These
+values act as defaults and are replaced with any specified when
+creating a container. If an `Entrypoint` value is
+not specified, then the first entry of the `Cmd`
+array should be interpreted as the executable to run.
+
+###### Volumes `struct`
+A set of directories which should be created as data volumes in
+a container running this image. This JSON structure value is
+unusual because it is a direct JSON serialization of the Go
+type `map[string]struct{}` and is represented in
+JSON as an object mapping its keys to an empty object. Here is
+an example:
+```javascript{
     "/var/my-app-data/": {},
     "/etc/some-config.d/": {},
-}</pre>
-            </dd>
-            <dt>
-                WorkingDir <code>string</code>
-            </dt>
-            <dd>
-                Sets the current working directory of the entry point process
-                in the container. This value acts as a default and is replaced
-                by a working directory specified when creating a container.
-            </dd>
-        </dl>
-    </dd>
-</dl>
+}
+```
+
+###### WorkingDir `string`
+Sets the current working directory of the entry point process
+in the container. This value acts as a default and is replaced
+by a working directory specified when creating a container.
 
 Any extra fields in the Image JSON struct are considered implementation
 specific and should be ignored by any implementations which are unable to


### PR DESCRIPTION
Currently the markdown structure is not right, hence it shows up broken in github preview. Fixed the structure so that it shows up correctly.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed the markdown of v1.md

**- How I did it**
Replaced the HTML tags with correct markdown syntax

**- How to verify it**
Check the markdown preview on github

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix markdown syntax of v1.md

**- A picture of a cute animal (not mandatory but encouraged)**
