### PR TITLE
Move plugin client to separate interface

### DIFF
--- a/daemon/logger/plugin.go
+++ b/daemon/logger/plugin.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/docker/docker/api/types/plugins/logdriver"
+	"github.com/docker/docker/errdefs"
 	getter "github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/docker/pkg/stringid"
@@ -46,9 +47,12 @@ func getPlugin(name string, mode int) (Creator, error) {
 }
 
 func makePluginClient(p getter.CompatPlugin) (logPlugin, error) {
+	if pc, ok := p.(getter.PluginWithV1Client); ok {
+		return &logPluginProxy{pc.Client()}, nil
+	}
 	pa, ok := p.(getter.PluginAddr)
 	if !ok {
-		return &logPluginProxy{p.Client()}, nil
+		return nil, errdefs.System(errors.Errorf("got unknown plugin type %T", p))
 	}
 
 	if pa.Protocol() != plugins.ProtocolSchemeHTTPV1 {

--- a/pkg/plugingetter/getter.go
+++ b/pkg/plugingetter/getter.go
@@ -18,15 +18,19 @@ const (
 
 // CompatPlugin is an abstraction to handle both v2(new) and v1(legacy) plugins.
 type CompatPlugin interface {
-	Client() *plugins.Client
 	Name() string
 	ScopedPath(string) string
 	IsV1() bool
+	PluginWithV1Client
+}
+
+// PluginWithV1Client is a plugin that directly utilizes the v1/http plugin client
+type PluginWithV1Client interface {
+	Client() *plugins.Client
 }
 
 // PluginAddr is a plugin that exposes the socket address for creating custom clients rather than the built-in `*plugins.Client`
 type PluginAddr interface {
-	CompatPlugin
 	Addr() net.Addr
 	Timeout() time.Duration
 	Protocol() string


### PR DESCRIPTION
This makes it a bit simpler to remove this interface for v2 plugins
and not break external projects (libnetwork and swarmkit).

Note that before we remove the `Client()` interface from `CompatPlugin`
libnetwork and swarmkit must be updated to explicitly check for the v1
client interface as is done int his PR.

This is just a minor tweak that I realized is needed after trying to
implement the needed changes on libnetwork.