### PR TITLE
Fix typo on test.md

### DIFF
--- a/docs/contributing/test.md
+++ b/docs/contributing/test.md
@@ -153,7 +153,7 @@ $ TESTDIRS='opts' make test-unit
 
 You can also use the `TESTFLAGS` environment variable to run a single test. The
 flag's value is passed as arguments to the `go test` command. For example, from
-your local host you can run the `TestBuild` test with this command:
+your local host you can run the `TestValidateIPAddress` test with this command:
 
 ```bash
 $ TESTFLAGS='-test.run ^TestValidateIPAddress$' make test-unit


### PR DESCRIPTION
It said `TESTFLAGS='-test.run ^TestValidateIPAddress$' make test-unit`
runs `TestBuild` test, but actually runs `TestValidateIPAddress` test.

Signed-off-by: Donghwa Kim <shanytt@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
 Modify test.md file

 It is very simple commit, so I don't fill following form.

**- How I did it**

**- How to verify it**
 
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
