### PR TITLE
Move containerIsStopped/containerIsInState to integration/internal/container

### DIFF
--- a/integration/container/diff_test.go
+++ b/integration/container/diff_test.go
@@ -29,7 +29,7 @@ func TestDiffFilenameShownInOutput(t *testing.T) {
 	// a "Files/" prefix.
 	lookingFor := containertypes.ContainerChangeResponseItem{Kind: archive.ChangeAdd, Path: "/foo/bar"}
 	if testEnv.OSType == "windows" {
-		poll.WaitOn(t, containerIsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(60*time.Second))
+		poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(60*time.Second))
 		lookingFor = containertypes.ContainerChangeResponseItem{Kind: archive.ChangeModify, Path: "Files/foo/bar"}
 	}
 

--- a/integration/container/inspect_test.go
+++ b/integration/container/inspect_test.go
@@ -30,7 +30,7 @@ func TestInspectCpusetInConfigPre120(t *testing.T) {
 			c.HostConfig.Resources.CpusetCpus = "0"
 		},
 	)
-	poll.WaitOn(t, containerIsInState(ctx, client, name, "exited"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, name, "exited"), poll.WithDelay(100*time.Millisecond))
 
 	_, body, err := client.ContainerInspectWithRaw(ctx, name, false)
 	require.NoError(t, err)

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -23,11 +23,11 @@ func TestKillContainerInvalidSignal(t *testing.T) {
 
 	err := client.ContainerKill(ctx, id, "0")
 	require.EqualError(t, err, "Error response from daemon: Invalid signal: 0")
-	poll.WaitOn(t, containerIsInState(ctx, client, id, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, id, "running"), poll.WithDelay(100*time.Millisecond))
 
 	err = client.ContainerKill(ctx, id, "SIG42")
 	require.EqualError(t, err, "Error response from daemon: Invalid signal: SIG42")
-	poll.WaitOn(t, containerIsInState(ctx, client, id, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, id, "running"), poll.WithDelay(100*time.Millisecond))
 }
 
 func TestKillContainer(t *testing.T) {
@@ -64,7 +64,7 @@ func TestKillContainer(t *testing.T) {
 			err := client.ContainerKill(ctx, id, tc.signal)
 			require.NoError(t, err)
 
-			poll.WaitOn(t, containerIsInState(ctx, client, id, tc.status), poll.WithDelay(100*time.Millisecond))
+			poll.WaitOn(t, container.IsInState(ctx, client, id, tc.status), poll.WithDelay(100*time.Millisecond))
 		})
 	}
 }
@@ -104,7 +104,7 @@ func TestKillWithStopSignalAndRestartPolicies(t *testing.T) {
 			err := client.ContainerKill(ctx, id, "TERM")
 			require.NoError(t, err)
 
-			poll.WaitOn(t, containerIsInState(ctx, client, id, tc.status), poll.WithDelay(100*time.Millisecond))
+			poll.WaitOn(t, container.IsInState(ctx, client, id, tc.status), poll.WithDelay(100*time.Millisecond))
 		})
 	}
 }
@@ -141,11 +141,11 @@ func TestKillDifferentUserContainer(t *testing.T) {
 	id := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
 		c.Config.User = "daemon"
 	})
-	poll.WaitOn(t, containerIsInState(ctx, client, id, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, id, "running"), poll.WithDelay(100*time.Millisecond))
 
 	err := client.ContainerKill(ctx, id, "SIGKILL")
 	require.NoError(t, err)
-	poll.WaitOn(t, containerIsInState(ctx, client, id, "exited"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, id, "exited"), poll.WithDelay(100*time.Millisecond))
 }
 
 func TestInspectOomKilledTrue(t *testing.T) {
@@ -160,7 +160,7 @@ func TestInspectOomKilledTrue(t *testing.T) {
 		c.HostConfig.Resources.Memory = 32 * 1024 * 1024
 	})
 
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 
 	inspect, err := client.ContainerInspect(ctx, cID)
 	require.NoError(t, err)
