### PR TITLE
Whitelist syscalls linked to CAP_SYS_NICE in default seccomp profile

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -746,6 +746,22 @@
 				]
 			},
 			"excludes": {}
+		},
+		{
+			"names": [
+				"get_mempolicy",
+				"mbind",
+				"set_mempolicy"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_NICE"
+				]
+			},
+			"excludes": {}
 		}
 	]
 }

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -630,6 +630,18 @@ func DefaultProfile() *types.Seccomp {
 				Caps: []string{"CAP_SYS_TTY_CONFIG"},
 			},
 		},
+		{
+			Names: []string{
+				"get_mempolicy",
+				"mbind",
+				"set_mempolicy",
+			},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Caps: []string{"CAP_SYS_NICE"},
+			},
+		},
 	}
 
 	return &types.Seccomp{


### PR DESCRIPTION
* Update seccomp profile to match docker documentation at
  https://docs.docker.com/engine/security/seccomp/
* fixes #37241
Signed-off-by: Nicolas V Castet <nvcastet@us.ibm.com>