### PR TITLE
Pass log-level to containerd

### DIFF
--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -48,6 +48,8 @@ func (cli *DaemonCli) getPlatformRemoteOptions() ([]libcontainerd.RemoteOption, 
 	}
 	if cli.Config.Debug {
 		opts = append(opts, libcontainerd.WithLogLevel("debug"))
+	} else if cli.Config.LogLevel != "" {
+		opts = append(opts, libcontainerd.WithLogLevel(cli.Config.LogLevel))
 	}
 	if cli.Config.ContainerdAddr != "" {
 		opts = append(opts, libcontainerd.WithRemoteAddr(cli.Config.ContainerdAddr))

--- a/libcontainerd/remote_daemon.go
+++ b/libcontainerd/remote_daemon.go
@@ -221,6 +221,11 @@ func (r *remote) startContainerd() error {
 	}
 
 	args := []string{"--config", configFile}
+
+	if r.Debug.Level != "" {
+		args = append(args, "--log-level", r.Debug.Level)
+	}
+
 	cmd := exec.Command(binaryName, args...)
 	// redirect containerd logs to docker logs
 	cmd.Stdout = os.Stdout

--- a/libcontainerd/remote_daemon_linux.go
+++ b/libcontainerd/remote_daemon_linux.go
@@ -28,9 +28,6 @@ func (r *remote) setDefaults() {
 	if r.Debug.Address == "" {
 		r.Debug.Address = filepath.Join(r.stateDir, debugSockFile)
 	}
-	if r.Debug.Level == "" {
-		r.Debug.Level = "info"
-	}
 	if r.OOMScore == 0 {
 		r.OOMScore = -999
 	}

--- a/libcontainerd/remote_daemon_windows.go
+++ b/libcontainerd/remote_daemon_windows.go
@@ -18,9 +18,6 @@ func (r *remote) setDefaults() {
 	if r.Debug.Address == "" {
 		r.Debug.Address = debugPipeName
 	}
-	if r.Debug.Level == "" {
-		r.Debug.Level = "info"
-	}
 	if r.snapshotter == "" {
 		r.snapshotter = "naive" // TODO(mlaventure): switch to "windows" once implemented
 	}


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/37343

dockerd allows the `--log-level` to be specified, but this log-level was not forwarded to the containerd process.

This patch sets containerd's log-level to the same as dockerd if a custom level is provided.

Now that `--log-level` is also passed to containerd, the default "info" is removed, so that containerd's default (or the level configured in containerd.toml) is still used if no log-level is set.

### Before this change:

containerd would always be started without a log-level set (only the level that's configured in `containerd.toml`);

```
root      1014  2.5  2.1 496484 43468 pts/0    Sl+  12:23   0:00 dockerd
root      1023  1.2  1.1 681768 23832 ?        Ssl  12:23   0:00  \_ docker-containerd --config /var/run/docker/containerd/containerd.toml
```

### After this change:

when running `dockerd` without options (same as current);

```
root      1014  2.5  2.1 496484 43468 pts/0    Sl+  12:23   0:00 dockerd
root      1023  1.2  1.1 681768 23832 ?        Ssl  12:23   0:00  \_ docker-containerd --config /var/run/docker/containerd/containerd.toml
```

when running `dockerd --debug`:

```
root       600  0.8  2.1 512876 43180 pts/0    Sl+  12:20   0:00 dockerd --debug
root       608  0.6  1.1 624428 23672 ?        Ssl  12:20   0:00  \_ docker-containerd --config /var/run/docker/containerd/containerd.toml --log-level debug
```

when running `dockerd --log-level=panic`

```
root       747  0.6  2.1 496548 43996 pts/0    Sl+  12:21   0:00 dockerd --log-level=panic
root       755  0.7  1.1 550696 24100 ?        Ssl  12:21   0:00  \_ docker-containerd --config /var/run/docker/containerd/containerd.toml --log-level panic
```

combining `--debug` and `--log-level` (`--debug` takes precedence):

```
root       880  2.7  2.1 634692 43336 pts/0    Sl+  12:23   0:00 dockerd --debug --log-level=panic
root       888  1.0  1.1 616232 23652 ?        Ssl  12:23   0:00  \_ docker-containerd --config /var/run/docker/containerd/containerd.toml --log-level debug
```

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
+ Configure containerd log-level to be the same as dockerd
```

**- A picture of a cute animal (not mandatory but encouraged)**
