### PR TITLE
wip: jenkinsfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,12 +160,13 @@ shell: build ## start a shell inside the build env
 	$(DOCKER_RUN_DOCKER) bash
 
 test: build test-unit ## run the unit, integration and docker-py tests
-	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary cross test-integration test-docker-py
+	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary cross test-integration test-integration-cli test-docker-py
 
 test-docker-py: build ## run the docker-py tests
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary test-docker-py
 
-test-integration-cli: test-integration ## (DEPRECATED) use test-integration
+test-integration-cli: ## (DEPRECATED) use test-integration
+	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary test-integration-cli
 
 test-integration: build ## run the integration tests
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary test-integration

--- a/Makefile.jenkins
+++ b/Makefile.jenkins
@@ -1,0 +1,99 @@
+EXTRA_FLAGS?=
+DOCKERFILE?=Dockerfile
+DOCKER_IMAGE?=docker-dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
+CODECOV_TOKEN?=02f32798-f710-46b7-b6b6-fe0bbc2b6f57
+GITCOMMIT?=$(shell git rev-parse --short HEAD)
+BUILD_IMAGE?=0
+RUN:=docker run --rm -t --privileged \
+	-v "$(CURDIR)/bundles":/go/src/github.com/docker/docker/bundles \
+	-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
+	-e DOCKER_GRAPHDRIVER=vfs \
+	-e DOCKER_EXECDRIVER=native \
+
+clean:
+	-docker rm -vf docker-pr$(BUILD_NUMBER)
+	-docker rmi -f docker:$(GITCOMMIT)
+	docker run --rm -v "$(CURDIR)":/v busybox chown -R "$$(id -u):$$(id -g)" /v
+
+%-bundles.tar.gz:
+	-find bundles -name '*.log' | xargs tar -czf $@
+
+.PHONY: test-integration-cli
+test-integration-cli: hack/make/test-integration-cli
+	if test "$(BUILD_IMAGE)" = "1"; then \
+		docker build -t $(DOCKER_IMAGE) -f $(DOCKERFILE) .; \
+	fi; \
+	$(RUN) \
+		$(EXTRA_FLAGS) \
+		-e GIT_SHA1="$$(git rev-parse HEAD)" \
+		-v "$(CURDIR)/.git":/go/src/github.com/docker/docker/.git \
+		--name docker-pr$(BUILD_NUMBER) \
+		-e TESTFLAGS='-check.f $(TEST_SUITE).*' \
+		$(DOCKER_IMAGE) \
+		./hack/make.sh dynbinary test-integration-cli
+
+.PHONY: test-integration
+test-integration: hack/make/test-integration
+	if test "$(BUILD_IMAGE)" = "1"; then \
+		docker build -t $(DOCKER_IMAGE) -f $(DOCKERFILE) .; \
+	fi; \
+	$(RUN) \
+		$(EXTRA_FLAGS) \
+		-e GIT_SHA1="$$(git rev-parse HEAD)" \
+		-v "$(CURDIR)/.git":/go/src/github.com/docker/docker/.git \
+		--name docker-pr$(BUILD_NUMBER) \
+		$(DOCKER_IMAGE) \
+		./hack/make.sh dynbinary test-integration
+
+.PHONY: test-unit
+test-unit: hack/test/unit
+	@export CODECOV_TOKEN="$(CODECOV_TOKEN)"
+	if test "$(BUILD_IMAGE)" = "1"; then \
+		docker build -t $(DOCKER_IMAGE) -f $(DOCKERFILE) .; \
+	fi; \
+	$(RUN) \
+		$(EXTRA_FLAGS) \
+		-e GIT_SHA1="$$(git rev-parse HEAD)" \
+		-v "$(CURDIR)/.git":/go/src/github.com/docker/docker/.git \
+		--name docker-pr$(BUILD_NUMBER) \
+		$(DOCKER_IMAGE) \
+		$<
+
+.PHONY: dynbinary
+dynbinary: hack/make/dynbinary
+	if test "$(BUILD_IMAGE)" = "1"; then \
+		docker build -t $(DOCKER_IMAGE) -f $(DOCKERFILE) .; \
+	fi; \
+	$(RUN) \
+		$(EXTRA_FLAGS) \
+		-e GIT_SHA1="$$(git rev-parse HEAD)" \
+		-v "$(CURDIR)/.git":/go/src/github.com/docker/docker/.git \
+		--name docker-pr$(BUILD_NUMBER) \
+		$(DOCKER_IMAGE) \
+		./hack/make.sh dynbinary
+
+.PHONY: binary
+binary: hack/make/binary
+	if test "$(BUILD_IMAGE)" = "1"; then \
+		docker build -t $(DOCKER_IMAGE) -f $(DOCKERFILE) .; \
+	fi; \
+	$(RUN) \
+		$(EXTRA_FLAGS) \
+		-e GIT_SHA1="$$(git rev-parse HEAD)" \
+		-v "$(CURDIR)/.git":/go/src/github.com/docker/docker/.git \
+		--name docker-pr$(BUILD_NUMBER) \
+		$(DOCKER_IMAGE) \
+		./hack/make.sh binary
+
+.PHONY: validate
+validate: hack/validate/all
+	if test "$(BUILD_IMAGE)" = "1"; then \
+		docker build -t $(DOCKER_IMAGE) -f $(DOCKERFILE) .; \
+	fi; \
+	$(RUN) \
+		$(EXTRA_FLAGS) \
+		-e GIT_SHA1="$$(git rev-parse HEAD)" \
+		-v "$(CURDIR)/.git":/go/src/github.com/docker/docker/.git \
+		--name docker-pr$(BUILD_NUMBER) \
+		$(DOCKER_IMAGE) \
+		$<

