### PR TITLE
Some enhancement in integration tests

### DIFF
--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -46,7 +46,7 @@ func TestCreateFailsWhenIdentifierDoesNotExist(t *testing.T) {
 				&container.Config{Image: tc.image},
 				&container.HostConfig{},
 				&network.NetworkingConfig{},
-				"foo",
+				"",
 			)
 			testutil.ErrorContains(t, err, tc.expectedError)
 		})
@@ -86,7 +86,7 @@ func TestCreateWithInvalidEnv(t *testing.T) {
 				},
 				&container.HostConfig{},
 				&network.NetworkingConfig{},
-				"foo",
+				"",
 			)
 			testutil.ErrorContains(t, err, tc.expectedError)
 		})

--- a/integration/container/export_test.go
+++ b/integration/container/export_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
-	containerTypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/request"
@@ -70,15 +69,10 @@ func TestExportContainerAfterDaemonRestart(t *testing.T) {
 	defer d.Stop(t)
 
 	ctx := context.Background()
-	cfg := containerTypes.Config{
-		Image: "busybox",
-		Cmd:   []string{"top"},
-	}
-	ctr, err := client.ContainerCreate(ctx, &cfg, nil, nil, "")
-	assert.NilError(t, err)
+	ctrID := container.Create(t, ctx, client)
 
 	d.Restart(t)
 
-	_, err = client.ContainerExport(ctx, ctr.ID)
+	_, err = client.ContainerExport(ctx, ctrID)
 	assert.NilError(t, err)
 }

--- a/integration/system/cgroupdriver_systemd_test.go
+++ b/integration/system/cgroupdriver_systemd_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/test/daemon"
 
 	"github.com/gotestyourself/gotestyourself/assert"
@@ -40,25 +40,17 @@ func TestCgroupDriverSystemdMemoryLimit(t *testing.T) {
 	defer d.Stop(t)
 
 	const mem = 64 * 1024 * 1024 // 64 MB
-	cfg := container.Config{
-		Image: "busybox",
-		Cmd:   []string{"top"},
-	}
-	hostcfg := container.HostConfig{
-		Resources: container.Resources{
-			Memory: mem,
-		},
-	}
 
 	ctx := context.Background()
-	ctr, err := client.ContainerCreate(ctx, &cfg, &hostcfg, nil, "")
-	assert.NilError(t, err)
-	defer client.ContainerRemove(ctx, ctr.ID, types.ContainerRemoveOptions{Force: true})
+	ctrID := container.Create(t, ctx, client, func(c *container.TestContainerConfig) {
+		c.HostConfig.Resources.Memory = mem
+	})
+	defer client.ContainerRemove(ctx, ctrID, types.ContainerRemoveOptions{Force: true})
 
-	err = client.ContainerStart(ctx, ctr.ID, types.ContainerStartOptions{})
+	err = client.ContainerStart(ctx, ctrID, types.ContainerStartOptions{})
 	assert.NilError(t, err)
 
-	s, err := client.ContainerInspect(ctx, ctr.ID)
+	s, err := client.ContainerInspect(ctx, ctrID)
 	assert.NilError(t, err)
 	assert.Equal(t, s.HostConfig.Memory, mem)
 }


### PR DESCRIPTION
This fix converts some `client.ContainerCreate` to `container.Create`,
and removes some unneeded `name` fields when test containers are created.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

