### PR TITLE
Disable service on release network

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -966,6 +966,9 @@ func (daemon *Daemon) releaseNetwork(container *container.Container) {
 		logrus.Warnf("error locating sandbox id %s: %v", sid, err)
 		return
 	}
+	if err := sb.DisableService(); err != nil {
+		logrus.WithFields(logrus.Fields{"container": container.ID, "sandbox": sid}).WithError(err).Error("Error removing service from sandbox")
+	}
 
 	if err := sb.Delete(); err != nil {
 		logrus.Errorf("Error deleting sandbox id %s for container %s: %v", sid, container.ID, err)

--- a/vendor.conf
+++ b/vendor.conf
@@ -30,7 +30,7 @@ github.com/moby/buildkit aaff9d591ef128560018433fe61beb802e149de8
 github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 
 #get libnetwork packages
-github.com/docker/libnetwork a1dfea384b39779552a3b4837ea9303194950976
+github.com/docker/libnetwork 315a076a4e9ded2abc950318c71d5f1637547977 
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/endpoint.go
+++ b/vendor/github.com/docker/libnetwork/endpoint.go
@@ -311,16 +311,25 @@ func (ep *endpoint) isAnonymous() bool {
 	return ep.anonymous
 }
 
-// enableService sets ep's serviceEnabled to the passed value if it's not in the
-// current state and returns true; false otherwise.
-func (ep *endpoint) enableService(state bool) bool {
+// isServiceEnabled check if service is enabled on the endpoint
+func (ep *endpoint) isServiceEnabled() bool {
 	ep.Lock()
 	defer ep.Unlock()
-	if ep.serviceEnabled != state {
-		ep.serviceEnabled = state
-		return true
-	}
-	return false
+	return ep.serviceEnabled
+}
+
+// enableService sets service enabled on the endpoint
+func (ep *endpoint) enableService() {
+	ep.Lock()
+	defer ep.Unlock()
+	ep.serviceEnabled = true
+}
+
+// disableService disables service on the endpoint
+func (ep *endpoint) disableService() {
+	ep.Lock()
+	defer ep.Unlock()
+	ep.serviceEnabled = false
 }
 
 func (ep *endpoint) needResolver() bool {
@@ -757,10 +766,6 @@ func (ep *endpoint) sbLeave(sb *sandbox, force bool, options ...EndpointOption) 
 	// detach but after store has been updated.
 	if err := n.getController().updateToStore(ep); err != nil {
 		return err
-	}
-
-	if e := ep.deleteServiceInfoFromCluster(sb, "sbLeave"); e != nil {
-		logrus.Errorf("Could not delete service state for endpoint %s from cluster: %v", ep.Name(), e)
 	}
 
 	if e := ep.deleteDriverInfoFromCluster(); e != nil {


### PR DESCRIPTION
This PR contains a fix for moby/moby#30321. There was a moby/moby#31142
PR intending to fix the issue by adding a delay between disabling the
service in the cluster and the shutdown of the tasks. However
disabling the service was not deleting the service info in the cluster.
Added a fix to delete service info from cluster and verified using siege
to ensure there is zero downtime on rolling update of a service.In order
to support it and ensure consitency of enabling and disable service knob
from the daemon, we need to ensure we disable service when we release
the network from the container. This helps in making the enable and
disable service less racy. The corresponding part of libnetwork fix is
part of docker/libnetwork#1824

Signed-off-by: abhi <abhi@docker.com>

**- What I did**
In order to ensure enable and disable a service on an sandbox less racy , explictly disable service on the sandbox during a container exit event on the network side. This entry point is the releaseNetwork action which triggers the tearing of the network resource for a container.
**- How I did it**
Added DisableService action on releaseNetwork
**- How to verify it**
This is particularly important during rolling update of a service and when the tasks in a swarm service goes down. Verified using siege and performing zero downtime rolling update.

**- Description for the changelog**
<!--
Zero downtime rolling update for swarm
-->


**- A picture of a cute animal (not mandatory but encouraged)**

