### PR TITLE
Splunk logger update to include a flat format

### DIFF
--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -113,6 +113,12 @@ type splunkLoggerRaw struct {
 	prefix []byte
 }
 
+type splunkLoggerFlat struct {
+	*splunkLogger
+
+	nullEvent *splunkMessageEvent
+}
+
 type splunkMessage struct {
 	Event      interface{} `json:"event"`
 	Time       string      `json:"time"`
@@ -133,16 +139,8 @@ const (
 	splunkFormatRaw    = "raw"
 	splunkFormatJSON   = "json"
 	splunkFormatInline = "inline"
+	splunkFormatFlat   = "flat"
 )
-
-func init() {
-	if err := logger.RegisterLogDriver(driverName, New); err != nil {
-		logrus.Fatal(err)
-	}
-	if err := logger.RegisterLogOptValidator(driverName, ValidateLogOpt); err != nil {
-		logrus.Fatal(err)
-	}
-}
 
 // New creates splunk logger driver using configuration passed in context
 func New(info logger.Info) (logger.Logger, error) {
@@ -207,7 +205,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		}
 		gzipCompressionLevel = int(gzipCompressionLevel64)
 		if gzipCompressionLevel < gzip.DefaultCompression || gzipCompressionLevel > gzip.BestCompression {
-			err := fmt.Errorf("not supported level '%s' for %s (supported values between %d and %d)",
+			err := fmt.Errorf("Not supported level '%s' for %s (supported values between %d and %d).",
 				gzipCompressionLevelStr, splunkGzipCompressionLevelKey, gzip.DefaultCompression, gzip.BestCompression)
 			return nil, err
 		}
@@ -288,8 +286,9 @@ func New(info logger.Info) (logger.Logger, error) {
 		case splunkFormatInline:
 		case splunkFormatJSON:
 		case splunkFormatRaw:
+		case splunkFormatFlat:
 		default:
-			return nil, fmt.Errorf("Unknown format specified %s, supported formats are inline, json and raw", splunkFormat)
+			return nil, fmt.Errorf("Unknown format specified %s, supported formats are inline, json, raw, and flat", splunkFormat)
 		}
 		splunkFormat = splunkFormatParsed
 	} else {
@@ -313,6 +312,13 @@ func New(info logger.Info) (logger.Logger, error) {
 		}
 
 		loggerWrapper = &splunkLoggerJSON{&splunkLoggerInline{logger, nullEvent}}
+	case splunkFormatFlat:
+		nullEvent := &splunkMessageEvent{
+			Tag:   tag,
+			Attrs: attrs,
+		}
+
+		loggerWrapper = &splunkLoggerFlat{logger, nullEvent}
 	case splunkFormatRaw:
 		var prefix bytes.Buffer
 		if tag != "" {
@@ -366,12 +372,18 @@ func (l *splunkLoggerJSON) Log(msg *logger.Message) error {
 	return l.queueMessageAsync(message)
 }
 
-func (l *splunkLoggerRaw) Log(msg *logger.Message) error {
-	// empty or whitespace-only messages are not accepted by HEC
-	if strings.TrimSpace(string(msg.Line)) == "" {
-		return nil
-	}
+func (l *splunkLoggerFlat) Log(msg *logger.Message) error {
+	message := l.createSplunkMessage(msg)
+	event := *l.nullEvent
 
+	message.Event = string(msg.Line)
+	message.Source = string(event.Tag)
+
+	logger.PutMessage(msg)
+	return l.queueMessageAsync(message)
+}
+
+func (l *splunkLoggerRaw) Log(msg *logger.Message) error {
 	message := l.createSplunkMessage(msg)
 
 	message.Event = string(append(l.prefix, msg.Line...))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
New flat format added to the Splunk logger. We want to use this at the daemon level but there is currently a bug where we can't use custom logging plugins: https://github.com/moby/moby/issues/35553. This seems to be the fastest path.

**- How I did it**
We want the line in the JSON format to be the raw text (without the prefix). The tag makes more sense as the source.

**- How to verify it**
Test case added

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
New flat format added to the Splunk logger

**- A picture of a cute animal (not mandatory but encouraged)**

