### PR TITLE
Set item-type for ExecIDs

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4663,7 +4663,11 @@ paths:
               AppArmorProfile:
                 type: "string"
               ExecIDs:
+                description: "IDs of exec instances that are running in the container."
                 type: "array"
+                items:
+                  type: "string"
+                x-nullable: true
               HostConfig:
                 $ref: "#/definitions/HostConfig"
               GraphDriver:
@@ -4720,6 +4724,9 @@ paths:
                 StopTimeout: 10
               Created: "2015-01-06T15:47:31.485331387Z"
               Driver: "devicemapper"
+              ExecIDs:
+                - "b35395de42bc8abd327f9dd65d913b9ba28c74d2f0734eeeae84fa1c616a0fca"
+                - "3fc1232e5cd20c8de182ed81178503dc6437f4e7ef12b52cc5e8de020652f1c4"
               HostConfig:
                 MaximumIOps: 0
                 MaximumIOBps: 0


### PR DESCRIPTION
Arrays expect a type to be set for items in the array.

This patch adds the "string" type, adds a short description, and some example values.

follow-up to https://github.com/moby/moby/pull/36962/files