### PR TITLE
Retry next DNS server on NXDOMAIN and REFUSED

### DIFF
--- a/vendor/github.com/docker/libnetwork/resolver.go
+++ b/vendor/github.com/docker/libnetwork/resolver.go
@@ -491,9 +491,9 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 			}
 			r.forwardQueryEnd()
 			if resp != nil {
-				if resp.Rcode == dns.RcodeServerFailure {
-					// for Server Failure response, continue to the next external DNS server
-					logrus.Debugf("[resolver] external DNS %s:%s responded with ServFail for %q", proto, extDNS.IPStr, name)
+				if resp.Rcode == dns.RcodeServerFailure || resp.Rcode == dns.RcodeNameError || resp.Rcode == dns.RcodeRefused {
+					// for Server Failure, No Domain or Server Refusal responses, continue to the next external DNS server
+					logrus.Debugf("[resolver] external DNS %s:%s responded with %s for %q", proto, extDNS.IPStr, dns.RcodeToString[resp.Rcode], name)
 					continue
 				}
 				answers := 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Relates to https://github.com/moby/moby/issues/20494 and https://github.com/docker/compose/issues/5991

Complements https://github.com/docker/libnetwork/pull/2121

**- What I did**
Currently we only fallback on the next DNS server in case of a `ServFail`, I added the cases where the server response if `NXDOMAIN` or `REFUSED`. In both cases the OS falls back to the next server and it is expected by a normal user that it does the same in docker.

**- How I did it**
Simply added the two conditions

**- How to verify it**
Not sure where the tests for this resolver are on this repository, I would gladly add one.
Testing in real life is tricky since you have to setup an external DNS server that returns the codes.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added retry with next DNS server upon NXDOMAIN or REFUSAL response

