### PR TITLE
Add suport to multiline JSON arrays

### DIFF
--- a/builder/dockerfile/parser/json_test.go
+++ b/builder/dockerfile/parser/json_test.go
@@ -23,7 +23,8 @@ var validJSONArraysOfStrings = map[string][]string{
 	`[ "a", "b" ]`: {"a", "b"},
 	`[	"a",	"b"	]`: {"a", "b"},
 	`	[	"a",	"b"	]	`: {"a", "b"},
-	`["abc 123", "♥", "☃", "\" \\ \/ \b \f \n \r \t \u0000"]`: {"abc 123", "♥", "☃", "\" \\ / \b \f \n \r \t \u0000"},
+	"[\"a\", \n \"b\"]":                                      {"a", "b"},
+	`["abc 123","♥", "☃", "\" \\ \/ \b \f \n \r \t \u0000"]`: {"abc 123", "♥", "☃", "\" \\ / \b \f \n \r \t \u0000"},
 }
 
 func TestJSONArraysOfStrings(t *testing.T) {

--- a/builder/dockerfile/parser/testfiles/ADD-COPY-with-JSON/Dockerfile
+++ b/builder/dockerfile/parser/testfiles/ADD-COPY-with-JSON/Dockerfile
@@ -8,4 +8,9 @@ COPY	nullfile /tmp
 ADD		[ "vimrc", "/tmp" ]
 COPY	[ "bashrc", "/tmp" ]
 COPY	[ "test file", "/tmp" ]
-ADD		[ "test file", "/tmp/test file" ]
+ADD		\
+    [
+         "test file",
+    
+    "/tmp/test file"
+]


### PR DESCRIPTION
I just added support to multiline JSON arrays in Dockerfile by adding one more rule to line continuation during parsing.

```Dockerfile
ENTRYPOINT [                                    
    "wait-for-it", "postgres:5432", "-s", "--", 
    "wait-for-it", "redis:6379", "-s", "--"     
]
```

Now it works!

Signed-off-by: Pedro Lacerda <pslacerda@gmail.com>
fixes #36343 

![image](https://user-images.githubusercontent.com/149358/36348605-349a9316-146b-11e8-8888-d0b396a99f6f.png)

