### PR TITLE
Change return for errdefs.getImplementer()

### DIFF
--- a/errdefs/defs.go
+++ b/errdefs/defs.go
@@ -35,7 +35,7 @@ type ErrForbidden interface {
 // ErrSystem signals that some internal error occurred.
 // An example of this would be a failed mount request.
 type ErrSystem interface {
-	ErrSystem()
+	System()
 }
 
 // ErrNotModified signals that an action can't be performed because it's already in the desired state

--- a/errdefs/helpers_test.go
+++ b/errdefs/helpers_test.go
@@ -179,3 +179,16 @@ func TestUnavailable(t *testing.T) {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 }
+
+func TestSystem(t *testing.T) {
+	if IsSystem(errTest) {
+		t.Fatalf("did not expect system error, got %T", errTest)
+	}
+	e := System(errTest)
+	if !IsSystem(e) {
+		t.Fatalf("expected system error, got %T", e)
+	}
+	if cause := e.(causal).Cause(); cause != errTest {
+		t.Fatalf("causual should be errTest, got: %v", cause)
+	}
+}

--- a/errdefs/helpers_test.go
+++ b/errdefs/helpers_test.go
@@ -12,6 +12,9 @@ type causal interface {
 }
 
 func TestNotFound(t *testing.T) {
+	if IsNotFound(errTest) {
+		t.Fatalf("did not expect not found error, got %T", errTest)
+	}
 	e := NotFound(errTest)
 	if !IsNotFound(e) {
 		t.Fatalf("expected not found error, got: %T", e)
@@ -22,6 +25,9 @@ func TestNotFound(t *testing.T) {
 }
 
 func TestConflict(t *testing.T) {
+	if IsConflict(errTest) {
+		t.Fatalf("did not expect conflcit error, got %T", errTest)
+	}
 	e := Conflict(errTest)
 	if !IsConflict(e) {
 		t.Fatalf("expected conflcit error, got: %T", e)
@@ -32,6 +38,9 @@ func TestConflict(t *testing.T) {
 }
 
 func TestForbidden(t *testing.T) {
+	if IsForbidden(errTest) {
+		t.Fatalf("did not expect forbidden error, got %T", errTest)
+	}
 	e := Forbidden(errTest)
 	if !IsForbidden(e) {
 		t.Fatalf("expected forbidden error, got: %T", e)
@@ -42,6 +51,9 @@ func TestForbidden(t *testing.T) {
 }
 
 func TestInvalidParameter(t *testing.T) {
+	if IsInvalidParameter(errTest) {
+		t.Fatalf("did not expect invalid argument error, got %T", errTest)
+	}
 	e := InvalidParameter(errTest)
 	if !IsInvalidParameter(e) {
 		t.Fatalf("expected invalid argument error, got %T", e)
@@ -52,6 +64,9 @@ func TestInvalidParameter(t *testing.T) {
 }
 
 func TestNotImplemented(t *testing.T) {
+	if IsNotImplemented(errTest) {
+		t.Fatalf("did not expect not implemented error, got %T", errTest)
+	}
 	e := NotImplemented(errTest)
 	if !IsNotImplemented(e) {
 		t.Fatalf("expected not implemented error, got %T", e)
@@ -62,6 +77,9 @@ func TestNotImplemented(t *testing.T) {
 }
 
 func TestNotModified(t *testing.T) {
+	if IsNotModified(errTest) {
+		t.Fatalf("did not expect not modified error, got %T", errTest)
+	}
 	e := NotModified(errTest)
 	if !IsNotModified(e) {
 		t.Fatalf("expected not modified error, got %T", e)
@@ -72,6 +90,9 @@ func TestNotModified(t *testing.T) {
 }
 
 func TestAlreadyExists(t *testing.T) {
+	if IsAlreadyExists(errTest) {
+		t.Fatalf("did not expect already exists error, got %T", errTest)
+	}
 	e := AlreadyExists(errTest)
 	if !IsAlreadyExists(e) {
 		t.Fatalf("expected already exists error, got %T", e)
@@ -82,6 +103,9 @@ func TestAlreadyExists(t *testing.T) {
 }
 
 func TestUnauthorized(t *testing.T) {
+	if IsUnauthorized(errTest) {
+		t.Fatalf("did not expect unauthorized error, got %T", errTest)
+	}
 	e := Unauthorized(errTest)
 	if !IsUnauthorized(e) {
 		t.Fatalf("expected unauthorized error, got %T", e)
@@ -92,6 +116,9 @@ func TestUnauthorized(t *testing.T) {
 }
 
 func TestUnknown(t *testing.T) {
+	if IsUnknown(errTest) {
+		t.Fatalf("did not expect unknown error, got %T", errTest)
+	}
 	e := Unknown(errTest)
 	if !IsUnknown(e) {
 		t.Fatalf("expected unknown error, got %T", e)
@@ -102,9 +129,12 @@ func TestUnknown(t *testing.T) {
 }
 
 func TestCancelled(t *testing.T) {
+	if IsCancelled(errTest) {
+		t.Fatalf("did not expect cancelled error, got %T", errTest)
+	}
 	e := Cancelled(errTest)
 	if !IsCancelled(e) {
-		t.Fatalf("expected canclled error, got %T", e)
+		t.Fatalf("expected cancelled error, got %T", e)
 	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
@@ -112,6 +142,9 @@ func TestCancelled(t *testing.T) {
 }
 
 func TestDeadline(t *testing.T) {
+	if IsDeadline(errTest) {
+		t.Fatalf("did not expect deadline error, got %T", errTest)
+	}
 	e := Deadline(errTest)
 	if !IsDeadline(e) {
 		t.Fatalf("expected deadline error, got %T", e)
@@ -121,10 +154,26 @@ func TestDeadline(t *testing.T) {
 	}
 }
 
-func TestIsDataLoss(t *testing.T) {
+func TestDataLoss(t *testing.T) {
+	if IsDataLoss(errTest) {
+		t.Fatalf("did not expect data loss error, got %T", errTest)
+	}
 	e := DataLoss(errTest)
 	if !IsDataLoss(e) {
 		t.Fatalf("expected data loss error, got %T", e)
+	}
+	if cause := e.(causal).Cause(); cause != errTest {
+		t.Fatalf("causual should be errTest, got: %v", cause)
+	}
+}
+
+func TestUnavailable(t *testing.T) {
+	if IsUnavailable(errTest) {
+		t.Fatalf("did not expect unavaillable error, got %T", errTest)
+	}
+	e := Unavailable(errTest)
+	if !IsUnavailable(e) {
+		t.Fatalf("expected unavaillable error, got %T", e)
 	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)

--- a/errdefs/is.go
+++ b/errdefs/is.go
@@ -21,7 +21,7 @@ func getImplementer(err error) error {
 		ErrDeadline,
 		ErrDataLoss,
 		ErrUnknown:
-		return e
+		return err
 	case causer:
 		return getImplementer(e.Cause())
 	default:


### PR DESCRIPTION
The types defined in the errdefs package do not satisfy the `error` interface, because they do not implement `Error()`.

Instead of returning the matched interface, return the original error.

When matching _multiple_ interfaces/types, Golang doesn't complain:

```go
func getImplementer(err error) error {
    switch e := err.(type) {
    case
        ErrNotFound,
        ErrInvalidParameter:
        return e
    default:
        return err
    }
}
```

But matching a single interface/type:

```go
func getImplementer(err error) error {
    switch e := err.(type) {
    case
        ErrNotFound:
        return e
    default:
        return err
    }
}
```

Produces an error (see https://play.golang.org/p/tUOyQHpedyg):

    cannot use e (type ErrNotFound) as type error in return argument: ErrNotFound does not implement error (missing Error method)

Return the original `err` instead of the matched interface/type instead.

Also added some additional tests

