### PR TITLE
Add windows recycle bin test and update hcsshim to v0.6.11

### DIFF
--- a/integration-cli/docker_api_build_windows_test.go
+++ b/integration-cli/docker_api_build_windows_test.go
@@ -1,0 +1,39 @@
+// +build windows
+
+package main
+
+import (
+	"net/http"
+
+	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/internal/test/fakecontext"
+	"github.com/docker/docker/internal/test/request"
+	"github.com/go-check/check"
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+)
+
+func (s *DockerSuite) TestBuildWithRecycleBin(c *check.C) {
+	testRequires(c, DaemonIsWindows)
+
+	dockerfile := "" +
+		"FROM " + testEnv.PlatformDefaults.BaseImage + "\n" +
+		"RUN md $REcycLE.biN && md missing\n" +
+		"RUN dir $Recycle.Bin && exit 1 || exit 0\n" +
+		"RUN dir missing\n"
+
+	ctx := fakecontext.New(c, "", fakecontext.WithDockerfile(dockerfile))
+	defer ctx.Close()
+
+	res, body, err := request.Post(
+		"/build",
+		request.RawContent(ctx.AsTarReader(c)),
+		request.ContentType("application/x-tar"))
+
+	c.Assert(err, checker.IsNil)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
+
+	out, err := request.ReadBody(body)
+	assert.NilError(c, err)
+	assert.Check(c, is.Contains(string(out), "Successfully built"))
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,6 +1,6 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim v0.6.10
+github.com/Microsoft/hcsshim v0.6.11
 github.com/Microsoft/go-winio v0.4.6
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git

--- a/vendor/github.com/Microsoft/hcsshim/README.md
+++ b/vendor/github.com/Microsoft/hcsshim/README.md
@@ -4,9 +4,30 @@ This package supports launching Windows Server containers from Go. It is
 primarily used in the [Docker Engine](https://github.com/docker/docker) project,
 but it can be freely used by other projects as well.
 
-This project has adopted the [Microsoft Open Source Code of
-Conduct](https://opensource.microsoft.com/codeofconduct/). For more information
-see the [Code of Conduct
-FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
-[opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional
-questions or comments.
+
+## Contributing
+---------------
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+
+## Reporting Security Issues
+
+Security issues and bugs should be reported privately, via email, to the Microsoft Security
+Response Center (MSRC) at [secure@microsoft.com](mailto:secure@microsoft.com). You should
+receive a response within 24 hours. If for some reason you do not, please follow up via
+email to ensure we received your original message. Further information, including the
+[MSRC PGP](https://technet.microsoft.com/en-us/security/dn606155) key, can be found in
+the [Security TechCenter](https://technet.microsoft.com/en-us/security/default).
+
+-------------------------------------------
+Copyright (c) 2018 Microsoft Corp.  All rights reserved.

--- a/vendor/github.com/Microsoft/hcsshim/legacy.go
+++ b/vendor/github.com/Microsoft/hcsshim/legacy.go
@@ -127,7 +127,7 @@ func (r *legacyLayerReader) walkUntilCancelled() error {
 		// UTF16 to UTF8 in files which are left in the recycle bin. Os.Lstat
 		// which is called by filepath.Walk will fail when a filename contains
 		// unicode characters. Skip the recycle bin regardless which is goodness.
-		if path == filepath.Join(r.root, `Files\$Recycle.Bin`) && info.IsDir() {
+		if strings.EqualFold(path, filepath.Join(r.root, `Files\$Recycle.Bin`)) && info.IsDir() {
 			return filepath.SkipDir
 		}
 


### PR DESCRIPTION
These changes update hcsshim to v0.6.11 (to perform a case-insensitive file name comparison when checking for $Recycle.Bin) and add integration tests to verify three things:

1. The case of $Recycle.Bin does not prevent hcsshim from skipping it.
2. The $Recycle.Bin directory is not committed to images.
3. No files are missing after $Recycle.Bin; see https://github.com/docker/for-win/issues/1947.