### PR TITLE
Update Graylog2/go-gelf vendoring. Fixes #35613

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -77,7 +77,7 @@ github.com/syndtr/gocapability 2c00daeb6c3b45114c80ac44119e7b8801fdd852
 github.com/golang/protobuf 7a211bcf3bce0e3f1d74f9894916e6f116ae83b4
 
 # gelf logging driver deps
-github.com/Graylog2/go-gelf v2
+github.com/Graylog2/go-gelf ba920adcee0319adcc15f52851f1458f56547975
 
 github.com/fluent/fluent-logger-golang v1.3.0
 # fluent-logger-golang deps

--- a/vendor.conf
+++ b/vendor.conf
@@ -77,7 +77,7 @@ github.com/syndtr/gocapability 2c00daeb6c3b45114c80ac44119e7b8801fdd852
 github.com/golang/protobuf 7a211bcf3bce0e3f1d74f9894916e6f116ae83b4
 
 # gelf logging driver deps
-github.com/Graylog2/go-gelf ba920adcee0319adcc15f52851f1458f56547975
+github.com/Graylog2/go-gelf 4143646226541087117ff2f83334ea48b3201841
 
 github.com/fluent/fluent-logger-golang v1.3.0
 # fluent-logger-golang deps

--- a/vendor/github.com/Graylog2/go-gelf/gelf/writer.go
+++ b/vendor/github.com/Graylog2/go-gelf/gelf/writer.go
@@ -27,5 +27,8 @@ type GelfWriter struct {
 
 // Close connection and interrupt blocked Read or Write operations
 func (w *GelfWriter) Close() error {
+	if w.conn == nil {
+		return nil
+	}
 	return w.conn.Close()
 }


### PR DESCRIPTION
**- What I did**

Updated the vendoring of Graylog2/go-gelf to get the latest bug fix. Fixes #35613.

**- How I did it**

Simply fetch the changes with vndr.

**- How to verify it**

1. start something to imitate log server ex: "nc -l -p 12000"
2. start something to imitate log server ex: "nc -l -p 12000"
3. start container "docker run --rm -it --log-driver gelf --log-opt gelf-address=tcp://127.0.0.1:12000 debian bash"
4. type something in the container's terminal (generate some logs)
5. stop the nc process
6. type something again in the container's terminal (generate some more logs)

Validate that the docker daemon does not crash.

**- Description for the changelog**

Fixed daemon crash when using the GELF log driver over TCP when the GELF server goes down.

**- A picture of a cute animal (not mandatory but encouraged)**

