### PR TITLE
Ignore permission error when accessing certs.d directory

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -35,7 +35,11 @@ func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
 		hostDir := filepath.Join(CertsDir, cleanPath(hostname))
 		logrus.Debugf("hostDir: %s", hostDir)
 		if err := ReadCertsDirectory(tlsConfig, hostDir); err != nil {
-			return nil, err
+			if os.IsPermission(err) {
+				logrus.Debugf("error accessing %s: %v", hostDir, err)
+			} else {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

CertsDir is hardcoded to "/etc/docker/certs.d". On some distros the
/etc/docker directory is locked down (700). So we get a permission
denied error. At this point we can't tell if the directory is actually
present or not. but either way we can't read anything under it.

Please see https://github.com/docker/for-linux/issues/396 for a detailed description

**- How I did it**

At this point we have 2 options, we fail immediately which is the
current behavior. The other other option is to ignore the permission
denied and hope that the certs are not needed and try to continue. In
this change, we use the 2nd option to allow the process to continue
("docker manifest create"). Added a debug statement to log if we do have
a permission issue so it's easy to spot by using "-D" on the docker CLI
command line.

**- How to verify it**

This basically helps non-root users be able to execute the "docker
manifest create" without having to "sudo".

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Allow non-root users to run some CLI commands even when /etc/docker/certs.d/ directory is not accessible

**- A picture of a cute animal (not mandatory but encouraged)**

