### PR TITLE
Update documents of `dispatchAdd`

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -89,7 +89,7 @@ func dispatchLabel(d dispatchRequest, c *instructions.LabelCommand) error {
 
 // ADD foo /path
 //
-// Add the file 'foo' to '/path'. Tarball and Remote URL (git, http) handling
+// Add the file 'foo' to '/path'. Tarball and Remote URL (http, https) handling
 // exist here. If you do not wish to have this automatic handling, use COPY.
 //
 func dispatchAdd(d dispatchRequest, c *instructions.AddCommand) error {


### PR DESCRIPTION
`ADD` does not support git.

Ref: https://github.com/moby/moby/issues/14704#issuecomment-298134333

Signed-off-by: Yuichiro Kaneko <spiketeika@gmail.com>
