### PR TITLE
remove import of opencontainers/runc in windows

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -27,7 +27,7 @@ import (
 	winlibnetwork "github.com/docker/libnetwork/drivers/windows"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/options"
-	blkiodev "github.com/opencontainers/runc/libcontainer/configs"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
@@ -48,7 +48,7 @@ func getPluginExecRoot(root string) string {
 	return filepath.Join(root, "plugins")
 }
 
-func getBlkioWeightDevices(config *containertypes.HostConfig) ([]blkiodev.WeightDevice, error) {
+func getBlkioWeightDevices(config containertypes.Resources) ([]specs.LinuxWeightDevice, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
We are planning to remove supports for non-Linux platform in
runc (https://github.com/opencontainers/runc/pull/1654).  The current
import here is the only thing that i found in docker that is windows-related
so fixing this would remove the rest of windows code in runc.

This changes some functions in daemon_windows to be the same as
daemon_unix to use runtime-spec public API instead of runc.

cc @jhowardmsft @justincormack @crosbymichael 

