### PR TITLE
fix build on OpenBSD by defining Self()

### DIFF
--- a/pkg/reexec/command_unsupported.go
+++ b/pkg/reexec/command_unsupported.go
@@ -6,6 +6,10 @@ import (
 	"os/exec"
 )
 
+func Self() string {
+	return ""
+}
+
 // Command is unsupported on operating systems apart from Linux, Windows, and Darwin.
 func Command(args ...string) *exec.Cmd {
 	return nil


### PR DESCRIPTION
**- What I did**
While building all tools from https://github.com/ethereum/go-ethereum on OpenBSD, I got an error because Self was not defined in `reexec/command_unsupported.go`.

**- How I did it**
This PR defines the method.

**- How to verify it**
It builds now under OpenBSD. I did not do any runtime testing though.

**- Description for the changelog**

fix the build on OpenBSD.

