### PR TITLE
Prevent potential panic in TestLogsAPIUntil

### DIFF
--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -172,6 +172,8 @@ func (s *DockerSuite) TestLogsAPIUntil(c *check.C) {
 
 	// Get timestamp of second log line
 	allLogs := extractBody(c, types.ContainerLogsOptions{Timestamps: true, ShowStdout: true})
+	c.Assert(len(allLogs), checker.GreaterOrEqualThan, 3)
+
 	t, err := time.Parse(time.RFC3339Nano, strings.Split(allLogs[1], " ")[0])
 	c.Assert(err, checker.IsNil)
 	until := t.Format(time.RFC3339Nano)


### PR DESCRIPTION
Seen failing on Windows (https://github.com/moby/moby/pull/35793#issuecomment-351881642):

    22:27:52 ----------------------------------------------------------------------
    22:27:52 PANIC: docker_api_logs_test.go:152: DockerSuite.TestLogsAPIUntil
    22:27:52
    22:27:52 ... Panic: runtime error: index out of range (PC=0x45AC01)
    22:27:52
    22:27:52 d:/CI/CI-7caa30e89/go/src/runtime/asm_amd64.s:509
    22:27:52   in call32
    22:27:52 d:/CI/CI-7caa30e89/go/src/runtime/panic.go:491
    22:27:52   in gopanic
    22:27:52 d:/CI/CI-7caa30e89/go/src/runtime/panic.go:28
    22:27:52   in panicindex
    22:27:52 docker_api_logs_test.go:175
    22:27:52   in DockerSuite.TestLogsAPIUntil
    22:27:52 d:/CI/CI-7caa30e89/go/src/runtime/asm_amd64.s:509
    22:27:52   in call32
    22:27:52 d:/CI/CI-7caa30e89/go/src/reflect/value.go:434
    22:27:52   in Value.call
    22:27:52 d:/CI/CI-7caa30e89/go/src/reflect/value.go:302
    22:27:52   in Value.Call
    22:27:52 c:/gopath/src/github.com/docker/docker/vendor/github.com/go-check/check/check.go:816
    22:27:52   in suiteRunner.forkTest.func1
    22:27:52 c:/gopath/src/github.com/docker/docker/vendor/github.com/go-check/check/check.go:672
    22:27:52   in suiteRunner.forkCall.func1
    22:27:52 d:/CI/CI-7caa30e89/go/src/runtime/asm_amd64.s:2337
    22:27:52   in goexit
    22:27:54
    22:27:54 ----------------------------------------------------------------------


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
