### PR TITLE
[WIP] Pass SELinux Mount label down to graphdriver

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -453,9 +453,9 @@ func (a *Driver) isParent(id, parent string) bool {
 
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
-func (a *Driver) Diff(id, parent string) (io.ReadCloser, error) {
+func (a *Driver) Diff(id, parent, mountLabel string) (io.ReadCloser, error) {
 	if !a.isParent(id, parent) {
-		return a.naiveDiff.Diff(id, parent)
+		return a.naiveDiff.Diff(id, parent, mountLabel)
 	}
 
 	// AUFS doesn't need the parent layer to produce a diff.
@@ -492,9 +492,9 @@ func (a *Driver) applyDiff(id string, diff io.Reader) error {
 // DiffSize calculates the changes between the specified id
 // and its parent and returns the size in bytes of the changes
 // relative to its base filesystem directory.
-func (a *Driver) DiffSize(id, parent string) (size int64, err error) {
+func (a *Driver) DiffSize(id, parent, mountLabel string) (size int64, err error) {
 	if !a.isParent(id, parent) {
-		return a.naiveDiff.DiffSize(id, parent)
+		return a.naiveDiff.DiffSize(id, parent, mountLabel)
 	}
 	// AUFS doesn't need the parent layer to calculate the diff size.
 	return directory.Size(context.TODO(), path.Join(a.rootPath(), "diff", id))
@@ -503,9 +503,9 @@ func (a *Driver) DiffSize(id, parent string) (size int64, err error) {
 // ApplyDiff extracts the changeset from the given diff into the
 // layer with the specified id and parent, returning the size of the
 // new layer in bytes.
-func (a *Driver) ApplyDiff(id, parent string, diff io.Reader) (size int64, err error) {
+func (a *Driver) ApplyDiff(id, parent, mountLabel string, diff io.Reader) (size int64, err error) {
 	if !a.isParent(id, parent) {
-		return a.naiveDiff.ApplyDiff(id, parent, diff)
+		return a.naiveDiff.ApplyDiff(id, parent, mountLabel, diff)
 	}
 
 	// AUFS doesn't need the parent id to apply the diff if it is the direct parent.
@@ -513,14 +513,14 @@ func (a *Driver) ApplyDiff(id, parent string, diff io.Reader) (size int64, err e
 		return
 	}
 
-	return a.DiffSize(id, parent)
+	return a.DiffSize(id, parent, mountLabel)
 }
 
 // Changes produces a list of changes between the specified layer
 // and its parent layer. If parent is "", then all changes will be ADD changes.
-func (a *Driver) Changes(id, parent string) ([]archive.Change, error) {
+func (a *Driver) Changes(id, parent, mountLabel string) ([]archive.Change, error) {
 	if !a.isParent(id, parent) {
-		return a.naiveDiff.Changes(id, parent)
+		return a.naiveDiff.Changes(id, parent, mountLabel)
 	}
 
 	// AUFS doesn't have snapshots, so we need to get changes from all parent

--- a/daemon/graphdriver/aufs/aufs_test.go
+++ b/daemon/graphdriver/aufs/aufs_test.go
@@ -339,7 +339,7 @@ func TestGetDiff(t *testing.T) {
 	}
 	f.Close()
 
-	a, err := d.Diff("1", "")
+	a, err := d.Diff("1", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -384,7 +384,7 @@ func TestChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	changes, err := d.Changes("2", "")
+	changes, err := d.Changes("2", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -423,7 +423,7 @@ func TestChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	changes, err = d.Changes("3", "2")
+	changes, err = d.Changes("3", "2", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -475,7 +475,7 @@ func TestDiffSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	diffSize, err := d.DiffSize("1", "")
+	diffSize, err := d.DiffSize("1", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -517,7 +517,7 @@ func TestChildDiffSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	diffSize, err := d.DiffSize("1", "")
+	diffSize, err := d.DiffSize("1", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -529,7 +529,7 @@ func TestChildDiffSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	diffSize, err = d.DiffSize("2", "1")
+	diffSize, err = d.DiffSize("2", "1", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -611,7 +611,7 @@ func TestApplyDiff(t *testing.T) {
 	}
 	f.Close()
 
-	diff, err := d.Diff("1", "")
+	diff, err := d.Diff("1", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -84,19 +84,19 @@ type ProtoDriver interface {
 type DiffDriver interface {
 	// Diff produces an archive of the changes between the specified
 	// layer and its parent layer which may be "".
-	Diff(id, parent string) (io.ReadCloser, error)
+	Diff(id, parent, mountLabel string) (io.ReadCloser, error)
 	// Changes produces a list of changes between the specified layer
 	// and its parent layer. If parent is "", then all changes will be ADD changes.
-	Changes(id, parent string) ([]archive.Change, error)
+	Changes(id, parent, mountLabel string) ([]archive.Change, error)
 	// ApplyDiff extracts the changeset from the given diff into the
 	// layer with the specified id and parent, returning the size of the
 	// new layer in bytes.
 	// The archive.Reader must be an uncompressed stream.
-	ApplyDiff(id, parent string, diff io.Reader) (size int64, err error)
+	ApplyDiff(id, parent, mountLabel string, diff io.Reader) (size int64, err error)
 	// DiffSize calculates the changes between the specified id
 	// and its parent and returns the size in bytes of the changes
 	// relative to its base filesystem directory.
-	DiffSize(id, parent string) (size int64, err error)
+	DiffSize(id, parent, mountLabel string) (size int64, err error)
 }
 
 // Driver is the interface for layered/snapshot file system drivers.

--- a/daemon/graphdriver/graphtest/graphbench_unix.go
+++ b/daemon/graphdriver/graphtest/graphbench_unix.go
@@ -72,7 +72,7 @@ func DriverBenchDiffBase(b *testing.B, drivername string, driveroptions ...strin
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		arch, err := driver.Diff(base, "")
+		arch, err := driver.Diff(base, "", "")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -108,7 +108,7 @@ func DriverBenchDiffN(b *testing.B, bottom, top int, drivername string, driverop
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		arch, err := driver.Diff(upper, "")
+		arch, err := driver.Diff(upper, "", "")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -141,7 +141,7 @@ func DriverBenchDiffApplyN(b *testing.B, fileCount int, drivername string, drive
 	if err := addManyFiles(driver, upper, fileCount, 6); err != nil {
 		b.Fatal(err)
 	}
-	diffSize, err := driver.DiffSize(upper, "")
+	diffSize, err := driver.DiffSize(upper, "", "")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -159,12 +159,12 @@ func DriverBenchDiffApplyN(b *testing.B, fileCount int, drivername string, drive
 
 		b.StartTimer()
 
-		arch, err := driver.Diff(upper, "")
+		arch, err := driver.Diff(upper, "", "")
 		if err != nil {
 			b.Fatal(err)
 		}
 
-		applyDiffSize, err := driver.ApplyDiff(diff, "", arch)
+		applyDiffSize, err := driver.ApplyDiff(diff, "", "", arch)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -203,7 +203,7 @@ func DriverBenchDeepLayerDiff(b *testing.B, layerCount int, drivername string, d
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		arch, err := driver.Diff(topLayer, "")
+		arch, err := driver.Diff(topLayer, "", "")
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/daemon/graphdriver/graphtest/graphtest_unix.go
+++ b/daemon/graphdriver/graphtest/graphtest_unix.go
@@ -207,7 +207,7 @@ func DriverTestDiffApply(t testing.TB, fileCount int, drivername string, driverO
 		t.Fatal(err)
 	}
 
-	diffSize, err := driver.DiffSize(upper, "")
+	diffSize, err := driver.DiffSize(upper, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +225,7 @@ func DriverTestDiffApply(t testing.TB, fileCount int, drivername string, driverO
 		t.Fatal(err)
 	}
 
-	arch, err := driver.Diff(upper, base)
+	arch, err := driver.Diff(upper, base, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +238,7 @@ func DriverTestDiffApply(t testing.TB, fileCount int, drivername string, driverO
 		t.Fatal(err)
 	}
 
-	applyDiffSize, err := driver.ApplyDiff(diff, base, bytes.NewReader(buf.Bytes()))
+	applyDiffSize, err := driver.ApplyDiff(diff, base, "", bytes.NewReader(buf.Bytes()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -283,7 +283,7 @@ func DriverTestChanges(t testing.TB, drivername string, driverOptions ...string)
 		t.Fatal(err)
 	}
 
-	changes, err := driver.Changes(upper, base)
+	changes, err := driver.Changes(upper, base, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/graphdriver/lcow/lcow.go
+++ b/daemon/graphdriver/lcow/lcow.go
@@ -753,7 +753,7 @@ func (d *Driver) Cleanup() error {
 // of this function dictate that the layer is already mounted.
 // However, as we do lazy mounting as a performance optimisation,
 // this will likely not be the case.
-func (d *Driver) Diff(id, parent string) (io.ReadCloser, error) {
+func (d *Driver) Diff(id, parent, label string) (io.ReadCloser, error) {
 	title := fmt.Sprintf("lcowdriver: diff: %s", id)
 
 	// Get VHDX info
@@ -811,7 +811,7 @@ func (d *Driver) Diff(id, parent string) (io.ReadCloser, error) {
 // new layer in bytes. The layer should not be mounted when calling
 // this function. Another way of describing this is that ApplyDiff writes
 // to a new layer (a VHD in LCOW) the contents of a tarstream it's given.
-func (d *Driver) ApplyDiff(id, parent string, diff io.Reader) (int64, error) {
+func (d *Driver) ApplyDiff(id, parent, label string, diff io.Reader) (int64, error) {
 	logrus.Debugf("lcowdriver: applydiff: id %s", id)
 
 	svm, err := d.startServiceVMIfNotRunning(id, nil, fmt.Sprintf("applydiff %s", id))
@@ -845,7 +845,7 @@ func (d *Driver) ApplyDiff(id, parent string, diff io.Reader) (int64, error) {
 // Changes produces a list of changes between the specified layer
 // and its parent layer. If parent is "", then all changes will be ADD changes.
 // The layer should not be mounted when calling this function.
-func (d *Driver) Changes(id, parent string) ([]archive.Change, error) {
+func (d *Driver) Changes(id, parent, label string) ([]archive.Change, error) {
 	logrus.Debugf("lcowdriver: changes: id %s parent %s", id, parent)
 	// TODO @gupta-ak. Needs implementation with assistance from service VM
 	return nil, nil
@@ -854,7 +854,7 @@ func (d *Driver) Changes(id, parent string) ([]archive.Change, error) {
 // DiffSize calculates the changes between the specified layer
 // and its parent and returns the size in bytes of the changes
 // relative to its base filesystem directory.
-func (d *Driver) DiffSize(id, parent string) (size int64, err error) {
+func (d *Driver) DiffSize(id, parent, label string) (size int64, err error) {
 	logrus.Debugf("lcowdriver: diffsize: id %s", id)
 	// TODO @gupta-ak. Needs implementation with assistance from service VM
 	return 0, nil

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -44,7 +44,7 @@ type ApplyDiffProtoDriver interface {
 	graphdriver.ProtoDriver
 	// ApplyDiff writes the diff to the archive for the given id and parent id.
 	// It returns the size in bytes written if successful, an error ErrApplyDiffFallback is returned otherwise.
-	ApplyDiff(id, parent string, diff io.Reader) (size int64, err error)
+	ApplyDiff(id, parent, mountLabel string, diff io.Reader) (size int64, err error)
 }
 
 type naiveDiffDriverWithApply struct {
@@ -61,10 +61,10 @@ func NaiveDiffDriverWithApply(driver ApplyDiffProtoDriver, uidMaps, gidMaps []id
 }
 
 // ApplyDiff creates a diff layer with either the NaiveDiffDriver or with a fallback.
-func (d *naiveDiffDriverWithApply) ApplyDiff(id, parent string, diff io.Reader) (int64, error) {
-	b, err := d.applyDiff.ApplyDiff(id, parent, diff)
+func (d *naiveDiffDriverWithApply) ApplyDiff(id, parent, mountLabel string, diff io.Reader) (int64, error) {
+	b, err := d.applyDiff.ApplyDiff(id, parent, mountLabel, diff)
 	if err == ErrApplyDiffFallback {
-		return d.Driver.ApplyDiff(id, parent, diff)
+		return d.Driver.ApplyDiff(id, parent, mountLabel, diff)
 	}
 	return b, err
 }
@@ -466,7 +466,7 @@ func (d *Driver) Put(id string) error {
 }
 
 // ApplyDiff applies the new layer on top of the root, if parent does not exist with will return an ErrApplyDiffFallback error.
-func (d *Driver) ApplyDiff(id string, parent string, diff io.Reader) (size int64, err error) {
+func (d *Driver) ApplyDiff(id, parent, mountLabel string, diff io.Reader) (size int64, err error) {
 	dir := d.dir(id)
 
 	if parent == "" {

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -697,9 +697,9 @@ func (d *Driver) isParent(id, parent string) bool {
 }
 
 // ApplyDiff applies the new layer into a root
-func (d *Driver) ApplyDiff(id string, parent string, diff io.Reader) (size int64, err error) {
+func (d *Driver) ApplyDiff(id, parent, mountLabel string, diff io.Reader) (size int64, err error) {
 	if !d.isParent(id, parent) {
-		return d.naiveDiff.ApplyDiff(id, parent, diff)
+		return d.naiveDiff.ApplyDiff(id, parent, mountLabel, diff)
 	}
 
 	applyDir := d.getDiffPath(id)
@@ -727,18 +727,18 @@ func (d *Driver) getDiffPath(id string) string {
 // DiffSize calculates the changes between the specified id
 // and its parent and returns the size in bytes of the changes
 // relative to its base filesystem directory.
-func (d *Driver) DiffSize(id, parent string) (size int64, err error) {
+func (d *Driver) DiffSize(id, parent, mountLabel string) (size int64, err error) {
 	if useNaiveDiff(d.home) || !d.isParent(id, parent) {
-		return d.naiveDiff.DiffSize(id, parent)
+		return d.naiveDiff.DiffSize(id, parent, mountLabel)
 	}
 	return directory.Size(context.TODO(), d.getDiffPath(id))
 }
 
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
-func (d *Driver) Diff(id, parent string) (io.ReadCloser, error) {
+func (d *Driver) Diff(id, parent, mountLabel string) (io.ReadCloser, error) {
 	if useNaiveDiff(d.home) || !d.isParent(id, parent) {
-		return d.naiveDiff.Diff(id, parent)
+		return d.naiveDiff.Diff(id, parent, mountLabel)
 	}
 
 	diffPath := d.getDiffPath(id)
@@ -753,6 +753,6 @@ func (d *Driver) Diff(id, parent string) (io.ReadCloser, error) {
 
 // Changes produces a list of changes between the specified layer and its
 // parent layer. If parent is "", then all changes will be ADD changes.
-func (d *Driver) Changes(id, parent string) ([]archive.Change, error) {
-	return d.naiveDiff.Changes(id, parent)
+func (d *Driver) Changes(id, parent, mountLabel string) ([]archive.Change, error) {
+	return d.naiveDiff.Changes(id, parent, mountLabel)
 }

--- a/daemon/graphdriver/proxy.go
+++ b/daemon/graphdriver/proxy.go
@@ -209,7 +209,7 @@ func (d *graphDriverProxy) Cleanup() error {
 	return nil
 }
 
-func (d *graphDriverProxy) Diff(id, parent string) (io.ReadCloser, error) {
+func (d *graphDriverProxy) Diff(id, parent, mountLabel string) (io.ReadCloser, error) {
 	args := &graphDriverRequest{
 		ID:     id,
 		Parent: parent,
@@ -221,7 +221,7 @@ func (d *graphDriverProxy) Diff(id, parent string) (io.ReadCloser, error) {
 	return body, nil
 }
 
-func (d *graphDriverProxy) Changes(id, parent string) ([]archive.Change, error) {
+func (d *graphDriverProxy) Changes(id, parent, mountLabel string) ([]archive.Change, error) {
 	args := &graphDriverRequest{
 		ID:     id,
 		Parent: parent,
@@ -237,7 +237,7 @@ func (d *graphDriverProxy) Changes(id, parent string) ([]archive.Change, error) 
 	return ret.Changes, nil
 }
 
-func (d *graphDriverProxy) ApplyDiff(id, parent string, diff io.Reader) (int64, error) {
+func (d *graphDriverProxy) ApplyDiff(id, parent, mountLabel string, diff io.Reader) (int64, error) {
 	var ret graphDriverResponse
 	if err := d.client.SendFile(fmt.Sprintf("GraphDriver.ApplyDiff?id=%s&parent=%s", id, parent), diff, &ret); err != nil {
 		return -1, err
@@ -248,7 +248,7 @@ func (d *graphDriverProxy) ApplyDiff(id, parent string, diff io.Reader) (int64, 
 	return ret.Size, nil
 }
 
-func (d *graphDriverProxy) DiffSize(id, parent string) (int64, error) {
+func (d *graphDriverProxy) DiffSize(id, parent, mountLabel string) (int64, error) {
 	args := &graphDriverRequest{
 		ID:     id,
 		Parent: parent,

--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -462,7 +462,7 @@ func (d *Driver) Cleanup() error {
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
 // The layer should be mounted when calling this function
-func (d *Driver) Diff(id, parent string) (_ io.ReadCloser, err error) {
+func (d *Driver) Diff(id, parent, mountLabel string) (_ io.ReadCloser, err error) {
 	rID, err := d.resolveID(id)
 	if err != nil {
 		return
@@ -498,7 +498,7 @@ func (d *Driver) Diff(id, parent string) (_ io.ReadCloser, err error) {
 // Changes produces a list of changes between the specified layer
 // and its parent layer. If parent is "", then all changes will be ADD changes.
 // The layer should not be mounted when calling this function.
-func (d *Driver) Changes(id, parent string) ([]archive.Change, error) {
+func (d *Driver) Changes(id, parent, mountLabel string) ([]archive.Change, error) {
 	rID, err := d.resolveID(id)
 	if err != nil {
 		return nil, err
@@ -553,7 +553,7 @@ func (d *Driver) Changes(id, parent string) ([]archive.Change, error) {
 // layer with the specified id and parent, returning the size of the
 // new layer in bytes.
 // The layer should not be mounted when calling this function
-func (d *Driver) ApplyDiff(id, parent string, diff io.Reader) (int64, error) {
+func (d *Driver) ApplyDiff(id, parent, mountLabel string, diff io.Reader) (int64, error) {
 	var layerChain []string
 	if parent != "" {
 		rPId, err := d.resolveID(parent)
@@ -587,13 +587,13 @@ func (d *Driver) ApplyDiff(id, parent string, diff io.Reader) (int64, error) {
 // DiffSize calculates the changes between the specified layer
 // and its parent and returns the size in bytes of the changes
 // relative to its base filesystem directory.
-func (d *Driver) DiffSize(id, parent string) (size int64, err error) {
+func (d *Driver) DiffSize(id, parent, mountLabel string) (size int64, err error) {
 	rPId, err := d.resolveID(parent)
 	if err != nil {
 		return
 	}
 
-	changes, err := d.Changes(id, rPId)
+	changes, err := d.Changes(id, rPId, mountLabel)
 	if err != nil {
 		return
 	}

--- a/integration/plugin/graphdriver/external_test.go
+++ b/integration/plugin/graphdriver/external_test.go
@@ -285,7 +285,7 @@ func setupPlugin(t *testing.T, ec map[string]*graphEventsCounter, ext string, mu
 			return
 		}
 
-		diff, err := driver.Diff(req.ID, req.Parent)
+		diff, err := driver.Diff(req.ID, req.Parent, req.MountLabel)
 		if err != nil {
 			respond(w, err)
 			return
@@ -300,7 +300,7 @@ func setupPlugin(t *testing.T, ec map[string]*graphEventsCounter, ext string, mu
 			return
 		}
 
-		changes, err := driver.Changes(req.ID, req.Parent)
+		changes, err := driver.Changes(req.ID, req.Parent, req.MountLabel)
 		if err != nil {
 			respond(w, err)
 			return
@@ -313,6 +313,10 @@ func setupPlugin(t *testing.T, ec map[string]*graphEventsCounter, ext string, mu
 		diff := r.Body
 		defer r.Body.Close()
 
+		var req graphDriverRequest
+		if err := decReq(r.Body, &req, w); err != nil {
+			return
+		}
 		id := r.URL.Query().Get("id")
 		parent := r.URL.Query().Get("parent")
 
@@ -320,7 +324,7 @@ func setupPlugin(t *testing.T, ec map[string]*graphEventsCounter, ext string, mu
 			http.Error(w, fmt.Sprintf("missing id"), 409)
 		}
 
-		size, err := driver.ApplyDiff(id, parent, diff)
+		size, err := driver.ApplyDiff(id, parent, req.MountLabel, diff)
 		if err != nil {
 			respond(w, err)
 			return
@@ -336,7 +340,7 @@ func setupPlugin(t *testing.T, ec map[string]*graphEventsCounter, ext string, mu
 			return
 		}
 
-		size, err := driver.DiffSize(req.ID, req.Parent)
+		size, err := driver.DiffSize(req.ID, req.Parent, req.MountLabel)
 		if err != nil {
 			respond(w, err)
 			return

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -252,7 +252,7 @@ func (ls *layerStore) applyTar(tx *fileMetadataTransaction, ts io.Reader, parent
 		}
 	}
 
-	applySize, err := ls.driver.ApplyDiff(layer.cacheID, parent, rdr)
+	applySize, err := ls.driver.ApplyDiff(layer.cacheID, parent, "", rdr)
 	if err != nil {
 		return err
 	}
@@ -520,6 +520,7 @@ func (ls *layerStore) CreateRWLayer(name string, parent ChainID, opts *CreateRWL
 		name:       name,
 		parent:     p,
 		mountID:    ls.mountID(name),
+		mountLabel: mountLabel,
 		layerStore: ls,
 		references: map[RWLayer]*referencedRWLayer{},
 	}
@@ -653,7 +654,7 @@ func (ls *layerStore) initMount(graphID, parent, mountLabel string, initFunc Mou
 	if err := ls.driver.CreateReadWrite(initID, parent, createOpts); err != nil {
 		return "", err
 	}
-	p, err := ls.driver.Get(initID, "")
+	p, err := ls.driver.Get(initID, mountLabel)
 	if err != nil {
 		return "", err
 	}
@@ -677,7 +678,7 @@ func (ls *layerStore) getTarStream(rl *roLayer) (io.ReadCloser, error) {
 			parentCacheID = rl.parent.cacheID
 		}
 
-		return ls.driver.Diff(rl.cacheID, parentCacheID)
+		return ls.driver.Diff(rl.cacheID, parentCacheID, "")
 	}
 
 	r, err := ls.store.TarSplitReader(rl.chainID)

--- a/layer/layer_unix_test.go
+++ b/layer/layer_unix_test.go
@@ -12,7 +12,7 @@ func graphDiffSize(ls Store, l Layer) (int64, error) {
 	if cl.parent != nil {
 		parent = cl.parent.cacheID
 	}
-	return ls.(*layerStore).driver.DiffSize(cl.cacheID, parent)
+	return ls.(*layerStore).driver.DiffSize(cl.cacheID, parent, "")
 }
 
 // Unix as Windows graph driver does not support Changes which is indirectly

--- a/layer/migration.go
+++ b/layer/migration.go
@@ -111,7 +111,7 @@ func (ls *layerStore) ChecksumForGraphID(id, parent, oldTarDataPath, newTarDataP
 }
 
 func (ls *layerStore) checksumForGraphIDNoTarsplit(id, parent, newTarDataPath string) (diffID DiffID, size int64, err error) {
-	rawarchive, err := ls.driver.Diff(id, parent)
+	rawarchive, err := ls.driver.Diff(id, parent, ls.mounts[id].mountLabel)
 	if err != nil {
 		return
 	}

--- a/layer/migration_test.go
+++ b/layer/migration_test.go
@@ -81,7 +81,7 @@ func TestLayerMigration(t *testing.T) {
 	if err := graph.Create(graphID1, "", nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := graph.ApplyDiff(graphID1, "", bytes.NewReader(tar1)); err != nil {
+	if _, err := graph.ApplyDiff(graphID1, "", "", bytes.NewReader(tar1)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -123,7 +123,7 @@ func TestLayerMigration(t *testing.T) {
 	if err := graph.Create(graphID2, graphID1, nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := graph.ApplyDiff(graphID2, graphID1, bytes.NewReader(tar2)); err != nil {
+	if _, err := graph.ApplyDiff(graphID2, graphID1, "", bytes.NewReader(tar2)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -165,11 +165,11 @@ func tarFromFilesInGraph(graph graphdriver.Driver, graphID, parentID string, fil
 	if err := graph.Create(graphID, parentID, nil); err != nil {
 		return nil, err
 	}
-	if _, err := graph.ApplyDiff(graphID, parentID, bytes.NewReader(t)); err != nil {
+	if _, err := graph.ApplyDiff(graphID, parentID, "", bytes.NewReader(t)); err != nil {
 		return nil, err
 	}
 
-	ar, err := graph.Diff(graphID, parentID)
+	ar, err := graph.Diff(graphID, parentID, "")
 	if err != nil {
 		return nil, err
 	}
@@ -317,14 +317,14 @@ func TestMountMigration(t *testing.T) {
 	if err := graph.Create(containerInit, graphID1, nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := graph.ApplyDiff(containerInit, graphID1, bytes.NewReader(initTar)); err != nil {
+	if _, err := graph.ApplyDiff(containerInit, graphID1, "", bytes.NewReader(initTar)); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := graph.Create(containerID, containerInit, nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := graph.ApplyDiff(containerID, containerInit, bytes.NewReader(mountTar)); err != nil {
+	if _, err := graph.ApplyDiff(containerID, containerInit, "", bytes.NewReader(mountTar)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/layer/mounted_layer.go
+++ b/layer/mounted_layer.go
@@ -13,6 +13,7 @@ type mountedLayer struct {
 	initID     string
 	parent     *roLayer
 	path       string
+	mountLabel string
 	layerStore *layerStore
 
 	references map[RWLayer]*referencedRWLayer
@@ -29,7 +30,7 @@ func (ml *mountedLayer) cacheParent() string {
 }
 
 func (ml *mountedLayer) TarStream() (io.ReadCloser, error) {
-	return ml.layerStore.driver.Diff(ml.mountID, ml.cacheParent())
+	return ml.layerStore.driver.Diff(ml.mountID, ml.cacheParent(), ml.mountLabel)
 }
 
 func (ml *mountedLayer) Name() string {
@@ -47,11 +48,11 @@ func (ml *mountedLayer) Parent() Layer {
 }
 
 func (ml *mountedLayer) Size() (int64, error) {
-	return ml.layerStore.driver.DiffSize(ml.mountID, ml.cacheParent())
+	return ml.layerStore.driver.DiffSize(ml.mountID, ml.cacheParent(), ml.mountLabel)
 }
 
 func (ml *mountedLayer) Changes() ([]archive.Change, error) {
-	return ml.layerStore.driver.Changes(ml.mountID, ml.cacheParent())
+	return ml.layerStore.driver.Changes(ml.mountID, ml.cacheParent(), ml.mountLabel)
 }
 
 func (ml *mountedLayer) Metadata() (map[string]string, error) {

--- a/layer/ro_layer.go
+++ b/layer/ro_layer.go
@@ -51,7 +51,7 @@ func (rl *roLayer) TarStreamFrom(parent ChainID) (io.ReadCloser, error) {
 	if parent != ChainID("") && parentCacheID == "" {
 		return nil, fmt.Errorf("layer ID '%s' is not a parent of the specified layer: cannot provide diff to non-parent", parent)
 	}
-	return rl.layerStore.driver.Diff(rl.cacheID, parentCacheID)
+	return rl.layerStore.driver.Diff(rl.cacheID, parentCacheID, "")
 }
 
 func (rl *roLayer) CacheID() string {


### PR DESCRIPTION
Currently when we do a commmit, we are mounting the container without using
the mountlabel. In certain situations we can leak mount points where the
image is already mounted with a label. If you then attempt to commit the
image, the kernel will attempt to mount the image without a label. The
kernel will reject this mount since SELinux does not allow the same image
to be mounted with different labels.

Passing down the label to the diff drivers, fixes this issue.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

