### PR TITLE
lcow: Allow the client to adjust capabilities and device cgroup rules

### DIFF
--- a/daemon/caps/utils.go
+++ b/daemon/caps/utils.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package caps // import "github.com/docker/docker/daemon/caps"
 
 import (

--- a/daemon/oci.go
+++ b/daemon/oci.go
@@ -1,0 +1,31 @@
+package daemon // import "github.com/docker/docker/daemon"
+
+import (
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/caps"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func setCapabilities(s *specs.Spec, c *container.Container) error {
+	var caplist []string
+	var err error
+	if c.HostConfig.Privileged {
+		caplist = caps.GetAllCapabilities()
+	} else {
+		caplist, err = caps.TweakCapabilities(s.Process.Capabilities.Bounding, c.HostConfig.CapAdd, c.HostConfig.CapDrop)
+		if err != nil {
+			return err
+		}
+	}
+	s.Process.Capabilities.Effective = caplist
+	s.Process.Capabilities.Bounding = caplist
+	s.Process.Capabilities.Permitted = caplist
+	s.Process.Capabilities.Inheritable = caplist
+	// setUser has already been executed here
+	// if non root drop capabilities in the way execve does
+	if s.Process.User.UID != 0 {
+		s.Process.Capabilities.Effective = []string{}
+		s.Process.Capabilities.Permitted = []string{}
+	}
+	return nil
+}

--- a/daemon/oci.go
+++ b/daemon/oci.go
@@ -1,9 +1,18 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"fmt"
+	"regexp"
+	"strconv"
+
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/caps"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// nolint: gosimple
+var (
+	deviceCgroupRuleRegex = regexp.MustCompile("^([acb]) ([0-9]+|\\*):([0-9]+|\\*) ([rwm]{1,3})$")
 )
 
 func setCapabilities(s *specs.Spec, c *container.Container) error {
@@ -28,4 +37,42 @@ func setCapabilities(s *specs.Spec, c *container.Container) error {
 		s.Process.Capabilities.Permitted = []string{}
 	}
 	return nil
+}
+
+func appendDevicePermissionsFromCgroupRules(devPermissions []specs.LinuxDeviceCgroup, rules []string) ([]specs.LinuxDeviceCgroup, error) {
+	for _, deviceCgroupRule := range rules {
+		ss := deviceCgroupRuleRegex.FindAllStringSubmatch(deviceCgroupRule, -1)
+		if len(ss[0]) != 5 {
+			return nil, fmt.Errorf("invalid device cgroup rule format: '%s'", deviceCgroupRule)
+		}
+		matches := ss[0]
+
+		dPermissions := specs.LinuxDeviceCgroup{
+			Allow:  true,
+			Type:   matches[1],
+			Access: matches[4],
+		}
+		if matches[2] == "*" {
+			major := int64(-1)
+			dPermissions.Major = &major
+		} else {
+			major, err := strconv.ParseInt(matches[2], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid major value in device cgroup rule format: '%s'", deviceCgroupRule)
+			}
+			dPermissions.Major = &major
+		}
+		if matches[3] == "*" {
+			minor := int64(-1)
+			dPermissions.Minor = &minor
+		} else {
+			minor, err := strconv.ParseInt(matches[3], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid minor value in device cgroup rule format: '%s'", deviceCgroupRule)
+			}
+			dPermissions.Minor = &minor
+		}
+		devPermissions = append(devPermissions, dPermissions)
+	}
+	return devPermissions, nil
 }

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -13,7 +13,6 @@ import (
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
-	"github.com/docker/docker/daemon/caps"
 	daemonconfig "github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/oci"
 	"github.com/docker/docker/pkg/idtools"
@@ -247,30 +246,6 @@ func setNamespace(s *specs.Spec, ns specs.LinuxNamespace) {
 		}
 	}
 	s.Linux.Namespaces = append(s.Linux.Namespaces, ns)
-}
-
-func setCapabilities(s *specs.Spec, c *container.Container) error {
-	var caplist []string
-	var err error
-	if c.HostConfig.Privileged {
-		caplist = caps.GetAllCapabilities()
-	} else {
-		caplist, err = caps.TweakCapabilities(s.Process.Capabilities.Bounding, c.HostConfig.CapAdd, c.HostConfig.CapDrop)
-		if err != nil {
-			return err
-		}
-	}
-	s.Process.Capabilities.Effective = caplist
-	s.Process.Capabilities.Bounding = caplist
-	s.Process.Capabilities.Permitted = caplist
-	s.Process.Capabilities.Inheritable = caplist
-	// setUser has already been executed here
-	// if non root drop capabilities in the way execve does
-	if s.Process.User.UID != 0 {
-		s.Process.Capabilities.Effective = []string{}
-		s.Process.Capabilities.Permitted = []string{}
-	}
-	return nil
 }
 
 func setNamespaces(daemon *Daemon, s *specs.Spec, c *container.Container) error {

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -211,7 +211,9 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 		if !system.LCOWSupported() {
 			return nil, fmt.Errorf("Linux containers on Windows are not supported")
 		}
-		daemon.createSpecLinuxFields(c, &s)
+		if err := daemon.createSpecLinuxFields(c, &s); err != nil {
+			return nil, err
+		}
 	default:
 		return nil, fmt.Errorf("Unsupported platform %q", img.OS)
 	}
@@ -336,12 +338,16 @@ func (daemon *Daemon) createSpecWindowsFields(c *container.Container, s *specs.S
 // Sets the Linux-specific fields of the OCI spec
 // TODO: @jhowardmsft LCOW Support. We need to do a lot more pulling in what can
 // be pulled in from oci_linux.go.
-func (daemon *Daemon) createSpecLinuxFields(c *container.Container, s *specs.Spec) {
+func (daemon *Daemon) createSpecLinuxFields(c *container.Container, s *specs.Spec) error {
 	if len(s.Process.Cwd) == 0 {
 		s.Process.Cwd = `/`
 	}
 	s.Root.Path = "rootfs"
 	s.Root.Readonly = c.HostConfig.ReadonlyRootfs
+	if err := setCapabilities(s, c); err != nil {
+		return fmt.Errorf("linux spec capabilities: %v", err)
+	}
+	return nil
 }
 
 func escapeArgs(args []string) []string {

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -347,6 +347,11 @@ func (daemon *Daemon) createSpecLinuxFields(c *container.Container, s *specs.Spe
 	if err := setCapabilities(s, c); err != nil {
 		return fmt.Errorf("linux spec capabilities: %v", err)
 	}
+	devPermissions, err := appendDevicePermissionsFromCgroupRules(nil, c.HostConfig.DeviceCgroupRules)
+	if err != nil {
+		return fmt.Errorf("linux runtime spec devices: %v", err)
+	}
+	s.Linux.Resources.Devices = devPermissions
 	return nil
 }
 


### PR DESCRIPTION
**- What I did**
Allowed LCOW clients to pass --cap-add, --device-group-rule etc. to customize the capabilities and device cgroup rules for their containers.
**- How I did it**
Moved the capabilities- and device cgroup-related OCI spec creation code from Linux-specific code to a common area.
**- How to verify it**
`docker run --cap-add=SYSLOG ubuntu dmesg` now succeeds on LCOW.
**- Description for the changelog**
Allow the client to customize capabilities and device cgroup rules for LCOW containers

**- A picture of a cute animal (not mandatory but encouraged)**

