### PR TITLE
client: respect context deadline in attach

### DIFF
--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -97,8 +99,7 @@ func TestContainerExecAttachTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 	defer cancel()
 	_, err = client.ContainerExecAttach(ctx, "nothing", types.ExecStartCheck{})
-	if err == nil || (!strings.Contains(err.Error(), "i/o timeout") && // unix
-		!strings.Contains(err.Error(), "requested service provider could not be loaded")) { // win
+	if err == nil || !errors.Cause(err).(net.Error).Timeout() {
 		t.Fatalf("expected a timeout error, got %v", err)
 	}
 }

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -82,7 +82,7 @@ func TestContainerExecStartError(t *testing.T) {
 }
 
 func TestContainerExecAttachTimeout(t *testing.T) {
-	hostURL, err := ParseHostURL("unix:///var/run/docker.sock")
+	hostURL, err := ParseHostURL("tcp://0.0.0.0:4243")
 	require.NoError(t, err)
 
 	client := &Client{
@@ -97,7 +97,8 @@ func TestContainerExecAttachTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 	defer cancel()
 	_, err = client.ContainerExecAttach(ctx, "nothing", types.ExecStartCheck{})
-	if err == nil || !strings.Contains(err.Error(), "i/o timeout") {
+	if err == nil || (!strings.Contains(err.Error(), "i/o timeout") && // unix
+		!strings.Contains(err.Error(), "requested service provider could not be loaded")) { // win
 		t.Fatalf("expected a timeout error, got %v", err)
 	}
 }


### PR DESCRIPTION
ContainerExecAttach and ContainerAttach both use postHijacked to hijack a
connection and do hijack things. However, postHijacked, while taking a
context.Context as a param, its callees do not obey this context, of note:
dial and the initial http request before hijacking. This is an attempt to
remedy that. Unfortunately, most of the underlying methods themselves do not
accept a context and this was not simply a matter of passing that context
along -- this isn't very pretty and I'm open to ideas on how best to do this.

there is a test that verifies this behavior from dial now. I hope the ci tests are good enough to catch the existing happy paths :)

thank you all for your work!

fixes #36543 

![timeout_spirit_animal](http://roflzoo.com/pics/042010/happy-smiling-sloth.jpg)