### PR TITLE
Bump gometalinter to v2.0.6

### DIFF
--- a/hack/dockerfile/install/gometalinter.installer
+++ b/hack/dockerfile/install/gometalinter.installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-GOMETALINTER_COMMIT=bfcc1d6942136fd86eb6f1a6fb328de8398fbd80
+GOMETALINTER_COMMIT=v2.0.6
 
 install_gometalinter() {
 	echo "Installing gometalinter version $GOMETALINTER_COMMIT"


### PR DESCRIPTION
Taken from https://github.com/moby/moby/pull/37358

Full diff: https://github.com/alecthomas/gometalinter/compare/bfcc1d6942136fd86eb6f1a6fb328de8398fbd80...v2.0.6

ping @kolyshkin @vdemeester 