### PR TITLE
Add if judgment before receiving operations on daemonWaitCh

### DIFF
--- a/libcontainerd/remote_daemon.go
+++ b/libcontainerd/remote_daemon.go
@@ -307,7 +307,9 @@ func (r *remote) monitorConnection(monitor *containerd.Client) {
 			<-time.After(100 * time.Millisecond)
 			system.KillProcess(r.daemonPid)
 		}
-		<-r.daemonWaitCh
+		if r.daemonWaitCh != nil {
+			<-r.daemonWaitCh
+		}
 
 		monitor.Close()
 		os.Remove(r.GRPC.Address)


### PR DESCRIPTION
Receive operations on a nil channel will always block, when receive from daemonWaitCh, if daemonWaitCh 
 is nil, it lead containerd not started.

Signed-off-by: Shukui Yang <yangshukui@huawei.com>

## How to reproduce
```
root@ubuntu:~# sleep 10000 &
[1] 17064
root@ubuntu:~# echo -n 17064 > /run/docker/containerd/docker-containerd.pid   
root@ubuntu:~# ps -eaf|grep docker
root     17078 17008  0 06:02 pts/1    00:00:00 grep docker
root     29413     1  0 Feb12 ?        01:15:58 /usr/bin/dockerd -H fd://
root     29419 29413  0 Feb12 ?        04:00:35 docker-containerd --config /var/run/docker/containerd/containerd.toml
root@ubuntu:~# kill -9 29413
root@ubuntu:~# systemctl start docker
root@ubuntu:~# ps -eaf|grep docker   
root     17109     1  2 06:03 ?        00:00:00 /usr/bin/dockerd -H fd://
root     17238 17008  0 06:03 pts/1    00:00:00 grep docker
root@ubuntu:~# 
```