### PR TITLE
Fix timeout issue of  multi-services creation on AArch64

### DIFF
--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -43,7 +43,8 @@ func TestCreateServiceMultipleTimes(t *testing.T) {
 	require.NoError(t, err)
 
 	pollSettings := func(config *poll.Settings) {
-		if runtime.GOARCH == "arm" {
+		// It takes about ~25s to finish the multi services creation in this case per the pratical observation on arm64/arm platform
+		if runtime.GOARCH == "arm64" || runtime.GOARCH == "arm" {
 			config.Timeout = 30 * time.Second
 			config.Delay = 100 * time.Millisecond
 		}


### PR DESCRIPTION
Now we only adjust the timeout value for `arm` while not `arm64`,
actually the avarage duration for this test is about 25s to create
multiple services on arm64, else the integration test will terminate
with below error:

> --- FAIL: TestCreateServiceMultipleTimes (24.11s)
>         daemon.go:285: [ddc3c7c1476c2] waiting for daemon to start
>         daemon.go:317: [ddc3c7c1476c2] daemon started
>         poll.go:121: timeout hit after 10s: task count at 4 waiting for 0
>         daemon.go:275: [ddc3c7c1476c2] exiting daemon
>         clean.go:108: Removing image sha256:e6a8d12d58602a19277ee5632b7ff9fa56a4ea52ba00eedf1d3f6f5a495fe761
>         clean.go:108: Removing image sha256:876244cc2ecb8fe1b0b2e817e3b78709a2a735edb093bc6849f99aa6c18f3a01

This PR adjusts the timeout value for both `arm64` and `arm` to mitigate
this issue on those 2 platforms.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix a timeout issue which terminates the integration test
**- How I did it**
Adjust the timeout value
**- How to verify it**
`make test-integration` based on the latest codes.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

