### PR TITLE
Make TestLogsAPIUntil less flaky

### DIFF
--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -151,7 +151,7 @@ func (s *DockerSuite) TestLogsAPIUntilFutureFollow(c *check.C) {
 
 func (s *DockerSuite) TestLogsAPIUntil(c *check.C) {
 	name := "logsuntil"
-	dockerCmd(c, "run", "--name", name, "busybox", "/bin/sh", "-c", "for i in $(seq 1 3); do echo log$i; done")
+	dockerCmd(c, "run", "--name", name, "busybox", "/bin/sh", "-c", "for i in $(seq 1 3); do echo log$i; sleep 1; done")
 
 	client, err := request.NewClient()
 	if err != nil {


### PR DESCRIPTION
Commit https://github.com/moby/moby/commit/ee594dcb7d42f95048c9047d86c61447243db3cd (https://github.com/moby/moby/pull/35745) removed the `sleep 0.5` from this test, because sleep has a full-second precision. However, in some cases, all three log-entries are output at the same time, causing the `--until` filter to fail.

This patch adds back a `sleep`, but uses 1 second instead.

ping @cpuguy83 @dnephin @vdemeester PTAL