### PR TITLE
`memory` is an int64 (long)

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -332,6 +332,7 @@ definitions:
       Memory:
         description: "Memory limit in bytes."
         type: "integer"
+        format: "int64"
         default: 0
       # Applicable to UNIX platforms
       CgroupParent:


### PR DESCRIPTION
**- What I did**

I generate API model using swagger-codegen. HostConfig#memory is then generated as an integer, while it should be a long (like other memory* attributes)

**- How I did it**

swagger-codegen-maven-plugin
https://github.com/Dockins/jocker/blob/master/pom.xml

**- How to verify it**

re-generate

**- Description for the changelog**

declare HostConfig memory attribute as an int64.

**- A picture of a cute animal (not mandatory but encouraged)**

![9d39478cd6e8586c03d8e14d225b6c34--montpellier-cute](https://user-images.githubusercontent.com/132757/33171165-8188b18a-d04b-11e7-808b-2644a6cf5b60.jpg)

