### PR TITLE
Fix issue where full-SHA alias is not supported for links with user defined networks

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -18,7 +18,6 @@ import (
 	clustertypes "github.com/docker/docker/daemon/cluster/provider"
 	internalnetwork "github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/errdefs"
-	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/go-connections/nat"
@@ -1100,25 +1099,4 @@ func buildEndpointInfo(networkSettings *internalnetwork.Settings, n libnetwork.N
 	}
 
 	return nil
-}
-
-// buildJoinOptions builds endpoint Join options from a given network.
-func buildJoinOptions(networkSettings *internalnetwork.Settings, n interface {
-	Name() string
-}) ([]libnetwork.EndpointOption, error) {
-	var joinOptions []libnetwork.EndpointOption
-	if epConfig, ok := networkSettings.Networks[n.Name()]; ok {
-		for _, str := range epConfig.Links {
-			name, alias, err := opts.ParseLink(str)
-			if err != nil {
-				return nil, err
-			}
-			joinOptions = append(joinOptions, libnetwork.CreateOptionAlias(name, alias))
-		}
-		for k, v := range epConfig.DriverOpts {
-			joinOptions = append(joinOptions, libnetwork.EndpointOptionGeneric(options.Generic{k: v}))
-		}
-	}
-
-	return joinOptions, nil
 }

--- a/integration/network/link_test.go
+++ b/integration/network/link_test.go
@@ -1,0 +1,58 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/internal/test/request"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+	"gotest.tools/poll"
+)
+
+func TestDockerNetworkLinkAlias(t *testing.T) {
+	defer setupTest(t)()
+	client := request.NewAPIClient(t)
+	ctx := context.Background()
+
+	mynet, err := client.NetworkCreate(ctx, "mynet", types.NetworkCreate{})
+	assert.NilError(t, err)
+
+	nws, err := client.NetworkList(ctx, types.NetworkListOptions{})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(true, containsNetwork(nws, mynet.ID)), "failed to create network mynet")
+
+	fooID := container.Run(t, ctx, client, container.WithNetworkMode("mynet"), container.WithName("foo"))
+
+	// These are the test cases of full id,partial id, and container name.
+	aliases := []string{fooID, fooID[:5], "foo"}
+	for _, l := range aliases {
+		barID := container.Run(t, ctx, client, container.WithCmd("ping", "-c", "3", "server"), func(c *container.TestContainerConfig) {
+			c.HostConfig.NetworkMode = "mynet"
+			c.HostConfig.Links = []string{fmt.Sprintf("%s:server", l)}
+			c.NetworkingConfig = &network.NetworkingConfig{
+				EndpointsConfig: map[string]*network.EndpointSettings{
+					"mynet": {
+						Links: []string{fmt.Sprintf("%s:server", l)},
+					},
+				},
+			}
+		})
+		poll.WaitOn(t, container.IsStopped(ctx, client, barID), poll.WithDelay(100*time.Millisecond))
+
+		body, err := client.ContainerLogs(ctx, barID, types.ContainerLogsOptions{
+			ShowStdout: true,
+		})
+		assert.NilError(t, err)
+
+		log, err := ioutil.ReadAll(body)
+		assert.NilError(t, err)
+		assert.Check(t, is.Contains(string(log), "bytes from "))
+	}
+}


### PR DESCRIPTION
**- What I did**


This fix tries to address the issue raised in #35573 where full-SHA alias is not supported for links with user defined networks.


**- How I did it**

The reason was that CreateOptionAlias used name directly but CreateOptionMyAlias used short ID of the container to alias.

This fix use short ID for CreateOptionAlias so that the issue could be addressed.

**- How to verify it**

A test case has been added to cover the changes.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![unnamed](https://user-images.githubusercontent.com/6932348/34229333-bb5f22e8-e588-11e7-8387-7c0d55cbbda6.jpg)

This fix fixes #35573.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
