### PR TITLE
daemon/logger/ring.go: log error not instance

### DIFF
--- a/daemon/logger/ring.go
+++ b/daemon/logger/ring.go
@@ -93,7 +93,10 @@ func (r *RingLogger) Close() error {
 		}
 
 		if err := r.l.Log(msg); err != nil {
-			logrus.WithField("driver", r.l.Name()).WithField("container", r.logInfo.ContainerID).Errorf("Error writing log message: %v", r.l)
+			logrus.WithField("driver", r.l.Name()).
+				WithField("container", r.logInfo.ContainerID).
+				WithError(err).
+				Errorf("Error writing log message")
 			logErr = true
 		}
 	}
@@ -114,7 +117,10 @@ func (r *RingLogger) run() {
 			return
 		}
 		if err := r.l.Log(msg); err != nil {
-			logrus.WithField("driver", r.l.Name()).WithField("container", r.logInfo.ContainerID).Errorf("Error writing log message: %v", r.l)
+			logrus.WithField("driver", r.l.Name()).
+				WithField("container", r.logInfo.ContainerID).
+				WithError(err).
+				Errorf("Error writing log message")
 		}
 	}
 }


### PR DESCRIPTION
Log the error returned from logdriver.Log() instead of the logdriver
itself.

Signed-off-by: Cody Roseborough <crrosebo@amazon.com>