### PR TITLE
Updated path to be consistent w/ current Windows build process

### DIFF
--- a/docs/contributing/software-req-win.md
+++ b/docs/contributing/software-req-win.md
@@ -100,8 +100,8 @@ To build Moby, run:
 Copy out the resulting Windows Moby Engine binary to `dockerd.exe` in the
 current directory:
 
-    docker cp binaries:C:\go\src\github.com\moby\moby\bundles\docker.exe docker.exe
-    docker cp binaries:C:\go\src\github.com\moby\moby\bundles\dockerd.exe dockerd.exe
+    docker cp binaries:C:\go\src\github.com\docker\docker\bundles\docker.exe docker.exe
+    docker cp binaries:C:\go\src\github.com\docker\docker\bundles\dockerd.exe dockerd.exe
 
 To test it, stop the system Docker daemon and start the one you just built:
 


### PR DESCRIPTION
Signed-off-by: Benjamin Baker <Benjamin.baker@utexas.edu>

**- What I did**
Changed a path in the tutorial from /moby/moby/ to /docker/docker/ because the current build process
for docker on windows puts it in a different location than in the tutorial.

**- How I did it**
Changed text in tutorial

**- How to verify it**
Follow the tutorial on Windows until the line that I changed. The original path will not work, but
the new path will.

**- Description for the changelog**
Changed path given for executable output in windows to actual location of executable output.


**- A picture of a cute animal (not mandatory but encouraged)**
https://vignette.wikia.nocookie.net/aliens/images/1/16/Spathi.gif/revision/latest?cb=20080625124520
