### PR TITLE
Pass endpoint to the CloudWatch Logs logging driver

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -67,13 +67,11 @@ func TestNewAWSLogsClientUserAgentHandler(t *testing.T) {
 	}
 
 	client, err := newAWSLogsClient(info)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
+
 	realClient, ok := client.(*cloudwatchlogs.CloudWatchLogs)
-	if !ok {
-		t.Fatal("Could not cast client to cloudwatchlogs.CloudWatchLogs")
-	}
+	assert.Check(t, ok, "Could not cast client to cloudwatchlogs.CloudWatchLogs")
+
 	buildHandlerList := realClient.Handlers.Build
 	request := &request.Request{
 		HTTPRequest: &http.Request{
@@ -90,6 +88,26 @@ func TestNewAWSLogsClientUserAgentHandler(t *testing.T) {
 	}
 }
 
+func TestNewAWSLogsClientAWSLogsEndpoint(t *testing.T) {
+	endpoint := "mock-endpoint"
+	info := logger.Info{
+		Config: map[string]string{
+			regionKey:   "us-east-1",
+			endpointKey: endpoint,
+		},
+	}
+
+	client, err := newAWSLogsClient(info)
+	assert.NilError(t, err)
+
+	realClient, ok := client.(*cloudwatchlogs.CloudWatchLogs)
+	assert.Check(t, ok, "Could not cast client to cloudwatchlogs.CloudWatchLogs")
+
+	endpointWithScheme := realClient.Endpoint
+	expectedEndpointWithScheme := "https://" + endpoint
+	assert.Equal(t, endpointWithScheme, expectedEndpointWithScheme, "Wrong endpoint")
+}
+
 func TestNewAWSLogsClientRegionDetect(t *testing.T) {
 	info := logger.Info{
 		Config: map[string]string{},
@@ -104,9 +122,7 @@ func TestNewAWSLogsClientRegionDetect(t *testing.T) {
 	}
 
 	_, err := newAWSLogsClient(info)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }
 
 func TestCreateSuccess(t *testing.T) {
@@ -196,9 +212,7 @@ func TestCreateAlreadyExists(t *testing.T) {
 
 	err := stream.create()
 
-	if err != nil {
-		t.Fatal("Expected nil err")
-	}
+	assert.NilError(t, err)
 }
 
 func TestLogClosed(t *testing.T) {
@@ -242,9 +256,8 @@ func TestLogBlocking(t *testing.T) {
 	}
 	select {
 	case err := <-errorCh:
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
+
 	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for read")
 	}
@@ -258,9 +271,7 @@ func TestLogNonBlockingBufferEmpty(t *testing.T) {
 		logNonBlocking: true,
 	}
 	err := stream.Log(&logger.Message{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }
 
 func TestLogNonBlockingBufferFull(t *testing.T) {
@@ -1246,9 +1257,7 @@ func TestCreateTagSuccess(t *testing.T) {
 
 	err := stream.create()
 
-	if err != nil {
-		t.Errorf("Received unexpected err: %v\n", err)
-	}
+	assert.NilError(t, err)
 	argument := <-mockClient.createLogStreamArgument
 
 	if *argument.LogStreamName != "test-container/container-abcdefghijklmnopqrstuvwxyz01234567890" {
@@ -1340,7 +1349,6 @@ func TestNewAWSLogsClientCredentialEnvironmentVariable(t *testing.T) {
 
 	assert.Check(t, is.Equal(expectedAccessKeyID, creds.AccessKeyID))
 	assert.Check(t, is.Equal(expectedSecretAccessKey, creds.SecretAccessKey))
-
 }
 
 func TestNewAWSLogsClientCredentialSharedFile(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: haikuoliu <haikuo@amazon.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Pass endpoint to the CloudWatch Logs logging driver. This enables the driver to be used in AWS regions where the endpoint is not guessed correctly (e.g., regions like `cn-northwest-1` where the correct endpoint is "logs.cn-northwest-1.amazonaws.com.cn" instead of "logs.cn-northwest-1.amazonaws.com") *without* updating the vendored revision of the AWS SDK.

**- How I did it**
Extract the endpoint from logger info with a predefined endpoint key, pass it to the session which is used to configure CloudWatch client.

Also add the endpoint key in ValidateLogOpt.

**- How to verify it**
When we call `newAWSLogsClient` in `cloudwatchlogs.go` and provide endpoint in logger info, we should be able to get the a client whose endpoint filed is set to the endpoint we passed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
None

**- A picture of a cute animal (not mandatory but encouraged)**

╱▏┈┈┈┈┈┈▕╲▕╲┈┈┈
▏▏┈┈┈┈┈┈▕▏▔▔╲┈┈
▏╲┈┈┈┈┈┈╱┈▔┈▔╲┈
╲▏▔▔▔▔▔▔╯╯╰┳━━▀
┈▏╯╯╯╯╯╯╯╯╱┃┈┈┈
┈┃┏┳┳━━━┫┣┳┃┈┈┈
┈┃┃┃┃┈┈┈┃┃┃┃┈┈┈
┈┗┛┗┛┈┈┈┗┛┗┛┈┈┈


