### PR TITLE
Bump libnetwork to d00ceed44cc447c77f25cdf5d59e83163bdcb4c9

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -37,7 +37,7 @@ github.com/mitchellh/hashstructure 2bca23e0e452137f789efbc8610126fd8b94f73b
 #get libnetwork packages
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
-github.com/docker/libnetwork 3ac297bc7fd0afec9051bbb47024c9bc1d75bf5b
+github.com/docker/libnetwork d00ceed44cc447c77f25cdf5d59e83163bdcb4c9
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/osl/namespace_linux.go
+++ b/vendor/github.com/docker/libnetwork/osl/namespace_linux.go
@@ -616,6 +616,15 @@ func reexecSetIPv6() {
 		value = byte('0')
 	}
 
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			logrus.Warnf("file does not exist: %s : %v Has IPv6 been disabled in this node's kernel?", path, err)
+			os.Exit(0)
+		}
+		logrus.Errorf("failed to stat %s : %v", path, err)
+		os.Exit(5)
+	}
+
 	if err = ioutil.WriteFile(path, []byte{value, '\n'}, 0644); err != nil {
 		logrus.Errorf("failed to %s IPv6 forwarding for container's interface %s: %v", action, os.Args[2], err)
 		os.Exit(4)

--- a/vendor/github.com/docker/libnetwork/vendor.conf
+++ b/vendor/github.com/docker/libnetwork/vendor.conf
@@ -6,12 +6,9 @@ github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/boltdb/bolt fff57c100f4dea1905678da7e90d92429dff2904
 github.com/codegangsta/cli a65b733b303f0055f8d324d805f393cd3e7a7904
-github.com/containerd/console cb7008ab3d8359b78c5f464cb7cf160107ad5925
 github.com/containerd/continuity d3c23511c1bf5851696cba83143d9cbcd666869b
 github.com/coreos/etcd v3.2.1
 github.com/coreos/go-semver v0.2.0
-github.com/coreos/go-systemd v17
-github.com/coreos/pkg fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
 github.com/deckarep/golang-set ef32fa3046d9f249d399f98ebaf9be944430fd1d
 
 github.com/docker/docker 162ba6016def672690ee4a1f3978368853a1e149
@@ -22,7 +19,6 @@ github.com/docker/libkv 1d8431073ae03cdaedb198a89722f3aab6d418ef
 
 github.com/godbus/dbus v4.0.0
 github.com/gogo/protobuf v1.0.0
-github.com/golang/protobuf v1.1.0
 github.com/gorilla/context v1.1
 github.com/gorilla/mux v1.1
 github.com/hashicorp/consul v0.5.2
@@ -34,16 +30,12 @@ github.com/hashicorp/go-sockaddr 6d291a969b86c4b633730bfc6b8b9d64c3aafed9
 github.com/hashicorp/serf 598c54895cc5a7b1a24a398d635e8c0ea0959870
 github.com/mattn/go-shellwords v1.0.3
 github.com/miekg/dns v1.0.7
-github.com/mrunalp/fileutils ed869b029674c0e9ce4c0dfa781405c2d9946d08
 github.com/opencontainers/go-digest v1.0.0-rc1
 github.com/opencontainers/image-spec v1.0.1
 github.com/opencontainers/runc 69663f0bd4b60df09991c08812a60108003fa340
 github.com/opencontainers/runtime-spec v1.0.1
-github.com/opencontainers/selinux b29023b86e4a69d1b46b7e7b4e2b6fda03f0b9cd
 github.com/samuel/go-zookeeper d0e0d8e11f318e000a8cc434616d69e329edc374
-github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
 github.com/sirupsen/logrus v1.0.3
-github.com/stretchr/testify v1.2.2
 github.com/syndtr/gocapability 33e07d32887e1e06b7c025f27ce52f62c7990bc0
 github.com/ugorji/go f1f1a805ed361a0e078bb537e4ea78cd37dcf065
 github.com/vishvananda/netlink b2de5d10e38ecce8607e6b438b6d174f389a004e
@@ -55,12 +47,5 @@ golang.org/x/sync fd80eb99c8f653c847d294a001bdf2a3a6f768f5
 github.com/pkg/errors 839d9e913e063e28dfd0e6c7b7512793e0a48be9
 github.com/ishidawataru/sctp 07191f837fedd2f13d1ec7b5f885f0f3ec54b1cb
 
-github.com/davecgh/go-spew v1.1.0
-github.com/pmezard/go-difflib v1.0.0
-github.com/cyphar/filepath-securejoin v0.2.1
-github.com/hashicorp/errwrap 7554cd9344cec97297fa6649b055a8c98c2a1e55
-github.com/hashicorp/go-immutable-radix 7f3cd4390caab3250a57f30efdb2a65dd7649ecf
-github.com/hashicorp/golang-lru 0fb14efe8c47ae851c0034ed7a448854d3d34cf3
-github.com/hashicorp/go-cleanhttp d5fe4b57a186c716b0e00b8c301cbd9b4182694d
-github.com/hashicorp/go-rootcerts 6bb64b370b90e7ef1fa532be9e591a81c3493e00
-github.com/mitchellh/go-homedir 3864e76763d94a6df2f9960b16a20a33da9f9a66
+gotest.tools v2.1.0
+github.com/google/go-cmp v0.2.0


### PR DESCRIPTION
The absence of the file /proc/sys/net/ipv6/conf/all/disable_ipv6
doesn't appear to affect functionality, at least at this time.

full diff: https://github.com/docker/libnetwork/compare/3ac297bc7fd0afec9051bbb47024c9bc1d75bf5b...d00ceed44cc447c77f25cdf5d59e83163bdcb4c9

brings in:

- https://github.com/docker/libnetwork/pull/2122 Changed loglevel from error to warning


ping @quadespresso @ddebroy @fcrisciani PTAL 