### PR TITLE
Migrate TestSecretInspect from integration-cli to api tests

### DIFF
--- a/integration-cli/docker_cli_secret_inspect_test.go
+++ b/integration-cli/docker_cli_secret_inspect_test.go
@@ -10,29 +10,6 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSwarmSuite) TestSecretInspect(c *check.C) {
-	d := s.AddDaemon(c, true, true)
-
-	testName := "test_secret"
-	id := d.CreateSecret(c, swarm.SecretSpec{
-		Annotations: swarm.Annotations{
-			Name: testName,
-		},
-		Data: []byte("TESTINGDATA"),
-	})
-	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
-
-	secret := d.GetSecret(c, id)
-	c.Assert(secret.Spec.Name, checker.Equals, testName)
-
-	out, err := d.Cmd("secret", "inspect", testName)
-	c.Assert(err, checker.IsNil, check.Commentf(out))
-
-	var secrets []swarm.Secret
-	c.Assert(json.Unmarshal([]byte(out), &secrets), checker.IsNil)
-	c.Assert(secrets, checker.HasLen, 1)
-}
-
 func (s *DockerSwarmSuite) TestSecretInspectMultiple(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 

--- a/integration/secret/main_test.go
+++ b/integration/secret/main_test.go
@@ -1,0 +1,35 @@
+package secret
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/docker/docker/internal/test/environment"
+)
+
+var testEnv *environment.Execution
+
+const dockerdBinary = "dockerd"
+
+func TestMain(m *testing.M) {
+	var err error
+	testEnv, err = environment.New()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	err = environment.EnsureFrozenImagesLinux(testEnv)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	testEnv.Print()
+	os.Exit(m.Run())
+}
+
+func setupTest(t *testing.T) func() {
+	environment.ProtectAll(t, testEnv)
+	return func() { testEnv.Clean(t) }
+}

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -1,0 +1,43 @@
+package secret
+
+import (
+	"testing"
+
+	swarmtypes "github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/integration-cli/request"
+	"github.com/docker/docker/integration/util/swarm"
+	"github.com/gotestyourself/gotestyourself/skip"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func TestSecretInspect(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+
+	defer setupTest(t)()
+	d := swarm.NewSwarm(t, testEnv)
+	defer d.Stop(t)
+	client, err := request.NewClientForHost(d.Sock())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	testName := "test_secret"
+	secretResp, err := client.SecretCreate(ctx, swarmtypes.SecretSpec{
+		Annotations: swarmtypes.Annotations{
+			Name: testName,
+		},
+		Data: []byte("TESTINGDATA"),
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, secretResp.ID, "")
+
+	secret, _, err := client.SecretInspectWithRaw(context.Background(), secretResp.ID)
+	require.NoError(t, err)
+	assert.Equal(t, secret.Spec.Name, testName)
+
+	secret, _, err = client.SecretInspectWithRaw(context.Background(), testName)
+	require.NoError(t, err)
+	assert.Equal(t, secret.ID, secretResp.ID)
+}

--- a/integration/service/inspect_test.go
+++ b/integration/service/inspect_test.go
@@ -1,17 +1,16 @@
 package service
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/swarm"
+	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/integration-cli/request"
+	"github.com/docker/docker/integration/util/swarm"
 	"github.com/gotestyourself/gotestyourself/poll"
 	"github.com/gotestyourself/gotestyourself/skip"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +21,7 @@ import (
 func TestInspect(t *testing.T) {
 	skip.IfCondition(t, !testEnv.IsLocalDaemon())
 	defer setupTest(t)()
-	d := newSwarm(t)
+	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)
 	client, err := request.NewClientForHost(d.Sock())
 	require.NoError(t, err)
@@ -49,19 +48,19 @@ func TestInspect(t *testing.T) {
 	assert.WithinDuration(t, before, service.UpdatedAt, 30*time.Second)
 }
 
-func fullSwarmServiceSpec(name string, replicas uint64) swarm.ServiceSpec {
+func fullSwarmServiceSpec(name string, replicas uint64) swarmtypes.ServiceSpec {
 	restartDelay := 100 * time.Millisecond
 	maxAttempts := uint64(4)
 
-	return swarm.ServiceSpec{
-		Annotations: swarm.Annotations{
+	return swarmtypes.ServiceSpec{
+		Annotations: swarmtypes.Annotations{
 			Name: name,
 			Labels: map[string]string{
 				"service-label": "service-label-value",
 			},
 		},
-		TaskTemplate: swarm.TaskSpec{
-			ContainerSpec: &swarm.ContainerSpec{
+		TaskTemplate: swarmtypes.TaskSpec{
+			ContainerSpec: &swarmtypes.ContainerSpec{
 				Image:           "busybox:latest",
 				Labels:          map[string]string{"container-label": "container-value"},
 				Command:         []string{"/bin/top"},
@@ -73,62 +72,41 @@ func fullSwarmServiceSpec(name string, replicas uint64) swarm.ServiceSpec {
 				StopSignal:      "SIGINT",
 				StopGracePeriod: &restartDelay,
 				Hosts:           []string{"8.8.8.8  google"},
-				DNSConfig: &swarm.DNSConfig{
+				DNSConfig: &swarmtypes.DNSConfig{
 					Nameservers: []string{"8.8.8.8"},
 					Search:      []string{"somedomain"},
 				},
 				Isolation: container.IsolationDefault,
 			},
-			RestartPolicy: &swarm.RestartPolicy{
+			RestartPolicy: &swarmtypes.RestartPolicy{
 				Delay:       &restartDelay,
-				Condition:   swarm.RestartPolicyConditionOnFailure,
+				Condition:   swarmtypes.RestartPolicyConditionOnFailure,
 				MaxAttempts: &maxAttempts,
 			},
-			Runtime: swarm.RuntimeContainer,
+			Runtime: swarmtypes.RuntimeContainer,
 		},
-		Mode: swarm.ServiceMode{
-			Replicated: &swarm.ReplicatedService{
+		Mode: swarmtypes.ServiceMode{
+			Replicated: &swarmtypes.ReplicatedService{
 				Replicas: &replicas,
 			},
 		},
-		UpdateConfig: &swarm.UpdateConfig{
+		UpdateConfig: &swarmtypes.UpdateConfig{
 			Parallelism:     2,
 			Delay:           200 * time.Second,
-			FailureAction:   swarm.UpdateFailureActionContinue,
+			FailureAction:   swarmtypes.UpdateFailureActionContinue,
 			Monitor:         2 * time.Second,
 			MaxFailureRatio: 0.2,
-			Order:           swarm.UpdateOrderStopFirst,
+			Order:           swarmtypes.UpdateOrderStopFirst,
 		},
-		RollbackConfig: &swarm.UpdateConfig{
+		RollbackConfig: &swarmtypes.UpdateConfig{
 			Parallelism:     3,
 			Delay:           300 * time.Second,
-			FailureAction:   swarm.UpdateFailureActionPause,
+			FailureAction:   swarmtypes.UpdateFailureActionPause,
 			Monitor:         3 * time.Second,
 			MaxFailureRatio: 0.3,
-			Order:           swarm.UpdateOrderStartFirst,
+			Order:           swarmtypes.UpdateOrderStartFirst,
 		},
 	}
-}
-
-const defaultSwarmPort = 2477
-
-func newSwarm(t *testing.T) *daemon.Swarm {
-	d := &daemon.Swarm{
-		Daemon: daemon.New(t, "", dockerdBinary, daemon.Config{
-			Experimental: testEnv.DaemonInfo.ExperimentalBuild,
-		}),
-		// TODO: better method of finding an unused port
-		Port: defaultSwarmPort,
-	}
-	// TODO: move to a NewSwarm constructor
-	d.ListenAddr = fmt.Sprintf("0.0.0.0:%d", d.Port)
-
-	// avoid networking conflicts
-	args := []string{"--iptables=false", "--swarm-default-advertise-addr=lo"}
-	d.StartWithBusybox(t, args...)
-
-	require.NoError(t, d.Init(swarm.InitRequest{}))
-	return d
 }
 
 func serviceContainerCount(client client.ServiceAPIClient, id string, count uint64) func(log poll.LogT) poll.Result {

--- a/integration/service/network_test.go
+++ b/integration/service/network_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/integration-cli/request"
+	"github.com/docker/docker/integration/util/swarm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDockerNetworkConnectAlias(t *testing.T) {
 	defer setupTest(t)()
-	d := newSwarm(t)
+	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)
 	client, err := request.NewClientForHost(d.Sock())
 	require.NoError(t, err)

--- a/integration/util/swarm/service.go
+++ b/integration/util/swarm/service.go
@@ -15,6 +15,7 @@ const (
 	defaultSwarmPort = 2477
 )
 
+// NewSwarm creates a swarm daemon for testing
 func NewSwarm(t *testing.T, testEnv *environment.Execution) *daemon.Swarm {
 	d := &daemon.Swarm{
 		Daemon: daemon.New(t, "", dockerdBinary, daemon.Config{

--- a/integration/util/swarm/service.go
+++ b/integration/util/swarm/service.go
@@ -1,0 +1,35 @@
+package swarm
+
+import (
+	"fmt"
+	"testing"
+
+	swarmtypes "github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/integration-cli/daemon"
+	"github.com/docker/docker/internal/test/environment"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	dockerdBinary    = "dockerd"
+	defaultSwarmPort = 2477
+)
+
+func NewSwarm(t *testing.T, testEnv *environment.Execution) *daemon.Swarm {
+	d := &daemon.Swarm{
+		Daemon: daemon.New(t, "", dockerdBinary, daemon.Config{
+			Experimental: testEnv.DaemonInfo.ExperimentalBuild,
+		}),
+		// TODO: better method of finding an unused port
+		Port: defaultSwarmPort,
+	}
+	// TODO: move to a NewSwarm constructor
+	d.ListenAddr = fmt.Sprintf("0.0.0.0:%d", d.Port)
+
+	// avoid networking conflicts
+	args := []string{"--iptables=false", "--swarm-default-advertise-addr=lo"}
+	d.StartWithBusybox(t, args...)
+
+	require.NoError(t, d.Init(swarmtypes.InitRequest{}))
+	return d
+}


### PR DESCRIPTION
This fix migrates TestSecretInspect from integration-cli to api tests

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
