### PR TITLE
migrate TestAPINetworkCreateDelete from integration-cli/ to integration/

### DIFF
--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -26,24 +26,6 @@ func (s *DockerSuite) TestAPINetworkGetDefaults(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestAPINetworkCreateDelete(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	// Create a network
-	name := "testnetwork"
-	config := types.NetworkCreateRequest{
-		Name: name,
-		NetworkCreate: types.NetworkCreate{
-			CheckDuplicate: true,
-		},
-	}
-	id := createNetwork(c, config, http.StatusCreated)
-	c.Assert(isNetworkAvailable(c, name), checker.Equals, true)
-
-	// delete the network and make sure it is deleted
-	deleteNetwork(c, id, true)
-	c.Assert(isNetworkAvailable(c, name), checker.Equals, false)
-}
-
 func (s *DockerSuite) TestAPINetworkCreateCheckDuplicate(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testcheckduplicate"

--- a/integration/network/delete_test.go
+++ b/integration/network/delete_test.go
@@ -44,6 +44,24 @@ func createAmbiguousNetworks(t *testing.T) (string, string, string) {
 	return testNet, idPrefixNet, fullIDNet
 }
 
+func TestNetworkCreateDelete(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	defer setupTest(t)()
+	client := request.NewAPIClient(t)
+	ctx := context.Background()
+
+	netName := "testnetwork_" + t.Name()
+	network.CreateNoError(t, ctx, client, netName,
+		network.WithCheckDuplicate(),
+	)
+	assert.Check(t, IsNetworkAvailable(client, netName))
+
+	// delete the network and make sure it is deleted
+	err := client.NetworkRemove(ctx, netName)
+	assert.NilError(t, err)
+	assert.Check(t, IsNetworkNotAvailable(client, netName))
+}
+
 // TestDockerNetworkDeletePreferID tests that if a network with a name
 // equal to another network's ID exists, the Network with the given
 // ID is removed, and not the network with the given name.


### PR DESCRIPTION
**- What I did**
migrated TestAPINetworkCreateDelete from integration-cli/ to integration/

**- How I did it**
Removed the test from `integration-cli/docker_api_network_test.go`, created an equivalent test under integration

**- How to verify it**

**- Description for the changelog**
migrate TestAPINetworkCreateDelete from integration-cli/ to integration/

**- A picture of a cute animal (not mandatory but encouraged)**

