### PR TITLE
builder: temporarily disable bridge networking when using buildkit

### DIFF
--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@ -18,16 +18,13 @@ import (
 
 const networkName = "bridge"
 
-func init() {
-	// FIXME: https://github.com/moby/moby/issues/37676
-	runcexecutor.DisableSubReaper()
-}
-
 func newExecutor(root string, net libnetwork.NetworkController) (executor.Executor, error) {
+	// FIXME: fix bridge networking
+	_ = bridgeProvider{}
 	return runcexecutor.New(runcexecutor.Opt{
 		Root:              filepath.Join(root, "executor"),
 		CommandCandidates: []string{"docker-runc", "runc"},
-	}, &bridgeProvider{NetworkController: net})
+	}, nil)
 }
 
 type bridgeProvider struct {

--- a/vendor.conf
+++ b/vendor.conf
@@ -26,7 +26,7 @@ github.com/imdario/mergo v0.3.6
 golang.org/x/sync 1d60e4601c6fd243af51cc01ddf169918a5407ca
 
 # buildkit
-github.com/moby/buildkit 46f9075ab68a07df2c40ae6e240ce4f9392b3a66 git://github.com/tiborvass/buildkit.git
+github.com/moby/buildkit 49906c62925ed429ec9174a0b6869982967f1a39
 github.com/tonistiigi/fsutil b19464cd1b6a00773b4f2eb7acf9c30426f9df42
 github.com/grpc-ecosystem/grpc-opentracing 8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go 1361b9cd60be79c4c3a7fa9841b3c132e40066a7

--- a/vendor/github.com/moby/buildkit/executor/runcexecutor/executor.go
+++ b/vendor/github.com/moby/buildkit/executor/runcexecutor/executor.go
@@ -404,12 +404,6 @@ func (s *forwardIO) writeCloserToFile(wc io.WriteCloser) (*os.File, error) {
 var subReaperOnce sync.Once
 var subReaperError error
 
-// DisableSubReaper prevents setting subreaper on the current process.
-// Do not rely on this function it may change or be removed.
-func DisableSubReaper() {
-	subReaperOnce.Do(func() {})
-}
-
 func setSubReaper() error {
 	subReaperOnce.Do(func() {
 		subReaperError = runcsystem.SetSubreaper(1)

--- a/vendor/github.com/moby/buildkit/vendor.conf
+++ b/vendor/github.com/moby/buildkit/vendor.conf
@@ -14,7 +14,7 @@ google.golang.org/grpc v1.12.0
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
 golang.org/x/net 0ed95abb35c445290478a5348a7b38bb154135fd
 github.com/gogo/protobuf v1.0.0
-github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
+github.com/gogo/googleapis b23578765ee54ff6bceff57f397d833bf4ca6869
 github.com/golang/protobuf v1.1.0
 github.com/containerd/continuity d3c23511c1bf5851696cba83143d9cbcd666869b
 github.com/opencontainers/image-spec v1.0.1


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>