### PR TITLE
Make LogFile perms configurable

### DIFF
--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -95,7 +95,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		return b, nil
 	}
 
-	writer, err := loggerutils.NewLogFile(info.LogPath, capval, maxFiles, marshalFunc, decodeFunc)
+	writer, err := loggerutils.NewLogFile(info.LogPath, capval, maxFiles, marshalFunc, decodeFunc, 0640)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**- What I did**
Added a configurable `perms` param into the `LogFile` struct. This allows users creating custom logging plugins to control the permissions on any generated files.

Addresses https://github.com/moby/moby/issues/36521.

**- How I did it**
Added an extra argument to `NewLogFile`, saved the permissions in the struct, and then used these permissions whenever creating a new file.

**- How to verify it**
Unit tests.

**- Description for the changelog**
Make LogFile perms configurable.


**- A picture of a cute animal (not mandatory but encouraged)**
![hqdefault](https://user-images.githubusercontent.com/33035916/37124035-7b66590c-221b-11e8-974a-378de6bc0832.jpg)


Signed-off-by: Benjamin Yolken <yolken@stripe.com>