### PR TITLE
daemon/setMounts(): don't let user mounts overshadow spec mounts

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -627,6 +627,11 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 		}
 	}
 
+	// make sure mounts are not shadowing other mounts
+	sort.SliceStable(s.Mounts, func(i, j int) bool {
+		return s.Mounts[i].Destination < s.Mounts[j].Destination
+	})
+
 	return nil
 }
 
@@ -797,7 +802,6 @@ func (daemon *Daemon) createSpec(c *container.Container) (retSpec *specs.Spec, e
 	}
 	ms = append(ms, secretMounts...)
 
-	sort.Sort(mounts(ms))
 	if err := setMounts(daemon, &s, c, ms); err != nil {
 		return nil, fmt.Errorf("linux mounts: %v", err)
 	}


### PR DESCRIPTION
There are some scenarios in which a user-supplied mount overshadows
a one from spec. For example, in case of `docker run -v /tmp:/sys/fs`
the spec-supplied /sys/fs/cgroup mount will not be visible from
inside the container since user-supplied mount /sys/fs will be mounted
later.

The solution in this commit is to sort mounts 
so that the shallower ones (like /a/b) will come before deeper ones
(like /a/b/c). Note this changes the order of mounts but AFAIK it is
not important (except for the case that this commit fixes).

Since sorting is now done for all mounts, there is no sense to
do sort of user mounts before calling setMounts(), so remove it.

NOTE there are many ways to sort mounts, such as:
 1. alphabetically (what this commit does);
 2. by number of slashes (as in daemon/volumes.go)
 3. by checking that later mounts are not prefixes for earlier ones,
    and swapping those if they are

I tried a few and settled on simple alphabetical sort, as
it does the job and its code is the simplest.

Fixes https://github.com/moby/moby/issues/37702