### PR TITLE
Display a warn message when there is binding ports and net mode is host

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -333,6 +333,16 @@ func (daemon *Daemon) verifyContainerSettings(platform string, hostConfig *conta
 		return nil, errors.Errorf("invalid isolation '%s' on %s", hostConfig.Isolation, runtime.GOOS)
 	}
 
+	var (
+		err      error
+		warnings []string
+	)
 	// Now do platform-specific verification
-	return verifyPlatformContainerSettings(daemon, hostConfig, config, update)
+	if warnings, err = verifyPlatformContainerSettings(daemon, hostConfig, config, update); err != nil {
+		return warnings, err
+	}
+	if hostConfig.NetworkMode.IsHost() && len(hostConfig.PortBindings) > 0 {
+		warnings = append(warnings, "Published ports are discarded when using host network mode")
+	}
+	return warnings, err
 }

--- a/daemon/container_unix_test.go
+++ b/daemon/container_unix_test.go
@@ -1,0 +1,44 @@
+// +build linux freebsd
+
+package daemon
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/daemon/config"
+	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/require"
+)
+
+// TestContainerWarningHostAndPublishPorts that a warning is returned when setting network mode to host and specifying published ports.
+// This should not be tested on Windows because Windows doesn't support "host" network mode.
+func TestContainerWarningHostAndPublishPorts(t *testing.T) {
+	testCases := []struct {
+		ports    nat.PortMap
+		warnings []string
+	}{
+		{ports: nat.PortMap{}},
+		{ports: nat.PortMap{
+			"8080": []nat.PortBinding{{HostPort: "8989"}},
+		}, warnings: []string{"Published ports are discarded when using host network mode"}},
+	}
+
+	for _, tc := range testCases {
+		hostConfig := &containertypes.HostConfig{
+			Runtime:      "runc",
+			NetworkMode:  "host",
+			PortBindings: tc.ports,
+		}
+		cs := &config.Config{
+			CommonUnixConfig: config.CommonUnixConfig{
+				Runtimes: map[string]types.Runtime{"runc": {}},
+			},
+		}
+		d := &Daemon{configStore: cs}
+		wrns, err := d.verifyContainerSettings("", hostConfig, &containertypes.Config{}, false)
+		require.NoError(t, err)
+		require.Equal(t, tc.warnings, wrns)
+	}
+}


### PR DESCRIPTION
**- What I did**
Fixes #35500 

When a container is created if `--network` is set to `host` all the ports in the container are bound to the host. Thus, when adding `-p` or `--publish` to the command line is meaningless.

Unlike `docker run` and `docker create`, `docker service create` returns an error message when network mode is host and port bindings are given.

**- How I did it**

This patch however suggests to send a warning message to the client when
such a case occurs.

By adding it to the warnings returned from `verifyPlatformContainerSettings`

**- How to verify it**

Added integration test to that so just run `make test-integration`.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

