### PR TITLE
Pass the label of docker container to the annotation of OCI runtime spec

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -853,6 +853,15 @@ func (daemon *Daemon) createSpec(c *container.Container) (retSpec *specs.Spec, e
 	s.Process.NoNewPrivileges = c.NoNewPrivileges
 	s.Process.OOMScoreAdj = &c.HostConfig.OomScoreAdj
 	s.Linux.MountLabel = c.MountLabel
+	if s.Annotations == nil {
+		s.Annotations = make(map[string]string)
+	}
+	for k, v := range c.Config.Labels {
+		if oldValue, ok := s.Annotations[k]; ok {
+			return nil, errors.Errorf("Key %q already exists in Annotations, the new value will be ignored, old value=%q, new value=%q", k, oldValue, v)
+		}
+		s.Annotations[k] = v
+	}
 
 	// Set the masked and readonly paths with regard to the host config options if they are set.
 	if c.HostConfig.MaskedPaths != nil {


### PR DESCRIPTION
Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Currectly, docker save the label data in container struct of docker, but not in `config.json` defined by OCI.
This pr pass the label of docker container to the annotation of OCI runtime spec, so that the label data which is set by kubernetes can be used by the VM-based runtime (like `clear-containers`) .
For example:
```go
	containerTypeLabelKey       = "io.kubernetes.docker.type"
	containerTypeLabelSandbox   = "podsandbox"
	containerTypeLabelContainer = "container"
	containerLogPathLabelKey    = "io.kubernetes.container.logpath"
	sandboxIDLabelKey           = "io.kubernetes.sandbox.id"
```

/cc @sameo @plutoinmii

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

