### PR TITLE
TestContainerAPITop: fix flakyness

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -442,7 +442,8 @@ func (s *DockerSuite) TestContainerAPITop(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cli.Close()
 
-	top, err := cli.ContainerTop(context.Background(), id, []string{"aux"})
+	// sort by comm[andline] to make sure order stays the same in case of PID rollover
+	top, err := cli.ContainerTop(context.Background(), id, []string{"aux", "--sort=comm"})
 	c.Assert(err, checker.IsNil)
 	c.Assert(top.Titles, checker.HasLen, 11, check.Commentf("expected 11 titles, found %d: %v", len(top.Titles), top.Titles))
 


### PR DESCRIPTION
The following failure is seen in CI from time to time:

> FAIL: docker_api_containers_test.go:435: DockerSuite.TestContainerAPITop
>
> docker_api_containers_test.go:453:
>     c.Assert(top.Processes[0][10], checker.Equals, "/bin/sh -c top")
> ... obtained string = "top"
> ... expected string = "/bin/sh -c top"

The test case expects two processes in the output:

1. /bin/sh -c top
2. top

in the given order.

Now, "ps aux" output is sorted by PID`*`, and so since the "top" is a child of "/bin/sh -c top" it has a higher PID and will come second as expected by the test... unless the PIDs on the system are exhausted and PID rollover happens, in which case PID of "top" will be lower than that of "/bin/sh".

The obvious fix is to sort ps output by command line.

Should fix https://github.com/moby/moby/issues/37109

`*`  in fact it is not sorted, but is being printed in the same order as the kernel list PID entries in /proc directory, which appears to be sorted by PID (see ls -1 -U /proc).