### PR TITLE
Address `expected` vs `actual` in integration tests

### DIFF
--- a/integration/container/inspect_test.go
+++ b/integration/container/inspect_test.go
@@ -40,9 +40,9 @@ func TestInspectCpusetInConfigPre120(t *testing.T) {
 	require.NoError(t, err, "unable to unmarshal body for version 1.19: %s", err)
 
 	config, ok := inspectJSON["Config"]
-	assert.Equal(t, ok, true, "Unable to find 'Config'")
+	assert.Equal(t, true, ok, "Unable to find 'Config'")
 
 	cfg := config.(map[string]interface{})
 	_, ok = cfg["Cpuset"]
-	assert.Equal(t, ok, true, "API version 1.19 expected to include Cpuset in 'Config'")
+	assert.Equal(t, true, ok, "API version 1.19 expected to include Cpuset in 'Config'")
 }

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -163,7 +163,7 @@ func TestInspectOomKilledTrue(t *testing.T) {
 
 	inspect, err := client.ContainerInspect(ctx, cID)
 	require.NoError(t, err)
-	assert.Equal(t, inspect.State.OOMKilled, true)
+	assert.Equal(t, true, inspect.State.OOMKilled)
 }
 
 func TestInspectOomKilledFalse(t *testing.T) {
@@ -179,5 +179,5 @@ func TestInspectOomKilledFalse(t *testing.T) {
 
 	inspect, err := client.ContainerInspect(ctx, cID)
 	require.NoError(t, err)
-	assert.Equal(t, inspect.State.OOMKilled, false)
+	assert.Equal(t, false, inspect.State.OOMKilled)
 }

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -35,7 +35,7 @@ func TestPause(t *testing.T) {
 
 	inspect, err := client.ContainerInspect(ctx, cID)
 	require.NoError(t, err)
-	assert.Equal(t, inspect.State.Paused, true)
+	assert.Equal(t, true, inspect.State.Paused)
 
 	err = client.ContainerUnpause(ctx, cID)
 	require.NoError(t, err)
@@ -47,7 +47,7 @@ func TestPause(t *testing.T) {
 		Until:   until,
 		Filters: filters.NewArgs(filters.Arg("container", cID)),
 	})
-	assert.Equal(t, getEventActions(t, messages, errs), []string{"pause", "unpause"})
+	assert.Equal(t, []string{"pause", "unpause"}, getEventActions(t, messages, errs))
 }
 
 func TestPauseFailsOnWindowsServerContainers(t *testing.T) {
@@ -88,7 +88,7 @@ func getEventActions(t *testing.T, messages <-chan events.Message, errs <-chan e
 	for {
 		select {
 		case err := <-errs:
-			assert.Equal(t, err == nil || err == io.EOF, true)
+			assert.True(t, err == nil || err == io.EOF)
 			return actions
 		case e := <-messages:
 			actions = append(actions, e.Status)

--- a/integration/container/remove_test.go
+++ b/integration/container/remove_test.go
@@ -66,7 +66,7 @@ func TestRemoveContainerWithVolume(t *testing.T) {
 
 	insp, _, err := client.ContainerInspectWithRaw(ctx, cID, true)
 	require.NoError(t, err)
-	assert.Equal(t, len(insp.Mounts), 1)
+	assert.Equal(t, 1, len(insp.Mounts))
 	volName := insp.Mounts[0].Name
 
 	err = client.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{
@@ -76,7 +76,7 @@ func TestRemoveContainerWithVolume(t *testing.T) {
 
 	volumes, err := client.VolumeList(ctx, filters.NewArgs(filters.Arg("name", volName)))
 	require.NoError(t, err)
-	assert.Equal(t, len(volumes.Volumes), 0)
+	assert.Equal(t, 0, len(volumes.Volumes))
 }
 
 func TestRemoveContainerRunning(t *testing.T) {

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -44,7 +44,7 @@ func TestResizeWithInvalidSize(t *testing.T) {
 	endpoint := "/containers/" + cID + "/resize?h=foo&w=bar"
 	res, _, err := req.Post(endpoint)
 	require.NoError(t, err)
-	assert.Equal(t, res.StatusCode, http.StatusBadRequest)
+	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
 }
 
 func TestResizeWhenContainerNotStarted(t *testing.T) {


### PR DESCRIPTION
This fix addresses `expected` vs `actual` in integration tests
so that they match `assert.Equal(t, expected, actual)`

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
