### PR TITLE
Use unique names for container/rename_test.go

### DIFF
--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/request"
@@ -26,22 +27,24 @@ func TestRenameLinkedContainer(t *testing.T) {
 	ctx := context.Background()
 	client := request.NewAPIClient(t)
 
-	aID := container.Run(t, ctx, client, container.WithName("a0"))
-	bID := container.Run(t, ctx, client, container.WithName("b0"), container.WithLinks("a0"))
+	aName := "a0" + t.Name()
+	bName := "b0" + t.Name()
+	aID := container.Run(t, ctx, client, container.WithName(aName))
+	bID := container.Run(t, ctx, client, container.WithName(bName), container.WithLinks(aName))
 
-	err := client.ContainerRename(ctx, aID, "a1")
+	err := client.ContainerRename(ctx, aID, "a1"+t.Name())
 	assert.NilError(t, err)
 
-	container.Run(t, ctx, client, container.WithName("a0"))
+	container.Run(t, ctx, client, container.WithName(aName))
 
 	err = client.ContainerRemove(ctx, bID, types.ContainerRemoveOptions{Force: true})
 	assert.NilError(t, err)
 
-	bID = container.Run(t, ctx, client, container.WithName("b0"), container.WithLinks("a0"))
+	bID = container.Run(t, ctx, client, container.WithName(bName), container.WithLinks(aName))
 
 	inspect, err := client.ContainerInspect(ctx, bID)
 	assert.NilError(t, err)
-	assert.Check(t, is.DeepEqual([]string{"/a0:/b0/a0"}, inspect.HostConfig.Links))
+	assert.Check(t, is.DeepEqual([]string{"/" + aName + ":/" + bName + "/" + aName}, inspect.HostConfig.Links))
 }
 
 func TestRenameStoppedContainer(t *testing.T) {
@@ -49,7 +52,7 @@ func TestRenameStoppedContainer(t *testing.T) {
 	ctx := context.Background()
 	client := request.NewAPIClient(t)
 
-	oldName := "first_name"
+	oldName := "first_name" + t.Name()
 	cID := container.Run(t, ctx, client, container.WithName(oldName), container.WithCmd("sh"))
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 
@@ -71,7 +74,7 @@ func TestRenameRunningContainerAndReuse(t *testing.T) {
 	ctx := context.Background()
 	client := request.NewAPIClient(t)
 
-	oldName := "first_name"
+	oldName := "first_name" + t.Name()
 	cID := container.Run(t, ctx, client, container.WithName(oldName))
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
@@ -99,7 +102,7 @@ func TestRenameInvalidName(t *testing.T) {
 	ctx := context.Background()
 	client := request.NewAPIClient(t)
 
-	oldName := "first_name"
+	oldName := "first_name" + t.Name()
 	cID := container.Run(t, ctx, client, container.WithName(oldName))
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
@@ -123,21 +126,25 @@ func TestRenameAnonymousContainer(t *testing.T) {
 	ctx := context.Background()
 	client := request.NewAPIClient(t)
 
-	_, err := client.NetworkCreate(ctx, "network1", types.NetworkCreate{})
+	networkName := "network1" + t.Name()
+	_, err := client.NetworkCreate(ctx, networkName, types.NetworkCreate{})
+
 	assert.NilError(t, err)
 	cID := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
 		c.NetworkingConfig.EndpointsConfig = map[string]*network.EndpointSettings{
-			"network1": {},
+			networkName: {},
 		}
-		c.HostConfig.NetworkMode = "network1"
+		c.HostConfig.NetworkMode = containertypes.NetworkMode(networkName)
 	})
-	err = client.ContainerRename(ctx, cID, "container1")
+
+	container1Name := "container1" + t.Name()
+	err = client.ContainerRename(ctx, cID, container1Name)
 	assert.NilError(t, err)
 	// Stop/Start the container to get registered
 	// FIXME(vdemeester) this is a really weird behavior as it fails otherwise
-	err = client.ContainerStop(ctx, "container1", nil)
+	err = client.ContainerStop(ctx, container1Name, nil)
 	assert.NilError(t, err)
-	err = client.ContainerStart(ctx, "container1", types.ContainerStartOptions{})
+	err = client.ContainerStart(ctx, container1Name, types.ContainerStartOptions{})
 	assert.NilError(t, err)
 
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
@@ -148,10 +155,10 @@ func TestRenameAnonymousContainer(t *testing.T) {
 	}
 	cID = container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
 		c.NetworkingConfig.EndpointsConfig = map[string]*network.EndpointSettings{
-			"network1": {},
+			networkName: {},
 		}
-		c.HostConfig.NetworkMode = "network1"
-	}, container.WithCmd("ping", count, "1", "container1"))
+		c.HostConfig.NetworkMode = containertypes.NetworkMode(networkName)
+	}, container.WithCmd("ping", count, "1", container1Name))
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 
 	inspect, err := client.ContainerInspect(ctx, cID)
@@ -165,11 +172,13 @@ func TestRenameContainerWithSameName(t *testing.T) {
 	ctx := context.Background()
 	client := request.NewAPIClient(t)
 
-	cID := container.Run(t, ctx, client, container.WithName("old"))
+	oldName := "old" + t.Name()
+	cID := container.Run(t, ctx, client, container.WithName(oldName))
+
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
-	err := client.ContainerRename(ctx, "old", "old")
+	err := client.ContainerRename(ctx, oldName, oldName)
 	testutil.ErrorContains(t, err, "Renaming a container with the same name")
-	err = client.ContainerRename(ctx, cID, "old")
+	err = client.ContainerRename(ctx, cID, oldName)
 	testutil.ErrorContains(t, err, "Renaming a container with the same name")
 }
 
@@ -185,16 +194,19 @@ func TestRenameContainerWithLinkedContainer(t *testing.T) {
 	ctx := context.Background()
 	client := request.NewAPIClient(t)
 
-	db1ID := container.Run(t, ctx, client, container.WithName("db1"))
+	db1Name := "db1" + t.Name()
+	db1ID := container.Run(t, ctx, client, container.WithName(db1Name))
 	poll.WaitOn(t, container.IsInState(ctx, client, db1ID, "running"), poll.WithDelay(100*time.Millisecond))
 
-	app1ID := container.Run(t, ctx, client, container.WithName("app1"), container.WithLinks("db1:/mysql"))
+	app1Name := "app1" + t.Name()
+	app2Name := "app2" + t.Name()
+	app1ID := container.Run(t, ctx, client, container.WithName(app1Name), container.WithLinks(db1Name+":/mysql"))
 	poll.WaitOn(t, container.IsInState(ctx, client, app1ID, "running"), poll.WithDelay(100*time.Millisecond))
 
-	err := client.ContainerRename(ctx, "app1", "app2")
+	err := client.ContainerRename(ctx, app1Name, app2Name)
 	assert.NilError(t, err)
 
-	inspect, err := client.ContainerInspect(ctx, "app2/mysql")
+	inspect, err := client.ContainerInspect(ctx, app2Name+"/mysql")
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(db1ID, inspect.ID))
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

Use unique names for resources used by integration tests container/inspect_test, container/ps_test, container/stop_test. Part of work on #36583 .
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Use unique names for resources used by container/rename_test.go. Part of  #36583 .

**- What I did**
Changed   container/rename_test.go to use unique names for test resources.

**- How I did it**
Added t.Name() to resources names.

**- How to verify it**

**- Description for the changelog**
container/rename_test.go use unique names for test resources.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6519792/37878182-78f713d6-306d-11e8-9ba9-60f65945d0c4.png)

