### PR TITLE
LCOW: Autoselect platform

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -229,7 +229,7 @@ func (d *dispatchRequest) getOsFromFlagsAndStage(stageOS string) string {
 		// multi-arch aware yet, it is guaranteed to only hold the OS part here.
 		return d.builder.options.Platform
 	default:
-		return runtime.GOOS
+		return "" // Auto-select
 	}
 }
 
@@ -248,9 +248,9 @@ func (d *dispatchRequest) getImageOrStage(name string, stageOS string) (builder.
 		imageImage.OS = runtime.GOOS
 		if runtime.GOOS == "windows" {
 			switch os {
-			case "windows", "":
+			case "windows":
 				return nil, errors.New("Windows does not support FROM scratch")
-			case "linux":
+			case "linux", "":
 				if !system.LCOWSupported() {
 					return nil, errors.New("Linux containers are not supported on this system")
 				}

--- a/daemon/images/image_builder.go
+++ b/daemon/images/image_builder.go
@@ -166,7 +166,7 @@ func (i *ImageService) pullForBuilder(ctx context.Context, name string, authConf
 // Every call to GetImageAndReleasableLayer MUST call releasableLayer.Release() to prevent
 // leaking of layers.
 func (i *ImageService) GetImageAndReleasableLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (builder.Image, builder.ROLayer, error) {
-	if refOrID == "" {
+	if refOrID == "" { // ie FROM scratch
 		if !system.IsOSSupported(opts.OS) {
 			return nil, nil, system.ErrNotSupportedOperatingSystem
 		}

--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -2,7 +2,6 @@ package images // import "github.com/docker/docker/daemon/images"
 
 import (
 	"io"
-	"runtime"
 	"strings"
 
 	dist "github.com/docker/distribution"
@@ -60,11 +59,6 @@ func (i *ImageService) pullImageWithReference(ctx context.Context, ref reference
 		progressutils.WriteDistributionProgress(cancelFunc, outStream, progressChan)
 		close(writesDone)
 	}()
-
-	// Default to the host OS platform in case it hasn't been populated with an explicit value.
-	if os == "" {
-		os = runtime.GOOS
-	}
 
 	imagePullConfig := &distribution.ImagePullConfig{
 		Config: distribution.Config{

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -2,7 +2,6 @@ package distribution // import "github.com/docker/docker/distribution"
 
 import (
 	"fmt"
-	"runtime"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api"
@@ -113,11 +112,6 @@ func Pull(ctx context.Context, ref reference.Named, imagePullConfig *ImagePullCo
 		if err != nil {
 			lastErr = err
 			continue
-		}
-
-		// Make sure we default the OS if it hasn't been supplied
-		if imagePullConfig.OS == "" {
-			imagePullConfig.OS = runtime.GOOS
 		}
 
 		if err := puller.Pull(ctx, ref, imagePullConfig.OS); err != nil {

--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -16,13 +16,13 @@ func (ld *v2LayerDescriptor) open(ctx context.Context) (distribution.ReadSeekClo
 	return blobs.Open(ctx, ld.digest)
 }
 
-func filterManifests(manifests []manifestlist.ManifestDescriptor, os string) []manifestlist.ManifestDescriptor {
+func filterManifests(manifests []manifestlist.ManifestDescriptor, _ string) []manifestlist.ManifestDescriptor {
 	var matches []manifestlist.ManifestDescriptor
 	for _, manifestDescriptor := range manifests {
-		if manifestDescriptor.Platform.Architecture == runtime.GOARCH && manifestDescriptor.Platform.OS == os {
+		if manifestDescriptor.Platform.Architecture == runtime.GOARCH && manifestDescriptor.Platform.OS == runtime.GOOS {
 			matches = append(matches, manifestDescriptor)
 
-			logrus.Debugf("found match for %s/%s with media type %s, digest %s", os, runtime.GOARCH, manifestDescriptor.MediaType, manifestDescriptor.Digest.String())
+			logrus.Debugf("found match for %s/%s with media type %s, digest %s", runtime.GOOS, runtime.GOARCH, manifestDescriptor.MediaType, manifestDescriptor.Digest.String())
 		}
 	}
 	return matches

--- a/distribution/pull_v2_windows.go
+++ b/distribution/pull_v2_windows.go
@@ -62,24 +62,27 @@ func (ld *v2LayerDescriptor) open(ctx context.Context) (distribution.ReadSeekClo
 	return rsc, err
 }
 
-func filterManifests(manifests []manifestlist.ManifestDescriptor, os string) []manifestlist.ManifestDescriptor {
-	osVersion := ""
-	if os == "windows" {
-		version := system.GetOSVersion()
-		osVersion = fmt.Sprintf("%d.%d.%d", version.MajorVersion, version.MinorVersion, version.Build)
-		logrus.Debugf("will prefer entries with version %s", osVersion)
-	}
+func filterManifests(manifests []manifestlist.ManifestDescriptor, requestedOS string) []manifestlist.ManifestDescriptor {
+	version := system.GetOSVersion()
+	osVersion := fmt.Sprintf("%d.%d.%d", version.MajorVersion, version.MinorVersion, version.Build)
+	logrus.Debugf("will prefer Windows entries with version %s", osVersion)
 
 	var matches []manifestlist.ManifestDescriptor
+	foundWindowsMatch := false
 	for _, manifestDescriptor := range manifests {
-		if manifestDescriptor.Platform.Architecture == runtime.GOARCH && manifestDescriptor.Platform.OS == os {
+		if (manifestDescriptor.Platform.Architecture == runtime.GOARCH) &&
+			((requestedOS != "" && manifestDescriptor.Platform.OS == requestedOS) || // Explicit user request for an OS we know we support
+				(requestedOS == "" && system.IsOSSupported(manifestDescriptor.Platform.OS))) { // No user requested OS, but one we can support
 			matches = append(matches, manifestDescriptor)
-			logrus.Debugf("found match for %s/%s %s with media type %s, digest %s", os, runtime.GOARCH, manifestDescriptor.Platform.OSVersion, manifestDescriptor.MediaType, manifestDescriptor.Digest.String())
+			logrus.Debugf("found match %s/%s %s with media type %s, digest %s", manifestDescriptor.Platform.OS, runtime.GOARCH, manifestDescriptor.Platform.OSVersion, manifestDescriptor.MediaType, manifestDescriptor.Digest.String())
+			if strings.EqualFold("windows", manifestDescriptor.Platform.OS) {
+				foundWindowsMatch = true
+			}
 		} else {
-			logrus.Debugf("ignoring %s/%s %s with media type %s, digest %s", os, runtime.GOARCH, manifestDescriptor.Platform.OSVersion, manifestDescriptor.MediaType, manifestDescriptor.Digest.String())
+			logrus.Debugf("ignoring %s/%s %s with media type %s, digest %s", manifestDescriptor.Platform.OS, manifestDescriptor.Platform.Architecture, manifestDescriptor.Platform.OSVersion, manifestDescriptor.MediaType, manifestDescriptor.Digest.String())
 		}
 	}
-	if os == "windows" {
+	if foundWindowsMatch {
 		sort.Stable(manifestsByVersion{osVersion, matches})
 	}
 	return matches

--- a/image/store.go
+++ b/image/store.go
@@ -76,7 +76,8 @@ func (is *store) restore() error {
 		var l layer.Layer
 		if chainID := img.RootFS.ChainID(); chainID != "" {
 			if !system.IsOSSupported(img.OperatingSystem()) {
-				return system.ErrNotSupportedOperatingSystem
+				logrus.Errorf("not restoring image with unsupported operating system %v, %v, %s", dgst, chainID, img.OperatingSystem())
+				return nil
 			}
 			l, err = is.lss[img.OperatingSystem()].Get(chainID)
 			if err != nil {

--- a/pkg/system/lcow.go
+++ b/pkg/system/lcow.go
@@ -59,10 +59,10 @@ func ParsePlatform(in string) *specs.Platform {
 
 // IsOSSupported determines if an operating system is supported by the host
 func IsOSSupported(os string) bool {
-	if runtime.GOOS == os {
+	if strings.EqualFold(runtime.GOOS, os) {
 		return true
 	}
-	if LCOWSupported() && os == "linux" {
+	if LCOWSupported() && strings.EqualFold(os, "linux") {
 		return true
 	}
 	return false


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes #36560

Addresses https://github.com/moby/moby/pull/35089#issuecomment-367816124 and https://github.com/moby/moby/pull/35089#issuecomment-367802698. 

With this PR, an LCOW daemon will choose to pull the Linux image (both for multi-manifest and single tag images) if

- The daemon is obviously in LCOW mode
- No API flag has been added to indicate an explicit platform
- In the case of the builder, no explicit platform indicator in the FROM statement
- No matching Windows image exists if multi-manifest

So for example:

```
PS E:\docker\build\nyan> docker pull busybox
Using default tag: latest
latest: Pulling from library/busybox
57310166fe88: Pull complete
Digest: sha256:1669a6aa7350e1cdd28f972ddad5aceba2912f589f19a090ac75b7083da748db
Status: Downloaded newer image for busybox:latest
```

```
PS E:\docker\build\nyan> docker run --rm busybox uname -r; docker rmi busybox
Unable to find image 'busybox:latest' locally
latest: Pulling from library/busybox
57310166fe88: Pull complete
Digest: sha256:1669a6aa7350e1cdd28f972ddad5aceba2912f589f19a090ac75b7083da748db
Status: Downloaded newer image for busybox:latest
4.14.29-linuxkit
Untagged: busybox:latest
Untagged: busybox@sha256:1669a6aa7350e1cdd28f972ddad5aceba2912f589f19a090ac75b7083da748db
Deleted: sha256:5b0d59026729b68570d99bc4f3f7c31a2e4f2a5736435641565d93e7c25bd2c3
Deleted: sha256:4febd3792a1fb2153108b4fa50161c6ee5e3d16aa483a63215f936a113a88e9a
PS E:\docker\build\nyan>
```

```
PS E:\docker\build\nyan> docker create ubuntu sh
Unable to find image 'ubuntu:latest' locally
latest: Pulling from library/ubuntu
1be7f2b886e8: Pull complete
6fbc4a21b806: Pull complete
c71a6f8e1378: Pull complete
4be3072e5a37: Pull complete
06c6d2f59700: Pull complete
Digest: sha256:e27e9d7f7f28d67aa9e2d7540bdc2b33254b452ee8e60f388875e5b7d9b2b696
Status: Downloaded newer image for ubuntu:latest
285bc85171a6e97d82852fedc614a99b5913fe6df5d253722bd7f24b42d54d64
PS E:\docker\build\nyan> docker inspect -f "{{.Os}}" ubuntu
linux
PS E:\docker\build\nyan>
```


```
PS E:\docker\build\nyan> type dockerfile
FROM supertest2014/nyan
ADD Dockerfile /
PS E:\docker\build\nyan> docker build .
e472211e4879: Pull complete
bba4bc236bcb: Pull complete
9d52b79a9349: Pull complete
c1f720c0024d: Pull complete
Digest: sha256:757f8da8d28e0ac8b1ddda3e8082acf94216b5dc719f6df71d92fe87a782648f 557.1kB/67.49MB
Status: Downloaded newer image for supertest2014/nyan:latest
 ---> 3dd6111154fcload complete
Step 2/2 : ADD Dockerfile /lete
 ---> 9676ceb6201b
Successfully built 9676ceb6201b
PS E:\docker\build\nyan>
```

Note microsoft/dotnet has both Linux and multiple Windows images in it's manifest list, so it should pull the best matching Windows image, not the Linux one.
```
PS E:\docker\build\dotnet> docker pull microsoft/dotnet
Using default tag: latest
latest: Pulling from microsoft/dotnet
407ada6e90de: Pull complete
3cb15ab58a2c: Pull complete
7d9a060b42e0: Pull complete
ebf9532b71d2: Pull complete
b070f5627406: Pull complete
a8c0bb44ce47: Pull complete
255a996d7ecd: Pull complete
fb09697854d5: Pull complete
Digest: sha256:c5916d40aa6b210fa7e587bf4cb890615177e70ab4196d702e29addd3a29ffdc
Status: Downloaded newer image for microsoft/dotnet:latest
PS E:\docker\build\dotnet> docker inspect -f "{{.Os}}" microsoft/dotnet
windows
PS E:\docker\build\dotnet>
```

And the above through the builder
```
PS E:\docker\build\dotnet> type dockerfile
FROM microsoft/dotnet
ENV foo=bar
PS E:\docker\build\dotnet> docker build .
Sending build context to Docker daemon  2.048kB
Step 1/2 : FROM microsoft/dotnet
latest: Pulling from microsoft/dotnet
407ada6e90de: Pull complete
3cb15ab58a2c: Pull complete
7d9a060b42e0: Pull complete
ebf9532b71d2: Pull complete
b070f5627406: Pull complete
a8c0bb44ce47: Pull complete
255a996d7ecd: Pull complete
fb09697854d5: Pull complete
Digest: sha256:c5916d40aa6b210fa7e587bf4cb890615177e70ab4196d702e29addd3a29ffdc
Status: Downloaded newer image for microsoft/dotnet:latest
 ---> 0e25af8b4121
Step 2/2 : ENV foo=bar
 ---> Running in e54406702885
Removing intermediate container e54406702885
 ---> b3f1d2bcdc14
Successfully built b3f1d2bcdc14
PS E:\docker\build\dotnet> docker inspect -f "{{.Os}}" b3f1d
windows
PS E:\docker\build\dotnet>
```

And an explicit Linux request of microsoft/dotnet
```
PS E:\docker\build\dotnet> type dockerfile
FROM --platform=linux microsoft/dotnet
ENV foo=bar
PS E:\docker\build\dotnet> docker build .
Sending build context to Docker daemon  2.048kB
Step 1/2 : FROM --platform=linux microsoft/dotnet
latest: Pulling from microsoft/dotnet
3e731ddb7fc9: Pull complete
47cafa6a79d0: Pull complete
79fcf5a213c7: Pull complete
68e99216b7ad: Pull complete
0bb6c6c2d2ad: Pull complete
11ab17bd0b71: Pull complete
181624c7f5b3: Pull complete
Digest: sha256:c5916d40aa6b210fa7e587bf4cb890615177e70ab4196d702e29addd3a29ffdc
Status: Downloaded newer image for microsoft/dotnet:latest
 ---> 9969575612df
Step 2/2 : ENV foo=bar
 ---> Running in efbed1aa945f
Removing intermediate container efbed1aa945f
 ---> 17db0ce2d48d
Successfully built 17db0ce2d48d
PS E:\docker\build\dotnet> docker inspect -f "{{.Os}}" microsoft/dotnet
linux
PS E:\docker\build\dotnet>
```

And using scratch
```
PS E:\docker\build\scratch> type dockerfile
FROM scratch
ADD testfile.txt /
PS E:\docker\build\scratch> docker build .
Sending build context to Docker daemon    810kB
Step 1/2 : FROM scratch
 --->
Step 2/2 : ADD testfile.txt /
 ---> 6281659d3b21
Successfully built 6281659d3b21
PS E:\docker\build\scratch> docker inspect -f "{{.Os}}" 6281
linux
PS E:\docker\build\scratch>
```
