### PR TITLE
Add "secret" as allowed build args

### DIFF
--- a/builder/dockerfile/buildargs.go
+++ b/builder/dockerfile/buildargs.go
@@ -19,6 +19,8 @@ var builtinAllowedBuildArgs = map[string]bool{
 	"ftp_proxy":   true,
 	"NO_PROXY":    true,
 	"no_proxy":    true,
+	"SECRET":      true,
+	"secret":      true,
 }
 
 // buildArgs manages arguments used by the builder


### PR DESCRIPTION
Signed-off-by: Manabu Sakai <rea.527@gmail.com>

**- What I did**

Added build-args to pass secrets variable when `docker build`.

I want to improve this.

> Warning: It is not recommended to use build-time variables for passing secrets like github keys, user credentials etc. Build-time variable values are visible to any user of the image with the `docker history` command.

ref: https://docs.docker.com/engine/reference/builder/#arg

**- How I did it**

Added `SECRET` and `secret` to `builtinAllowedBuildArgs`.

**- How to verify it**

Dockerfile:
```
FROM ubuntu
RUN echo ${SECRET}
```

Then,
```
$ docker build -t build-args-test . --build-arg SECRET=secret-string
$ docker history build-args-test
```

**- Description for the changelog**

The `SECRET` and `secret` of `--build-arg` are no longer displayed in docker image history.

**- A picture of a cute animal (not mandatory but encouraged)**

![dsc_0755](https://user-images.githubusercontent.com/2246869/36795157-a1fd4b06-1ce5-11e8-9d6f-70a924cc6728.jpg)

ref: http://blog.pokkeboy.com/about