### PR TITLE
Migrate export tests to api tests

### DIFF
--- a/integration-cli/docker_cli_export_import_test.go
+++ b/integration-cli/docker_cli_export_import_test.go
@@ -9,25 +9,8 @@ import (
 	"github.com/gotestyourself/gotestyourself/icmd"
 )
 
-// export an image and try to import it into a new one
-func (s *DockerSuite) TestExportContainerAndImportImage(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	containerID := "testexportcontainerandimportimage"
-
-	dockerCmd(c, "run", "--name", containerID, "busybox", "true")
-
-	out, _ := dockerCmd(c, "export", containerID)
-
-	result := icmd.RunCmd(icmd.Cmd{
-		Command: []string{dockerBinary, "import", "-", "repo/testexp:v1"},
-		Stdin:   strings.NewReader(out),
-	})
-	result.Assert(c, icmd.Success)
-
-	cleanedImageID := strings.TrimSpace(result.Combined())
-	c.Assert(cleanedImageID, checker.Not(checker.Equals), "", check.Commentf("output should have been an image id"))
-}
-
+// TODO: Move this test to docker/cli, as it is essentially the same test
+// as TestExportContainerAndImportImage except output to a file.
 // Used to test output flag in the export command
 func (s *DockerSuite) TestExportContainerWithOutputAndImportImage(c *check.C) {
 	testRequires(c, DaemonIsLinux)

--- a/integration/container/export_test.go
+++ b/integration/container/export_test.go
@@ -1,0 +1,53 @@
+package container // import "github.com/docker/docker/integration/container"
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/integration/internal/request"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/gotestyourself/gotestyourself/poll"
+	"github.com/gotestyourself/gotestyourself/skip"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// export an image and try to import it into a new one
+func TestExportContainerAndImportImage(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+
+	defer setupTest(t)()
+	client := request.NewAPIClient(t)
+	ctx := context.Background()
+
+	cID := container.Run(t, ctx, client, container.WithCmd("true"))
+	poll.WaitOn(t, container.IsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
+
+	reference := "repo/testexp:v1"
+	exportResp, err := client.ContainerExport(ctx, cID)
+	require.NoError(t, err)
+	importResp, err := client.ImageImport(ctx, types.ImageImportSource{
+		Source:     exportResp,
+		SourceName: "-",
+	}, reference, types.ImageImportOptions{})
+	require.NoError(t, err)
+
+	// If the import is successfully, then the message output should contain
+	// the image ID and match with the output from `docker images`.
+
+	dec := json.NewDecoder(importResp)
+	var jm jsonmessage.JSONMessage
+	err = dec.Decode(&jm)
+	require.NoError(t, err)
+
+	images, err := client.ImageList(ctx, types.ImageListOptions{
+		Filters: filters.NewArgs(filters.Arg("reference", reference)),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, jm.Status, images[0].ID)
+}


### PR DESCRIPTION
This fix migrates export tests in integration-cli to api tests.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
