### PR TITLE
Bump containerd daemon to v1.1.2

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=d64c661f1d51c48782c9cec8fda7604785f93587 # v1.1.1
+CONTAINERD_COMMIT=468a545b9edcd5932818eb9de8e72413e616e86e # v1.1.2
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
Updates cri version to 1.0.4, to add `max-container-log-line-size`

full diff: https://github.com/containerd/containerd/compare/v1.1.1...v1.1.2
