### PR TITLE
Fixing network inspect for swarm

### DIFF
--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -140,13 +140,13 @@ func swarmPortConfigToAPIPortConfig(portConfig *swarmapi.PortConfig) types.PortC
 func BasicNetworkFromGRPC(n swarmapi.Network) basictypes.NetworkResource {
 	spec := n.Spec
 	var ipam networktypes.IPAM
-	if spec.IPAM != nil {
-		if spec.IPAM.Driver != nil {
-			ipam.Driver = spec.IPAM.Driver.Name
-			ipam.Options = spec.IPAM.Driver.Options
+	if n.IPAM != nil {
+		if n.IPAM.Driver != nil {
+			ipam.Driver = n.IPAM.Driver.Name
+			ipam.Options = n.IPAM.Driver.Options
 		}
-		ipam.Config = make([]networktypes.IPAMConfig, 0, len(spec.IPAM.Configs))
-		for _, ic := range spec.IPAM.Configs {
+		ipam.Config = make([]networktypes.IPAMConfig, 0, len(n.IPAM.Configs))
+		for _, ic := range n.IPAM.Configs {
 			ipamConfig := networktypes.IPAMConfig{
 				Subnet:     ic.Subnet,
 				IPRange:    ic.Range,

--- a/integration/network/inspect_test.go
+++ b/integration/network/inspect_test.go
@@ -162,9 +162,19 @@ func noTasks(client client.ServiceAPIClient) func(log poll.LogT) poll.Result {
 // Check to see if Service and Tasks info are part of the inspect verbose response
 func validNetworkVerbose(network types.NetworkResource, service string, instances uint64) bool {
 	if service, ok := network.Services[service]; ok {
-		if len(service.Tasks) == int(instances) {
-			return true
+		if len(service.Tasks) != int(instances) {
+			return false
 		}
 	}
-	return false
+
+	if network.IPAM.Config == nil {
+		return false
+	}
+
+	for _, cfg := range network.IPAM.Config {
+		if cfg.Gateway == "" || cfg.Subnet == "" {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Signed-off-by: Abhinandan Prativadi <abhi@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
```docker network inspect ``` of a swarm network on a manager node was not displaying the subnet information unless there was a task in that network on manager node. 

**- What I did**
Fixed the GRPC conversion function
**- How I did it**

**- How to verify it**
```
$ docker network inspect net1
[
    {
        "Name": "net1",
        "Id": "6k4f6lg5xr34pndh33ikc9cwo",
        "Created": "2018-05-11T21:04:52.744708462Z",
        "Scope": "swarm",
        "Driver": "overlay",
        "EnableIPv6": false,
        "IPAM": {
            "Driver": "default",
            "Options": null,
            "Config": [
                {
                    "Subnet": "10.0.4.0/24",
                    "Gateway": "10.0.4.1"
                }
            ]
        },
        "Internal": false,
        "Attachable": false,
        "Ingress": false,
        "ConfigFrom": {
            "Network": ""
        },
        "ConfigOnly": false,
        "Containers": null,
        "Options": {
            "com.docker.network.driver.overlay.vxlanid_list": "4108"
        },
        "Labels": null
```

**- Description for the changelog**
Fix network inspect for overlay network


**- A picture of a cute animal (not mandatory but encouraged)**

