### PR TITLE
mkimage-alpine.sh: Removed the "-i -t" arguments from the smoke test calling printf (the…

### DIFF
--- a/contrib/mkimage-alpine.sh
+++ b/contrib/mkimage-alpine.sh
@@ -43,7 +43,7 @@ pack() {
 	id=$(tar --numeric-owner -C $ROOTFS -c . | docker import - alpine:$REL)
 
 	docker tag $id alpine:latest
-	docker run -i -t --rm alpine printf 'alpine:%s with id=%s created!\n' $REL $id
+	docker run --rm alpine printf 'alpine:%s with id=%s created!\n' $REL $id
 }
 
 save() {


### PR DESCRIPTION
…se flags seem not really needed, and break jenkins builds with error "the input device is not a TTY")
Signed-off-by: Mickaël Remars github@remars.com