### PR TITLE
dockerd: make -H tcp://... even harder without --tlsverify

### DIFF
--- a/cmd/dockerd/options.go
+++ b/cmd/dockerd/options.go
@@ -30,15 +30,16 @@ var (
 )
 
 type daemonOptions struct {
-	configFile   string
-	daemonConfig *config.Config
-	flags        *pflag.FlagSet
-	Debug        bool
-	Hosts        []string
-	LogLevel     string
-	TLS          bool
-	TLSVerify    bool
-	TLSOptions   *tlsconfig.Options
+	configFile       string
+	daemonConfig     *config.Config
+	flags            *pflag.FlagSet
+	Debug            bool
+	Hosts            []string
+	LogLevel         string
+	TLS              bool
+	TLSVerify        bool
+	InsecureHostBind bool
+	TLSOptions       *tlsconfig.Options
 }
 
 // newDaemonOptions returns a new daemonFlags
@@ -72,7 +73,8 @@ func (o *daemonOptions) InstallFlags(flags *pflag.FlagSet) {
 	flags.Var(opts.NewQuotedString(&tlsOptions.KeyFile), "tlskey", "Path to TLS key file")
 
 	hostOpt := opts.NewNamedListOptsRef("hosts", &o.Hosts, opts.ValidateHost)
-	flags.VarP(hostOpt, "host", "H", "Daemon socket(s) to connect to")
+	flags.VarP(hostOpt, "host", "H", "Daemon socket(s) to bind to")
+	flags.BoolVar(&o.InsecureHostBind, "give-the-internet-root-access", false, "Allow -H to bind to a TCP address without --tlsverify (this could allow anyone on your network to get root access to your *host*)")
 }
 
 // SetDefaultOptions sets default values for options after flag parsing is

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -149,11 +149,12 @@ type CommonConfig struct {
 	// to stop when daemon is being shutdown
 	ShutdownTimeout int `json:"shutdown-timeout,omitempty"`
 
-	Debug     bool     `json:"debug,omitempty"`
-	Hosts     []string `json:"hosts,omitempty"`
-	LogLevel  string   `json:"log-level,omitempty"`
-	TLS       bool     `json:"tls,omitempty"`
-	TLSVerify bool     `json:"tlsverify,omitempty"`
+	Debug            bool     `json:"debug,omitempty"`
+	Hosts            []string `json:"hosts,omitempty"`
+	InsecureHostBind bool     `json:"give-the-internet-root-access,omitempty"`
+	LogLevel         string   `json:"log-level,omitempty"`
+	TLS              bool     `json:"tls,omitempty"`
+	TLSVerify        bool     `json:"tlsverify,omitempty"`
 
 	// Embedded structs that allow config
 	// deserialization without the full struct.

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -530,7 +530,7 @@ func (s *DockerDaemonSuite) TestDaemonAllocatesListeningPort(c *check.C) {
 
 	cmdArgs := make([]string, 0, len(listeningPorts)*2)
 	for _, hostDirective := range listeningPorts {
-		cmdArgs = append(cmdArgs, "--host", fmt.Sprintf("tcp://%s:%s", hostDirective[0], hostDirective[2]))
+		cmdArgs = append(cmdArgs, "--host", fmt.Sprintf("tcp://%s:%s", hostDirective[0], hostDirective[2]), "--give-the-internet-root-access")
 	}
 
 	s.d.StartWithBusybox(c, cmdArgs...)
@@ -1568,7 +1568,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartCleanupNetns(c *check.C) {
 // tests regression detailed in #13964 where DOCKER_TLS_VERIFY env is ignored
 func (s *DockerDaemonSuite) TestDaemonTLSVerifyIssue13964(c *check.C) {
 	host := "tcp://localhost:4271"
-	s.d.Start(c, "-H", host)
+	s.d.Start(c, "-H", host, "--give-the-internet-root-access")
 	icmd.RunCmd(icmd.Cmd{
 		Command: []string{dockerBinary, "-H", host, "info"},
 		Env:     []string{"DOCKER_TLS_VERIFY=1", "DOCKER_CERT_PATH=fixtures/https"},

--- a/integration-cli/docker_cli_proxy_test.go
+++ b/integration-cli/docker_cli_proxy_test.go
@@ -37,7 +37,7 @@ func (s *DockerDaemonSuite) TestCLIProxyProxyTCPSock(c *check.C) {
 
 	c.Assert(ip, checker.Not(checker.Equals), "")
 
-	s.d.Start(c, "-H", "tcp://"+ip+":2375")
+	s.d.Start(c, "-H", "tcp://"+ip+":2375", "--give-the-internet-root-access")
 
 	icmd.RunCmd(icmd.Cmd{
 		Command: []string{dockerBinary, "info"},


### PR DESCRIPTION
Historically we have been a little bit too forgiving to people who run
Docker with an unauthenticated API server, and [recent events][1] have
shown that a worrying amount of people are running Docker daemons with
the API accessible from the internet.

For a long time Docker has not used a TCP port by default, and using it
without --tlsverify has elicited an all-caps warning for a while as
well. But obviously this is not sufficient (maybe people aren't noticing
the warnings). We cannot just disallow this (because it is in theory
possible to set this up safely, and we use it ourselves in testing), so
instead add a new flag with a scary name to make sure that users are
aware of the significant risk of binding the API server to a TCP port
without any authentication:

  % sudo dockerd -H tcp://0.0.0.0:1337 --give-the-internet-root-access

While it might sound like a bit of a joke, these sorts of "scary and
very obvious" flags exist in other tools. For instance, flashrom
requires you to use the flag "i_want_a_brick" if you are trying to flash
a laptop's ROM in a way it doesn't think is safe (and anyone reading
such an option should recognise why the flag has such a scary name).

[1]: https://kromtech.com/blog/security-center/cryptojacking-invades-cloud-how-modern-containerization-trend-is-exploited-by-attackers

[![Midge our cute new kitten cat by dougwoods](https://farm1.staticflickr.com/202/551399323_da23725ed3_b.jpg)](https://flic.kr/p/QJ4NT)

###### [Midge our cute new kitten cat](https://flic.kr/p/QJ4NT) by [dougwoods](https://www.flickr.com/photos/deerwooduk/)

Ref: docker/hub-feedback#1121
Signed-off-by: Aleksa Sarai <asarai@suse.de>
