### PR TITLE
Add elapsed time for each step during docker build

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"runtime"
+   "strconv"
 	"strings"
 	"time"
 
@@ -42,8 +43,11 @@ var validCommitCommands = map[string]bool{
 }
 
 const (
-	stepFormat = "Step %d/%d : %v"
+	stepFormat = "%s Step %d/%d : %v"
 )
+
+// time tracking variable
+var starttime = time.Now()
 
 // SessionGetter is object used to get access to a session by uuid
 type SessionGetter interface {
@@ -269,8 +273,10 @@ func processMetaArg(meta instructions.ArgCommand, shlex *ShellLex, args *buildAr
 }
 
 func printCommand(out io.Writer, currentCommandIndex int, totalCommands int, cmd interface{}) int {
-	fmt.Fprintf(out, stepFormat, currentCommandIndex, totalCommands, cmd)
+   exectime := time.Now()
+   fmt.Fprintf(out, stepFormat, strconv.FormatInt(int64(exectime.Sub(starttime)/time.Millisecond),10),currentCommandIndex, totalCommands, cmd)
 	fmt.Fprintln(out)
+   starttime = time.Now()
 	return currentCommandIndex + 1
 }
 

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -42,8 +42,12 @@ var validCommitCommands = map[string]bool{
 }
 
 const (
-	stepFormat = "Step %d/%d : %v"
+	stepFormat   = "Step %d/%d : %v"
+	timingFormat = " ---> completed in: %s"
 )
+
+// time tracking variable
+var starttime = time.Now()
 
 // SessionGetter is object used to get access to a session by uuid
 type SessionGetter interface {
@@ -269,8 +273,12 @@ func processMetaArg(meta instructions.ArgCommand, shlex *ShellLex, args *buildAr
 }
 
 func printCommand(out io.Writer, currentCommandIndex int, totalCommands int, cmd interface{}) int {
+	exectime := time.Now()
 	fmt.Fprintf(out, stepFormat, currentCommandIndex, totalCommands, cmd)
 	fmt.Fprintln(out)
+	fmt.Fprintf(out, timingFormat, exectime.Sub(starttime)/time.Millisecond)
+	fmt.Fprintln(out)
+	starttime = time.Now()
 	return currentCommandIndex + 1
 }
 

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"runtime"
-   "strconv"
 	"strings"
 	"time"
 
@@ -43,7 +42,8 @@ var validCommitCommands = map[string]bool{
 }
 
 const (
-	stepFormat = "%s Step %d/%d : %v"
+	stepFormat   = "Step %d/%d : %v"
+	timingFormat = " ---> completed in: %s"
 )
 
 // time tracking variable
@@ -273,10 +273,12 @@ func processMetaArg(meta instructions.ArgCommand, shlex *ShellLex, args *buildAr
 }
 
 func printCommand(out io.Writer, currentCommandIndex int, totalCommands int, cmd interface{}) int {
-   exectime := time.Now()
-   fmt.Fprintf(out, stepFormat, strconv.FormatInt(int64(exectime.Sub(starttime)/time.Millisecond),10),currentCommandIndex, totalCommands, cmd)
+	exectime := time.Now()
+	fmt.Fprintf(out, stepFormat, currentCommandIndex, totalCommands, cmd)
 	fmt.Fprintln(out)
-   starttime = time.Now()
+	fmt.Fprintf(out, timingFormat, exectime.Sub(starttime)/time.Millisecond)
+	fmt.Fprintln(out)
+	starttime = time.Now()
 	return currentCommandIndex + 1
 }
 


### PR DESCRIPTION
**- What I did**
I added a new value in the Step phase during a container build, in order to show the elapsed time for every step during the container build. This is particularly useful to optimize any automatic docker creation pipeline

**- How I did it**

Simply edited a function and created two variables

**- How to verify it**

run any 'docker build' and the first value of the "Step #" line will show the millisecond elapsed to complete the previous phase.  

**- Description for the changelog**
Add elapsed time for each step during docker build

**- A picture of a cute animal (not mandatory but encouraged)**

