### PR TITLE
[WIP] api: add a GPU resource type

### DIFF
--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -304,12 +304,28 @@ type LogConfig struct {
 	Config map[string]string
 }
 
+// GPUSet represents all the GPU resources of the container for a given hardware vendor.
+type GPUSet struct {
+	Vendor  string // e.g. 'nvidia', 'intel', 'amd'
+	GPUs    []GPU
+	Options map[string]string
+}
+
+// GPU represents a single GPU resource for the container.
+type GPU struct {
+	ID      string
+	Options map[string]string
+}
+
 // Resources contains container's resources (cgroups config, ulimits...)
 type Resources struct {
 	// Applicable to all platforms
 	CPUShares int64 `json:"CpuShares"` // CPU shares (relative weight vs. other containers)
 	Memory    int64 // Memory limit (in bytes)
 	NanoCPUs  int64 `json:"NanoCpus"` // CPU quota in units of 10<sup>-9</sup> CPUs.
+
+	// Applicable to all platforms, but not guaranteed to be supported.
+	GPUs []GPUSet `json:",omitempty"` // List of GPUs to map inside the container.
 
 	// Applicable to UNIX platforms
 	CgroupParent         string // Parent cgroup.


### PR DESCRIPTION
CLI discussion: https://github.com/docker/cli/issues/1200

First draft of what the API might look like. I don't believe we need something more complex than that.

Discussion points
* Since in the CLI discussion we agreed to namespace GPUs per vendor, naturally the entrypoint for the API is a map to access all the GPUs/options for a single vendor. We could have a single slice of GPUs and a single option map, but it feel awkward if a vendor needs to skip devices/options that it doesn't own.
* Naming is hard, so `Resources` (plural) is all the GPUs from all vendor. `Resource` is all the GPUs from a **single** vendor. Thoughts?
* Let's not support per-GPU options for now, but we can add that to the `GPU` struct later without breaking existing code.
* In the CLI discussion we discussed a shortcut to select all GPUs: `--gpus nvidia`. However at this point it's not possible to get the actual list of GPU ids. We have two options: a) if `gpu.Resource.GPUs` is empty, then select all GPUs OR b) if `gpu.Resource.GPUs[0].ID == "*"` then select all GPUs.

