### PR TITLE
Check for BRIDGE_VLAN_FILTERING in overlay section

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -292,7 +292,7 @@ fi
 
 echo '- Network Drivers:'
 echo "  - \"$(wrap_color 'overlay' blue)\":"
-check_flags VXLAN | sed 's/^/    /'
+check_flags VXLAN BRIDGE_VLAN_FILTERING | sed 's/^/    /'
 echo '      Optional (for encrypted networks):'
 check_flags CRYPTO CRYPTO_AEAD CRYPTO_GCM CRYPTO_SEQIV CRYPTO_GHASH \
             XFRM XFRM_USER XFRM_ALGO INET_ESP INET_XFRM_MODE_TRANSPORT | sed 's/^/      /'


### PR DESCRIPTION
Overlay networking in docker stack does not work correctly if this option is missing, docker will output the following error:

```
enabling default vlan on bridge br0 failed open /sys/class/net/br0/bridge/default_pvdi: permission denied
```

This because `default_pvdi` does not exist without this option.

Signed-off-by: Pascal Bach <pascal.bach@siemens.com>
Signed-off-by: Simon Ausserlechner <simon.ausserlechner@siemens.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->