### PR TITLE
-buildmode=pie is not supported on Linux on MIPS either

### DIFF
--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -50,10 +50,14 @@ if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARC
 	esac
 fi
 
-# -buildmode=pie is not supported on Windows.
-if [ "$(go env GOOS)" != "windows" ]; then
-	BUILDFLAGS+=( "-buildmode=pie" )
-fi
+# -buildmode=pie is not supported on Windows and Linux on mips.
+case "$(go env GOOS)/$(go env GOARCH)" in
+	windows/*|linux/mips*)
+		;;
+	*)
+		BUILDFLAGS+=( "-buildmode=pie" )
+		;;
+esac
 
 echo "Building: $DEST/$BINARY_FULLNAME"
 go build \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Ensured we don't try to build with -buildmode=pie on MIPS as it isn't supported right now.

**- How I did it**
Changed the check in hack/make/.binary to switch on GOOS and GOARCH and added mips and mipsle as targets where -buildmode=pie is unsupported.

**- How to verify it**
Try building targeting mips (it still doesn't build but it doesn't fail on -buildmode=pie not supported)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

