### PR TITLE
Extend client API with custom HTTP requests

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -356,6 +356,11 @@ func (cli *Client) DaemonHost() string {
 	return cli.host
 }
 
+// HTTPClient returns a copy of the HTTP client bound to the server
+func (cli *Client) HTTPClient() *http.Client {
+	return &*cli.client
+}
+
 // ParseHostURL parses a url string, validates the string is a host url, and
 // returns the parsed URL
 func ParseHostURL(host string) (*url.URL, error) {

--- a/client/interface.go
+++ b/client/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"net/http"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -33,6 +34,7 @@ type CommonAPIClient interface {
 	VolumeAPIClient
 	ClientVersion() string
 	DaemonHost() string
+	HTTPClient() *http.Client
 	ServerVersion(ctx context.Context) (types.Version, error)
 	NegotiateAPIVersion(ctx context.Context)
 	NegotiateAPIVersionPing(types.Ping)


### PR DESCRIPTION
**- What I did**

I made the client underlying HTTP client accessible, useful for instance for https://github.com/docker/cli/pull/1034

**- How I did it**

Added a `HTTPClient()` accessor to the `Client` interface.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/2386884/40059171-aac3b3f2-5853-11e8-856d-78c985863ade.png)
