### PR TITLE
Add osusergo build tar for static binaries

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -14,7 +14,7 @@ install_containerd() {
 
 	(
 
-		export BUILDTAGS='static_build netgo'
+		export BUILDTAGS='netgo osusergo static_build'
 		export EXTRA_FLAGS='-buildmode=pie'
 		export EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"'
 

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -145,7 +145,7 @@ LDFLAGS_STATIC=''
 EXTLDFLAGS_STATIC='-static'
 # ORIG_BUILDFLAGS is necessary for the cross target which cannot always build
 # with options like -race.
-ORIG_BUILDFLAGS=( -tags "autogen netgo static_build $DOCKER_BUILDTAGS" -installsuffix netgo )
+ORIG_BUILDFLAGS=( -tags "autogen netgo osusergo static_build $DOCKER_BUILDTAGS" -installsuffix netgo )
 # see https://github.com/golang/go/issues/9369#issuecomment-69864440 for why -installsuffix is necessary here
 
 # When $DOCKER_INCREMENTAL_BINARY is set in the environment, enable incremental

--- a/hack/make/dynbinary-daemon
+++ b/hack/make/dynbinary-daemon
@@ -5,6 +5,7 @@ set -e
 	export IAMSTATIC='false'
 	export LDFLAGS_STATIC_DOCKER=''
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/netgo /}" ) # disable netgo, since we don't need it for a dynamic binary
+	export BUILDFLAGS=( "${BUILDFLAGS[@]/osusergo /}" ) # ditto for osusergo
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/static_build /}" ) # we're not building a "static" binary here
 	source "${MAKEDIR}/.binary"
 )


### PR DESCRIPTION
Go 1.11 includes a fix to os/user to be working in a static binary
(fixing https://github.com/golang/go/issues/23265). The fix requires
`osusergo` build tag to be set for static binaries, which is what
this commit adds (also for containerd).

See also: https://github.com/containerd/containerd/pull/2476