### PR TITLE
Temporarily disable failing tests on Windows RS3

### DIFF
--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -13,6 +15,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/internal/test/request"
+	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/go-check/check"
 )
 
@@ -55,6 +58,15 @@ func (s *DockerSuite) TestAPIImagesFilter(c *check.C) {
 }
 
 func (s *DockerSuite) TestAPIImagesSaveAndLoad(c *check.C) {
+	if runtime.GOOS == "windows" {
+		v, err := kernel.GetKernelVersion()
+		c.Assert(err, checker.IsNil)
+		build, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
+		if build == 16299 {
+			c.Skip("Temporarily disabled on RS3 builds")
+		}
+	}
+
 	testRequires(c, Network)
 	buildImageSuccessfully(c, "saveandload", build.WithDockerfile("FROM busybox\nENV FOO bar"))
 	id := getIDByName(c, "saveandload")
@@ -126,6 +138,15 @@ func (s *DockerSuite) TestAPIImagesHistory(c *check.C) {
 }
 
 func (s *DockerSuite) TestAPIImagesImportBadSrc(c *check.C) {
+	if runtime.GOOS == "windows" {
+		v, err := kernel.GetKernelVersion()
+		c.Assert(err, checker.IsNil)
+		build, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
+		if build == 16299 {
+			c.Skip("Temporarily disabled on RS3 builds")
+		}
+	}
+
 	testRequires(c, Network, SameHostDaemon)
 
 	server := httptest.NewServer(http.NewServeMux())


### PR DESCRIPTION
ping @johnstep @jhowardmsft this was a patch we had internally for CI running on RS3