### PR TITLE
When link id is empty for overlay2, do not remove this link.

### DIFF
--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -366,6 +366,9 @@ func (d *Driver) dir(id string) string {
 
 // Remove cleans the directories that are created for this id.
 func (d *Driver) Remove(id string) error {
+	if id == "" {
+		return fmt.Errorf("refusing to remove the directories: id is empty")
+	}
 	d.locker.Lock(id)
 	defer d.locker.Unlock(id)
 	return system.EnsureRemoveAll(d.dir(id))

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -513,12 +513,17 @@ func (d *Driver) getLowerDirs(id string) ([]string, error) {
 
 // Remove cleans the directories that are created for this id.
 func (d *Driver) Remove(id string) error {
+	if id == "" {
+		return fmt.Errorf("refusing to remove the directories: id is empty")
+	}
 	d.locker.Lock(id)
 	defer d.locker.Unlock(id)
 	dir := d.dir(id)
 	lid, err := ioutil.ReadFile(path.Join(dir, "link"))
 	if err == nil {
-		if err := os.RemoveAll(path.Join(d.home, linkDir, string(lid))); err != nil {
+		if len(lid) == 0 {
+			logrus.WithField("storage-driver", "overlay2").Errorf("refusing to remove empty link for layer %v", id)
+		} else if err := os.RemoveAll(path.Join(d.home, linkDir, string(lid))); err != nil {
 			logrus.WithField("storage-driver", "overlay2").Debugf("Failed to remove link: %v", err)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: fanjiyun <fan.jiyun@zte.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
If we want to remove a image in the overlay2,  all layers of this image will be removed and the link ~/overlay2/l/$linkId also will be removed. But, if a images is abnormal, so that the content of file ~/overlay2/$layerId/link becomes empty, the directory ~/overlay2/l/ will be deleted by mistake. It has a serious consequence, which is causing all the images exceptions.
So, I add a protection mechanism to avoid this negative impact.

**- How I did it**
Detect link id is empty or not before removing a link. If the link id is empty, do not delete the corresponding link.

**- Description for the changelog**
When link id is empty for overlay2, do not remove this link.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
