### PR TITLE
bump docker/go-connections to 98e7d807e5d804e4e42a98d74d1dd695321224ef

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -16,7 +16,7 @@ github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 golang.org/x/net 7dcfb8076726a3fdd9353b6b8a1f1b6be6811bd6
 golang.org/x/sys 95c6576299259db960f6c5b9b69ea52422860fce
 github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
-github.com/docker/go-connections 3ede32e2033de7505e6500d6c868c2b9ed9f169d
+github.com/docker/go-connections 98e7d807e5d804e4e42a98d74d1dd695321224ef
 golang.org/x/text f72d8390a633d5dfb0cc84043294db9f6c935756
 github.com/stretchr/testify 4d4bfba8f1d1027c4fdbe371823030df51419987
 github.com/pmezard/go-difflib v1.0.0

--- a/vendor/github.com/docker/go-connections/tlsconfig/config.go
+++ b/vendor/github.com/docker/go-connections/tlsconfig/config.go
@@ -65,22 +65,34 @@ var allTLSVersions = map[uint16]struct{}{
 }
 
 // ServerDefault returns a secure-enough TLS configuration for the server TLS configuration.
-func ServerDefault() *tls.Config {
-	return &tls.Config{
-		// Avoid fallback to SSL protocols < TLS1.0
+func ServerDefault(ops ...func(*tls.Config)) *tls.Config {
+	tlsconfig := &tls.Config{
+		// Avoid fallback by default to SSL protocols < TLS1.0
 		MinVersion:               tls.VersionTLS10,
 		PreferServerCipherSuites: true,
 		CipherSuites:             DefaultServerAcceptedCiphers,
 	}
+
+	for _, op := range ops {
+		op(tlsconfig)
+	}
+
+	return tlsconfig
 }
 
 // ClientDefault returns a secure-enough TLS configuration for the client TLS configuration.
-func ClientDefault() *tls.Config {
-	return &tls.Config{
+func ClientDefault(ops ...func(*tls.Config)) *tls.Config {
+	tlsconfig := &tls.Config{
 		// Prefer TLS1.2 as the client minimum
 		MinVersion:   tls.VersionTLS12,
 		CipherSuites: clientCipherSuites,
 	}
+
+	for _, op := range ops {
+		op(tlsconfig)
+	}
+
+	return tlsconfig
 }
 
 // certPool returns an X.509 certificate pool from `caFile`, the certificate file.


### PR DESCRIPTION
full diff: https://github.com/docker/go-connections/compare/3ede32e2033de7505e6500d6c868c2b9ed9f169d... 98e7d807e5d804e4e42a98d74d1dd695321224ef

ping @n4ss @vdemeester 