### PR TITLE
Added validation of isolation settings on daemon.verifyContainerSettings

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -329,6 +329,10 @@ func (daemon *Daemon) verifyContainerSettings(platform string, hostConfig *conta
 		return nil, errors.Errorf("invalid restart policy '%s'", p.Name)
 	}
 
+	if !hostConfig.Isolation.IsValid() {
+		return nil, errors.Errorf("invalid isolation '%s' on %s", hostConfig.Isolation, runtime.GOOS)
+	}
+
 	// Now do platform-specific verification
 	return verifyPlatformContainerSettings(daemon, hostConfig, config, update)
 }

--- a/daemon/daemon_linux_test.go
+++ b/daemon/daemon_linux_test.go
@@ -157,3 +157,10 @@ func TestTmpfsDevShmSizeOverride(t *testing.T) {
 		t.Fatal("/dev/shm not found in spec, or size option missing")
 	}
 }
+
+func TestValidateContainerIsolationLinux(t *testing.T) {
+	d := Daemon{}
+
+	_, err := d.verifyContainerSettings("linux", &containertypes.HostConfig{Isolation: containertypes.IsolationHyperV}, nil, false)
+	assert.EqualError(t, err, "invalid isolation 'hyperv' on linux")
+}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	containertypes "github.com/docker/docker/api/types/container"
@@ -16,6 +17,7 @@ import (
 	"github.com/docker/docker/volume/local"
 	"github.com/docker/docker/volume/store"
 	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/assert"
 )
 
 //
@@ -301,4 +303,11 @@ func TestMerge(t *testing.T) {
 			t.Fatalf("Expected %q or %q or %q or %q, found %s", 0, 1111, 2222, 3333, portSpecs)
 		}
 	}
+}
+
+func TestValidateContainerIsolation(t *testing.T) {
+	d := Daemon{}
+
+	_, err := d.verifyContainerSettings(runtime.GOOS, &containertypes.HostConfig{Isolation: containertypes.Isolation("invalid")}, nil, false)
+	assert.EqualError(t, err, "invalid isolation 'invalid' on "+runtime.GOOS)
 }


### PR DESCRIPTION
Following up https://github.com/moby/moby/pull/34424 and @thaJeztah remark about isolation validation 
 that should be done daemon-side as depending on version/os, valid isolations can vary, I found that this validation can only be done (and was not done before) when the task is scheduled on a node.
Before introducing isolation setting for swarm service, isolation parameter validation was done on the http request validation side, and not on lower levels. Now that we have isolation in swarm service specs, it turns out that we require this validation (without that PR, isolation setting was not validated on Linux nodes, and they accepted isolation="hyperv" without complaining)

**- What I did**

Added validation of isolation low-enough in the stack such that scheduled tasks have their isolation validated

**- How I did it**

daemon already has a `verifyContainerSettings` method doing hostConfig validation. I added a check there

**- How to verify it**

There is unit test for that :)

