### PR TITLE
Allow containerd to detect running from initramfs on Linux

### DIFF
--- a/libcontainerd/client_daemon.go
+++ b/libcontainerd/client_daemon.go
@@ -263,7 +263,7 @@ func (c *client) Start(ctx context.Context, id, checkpointDir string, withStdin 
 			info.Options = &runctypes.CreateOptions{
 				IoUid:       uint32(uid),
 				IoGid:       uint32(gid),
-				NoPivotRoot: os.Getenv("DOCKER_RAMDISK") != "",
+				NoPivotRoot: os.Getenv("DOCKER_RAMDISK") != "" || isInitramfs(),
 			}
 			return nil
 		})

--- a/libcontainerd/client_daemon_windows.go
+++ b/libcontainerd/client_daemon_windows.go
@@ -53,3 +53,7 @@ func newFIFOSet(bundleDir, processID string, withStdin, withTerminal bool) *cio.
 
 	return cio.NewFIFOSet(config, nil)
 }
+
+func isInitramfs() bool {
+	return false
+}


### PR DESCRIPTION
It is very easy to forget to configure `DOCKER_RAMDISK` environment variable, when setting up Docker on stateless systems/initrds.

The code should autodetect, if the root filesystem is on ramfs/tmpfs and do not try to `pivot_root`.