### PR TITLE
Refactor ipvlan network integration tests to use network package

### DIFF
--- a/integration/internal/network/ops.go
+++ b/integration/internal/network/ops.go
@@ -26,6 +26,13 @@ func WithCheckDuplicate() func(*types.NetworkCreate) {
 	}
 }
 
+// WithInternal sets the Internal flag on the network
+func WithInternal() func(*types.NetworkCreate) {
+	return func(n *types.NetworkCreate) {
+		n.Internal = true
+	}
+}
+
 // WithMacvlan sets the network as macvlan with the specified parent
 func WithMacvlan(parent string) func(*types.NetworkCreate) {
 	return func(n *types.NetworkCreate) {
@@ -34,6 +41,22 @@ func WithMacvlan(parent string) func(*types.NetworkCreate) {
 			n.Options = map[string]string{
 				"parent": parent,
 			}
+		}
+	}
+}
+
+// WithIPvlan sets the network as ipvlan with the specified parent and mode
+func WithIPvlan(parent, mode string) func(*types.NetworkCreate) {
+	return func(n *types.NetworkCreate) {
+		n.Driver = "ipvlan"
+		if n.Options == nil {
+			n.Options = map[string]string{}
+		}
+		if parent != "" {
+			n.Options["parent"] = parent
+		}
+		if mode != "" {
+			n.Options["ipvlan_mode"] = mode
 		}
 	}
 }


### PR DESCRIPTION
**- What I did**
refactored ipvlan network integration tests to use network.Create from `integration/internal/network` package.

**- How I did it**
Modified integration tests under `integration/network/ipvlan`

**- How to verify it**

**- Description for the changelog**
ipvlan network Integration tests now use network package 

**- A picture of a cute animal (not mandatory but encouraged)**

