### PR TITLE
Re-validate Mounts on container start

### DIFF
--- a/volume/lcow_parser.go
+++ b/volume/lcow_parser.go
@@ -22,7 +22,7 @@ type lcowParser struct {
 	windowsParser
 }
 
-func (p *lcowParser) validateMountConfig(mnt *mount.Mount) error {
+func (p *lcowParser) ValidateMountConfig(mnt *mount.Mount) error {
 	return p.validateMountConfigReg(mnt, rxLCOWDestination, lcowSpecificValidators)
 }
 

--- a/volume/linux_parser.go
+++ b/volume/linux_parser.go
@@ -40,7 +40,7 @@ func linuxValidateAbsolute(p string) error {
 	}
 	return fmt.Errorf("invalid mount path: '%s' mount path must be absolute", p)
 }
-func (p *linuxParser) validateMountConfig(mnt *mount.Mount) error {
+func (p *linuxParser) ValidateMountConfig(mnt *mount.Mount) error {
 	// there was something looking like a bug in existing codebase:
 	// - validateMountConfig on linux was called with options skipping bind source existence when calling ParseMountRaw
 	// - but not when calling ParseMountSpec directly... nor when the unit test called it directly

--- a/volume/parser.go
+++ b/volume/parser.go
@@ -26,8 +26,7 @@ type Parser interface {
 	IsBackwardCompatible(m *MountPoint) bool
 	HasResource(m *MountPoint, absPath string) bool
 	ValidateTmpfsMountDestination(dest string) error
-
-	validateMountConfig(mt *mount.Mount) error
+	ValidateMountConfig(mt *mount.Mount) error
 }
 
 // NewParser creates a parser for a given container OS, depending on the current host OS (linux on a windows host will resolve to an lcowParser)

--- a/volume/validate_test.go
+++ b/volume/validate_test.go
@@ -31,13 +31,9 @@ func TestValidateMount(t *testing.T) {
 
 		{mount.Mount{Type: mount.TypeBind, Source: testDir, Target: testDestinationPath}, nil},
 		{mount.Mount{Type: "invalid", Target: testDestinationPath}, errors.New("mount type unknown")},
+		{mount.Mount{Type: mount.TypeBind, Source: testSourcePath, Target: testDestinationPath}, errBindNotExist},
 	}
-	if runtime.GOOS == "windows" {
-		cases = append(cases, struct {
-			input    mount.Mount
-			expected error
-		}{mount.Mount{Type: mount.TypeBind, Source: testSourcePath, Target: testDestinationPath}, errBindNotExist}) // bind source existance is not checked on linux
-	}
+
 	lcowCases := []struct {
 		input    mount.Mount
 		expected error
@@ -54,7 +50,7 @@ func TestValidateMount(t *testing.T) {
 	}
 	parser := NewParser(runtime.GOOS)
 	for i, x := range cases {
-		err := parser.validateMountConfig(&x.input)
+		err := parser.ValidateMountConfig(&x.input)
 		if err == nil && x.expected == nil {
 			continue
 		}
@@ -65,7 +61,7 @@ func TestValidateMount(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		parser = &lcowParser{}
 		for i, x := range lcowCases {
-			err := parser.validateMountConfig(&x.input)
+			err := parser.ValidateMountConfig(&x.input)
 			if err == nil && x.expected == nil {
 				continue
 			}

--- a/volume/windows_parser.go
+++ b/volume/windows_parser.go
@@ -189,7 +189,7 @@ func (p *windowsParser) ValidateVolumeName(name string) error {
 	}
 	return nil
 }
-func (p *windowsParser) validateMountConfig(mnt *mount.Mount) error {
+func (p *windowsParser) ValidateMountConfig(mnt *mount.Mount) error {
 	return p.validateMountConfigReg(mnt, rxDestination, windowsSpecificValidators)
 }
 


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/35821
- fixes https://github.com/moby/moby/issues/36634

Validation of Mounts was only performed on container _creation_, not on container _start_. As a result, if the host-path no longer existed when the container was started, a directory was created in the given location.

This is the wrong behavior, because when using the `Mounts` API, host paths should never be created, and an error should be produced instead.

This patch adds a validation step on container start, and produces an error if the host path is not found.

**- How to verify it**


Create a container that bind-mounts a directory that exists;

```bash
$ mkdir once-existed
$ docker create --name repro-35821 \
   --mount type=bind,source="$(pwd)"/once-existed,target=/app \
   busybox
a7b4d510d1afd3eabea59414b94e9565af2927606f8a79f27aa855f3a8ea2817
```

After creating, remove the directory, and verify the directory is gone;

```bash
$ rm -r once-existed
$ ls
(empty)
```

Verify that the container refuses to start because the directory no longer exists;

```bash
$ docker start repro-35821
Error response from daemon: invalid mount config for type "bind": bind source path does not exist
```



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
* Validate Mount-specs on container start to prevent creating missing host-paths [moby/moby#35833](https://github.com/moby/moby/pull/35833)
```

**- A picture of a cute animal (not mandatory but encouraged)**

![bird-sparrow](https://user-images.githubusercontent.com/1804568/34155160-86cd0480-e4b8-11e7-9d69-b3a817e3b351.jpg)

  