### PR TITLE
Fix #28814: use emulation for ConEmu and ConsoleZ

### DIFF
--- a/pkg/term/term_windows.go
+++ b/pkg/term/term_windows.go
@@ -62,13 +62,6 @@ func StdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
 		}
 	}
 
-	if os.Getenv("ConEmuANSI") == "ON" || os.Getenv("ConsoleZVersion") != "" {
-		// The ConEmu and ConsoleZ terminals emulate ANSI on output streams well.
-		emulateStdin = true
-		emulateStdout = false
-		emulateStderr = false
-	}
-
 	// Temporarily use STD_INPUT_HANDLE, STD_OUTPUT_HANDLE and
 	// STD_ERROR_HANDLE from syscall rather than x/sys/windows as long as
 	// go-ansiterm hasn't switch to x/sys/windows.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I remove a special-case handling of the ConEmu and ConsoleZ console emulators, which was causing problems with pipes. ConEmu and ConsoleZ will now be handled like any other console emulator in windows: by using emulated streams that handle VT codes inside Go.

**- How I did it**
By removing an `if` block

**- How to verify it**
 I verified it on Windows 10 1803 (17134.112) by using ConEmu 180626 and ConsoleZ 1.18.3.18143

```powershell
> echo 'FROM hello-world' | .\build\docker-windows-amd64.exe build -t temp -
Sending build context to Docker daemon  2.048kB
Step 1/1 : FROM hello-world
 ---> 2cb0d9787c4d
Successfully built 2cb0d9787c4d
Successfully tagged temp:latest
SECURITY WARNING: You are building a Docker image from Windows against a non-Windows Docker host. All files and directories added to build context will have '-rwxr-xr-x' permissions. It is recommended to double check and reset permissions for sensitive files and directories.
~\git\cli [master ≡ +0 ~1 -0 !]
> echo 'FROM hello-world' | docker build -t temp -
unable to prepare context: failed to peek context header from STDIN: Función incorrecta.
```

I have also verified that removing this block does not produce a regression on https://github.com/moby/moby/issues/25475

**- Description for the changelog**
Fix pipe handling in ConEmu and ConsoleZ
