### PR TITLE
[ci] use alternate sh comparison

### DIFF
--- a/contrib/download-frozen-image-v2.sh
+++ b/contrib/download-frozen-image-v2.sh
@@ -63,7 +63,7 @@ fetch_blob() {
 			-D-
 	)"
 	curlHeaders="$(echo "$curlHeaders" | tr -d '\r')"
-	if echo "$curlHeaders" | grep -qE "^HTTP/[0-9].[0-9] 3"; then
+	if grep -qE "^HTTP/[0-9].[0-9] 3" <<<"$curlHeaders"; then
 		rm -f "$targetFile"
 
 		local blobRedirect="$(echo "$curlHeaders" | awk -F ': ' 'tolower($1) == "location" { print $2; exit }')"


### PR DESCRIPTION
The pattern `echo str | grep -qE pattern` likes to fail on the z CI here for
an unknown reason, which causes one of the layers of the frozen-image to not download. Use `grep -qE pattern <<< str` instead.

I've ran more than 1k tests on this in total over the past two weeks and can provide no definitive conclusion on what the actual problem is, but this seems to work around it.


Notes if anyone wants to continue looking into the original failure: 

- The original pattern passes unless it has any grep quiet flags (-q, --quiet, --silent). This isn't reproducible on similar vms with the same version of grep, in the same container. Additionally _this_ pattern passes _with_ the quiet flag.

- $curlHeaders appears to always output _something_ here, i.e. not nil

- the beginning 104 bytes of a passing $curlHeaders and a failing $curlHeaders, are exactly the same. differences past that are most likely due to the redirect link being different as well as the time


Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>

![how i feel](http://www.woofipedia.com/images/uploads/_600x400/tailchasing.jpg)