### PR TITLE
Don not lose an error message from d.StartWithError in d.Start

### DIFF
--- a/internal/test/daemon/daemon.go
+++ b/internal/test/daemon/daemon.go
@@ -200,7 +200,7 @@ func (d *Daemon) Start(t testingT, args ...string) {
 		ht.Helper()
 	}
 	if err := d.StartWithError(args...); err != nil {
-		t.Fatalf("Error starting daemon with arguments: %v", args)
+		t.Fatalf("Error starting daemon with arguments %v : %v", args, err)
 	}
 }
 
@@ -324,8 +324,8 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 				return errors.Errorf("[%s] error querying daemon for root directory: %v", d.id, err)
 			}
 			return nil
-		case <-d.Wait:
-			return errors.Errorf("[%s] Daemon exited during startup", d.id)
+		case err := <-d.Wait:
+			return errors.Errorf("[%s] Daemon exited during startup: %v", d.id, err)
 		}
 	}
 }


### PR DESCRIPTION
Else it is harder to understand where we've failed in StartWithLogFile

We have an errror:

[d42ce729d0b06] waiting for daemon to start
[d42ce729d0b06] waiting for daemon to start
[d42ce729d0b06] waiting for daemon to start
[d42ce729d0b06] waiting for daemon to start
[d42ce729d0b06] waiting for daemon to start
[d42ce729d0b06] waiting for daemon to start
[d42ce729d0b06] waiting for daemon to start
[d42ce729d0b06] waiting for daemon to start
[d42ce729d0b06] waiting for daemon to start
[d42ce729d0b06] waiting for daemon to start
[d42ce729d0b06] waiting for daemon to start
[d42ce729d0b06] waiting for daemon to start
docker_cli_userns_test.go:27:
    s.d.StartWithBusybox(c, "--userns-remap", "default")
/go/src/github.com/docker/docker/internal/test/daemon/daemon.go:203:
    t.Fatalf("Error starting daemon with arguments: %v", args)
... Error: Error starting daemon with arguments: [--userns-remap default]

[d42ce729d0b06] exiting daemon

Likely it is "[..] Daemon exited during startup" case, but these error
message is lost

Also we lose the error returned by waiting daemon so also add it

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>