### PR TITLE
integration/TestUpdateMemory: fix false failure

### DIFF
--- a/integration/container/update_linux_test.go
+++ b/integration/container/update_linux_test.go
@@ -66,7 +66,7 @@ func TestUpdateMemory(t *testing.T) {
 	assert.Equal(t, strconv.FormatInt(setMemorySwap, 10), strings.TrimSpace(res.Stdout()))
 }
 
-func TestUpdateCPUQUota(t *testing.T) {
+func TestUpdateCPUQuota(t *testing.T) {
 	t.Parallel()
 
 	defer setupTest(t)()

--- a/integration/container/update_linux_test.go
+++ b/integration/container/update_linux_test.go
@@ -35,7 +35,7 @@ func TestUpdateMemory(t *testing.T) {
 
 	const (
 		setMemory     int64 = 314572800
-		setMemorySwap       = 524288000
+		setMemorySwap int64 = 524288000
 	)
 
 	_, err := client.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{


### PR DESCRIPTION
### integration/TestUpdateMemory: fix false failure

This fixes the following test failure:
    
> --- FAIL: TestUpdateMemory (0.53s)
>       assertions.go:226:
>       Error Trace:    update_linux_test.go:52
>       Error:          Not equal:
>                       expected: int(524288000)
>                       received: int64(524288000)
    
Fixes: 0f9da07b569f0d9

----

While at it, a nitpick:

### integration/testUpdateCPUQuota: fix name
    
The function name should be TestUpdateCPUQuota and not TestUpdateCPUQUota.