### PR TITLE
Fix the target name issue for multi-stage build

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -226,7 +226,7 @@ func (b *Builder) build(source builder.Source, dockerfile *parser.Result) (*buil
 		targetIx, found := instructions.HasStage(stages, b.options.Target)
 		if !found {
 			buildsFailed.WithValues(metricsBuildTargetNotReachableError).Inc()
-			return nil, errors.Errorf("failed to reach build target %s in Dockerfile", b.options.Target)
+			return nil, errdefs.InvalidParameter(errors.Errorf("failed to reach build target %s in Dockerfile", b.options.Target))
 		}
 		stages = stages[:targetIx+1]
 	}

--- a/builder/dockerfile/instructions/commands.go
+++ b/builder/dockerfile/instructions/commands.go
@@ -390,7 +390,8 @@ func CurrentStage(s []Stage) (*Stage, error) {
 // HasStage looks for the presence of a given stage name
 func HasStage(s []Stage, name string) (int, bool) {
 	for i, stage := range s {
-		if stage.Name == name {
+		// Stage name is case-insensitive by design
+		if strings.EqualFold(stage.Name, name) {
 			return i, true
 		}
 	}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5965,8 +5965,14 @@ func (s *DockerSuite) TestBuildIntermediateTarget(c *check.C) {
 	cli.BuildCmd(c, "build1", build.WithExternalBuildContext(ctx),
 		cli.WithFlags("--target", "build-env"))
 
-	//res := inspectFieldJSON(c, "build1", "Config.Cmd")
 	res := cli.InspectCmd(c, "build1", cli.Format("json .Config.Cmd")).Combined()
+	c.Assert(strings.TrimSpace(res), checker.Equals, `["/dev"]`)
+
+	// Stage name is case-insensitive by design
+	cli.BuildCmd(c, "build1", build.WithExternalBuildContext(ctx),
+		cli.WithFlags("--target", "BUIld-EnV"))
+
+	res = cli.InspectCmd(c, "build1", cli.Format("json .Config.Cmd")).Combined()
 	c.Assert(strings.TrimSpace(res), checker.Equals, `["/dev"]`)
 
 	result := cli.Docker(cli.Build("build1"), build.WithExternalBuildContext(ctx),


### PR DESCRIPTION
This PR is trying to fix issue #36956.

Stage name is case-insensitive, so we need to use `strings.EqualFold()` as the comparing way instead of the `==` to eliminate the case sensitive issue.
Also we should return a pre-defined error code order to avoid below
error message like:
```
FIXME: Got an API for which error does not match any expected type!!!:
failed to reach build target dev in Dockerfile
```
Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix the `--target` name issue for multi-stage build 
**- How I did it**
Return the original stage name after sanity check.
**- How to verify it**
Follow the steps specified by issue #36956
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

