### PR TITLE
Add flag annotation 

### DIFF
--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -41,29 +41,30 @@ type HealthConfig struct {
 // All fields added to this struct must be marked `omitempty` to keep getting
 // predictable hashes from the old `v1Compatibility` configuration.
 type Config struct {
-	Hostname        string              // Hostname
-	Domainname      string              // Domainname
-	User            string              // User that will run the command(s) inside the container, also support user:group
-	AttachStdin     bool                // Attach the standard input, makes possible user interaction
-	AttachStdout    bool                // Attach the standard output
-	AttachStderr    bool                // Attach the standard error
-	ExposedPorts    nat.PortSet         `json:",omitempty"` // List of exposed ports
-	Tty             bool                // Attach standard streams to a tty, including stdin if it is not closed.
-	OpenStdin       bool                // Open stdin
-	StdinOnce       bool                // If true, close stdin after the 1 attached client disconnects.
-	Env             []string            // List of environment variable to set in the container
-	Cmd             strslice.StrSlice   // Command to run when starting the container
-	Healthcheck     *HealthConfig       `json:",omitempty"` // Healthcheck describes how to check the container is healthy
-	ArgsEscaped     bool                `json:",omitempty"` // True if command is already escaped (Windows specific)
-	Image           string              // Name of the image as it was passed by the operator (e.g. could be symbolic)
-	Volumes         map[string]struct{} // List of volumes (mounts) used for the container
-	WorkingDir      string              // Current directory (PWD) in the command will be launched
-	Entrypoint      strslice.StrSlice   // Entrypoint to run when starting the container
-	NetworkDisabled bool                `json:",omitempty"` // Is network disabled
-	MacAddress      string              `json:",omitempty"` // Mac Address of the container
-	OnBuild         []string            // ONBUILD metadata that were defined on the image Dockerfile
-	Labels          map[string]string   // List of labels set to this container
-	StopSignal      string              `json:",omitempty"` // Signal to stop a container
-	StopTimeout     *int                `json:",omitempty"` // Timeout (in seconds) to stop a container
-	Shell           strslice.StrSlice   `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
+	Hostname           string              // Hostname
+	Domainname         string              // Domainname
+	User               string              // User that will run the command(s) inside the container, also support user:group
+	AttachStdin        bool                // Attach the standard input, makes possible user interaction
+	AttachStdout       bool                // Attach the standard output
+	AttachStderr       bool                // Attach the standard error
+	ExposedPorts       nat.PortSet         `json:",omitempty"` // List of exposed ports
+	Tty                bool                // Attach standard streams to a tty, including stdin if it is not closed.
+	OpenStdin          bool                // Open stdin
+	StdinOnce          bool                // If true, close stdin after the 1 attached client disconnects.
+	Env                []string            // List of environment variable to set in the container
+	Cmd                strslice.StrSlice   // Command to run when starting the container
+	Healthcheck        *HealthConfig       `json:",omitempty"` // Healthcheck describes how to check the container is healthy
+	ArgsEscaped        bool                `json:",omitempty"` // True if command is already escaped (Windows specific)
+	Image              string              // Name of the image as it was passed by the operator (e.g. could be symbolic)
+	Volumes            map[string]struct{} // List of volumes (mounts) used for the container
+	WorkingDir         string              // Current directory (PWD) in the command will be launched
+	Entrypoint         strslice.StrSlice   // Entrypoint to run when starting the container
+	NetworkDisabled    bool                `json:",omitempty"` // Is network disabled
+	MacAddress         string              `json:",omitempty"` // Mac Address of the container
+	OnBuild            []string            // ONBUILD metadata that were defined on the image Dockerfile
+	Labels             map[string]string   // List of labels set to this container
+	RuntimeAnnotations map[string]string   // List of runtime annotations set to this container
+	StopSignal         string              `json:",omitempty"` // Signal to stop a container
+	StopTimeout        *int                `json:",omitempty"` // Timeout (in seconds) to stop a container
+	Shell              strslice.StrSlice   `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -56,19 +56,20 @@ type ImageMetadata struct {
 // Container contains response of Engine API:
 // GET "/containers/json"
 type Container struct {
-	ID         string `json:"Id"`
-	Names      []string
-	Image      string
-	ImageID    string
-	Command    string
-	Created    int64
-	Ports      []Port
-	SizeRw     int64 `json:",omitempty"`
-	SizeRootFs int64 `json:",omitempty"`
-	Labels     map[string]string
-	State      string
-	Status     string
-	HostConfig struct {
+	ID                 string `json:"Id"`
+	Names              []string
+	Image              string
+	ImageID            string
+	Command            string
+	Created            int64
+	Ports              []Port
+	SizeRw             int64 `json:",omitempty"`
+	SizeRootFs         int64 `json:",omitempty"`
+	Labels             map[string]string
+	RuntimeAnnotations map[string]string
+	State              string
+	Status             string
+	HostConfig         struct {
 		NetworkMode string `json:",omitempty"`
 	}
 	NetworkSettings *SummaryNetworkSettings

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -911,6 +911,8 @@ func (daemon *Daemon) createSpec(c *container.Container) (retSpec *specs.Spec, e
 		s.Linux.ReadonlyPaths = c.HostConfig.ReadonlyPaths
 	}
 
+	s.Annotations = c.Config.RuntimeAnnotations
+
 	return &s, nil
 }
 


### PR DESCRIPTION
As talked in #37262, it will be very useful to support `annotations` flag in `docker cli`.

Support `annotation` will bring a lot of benefits not only for `dockershim` model for `kubernetes` and also 
native docker users will have additional ways to pass there `key-value` to container.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

