### PR TITLE
Revendor Microsoft/opengcs @ v0.3.5

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -7,7 +7,7 @@ github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git
 github.com/gorilla/context v1.1
 github.com/gorilla/mux v1.1
-github.com/Microsoft/opengcs v0.3.4
+github.com/Microsoft/opengcs v0.3.5
 github.com/kr/pty 5cf931ef8f
 github.com/mattn/go-shellwords v1.0.3
 github.com/sirupsen/logrus v1.0.3

--- a/vendor/github.com/Microsoft/opengcs/client/init.go
+++ b/vendor/github.com/Microsoft/opengcs/client/init.go
@@ -1,0 +1,24 @@
+// +build windows
+
+package client
+
+import (
+	"os"
+	"strconv"
+)
+
+var (
+	logDataFromUVM int64
+)
+
+func init() {
+	bytes := os.Getenv("OPENGCS_LOG_DATA_FROM_UVM")
+	if len(bytes) == 0 {
+		return
+	}
+	u, err := strconv.ParseUint(bytes, 10, 32)
+	if err != nil {
+		return
+	}
+	logDataFromUVM = int64(u)
+}

--- a/vendor/github.com/Microsoft/opengcs/client/process.go
+++ b/vendor/github.com/Microsoft/opengcs/client/process.go
@@ -130,13 +130,17 @@ func (config *Config) DebugGCS() {
 	cmd := os.Getenv("OPENGCS_DEBUG_COMMAND")
 	if cmd == "" {
 		cmd = `sh -c "`
+		cmd += debugCommand("kill -10 `pidof gcs`") // SIGUSR1 for stackdump
 		cmd += debugCommand("ls -l /tmp")
 		cmd += debugCommand("cat /tmp/gcs.log")
+		cmd += debugCommand("cat /tmp/gcs/gcs-stacks*")
+		cmd += debugCommand("cat /tmp/gcs/paniclog*")
 		cmd += debugCommand("ls -l /tmp/gcs")
 		cmd += debugCommand("ls -l /tmp/gcs/*")
 		cmd += debugCommand("cat /tmp/gcs/*/config.json")
 		cmd += debugCommand("ls -lR /var/run/gcsrunc")
-		cmd += debugCommand("cat /var/run/gcsrunc/log.log")
+		cmd += debugCommand("cat /tmp/gcs/global-runc.log")
+		cmd += debugCommand("cat /tmp/gcs/*/runc.log")
 		cmd += debugCommand("ps -ef")
 		cmd += `"`
 	}
@@ -153,5 +157,5 @@ func (config *Config) DebugGCS() {
 	if proc != nil {
 		proc.WaitTimeout(time.Duration(int(time.Second) * 30))
 	}
-	logrus.Debugf("GCS Debugging:\n%s\n\nEnd GCS Debugging\n", strings.TrimSpace(out.String()))
+	logrus.Debugf("GCS Debugging:\n%s\n\nEnd GCS Debugging", strings.TrimSpace(out.String()))
 }

--- a/vendor/github.com/Microsoft/opengcs/service/gcsutils/remotefs/utils.go
+++ b/vendor/github.com/Microsoft/opengcs/service/gcsutils/remotefs/utils.go
@@ -43,6 +43,8 @@ func ExportedToError(ee *ExportedError) error {
 		return os.ErrExist
 	} else if ee.Error() == os.ErrPermission.Error() {
 		return os.ErrPermission
+	} else if ee.Error() == io.EOF.Error() {
+		return io.EOF
 	}
 	return ee
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Refresh of opengcs to the latest version. Contains part of the fix to support `FROM scratch` in LCOW mode, and additional debugging.