### PR TITLE
Remove uneeded sleep in test bash loop

### DIFF
--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -151,7 +151,7 @@ func (s *DockerSuite) TestLogsAPIUntilFutureFollow(c *check.C) {
 
 func (s *DockerSuite) TestLogsAPIUntil(c *check.C) {
 	name := "logsuntil"
-	dockerCmd(c, "run", "--name", name, "busybox", "/bin/sh", "-c", "for i in $(seq 1 3); do echo log$i; sleep 0.5; done")
+	dockerCmd(c, "run", "--name", name, "busybox", "/bin/sh", "-c", "for i in $(seq 1 3); do echo log$i; done")
 
 	client, err := request.NewClient()
 	if err != nil {


### PR DESCRIPTION
This sleep probably doesn't work because sleep typcially takes only
whole numbers, to do < 1s you need to use usleep. It also is not really
needed as the loop has a very low bound that will not eat up too much
CPU.