### PR TITLE
Logentries driver line-only=true []byte output fix

### DIFF
--- a/daemon/logger/logentries/logentries.go
+++ b/daemon/logger/logentries/logentries.go
@@ -76,7 +76,7 @@ func (f *logentries) Log(msg *logger.Message) error {
 		logger.PutMessage(msg)
 		f.writer.Println(f.tag, ts, data)
 	} else {
-		line := msg.Line
+		line := string(msg.Line)
 		logger.PutMessage(msg)
 		f.writer.Println(line)
 	}


### PR DESCRIPTION
This fixes casting of log message []byte into string with --log-opt line-only=true

The fix is for #35610

Signed-off-by: Igor Karpovich <igor@karpovich.me>