### PR TITLE
Skip the pull test of arm64-missed image

### DIFF
--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -192,6 +193,13 @@ func (s *DockerHubPullSuite) TestPullScratchNotAllowed(c *check.C) {
 // TestPullAllTagsFromCentralRegistry pulls using `all-tags` for a given image and verifies that it
 // results in more images than a naked pull.
 func (s *DockerHubPullSuite) TestPullAllTagsFromCentralRegistry(c *check.C) {
+	// The manifest of the `dockercore/engine-pull-all-test-fixture` image doesn't support `arm64` yet,
+	// refer to `https://hub.docker.com/r/dockercore/engine-pull-all-test-fixture/`, skip it now and
+	// will trigger the rest of this test in the future after `arm64` has been squashed into the manifest
+	if runtime.GOARCH == "arm64" {
+		c.Skip("The testing image doesn't support arm64 yet")
+	}
+
 	testRequires(c, DaemonIsLinux)
 	s.Cmd(c, "pull", "dockercore/engine-pull-all-test-fixture")
 	outImageCmd := s.Cmd(c, "images", "dockercore/engine-pull-all-test-fixture")


### PR DESCRIPTION
There's no `arm64` arch support in the manifest of the
`dockercore/engine-pull-all-test-fixture` image currently[1],so let's
skip it to avoid the `no matching manifest for linux/arm64 in the
manifest list entries` error.

[1] https://hub.docker.com/r/dockercore/engine-pull-all-test-fixture/

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
skip a test case which doesn't support arm64 at all
**- How I did it**
just skip it
**- How to verify it**
`make test-integration`
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![summit1](https://user-images.githubusercontent.com/29669302/34940223-b322005e-fa29-11e7-8bf9-ba4cd5a78001.jpg)

