### PR TITLE
Fix import path

### DIFF
--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/daemon"
-	"github.com/docker/docker/integration/util/request"
+	"github.com/docker/docker/integration/internal/request"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/pkg/system"
 	"github.com/gotestyourself/gotestyourself/fs"


### PR DESCRIPTION
The utils package was moved to "internal" in commit af306d149e76b100e08972cda364647bd7bcfe1e (https://github.com/moby/moby/pull/36265).

https://github.com/moby/moby/pull/36055 was outdated when merged, causing this
