### PR TITLE
Allow socket activation

### DIFF
--- a/contrib/init/systemd/docker.socket
+++ b/contrib/init/systemd/docker.socket
@@ -1,6 +1,5 @@
 [Unit]
 Description=Docker Socket for the API
-PartOf=docker.service
 
 [Socket]
 ListenStream=/var/run/docker.sock


### PR DESCRIPTION
PartOf deactivates the socket whenever the service get deactivated. The socket unit however should be active nevertheless.

fixes #37468

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