--- a/hack/ci/janky
+++ b/hack/ci/janky
@@ -3,12 +3,6 @@
 set -eu -o pipefail
 
 hack/validate/default
-hack/test/unit
-bash <(curl -s https://codecov.io/bash) \
-    -f coverage.txt \
-    -C $GIT_SHA1 || \
-    echo 'Codecov failed to upload'
-
 hack/make.sh \
 	binary-daemon \
 	dynbinary \

--- a/hack/jenkinsfile/common.jenkinsfile
+++ b/hack/jenkinsfile/common.jenkinsfile
@@ -1,0 +1,152 @@
+IMAGE="vdemeester/docker-dev"
+MAKE="make -f Makefile.jenkins"
+
+hubCred = [
+    $class: 'UsernamePasswordMultiBinding',
+    usernameVariable: 'DOCKER_HUB_USERNAME',
+    passwordVariable: 'DOCKER_HUB_PASSWORD',
+    credentialsId: 'vdemeester-docker-hub',
+]
+
+
+def withStatus(String context, Closure cl) {
+    def setGithubStatus = { String state ->
+	try {
+	    def backref = "${BUILD_URL}flowGraphTable/"
+	    def reposSourceURL = scm.repositories[0].getURIs()[0].toString()
+	    step(
+		$class: 'GitHubCommitStatusSetter',
+		contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
+		errorHandlers: [[$class: 'ShallowAnyErrorHandler']],
+		reposSource: [$class: 'ManuallyEnteredRepositorySource', url: reposSourceURL],
+		statusBackrefSource: [$class: 'ManuallyEnteredBackrefSource', backref: backref],
+		statusResultSource: [$class: 'ConditionalStatusResultSource', results: [[$class: 'AnyBuildResult', state: state]]],
+	    )
+	} catch (err) {
+	    echo "Exception from GitHubCommitStatusSetter for $context: $err"
+	}
+    }
+
+    setGithubStatus 'PENDING'
+    try {
+	cl()
+    } catch (err) {
+	// AbortException signals a "normal" build failure.
+	if (!(err instanceof hudson.AbortException)) {
+	    echo "Exception in withGithubStatus for $context: $err"
+	}
+	setGithubStatus 'FAILURE'
+	throw err
+    }
+    setGithubStatus 'SUCCESS'
+}
+
+def getImage(String platform) {
+    return "${IMAGE}:\$(git rev-parse --short HEAD)-${platform}"
+}
+
+def getTestSuites() {
+    return [
+	'DockerSuite',
+	'DockerSwarmSuite',
+	'DockerAuthzSuite',
+	'DockerAuthzV2Suite',
+	'DockerDaemonSuite',
+	'DockerExternalGraphdriverSuite',
+	'DockerExternalVolumeSuite',
+	'DockerHubPullSuite',
+	'DockerNetworkSuite',
+	'DockerRegistrySuite',
+	'DockerRegistryAuthHtpasswdSuite',
+	'DockerRegistryAuthTokenSuite',
+	'DockerSchema1RegistrySuite',
+    ]
+}
+
+def buildImage(String platform, String label) {
+    def image = getImage(platform)
+    return stage("${platform}.image-build") {
+	wrappedNode(label: label, cleanWorkspace: true) {
+	    // withGithubStatus("${platform}.image-build") {
+	    withCredentials([hubCred]) {
+		checkout scm
+		sh '''
+docker login \
+  --username="$DOCKER_HUB_USERNAME" \
+  --password="$DOCKER_HUB_PASSWORD"
+'''
+		sh("make DOCKER_IMAGE=${image} build")
+		sh("docker push ${image}")
+	    }
+	    // }
+	}
+    }
+}
+
+def validateStep(String platform, String label) {
+    def image = getImage(platform)
+    return stage("validate") {
+	wrappedNode(label: label, cleanWorkspace: true) {
+	    // withGithubStatus("binary") {
+	    checkout scm
+	    sh("${MAKE} DOCKER_IMAGE=${image} validate")
+	    // }
+	}
+    }
+}
+
+def binaryStep(String platform, String label) {
+    def image = getImage(platform)
+    return stage("${platform}.binary") {
+	wrappedNode(label: label, cleanWorkspace: true) {
+	    // withGithubStatus("binary") {
+	    checkout scm
+	    sh("${MAKE} DOCKER_IMAGE=${image} binary")
+	    // }
+	}
+    }
+}
+
+def testIntegrationStep(String platform, String label) {
+    def image = getImage(platform)
+    return stage("${platform}.test-integration") {
+	wrappedNode(label: label, cleanWorkspace: true) {
+	    // withGithubStatus("${platform}.test-integration") {
+	    checkout scm
+	    sh("${MAKE} DOCKER_IMAGE=${image} test-integration")
+	    // }
+	}
+    }
+}
+
+def testUnitStep(String platform, String label) {
+    def image = getImage(platform)
+    return stage("${platform}.test-unit") {
+	wrappedNode(label: label, cleanWorkspace: true) {
+	    // withGithubStatus("${platform}.test-unit") {
+	    checkout scm
+	    sh("${MAKE} DOCKER_IMAGE=${image} test-unit")
+	    // }
+	}
+    }
+}
+
+def genTestIntegrationCliStep(String suite, String platform, String label) {
+    def image = getImage(platform)
+    return [ "${suite}" : { ->
+	    stage("${platform}.${suite}") {
+		wrappedNode(label: label, cleanWorkspace: true) {
+		    withChownWorkspace {
+			// withGithubStatus("${platform}.${suite}") {
+			checkout scm
+			timeout(60) {
+			    sh("${MAKE} DOCKER_IMAGE=${image} TEST_SUITE=${suite} test-integration-cli")
+			}
+			// }
+		    }
+		}
+	    }
+	} ]
+}
+
+return this;

--- a/hack/jenkinsfile/janky-integration.Jenkinsfile
+++ b/hack/jenkinsfile/janky-integration.Jenkinsfile
@@ -1,0 +1,21 @@
+#!/usr/bin/env groovy
+node {
+    checkout scm
+    def common = load("hack/jenkinsfile/common.jenkinsfile")
+    
+    def test_steps = [
+	'janky.integration': { ->
+	    common.testIntegrationStep('janky', 'ubuntu-1604-aufs-edge')
+	}, 'janky.test-unit': { ->
+	    common.testUnitStep('janky', 'ubuntu-1604-aufs-edge')
+	}
+    ]
+
+    for (s in common.getTestSuites()) {
+	test_steps << common.genTestIntegrationCliStep(s, 'janky', 'ubuntu-1604-aufs-edge')
+    }
+
+    stage("integration") {
+	parallel(test_steps)
+    }
+}

--- a/hack/jenkinsfile/janky.Jenkinsfile
+++ b/hack/jenkinsfile/janky.Jenkinsfile
@@ -1,0 +1,37 @@
+#!/usr/bin/env groovy
+node {
+    checkout scm
+    def common = load("hack/jenkinsfile/common.jenkinsfile")
+    
+    stage("images-build") {
+	parallel 'janky':{ ->
+	    common.buildImage('janky', 'ubuntu-1604-aufs-edge')
+	}, 'powerpc': { ->
+	    common.buildImage("powerpc", 'ppc64le-ubuntu-1604')
+	}, 'z': { ->
+	    common.buildImage("z", 's390x-ubuntu-1604')
+	}
+    }
+
+    stage("janky") {
+	parallel 'validate':{ ->
+	    common.validateStep('janky', 'ubuntu-1604-aufs-edge')
+	}, 'janky.binary': { ->
+	    common.binaryStep('janky', 'ubuntu-1604-aufs-edge')
+	}, 'z.binary': { ->
+	    common.binaryStep('z', 's390x-ubuntu-1604')
+	}, 'powerpc.binary': { ->
+	    common.binaryStep('powerpc', 'ppc64le-ubuntu-1604')
+	}
+    }
+
+    stage("integration-triggers") {
+	parallel 'janky-integration':{ ->
+	    build job: 'vdemeester/moby-janky-integration' // FIXME(vdemeester) handle parameters
+	}, 'powerpc-integration':{ ->
+            build job: 'vdemeester/moby-powerpc-integration' // FIXME(vdemeester) handle parameters
+	}, 'z-integration':{ ->
+	    build job: 'vdemeester/moby-z-integration' // FIXME(vdemeester) handle parameters
+	}
+    }
+}

--- a/hack/jenkinsfile/powerpc.Jenkinsfile
+++ b/hack/jenkinsfile/powerpc.Jenkinsfile
@@ -1,0 +1,21 @@
+#!/usr/bin/env groovy
+node {
+    checkout scm
+    def common = load("hack/jenkinsfile/common.jenkinsfile")
+    
+    def test_steps = [
+	'powerpc.integration': { ->
+	    common.testIntegrationStep('powerpc', 'ppc64le-ubuntu-1604')
+	}, 'powerpc.test-unit': { ->
+	    common.testUnitStep('powerpc', 'ppc64le-ubuntu-1604')
+	}
+    ]
+
+    for (s in common.getTestSuites()) {
+	test_steps << common.genTestIntegrationCliStep(s, 'powerpc', 'ppc64le-ubuntu-1604')
+    }
+
+    stage("integration") {
+	parallel(test_steps)
+    }
+}

--- a/hack/jenkinsfile/z.Jenkinsfile
+++ b/hack/jenkinsfile/z.Jenkinsfile
@@ -1,0 +1,21 @@
+#!/usr/bin/env groovy
+node {
+    checkout scm
+    def common = load("hack/jenkinsfile/common.jenkinsfile")
+    
+    def test_steps = [
+	'z.integration': { ->
+	    common.testIntegrationStep('z', 's390x-ubuntu-1604')
+	}, 'z.test-unit': { ->
+	    common.testUnitStep('z', 's390x-ubuntu-1604')
+	}
+    ]
+
+    for (s in common.getTestSuites()) {
+	test_steps << common.genTestIntegrationCliStep(s, 'z', 's390x-ubuntu-1604')
+    }
+
+    stage("integration") {
+	parallel(test_steps)
+    }
+}

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -60,6 +60,7 @@ DEFAULT_BUNDLES=(
 	dynbinary
 
 	test-integration
+	test-integration-cli
 	test-docker-py
 
 	cross

--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -49,10 +49,17 @@ build_test_suite_binaries() {
 		echo "Skipping building test binaries; as DOCKER_INTEGRATION_TESTS_VERIFIED is set"
 		return
 	fi
-	build_test_suite_binary ./integration-cli "test.main"
 	for dir in $integration_api_dirs; do
 		build_test_suite_binary "$dir" "test.main"
 	done
+}
+
+build_legacy_test_suite_binaries() {
+	if [ ${DOCKER_INTEGRATION_TESTS_VERIFIED-} ]; then
+		echo "Skipping building test binaries; as DOCKER_INTEGRATION_TESTS_VERIFIED is set"
+		return
+	fi
+	build_test_suite_binary ./integration-cli "test.main"
 }
 
 # Build a binary for a test suite package

--- a/hack/make/test-integration
+++ b/hack/make/test-integration
@@ -9,7 +9,7 @@ source hack/make/.integration-test-helpers
 	bundle .integration-daemon-setup
 
 	local testexit=0
-	( repeat run_test_integration ) || testexit=$?
+	( repeat run_test_integration_suites ) || testexit=$?
 
 	# Always run cleanup, even if the subshell fails
 	bundle .integration-daemon-stop
@@ -18,4 +18,4 @@ source hack/make/.integration-test-helpers
 
 	exit $testexit
 
-) 2>&1 | tee -a "$DEST/test.log"
+) 2>&1 | tee -a "$DEST/test-integration.log"

