### PR TITLE
Fix MkdirAll* and its usage

### DIFF
--- a/daemon/checkpoint.go
+++ b/daemon/checkpoint.go
@@ -34,9 +34,6 @@ func getCheckpointDir(checkDir, checkpointID, ctrName, ctrID, ctrCheckpointDir s
 			err2 = fmt.Errorf("checkpoint with name %s already exists for container %s", checkpointID, ctrName)
 		case err != nil && os.IsNotExist(err):
 			err2 = os.MkdirAll(checkpointAbsDir, 0700)
-			if os.IsExist(err2) {
-				err2 = nil
-			}
 		case err != nil:
 			err2 = err
 		case err == nil:

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -675,14 +675,14 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 	}
 
 	daemonRepo := filepath.Join(config.Root, "containers")
-	if err := idtools.MkdirAllAndChown(daemonRepo, 0700, rootIDs); err != nil && !os.IsExist(err) {
+	if err := idtools.MkdirAllAndChown(daemonRepo, 0700, rootIDs); err != nil {
 		return nil, err
 	}
 
 	// Create the directory where we'll store the runtime scripts (i.e. in
 	// order to support runtimeArgs)
 	daemonRuntimes := filepath.Join(config.Root, "runtimes")
-	if err := system.MkdirAll(daemonRuntimes, 0700, ""); err != nil && !os.IsExist(err) {
+	if err := system.MkdirAll(daemonRuntimes, 0700, ""); err != nil {
 		return nil, err
 	}
 	if err := d.loadRuntimes(); err != nil {
@@ -690,7 +690,7 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 	}
 
 	if runtime.GOOS == "windows" {
-		if err := system.MkdirAll(filepath.Join(config.Root, "credentialspecs"), 0, ""); err != nil && !os.IsExist(err) {
+		if err := system.MkdirAll(filepath.Join(config.Root, "credentialspecs"), 0, ""); err != nil {
 			return nil, err
 		}
 	}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1514,7 +1514,7 @@ func (daemon *Daemon) initCgroupsPath(path string) error {
 
 func maybeCreateCPURealTimeFile(sysinfoPresent bool, configValue int64, file string, path string) error {
 	if sysinfoPresent && configValue != 0 {
-		if err := os.MkdirAll(path, 0755); err != nil && !os.IsExist(err) {
+		if err := os.MkdirAll(path, 0755); err != nil {
 			return err
 		}
 		if err := ioutil.WriteFile(filepath.Join(path, file), []byte(strconv.FormatInt(configValue, 10)), 0700); err != nil {

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -485,7 +484,7 @@ func setupRemappedRoot(config *config.Config) (*idtools.IDMappings, error) {
 func setupDaemonRoot(config *config.Config, rootDir string, rootIDs idtools.IDPair) error {
 	config.Root = rootDir
 	// Create the root directory if it doesn't exists
-	if err := system.MkdirAllWithACL(config.Root, 0, system.SddlAdministratorsLocalSystem); err != nil && !os.IsExist(err) {
+	if err := system.MkdirAllWithACL(config.Root, 0, system.SddlAdministratorsLocalSystem); err != nil {
 		return err
 	}
 	return nil

--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -122,13 +122,8 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	if err != nil {
 		return nil, err
 	}
-	// Create the root aufs driver dir and return
-	// if it already exists
-	// If not populate the dir structure
+	// Create the root aufs driver dir
 	if err := idtools.MkdirAllAndChown(root, 0700, idtools.IDPair{UID: rootUID, GID: rootGID}); err != nil {
-		if os.IsExist(err) {
-			return a, nil
-		}
 		return nil, err
 	}
 

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -268,7 +268,7 @@ func (devices *DeviceSet) ensureImage(name string, size int64) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := idtools.MkdirAllAndChown(dirname, 0700, idtools.IDPair{UID: uid, GID: gid}); err != nil && !os.IsExist(err) {
+	if err := idtools.MkdirAllAndChown(dirname, 0700, idtools.IDPair{UID: uid, GID: gid}); err != nil {
 		return "", err
 	}
 
@@ -1697,10 +1697,10 @@ func (devices *DeviceSet) initDevmapper(doInit bool) (retErr error) {
 	if err != nil {
 		return err
 	}
-	if err := idtools.MkdirAndChown(devices.root, 0700, idtools.IDPair{UID: uid, GID: gid}); err != nil && !os.IsExist(err) {
+	if err := idtools.MkdirAndChown(devices.root, 0700, idtools.IDPair{UID: uid, GID: gid}); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(devices.metadataDir(), 0700); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(devices.metadataDir(), 0700); err != nil {
 		return err
 	}
 

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -189,7 +189,7 @@ func (d *Driver) Get(id, mountLabel string) (containerfs.ContainerFS, error) {
 	}
 
 	// Create the target directories if they don't exist
-	if err := idtools.MkdirAllAndChown(path.Join(d.home, "mnt"), 0755, idtools.IDPair{UID: uid, GID: gid}); err != nil && !os.IsExist(err) {
+	if err := idtools.MkdirAllAndChown(path.Join(d.home, "mnt"), 0755, idtools.IDPair{UID: uid, GID: gid}); err != nil {
 		d.ctr.Decrement(mp)
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (d *Driver) Get(id, mountLabel string) (containerfs.ContainerFS, error) {
 		return nil, err
 	}
 
-	if err := idtools.MkdirAllAndChown(rootFs, 0755, idtools.IDPair{UID: uid, GID: gid}); err != nil && !os.IsExist(err) {
+	if err := idtools.MkdirAllAndChown(rootFs, 0755, idtools.IDPair{UID: uid, GID: gid}); err != nil {
 		d.ctr.Decrement(mp)
 		d.DeviceSet.UnmountDevice(id, mp)
 		return nil, err

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -136,7 +136,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 	// Create the driver home dir
-	if err := idtools.MkdirAllAndChown(home, 0700, idtools.IDPair{rootUID, rootGID}); err != nil && !os.IsExist(err) {
+	if err := idtools.MkdirAllAndChown(home, 0700, idtools.IDPair{rootUID, rootGID}); err != nil {
 		return nil, err
 	}
 

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -171,7 +171,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 	// Create the driver home dir
-	if err := idtools.MkdirAllAndChown(path.Join(home, linkDir), 0700, idtools.IDPair{rootUID, rootGID}); err != nil && !os.IsExist(err) {
+	if err := idtools.MkdirAllAndChown(path.Join(home, linkDir), 0700, idtools.IDPair{rootUID, rootGID}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -42,7 +42,9 @@ func MkdirAllAndChown(path string, mode os.FileMode, owner IDPair) error {
 }
 
 // MkdirAndChown creates a directory and then modifies ownership to the requested uid/gid.
-// If the directory already exists, this function still changes ownership
+// If the directory already exists, this function still changes ownership.
+// Note that unlike os.Mkdir(), this function does not return IsExist error
+// in case path already exists.
 func MkdirAndChown(path string, mode os.FileMode, owner IDPair) error {
 	return mkdirAs(path, mode, owner.UID, owner.GID, false, true)
 }

--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -31,7 +31,7 @@ func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll, chown
 	stat, err := system.Stat(path)
 	if err == nil {
 		if !stat.IsDir() {
-			return &os.PathError{"mkdir", path, syscall.ENOTDIR}
+			return &os.PathError{Op: "mkdir", Path: path, Err: syscall.ENOTDIR}
 		}
 		if !chownExisting {
 			return nil
@@ -58,7 +58,7 @@ func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll, chown
 				paths = append(paths, dirPath)
 			}
 		}
-		if err := system.MkdirAll(path, mode, ""); err != nil && !os.IsExist(err) {
+		if err := system.MkdirAll(path, mode, ""); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/docker/docker/pkg/system"
 	"github.com/opencontainers/runc/libcontainer/user"
@@ -29,6 +30,9 @@ func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll, chown
 
 	stat, err := system.Stat(path)
 	if err == nil {
+		if !stat.IsDir() {
+			return &os.PathError{"mkdir", path, syscall.ENOTDIR}
+		}
 		if !chownExisting {
 			return nil
 		}

--- a/pkg/idtools/idtools_unix_test.go
+++ b/pkg/idtools/idtools_unix_test.go
@@ -378,6 +378,20 @@ func TestLookupUserAndGroupThatDoesNotExist(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestMkdirIsNotDir checks that mkdirAs() function (used by MkdirAll...)
+// returns a correct error in case a directory which it is about to create
+// already exists but is a file (rather than a directory).
+func TestMkdirIsNotDir(t *testing.T) {
+	file, err := ioutil.TempFile("", t.Name())
+	if err != nil {
+		t.Fatalf("Couldn't create temp dir: %v", err)
+	}
+	defer os.Remove(file.Name())
+
+	err = mkdirAs(file.Name(), 0755, 0, 0, false, false)
+	assert.EqualError(t, err, "mkdir "+file.Name()+": not a directory")
+}
+
 func RequiresRoot(t *testing.T) {
 	skip.IfCondition(t, os.Getuid() != 0, "skipping test that requires root")
 }

--- a/pkg/idtools/idtools_windows.go
+++ b/pkg/idtools/idtools_windows.go
@@ -11,7 +11,7 @@ import (
 // Platforms such as Windows do not support the UID/GID concept. So make this
 // just a wrapper around system.MkdirAll.
 func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll, chownExisting bool) error {
-	if err := system.MkdirAll(path, mode, ""); err != nil && !os.IsExist(err) {
+	if err := system.MkdirAll(path, mode, ""); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/system/stat_unix.go
+++ b/pkg/system/stat_unix.go
@@ -47,6 +47,11 @@ func (s StatT) Mtim() syscall.Timespec {
 	return s.mtim
 }
 
+// IsDir reports whether s describes a directory.
+func (s StatT) IsDir() bool {
+	return s.mode&syscall.S_IFDIR != 0
+}
+
 // Stat takes a path to a file and returns
 // a system.StatT type pertaining to that file.
 //

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -139,16 +139,6 @@ func (r *Root) Name() string {
 	return volume.DefaultDriverName
 }
 
-type alreadyExistsError struct {
-	path string
-}
-
-func (e alreadyExistsError) Error() string {
-	return "local volume already exists under " + e.path
-}
-
-func (e alreadyExistsError) Conflict() {}
-
 type systemError struct {
 	err error
 }
@@ -181,9 +171,6 @@ func (r *Root) Create(name string, opts map[string]string) (volume.Volume, error
 
 	path := r.DataPath(name)
 	if err := idtools.MkdirAllAndChown(path, 0755, r.rootIDs); err != nil {
-		if os.IsExist(err) {
-			return nil, alreadyExistsError{filepath.Dir(path)}
-		}
 		return nil, errors.Wrapf(systemError{err}, "error while creating volume path '%s'", path)
 	}
 

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -192,7 +192,6 @@ func (m *MountPoint) Setup(mountLabel string, rootIDs idtools.IDPair, checkFun f
 		return "", fmt.Errorf("Unable to setup mount point, neither source nor volume defined")
 	}
 
-	// system.MkdirAll() produces an error if m.Source exists and is a file (not a directory),
 	if m.Type == mounttypes.TypeBind {
 		// Before creating the source directory on the host, invoke checkFun if it's not nil. One of
 		// the use case is to forbid creating the daemon socket as a directory if the daemon is in


### PR DESCRIPTION
**- What I did**

1. Fixed `idtools.Mkdir*` functions to return an error if a directory to be created already exists but is not a directory.
2. Fixed using `MkdirAll*` functions to not ignore `IsExist` errors.

Please see commit messages for details.

**- How I did it**
Manually checked all the code paths using MkdirAll and idtools.Mkdir functions.

**- How to verify it**
For idtools.Mkdir*, there is a test case included.

**- Description for the changelog**
- not required

**- A picture of a cute animal (not mandatory but encouraged)**