### PR TITLE
Various formatting fixes / compilation issues caught by Go 1.11

### DIFF
--- a/daemon/cluster/controllers/plugin/controller.go
+++ b/daemon/cluster/controllers/plugin/controller.go
@@ -180,7 +180,7 @@ func (p *Controller) Wait(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case e := <-events:
-			p.logger.Debugf("got event %#T", e)
+			p.logger.Debugf("got event %T", e)
 
 			switch e.(type) {
 			case plugin.EventEnable:

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -538,7 +538,7 @@ func (daemon *Daemon) DaemonLeavesCluster() {
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):
-			logrus.Warnf("timeout while waiting for ingress network removal")
+			logrus.Warn("timeout while waiting for ingress network removal")
 		}
 	} else {
 		logrus.Warnf("failed to initiate ingress network removal: %v", err)

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -646,13 +646,13 @@ func (daemon *Daemon) initRuntimes(runtimes map[string]types.Runtime) (err error
 	os.RemoveAll(runtimeDir + "-old")
 	tmpDir, err := ioutils.TempDir(daemon.configStore.Root, "gen-runtimes")
 	if err != nil {
-		return errors.Wrapf(err, "failed to get temp dir to generate runtime scripts")
+		return errors.Wrap(err, "failed to get temp dir to generate runtime scripts")
 	}
 	defer func() {
 		if err != nil {
 			if err1 := os.RemoveAll(tmpDir); err1 != nil {
 				logrus.WithError(err1).WithField("dir", tmpDir).
-					Warnf("failed to remove tmp dir")
+					Warn("failed to remove tmp dir")
 			}
 			return
 		}
@@ -661,12 +661,12 @@ func (daemon *Daemon) initRuntimes(runtimes map[string]types.Runtime) (err error
 			return
 		}
 		if err = os.Rename(tmpDir, runtimeDir); err != nil {
-			err = errors.Wrapf(err, "failed to setup runtimes dir, new containers may not start")
+			err = errors.Wrap(err, "failed to setup runtimes dir, new containers may not start")
 			return
 		}
 		if err = os.RemoveAll(runtimeDir + "-old"); err != nil {
 			logrus.WithError(err).WithField("dir", tmpDir).
-				Warnf("failed to remove old runtimes dir")
+				Warn("failed to remove old runtimes dir")
 		}
 	}()
 
@@ -1126,7 +1126,7 @@ func setupRemappedRoot(config *config.Config) (*idtools.IDMappings, error) {
 
 		mappings, err := idtools.NewIDMappings(username, groupname)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Can't create ID mappings: %v")
+			return nil, errors.Wrap(err, "Can't create ID mappings")
 		}
 		return mappings, nil
 	}

--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -373,7 +373,7 @@ func atomicRemove(source string) error {
 	case os.IsExist(err):
 		// Got error saying the target dir already exists, maybe the source doesn't exist due to a previous (failed) remove
 		if _, e := os.Stat(source); !os.IsNotExist(e) {
-			return errors.Wrapf(err, "target rename dir '%s' exists but should not, this needs to be manually cleaned up")
+			return errors.Wrapf(err, "target rename dir %q exists but should not, this needs to be manually cleaned up", target)
 		}
 	default:
 		return errors.Wrapf(err, "error preparing atomic delete")

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -108,7 +108,7 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, sig int)
 	if unpause {
 		// above kill signal will be sent once resume is finished
 		if err := daemon.containerd.Resume(context.Background(), container.ID); err != nil {
-			logrus.Warn("Cannot unpause container %s: %s", container.ID, err)
+			logrus.Warnf("Cannot unpause container %s: %s", container.ID, err)
 		}
 	}
 

--- a/daemon/logger/loggerutils/logfile.go
+++ b/daemon/logger/loggerutils/logfile.go
@@ -332,7 +332,7 @@ func (w *LogFile) ReadLogs(config logger.ReadConfig, watcher *logger.LogWatcher)
 			if strings.HasSuffix(fileName, tmpLogfileSuffix) {
 				err := w.filesRefCounter.Dereference(fileName)
 				if err != nil {
-					logrus.Errorf("Failed to dereference the log file %q: %v", fileName, err)
+					logrus.Errorf("Failed to dereference log file %q: %v", fileName, err)
 				}
 			}
 		}
