### PR TITLE
Rewrote data-root escape error message

### DIFF
--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -211,7 +211,7 @@ func (r *Root) Remove(v volume.Volume) error {
 	}
 
 	if !r.scopedPath(realPath) {
-		return errdefs.System(errors.Errorf("Unable to remove a directory outside of the Docker root %s: %s", r.scope, realPath))
+		return errdefs.System(errors.Errorf("Unable to remove a directory outside of the local volume root %s: %s", r.scope, realPath))
 	}
 
 	if err := removePath(realPath); err != nil {

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -211,7 +211,7 @@ func (r *Root) Remove(v volume.Volume) error {
 	}
 
 	if !r.scopedPath(realPath) {
-		return errdefs.System(errors.Errorf("Unable to remove a directory of out the Docker root %s: %s", r.scope, realPath))
+		return errdefs.System(errors.Errorf("Unable to remove a directory outside of the Docker root %s: %s", r.scope, realPath))
 	}
 
 	if err := removePath(realPath); err != nil {


### PR DESCRIPTION
Signed-off-by: Jonathan Choy <jonathan.j.choy@gmail.com>

**- What I did**
Rewrote the error message thrown when a `docker volume rm` would escape the `data-root`.
**- How I did it**
Inline edits on GitHub (which don't create signed-off-by taggable commits)

**- How to verify it**

**- Description for the changelog**
Improved the error message thrown when a `docker volume rm` would, for example, follow a junction outside of the scope of the data-root.

**- A picture of a cute animal (not mandatory but encouraged)**

