### PR TITLE
Windows: Start of enabling tests under integration/

### DIFF
--- a/hack/ci/windowsRS1.ps1
+++ b/hack/ci/windowsRS1.ps1
@@ -1,0 +1,909 @@
+# Jenkins CI scripts for Windows to Windows CI (Powershell Version)
+# By John Howard (@jhowardmsft) January 2016 - bash version; July 2016 Ported to PowerShell
+
+$ErrorActionPreference = 'Stop'
+$StartTime=Get-Date
+#$env:DOCKER_DUT_DEBUG="yes" # Comment out to not be in debug mode
+
+# -------------------------------------------------------------------------------------------
+# When executed, we rely on four variables being set in the environment:
+#
+# [The reason for being environment variables rather than parameters is historical. No reason
+# why it couldn't be updated.]
+#
+#    SOURCES_DRIVE       is the drive on which the sources being tested are cloned from.
+#                        This should be a straight drive letter, no platform semantics.
+#                        For example 'c'
+#
+#    SOURCES_SUBDIR      is the top level directory under SOURCES_DRIVE where the
+#                        sources are cloned to. There are no platform semantics in this
+#                        as it does not include slashes.
+#                        For example 'gopath'
+#
+#                        Based on the above examples, it would be expected that Jenkins
+#                        would clone the sources being tested to
+#                        SOURCES_DRIVE\SOURCES_SUBDIR\src\github.com\docker\docker, or
+#                        c:\gopath\src\github.com\docker\docker
+#
+#    TESTRUN_DRIVE       is the drive where we build the binary on and redirect everything
+#                        to for the daemon under test. On an Azure D2 type host which has
+#                        an SSD temporary storage D: drive, this is ideal for performance.
+#                        For example 'd'
+#
+#    TESTRUN_SUBDIR      is the top level directory under TESTRUN_DRIVE where we redirect
+#                        everything to for the daemon under test. For example 'CI'.
+#                        Hence, the daemon under test is run under
+#                        TESTRUN_DRIVE\TESTRUN_SUBDIR\CI-<CommitID> or
+#                        d:\CI\CI-<CommitID>
+#
+# In addition, the following variables can control the run configuration:
+#
+#    DOCKER_DUT_DEBUG         if defined starts the daemon under test in debug mode.
+#
+#    SKIP_VALIDATION_TESTS    if defined skips the validation tests
+#
+#    SKIP_UNIT_TESTS          if defined skips the unit tests
+#
+#    SKIP_INTEGRATION_TESTS   if defined skips the integration tests
+#
+#    SKIP_COPY_GO             if defined skips copy the go installer from the image
+#
+#    DOCKER_DUT_HYPERV        if default daemon under test default isolation is hyperv
+#
+#    INTEGRATION_TEST_NAME    to only run partial tests eg "TestInfo*" will only run
+#                             any tests starting "TestInfo"
+#
+#    SKIP_BINARY_BUILD        if defined skips building the binary
+#
+#    SKIP_ZAP_DUT             if defined doesn't zap the daemon under test directory
+#
+#    SKIP_IMAGE_BUILD         if defined doesn't build the 'docker' image
+#
+#    INTEGRATION_IN_CONTAINER if defined, runs the integration tests from inside a container.
+#                             As of July 2016, there are known issues with this.
+#
+#    SKIP_ALL_CLEANUP         if defined, skips any cleanup at the start or end of the run
+#
+#    WINDOWS_BASE_IMAGE       if defined, uses that as the base image. Note that the
+#                             docker integration tests are also coded to use the same
+#                             environment variable, and if no set, defaults to microsoft/windowsservercore
+# -------------------------------------------------------------------------------------------
+#
+# Jenkins Integration. Add a Windows Powershell build step as follows:
+#
+#    Write-Host -ForegroundColor green "INFO: Jenkins build step starting"
+#    $CISCRIPT_DEFAULT_LOCATION = "https://raw.githubusercontent.com/jhowardmsft/docker-w2wCIScripts/master/runCI/executeCI.ps1"
+#    $CISCRIPT_LOCAL_LOCATION = "$env:TEMP\executeCI.ps1"
+#    Write-Host -ForegroundColor green "INFO: Removing cached execution script"
+#    Remove-Item $CISCRIPT_LOCAL_LOCATION -Force -ErrorAction SilentlyContinue 2>&1 | Out-Null
+#    $wc = New-Object net.webclient
+#    try {
+#        Write-Host -ForegroundColor green "INFO: Downloading latest execution script..."
+#        $wc.Downloadfile($CISCRIPT_DEFAULT_LOCATION, $CISCRIPT_LOCAL_LOCATION)
+#    }
+#    catch [System.Net.WebException]
+#    {
+#        Throw ("Failed to download: $_")
+#    }
+#    & $CISCRIPT_LOCAL_LOCATION
+# -------------------------------------------------------------------------------------------
+
+$SCRIPT_VER="10-May-2017 12:16 PDT"
+$FinallyColour="Cyan"
+
+#$env:SKIP_UNIT_TESTS="yes"
+#$env:SKIP_VALIDATION_TESTS="yes"
+#$env:SKIP_ZAP_DUT=""
+#$env:SKIP_BINARY_BUILD="yes"
+#$env:INTEGRATION_TEST_NAME=""
+#$env:SKIP_IMAGE_BUILD="yes"
+#$env:SKIP_ALL_CLEANUP="yes"
+#$env:INTEGRATION_IN_CONTAINER="yes"
+#$env:WINDOWS_BASE_IMAGE=""
+#$env:SKIP_COPY_GO="yes"
+
+Function Nuke-Everything {
+    $ErrorActionPreference = 'SilentlyContinue'
+    if ($env:SKIP_ALL_CLEANUP -ne $null) {
+        Write-Host -ForegroundColor Magenta "WARN: Skipping all cleanup"
+        return
+    }
+
+    try {
+        Write-Host -ForegroundColor green "INFO: Nuke-Everything..."
+        $containerCount = ($(docker ps -aq | Measure-Object -line).Lines)
+        if (-not $LastExitCode -eq 0) {
+            Throw "ERROR: Failed to get container count from control daemon while nuking"
+        }
+
+        Write-Host -ForegroundColor green "INFO: Container count on control daemon to delete is $containerCount"
+        if ($(docker ps -aq | Measure-Object -line).Lines -gt 0) {
+            docker rm -f $(docker ps -aq)
+        }
+        $imageCount=($(docker images --format "{{.Repository}}:{{.ID}}" | `
+                        select-string -NotMatch "windowsservercore" | `
+                        select-string -NotMatch "nanoserver" | `
+                        select-string -NotMatch "docker" | `
+                        Measure-Object -line).Lines)
+        if ($imageCount -gt 0) {
+            Write-Host -Foregroundcolor green "INFO: Non-base image count on control daemon to delete is $imageCount"
+            docker rmi -f `
+                $(docker images --format "{{.Repository}}:{{.ID}}" | `
+                        select-string -NotMatch "windowsservercore" | `
+                        select-string -NotMatch "nanoserver" | `
+                        select-string -NotMatch "docker").ToString().Split(":")[1]
+        }
+
+        # Kill any spurious daemons. The '-' is IMPORTANT otherwise will kill the control daemon!
+        $pids=$(get-process | where-object {$_.ProcessName -like 'dockerd-*'}).id
+        foreach ($p in $pids) {
+            Write-Host "INFO: Killing daemon with PID $p"
+            Stop-Process -Id $p -Force -ErrorAction SilentlyContinue
+        }
+
+        Stop-Process -name "cc1" -Force -ErrorAction SilentlyContinue 2>&1 | Out-Null
+        Stop-Process -name "link" -Force -ErrorAction SilentlyContinue 2>&1 | Out-Null
+        Stop-Process -name "compile" -Force -ErrorAction SilentlyContinue 2>&1 | Out-Null
+        Stop-Process -name "ld" -Force -ErrorAction SilentlyContinue 2>&1 | Out-Null
+        Stop-Process -name "go" -Force -ErrorAction SilentlyContinue 2>&1 | Out-Null
+        Stop-Process -name "git" -Force -ErrorAction SilentlyContinue 2>&1 | Out-Null
+        Stop-Process -name "git-remote-https" -Force -ErrorAction SilentlyContinue 2>&1 | Out-Null
+        Stop-Process -name "integration-cli.test" -Force -ErrorAction SilentlyContinue 2>&1 | Out-Null
+        Stop-Process -name "tail" -Force -ErrorAction SilentlyContinue 2>&1 | Out-Null
+
+        # Detach any VHDs
+        gwmi msvm_mountedstorageimage -namespace root/virtualization/v2 -ErrorAction SilentlyContinue | foreach-object {$_.DetachVirtualHardDisk() }
+
+        # Stop any compute processes
+        Get-ComputeProcess | Stop-ComputeProcess -Force
+
+        # Delete the directory using our dangerous utility unless told not to
+        if (Test-Path "$env:TESTRUN_DRIVE`:\$env:TESTRUN_SUBDIR") {
+            if ($env:SKIP_ZAP_DUT -eq $null) {
+                Write-Host -ForegroundColor Green "INFO: Nuking $env:TESTRUN_DRIVE`:\$env:TESTRUN_SUBDIR"
+                docker-ci-zap "-folder=$env:TESTRUN_DRIVE`:\$env:TESTRUN_SUBDIR"
+            } else {
+                Write-Host -ForegroundColor Magenta "WARN: Skip nuking $env:TESTRUN_DRIVE`:\$env:TESTRUN_SUBDIR"
+            }
+        }
+
+        # RS1 Production Server workaround - Psched
+        $reg = "HKLM:\System\CurrentControlSet\Services\Psched\Parameters\NdisAdapters"
+        $count=(Get-ChildItem $reg | Measure-Object).Count
+        if ($count -gt 0) {
+            Write-Warning "There are $count NdisAdapters leaked under Psched\Parameters"
+            if ($env:COMPUTERNAME -match "jenkins-rs1-") {
+                Write-Warning "Cleaning Psched..."
+                Get-ChildItem $reg | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
+            } else {
+                Write-Warning "Not cleaning as not a production RS1 server"
+            }
+        }
+
+        # RS1 Production Server workaround - WFPLWFS
+        $reg = "HKLM:\System\CurrentControlSet\Services\WFPLWFS\Parameters\NdisAdapters"
+        $count=(Get-ChildItem $reg | Measure-Object).Count
+        if ($count -gt 0) {
+            Write-Warning "There are $count NdisAdapters leaked under WFPLWFS\Parameters"
+            if ($env:COMPUTERNAME -match "jenkins-rs1-") {
+                Write-Warning "Cleaning WFPLWFS..."
+                Get-ChildItem $reg | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
+            } else {
+                Write-Warning "Not cleaning as not a production RS1 server"
+            }
+        }
+    } catch {
+        # Don't throw any errors onwards Throw $_
+    }
+}
+
+Try {
+    Write-Host -ForegroundColor Cyan "`nINFO: executeCI.ps1 starting at $(date)`n"
+    Write-Host  -ForegroundColor Green "INFO: Script version $SCRIPT_VER"
+    Set-PSDebug -Trace 0  # 1 to turn on
+    $origPath="$env:PATH"            # so we can restore it at the end
+    $origDOCKER_HOST="$DOCKER_HOST"  # So we can restore it at the end
+    $origGOROOT="$env:GOROOT"        # So we can restore it at the end
+    $origGOPATH="$env:GOPATH"        # So we can restore it at the end
+
+    # Turn off progress bars
+    $origProgressPreference=$global:ProgressPreference
+    $global:ProgressPreference='SilentlyContinue'
+
+    # Git version
+    Write-Host  -ForegroundColor Green "INFO: Running $(git version)"
+
+    # OS Version
+    $bl=(Get-ItemProperty -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion"  -Name BuildLabEx).BuildLabEx
+    $a=$bl.ToString().Split(".")
+    $Branch=$a[3]
+    $WindowsBuild=$a[0]+"."+$a[1]+"."+$a[4]
+    Write-Host -ForegroundColor green "INFO: Branch:$Branch Build:$WindowsBuild"
+
+    # List the environment variables
+    Write-Host -ForegroundColor green "INFO: Environment variables:"
+    Get-ChildItem Env: | Out-String
+
+    # PR
+    if (-not ($env:PR -eq $Null)) { echo "INFO: PR#$env:PR (https://github.com/docker/docker/pull/$env:PR)" }
+
+    # Make sure docker is installed
+    if ((Get-Command "docker" -ErrorAction SilentlyContinue) -eq $null) { Throw "ERROR: docker is not installed or not found on path" }
+
+    # Make sure docker-ci-zap is installed
+    if ((Get-Command "docker-ci-zap" -ErrorAction SilentlyContinue) -eq $null) { Throw "ERROR: docker-ci-zap is not installed or not found on path" }
+
+    # Make sure SOURCES_DRIVE is set
+    if ($env:SOURCES_DRIVE -eq $Null) { Throw "ERROR: Environment variable SOURCES_DRIVE is not set" }
+
+    # Make sure TESTRUN_DRIVE is set
+    if ($env:TESTRUN_DRIVE -eq $Null) { Throw "ERROR: Environment variable TESTRUN_DRIVE is not set" }
+
+    # Make sure SOURCES_SUBDIR is set
+    if ($env:SOURCES_SUBDIR -eq $Null) { Throw "ERROR: Environment variable SOURCES_SUBDIR is not set" }
+
+    # Make sure TESTRUN_SUBDIR is set
+    if ($env:TESTRUN_SUBDIR -eq $Null) { Throw "ERROR: Environment variable TESTRUN_SUBDIR is not set" }
+
+    # SOURCES_DRIVE\SOURCES_SUBDIR must be a directory and exist
+    if (-not (Test-Path -PathType Container "$env:SOURCES_DRIVE`:\$env:SOURCES_SUBDIR")) { Throw "ERROR: $env:SOURCES_DRIVE`:\$env:SOURCES_SUBDIR must be an existing directory" }
+
+
+    # Create the TESTRUN_DRIVE\TESTRUN_SUBDIR if it does not already exist
+    New-Item -ItemType Directory -Force -Path "$env:TESTRUN_DRIVE`:\$env:TESTRUN_SUBDIR" -ErrorAction SilentlyContinue | Out-Null
+
+    Write-Host  -ForegroundColor Green "INFO: Sources under $env:SOURCES_DRIVE`:\$env:SOURCES_SUBDIR\..."
+    Write-Host  -ForegroundColor Green "INFO: Test run under $env:TESTRUN_DRIVE`:\$env:TESTRUN_SUBDIR\..."
+
+    # Check the intended source location is a directory
+    if (-not (Test-Path -PathType Container "$env:SOURCES_DRIVE`:\$env:SOURCES_SUBDIR\src\github.com\docker\docker" -ErrorAction SilentlyContinue)) {
+        Throw "ERROR: $env:SOURCES_DRIVE`:\$env:SOURCES_SUBDIR\src\github.com\docker\docker is not a directory!"
+    }
+
+    # Make sure we start at the root of the sources
+    cd "$env:SOURCES_DRIVE`:\$env:SOURCES_SUBDIR\src\github.com\docker\docker"
+    Write-Host  -ForegroundColor Green "INFO: Running in $(pwd)"
+
+    # Make sure we are in repo
+    if (-not (Test-Path -PathType Leaf -Path ".\Dockerfile.windows")) {
+        Throw "$(pwd) does not container Dockerfile.Windows!"
+    }
+    Write-Host  -ForegroundColor Green "INFO: docker/docker repository was found"
+
+    # Make sure microsoft/windowsservercore:latest image is installed in the control daemon. On public CI machines, windowsservercore.tar and nanoserver.tar
+    # are pre-baked and tagged appropriately in the c:\baseimages directory, and can be directly loaded.
+    # Note - this script will only work on 10B (Oct 2016) or later machines! Not 9D or previous due to image tagging assumptions.
+    #
+    # On machines not on Microsoft corpnet, or those which have not been pre-baked, we have to docker pull the image in which case it will
+    # will come in directly as microsoft/windowsservercore:latest. The ultimate goal of all this code is to ensure that whatever,
+    # we have microsoft/windowsservercore:latest
+    #
+    # Note we cannot use (as at Oct 2016) nanoserver as the control daemons base image, even if nanoserver is used in the tests themselves.
+
+    $ErrorActionPreference = "SilentlyContinue"
+    $ControlDaemonBaseImage="windowsservercore"
+
+    $readBaseFrom="c"
+    if ($((docker images --format "{{.Repository}}:{{.Tag}}" | Select-String $("microsoft/"+$ControlDaemonBaseImage+":latest") | Measure-Object -Line).Lines) -eq 0) {
+        # Try the internal azure CI image version or Microsoft internal corpnet where the base image is already pre-prepared on the disk,
+        # either through Invoke-DockerCI or, in the case of Azure CI servers, baked into the VHD at the same location.
+        if (Test-Path $("$env:SOURCES_DRIVE`:\baseimages\"+$ControlDaemonBaseImage+".tar")) {
+
+            # An optimization for CI servers to copy it to the D: drive which is an SSD.
+            if ($env:SOURCES_DRIVE -ne $env:TESTRUN_DRIVE) {
+                $readBaseFrom=$env:TESTRUN_DRIVE
+                if (!(Test-Path "$env:TESTRUN_DRIVE`:\baseimages")) {
+                    New-Item "$env:TESTRUN_DRIVE`:\baseimages" -type directory | Out-Null
+                }
+                if (!(Test-Path "$env:TESTRUN_DRIVE`:\baseimages\windowsservercore.tar")) {
+                    if (Test-Path "$env:SOURCES_DRIVE`:\baseimages\windowsservercore.tar") {
+                        Write-Host -ForegroundColor Green "INFO: Optimisation - copying $env:SOURCES_DRIVE`:\baseimages\windowsservercore.tar to $env:TESTRUN_DRIVE`:\baseimages"
+                        Copy-Item "$env:SOURCES_DRIVE`:\baseimages\windowsservercore.tar" "$env:TESTRUN_DRIVE`:\baseimages"
+                    }
+                }
+                if (!(Test-Path "$env:TESTRUN_DRIVE`:\baseimages\nanoserver.tar")) {
+                    if (Test-Path "$env:SOURCES_DRIVE`:\baseimages\nanoserver.tar") {
+                        Write-Host -ForegroundColor Green "INFO: Optimisation - copying $env:SOURCES_DRIVE`:\baseimages\nanoserver.tar to $env:TESTRUN_DRIVE`:\baseimages"
+                        Copy-Item "$env:SOURCES_DRIVE`:\baseimages\nanoserver.tar" "$env:TESTRUN_DRIVE`:\baseimages"
+                    }
+                }
+                $readBaseFrom=$env:TESTRUN_DRIVE
+            }
+
+            Write-Host  -ForegroundColor Green "INFO: Loading"$ControlDaemonBaseImage".tar from disk. This may take some time..."
+            $ErrorActionPreference = "SilentlyContinue"
+            docker load -i $("$readBaseFrom`:\baseimages\"+$ControlDaemonBaseImage+".tar")
+            $ErrorActionPreference = "Stop"
+            if (-not $LastExitCode -eq 0) {
+                Throw $("ERROR: Failed to load $readBaseFrom`:\baseimages\"+$ControlDaemonBaseImage+".tar")
+            }
+            Write-Host -ForegroundColor Green "INFO: docker load of"$ControlDaemonBaseImage" completed successfully"
+        } else {
+            # We need to docker pull it instead. It will come in directly as microsoft/imagename:latest
+            Write-Host -ForegroundColor Green $("INFO: Pulling microsoft/"+$ControlDaemonBaseImage+":latest from docker hub. This may take some time...")
+            $ErrorActionPreference = "SilentlyContinue"
+            docker pull $("microsoft/"+$ControlDaemonBaseImage)
+            $ErrorActionPreference = "Stop"
+            if (-not $LastExitCode -eq 0) {
+                Throw $("ERROR: Failed to docker pull microsoft/"+$ControlDaemonBaseImage+":latest.")
+            }
+            Write-Host -ForegroundColor Green $("INFO: docker pull of microsoft/"+$ControlDaemonBaseImage+":latest completed successfully")
+        }
+    } else {
+        Write-Host -ForegroundColor Green "INFO: Image"$("microsoft/"+$ControlDaemonBaseImage+":latest")"is already loaded in the control daemon"
+    }
+
+    # Inspect the pulled image to get the version directly
+    $ErrorActionPreference = "SilentlyContinue"
+    $imgVersion = $(docker inspect  $("microsoft/"+$ControlDaemonBaseImage) --format "{{.OsVersion}}")
+    $ErrorActionPreference = "Stop"
+    Write-Host -ForegroundColor Green $("INFO: Version of microsoft/"+$ControlDaemonBaseImage+":latest is '"+$imgVersion+"'")
+
+    # Provide the docker version for debugging purposes.
+    Write-Host  -ForegroundColor Green "INFO: Docker version of control daemon"
+    Write-Host
+    $ErrorActionPreference = "SilentlyContinue"
+    docker version
+    $ErrorActionPreference = "Stop"
+    if (-not($LastExitCode -eq 0)) {
+        Write-Host
+        Write-Host  -ForegroundColor Green "---------------------------------------------------------------------------"
+        Write-Host  -ForegroundColor Green " Failed to get a response from the control daemon. It may be down."
+        Write-Host  -ForegroundColor Green " Try re-running this CI job, or ask on #docker-dev or #docker-maintainers"
+        Write-Host  -ForegroundColor Green " to see if the the daemon is running. Also check the nssm configuration."
+        Write-Host  -ForegroundColor Green " DOCKER_HOST is set to $DOCKER_HOST."
+        Write-Host  -ForegroundColor Green "---------------------------------------------------------------------------"
+        Write-Host
+        Throw "ERROR: The control daemon does not appear to be running."
+    }
+    Write-Host
+
+    # Same as above, but docker info
+    Write-Host  -ForegroundColor Green "INFO: Docker info of control daemon"
+    Write-Host
+    $ErrorActionPreference = "SilentlyContinue"
+    docker info
+    $ErrorActionPreference = "Stop"
+    if (-not($LastExitCode -eq 0)) {
+        Throw "ERROR: The control daemon does not appear to be running."
+    }
+    Write-Host
+
+    # Get the commit has and verify we have something
+    $ErrorActionPreference = "SilentlyContinue"
+    $COMMITHASH=$(git rev-parse --short HEAD)
+    $ErrorActionPreference = "Stop"
+    if (-not($LastExitCode -eq 0)) {
+        Throw "ERROR: Failed to get commit hash. Are you sure this is a docker repository?"
+    }
+    Write-Host  -ForegroundColor Green "INFO: Commit hash is $COMMITHASH"
+
+    # Nuke everything and go back to our sources after
+    Nuke-Everything
+    cd "$env:SOURCES_DRIVE`:\$env:SOURCES_SUBDIR\src\github.com\docker\docker"
+
+    # Redirect to a temporary location.
+    $TEMPORIG=$env:TEMP
+    $env:TEMP="$env:TESTRUN_DRIVE`:\$env:TESTRUN_SUBDIR\CI-$COMMITHASH"
+    $env:LOCALAPPDATA="$TEMP\localappdata"
+    $errorActionPreference='Stop'
+    New-Item -ItemType Directory "$env:TEMP" -ErrorAction SilentlyContinue | Out-Null
+    New-Item -ItemType Directory "$env:TEMP\userprofile" -ErrorAction SilentlyContinue  | Out-Null
+    New-Item -ItemType Directory "$env:TEMP\localappdata" -ErrorAction SilentlyContinue | Out-Null
+    New-Item -ItemType Directory "$env:TEMP\binary" -ErrorAction SilentlyContinue | Out-Null
+    New-Item -ItemType Directory "$env:TEMP\installer" -ErrorAction SilentlyContinue | Out-Null
+    if ($env:SKIP_COPY_GO -eq $null) {
+        # Wipe the previous version of GO - we're going to get it out of the image
+        if (Test-Path "$env:TEMP\go") { Remove-Item "$env:TEMP\go" -Recurse -Force -ErrorAction SilentlyContinue | Out-Null }
+        New-Item -ItemType Directory "$env:TEMP\go" -ErrorAction SilentlyContinue | Out-Null
+    }
+
+    Write-Host -ForegroundColor Green "INFO: Location for testing is $env:TEMP"
+
+    # CI Integrity check - ensure Dockerfile.windows and Dockerfile go versions match
+    $goVersionDockerfileWindows=$(Get-Content ".\Dockerfile.windows" | Select-String "ENV GO_VERSION").ToString().Replace("ENV GO_VERSION=","").Replace("\","").Replace("``","").Trim()
+    $goVersionDockerfile=$(Get-Content ".\Dockerfile" | Select-String "ENV GO_VERSION").ToString().Split(" ")[2]
+    Write-Host  -ForegroundColor Green "INFO: Validating GOLang consistency in Dockerfile.windows..."
+    if (-not ($goVersionDockerfile -eq $goVersionDockerfileWindows)) {
+        Throw "ERROR: Mismatched GO versions between Dockerfile and Dockerfile.windows. Update your PR to ensure that both files are updated and in sync. $goVersionDockerfile $goVersionDockerfileWindows"
+    }
+
+    # Build the image
+    if ($env:SKIP_IMAGE_BUILD -eq $null) {
+        Write-Host  -ForegroundColor Cyan "`n`nINFO: Building the image from Dockerfile.windows at $(Get-Date)..."
+        Write-Host
+        $ErrorActionPreference = "SilentlyContinue"
+        $Duration=$(Measure-Command { docker build -t docker -f Dockerfile.windows . | Out-Host })
+        $ErrorActionPreference = "Stop"
+        if (-not($LastExitCode -eq 0)) {
+           Throw "ERROR: Failed to build image from Dockerfile.windows"
+        }
+        Write-Host  -ForegroundColor Green "INFO: Image build ended at $(Get-Date). Duration`:$Duration"
+    } else {
+        Write-Host -ForegroundColor Magenta "WARN: Skipping building the docker image"
+    }
+
+    # DON'T THINK THIS IS USED ANYMORE.... $v=$(Get-Content ".\VERSION" -raw).ToString().Replace("`n","").Trim()
+    $contPath="$COMMITHASH`:c`:\go\src\github.com\docker\docker\bundles"
+
+    # After https://github.com/docker/docker/pull/30290, .git was added to .dockerignore. Therefore
+    # we have to calculate unsupported outside of the container, and pass the commit ID in through
+    # an environment variable for the binary build
+    $CommitUnsupported=""
+    if ($(git status --porcelain --untracked-files=no).Length -ne 0) {
+        $CommitUnsupported="-unsupported"
+    }
+
+    # Build the binary in a container unless asked to skip it.
+    if ($env:SKIP_BINARY_BUILD -eq $null) {
+        Write-Host  -ForegroundColor Cyan "`n`nINFO: Building the test binaries at $(Get-Date)..."
+        $ErrorActionPreference = "SilentlyContinue"
+        docker rm -f $COMMITHASH 2>&1 | Out-Null
+        if ($CommitUnsupported -ne "") {
+            Write-Host ""
+            Write-Warning "This version is unsupported because there are uncommitted file(s)."
+            Write-Warning "Either commit these changes, or add them to .gitignore."
+            git status --porcelain --untracked-files=no | Write-Warning
+             Write-Host ""
+        }
+        $Duration=$(Measure-Command {docker run --name $COMMITHASH -e DOCKER_GITCOMMIT=$COMMITHASH$CommitUnsupported docker hack\make.ps1 -Binary | Out-Host })
+        $ErrorActionPreference = "Stop"
+        if (-not($LastExitCode -eq 0)) {
+            Throw "ERROR: Failed to build binary"
+        }
+        Write-Host  -ForegroundColor Green "INFO: Binaries build ended at $(Get-Date). Duration`:$Duration"
+
+        # Copy the binaries and the generated version_autogen.go out of the container
+        $ErrorActionPreference = "SilentlyContinue"
+        docker cp "$contPath\docker.exe" $env:TEMP\binary\
+        if (-not($LastExitCode -eq 0)) {
+            Throw "ERROR: Failed to docker cp the client binary (docker.exe) to $env:TEMP\binary"
+        }
+        docker cp "$contPath\dockerd.exe" $env:TEMP\binary\
+        if (-not($LastExitCode -eq 0)) {
+            Throw "ERROR: Failed to docker cp the daemon binary (dockerd.exe) to $env:TEMP\binary"
+        }
+        $ErrorActionPreference = "Stop"
+
+        # Copy the built dockerd.exe to dockerd-$COMMITHASH.exe so that easily spotted in task manager.
+        Write-Host -ForegroundColor Green "INFO: Copying the built daemon binary to $env:TEMP\binary\dockerd-$COMMITHASH.exe..."
+        Copy-Item $env:TEMP\binary\dockerd.exe $env:TEMP\binary\dockerd-$COMMITHASH.exe -Force -ErrorAction SilentlyContinue
+
+        # Copy the built docker.exe to docker-$COMMITHASH.exe
+        Write-Host -ForegroundColor Green "INFO: Copying the built client binary to $env:TEMP\binary\docker-$COMMITHASH.exe..."
+        Copy-Item $env:TEMP\binary\docker.exe $env:TEMP\binary\docker-$COMMITHASH.exe -Force -ErrorAction SilentlyContinue
+
+    } else {
+        Write-Host -ForegroundColor Magenta "WARN: Skipping building the binaries"
+    }
+
+    Write-Host -ForegroundColor Green "INFO: Copying dockerversion from the container..."
+    $ErrorActionPreference = "SilentlyContinue"
+    docker cp "$contPath\..\dockerversion\version_autogen.go" "$env:SOURCES_DRIVE`:\$env:SOURCES_SUBDIR\src\github.com\docker\docker\dockerversion"
+    if (-not($LastExitCode -eq 0)) {
+         Throw "ERROR: Failed to docker cp the generated version_autogen.go to $env:SOURCES_DRIVE`:\$env:SOURCES_SUBDIR\src\github.com\docker\docker\dockerversion"
+    }
+    $ErrorActionPreference = "Stop"
+
+    # Grab the golang installer out of the built image. That way, we know we are consistent once extracted and paths set,
+    # so there's no need to re-deploy on account of an upgrade to the version of GO being used in docker.
+    if ($env:SKIP_COPY_GO -eq $null) {
+        Write-Host -ForegroundColor Green "INFO: Copying the golang package from the container to $env:TEMP\installer\go.zip..."
+        docker cp "$COMMITHASH`:c`:\go.zip" $env:TEMP\installer\
+        if (-not($LastExitCode -eq 0)) {
+            Throw "ERROR: Failed to docker cp the golang installer 'go.zip' from container:c:\go.zip to $env:TEMP\installer"
+        }
+        $ErrorActionPreference = "Stop"
+
+        # Extract the golang installer
+        Write-Host -ForegroundColor Green "INFO: Extracting go.zip to $env:TEMP\go"
+        $Duration=$(Measure-Command { Expand-Archive $env:TEMP\installer\go.zip $env:TEMP -Force | Out-Null})
+        Write-Host  -ForegroundColor Green "INFO: Extraction ended at $(Get-Date). Duration`:$Duration"
+    } else {
+        Write-Host -ForegroundColor Magenta "WARN: Skipping copying and extracting golang from the image"
+    }
+
+    # Set the GOPATH
+    Write-Host -ForegroundColor Green "INFO: Updating the golang and path environment variables"
+    $env:GOPATH="$env:SOURCES_DRIVE`:\$env:SOURCES_SUBDIR"
+    Write-Host -ForegroundColor Green "INFO: GOPATH=$env:GOPATH"
+
+    # Set the path to have the version of go from the image at the front
+    $env:PATH="$env:TEMP\go\bin;$env:PATH"
+
+    # Set the GOROOT to be our copy of go from the image
+    $env:GOROOT="$env:TEMP\go"
+    Write-Host -ForegroundColor Green "INFO: $(go version)"
+
+    # Work out the the -H parameter for the daemon under test (DASHH_DUT) and client under test (DASHH_CUT)
+    #$DASHH_DUT="npipe:////./pipe/$COMMITHASH" # Can't do remote named pipe
+    #$ip = (resolve-dnsname $env:COMPUTERNAME -type A -NoHostsFile -LlmnrNetbiosOnly).IPAddress # Useful to tie down
+    $DASHH_CUT="tcp://127.0.0.1`:2357"    # Not a typo for 2375!
+    $DASHH_DUT="tcp://0.0.0.0:2357"       # Not a typo for 2375!
+
+    # Arguments for the daemon under test
+    $dutArgs=@()
+    $dutArgs += "-H $DASHH_DUT"
+    $dutArgs += "--graph $env:TEMP\daemon"
+    $dutArgs += "--pidfile $env:TEMP\docker.pid"
+
+    # Arguments: Are we starting the daemon under test in debug mode?
+    if (-not ("$env:DOCKER_DUT_DEBUG" -eq "")) {
+        Write-Host -ForegroundColor Green "INFO: Running the daemon under test in debug mode"
+        $dutArgs += "-D"
+    }
+
+    # Arguments: Are we starting the daemon under test with Hyper-V containers as the default isolation?
+    if (-not ("$env:DOCKER_DUT_HYPERV" -eq "")) {
+        Write-Host -ForegroundColor Green "INFO: Running the daemon under test with Hyper-V containers as the default"
+        $dutArgs += "--exec-opt isolation=hyperv"
+    }
+
+    # Start the daemon under test, ensuring everything is redirected to folders under $TEMP.
+    # Important - we launch the -$COMMITHASH version so that we can kill it without
+    # killing the control daemon.
+    Write-Host -ForegroundColor Green "INFO: Starting a daemon under test..."
+    Write-Host -ForegroundColor Green "INFO: Args: $dutArgs"
+    New-Item -ItemType Directory $env:TEMP\daemon -ErrorAction SilentlyContinue  | Out-Null
+
+    # Cannot fathom why, but always writes to stderr....
+    Start-Process "$env:TEMP\binary\dockerd-$COMMITHASH" `
+                  -ArgumentList $dutArgs `
+                  -RedirectStandardOutput "$env:TEMP\dut.out" `
+                  -RedirectStandardError "$env:TEMP\dut.err"
+    Write-Host -ForegroundColor Green "INFO: Process started successfully."
+    $daemonStarted=1
+
+    # Start tailing the daemon under test if the command is installed
+    if ((Get-Command "tail" -ErrorAction SilentlyContinue) -ne $null) {
+        $tail = start-process "tail" -ArgumentList "-f $env:TEMP\dut.out" -ErrorAction SilentlyContinue
+    }
+
+    # Verify we can get the daemon under test to respond
+    $tries=20
+    Write-Host -ForegroundColor Green "INFO: Waiting for the daemon under test to start..."
+    while ($true) {
+        $ErrorActionPreference = "SilentlyContinue"
+        & "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" version 2>&1 | Out-Null
+        $ErrorActionPreference = "Stop"
+        if ($LastExitCode -eq 0) {
+            break
+        }
+
+        $tries--
+        if ($tries -le 0) {
+            $DumpDaemonLog=1
+            Throw "ERROR: Failed to get a response from the daemon under test"
+        }
+        Write-Host -NoNewline "."
+        sleep 1
+    }
+    Write-Host -ForegroundColor Green "INFO: Daemon under test started and replied!"
+
+    # Provide the docker version of the daemon under test for debugging purposes.
+    Write-Host -ForegroundColor Green "INFO: Docker version of the daemon under test"
+    Write-Host
+    $ErrorActionPreference = "SilentlyContinue"
+    & "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" version
+    $ErrorActionPreference = "Stop"
+    if ($LastExitCode -ne 0) {
+        Throw "ERROR: The daemon under test does not appear to be running."
+        $DumpDaemonLog=1
+    }
+    Write-Host
+
+    # Same as above but docker info
+    Write-Host -ForegroundColor Green "INFO: Docker info of the daemon under test"
+    Write-Host
+    $ErrorActionPreference = "SilentlyContinue"
+    & "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" info
+    $ErrorActionPreference = "Stop"
+    if ($LastExitCode -ne 0) {
+        Throw "ERROR: The daemon under test does not appear to be running."
+        $DumpDaemonLog=1
+    }
+    Write-Host
+
+    # Same as above but docker images
+    Write-Host -ForegroundColor Green "INFO: Docker images of the daemon under test"
+    Write-Host
+    $ErrorActionPreference = "SilentlyContinue"
+    & "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" images
+    $ErrorActionPreference = "Stop"
+    if ($LastExitCode -ne 0) {
+        Throw "ERROR: The daemon under test does not appear to be running."
+        $DumpDaemonLog=1
+    }
+    Write-Host
+
+    # Default to windowsservercore for the base image used for the tests. The "docker" image
+    # and the control daemon use microsoft/windowsservercore regardless. This is *JUST* for the tests.
+    if ($env:WINDOWS_BASE_IMAGE -eq $Null) {
+        $env:WINDOWS_BASE_IMAGE="microsoft/windowsservercore"
+    }
+
+    # Lowercase and make sure it has a microsoft/ prefix
+    $env:WINDOWS_BASE_IMAGE = $env:WINDOWS_BASE_IMAGE.ToLower()
+    if ($($env:WINDOWS_BASE_IMAGE -Split "/")[0] -ne "microsoft") {
+        Throw "ERROR: WINDOWS_BASE_IMAGE should start microsoft/"
+    }
+
+    Write-Host -ForegroundColor Green "INFO: Base image for tests is $env:WINDOWS_BASE_IMAGE"
+
+    $ErrorActionPreference = "SilentlyContinue"
+    if ($((& "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" images --format "{{.Repository}}:{{.Tag}}" | Select-String $($env:WINDOWS_BASE_IMAGE+":latest") | Measure-Object -Line).Lines) -eq 0) {
+        # Try the internal azure CI image version or Microsoft internal corpnet where the base image is already pre-prepared on the disk,
+        # either through Invoke-DockerCI or, in the case of Azure CI servers, baked into the VHD at the same location.
+        if (Test-Path $("c:\baseimages\"+$($env:WINDOWS_BASE_IMAGE -Split "/")[1]+".tar")) {
+            Write-Host  -ForegroundColor Green "INFO: Loading"$($env:WINDOWS_BASE_IMAGE -Split "/")[1]".tar from disk into the daemon under test. This may take some time..."
+            $ErrorActionPreference = "SilentlyContinue"
+            & "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" load -i $("$readBaseFrom`:\baseimages\"+$($env:WINDOWS_BASE_IMAGE -Split "/")[1]+".tar")
+            $ErrorActionPreference = "Stop"
+            if (-not $LastExitCode -eq 0) {
+                Throw $("ERROR: Failed to load $readBaseFrom`:\baseimages\"+$($env:WINDOWS_BASE_IMAGE -Split "/")[1]+".tar into daemon under test")
+            }
+            Write-Host -ForegroundColor Green "INFO: docker load of"$($env:WINDOWS_BASE_IMAGE -Split "/")[1]" into daemon under test completed successfully"
+        } else {
+            # We need to docker pull it instead. It will come in directly as microsoft/imagename:latest
+            Write-Host -ForegroundColor Green $("INFO: Pulling "+$env:WINDOWS_BASE_IMAGE+":latest from docker hub into daemon under test. This may take some time...")
+            $ErrorActionPreference = "SilentlyContinue"
+            & "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" pull $($env:WINDOWS_BASE_IMAGE)
+            $ErrorActionPreference = "Stop"
+            if (-not $LastExitCode -eq 0) {
+                Throw $("ERROR: Failed to docker pull "+$env:WINDOWS_BASE_IMAGE+":latest into daemon under test.")
+            }
+            Write-Host -ForegroundColor Green $("INFO: docker pull of "+$env:WINDOWS_BASE_IMAGE+":latest into daemon under test completed successfully")
+        }
+    } else {
+        Write-Host -ForegroundColor Green "INFO: Image"$($env:WINDOWS_BASE_IMAGE+":latest")"is already loaded in the daemon under test"
+    }
+
+    # Inspect the pulled or loaded image to get the version directly
+    $ErrorActionPreference = "SilentlyContinue"
+    $dutimgVersion = $(&"$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" inspect  $($env:WINDOWS_BASE_IMAGE) --format "{{.OsVersion}}")
+    $ErrorActionPreference = "Stop"
+    Write-Host -ForegroundColor Green $("INFO: Version of "+$env:WINDOWS_BASE_IMAGE+":latest is '"+$dutimgVersion+"'")
+
+    # Run the validation tests unless SKIP_VALIDATION_TESTS is defined.
+    if ($env:SKIP_VALIDATION_TESTS -eq $null) {
+        Write-Host -ForegroundColor Cyan "INFO: Running validation tests at $(Get-Date)..."
+        $ErrorActionPreference = "SilentlyContinue"
+        $Duration=$(Measure-Command { hack\make.ps1 -DCO -GoFormat -PkgImports | Out-Host })
+        $ErrorActionPreference = "Stop"
+        if (-not($LastExitCode -eq 0)) {
+            Throw "ERROR: Validation tests failed"
+        }
+        Write-Host  -ForegroundColor Green "INFO: Validation tests ended at $(Get-Date). Duration`:$Duration"
+    } else {
+        Write-Host -ForegroundColor Magenta "WARN: Skipping validation tests"
+    }
+
+    # Run the unit tests inside a container unless SKIP_UNIT_TESTS is defined
+    if ($env:SKIP_UNIT_TESTS -eq $null) {
+        Write-Host -ForegroundColor Cyan "INFO: Running unit tests at $(Get-Date)..."
+        $ErrorActionPreference = "SilentlyContinue"
+        $Duration=$(Measure-Command {docker run -e DOCKER_GITCOMMIT=$COMMITHASH$CommitUnsupported docker hack\make.ps1 -TestUnit | Out-Host })
+        $ErrorActionPreference = "Stop"
+        if (-not($LastExitCode -eq 0)) {
+            Throw "ERROR: Unit tests failed"
+        }
+        Write-Host  -ForegroundColor Green "INFO: Unit tests ended at $(Get-Date). Duration`:$Duration"
+    } else {
+        Write-Host -ForegroundColor Magenta "WARN: Skipping unit tests"
+    }
+
+    # Add the busybox image. Needed for integration tests
+    if ($env:SKIP_INTEGRATION_TESTS -eq $null) {
+        $ErrorActionPreference = "SilentlyContinue"
+        # Build it regardless while switching between nanoserver and windowsservercore
+        #$bbCount = $(& "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" images | Select-String "busybox" | Measure-Object -line).Lines
+        #$ErrorActionPreference = "Stop"
+        #if (-not($LastExitCode -eq 0)) {
+        #    Throw "ERROR: Could not determine if busybox image is present"
+        #}
+        #if ($bbCount -eq 0) {
+            Write-Host -ForegroundColor Green "INFO: Building busybox"
+            $ErrorActionPreference = "SilentlyContinue"
+
+            # This is a temporary hack for nanoserver
+            if ($env:WINDOWS_BASE_IMAGE -ne "microsoft/windowsservercore") {
+                Write-Host -ForegroundColor Red "HACK HACK HACK - Building 64-bit nanoserver busybox image"
+                $(& "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" build -t busybox https://raw.githubusercontent.com/jhowardmsft/busybox64/master/Dockerfile | Out-Host)
+            } else {
+                $(& "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" build -t busybox https://raw.githubusercontent.com/jhowardmsft/busybox/master/Dockerfile | Out-Host)
+            }
+            $ErrorActionPreference = "Stop"
+            if (-not($LastExitCode -eq 0)) {
+                Throw "ERROR: Failed to build busybox image"
+            }
+        #}
+
+
+        Write-Host -ForegroundColor Green "INFO: Docker images of the daemon under test"
+        Write-Host
+        $ErrorActionPreference = "SilentlyContinue"
+        & "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" images
+        $ErrorActionPreference = "Stop"
+        if ($LastExitCode -ne 0) {
+            Throw "ERROR: The daemon under test does not appear to be running."
+            $DumpDaemonLog=1
+        }
+        Write-Host
+    }
+
+    # Run the integration tests unless SKIP_INTEGRATION_TESTS is defined
+    if ($env:SKIP_INTEGRATION_TESTS -eq $null) {
+        Write-Host -ForegroundColor Cyan "INFO: Running integration tests at $(Get-Date)..."
+        $ErrorActionPreference = "SilentlyContinue"
+
+        # Location of the daemon under test.
+        $env:OrigDOCKER_HOST="$env:DOCKER_HOST"
+
+        #https://blogs.technet.microsoft.com/heyscriptingguy/2011/09/20/solve-problems-with-external-command-lines-in-powershell/ is useful to see tokenising
+        $c = "go test "
+        $c += "`"-tags`" " + "`"autogen`" "
+        $c += "./integration/..."
+
+        if ($env:INTEGRATION_IN_CONTAINER -ne $null) {
+            Write-Host -ForegroundColor Green "INFO: Integration tests being run inside a container"
+            # Note we talk back through the containers gateway address
+            # And the ridiculous lengths we have to go to to get the default gateway address... (GetNetIPConfiguration doesn't work in nanoserver)
+            # I just could not get the escaping to work in a single command, so output $c to a file and run that in the container instead...
+            # Not the prettiest, but it works.
+            $c | Out-File -Force "$env:TEMP\binary\runIntegration.ps1"
+            $Duration= $(Measure-Command { & docker run `
+                                                    --rm `
+                                                    -e c=$c `
+                                                    --workdir "c`:\go\src\github.com\docker\docker\" `
+                                                    -v "$env:TEMP\binary`:c:\target" `
+                                                    docker `
+                                                    "`$env`:PATH`='c`:\target;'+`$env:PATH`;  `$env:DOCKER_HOST`='tcp`://'+(ipconfig | select -last 1).Substring(39)+'`:2357'; c:\target\runIntegrationCLI.ps1" | Out-Host } )
+        } else  {
+            Write-Host -ForegroundColor Green "INFO: Integration tests being run from the host:"
+            #cd "$env:SOURCES_DRIVE`:\$env:SOURCES_SUBDIR\src\github.com\docker\docker\integration"
+            $env:DOCKER_HOST=$DASHH_CUT
+            $env:PATH="$env:TEMP\binary;$env:PATH;"  # Force to use the test binaries, not the host ones.
+            Write-Host -ForegroundColor Green "INFO: $c"
+            Write-Host -ForegroundColor Green "INFO: DOCKER_HOST at $DASHH_CUT"
+            # Explicit to not use measure-command otherwise don't get output as it goes
+            $start=(Get-Date); Invoke-Expression $c; $Duration=New-Timespan -Start $start -End (Get-Date)
+        }
+        $ErrorActionPreference = "Stop"
+        if (-not($LastExitCode -eq 0)) {
+            Throw "ERROR: Integration tests failed at $(Get-Date). Duration`:$Duration"
+        }
+        Write-Host  -ForegroundColor Green "INFO: Integration tests ended at $(Get-Date). Duration`:$Duration"
+    }else {
+        Write-Host -ForegroundColor Magenta "WARN: Skipping integration tests"
+    }
+
+    # Run the integration tests unless SKIP_INTEGRATION_TESTS is defined
+    if ($env:SKIP_INTEGRATION_TESTS -eq $null) {
+        Write-Host -ForegroundColor Cyan "INFO: Running integration cli tests at $(Get-Date)..."
+        $ErrorActionPreference = "SilentlyContinue"
+
+        # Location of the daemon under test.
+        $env:OrigDOCKER_HOST="$env:DOCKER_HOST"
+
+        #https://blogs.technet.microsoft.com/heyscriptingguy/2011/09/20/solve-problems-with-external-command-lines-in-powershell/ is useful to see tokenising
+        $c = "go test "
+        $c += "`"-check.v`" "
+        if ($env:INTEGRATION_TEST_NAME -ne $null) { # Makes is quicker for debugging to be able to run only a subset of the integration tests
+            $c += "`"-check.f`" "
+            $c += "`"$env:INTEGRATION_TEST_NAME`" "
+            Write-Host -ForegroundColor Magenta "WARN: Only running integration tests matching $env:INTEGRATION_TEST_NAME"
+        }
+        $c += "`"-tags`" " + "`"autogen`" "
+        $c += "`"-check.timeout`" " + "`"10m`" "
+        $c += "`"-test.timeout`" " + "`"200m`" "
+
+        if ($env:INTEGRATION_IN_CONTAINER -ne $null) {
+            Write-Host -ForegroundColor Green "INFO: Integration tests being run inside a container"
+            # Note we talk back through the containers gateway address
+            # And the ridiculous lengths we have to go to to get the default gateway address... (GetNetIPConfiguration doesn't work in nanoserver)
+            # I just could not get the escaping to work in a single command, so output $c to a file and run that in the container instead...
+            # Not the prettiest, but it works.
+            $c | Out-File -Force "$env:TEMP\binary\runIntegrationCLI.ps1"
+            $Duration= $(Measure-Command { & docker run `
+                                                    --rm `
+                                                    -e c=$c `
+                                                    --workdir "c`:\go\src\github.com\docker\docker\integration-cli" `
+                                                    -v "$env:TEMP\binary`:c:\target" `
+                                                    docker `
+                                                    "`$env`:PATH`='c`:\target;'+`$env:PATH`;  `$env:DOCKER_HOST`='tcp`://'+(ipconfig | select -last 1).Substring(39)+'`:2357'; c:\target\runIntegrationCLI.ps1" | Out-Host } )
+        } else  {
+            Write-Host -ForegroundColor Green "INFO: Integration tests being run from the host:"
+            cd "$env:SOURCES_DRIVE`:\$env:SOURCES_SUBDIR\src\github.com\docker\docker\integration-cli"
+            $env:DOCKER_HOST=$DASHH_CUT
+            $env:PATH="$env:TEMP\binary;$env:PATH;"  # Force to use the test binaries, not the host ones.
+            Write-Host -ForegroundColor Green "INFO: $c"
+            Write-Host -ForegroundColor Green "INFO: DOCKER_HOST at $DASHH_CUT"
+            # Explicit to not use measure-command otherwise don't get output as it goes
+            $start=(Get-Date); Invoke-Expression $c; $Duration=New-Timespan -Start $start -End (Get-Date)
+        }
+        $ErrorActionPreference = "Stop"
+        if (-not($LastExitCode -eq 0)) {
+            Throw "ERROR: Integration tests failed at $(Get-Date). Duration`:$Duration"
+        }
+        Write-Host  -ForegroundColor Green "INFO: Integration tests ended at $(Get-Date). Duration`:$Duration"
+    }else {
+        Write-Host -ForegroundColor Magenta "WARN: Skipping integration tests"
+    }
+
+    # Docker info now to get counts (after or if jjh/containercounts is merged)
+    if ($daemonStarted -eq 1) {
+        Write-Host -ForegroundColor Green "INFO: Docker info of the daemon under test at end of run"
+        Write-Host
+        $ErrorActionPreference = "SilentlyContinue"
+        & "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" info
+        $ErrorActionPreference = "Stop"
+        if ($LastExitCode -ne 0) {
+            Throw "ERROR: The daemon under test does not appear to be running."
+            $DumpDaemonLog=1
+        }
+        Write-Host
+    }
+
+    # Stop the daemon under test
+    if ($daemonStarted -eq 1) {
+        if (Test-Path "$env:TEMP\docker.pid") {
+            $p=Get-Content "$env:TEMP\docker.pid" -raw
+            if ($p -ne $null) {
+                Write-Host -ForegroundColor green "INFO: Stopping daemon under test"
+                taskkill -f -t -pid $p
+                Remove-Item "$env:TEMP\docker.pid" -force -ErrorAction SilentlyContinue
+                #sleep 5
+            }
+        }
+    }
+
+    Write-Host -ForegroundColor Green "INFO: executeCI.ps1 Completed successfully at $(Get-Date)."
+}
+Catch [Exception] {
+    $FinallyColour="Red"
+    Write-Host -ForegroundColor Red ("`r`n`r`nERROR: Failed '$_' at $(Get-Date)")
+    Write-Host "`n`n"
+
+    # Exit to ensure Jenkins captures it. Don't do this in the ISE or interactive Powershell - they will catch the Throw onwards.
+    if ( ([bool]([Environment]::GetCommandLineArgs() -Like '*-NonInteractive*')) -and `
+        ([bool]([Environment]::GetCommandLineArgs() -NotLike "*Powershell_ISE.exe*"))) {
+        exit 1
+    }
+    Throw $_
+}
+Finally {
+    $ErrorActionPreference="SilentlyContinue"
+    $global:ProgressPreference=$origProgressPreference
+    Write-Host  -ForegroundColor Green "INFO: Tidying up at end of run"
+
+    # Restore the path
+    if ($origPath -ne $null) { $env:PATH=$origPath }
+
+    # Restore the DOCKER_HOST
+    if ($origDOCKER_HOST -ne $null) { $env:DOCKER_HOST=$origDOCKER_HOST }
+
+    # Restore the GOROOT and GOPATH variables
+    if ($origGOROOT -ne $null) { $env:GOROOT=$origGOROOT }
+    if ($origGOPATH -ne $null) { $env:GOPATH=$origGOPATH }
+
+    # Dump the daemon log if asked to
+    if ($daemonStarted -eq 1) {
+        if ($dumpDaemonLog -eq 1) {
+            Write-Host -ForegroundColor Cyan "----------- DAEMON LOG ------------"
+            Get-Content "$env:TEMP\dut.err" -ErrorAction SilentlyContinue | Write-Host -ForegroundColor Cyan
+            Write-Host -ForegroundColor Cyan "----------- END DAEMON LOG --------"
+        }
+    }
+
+    # Save the daemon under test log
+    if ($daemonStarted -eq 1) {
+        Write-Host -ForegroundColor Green "INFO: Saving daemon under test log ($env:TEMP\dut.err) to $TEMPORIG\CIDUT.log"
+        Copy-Item  "$env:TEMP\dut.err" "$TEMPORIG\CIDUT.log" -Force -ErrorAction SilentlyContinue
+    }
+
+    cd "$env:SOURCES_DRIVE\$env:SOURCES_SUBDIR" -ErrorAction SilentlyContinue
+    Nuke-Everything
+    $Dur=New-TimeSpan -Start $StartTime -End $(Get-Date)
+    Write-Host -ForegroundColor $FinallyColour "`nINFO: executeCI.ps1 exiting at $(date). Duration $dur`n"
+}
+

--- a/integration/build/build_session_test.go
+++ b/integration/build/build_session_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	dclient "github.com/docker/docker/client"
+	"github.com/docker/docker/internal/test/daemon"
 	"github.com/docker/docker/internal/test/fakecontext"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/moby/buildkit/session"
@@ -19,7 +20,11 @@ import (
 )
 
 func TestBuildWithSession(t *testing.T) {
-	skip.If(t, !testEnv.DaemonInfo.ExperimentalBuild)
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	d := daemon.New(t, daemon.WithExperimental)
+	d.StartWithBusybox(t)
+	defer d.Stop(t)
 
 	client := testEnv.APIClient()
 

--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/internal/test/daemon"
 	"github.com/docker/docker/internal/test/fakecontext"
 	"github.com/docker/docker/pkg/stdcopy"
 	"gotest.tools/assert"
@@ -18,7 +19,11 @@ import (
 )
 
 func TestBuildSquashParent(t *testing.T) {
-	skip.If(t, !testEnv.DaemonInfo.ExperimentalBuild)
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	d := daemon.New(t, daemon.WithExperimental)
+	d.StartWithBusybox(t)
+	defer d.Stop(t)
 
 	client := testEnv.APIClient()
 

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -22,6 +23,7 @@ import (
 )
 
 func TestBuildWithRemoveAndForceRemove(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	t.Parallel()
 	cases := []struct {
@@ -137,6 +139,7 @@ func buildContainerIdsFilter(buildOutput io.Reader) (filters.Args, error) {
 
 func TestBuildMultiStageParentConfig(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.35"), "broken in earlier versions")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	dockerfile := `
 		FROM busybox AS stage0
 		ENV WHO=parent
@@ -166,10 +169,20 @@ func TestBuildMultiStageParentConfig(t *testing.T) {
 	resp.Body.Close()
 	assert.NilError(t, err)
 
+	time.Sleep(30 * time.Second)
+
+	imgs, err := apiclient.ImageList(ctx, types.ImageListOptions{})
+	assert.NilError(t, err)
+	t.Log(imgs)
+
 	image, _, err := apiclient.ImageInspectWithRaw(ctx, "build1")
 	assert.NilError(t, err)
 
-	assert.Check(t, is.Equal("/foo/sub2", image.Config.WorkingDir))
+	expected := "/foo/sub2"
+	if testEnv.DaemonInfo.OSType == "windows" {
+		expected = `C:\foo\sub2`
+	}
+	assert.Check(t, is.Equal(expected, image.Config.WorkingDir))
 	assert.Check(t, is.Contains(image.Config.Env, "WHO=parent"))
 }
 
@@ -282,6 +295,7 @@ func TestBuildWithEmptyLayers(t *testing.T) {
 // #35652
 func TestBuildMultiStageOnBuild(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.33"), "broken in earlier versions")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	// test both metadata and layer based commands as they may be implemented differently
 	dockerfile := `FROM busybox AS stage1
@@ -289,7 +303,8 @@ ONBUILD RUN echo 'foo' >somefile
 ONBUILD ENV bar=baz
 
 FROM stage1
-RUN cat somefile # fails if ONBUILD RUN fails
+# fails if ONBUILD RUN fails
+RUN cat somefile
 
 FROM stage1
 RUN cat somefile`
@@ -327,6 +342,8 @@ RUN cat somefile`
 // #35403 #36122
 func TestBuildUncleanTarFilenames(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.37"), "broken in earlier versions")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
+
 	ctx := context.TODO()
 	defer setupTest(t)()
 
@@ -385,6 +402,7 @@ COPY bar /`
 // docker/for-linux#135
 // #35641
 func TestBuildMultiStageLayerLeak(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.37"), "broken in earlier versions")
 	ctx := context.TODO()
 	defer setupTest(t)()

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestConfigList(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
@@ -111,7 +111,7 @@ func createConfig(ctx context.Context, t *testing.T, client client.APIClient, na
 }
 
 func TestConfigsCreateAndDelete(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
@@ -139,7 +139,7 @@ func TestConfigsCreateAndDelete(t *testing.T) {
 }
 
 func TestConfigsUpdate(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
@@ -193,6 +193,7 @@ func TestConfigsUpdate(t *testing.T) {
 }
 
 func TestTemplatedConfig(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)
 	client := d.NewClientT(t)
@@ -332,7 +333,7 @@ func waitAndAssert(t *testing.T, timeout time.Duration, f func(*testing.T) bool)
 }
 
 func TestConfigInspect(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestCopyFromContainerPathDoesNotExist(t *testing.T) {
 	defer setupTest(t)()
+	skip.If(t, testEnv.OSType == "windows")
 
 	ctx := context.Background()
 	apiclient := testEnv.APIClient()

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -103,7 +103,7 @@ func TestCreateWithInvalidEnv(t *testing.T) {
 
 // Test case for #30166 (target was not validated)
 func TestCreateTmpfsMountsTarget(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)

--- a/integration/container/daemon_linux_test.go
+++ b/integration/container/daemon_linux_test.go
@@ -28,6 +28,8 @@ import (
 // container again.
 func TestContainerStartOnDaemonRestart(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot start daemon on remote test run")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	skip.If(t, testEnv.IsRemoteDaemon(), "cannot start daemon on remote test run")
 	t.Parallel()
 
 	d := daemon.New(t)

--- a/integration/container/diff_test.go
+++ b/integration/container/diff_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/docker/docker/pkg/archive"
 	"gotest.tools/assert"
 	"gotest.tools/poll"
+	"gotest.tools/skip"
 )
 
 func TestDiff(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestExec(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.35"), "broken in earlier versions")
+	skip.If(t, testEnv.OSType == "windows", "FIXME. Probably needs to wait for container to be in running state.")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := request.NewAPIClient(t)

--- a/integration/container/export_test.go
+++ b/integration/container/export_test.go
@@ -20,7 +20,7 @@ import (
 
 // export an image and try to import it into a new one
 func TestExportContainerAndImportImage(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
@@ -58,7 +58,7 @@ func TestExportContainerAndImportImage(t *testing.T) {
 // can be exported (as reported in #36561). To satisfy this
 // condition, daemon restart is needed after container creation.
 func TestExportContainerAfterDaemonRestart(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon())
 
 	d := daemon.New(t)

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -11,11 +11,13 @@ import (
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/poll"
+	"gotest.tools/skip"
 )
 
 // TestHealthCheckWorkdir verifies that health-checks inherit the containers'
 // working-dir.
 func TestHealthCheckWorkdir(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := request.NewAPIClient(t)

--- a/integration/container/inspect_test.go
+++ b/integration/container/inspect_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestInspectCpusetInConfigPre120(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux" || !testEnv.DaemonInfo.CPUSet)
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows" || !testEnv.DaemonInfo.CPUSet)
 
 	defer setupTest(t)()
 	client := request.NewAPIClient(t, client.WithVersion("1.19"))

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -31,6 +31,7 @@ func TestKillContainerInvalidSignal(t *testing.T) {
 }
 
 func TestKillContainer(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows", "TODO Windows: FIXME. No SIGWINCH")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 
@@ -70,7 +71,7 @@ func TestKillContainer(t *testing.T) {
 }
 
 func TestKillWithStopSignalAndRestartPolicies(t *testing.T) {
-	skip.If(t, testEnv.OSType != "linux", "Windows only supports 1.25 or later")
+	skip.If(t, testEnv.OSType == "windows", "Windows only supports 1.25 or later")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 
@@ -110,7 +111,7 @@ func TestKillWithStopSignalAndRestartPolicies(t *testing.T) {
 }
 
 func TestKillStoppedContainer(t *testing.T) {
-	skip.If(t, testEnv.OSType != "linux") // Windows only supports 1.25 or later
+	skip.If(t, testEnv.OSType == "windows", "Windows only supports 1.25 or later")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := request.NewAPIClient(t)
@@ -121,7 +122,7 @@ func TestKillStoppedContainer(t *testing.T) {
 }
 
 func TestKillStoppedContainerAPIPre120(t *testing.T) {
-	skip.If(t, testEnv.OSType != "linux") // Windows only supports 1.25 or later
+	skip.If(t, testEnv.OSType == "windows", "Windows only supports 1.25 or later")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := request.NewAPIClient(t, client.WithVersion("1.19"))
@@ -132,7 +133,7 @@ func TestKillStoppedContainerAPIPre120(t *testing.T) {
 
 func TestKillDifferentUserContainer(t *testing.T) {
 	// TODO Windows: Windows does not yet support -u (Feb 2016).
-	skip.If(t, testEnv.OSType != "linux", "User containers (container.Config.User) are not yet supported on %q platform", testEnv.OSType)
+	skip.If(t, testEnv.OSType == "windows", "User containers (container.Config.User) are not yet supported on %q platform", testEnv.OSType)
 
 	defer setupTest(t)()
 	ctx := context.Background()
@@ -149,7 +150,7 @@ func TestKillDifferentUserContainer(t *testing.T) {
 }
 
 func TestInspectOomKilledTrue(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux" || !testEnv.DaemonInfo.MemoryLimit || !testEnv.DaemonInfo.SwapLimit)
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows" || !testEnv.DaemonInfo.MemoryLimit || !testEnv.DaemonInfo.SwapLimit)
 
 	defer setupTest(t)()
 	ctx := context.Background()
@@ -167,7 +168,7 @@ func TestInspectOomKilledTrue(t *testing.T) {
 }
 
 func TestInspectOomKilledFalse(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux" || !testEnv.DaemonInfo.MemoryLimit || !testEnv.DaemonInfo.SwapLimit)
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows" || !testEnv.DaemonInfo.MemoryLimit || !testEnv.DaemonInfo.SwapLimit)
 
 	defer setupTest(t)()
 	ctx := context.Background()

--- a/integration/container/links_linux_test.go
+++ b/integration/container/links_linux_test.go
@@ -35,7 +35,7 @@ func TestLinksEtcHostsContentMatch(t *testing.T) {
 }
 
 func TestLinksContainerNames(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)

--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestContainerNetworkMountsNoChown(t *testing.T) {
 	// chown only applies to Linux bind mounted volumes; must be same host to verify
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux" || testEnv.IsRemoteDaemon())
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows" || testEnv.IsRemoteDaemon())
 
 	defer setupTest(t)()
 
@@ -81,7 +81,7 @@ func TestContainerNetworkMountsNoChown(t *testing.T) {
 }
 
 func TestMountDaemonRoot(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux" || testEnv.IsRemoteDaemon())
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows" || testEnv.IsRemoteDaemon())
 	t.Parallel()
 
 	client := request.NewAPIClient(t)

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -40,6 +40,7 @@ func TestNetworkNat(t *testing.T) {
 }
 
 func TestNetworkLocalhostTCPNat(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	skip.If(t, testEnv.IsRemoteDaemon())
 
 	defer setupTest(t)()
@@ -106,6 +107,7 @@ func startServerContainer(t *testing.T, msg string, port int) string {
 }
 
 func getExternalAddress(t *testing.T) net.IP {
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	iface, err := net.InterfaceByName("eth0")
 	skip.If(t, err != nil, "Test not running with `make test-integration`. Interface eth0 not found: %s", err)
 

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -65,9 +65,8 @@ func TestPauseFailsOnWindowsServerContainers(t *testing.T) {
 }
 
 func TestPauseStopPausedContainer(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.31"), "broken in earlier versions")
-
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()

--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -24,6 +24,7 @@ import (
 // This checks that "rename" updates source container correctly and doesn't set it to null.
 func TestRenameLinkedContainer(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.32"), "broken in earlier versions")
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := request.NewAPIClient(t)
@@ -123,6 +124,7 @@ func TestRenameInvalidName(t *testing.T) {
 // This test is to make sure once the container has been renamed,
 // the service discovery for the (re)named container works.
 func TestRenameAnonymousContainer(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := request.NewAPIClient(t)
@@ -190,6 +192,7 @@ func TestRenameContainerWithSameName(t *testing.T) {
 // container could still reference to the container that is renamed.
 func TestRenameContainerWithLinkedContainer(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon())
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 
 	defer setupTest(t)()
 	ctx := context.Background()

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestResize(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
@@ -35,6 +36,7 @@ func TestResize(t *testing.T) {
 
 func TestResizeWithInvalidSize(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.32"), "broken in earlier versions")
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()

--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestDaemonRestartKillContainers(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot start daemon on remote test run")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	type testCase struct {
 		desc       string
 		config     *container.Config

--- a/integration/container/update_linux_test.go
+++ b/integration/container/update_linux_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestUpdateMemory(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, !testEnv.DaemonInfo.MemoryLimit)
 	skip.If(t, !testEnv.DaemonInfo.SwapLimit)
 

--- a/integration/image/commit_test.go
+++ b/integration/image/commit_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestCommitInheritsEnv(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.36"), "broken in earlier versions")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()

--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/internal/testutil"
+	"github.com/gotestyourself/gotestyourself/skip"
 )
 
 // Ensure we don't regress on CVE-2017-14992.
 func TestImportExtremelyLargeImageWorks(t *testing.T) {
-	if runtime.GOARCH == "arm64" {
-		t.Skip("effective test will be time out")
-	}
+	skip.If(t, runtime.GOARCH == "arm64", "effective test will be time out")
+	skip.If(t, testEnv.OSType == "windows", "TODO enable on windows")
 
 	client := request.NewAPIClient(t)
 

--- a/integration/image/remove_test.go
+++ b/integration/image/remove_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
+	"gotest.tools/skip"
 )
 
 func TestRemoveImageOrphaning(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := request.NewAPIClient(t)

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -51,6 +51,7 @@ func ContainerPoll(config *poll.Settings) {
 func NewSwarm(t *testing.T, testEnv *environment.Execution, ops ...func(*daemon.Daemon)) *daemon.Daemon {
 	t.Helper()
 	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	if testEnv.DaemonInfo.ExperimentalBuild {
 		ops = append(ops, daemon.WithExperimental)
 	}

--- a/integration/network/delete_test.go
+++ b/integration/network/delete_test.go
@@ -67,6 +67,8 @@ func TestNetworkCreateDelete(t *testing.T) {
 // ID is removed, and not the network with the given name.
 func TestDockerNetworkDeletePreferID(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.34"), "broken in earlier versions")
+	skip.If(t, testEnv.OSType == "windows",
+		"FIXME. Windows doesn't run DinD and uses networks shared between control daemon and daemon under test")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()

--- a/integration/network/helpers.go
+++ b/integration/network/helpers.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package network
 
 import (

--- a/integration/network/inspect_test.go
+++ b/integration/network/inspect_test.go
@@ -13,11 +13,13 @@ import (
 	"github.com/docker/docker/integration/internal/swarm"
 	"gotest.tools/assert"
 	"gotest.tools/poll"
+	"gotest.tools/skip"
 )
 
 const defaultSwarmPort = 2477
 
 func TestInspectNetwork(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)

--- a/integration/network/ipvlan/ipvlan_test.go
+++ b/integration/network/ipvlan/ipvlan_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package ipvlan
 
 import (
@@ -17,7 +19,7 @@ import (
 
 func TestDockerNetworkIpvlanPersistance(t *testing.T) {
 	// verify the driver automatically provisions the 802.1q link (di-dummy0.70)
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon())
 	skip.If(t, !ipvlanKernelSupport(), "Kernel doesn't support ipvlan")
 
@@ -46,7 +48,7 @@ func TestDockerNetworkIpvlanPersistance(t *testing.T) {
 }
 
 func TestDockerNetworkIpvlan(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon())
 	skip.If(t, !ipvlanKernelSupport(), "Kernel doesn't support ipvlan")
 

--- a/integration/network/macvlan/macvlan_test.go
+++ b/integration/network/macvlan/macvlan_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package macvlan
 
 import (
@@ -17,7 +19,7 @@ import (
 
 func TestDockerNetworkMacvlanPersistance(t *testing.T) {
 	// verify the driver automatically provisions the 802.1q link (dm-dummy0.60)
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon())
 	skip.If(t, !macvlanKernelSupport(), "Kernel doesn't support macvlan")
 
@@ -42,7 +44,7 @@ func TestDockerNetworkMacvlanPersistance(t *testing.T) {
 }
 
 func TestDockerNetworkMacvlan(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon())
 	skip.If(t, !macvlanKernelSupport(), "Kernel doesn't support macvlan")
 

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -188,6 +188,7 @@ func TestDaemonWithBipAndDefaultNetworkPool(t *testing.T) {
 }
 
 func TestServiceWithPredefinedNetwork(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows")
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)
@@ -216,6 +217,7 @@ func TestServiceWithPredefinedNetwork(t *testing.T) {
 const ingressNet = "ingress"
 
 func TestServiceRemoveKeepsIngressNetwork(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows")
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -212,6 +212,7 @@ func TestAuthZPluginDenyResponse(t *testing.T) {
 // correctly after request pass through by the authorization plugin
 func TestAuthZPluginAllowEventStream(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTestV1(t)()
 	ctrl.reqRes.Allow = true

--- a/integration/plugin/authz/authz_plugin_v2_test.go
+++ b/integration/plugin/authz/authz_plugin_v2_test.go
@@ -29,7 +29,7 @@ var (
 )
 
 func setupTestV2(t *testing.T) func() {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, !requirement.HasHubConnectivity(t))
 
 	teardown := setupTest(t)

--- a/integration/plugin/authz/main_test.go
+++ b/integration/plugin/authz/main_test.go
@@ -48,6 +48,7 @@ func TestMain(m *testing.M) {
 
 func setupTest(t *testing.T) func() {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	environment.ProtectAll(t, testEnv)
 
 	d = daemon.New(t, daemon.WithExperimental)

--- a/integration/plugin/authz/main_windows_test.go
+++ b/integration/plugin/authz/main_windows_test.go
@@ -1,0 +1,1 @@
+package authz // import "github.com/docker/docker/integration/plugin/authz"

--- a/integration/plugin/logging/validation_test.go
+++ b/integration/plugin/logging/validation_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package logging
 
 import (
@@ -15,6 +17,7 @@ import (
 // does not keep the daemon from starting.
 func TestDaemonStartWithLogOpt(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	t.Parallel()
 
 	d := daemon.New(t)

--- a/integration/plugin/volumes/mounts_test.go
+++ b/integration/plugin/volumes/mounts_test.go
@@ -17,6 +17,7 @@ import (
 // (sorted in the daemon). See #36698
 func TestPluginWithDevMounts(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	t.Parallel()
 
 	d := daemon.New(t)

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestSecretInspect(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
@@ -42,7 +42,7 @@ func TestSecretInspect(t *testing.T) {
 }
 
 func TestSecretList(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
@@ -128,7 +128,7 @@ func createSecret(ctx context.Context, t *testing.T, client client.APIClient, na
 }
 
 func TestSecretsCreateAndDelete(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
@@ -175,7 +175,7 @@ func TestSecretsCreateAndDelete(t *testing.T) {
 }
 
 func TestSecretsUpdate(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
@@ -226,6 +226,7 @@ func TestSecretsUpdate(t *testing.T) {
 }
 
 func TestTemplatedSecret(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)
 	client := d.NewClientT(t)

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -17,6 +17,7 @@ import (
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/poll"
+	"gotest.tools/skip"
 )
 
 func TestServiceCreateInit(t *testing.T) {
@@ -72,6 +73,7 @@ func inspectServiceContainer(t *testing.T, client client.APIClient, serviceID st
 }
 
 func TestCreateServiceMultipleTimes(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)
@@ -121,6 +123,7 @@ func TestCreateServiceMultipleTimes(t *testing.T) {
 }
 
 func TestCreateWithDuplicateNetworkNames(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)
@@ -180,6 +183,7 @@ func TestCreateWithDuplicateNetworkNames(t *testing.T) {
 }
 
 func TestCreateServiceSecretFileMode(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)
@@ -245,6 +249,7 @@ func TestCreateServiceSecretFileMode(t *testing.T) {
 }
 
 func TestCreateServiceConfigFileMode(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)

--- a/integration/service/inspect_test.go
+++ b/integration/service/inspect_test.go
@@ -20,6 +20,7 @@ import (
 
 func TestInspect(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon())
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)

--- a/integration/service/network_test.go
+++ b/integration/service/network_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/docker/docker/integration/internal/swarm"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
+	"gotest.tools/skip"
 )
 
 func TestDockerNetworkConnectAlias(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)

--- a/integration/session/session_test.go
+++ b/integration/session/session_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestSessionCreate(t *testing.T) {
 	skip.If(t, !testEnv.DaemonInfo.ExperimentalBuild)
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 
 	defer setupTest(t)()
 
@@ -28,6 +29,7 @@ func TestSessionCreate(t *testing.T) {
 
 func TestSessionCreateWithBadUpgrade(t *testing.T) {
 	skip.If(t, !testEnv.DaemonInfo.ExperimentalBuild)
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 
 	res, body, err := req.Post("/session")
 	assert.NilError(t, err)

--- a/integration/system/cgroupdriver_systemd_test.go
+++ b/integration/system/cgroupdriver_systemd_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/internal/test/daemon"
 
 	"gotest.tools/assert"
+	"gotest.tools/skip"
 )
 
 // hasSystemd checks whether the host was booted with systemd as its init
@@ -27,6 +28,7 @@ func hasSystemd() bool {
 // memory limit can be set when using systemd cgroupdriver.
 //  https://github.com/moby/moby/issues/35123
 func TestCgroupDriverSystemdMemoryLimit(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	t.Parallel()
 
 	if !hasSystemd() {

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -25,6 +25,7 @@ import (
 
 func TestEventsExecDie(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.36"), "broken in earlier versions")
+	skip.If(t, testEnv.OSType == "windows", "FIXME. Suspect may need to wait until container is running before exec")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := request.NewAPIClient(t)
@@ -74,6 +75,7 @@ func TestEventsExecDie(t *testing.T) {
 // backward compatibility so old `JSONMessage` could still be used.
 // This test verifies that backward compatibility maintains.
 func TestEventsBackwardsCompatible(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows", "Windows doesn't support back-compat messages")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := request.NewAPIClient(t)

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -20,6 +20,7 @@ import (
 
 func TestVolumesCreateAndList(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
@@ -49,6 +50,7 @@ func TestVolumesCreateAndList(t *testing.T) {
 }
 
 func TestVolumesRemove(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
@@ -75,6 +77,7 @@ func TestVolumesRemove(t *testing.T) {
 
 func TestVolumesInspect(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()


### PR DESCRIPTION
Taking over @jhowardmsft's work on enabling the `integration` tests on windows CI (see https://github.com/moby/moby/issues/36748)

This is also a follow up of https://github.com/moby/moby/pull/35362 — initial description below.

<del>Currently in progress, with a custom job in jenkins.</del>

---

This change is a requirement for #34226.

This change also brings the windowsRS1 build in line with all the other builds, which have an entry point at `hack/ci`. The [windowsRS1 config](https://jenkins.dockerproject.org/job/Docker-PRs-WoW-RS1/configure) has been updated to call this script.

This change is important because currently the configuration in jenkins makes too many assumptions about the repo and artifacts created by the build. We need a minimal interface between our CI configuration and the repo, so that we are free to make changes in a PR without requiring complicated acrobatics to support those changes in CI.

Signed-off-by: John Howard <jhoward@microsoft.com>