### PR TITLE
LCOW: lazycontext: Use correct lstat, fix archive check

### DIFF
--- a/builder/remotecontext/lazycontext.go
+++ b/builder/remotecontext/lazycontext.go
@@ -45,7 +45,7 @@ func (c *lazySource) Hash(path string) (string, error) {
 		return "", errors.WithStack(convertPathError(err, cleanPath))
 	}
 
-	fi, err := os.Lstat(fullPath)
+	fi, err := c.root.Lstat(fullPath)
 	if err != nil {
 		// Backwards compatibility: a missing file returns a path as hash.
 		// This is reached in the case of a broken symlink.

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -367,11 +367,7 @@ func FileInfoHeader(name string, fi os.FileInfo, link string) (*tar.Header, erro
 	hdr.AccessTime = time.Time{}
 	hdr.ChangeTime = time.Time{}
 	hdr.Mode = fillGo18FileTypeBits(int64(chmodTarEntry(os.FileMode(hdr.Mode))), fi)
-	name, err = canonicalTarName(name, fi.IsDir())
-	if err != nil {
-		return nil, fmt.Errorf("tar: cannot canonicalize path: %v", err)
-	}
-	hdr.Name = name
+	hdr.Name = canonicalTarName(name, fi.IsDir())
 	if err := setHeaderForSpecialDevice(hdr, name, fi.Sys()); err != nil {
 		return nil, err
 	}
@@ -447,17 +443,14 @@ func newTarAppender(idMapping *idtools.IDMappings, writer io.Writer, chownOpts *
 
 // canonicalTarName provides a platform-independent and consistent posix-style
 //path for files and directories to be archived regardless of the platform.
-func canonicalTarName(name string, isDir bool) (string, error) {
-	name, err := CanonicalTarNameForPath(name)
-	if err != nil {
-		return "", err
-	}
+func canonicalTarName(name string, isDir bool) string {
+	name = CanonicalTarNameForPath(name)
 
 	// suffix with '/' for directories
 	if isDir && !strings.HasSuffix(name, "/") {
 		name += "/"
 	}
-	return name, nil
+	return name
 }
 
 // addTarFile adds to the tar archive a file from `path` as `name`

--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -32,8 +32,8 @@ func getWalkRoot(srcPath string, include string) string {
 // CanonicalTarNameForPath returns platform-specific filepath
 // to canonical posix-style path for tar archival. p is relative
 // path.
-func CanonicalTarNameForPath(p string) (string, error) {
-	return p, nil // already unix-style
+func CanonicalTarNameForPath(p string) string {
+	return p // already unix-style
 }
 
 // chmodTarEntry is used to adjust the file permissions used in tar header based

--- a/pkg/archive/archive_unix_test.go
+++ b/pkg/archive/archive_unix_test.go
@@ -26,10 +26,8 @@ func TestCanonicalTarNameForPath(t *testing.T) {
 		{"foo/dir/", "foo/dir/"},
 	}
 	for _, v := range cases {
-		if out, err := CanonicalTarNameForPath(v.in); err != nil {
-			t.Fatalf("cannot get canonical name for path: %s: %v", v.in, err)
-		} else if out != v.expected {
-			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, out)
+		if CanonicalTarNameForPath(v.in) != v.expected {
+			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, CanonicalTarNameForPath(v.in))
 		}
 	}
 }
@@ -46,10 +44,8 @@ func TestCanonicalTarName(t *testing.T) {
 		{"foo/bar", true, "foo/bar/"},
 	}
 	for _, v := range cases {
-		if out, err := canonicalTarName(v.in, v.isDir); err != nil {
-			t.Fatalf("cannot get canonical name for path: %s: %v", v.in, err)
-		} else if out != v.expected {
-			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, out)
+		if canonicalTarName(v.in, v.isDir) != v.expected {
+			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, canonicalTarName(v.in, v.isDir))
 		}
 	}
 }

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -2,10 +2,8 @@ package archive // import "github.com/docker/docker/pkg/archive"
 
 import (
 	"archive/tar"
-	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/longpath"
@@ -26,16 +24,8 @@ func getWalkRoot(srcPath string, include string) string {
 // CanonicalTarNameForPath returns platform-specific filepath
 // to canonical posix-style path for tar archival. p is relative
 // path.
-func CanonicalTarNameForPath(p string) (string, error) {
-	// windows: convert windows style relative path with backslashes
-	// into forward slashes. Since windows does not allow '/' or '\'
-	// in file names, it is mostly safe to replace however we must
-	// check just in case
-	if strings.Contains(p, "/") {
-		return "", fmt.Errorf("Windows path contains forward slash: %s", p)
-	}
-	return strings.Replace(p, string(os.PathSeparator), "/", -1), nil
-
+func CanonicalTarNameForPath(p string) string {
+	return filepath.ToSlash(p)
 }
 
 // chmodTarEntry is used to adjust the file permissions used in tar header based

--- a/pkg/archive/archive_windows_test.go
+++ b/pkg/archive/archive_windows_test.go
@@ -36,19 +36,14 @@ func TestCopyFileWithInvalidDest(t *testing.T) {
 func TestCanonicalTarNameForPath(t *testing.T) {
 	cases := []struct {
 		in, expected string
-		shouldFail   bool
 	}{
-		{"foo", "foo", false},
-		{"foo/bar", "___", true}, // unix-styled windows path must fail
-		{`foo\bar`, "foo/bar", false},
+		{"foo", "foo"},
+		{"foo/bar", "foo/bar"},
+		{`foo\bar`, "foo/bar"},
 	}
 	for _, v := range cases {
-		if out, err := CanonicalTarNameForPath(v.in); err != nil && !v.shouldFail {
-			t.Fatalf("cannot get canonical name for path: %s: %v", v.in, err)
-		} else if v.shouldFail && err == nil {
-			t.Fatalf("canonical path call should have failed with error. in=%s out=%s", v.in, out)
-		} else if !v.shouldFail && out != v.expected {
-			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, out)
+		if CanonicalTarNameForPath(v.in) != v.expected {
+			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, CanonicalTarNameForPath(v.in))
 		}
 	}
 }
@@ -65,10 +60,8 @@ func TestCanonicalTarName(t *testing.T) {
 		{`foo\bar`, true, "foo/bar/"},
 	}
 	for _, v := range cases {
-		if out, err := canonicalTarName(v.in, v.isDir); err != nil {
-			t.Fatalf("cannot get canonical name for path: %s: %v", v.in, err)
-		} else if out != v.expected {
-			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, out)
+		if canonicalTarName(v.in, v.isDir) != v.expected {
+			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, canonicalTarName(v.in, v.isDir))
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes #36793. Replacement for https://github.com/moby/moby/pull/37316

First - thanks @yusuf-gunaydin for debugging and coming up with a fix. Yours was so very close :)

Here's the output using the same files as described in https://github.com/moby/moby/issues/36793 with the updated fix:

```
PS E:\docker\build\36793> docker build --platform=linux -t testcachelinux 1
Sending build context to Docker daemon  2.048kB
Step 1/2 : FROM alpine
latest: Pulling from library/alpine
ff3a5c916c92: Pull complete
Digest: sha256:e1871801d30885a610511c867de0d6baca7ed4e6a2573d506bbec7fd3b03873f
Status: Downloaded newer image for alpine:latest
 ---> 3fd9065eaf02
Step 2/2 : RUN echo 1 > /test.txt
 ---> Running in 260838f99d98
Removing intermediate container 260838f99d98
 ---> e09ed90c53b3
Successfully built e09ed90c53b3
Successfully tagged testcachelinux:latest
```


```
PS E:\docker\build\36793> docker build --platform=linux -t testusecachelinux 3
Sending build context to Docker daemon  2.048kB
Step 1/3 : FROM alpine
 ---> 3fd9065eaf02
Step 2/3 : COPY --from=testcachelinux /test.txt /t.txt
 ---> a68b85ea733c
Step 3/3 : RUN cat /t.txt
 ---> Running in 49834d78be86
1
Removing intermediate container 49834d78be86
 ---> be1ac7fc3569
Successfully built be1ac7fc3569
Successfully tagged testusecachelinux:latest
```

```
PS E:\docker\build\36793> docker build --platform=linux -t testcachelinux 2
Sending build context to Docker daemon  2.048kB
Step 1/2 : FROM alpine
 ---> 3fd9065eaf02
Step 2/2 : RUN echo 2 > /test.txt
 ---> Running in 004c92e53c89
Removing intermediate container 004c92e53c89
 ---> c6ed3a426e67
Successfully built c6ed3a426e67
Successfully tagged testcachelinux:latest
```

```
PS E:\docker\build\36793> docker build --platform=linux -t testusecachelinux 3
Sending build context to Docker daemon  2.048kB
Step 1/3 : FROM alpine
 ---> 3fd9065eaf02
Step 2/3 : COPY --from=testcachelinux /test.txt /t.txt
 ---> a02aa0e250d1
Step 3/3 : RUN cat /t.txt
 ---> Running in fa75974f48e8
2
Removing intermediate container fa75974f48e8
 ---> bce0113cecf4
Successfully built bce0113cecf4
Successfully tagged testusecachelinux:latest
PS E:\docker\build\36793>
```

Note on the last build step:

- Step 2/3 correctly does NOT use the cache.
- Step 3/3 correctly outputs 2 and tags `bce0113cef4` correctly.


During debugging this (happened to be building the Microsoft/opengcs repo as that exercises LCOW code quite well in lieu of format CI yet), as mentioned in the issue, I noticed that as the `Lstat` call is now being made, and can succeed, there's an incorrect assertion in generating the hash (`prepareHash` function) when it calls into the archiver to Canonicalise the path, which causes build failures to occur on a step such as `COPY --from=runc /usr/bin/runc /usr/bin`. Have removed the incorrect assertion, updated the function to no longer return an `error`, and updated unit tests/call-sites not to handle the error there.





