### PR TITLE
Close pipe in chrootarchive.invokeUnpack when cmd.Start()/json.NewEncoder failed

### DIFF
--- a/pkg/chrootarchive/archive_unix.go
+++ b/pkg/chrootarchive/archive_unix.go
@@ -66,10 +66,12 @@ func invokeUnpack(decompressedArchive io.Reader, dest string, options *archive.T
 	cmd.Stderr = output
 
 	if err := cmd.Start(); err != nil {
+		w.Close()
 		return fmt.Errorf("Untar error on re-exec cmd: %v", err)
 	}
 	//write the options to the pipe for the untar exec to read
 	if err := json.NewEncoder(w).Encode(options); err != nil {
+		w.Close()
 		return fmt.Errorf("Untar json encode to pipe failed: %v", err)
 	}
 	w.Close()


### PR DESCRIPTION
If cmd.Start()/json.NewEncoder failed in invokeUnpack, we will have pipe not closed，it is a tiny problem, but I think we still need  fix it.

Similar to https://github.com/moby/moby/pull/34863