### PR TITLE
Some slight tweaks for the integration test

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -159,7 +159,7 @@ ORIG_BUILDFLAGS+=( $REBUILD_FLAG )
 BUILDFLAGS=( $BUILDFLAGS "${ORIG_BUILDFLAGS[@]}" )
 
 # Test timeout.
-if [ "${DOCKER_ENGINE_GOARCH}" == "arm" ]; then
+if [ "${DOCKER_ENGINE_GOARCH}" == "arm64" ] || [ "${DOCKER_ENGINE_GOARCH}" == "arm" ]; then
 	: ${TIMEOUT:=10m}
 elif [ "${DOCKER_ENGINE_GOARCH}" == "windows" ]; then
 	: ${TIMEOUT:=8m}

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -22,7 +22,7 @@ func ServicePoll(config *poll.Settings) {
 	config.Timeout = 30 * time.Second
 	config.Delay = 100 * time.Millisecond
 	if runtime.GOARCH == "arm64" || runtime.GOARCH == "arm" {
-		config.Timeout = 1 * time.Minute
+		config.Timeout = 90 * time.Second
 	}
 }
 


### PR DESCRIPTION
Service is time-consuming operation, we've observed some timeout failures for this kind of test such as [TestServicePlugin](https://jenkins.dockerproject.org/job/Docker-PRs/49447/console), so we adjust the timeout value from '30s' to '1m' in this PR..

`arm64` needs get more time duration for the test to finish.

`pty.Start()` opens a file, so the caller should close it explicitly, else the file I/O can result in unexpected data synchronization issue.

All those changes will not affect the test itself.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

