### PR TITLE
dockerfile: restore yamllint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -233,6 +233,7 @@ COPY --from=docker-py /docker-py /docker-py
 # above.
 RUN cd /docker-py \
 	&& pip install docker-pycreds==0.2.1 \
+	&& pip install yamllint==1.5.0 \
 	&& pip install -r test-requirements.txt
 
 ENV PATH=/usr/local/cli:$PATH


### PR DESCRIPTION
Restore https://github.com/moby/moby/commit/d539038d9712daa44254412c6fcc6d78a14da691#diff-3254677a7917c6c01f55212f86c57fbfL154

Blocking #36724

This could be made better with another stage but as other pip dependencies are installed this way atm I just added it to there.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>

