### PR TITLE
daemon/setMounts(): do not make /dev/shm ro

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -667,7 +667,7 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 	if s.Root.Readonly {
 		for i, m := range s.Mounts {
 			switch m.Destination {
-			case "/proc", "/dev/pts", "/dev/mqueue", "/dev":
+			case "/proc", "/dev/pts", "/dev/shm", "/dev/mqueue", "/dev":
 				continue
 			}
 			if _, ok := userMounts[m.Destination]; !ok {


### PR DESCRIPTION
It has been pointed out that if --read-only flag is given, /dev/shm
also becomes read-only, and it does not make sense, especially for
the case of --ipc private (added in https://github.com/moby/moby/pull/34087).

It is still debatable whether it makes sense to have it read-only
for --ipc shareable|host|container:NNN, but let's follow the --tmpfs
logic here and do NOT make /dev/shm read-only for all the cases.

Fixes #36503 