### PR TITLE
Bump containerd to 1.0.2 (cfd04396dc68220d1cecbe686a6cc3aa5ce3667c)

### DIFF
--- a/hack/dockerfile/binaries-commits
+++ b/hack/dockerfile/binaries-commits
@@ -8,7 +8,7 @@ RUNC_COMMIT=6c55f98695e902427906eed2c799e566e3d3dfb5
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=9b55aab90508bd389d7654c4baf173a981477d55 # v1.0.1
+CONTAINERD_COMMIT=cfd04396dc68220d1cecbe686a6cc3aa5ce3667c # v1.0.2
 TINI_COMMIT=949e6facb77383876aeff8a6944dde66b3089574
 LIBNETWORK_COMMIT=fcf1c3b5e57833aaaa756ae3c4140ea54da00319
 VNDR_COMMIT=a6e196d8b4b0cbbdc29aebdb20c59ac6926bb384

--- a/vendor.conf
+++ b/vendor.conf
@@ -107,12 +107,12 @@ google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 github.com/containerd/containerd 3fa104f843ec92328912e042b767d26825f202aa
 github.com/containerd/fifo fbfb6a11ec671efbe94ad1c12c2e98773f19e1e6
 github.com/containerd/continuity 992a5f112bd2211d0983a1cc8562d2882848f3a3
-github.com/containerd/cgroups 29da22c6171a4316169f9205ab6c49f59b5b852f
+github.com/containerd/cgroups c0710c92e8b3a44681d1321dcfd1360fc5c6c089
 github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
-github.com/containerd/go-runc ed1cbe1fc31f5fb2359d3a54b6330d1a097858b7
+github.com/containerd/go-runc 4f6e87ae043f859a38255247b49c9abc262d002f
 github.com/containerd/typeurl f6943554a7e7e88b3c14aad190bf05932da84788
 github.com/dmcgowan/go-tar go1.10
-github.com/stevvooe/ttrpc 76e68349ad9ab4d03d764c713826d31216715e4f
+github.com/stevvooe/ttrpc d4528379866b0ce7e9d71f3eb96f0582fc374577
 
 # cluster
 github.com/docker/swarmkit 68a376dc30d8c4001767c39456b990dbd821371b

--- a/vendor/github.com/containerd/cgroups/errors.go
+++ b/vendor/github.com/containerd/cgroups/errors.go
@@ -12,7 +12,7 @@ var (
 	ErrFreezerNotSupported      = errors.New("cgroups: freezer cgroup not supported on this system")
 	ErrMemoryNotSupported       = errors.New("cgroups: memory cgroup not supported on this system")
 	ErrCgroupDeleted            = errors.New("cgroups: cgroup deleted")
-	ErrNoCgroupMountDestination = errors.New("cgroups: cannot found cgroup mount destination")
+	ErrNoCgroupMountDestination = errors.New("cgroups: cannot find cgroup mount destination")
 )
 
 // ErrorHandler is a function that handles and acts on errors

--- a/vendor/github.com/containerd/go-runc/utils.go
+++ b/vendor/github.com/containerd/go-runc/utils.go
@@ -1,8 +1,10 @@
 package runc
 
 import (
+	"bytes"
 	"io/ioutil"
 	"strconv"
+	"sync"
 	"syscall"
 )
 
@@ -25,4 +27,19 @@ func exitStatus(status syscall.WaitStatus) int {
 		return exitSignalOffset + int(status.Signal())
 	}
 	return status.ExitStatus()
+}
+
+var bytesBufferPool = sync.Pool{
+	New: func() interface{} {
+		return bytes.NewBuffer(nil)
+	},
+}
+
+func getBuf() *bytes.Buffer {
+	return bytesBufferPool.Get().(*bytes.Buffer)
+}
+
+func putBuf(b *bytes.Buffer) {
+	b.Reset()
+	bytesBufferPool.Put(b)
 }

--- a/vendor/github.com/stevvooe/ttrpc/channel.go
+++ b/vendor/github.com/stevvooe/ttrpc/channel.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"io"
+	"net"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -60,16 +61,18 @@ func writeMessageHeader(w io.Writer, p []byte, mh messageHeader) error {
 var buffers sync.Pool
 
 type channel struct {
+	conn  net.Conn
 	bw    *bufio.Writer
 	br    *bufio.Reader
 	hrbuf [messageHeaderLength]byte // avoid alloc when reading header
 	hwbuf [messageHeaderLength]byte
 }
 
-func newChannel(w io.Writer, r io.Reader) *channel {
+func newChannel(conn net.Conn) *channel {
 	return &channel{
-		bw: bufio.NewWriter(w),
-		br: bufio.NewReader(r),
+		conn: conn,
+		bw:   bufio.NewWriter(conn),
+		br:   bufio.NewReader(conn),
 	}
 }
 

--- a/vendor/github.com/stevvooe/ttrpc/server.go
+++ b/vendor/github.com/stevvooe/ttrpc/server.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	ErrServerClosed = errors.New("ttrpc: server close")
+	ErrServerClosed = errors.New("ttrpc: server closed")
 )
 
 type Server struct {
@@ -281,7 +281,7 @@ func (c *serverConn) run(sctx context.Context) {
 	)
 
 	var (
-		ch          = newChannel(c.conn, c.conn)
+		ch          = newChannel(c.conn)
 		ctx, cancel = context.WithCancel(sctx)
 		active      int
 		state       connState = connStateIdle


### PR DESCRIPTION
Release notes: https://github.com/containerd/containerd/releases/tag/v1.0.2

Full diff: https://github.com/containerd/containerd/compare/9b55aab90508bd389d7654c4baf173a981477d55...cfd04396dc68220d1cecbe686a6cc3aa5ce3667c

Also bump dependencies:

- https://github.com/containerd/go-runc/compare/ed1cbe1fc31f5fb2359d3a54b6330d1a097858b7...4f6e87ae043f859a38255247b49c9abc262d002f
- https://github.com/containerd/cgroups/compare/29da22c6171a4316169f9205ab6c49f59b5b852f...c0710c92e8b3a44681d1321dcfd1360fc5c6c089
- https://github.com/stevvooe/ttrpc/compare/76e68349ad9ab4d03d764c713826d31216715e4f...d4528379866b0ce7e9d71f3eb96f0582fc374577
- containerd/continuity (already ahead)
- opencontainers/runc (already ahead)
