### PR TITLE
Adjust minimum API version for templated configs/secrets

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api // import "github.com/docker/docker/api"
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion string = "1.36"
+	DefaultVersion string = "1.37"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -373,7 +373,7 @@ func (sr *swarmRouter) createSecret(ctx context.Context, w http.ResponseWriter, 
 		return err
 	}
 	version := httputils.VersionFromContext(ctx)
-	if secret.Templating != nil && versions.LessThan(version, "1.36") {
+	if secret.Templating != nil && versions.LessThan(version, "1.37") {
 		return errdefs.InvalidParameter(errors.Errorf("secret templating is not supported on the specified API version: %s", version))
 	}
 
@@ -445,7 +445,7 @@ func (sr *swarmRouter) createConfig(ctx context.Context, w http.ResponseWriter, 
 	}
 
 	version := httputils.VersionFromContext(ctx)
-	if config.Templating != nil && versions.LessThan(version, "1.36") {
+	if config.Templating != nil && versions.LessThan(version, "1.37") {
 		return errdefs.InvalidParameter(errors.Errorf("config templating is not supported on the specified API version: %s", version))
 	}
 

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -18,6 +18,10 @@ keywords: "API, Docker, rcli, REST, documentation"
 [Docker Engine API v1.37](https://docs.docker.com/engine/api/v1.36/) documentation
 
 * `POST /containers/create` and `POST /services/create` now supports exposing SCTP ports.
+* `POST /configs/create` and `POST /configs/{id}/create` now accept a `Templating` driver.
+* `GET /configs` and `GET /configs/{id}` now return the `Templating` driver of the config.
+* `POST /secrets/create` and `POST /secrets/{id}/create` now accept a `Templating` driver.
+* `GET /secrets` and `GET /secrets/{id}` now return the `Templating` driver of the secret.
 
 ## v1.36 API changes
 


### PR DESCRIPTION
Also adds a note to the API version history

follow-up to https://github.com/moby/moby/pull/33702, which used the wrong API version in this check


ping @cpuguy83 @vdemeester 
