### PR TITLE
Added support for persisting Windows network driver specific options …

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -350,6 +350,9 @@ func (daemon *Daemon) initNetworkController(config *config.Config, activeSandbox
 		}
 
 		controller.WalkNetworks(s)
+
+		drvOptions := make(map[string]string)
+
 		if n != nil {
 			// global networks should not be deleted by local HNS
 			if n.Info().Scope() == datastore.GlobalScope {
@@ -358,12 +361,21 @@ func (daemon *Daemon) initNetworkController(config *config.Config, activeSandbox
 			v.Name = n.Name()
 			// This will not cause network delete from HNS as the network
 			// is not yet populated in the libnetwork windows driver
+
+			// restore option if it existed before
+			drvOptions = n.Info().DriverOptions()
 			n.Delete()
 		}
-
 		netOption := map[string]string{
 			winlibnetwork.NetworkName: v.Name,
 			winlibnetwork.HNSID:       v.Id,
+		}
+
+		// add persisted driver options
+		for k, v := range drvOptions {
+			if k != winlibnetwork.NetworkName && k != winlibnetwork.HNSID {
+				netOption[k] = v
+			}
 		}
 
 		v4Conf := []*libnetwork.IpamConf{}


### PR DESCRIPTION
…over reboot or service restart

Signed-off-by: Cheng-mean Liu <soccerl@microsoft.com>

The changes in this PR were to make sure all driver specific options are retrieved from a network's store before recreating network instances, all the changes are inside the initNetworkController().

This PR also addresses the following two known issues
https://github.com/moby/moby/issues/34716
https://github.com/moby/moby/issues/30260


