### PR TITLE
LCOW: Regular mount if only one layer

### DIFF
--- a/daemon/graphdriver/lcow/lcow_svm.go
+++ b/daemon/graphdriver/lcow/lcow_svm.go
@@ -299,7 +299,10 @@ func (svm *serviceVM) createUnionMount(mountName string, mvds ...hcsshim.MappedV
 	}
 
 	var cmd string
-	if mvds[0].ReadOnly {
+	if len(mvds) == 1 {
+		// `FROM SCRATCH` case and the only layer. No overlay required.
+		cmd = fmt.Sprintf("mount %s %s", mvds[0].ContainerPath, mountName)
+	} else if mvds[0].ReadOnly {
 		// Readonly overlay
 		cmd = fmt.Sprintf("mount -t overlay overlay -olowerdir=%s %s",
 			strings.Join(lowerLayers, ","),


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This is the moby/moby side of the fix to support `FROM scratch`. If there's only one layer, then don't do an overlay mount, just a regular mount instead.  (Note there's opengcs fixes required too for the end-to-end scenario to work, I'm putting those changes together and teasing them apart from my work-in-progress branch where I'm fixing a slew of LCOW bugs)

@gupta-ak @johnstep PTAL.