### PR TITLE
Add FIPS types to the moby types

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2068,6 +2068,11 @@ definitions:
         $ref: "#/definitions/EngineDescription"
       TLSInfo:
         $ref: "#/definitions/TLSInfo"
+      FIPS:
+        type: "boolean"
+        example: true
+        default: false
+        description: Indicates whether the node is running in FIPS mode
 
   Platform:
     description: |

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2421,6 +2421,12 @@ definitions:
         description: "Whether there is currently a root CA rotation in progress for the swarm"
         type: "boolean"
         example: false
+        default: false
+      MandatoryFips:
+        description: "Whether this cluster requires that all nodes be in FIPS mode"
+        type: "boolean"
+        example: true
+        default: false
 
   JoinTokens:
     description: |

--- a/api/types/swarm/node.go
+++ b/api/types/swarm/node.go
@@ -53,6 +53,7 @@ type NodeDescription struct {
 	Resources Resources         `json:",omitempty"`
 	Engine    EngineDescription `json:",omitempty"`
 	TLSInfo   TLSInfo           `json:",omitempty"`
+	FIPS      bool              `json:",omitempty"`
 }
 
 // Platform represents the platform (Arch/OS).

--- a/api/types/swarm/swarm.go
+++ b/api/types/swarm/swarm.go
@@ -10,6 +10,7 @@ type ClusterInfo struct {
 	Spec                   Spec
 	TLSInfo                TLSInfo
 	RootRotationInProgress bool
+	MandatoryFIPS          bool
 }
 
 // Swarm represents a swarm.

--- a/daemon/cluster/convert/node.go
+++ b/daemon/cluster/convert/node.go
@@ -35,6 +35,7 @@ func NodeFromGRPC(n swarmapi.Node) types.Node {
 	//Description
 	if n.Description != nil {
 		node.Description.Hostname = n.Description.Hostname
+		node.Description.FIPS = n.Description.FIPS
 		if n.Description.Platform != nil {
 			node.Description.Platform.Architecture = n.Description.Platform.Architecture
 			node.Description.Platform.OS = n.Description.Platform.OS


### PR DESCRIPTION
This PR adds a FIPS boolean to the node description and cluster info for a swarm.

The node description boolean was added to swarmkit in https://github.com/docker/swarmkit/pull/2587, and was pulled into moby/moby with https://github.com/moby/moby/pull/36880.
The cluster boolean is added here:  https://github.com/docker/swarmkit/pull/2594, and has not yet been merged into swarmkit.

But adding the types now lets us modify the CLI concurrently to display said information.

![cute](https://data.whicdn.com/images/31736497/original.jpg)