### PR TITLE
Don't append the container id to custom directory checkpoints.

### DIFF
--- a/daemon/checkpoint.go
+++ b/daemon/checkpoint.go
@@ -22,7 +22,7 @@ func getCheckpointDir(checkDir, checkpointID, ctrName, ctrID, ctrCheckpointDir s
 	var checkpointDir string
 	var err2 error
 	if checkDir != "" {
-		checkpointDir = filepath.Join(checkDir, ctrID, "checkpoints")
+		checkpointDir = checkDir
 	} else {
 		checkpointDir = ctrCheckpointDir
 	}


### PR DESCRIPTION
**- What I did**

Issue #34601 documents a change in the way the `--checkpoint-dir` flag works, breaking the behavior for people using it. This fixes that issue.

**- How I did it**

Simply don't append the container id to the checkpoint path.

**- How to verify it**

You can verify by building and creating a custom dir checkpoint, and seeing that the resulting folder isn't nested inside one with the container's id. 

Unfortunately, implementing this fix highlighted a new problem:
https://github.com/moby/moby/commit/ddae20c032#diff-3cb140026df40998ea29c5bcb6bb292eR118

As of the above commit, restoring from a custom directory is no longer supported anyway. So, I'm not really sure what to do. If a subsequent release of pre containerd 1.0 docker is going to be created it would be nice to get this fix in I think.
