### PR TITLE
pkg/mount unit tests: skip some test under non-root

### DIFF
--- a/pkg/mount/mount_unix_test.go
+++ b/pkg/mount/mount_unix_test.go
@@ -25,6 +25,10 @@ func TestMountOptionsParsing(t *testing.T) {
 }
 
 func TestMounted(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root required")
+	}
+
 	tmp := path.Join(os.TempDir(), "mount-tests")
 	if err := os.MkdirAll(tmp, 0777); err != nil {
 		t.Fatal(err)
@@ -76,6 +80,10 @@ func TestMounted(t *testing.T) {
 }
 
 func TestMountReadonly(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root required")
+	}
+
 	tmp := path.Join(os.TempDir(), "mount-tests")
 	if err := os.MkdirAll(tmp, 0777); err != nil {
 		t.Fatal(err)

--- a/pkg/mount/mounter_linux_test.go
+++ b/pkg/mount/mounter_linux_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestMount(t *testing.T) {
 	if os.Getuid() != 0 {
-		t.Skip("not root tests would fail")
+		t.Skip("root required")
 	}
 
 	source, err := ioutil.TempDir("", "mount-test-source-")

--- a/pkg/mount/sharedsubtree_linux_test.go
+++ b/pkg/mount/sharedsubtree_linux_test.go
@@ -12,6 +12,10 @@ import (
 
 // nothing is propagated in or out
 func TestSubtreePrivate(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root required")
+	}
+
 	tmp := path.Join(os.TempDir(), "mount-tests")
 	if err := os.MkdirAll(tmp, 0777); err != nil {
 		t.Fatal(err)
@@ -110,6 +114,10 @@ func TestSubtreePrivate(t *testing.T) {
 // Testing that when a target is a shared mount,
 // then child mounts propagate to the source
 func TestSubtreeShared(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root required")
+	}
+
 	tmp := path.Join(os.TempDir(), "mount-tests")
 	if err := os.MkdirAll(tmp, 0777); err != nil {
 		t.Fatal(err)
@@ -178,6 +186,10 @@ func TestSubtreeShared(t *testing.T) {
 // testing that mounts to a shared source show up in the slave target,
 // and that mounts into a slave target do _not_ show up in the shared source
 func TestSubtreeSharedSlave(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root required")
+	}
+
 	tmp := path.Join(os.TempDir(), "mount-tests")
 	if err := os.MkdirAll(tmp, 0777); err != nil {
 		t.Fatal(err)
@@ -282,6 +294,10 @@ func TestSubtreeSharedSlave(t *testing.T) {
 }
 
 func TestSubtreeUnbindable(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root required")
+	}
+
 	tmp := path.Join(os.TempDir(), "mount-tests")
 	if err := os.MkdirAll(tmp, 0777); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This makes `go test .` to pass if run as non-root user, skipping those tests that require superuser privileges (for `mount`).

(this used to be part of https://github.com/moby/moby/pull/36091; separated for the sake of cleaner review)