### PR TITLE
Use os.ReadDir instead of filepath.Walk in netns cleanup

### DIFF
--- a/internal/testutil/daemon/daemon_linux.go
+++ b/internal/testutil/daemon/daemon_linux.go
@@ -19,13 +19,32 @@ func cleanupNetworkNamespace(t testing.TB, d *Daemon) {
 	// daemon instance and has no chance of getting
 	// cleaned up when a new daemon is instantiated with a
 	// new exec root.
-	filepath.WalkDir(filepath.Join(d.execRoot, "netns"), func(path string, _ os.DirEntry, _ error) error {
-		if err := unix.Unmount(path, unix.MNT_DETACH); err != nil && !errors.Is(err, unix.EINVAL) && !errors.Is(err, unix.ENOENT) {
-			t.Logf("[%s] unmount of %s failed: %v", d.id, path, err)
+	netnsPath := filepath.Join(d.execRoot, "netns")
+	files, err := os.ReadDir(netnsPath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Logf("[%s] unable to read netns path (%s): %s", d.id, netnsPath, err)
 		}
-		os.Remove(path)
-		return nil
-	})
+		return
+	}
+
+	for _, dir := range files {
+		if !dir.IsDir() {
+			continue
+		}
+
+		path := filepath.Join(netnsPath, dir.Name())
+
+		// Unmount the network namespace using MNT_DETACH (lazy unmount).
+		// Ignore EINVAL ("target is not a mount point"), and ENOENT (not found),
+		// which could occur if the network namespace was already gone.
+		if err := unix.Unmount(path, unix.MNT_DETACH); err != nil && !errors.Is(err, unix.EINVAL) && !errors.Is(err, unix.ENOENT) {
+			t.Logf("[%s] unmount of network namespace %s failed: %v", d.id, path, err)
+		}
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			t.Logf("[%s] unable to remove network namespace %s: %s", d.id, path, err)
+		}
+	}
 }
 
 // CgroupNamespace returns the cgroup namespace the daemon is running in


### PR DESCRIPTION
- Use `ioutil.ReadDir()` instead of `filepath.Walk()`, because
`filepath.Walk()` does a lot of extra things we don't need
- Log errors on directory removal (omitting `os.IsNotExist`)
- Touch-up error messages for consistency
