### PR TITLE
Allow to override the Makefile's `DOCKER_MOUNT` variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ DOCKER_ENVS := \
 # (default to no bind mount if DOCKER_HOST is set)
 # note: BINDDIR is supported for backwards-compatibility here
 BIND_DIR := $(if $(BINDDIR),$(BINDDIR),$(if $(DOCKER_HOST),,bundles))
+
+# DOCKER_MOUNT can be overriden, but use at your own risk!
+ifndef DOCKER_MOUNT
 DOCKER_MOUNT := $(if $(BIND_DIR),-v "$(CURDIR)/$(BIND_DIR):/go/src/github.com/docker/docker/$(BIND_DIR)")
 
 # This allows the test suite to be able to run without worrying about the underlying fs used by the container running the daemon (e.g. aufs-on-aufs), so long as the host running the container is running a supported fs.
@@ -69,13 +72,14 @@ DOCKER_MOUNT := $(if $(BIND_DIR),-v "$(CURDIR)/$(BIND_DIR):/go/src/github.com/do
 # Note that `BIND_DIR` will already be set to `bundles` if `DOCKER_HOST` is not set (see above BIND_DIR line), in such case this will do nothing since `DOCKER_MOUNT` will already be set.
 DOCKER_MOUNT := $(if $(DOCKER_MOUNT),$(DOCKER_MOUNT),-v /go/src/github.com/docker/docker/bundles) -v "$(CURDIR)/.git:/go/src/github.com/docker/docker/.git"
 
-# This allows to set the docker-dev container name
-DOCKER_CONTAINER_NAME := $(if $(CONTAINER_NAME),--name $(CONTAINER_NAME),)
-
 DOCKER_MOUNT_CACHE := -v docker-dev-cache:/root/.cache
 DOCKER_MOUNT_CLI := $(if $(DOCKER_CLI_PATH),-v $(shell dirname $(DOCKER_CLI_PATH)):/usr/local/cli,)
 DOCKER_MOUNT_BASH_COMPLETION := $(if $(DOCKER_BASH_COMPLETION_PATH),-v $(shell dirname $(DOCKER_BASH_COMPLETION_PATH)):/usr/local/completion/bash,)
 DOCKER_MOUNT := $(DOCKER_MOUNT) $(DOCKER_MOUNT_CACHE) $(DOCKER_MOUNT_CLI) $(DOCKER_MOUNT_BASH_COMPLETION)
+endif # ifndef DOCKER_MOUNT
+
+# This allows to set the docker-dev container name
+DOCKER_CONTAINER_NAME := $(if $(CONTAINER_NAME),--name $(CONTAINER_NAME),)
 
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")


### PR DESCRIPTION
**- What I did**

This patch provides some way for non-Linux devs to work on this repo without
suffering too much from the notorious terrible I/O perf of mounted volumes (eg
on OS X).

**- How I did it**

We now allow to override the Makefile's `DOCKER_MOUNT` variable through the env
variable of the same name.

The idea here is pretty simple: I/O perf on native mounted disks
on non-Linux (notably Mac OS) is just terrible, thus making it
a real pain to develop: one has to choose between re-building
the image after every single change (eg to run a test) or just
work directly inside the same container (eg with vim, but even then
one would have to re-configure their dev container every time
it gets destroyed - containers, after all, are not supposed to
be long-lived).

Allowing to override `DOCKER_MOUNT` makes it easy for everyone
to decide what their volume/syncing strategy is; for example
one can choose to use [docker-sync](https://github.com/EugenMayer/docker-sync)

This patch won't change anything for anyone who doesn't set the `DOCKER_MOUNT`
env variable in their environment; really tried to make it as little disrputive
as possible.

**- How to verify it**

The outputs of:
```
make -n shell
BIND_DIR=. make -n shell
```
should be unchanged compared to what it was before this patch; but:
```
DOCKER_MOUNT='-v test:/test' make -n shell
```
should replace all the `-v` flags from the commands above with just
`-v test:/test`, and finally:
```
DOCKER_MOUNT=' ' make -n shell
```
should be devoid of any `-v` flags.

**- A picture of a cute animal (not mandatory but encouraged)**

![bunny](https://static.boredpanda.com/blog/wp-content/uploads/2015/09/cute-bunnies-105__605.jpg)
