### PR TITLE
Bump libnetwork to a1dfea384b39779552a3b4837ea9303194950976

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -30,7 +30,7 @@ github.com/moby/buildkit aaff9d591ef128560018433fe61beb802e149de8
 github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 
 #get libnetwork packages
-github.com/docker/libnetwork 26531e56a76d7334e594098d7cfab88285d9065c
+github.com/docker/libnetwork a1dfea384b39779552a3b4837ea9303194950976
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/drivers/overlay/ov_network.go
+++ b/vendor/github.com/docker/libnetwork/drivers/overlay/ov_network.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/libnetwork/datastore"
@@ -693,6 +692,12 @@ func (n *network) initSandbox(restore bool) error {
 		n.driver.initSandboxPeerDB(n.id)
 	}
 
+	// If we are in swarm mode, we don't need anymore the watchMiss routine.
+	// This will save 1 thread and 1 netlink socket per network
+	if !n.driver.isSerfAlive() {
+		return nil
+	}
+
 	var nlSock *nl.NetlinkSocket
 	sbox.InvokeFunc(func() {
 		nlSock, err = nl.Subscribe(syscall.NETLINK_ROUTE, syscall.RTNLGRP_NEIGH)
@@ -716,7 +721,6 @@ func (n *network) initSandbox(restore bool) error {
 }
 
 func (n *network) watchMiss(nlSock *nl.NetlinkSocket) {
-	t := time.Now()
 	for {
 		msgs, err := nlSock.Receive()
 		if err != nil {
@@ -772,30 +776,13 @@ func (n *network) watchMiss(nlSock *nl.NetlinkSocket) {
 				continue
 			}
 
-			if n.driver.isSerfAlive() {
-				logrus.Debugf("miss notification: dest IP %v, dest MAC %v", ip, mac)
-				mac, IPmask, vtep, err := n.driver.resolvePeer(n.id, ip)
-				if err != nil {
-					logrus.Errorf("could not resolve peer %q: %v", ip, err)
-					continue
-				}
-				n.driver.peerAdd(n.id, "dummy", ip, IPmask, mac, vtep, l2Miss, l3Miss, false)
-			} else if l3Miss && time.Since(t) > time.Second {
-				// All the local peers will trigger a miss notification but this one is expected and the local container will reply
-				// autonomously to the ARP request
-				// In case the gc_thresh3 values is low kernel might reject new entries during peerAdd. This will trigger the following
-				// extra logs that will inform of the possible issue.
-				// Entries created would not be deleted see documentation http://man7.org/linux/man-pages/man7/arp.7.html:
-				// Entries which are marked as permanent are never deleted by the garbage-collector.
-				// The time limit here is to guarantee that the dbSearch is not
-				// done too frequently causing a stall of the peerDB operations.
-				pKey, pEntry, err := n.driver.peerDbSearch(n.id, ip)
-				if err == nil && !pEntry.isLocal {
-					t = time.Now()
-					logrus.Warnf("miss notification for peer:%+v l3Miss:%t l2Miss:%t, if the problem persist check the gc_thresh on the host pKey:%+v pEntry:%+v err:%v",
-						neigh, l3Miss, l2Miss, *pKey, *pEntry, err)
-				}
+			logrus.Debugf("miss notification: dest IP %v, dest MAC %v", ip, mac)
+			mac, IPmask, vtep, err := n.driver.resolvePeer(n.id, ip)
+			if err != nil {
+				logrus.Errorf("could not resolve peer %q: %v", ip, err)
+				continue
 			}
+			n.driver.peerAdd(n.id, "dummy", ip, IPmask, mac, vtep, l2Miss, l3Miss, false)
 		}
 	}
 }

--- a/vendor/github.com/docker/libnetwork/osl/namespace_linux.go
+++ b/vendor/github.com/docker/libnetwork/osl/namespace_linux.go
@@ -220,9 +220,11 @@ func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error) {
 	if err != nil {
 		logrus.Warnf("Failed to set the timeout on the sandbox netlink handle sockets: %v", err)
 	}
-
+	// In live-restore mode, IPV6 entries are getting cleaned up due to below code
+	// We should retain IPV6 configrations in live-restore mode when Docker Daemon
+	// comes back. It should work as it is on other cases
 	// As starting point, disable IPv6 on all interfaces
-	if !n.isDefault {
+	if !isRestore && !n.isDefault {
 		err = setIPv6(n.path, "all", false)
 		if err != nil {
 			logrus.Warnf("Failed to disable IPv6 on all interfaces on network namespace %q: %v", n.path, err)

--- a/vendor/github.com/docker/libnetwork/sandbox_dns_unix.go
+++ b/vendor/github.com/docker/libnetwork/sandbox_dns_unix.go
@@ -362,7 +362,7 @@ func (sb *sandbox) rebuildDNS() error {
 dnsOpt:
 	for _, resOpt := range resOptions {
 		if strings.Contains(resOpt, "ndots") {
-			for _, option := range dnsOptionsList {
+			for i, option := range dnsOptionsList {
 				if strings.Contains(option, "ndots") {
 					parts := strings.Split(option, ":")
 					if len(parts) != 2 {
@@ -371,7 +371,10 @@ dnsOpt:
 					if num, err := strconv.Atoi(parts[1]); err != nil {
 						return fmt.Errorf("invalid number for ndots option %v", option)
 					} else if num > 0 {
+						// if the user sets ndots, we mark it as set but we remove the option to guarantee
+						// that into the container land only ndots:0
 						sb.ndotsSet = true
+						dnsOptionsList = append(dnsOptionsList[:i], dnsOptionsList[i+1:]...)
 						break dnsOpt
 					}
 				}


### PR DESCRIPTION
Full diff: https://github.com/docker/libnetwork/compare/26531e56a76d7334e594098d7cfab88285d9065c...a1dfea384b39779552a3b4837ea9303194950976


Changes included:

- https://github.com/docker/libnetwork/pull/1995 Fix ndots configuration (fixes https://github.com/docker/libnetwork/issues/1988 "ndots issue on daemon config for services")
- https://github.com/docker/libnetwork/pull/2043 Enable IPV6 config on Sandbox creation on live-restore case (fixes https://github.com/moby/moby/issues/35757)
- https://github.com/docker/libnetwork/pull/2041 Handle DNS queries of type MX (addresses: https://github.com/docker/libnetwork/issues/2026 "DNS returns NXDOMAIN for MX request of existing host")

Other changes:
- https://github.com/docker/libnetwork/pull/2047 Remove watchMiss for swarm mode
- https://github.com/docker/libnetwork/pull/2042 enable unit test in arm64


I left out https://github.com/docker/libnetwork/pull/1824, which is being addressed in https://github.com/moby/moby/pull/35960 and requires local changes.