### PR TITLE
graphdriver: custom build-time priority list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@ export DOCKER_GITCOMMIT
 # env vars passed through directly to Docker's build scripts
 # to allow things like `make KEEPBUNDLE=1 binary` easily
 # `project/PACKAGERS.md` have some limited documentation of some of these
+#
+# DOCKER_LDFLAGS can be used to pass additional parameters to -ldflags
+# option of "go build". For example, a built-in graphdriver priority list
+# can be changed during build time like this:
+#
+# make DOCKER_LDFLAGS="-X github.com/docker/docker/daemon/graphdriver.priority=overlay2,devicemapper" dynbinary
+#
 DOCKER_ENVS := \
 	-e DOCKER_CROSSPLATFORMS \
 	-e BUILD_APT_MIRROR \
@@ -31,6 +38,7 @@ DOCKER_ENVS := \
 	-e DOCKER_GITCOMMIT \
 	-e DOCKER_GRAPHDRIVER \
 	-e DOCKER_INCREMENTAL_BINARY \
+	-e DOCKER_LDFLAGS \
 	-e DOCKER_PORT \
 	-e DOCKER_REMAP_ROOT \
 	-e DOCKER_STORAGE_OPTS \

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -208,7 +208,9 @@ func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, err
 
 	// Guess for prior driver
 	driversMap := scanPriorDrivers(config.Root)
-	for _, name := range priority {
+	list := strings.Split(priority, ",")
+	logrus.Debugf("[graphdriver] priority list: %v", list)
+	for _, name := range list {
 		if name == "vfs" {
 			// don't use vfs even if there is state present.
 			continue
@@ -243,7 +245,7 @@ func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, err
 	}
 
 	// Check for priority drivers first
-	for _, name := range priority {
+	for _, name := range list {
 		driver, err := getBuiltinDriver(name, config.Root, config.DriverOptions, config.UIDMaps, config.GIDMaps)
 		if err != nil {
 			if isDriverNotSupported(err) {

--- a/daemon/graphdriver/driver_freebsd.go
+++ b/daemon/graphdriver/driver_freebsd.go
@@ -7,10 +7,8 @@ import (
 )
 
 var (
-	// Slice of drivers that should be used in an order
-	priority = []string{
-		"zfs",
-	}
+	// List of drivers that should be used in an order
+	priority = "zfs"
 )
 
 // Mounted checks if the given path is mounted as the fs type

--- a/daemon/graphdriver/driver_linux.go
+++ b/daemon/graphdriver/driver_linux.go
@@ -51,16 +51,8 @@ const (
 )
 
 var (
-	// Slice of drivers that should be used in an order
-	priority = []string{
-		"btrfs",
-		"zfs",
-		"overlay2",
-		"aufs",
-		"overlay",
-		"devicemapper",
-		"vfs",
-	}
+	// List of drivers that should be used in an order
+	priority = "btrfs,zfs,overlay2,aufs,overlay,devicemapper,vfs"
 
 	// FsNames maps filesystem id to name of the filesystem.
 	FsNames = map[FsMagic]string{

--- a/daemon/graphdriver/driver_unsupported.go
+++ b/daemon/graphdriver/driver_unsupported.go
@@ -3,10 +3,8 @@
 package graphdriver
 
 var (
-	// Slice of drivers that should be used in an order
-	priority = []string{
-		"unsupported",
-	}
+	// List of drivers that should be used in an order
+	priority = "unsupported"
 )
 
 // GetFSMagic returns the filesystem id given the path.

--- a/daemon/graphdriver/driver_windows.go
+++ b/daemon/graphdriver/driver_windows.go
@@ -1,10 +1,8 @@
 package graphdriver
 
 var (
-	// Slice of drivers that should be used in order
-	priority = []string{
-		"windowsfilter",
-	}
+	// List of drivers that should be used in order
+	priority = "windowsfilter"
 )
 
 // GetFSMagic returns the filesystem id given the path.

--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -57,6 +57,7 @@ go build \
 	-ldflags "
 		$LDFLAGS
 		$LDFLAGS_STATIC_DOCKER
+		$DOCKER_LDFLAGS
 	" \
 	$GO_PACKAGE
 )


### PR DESCRIPTION
Add a way to specify a custom graphdriver priority list during build. This can be done with something like
```
go build -ldflags "-X github.com/docker/docker/daemon/graphdriver.priorityOverride=overlay2,devicemapper"
```
As ldflags are already used by the engine build process, and it seems that only one (last) `-ldflags` argument is taken into account by go, an envoronment variable `DOCKER_LDFLAGS` is introduced in order to be able to append some text to `-ldflags`. With this in place, using the feature becomes
```
make DOCKER_LDFLAGS="-X github.com/docker/docker/daemon/graphdriver.priorityOverride=overlay2,devicemapper" dynbinary
```

If this variable is either unset during compile time or empty, the default list (`priority`) is used.

The idea behind this is, the priority list might be different for different distros, so vendors are now able to change it without patching the source code.
