### PR TITLE
LCOW: Fix OpenFile parameters

### DIFF
--- a/daemon/graphdriver/lcow/remotefs_file.go
+++ b/daemon/graphdriver/lcow/remotefs_file.go
@@ -33,7 +33,7 @@ func (l *lcowfs) OpenFile(path string, flag int, perm os.FileMode) (_ driver.Fil
 	flagStr := strconv.FormatInt(int64(flag), 10)
 	permStr := strconv.FormatUint(uint64(perm), 8)
 
-	commandLine := fmt.Sprintf("%s %s %s %s", remotefs.RemotefsCmd, remotefs.OpenFileCmd, flagStr, permStr)
+	commandLine := fmt.Sprintf("%s %s %s %s %s", remotefs.RemotefsCmd, remotefs.OpenFileCmd, path, flagStr, permStr)
 	env := make(map[string]string)
 	env["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:"
 	processConfig := &hcsshim.ProcessConfig{


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

While debugging multiple LCOW issues, found that the `OpenFile` call in the remote fs was calling gcstools with the wrong parameters - `path` was omitted.

@darrenstahlmsft @gupta-ak @johnstep PTAL