### PR TITLE
Build containerd, runc, and proxy statically

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -14,10 +14,15 @@ install_containerd() {
 
 	(
 
-		if [ "$1" == "static" ]; then
-			export BUILDTAGS='static_build netgo'
-			export EXTRA_FLAGS='-buildmod pie'
-			export EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"'
+		export BUILDTAGS='static_build netgo'
+		export EXTRA_FLAGS='-buildmod pie'
+		export EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"'
+
+		# Reset build flags to nothing if we want a dynbinary
+		if [ "$1" == "dynamic" ]; then
+			export BUILDTAGS=''
+			export EXTRA_FLAGS=''
+			export EXTRA_LDFLAGS=''
 		fi
 
 		make

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ install_containerd() {
 	(
 
 		export BUILDTAGS='static_build netgo'
-		export EXTRA_FLAGS='-buildmod pie'
+		export EXTRA_FLAGS='-buildmode=pie'
 		export EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"'
 
 		# Reset build flags to nothing if we want a dynbinary

--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -23,6 +23,7 @@ install_proxy() {
 
 install_proxy_dynamic() {
 	export PROXY_LDFLAGS="-linkmode=external" install_proxy
+	export BUILD_MODE="-buildmode=pie"
 	_install_proxy
 }
 
@@ -31,7 +32,7 @@ _install_proxy() {
 	git clone https://github.com/docker/libnetwork.git "$GOPATH/src/github.com/docker/libnetwork"
 	cd "$GOPATH/src/github.com/docker/libnetwork"
 	git checkout -q "$LIBNETWORK_COMMIT"
-	go build -buildmode=pie -ldflags="$PROXY_LDFLAGS" -o ${PREFIX}/docker-proxy github.com/docker/libnetwork/cmd/proxy
+	go build $BUILD_MODE -ldflags="$PROXY_LDFLAGS" -o ${PREFIX}/docker-proxy github.com/docker/libnetwork/cmd/proxy
 }
 
 

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -11,7 +11,12 @@ install_runc() {
 	git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"
 	cd "$GOPATH/src/github.com/opencontainers/runc"
 	git checkout -q "$RUNC_COMMIT"
-	make BUILDTAGS="$RUNC_BUILDTAGS" $1
+	if [ -z "$1" ]; then
+		target=static
+	else
+		target="$1"
+	fi
+	make BUILDTAGS="$RUNC_BUILDTAGS" "$target"
 	mkdir -p ${PREFIX}
 	cp runc ${PREFIX}/docker-runc
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The `docker-containerd`, `docker-runc`, and `docker-proxy` binaries were originally built statically and were changed to build dynamically in both https://github.com/moby/moby/pull/36336 and https://github.com/moby/moby/pull/35100.

This seeks to remedy that.

**- How I did it**
Re-factored the scripts to build those binaries statically by default

**- How to verify it**

```
$ make clean binary
...
$ for file in bundles/binary-daemon/docker-*; do ldd $file >/dev/null 2>/dev/null && echo "$file is not static"; done
<no output>
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
` * Fixed static binary creation for containerd, runc, and proxy`

**- A picture of a cute animal (not mandatory but encouraged)**
![bird with arms](http://cdn.ebaumsworld.com/mediaFiles/picture/939060/81364249.jpg)
