### PR TITLE
Refactor daemon.info to reduce cyclomatic complexity

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -69,7 +69,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 	}
 
 	// Retrieve platform specific info
-	daemon.FillPlatformInfo(v, sysInfo)
+	daemon.fillPlatformInfo(v, sysInfo)
 	daemon.fillDriverInfo(v)
 	daemon.fillPluginsInfo(v)
 	daemon.fillSecurityOptions(v, sysInfo)

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -14,8 +14,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// FillPlatformInfo fills the platform related info.
-func (daemon *Daemon) FillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) {
+// fillPlatformInfo fills the platform related info.
+func (daemon *Daemon) fillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) {
 	v.MemoryLimit = sysInfo.MemoryLimit
 	v.SwapLimit = sysInfo.SwapLimit
 	v.KernelMemory = sysInfo.KernelMemory

--- a/daemon/info_windows.go
+++ b/daemon/info_windows.go
@@ -5,6 +5,6 @@ import (
 	"github.com/docker/docker/pkg/sysinfo"
 )
 
-// FillPlatformInfo fills the platform related info.
-func (daemon *Daemon) FillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) {
+// fillPlatformInfo fills the platform related info.
+func (daemon *Daemon) fillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) {
 }


### PR DESCRIPTION
Today's "Lunch time special!"

Before this change;

    gocyclo daemon/info.go
    17 daemon (*Daemon).SystemInfo daemon/info.go:27:1
    2 daemon (*Daemon).SystemVersion daemon/info.go:150:1
    1 daemon (*Daemon).showPluginsInfo daemon/info.go:195:1

After this change;

    gocyclo daemon/info.go
    8 daemon (*Daemon).fillSecurityOptions daemon/info.go:150:1
    5 daemon operatingSystem daemon/info.go:201:1
    3 daemon (*Daemon).fillDriverInfo daemon/info.go:121:1
    2 daemon hostName daemon/info.go:172:1
    2 daemon memInfo daemon/info.go:192:1
    2 daemon kernelVersion daemon/info.go:182:1
    1 daemon (*Daemon).SystemVersion daemon/info.go:81:1
    1 daemon (*Daemon).SystemInfo daemon/info.go:27:1
    1 daemon (*Daemon).fillPluginsInfo daemon/info.go:138:1

