### PR TITLE
Add missing canonical import comment to files in integration tests

### DIFF
--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -1,4 +1,4 @@
-package config
+package config // import "github.com/docker/docker/integration/config"
 
 import (
 	"bytes"

--- a/integration/config/main_test.go
+++ b/integration/config/main_test.go
@@ -1,4 +1,4 @@
-package config
+package config // import "github.com/docker/docker/integration/config"
 
 import (
 	"fmt"

--- a/integration/container/daemon_linux_test.go
+++ b/integration/container/daemon_linux_test.go
@@ -1,4 +1,4 @@
-package container
+package container // import "github.com/docker/docker/integration/container"
 
 import (
 	"context"

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -1,4 +1,4 @@
-package container
+package container // import "github.com/docker/docker/integration/container"
 
 import (
 	"context"

--- a/integration/container/logs_test.go
+++ b/integration/container/logs_test.go
@@ -1,4 +1,4 @@
-package container
+package container // import "github.com/docker/docker/integration/container"
 
 import (
 	"context"

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -1,4 +1,4 @@
-package container
+package container // import "github.com/docker/docker/integration/container"
 
 import (
 	"bytes"

--- a/integration/secret/main_test.go
+++ b/integration/secret/main_test.go
@@ -1,4 +1,4 @@
-package secret
+package secret // import "github.com/docker/docker/integration/secret"
 
 import (
 	"fmt"

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -1,4 +1,4 @@
-package secret
+package secret // import "github.com/docker/docker/integration/secret"
 
 import (
 	"bytes"

--- a/integration/system/info_test.go
+++ b/integration/system/info_test.go
@@ -1,4 +1,4 @@
-package system
+package system // import "github.com/docker/docker/integration/system"
 
 import (
 	"fmt"


### PR DESCRIPTION
The  canonical import comment was added some time ago, though several
newly added files do not have the comment. This fix adds the missing
canonical import comment to files in integration tests

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
