### PR TITLE
builder: do not cancel buildkit status request

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -258,9 +258,10 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 
 	eg.Go(func() error {
 		defer close(ch)
-		return b.controller.Status(&controlapi.StatusRequest{
-			Ref: id,
-		}, &statusProxy{streamProxy: streamProxy{ctx: ctx}, ch: ch})
+		// streamProxy.ctx is not set to ctx because when request is cancelled,
+		// only the build request has to be cancelled, not the status request.
+		stream := &statusProxy{streamProxy: streamProxy{ctx: context.TODO()}, ch: ch}
+		return b.controller.Status(&controlapi.StatusRequest{Ref: id}, stream)
 	})
 
 	eg.Go(func() error {


### PR DESCRIPTION
This fixes a bug when the build results in an error and instead of sending
the logs of the container to the client, it signals a cancelation.

The context should not be wired to the status request, as only the
build requests need to be canceled.

Signed-off-by: Tibor Vass <tibor@docker.com>