### PR TITLE
Fix race condition between exec start and resize.

### DIFF
--- a/daemon/resize.go
+++ b/daemon/resize.go
@@ -37,5 +37,8 @@ func (daemon *Daemon) ContainerExecResize(name string, height, width int) error 
 	if err != nil {
 		return err
 	}
-	return daemon.containerd.ResizeTerminal(context.Background(), ec.ContainerID, ec.ID, width, height)
+  ec.Lock()
+	err = daemon.containerd.ResizeTerminal(context.Background(), ec.ContainerID, ec.ID, width, height)
+  ec.Unlock()
+  return err
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix a race condition between exec start and resize
**- How I did it**
Use the already-existed lock to avoid race condition
**- How to verify it**
run `docker run --rm -it centos bash`, and then type a long line to verify the the line would auto wraparound the terminal.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fixes #31223 #35407 

**- A picture of a cute animal (not mandatory but encouraged)**

