### PR TITLE
Update containerd to v1.1.1-rc.2

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=cbef57047e900aeb2bafe7a634919bec13f4a2a5 # v1.1.1-rc.1
+CONTAINERD_COMMIT=e5fb877b9f6c14b15f48643735a8c9764a7319d3 # v1.1.1-rc.2
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
Full diff: https://github.com/containerd/containerd/compare/v1.1.1-rc.1...v1.1.1-rc.2


- Fixes crash on startup when the cri plugin fails to load in containerd https://github.com/containerd/containerd/pull/2413
- Fixes ARM arm platform matching https://github.com/containerd/containerd/pull/2416
