### PR TITLE
Allow mount type npipe on service/stack

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -238,11 +238,13 @@ definitions:
           - `bind` Mounts a file or directory from the host into the container. Must exist prior to creating the container.
           - `volume` Creates a volume with the given name and options (or uses a pre-existing volume with the same name and options). These are **not** removed when the container is removed.
           - `tmpfs` Create a tmpfs with the given options. The mount source cannot be specified for tmpfs.
+          - `npipe` Mounts a named pipe from the host into the container. Must exist prior to creating the container.
         type: "string"
         enum:
           - "bind"
           - "volume"
           - "tmpfs"
+          - "npipe"
       ReadOnly:
         description: "Whether the mount should be read-only."
         type: "boolean"

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -285,6 +285,8 @@ func convertMount(m api.Mount) enginemount.Mount {
 		mount.Type = enginemount.TypeVolume
 	case api.MountTypeTmpfs:
 		mount.Type = enginemount.TypeTmpfs
+	case api.MountTypeNamedPipe:
+		mount.Type = enginemount.TypeNamedPipe
 	}
 
 	if m.BindOptions != nil {

--- a/daemon/cluster/executor/container/validate.go
+++ b/daemon/cluster/executor/container/validate.go
@@ -11,7 +11,8 @@ import (
 func validateMounts(mounts []api.Mount) error {
 	for _, mount := range mounts {
 		// Target must always be absolute
-		if !filepath.IsAbs(mount.Target) {
+		// except if target is Windows named pipe
+		if !filepath.IsAbs(mount.Target) && mount.Type != api.MountTypeNamedPipe {
 			return fmt.Errorf("invalid mount target, must be an absolute path: %s", mount.Target)
 		}
 
@@ -31,6 +32,10 @@ func validateMounts(mounts []api.Mount) error {
 		case api.MountTypeTmpfs:
 			if mount.Source != "" {
 				return errors.New("invalid tmpfs source, source must be empty")
+			}
+		case api.MountTypeNamedPipe:
+			if mount.Source == "" {
+				return errors.New("invalid npipe source, source must not be empty")
 			}
 		default:
 			return fmt.Errorf("invalid mount type: %s", mount.Type)

--- a/daemon/cluster/executor/container/validate_windows_test.go
+++ b/daemon/cluster/executor/container/validate_windows_test.go
@@ -1,8 +1,24 @@
 // +build windows
 
 package container // import "github.com/docker/docker/daemon/cluster/executor/container"
+import (
+	"strings"
+	"testing"
+
+	"github.com/docker/swarmkit/api"
+)
 
 const (
 	testAbsPath        = `c:\foo`
 	testAbsNonExistent = `c:\some-non-existing-host-path\`
 )
+
+func TestControllerValidateMountNamedPipe(t *testing.T) {
+	if _, err := newTestControllerWithMount(api.Mount{
+		Type:   api.MountTypeNamedPipe,
+		Source: "",
+		Target: `\\.\pipe\foo`,
+	}); err == nil || !strings.Contains(err.Error(), "invalid npipe source, source must not be empty") {
+		t.Fatalf("expected error, got: %v", err)
+	}
+}


### PR DESCRIPTION
**- What I did**
Added support named pipes support to cluster executor.

**- How I did it**
Added npipe type same way than it is added to engine on https://github.com/moby/moby/pull/33852

**- How to verify it**
1. Create service to Windows using Windows mounting format:
```
docker service create --name windows --mount 'type=npipe,source=\\.\pipe\docker_engine,destination=\\.\pipe\docker_engine' microsoft/nanoserver:1803
```

2. Deploy test stack using type=npipe:
```
version: "3.3"
services:
  web:
    image: ollijanatuinen/portainer:windows1803-amd64-npipe-3
    ports:
      - "9000:9000"
    networks:
      - test
    volumes:
      - type: npipe
        source: \\.\pipe\docker_engine
        target: \\.\pipe\docker_engine

networks:
  test:
    driver: overlay
```

**- Description for the changelog**
- Added npipe protocol to SwarmKit side on: https://github.com/docker/swarmkit/pull/2691
- Added MountTypeNamedPipe cluster executor on 1b03440 (that makes docker service create command working)
- Added type=npipe support to stack files on https://github.com/docker/cli/pull/1195

Fixes: #34795