### PR TITLE
integration/TestExportContainerAfterDaemonRestart: add

### DIFF
--- a/integration/container/export_test.go
+++ b/integration/container/export_test.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	containerTypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/request"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -50,4 +52,33 @@ func TestExportContainerAndImportImage(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, jm.Status, images[0].ID)
+}
+
+// TestExportContainerAfterDaemonRestart checks that a container
+// created before start of the currently running dockerd
+// can be exported (as reported in #36561). To satisfy this
+// condition, daemon restart is needed after container creation.
+func TestExportContainerAfterDaemonRestart(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRemoteDaemon())
+
+	d := daemon.New(t, "", "dockerd", daemon.Config{})
+	client, err := d.NewClient()
+	require.NoError(t, err)
+
+	d.StartWithBusybox(t)
+	defer d.Stop(t)
+
+	ctx := context.Background()
+	cfg := containerTypes.Config{
+		Image: "busybox",
+		Cmd:   []string{"top"},
+	}
+	ctr, err := client.ContainerCreate(ctx, &cfg, nil, nil, "")
+	require.NoError(t, err)
+
+	d.Restart(t)
+
+	_, err = client.ContainerExport(ctx, ctr.ID)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
This test case checks that a container created before start of the currently running dockerd can be exported (as reported in #36561). To satisfy this condition, either a pre-existing container is required, or a daemon restart after container creation.