### PR TITLE
Do not recursive unmount on cleanup of zfs/btrfs

### DIFF
--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -29,7 +29,6 @@ import (
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/containerfs"
 	"github.com/docker/docker/pkg/idtools"
-	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/go-units"
@@ -163,7 +162,7 @@ func (d *Driver) Cleanup() error {
 		return err
 	}
 
-	return mount.RecursiveUnmount(d.home)
+	return nil
 }
 
 func free(p *C.char) {

--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -178,9 +178,10 @@ func (d *Driver) String() string {
 	return "zfs"
 }
 
-// Cleanup is called on daemon shutdown, it is used to clean up any remaining mounts
+// Cleanup is called on daemon shutdown, it is a no-op for ZFS.
+// TODO(@cpuguy83): Walk layer tree and check mounts?
 func (d *Driver) Cleanup() error {
-	return mount.RecursiveUnmount(d.options.mountPath)
+	return nil
 }
 
 // Status returns information about the ZFS filesystem. It returns a two dimensional array of information


### PR DESCRIPTION
This was added in #36047 just as a way to make sure the tree is fully
unmounted on shutdown.

For ZFS this could be a breaking change since there was no unmount before.
Someone could have setup the zfs tree themselves. It would be better, if
we really do want the cleanup to actually the unpacked layers checking
for mounts rather than a blind recursive unmount of the root.

BTRFS does not use mounts and does not need to unmount anyway.
These was only an unmount to begin with because for some reason the
btrfs tree was being moutned with `private` propagation.

For the other graphdrivers that still have a recursive unmount here...
these were already being unmounted and performing the recursive unmount
shouldn't break anything. If anyone had anything mounted at the
graphdriver location it would have been unmounted on shutdown anyway.