### PR TITLE
Vendor docker/swarmkit to 713d79d

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -114,7 +114,7 @@ github.com/dmcgowan/go-tar go1.10
 github.com/stevvooe/ttrpc 76e68349ad9ab4d03d764c713826d31216715e4f
 
 # cluster
-github.com/docker/swarmkit a6519e28ff2a558f5d32b2dab9fcb0882879b398 
+github.com/docker/swarmkit 713d79dc8799b33465c58ed120b870c52eb5eb4f
 github.com/gogo/protobuf v0.4
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a
 github.com/google/certificate-transparency d90e65c3a07988180c5b1ece71791c0b6506826e


### PR DESCRIPTION
**- What I did**
Revendor swarmkit to 713d79dc8799b33465c58ed120b870c52eb5eb4f to include
https://github.com/docker/swarmkit/pull/2473.

**- How I did it**
`vndr github.com/docker/swarmkit 713d79dc8799b33465c58ed120b870c52eb5eb4f`

**- How to verify it**
Tests in https://github.com/docker/swarmkit/blob/e5b310727c4c8b186c774b4e28d154c3fb4e32b8/manager/orchestrator/taskreaper/task_reaper_test.go

**- Description for the changelog**
Fix task reaper not cleaning up COMPLETE tasks

Signed-off-by: Marcus Martins <marcus@docker.com>