### PR TITLE
Fix golint warning on generated "volume" types

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5922,7 +5922,7 @@ paths:
           headers:
             X-Docker-Container-Path-Stat:
               type: "string"
-              description: "TODO"
+              description: "A base64 - encoded JSON object with some filesystem header information about the path"
         400:
           description: "Bad parameter"
           schema:
@@ -7589,6 +7589,7 @@ paths:
           schema:
             type: "object"
             title: "VolumeListResponse"
+            description: "Volume list response"
             required: [Volumes, Warnings]
             properties:
               Volumes:
@@ -7665,6 +7666,8 @@ paths:
           description: "Volume configuration"
           schema:
             type: "object"
+            description: "Volume configuration"
+            title: "VolumeConfig"
             properties:
               Name:
                 description: "The new volume's name. If not specified, Docker generates a name."

--- a/api/types/volume/volume_create.go
+++ b/api/types/volume/volume_create.go
@@ -7,7 +7,7 @@ package volume
 // See hack/generate-swagger-api.sh
 // ----------------------------------------------------------------------------
 
-// VolumeCreateBody
+// VolumeCreateBody Volume configuration
 // swagger:model VolumeCreateBody
 type VolumeCreateBody struct {
 

--- a/api/types/volume/volume_list.go
+++ b/api/types/volume/volume_list.go
@@ -9,7 +9,7 @@ package volume
 
 import "github.com/docker/docker/api/types"
 
-// VolumeListOKBody
+// VolumeListOKBody Volume list response
 // swagger:model VolumeListOKBody
 type VolumeListOKBody struct {
 


### PR DESCRIPTION
Should fix

```
api/types/volume/volume_create.go
Line 10: warning: comment on exported type VolumeCreateBody should be of the form "VolumeCreateBody ..." (with optional leading article) (golint)


api/types/volume/volume_list.go
Line 12: warning: comment on exported type VolumeListOKBody should be of the form "VolumeListOKBody ..." (with optional leading article) (golint)
```