### PR TITLE
Add storage options to build options

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -146,6 +146,15 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 		options.Labels = labels
 	}
 
+	storageOptJSON := r.FormValue("storageopt")
+	if storageOptJSON != "" {
+		var storageOpt = map[string]string{}
+		if err := json.Unmarshal([]byte(storageOptJSON), &storageOpt); err != nil {
+			return nil, errors.Wrap(validationError{err}, "error reading storage options")
+		}
+		options.StorageOpt = storageOpt
+	}
+
 	cacheFromJSON := r.FormValue("cachefrom")
 	if cacheFromJSON != "" {
 		var cacheFrom = []string{}

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -177,6 +177,7 @@ type ImageBuildOptions struct {
 	// specified here do not need to have a valid parent chain to match cache.
 	CacheFrom   []string
 	SecurityOpt []string
+	StorageOpt  map[string]string
 	ExtraHosts  []string // List of extra hosts
 	Target      string
 	SessionID   string

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -536,6 +536,7 @@ func hostConfigFromOptions(options *types.ImageBuildOptions) *container.HostConf
 
 	return &container.HostConfig{
 		SecurityOpt: options.SecurityOpt,
+		StorageOpt:  options.StorageOpt,
 		Isolation:   options.Isolation,
 		ShmSize:     options.ShmSize,
 		Resources:   resources,

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -123,6 +123,12 @@ func (cli *Client) imageBuildOptionsToQuery(options types.ImageBuildOptions) (ur
 	}
 	query.Set("labels", string(labelsJSON))
 
+	storageOptJSON, err := json.Marshal(options.StorageOpt)
+	if err != nil {
+		return query, err
+	}
+	query.Set("storageopt", string(storageOptJSON))
+
 	cacheFromJSON, err := json.Marshal(options.CacheFrom)
 	if err != nil {
 		return query, err


### PR DESCRIPTION
Signed-off-by: John Stephens <johnstep@docker.com>

This addresses builder support in the daemon needed for https://github.com/moby/moby/issues/34947, allowing storage options to be passed to the graph driver. Per that issue, the default Windows read-write layer size of 20 GB is too small in some cases. This allows it to be set per build instead of requiring global configuration.