### PR TITLE
When link id is empty for overlay2, do not remove this link.

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -515,7 +515,9 @@ func (d *Driver) Remove(id string) error {
 	dir := d.dir(id)
 	lid, err := ioutil.ReadFile(path.Join(dir, "link"))
 	if err == nil {
-		if err := os.RemoveAll(path.Join(d.home, linkDir, string(lid))); err != nil {
+                if len(lid) == 0 {
+                        logrus.Errorf("when remove layer %v, link id is empty, and do not remove this link", id)
+                }else if err := os.RemoveAll(path.Join(d.home, linkDir, string(lid))); err != nil {
 			logrus.Debugf("Failed to remove link: %v", err)
 		}
 	}

--- a/vendor/github.com/docker/libnetwork/service_linux.go
+++ b/vendor/github.com/docker/libnetwork/service_linux.go
@@ -182,6 +182,7 @@ func (sb *sandbox) addLBBackend(ip, vip net.IP, fwMark uint32, ingressPorts []*P
 		if sb.ingress {
 			filteredPorts = filterPortConfigs(ingressPorts, false)
 			if err := programIngress(gwIP, filteredPorts, false); err != nil {
+                                filterPortConfigs(filteredPorts, true)
 				logrus.Errorf("Failed to add ingress: %v", err)
 				return
 			}
@@ -255,6 +256,7 @@ func (sb *sandbox) rmLBBackend(ip, vip net.IP, fwMark uint32, ingressPorts []*Po
 		if sb.ingress {
 			filteredPorts = filterPortConfigs(ingressPorts, true)
 			if err := programIngress(gwIP, filteredPorts, true); err != nil {
+                                filterPortConfigs(filteredPorts, false)
 				logrus.Errorf("Failed to delete ingress: %v", err)
 			}
 		}


### PR DESCRIPTION
Signed-off-by: fanjiyun <fan.jiyun@zte.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
If we want to remove a image in the overlay2, the all layers of this image will be removed and the link ~/overlay2/l/$linkId also will be removed. But, if a images is abnormal, so that the link id of a layer becomes empty, the directory ~/overlay2/l/ will be deleted by mistake. It has a serious consequence, which is causing all the images exceptions.
So, I add a protection mechanism to avoid this negative impact.

**- How I did it**
Detect link id is empty or not before removing it. If the link id is empty, do not delete the corresponding link.

**- Description for the changelog**
When link id is empty for overlay2, do not remove this link.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

