### PR TITLE
Use unique names for test resources of container/inspect, container/ps, container/stop tests

### DIFF
--- a/integration/container/inspect_test.go
+++ b/integration/container/inspect_test.go
@@ -22,7 +22,7 @@ func TestInspectCpusetInConfigPre120(t *testing.T) {
 	client := request.NewAPIClient(t, client.WithVersion("1.19"))
 	ctx := context.Background()
 
-	name := "cpusetinconfig-pre120"
+	name := "cpusetinconfig-pre120-" + t.Name()
 	// Create container with up to-date-API
 	container.Run(t, ctx, request.NewAPIClient(t), container.WithName(name),
 		container.WithCmd("true"),

--- a/integration/container/ps_test.go
+++ b/integration/container/ps_test.go
@@ -17,9 +17,10 @@ func TestPsFilter(t *testing.T) {
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
 
-	prev := container.Create(t, ctx, client, container.WithName("prev"))
-	container.Create(t, ctx, client, container.WithName("top"))
-	next := container.Create(t, ctx, client, container.WithName("next"))
+	prev := container.Create(t, ctx, client, container.WithName("prev-"+t.Name()))
+	topContainerName := "top-" + t.Name()
+	container.Create(t, ctx, client, container.WithName(topContainerName))
+	next := container.Create(t, ctx, client, container.WithName("next-"+t.Name()))
 
 	containerIDs := func(containers []types.Container) []string {
 		entries := []string{}
@@ -30,7 +31,7 @@ func TestPsFilter(t *testing.T) {
 	}
 
 	f1 := filters.NewArgs()
-	f1.Add("since", "top")
+	f1.Add("since", topContainerName)
 	q1, err := client.ContainerList(ctx, types.ContainerListOptions{
 		All:     true,
 		Filters: f1,
@@ -39,7 +40,7 @@ func TestPsFilter(t *testing.T) {
 	assert.Check(t, is.Contains(containerIDs(q1), next))
 
 	f2 := filters.NewArgs()
-	f2.Add("before", "top")
+	f2.Add("before", topContainerName)
 	q2, err := client.ContainerList(ctx, types.ContainerListOptions{
 		All:     true,
 		Filters: f2,

--- a/integration/container/stop_test.go
+++ b/integration/container/stop_test.go
@@ -21,7 +21,7 @@ func TestStopContainerWithRestartPolicyAlways(t *testing.T) {
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
 
-	names := []string{"verifyRestart1", "verifyRestart2"}
+	names := []string{"verifyRestart1-" + t.Name(), "verifyRestart2-" + t.Name()}
 	for _, name := range names {
 		container.Run(t, ctx, client, container.WithName(name), container.WithCmd("false"), func(c *container.TestContainerConfig) {
 			c.HostConfig.RestartPolicy.Name = "always"
@@ -49,7 +49,7 @@ func TestDeleteDevicemapper(t *testing.T) {
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
 
-	id := container.Run(t, ctx, client, container.WithName("foo"), container.WithCmd("echo"))
+	id := container.Run(t, ctx, client, container.WithName("foo-"+t.Name()), container.WithCmd("echo"))
 
 	poll.WaitOn(t, container.IsStopped(ctx, client, id), poll.WithDelay(100*time.Millisecond))
 


### PR DESCRIPTION
use unique names for resources used by integration tests container/inspect_test, container/ps_test, container/stop_test. Part of work on #36583 .

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**- What I did**
Changed integration tests container/inspect_test, container/ps_test, container/stop_test, to use unique names for test resources.

**- How I did it**
Used t.Name() with resource names (generally containers) used by the above integration tests.

**- How to verify it**

**- Description for the changelog**
Integration tests container/inspect_test, container/ps_test, container/stop_test use unique names for test resources.

**- A picture of a cute animal (not mandatory but encouraged)**

