### PR TITLE
Follow-up fixes on multi-stage moby's Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -242,7 +242,6 @@ COPY --from=runc /opt/runc/ /usr/local/bin/
 COPY --from=containerd /opt/containerd/ /usr/local/bin/
 COPY --from=proxy /opt/proxy/ /usr/local/bin/
 COPY --from=dockercli /opt/dockercli /usr/local/cli
-COPY --from=golang /usr/local/go /usr/local/go
 COPY --from=registry /usr/local/bin/registry* /usr/local/bin/
 COPY --from=notary /usr/local/bin/notary* /usr/local/bin/
 COPY --from=criu /opt/criu/ /usr/local/


### PR DESCRIPTION
- Do not copy golang in itself (`runtime-dev` is already base on `golang`)
- Use `golang` official image as base (instead of `debian:stretch` and installing go manually)

This is gonna affect the cache quite a lot (because well, it's updating the base image for almost everything 😅 )

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
