### PR TITLE
Fix string type for buildargs API definition

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6178,6 +6178,12 @@ paths:
             uses the buildargs as the environment context for commands run via the `Dockerfile` RUN
             instruction, or for variable expansion in other `Dockerfile` instructions. This is not meant for
             passing secret values.
+
+
+            For example, the build arg `FOO=bar` would become `{"FOO":"bar"}` in JSON. This would result in the
+            the query parameter `buildargs={"FOO":"bar"}`. Note that `{"FOO":"bar"}` should be URI component encoded.
+
+
             [Read more about the buildargs instruction.](https://docs.docker.com/engine/reference/builder/#arg)
           type: "string"
         - name: "shmsize"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6174,7 +6174,7 @@ paths:
         - name: "buildargs"
           in: "query"
           description: "JSON map of string pairs for build-time variables. Users pass these values at build-time. Docker uses the buildargs as the environment context for commands run via the `Dockerfile` RUN instruction, or for variable expansion in other `Dockerfile` instructions. This is not meant for passing secret values. [Read more about the buildargs instruction.](https://docs.docker.com/engine/reference/builder/#arg)"
-          type: "integer"
+          type: "string"
         - name: "shmsize"
           in: "query"
           description: "Size of `/dev/shm` in bytes. The size must be greater than 0. If omitted the system uses 64MB."

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6173,7 +6173,12 @@ paths:
           type: "integer"
         - name: "buildargs"
           in: "query"
-          description: "JSON map of string pairs for build-time variables. Users pass these values at build-time. Docker uses the buildargs as the environment context for commands run via the `Dockerfile` RUN instruction, or for variable expansion in other `Dockerfile` instructions. This is not meant for passing secret values. [Read more about the buildargs instruction.](https://docs.docker.com/engine/reference/builder/#arg)"
+          description: >
+            JSON map of string pairs for build-time variables. Users pass these values at build-time. Docker
+            uses the buildargs as the environment context for commands run via the `Dockerfile` RUN
+            instruction, or for variable expansion in other `Dockerfile` instructions. This is not meant for
+            passing secret values.
+            [Read more about the buildargs instruction.](https://docs.docker.com/engine/reference/builder/#arg)
           type: "string"
         - name: "shmsize"
           in: "query"


### PR DESCRIPTION
**- What I did**

Update buildargs API swagger definition from `integer` to `string`

**- How I did it**

n/a

**- How to verify it**

n/a

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Docs - Correct `buildargs` API type to `string`

**- A picture of a cute animal (not mandatory but encouraged)**

![Legit?](https://media.giphy.com/media/P1PemPnyp4g1i/giphy.gif)