### PR TITLE
Fix daemon.getSourceMount() for /

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -405,13 +405,7 @@ func getSourceMount(source string) (string, string, error) {
 			idx = i
 		}
 	}
-	// and return it unless it's "/"
-	if mi[idx].Mountpoint != "/" {
-		return mi[idx].Mountpoint, mi[idx].Optional, nil
-	}
-
-	// If we are here, we did not find parent mount. Something is wrong.
-	return "", "", fmt.Errorf("Could not find source mount of %s", source)
+	return mi[idx].Mountpoint, mi[idx].Optional, nil
 }
 
 const (

--- a/daemon/oci_linux_test.go
+++ b/daemon/oci_linux_test.go
@@ -1,6 +1,7 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"os"
 	"testing"
 
 	containertypes "github.com/docker/docker/api/types/container"
@@ -85,4 +86,17 @@ func TestIpcPrivateVsReadonly(t *testing.T) {
 		}
 		assert.Check(t, is.Equal(false, inSlice(m.Options, "ro")))
 	}
+}
+
+func TestGetSourceMount(t *testing.T) {
+	// must be able to find source mount for /
+	mnt, _, err := getSourceMount("/")
+	assert.NilError(t, err)
+	assert.Equal(t, mnt, "/")
+
+	// must be able to find source mount for current directory
+	cwd, err := os.Getwd()
+	assert.NilError(t, err)
+	_, _, err = getSourceMount(cwd)
+	assert.NilError(t, err)
 }


### PR DESCRIPTION
A recent optimization (#36091) in getSourceMount() made it return an error in case when the source mount is "/". This prevented bind-mounted volumes from working in such cases.

Fixes: 871c957242 ("getSourceMount(): simplify")

**- What I did**
Fixed `getSourceMount()` which I broke earlier

**- How I did it**
By removing the unnecessary and wrong check from the code

**- How to verify it**
I have added a unit test

**- Description for the changelog**
fix bind mounts not working in some cases

**- A picture of a cute animal (not mandatory but encouraged)**
![squirrel](https://upload.wikimedia.org/wikipedia/commons/9/9f/Mea_culpa_%2820331932453%29.jpg "squirrel")