### PR TITLE
Clarify scope-escape error for `docker volume rm`

### DIFF
--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -211,7 +211,7 @@ func (r *Root) Remove(v volume.Volume) error {
 	}
 
 	if !r.scopedPath(realPath) {
-		return errdefs.System(errors.Errorf("Unable to remove a directory of out the Docker root %s: %s", r.scope, realPath))
+		return errdefs.System(errors.Errorf("Unable to remove a directory outside of the Docker root %s: %s", r.scope, realPath))
 	}
 
 	if err := removePath(realPath); err != nil {


### PR DESCRIPTION
**- What I did**
Rewrote the error message to correct grammar and clarify.
**- How I did it**

**- How to verify it**
Discovered and demonstrated by creating a volume, linking its _data directory outside of the data-root 
> PS C:\> docker create volume bracket-tracker-app
> PS C:\> stop-service docker
> PS C:\> remove-item C:\ProgramData\Docker\Volumes\bracket-tracker-app\_data
> PS C:\> new-item -Type Junction -target C:\Work\Bracket-Tracker\app -Path C:\ProgramData\Docker\Volumes\bracket-tracker-app\_data
> PS C:\> start-service docker
> PS C:\> docker rm volume bracket-tracker-app
> Error response from daemon: unable to remove volume: remove bracket-tracker-app: Unable to remove a directory of out the Docker root C:\ProgramData\Docker: C:\Work\bracket-tracker\app
**- Description for the changelog**
Cleaned up error message thrown when `docker volume rm` will escape the `data-root`.
**- A picture of a cute animal (not mandatory but encouraged)**
