### PR TITLE
Bump mergo to v0.3.6

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -22,7 +22,7 @@ gotest.tools v2.1.0
 github.com/google/go-cmp v0.2.0
 
 github.com/RackSec/srslog 456df3a81436d29ba874f3590eeeee25d666f8a5
-github.com/imdario/mergo v0.3.5
+github.com/imdario/mergo v0.3.6
 golang.org/x/sync fd80eb99c8f653c847d294a001bdf2a3a6f768f5
 
 # buildkit

--- a/vendor/github.com/imdario/mergo/README.md
+++ b/vendor/github.com/imdario/mergo/README.md
@@ -27,7 +27,7 @@ It is ready for production use. [It is used in several projects by Docker, Googl
 
 ### Latest release
 
-[Release v0.3.4](https://github.com/imdario/mergo/releases/tag/v0.3.4).
+[Release v0.3.6](https://github.com/imdario/mergo/releases/tag/v0.3.6).
 
 ### Important note
 

--- a/vendor/github.com/imdario/mergo/merge.go
+++ b/vendor/github.com/imdario/mergo/merge.go
@@ -9,6 +9,7 @@
 package mergo
 
 import (
+	"fmt"
 	"reflect"
 )
 
@@ -127,6 +128,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 					if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
 						dstSlice = srcSlice
 					} else if config.AppendSlice {
+						if srcSlice.Type() != dstSlice.Type() {
+							return fmt.Errorf("cannot append two slice with different type (%s, %s)", srcSlice.Type(), dstSlice.Type())
+						}
 						dstSlice = reflect.AppendSlice(dstSlice, srcSlice)
 					}
 					dst.SetMapIndex(key, dstSlice)
@@ -150,6 +154,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 		if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
 			dst.Set(src)
 		} else if config.AppendSlice {
+			if src.Type() != dst.Type() {
+				return fmt.Errorf("cannot append two slice with different type (%s, %s)", src.Type(), dst.Type())
+			}
 			dst.Set(reflect.AppendSlice(dst, src))
 		}
 	case reflect.Ptr:


### PR DESCRIPTION
Diff is https://github.com/imdario/mergo/compare/v0.3.5...v0.3.6

```diff
diff --git a/merge.go b/merge.go
index 706b220..44f70a8 100644
--- a/merge.go
+++ b/merge.go
@@ -9,6 +9,7 @@
 package mergo
 import (
+       "fmt"
        "reflect"
 )
@@ -127,6 +128,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
                                        if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
                                                dstSlice = srcSlice
                                        } else if config.AppendSlice {
+                                               if srcSlice.Type() != dstSlice.Type() {
+                                                       return fmt.Errorf("cannot append two slice with different type (%s, %s)", srcSlice.Type(), dstSlice.Type())
+                                               }
                                                dstSlice = reflect.AppendSlice(dstSlice, srcSlice)
                                        }
                                        dst.SetMapIndex(key, dstSlice)
@@ -150,6 +154,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
                if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
                        dst.Set(src)
                } else if config.AppendSlice {
+                       if src.Type() != dst.Type() {
+                               return fmt.Errorf("cannot append two slice with different type (%s, %s)", src.Type(), dst.Type())
+                       }
                        dst.Set(reflect.AppendSlice(dst, src))
                }
        case reflect.Ptr:
```

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
