### PR TITLE
Return 400 status instead of 500 for empty volume create body

### DIFF
--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -2,11 +2,14 @@ package volume
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types/filters"
 	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/errdefs"
 	"golang.org/x/net/context"
 )
 
@@ -45,6 +48,9 @@ func (v *volumeRouter) postVolumesCreate(ctx context.Context, w http.ResponseWri
 
 	var req volumetypes.VolumesCreateBody
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if err == io.EOF {
+			return errdefs.InvalidParameter(errors.New("got EOF while reading request body"))
+		}
 		return err
 	}
 


### PR DESCRIPTION
Fixes https://github.com/moby/moby/issues/34181

The `POST /volumes/create` expects a request body to be provided. If no body was provided, a 500 status was returned. A 500 status is incorrect, because the request is invalid (it's not a server error).

Before this change:

    $ curl --unix-socket /var/run/docker.sock -v -X POST http://localhost/volumes/create

    *   Trying /var/run/docker.sock...
    * Connected to localhost (/Users/sebastiaan/Library/Containers/com.dock) port 80 (#0)
    > POST /volumes/create HTTP/1.1
    > Host: localhost
    > User-Agent: curl/7.51.0
    > Accept: */*
    >
    < HTTP/1.1 500 Internal Server Error
    < Api-Version: 1.30
    < Content-Length: 18
    < Content-Type: application/json
    < Date: Wed, 19 Jul 2017 11:29:26 GMT
    < Docker-Experimental: true
    < Ostype: linux
    < Server: Docker/17.06.0-ce (linux)
    <
    {"message":"EOF"}
    * Curl_http_done: called premature == 0
    * Connection #0 to host localhost left intact

After this change:

    $ curl --unix-socket /var/run/docker.sock -v -X POST http://localhost/volumes/create

    *   Trying /var/run/docker.sock...
    * Connected to localhost (/var/run/docker.sock) port 80 (#0)
    > POST /volumes/create HTTP/1.1
    > Host: localhost
    > User-Agent: curl/7.52.1
    > Accept: */*
    >
    < HTTP/1.1 400 Bad Request
    < Api-Version: 1.36
    < Content-Type: application/json
    < Docker-Experimental: false
    < Ostype: linux
    < Server: Docker/dev (linux)
    < Date: Tue, 09 Jan 2018 15:00:13 GMT
    < Content-Length: 42
    <
    {"message":"no body provided in request"}
    * Curl_http_done: called premature == 0
    * Connection #0 to host localhost left intact

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
* Fix incorrect `500` status code for `POST /volumes/create` with empty body [moby/moby#35965](https://github.com/moby/moby/pull/35965)
```


  