### PR TITLE
Make Windows 10 have process isolation only.

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -195,12 +195,6 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 	warnings := []string{}
 
 	hyperv := daemon.runAsHyperVContainer(hostConfig)
-	if !hyperv && system.IsWindowsClient() && !system.IsIoTCore() {
-		// @engine maintainers. This block should not be removed. It partially enforces licensing
-		// restrictions on Windows. Ping @jhowardmsft if there are concerns or PRs to change this.
-		return warnings, fmt.Errorf("Windows client operating systems only support Hyper-V containers")
-	}
-
 	w, err := verifyContainerResources(&hostConfig.Resources, hyperv)
 	warnings = append(warnings, w...)
 	return warnings, err
@@ -593,9 +587,6 @@ func (daemon *Daemon) setDefaultIsolation() error {
 	daemon.defaultIsolation = containertypes.Isolation("process")
 	// On client SKUs, default to Hyper-V. Note that IoT reports as a client SKU
 	// but it should not be treated as such.
-	if system.IsWindowsClient() && !system.IsIoTCore() {
-		daemon.defaultIsolation = containertypes.Isolation("hyperv")
-	}
 	for _, option := range daemon.configStore.ExecOptions {
 		key, val, err := parsers.ParseKeyValueOpt(option)
 		if err != nil {
@@ -612,11 +603,6 @@ func (daemon *Daemon) setDefaultIsolation() error {
 				daemon.defaultIsolation = containertypes.Isolation("hyperv")
 			}
 			if containertypes.Isolation(val).IsProcess() {
-				if system.IsWindowsClient() && !system.IsIoTCore() {
-					// @engine maintainers. This block should not be removed. It partially enforces licensing
-					// restrictions on Windows. Ping @jhowardmsft if there are concerns or PRs to change this.
-					return fmt.Errorf("Windows client operating systems only support Hyper-V containers")
-				}
 				daemon.defaultIsolation = containertypes.Isolation("process")
 			}
 		default:


### PR DESCRIPTION
**- What I did**

Removed ability to run hyper-v isolation on windows 10.

**- How I did it**

Delete code to detect windows 10, on non iotc versions.

**- How to verify it**

Overwrite dockerd.exe on windows 10 and run any docker command, verify in process explorer that you can see the process.



All of this is to raise awareness.
