### PR TITLE
Describe IP field of Port definition

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -155,6 +155,7 @@ definitions:
       IP:
         type: "string"
         format: "ip-address"
+        description: "Host IP address that the container's port is mapped to"
       PrivatePort:
         type: "integer"
         format: "uint16"

--- a/api/types/port.go
+++ b/api/types/port.go
@@ -7,7 +7,7 @@ package types
 // swagger:model Port
 type Port struct {
 
-	// IP
+	// Host IP address that the container's port is mapped to
 	IP string `json:"IP,omitempty"`
 
 	// Port on the container


### PR DESCRIPTION
First PR, tried not to touch anything too important just in case. I saw it as the first step in clarifying docker/docker.github.io#6478, even if not directly related

**- What I did**
Attempted to clarify what "Container.Ports[].IP" refers to

**- How I did it**
Added a description

**- How to verify it**
Build docs and read, eg, 200 response info for "List Containers" (/containers/json)

**- Description for the changelog**
Describe IP field of swagger Port definition

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/789922/39415011-f403abe8-4bf2-11e8-98a8-78e3944ceae5.png)

