### PR TITLE
Migrate test-integration-cli experimental build tests to integration

### DIFF
--- a/integration/build/build_session_test.go
+++ b/integration/build/build_session_test.go
@@ -1,0 +1,132 @@
+package build
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	dclient "github.com/docker/docker/client"
+	"github.com/docker/docker/integration-cli/cli/build/fakecontext"
+	"github.com/docker/docker/integration-cli/daemon"
+	"github.com/docker/docker/integration-cli/request"
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/filesync"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestBuildWithSession(t *testing.T) {
+	d := daemon.New(t, "", "dockerd", daemon.Config{
+		Experimental: true,
+	})
+	d.StartWithBusybox(t)
+	defer d.Stop(t)
+
+	client, err := d.NewClient()
+	assert.NilError(t, err)
+
+	dockerfile := `
+		FROM busybox
+		COPY file /
+		RUN cat /file
+	`
+
+	fctx := fakecontext.New(t, "",
+		fakecontext.WithFile("file", "some content"),
+	)
+	defer fctx.Close()
+
+	out := testBuildWithSession(t, client, d.Sock(), fctx.Dir, dockerfile)
+	assert.Check(t, is.Contains(out, "some content"))
+
+	fctx.Add("second", "contentcontent")
+
+	dockerfile += `
+	COPY second /
+	RUN cat /second
+	`
+
+	out = testBuildWithSession(t, client, d.Sock(), fctx.Dir, dockerfile)
+	assert.Check(t, is.Equal(strings.Count(out, "Using cache"), 2))
+	assert.Check(t, is.Contains(out, "contentcontent"))
+
+	du, err := client.DiskUsage(context.TODO())
+	assert.Check(t, err)
+	assert.Check(t, du.BuilderSize > 10)
+
+	out = testBuildWithSession(t, client, d.Sock(), fctx.Dir, dockerfile)
+	assert.Check(t, is.Equal(strings.Count(out, "Using cache"), 4))
+
+	du2, err := client.DiskUsage(context.TODO())
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(du.BuilderSize, du2.BuilderSize))
+
+	// rebuild with regular tar, confirm cache still applies
+	fctx.Add("Dockerfile", dockerfile)
+	// FIXME(vdemeester) use sock here
+	res, body, err := request.DoOnHost(d.Sock(),
+		"/build",
+		request.Method(http.MethodPost),
+		request.RawContent(fctx.AsTarReader(t)),
+		request.ContentType("application/x-tar"))
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(http.StatusOK, res.StatusCode))
+
+	outBytes, err := request.ReadBody(body)
+	assert.NilError(t, err)
+	assert.Check(t, is.Contains(string(outBytes), "Successfully built"))
+	assert.Check(t, is.Equal(strings.Count(string(outBytes), "Using cache"), 4))
+
+	_, err = client.BuildCachePrune(context.TODO())
+	assert.Check(t, err)
+
+	du, err = client.DiskUsage(context.TODO())
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(du.BuilderSize, int64(0)))
+}
+
+func testBuildWithSession(t *testing.T, client dclient.APIClient, daemonSock string, dir, dockerfile string) (outStr string) {
+	sess, err := session.NewSession("foo1", "foo")
+	assert.Check(t, err)
+
+	fsProvider := filesync.NewFSSyncProvider([]filesync.SyncedDir{
+		{Dir: dir},
+	})
+	sess.Allow(fsProvider)
+
+	g, ctx := errgroup.WithContext(context.Background())
+
+	g.Go(func() error {
+		return sess.Run(ctx, client.DialSession)
+	})
+
+	g.Go(func() error {
+		// FIXME use sock here
+		res, body, err := request.DoOnHost(
+			daemonSock,
+			"/build?remote=client-session&session="+sess.ID(),
+			request.Method(http.MethodPost),
+			func(req *http.Request) error {
+				req.Body = ioutil.NopCloser(strings.NewReader(dockerfile))
+				return nil
+			},
+		)
+		if err != nil {
+			return err
+		}
+		assert.Check(t, is.DeepEqual(res.StatusCode, http.StatusOK))
+		out, err := request.ReadBody(body)
+		assert.NilError(t, err)
+		assert.Check(t, is.Contains(string(out), "Successfully built"))
+		sess.Close()
+		outStr = string(out)
+		return nil
+	})
+
+	err = g.Wait()
+	assert.Check(t, err)
+	return
+}

