### PR TITLE
Make testing helpers as such…

### DIFF
--- a/integration/internal/requirement/requirement.go
+++ b/integration/internal/requirement/requirement.go
@@ -13,6 +13,7 @@ import (
 // HasHubConnectivity checks to see if https://hub.docker.com is
 // accessible from the present environment
 func HasHubConnectivity(t *testing.T) bool {
+	t.Helper()
 	// Set a timeout on the GET at 15s
 	var timeout = 15 * time.Second
 	var url = "https://hub.docker.com"

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -49,6 +49,7 @@ func ContainerPoll(config *poll.Settings) {
 
 // NewSwarm creates a swarm daemon for testing
 func NewSwarm(t *testing.T, testEnv *environment.Execution, ops ...func(*daemon.Daemon)) *daemon.Daemon {
+	t.Helper()
 	skip.IfCondition(t, testEnv.IsRemoteDaemon())
 	if testEnv.DaemonInfo.ExperimentalBuild {
 		ops = append(ops, daemon.WithExperimental)
@@ -63,6 +64,7 @@ type ServiceSpecOpt func(*swarmtypes.ServiceSpec)
 
 // CreateService creates a service on the passed in swarm daemon.
 func CreateService(t *testing.T, d *daemon.Daemon, opts ...ServiceSpecOpt) string {
+	t.Helper()
 	spec := defaultServiceSpec()
 	for _, o := range opts {
 		o(&spec)
@@ -136,6 +138,7 @@ func ServiceWithName(name string) ServiceSpecOpt {
 
 // GetRunningTasks gets the list of running tasks for a service
 func GetRunningTasks(t *testing.T, d *daemon.Daemon, serviceID string) []swarmtypes.Task {
+	t.Helper()
 	client := d.NewClientT(t)
 	defer client.Close()
 
@@ -153,6 +156,7 @@ func GetRunningTasks(t *testing.T, d *daemon.Daemon, serviceID string) []swarmty
 
 // ExecTask runs the passed in exec config on the given task
 func ExecTask(t *testing.T, d *daemon.Daemon, task swarmtypes.Task, config types.ExecConfig) types.HijackedResponse {
+	t.Helper()
 	client := d.NewClientT(t)
 	defer client.Close()
 

--- a/internal/test/daemon/config.go
+++ b/internal/test/daemon/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/internal/test"
 	"github.com/gotestyourself/gotestyourself/assert"
 )
 
@@ -13,6 +14,9 @@ type ConfigConstructor func(*swarm.Config)
 
 // CreateConfig creates a config given the specified spec
 func (d *Daemon) CreateConfig(t assert.TestingT, configSpec swarm.ConfigSpec) string {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -23,6 +27,9 @@ func (d *Daemon) CreateConfig(t assert.TestingT, configSpec swarm.ConfigSpec) st
 
 // ListConfigs returns the list of the current swarm configs
 func (d *Daemon) ListConfigs(t assert.TestingT) []swarm.Config {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -33,6 +40,9 @@ func (d *Daemon) ListConfigs(t assert.TestingT) []swarm.Config {
 
 // GetConfig returns a swarm config identified by the specified id
 func (d *Daemon) GetConfig(t assert.TestingT, id string) *swarm.Config {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -43,6 +53,9 @@ func (d *Daemon) GetConfig(t assert.TestingT, id string) *swarm.Config {
 
 // DeleteConfig removes the swarm config identified by the specified id
 func (d *Daemon) DeleteConfig(t assert.TestingT, id string) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -53,6 +66,9 @@ func (d *Daemon) DeleteConfig(t assert.TestingT, id string) {
 // UpdateConfig updates the swarm config identified by the specified id
 // Currently, only label update is supported.
 func (d *Daemon) UpdateConfig(t assert.TestingT, id string, f ...ConfigConstructor) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 

--- a/internal/test/daemon/container.go
+++ b/internal/test/daemon/container.go
@@ -4,11 +4,15 @@ import (
 	"context"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/internal/test"
 	"github.com/gotestyourself/gotestyourself/assert"
 )
 
 // ActiveContainers returns the list of ids of the currently running containers
 func (d *Daemon) ActiveContainers(t assert.TestingT) []string {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -24,6 +28,9 @@ func (d *Daemon) ActiveContainers(t assert.TestingT) []string {
 
 // FindContainerIP returns the ip of the specified container
 func (d *Daemon) FindContainerIP(t assert.TestingT, id string) string {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 

--- a/internal/test/daemon/daemon.go
+++ b/internal/test/daemon/daemon.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/internal/test"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/ioutils"
@@ -80,6 +81,9 @@ type Daemon struct {
 // This will create a directory such as d123456789 in the folder specified by $DOCKER_INTEGRATION_DAEMON_DEST or $DEST.
 // The daemon will not automatically start.
 func New(t testingT, ops ...func(*Daemon)) *Daemon {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	dest := os.Getenv("DOCKER_INTEGRATION_DAEMON_DEST")
 	if dest == "" {
 		dest = os.Getenv("DEST")
@@ -169,6 +173,9 @@ func (d *Daemon) NewClient() (*client.Client, error) {
 // NewClientT creates new client based on daemon's socket path
 // FIXME(vdemeester): replace NewClient with NewClientT
 func (d *Daemon) NewClientT(t assert.TestingT) *client.Client {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	c, err := client.NewClientWithOpts(
 		client.FromEnv,
 		client.WithHost(d.Sock()))
@@ -178,6 +185,9 @@ func (d *Daemon) NewClientT(t assert.TestingT) *client.Client {
 
 // Cleanup cleans the daemon files : exec root (network namespaces, ...), swarmkit files
 func (d *Daemon) Cleanup(t testingT) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	// Cleanup swarmkit wal files if present
 	cleanupRaftDir(t, d.Root)
 	cleanupNetworkNamespace(t, d.execRoot)
@@ -185,6 +195,9 @@ func (d *Daemon) Cleanup(t testingT) {
 
 // Start starts the daemon and return once it is ready to receive requests.
 func (d *Daemon) Start(t testingT, args ...string) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	if err := d.StartWithError(args...); err != nil {
 		t.Fatalf("Error starting daemon with arguments: %v", args)
 	}
@@ -316,6 +329,9 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 // StartWithBusybox will first start the daemon with Daemon.Start()
 // then save the busybox image from the main daemon and load it into this Daemon instance.
 func (d *Daemon) StartWithBusybox(t testingT, arg ...string) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	d.Start(t, arg...)
 	d.LoadBusybox(t)
 }
@@ -372,6 +388,9 @@ func (d *Daemon) DumpStackAndQuit() {
 // instantiate a new one with NewDaemon.
 // If an error occurs while starting the daemon, the test will fail.
 func (d *Daemon) Stop(t testingT) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	err := d.StopWithError()
 	if err != nil {
 		if err != errDaemonNotStarted {
@@ -448,6 +467,9 @@ out2:
 // Restart will restart the daemon by first stopping it and the starting it.
 // If an error occurs while starting the daemon, the test will fail.
 func (d *Daemon) Restart(t testingT, args ...string) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	d.Stop(t)
 	d.Start(t, args...)
 }
@@ -521,6 +543,9 @@ func (d *Daemon) ReloadConfig() error {
 
 // LoadBusybox image into the daemon
 func (d *Daemon) LoadBusybox(t assert.TestingT) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	clientHost, err := client.NewEnvClient()
 	assert.NilError(t, err, "failed to create client")
 	defer clientHost.Close()
@@ -631,6 +656,9 @@ func (d *Daemon) queryRootDir() (string, error) {
 
 // Info returns the info struct for this daemon
 func (d *Daemon) Info(t assert.TestingT) types.Info {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	apiclient, err := d.NewClient()
 	assert.NilError(t, err)
 	info, err := apiclient.Info(context.Background())
@@ -639,6 +667,9 @@ func (d *Daemon) Info(t assert.TestingT) types.Info {
 }
 
 func cleanupRaftDir(t testingT, rootPath string) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	walDir := filepath.Join(rootPath, "swarm/raft/wal")
 	if err := os.RemoveAll(walDir); err != nil {
 		t.Logf("error removing %v: %v", walDir, err)

--- a/internal/test/daemon/daemon_unix.go
+++ b/internal/test/daemon/daemon_unix.go
@@ -6,10 +6,14 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/docker/docker/internal/test"
 	"golang.org/x/sys/unix"
 )
 
 func cleanupNetworkNamespace(t testingT, execRoot string) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	// Cleanup network namespaces in the exec root of this
 	// daemon because this exec root is specific to this
 	// daemon instance and has no chance of getting

--- a/internal/test/daemon/node.go
+++ b/internal/test/daemon/node.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/internal/test"
 	"github.com/gotestyourself/gotestyourself/assert"
 )
 
@@ -15,6 +16,9 @@ type NodeConstructor func(*swarm.Node)
 
 // GetNode returns a swarm node identified by the specified id
 func (d *Daemon) GetNode(t assert.TestingT, id string) *swarm.Node {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -26,6 +30,9 @@ func (d *Daemon) GetNode(t assert.TestingT, id string) *swarm.Node {
 
 // RemoveNode removes the specified node
 func (d *Daemon) RemoveNode(t assert.TestingT, id string, force bool) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -38,6 +45,9 @@ func (d *Daemon) RemoveNode(t assert.TestingT, id string, force bool) {
 
 // UpdateNode updates a swarm node with the specified node constructor
 func (d *Daemon) UpdateNode(t assert.TestingT, id string, f ...NodeConstructor) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -59,6 +69,9 @@ func (d *Daemon) UpdateNode(t assert.TestingT, id string, f ...NodeConstructor) 
 
 // ListNodes returns the list of the current swarm nodes
 func (d *Daemon) ListNodes(t assert.TestingT) []swarm.Node {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 

--- a/internal/test/daemon/secret.go
+++ b/internal/test/daemon/secret.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/internal/test"
 	"github.com/gotestyourself/gotestyourself/assert"
 )
 
@@ -13,6 +14,9 @@ type SecretConstructor func(*swarm.Secret)
 
 // CreateSecret creates a secret given the specified spec
 func (d *Daemon) CreateSecret(t assert.TestingT, secretSpec swarm.SecretSpec) string {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -24,6 +28,9 @@ func (d *Daemon) CreateSecret(t assert.TestingT, secretSpec swarm.SecretSpec) st
 
 // ListSecrets returns the list of the current swarm secrets
 func (d *Daemon) ListSecrets(t assert.TestingT) []swarm.Secret {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -34,6 +41,9 @@ func (d *Daemon) ListSecrets(t assert.TestingT) []swarm.Secret {
 
 // GetSecret returns a swarm secret identified by the specified id
 func (d *Daemon) GetSecret(t assert.TestingT, id string) *swarm.Secret {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -44,6 +54,9 @@ func (d *Daemon) GetSecret(t assert.TestingT, id string) *swarm.Secret {
 
 // DeleteSecret removes the swarm secret identified by the specified id
 func (d *Daemon) DeleteSecret(t assert.TestingT, id string) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -54,6 +67,9 @@ func (d *Daemon) DeleteSecret(t assert.TestingT, id string) {
 // UpdateSecret updates the swarm secret identified by the specified id
 // Currently, only label update is supported.
 func (d *Daemon) UpdateSecret(t assert.TestingT, id string, f ...SecretConstructor) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 

--- a/internal/test/daemon/service.go
+++ b/internal/test/daemon/service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/internal/test"
 	"github.com/gotestyourself/gotestyourself/assert"
 )
 
@@ -14,6 +15,9 @@ import (
 type ServiceConstructor func(*swarm.Service)
 
 func (d *Daemon) createServiceWithOptions(t assert.TestingT, opts types.ServiceCreateOptions, f ...ServiceConstructor) string {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	var service swarm.Service
 	for _, fn := range f {
 		fn(&service)
@@ -32,11 +36,17 @@ func (d *Daemon) createServiceWithOptions(t assert.TestingT, opts types.ServiceC
 
 // CreateService creates a swarm service given the specified service constructor
 func (d *Daemon) CreateService(t assert.TestingT, f ...ServiceConstructor) string {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	return d.createServiceWithOptions(t, types.ServiceCreateOptions{}, f...)
 }
 
 // GetService returns the swarm service corresponding to the specified id
 func (d *Daemon) GetService(t assert.TestingT, id string) *swarm.Service {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -47,6 +57,9 @@ func (d *Daemon) GetService(t assert.TestingT, id string) *swarm.Service {
 
 // GetServiceTasks returns the swarm tasks for the specified service
 func (d *Daemon) GetServiceTasks(t assert.TestingT, service string) []swarm.Task {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -65,6 +78,9 @@ func (d *Daemon) GetServiceTasks(t assert.TestingT, service string) []swarm.Task
 
 // UpdateService updates a swarm service with the specified service constructor
 func (d *Daemon) UpdateService(t assert.TestingT, service *swarm.Service, f ...ServiceConstructor) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -78,6 +94,9 @@ func (d *Daemon) UpdateService(t assert.TestingT, service *swarm.Service, f ...S
 
 // RemoveService removes the specified service
 func (d *Daemon) RemoveService(t assert.TestingT, id string) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -87,6 +106,9 @@ func (d *Daemon) RemoveService(t assert.TestingT, id string) {
 
 // ListServices returns the list of the current swarm services
 func (d *Daemon) ListServices(t assert.TestingT) []swarm.Service {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -97,6 +119,9 @@ func (d *Daemon) ListServices(t assert.TestingT) []swarm.Service {
 
 // GetTask returns the swarm task identified by the specified id
 func (d *Daemon) GetTask(t assert.TestingT, id string) swarm.Task {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 

--- a/internal/test/daemon/swarm.go
+++ b/internal/test/daemon/swarm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/internal/test"
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/pkg/errors"
 )
@@ -17,6 +18,9 @@ const (
 
 // StartAndSwarmInit starts the daemon (with busybox) and init the swarm
 func (d *Daemon) StartAndSwarmInit(t testingT) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	// avoid networking conflicts
 	args := []string{"--iptables=false", "--swarm-default-advertise-addr=lo"}
 	d.StartWithBusybox(t, args...)
@@ -26,6 +30,9 @@ func (d *Daemon) StartAndSwarmInit(t testingT) {
 
 // StartAndSwarmJoin starts the daemon (with busybox) and join the specified swarm as worker or manager
 func (d *Daemon) StartAndSwarmJoin(t testingT, leader *Daemon, manager bool) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	// avoid networking conflicts
 	args := []string{"--iptables=false", "--swarm-default-advertise-addr=lo"}
 	d.StartWithBusybox(t, args...)
@@ -56,6 +63,9 @@ func (d *Daemon) NodeID() string {
 
 // SwarmInit initializes a new swarm cluster.
 func (d *Daemon) SwarmInit(t assert.TestingT, req swarm.InitRequest) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	if req.ListenAddr == "" {
 		req.ListenAddr = fmt.Sprintf("%s:%d", d.swarmListenAddr, d.SwarmPort)
 	}
@@ -68,6 +78,9 @@ func (d *Daemon) SwarmInit(t assert.TestingT, req swarm.InitRequest) {
 
 // SwarmJoin joins a daemon to an existing cluster.
 func (d *Daemon) SwarmJoin(t assert.TestingT, req swarm.JoinRequest) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	if req.ListenAddr == "" {
 		req.ListenAddr = fmt.Sprintf("%s:%d", d.swarmListenAddr, d.SwarmPort)
 	}
@@ -94,6 +107,9 @@ func (d *Daemon) SwarmLeave(force bool) error {
 
 // SwarmInfo returns the swarm information of the daemon
 func (d *Daemon) SwarmInfo(t assert.TestingT) swarm.Info {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	info, err := cli.Info(context.Background())
 	assert.NilError(t, err, "get swarm info")
@@ -116,6 +132,9 @@ func (d *Daemon) SwarmUnlock(req swarm.UnlockRequest) error {
 
 // GetSwarm returns the current swarm object
 func (d *Daemon) GetSwarm(t assert.TestingT) swarm.Swarm {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -126,6 +145,9 @@ func (d *Daemon) GetSwarm(t assert.TestingT) swarm.Swarm {
 
 // UpdateSwarm updates the current swarm object with the specified spec constructors
 func (d *Daemon) UpdateSwarm(t assert.TestingT, f ...SpecConstructor) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -140,6 +162,9 @@ func (d *Daemon) UpdateSwarm(t assert.TestingT, f ...SpecConstructor) {
 
 // RotateTokens update the swarm to rotate tokens
 func (d *Daemon) RotateTokens(t assert.TestingT) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -157,6 +182,9 @@ func (d *Daemon) RotateTokens(t assert.TestingT) {
 
 // JoinTokens returns the current swarm join tokens
 func (d *Daemon) JoinTokens(t assert.TestingT) swarm.JoinTokens {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	cli := d.NewClientT(t)
 	defer cli.Close()
 

--- a/internal/test/environment/clean.go
+++ b/internal/test/environment/clean.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/internal/test"
 	"github.com/gotestyourself/gotestyourself/assert"
 	"golang.org/x/net/context"
 )
@@ -25,6 +26,9 @@ type logT interface {
 // and removing everything else. It's meant to run after any tests so that they don't
 // depend on each others.
 func (e *Execution) Clean(t testingT) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	client := e.APIClient()
 
 	platform := e.OSType
@@ -41,6 +45,9 @@ func (e *Execution) Clean(t testingT) {
 }
 
 func unpauseAllContainers(t assert.TestingT, client client.ContainerAPIClient) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	ctx := context.Background()
 	containers := getPausedContainers(ctx, t, client)
 	if len(containers) > 0 {
@@ -52,6 +59,9 @@ func unpauseAllContainers(t assert.TestingT, client client.ContainerAPIClient) {
 }
 
 func getPausedContainers(ctx context.Context, t assert.TestingT, client client.ContainerAPIClient) []types.Container {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	filter := filters.NewArgs()
 	filter.Add("status", "paused")
 	containers, err := client.ContainerList(ctx, types.ContainerListOptions{
@@ -66,6 +76,9 @@ func getPausedContainers(ctx context.Context, t assert.TestingT, client client.C
 var alreadyExists = regexp.MustCompile(`Error response from daemon: removal of container (\w+) is already in progress`)
 
 func deleteAllContainers(t assert.TestingT, apiclient client.ContainerAPIClient, protectedContainers map[string]struct{}) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	ctx := context.Background()
 	containers := getAllContainers(ctx, t, apiclient)
 	if len(containers) == 0 {
@@ -88,6 +101,9 @@ func deleteAllContainers(t assert.TestingT, apiclient client.ContainerAPIClient,
 }
 
 func getAllContainers(ctx context.Context, t assert.TestingT, client client.ContainerAPIClient) []types.Container {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	containers, err := client.ContainerList(ctx, types.ContainerListOptions{
 		Quiet: true,
 		All:   true,
@@ -97,6 +113,9 @@ func getAllContainers(ctx context.Context, t assert.TestingT, client client.Cont
 }
 
 func deleteAllImages(t testingT, apiclient client.ImageAPIClient, protectedImages map[string]struct{}) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	images, err := apiclient.ImageList(context.Background(), types.ImageListOptions{})
 	assert.Check(t, err, "failed to list images")
 
@@ -119,6 +138,9 @@ func deleteAllImages(t testingT, apiclient client.ImageAPIClient, protectedImage
 }
 
 func removeImage(ctx context.Context, t assert.TestingT, apiclient client.ImageAPIClient, ref string) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	_, err := apiclient.ImageRemove(ctx, ref, types.ImageRemoveOptions{
 		Force: true,
 	})
@@ -129,6 +151,9 @@ func removeImage(ctx context.Context, t assert.TestingT, apiclient client.ImageA
 }
 
 func deleteAllVolumes(t assert.TestingT, c client.VolumeAPIClient, protectedVolumes map[string]struct{}) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	volumes, err := c.VolumeList(context.Background(), filters.Args{})
 	assert.Check(t, err, "failed to list volumes")
 
@@ -146,6 +171,9 @@ func deleteAllVolumes(t assert.TestingT, c client.VolumeAPIClient, protectedVolu
 }
 
 func deleteAllNetworks(t assert.TestingT, c client.NetworkAPIClient, daemonPlatform string, protectedNetworks map[string]struct{}) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	networks, err := c.NetworkList(context.Background(), types.NetworkListOptions{})
 	assert.Check(t, err, "failed to list networks")
 
@@ -166,6 +194,9 @@ func deleteAllNetworks(t assert.TestingT, c client.NetworkAPIClient, daemonPlatf
 }
 
 func deleteAllPlugins(t assert.TestingT, c client.PluginAPIClient, protectedPlugins map[string]struct{}) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	plugins, err := c.PluginList(context.Background(), filters.Args{})
 	// Docker EE does not allow cluster-wide plugin management.
 	if client.IsErrNotImplemented(err) {

--- a/internal/test/environment/protect.go
+++ b/internal/test/environment/protect.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	dclient "github.com/docker/docker/client"
+	"github.com/docker/docker/internal/test"
 	"github.com/gotestyourself/gotestyourself/assert"
 )
 
@@ -33,6 +34,9 @@ func newProtectedElements() protectedElements {
 // volumes, and, on Linux, plugins) from being cleaned up at the end of test
 // runs
 func ProtectAll(t testingT, testEnv *Execution) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	ProtectContainers(t, testEnv)
 	ProtectImages(t, testEnv)
 	ProtectNetworks(t, testEnv)
@@ -45,6 +49,9 @@ func ProtectAll(t testingT, testEnv *Execution) {
 // ProtectContainer adds the specified container(s) to be protected in case of
 // clean
 func (e *Execution) ProtectContainer(t testingT, containers ...string) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	for _, container := range containers {
 		e.protectedElements.containers[container] = struct{}{}
 	}
@@ -53,11 +60,17 @@ func (e *Execution) ProtectContainer(t testingT, containers ...string) {
 // ProtectContainers protects existing containers from being cleaned up at the
 // end of test runs
 func ProtectContainers(t testingT, testEnv *Execution) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	containers := getExistingContainers(t, testEnv)
 	testEnv.ProtectContainer(t, containers...)
 }
 
 func getExistingContainers(t assert.TestingT, testEnv *Execution) []string {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	client := testEnv.APIClient()
 	containerList, err := client.ContainerList(context.Background(), types.ContainerListOptions{
 		All: true,
@@ -73,6 +86,9 @@ func getExistingContainers(t assert.TestingT, testEnv *Execution) []string {
 
 // ProtectImage adds the specified image(s) to be protected in case of clean
 func (e *Execution) ProtectImage(t testingT, images ...string) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	for _, image := range images {
 		e.protectedElements.images[image] = struct{}{}
 	}
@@ -81,6 +97,9 @@ func (e *Execution) ProtectImage(t testingT, images ...string) {
 // ProtectImages protects existing images and on linux frozen images from being
 // cleaned up at the end of test runs
 func ProtectImages(t testingT, testEnv *Execution) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	images := getExistingImages(t, testEnv)
 
 	if testEnv.OSType == "linux" {
@@ -90,6 +109,9 @@ func ProtectImages(t testingT, testEnv *Execution) {
 }
 
 func getExistingImages(t assert.TestingT, testEnv *Execution) []string {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	client := testEnv.APIClient()
 	filter := filters.NewArgs()
 	filter.Add("dangling", "false")
@@ -124,6 +146,9 @@ func tagsFromImageSummary(image types.ImageSummary) []string {
 // ProtectNetwork adds the specified network(s) to be protected in case of
 // clean
 func (e *Execution) ProtectNetwork(t testingT, networks ...string) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	for _, network := range networks {
 		e.protectedElements.networks[network] = struct{}{}
 	}
@@ -132,11 +157,17 @@ func (e *Execution) ProtectNetwork(t testingT, networks ...string) {
 // ProtectNetworks protects existing networks from being cleaned up at the end
 // of test runs
 func ProtectNetworks(t testingT, testEnv *Execution) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	networks := getExistingNetworks(t, testEnv)
 	testEnv.ProtectNetwork(t, networks...)
 }
 
 func getExistingNetworks(t assert.TestingT, testEnv *Execution) []string {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	client := testEnv.APIClient()
 	networkList, err := client.NetworkList(context.Background(), types.NetworkListOptions{})
 	assert.NilError(t, err, "failed to list networks")
@@ -150,6 +181,9 @@ func getExistingNetworks(t assert.TestingT, testEnv *Execution) []string {
 
 // ProtectPlugin adds the specified plugin(s) to be protected in case of clean
 func (e *Execution) ProtectPlugin(t testingT, plugins ...string) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	for _, plugin := range plugins {
 		e.protectedElements.plugins[plugin] = struct{}{}
 	}
@@ -158,11 +192,17 @@ func (e *Execution) ProtectPlugin(t testingT, plugins ...string) {
 // ProtectPlugins protects existing plugins from being cleaned up at the end of
 // test runs
 func ProtectPlugins(t testingT, testEnv *Execution) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	plugins := getExistingPlugins(t, testEnv)
 	testEnv.ProtectPlugin(t, plugins...)
 }
 
 func getExistingPlugins(t assert.TestingT, testEnv *Execution) []string {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	client := testEnv.APIClient()
 	pluginList, err := client.PluginList(context.Background(), filters.Args{})
 	// Docker EE does not allow cluster-wide plugin management.
@@ -180,6 +220,9 @@ func getExistingPlugins(t assert.TestingT, testEnv *Execution) []string {
 
 // ProtectVolume adds the specified volume(s) to be protected in case of clean
 func (e *Execution) ProtectVolume(t testingT, volumes ...string) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	for _, volume := range volumes {
 		e.protectedElements.volumes[volume] = struct{}{}
 	}
@@ -188,11 +231,17 @@ func (e *Execution) ProtectVolume(t testingT, volumes ...string) {
 // ProtectVolumes protects existing volumes from being cleaned up at the end of
 // test runs
 func ProtectVolumes(t testingT, testEnv *Execution) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	volumes := getExistingVolumes(t, testEnv)
 	testEnv.ProtectVolume(t, volumes...)
 }
 
 func getExistingVolumes(t assert.TestingT, testEnv *Execution) []string {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	client := testEnv.APIClient()
 	volumeList, err := client.VolumeList(context.Background(), filters.Args{})
 	assert.NilError(t, err, "failed to list volumes")

--- a/internal/test/fakecontext/context.go
+++ b/internal/test/fakecontext/context.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/docker/docker/internal/test"
 	"github.com/docker/docker/pkg/archive"
 )
 
@@ -17,6 +18,9 @@ type testingT interface {
 
 // New creates a fake build context
 func New(t testingT, dir string, modifiers ...func(*Fake) error) *Fake {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	fakeContext := &Fake{Dir: dir}
 	if dir == "" {
 		if err := newDir(fakeContext); err != nil {
@@ -116,6 +120,9 @@ func (f *Fake) Close() error {
 
 // AsTarReader returns a ReadCloser with the contents of Dir as a tar archive.
 func (f *Fake) AsTarReader(t testingT) io.ReadCloser {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	reader, err := archive.TarWithOptions(f.Dir, &archive.TarOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create tar from %s: %s", f.Dir, err)

--- a/internal/test/fakegit/fakegit.go
+++ b/internal/test/fakegit/fakegit.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/docker/docker/internal/test"
 	"github.com/docker/docker/internal/test/fakecontext"
 	"github.com/docker/docker/internal/test/fakestorage"
 	"github.com/gotestyourself/gotestyourself/assert"
@@ -63,6 +64,9 @@ func (g *FakeGit) Close() {
 
 // New create a fake git server that can be used for git related tests
 func New(c testingT, name string, files map[string]string, enforceLocalServer bool) *FakeGit {
+	if ht, ok := c.(test.HelperT); ok {
+		ht.Helper()
+	}
 	ctx := fakecontext.New(c, "", fakecontext.WithFiles(files))
 	defer ctx.Close()
 	curdir, err := os.Getwd()

--- a/internal/test/fakestorage/fixtures.go
+++ b/internal/test/fakestorage/fixtures.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/internal/test"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/gotestyourself/gotestyourself/assert"
 )
@@ -17,6 +18,9 @@ import (
 var ensureHTTPServerOnce sync.Once
 
 func ensureHTTPServerImage(t testingT) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	var doIt bool
 	ensureHTTPServerOnce.Do(func() {
 		doIt = true

--- a/internal/test/fakestorage/storage.go
+++ b/internal/test/fakestorage/storage.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/internal/test"
 	"github.com/docker/docker/internal/test/environment"
 	"github.com/docker/docker/internal/test/fakecontext"
 	"github.com/docker/docker/internal/test/request"
@@ -56,6 +57,9 @@ func SetTestEnvironment(env *environment.Execution) {
 
 // New returns a static file server that will be use as build context.
 func New(t testingT, dir string, modifiers ...func(*fakecontext.Fake) error) Fake {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	if testEnv == nil {
 		t.Fatal("fakstorage package requires SetTestEnvironment() to be called before use.")
 	}

--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -1,0 +1,6 @@
+package test
+
+// HelperT is a subset of testing.T that implements the Helper function
+type HelperT interface {
+	Helper()
+}

--- a/internal/test/registry/registry.go
+++ b/internal/test/registry/registry.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/docker/docker/internal/test"
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/opencontainers/go-digest"
 )
@@ -54,6 +55,9 @@ type Config struct {
 
 // NewV2 creates a v2 registry server
 func NewV2(t testingT, ops ...func(*Config)) *V2 {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	c := &Config{
 		registryURL: DefaultURL,
 	}
@@ -135,6 +139,9 @@ http:
 
 // WaitReady waits for the registry to be ready to serve requests (or fail after a while)
 func (r *V2) WaitReady(t testingT) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	var err error
 	for i := 0; i != 50; i++ {
 		if err = r.Ping(); err == nil {
@@ -183,6 +190,9 @@ func (r *V2) getBlobFilename(blobDigest digest.Digest) string {
 
 // ReadBlobContents read the file corresponding to the specified digest
 func (r *V2) ReadBlobContents(t assert.TestingT, blobDigest digest.Digest) []byte {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	// Load the target manifest blob.
 	manifestBlob, err := ioutil.ReadFile(r.getBlobFilename(blobDigest))
 	assert.NilError(t, err, "unable to read blob")
@@ -191,6 +201,9 @@ func (r *V2) ReadBlobContents(t assert.TestingT, blobDigest digest.Digest) []byt
 
 // WriteBlobContents write the file corresponding to the specified digest with the given content
 func (r *V2) WriteBlobContents(t assert.TestingT, blobDigest digest.Digest, data []byte) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	err := ioutil.WriteFile(r.getBlobFilename(blobDigest), data, os.FileMode(0644))
 	assert.NilError(t, err, "unable to write malicious data blob")
 }
@@ -198,6 +211,9 @@ func (r *V2) WriteBlobContents(t assert.TestingT, blobDigest digest.Digest, data
 // TempMoveBlobData moves the existing data file aside, so that we can replace it with a
 // malicious blob of data for example.
 func (r *V2) TempMoveBlobData(t testingT, blobDigest digest.Digest) (undo func()) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	tempFile, err := ioutil.TempFile("", "registry-temp-blob-")
 	assert.NilError(t, err, "unable to get temporary blob file")
 	tempFile.Close()

--- a/internal/test/registry/registry_mock.go
+++ b/internal/test/registry/registry_mock.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/docker/docker/internal/test"
 )
 
 type handlerFunc func(w http.ResponseWriter, r *http.Request)
@@ -27,6 +29,9 @@ func (tr *Mock) RegisterHandler(path string, h handlerFunc) {
 
 // NewMock creates a registry mock
 func NewMock(t testingT) (*Mock, error) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	testReg := &Mock{handlers: make(map[string]handlerFunc)}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/test/request/request.go
+++ b/internal/test/request/request.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/internal/test"
 	"github.com/docker/docker/internal/test/environment"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/ioutils"
@@ -25,6 +26,9 @@ import (
 
 // NewAPIClient returns a docker API client configured from environment variables
 func NewAPIClient(t assert.TestingT, ops ...func(*client.Client) error) client.APIClient {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	ops = append([]func(*client.Client) error{client.FromEnv}, ops...)
 	clt, err := client.NewClientWithOpts(ops...)
 	assert.NilError(t, err)
@@ -33,6 +37,9 @@ func NewAPIClient(t assert.TestingT, ops ...func(*client.Client) error) client.A
 
 // DaemonTime provides the current time on the daemon host
 func DaemonTime(ctx context.Context, t assert.TestingT, client client.APIClient, testEnv *environment.Execution) time.Time {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	if testEnv.IsLocalDaemon() {
 		return time.Now()
 	}
@@ -48,6 +55,9 @@ func DaemonTime(ctx context.Context, t assert.TestingT, client client.APIClient,
 // DaemonUnixTime returns the current time on the daemon host with nanoseconds precision.
 // It return the time formatted how the client sends timestamps to the server.
 func DaemonUnixTime(ctx context.Context, t assert.TestingT, client client.APIClient, testEnv *environment.Execution) string {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	dt := DaemonTime(ctx, t, client, testEnv)
 	return fmt.Sprintf("%d.%09d", dt.Unix(), int64(dt.Nanosecond()))
 }


### PR DESCRIPTION
That way, those lines won't be reported in the failure.

```
Helper marks the calling function as a test helper function. When printing file and line information, that function will be skipped. 
```

:tiger: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
