### PR TITLE
Return error if basename is expanded to blank

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -274,11 +274,17 @@ func (d *dispatchRequest) getImageOrStage(name string, platform *specs.Platform)
 	}
 	return imageMount.Image(), nil
 }
-func (d *dispatchRequest) getFromImage(shlex *shell.Lex, name string, platform *specs.Platform) (builder.Image, error) {
-	name, err := d.getExpandedString(shlex, name)
+func (d *dispatchRequest) getFromImage(shlex *shell.Lex, basename string, platform *specs.Platform) (builder.Image, error) {
+	name, err := d.getExpandedString(shlex, basename)
 	if err != nil {
 		return nil, err
 	}
+	// Empty string is interpreted to FROM scratch by images.GetImageAndReleasableLayer,
+	// so validate expanded result is not empty.
+	if name == "" {
+		return nil, errors.Errorf("base name (%s) should not be blank", basename)
+	}
+
 	return d.getImageOrStage(name, platform)
 }
 

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -157,6 +157,22 @@ func TestFromWithArg(t *testing.T) {
 	assert.Check(t, is.Len(sb.state.buildArgs.GetAllMeta(), 1))
 }
 
+func TestFromWithArgButBuildArgsNotGiven(t *testing.T) {
+	b := newBuilderWithMockBackend()
+	args := NewBuildArgs(make(map[string]*string))
+
+	metaArg := instructions.ArgCommand{}
+	cmd := &instructions.Stage{
+		BaseName: "${THETAG}",
+	}
+	err := processMetaArg(metaArg, shell.NewLex('\\'), args)
+
+	sb := newDispatchRequest(b, '\\', nil, args, newStagesBuildResults())
+	assert.NilError(t, err)
+	err = initializeStage(sb, cmd)
+	assert.Error(t, err, "base name (${THETAG}) should not be blank")
+}
+
 func TestFromWithUndefinedArg(t *testing.T) {
 	tag, expected := "sometag", "expectedthisid"
 


### PR DESCRIPTION
Fix: https://github.com/moby/moby/issues/37325

Signed-off-by: Yuichiro Kaneko <spiketeika@gmail.com>
