### PR TITLE
Dockerbuilder: use the arch info from base image

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -96,6 +96,15 @@ func (img *Image) RunConfig() *container.Config {
 	return img.Config
 }
 
+// BaseImgArch returns the image's architecture. If not populated, defaults to the host runtime arch.
+func (img *Image) BaseImgArch() string {
+	arch := img.Architecture
+	if arch == "" {
+		arch = runtime.GOARCH
+	}
+	return arch
+}
+
 // OperatingSystem returns the image's operating system. If not populated, defaults to the host runtime OS.
 func (img *Image) OperatingSystem() string {
 	os := img.OS
@@ -157,7 +166,7 @@ func NewChildImage(img *Image, child ChildConfig, platform string) *Image {
 		V1Image: V1Image{
 			DockerVersion:   dockerversion.Version,
 			Config:          child.Config,
-			Architecture:    runtime.GOARCH,
+			Architecture:    img.BaseImgArch(),
 			OS:              platform,
 			Container:       child.ContainerID,
 			ContainerConfig: *child.ContainerConfig,


### PR DESCRIPTION
Currently we hardcode the architecture to the `runtime.GOARCH` when building
a docker image, this will result in a confusing info if the arch in the base image is 
different from the one on the host.

This PR takes use of the arch data from the base image during the build process, thus
we can get consistent arch info between the base image and the finally built image.

This PR is trying to resolve one of the defects mentioned in issue #36552.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Make the final generated image has consistent arch info with the base image.
**- How I did it**
Take use of the arch data from the base image.
**- How to verify it**
Using below `Dockerfile` as test:
```
FROM arm32v6/alpine:3.7
CMD ["sh", "-c" , "uname -a"]
```
Then `docker build --no-cache -t test .`
With this PR, we get below output with `docker inspect` on AArch64:
```
...
"Architecture": "arm64",
"Os": "linux",
...
```
After this PR applied, `docker inspect` shows:
```
...
"Architecture": "arm",
"Os": "linux",
...
```
`docker inspect arm32v6/alpine:3.7` shows:
```
...
"Architecture": "arm",
"Os": "linux",
...
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

