### PR TITLE
test.md improvements and corrections

### DIFF
--- a/docs/contributing/set-up-dev-env.md
+++ b/docs/contributing/set-up-dev-env.md
@@ -131,7 +131,7 @@ can take over 15 minutes to complete.
    Successfully built 3d872560918e
    Successfully tagged docker-dev:dry-run-test
    docker run --rm -i --privileged -e BUILDFLAGS -e KEEPBUNDLE -e DOCKER_BUILD_GOGC -e DOCKER_BUILD_PKGS -e DOCKER_CLIENTONLY -e DOCKER_DEBUG -e DOCKER_EXPERIMENTAL -e DOCKER_GITCOMMIT -e DOCKER_GRAPHDRIVER=devicemapper -e DOCKER_INCREMENTAL_BINARY -e DOCKER_REMAP_ROOT -e DOCKER_STORAGE_OPTS -e DOCKER_USERLANDPROXY -e TESTDIRS -e TESTFLAGS -e TIMEOUT -v "home/ubuntu/repos/docker/bundles:/go/src/github.com/docker/docker/bundles" -t "docker-dev:dry-run-test" bash
-   root@f31fa223770f:/go/src/github.com/docker/docker#
+   #
    ```
 
    At this point, your prompt reflects the container's BASH shell.
@@ -146,7 +146,7 @@ can take over 15 minutes to complete.
 6. Make a `dockerd` binary.
 
    ```none
-   root@a8b2885ab900:/go/src/github.com/docker/docker# hack/make.sh binary
+   # hack/make.sh binary
    Removing bundles/
 
    ---> Making bundle: binary (in bundles/binary)
@@ -160,13 +160,13 @@ can take over 15 minutes to complete.
    `/usr/local/bin/` directory.
 
    ```none
-   root@a8b2885ab900:/go/src/github.com/docker/docker# make install
+   # make install
    ```
 
 8. Start the Engine daemon running in the background.
 
    ```none
-   root@a8b2885ab900:/go/src/github.com/docker/docker# dockerd -D &
+   # dockerd -D &
    ...output snipped...
    DEBU[0001] Registering POST, /networks/{id:.*}/connect
    DEBU[0001] Registering POST, /networks/{id:.*}/disconnect
@@ -252,13 +252,13 @@ can take over 15 minutes to complete.
 10. Run the `hello-world` image.
 
     ```none
-    root@5f8630b873fe:/go/src/github.com/docker/docker# docker run hello-world
+    # docker run hello-world
     ```
 
 11. List the image you just downloaded.
 
     ```none
-    root@5f8630b873fe:/go/src/github.com/docker/docker# docker images
+    # docker images
 	REPOSITORY   TAG     IMAGE ID      CREATED        SIZE
 	hello-world  latest  c54a2cc56cbb  3 months ago   1.85 kB
     ```
@@ -347,7 +347,7 @@ example, you'll edit the help for the `attach` subcommand.
 10. To view your change, run the `dockerd --help` command in the docker development container shell.
 
    ```bash
-   root@b0cb4f22715d:/go/src/github.com/docker/docker# dockerd --help
+   # dockerd --help
 
    Usage:        dockerd COMMAND
 

--- a/docs/contributing/test.md
+++ b/docs/contributing/test.md
@@ -29,7 +29,10 @@ Depending on your contribution, you may need to add _integration tests_. These
 are tests that combine two or more work units into one component. These work
 units each have unit tests and then, together, integration tests that test the
 interface between the components. The `integration` and `integration-cli`
-directories in the Docker repository contain integration test code.
+directories in the Docker repository contain integration test code.  Note that
+`integration-cli` tests are now deprecated in the Moby project, and new tests
+cannot be added to this suite - add `integration` tests instead using the API
+client.
 
 Testing is its own specialty. If you aren't familiar with testing techniques,
 there is a lot of information available to you on the Web. For now, you should
@@ -93,7 +96,8 @@ hour. To run the test suite, do the following:
 ## Run targets inside a development container
 
 If you are working inside a development container, you use the
-`hack/make.sh` script to run tests. The `hack/make.sh` script doesn't
+`hack/test/unit` script to run unit-tests, and `hack/make.sh` script to run
+integration and other tests. The `hack/make.sh` script doesn't
 have a single target that runs all the tests. Instead, you provide a single
 command line with multiple targets that does the same thing.
 
@@ -110,19 +114,25 @@ Try this now.
     $ docker run --privileged --rm -ti -v `pwd`:/go/src/github.com/docker/docker dry-run-test /bin/bash
     ```
 
-3.  Run the tests using the `hack/make.sh` script.
+3.  Run the unit tests using the `hack/test/unit` script.
 
     ```bash
-    root@5f8630b873fe:/go/src/github.com/docker/docker# hack/make.sh dynbinary binary cross test-unit test-integration test-docker-py
+    root@5f8630b873fe:/go/src/github.com/docker/docker# hack/test/unit
+    ```
+
+4.  Run the tests using the `hack/make.sh` script.
+
+    ```bash
+    root@5f8630b873fe:/go/src/github.com/docker/docker# hack/make.sh dynbinary binary cross test-integration test-docker-py
     ```
 
     The tests run just as they did within your local host.
 
     Of course, you can also run a subset of these targets too. For example, to run
-    just the unit tests:
+    just the integration tests:
 
     ```bash
-    root@5f8630b873fe:/go/src/github.com/docker/docker# hack/make.sh dynbinary binary cross test-unit
+    root@5f8630b873fe:/go/src/github.com/docker/docker# hack/make.sh dynbinary binary cross test-integration
     ```
 
     Most test targets require that you build these precursor targets first:

--- a/docs/contributing/test.md
+++ b/docs/contributing/test.md
@@ -117,13 +117,13 @@ Try this now.
 3.  Run the unit tests using the `hack/test/unit` script.
 
     ```bash
-    root@5f8630b873fe:/go/src/github.com/docker/docker# hack/test/unit
+    # hack/test/unit
     ```
 
 4.  Run the tests using the `hack/make.sh` script.
 
     ```bash
-    root@5f8630b873fe:/go/src/github.com/docker/docker# hack/make.sh dynbinary binary cross test-integration test-docker-py
+    # hack/make.sh dynbinary binary cross test-integration test-docker-py
     ```
 
     The tests run just as they did within your local host.
@@ -132,7 +132,7 @@ Try this now.
     just the integration tests:
 
     ```bash
-    root@5f8630b873fe:/go/src/github.com/docker/docker# hack/make.sh dynbinary binary cross test-integration
+    # hack/make.sh dynbinary binary cross test-integration
     ```
 
     Most test targets require that you build these precursor targets first:
@@ -180,7 +180,7 @@ $ TESTFLAGS='-check.f DockerSuite.TestBuild*' make test-integration
 To run the same test inside your Docker development container, you do this:
 
 ```bash
-root@5f8630b873fe:/go/src/github.com/docker/docker# TESTFLAGS='-check.f TestBuild*' hack/make.sh binary test-integration
+# TESTFLAGS='-check.f TestBuild*' hack/make.sh binary test-integration
 ```
 
 ## Test the Windows binary against a Linux daemon


### PR DESCRIPTION
- Mentioned `integration-cli` test-suite deprecation.
- Removed mentions of removed in-container `hack/make.sh` target `test-unit`, replaced with `hack/test/unit`.