### PR TITLE
builder: fix duplicate calls to mountable

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -208,7 +208,6 @@ func (br *buildRouter) postBuild(ctx context.Context, w http.ResponseWriter, r *
 			output.Write(notVerboseBuffer.Bytes())
 		}
 
-		logrus.Debugf("isflushed %v", output.Flushed())
 		// Do not write the error in the http output if it's still empty.
 		// This prevents from writing a 200(OK) when there is an internal error.
 		if !output.Flushed() {


### PR DESCRIPTION
The adapter connecting containerd snapshots used by buildkit to moby storagedrivers/layerstore assumed that instance of `Mountable` interface will only be called once. Actually, there is an optimization that allows the readonly mounts to be reused if the reference has not been released. With Moby mounts that are not stateless, this caused the first release to unmount the source and second use of the mount to fail.

In Dockerfiles, an example to reproduce the issue would have been:

```
from busybox as bb
run ls -l
```

followed by

```
from busybox as bb
run ls -l
from scratch
env foo bar
copy --from=bb /etc/passwd aa
```

@tiborvass 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
