### PR TITLE
Fix a typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ the contributors guide.
       <p>
         Register for the Docker Community Slack at
 	<a href="https://community.docker.com/registrations/groups/4316" target="_blank">https://community.docker.com/registrations/groups/4316</a>.
-        We use the #moby-project channel for general discussion, and there are seperate channels for other Moby projects such as #containerd.
+        We use the #moby-project channel for general discussion, and there are separate channels for other Moby projects such as #containerd.
 	Archives are available at <a href="https://dockercommunity.slackarchive.io/" target="_blank">https://dockercommunity.slackarchive.io/</a>.
       </p>
     </td>


### PR DESCRIPTION
`seperate` -> `separate`

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
