### PR TITLE
LCOW: adds memory limit for linux containers

### DIFF
--- a/libcontainerd/client_local_windows.go
+++ b/libcontainerd/client_local_windows.go
@@ -419,7 +419,7 @@ func (c *client) createLinux(id string, spec *specs.Spec, runtimeOptions interfa
 		configuration.NetworkSharedContainerName = spec.Windows.Network.NetworkSharedContainerName
 	}
 	
-	// Add memory limit (if omittet the memory will be limited to default (1GB) in Hyper-V isolation)
+	// Add memory limit (if omitted the memory will be limited to default (1GB) in Hyper-V isolation)
 	if spec.Windows.Resources.Memory != nil {
 		if spec.Windows.Resources.Memory.Limit != nil {
 			configuration.MemoryMaximumInMB = int64(*spec.Windows.Resources.Memory.Limit) / 1024 / 1024

--- a/libcontainerd/client_local_windows.go
+++ b/libcontainerd/client_local_windows.go
@@ -418,6 +418,13 @@ func (c *client) createLinux(id string, spec *specs.Spec, runtimeOptions interfa
 		}
 		configuration.NetworkSharedContainerName = spec.Windows.Network.NetworkSharedContainerName
 	}
+	
+	// Add memory limit (if omittet the memory will be limited to default (1GB) in Hyper-V isolation)
+	if spec.Windows.Resources.Memory != nil {
+		if spec.Windows.Resources.Memory.Limit != nil {
+			configuration.MemoryMaximumInMB = int64(*spec.Windows.Resources.Memory.Limit) / 1024 / 1024
+		}
+	}
 
 	// Add the mounts (volumes, bind mounts etc) to the structure. We have to do
 	// some translation for both the mapped directories passed into HCS and in


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
LCOW: adds memory limit to linux containers
Because if omitted a Hyper-V container is limited to 1GB and couldn't changed.

**- How I did it**
copy and paste from windows container creation

**- How to verify it**
run meminfo in linux container under windows

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
LCOW: Adds memory limit for linux containers

**- A picture of a cute animal (not mandatory but encouraged)**

