### PR TITLE
Check that the VOLUME instruction arguments are not '.' or '/'

### DIFF
--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -349,6 +349,60 @@ func TestVolume(t *testing.T) {
 	assert.Contains(t, sb.state.runConfig.Volumes, exposedVolume)
 }
 
+type PathVolTest struct {
+	volume     string
+	os         string
+	workingDir string
+	volumes    map[string]struct{}
+	err        string
+}
+
+var winVolumes = []PathVolTest{
+	{volume: "code", workingDir: "", os: "windows", volumes: nil, err: ""},
+	{volume: `C:\code`, workingDir: "", os: "windows", volumes: nil, err: ""},
+	{volume: `C:\`, workingDir: "", os: "windows", volumes: nil, err: "invalid mount config for type \"volume\": destination path cannot be `c:` or `c:\\`: c:\\"},
+}
+
+var unixVolumes = []PathVolTest{
+	{volume: "opt", workingDir: "", os: "linux", volumes: nil, err: ""},
+	{volume: "/opt", workingDir: "", os: "linux", volumes: map[string]struct{}{"/opt": {}}, err: "VOLUME '/opt' was specified more than once"},
+	{volume: "/opt", workingDir: "", os: "linux", volumes: nil, err: ""},
+	{volume: "/", workingDir: "", os: "linux", volumes: nil, err: "invalid mount config for type \"volume\": invalid specification: destination can't be '/'"},
+	{volume: "/opt/..", workingDir: "", os: "linux", volumes: nil, err: "invalid mount config for type \"volume\": invalid specification: destination can't be '/'"},
+	{volume: "/..", workingDir: "", os: "linux", volumes: nil, err: "invalid mount config for type \"volume\": invalid specification: destination can't be '/'"},
+	{volume: ".", workingDir: "", os: "linux", volumes: nil, err: "invalid mount config for type \"volume\": invalid specification: destination can't be '/'"},
+	{volume: ".", workingDir: "/hello", os: "linux", volumes: nil, err: ""},
+}
+
+func TestVolumeValidation(t *testing.T) {
+	testCases := unixVolumes
+	if runtime.GOOS == "windows" {
+		testCases = winVolumes
+	}
+
+	for _, c := range testCases {
+		b := newBuilderWithMockBackend()
+		sb := newDispatchRequest(b, '`', nil, newBuildArgs(make(map[string]*string)), newStagesBuildResults())
+		sb.state.operatingSystem = c.os
+		sb.state.runConfig.Volumes = c.volumes
+		sb.state.runConfig.WorkingDir = c.workingDir
+
+		cmd := &instructions.VolumeCommand{
+			Volumes: []string{c.volume},
+		}
+		err := dispatch(sb, cmd)
+		if c.err == "" {
+			require.NoError(t, err, "volume %q", c.volume)
+		} else {
+			if err == nil {
+				t.Errorf("expected to return error %q but got nil", c.err)
+				continue
+			}
+			require.Equal(t, c.err, err.Error())
+		}
+	}
+}
+
 func TestStopSignal(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows does not support stopsignal")


### PR DESCRIPTION
**- What I did**
Fixes #35879

This patch adds more verifications to the VOLUME instruction and makes sure that the '/' and '.' inside the container can not be mounted because it removes all the files in the container.

This kind of verification is already done when running a container and thus it makes sense to run a similar one when/before building an image.

For example, when running:

```
$ docker run -it --rm -v myvolume:/ nginx
```

The following error will be displayed:

```
invalid specification: destination can't be '/'.
```

However, when building the following Dockerfile:

```
FROM nginx
VOLUME ["/"]
```

when running a container that's using that image this is the error message:

```
container init caused \"open /dev/ptmx: no such file or directory\"
```

If the above Dockerfile was built using this patch then this would have been the error:

```
VOLUME specified can not be '/'
```

which is less confusing.


**- How I did it**

* Add a check to `builder/dockerfile/instructions/parse.parseVolume`
* Where we check that the argument is not an empty string, I added another check for `/` and `.`.

**- How to verify it**

Run unit-tests. I added three testcases to `TestErrorCases` in `parse_test.go`.

**- Description for the changelog**
