### PR TITLE
daemon/logger/journald: simplify readers field

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -20,12 +20,8 @@ const name = "journald"
 type journald struct {
 	mu      sync.Mutex
 	vars    map[string]string // additional variables and values to send to the journal along with the log message
-	readers readerList
+	readers map[*logger.LogWatcher]struct{}
 	closed  bool
-}
-
-type readerList struct {
-	readers map[*logger.LogWatcher]*logger.LogWatcher
 }
 
 func init() {
@@ -84,7 +80,7 @@ func New(info logger.Info) (logger.Logger, error) {
 	for k, v := range extraAttrs {
 		vars[k] = v
 	}
-	return &journald{vars: vars, readers: readerList{readers: make(map[*logger.LogWatcher]*logger.LogWatcher)}}, nil
+	return &journald{vars: vars, readers: make(map[*logger.LogWatcher]struct{})}, nil
 }
 
 // We don't actually accept any options, but we have to supply a callback for

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -164,8 +164,10 @@ import (
 func (s *journald) Close() error {
 	s.mu.Lock()
 	s.closed = true
-	for reader := range s.readers.readers {
-		reader.ProducerGone()
+	for r := range s.readers {
+		r.ProducerGone()
+		delete(s.readers, r)
+
 	}
 	s.mu.Unlock()
 	return nil
@@ -253,7 +255,7 @@ drain:
 
 func (s *journald) followJournal(logWatcher *logger.LogWatcher, j *C.sd_journal, pfd [2]C.int, cursor *C.char, untilUnixMicro uint64) *C.char {
 	s.mu.Lock()
-	s.readers.readers[logWatcher] = logWatcher
+	s.readers[logWatcher] = struct{}{}
 	if s.closed {
 		// the journald Logger is closed, presumably because the container has been
 		// reset.  So we shouldn't follow, because we'll never be woken up.  But we
@@ -290,7 +292,7 @@ func (s *journald) followJournal(logWatcher *logger.LogWatcher, j *C.sd_journal,
 		// Clean up.
 		C.close(pfd[0])
 		s.mu.Lock()
-		delete(s.readers.readers, logWatcher)
+		delete(s.readers, logWatcher)
 		s.mu.Unlock()
 		close(logWatcher.Msg)
 		newCursor <- cursor


### PR DESCRIPTION
As in other similar drivers (jsonlog, local), use a set
(i.e. `map[whatever]struct{}`), making the code simpler.

While at it, make sure we remove the reader from the set
after calling `ProducerGone()` on it.