### PR TITLE
api: Change Platform field back to string (temporary workaround)

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
@@ -24,8 +23,7 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
-	"github.com/docker/docker/pkg/system"
-	"github.com/docker/go-units"
+	units "github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -72,17 +70,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	options.Target = r.FormValue("target")
 	options.RemoteContext = r.FormValue("remote")
 	if versions.GreaterThanOrEqualTo(version, "1.32") {
-		apiPlatform := r.FormValue("platform")
-		if apiPlatform != "" {
-			sp, err := platforms.Parse(apiPlatform)
-			if err != nil {
-				return nil, err
-			}
-			if err := system.ValidatePlatform(sp); err != nil {
-				return nil, err
-			}
-			options.Platform = &sp
-		}
+		options.Platform = r.FormValue("platform")
 	}
 
 	if r.Form.Get("shmsize") != "" {

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -7,8 +7,7 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/go-units"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	units "github.com/docker/go-units"
 )
 
 // CheckpointCreateOptions holds parameters to create a checkpoint from a container
@@ -181,7 +180,7 @@ type ImageBuildOptions struct {
 	ExtraHosts  []string // List of extra hosts
 	Target      string
 	SessionID   string
-	Platform    *specs.Platform
+	Platform    string
 	// Version specifies the version of the unerlying builder to use
 	Version BuilderVersion
 	// BuildID is an optional identifier that can be passed together with the

--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -87,7 +87,7 @@ func copierFromDispatchRequest(req dispatchRequest, download sourceDownloader, i
 		pathCache:   req.builder.pathCache,
 		download:    download,
 		imageSource: imageSource,
-		platform:    req.builder.options.Platform,
+		platform:    req.builder.platform,
 	}
 }
 

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -146,7 +146,7 @@ func (d *dispatchRequest) getImageMount(imageRefOrID string) (*imageMount, error
 		imageRefOrID = stage.Image
 		localOnly = true
 	}
-	return d.builder.imageSources.Get(imageRefOrID, localOnly, d.builder.options.Platform)
+	return d.builder.imageSources.Get(imageRefOrID, localOnly, d.builder.platform)
 }
 
 // FROM [--platform=platform] imagename[:tag | @digest] [AS build-stage-name]
@@ -238,7 +238,7 @@ func (d *dispatchRequest) getImageOrStage(name string, platform *specs.Platform)
 	}
 
 	if platform == nil {
-		platform = d.builder.options.Platform
+		platform = d.builder.platform
 	}
 
 	// Windows cannot support a container with no base image unless it is LCOW.

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -6,7 +6,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
@@ -23,8 +22,7 @@ import (
 
 func newBuilderWithMockBackend() *Builder {
 	mockBackend := &MockBackend{}
-	defaultPlatform := platforms.DefaultSpec()
-	opts := &types.ImageBuildOptions{Platform: &defaultPlatform}
+	opts := &types.ImageBuildOptions{}
 	ctx := context.Background()
 	b := &Builder{
 		options:       opts,
@@ -116,7 +114,7 @@ func TestFromScratch(t *testing.T) {
 	err := initializeStage(sb, cmd)
 
 	if runtime.GOOS == "windows" && !system.LCOWSupported() {
-		assert.Check(t, is.Error(err, "Windows does not support FROM scratch"))
+		assert.Check(t, is.Error(err, "Linux containers are not supported on this system"))
 		return
 	}
 


### PR DESCRIPTION
This partially reverts https://github.com/moby/moby/pull/37350

Although specs.Platform is desirable in the API, there is more work
to be done on helper functions, namely containerd's platforms.Parse
that assumes the default platform of the Go runtime.

That prevents a client to use the recommended Parse function to
retrieve a specs.Platform object.

With this change, no parsing is expected from the client.

Signed-off-by: Tibor Vass <tibor@docker.com>