### PR TITLE
Update overlay2 to use naive diff for changes

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -754,16 +754,5 @@ func (d *Driver) Diff(id, parent string) (io.ReadCloser, error) {
 // Changes produces a list of changes between the specified layer and its
 // parent layer. If parent is "", then all changes will be ADD changes.
 func (d *Driver) Changes(id, parent string) ([]archive.Change, error) {
-	if useNaiveDiff(d.home) || !d.isParent(id, parent) {
-		return d.naiveDiff.Changes(id, parent)
-	}
-	// Overlay doesn't have snapshots, so we need to get changes from all parent
-	// layers.
-	diffPath := d.getDiffPath(id)
-	layers, err := d.getLowerDirs(id)
-	if err != nil {
-		return nil, err
-	}
-
-	return archive.OverlayChanges(layers, diffPath)
+	return d.naiveDiff.Changes(id, parent)
 }

--- a/daemon/graphdriver/overlay2/overlay_test.go
+++ b/daemon/graphdriver/overlay2/overlay_test.go
@@ -62,7 +62,7 @@ func TestOverlayDiffApply10Files(t *testing.T) {
 }
 
 func TestOverlayChanges(t *testing.T) {
-	skipIfNaive(t)
+	t.Skipf("Cannot run test with naive change algorithm")
 	graphtest.DriverTestChanges(t, driverName)
 }
 


### PR DESCRIPTION
The archive changes function is not implemented correctly to handle opaque directories.

There are actually 2 bugs with the overlay changes function. The first marks opaque directories as deleted. The second is that opaque directories are not handled at all by the changes function, not picking up the deletions that result from being opaque. I don't have an AUFS setup but I would expect to see this in AUFS if a version of AUFS is still creating the opaque directory files.

Using the naive diff logic in all cases may cause a difference in output between what `Changes` produces and what `Diff` produces. In practice I don't see this having an impact on anything since `Changes` is pretty useless and provides no accuracy guarantees in regards to the diff tar which may get produced.