### PR TITLE
Add the runtime with the name of default for backward compatibility.

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -35,6 +35,8 @@ const (
 	// StockRuntimeName is the reserved name/alias used to represent the
 	// OCI runtime being shipped with the docker daemon package.
 	StockRuntimeName = "runc"
+	// DefaultStockRuntimeName is the reserved name/alias used for backward compatibility.
+	DefaultStockRuntimeName = "default"
 	// DefaultShmSize is the default value for container's shm size
 	DefaultShmSize = int64(67108864)
 	// DefaultNetworkMtu is the default value for network MTU

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -712,7 +712,7 @@ func verifyDaemonSettings(conf *config.Config) error {
 		conf.Runtimes = make(map[string]types.Runtime)
 	}
 	conf.Runtimes[config.StockRuntimeName] = types.Runtime{Path: DefaultRuntimeName}
-
+	conf.Runtimes[config.DefaultStockRuntimeName] = types.Runtime{Path: DefaultRuntimeName}
 	return nil
 }
 


### PR DESCRIPTION
With the upstream docker , we can't start the container which is created by low version docker(e.g. docker-1.11.2)

** How to reproduce?
With docker-1.11.2,we create a abc container,
```
[root@localhost ~]# docker run -ti --name abc  busybox ash
/ # exit
[root@localhost ~]# cat /var/lib/docker/containers/a68dcae65d78e533d09fa4c6d048c764bdcdb65c185a104893ced10f9c83a456/hostconfig.json|python -mjson.tool|grep Runtime
    "CpuRealtimeRuntime": 0,
    "Runtime": "default",
```
update to upstream docker, we start the abc container,
```
[root@localhost ~]# docker start abc
Error response from daemon: Unknown runtime specified default
Error: failed to start containers: abc
```
Signed-off-by: Shukui Yang <yangshukui@huawei.com>

