### PR TITLE
Fix "--node-generic-resource" singular/plural

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -67,7 +67,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 
 	flags.StringVar(&conf.MetricsAddress, "metrics-addr", "", "Set default address and port to serve the metrics api on")
 
-	flags.Var(opts.NewListOptsRef(&conf.NodeGenericResources, opts.ValidateSingleGenericResource), "node-generic-resources", "Advertise user-defined resource")
+	flags.Var(opts.NewNamedListOptsRef("node-generic-resources", &conf.NodeGenericResources, opts.ValidateSingleGenericResource), "node-generic-resource", "Advertise user-defined resource")
 
 	flags.IntVar(&conf.NetworkControlPlaneMTU, "network-control-plane-mtu", config.DefaultNetworkMtu, "Network Control plane MTU")
 

--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -61,6 +61,22 @@ func TestLoadDaemonCliConfigWithConflicts(t *testing.T) {
 	testutil.ErrorContains(t, err, "as a flag and in the configuration file: labels")
 }
 
+func TestLoadDaemonCliWithConflictingNodeGenericResources(t *testing.T) {
+	tempFile := fs.NewFile(t, "config", fs.WithContent(`{"node-generic-resources": ["foo=bar", "bar=baz"]}`))
+	defer tempFile.Remove()
+	configFile := tempFile.Path()
+
+	opts := defaultOptions(configFile)
+	flags := opts.flags
+
+	assert.NoError(t, flags.Set("config-file", configFile))
+	assert.NoError(t, flags.Set("node-generic-resource", "r1=bar"))
+	assert.NoError(t, flags.Set("node-generic-resource", "r2=baz"))
+
+	_, err := loadDaemonCliConfig(opts)
+	testutil.ErrorContains(t, err, "as a flag and in the configuration file: node-generic-resources")
+}
+
 func TestLoadDaemonCliWithConflictingLabels(t *testing.T) {
 	opts := defaultOptions("")
 	flags := opts.flags


### PR DESCRIPTION
Daemon flags that can be specified multiple times use singlar names for flags, but plural names for the configuration file.

To make the daemon configuration know how to correlate the flag with the corresponding configuration option, `opt.NewNamedListOptsRef()` should be used instead of `opt.NewListOptsRef()`.

Commit https://github.com/moby/moby/pull/35970/commits/6702ac590e6148cb3f606388dde93a011cb14931 (https://github.com/moby/moby/pull/35970) attempted to fix the daemon not corresponding the flag with the configuration file option, but did so by changing the name of the flag to plural.

This patch reverts that change, and uses `opt.NewNamedListOptsRef()` instead.


ping @vdemeester @AkihiroSuda @RenaudWasTaken 