### PR TITLE
Optimize ContainerTop() aka docker top

### DIFF
--- a/daemon/daemon_linux_test.go
+++ b/daemon/daemon_linux_test.go
@@ -229,6 +229,10 @@ func checkMounted(t *testing.T, p string, expect bool) {
 }
 
 func TestRootMountCleanup(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root required")
+	}
+
 	t.Parallel()
 
 	testRoot, err := ioutil.TempDir("", t.Name())

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -153,6 +153,10 @@ func TestValidContainerNames(t *testing.T) {
 }
 
 func TestContainerInitDNS(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root required") // for chown
+	}
+
 	tmp, err := ioutil.TempDir("", "docker-container-test-")
 	if err != nil {
 		t.Fatal(err)

--- a/daemon/reload_test.go
+++ b/daemon/reload_test.go
@@ -1,6 +1,7 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -499,6 +500,9 @@ func TestDaemonDiscoveryReloadOnlyClusterAdvertise(t *testing.T) {
 }
 
 func TestDaemonReloadNetworkDiagnosticPort(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root required")
+	}
 	daemon := &Daemon{
 		imageService: images.NewImageService(images.ImageServiceConfig{}),
 	}

--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -70,6 +70,7 @@ func parsePSOutput(output []byte, procs []uint32) (*container.ContainerTopOKBody
 	for i, name := range procList.Titles {
 		if name == "PID" {
 			pidIndex = i
+			break
 		}
 	}
 	if pidIndex == -1 {


### PR DESCRIPTION
**- What I did**

Optimized the implementation of `ContainerTop()` (aka `docker top`) resulting in 5x to 100x speed improvement (and some savings in CPU and memory usage that were not measured).

**- How I did it**

Current ContainerTop (a.k.a. docker top) implementation uses "ps" to get the info about *all* running processes, then parses it, then    filters the results to only contain PIDs used by the container.    Collecting data only to throw most of it away is inefficient,    especially on a system running many containers (or processes).    For example, "docker top" on a container with a single process    can take up to 0.5 seconds to execute (on a mostly idle system)    which is noticeably slow.
    
Since the containers PIDs are known beforehand, let's use ps's    "q" option to provide it with a list of PIDs we want info about.

**- How to verify it**

1. Existing integration test case `TestContainerAPITop`.
2. Manual run of `docker top` with various options.

**- Description for the changelog**
* ContainerTop speed up

**- A picture of a cute animal (not mandatory but encouraged)**

![Moscow zoo racoon](https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Raccoon_Moscow_zoo.JPG/1280px-Raccoon_Moscow_zoo.JPG)
Source: https://commons.wikimedia.org/wiki/File:Raccoon_Moscow_zoo.JPG