### PR TITLE
Fix overlay2 storage driver inside a user namespace

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -31,6 +31,7 @@ import (
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/go-units"
+	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -704,6 +705,7 @@ func (d *Driver) ApplyDiff(id string, parent string, diff io.Reader) (size int64
 		UIDMaps:        d.uidMaps,
 		GIDMaps:        d.gidMaps,
 		WhiteoutFormat: archive.OverlayWhiteoutFormat,
+		InUserNS:       rsystem.RunningInUserNS(),
 	}); err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
The overlay2 driver was not setting up the `archive.TarOptions` field
for userns properly, like other storage backend routes to "applyTarLayer"
functionality are. The `InUserNS` field is now populated for overlay2 using
the same query function used by the other storage drivers.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

Fixes: #35245