### PR TITLE
Use errdefs instead of string contains for checking not found

### DIFF
--- a/libcontainerd/client_daemon.go
+++ b/libcontainerd/client_daemon.go
@@ -147,7 +147,7 @@ func (c *client) Restore(ctx context.Context, id string, attachStdio StdioCallba
 		rio, err = attachStdio(io)
 		return rio, err
 	})
-	if err != nil && !strings.Contains(err.Error(), "no running task found") {
+	if err != nil && !errdefs.IsNotFound(errors.Cause(err)) {
 		return false, -1, err
 	}
 


### PR DESCRIPTION
Looking at the code path for `Container.Task()` any error with the message should always be a not found error.