### PR TITLE
Add default pollSettings config functions

### DIFF
--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -3,7 +3,9 @@ package swarm
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -12,6 +14,7 @@ import (
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/internal/test/environment"
 	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/poll"
 	"github.com/gotestyourself/gotestyourself/skip"
 )
 
@@ -19,6 +22,37 @@ const (
 	dockerdBinary    = "dockerd"
 	defaultSwarmPort = 2477
 )
+
+// ServicePoll tweaks the pollSettings for `service`
+func ServicePoll(config *poll.Settings) {
+	// Override the default pollSettings for `service` resource here ...
+
+	if runtime.GOARCH == "arm64" || runtime.GOARCH == "arm" {
+		config.Timeout = 1 * time.Minute
+		config.Delay = 100 * time.Millisecond
+	}
+}
+
+// NetworkPoll tweaks the pollSettings for `network`
+func NetworkPoll(config *poll.Settings) {
+	// Override the default pollSettings for `network` resource here ...
+	config.Timeout = 30 * time.Second
+	config.Delay = 100 * time.Millisecond
+
+	if runtime.GOARCH == "arm64" || runtime.GOARCH == "arm" {
+		config.Timeout = 50 * time.Second
+	}
+}
+
+// ContainerPoll tweaks the pollSettings for `container`
+func ContainerPoll(config *poll.Settings) {
+	// Override the default pollSettings for `container` resource here ...
+
+	if runtime.GOARCH == "arm64" || runtime.GOARCH == "arm" {
+		config.Timeout = 30 * time.Second
+		config.Delay = 100 * time.Millisecond
+	}
+}
 
 // NewSwarm creates a swarm daemon for testing
 func NewSwarm(t *testing.T, testEnv *environment.Execution) *daemon.Swarm {

--- a/integration/network/inspect_test.go
+++ b/integration/network/inspect_test.go
@@ -1,7 +1,6 @@
 package network // import "github.com/docker/docker/integration/network"
 
 import (
-	"runtime"
 	"testing"
 	"time"
 
@@ -46,15 +45,8 @@ func TestInspectNetwork(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	pollSettings := func(config *poll.Settings) {
-		if runtime.GOARCH == "arm64" || runtime.GOARCH == "arm" {
-			config.Timeout = 30 * time.Second
-			config.Delay = 100 * time.Millisecond
-		}
-	}
-
 	serviceID := serviceResp.ID
-	poll.WaitOn(t, serviceRunningTasksCount(client, serviceID, instances), pollSettings)
+	poll.WaitOn(t, serviceRunningTasksCount(client, serviceID, instances), swarm.ServicePoll)
 
 	_, _, err = client.ServiceInspectWithRaw(context.Background(), serviceID, types.ServiceInspectOptions{})
 	assert.NilError(t, err)
@@ -84,8 +76,8 @@ func TestInspectNetwork(t *testing.T) {
 	err = client.ServiceRemove(context.Background(), serviceID)
 	assert.NilError(t, err)
 
-	poll.WaitOn(t, serviceIsRemoved(client, serviceID), pollSettings)
-	poll.WaitOn(t, noTasks(client), pollSettings)
+	poll.WaitOn(t, serviceIsRemoved(client, serviceID), swarm.ServicePoll)
+	poll.WaitOn(t, noTasks(client), swarm.ServicePoll)
 
 	serviceResp, err = client.ServiceCreate(context.Background(), serviceSpec, types.ServiceCreateOptions{
 		QueryRegistry: false,
@@ -93,13 +85,13 @@ func TestInspectNetwork(t *testing.T) {
 	assert.NilError(t, err)
 
 	serviceID2 := serviceResp.ID
-	poll.WaitOn(t, serviceRunningTasksCount(client, serviceID2, instances), pollSettings)
+	poll.WaitOn(t, serviceRunningTasksCount(client, serviceID2, instances), swarm.ServicePoll)
 
 	err = client.ServiceRemove(context.Background(), serviceID2)
 	assert.NilError(t, err)
 
-	poll.WaitOn(t, serviceIsRemoved(client, serviceID2), pollSettings)
-	poll.WaitOn(t, noTasks(client), pollSettings)
+	poll.WaitOn(t, serviceIsRemoved(client, serviceID2), swarm.ServicePoll)
+	poll.WaitOn(t, noTasks(client), swarm.ServicePoll)
 
 	err = client.NetworkRemove(context.Background(), overlayID)
 	assert.NilError(t, err)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
This PR will:

1. Add the default function per resource to override the `pollSettings` which will be re-used where it's needed, this will avoid to configure the timeout value each time.
2. Remove all the previous timeout value adjustment codes, replace them with the new added default function in above item 1.

**- What I did**
Override the timeout value for some time-consuming test cases.
**- How I did it**
Add default function to override the timeout value per resource, and reuse it where it's needed.
**- How to verify it**
`make test-integration`
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

