### PR TITLE
WIP: Use windowsRS4 instead of RS1

### DIFF
--- a/poule.yml
+++ b/poule.yml
@@ -86,8 +86,8 @@
         }
       - type:       rebuild
         settings: {
-            configurations: [ windowsRS1 ],
-            label:          "rebuild/windowsRS1",
+            configurations: [ windowsRS4 ],
+            label:          "rebuild/windowsRS4",
         }
       - type:       rebuild
         settings: {


### PR DESCRIPTION
I noticed that example https://github.com/moby/moby/blob/8e610b2b55bfd1bfa9436ab110d311f5e8a74dcb/integration-cli/docker_api_containers_windows_test.go#L22 test does not run on current windowsRS1 node so I wanted to check if that would work by using RS4 which looks to be there (if I understood this one correctly).

So this PR is there now to be able to see if tests passes on that version.
