### PR TITLE
Windows: Hyper-V containers are broken after 36586 was merged

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -221,9 +221,6 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 
 // Sets the Windows-specific fields of the OCI spec
 func (daemon *Daemon) createSpecWindowsFields(c *container.Container, s *specs.Spec, isHyperV bool) error {
-	if c.BaseFS == nil {
-		return errors.New("createSpecWindowsFields: BaseFS of container " + c.ID + " is unexpectedly nil")
-	}
 	if len(s.Process.Cwd) == 0 {
 		// We default to C:\ to workaround the oddity of the case that the
 		// default directory for cmd running as LocalSystem (or
@@ -237,6 +234,10 @@ func (daemon *Daemon) createSpecWindowsFields(c *container.Container, s *specs.S
 
 	s.Root.Readonly = false // Windows does not support a read-only root filesystem
 	if !isHyperV {
+		if c.BaseFS == nil {
+			return errors.New("createSpecWindowsFields: BaseFS of container " + c.ID + " is unexpectedly nil")
+		}
+
 		s.Root.Path = c.BaseFS.Path() // This is not set for Hyper-V containers
 		if !strings.HasSuffix(s.Root.Path, `\`) {
 			s.Root.Path = s.Root.Path + `\` // Ensure a correctly formatted volume GUID path \\?\Volume{GUID}\


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@kolyshkin The fix in https://github.com/moby/moby/pull/36586 was too aggressive and stops Hyper-V containers from working (effectively this means all use of Docker on Windows 10). I moved the check to only apply for Windows Server containers

@thaJeztah @johnstep @vdemeester PTAL