### PR TITLE
ContainerTop: harden

### DIFF
--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -285,6 +285,22 @@ func (daemon *Daemon) ContainerTop(name string, psArgs string) (*container.Conta
 
 	args := strings.Split(psArgs, " ")
 
+	// can't work without headers
+	for _, arg := range args {
+		switch arg {
+		case
+			"--no-header",
+			"--no-headers",
+			"--no-heading",
+			"--no-headings",
+			"--noheader",
+			"--noheaders",
+			"--noheading",
+			"--noheadings":
+			return nil, errdefs.System(errors.New("option " + arg + " is not allowed"))
+		}
+	}
+
 	var extraPidColumn bool
 	if customArgs && customFields(args) {
 		// make sure the PID field is shown in the first column

--- a/integration/container/top_test.go
+++ b/integration/container/top_test.go
@@ -110,6 +110,10 @@ func TestContainerTop(t *testing.T) {
 			opts:      []string{"-o", "sasha"},
 			expectErr: true,
 		},
+		{
+			opts:      []string{"--no-headers"},
+			expectErr: true,
+		},
 	}
 
 	for _, c := range cases {

--- a/integration/container/top_test.go
+++ b/integration/container/top_test.go
@@ -1,0 +1,126 @@
+package container // import "github.com/docker/docker/integration/container"
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/internal/test/request"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+	"gotest.tools/skip"
+)
+
+func TestContainerTop(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows")
+	defer setupTest(t)()
+	client := request.NewAPIClient(t)
+	ctx := context.Background()
+
+	id := container.Run(t, ctx, client, container.WithCmd("sleep", "100000"))
+
+	cases := []struct {
+		opts      []string
+		expectErr bool
+		numProc   int
+	}{
+		{
+			opts:      []string{""},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-C", "sleep"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-o", "cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-ocmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"ocmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"o cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"--format", "cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-C", "sleep", "-o", "cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-C", "sleep", "-o", "pid,cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-Csleep", "-opid,cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-ouid=PID,cmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"efocmd"},
+			expectErr: false,
+		},
+		{
+			opts:      []string{"-A", "efocmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-C", "sleep", "eocmd"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-U", "efocmd"},
+			expectErr: true,
+		},
+		{
+			opts:      []string{"axf"},
+			expectErr: false,
+			numProc:   1,
+		},
+		{
+			opts:      []string{"-o"},
+			expectErr: true,
+		},
+		{
+			opts:      []string{"-o", "sasha"},
+			expectErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		resp, err := client.ContainerTop(ctx, id, c.opts)
+		if !c.expectErr {
+			t.Logf("req: %v; response: %+v", c.opts, resp)
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(len(resp.Processes), c.numProc))
+		} else {
+			t.Logf("req: %v; err: %v", c.opts, err)
+			assert.Check(t, err != nil)
+		}
+	}
+}


### PR DESCRIPTION
In case a user specifies arguments such as -C or f, optimization
introduced by commit a076bad is not used, and so the code falls back
to list all the processes and filter those with PIDs of the
container specified.

In case a user also specifies -o with some fields that may contain
spaces, and those fields are before the PID field (such as -o comm,pid),
PID filtering is broken. In the worst case scenario, command can
contain numeric arguments which are then parsed as PIDs, leading to
showing some processes not belonging to the container specified.

To fix, we need to make sure that PID field is either the first one
or at least before any other fields that may contain spaces. Here
we assume this is the case for any ps built-in formats; we only
need to fix it for the case when a custom format is specified.

So, we need to check if ps arguments contains custom formatting
options (-o/o/--format). If true:

1. Prepend `-opid` to ps arguments (so the first field is PID).
2. Always use the first field to obtain PID for filtering purposes.
3. Remove the first field from the output.

This fix looks easy in theory; in practice, though, due to variety
of ways ps can parse its arguments. Because of that, function
`isCustomFormat()` is not that trivial, plus a unit test case
is added to validate it works as expected.
    
This fixes two bugs:
 - wrongly listing processes not belonging to a container;
 - inability to use -o if it does not contain pid.

In addition, now, since we are adding our own PID column, any
tricks that a malicious user might do with column naming (such
as adding `-ouid=PID`) won't work anymore, so we can drop
the option validation (introduced in PR #24358) entirely, as well
as its test case.

Big thanks to https://github.com/lifubang for analysis, ideas and
patches (see https://github.com/moby/moby/pull/37748).

Test cases are available in the second commit.