### PR TITLE
Stat_t on MIPS uses 32-bit fields for Dev and Rdev, so we need to cast these to uint64.

### DIFF
--- a/daemon/graphdriver/copy/copy.go
+++ b/daemon/graphdriver/copy/copy.go
@@ -154,7 +154,7 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
 
 		switch f.Mode() & os.ModeType {
 		case 0: // Regular file
-			id := fileID{dev: stat.Dev, ino: stat.Ino}
+			id := fileID{dev: uint64(stat.Dev), ino: stat.Ino}
 			if copyMode == Hardlink {
 				isHardlink = true
 				if err2 := os.Link(srcPath, dstPath); err2 != nil {

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1528,8 +1528,8 @@ func getDeviceMajorMinor(file *os.File) (uint64, uint64, error) {
 	}
 
 	dev := stat.Rdev
-	majorNum := major(dev)
-	minorNum := minor(dev)
+	majorNum := major(uint64(dev))
+	minorNum := minor(uint64(dev))
 
 	logrus.WithField("storage-driver", "devicemapper").Debugf("Major:Minor for device: %s is:%v:%v", file.Name(), majorNum, minorNum)
 	return majorNum, minorNum, nil
@@ -1738,7 +1738,7 @@ func (devices *DeviceSet) initDevmapper(doInit bool) (retErr error) {
 	//	- Managed by docker
 	//	- The target of this device is at major <maj> and minor <min>
 	//	- If <inode> is defined, use that file inside the device as a loopback image. Otherwise use the device itself.
-	devices.devicePrefix = fmt.Sprintf("docker-%d:%d-%d", major(st.Dev), minor(st.Dev), st.Ino)
+	devices.devicePrefix = fmt.Sprintf("docker-%d:%d-%d", major(uint64(st.Dev)), minor(uint64(st.Dev)), st.Ino)
 	logger.Debugf("Generated prefix: %s", devices.devicePrefix)
 
 	// Check for the existence of the thin-pool device

--- a/pkg/loopback/loopback.go
+++ b/pkg/loopback/loopback.go
@@ -54,7 +54,7 @@ func FindLoopDeviceFor(file *os.File) *os.File {
 		}
 
 		dev, inode, err := getLoopbackBackingFile(file)
-		if err == nil && dev == targetDevice && inode == targetInode {
+		if err == nil && dev == uint64(targetDevice) && inode == targetInode {
 			return file
 		}
 		file.Close()

--- a/pkg/system/stat_linux.go
+++ b/pkg/system/stat_linux.go
@@ -8,7 +8,7 @@ func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 		mode: s.Mode,
 		uid:  s.Uid,
 		gid:  s.Gid,
-		rdev: s.Rdev,
+		rdev: uint64(s.Rdev),
 		mtim: s.Mtim}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Kasper Fabæch Brandt <poizan@poizan.dk>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed build errors about like "cannot use s.Rdev (type uint32) as type uint64" when targeting mips due to the Dev and Rdev in Stat_t being 32-bit on 32-bit mips.

**- How I did it**
Inserted casts to uint64 where needed.

(fixes #28058 it would seem)

**- How to verify it**
Try building docker targeting mips (still won't build successfully)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

