### PR TITLE
Update go-swagger installation steps in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,9 +145,12 @@ RUN pip install yamllint==1.5.0
 
 # Install go-swagger for validating swagger.yaml
 ENV GO_SWAGGER_COMMIT c28258affb0b6251755d92489ef685af8d4ff3eb
-RUN git clone https://github.com/go-swagger/go-swagger.git /go/src/github.com/go-swagger/go-swagger \
-	&& (cd /go/src/github.com/go-swagger/go-swagger && git checkout -q $GO_SWAGGER_COMMIT) \
-	&& go install -v github.com/go-swagger/go-swagger/cmd/swagger
+RUN set -x \
+	&& export GOPATH="$(mktemp -d)" \
+	&& git clone https://github.com/go-swagger/go-swagger.git "$GOPATH/src/github.com/go-swagger/go-swagger" \
+	&& (cd "$GOPATH/src/github.com/go-swagger/go-swagger" && git checkout -q "$GO_SWAGGER_COMMIT") \
+	&& go build -o /usr/local/bin/swagger github.com/go-swagger/go-swagger/cmd/swagger \
+	&& rm -rf "$GOPATH"
 
 # Set user.email so crosbymichael's in-container merge commits go smoothly
 RUN git config --global user.email 'docker-dummy@example.com'

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -118,9 +118,12 @@ RUN pip install yamllint==1.5.0
 
 # Install go-swagger for validating swagger.yaml
 ENV GO_SWAGGER_COMMIT c28258affb0b6251755d92489ef685af8d4ff3eb
-RUN git clone https://github.com/go-swagger/go-swagger.git /go/src/github.com/go-swagger/go-swagger \
-	&& (cd /go/src/github.com/go-swagger/go-swagger && git checkout -q $GO_SWAGGER_COMMIT) \
-	&& go install -v github.com/go-swagger/go-swagger/cmd/swagger
+RUN set -x \
+	&& export GOPATH="$(mktemp -d)" \
+	&& git clone https://github.com/go-swagger/go-swagger.git "$GOPATH/src/github.com/go-swagger/go-swagger" \
+	&& (cd "$GOPATH/src/github.com/go-swagger/go-swagger" && git checkout -q "$GO_SWAGGER_COMMIT") \
+	&& go build -o /usr/local/bin/swagger github.com/go-swagger/go-swagger/cmd/swagger \
+	&& rm -rf "$GOPATH"
 
 # Set user.email so crosbymichael's in-container merge commits go smoothly
 RUN git config --global user.email 'docker-dummy@example.com'


### PR DESCRIPTION
The installation steps for go-swagger was a bit noisy, and not consistent with
other installation steps.

<details>
<summary>Output before</summary>

