### PR TITLE
Fix codegen problems in swagger spec

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -254,6 +254,7 @@ definitions:
         properties:
           Propagation:
             description: "A propagation mode with the value `[r]private`, `[r]shared`, or `[r]slave`."
+            type: "string"
             enum:
               - "private"
               - "rprivate"
@@ -823,9 +824,7 @@ definitions:
           type: "string"
       Cmd:
         description: "Command to run specified as a string or an array of strings."
-        type:
-          - "array"
-          - "string"
+        type: "array"
         items:
           type: "string"
       Healthcheck:
@@ -853,9 +852,7 @@ definitions:
           The entry point for the container as a string or an array of strings.
 
           If the array consists of exactly one empty string (`[""]`) then the entry point is reset to system default (i.e., the entry point used by docker when there is no `ENTRYPOINT` instruction in the `Dockerfile`).
-        type:
-          - "array"
-          - "string"
+        type: "array"
         items:
           type: "string"
       NetworkDisabled:


### PR DESCRIPTION
Code generation does't support multiple types, and an enum was missing a type.

`Cmd`, and `Entrypoint` should only be used as arrays anyway. The client has had this behaviour for a while now.