### PR TITLE
[WIP] Set SELinux labels, and NoNewPrivileges on exec'd process

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -422,7 +422,7 @@ func (container *Container) StartLogger() (logger.Logger, error) {
 func (container *Container) GetProcessLabel() string {
 	// even if we have a process label return "" if we are running
 	// in privileged mode
-	if container.HostConfig.Privileged {
+	if container.HostConfig != nil && container.HostConfig.Privileged {
 		return ""
 	}
 	return container.ProcessLabel

--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -54,6 +54,13 @@ func (daemon *Daemon) execSetPlatformOpt(c *container.Container, ec *exec.Config
 		}
 		p.ApparmorProfile = appArmorProfile
 	}
+	if !ec.Privileged {
+		// Do not use c.GetProcessLabel() here, because exec "Privileged" is
+		// separate from the containers' "HostConfig.Privileged"
+		p.SelinuxLabel = c.ProcessLabel
+		p.NoNewPrivileges = c.NoNewPrivileges
+	}
+
 	daemon.setRlimits(&specs.Spec{Process: p}, c)
 	return nil
 }

--- a/daemon/exec_linux_test.go
+++ b/daemon/exec_linux_test.go
@@ -14,40 +14,49 @@ import (
 )
 
 func TestExecSetPlatformOpt(t *testing.T) {
-	if !apparmor.IsEnabled() {
-		t.Skip("requires AppArmor to be enabled")
-	}
 	d := &Daemon{}
-	c := &container.Container{AppArmorProfile: "my-custom-profile"}
+	c := &container.Container{
+		AppArmorProfile: "my-custom-profile",
+		ProcessLabel:    "some-selinux-label",
+	}
 	ec := &exec.Config{}
 	p := &specs.Process{}
 
 	err := d.execSetPlatformOpt(c, ec, p)
 	assert.NilError(t, err)
-	assert.Equal(t, "my-custom-profile", p.ApparmorProfile)
+	if apparmor.IsEnabled() {
+		assert.Equal(t, "my-custom-profile", p.ApparmorProfile)
+	}
+	assert.Equal(t, "some-selinux-label", p.SelinuxLabel)
 }
 
 // TestExecSetPlatformOptPrivileged verifies that `docker exec --privileged`
-// does not disable AppArmor profiles. Exec currently inherits the `Privileged`
+// does not disable AppArmor and SELinux profiles. Exec currently inherits the `Privileged`
 // configuration of the container. See https://github.com/moby/moby/pull/31773#discussion_r105586900
 //
 // This behavior may change in future, but test for the behavior to prevent it
 // from being changed accidentally.
 func TestExecSetPlatformOptPrivileged(t *testing.T) {
-	if !apparmor.IsEnabled() {
-		t.Skip("requires AppArmor to be enabled")
-	}
 	d := &Daemon{}
-	c := &container.Container{AppArmorProfile: "my-custom-profile"}
+	c := &container.Container{
+		AppArmorProfile: "my-custom-profile",
+		ProcessLabel:    "some-selinux-label",
+	}
 	ec := &exec.Config{Privileged: true}
 	p := &specs.Process{}
 
 	err := d.execSetPlatformOpt(c, ec, p)
 	assert.NilError(t, err)
-	assert.Equal(t, "my-custom-profile", p.ApparmorProfile)
+	if apparmor.IsEnabled() {
+		assert.Equal(t, "my-custom-profile", p.ApparmorProfile)
+	}
+	assert.Equal(t, "some-selinux-label", p.SelinuxLabel)
 
 	c.HostConfig = &containertypes.HostConfig{Privileged: true}
 	err = d.execSetPlatformOpt(c, ec, p)
 	assert.NilError(t, err)
-	assert.Equal(t, "unconfined", p.ApparmorProfile)
+	if apparmor.IsEnabled() {
+		assert.Equal(t, "unconfined", p.ApparmorProfile)
+	}
+	assert.Equal(t, "", p.SelinuxLabel)
 }

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -135,18 +135,19 @@ func (daemon *Daemon) setDevices(s *specs.Spec, c *container.Container) error {
 func (daemon *Daemon) setRlimits(s *specs.Spec, c *container.Container) error {
 	var rlimits []specs.POSIXRlimit
 
-	// We want to leave the original HostConfig alone so make a copy here
-	hostConfig := *c.HostConfig
-	// Merge with the daemon defaults
-	daemon.mergeUlimits(&hostConfig)
-	for _, ul := range hostConfig.Ulimits {
-		rlimits = append(rlimits, specs.POSIXRlimit{
-			Type: "RLIMIT_" + strings.ToUpper(ul.Name),
-			Soft: uint64(ul.Soft),
-			Hard: uint64(ul.Hard),
-		})
+	if c.HostConfig != nil {
+		// We want to leave the original HostConfig alone so make a copy here
+		hostConfig := *c.HostConfig
+		// Merge with the daemon defaults
+		daemon.mergeUlimits(&hostConfig)
+		for _, ul := range hostConfig.Ulimits {
+			rlimits = append(rlimits, specs.POSIXRlimit{
+				Type: "RLIMIT_" + strings.ToUpper(ul.Name),
+				Soft: uint64(ul.Soft),
+				Hard: uint64(ul.Hard),
+			})
+		}
 	}
-
 	s.Process.Rlimits = rlimits
 	return nil
 }


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/37667

Processes started through `docker exec` did not automatically inherit the SELinux labels, and "No New Privileges" configuration from the containers' main process.

Making this "WIP", pending tests

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

