### PR TITLE
Fix flaky test case of `TestExecInteractiveStdinClose`

### DIFF
--- a/integration-cli/docker_cli_exec_unix_test.go
+++ b/integration-cli/docker_cli_exec_unix_test.go
@@ -33,7 +33,9 @@ func (s *DockerSuite) TestExecInteractiveStdinClose(c *check.C) {
 	select {
 	case err := <-ch:
 		c.Assert(err, checker.IsNil)
-		output := b.String()
+		bs := b.Bytes()
+		bs = bytes.Trim(bs, "\x00")
+		output := string(bs[:])
 		c.Assert(strings.TrimSpace(output), checker.Equals, "hello")
 	case <-time.After(5 * time.Second):
 		c.Fatal("timed out running docker exec")


### PR DESCRIPTION
fixes #36877

This issue has been reported by issue #36877.

The purpose of this test case is for the regression test of #12546,
so we only need to make sure the essential of the testing is still
in the way to check that while not disturbed by some testing noises,
which is exactly what this PR want to do.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

