### PR TITLE
Migrate test-integration-cli experimental macvlan test to integration

### DIFF
--- a/integration-cli/docker_experimental_network_test.go
+++ b/integration-cli/docker_experimental_network_test.go
@@ -34,25 +34,6 @@ func checkKernelMajorVersionGreaterOrEqualThen(kernelVersion int, majorVersion i
 	return true
 }
 
-func (s *DockerNetworkSuite) TestDockerNetworkMacvlanPersistance(c *check.C) {
-	// verify the driver automatically provisions the 802.1q link (dm-dummy0.60)
-	testRequires(c, DaemonIsLinux, macvlanKernelSupport, NotUserNamespace, NotArm, ExperimentalDaemon)
-
-	// master dummy interface 'dm' abbreviation represents 'docker macvlan'
-	master := "dm-dummy0"
-	// simulate the master link the vlan tagged subinterface parent link will use
-	createMasterDummy(c, master)
-	// cleanup the master interface that also collects the slave dev
-	defer deleteInterface(c, master)
-	// create a network specifying the desired sub-interface name
-	dockerCmd(c, "network", "create", "--driver=macvlan", "-o", "parent=dm-dummy0.60", "dm-persist")
-	assertNwIsAvailable(c, "dm-persist")
-	// Restart docker daemon to test the config has persisted to disk
-	s.d.Restart(c)
-	// verify network is recreated from persistence
-	assertNwIsAvailable(c, "dm-persist")
-}
-
 func (s *DockerNetworkSuite) TestDockerNetworkIpvlanPersistance(c *check.C) {
 	// verify the driver automatically provisions the 802.1q link (di-dummy0.70)
 	testRequires(c, DaemonIsLinux, ipvlanKernelSupport, NotUserNamespace, NotArm, ExperimentalDaemon)
@@ -71,20 +52,6 @@ func (s *DockerNetworkSuite) TestDockerNetworkIpvlanPersistance(c *check.C) {
 	assertNwIsAvailable(c, "di-persist")
 }
 
-func (s *DockerNetworkSuite) TestDockerNetworkMacvlanSubIntCreate(c *check.C) {
-	// verify the driver automatically provisions the 802.1q link (dm-dummy0.50)
-	testRequires(c, DaemonIsLinux, macvlanKernelSupport, NotUserNamespace, NotArm, ExperimentalDaemon)
-	// master dummy interface 'dm' abbreviation represents 'docker macvlan'
-	master := "dm-dummy0"
-	// simulate the master link the vlan tagged subinterface parent link will use
-	createMasterDummy(c, master)
-	// cleanup the master interface which also collects the slave dev
-	defer deleteInterface(c, master)
-	// create a network specifying the desired sub-interface name
-	dockerCmd(c, "network", "create", "--driver=macvlan", "-o", "parent=dm-dummy0.50", "dm-subinterface")
-	assertNwIsAvailable(c, "dm-subinterface")
-}
-
 func (s *DockerNetworkSuite) TestDockerNetworkIpvlanSubIntCreate(c *check.C) {
 	// verify the driver automatically provisions the 802.1q link (di-dummy0.50)
 	testRequires(c, DaemonIsLinux, ipvlanKernelSupport, NotUserNamespace, NotArm, ExperimentalDaemon)
@@ -97,24 +64,6 @@ func (s *DockerNetworkSuite) TestDockerNetworkIpvlanSubIntCreate(c *check.C) {
 	// create a network specifying the desired sub-interface name
 	dockerCmd(c, "network", "create", "--driver=ipvlan", "-o", "parent=di-dummy0.60", "di-subinterface")
 	assertNwIsAvailable(c, "di-subinterface")
-}
-
-func (s *DockerNetworkSuite) TestDockerNetworkMacvlanOverlapParent(c *check.C) {
-	// verify the same parent interface cannot be used if already in use by an existing network
-	testRequires(c, DaemonIsLinux, macvlanKernelSupport, NotUserNamespace, NotArm, ExperimentalDaemon)
-	// master dummy interface 'dm' abbreviation represents 'docker macvlan'
-	master := "dm-dummy0"
-	createMasterDummy(c, master)
-	// cleanup the master interface which also collects the slave dev
-	defer deleteInterface(c, master)
-	createVlanInterface(c, master, "dm-dummy0.40", "40")
-	// create a network using an existing parent interface
-	dockerCmd(c, "network", "create", "--driver=macvlan", "-o", "parent=dm-dummy0.40", "dm-subinterface")
-	assertNwIsAvailable(c, "dm-subinterface")
-	// attempt to create another network using the same parent iface that should fail
-	out, _, err := dockerCmdWithError("network", "create", "--driver=macvlan", "-o", "parent=dm-dummy0.40", "dm-parent-net-overlap")
-	// verify that the overlap returns an error
-	c.Assert(err, check.NotNil, check.Commentf(out))
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkIpvlanOverlapParent(c *check.C) {
@@ -133,61 +82,6 @@ func (s *DockerNetworkSuite) TestDockerNetworkIpvlanOverlapParent(c *check.C) {
 	out, _, err := dockerCmdWithError("network", "create", "--driver=ipvlan", "-o", "parent=di-dummy0.30", "di-parent-net-overlap")
 	// verify that the overlap returns an error
 	c.Assert(err, check.NotNil, check.Commentf(out))
-}
-
-func (s *DockerNetworkSuite) TestDockerNetworkMacvlanMultiSubnet(c *check.C) {
-	// create a dual stack multi-subnet Macvlan bridge mode network and validate connectivity between four containers, two on each subnet
-	testRequires(c, DaemonIsLinux, IPv6, macvlanKernelSupport, NotUserNamespace, NotArm, ExperimentalDaemon)
-	dockerCmd(c, "network", "create", "--driver=macvlan", "--ipv6", "--subnet=172.28.100.0/24", "--subnet=172.28.102.0/24", "--gateway=172.28.102.254",
-		"--subnet=2001:db8:abc2::/64", "--subnet=2001:db8:abc4::/64", "--gateway=2001:db8:abc4::254", "dualstackbridge")
-	// Ensure the network was created
-	assertNwIsAvailable(c, "dualstackbridge")
-	// start dual stack containers and verify the user specified --ip and --ip6 addresses on subnets 172.28.100.0/24 and 2001:db8:abc2::/64
-	dockerCmd(c, "run", "-d", "--net=dualstackbridge", "--name=first", "--ip", "172.28.100.20", "--ip6", "2001:db8:abc2::20", "busybox:glibc", "top")
-	dockerCmd(c, "run", "-d", "--net=dualstackbridge", "--name=second", "--ip", "172.28.100.21", "--ip6", "2001:db8:abc2::21", "busybox:glibc", "top")
-
-	// Inspect and store the v4 address from specified container on the network dualstackbridge
-	ip := inspectField(c, "first", "NetworkSettings.Networks.dualstackbridge.IPAddress")
-	// Inspect and store the v6 address from specified container on the network dualstackbridge
-	ip6 := inspectField(c, "first", "NetworkSettings.Networks.dualstackbridge.GlobalIPv6Address")
-
-	// verify ipv4 connectivity to the explicit --ipv address second to first
-	_, _, err := dockerCmdWithError("exec", "second", "ping", "-c", "1", strings.TrimSpace(ip))
-	c.Assert(err, check.IsNil)
-	// verify ipv6 connectivity to the explicit --ipv6 address second to first
-	c.Skip("Temporarily skipping while investigating sporadic v6 CI issues")
-	_, _, err = dockerCmdWithError("exec", "second", "ping6", "-c", "1", strings.TrimSpace(ip6))
-	c.Assert(err, check.IsNil)
-
-	// start dual stack containers and verify the user specified --ip and --ip6 addresses on subnets 172.28.102.0/24 and 2001:db8:abc4::/64
-	dockerCmd(c, "run", "-d", "--net=dualstackbridge", "--name=third", "--ip", "172.28.102.20", "--ip6", "2001:db8:abc4::20", "busybox:glibc", "top")
-	dockerCmd(c, "run", "-d", "--net=dualstackbridge", "--name=fourth", "--ip", "172.28.102.21", "--ip6", "2001:db8:abc4::21", "busybox:glibc", "top")
-
-	// Inspect and store the v4 address from specified container on the network dualstackbridge
-	ip = inspectField(c, "third", "NetworkSettings.Networks.dualstackbridge.IPAddress")
-	// Inspect and store the v6 address from specified container on the network dualstackbridge
-	ip6 = inspectField(c, "third", "NetworkSettings.Networks.dualstackbridge.GlobalIPv6Address")
-
-	// verify ipv4 connectivity to the explicit --ipv address from third to fourth
-	_, _, err = dockerCmdWithError("exec", "fourth", "ping", "-c", "1", strings.TrimSpace(ip))
-	c.Assert(err, check.IsNil)
-	// verify ipv6 connectivity to the explicit --ipv6 address from third to fourth
-	_, _, err = dockerCmdWithError("exec", "fourth", "ping6", "-c", "1", strings.TrimSpace(ip6))
-	c.Assert(err, check.IsNil)
-
-	// Inspect the v4 gateway to ensure the proper default GW was assigned
-	ip4gw := inspectField(c, "first", "NetworkSettings.Networks.dualstackbridge.Gateway")
-	c.Assert(strings.TrimSpace(ip4gw), check.Equals, "172.28.100.1")
-	// Inspect the v6 gateway to ensure the proper default GW was assigned
-	ip6gw := inspectField(c, "first", "NetworkSettings.Networks.dualstackbridge.IPv6Gateway")
-	c.Assert(strings.TrimSpace(ip6gw), check.Equals, "2001:db8:abc2::1")
-
-	// Inspect the v4 gateway to ensure the proper explicitly assigned default GW was assigned
-	ip4gw = inspectField(c, "third", "NetworkSettings.Networks.dualstackbridge.Gateway")
-	c.Assert(strings.TrimSpace(ip4gw), check.Equals, "172.28.102.254")
-	// Inspect the v6 gateway to ensure the proper explicitly assigned default GW was assigned
-	ip6gw = inspectField(c, "third", "NetworkSettings.Networks.dualstackbridge.IPv6Gateway")
-	c.Assert(strings.TrimSpace(ip6gw), check.Equals, "2001:db8:abc4::254")
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkIpvlanL2MultiSubnet(c *check.C) {
@@ -349,45 +243,6 @@ func (s *DockerNetworkSuite) TestDockerNetworkIpvlanAddressing(c *check.C) {
 	c.Assert(out, checker.Contains, "default dev eth0")
 }
 
-func (s *DockerSuite) TestDockerNetworkMacVlanBridgeNilParent(c *check.C) {
-	// macvlan bridge mode - dummy parent interface is provisioned dynamically
-	testRequires(c, DaemonIsLinux, macvlanKernelSupport, NotUserNamespace, NotArm, ExperimentalDaemon)
-	dockerCmd(c, "network", "create", "--driver=macvlan", "dm-nil-parent")
-	assertNwIsAvailable(c, "dm-nil-parent")
-
-	// start two containers on the same subnet
-	dockerCmd(c, "run", "-d", "--net=dm-nil-parent", "--name=first", "busybox:glibc", "top")
-	c.Assert(waitRun("first"), check.IsNil)
-	dockerCmd(c, "run", "-d", "--net=dm-nil-parent", "--name=second", "busybox:glibc", "top")
-	c.Assert(waitRun("second"), check.IsNil)
-
-	// intra-network communications should succeed
-	_, _, err := dockerCmdWithError("exec", "second", "ping", "-c", "1", "first")
-	c.Assert(err, check.IsNil)
-}
-
-func (s *DockerSuite) TestDockerNetworkMacVlanBridgeInternalMode(c *check.C) {
-	// macvlan bridge mode --internal containers can communicate inside the network but not externally
-	testRequires(c, DaemonIsLinux, macvlanKernelSupport, NotUserNamespace, NotArm, ExperimentalDaemon)
-	cli.DockerCmd(c, "network", "create", "--driver=macvlan", "--internal", "dm-internal")
-	assertNwIsAvailable(c, "dm-internal")
-	nr := getNetworkResource(c, "dm-internal")
-	c.Assert(nr.Internal, checker.True)
-
-	// start two containers on the same subnet
-	cli.DockerCmd(c, "run", "-d", "--net=dm-internal", "--name=first", "busybox:glibc", "top")
-	c.Assert(waitRun("first"), check.IsNil)
-	cli.DockerCmd(c, "run", "-d", "--net=dm-internal", "--name=second", "busybox:glibc", "top")
-	c.Assert(waitRun("second"), check.IsNil)
-
-	// access outside of the network should fail
-	result := cli.Docker(cli.Args("exec", "first", "ping", "-c", "1", "-w", "1", "8.8.8.8"), cli.WithTimeout(time.Second))
-	result.Assert(c, icmd.Expected{Timeout: true})
-
-	// intra-network communications should succeed
-	cli.DockerCmd(c, "exec", "second", "ping", "-c", "1", "first")
-}
-
 func (s *DockerSuite) TestDockerNetworkIpvlanL2NilParent(c *check.C) {
 	// ipvlan l2 mode - dummy parent interface is provisioned dynamically
 	testRequires(c, DaemonIsLinux, ipvlanKernelSupport, NotUserNamespace, NotArm, ExperimentalDaemon)
@@ -464,54 +319,6 @@ func (s *DockerSuite) TestDockerNetworkIpvlanL3InternalMode(c *check.C) {
 	result.Assert(c, icmd.Expected{Timeout: true})
 	// intra-network communications should succeed
 	cli.DockerCmd(c, "exec", "second", "ping", "-c", "1", "first")
-}
-
-func (s *DockerSuite) TestDockerNetworkMacVlanExistingParent(c *check.C) {
-	// macvlan bridge mode - empty parent interface containers can reach each other internally but not externally
-	testRequires(c, DaemonIsLinux, macvlanKernelSupport, NotUserNamespace, NotArm, ExperimentalDaemon)
-	netName := "dm-parent-exists"
-	createMasterDummy(c, "dm-dummy0")
-	defer deleteInterface(c, "dm-dummy0")
-	//out, err := createVlanInterface(c, "dm-parent", "dm-slave", "macvlan", "bridge")
-	// create a network using an existing parent interface
-	dockerCmd(c, "network", "create", "--driver=macvlan", "-o", "parent=dm-dummy0", netName)
-	assertNwIsAvailable(c, netName)
-	// delete the network while preserving the parent link
-	dockerCmd(c, "network", "rm", netName)
-	assertNwNotAvailable(c, netName)
-	// verify the network delete did not delete the predefined link
-	linkExists(c, "dm-dummy0")
-}
-
-func (s *DockerSuite) TestDockerNetworkMacVlanSubinterface(c *check.C) {
-	// macvlan bridge mode -  empty parent interface containers can reach each other internally but not externally
-	testRequires(c, DaemonIsLinux, macvlanKernelSupport, NotUserNamespace, NotArm, ExperimentalDaemon)
-	netName := "dm-subinterface"
-	createMasterDummy(c, "dm-dummy0")
-	// delete the parent interface which also collects the slave
-	defer deleteInterface(c, "dm-dummy0")
-	createVlanInterface(c, "dm-dummy0", "dm-dummy0.20", "20")
-	// create a network using an existing parent interface
-	dockerCmd(c, "network", "create", "--driver=macvlan", "-o", "parent=dm-dummy0.20", netName)
-	assertNwIsAvailable(c, netName)
-
-	// start containers on 802.1q tagged '-o parent' sub-interface
-	dockerCmd(c, "run", "-d", "--net=dm-subinterface", "--name=first", "busybox:glibc", "top")
-	c.Assert(waitRun("first"), check.IsNil)
-	dockerCmd(c, "run", "-d", "--net=dm-subinterface", "--name=second", "busybox:glibc", "top")
-	c.Assert(waitRun("second"), check.IsNil)
-	// verify containers can communicate
-	_, _, err := dockerCmdWithError("exec", "second", "ping", "-c", "1", "first")
-	c.Assert(err, check.IsNil)
-
-	// remove the containers
-	dockerCmd(c, "rm", "-f", "first")
-	dockerCmd(c, "rm", "-f", "second")
-	// delete the network while preserving the parent link
-	dockerCmd(c, "network", "rm", netName)
-	assertNwNotAvailable(c, netName)
-	// verify the network delete did not delete the predefined sub-interface
-	linkExists(c, "dm-dummy0.20")
 }
 
 func createMasterDummy(c *check.C, master string) {

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	containertypes "github.com/docker/docker/api/types/container"
+	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/go-connections/nat"
 )
@@ -81,5 +82,31 @@ func WithVolume(name string) func(*TestContainerConfig) {
 func WithBind(src, target string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {
 		c.HostConfig.Binds = append(c.HostConfig.Binds, fmt.Sprintf("%s:%s", src, target))
+	}
+}
+
+// WithIPv4 sets the specified ip for the specified network of the container
+func WithIPv4(network, ip string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		if v, ok := c.NetworkingConfig.EndpointsConfig[network]; !ok || v == nil {
+			c.NetworkingConfig.EndpointsConfig[network] = &networktypes.EndpointSettings{}
+		}
+		if c.NetworkingConfig.EndpointsConfig[network].IPAMConfig == nil {
+			c.NetworkingConfig.EndpointsConfig[network].IPAMConfig = &networktypes.EndpointIPAMConfig{}
+		}
+		c.NetworkingConfig.EndpointsConfig[network].IPAMConfig.IPv4Address = ip
+	}
+}
+
+// WithIPv6 sets the specified ip6 for the specified network of the container
+func WithIPv6(network, ip string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		if v, ok := c.NetworkingConfig.EndpointsConfig[network]; !ok || v == nil {
+			c.NetworkingConfig.EndpointsConfig[network] = &networktypes.EndpointSettings{}
+		}
+		if c.NetworkingConfig.EndpointsConfig[network].IPAMConfig == nil {
+			c.NetworkingConfig.EndpointsConfig[network].IPAMConfig = &networktypes.EndpointIPAMConfig{}
+		}
+		c.NetworkingConfig.EndpointsConfig[network].IPAMConfig.IPv6Address = ip
 	}
 }

--- a/integration/network/macvlan_test.go
+++ b/integration/network/macvlan_test.go
@@ -1,0 +1,354 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/integration-cli/daemon"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/pkg/parsers/kernel"
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
+	"github.com/gotestyourself/gotestyourself/icmd"
+	"github.com/gotestyourself/gotestyourself/skip"
+)
+
+func TestDockerNetworkMacvlanPersistance(t *testing.T) {
+	// verify the driver automatically provisions the 802.1q link (dm-dummy0.60)
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRemoteDaemon())
+	skip.If(t, !macvlanKernelSupport(), "Kernel doesn't support macvlan")
+
+	d := daemon.New(t, "", "dockerd", daemon.Config{})
+	d.StartWithBusybox(t)
+	defer d.Stop(t)
+
+	master := "dm-dummy0"
+	createMasterDummy(t, master)
+	defer deleteInterface(t, master)
+
+	client, err := d.NewClient()
+	assert.NilError(t, err)
+
+	_, err = client.NetworkCreate(context.Background(), "dm-persist", types.NetworkCreate{
+		Driver: "macvlan",
+		Options: map[string]string{
+			"parent": "dm-dummy0.60",
+		},
+	})
+	assert.NilError(t, err)
+	assert.Check(t, isNetworkAvailable(client, "dm-persist"))
+	d.Restart(t)
+	assert.Check(t, isNetworkAvailable(client, "dm-persist"))
+}
+
+func TestDockerNetworkMacvlanOverlapParent(t *testing.T) {
+	// verify the same parent interface cannot be used if already in use by an existing network
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRemoteDaemon())
+	skip.If(t, !macvlanKernelSupport(), "Kernel doesn't support macvlan")
+
+	d := daemon.New(t, "", "dockerd", daemon.Config{})
+	d.StartWithBusybox(t)
+	defer d.Stop(t)
+
+	master := "dm-dummy0"
+	createMasterDummy(t, master)
+	defer deleteInterface(t, master)
+
+	client, err := d.NewClient()
+	assert.NilError(t, err)
+
+	_, err = client.NetworkCreate(context.Background(), "dm-subinterface", types.NetworkCreate{
+		Driver: "macvlan",
+		Options: map[string]string{
+			"parent": "dm-dummy0.40",
+		},
+	})
+	assert.NilError(t, err)
+	assert.Check(t, isNetworkAvailable(client, "dm-subinterface"))
+
+	_, err = client.NetworkCreate(context.Background(), "dm-parent-net-overlap", types.NetworkCreate{
+		Driver: "macvlan",
+		Options: map[string]string{
+			"parent": "dm-dummy0.40",
+		},
+	})
+	assert.Check(t, err != nil)
+	// delete the network while preserving the parent link
+	err = client.NetworkRemove(context.Background(), "dm-subinterface")
+	assert.NilError(t, err)
+
+	assert.Check(t, isNetworkNotAvailable(client, "dm-subinterface"))
+	// verify the network delete did not delete the predefined link
+	linkExists(t, "dm-dummy0")
+}
+
+func TestDockerNetworkMacvlanSubinterface(t *testing.T) {
+	// verify the same parent interface cannot be used if already in use by an existing network
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRemoteDaemon())
+	skip.If(t, !macvlanKernelSupport(), "Kernel doesn't support macvlan")
+
+	d := daemon.New(t, "", "dockerd", daemon.Config{})
+	d.StartWithBusybox(t)
+	defer d.Stop(t)
+
+	master := "dm-dummy0"
+	createMasterDummy(t, master)
+	defer deleteInterface(t, master)
+	createVlanInterface(t, master, "dm-dummy0.20", "20")
+
+	client, err := d.NewClient()
+	assert.NilError(t, err)
+
+	_, err = client.NetworkCreate(context.Background(), "dm-subinterface", types.NetworkCreate{
+		Driver: "macvlan",
+		Options: map[string]string{
+			"parent": "dm-dummy0.20",
+		},
+	})
+	assert.NilError(t, err)
+	assert.Check(t, isNetworkAvailable(client, "dm-subinterface"))
+
+	// delete the network while preserving the parent link
+	err = client.NetworkRemove(context.Background(), "dm-subinterface")
+	assert.NilError(t, err)
+
+	assert.Check(t, isNetworkNotAvailable(client, "dm-subinterface"))
+	// verify the network delete did not delete the predefined link
+	linkExists(t, "dm-dummy0.20")
+}
+
+func TestDockerNetworkMacvlanBridgeNilParent(t *testing.T) {
+	// macvlan bridge mode - dummy parent interface is provisioned dynamically
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRemoteDaemon())
+	skip.If(t, !macvlanKernelSupport(), "Kernel doesn't support macvlan")
+
+	d := daemon.New(t, "", "dockerd", daemon.Config{})
+	d.StartWithBusybox(t)
+	defer d.Stop(t)
+	client, err := d.NewClient()
+	assert.NilError(t, err)
+
+	_, err = client.NetworkCreate(context.Background(), "dm-nil-parent", types.NetworkCreate{
+		Driver: "macvlan",
+	})
+	assert.NilError(t, err)
+	assert.Check(t, isNetworkAvailable(client, "dm-nil-parent"))
+
+	ctx := context.Background()
+	container.Run(t, ctx, client, container.WithNetworkMode("dm-nil-parent"), container.WithName(t.Name()+"first"))
+	id2 := container.Run(t, ctx, client, container.WithNetworkMode("dm-nil-parent"), container.WithName(t.Name()+"second"))
+
+	_, err = container.Exec(ctx, client, id2, []string{"ping", "-c", "1", t.Name() + "first"})
+	assert.Check(t, err == nil)
+}
+
+func TestDockerNetworkMacvlanBridgeInternal(t *testing.T) {
+	// macvlan bridge mode - dummy parent interface is provisioned dynamically
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRemoteDaemon())
+	skip.If(t, !macvlanKernelSupport(), "Kernel doesn't support macvlan")
+
+	d := daemon.New(t, "", "dockerd", daemon.Config{})
+	d.StartWithBusybox(t)
+	defer d.Stop(t)
+	client, err := d.NewClient()
+	assert.NilError(t, err)
+
+	_, err = client.NetworkCreate(context.Background(), "dm-internal", types.NetworkCreate{
+		Driver:   "macvlan",
+		Internal: true,
+	})
+	assert.NilError(t, err)
+	assert.Check(t, isNetworkAvailable(client, "dm-internal"))
+
+	ctx := context.Background()
+	id1 := container.Run(t, ctx, client, container.WithNetworkMode("dm-internal"), container.WithName(t.Name()+"first"))
+	id2 := container.Run(t, ctx, client, container.WithNetworkMode("dm-internal"), container.WithName(t.Name()+"second"))
+
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	_, err = container.Exec(timeoutCtx, client, id1, []string{"ping", "-c", "1", "-w", "1", "8.8.8.8"})
+	// FIXME(vdemeester) check the time of error ?
+	assert.Check(t, err != nil)
+	assert.Check(t, timeoutCtx.Err() == context.DeadlineExceeded)
+
+	_, err = container.Exec(ctx, client, id2, []string{"ping", "-c", "1", t.Name() + "first"})
+	assert.Check(t, err == nil)
+}
+
+func TestDockerNetworkMacvlanMultiSubnet(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRemoteDaemon())
+	skip.If(t, !macvlanKernelSupport(), "Kernel doesn't support macvlan")
+	t.Skip("Temporarily skipping while investigating sporadic v6 CI issues")
+
+	d := daemon.New(t, "", "dockerd", daemon.Config{})
+	d.StartWithBusybox(t)
+	defer d.Stop(t)
+	client, err := d.NewClient()
+	assert.NilError(t, err)
+
+	_, err = client.NetworkCreate(context.Background(), "dualstackbridge", types.NetworkCreate{
+		Driver:     "macvlan",
+		EnableIPv6: true,
+		IPAM: &network.IPAM{
+			Config: []network.IPAMConfig{
+				{
+					Subnet:     "172.28.100.0/24",
+					AuxAddress: map[string]string{},
+				},
+				{
+					Subnet:     "172.28.102.0/24",
+					Gateway:    "172.28.102.54",
+					AuxAddress: map[string]string{},
+				},
+				{
+					Subnet:     "2001:db8:abc2::/64",
+					AuxAddress: map[string]string{},
+				},
+				{
+					Subnet:     "2001:db8:abc4::/64",
+					Gateway:    "2001:db8:abc4::254",
+					AuxAddress: map[string]string{},
+				},
+			},
+		},
+	})
+	assert.NilError(t, err)
+	assert.Check(t, isNetworkAvailable(client, "dualstackbridge"))
+
+	// start dual stack containers and verify the user specified --ip and --ip6 addresses on subnets 172.28.100.0/24 and 2001:db8:abc2::/64
+	ctx := context.Background()
+	id1 := container.Run(t, ctx, client,
+		container.WithNetworkMode("dualstackbridge"),
+		container.WithName(t.Name()+"first"),
+		container.WithIPv4("dualstackbridge", "172.28.100.20"),
+		container.WithIPv6("dualstackbridge", "2001:db8:abc2::20"),
+	)
+	id2 := container.Run(t, ctx, client,
+		container.WithNetworkMode("dualstackbridge"),
+		container.WithName(t.Name()+"second"),
+		container.WithIPv4("dualstackbridge", "172.28.100.21"),
+		container.WithIPv6("dualstackbridge", "2001:db8:abc2::21"),
+	)
+	c1, err := client.ContainerInspect(ctx, id1)
+	assert.NilError(t, err)
+
+	// verify ipv4 connectivity to the explicit --ipv address second to first
+	_, err = container.Exec(ctx, client, id2, []string{"ping", "-c", "1", c1.NetworkSettings.Networks["dualstackbridge"].IPAddress})
+	assert.NilError(t, err)
+	// verify ipv6 connectivity to the explicit --ipv6 address second to first
+	_, err = container.Exec(ctx, client, id2, []string{"ping6", "-c", "1", c1.NetworkSettings.Networks["dualstackbridge"].GlobalIPv6Address})
+	assert.NilError(t, err)
+
+	// start dual stack containers and verify the user specified --ip and --ip6 addresses on subnets 172.28.102.0/24 and 2001:db8:abc4::/64
+	id3 := container.Run(t, ctx, client,
+		container.WithNetworkMode("dualstackbridge"),
+		container.WithName(t.Name()+"third"),
+		container.WithIPv4("dualstackbridge", "172.28.102.20"),
+		container.WithIPv6("dualstackbridge", "2001:db8:abc4::20"),
+	)
+	id4 := container.Run(t, ctx, client,
+		container.WithNetworkMode("dualstackbridge"),
+		container.WithName(t.Name()+"fourth"),
+		container.WithIPv4("dualstackbridge", "172.28.102.21"),
+		container.WithIPv6("dualstackbridge", "2001:db8:abc4::21"),
+	)
+	c3, err := client.ContainerInspect(ctx, id3)
+	assert.NilError(t, err)
+
+	// verify ipv4 connectivity to the explicit --ipv address from third to fourth
+	_, err = container.Exec(ctx, client, id4, []string{"ping", "-c", "1", c3.NetworkSettings.Networks["dualstackbridge"].IPAddress})
+	assert.NilError(t, err)
+	// verify ipv6 connectivity to the explicit --ipv6 address from third to fourth
+	_, err = container.Exec(ctx, client, id4, []string{"ping6", "-c", "1", c3.NetworkSettings.Networks["dualstackbridge"].GlobalIPv6Address})
+	assert.NilError(t, err)
+
+	// Inspect the v4 gateway to ensure the proper default GW was assigned
+	assert.Equal(t, c1.NetworkSettings.Networks["dualstackbridge"].Gateway, "172.28.100.1")
+	// Inspect the v6 gateway to ensure the proper default GW was assigned
+	assert.Equal(t, c1.NetworkSettings.Networks["dualstackbridge"].IPv6Gateway, "2001:db8:abc2::1")
+	// Inspect the v4 gateway to ensure the proper explicitly assigned default GW was assigned
+	assert.Equal(t, c3.NetworkSettings.Networks["dualstackbridge"].Gateway, "172.28.102.254")
+	// Inspect the v6 gateway to ensure the proper explicitly assigned default GW was assigned
+	assert.Equal(t, c3.NetworkSettings.Networks["dualstackbridge"].IPv6Gateway, "2001:db8.abc4::254")
+}
+
+func isNetworkAvailable(c client.NetworkAPIClient, name string) cmp.Comparison {
+	return func() cmp.Result {
+		networks, err := c.NetworkList(context.Background(), types.NetworkListOptions{})
+		if err != nil {
+			return cmp.ResultFromError(err)
+		}
+		for _, network := range networks {
+			if network.Name == name {
+				return cmp.ResultSuccess
+			}
+		}
+		return cmp.ResultFailure(fmt.Sprintf("could not find network %s", name))
+	}
+}
+
+func isNetworkNotAvailable(c client.NetworkAPIClient, name string) cmp.Comparison {
+	return func() cmp.Result {
+		networks, err := c.NetworkList(context.Background(), types.NetworkListOptions{})
+		if err != nil {
+			return cmp.ResultFromError(err)
+		}
+		for _, network := range networks {
+			if network.Name == name {
+				return cmp.ResultFailure(fmt.Sprintf("network %s is still present", name))
+			}
+		}
+		return cmp.ResultSuccess
+	}
+}
+
+func createMasterDummy(t *testing.T, master string) {
+	// ip link add <dummy_name> type dummy
+	icmd.RunCommand("ip", "link", "add", master, "type", "dummy").Assert(t, icmd.Success)
+	icmd.RunCommand("ip", "link", "set", master, "up").Assert(t, icmd.Success)
+}
+
+func createVlanInterface(t *testing.T, master, slave, id string) {
+	// ip link add link <master> name <master>.<VID> type vlan id <VID>
+	icmd.RunCommand("ip", "link", "add", "link", master, "name", slave, "type", "vlan", "id", id).Assert(t, icmd.Success)
+	// ip link set <sub_interface_name> up
+	icmd.RunCommand("ip", "link", "set", slave, "up").Assert(t, icmd.Success)
+}
+
+func deleteInterface(t *testing.T, ifName string) {
+	icmd.RunCommand("ip", "link", "delete", ifName).Assert(t, icmd.Success)
+	icmd.RunCommand("iptables", "-t", "nat", "--flush").Assert(t, icmd.Success)
+	icmd.RunCommand("iptables", "--flush").Assert(t, icmd.Success)
+}
+
+func linkExists(t *testing.T, master string) {
+	// verify the specified link exists, ip link show <link_name>
+	icmd.RunCommand("ip", "link", "show", master).Assert(t, icmd.Success)
+}
+
+// ensure Kernel version is >= v3.9 for macvlan support
+func macvlanKernelSupport() bool {
+	return checkKernelMajorVersionGreaterOrEqualThen(3, 9)
+}
+
+func checkKernelMajorVersionGreaterOrEqualThen(kernelVersion int, majorVersion int) bool {
+	kv, err := kernel.GetKernelVersion()
+	if err != nil {
+		return false
+	}
+	if kv.Kernel < kernelVersion || (kv.Kernel == kernelVersion && kv.Major < majorVersion) {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
All `Macvlan` related test on `DockerSuite` and `DockerNetworkSuite`
are migrated to `macvlan_test.go`.

Also, as `macvlan` seems to be out of experimental, this removes
the *skip* when the run is not experimental (and doesn't start a
daemon with experimental either).

The end goal being to remove the `experimental` builds.

:lion: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>