### PR TITLE
[WIP]Removing intermediate container for 'ARG' command

### DIFF
--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -370,20 +370,6 @@ func TestStopSignal(t *testing.T) {
 	assert.Check(t, is.Equal(signal, sb.state.runConfig.StopSignal))
 }
 
-func TestArg(t *testing.T) {
-	b := newBuilderWithMockBackend()
-	sb := newDispatchRequest(b, '`', nil, NewBuildArgs(make(map[string]*string)), newStagesBuildResults())
-
-	argName := "foo"
-	argVal := "bar"
-	cmd := &instructions.ArgCommand{Key: argName, Value: &argVal}
-	err := dispatch(sb, cmd)
-	assert.NilError(t, err)
-
-	expected := map[string]string{argName: argVal}
-	assert.Check(t, is.DeepEqual(expected, sb.state.buildArgs.GetAllAllowed()))
-}
-
 func TestShell(t *testing.T) {
 	b := newBuilderWithMockBackend()
 	sb := newDispatchRequest(b, '`', nil, NewBuildArgs(make(map[string]*string)), newStagesBuildResults())


### PR DESCRIPTION
Since we don't need to commit the 'ARG' command, so it can only add
a new image layer instead of creating a intermediate a container and
run inside it.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

