### PR TITLE
Make image (layer) downloads faster by using pigz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN apt-get update && apt-get install -y \
 	libudev-dev \
 	mercurial \
 	net-tools \
+	pigz \
 	pkg-config \
 	protobuf-compiler \
 	protobuf-c-compiler \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -52,6 +52,7 @@ RUN apt-get update && apt-get install -y \
 	libudev-dev \
 	mercurial \
 	net-tools \
+	pigz \
 	pkg-config \
 	protobuf-compiler \
 	protobuf-c-compiler \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -45,6 +45,7 @@ RUN apt-get update && apt-get install -y \
 	libtool \
 	libudev-dev \
 	mercurial \
+	pigz \
 	pkg-config \
 	python-backports.ssl-match-hostname \
 	python-dev \

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -47,6 +47,7 @@ RUN apk add --update \
     g++ \
     git \
     iptables \
+    pigz \
     tar \
     xz \
     && rm -rf /var/cache/apk/*

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -46,6 +46,7 @@ RUN apt-get update && apt-get install -y \
 	libtool \
 	libudev-dev \
 	mercurial \
+	pigz \
 	pkg-config \
 	python-backports.ssl-match-hostname \
 	python-dev \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -42,6 +42,7 @@ RUN apt-get update && apt-get install -y \
 	libtool \
 	libudev-dev \
 	mercurial \
+	pigz \
 	pkg-config \
 	python-backports.ssl-match-hostname \
 	python-dev \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		e2fsprogs \
 		iptables \
 		pkg-config \
+		pigz \
 		procps \
 		xfsprogs \
 		xz-utils \

--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -8,18 +8,22 @@ import (
 	"golang.org/x/net/context"
 )
 
-type readCloserWrapper struct {
+// ReadCloserWrapper wraps an io.Reader, and implements an io.ReadCloser
+// It calls the given callback function when closed. It should be constructed
+// with NewReadCloserWrapper
+type ReadCloserWrapper struct {
 	io.Reader
 	closer func() error
 }
 
-func (r *readCloserWrapper) Close() error {
+// Close calls back the passed closer function
+func (r *ReadCloserWrapper) Close() error {
 	return r.closer()
 }
 
 // NewReadCloserWrapper returns a new io.ReadCloser.
 func NewReadCloserWrapper(r io.Reader, closer func() error) io.ReadCloser {
-	return &readCloserWrapper{
+	return &ReadCloserWrapper{
 		Reader: r,
 		closer: closer,
 	}


### PR DESCRIPTION
**- What I did**
The Golang built-in gzip library is serialized, and fairly slow
at decompressing. It also only decompresses on demand, versus
pipelining decompression. This fixes those problems.

**- How I did it**
This change switches to trying to use parallel gzip for gzip decompression as opposed to the 
golang one. If it isn't available, it'll fall back to the default. This code path can also be disabled by environment variable.

**- How to verify it**
There are existing tests for this codepath to ensure correctness of this implementation. I ran some manual benchmarks, and I found I was able to get about 50% better performance as opposed to the build in library. These performance gains were primarily seen on images with layers about 10MB.

**- Description for the changelog**
Make image (layer) downloads faster by using pgzip

