### PR TITLE
Add /proc/keys to masked paths

### DIFF
--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -115,6 +115,7 @@ func DefaultLinuxSpec() specs.Spec {
 	s.Linux = &specs.Linux{
 		MaskedPaths: []string{
 			"/proc/kcore",
+			"/proc/keys",
 			"/proc/latency_stats",
 			"/proc/timer_list",
 			"/proc/timer_stats",


### PR DESCRIPTION
This leaks information about keyrings on the host. Keyrings are
not namespaced.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![kittykeys](https://user-images.githubusercontent.com/482364/36491964-f29937d6-1723-11e8-8ede-97326e161102.jpg)
