### PR TITLE
Fix log tail with empty logs

### DIFF
--- a/daemon/logger/loggerutils/logfile.go
+++ b/daemon/logger/loggerutils/logfile.go
@@ -192,8 +192,12 @@ func (w *LogFile) ReadLogs(config logger.ReadConfig, watcher *logger.LogWatcher)
 		for _, f := range files {
 			seekers = append(seekers, f)
 		}
-		seekers = append(seekers, currentChunk)
-		tailFile(multireader.MultiReadSeeker(seekers...), watcher, w.createDecoder, config)
+		if currentChunk.Size() > 0 {
+			seekers = append(seekers, currentChunk)
+		}
+		if len(seekers) > 0 {
+			tailFile(multireader.MultiReadSeeker(seekers...), watcher, w.createDecoder, config)
+		}
 	}
 
 	w.mu.RLock()

--- a/integration/container/logs_test.go
+++ b/integration/container/logs_test.go
@@ -1,0 +1,33 @@
+package container
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/integration/internal/request"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression test for #35370
+// Makes sure that when following we don't get an EOF error when there are no logs
+func TestLogsFollowTailEmpty(t *testing.T) {
+	defer setupTest(t)()
+	client := request.NewAPIClient(t)
+	ctx := context.Background()
+
+	id := container.Run(t, ctx, client, container.WithCmd("sleep", "100000"))
+	defer client.ContainerRemove(ctx, id, types.ContainerRemoveOptions{Force: true})
+
+	logs, err := client.ContainerLogs(ctx, id, types.ContainerLogsOptions{ShowStdout: true, Tail: "2"})
+	if logs != nil {
+		defer logs.Close()
+	}
+	assert.NoError(t, err)
+
+	_, err = stdcopy.StdCopy(ioutil.Discard, ioutil.Discard, logs)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
When tailing a container log, if the log file is empty it will cause the
log stream to abort with an unexpected `EOF`.
Note that this only applies to the "current" log file as rotated files
cannot be empty.

This fix just skips adding the "current" file the log tail if it is
empty.

Fixes #35370 