### PR TITLE
callWithRetry: do not reuse a io.Reader for multiple HTTP requests

### DIFF
--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -132,8 +132,13 @@ func (c *Client) callWithRetry(serviceMethod string, data io.Reader, retry bool)
 	var retries int
 	start := time.Now()
 
+	reqBody, err := ioutil.ReadAll(data)
+	if err != nil {
+		return nil, err
+	}
+
 	for {
-		req, err := c.requestFactory.NewRequest(serviceMethod, data)
+		req, err := c.requestFactory.NewRequest(serviceMethod, bytes.NewReader(reqBody))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Update TestFailOnce to check for the body content on the second attempt.

Fix: #35459

The updated `TestFailOnce`, before the fix:
```sh
$ go test -test.run TestFailOnce
2017/11/10 13:33:21 http: panic serving 127.0.0.1:47798: Plugin not ready
goroutine 18 [running]:
net/http.(*conn).serve.func1(0xc420134000)
        /usr/local/go/src/net/http/server.go:1721 +0xd0
panic(0x6f29a0, 0xc420158040)
        /usr/local/go/src/runtime/panic.go:489 +0x2cf
github.com/moby/moby/pkg/plugins.TestFailOnce.func1(0x8c5c80, 0xc420164000, 0xc42007c100)
        /home/fabecassis/go/src/github.com/moby/moby/pkg/plugins/client_test.go:60 +0x30d
net/http.HandlerFunc.ServeHTTP(0xc420019890, 0x8c5c80, 0xc420164000, 0xc42007c100)
        /usr/local/go/src/net/http/server.go:1942 +0x44
net/http.(*ServeMux).ServeHTTP(0xc4200197d0, 0x8c5c80, 0xc420164000, 0xc42007c100)
        /usr/local/go/src/net/http/server.go:2238 +0x130
net/http.serverHandler.ServeHTTP(0xc42009a2c0, 0x8c5c80, 0xc420164000, 0xc42007c100)
        /usr/local/go/src/net/http/server.go:2568 +0x92
net/http.(*conn).serve(0xc420134000, 0x8c6200, 0xc420144040)
        /usr/local/go/src/net/http/server.go:1825 +0x612
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:2668 +0x2ce
WARN[0000] Unable to connect to plugin: 127.0.0.1:32898/Test.FailOnce: Post http://127.0.0.1:32898/Test.FailOnce: EOF, retrying in 1s 
WARN[0001] Unable to connect to plugin: 127.0.0.1:32898/Test.FailOnce: Post http://127.0.0.1:32898/Test.FailOnce: EOF, retrying in 2s 
WARN[0003] Unable to connect to plugin: 127.0.0.1:32898/Test.FailOnce: Post http://127.0.0.1:32898/Test.FailOnce: EOF, retrying in 4s 
WARN[0007] Unable to connect to plugin: 127.0.0.1:32898/Test.FailOnce: Post http://127.0.0.1:32898/Test.FailOnce: EOF, retrying in 8s 
--- FAIL: TestFailOnce (15.01s)
        client_test.go:64: Request body: expected "test-body-content", got ""
        client_test.go:64: Request body: expected "test-body-content", got ""
        client_test.go:64: Request body: expected "test-body-content", got ""
        client_test.go:64: Request body: expected "test-body-content", got ""
        client_test.go:72: Post http://127.0.0.1:32898/Test.FailOnce: EOF
FAIL
exit status 1
FAIL    github.com/moby/moby/pkg/plugins        15.012s
```

The updated `TestFailOnce`, after the fix:
```sh
$ go test -test.run TestFailOnce
2017/11/10 13:34:34 http: panic serving 127.0.0.1:40952: Plugin not ready
goroutine 18 [running]:
net/http.(*conn).serve.func1(0xc42013e000)
        /usr/local/go/src/net/http/server.go:1721 +0xd0
panic(0x6f29a0, 0xc420013f40)
        /usr/local/go/src/runtime/panic.go:489 +0x2cf
github.com/moby/moby/pkg/plugins.TestFailOnce.func1(0x8c5c80, 0xc4200b0460, 0xc42007c100)
        /home/fabecassis/go/src/github.com/moby/moby/pkg/plugins/client_test.go:60 +0x30d
net/http.HandlerFunc.ServeHTTP(0xc420019890, 0x8c5c80, 0xc4200b0460, 0xc42007c100)
        /usr/local/go/src/net/http/server.go:1942 +0x44
net/http.(*ServeMux).ServeHTTP(0xc4200197d0, 0x8c5c80, 0xc4200b0460, 0xc42007c100)
        /usr/local/go/src/net/http/server.go:2238 +0x130
net/http.serverHandler.ServeHTTP(0xc42009a2c0, 0x8c5c80, 0xc4200b0460, 0xc42007c100)
        /usr/local/go/src/net/http/server.go:2568 +0x92
net/http.(*conn).serve(0xc42013e000, 0x8c6200, 0xc42011c100)
        /usr/local/go/src/net/http/server.go:1825 +0x612
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:2668 +0x2ce
WARN[0000] Unable to connect to plugin: 127.0.0.1:40725/Test.FailOnce: Post http://127.0.0.1:40725/Test.FailOnce: EOF, retrying in 1s 
PASS
ok      github.com/moby/moby/pkg/plugins        1.008s
```
