### PR TITLE
Move plugin client creation to the extension point

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1859,6 +1859,13 @@ definitions:
                 type: "string"
                 x-nullable: false
                 example: "plugins.sock"
+              ProtocolScheme:
+                type: "string"
+                example: "some.protocol/v1.0"
+                description: "Protocol to use for clients connecting to the plugin."
+                enum:
+                  - ""
+                  - "moby.plugins.http/v1"
           Entrypoint:
             type: "array"
             items:

--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -121,6 +121,9 @@ type PluginConfigArgs struct {
 // swagger:model PluginConfigInterface
 type PluginConfigInterface struct {
 
+	// Protocol to use for clients connecting to the plugin.
+	ProtocolScheme string `json:"ProtocolScheme,omitempty"`
+
 	// socket
 	// Required: true
 	Socket string `json:"Socket"`

--- a/daemon/graphdriver/plugin.go
+++ b/daemon/graphdriver/plugin.go
@@ -5,7 +5,9 @@ import (
 	"path/filepath"
 
 	"github.com/docker/docker/pkg/plugingetter"
+	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/docker/plugin/v2"
+	"github.com/pkg/errors"
 )
 
 func lookupPlugin(name string, pg plugingetter.PluginGetter, config Options) (Driver, error) {
@@ -28,6 +30,22 @@ func newPluginDriver(name string, pl plugingetter.CompatPlugin, config Options) 
 			}
 		}
 	}
-	proxy := &graphDriverProxy{name, pl, Capabilities{}}
+
+	var proxy *graphDriverProxy
+
+	pa, ok := pl.(plugingetter.PluginAddr)
+	if !ok {
+		proxy = &graphDriverProxy{name, pl, Capabilities{}, pl.Client()}
+	} else {
+		if pa.Protocol() != plugins.ProtocolSchemeHTTPV1 {
+			return nil, errors.Errorf("plugin protocol not supported: %s", pa.Protocol())
+		}
+		addr := pa.Addr()
+		client, err := plugins.NewClientWithTimeout(addr.Network()+"://"+addr.String(), nil, pa.Timeout())
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating plugin client")
+		}
+		proxy = &graphDriverProxy{name, pl, Capabilities{}, client}
+	}
 	return proxy, proxy.Init(filepath.Join(home, name), config.DriverOptions, config.UIDMaps, config.GIDMaps)
 }

--- a/daemon/metrics_unix.go
+++ b/daemon/metrics_unix.go
@@ -49,8 +49,12 @@ func registerMetricsPluginCallback(store *plugin.Store, sockPath string) {
 			return
 		}
 
-		if err := pluginStartMetricsCollection(p); err != nil {
-			logrus.WithError(err).WithField("name", name).Error("error while initializing metrics plugin")
+		adapter, err := makePluginAdapter(p)
+		if err != nil {
+			logrus.WithError(err).WithField("plugin", p.Name()).Error("Error creating plugin adapater")
+		}
+		if err := adapter.StartMetrics(); err != nil {
+			logrus.WithError(err).WithField("plugin", p.Name()).Error("Error starting metrics collector plugin")
 		}
 	})
 }

--- a/pkg/plugingetter/getter.go
+++ b/pkg/plugingetter/getter.go
@@ -1,6 +1,9 @@
 package plugingetter // import "github.com/docker/docker/pkg/plugingetter"
 
 import (
+	"net"
+	"time"
+
 	"github.com/docker/docker/pkg/plugins"
 )
 
@@ -19,6 +22,14 @@ type CompatPlugin interface {
 	Name() string
 	ScopedPath(string) string
 	IsV1() bool
+}
+
+// PluginAddr is a plugin that exposes the socket address for creating custom clients rather than the built-in `*plugins.Client`
+type PluginAddr interface {
+	CompatPlugin
+	Addr() net.Addr
+	Timeout() time.Duration
+	Protocol() string
 }
 
 // CountedPlugin is a plugin which is reference counted.

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -31,6 +31,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// ProtocolSchemeHTTPV1 is the name of the protocol used for interacting with plugins using this package.
+const ProtocolSchemeHTTPV1 = "moby.plugins.http/v1"
+
 var (
 	// ErrNotImplements is returned if the plugin does not implement the requested driver.
 	ErrNotImplements = errors.New("Plugin does not implement the requested driver")
@@ -86,6 +89,11 @@ func (p *Plugin) Name() string {
 // Client returns a ready-to-use plugin client that can be used to communicate with the plugin.
 func (p *Plugin) Client() *Client {
 	return p.client
+}
+
+// Protocol returns the protocol name/version used for plugins in this package.
+func (p *Plugin) Protocol() string {
+	return ProtocolSchemeHTTPV1
 }
 
 // IsV1 returns true for V1 plugins and false otherwise.

--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -71,14 +71,20 @@ func (pm *Manager) enable(p *v2.Plugin, c *controller, force bool) error {
 
 func (pm *Manager) pluginPostStart(p *v2.Plugin, c *controller) error {
 	sockAddr := filepath.Join(pm.config.ExecRoot, p.GetID(), p.GetSocket())
-	client, err := plugins.NewClientWithTimeout("unix://"+sockAddr, nil, time.Duration(c.timeoutInSecs)*time.Second)
-	if err != nil {
-		c.restart = false
-		shutdownPlugin(p, c, pm.executor)
-		return errors.WithStack(err)
-	}
+	p.SetTimeout(time.Duration(c.timeoutInSecs) * time.Second)
+	addr := &net.UnixAddr{Net: "unix", Name: sockAddr}
+	p.SetAddr(addr)
 
-	p.SetPClient(client)
+	if p.Protocol() == plugins.ProtocolSchemeHTTPV1 {
+		client, err := plugins.NewClientWithTimeout(addr.Network()+"://"+addr.String(), nil, p.Timeout())
+		if err != nil {
+			c.restart = false
+			shutdownPlugin(p, c, pm.executor)
+			return errors.WithStack(err)
+		}
+
+		p.SetPClient(client)
+	}
 
 	// Initial sleep before net Dial to allow plugin to listen on socket.
 	time.Sleep(500 * time.Millisecond)

--- a/plugin/v2/plugin_unsupported.go
+++ b/plugin/v2/plugin_unsupported.go
@@ -5,7 +5,7 @@ package v2 // import "github.com/docker/docker/plugin/v2"
 import (
 	"errors"
 
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // InitSpec creates an OCI spec from the plugin's config.

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -17,7 +17,7 @@ type volumeDriverAdapter struct {
 	name         string
 	scopePath    func(s string) string
 	capabilities *volume.Capability
-	proxy        *volumeDriverProxy
+	proxy        volumeDriver
 }
 
 func (a *volumeDriverAdapter) Name() string {
@@ -114,7 +114,7 @@ func (a *volumeDriverAdapter) getCapabilities() volume.Capability {
 }
 
 type volumeAdapter struct {
-	proxy      *volumeDriverProxy
+	proxy      volumeDriver
 	name       string
 	scopePath  func(string) string
 	driverName string


### PR DESCRIPTION
This starts the work to add support for new plugin client protocols.
Instead of only supporting the http+json RPC plugins for any kind of (v2) plugin, the subsystem which is integrating with the plugin can make the determination on how to communicate with the it by reading the plugin metadata.

Because plugins are being used in libnetwork and swarmkit, this keeps the older interfaces in tact until those repos can be updated to make use of the new interfaces.

Why is this needed?

It would be nice to support other protocols for plugins such as GRPC. For instance, this is a requirement for supporting CSI plugins which mandate GRPC.