### PR TITLE
hack/make.ps1: don't rely on GO_VERSION

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -130,7 +130,7 @@ Function Check-InContainer() {
 # outside of a container where it may be out of date with master.
 Function Verify-GoVersion() {
     Try {
-        $goVersionDockerfile=(Get-Content ".\Dockerfile" | Select-String "ENV GO_VERSION").ToString().Split(" ")[2]
+        $goVersionDockerfile=(Select-String -Path ".\Dockerfile" -Pattern "^FROM golang:").ToString().Split(" ")[1].SubString(7)
         $goVersionInstalled=(go version).ToString().Split(" ")[2].SubString(2)
     }
     Catch [Exception] {


### PR DESCRIPTION
This removes the last use of `ENV GO_VERSION` which happened to be in `hack/make.ps`. Once this is merged, we can remove `ENV GO_VERSION` from the Dockerfile.

Apparently one can't modify both `Dockerfile` and `hack/make.ps1` in a single commit (although I fail to understand why), so Dockerfile remains intact for now.