### PR TITLE
Temporarily disable OOM tests for ppc64le

### DIFF
--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -49,7 +49,8 @@ func (s *DockerSuite) TestEventsRedirectStdout(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsOOMDisableFalse(c *check.C) {
-	testRequires(c, DaemonIsLinux, oomControl, memoryLimitSupport, swapMemorySupport)
+	// TODO temporarily disabled for ppc64le as it is failing due to configuration changes of the nodes
+	testRequires(c, NotPpc64le, DaemonIsLinux, oomControl, memoryLimitSupport, swapMemorySupport)
 
 	errChan := make(chan error)
 	go func() {

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -615,7 +615,8 @@ func (s *DockerSuite) TestRunWithInvalidPathforBlkioDeviceWriteIOps(c *check.C) 
 }
 
 func (s *DockerSuite) TestRunOOMExitCode(c *check.C) {
-	testRequires(c, memoryLimitSupport, swapMemorySupport)
+	// TODO temporarily disabled for ppc64le as it is failing due to configuration changes of the nodes
+	testRequires(c, NotPpc64le, memoryLimitSupport, swapMemorySupport)
 	errChan := make(chan error)
 	go func() {
 		defer close(errChan)


### PR DESCRIPTION
Tests are failing due to configuration changes of the machines running CI.

see https://github.com/moby/moby/issues/36540


ping @vdemeester @dnephin @tophj-ibm @andrewhsu 
