### PR TITLE
Added memory limit support for LCOW

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -352,6 +352,12 @@ func (daemon *Daemon) createSpecLinuxFields(c *container.Container, s *specs.Spe
 		return fmt.Errorf("linux runtime spec devices: %v", err)
 	}
 	s.Linux.Resources.Devices = devPermissions
+	memoryLimit := uint64(c.HostConfig.Memory)
+	s.Windows.Resources = &specs.WindowsResources{
+		Memory: &specs.WindowsMemoryResources{
+			Limit: &memoryLimit,
+		},
+	}
 	return nil
 }
 

--- a/libcontainerd/client_local_windows.go
+++ b/libcontainerd/client_local_windows.go
@@ -404,6 +404,14 @@ func (c *client) createLinux(id string, spec *specs.Spec, runtimeOptions interfa
 		return fmt.Errorf("spec.Windows must not be nil for LCOW containers")
 	}
 
+	if spec.Windows.Resources != nil {
+		if spec.Windows.Resources.Memory != nil {
+			if spec.Windows.Resources.Memory.Limit != nil {
+				configuration.MemoryMaximumInMB = int64(*spec.Windows.Resources.Memory.Limit) / 1024 / 1024
+			}
+		}
+	}
+
 	// We must have least one layer in the spec
 	if spec.Windows.LayerFolders == nil || len(spec.Windows.LayerFolders) == 0 {
 		return fmt.Errorf("OCI spec is invalid - at least one LayerFolders must be supplied to the runtime")


### PR DESCRIPTION
Signed-off-by: Ryan Daniels <rdaniels6813@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
fixes #37859
Allow memory limits to be set on LCOW containers

Pass through the memory parameter to the spec, then the configuration for LCOW

docker run -ti -m 3GB alpine sh -c "cat /proc/meminfo | grep MemTotal"



Updated spec and config to pass through HostConfig.Memory parameter.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


![20140125_111212](https://user-images.githubusercontent.com/6432517/45591651-01365080-b927-11e8-99d2-5cb8b9d240d8.jpg)

