### PR TITLE
Ensure that install the latest version of tini

### DIFF
--- a/hack/dockerfile/install/tini.installer
+++ b/hack/dockerfile/install/tini.installer
@@ -1,12 +1,12 @@
 #!/bin/sh
 
-TINI_COMMIT=fec3683b971d9c3ef73f284f176672c44b448662 # v0.18.0
+TINI_LATEST_VERSION=v$(curl -fsSL https://api.github.com/repos/krallin/tini/releases/latest| grep '"tag_name":'|sed -E 's/.*"v([0-9.]+)".*/\1/')
 
 install_tini() {
-	echo "Install tini version $TINI_COMMIT"
-	git clone https://github.com/krallin/tini.git "$GOPATH/tini"
-	cd "$GOPATH/tini"
-	git checkout -q "$TINI_COMMIT"
+	echo "Install tini version ${TINI_LATEST_VERSION}"
+	git clone https://github.com/krallin/tini.git "${GOPATH}/tini"
+	cd "${GOPATH}/tini"
+	git checkout -q "${TINI_LATEST_VERSION}"
 	cmake .
 	make tini-static
 	mkdir -p ${PREFIX}


### PR DESCRIPTION
### Ensure that install the latest version of tini
*    Get information of the  latest tini version from [here](https://api.github.com/repos/krallin/tini/releases/latest)
*    Get the latest version automatically
*    Discard update tini manually