### PR TITLE
LCOW: Log stderr on failures to ease diagnosis

### DIFF
--- a/builder/dockerfile/evaluator_test.go
+++ b/builder/dockerfile/evaluator_test.go
@@ -2,6 +2,7 @@ package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/docker/docker/builder/remotecontext"
@@ -97,7 +98,9 @@ func initDispatchTestCases() []dispatchTestCase {
 }
 
 func TestDispatch(t *testing.T) {
-	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
+	if runtime.GOOS != "windows" {
+		skip.If(t, os.Getuid() != 0, "skipping test that requires root")
+	}
 	testCases := initDispatchTestCases()
 
 	for _, testCase := range testCases {

--- a/builder/dockerfile/internals_test.go
+++ b/builder/dockerfile/internals_test.go
@@ -47,6 +47,9 @@ func TestDockerfileOutsideTheBuildContext(t *testing.T) {
 	defer cleanup()
 
 	expectedError := "Forbidden path outside the build context: ../../Dockerfile ()"
+	if runtime.GOOS == "windows" {
+		expectedError = "failed to resolve scoped path ../../Dockerfile ()"
+	}
 
 	readAndCheckDockerfile(t, "DockerfileOutsideTheBuildContext", contextDir, "../../Dockerfile", expectedError)
 }
@@ -61,7 +64,9 @@ func TestNonExistingDockerfile(t *testing.T) {
 }
 
 func readAndCheckDockerfile(t *testing.T, testName, contextDir, dockerfilePath, expectedError string) {
-	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
+	if runtime.GOOS != "windows" {
+		skip.If(t, os.Getuid() != 0, "skipping test that requires root")
+	}
 	tarStream, err := archive.Tar(contextDir, archive.Uncompressed)
 	assert.NilError(t, err)
 
@@ -80,7 +85,7 @@ func readAndCheckDockerfile(t *testing.T, testName, contextDir, dockerfilePath, 
 		Source:  tarStream,
 	}
 	_, _, err = remotecontext.Detect(config)
-	assert.Check(t, is.Error(err, expectedError))
+	assert.Check(t, is.ErrorContains(err, expectedError))
 }
 
 func TestCopyRunConfig(t *testing.T) {

--- a/daemon/graphdriver/lcow/lcow_svm.go
+++ b/daemon/graphdriver/lcow/lcow_svm.go
@@ -4,7 +4,6 @@ package lcow // import "github.com/docker/docker/daemon/graphdriver/lcow"
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/Microsoft/hcsshim"
 	"github.com/Microsoft/opengcs/client"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -323,8 +323,9 @@ func (svm *serviceVM) createUnionMount(mountName string, mvds ...hcsshim.MappedV
 	}
 
 	logrus.Debugf("Doing the overlay mount with union directory=%s", mountName)
-	if err = svm.runProcess(fmt.Sprintf("mkdir -p %s", mountName), nil, nil, nil); err != nil {
-		return err
+	errOut := &bytes.Buffer{}
+	if err = svm.runProcess(fmt.Sprintf("mkdir -p %s", mountName), nil, nil, errOut); err != nil {
+		return errors.Wrapf(err, "mkdir -p %s failed (%s)", mountName, errOut.String())
 	}
 
 	var cmd string
@@ -340,8 +341,9 @@ func (svm *serviceVM) createUnionMount(mountName string, mvds ...hcsshim.MappedV
 		upper := fmt.Sprintf("%s/upper", svm.getShortContainerPath(&mvds[0]))
 		work := fmt.Sprintf("%s/work", svm.getShortContainerPath(&mvds[0]))
 
-		if err = svm.runProcess(fmt.Sprintf("mkdir -p %s %s", upper, work), nil, nil, nil); err != nil {
-			return err
+		errOut := &bytes.Buffer{}
+		if err = svm.runProcess(fmt.Sprintf("mkdir -p %s %s", upper, work), nil, nil, errOut); err != nil {
+			return errors.Wrapf(err, "mkdir -p %s failed (%s)", mountName, errOut.String())
 		}
 
 		cmd = fmt.Sprintf("mount -t overlay overlay -olowerdir=%s,upperdir=%s,workdir=%s %s",
@@ -352,8 +354,9 @@ func (svm *serviceVM) createUnionMount(mountName string, mvds ...hcsshim.MappedV
 	}
 
 	logrus.Debugf("createUnionMount: Executing mount=%s", cmd)
-	if err = svm.runProcess(cmd, nil, nil, nil); err != nil {
-		return err
+	errOut = &bytes.Buffer{}
+	if err = svm.runProcess(cmd, nil, nil, errOut); err != nil {
+		return errors.Wrapf(err, "%s failed (%s)", cmd, errOut.String())
 	}
 
 	svm.unionMounts[mountName] = 1


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Adds logging of stderr on three commands which are intermittently failing on RS3 builds to aid customer diagnosis. It appears to be an RS3 vSMB platform bug causing a SCSI disk to be ejected from the utility VM, and is being investigated for possible backport, but it's extremely hard to get any clue when this is happening.  Doesn't seem to occur on RS4 builds.

@johnstep PTAL.
