### PR TITLE
TestStartReturnCorrectExitCode: show error

### DIFF
--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -190,10 +190,11 @@ func (s *DockerSuite) TestStartReturnCorrectExitCode(c *check.C) {
 	dockerCmd(c, "create", "--restart=on-failure:2", "--name", "withRestart", "busybox", "sh", "-c", "exit 11")
 	dockerCmd(c, "create", "--rm", "--name", "withRm", "busybox", "sh", "-c", "exit 12")
 
-	_, exitCode, err := dockerCmdWithError("start", "-a", "withRestart")
+	out, exitCode, err := dockerCmdWithError("start", "-a", "withRestart")
 	c.Assert(err, checker.NotNil)
-	c.Assert(exitCode, checker.Equals, 11)
-	_, exitCode, err = dockerCmdWithError("start", "-a", "withRm")
+	c.Assert(exitCode, checker.Equals, 11, check.Commentf("out: %s", out))
+
+	out, exitCode, err = dockerCmdWithError("start", "-a", "withRm")
 	c.Assert(err, checker.NotNil)
-	c.Assert(exitCode, checker.Equals, 12)
+	c.Assert(exitCode, checker.Equals, 12, check.Commentf("out: %s", out))
 }


### PR DESCRIPTION
Seen this error:

```
00:54:01.860 
00:54:01.860 ----------------------------------------------------------------------
00:54:01.860 FAIL: docker_cli_start_test.go:189: DockerSuite.TestStartReturnCorrectExitCode
00:54:01.860 
00:54:01.860 docker_cli_start_test.go:198:
00:54:01.860     c.Assert(exitCode, checker.Equals, 12)
00:54:01.861 ... obtained int = 125
00:54:01.861 ... expected int = 12
00:54:01.861 
00:54:01.861 
00:54:01.861 ----------------------------------------------------------------------
```

Apparently there's something going on with `docker start`, and it would be good to know what.