@@ -364,7 +364,7 @@ func (w *LogFile) openRotatedFiles(config logger.ReadConfig) (files []*os.File, 
 			if strings.HasSuffix(f.Name(), tmpLogfileSuffix) {
 				err := os.Remove(f.Name())
 				if err != nil && !os.IsNotExist(err) {
-					logrus.Warningf("Failed to remove the logfile %q: %v", f.Name, err)
+					logrus.Warnf("Failed to remove logfile: %v", err)
 				}
 			}
 		}
@@ -436,7 +436,7 @@ func decompressfile(fileName, destFileName string, since time.Time) (*os.File, e
 		rs.Close()
 		rErr := os.Remove(rs.Name())
 		if rErr != nil && !os.IsNotExist(rErr) {
-			logrus.Errorf("Failed to remove the logfile %q: %v", rs.Name(), rErr)
+			logrus.Errorf("Failed to remove logfile: %v", rErr)
 		}
 		return nil, errors.Wrap(err, "error while copying decompressed log stream to file")
 	}
@@ -561,7 +561,7 @@ func followLogs(f *os.File, logWatcher *logger.LogWatcher, notifyRotate chan int
 			}
 			return errRetry
 		case err := <-fileWatcher.Errors():
-			logrus.Debug("logger got error watching file: %v", err)
+			logrus.Debugf("logger got error watching file: %v", err)
 			// Something happened, let's try and stay alive and create a new watcher
 			if retries <= 5 {
 				fileWatcher.Close()

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -138,7 +138,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerd.EventType, ei libc
 				"container": c.ID,
 				"exec-id":   ei.ProcessID,
 				"exec-pid":  ei.Pid,
-			}).Warnf("Ignoring Exit Event, no such exec command found")
+			}).Warn("Ignoring Exit Event, no such exec command found")
 		}
 	case libcontainerd.EventStart:
 		c.Lock()

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -186,7 +186,7 @@ func (daemon *Daemon) reloadClusterDiscovery(conf *config.Config, attributes map
 	}
 	netOptions, err := daemon.networkOptions(daemon.configStore, daemon.PluginStore, nil)
 	if err != nil {
-		logrus.WithError(err).Warnf("failed to get options with network controller")
+		logrus.WithError(err).Warn("failed to get options with network controller")
 		return nil
 	}
 	err = daemon.netController.ReloadConfiguration(netOptions...)

--- a/daemon/unpause.go
+++ b/daemon/unpause.go
@@ -37,7 +37,7 @@ func (daemon *Daemon) containerUnpause(container *container.Container) error {
 	daemon.LogContainerEvent(container, "unpause")
 
 	if err := container.CheckpointTo(daemon.containersReplica); err != nil {
-		logrus.WithError(err).Warnf("could not save container to disk")
+		logrus.WithError(err).Warn("could not save container to disk")
 	}
 
 	return nil


### PR DESCRIPTION
Taken from https://github.com/moby/moby/pull/37358

First commit didn't apply, but change could be ignored


```
git apply --reject --whitespace=fix bla/0006-daemon-.go-fix-some-Wrap-f-Warn-f-errors.patch

Checking patch daemon/daemon.go...
error: while searching for:

	for operatingSystem, gd := range d.graphDrivers {
		layerStores[operatingSystem], err = layer.NewStoreFromOptions(layer.StoreOptions{
			Root:                      config.Root,
			MetadataStorePathTemplate: filepath.Join(config.Root, "image", "%s", "layerdb"),
			GraphDriver:               gd,
			GraphDriverOptions:        config.GraphOptions,

error: patch failed: daemon/daemon.go:742
Checking patch daemon/daemon_unix.go...
Checking patch daemon/kill.go...
Checking patch daemon/monitor.go...
Checking patch daemon/reload.go...
Checking patch daemon/unpause.go...
Applying patch daemon/daemon.go with 1 reject...
Hunk #1 applied cleanly.
Rejected hunk #2.
Applied patch daemon/daemon_unix.go cleanly.
Applied patch daemon/kill.go cleanly.
Applied patch daemon/monitor.go cleanly.
Applied patch daemon/reload.go cleanly.
Applied patch daemon/unpause.go cleanly.
```


ping @kolyshkin @vdemeester 