@@ -177,7 +177,7 @@ func TestInspectOomKilledFalse(t *testing.T) {
 	name := "testoomkilled"
 	cID := container.Run(t, ctx, client, container.WithName(name), container.WithCmd("sh", "-c", "echo hello world"))
 
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 
 	inspect, err := client.ContainerInspect(ctx, cID)
 	require.NoError(t, err)

--- a/integration/container/links_linux_test.go
+++ b/integration/container/links_linux_test.go
@@ -31,7 +31,7 @@ func TestLinksEtcHostsContentMatch(t *testing.T) {
 
 	cID := container.Run(t, ctx, client, container.WithCmd("cat", "/etc/hosts"), container.WithNetworkMode("host"))
 
-	poll.WaitOn(t, containerIsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
 
 	body, err := client.ContainerLogs(ctx, cID, types.ContainerLogsOptions{
 		ShowStdout: true,

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -69,7 +69,7 @@ func TestNetworkLoopbackNat(t *testing.T) {
 
 	cID := container.Run(t, ctx, client, container.WithCmd("sh", "-c", fmt.Sprintf("stty raw && nc -w 5 %s 8080", endpoint.String())), container.WithTty(true), container.WithNetworkMode("container:server"))
 
-	poll.WaitOn(t, containerIsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
 
 	body, err := client.ContainerLogs(ctx, cID, types.ContainerLogsOptions{
 		ShowStdout: true,
@@ -98,7 +98,7 @@ func startServerContainer(t *testing.T, msg string, port int) string {
 		}
 	})
 
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	return cID
 }

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -27,7 +27,7 @@ func TestPause(t *testing.T) {
 
 	name := "testeventpause"
 	cID := container.Run(t, ctx, client, container.WithName(name))
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	since := request.DaemonUnixTime(ctx, t, client, testEnv)
 
@@ -59,7 +59,7 @@ func TestPauseFailsOnWindowsServerContainers(t *testing.T) {
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client)
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	err := client.ContainerPause(ctx, cID)
 	testutil.ErrorContains(t, err, "cannot pause Windows Server Containers")
@@ -73,7 +73,7 @@ func TestPauseStopPausedContainer(t *testing.T) {
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client)
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	err := client.ContainerPause(ctx, cID)
 	require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestPauseStopPausedContainer(t *testing.T) {
 	err = client.ContainerStop(ctx, cID, nil)
 	require.NoError(t, err)
 
-	poll.WaitOn(t, containerIsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
 }
 
 func getEventActions(t *testing.T, messages <-chan events.Message, errs <-chan error) []string {

--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -51,7 +51,7 @@ func TestRenameStoppedContainer(t *testing.T) {
 
 	oldName := "first_name"
 	cID := container.Run(t, ctx, client, container.WithName(oldName), container.WithCmd("sh"))
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 
 	inspect, err := client.ContainerInspect(ctx, cID)
 	require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestRenameRunningContainerAndReuse(t *testing.T) {
 
 	oldName := "first_name"
 	cID := container.Run(t, ctx, client, container.WithName(oldName))
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	newName := "new_name" + stringid.GenerateNonCryptoID()
 	err := client.ContainerRename(ctx, oldName, newName)
@@ -87,7 +87,7 @@ func TestRenameRunningContainerAndReuse(t *testing.T) {
 	testutil.ErrorContains(t, err, "No such container: "+oldName)
 
 	cID = container.Run(t, ctx, client, container.WithName(oldName))
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	inspect, err = client.ContainerInspect(ctx, cID)
 	require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestRenameInvalidName(t *testing.T) {
 
 	oldName := "first_name"
 	cID := container.Run(t, ctx, client, container.WithName(oldName))
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	err := client.ContainerRename(ctx, oldName, "new:invalid")
 	testutil.ErrorContains(t, err, "Invalid container name")
@@ -136,7 +136,7 @@ func TestRenameAnonymousContainer(t *testing.T) {
 	err = client.ContainerStart(ctx, "container1", types.ContainerStartOptions{})
 	require.NoError(t, err)
 
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	count := "-c"
 	if testEnv.OSType == "windows" {
@@ -148,7 +148,7 @@ func TestRenameAnonymousContainer(t *testing.T) {
 		}
 		c.HostConfig.NetworkMode = "network1"
 	}, container.WithCmd("ping", count, "1", "container1"))
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 
 	inspect, err := client.ContainerInspect(ctx, cID)
 	require.NoError(t, err)
@@ -162,7 +162,7 @@ func TestRenameContainerWithSameName(t *testing.T) {
 	client := request.NewAPIClient(t)
 
 	cID := container.Run(t, ctx, client, container.WithName("old"))
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 	err := client.ContainerRename(ctx, "old", "old")
 	testutil.ErrorContains(t, err, "Renaming a container with the same name")
 	err = client.ContainerRename(ctx, cID, "old")
@@ -182,10 +182,10 @@ func TestRenameContainerWithLinkedContainer(t *testing.T) {
 	client := request.NewAPIClient(t)
 
 	db1ID := container.Run(t, ctx, client, container.WithName("db1"))
-	poll.WaitOn(t, containerIsInState(ctx, client, db1ID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, db1ID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	app1ID := container.Run(t, ctx, client, container.WithName("app1"), container.WithLinks("db1:/mysql"))
-	poll.WaitOn(t, containerIsInState(ctx, client, app1ID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, app1ID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	err := client.ContainerRename(ctx, "app1", "app2")
 	require.NoError(t, err)

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -23,7 +23,7 @@ func TestResize(t *testing.T) {
 
 	cID := container.Run(t, ctx, client)
 
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	err := client.ContainerResize(ctx, cID, types.ResizeOptions{
 		Height: 40,
@@ -39,7 +39,7 @@ func TestResizeWithInvalidSize(t *testing.T) {
 
 	cID := container.Run(t, ctx, client)
 
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	endpoint := "/containers/" + cID + "/resize?h=foo&w=bar"
 	res, _, err := req.Post(endpoint)
@@ -54,7 +54,7 @@ func TestResizeWhenContainerNotStarted(t *testing.T) {
 
 	cID := container.Run(t, ctx, client, container.WithCmd("echo"))
 
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 
 	err := client.ContainerResize(ctx, cID, types.ResizeOptions{
 		Height: 40,

--- a/integration/container/stats_test.go
+++ b/integration/container/stats_test.go
@@ -28,7 +28,7 @@ func TestStats(t *testing.T) {
 
 	cID := container.Run(t, ctx, client)
 
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	resp, err := client.ContainerStats(ctx, cID, false)
 	require.NoError(t, err)

--- a/integration/container/update_linux_test.go
+++ b/integration/container/update_linux_test.go
@@ -31,7 +31,7 @@ func TestUpdateMemory(t *testing.T) {
 		}
 	})
 
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	const (
 		setMemory     int64 = 314572800

--- a/integration/container/update_test.go
+++ b/integration/container/update_test.go
@@ -39,7 +39,7 @@ func TestUpdateRestartPolicy(t *testing.T) {
 		timeout = 180 * time.Second
 	}
 
-	poll.WaitOn(t, containerIsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(timeout))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(timeout))
 
 	inspect, err := client.ContainerInspect(ctx, cID)
 	require.NoError(t, err)

--- a/integration/internal/container/states.go
+++ b/integration/internal/container/states.go
@@ -1,0 +1,41 @@
+package container
+
+import (
+	"strings"
+
+	"github.com/docker/docker/client"
+	"github.com/gotestyourself/gotestyourself/poll"
+	"golang.org/x/net/context"
+)
+
+// IsStopped verifies the container is in stopped state.
+func IsStopped(ctx context.Context, client client.APIClient, containerID string) func(log poll.LogT) poll.Result {
+	return func(log poll.LogT) poll.Result {
+		inspect, err := client.ContainerInspect(ctx, containerID)
+
+		switch {
+		case err != nil:
+			return poll.Error(err)
+		case !inspect.State.Running:
+			return poll.Success()
+		default:
+			return poll.Continue("waiting for container to be stopped")
+		}
+	}
+}
+
+// IsInState verifies the container is in one of the specified state, e.g., "running", "exited", etc.
+func IsInState(ctx context.Context, client client.APIClient, containerID string, state ...string) func(log poll.LogT) poll.Result {
+	return func(log poll.LogT) poll.Result {
+		inspect, err := client.ContainerInspect(ctx, containerID)
+		if err != nil {
+			return poll.Error(err)
+		}
+		for _, v := range state {
+			if inspect.State.Status == v {
+				return poll.Success()
+			}
+		}
+		return poll.Continue("waiting for container to be one of (%s), currently %s", strings.Join(state, ", "), inspect.State.Status)
+	}
+}


### PR DESCRIPTION
This fix moves helper functions containerIsStopped and
containerIsInState to integration/internal/container,
so that they could be used outside of integration/container.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
