### PR TITLE
Add support for zstd compressed archives

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -213,6 +213,7 @@ RUN apt-get update && apt-get install -y \
 	zip \
 	bzip2 \
 	xz-utils \
+	zstd \
 	--no-install-recommends
 COPY --from=swagger /usr/local/bin/swagger* /usr/local/bin/
 COPY --from=frozen-images /docker-frozen-images /docker-frozen-images

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		procps \
 		xfsprogs \
 		xz-utils \
+		zstd \
 		\
 		aufs-tools \
 		vim-common \

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -94,6 +94,8 @@ const (
 	Gzip
 	// Xz is xz compression algorithm.
 	Xz
+	// Zstd is zstd compression algorithm.
+	Zstd
 )
 
 const (
@@ -133,17 +135,23 @@ func IsArchivePath(path string) bool {
 
 // DetectCompression detects the compression algorithm of the source.
 func DetectCompression(source []byte) Compression {
-	for compression, m := range map[Compression][]byte{
-		Bzip2: {0x42, 0x5A, 0x68},
-		Gzip:  {0x1F, 0x8B, 0x08},
-		Xz:    {0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00},
+	for compression, number := range map[Compression][][]byte{
+		Bzip2: {{0x42, 0x5A, 0x68}},
+		Gzip:  {{0x1F, 0x8B, 0x08}},
+		Xz:    {{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00}},
+		Zstd: {{0x22, 0xB5, 0x2F, 0xFD}, {0x23, 0xB5, 0x2F, 0xFD},
+			{0x24, 0xB5, 0x2F, 0xFD}, {0x25, 0xB5, 0x2F, 0xFD},
+			{0x26, 0xB5, 0x2F, 0xFD}, {0x27, 0xB5, 0x2F, 0xFD},
+			{0x28, 0xB5, 0x2F, 0xFD}},
 	} {
-		if len(source) < len(m) {
-			logrus.Debug("Len too short")
-			continue
-		}
-		if bytes.Equal(m, source[:len(m)]) {
-			return compression
+		for _, m := range number {
+			if len(source) < len(m) {
+				logrus.Debug("Len too short")
+				continue
+			}
+			if bytes.Equal(m, source[:len(m)]) {
+				return compression
+			}
 		}
 	}
 	return Uncompressed
@@ -151,6 +159,12 @@ func DetectCompression(source []byte) Compression {
 
 func xzDecompress(ctx context.Context, archive io.Reader) (io.ReadCloser, error) {
 	args := []string{"xz", "-d", "-c", "-q"}
+
+	return cmdStream(exec.CommandContext(ctx, args[0], args[1:]...), archive)
+}
+
+func zstdDecompress(ctx context.Context, archive io.Reader) (io.ReadCloser, error) {
+	args := []string{"zstd", "-d", "-c", "-q"}
 
 	return cmdStream(exec.CommandContext(ctx, args[0], args[1:]...), archive)
 }
@@ -223,6 +237,16 @@ func DecompressStream(archive io.Reader) (io.ReadCloser, error) {
 		}
 		readBufWrapper := p.NewReadCloserWrapper(buf, xzReader)
 		return wrapReadCloser(readBufWrapper, cancel), nil
+	case Zstd:
+		ctx, cancel := context.WithCancel(context.Background())
+
+		zstdReader, err := zstdDecompress(ctx, buf)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		readBufWrapper := p.NewReadCloserWrapper(buf, zstdReader)
+		return wrapReadCloser(readBufWrapper, cancel), nil
 	default:
 		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
 	}
@@ -240,7 +264,7 @@ func CompressStream(dest io.Writer, compression Compression) (io.WriteCloser, er
 		gzWriter := gzip.NewWriter(dest)
 		writeBufWrapper := p.NewWriteCloserWrapper(buf, gzWriter)
 		return writeBufWrapper, nil
-	case Bzip2, Xz:
+	case Bzip2, Xz, Zstd:
 		// archive/bzip2 does not support writing, and there is no xz support at all
 		// However, this is not a problem as docker only currently generates gzipped tars
 		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
@@ -347,6 +371,8 @@ func (compression *Compression) Extension() string {
 		return "tar.gz"
 	case Xz:
 		return "tar.xz"
+	case Zstd:
+		return "tar.zst"
 	}
 	return ""
 }
@@ -1020,7 +1046,7 @@ loop:
 // Untar reads a stream of bytes from `archive`, parses it as a tar archive,
 // and unpacks it into the directory at `dest`.
 // The archive may be compressed with one of the following algorithms:
-//  identity (uncompressed), gzip, bzip2, xz.
+//  identity (uncompressed), gzip, bzip2, xz, zstd.
 // FIXME: specify behavior when target path exists vs. doesn't exist.
 func Untar(tarArchive io.Reader, dest string, options *TarOptions) error {
 	return untarHandler(tarArchive, dest, options, true)

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -133,6 +133,13 @@ func TestDecompressStreamXz(t *testing.T) {
 	testDecompressStream(t, "xz", "xz -f")
 }
 
+func TestDecompressStreamZstd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Zstd not present in msys2")
+	}
+	testDecompressStream(t, "zst", "zstd -f")
+}
+
 func TestCompressStreamXzUnsupported(t *testing.T) {
 	dest, err := os.Create(tmp + "dest")
 	if err != nil {
@@ -156,6 +163,19 @@ func TestCompressStreamBzip2Unsupported(t *testing.T) {
 	_, err = CompressStream(dest, Xz)
 	if err == nil {
 		t.Fatalf("Should fail as xz is unsupported for compression format.")
+	}
+}
+
+func TestCompressStreamZstdUnsupported(t *testing.T) {
+	dest, err := os.Create(tmp + "dest")
+	if err != nil {
+		t.Fatalf("Fail to create the destination file")
+	}
+	defer dest.Close()
+
+	_, err = CompressStream(dest, Zstd)
+	if err == nil {
+		t.Fatalf("Should fail as zstd is unsupported for compression format.")
 	}
 }
 
@@ -206,6 +226,14 @@ func TestExtensionXz(t *testing.T) {
 	output := compression.Extension()
 	if output != "tar.xz" {
 		t.Fatalf("The extension of a bzip2 archive should be 'tar.xz'")
+	}
+}
+
+func TestExtensionZstd(t *testing.T) {
+	compression := Zstd
+	output := compression.Extension()
+	if output != "tar.zst" {
+		t.Fatalf("The extension of a zstd archive should be 'tar.zst'")
 	}
 }
 

--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -25,7 +25,7 @@ func NewArchiver(idMappings *idtools.IDMappings) *archive.Archiver {
 // Untar reads a stream of bytes from `archive`, parses it as a tar archive,
 // and unpacks it into the directory at `dest`.
 // The archive may be compressed with one of the following algorithms:
-//  identity (uncompressed), gzip, bzip2, xz.
+//  identity (uncompressed), gzip, bzip2, xz, zstd.
 func Untar(tarArchive io.Reader, dest string, options *archive.TarOptions) error {
 	return untarHandler(tarArchive, dest, options, true)
 }


### PR DESCRIPTION
**- What I did**
Added support for zstd compression (https://github.com/facebook/zstd)  Issue: https://github.com/moby/moby/issues/28394
**- How I did it**
Added it to archive, which hopefully should be enough to support it. This will add a requirement on zstd to be installed on your system.
**- How to verify it**
* Create a tar.zst archive: `touch foo;  tar -c -I zstd -f foo.tar.zst foo`
* Create a Dockerfile that includes `ADD foo.zst .`
* The archive file should be uncompressed within the docker container

**- Description for the changelog**
Add support for zstd compressed archives