### PR TITLE
Bump to RS3 final build, and remove LCOW_SUPPORTED

### DIFF
--- a/pkg/system/init_windows.go
+++ b/pkg/system/init_windows.go
@@ -1,17 +1,12 @@
 package system
 
-import "os"
-
 // lcowSupported determines if Linux Containers on Windows are supported.
 var lcowSupported = false
 
 // InitLCOW sets whether LCOW is supported or not
-// TODO @jhowardmsft.
-// 1. Replace with RS3 RTM build number.
-// 2. Remove the getenv check when image-store is coalesced as shouldn't be needed anymore.
 func InitLCOW(experimental bool) {
 	v := GetOSVersion()
-	if experimental && v.Build > 16278 && os.Getenv("LCOW_SUPPORTED") != "" {
+	if experimental && v.Build >= 16299 {
 		lcowSupported = true
 	}
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes a long-standing todo now the image store re-coalescing PR has been merged. No need for the environment variable to determine if LCOW is supported any more, just experimental. At the same time, it bumps the minimum requirement to RS3 RTM build (16299)

@johnstep PTAL.