### PR TITLE
Bump containerd version for installer to v1.0.3

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=cfd04396dc68220d1cecbe686a6cc3aa5ce3667c # v1.0.2
+CONTAINERD_COMMIT=2b3b44fd7d1cd1c8732918b8afcb8c84998f1e55 # v1.0.3-rc.0
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Relates to https://github.com/containerd/btrfs/issues/15, https://github.com/containerd/containerd/pull/2191, and https://github.com/docker/docker-ce-packaging/pull/98

**- What I did**
Made the daemon buildable on Fedora 28 by making `containerd` buildable on Fedora 28,

This should probably be held until `containerd` has a full GA release of v1.0.3

**- How I did it**
* Changed the commit for `containerd.installer` to 2b3b44fd7d1cd1c8732918b8afcb8c84998f1e55

**- How to verify it**
```
$ git clone git@github.com:seemethere/docker-ce-packaging
$ git -C docker-ce-packaging checkout f28
$ make -C docker-ce-packaging/rpm ENGINE_DIR=~/go/src/github.com/docker/docker CLI_DIR=~/go/src/github.com/docker/cli fedora-28
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

`* Bump containerd to v1.0.3`

**- A picture of a cute animal (not mandatory but encouraged)**
![Bird with arms](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQRaTtoNPYhWGjSVhJJnpcKGXbZNTC5H3rw82i10vcmc3LKH8tdpg)

ping @stevvooe @andrewhsu 