### PR TITLE
Refactor /client/client.go code in ParseHostURL method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ ENV CRIU_VERSION 3.6
 # Install dependancy packages specific to criu
 RUN apt-get update && apt-get install -y \
 	libnet-dev \
+	--no-install-recommends apt-utils \
 	libprotobuf-c0-dev \
 	libprotobuf-dev \
 	libnl-3-dev \

--- a/TEST.md
+++ b/TEST.md
@@ -1,0 +1,1 @@
+etalamante@nearsoft.com Hermosillo, Sonora

--- a/client/client.go
+++ b/client/client.go
@@ -368,22 +368,23 @@ func ParseHostURL(host string) (*url.URL, error) {
 	if len(protoAddrParts) == 1 {
 		return nil, fmt.Errorf("unable to parse docker host `%s`", host)
 	}
-
-	var basePath string
-	proto, addr := protoAddrParts[0], protoAddrParts[1]
-	if proto == "tcp" {
+	if proto, addr := protoAddrParts[0], protoAddrParts[1] ; proto == "tcp" {
 		parsed, err := url.Parse("tcp://" + addr)
 		if err != nil {
 			return nil, err
+		} else {
+			return &url.URL{
+				Scheme: proto,
+				Host:   parsed.Host,
+				Path:   parsed.Path,
+			}, nil
 		}
-		addr = parsed.Host
-		basePath = parsed.Path
+	} else {
+		return &url.URL{
+			Scheme: proto,
+			Host:   addr,
+		}, nil
 	}
-	return &url.URL{
-		Scheme: proto,
-		Host:   addr,
-		Path:   basePath,
-	}, nil
 }
 
 // CustomHTTPHeaders returns the custom http headers stored by the client.


### PR DESCRIPTION
**- What I did**
Refactored code in [client.go](https://github.com/moby/moby/blob/master/client/client.go) 

**- How I did it**
By changing, on the `ParseHostURL` method, the if statement which checked if the URL Schema was "tcp" in order to have a better use of the `basePath, proto, addr` variables, and incorporating the declaration of the last two as optional statements and returning the required ones as necessary.


**- Reference**
Issue #[37185](https://github.com/moby/moby/issues/37185)

**- Notes**
This is my first PR to contribute to an open source project. Any feedback will be appreciated : D