### PR TITLE
Create service integration tests use network package

### DIFF
--- a/integration/internal/network/ops.go
+++ b/integration/internal/network/ops.go
@@ -19,6 +19,13 @@ func WithIPv6() func(*types.NetworkCreate) {
 	}
 }
 
+// WithCheckDuplicate enables CheckDuplicate on the create network request
+func WithCheckDuplicate() func(*types.NetworkCreate) {
+	return func(n *types.NetworkCreate) {
+		n.CheckDuplicate = true
+	}
+}
+
 // WithMacvlan sets the network as macvlan with the specified parent
 func WithMacvlan(parent string) func(*types.NetworkCreate) {
 	return func(n *types.NetworkCreate) {


### PR DESCRIPTION
**- What I did**
Refactored create service integration tests to use network package

**- How I did it**
Modified integration tests under `integration/service/create_test.go`

**- How to verify it**

**- Description for the changelog**
Service create integration tests use network package to create network resources

**- A picture of a cute animal (not mandatory but encouraged)**

