### PR TITLE
Split daemon service code to _windows file

### DIFF
--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -104,10 +104,6 @@ func allocateDaemonPort(addr string) error {
 	return nil
 }
 
-// notifyShutdown is called after the daemon shuts down but before the process exits.
-func notifyShutdown(err error) {
-}
-
 func wrapListeners(proto string, ls []net.Listener) []net.Listener {
 	switch proto {
 	case "unix":

--- a/cmd/dockerd/docker_unix.go
+++ b/cmd/dockerd/docker_unix.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package main
+
+func runDaemon(opts *daemonOptions) error {
+	daemonCli := NewDaemonCli()
+	return daemonCli.start(opts)
+}

--- a/cmd/dockerd/docker_windows.go
+++ b/cmd/dockerd/docker_windows.go
@@ -1,5 +1,38 @@
 package main
 
 import (
+	"path/filepath"
+
 	_ "github.com/docker/docker/autogen/winresources/dockerd"
+	"github.com/sirupsen/logrus"
 )
+
+func runDaemon(opts *daemonOptions) error {
+	daemonCli := NewDaemonCli()
+
+	// On Windows, this may be launching as a service or with an option to
+	// register the service.
+	stop, runAsService, err := initService(daemonCli)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	if stop {
+		return nil
+	}
+
+	// Windows specific settings as these are not defaulted.
+	if opts.configFile == "" {
+		opts.configFile = filepath.Join(opts.daemonConfig.Root, `config\daemon.json`)
+	}
+	if runAsService {
+		// If Windows SCM manages the service - no need for PID files
+		opts.daemonConfig.Pidfile = ""
+	} else if opts.daemonConfig.Pidfile == "" {
+		opts.daemonConfig.Pidfile = filepath.Join(opts.daemonConfig.Root, "docker.pid")
+	}
+
+	err = daemonCli.start(opts)
+	notifyShutdown(err)
+	return err
+}

--- a/cmd/dockerd/service_unsupported.go
+++ b/cmd/dockerd/service_unsupported.go
@@ -6,9 +6,5 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func initService(daemonCli *DaemonCli) (bool, bool, error) {
-	return false, false, nil
-}
-
 func installServiceFlags(flags *pflag.FlagSet) {
 }


### PR DESCRIPTION
Just a minor refactor: this moves some of the code that was conditionally executed on Windows to a separate, windows-only file.

ping @jhowardmsft @vdemeester PTAL
