### PR TITLE
refactored remaining macvlan integration tests to use network package

### DIFF
--- a/integration/internal/network/ops.go
+++ b/integration/internal/network/ops.go
@@ -26,7 +26,7 @@ func WithCheckDuplicate() func(*types.NetworkCreate) {
 	}
 }
 
-// WithInternal sets the Internal flag on the network
+// WithInternal enables Internal flag on the create network request
 func WithInternal() func(*types.NetworkCreate) {
 	return func(n *types.NetworkCreate) {
 		n.Internal = true


### PR DESCRIPTION
**- What I did**
Refactored remaining macvlan integration tests to use network package for creating networks

**- How I did it**
Modified 2 macvlan integration tests which were not using the network package

**- How to verify it**

**- Description for the changelog**
Macvlan integration tests use network package

**- A picture of a cute animal (not mandatory but encouraged)**

