### PR TITLE
fixes display other container's process when docker top

### DIFF
--- a/daemon/top_unix_test.go
+++ b/daemon/top_unix_test.go
@@ -42,20 +42,20 @@ func TestContainerTopParsePSOutput(t *testing.T) {
 		{[]byte(`  PID COMMAND
    42 foo
    43 bar
-		- -
+    - -
   100 baz
 `), []uint32{42, 43}, false},
 		{[]byte(`  UID COMMAND
    42 foo
    43 bar
-		- -
+    - -
   100 baz
 `), []uint32{42, 43}, true},
 		// unicode space (U+2003, 0xe2 0x80 0x83)
 		{[]byte(` PID COMMAND
    42 foo
    43 bar
-		- -
+    - -
   100 baz
 `), []uint32{42, 43}, true},
 		// the first space is U+2003, the second one is ascii.

--- a/integration/container/top_test.go
+++ b/integration/container/top_test.go
@@ -35,34 +35,48 @@ func TestContainerTop(t *testing.T) {
 			numProc:   1,
 		},
 		{
-			opts:      []string{"-o", "cmd"},
+			opts:      []string{"-o", "pid,cmd"},
 			expectErr: false,
 			numProc:   1,
 		},
 		{
-			opts:      []string{"-ocmd"},
+			opts:      []string{"-opid,cmd"},
 			expectErr: false,
 			numProc:   1,
 		},
 		{
-			opts:      []string{"ocmd"},
+			opts:      []string{"opid,cmd"},
 			expectErr: false,
 			numProc:   1,
 		},
 		{
-			opts:      []string{"o cmd"},
+			opts:      []string{"eopid,cmd"},
 			expectErr: false,
 			numProc:   1,
 		},
 		{
-			opts:      []string{"--format", "cmd"},
+			opts:      []string{"-Csleep", "eopid,cmd,cgroup", "--sort=pid"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"o pid,cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"--format", "pid,cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-o", "pid,cmd", "oargs,uid", "--format", "%cpu"},
 			expectErr: false,
 			numProc:   1,
 		},
 		{
 			opts:      []string{"-C", "sleep", "-o", "cmd"},
-			expectErr: false,
-			numProc:   1,
+			expectErr: true,
 		},
 		{
 			opts:      []string{"-C", "sleep", "-o", "pid,cmd"},
@@ -75,32 +89,31 @@ func TestContainerTop(t *testing.T) {
 			numProc:   1,
 		},
 		{
-			opts:      []string{"-ouid=PID,cmd"},
-			expectErr: false,
-			numProc:   1,
-		},
-		{
-			opts:      []string{"efocmd"},
-			expectErr: false,
-		},
-		{
-			opts:      []string{"-A", "efocmd"},
-			expectErr: false,
-			numProc:   1,
-		},
-		{
-			opts:      []string{"-C", "sleep", "eocmd"},
-			expectErr: false,
-			numProc:   1,
-		},
-		{
-			opts:      []string{"-U", "efocmd"},
+			opts:      []string{"-o uid=PID,cmd"},
 			expectErr: true,
 		},
 		{
 			opts:      []string{"axf"},
 			expectErr: false,
 			numProc:   1,
+		},
+		{
+			opts:      []string{"--no-headers"},
+			expectErr: true,
+		},
+		{
+			opts:      []string{"aux", "--sort=comm"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"aux", "--sort", "pid"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"aux", "--sort", "pid", "--noheader"},
+			expectErr: true,
 		},
 		{
 			opts:      []string{"-o"},

--- a/integration/container/top_test.go
+++ b/integration/container/top_test.go
@@ -1,0 +1,126 @@
+package container // import "github.com/docker/docker/integration/container"
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/internal/test/request"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+	"gotest.tools/skip"
+)
+
+func TestContainerTop(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows")
+	defer setupTest(t)()
+	client := request.NewAPIClient(t)
+	ctx := context.Background()
+
+	id := container.Run(t, ctx, client, container.WithCmd("sleep", "100000"))
+
+	cases := []struct {
+		opts      []string
+		expectErr bool
+		numProc   int
+	}{
+		{
+			opts:      []string{""},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-C", "sleep"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-o", "cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-ocmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"ocmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"o cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"--format", "cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-C", "sleep", "-o", "cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-C", "sleep", "-o", "pid,cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-Csleep", "-opid,cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-ouid=PID,cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"efocmd"},
+			expectErr: false,
+		},
+		{
+			opts:      []string{"-A", "efocmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-C", "sleep", "eocmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-U", "efocmd"},
+			expectErr: true,
+		},
+		{
+			opts:      []string{"axf"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-o"},
+			expectErr: true,
+		},
+		{
+			opts:      []string{"-o", "sasha"},
+			expectErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		resp, err := client.ContainerTop(ctx, id, c.opts)
+		if !c.expectErr {
+			t.Logf("req: %v; response: %+v", c.opts, resp)
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(len(resp.Processes), c.numProc))
+		} else {
+			t.Logf("req: %v; err: %v", c.opts, err)
+			assert.Check(t, err != nil)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

Sometimes, docker top <containerid> [args] may return some process not belonged to my container. This bug will appear in a very small probability.

**- What I did**
~~Remove try ps without -q~~
parse output of ps correctly

**- How I did it**
~~Always with -q~~
find the vertical dividing lines of the output content which is a two-dimensional matrix.
This can also fix the display of the content.

**- How to verify it**
**Before fix:**
**There is a docker entrypoint file: /st**
```
root@dockerdemo:~/gocode# docker exec redisps /bin/cat /st
#!/bin/bash
redis-server --port $1
```
Then start two containers:
```
root@dockerdemo:~/moby# docker run -d --name=redisps --entrypoint=/st redis:testps 6379
root@dockerdemo:~/moby# docker run -d --name=redisps1 --entrypoint=/st redis:testps 17287
root@dockerdemo:~/moby# docker ps | grep redisps
5d19a9c1804b        redis:testps        "/st 17287"         13 minutes ago      Up 13 minutes       6379/tcp            redisps1
4ada0f1dc848        redis:testps        "/st 6379"          2 hours ago         Up 14 minutes       6379/tcp            redisps
root@dockerdemo:~/moby#
```

Docker top:
```
root@dockerdemo:~/moby# docker top redisps
UID                 PID                 PPID                C                   STIME               TTY                 TIME                CMD
root                17287               17271               0                   17:25               ?                   00:00:00            /bin/bash /st 6379
root                17324               17287               0                   17:25               ?                   00:00:00            redis-server *:6379
root@dockerdemo:~/moby# docker top redisps1
UID                 PID                 PPID                C                   STIME               TTY                 TIME                CMD
root                17407               17391               0                   17:25               ?                   00:00:00            /bin/bash /st 17287
root                17439               17407               0                   17:25               ?                   00:00:00            redis-server *:17287
root@dockerdemo:~/moby#
```

The redis's port in container redisps1 is 17287, which is just equals to st's pid in container redisps.
Then run this command:
```
root@dockerdemo:~/moby# docker top redisps -C st -o cmd,user,pid,%cpu
CMD                 USER                PID                 %CPU
/bin/bash           /st                 17287               root 17407 0.0
root@dockerdemo:~/moby# cd /opt/runctest/redis/
```
The PID 17407 belongs to container redisps1, not redisps. If I kill this pid, something will wrong.

**- Description for the changelog**
In most situations, ps -q can work.
such as: ps -ef -q <pids> will return success result.
For some parameters can't work with -q, I think we should not retry without -q, because it is very dangerous.


**- A picture of a cute animal (not mandatory but encouraged)**
![xiongmao](https://user-images.githubusercontent.com/783424/44954717-fc11e400-aed8-11e8-95f2-67f06672a97b.jpg)
