### PR TITLE
Set a go_package on api/types/swarm/runtime to make it Bazel compatible

### DIFF
--- a/api/types/swarm/runtime/plugin.proto
+++ b/api/types/swarm/runtime/plugin.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+option go_package = "github.com/docker/docker/api/types/swarm/runtime;runtime";
+
 // PluginSpec defines the base payload which clients can specify for creating
 // a service with the plugin runtime.
 message PluginSpec {


### PR DESCRIPTION
Before this change, it wasn't possible to build this repository using auto-generated BUILD files with Bazel (see http://bazel.build) because the generated package was placed in the wrong directory path.

By adding the go_package option to the proto, it ensures the package gets compiled and placed into a directory that libraries can use.

This is my first patch to docker in a while, so any feedback on how to do this better is much appreciated. Thanks!