### PR TITLE
support unix:// addresses for --registry-mirrors

### DIFF
--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -291,7 +291,13 @@ func parseEventTime(t time.Time) string {
 }
 
 func setupRegistry(c *check.C, schema1 bool, auth, tokenURL string) *registry.V2 {
-	reg, err := registry.NewV2(schema1, auth, tokenURL, privateRegistryURL)
+	cfg := registry.V2Config{
+		Schema1:     schema1,
+		Auth:        auth,
+		TokenURL:    tokenURL,
+		RegistryURL: "http://" + privateRegistryURL,
+	}
+	reg, err := registry.NewV2(cfg)
 	c.Assert(err, check.IsNil)
 
 	// Wait for registry to be ready to serve requests.

--- a/integration-cli/registry/registry.go
+++ b/integration-cli/registry/registry.go
@@ -7,8 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
+	"github.com/docker/go-connections/sockets"
 	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -37,27 +40,48 @@ type V2 struct {
 	email       string
 }
 
+type V2Config struct {
+	RegistryURL    string
+	Schema1        bool
+	Auth           string
+	TokenURL       string
+	ProxyRemoteURL string // requires scheme part (http:// or unix://)
+}
+
 // NewV2 creates a v2 registry server
-func NewV2(schema1 bool, auth, tokenURL, registryURL string) (*V2, error) {
+func NewV2(c V2Config) (*V2, error) {
+	if strings.Count(c.RegistryURL, "://") != 1 {
+		return nil, errors.Errorf("unexpected registry URL: %q", c.RegistryURL)
+	}
 	tmp, err := ioutil.TempDir("", "registry-test-")
 	if err != nil {
 		return nil, err
 	}
-	template := `version: 0.1
+	net := "tcp"
+	addr := strings.TrimPrefix(c.RegistryURL, "http://")
+	if strings.HasPrefix(c.RegistryURL, "unix://") {
+		net = "unix"
+		addr = strings.TrimPrefix(c.RegistryURL, "unix://")
+	}
+	template := fmt.Sprintf(`version: 0.1
 loglevel: debug
 storage:
+    cache:
+        blobdescriptor: inmemory
     filesystem:
         rootdirectory: %s
 http:
     addr: %s
-%s`
+    net: %s
+`, tmp, addr, net)
 	var (
-		authTemplate string
-		username     string
-		password     string
-		email        string
+		authTemplate  string
+		proxyTemplate string
+		username      string
+		password      string
+		email         string
 	)
-	switch auth {
+	switch c.Auth {
 	case "htpasswd":
 		htpasswdPath := filepath.Join(tmp, "htpasswd")
 		// generated with: htpasswd -Bbn testuser testpassword
@@ -80,7 +104,12 @@ http:
         service: "registry"
         issuer: "auth-registry"
         rootcertbundle: "fixtures/registry/cert.pem"
-`, tokenURL)
+`, c.TokenURL)
+	}
+	if c.ProxyRemoteURL != "" {
+		proxyTemplate = fmt.Sprintf(`proxy:
+    remoteurl: %s
+`, c.ProxyRemoteURL)
 	}
 
 	confPath := filepath.Join(tmp, "config.yaml")
@@ -90,13 +119,13 @@ http:
 	}
 	defer config.Close()
 
-	if _, err := fmt.Fprintf(config, template, tmp, registryURL, authTemplate); err != nil {
+	if _, err := fmt.Fprintf(config, strings.Join([]string{template, authTemplate, proxyTemplate}, "\n")); err != nil {
 		os.RemoveAll(tmp)
 		return nil, err
 	}
 
 	binary := v2binary
-	if schema1 {
+	if c.Schema1 {
 		binary = v2binarySchema1
 	}
 	cmd := exec.Command(binary, confPath)
@@ -107,18 +136,31 @@ http:
 	return &V2{
 		cmd:         cmd,
 		dir:         tmp,
-		auth:        auth,
+		auth:        c.Auth,
 		username:    username,
 		password:    password,
 		email:       email,
-		registryURL: registryURL,
+		registryURL: c.RegistryURL,
 	}, nil
 }
 
 // Ping sends an http request to the current registry, and fail if it doesn't respond correctly
 func (r *V2) Ping() error {
-	// We always ping through HTTP for our test registry.
-	resp, err := http.Get(fmt.Sprintf("http://%s/v2/", r.registryURL))
+	reqURL := r.registryURL + "/v2/"
+	var tr http.Transport
+	if strings.HasPrefix(r.registryURL, "unix://") {
+		reqURL = "http://registry/v2/"
+		path := strings.TrimPrefix(r.registryURL, "unix://")
+		if err := sockets.ConfigureTransport(&tr, "unix", path); err != nil {
+			return err
+		}
+	}
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return err
+	}
+	client := http.Client{Transport: &tr}
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -191,6 +233,17 @@ func (r *V2) TempMoveBlobData(t testingT, blobDigest digest.Digest) (undo func()
 		os.Rename(tempFile.Name(), blobFilename)
 		os.Remove(tempFile.Name())
 	}
+}
+
+// ManifestDigest does not verify args, as this is just for test utility.
+// usage: ManifestDigest("library/hello-world", latest)
+func (r *V2) ManifestDigest(repo, tag string) (digest.Digest, error) {
+	path := filepath.Join(r.Path(), "repositories", repo, "_manifests", "tags", tag, "current", "link")
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return digest.Digest(string(b)), nil
 }
 
 // Username returns the configured user name of the server

--- a/integration/image/registry_mirrors_test.go
+++ b/integration/image/registry_mirrors_test.go
@@ -1,0 +1,73 @@
+package image
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/integration-cli/daemon"
+	"github.com/docker/docker/integration-cli/registry"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test --registry-mirrors with unix:// sockets.
+// Requires Internet connection.
+func TestImageRegistryMirrorsUNIX(t *testing.T) {
+	t.Parallel()
+	tmp, err := ioutil.TempDir("", "test-image-registry-mirrors")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmp)
+	registrySocket := filepath.Join(tmp, "registry.sock")
+	registryURL := "unix://" + registrySocket
+	testImageRegistryMirrors(t, registryURL)
+}
+
+// Test --registry-mirrors with http:// sockets.
+// Requires Internet connection.
+func TestImageRegistryMirrorsHTTP(t *testing.T) {
+	// FIXME(AkihiroSuda): this is also defined in the legacy integration-cli (`privateRegistryURL`)
+	registryURL := "http://127.0.0.1:5000"
+	testImageRegistryMirrors(t, registryURL)
+}
+
+func testImageRegistryMirrors(t *testing.T, registryURL string) {
+	registry, err := registry.NewV2(registry.V2Config{
+		RegistryURL:    registryURL,
+		ProxyRemoteURL: "https://registry-1.docker.io",
+	})
+	assert.NoError(t, err)
+	defer registry.Close()
+
+	// Wait for registry to be ready to serve requests.
+	for i := 0; i != 50; i++ {
+		if err = registry.Ping(); err == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	assert.NoError(t, err)
+
+	d := daemon.New(t, "", "dockerd", daemon.Config{})
+	d.Start(t, "--registry-mirror="+registryURL)
+	defer d.Stop(t)
+
+	client, err := d.NewClient()
+	assert.NoError(t, err, "error creating client")
+
+	ctx := context.Background()
+	rc, err := client.ImagePull(ctx, "hello-world", types.ImagePullOptions{})
+	assert.NoError(t, err)
+	_, err = io.Copy(ioutil.Discard, rc)
+	assert.NoError(t, err)
+	rc.Close()
+
+	// Make sure the image is cached to the local registry
+	manifestDigest, err := registry.ManifestDigest("library/hello-world", "latest")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, manifestDigest)
+}

