### PR TITLE
Detect overlay2 support on pre-4.0 kernels

### DIFF
--- a/daemon/graphdriver/overlay2/check.go
+++ b/daemon/graphdriver/overlay2/check.go
@@ -100,3 +100,35 @@ func doesSupportNativeDiff(d string) error {
 
 	return nil
 }
+
+// supportsMultipleLowerDir checks if the system supports multiple lowerdirs,
+// which is required for the overlay2 driver. On 4.x kernels, multiple lowerdirs
+// are always available (so this check isn't needed), and backported to RHEL and
+// CentOS 3.x kernels (3.10.0-693.el7.x86_64 and up). This function is to detect
+// support on those kernels, without doing a kernel version compare.
+func supportsMultipleLowerDir(d string) error {
+	td, err := ioutil.TempDir(d, "multiple-lowerdir-check")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := os.RemoveAll(td); err != nil {
+			logrus.Warnf("Failed to remove check directory %v: %v", td, err)
+		}
+	}()
+
+	for _, dir := range []string{"lower1", "lower2", "upper", "work", "merged"} {
+		if err := os.Mkdir(filepath.Join(td, dir), 0755); err != nil {
+			return err
+		}
+	}
+
+	opts := fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", path.Join(td, "lower2"), path.Join(td, "lower1"), path.Join(td, "upper"), path.Join(td, "work"))
+	if err := unix.Mount("overlay", filepath.Join(td, "merged"), "overlay", 0, opts); err != nil {
+		return errors.Wrap(err, "failed to mount overlay")
+	}
+	if err := unix.Unmount(filepath.Join(td, "merged"), 0); err != nil {
+		logrus.Warnf("Failed to unmount check directory %v: %v", filepath.Join(td, "merged"), err)
+	}
+	return nil
+}


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/34368

The overlay2 storage-driver requires multiple lower dir support for overlayFs. Support for this feature was added in kernel 4.x, but some distros (RHEL 7.4, CentOS 7.4) ship with an older kernel with this feature backported.

This patch adds feature-detection for multiple lower dirs, and will perform this feature-detection on pre-4.x kernels with overlayFS support.

With this patch applied, daemons running on a kernel with multiple lower dir support will now select "overlay2" as storage-driver, instead of falling back to "overlay".

**- Description for the changelog**

```Markdown
+ Add support for `overlay2` storage driver on CentOS/RHEL 7.4 [moby/moby#35527](https://github.com/moby/moby/pull/35527)
```