### PR TITLE
Fix golint error

### DIFF
--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -61,10 +61,7 @@ func (daemon *Daemon) Reload(conf *config.Config) (err error) {
 	if err := daemon.reloadLiveRestore(conf, attributes); err != nil {
 		return err
 	}
-	if err := daemon.reloadNetworkDiagnosticPort(conf, attributes); err != nil {
-		return err
-	}
-	return nil
+	return daemon.reloadNetworkDiagnosticPort(conf, attributes)
 }
 
 // reloadDebug updates configuration with Debug option


### PR DESCRIPTION
PR #36011 fixed almost all of the golint issues though there is still one golint error:
https://goreportcard.com/report/github.com/docker/docker#golint
```
Golint is a linter for Go source code.
docker/daemon/reload.go
Line 64: warning: redundant if ...; err != nil check, just return error instead. (golint)
```

This fix fixes the last one.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
