### PR TITLE
Perform plugin mounts in the runtime

### DIFF
--- a/daemon/graphdriver/plugin.go
+++ b/daemon/graphdriver/plugin.go
@@ -23,7 +23,7 @@ func newPluginDriver(name string, pl plugingetter.CompatPlugin, config Options) 
 	home := config.Root
 	if !pl.IsV1() {
 		if p, ok := pl.(*v2.Plugin); ok {
-			if p.PropagatedMount != "" {
+			if p.PluginObj.Config.PropagatedMount != "" {
 				home = p.PluginObj.Config.PropagatedMount
 			}
 		}

--- a/daemon/graphdriver/proxy.go
+++ b/daemon/graphdriver/proxy.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/containerfs"
@@ -143,7 +142,7 @@ func (d *graphDriverProxy) Get(id, mountLabel string) (containerfs.ContainerFS, 
 	if ret.Err != "" {
 		err = errors.New(ret.Err)
 	}
-	return containerfs.NewLocalContainerFS(filepath.Join(d.p.BasePath(), ret.Dir)), err
+	return containerfs.NewLocalContainerFS(d.p.ScopedPath(ret.Dir)), err
 }
 
 func (d *graphDriverProxy) Put(id string) error {

--- a/daemon/logger/adapter.go
+++ b/daemon/logger/adapter.go
@@ -3,7 +3,7 @@ package logger
 import (
 	"io"
 	"os"
-	"strings"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -19,7 +19,6 @@ type pluginAdapter struct {
 	driverName   string
 	id           string
 	plugin       logPlugin
-	basePath     string
 	fifoPath     string
 	capabilities Capability
 	logInfo      Info
@@ -58,7 +57,7 @@ func (a *pluginAdapter) Close() error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	if err := a.plugin.StopLogging(strings.TrimPrefix(a.fifoPath, a.basePath)); err != nil {
+	if err := a.plugin.StopLogging(filepath.Join("/", "run", "docker", "logging", a.id)); err != nil {
 		return err
 	}
 

--- a/daemon/metrics_unix.go
+++ b/daemon/metrics_unix.go
@@ -5,13 +5,13 @@ package daemon
 import (
 	"net"
 	"net/http"
-	"os"
 	"path/filepath"
 
-	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/pkg/plugins"
+	"github.com/docker/docker/plugin"
 	metrics "github.com/docker/go-metrics"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -34,52 +34,22 @@ func (daemon *Daemon) listenMetricsSock() (string, error) {
 	return path, nil
 }
 
-func registerMetricsPluginCallback(getter plugingetter.PluginGetter, sockPath string) {
-	getter.Handle(metricsPluginType, func(name string, client *plugins.Client) {
+func registerMetricsPluginCallback(store *plugin.Store, sockPath string) {
+	store.RegisterRuntimeOpt(metricsPluginType, func(s *specs.Spec) {
+		f := plugin.WithSpecMounts([]specs.Mount{
+			{Type: "bind", Source: sockPath, Destination: "/run/docker/metrics.sock", Options: []string{"bind", "ro"}},
+		})
+		f(s)
+	})
+	store.Handle(metricsPluginType, func(name string, client *plugins.Client) {
 		// Use lookup since nothing in the system can really reference it, no need
 		// to protect against removal
-		p, err := getter.Get(name, metricsPluginType, plugingetter.Lookup)
+		p, err := store.Get(name, metricsPluginType, plugingetter.Lookup)
 		if err != nil {
 			return
 		}
 
-		mp := metricsPlugin{p}
-		sockBase := mp.sockBase()
-		if err := os.MkdirAll(sockBase, 0755); err != nil {
-			logrus.WithError(err).WithField("name", name).WithField("path", sockBase).Error("error creating metrics plugin base path")
-			return
-		}
-
-		defer func() {
-			if err != nil {
-				os.RemoveAll(sockBase)
-			}
-		}()
-
-		pluginSockPath := filepath.Join(sockBase, mp.sock())
-		_, err = os.Stat(pluginSockPath)
-		if err == nil {
-			mount.Unmount(pluginSockPath)
-		} else {
-			logrus.WithField("path", pluginSockPath).Debugf("creating plugin socket")
-			f, err := os.OpenFile(pluginSockPath, os.O_CREATE, 0600)
-			if err != nil {
-				return
-			}
-			f.Close()
-		}
-
-		if err := mount.Mount(sockPath, pluginSockPath, "none", "bind,ro"); err != nil {
-			logrus.WithError(err).WithField("name", name).Error("could not mount metrics socket to plugin")
-			return
-		}
-
 		if err := pluginStartMetricsCollection(p); err != nil {
-			if err := mount.Unmount(pluginSockPath); err != nil {
-				if mounted, _ := mount.Mounted(pluginSockPath); mounted {
-					logrus.WithError(err).WithField("sock_path", pluginSockPath).Error("error unmounting metrics socket from plugin during cleanup")
-				}
-			}
 			logrus.WithError(err).WithField("name", name).Error("error while initializing metrics plugin")
 		}
 	})

--- a/pkg/plugingetter/getter.go
+++ b/pkg/plugingetter/getter.go
@@ -17,7 +17,7 @@ const (
 type CompatPlugin interface {
 	Client() *plugins.Client
 	Name() string
-	BasePath() string
+	ScopedPath(string) string
 	IsV1() bool
 }
 

--- a/pkg/plugins/plugins_unix.go
+++ b/pkg/plugins/plugins_unix.go
@@ -2,8 +2,8 @@
 
 package plugins
 
-// BasePath returns the path to which all paths returned by the plugin are relative to.
-// For v1 plugins, this always returns the host's root directory.
-func (p *Plugin) BasePath() string {
-	return "/"
+// ScopedPath returns the path scoped to the plugin's rootfs.
+// For v1 plugins, this always returns the path unchanged as v1 plugins run directly on the host.
+func (p *Plugin) ScopedPath(s string) string {
+	return s
 }

--- a/pkg/plugins/plugins_windows.go
+++ b/pkg/plugins/plugins_windows.go
@@ -1,8 +1,7 @@
 package plugins
 
-// BasePath returns the path to which all paths returned by the plugin are relative to.
-// For Windows v1 plugins, this returns an empty string, since the plugin is already aware
-// of the absolute path of the mount.
-func (p *Plugin) BasePath() string {
-	return ""
+// ScopedPath returns the path scoped to the plugin's rootfs.
+// For v1 plugins, this always returns the path unchanged as v1 plugins run directly on the host.
+func (p *Plugin) ScopedPath(s string) string {
+	return s
 }

--- a/plugin/defs.go
+++ b/plugin/defs.go
@@ -5,12 +5,14 @@ import (
 
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/docker/plugin/v2"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // Store manages the plugin inventory in memory and on-disk
 type Store struct {
 	sync.RWMutex
-	plugins map[string]*v2.Plugin
+	plugins  map[string]*v2.Plugin
+	specOpts map[string][]SpecOpt
 	/* handlers are necessary for transition path of legacy plugins
 	 * to the new model. Legacy plugins use Handle() for registering an
 	 * activation callback.*/
@@ -21,9 +23,13 @@ type Store struct {
 func NewStore() *Store {
 	return &Store{
 		plugins:  make(map[string]*v2.Plugin),
+		specOpts: make(map[string][]SpecOpt),
 		handlers: make(map[string][]func(string, *plugins.Client)),
 	}
 }
+
+// SpecOpt is used for subsystems that need to modify the runtime spec of a plugin
+type SpecOpt func(*specs.Spec)
 
 // CreateOpt is used to configure specific plugin details when created
 type CreateOpt func(p *v2.Plugin)
@@ -33,5 +39,12 @@ type CreateOpt func(p *v2.Plugin)
 func WithSwarmService(id string) CreateOpt {
 	return func(p *v2.Plugin) {
 		p.SwarmServiceID = id
+	}
+}
+
+// WithSpecMounts is a SpecOpt which appends the provided mounts to the runtime spec
+func WithSpecMounts(mounts []specs.Mount) SpecOpt {
+	return func(s *specs.Spec) {
+		s.Mounts = append(s.Mounts, mounts...)
 	}
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/authorization"
 	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/pubsub"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/plugin/v2"
@@ -155,6 +156,10 @@ func (pm *Manager) HandleExitEvent(id string) error {
 
 	if restart {
 		pm.enable(p, c, true)
+	} else {
+		if err := mount.RecursiveUnmount(filepath.Join(pm.config.Root, id)); err != nil {
+			return errors.Wrap(err, "error cleaning up plugin mounts")
+		}
 	}
 	return nil
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -111,11 +111,6 @@ func NewManager(config ManagerConfig) (*Manager, error) {
 			return nil, errors.Wrapf(err, "failed to mkdir %v", dirName)
 		}
 	}
-
-	if err := setupRoot(manager.config.Root); err != nil {
-		return nil, err
-	}
-
 	var err error
 	manager.executor, err = config.CreateExecutor(manager)
 	if err != nil {

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -19,7 +19,6 @@ import (
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/authorization"
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/pubsub"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/plugin/v2"
@@ -151,16 +150,6 @@ func (pm *Manager) HandleExitEvent(id string) error {
 
 	os.RemoveAll(filepath.Join(pm.config.ExecRoot, id))
 
-	if p.PropagatedMount != "" {
-		if err := mount.Unmount(p.PropagatedMount); err != nil {
-			logrus.Warnf("Could not unmount %s: %v", p.PropagatedMount, err)
-		}
-		propRoot := filepath.Join(filepath.Dir(p.Rootfs), "propagated-mount")
-		if err := mount.Unmount(propRoot); err != nil {
-			logrus.Warn("Could not unmount %s: %v", propRoot, err)
-		}
-	}
-
 	pm.mu.RLock()
 	c := pm.cMap[p]
 	if c.exitChan != nil {
@@ -239,27 +228,16 @@ func (pm *Manager) reload() error { // todo: restore
 						// check if we need to migrate an older propagated mount from before
 						// these mounts were stored outside the plugin rootfs
 						if _, err := os.Stat(propRoot); os.IsNotExist(err) {
-							if _, err := os.Stat(p.PropagatedMount); err == nil {
-								// make sure nothing is mounted here
-								// don't care about errors
-								mount.Unmount(p.PropagatedMount)
-								if err := os.Rename(p.PropagatedMount, propRoot); err != nil {
+							rootfsProp := filepath.Join(p.Rootfs, p.PluginObj.Config.PropagatedMount)
+							if _, err := os.Stat(rootfsProp); err == nil {
+								if err := os.Rename(rootfsProp, propRoot); err != nil {
 									logrus.WithError(err).WithField("dir", propRoot).Error("error migrating propagated mount storage")
-								}
-								if err := os.MkdirAll(p.PropagatedMount, 0755); err != nil {
-									logrus.WithError(err).WithField("dir", p.PropagatedMount).Error("error migrating propagated mount storage")
 								}
 							}
 						}
 
 						if err := os.MkdirAll(propRoot, 0755); err != nil {
 							logrus.Errorf("failed to create PropagatedMount directory at %s: %v", propRoot, err)
-						}
-						// TODO: sanitize PropagatedMount and prevent breakout
-						p.PropagatedMount = filepath.Join(p.Rootfs, p.PluginObj.Config.PropagatedMount)
-						if err := os.MkdirAll(p.PropagatedMount, 0755); err != nil {
-							logrus.Errorf("failed to create PropagatedMount directory at %s: %v", p.PropagatedMount, err)
-							return
 						}
 					}
 				}

--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -159,13 +159,6 @@ func shutdownPlugin(p *v2.Plugin, c *controller, executor Executor) {
 	}
 }
 
-func setupRoot(root string) error {
-	if err := mount.MakePrivate(root); err != nil {
-		return errors.Wrap(err, "error setting plugin manager root to private")
-	}
-	return nil
-}
-
 func (pm *Manager) disable(p *v2.Plugin, c *controller) error {
 	if !p.IsEnabled() {
 		return errors.Wrap(errDisabled(p.Name()), "plugin is already disabled")
@@ -194,7 +187,6 @@ func (pm *Manager) Shutdown() {
 			shutdownPlugin(p, c, pm.executor)
 		}
 	}
-	mount.Unmount(pm.config.Root)
 }
 
 func (pm *Manager) upgradePlugin(p *v2.Plugin, configDigest digest.Digest, blobsums []digest.Digest, tmpRootFSDir string, privileges *types.PluginPrivileges) (err error) {

--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -65,7 +65,6 @@ func (pm *Manager) enable(p *v2.Plugin, c *controller, force bool) error {
 			}
 		}
 	}
-
 	return pm.pluginPostStart(p, c)
 }
 

--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -187,6 +187,9 @@ func (pm *Manager) Shutdown() {
 			shutdownPlugin(p, c, pm.executor)
 		}
 	}
+	if err := mount.RecursiveUnmount(pm.config.Root); err != nil {
+		logrus.WithError(err).Warn("error cleaning up plugin mounts")
+	}
 }
 
 func (pm *Manager) upgradePlugin(p *v2.Plugin, configDigest digest.Digest, blobsums []digest.Digest, tmpRootFSDir string, privileges *types.PluginPrivileges) (err error) {

--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func (pm *Manager) enable(p *v2.Plugin, c *controller, force bool) (err error) {
+func (pm *Manager) enable(p *v2.Plugin, c *controller, force bool) error {
 	p.Rootfs = filepath.Join(pm.config.Root, p.PluginObj.ID, "rootfs")
 	if p.IsEnabled() && !force {
 		return errors.Wrap(enabledError(p.Name()), "plugin already enabled")
@@ -40,19 +40,15 @@ func (pm *Manager) enable(p *v2.Plugin, c *controller, force bool) (err error) {
 	pm.mu.Unlock()
 
 	var propRoot string
-	if p.PropagatedMount != "" {
+	if p.PluginObj.Config.PropagatedMount != "" {
 		propRoot = filepath.Join(filepath.Dir(p.Rootfs), "propagated-mount")
 
-		if err = os.MkdirAll(propRoot, 0755); err != nil {
+		if err := os.MkdirAll(propRoot, 0755); err != nil {
 			logrus.Errorf("failed to create PropagatedMount directory at %s: %v", propRoot, err)
 		}
 
-		if err = mount.MakeRShared(propRoot); err != nil {
+		if err := mount.MakeRShared(propRoot); err != nil {
 			return errors.Wrap(err, "error setting up propagated mount dir")
-		}
-
-		if err = mount.Mount(propRoot, p.PropagatedMount, "none", "rbind"); err != nil {
-			return errors.Wrap(err, "error creating mount for propagated mount")
 		}
 	}
 
@@ -63,10 +59,7 @@ func (pm *Manager) enable(p *v2.Plugin, c *controller, force bool) (err error) {
 
 	stdout, stderr := makeLoggerStreams(p.GetID())
 	if err := pm.executor.Create(p.GetID(), *spec, stdout, stderr); err != nil {
-		if p.PropagatedMount != "" {
-			if err := mount.Unmount(p.PropagatedMount); err != nil {
-				logrus.Warnf("Could not unmount %s: %v", p.PropagatedMount, err)
-			}
+		if p.PluginObj.Config.PropagatedMount != "" {
 			if err := mount.Unmount(propRoot); err != nil {
 				logrus.Warnf("Could not unmount %s: %v", propRoot, err)
 			}

--- a/plugin/manager_windows.go
+++ b/plugin/manager_windows.go
@@ -26,5 +26,3 @@ func (pm *Manager) restore(p *v2.Plugin) error {
 // Shutdown plugins
 func (pm *Manager) Shutdown() {
 }
-
-func setupRoot(root string) error { return nil }

--- a/plugin/v2/plugin.go
+++ b/plugin/v2/plugin.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -39,10 +40,13 @@ func (e ErrInadequateCapability) Error() string {
 	return fmt.Sprintf("plugin does not provide %q capability", e.cap)
 }
 
-// BasePath returns the path to which all paths returned by the plugin are relative to.
-// For Plugin objects this returns the host path of the plugin container's rootfs.
-func (p *Plugin) BasePath() string {
-	return p.Rootfs
+// ScopedPath returns the path scoped to the plugin rootfs
+func (p *Plugin) ScopedPath(s string) string {
+	if p.PluginObj.Config.PropagatedMount != "" && strings.HasPrefix(s, p.PluginObj.Config.PropagatedMount) {
+		// re-scope to the propagated mount path on the host
+		return filepath.Join(filepath.Dir(p.Rootfs), "propagated-mount", strings.TrimPrefix(s, p.PluginObj.Config.PropagatedMount))
+	}
+	return filepath.Join(p.Rootfs, s)
 }
 
 // Client returns the plugin client.

--- a/plugin/v2/plugin.go
+++ b/plugin/v2/plugin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // Plugin represents an individual plugin.
@@ -22,6 +23,8 @@ type Plugin struct {
 
 	Config   digest.Digest
 	Blobsums []digest.Digest
+
+	modifyRuntimeSpec func(*specs.Spec)
 
 	SwarmServiceID string
 }
@@ -249,4 +252,12 @@ func (p *Plugin) Acquire() {
 // via `Acquire()` or getter.Get("name", "type", plugingetter.Acquire)
 func (p *Plugin) Release() {
 	p.AddRefCount(plugingetter.Release)
+}
+
+// SetSpecOptModifier sets the function to use to modify the the generated
+// runtime spec.
+func (p *Plugin) SetSpecOptModifier(f func(*specs.Spec)) {
+	p.mu.Lock()
+	p.modifyRuntimeSpec = f
+	p.mu.Unlock()
 }

--- a/plugin/v2/plugin.go
+++ b/plugin/v2/plugin.go
@@ -14,12 +14,11 @@ import (
 
 // Plugin represents an individual plugin.
 type Plugin struct {
-	mu              sync.RWMutex
-	PluginObj       types.Plugin `json:"plugin"` // todo: embed struct
-	pClient         *plugins.Client
-	refCount        int
-	PropagatedMount string // TODO: make private
-	Rootfs          string // TODO: make private
+	mu        sync.RWMutex
+	PluginObj types.Plugin `json:"plugin"` // todo: embed struct
+	pClient   *plugins.Client
+	refCount  int
+	Rootfs    string // TODO: make private
 
 	Config   digest.Digest
 	Blobsums []digest.Digest

--- a/plugin/v2/plugin_linux.go
+++ b/plugin/v2/plugin_linux.go
@@ -16,6 +16,7 @@ import (
 // InitSpec creates an OCI spec from the plugin's config.
 func (p *Plugin) InitSpec(execRoot string) (*specs.Spec, error) {
 	s := oci.DefaultSpec()
+
 	s.Root = &specs.Root{
 		Path:     p.Rootfs,
 		Readonly: false, // TODO: all plugins should be readonly? settable in config?
@@ -125,6 +126,10 @@ func (p *Plugin) InitSpec(execRoot string) (*specs.Spec, error) {
 	caps.Permitted = append(caps.Permitted, p.PluginObj.Config.Linux.Capabilities...)
 	caps.Inheritable = append(caps.Inheritable, p.PluginObj.Config.Linux.Capabilities...)
 	caps.Effective = append(caps.Effective, p.PluginObj.Config.Linux.Capabilities...)
+
+	if p.modifyRuntimeSpec != nil {
+		p.modifyRuntimeSpec(&s)
+	}
 
 	return &s, nil
 }

--- a/volume/testutils/testutils.go
+++ b/volume/testutils/testutils.go
@@ -178,8 +178,8 @@ func (p *fakePlugin) IsV1() bool {
 	return false
 }
 
-func (p *fakePlugin) BasePath() string {
-	return ""
+func (p *fakePlugin) ScopedPath(s string) string {
+	return s
 }
 
 type fakePluginGetter struct {


### PR DESCRIPTION
- For metrics plugins, mount the metrics socket using the runtime spec rather than on the host. This prevents mount leakages of the socket which can lead to failed plugin removal. This made it necessary to expose an interface to subsystems that interact with plugins to be able to modify the runtime spec.
- Make the "propagated" mount for plugins happen in the runtime spec. This also prevents mount leakages from the plugin rootfs
- Have volume plugins request a scoped path from the plugin (object) rather than assuming a hard-coded base path. This is required due to changes to using the runtime spec to handle the "propagated mount" for the plugin.
- Revert 0c2821d6f2de692d105e50a399daa65169697cca -- private /var/lib/docker/plugins is no longer needed and causes issues for other systems.
- Do not use "lazy" unmounts in recursive unmount, which can cause issues with submounts that exist in running containers, additionally makes sure plugin shutdown uses recursive unmounts.
