### PR TITLE
Update to containerd v1.1.1-rc.1

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=395068d2b7256518259816ae19e45824b15da071 # v1.1.1-rc.0
+CONTAINERD_COMMIT=cbef57047e900aeb2bafe7a634919bec13f4a2a5 # v1.1.1-rc.1
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
Full diff: https://github.com/containerd/containerd/compare/395068d2b7256518259816ae19e45824b15da071...cbef57047e900aeb2bafe7a634919bec13f4a2a5

Relevant change is; https://github.com/containerd/containerd/pull/2395 [release/1.1] update cri to v1.0.3, which brings in these changes: https://github.com/containerd/cri/compare/v1.0.2...v1.0.3

- https://github.com/containerd/cri/pull/812 Erase ambient capabilities (cherry-pick of https://github.com/containerd/cri/pull/808)
- https://github.com/containerd/cri/pull/814 Fix empty volume ownership (cherry-pick of https://github.com/containerd/cri/pull/811)

