### PR TITLE
Produce errors when empty ids are passed into inspect calls. 

### DIFF
--- a/client/config_inspect.go
+++ b/client/config_inspect.go
@@ -11,6 +11,9 @@ import (
 
 // ConfigInspectWithRaw returns the config information with raw data
 func (cli *Client) ConfigInspectWithRaw(ctx context.Context, id string) (swarm.Config, []byte, error) {
+	if id == "" {
+		return swarm.Config{}, nil, objectNotFoundError{object: "config", id: id}
+	}
 	if err := cli.NewVersionError("1.30", "config inspect"); err != nil {
 		return swarm.Config{}, nil, err
 	}

--- a/client/container_inspect.go
+++ b/client/container_inspect.go
@@ -12,6 +12,9 @@ import (
 
 // ContainerInspect returns the container information.
 func (cli *Client) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+	if containerID == "" {
+		return types.ContainerJSON{}, objectNotFoundError{object: "container", id: containerID}
+	}
 	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", nil, nil)
 	if err != nil {
 		return types.ContainerJSON{}, wrapResponseError(err, serverResp, "container", containerID)
@@ -25,6 +28,9 @@ func (cli *Client) ContainerInspect(ctx context.Context, containerID string) (ty
 
 // ContainerInspectWithRaw returns the container information and its raw representation.
 func (cli *Client) ContainerInspectWithRaw(ctx context.Context, containerID string, getSize bool) (types.ContainerJSON, []byte, error) {
+	if containerID == "" {
+		return types.ContainerJSON{}, nil, objectNotFoundError{object: "container", id: containerID}
+	}
 	query := url.Values{}
 	if getSize {
 		query.Set("size", "1")

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -32,6 +33,18 @@ func TestContainerInspectContainerNotFound(t *testing.T) {
 	_, err := client.ContainerInspect(context.Background(), "unknown")
 	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected a containerNotFound error, got %v", err)
+	}
+}
+
+func TestContainerInspectWithEmptyID(t *testing.T) {
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("should not make request")
+		}),
+	}
+	_, _, err := client.ContainerInspectWithRaw(context.Background(), "", true)
+	if !IsErrNotFound(err) {
+		t.Fatalf("Expected NotFoundError, got %v", err)
 	}
 }
 

--- a/client/distribution_inspect.go
+++ b/client/distribution_inspect.go
@@ -12,6 +12,9 @@ import (
 func (cli *Client) DistributionInspect(ctx context.Context, image, encodedRegistryAuth string) (registrytypes.DistributionInspect, error) {
 	// Contact the registry to retrieve digest and platform information
 	var distributionInspect registrytypes.DistributionInspect
+	if image == "" {
+		return distributionInspect, objectNotFoundError{object: "distribution", id: image}
+	}
 
 	if err := cli.NewVersionError("1.30", "distribution inspect"); err != nil {
 		return distributionInspect, err

--- a/client/distribution_inspect_test.go
+++ b/client/distribution_inspect_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
@@ -15,4 +16,16 @@ func TestDistributionInspectUnsupported(t *testing.T) {
 	}
 	_, err := client.DistributionInspect(context.Background(), "foobar:1.0", "")
 	assert.EqualError(t, err, `"distribution inspect" requires API version 1.30, but the Docker daemon API version is 1.29`)
+}
+
+func TestDistributionInspectWithEmptyID(t *testing.T) {
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("should not make request")
+		}),
+	}
+	_, err := client.DistributionInspect(context.Background(), "", "")
+	if !IsErrNotFound(err) {
+		t.Fatalf("Expected NotFoundError, got %v", err)
+	}
 }

--- a/client/image_inspect.go
+++ b/client/image_inspect.go
@@ -11,6 +11,9 @@ import (
 
 // ImageInspectWithRaw returns the image information and its raw representation.
 func (cli *Client) ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error) {
+	if imageID == "" {
+		return types.ImageInspect{}, nil, objectNotFoundError{object: "image", id: imageID}
+	}
 	serverResp, err := cli.get(ctx, "/images/"+imageID+"/json", nil, nil)
 	if err != nil {
 		return types.ImageInspect{}, nil, wrapResponseError(err, serverResp, "image", imageID)

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -33,6 +34,18 @@ func TestImageInspectImageNotFound(t *testing.T) {
 	_, _, err := client.ImageInspectWithRaw(context.Background(), "unknown")
 	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected an imageNotFound error, got %v", err)
+	}
+}
+
+func TestImageInspectWithEmptyID(t *testing.T) {
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("should not make request")
+		}),
+	}
+	_, _, err := client.ImageInspectWithRaw(context.Background(), "")
+	if !IsErrNotFound(err) {
+		t.Fatalf("Expected NotFoundError, got %v", err)
 	}
 }
 

