### PR TITLE
Fix `before` and `since` filter for `docker ps`

### DIFF
--- a/integration/container/ps_test.go
+++ b/integration/container/ps_test.go
@@ -1,0 +1,64 @@
+package container
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/integration/util/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPsFilter(t *testing.T) {
+	defer setupTest(t)()
+	client := request.NewAPIClient(t)
+	ctx := context.Background()
+
+	createContainerForFilter := func(ctx context.Context, name string) string {
+		body, err := client.ContainerCreate(ctx,
+			&container.Config{
+				Cmd:   []string{"top"},
+				Image: "busybox",
+			},
+			&container.HostConfig{},
+			&network.NetworkingConfig{},
+			name,
+		)
+		require.NoError(t, err)
+		return body.ID
+	}
+
+	prev := createContainerForFilter(ctx, "prev")
+	createContainerForFilter(ctx, "top")
+	next := createContainerForFilter(ctx, "next")
+
+	containerIDs := func(containers []types.Container) []string {
+		entries := []string{}
+		for _, container := range containers {
+			entries = append(entries, container.ID)
+		}
+		return entries
+	}
+
+	f1 := filters.NewArgs()
+	f1.Add("since", "top")
+	q1, err := client.ContainerList(ctx, types.ContainerListOptions{
+		All:     true,
+		Filters: f1,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, containerIDs(q1), next)
+
+	f2 := filters.NewArgs()
+	f2.Add("before", "top")
+	q2, err := client.ContainerList(ctx, types.ContainerListOptions{
+		All:     true,
+		Filters: f2,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, containerIDs(q2), prev)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This fix tries to address the issue raised in #35931 where `before` and `since` filter for `docker ps` does not work and returns an error:

```
Error response from daemon: no such container <container_name>
```

**- How I did it**

The issue was that `before` and `since` filter are matched with `view.Get()` which does not take into considerations of name match.

This fix fixes the issue by adding additional logic for name match.

**- How to verify it**

An integration test has been added.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![cute-baby-penguin-10](https://user-images.githubusercontent.com/6932348/34592382-607a2d0e-f178-11e7-888a-249a36b553d1.jpg)

This fix fixes #35931.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>