### PR TITLE
Honor DOCKER_BUILDKIT in integration tests

### DIFF
--- a/builder/buildutil/session.go
+++ b/builder/buildutil/session.go
@@ -1,0 +1,58 @@
+package buildutil
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+
+	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/client"
+	"github.com/moby/buildkit/session"
+	"github.com/pkg/errors"
+)
+
+const clientSessionRemote = "client-session"
+
+var nodeID = "nodeID"
+
+func isSessionSupported(c client.APIClient) bool {
+	ping, err := c.Ping(context.TODO())
+	if err != nil {
+		panic(fmt.Errorf("could not ping: %v", err))
+	}
+	return ping.Experimental && versions.GreaterThanOrEqualTo(c.ClientVersion(), "1.31")
+}
+
+func trySession(c client.APIClient, contextDir string) (*session.Session, error) {
+	var s *session.Session
+	if isSessionSupported(c) {
+		sharedKey, err := getBuildSharedKey(contextDir)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get build shared key")
+		}
+		s, err = session.NewSession(context.Background(), filepath.Base(contextDir), sharedKey)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create session")
+		}
+	}
+	return s, nil
+}
+
+func getBuildSharedKey(dir string) (string, error) {
+	// build session is hash of build dir with node based randomness
+	s := sha256.Sum256([]byte(fmt.Sprintf("%s:%s", tryNodeIdentifier(), dir)))
+	return hex.EncodeToString(s[:]), nil
+}
+
+func tryNodeIdentifier() string {
+	if nodeID == "nodeID" {
+		b := make([]byte, 32)
+		if _, err := rand.Read(b); err == nil {
+			nodeID = hex.EncodeToString(b)
+		}
+	}
+	return nodeID
+}

--- a/builder/buildutil/util.go
+++ b/builder/buildutil/util.go
@@ -1,30 +1,93 @@
 /*
 Package buildutil is a wrapper around client package for easier to use build functions.
+To be used only in tests for now.
 */
 package buildutil
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
+	controlapi "github.com/moby/buildkit/api/services/control"
+	bkclient "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/sirupsen/logrus"
+	"github.com/tonistiigi/fsutil"
 )
+
+// BuildKitEnabled returns whether BuildKit was enabled through the DOCKER_BUILDKIT environment variable.
+// TODO: Remove this and allow caller to set it.
+func BuildKitEnabled() bool {
+	return os.Getenv("DOCKER_BUILDKIT") == "1"
+}
 
 // BuildResult encapsulates the result of a build.
 type BuildResult struct {
 	types.BuildResult
+
+	ss bkclient.SolveStatus
+
+	// for legacy builder
+
 	Output []byte
 }
 
