### PR TITLE
Wrap response error for container logs method.

### DIFF
--- a/client/container_logs.go
+++ b/client/container_logs.go
@@ -74,7 +74,7 @@ func (cli *Client) ContainerLogs(ctx context.Context, container string, options 
 
 	resp, err := cli.get(ctx, "/containers/"+container+"/logs", query, nil)
 	if err != nil {
-		return nil, err
+		return nil, wrapResponseError(err, resp, "container", container)
 	}
 	return resp.body, nil
 }

--- a/client/container_logs_test.go
+++ b/client/container_logs_test.go
@@ -18,6 +18,16 @@ import (
 	"golang.org/x/net/context"
 )
 
+func TestContainerLogsNotFoundError(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusNotFound, "Not found")),
+	}
+	_, err := client.ContainerLogs(context.Background(), "container_id", types.ContainerLogsOptions{})
+	if !IsErrNotFound(err) {
+		t.Fatalf("expected a not found error, got %v", err)
+	}
+}
+
 func TestContainerLogsError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did / How I did it**

I wrapped the response error for `/containers/{id}/logs` requests so that `IsErrNotFound` and `IsErrNotImplemented` could work as intended.

**- How to verify it**

Test added.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed error detection using `IsErrNotFound` and `IsErrNotImplemented` for the `ContainerLogs` method.
