### PR TITLE
daemon.cleanupContainer: nullify container RWLayer upon release

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -128,6 +128,7 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 			container.SetRemovalError(e)
 			return e
 		}
+		container.RWLayer = nil
 	}
 
 	if err := system.EnsureRemoveAll(container.Root); err != nil {


### PR DESCRIPTION
ReleaseRWLayer can and should only be called once (unless it returns
an error), but might be called twice in case of a failure from
`system.EnsureRemoveAll(container.Root)`. This results in the
following error:

> Error response from daemon: driver "XXX" failed to remove root filesystem for YYY: layer not retained

The obvious fix is to set container.RWLayer to nil as soon as
ReleaseRWLayer() succeeds.