### PR TITLE
Rename FindUniqueNetwork to FindNetwork

### DIFF
--- a/api/server/router/network/backend.go
+++ b/api/server/router/network/backend.go
@@ -12,7 +12,7 @@ import (
 // Backend is all the methods that need to be implemented
 // to provide network specific functionality.
 type Backend interface {
-	FindUniqueNetwork(idName string) (libnetwork.Network, error)
+	FindNetwork(idName string) (libnetwork.Network, error)
 	GetNetworks() []libnetwork.Network
 	CreateNetwork(nc types.NetworkCreateRequest) (*types.NetworkCreateResponse, error)
 	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -290,7 +290,7 @@ func (n *networkRouter) postNetworkConnect(ctx context.Context, w http.ResponseW
 	}
 
 	// Always make sure there is no ambiguity with respect to the network ID/name
-	nw, err := n.backend.FindUniqueNetwork(vars["id"])
+	nw, err := n.backend.FindNetwork(vars["id"])
 	if err != nil {
 		return err
 	}
@@ -530,7 +530,7 @@ func (n *networkRouter) postNetworksPrune(ctx context.Context, w http.ResponseWr
 }
 
 // findUniqueNetwork will search network across different scopes (both local and swarm).
-// NOTE: This findUniqueNetwork is different from FindUniqueNetwork in the daemon.
+// NOTE: This findUniqueNetwork is different from FindNetwork in the daemon.
 // In case multiple networks have duplicate names, return error.
 // First find based on full ID, return immediately once one is found.
 // If a network appears both in swarm and local, assume it is in local first

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -28,7 +28,7 @@ import (
 type Backend interface {
 	CreateManagedNetwork(clustertypes.NetworkCreateRequest) error
 	DeleteManagedNetwork(networkID string) error
-	FindUniqueNetwork(idName string) (libnetwork.Network, error)
+	FindNetwork(idName string) (libnetwork.Network, error)
 	SetupIngress(clustertypes.NetworkCreateRequest, string) (<-chan struct{}, error)
 	ReleaseIngress() (<-chan struct{}, error)
 	PullImage(ctx context.Context, image, tag, platform string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -507,7 +507,7 @@ func getEndpointConfig(na *api.NetworkAttachment, b executorpkg.Backend) *networ
 		DriverOpts: na.DriverAttachmentOpts,
 	}
 	if v, ok := na.Network.Spec.Annotations.Labels["com.docker.swarm.predefined"]; ok && v == "true" {
-		if ln, err := b.FindUniqueNetwork(na.Network.Spec.Annotations.Name); err == nil {
+		if ln, err := b.FindNetwork(na.Network.Spec.Annotations.Name); err == nil {
 			n.NetworkID = ln.ID()
 		}
 	}

--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -292,7 +292,7 @@ func (c *Cluster) populateNetworkID(ctx context.Context, client swarmapi.Control
 	for i, n := range networks {
 		apiNetwork, err := getNetwork(ctx, client, n.Target)
 		if err != nil {
-			ln, _ := c.config.Backend.FindUniqueNetwork(n.Target)
+			ln, _ := c.config.Backend.FindNetwork(n.Target)
 			if ln != nil && runconfig.IsPreDefinedNetwork(ln.Name()) {
 				// Need to retrieve the corresponding predefined swarm network
 				// and use its id for the request.

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -252,7 +252,7 @@ func (daemon *Daemon) updateNetworkSettings(container *container.Container, n li
 	}
 
 	for s, v := range container.NetworkSettings.Networks {
-		sn, err := daemon.FindUniqueNetwork(getNetworkID(s, v.EndpointSettings))
+		sn, err := daemon.FindNetwork(getNetworkID(s, v.EndpointSettings))
 		if err != nil {
 			continue
 		}
@@ -309,7 +309,7 @@ func (daemon *Daemon) updateNetwork(container *container.Container) error {
 	// Find if container is connected to the default bridge network
 	var n libnetwork.Network
 	for name, v := range container.NetworkSettings.Networks {
-		sn, err := daemon.FindUniqueNetwork(getNetworkID(name, v.EndpointSettings))
+		sn, err := daemon.FindNetwork(getNetworkID(name, v.EndpointSettings))
 		if err != nil {
 			continue
 		}
@@ -339,7 +339,7 @@ func (daemon *Daemon) updateNetwork(container *container.Container) error {
 }
 
 func (daemon *Daemon) findAndAttachNetwork(container *container.Container, idOrName string, epConfig *networktypes.EndpointSettings) (libnetwork.Network, *networktypes.NetworkingConfig, error) {
-	n, err := daemon.FindUniqueNetwork(getNetworkID(idOrName, epConfig))
+	n, err := daemon.FindNetwork(getNetworkID(idOrName, epConfig))
 	if err != nil {
 		// We should always be able to find the network for a
 		// managed container.
@@ -383,7 +383,7 @@ func (daemon *Daemon) findAndAttachNetwork(container *container.Container, idOrN
 			}
 		}
 
-		n, err = daemon.FindUniqueNetwork(getNetworkID(idOrName, epConfig))
+		n, err = daemon.FindNetwork(getNetworkID(idOrName, epConfig))
 		if err != nil {
 			if daemon.clusterProvider != nil {
 				if err := daemon.clusterProvider.DetachNetwork(getNetworkID(idOrName, epConfig), container.ID); err != nil {
@@ -437,7 +437,7 @@ func (daemon *Daemon) updateContainerNetworkSettings(container *container.Contai
 	if mode.IsUserDefined() {
 		var err error
 
-		n, err = daemon.FindUniqueNetwork(networkName)
+		n, err = daemon.FindNetwork(networkName)
 		if err == nil {
 			networkName = n.Name()
 		}
@@ -797,7 +797,7 @@ func (daemon *Daemon) connectToNetwork(container *container.Container, idOrName 
 
 // ForceEndpointDelete deletes an endpoint from a network forcefully
 func (daemon *Daemon) ForceEndpointDelete(name string, networkName string) error {
-	n, err := daemon.FindUniqueNetwork(networkName)
+	n, err := daemon.FindNetwork(networkName)
 	if err != nil {
 		return err
 	}
@@ -949,7 +949,7 @@ func (daemon *Daemon) releaseNetwork(container *container.Container) {
 
 	var networks []libnetwork.Network
 	for n, epSettings := range settings {
-		if nw, err := daemon.FindUniqueNetwork(getNetworkID(n, epSettings.EndpointSettings)); err == nil {
+		if nw, err := daemon.FindNetwork(getNetworkID(n, epSettings.EndpointSettings)); err == nil {
 			networks = append(networks, nw)
 		}
 
@@ -993,7 +993,7 @@ func (daemon *Daemon) ConnectToNetwork(container *container.Container, idOrName 
 			return errRemovalContainer(container.ID)
 		}
 
-		n, err := daemon.FindUniqueNetwork(idOrName)
+		n, err := daemon.FindNetwork(idOrName)
 		if err == nil && n != nil {
 			if err := daemon.updateNetworkConfig(container, n, endpointConfig, true); err != nil {
 				return err
@@ -1016,7 +1016,7 @@ func (daemon *Daemon) ConnectToNetwork(container *container.Container, idOrName 
 
 // DisconnectFromNetwork disconnects container from network n.
 func (daemon *Daemon) DisconnectFromNetwork(container *container.Container, networkName string, force bool) error {
-	n, err := daemon.FindUniqueNetwork(networkName)
+	n, err := daemon.FindNetwork(networkName)
 	container.Lock()
 	defer container.Unlock()
 

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -170,7 +170,7 @@ func (daemon *Daemon) initializeNetworkingPaths(container *container.Container, 
 
 	if nc.NetworkSettings != nil {
 		for n := range nc.NetworkSettings.Networks {
-			sn, err := daemon.FindUniqueNetwork(n)
+			sn, err := daemon.FindNetwork(n)
 			if err != nil {
 				continue
 			}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -317,7 +317,7 @@ func TestValidateContainerIsolation(t *testing.T) {
 
 func TestFindNetworkErrorType(t *testing.T) {
 	d := Daemon{}
-	_, err := d.FindUniqueNetwork("fakeNet")
+	_, err := d.FindNetwork("fakeNet")
 	_, ok := errors.Cause(err).(libnetwork.ErrNoSuchNetwork)
 	if !errdefs.IsNotFound(err) || !ok {
 		assert.Fail(t, "The FindNetwork method MUST always return an error that implements the NotFound interface and is ErrNoSuchNetwork")

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -29,12 +29,12 @@ func (daemon *Daemon) NetworkControllerEnabled() bool {
 	return daemon.netController != nil
 }
 
-// FindUniqueNetwork returns a network based on:
+// FindNetwork returns a network based on:
 // 1. Full ID
 // 2. Full Name
 // 3. Partial ID
 // as long as there is no ambiguity
-func (daemon *Daemon) FindUniqueNetwork(term string) (libnetwork.Network, error) {
+func (daemon *Daemon) FindNetwork(term string) (libnetwork.Network, error) {
 	listByFullName := []libnetwork.Network{}
 	listByPartialID := []libnetwork.Network{}
 	for _, nw := range daemon.GetNetworks() {

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -159,7 +159,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 	gwHNSID := ""
 	if c.NetworkSettings != nil {
 		for n := range c.NetworkSettings.Networks {
-			sn, err := daemon.FindUniqueNetwork(n)
+			sn, err := daemon.FindNetwork(n)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
This fix is a follow up to #30397, with `FindUniqueNetwork`
changed to `FindNetwork` based on the review feedback:
https://github.com/moby/moby/pull/30897#discussion_r160921585

/cc @thaJeztah

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>