### PR TITLE
Fix incorrect spelling in error message

### DIFF
--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -50,7 +50,7 @@ func New(info logger.Info) (logger.Logger, error) {
 			return nil, err
 		}
 		if capval <= 0 {
-			return nil, fmt.Errorf("max-size should be a positive numbler")
+			return nil, fmt.Errorf("max-size must be a positive number")
 		}
 	}
 	var maxFiles = 1


### PR DESCRIPTION
Someone asked me to take a look at some logic in this file and now I can't unsee the misspelled "number" in the error message. :innocent: 

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>

