### PR TITLE
 Fix secret and config mode issue

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -239,6 +239,9 @@ func (daemon *Daemon) setupSecretDir(c *container.Container) (setupErr error) {
 		if err := os.Chown(fPath, rootIDs.UID+uid, rootIDs.GID+gid); err != nil {
 			return errors.Wrap(err, "error setting ownership for secret")
 		}
+		if err := os.Chmod(fPath, s.File.Mode); err != nil {
+			return errors.Wrap(err, "error setting file mode for secret")
+		}
 	}
 
 	label.Relabel(localMountPath, c.MountLabel, false)
@@ -319,6 +322,9 @@ func (daemon *Daemon) setupConfigDir(c *container.Container) (setupErr error) {
 
 		if err := os.Chown(fPath, rootIDs.UID+uid, rootIDs.GID+gid); err != nil {
 			return errors.Wrap(err, "error setting ownership for config")
+		}
+		if err := os.Chmod(fPath, configRef.File.Mode); err != nil {
+			return errors.Wrap(err, "error setting file mode for config")
 		}
 
 		label.Relabel(fPath, c.MountLabel, false)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This fix tries to address the issue raised in #36042 where secret and config are not configured with the specified file mode.

**- How I did it**


This fix update the file mode so that it is not impacted with umask.

**- How to verify it**

Additional tests have been added.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```Markdown
* Fix configs and secrets custom file mode being overwritten by umask [moby/moby*36130](https://github.com/moby/moby/pull/36130)
```

**- A picture of a cute animal (not mandatory but encouraged)**
![baby-polar-bear-is-hiching-a-ride-on-his-mom-big](https://user-images.githubusercontent.com/6932348/35484450-bbf202da-0404-11e8-9774-0b09e24d490f.jpg)


This fix fixes #36042.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>