### PR TITLE
Refactor macvlan network integration tests to use network.Create

### DIFF
--- a/integration/internal/network/network.go
+++ b/integration/internal/network/network.go
@@ -1,0 +1,35 @@
+package network
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/gotestyourself/gotestyourself/assert"
+)
+
+func createNetwork(ctx context.Context, client client.APIClient, name string, ops ...func(*types.NetworkCreate)) (string, error) {
+	config := types.NetworkCreate{}
+
+	for _, op := range ops {
+		op(&config)
+	}
+
+	n, err := client.NetworkCreate(ctx, name, config)
+	return n.ID, err
+}
+
+// Create creates a network with the specified options
+func Create(ctx context.Context, client client.APIClient, name string, ops ...func(*types.NetworkCreate)) (string, error) {
+	return createNetwork(ctx, client, name, ops...)
+}
+
+// CreateNoError creates a network with the specified options and verifies there were no errors
+func CreateNoError(t *testing.T, ctx context.Context, client client.APIClient, name string, ops ...func(*types.NetworkCreate)) string { // nolint: golint
+	t.Helper()
+
+	name, err := createNetwork(ctx, client, name, ops...)
+	assert.NilError(t, err)
+	return name
+}

--- a/integration/internal/network/ops.go
+++ b/integration/internal/network/ops.go
@@ -1,0 +1,57 @@
+package network
+
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
+)
+
+// WithDriver sets the driver of the network
+func WithDriver(driver string) func(*types.NetworkCreate) {
+	return func(n *types.NetworkCreate) {
+		n.Driver = driver
+	}
+}
+
+// WithIPv6 Enables IPv6 on the network
+func WithIPv6() func(*types.NetworkCreate) {
+	return func(n *types.NetworkCreate) {
+		n.EnableIPv6 = true
+	}
+}
+
+// WithMacvlan sets the network as macvlan with the specified parent
+func WithMacvlan(parent string) func(*types.NetworkCreate) {
+	return func(n *types.NetworkCreate) {
+		n.Driver = "macvlan"
+		if parent != "" {
+			n.Options = map[string]string{
+				"parent": parent,
+			}
+		}
+	}
+}
+
+// WithOption adds the specified key/value pair to network's options
+func WithOption(key, value string) func(*types.NetworkCreate) {
+	return func(n *types.NetworkCreate) {
+		if n.Options == nil {
+			n.Options = map[string]string{}
+		}
+		n.Options[key] = value
+	}
+}
+
+// WithIPAM adds an IPAM with the specified Subnet and Gateway to the network
+func WithIPAM(subnet, gateway string) func(*types.NetworkCreate) {
+	return func(n *types.NetworkCreate) {
+		if n.IPAM == nil {
+			n.IPAM = &network.IPAM{}
+		}
+
+		n.IPAM.Config = append(n.IPAM.Config, network.IPAMConfig{
+			Subnet:     subnet,
+			Gateway:    gateway,
+			AuxAddress: map[string]string{},
+		})
+	}
+}

--- a/integration/network/macvlan/macvlan_test.go
+++ b/integration/network/macvlan/macvlan_test.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
+	net "github.com/docker/docker/integration/internal/network"
 	n "github.com/docker/docker/integration/network"
 	"github.com/docker/docker/internal/test/daemon"
 	"github.com/gotestyourself/gotestyourself/assert"
