### PR TITLE
Fix issue of filter in `docker ps` where `health=starting` returns nothing

### DIFF
--- a/container/state.go
+++ b/container/state.go
@@ -102,15 +102,6 @@ func (s *State) String() string {
 	return fmt.Sprintf("Exited (%d) %s ago", s.ExitCodeValue, units.HumanDuration(time.Now().UTC().Sub(s.FinishedAt)))
 }
 
-// HealthString returns a single string to describe health status.
-func (s *State) HealthString() string {
-	if s.Health == nil {
-		return types.NoHealthcheck
-	}
-
-	return s.Health.String()
-}
-
 // IsValidHealthString checks if the provided string is a valid container health status or not.
 func IsValidHealthString(s string) bool {
 	return s == types.Starting ||

--- a/container/view.go
+++ b/container/view.go
@@ -295,6 +295,10 @@ func (v *memdbView) GetAllNames() map[string][]string {
 // transform maps a (deep) copied Container object to what queries need.
 // A lock on the Container is not held because these are immutable deep copies.
 func (v *memdbView) transform(container *Container) *Snapshot {
+	health := types.NoHealthcheck
+	if container.Health != nil {
+		health = container.Health.Status()
+	}
 	snapshot := &Snapshot{
 		Container: types.Container{
 			ID:      container.ID,
@@ -313,7 +317,7 @@ func (v *memdbView) transform(container *Container) *Snapshot {
 		Managed:      container.Managed,
 		ExposedPorts: make(nat.PortSet),
 		PortBindings: make(nat.PortSet),
-		Health:       container.HealthString(),
+		Health:       health,
 		Running:      container.Running,
 		Paused:       container.Paused,
 		ExitCode:     container.ExitCode(),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This fix tries to address the issue raised in 35920 where the filter of `docker ps` with  `health=starting` always returns nothing.

**- How I did it**

The issue was that in container view, the human readable string (`HealthString()` => `Health.String()`) of health status was used. In case of starting it is `"health: starting"`. However, the filter still uses `starting` so no match returned.

This fix fixes the issue by using `container.Health.Status()` instead so that it matches the string (`starting`) passed by filter.

**- How to verify it**

An integration test has been added.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![arhero-rabbits-20161209](https://user-images.githubusercontent.com/6932348/34595859-148af9ba-f190-11e7-86e6-229eb0cd674e.jpeg)

This fix fixes #35920.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>