### PR TITLE
Adds a --chmod flag to ADD and COPY

### DIFF
--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -62,6 +62,7 @@ type copyInstruction struct {
 	infos                   []copyInfo
 	dest                    string
 	chownStr                string
+	chmodStr                string
 	allowLocalDecompression bool
 }
 
@@ -429,6 +430,7 @@ func downloadSource(output io.Writer, stdout io.Writer, srcURL string) (remote b
 type copyFileOptions struct {
 	decompress bool
 	chownPair  idtools.IDPair
+	chmodVal   uint16
 	archiver   Archiver
 }
 
@@ -458,7 +460,7 @@ func performCopyForInfo(dest copyInfo, source copyInfo, options copyFileOptions)
 		return errors.Wrapf(err, "source path not found")
 	}
 	if src.IsDir() {
-		return copyDirectory(archiver, srcEndpoint, destEndpoint, options.chownPair)
+		return copyDirectory(archiver, srcEndpoint, destEndpoint, options.chownPair, options.chmodVal)
 	}
 	if options.decompress && isArchivePath(source.root, srcPath) && !source.noDecompress {
 		return archiver.UntarPath(srcPath, destPath)
@@ -476,7 +478,7 @@ func performCopyForInfo(dest copyInfo, source copyInfo, options copyFileOptions)
 		destPath = dest.root.Join(destPath, source.root.Base(source.path))
 		destEndpoint = &copyEndpoint{driver: dest.root, path: destPath}
 	}
