### PR TITLE
Fix issue of ExitCode and PID not show up in Task.Status.ContainerStatus

### DIFF
--- a/api/types/swarm/task.go
+++ b/api/types/swarm/task.go
@@ -162,19 +162,19 @@ const (
 
 // TaskStatus represents the status of a task.
 type TaskStatus struct {
-	Timestamp       time.Time       `json:",omitempty"`
-	State           TaskState       `json:",omitempty"`
-	Message         string          `json:",omitempty"`
-	Err             string          `json:",omitempty"`
-	ContainerStatus ContainerStatus `json:",omitempty"`
-	PortStatus      PortStatus      `json:",omitempty"`
+	Timestamp       time.Time        `json:",omitempty"`
+	State           TaskState        `json:",omitempty"`
+	Message         string           `json:",omitempty"`
+	Err             string           `json:",omitempty"`
+	ContainerStatus *ContainerStatus `json:",omitempty"`
+	PortStatus      PortStatus       `json:",omitempty"`
 }
 
 // ContainerStatus represents the status of a container.
 type ContainerStatus struct {
-	ContainerID string `json:",omitempty"`
-	PID         int    `json:",omitempty"`
-	ExitCode    int    `json:",omitempty"`
+	ContainerID string
+	PID         int
+	ExitCode    int
 }
 
 // PortStatus represents the port status of a task's host ports whose

--- a/daemon/cluster/convert/task.go
+++ b/daemon/cluster/convert/task.go
@@ -42,9 +42,11 @@ func TaskFromGRPC(t swarmapi.Task) (types.Task, error) {
 	task.Status.Timestamp, _ = gogotypes.TimestampFromProto(t.Status.Timestamp)
 
 	if containerStatus != nil {
-		task.Status.ContainerStatus.ContainerID = containerStatus.ContainerID
-		task.Status.ContainerStatus.PID = int(containerStatus.PID)
-		task.Status.ContainerStatus.ExitCode = int(containerStatus.ExitCode)
+		task.Status.ContainerStatus = &types.ContainerStatus{
+			ContainerID: containerStatus.ContainerID,
+			PID:         int(containerStatus.PID),
+			ExitCode:    int(containerStatus.ExitCode),
+		}
 	}
 
 	// NetworksAttachments

--- a/integration-cli/docker_cli_service_create_test.go
+++ b/integration-cli/docker_cli_service_create_test.go
@@ -29,10 +29,10 @@ func (s *DockerSwarmSuite) TestServiceCreateMountVolume(c *check.C) {
 
 	task := tasks[0]
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		if task.NodeID == "" || task.Status.ContainerStatus.ContainerID == "" {
+		if task.NodeID == "" || task.Status.ContainerStatus == nil {
 			task = d.GetTask(c, task.ID)
 		}
-		return task.NodeID != "" && task.Status.ContainerStatus.ContainerID != "", nil
+		return task.NodeID != "" && task.Status.ContainerStatus != nil, nil
 	}, checker.Equals, true)
 
 	// check container mount config
@@ -143,10 +143,10 @@ func (s *DockerSwarmSuite) TestServiceCreateWithSecretSourceTargetPaths(c *check
 
 	task := tasks[0]
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		if task.NodeID == "" || task.Status.ContainerStatus.ContainerID == "" {
+		if task.NodeID == "" || task.Status.ContainerStatus == nil {
 			task = d.GetTask(c, task.ID)
 		}
-		return task.NodeID != "" && task.Status.ContainerStatus.ContainerID != "", nil
+		return task.NodeID != "" && task.Status.ContainerStatus != nil, nil
 	}, checker.Equals, true)
 
 	for testName, testTarget := range testPaths {
@@ -193,10 +193,10 @@ func (s *DockerSwarmSuite) TestServiceCreateWithSecretReferencedTwice(c *check.C
 
 	task := tasks[0]
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		if task.NodeID == "" || task.Status.ContainerStatus.ContainerID == "" {
+		if task.NodeID == "" || task.Status.ContainerStatus == nil {
 			task = d.GetTask(c, task.ID)
 		}
-		return task.NodeID != "" && task.Status.ContainerStatus.ContainerID != "", nil
+		return task.NodeID != "" && task.Status.ContainerStatus != nil, nil
 	}, checker.Equals, true)
 
 	for _, target := range []string{"target1", "target2"} {
@@ -290,10 +290,10 @@ func (s *DockerSwarmSuite) TestServiceCreateWithConfigSourceTargetPaths(c *check
 
 	task := tasks[0]
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		if task.NodeID == "" || task.Status.ContainerStatus.ContainerID == "" {
+		if task.NodeID == "" || task.Status.ContainerStatus == nil {
 			task = d.GetTask(c, task.ID)
 		}
-		return task.NodeID != "" && task.Status.ContainerStatus.ContainerID != "", nil
+		return task.NodeID != "" && task.Status.ContainerStatus != nil, nil
 	}, checker.Equals, true)
 
 	for testName, testTarget := range testPaths {
@@ -340,10 +340,10 @@ func (s *DockerSwarmSuite) TestServiceCreateWithConfigReferencedTwice(c *check.C
 
 	task := tasks[0]
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		if task.NodeID == "" || task.Status.ContainerStatus.ContainerID == "" {
+		if task.NodeID == "" || task.Status.ContainerStatus == nil {
 			task = d.GetTask(c, task.ID)
 		}
-		return task.NodeID != "" && task.Status.ContainerStatus.ContainerID != "", nil
+		return task.NodeID != "" && task.Status.ContainerStatus != nil, nil
 	}, checker.Equals, true)
 
 	for _, target := range []string{"target1", "target2"} {
@@ -372,10 +372,10 @@ func (s *DockerSwarmSuite) TestServiceCreateMountTmpfs(c *check.C) {
 
 	task := tasks[0]
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		if task.NodeID == "" || task.Status.ContainerStatus.ContainerID == "" {
+		if task.NodeID == "" || task.Status.ContainerStatus == nil {
 			task = d.GetTask(c, task.ID)
 		}
-		return task.NodeID != "" && task.Status.ContainerStatus.ContainerID != "", nil
+		return task.NodeID != "" && task.Status.ContainerStatus != nil, nil
 	}, checker.Equals, true)
 
 	// check container mount config
@@ -428,10 +428,10 @@ func (s *DockerSwarmSuite) TestServiceCreateWithNetworkAlias(c *check.C) {
 
 	task := tasks[0]
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
-		if task.NodeID == "" || task.Status.ContainerStatus.ContainerID == "" {
+		if task.NodeID == "" || task.Status.ContainerStatus == nil {
 			task = d.GetTask(c, task.ID)
 		}
-		return task.NodeID != "" && task.Status.ContainerStatus.ContainerID != "", nil
+		return task.NodeID != "" && task.Status.ContainerStatus != nil, nil
 	}, checker.Equals, true)
 
 	// check container alias config


### PR DESCRIPTION
This fix tries to address the issue raised in #36139 where ExitCode and PID does not show up in Task.Status.ContainerStatus

The issue was caused by `json:",omitempty"` in PID and ExitCode which interprate 0 as null.

This is confusing as ExitCode 0 does have a meaning.

This fix removes  `json:",omitempty"` in ExitCode and PID, but changes ContainerStatus to pointer so that ContainerStatus does not show up at all if no content. If ContainerStatus does have a content, then ExitCode and PID will show up (even if they are 0).

This fix fixes #36139.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
