### PR TITLE
Fix swagger file type for ExecIds

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4663,7 +4663,7 @@ paths:
               AppArmorProfile:
                 type: "string"
               ExecIDs:
-                type: "string"
+                type: "array"
               HostConfig:
                 $ref: "#/definitions/HostConfig"
               GraphDriver:


### PR DESCRIPTION
This PR fixes #36933

The type for ExecIds in the swagger file was string and not array.

**- What I did**
Corrected the ExecIds type
**- How I did it**
Changed `"string"` to `"array"`
**- How to verify it**
Look at the commit :)
**- Description for the changelog**
Fixed swagger file type for ExecIds


**- A picture of a cute animal (not mandatory but encouraged)**
![e9bb2a136a67b3aa4f28fa89ff2e9e1f-1024x897](https://user-images.githubusercontent.com/3407496/39365055-fa028a86-4a27-11e8-850b-9548da671b67.jpg)
