### PR TITLE
Fix TestAttachAfterDetach to work with latest client

### DIFF
--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -69,10 +69,10 @@ func (s *DockerSuite) TestAttachAfterDetach(c *check.C) {
 	cmd.Stdout = tty
 	cmd.Stderr = tty
 
-	errChan := make(chan error)
+	cmdExit := make(chan error)
 	go func() {
-		errChan <- cmd.Run()
-		close(errChan)
+		cmdExit <- cmd.Run()
+		close(cmdExit)
 	}()
 
 	c.Assert(waitRun(name), check.IsNil)
@@ -82,12 +82,7 @@ func (s *DockerSuite) TestAttachAfterDetach(c *check.C) {
 	cpty.Write([]byte{17})
 
 	select {
-	case err := <-errChan:
-		if err != nil {
-			buff := make([]byte, 200)
-			tty.Read(buff)
-			c.Fatalf("%s: %s", err, buff)
-		}
+	case <-cmdExit:
 	case <-time.After(5 * time.Second):
 		c.Fatal("timeout while detaching")
 	}
@@ -102,6 +97,7 @@ func (s *DockerSuite) TestAttachAfterDetach(c *check.C) {
 
 	err = cmd.Start()
 	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
 
 	bytes := make([]byte, 10)
 	var nBytes int
@@ -124,11 +120,7 @@ func (s *DockerSuite) TestAttachAfterDetach(c *check.C) {
 		c.Fatal("timeout waiting for attach read")
 	}
 
-	err = cmd.Wait()
-	c.Assert(err, checker.IsNil)
-
 	c.Assert(string(bytes[:nBytes]), checker.Contains, "/ #")
-
 }
 
 // TestAttachDetach checks that attach in tty mode can be detached using the long container ID


### PR DESCRIPTION
Fixes https://github.com/docker/cli/pull/696#issuecomment-361831262

There seemed to be a few problems with this test:
1. detaching from a client now returns the proper exit code, so `errChan` had an error, but `tty.Read(buff)` was blocking because there was nothing to read.
2. it was expecting the `docker attach` to exit, but I don't see why it would. There was no `exit` call. The original version of this test (28cf8fddd4c19e98fd0a6fcf0a6e7ea545521412) sent `exit\n`, but it was removed in 6ef8057700b63e2c5fd5cec206915ef1f2088578. Waiting on attach to exit is out of scope of this test, so I changed it to just `Kill()`.