### PR TITLE
Add exec option to tmpfs

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -368,6 +368,9 @@ definitions:
           Mode:
             description: "The permission mode for the tmpfs mount in an integer."
             type: "integer"
+          Options:
+            description: "The list of options to be passed to the tmpfs mount in a string."
+            type: "string"
 
   RestartPolicy:
     description: |

--- a/api/types/mount/mount.go
+++ b/api/types/mount/mount.go
@@ -109,7 +109,8 @@ type TmpfsOptions struct {
 	SizeBytes int64 `json:",omitempty"`
 	// Mode of the tmpfs upon creation
 	Mode os.FileMode `json:",omitempty"`
-
+	// Options passed directly to the tmpfs mount
+	Options string `json:",omitempty"`
 	// TODO(stevvooe): There are several more tmpfs flags, specified in the
 	// daemon, that are accepted. Only the most basic are added for now.
 	//

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -103,6 +103,7 @@ func containerSpecFromGRPC(c *swarmapi.ContainerSpec) *types.ContainerSpec {
 			mount.TmpfsOptions = &mounttypes.TmpfsOptions{
 				SizeBytes: m.TmpfsOptions.SizeBytes,
 				Mode:      m.TmpfsOptions.Mode,
+				Options:   m.TmpfsOptions.Options,
 			}
 		}
 		containerSpec.Mounts = append(containerSpec.Mounts, mount)
@@ -362,6 +363,7 @@ func containerToGRPC(c *types.ContainerSpec) (*swarmapi.ContainerSpec, error) {
 			mount.TmpfsOptions = &swarmapi.Mount_TmpfsOptions{
 				SizeBytes: m.TmpfsOptions.SizeBytes,
 				Mode:      m.TmpfsOptions.Mode,
+				Options:   m.TmpfsOptions.Options,
 			}
 		}
 

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -328,6 +328,7 @@ func convertMount(m api.Mount) enginemount.Mount {
 		mount.TmpfsOptions = &enginemount.TmpfsOptions{
 			SizeBytes: m.TmpfsOptions.SizeBytes,
 			Mode:      m.TmpfsOptions.Mode,
+			Options:   m.TmpfsOptions.Options,
 		}
 	}
 

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -84,6 +84,7 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /services/{id}` now returns `Ulimits` as part of `ContainerSpec`.
 * `POST /services/create` now accepts `Ulimits` as part of `ContainerSpec`.
 * `POST /services/{id}/update` now accepts `Ulimits` as part of `ContainerSpec`.
+* `POST /containers/create` now takes `Options` as part of `HostConfig.Mounts` to set options for tmpfs mounts.
 
 ## v1.40 API changes
 

--- a/volume/mounts/parser_test.go
+++ b/volume/mounts/parser_test.go
@@ -24,6 +24,7 @@ func TestConvertTmpfsOptions(t *testing.T) {
 		readOnly             bool
 		expectedSubstrings   []string
 		unexpectedSubstrings []string
+		err                  bool
 	}
 	cases := []testCase{
 		{
@@ -38,10 +39,26 @@ func TestConvertTmpfsOptions(t *testing.T) {
 			expectedSubstrings:   []string{"ro"},
 			unexpectedSubstrings: []string{},
 		},
+		{
+			opt:                  mount.TmpfsOptions{Options: "exec"},
+			readOnly:             true,
+			expectedSubstrings:   []string{"ro", "exec"},
+			unexpectedSubstrings: []string{"noexec"},
+		},
+		{
+			opt: mount.TmpfsOptions{Options: "INVALID"},
+			err: true,
+		},
 	}
 	p := &linuxParser{}
 	for _, c := range cases {
 		data, err := p.ConvertTmpfsOptions(&c.opt, c.readOnly)
+		if c.err {
+			if err == nil {
+				t.Fatalf("expected error for %+v, got nil", c.opt)
+			}
+			continue
+		}
 		if err != nil {
 			t.Fatalf("could not convert %+v (readOnly: %v) to string: %v",
 				c.opt, c.readOnly, err)


### PR DESCRIPTION
This PR adds the ability to handle exec option on tmpfs mounts. 

- fixes #32131 
- fixes https://github.com/moby/moby/issues/45385

Notes:

This is the first draft. As discussed here: https://github.com/moby/moby/issues/32131#issuecomment-375074893, I have included the changes on `docker/swarmkit` types that will need vendoring. I will submit PR(s) on `docker/swarmkit` and `docker/cli` once if this PR is approved.




**- What I did**
Feature: allow specifying exec option for tmpfs mounts

**- How I did it**
Added the required code and tests to pkg/mount, volume, api/types, and daemon.

**- How to verify it**
I have added an integration test for verification. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

