### PR TITLE
hack/make.ps1: know where we failed

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -437,6 +437,7 @@ Try {
 }
 Catch [Exception] {
     Write-Host -ForegroundColor Red ("`nERROR: make.ps1 failed:`n$_")
+    Write-Host -ForegroundColor Red ($_.InvocationInfo.PositionMessage)
 
     # More gratuitous ASCII art.
     Write-Host


### PR DESCRIPTION
In case of an exception, it makes great sense to print out some
information telling where exactly it happened.

`_.InvocationInfo.PositionMessage` gives script name, line number,
character position and (depending on the PS version) highlights
the part where error has happened.