### PR TITLE
Fix the several typos detected by github.com/client9/misspell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 FROM base AS criu
 # Install CRIU for checkpoint/restore support
 ENV CRIU_VERSION 3.6
-# Install dependancy packages specific to criu
+# Install dependency packages specific to criu
 RUN apt-get update && apt-get install -y \
 	libnet-dev \
 	libprotobuf-c0-dev \

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -162,7 +162,7 @@
 
 			# Alexander Morozov contributed many features to Docker, worked on the premise of 
 			# what later became containerd (and worked on that too), and made a "stupid" Go
-			# vendor tool specificaly for docker/docker needs: vndr (https://github.com/LK4D4/vndr).
+			# vendor tool specifically for docker/docker needs: vndr (https://github.com/LK4D4/vndr).
 			# Not many know that Alexander is a master negotiator, being able to change course
 			# of action with a single "Nope, we're not gonna do that".
 			"lk4d4",

--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -374,7 +374,7 @@ func (p *puller) Snapshot(ctx context.Context) (cache.ImmutableRef, error) {
 		childrenHandler := images.ChildrenHandler(p.is.ContentStore)
 		// Set any children labels for that content
 		childrenHandler = images.SetChildrenLabels(p.is.ContentStore, childrenHandler)
-		// Filter the childen by the platform
+		// Filter the children by the platform
 		childrenHandler = images.FilterPlatforms(childrenHandler, platforms.Default())
 
 		handlers = append(handlers,

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -321,7 +321,7 @@ func (daemon *Daemon) cleanupSecretDir(c *container.Container) {
 		logrus.WithError(err).WithField("container", c.ID).Warn("error getting secrets mount path for container")
 	}
 	if err := mount.RecursiveUnmount(dir); err != nil {
-		logrus.WithField("dir", dir).WithError(err).Warn("Error while attmepting to unmount dir, this may prevent removal of container.")
+		logrus.WithField("dir", dir).WithError(err).Warn("Error while attempting to unmount dir, this may prevent removal of container.")
 	}
 	if err := os.RemoveAll(dir); err != nil && !os.IsNotExist(err) {
 		logrus.WithField("dir", dir).WithError(err).Error("Error removing dir.")

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -462,7 +462,7 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 	}
 
 	// Copy all mounts from spec to defaultMounts, except for
-	//  - mounts overriden by a user supplied mount;
+	//  - mounts overridden by a user supplied mount;
 	//  - all mounts under /dev if a user supplied /dev is present;
 	//  - /dev/shm, in case IpcMode is none.
 	// While at it, also
@@ -539,7 +539,7 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 		case mount.SLAVE, mount.RSLAVE:
 			var fallback bool
 			if err := ensureSharedOrSlave(m.Source); err != nil {
-				// For backwards compatability purposes, treat mounts from the daemon root
+				// For backwards compatibility purposes, treat mounts from the daemon root
 				// as special since we automatically add rslave propagation to these mounts
 				// when the user did not set anything, so we should fallback to the old
 				// behavior which is to use private propagation which is normally the

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -316,7 +316,7 @@ func (daemon *Daemon) reloadNetworkDiagnosticPort(conf *config.Config, attribute
 		}
 		return nil
 	}
-	// Enable the network diagnostic if the flag is set with a valid port withing the range
+	// Enable the network diagnostic if the flag is set with a valid port within the range
 	logrus.WithFields(logrus.Fields{"port": conf.NetworkDiagnosticPort, "ip": "127.0.0.1"}).Warn("Starting network diagnostic server")
 	daemon.netController.StartDiagnostic(conf.NetworkDiagnosticPort)
 

--- a/daemon/volumes_linux.go
+++ b/daemon/volumes_linux.go
@@ -10,7 +10,7 @@ import (
 
 // validateBindDaemonRoot ensures that if a given mountpoint's source is within
 // the daemon root path, that the propagation is setup to prevent a container
-// from holding private refereneces to a mount within the daemon root, which
+// from holding private references to a mount within the daemon root, which
 // can cause issues when the daemon attempts to remove the mountpoint.
 func (daemon *Daemon) validateBindDaemonRoot(m mount.Mount) (bool, error) {
 	if m.Type != mount.TypeBind {

--- a/errdefs/helpers_test.go
+++ b/errdefs/helpers_test.go
@@ -26,11 +26,11 @@ func TestNotFound(t *testing.T) {
 
 func TestConflict(t *testing.T) {
 	if IsConflict(errTest) {
-		t.Fatalf("did not expect conflcit error, got %T", errTest)
+		t.Fatalf("did not expect conflict error, got %T", errTest)
 	}
 	e := Conflict(errTest)
 	if !IsConflict(e) {
-		t.Fatalf("expected conflcit error, got: %T", e)
+		t.Fatalf("expected conflict error, got: %T", e)
 	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -126,7 +126,7 @@ fi
 # test whether "libdevmapper.h" is new enough to support deferred remove
 # functionality. We favour libdm_dlsym_deferred_remove over
 # libdm_no_deferred_remove in dynamic cases because the binary could be shipped
-# with a newer libdevmapper than the one it was built wih.
+# with a newer libdevmapper than the one it was built with.
 if \
 	command -v gcc &> /dev/null \
 	&& ! ( echo -e  '#include <libdevmapper.h>\nint main() { dm_task_deferred_remove(NULL); }'| gcc -xc - -o /dev/null $(pkg-config --libs devmapper) &> /dev/null ) \

--- a/volume/mounts/mounts.go
+++ b/volume/mounts/mounts.go
@@ -63,7 +63,7 @@ type MountPoint struct {
 	Spec mounttypes.Mount
 
 	// Some bind mounts should not be automatically created.
-	// (Some are auto-created for backwards-compatability)
+	// (Some are auto-created for backwards-compatibility)
 	// This is checked on the API but setting this here prevents race conditions.
 	// where a bind dir existed during validation was removed before reaching the setup code.
 	SkipMountpointCreation bool


### PR DESCRIPTION
**- What I did**

This pull request fixes typos in this repository. Although I am not a native English speaker, [misspell](https://github.com/client9/misspell) detected obvious mistakes for us. I've fixed them except for false positives.

**- How I did it**

```
$ misspell .
.mailmap:370:0: "Sebastiaan" is a misspelling of "Sebastian"
.mailmap:371:0: "Sebastiaan" is a misspelling of "Sebastian"
Dockerfile:38:10: "dependancy" is a misspelling of "dependency"
AUTHORS:1612:0: "Sebastiaan" is a misspelling of "Sebastian"
AUTHORS:1613:0: "Sebastiaan" is a misspelling of "Sebastian"
MAINTAINERS:165:17: "specificaly" is a misspelling of "specifically"
MAINTAINERS:439:9: "Sebastiaan" is a misspelling of "Sebastian"
builder/builder-next/adapters/containerimage/pull.go:377:16: "childen" is a misspelling of "children"
daemon/container_operations_unix.go:324:64: "attmepting" is a misspelling of "attempting"
daemon/oci_linux.go:465:14: "overriden" is a misspelling of "overridden"
daemon/oci_linux.go:542:21: "compatability" is a misspelling of "compatibility"
daemon/reload.go:319:71: "withing" is a misspelling of "within"
daemon/volumes_linux.go:13:24: "refereneces" is a misspelling of "references"
errdefs/helpers_test.go:29:27: "conflcit" is a misspelling of "conflict"
errdefs/helpers_test.go:33:21: "conflcit" is a misspelling of "conflict"
hack/make.sh:129:54: "wih" is a misspelling of "with"
integration-cli/docker_api_containers_test.go:1065:6: "waitres" is a misspelling of "waiters"
vendor/github.com/Microsoft/go-winio/sd.go:90:53: "aribtrary" is a misspelling of "arbitrary"
vendor/github.com/Microsoft/hcsshim/cgo.go:6:49: "comming" is a misspelling of "coming"
vendor/github.com/Microsoft/hcsshim/hnsnetwork.go:10:13: "assoicated" is a misspelling of "associated"
vendor/github.com/Microsoft/hcsshim/hnsnetwork.go:18:14: "assoicated" is a misspelling of "associated"
vendor/github.com/Microsoft/hcsshim/container.go:755:51: "syncronization" is a misspelling of "synchronization"
vendor/github.com/Microsoft/hcsshim/interface.go:102:78: "seperated" is a misspelling of "separated"
vendor/github.com/Microsoft/hcsshim/process.go:368:45: "syncronization" is a misspelling of "synchronization"
vendor/github.com/Microsoft/opengcs/service/gcsutils/remotefs/defs.go:40:29: "unkown" is a misspelling of "unknown"
vendor/github.com/armon/go-metrics/start.go:10:61: "seperate" is a misspelling of "separate"
vendor/github.com/aws/aws-sdk-go/aws/endpoints/endpoints.go:38:57: "unkonwn" is a misspelling of "unknown"
vendor/github.com/aws/aws-sdk-go/aws/session/env_config.go:81:42: "Authroity" is a misspelling of "Authority"
vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go:728:11: "muliple" is a misspelling of "multiple"
vendor/github.com/aws/aws-sdk-go/service/sts/api.go:17:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/sts/api.go:18:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/sts/api.go:197:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/sts/api.go:198:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/sts/api.go:370:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/sts/api.go:371:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/sts/api.go:572:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/sts/api.go:573:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/sts/api.go:684:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/sts/api.go:685:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/sts/api.go:759:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/sts/api.go:760:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/sts/api.go:928:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/sts/api.go:929:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:19:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:20:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:122:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:123:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:214:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:215:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:319:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:320:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:433:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:434:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:534:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:535:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:626:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:627:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:717:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:718:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:808:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:809:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:898:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:899:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:986:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:987:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1079:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1080:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1169:72: "complets" is a misspelling of "completes"
vendor/github.com/containerd/cgroups/subsystem.go:44:3: "avaliable" is a misspelling of "available"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1170:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1308:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1309:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1391:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1392:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1530:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1531:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1676:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1677:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1819:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1820:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1901:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:1902:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2044:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2045:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2142:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2143:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2291:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2292:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2437:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2438:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2519:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2520:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2614:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2615:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2704:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2705:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2822:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2823:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2920:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:2921:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:3007:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:3008:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:3099:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:3100:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:3212:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:3213:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:3303:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:3304:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:3387:72: "complets" is a misspelling of "completes"
vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go:3388:3: "successfuly" is a misspelling of "successfully"
vendor/github.com/containerd/containerd/api/services/content/v1/content.proto:58:45: "ommitted" is a misspelling of "omitted"
vendor/github.com/containerd/containerd/api/services/content/v1/content.pb.go:446:45: "ommitted" is a misspelling of "omitted"
vendor/github.com/containerd/containerd/api/services/content/v1/content.pb.go:661:45: "ommitted" is a misspelling of "omitted"
vendor/github.com/containerd/containerd/remotes/docker/fetcher.go:120:35: "considerd" is a misspelling of "considered"
vendor/github.com/containerd/go-runc/runc.go:37:48: "avaliable" is a misspelling of "available"
vendor/github.com/containerd/go-runc/runc.go:174:41: "sucessfully" is a misspelling of "successfully"
vendor/github.com/containerd/go-runc/runc.go:253:41: "sucessfully" is a misspelling of "successfully"
vendor/github.com/containerd/go-runc/runc.go:673:42: "sucessfully" is a misspelling of "successfully"
vendor/github.com/containerd/go-runc/runc.go:699:41: "sucessfully" is a misspelling of "successfully"
vendor/github.com/containerd/ttrpc/client.go:248:21: "unkown" is a misspelling of "unknown"
vendor/github.com/coreos/pkg/capnslog/init.go:35:13: "pacakge" is a misspelling of "package"
vendor/github.com/deckarep/golang-set/set.go:45:8: "emtpy" is a misspelling of "empty"
vendor/github.com/docker/go-metrics/README.md:73:54: "avaliable" is a misspelling of "available"
vendor/github.com/docker/libkv/store/consul/consul.go:27:7: "explicitely" is a misspelling of "explicitly"
vendor/github.com/docker/libkv/store/consul/consul.go:432:37: "explicitely" is a misspelling of "explicitly"
vendor/github.com/docker/libkv/store/consul/consul.go:452:31: "explicitely" is a misspelling of "explicitly"
vendor/github.com/docker/libtrust/util.go:155:56: "ommitted" is a misspelling of "omitted"
vendor/github.com/go-check/check/check.go:706:22: "syncronous" is a misspelling of "synchronous"
vendor/github.com/go-check/check/check.go:865:22: "syncronous" is a misspelling of "synchronous"
vendor/github.com/go-ini/ini/error.go:1:18: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/README_ZH.md:428:7: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/README_ZH.md:500:7: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/README_ZH.md:560:5: "Embeded" is a misspelling of "Embedded"
vendor/github.com/go-ini/ini/README_ZH.md:572:2: "Embeded" is a misspelling of "Embedded"
vendor/github.com/go-ini/ini/README_ZH.md:576:15: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/README_ZH.md:577:3: "Embeded" is a misspelling of "Embedded"
vendor/github.com/go-ini/ini/README_ZH.md:591:7: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/README_ZH.md:596:1: "Embeded" is a misspelling of "Embedded"
vendor/github.com/go-ini/ini/README_ZH.md:678:7: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/README_ZH.md:708:7: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/ini.go:1:18: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/key.go:1:18: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/README.md:435:7: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/README.md:507:7: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/README.md:569:5: "Embeded" is a misspelling of "Embedded"
vendor/github.com/go-ini/ini/README.md:581:2: "Embeded" is a misspelling of "Embedded"
vendor/github.com/go-ini/ini/README.md:585:15: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/README.md:586:3: "Embeded" is a misspelling of "Embedded"
vendor/github.com/go-ini/ini/README.md:600:7: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/README.md:605:1: "Embeded" is a misspelling of "Embedded"
vendor/github.com/go-ini/ini/README.md:687:7: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/README.md:717:7: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/parser.go:1:18: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/go-ini/ini/parser.go:277:11: "unknwon" is a misspelling of "unknown"
vendor/github.com/go-ini/ini/section.go:1:18: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/godbus/dbus/auth_sha1.go:63:29: "occured" is a misspelling of "occurred"
vendor/github.com/go-check/check/checkers.go:215:6: "conjuction" is a misspelling of "conjunction"
vendor/github.com/godbus/dbus/auth.go:131:9: "occured" is a misspelling of "occurred"
vendor/github.com/go-ini/ini/struct.go:1:18: "Unknwon" is a misspelling of "Unknown"
vendor/github.com/godbus/dbus/doc.go:58:56: "Similarily" is a misspelling of "Similarly"
vendor/github.com/godbus/dbus/encoder.go:63:42: "underyling" is a misspelling of "underlying"
vendor/github.com/godbus/dbus/conn.go:206:15: "appropiate" is a misspelling of "appropriate"
vendor/github.com/godbus/dbus/conn.go:352:22: "occured" is a misspelling of "occurred"
vendor/github.com/godbus/dbus/conn.go:614:23: "containes" is a misspelling of "contains"
vendor/github.com/godbus/dbus/sig.go:165:57: "successfull" is a misspelling of "successful"
vendor/github.com/gogo/protobuf/gogoproto/doc.go:118:128: "avialable" is a misspelling of "available"
vendor/github.com/gogo/protobuf/gogoproto/doc.go:164:19: "seperate" is a misspelling of "separate"
vendor/github.com/gogo/protobuf/gogoproto/doc.go:165:37: "independant" is a misspelling of "independent"
vendor/github.com/google/certificate-transparency-go/x509/verify.go:53:50: "comparision" is a misspelling of "comparison"
vendor/github.com/hashicorp/consul/api/api.go:39:47: "overriden" is a misspelling of "overridden"
vendor/github.com/hashicorp/consul/api/health.go:107:20: "retreive" is a misspelling of "retrieve"
vendor/github.com/hashicorp/consul/api/semaphore.go:126:54: "encounted" is a misspelling of "encountered"
vendor/github.com/hashicorp/go-memdb/txn.go:509:16: "mroe" is a misspelling of "more"
vendor/github.com/hashicorp/go-msgpack/codec/rpc.go:20:34: "accomodates" is a misspelling of "accommodates"
vendor/github.com/hashicorp/go-msgpack/codec/simple.go:425:37: "preceeded" is a misspelling of "preceded"
vendor/github.com/hashicorp/go-msgpack/codec/simple.go:430:7: "Lenght" is a misspelling of "Length"
vendor/github.com/hashicorp/go-multierror/multierror.go:43:12: "implementatin" is a misspelling of "implementations"
vendor/github.com/hashicorp/memberlist/net.go:668:13: "compresion" is a misspelling of "compression"
vendor/github.com/hashicorp/memberlist/memberlist.go:624:37: "maintanence" is a misspelling of "maintenance"
vendor/github.com/hashicorp/serf/serf/event.go:165:4: "Clera" is a misspelling of "Clear"
vendor/github.com/imdario/mergo/merge.go:209:93: "overriden" is a misspelling of "overridden"
vendor/github.com/miekg/dns/edns.go:493:16: "implementes" is a misspelling of "implements"
vendor/github.com/mistifyio/go-zfs/README.md:32:17: "ommitted" is a misspelling of "omitted"
vendor/github.com/moby/buildkit/solver/jobs.go:29:62: "happends" is a misspelling of "happens"
vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c:214:54: "desparate" is a misspelling of "desperate"
vendor/github.com/opentracing-contrib/go-stdlib/nethttp/server.go:50:15: "overriden" is a misspelling of "overridden"
vendor/github.com/prometheus/client_golang/prometheus/desc.go:68:25: "occured" is a misspelling of "occurred"
vendor/github.com/prometheus/common/model/silence.go:62:51: "definiton" is a misspelling of "definition"
vendor/github.com/spf13/pflag/ip_slice.go:77:4: "Emtpy" is a misspelling of "Empty"
vendor/github.com/ugorji/go/codec/0doc.go:70:18: "idiosynchracies" is a misspelling of "idiosyncrasies"
vendor/github.com/ugorji/go/codec/README.md:71:18: "idiosynchracies" is a misspelling of "idiosyncrasies"
vendor/github.com/ugorji/go/codec/binc.go:708:25: "accomodate" is a misspelling of "accommodate"
vendor/github.com/ugorji/go/codec/encode.go:299:18: "addresable" is a misspelling of "addressable"
vendor/github.com/ugorji/go/codec/encode.go:928:8: "accomodates" is a misspelling of "accommodates"
vendor/github.com/ugorji/go/codec/gen-helper.generated.go:20:35: "continously" is a misspelling of "continuously"
vendor/github.com/ugorji/go/codec/gen-helper.generated.go:29:57: "CONTINOUSLY" is a misspelling of "CONTINUOUSLY"
vendor/github.com/ugorji/go/codec/gen-helper.generated.go:35:57: "CONTINOUSLY" is a misspelling of "CONTINUOUSLY"
vendor/github.com/ugorji/go/codec/decode.go:1169:30: "accomodate" is a misspelling of "accommodate"
vendor/github.com/ugorji/go/codec/gen.go:79:14: "concious" is a misspelling of "conscious"
vendor/github.com/ugorji/go/codec/gen.go:163:58: "CONTINOUSLY" is a misspelling of "CONTINUOUSLY"
vendor/github.com/ugorji/go/codec/gen.go:1367:13: "accomodate" is a misspelling of "accommodate"
vendor/github.com/ugorji/go/codec/gen.go:1455:13: "accomodate" is a misspelling of "accommodate"
vendor/github.com/ugorji/go/codec/gen.go:1859:49: "symetrical" is a misspelling of "symmetrical"
vendor/github.com/ugorji/go/codec/json.go:491:24: "alse" is a misspelling of "else"
vendor/github.com/ugorji/go/codec/json.go:948:24: "alse" is a misspelling of "else"
vendor/github.com/ugorji/go/codec/rpc.go:28:34: "accomodates" is a misspelling of "accommodates"
vendor/github.com/ugorji/go/codec/simple.go:477:37: "preceeded" is a misspelling of "preceded"
vendor/github.com/ugorji/go/codec/simple.go:482:7: "Lenght" is a misspelling of "Length"
vendor/github.com/vbatts/tar-split/README.md:18:17: "utilitiy" is a misspelling of "utility"
vendor/github.com/vishvananda/netlink/conntrack_linux.go:288:42: "addres" is a misspelling of "address"
vendor/github.com/vishvananda/netlink/neigh_linux.go:244:30: "perfomance" is a misspelling of "performance"
vendor/github.com/vishvananda/netlink/link.go:598:47: "retrived" is a misspelling of "retrieved"
vendor/github.com/vishvananda/netlink/nl/addr_linux.go:50:14: "prefered" is a misspelling of "preferred"
vendor/github.com/vishvananda/netlink/nl/syscall.go:3:32: "atributes" is a misspelling of "attributes"
vendor/github.com/vishvananda/netlink/xfrm_state_linux.go:241:25: "constitue" is a misspelling of "constitutes"
vendor/github.com/vishvananda/netlink/xfrm_state_linux.go:250:25: "constitue" is a misspelling of "constitutes"
vendor/go.opencensus.io/plugin/ochttp/propagation/b3/b3.go:41:14: "reciever" is a misspelling of "receiver"
vendor/golang.org/x/net/internal/iana/const.go:31:37: "ECT" is a misspelling of "ETC"
vendor/golang.org/x/net/internal/iana/const.go:32:33: "ECT" is a misspelling of "ETC"
vendor/golang.org/x/net/internal/iana/const.go:33:33: "ECT" is a misspelling of "ETC"
vendor/github.com/ugorji/go/codec/fast-path.generated.go:26:8: "symetrical" is a misspelling of "symmetrical"
vendor/golang.org/x/sys/windows/types_windows.go:1355:39: "retreive" is a misspelling of "retrieve"
volume/mounts/mounts.go:66:41: "compatability" is a misspelling of "compatibility"
```

**- How to verify it**

I carefully checked the detections one by one, and fixed the only necessary ones. After my changes:

```
$ misspell .
.mailmap:370:0: "Sebastiaan" is a misspelling of "Sebastian"
.mailmap:371:0: "Sebastiaan" is a misspelling of "Sebastian"
AUTHORS:1612:0: "Sebastiaan" is a misspelling of "Sebastian"
AUTHORS:1613:0: "Sebastiaan" is a misspelling of "Sebastian"
MAINTAINERS:439:9: "Sebastiaan" is a misspelling of "Sebastian"
integration-cli/docker_api_containers_test.go:1065:6: "waitres" is a misspelling of "waiters"
vendor/github.com/ugorji/go/codec/json.go:491:24: "alse" is a misspelling of "else"
vendor/github.com/ugorji/go/codec/json.go:948:24: "alse" is a misspelling of "else"
vendor/golang.org/x/net/internal/iana/const.go:31:37: "ECT" is a misspelling of "ETC"
vendor/golang.org/x/net/internal/iana/const.go:32:33: "ECT" is a misspelling of "ETC"
vendor/golang.org/x/net/internal/iana/const.go:33:33: "ECT" is a misspelling of "ETC"
```

**- Description for the changelog**

None.