### PR TITLE
Don't fail to start daemon if builder source is not available

### DIFF
--- a/builder/builder-next/worker/worker.go
+++ b/builder/builder-next/worker/worker.go
@@ -37,6 +37,7 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // Opt defines a structure for creating a worker.
@@ -77,32 +78,33 @@ func NewWorker(opt Opt) (*Worker, error) {
 		CacheAccessor: cm,
 		MetadataStore: opt.MetadataStore,
 	})
-	if err != nil {
-		return nil, err
+	if err == nil {
+		sm.Register(gs)
+	} else {
+		logrus.Warnf("Could not register builder git source: %s", err)
 	}
-
-	sm.Register(gs)
 
 	hs, err := http.NewSource(http.Opt{
 		CacheAccessor: cm,
 		MetadataStore: opt.MetadataStore,
 		Transport:     opt.Transport,
 	})
-	if err != nil {
-		return nil, err
+	if err == nil {
+		sm.Register(hs)
+	} else {
+		logrus.Warnf("Could not register builder http source: %s", err)
 	}
-
-	sm.Register(hs)
 
 	ss, err := local.NewSource(local.Opt{
 		SessionManager: opt.SessionManager,
 		CacheAccessor:  cm,
 		MetadataStore:  opt.MetadataStore,
 	})
-	if err != nil {
-		return nil, err
+	if err == nil {
+		sm.Register(ss)
+	} else {
+		logrus.Warnf("Could not register builder local source: %s", err)
 	}
-	sm.Register(ss)
 
 	return &Worker{
 		Opt:           opt,


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes https://github.com/moby/moby/issues/37278. Following the merge of https://github.com/moby/moby/pull/37151#issuecomment-396995129, the daemon no longer starts if git is not in the path.

Temporary solution (not sure if correct, but at least to get master running again) is to only register the source if it initialises, and warn if failed.

@tonistiigi @tiborvass @johnstep @thaJeztah PTAL

@tianon @jstarks FYI

Before
```
PS C:\> dockerd
INFO[2018-06-13T09:04:23.208583500-07:00] Windows default isolation mode: process
INFO[2018-06-13T09:04:23.294671100-07:00] Loading containers: start.
INFO[2018-06-13T09:04:23.298646300-07:00] Restoring existing overlay networks from HNS into docker
INFO[2018-06-13T09:04:23.399254200-07:00] Loading containers: done.
INFO[2018-06-13T09:04:23.402261600-07:00] Docker daemon                                 commit=692df4699c graphdriver(s)=windowsfilter version=0.0.0-dev
INFO[2018-06-13T09:04:23.405258500-07:00] Daemon has completed initialization
failed to find git binary: exec: "git": executable file not found in %PATH%
PS C:\>
```

After
```
PS C:\> dockerd
INFO[2018-06-13T09:32:09.243682200-07:00] Windows default isolation mode: process
INFO[2018-06-13T09:32:09.287684200-07:00] Loading containers: start.
INFO[2018-06-13T09:32:09.290706100-07:00] Restoring existing overlay networks from HNS into docker
INFO[2018-06-13T09:32:09.398698500-07:00] Loading containers: done.
INFO[2018-06-13T09:32:09.401675600-07:00] Docker daemon                                 commit=692df4699c-unsupported graphdriver(s)=windowsfilter version=0.0.0-dev
INFO[2018-06-13T09:32:09.404660000-07:00] Daemon has completed initialization
INFO[2018-06-13T09:32:09.448672000-07:00] API listen on //./pipe/docker_engine
```


