### PR TITLE
Change references from test-integration-cli to test-integration

### DIFF
--- a/builder/dockerfile/parser/testfiles/docker/Dockerfile
+++ b/builder/dockerfile/parser/testfiles/docker/Dockerfile
@@ -9,7 +9,7 @@
 # docker run -v `pwd`:/go/src/github.com/docker/docker --privileged -i -t docker bash
 #
 # # Run the test suite:
-# docker run --privileged docker hack/make.sh test-unit test-integration-cli test-docker-py
+# docker run --privileged docker hack/make.sh test-unit test-integration test-docker-py
 #
 # # Publish a release:
 # docker run --privileged \

--- a/docs/contributing/test.md
+++ b/docs/contributing/test.md
@@ -47,7 +47,7 @@ testing:
 | ---------------------- | ---------------------------------------------- |
 | `test`                 | Run the unit, integration, and docker-py tests |
 | `test-unit`            | Run just the unit tests                        |
-| `test-integration-cli` | Run the integration tests for the CLI          |
+| `test-integration`     | Run the integration tests                      |
 | `test-docker-py`       | Run the tests for the Docker API client        |
 
 Running the entire test suite on your current repository can take over half an
@@ -113,7 +113,7 @@ Try this now.
 3.  Run the tests using the `hack/make.sh` script.
 
     ```bash
-    root@5f8630b873fe:/go/src/github.com/moby/moby# hack/make.sh dynbinary binary cross test-unit test-integration-cli test-docker-py
+    root@5f8630b873fe:/go/src/github.com/moby/moby# hack/make.sh dynbinary binary cross test-unit test-integration test-docker-py
     ```
 
     The tests run just as they did within your local host.
@@ -164,13 +164,13 @@ flag's value is passed as arguments to the `go test` command. For example, from
 your local host you can run the `TestBuild` test with this command:
 
 ```bash
-$ TESTFLAGS='-check.f DockerSuite.TestBuild*' make test-integration-cli
+$ TESTFLAGS='-check.f DockerSuite.TestBuild*' make test-integration
 ```
 
 To run the same test inside your Docker development container, you do this:
 
 ```bash
-root@5f8630b873fe:/go/src/github.com/moby/moby# TESTFLAGS='-check.f TestBuild*' hack/make.sh binary test-integration-cli
+root@5f8630b873fe:/go/src/github.com/moby/moby# TESTFLAGS='-check.f TestBuild*' hack/make.sh binary test-integration
 ```
 
 ## Test the Windows binary against a Linux daemon
@@ -207,14 +207,14 @@ run a Bash terminal on Windows.
 5.  Make the binary and run the tests:
 
     ```bash
-    $ hack/make.sh binary test-integration-cli
+    $ hack/make.sh binary test-integration
     ```
     Some tests are skipped on Windows for various reasons. You can see which
     tests were skipped by re-running the make and passing in the
    `TESTFLAGS='-test.v'` value. For example
 
     ```bash
-    $ TESTFLAGS='-test.v' hack/make.sh binary test-integration-cli
+    $ TESTFLAGS='-test.v' hack/make.sh binary test-integration
     ```
 
     Should you wish to run a single test such as one with the name
@@ -222,7 +222,7 @@ run a Bash terminal on Windows.
     example
 
     ```bash
-    $ TESTFLAGS='-check.f TestExample' hack/make.sh binary test-integration-cli
+    $ TESTFLAGS='-check.f TestExample' hack/make.sh binary test-integration
     ```
 
 You can now choose to make changes to the Moby source or the tests. If you

--- a/hack/integration-cli-on-swarm/README.md
+++ b/hack/integration-cli-on-swarm/README.md
@@ -12,7 +12,7 @@ IT on Swarm allows you to execute integration test in parallel across a Docker S
 ### Worker service
 
   - Works as a funker callee
-  - Executes an equivalent of `TESTFLAGS=-check.f TestFoo|TestBar|TestBaz ... make test-integration-cli` using the bind-mounted API socket (`docker.sock`)
+  - Executes an equivalent of `TESTFLAGS=-check.f TestFoo|TestBar|TestBaz ... make test-integration` using the bind-mounted API socket (`docker.sock`)
 
 ### Client
 

--- a/hack/integration-cli-on-swarm/agent/worker/executor.go
+++ b/hack/integration-cli-on-swarm/agent/worker/executor.go
@@ -43,7 +43,7 @@ func privilegedTestChunkExecutor(autoRemove bool) testChunkExecutor {
 			}
 			graphdriver = info.Driver
 		}
-		// `daemon_dest` is similar to `$DEST` (e.g. `bundles/VERSION/test-integration-cli`)
+		// `daemon_dest` is similar to `$DEST` (e.g. `bundles/VERSION/test-integration`)
 		// but it exists outside of `bundles` so as to make `$DOCKER_GRAPHDRIVER` work.
 		//
 		// Without this hack, `$DOCKER_GRAPHDRIVER` fails because of (e.g.) `overlay2 is not supported over overlayfs`
@@ -65,7 +65,7 @@ func privilegedTestChunkExecutor(autoRemove bool) testChunkExecutor {
 				"org.dockerproject.integration-cli-on-swarm.comment": "this non-service container is created for running privileged programs on Swarm. you can remove this container manually if the corresponding service is already stopped.",
 			},
 			Entrypoint: []string{"hack/dind"},
-			Cmd:        []string{"hack/make.sh", "test-integration-cli"},
+			Cmd:        []string{"hack/make.sh", "test-integration"},
 		}
 		hostConfig := container.HostConfig{
 			AutoRemove: autoRemove,

--- a/hack/integration-cli-on-swarm/host/enumerate.go
+++ b/hack/integration-cli-on-swarm/host/enumerate.go
@@ -26,7 +26,7 @@ func enumerateTestsForBytes(b []byte) ([]string, error) {
 
 // enumerateTests enumerates valid `-check.f` strings for all the test functions.
 // Note that we use regexp rather than parsing Go files for performance reason.
-// (Try `TESTFLAGS=-check.list make test-integration-cli` to see the slowness of parsing)
+// (Try `TESTFLAGS=-check.list make test-integration` to see the slowness of parsing)
 // The files needs to be `gofmt`-ed
 //
 // The result will be as follows, but unsorted ('$' is appended because they are regexp for `-check.f`):


### PR DESCRIPTION
**- What I did**
manual human `sed`

**- How I did it**
![](https://i.fluffy.cc/R6wzfJrwQS9wwpDZW9Q6VtrmT98j2G7D.gif)

**- How to verify it**
:eyes:

**- Description for the changelog**
Update testing documentation to remove deprecated `integration-test-cli` target mentions.

**- A picture of a cute animal (not mandatory but encouraged)**

