### PR TITLE
[test/integration-cli] small cleanups of FIXME(s)

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -350,14 +350,7 @@ func (s *DockerSwarmSuite) TearDownTest(c *check.C) {
 	for _, d := range s.daemons {
 		if d != nil {
 			d.Stop(c)
-			// FIXME(vdemeester) should be handled by SwarmDaemon ?
-			// raft state file is quite big (64MB) so remove it after every test
-			walDir := filepath.Join(d.Root, "swarm/raft/wal")
-			if err := os.RemoveAll(walDir); err != nil {
-				c.Logf("error removing %v: %v", walDir, err)
-			}
-
-			d.CleanupExecRoot(c)
+			d.Cleanup(c)
 		}
 	}
 	s.daemons = nil

--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -2,7 +2,6 @@ package daemon // import "github.com/docker/docker/integration-cli/daemon"
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -88,19 +87,6 @@ func (d *Daemon) inspectFieldWithError(name, field string) (string, error) {
 	return d.inspectFilter(name, fmt.Sprintf(".%s", field))
 }
 
-// BuildImageWithOut builds an image with the specified dockerfile and options and returns the output
-func (d *Daemon) BuildImageWithOut(name, dockerfile string, useCache bool, buildFlags ...string) (string, int, error) {
-	buildCmd := BuildImageCmdWithHost(d.dockerBinary, name, dockerfile, d.Sock(), useCache, buildFlags...)
-	result := icmd.RunCmd(icmd.Cmd{
-		Command: buildCmd.Args,
-		Env:     buildCmd.Env,
-		Dir:     buildCmd.Dir,
-		Stdin:   buildCmd.Stdin,
-		Stdout:  buildCmd.Stdout,
-	})
-	return result.Combined(), result.ExitCode, result.Error
-}
-
 // CheckActiveContainerCount returns the number of active containers
 // FIXME(vdemeester) should re-use ActivateContainers in some way
 func (d *Daemon) CheckActiveContainerCount(c *check.C) (interface{}, check.CommentInterface) {
@@ -154,23 +140,4 @@ func WaitInspectWithArgs(dockerBinary, name, expr, expected string, timeout time
 		time.Sleep(100 * time.Millisecond)
 	}
 	return nil
-}
-
-// BuildImageCmdWithHost create a build command with the specified arguments.
-// Deprecated
-// FIXME(vdemeester) move this away
-func BuildImageCmdWithHost(dockerBinary, name, dockerfile, host string, useCache bool, buildFlags ...string) *exec.Cmd {
-	args := []string{}
-	if host != "" {
-		args = append(args, "--host", host)
-	}
-	args = append(args, "build", "-t", name)
-	if !useCache {
-		args = append(args, "--no-cache")
-	}
-	args = append(args, buildFlags...)
-	args = append(args, "-")
-	buildCmd := exec.Command(dockerBinary, args...)
-	buildCmd.Stdin = strings.NewReader(dockerfile)
-	return buildCmd
 }

--- a/integration-cli/docker_api_swarm_service_test.go
+++ b/integration-cli/docker_api_swarm_service_test.go
@@ -13,11 +13,14 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/swarm/runtime"
 	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/cli"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/integration-cli/daemon"
 	testdaemon "github.com/docker/docker/internal/test/daemon"
 	"github.com/docker/docker/internal/test/fixtures/plugin"
 	"github.com/docker/docker/internal/test/registry"
 	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/icmd"
 	"golang.org/x/net/context"
 	"golang.org/x/sys/unix"
 )
