### PR TITLE
Add journald tag as SYSLOG_IDENTIFIER

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -75,6 +75,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		"CONTAINER_ID_FULL": info.ContainerID,
 		"CONTAINER_NAME":    info.Name(),
 		"CONTAINER_TAG":     tag,
+		"SYSLOG_IDENTIFIER": tag,
 	}
 	extraAttrs, err := info.ExtraAttributes(sanitizeKeyMod)
 	if err != nil {


### PR DESCRIPTION
**- What I did**
This PR fixes #30023 (not showing journald tag in basic `journalctl` output).
See example below.

Run container with logging driver `journald` with option `tag`:

```bash
docker run --log-driver=journald --log-opt tag="{{.ImageName}}/{{.Name}}/{{.ID}}" --rm alpine ping -c 1 8.8.8.8
```

Currently, logs are sent to `journald` without setting tag to `SYSLOG_IDENTIFIER` which causing that user inspecting logs from cli using `journalctl` is not able to assign log record to container/tag. All logs are shown as `dockerd` messages.

```bash
Nov 21 14:58:05 DB0275 kernel: docker0: port 3(vethd3b8cf9) entered blocking state
Nov 21 14:58:05 DB0275 kernel: docker0: port 3(vethd3b8cf9) entered disabled state
Nov 21 14:58:05 DB0275 kernel: device vethd3b8cf9 entered promiscuous mode
Nov 21 14:58:05 DB0275 kernel: IPv6: ADDRCONF(NETDEV_UP): vethd3b8cf9: link is not ready
Nov 21 14:58:05 DB0275 dockerd[1616]: time="2017-11-21T14:58:05.717108935Z" level=info msg="No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: [nameserver 8.8.8.8 nameserver 8.8.4.4]"
Nov 21 14:58:05 DB0275 dockerd[1616]: time="2017-11-21T14:58:05.717126983Z" level=info msg="IPv6 enabled; Adding default IPv6 external servers: [nameserver 2001:4860:4860::8888 nameserver 2001:4860:4860::8844]"
Nov 21 14:58:05 DB0275 kernel: IPVS: Creating netns size=2168 id=693
Nov 21 14:58:05 DB0275 kernel: eth0: renamed from vethe369a76
Nov 21 14:58:05 DB0275 kernel: IPv6: ADDRCONF(NETDEV_CHANGE): vethd3b8cf9: link becomes ready
Nov 21 14:58:05 DB0275 kernel: docker0: port 3(vethd3b8cf9) entered blocking state
Nov 21 14:58:05 DB0275 kernel: docker0: port 3(vethd3b8cf9) entered forwarding state
Nov 21 14:58:06 DB0275 dockerd[1616]: PING 8.8.8.8 (8.8.8.8): 56 data bytes
Nov 21 14:58:06 DB0275 dockerd[1616]: 64 bytes from 8.8.8.8: seq=0 ttl=58 time=5.034 ms
Nov 21 14:58:06 DB0275 dockerd[1616]:
Nov 21 14:58:06 DB0275 dockerd[1616]: --- 8.8.8.8 ping statistics ---
Nov 21 14:58:06 DB0275 dockerd[1616]: 1 packets transmitted, 1 packets received, 0% packet loss
Nov 21 14:58:06 DB0275 dockerd[1616]: round-trip min/avg/max = 5.034/5.034/5.034 ms
Nov 21 14:58:06 DB0275 kernel: docker0: port 3(vethd3b8cf9) entered disabled state
Nov 21 14:58:06 DB0275 kernel: vethe369a76: renamed from eth0
Nov 21 14:58:06 DB0275 kernel: docker0: port 3(vethd3b8cf9) entered disabled state
Nov 21 14:58:06 DB0275 kernel: device vethd3b8cf9 left promiscuous mode
Nov 21 14:58:06 DB0275 kernel: docker0: port 3(vethd3b8cf9) entered disabled state
```

Adding tag also to `SYSLOG_IDENTIFIER` enable a user to see it in `journalctl` and use `--identifier` with pattern matching. Useful if tag contains swarm stack name, service name, task, etc. It will also do not confuse a user which reads [documentation](https://docs.docker.com/engine/admin/logging/log_tags/) about tags.

```bash
Nov 21 14:54:27 cec571b26922 kernel: docker0: port 1(vetha146757) entered blocking state
Nov 21 14:54:27 cec571b26922 kernel: docker0: port 1(vetha146757) entered disabled state
Nov 21 14:54:27 cec571b26922 kernel: device vetha146757 entered promiscuous mode
Nov 21 14:54:27 cec571b26922 kernel: IPVS: Creating netns size=2168 id=692
Nov 21 14:54:27 cec571b26922 kernel: eth0: renamed from veth9334d15
Nov 21 14:54:27 cec571b26922 kernel: docker0: port 1(vetha146757) entered blocking state
Nov 21 14:54:27 cec571b26922 kernel: docker0: port 1(vetha146757) entered forwarding state
Nov 21 14:54:27 cec571b26922 alpine/naughty_dijkstra/bf037aee4dcf[217]: PING 8.8.8.8 (8.8.8.8): 56 data bytes
Nov 21 14:54:27 cec571b26922 alpine/naughty_dijkstra/bf037aee4dcf[217]: 64 bytes from 8.8.8.8: seq=0 ttl=57 time=5.079 ms
Nov 21 14:54:27 cec571b26922 alpine/naughty_dijkstra/bf037aee4dcf[217]:
Nov 21 14:54:27 cec571b26922 alpine/naughty_dijkstra/bf037aee4dcf[217]: --- 8.8.8.8 ping statistics ---
Nov 21 14:54:27 cec571b26922 alpine/naughty_dijkstra/bf037aee4dcf[217]: 1 packets transmitted, 1 packets received, 0% packet loss
Nov 21 14:54:27 cec571b26922 alpine/naughty_dijkstra/bf037aee4dcf[217]: round-trip min/avg/max = 5.079/5.079/5.079 ms
Nov 21 14:54:27 cec571b26922 kernel: docker0: port 1(vetha146757) entered disabled state
Nov 21 14:54:27 cec571b26922 kernel: veth9334d15: renamed from eth0
Nov 21 14:54:27 cec571b26922 kernel: docker0: port 1(vetha146757) entered disabled state
Nov 21 14:54:27 cec571b26922 kernel: device vetha146757 left promiscuous mode
Nov 21 14:54:27 cec571b26922 kernel: docker0: port 1(vetha146757) entered disabled state
```

**- How I did it**
Added logging driver option `tag` not only as `CONTAINER_TAG`  (visible only in extended view, which is not usable for practical troubleshooting) but also as [`SYSLOG_IDENTIFIER`](https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html#SYSLOG_FACILITY=) which support pattern matching.

**- How to verify it**

See **what I did**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add journald tag as SYSLOG_IDENTIFIER

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/18702153/33119943-79cfd2fe-cf68-11e7-8753-9405fcbb131a.png)
>http://clipart-library.com/clipart/LTd5bk6pc.htm

