### PR TITLE
integration: restart tests: don't run in parallel

### DIFF
--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -51,8 +51,6 @@ func TestDaemonRestartKillContainers(t *testing.T) {
 					liveRestoreEnabled := liveRestoreEnabled
 					stopDaemon := stopDaemon
 
-					t.Parallel()
-
 					d := daemon.New(t, "", "dockerd", daemon.Config{})
 					client, err := d.NewClient()
 					if err != nil {


### PR DESCRIPTION
Do not execute `TestDaemonRestartKillContainers` in parallel, which is likely to cause the tests breaking randomly. During development of https://github.com/moby/moby/pull/34319 we've seen restart tests to break randomly and this change helped to fix them. Browsing through some open PRs it looks like others suffer similar issues (e.g., https://github.com/moby/moby/pull/35946).

Cc: @stevvooe 
  