### PR TITLE
fix a failed test TestRunOOMExitCode

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -619,7 +619,8 @@ func (s *DockerSuite) TestRunOOMExitCode(c *check.C) {
 	errChan := make(chan error)
 	go func() {
 		defer close(errChan)
-		out, exitCode, _ := dockerCmdWithError("run", "-m", "4MB", "busybox", "sh", "-c", "x=a; while true; do x=$x$x$x$x; done")
+		// memory limit lower than 8MB will raise an error of "device or resource busy" from docker-runc.
+		out, exitCode, _ := dockerCmdWithError("run", "-m", "8MB", "busybox", "sh", "-c", "x=a; while true; do x=$x$x$x$x; done")
 		if expected := 137; exitCode != expected {
 			errChan <- fmt.Errorf("wrong exit code for OOM container: expected %d, got %d (output: %q)", expected, exitCode, out)
 		}


### PR DESCRIPTION
Signed-off-by: Anda Xu <anda.xu@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- fix the failed test - `TestRunOOMExitCode`
  - the original test fails on rhel_7.4, rhel_7.3-dm and rhel_7.4-dm in engine 18.03. When memory limit set lower than 7MB it will raise an error of "device or resource busy" from docker-runc. Here is a failure snippet from test
```
01:18:52 FAIL: /go/src/github.com/docker/docker/integration-cli/docker_cli_run_unix_test.go:617: DockerSuite.TestRunOOMExitCode
01:18:52 
01:18:52 /go/src/github.com/docker/docker/integration-cli/docker_cli_run_unix_test.go:630:
01:18:52     ...open /go/src/github.com/docker/docker/integration-cli/docker_cli_run_unix_test.go: no such file or directory
01:18:52 ... value *errors.errorString = &errors.errorString{s:"wrong exit code for OOM container: expected 137, got 125 (output: \"/usr/bin/docker: Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused \\\"process_linux.go:402: container init caused \\\\\\\"process_linux.go:367: setting cgroup config for procHooks process caused \\\\\\\\\\\\\\\"failed to write 4194304 to memory.limit_in_bytes: write /sys/fs/cgroup/memory/docker/c31458a08eb2d786394076fd50f84106afc6d7d708053de7fe44a4e214a09391/memory.limit_in_bytes: device or resource busy\\\\\\\\\\\\\\\"\\\\\\\"\\\": unknown.\\ntime=\\\"2018-06-01T01:18:52Z\\\" level=error msg=\\\"error waiting for container: context canceled\\\" \\n\")"} ("wrong exit code for OOM container: expected 137, got 125 (output: \"/usr/bin/docker: Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused \\\"process_linux.go:402: container init caused \\\\\\\"process_linux.go:367: setting cgroup config for procHooks process caused \\\\\\\\\\\\\\\"failed to write 4194304 to memory.limit_in_bytes: write /sys/fs/cgroup/memory/docker/c31458a08eb2d786394076fd50f84106afc6d7d708053de7fe44a4e214a09391/memory.limit_in_bytes: device or resource busy\\\\\\\\\\\\\\\"\\\\\\\"\\\": unknown.\\ntime=\\\"2018-06-01T01:18:52Z\\\" level=error msg=\\\"error waiting for container: context canceled\\\" \\n\")")
```
Main problem is very likely to be a centos based kernel bug. When docker-runc tries to write memory limit in /sys/fs/cgroup/memory/docker/<containerID>/memory.limit_in_bytes it returns a "device or resource busy" error. There seems to be conflict with kernel process. Related link reporting a similar error - https://unix.stackexchange.com/questions/412040/cgroups-memory-limit-write-error-device-or-resource-busy

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

cc @tonistiigi 