### PR TITLE
 Fix network alias issue with `network connect`

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -275,12 +275,11 @@ func (n *networkRouter) postNetworkConnect(ctx context.Context, w http.ResponseW
 		return err
 	}
 
-	// Always make sure there is no ambiguity with respect to the network ID/name
-	nw, err := n.backend.FindNetwork(vars["id"])
-	if err != nil {
-		return err
-	}
-	return n.backend.ConnectContainerToNetwork(connect.Container, nw.ID(), connect.EndpointConfig)
+	// Unlike other operations, we does not check ambiguity of the name/ID here.
+	// The reason is that, In case of attachable network in swarm scope, the actual local network
+	// may not be available at the time. At the same time, inside daemon `ConnectContainerToNetwork`
+	// does the ambiguity check anyway. Therefore, passing the name to daemon would be enough.
+	return n.backend.ConnectContainerToNetwork(connect.Container, vars["id"], connect.EndpointConfig)
 }
 
 func (n *networkRouter) postNetworkDisconnect(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/integration/service/network_test.go
+++ b/integration/service/network_test.go
@@ -1,0 +1,86 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/integration-cli/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerNetworkConnectAlias(t *testing.T) {
+	defer setupTest(t)()
+	d := newSwarm(t)
+	defer d.Stop(t)
+	client, err := request.NewClientForHost(d.Sock())
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	name := "test-alias"
+	_, err = client.NetworkCreate(ctx, name, types.NetworkCreate{
+		Driver:     "overlay",
+		Attachable: true,
+	})
+	require.NoError(t, err)
+	_, err = client.ContainerCreate(ctx,
+		&container.Config{
+			Cmd:   []string{"top"},
+			Image: "busybox",
+		},
+		&container.HostConfig{},
+		&network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{
+				name: {},
+			},
+		},
+		"ng1",
+	)
+	require.NoError(t, err)
+	err = client.NetworkConnect(ctx, name, "ng1", &network.EndpointSettings{
+		Aliases: []string{
+			"aaa",
+		},
+	})
+	require.NoError(t, err)
+
+	err = client.ContainerStart(ctx, "ng1", types.ContainerStartOptions{})
+	require.NoError(t, err)
+
+	ng1, err := client.ContainerInspect(ctx, "ng1")
+	require.NoError(t, err)
+	assert.Equal(t, len(ng1.NetworkSettings.Networks[name].Aliases), 2)
+	assert.Equal(t, ng1.NetworkSettings.Networks[name].Aliases[0], "aaa")
+
+	_, err = client.ContainerCreate(ctx,
+		&container.Config{
+			Cmd:   []string{"top"},
+			Image: "busybox",
+		},
+		&container.HostConfig{},
+		&network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{
+				name: {},
+			},
+		},
+		"ng2",
+	)
+	require.NoError(t, err)
+	err = client.NetworkConnect(ctx, name, "ng2", &network.EndpointSettings{
+		Aliases: []string{
+			"bbb",
+		},
+	})
+	require.NoError(t, err)
+
+	err = client.ContainerStart(ctx, "ng2", types.ContainerStartOptions{})
+	require.NoError(t, err)
+
+	ng2, err := client.ContainerInspect(ctx, "ng2")
+	require.NoError(t, err)
+	assert.Equal(t, len(ng2.NetworkSettings.Networks[name].Aliases), 2)
+	assert.Equal(t, ng2.NetworkSettings.Networks[name].Aliases[0], "bbb")
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This fix tries to address the issue raised in #33661 where network alias does not work when connect to a network the second time.

This fix address the issue by updating the network settings when `connect`

**- How I did it**

**- How to verify it**

An integration test has been added.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

![ayxirim](https://user-images.githubusercontent.com/6932348/34739351-decb816a-f530-11e7-9144-9b748b88f550.jpg)


This fix fixes #33661.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>