### PR TITLE
Move commit to container backend

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -68,8 +68,13 @@ type systemBackend interface {
 	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (*types.ContainersPruneReport, error)
 }
 
+type commitBackend interface {
+	CreateImageFromContainer(name string, config *backend.CreateImageConfig) (imageID string, err error)
+}
+
 // Backend is all the methods that need to be implemented to provide container specific functionality.
 type Backend interface {
+	commitBackend
 	execBackend
 	copyBackend
 	stateBackend

--- a/api/server/router/container/container.go
+++ b/api/server/router/container/container.go
@@ -61,6 +61,7 @@ func (r *containerRouter) initRoutes() {
 		router.NewPostRoute("/containers/{name:.*}/rename", r.postContainerRename),
 		router.NewPostRoute("/containers/{name:.*}/update", r.postContainerUpdate),
 		router.NewPostRoute("/containers/prune", r.postContainersPrune, router.WithCancel),
+		router.NewPostRoute("/commit", r.postCommit),
 		// PUT
 		router.NewPutRoute("/containers/{name:.*}/archive", r.putContainersArchive),
 		// DELETE

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -24,6 +24,45 @@ import (
 	"golang.org/x/net/websocket"
 )
 
+func (s *containerRouter) postCommit(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+
+	if err := httputils.CheckForJSON(r); err != nil {
+		return err
+	}
+
+	// TODO: remove pause arg, and always pause in backend
+	pause := httputils.BoolValue(r, "pause")
+	version := httputils.VersionFromContext(ctx)
+	if r.FormValue("pause") == "" && versions.GreaterThanOrEqualTo(version, "1.13") {
+		pause = true
+	}
+
+	config, _, _, err := s.decoder.DecodeConfig(r.Body)
+	if err != nil && err != io.EOF { //Do not fail if body is empty.
+		return err
+	}
+
+	commitCfg := &backend.CreateImageConfig{
+		Pause:   pause,
+		Repo:    r.Form.Get("repo"),
+		Tag:     r.Form.Get("tag"),
+		Author:  r.Form.Get("author"),
+		Comment: r.Form.Get("comment"),
+		Config:  config,
+		Changes: r.Form["changes"],
+	}
+
+	imgID, err := s.backend.CreateImageFromContainer(r.Form.Get("container"), commitCfg)
+	if err != nil {
+		return err
+	}
+
+	return httputils.WriteJSON(w, http.StatusCreated, &types.IDResponse{ID: imgID})
+}
+
 func (s *containerRouter) getContainersJSON(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
 		return err

--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -4,7 +4,6 @@ import (
 	"io"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
@@ -14,14 +13,9 @@ import (
 // Backend is all the methods that need to be implemented
 // to provide image specific functionality.
 type Backend interface {
-	containerBackend
 	imageBackend
 	importExportBackend
 	registryBackend
-}
-
-type containerBackend interface {
-	CreateImageFromContainer(name string, config *backend.CreateImageConfig) (imageID string, err error)
 }
 
 type imageBackend interface {

--- a/api/server/router/image/image.go
+++ b/api/server/router/image/image.go
@@ -1,23 +1,18 @@
 package image // import "github.com/docker/docker/api/server/router/image"
 
 import (
-	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/server/router"
 )
 
 // imageRouter is a router to talk with the image controller
 type imageRouter struct {
 	backend Backend
-	decoder httputils.ContainerDecoder
 	routes  []router.Route
 }
 
 // NewRouter initializes a new image router
-func NewRouter(backend Backend, decoder httputils.ContainerDecoder) router.Router {
-	r := &imageRouter{
-		backend: backend,
-		decoder: decoder,
-	}
+func NewRouter(backend Backend) router.Router {
+	r := &imageRouter{backend: backend}
 	r.initRoutes()
 	return r
 }
@@ -38,7 +33,6 @@ func (r *imageRouter) initRoutes() {
 		router.NewGetRoute("/images/{name:.*}/history", r.getImagesHistory),
 		router.NewGetRoute("/images/{name:.*}/json", r.getImagesByName),
 		// POST
-		router.NewPostRoute("/commit", r.postCommit),
 		router.NewPostRoute("/images/load", r.postImagesLoad),
 		router.NewPostRoute("/images/create", r.postImagesCreate, router.WithCancel),
 		router.NewPostRoute("/images/{name:.*}/push", r.postImagesPush, router.WithCancel),

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -514,7 +514,7 @@ func initRouter(opts routerOptions) {
 		// we need to add the checkpoint router before the container router or the DELETE gets masked
 		checkpointrouter.NewRouter(opts.daemon, decoder),
 		container.NewRouter(opts.daemon, decoder),
-		image.NewRouter(opts.daemon, decoder),
+		image.NewRouter(opts.daemon),
 		systemrouter.NewRouter(opts.daemon, opts.cluster, opts.buildCache),
 		volume.NewRouter(opts.daemon),
 		build.NewRouter(opts.buildBackend, opts.daemon),


### PR DESCRIPTION
Follow up to #36224
Extracted from #36240 to shrink that PR

Move the commit API endpoint from the image router to the container router.

* the client and cli both already groups commit into container operations
* the backend implementation of `CreateImageFromContainer` depends heavily on container operations
* removes the image router dependency on a container decoder