### PR TITLE
builder: remove unused netnsRoot field in builder-next

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -37,7 +37,6 @@ func init() {
 type Opt struct {
 	SessionManager    *session.Manager
 	Root              string
-	NetnsRoot         string
 	Dist              images.DistributionServices
 	NetworkController libnetwork.NetworkController
 }

--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -90,7 +90,7 @@ func newController(rt http.RoundTripper, opt Opt) (*control.Controller, error) {
 		return nil, err
 	}
 
-	exec, err := newExecutor(root, opt.NetnsRoot, opt.NetworkController)
+	exec, err := newExecutor(root, opt.NetworkController)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@ -19,9 +19,9 @@ import (
 
 const networkName = "bridge"
 
-func newExecutor(root, netnsRoot string, net libnetwork.NetworkController) (executor.Executor, error) {
+func newExecutor(root string, net libnetwork.NetworkController) (executor.Executor, error) {
 	networkProviders := map[pb.NetMode]network.Provider{
-		pb.NetMode_UNSET: &bridgeProvider{NetworkController: net, netnsRoot: netnsRoot},
+		pb.NetMode_UNSET: &bridgeProvider{NetworkController: net},
 		pb.NetMode_HOST:  network.NewHostProvider(),
 		pb.NetMode_NONE:  network.NewNoneProvider(),
 	}
@@ -33,7 +33,6 @@ func newExecutor(root, netnsRoot string, net libnetwork.NetworkController) (exec
 
 type bridgeProvider struct {
 	libnetwork.NetworkController
-	netnsRoot string
 }
 
 func (p *bridgeProvider) New() (network.Namespace, error) {

--- a/builder/builder-next/executor_windows.go
+++ b/builder/builder-next/executor_windows.go
@@ -10,7 +10,7 @@ import (
 	"github.com/moby/buildkit/executor"
 )
 
-func newExecutor(_, _ string, _ libnetwork.NetworkController) (executor.Executor, error) {
+func newExecutor(_ string, _ libnetwork.NetworkController) (executor.Executor, error) {
 	return &winExecutor{}, nil
 }
 

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -288,7 +288,6 @@ func newRouterOptions(config *config.Config, daemon *daemon.Daemon) (routerOptio
 	bk, err := buildkit.New(buildkit.Opt{
 		SessionManager:    sm,
 		Root:              filepath.Join(config.Root, "buildkit"),
-		NetnsRoot:         filepath.Join(config.ExecRoot, "netns"),
 		Dist:              daemon.DistributionServices(),
 		NetworkController: daemon.NetworkController(),
 	})


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>
