### PR TITLE
Bump go-digest to v1.0.0-rc.1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -61,7 +61,7 @@ github.com/ishidawataru/sctp 07191f837fedd2f13d1ec7b5f885f0f3ec54b1cb
 # get graph and distribution packages
 github.com/docker/distribution edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c
 github.com/vbatts/tar-split v0.10.2
-github.com/opencontainers/go-digest a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb
+github.com/opencontainers/go-digest v1.0.0-rc1
 
 # get go-zfs packages
 github.com/mistifyio/go-zfs 22c9b32c84eb0d0c6f4043b6e90fc94073de92fa

--- a/vendor/github.com/opencontainers/go-digest/README.md
+++ b/vendor/github.com/opencontainers/go-digest/README.md
@@ -1,10 +1,10 @@
 # go-digest
 
-[![GoDoc](https://godoc.org/github.com/docker/go-digest?status.svg)](https://godoc.org/github.com/docker/go-digest) [![Go Report Card](https://goreportcard.com/badge/github.com/docker/go-digest)](https://goreportcard.com/report/github.com/docker/go-digest) [![Build Status](https://travis-ci.org/docker/go-digest.svg?branch=master)](https://travis-ci.org/docker/go-digest)
+[![GoDoc](https://godoc.org/github.com/opencontainers/go-digest?status.svg)](https://godoc.org/github.com/opencontainers/go-digest) [![Go Report Card](https://goreportcard.com/badge/github.com/opencontainers/go-digest)](https://goreportcard.com/report/github.com/opencontainers/go-digest) [![Build Status](https://travis-ci.org/opencontainers/go-digest.svg?branch=master)](https://travis-ci.org/opencontainers/go-digest)
 
 Common digest package used across the container ecosystem.
 
-Please see the [godoc](https://godoc.org/github.com/docker/go-digest) for more information.
+Please see the [godoc](https://godoc.org/github.com/opencontainers/go-digest) for more information.
 
 # What is a digest?
 
@@ -49,7 +49,7 @@ can power a rich, safe, content distribution system.
 
 # Usage
 
-While the [godoc](https://godoc.org/github.com/docker/go-digest) is 
+While the [godoc](https://godoc.org/github.com/opencontainers/go-digest) is
 considered the best resource, a few important items need to be called 
 out when using this package.
 
@@ -76,7 +76,7 @@ out when using this package.
 
 The Go API, at this stage, is considered stable, unless otherwise noted.
 
-As always, before using a package export, read the [godoc](https://godoc.org/github.com/docker/go-digest).
+As always, before using a package export, read the [godoc](https://godoc.org/github.com/opencontainers/go-digest).
 
 # Contributing
 
@@ -88,16 +88,16 @@ the alternatives you tried before submitting a PR.
 
 # Reporting security issues
 
-The maintainers take security seriously. If you discover a security 
-issue, please bring it to their attention right away!
+Please DO NOT file a public issue, instead send your report privately to
+security@opencontainers.org.
 
-Please DO NOT file a public issue, instead send your report privately
-to security@docker.com.
+The maintainers take security seriously. If you discover a security issue,
+please bring it to their attention right away!
 
-Security reports are greatly appreciated and we will publicly thank you 
-for it. We also like to send gifts—if you're into Docker schwag, make 
-sure to let us know. We currently do not offer a paid security bounty 
-program, but are not ruling it out in the future.
+If you are reporting a security issue, do not create an issue or file a pull
+request on GitHub. Instead, disclose the issue responsibly by sending an email
+to security@opencontainers.org (which is inhabited only by the maintainers of
+the various OCI projects).
 
 # Copyright and license
 

--- a/vendor/github.com/opencontainers/go-digest/digester.go
+++ b/vendor/github.com/opencontainers/go-digest/digester.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package digest
 
 import "hash"

--- a/vendor/github.com/opencontainers/go-digest/doc.go
+++ b/vendor/github.com/opencontainers/go-digest/doc.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package digest provides a generalized type to opaquely represent message
 // digests and their operations within the registry. The Digest type is
 // designed to serve as a flexible identifier in a content-addressable system.

--- a/vendor/github.com/opencontainers/go-digest/verifiers.go
+++ b/vendor/github.com/opencontainers/go-digest/verifiers.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package digest
 
 import (


### PR DESCRIPTION
full diff: https://github.com/opencontainers/go-digest/compare/a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb...v1.0.0-rc1

Changes included:

- https://github.com/opencontainers/go-digest/pull/33 digest: allow separators in algorithm field
- https://github.com/opencontainers/go-digest/pull/34 disallow upper characters (/A-F/) in hex-encoded portion


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
* Update go-digest to v1.0.0-rc.1
```

