### PR TITLE
Update copyright years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2013-2017 Docker, Inc.
+   Copyright 2013-2018 Docker, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pkg/symlink/LICENSE.APACHE
+++ b/pkg/symlink/LICENSE.APACHE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2014-2017 Docker, Inc.
+   Copyright 2014-2018 Docker, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pkg/symlink/LICENSE.BSD
+++ b/pkg/symlink/LICENSE.BSD
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2017 The Docker & Go Authors. All rights reserved.
+Copyright (c) 2014-2018 The Docker & Go Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are


### PR DESCRIPTION
Signed-off-by: vereas oli@overrateddev.co

Updated copyright years to "2018" from "2017"

P.S:
![](https://file.ovdev.io/img/u1ldy6twog.png)