### PR TITLE
gometalinter: fix --deadline option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -190,7 +190,7 @@ RUN ln -s /usr/local/completion/bash/docker /etc/bash_completion.d/docker
 ENTRYPOINT ["hack/dind"]
 
 # Options for hack/validate/gometalinter
-ENV GOMETALINTER_OPTS="--deadline 2m"
+ENV GOMETALINTER_OPTS="--deadline=2m"
 
 # Upload docker source
 COPY . /go/src/github.com/docker/docker

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -159,7 +159,7 @@ ENV PATH=/usr/local/cli:$PATH
 ENTRYPOINT ["hack/dind"]
 
 # Options for hack/validate/gometalinter
-ENV GOMETALINTER_OPTS="--deadline 4m -j2"
+ENV GOMETALINTER_OPTS="--deadline=4m -j2"
 
 # Upload docker source
 COPY . /go/src/github.com/docker/docker

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -147,7 +147,7 @@ ENV PATH=/usr/local/cli:$PATH
 ENTRYPOINT ["hack/dind"]
 
 # Options for hack/validate/gometalinter
-ENV GOMETALINTER_OPTS="--deadline 10m -j2"
+ENV GOMETALINTER_OPTS="--deadline=10m -j2"
 
 # Upload docker source
 COPY . /go/src/github.com/docker/docker

--- a/hack/validate/gometalinter
+++ b/hack/validate/gometalinter
@@ -6,6 +6,8 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # CI platforms differ, so per-platform GOMETALINTER_OPTS can be set
 # from a platform-specific Dockerfile, otherwise let's just set
 # (somewhat pessimistic) default of 10 minutes.
+: ${GOMETALINTER_OPTS=--deadline=10m}
+
 gometalinter \
-	${GOMETALINTER_OPTS:--deadine 10m} \
+	${GOMETALINTER_OPTS} \
 	--config $SCRIPTDIR/gometalinter.json ./...


### PR DESCRIPTION
1. Add = between the option and the argument, otherwise the argument
   appears to be passed on to the linters directly, as in:

> DEBUG: [golint.8]: executing /home/kir/go/bin/golint
> -min_confidence 0.800000 ./10m ./api ./api/errdefs <...>

2. Fix setting the default for GOMETALINTER_OPTS -- the default
   was -deadline (rather than --deadline).

Fixes: b96093fa56a9 ("gometalinter: add per-platform configurable options")