### PR TITLE
Fix faulty error type checking in removeNetwork()

### DIFF
--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,6 +27,7 @@ import (
 	"github.com/docker/swarmkit/log"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 )
@@ -172,7 +172,7 @@ func (c *containerAdapter) createNetworks(ctx context.Context) error {
 func (c *containerAdapter) removeNetworks(ctx context.Context) error {
 	for name, v := range c.container.networksAttachments {
 		if err := c.backend.DeleteManagedNetwork(v.Network.ID); err != nil {
-			switch err.(type) {
+			switch errors.Cause(err).(type) {
 			case *libnetwork.ActiveEndpointsError:
 				continue
 			case libnetwork.ErrNoSuchNetwork:


### PR DESCRIPTION
**- What I did**

Commit c0bc14e8 (https://github.com/moby/moby/pull/37156) wrapped the return value of nw.Delete() from within daemon.deleteNetworks() with some extra verbage.  However, this breaks the code in containerAdaptor.removeNetworks() which ignores certain specific libnetwork error return codes.  Said codes actually don't represent errors, but just regular conditions to be expected in normal operation. The removeNetworks() call checked for these errors by type assertions which is why errors.Wrap(err...) breaks it.

This has a cascading effect, because controller.Remove() invokes containerAdaptor.removeNetworks() and if the latter returns an error, then Remove() fails to remove the container itself.  This is not necessarily catastrophic since the container reaper apparently will purge the container later, but it is clearly not the behavior we want.

**- How I did it**

Updated the removeNetwork() error type switch to use `errors.Cause(err).(type)` instead of just `err.(type)`.

**- How to verify it**

One should no longer see errors in the logs of the form:
```
Jul 06 18:34:48 AAA dockerd[20635]: time="2018-07-06T18:34:48.909384904Z" level=error msg="network NETNAME remove failed: error while removing network: network NETNAME id BLAH has active endpoints" module=node/agent node.id=BLAH
```
**- Description for the changelog**

Remove faulty error wrapping for nw.Delete()