### PR TITLE
integration-cli/TestSlowStdinClosing: increase timeout

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4357,7 +4357,7 @@ func (s *DockerSuite) TestSlowStdinClosing(c *check.C) {
 		}()
 
 		select {
-		case <-time.After(15 * time.Second):
+		case <-time.After(30 * time.Second):
 			c.Fatal("running container timed out") // cleanup in teardown
 		case err := <-done:
 			c.Assert(err, checker.IsNil)


### PR DESCRIPTION
I noticed this test failed on Windows:

> 17:46:24 docker_cli_run_test.go:4361:
> 17:46:24 c.Fatal("running container timed out") // cleanup in teardown

I also noticed that in general tests are running slower on Windows, for example `TestStartAttachSilen `(which runs a container with `busybox echo test` and then starts it again) took 29.763s. This means a simple container start can easily take 15s, which explains the above failure.

Double the timeout from 15s to 30s.

Fixes: 4e262f6387 ("Fix race on sending stdin close event")