### PR TITLE
builder: fix processing of invalid substitution syntax

### DIFF
--- a/builder/dockerfile/shell/envVarTest
+++ b/builder/dockerfile/shell/envVarTest
@@ -174,3 +174,38 @@ A|$9                        |
 A|${9}                      |
 A|${9:+bbb}                 |
 A|${9:-bbb}                 |     bbb
+
+# Special parameters won't be set in the Dockerfile:
+# http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_05_02
+A|$@                        |
+A|${@}                      |
+A|${@:+bbb}                 |
+A|${@:-bbb}                 |     bbb
+A|$*                        |
+A|${*}                      |
+A|${*:+bbb}                 |
+A|${*:-bbb}                 |     bbb
+A|$#                        |
+A|${#}                      |
+A|${#:+bbb}                 |
+A|${#:-bbb}                 |     bbb
+A|$?                        |
+A|${?}                      |
+A|${?:+bbb}                 |
+A|${?:-bbb}                 |     bbb
+A|$-                        |
+A|${-}                      |
+A|${-:+bbb}                 |
+A|${-:-bbb}                 |     bbb
+A|$$                        |
+A|${$}                      |
+A|${$:+bbb}                 |
+A|${$:-bbb}                 |     bbb
+A|$!                        |
+A|${!}                      |
+A|${!:+bbb}                 |
+A|${!:-bbb}                 |     bbb
+A|$0                        |
+A|${0}                      |
+A|${0:+bbb}                 |
+A|${0:-bbb}                 |     bbb

--- a/builder/dockerfile/shell/envVarTest
+++ b/builder/dockerfile/shell/envVarTest
@@ -18,7 +18,6 @@ A|'hello\there'            |     hello\there
 A|'hello\\there'           |     hello\\there
 A|"''"                     |     ''
 A|$.                       |     $.
-A|$1                       |
 A|he$1x                    |     hex
 A|he$.x                    |     he$.x
 # Next one is different on Windows as $pwd==$PWD
@@ -137,3 +136,41 @@ A|${:}                      |     error
 A|${:-bbb}                  |     error
 A|${:+bbb}                  |     error
 
+# Positional parameters won't be set:
+# http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_05_01
+A|$1                        |
+A|${1}                      |
+A|${1:+bbb}                 |
+A|${1:-bbb}                 |     bbb
+A|$2                        |
+A|${2}                      |
+A|${2:+bbb}                 |
+A|${2:-bbb}                 |     bbb
+A|$3                        |
+A|${3}                      |
+A|${3:+bbb}                 |
+A|${3:-bbb}                 |     bbb
+A|$4                        |
+A|${4}                      |
+A|${4:+bbb}                 |
+A|${4:-bbb}                 |     bbb
+A|$5                        |
+A|${5}                      |
+A|${5:+bbb}                 |
+A|${5:-bbb}                 |     bbb
+A|$6                        |
+A|${6}                      |
+A|${6:+bbb}                 |
+A|${6:-bbb}                 |     bbb
+A|$7                        |
+A|${7}                      |
+A|${7:+bbb}                 |
+A|${7:-bbb}                 |     bbb
+A|$8                        |
+A|${8}                      |
+A|${8:+bbb}                 |
+A|${8:-bbb}                 |     bbb
+A|$9                        |
+A|${9}                      |
+A|${9:+bbb}                 |
+A|${9:-bbb}                 |     bbb

--- a/builder/dockerfile/shell/envVarTest
+++ b/builder/dockerfile/shell/envVarTest
@@ -119,3 +119,14 @@ A|안녕${XXX:-\$PWD:}xx       |     안녕$PWD:xx
 A|안녕${XXX:-\${PWD}z}xx     |     안녕${PWDz}xx
 A|$KOREAN                    |     한국어
 A|안녕$KOREAN                |     안녕한국어
+A|${{aaa}                   |     error
+A|${aaa}}                   |     }
+A|${aaa                     |     error
+A|${{aaa:-bbb}              |     error
+A|${aaa:-bbb}}              |     bbb}
+A|${aaa:-bbb                |     error
+A|${aaa:-bbb}               |     bbb
+A|${aaa:-${bbb:-ccc}}       |     ccc
+A|${aaa:-bbb ${foo}         |     error
+A|${aaa:-bbb {foo}          |     bbb {foo
+

--- a/builder/dockerfile/shell/envVarTest
+++ b/builder/dockerfile/shell/envVarTest
@@ -29,10 +29,14 @@ A|he\$PWD                  |     he$PWD
 A|he\\$PWD                 |     he\/home
 A|"he\$PWD"                |     he$PWD
 A|"he\\$PWD"               |     he\/home
+A|\${}                     |     ${}
+A|\${}aaa                  |     ${}aaa
 A|he\${}                   |     he${}
 A|he\${}xx                 |     he${}xx
-A|he${}                    |     he
-A|he${}xx                  |     hexx
+A|${}                      |     error
+A|${}aaa                   |     error
+A|he${}                    |     error
+A|he${}xx                  |     error
 A|he${hi}                  |     he
 A|he${hi}xx                |     hexx
 A|he${PWD}                 |     he/home
@@ -88,8 +92,8 @@ A|안녕\$PWD                  |     안녕$PWD
 A|안녕\\$PWD                 |     안녕\/home
 A|안녕\${}                   |     안녕${}
 A|안녕\${}xx                 |     안녕${}xx
-A|안녕${}                    |     안녕
-A|안녕${}xx                  |     안녕xx
+A|안녕${}                    |     error
+A|안녕${}xx                  |     error
 A|안녕${hi}                  |     안녕
 A|안녕${hi}xx                |     안녕xx
 A|안녕${PWD}                 |     안녕/home
@@ -129,4 +133,7 @@ A|${aaa:-bbb}               |     bbb
 A|${aaa:-${bbb:-ccc}}       |     ccc
 A|${aaa:-bbb ${foo}         |     error
 A|${aaa:-bbb {foo}          |     bbb {foo
+A|${:}                      |     error
+A|${:-bbb}                  |     error
+A|${:+bbb}                  |     error
 

--- a/builder/dockerfile/shell/envVarTest
+++ b/builder/dockerfile/shell/envVarTest
@@ -174,6 +174,22 @@ A|$9                        |
 A|${9}                      |
 A|${9:+bbb}                 |
 A|${9:-bbb}                 |     bbb
+A|$999                      |
+A|${999}                    |
+A|${999:+bbb}               |
+A|${999:-bbb}               |     bbb
+A|$999aaa                   |     aaa
+A|${999}aaa                 |     aaa
+A|${999:+bbb}aaa            |     aaa
+A|${999:-bbb}aaa            |     bbbaaa
+A|$001                      |
+A|${001}                    |
+A|${001:+bbb}               |
+A|${001:-bbb}               |     bbb
+A|$001aaa                   |     aaa
+A|${001}aaa                 |     aaa
+A|${001:+bbb}aaa            |     aaa
+A|${001:-bbb}aaa            |     bbbaaa
 
 # Special parameters won't be set in the Dockerfile:
 # http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_05_02
@@ -181,6 +197,11 @@ A|$@                        |
 A|${@}                      |
 A|${@:+bbb}                 |
 A|${@:-bbb}                 |     bbb
+A|$@@@                      |     @@
+A|$@aaa                     |     aaa
+A|${@}aaa                   |     aaa
+A|${@:+bbb}aaa              |     aaa
+A|${@:-bbb}aaa              |     bbbaaa
 A|$*                        |
 A|${*}                      |
 A|${*:+bbb}                 |

--- a/builder/dockerfile/shell/lex.go
+++ b/builder/dockerfile/shell/lex.go
@@ -318,7 +318,7 @@ func (sw *shellWord) processName() string {
 
 	for sw.scanner.Peek() != scanner.EOF {
 		ch := sw.scanner.Peek()
-		if name.Len() == 0 && unicode.IsDigit(ch) {
+		if name.Len() == 0 && (unicode.IsDigit(ch) || isSpecialParam(ch)) {
 			ch = sw.scanner.Next()
 			return string(ch)
 		}
@@ -330,6 +330,18 @@ func (sw *shellWord) processName() string {
 	}
 
 	return name.String()
+}
+
+// isSpecialParam checks if the provided character is a special parameters,
+// as defined in http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_05_02
+func isSpecialParam(char rune) bool {
+	switch char {
+	case '@', '*', '#', '?', '-', '$', '!', '0':
+		// Special parameters
+		// http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_05_02
+		return true
+	}
+	return false
 }
 
 func (sw *shellWord) getEnv(name string) string {

--- a/builder/dockerfile/shell/lex.go
+++ b/builder/dockerfile/shell/lex.go
@@ -318,7 +318,15 @@ func (sw *shellWord) processName() string {
 
 	for sw.scanner.Peek() != scanner.EOF {
 		ch := sw.scanner.Peek()
-		if name.Len() == 0 && (unicode.IsDigit(ch) || isSpecialParam(ch)) {
+		if name.Len() == 0 && unicode.IsDigit(ch) {
+			for sw.scanner.Peek() != scanner.EOF && unicode.IsDigit(sw.scanner.Peek()) {
+				// Keep reading until the first non-digit character, or EOF
+				ch = sw.scanner.Next()
+				name.WriteRune(ch)
+			}
+			return name.String()
+		}
+		if name.Len() == 0 && isSpecialParam(ch) {
 			ch = sw.scanner.Next()
 			return string(ch)
 		}

--- a/builder/dockerfile/shell/lex_test.go
+++ b/builder/dockerfile/shell/lex_test.go
@@ -55,8 +55,8 @@ func TestShellParser4EnvVars(t *testing.T) {
 			if expected == "error" {
 				assert.Check(t, is.ErrorContains(err, ""), "input: %q, result: %q", source, newWord)
 			} else {
-				assert.Check(t, err)
-				assert.Check(t, is.Equal(newWord, expected))
+				assert.Check(t, err, "at line %d of %s", lineCount, fn)
+				assert.Check(t, is.Equal(newWord, expected), "at line %d of %s", lineCount, fn)
 			}
 		}
 	}

--- a/builder/dockerfile/shell/lex_test.go
+++ b/builder/dockerfile/shell/lex_test.go
@@ -53,7 +53,7 @@ func TestShellParser4EnvVars(t *testing.T) {
 			((platform == "U" || platform == "A") && runtime.GOOS != "windows") {
 			newWord, err := shlex.ProcessWord(source, envs)
 			if expected == "error" {
-				assert.Check(t, is.ErrorContains(err, ""))
+				assert.Check(t, is.ErrorContains(err, ""), "input: %q, result: %q", source, newWord)
 			} else {
 				assert.Check(t, err)
 				assert.Check(t, is.Equal(newWord, expected))

--- a/builder/dockerfile/shell/lex_test.go
+++ b/builder/dockerfile/shell/lex_test.go
@@ -26,13 +26,11 @@ func TestShellParser4EnvVars(t *testing.T) {
 		line := scanner.Text()
 		lineCount++
 
-		// Trim comments and blank lines
-		i := strings.Index(line, "#")
-		if i >= 0 {
-			line = line[:i]
+		// Skip comments and blank lines
+		if strings.HasPrefix(line, "#") {
+			continue
 		}
 		line = strings.TrimSpace(line)
-
 		if line == "" {
 			continue
 		}


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/37128

The builder did not detect syntax errors in substitutions in the
Dockerfile, causing those values to be processed incorrectly instead of
producing an error.

### Example 1: missing `}`

    docker build --no-cache -<<'EOF'
    FROM busybox
    ARG var=${aaa:-bbb
    RUN echo $var
    EOF

#### Before:

    Step 3/3 : RUN echo $var
     ---> Running in f06571e77146
    bbb

#### After:

    Step 2/3 : ARG var=${aaa:-bbb
    failed to process "${aaa:-bbb": syntax error: missing '}'

### Example 2: missing closing `}`, no default value

    docker build --no-cache -<<'EOF'
    FROM busybox
    ARG var=${aaa
    RUN echo $var
    EOF

#### Before:

    Step 2/3 : ARG var=${aaa
    failed to process "${aaa": missing ':' in substitution

#### After:

    Step 2/3 : ARG var=${aaa
    failed to process "${aaa": syntax error: missing '}'

### Example 3: double opening bracket (`{`)

    docker build --no-cache -<<'EOF'
    FROM busybox
    ARG var=${{aaa:-bbb}
    RUN echo $var
    EOF

#### Before:

    Step 2/3 : ARG var=${{aaa:-bbb}
    failed to process "${{aaa:-bbb}": missing ':' in substitution

#### After:

    Step 2/3 : ARG var=${{aaa:-bbb}
    failed to process "${{aaa:-bbb}": syntax error: bad substitution

### Example 4: double opening bracket (`{`), no default value

    docker build --no-cache -<<'EOF'
    FROM busybox
    ARG var=${{aaa}
    RUN echo $var
    EOF

#### Before:

    Step 2/3 : ARG var=${{aaa}
    failed to process "${{aaa}": missing ':' in substitution

#### After:

    Step 2/3 : ARG var=${{aaa}
    failed to process "${{aaa}": syntax error: bad substitution


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
* Fix parsing of invalid environment variable substitution 
```
