### PR TITLE
integration/service/network integration tests to use network package

### DIFF
--- a/integration/internal/network/ops.go
+++ b/integration/internal/network/ops.go
@@ -33,6 +33,13 @@ func WithInternal() func(*types.NetworkCreate) {
 	}
 }
 
+// WithAttachable sets Attachable flag on the create network request
+func WithAttachable() func(*types.NetworkCreate) {
+	return func(n *types.NetworkCreate) {
+		n.Attachable = true
+	}
+}
+
 // WithMacvlan sets the network as macvlan with the specified parent
 func WithMacvlan(parent string) func(*types.NetworkCreate) {
 	return func(n *types.NetworkCreate) {

--- a/integration/service/network_test.go
+++ b/integration/service/network_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/integration/internal/container"
+	net "github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/integration/internal/swarm"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
@@ -21,11 +22,10 @@ func TestDockerNetworkConnectAlias(t *testing.T) {
 	ctx := context.Background()
 
 	name := t.Name() + "test-alias"
-	_, err := client.NetworkCreate(ctx, name, types.NetworkCreate{
-		Driver:     "overlay",
-		Attachable: true,
-	})
-	assert.NilError(t, err)
+	net.CreateNoError(t, ctx, client, name,
+		net.WithDriver("overlay"),
+		net.WithAttachable(),
+	)
 
 	cID1 := container.Create(t, ctx, client, func(c *container.TestContainerConfig) {
 		c.NetworkingConfig = &network.NetworkingConfig{
@@ -35,7 +35,7 @@ func TestDockerNetworkConnectAlias(t *testing.T) {
 		}
 	})
 
-	err = client.NetworkConnect(ctx, name, cID1, &network.EndpointSettings{
+	err := client.NetworkConnect(ctx, name, cID1, &network.EndpointSettings{
 		Aliases: []string{
 			"aaa",
 		},


### PR DESCRIPTION
**- What I did**
refactored integration/service/network integration tests to use network package for consistency

**- How I did it**
Modified integration tests under `integration/service/network_test.go` to use the network package

**- How to verify it**

**- Description for the changelog**
integration/service/network integration tests use the network package to create network test resources

**- A picture of a cute animal (not mandatory but encouraged)**

