### PR TITLE
Closes #35384 Add support for SubSecondPrecision flag in fluentd logger

### DIFF
--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -48,11 +48,12 @@ const (
 	defaultRetryWait  = 1000
 	defaultMaxRetries = math.MaxInt32
 
-	addressKey      = "fluentd-address"
-	bufferLimitKey  = "fluentd-buffer-limit"
-	retryWaitKey    = "fluentd-retry-wait"
-	maxRetriesKey   = "fluentd-max-retries"
-	asyncConnectKey = "fluentd-async-connect"
+	addressKey            = "fluentd-address"
+	bufferLimitKey        = "fluentd-buffer-limit"
+	retryWaitKey          = "fluentd-retry-wait"
+	maxRetriesKey         = "fluentd-max-retries"
+	asyncConnectKey       = "fluentd-async-connect"
+	subSecondPrecisionKey = "fluentd-sub-second-precision"
 )
 
 func init() {
@@ -117,15 +118,23 @@ func New(info logger.Info) (logger.Logger, error) {
 		}
 	}
 
+	subSecondPrecision := false
+	if info.Config[subSecondPrecisionKey] != "" {
+		if subSecondPrecision, err = strconv.ParseBool(info.Config[subSecondPrecisionKey]); err != nil {
+			return nil, err
+		}
+	}
+
 	fluentConfig := fluent.Config{
-		FluentPort:       loc.port,
-		FluentHost:       loc.host,
-		FluentNetwork:    loc.protocol,
-		FluentSocketPath: loc.path,
-		BufferLimit:      bufferLimit,
-		RetryWait:        retryWait,
-		MaxRetry:         maxRetries,
-		AsyncConnect:     asyncConnect,
+		FluentPort:         loc.port,
+		FluentHost:         loc.host,
+		FluentNetwork:      loc.protocol,
+		FluentSocketPath:   loc.path,
+		BufferLimit:        bufferLimit,
+		RetryWait:          retryWait,
+		MaxRetry:           maxRetries,
+		AsyncConnect:       asyncConnect,
+		SubSecondPrecision: subSecondPrecision,
 	}
 
 	logrus.WithField("container", info.ContainerID).WithField("config", fluentConfig).
@@ -183,6 +192,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case retryWaitKey:
 		case maxRetriesKey:
 		case asyncConnectKey:
+		case subSecondPrecisionKey:
 			// Accepted
 		default:
 			return fmt.Errorf("unknown log opt '%s' for fluentd log driver", key)

--- a/vendor/github.com/fluent/fluent-logger-golang/fluent/fluent.go
+++ b/vendor/github.com/fluent/fluent-logger-golang/fluent/fluent.go
@@ -26,17 +26,18 @@ const (
 )
 
 type Config struct {
-	FluentPort       int           `json:"fluent_port"`
-	FluentHost       string        `json:"fluent_host"`
-	FluentNetwork    string        `json:"fluent_network"`
-	FluentSocketPath string        `json:"fluent_socket_path"`
-	Timeout          time.Duration `json:"timeout"`
-	BufferLimit      int           `json:"buffer_limit"`
-	RetryWait        int           `json:"retry_wait"`
-	MaxRetry         int           `json:"max_retry"`
-	TagPrefix        string        `json:"tag_prefix"`
-	AsyncConnect     bool          `json:"async_connect"`
-	MarshalAsJSON    bool          `json:"marshal_as_json"`
+	FluentPort             int           `json:"fluent_port"`
+	FluentHost             string        `json:"fluent_host"`
+	FluentNetwork          string        `json:"fluent_network"`
+	FluentSocketPath       string        `json:"fluent_socket_path"`
+	Timeout                time.Duration `json:"timeout"`
+	BufferLimit            int           `json:"buffer_limit"`
+	RetryWait              int           `json:"retry_wait"`
+	MaxRetry               int           `json:"max_retry"`
+	TagPrefix              string        `json:"tag_prefix"`
+	AsyncConnect           bool          `json:"async_connect"`
+	SubSecondPrecision     bool          `json:"sub_second_precision"`
+	MarshalAsJSON          bool          `json:"marshal_as_json"`
 }
 
 type Fluent struct {
@@ -82,6 +83,9 @@ func New(config Config) (f *Fluent, err error) {
 	} else {
 		f = &Fluent{Config: config, reconnecting: false}
 		err = f.connect()
+	}
+	if !config.SubSecondPrecision {
+		config.SubSecondPrecision = false
 	}
 	return
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
**- What I did**

Exposed SubSecondPrecision option for fluentd logger

**- How I did it**

Added a new input parameter fluentd-sub-second-precision which will be passed on to the fluentd logger

**- How to verify it**

Pass in fluentd-sub-second-precision parameter as true for fuentd logger and verify that the logs contain sub second precision

**- The fluentd log driver learned the following option: fluentd-sub-second-precision**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- Changelog**

The fluentd log driver learned the following option: fluentd-sub-second-precision