### PR TITLE
Update API docs to show that /containers/{id}/kill returns HTTP 409

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5351,6 +5351,13 @@ paths:
           examples:
             application/json:
               message: "No such container: c2ada9df5af8"
+        409:
+          description: "container is not running"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+          examples:
+            application/json:
+              message: "Container d37cde0fe4ad63c3a7252023b2f9800282894247d145cb5933ddf6e52cc03a28 is not running"
         500:
           description: "server error"
           schema:


### PR DESCRIPTION
Resolves #36068