### PR TITLE
Validate cluster name on update

### DIFF
--- a/daemon/cluster/swarm_test.go
+++ b/daemon/cluster/swarm_test.go
@@ -1,0 +1,15 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/swarm"
+	"gotest.tools/v3/assert"
+)
+
+func TestClusterUpdateNameInvalid(t *testing.T) {
+	c := &Cluster{}
+
+	err := c.Update(1, swarm.Spec{Annotations: swarm.Annotations{Name: "whoops"}}, swarm.UpdateFlags{})
+	assert.Error(t, err, `invalid Name "whoops": swarm spec must be named "default"`)
+}

--- a/integration/swarm/main_test.go
+++ b/integration/swarm/main_test.go
@@ -1,0 +1,56 @@
+package swarm
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/docker/docker/testutil"
+	"github.com/docker/docker/testutil/environment"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+)
+
+var (
+	testEnv     *environment.Execution
+	baseContext context.Context
+)
+
+func TestMain(m *testing.M) {
+	shutdown := testutil.ConfigureTracing()
+
+	ctx, span := otel.Tracer("").Start(context.Background(), "integration/build/TestMain")
+	baseContext = ctx
+
+	var err error
+	testEnv, err = environment.New(ctx)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.End()
+		shutdown(ctx)
+		panic(err)
+	}
+	err = environment.EnsureFrozenImagesLinux(ctx, testEnv)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.End()
+		shutdown(ctx)
+		panic(err)
+	}
+
+	testEnv.Print()
+	code := m.Run()
+	if code != 0 {
+		span.SetStatus(codes.Error, "m.Run() exited with non-zero code")
+	}
+	span.End()
+	shutdown(ctx)
+	os.Exit(code)
+}
+
+func setupTest(t *testing.T) context.Context {
+	ctx := testutil.StartSpan(baseContext, t)
+	environment.ProtectAll(ctx, t, testEnv)
+	t.Cleanup(func() { testEnv.Clean(ctx, t) })
+	return ctx
+}

--- a/integration/swarm/update_test.go
+++ b/integration/swarm/update_test.go
@@ -1,0 +1,25 @@
+package swarm
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/testutil/request"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/skip"
+)
+
+func TestSwarmUpdate(t *testing.T) {
+	skip.If(t, testEnv.IsLocalDaemon())
+	ctx := setupTest(t)
+
+	client := request.NewAPIClient(t)
+
+	_, err := client.SwarmInit(ctx, swarm.InitRequest{ListenAddr: "127.0.0.1:2478", AdvertiseAddr: "127.0.0.1"})
+	assert.NilError(t, err)
+
+	swarmInspect, err := client.SwarmInspect(ctx)
+	assert.NilError(t, err)
+	err = client.SwarmUpdate(ctx, swarmInspect.Version, swarm.Spec{Annotations: swarm.Annotations{Name: "whoops"}}, swarm.UpdateFlags{})
+	assert.Error(t, err, `Error response from daemon: invalid Name "whoops": swarm spec must be named "default"`)
+}


### PR DESCRIPTION
Swarm clusters are only allowed to be named "default". If no name is given during update, use the "default" name, otherwise check the name and produce an error if the name is not "default".

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

