### PR TITLE
refactored network integration tests to make use of swarm.CreateService

### DIFF
--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -136,6 +136,21 @@ func ServiceWithName(name string) ServiceSpecOpt {
 	}
 }
 
+// ServiceWithNetwork sets the network of the service
+func ServiceWithNetwork(network string) ServiceSpecOpt {
+	return func(spec *swarmtypes.ServiceSpec) {
+		spec.TaskTemplate.Networks = append(spec.TaskTemplate.Networks,
+			swarmtypes.NetworkAttachmentConfig{Target: network})
+	}
+}
+
+// ServiceWithEndpoint sets the Endpoint of the service
+func ServiceWithEndpoint(endpoint *swarmtypes.EndpointSpec) ServiceSpecOpt {
+	return func(spec *swarmtypes.ServiceSpec) {
+		spec.EndpointSpec = endpoint
+	}
+}
+
 // GetRunningTasks gets the list of running tasks for a service
 func GetRunningTasks(t *testing.T, d *daemon.Daemon, serviceID string) []swarmtypes.Task {
 	t.Helper()


### PR DESCRIPTION
Refactored the network integration tests to make use of `swarm.CreateService` utility function, to address the `//FIXME` item under `integration/network/inspect_test.go`

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**- What I did**
Refactored the network integration tests to make use of `swarm.CreateService` utility function.

**- How I did it**
Refactored tests under `integration/network`, and added the required functions under `integration/internal/swarm/service.go`

**- How to verify it**

**- Description for the changelog**
Network integration tests use swarm.CreateService for testing.

**- A picture of a cute animal (not mandatory but encouraged)**

