### PR TITLE
Bump Runc to 1.0.0-rc5

### DIFF
--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # When updating RUNC_COMMIT, also update runc in vendor.conf accordingly
-RUNC_COMMIT=6c55f98695e902427906eed2c799e566e3d3dfb5
+RUNC_COMMIT=4fc53a81fb7c994640722ac585fa9ca548971871
 
 install_runc() {
 	# Do not build with ambient capabilities support

--- a/vendor.conf
+++ b/vendor.conf
@@ -72,7 +72,7 @@ github.com/pborman/uuid v1.0
 google.golang.org/grpc v1.3.0
 
 # When updating, also update RUNC_COMMIT in hack/dockerfile/install/runc accordingly
-github.com/opencontainers/runc 6c55f98695e902427906eed2c799e566e3d3dfb5
+github.com/opencontainers/runc 4fc53a81fb7c994640722ac585fa9ca548971871
 github.com/opencontainers/runtime-spec v1.0.1
 github.com/opencontainers/image-spec v1.0.1
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0

--- a/vendor.conf
+++ b/vendor.conf
@@ -114,7 +114,7 @@ github.com/containerd/containerd 3fa104f843ec92328912e042b767d26825f202aa
 github.com/containerd/fifo fbfb6a11ec671efbe94ad1c12c2e98773f19e1e6
 github.com/containerd/continuity d8fb8589b0e8e85b8c8bbaa8840226d0dfeb7371
 github.com/containerd/cgroups c0710c92e8b3a44681d1321dcfd1360fc5c6c089
-github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
+github.com/containerd/console 2748ece16665b45a47f884001d5831ec79703880
 github.com/containerd/go-runc 4f6e87ae043f859a38255247b49c9abc262d002f
 github.com/containerd/typeurl f6943554a7e7e88b3c14aad190bf05932da84788
 github.com/dmcgowan/go-tar go1.10

--- a/vendor/github.com/containerd/console/tc_linux.go
+++ b/vendor/github.com/containerd/console/tc_linux.go
@@ -13,25 +13,21 @@ const (
 	cmdTcSet = unix.TCSETS
 )
 
-func ioctl(fd, flag, data uintptr) error {
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, fd, flag, data); err != 0 {
+// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
+// unlockpt should be called before opening the slave side of a pty.
+func unlockpt(f *os.File) error {
+	var u int32
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&u))); err != 0 {
 		return err
 	}
 	return nil
 }
 
-// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
-// unlockpt should be called before opening the slave side of a pty.
-func unlockpt(f *os.File) error {
-	var u int32
-	return ioctl(f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&u)))
-}
-
 // ptsname retrieves the name of the first available pts for the given master.
 func ptsname(f *os.File) (string, error) {
-	n, err := unix.IoctlGetInt(int(f.Fd()), unix.TIOCGPTN)
-	if err != nil {
+	var u uint32
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.TIOCGPTN, uintptr(unsafe.Pointer(&u))); err != 0 {
 		return "", err
 	}
-	return fmt.Sprintf("/dev/pts/%d", n), nil
+	return fmt.Sprintf("/dev/pts/%d", u), nil
 }

--- a/vendor/github.com/opencontainers/runc/README.md
+++ b/vendor/github.com/opencontainers/runc/README.md
@@ -41,7 +41,17 @@ make
 sudo make install
 ```
 
+You can also use `go get` to install to your `GOPATH`, assuming that you have a `github.com` parent folder already created under `src`:
+
+```bash
+go get github.com/opencontainers/runc
+cd $GOPATH/src/github.com/opencontainers/runc
+make
+sudo make install
+```
+
 `runc` will be installed to `/usr/local/sbin/runc` on your system.
+
 
 #### Build Tags
 

--- a/vendor/github.com/opencontainers/runc/vendor.conf
+++ b/vendor/github.com/opencontainers/runc/vendor.conf
@@ -21,5 +21,5 @@ github.com/urfave/cli d53eb991652b1d438abdd34ce4bfa3ef1539108e
 golang.org/x/sys 7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce https://github.com/golang/sys
 
 # console dependencies
-github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
+github.com/containerd/console 2748ece16665b45a47f884001d5831ec79703880
 github.com/pkg/errors v0.8.0


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/36446
fixes https://github.com/moby/moby/issues/36457
fixes https://github.com/moby/moby/issues/36467
fixes https://github.com/moby/moby/issues/36628
fixes https://github.com/docker/for-linux/issues/238
fixes https://github.com/docker/for-linux/issues/228

Bump Runc to [1.0.0-rc5](https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc5) / [4fc53a81fb7c994640722ac585fa9ca548971871](https://github.com/opencontainers/runc/commit/4fc53a81fb7c994640722ac585fa9ca548971871)

Release notes: https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc5

Full diff: https://github.com/opencontainers/runc/compare/6c55f98695e902427906eed2c799e566e3d3dfb5...4fc53a81fb7c994640722ac585fa9ca548971871


Possibly relevant changes included:

- https://github.com/opencontainers/runc/pull/1702 chroot when no mount namespaces is provided
- https://github.com/opencontainers/runc/pull/1722 fix systemd slice expansion so that it could be consumed by cAdvisor
- https://github.com/opencontainers/runc/pull/1724 libcontainer/capabilities_linux: Drop os.Getpid() call
- https://github.com/opencontainers/runc/pull/1727 Update console dependency to fix runc exec on BE (causing: `container_linux.go:265: starting container process caused "open /dev/pts/4294967296: no such file or directory"`)
- https://github.com/opencontainers/runc/pull/1743 libcontainer: setupUserNamespace is always called (fixes: Devices are mounted with wrong uid/gid)

