### PR TITLE
bump libnetwork to 5ab4ab830062fe8a30a44b75b0bda6b1f4f166a4

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -31,7 +31,7 @@ github.com/moby/buildkit aaff9d591ef128560018433fe61beb802e149de8
 github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 
 #get libnetwork packages
-github.com/docker/libnetwork fcf1c3b5e57833aaaa756ae3c4140ea54da00319
+github.com/docker/libnetwork 5ab4ab830062fe8a30a44b75b0bda6b1f4f166a4
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/controller.go
+++ b/vendor/github.com/docker/libnetwork/controller.go
@@ -48,6 +48,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -1074,10 +1075,15 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (S
 	}
 	c.Unlock()
 
+	sandboxID := stringid.GenerateRandomID()
+	if runtime.GOOS == "windows" {
+		sandboxID = containerID
+	}
+
 	// Create sandbox and process options first. Key generation depends on an option
 	if sb == nil {
 		sb = &sandbox{
-			id:                 stringid.GenerateRandomID(),
+			id:                 sandboxID,
 			containerID:        containerID,
 			endpoints:          epHeap{},
 			epPriority:         map[string]int{},


### PR DESCRIPTION
full diff: https://github.com/docker/libnetwork/compare/fcf1c3b5e57833aaaa756ae3c4140ea54da00319...5ab4ab830062fe8a30a44b75b0bda6b1f4f166a4

includes:




- https://github.com/docker/libnetwork/pull/2010 - Fix to use ContainerID for windows instead of SanbdoxID

