### PR TITLE
Use TagImage in Commit

### DIFF
--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -29,7 +29,7 @@ type imageBackend interface {
 	ImageHistory(imageName string) ([]*image.HistoryResponseItem, error)
 	Images(imageFilters filters.Args, all bool, withExtraAttrs bool) ([]*types.ImageSummary, error)
 	LookupImage(name string) (*types.ImageInspect, error)
-	TagImage(imageName, repository, tag string) error
+	TagImage(imageName, repository, tag string) (string, error)
 	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error)
 }
 

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -303,7 +303,7 @@ func (s *imageRouter) postImagesTag(ctx context.Context, w http.ResponseWriter, 
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
-	if err := s.backend.TagImage(vars["name"], r.Form.Get("repo"), r.Form.Get("tag")); err != nil {
+	if _, err := s.backend.TagImage(vars["name"], r.Form.Get("repo"), r.Form.Get("tag")); err != nil {
 		return err
 	}
 	w.WriteHeader(http.StatusCreated)

--- a/daemon/image_tag.go
+++ b/daemon/image_tag.go
@@ -7,23 +7,24 @@ import (
 
 // TagImage creates the tag specified by newTag, pointing to the image named
 // imageName (alternatively, imageName can also be an image ID).
-func (daemon *Daemon) TagImage(imageName, repository, tag string) error {
+func (daemon *Daemon) TagImage(imageName, repository, tag string) (string, error) {
 	imageID, _, err := daemon.GetImageIDAndOS(imageName)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	newTag, err := reference.ParseNormalizedNamed(repository)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if tag != "" {
 		if newTag, err = reference.WithTag(reference.TrimNamed(newTag), tag); err != nil {
-			return err
+			return "", err
 		}
 	}
 
-	return daemon.TagImageWithReference(imageID, newTag)
+	err = daemon.TagImageWithReference(imageID, newTag)
+	return reference.FamiliarString(newTag), err
 }
 
 // TagImageWithReference adds the given reference to the image ID provided.


### PR DESCRIPTION
Follow up to #36224
Extracted from #36240 to shrink the PR

Use `Daemon.TagImage` in `Commit()` instead of rewriting it.