### PR TITLE
Update API version to v1 38

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api // import "github.com/docker/docker/api"
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion = "1.37"
+	DefaultVersion = "1.38"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.37"
+basePath: "/v1.38"
 info:
   title: "Docker Engine API"
-  version: "1.37"
+  version: "1.38"
   x-logo:
     url: "https://docs.docker.com/images/logo-docker-main.png"
   description: |
@@ -49,8 +49,8 @@ info:
     the URL is not supported by the daemon, a HTTP `400 Bad Request` error message
     is returned.
 
-    If you omit the version-prefix, the current version of the API (v1.37) is used.
-    For example, calling `/info` is the same as calling `/v1.37/info`. Using the
+    If you omit the version-prefix, the current version of the API (v1.38) is used.
+    For example, calling `/info` is the same as calling `/v1.38/info`. Using the
     API without a version-prefix is deprecated and will be removed in a future release.
 
     Engine releases in the near future should support this version of the API,

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -15,6 +15,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 ## V1.38 API changes
 
+[Docker Engine API v1.38](https://docs.docker.com/engine/api/v1.38/) documentation
+
+
 * `GET /tasks` and `GET /tasks/{id}` now return a `NetworkAttachmentSpec` field,
   containing the `ContainerID` for non-service containers connected to "attachable"
   swarm-scoped networks.

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -175,7 +175,7 @@ func TestBuildMultiStageParentConfig(t *testing.T) {
 
 // Test cases in #36996
 func TestBuildLabelWithTargets(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.37"), "test added after 1.37")
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.38"), "test added after 1.38")
 	bldName := "build-a"
 	testLabels := map[string]string{
 		"foo":  "bar",


### PR DESCRIPTION
Relates to https://github.com/moby/moby/pull/35246

Also added an extra commit to update one test, which used v1.37 as selector, but the fix was not part of Docker 18.03, 18.04, or 18.05 (which all use API v1.37)

ping @AntaresS  @tiborvass 