### PR TITLE
Update libnetwork to fix stale HNS endpoints on Windows

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=8892d7537c67232591f1f3af60587e3e77e61d41
+LIBNETWORK_COMMIT=1b91bc94094ecfdae41daa465cc0c8df37dfb3dd
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -34,7 +34,7 @@ github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 #get libnetwork packages
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
-github.com/docker/libnetwork 8892d7537c67232591f1f3af60587e3e77e61d41
+github.com/docker/libnetwork 1b91bc94094ecfdae41daa465cc0c8df37dfb3dd
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec


### PR DESCRIPTION
Update libnetwork to https://github.com/docker/libnetwork/commit/1b91bc94094ecfdae41daa465cc0c8df37dfb3dd to bring in a fix
for stale HNS endpoints on Windows:

When Windows Server 2016 is restarted with the Docker service running, it is
possible for endpoints to be deleted from the libnetwork store without being
deleted from HNS. This does not occur if the Docker service is stopped cleanly
first, or forcibly terminated (since the endpoints still exist in both). This
change works around the issue by removing any stale HNS endpoints for a network
when creating it.

Brings in the fix from libnetwork PR: https://github.com/docker/libnetwork/pull/2098

Full diff: https://github.com/docker/libnetwork/compare/8892d7537c67232591f1f3af60587e3e77e61d41...1b91bc94094ecfdae41daa465cc0c8df37dfb3dd


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
