### PR TITLE
Make integration tests less noisy

### DIFF
--- a/internal/test/environment/clean.go
+++ b/internal/test/environment/clean.go
@@ -25,7 +25,7 @@ type logT interface {
 // Clean the environment, preserving protected objects (images, containers, ...)
 // and removing everything else. It's meant to run after any tests so that they don't
 // depend on each others.
-func (e *Execution) Clean(t testingT) {
+func (e *Execution) Clean(t assert.TestingT) {
 	if ht, ok := t.(test.HelperT); ok {
 		ht.Helper()
 	}
@@ -112,7 +112,7 @@ func getAllContainers(ctx context.Context, t assert.TestingT, client client.Cont
 	return containers
 }
 
-func deleteAllImages(t testingT, apiclient client.ImageAPIClient, protectedImages map[string]struct{}) {
+func deleteAllImages(t assert.TestingT, apiclient client.ImageAPIClient, protectedImages map[string]struct{}) {
 	if ht, ok := t.(test.HelperT); ok {
 		ht.Helper()
 	}
@@ -123,15 +123,12 @@ func deleteAllImages(t testingT, apiclient client.ImageAPIClient, protectedImage
 	for _, image := range images {
 		tags := tagsFromImageSummary(image)
 		if len(tags) == 0 {
-			t.Logf("Removing image %s", image.ID)
 			removeImage(ctx, t, apiclient, image.ID)
 			continue
 		}
 		for _, tag := range tags {
 			if _, ok := protectedImages[tag]; !ok {
-				t.Logf("Removing image %s", tag)
 				removeImage(ctx, t, apiclient, tag)
-				continue
 			}
 		}
 	}


### PR DESCRIPTION
The `deleteAllImages()` cleanup step in the integration suite was printing a message for each image that was removed.

These messages were not very informative (given that `removeImage()` prints an error if image removal failed), and made the test output harder to read (more difficult to see error-conditions when scanning the output).

This patch removes the messages to make the output slightly less noisy.

Before this patch applied:

    --- PASS: TestBuildMultiStageOnBuild (7.15s)
    	main_test.go:32: Removing image sha256:9db3ddbaaadd52804d8a417081f68db41fd4b8f80c85c1b4c4aee2d9b584c074
    	main_test.go:32: Removing image sha256:7eeb04d90b5e62a99ac6a5b2c10b9ba54b89b176fe2783e41461581c482852b3
    	main_test.go:32: Removing image sha256:adf42475eefff99b4a611c1a5d8353c4d0a011a7f7b9dc59a75d951cd54fa77f
    	main_test.go:32: Removing image sha256:c547a770806e0445f5dfc255683ced771a23be6157ba8d0617bb9ab55dcee6d1
    	main_test.go:32: Removing image sha256:b79659c3e6d34faf2a075f1df1ea2c805833982f112666b25a466177b5d1352d
    	main_test.go:32: Removing image sha256:29430078cdc927c19c87416cd1fb1ec386f167c5e201ee5dfb1644dcf268a3c2
    === RUN   TestBuildUncleanTarFilenames
    --- PASS: TestBuildUncleanTarFilenames (2.47s)
    	main_test.go:32: Removing image sha256:0a6418fb221dc2f25085a1a7e507e01c4a3938cc5c65f1cb85a8c0fb09d6814f
    	main_test.go:32: Removing image sha256:3d6e4bd0cce01ce5823b40dcb717cd16b3b4b769ff73dd86fa448aac49aa6d7c
    	main_test.go:32: Removing image sha256:98e3f335e874612668335b3a5f125a1e5cbd0f6c79a7c3f719529b69d0abf2a5
    	main_test.go:32: Removing image sha256:08919f344b382fd1447da7f3e8ffd2a7125f5f7d191ed7d33242736dbe3c59cf
    	main_test.go:32: Removing image sha256:d144b3c13838e841ec319a17e1046471d726bb2aa3211e167a6a53f766a2dcdc
    	main_test.go:32: Removing image sha256:7c768ec742d628020f50c99dc5af32400b78534ca9fc4c01a9f00ec0ab19193a
    	main_test.go:32: Removing image sha256:4c26c71d142045fbf3448aa1f6363d5a7a803cb438a78a4b20b7c847df03d50a
    	main_test.go:32: Removing image sha256:08dcd63c964f2dbb17ff2665b6b86993fb14c0d3e169da187ac48f078a560d25
    	main_test.go:32: Removing image sha256:c1743fab233f36f2d7f83cb13f8c10ff06bdbda8f8a218d25a3796d1bc2f9e84
    === RUN   TestBuildMultiStageLayerLeak
    --- PASS: TestBuildMultiStageLayerLeak (5.59s)
    	main_test.go:32: Removing image sha256:5e9974558276c34d7c9aab3fad408d433047b7b15bdae43ab5048adc58a15431
    	main_test.go:32: Removing image sha256:ac3c613c8c48794237c1e46ac0657ebbb1132910a240086bb2e9df9770fdc017
    	main_test.go:32: Removing image sha256:a936df268131ad427f7b4b66ce3dbb1e41866d7269a4d383cebcb1c5930d3346
    	main_test.go:32: Removing image sha256:5e613ea0ce7dbc908b0315c49585ae43ad6c34158e9e0b59a3dc93b00ef0ea41
    	main_test.go:32: Removing image sha256:e676f4ec41a42823b6d91e05e3290d3827f9175dea6fba5d8b769aa13aa7e082
    	main_test.go:32: Removing image sha256:93c8daab2703126b23d957d4d6b04f07949356f1cd95d4f8fdbededf4ab5c21e


With this patch applied:

    === RUN   TestBuildMultiStageOnBuild
    --- PASS: TestBuildMultiStageOnBuild (6.74s)
    === RUN   TestBuildUncleanTarFilenames
    --- PASS: TestBuildUncleanTarFilenames (2.49s)
    === RUN   TestBuildMultiStageLayerLeak
    --- PASS: TestBuildMultiStageLayerLeak (5.14s)

