### PR TITLE
add vim-plug setting

### DIFF
--- a/contrib/syntax/vim/README.md
+++ b/contrib/syntax/vim/README.md
@@ -11,6 +11,10 @@ With [Vundle](https://github.com/gmarik/Vundle.vim)
   
     Plugin 'docker/docker' , {'rtp': '/contrib/syntax/vim/'}
 
+With [vim-plug](https://github.com/junegunn/vim-plug)
+  
+    Plug 'docker/docker' , {'rtp': '/contrib/syntax/vim/'}   
+
 Features
 --------
 


### PR DESCRIPTION
this should work ( tried on my machine)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
add instructions for vim-plug users

**- How I did it**
look into [vim-plug's documentation](https://github.com/junegunn/vim-plug)
and  'rtp' is a supported option

**- How to verify it**
this can make the syntax highlighting works on my machine( which use vim-plug )

**- Description for the changelog**
add instructions for vim-plug users

