### PR TITLE
Update tmLanguage file to cover first escape character

### DIFF
--- a/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
+++ b/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
@@ -8,6 +8,16 @@
 	</array>
 	<key>name</key>
 	<string>Dockerfile</string>
+	<key>repository</key>
+	<dict>
+		<key>string-character-escape</key>
+		<dict>
+			<key>name</key>
+			<string>constant.character.escaped.dockerfile</string>
+			<key>match</key>
+			<string>\\.</string>
+		</dict>
+	</dict>
 	<key>patterns</key>
 	<array>
 		<dict>
@@ -62,6 +72,10 @@
 			<string>^\s*(?i:(ONBUILD)\s+)?(?i:(CMD|ENTRYPOINT))\s</string>
 		</dict>
 		<dict>
+			<key>include</key>
+			<string>#string-character-escape</string>
+		</dict>
+		<dict>
 			<key>begin</key>
 			<string>"</string>
 			<key>beginCaptures</key>
@@ -87,10 +101,8 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>match</key>
-					<string>\\.</string>
-					<key>name</key>
-					<string>constant.character.escaped.dockerfile</string>
+					<key>include</key>
+					<string>#string-character-escape</string>
 				</dict>
 			</array>
 		</dict>
@@ -120,10 +132,8 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>match</key>
-					<string>\\.</string>
-					<key>name</key>
-					<string>constant.character.escaped.dockerfile</string>
+					<key>include</key>
+					<string>#string-character-escape</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
**- What I did**
fixes https://github.com/moby/moby/issues/36695.

**- How I did it**
make duplicated escape code to variable and use it outside of begin,end statement.

**- How to verify it**
test this code.
This is in https://github.com/moby/moby/issues/36695
```
FROM ubunto:16.06 

RUN echo //blep.derp.com:9875/:_authToken=\'er99iWoLDerYl666'YRUS134YfE'ghohhrrrr516LwfM=\' >> ~/.npmrc
RUN echo //blep.derp.com:9875/:_authToken=\"er99iWoLDerYl666YRUS134YfEghohhrrrr516LwfM=\" >> ~/.npmrc
RUN echo //blep.derp.com:9875/:'_authToken=\'er99iWoLDerYl666YRUS134YfEghohhrrrr516LwfM=\' >> ~/.np'mrc
RUN echo //blep.derp.com:9875/:_aut"hToken=\'er99iWoLDerYl666Y"RUS134YfEghohhrrrr516LwfM=\' >> ~/.npmrc
```
![test_code](https://user-images.githubusercontent.com/17864835/38202752-cf3b30ae-36d7-11e8-8340-785b67912c93.PNG)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
updated tmLanguage file

**- A picture of a cute animal (not mandatory but encouraged)**
![cat](https://user-images.githubusercontent.com/17864835/38202725-b234f076-36d7-11e8-87ab-bccc3762ad42.jpg)


Signed-off-by: Myeongjooon Kim kimmj8409@gmail.com