### PR TITLE
Bump API version to 1.36

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion string = "1.35"
+	DefaultVersion string = "1.36"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.35"
+basePath: "/v1.36"
 info:
   title: "Docker Engine API"
-  version: "1.35"
+  version: "1.36"
   x-logo:
     url: "https://docs.docker.com/images/logo-docker-main.png"
   description: |
@@ -49,8 +49,8 @@ info:
     the URL is not supported by the daemon, a HTTP `400 Bad Request` error message
     is returned.
 
-    If you omit the version-prefix, the current version of the API (v1.35) is used.
-    For example, calling `/info` is the same as calling `/v1.35/info`. Using the
+    If you omit the version-prefix, the current version of the API (v1.36) is used.
+    For example, calling `/info` is the same as calling `/v1.36/info`. Using the
     API without a version-prefix is deprecated and will be removed in a future release.
 
     Engine releases in the near future should support this version of the API,

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,11 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.36 API changes
+
+[Docker Engine API v1.36](https://docs.docker.com/engine/api/v1.36/) documentation
+
+
 ## v1.35 API changes
 
 [Docker Engine API v1.35](https://docs.docker.com/engine/api/v1.35/) documentation


### PR DESCRIPTION
API v1.35 was cut off at https://github.com/moby/moby/commit/a023a599913439f0a08adffc3f242ce187fd8bdd

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
+ Bump API version to v1.35 [moby/moby#35738](https://github.com/moby/moby/pull/35738)
```