### PR TITLE
[RFC] Add DNS configuration to /info endpoint

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4629,6 +4629,8 @@ definitions:
         $ref: "#/definitions/RegistryServiceConfig"
       GenericResources:
         $ref: "#/definitions/GenericResources"
+      DNSDefaults:
+        $ref: "#/definitions/DNSInfo"
       HttpProxy:
         description: |
           HTTP-proxy configured for the daemon. This value is obtained from the
@@ -4853,6 +4855,53 @@ definitions:
           - "WARNING: bridge-nf-call-iptables is disabled"
           - "WARNING: bridge-nf-call-ip6tables is disabled"
 
+
+  DNSInfo:
+    description: |
+      Default DNS configuration to use when creating containers.
+
+      These values can be overridden per container.
+    type: "object"
+    properties:
+      DNS:
+        description: |
+          Default DNS server IP-addresses (IPv4 or IPv6) for containers.
+
+          This field is omitted in the response if not set.
+        type: "array"
+        x-nullable: true
+        items:
+          type: "string"
+          format: "ip-address"
+        example: ["8.8.8.8", "2001:4860:4860::8888"]
+      DNSOptions:
+        description: |
+          Default DNS options for containers.
+
+          These options will be included in the container's `/etc/resolv.conf`
+          file. Refer to [resolv.conf(5)](https://man7.org/linux/man-pages/man5/resolv.conf.5.html)
+          to learn about available options.
+
+          This field is omitted in the response if not set.
+        type: "array"
+        x-nullable: true
+        items:
+          type: "string"
+        example: ["ndots:5", "timeout:5", "single-request"]
+      DNSSearch:
+        description: |
+          Default DNS search list for containers.
+
+          This option will be set in the `search` configuration in the
+          container's `/etc/resolv.conf` file. Refer to [resolv.conf(5)](https://man7.org/linux/man-pages/man5/resolv.conf.5.html)
+          to learn about the `search` option.
+
+          This field is omitted in the response if not set.
+        type: "array"
+        x-nullable: true
+        items:
+          type: "string"
+        example: ["internal", "dev"]
 
   # PluginsInfo is a temp struct holding Plugins name
   # registered with docker daemon. It is used by Info struct

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -188,8 +188,9 @@ type Info struct {
 	MemTotal           int64
 	GenericResources   []swarm.GenericResource
 	DockerRootDir      string
-	HTTPProxy          string `json:"HttpProxy"`
-	HTTPSProxy         string `json:"HttpsProxy"`
+	DNSDefaults        DNSInfo `json:"DNSDefaults"`
+	HTTPProxy          string  `json:"HttpProxy"`
+	HTTPSProxy         string  `json:"HttpsProxy"`
 	NoProxy            string
 	Name               string
 	Labels             []string
@@ -218,6 +219,24 @@ type Info struct {
 	// messages for the user, and are not intended to be parsed / used for
 	// other purposes, as they do not have a fixed format.
 	Warnings []string
+}
+
+// DNSInfo contains the default DNS configuration to use for containers.
+// These values can be overridden per container.
+// TODO use a "ContainerDefaults" wrapper for this instead, and deprecate top-level defaults????
+type DNSInfo struct {
+	// DNS is the list of default DNS server IP-addresses (IPv4 or IPv6) for containers.
+	DNS []string `json:"DNS,omitempty"`
+	// DNSOptions holds the default DNS options for containers. These options
+	// will be included in the container's /etc/resolv.conf.
+	//
+	// See resolv.conf(5) for details.
+	DNSOptions []string `json:"DNSOptions,omitempty"`
+	// DNSSearch holds the default DNS search list for containers. This option
+	// will be set as the 'search' configuration in the container's /etc/resolv.conf.
+	//
+	// See resolv.conf(5) for details.
+	DNSSearch []string `json:"DNSSearch,omitempty"`
 }
 
 // KeyValue holds a key/value pair

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -63,6 +63,11 @@ func (daemon *Daemon) SystemInfo() *types.Info {
 		Labels:             daemon.configStore.Labels,
 		ExperimentalBuild:  daemon.configStore.Experimental,
 		ServerVersion:      dockerversion.Version,
+		DNSDefaults: types.DNSInfo{
+			DNS:        daemon.configStore.DNS,
+			DNSOptions: daemon.configStore.DNSOptions,
+			DNSSearch:  daemon.configStore.DNSSearch,
+		},
 		HTTPProxy:          config.MaskCredentials(getConfigOrEnv(daemon.configStore.HTTPProxy, "HTTP_PROXY", "http_proxy")),
 		HTTPSProxy:         config.MaskCredentials(getConfigOrEnv(daemon.configStore.HTTPSProxy, "HTTPS_PROXY", "https_proxy")),
 		NoProxy:            getConfigOrEnv(daemon.configStore.NoProxy, "NO_PROXY", "no_proxy"),

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -40,6 +40,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   was used and the architecture was ignored. If no `platform` option is set, the
   host's operating system and architecture as used as default. This change is not
   versioned, and affects all API versions if the daemon has this patch.
+* `GET /info` now includes a `DNSDefaults` struct, providing the default DNS
+  configuration that is used when creating new containers (`DNS`, `DNSOptions`,
+  `DNSSearch`).
 
 ## v1.41 API changes
 


### PR DESCRIPTION
The `/info` endpoint currently doesn't show what DNS options are configured on the daemon. This information can be useful, for example in situations where a "local" DNS server is configured (which may not work if the IP address of the local DNS overlaps with the container's IP range).

This patch adds the DNS configuration that is set on the daemon to the output of the `/info` endpoint.


@fcrisciani I could use some input on this one; the problem I was trying to solve here is situations where a local DNS is used (which could be _localhost_ / 127.0.0.1, or a DNS server in a local address range).

_However_ this patch would only make this discoverable if that DNS is _explicitly_ set as a daemon configuration; if _no_ `--dns` option is set on the daemon, the default behaviour for containers is to bind-mount a _copy_ of the hosts's `/etc/resolv.conf` into the container, so if that file contains the actual (e.g.) `127.0.0.1` DNS server, things still don't work (and are not visible in the `docker info` output).

Trying to parse the host's `/etc/resolv.conf` in order to extract the configuration sounds like a bad idea for this purpose, but perhaps you have other suggestions.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```Markdown
* Add DNS information to the `/info` endpoint [moby/moby#35506](https://github.com/moby/moby/pull/35506)
```

**- A picture of a cute animal (not mandatory but encouraged)**