### PR TITLE
Fix FIFO, sockets and device files when run in user NS

### DIFF
--- a/daemon/graphdriver/copy/copy.go
+++ b/daemon/graphdriver/copy/copy.go
@@ -189,15 +189,15 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
 		case os.ModeNamedPipe:
 			fallthrough
 		case os.ModeSocket:
-			if rsystem.RunningInUserNS() {
-				// cannot create a device if running in user namespace
-				return nil
-			}
 			if err := unix.Mkfifo(dstPath, stat.Mode); err != nil {
 				return err
 			}
 
 		case os.ModeDevice:
+			if rsystem.RunningInUserNS() {
+				// cannot create a device if running in user namespace
+				return nil
+			}
 			if err := unix.Mknod(dstPath, stat.Mode, int(stat.Rdev)); err != nil {
 				return err
 			}


### PR DESCRIPTION
commit 617c352e9225 (https://github.com/moby/moby/pull/25672) "Don't create devices if in a user namespace"

introduced check, which meant to skip mknod operation when run
in user namespace, but instread skipped FIFO and socket files
copy.

Fixes https://github.com/moby/moby/issues/36622

Signed-off-by: Maxim Ivanov <ivanov.maxim@gmail.com>