### PR TITLE
Enable gcplogs driver on windows

### DIFF
--- a/daemon/logdrivers_windows.go
+++ b/daemon/logdrivers_windows.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/docker/docker/daemon/logger/awslogs"
 	_ "github.com/docker/docker/daemon/logger/etwlogs"
 	_ "github.com/docker/docker/daemon/logger/fluentd"
+	_ "github.com/docker/docker/daemon/logger/gcplogs"
 	_ "github.com/docker/docker/daemon/logger/gelf"
 	_ "github.com/docker/docker/daemon/logger/jsonfilelog"
 	_ "github.com/docker/docker/daemon/logger/logentries"


### PR DESCRIPTION
Signed-off-by: Taylan Isikdemir <taylani@google.com>

**- What I did**
Enabled gcplogs (stackdriver) log driver on windows.

**- How to verify it**
1. Install dockerd on a Windows VM which includes the change in this PR
2. Run a container with gcplogs driver. See [gcplogs documentation](https://docs.docker.com/config/containers/logging/gcplogs) for configuration details.
e.g.  docker run --log-driver=gcplogs microsoft/windowsservercore cmd /C echo "hello"
3. Verify that container logs show up in your target stackdriver

