### PR TITLE
Update containerd/continuity to fix ARM 32-bit builds

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -110,7 +110,7 @@ google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 # containerd
 github.com/containerd/containerd 3fa104f843ec92328912e042b767d26825f202aa
 github.com/containerd/fifo fbfb6a11ec671efbe94ad1c12c2e98773f19e1e6
-github.com/containerd/continuity 992a5f112bd2211d0983a1cc8562d2882848f3a3
+github.com/containerd/continuity d8fb8589b0e8e85b8c8bbaa8840226d0dfeb7371
 github.com/containerd/cgroups c0710c92e8b3a44681d1321dcfd1360fc5c6c089
 github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
 github.com/containerd/go-runc 4f6e87ae043f859a38255247b49c9abc262d002f

--- a/vendor/github.com/containerd/continuity/fs/stat_linux.go
+++ b/vendor/github.com/containerd/continuity/fs/stat_linux.go
@@ -22,5 +22,6 @@ func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 
 // StatATimeAsTime returns st.Atim as a time.Time
 func StatATimeAsTime(st *syscall.Stat_t) time.Time {
-	return time.Unix(st.Atim.Sec, st.Atim.Nsec)
+	// The int64 conversions ensure the line compiles for 32-bit systems as well.
+	return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) // nolint: unconvert
 }

--- a/vendor/github.com/containerd/continuity/sysx/xattr_openbsd.go
+++ b/vendor/github.com/containerd/continuity/sysx/xattr_openbsd.go
@@ -1,0 +1,7 @@
+package sysx
+
+import (
+	"errors"
+)
+
+var unsupported = errors.New("extended attributes unsupported on OpenBSD")

--- a/vendor/github.com/containerd/continuity/sysx/xattr_unsupported.go
+++ b/vendor/github.com/containerd/continuity/sysx/xattr_unsupported.go
@@ -1,4 +1,4 @@
-// +build freebsd solaris
+// +build freebsd openbsd solaris
 
 package sysx
 


### PR DESCRIPTION
This updates the containerd/continuity package to https://github.com/containerd/continuity/commit/d876b2b1f16dbb43980a25660da3e7ca0aca7016,
which fixes builds failing on ARM 32-bit, after this dependency was added in
https://github.com/moby/moby/pull/36290/commits/b3aab5e31faf04d8a29f17be55562e4d0c0cb364 (https://github.com/moby/moby/pull/36290)

Full diff: https://github.com/containerd/continuity/compare/992a5f112bd2211d0983a1cc8562d2882848f3a3...d8fb8589b0e8e85b8c8bbaa8840226d0dfeb7371


Changes:

- https://github.com/containerd/continuity/pull/104 Make sysx compile on OpenBSD; mark OpenBSD as unsupported for xattr
- https://github.com/containerd/continuity/pull/105 Add time type conversion for 32 bit linix platforms
- https://github.com/containerd/continuity/pull/107 Add comment about why an int64 conversion is needed in fs.StatATimeAsTime


ping @seemethere @cpuguy83 @dnephin 