### PR TITLE
Whitelist statx syscall

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -322,6 +322,7 @@
 				"stat64",
 				"statfs",
 				"statfs64",
+				"statx",
 				"symlink",
 				"symlinkat",
 				"sync",

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -315,6 +315,7 @@ func DefaultProfile() *types.Seccomp {
 				"stat64",
 				"statfs",
 				"statfs64",
+				"statx",
 				"symlink",
 				"symlinkat",
 				"sync",


### PR DESCRIPTION
Signed-off-by: NobodyOnSE <ich@sektor.selfip.com>

Edited via github's webeditor, so the signoff was done manually, I hope that is enough.

The need for this addition is explained in [this SO post](https://stackoverflow.com/questions/48995826/which-capabilities-are-needed-for-statx-to-stop-giving-eperm). In short: building a Qt 5.10.1 application fails in `moc` because it uses `statx` to find includes.

**- What I did**
Added statx to whitelist of allowed syscalls.

**- How I did it**
Added it in the default.json for seccomp.

**- How to verify it**
Try to use `statx` and don't get an EPERM anymore on non-privileged containers.

**- Description for the changelog**
Whitelist statx syscall

**- A picture of a cute animal (not mandatory but encouraged)**

![Hedgehog with christmas hat](http://i.imgur.com/7KJzx.jpg)