### PR TITLE
Bump SwarmKit to remove deprecated grpc metadata wrappers

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -119,7 +119,7 @@ github.com/dmcgowan/go-tar go1.10
 github.com/stevvooe/ttrpc d4528379866b0ce7e9d71f3eb96f0582fc374577
 
 # cluster
-github.com/docker/swarmkit 9c2aa152c3054371b833483a7ddad8d15052ec4f
+github.com/docker/swarmkit 33d06bf5189881b4d1e371b5571f4d3acf832816
 github.com/gogo/protobuf v0.4
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a
 github.com/fernet/fernet-go 1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2

--- a/vendor/github.com/docker/swarmkit/api/ca.pb.go
+++ b/vendor/github.com/docker/swarmkit/api/ca.pb.go
@@ -990,7 +990,7 @@ func NewRaftProxyCAServer(local CAServer, connSelector raftselector.ConnProvider
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -998,7 +998,7 @@ func NewRaftProxyCAServer(local CAServer, connSelector raftselector.ConnProvider
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)
@@ -1132,7 +1132,7 @@ func NewRaftProxyNodeCAServer(local NodeCAServer, connSelector raftselector.Conn
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -1140,7 +1140,7 @@ func NewRaftProxyNodeCAServer(local NodeCAServer, connSelector raftselector.Conn
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/vendor/github.com/docker/swarmkit/api/control.pb.go
+++ b/vendor/github.com/docker/swarmkit/api/control.pb.go
@@ -5863,7 +5863,7 @@ func NewRaftProxyControlServer(local ControlServer, connSelector raftselector.Co
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -5871,7 +5871,7 @@ func NewRaftProxyControlServer(local ControlServer, connSelector raftselector.Co
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/vendor/github.com/docker/swarmkit/api/dispatcher.pb.go
+++ b/vendor/github.com/docker/swarmkit/api/dispatcher.pb.go
@@ -1606,7 +1606,7 @@ func NewRaftProxyDispatcherServer(local DispatcherServer, connSelector raftselec
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -1614,7 +1614,7 @@ func NewRaftProxyDispatcherServer(local DispatcherServer, connSelector raftselec
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/vendor/github.com/docker/swarmkit/api/health.pb.go
+++ b/vendor/github.com/docker/swarmkit/api/health.pb.go
@@ -290,7 +290,7 @@ func NewRaftProxyHealthServer(local HealthServer, connSelector raftselector.Conn
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -298,7 +298,7 @@ func NewRaftProxyHealthServer(local HealthServer, connSelector raftselector.Conn
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/vendor/github.com/docker/swarmkit/api/logbroker.pb.go
+++ b/vendor/github.com/docker/swarmkit/api/logbroker.pb.go
@@ -1277,7 +1277,7 @@ func NewRaftProxyLogsServer(local LogsServer, connSelector raftselector.ConnProv
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -1285,7 +1285,7 @@ func NewRaftProxyLogsServer(local LogsServer, connSelector raftselector.ConnProv
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)
@@ -1400,7 +1400,7 @@ func NewRaftProxyLogBrokerServer(local LogBrokerServer, connSelector raftselecto
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -1408,7 +1408,7 @@ func NewRaftProxyLogBrokerServer(local LogBrokerServer, connSelector raftselecto
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/vendor/github.com/docker/swarmkit/api/raft.pb.go
+++ b/vendor/github.com/docker/swarmkit/api/raft.pb.go
@@ -1653,7 +1653,7 @@ func NewRaftProxyRaftServer(local RaftServer, connSelector raftselector.ConnProv
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -1661,7 +1661,7 @@ func NewRaftProxyRaftServer(local RaftServer, connSelector raftselector.ConnProv
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)
@@ -1852,7 +1852,7 @@ func NewRaftProxyRaftMembershipServer(local RaftMembershipServer, connSelector r
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -1860,7 +1860,7 @@ func NewRaftProxyRaftMembershipServer(local RaftMembershipServer, connSelector r
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/vendor/github.com/docker/swarmkit/api/resource.pb.go
+++ b/vendor/github.com/docker/swarmkit/api/resource.pb.go
@@ -407,7 +407,7 @@ func NewRaftProxyResourceAllocatorServer(local ResourceAllocatorServer, connSele
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -415,7 +415,7 @@ func NewRaftProxyResourceAllocatorServer(local ResourceAllocatorServer, connSele
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/vendor/github.com/docker/swarmkit/api/watch.pb.go
+++ b/vendor/github.com/docker/swarmkit/api/watch.pb.go
@@ -2047,7 +2047,7 @@ func NewRaftProxyWatchServer(local WatchServer, connSelector raftselector.ConnPr
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -2055,7 +2055,7 @@ func NewRaftProxyWatchServer(local WatchServer, connSelector raftselector.ConnPr
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/vendor/github.com/docker/swarmkit/ca/forward.go
+++ b/vendor/github.com/docker/swarmkit/ca/forward.go
@@ -17,7 +17,7 @@ const (
 // forwardedTLSInfoFromContext obtains forwarded TLS CN/OU from the grpc.MD
 // object in ctx.
 func forwardedTLSInfoFromContext(ctx context.Context) (remoteAddr string, cn string, org string, ous []string) {
-	md, _ := metadata.FromContext(ctx)
+	md, _ := metadata.FromIncomingContext(ctx)
 	if len(md[remoteAddrKey]) != 0 {
 		remoteAddr = md[remoteAddrKey][0]
 	}
@@ -32,7 +32,7 @@ func forwardedTLSInfoFromContext(ctx context.Context) (remoteAddr string, cn str
 }
 
 func isForwardedRequest(ctx context.Context) bool {
-	md, _ := metadata.FromContext(ctx)
+	md, _ := metadata.FromIncomingContext(ctx)
 	if len(md[certForwardedKey]) != 1 {
 		return false
 	}
@@ -42,7 +42,7 @@ func isForwardedRequest(ctx context.Context) bool {
 // WithMetadataForwardTLSInfo reads certificate from context and returns context where
 // ForwardCert is set based on original certificate.
 func WithMetadataForwardTLSInfo(ctx context.Context) (context.Context, error) {
-	md, ok := metadata.FromContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		md = metadata.MD{}
 	}
@@ -73,5 +73,5 @@ func WithMetadataForwardTLSInfo(ctx context.Context) (context.Context, error) {
 		md[remoteAddrKey] = []string{peer.Addr.String()}
 	}
 
-	return metadata.NewContext(ctx, md), nil
+	return metadata.NewOutgoingContext(ctx, md), nil
 }


### PR DESCRIPTION
Updates swarmkit to 33d06bf5189881b4d1e371b5571f4d3acf832816, to bring in
docker/swarmkit#2610 (Don't use wrappers for grpc metadata)


full diff: https://github.com/docker/swarmkit/compare/9c2aa152c3054371b833483a7ddad8d15052ec4f...33d06bf5189881b4d1e371b5571f4d3acf832816

ping @dmcgowan @crosbymichael @tonistiigi 
