### PR TITLE
Add the missing call to setupTest to TestNetworkLoopbackNat test

### DIFF
--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -59,6 +59,8 @@ func TestNetworkLocalhostTCPNat(t *testing.T) {
 func TestNetworkLoopbackNat(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon())
 
+	defer setupTest(t)()
+
 	msg := "it works"
 	startServerContainer(t, msg, 8080)
 


### PR DESCRIPTION
Added a call to `setupTest()` to `TestNetworkLoopbackNat()` test function, to avoid leaving behind test containers.

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Cleaned up the test containers left behind by the `TestNetworkLoopbackNat` test.

**- How I did it**
Added a call to `setupTest()` in the test function.

**- How to verify it**
Currently, running the integration test suite leaves behind the test containers created by `TestNetworkLoopbackNat`:

```
$ docker ps -a --no-trunc
CONTAINER ID                                                       IMAGE               COMMAND                                         CREATED              STATUS                          PORTS               NAMES
b3c9852aa6ef51f518fe27e7bd9de5871e00781c97f639cd1a4fe86d0c610d87   busybox             "sh -c 'stty raw && nc -w 5 172.17.0.3 8080'"   About a minute ago   Exited (0) About a minute ago                       peaceful_khorana
7da88c6b47d62333fc3a90a23a38cdfa43afa7f36ce7cb8fe8aa811042c1f76f   busybox             "sh -c 'echo \"it works\" | nc -lp 8080'"       About a minute ago   Exited (0) About a minute ago                       server
```

With the changes proposed by this PR, the above containers get cleaned up once the test is done.

**- Description for the changelog**
Added a call to setupTest() to TestNetworkLoopbackNat() 

**- A picture of a cute animal (not mandatory but encouraged)**

