### PR TITLE
pkg/system: return nil explicitly

### DIFF
--- a/pkg/system/rm.go
+++ b/pkg/system/rm.go
@@ -34,7 +34,7 @@ func EnsureRemoveAll(dir string) error {
 	for {
 		err := os.RemoveAll(dir)
 		if err == nil {
-			return err
+			return nil
 		}
 
 		pe, ok := err.(*os.PathError)


### PR DESCRIPTION
Makes code less confusing.
Otherwise it looks like an error (typo of "==" instead "!=").

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>
