### PR TITLE
Fix fluentd partial detection

### DIFF
--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -163,7 +163,7 @@ func (f *fluentd) Log(msg *logger.Message) error {
 	for k, v := range f.extra {
 		data[k] = v
 	}
-	if msg.Partial {
+	if msg.PLogMetaData != nil {
 		data["partial_message"] = "true"
 	}
 


### PR DESCRIPTION
The Partial property of the Logger message was replaced by PLogMetaData in https://github.com/moby/moby/pull/35831, causing the build to fail.

This was broken by https://github.com/moby/moby/pull/36159, which had a stale CI (my bad 😅)

ping @anusha-ragunathan @cpuguy83 PTAL