### PR TITLE
Do not return "<unknown>" in /info response

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -60,6 +60,14 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 		old.SecurityOptions = nameOnlySecurityOptions
 		return httputils.WriteJSON(w, http.StatusOK, old)
 	}
+	if versions.LessThan(httputils.VersionFromContext(ctx), "1.39") {
+		if info.KernelVersion == "" {
+			info.KernelVersion = "<unknown>"
+		}
+		if info.OperatingSystem == "" {
+			info.OperatingSystem = "<unknown>"
+		}
+	}
 	return httputils.WriteJSON(w, http.StatusOK, info)
 }
 

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -179,7 +179,7 @@ func hostName() string {
 }
 
 func kernelVersion() string {
-	kernelVersion := "<unknown>"
+	var kernelVersion string
 	if kv, err := kernel.GetKernelVersion(); err != nil {
 		logrus.Warnf("Could not get kernel version: %v", err)
 	} else {
@@ -198,7 +198,7 @@ func memInfo() *system.MemInfo {
 }
 
 func operatingSystem() string {
-	operatingSystem := "<unknown>"
+	var operatingSystem string
 	if s, err := operatingsystem.GetOperatingSystem(); err != nil {
 		logrus.Warnf("Could not get operating system name: %v", err)
 	} else {

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,13 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## V1.39 API changes
+
+[Docker Engine API v1.39](https://docs.docker.com/engine/api/v1.39/) documentation
+
+* `GET /info` now returns an empty string, instead of `<unknown>` for `KernelVersion`
+  and `OperatingSystem` if the daemon was unable to obtain this information.
+
 ## V1.38 API changes
 
 [Docker Engine API v1.38](https://docs.docker.com/engine/api/v1.38/) documentation


### PR DESCRIPTION
The `<unknown>` string is presentation, and should be created by the CLI (if desirable); follow-up to https://github.com/moby/moby/pull/37451