### PR TITLE
Fix node-generic-resources CLI typo

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -67,7 +67,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 
 	flags.StringVar(&conf.MetricsAddress, "metrics-addr", "", "Set default address and port to serve the metrics api on")
 
-	flags.Var(opts.NewListOptsRef(&conf.NodeGenericResources, opts.ValidateSingleGenericResource), "node-generic-resource", "Advertise user-defined resource")
+	flags.Var(opts.NewListOptsRef(&conf.NodeGenericResources, opts.ValidateSingleGenericResource), "node-generic-resources", "Advertise user-defined resource")
 
 	flags.IntVar(&conf.NetworkControlPlaneMTU, "network-control-plane-mtu", config.DefaultNetworkMtu, "Network Control plane MTU")
 


### PR DESCRIPTION
Signed-off-by: Renaud Gaubert <rgaubert@nvidia.com>


**- What I did**
The CLI argument `node-generic-resource` was incorrectly spelled.
That create a bug where it was not merged into the config when specified in the a config file.

/ping @thaJeztah 
Do you think we can get this in 18.01 ?

Thanks!
  