### PR TITLE
No global volume driver store

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -179,11 +179,6 @@ func (daemon *Daemon) restore() error {
 			delete(containers, id)
 			continue
 		}
-		// verify that all volumes valid and have been migrated from the pre-1.7 layout
-		if err := daemon.verifyVolumesInfo(c); err != nil {
-			// don't skip the container due to error
-			logrus.Errorf("Failed to verify volumes for container '%s': %v", c.ID, err)
-		}
 		if err := daemon.Register(c); err != nil {
 			logrus.Errorf("Failed to register container %s: %s", c.ID, err)
 			delete(containers, id)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1145,17 +1145,15 @@ func setDefaultMtu(conf *config.Config) {
 }
 
 func (daemon *Daemon) configureVolumes(rootIDs idtools.IDPair) (*store.VolumeStore, error) {
-	volumesDriver, err := local.New(daemon.configStore.Root, rootIDs)
+	volumeDriver, err := local.New(daemon.configStore.Root, rootIDs)
 	if err != nil {
 		return nil, err
 	}
-
-	volumedrivers.RegisterPluginGetter(daemon.PluginStore)
-
-	if !volumedrivers.Register(volumesDriver, volumesDriver.Name()) {
+	drivers := volumedrivers.NewStore(daemon.PluginStore)
+	if !drivers.Register(volumeDriver, volumeDriver.Name()) {
 		return nil, errors.New("local volume driver could not be registered")
 	}
-	return store.New(daemon.configStore.Root)
+	return store.New(daemon.configStore.Root, drivers)
 }
 
 // IsShuttingDown tells whether the daemon is shutting down or not

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -13,7 +13,6 @@ import (
 	_ "github.com/docker/docker/pkg/discovery/memory"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/truncindex"
-	"github.com/docker/docker/volume"
 	volumedrivers "github.com/docker/docker/volume/drivers"
 	"github.com/docker/docker/volume/local"
 	"github.com/docker/docker/volume/store"
@@ -121,7 +120,8 @@ func initDaemonWithVolumeStore(tmp string) (*Daemon, error) {
 		repository: tmp,
 		root:       tmp,
 	}
-	daemon.volumes, err = store.New(tmp)
+	drivers := volumedrivers.NewStore(nil)
+	daemon.volumes, err = store.New(tmp, drivers)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func initDaemonWithVolumeStore(tmp string) (*Daemon, error) {
 	if err != nil {
 		return nil, err
 	}
-	volumedrivers.Register(volumesDriver, volumesDriver.Name())
+	drivers.Register(volumesDriver, volumesDriver.Name())
 
 	return daemon, nil
 }
@@ -208,7 +208,6 @@ func TestContainerInitDNS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer volumedrivers.Unregister(volume.DefaultDriverName)
 
 	c, err := daemon.load(containerID)
 	if err != nil {

--- a/daemon/daemon_unix_test.go
+++ b/daemon/daemon_unix_test.go
@@ -6,18 +6,11 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/config"
-	"github.com/docker/docker/pkg/idtools"
-	"github.com/docker/docker/volume"
-	"github.com/docker/docker/volume/drivers"
-	"github.com/docker/docker/volume/local"
-	"github.com/docker/docker/volume/store"
-	"github.com/gotestyourself/gotestyourself/assert"
 )
 
 type fakeContainerGetter struct {
@@ -271,87 +264,5 @@ func TestNetworkOptions(t *testing.T) {
 
 	if _, err := daemon.networkOptions(dconfigWrong, nil, nil); err == nil {
 		t.Fatal("Expected networkOptions error, got nil")
-	}
-}
-
-func TestMigratePre17Volumes(t *testing.T) {
-	rootDir, err := ioutil.TempDir("", "test-daemon-volumes")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(rootDir)
-
-	volumeRoot := filepath.Join(rootDir, "volumes")
-	err = os.MkdirAll(volumeRoot, 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	containerRoot := filepath.Join(rootDir, "containers")
-	cid := "1234"
-	err = os.MkdirAll(filepath.Join(containerRoot, cid), 0755)
-	assert.NilError(t, err)
-
-	vid := "5678"
-	vfsPath := filepath.Join(rootDir, "vfs", "dir", vid)
-	err = os.MkdirAll(vfsPath, 0755)
-	assert.NilError(t, err)
-
-	config := []byte(`
-		{
-			"ID": "` + cid + `",
-			"Volumes": {
-				"/foo": "` + vfsPath + `",
-				"/bar": "/foo",
-				"/quux": "/quux"
-			},
-			"VolumesRW": {
-				"/foo": true,
-				"/bar": true,
-				"/quux": false
-			}
-		}
-	`)
-
-	volStore, err := store.New(volumeRoot)
-	if err != nil {
-		t.Fatal(err)
-	}
-	drv, err := local.New(volumeRoot, idtools.IDPair{UID: 0, GID: 0})
-	if err != nil {
-		t.Fatal(err)
-	}
-	volumedrivers.Register(drv, volume.DefaultDriverName)
-
-	daemon := &Daemon{
-		root:       rootDir,
-		repository: containerRoot,
-		volumes:    volStore,
-	}
-	err = ioutil.WriteFile(filepath.Join(containerRoot, cid, "config.v2.json"), config, 600)
-	if err != nil {
-		t.Fatal(err)
-	}
-	c, err := daemon.load(cid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := daemon.verifyVolumesInfo(c); err != nil {
-		t.Fatal(err)
-	}
-
-	expected := map[string]volume.MountPoint{
-		"/foo":  {Destination: "/foo", RW: true, Name: vid},
-		"/bar":  {Source: "/foo", Destination: "/bar", RW: true},
-		"/quux": {Source: "/quux", Destination: "/quux", RW: false},
-	}
-	for id, mp := range c.MountPoints {
-		x, exists := expected[id]
-		if !exists {
-			t.Fatal("volume not migrated")
-		}
-		if mp.Source != x.Source || mp.Destination != x.Destination || mp.RW != x.RW || mp.Name != x.Name {
-			t.Fatalf("got unexpected mountpoint, expected: %+v, got: %+v", x, mp)
-		}
 	}
 }

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -632,13 +632,6 @@ func setupDaemonProcess(config *config.Config) error {
 	return nil
 }
 
-// verifyVolumesInfo is a no-op on windows.
-// This is called during daemon initialization to migrate volumes from pre-1.7.
-// volumes were not supported on windows pre-1.7
-func (daemon *Daemon) verifyVolumesInfo(container *container.Container) error {
-	return nil
-}
-
 func (daemon *Daemon) setupSeccompProfile() error {
 	return nil
 }

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -19,7 +19,6 @@ import (
 	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/registry"
-	"github.com/docker/docker/volume/drivers"
 	"github.com/docker/go-connections/sockets"
 	"github.com/sirupsen/logrus"
 )
@@ -196,7 +195,7 @@ func (daemon *Daemon) SystemVersion() types.Version {
 func (daemon *Daemon) showPluginsInfo() types.PluginsInfo {
 	var pluginsInfo types.PluginsInfo
 
-	pluginsInfo.Volume = volumedrivers.GetDriverList()
+	pluginsInfo.Volume = daemon.volumes.GetDriverList()
 	pluginsInfo.Network = daemon.GetNetworkDriverList()
 	// The authorization plugins are returned in the order they are
 	// used as they constitute a request/response modification chain.

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -1,7 +1,6 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -15,7 +14,6 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/volume"
-	"github.com/docker/docker/volume/drivers"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -384,33 +382,4 @@ func (daemon *Daemon) backportMountSpec(container *container.Container) {
 		cm.Spec.Target = cm.Destination
 		cm.Spec.ReadOnly = !cm.RW
 	}
-}
-
-func (daemon *Daemon) traverseLocalVolumes(fn func(volume.Volume) error) error {
-	localVolumeDriver, err := volumedrivers.GetDriver(volume.DefaultDriverName)
-	if err != nil {
-		return fmt.Errorf("can't retrieve local volume driver: %v", err)
-	}
-	vols, err := localVolumeDriver.List()
-	if err != nil {
-		return fmt.Errorf("can't retrieve local volumes: %v", err)
-	}
-
-	for _, v := range vols {
-		name := v.Name()
-		vol, err := daemon.volumes.Get(name)
-		if err != nil {
-			logrus.Warnf("failed to retrieve volume %s from store: %v", name, err)
-		} else {
-			// daemon.volumes.Get will return DetailedVolume
-			v = vol
-		}
-
-		err = fn(v)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -3,10 +3,8 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -15,9 +13,6 @@ import (
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/volume"
-	"github.com/docker/docker/volume/drivers"
-	"github.com/docker/docker/volume/local"
-	"github.com/pkg/errors"
 )
 
 // setupMounts iterates through each of the mount points for a container and
@@ -111,80 +106,6 @@ func setBindModeIfNull(bind *volume.MountPoint) {
 	if bind.Mode == "" {
 		bind.Mode = "z"
 	}
-}
-
-// migrateVolume links the contents of a volume created pre Docker 1.7
-// into the location expected by the local driver.
-// It creates a symlink from DOCKER_ROOT/vfs/dir/VOLUME_ID to DOCKER_ROOT/volumes/VOLUME_ID/_container_data.
-// It preserves the volume json configuration generated pre Docker 1.7 to be able to
-// downgrade from Docker 1.7 to Docker 1.6 without losing volume compatibility.
-func migrateVolume(id, vfs string) error {
-	l, err := volumedrivers.GetDriver(volume.DefaultDriverName)
-	if err != nil {
-		return err
-	}
-
-	newDataPath := l.(*local.Root).DataPath(id)
-	fi, err := os.Stat(newDataPath)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	if fi != nil && fi.IsDir() {
-		return nil
-	}
-
-	return os.Symlink(vfs, newDataPath)
-}
-
-// verifyVolumesInfo ports volumes configured for the containers pre docker 1.7.
-// It reads the container configuration and creates valid mount points for the old volumes.
-func (daemon *Daemon) verifyVolumesInfo(container *container.Container) error {
-	container.Lock()
-	defer container.Unlock()
-
-	// Inspect old structures only when we're upgrading from old versions
-	// to versions >= 1.7 and the MountPoints has not been populated with volumes data.
-	type volumes struct {
-		Volumes   map[string]string
-		VolumesRW map[string]bool
-	}
-	cfgPath, err := container.ConfigPath()
-	if err != nil {
-		return err
-	}
-	f, err := os.Open(cfgPath)
-	if err != nil {
-		return errors.Wrap(err, "could not open container config")
-	}
-	defer f.Close()
-	var cv volumes
-	if err := json.NewDecoder(f).Decode(&cv); err != nil {
-		return errors.Wrap(err, "could not decode container config")
-	}
-
-	if len(container.MountPoints) == 0 && len(cv.Volumes) > 0 {
-		for destination, hostPath := range cv.Volumes {
-			vfsPath := filepath.Join(daemon.root, "vfs", "dir")
-			rw := cv.VolumesRW != nil && cv.VolumesRW[destination]
-
-			if strings.HasPrefix(hostPath, vfsPath) {
-				id := filepath.Base(hostPath)
-				v, err := daemon.volumes.CreateWithRef(id, volume.DefaultDriverName, container.ID, nil, nil)
-				if err != nil {
-					return err
-				}
-				if err := migrateVolume(id, hostPath); err != nil {
-					return err
-				}
-				container.AddMountPointWithVolume(destination, v, true)
-			} else { // Bind mount
-				m := volume.MountPoint{Source: hostPath, Destination: destination, RW: rw}
-				container.MountPoints[destination] = &m
-			}
-		}
-	}
-	return nil
 }
 
 func (daemon *Daemon) mountVolumes(container *container.Container) error {

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -35,7 +35,6 @@ import (
 	testdaemon "github.com/docker/docker/internal/test/daemon"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/mount"
-	"github.com/docker/docker/pkg/stringid"
 	units "github.com/docker/go-units"
 	"github.com/docker/libnetwork/iptables"
 	"github.com/docker/libtrust"
@@ -2670,84 +2669,6 @@ func (s *DockerDaemonSuite) TestDaemonRestartSaveContainerExitCode(c *check.C) {
 	out = strings.TrimSpace(out)
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Equals, errMsg1)
-}
-
-func (s *DockerDaemonSuite) TestDaemonBackcompatPre17Volumes(c *check.C) {
-	testRequires(c, SameHostDaemon)
-	d := s.d
-	d.StartWithBusybox(c)
-
-	// hack to be able to side-load a container config
-	out, err := d.Cmd("create", "busybox:latest")
-	c.Assert(err, checker.IsNil, check.Commentf(out))
-	id := strings.TrimSpace(out)
-
-	out, err = d.Cmd("inspect", "--type=image", "--format={{.ID}}", "busybox:latest")
-	c.Assert(err, checker.IsNil, check.Commentf(out))
-	d.Stop(c)
-	<-d.Wait
-
-	imageID := strings.TrimSpace(out)
-	volumeID := stringid.GenerateNonCryptoID()
-	vfsPath := filepath.Join(d.Root, "vfs", "dir", volumeID)
-	c.Assert(os.MkdirAll(vfsPath, 0755), checker.IsNil)
-
-	config := []byte(`
-		{
-			"ID": "` + id + `",
-			"Name": "hello",
-			"Driver": "` + d.StorageDriver() + `",
-			"Image": "` + imageID + `",
-			"Config": {"Image": "busybox:latest"},
-			"NetworkSettings": {},
-			"Volumes": {
-				"/bar":"/foo",
-				"/foo": "` + vfsPath + `",
-				"/quux":"/quux"
-			},
-			"VolumesRW": {
-				"/bar": true,
-				"/foo": true,
-				"/quux": false
-			}
-		}
-	`)
-
-	configPath := filepath.Join(d.Root, "containers", id, "config.v2.json")
-	c.Assert(ioutil.WriteFile(configPath, config, 600), checker.IsNil)
-	d.Start(c)
-
-	out, err = d.Cmd("inspect", "--type=container", "--format={{ json .Mounts }}", id)
-	c.Assert(err, checker.IsNil, check.Commentf(out))
-	type mount struct {
-		Name        string
-		Source      string
-		Destination string
-		Driver      string
-		RW          bool
-	}
-
-	ls := []mount{}
-	err = json.NewDecoder(strings.NewReader(out)).Decode(&ls)
-	c.Assert(err, checker.IsNil)
-
-	expected := []mount{
-		{Source: "/foo", Destination: "/bar", RW: true},
-		{Name: volumeID, Destination: "/foo", RW: true},
-		{Source: "/quux", Destination: "/quux", RW: false},
-	}
-	c.Assert(ls, checker.HasLen, len(expected))
-
-	for _, m := range ls {
-		var matched bool
-		for _, x := range expected {
-			if m.Source == x.Source && m.Destination == x.Destination && m.RW == x.RW || m.Name != x.Name {
-				matched = true
-				break
-			}
-		}
-		c.Assert(matched, checker.True, check.Commentf("did find match for %+v", m))
-	}
 }
 
 func (s *DockerDaemonSuite) TestDaemonWithUserlandProxyPath(c *check.C) {

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -1,4 +1,4 @@
-package volumedrivers // import "github.com/docker/docker/volume/drivers"
+package drivers // import "github.com/docker/docker/volume/drivers"
 
 import (
 	"errors"

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -1,6 +1,6 @@
 //go:generate pluginrpc-gen -i $GOFILE -o proxy.go -type volumeDriver -name VolumeDriver
 
-package volumedrivers // import "github.com/docker/docker/volume/drivers"
+package drivers // import "github.com/docker/docker/volume/drivers"
 
 import (
 	"fmt"

--- a/volume/drivers/extpoint_test.go
+++ b/volume/drivers/extpoint_test.go
@@ -7,13 +7,14 @@ import (
 )
 
 func TestGetDriver(t *testing.T) {
-	_, err := GetDriver("missing")
+	s := NewStore(nil)
+	_, err := s.GetDriver("missing")
 	if err == nil {
 		t.Fatal("Expected error, was nil")
 	}
-	Register(volumetestutils.NewFakeDriver("fake"), "fake")
+	s.Register(volumetestutils.NewFakeDriver("fake"), "fake")
 
-	d, err := GetDriver("fake")
+	d, err := s.GetDriver("fake")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/volume/drivers/extpoint_test.go
+++ b/volume/drivers/extpoint_test.go
@@ -1,4 +1,4 @@
-package volumedrivers // import "github.com/docker/docker/volume/drivers"
+package drivers // import "github.com/docker/docker/volume/drivers"
 
 import (
 	"testing"

--- a/volume/drivers/proxy.go
+++ b/volume/drivers/proxy.go
@@ -1,6 +1,6 @@
 // generated code - DO NOT EDIT
 
-package volumedrivers // import "github.com/docker/docker/volume/drivers"
+package drivers // import "github.com/docker/docker/volume/drivers"
 
 import (
 	"errors"

--- a/volume/drivers/proxy_test.go
+++ b/volume/drivers/proxy_test.go
@@ -1,4 +1,4 @@
-package volumedrivers // import "github.com/docker/docker/volume/drivers"
+package drivers // import "github.com/docker/docker/volume/drivers"
 
 import (
 	"fmt"

--- a/volume/store/restore.go
+++ b/volume/store/restore.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/docker/docker/volume"
-	"github.com/docker/docker/volume/drivers"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,7 +32,7 @@ func (s *VolumeStore) restore() {
 			var v volume.Volume
 			var err error
 			if meta.Driver != "" {
-				v, err = lookupVolume(meta.Driver, meta.Name)
+				v, err = lookupVolume(s.drivers, meta.Driver, meta.Name)
 				if err != nil && err != errNoSuchVolume {
 					logrus.WithError(err).WithField("driver", meta.Driver).WithField("volume", meta.Name).Warn("Error restoring volume")
 					return
@@ -59,7 +58,7 @@ func (s *VolumeStore) restore() {
 			}
 
 			// increment driver refcount
-			volumedrivers.CreateDriver(meta.Driver)
+			s.drivers.CreateDriver(meta.Driver)
 
 			// cache the volume
 			s.globalLock.Lock()

--- a/volume/store/restore_test.go
+++ b/volume/store/restore_test.go
@@ -18,11 +18,11 @@ func TestRestore(t *testing.T) {
 	assert.NilError(t, err)
 	defer os.RemoveAll(dir)
 
+	drivers := volumedrivers.NewStore(nil)
 	driverName := "test-restore"
-	volumedrivers.Register(volumetestutils.NewFakeDriver(driverName), driverName)
-	defer volumedrivers.Unregister("test-restore")
+	drivers.Register(volumetestutils.NewFakeDriver(driverName), driverName)
 
-	s, err := New(dir)
+	s, err := New(dir, drivers)
 	assert.NilError(t, err)
 	defer s.Shutdown()
 
@@ -36,7 +36,7 @@ func TestRestore(t *testing.T) {
 
 	s.Shutdown()
 
-	s, err = New(dir)
+	s, err = New(dir, drivers)
 	assert.NilError(t, err)
 
 	v, err := s.Get("test1")


### PR DESCRIPTION
Refactors volume driver storage to not use a global store.
This makes things a bit nicer to deal with, especially in tests which are now much more easily parallelized.
