### PR TITLE
Add options validation to syslog logger

### DIFF
--- a/daemon/logger/syslog/syslog_test.go
+++ b/daemon/logger/syslog/syslog_test.go
@@ -1,6 +1,7 @@
 package syslog // import "github.com/docker/docker/daemon/logger/syslog"
 
 import (
+	"net"
 	"reflect"
 	"testing"
 
@@ -58,5 +59,101 @@ func TestValidateLogOptEmpty(t *testing.T) {
 	emptyConfig := make(map[string]string)
 	if err := ValidateLogOpt(emptyConfig); err != nil {
 		t.Fatal("Failed to parse empty config", err)
+	}
+}
+
+func TestValidateSyslogAddress(t *testing.T) {
+	err := ValidateLogOpt(map[string]string{
+		"syslog-address": "this is not an uri",
+	})
+	if err == nil {
+		t.Fatal("Expected error with invalid uri")
+	}
+
+	// File exists
+	err = ValidateLogOpt(map[string]string{
+		"syslog-address": "unix:///",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// File does not exist
+	err = ValidateLogOpt(map[string]string{
+		"syslog-address": "unix:///does_not_exist",
+	})
+	if err == nil {
+		t.Fatal("Expected error when address is non existing file")
+	}
+
+	// accepts udp and tcp URIs
+	err = ValidateLogOpt(map[string]string{
+		"syslog-address": "udp://1.2.3.4",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ValidateLogOpt(map[string]string{
+		"syslog-address": "tcp://1.2.3.4",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseAddressDefaultPort(t *testing.T) {
+	_, address, err := parseAddress("tcp://1.2.3.4")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, port, _ := net.SplitHostPort(address)
+	if port != "514" {
+		t.Fatalf("Expected to default to port 514. It used port %s", port)
+	}
+}
+
+func TestValidateSyslogFacility(t *testing.T) {
+	err := ValidateLogOpt(map[string]string{
+		"syslog-facility": "Invalid facility",
+	})
+	if err == nil {
+		t.Fatal("Expected error if facility level is invalid")
+	}
+}
+
+func TestValidateLogOptSyslogFormat(t *testing.T) {
+	err := ValidateLogOpt(map[string]string{
+		"syslog-format": "Invalid format",
+	})
+	if err == nil {
+		t.Fatal("Expected error if format is invalid")
+	}
+}
+
+func TestValidateLogOpt(t *testing.T) {
+	err := ValidateLogOpt(map[string]string{
+		"env":                    "http://127.0.0.1",
+		"env-regex":              "abc",
+		"labels":                 "labelA",
+		"syslog-address":         "udp://1.2.3.4:1111",
+		"syslog-facility":        "daemon",
+		"syslog-tls-ca-cert":     "/etc/ca-certificates/custom/ca.pem",
+		"syslog-tls-cert":        "/etc/ca-certificates/custom/cert.pem",
+		"syslog-tls-key":         "/etc/ca-certificates/custom/key.pem",
+		"syslog-tls-skip-verify": "true",
+		"tag":                    "true",
+		"syslog-format":          "rfc3164",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ValidateLogOpt(map[string]string{
+		"not-supported-option": "a",
+	})
+	if err == nil {
+		t.Fatal("Expecting error on unsupported options")
 	}
 }


### PR DESCRIPTION
Adds the following validations to the syslog logger test:

 1. Only supported options are valid
 2. Log option syslog-address has to be a valid URI
 3. Log option syslog-address if is file has to exist
 4. Log option syslog-address if udp/tcp scheme, default to port 513
 5. Log-option syslog-facility has to be a valid facility
 6. Log-option syslog-format has to be a valid format

Signed-off-by: Joao Trindade <trindade.joao@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Improved the syslog test suite. Test coverage increased from 20% to 40%.

**- How I did it**
Added tests for some of the validations. This helps users that want to see examples of log options (this is why i added the tests, i needed to see some concrete examples and tests didn't had them)

**- How to verify it**
Run the tests

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add options validation to syslog logger test

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/150758/34426746-a59680d2-ec31-11e7-8665-89341755207a.png)
