### PR TITLE
[integration] add main_test for image test

### DIFF
--- a/integration/image/main_test.go
+++ b/integration/image/main_test.go
@@ -1,0 +1,33 @@
+package image
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/docker/docker/internal/test/environment"
+)
+
+var testEnv *environment.Execution
+
+func TestMain(m *testing.M) {
+	var err error
+	testEnv, err = environment.New()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	err = environment.EnsureFrozenImagesLinux(testEnv)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	testEnv.Print()
+	os.Exit(m.Run())
+}
+
+func setupTest(t *testing.T) func() {
+	environment.ProtectAll(t, testEnv)
+	return func() { testEnv.Clean(t) }
+}


### PR DESCRIPTION
Adds a main_test for the image integration test, so we can download
frozen images, and clean up after the test is ran

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>