### PR TITLE
Fix ownership-regression in docker cp to container

### DIFF
--- a/daemon/archive_tarcopyoptions.go
+++ b/daemon/archive_tarcopyoptions.go
@@ -11,5 +11,6 @@ func (daemon *Daemon) defaultTarCopyOptions(noOverwriteDirNonDir bool) *archive.
 		NoOverwriteDirNonDir: noOverwriteDirNonDir,
 		UIDMaps:              daemon.idMapping.UIDs(),
 		GIDMaps:              daemon.idMapping.GIDs(),
+		NoLchown:             true,
 	}
 }

--- a/daemon/archive_tarcopyoptions_unix.go
+++ b/daemon/archive_tarcopyoptions_unix.go
@@ -5,25 +5,10 @@ package daemon // import "github.com/docker/docker/daemon"
 import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/pkg/idtools"
-	"github.com/sirupsen/logrus"
 )
 
 func (daemon *Daemon) tarCopyOptions(container *container.Container, noOverwriteDirNonDir bool) (*archive.TarOptions, error) {
-	if container.Config.User == "" {
-		logrus.Debug("container.Config.User is empty, using defaultTarCopyOptions.")
-		return daemon.defaultTarCopyOptions(noOverwriteDirNonDir), nil
-	}
-
-	user, err := idtools.LookupUser(container.Config.User)
-	if err != nil {
-		return nil, err
-	}
-
-	identity := idtools.Identity{UID: user.Uid, GID: user.Gid}
-
-	return &archive.TarOptions{
-		NoOverwriteDirNonDir: noOverwriteDirNonDir,
-		ChownOpts:            &identity,
-	}, nil
+	tarOptions := daemon.defaultTarCopyOptions(noOverwriteDirNonDir)
+	tarOptions.NoLchown = false
+	return tarOptions, nil
 }

--- a/daemon/archive_tarcopyoptions_unix.go
+++ b/daemon/archive_tarcopyoptions_unix.go
@@ -6,10 +6,12 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
+	"github.com/sirupsen/logrus"
 )
 
 func (daemon *Daemon) tarCopyOptions(container *container.Container, noOverwriteDirNonDir bool) (*archive.TarOptions, error) {
 	if container.Config.User == "" {
+		logrus.Debug("container.Config.User is empty, using defaultTarCopyOptions.")
 		return daemon.defaultTarCopyOptions(noOverwriteDirNonDir), nil
 	}
 


### PR DESCRIPTION
Following the addition of the `-a` (archive, owner, permissions) option to `docker cp` (#28923), the command behaviour _without_ the new option has changed, and files are no-longer copied into the container as _root_, but as a UID/GID of the user running the command in the host.

**- What I did**

* Added a (failng) integration-test `TestCpToContainerWithoutPermissions`, the inverse of the new test `TestCpToContainerWithPermissions` added in #28923) . Pre-existing test seemed to not correctly check permissions as this test does (by shelling-in to the container and running `stat`).
* Back-ported that test to the parent commit before #28923 landed, https://github.com/javabrett/moby/tree/34096-before-cp-a-option-added , where the test passes.
* Found that the logic added for `docker cp -a` seems accidentally inverted and depends on whether `container.Config.User` is set, when it then tries to not apply owner-logic.  However `NoLchown` was not test in `defaultTarCopyOptions`, so the reverse occurs.
* Set `NoLchown=true` in `defaultTarCopyOptions` to deactivate the `chown` when the option is not present.
* Reactivated with `NoLchown=false` in `tarCopyOptions` when `-a` is set.

**- How to verify it**
Run updated tests.  Run current Docker CLI `docker cp` as non-root and note incorrect permissions in container.  Run patched and check files are owned by `root:root`.  Check `docker cp -a` still sets UID/GID.

**- Description for the changelog**
Fixed regression in `docker cp` where files copied to the container are no longer owned by `root:root`.  `docker cp -a` should be used to set file-ownership in-container.

Fixes #34096.