### PR TITLE
[WIP/DO NOT MERGE] libcontainerd use global lock for some ops

### DIFF
--- a/libcontainerd/client_daemon.go
+++ b/libcontainerd/client_daemon.go
@@ -276,7 +276,9 @@ func (c *client) Start(ctx context.Context, id, checkpointDir string, withStdin 
 		return -1, err
 	}
 
+	c.Lock()
 	ctr.setTask(t)
+	c.Unlock()
 
 	// Signal c.createIO that it can call CloseIO
 	close(stdinCloseSync)
@@ -286,7 +288,9 @@ func (c *client) Start(ctx context.Context, id, checkpointDir string, withStdin 
 			c.logger.WithError(err).WithField("container", id).
 				Error("failed to delete task after fail start")
 		}
+		c.Lock()
 		ctr.setTask(nil)
+		c.Unlock()
 		return -1, err
 	}
 
@@ -472,9 +476,11 @@ func (c *client) DeleteTask(ctx context.Context, containerID string) (uint32, ti
 		return 255, time.Now(), nil
 	}
 
-	if ctr := c.getContainer(containerID); ctr != nil {
+	c.Lock()
+	if ctr, ok := c.containers[containerID]; ok {
 		ctr.setTask(nil)
 	}
+	c.Unlock()
 	return status.ExitCode(), status.ExitTime(), nil
 }
 
@@ -678,7 +684,10 @@ func (c *client) processEvent(ctr *container, et EventType, ei EventInfo) {
 					"process":   ei.ProcessID,
 				}).Warn("failed to delete process")
 			}
+
+			c.Lock()
 			ctr.deleteProcess(ei.ProcessID)
+			c.Unlock()
 
 			ctr := c.getContainer(ei.ContainerID)
 			if ctr == nil {


### PR DESCRIPTION
647cec4324186faa3183bd6a7bc72a032a86c8c9 changed some of the locking
around in libcontainerd. There now appears to be a deadlock with how we
are interacting with containerd.
This patch seeks to put back the usage of a global lock for certain
client operations for libcontainerd.