### PR TITLE
Update API version history for `Init` with `POST /containers/create`

### DIFF
--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -236,7 +236,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /secrets/{id}/update` updates the secret `id`.
 * `POST /services/(id or name)/update` now accepts service name or prefix of service id as a parameter.
 * `POST /containers/create` added 2 built-in log-opts that work on all logging drivers,
-`mode` (`blocking`|`non-blocking`), and `max-buffer-size` (e.g. `2m`) which enables a non-blocking log buffer.
+  `mode` (`blocking`|`non-blocking`), and `max-buffer-size` (e.g. `2m`) which enables a non-blocking log buffer.
+* `POST /containers/create` now takes `HostConfig.Init` field to run an init
+  inside the container that forwards signals and reaps processes.
 
 ## v1.24 API changes
 


### PR DESCRIPTION
This is a follow up to https://github.com/moby/moby/pull/34655#pullrequestreview-91096779

to update API version history for `Init` field.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
