### PR TITLE
Fix flaky TestExternalGraphDriver/pull test

### DIFF
--- a/integration/plugin/graphdriver/external_test.go
+++ b/integration/plugin/graphdriver/external_test.go
@@ -394,12 +394,12 @@ func testGraphDriverPull(c client.APIClient, d *daemon.Daemon) func(*testing.T) 
 		defer d.Stop(t)
 		ctx := context.Background()
 
-		r, err := c.ImagePull(ctx, "busybox:latest", types.ImagePullOptions{})
+		r, err := c.ImagePull(ctx, "busybox:latest@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0", types.ImagePullOptions{})
 		assert.NilError(t, err)
 		_, err = io.Copy(ioutil.Discard, r)
 		assert.NilError(t, err)
 
-		container.Run(t, ctx, c, container.WithImage("busybox:latest"))
+		container.Run(t, ctx, c, container.WithImage("busybox:latest@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0"))
 	}
 }
 


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/37150

This test occassionally fails on s390x and Power;

    03:16:04 --- FAIL: TestExternalGraphDriver/pull (1.08s)
    03:16:04 external_test.go:402: assertion failed: error is not nil: Error: No such image: busybox:latest

Most likely these failures are caused due to Docker Hub updating the busybox:latest image, but not all architectures yet being available.

Instead of using `:latest`, pull an image by digest, so that the test doesn't depend on Docker Hub having all architectures available for `:latest`.

I selected the same digest as is currently used as "frozen image" in the Dockerfile.

