### PR TITLE
A running container exits before initNetworkController() completes

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -354,6 +354,8 @@ func (daemon *Daemon) restore() error {
 		return fmt.Errorf("Error initializing network controller: %v", err)
 	}
 
+	daemon.releaseExitedNetworks()
+
 	// Now that all the containers are registered, register the links
 	for _, c := range containers {
 		if err := daemon.registerLinks(c, c.HostConfig); err != nil {
@@ -437,6 +439,34 @@ func (daemon *Daemon) restore() error {
 	logrus.Info("Loading containers: done.")
 
 	return nil
+}
+
+//In the case of live-restore==true, if a running containerexits before
+//initNetworkController() completes, the daemon will fail to call
+//releaseNetwork() for the container because daemon.netController == nil.
+func (daemon *Daemon) releaseExitedNetworks() {
+	if daemon.containers != nil {
+		daemon.containers.ApplyAll(func(c *container.Container) {
+			if c.IsRunning() || c.IsPaused() {
+				return
+			}
+			c.Lock()
+			defer c.Unlock()
+			sid := c.NetworkSettings.SandboxID
+			if sid == "" {
+				return
+			}
+			if _, err := daemon.netController.SandboxByID(sid); err != nil {
+				return
+			}
+			logrus.Infof("start to release network for stopped container %s", c.ID)
+			daemon.releaseNetwork(c)
+			if err := c.CheckpointTo(daemon.containersReplica); err != nil {
+				logrus.Errorf("Failed to update stopped container %s network state: %v", c.ID, err)
+			}
+		})
+	}
+
 }
 
 // RestartSwarmContainers restarts any autostart container which has a


### PR DESCRIPTION
Signed-off-by: fanjiyun <fan.jiyun@zte.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
In the case of live-restore==true, if container exits after "activeSandboxes[...] = ..." and before initNetworkController() completes, the daemon will fail to call releaseNetwork() for the container because daemon.netController == nil. This causes the network resources of the container to be left, including endpoints and docker-proxy, etc. Maybe we should deal with this situation.

**- How I did it**
After initNetworkController(), we decide whether to call releaseNetwork() again by checking the sandbox of the exited container. If the sandbox of an exited container still exists, we need to call releaseNetwork() to clean it up.

**- How to verify it**
Maybe we can kill a container process during initNetworkController() with live-restore==true. But this is a small probability event.

**- Description for the changelog**
Processing container exited before initNetworkController() is completed


