### PR TITLE
Update Microsoft/go-winio to 0.4.8

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,7 +1,7 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm d6e3b3328b783f23731bc4d058875b0371ff8109
 github.com/Microsoft/hcsshim v0.6.11
-github.com/Microsoft/go-winio v0.4.7
+github.com/Microsoft/go-winio v0.4.8
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git
 github.com/golang/gddo 9b12a26f3fbd7397dee4e20939ddca719d840d2a


### PR DESCRIPTION
Fixes named pipe support for hyper-v isolated containers

fixes https://github.com/moby/moby/issues/36562 ("Cannot locate Windows named pipe "docker_engine" after passing -v \\.\pipe\docker_engine:\\.\pipe\docker_engine")

Full diff: https://github.com/Microsoft/go-winio/compare/v0.4.7...v0.4.8; changes included:

- https://github.com/Microsoft/go-winio/pull/77 Call Fatalf to use the format specifier
- https://github.com/Microsoft/go-winio/pull/78 / https://github.com/Microsoft/go-winio/pull/82 Support pipe message read mode



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
- Fix error "Cannot locate Windows named pipe" when bind-mounting mounting Windows named pipes in a container
```


**- A picture of a cute animal (not mandatory but encouraged)**
