### PR TITLE
Migrate several docker rm tests to api tests

### DIFF
--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -1,55 +1,10 @@
 package main
 
 import (
-	"io/ioutil"
-	"os"
-
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/go-check/check"
 )
-
-func (s *DockerSuite) TestRmContainerWithRemovedVolume(c *check.C) {
-	testRequires(c, SameHostDaemon)
-
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-
-	tempDir, err := ioutil.TempDir("", "test-rm-container-with-removed-volume-")
-	if err != nil {
-		c.Fatalf("failed to create temporary directory: %s", tempDir)
-	}
-	defer os.RemoveAll(tempDir)
-
-	dockerCmd(c, "run", "--name", "losemyvolumes", "-v", tempDir+":"+prefix+slash+"test", "busybox", "true")
-
-	err = os.RemoveAll(tempDir)
-	c.Assert(err, check.IsNil)
-
-	dockerCmd(c, "rm", "-v", "losemyvolumes")
-}
-
-func (s *DockerSuite) TestRmContainerWithVolume(c *check.C) {
-	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-
-	dockerCmd(c, "run", "--name", "foo", "-v", prefix+slash+"srv", "busybox", "true")
-
-	dockerCmd(c, "rm", "-v", "foo")
-}
-
-func (s *DockerSuite) TestRmContainerRunning(c *check.C) {
-	createRunningContainer(c, "foo")
-
-	res, _, err := dockerCmdWithError("rm", "foo")
-	c.Assert(err, checker.NotNil, check.Commentf("Expected error, can't rm a running container"))
-	c.Assert(res, checker.Contains, "cannot remove a running container")
-}
-
-func (s *DockerSuite) TestRmContainerForceRemoveRunning(c *check.C) {
-	createRunningContainer(c, "foo")
-
-	// Stop then remove with -f
-	dockerCmd(c, "rm", "-f", "foo")
-}
 
 func (s *DockerSuite) TestRmContainerOrphaning(c *check.C) {
 	dockerfile1 := `FROM busybox:latest
@@ -74,14 +29,4 @@ func (s *DockerSuite) TestRmContainerOrphaning(c *check.C) {
 	out, _ = dockerCmd(c, "images", "-q", "--no-trunc")
 	c.Assert(out, checker.Contains, img1, check.Commentf("Orphaned container (could not find %q in docker images): %s", img1, out))
 
-}
-
-func (s *DockerSuite) TestRmInvalidContainer(c *check.C) {
-	out, _, err := dockerCmdWithError("rm", "unknown")
-	c.Assert(err, checker.NotNil, check.Commentf("Expected error on rm unknown container, got none"))
-	c.Assert(out, checker.Contains, "No such container")
-}
-
-func createRunningContainer(c *check.C, name string) {
-	runSleepingContainer(c, "-dt", "--name", name)
 }

--- a/integration/container/remove_test.go
+++ b/integration/container/remove_test.go
@@ -1,0 +1,113 @@
+package container // import "github.com/docker/docker/integration/container"
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/integration/internal/request"
+	"github.com/docker/docker/internal/testutil"
+	"github.com/gotestyourself/gotestyourself/fs"
+	"github.com/gotestyourself/gotestyourself/poll"
+	"github.com/gotestyourself/gotestyourself/skip"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getPrefixAndSlashFromDaemonPlatform() (prefix, slash string) {
+	if testEnv.OSType == "windows" {
+		return "c:", `\`
+	}
+	return "", "/"
+}
+
+// Test case for #5244: `docker rm` fails if bind dir doesn't exist anymore
+func TestRemoveContainerWithRemovedVolume(t *testing.T) {
+	skip.If(t, !testEnv.IsLocalDaemon())
+
+	defer setupTest(t)()
+	ctx := context.Background()
+	client := request.NewAPIClient(t)
+
+	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
+
+	tempDir := fs.NewDir(t, "test-rm-container-with-removed-volume", fs.WithMode(0755))
+	defer tempDir.Remove()
+
+	cID := container.Run(t, ctx, client, container.WithCmd("true"), container.WithBind(tempDir.Path(), prefix+slash+"test"))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
+
+	err := os.RemoveAll(tempDir.Path())
+	require.NoError(t, err)
+
+	err = client.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{
+		RemoveVolumes: true,
+	})
+	require.NoError(t, err)
+
+	_, _, err = client.ContainerInspectWithRaw(ctx, cID, true)
+	testutil.ErrorContains(t, err, "No such container")
+}
+
+// Test case for #2099/#2125
+func TestRemoveContainerWithVolume(t *testing.T) {
+	defer setupTest(t)()
+	ctx := context.Background()
+	client := request.NewAPIClient(t)
+
+	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
+
+	cID := container.Run(t, ctx, client, container.WithCmd("true"), container.WithVolume(prefix+slash+"srv"))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
+
+	insp, _, err := client.ContainerInspectWithRaw(ctx, cID, true)
+	require.NoError(t, err)
+	assert.Equal(t, len(insp.Mounts), 1)
+	volName := insp.Mounts[0].Name
+
+	err = client.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{
+		RemoveVolumes: true,
+	})
+	require.NoError(t, err)
+
+	volumes, err := client.VolumeList(ctx, filters.NewArgs(filters.Arg("name", volName)))
+	require.NoError(t, err)
+	assert.Equal(t, len(volumes.Volumes), 0)
+}
+
+func TestRemoveContainerRunning(t *testing.T) {
+	defer setupTest(t)()
+	ctx := context.Background()
+	client := request.NewAPIClient(t)
+
+	cID := container.Run(t, ctx, client)
+
+	err := client.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{})
+	testutil.ErrorContains(t, err, "cannot remove a running container")
+}
+
+func TestRemoveContainerForceRemoveRunning(t *testing.T) {
+	defer setupTest(t)()
+	ctx := context.Background()
+	client := request.NewAPIClient(t)
+
+	cID := container.Run(t, ctx, client)
+
+	err := client.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{
+		Force: true,
+	})
+	require.NoError(t, err)
+}
+
+func TestRemoveInvalidContainer(t *testing.T) {
+	defer setupTest(t)()
+	ctx := context.Background()
+	client := request.NewAPIClient(t)
+
+	err := client.ContainerRemove(ctx, "unknown", types.ContainerRemoveOptions{})
+	testutil.ErrorContains(t, err, "No such container")
+}


### PR DESCRIPTION
This fix migrates several docker rm tests to api tests

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>