### PR TITLE
Security: Restrict container to set suid without the capability of sys_admin.

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -62,7 +62,6 @@
 				"capget",
 				"capset",
 				"chdir",
-				"chmod",
 				"chown",
 				"chown32",
 				"clock_getres",
@@ -94,8 +93,6 @@
 				"fallocate",
 				"fanotify_mark",
 				"fchdir",
-				"fchmod",
-				"fchmodat",
 				"fchown",
 				"fchown32",
 				"fchownat",
@@ -550,8 +547,11 @@
 		{
 			"names": [
 				"bpf",
+				"chmod",
 				"clone",
 				"fanotify_init",
+				"fchmod",
+				"fchmodat",
 				"lookup_dcookie",
 				"mount",
 				"name_to_handle_at",
@@ -745,6 +745,49 @@
 				]
 			},
 			"excludes": {}
+		},
+		{
+			"names": [
+				"chmod",
+				"fchmod"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 1,
+					"value": 2048,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			}
+		},
+		{
+			"names": [
+				"fchmodat"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 2,
+					"value": 2048,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			}
 		}
 	]
 }

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -55,7 +55,6 @@ func DefaultProfile() *types.Seccomp {
 				"capget",
 				"capset",
 				"chdir",
-				"chmod",
 				"chown",
 				"chown32",
 				"clock_getres",
@@ -87,8 +86,6 @@ func DefaultProfile() *types.Seccomp {
 				"fallocate",
 				"fanotify_mark",
 				"fchdir",
-				"fchmod",
-				"fchmodat",
 				"fchown",
 				"fchown32",
 				"fchownat",
@@ -481,8 +478,11 @@ func DefaultProfile() *types.Seccomp {
 		{
 			Names: []string{
 				"bpf",
+				"chmod",
 				"clone",
 				"fanotify_init",
+				"fchmod",
+				"fchmodat",
 				"lookup_dcookie",
 				"mount",
 				"name_to_handle_at",
@@ -627,6 +627,41 @@ func DefaultProfile() *types.Seccomp {
 			Args:   []*types.Arg{},
 			Includes: types.Filter{
 				Caps: []string{"CAP_SYS_TTY_CONFIG"},
+			},
+		},
+		{
+			Names: []string{
+				"chmod",
+				"fchmod",
+			},
+			Action: types.ActAllow,
+			Args: []*types.Arg{
+				{
+					Index:    1,
+					Value:    unix.S_ISUID,
+					ValueTwo: 0,
+					Op:       types.OpMaskedEqual,
+				},
+			},
+			Excludes: types.Filter{
+				Caps: []string{"CAP_SYS_ADMIN"},
+			},
+		},
+		{
+			Names: []string{
+				"fchmodat",
+			},
+			Action: types.ActAllow,
+			Args: []*types.Arg{
+				{
+					Index:    2,
+					Value:    unix.S_ISUID,
+					ValueTwo: 0,
+					Op:       types.OpMaskedEqual,
+				},
+			},
+			Excludes: types.Filter{
+				Caps: []string{"CAP_SYS_ADMIN"},
 			},
 		},
 	}


### PR DESCRIPTION
Nonroot use non privilege container to elevate privileges.

Before this pr,
```
[root@localhost seccomp]# docker run --rm -ti -v /bin/ls:/home/ls -w /home  busybox ash          
/home # chmod 4777 ls
/home # 
```
another terminal:
```
[hello@localhost ~]$ id
uid=1000(hello) gid=1000(hello) groups=1000(hello) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
[hello@localhost ~]$ ls /root
anaconda-ks.cfg  autofs-5.0.7-56.el7.src.rpm  dirty 
```

After this pr,
```
[root@localhost seccomp]# docker run --rm -ti -v /bin/ls:/home -w /home  busybox ash                   
/home # chmod 777 ls
/home # chmod 4777 ls
chmod: ls: Operation not permitted
/home # 
```
If you want to set suid in container, you can add sys_admin, e.g.
```
[root@localhost seccomp]# docker run --rm -ti -v /bin/ls:/home -w /home  --cap-add sys_admin busybox ash
/home # chmod 4777 ls
/home # 
```