### PR TITLE
Skip graphdriver/quota TestBlockDev if dependencies are not available

### DIFF
--- a/daemon/graphdriver/quota/projectquota_test.go
+++ b/daemon/graphdriver/quota/projectquota_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gotestyourself/gotestyourself/fs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
@@ -22,7 +23,7 @@ const imageSize = 64 * 1024 * 1024
 func TestBlockDev(t *testing.T) {
 	mkfs, err := exec.LookPath("mkfs.xfs")
 	if err != nil {
-		t.Fatal("mkfs.xfs not installed")
+		t.Skip("mkfs.xfs not found in PATH")
 	}
 
 	// create a sparse image
@@ -52,18 +53,11 @@ func TestBlockDev(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	runTest(t, "testBlockDevQuotaDisabled", wrapMountTest(imageFileName, false, testBlockDevQuotaDisabled))
-	runTest(t, "testBlockDevQuotaEnabled", wrapMountTest(imageFileName, true, testBlockDevQuotaEnabled))
-	runTest(t, "testSmallerThanQuota", wrapMountTest(imageFileName, true, wrapQuotaTest(testSmallerThanQuota)))
-	runTest(t, "testBiggerThanQuota", wrapMountTest(imageFileName, true, wrapQuotaTest(testBiggerThanQuota)))
-	runTest(t, "testRetrieveQuota", wrapMountTest(imageFileName, true, wrapQuotaTest(testRetrieveQuota)))
-}
-
-func runTest(t *testing.T, testName string, testFunc func(*testing.T)) {
-	if success := t.Run(testName, testFunc); !success {
-		out, _ := exec.Command("dmesg").CombinedOutput()
-		t.Log(string(out))
-	}
+	t.Run("testBlockDevQuotaDisabled", wrapMountTest(imageFileName, false, testBlockDevQuotaDisabled))
+	t.Run("testBlockDevQuotaEnabled", wrapMountTest(imageFileName, true, testBlockDevQuotaEnabled))
+	t.Run("testSmallerThanQuota", wrapMountTest(imageFileName, true, wrapQuotaTest(testSmallerThanQuota)))
+	t.Run("testBiggerThanQuota", wrapMountTest(imageFileName, true, wrapQuotaTest(testBiggerThanQuota)))
+	t.Run("testRetrieveQuota", wrapMountTest(imageFileName, true, wrapQuotaTest(testRetrieveQuota)))
 }
 
 func wrapMountTest(imageFileName string, enableQuota bool, testFunc func(t *testing.T, mountPoint, backingFsDev string)) func(*testing.T) {
@@ -74,25 +68,22 @@ func wrapMountTest(imageFileName string, enableQuota bool, testFunc func(t *test
 			mountOptions = mountOptions + ",prjquota"
 		}
 
-		// create a mountPoint
-		mountPoint, err := ioutil.TempDir("", "xfs-mountPoint")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(mountPoint)
+		mountPointDir := fs.NewDir(t, "xfs-mountPoint")
+		defer mountPointDir.Remove()
+		mountPoint := mountPointDir.Path()
 
 		out, err := exec.Command("mount", "-o", mountOptions, imageFileName, mountPoint).CombinedOutput()
-		if len(out) > 0 {
-			t.Log(string(out))
-		}
 		if err != nil {
-			t.Fatal("mount failed")
+			_, err := os.Stat("/proc/fs/xfs")
+			if os.IsNotExist(err) {
+				t.Skip("no /proc/fs/xfs")
+			}
 		}
 
+		require.NoError(t, err, "mount failed: %s", out)
+
 		defer func() {
-			if err := unix.Unmount(mountPoint, 0); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, unix.Unmount(mountPoint, 0))
 		}()
 
 		backingFsDev, err := makeBackingFsDev(mountPoint)


### PR DESCRIPTION
Previously running this test in the standard docker-dev container (kernel 4.13.12) would result in thousands of lines of dmesg output cluttering the test output, and a test failure.

This change skips the test instead of failing when xfs is not available, and only prints the last 100 liens of dmesg on failure.

I'd also be happy to remove the `dmesg` output entirely, I'm not sure if it's really necessary.

cc @sargun