@@ -33,16 +33,13 @@ func TestDockerNetworkMacvlanPersistance(t *testing.T) {
 	client, err := d.NewClient()
 	assert.NilError(t, err)
 
-	_, err = client.NetworkCreate(context.Background(), "dm-persist", types.NetworkCreate{
-		Driver: "macvlan",
-		Options: map[string]string{
-			"parent": "dm-dummy0.60",
-		},
-	})
-	assert.NilError(t, err)
-	assert.Check(t, n.IsNetworkAvailable(client, "dm-persist"))
+	netName := "dm-persist"
+	net.CreateNoError(t, context.Background(), client, netName,
+		net.WithMacvlan("dm-dummy0.60"),
+	)
+	assert.Check(t, n.IsNetworkAvailable(client, netName))
 	d.Restart(t)
-	assert.Check(t, n.IsNetworkAvailable(client, "dm-persist"))
+	assert.Check(t, n.IsNetworkAvailable(client, netName))
 }
 
 func TestDockerNetworkMacvlan(t *testing.T) {
@@ -91,29 +88,25 @@ func testMacvlanOverlapParent(client client.APIClient) func(*testing.T) {
 		n.CreateMasterDummy(t, master)
 		defer n.DeleteInterface(t, master)
 
-		_, err := client.NetworkCreate(context.Background(), "dm-subinterface", types.NetworkCreate{
-			Driver: "macvlan",
-			Options: map[string]string{
-				"parent": "dm-dummy0.40",
-			},
-		})
-		assert.NilError(t, err)
-		assert.Check(t, n.IsNetworkAvailable(client, "dm-subinterface"))
+		netName := "dm-subinterface"
+		parentName := "dm-dummy0.40"
+		net.CreateNoError(t, context.Background(), client, netName,
+			net.WithMacvlan(parentName),
+		)
+		assert.Check(t, n.IsNetworkAvailable(client, netName))
 
-		_, err = client.NetworkCreate(context.Background(), "dm-parent-net-overlap", types.NetworkCreate{
-			Driver: "macvlan",
-			Options: map[string]string{
-				"parent": "dm-dummy0.40",
-			},
-		})
+		_, err := net.Create(context.Background(), client, "dm-parent-net-overlap",
+			net.WithMacvlan(parentName),
+		)
 		assert.Check(t, err != nil)
+
 		// delete the network while preserving the parent link
-		err = client.NetworkRemove(context.Background(), "dm-subinterface")
+		err = client.NetworkRemove(context.Background(), netName)
 		assert.NilError(t, err)
 
-		assert.Check(t, n.IsNetworkNotAvailable(client, "dm-subinterface"))
+		assert.Check(t, n.IsNetworkNotAvailable(client, netName))
 		// verify the network delete did not delete the predefined link
-		n.LinkExists(t, "dm-dummy0")
+		n.LinkExists(t, master)
 	}
 }
 
@@ -121,26 +114,24 @@ func testMacvlanSubinterface(client client.APIClient) func(*testing.T) {
 	return func(t *testing.T) {
 		// verify the same parent interface cannot be used if already in use by an existing network
 		master := "dm-dummy0"
+		parentName := "dm-dummy0.20"
 		n.CreateMasterDummy(t, master)
 		defer n.DeleteInterface(t, master)
-		n.CreateVlanInterface(t, master, "dm-dummy0.20", "20")
+		n.CreateVlanInterface(t, master, parentName, "20")
 
-		_, err := client.NetworkCreate(context.Background(), "dm-subinterface", types.NetworkCreate{
-			Driver: "macvlan",
-			Options: map[string]string{
-				"parent": "dm-dummy0.20",
-			},
-		})
-		assert.NilError(t, err)
-		assert.Check(t, n.IsNetworkAvailable(client, "dm-subinterface"))
+		netName := "dm-subinterface"
+		net.CreateNoError(t, context.Background(), client, netName,
+			net.WithMacvlan(parentName),
+		)
+		assert.Check(t, n.IsNetworkAvailable(client, netName))
 
 		// delete the network while preserving the parent link
-		err = client.NetworkRemove(context.Background(), "dm-subinterface")
+		err := client.NetworkRemove(context.Background(), netName)
 		assert.NilError(t, err)
 
-		assert.Check(t, n.IsNetworkNotAvailable(client, "dm-subinterface"))
+		assert.Check(t, n.IsNetworkNotAvailable(client, netName))
 		// verify the network delete did not delete the predefined link
-		n.LinkExists(t, "dm-dummy0.20")
+		n.LinkExists(t, parentName)
 	}
 }
 
