### PR TITLE
Implemented memory and CPU limits for LCOW.

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -250,45 +250,7 @@ func (daemon *Daemon) createSpecWindowsFields(c *container.Container, s *specs.S
 	// First boot optimization
 	s.Windows.IgnoreFlushesDuringBoot = !c.HasBeenStartedBefore
 
-	// In s.Windows.Resources
-	cpuShares := uint16(c.HostConfig.CPUShares)
-	cpuMaximum := uint16(c.HostConfig.CPUPercent) * 100
-	cpuCount := uint64(c.HostConfig.CPUCount)
-	if c.HostConfig.NanoCPUs > 0 {
-		if isHyperV {
-			cpuCount = uint64(c.HostConfig.NanoCPUs / 1e9)
-			leftoverNanoCPUs := c.HostConfig.NanoCPUs % 1e9
-			if leftoverNanoCPUs != 0 {
-				cpuCount++
-				cpuMaximum = uint16(c.HostConfig.NanoCPUs / int64(cpuCount) / (1e9 / 10000))
-				if cpuMaximum < 1 {
-					// The requested NanoCPUs is so small that we rounded to 0, use 1 instead
-					cpuMaximum = 1
-				}
-			}
-		} else {
-			cpuMaximum = uint16(c.HostConfig.NanoCPUs / int64(sysinfo.NumCPU()) / (1e9 / 10000))
-			if cpuMaximum < 1 {
-				// The requested NanoCPUs is so small that we rounded to 0, use 1 instead
-				cpuMaximum = 1
-			}
-		}
-	}
-	memoryLimit := uint64(c.HostConfig.Memory)
-	s.Windows.Resources = &specs.WindowsResources{
-		CPU: &specs.WindowsCPUResources{
-			Maximum: &cpuMaximum,
-			Shares:  &cpuShares,
-			Count:   &cpuCount,
-		},
-		Memory: &specs.WindowsMemoryResources{
-			Limit: &memoryLimit,
-		},
-		Storage: &specs.WindowsStorageResources{
-			Bps:  &c.HostConfig.IOMaximumBandwidth,
-			Iops: &c.HostConfig.IOMaximumIOps,
-		},
-	}
+	setResourcesInSpec(c, s, isHyperV)
 
 	// Read and add credentials from the security options if a credential spec has been provided.
 	if c.HostConfig.SecurityOpt != nil {
@@ -369,6 +331,9 @@ func (daemon *Daemon) createSpecLinuxFields(c *container.Container, s *specs.Spe
 	}
 	s.Root.Path = "rootfs"
 	s.Root.Readonly = c.HostConfig.ReadonlyRootfs
+
+	setResourcesInSpec(c, s, true) // LCOW is Hyper-V only
+
 	capabilities, err := caps.TweakCapabilities(oci.DefaultCapabilities(), c.HostConfig.CapAdd, c.HostConfig.CapDrop, c.HostConfig.Capabilities, c.HostConfig.Privileged)
 	if err != nil {
 		return fmt.Errorf("linux spec capabilities: %v", err)
@@ -382,6 +347,48 @@ func (daemon *Daemon) createSpecLinuxFields(c *container.Container, s *specs.Spe
 	}
 	s.Linux.Resources.Devices = devPermissions
 	return nil
+}
+
+func setResourcesInSpec(c *container.Container, s *specs.Spec, isHyperV bool) {
+	// In s.Windows.Resources
+	cpuShares := uint16(c.HostConfig.CPUShares)
+	cpuMaximum := uint16(c.HostConfig.CPUPercent) * 100
+	cpuCount := uint64(c.HostConfig.CPUCount)
+	if c.HostConfig.NanoCPUs > 0 {
+		if isHyperV {
+			cpuCount = uint64(c.HostConfig.NanoCPUs / 1e9)
+			leftoverNanoCPUs := c.HostConfig.NanoCPUs % 1e9
+			if leftoverNanoCPUs != 0 {
+				cpuCount++
+				cpuMaximum = uint16(c.HostConfig.NanoCPUs / int64(cpuCount) / (1e9 / 10000))
+				if cpuMaximum < 1 {
+					// The requested NanoCPUs is so small that we rounded to 0, use 1 instead
+					cpuMaximum = 1
+				}
+			}
+		} else {
+			cpuMaximum = uint16(c.HostConfig.NanoCPUs / int64(sysinfo.NumCPU()) / (1e9 / 10000))
+			if cpuMaximum < 1 {
+				// The requested NanoCPUs is so small that we rounded to 0, use 1 instead
+				cpuMaximum = 1
+			}
+		}
+	}
+	memoryLimit := uint64(c.HostConfig.Memory)
+	s.Windows.Resources = &specs.WindowsResources{
+		CPU: &specs.WindowsCPUResources{
+			Maximum: &cpuMaximum,
+			Shares:  &cpuShares,
+			Count:   &cpuCount,
+		},
+		Memory: &specs.WindowsMemoryResources{
+			Limit: &memoryLimit,
+		},
+		Storage: &specs.WindowsStorageResources{
+			Bps:  &c.HostConfig.IOMaximumBandwidth,
+			Iops: &c.HostConfig.IOMaximumIOps,
+		},
+	}
 }
 
 func escapeArgs(args []string) []string {


### PR DESCRIPTION
Signed-off-by: Yusuf Tarık Günaydın <yusuf_tarik@hotmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added implementation of --memory and --cpu switches for LCOW.

**- How I did it**
Filled the Resources object in spec.Windows for both Windows and Linux by separating it into a new method. Also separated the code that fills the CPU and memory part of the hcsshim configuration and called it for both Windows and Linux.

**- How to verify it**
docker run -it --memory=2G --cpus=8 alpine sh -c "nproc && cat /proc/meminfo"

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added memory and CPU limits for LCOW.

**- A picture of a cute animal (not mandatory but encouraged)**

