### PR TITLE
Added "--no-cache" to apk call to reduce alpine base image by 10-12% …

### DIFF
--- a/contrib/mkimage-alpine.sh
+++ b/contrib/mkimage-alpine.sh
@@ -29,7 +29,7 @@ getapk() {
 }
 
 mkbase() {
-	$TMP/sbin/apk.static --repository $MAINREPO --update-cache --allow-untrusted \
+	$TMP/sbin/apk.static --repository $MAINREPO --no-cache --allow-untrusted \
 		--root $ROOTFS --initdb add alpine-base
 }
 


### PR DESCRIPTION
…(avoid useless indexes in /var/cache/apk)

Signed-off-by: Mickaël Remars <github@remars.com>