### PR TITLE
Have VFS graphdriver use accelerated in-kernel copy

### DIFF
--- a/daemon/graphdriver/copy/copy.go
+++ b/daemon/graphdriver/copy/copy.go
@@ -65,7 +65,7 @@ func copyRegular(srcPath, dstPath string, fileinfo os.FileInfo, copyWithFileRang
 		// as the ioctl may not have been available (therefore EINVAL)
 		if err == unix.EXDEV || err == unix.ENOSYS {
 			*copyWithFileRange = false
-		} else if err != nil {
+		} else {
 			return err
 		}
 	}

--- a/daemon/graphdriver/copy/copy_test.go
+++ b/daemon/graphdriver/copy/copy_test.go
@@ -86,7 +86,7 @@ func TestCopyHardlink(t *testing.T) {
 	require.NoError(t, ioutil.WriteFile(srcFile1, []byte{}, 0777))
 	require.NoError(t, os.Link(srcFile1, srcFile2))
 
-	assert.NoError(t, DirCopy(srcDir, dstDir, Content))
+	assert.NoError(t, DirCopy(srcDir, dstDir, Content, false))
 
 	require.NoError(t, unix.Stat(srcFile1, &srcFile1FileInfo))
 	require.NoError(t, unix.Stat(srcFile2, &srcFile2FileInfo))

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -330,7 +330,7 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) (retErr
 		return err
 	}
 
-	return copy.DirCopy(parentUpperDir, upperDir, copy.Content)
+	return copy.DirCopy(parentUpperDir, upperDir, copy.Content, true)
 }
 
 func (d *Driver) dir(id string) string {
@@ -446,7 +446,7 @@ func (d *Driver) ApplyDiff(id string, parent string, diff io.Reader) (size int64
 		}
 	}()
 
-	if err = copy.DirCopy(parentRootDir, tmpRootDir, copy.Hardlink); err != nil {
+	if err = copy.DirCopy(parentRootDir, tmpRootDir, copy.Hardlink, true); err != nil {
 		return 0, err
 	}
 

--- a/daemon/graphdriver/vfs/copy_linux.go
+++ b/daemon/graphdriver/vfs/copy_linux.go
@@ -1,0 +1,9 @@
+// +build linux
+
+package vfs
+
+import "github.com/docker/docker/daemon/graphdriver/copy"
+
+func dirCopy(srcDir, dstDir string) error {
+	return copy.DirCopy(srcDir, dstDir, copy.Content, false)
+}

--- a/daemon/graphdriver/vfs/copy_unsupported.go
+++ b/daemon/graphdriver/vfs/copy_unsupported.go
@@ -1,0 +1,9 @@
+// +build !linux
+
+package vfs
+
+import "github.com/docker/docker/pkg/chrootarchive"
+
+func dirCopy(srcDir, dstDir string) error {
+	return chrootarchive.NewArchiver(nil).CopyWithTar(srcDir, dstDir)
+}

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/daemon/graphdriver/quota"
-	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/containerfs"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/system"
@@ -16,8 +15,8 @@ import (
 )
 
 var (
-	// CopyWithTar defines the copy method to use.
-	CopyWithTar = chrootarchive.NewArchiver(nil).CopyWithTar
+	// CopyDir defines the copy method to use.
+	CopyDir = dirCopy
 )
 
 func init() {
@@ -133,7 +132,7 @@ func (d *Driver) create(id, parent string, size uint64) error {
 	if err != nil {
 		return fmt.Errorf("%s: %s", parent, err)
 	}
-	return CopyWithTar(parentDir.Path(), dir)
+	return CopyDir(parentDir.Path(), dir)
 }
 
 func (d *Driver) dir(id string) string {

--- a/layer/layer_test.go
+++ b/layer/layer_test.go
@@ -23,7 +23,7 @@ import (
 func init() {
 	graphdriver.ApplyUncompressedLayer = archive.UnpackLayer
 	defaultArchiver := archive.NewDefaultArchiver()
-	vfs.CopyWithTar = defaultArchiver.CopyWithTar
+	vfs.CopyDir = defaultArchiver.CopyWithTar
 }
 
 func newVFSGraphDriver(td string) (graphdriver.Driver, error) {


### PR DESCRIPTION
**- What I did**
This change makes the VFS graphdriver use the kernel-accelerated
(copy_file_range) mechanism of copying files, which is able to
leverage reflinks.

The copy package should fulfill all of the capabilities that CopyWithTar
fulfilled as well. 

I learned a lot about file system performance on Linux. At least about XFS on machines with reasonably fast I/O, and many cores with lots of memory. The primary barrier here is not disk I/O, as it turns out, but contention inside of the dentry, inode, and allocation group. 
**- How I did it**
I reused the accelerated copy code I had written for the overlay graphdriver.

**- How to verify it**
I used the existing tests to verify the behaviour.

**- Description for the changelog**
Use copy_file_range to copy files for VFS on Linux.