--- a/client/network_inspect.go
+++ b/client/network_inspect.go
@@ -18,6 +18,9 @@ func (cli *Client) NetworkInspect(ctx context.Context, networkID string, options
 
 // NetworkInspectWithRaw returns the information for a specific network configured in the docker host and its raw representation.
 func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, []byte, error) {
+	if networkID == "" {
+		return types.NetworkResource{}, nil, objectNotFoundError{object: "network", id: networkID}
+	}
 	var (
 		networkResource types.NetworkResource
 		resp            serverResponse

--- a/client/network_inspect_test.go
+++ b/client/network_inspect_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
@@ -32,6 +33,18 @@ func TestNetworkInspectNotFoundError(t *testing.T) {
 	_, err := client.NetworkInspect(context.Background(), "unknown", types.NetworkInspectOptions{})
 	assert.EqualError(t, err, "Error: No such network: unknown")
 	assert.True(t, IsErrNotFound(err))
+}
+
+func TestNetworkInspectWithEmptyID(t *testing.T) {
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("should not make request")
+		}),
+	}
+	_, _, err := client.NetworkInspectWithRaw(context.Background(), "", types.NetworkInspectOptions{})
+	if !IsErrNotFound(err) {
+		t.Fatalf("Expected NotFoundError, got %v", err)
+	}
 }
 
 func TestNetworkInspect(t *testing.T) {

--- a/client/node_inspect.go
+++ b/client/node_inspect.go
@@ -11,6 +11,9 @@ import (
 
 // NodeInspectWithRaw returns the node information.
 func (cli *Client) NodeInspectWithRaw(ctx context.Context, nodeID string) (swarm.Node, []byte, error) {
+	if nodeID == "" {
+		return swarm.Node{}, nil, objectNotFoundError{object: "node", id: nodeID}
+	}
 	serverResp, err := cli.get(ctx, "/nodes/"+nodeID, nil, nil)
 	if err != nil {
 		return swarm.Node{}, nil, wrapResponseError(err, serverResp, "node", nodeID)

--- a/client/node_inspect_test.go
+++ b/client/node_inspect_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -32,6 +33,18 @@ func TestNodeInspectNodeNotFound(t *testing.T) {
 	_, _, err := client.NodeInspectWithRaw(context.Background(), "unknown")
 	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected a nodeNotFoundError error, got %v", err)
+	}
+}
+
+func TestNodeInspectWithEmptyID(t *testing.T) {
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("should not make request")
+		}),
+	}
+	_, _, err := client.NodeInspectWithRaw(context.Background(), "")
+	if !IsErrNotFound(err) {
+		t.Fatalf("Expected NotFoundError, got %v", err)
 	}
 }
 

--- a/client/plugin_inspect.go
+++ b/client/plugin_inspect.go
@@ -11,6 +11,9 @@ import (
 
 // PluginInspectWithRaw inspects an existing plugin
 func (cli *Client) PluginInspectWithRaw(ctx context.Context, name string) (*types.Plugin, []byte, error) {
+	if name == "" {
+		return nil, nil, objectNotFoundError{object: "plugin", id: name}
+	}
 	resp, err := cli.get(ctx, "/plugins/"+name+"/json", nil, nil)
 	if err != nil {
 		return nil, nil, wrapResponseError(err, resp, "plugin", name)

--- a/client/plugin_inspect_test.go
+++ b/client/plugin_inspect_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -21,6 +22,18 @@ func TestPluginInspectError(t *testing.T) {
 	_, _, err := client.PluginInspectWithRaw(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestPluginInspectWithEmptyID(t *testing.T) {
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("should not make request")
+		}),
+	}
+	_, _, err := client.PluginInspectWithRaw(context.Background(), "")
+	if !IsErrNotFound(err) {
+		t.Fatalf("Expected NotFoundError, got %v", err)
 	}
 }
 

--- a/client/secret_inspect.go
+++ b/client/secret_inspect.go
@@ -14,6 +14,9 @@ func (cli *Client) SecretInspectWithRaw(ctx context.Context, id string) (swarm.S
 	if err := cli.NewVersionError("1.25", "secret inspect"); err != nil {
 		return swarm.Secret{}, nil, err
 	}
+	if id == "" {
+		return swarm.Secret{}, nil, objectNotFoundError{object: "secret", id: id}
+	}
 	resp, err := cli.get(ctx, "/secrets/"+id, nil, nil)
 	if err != nil {
 		return swarm.Secret{}, nil, wrapResponseError(err, resp, "secret", id)

--- a/client/secret_inspect_test.go
+++ b/client/secret_inspect_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
@@ -44,6 +45,18 @@ func TestSecretInspectSecretNotFound(t *testing.T) {
 	_, _, err := client.SecretInspectWithRaw(context.Background(), "unknown")
 	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected a secretNotFoundError error, got %v", err)
+	}
+}
+
+func TestSecretInspectWithEmptyID(t *testing.T) {
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("should not make request")
+		}),
+	}
+	_, _, err := client.SecretInspectWithRaw(context.Background(), "")
+	if !IsErrNotFound(err) {
+		t.Fatalf("Expected NotFoundError, got %v", err)
 	}
 }
 

