### PR TITLE
Fix VFS vs quota regression

### DIFF
--- a/daemon/graphdriver/quota/projectquota.go
+++ b/daemon/graphdriver/quota/projectquota.go
@@ -350,11 +350,17 @@ func makeBackingFsDev(home string) (string, error) {
 	backingFsBlockDev := path.Join(home, "backingFsBlockDev")
 	// Re-create just in case someone copied the home directory over to a new device
 	unix.Unlink(backingFsBlockDev)
-	if err := unix.Mknod(backingFsBlockDev, unix.S_IFBLK|0600, int(stat.Dev)); err != nil {
+	err := unix.Mknod(backingFsBlockDev, unix.S_IFBLK|0600, int(stat.Dev))
+	switch err {
+	case nil:
+		return backingFsBlockDev, nil
+
+	case unix.ENOSYS:
+		return "", ErrQuotaNotSupported
+
+	default:
 		return "", fmt.Errorf("Failed to mknod %s: %v", backingFsBlockDev, err)
 	}
-
-	return backingFsBlockDev, nil
 }
 
 func hasQuotaSupport(backingFsBlockDev string) (bool, error) {

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -35,9 +35,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 
-	if err := setupDriverQuota(d); err != nil {
-		return nil, err
-	}
+	setupDriverQuota(d)
 
 	return graphdriver.NewNaiveDiffDriver(d, uidMaps, gidMaps), nil
 }

--- a/daemon/graphdriver/vfs/quota_linux.go
+++ b/daemon/graphdriver/vfs/quota_linux.go
@@ -2,20 +2,21 @@
 
 package vfs
 
-import "github.com/docker/docker/daemon/graphdriver/quota"
+import (
+	"github.com/docker/docker/daemon/graphdriver/quota"
+	"github.com/sirupsen/logrus"
+)
 
 type driverQuota struct {
 	quotaCtl *quota.Control
 }
 
-func setupDriverQuota(driver *Driver) error {
+func setupDriverQuota(driver *Driver) {
 	if quotaCtl, err := quota.NewControl(driver.home); err == nil {
 		driver.quotaCtl = quotaCtl
 	} else if err != quota.ErrQuotaNotSupported {
-		return err
+		logrus.Warnf("Unable to setup quota: %v\n", err)
 	}
-
-	return nil
 }
 
 func (d *Driver) setupQuota(dir string, size uint64) error {


### PR DESCRIPTION
**- What I did**
Fixed https://github.com/moby/moby/issues/35815

**- How I did it**
1. `ENOSYS` from `mknod()` is now treated as "quota not supported".
2. Any errors returned from `quota.NewControl()` are now ignored (and logged).

**- How to verify it**
Start daemon with vfs driver backed by osxfs

**- Description for the changelog**
Fix vfs graph driver failure to initialize because of failure to setup fs quota

