### PR TITLE
Add tasks to swarm-scoped watched events

### DIFF
--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -205,6 +205,10 @@ func (n *nodeRunner) watchClusterEvents(ctx context.Context, conn *grpc.ClientCo
 				Action: swarmapi.WatchActionKindCreate | swarmapi.WatchActionKindUpdate | swarmapi.WatchActionKindRemove,
 			},
 			{
+				Kind:   "task",
+				Action: swarmapi.WatchActionKindCreate | swarmapi.WatchActionKindUpdate | swarmapi.WatchActionKindRemove,
+			},
+			{
 				Kind:   "network",
 				Action: swarmapi.WatchActionKindCreate | swarmapi.WatchActionKindUpdate | swarmapi.WatchActionKindRemove,
 			},


### PR DESCRIPTION
This will allows consumer of events to detect more of the services
lifecycle — like when a task fail and is re-scheduled, being able to
act based on that.

```
2018-07-12T11:34:37.686750665+02:00 service update iya6c6pkpf5b0xv3si39r0xfx (name=objective_kare, updatestate.new=updating)
2018-07-12T11:34:37.689033595+02:00 task create nj8nwmcb9aifbzh3rt62xiosa (service=iya6c6pkpf5b0xv3si39r0xfx)
2018-07-12T11:34:37.689094828+02:00 task update iw9guozw00eoupd99vceozpr6 (message=started, service=iya6c6pkpf5b0xv3si39r0xfx, state=RUNNING)
2018-07-12T11:34:37.691960970+02:00 task update nj8nwmcb9aifbzh3rt62xiosa (message=pending task scheduling, service=iya6c6pkpf5b0xv3si39r0xfx, state=PENDING)
2018-07-12T11:34:37.749417436+02:00 task update nj8nwmcb9aifbzh3rt62xiosa (message=scheduler assigned task to node, service=iya6c6pkpf5b0xv3si39r0xfx, state=ASSIGNED)
2018-07-12T11:34:37.918525136+02:00 task update nj8nwmcb9aifbzh3rt62xiosa (message=preparing, service=iya6c6pkpf5b0xv3si39r0xfx, state=PREPARING)
2018-07-12T11:34:37.918709152+02:00 task update iw9guozw00eoupd99vceozpr6 (message=started, service=iya6c6pkpf5b0xv3si39r0xfx, state=RUNNING)
2018-07-12T11:34:39.231532408+02:00 task update iw9guozw00eoupd99vceozpr6 (message=shutdown, service=iya6c6pkpf5b0xv3si39r0xfx, state=SHUTDOWN)
2018-07-12T11:34:39.234018965+02:00 task update nj8nwmcb9aifbzh3rt62xiosa (message=prepared, service=iya6c6pkpf5b0xv3si39r0xfx, state=READY)
2018-07-12T11:34:39.640967202+02:00 task update nj8nwmcb9aifbzh3rt62xiosa (message=started, service=iya6c6pkpf5b0xv3si39r0xfx, state=RUNNING)
2018-07-12T11:34:44.643637056+02:00 service update iya6c6pkpf5b0xv3si39r0xfx (name=objective_kare, updatestate.new=completed, updatestate.old=updating)
2018-07-12T11:35:18.625725714+02:00 service remove iya6c6pkpf5b0xv3si39r0xfx (name=objective_kare)
2018-07-12T11:35:18.625085872+02:00 task update iw9guozw00eoupd99vceozpr6 (message=shutdown, service=iya6c6pkpf5b0xv3si39r0xfx, state=SHUTDOWN)
2018-07-12T11:35:18.625142609+02:00 task update lzslfuqcnox84sje3v0mck9sy (err=task: non-zero exit (137), message=started, service=iya6c6pkpf5b0xv3si39r0xfx, state=FAILED)
2018-07-12T11:35:18.625171428+02:00 task update nj8nwmcb9aifbzh3rt62xiosa (message=started, service=iya6c6pkpf5b0xv3si39r0xfx, state=RUNNING)
2018-07-12T11:35:18.790555003+02:00 task update lzslfuqcnox84sje3v0mck9sy (err=task: non-zero exit (137), message=started, service=iya6c6pkpf5b0xv3si39r0xfx, state=FAILED)
2018-07-12T11:35:18.790697969+02:00 task update iw9guozw00eoupd99vceozpr6 (message=shutdown, service=iya6c6pkpf5b0xv3si39r0xfx, state=SHUTDOWN)
2018-07-12T11:35:18.790766029+02:00 task update nj8nwmcb9aifbzh3rt62xiosa (message=started, service=iya6c6pkpf5b0xv3si39r0xfx, state=RUNNING)
2018-07-12T11:35:20.101838255+02:00 task update nj8nwmcb9aifbzh3rt62xiosa (message=shutdown, service=iya6c6pkpf5b0xv3si39r0xfx, state=SHUTDOWN)
2018-07-12T11:35:20.357825226+02:00 task remove nj8nwmcb9aifbzh3rt62xiosa (service=iya6c6pkpf5b0xv3si39r0xfx)
```

I guess it was not there either to hide this *implementation detail* or because it's generating a bit more events.

cc @dperny

Closes #37403

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
