### PR TITLE
Fixes some integration/container tests to run on remote daemon

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -85,7 +85,7 @@ type DockerSuite struct {
 }
 
 func (s *DockerSuite) OnTimeout(c *check.C) {
-	if !testEnv.IsLocalDaemon() {
+	if testEnv.IsRemoteDaemon() {
 		return
 	}
 	path := filepath.Join(os.Getenv("DEST"), "docker.pid")

--- a/integration/container/daemon_linux_test.go
+++ b/integration/container/daemon_linux_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/integration/internal/container"
+	"github.com/gotestyourself/gotestyourself/skip"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
 )
@@ -26,6 +27,7 @@ import (
 // the container process, then start dockerd back up and attempt to start the
 // container again.
 func TestContainerStartOnDaemonRestart(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon(), "cannot start daemon on remote test run")
 	t.Parallel()
 
 	d := daemon.New(t, "", "dockerd", daemon.Config{})

--- a/integration/container/links_linux_test.go
+++ b/integration/container/links_linux_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestLinksEtcHostsContentMatch(t *testing.T) {
-	skip.If(t, !testEnv.IsLocalDaemon())
+	skip.If(t, testEnv.IsRemoteDaemon())
 
 	hosts, err := ioutil.ReadFile("/etc/hosts")
 	skip.If(t, os.IsNotExist(err))

--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestContainerShmNoLeak(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon(), "cannot start daemon on remote test run")
 	t.Parallel()
 	d := daemon.New(t, "docker", "dockerd", daemon.Config{})
 	client, err := d.NewClient()
@@ -94,7 +95,7 @@ func TestContainerShmNoLeak(t *testing.T) {
 
 func TestContainerNetworkMountsNoChown(t *testing.T) {
 	// chown only applies to Linux bind mounted volumes; must be same host to verify
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux" || !testEnv.IsLocalDaemon())
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux" || testEnv.IsRemoteDaemon())
 
 	defer setupTest(t)()
 

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestNetworkNat(t *testing.T) {
-	skip.If(t, !testEnv.IsLocalDaemon())
+	skip.If(t, testEnv.IsRemoteDaemon())
 
 	defer setupTest(t)()
 
@@ -40,7 +40,7 @@ func TestNetworkNat(t *testing.T) {
 }
 
 func TestNetworkLocalhostTCPNat(t *testing.T) {
-	skip.If(t, !testEnv.IsLocalDaemon())
+	skip.If(t, testEnv.IsRemoteDaemon())
 
 	defer setupTest(t)()
 
@@ -57,7 +57,7 @@ func TestNetworkLocalhostTCPNat(t *testing.T) {
 }
 
 func TestNetworkLoopbackNat(t *testing.T) {
-	skip.If(t, !testEnv.IsLocalDaemon())
+	skip.If(t, testEnv.IsRemoteDaemon())
 
 	msg := "it works"
 	startServerContainer(t, msg, 8080)

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -25,20 +25,19 @@ func TestPause(t *testing.T) {
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
 
-	name := "testeventpause"
-	cID := container.Run(t, ctx, client, container.WithName(name))
+	cID := container.Run(t, ctx, client)
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	since := request.DaemonUnixTime(ctx, t, client, testEnv)
 
-	err := client.ContainerPause(ctx, name)
+	err := client.ContainerPause(ctx, cID)
 	require.NoError(t, err)
 
 	inspect, err := client.ContainerInspect(ctx, cID)
 	require.NoError(t, err)
 	assert.Equal(t, inspect.State.Paused, true)
 
-	err = client.ContainerUnpause(ctx, name)
+	err = client.ContainerUnpause(ctx, cID)
 	require.NoError(t, err)
 
 	until := request.DaemonUnixTime(ctx, t, client, testEnv)
@@ -46,7 +45,7 @@ func TestPause(t *testing.T) {
 	messages, errs := client.Events(ctx, types.EventsOptions{
 		Since:   since,
 		Until:   until,
-		Filters: filters.NewArgs(filters.Arg("container", name)),
+		Filters: filters.NewArgs(filters.Arg("container", cID)),
 	})
 	assert.Equal(t, getEventActions(t, messages, errs), []string{"pause", "unpause"})
 }

--- a/integration/container/remove_test.go
+++ b/integration/container/remove_test.go
@@ -27,7 +27,7 @@ func getPrefixAndSlashFromDaemonPlatform() (prefix, slash string) {
 
 // Test case for #5244: `docker rm` fails if bind dir doesn't exist anymore
 func TestRemoveContainerWithRemovedVolume(t *testing.T) {
-	skip.If(t, !testEnv.IsLocalDaemon())
+	skip.If(t, testEnv.IsRemoteDaemon())
 
 	defer setupTest(t)()
 	ctx := context.Background()

--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration-cli/daemon"
+	"github.com/gotestyourself/gotestyourself/skip"
 )
 
 func TestDaemonRestartKillContainers(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon(), "cannot start daemon on remote test run")
 	type testCase struct {
 		desc       string
 		config     *container.Config

--- a/integration/service/inspect_test.go
+++ b/integration/service/inspect_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestInspect(t *testing.T) {
-	skip.IfCondition(t, !testEnv.IsLocalDaemon())
+	skip.IfCondition(t, testEnv.IsRemoteDaemon())
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)

--- a/internal/test/environment/environment.go
+++ b/internal/test/environment/environment.go
@@ -96,7 +96,7 @@ func toSlash(path string) string {
 }
 
 // IsLocalDaemon is true if the daemon under test is on the same
-// host as the CLI.
+// host as the test process.
 //
 // Deterministically working out the environment in which CI is running
 // to evaluate whether the daemon is local or remote is not possible through
@@ -113,6 +113,12 @@ func toSlash(path string) string {
 // a Linux CLI (built with the daemon tag) against a Windows daemon.
 func (e *Execution) IsLocalDaemon() bool {
 	return os.Getenv("DOCKER_REMOTE_DAEMON") == ""
+}
+
+// IsRemoteDaemon is true if the daemon under test is on different host
+// as the test process.
+func (e *Execution) IsRemoteDaemon() bool {
+	return !e.IsLocalDaemon()
 }
 
 // Print the execution details to stdout


### PR DESCRIPTION
```
docker build -f Dockerfile.e2e -t moby-e2e .
docker run -v /var/run/docker.sock:/var/run/docker.sock \
           -e TEST_INTEGRATION_DIR=/tests/integration/container \
           -e DOCKER_API_VERSION=1.36 moby-e2e
# […]
PASS
# […]
```

🦁 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