-// BuildInput specifies how to get the context or Dockerfile.
+// OutputContains returns whether the output from RUN instructions contains a specified search term.
+// In legacy builder, this will search within the entire output of the build (not just RUN instructions' output).
+func (br *BuildResult) OutputContains(b []byte) bool {
+	if !BuildKitEnabled() {
+		return bytes.Contains(br.Output, b)
+	}
+	for _, v := range br.ss.Logs {
+		if bytes.Contains(v.Data, b) {
+			return true
+		}
+	}
+	return false
+}
+
+// CacheHit looks for a Dockerfile step to match with substr and returns whether that step was cached.
+// Use randomized strings to match for best quality. Otherwise double check there are no false positives.
+func (br *BuildResult) CacheHit(substr string) bool {
+	if !BuildKitEnabled() {
+		// Parse output by finding first line matching "Using cache", that is below a line matching substr
+		s := bufio.NewScanner(bytes.NewReader(br.Output))
+		substrMatched := false
+		for s.Scan() {
+			if !substrMatched {
+				if bytes.Contains(s.Bytes(), []byte(substr)) {
+					substrMatched = true
+				}
+			} else {
+				if bytes.Equal(s.Bytes(), []byte(" ---> Using cache")) {
+					return true
+				}
+				substrMatched = false
+			}
+		}
+		return false
+	}
+	for _, v := range br.ss.Vertexes {
+		if strings.Contains(v.Name, substr) && v.Cached {
+			return true
+		}
+	}
+	return false
+}
+
+// BuildInput specifies how to get the build context or Dockerfile.
 type BuildInput struct {
 	Context    io.Reader
 	ContextDir string
@@ -40,7 +103,16 @@ func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	if BuildKitEnabled() {
+		if options.Version != "" && options.Version != types.BuilderBuildKit {
+			return br, fmt.Errorf("Conflict: buildkit was enabled but ImageBuildOptions.Version differs: %s", options.Version)
+		}
+		options.Version = types.BuilderBuildKit
+	}
+
 	buildCtx := input.Context
+
+	// if streaming
 	if input.Context == nil && options.RemoteContext == "" {
 		sess, err := trySession(c, input.ContextDir)
 		if err != nil {
@@ -52,10 +124,26 @@ func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions
 
 		dirs := make([]filesync.SyncedDir, 0, 1)
 		if input.ContextDir != "" {
-			dirs = append(dirs, filesync.SyncedDir{Dir: input.ContextDir})
+			var name string
+			if BuildKitEnabled() {
+				name = "context"
+			}
+			dirs = append(dirs, filesync.SyncedDir{Name: name, Dir: input.ContextDir, Map: resetUIDAndGID})
 		}
 		if input.Dockerfile != nil {
-			buildCtx = bytes.NewReader(input.Dockerfile)
+			if BuildKitEnabled() {
+				dd, err := ioutil.TempDir("", "dockerfiledir")
+				if err != nil {
+					return br, err
+				}
+				defer os.RemoveAll(dd)
+				if err := ioutil.WriteFile(filepath.Join(dd, "Dockerfile"), input.Dockerfile, 0644); err != nil {
+					return br, err
+				}
+				dirs = append(dirs, filesync.SyncedDir{Name: "dockerfile", Dir: dd})
+			} else {
+				buildCtx = bytes.NewReader(input.Dockerfile)
+			}
 		}
 		sess.Allow(filesync.NewFSSyncProvider(dirs))
 
@@ -76,7 +164,7 @@ func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions
 
 	resp, err := c.ImageBuild(ctx, buildCtx, options)
 	if err != nil {
-		return nil, err
+		return br, err
 	}
 	defer resp.Body.Close()
 	dec := json.NewDecoder(resp.Body)
@@ -96,7 +184,51 @@ func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions
 		}
 		if jm.Aux != nil {
 			switch jm.ID {
-			case "": // legacy builder
+			case "moby.buildkit.trace":
+				var resp controlapi.StatusResponse
+				var dt []byte
+
+				// ignoring all messages that are not understood
+				if err := json.Unmarshal(*jm.Aux, &dt); err != nil {
+					continue
+				}
+				if err := (&resp).Unmarshal(dt); err != nil {
+					continue
+				}
+
+				s := &br.ss
+				for _, v := range resp.Vertexes {
+					s.Vertexes = append(s.Vertexes, &bkclient.Vertex{
+						Digest:    v.Digest,
+						Inputs:    v.Inputs,
+						Name:      v.Name,
+						Started:   v.Started,
+						Completed: v.Completed,
+						Error:     v.Error,
+						Cached:    v.Cached,
+					})
+				}
+				for _, v := range resp.Statuses {
+					s.Statuses = append(s.Statuses, &bkclient.VertexStatus{
+						ID:        v.ID,
+						Vertex:    v.Vertex,
+						Name:      v.Name,
+						Total:     v.Total,
+						Current:   v.Current,
+						Timestamp: v.Timestamp,
+						Started:   v.Started,
+						Completed: v.Completed,
+					})
+				}
+				for _, v := range resp.Logs {
+					s.Logs = append(s.Logs, &bkclient.VertexLog{
+						Vertex:    v.Vertex,
+						Stream:    int(v.Stream),
+						Data:      v.Msg,
+						Timestamp: v.Timestamp,
+					})
+				}
+			case "", "moby.image.id":
 				if err := json.Unmarshal(*jm.Aux, &br.BuildResult); err != nil {
 					return br, err
 				}
@@ -107,4 +239,10 @@ func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions
 		}
 	}
 	return br, nil
+}
+
+func resetUIDAndGID(s *fsutil.Stat) bool {
+	s.Uid = 0
+	s.Gid = 0
+	return true
 }

--- a/builder/buildutil/util.go
+++ b/builder/buildutil/util.go
@@ -1,0 +1,64 @@
+/*
+Package buildutil is a wrapper around client package for easier to use build functions.
+*/
+package buildutil
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
+)
+
+// BuildResult encapsulates the result of a build.
+type BuildResult struct {
+	types.BuildResult
+	Output []byte
+}
+
+// BuildInput specifies how to get the context.
+type BuildInput struct {
+	Context io.Reader
+}
+
+// Build will call client package's ImageBuild and parse the JSONMessage responses into an easy to consume BuildResult.
+func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions) (*BuildResult, error) {
+	ctx := context.Background()
+	br := &BuildResult{}
+	resp, err := c.ImageBuild(ctx, input.Context, options)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	dec := json.NewDecoder(resp.Body)
+	for {
+		var jm jsonmessage.JSONMessage
+		if err := dec.Decode(&jm); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return br, err
+		}
+		if jm.Error != nil {
+			return br, jm.Error
+		}
+		if jm.ID == "" {
+			br.Output = append(br.Output, []byte(jm.Stream)...)
+		}
+		if jm.Aux != nil {
+			switch jm.ID {
+			case "": // legacy builder
+				if err := json.Unmarshal(*jm.Aux, &br.BuildResult); err != nil {
+					return br, err
+				}
+				if br.ID != "" {
+					br.ID = br.ID
+				}
+			}
+		}
+	}
+	return br, nil
+}

