### PR TITLE
Fix consumes MIME type for NetworkConnect

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7891,7 +7891,7 @@ paths:
       summary: "Connect a container to a network"
       operationId: "NetworkConnect"
       consumes:
-        - "application/octet-stream"
+        - "application/json"
       responses:
         200:
           description: "No error"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Changed the MIME type of the NetworkConnect route to the correct type.

**- How I did it**
The route expects `application/json` instead of `application/octet-stream`. This can be seen from the schema of the `body` parameter as well as from actually calling the route (it explodes if sent an `application/octet-stream` content type header).

**- How to verify it**
Try calling the route with the old and new MIME types for the `Content-Type` header. Only the new one will work.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Changed the MIME type of the NetworkConnect route to the correct type.

**- A picture of a cute animal (not mandatory but encouraged)**
![youhavedonemeabetray.jpg](https://i.imgur.com/ZcdcEsa.jpg)