### PR TITLE
fix typo: transtions->transitions

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1140,7 +1140,7 @@ func (s *DockerSuite) TestRunSeccompDefaultProfileNS(c *check.C) {
 }
 
 // TestRunNoNewPrivSetuid checks that --security-opt='no-new-privileges=true' prevents
-// effective uid transtions on executing setuid binaries.
+// effective uid transitions on executing setuid binaries.
 func (s *DockerSuite) TestRunNoNewPrivSetuid(c *check.C) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace, SameHostDaemon)
 	ensureNNPTest(c)
@@ -1153,7 +1153,7 @@ func (s *DockerSuite) TestRunNoNewPrivSetuid(c *check.C) {
 }
 
 // TestLegacyRunNoNewPrivSetuid checks that --security-opt=no-new-privileges prevents
-// effective uid transtions on executing setuid binaries.
+// effective uid transitions on executing setuid binaries.
 func (s *DockerSuite) TestLegacyRunNoNewPrivSetuid(c *check.C) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace, SameHostDaemon)
 	ensureNNPTest(c)


### PR DESCRIPTION
Signed-off-by: Chengfei Shang <cfshang@alauda.io>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- What I did
fix typos
- How I did it
transtions->transitions
