### PR TITLE
migrate create secret integration tests from integration-cli to integration/secret

### DIFF
--- a/integration-cli/docker_cli_secret_create_test.go
+++ b/integration-cli/docker_cli_secret_create_test.go
@@ -7,71 +7,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/go-check/check"
 )
-
-// Test case for 28884
-func (s *DockerSwarmSuite) TestSecretCreateResolve(c *check.C) {
-	d := s.AddDaemon(c, true, true)
-
-	name := "test_secret"
-	id := d.CreateSecret(c, swarm.SecretSpec{
-		Annotations: swarm.Annotations{
-			Name: name,
-		},
-		Data: []byte("foo"),
-	})
-	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
-
-	fake := d.CreateSecret(c, swarm.SecretSpec{
-		Annotations: swarm.Annotations{
-			Name: id,
-		},
-		Data: []byte("fake foo"),
-	})
-	c.Assert(fake, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", fake))
-
-	out, err := d.Cmd("secret", "ls")
-	c.Assert(err, checker.IsNil)
-	c.Assert(out, checker.Contains, name)
-	c.Assert(out, checker.Contains, fake)
-
-	out, err = d.Cmd("secret", "rm", id)
-	c.Assert(err, checker.IsNil)
-	c.Assert(out, checker.Contains, id)
-
-	// Fake one will remain
-	out, err = d.Cmd("secret", "ls")
-	c.Assert(err, checker.IsNil)
-	c.Assert(out, checker.Not(checker.Contains), name)
-	c.Assert(out, checker.Contains, fake)
-
-	// Remove based on name prefix of the fake one
-	// (which is the same as the ID of foo one) should not work
-	// as search is only done based on:
-	// - Full ID
-	// - Full Name
-	// - Partial ID (prefix)
-	out, err = d.Cmd("secret", "rm", id[:5])
-	c.Assert(err, checker.Not(checker.IsNil))
-	c.Assert(out, checker.Not(checker.Contains), id)
-	out, err = d.Cmd("secret", "ls")
-	c.Assert(err, checker.IsNil)
-	c.Assert(out, checker.Not(checker.Contains), name)
-	c.Assert(out, checker.Contains, fake)
-
-	// Remove based on ID prefix of the fake one should succeed
-	out, err = d.Cmd("secret", "rm", fake[:5])
-	c.Assert(err, checker.IsNil)
-	c.Assert(out, checker.Contains, fake[:5])
-	out, err = d.Cmd("secret", "ls")
-	c.Assert(err, checker.IsNil)
-	c.Assert(out, checker.Not(checker.Contains), name)
-	c.Assert(out, checker.Not(checker.Contains), id)
-	c.Assert(out, checker.Not(checker.Contains), fake)
-}
 
 func (s *DockerSwarmSuite) TestSecretCreateWithFile(c *check.C) {
 	d := s.AddDaemon(c, true, true)


### PR DESCRIPTION
**- What I did**
Migrated create secret integration tests from `integration-cli` package to `integration/secret`

**- How I did it**
Refactored and moved integration tests from `integration-cli/docker_cli_secret_create_test.go` to `integration/secret` package.

**- How to verify it**

**- Description for the changelog**
Create secret integration tests migrated from integration-cli/docker_cli_secret_create_test.go to integration/secret.

**- A picture of a cute animal (not mandatory but encouraged)**

