### PR TITLE
Add target field to build API docs

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6253,6 +6253,11 @@ paths:
           description: "Platform in the format os[/arch[/variant]]"
           type: "string"
           default: ""
+        - name: "target"
+          in: "query"
+          description: "Target build stage"
+          type: "string"
+          default: ""
       responses:
         200:
           description: "no error"


### PR DESCRIPTION
I guess this was missed when `target` was added.