### PR TITLE
Fix potential panic during plugin set.

### DIFF
--- a/plugin/v2/plugin.go
+++ b/plugin/v2/plugin.go
@@ -142,6 +142,9 @@ next:
 				}
 
 				// it is, so lets update the settings in memory
+				if mount.Source == nil {
+					return fmt.Errorf("Plugin config has no mount source")
+				}
 				*mount.Source = s.value
 				continue next
 			}
@@ -159,6 +162,9 @@ next:
 				}
 
 				// it is, so lets update the settings in memory
+				if device.Path == nil {
+					return fmt.Errorf("Plugin config has no device path")
+				}
 				*device.Path = s.value
 				continue next
 			}


### PR DESCRIPTION
Plugin config can have Mounts without a 'Source' field. In such cases,
performing a 'plugin set' on the mount source will panic the daemon. Its
the same case for device paths as well. This detects the case and
returns error.

Signed-off-by: Anusha Ragunathan <anusha.ragunathan@docker.com>

