### PR TITLE
Clean up in TestNegotiateAPIVersionEmpty

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -193,7 +193,7 @@ func TestNewEnvClientSetsDefaultVersion(t *testing.T) {
 // TestNegotiateAPIVersionEmpty asserts that client.Client can
 // negotiate a compatible APIVersion when omitted
 func TestNegotiateAPIVersionEmpty(t *testing.T) {
-	defer env.PatchAll(t, map[string]string{"DOCKER_API_VERSION": ""})
+	defer env.PatchAll(t, map[string]string{"DOCKER_API_VERSION": ""})()
 
 	client, err := NewEnvClient()
 	assert.NilError(t, err)


### PR DESCRIPTION
Signed-off-by: John Stephens <johnstep@docker.com>

Clean up the environment after it was cleared, and replaced by a single variable. Failing to clean this up leaves the environment nearly empty, which causes a new test, in another PR, to fail on Windows because the `SystemRoot` environment variable is not set. See https://github.com/moby/moby/pull/36687#issuecomment-395628738 for more information.