### PR TITLE
daemon/cluster: handle partial attachment entries during configure

### DIFF
--- a/daemon/cluster/executor/container/executor.go
+++ b/daemon/cluster/executor/container/executor.go
@@ -143,13 +143,22 @@ func (e *executor) Configure(ctx context.Context, node *api.Node) error {
 	attachments := make(map[string]string)
 
 	for _, na := range node.Attachments {
+		if na == nil || na.Network == nil || len(na.Addresses) == 0 {
+			// this should not happen, but we got a panic here and don't have a
+			// good idea about what the underlying data structure looks like.
+			logrus.WithField("NetworkAttachment", fmt.Sprintf("%#v", na)).
+				Warnf("skipping nil or malformed node network attachment entry")
+			continue
+		}
+
 		if na.Network.Spec.Ingress {
 			ingressNA = na
 		}
+
 		attachments[na.Network.ID] = na.Addresses[0]
 	}
 
-	if (ingressNA == nil) && (node.Attachment != nil) {
+	if (ingressNA == nil) && (node.Attachment != nil) && (len(node.Attachment.Addresses) > 0) {
 		ingressNA = node.Attachment
 		attachments[ingressNA.Network.ID] = ingressNA.Addresses[0]
 	}


### PR DESCRIPTION
We have seen a panic when re-joining a node to a swarm cluster. The
cause of the issue is unknown, so we just need to add a test for nil
objects and log when we get the condition. Hopefully this can prevent
the crash and we can recover the config at a later time.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

This is like a pokemon, but once actually existed, Bulbasaurus:

![](https://i.redditmedia.com/XE_Ooxuu0MMV3cxWmRQHNrELFGDT0Ip20Vy8gxKqXYY.png?w=900&s=73295411e6a8fe13ecd13b9b34f45687)