### PR TITLE
daemon.setMounts(): copy slice in place

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -533,7 +533,7 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 	//  - /dev/shm, in case IpcMode is none.
 	// While at it, also
 	//  - set size for /dev/shm from shmsize.
-	var defaultMounts []specs.Mount
+	defaultMounts := s.Mounts[:0]
 	_, mountDev := userMounts["/dev"]
 	for _, m := range s.Mounts {
 		if _, ok := userMounts[m.Destination]; ok {


### PR DESCRIPTION
It does not make sense to copy a slice element by element, then discard the source one. Let's do copy in place instead which is more efficient.

(This is something that barely deserves a pull request, so it was sitting in my backlog for months. Better merge and forget about it.)