### PR TITLE
Parse multi-platforms parameters with containerd method

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/streamformatter"
-	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/registry"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -45,9 +44,13 @@ func (s *imageRouter) postImagesCreate(ctx context.Context, w http.ResponseWrite
 	version := httputils.VersionFromContext(ctx)
 	if versions.GreaterThanOrEqualTo(version, "1.32") {
 		apiPlatform := r.FormValue("platform")
-		platform = system.ParsePlatform(apiPlatform)
-		if err = system.ValidatePlatform(platform); err != nil {
-			err = fmt.Errorf("invalid platform: %s", err)
+		if len(strings.TrimSpace(apiPlatform)) != 0 {
+			m, err := platforms.Parse(apiPlatform)
+			if err != nil {
+				return err
+			}
+			sp := m.Spec()
+			platform = &sp
 		}
 	}
 

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
@@ -24,6 +25,7 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/system"
 	"github.com/moby/buildkit/session"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/syncmap"
@@ -104,7 +106,16 @@ func (bm *BuildManager) Build(ctx context.Context, config backend.BuildConfig) (
 	}
 
 	os := ""
-	apiPlatform := system.ParsePlatform(config.Options.Platform)
+	apiPlatform := &specs.Platform{}
+	if len(strings.TrimSpace(config.Options.Platform)) != 0 {
+		m, err := platforms.Parse(config.Options.Platform)
+		if err != nil {
+			return nil, err
+		}
+		sp := m.Spec()
+		apiPlatform = &sp
+	}
+
 	if apiPlatform.OS != "" {
 		os = apiPlatform.OS
 	}

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
@@ -152,13 +153,18 @@ func (d *dispatchRequest) getImageMount(imageRefOrID string) (*imageMount, error
 //
 func initializeStage(d dispatchRequest, cmd *instructions.Stage) error {
 	d.builder.imageProber.Reset()
-	if err := system.ValidatePlatform(&cmd.Platform); err != nil {
-		return err
+
+	if len(strings.TrimSpace(cmd.Platform.OS)) != 0 {
+		if _, err := platforms.Parse(cmd.Platform.OS); err != nil {
+			return err
+		}
 	}
+
 	image, err := d.getFromImage(d.shlex, cmd.BaseName, cmd.Platform.OS)
 	if err != nil {
 		return err
 	}
+
 	state := d.state
 	if err := state.beginStage(cmd.Name, image); err != nil {
 		return err

--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"runtime"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/image"
@@ -421,9 +422,9 @@ func checkCompatibleOS(imageOS string) error {
 	if runtime.GOOS != "windows" && imageOS == "windows" {
 		return fmt.Errorf("cannot load %s image on %s", imageOS, runtime.GOOS)
 	}
-	// Finally, check the image OS is supported for the platform.
-	if err := system.ValidatePlatform(system.ParsePlatform(imageOS)); err != nil {
-		return fmt.Errorf("cannot load %s image on %s: %s", imageOS, runtime.GOOS, err)
+
+	if _, err := platforms.Parse(imageOS); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/system/lcow.go
+++ b/pkg/system/lcow.go
@@ -1,61 +1,8 @@
 package system // import "github.com/docker/docker/pkg/system"
 
 import (
-	"fmt"
 	"runtime"
-	"strings"
-
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
-
-// ValidatePlatform determines if a platform structure is valid.
-// TODO This is a temporary function - can be replaced by parsing from
-// https://github.com/containerd/containerd/pull/1403/files at a later date.
-// @jhowardmsft
-func ValidatePlatform(platform *specs.Platform) error {
-	platform.Architecture = strings.ToLower(platform.Architecture)
-	platform.OS = strings.ToLower(platform.OS)
-	// Based on https://github.com/moby/moby/pull/34642#issuecomment-330375350, do
-	// not support anything except operating system.
-	if platform.Architecture != "" {
-		return fmt.Errorf("invalid platform architecture %q", platform.Architecture)
-	}
-	if platform.OS != "" {
-		if !(platform.OS == runtime.GOOS || (LCOWSupported() && platform.OS == "linux")) {
-			return fmt.Errorf("invalid platform os %q", platform.OS)
-		}
-	}
-	if len(platform.OSFeatures) != 0 {
-		return fmt.Errorf("invalid platform osfeatures %q", platform.OSFeatures)
-	}
-	if platform.OSVersion != "" {
-		return fmt.Errorf("invalid platform osversion %q", platform.OSVersion)
-	}
-	if platform.Variant != "" {
-		return fmt.Errorf("invalid platform variant %q", platform.Variant)
-	}
-	return nil
-}
-
-// ParsePlatform parses a platform string in the format os[/arch[/variant]
-// into an OCI image-spec platform structure.
-// TODO This is a temporary function - can be replaced by parsing from
-// https://github.com/containerd/containerd/pull/1403/files at a later date.
-// @jhowardmsft
-func ParsePlatform(in string) *specs.Platform {
-	p := &specs.Platform{}
-	elements := strings.SplitN(strings.ToLower(in), "/", 3)
-	if len(elements) == 3 {
-		p.Variant = elements[2]
-	}
-	if len(elements) >= 2 {
-		p.Architecture = elements[1]
-	}
-	if len(elements) >= 1 {
-		p.OS = elements[0]
-	}
-	return p
-}
 
 // IsOSSupported determines if an operating system is supported by the host
 func IsOSSupported(os string) bool {


### PR DESCRIPTION
Currently we use 2 temporary functions to parse and validate the platform parameters specified by `--platform` or `FROM [--platform=platform] imagename[:tag]` in Dockerfile. This patch replaces those 2 functions with the `Parse` function in containerd to align with OCI specification.

There're 2 purposes of this PR:
1. Prepare for the multi-platforms support in future, so we need to switch all the platform info, as the first step,  to the `specs.Platform` specified by OCI spec. Refer to issue #36552.
2. Fix below issues for an experimental enabled docker daemon:
`#docker build --rm --no-cache --platform darwin -t multi-platform:test .`
Error response from daemon: invalid platform: invalid platform os "darwin"

`darwin` should be a known OS can be assigned as the OS/Arch pair when supporting multi-platforms feature.

After this PR applied, the output is:
`#docker build --rm --no-cache --platform darwin -t multi-platform:test .`
```
Sending build context to Docker daemon  15.93MB
Step 1/2 : FROM arm32v6/alpine:3.7
 ---> 889c6315e8d7
Step 2/2 : CMD ["sh", "-c" , "uname -a"]
 ---> Running in 385315473b54
Removing intermediate container 385315473b54
 ---> 8fc16846649b
Successfully built 8fc16846649b
Successfully tagged arm32:test
```
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
OCI spec platform parameters parsing and validation
**- How I did it**
Take use of the routine provided by containerd
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

