### PR TITLE
Support file mounts on Windows 1803 and above

### DIFF
--- a/volume/mounts/lcow_parser.go
+++ b/volume/mounts/lcow_parser.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package mounts // import "github.com/docker/docker/volume/mounts"
 
 import (

--- a/volume/mounts/linux_parser.go
+++ b/volume/mounts/linux_parser.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package mounts // import "github.com/docker/docker/volume/mounts"
 
 import (
@@ -107,12 +109,6 @@ func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSour
 		return &errMountConfig{mnt, errors.New("mount type unknown")}
 	}
 	return nil
-}
-
-// read-write modes
-var rwModes = map[string]bool{
-	"rw": true,
-	"ro": true,
 }
 
 // label modes

--- a/volume/mounts/validate_test.go
+++ b/volume/mounts/validate_test.go
@@ -48,6 +48,7 @@ func TestValidateMount(t *testing.T) {
 		{mount.Mount{Type: mount.TypeBind, Source: testDir, Target: "/foo"}, nil},
 		{mount.Mount{Type: "invalid", Target: "/foo"}, errors.New("mount type unknown")},
 	}
+
 	parser := NewParser(runtime.GOOS)
 	for i, x := range cases {
 		err := parser.ValidateMountConfig(&x.input)
@@ -58,8 +59,9 @@ func TestValidateMount(t *testing.T) {
 			t.Errorf("expected %q, got %q, case: %d", x.expected, err, i)
 		}
 	}
+
 	if runtime.GOOS == "windows" {
-		parser = &lcowParser{}
+		parser = NewParser(OSLinux)
 		for i, x := range lcowCases {
 			err := parser.ValidateMountConfig(&x.input)
 			if err == nil && x.expected == nil {

--- a/volume/mounts/volume_unix.go
+++ b/volume/mounts/volume_unix.go
@@ -13,6 +13,7 @@ func (p *linuxParser) HasResource(m *MountPoint, absolutePath string) bool {
 	return err == nil && relPath != ".." && !strings.HasPrefix(relPath, fmt.Sprintf("..%c", filepath.Separator))
 }
 
-func (p *windowsParser) HasResource(m *MountPoint, absolutePath string) bool {
-	return false
+// NewParser creates a parser for a given container OS, depending on the current host OS (linux on a windows host will resolve to an lcowParser)
+func NewParser(containerOS string) Parser {
+	return &linuxParser{}
 }

--- a/volume/mounts/volume_windows.go
+++ b/volume/mounts/volume_windows.go
@@ -3,6 +3,12 @@ package mounts // import "github.com/docker/docker/volume/mounts"
 func (p *windowsParser) HasResource(m *MountPoint, absolutePath string) bool {
 	return false
 }
-func (p *linuxParser) HasResource(m *MountPoint, absolutePath string) bool {
-	return false
+
+// NewParser creates a parser for a given container OS, depending on the current host OS (linux on a windows host will resolve to an lcowParser)
+func NewParser(containerOS string) Parser {
+	switch containerOS {
+	case OSWindows:
+		return &windowsParser{}
+	}
+	return &lcowParser{}
 }


### PR DESCRIPTION
Windows 1803 introduces the bind filter driver, bindflt.sys, which introduces several mounting improvements over the previous directory symbolic link approach. These improvements include:

- No longer appear as symbolic links, improving compatibilty.
- Can be mounted on top of existing directories and files.
- Can be files, instead of only directories.

This change addresses the last point by allowing non-directory file mounts on Windows 1803 (build 17134) and greater. The first two improvements already work without this, or any other change.

This change also rearranges the code such that the Windows and LCOW mount parsers are only built for, and tested on Windows, and the Linux parser is only built for, and tested on Linux. This allows the Windows parser to call system.GetOSVersion, which only exists for Windows.

Signed-off-by: John Stephens <johnstep@docker.com>