### PR TITLE
Fix relabeling local volume source dir

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -210,6 +210,8 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			mp.Name = v.Name
 			mp.Driver = v.Driver
 
+			// need to selinux-relabel local mounts
+			mp.Source = v.Mountpoint
 			if mp.Driver == volume.DefaultDriverName {
 				setBindModeIfNull(mp)
 			}


### PR DESCRIPTION
**- What I did** / **- How I did it** / **- How to verify it** 
In case a volume is specified via Mounts API, and SELinux is enabled,
the following error happens on container start:

> $ docker volume create testvol
> $ docker run --rm --mount source=testvol,target=/tmp busybox true
> docker: Error response from daemon: error setting label on mount
> source '': no such file or directory.

The functionality to relabel the source of a local mount specified via
Mounts API was introduced in commit 5bbf5cc (https://github.com/moby/moby/pull/34684) and later broken by commit
e4b6adc (https://github.com/moby/moby/pull/36688), which removed setting mp.Source field.

With the current data structures, the host dir is already available in
v.Mountpoint, so let's just use it.

Fixes: e4b6adc

**- Description for the changelog**

Fix relabeling of local volumes specified via Mounts API on selinux-enabled systems