### PR TITLE
fixes: urlencode containerid and other id when add to url in client library

### DIFF
--- a/client/checkpoint_create.go
+++ b/client/checkpoint_create.go
@@ -8,7 +8,7 @@ import (
 
 // CheckpointCreate creates a checkpoint from the given container with the given name
 func (cli *Client) CheckpointCreate(ctx context.Context, container string, options types.CheckpointCreateOptions) error {
-	resp, err := cli.post(ctx, "/containers/"+container+"/checkpoints", nil, options, nil)
+	resp, err := cli.post(ctx, "/containers/"+FilterURL(container)+"/checkpoints", nil, options, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/checkpoint_delete.go
+++ b/client/checkpoint_delete.go
@@ -14,7 +14,7 @@ func (cli *Client) CheckpointDelete(ctx context.Context, containerID string, opt
 		query.Set("dir", options.CheckpointDir)
 	}
 
-	resp, err := cli.delete(ctx, "/containers/"+containerID+"/checkpoints/"+options.CheckpointID, query, nil)
+	resp, err := cli.delete(ctx, "/containers/"+FilterURL(containerID)+"/checkpoints/"+options.CheckpointID, query, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/checkpoint_list.go
+++ b/client/checkpoint_list.go
@@ -17,7 +17,7 @@ func (cli *Client) CheckpointList(ctx context.Context, container string, options
 		query.Set("dir", options.CheckpointDir)
 	}
 
-	resp, err := cli.get(ctx, "/containers/"+container+"/checkpoints", query, nil)
+	resp, err := cli.get(ctx, "/containers/"+FilterURL(container)+"/checkpoints", query, nil)
 	if err != nil {
 		return checkpoints, wrapResponseError(err, resp, "container", container)
 	}

--- a/client/config_inspect.go
+++ b/client/config_inspect.go
@@ -17,7 +17,7 @@ func (cli *Client) ConfigInspectWithRaw(ctx context.Context, id string) (swarm.C
 	if err := cli.NewVersionError("1.30", "config inspect"); err != nil {
 		return swarm.Config{}, nil, err
 	}
-	resp, err := cli.get(ctx, "/configs/"+id, nil, nil)
+	resp, err := cli.get(ctx, "/configs/"+FilterURL(id), nil, nil)
 	if err != nil {
 		return swarm.Config{}, nil, wrapResponseError(err, resp, "config", id)
 	}

--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -19,7 +19,7 @@ func (cli *Client) ContainerStatPath(ctx context.Context, containerID, path stri
 	query := url.Values{}
 	query.Set("path", filepath.ToSlash(path)) // Normalize the paths used in the API.
 
-	urlStr := "/containers/" + containerID + "/archive"
+	urlStr := "/containers/" + FilterURL(containerID) + "/archive"
 	response, err := cli.head(ctx, urlStr, query, nil)
 	if err != nil {
 		return types.ContainerPathStat{}, wrapResponseError(err, response, "container:path", containerID+":"+path)

--- a/client/container_diff.go
+++ b/client/container_diff.go
@@ -12,7 +12,7 @@ import (
 func (cli *Client) ContainerDiff(ctx context.Context, containerID string) ([]container.ContainerChangeResponseItem, error) {
 	var changes []container.ContainerChangeResponseItem
 
-	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/changes", url.Values{}, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+FilterURL(containerID)+"/changes", url.Values{}, nil)
 	if err != nil {
 		return changes, err
 	}

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -15,7 +15,7 @@ func (cli *Client) ContainerExecCreate(ctx context.Context, container string, co
 		return response, err
 	}
 
-	resp, err := cli.post(ctx, "/containers/"+container+"/exec", nil, config, nil)
+	resp, err := cli.post(ctx, "/containers/"+FilterURL(container)+"/exec", nil, config, nil)
 	if err != nil {
 		return response, err
 	}

--- a/client/container_export.go
+++ b/client/container_export.go
@@ -10,7 +10,7 @@ import (
 // and returns them as an io.ReadCloser. It's up to the caller
 // to close the stream.
 func (cli *Client) ContainerExport(ctx context.Context, containerID string) (io.ReadCloser, error) {
-	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/export", url.Values{}, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+FilterURL(containerID)+"/export", url.Values{}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/container_inspect.go
+++ b/client/container_inspect.go
@@ -15,7 +15,7 @@ func (cli *Client) ContainerInspect(ctx context.Context, containerID string) (ty
 	if containerID == "" {
 		return types.ContainerJSON{}, objectNotFoundError{object: "container", id: containerID}
 	}
-	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", nil, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+FilterURL(containerID)+"/json", nil, nil)
 	if err != nil {
 		return types.ContainerJSON{}, wrapResponseError(err, serverResp, "container", containerID)
 	}
@@ -35,7 +35,7 @@ func (cli *Client) ContainerInspectWithRaw(ctx context.Context, containerID stri
 	if getSize {
 		query.Set("size", "1")
 	}
-	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", query, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+FilterURL(containerID)+"/json", query, nil)
 	if err != nil {
 		return types.ContainerJSON{}, nil, wrapResponseError(err, serverResp, "container", containerID)
 	}

--- a/client/container_kill.go
+++ b/client/container_kill.go
@@ -10,7 +10,7 @@ func (cli *Client) ContainerKill(ctx context.Context, containerID, signal string
 	query := url.Values{}
 	query.Set("signal", signal)
 
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/kill", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+FilterURL(containerID)+"/kill", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_logs.go
+++ b/client/container_logs.go
@@ -72,7 +72,7 @@ func (cli *Client) ContainerLogs(ctx context.Context, container string, options 
 	}
 	query.Set("tail", options.Tail)
 
-	resp, err := cli.get(ctx, "/containers/"+container+"/logs", query, nil)
+	resp, err := cli.get(ctx, "/containers/"+FilterURL(container)+"/logs", query, nil)
 	if err != nil {
 		return nil, wrapResponseError(err, resp, "container", container)
 	}

--- a/client/container_pause.go
+++ b/client/container_pause.go
@@ -4,7 +4,7 @@ import "context"
 
 // ContainerPause pauses the main process of a given container without terminating it.
 func (cli *Client) ContainerPause(ctx context.Context, containerID string) error {
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/pause", nil, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+FilterURL(containerID)+"/pause", nil, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_remove.go
+++ b/client/container_remove.go
@@ -21,7 +21,7 @@ func (cli *Client) ContainerRemove(ctx context.Context, containerID string, opti
 		query.Set("force", "1")
 	}
 
-	resp, err := cli.delete(ctx, "/containers/"+containerID, query, nil)
+	resp, err := cli.delete(ctx, "/containers/"+FilterURL(containerID), query, nil)
 	ensureReaderClosed(resp)
 	return wrapResponseError(err, resp, "container", containerID)
 }

--- a/client/container_rename.go
+++ b/client/container_rename.go
@@ -9,7 +9,7 @@ import (
 func (cli *Client) ContainerRename(ctx context.Context, containerID, newContainerName string) error {
 	query := url.Values{}
 	query.Set("name", newContainerName)
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/rename", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+FilterURL(containerID)+"/rename", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_resize.go
+++ b/client/container_resize.go
@@ -10,12 +10,12 @@ import (
 
 // ContainerResize changes the size of the tty for a container.
 func (cli *Client) ContainerResize(ctx context.Context, containerID string, options types.ResizeOptions) error {
-	return cli.resize(ctx, "/containers/"+containerID, options.Height, options.Width)
+	return cli.resize(ctx, "/containers/"+FilterURL(containerID), options.Height, options.Width)
 }
 
 // ContainerExecResize changes the size of the tty for an exec process running inside a container.
 func (cli *Client) ContainerExecResize(ctx context.Context, execID string, options types.ResizeOptions) error {
-	return cli.resize(ctx, "/exec/"+execID, options.Height, options.Width)
+	return cli.resize(ctx, "/exec/"+FilterURL(execID), options.Height, options.Width)
 }
 
 func (cli *Client) resize(ctx context.Context, basePath string, height, width uint) error {

--- a/client/container_restart.go
+++ b/client/container_restart.go
@@ -16,7 +16,7 @@ func (cli *Client) ContainerRestart(ctx context.Context, containerID string, tim
 	if timeout != nil {
 		query.Set("t", timetypes.DurationToSecondsString(*timeout))
 	}
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/restart", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+FilterURL(containerID)+"/restart", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_start.go
+++ b/client/container_start.go
@@ -17,7 +17,7 @@ func (cli *Client) ContainerStart(ctx context.Context, containerID string, optio
 		query.Set("checkpoint-dir", options.CheckpointDir)
 	}
 
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/start", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+FilterURL(containerID)+"/start", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_stats.go
+++ b/client/container_stats.go
@@ -16,7 +16,7 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 		query.Set("stream", "1")
 	}
 
-	resp, err := cli.get(ctx, "/containers/"+containerID+"/stats", query, nil)
+	resp, err := cli.get(ctx, "/containers/"+FilterURL(containerID)+"/stats", query, nil)
 	if err != nil {
 		return types.ContainerStats{}, err
 	}

--- a/client/container_stop.go
+++ b/client/container_stop.go
@@ -20,7 +20,7 @@ func (cli *Client) ContainerStop(ctx context.Context, containerID string, timeou
 	if timeout != nil {
 		query.Set("t", timetypes.DurationToSecondsString(*timeout))
 	}
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/stop", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+FilterURL(containerID)+"/stop", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_top.go
+++ b/client/container_top.go
@@ -17,7 +17,7 @@ func (cli *Client) ContainerTop(ctx context.Context, containerID string, argumen
 		query.Set("ps_args", strings.Join(arguments, " "))
 	}
 
-	resp, err := cli.get(ctx, "/containers/"+containerID+"/top", query, nil)
+	resp, err := cli.get(ctx, "/containers/"+FilterURL(containerID)+"/top", query, nil)
 	if err != nil {
 		return response, err
 	}

--- a/client/container_unpause.go
+++ b/client/container_unpause.go
@@ -4,7 +4,7 @@ import "context"
 
 // ContainerUnpause resumes the process execution within a container
 func (cli *Client) ContainerUnpause(ctx context.Context, containerID string) error {
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/unpause", nil, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+FilterURL(containerID)+"/unpause", nil, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_update.go
+++ b/client/container_update.go
@@ -10,7 +10,7 @@ import (
 // ContainerUpdate updates resources of a container
 func (cli *Client) ContainerUpdate(ctx context.Context, containerID string, updateConfig container.UpdateConfig) (container.ContainerUpdateOKBody, error) {
 	var response container.ContainerUpdateOKBody
-	serverResp, err := cli.post(ctx, "/containers/"+containerID+"/update", nil, updateConfig, nil)
+	serverResp, err := cli.post(ctx, "/containers/"+FilterURL(containerID)+"/update", nil, updateConfig, nil)
 	if err != nil {
 		return response, err
 	}

--- a/client/container_wait.go
+++ b/client/container_wait.go
@@ -35,7 +35,7 @@ func (cli *Client) ContainerWait(ctx context.Context, containerID string, condit
 	query := url.Values{}
 	query.Set("condition", string(condition))
 
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/wait", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+FilterURL(containerID)+"/wait", query, nil, nil)
 	if err != nil {
 		defer ensureReaderClosed(resp)
 		errC <- err

--- a/client/distribution_inspect.go
+++ b/client/distribution_inspect.go
@@ -27,7 +27,7 @@ func (cli *Client) DistributionInspect(ctx context.Context, image, encodedRegist
 		}
 	}
 
-	resp, err := cli.get(ctx, "/distribution/"+image+"/json", url.Values{}, headers)
+	resp, err := cli.get(ctx, "/distribution/"+FilterURL(image)+"/json", url.Values{}, headers)
 	if err != nil {
 		return distributionInspect, err
 	}

--- a/client/image_history.go
+++ b/client/image_history.go
@@ -11,7 +11,7 @@ import (
 // ImageHistory returns the changes in an image in history format.
 func (cli *Client) ImageHistory(ctx context.Context, imageID string) ([]image.HistoryResponseItem, error) {
 	var history []image.HistoryResponseItem
-	serverResp, err := cli.get(ctx, "/images/"+imageID+"/history", url.Values{}, nil)
+	serverResp, err := cli.get(ctx, "/images/"+FilterURL(imageID)+"/history", url.Values{}, nil)
 	if err != nil {
 		return history, err
 	}

--- a/client/image_inspect.go
+++ b/client/image_inspect.go
@@ -14,7 +14,7 @@ func (cli *Client) ImageInspectWithRaw(ctx context.Context, imageID string) (typ
 	if imageID == "" {
 		return types.ImageInspect{}, nil, objectNotFoundError{object: "image", id: imageID}
 	}
-	serverResp, err := cli.get(ctx, "/images/"+imageID+"/json", nil, nil)
+	serverResp, err := cli.get(ctx, "/images/"+FilterURL(imageID)+"/json", nil, nil)
 	if err != nil {
 		return types.ImageInspect{}, nil, wrapResponseError(err, serverResp, "image", imageID)
 	}

--- a/client/image_push.go
+++ b/client/image_push.go
@@ -51,5 +51,5 @@ func (cli *Client) ImagePush(ctx context.Context, image string, options types.Im
 
 func (cli *Client) tryImagePush(ctx context.Context, imageID string, query url.Values, registryAuth string) (serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
-	return cli.post(ctx, "/images/"+imageID+"/push", query, nil, headers)
+	return cli.post(ctx, "/images/"+FilterURL(imageID)+"/push", query, nil, headers)
 }

--- a/client/image_remove.go
+++ b/client/image_remove.go
@@ -20,7 +20,7 @@ func (cli *Client) ImageRemove(ctx context.Context, imageID string, options type
 	}
 
 	var dels []types.ImageDeleteResponseItem
-	resp, err := cli.delete(ctx, "/images/"+imageID, query, nil)
+	resp, err := cli.delete(ctx, "/images/"+FilterURL(imageID), query, nil)
 	if err != nil {
 		return dels, wrapResponseError(err, resp, "image", imageID)
 	}

--- a/client/image_tag.go
+++ b/client/image_tag.go
@@ -31,7 +31,7 @@ func (cli *Client) ImageTag(ctx context.Context, source, target string) error {
 		query.Set("tag", tagged.Tag())
 	}
 
-	resp, err := cli.post(ctx, "/images/"+source+"/tag", query, nil, nil)
+	resp, err := cli.post(ctx, "/images/"+FilterURL(source)+"/tag", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/names.go
+++ b/client/names.go
@@ -1,0 +1,45 @@
+package client // import "github.com/docker/docker/client"
+
+import (
+	"net/url"
+	"strings"
+)
+
+// FilterURL filters url to avoid invalid req
+func FilterURL(name string) string {
+	bldot := false
+	if strings.HasSuffix(name, "/..") {
+		bldot = true
+	}
+	if strings.HasSuffix(name, "/.") {
+		bldot = true
+	}
+	if strings.HasPrefix(name, "../") {
+		bldot = true
+	}
+	if strings.HasPrefix(name, "./") {
+		bldot = true
+	}
+	if strings.Contains(name, "/../") {
+		bldot = true
+	}
+	if strings.Contains(name, "/./") {
+		bldot = true
+	}
+	if bldot {
+		if strings.HasPrefix(name, "/") {
+			return "/" + url.PathEscape(strings.TrimPrefix(name, "/"))
+		}
+		return url.PathEscape(name)
+	}
+	prefix := ""
+	if strings.HasPrefix(name, "/") {
+		prefix = "/"
+		name = strings.TrimPrefix(name, "/")
+	}
+	nameParts := strings.Split(name, "/")
+	for idx, str := range nameParts {
+		nameParts[idx] = url.PathEscape(str)
+	}
+	return prefix + strings.Join(nameParts, "/")
+}

--- a/client/network_connect.go
+++ b/client/network_connect.go
@@ -13,7 +13,7 @@ func (cli *Client) NetworkConnect(ctx context.Context, networkID, containerID st
 		Container:      containerID,
 		EndpointConfig: config,
 	}
-	resp, err := cli.post(ctx, "/networks/"+networkID+"/connect", nil, nc, nil)
+	resp, err := cli.post(ctx, "/networks/"+FilterURL(networkID)+"/connect", nil, nc, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/network_disconnect.go
+++ b/client/network_disconnect.go
@@ -9,7 +9,7 @@ import (
 // NetworkDisconnect disconnects a container from an existent network in the docker host.
 func (cli *Client) NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error {
 	nd := types.NetworkDisconnect{Container: containerID, Force: force}
-	resp, err := cli.post(ctx, "/networks/"+networkID+"/disconnect", nil, nd, nil)
+	resp, err := cli.post(ctx, "/networks/"+FilterURL(networkID)+"/disconnect", nil, nd, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/network_inspect.go
+++ b/client/network_inspect.go
@@ -33,7 +33,7 @@ func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, 
 	if options.Scope != "" {
 		query.Set("scope", options.Scope)
 	}
-	resp, err = cli.get(ctx, "/networks/"+networkID, query, nil)
+	resp, err = cli.get(ctx, "/networks/"+FilterURL(networkID), query, nil)
 	if err != nil {
 		return networkResource, nil, wrapResponseError(err, resp, "network", networkID)
 	}

--- a/client/network_remove.go
+++ b/client/network_remove.go
@@ -4,7 +4,7 @@ import "context"
 
 // NetworkRemove removes an existent network from the docker host.
 func (cli *Client) NetworkRemove(ctx context.Context, networkID string) error {
-	resp, err := cli.delete(ctx, "/networks/"+networkID, nil, nil)
+	resp, err := cli.delete(ctx, "/networks/"+FilterURL(networkID), nil, nil)
 	ensureReaderClosed(resp)
 	return wrapResponseError(err, resp, "network", networkID)
 }

--- a/client/node_inspect.go
+++ b/client/node_inspect.go
@@ -14,7 +14,7 @@ func (cli *Client) NodeInspectWithRaw(ctx context.Context, nodeID string) (swarm
 	if nodeID == "" {
 		return swarm.Node{}, nil, objectNotFoundError{object: "node", id: nodeID}
 	}
-	serverResp, err := cli.get(ctx, "/nodes/"+nodeID, nil, nil)
+	serverResp, err := cli.get(ctx, "/nodes/"+FilterURL(nodeID), nil, nil)
 	if err != nil {
 		return swarm.Node{}, nil, wrapResponseError(err, serverResp, "node", nodeID)
 	}

--- a/client/node_remove.go
+++ b/client/node_remove.go
@@ -14,7 +14,7 @@ func (cli *Client) NodeRemove(ctx context.Context, nodeID string, options types.
 		query.Set("force", "1")
 	}
 
-	resp, err := cli.delete(ctx, "/nodes/"+nodeID, query, nil)
+	resp, err := cli.delete(ctx, "/nodes/"+FilterURL(nodeID), query, nil)
 	ensureReaderClosed(resp)
 	return wrapResponseError(err, resp, "node", nodeID)
 }

--- a/client/node_update.go
+++ b/client/node_update.go
@@ -12,7 +12,7 @@ import (
 func (cli *Client) NodeUpdate(ctx context.Context, nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 	query := url.Values{}
 	query.Set("version", strconv.FormatUint(version.Index, 10))
-	resp, err := cli.post(ctx, "/nodes/"+nodeID+"/update", query, node, nil)
+	resp, err := cli.post(ctx, "/nodes/"+FilterURL(nodeID)+"/update", query, node, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/plugin_disable.go
+++ b/client/plugin_disable.go
@@ -13,7 +13,7 @@ func (cli *Client) PluginDisable(ctx context.Context, name string, options types
 	if options.Force {
 		query.Set("force", "1")
 	}
-	resp, err := cli.post(ctx, "/plugins/"+name+"/disable", query, nil, nil)
+	resp, err := cli.post(ctx, "/plugins/"+FilterURL(name)+"/disable", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/plugin_enable.go
+++ b/client/plugin_enable.go
@@ -13,7 +13,7 @@ func (cli *Client) PluginEnable(ctx context.Context, name string, options types.
 	query := url.Values{}
 	query.Set("timeout", strconv.Itoa(options.Timeout))
 
-	resp, err := cli.post(ctx, "/plugins/"+name+"/enable", query, nil, nil)
+	resp, err := cli.post(ctx, "/plugins/"+FilterURL(name)+"/enable", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/plugin_inspect.go
+++ b/client/plugin_inspect.go
@@ -14,7 +14,7 @@ func (cli *Client) PluginInspectWithRaw(ctx context.Context, name string) (*type
 	if name == "" {
 		return nil, nil, objectNotFoundError{object: "plugin", id: name}
 	}
-	resp, err := cli.get(ctx, "/plugins/"+name+"/json", nil, nil)
+	resp, err := cli.get(ctx, "/plugins/"+FilterURL(name)+"/json", nil, nil)
 	if err != nil {
 		return nil, nil, wrapResponseError(err, resp, "plugin", name)
 	}

--- a/client/plugin_install.go
+++ b/client/plugin_install.go
@@ -44,7 +44,7 @@ func (cli *Client) PluginInstall(ctx context.Context, name string, options types
 		}
 		defer func() {
 			if err != nil {
-				delResp, _ := cli.delete(ctx, "/plugins/"+name, nil, nil)
+				delResp, _ := cli.delete(ctx, "/plugins/"+FilterURL(name), nil, nil)
 				ensureReaderClosed(delResp)
 			}
 		}()

--- a/client/plugin_push.go
+++ b/client/plugin_push.go
@@ -8,7 +8,7 @@ import (
 // PluginPush pushes a plugin to a registry
 func (cli *Client) PluginPush(ctx context.Context, name string, registryAuth string) (io.ReadCloser, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
-	resp, err := cli.post(ctx, "/plugins/"+name+"/push", nil, nil, headers)
+	resp, err := cli.post(ctx, "/plugins/"+FilterURL(name)+"/push", nil, nil, headers)
 	if err != nil {
 		return nil, err
 	}

--- a/client/plugin_remove.go
+++ b/client/plugin_remove.go
@@ -14,7 +14,7 @@ func (cli *Client) PluginRemove(ctx context.Context, name string, options types.
 		query.Set("force", "1")
 	}
 
-	resp, err := cli.delete(ctx, "/plugins/"+name, query, nil)
+	resp, err := cli.delete(ctx, "/plugins/"+FilterURL(name), query, nil)
 	ensureReaderClosed(resp)
 	return wrapResponseError(err, resp, "plugin", name)
 }

--- a/client/plugin_set.go
+++ b/client/plugin_set.go
@@ -6,7 +6,7 @@ import (
 
 // PluginSet modifies settings for an existing plugin
 func (cli *Client) PluginSet(ctx context.Context, name string, args []string) error {
-	resp, err := cli.post(ctx, "/plugins/"+name+"/set", nil, args, nil)
+	resp, err := cli.post(ctx, "/plugins/"+FilterURL(name)+"/set", nil, args, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/plugin_upgrade.go
+++ b/client/plugin_upgrade.go
@@ -35,5 +35,5 @@ func (cli *Client) PluginUpgrade(ctx context.Context, name string, options types
 
 func (cli *Client) tryPluginUpgrade(ctx context.Context, query url.Values, privileges types.PluginPrivileges, name, registryAuth string) (serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
-	return cli.post(ctx, "/plugins/"+name+"/upgrade", query, privileges, headers)
+	return cli.post(ctx, "/plugins/"+FilterURL(name)+"/upgrade", query, privileges, headers)
 }

--- a/client/secret_inspect.go
+++ b/client/secret_inspect.go
@@ -17,7 +17,7 @@ func (cli *Client) SecretInspectWithRaw(ctx context.Context, id string) (swarm.S
 	if id == "" {
 		return swarm.Secret{}, nil, objectNotFoundError{object: "secret", id: id}
 	}
-	resp, err := cli.get(ctx, "/secrets/"+id, nil, nil)
+	resp, err := cli.get(ctx, "/secrets/"+FilterURL(id), nil, nil)
 	if err != nil {
 		return swarm.Secret{}, nil, wrapResponseError(err, resp, "secret", id)
 	}

--- a/client/secret_remove.go
+++ b/client/secret_remove.go
@@ -7,7 +7,7 @@ func (cli *Client) SecretRemove(ctx context.Context, id string) error {
 	if err := cli.NewVersionError("1.25", "secret remove"); err != nil {
 		return err
 	}
-	resp, err := cli.delete(ctx, "/secrets/"+id, nil, nil)
+	resp, err := cli.delete(ctx, "/secrets/"+FilterURL(id), nil, nil)
 	ensureReaderClosed(resp)
 	return wrapResponseError(err, resp, "secret", id)
 }

--- a/client/secret_update.go
+++ b/client/secret_update.go
@@ -15,7 +15,7 @@ func (cli *Client) SecretUpdate(ctx context.Context, id string, version swarm.Ve
 	}
 	query := url.Values{}
 	query.Set("version", strconv.FormatUint(version.Index, 10))
-	resp, err := cli.post(ctx, "/secrets/"+id+"/update", query, secret, nil)
+	resp, err := cli.post(ctx, "/secrets/"+FilterURL(id)+"/update", query, secret, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/service_inspect.go
+++ b/client/service_inspect.go
@@ -19,7 +19,7 @@ func (cli *Client) ServiceInspectWithRaw(ctx context.Context, serviceID string, 
 	}
 	query := url.Values{}
 	query.Set("insertDefaults", fmt.Sprintf("%v", opts.InsertDefaults))
-	serverResp, err := cli.get(ctx, "/services/"+serviceID, query, nil)
+	serverResp, err := cli.get(ctx, "/services/"+FilterURL(serviceID), query, nil)
 	if err != nil {
 		return swarm.Service{}, nil, wrapResponseError(err, serverResp, "service", serviceID)
 	}

--- a/client/service_logs.go
+++ b/client/service_logs.go
@@ -44,7 +44,7 @@ func (cli *Client) ServiceLogs(ctx context.Context, serviceID string, options ty
 	}
 	query.Set("tail", options.Tail)
 
-	resp, err := cli.get(ctx, "/services/"+serviceID+"/logs", query, nil)
+	resp, err := cli.get(ctx, "/services/"+FilterURL(serviceID)+"/logs", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/service_remove.go
+++ b/client/service_remove.go
@@ -4,7 +4,7 @@ import "context"
 
 // ServiceRemove kills and removes a service.
 func (cli *Client) ServiceRemove(ctx context.Context, serviceID string) error {
-	resp, err := cli.delete(ctx, "/services/"+serviceID, nil, nil)
+	resp, err := cli.delete(ctx, "/services/"+FilterURL(serviceID), nil, nil)
 	ensureReaderClosed(resp)
 	return wrapResponseError(err, resp, "service", serviceID)
 }

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -76,7 +76,7 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 	}
 
 	var response types.ServiceUpdateResponse
-	resp, err := cli.post(ctx, "/services/"+serviceID+"/update", query, service, headers)
+	resp, err := cli.post(ctx, "/services/"+FilterURL(serviceID)+"/update", query, service, headers)
 	if err != nil {
 		return response, err
 	}

--- a/client/task_inspect.go
+++ b/client/task_inspect.go
@@ -14,7 +14,7 @@ func (cli *Client) TaskInspectWithRaw(ctx context.Context, taskID string) (swarm
 	if taskID == "" {
 		return swarm.Task{}, nil, objectNotFoundError{object: "task", id: taskID}
 	}
-	serverResp, err := cli.get(ctx, "/tasks/"+taskID, nil, nil)
+	serverResp, err := cli.get(ctx, "/tasks/"+FilterURL(taskID), nil, nil)
 	if err != nil {
 		return swarm.Task{}, nil, wrapResponseError(err, serverResp, "task", taskID)
 	}

--- a/client/task_logs.go
+++ b/client/task_logs.go
@@ -43,7 +43,7 @@ func (cli *Client) TaskLogs(ctx context.Context, taskID string, options types.Co
 	}
 	query.Set("tail", options.Tail)
 
-	resp, err := cli.get(ctx, "/tasks/"+taskID+"/logs", query, nil)
+	resp, err := cli.get(ctx, "/tasks/"+FilterURL(taskID)+"/logs", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/volume_inspect.go
+++ b/client/volume_inspect.go
@@ -22,7 +22,7 @@ func (cli *Client) VolumeInspectWithRaw(ctx context.Context, volumeID string) (t
 	}
 
 	var volume types.Volume
-	resp, err := cli.get(ctx, "/volumes/"+volumeID, nil, nil)
+	resp, err := cli.get(ctx, "/volumes/"+FilterURL(volumeID), nil, nil)
 	if err != nil {
 		return volume, nil, wrapResponseError(err, resp, "volume", volumeID)
 	}

--- a/client/volume_remove.go
+++ b/client/volume_remove.go
@@ -15,7 +15,7 @@ func (cli *Client) VolumeRemove(ctx context.Context, volumeID string, force bool
 			query.Set("force", "1")
 		}
 	}
-	resp, err := cli.delete(ctx, "/volumes/"+volumeID, query, nil)
+	resp, err := cli.delete(ctx, "/volumes/"+FilterURL(volumeID), query, nil)
 	ensureReaderClosed(resp)
 	return wrapResponseError(err, resp, "volume", volumeID)
 }


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

urlencode containerid and other id when add to url in client library

Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
When add string to URL path, it should urlencode.

**- How I did it**
Add a func to encode container/volume/task/image's id/name
The first / in id/name should not encode.

**- How to verify it**
docker stop /redis/../redis1
Then redis1 will be stopped.
Please see https://github.com/docker/cli/pull/1331

**- Description for the changelog**
urlencode the path

**- A picture of a cute animal**
![sheep](https://user-images.githubusercontent.com/783424/45585533-764e5980-b918-11e8-8b27-b8a5c421d6e8.jpg)

