### PR TITLE
remove experimental guard for buildkit

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -231,8 +231,7 @@ func (br *buildRouter) postBuild(ctx context.Context, w http.ResponseWriter, r *
 	}
 
 	// check if the builder feature has been enabled from daemon as well.
-	if buildOptions.Version == types.BuilderBuildKit &&
-		(br.builderVersion != types.BuilderBuildKit || !br.daemon.HasExperimental()) {
+	if buildOptions.Version == types.BuilderBuildKit && br.builderVersion != types.BuilderBuildKit {
 		return errdefs.InvalidParameter(errors.New("buildkit is not enabled on daemon"))
 	}
 

--- a/api/server/router/session/session.go
+++ b/api/server/router/session/session.go
@@ -24,6 +24,6 @@ func (r *sessionRouter) Routes() []router.Route {
 
 func (r *sessionRouter) initRoutes() {
 	r.routes = []router.Route{
-		router.Experimental(router.NewPostRoute("/session", r.startSession)),
+		router.NewPostRoute("/session", r.startSession),
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Allow buildkit builds to run without experimental mode enabled. Buildkit can now be twiddled with a specific flag https://github.com/moby/moby/pull/37593

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
+ Bring buildkit builds out of experimental.

**- A picture of a cute animal (not mandatory but encouraged)**

🐈 