### PR TITLE
Loosen permissions on /etc/docker directory

### DIFF
--- a/daemon/trustkey.go
+++ b/daemon/trustkey.go
@@ -17,7 +17,7 @@ import (
 // TODO: this should use more of libtrust.LoadOrCreateTrustKey which may need
 // a refactor or this function to be moved into libtrust
 func loadOrCreateTrustKey(trustKeyPath string) (libtrust.PrivateKey, error) {
-	err := system.MkdirAll(filepath.Dir(trustKeyPath), 0700, "")
+	err := system.MkdirAll(filepath.Dir(trustKeyPath), 0755, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/37840
fixes https://github.com/docker/cli/issues/1358
closes https://github.com/moby/moby/pull/37619

The `/etc/docker` directory is used both by the dockerd daemon and the docker cli (if installed on the same host as the daemon).

In situations where the `/etc/docker` directory does not exist, and an initial `key.json` (legacy trust key) is generated (at the default location), the `/etc/docker/` directory was created with 0700 permissions, making the directory only accessible by `root`.

Given that the `0600` permissions on the key itself already protect it from being used by other users, the permissions of `/etc/docker` can be less restrictive.

This patch changes the permissions for the directory to `0755`, so that the CLI (if executed as non-root) can also access this directory.

> **NOTE**: "strictly", this patch is only needed for situations where no _custom_
> location for the trustkey is specified (not overridden with `--deprecated-key-path`),
> but setting the permissions only for the "default" case would make
> this more complicated.

To verify this patch;

```bash
make binary shell

# inside the container;
make install

# verify the directory doesn't exist
ls -la /etc/ | grep docker

# start, and terminate the `dockerd` daemon
dockerd
^C

# check that the directory was created with the correct permissions
ls -la /etc/ | grep docker
drwxr-xr-x 2 root root    4096 Sep 14 12:11 docker
```

