### PR TITLE
Lock daemon ExecStore to prevent concurrent map writes

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -36,7 +36,7 @@ func (d *Daemon) registerExecPidUnlocked(container *container.Container, config 
 	// Storing execs in container in order to kill them gracefully whenever the container is stopped or removed.
 	container.ExecCommands.SetPidUnlocked(config.ID, config.Pid)
 	// Storing execs in daemon for easy access via Engine API.
-	d.execCommands.SetPidUnlocked(config.ID, config.Pid)
+	d.execCommands.SetPid(config.ID, config.Pid)
 }
 
 // ExecExists looks up the exec instance and returns a bool if it exists or not.

--- a/daemon/exec/exec.go
+++ b/daemon/exec/exec.go
@@ -119,6 +119,15 @@ func (e *Store) Add(id string, Config *Config) {
 	e.Unlock()
 }
 
+// SetPid adds an association between a Pid and a config.
+func (e *Store) SetPid(id string, pid int) {
+	e.Lock()
+	if config, ok := e.byID[id]; ok {
+		e.byPid[pid] = config
+	}
+	e.Unlock()
+}
+
 // SetPidUnlocked adds an association between a Pid and a config, it does not
 // synchronized with other operations.
 func (e *Store) SetPidUnlocked(id string, pid int) {


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/35588
fixes https://github.com/moby/moby/issues/35590

This prevents a panic if Execs are started concurrently, which may be due to HealthChecks starting on daemon restart.

**- Description for the changelog**

```Markdown
* Fix panic due to concurrent map writes when health checks are started []()
```
