### PR TITLE
image: skip the import test on AArch64

### DIFF
--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"runtime"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -14,12 +15,17 @@ import (
 
 // Ensure we don't regress on CVE-2017-14992.
 func TestImportExtremelyLargeImageWorks(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("effective test will be time out")
+	}
+
 	client := request.NewAPIClient(t)
 
 	// Construct an empty tar archive with about 8GB of junk padding at the
 	// end. This should not cause any crashes (the padding should be mostly
 	// ignored).
 	var tarBuffer bytes.Buffer
+
 	tw := tar.NewWriter(&tarBuffer)
 	if err := tw.Close(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The commit '0a13f827a10d3bf61744d9b3f7165c5885a39c5d' introduces an 
import test for CVE-2017-14992, it uses a 8GB image to make sure we 
don't revert CVE-2017-14992, but unfortunately this test can't finish in 5-min
on AArch64, as a fact, in most cases we have to crate a very big image to make 
the test effective on AArch64, but this will result in a test panic as mentioned, 
so now we skip it order to avoid termination of others tests followed.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix the panic of 'TestImportExtremelyLargeImageWorks' case
**- How I did it**
Make the image can be finished within 5 mins by decreasing the size from 8GB to 6GB
**- How to verify it**
`make test-integration` and the `TestImportExtremelyLargeImageWorks` passed and continue the following tests.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

