### PR TITLE
install-containerd-static: use netgo buildtag

### DIFF
--- a/hack/dockerfile/install-binaries.sh
+++ b/hack/dockerfile/install-binaries.sh
@@ -48,7 +48,7 @@ install_containerd_static() {
 	git checkout -q "$CONTAINERD_COMMIT"
 	(
 		export GOPATH
-		make BUILDTAGS='static_build' EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"'
+		make BUILDTAGS='static_build netgo' EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"'
 	)
 	cp bin/containerd /usr/local/bin/docker-containerd
 	cp bin/containerd-shim /usr/local/bin/docker-containerd-shim


### PR DESCRIPTION
When compiling containerd binaries statically, linker rightfully complains:
```
 + make BUILDTAGS=static_build 'EXTRA_FLAGS=-buildmode pie' 'EXTRA_LDFLAGS=-extldflags "-fno-PIC -static"'
 🇩 bin/ctr
 # github.com/containerd/containerd/cmd/ctr
 /tmp/go-link-343047789/000000.o: In function `_cgo_b0c710f30cfd_C2func_getaddrinfo':
 /tmp/go-build/net/_obj/cgo-gcc-prolog:46: warning: Using 'getaddrinfo'
 in statically linked applications requires at runtime the shared
 libraries from the glibc version used for linking
```

The same error appears for `ctr`, `containerd`, and `containerd-stress` binaries.

The fix is to use Go's own DNS resolver functions, rather than glibc's `getaddrinfo()` which is not expected to work in a static binary. The option to use Go internal implementation is turned on by `netgo` build tag.

See https://golang.org/pkg/net/ (look for "Name Resolution") for more details.
