### PR TITLE
integration/TestContainerShmNoLeak: use --iptables=false

### DIFF
--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -30,7 +30,7 @@ func TestContainerShmNoLeak(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d.StartWithBusybox(t)
+	d.StartWithBusybox(t, "--iptables=false")
 	defer d.Stop(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
As mentioned in commit 9e31938, test cases that use t.Parallel()
and start a docker daemon might step on each other toes as they
try to configure iptables during startup, resulting in flaky tests.

To avoid this, --iptables=false should be used while starting daemon.

Fixes: eaa5192856c1 ("Make container resource mounts unbindable")