### PR TITLE
Use go-systemd const instead of magic string in Linux version of dockerd

### DIFF
--- a/cmd/dockerd/daemon_linux.go
+++ b/cmd/dockerd/daemon_linux.go
@@ -9,5 +9,5 @@ func preNotifySystem() {
 // notifySystem sends a message to the host when the server is ready to be used
 func notifySystem() {
 	// Tell the init daemon we are accepting requests
-	go systemdDaemon.SdNotify(false, "READY=1")
+	go systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyReady)
 }

--- a/daemon/listeners/listeners_linux.go
+++ b/daemon/listeners/listeners_linux.go
@@ -62,9 +62,9 @@ func listenFD(addr string, tlsConfig *tls.Config) ([]net.Listener, error) {
 	)
 	// socket activation
 	if tlsConfig != nil {
-		listeners, err = activation.TLSListeners(false, tlsConfig)
+		listeners, err = activation.TLSListeners(tlsConfig)
 	} else {
-		listeners, err = activation.Listeners(false)
+		listeners, err = activation.Listeners()
 	}
 	if err != nil {
 		return nil, err

--- a/vendor.conf
+++ b/vendor.conf
@@ -76,7 +76,7 @@ github.com/opencontainers/image-spec v1.0.1
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
 
 # libcontainer deps (see src/github.com/opencontainers/runc/Godeps/Godeps.json)
-github.com/coreos/go-systemd v15
+github.com/coreos/go-systemd v17
 github.com/godbus/dbus v4.0.0
 github.com/syndtr/gocapability 2c00daeb6c3b45114c80ac44119e7b8801fdd852
 github.com/golang/protobuf 7a211bcf3bce0e3f1d74f9894916e6f116ae83b4

--- a/vendor/github.com/coreos/go-systemd/NOTICE
+++ b/vendor/github.com/coreos/go-systemd/NOTICE
@@ -1,0 +1,5 @@
+CoreOS Project
+Copyright 2018 CoreOS, Inc
+
+This product includes software developed at CoreOS, Inc.
+(http://www.coreos.com/).

--- a/vendor/github.com/coreos/go-systemd/README.md
+++ b/vendor/github.com/coreos/go-systemd/README.md
@@ -6,9 +6,11 @@
 Go bindings to systemd. The project has several packages:
 
 - `activation` - for writing and using socket activation from Go
+- `daemon` - for notifying systemd of service status changes
 - `dbus` - for starting/stopping/inspecting running services and units
 - `journal` - for writing to systemd's logging service, journald
 - `sdjournal` - for reading from journald by wrapping its C API
+- `login1` - for integration with the systemd logind API
 - `machine1` - for registering machines/containers with systemd
 - `unit` - for (de)serialization and comparison of unit files
 
@@ -18,10 +20,9 @@ An example HTTP server using socket activation can be quickly set up by followin
 
 https://github.com/coreos/go-systemd/tree/master/examples/activation/httpserver
 
-## Journal
+## systemd Service Notification
 
-Using the pure-Go `journal` package you can submit journal entries directly to systemd's journal, taking advantage of features like indexed key/value pairs for each log entry.
-The `sdjournal` package provides read access to the journal by wrapping around journald's native C API; consequently it requires cgo and the journal headers to be available.
+The `daemon` package is an implementation of the [sd_notify protocol](https://www.freedesktop.org/software/systemd/man/sd_notify.html#Description). It can be used to inform systemd of service start-up completion, watchdog events, and other status changes.
 
 ## D-Bus
 
@@ -44,6 +45,20 @@ Create `/etc/dbus-1/system-local.conf` that looks like this:
     </policy>
 </busconfig>
 ```
+
+## Journal
+
+### Writing to the Journal
+
+Using the pure-Go `journal` package you can submit journal entries directly to systemd's journal, taking advantage of features like indexed key/value pairs for each log entry.
+
+### Reading from the Journal
+
+The `sdjournal` package provides read access to the journal by wrapping around journald's native C API; consequently it requires cgo and the journal headers to be available.
+
+## logind
+
+The `login1` package provides functions to integrate with the [systemd logind API](http://www.freedesktop.org/wiki/Software/systemd/logind/).
 
 ## machined
 

--- a/vendor/github.com/coreos/go-systemd/activation/listeners.go
+++ b/vendor/github.com/coreos/go-systemd/activation/listeners.go
@@ -25,13 +25,33 @@ import (
 // The order of the file descriptors is preserved in the returned slice.
 // Nil values are used to fill any gaps. For example if systemd were to return file descriptors
 // corresponding with "udp, tcp, tcp", then the slice would contain {nil, net.Listener, net.Listener}
-func Listeners(unsetEnv bool) ([]net.Listener, error) {
-	files := Files(unsetEnv)
+func Listeners() ([]net.Listener, error) {
+	files := Files(true)
 	listeners := make([]net.Listener, len(files))
 
 	for i, f := range files {
 		if pc, err := net.FileListener(f); err == nil {
 			listeners[i] = pc
+			f.Close()
+		}
+	}
+	return listeners, nil
+}
+
+// ListenersWithNames maps a listener name to a set of net.Listener instances.
+func ListenersWithNames() (map[string][]net.Listener, error) {
+	files := Files(true)
+	listeners := map[string][]net.Listener{}
+
+	for _, f := range files {
+		if pc, err := net.FileListener(f); err == nil {
+			current, ok := listeners[f.Name()]
+			if !ok {
+				listeners[f.Name()] = []net.Listener{pc}
+			} else {
+				listeners[f.Name()] = append(current, pc)
+			}
+			f.Close()
 		}
 	}
 	return listeners, nil
@@ -40,8 +60,8 @@ func Listeners(unsetEnv bool) ([]net.Listener, error) {
 // TLSListeners returns a slice containing a net.listener for each matching TCP socket type
 // passed to this process.
 // It uses default Listeners func and forces TCP sockets handlers to use TLS based on tlsConfig.
-func TLSListeners(unsetEnv bool, tlsConfig *tls.Config) ([]net.Listener, error) {
-	listeners, err := Listeners(unsetEnv)
+func TLSListeners(tlsConfig *tls.Config) ([]net.Listener, error) {
+	listeners, err := Listeners()
 
 	if listeners == nil || err != nil {
 		return nil, err
@@ -52,6 +72,29 @@ func TLSListeners(unsetEnv bool, tlsConfig *tls.Config) ([]net.Listener, error) 
 			// Activate TLS only for TCP sockets
 			if l.Addr().Network() == "tcp" {
 				listeners[i] = tls.NewListener(l, tlsConfig)
+			}
+		}
+	}
+
+	return listeners, err
+}
+
+// TLSListenersWithNames maps a listener name to a net.Listener with
+// the associated TLS configuration.
+func TLSListenersWithNames(tlsConfig *tls.Config) (map[string][]net.Listener, error) {
+	listeners, err := ListenersWithNames()
+
+	if listeners == nil || err != nil {
+		return nil, err
+	}
+
+	if tlsConfig != nil && err == nil {
+		for _, ll := range listeners {
+			// Activate TLS only for TCP sockets
+			for i, l := range ll {
+				if l.Addr().Network() == "tcp" {
+					ll[i] = tls.NewListener(l, tlsConfig)
+				}
 			}
 		}
 	}

--- a/vendor/github.com/coreos/go-systemd/activation/packetconns.go
+++ b/vendor/github.com/coreos/go-systemd/activation/packetconns.go
@@ -24,13 +24,14 @@ import (
 // The order of the file descriptors is preserved in the returned slice.
 // Nil values are used to fill any gaps. For example if systemd were to return file descriptors
 // corresponding with "udp, tcp, udp", then the slice would contain {net.PacketConn, nil, net.PacketConn}
-func PacketConns(unsetEnv bool) ([]net.PacketConn, error) {
-	files := Files(unsetEnv)
+func PacketConns() ([]net.PacketConn, error) {
+	files := Files(true)
 	conns := make([]net.PacketConn, len(files))
 
 	for i, f := range files {
 		if pc, err := net.FilePacketConn(f); err == nil {
 			conns[i] = pc
+			f.Close()
 		}
 	}
 	return conns, nil

--- a/vendor/github.com/coreos/go-systemd/daemon/sdnotify.go
+++ b/vendor/github.com/coreos/go-systemd/daemon/sdnotify.go
@@ -1,4 +1,5 @@
 // Copyright 2014 Docker, Inc.
+// Copyright 2015-2018 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,12 +14,35 @@
 // limitations under the License.
 //
 
-// Code forked from Docker project
+// Package daemon provides a Go implementation of the sd_notify protocol.
+// It can be used to inform systemd of service start-up completion, watchdog
+// events, and other status changes.
+//
+// https://www.freedesktop.org/software/systemd/man/sd_notify.html#Description
 package daemon
 
 import (
 	"net"
 	"os"
+)
+
+const (
+	// SdNotifyReady tells the service manager that service startup is finished
+	// or the service finished loading its configuration.
+	SdNotifyReady = "READY=1"
+
+	// SdNotifyStopping tells the service manager that the service is beginning
+	// its shutdown.
+	SdNotifyStopping = "STOPPING=1"
+
+	// SdNotifyReloading tells the service manager that this service is
+	// reloading its configuration. Note that you must call SdNotifyReady when
+	// it completed reloading.
+	SdNotifyReloading = "RELOADING=1"
+
+	// SdNotifyWatchdog tells the service manager to update the watchdog
+	// timestamp for the service.
+	SdNotifyWatchdog = "WATCHDOG=1"
 )
 
 // SdNotify sends a message to the init daemon. It is common to ignore the error.
@@ -29,7 +53,7 @@ import (
 // (false, nil) - notification not supported (i.e. NOTIFY_SOCKET is unset)
 // (false, err) - notification supported, but failure happened (e.g. error connecting to NOTIFY_SOCKET or while sending data)
 // (true, nil) - notification supported, data has been sent
-func SdNotify(unsetEnvironment bool, state string) (sent bool, err error) {
+func SdNotify(unsetEnvironment bool, state string) (bool, error) {
 	socketAddr := &net.UnixAddr{
 		Name: os.Getenv("NOTIFY_SOCKET"),
 		Net:  "unixgram",
@@ -41,10 +65,9 @@ func SdNotify(unsetEnvironment bool, state string) (sent bool, err error) {
 	}
 
 	if unsetEnvironment {
-		err = os.Unsetenv("NOTIFY_SOCKET")
-	}
-	if err != nil {
-		return false, err
+		if err := os.Unsetenv("NOTIFY_SOCKET"); err != nil {
+			return false, err
+		}
 	}
 
 	conn, err := net.DialUnix(socketAddr.Net, nil, socketAddr)
@@ -54,9 +77,7 @@ func SdNotify(unsetEnvironment bool, state string) (sent bool, err error) {
 	}
 	defer conn.Close()
 
-	_, err = conn.Write([]byte(state))
-	// Error sending the message
-	if err != nil {
+	if _, err = conn.Write([]byte(state)); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/vendor/github.com/coreos/go-systemd/daemon/watchdog.go
+++ b/vendor/github.com/coreos/go-systemd/daemon/watchdog.go
@@ -21,10 +21,11 @@ import (
 	"time"
 )
 
-// SdWatchdogEnabled return watchdog information for a service.
-// Process should send daemon.SdNotify("WATCHDOG=1") every time / 2.
-// If `unsetEnvironment` is true, the environment variables `WATCHDOG_USEC`
-// and `WATCHDOG_PID` will be unconditionally unset.
+// SdWatchdogEnabled returns watchdog information for a service.
+// Processes should call daemon.SdNotify(false, daemon.SdNotifyWatchdog) every
+// time / 2.
+// If `unsetEnvironment` is true, the environment variables `WATCHDOG_USEC` and
+// `WATCHDOG_PID` will be unconditionally unset.
 //
 // It returns one of the following:
 // (0, nil) - watchdog isn't enabled or we aren't the watched PID.

--- a/vendor/github.com/coreos/go-systemd/dbus/dbus.go
+++ b/vendor/github.com/coreos/go-systemd/dbus/dbus.go
@@ -16,6 +16,7 @@
 package dbus
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strconv"
@@ -60,6 +61,27 @@ func PathBusEscape(path string) string {
 	return string(n)
 }
 
+// pathBusUnescape is the inverse of PathBusEscape.
+func pathBusUnescape(path string) string {
+	if path == "_" {
+		return ""
+	}
+	n := []byte{}
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		if c == '_' && i+2 < len(path) {
+			res, err := hex.DecodeString(path[i+1 : i+3])
+			if err == nil {
+				n = append(n, res...)
+			}
+			i += 2
+		} else {
+			n = append(n, c)
+		}
+	}
+	return string(n)
+}
+
 // Conn is a connection to systemd's dbus endpoint.
 type Conn struct {
 	// sysconn/sysobj are only used to call dbus methods
@@ -74,12 +96,17 @@ type Conn struct {
 		jobs map[dbus.ObjectPath]chan<- string
 		sync.Mutex
 	}
-	subscriber struct {
+	subStateSubscriber struct {
 		updateCh chan<- *SubStateUpdate
 		errCh    chan<- error
 		sync.Mutex
 		ignore      map[dbus.ObjectPath]int64
 		cleanIgnore int64
+	}
+	propertiesSubscriber struct {
+		updateCh chan<- *PropertiesUpdate
+		errCh    chan<- error
+		sync.Mutex
 	}
 }
 
@@ -152,7 +179,7 @@ func NewConnection(dialBus func() (*dbus.Conn, error)) (*Conn, error) {
 		sigobj:  systemdObject(sigconn),
 	}
 
-	c.subscriber.ignore = make(map[dbus.ObjectPath]int64)
+	c.subStateSubscriber.ignore = make(map[dbus.ObjectPath]int64)
 	c.jobListener.jobs = make(map[dbus.ObjectPath]chan<- string)
 
 	// Setup the listeners on jobs so that we can get completions

--- a/vendor/github.com/coreos/go-systemd/dbus/set.go
+++ b/vendor/github.com/coreos/go-systemd/dbus/set.go
@@ -36,7 +36,7 @@ func (s *set) Length() int {
 }
 
 func (s *set) Values() (values []string) {
-	for val, _ := range s.data {
+	for val := range s.data {
 		values = append(values, val)
 	}
 	return

--- a/vendor/github.com/coreos/go-systemd/journal/journal.go
+++ b/vendor/github.com/coreos/go-systemd/journal/journal.go
@@ -103,7 +103,10 @@ func Send(message string, priority Priority, vars map[string]string) error {
 		if !ok {
 			return journalError("can't send file through non-Unix connection")
 		}
-		unixConn.WriteMsgUnix([]byte{}, rights, nil)
+		_, _, err = unixConn.WriteMsgUnix([]byte{}, rights, nil)
+		if err != nil {
+			return journalError(err.Error())
+		}
 	} else if err != nil {
 		return journalError(err.Error())
 	}
@@ -165,7 +168,7 @@ func tempFd() (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	syscall.Unlink(file.Name())
+	err = syscall.Unlink(file.Name())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**- What I did**

We currently use a magic string `READY=1` to indicate readiness of dockerd to systemd.
`go-systemd` `v17` provides a const we can use, so we can drop the magic string (which is a rather protocol-specific detail).

**- How I did it**

Bumped moby's `go-systemd` dependency to `v17`.

**- Description for the changelog**
```
Use go-systemd const instead of magic string in Linux version of dockerd
```
