### PR TITLE
tagging stdout/stderr log differently with fluentd logging

### DIFF
--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -22,6 +22,7 @@ import (
 
 type fluentd struct {
 	tag           string
+	tagStderr     string
 	containerID   string
 	containerName string
 	writer        *fluent.Fluent
@@ -75,6 +76,11 @@ func New(info logger.Info) (logger.Logger, error) {
 	}
 
 	tag, err := loggerutils.ParseLogTag(info, loggerutils.DefaultTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	tagStderr, err := loggerutils.ParseLogTagStderr(info, loggerutils.DefaultTemplate)
 	if err != nil {
 		return nil, err
 	}
@@ -146,6 +152,7 @@ func New(info logger.Info) (logger.Logger, error) {
 	}
 	return &fluentd{
 		tag:           tag,
+		tagStderr:     tagStderr,
 		containerID:   info.ContainerID,
 		containerName: info.ContainerName,
 		writer:        log,
@@ -165,10 +172,15 @@ func (f *fluentd) Log(msg *logger.Message) error {
 	}
 
 	ts := msg.Timestamp
+	source := msg.Source
 	logger.PutMessage(msg)
 	// fluent-logger-golang buffers logs from failures and disconnections,
 	// and these are transferred again automatically.
-	return f.writer.PostWithTime(f.tag, ts, data)
+	if source == "stderr" && f.tagStderr != "" {
+		return f.writer.PostWithTime(f.tagStderr, ts, data)
+	} else {
+		return f.writer.PostWithTime(f.tag, ts, data)
+	}
 }
 
 func (f *fluentd) Close() error {
@@ -187,6 +199,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case "env-regex":
 		case "labels":
 		case "tag":
+		case "tag-stderr":
 		case addressKey:
 		case bufferLimitKey:
 		case retryWaitKey:

--- a/daemon/logger/loggerutils/log_tag.go
+++ b/daemon/logger/loggerutils/log_tag.go
@@ -29,3 +29,21 @@ func ParseLogTag(info logger.Info, defaultTemplate string) (string, error) {
 
 	return buf.String(), nil
 }
+
+func ParseLogTagStderr(info logger.Info, defaultTemplate string) (string, error) {
+	tagTemplate := info.Config["tag-stderr"]
+	if tagTemplate == "" {
+		tagTemplate = defaultTemplate
+	}
+
+	tmpl, err := templates.NewParse("log-tag", tagTemplate)
+	if err != nil {
+		return "", err
+	}
+	buf := new(bytes.Buffer)
+	if err := tmpl.Execute(buf, &info); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}


### PR DESCRIPTION
for tagging stdout/stderr log differently with fluentd logging

for test
```
$ docker run --net=host --rm -ti --name=fluentbit fluent/fluent-bit:0.12 /fluent-bit/bin/fluent-bit -i forward -o stdout -f 1
```
```
$ docker run -d --log-driver=fluentd --log-opt tag=tag-stdout --log-opt tag-stderr=tag-stderr --log-opt fluentd-address=localhost:24224 nginx
```