### PR TITLE
Fix timeout issue of `InspectNetwork` on AArch64

### DIFF
--- a/integration/network/inspect_test.go
+++ b/integration/network/inspect_test.go
@@ -47,7 +47,7 @@ func TestInspectNetwork(t *testing.T) {
 	require.NoError(t, err)
 
 	pollSettings := func(config *poll.Settings) {
-		if runtime.GOARCH == "arm" {
+		if runtime.GOARCH == "arm64" || runtime.GOARCH == "arm" {
 			config.Timeout = 30 * time.Second
 			config.Delay = 100 * time.Millisecond
 		}


### PR DESCRIPTION
Service of `InspectNetwork` can't be finished within 10s on AArch64 platform,
so we need to adjust the timeout value avoid to paper cover the real issue, plus
to make the integreation test can continue while not terminate with below error:

> === RUN   TestInspectNetwork
> --- FAIL: TestInspectNetwork (27.65s)
>         daemon.go:285: [de79880f4ed4a] waiting for daemon to start
>         daemon.go:317: [de79880f4ed4a] daemon started
>         inspect_test.go:57: timeout hit after 10s: waiting for tasks to enter run state
>         daemon.go:275: [de79880f4ed4a] exiting daemon
> FAIL
> ---> Making bundle: .integration-daemon-stop (in bundles/test-integration)
> Removing test suite binaries
> Makefile:171: recipe for target 'test-integration' failed

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix timeout issue of `InspectNetwork` test case on AArch64
**- How I did it**
Adjust the timeout value from 10s to 30m on AArch64
**- How to verify it**
`#make test-integration`
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

