### PR TITLE
refactor network inspect integration tests to use network package

### DIFF
--- a/integration/internal/network/ops.go
+++ b/integration/internal/network/ops.go
@@ -19,7 +19,7 @@ func WithIPv6() func(*types.NetworkCreate) {
 	}
 }
 
-// WithCheckDuplicate enables CheckDuplicate on the create network request
+// WithCheckDuplicate sets the CheckDuplicate field on create network request
 func WithCheckDuplicate() func(*types.NetworkCreate) {
 	return func(n *types.NetworkCreate) {
 		n.CheckDuplicate = true


### PR DESCRIPTION
**- What I did**
Refactored network inspect integration tests to use network package

**- How I did it**
Modified integration tests under `integration/network/inspect_test.go` to use network package for creating networks.

**- How to verify it**

**- Description for the changelog**
Inspect network integration tests use network package to create networks.

**- A picture of a cute animal (not mandatory but encouraged)**