--- a/client/service_inspect.go
+++ b/client/service_inspect.go
@@ -14,6 +14,9 @@ import (
 
 // ServiceInspectWithRaw returns the service information and the raw data.
 func (cli *Client) ServiceInspectWithRaw(ctx context.Context, serviceID string, opts types.ServiceInspectOptions) (swarm.Service, []byte, error) {
+	if serviceID == "" {
+		return swarm.Service{}, nil, objectNotFoundError{object: "service", id: serviceID}
+	}
 	query := url.Values{}
 	query.Set("insertDefaults", fmt.Sprintf("%v", opts.InsertDefaults))
 	serverResp, err := cli.get(ctx, "/services/"+serviceID, query, nil)

--- a/client/service_inspect_test.go
+++ b/client/service_inspect_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -33,6 +34,18 @@ func TestServiceInspectServiceNotFound(t *testing.T) {
 	_, _, err := client.ServiceInspectWithRaw(context.Background(), "unknown", types.ServiceInspectOptions{})
 	if err == nil || !IsErrNotFound(err) {
 		t.Fatalf("expected a serviceNotFoundError error, got %v", err)
+	}
+}
+
+func TestServiceInspectWithEmptyID(t *testing.T) {
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("should not make request")
+		}),
+	}
+	_, _, err := client.ServiceInspectWithRaw(context.Background(), "", types.ServiceInspectOptions{})
+	if !IsErrNotFound(err) {
+		t.Fatalf("Expected NotFoundError, got %v", err)
 	}
 }
 

--- a/client/task_inspect.go
+++ b/client/task_inspect.go
@@ -11,6 +11,9 @@ import (
 
 // TaskInspectWithRaw returns the task information and its raw representation..
 func (cli *Client) TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error) {
+	if taskID == "" {
+		return swarm.Task{}, nil, objectNotFoundError{object: "task", id: taskID}
+	}
 	serverResp, err := cli.get(ctx, "/tasks/"+taskID, nil, nil)
 	if err != nil {
 		return swarm.Task{}, nil, wrapResponseError(err, serverResp, "task", taskID)

--- a/client/task_inspect_test.go
+++ b/client/task_inspect_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -21,6 +22,18 @@ func TestTaskInspectError(t *testing.T) {
 	_, _, err := client.TaskInspectWithRaw(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestTaskInspectWithEmptyID(t *testing.T) {
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("should not make request")
+		}),
+	}
+	_, _, err := client.TaskInspectWithRaw(context.Background(), "")
+	if !IsErrNotFound(err) {
+		t.Fatalf("Expected NotFoundError, got %v", err)
 	}
 }
 

--- a/client/volume_inspect.go
+++ b/client/volume_inspect.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
-	"path"
 
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
@@ -18,15 +17,12 @@ func (cli *Client) VolumeInspect(ctx context.Context, volumeID string) (types.Vo
 
 // VolumeInspectWithRaw returns the information about a specific volume in the docker host and its raw representation
 func (cli *Client) VolumeInspectWithRaw(ctx context.Context, volumeID string) (types.Volume, []byte, error) {
-	// The empty ID needs to be handled here because with an empty ID the
-	// request url will not contain a trailing / which calls the volume list API
-	// instead of volume inspect
 	if volumeID == "" {
 		return types.Volume{}, nil, objectNotFoundError{object: "volume", id: volumeID}
 	}
 
 	var volume types.Volume
-	resp, err := cli.get(ctx, path.Join("/volumes", volumeID), nil, nil)
+	resp, err := cli.get(ctx, "/volumes/"+volumeID, nil, nil)
 	if err != nil {
 		return volume, nil, wrapResponseError(err, resp, "volume", volumeID)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Made the client validate when empty IDs are passed into inspect methods to prevent calling the wrong endpoint and returning the wrong error.

Previously, if for example a blank `nodeID` was passed in to `NodeInspectWithRaw` the result was a node list request. The response would then fail to unmarshal into a `Node` type returning a JSON error.

**- How I did it**

Checked ids passed into inspect calls and returned an error if they were empty.

**- How to verify it**

Test added.

**- Description for the changelog**
Produce errors when empty ids are passed into inspect calls.

