### PR TITLE
skip container ID remapping, if the file is overlayfs whiteout.

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -456,10 +456,16 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 		}
 	}
 
+	//check whether the file is overlayfs whiteout
+	//if yes, skip re-mapping container ID mappings.
+	isOverlayWhiteout := fi.Mode()&os.ModeCharDevice != 0 && hdr.Devmajor == 0 && hdr.Devminor == 0
+
 	//handle re-mapping container ID mappings back to host ID mappings before
 	//writing tar headers/files. We skip whiteout files because they were written
 	//by the kernel and already have proper ownership relative to the host
-	if !strings.HasPrefix(filepath.Base(hdr.Name), WhiteoutPrefix) && !ta.IDMappings.Empty() {
+	if !isOverlayWhiteout &&
+		!strings.HasPrefix(filepath.Base(hdr.Name), WhiteoutPrefix) &&
+		!ta.IDMappings.Empty() {
 		fileIDPair, err := getFileUIDGID(fi.Sys())
 		if err != nil {
 			return err


### PR DESCRIPTION
fixes #35709 

Signed-off-by: Chanhun Jeong <chanhun.jeong@navercorp.com>

**- What I did**
during docker image build,
do check whether the file in intermediate container is overlayfs whiteout (0/0 device).
if then, skip uid/gid remapping.

**- How I did it**
using AUFS, dockerd skips its whiteout file,
but not for overlayfs.

**- How to verify it**
with userns, overlay2 storage driver,
do below,
```
docker build -f - . <<<$'FROM centos\nRUN ls -lad /etc/se*; rm -v /etc/services\nRUN ls -lad /etc/se*'
```
then check whether the file /etc/services is removed.

**- Description for the changelog**
skip container ID remapping, if the file is overlayfs whiteout.

**- A picture of a cute animal (not mandatory but encouraged)**
: - ()

  