### PR TITLE
Fix wrong assertion in volume/service package

### DIFF
--- a/volume/service/service_linux_test.go
+++ b/volume/service/service_linux_test.go
@@ -63,5 +63,4 @@ func TestLocalVolumeSize(t *testing.T) {
 			t.Fatalf("got unexpected volume: %+v", v)
 		}
 	}
-	assert.Assert(t, is.Equal(ls[1].UsageData.Size, int64(len(data[:1]))))
 }


### PR DESCRIPTION
This last assertion shouldn't be there, those cases should be handled
by the for/switch above.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
