### PR TITLE
Update swarmkit to 68a376dc30d8c4001767c39456b990dbd821371b

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -115,7 +115,7 @@ github.com/dmcgowan/go-tar go1.10
 github.com/stevvooe/ttrpc 76e68349ad9ab4d03d764c713826d31216715e4f
 
 # cluster
-github.com/docker/swarmkit 713d79dc8799b33465c58ed120b870c52eb5eb4f
+github.com/docker/swarmkit 68a376dc30d8c4001767c39456b990dbd821371b
 github.com/gogo/protobuf v0.4
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a
 github.com/google/certificate-transparency d90e65c3a07988180c5b1ece71791c0b6506826e

--- a/vendor/github.com/docker/swarmkit/agent/agent.go
+++ b/vendor/github.com/docker/swarmkit/agent/agent.go
@@ -333,11 +333,11 @@ func (a *Agent) run(ctx context.Context) {
 					a.config.SessionTracker.SessionError(err)
 				}
 
-				log.G(ctx).WithError(err).Error("agent: session failed")
 				backoff = initialSessionFailureBackoff + 2*backoff
 				if backoff > maxSessionFailureBackoff {
 					backoff = maxSessionFailureBackoff
 				}
+				log.G(ctx).WithError(err).WithField("backoff", backoff).Errorf("agent: session failed")
 			}
 
 			if err := session.close(); err != nil {

--- a/vendor/github.com/docker/swarmkit/agent/errors.go
+++ b/vendor/github.com/docker/swarmkit/agent/errors.go
@@ -13,7 +13,7 @@ var (
 	errAgentStarted    = errors.New("agent: already started")
 	errAgentNotStarted = errors.New("agent: not started")
 
-	errTaskNoContoller          = errors.New("agent: no task controller")
+	errTaskNoController         = errors.New("agent: no task controller")
 	errTaskNotAssigned          = errors.New("agent: task not assigned")
 	errTaskStatusUpdateNoChange = errors.New("agent: no change in task status")
 	errTaskUnknown              = errors.New("agent: task unknown")

--- a/vendor/github.com/docker/swarmkit/connectionbroker/broker.go
+++ b/vendor/github.com/docker/swarmkit/connectionbroker/broker.go
@@ -58,6 +58,7 @@ func (b *Broker) Select(dialOpts ...grpc.DialOption) (*Conn, error) {
 // connection.
 func (b *Broker) SelectRemote(dialOpts ...grpc.DialOption) (*Conn, error) {
 	peer, err := b.remotes.Select()
+
 	if err != nil {
 		return nil, err
 	}
@@ -96,6 +97,11 @@ type Conn struct {
 	isLocal bool
 	remotes remotes.Remotes
 	peer    api.Peer
+}
+
+// Peer returns the peer for this Conn.
+func (c *Conn) Peer() api.Peer {
+	return c.peer
 }
 
 // Close closes the client connection if it is a remote connection. It also

--- a/vendor/github.com/docker/swarmkit/manager/logbroker/broker.go
+++ b/vendor/github.com/docker/swarmkit/manager/logbroker/broker.go
@@ -33,7 +33,7 @@ type logMessage struct {
 // LogBroker coordinates log subscriptions to services and tasks. Clients can
 // publish and subscribe to logs channels.
 //
-// Log subscriptions are pushed to the work nodes by creating log subscsription
+// Log subscriptions are pushed to the work nodes by creating log subscription
 // tasks. As such, the LogBroker also acts as an orchestrator of these tasks.
 type LogBroker struct {
 	mu                sync.RWMutex

--- a/vendor/github.com/docker/swarmkit/manager/state/raft/transport/peer.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/raft/transport/peer.go
@@ -239,6 +239,7 @@ func (p *peer) sendProcessMessage(ctx context.Context, m raftpb.Message) error {
 
 	// Try doing a regular rpc if the receiver doesn't support streaming.
 	if grpc.Code(err) == codes.Unimplemented {
+		log.G(ctx).Info("sending message to raft peer using ProcessRaftMessage()")
 		_, err = api.NewRaftClient(p.conn()).ProcessRaftMessage(ctx, &api.ProcessRaftMessageRequest{Message: &m})
 	}
 


### PR DESCRIPTION
This fix updates swarmkit to 68a376dc30d8c4001767c39456b990dbd821371b:
```
-github.com/docker/swarmkit 713d79dc8799b33465c58ed120b870c52eb5eb4f
+github.com/docker/swarmkit 68a376dc30d8c4001767c39456b990dbd821371b
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

Full diff: https://github.com/docker/swarmkit/compare/713d79dc8799b33465c58ed120b870c52eb5eb4f...68a376dc30d8c4001767c39456b990dbd821371b

Changes included:

- https://github.com/docker/swarmkit/pull/2483 raft/transport: add log message to indicate message send retry if streaming unimplemented
- https://github.com/docker/swarmkit/pull/2486 [agent] debug logs for session, node events on dispatcher, heartbeats
- https://github.com/docker/swarmkit/pull/2492 [agent] Minor fix for session log to be in the correct place