### PR TITLE
pkg/mount: use sort.Slice

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -72,7 +72,9 @@ func RecursiveUnmount(target string) error {
 	}
 
 	// Make the deepest mount be first
-	sort.Sort(sort.Reverse(byMountpoint(mounts)))
+	sort.Slice(mounts, func(i, j int) bool {
+		return len(mounts[i].Mountpoint) > len(mounts[j].Mountpoint)
+	})
 
 	for i, m := range mounts {
 		if !strings.HasPrefix(m.Mountpoint, target) {

--- a/pkg/mount/mountinfo.go
+++ b/pkg/mount/mountinfo.go
@@ -38,17 +38,3 @@ type Info struct {
 	// VfsOpts represents per super block options.
 	VfsOpts string
 }
-
-type byMountpoint []*Info
-
-func (by byMountpoint) Len() int {
-	return len(by)
-}
-
-func (by byMountpoint) Less(i, j int) bool {
-	return by[i].Mountpoint < by[j].Mountpoint
-}
-
-func (by byMountpoint) Swap(i, j int) {
-	by[i], by[j] = by[j], by[i]
-}


### PR DESCRIPTION
 Sorting by mount point length can be implemented in a more straightforward fashion since Go 1.8 introduced `sort.Slice()` with an ability to provide a `less()` function in place.

(this used to be part of https://github.com/moby/moby/pull/36091; singled out for easier review)
