### PR TITLE
Bump containerd daemon to v1.1.1

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=e5fb877b9f6c14b15f48643735a8c9764a7319d3 # v1.1.1-rc.2
+CONTAINERD_COMMIT=d64c661f1d51c48782c9cec8fda7604785f93587 # v1.1.1
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
full diff: https://github.com/containerd/containerd/compare/e5fb877b9f6c14b15f48643735a8c9764a7319d3...d64c661f1d51c48782c9cec8fda7604785f93587