### PR TITLE
Be explicit about github.com prefix being a legacy feature

### DIFF
--- a/pkg/urlutil/urlutil.go
+++ b/pkg/urlutil/urlutil.go
@@ -9,7 +9,15 @@ import (
 
 var (
 	validPrefixes = map[string][]string{
-		"url":       {"http://", "https://"},
+		"url": {"http://", "https://"},
+
+		// The github.com/ prefix is a special case used to treat context-paths
+		// starting with `github.com` as a git URL if the given path does not
+		// exist locally. The "github.com/" prefix is kept for backward compatibility,
+		// and is a legacy feature.
+		//
+		// Going forward, no additional prefixes should be added, and users should
+		// be encouraged to use explicit URLs (https://github.com/user/repo.git) instead.
 		"git":       {"git://", "github.com/", "git@"},
 		"transport": {"tcp://", "tcp+tls://", "udp://", "unix://", "unixgram://"},
 	}


### PR DESCRIPTION
relates to https://github.com/moby/moby/issues/37173 and https://github.com/moby/moby/pull/30412