### PR TITLE
Update documents of `Detect`

### DIFF
--- a/builder/remotecontext/detect.go
+++ b/builder/remotecontext/detect.go
@@ -22,8 +22,7 @@ import (
 const ClientSessionRemote = "client-session"
 
 // Detect returns a context and dockerfile from remote location or local
-// archive. progressReader is only used if remoteURL is actually a URL
-// (not empty, and not a Git endpoint).
+// archive.
 func Detect(config backend.BuildConfig) (remote builder.Source, dockerfile *parser.Result, err error) {
 	remoteURL := config.Options.RemoteContext
 	dockerfilePath := config.Options.Dockerfile


### PR DESCRIPTION
By 0296797f0f39477d675128c93c1646b3186937ee, `progressReader`
and `remoteURL` were removed from arguments. So developers who
use `Detect` not need to care about when `ProgressReaderFunc`
is used.

Signed-off-by: Yuichiro Kaneko <spiketeika@gmail.com>
