### PR TITLE
bump libnetwork to 3931ba4d815e385ab97093c64477b82f14dadefb

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=c15b372ef22125880d378167dde44f4b134e1a77
+LIBNETWORK_COMMIT=3931ba4d815e385ab97093c64477b82f14dadefb
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -35,7 +35,7 @@ github.com/opentracing/opentracing-go 1361b9cd60be79c4c3a7fa9841b3c132e40066a7
 #get libnetwork packages
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
-github.com/docker/libnetwork eb6b2a57955e5c149d47c3973573216e8f8baa09
+github.com/docker/libnetwork 3931ba4d815e385ab97093c64477b82f14dadefb
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/controller.go
+++ b/vendor/github.com/docker/libnetwork/controller.go
@@ -44,7 +44,6 @@ create network namespaces and allocate interfaces for containers to use.
 package libnetwork
 
 import (
-	"container/heap"
 	"fmt"
 	"net"
 	"path/filepath"
@@ -1085,7 +1084,7 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (S
 		sb = &sandbox{
 			id:                 sandboxID,
 			containerID:        containerID,
-			endpoints:          epHeap{},
+			endpoints:          []*endpoint{},
 			epPriority:         map[string]int{},
 			populatedEndpoints: map[string]struct{}{},
 			config:             containerConfig{},
@@ -1093,8 +1092,6 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (S
 			extDNS:             []extDNSEntry{},
 		}
 	}
-
-	heap.Init(&sb.endpoints)
 
 	sb.processOptions(options...)
 

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -706,8 +706,8 @@ func (d *driver) createNetwork(config *networkConfiguration) error {
 		// Enable IPv6 Forwarding
 		{enableIPv6Forwarding, setupIPv6Forwarding},
 
-		// Setup Loopback Adresses Routing
-		{!d.config.EnableUserlandProxy, setupLoopbackAdressesRouting},
+		// Setup Loopback Addresses Routing
+		{!d.config.EnableUserlandProxy, setupLoopbackAddressesRouting},
 
 		// Setup IPTables.
 		{d.config.EnableIPTables, network.setupIPTables},

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ipv4.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ipv4.go
@@ -64,13 +64,13 @@ func setupGatewayIPv4(config *networkConfiguration, i *bridgeInterface) error {
 	return nil
 }
 
-func setupLoopbackAdressesRouting(config *networkConfiguration, i *bridgeInterface) error {
+func setupLoopbackAddressesRouting(config *networkConfiguration, i *bridgeInterface) error {
 	sysPath := filepath.Join("/proc/sys/net/ipv4/conf", config.BridgeName, "route_localnet")
 	ipv4LoRoutingData, err := ioutil.ReadFile(sysPath)
 	if err != nil {
 		return fmt.Errorf("Cannot read IPv4 local routing setup: %v", err)
 	}
-	// Enable loopback adresses routing only if it isn't already enabled
+	// Enable loopback addresses routing only if it isn't already enabled
 	if ipv4LoRoutingData[0] != '1' {
 		if err := ioutil.WriteFile(sysPath, []byte{'1', '\n'}, 0644); err != nil {
 			return fmt.Errorf("Unable to enable local routing for hairpin mode: %v", err)

--- a/vendor/github.com/docker/libnetwork/drivers/ipvlan/ipvlan_setup.go
+++ b/vendor/github.com/docker/libnetwork/drivers/ipvlan/ipvlan_setup.go
@@ -150,7 +150,7 @@ func parseVlan(linkName string) (string, int, error) {
 	}
 	// Check if the interface exists
 	if !parentExists(parent) {
-		return "", 0, fmt.Errorf("-o parent interface does was not found on the host: %s", parent)
+		return "", 0, fmt.Errorf("-o parent interface was not found on the host: %s", parent)
 	}
 
 	return parent, vidInt, nil

--- a/vendor/github.com/docker/libnetwork/ipam/allocator.go
+++ b/vendor/github.com/docker/libnetwork/ipam/allocator.go
@@ -389,7 +389,7 @@ func (a *Allocator) getPredefinedPool(as string, ipV6 bool) (*net.IPNet, error) 
 	}
 
 	if as != localAddressSpace && as != globalAddressSpace {
-		return nil, types.NotImplementedErrorf("no default pool availbale for non-default addresss spaces")
+		return nil, types.NotImplementedErrorf("no default pool available for non-default address spaces")
 	}
 
 	aSpace, err := a.getAddrSpace(as)

--- a/vendor/github.com/docker/libnetwork/resolver.go
+++ b/vendor/github.com/docker/libnetwork/resolver.go
@@ -280,7 +280,7 @@ func (r *resolver) handleIPQuery(name string, query *dns.Msg, ipType int) (*dns.
 }
 
 func (r *resolver) handlePTRQuery(ptr string, query *dns.Msg) (*dns.Msg, error) {
-	parts := []string{}
+	var parts []string
 
 	if strings.HasSuffix(ptr, ptrIPv4domain) {
 		parts = strings.Split(ptr, ptrIPv4domain)

--- a/vendor/github.com/docker/libnetwork/sandbox.go
+++ b/vendor/github.com/docker/libnetwork/sandbox.go
@@ -1,10 +1,10 @@
 package libnetwork
 
 import (
-	"container/heap"
 	"encoding/json"
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -63,8 +63,6 @@ func (sb *sandbox) processOptions(options ...SandboxOption) {
 	}
 }
 
-type epHeap []*endpoint
-
 type sandbox struct {
 	id                 string
 	containerID        string
@@ -75,7 +73,7 @@ type sandbox struct {
 	resolver           Resolver
 	resolverOnce       sync.Once
 	refCnt             int
-	endpoints          epHeap
+	endpoints          []*endpoint
 	epPriority         map[string]int
 	populatedEndpoints map[string]struct{}
 	joinLeaveDone      chan struct{}
@@ -353,20 +351,36 @@ func (sb *sandbox) getConnectedEndpoints() []*endpoint {
 	defer sb.Unlock()
 
 	eps := make([]*endpoint, len(sb.endpoints))
-	for i, ep := range sb.endpoints {
-		eps[i] = ep
-	}
+	copy(eps, sb.endpoints)
 
 	return eps
+}
+
+func (sb *sandbox) addEndpoint(ep *endpoint) {
+	sb.Lock()
+	defer sb.Unlock()
+
+	l := len(sb.endpoints)
+	i := sort.Search(l, func(j int) bool {
+		return ep.Less(sb.endpoints[j])
+	})
+
+	sb.endpoints = append(sb.endpoints, nil)
+	copy(sb.endpoints[i+1:], sb.endpoints[i:])
+	sb.endpoints[i] = ep
 }
 
 func (sb *sandbox) removeEndpoint(ep *endpoint) {
 	sb.Lock()
 	defer sb.Unlock()
 
+	sb.removeEndpointRaw(ep)
+}
+
+func (sb *sandbox) removeEndpointRaw(ep *endpoint) {
 	for i, e := range sb.endpoints {
 		if e == ep {
-			heap.Remove(&sb.endpoints, i)
+			sb.endpoints = append(sb.endpoints[:i], sb.endpoints[i+1:]...)
 			return
 		}
 	}
@@ -940,7 +954,7 @@ func (sb *sandbox) clearNetworkResources(origEp *endpoint) error {
 		return nil
 	}
 
-	heap.Remove(&sb.endpoints, index)
+	sb.removeEndpointRaw(ep)
 	for _, e := range sb.endpoints {
 		if len(e.Gateway()) > 0 {
 			gwepAfter = e
@@ -1165,80 +1179,69 @@ func OptionIngress() SandboxOption {
 	}
 }
 
-func (eh epHeap) Len() int { return len(eh) }
-
-func (eh epHeap) Less(i, j int) bool {
+// <=> Returns true if a < b, false if a > b and advances to next level if a == b
+// epi.prio <=> epj.prio           # 2 < 1
+// epi.gw <=> epj.gw               # non-gw < gw
+// epi.internal <=> epj.internal   # non-internal < internal
+// epi.joininfo <=> epj.joininfo   # ipv6 < ipv4
+// epi.name <=> epj.name           # bar < foo
+func (epi *endpoint) Less(epj *endpoint) bool {
 	var (
-		cip, cjp int
-		ok       bool
+		prioi, prioj int
 	)
 
-	ci, _ := eh[i].getSandbox()
-	cj, _ := eh[j].getSandbox()
+	sbi, _ := epi.getSandbox()
+	sbj, _ := epj.getSandbox()
 
-	epi := eh[i]
-	epj := eh[j]
-
-	if epi.endpointInGWNetwork() {
-		return false
+	// Prio defaults to 0
+	if sbi != nil {
+		prioi = sbi.epPriority[epi.ID()]
+	}
+	if sbj != nil {
+		prioj = sbj.epPriority[epj.ID()]
 	}
 
-	if epj.endpointInGWNetwork() {
-		return true
+	if prioi != prioj {
+		return prioi > prioj
 	}
 
-	if epi.getNetwork().Internal() {
-		return false
+	gwi := epi.endpointInGWNetwork()
+	gwj := epj.endpointInGWNetwork()
+	if gwi != gwj {
+		return gwj
 	}
 
-	if epj.getNetwork().Internal() {
-		return true
+	inti := epi.getNetwork().Internal()
+	intj := epj.getNetwork().Internal()
+	if inti != intj {
+		return intj
 	}
 
-	if epi.joinInfo != nil && epj.joinInfo != nil {
-		if (epi.joinInfo.gw != nil && epi.joinInfo.gw6 != nil) &&
-			(epj.joinInfo.gw == nil || epj.joinInfo.gw6 == nil) {
-			return true
+	jii := 0
+	if epi.joinInfo != nil {
+		if epi.joinInfo.gw != nil {
+			jii = jii + 1
 		}
-		if (epj.joinInfo.gw != nil && epj.joinInfo.gw6 != nil) &&
-			(epi.joinInfo.gw == nil || epi.joinInfo.gw6 == nil) {
-			return false
-		}
-	}
-
-	if ci != nil {
-		cip, ok = ci.epPriority[eh[i].ID()]
-		if !ok {
-			cip = 0
+		if epi.joinInfo.gw6 != nil {
+			jii = jii + 2
 		}
 	}
 
-	if cj != nil {
-		cjp, ok = cj.epPriority[eh[j].ID()]
-		if !ok {
-			cjp = 0
+	jij := 0
+	if epj.joinInfo != nil {
+		if epj.joinInfo.gw != nil {
+			jij = jij + 1
+		}
+		if epj.joinInfo.gw6 != nil {
+			jij = jij + 2
 		}
 	}
 
-	if cip == cjp {
-		return eh[i].network.Name() < eh[j].network.Name()
+	if jii != jij {
+		return jii > jij
 	}
 
-	return cip > cjp
-}
-
-func (eh epHeap) Swap(i, j int) { eh[i], eh[j] = eh[j], eh[i] }
-
-func (eh *epHeap) Push(x interface{}) {
-	*eh = append(*eh, x.(*endpoint))
-}
-
-func (eh *epHeap) Pop() interface{} {
-	old := *eh
-	n := len(old)
-	x := old[n-1]
-	*eh = old[0 : n-1]
-	return x
+	return epi.network.Name() < epj.network.Name()
 }
 
 func (sb *sandbox) NdotsSet() bool {

--- a/vendor/github.com/docker/libnetwork/sandbox_store.go
+++ b/vendor/github.com/docker/libnetwork/sandbox_store.go
@@ -1,7 +1,6 @@
 package libnetwork
 
 import (
-	"container/heap"
 	"encoding/json"
 	"sync"
 
@@ -215,7 +214,7 @@ func (c *controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 			id:                 sbs.ID,
 			controller:         sbs.c,
 			containerID:        sbs.Cid,
-			endpoints:          epHeap{},
+			endpoints:          []*endpoint{},
 			populatedEndpoints: map[string]struct{}{},
 			dbIndex:            sbs.dbIndex,
 			isStub:             true,
@@ -242,7 +241,6 @@ func (c *controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 			sb.processOptions(opts...)
 			sb.restorePath()
 			create = !sb.config.useDefaultSandBox
-			heap.Init(&sb.endpoints)
 		}
 		sb.osSbox, err = osl.NewSandbox(sb.Key(), create, isRestore)
 		if err != nil {
@@ -272,7 +270,7 @@ func (c *controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 				logrus.Errorf("failed to restore endpoint %s in %s for container %s due to %v", eps.Eid, eps.Nid, sb.ContainerID(), err)
 				continue
 			}
-			heap.Push(&sb.endpoints, ep)
+			sb.addEndpoint(ep)
 		}
 
 		if _, ok := activeSandboxes[sb.ID()]; !ok {

--- a/vendor/github.com/docker/libnetwork/types/types.go
+++ b/vendor/github.com/docker/libnetwork/types/types.go
@@ -145,7 +145,7 @@ func (p *PortBinding) String() string {
 	return ret
 }
 
-// FromString reads the TransportPort structure from string
+// FromString reads the PortBinding structure from string
 func (p *PortBinding) FromString(s string) error {
 	ps := strings.Split(s, "/")
 	if len(ps) != 3 {


### PR DESCRIPTION
full diff: https://github.com/docker/libnetwork/compare/eb6b2a57955e5c149d47c3973573216e8f8baa09...3931ba4d815e385ab97093c64477b82f14dadefb

Relevant changes:

- https://github.com/docker/libnetwork/pull/2132 Improve interface order
  - resolves https://github.com/docker/libnetwork/issues/2093 Predictive interface order / default gateway
- https://github.com/docker/libnetwork/pull/2176 Remove non-service cluster info on sbLeave

Also fixes some typos (https://github.com/docker/libnetwork/pull/2159, https://github.com/docker/libnetwork/pull/2164, https://github.com/docker/libnetwork/pull/2167)
