### PR TITLE
apparmor: clobber docker-default profile on start

### DIFF
--- a/daemon/apparmor_default.go
+++ b/daemon/apparmor_default.go
@@ -14,6 +14,15 @@ const (
 	defaultApparmorProfile = "docker-default"
 )
 
+func clobberDefaultAppArmorProfile() error {
+	if apparmor.IsEnabled() {
+		if err := aaprofile.InstallDefault(defaultApparmorProfile); err != nil {
+			return fmt.Errorf("AppArmor enabled on system but the %s profile could not be loaded: %s", defaultApparmorProfile, err)
+		}
+	}
+	return nil
+}
+
 func ensureDefaultAppArmorProfile() error {
 	if apparmor.IsEnabled() {
 		loaded, err := aaprofile.IsLoaded(defaultApparmorProfile)
@@ -27,10 +36,7 @@ func ensureDefaultAppArmorProfile() error {
 		}
 
 		// Load the profile.
-		if err := aaprofile.InstallDefault(defaultApparmorProfile); err != nil {
-			return fmt.Errorf("AppArmor enabled on system but the %s profile could not be loaded: %s", defaultApparmorProfile, err)
-		}
+		return clobberDefaultAppArmorProfile()
 	}
-
 	return nil
 }

--- a/daemon/apparmor_default_unsupported.go
+++ b/daemon/apparmor_default_unsupported.go
@@ -2,6 +2,10 @@
 
 package daemon // import "github.com/docker/docker/daemon"
 
+func clobberDefaultAppArmorProfile() error {
+	return nil
+}
+
 func ensureDefaultAppArmorProfile() error {
 	return nil
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -667,7 +667,9 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 		logrus.Warnf("Failed to configure golang's threads limit: %v", err)
 	}
 
-	if err := ensureDefaultAppArmorProfile(); err != nil {
+	// Make sure we clobber any pre-existing docker-default profile to ensure
+	// that upgrades to the profile actually work smoothly.
+	if err := clobberDefaultAppArmorProfile(); err != nil {
 		logrus.Errorf(err.Error())
 	}
 


### PR DESCRIPTION
In the process of making docker-default reloading far less expensive,
567ef8e7858c ("daemon: switch to 'ensure' workflow for AppArmor
profiles") mistakenly made the initial profile load at dockerd start-up
lazy. As a result, if you have a running Docker daemon and upgrade it to
a new one with an updated AppArmor profile the new profile will not take
effect (because the old one is still loaded). The fix for this is quite
trivial, and just requires us to clobber the profile on start-up.

Fixes: 567ef8e7858c ("daemon: switch to 'ensure' workflow for AppArmor profiles")
Signed-off-by: Aleksa Sarai <asarai@suse.de>