### PR TITLE
gitutils: fix checking out submodules

### DIFF
--- a/builder/remotecontext/git/gitutils_test.go
+++ b/builder/remotecontext/git/gitutils_test.go
@@ -234,17 +234,17 @@ func TestCheckoutGit(t *testing.T) {
 		if c.fail {
 			assert.Error(t, err)
 			continue
-		} else {
+		}
+		require.NoError(t, err)
+		defer os.RemoveAll(r)
+		if c.submodule {
+			b, err := ioutil.ReadFile(filepath.Join(r, "sub/subfile"))
 			require.NoError(t, err)
-			if c.submodule {
-				b, err := ioutil.ReadFile(filepath.Join(r, "sub/subfile"))
-				require.NoError(t, err)
-				assert.Equal(t, "subcontents", string(b))
-			} else {
-				_, err := os.Stat(filepath.Join(r, "sub/subfile"))
-				require.Error(t, err)
-				require.True(t, os.IsNotExist(err))
-			}
+			assert.Equal(t, "subcontents", string(b))
+		} else {
+			_, err := os.Stat(filepath.Join(r, "sub/subfile"))
+			require.Error(t, err)
+			require.True(t, os.IsNotExist(err))
 		}
 
 		b, err := ioutil.ReadFile(filepath.Join(r, "Dockerfile"))


### PR DESCRIPTION
Fix issue reported in https://github.com/moby/moby/pull/32502#issuecomment-349873402

In addition to adding new command, this also separates the internal clone function so that the test actually tests the commands instead of just validating the commands strings.

@ijc @dnephin @lgarithm

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
