### PR TITLE
Improvement in integration tests

### DIFF
--- a/integration/container/logs_test.go
+++ b/integration/container/logs_test.go
@@ -20,7 +20,6 @@ func TestLogsFollowTailEmpty(t *testing.T) {
 	ctx := context.Background()
 
 	id := container.Run(t, ctx, client, container.WithCmd("sleep", "100000"))
-	defer client.ContainerRemove(ctx, id, types.ContainerRemoveOptions{Force: true})
 
 	logs, err := client.ContainerLogs(ctx, id, types.ContainerLogsOptions{ShowStdout: true, Tail: "2"})
 	if logs != nil {

--- a/integration/image/commit_test.go
+++ b/integration/image/commit_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/request"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,10 +16,9 @@ func TestCommitInheritsEnv(t *testing.T) {
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
 
-	createResp1, err := client.ContainerCreate(ctx, &container.Config{Image: "busybox"}, nil, nil, "")
-	require.NoError(t, err)
+	cID1 := container.Create(t, ctx, client)
 
-	commitResp1, err := client.ContainerCommit(ctx, createResp1.ID, types.ContainerCommitOptions{
+	commitResp1, err := client.ContainerCommit(ctx, cID1, types.ContainerCommitOptions{
 		Changes:   []string{"ENV PATH=/bin"},
 		Reference: "test-commit-image",
 	})
@@ -31,10 +30,9 @@ func TestCommitInheritsEnv(t *testing.T) {
 	expectedEnv1 := []string{"PATH=/bin"}
 	assert.Equal(t, expectedEnv1, image1.Config.Env)
 
-	createResp2, err := client.ContainerCreate(ctx, &container.Config{Image: image1.ID}, nil, nil, "")
-	require.NoError(t, err)
+	cID2 := container.Create(t, ctx, client, container.WithImage(image1.ID))
 
-	commitResp2, err := client.ContainerCommit(ctx, createResp2.ID, types.ContainerCommitOptions{
+	commitResp2, err := client.ContainerCommit(ctx, cID2, types.ContainerCommitOptions{
 		Changes:   []string{"ENV PATH=/usr/bin:$PATH"},
 		Reference: "test-commit-image",
 	})

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -22,6 +22,13 @@ func WithLinks(links ...string) func(*TestContainerConfig) {
 	}
 }
 
+// WithImage sets the image of the container
+func WithImage(image string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.Config.Image = image
+	}
+}
+
 // WithCmd sets the comannds of the container
 func WithCmd(cmds ...string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {


### PR DESCRIPTION
This fix adds several improvement:
1. No need for explicit ContainerRemove as it has been handled in setupTest()
2. Added `container.WithImage` helper function and used it in commit tests.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>