### PR TITLE
LCOW: Implement `docker save`

### DIFF
--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -158,6 +158,9 @@ func (l *tarexporter) takeLayerReference(id image.ID, imgDescr *imageDescriptor)
 	if os == "" {
 		os = runtime.GOOS
 	}
+	if !system.IsOSSupported(os) {
+		return fmt.Errorf("os %q is not supported", os)
+	}
 	layer, err := l.lss[os].Get(topLayerID)
 	if err != nil {
 		return err

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -219,7 +220,11 @@ func (s *saveSession) save(outStream io.Writer) error {
 		}
 
 		for _, l := range imageDescr.layers {
-			layers = append(layers, filepath.Join(l, legacyLayerFileName))
+			// IMPORTANT: We use path, not filepath here to ensure the layers
+			// in the manifest use Unix-style forward-slashes. Otherwise, a
+			// Linux image saved from LCOW won't be able to be imported on
+			// LCOL.
+			layers = append(layers, path.Join(l, legacyLayerFileName))
 		}
 
 		manifest = append(manifest, manifestItem{

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -316,6 +316,7 @@ func (s *saveSession) saveImage(id image.ID) (map[layer.DiffID]distribution.Desc
 			v1Img.Parent = parent.Hex()
 		}
 
+		v1Img.OS = img.OS
 		src, err := s.saveLayer(rootFS.ChainID(), v1Img, img.Created)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This PR contains three small fixes around `docker save` and a DiffGetter implementation for the LCOW graphdriver. The smaller fixes are

- A check to ensure we don't nil de-reference saving an LCOW image in `image\tarexport\save.go`
- Making sure the operating system is passed through to `saveLayer`
- Making sure manifest.json file is written in Unix paths, otherwise the saved .tar from LCOW can't be loaded by a Linux daemon.

```
PS C:\> docker pull --platform=linux busybox
Using default tag: latest
latest: Pulling from library/busybox
d070b8ef96fc: Pull complete
Digest: sha256:2107a35b58593c58ec5f4e8f2c4a70d195321078aebfadfbfb223a2ff4a4ed21
Status: Downloaded newer image for busybox:latest
PS C:\> docker save -o x:\lcow-save-busybox.tar busybox
PS C:\> dir X:\lcow-save-busybox.tar


    Directory: X:\


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        3/14/2018  12:39 PM        1369600 lcow-save-busybox.tar


PS C:\>
```

And the import on Linux:

![image](https://user-images.githubusercontent.com/10522484/37426951-14f38536-2785-11e8-9a86-c4d414b25c19.png)


