### PR TITLE
Windows: Fix width/height swap

### DIFF
--- a/libcontainerd/client_local_windows.go
+++ b/libcontainerd/client_local_windows.go
@@ -934,7 +934,7 @@ func (c *client) ResizeTerminal(_ context.Context, containerID, processID string
 		"width":     width,
 		"pid":       p.pid,
 	}).Debug("resizing")
-	return p.hcsProcess.ResizeConsole(uint16(height), uint16(width))
+	return p.hcsProcess.ResizeConsole(uint16(width), uint16(height))
 }
 
 func (c *client) CloseStdin(_ context.Context, containerID, processID string) error {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes #35616

@johnstep PTAL

In the containerd move to 1.0 (commit ddae20c032058a0fd42c34c2e9750ee8f6296ac8 in PR https://github.com/moby/moby/pull/34895), width/height were inadvertently swapped. The correct calling convention into `hcsProcess.ResizeConsole` is (w, h). 

Previous code was at https://github.com/moby/moby/pull/34895/commits/ddae20c032058a0fd42c34c2e9750ee8f6296ac8#diff-da772cf2abf2ae03bec24ef9b38f8200L699

Updated code is at https://github.com/moby/moby/pull/34895/commits/ddae20c032058a0fd42c34c2e9750ee8f6296ac8#diff-1a69c80e50d3f16bc95fc6e8bb3a7254R932 where you can see the parameters have been switched.

@mlaventure FYI