### PR TITLE
Verify NetworkingConfig to make sure EndpointSettings is not nil

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -322,8 +322,11 @@ func verifyNetworkingConfig(nwConfig *networktypes.NetworkingConfig) error {
 		return nil
 	}
 	if len(nwConfig.EndpointsConfig) == 1 {
-		for _, v := range nwConfig.EndpointsConfig {
-			if v != nil && v.IPAMConfig != nil {
+		for k, v := range nwConfig.EndpointsConfig {
+			if v == nil {
+				return errdefs.InvalidParameter(errors.Errorf("no EndpointSettings for %s", k))
+			}
+			if v.IPAMConfig != nil {
 				if v.IPAMConfig.IPv4Address != "" && net.ParseIP(v.IPAMConfig.IPv4Address).To4() == nil {
 					return errors.Errorf("invalid IPv4 address: %s", v.IPAMConfig.IPv4Address)
 				}

--- a/daemon/create_test.go
+++ b/daemon/create_test.go
@@ -1,0 +1,21 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/errdefs"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test case for 35752
+func TestVerifyNetworkingConfig(t *testing.T) {
+	name := "mynet"
+	endpoints := make(map[string]*network.EndpointSettings, 1)
+	endpoints[name] = nil
+	nwConfig := &network.NetworkingConfig{
+		EndpointsConfig: endpoints,
+	}
+	err := verifyNetworkingConfig(nwConfig)
+	assert.True(t, errdefs.IsInvalidParameter(err))
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This fix tries to address the issue raised in #35752 where container start will trigger a crash if EndpointSettings is nil.

**- How I did it**

This fix adds the validation to make sure EndpointSettings != nil

**- How to verify it**

A unit test has been added.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![baby-animals-animal-ocean-whale-nature-image-background](https://user-images.githubusercontent.com/6932348/35189487-391bc5d0-fe00-11e7-8fe5-cf6909d6d41d.jpg)

This fix fixes #35752.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>