### PR TITLE
Add an integration/internal/container helper package 

### DIFF
--- a/integration/container/inspect_test.go
+++ b/integration/container/inspect_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/request"
 	"github.com/gotestyourself/gotestyourself/poll"
 	"github.com/gotestyourself/gotestyourself/skip"
@@ -25,10 +24,12 @@ func TestInspectCpusetInConfigPre120(t *testing.T) {
 
 	name := "cpusetinconfig-pre120"
 	// Create container with up to-date-API
-	runSimpleContainer(ctx, t, request.NewAPIClient(t), name, func(config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig) {
-		config.Cmd = []string{"true"}
-		hostConfig.Resources.CpusetCpus = "0"
-	})
+	container.Run(t, ctx, request.NewAPIClient(t), container.WithName(name),
+		container.WithCmd("true"),
+		func(c *container.TestContainerConfig) {
+			c.HostConfig.Resources.CpusetCpus = "0"
+		},
+	)
 	poll.WaitOn(t, containerIsInState(ctx, client, name, "exited"), poll.WithDelay(100*time.Millisecond))
 
 	_, body, err := client.ContainerInspectWithRaw(ctx, name, false)

--- a/integration/container/main_test.go
+++ b/integration/container/main_test.go
@@ -1,17 +1,11 @@
 package container // import "github.com/docker/docker/integration/container"
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
 
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/client"
 	"github.com/docker/docker/internal/test/environment"
-	"github.com/stretchr/testify/require"
 )
 
 var testEnv *environment.Execution
@@ -36,33 +30,4 @@ func TestMain(m *testing.M) {
 func setupTest(t *testing.T) func() {
 	environment.ProtectAll(t, testEnv)
 	return func() { testEnv.Clean(t) }
-}
-
-type containerConstructor func(config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig)
-
-func createSimpleContainer(ctx context.Context, t *testing.T, client client.APIClient, name string, f ...containerConstructor) string {
-	config := &container.Config{
-		Cmd:   []string{"top"},
-		Image: "busybox",
-	}
-	hostConfig := &container.HostConfig{}
-	networkingConfig := &network.NetworkingConfig{}
-
-	for _, fn := range f {
-		fn(config, hostConfig, networkingConfig)
-	}
-
-	c, err := client.ContainerCreate(ctx, config, hostConfig, networkingConfig, name)
-	require.NoError(t, err)
-
-	return c.ID
-}
-
-func runSimpleContainer(ctx context.Context, t *testing.T, client client.APIClient, name string, f ...containerConstructor) string {
-	cID := createSimpleContainer(ctx, t, client, name, f...)
-
-	err := client.ContainerStart(ctx, cID, types.ContainerStartOptions{})
-	require.NoError(t, err)
-
-	return cID
 }

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -7,9 +7,8 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/network"
 	req "github.com/docker/docker/integration-cli/request"
+	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/request"
 	"github.com/docker/docker/internal/testutil"
 	"github.com/gotestyourself/gotestyourself/poll"
@@ -22,7 +21,7 @@ func TestResize(t *testing.T) {
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
 
-	cID := runSimpleContainer(ctx, t, client, "")
+	cID := container.Run(t, ctx, client)
 
 	poll.WaitOn(t, containerIsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
@@ -38,7 +37,7 @@ func TestResizeWithInvalidSize(t *testing.T) {
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
 
-	cID := runSimpleContainer(ctx, t, client, "")
+	cID := container.Run(t, ctx, client)
 
 	poll.WaitOn(t, containerIsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
@@ -53,9 +52,7 @@ func TestResizeWhenContainerNotStarted(t *testing.T) {
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
 
-	cID := runSimpleContainer(ctx, t, client, "", func(config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig) {
-		config.Cmd = []string{"echo"}
-	})
+	cID := container.Run(t, ctx, client, container.WithCmd("echo"))
 
 	poll.WaitOn(t, containerIsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 

--- a/integration/internal/container/container.go
+++ b/integration/internal/container/container.go
@@ -1,0 +1,54 @@
+package container
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/require"
+)
+
+// TestContainerConfig holds container configuration struct that
+// are used in api calls.
+type TestContainerConfig struct {
+	Name             string
+	Config           *container.Config
+	HostConfig       *container.HostConfig
+	NetworkingConfig *network.NetworkingConfig
+}
+
+// Create creates a container with the specified options
+func Create(t *testing.T, ctx context.Context, client client.APIClient, ops ...func(*TestContainerConfig)) string { // nolint: golint
+	t.Helper()
+	config := &TestContainerConfig{
+		Config: &container.Config{
+			Image: "busybox",
+			Cmd:   []string{"top"},
+		},
+		HostConfig:       &container.HostConfig{},
+		NetworkingConfig: &network.NetworkingConfig{},
+	}
+
+	for _, op := range ops {
+		op(config)
+	}
+
+	c, err := client.ContainerCreate(ctx, config.Config, config.HostConfig, config.NetworkingConfig, config.Name)
+	require.NoError(t, err)
+
+	return c.ID
+}
+
+// Run creates and start a container with the specified options
+func Run(t *testing.T, ctx context.Context, client client.APIClient, ops ...func(*TestContainerConfig)) string { // nolint: golint
+	t.Helper()
+	id := Create(t, ctx, client, ops...)
+
+	err := client.ContainerStart(ctx, id, types.ContainerStartOptions{})
+	require.NoError(t, err)
+
+	return id
+}

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -1,0 +1,24 @@
+package container
+
+import "github.com/docker/docker/api/types/strslice"
+
+// WithName sets the name of the container
+func WithName(name string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.Name = name
+	}
+}
+
+// WithLinks sets the links of the container
+func WithLinks(links ...string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.HostConfig.Links = links
+	}
+}
+
+// WithCmd sets the comannds of the container
+func WithCmd(cmds ...string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.Config.Cmd = strslice.StrSlice(cmds)
+	}
+}


### PR DESCRIPTION
On top of #36265 

To help creating/running/… containers using the client for test integration.
This should make test more readable and reduce duplication a bit.

Usage example

```go
// Create a default container named foo
id1 := container.Create(t, ctx, client, container.WithName("foo"))
// Run a default container with a custom command
id2 := container.Run(t, ctx, client, container.WithCmd("echo", "hello world"))
```

This replace `runSimpleContainer` and `createSimpleContainer` 👼 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>