--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -1,0 +1,108 @@
+package build
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/integration-cli/cli/build/fakecontext"
+	"github.com/docker/docker/integration-cli/daemon"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+)
+
+func TestBuildSquashParent(t *testing.T) {
+	d := daemon.New(t, "", "dockerd", daemon.Config{
+		Experimental: true,
+	})
+	d.StartWithBusybox(t)
+	defer d.Stop(t)
+
+	client, err := d.NewClient()
+	assert.NilError(t, err)
+
+	dockerfile := `
+		FROM busybox
+		RUN echo hello > /hello
+		RUN echo world >> /hello
+		RUN echo hello > /remove_me
+		ENV HELLO world
+		RUN rm /remove_me
+		`
+
+	// build and get the ID that we can use later for history comparison
+	ctx := context.Background()
+	source := fakecontext.New(t, "", fakecontext.WithDockerfile(dockerfile))
+	defer source.Close()
+
+	name := "test"
+	resp, err := client.ImageBuild(ctx,
+		source.AsTarReader(t),
+		types.ImageBuildOptions{
+			Remove:      true,
+			ForceRemove: true,
+			Tags:        []string{name},
+		})
+	assert.NilError(t, err)
+	_, err = io.Copy(ioutil.Discard, resp.Body)
+	resp.Body.Close()
+	assert.NilError(t, err)
+
+	inspect, _, err := client.ImageInspectWithRaw(ctx, name)
+	assert.NilError(t, err)
+	origID := inspect.ID
+
+	// build with squash
+	resp, err = client.ImageBuild(ctx,
+		source.AsTarReader(t),
+		types.ImageBuildOptions{
+			Remove:      true,
+			ForceRemove: true,
+			Squash:      true,
+			Tags:        []string{name},
+		})
+	assert.NilError(t, err)
+	_, err = io.Copy(ioutil.Discard, resp.Body)
+	resp.Body.Close()
+	assert.NilError(t, err)
+
+	cid := container.Run(t, ctx, client,
+		container.WithImage(name),
+		container.WithCmd("/bin/sh", "-c", "cat /hello"),
+	)
+	reader, err := client.ContainerLogs(ctx, cid, types.ContainerLogsOptions{
+		ShowStdout: true,
+	})
+	assert.NilError(t, err)
+
+	actualStdout := new(bytes.Buffer)
+	actualStderr := ioutil.Discard
+	_, err = stdcopy.StdCopy(actualStdout, actualStderr, reader)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(strings.TrimSpace(actualStdout.String()), "hello\nworld"))
+
+	container.Run(t, ctx, client,
+		container.WithImage(name),
+		container.WithCmd("/bin/sh", "-c", "[ ! -f /remove_me ]"),
+	)
+	container.Run(t, ctx, client,
+		container.WithImage(name),
+		container.WithCmd("/bin/sh", "-c", `[ "$(echo $HELLO)" == "world" ]`),
+	)
+
+	origHistory, err := client.ImageHistory(ctx, origID)
+	assert.NilError(t, err)
+	testHistory, err := client.ImageHistory(ctx, name)
+	assert.NilError(t, err)
+
+	inspect, _, err = client.ImageInspectWithRaw(ctx, name)
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(testHistory, len(origHistory)+1))
+	assert.Check(t, is.Len(inspect.RootFS.Layers, 2))
+}


### PR DESCRIPTION
All `docker build` tests that require an `ExperimentalDaemon` are
migrated to `integration/build` package and start an experimental
daemon to test on it.

The end goal being to remove the `experimental` builds.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>