### PR TITLE
Download support of images with multi-arch manifest

### DIFF
--- a/hack/make/.detect-daemon-osarch
+++ b/hack/make/.detect-daemon-osarch
@@ -64,7 +64,9 @@ case "$PACKAGE_ARCH" in
 		;;
 	*)
 		DOCKERFILE="Dockerfile.$PACKAGE_ARCH"
-		TEST_IMAGE_NAMESPACE="$PACKAGE_ARCH"
+		if [ "$PACKAGE_ARCH" != "aarch64" ]; then
+			TEST_IMAGE_NAMESPACE="$PACKAGE_ARCH"
+		fi
 		;;
 esac
 export DOCKERFILE TEST_IMAGE_NAMESPACE


### PR DESCRIPTION
Currently we only support 'application/vnd.docker.distribution.manifest.v2+json'
manifest images download, with more multi-arch images used, we need to support
download images with 'application/vnd.docker.distribution.manifest.list.v2+json'
format(aka "fat manifest"), else we will fail to download those multi-arch images.

This PR adds 'application/vnd.docker.distribution.manifest.list.v2+json' manifest
support, thus we can download both multi-arch and legacy images.

Fix: #35841

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add 'application/vnd.docker.distribution.manifest.list.v2+json' manifest images download support. 
**- How I did it**
Get the first level manifest, if it's a 'fat manifest', then get the 2nd level manifest which can match the run time arch.
**- How to verify it**
After apply the patch, `make binary` & `make  test-integration` upon both legacy and multi-arch docker images, on both arm64 and amd64 platforms.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![summit](https://user-images.githubusercontent.com/29669302/33869898-47b2b762-df46-11e7-99ef-bc1e21734d27.jpg)

