### PR TITLE
Fix docker system df when LCOW and WCOW images loaded

### DIFF
--- a/daemon/images/images.go
+++ b/daemon/images/images.go
@@ -187,7 +187,15 @@ func (i *ImageService) Images(imageFilters filters.Args, all bool, withExtraAttr
 			// lazily init variables
 			if imagesMap == nil {
 				allContainers = i.containers.List()
-				allLayers = i.layerStores[img.OperatingSystem()].Map()
+
+				// allLayers is built from all layerstores combined
+				allLayers = make(map[layer.ChainID]layer.Layer)
+				for _, ls := range i.layerStores {
+					layers := ls.Map()
+					for k, v := range layers {
+						allLayers[k] = v
+					}
+				}
 				imagesMap = make(map[*image.Image]*types.ImageSummary)
 				layerRefs = make(map[layer.ChainID]int)
 			}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes #37687. The fix is to ensure that lazily-built `allLayers` map is build from -all- layerstores supported by the daemon, not just the layerstore of the first image being processed.

After this fix:

```
PS E:\go\src\github.com\docker\docker> docker images
REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
microsoft/nanoserver   latest              b41972252ade        7 days ago          244MB
alpine                 latest              11cd0b38bc3c        2 months ago        6.82MB
PS E:\go\src\github.com\docker\docker> docker system df
TYPE                TOTAL               ACTIVE              SIZE                RECLAIMABLE
Images              2                   0                   251MB               251MB (100%)
Containers          0                   0                   0B                  0B
Local Volumes       0                   0                   0B                  0B
Build Cache         0                   0                   0B                  0B
```

Before this fix:

```
PS E:\go\src\github.com\docker\docker> docker images
REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
microsoft/nanoserver   latest              b41972252ade        7 days ago          244MB
alpine                 latest              11cd0b38bc3c        2 months ago        6.82MB
PS E:\go\src\github.com\docker\docker> docker system df
Error response from daemon: failed to retrieve image list: layer sha256:42f81514d820f68f1d6b46f8b15e55dd2cbd67eb4b3fcb18c51c211ebe14c61b was not found (corruption?)
```

@tonistiigi, @johnstep PTAL