### PR TITLE
daemon.cleanupMetricsPlugins(): fix

### DIFF
--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -118,7 +118,8 @@ func (d *Daemon) cleanupMetricsPlugins() {
 	var wg sync.WaitGroup
 	wg.Add(len(ls))
 
-	for _, p := range ls {
+	for _, plugin := range ls {
+		p := plugin
 		go func() {
 			defer wg.Done()
 			pluginStopMetricsCollection(p)


### PR DESCRIPTION
A linter (vet) found the following bug in the code:

> daemon/metrics.go:124::error: range variable p captured by func literal (vet)

Here a variable p is used in an async fashion by goroutine, and most
probably by the time of use it is set to the last element of a range.

For example, the following code

```go
	for _, c := range []string{"here ", "we ", "go"} {
		go func() {
			fmt.Print(c)
		}()
	}
```

will print `gogogo` rather than `here we go` as one would expect.

Fixes: 0e8e8f0f31 ("Add support for metrics plugins")