### PR TITLE
Windows: Report Version and UBR

### DIFF
--- a/pkg/parsers/operatingsystem/operatingsystem_windows.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_windows.go
@@ -1,44 +1,45 @@
 package operatingsystem // import "github.com/docker/docker/pkg/parsers/operatingsystem"
 
 import (
-	"unsafe"
+	"fmt"
 
-	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
 )
-
-// See https://code.google.com/p/go/source/browse/src/pkg/mime/type_windows.go?r=d14520ac25bf6940785aabb71f5be453a286f58c
-// for a similar sample
 
 // GetOperatingSystem gets the name of the current operating system.
 func GetOperatingSystem() (string, error) {
 
-	var h windows.Handle
-
 	// Default return value
 	ret := "Unknown Operating System"
 
-	if err := windows.RegOpenKeyEx(windows.HKEY_LOCAL_MACHINE,
-		windows.StringToUTF16Ptr(`SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\`),
-		0,
-		windows.KEY_READ,
-		&h); err != nil {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\WIndows NT\CurrentVersion`, registry.QUERY_VALUE)
+	if err != nil {
 		return ret, err
 	}
-	defer windows.RegCloseKey(h)
+	defer k.Close()
 
-	var buf [1 << 10]uint16
-	var typ uint32
-	n := uint32(len(buf) * 2) // api expects array of bytes, not uint16
-
-	if err := windows.RegQueryValueEx(h,
-		windows.StringToUTF16Ptr("ProductName"),
-		nil,
-		&typ,
-		(*byte)(unsafe.Pointer(&buf[0])),
-		&n); err != nil {
+	pn, _, err := k.GetStringValue("ProductName")
+	if err != nil {
 		return ret, err
 	}
-	ret = windows.UTF16ToString(buf[:])
+	ret = pn
+
+	ri, _, err := k.GetStringValue("ReleaseId")
+	if err != nil {
+		return ret, err
+	}
+	ret = fmt.Sprintf("%s Version %s", ret, ri)
+
+	cbn, _, err := k.GetStringValue("CurrentBuildNumber")
+	if err != nil {
+		return ret, err
+	}
+
+	ubr, _, err := k.GetIntegerValue("UBR")
+	if err != nil {
+		return ret, err
+	}
+	ret = fmt.Sprintf("%s (OS Build %s.%d)", ret, cbn, ubr)
 
 	return ret, nil
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@johnstep as talked about offline. Reports back the ReleaseID (aka Version) and UBR in the operating system string reported by Docker Info.  Also switches this to use the golang built in registry reader rather than direct API while I was there.

```
…
Default Isolation: process
Kernel Version: 10.0 17111 (17111.1.amd64fre.rs4_release.180226-1411)
Operating System: Windows Server Datacenter Version 1803, Update Build Revision 1
OSType: windows
Architecture: x86_64
CPUs: 8
…
```
