### PR TITLE
Add `REMOVE` and `ORPHANED` to TaskState

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2804,6 +2804,8 @@ definitions:
       - "shutdown"
       - "failed"
       - "rejected"
+      - "remove"
+      - "orphaned"
 
   Task:
     type: "object"

--- a/api/types/swarm/task.go
+++ b/api/types/swarm/task.go
@@ -36,6 +36,10 @@ const (
 	TaskStateFailed TaskState = "failed"
 	// TaskStateRejected REJECTED
 	TaskStateRejected TaskState = "rejected"
+	// TaskStateRemove REMOVE
+	TaskStateRemove TaskState = "remove"
+	// TaskStateOrphaned ORPHANED
+	TaskStateOrphaned TaskState = "orphaned"
 )
 
 // Task represents a task.


### PR DESCRIPTION
This fix tries to address the issue raised in #36142 where
there are discrepancies between Swarm API and swagger.yaml.

This fix adds two recently added state `REMOVE` and `ORPHANED` to TaskState.

This fix fixes #36142.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
