### PR TITLE
 Fix issue with "ENV <key> <value>" where quotes were removed

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -260,7 +260,7 @@ func processMetaArg(meta instructions.ArgCommand, shlex *ShellLex, args *buildAr
 	// ShellLex currently only support the concatenated string format
 	envs := convertMapToEnvList(args.GetAllAllowed())
 	if err := meta.Expand(func(word string) (string, error) {
-		return shlex.ProcessWord(word, envs)
+		return shlex.ProcessWord(word, envs, false)
 	}); err != nil {
 		return err
 	}

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -201,7 +201,7 @@ func (d *dispatchRequest) getExpandedImageName(shlex *ShellLex, name string) (st
 		substitutionArgs = append(substitutionArgs, key+"="+value)
 	}
 
-	name, err := shlex.ProcessWord(name, substitutionArgs)
+	name, err := shlex.ProcessWord(name, substitutionArgs, false)
 	if err != nil {
 		return "", err
 	}

--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -46,7 +46,10 @@ func dispatch(d dispatchRequest, cmd instructions.Command) (err error) {
 
 	if ex, ok := cmd.(instructions.SupportsSingleWordExpansion); ok {
 		err := ex.Expand(func(word string) (string, error) {
-			return d.shlex.ProcessWord(word, envs)
+			if e, ok := cmd.(*instructions.EnvCommand); ok && e.Old {
+				return d.shlex.ProcessWord(word, envs, true)
+			}
+			return d.shlex.ProcessWord(word, envs, false)
 		})
 		if err != nil {
 			return errdefs.InvalidParameter(err)

--- a/builder/dockerfile/instructions/commands.go
+++ b/builder/dockerfile/instructions/commands.go
@@ -96,6 +96,7 @@ func expandSliceInPlace(values []string, expander SingleWordExpander) error {
 type EnvCommand struct {
 	withNameAndCode
 	Env KeyValuePairs // kvp slice instead of map to preserve ordering
+	Old bool          // `ENV <key> <value>` or `ENV <key>=<value>`
 }
 
 // Expand variables

--- a/builder/dockerfile/instructions/parse.go
+++ b/builder/dockerfile/instructions/parse.go
@@ -188,7 +188,6 @@ func parseKvps(args []string, cmdName string) (KeyValuePairs, error) {
 }
 
 func parseEnv(req parseRequest) (*EnvCommand, error) {
-
 	if err := req.flags.Parse(); err != nil {
 		return nil, err
 	}
@@ -196,9 +195,16 @@ func parseEnv(req parseRequest) (*EnvCommand, error) {
 	if err != nil {
 		return nil, err
 	}
+	old := false
+	if req.attributes != nil {
+		if v, ok := req.attributes["old"]; ok {
+			old = v
+		}
+	}
 	return &EnvCommand{
 		Env:             envs,
 		withNameAndCode: newWithNameAndCode(req),
+		Old:             old,
 	}, nil
 }
 

--- a/builder/dockerfile/shell_parser_test.go
+++ b/builder/dockerfile/shell_parser_test.go
@@ -50,7 +50,7 @@ func TestShellParser4EnvVars(t *testing.T) {
 
 		if ((platform == "W" || platform == "A") && runtime.GOOS == "windows") ||
 			((platform == "U" || platform == "A") && runtime.GOOS != "windows") {
-			newWord, err := shlex.ProcessWord(source, envs)
+			newWord, err := shlex.ProcessWord(source, envs, false)
 			if expected == "error" {
 				assert.Error(t, err)
 			} else {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This fix tries to address the issue raised in #36027: when using `ENV` in the form `ENV <key> <value>` both single and double quotes are being stripped from `<value>`.

**- How I did it**

This fix address this issue so that when old format `ENV <key> <value>` is used, it is treated as if `<value>` is one word during the expand.

**- How to verify it**

Unit tests have been added.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![a7b9c9f3da5068874ca89f69ea2b0eae](https://user-images.githubusercontent.com/6932348/35025590-3125851c-fafb-11e7-9041-42c69519dd68.jpg)


This fix fixes #36027.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>