### PR TITLE
Add "Warnings" to /info endpoint, and move detection to the daemon

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3904,6 +3904,19 @@ definitions:
           such as number of nodes, and expiration are included.
         type: "string"
         example: "Community Engine"
+      Warnings:
+        description: |
+          List of warnings / informational messages about missing features, or
+          issues related to the daemon configuration.
+
+          These messages can be printed by the client as information to the user.
+        type: "array"
+        items:
+          type: "string"
+        example:
+          - "WARNING: No memory limit support"
+          - "WARNING: bridge-nf-call-iptables is disabled"
+          - "WARNING: bridge-nf-call-ip6tables is disabled"
 
 
   # PluginsInfo is a temp struct holding Plugins name

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -206,6 +206,7 @@ type Info struct {
 	InitCommit         Commit
 	SecurityOptions    []string
 	ProductLicense     string `json:",omitempty"`
+	Warnings           []string
 }
 
 // KeyValue holds a key/value pair

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -134,6 +134,8 @@ func (daemon *Daemon) fillDriverInfo(v *types.Info) {
 
 	v.Driver = drivers
 	v.DriverStatus = ds
+
+	fillDriverWarnings(v)
 }
 
 func (daemon *Daemon) fillPluginsInfo(v *types.Info) {

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -4,6 +4,7 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -68,6 +69,80 @@ func (daemon *Daemon) fillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) 
 		logrus.Warnf("failed to retrieve %s version: %s", defaultInitBinary, err)
 		v.InitCommit.ID = "N/A"
 	}
+
+	if !v.MemoryLimit {
+		v.Warnings = append(v.Warnings, "WARNING: No memory limit support")
+	}
+	if !v.SwapLimit {
+		v.Warnings = append(v.Warnings, "WARNING: No swap limit support")
+	}
+	if !v.KernelMemory {
+		v.Warnings = append(v.Warnings, "WARNING: No kernel memory limit support")
+	}
+	if !v.OomKillDisable {
+		v.Warnings = append(v.Warnings, "WARNING: No oom kill disable support")
+	}
+	if !v.CPUCfsQuota {
+		v.Warnings = append(v.Warnings, "WARNING: No cpu cfs quota support")
+	}
+	if !v.CPUCfsPeriod {
+		v.Warnings = append(v.Warnings, "WARNING: No cpu cfs period support")
+	}
+	if !v.CPUShares {
+		v.Warnings = append(v.Warnings, "WARNING: No cpu shares support")
+	}
+	if !v.CPUSet {
+		v.Warnings = append(v.Warnings, "WARNING: No cpuset support")
+	}
+	if !v.IPv4Forwarding {
+		v.Warnings = append(v.Warnings, "WARNING: IPv4 forwarding is disabled")
+	}
+	if !v.BridgeNfIptables {
+		v.Warnings = append(v.Warnings, "WARNING: bridge-nf-call-iptables is disabled")
+	}
+	if !v.BridgeNfIP6tables {
+		v.Warnings = append(v.Warnings, "WARNING: bridge-nf-call-ip6tables is disabled")
+	}
+}
+
+func fillDriverWarnings(v *types.Info) {
+	if v.DriverStatus == nil {
+		return
+	}
+	for _, pair := range v.DriverStatus {
+		if pair[0] == "Data loop file" {
+			msg := fmt.Sprintf("WARNING: %s: usage of loopback devices is "+
+				"strongly discouraged for production use.\n         "+
+				"Use `--storage-opt dm.thinpooldev` to specify a custom block storage device.", v.Driver)
+
+			v.Warnings = append(v.Warnings, msg)
+			continue
+		}
+		if pair[0] == "Supports d_type" && pair[1] == "false" {
+			backingFs := getBackingFs(v)
+
+			msg := fmt.Sprintf("WARNING: %s: the backing %s filesystem is formatted without d_type support, which leads to incorrect behavior.\n", v.Driver, backingFs)
+			if backingFs == "xfs" {
+				msg += "         Reformat the filesystem with ftype=1 to enable d_type support.\n"
+			}
+			msg += "         Running without d_type support will not be supported in future releases."
+
+			v.Warnings = append(v.Warnings, msg)
+			continue
+		}
+	}
+}
+
+func getBackingFs(v *types.Info) string {
+	if v.DriverStatus == nil {
+		return ""
+	}
+	for _, pair := range v.DriverStatus {
+		if pair[0] == "Backing Filesystem" {
+			return pair[1]
+		}
+	}
+	return ""
 }
 
 // parseInitVersion parses a Tini version string, and extracts the version.

--- a/daemon/info_windows.go
+++ b/daemon/info_windows.go
@@ -8,3 +8,6 @@ import (
 // fillPlatformInfo fills the platform related info.
 func (daemon *Daemon) fillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) {
 }
+
+func fillDriverWarnings(v *types.Info) {
+}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -21,6 +21,8 @@ keywords: "API, Docker, rcli, REST, documentation"
   and `OperatingSystem` if the daemon was unable to obtain this information.
 * `GET /info` now returns information about the product license, if a license
   has been applied to the daemon.
+* `GET /info` now returns a `Warnings` field, containing warnings and informational
+  messages about missing features, or issues related to the daemon configuration.
 * `POST /swarm/init` now accepts a `DefaultAddrPool` property to set global scope default address pool
 * `POST /swarm/init` now accepts a `SubnetSize` property to set global scope networks by giving the
   length of the subnet masks for every such network


### PR DESCRIPTION
When requesting information about the daemon's configuration through the `/info`
endpoint, missing features (or non-recommended settings) may have to be presented
to the user.

Detecting these situations, and printing warnings currently is handled by the
cli, which results in some complications:

- duplicated effort: each client has to re-implement detection and warnings.
- it's not possible to generate warnings for reasons outside of the information
  returned in the `/info` response.
- cli-side detection has to be updated for new conditions. This means that an
  older cli connecting to a new daemon may not print all warnings (due to
  it not detecting the new conditions)
- some warnings (in particular, warnings about storage-drivers) depend on
  driver-status (`DriverStatus`) information. The format of the information
  returned in this field is not part of the API specification and can change
  over time, resulting in cli-side detection no longer being functional.

This patch adds a new `Warnings` field to the `/info` response. This field is
to return warnings to be presented by the user.

Existing warnings that are currently handled by the CLI are copied to the daemon
as part of this patch; This change is backward-compatible with existing
clients; old client can continue to use the client-side warnings, whereas new
clients can skip client-side detection, and print warnings that are returned by
the daemon.

Example response with this patch applied;

```bash
curl --unix-socket /var/run/docker.sock http://localhost/info | jq .Warnings
```

```json
[
  "WARNING: bridge-nf-call-iptables is disabled",
  "WARNING: bridge-nf-call-ip6tables is disabled"
]
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
* The `GET /info` API endpoint now returns a `Warnings` field, containing warnings
  and informational messages about missing features, or issues related to the daemon
  configuration.
```


**- A picture of a cute animal (not mandatory but encouraged)**


![vampire13-660x495](https://user-images.githubusercontent.com/1804568/42940637-81c2b540-8b5a-11e8-8882-32cdb01f401b.jpg)

[image source](https://24.hu/light/2016/06/14/ahogy-ennek-a-cuki-vampir-suninek-a-kepei-felkerultek-elolvadt-a-facebook/)