### PR TITLE
Fix checkpoint's exiting semantics.

### DIFF
--- a/libcontainerd/client_daemon.go
+++ b/libcontainerd/client_daemon.go
@@ -561,7 +561,11 @@ func (c *client) CreateCheckpoint(ctx context.Context, containerID, checkpointDi
 		return err
 	}
 
-	img, err := p.(containerd.Task).Checkpoint(ctx)
+	opts := []containerd.CheckpointTaskOpts{}
+	if exit {
+		opts = append(opts, containerd.WithExit)
+	}
+	img, err := p.(containerd.Task).Checkpoint(ctx, opts...)
 	if err != nil {
 		return wrapError(err)
 	}


### PR DESCRIPTION
Previously, dockerd would always ask containerd to pass --leave-running
to runc/runsc, ignoring the exit boolean value. Hence, even `docker
checkpoint create --leave-running=false ...` would not stop the
container.

Signed-off-by: Brielle Broder <bbroder@google.com>