### PR TITLE
Bump libnetwork to fix panic on concurrent read/write to a map

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=5c1218c956c99f3365711974e300087810c31379
+LIBNETWORK_COMMIT=c15b372ef22125880d378167dde44f4b134e1a77
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -32,7 +32,7 @@ github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 #get libnetwork packages
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
-github.com/docker/libnetwork 5c1218c956c99f3365711974e300087810c31379
+github.com/docker/libnetwork c15b372ef22125880d378167dde44f4b134e1a77
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/drivers/overlay/ostweaks_linux.go
+++ b/vendor/github.com/docker/libnetwork/drivers/overlay/ostweaks_linux.go
@@ -3,15 +3,36 @@ package overlay
 import (
 	"io/ioutil"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 )
 
-var sysctlConf = map[string]string{
-	"net.ipv4.neigh.default.gc_thresh1": "8192",
-	"net.ipv4.neigh.default.gc_thresh2": "49152",
-	"net.ipv4.neigh.default.gc_thresh3": "65536",
+type conditionalCheck func(val1, val2 string) bool
+
+type osValue struct {
+	value   string
+	checkFn conditionalCheck
+}
+
+var osConfig = map[string]osValue{
+	"net.ipv4.neigh.default.gc_thresh1": {"8192", checkHigher},
+	"net.ipv4.neigh.default.gc_thresh2": {"49152", checkHigher},
+	"net.ipv4.neigh.default.gc_thresh3": {"65536", checkHigher},
+}
+
+func propertyIsValid(val1, val2 string, check conditionalCheck) bool {
+	if check == nil || check(val1, val2) {
+		return true
+	}
+	return false
+}
+
+func checkHigher(val1, val2 string) bool {
+	val1Int, _ := strconv.ParseInt(val1, 10, 32)
+	val2Int, _ := strconv.ParseInt(val2, 10, 32)
+	return val1Int < val2Int
 }
 
 // writeSystemProperty writes the value to a path under /proc/sys as determined from the key.
@@ -21,10 +42,31 @@ func writeSystemProperty(key, value string) error {
 	return ioutil.WriteFile(path.Join("/proc/sys", keyPath), []byte(value), 0644)
 }
 
+func readSystemProperty(key string) (string, error) {
+	keyPath := strings.Replace(key, ".", "/", -1)
+	value, err := ioutil.ReadFile(path.Join("/proc/sys", keyPath))
+	if err != nil {
+		return "", err
+	}
+	return string(value), nil
+}
+
 func applyOStweaks() {
-	for k, v := range sysctlConf {
-		if err := writeSystemProperty(k, v); err != nil {
-			logrus.Errorf("error setting the kernel parameter %s = %s, err: %s", k, v, err)
+	for k, v := range osConfig {
+		// read the existing property from disk
+		oldv, err := readSystemProperty(k)
+		if err != nil {
+			logrus.Errorf("error reading the kernel parameter %s, error: %s", k, err)
+			continue
+		}
+
+		if propertyIsValid(oldv, v.value, v.checkFn) {
+			// write new prop value to disk
+			if err := writeSystemProperty(k, v.value); err != nil {
+				logrus.Errorf("error setting the kernel parameter %s = %s, (leaving as %s) error: %s", k, v.value, oldv, err)
+				continue
+			}
+			logrus.Debugf("updated kernel parameter %s = %s (was %s)", k, v.value, oldv)
 		}
 	}
 }

--- a/vendor/github.com/docker/libnetwork/networkdb/delegate.go
+++ b/vendor/github.com/docker/libnetwork/networkdb/delegate.go
@@ -21,8 +21,8 @@ func (nDB *NetworkDB) handleNodeEvent(nEvent *NodeEvent) bool {
 	// time.
 	nDB.networkClock.Witness(nEvent.LTime)
 
-	nDB.RLock()
-	defer nDB.RUnlock()
+	nDB.Lock()
+	defer nDB.Unlock()
 
 	// check if the node exists
 	n, _, _ := nDB.findNode(nEvent.NodeName)


### PR DESCRIPTION
Full diff
https://github.com/docker/libnetwork/compare/5c1218c956c99f3365711974e300087810c31379...c15b372ef22125880d378167dde44f4b134e1a77

Fixes ##36814 -- panic on concurrent read/write to a map.

Changes included:

- https://github.com/docker/libnetwork/pull/2124 Allow for larger preset property values, do not override
- https://github.com/docker/libnetwork/pull/2136 networkdb: Use write lock in handleNodeEvent