@@ -190,34 +181,17 @@ func testMacvlanInternalMode(client client.APIClient) func(*testing.T) {
 
 func testMacvlanMultiSubnet(client client.APIClient) func(*testing.T) {
 	return func(t *testing.T) {
-		_, err := client.NetworkCreate(context.Background(), "dualstackbridge", types.NetworkCreate{
-			Driver:     "macvlan",
-			EnableIPv6: true,
-			IPAM: &network.IPAM{
-				Config: []network.IPAMConfig{
-					{
-						Subnet:     "172.28.100.0/24",
-						AuxAddress: map[string]string{},
-					},
-					{
-						Subnet:     "172.28.102.0/24",
-						Gateway:    "172.28.102.254",
-						AuxAddress: map[string]string{},
-					},
-					{
-						Subnet:     "2001:db8:abc2::/64",
-						AuxAddress: map[string]string{},
-					},
-					{
-						Subnet:     "2001:db8:abc4::/64",
-						Gateway:    "2001:db8:abc4::254",
-						AuxAddress: map[string]string{},
-					},
-				},
-			},
-		})
-		assert.NilError(t, err)
-		assert.Check(t, n.IsNetworkAvailable(client, "dualstackbridge"))
+		netName := "dualstackbridge"
+		net.CreateNoError(t, context.Background(), client, netName,
+			net.WithMacvlan(""),
+			net.WithIPv6(),
+			net.WithIPAM("172.28.100.0/24", ""),
+			net.WithIPAM("172.28.102.0/24", "172.28.102.254"),
+			net.WithIPAM("2001:db8:abc2::/64", ""),
+			net.WithIPAM("2001:db8:abc4::/64", "2001:db8:abc4::254"),
+		)
+
+		assert.Check(t, n.IsNetworkAvailable(client, netName))
 
 		// start dual stack containers and verify the user specified --ip and --ip6 addresses on subnets 172.28.100.0/24 and 2001:db8:abc2::/64
 		ctx := context.Background()
@@ -276,28 +250,15 @@ func testMacvlanMultiSubnet(client client.APIClient) func(*testing.T) {
 func testMacvlanAddressing(client client.APIClient) func(*testing.T) {
 	return func(t *testing.T) {
 		// Ensure the default gateways, next-hops and default dev devices are properly set
-		_, err := client.NetworkCreate(context.Background(), "dualstackbridge", types.NetworkCreate{
-			Driver:     "macvlan",
-			EnableIPv6: true,
-			Options: map[string]string{
-				"macvlan_mode": "bridge",
-			},
-			IPAM: &network.IPAM{
-				Config: []network.IPAMConfig{
-					{
-						Subnet:     "172.28.130.0/24",
-						AuxAddress: map[string]string{},
-					},
-					{
-						Subnet:     "2001:db8:abca::/64",
-						Gateway:    "2001:db8:abca::254",
-						AuxAddress: map[string]string{},
-					},
-				},
-			},
-		})
-		assert.NilError(t, err)
-		assert.Check(t, n.IsNetworkAvailable(client, "dualstackbridge"))
+		netName := "dualstackbridge"
+		net.CreateNoError(t, context.Background(), client, netName,
+			net.WithMacvlan(""),
+			net.WithIPv6(),
+			net.WithOption("macvlan_mode", "bridge"),
+			net.WithIPAM("172.28.130.0/24", ""),
+			net.WithIPAM("2001:db8:abca::/64", "2001:db8:abca::254"),
+		)
+		assert.Check(t, n.IsNetworkAvailable(client, netName))
 
 		ctx := context.Background()
 		id1 := container.Run(t, ctx, client,


### PR DESCRIPTION
**- What I did**
- Added a package  for creating networks in integration tests
- Refactored macvlan network integration tests to use the new package

**- How I did it**
- Added new package `integration/internal/network`
- Refactored `integration/network/macvlan` tests to use the new package instead of `client.NetworkCreate` calls

**- How to verify it**

**- Description for the changelog**
Integration tests under `integration/network/macvlan` use network.Create for creating networks.

**- A picture of a cute animal (not mandatory but encouraged)**

