### PR TITLE
bump defaultReconciliationTimeout to 60 sec

### DIFF
--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-var defaultReconciliationTimeout = 30 * time.Second
+var defaultReconciliationTimeout = 60 * time.Second
 
 func (s *DockerSwarmSuite) TestAPISwarmInit(c *check.C) {
 	// todo: should find a better way to verify that components are running than /info


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

bump `defaultReconciliationTimeout` from 30 sec to 60 sec

To accommodate for [increase in leader election from 3 seconds to 10
seconds](https://github.com/moby/moby/pull/36701). This will give more cycles to find another leader.

**- How I did it**

in the tests

**- How to verify it**

run `DockerSwarmSuite.TestAPISwarmLeaderElection` test

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A


**- A picture of a cute animal (not mandatory but encouraged)**
🐋 
