### PR TITLE
Include original error when translating distribution errors

### DIFF
--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/docker/distribution/xfer"
 	"github.com/docker/docker/errdefs"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -70,11 +71,11 @@ func (e notFoundError) Error() string {
 	switch e.cause.Code {
 	case errcode.ErrorCodeDenied:
 		// ErrorCodeDenied is used when access to the repository was denied
-		return fmt.Sprintf("pull access denied for %s, repository does not exist or may require 'docker login'", reference.FamiliarName(e.ref))
+		return errors.Wrapf(e.cause, "pull access denied for %s, repository does not exist or may require 'docker login'", reference.FamiliarName(e.ref)).Error()
 	case v2.ErrorCodeManifestUnknown:
-		return fmt.Sprintf("manifest for %s not found", reference.FamiliarString(e.ref))
+		return errors.Wrapf(e.cause, "manifest for %s not found", reference.FamiliarString(e.ref)).Error()
 	case v2.ErrorCodeNameUnknown:
-		return fmt.Sprintf("repository %s not found", reference.FamiliarName(e.ref))
+		return errors.Wrapf(e.cause, "repository %s not found", reference.FamiliarName(e.ref)).Error()
 	}
 	// Shouldn't get here, but this is better than returning an empty string
 	return e.cause.Message


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/36565 (possibly); I don't have a test setup to test the reported issue; also not sure if this is the best approach

Before:

    curl -v -X POST --unix-socket /var/run/docker.sock "http://localhost/images/create?fromImage=library/busybox:lsfkjsdflkjsdf"
    {"message":"manifest for busybox:lsfkjsdflkjsdf not found"}

    curl -v -X POST --unix-socket /var/run/docker.sock "http://localhost/images/create?fromImage=library/nosuchimage:latest"
    {"message":"pull access denied for nosuchimage, repository does not exist or may require 'docker login'"}

After:

    curl -v -X POST --unix-socket /var/run/docker.sock "http://localhost/images/create?fromImage=library/busybox:lsfkjsdflkjsdf"
    {"message":"manifest for busybox:lsfkjsdflkjsdf not found: manifest unknown: manifest unknown"}

    curl -v -X POST --unix-socket /var/run/docker.sock "http://localhost/images/create?fromImage=library/nosuchimage:latest"
    {"message":"pull access denied for nosuchimage, repository does not exist or may require 'docker login': denied: requested access to the resource is denied"}
