### PR TITLE
api: add MaskedPaths and ReadonlyPaths options

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -772,6 +772,16 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+          MaskedPaths:
+            type: "array"
+            description: "The list of paths to be masked inside the container (this overrides the default set of paths)"
+            items:
+              type: "string"
+          ReadonlyPaths:
+            type: "array"
+            description: "The list of paths to be set as read-only inside the container (this overrides the default set of paths)"
+            items:
+              type: "string"
 
   ContainerConfig:
     description: "Configuration for a container that is portable between hosts"

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -401,6 +401,12 @@ type HostConfig struct {
 	// Mounts specs used by the container
 	Mounts []mount.Mount `json:",omitempty"`
 
+	// MaskedPaths is the list of paths to be masked inside the container (this overrides the default set of paths)
+	MaskedPaths []string
+
+	// ReadonlyPaths is the list of paths to be set as read-only inside the container (this overrides the default set of paths)
+	ReadonlyPaths []string
+
 	// Run a custom init inside the container, if null, use the daemon's configured settings
 	Init *bool `json:",omitempty"`
 }

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -11,6 +11,7 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/oci"
 	"github.com/docker/docker/pkg/stringid"
 	volumeopts "github.com/docker/docker/volume/service/opts"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -27,6 +28,16 @@ func (daemon *Daemon) createContainerOSSpecificSettings(container *container.Con
 	rootIDs := daemon.idMappings.RootPair()
 	if err := container.SetupWorkingDirectory(rootIDs); err != nil {
 		return err
+	}
+
+	// Set the default masked and readonly paths with regard to the host config options if they are not set.
+	if hostConfig.MaskedPaths == nil && !hostConfig.Privileged {
+		hostConfig.MaskedPaths = oci.DefaultSpec().Linux.MaskedPaths // Set it to the default if nil
+		container.HostConfig.MaskedPaths = hostConfig.MaskedPaths
+	}
+	if hostConfig.ReadonlyPaths == nil && !hostConfig.Privileged {
+		hostConfig.ReadonlyPaths = oci.DefaultSpec().Linux.ReadonlyPaths // Set it to the default if nil
+		container.HostConfig.ReadonlyPaths = hostConfig.ReadonlyPaths
 	}
 
 	for spec := range config.Volumes {

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -903,6 +903,14 @@ func (daemon *Daemon) createSpec(c *container.Container) (retSpec *specs.Spec, e
 	s.Process.OOMScoreAdj = &c.HostConfig.OomScoreAdj
 	s.Linux.MountLabel = c.MountLabel
 
+	// Set the masked and readonly paths with regard to the host config options if they are set.
+	if c.HostConfig.MaskedPaths != nil {
+		s.Linux.MaskedPaths = c.HostConfig.MaskedPaths
+	}
+	if c.HostConfig.ReadonlyPaths != nil {
+		s.Linux.ReadonlyPaths = c.HostConfig.ReadonlyPaths
+	}
+
 	return &s, nil
 }
 


### PR DESCRIPTION
This adds a RawAccess option to HostConfig for containers so that a user
can pass in an array of paths to not be set as masked or readonly.

closes #36597

**- What I did**

Added new API options for `Masked Paths` and `ReadonlyPaths` to the container `HostConfig`

**- How I did it**

Added it to the API and oci package.

**- How to verify it**

I wrote a test.

**- Description for the changelog**
RawAccess allows a set of paths to be not set as masked or readonly


**- A picture of a cute animal (not mandatory but encouraged)**
![blizzardslide2](https://user-images.githubusercontent.com/1445228/37673201-042a35cc-2c46-11e8-9bdf-2211189b6fc7.jpg)


