### PR TITLE
apparmor: allow receiving of signals from 'docker kill'

### DIFF
--- a/profiles/apparmor/template.go
+++ b/profiles/apparmor/template.go
@@ -17,6 +17,10 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   capability,
   file,
   umount,
+{{if ge .Version 208096}}
+{{/* Allow 'docker kill' to actually send signals to container processes. */}}
+  signal (receive) peer=unconfined,
+{{end}}
 
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**


### PR DESCRIPTION
In newer kernels, AppArmor will reject attempts to send signals to a
container because the signal originated from outside of that AppArmor
profile. Correct this by allowing all unconfined signals to be received.


Fixes #36809

Signed-off-by: Aleksa Sarai <asarai@suse.de>