### PR TITLE
  Fix "make test" failing on missing "test-unit"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,8 +158,8 @@ run: build ## run the docker daemon in a container
 shell: build ## start a shell inside the build env
 	$(DOCKER_RUN_DOCKER) bash
 
-test: build ## run the unit, integration and docker-py tests
-	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary cross test-unit test-integration test-docker-py
+test: build test-unit ## run the unit, integration and docker-py tests
+	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary cross test-integration test-docker-py
 
 test-docker-py: build ## run the docker-py tests
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary test-docker-py


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/35540

Commit https://github.com/moby/moby/pull/34911/commits/dbf580be57a4bb854d7ce20d313e3a22ea337be5 (https://github.com/moby/moby/pull/34911) removed
this helper script because it's no longer used in CI.

However, the `make test` target in the Makefile still called this helper, resulting it to fail.

ping @dnephin @vdemeester PTAL
