### PR TITLE
Remove ByPid from ExecCommands

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -31,14 +31,6 @@ func (d *Daemon) registerExecCommand(container *container.Container, config *exe
 	d.execCommands.Add(config.ID, config)
 }
 
-func (d *Daemon) registerExecPidUnlocked(container *container.Container, config *exec.Config) {
-	logrus.Debugf("registering pid %v for exec %v", config.Pid, config.ID)
-	// Storing execs in container in order to kill them gracefully whenever the container is stopped or removed.
-	container.ExecCommands.SetPidUnlocked(config.ID, config.Pid)
-	// Storing execs in daemon for easy access via Engine API.
-	d.execCommands.SetPidUnlocked(config.ID, config.Pid)
-}
-
 // ExecExists looks up the exec instance and returns a bool if it exists or not.
 // It will also return the error produced by `getConfig`
 func (d *Daemon) ExecExists(name string) (bool, error) {
@@ -253,7 +245,6 @@ func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.R
 		return translateContainerdStartErr(ec.Entrypoint, ec.SetExitCode, err)
 	}
 	ec.Pid = systemPid
-	d.registerExecPidUnlocked(c, ec)
 	c.ExecCommands.Unlock()
 	ec.Unlock()
 

--- a/daemon/exec/exec.go
+++ b/daemon/exec/exec.go
@@ -88,16 +88,14 @@ func (c *Config) SetExitCode(code int) {
 
 // Store keeps track of the exec configurations.
 type Store struct {
-	byID  map[string]*Config
-	byPid map[int]*Config
+	byID map[string]*Config
 	sync.RWMutex
 }
 
 // NewStore initializes a new exec store.
 func NewStore() *Store {
 	return &Store{
-		byID:  make(map[string]*Config),
-		byPid: make(map[int]*Config),
+		byID: make(map[string]*Config),
 	}
 }
 
@@ -119,14 +117,6 @@ func (e *Store) Add(id string, Config *Config) {
 	e.Unlock()
 }
 
-// SetPidUnlocked adds an association between a Pid and a config, it does not
-// synchronized with other operations.
-func (e *Store) SetPidUnlocked(id string, pid int) {
-	if config, ok := e.byID[id]; ok {
-		e.byPid[pid] = config
-	}
-}
-
 // Get returns an exec configuration by its id.
 func (e *Store) Get(id string) *Config {
 	e.RLock()
@@ -135,18 +125,9 @@ func (e *Store) Get(id string) *Config {
 	return res
 }
 
-// ByPid returns an exec configuration by its pid.
-func (e *Store) ByPid(pid int) *Config {
-	e.RLock()
-	res := e.byPid[pid]
-	e.RUnlock()
-	return res
-}
-
 // Delete removes an exec configuration from the store.
 func (e *Store) Delete(id string, pid int) {
 	e.Lock()
-	delete(e.byPid, pid)
 	delete(e.byID, id)
 	e.Unlock()
 }

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -108,7 +108,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerd.EventType, ei libc
 			return daemon.postRunProcessing(c, ei)
 		}
 
-		if execConfig := c.ExecCommands.ByPid(int(ei.Pid)); execConfig != nil {
+		if execConfig := c.ExecCommands.Get(ei.ProcessID); execConfig != nil {
 			ec := int(ei.ExitCode)
 			execConfig.Lock()
 			defer execConfig.Unlock()
@@ -125,6 +125,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerd.EventType, ei libc
 		} else {
 			logrus.WithFields(logrus.Fields{
 				"container": c.ID,
+				"exec-id":   ei.ProcessID,
 				"exec-pid":  ei.Pid,
 			}).Warnf("Ignoring Exit Event, no such exec command found")
 		}


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/35588
fixes https://github.com/moby/moby/issues/35590

**- What I did**

Remove all references to ExecCommands `byPid` map

**- How I did it**

Only rely on the event `ProcessID` when processing events

**- How to verify it**

Hopefully the automated tests are enough

**- Description for the changelog**

:man_shrugging: 

**- A picture of a cute animal (not mandatory but encouraged)**

:cow: 