-	return copyFile(archiver, srcEndpoint, destEndpoint, options.chownPair)
+	return copyFile(archiver, srcEndpoint, destEndpoint, options.chownPair, options.chmodVal)
 }
 
 func isArchivePath(driver containerfs.ContainerFS, path string) bool {
@@ -494,7 +496,7 @@ func isArchivePath(driver containerfs.ContainerFS, path string) bool {
 	return err == nil
 }
 
-func copyDirectory(archiver Archiver, source, dest *copyEndpoint, chownPair idtools.IDPair) error {
+func copyDirectory(archiver Archiver, source, dest *copyEndpoint, chownPair idtools.IDPair, chmodVal uint16) error {
 	destExists, err := isExistingDirectory(dest)
 	if err != nil {
 		return errors.Wrapf(err, "failed to query destination path")
@@ -504,17 +506,23 @@ func copyDirectory(archiver Archiver, source, dest *copyEndpoint, chownPair idto
 		return errors.Wrapf(err, "failed to copy directory")
 	}
 	// TODO: @gupta-ak. Investigate how LCOW permission mappings will work.
-	return fixPermissions(source.path, dest.path, chownPair, !destExists)
+	return fixPermissions(source.path, dest.path, chownPair, chmodVal, !destExists)
 }
 
-func copyFile(archiver Archiver, source, dest *copyEndpoint, chownPair idtools.IDPair) error {
+func copyFile(archiver Archiver, source, dest *copyEndpoint, chownPair idtools.IDPair, chmodVal uint16) error {
+	mod := os.FileMode(0755)
+
+	if chmodVal > 0 {
+		mod = os.FileMode(chmodVal)
+	}
+
 	if runtime.GOOS == "windows" && dest.driver.OS() == "linux" {
 		// LCOW
-		if err := dest.driver.MkdirAll(dest.driver.Dir(dest.path), 0755); err != nil {
+		if err := dest.driver.MkdirAll(dest.driver.Dir(dest.path), mod); err != nil {
 			return errors.Wrapf(err, "failed to create new directory")
 		}
 	} else {
-		if err := idtools.MkdirAllAndChownNew(filepath.Dir(dest.path), 0755, chownPair); err != nil {
+		if err := idtools.MkdirAllAndChownNew(filepath.Dir(dest.path), mod, chownPair); err != nil {
 			// Normal containers
 			return errors.Wrapf(err, "failed to create new directory")
 		}
@@ -524,7 +532,7 @@ func copyFile(archiver Archiver, source, dest *copyEndpoint, chownPair idtools.I
 		return errors.Wrapf(err, "failed to copy file")
 	}
 	// TODO: @gupta-ak. Investigate how LCOW permission mappings will work.
-	return fixPermissions(source.path, dest.path, chownPair, false)
+	return fixPermissions(source.path, dest.path, chownPair, chmodVal, false)
 }
 
 func endsInSlash(driver containerfs.Driver, path string) bool {

--- a/builder/dockerfile/copy_unix.go
+++ b/builder/dockerfile/copy_unix.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 )
 
-func fixPermissions(source, destination string, rootIDs idtools.IDPair, overrideSkip bool) error {
+func fixPermissions(source, destination string, rootIDs idtools.IDPair, mod uint16, overrideSkip bool) error {
 	var (
 		skipChownRoot bool
 		err           error
@@ -39,7 +39,17 @@ func fixPermissions(source, destination string, rootIDs idtools.IDPair, override
 		}
 
 		fullpath = filepath.Join(destination, cleaned)
-		return os.Lchown(fullpath, rootIDs.UID, rootIDs.GID)
+		if !skipChownRoot {
+			err := os.Lchown(fullpath, rootIDs.UID, rootIDs.GID)
+			if err != nil {
+				return err
+			}
+		}
+		if mod > 0 {
+			err = os.Chmod(fullpath, os.FileMode(mod))
+		}
+
+		return err
 	})
 }
 

--- a/builder/dockerfile/copy_windows.go
+++ b/builder/dockerfile/copy_windows.go
@@ -13,7 +13,7 @@ var pathBlacklist = map[string]bool{
 	"c:\\windows": true,
 }
 
-func fixPermissions(source, destination string, rootIDs idtools.IDPair, overrideSkip bool) error {
+func fixPermissions(source, destination string, rootIDs idtools.IDPair, mod uint16, overrideSkip bool) error {
 	// chown is not supported on Windows
 	return nil
 }

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -100,6 +100,7 @@ func dispatchAdd(d dispatchRequest, c *instructions.AddCommand) error {
 		return err
 	}
 	copyInstruction.chownStr = c.Chown
+	copyInstruction.chmodStr = c.Chmod
 	copyInstruction.allowLocalDecompression = true
 
 	return d.builder.performCopy(d.state, copyInstruction)
@@ -125,6 +126,7 @@ func dispatchCopy(d dispatchRequest, c *instructions.CopyCommand) error {
 		return err
 	}
 	copyInstruction.chownStr = c.Chown
+	copyInstruction.chmodStr = c.Chmod
 
 	return d.builder.performCopy(d.state, copyInstruction)
 }

--- a/builder/dockerfile/instructions/commands.go
+++ b/builder/dockerfile/instructions/commands.go
@@ -147,6 +147,7 @@ type AddCommand struct {
 	withNameAndCode
 	SourcesAndDest
 	Chown string
+	Chmod string
 }
 
 // Expand variables
@@ -163,6 +164,7 @@ type CopyCommand struct {
 	SourcesAndDest
 	From  string
 	Chown string
+	Chmod string
 }
 
 // Expand variables

--- a/builder/dockerfile/instructions/parse.go
+++ b/builder/dockerfile/instructions/parse.go
@@ -238,6 +238,7 @@ func parseAdd(req parseRequest) (*AddCommand, error) {
 		return nil, errNoDestinationArgument("ADD")
 	}
 	flChown := req.flags.AddString("chown", "")
+	flChmod := req.flags.AddString("chmod", "")
 	if err := req.flags.Parse(); err != nil {
 		return nil, err
 	}
@@ -245,6 +246,7 @@ func parseAdd(req parseRequest) (*AddCommand, error) {
 		SourcesAndDest:  SourcesAndDest(req.args),
 		withNameAndCode: newWithNameAndCode(req),
 		Chown:           flChown.Value,
+		Chmod:           flChmod.Value,
 	}, nil
 }
 
@@ -254,6 +256,8 @@ func parseCopy(req parseRequest) (*CopyCommand, error) {
 	}
 	flChown := req.flags.AddString("chown", "")
 	flFrom := req.flags.AddString("from", "")
+	flChmod := req.flags.AddString("chmod", "")
+
 	if err := req.flags.Parse(); err != nil {
 		return nil, err
 	}
@@ -262,6 +266,7 @@ func parseCopy(req parseRequest) (*CopyCommand, error) {
 		From:            flFrom.Value,
 		withNameAndCode: newWithNameAndCode(req),
 		Chown:           flChown.Value,
+		Chmod:           flChmod.Value,
 	}, nil
 }
 

--- a/builder/dockerfile/internals_linux.go
+++ b/builder/dockerfile/internals_linux.go
@@ -49,6 +49,15 @@ func parseChownFlag(chown, ctrRootPath string, idMappings *idtools.IDMappings) (
 	return chownPair, nil
 }
 
+func parseChmodFlag(chmodStr string) (uint16, error) {
+	parsedVal, err := strconv.ParseUint(chmodStr, 8, 64)
+	if err != nil {
+		return 0, errors.New("invalid chmod flag " + chmodStr)
+	}
+
+	return uint16(parsedVal), nil
+}
+
 func lookupUser(userStr, filepath string) (int, error) {
 	// if the string is actually a uid integer, parse to int and return
 	// as we don't need to translate with the help of files

--- a/builder/dockerfile/internals_linux.go
+++ b/builder/dockerfile/internals_linux.go
@@ -1,6 +1,7 @@
 package dockerfile
 
 import (
+	"fmt"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -52,10 +53,74 @@ func parseChownFlag(chown, ctrRootPath string, idMappings *idtools.IDMappings) (
 func parseChmodFlag(chmodStr string) (uint16, error) {
 	parsedVal, err := strconv.ParseUint(chmodStr, 8, 64)
 	if err != nil {
-		return 0, errors.New("invalid chmod flag " + chmodStr)
+		return chmodSymbolsToInt(chmodStr)
 	}
 
 	return uint16(parsedVal), nil
+}
+
+func chmodSymbolsToInt(chmodStr string) (uint16, error) {
+	perms := map[string]uint{
+		"u": 0,
+		"g": 0,
+		"o": 0,
+	}
+
+	chmodBits := map[string]uint{
+		"r": 4, //100
+		"w": 2, //010
+		"x": 1, //001
+	}
+
+	tokenizers := []string{"=", "+", "-"}
+	for _, segment := range strings.Split(chmodStr, ",") {
+		for _, delimiter := range tokenizers {
+			values := strings.Split(segment, delimiter)
+			if len(values) == 1 {
+				continue
+			}
+
+			for _, subject := range strings.Split(values[0], "") {
+				for _, symbol := range strings.Split(values[1], "") {
+					val, ok := chmodBits[symbol]
+					if !ok {
+						return 0, errors.New("invalid chmod flags " + chmodStr)
+					}
+					switch delimiter {
+					case "=":
+						if subject == "a" {
+							perms["u"] = val
+							perms["g"] = val
+							perms["0"] = val
+						} else {
+							perms[subject] = val
+						}
+					case "+":
+						if subject == "a" {
+							perms["u"] |= val
+							perms["g"] |= val
+							perms["o"] |= val
+						} else {
+							perms[subject] |= val
+						}
+					case "-":
+						if subject == "a" {
+							perms["u"] &= ^val
+							perms["g"] &= ^val
+							perms["o"] &= ^val
+						} else {
+							perms[subject] &= ^val
+						}
+					default:
+						return 0, errors.New("invalid chmod flag " + chmodStr)
+					}
+				}
+			}
+		}
+	}
+
+	val, _ := strconv.ParseUint(fmt.Sprintf("%d%d%d", perms["u"], perms["g"], perms["o"]), 8, 64)
+	return uint16(val), nil
 }
 
 func lookupUser(userStr, filepath string) (int, error) {

--- a/builder/dockerfile/internals_linux_test.go
+++ b/builder/dockerfile/internals_linux_test.go
@@ -136,3 +136,42 @@ othergrp:x:6666:
 		})
 	}
 }
+
+func TestChmodFlagParsing(t *testing.T) {
+	// positive tests
+	for _, testcase := range []struct {
+		name     string
+		chmodStr string
+		expected uint16
+	}{
+		{
+			name:     "CorrectFlag",
+			chmodStr: "777",
+			expected: 0777,
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			parsedFlag, err := parseChmodFlag(testcase.chmodStr)
+			require.NoError(t, err, "Failed to parse chmod flag: %q", testcase.chmodStr)
+			assert.Equal(t, testcase.expected, parsedFlag, "chmod flag parsing failure")
+		})
+	}
+
+	// error tests
+	for _, testcase := range []struct {
+		name     string
+		chmodStr string
+		descr    string
+	}{
+		{
+			name:     "WrongFlag",
+			chmodStr: "688",
+			descr:    "invalid chmod flag 688",
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			_, err := parseChmodFlag(testcase.chmodStr)
+			assert.EqualError(t, err, testcase.descr, "Expected error string doesn't match")
+		})
+	}
+}

--- a/builder/dockerfile/internals_windows.go
+++ b/builder/dockerfile/internals_windows.go
@@ -5,3 +5,7 @@ import "github.com/docker/docker/pkg/idtools"
 func parseChownFlag(chown, ctrRootPath string, idMappings *idtools.IDMappings) (idtools.IDPair, error) {
 	return idMappings.RootPair(), nil
 }
+
+func parseChmodFlag(chmodStr string) (uint16, error) {
+	return 0, nil
+}

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -439,6 +439,57 @@ func (s *DockerSuite) TestBuildChownOnCopy(c *check.C) {
 	assert.Contains(c, string(out), "Successfully built")
 }
 
+func (s *DockerSuite) TestBuildChmodOnCopy(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	dockerfile := `FROM busybox
+		COPY --chmod=777 . /new_dir
+		RUN ls -l /
+		RUN [ $(stat /new_dir | grep "Access: (" | cut -d\( -f2 | cut -d\/ -f1 ) = '0777' ]
+	`
+	ctx := fakecontext.New(c, "",
+		fakecontext.WithDockerfile(dockerfile),
+		fakecontext.WithFile("test_file1", "some test content"),
+	)
+	defer ctx.Close()
+
+	res, body, err := request.Post(
+		"/build",
+		request.RawContent(ctx.AsTarReader(c)),
+		request.ContentType("application/x-tar"))
+	c.Assert(err, checker.IsNil)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
+
+	out, err := request.ReadBody(body)
+	require.NoError(c, err)
+	assert.Contains(c, string(out), "Successfully built")
+}
+
+
+func (s *DockerSuite) TestBuildChmodOnAdd(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	dockerfile := `FROM busybox
+		ADD --chmod=777 . /new_dir
+		RUN ls -l /
+		RUN [ $(stat /new_dir | grep "Access: (" | cut -d\( -f2 | cut -d\/ -f1 ) = '0777' ]
+	`
+	ctx := fakecontext.New(c, "",
+		fakecontext.WithDockerfile(dockerfile),
+		fakecontext.WithFile("test_file1", "some test content"),
+	)
+	defer ctx.Close()
+
+	res, body, err := request.Post(
+		"/build",
+		request.RawContent(ctx.AsTarReader(c)),
+		request.ContentType("application/x-tar"))
+	c.Assert(err, checker.IsNil)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
+
+	out, err := request.ReadBody(body)
+	require.NoError(c, err)
+	assert.Contains(c, string(out), "Successfully built")
+}
+
 func (s *DockerSuite) TestBuildCopyCacheOnFileChange(c *check.C) {
 
 	dockerfile := `FROM busybox


### PR DESCRIPTION
Closes https://github.com/moby/moby/issues/34819 

**What I did**: Implemented a `--chmod` flag for `ADD` and `COPY` instructions to allow the user to set file permissions in the same time while adding or copying without having to explicitly run `chmod` command.

**How I did it**: I implemented it in a way analogous to how `--chown` was implemented where `fixPermissions` sets the file permissions if `--chmod` was provided.

**How to verify it**: Either by running the tests or by manually adding `--chmod=xxx` to one of your docker files and inspecting the resulting image. 

**Summary**
This adds the ability to change file permissions while copying or adding by supplying an additional optional flag `--chmod`
For example: `COPY --chmod=777 . /new_dir` will copy files to `/new_dir` with open permissions of `777`

It also supports symbolic modes 

For example: `COPY --chmod u+rwx,go+rx ./new_dir` will result in `755` permission
