### PR TITLE
daemon/graphdriver/register: separate overlay2

### DIFF
--- a/daemon/graphdriver/register/register_overlay.go
+++ b/daemon/graphdriver/register/register_overlay.go
@@ -5,5 +5,4 @@ package register
 import (
 	// register the overlay graphdriver
 	_ "github.com/docker/docker/daemon/graphdriver/overlay"
-	_ "github.com/docker/docker/daemon/graphdriver/overlay2"
 )

--- a/daemon/graphdriver/register/register_overlay2.go
+++ b/daemon/graphdriver/register/register_overlay2.go
@@ -1,0 +1,8 @@
+// +build !exclude_graphdriver_overlay2,linux
+
+package register
+
+import (
+	// register the overlay2 graphdriver
+	_ "github.com/docker/docker/daemon/graphdriver/overlay2"
+)


### PR DESCRIPTION
Make it possible to disable overlay and overlay2 separately.

With this commit, we now have `exclude_graphdriver_overlay` and
`exclude_graphdriver_overlay2` build tags for the engine, which
is in line with any other graph driver.

![](https://static.pexels.com/photos/5143/cute-animals-easter-chicken.jpg)