### PR TITLE
Fix vendor validation

### DIFF
--- a/hack/validate/vendor
+++ b/hack/validate/vendor
@@ -9,9 +9,13 @@ validate_vendor_diff(){
 	unset IFS
 
 	if [ ${#files[@]} -gt 0 ]; then
-		# We run vndr to and see if we have a diff afterwards
+		# Remove vendor/ first so  that anything not included in vendor.conf will
+		# cause the validation to fail. archive/tar is a special case, see vendor.conf
+		# for details.
+		ls -d vendor/* | grep -v vendor/archive | xargs rm -rf
+		# run vndr to recreate vendor/
 		vndr
-		# Let see if the working directory is clean
+		# check if any files have changed
 		diffs="$(git status --porcelain -- vendor 2>/dev/null)"
 		if [ "$diffs" ]; then
 			{
@@ -34,17 +38,17 @@ validate_vendor_diff(){
 # 1. make sure all the vendored packages are used
 # 2. make sure all the packages contain license information (just warning, because it can cause false-positive)
 validate_vendor_used() {
-    pkgs=$(mawk '/^[a-zA-Z0-9]/ { print $1 }' < vendor.conf)
-    for f in $pkgs; do
+	pkgs=$(mawk '/^[a-zA-Z0-9]/ { print $1 }' < vendor.conf)
+	for f in $pkgs; do
 	if ls -d vendor/$f  > /dev/null 2>&1; then
-	    found=$(find vendor/$f -iregex '.*LICENSE.*' -or -iregex '.*COPYRIGHT.*' -or -iregex '.*COPYING.*' | wc -l)
-	    if [ $found -eq 0 ]; then
+		found=$(find vendor/$f -iregex '.*LICENSE.*' -or -iregex '.*COPYRIGHT.*' -or -iregex '.*COPYING.*' | wc -l)
+		if [ $found -eq 0 ]; then
 		echo "WARNING: could not find copyright information for $f"
-	    fi
+		fi
 	else
-	    echo "WARNING: $f is vendored but unused"
+		echo "WARNING: $f is vendored but unused"
 	fi
-    done
+	done
 }
 
 validate_vendor_diff


### PR DESCRIPTION
Previously adding files to vendor/ without adding to vendor.conf would not fail the
validation. This was noticed in #36164