### PR TITLE
Fix typos: remove duplicated "the"

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3815,7 +3815,7 @@ definitions:
           - "process"
       InitBinary:
         description: |
-          Name and, optional, path of the the `docker-init` binary.
+          Name and, optional, path of the `docker-init` binary.
 
           If the path is omitted, the daemon searches the host's `$PATH` for the
           binary and uses the first result.
@@ -4033,7 +4033,7 @@ definitions:
           - "https://registry-3.docker.io/"
       Secure:
         description: |
-          Indicates if the the registry is part of the list of insecure
+          Indicates if the registry is part of the list of insecure
           registries.
 
           If `false`, the registry is insecure. Insecure registries accept

--- a/daemon/cluster/controllers/plugin/controller.go
+++ b/daemon/cluster/controllers/plugin/controller.go
@@ -20,7 +20,7 @@ import (
 
 // Controller is the controller for the plugin backend.
 // Plugins are managed as a singleton object with a desired state (different from containers).
-// With the the plugin controller instead of having a strict create->start->stop->remove
+// With the plugin controller instead of having a strict create->start->stop->remove
 // task lifecycle like containers, we manage the desired state of the plugin and let
 // the plugin manager do what it already does and monitor the plugin.
 // We'll also end up with many tasks all pointing to the same plugin ID.

--- a/errdefs/is.go
+++ b/errdefs/is.go
@@ -47,7 +47,7 @@ func IsConflict(err error) bool {
 	return ok
 }
 
-// IsUnauthorized returns if the the passed in error is an ErrUnauthorized
+// IsUnauthorized returns if the passed in error is an ErrUnauthorized
 func IsUnauthorized(err error) bool {
 	_, ok := getImplementer(err).(ErrUnauthorized)
 	return ok

--- a/pkg/stdcopy/stdcopy.go
+++ b/pkg/stdcopy/stdcopy.go
@@ -21,7 +21,7 @@ const (
 	// Stderr represents standard error steam type.
 	Stderr
 	// Systemerr represents errors originating from the system that make it
-	// into the the multiplexed stream.
+	// into the multiplexed stream.
 	Systemerr
 
 	stdWriterPrefixLen = 8

--- a/plugin/v2/plugin.go
+++ b/plugin/v2/plugin.go
@@ -257,7 +257,7 @@ func (p *Plugin) Release() {
 	p.AddRefCount(plugingetter.Release)
 }
 
-// SetSpecOptModifier sets the function to use to modify the the generated
+// SetSpecOptModifier sets the function to use to modify the generated
 // runtime spec.
 func (p *Plugin) SetSpecOptModifier(f func(*specs.Spec)) {
 	p.mu.Lock()


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I just fixed typos of duplicated "the", which commonly happen. 

**- How I did it**

`s/the the /the /g`

**- How to verify it**

I believe the diff looks enough clear.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

None.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1811616/40176663-27751f52-5a17-11e8-8234-1694e2f4a235.png)

<image src="https://user-images.githubusercontent.com/1811616/40176639-0ce88822-5a17-11e8-8ae7-244364e84b4f.png" width="400px">