### PR TITLE
Update api tests to use container.Run/Create in helper package

### DIFF
--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -17,10 +17,7 @@ func TestExec(t *testing.T) {
 	ctx := context.Background()
 	client := request.NewAPIClient(t)
 
-	cID := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
-		c.Config.Tty = true
-		c.Config.WorkingDir = "/root"
-	})
+	cID := container.Run(t, ctx, client, container.WithTty(true), container.WithWorkingDir("/root"))
 
 	id, err := client.ContainerExecCreate(ctx, cID,
 		types.ExecConfig{

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/strslice"
+	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/request"
 	"github.com/stretchr/testify/require"
 )
@@ -18,22 +17,12 @@ func TestExec(t *testing.T) {
 	ctx := context.Background()
 	client := request.NewAPIClient(t)
 
-	container, err := client.ContainerCreate(ctx,
-		&container.Config{
-			Image:      "busybox",
-			Tty:        true,
-			WorkingDir: "/root",
-			Cmd:        strslice.StrSlice([]string{"top"}),
-		},
-		&container.HostConfig{},
-		&network.NetworkingConfig{},
-		"foo",
-	)
-	require.NoError(t, err)
-	err = client.ContainerStart(ctx, container.ID, types.ContainerStartOptions{})
-	require.NoError(t, err)
+	cID := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
+		c.Config.Tty = true
+		c.Config.WorkingDir = "/root"
+	})
 
-	id, err := client.ContainerExecCreate(ctx, container.ID,
+	id, err := client.ContainerExecCreate(ctx, cID,
 		types.ExecConfig{
 			WorkingDir:   "/tmp",
 			Env:          strslice.StrSlice([]string{"FOO=BAR"}),

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -20,9 +20,7 @@ func TestHealthCheckWorkdir(t *testing.T) {
 	ctx := context.Background()
 	client := request.NewAPIClient(t)
 
-	cID := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
-		c.Config.Tty = true
-		c.Config.WorkingDir = "/foo"
+	cID := container.Run(t, ctx, client, container.WithTty(true), container.WithWorkingDir("/foo"), func(c *container.TestContainerConfig) {
 		c.Config.Healthcheck = &containertypes.HealthConfig{
 			Test:     []string{"CMD-SHELL", "if [ \"$PWD\" = \"/foo\" ]; then exit 0; else exit 1; fi;"},
 			Interval: 50 * time.Millisecond,

--- a/integration/container/links_linux_test.go
+++ b/integration/container/links_linux_test.go
@@ -28,9 +28,7 @@ func TestLinksEtcHostsContentMatch(t *testing.T) {
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client, container.WithCmd("cat", "/etc/hosts"), func(c *container.TestContainerConfig) {
-		c.HostConfig.NetworkMode = "host"
-	})
+	cID := container.Run(t, ctx, client, container.WithCmd("cat", "/etc/hosts"), container.WithNetworkMode("host"))
 
 	poll.WaitOn(t, containerIsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
 

--- a/integration/container/links_linux_test.go
+++ b/integration/container/links_linux_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/request"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/gotestyourself/gotestyourself/poll"
@@ -28,24 +28,13 @@ func TestLinksEtcHostsContentMatch(t *testing.T) {
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
 
-	c, err := client.ContainerCreate(ctx,
-		&container.Config{
-			Image: "busybox",
-			Cmd:   []string{"cat", "/etc/hosts"},
-		},
-		&container.HostConfig{
-			NetworkMode: "host",
-		},
-		nil,
-		"")
-	require.NoError(t, err)
+	cID := container.Run(t, ctx, client, container.WithCmd("cat", "/etc/hosts"), func(c *container.TestContainerConfig) {
+		c.HostConfig.NetworkMode = "host"
+	})
 
-	err = client.ContainerStart(ctx, c.ID, types.ContainerStartOptions{})
-	require.NoError(t, err)
+	poll.WaitOn(t, containerIsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
 
-	poll.WaitOn(t, containerIsStopped(ctx, client, c.ID), poll.WithDelay(100*time.Millisecond))
-
-	body, err := client.ContainerLogs(ctx, c.ID, types.ContainerLogsOptions{
+	body, err := client.ContainerLogs(ctx, cID, types.ContainerLogsOptions{
 		ShowStdout: true,
 	})
 	require.NoError(t, err)

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -67,10 +67,7 @@ func TestNetworkLoopbackNat(t *testing.T) {
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client, container.WithCmd("sh", "-c", fmt.Sprintf("stty raw && nc -w 5 %s 8080", endpoint.String())), func(c *container.TestContainerConfig) {
-		c.Config.Tty = true
-		c.HostConfig.NetworkMode = "container:server"
-	})
+	cID := container.Run(t, ctx, client, container.WithCmd("sh", "-c", fmt.Sprintf("stty raw && nc -w 5 %s 8080", endpoint.String())), container.WithTty(true), container.WithNetworkMode("container:server"))
 
 	poll.WaitOn(t, containerIsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
 
@@ -91,10 +88,7 @@ func startServerContainer(t *testing.T, msg string, port int) string {
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client, container.WithCmd("sh", "-c", fmt.Sprintf("echo %q | nc -lp %d", msg, port)), func(c *container.TestContainerConfig) {
-		c.Config.ExposedPorts = map[nat.Port]struct{}{
-			nat.Port(fmt.Sprintf("%d/tcp", port)): {},
-		}
+	cID := container.Run(t, ctx, client, container.WithName("server"), container.WithCmd("sh", "-c", fmt.Sprintf("echo %q | nc -lp %d", msg, port)), container.WithExposedPorts(fmt.Sprintf("%d/tcp", port)), func(c *container.TestContainerConfig) {
 		c.HostConfig.PortBindings = nat.PortMap{
 			nat.Port(fmt.Sprintf("%d/tcp", port)): []nat.PortBinding{
 				{

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -1,6 +1,10 @@
 package container
 
-import "github.com/docker/docker/api/types/strslice"
+import (
+	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/strslice"
+	"github.com/docker/go-connections/nat"
+)
 
 // WithName sets the name of the container
 func WithName(name string) func(*TestContainerConfig) {
@@ -20,5 +24,36 @@ func WithLinks(links ...string) func(*TestContainerConfig) {
 func WithCmd(cmds ...string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {
 		c.Config.Cmd = strslice.StrSlice(cmds)
+	}
+}
+
+// WithNetworkMode sets the network mode of the container
+func WithNetworkMode(mode string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.HostConfig.NetworkMode = containertypes.NetworkMode(mode)
+	}
+}
+
+// WithExposedPorts sets the exposed ports of the container
+func WithExposedPorts(ports ...string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.Config.ExposedPorts = map[nat.Port]struct{}{}
+		for _, port := range ports {
+			c.Config.ExposedPorts[nat.Port(port)] = struct{}{}
+		}
+	}
+}
+
+// WithTty sets the TTY mode of the container
+func WithTty(tty bool) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.Config.Tty = tty
+	}
+}
+
+// WithWorkingDir sets the working dir of the container
+func WithWorkingDir(dir string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.Config.WorkingDir = dir
 	}
 }


### PR DESCRIPTION
This fix is a sync up with #36266 so that relevant api tests use the newly added container.Run/Create in helper package

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
