### PR TITLE
Remove unused method from multireader package

### DIFF
--- a/daemon/logger/loggerutils/multireader/multireader.go
+++ b/daemon/logger/loggerutils/multireader/multireader.go
@@ -138,22 +138,6 @@ func (r *multiReadSeeker) getCurOffset() (int64, error) {
 	return totalSize, nil
 }
 
-func (r *multiReadSeeker) getOffsetToReader(rdr io.ReadSeeker) (int64, error) {
-	var offset int64
-	for _, r := range r.readers {
-		if r == rdr {
-			break
-		}
-
-		size, err := getReadSeekerSize(rdr)
-		if err != nil {
-			return -1, err
-		}
-		offset += size
-	}
-	return offset, nil
-}
-
 func (r *multiReadSeeker) Read(b []byte) (int, error) {
 	if r.pos == nil {
 		// make sure all readers are at 0


### PR DESCRIPTION
**- What I did**
Remove unused method `getOffsetToReader` from package `github.com/docker/docker/daemon/logger/loggerutils/multireader`.

**- How to verify it**
It is private method in package I search all in package and not found any point use that method.