### PR TITLE
context.WithTimeout: do call the cancel func

### DIFF
--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -504,7 +504,8 @@ func validateAddr(addr string) (string, error) {
 }
 
 func initClusterSpec(node *swarmnode.Node, spec types.Spec) error {
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	for conn := range node.ListenControlSocket(ctx) {
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/pkg/ioutils/readers_test.go
+++ b/pkg/ioutils/readers_test.go
@@ -80,7 +80,8 @@ func (p *perpetualReader) Read(buf []byte) (n int, err error) {
 }
 
 func TestCancelReadCloser(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
 	cancelReadCloser := NewCancelReadCloser(ctx, ioutil.NopCloser(&perpetualReader{}))
 	for {
 		var buf [128]byte


### PR DESCRIPTION
govet complains (when using standard "context" package in #36904):

> the cancel function returned by context.WithTimeout should be called,
> not discarded, to avoid a context leak (vet)

fix it.