### PR TITLE
Adds LinuxMetadata support by default on Windows

### DIFF
--- a/libcontainerd/client_local_windows.go
+++ b/libcontainerd/client_local_windows.go
@@ -494,6 +494,10 @@ func (c *client) createLinux(id string, spec *specs.Spec, runtimeOptions interfa
 				CreateInUtilityVM: true,
 				ReadOnly:          readonly,
 			}
+			// If we are 1803/RS4+ enable LinuxMetadata support by default
+			if system.GetOSVersion().Build >= 17134 {
+				md.LinuxMetadata = true
+			}
 			mds = append(mds, md)
 			specMount.Source = path.Join(uvmPath, mount.Destination)
 		}

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,6 +1,6 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim v0.6.11
+github.com/Microsoft/hcsshim v0.6.12
 github.com/Microsoft/go-winio v0.4.8
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git

--- a/vendor/github.com/Microsoft/hcsshim/interface.go
+++ b/vendor/github.com/Microsoft/hcsshim/interface.go
@@ -36,6 +36,8 @@ type MappedDir struct {
 	BandwidthMaximum  uint64
 	IOPSMaximum       uint64
 	CreateInUtilityVM bool
+	// LinuxMetadata - Support added in 1803/RS4+.
+	LinuxMetadata bool `json:",omitempty"`
 }
 
 type MappedPipe struct {
@@ -60,6 +62,14 @@ type MappedVirtualDisk struct {
 	ReadOnly          bool   `json:",omitempty"`
 	Cache             string `json:",omitempty"` // "" (Unspecified); "Disabled"; "Enabled"; "Private"; "PrivateAllowSharing"
 	AttachOnly        bool   `json:",omitempty:`
+}
+
+// AssignedDevice represents a device that has been directly assigned to a container
+//
+// NOTE: Support added in RS5
+type AssignedDevice struct {
+	//  InterfaceClassGUID of the device to assign to container.
+	InterfaceClassGUID string `json:"InterfaceClassGuid,omitempty"`
 }
 
 // ContainerConfig is used as both the input of CreateContainer
@@ -93,6 +103,7 @@ type ContainerConfig struct {
 	ContainerType               string              `json:",omitempty"` // "Linux" for Linux containers on Windows. Omitted otherwise.
 	TerminateOnLastHandleClosed bool                `json:",omitempty"` // Should HCS terminate the container once all handles have been closed
 	MappedVirtualDisks          []MappedVirtualDisk `json:",omitempty"` // Array of virtual disks to mount at start
+	AssignedDevices             []AssignedDevice    `json:",omitempty"` // Array of devices to assign. NOTE: Support added in RS5
 }
 
 type ComputeSystemQuery struct {


### PR DESCRIPTION
1. Sets the LinuxMetadata flag by default on Windows LCOW v1
MappedDirectories.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added LinuxMetadata support for MappedDirectories on Windows LCOW v1.

**- How I did it**
RS4 added platform support for this in Windows. This adds the proper forwarding on these builds to enable it by default.

**- How to verify it**
Pre-Fix
```cmd
> mkdir test
> echo test > test\test.log
> docker run -it -v <pwd>\test:/mnt/test alpine sh
/ # ls -al /mnt/test/test.log
-rwxrwxrwx    1 root     root             2 Jul 23 17:16 /mnt/test/test.log
/ # chmod 0700 /mnt/test/test.log
/ # ls -al /mnt/test/test.log
-rwxrwxrwx    1 root     root             2 Jul 23 17:16 /mnt/test/test.log
/ # exit
>
```
Post-Fix (notice the chmod bits changed at runtime)
```cmd
> mkdir test
> echo test > test\test.log
> docker run -it -v <pwd>\test:/mnt/test alpine sh
/ # ls -al /mnt/test/test.log
-rwxrwxrwx    1 root     root             2 Jul 23 17:16 /mnt/test/test.log
/ # chmod 0700 /mnt/test/test.log
/ # ls -al /mnt/test/test.log
-rwx------    1 root     root             2 Jul 23 17:16 /mnt/test/test.log
/ # exit
>
```
And it persists across runs!
```cmd
> docker run -it -v E:\docker\testshare:/mnt/test alpine sh
/ # ls -al /mnt/test/test.log
-rwx------    1 root     root             2 Jul 23 17:16 /mnt/test/test.log
/ # exit
>
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Adds LinuxMetadata support to all RS4+ LCOW v1 containers on Windows.

**- A picture of a cute animal (not mandatory but encouraged)**
![Flameback Cichlid](http://images.tapatalk-cdn.com/15/04/12/587cbd6c09145cca565b0e2d6a5bf643.jpg)
