### PR TITLE
Add configuration option for cri-containerd 

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -29,6 +29,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.StringVarP(&conf.Root, "graph", "g", defaultDataRoot, "Root of the Docker runtime")
 	flags.StringVar(&conf.ExecRoot, "exec-root", defaultExecRoot, "Root directory for execution state files")
 	flags.StringVar(&conf.ContainerdAddr, "containerd", "", "containerd grpc address")
+	flags.BoolVar(&conf.CriContainerd, "cri-containerd", false, "start containerd with cri")
 
 	// "--graph" is "soft-deprecated" in favor of "data-root". This flag was added
 	// before Docker 1.0, so won't be removed, only hidden, to discourage its usage.

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -56,6 +56,9 @@ func (cli *DaemonCli) getPlatformRemoteOptions() ([]libcontainerd.RemoteOption, 
 	} else {
 		opts = append(opts, libcontainerd.WithStartDaemon(true))
 	}
+	if !cli.Config.CriContainerd {
+		opts = append(opts, libcontainerd.WithPlugin("cri", nil))
+	}
 
 	return opts, nil
 }

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -198,6 +198,11 @@ type CommonConfig struct {
 	// ContainerAddr is the address used to connect to containerd if we're
 	// not starting it ourselves
 	ContainerdAddr string `json:"containerd,omitempty"`
+
+	// CriContainerd determines whether a supervised containerd instance
+	// should be configured with the CRI plugin enabled. This allows using
+	// Docker's containerd instance directly with a Kubernetes kubelet.
+	CriContainerd bool `json:"cri-containerd,omitempty"`
 }
 
 // IsValueSet returns true if a configuration value

--- a/libcontainerd/remote_daemon_linux.go
+++ b/libcontainerd/remote_daemon_linux.go
@@ -31,6 +31,14 @@ func (r *remote) setDefaults() {
 	if r.OOMScore == 0 {
 		r.OOMScore = -999
 	}
+
+	for key, conf := range r.pluginConfs.Plugins {
+		if conf == nil {
+			r.DisabledPlugins = append(r.DisabledPlugins, key)
+			delete(r.pluginConfs.Plugins, key)
+		}
+	}
+
 	if r.snapshotter == "" {
 		r.snapshotter = "overlay"
 	}

--- a/libcontainerd/remote_daemon_options.go
+++ b/libcontainerd/remote_daemon_options.go
@@ -119,6 +119,7 @@ func (s snapshotter) Apply(r Remote) error {
 // WithPlugin allow configuring a containerd plugin
 // configuration values passed needs to be quoted if quotes are needed in
 // the toml format.
+// Setting the config to nil will disable a built-in plugin
 func WithPlugin(name string, conf interface{}) RemoteOption {
 	return pluginConf{
 		name: name,


### PR DESCRIPTION
Disable cri plugin by default in containerd and allows an option to enable the plugin. This only
has an effect on containerd when supervised by dockerd. When containerd is managed outside of dockerd, the configuration is not effected.

fixes https://github.com/moby/moby/issues/37507