### PR TITLE
Fix PortBindings definition in Swagger

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -606,17 +606,7 @@ definitions:
             description: "Network mode to use for this container. Supported standard values are: `bridge`, `host`, `none`, and `container:<name|id>`. Any other value is taken
               as a custom network's name to which this container should connect to."
           PortBindings:
-            type: "object"
-            description: "A map of exposed container ports and the host port they should map to."
-            additionalProperties:
-              type: "object"
-              properties:
-                HostIp:
-                  type: "string"
-                  description: "The host IP address"
-                HostPort:
-                  type: "string"
-                  description: "The host port number, as a string"
+            $ref: "#/definitions/PortMap"
           RestartPolicy:
             $ref: "#/definitions/RestartPolicy"
           AutoRemove:


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/35577

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```Markdown
* Fix incorrect definition of `HostConfig.PortBindings` in Swagger [moby/moby#35578](https://github.com/moby/moby/pull/35578)
```