### PR TITLE
improve daemon config reload; log active configuration

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -167,7 +167,7 @@ type CommonConfig struct {
 	sync.Mutex
 	// FIXME(vdemeester) This part is not that clear and is mainly dependent on cli flags
 	// It should probably be handled outside this package.
-	ValuesSet map[string]interface{}
+	ValuesSet map[string]interface{} `json:"-"`
 
 	Experimental bool `json:"experimental"` // Experimental indicates whether experimental features should be exposed or not
 

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -4,7 +4,6 @@ package daemon
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -677,51 +676,6 @@ func (daemon *Daemon) initRuntimes(runtimes map[string]types.Runtime) (err error
 			return err
 		}
 	}
-	return nil
-}
-
-// reloadPlatform updates configuration with platform specific options
-// and updates the passed attributes
-func (daemon *Daemon) reloadPlatform(conf *config.Config, attributes map[string]string) error {
-	if err := conf.ValidatePlatformConfig(); err != nil {
-		return err
-	}
-
-	if conf.IsValueSet("runtimes") {
-		// Always set the default one
-		conf.Runtimes[config.StockRuntimeName] = types.Runtime{Path: DefaultRuntimeBinary}
-		if err := daemon.initRuntimes(conf.Runtimes); err != nil {
-			return err
-		}
-		daemon.configStore.Runtimes = conf.Runtimes
-	}
-
-	if conf.DefaultRuntime != "" {
-		daemon.configStore.DefaultRuntime = conf.DefaultRuntime
-	}
-
-	if conf.IsValueSet("default-shm-size") {
-		daemon.configStore.ShmSize = conf.ShmSize
-	}
-
-	if conf.IpcMode != "" {
-		daemon.configStore.IpcMode = conf.IpcMode
-	}
-
-	// Update attributes
-	var runtimeList bytes.Buffer
-	for name, rt := range daemon.configStore.Runtimes {
-		if runtimeList.Len() > 0 {
-			runtimeList.WriteRune(' ')
-		}
-		runtimeList.WriteString(fmt.Sprintf("%s:%s", name, rt))
-	}
-
-	attributes["runtimes"] = runtimeList.String()
-	attributes["default-runtime"] = daemon.configStore.DefaultRuntime
-	attributes["default-shm-size"] = fmt.Sprintf("%d", daemon.configStore.ShmSize)
-	attributes["default-ipc-mode"] = daemon.configStore.IpcMode
-
 	return nil
 }
 

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -207,12 +207,6 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 	return warnings, err
 }
 
-// reloadPlatform updates configuration with platform specific options
-// and updates the passed attributes
-func (daemon *Daemon) reloadPlatform(config *config.Config, attributes map[string]string) error {
-	return nil
-}
-
 // verifyDaemonSettings performs validation of daemon config struct
 func verifyDaemonSettings(config *config.Config) error {
 	return nil

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -27,11 +27,14 @@ func (daemon *Daemon) Reload(conf *config.Config) (err error) {
 	attributes := map[string]string{}
 
 	defer func() {
+		jsonString, _ := json.Marshal(daemon.configStore)
+
 		// we're unlocking here, because
 		// LogDaemonEventWithAttributes() -> SystemInfo() -> GetAllRuntimes()
 		// holds that lock too.
 		daemon.configStore.Unlock()
 		if err == nil {
+			logrus.Infof("Reloaded configuration: %s", jsonString)
 			daemon.LogDaemonEventWithAttributes("reload", attributes)
 		}
 	}()

--- a/daemon/reload_unix.go
+++ b/daemon/reload_unix.go
@@ -1,0 +1,56 @@
+// +build linux freebsd
+
+package daemon
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/daemon/config"
+)
+
+// reloadPlatform updates configuration with platform specific options
+// and updates the passed attributes
+func (daemon *Daemon) reloadPlatform(conf *config.Config, attributes map[string]string) error {
+	if err := conf.ValidatePlatformConfig(); err != nil {
+		return err
+	}
+
+	if conf.IsValueSet("runtimes") {
+		// Always set the default one
+		conf.Runtimes[config.StockRuntimeName] = types.Runtime{Path: DefaultRuntimeBinary}
+		if err := daemon.initRuntimes(conf.Runtimes); err != nil {
+			return err
+		}
+		daemon.configStore.Runtimes = conf.Runtimes
+	}
+
+	if conf.DefaultRuntime != "" {
+		daemon.configStore.DefaultRuntime = conf.DefaultRuntime
+	}
+
+	if conf.IsValueSet("default-shm-size") {
+		daemon.configStore.ShmSize = conf.ShmSize
+	}
+
+	if conf.IpcMode != "" {
+		daemon.configStore.IpcMode = conf.IpcMode
+	}
+
+	// Update attributes
+	var runtimeList bytes.Buffer
+	for name, rt := range daemon.configStore.Runtimes {
+		if runtimeList.Len() > 0 {
+			runtimeList.WriteRune(' ')
+		}
+		runtimeList.WriteString(fmt.Sprintf("%s:%s", name, rt))
+	}
+
+	attributes["runtimes"] = runtimeList.String()
+	attributes["default-runtime"] = daemon.configStore.DefaultRuntime
+	attributes["default-shm-size"] = fmt.Sprintf("%d", daemon.configStore.ShmSize)
+	attributes["default-ipc-mode"] = daemon.configStore.IpcMode
+
+	return nil
+}

--- a/daemon/reload_windows.go
+++ b/daemon/reload_windows.go
@@ -1,0 +1,9 @@
+package daemon
+
+import "github.com/docker/docker/daemon/config"
+
+// reloadPlatform updates configuration with platform specific options
+// and updates the passed attributes
+func (daemon *Daemon) reloadPlatform(config *config.Config, attributes map[string]string) error {
+	return nil
+}


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/issues/21559 How to check docker daemon options when using daemon.json
- https://github.com/moby/moby/issues/31381 Expose daemon config state through the `docker info` such as --init

When reloading the daemon configuration file, log the active configuration after successfully reloading. Also do a small refactor, and move reload-related functions to `reload_XX.go` files


Note that configuration reloading is currently not an atomic operation; this is something we need to address: it's currently possible that only "half" of the configuration changes are loaded (which is not desirable).