### PR TITLE
Fixing ingress network when upgrading from 17.09 to 17.12.

### DIFF
--- a/daemon/cluster/executor/container/executor.go
+++ b/daemon/cluster/executor/container/executor.go
@@ -146,6 +146,11 @@ func (e *executor) Configure(ctx context.Context, node *api.Node) error {
 		attachments[na.Network.ID] = na.Addresses[0]
 	}
 
+	if (ingressNA == nil) && (node.Attachment != nil) {
+		ingressNA = node.Attachment
+		attachments[ingressNA.Network.ID] = ingressNA.Addresses[0]
+	}
+
 	if ingressNA == nil {
 		e.backend.ReleaseIngress()
 		return e.backend.GetAttachmentStore().ResetAttachments(attachments)


### PR DESCRIPTION
Signed-off-by: Pradip Dhara <pradipd@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This change fixes #35941.

**- How I did it**
The fix is to use node.Attachment when the node message is sent from an older (17.09) docker node.

**- How to verify it**
Followed the steps outlined in https://github.com/moby/moby/issues/35941
Just to re-iterate the steps:
1. create a 3 manager swarm cluster with 17.09.
2. stopped a node (the leader)
3. upgraded the leader to 17.12.
4. restarted the node

Before the change:
The node would re-join the swarm but the ingress network would not be setup.  I.e. docker inspect ingress would not the ingress-sbox.
```
[
    {
        "Name": "ingress",
        "Id": "08yngdvcwrj9a5eyn4ky0zx3c",
<omitted for brevity>
        "Containers": null,
<...>
    }
]
```

After the change:
The node re-joins the swarm and the ingress network is set up.  
```
[
    {
        "Name": "ingress",
<...>
        "Containers": {
            "ingress-sbox": {
                "Name": "ingress-endpoint",
                "EndpointID": "0131766b4cd69b1d32bac53379ca0e89d20262ebc6db36d3ecfba98a21683d98",
                "MacAddress": "02:42:0a:ff:00:02",
                "IPv4Address": "10.255.0.2/16",
                "IPv6Address": ""
            }
        },
        "Options": {
            "com.docker.network.driver.overlay.vxlanid_list": "4096"
        },
        "Labels": {},
        "Peers": [
            {
                "Name": "ab4fd85edacb",
                "IP": "172.16.2.8"
            },
            {
                "Name": "84fc8105e3d0",
                "IP": "172.16.2.9"
            },
            {
                "Name": "5b29937591d1",
                "IP": "172.16.2.10"
            }
        ]
    }
]
```

I then finished upgrading all nodes to 17.12.

**- Description for the changelog**
Handle swarm node messages from older docker daemons.

**- A picture of a cute animal (not mandatory but encouraged)**
Imagine 2 kittens cuddling.
