### PR TITLE
Fixed issue of this being a broken api

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/MovieStoreGuy/moby/internal/testutil"
+	"github.com/moby/moby/internal/testutil"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/assert"

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/moby/moby/internal/testutil"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/MovieStoreGuy/moby/internal/testutil"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -92,8 +92,8 @@ func imageDigestAndPlatforms(ctx context.Context, cli DistributionAPIClient, ima
 	if err != nil {
 		return "", nil, err
 	}
-
-	imageWithDigest := imageWithDigestString(image, distributionInspect.Descriptor.Digest)
+	// Type casting fixes issue of not being able to download
+	imageWithDigest := imageWithDigestString(image, digest.Digest(distributionInspect.Descriptor.Digest))
 
 	if len(distributionInspect.Platforms) > 0 {
 		platforms = make([]swarm.Platform, 0, len(distributionInspect.Platforms))


### PR DESCRIPTION
**- What I did**
Got mad that I couldn't use `go get ...` on this library.

**- How I did it**
I changed one line of code.

**- How to verify it**
I was able to compile and use the api again.

**- Description for the changelog**
Enforced type casting on an struct being passed through to a different function.