### PR TITLE
[DO NOT MERGE] TestAPISwarmLeaderElection: debug

### DIFF
--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -50,9 +50,9 @@ build_test_suite_binaries() {
 		return
 	fi
 	build_test_suite_binary ./integration-cli "test.main"
-	for dir in $integration_api_dirs; do
-		build_test_suite_binary "$dir" "test.main"
-	done
+#	for dir in $integration_api_dirs; do
+#		build_test_suite_binary "$dir" "test.main"
+#	done
 }
 
 # Build a binary for a test suite package

--- a/hack/make/test-integration
+++ b/hack/make/test-integration
@@ -4,6 +4,7 @@ set -e -o pipefail
 source hack/make/.integration-test-helpers
 
 (
+	TESTFLAGS="-check.f TestAPISwarm -check.vv"
 	build_test_suite_binaries
 	bundle .integration-daemon-start
 	bundle .integration-daemon-setup

--- a/hack/test/unit
+++ b/hack/test/unit
@@ -10,6 +10,7 @@
 #
 #    TESTDIRS="./pkg/term" hack/test/unit
 #
+exit 0
 set -eu -o pipefail
 
 TESTFLAGS+=" -test.timeout=${TIMEOUT:-5m}"

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -332,6 +332,7 @@ func (s *DockerSwarmSuite) TestAPISwarmLeaderElection(c *check.C) {
 	}
 
 	// wait for an election to occur
+	c.Logf("Waiting for election to occur...")
 	waitAndAssert(c, defaultReconciliationTimeout, checkLeader(d2, d3), checker.True)
 
 	// assert that we have a new leader
@@ -343,9 +344,8 @@ func (s *DockerSwarmSuite) TestAPISwarmLeaderElection(c *check.C) {
 	// add the d1, the initial leader, back
 	d1.Start(c)
 
-	// TODO(stevvooe): may need to wait for rejoin here
-
 	// wait for possible election
+	c.Logf("Waiting for possible election...")
 	waitAndAssert(c, defaultReconciliationTimeout, checkLeader(d1, d2, d3), checker.True)
 	// pick out the leader and the followers again
 

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -419,6 +419,12 @@ func getErrorMessage(c *check.C, body []byte) string {
 }
 
 func waitAndAssert(c *check.C, timeout time.Duration, f checkF, checker check.Checker, args ...interface{}) {
+	t1 := time.Now()
+	defer func() {
+		t2 := time.Now()
+		c.Logf("waited for %v (out of %v)", t2.Sub(t1), timeout)
+	}()
+
 	after := time.After(timeout)
 	for {
 		v, comment := f(c)

--- a/internal/test/daemon/daemon_unix.go
+++ b/internal/test/daemon/daemon_unix.go
@@ -21,7 +21,7 @@ func cleanupNetworkNamespace(t testingT, execRoot string) {
 	// new exec root.
 	netnsPath := filepath.Join(execRoot, "netns")
 	filepath.Walk(netnsPath, func(path string, info os.FileInfo, err error) error {
-		if err := unix.Unmount(path, unix.MNT_FORCE); err != nil {
+		if err := unix.Unmount(path, unix.MNT_DETACH); err != nil && err != unix.EINVAL && err != unix.ENOENT {
 			t.Logf("unmount of %s failed: %v", path, err)
 		}
 		os.Remove(path)

--- a/internal/test/daemon/node.go
+++ b/internal/test/daemon/node.go
@@ -23,7 +23,7 @@ func (d *Daemon) GetNode(t assert.TestingT, id string) *swarm.Node {
 	defer cli.Close()
 
 	node, _, err := cli.NodeInspectWithRaw(context.Background(), id)
-	assert.NilError(t, err)
+	assert.NilError(t, err, "[%s] (*Daemon).GetNode: NodeInspectWithRaw(%q) failed", d.id, id)
 	assert.Check(t, node.ID == id)
 	return &node
 }


### PR DESCRIPTION
*(summary of my findings based on debug obtained)*

Here's the test workflow leading to a failure:
1. Start three swarm nodes (d1, d2, d3), sequentially.
2. Check that d1 is the leader.
3. Stop d1.
4. Wait until either d2 or d3 become a leader, by calling `/nodes/<ID>` every 100ms for both of them repeatedly, until `ManagerStatus.Leader` is true for any of these two.

One of the calls to `/nodes/<ID>` times out after 20s, probably meaning it is stuck somewhere in `(*Cluster).GetNode()` (source file `daemon/cluster/nodes.go`).

Also note that cherry-picking docker/swarmkit#2744 didn't help.