### PR TITLE
Switch from x/net/context -> context

### DIFF
--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -1,6 +1,7 @@
 package build // import "github.com/docker/docker/api/server/backend/build"
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/distribution/reference"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // ImageComponent provides an interface for working with images

--- a/api/server/httputils/httputils.go
+++ b/api/server/httputils/httputils.go
@@ -1,6 +1,7 @@
 package httputils // import "github.com/docker/docker/api/server/httputils"
 
 import (
+	"context"
 	"io"
 	"mime"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type contextKey string

--- a/api/server/httputils/write_log_stream.go
+++ b/api/server/httputils/write_log_stream.go
@@ -1,12 +1,11 @@
 package httputils // import "github.com/docker/docker/api/server/httputils"
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/url"
 	"sort"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"

--- a/api/server/middleware/cors.go
+++ b/api/server/middleware/cors.go
@@ -1,10 +1,10 @@
 package middleware // import "github.com/docker/docker/api/server/middleware"
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // CORSMiddleware injects CORS headers to each request

--- a/api/server/middleware/debug.go
+++ b/api/server/middleware/debug.go
@@ -2,6 +2,7 @@ package middleware // import "github.com/docker/docker/api/server/middleware"
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // DebugRequestMiddleware dumps the request to logger

--- a/api/server/middleware/experimental.go
+++ b/api/server/middleware/experimental.go
@@ -1,9 +1,8 @@
 package middleware // import "github.com/docker/docker/api/server/middleware"
 
 import (
+	"context"
 	"net/http"
-
-	"golang.org/x/net/context"
 )
 
 // ExperimentalMiddleware is a the middleware in charge of adding the

--- a/api/server/middleware/middleware.go
+++ b/api/server/middleware/middleware.go
@@ -1,9 +1,8 @@
 package middleware // import "github.com/docker/docker/api/server/middleware"
 
 import (
+	"context"
 	"net/http"
-
-	"golang.org/x/net/context"
 )
 
 // Middleware is an interface to allow the use of ordinary functions as Docker API filters.

--- a/api/server/middleware/version.go
+++ b/api/server/middleware/version.go
@@ -1,13 +1,13 @@
 package middleware // import "github.com/docker/docker/api/server/middleware"
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"runtime"
 
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types/versions"
-	"golang.org/x/net/context"
 )
 
 // VersionMiddleware is a middleware that

