### PR TITLE
Fix version mismatch in API the documentation

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -50,7 +50,7 @@ info:
     is returned.
 
     If you omit the version-prefix, the current version of the API (v1.37) is used.
-    For example, calling `/info` is the same as calling `/v1.36/info`. Using the
+    For example, calling `/info` is the same as calling `/v1.37/info`. Using the
     API without a version-prefix is deprecated and will be removed in a future release.
 
     Engine releases in the near future should support this version of the API,


### PR DESCRIPTION
Fix a version mismatch in the API documentation.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I've modified the version written in a sentence in the API documentation

**- Description for the changelog**
Fix version mismatch in the API documentation

> If you omit the version-prefix, the current version of the API (v1.37) is used. For example, calling /info is the same as calling /v1.36/info.

In this example, the correct version is 1.37, not 1.36

**- A picture of a cute animal (not mandatory but encouraged)**
![](http://cutepics.org/wp-content/uploads/2011/09/cute-pictures-of-ewoks.jpg)

