### PR TITLE
api/server, dockerversion: modify context key

### DIFF
--- a/api/server/httputils/httputils.go
+++ b/api/server/httputils/httputils.go
@@ -12,10 +12,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type contextKey string
-
 // APIVersionKey is the client's requested API version.
-const APIVersionKey contextKey = "api-version"
+type APIVersionKey struct{}
 
 // APIFunc is an adapter to allow the use of ordinary functions as Docker API endpoints.
 // Any function that has the appropriate signature can be registered as an API endpoint (e.g. getVersion).
@@ -83,7 +81,7 @@ func VersionFromContext(ctx context.Context) string {
 		return ""
 	}
 
-	if val := ctx.Value(APIVersionKey); val != nil {
+	if val := ctx.Value(APIVersionKey{}); val != nil {
 		return val.(string)
 	}
 

--- a/api/server/middleware/version.go
+++ b/api/server/middleware/version.go
@@ -58,7 +58,7 @@ func (v VersionMiddleware) WrapHandler(handler func(ctx context.Context, w http.
 		if versions.GreaterThan(apiVersion, v.defaultVersion) {
 			return versionUnsupportedError{version: apiVersion, maxVersion: v.defaultVersion}
 		}
-		ctx = context.WithValue(ctx, httputils.APIVersionKey, apiVersion)
+		ctx = context.WithValue(ctx, httputils.APIVersionKey{}, apiVersion)
 		return handler(ctx, w, r, vars)
 	}
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -129,8 +129,7 @@ func (s *Server) makeHTTPHandler(handler httputils.APIFunc) http.HandlerFunc {
 
 		// use intermediate variable to prevent "should not use basic type
 		// string as key in context.WithValue" golint errors
-		var ki interface{} = dockerversion.UAStringKey
-		ctx := context.WithValue(context.Background(), ki, r.Header.Get("User-Agent"))
+		ctx := context.WithValue(context.Background(), dockerversion.UAStringKey{}, r.Header.Get("User-Agent"))
 		handlerFunc := s.handlerWithGlobalMiddlewares(handler)
 
 		vars := mux.Vars(r)

--- a/dockerversion/useragent.go
+++ b/dockerversion/useragent.go
@@ -10,7 +10,7 @@ import (
 )
 
 // UAStringKey is used as key type for user-agent string in net/context struct
-const UAStringKey = "upstream-user-agent"
+type UAStringKey struct{}
 
 // DockerUserAgent is the User-Agent the Docker client uses to identify itself.
 // In accordance with RFC 7231 (5.5.3) is of the form:
@@ -39,9 +39,9 @@ func DockerUserAgent(ctx context.Context) string {
 func getUserAgentFromContext(ctx context.Context) string {
 	var upstreamUA string
 	if ctx != nil {
-		var ki interface{} = ctx.Value(UAStringKey)
+		var ki interface{} = ctx.Value(UAStringKey{})
 		if ki != nil {
-			upstreamUA = ctx.Value(UAStringKey).(string)
+			upstreamUA = ctx.Value(UAStringKey{}).(string)
 		}
 	}
 	return upstreamUA


### PR DESCRIPTION
Signed-off-by: KimMachineGun <geon0250@gmail.com>

**- What I did**
Currently, the `APIVersionKey` is a string type, so basically, there are some possibilities of key conflict with another key.
This change makes it to use another type (with an empty struct) so that it can avoid any unexpected conflicts.
 \+ And the empty struct type has a (very) tiny benefit to allocate memory.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
Modify context key to empty struct type value.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/20117947/44439464-97b07400-a5fe-11e8-88af-32ab4bcf2933.png)
Moby~
