### PR TITLE
Bump API version to 1.39

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api // import "github.com/docker/docker/api"
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion = "1.38"
+	DefaultVersion = "1.39"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.


### PR DESCRIPTION
Signed-off-by: Daniel Hiltgen <daniel.hiltgen@docker.com>