### PR TITLE
Fix missing plugin name in message

### DIFF
--- a/internal/test/daemon/plugin.go
+++ b/internal/test/daemon/plugin.go
@@ -38,7 +38,7 @@ func (d *Daemon) PluginIsNotPresent(name string) func(poll.LogT) poll.Result {
 		if err != nil {
 			return poll.Error(err)
 		}
-		return poll.Continue("plugin %q exists")
+		return poll.Continue("plugin %q exists", name)
 	})
 }
 


### PR DESCRIPTION
This message was missing the name of the plugin, resulting in

    plugin_test.go:92: timeout hit after 30s: plugin %!q(MISSING) exists

On failing tests.