--- a/api/server/middleware/version_test.go
+++ b/api/server/middleware/version_test.go
@@ -1,6 +1,7 @@
 package middleware // import "github.com/docker/docker/api/server/middleware"
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestVersionMiddlewareVersion(t *testing.T) {

--- a/api/server/router/build/backend.go
+++ b/api/server/router/build/backend.go
@@ -1,9 +1,10 @@
 package build // import "github.com/docker/docker/api/server/router/build"
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
-	"golang.org/x/net/context"
 )
 
 // Backend abstracts an image builder whose only purpose is to build an image referenced by an imageID.

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -2,6 +2,7 @@ package build // import "github.com/docker/docker/api/server/router/build"
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -25,7 +26,6 @@ import (
 	units "github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type invalidIsolationError string

--- a/api/server/router/checkpoint/checkpoint_routes.go
+++ b/api/server/router/checkpoint/checkpoint_routes.go
@@ -1,12 +1,12 @@
 package checkpoint // import "github.com/docker/docker/api/server/router/checkpoint"
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 func (s *checkpointRouter) postContainerCheckpoint(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -1,9 +1,8 @@
 package container // import "github.com/docker/docker/api/server/router/container"
 
 import (
+	"context"
 	"io"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -1,6 +1,7 @@
 package container // import "github.com/docker/docker/api/server/router/container"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,7 +21,6 @@ import (
 	"github.com/docker/docker/pkg/signal"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"golang.org/x/net/websocket"
 )
 

--- a/api/server/router/container/copy.go
+++ b/api/server/router/container/copy.go
@@ -3,6 +3,7 @@ package container // import "github.com/docker/docker/api/server/router/containe
 import (
 	"compress/flate"
 	"compress/gzip"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	gddohttputil "github.com/golang/gddo/httputil"
-	"golang.org/x/net/context"
 )
 
 type pathError struct{}

--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -1,6 +1,7 @@
 package container // import "github.com/docker/docker/api/server/router/container"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 func (s *containerRouter) getExecByID(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/api/server/router/container/inspect.go
+++ b/api/server/router/container/inspect.go
@@ -1,10 +1,10 @@
 package container // import "github.com/docker/docker/api/server/router/container"
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/docker/docker/api/server/httputils"
-	"golang.org/x/net/context"
 )
 
 // getContainersByName inspects container's configuration and serializes it as json.

--- a/api/server/router/debug/debug.go
+++ b/api/server/router/debug/debug.go
@@ -1,13 +1,13 @@
 package debug // import "github.com/docker/docker/api/server/router/debug"
 
 import (
+	"context"
 	"expvar"
 	"net/http"
 	"net/http/pprof"
 
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/server/router"
-	"golang.org/x/net/context"
 )
 
 // NewRouter creates a new debug router

--- a/api/server/router/debug/debug_routes.go
+++ b/api/server/router/debug/debug_routes.go
@@ -1,10 +1,9 @@
 package debug // import "github.com/docker/docker/api/server/router/debug"
 
 import (
+	"context"
 	"net/http"
 	"net/http/pprof"
-
-	"golang.org/x/net/context"
 )
 
 func handlePprof(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/api/server/router/distribution/backend.go
+++ b/api/server/router/distribution/backend.go
@@ -1,10 +1,11 @@
 package distribution // import "github.com/docker/docker/api/server/router/distribution"
 
 import (
+	"context"
+
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // Backend is all the methods that need to be implemented

--- a/api/server/router/distribution/distribution_routes.go
+++ b/api/server/router/distribution/distribution_routes.go
@@ -1,6 +1,7 @@
 package distribution // import "github.com/docker/docker/api/server/router/distribution"
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -15,7 +16,6 @@ import (
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func (s *distributionRouter) getDistributionInfo(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/api/server/router/experimental.go
+++ b/api/server/router/experimental.go
@@ -1,9 +1,8 @@
 package router // import "github.com/docker/docker/api/server/router"
 
 import (
+	"context"
 	"net/http"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/server/httputils"
 )

--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -1,13 +1,13 @@
 package image // import "github.com/docker/docker/api/server/router/image"
 
 import (
+	"context"
 	"io"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
-	"golang.org/x/net/context"
 )
 
 // Backend is all the methods that need to be implemented

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -1,6 +1,7 @@
 package image // import "github.com/docker/docker/api/server/router/image"
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -19,7 +20,6 @@ import (
 	"github.com/docker/docker/registry"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // Creates an image from Pull or from Import

--- a/api/server/router/local.go
+++ b/api/server/router/local.go
@@ -1,10 +1,10 @@
 package router // import "github.com/docker/docker/api/server/router"
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/docker/docker/api/server/httputils"
-	"golang.org/x/net/context"
 )
 
 // RouteWrapper wraps a route with extra functionality.

--- a/api/server/router/network/backend.go
+++ b/api/server/router/network/backend.go
@@ -1,7 +1,7 @@
 package network // import "github.com/docker/docker/api/server/router/network"
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -1,12 +1,11 @@
 package network // import "github.com/docker/docker/api/server/router/network"
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"

--- a/api/server/router/plugin/backend.go
+++ b/api/server/router/plugin/backend.go
@@ -1,6 +1,7 @@
 package plugin // import "github.com/docker/docker/api/server/router/plugin"
 
 import (
+	"context"
 	"io"
 	"net/http"
 
@@ -8,7 +9,6 @@ import (
 	enginetypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/plugin"
-	"golang.org/x/net/context"
 )
 
 // Backend for Plugin

--- a/api/server/router/plugin/plugin_routes.go
+++ b/api/server/router/plugin/plugin_routes.go
@@ -1,6 +1,7 @@
 package plugin // import "github.com/docker/docker/api/server/router/plugin"
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func parseHeaders(headers http.Header) (map[string][]string, *types.AuthConfig) {

--- a/api/server/router/session/backend.go
+++ b/api/server/router/session/backend.go
@@ -1,9 +1,8 @@
 package session // import "github.com/docker/docker/api/server/router/session"
 
 import (
+	"context"
 	"net/http"
-
-	"golang.org/x/net/context"
 )
 
 // Backend abstracts an session receiver from an http request.

--- a/api/server/router/session/session_routes.go
+++ b/api/server/router/session/session_routes.go
@@ -1,10 +1,10 @@
 package session // import "github.com/docker/docker/api/server/router/session"
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/docker/docker/errdefs"
-	"golang.org/x/net/context"
 )
 
 func (sr *sessionRouter) startSession(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/api/server/router/swarm/backend.go
+++ b/api/server/router/swarm/backend.go
@@ -1,10 +1,11 @@
 package swarm // import "github.com/docker/docker/api/server/router/swarm"
 
 import (
+	"context"
+
 	basictypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	types "github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // Backend abstracts a swarm manager.

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -1,6 +1,7 @@
 package swarm // import "github.com/docker/docker/api/server/router/swarm"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -15,7 +16,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 func (sr *swarmRouter) initCluster(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/api/server/router/swarm/helpers.go
+++ b/api/server/router/swarm/helpers.go
@@ -1,6 +1,7 @@
 package swarm // import "github.com/docker/docker/api/server/router/swarm"
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	basictypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
-	"golang.org/x/net/context"
 )
 
 // swarmLogs takes an http response, request, and selector, and writes the logs

--- a/api/server/router/system/backend.go
+++ b/api/server/router/system/backend.go
@@ -1,13 +1,13 @@
 package system // import "github.com/docker/docker/api/server/router/system"
 
 import (
+	"context"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // Backend is the methods that need to be implemented to provide

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -1,6 +1,7 @@
 package system // import "github.com/docker/docker/api/server/router/system"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -16,7 +17,6 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 func optionsHandler(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/api/server/router/volume/backend.go
+++ b/api/server/router/volume/backend.go
@@ -1,7 +1,7 @@
 package volume // import "github.com/docker/docker/api/server/router/volume"
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	// TODO return types need to be refactored into pkg
 	"github.com/docker/docker/api/types"

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -1,6 +1,7 @@
 package volume // import "github.com/docker/docker/api/server/router/volume"
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/errdefs"
-	"golang.org/x/net/context"
 )
 
 func (v *volumeRouter) getVolumesList(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1,6 +1,7 @@
 package server // import "github.com/docker/docker/api/server"
 
 import (
+	"context"
 	"crypto/tls"
 	"net"
 	"net/http"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/dockerversion"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // versionMatcher defines a variable matcher to be parsed by the router

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 	"testing"
 
+	"context"
+
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/server/middleware"
-
-	"golang.org/x/net/context"
 )
 
 func TestMiddlewares(t *testing.T) {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -5,6 +5,7 @@
 package builder // import "github.com/docker/docker/builder"
 
 import (
+	"context"
 	"io"
 
 	"github.com/docker/docker/api/types"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/containerfs"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -2,6 +2,7 @@ package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -25,7 +26,6 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"golang.org/x/sync/syncmap"
 )
 

--- a/builder/dockerfile/clientsession.go
+++ b/builder/dockerfile/clientsession.go
@@ -1,6 +1,7 @@
 package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 
 import (
+	"context"
 	"time"
 
 	"github.com/docker/docker/builder/fscache"
@@ -8,7 +9,6 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 const sessionConnectTimeout = 5 * time.Second

--- a/builder/dockerfile/containerbackend.go
+++ b/builder/dockerfile/containerbackend.go
@@ -1,6 +1,7 @@
 package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type containerManager struct {

--- a/builder/dockerfile/imagecontext.go
+++ b/builder/dockerfile/imagecontext.go
@@ -1,6 +1,7 @@
 package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 
 import (
+	"context"
 	"runtime"
 
 	"github.com/docker/docker/api/types/backend"
@@ -8,7 +9,6 @@ import (
 	dockerimage "github.com/docker/docker/image"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type getAndMountFunc func(string, bool, string) (builder.Image, builder.ROLayer, error)

--- a/builder/dockerfile/mockbackend_test.go
+++ b/builder/dockerfile/mockbackend_test.go
@@ -1,6 +1,7 @@
 package dockerfile // import "github.com/docker/docker/builder/dockerfile"
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"runtime"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/containerfs"
-	"golang.org/x/net/context"
 )
 
 // MockBackend implements the builder.Backend interface for unit testing

--- a/builder/fscache/fscache.go
+++ b/builder/fscache/fscache.go
@@ -2,6 +2,7 @@ package fscache // import "github.com/docker/docker/builder/fscache"
 
 import (
 	"archive/tar"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"hash"
@@ -22,7 +23,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/tonistiigi/fsutil"
-	"golang.org/x/net/context"
 	"golang.org/x/sync/singleflight"
 )
 

--- a/builder/fscache/fscache_test.go
+++ b/builder/fscache/fscache_test.go
@@ -1,6 +1,7 @@
 package fscache // import "github.com/docker/docker/builder/fscache"
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -10,7 +11,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/moby/buildkit/session/filesync"
-	"golang.org/x/net/context"
 )
 
 func TestFSCache(t *testing.T) {

--- a/client/build_prune.go
+++ b/client/build_prune.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // BuildCachePrune requests the daemon to delete unused cache data

--- a/client/checkpoint_create.go
+++ b/client/checkpoint_create.go
@@ -1,8 +1,9 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // CheckpointCreate creates a checkpoint from the given container with the given name

--- a/client/checkpoint_create_test.go
+++ b/client/checkpoint_create_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 func TestCheckpointCreateError(t *testing.T) {

--- a/client/checkpoint_delete.go
+++ b/client/checkpoint_delete.go
@@ -1,10 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // CheckpointDelete deletes the checkpoint with the given name from the given container

--- a/client/checkpoint_delete_test.go
+++ b/client/checkpoint_delete_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 func TestCheckpointDeleteError(t *testing.T) {

--- a/client/checkpoint_list.go
+++ b/client/checkpoint_list.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // CheckpointList returns the checkpoints of the given container in the docker host

--- a/client/checkpoint_list_test.go
+++ b/client/checkpoint_list_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 func TestCheckpointListError(t *testing.T) {

--- a/client/client.go
+++ b/client/client.go
@@ -42,6 +42,7 @@ For example, to list running containers (the equivalent of "docker ps"):
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -57,7 +58,6 @@ import (
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // ErrRedirect is the error returned by checkRedirect when the request is non-GET.

--- a/client/config_create.go
+++ b/client/config_create.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // ConfigCreate creates a new Config.

--- a/client/config_create_test.go
+++ b/client/config_create_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestConfigCreateUnsupported(t *testing.T) {

--- a/client/config_inspect.go
+++ b/client/config_inspect.go
@@ -2,11 +2,11 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io/ioutil"
 
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // ConfigInspectWithRaw returns the config information with raw data

--- a/client/config_inspect_test.go
+++ b/client/config_inspect_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -13,7 +14,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestConfigInspectNotFound(t *testing.T) {

--- a/client/config_list.go
+++ b/client/config_list.go
@@ -1,13 +1,13 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // ConfigList returns the list of configs.

--- a/client/config_list_test.go
+++ b/client/config_list_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestConfigListUnsupported(t *testing.T) {

--- a/client/config_remove.go
+++ b/client/config_remove.go
@@ -1,6 +1,6 @@
 package client // import "github.com/docker/docker/client"
 
-import "golang.org/x/net/context"
+import "context"
 
 // ConfigRemove removes a Config.
 func (cli *Client) ConfigRemove(ctx context.Context, id string) error {

--- a/client/config_remove_test.go
+++ b/client/config_remove_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestConfigRemoveUnsupported(t *testing.T) {

--- a/client/config_update.go
+++ b/client/config_update.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // ConfigUpdate attempts to update a Config

--- a/client/config_update_test.go
+++ b/client/config_update_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestConfigUpdateUnsupported(t *testing.T) {

--- a/client/container_attach.go
+++ b/client/container_attach.go
@@ -1,10 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // ContainerAttach attaches a connection to a container in the server.

--- a/client/container_commit.go
+++ b/client/container_commit.go
@@ -1,13 +1,13 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/url"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // ContainerCommit applies changes into a container and creates a new tagged image.

--- a/client/container_commit_test.go
+++ b/client/container_commit_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 func TestContainerCommitError(t *testing.T) {

--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -1,6 +1,7 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -9,8 +10,6 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 )

--- a/client/container_copy_test.go
+++ b/client/container_copy_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -9,8 +10,6 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 )

--- a/client/container_create.go
+++ b/client/container_create.go
@@ -1,6 +1,7 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 	"strings"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
-	"golang.org/x/net/context"
 )
 
 type configWrapper struct {

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
-	"golang.org/x/net/context"
 )
 
 func TestContainerCreateError(t *testing.T) {

--- a/client/container_diff.go
+++ b/client/container_diff.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 
 	"github.com/docker/docker/api/types/container"
-	"golang.org/x/net/context"
 )
 
 // ContainerDiff shows differences in a container filesystem since it was started.

--- a/client/container_diff_test.go
+++ b/client/container_diff_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
-	"golang.org/x/net/context"
 )
 
 func TestContainerDiffError(t *testing.T) {

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -1,10 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // ContainerExecCreate creates a new exec configuration to run an exec process.

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -2,14 +2,13 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 )

--- a/client/container_export.go
+++ b/client/container_export.go
@@ -1,10 +1,9 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"io"
 	"net/url"
-
-	"golang.org/x/net/context"
 )
 
 // ContainerExport retrieves the raw contents of a container

--- a/client/container_export_test.go
+++ b/client/container_export_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestContainerExportError(t *testing.T) {

--- a/client/container_inspect.go
+++ b/client/container_inspect.go
@@ -2,12 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // ContainerInspect returns the container information.

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestContainerInspectError(t *testing.T) {

--- a/client/container_kill.go
+++ b/client/container_kill.go
@@ -1,9 +1,8 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
-
-	"golang.org/x/net/context"
 )
 
 // ContainerKill terminates the container process but does not remove the container from the docker host.

--- a/client/container_kill_test.go
+++ b/client/container_kill_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestContainerKillError(t *testing.T) {

--- a/client/container_list.go
+++ b/client/container_list.go
@@ -1,13 +1,13 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 	"strconv"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"golang.org/x/net/context"
 )
 
 // ContainerList returns the list of containers in the docker host.

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"golang.org/x/net/context"
 )
 
 func TestContainerListError(t *testing.T) {

--- a/client/container_logs.go
+++ b/client/container_logs.go
@@ -1,11 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"io"
 	"net/url"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	timetypes "github.com/docker/docker/api/types/time"

--- a/client/container_logs_test.go
+++ b/client/container_logs_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/internal/testutil"
-
-	"golang.org/x/net/context"
 )
 
 func TestContainerLogsNotFoundError(t *testing.T) {

--- a/client/container_pause.go
+++ b/client/container_pause.go
@@ -1,6 +1,6 @@
 package client // import "github.com/docker/docker/client"
 
-import "golang.org/x/net/context"
+import "context"
 
 // ContainerPause pauses the main process of a given container without terminating it.
 func (cli *Client) ContainerPause(ctx context.Context, containerID string) error {

--- a/client/container_pause_test.go
+++ b/client/container_pause_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestContainerPauseError(t *testing.T) {

--- a/client/container_prune.go
+++ b/client/container_prune.go
@@ -1,12 +1,12 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"golang.org/x/net/context"
 )
 
 // ContainersPrune requests the daemon to delete unused data

--- a/client/container_prune_test.go
+++ b/client/container_prune_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestContainersPruneError(t *testing.T) {

--- a/client/container_remove.go
+++ b/client/container_remove.go
@@ -1,10 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // ContainerRemove kills and removes a container from the docker host.

--- a/client/container_remove_test.go
+++ b/client/container_remove_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestContainerRemoveError(t *testing.T) {

--- a/client/container_rename.go
+++ b/client/container_rename.go
@@ -1,9 +1,8 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
-
-	"golang.org/x/net/context"
 )
 
 // ContainerRename changes the name of a given container.

--- a/client/container_rename_test.go
+++ b/client/container_rename_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestContainerRenameError(t *testing.T) {

--- a/client/container_resize.go
+++ b/client/container_resize.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // ContainerResize changes the size of the tty for a container.

--- a/client/container_resize_test.go
+++ b/client/container_resize_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 func TestContainerResizeError(t *testing.T) {

--- a/client/container_restart.go
+++ b/client/container_restart.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
 	"time"
 
 	timetypes "github.com/docker/docker/api/types/time"
-	"golang.org/x/net/context"
 )
 
 // ContainerRestart stops and starts a container again.

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -2,14 +2,13 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func TestContainerRestartError(t *testing.T) {

--- a/client/container_start.go
+++ b/client/container_start.go
@@ -1,9 +1,8 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 )

--- a/client/container_start_test.go
+++ b/client/container_start_test.go
@@ -2,14 +2,13 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 )

--- a/client/container_stats.go
+++ b/client/container_stats.go
@@ -1,10 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // ContainerStats returns near realtime stats for a given container.

--- a/client/container_stats_test.go
+++ b/client/container_stats_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestContainerStatsError(t *testing.T) {

--- a/client/container_stop.go
+++ b/client/container_stop.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
 	"time"
 
 	timetypes "github.com/docker/docker/api/types/time"
-	"golang.org/x/net/context"
 )
 
 // ContainerStop stops a container without terminating the process.

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -2,14 +2,13 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func TestContainerStopError(t *testing.T) {

--- a/client/container_top.go
+++ b/client/container_top.go
@@ -1,12 +1,12 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 	"strings"
 
 	"github.com/docker/docker/api/types/container"
-	"golang.org/x/net/context"
 )
 
 // ContainerTop shows process information from within a container.

--- a/client/container_top_test.go
+++ b/client/container_top_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -11,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
-	"golang.org/x/net/context"
 )
 
 func TestContainerTopError(t *testing.T) {

--- a/client/container_unpause.go
+++ b/client/container_unpause.go
@@ -1,6 +1,6 @@
 package client // import "github.com/docker/docker/client"
 
-import "golang.org/x/net/context"
+import "context"
 
 // ContainerUnpause resumes the process execution within a container
 func (cli *Client) ContainerUnpause(ctx context.Context, containerID string) error {

--- a/client/container_unpause_test.go
+++ b/client/container_unpause_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestContainerUnpauseError(t *testing.T) {

--- a/client/container_update.go
+++ b/client/container_update.go
@@ -1,10 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/docker/docker/api/types/container"
-	"golang.org/x/net/context"
 )
 
 // ContainerUpdate updates resources of a container

--- a/client/container_update_test.go
+++ b/client/container_update_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
-	"golang.org/x/net/context"
 )
 
 func TestContainerUpdateError(t *testing.T) {

--- a/client/container_wait.go
+++ b/client/container_wait.go
@@ -1,10 +1,9 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/versions"

--- a/client/container_wait_test.go
+++ b/client/container_wait_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
+	"context"
 
-	"golang.org/x/net/context"
+	"github.com/docker/docker/api/types/container"
 )
 
 func TestContainerWaitError(t *testing.T) {

--- a/client/disk_usage.go
+++ b/client/disk_usage.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // DiskUsage requests the current data usage from the daemon

--- a/client/disk_usage_test.go
+++ b/client/disk_usage_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 func TestDiskUsageError(t *testing.T) {

--- a/client/distribution_inspect.go
+++ b/client/distribution_inspect.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 
 	registrytypes "github.com/docker/docker/api/types/registry"
-	"golang.org/x/net/context"
 )
 
 // DistributionInspect returns the image digest with full Manifest

--- a/client/distribution_inspect_test.go
+++ b/client/distribution_inspect_test.go
@@ -1,13 +1,13 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestDistributionInspectUnsupported(t *testing.T) {

--- a/client/events.go
+++ b/client/events.go
@@ -1,11 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"

--- a/client/events_test.go
+++ b/client/events_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,8 +10,6 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"

--- a/client/hijack.go
+++ b/client/hijack.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bufio"
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/go-connections/sockets"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // tlsClientCon holds tls information and a dialed connection.

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -1,6 +1,7 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -8,8 +9,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"

--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -2,14 +2,13 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"

--- a/client/image_create.go
+++ b/client/image_create.go
@@ -1,11 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"io"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"

--- a/client/image_create_test.go
+++ b/client/image_create_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 )

--- a/client/image_history.go
+++ b/client/image_history.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 
 	"github.com/docker/docker/api/types/image"
-	"golang.org/x/net/context"
 )
 
 // ImageHistory returns the changes in an image in history format.

--- a/client/image_history_test.go
+++ b/client/image_history_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/image"
-	"golang.org/x/net/context"
 )
 
 func TestImageHistoryError(t *testing.T) {

--- a/client/image_import.go
+++ b/client/image_import.go
@@ -1,11 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"io"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"

--- a/client/image_import_test.go
+++ b/client/image_import_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 func TestImageImportError(t *testing.T) {

--- a/client/image_inspect.go
+++ b/client/image_inspect.go
@@ -2,11 +2,11 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io/ioutil"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // ImageInspectWithRaw returns the image information and its raw representation.

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestImageInspectError(t *testing.T) {

--- a/client/image_list.go
+++ b/client/image_list.go
@@ -1,13 +1,13 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/versions"
-	"golang.org/x/net/context"
 )
 
 // ImageList returns a list of images in the docker host.

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"golang.org/x/net/context"
 )
 
 func TestImageListError(t *testing.T) {

--- a/client/image_load.go
+++ b/client/image_load.go
@@ -1,10 +1,9 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"io"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 )

--- a/client/image_load_test.go
+++ b/client/image_load_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestImageLoadError(t *testing.T) {

--- a/client/image_prune.go
+++ b/client/image_prune.go
@@ -1,12 +1,12 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"golang.org/x/net/context"
 )
 
 // ImagesPrune requests the daemon to delete unused data

--- a/client/image_prune_test.go
+++ b/client/image_prune_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestImagesPruneError(t *testing.T) {

--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -1,12 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"

--- a/client/image_pull_test.go
+++ b/client/image_pull_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 )

--- a/client/image_push.go
+++ b/client/image_push.go
@@ -1,12 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"

--- a/client/image_push_test.go
+++ b/client/image_push_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 )

--- a/client/image_remove.go
+++ b/client/image_remove.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // ImageRemove removes an image from the docker host.

--- a/client/image_remove_test.go
+++ b/client/image_remove_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestImageRemoveError(t *testing.T) {

--- a/client/image_save.go
+++ b/client/image_save.go
@@ -1,10 +1,9 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"io"
 	"net/url"
-
-	"golang.org/x/net/context"
 )
 
 // ImageSave retrieves one or more images from the docker host as an io.ReadCloser.

--- a/client/image_save_test.go
+++ b/client/image_save_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"strings"
 )

--- a/client/image_search.go
+++ b/client/image_search.go
@@ -1,6 +1,7 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
-	"golang.org/x/net/context"
 )
 
 // ImageSearch makes the docker host to search by a term in a remote registry.

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
-	"golang.org/x/net/context"
 )
 
 func TestImageSearchAnyError(t *testing.T) {

--- a/client/image_tag.go
+++ b/client/image_tag.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // ImageTag tags an image in the docker host

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestImageTagError(t *testing.T) {

--- a/client/info.go
+++ b/client/info.go
@@ -1,12 +1,12 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // Info returns information about the docker server.

--- a/client/info_test.go
+++ b/client/info_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 func TestInfoServerError(t *testing.T) {

--- a/client/interface.go
+++ b/client/interface.go
@@ -1,6 +1,7 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"io"
 	"net"
 	"time"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
 	volumetypes "github.com/docker/docker/api/types/volume"
-	"golang.org/x/net/context"
 )
 
 // CommonAPIClient is the common methods between stable and experimental versions of APIClient.

--- a/client/interface_experimental.go
+++ b/client/interface_experimental.go
@@ -1,8 +1,9 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 type apiClientExperimental interface {

--- a/client/login.go
+++ b/client/login.go
@@ -1,13 +1,13 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/registry"
-	"golang.org/x/net/context"
 )
 
 // RegistryLogin authenticates the docker server with a given docker registry.

--- a/client/network_connect.go
+++ b/client/network_connect.go
@@ -1,9 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
-	"golang.org/x/net/context"
 )
 
 // NetworkConnect connects a container to an existent network in the docker host.

--- a/client/network_connect_test.go
+++ b/client/network_connect_test.go
@@ -2,14 +2,13 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"

--- a/client/network_create.go
+++ b/client/network_create.go
@@ -1,10 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // NetworkCreate creates a new network in the docker host.

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 func TestNetworkCreateError(t *testing.T) {

--- a/client/network_disconnect.go
+++ b/client/network_disconnect.go
@@ -1,8 +1,9 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // NetworkDisconnect disconnects a container from an existent network in the docker host.

--- a/client/network_disconnect_test.go
+++ b/client/network_disconnect_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 func TestNetworkDisconnectError(t *testing.T) {

--- a/client/network_inspect.go
+++ b/client/network_inspect.go
@@ -2,12 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // NetworkInspect returns the information for a specific network configured in the docker host.

--- a/client/network_inspect_test.go
+++ b/client/network_inspect_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -14,7 +15,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestNetworkInspectError(t *testing.T) {

--- a/client/network_list.go
+++ b/client/network_list.go
@@ -1,12 +1,12 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"golang.org/x/net/context"
 )
 
 // NetworkList returns the list of networks configured in the docker host.

--- a/client/network_list_test.go
+++ b/client/network_list_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"golang.org/x/net/context"
 )
 
 func TestNetworkListError(t *testing.T) {

--- a/client/network_prune.go
+++ b/client/network_prune.go
@@ -1,12 +1,12 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"golang.org/x/net/context"
 )
 
 // NetworksPrune requests the daemon to delete unused networks

--- a/client/network_prune_test.go
+++ b/client/network_prune_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestNetworksPruneError(t *testing.T) {

--- a/client/network_remove.go
+++ b/client/network_remove.go
@@ -1,6 +1,6 @@
 package client // import "github.com/docker/docker/client"
 
-import "golang.org/x/net/context"
+import "context"
 
 // NetworkRemove removes an existent network from the docker host.
 func (cli *Client) NetworkRemove(ctx context.Context, networkID string) error {

--- a/client/network_remove_test.go
+++ b/client/network_remove_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestNetworkRemoveError(t *testing.T) {

--- a/client/node_inspect.go
+++ b/client/node_inspect.go
@@ -2,11 +2,11 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io/ioutil"
 
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // NodeInspectWithRaw returns the node information.

--- a/client/node_inspect_test.go
+++ b/client/node_inspect_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestNodeInspectError(t *testing.T) {

--- a/client/node_list.go
+++ b/client/node_list.go
@@ -1,13 +1,13 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // NodeList returns the list of nodes.

--- a/client/node_list_test.go
+++ b/client/node_list_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 func TestNodeListError(t *testing.T) {

--- a/client/node_remove.go
+++ b/client/node_remove.go
@@ -3,9 +3,9 @@ package client // import "github.com/docker/docker/client"
 import (
 	"net/url"
 
-	"github.com/docker/docker/api/types"
+	"context"
 
-	"golang.org/x/net/context"
+	"github.com/docker/docker/api/types"
 )
 
 // NodeRemove removes a Node.

--- a/client/node_remove_test.go
+++ b/client/node_remove_test.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"context"
 
-	"golang.org/x/net/context"
+	"github.com/docker/docker/api/types"
 )
 
 func TestNodeRemoveError(t *testing.T) {

--- a/client/node_update.go
+++ b/client/node_update.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // NodeUpdate updates a Node.

--- a/client/node_update_test.go
+++ b/client/node_update_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types/swarm"
 )

--- a/client/ping.go
+++ b/client/ping.go
@@ -1,10 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"path"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // Ping pings the server and returns the value of the "Docker-Experimental", "OS-Type" & "API-Version" headers

--- a/client/ping_test.go
+++ b/client/ping_test.go
@@ -1,6 +1,7 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 // TestPingFail tests that when a server sends a non-successful response that we

--- a/client/plugin_create.go
+++ b/client/plugin_create.go
@@ -1,12 +1,12 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // PluginCreate creates a plugin

--- a/client/plugin_disable.go
+++ b/client/plugin_disable.go
@@ -1,10 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // PluginDisable disables a plugin

--- a/client/plugin_disable_test.go
+++ b/client/plugin_disable_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 func TestPluginDisableError(t *testing.T) {

--- a/client/plugin_enable.go
+++ b/client/plugin_enable.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // PluginEnable enables a plugin

--- a/client/plugin_enable_test.go
+++ b/client/plugin_enable_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 func TestPluginEnableError(t *testing.T) {

--- a/client/plugin_inspect.go
+++ b/client/plugin_inspect.go
@@ -2,11 +2,11 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io/ioutil"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // PluginInspectWithRaw inspects an existing plugin

--- a/client/plugin_inspect_test.go
+++ b/client/plugin_inspect_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestPluginInspectError(t *testing.T) {

--- a/client/plugin_install.go
+++ b/client/plugin_install.go
@@ -1,6 +1,7 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // PluginInstall installs a plugin

--- a/client/plugin_list.go
+++ b/client/plugin_list.go
@@ -1,12 +1,12 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"golang.org/x/net/context"
 )
 
 // PluginList returns the installed plugins

--- a/client/plugin_list_test.go
+++ b/client/plugin_list_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"golang.org/x/net/context"
 )
 
 func TestPluginListError(t *testing.T) {

--- a/client/plugin_push.go
+++ b/client/plugin_push.go
@@ -1,9 +1,8 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"io"
-
-	"golang.org/x/net/context"
 )
 
 // PluginPush pushes a plugin to a registry

--- a/client/plugin_push_test.go
+++ b/client/plugin_push_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestPluginPushError(t *testing.T) {

--- a/client/plugin_remove.go
+++ b/client/plugin_remove.go
@@ -1,10 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // PluginRemove removes a plugin

--- a/client/plugin_remove_test.go
+++ b/client/plugin_remove_test.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"context"
 
-	"golang.org/x/net/context"
+	"github.com/docker/docker/api/types"
 )
 
 func TestPluginRemoveError(t *testing.T) {

--- a/client/plugin_set.go
+++ b/client/plugin_set.go
@@ -1,7 +1,7 @@
 package client // import "github.com/docker/docker/client"
 
 import (
-	"golang.org/x/net/context"
+	"context"
 )
 
 // PluginSet modifies settings for an existing plugin

--- a/client/plugin_set_test.go
+++ b/client/plugin_set_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestPluginSetError(t *testing.T) {

--- a/client/plugin_upgrade.go
+++ b/client/plugin_upgrade.go
@@ -1,13 +1,13 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"io"
 	"net/url"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // PluginUpgrade upgrades a plugin

--- a/client/request.go
+++ b/client/request.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,7 +16,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"golang.org/x/net/context/ctxhttp"
 )
 

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/gotestyourself/gotestyourself/assert"
-	"golang.org/x/net/context"
 )
 
 // TestSetHostHeader should set fake host for local communications, set real host

--- a/client/secret_create.go
+++ b/client/secret_create.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // SecretCreate creates a new Secret.

--- a/client/secret_create_test.go
+++ b/client/secret_create_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestSecretCreateUnsupported(t *testing.T) {

--- a/client/secret_inspect.go
+++ b/client/secret_inspect.go
@@ -2,11 +2,11 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io/ioutil"
 
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // SecretInspectWithRaw returns the secret information with raw data

--- a/client/secret_inspect_test.go
+++ b/client/secret_inspect_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -13,7 +14,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestSecretInspectUnsupported(t *testing.T) {

--- a/client/secret_list.go
+++ b/client/secret_list.go
@@ -1,13 +1,13 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // SecretList returns the list of secrets.

--- a/client/secret_list_test.go
+++ b/client/secret_list_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestSecretListUnsupported(t *testing.T) {

--- a/client/secret_remove.go
+++ b/client/secret_remove.go
@@ -1,6 +1,6 @@
 package client // import "github.com/docker/docker/client"
 
-import "golang.org/x/net/context"
+import "context"
 
 // SecretRemove removes a Secret.
 func (cli *Client) SecretRemove(ctx context.Context, id string) error {

--- a/client/secret_remove_test.go
+++ b/client/secret_remove_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestSecretRemoveUnsupported(t *testing.T) {

--- a/client/secret_update.go
+++ b/client/secret_update.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // SecretUpdate attempts to update a Secret

--- a/client/secret_update_test.go
+++ b/client/secret_update_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestSecretUpdateUnsupported(t *testing.T) {

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -1,6 +1,7 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // ServiceCreate creates a new Service.

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -16,7 +17,6 @@ import (
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go/v1"
-	"golang.org/x/net/context"
 )
 
 func TestServiceCreateError(t *testing.T) {

--- a/client/service_inspect.go
+++ b/client/service_inspect.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // ServiceInspectWithRaw returns the service information and the raw data.

--- a/client/service_inspect_test.go
+++ b/client/service_inspect_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestServiceInspectError(t *testing.T) {

--- a/client/service_list.go
+++ b/client/service_list.go
@@ -1,13 +1,13 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // ServiceList returns the list of services.

--- a/client/service_list_test.go
+++ b/client/service_list_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 func TestServiceListError(t *testing.T) {

--- a/client/service_logs.go
+++ b/client/service_logs.go
@@ -1,11 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"io"
 	"net/url"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	timetypes "github.com/docker/docker/api/types/time"

--- a/client/service_logs_test.go
+++ b/client/service_logs_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
+	"context"
 
-	"golang.org/x/net/context"
+	"github.com/docker/docker/api/types"
 )
 
 func TestServiceLogsError(t *testing.T) {

--- a/client/service_remove.go
+++ b/client/service_remove.go
@@ -1,6 +1,6 @@
 package client // import "github.com/docker/docker/client"
 
-import "golang.org/x/net/context"
+import "context"
 
 // ServiceRemove kills and removes a service.
 func (cli *Client) ServiceRemove(ctx context.Context, serviceID string) error {

--- a/client/service_remove_test.go
+++ b/client/service_remove_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestServiceRemoveError(t *testing.T) {

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -1,13 +1,13 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 	"strconv"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // ServiceUpdate updates a Service.

--- a/client/service_update_test.go
+++ b/client/service_update_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"

--- a/client/session.go
+++ b/client/session.go
@@ -1,10 +1,9 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net"
 	"net/http"
-
-	"golang.org/x/net/context"
 )
 
 // DialSession returns a connection that can be used communication with daemon

--- a/client/swarm_get_unlock_key.go
+++ b/client/swarm_get_unlock_key.go
@@ -1,10 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // SwarmGetUnlockKey retrieves the swarm's unlock key.

--- a/client/swarm_get_unlock_key_test.go
+++ b/client/swarm_get_unlock_key_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/internal/testutil"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestSwarmGetUnlockKeyError(t *testing.T) {

--- a/client/swarm_init.go
+++ b/client/swarm_init.go
@@ -1,10 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // SwarmInit initializes the swarm.

--- a/client/swarm_init_test.go
+++ b/client/swarm_init_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types/swarm"
 )

--- a/client/swarm_inspect.go
+++ b/client/swarm_inspect.go
@@ -1,10 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // SwarmInspect inspects the swarm.

--- a/client/swarm_inspect_test.go
+++ b/client/swarm_inspect_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 func TestSwarmInspectError(t *testing.T) {

--- a/client/swarm_join.go
+++ b/client/swarm_join.go
@@ -1,8 +1,9 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // SwarmJoin joins the swarm.

--- a/client/swarm_join_test.go
+++ b/client/swarm_join_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types/swarm"
 )

--- a/client/swarm_leave.go
+++ b/client/swarm_leave.go
@@ -1,9 +1,8 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
-
-	"golang.org/x/net/context"
 )
 
 // SwarmLeave leaves the swarm.

--- a/client/swarm_leave_test.go
+++ b/client/swarm_leave_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestSwarmLeaveError(t *testing.T) {

--- a/client/swarm_unlock.go
+++ b/client/swarm_unlock.go
@@ -1,8 +1,9 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // SwarmUnlock unlocks locked swarm.

--- a/client/swarm_unlock_test.go
+++ b/client/swarm_unlock_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types/swarm"
 )

--- a/client/swarm_update.go
+++ b/client/swarm_update.go
@@ -1,12 +1,12 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strconv"
 
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // SwarmUpdate updates the swarm.

--- a/client/swarm_update_test.go
+++ b/client/swarm_update_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types/swarm"
 )

--- a/client/task_inspect.go
+++ b/client/task_inspect.go
@@ -2,11 +2,11 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io/ioutil"
 
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // TaskInspectWithRaw returns the task information and its raw representation..

--- a/client/task_inspect_test.go
+++ b/client/task_inspect_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestTaskInspectError(t *testing.T) {

--- a/client/task_list.go
+++ b/client/task_list.go
@@ -1,13 +1,13 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 // TaskList returns the list of tasks.

--- a/client/task_list_test.go
+++ b/client/task_list_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 func TestTaskListError(t *testing.T) {

--- a/client/task_logs.go
+++ b/client/task_logs.go
@@ -1,11 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"io"
 	"net/url"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	timetypes "github.com/docker/docker/api/types/time"

--- a/client/version.go
+++ b/client/version.go
@@ -1,10 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // ServerVersion returns information of the docker client and server host.

--- a/client/volume_create.go
+++ b/client/volume_create.go
@@ -1,11 +1,11 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/docker/docker/api/types"
 	volumetypes "github.com/docker/docker/api/types/volume"
-	"golang.org/x/net/context"
 )
 
 // VolumeCreate creates a volume in the docker host.

--- a/client/volume_create_test.go
+++ b/client/volume_create_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	volumetypes "github.com/docker/docker/api/types/volume"
-	"golang.org/x/net/context"
 )
 
 func TestVolumeCreateError(t *testing.T) {

--- a/client/volume_inspect.go
+++ b/client/volume_inspect.go
@@ -2,11 +2,11 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io/ioutil"
 
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // VolumeInspect returns the information about a specific volume in the docker host.

--- a/client/volume_inspect_test.go
+++ b/client/volume_inspect_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -14,7 +15,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestVolumeInspectError(t *testing.T) {

--- a/client/volume_list.go
+++ b/client/volume_list.go
@@ -1,12 +1,12 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 
 	"github.com/docker/docker/api/types/filters"
 	volumetypes "github.com/docker/docker/api/types/volume"
-	"golang.org/x/net/context"
 )
 
 // VolumeList returns the volumes configured in the docker host.

--- a/client/volume_list_test.go
+++ b/client/volume_list_test.go
@@ -2,6 +2,7 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	volumetypes "github.com/docker/docker/api/types/volume"
-	"golang.org/x/net/context"
 )
 
 func TestVolumeListError(t *testing.T) {

--- a/client/volume_prune.go
+++ b/client/volume_prune.go
@@ -1,12 +1,12 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"golang.org/x/net/context"
 )
 
 // VolumesPrune requests the daemon to delete unused data

--- a/client/volume_remove.go
+++ b/client/volume_remove.go
@@ -1,10 +1,10 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/docker/docker/api/types/versions"
-	"golang.org/x/net/context"
 )
 
 // VolumeRemove removes a volume from the docker host.

--- a/client/volume_remove_test.go
+++ b/client/volume_remove_test.go
@@ -2,13 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestVolumeRemoveError(t *testing.T) {

--- a/container/container.go
+++ b/container/container.go
@@ -2,6 +2,7 @@ package container // import "github.com/docker/docker/container"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -47,7 +48,6 @@ import (
 	agentexec "github.com/docker/swarmkit/agent/exec"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const configFileName = "config.v2.json"

--- a/container/state.go
+++ b/container/state.go
@@ -1,12 +1,11 @@
 package container // import "github.com/docker/docker/container"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/go-units"

--- a/container/stream/attach.go
+++ b/container/stream/attach.go
@@ -1,10 +1,9 @@
 package stream // import "github.com/docker/docker/container/stream"
 
 import (
+	"context"
 	"io"
 	"sync"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/pkg/pools"
 	"github.com/docker/docker/pkg/term"

--- a/daemon/auth.go
+++ b/daemon/auth.go
@@ -1,7 +1,7 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/dockerversion"

--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -39,6 +39,7 @@ package cluster // import "github.com/docker/docker/daemon/cluster"
 //
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -56,7 +57,6 @@ import (
 	swarmnode "github.com/docker/swarmkit/node"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const swarmDirName = "swarm"

--- a/daemon/cluster/configs.go
+++ b/daemon/cluster/configs.go
@@ -1,11 +1,12 @@
 package cluster // import "github.com/docker/docker/daemon/cluster"
 
 import (
+	"context"
+
 	apitypes "github.com/docker/docker/api/types"
 	types "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/daemon/cluster/convert"
 	swarmapi "github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 // GetConfig returns a config from a managed swarm cluster

--- a/daemon/cluster/controllers/plugin/controller.go
+++ b/daemon/cluster/controllers/plugin/controller.go
@@ -1,6 +1,7 @@
 package plugin // import "github.com/docker/docker/daemon/cluster/controllers/plugin"
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -15,7 +16,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // Controller is the controller for the plugin backend.

--- a/daemon/cluster/controllers/plugin/controller_test.go
+++ b/daemon/cluster/controllers/plugin/controller_test.go
@@ -1,6 +1,7 @@
 package plugin // import "github.com/docker/docker/daemon/cluster/controllers/plugin"
 
 import (
+	"context"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -16,7 +17,6 @@ import (
 	"github.com/docker/docker/plugin"
 	"github.com/docker/docker/plugin/v2"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -1,6 +1,7 @@
 package executor // import "github.com/docker/docker/daemon/cluster/executor"
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -21,7 +22,6 @@ import (
 	"github.com/docker/libnetwork/cluster"
 	networktypes "github.com/docker/libnetwork/types"
 	"github.com/docker/swarmkit/agent/exec"
-	"golang.org/x/net/context"
 )
 
 // Backend defines the executor component for a swarm agent.

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -1,6 +1,7 @@
 package container // import "github.com/docker/docker/daemon/cluster/executor/container"
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -28,7 +29,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"golang.org/x/time/rate"
 )
 

--- a/daemon/cluster/executor/container/attachment.go
+++ b/daemon/cluster/executor/container/attachment.go
@@ -1,10 +1,11 @@
 package container // import "github.com/docker/docker/daemon/cluster/executor/container"
 
 import (
+	"context"
+
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 // networkAttacherController implements agent.Controller against docker's API.

--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -1,6 +1,7 @@
 package container // import "github.com/docker/docker/daemon/cluster/executor/container"
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -17,7 +18,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"golang.org/x/time/rate"
 )
 

--- a/daemon/cluster/executor/container/executor.go
+++ b/daemon/cluster/executor/container/executor.go
@@ -1,6 +1,7 @@
 package container // import "github.com/docker/docker/daemon/cluster/executor/container"
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -21,7 +22,6 @@ import (
 	"github.com/docker/swarmkit/api/naming"
 	"github.com/docker/swarmkit/template"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type executor struct {

--- a/daemon/cluster/executor/container/health_test.go
+++ b/daemon/cluster/executor/container/health_test.go
@@ -3,6 +3,7 @@
 package container // import "github.com/docker/docker/daemon/cluster/executor/container"
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 func TestHealthStates(t *testing.T) {

--- a/daemon/cluster/helpers.go
+++ b/daemon/cluster/helpers.go
@@ -1,12 +1,12 @@
 package cluster // import "github.com/docker/docker/daemon/cluster"
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/docker/errdefs"
 	swarmapi "github.com/docker/swarmkit/api"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func getSwarm(ctx context.Context, c swarmapi.ControlClient) (*swarmapi.Cluster, error) {

--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -1,6 +1,7 @@
 package cluster // import "github.com/docker/docker/daemon/cluster"
 
 import (
+	"context"
 	"fmt"
 
 	apitypes "github.com/docker/docker/api/types"
@@ -12,7 +13,6 @@ import (
 	swarmapi "github.com/docker/swarmkit/api"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // GetNetworks returns all current cluster managed networks.

--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -1,6 +1,7 @@
 package cluster // import "github.com/docker/docker/daemon/cluster"
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -15,7 +16,6 @@ import (
 	swarmnode "github.com/docker/swarmkit/node"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/daemon/cluster/nodes.go
+++ b/daemon/cluster/nodes.go
@@ -1,12 +1,13 @@
 package cluster // import "github.com/docker/docker/daemon/cluster"
 
 import (
+	"context"
+
 	apitypes "github.com/docker/docker/api/types"
 	types "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/daemon/cluster/convert"
 	"github.com/docker/docker/errdefs"
 	swarmapi "github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 // GetNodes returns a list of all nodes known to a cluster.

--- a/daemon/cluster/secrets.go
+++ b/daemon/cluster/secrets.go
@@ -1,11 +1,12 @@
 package cluster // import "github.com/docker/docker/daemon/cluster"
 
 import (
+	"context"
+
 	apitypes "github.com/docker/docker/api/types"
 	types "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/daemon/cluster/convert"
 	swarmapi "github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 // GetSecret returns a secret from a managed swarm cluster

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -1,6 +1,7 @@
 package cluster // import "github.com/docker/docker/daemon/cluster"
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -22,7 +23,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // GetServices returns all services of a managed swarm cluster.

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -1,6 +1,7 @@
 package cluster // import "github.com/docker/docker/daemon/cluster"
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -18,7 +19,6 @@ import (
 	swarmnode "github.com/docker/swarmkit/node"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // Init initializes new cluster from user provided request.

--- a/daemon/cluster/tasks.go
+++ b/daemon/cluster/tasks.go
@@ -1,12 +1,13 @@
 package cluster // import "github.com/docker/docker/daemon/cluster"
 
 import (
+	"context"
+
 	apitypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	types "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/daemon/cluster/convert"
 	swarmapi "github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 // GetTasks returns a list of tasks matching the filter options.

--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -1,10 +1,9 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -1,12 +1,11 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/strslice"

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -2,13 +2,12 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"

--- a/daemon/images/image_builder.go
+++ b/daemon/images/image_builder.go
@@ -1,6 +1,7 @@
 package images // import "github.com/docker/docker/daemon/images"
 
 import (
+	"context"
 	"io"
 
 	"github.com/docker/distribution/reference"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 type roLayer struct {

--- a/daemon/images/image_prune.go
+++ b/daemon/images/image_prune.go
@@ -1,6 +1,7 @@
 package images // import "github.com/docker/docker/daemon/images"
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/layer"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var imagesAcceptedFilters = map[string]bool{

--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -1,6 +1,7 @@
 package images // import "github.com/docker/docker/daemon/images"
 
 import (
+	"context"
 	"io"
 	"runtime"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/registry"
 	"github.com/opencontainers/go-digest"
-	"golang.org/x/net/context"
 )
 
 // PullImage initiates a pull operation. image is the repository name to pull, and

--- a/daemon/images/image_push.go
+++ b/daemon/images/image_push.go
@@ -1,6 +1,7 @@
 package images // import "github.com/docker/docker/daemon/images"
 
 import (
+	"context"
 	"io"
 
 	"github.com/docker/distribution/manifest/schema2"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/docker/distribution"
 	progressutils "github.com/docker/docker/distribution/utils"
 	"github.com/docker/docker/pkg/progress"
-	"golang.org/x/net/context"
 )
 
 // PushImage initiates a push operation on the repository named localName.

--- a/daemon/images/image_search.go
+++ b/daemon/images/image_search.go
@@ -1,9 +1,8 @@
 package images // import "github.com/docker/docker/daemon/images"
 
 import (
+	"context"
 	"strconv"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"

--- a/daemon/images/image_search_test.go
+++ b/daemon/images/image_search_test.go
@@ -1,11 +1,10 @@
 package images // import "github.com/docker/docker/daemon/images"
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"

--- a/daemon/logger/gcplogs/gcplogging.go
+++ b/daemon/logger/gcplogs/gcplogging.go
@@ -6,12 +6,13 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
+
 	"github.com/docker/docker/daemon/logger"
 
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/logging"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	mrpb "google.golang.org/genproto/googleapis/api/monitoredres"
 )
 

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -1,10 +1,9 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
 	"strconv"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -1,6 +1,7 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"runtime"
@@ -21,7 +22,6 @@ import (
 	networktypes "github.com/docker/libnetwork/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // PredefinedNetworkError is returned when user tries to create predefined network that already exists.

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -1,6 +1,7 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"sync/atomic"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/volume"
 	"github.com/docker/libnetwork"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -1,12 +1,11 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"runtime"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"

--- a/daemon/wait.go
+++ b/daemon/wait.go
@@ -1,8 +1,9 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
+
 	"github.com/docker/docker/container"
-	"golang.org/x/net/context"
 )
 
 // ContainerWait waits until the given container is in a certain state

--- a/distribution/config.go
+++ b/distribution/config.go
@@ -1,6 +1,7 @@
 package distribution // import "github.com/docker/docker/distribution"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,7 +21,6 @@ import (
 	"github.com/docker/libtrust"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
-	"golang.org/x/net/context"
 )
 
 // Config stores configuration for communicating

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -1,6 +1,7 @@
 package distribution // import "github.com/docker/docker/distribution"
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // Puller is an interface that abstracts pulling for different API versions.

--- a/distribution/pull_v1.go
+++ b/distribution/pull_v1.go
@@ -1,6 +1,7 @@
 package distribution // import "github.com/docker/docker/distribution"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -25,7 +26,6 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/registry"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type v1Puller struct {

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -1,6 +1,7 @@
 package distribution // import "github.com/docker/docker/distribution"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -33,7 +34,6 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -3,6 +3,7 @@ package distribution // import "github.com/docker/docker/distribution"
 import (
 	"bufio"
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/registry"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // Pusher is an interface that abstracts pushing for different API versions.

--- a/distribution/push_v1.go
+++ b/distribution/push_v1.go
@@ -1,6 +1,7 @@
 package distribution // import "github.com/docker/docker/distribution"
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/docker/docker/registry"
 	"github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type v1Pusher struct {

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -1,6 +1,7 @@
 package distribution // import "github.com/docker/docker/distribution"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -8,8 +9,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/schema1"

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -1,6 +1,7 @@
 package distribution // import "github.com/docker/docker/distribution"
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -16,7 +17,6 @@ import (
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/registry"
 	"github.com/docker/go-connections/sockets"
-	"golang.org/x/net/context"
 )
 
 // ImageTypes represents the schema2 config types for images

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -1,6 +1,7 @@
 package distribution // import "github.com/docker/docker/distribution"
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13,7 +14,6 @@ import (
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/registry"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const secretRegistryToken = "mysecrettoken"

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -1,6 +1,7 @@
 package xfer // import "github.com/docker/docker/distribution/xfer"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -15,7 +16,6 @@ import (
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/system"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const maxDownloadAttempts = 5

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -2,6 +2,7 @@ package xfer // import "github.com/docker/docker/distribution/xfer"
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -16,7 +17,6 @@ import (
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/opencontainers/go-digest"
-	"golang.org/x/net/context"
 )
 
 const maxDownloadConcurrency = 3

--- a/distribution/xfer/transfer.go
+++ b/distribution/xfer/transfer.go
@@ -1,11 +1,11 @@
 package xfer // import "github.com/docker/docker/distribution/xfer"
 
 import (
+	"context"
 	"runtime"
 	"sync"
 
 	"github.com/docker/docker/pkg/progress"
-	"golang.org/x/net/context"
 )
 
 // DoNotRetry is an error wrapper indicating that the error cannot be resolved

--- a/distribution/xfer/upload.go
+++ b/distribution/xfer/upload.go
@@ -1,6 +1,7 @@
 package xfer // import "github.com/docker/docker/distribution/xfer"
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const maxUploadAttempts = 5

--- a/distribution/xfer/upload_test.go
+++ b/distribution/xfer/upload_test.go
@@ -1,6 +1,7 @@
 package xfer // import "github.com/docker/docker/distribution/xfer"
 
 import (
+	"context"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/progress"
-	"golang.org/x/net/context"
 )
 
 const maxUploadConcurrency = 3

--- a/dockerversion/useragent.go
+++ b/dockerversion/useragent.go
@@ -1,12 +1,12 @@
 package dockerversion // import "github.com/docker/docker/dockerversion"
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/useragent"
-	"golang.org/x/net/context"
 )
 
 // UAStringKey is used as key type for user-agent string in net/context struct

--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http/httptest"
@@ -24,7 +25,6 @@ import (
 	"github.com/docker/docker/internal/test/registry"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/go-check/check"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/integration-cli/daemon/daemon_swarm.go
+++ b/integration-cli/daemon/daemon_swarm.go
@@ -1,6 +1,7 @@
 package daemon // import "github.com/docker/docker/integration-cli/daemon"
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/assert"
-	"golang.org/x/net/context"
 )
 
 // CheckServiceTasksInState returns the number of tasks with a matching state,

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,7 +21,6 @@ import (
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func (s *DockerSuite) TestBuildAPIDockerFileRemote(c *check.C) {

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -34,7 +35,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/poll"
-	"golang.org/x/net/context"
 )
 
 func (s *DockerSuite) TestContainerAPIGetAll(c *check.C) {

--- a/integration-cli/docker_api_containers_windows_test.go
+++ b/integration-cli/docker_api_containers_windows_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -15,7 +16,6 @@ import (
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func (s *DockerSuite) TestContainersAPICreateMountsBindNamedPipe(c *check.C) {

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -17,7 +18,6 @@ import (
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/go-check/check"
-	"golang.org/x/net/context"
 )
 
 // Regression test for #9414

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/go-check/check"
-	"golang.org/x/net/context"
 )
 
 func (s *DockerSuite) TestAPIImagesFilter(c *check.C) {

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -1,10 +1,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions/v1p20"

--- a/integration-cli/docker_api_ipcmode_test.go
+++ b/integration-cli/docker_api_ipcmode_test.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/go-check/check"
-	"golang.org/x/net/context"
 )
 
 /* testIpcCheckDevExists checks whether a given mount (identified by its

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -17,7 +18,6 @@ import (
 	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/go-check/check"
-	"golang.org/x/net/context"
 )
 
 func (s *DockerSuite) TestLogsAPIWithStdout(c *check.C) {

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -17,7 +18,6 @@ import (
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/go-check/check"
-	"golang.org/x/net/context"
 )
 
 var expectedNetworkInterfaceStats = strings.Split("rx_bytes rx_dropped rx_errors rx_packets tx_bytes tx_dropped tx_errors tx_packets", " ")

--- a/integration-cli/docker_api_swarm_service_test.go
+++ b/integration-cli/docker_api_swarm_service_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -17,7 +18,6 @@ import (
 	testdaemon "github.com/docker/docker/internal/test/daemon"
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/icmd"
-	"golang.org/x/net/context"
 	"golang.org/x/sys/unix"
 )
 

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -27,7 +28,6 @@ import (
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 var defaultReconciliationTimeout = 30 * time.Second

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,7 +21,6 @@ import (
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/icmd"
-	"golang.org/x/net/context"
 )
 
 func (s *DockerSuite) TestEventsTimestampFormats(c *check.C) {

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -20,7 +21,6 @@ import (
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/icmd"
-	"golang.org/x/net/context"
 )
 
 func (s *DockerSuite) TestExec(c *check.C) {

--- a/integration-cli/docker_cli_plugins_logdriver_test.go
+++ b/integration-cli/docker_cli_plugins_logdriver_test.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"context"
 	"strings"
 
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/go-check/check"
-	"golang.org/x/net/context"
 )
 
 func (s *DockerSuite) TestPluginLogDriver(c *check.C) {

--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -16,7 +17,6 @@ import (
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/internal/test/fixtures/plugin"
 	"github.com/go-check/check"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -36,7 +37,6 @@ import (
 	"github.com/docker/libnetwork/types"
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/icmd"
-	"golang.org/x/net/context"
 )
 
 // "test123" should be printed by docker run

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -29,7 +30,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/fs"
 	"github.com/gotestyourself/gotestyourself/icmd"
 	"github.com/vishvananda/netlink"
-	"golang.org/x/net/context"
 )
 
 func (s *DockerSwarmSuite) TestSwarmUpdate(c *check.C) {

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -16,7 +17,6 @@ import (
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/icmd"
-	"golang.org/x/net/context"
 )
 
 func (s *DockerSuite) TestVolumeCLICreate(c *check.C) {

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,7 +22,6 @@ import (
 	"github.com/docker/docker/internal/test/request"
 	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/icmd"
-	"golang.org/x/net/context"
 )
 
 // Deprecated

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -2,6 +2,7 @@ package config // import "github.com/docker/docker/integration/config"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"sort"
 	"testing"
@@ -17,7 +18,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/skip"
-	"golang.org/x/net/context"
 )
 
 func TestConfigList(t *testing.T) {

--- a/integration/internal/container/exec.go
+++ b/integration/internal/container/exec.go
@@ -2,11 +2,11 @@ package container
 
 import (
 	"bytes"
+	"context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
-	"golang.org/x/net/context"
 )
 
 // ExecResult represents a result returned from Exec()

--- a/integration/internal/container/states.go
+++ b/integration/internal/container/states.go
@@ -1,11 +1,11 @@
 package container
 
 import (
+	"context"
 	"strings"
 
 	"github.com/docker/docker/client"
 	"github.com/gotestyourself/gotestyourself/poll"
-	"golang.org/x/net/context"
 )
 
 // IsStopped verifies the container is in stopped state.

--- a/integration/network/inspect_test.go
+++ b/integration/network/inspect_test.go
@@ -1,6 +1,7 @@
 package network // import "github.com/docker/docker/integration/network"
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/docker/integration/internal/swarm"
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/gotestyourself/gotestyourself/poll"
-	"golang.org/x/net/context"
 )
 
 const defaultSwarmPort = 2477

--- a/integration/network/ipvlan/ipvlan_test.go
+++ b/integration/network/ipvlan/ipvlan_test.go
@@ -1,6 +1,7 @@
 package ipvlan
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/internal/test/daemon"
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/gotestyourself/gotestyourself/skip"
-	"golang.org/x/net/context"
 )
 
 func TestDockerNetworkIpvlanPersistance(t *testing.T) {

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -1,6 +1,7 @@
 package network // import "github.com/docker/docker/integration/network"
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/docker/integration/internal/swarm"
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/gotestyourself/gotestyourself/poll"
-	"golang.org/x/net/context"
 )
 
 func TestServiceWithPredefinedNetwork(t *testing.T) {

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -2,6 +2,7 @@ package secret // import "github.com/docker/docker/integration/secret"
 
 import (
 	"bytes"
+	"context"
 	"sort"
 	"testing"
 	"time"
@@ -16,7 +17,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/skip"
-	"golang.org/x/net/context"
 )
 
 func TestSecretInspect(t *testing.T) {

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -1,6 +1,7 @@
 package service // import "github.com/docker/docker/integration/service"
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -13,7 +14,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/poll"
-	"golang.org/x/net/context"
 )
 
 func TestCreateServiceMultipleTimes(t *testing.T) {

--- a/integration/service/inspect_test.go
+++ b/integration/service/inspect_test.go
@@ -1,6 +1,7 @@
 package service // import "github.com/docker/docker/integration/service"
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -15,7 +16,6 @@ import (
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/poll"
 	"github.com/gotestyourself/gotestyourself/skip"
-	"golang.org/x/net/context"
 )
 
 func TestInspect(t *testing.T) {

--- a/integration/system/info_linux_test.go
+++ b/integration/system/info_linux_test.go
@@ -3,6 +3,7 @@
 package system // import "github.com/docker/docker/integration/system"
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -10,7 +11,6 @@ import (
 	req "github.com/docker/docker/internal/test/request"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestInfoBinaryCommits(t *testing.T) {

--- a/integration/system/info_test.go
+++ b/integration/system/info_test.go
@@ -1,13 +1,13 @@
 package system // import "github.com/docker/docker/integration/system"
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/docker/docker/internal/test/request"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestInfoAPI(t *testing.T) {

--- a/integration/system/login_test.go
+++ b/integration/system/login_test.go
@@ -1,6 +1,7 @@
 package system // import "github.com/docker/docker/integration/system"
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -9,7 +10,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/skip"
-	"golang.org/x/net/context"
 )
 
 // Test case for GitHub 22244

--- a/integration/system/version_test.go
+++ b/integration/system/version_test.go
@@ -1,12 +1,12 @@
 package system // import "github.com/docker/docker/integration/system"
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/docker/internal/test/request"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestVersion(t *testing.T) {

--- a/internal/test/environment/clean.go
+++ b/internal/test/environment/clean.go
@@ -1,6 +1,7 @@
 package environment // import "github.com/docker/docker/internal/test/environment"
 
 import (
+	"context"
 	"regexp"
 	"strings"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/internal/test"
 	"github.com/gotestyourself/gotestyourself/assert"
-	"golang.org/x/net/context"
 )
 
 type testingT interface {

--- a/internal/test/environment/environment.go
+++ b/internal/test/environment/environment.go
@@ -1,6 +1,7 @@
 package environment // import "github.com/docker/docker/internal/test/environment"
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/internal/test/fixtures/load"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // Execution contains information about the current test execution and daemon

--- a/internal/test/fixtures/load/frozen.go
+++ b/internal/test/fixtures/load/frozen.go
@@ -3,13 +3,12 @@ package load // import "github.com/docker/docker/internal/test/fixtures/load"
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
-
-	"context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"

--- a/internal/test/fixtures/plugin/plugin.go
+++ b/internal/test/fixtures/plugin/plugin.go
@@ -1,6 +1,7 @@
 package plugin // import "github.com/docker/docker/internal/test/fixtures/plugin"
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/plugin"
 	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // CreateOpt is is passed used to change the default plugin config before

--- a/pkg/authorization/middleware.go
+++ b/pkg/authorization/middleware.go
@@ -1,12 +1,12 @@
 package authorization // import "github.com/docker/docker/pkg/authorization"
 
 import (
+	"context"
 	"net/http"
 	"sync"
 
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // Middleware uses a list of plugins to

--- a/pkg/authorization/middleware_unix_test.go
+++ b/pkg/authorization/middleware_unix_test.go
@@ -3,6 +3,7 @@
 package authorization // import "github.com/docker/docker/pkg/authorization"
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestMiddlewareWrapHandler(t *testing.T) {

--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -1,11 +1,10 @@
 package ioutils // import "github.com/docker/docker/pkg/ioutils"
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-
-	"golang.org/x/net/context"
 )
 
 // ReadCloserWrapper wraps an io.Reader, and implements an io.ReadCloser

--- a/pkg/ioutils/readers_test.go
+++ b/pkg/ioutils/readers_test.go
@@ -1,6 +1,7 @@
 package ioutils // import "github.com/docker/docker/pkg/ioutils"
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 // Implement io.Reader

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -3,6 +3,7 @@ package plugin // import "github.com/docker/docker/plugin"
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -36,7 +37,6 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var acceptedPluginFilterTags = map[string]bool{

--- a/plugin/backend_unsupported.go
+++ b/plugin/backend_unsupported.go
@@ -3,6 +3,7 @@
 package plugin // import "github.com/docker/docker/plugin"
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"golang.org/x/net/context"
 )
 
 var errNotSupported = errors.New("plugins are not supported on this platform")

--- a/plugin/blobstore.go
+++ b/plugin/blobstore.go
@@ -1,6 +1,7 @@
 package plugin // import "github.com/docker/docker/plugin"
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -18,7 +19,6 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type blobstore interface {

--- a/registry/service.go
+++ b/registry/service.go
@@ -1,13 +1,12 @@
 package registry // import "github.com/docker/docker/registry"
 
 import (
+	"context"
 	"crypto/tls"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/auth"


### PR DESCRIPTION
Since Go 1.7, `context` is a standard package. Since Go 1.9, all `x/net/context` is a few aliases to types in `context`.

Many vendored packages still use x/net/context, so vendor entry remains for now.

The commit is generated by this ugly script (I'm bad at sed so had to use awk in between):

```bash
#!/bin/bash

for f in $(git ls-files \*.go | grep -v ^vendor/); do
	printf .
	sed -i 's|"golang.org/x/net/context"|"context"|' $f
# fix the position of "context" line
	goimports -w $f
# remove the empty line before "context"
	awk '/^$/ {e=1; next;}
		/^\t"context"$/ {e=0;}
		{if (e) {print ""; e=0}; print;}' < $f > $f.new && mv $f.new $f
# fix the position of "context" line again
	goimports -w $f
done
echo
```

Note that there is a "standard" way of doing this change -- by running the `go tool fix -r context`, what it does is the same as the `sed` above. In addition, I had to fix the `"context"` line placement which was tricky in case there are empty lines in the imports list (thus the two `goimports` with an awk in between.