### PR TITLE
Make mount private before mounting.

### DIFF
--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -134,10 +134,6 @@ func (daemon *Daemon) mountVolumes(container *container.Container) error {
 			opts = "rbind,rw"
 		}
 
-		if err := mount.Mount(m.Source, dest, bindMountType, opts); err != nil {
-			return err
-		}
-
 		// mountVolumes() seems to be called for temporary mounts
 		// outside the container. Soon these will be unmounted with
 		// lazy unmount option and given we have mounted the rbind,
@@ -150,6 +146,11 @@ func (daemon *Daemon) mountVolumes(container *container.Container) error {
 		if err := mount.MakeRPrivate(dest); err != nil {
 			return err
 		}
+
+		if err := mount.Mount(m.Source, dest, bindMountType, opts); err != nil {
+			return err
+		}
+
 	}
 
 	return nil

--- a/integration/container/copy_linux_test.go
+++ b/integration/container/copy_linux_test.go
@@ -1,0 +1,71 @@
+package container // import "github.com/docker/docker/integration/container"
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/pkg/mount"
+	"gotest.tools/assert"
+)
+
+// Makes sure copy does not leak shared mounts
+// Relates to https://github.com/moby/moby/issues/37624
+func TestCopyToContainerDoesNotLeakMounts(t *testing.T) {
+	defer setupTest(t)()
+
+	ctx := context.Background()
+	apiClient := testEnv.APIClient()
+
+	tmp, err := ioutil.TempDir("", t.Name())
+	assert.NilError(t, err)
+	defer func() {
+		assert.Check(t, os.RemoveAll(tmp), "could not create temp dir")
+	}()
+	assert.NilError(t, mount.MakeRShared(tmp), "error setting test mountpoint to shared")
+
+	mnt := filepath.Join(tmp, "mnt")
+	assert.NilError(t, os.Mkdir(mnt, 0755), "failed to make nested temp dir")
+
+	assert.Assert(t, mount.Mount("tmpfs", mnt, "tmpfs", ""), "failed to create tmpfs on host")
+	defer func() {
+		assert.Check(t, mount.RecursiveUnmount(tmp))
+	}()
+
+	cid := container.Run(t, ctx, apiClient,
+		container.WithAutoRemove,
+		container.WithCmd("top"),
+		container.WithBind(tmp, "/test"),
+	)
+
+	buf := bytes.NewBuffer(nil)
+	tw := tar.NewWriter(buf)
+	data := []byte("hello")
+	err = tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "foo",
+		Size:     int64(len(data)),
+	})
+	assert.Assert(t, err, "error writing tar header for test file to copy to container")
+
+	_, err = tw.Write(data)
+	assert.NilError(t, err, "error writing tar data file for test file to copy to container")
+	assert.NilError(t, tw.Close(), "error closing out tar file")
+
+	err = apiClient.CopyToContainer(ctx, cid, "/tmp/", buf, types.CopyToContainerOptions{})
+	assert.Assert(t, err, "copying to container failed")
+
+	exec, err := container.Exec(ctx, apiClient, cid, []string{"/bin/sh", "-c", "cat /proc/mounts | grep '/test/mnt'"})
+	assert.NilError(t, err, exec.Stderr())
+
+	out := strings.TrimSpace(exec.Stdout())
+	split := strings.Split(out, "\n")
+	assert.Equal(t, len(split), 1, out)
+}


### PR DESCRIPTION
Attempts to work-around a case where when `/` is a shared mount on the
host, when a user has a bind or a volume with submounts and performs a
`docker cp`, the volume mounts are duplicated in the container.

I do not expect that this is the right fix for this, but in testing it
at least seems to solve it. I am not sure what side effects this may
have right now. Would love to get another set of eyes on it.

Related to #37624

ping @kolyshkin 
