### PR TITLE
Fix error 500 on distribution endpoint

### DIFF
--- a/api/server/router/distribution/distribution_routes.go
+++ b/api/server/router/distribution/distribution_routes.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/errdefs"
 	"github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -42,9 +43,10 @@ func (s *distributionRouter) getDistributionInfo(ctx context.Context, w http.Res
 
 	image := vars["name"]
 
+	// TODO why is reference.ParseAnyReference() / reference.ParseNormalizedNamed() not using the reference.ErrTagInvalidFormat (and so on) errors?
 	ref, err := reference.ParseAnyReference(image)
 	if err != nil {
-		return err
+		return errdefs.InvalidParameter(err)
 	}
 	namedRef, ok := ref.(reference.Named)
 	if !ok {
@@ -52,7 +54,7 @@ func (s *distributionRouter) getDistributionInfo(ctx context.Context, w http.Res
 			// full image ID
 			return errors.Errorf("no manifest found for full image ID")
 		}
-		return errors.Errorf("unknown image reference format: %s", image)
+		return errdefs.InvalidParameter(errors.Errorf("unknown image reference format: %s", image))
 	}
 
 	distrepo, _, err := s.backend.GetRepository(ctx, namedRef, config)
@@ -66,7 +68,7 @@ func (s *distributionRouter) getDistributionInfo(ctx context.Context, w http.Res
 
 		taggedRef, ok := namedRef.(reference.NamedTagged)
 		if !ok {
-			return errors.Errorf("image reference not tagged: %s", image)
+			return errdefs.InvalidParameter(errors.Errorf("image reference not tagged: %s", image))
 		}
 
 		descriptor, err := distrepo.Tags(ctx).Get(ctx, taggedRef.Tag())
@@ -92,6 +94,16 @@ func (s *distributionRouter) getDistributionInfo(ctx context.Context, w http.Res
 	}
 	mnfst, err := mnfstsrvc.Get(ctx, distributionInspect.Descriptor.Digest)
 	if err != nil {
+		switch err {
+		case reference.ErrReferenceInvalidFormat,
+			reference.ErrTagInvalidFormat,
+			reference.ErrDigestInvalidFormat,
+			reference.ErrNameContainsUppercase,
+			reference.ErrNameEmpty,
+			reference.ErrNameTooLong,
+			reference.ErrNameNotCanonical:
+			return errdefs.InvalidParameter(err)
+		}
 		return err
 	}
 

--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -92,7 +92,7 @@ func (i *ImageService) GetRepository(ctx context.Context, ref reference.Named, a
 	// get repository info
 	repoInfo, err := i.registryService.ResolveRepository(ref)
 	if err != nil {
-		return nil, false, err
+		return nil, false, errdefs.InvalidParameter(err)
 	}
 	// makes sure name is not empty or `scratch`
 	if err := distribution.ValidateRepoName(repoInfo.Name); err != nil {


### PR DESCRIPTION
This PR consists of two commits


## 1. Return "invalid parameter" (4xx) errors for distribution

For errors related to the provided input, return an `errdefs.InvalidParameter()`,
so that they can be returned as a `4xx` error by the API.


## 2. Handle correct status codes for distribution errors

This assists to address a regression where distribution errors were not properly
handled, resulting in a generic 500 (internal server error) to be returned for
`/distribution/name/json` if you weren't authenticated, whereas it should return
a 40x (401).

This patch attempts to extract the HTTP status-code that was returned by the
distribution code, and falls back to returning a 500 status if unable to match.

Before this change:

    curl -v --unix-socket /var/run/docker.sock http://localhost/distribution/name/json
    > GET /distribution/name/json HTTP/1.1
    >
    < HTTP/1.1 500 Internal Server Error
    <
    {"message":"errors:\ndenied: requested access to the resource is denied\nunauthorized: authentication required\n"}
    * Curl_http_done: called premature == 0
    * Connection #0 to host localhost left intact

daemon logs:

    DEBU[2018-07-03T15:52:51.424950601Z] Calling GET /distribution/name/json
    DEBU[2018-07-03T15:52:53.179895572Z] FIXME: Got an API for which error does not match any expected type!!!: errors:
    denied: requested access to the resource is denied
    unauthorized: authentication required
      error_type=errcode.Errors module=api
    ERRO[2018-07-03T15:52:53.179942783Z] Handler for GET /distribution/name/json returned error: errors:
    denied: requested access to the resource is denied
    unauthorized: authentication required

With this patch applied:

    curl -v --unix-socket /var/run/docker.sock http://localhost/distribution/name/json
    > GET /distribution/name/json HTTP/1.1
    >
    < HTTP/1.1 403 Forbidden
    <
    {"message":"errors:\ndenied: requested access to the resource is denied\nunauthorized: authentication required\n"}
    * Curl_http_done: called premature == 0
    * Connection #0 to host localhost left intact

daemon logs:

    DEBU[2018-08-03T14:58:08.018726228Z] Calling GET /distribution/name/json

