### PR TITLE
daemon: propagate exec-root to libnetwork-setkey

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -809,7 +809,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (retSpec *specs.Spec, e
 			s.Hooks = &specs.Hooks{
 				Prestart: []specs.Hook{{
 					Path: target,
-					Args: []string{"libnetwork-setkey", c.ID, daemon.netController.ID()},
+					Args: []string{"libnetwork-setkey", "-exec-root=" + daemon.configStore.GetExecRoot(), c.ID, daemon.netController.ID()},
 				}},
 			}
 		}

--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=36d3bed0e9f4b3c8c66df9bd45278bb90b33e911
+LIBNETWORK_COMMIT=20461b8539336a4b5fcf551a86dd24ebae211984
 
 install_proxy() {
 	case "$1" in

--- a/internal/test/daemon/daemon.go
+++ b/internal/test/daemon/daemon.go
@@ -111,12 +111,13 @@ func New(t testingT, ops ...func(*Daemon)) *Daemon {
 		}
 	}
 	d := &Daemon{
-		id:              id,
-		Folder:          daemonFolder,
-		Root:            daemonRoot,
-		storageDriver:   storageDriver,
-		userlandProxy:   userlandProxy,
-		execRoot:        filepath.Join(os.TempDir(), "docker-execroot", id),
+		id:            id,
+		Folder:        daemonFolder,
+		Root:          daemonRoot,
+		storageDriver: storageDriver,
+		userlandProxy: userlandProxy,
+		// dxr stands for docker-execroot (shortened for avoiding unix(7) path length limitation)
+		execRoot:        filepath.Join(os.TempDir(), "dxr", id),
 		dockerdBinary:   defaultDockerdBinary,
 		swarmListenAddr: defaultSwarmListenAddr,
 		SwarmPort:       DefaultSwarmPort,

--- a/vendor.conf
+++ b/vendor.conf
@@ -37,7 +37,7 @@ github.com/mitchellh/hashstructure 2bca23e0e452137f789efbc8610126fd8b94f73b
 #get libnetwork packages
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
-github.com/docker/libnetwork 36d3bed0e9f4b3c8c66df9bd45278bb90b33e911
+github.com/docker/libnetwork 20461b8539336a4b5fcf551a86dd24ebae211984
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/config/config.go
+++ b/vendor/github.com/docker/libnetwork/config/config.go
@@ -35,6 +35,7 @@ type DaemonCfg struct {
 	Debug                  bool
 	Experimental           bool
 	DataDir                string
+	ExecRoot               string
 	DefaultNetwork         string
 	DefaultDriver          string
 	Labels                 []string
@@ -217,6 +218,7 @@ func OptionDataDir(dataDir string) Option {
 // OptionExecRoot function returns an option setter for exec root folder
 func OptionExecRoot(execRoot string) Option {
 	return func(c *Config) {
+		c.Daemon.ExecRoot = execRoot
 		osl.SetBasePath(execRoot)
 	}
 }

--- a/vendor/github.com/docker/libnetwork/sandbox_externalkey_unix.go
+++ b/vendor/github.com/docker/libnetwork/sandbox_externalkey_unix.go
@@ -4,24 +4,30 @@ package libnetwork
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 
 	"github.com/docker/libnetwork/types"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/sirupsen/logrus"
 )
 
-const udsBase = "/run/docker/libnetwork/"
-const success = "success"
+const (
+	execSubdir      = "libnetwork"
+	defaultExecRoot = "/run/docker"
+	success         = "success"
+)
 
 // processSetKeyReexec is a private function that must be called only on an reexec path
 // It expects 3 args { [0] = "libnetwork-setkey", [1] = <container-id>, [2] = <controller-id> }
 // It also expects configs.HookState as a json string in <stdin>
 // Refer to https://github.com/opencontainers/runc/pull/160/ for more information
+// The docker exec-root can be specified as "-exec-root" flag. The default value is "/run/docker".
 func processSetKeyReexec() {
 	var err error
 
@@ -32,12 +38,17 @@ func processSetKeyReexec() {
 		}
 	}()
 
-	// expecting 3 args {[0]="libnetwork-setkey", [1]=<container-id>, [2]=<controller-id> }
-	if len(os.Args) < 3 {
-		err = fmt.Errorf("Re-exec expects 3 args, received : %d", len(os.Args))
+	execRoot := flag.String("exec-root", defaultExecRoot, "docker exec root")
+	flag.Parse()
+
+	// expecting 3 os.Args {[0]="libnetwork-setkey", [1]=<container-id>, [2]=<controller-id> }
+	// (i.e. expecting 2 flag.Args())
+	args := flag.Args()
+	if len(args) < 2 {
+		err = fmt.Errorf("Re-exec expects 2 args (after parsing flags), received : %d", len(args))
 		return
 	}
-	containerID := os.Args[1]
+	containerID, controllerID := args[0], args[1]
 
 	// We expect configs.HookState as a json string in <stdin>
 	stateBuf, err := ioutil.ReadAll(os.Stdin)
@@ -49,18 +60,17 @@ func processSetKeyReexec() {
 		return
 	}
 
-	controllerID := os.Args[2]
-
-	err = SetExternalKey(controllerID, containerID, fmt.Sprintf("/proc/%d/ns/net", state.Pid))
+	err = SetExternalKey(controllerID, containerID, fmt.Sprintf("/proc/%d/ns/net", state.Pid), *execRoot)
 }
 
 // SetExternalKey provides a convenient way to set an External key to a sandbox
-func SetExternalKey(controllerID string, containerID string, key string) error {
+func SetExternalKey(controllerID string, containerID string, key string, execRoot string) error {
 	keyData := setKeyData{
 		ContainerID: containerID,
 		Key:         key}
 
-	c, err := net.Dial("unix", udsBase+controllerID+".sock")
+	uds := filepath.Join(execRoot, execSubdir, controllerID+".sock")
+	c, err := net.Dial("unix", uds)
 	if err != nil {
 		return err
 	}
@@ -102,10 +112,15 @@ func processReturn(r io.Reader) error {
 }
 
 func (c *controller) startExternalKeyListener() error {
+	execRoot := defaultExecRoot
+	if v := c.Config().Daemon.ExecRoot; v != "" {
+		execRoot = v
+	}
+	udsBase := filepath.Join(execRoot, execSubdir)
 	if err := os.MkdirAll(udsBase, 0600); err != nil {
 		return err
 	}
-	uds := udsBase + c.id + ".sock"
+	uds := filepath.Join(udsBase, c.id+".sock")
 	l, err := net.Listen("unix", uds)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

propagate `exec-root` to `libnetwork-setkey`

**- How I did it**

https://github.com/docker/libnetwork/pull/2248

**- How to verify it**

```console
$ mount -t tmpfs -r none /run/docker/libnetwork
$ touch /run/docker/libnetwork/masked-for-testing
touch: cannot touch '/run/docker/libnetwork/masked-for-testing`: Read-only file system
$ dockerd --exec-root /tmp/foo
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

🐧 