```
RUN git clone https://github.com/go-swagger/go-swagger.git /go/src/github.com/go-swagger/go-swagger 	&& (cd /go/src/github.com/go-swagger/go-swagger && git checkout -q $GO_SWAGGER_COMMIT) 	&& go install -v github.com/go-swagger/go-swagger/cmd/swagger
 ---> Running in ace220f01383
Cloning into '/go/src/github.com/go-swagger/go-swagger'...
github.com/go-swagger/go-swagger/vendor/github.com/mailru/easyjson/buffer
github.com/go-swagger/go-swagger/vendor/github.com/mailru/easyjson/jlexer
github.com/go-swagger/go-swagger/vendor/github.com/mailru/easyjson/jwriter
github.com/go-swagger/go-swagger/vendor/github.com/PuerkitoBio/urlesc
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/swag
github.com/go-swagger/go-swagger/vendor/golang.org/x/net/idna
github.com/go-swagger/go-swagger/vendor/golang.org/x/text/internal/tag
github.com/go-swagger/go-swagger/vendor/golang.org/x/text/language
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/jsonpointer
github.com/go-swagger/go-swagger/vendor/golang.org/x/text/transform
github.com/go-swagger/go-swagger/vendor/golang.org/x/text/unicode/norm
github.com/go-swagger/go-swagger/vendor/golang.org/x/text/internal
github.com/go-swagger/go-swagger/vendor/golang.org/x/text/runes
github.com/go-swagger/go-swagger/vendor/golang.org/x/text/unicode/bidi
github.com/go-swagger/go-swagger/vendor/golang.org/x/text/cases
github.com/go-swagger/go-swagger/vendor/golang.org/x/text/secure/bidirule
github.com/go-swagger/go-swagger/vendor/golang.org/x/text/width
github.com/go-swagger/go-swagger/vendor/gopkg.in/yaml.v2
github.com/go-swagger/go-swagger/vendor/golang.org/x/text/secure/precis
github.com/go-swagger/go-swagger/vendor/github.com/PuerkitoBio/purell
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/jsonreference
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/spec
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/loads/fmts
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/errors
github.com/go-swagger/go-swagger/vendor/github.com/asaskevich/govalidator
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/analysis
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/loads
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/strfmt
github.com/go-swagger/go-swagger/vendor/golang.org/x/net/context
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/runtime/middleware/denco
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/runtime/middleware/header
github.com/go-swagger/go-swagger/vendor/github.com/gorilla/context
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/runtime
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/inflect
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/runtime/middleware/untyped
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/runtime/security
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/validate
github.com/go-swagger/go-swagger/vendor/golang.org/x/sys/unix
github.com/go-swagger/go-swagger/vendor/github.com/go-openapi/runtime/middleware
github.com/go-swagger/go-swagger/vendor/github.com/fsnotify/fsnotify
github.com/go-swagger/go-swagger/vendor/github.com/hashicorp/hcl/hcl/strconv
github.com/go-swagger/go-swagger/vendor/github.com/hashicorp/hcl/hcl/token
github.com/go-swagger/go-swagger/vendor/github.com/hashicorp/hcl/hcl/ast
github.com/go-swagger/go-swagger/vendor/github.com/hashicorp/hcl/hcl/scanner
github.com/go-swagger/go-swagger/vendor/github.com/hashicorp/hcl/json/token
github.com/go-swagger/go-swagger/vendor/github.com/hashicorp/hcl/json/scanner
github.com/go-swagger/go-swagger/vendor/github.com/hashicorp/hcl/hcl/parser
github.com/go-swagger/go-swagger/vendor/github.com/hashicorp/hcl/json/parser
github.com/go-swagger/go-swagger/vendor/github.com/magiconair/properties
github.com/go-swagger/go-swagger/vendor/github.com/hashicorp/hcl
github.com/go-swagger/go-swagger/vendor/github.com/mitchellh/mapstructure
github.com/go-swagger/go-swagger/vendor/github.com/pelletier/go-buffruneio
github.com/go-swagger/go-swagger/vendor/github.com/pelletier/go-toml
github.com/go-swagger/go-swagger/vendor/github.com/kr/fs
github.com/go-swagger/go-swagger/vendor/github.com/pkg/errors
github.com/go-swagger/go-swagger/vendor/golang.org/x/crypto/curve25519
github.com/go-swagger/go-swagger/vendor/golang.org/x/crypto/ed25519/internal/edwards25519
github.com/go-swagger/go-swagger/vendor/golang.org/x/crypto/ed25519
github.com/go-swagger/go-swagger/vendor/golang.org/x/crypto/ssh
github.com/go-swagger/go-swagger/vendor/github.com/spf13/afero/mem
github.com/go-swagger/go-swagger/vendor/github.com/spf13/cast
github.com/go-swagger/go-swagger/vendor/github.com/spf13/jwalterweatherman
github.com/go-swagger/go-swagger/vendor/github.com/spf13/pflag
github.com/go-swagger/go-swagger/vendor/golang.org/x/tools/go/ast/astutil
github.com/go-swagger/go-swagger/vendor/golang.org/x/tools/imports
github.com/go-swagger/go-swagger/vendor/github.com/pkg/sftp
github.com/go-swagger/go-swagger/vendor/golang.org/x/tools/go/buildutil
github.com/go-swagger/go-swagger/vendor/golang.org/x/tools/go/loader
github.com/go-swagger/go-swagger/vendor/github.com/spf13/afero/sftp
github.com/go-swagger/go-swagger/vendor/github.com/spf13/afero
github.com/go-swagger/go-swagger/scan
github.com/go-swagger/go-swagger/vendor/github.com/spf13/viper
github.com/go-swagger/go-swagger/generator
github.com/go-swagger/go-swagger/vendor/github.com/jessevdk/go-flags
github.com/go-swagger/go-swagger/cmd/swagger/commands/initcmd
github.com/go-swagger/go-swagger/vendor/github.com/gorilla/handlers
github.com/go-swagger/go-swagger/cmd/swagger/commands/generate
github.com/go-swagger/go-swagger/vendor/github.com/toqueteos/webbrowser
github.com/go-swagger/go-swagger/vendor/github.com/tylerb/graceful
github.com/go-swagger/go-swagger/cmd/swagger/commands
github.com/go-swagger/go-swagger/cmd/swagger
```

</details>

<details>
<summary>Output after</summary>

```
Step 20/39 : RUN set -x 	&& export GOPATH="$(mktemp -d)" 	&& git clone https://github.com/go-swagger/go-swagger.git "$GOPATH/src/github.com/go-swagger/go-swagger" 	&& (cd "$GOPATH/src/github.com/go-swagger/go-swagger" && git checkout -q "$GO_SWAGGER_COMMIT") 	&& go build -o /usr/local/bin/swagger github.com/go-swagger/go-swagger/cmd/swagger 	&& rm -rf "$GOPATH"
 ---> Running in 46bb96147a46
+ mktemp -d
+ export GOPATH=/tmp/tmp.EiBckTAo3o
+ git clone https://github.com/go-swagger/go-swagger.git /tmp/tmp.EiBckTAo3o/src/github.com/go-swagger/go-swagger
Cloning into '/tmp/tmp.EiBckTAo3o/src/github.com/go-swagger/go-swagger'...
+ cd /tmp/tmp.EiBckTAo3o/src/github.com/go-swagger/go-swagger
+ git checkout -q c28258affb0b6251755d92489ef685af8d4ff3eb
+ go build -o /usr/local/bin/swagger github.com/go-swagger/go-swagger/cmd/swagger
+ rm -rf /tmp/tmp.EiBckTAo3o
```

</details>


This patch makes it similar to other steps, which makes it less noisy, and
makes the image slightly smaller.

Before:

    b53d7aac3200  14 minutes ago  …   107MB
    fa74acf32f99  2 hours ago     …   0B 

After:

    b53d7aac3200  10 minutes ago  …   35.2MB
    fa74acf32f99  2 hours ago     …   0B 

**- A picture of a cute animal (not mandatory but encouraged)**

![deep-sea-angler-fish-is-an-important-predator-in-the-abyss-600x450](https://user-images.githubusercontent.com/1804568/33787230-344f5c8e-dc21-11e7-86f1-b47c2364dd5b.jpg)
