### PR TITLE
Windows: Case-insensitive filename matching against builder cache

### DIFF
--- a/pkg/tarsum/fileinfosums.go
+++ b/pkg/tarsum/fileinfosums.go
@@ -1,6 +1,10 @@
 package tarsum
 
-import "sort"
+import (
+	"runtime"
+	"sort"
+	"strings"
+)
 
 // FileInfoSumInterface provides an interface for accessing file checksum
 // information within a tar file. This info is accessed through interface
@@ -35,8 +39,11 @@ type FileInfoSums []FileInfoSumInterface
 
 // GetFile returns the first FileInfoSumInterface with a matching name.
 func (fis FileInfoSums) GetFile(name string) FileInfoSumInterface {
+	// We do case insensitive matching on Windows as c:\APP and c:\app are
+	// the same. See issue #33107.
 	for i := range fis {
-		if fis[i].Name() == name {
+		if (runtime.GOOS == "windows" && strings.EqualFold(fis[i].Name(), name)) ||
+			(runtime.GOOS != "windows" && fis[i].Name() == name) {
 			return fis[i]
 		}
 	}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This fixes #33107 where if a local directory is in uppercase and a docker build is run, then a file in that directory is altered and another build is run, it uses the cache rather than taking the update. This is because the comparison was being done exactly, where-as on Windows, c:\app and c:\APP are the same on NTFS.  See https://github.com/moby/moby/issues/33107#issuecomment-347700140

Given this build context (note the `App` directory has an upper-case letter in it):

```
PS E:\docker\build\33107> dir -r


    Directory: E:\docker\build\33107


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----       12/13/2017   3:46 PM                App
-a----       11/28/2017   3:16 PM            339 dockerfile


    Directory: E:\docker\build\33107\App


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----       12/13/2017  12:30 PM                UPPER
-a----       11/28/2017   2:48 PM              6 addedfile.aspx.cs
-a----       11/28/2017   3:13 PM              6 new1
-a----       11/28/2017   2:47 PM              6 somefile.aspx.cs
-a----       11/28/2017   3:28 PM            284 tEsT.txt
```

And this dockerfile content:
```
# escape=`
FROM microsoft/windowsservercore
RUN powershell md c:\app
COPY app c:\app
```

Here's the output from docker master 1cea9d3bdb427bbdd7f14c6b11a3f6cef332bd34 12/13/2017 showing the bug:

First build, forcing no-cache.
```
PS E:\docker\build\33107> docker build --no-cache .
Sending build context to Docker daemon  7.168kB
Step 1/3 : FROM microsoft/windowsservercore
 ---> 511077485562
Step 2/3 : RUN powershell md c:\app
 ---> Running in ed9b684e05e0


    Directory: C:\


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----       12/13/2017   4:35 PM                app


Removing intermediate container ed9b684e05e0
 ---> 3644daaaa31f
Step 3/3 : COPY app c:\app
 ---> 9250b3aad8cd
Successfully built 9250b3aad8cd
PS E:\docker\build\33107>
```

Update the contents of `app\test.txt`
```
PS E:\docker\build\33107> type .\App\test.txt
 FROM microsoft/windowsservercore
RUN dism /online /enable-feature /all /featurename:iis-webserver /NoRestart
RUNEXPOSE 8081
RUN powershell Remove-Website -Name 'Default Web Site'
RUN powershell md c:\
RUN powershell New-Website -Name 'app' -Port 8081 -PhysicalPath 'c:\app'

changed asjdfklasjdf
PS E:\docker\build\33107> echo "foobar" > .\App\test.txt
PS E:\docker\build\33107>
```

And build again, you see the bug - step 3 is using the cache when it shouldn't.
```
PS E:\docker\build\33107> docker build .
Sending build context to Docker daemon  7.168kB
Step 1/3 : FROM microsoft/windowsservercore
 ---> 511077485562
Step 2/3 : RUN powershell md c:\app
 ---> Using cache
 ---> 3644daaaa31f
Step 3/3 : COPY app c:\app
 ---> Using cache
 ---> 9250b3aad8cd
Successfully built 9250b3aad8cd
PS E:\docker\build\33107>
```

With this fix, you get the following instead. First, build forcing a cache-miss:
```
PS E:\docker\build\33107> docker build --no-cache .
Sending build context to Docker daemon  7.168kB
Step 1/3 : FROM microsoft/windowsservercore
 ---> 511077485562
Step 2/3 : RUN powershell md c:\app
 ---> Running in d504a5d35157


    Directory: C:\


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----       12/13/2017   4:39 PM                app


Removing intermediate container d504a5d35157
 ---> 2d0ba8e32f64
Step 3/3 : COPY app c:\app
 ---> e7287a3c2d5f
Successfully built e7287a3c2d5f
PS E:\docker\build\33107>
```

Next, update `app\test.txt again`

```
PS E:\docker\build\33107> type .\App\test.txt
foobar
PS E:\docker\build\33107> echo "fixed" > .\App\test.txt
PS E:\docker\build\33107>
```

And then a build showing that that cache is correctly broken through the changed file in the build context:

```
PS E:\docker\build\33107> docker build .
Sending build context to Docker daemon  7.168kB
Step 1/3 : FROM microsoft/windowsservercore
 ---> 511077485562
Step 2/3 : RUN powershell md c:\app
 ---> Using cache
 ---> 2d0ba8e32f64
Step 3/3 : COPY app c:\app
 ---> 1996084f86f8
Successfully built 1996084f86f8
PS E:\docker\build\33107>
```
