### PR TITLE
Warn when reserved-namespace engine labels are configured

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -255,6 +255,25 @@ func GetConflictFreeLabels(labels []string) ([]string, error) {
 	return newLabels, nil
 }
 
+// ValidateReservedNamespaceLabels errors if the reserved namespaces com.docker.*,
+// io.docker.*, org.dockerproject.* are used in a configured engine label.
+//
+// TODO: This is a separate function because we need to warn users first of the
+// deprecation.  When we return an error, this logic can be added to Validate
+// or GetConflictFreeLabels instead of being here.
+func ValidateReservedNamespaceLabels(labels []string) error {
+	for _, label := range labels {
+		lowered := strings.ToLower(label)
+		if strings.HasPrefix(lowered, "com.docker.") || strings.HasPrefix(lowered, "io.docker.") ||
+			strings.HasPrefix(lowered, "org.dockerproject.") {
+			return fmt.Errorf(
+				"label %s not allowed: the namespaces com.docker.*, io.docker.*, and org.dockerproject.* are reserved for Docker's internal use",
+				label)
+		}
+	}
+	return nil
+}
+
 // Reload reads the configuration in the host and reloads the daemon and server.
 func Reload(configFile string, flags *pflag.FlagSet, reload func(*Config)) error {
 	logrus.Infof("Got signal to reload configuration, reloading from: %s", configFile)


### PR DESCRIPTION
**- What I did**
~~Filter out engine labels that start with `com.docker.*`, `io.docker.*`, and `org.dockerproject.*` as per https://docs.docker.com/config/labels-custom-metadata/.~~

Warn when engine labels are configured that start with `com.docker.*`, `io.docker.*`, and `org.dockerproject.*` as per https://docs.docker.com/config/labels-custom-metadata/.

**- How I did it**
~~I filter out the labels every time `SystemInfo()` is called.  The labels are left as defined by the `daemon.json` or daemon CLI args in the `configStore`.  `SystemInfo()` labels are what is used by swarm.~~

~~Filtered out the labels when the configuration is loaded and issue a warning that the labels are being ignored.  In the future an error can be returned, as suggested by @thaJeztah and as per this example:  https://github.com/moby/moby/commit/e4c9079d091a2eeac8a74a0356e3f348db873b87#diff-a348195a1b645d5b477946b1efae728bR274~~

Added a label validation function that, when it errors, the daemon warns the user that label with a reserved namespace has been configured.  In the future loading the configuration can just fail, as per this example:  https://github.com/moby/moby/commit/e4c9079d091a2eeac8a74a0356e3f348db873b87#diff-a348195a1b645d5b477946b1efae728bR274

**- How to verify it**
~~`daemon/info_test.go`~~
~~`cmd/dockerd/daemon_test.go`~~
`daemon/config_test.go` and configuring a daemon with a `com.docker.*` label, and checking the daemon logs

**- Description for the changelog**
~~Enforce reserved namespaces in engine labels by filtering out any configured labels that start with `com.docker.*`, `io.docker.*`, or `org.dockerproject.*` as per https://docs.docker.com/config/labels-custom-metadata/.~~

Warn when an engine label using a reserved namespace (`com.docker.*`, `io.docker.*`, or `org.dockerproject.*`) is configured, as per https://docs.docker.com/config/labels-custom-metadata/.


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://i.ytimg.com/vi/mXHbj_1A1p4/hqdefault.jpg)
