### PR TITLE
Improve swagger schema for code generation

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4501,6 +4501,8 @@ paths:
           description: "Container created successfully"
           schema:
             type: "object"
+            title: "ContainerCreateResponse"
+            description: "OK response to ContainerCreate operation"
             required: [Id, Warnings]
             properties:
               Id:
@@ -4549,6 +4551,7 @@ paths:
           description: "no error"
           schema:
             type: "object"
+            title: "ContainerInspectResponse"
             properties:
               Id:
                 description: "The ID of the container"
@@ -4833,6 +4836,8 @@ paths:
           description: "no error"
           schema:
             type: "object"
+            title: "ContainerTopResponse"
+            description: "OK response to ContainerTop operation"
             properties:
               Titles:
                 description: "The ps column titles"
@@ -4993,6 +4998,8 @@ paths:
             items:
               type: "object"
               x-go-name: "ContainerChangeResponseItem"
+              title: "ContainerChangeResponseItem"
+              description: "change item in response to ContainerChanges operation"
               required: [Path, Kind]
               properties:
                 Path:
@@ -5371,6 +5378,8 @@ paths:
           description: "The container has been updated."
           schema:
             type: "object"
+            title: "ContainerUpdateResponse"
+            description: "OK response to ContainerUpdate operation"
             properties:
               Warnings:
                 type: "array"
@@ -5724,6 +5733,8 @@ paths:
           description: "The container has exit."
           schema:
             type: "object"
+            title: "ContainerWaitResponse"
+            description: "OK response to ContainerWait operation"
             required: [StatusCode]
             properties:
               StatusCode:
@@ -5969,6 +5980,7 @@ paths:
           description: "No error"
           schema:
             type: "object"
+            title: "ContainerPruneResponse"
             properties:
               ContainersDeleted:
                 description: "Container IDs that were deleted"
@@ -6225,6 +6237,7 @@ paths:
           description: "No error"
           schema:
             type: "object"
+            title: "BuildPruneResponse"
             properties:
               SpaceReclaimed:
                 description: "Disk space reclaimed in bytes"
@@ -6410,6 +6423,8 @@ paths:
             items:
               type: "object"
               x-go-name: HistoryResponseItem
+              title: "HistoryResponseItem"
+              description: "individual image layer information in response to ImageHistory operation"
               required: [Id, Created, CreatedBy, Tags, Size, Comment]
               properties:
                 Id:
@@ -6616,6 +6631,7 @@ paths:
             type: "array"
             items:
               type: "object"
+              title: "ImageSearchResponseItem"
               properties:
                 description:
                   type: "string"
@@ -6691,6 +6707,7 @@ paths:
           description: "No error"
           schema:
             type: "object"
+            title: "ImagePruneResponse"
             properties:
               ImagesDeleted:
                 description: "Images that were deleted"
@@ -6718,6 +6735,7 @@ paths:
           description: "An identity token was generated successfully."
           schema:
             type: "object"
+            title: "SystemAuthResponse"
             required: [Status]
             properties:
               Status:
@@ -6772,6 +6790,7 @@ paths:
           description: "no error"
           schema:
             type: "object"
+            title: "SystemVersionResponse"
             properties:
               Version:
                 type: "string"
@@ -6928,6 +6947,7 @@ paths:
           description: "no error"
           schema:
             type: "object"
+            title: "SystemEventsResponse"
             properties:
               Type:
                 description: "The type of object emitting the event"
@@ -7011,6 +7031,7 @@ paths:
           description: "no error"
           schema:
             type: "object"
+            title: "SystemDataUsageResponse"
             properties:
               LayersSize:
                 type: "integer"
@@ -7366,6 +7387,7 @@ paths:
           description: "No error"
           schema:
             type: "object"
+            title: "ExecInspectResponse"
             properties:
               CanRemove:
                 type: "boolean"
@@ -7436,6 +7458,7 @@ paths:
           description: "Summary volume data that matches the query"
           schema:
             type: "object"
+            title: "VolumeListResponse"
             required: [Volumes, Warnings]
             properties:
               Volumes:
@@ -7617,6 +7640,7 @@ paths:
           description: "No error"
           schema:
             type: "object"
+            title: "VolumePruneResponse"
             properties:
               VolumesDeleted:
                 description: "Volumes that were deleted"
@@ -7795,6 +7819,7 @@ paths:
           description: "No error"
           schema:
             type: "object"
+            title: "NetworkCreateResponse"
             properties:
               Id:
                 description: "The ID of the created network."
@@ -7997,6 +8022,7 @@ paths:
           description: "No error"
           schema:
             type: "object"
+            title: "NetworkPruneResponse"
             properties:
               NetworksDeleted:
                 description: "Networks that were deleted"
@@ -8048,6 +8074,7 @@ paths:
             items:
               description: "Describes a permission the user has to accept upon installing the plugin."
               type: "object"
+              title: "PluginPrivilegeItem"
               properties:
                 Name:
                   type: "string"
@@ -8750,6 +8777,7 @@ paths:
           description: "no error"
           schema:
             type: "object"
+            title: "UnlockKeyResponse"
             properties:
               UnlockKey:
                 description: "The swarm's unlock key."
@@ -8841,6 +8869,7 @@ paths:
           description: "no error"
           schema:
             type: "object"
