### PR TITLE
Fix event filter filtering on "or"

### DIFF
--- a/libcontainerd/client_daemon.go
+++ b/libcontainerd/client_daemon.go
@@ -715,8 +715,9 @@ func (c *client) processEventStream(ctx context.Context) {
 
 	eventStream, err = c.remote.EventService().Subscribe(ctx, &eventsapi.SubscribeRequest{
 		Filters: []string{
-			"namespace==" + c.namespace,
-			"topic~=/tasks/",
+			// Filter on both namespace *and* topic. To create an "and" filter,
+			// this must be a single, comma-separated string
+			"namespace==" + c.namespace + ",topic~=|^/tasks/|",
 		},
 	}, grpc.FailFast(false))
 	if err != nil {


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/35891

The event filter used two separate filter-conditions for "namespace" and "topic". As a result, both events matching "topic" and events matching "namespace" were subscribed to, causing events to be handled both by the "plugin" client, and "container" client.

This patch rewrites the filter to match only if both namespace and topic match.

Thanks to Stephen Day for providing the correct filter :)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
* Fix containerd events being processed twice
```

