### PR TITLE
Small nitpick: create ErrVolumeTargetIsRoot in the volume package

### DIFF
--- a/volume/lcow_parser.go
+++ b/volume/lcow_parser.go
@@ -2,7 +2,6 @@ package volume
 
 import (
 	"errors"
-	"fmt"
 	"path"
 
 	"github.com/docker/docker/api/types/mount"
@@ -10,7 +9,7 @@ import (
 
 var lcowSpecificValidators mountValidator = func(m *mount.Mount) error {
 	if path.Clean(m.Target) == "/" {
-		return fmt.Errorf("invalid specification: destination can't be '/'")
+		return ErrVolumeTargetIsRoot
 	}
 	if m.Type == mount.TypeNamedPipe {
 		return errors.New("Linux containers on Windows do not support named pipe mounts")

--- a/volume/linux_parser.go
+++ b/volume/linux_parser.go
@@ -29,7 +29,7 @@ func linuxSplitRawSpec(raw string) ([]string, error) {
 func linuxValidateNotRoot(p string) error {
 	p = path.Clean(strings.Replace(p, `\`, `/`, -1))
 	if p == "/" {
-		return fmt.Errorf("invalid specification: destination can't be '/'")
+		return ErrVolumeTargetIsRoot
 	}
 	return nil
 }

--- a/volume/parser.go
+++ b/volume/parser.go
@@ -1,6 +1,7 @@
 package volume
 
 import (
+	"errors"
 	"runtime"
 
 	"github.com/docker/docker/api/types/mount"
@@ -12,6 +13,10 @@ const (
 	// OSWindows is the same as runtime.GOOS on windows
 	OSWindows = "windows"
 )
+
+// ErrVolumeTargetIsRoot is returned when the target destination is root.
+// It's used by both LCOW and Linux parsers.
+var ErrVolumeTargetIsRoot = errors.New("invalid specification: destination can't be '/'")
 
 // Parser represents a platform specific parser for mount expressions
 type Parser interface {


### PR DESCRIPTION
**- What I did**

Both `lcow_parser.go` and `linux_parser.go` are duplicating the error: `invalid specification: destination can't be '/'`

This commit removes this duplication in the code.

**- How I did it**


This change creates a new error called `ErrVolumeTargetIsRoot` which contains this error message and that is used by both linux_parser and lcow_parser.

**- How to verify it**

Run unit tests