--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -3,4 +3,21 @@ set -e
 echo "WARNING: test-integration-cli is DEPRECATED. Use test-integration." >&2
 
 # TODO: remove this and exit 1 once CI has changed to use test-integration
-bundle test-integration
+source hack/make/.integration-test-helpers
+
+(
+	build_legacy_test_suite_binaries
+	bundle .integration-daemon-start
+	bundle .integration-daemon-setup
+
+	local testexit=0
+	( repeat run_test_integration_legacy_suites ) || testexit=$?
+
+	# Always run cleanup, even if the subshell fails
+	bundle .integration-daemon-stop
+	cleanup_test_suite_binaries
+	error_on_leaked_containerd_shims
+
+	exit $testexit
+
+) 2>&1 | tee -a "$DEST/test-integration-cli.log"


### PR DESCRIPTION
Linked to https://github.com/moby/moby/issues/36416, this PR create some jenkinsfile to re-define the CI directly inside the repository. This would allow to update the CI safely (in PRs) and to have everything required to setup the CI directly in the repository, historized.

Overall, the whole build takes around 1h or less (which is already a good achievement :stuck_out_tongue:, it's ~1h50 as of now).

What does this do :

- Define several `jenkinsfile` (for several pipeline`) :
  - `janky` is **the main pipeline** that will trigger the other ones. It builds the images (for each target, i.e. amd64, ppc, z, …), builds the binary and validate. *And then, it triggers the other builds*. It **fails fast**, i.e. if the code doesn't pass validation or does compile, it won't run anything else.
  - `janky.integration`, `powerpc` and `z`, are all based on the same model, just targeting different architecture. The run tests in parallel ; right now : test-unit, test-integration, and each listed test-integration-cli. *This means the build takes more or less the time the longest suite (which is currently `DockerSuite`, around 40min)*.
- It build and push (on the hub) the dev-images so they can be reused on other nodes.
- Will add way more check status than now : i.e. for almost all stages, we will have a check status. As an example, this means, just by looking at the github status, we will be able to know which Suites failed. Ideally we should be able to re-run only this suite, but this will come later on.
- It "re-split" `test-integration` and `test-integration-cli`… @dnephin this part could be reworked to not revert that, it was just easier to test at first :angel:
- This will *replace* the `hack/ci/…` script in the end.

What still to do (waiting for feedback a bit before doing those) :
- [ ] Parametrize the builds so it can be hooked to the repository and the bots (that allows us to rebuild some targs with the `rebuild/*` label or `!rebuild moby#…` on slack)
- [ ] Add windows to this (see https://github.com/moby/moby/pull/36775)
- [ ] Hook the builds and uncomment the `withGithubStatus` part to get status
- [ ] Use a *jenkins local* registry for the image instead of the hub to speed the process up (and not load the hub for the CI)
- [ ] Deprecate/remove older build job :angel:
- [ ] Share those recipes with `docker-ce`, etc.. if it's something we want to do :angel:

This is a big change in term of infra/ci, so.. putting it under `design-review`. An example of this running (and where I'm experimenting with) is [here](https://jenkins.dockerproject.org/job/vdemeester/)

cc @seemethere @andrewhsu 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
