### PR TITLE
Don't restore image if layer does not exist

### DIFF
--- a/image/store.go
+++ b/image/store.go
@@ -79,6 +79,10 @@ func (is *store) restore() error {
 			}
 			l, err = is.lss[img.OperatingSystem()].Get(chainID)
 			if err != nil {
+				if err == layer.ErrLayerDoesNotExist {
+					logrus.Errorf("layer does not exist, not restoring image %v, %v, %s", dgst, chainID, img.OperatingSystem())
+					return nil
+				}
 				return err
 			}
 		}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This was reported internally to me, and now I've run into it myself. If the daemon is under debug mode and killed at the right time, it's possible to leave an image referring to a layer which doesn't exist. During subsequent daemon startup, the daemon terminates and fails to start during image store `restore()` saying layer does not exist. 

This fix is similar to the check slightly higher in the `restore()` function which doesn't error out if `is.Get()` fails, instead logging it, but now checking explicitly for `ErrLayerDoesNotExist` when getting the layer from the layerstore.
