### PR TITLE
Minor optimizations

### DIFF
--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -77,7 +77,7 @@ type ImageService struct {
 // CountImages returns the number of images stored by ImageService
 // called from info.go
 func (i *ImageService) CountImages() int {
-	return len(i.imageStore.Map())
+	return i.imageStore.Len()
 }
 
 // Children returns the children image.IDs for a parent image.

--- a/image/store.go
+++ b/image/store.go
@@ -27,6 +27,7 @@ type Store interface {
 	Children(id ID) []ID
 	Map() map[ID]*Image
 	Heads() map[ID]*Image
+	Len() int
 }
 
 // LayerGetReleaser is a minimal interface for getting and releasing images.
@@ -335,4 +336,10 @@ func (is *store) imagesMap(all bool) map[ID]*Image {
 		images[id] = img
 	}
 	return images
+}
+
+func (is *store) Len() int {
+	is.RLock()
+	defer is.RUnlock()
+	return len(is.images)
 }

--- a/image/store_test.go
+++ b/image/store_test.go
@@ -1,6 +1,7 @@
 package image // import "github.com/docker/docker/image"
 
 import (
+	"fmt"
 	"runtime"
 	"testing"
 
@@ -169,6 +170,20 @@ func TestGetAndSetLastUpdated(t *testing.T) {
 	updated, err = store.GetLastUpdated(id)
 	assert.NoError(t, err)
 	assert.Equal(t, updated.IsZero(), false)
+}
+
+func TestStoreLen(t *testing.T) {
+	store, cleanup := defaultImageStore(t)
+	defer cleanup()
+
+	expected := 10
+	for i := 0; i < expected; i++ {
+		_, err := store.Create([]byte(fmt.Sprintf(`{"comment": "abc%d", "rootfs": {"type": "layers"}}`, i)))
+		assert.NoError(t, err)
+	}
+	numImages := store.Len()
+	assert.Equal(t, expected, numImages)
+	assert.Equal(t, len(store.Map()), numImages)
 }
 
 type mockLayerGetReleaser struct{}


### PR DESCRIPTION
While profiling dockerd, I noticed the following:

1. When swarm-mode is enabled, the swarm agent is hitting the daemon `info` backend a lot to get information about the system, leading to lots of calls to `imageStore.Map()`
2. The containerd monitor probing was consuming more CPU than expected

On `1`, the `info` backend only actually needs the count of images, but the image store iterates through each image and constructs a new image object. This means the more images there are the more resources are consumed by calling `info`. Instead this just adds an interface to get the image count. Upon doing this, this function drops off the CPU profile (was top of the list before).

On `2`, it's using a ticker to provide a sleep for probing contianerd, but this can actually be ticking faster than the probe actually takes, thus providing no real use. Instead I've made this use a sleep to ensure there is at least some time between probes.