### PR TITLE
integration/*: make e2e run without failure

### DIFF
--- a/hack/test/e2e-run.sh
+++ b/hack/test/e2e-run.sh
@@ -13,8 +13,8 @@ export DOCKER_ENGINE_GOARCH=${DOCKER_ENGINE_GOARCH:-${ARCH}}
 : ${TESTDEBUG:=}
 
 integration_api_dirs=${TEST_INTEGRATION_DIR:-"$(
-	find ./integration -type d |
-	grep -vE '(^./integration($|/internal)|/testdata)')"}
+	find /tests/integration -type d |
+	grep -vE '(^/tests/integration($|/internal)|/testdata)')"}
 
 run_test_integration() {
 	[[ "$TESTFLAGS" != *-check.f* ]] && run_test_integration_suites
@@ -35,7 +35,7 @@ run_test_integration_suites() {
 run_test_integration_legacy_suites() {
 	(
 		flags="-check.v -check.timeout=${TIMEOUT} -test.timeout=360m $TESTFLAGS"
-		cd test/integration-cli
+		cd /tests/integration-cli
 		echo "Running $PWD"
 		test_env ./test.main $flags
 	)

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -12,11 +13,13 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration-cli/cli/build/fakecontext"
 	"github.com/docker/docker/integration/internal/request"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+	"github.com/gotestyourself/gotestyourself/skip"
 )
 
 func TestBuildWithRemoveAndForceRemove(t *testing.T) {
@@ -304,6 +307,9 @@ COPY bar /`
 // docker/for-linux#135
 // #35641
 func TestBuildMultiStageLayerLeak(t *testing.T) {
+	fmt.Println(testEnv.DaemonAPIVersion())
+	skip.IfCondition(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.38"),
+		"Don't run on API lower than 1.38 as it has been fixed starting from that version")
 	ctx := context.TODO()
 	defer setupTest(t)()
 

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/internal/test/environment"
 	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/skip"
 )
 
 const (
@@ -21,6 +22,7 @@ const (
 
 // NewSwarm creates a swarm daemon for testing
 func NewSwarm(t *testing.T, testEnv *environment.Execution) *daemon.Swarm {
+	skip.IfCondition(t, testEnv.IsRemoteDaemon())
 	d := &daemon.Swarm{
 		Daemon: daemon.New(t, "", dockerdBinary, daemon.Config{
 			Experimental: testEnv.DaemonInfo.ExperimentalBuild,

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/swarm"
+	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/integration/internal/swarm"
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/gotestyourself/gotestyourself/poll"
 	"golang.org/x/net/context"
@@ -16,7 +17,7 @@ import (
 
 func TestServiceWithPredefinedNetwork(t *testing.T) {
 	defer setupTest(t)()
-	d := newSwarm(t)
+	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)
 	client, err := client.NewClientWithOpts(client.WithHost((d.Sock())))
 	assert.NilError(t, err)
@@ -25,7 +26,7 @@ func TestServiceWithPredefinedNetwork(t *testing.T) {
 	var instances uint64 = 1
 	serviceName := "TestService"
 	serviceSpec := swarmServiceSpec(serviceName, instances)
-	serviceSpec.TaskTemplate.Networks = append(serviceSpec.TaskTemplate.Networks, swarm.NetworkAttachmentConfig{Target: hostName})
+	serviceSpec.TaskTemplate.Networks = append(serviceSpec.TaskTemplate.Networks, swarmtypes.NetworkAttachmentConfig{Target: hostName})
 
 	serviceResp, err := client.ServiceCreate(context.Background(), serviceSpec, types.ServiceCreateOptions{
 		QueryRegistry: false,
@@ -60,7 +61,7 @@ const ingressNet = "ingress"
 
 func TestServiceWithIngressNetwork(t *testing.T) {
 	defer setupTest(t)()
-	d := newSwarm(t)
+	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)
 
 	client, err := client.NewClientWithOpts(client.WithHost((d.Sock())))
@@ -81,13 +82,13 @@ func TestServiceWithIngressNetwork(t *testing.T) {
 	var instances uint64 = 1
 	serviceName := "TestIngressService"
 	serviceSpec := swarmServiceSpec(serviceName, instances)
-	serviceSpec.TaskTemplate.Networks = append(serviceSpec.TaskTemplate.Networks, swarm.NetworkAttachmentConfig{Target: ingressNet})
-	serviceSpec.EndpointSpec = &swarm.EndpointSpec{
-		Ports: []swarm.PortConfig{
+	serviceSpec.TaskTemplate.Networks = append(serviceSpec.TaskTemplate.Networks, swarmtypes.NetworkAttachmentConfig{Target: ingressNet})
+	serviceSpec.EndpointSpec = &swarmtypes.EndpointSpec{
+		Ports: []swarmtypes.PortConfig{
 			{
-				Protocol:    swarm.PortConfigProtocolTCP,
+				Protocol:    swarmtypes.PortConfigProtocolTCP,
 				TargetPort:  80,
-				PublishMode: swarm.PortConfigPublishModeIngress,
+				PublishMode: swarmtypes.PortConfigPublishModeIngress,
 			},
 		},
 	}

--- a/integration/plugin/authz/main_test.go
+++ b/integration/plugin/authz/main_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/internal/test/environment"
 	"github.com/docker/docker/pkg/authorization"
 	"github.com/docker/docker/pkg/plugins"
+	"github.com/gotestyourself/gotestyourself/skip"
 )
 
 var (
@@ -48,6 +49,7 @@ func TestMain(m *testing.M) {
 }
 
 func setupTest(t *testing.T) func() {
+	skip.IfCondition(t, testEnv.IsRemoteDaemon(), "cannot run daemon when remote daemon")
 	environment.ProtectAll(t, testEnv)
 
 	d = daemon.New(t, "", dockerdBinary, daemon.Config{

--- a/integration/plugin/logging/helpers_test.go
+++ b/integration/plugin/logging/helpers_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const dockerdBinary = "dockerd"
-
 var pluginBuildLock = locker.New()
 
 func ensurePlugin(t *testing.T, name string) string {

--- a/integration/plugin/logging/main_test.go
+++ b/integration/plugin/logging/main_test.go
@@ -1,0 +1,31 @@
+package logging // import "github.com/docker/docker/integration/plugin/logging"
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/docker/docker/internal/test/environment"
+)
+
+var (
+	testEnv *environment.Execution
+)
+
+const dockerdBinary = "dockerd"
+
+func TestMain(m *testing.M) {
+	var err error
+	testEnv, err = environment.New()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	err = environment.EnsureFrozenImagesLinux(testEnv)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	testEnv.Print()
+	os.Exit(m.Run())
+}

--- a/integration/plugin/logging/validation_test.go
+++ b/integration/plugin/logging/validation_test.go
@@ -7,12 +7,14 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/skip"
 )
 
 // Regression test for #35553
 // Ensure that a daemon with a log plugin set as the default logger for containers
 // does not keep the daemon from starting.
 func TestDaemonStartWithLogOpt(t *testing.T) {
+	skip.IfCondition(t, testEnv.IsRemoteDaemon(), "cannot run daemon when remote daemon")
 	t.Parallel()
 
 	d := daemon.New(t, "", dockerdBinary, daemon.Config{})

--- a/internal/test/environment/environment.go
+++ b/internal/test/environment/environment.go
@@ -121,6 +121,15 @@ func (e *Execution) IsRemoteDaemon() bool {
 	return !e.IsLocalDaemon()
 }
 
+// DaemonAPIVersion returns the negociated daemon api version
+func (e *Execution) DaemonAPIVersion() string {
+	version, err := e.APIClient().ServerVersion(context.TODO())
+	if err != nil {
+		return ""
+	}
+	return version.APIVersion
+}
+
 // Print the execution details to stdout
 // TODO: print everything
 func (e *Execution) Print() {


### PR DESCRIPTION
… mainly by skipping if daemon is remote.

```
docker build -f Dockerfile.e2e -t moby-e2e .
docker run -v /var/run/docker.sock:/var/run/docker.sock \
           -e DOCKER_API_VERSION=1.36 moby-e2e
# […]
PASS
# […]
```

🦁 

Next is the integration-cli runs: currently it's `1017 passed, 570 skipped, 38 FAILED`.

cc @chris-crone 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
