### PR TITLE
Swagger: bump API version to v1.39

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.38"
+basePath: "/v1.39"
 info:
   title: "Docker Engine API"
-  version: "1.38"
+  version: "1.39"
   x-logo:
     url: "https://docs.docker.com/images/logo-docker-main.png"
   description: |
@@ -49,8 +49,8 @@ info:
     the URL is not supported by the daemon, a HTTP `400 Bad Request` error message
     is returned.
 
-    If you omit the version-prefix, the current version of the API (v1.38) is used.
-    For example, calling `/info` is the same as calling `/v1.38/info`. Using the
+    If you omit the version-prefix, the current version of the API (v1.39) is used.
+    For example, calling `/info` is the same as calling `/v1.39/info`. Using the
     API without a version-prefix is deprecated and will be removed in a future release.
 
     Engine releases in the near future should support this version of the API,


### PR DESCRIPTION
Follow up to https://github.com/moby/moby/pull/37640, which did not update the Swagger file. The API version history was already updated in https://github.com/moby/moby/pull/37472