### PR TITLE
skip xfs quota tests when running in user namespace

### DIFF
--- a/daemon/graphdriver/quota/projectquota.go
+++ b/daemon/graphdriver/quota/projectquota.go
@@ -58,6 +58,7 @@ import (
 	"path/filepath"
 	"unsafe"
 
+	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -98,6 +99,14 @@ type Control struct {
 // project ids.
 //
 func NewControl(basePath string) (*Control, error) {
+	//
+	// If we are running in a user namespace quota won't be supported for
+	// now since makeBackingFsDev() will try to mknod().
+	//
+	if rsystem.RunningInUserNS() {
+		return nil, ErrQuotaNotSupported
+	}
+
 	//
 	// create backing filesystem device node
 	//


### PR DESCRIPTION
Commit 7a1618ced359a3ac921d8a05903d62f544ff17d0 regresses running Docker
in user namespaces. The new test for quota support calls NewControl()
which in turn calls makeBackingFsDev() which tries to mknod(). Skip
quota tests when we detect that we are running in a user namespace. This
just restores the status quo.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Skip newly introduced check for quota support when running in user namespaces.

**- How I did it**
Added a check whether we are running in user namespace.

**- How to verify it**
Tests have been added for quota support as part of  7a1618ced359a3ac921d8a05903d62f544ff17d0.

**- Description for the changelog**
skip xfs quota tests when running in user namespace