### PR TITLE
client: fix hijackedconn reading from buffer

### DIFF
--- a/client/hijack.go
+++ b/client/hijack.go
@@ -192,7 +192,7 @@ func (cli *Client) setupHijackConn(req *http.Request, proto string) (net.Conn, e
 		// object that implements CloseWrite iff the underlying connection
 		// implements it.
 		if _, ok := c.(types.CloseWriter); ok {
-			c = &hijackedConnCloseWriter{c, br}
+			c = &hijackedConnCloseWriter{&hijackedConn{c, br}}
 		} else {
 			c = &hijackedConn{c, br}
 		}
@@ -220,7 +220,9 @@ func (c *hijackedConn) Read(b []byte) (int, error) {
 // CloseWrite().  It is returned by setupHijackConn in the case that a) there
 // was already buffered data in the http layer when Hijack() was called, and b)
 // the underlying net.Conn *does* implement CloseWrite().
-type hijackedConnCloseWriter hijackedConn
+type hijackedConnCloseWriter struct {
+	*hijackedConn
+}
 
 var _ types.CloseWriter = &hijackedConnCloseWriter{}
 


### PR DESCRIPTION
Fixes #36656
Regression from #36517

With the direct cast, the `Read` method is not inherited and the read doesn't go to the buffer but directly to the raw connection.

@jim-minter

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>


