### PR TITLE
Windows: Add GetLayerPath implementation in graphdriver

### DIFF
--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -340,6 +340,11 @@ func (d *Driver) Remove(id string) error {
 	return nil
 }
 
+// GetLayerPath gets the layer path on host
+func (d *Driver) GetLayerPath(id string) (string, error) {
+	return d.dir(id), nil
+}
+
 // Get returns the rootfs path for the id. This will mount the dir at its given path.
 func (d *Driver) Get(id, mountLabel string) (containerfs.ContainerFS, error) {
 	logrus.Debugf("WindowsGraphDriver Get() id %s mountLabel %s", id, mountLabel)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This saves ~5ms (on a test VM running on my dev box, other results may vary) per read-only layer in any container start on Windows, for both process and Hyper-V isolation. When starting a container image with many layers, this can add up to a reasonable saving. 

