### PR TITLE
Remove daemon dependency on api packages

### DIFF
--- a/api/server/router/network/backend.go
+++ b/api/server/router/network/backend.go
@@ -20,3 +20,13 @@ type Backend interface {
 	DeleteNetwork(networkID string) error
 	NetworksPrune(ctx context.Context, pruneFilters filters.Args) (*types.NetworksPruneReport, error)
 }
+
+// ClusterBackend is all the methods that need to be implemented
+// to provide cluster network specific functionality.
+type ClusterBackend interface {
+	GetNetworks() ([]types.NetworkResource, error)
+	GetNetwork(name string) (types.NetworkResource, error)
+	GetNetworksByName(name string) ([]types.NetworkResource, error)
+	CreateNetwork(nc types.NetworkCreateRequest) (string, error)
+	RemoveNetwork(name string) error
+}

--- a/api/server/router/network/network.go
+++ b/api/server/router/network/network.go
@@ -2,18 +2,17 @@ package network // import "github.com/docker/docker/api/server/router/network"
 
 import (
 	"github.com/docker/docker/api/server/router"
-	"github.com/docker/docker/daemon/cluster"
 )
 
 // networkRouter is a router to talk with the network controller
 type networkRouter struct {
 	backend Backend
-	cluster *cluster.Cluster
+	cluster ClusterBackend
 	routes  []router.Route
 }
 
 // NewRouter initializes a new network router
-func NewRouter(b Backend, c *cluster.Cluster) router.Router {
+func NewRouter(b Backend, c ClusterBackend) router.Router {
 	r := &networkRouter{
 		backend: b,
 		cluster: c,

--- a/api/server/router/system/backend.go
+++ b/api/server/router/system/backend.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/swarm"
 	"golang.org/x/net/context"
 )
 
@@ -18,4 +19,10 @@ type Backend interface {
 	SubscribeToEvents(since, until time.Time, ef filters.Args) ([]events.Message, chan interface{})
 	UnsubscribeFromEvents(chan interface{})
 	AuthenticateToRegistry(ctx context.Context, authConfig *types.AuthConfig) (string, string, error)
+}
+
+// ClusterBackend is all the methods that need to be implemented
+// to provide cluster system specific functionality.
+type ClusterBackend interface {
+	Info() swarm.Info
 }

--- a/api/server/router/system/system.go
+++ b/api/server/router/system/system.go
@@ -3,20 +3,19 @@ package system // import "github.com/docker/docker/api/server/router/system"
 import (
 	"github.com/docker/docker/api/server/router"
 	"github.com/docker/docker/builder/fscache"
-	"github.com/docker/docker/daemon/cluster"
 )
 
 // systemRouter provides information about the Docker system overall.
 // It gathers information about host, daemon and container events.
 type systemRouter struct {
 	backend Backend
-	cluster *cluster.Cluster
+	cluster ClusterBackend
 	routes  []router.Route
 	builder *fscache.FSCache
 }
 
 // NewRouter initializes a new system router
-func NewRouter(b Backend, c *cluster.Cluster, fscache *fscache.FSCache) router.Router {
+func NewRouter(b Backend, c ClusterBackend, fscache *fscache.FSCache) router.Router {
 	r := &systemRouter{
 		backend: b,
 		cluster: c,


### PR DESCRIPTION
We are using interface in the api routers to not explicitely depend on
the daemon struct (`daemon.Daemon`), but somehow, we do depend on the
`daemon` package for the cluster functionalities.

This removes this dependency by defining the correct interfaces.

:lion: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
