### PR TITLE
Create Swarm network with IPAM and driver spec

### DIFF
--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -598,16 +598,19 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 		}
 	}
 
-	if na.Network.DriverState != nil {
-		options.Driver = na.Network.DriverState.Name
-		options.Options = na.Network.DriverState.Options
+	driverConfig := na.Network.Spec.DriverConfig
+	if driverConfig != nil {
+		options.Driver = driverConfig.Name
+		options.Options = driverConfig.Options
 	}
-	if na.Network.IPAM != nil {
+
+	ipamConfig := na.Network.Spec.IPAM
+	if ipamConfig != nil {
 		options.IPAM = &network.IPAM{
-			Driver:  na.Network.IPAM.Driver.Name,
-			Options: na.Network.IPAM.Driver.Options,
+			Driver:  ipamConfig.Driver.Name,
+			Options: ipamConfig.Driver.Options,
 		}
-		for _, ic := range na.Network.IPAM.Configs {
+		for _, ic := range ipamConfig.Configs {
 			c := network.IPAMConfig{
 				Subnet:  ic.Subnet,
 				IPRange: ic.Range,


### PR DESCRIPTION
Fixes #37089 

**- What I did**

Fixed the swarm network creation to use the correct IPAM and driverConfig settings.

**- How I did it**

During the creation of the swarm network, now the Specs are used instead of the runtime configuration, which doesn't exist when creating the network.

**- How to verify it**

See reproduction instructions on #37089

**- Description for the changelog**

Creating a swarm scoped network now correctly uses the spec of IPAM and driver settings.

**- A picture of a cute animal (not mandatory but encouraged)**
