### PR TITLE
Call daemon.Mount before trying to export a container

### DIFF
--- a/daemon/export.go
+++ b/daemon/export.go
@@ -61,8 +61,7 @@ func (daemon *Daemon) containerExport(container *container.Container) (arch io.R
 		}
 	}()
 
-	_, err = rwlayer.Mount(container.GetMountLabel())
-	if err != nil {
+	if err := daemon.Mount(container); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
cc @kolyshkin 

Fix #36561

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
