### PR TITLE
SIGSTKFLT does not exist on MIPS, instead SIGEMT does. SIGRTMAX is also 127 on MIPS

### DIFF
--- a/pkg/signal/signal_linux_mipsx.go
+++ b/pkg/signal/signal_linux_mipsx.go
@@ -1,4 +1,5 @@
-// +build !mips,!mipsle,!mips64,!mips64le
+// +build linux
+// +build mips mipsle mips64 mips64le
 
 package signal // import "github.com/docker/docker/pkg/signal"
 
@@ -10,7 +11,7 @@ import (
 
 const (
 	sigrtmin = 34
-	sigrtmax = 64
+	sigrtmax = 127
 )
 
 // SignalMap is a map of Linux signals.
@@ -34,7 +35,7 @@ var SignalMap = map[string]syscall.Signal{
 	"PWR":      unix.SIGPWR,
 	"QUIT":     unix.SIGQUIT,
 	"SEGV":     unix.SIGSEGV,
-	"STKFLT":   unix.SIGSTKFLT,
+	"SIGEMT":   unix.SIGEMT,
 	"STOP":     unix.SIGSTOP,
 	"SYS":      unix.SIGSYS,
 	"TERM":     unix.SIGTERM,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed build error `pkg/signal/signal_linux.go:35:14: undefined: unix.SIGSTKFLT` caused by SIGSTKFLT not existing on mips. Added SIGEMT instead on mips. Made sure the RTMAX* signals reflects the fact that SIGRTMAX is bigger on mips.

This fixes  #37300.

**- How I did it**
Made a mips-specific version of pkg/signal/signal_linux.go (signal_linux_mipsx.go)

**- How to verify it**
Try building docker targeting mips (it still won't build successfully though)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

