### PR TITLE
copy: remove kernel version test

### DIFF
--- a/daemon/graphdriver/copy/copy_test.go
+++ b/daemon/graphdriver/copy/copy_test.go
@@ -12,31 +12,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/system"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"golang.org/x/sys/unix"
 )
-
-func TestIsCopyFileRangeSyscallAvailable(t *testing.T) {
-	// Verifies:
-	// 1. That copyFileRangeEnabled is being set to true when copy_file_range syscall is available
-	// 2. That isCopyFileRangeSyscallAvailable() works on "new" kernels
-	v, err := kernel.GetKernelVersion()
-	assert.NilError(t, err)
-
-	copyWithFileRange := true
-	copyWithFileClone := false
-	doCopyTest(t, &copyWithFileRange, &copyWithFileClone)
-
-	if kernel.CompareKernelVersion(*v, kernel.VersionInfo{Kernel: 4, Major: 5, Minor: 0}) < 0 {
-		assert.Check(t, !copyWithFileRange)
-	} else {
-		assert.Check(t, copyWithFileRange)
-	}
-
-}
 
 func TestCopy(t *testing.T) {
 	copyWithFileRange := true


### PR DESCRIPTION
This test started failing on rhel after ci upgrade, for example, https://jenkins.dockerproject.org/job/Docker%20Master/label=rhel-74-selinux-overlay2-stable/9768/console .Rhel uses a low kernel version but ports over new features making a comparison on kernel versions unusable. If needed we could detect the support for syscall in the test and then compare if `copyWithFileRange` was set but I'm not sure we would be actually testing anything then.

@sargun @vdemeester 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>


