### PR TITLE
Add a debug message when client closes websocket attach connection

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -593,7 +593,11 @@ func (s *containerRouter) wsContainersAttach(ctx context.Context, w http.Respons
 	close(done)
 	select {
 	case <-started:
-		logrus.Errorf("Error attaching websocket: %s", err)
+		if err != nil {
+			logrus.Errorf("Error attaching websocket: %s", err)
+		} else {
+			logrus.Debug("websocket connection was closed by client")
+		}
 		return nil
 	default:
 	}


### PR DESCRIPTION
**- What I did**

When the client closes connections that send containers output through websocket, an error message is displayed:
`Error attaching websocket: %!s(<nil>)`

This message is misleading. 

**- How I did it**

This change suggests to check if `error` is `nil` and print the correct message accordingly.
If `error` is not `nil`, print `Error attaching websocket:`. Otherwise, `websocket connection was closed by client`.

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

