### PR TITLE
Add --device support for Windows

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -332,6 +332,30 @@ func (daemon *Daemon) createSpecWindowsFields(c *container.Container, s *specs.S
 		s.Windows.CredentialSpec = cs
 	}
 
+	// Do we have any assigned devices?
+	if len(c.HostConfig.Devices) > 0 {
+		if isHyperV {
+			return errors.New("device assignment is not supported for HyperV containers")
+		}
+		if system.GetOSVersion().Build < 17763 {
+			return errors.New("device assignment requires Windows builds RS5 (17763+) or later")
+		}
+		for _, deviceMapping := range c.HostConfig.Devices {
+			srcParts := strings.SplitN(deviceMapping.PathOnHost, "/", 2)
+			if len(srcParts) != 2 {
+				return errors.New("invalid device assignment path")
+			}
+			if srcParts[0] != "class" {
+				return errors.Errorf("invalid device assignment type: '%s' should be 'class'", srcParts[0])
+			}
+			wd := specs.WindowsDevice{
+				ID:     srcParts[1],
+				IDType: srcParts[0],
+			}
+			s.Windows.Devices = append(s.Windows.Devices, wd)
+		}
+	}
+
 	return nil
 }
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,6 +1,6 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim v0.7.12
+github.com/Microsoft/hcsshim v0.7.12-1
 github.com/Microsoft/go-winio v0.4.11
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git

--- a/vendor/github.com/Microsoft/hcsshim/interface.go
+++ b/vendor/github.com/Microsoft/hcsshim/interface.go
@@ -17,6 +17,11 @@ type MappedPipe = schema1.MappedPipe
 type HvRuntime = schema1.HvRuntime
 type MappedVirtualDisk = schema1.MappedVirtualDisk
 
+// AssignedDevice represents a device that has been directly assigned to a container
+//
+// NOTE: Support added in RS5
+type AssignedDevice = schema1.AssignedDevice
+
 // ContainerConfig is used as both the input of CreateContainer
 // and to convert the parameters to JSON for passing onto the HCS
 type ContainerConfig = schema1.ContainerConfig


### PR DESCRIPTION
Implements the --device forwarding for Windows daemons. This maps the physical
device into the container at runtime.

Ex:

docker run --device="class/<clsid>" <image> <cmd>

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>

@jhowardmsft - FYI