### PR TITLE
Escape duplicated import of vendored "go-connections/nat" package

### DIFF
--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -404,3 +404,10 @@ type HostConfig struct {
 	// Run a custom init inside the container, if null, use the daemon's configured settings
 	Init *bool `json:",omitempty"`
 }
+
+// ParsePortSpecs is a proxy function to nat.ParsePortSpecs,
+// so that any applications who use this package "github.com/docker/docker/api/types/container"
+// don't have to import the vendored package "github.com/docker/go-connections" directly.
+func ParsePortSpecs(port []string) (map[nat.Port]struct{}, map[nat.Port][]nat.PortBinding, error) {
+	return nat.ParsePortSpecs(port)
+}


### PR DESCRIPTION
Fix #36664

Signed-off-by: Hiromu OCHIAI <otiai10@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Escaped duplicated import of `docker/go-connections/nat` package by users of `docker/docker/api/types/container` who want to configure `PortBindings` of container.

**- How I did it**

Capsulized `nat` package from users of `types/container` by creating proxy function to `func nat.ParsePortSpecs`

**- How to verify it**

Make sure the following code does **NOT** raise any **compiling error**.

```go
package main

import (
	"fmt"

	"github.com/docker/docker/api/types/container"
)

func main() {
	_, portmap, err := container.ParsePortSpecs([]string{})
	if err != nil {
		panic(err)
	}
	hostconfig := &container.HostConfig{
		PortBindings: portmap,
		// // Using "nat" package directly raises compiling error
		// PortBindings: &nat.PortMap{},
	}
	fmt.Printf("%+v\n", hostconfig)
}
```

**- Description for the changelog**

Add a proxy function to `nat.ParsePortSpecs` in `types/container` to capsulize vendored `nat` package.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/931554/37750977-1d0fa9bc-2dd3-11e8-85dc-8a4284b4bef2.png)
