### PR TITLE
Add `t.Name()` to tests so that service names are unique

### DIFF
--- a/integration/network/inspect_test.go
+++ b/integration/network/inspect_test.go
@@ -34,7 +34,7 @@ func TestInspectNetwork(t *testing.T) {
 	overlayID := netResp.ID
 
 	var instances uint64 = 4
-	serviceName := "TestService"
+	serviceName := "TestService" + t.Name()
 
 	serviceID := swarm.CreateService(t, d,
 		swarm.ServiceWithReplicas(instances),

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -207,7 +207,7 @@ func TestServiceWithPredefinedNetwork(t *testing.T) {
 
 	hostName := "host"
 	var instances uint64 = 1
-	serviceName := "TestService"
+	serviceName := "TestService" + t.Name()
 
 	serviceID := swarm.CreateService(t, d,
 		swarm.ServiceWithReplicas(instances),


### PR DESCRIPTION
This fix adds `t.Name()` to tests in integration/network
so that services created in those tests have unique names.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>