### PR TITLE
Suppress warning when NONE was set for healthcheck

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -253,6 +253,8 @@ func getProbe(c *container.Container) probe {
 		return &cmdProbe{shell: false}
 	case "CMD-SHELL":
 		return &cmdProbe{shell: true}
+	case "NONE":
+		return nil
 	default:
 		logrus.Warnf("Unknown healthcheck type '%s' (expected 'CMD') in container %s", config.Test[0], c.ID)
 		return nil


### PR DESCRIPTION
Signed-off-by: Li Yi <denverdino@gmail.com>

**- What I did**

When running K8S, or ```docker run -d --no-healthcheck nginx```  there are warnings in log of Docker engine as following

```
dockerd[11193]: time="2017-11-15T20:44:10.500712197+08:00" level=warning msg="Unknown healthcheck type 'NONE' (expected 'CMD') in c
ontainer 7c39f2ce6559e86d0bbff75a9cda1a14e1f44ed638f56f082f730064a7a90027"
```

But the NONE is the accepted type for healthcheck

**- How I did it**

Ignore warning for when NONE was set for healthcheck

**- How to verify it**

 ```docker run -d --no-healthcheck nginx``` should run without warnings. 

**- Description for the changelog**

