### PR TITLE
Bump tini to v0.18.0

### DIFF
--- a/hack/dockerfile/install/tini.installer
+++ b/hack/dockerfile/install/tini.installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-TINI_COMMIT=949e6facb77383876aeff8a6944dde66b3089574
+TINI_COMMIT=fec3683b971d9c3ef73f284f176672c44b448662 # v0.18.0
 
 install_tini() {
 	echo "Install tini version $TINI_COMMIT"


### PR DESCRIPTION
This bumps the version of tini used to fec3683b971d9c3ef73f284f176672c44b448662 (v0.18.0)

Full diff: https://github.com/krallin/tini/compare/949e6facb77383876aeff8a6944dde66b3089574...fec3683b971d9c3ef73f284f176672c44b448662

fixes https://github.com/moby/moby/issues/36943
