### PR TITLE
vndr go-connections to v0.4.0 - drop support for TLS < 1.2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -16,7 +16,7 @@ github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 golang.org/x/net a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1
 golang.org/x/sys ac767d655b305d4e9612f5f6e33120b9176c4ad4
 github.com/docker/go-units 47565b4f722fb6ceae66b95f853feed578a4a51c # v0.3.3
-github.com/docker/go-connections 7beb39f0b969b075d1325fecb092faf27fd357b6
+github.com/docker/go-connections 7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0
 golang.org/x/text f21a4dfb5e38f5895301dc265a8def02365cc3d0 # v0.3.0
 gotest.tools v2.1.0
 github.com/google/go-cmp v0.2.0

--- a/vendor/github.com/docker/go-connections/tlsconfig/config.go
+++ b/vendor/github.com/docker/go-connections/tlsconfig/config.go
@@ -46,8 +46,6 @@ var acceptedCBCCiphers = []uint16{
 	tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
 	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
 	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-	tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-	tls.TLS_RSA_WITH_AES_128_CBC_SHA,
 }
 
 // DefaultServerAcceptedCiphers should be uses by code which already has a crypto/tls
@@ -67,8 +65,8 @@ var allTLSVersions = map[uint16]struct{}{
 // ServerDefault returns a secure-enough TLS configuration for the server TLS configuration.
 func ServerDefault(ops ...func(*tls.Config)) *tls.Config {
 	tlsconfig := &tls.Config{
-		// Avoid fallback by default to SSL protocols < TLS1.0
-		MinVersion:               tls.VersionTLS10,
+		// Avoid fallback by default to SSL protocols < TLS1.2
+		MinVersion:               tls.VersionTLS12,
 		PreferServerCipherSuites: true,
 		CipherSuites:             DefaultServerAcceptedCiphers,
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Update vendor of go-connections to latest release [v0.4.0](https://github.com/docker/go-connections/releases/tag/v0.4.0). Comparison of upstream changes: https://github.com/docker/go-connections/compare/7beb39f0b969b075d1325fecb092faf27fd357b6...7395e3f8aa162843a74ed6d48e79627d9792ac55

**- How I did it**

```
$ vi vendor.conf
$ make BIND_DIR=. shell
$ vndr github.com/docker/go-connections
```

**- How to verify it**

```
$ make BIND_DIR=. shell
$ vndr github.com/docker/go-connections
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

* Update go-connections to v0.4.0

**- A picture of a cute animal (not mandatory but encouraged)**

🐭 

cc @dmcgowan @vdemeester @justincormack 