--- a/builder/buildutil/util.go
+++ b/builder/buildutil/util.go
@@ -4,13 +4,18 @@ Package buildutil is a wrapper around client package for easier to use build fun
 package buildutil
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/filesync"
+	"github.com/sirupsen/logrus"
 )
 
 // BuildResult encapsulates the result of a build.
@@ -19,16 +24,57 @@ type BuildResult struct {
 	Output []byte
 }
 
-// BuildInput specifies how to get the context.
+// BuildInput specifies how to get the context or Dockerfile.
 type BuildInput struct {
-	Context io.Reader
+	Context    io.Reader
+	ContextDir string
+	Dockerfile []byte
 }
 
 // Build will call client package's ImageBuild and parse the JSONMessage responses into an easy to consume BuildResult.
 func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions) (*BuildResult, error) {
 	ctx := context.Background()
 	br := &BuildResult{}
-	resp, err := c.ImageBuild(ctx, input.Context, options)
+	var sess *session.Session
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	buildCtx := input.Context
+	if input.Context == nil && options.RemoteContext == "" {
+		sess, err := trySession(c, input.ContextDir)
+		if err != nil {
+			return br, err
+		}
+		if sess == nil {
+			return br, fmt.Errorf("session not supported")
+		}
+
+		dirs := make([]filesync.SyncedDir, 0, 1)
+		if input.ContextDir != "" {
+			dirs = append(dirs, filesync.SyncedDir{Dir: input.ContextDir})
+		}
+		if input.Dockerfile != nil {
+			buildCtx = bytes.NewReader(input.Dockerfile)
+		}
+		sess.Allow(filesync.NewFSSyncProvider(dirs))
+
+		options.SessionID = sess.ID()
+		options.RemoteContext = clientSessionRemote
+
+		go func() {
+			if err := sess.Run(ctx, c.DialSession); err != nil {
+				logrus.Error(err)
+				cancel()
+			}
+		}()
+	}
+
+	if sess != nil {
+		defer sess.Close()
+	}
+
+	resp, err := c.ImageBuild(ctx, buildCtx, options)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/build/build_session_test.go
+++ b/integration/build/build_session_test.go
@@ -7,11 +7,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder/buildutil"
-	"github.com/docker/docker/client"
 	"github.com/docker/docker/internal/test/fakecontext"
-	"github.com/moby/buildkit/session"
-	"github.com/moby/buildkit/session/filesync"
-	"golang.org/x/sync/errgroup"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/skip"
@@ -33,8 +29,9 @@ func TestBuildWithSession(t *testing.T) {
 	)
 	defer fctx.Close()
 
-	out := testBuildWithSession(t, client, fctx.Dir, dockerfile)
-	assert.Check(t, is.Contains(out, "some content"))
+	res, err := buildutil.Build(client, buildutil.BuildInput{ContextDir: fctx.Dir, Dockerfile: []byte(dockerfile)}, types.ImageBuildOptions{})
+	assert.NilError(t, err)
+	assert.Check(t, is.Contains(string(res.Output), "some content"))
 
 	fctx.Add("second", "contentcontent")
 
@@ -43,16 +40,18 @@ func TestBuildWithSession(t *testing.T) {
 	RUN cat /second
 	`
 
-	out = testBuildWithSession(t, client, fctx.Dir, dockerfile)
-	assert.Check(t, is.Equal(strings.Count(out, "Using cache"), 2))
-	assert.Check(t, is.Contains(out, "contentcontent"))
+	res, err = buildutil.Build(client, buildutil.BuildInput{ContextDir: fctx.Dir, Dockerfile: []byte(dockerfile)}, types.ImageBuildOptions{})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(strings.Count(string(res.Output), "Using cache"), 2))
+	assert.Check(t, is.Contains(string(res.Output), "contentcontent"))
 
 	du, err := client.DiskUsage(context.TODO())
 	assert.Check(t, err)
 	assert.Check(t, du.BuilderSize > 10)
 
-	out = testBuildWithSession(t, client, fctx.Dir, dockerfile)
-	assert.Check(t, is.Equal(strings.Count(out, "Using cache"), 4))
+	res, err = buildutil.Build(client, buildutil.BuildInput{ContextDir: fctx.Dir, Dockerfile: []byte(dockerfile)}, types.ImageBuildOptions{})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(strings.Count(string(res.Output), "Using cache"), 4))
 
 	du2, err := client.DiskUsage(context.TODO())
 	assert.Check(t, err)
@@ -61,7 +60,7 @@ func TestBuildWithSession(t *testing.T) {
 	// rebuild with regular tar, confirm cache still applies
 	fctx.Add("Dockerfile", dockerfile)
 
-	res, err := buildutil.Build(
+	res, err = buildutil.Build(
 		client,
 		buildutil.BuildInput{Context: fctx.AsTarReader(t)},
 		types.ImageBuildOptions{},
@@ -77,40 +76,4 @@ func TestBuildWithSession(t *testing.T) {
 	du, err = client.DiskUsage(context.TODO())
 	assert.Check(t, err)
 	assert.Check(t, is.Equal(du.BuilderSize, int64(0)))
-}
-
-func testBuildWithSession(t *testing.T, client client.APIClient, dir, dockerfile string) (outStr string) {
-	ctx := context.Background()
-	sess, err := session.NewSession(ctx, "foo1", "foo")
-	assert.Check(t, err)
-
-	fsProvider := filesync.NewFSSyncProvider([]filesync.SyncedDir{
-		{Dir: dir},
-	})
-	sess.Allow(fsProvider)
-
-	g, ctx := errgroup.WithContext(ctx)
-
-	g.Go(func() error {
-		return sess.Run(ctx, client.DialSession)
-	})
-
-	g.Go(func() error {
-		res, err := buildutil.Build(
-			client,
-			buildutil.BuildInput{Context: strings.NewReader(dockerfile)},
-			types.ImageBuildOptions{
-				RemoteContext: "client-session",
-				SessionID:     sess.ID(),
-			},
-		)
-		assert.NilError(t, err)
-		sess.Close()
-		outStr = string(res.Output)
-		return nil
-	})
-
-	err = g.Wait()
-	assert.Check(t, err)
-	return
 }

--- a/integration/build/build_session_test.go
+++ b/integration/build/build_session_test.go
@@ -2,14 +2,13 @@ package build
 
 import (
 	"context"
-	"io/ioutil"
-	"net/http"
 	"strings"
 	"testing"
 
-	dclient "github.com/docker/docker/client"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/builder/buildutil"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/internal/test/fakecontext"
-	"github.com/docker/docker/internal/test/request"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"golang.org/x/sync/errgroup"
@@ -34,7 +33,7 @@ func TestBuildWithSession(t *testing.T) {
 	)
 	defer fctx.Close()
 
-	out := testBuildWithSession(t, client, client.DaemonHost(), fctx.Dir, dockerfile)
+	out := testBuildWithSession(t, client, fctx.Dir, dockerfile)
 	assert.Check(t, is.Contains(out, "some content"))
 
 	fctx.Add("second", "contentcontent")
@@ -44,7 +43,7 @@ func TestBuildWithSession(t *testing.T) {
 	RUN cat /second
 	`
 
-	out = testBuildWithSession(t, client, client.DaemonHost(), fctx.Dir, dockerfile)
+	out = testBuildWithSession(t, client, fctx.Dir, dockerfile)
 	assert.Check(t, is.Equal(strings.Count(out, "Using cache"), 2))
 	assert.Check(t, is.Contains(out, "contentcontent"))
 
@@ -52,7 +51,7 @@ func TestBuildWithSession(t *testing.T) {
 	assert.Check(t, err)
 	assert.Check(t, du.BuilderSize > 10)
 
-	out = testBuildWithSession(t, client, client.DaemonHost(), fctx.Dir, dockerfile)
+	out = testBuildWithSession(t, client, fctx.Dir, dockerfile)
 	assert.Check(t, is.Equal(strings.Count(out, "Using cache"), 4))
 
 	du2, err := client.DiskUsage(context.TODO())
@@ -61,20 +60,16 @@ func TestBuildWithSession(t *testing.T) {
 
 	// rebuild with regular tar, confirm cache still applies
 	fctx.Add("Dockerfile", dockerfile)
-	// FIXME(vdemeester) use sock here
-	res, body, err := request.Do(
-		"/build",
-		request.Host(client.DaemonHost()),
-		request.Method(http.MethodPost),
-		request.RawContent(fctx.AsTarReader(t)),
-		request.ContentType("application/x-tar"))
-	assert.NilError(t, err)
-	assert.Check(t, is.DeepEqual(http.StatusOK, res.StatusCode))
 
-	outBytes, err := request.ReadBody(body)
+	res, err := buildutil.Build(
+		client,
+		buildutil.BuildInput{Context: fctx.AsTarReader(t)},
+		types.ImageBuildOptions{},
+	)
 	assert.NilError(t, err)
-	assert.Check(t, is.Contains(string(outBytes), "Successfully built"))
-	assert.Check(t, is.Equal(strings.Count(string(outBytes), "Using cache"), 4))
+
+	assert.Check(t, is.Contains(string(res.Output), "Successfully built"))
+	assert.Check(t, is.Equal(strings.Count(string(res.Output), "Using cache"), 4))
 
 	_, err = client.BuildCachePrune(context.TODO())
 	assert.Check(t, err)
@@ -84,7 +79,7 @@ func TestBuildWithSession(t *testing.T) {
 	assert.Check(t, is.Equal(du.BuilderSize, int64(0)))
 }
 
-func testBuildWithSession(t *testing.T, client dclient.APIClient, daemonHost string, dir, dockerfile string) (outStr string) {
+func testBuildWithSession(t *testing.T, client client.APIClient, dir, dockerfile string) (outStr string) {
 	ctx := context.Background()
 	sess, err := session.NewSession(ctx, "foo1", "foo")
 	assert.Check(t, err)
@@ -101,25 +96,17 @@ func testBuildWithSession(t *testing.T, client dclient.APIClient, daemonHost str
 	})
 
 	g.Go(func() error {
-		// FIXME use sock here
-		res, body, err := request.Do(
-			"/build?remote=client-session&session="+sess.ID(),
-			request.Host(daemonHost),
-			request.Method(http.MethodPost),
-			request.With(func(req *http.Request) error {
-				req.Body = ioutil.NopCloser(strings.NewReader(dockerfile))
-				return nil
-			}),
+		res, err := buildutil.Build(
+			client,
+			buildutil.BuildInput{Context: strings.NewReader(dockerfile)},
+			types.ImageBuildOptions{
+				RemoteContext: "client-session",
+				SessionID:     sess.ID(),
+			},
 		)
-		if err != nil {
-			return err
-		}
-		assert.Check(t, is.DeepEqual(res.StatusCode, http.StatusOK))
-		out, err := request.ReadBody(body)
 		assert.NilError(t, err)
-		assert.Check(t, is.Contains(string(out), "Successfully built"))
 		sess.Close()
-		outStr = string(out)
+		outStr = string(res.Output)
 		return nil
 	})
 

--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestBuildSquashParent(t *testing.T) {
 	skip.If(t, !testEnv.DaemonInfo.ExperimentalBuild)
+	skip.If(t, buildutil.BuildKitEnabled, "TODO BuildKit + --squash ?")
 
 	client := testEnv.APIClient()
 

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -2,20 +2,19 @@ package build // import "github.com/docker/docker/integration/build"
 
 import (
 	"archive/tar"
+	"bufio"
 	"bytes"
 	"context"
-	"encoding/json"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/builder/buildutil"
 	"github.com/docker/docker/internal/test/fakecontext"
 	"github.com/docker/docker/internal/test/request"
-	"github.com/docker/docker/pkg/jsonmessage"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/skip"
@@ -103,10 +102,8 @@ func TestBuildWithRemoveAndForceRemove(t *testing.T) {
 			_, err := tw.Write(dockerfile)
 			assert.NilError(t, err)
 			assert.NilError(t, tw.Close())
-			resp, err := client.ImageBuild(ctx, buff, types.ImageBuildOptions{Remove: c.rm, ForceRemove: c.forceRm, NoCache: true})
-			assert.NilError(t, err)
-			defer resp.Body.Close()
-			filter, err := buildContainerIdsFilter(resp.Body)
+			resp, _ := buildutil.Build(client, buildutil.BuildInput{Context: buff}, types.ImageBuildOptions{Remove: c.rm, ForceRemove: c.forceRm, NoCache: true})
+			filter, err := buildContainerIdsFilter(bytes.NewReader(resp.Output))
 			assert.NilError(t, err)
 			remainingContainers, err := client.ContainerList(ctx, types.ContainerListOptions{Filters: filter, All: true})
 			assert.NilError(t, err)
@@ -119,20 +116,14 @@ func buildContainerIdsFilter(buildOutput io.Reader) (filters.Args, error) {
 	const intermediateContainerPrefix = " ---> Running in "
 	filter := filters.NewArgs()
 
-	dec := json.NewDecoder(buildOutput)
-	for {
-		m := jsonmessage.JSONMessage{}
-		err := dec.Decode(&m)
-		if err == io.EOF {
-			return filter, nil
-		}
-		if err != nil {
-			return filter, err
-		}
-		if ix := strings.Index(m.Stream, intermediateContainerPrefix); ix != -1 {
-			filter.Add("id", strings.TrimSpace(m.Stream[ix+len(intermediateContainerPrefix):]))
+	s := bufio.NewScanner(buildOutput)
+	for s.Scan() {
+		t := s.Text()
+		if ix := strings.Index(t, intermediateContainerPrefix); ix != -1 {
+			filter.Add("id", strings.TrimSpace(t[ix+len(intermediateContainerPrefix):]))
 		}
 	}
+	return filter, s.Err()
 }
 
 func TestBuildMultiStageParentConfig(t *testing.T) {
@@ -154,16 +145,11 @@ func TestBuildMultiStageParentConfig(t *testing.T) {
 	defer source.Close()
 
 	apiclient := testEnv.APIClient()
-	resp, err := apiclient.ImageBuild(ctx,
-		source.AsTarReader(t),
-		types.ImageBuildOptions{
-			Remove:      true,
-			ForceRemove: true,
-			Tags:        []string{"build1"},
-		})
-	assert.NilError(t, err)
-	_, err = io.Copy(ioutil.Discard, resp.Body)
-	resp.Body.Close()
+	_, err := buildutil.Build(apiclient, buildutil.BuildInput{Context: source.AsTarReader(t)}, types.ImageBuildOptions{
+		Remove:      true,
+		ForceRemove: true,
+		Tags:        []string{"build1"},
+	})
 	assert.NilError(t, err)
 
 	image, _, err := apiclient.ImageInspectWithRaw(ctx, "build1")
@@ -197,8 +183,8 @@ func TestBuildLabelWithTargets(t *testing.T) {
 
 	apiclient := testEnv.APIClient()
 	// For `target-a` build
-	resp, err := apiclient.ImageBuild(ctx,
-		source.AsTarReader(t),
+	_, err := buildutil.Build(apiclient,
+		buildutil.BuildInput{Context: source.AsTarReader(t)},
 		types.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
@@ -206,9 +192,6 @@ func TestBuildLabelWithTargets(t *testing.T) {
 			Labels:      testLabels,
 			Target:      "target-a",
 		})
-	assert.NilError(t, err)
-	_, err = io.Copy(ioutil.Discard, resp.Body)
-	resp.Body.Close()
 	assert.NilError(t, err)
 
 	image, _, err := apiclient.ImageInspectWithRaw(ctx, bldName)
@@ -224,8 +207,8 @@ func TestBuildLabelWithTargets(t *testing.T) {
 	// For `target-b` build
 	bldName = "build-b"
 	delete(testLabels, "label-a")
-	resp, err = apiclient.ImageBuild(ctx,
-		source.AsTarReader(t),
+	_, err = buildutil.Build(apiclient,
+		buildutil.BuildInput{Context: source.AsTarReader(t)},
 		types.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
@@ -233,9 +216,6 @@ func TestBuildLabelWithTargets(t *testing.T) {
 			Labels:      testLabels,
 			Target:      "target-b",
 		})
-	assert.NilError(t, err)
-	_, err = io.Copy(ioutil.Discard, resp.Body)
-	resp.Body.Close()
 	assert.NilError(t, err)
 
 	image, _, err = apiclient.ImageInspectWithRaw(ctx, bldName)
@@ -256,7 +236,6 @@ func TestBuildWithEmptyLayers(t *testing.T) {
 		COPY    2/ /target/
 		COPY    3/ /target/
 	`
-	ctx := context.Background()
 	source := fakecontext.New(t, "",
 		fakecontext.WithDockerfile(dockerfile),
 		fakecontext.WithFile("1/a", "asdf"),
@@ -265,15 +244,12 @@ func TestBuildWithEmptyLayers(t *testing.T) {
 	defer source.Close()
 
 	apiclient := testEnv.APIClient()
-	resp, err := apiclient.ImageBuild(ctx,
-		source.AsTarReader(t),
+	_, err := buildutil.Build(apiclient,
+		buildutil.BuildInput{Context: source.AsTarReader(t)},
 		types.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
-	assert.NilError(t, err)
-	_, err = io.Copy(ioutil.Discard, resp.Body)
-	resp.Body.Close()
 	assert.NilError(t, err)
 }
 
@@ -294,32 +270,23 @@ RUN cat somefile # fails if ONBUILD RUN fails
 FROM stage1
 RUN cat somefile`
 
-	ctx := context.Background()
 	source := fakecontext.New(t, "",
 		fakecontext.WithDockerfile(dockerfile))
 	defer source.Close()
 
 	apiclient := testEnv.APIClient()
-	resp, err := apiclient.ImageBuild(ctx,
-		source.AsTarReader(t),
+	resp, err := buildutil.Build(apiclient,
+		buildutil.BuildInput{Context: source.AsTarReader(t)},
 		types.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
 
-	out := bytes.NewBuffer(nil)
-	assert.NilError(t, err)
-	_, err = io.Copy(out, resp.Body)
-	resp.Body.Close()
 	assert.NilError(t, err)
 
-	assert.Check(t, is.Contains(out.String(), "Successfully built"))
+	assert.Check(t, is.Contains(string(resp.Output), "Successfully built"))
 
-	imageIDs, err := getImageIDsFromBuild(out.Bytes())
-	assert.NilError(t, err)
-	assert.Check(t, is.Equal(3, len(imageIDs)))
-
-	image, _, err := apiclient.ImageInspectWithRaw(context.Background(), imageIDs[2])
+	image, _, err := apiclient.ImageInspectWithRaw(context.Background(), resp.ID)
 	assert.NilError(t, err)
 	assert.Check(t, is.Contains(image.Config.Env, "bar=baz"))
 }
@@ -327,7 +294,6 @@ RUN cat somefile`
 // #35403 #36122
 func TestBuildUncleanTarFilenames(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.37"), "broken in earlier versions")
-	ctx := context.TODO()
 	defer setupTest(t)()
 
 	dockerfile := `FROM scratch
@@ -344,17 +310,12 @@ COPY bar /`
 	assert.NilError(t, err)
 
 	apiclient := testEnv.APIClient()
-	resp, err := apiclient.ImageBuild(ctx,
-		buf,
+	_, err = buildutil.Build(apiclient,
+		buildutil.BuildInput{Context: buf},
 		types.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
-
-	out := bytes.NewBuffer(nil)
-	assert.NilError(t, err)
-	_, err = io.Copy(out, resp.Body)
-	resp.Body.Close()
 	assert.NilError(t, err)
 
 	// repeat with changed data should not cause cache hits
@@ -367,26 +328,21 @@ COPY bar /`
 	err = w.Close()
 	assert.NilError(t, err)
 
-	resp, err = apiclient.ImageBuild(ctx,
-		buf,
+	resp, err := buildutil.Build(apiclient,
+		buildutil.BuildInput{Context: buf},
 		types.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
 
-	out = bytes.NewBuffer(nil)
 	assert.NilError(t, err)
-	_, err = io.Copy(out, resp.Body)
-	resp.Body.Close()
-	assert.NilError(t, err)
-	assert.Assert(t, !strings.Contains(out.String(), "Using cache"))
+	assert.Assert(t, !strings.Contains(string(resp.Output), "Using cache"))
 }
 
 // docker/for-linux#135
 // #35641
 func TestBuildMultiStageLayerLeak(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.37"), "broken in earlier versions")
-	ctx := context.TODO()
 	defer setupTest(t)()
 
 	// all commands need to match until COPY
@@ -407,20 +363,16 @@ RUN [ ! -f foo ]
 	defer source.Close()
 
 	apiclient := testEnv.APIClient()
-	resp, err := apiclient.ImageBuild(ctx,
-		source.AsTarReader(t),
+	resp, err := buildutil.Build(apiclient,
+		buildutil.BuildInput{Context: source.AsTarReader(t)},
 		types.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
 
-	out := bytes.NewBuffer(nil)
-	assert.NilError(t, err)
-	_, err = io.Copy(out, resp.Body)
-	resp.Body.Close()
 	assert.NilError(t, err)
 
-	assert.Check(t, is.Contains(out.String(), "Successfully built"))
+	assert.Check(t, is.Contains(string(resp.Output), "Successfully built"))
 }
 
 func writeTarRecord(t *testing.T, w *tar.Writer, fn, contents string) {
@@ -433,28 +385,4 @@ func writeTarRecord(t *testing.T, w *tar.Writer, fn, contents string) {
 	assert.NilError(t, err)
 	_, err = w.Write([]byte(contents))
 	assert.NilError(t, err)
-}
-
-type buildLine struct {
-	Stream string
-	Aux    struct {
-		ID string
-	}
-}
-
-func getImageIDsFromBuild(output []byte) ([]string, error) {
-	var ids []string
-	for _, line := range bytes.Split(output, []byte("\n")) {
-		if len(line) == 0 {
-			continue
-		}
-		entry := buildLine{}
-		if err := json.Unmarshal(line, &entry); err != nil {
-			return nil, err
-		}
-		if entry.Aux.ID != "" {
-			ids = append(ids, entry.Aux.ID)
-		}
-	}
-	return ids, nil
 }


### PR DESCRIPTION
This PR refactors code in `integration/build/` and honors the DOCKER_BUILDKIT environment variable.

It introduces a new `integration/build/buildutil` package that could in the future be refactored into a easier to use docker client package.

All integration (non-cli) tests should pass with or without BuildKit enabled.