### PR TITLE
Sync binary commits with vndr

### DIFF
--- a/hack/dockerfile/binaries-commits
+++ b/hack/dockerfile/binaries-commits
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# When updating TOMLV_COMMIT, consider updating github.com/BurntSushi/toml
+# in vendor.conf accordingly
 TOMLV_COMMIT=9baf8a8a9f2ed20a8e54160840c492f937eeaf9a
 
 # When updating RUNC_COMMIT, also update runc in vendor.conf accordingly
@@ -10,6 +12,10 @@ RUNC_COMMIT=6c55f98695e902427906eed2c799e566e3d3dfb5
 # fixes or new APIs.
 CONTAINERD_COMMIT=cfd04396dc68220d1cecbe686a6cc3aa5ce3667c # v1.0.2
 TINI_COMMIT=949e6facb77383876aeff8a6944dde66b3089574
+
+# LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
+# updating the binary version, consider updating github.com/docker/libnetwork
+# in vendor.conf accordingly
 LIBNETWORK_COMMIT=fcf1c3b5e57833aaaa756ae3c4140ea54da00319
 VNDR_COMMIT=a6e196d8b4b0cbbdc29aebdb20c59ac6926bb384
 

--- a/hack/dockerfile/binaries-commits
+++ b/hack/dockerfile/binaries-commits
@@ -2,7 +2,7 @@
 
 # When updating TOMLV_COMMIT, consider updating github.com/BurntSushi/toml
 # in vendor.conf accordingly
-TOMLV_COMMIT=9baf8a8a9f2ed20a8e54160840c492f937eeaf9a
+TOMLV_COMMIT=a368813c5e648fee92e5f6c30e3944ff9d5e8895
 
 # When updating RUNC_COMMIT, also update runc in vendor.conf accordingly
 RUNC_COMMIT=6c55f98695e902427906eed2c799e566e3d3dfb5

--- a/hack/dockerfile/binaries-commits
+++ b/hack/dockerfile/binaries-commits
@@ -16,7 +16,7 @@ TINI_COMMIT=949e6facb77383876aeff8a6944dde66b3089574
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=fcf1c3b5e57833aaaa756ae3c4140ea54da00319
+LIBNETWORK_COMMIT=20dd462e0a0e883437a274bd61df4bc4de980830
 VNDR_COMMIT=a6e196d8b4b0cbbdc29aebdb20c59ac6926bb384
 
 # Linting

--- a/vendor.conf
+++ b/vendor.conf
@@ -31,6 +31,8 @@ github.com/moby/buildkit aaff9d591ef128560018433fe61beb802e149de8
 github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 
 #get libnetwork packages
+
+# When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/binaries-commits accordingly
 github.com/docker/libnetwork 20dd462e0a0e883437a274bd61df4bc4de980830
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
@@ -44,6 +46,8 @@ github.com/hashicorp/serf 598c54895cc5a7b1a24a398d635e8c0ea0959870
 github.com/docker/libkv 1d8431073ae03cdaedb198a89722f3aab6d418ef
 github.com/vishvananda/netns 604eaf189ee867d8c147fafc28def2394e878d25
 github.com/vishvananda/netlink b2de5d10e38ecce8607e6b438b6d174f389a004e
+
+# When updating, consider updating TOMLV_COMMIT in hack/dockerfile/binaries-commits accordingly
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/samuel/go-zookeeper d0e0d8e11f318e000a8cc434616d69e329edc374
 github.com/deckarep/golang-set ef32fa3046d9f249d399f98ebaf9be944430fd1d


### PR DESCRIPTION
Mainly for "hygiene";

- Add comments to remind people to consider keeping these win sync with the vendored package
- Update binary-commit (`userland-proxy`) for libnetwork:  https://github.com/docker/libnetwork/compare/fcf1c3b5e57833aaaa756ae3c4140ea54da00319...20dd462e0a0e883437a274bd61df4bc4de980830
- Update tomlv binary to match vendor, and use MIT license: https://github.com/BurntSushi/toml/compare/9baf8a8a9f2ed20a8e54160840c492f937eeaf9a...a368813c5e648fee92e5f6c30e3944ff9d5e8895

ping @vdemeester @AkihiroSuda PTAL