### PR TITLE
Combine runSimpleContainer with runContainer for rename test

### DIFF
--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -7,21 +7,10 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/api/types/strslice"
-	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/util/request"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func runContainer(ctx context.Context, t *testing.T, client client.APIClient, cntCfg *container.Config, hstCfg *container.HostConfig, nwkCfg *network.NetworkingConfig, cntName string) string {
-	cnt, err := client.ContainerCreate(ctx, cntCfg, hstCfg, nwkCfg, cntName)
-	require.NoError(t, err)
-
-	err = client.ContainerStart(ctx, cnt.ID, types.ContainerStartOptions{})
-	require.NoError(t, err)
-	return cnt.ID
-}
 
 // This test simulates the scenario mentioned in #31392:
 // Having two linked container, renaming the target and bringing a replacement
@@ -32,57 +21,25 @@ func TestRenameLinkedContainer(t *testing.T) {
 	ctx := context.Background()
 	client := request.NewAPIClient(t)
 
-	cntConfig := &container.Config{
-		Image: "busybox",
-		Tty:   true,
-		Cmd:   strslice.StrSlice([]string{"top"}),
-	}
+	aID := runSimpleContainer(ctx, t, client, "a0")
 
-	var (
-		aID, bID string
-		cntJSON  types.ContainerJSON
-		err      error
-	)
+	bID := runSimpleContainer(ctx, t, client, "b0", func(config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig) {
+		hostConfig.Links = []string{"a0"}
+	})
 
-	aID = runContainer(ctx, t, client,
-		cntConfig,
-		&container.HostConfig{},
-		&network.NetworkingConfig{},
-		"a0",
-	)
-
-	bID = runContainer(ctx, t, client,
-		cntConfig,
-		&container.HostConfig{
-			Links: []string{"a0"},
-		},
-		&network.NetworkingConfig{},
-		"b0",
-	)
-
-	err = client.ContainerRename(ctx, aID, "a1")
+	err := client.ContainerRename(ctx, aID, "a1")
 	require.NoError(t, err)
 
-	runContainer(ctx, t, client,
-		cntConfig,
-		&container.HostConfig{},
-		&network.NetworkingConfig{},
-		"a0",
-	)
+	runSimpleContainer(ctx, t, client, "a0")
 
 	err = client.ContainerRemove(ctx, bID, types.ContainerRemoveOptions{Force: true})
 	require.NoError(t, err)
 
-	bID = runContainer(ctx, t, client,
-		cntConfig,
-		&container.HostConfig{
-			Links: []string{"a0"},
-		},
-		&network.NetworkingConfig{},
-		"b0",
-	)
+	bID = runSimpleContainer(ctx, t, client, "b0", func(config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig) {
+		hostConfig.Links = []string{"a0"}
+	})
 
-	cntJSON, err = client.ContainerInspect(ctx, bID)
+	inspect, err := client.ContainerInspect(ctx, bID)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"/a0:/b0/a0"}, cntJSON.HostConfig.Links)
+	assert.Equal(t, []string{"/a0:/b0/a0"}, inspect.HostConfig.Links)
 }


### PR DESCRIPTION
As there is already a  runSimpleContainer, I think it makes sense to combine runSimpleContainer with runContainer for rename test to reduce code duplication.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
