### PR TITLE
Add required pkg-config for Dockerfile.simple

### DIFF
--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
 		e2fsprogs \
 		iptables \
+		pkg-config \
 		procps \
 		xfsprogs \
 		xz-utils \


### PR DESCRIPTION
This fix tries to address the issue raised in #35980 where pkg-config was missing and was causing Dockerfile.simple build to fail.

```
$ docker build -t docker:simple -f Dockerfile.simple .
..........
CGO_ENABLED=1 go build  -tags "seccomp apparmor selinux netgo cgo static_build" -installsuffix netgo -ldflags "-w -extldflags -static -X main.gitCommit="b2567b37d7b75eb4cf325b77297b140ea686ce8f" -X main.version=1.0.0-rc4+dev " -o runc .
pkg-config: exec: "pkg-config": executable file not found in $PATH
make: *** [static] Error 2
Makefile:42: recipe for target 'static' failed
The command '/bin/sh -c /tmp/install-binaries.sh runc containerd tini proxy dockercli' returned a non-zero code: 2
```

This fix fixes #35980.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
