### PR TITLE
Fix issue where network inspect does not show Created time for networks in swarm scope

### DIFF
--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -168,6 +168,7 @@ func BasicNetworkFromGRPC(n swarmapi.Network) basictypes.NetworkResource {
 		Ingress:    IsIngressNetwork(&n),
 		Labels:     n.Spec.Annotations.Labels,
 	}
+	nr.Created, _ = gogotypes.TimestampFromProto(n.Meta.CreatedAt)
 
 	if n.Spec.GetNetwork() != "" {
 		nr.ConfigFrom = networktypes.ConfigReference{

--- a/daemon/cluster/convert/network_test.go
+++ b/daemon/cluster/convert/network_test.go
@@ -1,0 +1,34 @@
+package convert
+
+import (
+	"testing"
+	"time"
+
+	swarmapi "github.com/docker/swarmkit/api"
+	gogotypes "github.com/gogo/protobuf/types"
+)
+
+func TestNetworkConvertBasicNetworkFromGRPCCreatedAt(t *testing.T) {
+	expected, err := time.Parse("Jan 2, 2006 at 3:04pm (MST)", "Jan 10, 2018 at 7:54pm (PST)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	createdAt, err := gogotypes.TimestampProto(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nw := swarmapi.Network{
+		Meta: swarmapi.Meta{
+			Version: swarmapi.Version{
+				Index: 1,
+			},
+			CreatedAt: createdAt,
+		},
+	}
+
+	n := BasicNetworkFromGRPC(nw)
+	if !n.Created.Equal(expected) {
+		t.Fatalf("expected time %s; received %s", expected, n.Created)
+	}
+}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This fix tries to address the issue raised in #36083 where `network inspect` does not show Created time if the network is created in swarm scope.

**- How I did it**

The issue was that Created was not converted from swarm api.

This fix addresses the issue.

**- How to verify it**

An unit test has been added.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

![150902_wild_cutepenguins jpg crop promo-xlarge2-2](https://user-images.githubusercontent.com/6932348/35293450-8d41c202-0028-11e8-904a-c0f0e845d7e8.jpg)


This fix fixes #36083.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
