### PR TITLE
Make Splunk logger have a non-default, log line size limit.

### DIFF
--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -525,6 +525,10 @@ func (l *splunkLogger) Name() string {
 	return driverName
 }
 
+func (l *splunkLogger) BufSize() int {
+	return 80 * 1024
+}
+
 func (l *splunkLogger) createSplunkMessage(msg *logger.Message) *splunkMessage {
 	message := *l.nullMessage
 	message.Time = fmt.Sprintf("%f", float64(msg.Timestamp.UnixNano())/float64(time.Second))


### PR DESCRIPTION
Instead of the default 16K limit, Splunk loggers will have a 80K limit.
This is a stop-gap solution to the issue of long Splunk log messages being
chopped up as 16K chunks. Until the correct long term solution of the
Splunk driver implementing PARTIAL message support, this change can be
used to have a fixed higher upper limit.

Signed-off-by: Anusha Ragunathan <anusha.ragunathan@docker.com>

**- Description for the changelog**
Increase Splunk's log length limit to 80K 

