### PR TITLE
TestPostContainersAttach: minor improvements

### DIFF
--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/integration-cli/request"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/go-check/check"
+	"github.com/pkg/errors"
 	"golang.org/x/net/websocket"
 )
 
@@ -176,7 +177,6 @@ func (s *DockerSuite) TestPostContainersAttach(c *check.C) {
 	expectTimeout(conn, br, "stdout")
 
 	// Test the client API
-	// Make sure we don't see "hello" if Logs is false
 	client, err := client.NewEnvClient()
 	c.Assert(err, checker.IsNil)
 	defer client.Close()
@@ -184,10 +184,13 @@ func (s *DockerSuite) TestPostContainersAttach(c *check.C) {
 	cid, _ = dockerCmd(c, "run", "-di", "busybox", "/bin/sh", "-c", "echo hello; cat")
 	cid = strings.TrimSpace(cid)
 
+	// Make sure we don't see "hello" if Logs is false
 	attachOpts := types.ContainerAttachOptions{
 		Stream: true,
 		Stdin:  true,
 		Stdout: true,
+		Stderr: true,
+		Logs:   false,
 	}
 
 	resp, err := client.ContainerAttach(context.Background(), cid, attachOpts)
@@ -205,10 +208,15 @@ func (s *DockerSuite) TestPostContainersAttach(c *check.C) {
 	_, err = resp.Conn.Write([]byte("success"))
 	c.Assert(err, checker.IsNil)
 
-	actualStdout := new(bytes.Buffer)
-	actualStderr := new(bytes.Buffer)
-	stdcopy.StdCopy(actualStdout, actualStderr, resp.Reader)
-	c.Assert(actualStdout.Bytes(), checker.DeepEquals, []byte("hello\nsuccess"), check.Commentf("Attach didn't return the expected data from stdout"))
+	var outBuf, errBuf bytes.Buffer
+	_, err = stdcopy.StdCopy(&outBuf, &errBuf, resp.Reader)
+	if err != nil && errors.Cause(err).(net.Error).Timeout() {
+		// ignore the timeout error as it is expected
+		err = nil
+	}
+	c.Assert(err, checker.IsNil)
+	c.Assert(errBuf.String(), checker.Equals, "")
+	c.Assert(outBuf.String(), checker.Equals, "hello\nsuccess")
 }
 
 // SockRequestHijack creates a connection to specified host (with method, contenttype, …) and returns a hijacked connection


### PR DESCRIPTION
The API part of this test (the last test case in TestPostContainerAttach) is flaky, i.e. it sometimes fails on powerpc or s390 like this:

```
> FAIL: docker_api_attach_test.go:98: DockerSuite.TestPostContainersAttach
> docker_api_attach_test.go:211:
>     c.Assert(actualStdout.Bytes(), checker.DeepEquals, []byte("hello\nsuccess"), check.Commentf("Attach didn't return the expected data from stdout"))
> ... obtained []uint8 = []byte{0x73, 0x75, 0x63, 0x63, 0x65, 0x73, 0x73}
> ... expected []uint8 = []byte{0x68, 0x65, 0x6c, 0x6c, 0x6f, 0xa, 0x73, 0x75, 0x63, 0x63, 0x65, 0x73, 0x73}
> ... Attach didn't return the expected data from stdout
```

Is seems that "success" is returned but "hello\n" is not (as if ContainerAttachOptions.Logs was false).

After a careful code audit I still can't figure out why it fails. The two major differences from the other cases are:

 - it uses API (ContainerAttach()) rather than sockRequestHijack();
 - it uses stdcopy.StdCopy() not io.ReadFull(),

Nevertheless it looks _almost_ legit, except for ignoring the error from StdCopy. So I don't know how to fix it. Still, there are some things that can be improved here, including:

1. Get the container's stderr as well, make sure it's empty.

2. Check that stdcopy.StdCopy() did not return an error.

3. Use strings, so the test output will be more readable.

4. Nitpicks; move/remove comments, simplify var names.

This should ultimately fix https://github.com/moby/moby/issues/36611