### PR TITLE
Remove TestEventsLimit(), and minor cleanups

### DIFF
--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -28,7 +28,7 @@ func New() *Events {
 	}
 }
 
-// Subscribe adds new listener to events, returns slice of 64 stored
+// Subscribe adds new listener to events, returns slice of 256 stored
 // last events, a channel in which you can expect new events (in form
 // of interface{}, so you need type assertion), and a function to call
 // to stop the stream of events.
@@ -46,7 +46,7 @@ func (e *Events) Subscribe() ([]eventtypes.Message, chan interface{}, func()) {
 	return current, l, cancel
 }
 
-// SubscribeTopic adds new listener to events, returns slice of 64 stored
+// SubscribeTopic adds new listener to events, returns slice of 256 stored
 // last events, a channel in which you can expect new events (in form
 // of interface{}, so you need type assertion).
 func (e *Events) SubscribeTopic(since, until time.Time, ef *Filter) ([]eventtypes.Message, chan interface{}) {

--- a/daemon/events/events_test.go
+++ b/daemon/events/events_test.go
@@ -135,21 +135,28 @@ func TestLogEvents(t *testing.T) {
 		t.Fatalf("Must be %d events, got %d", eventsLimit, len(current))
 	}
 	first := current[0]
-	if first.Status != "action_16" {
-		t.Fatalf("First action is %s, must be action_16", first.Status)
+
+	// TODO remove this once we removed the deprecated `ID`, `Status`, and `From` fields
+	if first.Action != first.Status {
+		// Verify that the (deprecated) Status is set to the expected value
+		t.Fatalf("Action (%s) does not match Status (%s)", first.Action, first.Status)
+	}
+
+	if first.Action != "action_16" {
+		t.Fatalf("First action is %s, must be action_16", first.Action)
 	}
 	last := current[len(current)-1]
-	if last.Status != "action_271" {
-		t.Fatalf("Last action is %s, must be action_271", last.Status)
+	if last.Action != "action_271" {
+		t.Fatalf("Last action is %s, must be action_271", last.Action)
 	}
 
 	firstC := msgs[0]
-	if firstC.Status != "action_272" {
-		t.Fatalf("First action is %s, must be action_272", firstC.Status)
+	if firstC.Action != "action_272" {
+		t.Fatalf("First action is %s, must be action_272", firstC.Action)
 	}
 	lastC := msgs[len(msgs)-1]
-	if lastC.Status != "action_281" {
-		t.Fatalf("Last action is %s, must be action_281", lastC.Status)
+	if lastC.Action != "action_281" {
+		t.Fatalf("Last action is %s, must be action_281", lastC.Action)
 	}
 }
 

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -81,50 +81,6 @@ func (s *DockerSuite) TestEventsUntag(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestEventsLimit(c *check.C) {
-	// Windows: Limit to 4 goroutines creating containers in order to prevent
-	// timeouts creating so many containers simultaneously. This is a due to
-	// a bug in the Windows platform. It will be fixed in a Windows Update.
-	numContainers := 17
-	eventPerContainer := 7 // create, attach, network connect, start, die, network disconnect, destroy
-	numConcurrentContainers := numContainers
-	if testEnv.DaemonPlatform() == "windows" {
-		numConcurrentContainers = 4
-	}
-	sem := make(chan bool, numConcurrentContainers)
-	errChan := make(chan error, numContainers)
-
-	startTime := daemonUnixTime(c)
-
-	args := []string{"run", "--rm", "busybox", "true"}
-	for i := 0; i < numContainers; i++ {
-		sem <- true
-		go func(i int) {
-			defer func() { <-sem }()
-			out, err := exec.Command(dockerBinary, args...).CombinedOutput()
-			if err != nil {
-				err = fmt.Errorf("%v: %s", err, string(out))
-			}
-			errChan <- err
-		}(i)
-	}
-
-	// Wait for all goroutines to finish
-	for i := 0; i < cap(sem); i++ {
-		sem <- true
-	}
-	close(errChan)
-
-	for err := range errChan {
-		c.Assert(err, checker.IsNil, check.Commentf("%q failed with error", strings.Join(args, " ")))
-	}
-
-	out, _ := dockerCmd(c, "events", "--since="+startTime, "--until", daemonUnixTime(c))
-	events := strings.Split(out, "\n")
-	nEvents := len(events) - 1
-	c.Assert(nEvents, checker.Equals, numContainers*eventPerContainer, check.Commentf("events should be limited to 256, but received %d", nEvents))
-}
-
 func (s *DockerSuite) TestEventsContainerEvents(c *check.C) {
 	dockerCmd(c, "run", "--rm", "--name", "container-events-test", "busybox", "true")
 


### PR DESCRIPTION
This test was added a long time ago, and over the years has proven to be [flaky](https://github.com/moby/moby/search?q=TestEventsLimit&type=Issues&utf8=) (https://github.com/moby/moby/issues/28873, https://github.com/moby/moby/issues/22601, https://github.com/moby/moby/issues/25533, https://github.com/moby/moby/issues/21473, https://github.com/moby/moby/issues/13498), and slow (using [30 containers](https://github.com/moby/moby/blob/6b5b3250e8f63d2fcbbe132a02b7e4df9d1b60a5/integration-cli/docker_cli_events_test.go#L34-L46), and taking over a minute to run (https://github.com/moby/moby/issues/12675)).

To address those issues, it was modified to;

- cleanup containers afterwards (https://github.com/moby/moby/pull/9249)
- take clock-skew into account (https://github.com/moby/moby/pull/11330)
- improve performance by parallelizing the container runs (https://github.com/moby/moby/pull/12719)
- _reduce_ parallelization to address platform issues on Windows (twice..) https://github.com/moby/moby/pull/26968, https://github.com/moby/moby/pull/28968
- adjust the test to take new limits into account https://github.com/moby/moby/pull/32421
- adjust the test to account for more events being generated by containers (https://github.com/moby/moby/pull/34895)

The last change to this test (made in https://github.com/moby/moby/commit/ddae20c032058a0fd42c34c2e9750ee8f6296ac8#diff-9e07f7c1f4d16eb428d628f85ee1a6f1R125) actually broke the test, as it's now testing that all events sent by containers (`numContainers*eventPerContainer`) are received, but the number of events that is generated (17 containers * 7 events = 119) is less than the limit (256 events).

The limit is already covered by the [`TestLogEvents`](https://github.com/moby/moby/blob/8d056423f8c433927089bd7eb6bc97abbc1ed502/events/events_test.go#L97-L99) unit-test that was added in https://github.com/moby/moby/pull/7452, and tests that the number of events is limited to `eventsLimit`.

This patch removes the test, because it's not needed.

Two other changes were added;

- A small GoDoc change to document the correct limit
- A small update to the unit-test to not use deprecated fields
