### PR TITLE
daemon/setMounts(): remove dead code

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -494,12 +494,6 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 
 	s.Mounts = defaultMounts
 	for _, m := range mounts {
-		for _, cm := range s.Mounts {
-			if cm.Destination == m.Destination {
-				return duplicateMountPointError(m.Destination)
-			}
-		}
-
 		if m.Source == "tmpfs" {
 			data := m.Data
 			parser := volumemounts.NewParser("linux")


### PR DESCRIPTION
Since PR #11353 (commit 7804cd36eec45c "Filter out default mounts that
are override by user") there can be no duplicated mounts in the list,
so the check is redundant.

This should speed up container start by a nanosecond or two.