### PR TITLE
Fix integration tests and integration cli to run on older versions

### DIFF
--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -406,7 +406,8 @@ func (s *DockerSuite) TestBuildAddRemoteNoDecompress(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildChownOnCopy(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	// new feature added in 1.31 - https://github.com/moby/moby/pull/34263
+	testRequires(c, DaemonIsLinux, MinimumAPIVersion("1.31"))
 	dockerfile := `FROM busybox
 		RUN echo 'test1:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 		RUN echo 'test1:x:1001:' >> /etc/group

--- a/integration-cli/docker_api_create_test.go
+++ b/integration-cli/docker_api_create_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/go-check/check"
@@ -25,7 +26,11 @@ func (s *DockerSuite) TestAPICreateWithInvalidHealthcheckParams(c *check.C) {
 
 	res, body, err := request.Post("/containers/create?name="+name, request.JSONBody(config))
 	c.Assert(err, check.IsNil)
-	c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
+	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
+		c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
+	} else {
+		c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
+	}
 
 	buf, err := request.ReadBody(body)
 	c.Assert(err, checker.IsNil)
@@ -49,7 +54,11 @@ func (s *DockerSuite) TestAPICreateWithInvalidHealthcheckParams(c *check.C) {
 	buf, err = request.ReadBody(body)
 	c.Assert(err, checker.IsNil)
 
-	c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
+	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
+		c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
+	} else {
+		c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
+	}
 	c.Assert(getErrorMessage(c, buf), checker.Contains, expected)
 
 	// test invalid Timeout in Healthcheck: less than 1ms
@@ -64,7 +73,11 @@ func (s *DockerSuite) TestAPICreateWithInvalidHealthcheckParams(c *check.C) {
 	}
 	res, body, err = request.Post("/containers/create?name="+name, request.JSONBody(config))
 	c.Assert(err, check.IsNil)
-	c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
+	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
+		c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
+	} else {
+		c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
+	}
 
 	buf, err = request.ReadBody(body)
 	c.Assert(err, checker.IsNil)
@@ -84,7 +97,11 @@ func (s *DockerSuite) TestAPICreateWithInvalidHealthcheckParams(c *check.C) {
 	}
 	res, body, err = request.Post("/containers/create?name="+name, request.JSONBody(config))
 	c.Assert(err, check.IsNil)
-	c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
+	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
+		c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
+	} else {
+		c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
+	}
 
 	buf, err = request.ReadBody(body)
 	c.Assert(err, checker.IsNil)
@@ -105,7 +122,11 @@ func (s *DockerSuite) TestAPICreateWithInvalidHealthcheckParams(c *check.C) {
 	}
 	res, body, err = request.Post("/containers/create?name="+name, request.JSONBody(config))
 	c.Assert(err, check.IsNil)
-	c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
+	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
+		c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
+	} else {
+		c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
+	}
 
 	buf, err = request.ReadBody(body)
 	c.Assert(err, checker.IsNil)

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/go-check/check"
@@ -22,7 +23,11 @@ func (s *DockerSuite) TestExecResizeAPIHeightWidthNoInt(c *check.C) {
 	endpoint := "/exec/" + cleanedContainerID + "/resize?h=foo&w=bar"
 	res, _, err := request.Post(endpoint)
 	c.Assert(err, checker.IsNil)
-	c.Assert(res.StatusCode, checker.Equals, http.StatusBadRequest)
+	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
+		c.Assert(res.StatusCode, checker.Equals, http.StatusInternalServerError)
+	} else {
+		c.Assert(res.StatusCode, checker.Equals, http.StatusBadRequest)
+	}
 }
 
 // Part of #14845

--- a/integration-cli/docker_api_ipcmode_test.go
+++ b/integration-cli/docker_api_ipcmode_test.go
@@ -88,7 +88,7 @@ func testIpcNonePrivateShareable(c *check.C, mode string, mustBeMounted bool, mu
  * /dev/shm mount inside the container.
  */
 func (s *DockerSuite) TestAPIIpcModeNone(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, MinimumAPIVersion("1.32"))
 	testIpcNonePrivateShareable(c, "none", false, false)
 }
 
@@ -173,7 +173,7 @@ func (s *DockerSuite) TestAPIIpcModeShareableAndContainer(c *check.C) {
  * --ipc container:ID can NOT use IPC of another private container.
  */
 func (s *DockerSuite) TestAPIIpcModePrivateAndContainer(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, MinimumAPIVersion("1.32"))
 	testIpcContainer(s, c, "private", false)
 }
 

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -149,6 +149,7 @@ func (s *DockerSuite) TestLogsAPIUntilFutureFollow(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsAPIUntil(c *check.C) {
+	testRequires(c, MinimumAPIVersion("1.34"))
 	name := "logsuntil"
 	dockerCmd(c, "run", "--name", name, "busybox", "/bin/sh", "-c", "for i in $(seq 1 3); do echo log$i; sleep 1; done")
 

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/go-check/check"
@@ -64,7 +65,18 @@ func (s *DockerSuite) TestAPINetworkCreateCheckDuplicate(c *check.C) {
 	c.Assert(isNetworkAvailable(c, name), checker.Equals, true)
 
 	// Creating another network with same name and CheckDuplicate must fail
-	createNetwork(c, configOnCheck, http.StatusConflict)
+	isOlderAPI := versions.LessThan(testEnv.DaemonAPIVersion(), "1.34")
+	expectedStatus := http.StatusConflict
+	if isOlderAPI {
+		// In the early test code it uses bool value to represent
+		// whether createNetwork() is expected to fail or not.
+		// Therefore, we use negation to handle the same logic after
+		// the code was changed in https://github.com/moby/moby/pull/35030
+		// -http.StatusCreated will also be checked as NOT equal to
+		// http.StatusCreated in createNetwork() function.
+		expectedStatus = -http.StatusCreated
+	}
+	createNetwork(c, configOnCheck, expectedStatus)
 
 	// Creating another network with same name and not CheckDuplicate must succeed
 	createNetwork(c, configNotCheck, http.StatusCreated)
@@ -202,7 +214,11 @@ func (s *DockerSuite) TestAPINetworkIPAMMultipleBridgeNetworks(c *check.C) {
 			IPAM:   ipam1,
 		},
 	}
-	createNetwork(c, config1, http.StatusForbidden)
+	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
+		createNetwork(c, config1, http.StatusInternalServerError)
+	} else {
+		createNetwork(c, config1, http.StatusForbidden)
+	}
 	c.Assert(isNetworkAvailable(c, "test1"), checker.Equals, false)
 
 	ipam2 := &network.IPAM{
@@ -239,7 +255,7 @@ func (s *DockerSuite) TestAPINetworkIPAMMultipleBridgeNetworks(c *check.C) {
 }
 
 func (s *DockerSuite) TestAPICreateDeletePredefinedNetworks(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SwarmInactive)
 	createDeletePredefinedNetwork(c, "bridge")
 	createDeletePredefinedNetwork(c, "none")
 	createDeletePredefinedNetwork(c, "host")
@@ -253,7 +269,17 @@ func createDeletePredefinedNetwork(c *check.C, name string) {
 			CheckDuplicate: true,
 		},
 	}
-	createNetwork(c, config, http.StatusForbidden)
+	expectedStatus := http.StatusForbidden
+	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.34") {
+		// In the early test code it uses bool value to represent
+		// whether createNetwork() is expected to fail or not.
+		// Therefore, we use negation to handle the same logic after
+		// the code was changed in https://github.com/moby/moby/pull/35030
+		// -http.StatusCreated will also be checked as NOT equal to
+		// http.StatusCreated in createNetwork() function.
+		expectedStatus = -http.StatusCreated
+	}
+	createNetwork(c, config, expectedStatus)
 	deleteNetwork(c, name, false)
 }
 
@@ -320,9 +346,13 @@ func createNetwork(c *check.C, config types.NetworkCreateRequest, expectedStatus
 	c.Assert(err, checker.IsNil)
 	defer resp.Body.Close()
 
-	c.Assert(resp.StatusCode, checker.Equals, expectedStatusCode)
+	if expectedStatusCode >= 0 {
+		c.Assert(resp.StatusCode, checker.Equals, expectedStatusCode)
+	} else {
+		c.Assert(resp.StatusCode, checker.Not(checker.Equals), -expectedStatusCode)
+	}
 
-	if expectedStatusCode == http.StatusCreated {
+	if expectedStatusCode == http.StatusCreated || expectedStatusCode < 0 {
 		var nr types.NetworkCreateResponse
 		err = json.NewDecoder(body).Decode(&nr)
 		c.Assert(err, checker.IsNil)

--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/go-check/check"
@@ -59,7 +60,11 @@ func (s *DockerSuite) TestAPIClientVersionOldNotSupported(c *check.C) {
 func (s *DockerSuite) TestAPIErrorJSON(c *check.C) {
 	httpResp, body, err := request.Post("/containers/create", request.JSONBody(struct{}{}))
 	c.Assert(err, checker.IsNil)
-	c.Assert(httpResp.StatusCode, checker.Equals, http.StatusBadRequest)
+	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
+		c.Assert(httpResp.StatusCode, checker.Equals, http.StatusInternalServerError)
+	} else {
+		c.Assert(httpResp.StatusCode, checker.Equals, http.StatusBadRequest)
+	}
 	c.Assert(httpResp.Header.Get("Content-Type"), checker.Equals, "application/json")
 	b, err := request.ReadBody(body)
 	c.Assert(err, checker.IsNil)
@@ -72,7 +77,11 @@ func (s *DockerSuite) TestAPIErrorPlainText(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	httpResp, body, err := request.Post("/v1.23/containers/create", request.JSONBody(struct{}{}))
 	c.Assert(err, checker.IsNil)
-	c.Assert(httpResp.StatusCode, checker.Equals, http.StatusBadRequest)
+	if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {
+		c.Assert(httpResp.StatusCode, checker.Equals, http.StatusInternalServerError)
+	} else {
+		c.Assert(httpResp.StatusCode, checker.Equals, http.StatusBadRequest)
+	}
 	c.Assert(httpResp.Header.Get("Content-Type"), checker.Contains, "text/plain")
 	b, err := request.ReadBody(body)
 	c.Assert(err, checker.IsNil)

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5953,6 +5953,10 @@ func (s *DockerSuite) TestBuildMulitStageResetScratch(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildIntermediateTarget(c *check.C) {
+	//todo: need to be removed after 18.06 release
+	if strings.Contains(testEnv.DaemonInfo.ServerVersion, "18.05.0") {
+		c.Skip(fmt.Sprintf("Bug fixed in 18.06 or higher.Skipping it for %s", testEnv.DaemonInfo.ServerVersion))
+	}
 	dockerfile := `
 		FROM busybox AS build-env
 		CMD ["/dev"]

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/go-check/check"
@@ -121,12 +122,14 @@ func (s *DockerSuite) TestCommitChange(c *check.C) {
 		"test", "test-commit")
 	imageID = strings.TrimSpace(imageID)
 
-	// The ordering here is due to `PATH` being overridden from the container's
-	// ENV.  On windows, the container doesn't have a `PATH` ENV variable so
-	// the ordering is the same as the cli.
-	expectedEnv := "[PATH=/foo DEBUG=true test=1]"
-	if testEnv.OSType == "windows" {
-		expectedEnv = "[DEBUG=true test=1 PATH=/foo]"
+	expectedEnv := "[DEBUG=true test=1 PATH=/foo]"
+	// bug fixed in 1.36, add min APi >= 1.36 requirement
+	// PR record https://github.com/moby/moby/pull/35582
+	if versions.GreaterThan(testEnv.DaemonAPIVersion(), "1.35") && testEnv.OSType != "windows" {
+		// The ordering here is due to `PATH` being overridden from the container's
+		// ENV.  On windows, the container doesn't have a `PATH` ENV variable so
+		// the ordering is the same as the cli.
+		expectedEnv = "[PATH=/foo DEBUG=true test=1]"
 	}
 
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -463,5 +463,5 @@ func (s *DockerSuite) TestInspectInvalidReference(c *check.C) {
 	// This test should work on both Windows and Linux
 	out, _, err := dockerCmdWithError("inspect", "FooBar")
 	c.Assert(err, checker.NotNil)
-	c.Assert(out, checker.Contains, "no such image: FooBar")
+	c.Assert(out, checker.Contains, "invalid reference format: repository name must be lowercase")
 }

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -28,7 +28,9 @@ func (s *DockerSuite) TestLinksInvalidContainerTarget(c *check.C) {
 	// an invalid container target should produce an error
 	c.Assert(err, checker.NotNil, check.Commentf("out: %s", out))
 	// an invalid container target should produce an error
-	c.Assert(out, checker.Contains, "could not get container")
+	// note: convert the output to lowercase first as the error string
+	// capitalization was changed after API version 1.32
+	c.Assert(strings.ToLower(out), checker.Contains, "could not get container")
 }
 
 func (s *DockerSuite) TestLinksPingLinkedContainers(c *check.C) {

--- a/integration-cli/docker_cli_netmode_test.go
+++ b/integration-cli/docker_cli_netmode_test.go
@@ -46,7 +46,7 @@ func (s *DockerSuite) TestNetHostname(c *check.C) {
 	c.Assert(out, checker.Contains, runconfig.ErrConflictNetworkHostname.Error())
 
 	out, _ = dockerCmdWithFail(c, "run", "--net=container", "busybox", "ps")
-	c.Assert(out, checker.Contains, "Invalid network mode: invalid container format container:<name|id>")
+	c.Assert(out, checker.Contains, "invalid container format container:<name|id>")
 
 	out, _ = dockerCmdWithFail(c, "run", "--net=weird", "busybox", "ps")
 	c.Assert(strings.ToLower(out), checker.Contains, "not found")

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1165,7 +1165,7 @@ func (s *DockerSuite) TestLegacyRunNoNewPrivSetuid(c *check.C) {
 }
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesChown(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_CHOWN
@@ -1183,7 +1183,7 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesChown(c *check.C) {
 }
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesDacOverride(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_DAC_OVERRIDE
@@ -1196,7 +1196,7 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesDacOverride(c *check.C) {
 }
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesFowner(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_FOWNER
@@ -1212,7 +1212,7 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesFowner(c *check.C) {
 // TODO CAP_KILL
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesSetuid(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_SETUID
@@ -1230,7 +1230,7 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesSetuid(c *check.C) {
 }
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesSetgid(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_SETGID
@@ -1250,7 +1250,7 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesSetgid(c *check.C) {
 // TODO CAP_SETPCAP
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesNetBindService(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_NET_BIND_SERVICE
@@ -1268,7 +1268,7 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesNetBindService(c *check.C) 
 }
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesNetRaw(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_NET_RAW
@@ -1286,7 +1286,7 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesNetRaw(c *check.C) {
 }
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesChroot(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_SYS_CHROOT
@@ -1304,7 +1304,7 @@ func (s *DockerSuite) TestUserNoEffectiveCapabilitiesChroot(c *check.C) {
 }
 
 func (s *DockerSuite) TestUserNoEffectiveCapabilitiesMknod(c *check.C) {
-	testRequires(c, DaemonIsLinux, NotUserNamespace)
+	testRequires(c, DaemonIsLinux, NotUserNamespace, SameHostDaemon)
 	ensureSyscallTest(c)
 
 	// test that a root user has default capability CAP_MKNOD

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -330,7 +330,9 @@ func listTar(f io.Reader) ([]string, error) {
 // The layer.tar file is actually zero bytes, no padding or anything else.
 // See issue: 18170
 func (s *DockerSuite) TestLoadZeroSizeLayer(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	// this will definitely not work if using remote daemon
+	// very weird test
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 
 	dockerCmd(c, "load", "-i", "testdata/emptyLayer.tar")
 }

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -103,7 +103,7 @@ func (s *DockerSuite) TestStartPausedContainer(c *check.C) {
 	// an error should have been shown that you cannot start paused container
 	c.Assert(err, checker.NotNil, check.Commentf("out: %s", out))
 	// an error should have been shown that you cannot start paused container
-	c.Assert(out, checker.Contains, "cannot start a paused container, try unpause instead")
+	c.Assert(strings.ToLower(out), checker.Contains, "cannot start a paused container, try unpause instead")
 }
 
 func (s *DockerSuite) TestStartMultipleContainers(c *check.C) {

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/requirement"
 	"github.com/docker/docker/internal/test/registry"
@@ -38,6 +40,12 @@ func DaemonIsWindowsAtLeastBuild(buildNumber int) func() bool {
 
 func DaemonIsLinux() bool {
 	return testEnv.OSType == "linux"
+}
+
+func MinimumAPIVersion(version string) func() bool {
+	return func() bool {
+		return versions.GreaterThanOrEqualTo(testEnv.DaemonAPIVersion(), version)
+	}
 }
 
 func OnlyDefaultNetworks() bool {
@@ -109,6 +117,9 @@ func Network() bool {
 }
 
 func Apparmor() bool {
+	if strings.HasPrefix(testEnv.DaemonInfo.OperatingSystem, "SUSE Linux Enterprise Server ") {
+		return false
+	}
 	buf, err := ioutil.ReadFile("/sys/module/apparmor/parameters/enabled")
 	return err == nil && len(buf) > 1 && buf[0] == 'Y'
 }
@@ -191,6 +202,10 @@ func RegistryHosting() bool {
 	// registry binary is in PATH.
 	_, err := exec.LookPath(registry.V2binary)
 	return err == nil
+}
+
+func SwarmInactive() bool {
+	return testEnv.DaemonInfo.Swarm.LocalNodeState == swarm.LocalNodeStateInactive
 }
 
 // testRequires checks if the environment satisfies the requirements

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -136,6 +136,7 @@ func buildContainerIdsFilter(buildOutput io.Reader) (filters.Args, error) {
 }
 
 func TestBuildMultiStageParentConfig(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.35"), "broken in earlier versions")
 	dockerfile := `
 		FROM busybox AS stage0
 		ENV WHO=parent
@@ -204,6 +205,7 @@ func TestBuildWithEmptyLayers(t *testing.T) {
 // multiple subsequent stages
 // #35652
 func TestBuildMultiStageOnBuild(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.33"), "broken in earlier versions")
 	defer setupTest(t)()
 	// test both metadata and layer based commands as they may be implemented differently
 	dockerfile := `FROM busybox AS stage1

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -7,13 +7,16 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/strslice"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+	"github.com/gotestyourself/gotestyourself/skip"
 )
 
 func TestExec(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.35"), "broken in earlier versions")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := request.NewAPIClient(t)

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/internal/testutil"
@@ -66,6 +67,7 @@ func TestPauseFailsOnWindowsServerContainers(t *testing.T) {
 
 func TestPauseStopPausedContainer(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.31"), "broken in earlier versions")
 
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)

--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/internal/testutil"
@@ -23,6 +24,7 @@ import (
 // and then deleting and recreating the source container linked to the new target.
 // This checks that "rename" updates source container correctly and doesn't set it to null.
 func TestRenameLinkedContainer(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.32"), "broken in earlier versions")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := request.NewAPIClient(t)

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/test/request"
 	req "github.com/docker/docker/internal/test/request"
@@ -14,6 +15,7 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/poll"
+	"github.com/gotestyourself/gotestyourself/skip"
 )
 
 func TestResize(t *testing.T) {
@@ -33,6 +35,7 @@ func TestResize(t *testing.T) {
 }
 
 func TestResizeWithInvalidSize(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.32"), "broken in earlier versions")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()

--- a/integration/container/stop_test.go
+++ b/integration/container/stop_test.go
@@ -43,7 +43,8 @@ func TestStopContainerWithRestartPolicyAlways(t *testing.T) {
 }
 
 func TestDeleteDevicemapper(t *testing.T) {
-	skip.IfCondition(t, testEnv.DaemonInfo.Driver != "devicemapper")
+	skip.If(t, testEnv.DaemonInfo.Driver != "devicemapper")
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot start daemon on remote test run")
 
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)

--- a/integration/image/commit_test.go
+++ b/integration/image/commit_test.go
@@ -5,13 +5,16 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+	"github.com/gotestyourself/gotestyourself/skip"
 )
 
 func TestCommitInheritsEnv(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.36"), "broken in earlier versions")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()

--- a/integration/network/delete_test.go
+++ b/integration/network/delete_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+	"github.com/gotestyourself/gotestyourself/skip"
 )
 
 func containsNetwork(nws []types.NetworkResource, nw types.NetworkCreateResponse) bool {
@@ -48,6 +50,7 @@ func createAmbiguousNetworks(t *testing.T) (types.NetworkCreateResponse, types.N
 // equal to another network's ID exists, the Network with the given
 // ID is removed, and not the network with the given name.
 func TestDockerNetworkDeletePreferID(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.34"), "broken in earlier versions")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/gotestyourself/gotestyourself/icmd"
 	"github.com/gotestyourself/gotestyourself/poll"
+	"github.com/gotestyourself/gotestyourself/skip"
 )
 
 // delInterface removes given network interface
@@ -23,6 +24,7 @@ func delInterface(t *testing.T, ifName string) {
 }
 
 func TestDaemonRestartWithLiveRestore(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon())
 	d := daemon.New(t)
 	defer d.Stop(t)
 	d.Start(t)
@@ -42,6 +44,7 @@ func TestDaemonRestartWithLiveRestore(t *testing.T) {
 
 func TestDaemonDefaultNetworkPools(t *testing.T) {
 	// Remove docker0 bridge and the start daemon defining the predefined address pools
+	skip.If(t, testEnv.IsRemoteDaemon())
 	defaultNetworkBridge := "docker0"
 	delInterface(t, defaultNetworkBridge)
 	d := daemon.New(t)
@@ -86,6 +89,7 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 }
 
 func TestDaemonRestartWithExistingNetwork(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon())
 	defaultNetworkBridge := "docker0"
 	d := daemon.New(t)
 	d.Start(t)
@@ -119,6 +123,7 @@ func TestDaemonRestartWithExistingNetwork(t *testing.T) {
 }
 
 func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon())
 	defaultNetworkBridge := "docker0"
 	d := daemon.New(t)
 	d.Start(t)
@@ -174,6 +179,7 @@ func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
 }
 
 func TestDaemonWithBipAndDefaultNetworkPool(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon())
 	defaultNetworkBridge := "docker0"
 	d := daemon.New(t)
 	defer d.Stop(t)

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -13,15 +13,18 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/strslice"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/test/request"
 	req "github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+	"github.com/gotestyourself/gotestyourself/skip"
 )
 
-func TestEvents(t *testing.T) {
+func TestEventsExecDie(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.36"), "broken in earlier versions")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := request.NewAPIClient(t)

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -54,9 +54,9 @@ func TestVolumesRemove(t *testing.T) {
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
 
-	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
+	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 
-	id := container.Create(t, ctx, client, container.WithVolume(prefix+"foo"))
+	id := container.Create(t, ctx, client, container.WithVolume(prefix+slash+"foo"))
 
 	c, err := client.ContainerInspect(ctx, id)
 	assert.NilError(t, err)
@@ -75,6 +75,7 @@ func TestVolumesRemove(t *testing.T) {
 }
 
 func TestVolumesInspect(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix `integration` tests and `integration-cli` tests to run on older versions (e.g. 17.06-ee) with @tiborvass 

**- How I did it**
Add version requirements in some failed tests and skip tests that are not runnable in older versions.

**- How to verify it**
Run the whole test suit accross a version/platform matix. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixing failed `integration` and `integration-cli` tests against older engine versions. 

**- A picture of a cute animal (not mandatory but encouraged)**