@@ -209,12 +212,12 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesUpdateStartFirst(c *check.C) {
 	image2 := "testhealth:latest"
 
 	// service started from this image won't pass health check
-	_, _, err := d.BuildImageWithOut(image2,
-		`FROM busybox
+	result := cli.BuildCmd(c, image2, cli.Daemon(d),
+		build.WithDockerfile(`FROM busybox
 		HEALTHCHECK --interval=1s --timeout=30s --retries=1024 \
-		  CMD cat /status`,
-		true)
-	c.Check(err, check.IsNil)
+		  CMD cat /status`),
+	)
+	result.Assert(c, icmd.Success)
 
 	// create service
 	instances := 5

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -809,10 +808,6 @@ func (s *DockerSwarmSuite) TestAPISwarmRestartCluster(c *check.C) {
 				defer wg.Done()
 				if err := daemon.StopWithError(); err != nil {
 					errs <- err
-				}
-				// FIXME(vdemeester) This is duplicated…
-				if root := os.Getenv("DOCKER_REMAP_ROOT"); root != "" {
-					daemon.Root = filepath.Dir(daemon.Root)
 				}
 			}(d)
 		}

--- a/integration-cli/docker_cli_prune_unix_test.go
+++ b/integration-cli/docker_cli_prune_unix_test.go
@@ -12,8 +12,10 @@ import (
 
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/cli"
+	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/icmd"
 )
 
 func pruneNetworkAndVerify(c *check.C, d *daemon.Daemon, kept, pruned []string) {
@@ -79,13 +81,15 @@ func (s *DockerSwarmSuite) TestPruneNetwork(c *check.C) {
 func (s *DockerDaemonSuite) TestPruneImageDangling(c *check.C) {
 	s.d.StartWithBusybox(c)
 
-	out, _, err := s.d.BuildImageWithOut("test",
-		`FROM busybox
-                 LABEL foo=bar`, true, "-q")
-	c.Assert(err, checker.IsNil)
-	id := strings.TrimSpace(out)
+	result := cli.BuildCmd(c, "test", cli.Daemon(s.d),
+		build.WithDockerfile(`FROM busybox
+                 LABEL foo=bar`),
+		cli.WithFlags("-q"),
+	)
+	result.Assert(c, icmd.Success)
+	id := strings.TrimSpace(result.Combined())
 
-	out, err = s.d.Cmd("images", "-q", "--no-trunc")
+	out, err := s.d.Cmd("images", "-q", "--no-trunc")
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(out), checker.Contains, id)
 
@@ -266,20 +270,24 @@ func (s *DockerSuite) TestPruneNetworkLabel(c *check.C) {
 func (s *DockerDaemonSuite) TestPruneImageLabel(c *check.C) {
 	s.d.StartWithBusybox(c)
 
-	out, _, err := s.d.BuildImageWithOut("test1",
-		`FROM busybox
-                 LABEL foo=bar`, true, "-q")
-	c.Assert(err, checker.IsNil)
-	id1 := strings.TrimSpace(out)
-	out, err = s.d.Cmd("images", "-q", "--no-trunc")
+	result := cli.BuildCmd(c, "test1", cli.Daemon(s.d),
+		build.WithDockerfile(`FROM busybox
+                 LABEL foo=bar`),
+		cli.WithFlags("-q"),
+	)
+	result.Assert(c, icmd.Success)
+	id1 := strings.TrimSpace(result.Combined())
+	out, err := s.d.Cmd("images", "-q", "--no-trunc")
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(out), checker.Contains, id1)
 
-	out, _, err = s.d.BuildImageWithOut("test2",
-		`FROM busybox
-                 LABEL bar=foo`, true, "-q")
-	c.Assert(err, checker.IsNil)
-	id2 := strings.TrimSpace(out)
+	result = cli.BuildCmd(c, "test2", cli.Daemon(s.d),
+		build.WithDockerfile(`FROM busybox
+                 LABEL bar=foo`),
+		cli.WithFlags("-q"),
+	)
+	result.Assert(c, icmd.Success)
+	id2 := strings.TrimSpace(result.Combined())
 	out, err = s.d.Cmd("images", "-q", "--no-trunc")
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(out), checker.Contains, id2)

--- a/internal/test/daemon/daemon.go
+++ b/internal/test/daemon/daemon.go
@@ -176,8 +176,13 @@ func (d *Daemon) NewClientT(t assert.TestingT) *client.Client {
 	return c
 }
 
-// CleanupExecRoot cleans the daemon exec root (network namespaces, ...)
-func (d *Daemon) CleanupExecRoot(t testingT) {
+// Cleanup cleans the daemon files : exec root (network namespaces, ...), swarmkit files
+func (d *Daemon) Cleanup(t testingT) {
+	// Cleanup swarmkit wal files if present
+	walDir := filepath.Join(d.Root, "swarm/raft/wal")
+	if err := os.RemoveAll(walDir); err != nil {
+		t.Logf("error removing %v: %v", walDir, err)
+	}
 	cleanupExecRoot(t, d.execRoot)
 }
 
@@ -201,6 +206,7 @@ func (d *Daemon) StartWithError(args ...string) error {
 
 // StartWithLogFile will start the daemon and attach its streams to a given file.
 func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
+	d.handleUserns()
 	dockerdBinary, err := exec.LookPath(d.dockerdBinary)
 	if err != nil {
 		return errors.Wrapf(err, "[%s] could not find docker binary in $PATH", d.id)
@@ -446,7 +452,6 @@ out2:
 // If an error occurs while starting the daemon, the test will fail.
 func (d *Daemon) Restart(t testingT, args ...string) {
 	d.Stop(t)
-	d.handleUserns()
 	d.Start(t, args...)
 }
 
@@ -455,7 +460,6 @@ func (d *Daemon) RestartWithError(arg ...string) error {
 	if err := d.StopWithError(); err != nil {
 		return err
 	}
-	d.handleUserns()
 	return d.StartWithError(arg...)
 }
 

--- a/internal/test/daemon/daemon.go
+++ b/internal/test/daemon/daemon.go
@@ -179,11 +179,8 @@ func (d *Daemon) NewClientT(t assert.TestingT) *client.Client {
 // Cleanup cleans the daemon files : exec root (network namespaces, ...), swarmkit files
 func (d *Daemon) Cleanup(t testingT) {
 	// Cleanup swarmkit wal files if present
-	walDir := filepath.Join(d.Root, "swarm/raft/wal")
-	if err := os.RemoveAll(walDir); err != nil {
-		t.Logf("error removing %v: %v", walDir, err)
-	}
-	cleanupExecRoot(t, d.execRoot)
+	cleanupRaftDir(t, d.Root)
+	cleanupNetworkNamespace(t, d.execRoot)
 }
 
 // Start starts the daemon and return once it is ready to receive requests.
@@ -639,4 +636,11 @@ func (d *Daemon) Info(t assert.TestingT) types.Info {
 	info, err := apiclient.Info(context.Background())
 	assert.NilError(t, err)
 	return info
+}
+
+func cleanupRaftDir(t testingT, rootPath string) {
+	walDir := filepath.Join(rootPath, "swarm/raft/wal")
+	if err := os.RemoveAll(walDir); err != nil {
+		t.Logf("error removing %v: %v", walDir, err)
+	}
 }

--- a/internal/test/daemon/daemon_unix.go
+++ b/internal/test/daemon/daemon_unix.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func cleanupExecRoot(t testingT, execRoot string) {
+func cleanupNetworkNamespace(t testingT, execRoot string) {
 	// Cleanup network namespaces in the exec root of this
 	// daemon because this exec root is specific to this
 	// daemon instance and has no chance of getting

--- a/internal/test/daemon/daemon_windows.go
+++ b/internal/test/daemon/daemon_windows.go
@@ -21,5 +21,5 @@ func signalDaemonReload(pid int) error {
 	return fmt.Errorf("daemon reload not supported")
 }
 
-func cleanupExecRoot(t testingT, execRoot string) {
+func cleanupNetworkNamespace(t testingT, execRoot string) {
 }


### PR DESCRIPTION
- Add a Cleanup function that cleans exec root and swarm files directly in `internal/test/daemon`
- Remove `daemon.BuildImageWithOut` and use cli helpers function instead