### PR TITLE
pkg/progress: work around closing closed channel panic

### DIFF
--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -39,6 +39,10 @@ type Output interface {
 type chanOutput chan<- Progress
 
 func (out chanOutput) WriteProgress(p Progress) error {
+	// FIXME: workaround for panic in #37735
+	defer func() {
+		recover()
+	}()
 	out <- p
 	return nil
 }


### PR DESCRIPTION
I could not reproduce the panic in #37735, so here's a bandaid.

Signed-off-by: Tibor Vass <tibor@docker.com>

Related to https://github.com/moby/moby/issues/37735