### PR TITLE
Closes #35667: Add the node hostname to default task labels

### DIFF
--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -43,6 +43,7 @@ const (
 // components.
 type containerConfig struct {
 	task                *api.Task
+	node                *api.NodeDescription
 	networksAttachments map[string]*api.NetworkAttachment
 }
 
@@ -76,6 +77,7 @@ func (c *containerConfig) setTask(t *api.Task, node *api.NodeDescription) error 
 	}
 
 	c.task = t
+	c.node = node
 
 	if t.Spec.GetContainer() != nil {
 		preparedSpec, err := template.ExpandContainerSpec(node, t)
@@ -226,12 +228,13 @@ func (c *containerConfig) config() *enginecontainer.Config {
 func (c *containerConfig) labels() map[string]string {
 	var (
 		system = map[string]string{
-			"task":         "", // mark as cluster task
-			"task.id":      c.task.ID,
-			"task.name":    c.name(),
-			"node.id":      c.task.NodeID,
-			"service.id":   c.task.ServiceID,
-			"service.name": c.task.ServiceAnnotations.Name,
+			"task":          "", // mark as cluster task
+			"task.id":       c.task.ID,
+			"task.name":     c.name(),
+			"node.id":       c.task.NodeID,
+			"node.hostname": c.node.Hostname,
+			"service.id":    c.task.ServiceID,
+			"service.name":  c.task.ServiceAnnotations.Name,
 		}
 		labels = make(map[string]string)
 	)


### PR DESCRIPTION
Signed-off-by: Anton Hendriks <antongocode@gmail.com>

**- What I did**

Added the node hostname to the default task labels.

**- How I did it**

The node description is passed to the container config builder function since #34686. The config struct now keeps a reference to the node description and populates the default labels with the node's hostname when called.

**- How to verify it**

docker inspect shows node.hostname as a label by default.

**- Description for the changelog**

Added the node hostname to the default task labels.

**- A picture of a cute animal (not mandatory but encouraged)**

![fox](https://user-images.githubusercontent.com/33478188/34554356-2452a498-f135-11e7-99aa-5accacacc160.jpg)

  