### PR TITLE
Revendor Microsoft/opengcs @ v0.3.8

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -7,7 +7,7 @@ github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://githu
 github.com/golang/gddo 9b12a26f3fbd7397dee4e20939ddca719d840d2a
 github.com/gorilla/context v1.1
 github.com/gorilla/mux v1.1
-github.com/Microsoft/opengcs v0.3.6
+github.com/Microsoft/opengcs v0.3.8
 github.com/kr/pty 5cf931ef8f
 github.com/mattn/go-shellwords v1.0.3
 github.com/sirupsen/logrus v1.0.3

--- a/vendor/github.com/Microsoft/opengcs/client/config.go
+++ b/vendor/github.com/Microsoft/opengcs/client/config.go
@@ -110,7 +110,7 @@ func ParseOptions(options []string) (Options, error) {
 		rOpts.Vhdx = filepath.Join(rOpts.KirdPath, `uvm.vhdx`)
 	}
 	if rOpts.KernelFile == "" {
-		rOpts.KernelFile = `bootx64.efi`
+		rOpts.KernelFile = `kernel`
 	}
 	if rOpts.InitrdFile == "" {
 		rOpts.InitrdFile = `initrd.img`


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Bumps opengcs to v0.3.8.  @rn as mentioned offline. The most critical part of this change is that in LCOW, the crazily badly named `bootx64.efi` (historical reasons) is finally just called `kernel`. This will require upstream changes in D4W to match.  

@jterry75 @johnstep @carlfischer1 FYI, but no action needed.