### PR TITLE
daemon: use 'private' ipc mode by default

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -474,10 +474,8 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 		}
 		// Ignore KernelMemoryTCP because it was added in API 1.40.
 		hostConfig.KernelMemoryTCP = 0
-	}
 
-	// Ignore Capabilities because it was added in API 1.40.
-	if hostConfig != nil && versions.LessThan(version, "1.40") {
+		// Ignore Capabilities because it was added in API 1.40.
 		hostConfig.Capabilities = nil
 	}
 

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -477,6 +477,11 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 
 		// Ignore Capabilities because it was added in API 1.40.
 		hostConfig.Capabilities = nil
+
+		// Older clients (API < 1.40) expects the default to be shareable, make them happy
+		if hostConfig.IpcMode.IsEmpty() {
+			hostConfig.IpcMode = container.IpcMode("shareable")
+		}
 	}
 
 	ccr, err := s.backend.ContainerCreate(types.ContainerCreateConfig{

--- a/daemon/config/config_unix.go
+++ b/daemon/config/config_unix.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// DefaultIpcMode is default for container's IpcMode, if not set otherwise
-	DefaultIpcMode = "shareable" // TODO: change to private
+	DefaultIpcMode = "private"
 )
 
 // Config defines the configuration of a docker daemon.

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -72,7 +72,7 @@ func (daemon *Daemon) getIpcContainer(id string) (*container.Container, error) {
 	// Check the container ipc is shareable
 	if st, err := os.Stat(container.ShmPath); err != nil || !st.IsDir() {
 		if err == nil || os.IsNotExist(err) {
-			return nil, errors.New(errMsg + ": non-shareable IPC")
+			return nil, errors.New(errMsg + ": non-shareable IPC (hint: use IpcMode:shareable for the donor container)")
 		}
 		// stat() failed?
 		return nil, errors.Wrap(err, errMsg+": unexpected error from stat "+container.ShmPath)

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -61,6 +61,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /containers/create` now takes a `Capabilities` field to set the list of
   kernel capabilities to be available for the container (this overrides the default
   set).
+* `POST /containers/create` on Linux now creates a container with `HostConfig.IpcMode=private`
+  by default, if IpcMode is not explicitly specified. The per-daemon default can be changed
+  back to `shareable` by using `DefaultIpcMode` daemon configuration parameter.
 * `POST /containers/{id}/update` now accepts a `PidsLimit` field to tune a container's
   PID limit. Set `0` or `-1` for unlimited. Leave `null` to not change the current value.
 


### PR DESCRIPTION
_(this is a follow-up to https://github.com/moby/moby/pull/34087)_

This changes the default ipc mode of daemon/engine to be private, meaning the containers will not have their `/dev/shm` filesystem mounted on the host and then bind-mounted from host to a container by default.

The benefits of doing this are:

1. **No leaked mounts.** This eliminates a possibility to leak mounts into other namespaces (and therefore unfortunate errors like "Unable to remove filesystem for $ID: remove /var/lib/docker/containers/$ID/shm: device or resource busy").

2. **Working checkpoint/restore.** Make `docker checkpoint` not lose the contents of `/dev/shm`, but save it to the dump, and be restored back upon `docker start --checkpoint`.

3. **Better security.** Currently any container is opened to share its `/dev/shm` with any other container.

The downside is, obviously, this change will break the following usage scenario:
```
 $ docker run -d --name donor busybox top
 $ docker run --rm -it --ipc container:donor busybox sh
 Error response from daemon: linux spec namespaces: can't join IPC
 of  container <ID>: non-shareable IPC (hint: use --ipc shareable
 for the donor container)
```
The solution, as hinted by the (amended) error message, is to explicitly enable donor sharing by using `--ipc shareable` option to `docker run` or `docker create`:
```
 $ docker run -d --name donor --ipc shareable busybox top
```

## Compatibility notes

1. This only applies to containers created _after_ this change. Existing containers are not affected and will work fine as their ipc mode is stored in `HostConfig`.

2. Old (bad, but backward-compatible) behavior (i.e. "shareable" containers by default) can be enabled by either using `--default-ipc-mode shareable` daemon command line option, or by adding a `"default-ipc-mode": shareable"` line in `docker.json` configuration file.

3. If an older client (API < 1.40) is used, a "shareable" container is created. A test to check that is added.

4. An item in API version history explaining the new default, and a way to change it back, is added.

5. As a side effect, this PR fixes bug originally addressed in https://github.com/moby/moby/pull/38700 (that is obsoleted by this one).

**- A picture of a cute animal (not mandatory but encouraged)**

## See also 

* First part of this saga: https://github.com/moby/moby/pull/34087
* Documentation updates: https://github.com/docker/cli/pull/367
* Test case fixes that were originally part of this PR: https://github.com/moby/moby/pull/35840
* Kubernetes patch to not rely on IpcMode:shared being the default: https://github.com/kubernetes/kubernetes/pull/70826
* Some more test case updates: https://github.com/moby/moby/pull/38843/commits

![screenshot from 2017-11-27 17-05-55](https://user-images.githubusercontent.com/4522509/33297353-57d3a014-d395-11e7-96cb-9356e6d0323d.png)
_A  tiger cub from the 1984 USSR cartoon_  https://www.youtube.com/watch?v=0DnjD7w-2FI