### PR TITLE
Fix build from Git on old git versions versions

### DIFF
--- a/api/types/versions/compare.go
+++ b/api/types/versions/compare.go
@@ -9,8 +9,10 @@ import (
 // returns -1 if v1 < v2, 1 if v1 > v2, 0 otherwise.
 func compare(v1, v2 string) int {
 	var (
-		currTab  = strings.Split(v1, ".")
-		otherTab = strings.Split(v2, ".")
+		currTab         = strings.Split(trimSuffix(v1), ".")
+		otherTab        = strings.Split(trimSuffix(v2), ".")
+		curPreRelease   = trimSuffix(v1) != v1
+		otherPreRelease = trimSuffix(v2) != v2
 	)
 
 	max := len(currTab)
@@ -33,30 +35,52 @@ func compare(v1, v2 string) int {
 			return -1
 		}
 	}
-	return 0
+
+	// TODO this does not yet compare pre-release version (e.g. -beta.0 vs -beta.1, or -alpha.0 vs -beta.1)
+	if curPreRelease == otherPreRelease {
+		return 0
+	}
+	if curPreRelease {
+		return -1
+	}
+	return 1
 }
 
-// LessThan checks if a version is less than another
+func trimSuffix(input string) string {
+	parts := strings.SplitN(input, "-", 2)
+	if len(parts) == 2 {
+		return parts[0]
+	}
+	return input
+}
+
+// LessThan checks if a version is less than another. It is designed to compare
+// API versions, but has limited support for SemVer(ish) versions
 func LessThan(v, other string) bool {
 	return compare(v, other) == -1
 }
 
-// LessThanOrEqualTo checks if a version is less than or equal to another
+// LessThanOrEqualTo checks if a version is less than or equal to another. It is
+// designed to compare API versions, but has limited support for SemVer(ish) versions
 func LessThanOrEqualTo(v, other string) bool {
 	return compare(v, other) <= 0
 }
 
-// GreaterThan checks if a version is greater than another
+// GreaterThan checks if a version is greater than another. It is designed to
+// compare API versions, but has limited support for SemVer(ish) versions
 func GreaterThan(v, other string) bool {
 	return compare(v, other) == 1
 }
 
-// GreaterThanOrEqualTo checks if a version is greater than or equal to another
+// GreaterThanOrEqualTo checks if a version is greater than or equal to another.
+// It is designed to compare API versions, but has limited support for SemVer(ish)
+// versions
 func GreaterThanOrEqualTo(v, other string) bool {
 	return compare(v, other) >= 0
 }
 
-// Equal checks if a version is equal to another
+// Equal checks if a version is equal to another. It is designed to compare API
+// versions, but has limited support for SemVer(ish) versions
 func Equal(v, other string) bool {
 	return compare(v, other) == 0
 }

--- a/api/types/versions/compare_test.go
+++ b/api/types/versions/compare_test.go
@@ -23,4 +23,12 @@ func TestCompareVersion(t *testing.T) {
 	assertVersion(t, "1.1", "1.1.1", -1)
 	assertVersion(t, "1.1.1", "1.1.2", -1)
 	assertVersion(t, "1.1.2", "1.2", -1)
+	assertVersion(t, "1.1.2", "1.1.2-rc.1", 1)
+	assertVersion(t, "1.1.2", "1.1.3-rc.1", -1)
+	assertVersion(t, "1.1.2-rc.1", "1.1.2", -1)
+	assertVersion(t, "1.1.2-rc.1", "1.1.2-rc.1", 0)
+
+	// TODO these cases are to show limitations in the current implementation
+	assertVersion(t, "1.1.2-rc.1", "1.1.2-rc.0", 0)
+	assertVersion(t, "1.1.2-alpha.1", "1.1.2-beta.2", 0)
 }


### PR DESCRIPTION
The --depth option was added in Git 1.8.4-rc0; https://github.com/git/git/commit/275cd184d52b5b81cb89e4ec33e540fb2ae61c1f. If an older version of Git is installed on the host, omit the `--depth` option.

addresses https://github.com/moby/moby/issues/36965 (for server-side builds from git)