### PR TITLE
Windows: Block pulling uplevel images

### DIFF
--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -27,3 +27,8 @@ func filterManifests(manifests []manifestlist.ManifestDescriptor, os string) []m
 	}
 	return matches
 }
+
+// checkImageCompatibility is a Windows-specific function. No-op on Linux
+func checkImageCompatibility(imageOS, imageOSVersion string) error {
+	return nil
+}

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -118,12 +118,17 @@ func (p *v2Pusher) pushV2Tag(ctx context.Context, ref reference.NamedTagged, id 
 		return fmt.Errorf("could not find image from tag %s: %v", reference.FamiliarString(ref), err)
 	}
 
-	rootfs, os, err := p.config.ImageStore.RootFSAndOSFromConfig(imgConfig)
+	rootfs, err := p.config.ImageStore.RootFSFromConfig(imgConfig)
 	if err != nil {
 		return fmt.Errorf("unable to get rootfs for image %s: %s", reference.FamiliarString(ref), err)
 	}
 
-	l, err := p.config.LayerStores[os].Get(rootfs.ChainID())
+	platform, err := p.config.ImageStore.PlatformFromConfig(imgConfig)
+	if err != nil {
+		return fmt.Errorf("unable to get platform for image %s: %s", reference.FamiliarString(ref), err)
+	}
+
+	l, err := p.config.LayerStores[platform.OS].Get(rootfs.ChainID())
 	if err != nil {
 		return fmt.Errorf("failed to get top layer from image: %v", err)
 	}

--- a/pkg/system/syscall_windows.go
+++ b/pkg/system/syscall_windows.go
@@ -1,6 +1,7 @@
 package system // import "github.com/docker/docker/pkg/system"
 
 import (
+	"fmt"
 	"unsafe"
 
 	"github.com/sirupsen/logrus"
@@ -51,6 +52,10 @@ func GetOSVersion() OSVersion {
 	osv.MinorVersion = uint8(osv.Version >> 8 & 0xFF)
 	osv.Build = uint16(osv.Version >> 16)
 	return osv
+}
+
+func (osv OSVersion) ToString() string {
+	return fmt.Sprintf("%d.%d.%d", osv.MajorVersion, osv.MinorVersion, osv.Build)
 }
 
 // IsWindowsClient returns true if the SKU is client

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -33,6 +33,7 @@ import (
 	"github.com/docker/docker/plugin/v2"
 	refstore "github.com/docker/docker/reference"
 	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -146,8 +147,13 @@ func (s *tempConfigStore) Get(d digest.Digest) ([]byte, error) {
 	return s.config, nil
 }
 
-func (s *tempConfigStore) RootFSAndOSFromConfig(c []byte) (*image.RootFS, string, error) {
+func (s *tempConfigStore) RootFSFromConfig(c []byte) (*image.RootFS, error) {
 	return configToRootFS(c)
+}
+
+func (s *tempConfigStore) PlatformFromConfig(c []byte) (*specs.Platform, error) {
+	// TODO: LCOW/Plugins. This will need revisiting. For now use the runtime OS
+	return &specs.Platform{OS: runtime.GOOS}, nil
 }
 
 func computePrivileges(c types.PluginConfig) types.PluginPrivileges {
@@ -534,8 +540,13 @@ func (s *pluginConfigStore) Get(d digest.Digest) ([]byte, error) {
 	return ioutil.ReadAll(rwc)
 }
 
-func (s *pluginConfigStore) RootFSAndOSFromConfig(c []byte) (*image.RootFS, string, error) {
+func (s *pluginConfigStore) RootFSFromConfig(c []byte) (*image.RootFS, error) {
 	return configToRootFS(c)
+}
+
+func (s *pluginConfigStore) PlatformFromConfig(c []byte) (*specs.Platform, error) {
+	// TODO: LCOW/Plugins. This will need revisiting. For now use the runtime OS
+	return &specs.Platform{OS: runtime.GOOS}, nil
 }
 
 type pluginLayerProvider struct {

--- a/plugin/blobstore.go
+++ b/plugin/blobstore.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/docker/docker/distribution/xfer"
 	"github.com/docker/docker/image"
@@ -14,6 +15,7 @@ import (
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -178,6 +180,10 @@ func (dm *downloadManager) Put(dt []byte) (digest.Digest, error) {
 func (dm *downloadManager) Get(d digest.Digest) ([]byte, error) {
 	return nil, fmt.Errorf("digest not found")
 }
-func (dm *downloadManager) RootFSAndOSFromConfig(c []byte) (*image.RootFS, string, error) {
+func (dm *downloadManager) RootFSFromConfig(c []byte) (*image.RootFS, error) {
 	return configToRootFS(c)
+}
+func (dm *downloadManager) PlatformFromConfig(c []byte) (*specs.Platform, error) {
+	// TODO: LCOW/Plugins. This will need revisiting. For now use the runtime OS
+	return &specs.Platform{OS: runtime.GOOS}, nil
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -375,19 +374,17 @@ func isEqualPrivilege(a, b types.PluginPrivilege) bool {
 	return reflect.DeepEqual(a.Value, b.Value)
 }
 
-func configToRootFS(c []byte) (*image.RootFS, string, error) {
-	// TODO @jhowardmsft LCOW - Will need to revisit this.
-	os := runtime.GOOS
+func configToRootFS(c []byte) (*image.RootFS, error) {
 	var pluginConfig types.PluginConfig
 	if err := json.Unmarshal(c, &pluginConfig); err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	// validation for empty rootfs is in distribution code
 	if pluginConfig.Rootfs == nil {
-		return nil, os, nil
+		return nil, nil
 	}
 
-	return rootFSFromPlugin(pluginConfig.Rootfs), os, nil
+	return rootFSFromPlugin(pluginConfig.Rootfs), nil
 }
 
 func rootFSFromPlugin(pluginfs *types.PluginConfigRootfs) *image.RootFS {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes https://github.com/moby/moby/issues/36184. This change gives a decent error message about image incompatibility early, rather than blindly continuing to download the image, try to extract it, and then fail with an extremely misleading error:

Before this change, on an RS1 host, pulling a 1709/RS3 image:

```
PS E:\go\src\github.com\docker\docker> docker pull microsoft/nanoserver:1709
1709: Pulling from microsoft/nanoserver
407ada6e90de: Extracting [==================================================>]  81.04MB/81.04MB
3cb15ab58a2c: Download complete
failed to register layer: re-exec error: exit status 1: output: ProcessUtilityVMImage C:\control\windowsfilter\21c033dbff11f1084e2ef67c041c491fd04be6aea0eb6d622067f2136b6b48b4\UtilityVM: The system cannot find the path specified.
PS E:\go\src\github.com\docker\docker>
```

After this change:

```
PS E:\go\src\github.com\docker\docker> docker pull microsoft/nanoserver:1709
1709: Pulling from microsoft/nanoserver
a Windows version 10.0.16299-based image is incompatible with a 10.0.14393 host
PS E:\go\src\github.com\docker\docker>
```

@johnstep @darrenstahlmsft @thaJeztah PTAL