### PR TITLE
Fix stats collector spinning CPU if no stats are collected

### DIFF
--- a/daemon/stats/collector.go
+++ b/daemon/stats/collector.go
@@ -91,6 +91,10 @@ func (s *Collector) Run() {
 	var pairs []publishersPair
 
 	for {
+		// Put sleep at the start so that it will always be hit,
+		// preventing a tight loop if no stats are collected.
+		time.Sleep(s.interval)
+
 		// it does not make sense in the first iteration,
 		// but saves allocations in further iterations
 		pairs = pairs[:0]
@@ -141,8 +145,6 @@ func (s *Collector) Run() {
 				logrus.Errorf("collecting stats for %s: %v", pair.container.ID, err)
 			}
 		}
-
-		time.Sleep(s.interval)
 	}
 }
 


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/36608

Commit https://github.com/moby/moby/pull/36519/commits/fd0e24b7189374e0fe7c55b6d26ee916d3ee1655 (https://github.com/moby/moby/pull/36519) changed the stats collection loop to use a `sleep()` instead of `time.Tick()` in the for-loop.

This change caused a regression in situations where no stats are being collected, or an error is hit in the loop (in which case the loop would `continue`, and the `sleep()` is not hit).

This patch puts the sleep at the start of the loop to guarantee it's always hit.

This will delay the sampling, which is similar to the behavior before https://github.com/moby/moby/pull/36519/commits/fd0e24b7189374e0fe7c55b6d26ee916d3ee1655.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
