### PR TITLE
Vendor Microsoft/hcsshim @ v0.6.8

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,6 +1,6 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim v0.6.7
+github.com/Microsoft/hcsshim v0.6.8
 github.com/Microsoft/go-winio v0.4.5
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@johnstep This has a partial fix for https://github.com/moby/moby/issues/32838, specifically the one by @mback2k in this comment: https://github.com/moby/moby/issues/32838#issuecomment-343610048. There are unfortunately multiple failures in that issue, so I'm leaving it open for now while trying to repro the other cases.

@mback2k Once this is merged, an updated binary will be available at http://master.dockerproject.org. Re your question at https://github.com/moby/moby/issues/32838#issuecomment-355106018 about the release, I'll leave that for @thaJeztah to answer :)

@friism FYI. 