### PR TITLE
Logentries line-only logopt fix to maintain backwards compatibility

### DIFF
--- a/daemon/logger/logentries/logentries.go
+++ b/daemon/logger/logentries/logentries.go
@@ -50,8 +50,10 @@ func New(info logger.Info) (logger.Logger, error) {
 		return nil, errors.Wrap(err, "error connecting to logentries")
 	}
 	var lineOnly bool
-	if lineOnly, err = strconv.ParseBool(info.Config[lineonly]); err != nil {
-		return nil, errors.Wrap(err, "error parsing lineonly option")
+	if info.Config[lineonly] != "" {
+		if lineOnly, err = strconv.ParseBool(info.Config[lineonly]); err != nil {
+			return nil, errors.Wrap(err, "error parsing lineonly option")
+		}
 	}
 	return &logentries{
 		containerID:   info.ContainerID,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes #35626

Logentries line-only logopt breaks backwards compatibility, logentries driver won't start without this option so existing swarm stacks will stop working after the engine update.

**- How I did it**

Log driver will now ignore empty value and drop an error only in case of invalid boolean value.

**- How to verify it**

Try to do `docker run` without specifying line-only logopt at all.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/8340170/33317531-4f34adbe-d42f-11e7-91de-eccaf2307ac7.png)

Signed-off-by: Igor Karpovich <igor@karpovich.me>