+            title: "ServiceCreateResponse"
             properties:
               ID:
                 description: "The ID of the created service."
@@ -9857,6 +9886,7 @@ paths:
           schema:
             type: "object"
             x-go-name: DistributionInspect
+            title: "DistributionInspectResponse"
             required: [Descriptor, Platforms]
             properties:
               Descriptor:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9512,13 +9512,7 @@ paths:
         201:
           description: "no error"
           schema:
-            type: "object"
-            properties:
-              ID:
-                description: "The ID of the created secret."
-                type: "string"
-            example:
-              ID: "ktnbjxoalbkvbvedmg1urrz8h"
+            $ref: "#/definitions/IdResponse"
         409:
           description: "name conflicts with an existing object"
           schema:
@@ -9717,13 +9711,7 @@ paths:
         201:
           description: "no error"
           schema:
-            type: "object"
-            properties:
-              ID:
-                description: "The ID of the created config."
-                type: "string"
-            example:
-              ID: "ktnbjxoalbkvbvedmg1urrz8h"
+            $ref: "#/definitions/IdResponse"
         409:
           description: "name conflicts with an existing object"
           schema:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7367,6 +7367,10 @@ paths:
           schema:
             type: "object"
             properties:
+              CanRemove:
+                type: "boolean"
+              DetachKeys:
+                type: "string"
               ID:
                 type: "string"
               Running:

--- a/api/templates/server/operation.gotmpl
+++ b/api/templates/server/operation.gotmpl
@@ -20,7 +20,7 @@ import (
 
 
 {{ range .ExtraSchemas }}
-// {{ .Name }} {{ template "docstring" . }}
+// {{ .Name }} {{ comment .Description }}
 // swagger:model {{ .Name }}
 {{ template "schema" . }}
 {{ end }}

--- a/api/types/container/container_changes.go
+++ b/api/types/container/container_changes.go
@@ -7,7 +7,7 @@ package container
 // See hack/generate-swagger-api.sh
 // ----------------------------------------------------------------------------
 
-// ContainerChangeResponseItem container change response item
+// ContainerChangeResponseItem change item in response to ContainerChanges operation
 // swagger:model ContainerChangeResponseItem
 type ContainerChangeResponseItem struct {
 

--- a/api/types/container/container_create.go
+++ b/api/types/container/container_create.go
@@ -7,7 +7,7 @@ package container
 // See hack/generate-swagger-api.sh
 // ----------------------------------------------------------------------------
 
-// ContainerCreateCreatedBody container create created body
+// ContainerCreateCreatedBody OK response to ContainerCreate operation
 // swagger:model ContainerCreateCreatedBody
 type ContainerCreateCreatedBody struct {
 

--- a/api/types/container/container_top.go
+++ b/api/types/container/container_top.go
@@ -7,7 +7,7 @@ package container
 // See hack/generate-swagger-api.sh
 // ----------------------------------------------------------------------------
 
-// ContainerTopOKBody container top o k body
+// ContainerTopOKBody OK response to ContainerTop operation
 // swagger:model ContainerTopOKBody
 type ContainerTopOKBody struct {
 

--- a/api/types/container/container_update.go
+++ b/api/types/container/container_update.go
@@ -7,7 +7,7 @@ package container
 // See hack/generate-swagger-api.sh
 // ----------------------------------------------------------------------------
 
-// ContainerUpdateOKBody container update o k body
+// ContainerUpdateOKBody OK response to ContainerUpdate operation
 // swagger:model ContainerUpdateOKBody
 type ContainerUpdateOKBody struct {
 

--- a/api/types/container/container_wait.go
+++ b/api/types/container/container_wait.go
@@ -15,7 +15,7 @@ type ContainerWaitOKBodyError struct {
 	Message string `json:"Message,omitempty"`
 }
 
-// ContainerWaitOKBody container wait o k body
+// ContainerWaitOKBody OK response to ContainerWait operation
 // swagger:model ContainerWaitOKBody
 type ContainerWaitOKBody struct {
 

--- a/api/types/image/image_history.go
+++ b/api/types/image/image_history.go
@@ -7,7 +7,7 @@ package image
 // See hack/generate-swagger-api.sh
 // ----------------------------------------------------------------------------
 
-// HistoryResponseItem history response item
+// HistoryResponseItem individual image layer information in response to ImageHistory operation
 // swagger:model HistoryResponseItem
 type HistoryResponseItem struct {
 


### PR DESCRIPTION
**- What I did**

I generate java model for API from swagger.yaml. As the swagger spec uses a lot's of inline schema, I end up with various `InlineResponse200xx` types generated.
As swagger [do support `title` as model name](https://github.com/swagger-api/swagger-codegen/issues/2868), I added this metadata for better generated model.

**- How I did it**

swagger-codegen-plugin for maven
https://github.com/Dockins/jocker

**- How to verify it**

run code generator

**- Description for the changelog**

define titles for swagger inline schema objects so generated code use understandable names

**- A picture of a cute animal (not mandatory but encouraged)**

![8c87f181412dd85b618ffa21da105ed3](https://user-images.githubusercontent.com/132757/33207554-66f2f01a-d10e-11e7-9a2b-9f5e125515f7.jpg)
