### PR TITLE
fix #35843 regression on health check workingdir

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -80,6 +80,7 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container
 	execConfig.Tty = false
 	execConfig.Privileged = false
 	execConfig.User = cntr.Config.User
+	execConfig.WorkingDir = cntr.Config.WorkingDir
 
 	linkedEnv, err := d.setupLinkedContainers(cntr)
 	if err != nil {

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -1,0 +1,61 @@
+package container
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/strslice"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/integration/util/request"
+	"github.com/gotestyourself/gotestyourself/poll"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHealthCheckWorkdir verifies that health-checks inherit the containers'
+// working-dir.
+func TestHealthCheckWorkdir(t *testing.T) {
+	defer setupTest(t)()
+	ctx := context.Background()
+	client := request.NewAPIClient(t)
+
+	c, err := client.ContainerCreate(ctx,
+		&container.Config{
+			Image:      "busybox",
+			Tty:        true,
+			WorkingDir: "/foo",
+			Cmd:        strslice.StrSlice([]string{"top"}),
+			Healthcheck: &container.HealthConfig{
+				Test:     []string{"CMD-SHELL", "if [ \"$PWD\" = \"/foo\" ]; then exit 0; else exit 1; fi;"},
+				Interval: 50 * time.Millisecond,
+				Retries:  3,
+			},
+		},
+		&container.HostConfig{},
+		&network.NetworkingConfig{},
+		"healthtest",
+	)
+	require.NoError(t, err)
+	err = client.ContainerStart(ctx, c.ID, types.ContainerStartOptions{})
+	require.NoError(t, err)
+
+	poll.WaitOn(t, pollForHealthStatus(ctx, client, c.ID, types.Healthy), poll.WithDelay(100*time.Millisecond))
+}
+
+func pollForHealthStatus(ctx context.Context, client client.APIClient, containerID string, healthStatus string) func(log poll.LogT) poll.Result {
+	return func(log poll.LogT) poll.Result {
+		inspect, err := client.ContainerInspect(ctx, containerID)
+
+		switch {
+		case err != nil:
+			return poll.Error(err)
+		case inspect.State.Health.Status == healthStatus:
+			return poll.Success()
+		default:
+			return poll.Continue("waiting for container to become %s", healthStatus)
+		}
+	}
+}


### PR DESCRIPTION
**- What I did**

Fix for https://github.com/moby/moby/issues/35843

**- How I did it**

Set recently introduced exec.WorkingDir to container's workingdir

**- How to verify it**

see https://github.com/moby/moby/issues/35843 description

**- Description for the changelog**
Fixed https://github.com/moby/moby/issues/35843

**- A picture of a cute animal (not mandatory but encouraged)**

![2013_6beb](https://user-images.githubusercontent.com/132757/34208465-b7d05920-e58e-11e7-8fc0-2b7612e09939.jpg)

