### PR TITLE
Enable CRIU on non-amd64 architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,7 @@ FROM base AS criu
 # Install CRIU for checkpoint/restore support
 ENV CRIU_VERSION 3.6
 # Install dependancy packages specific to criu
-RUN case $(uname -m) in \
-    x86_64) \
-	apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y \
 	libnet-dev \
 	libprotobuf-c0-dev \
 	libprotobuf-dev \
@@ -59,13 +57,7 @@ RUN case $(uname -m) in \
 	&& curl -sSL https://github.com/checkpoint-restore/criu/archive/v${CRIU_VERSION}.tar.gz | tar -C /usr/src/criu/ -xz --strip-components=1 \
 	&& cd /usr/src/criu \
 	&& make \
-	&& make PREFIX=/opt/criu install-criu ;\
-	;; \
-    armv7l|aarch64|ppc64le|s390x) \
-	mkdir -p /opt/criu; \
-	;; \
-    esac
-
+	&& make PREFIX=/opt/criu install-criu
 
 FROM base AS registry
 # Install two versions of the registry. The first is an older version that


### PR DESCRIPTION
Since the recent release of CRIU has already supported other
arches such as AArch64, ppc64le, and s390x, so we can enable
it now.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
enable CRIU on other arches
**- How I did it**
drop the `case` selection statement
**- How to verify it**
`make binary`
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

