### PR TITLE
Avoid unique name usage in TestDockerNetworkConnectAlias

### DIFF
--- a/integration/service/network_test.go
+++ b/integration/service/network_test.go
@@ -20,14 +20,14 @@ func TestDockerNetworkConnectAlias(t *testing.T) {
 	defer client.Close()
 	ctx := context.Background()
 
-	name := "test-alias"
+	name := t.Name() + "test-alias"
 	_, err := client.NetworkCreate(ctx, name, types.NetworkCreate{
 		Driver:     "overlay",
 		Attachable: true,
 	})
 	assert.NilError(t, err)
 
-	container.Create(t, ctx, client, container.WithName("ng1"), func(c *container.TestContainerConfig) {
+	cID1 := container.Create(t, ctx, client, func(c *container.TestContainerConfig) {
 		c.NetworkingConfig = &network.NetworkingConfig{
 			map[string]*network.EndpointSettings{
 				name: {},
@@ -35,22 +35,22 @@ func TestDockerNetworkConnectAlias(t *testing.T) {
 		}
 	})
 
-	err = client.NetworkConnect(ctx, name, "ng1", &network.EndpointSettings{
+	err = client.NetworkConnect(ctx, name, cID1, &network.EndpointSettings{
 		Aliases: []string{
 			"aaa",
 		},
 	})
 	assert.NilError(t, err)
 
-	err = client.ContainerStart(ctx, "ng1", types.ContainerStartOptions{})
+	err = client.ContainerStart(ctx, cID1, types.ContainerStartOptions{})
 	assert.NilError(t, err)
 
-	ng1, err := client.ContainerInspect(ctx, "ng1")
+	ng1, err := client.ContainerInspect(ctx, cID1)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(len(ng1.NetworkSettings.Networks[name].Aliases), 2))
 	assert.Check(t, is.Equal(ng1.NetworkSettings.Networks[name].Aliases[0], "aaa"))
 
-	container.Create(t, ctx, client, container.WithName("ng2"), func(c *container.TestContainerConfig) {
+	cID2 := container.Create(t, ctx, client, func(c *container.TestContainerConfig) {
 		c.NetworkingConfig = &network.NetworkingConfig{
 			map[string]*network.EndpointSettings{
 				name: {},
@@ -58,17 +58,17 @@ func TestDockerNetworkConnectAlias(t *testing.T) {
 		}
 	})
 
-	err = client.NetworkConnect(ctx, name, "ng2", &network.EndpointSettings{
+	err = client.NetworkConnect(ctx, name, cID2, &network.EndpointSettings{
 		Aliases: []string{
 			"bbb",
 		},
 	})
 	assert.NilError(t, err)
 
-	err = client.ContainerStart(ctx, "ng2", types.ContainerStartOptions{})
+	err = client.ContainerStart(ctx, cID2, types.ContainerStartOptions{})
 	assert.NilError(t, err)
 
-	ng2, err := client.ContainerInspect(ctx, "ng2")
+	ng2, err := client.ContainerInspect(ctx, cID2)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(len(ng2.NetworkSettings.Networks[name].Aliases), 2))
 	assert.Check(t, is.Equal(ng2.NetworkSettings.Networks[name].Aliases[0], "bbb"))


### PR DESCRIPTION
In `TestDockerNetworkConnectAlias` the network and container names used are unique which are not preferred. This fix address the issue by appending `t.Name()` so that names are randomized.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