--- a/registry/config_test.go
+++ b/registry/config_test.go
@@ -127,19 +127,20 @@ func TestLoadAllowNondistributableArtifacts(t *testing.T) {
 }
 
 func TestValidateMirror(t *testing.T) {
-	valid := []string{
-		"http://mirror-1.com",
-		"http://mirror-1.com/",
-		"https://mirror-1.com",
-		"https://mirror-1.com/",
-		"http://localhost",
-		"https://localhost",
-		"http://localhost:5000",
-		"https://localhost:5000",
-		"http://127.0.0.1",
-		"https://127.0.0.1",
-		"http://127.0.0.1:5000",
-		"https://127.0.0.1:5000",
+	valid := map[string]string{
+		"http://mirror-1.com":    "http://mirror-1.com/",
+		"http://mirror-1.com/":   "http://mirror-1.com/",
+		"https://mirror-1.com":   "https://mirror-1.com/",
+		"https://mirror-1.com/":  "https://mirror-1.com/",
+		"http://localhost":       "http://localhost/",
+		"https://localhost":      "https://localhost/",
+		"http://localhost:5000":  "http://localhost:5000/",
+		"https://localhost:5000": "https://localhost:5000/",
+		"http://127.0.0.1":       "http://127.0.0.1/",
+		"https://127.0.0.1":      "https://127.0.0.1/",
+		"http://127.0.0.1:5000":  "http://127.0.0.1:5000/",
+		"https://127.0.0.1:5000": "https://127.0.0.1:5000/",
+		"unix:///foo/bar.sock":   "unix:///foo/bar.sock",
 	}
 
 	invalid := []string{
@@ -156,11 +157,15 @@ func TestValidateMirror(t *testing.T) {
 		"https://mirror-1.com/v1/",
 		"https://mirror-1.com/v1/#",
 		"https://mirror-1.com?q",
+		"unix:///foo/bar.sock/",
+		"unix:///foo/bar.sock?q",
+		"unix:///foo/bar.sock#frag",
 	}
 
-	for _, address := range valid {
-		if ret, err := ValidateMirror(address); err != nil || ret == "" {
-			t.Errorf("ValidateMirror(`"+address+"`) got %s %s", ret, err)
+	for address, expected := range valid {
+		ret, err := ValidateMirror(address)
+		if err != nil || ret == "" || expected != ret {
+			t.Errorf("ValidateMirror(`"+address+"`) got %s, expected %s, err=%s", ret, expected, err)
 		}
 	}
 

--- a/registry/service.go
+++ b/registry/service.go
@@ -113,6 +113,10 @@ func (s *DefaultService) Auth(ctx context.Context, authConfig *types.AuthConfig,
 	if serverAddress == "" {
 		serverAddress = IndexServer
 	}
+	if strings.HasPrefix(serverAddress, "unix://") {
+		// FIXME(AkihiroSuda): this should be ok for most usecases.
+		return "", "", errdefs.NotImplemented(errors.New("authentication is not implemented for the unix protocol"))
+	}
 	if !strings.HasPrefix(serverAddress, "https://") && !strings.HasPrefix(serverAddress, "http://") {
 		serverAddress = "https://" + serverAddress
 	}


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Support unix:// addresses for --registry-mirrors.


**- How I did it**

Please refer to the code

**- How to verify it**

1. Start `docker-registry serve a.yml` wit the following config
```yaml
version: 0.1                               
storage:                                   
  cache:                                   
    blobdescriptor: inmemory               
  filesystem:                              
    rootdirectory: /var/lib/docker-registry-cache                                     
http:                                      
  addr: /run/docker-registry-cache.sock    
  net: unix                                
proxy:                                     
  remoteurl: https://registry-1.docker.io
```

2. Start `dockerd` with `--registry-mirror=unix:///run/docker-registry-cache.sock`

3. Do `docker pull something` and make sure the image is cached into the local registry.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
support unix:// addresses for --registry-mirrors


**- A picture of a cute animal (not mandatory but encouraged)**

🐧 
