### PR TITLE
Make it easier to debug swagger-gen flakes

### DIFF
--- a/hack/validate/swagger-gen
+++ b/hack/validate/swagger-gen
@@ -10,7 +10,7 @@ unset IFS
 if [ ${#files[@]} -gt 0 ]; then
 	${SCRIPTDIR}/../generate-swagger-api.sh 2> /dev/null
 	# Let see if the working directory is clean
-	diffs="$(git status --porcelain -- api/types/ 2>/dev/null)"
+	diffs="$(git diff -- api/types/)"
 	if [ "$diffs" ]; then
 		{
 			echo 'The result of hack/generate-swagger-api.sh differs'


### PR DESCRIPTION
Sometimes this check fails, but git status doesn't give us enough information
to debug the failure.

cc @thaJeztah 