### PR TITLE
mount: make seclabel optional in tests

### DIFF
--- a/pkg/mount/mounter_linux_test.go
+++ b/pkg/mount/mounter_linux_test.go
@@ -205,7 +205,7 @@ func validateMount(t *testing.T, mnt string, opts, optional, vfs string) {
 			if mi.VfsOpts != "" {
 				for _, opt := range strings.Split(mi.VfsOpts, ",") {
 					opt = clean(opt)
-					if !has(wantedVFS, opt) {
+					if !has(wantedVFS, opt) && opt != "seclabel" { // seclabel may be added automatically even when selinuxfs is not mounted
 						t.Errorf("unexpected mount option %q expected %q", opt, vfs)
 					}
 					delete(wantedVFS, opt)


### PR DESCRIPTION
The current test always assumes that seclabel appears on mounts if and only if selinux is enabled. The `selinux.IsEnabled()` checks if `selinuxfs` is enabled, so in systems that support selinux but don't have this mount (for example dind) this test would fail. The exception is added so that extra `seclabel` option is allowed but if selinuxfs is present it is still required.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>


