### PR TITLE
Fix long startup on windows, with non-hns governed Hyper-V networks

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -323,7 +323,8 @@ func (daemon *Daemon) initNetworkController(config *config.Config, activeSandbox
 	// discover and add HNS networks to windows
 	// network that exist are removed and added again
 	for _, v := range hnsresponse {
-		if strings.ToLower(v.Type) == "private" {
+		networkTypeNorm := strings.ToLower(v.Type)
+		if networkTypeNorm == "private" || networkTypeNorm == "internal" {
 			continue // workaround for HNS reporting unsupported networks
 		}
 		var n libnetwork.Network


### PR DESCRIPTION
Similar to a related issue where previously, private Hyper-V networks
would each add 15 secs to the daemon startup (see https://github.com/moby/moby/pull/33053), non-hns governed internal
networks are reported by hns as network type "internal" which is not
mapped to any network plugin (and thus we get the same plugin load retry
loop as before).

This issue hits Docker for Desktop because we setup such a network for
the Linux VM communication.

**- What I did**

Added "internal" in the list of network plugins skipped on windows startup sequence

**- How I did it**

Just modified an existing "if" block handling the "private" network type

**- How to verify it**

- Create an internal HyperV virtual switch
- Start docker daemon
- Make sure the logs don't say things like
```
Unable to locate plugin: internal, retrying in 1s
Unable to locate plugin: internal, retrying in 2s
Unable to locate plugin: internal, retrying in 4s
Unable to locate plugin: internal, retrying in 8s
```


