### PR TITLE
DockerSuite.TestAttachDetach: increase timeout

### DIFF
--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -170,7 +170,7 @@ func (s *DockerSuite) TestAttachDetach(c *check.C) {
 
 	select {
 	case <-ch:
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 		c.Fatal("timed out waiting for container to exit")
 	}
 


### PR DESCRIPTION
The following failure was observed on power CI:

> FAIL: docker_cli_attach_unix_test.go:127: DockerSuite.TestAttachDetach
>
> docker_cli_attach_unix_test.go:174:
> c.Fatal("timed out waiting for container to exit")
> ... Error: timed out waiting for container to exit

Allegedly it is caused by a very small timeout of 10ms,
and a general slowness of power today. Also note that
the timeout used to be 500ms before commit ae0883ce009daa2
("Move TestAttachDetach to integration-cli").

Increase the timeout to 100ms to avoid false failures.