### PR TITLE
Remove deprecated support for duplicate label-keys

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -480,22 +480,12 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 		logrus.Warnf(`The "-g / --graph" flag is deprecated. Please use "--data-root" instead`)
 	}
 
-	// Labels of the docker engine used to allow multiple values associated with the same key.
-	// This is deprecated in 1.13, and, be removed after 3 release cycles.
-	// The following will check the conflict of labels, and report a warning for deprecation.
-	//
-	// TODO: After 3 release cycles (17.12) an error will be returned, and labels will be
-	// sanitized to consolidate duplicate key-value pairs (config.Labels = newLabels):
-	//
-	// newLabels, err := daemon.GetConflictFreeLabels(config.Labels)
-	// if err != nil {
-	//	return nil, err
-	// }
-	// config.Labels = newLabels
-	//
-	if _, err := config.GetConflictFreeLabels(conf.Labels); err != nil {
-		logrus.Warnf("Engine labels with duplicate keys and conflicting values have been deprecated: %s", err)
+	// Check if duplicate label-keys with different values are found
+	newLabels, err := config.GetConflictFreeLabels(conf.Labels)
+	if err != nil {
+		return nil, err
 	}
+	conf.Labels = newLabels
 
 	// Regardless of whether the user sets it to true or false, if they
 	// specify TLSVerify at all then we need to turn on TLS

--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -61,6 +61,28 @@ func TestLoadDaemonCliConfigWithConflicts(t *testing.T) {
 	testutil.ErrorContains(t, err, "as a flag and in the configuration file: labels")
 }
 
+func TestLoadDaemonCliWithConflictingLabels(t *testing.T) {
+	opts := defaultOptions("")
+	flags := opts.flags
+
+	assert.NoError(t, flags.Set("label", "foo=bar"))
+	assert.NoError(t, flags.Set("label", "foo=baz"))
+
+	_, err := loadDaemonCliConfig(opts)
+	assert.EqualError(t, err, "conflict labels for foo=baz and foo=bar")
+}
+
+func TestLoadDaemonCliWithDuplicateLabels(t *testing.T) {
+	opts := defaultOptions("")
+	flags := opts.flags
+
+	assert.NoError(t, flags.Set("label", "foo=the-same"))
+	assert.NoError(t, flags.Set("label", "foo=the-same"))
+
+	_, err := loadDaemonCliConfig(opts)
+	assert.NoError(t, err)
+}
+
 func TestLoadDaemonCliConfigWithTLSVerify(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"tlsverify": true}`))
 	defer tempFile.Remove()

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -258,22 +258,12 @@ func Reload(configFile string, flags *pflag.FlagSet, reload func(*Config)) error
 		return fmt.Errorf("file configuration validation failed (%v)", err)
 	}
 
-	// Labels of the docker engine used to allow multiple values associated with the same key.
-	// This is deprecated in 1.13, and, be removed after 3 release cycles.
-	// The following will check the conflict of labels, and report a warning for deprecation.
-	//
-	// TODO: After 3 release cycles (17.12) an error will be returned, and labels will be
-	// sanitized to consolidate duplicate key-value pairs (config.Labels = newLabels):
-	//
-	// newLabels, err := GetConflictFreeLabels(newConfig.Labels)
-	// if err != nil {
-	//      return err
-	// }
-	// newConfig.Labels = newLabels
-	//
-	if _, err := GetConflictFreeLabels(newConfig.Labels); err != nil {
-		logrus.Warnf("Engine labels with duplicate keys and conflicting values have been deprecated: %s", err)
+	// Check if duplicate label-keys with different values are found
+	newLabels, err := GetConflictFreeLabels(newConfig.Labels)
+	if err != nil {
+		return err
 	}
+	newConfig.Labels = newLabels
 
 	reload(newConfig)
 	return nil

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -233,17 +233,6 @@ func (s *DockerDaemonSuite) TestRegistryMirrors(c *check.C) {
 	c.Assert(out, checker.Contains, fmt.Sprintf(" %s", registryMirror2))
 }
 
-// Test case for #24392
-func (s *DockerDaemonSuite) TestInfoLabels(c *check.C) {
-	testRequires(c, SameHostDaemon, DaemonIsLinux)
-
-	s.d.Start(c, "--label", `test.empty=`, "--label", `test.empty=`, "--label", `test.label="1"`, "--label", `test.label="2"`)
-
-	out, err := s.d.Cmd("info")
-	c.Assert(err, checker.IsNil)
-	c.Assert(out, checker.Contains, "WARNING: labels with duplicate keys and conflicting values have been deprecated")
-}
-
 func existingContainerStates(c *check.C) map[string]int {
 	out, _ := dockerCmd(c, "info", "--format", "{{json .}}")
 	var m map[string]interface{}


### PR DESCRIPTION
Support for duplicate labels (but different values) was
deprecated in commit https://github.com/moby/moby/pull/24533/commits/e4c9079d091a2eeac8a74a0356e3f348db873b87 (https://github.com/moby/moby/pull/24533) (Docker 1.13), and scheduled for removal in 17.12


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```Markdown
* Produce an error if duplicate engine labels are specified. Support for duplicate labels was deprecated, and scheduled for removal [moby/moby#35470](https://github.com/moby/moby/pull/35470)
```

**- A picture of a cute animal (not mandatory but encouraged)**


![cute-animals-twins-16](https://user-images.githubusercontent.com/1804568/32695290-be9e433e-c757-11e7-8e07-8d6c74a52ee8.jpg)

(image [source](http://www.earthporm.com/25-animal-twins-tough-tell-apart/))