### PR TITLE
Fix Volumes property definition in ContainerConfig

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -838,12 +838,11 @@ definitions:
       Volumes:
         description: "An object mapping mount point paths inside the container to empty objects."
         type: "object"
-        properties:
-          additionalProperties:
-            type: "object"
-            enum:
-              - {}
-            default: {}
+        additionalProperties:
+          type: "object"
+          enum:
+            - {}
+          default: {}
       WorkingDir:
         description: "The working directory for commands to run in."
         type: "string"


### PR DESCRIPTION
Actually the specification was expecting a `additionalProperties` for the Volumes data, where in fact it's expecting a map of string pointing to empty object.


