### PR TITLE
Fix race with concurrent daemon startup in tests

### DIFF
--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -59,9 +59,9 @@ func TestDaemonRestartKillContainers(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					var args []string
+					args := []string{"--iptables=false"}
 					if liveRestoreEnabled {
-						args = []string{"--live-restore"}
+						args = append(args, "--live-restore")
 					}
 
 					d.StartWithBusybox(t, args...)


### PR DESCRIPTION
Using parallel tests is nice, however it can cause an issue with
multiple daemons trying to make changes to iptables at the same time
which causes flakey tests.

This just disables iptables for the set of tests since it is not
required.

Fixes #35914