### PR TITLE
layer: remove metadata store interface

### DIFF
--- a/layer/filestore.go
+++ b/layer/filestore.go
@@ -37,10 +37,10 @@ type fileMetadataTransaction struct {
 	ws    *ioutils.AtomicWriteSet
 }
 
-// NewFSMetadataStore returns an instance of a metadata store
+// newFSMetadataStore returns an instance of a metadata store
 // which is backed by files on disk using the provided root
 // as the root of metadata files.
-func NewFSMetadataStore(root string) (MetadataStore, error) {
+func newFSMetadataStore(root string) (*fileMetadataStore, error) {
 	if err := os.MkdirAll(root, 0700); err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (fms *fileMetadataStore) getMountFilename(mount, filename string) string {
 	return filepath.Join(fms.getMountDirectory(mount), filename)
 }
 
-func (fms *fileMetadataStore) StartTransaction() (MetadataTransaction, error) {
+func (fms *fileMetadataStore) StartTransaction() (*fileMetadataTransaction, error) {
 	tmpDir := filepath.Join(fms.root, "tmp")
 	if err := os.MkdirAll(tmpDir, 0755); err != nil {
 		return nil, err

--- a/layer/filestore_test.go
+++ b/layer/filestore_test.go
@@ -24,12 +24,12 @@ func newFileMetadataStore(t *testing.T) (*fileMetadataStore, string, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fms, err := NewFSMetadataStore(td)
+	fms, err := newFSMetadataStore(td)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	return fms.(*fileMetadataStore), td, func() {
+	return fms, td, func() {
 		if err := os.RemoveAll(td); err != nil {
 			t.Logf("Failed to cleanup %q: %s", td, err)
 		}

--- a/layer/layer.go
+++ b/layer/layer.go
@@ -201,54 +201,6 @@ type DescribableStore interface {
 	RegisterWithDescriptor(io.Reader, ChainID, distribution.Descriptor) (Layer, error)
 }
 
-// MetadataTransaction represents functions for setting layer metadata
-// with a single transaction.
-type MetadataTransaction interface {
-	SetSize(int64) error
-	SetParent(parent ChainID) error
-	SetDiffID(DiffID) error
-	SetCacheID(string) error
-	SetDescriptor(distribution.Descriptor) error
-	setOS(string) error
-	TarSplitWriter(compressInput bool) (io.WriteCloser, error)
-
-	Commit(ChainID) error
-	Cancel() error
-	String() string
-}
-
-// MetadataStore represents a backend for persisting
-// metadata about layers and providing the metadata
-// for restoring a Store.
-type MetadataStore interface {
-	// StartTransaction starts an update for new metadata
-	// which will be used to represent an ID on commit.
-	StartTransaction() (MetadataTransaction, error)
-
-	GetSize(ChainID) (int64, error)
-	GetParent(ChainID) (ChainID, error)
-	GetDiffID(ChainID) (DiffID, error)
-	GetCacheID(ChainID) (string, error)
-	GetDescriptor(ChainID) (distribution.Descriptor, error)
-	getOS(ChainID) (string, error)
-	TarSplitReader(ChainID) (io.ReadCloser, error)
-
-	SetMountID(string, string) error
-	SetInitID(string, string) error
-	SetMountParent(string, ChainID) error
-
-	GetMountID(string) (string, error)
-	GetInitID(string) (string, error)
-	GetMountParent(string) (ChainID, error)
-
-	// List returns the full list of referenced
-	// read-only and read-write layers
-	List() ([]ChainID, []string, error)
-
-	Remove(ChainID) error
-	RemoveMount(string) error
-}
-
 // CreateChainID returns ID for a layerDigest slice
 func CreateChainID(dgsts []DiffID) ChainID {
 	return createChainIDFromParent("", dgsts...)

--- a/layer/layer_test.go
+++ b/layer/layer_test.go
@@ -69,11 +69,8 @@ func newTestStore(t *testing.T) (Store, string, func()) {
 	}
 
 	graph, graphcleanup := newTestGraphDriver(t)
-	fms, err := NewFSMetadataStore(td)
-	if err != nil {
-		t.Fatal(err)
-	}
-	ls, err := NewStoreFromGraphDriver(fms, graph, runtime.GOOS)
+
+	ls, err := newStoreFromGraphDriver(td, graph, runtime.GOOS)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -403,7 +400,7 @@ func TestStoreRestore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ls2, err := NewStoreFromGraphDriver(ls.(*layerStore).store, ls.(*layerStore).driver, runtime.GOOS)
+	ls2, err := newStoreFromGraphDriver(ls.(*layerStore).store.root, ls.(*layerStore).driver, runtime.GOOS)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/layer/migration_test.go
+++ b/layer/migration_test.go
@@ -90,11 +90,8 @@ func TestLayerMigration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fms, err := NewFSMetadataStore(filepath.Join(td, "layers"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	ls, err := NewStoreFromGraphDriver(fms, graph, runtime.GOOS)
+	root := filepath.Join(td, "layers")
+	ls, err := newStoreFromGraphDriver(root, graph, runtime.GOOS)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,11 +215,8 @@ func TestLayerMigrationNoTarsplit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fms, err := NewFSMetadataStore(filepath.Join(td, "layers"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	ls, err := NewStoreFromGraphDriver(fms, graph, runtime.GOOS)
+	root := filepath.Join(td, "layers")
+	ls, err := newStoreFromGraphDriver(root, graph, runtime.GOOS)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/layer/ro_layer.go
+++ b/layer/ro_layer.go
@@ -121,7 +121,7 @@ func (rl *roLayer) depth() int {
 	return rl.parent.depth() + 1
 }
 
-func storeLayer(tx MetadataTransaction, layer *roLayer) error {
+func storeLayer(tx *fileMetadataTransaction, layer *roLayer) error {
 	if err := tx.SetDiffID(layer.diffID); err != nil {
 		return err
 	}


### PR DESCRIPTION
Layer metadata storage has not been implemented outside of the layer store and will be deprecated by containerd metadata storage. To prepare for this and freeze the current metadata storage, remove the exported interface and make it internal to the layer store.

Note: the original intent of exposing this interface was to make it possible in the future to use a transactional datastore rather than rely on keeping files on disk in sync. This ended up being achieved in containerd, which does not make use of this interface. This refactoring will also help in transitioning graph drivers to snapshotters by allowing shared functionality (e.g. diff, mount) to be pulled up into the layer store (without making confusing interface changes) before moving to containerd.