### PR TITLE
behavior entrypoint=[""] is different from doc

### DIFF
--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -65,13 +65,14 @@ func merge(userConf, imageConf *containertypes.Config) error {
 		}
 	}
 
-	if len(userConf.Entrypoint) == 0 {
+	blEntrypointEmpty := (len(userConf.Entrypoint) == 1 && len(userConf.Entrypoint[0]) == 0)
+	if len(userConf.Entrypoint) == 0 || blEntrypointEmpty {
 		if len(userConf.Cmd) == 0 {
 			userConf.Cmd = imageConf.Cmd
 			userConf.ArgsEscaped = imageConf.ArgsEscaped
 		}
 
-		if userConf.Entrypoint == nil {
+		if userConf.Entrypoint == nil || blEntrypointEmpty {
 			userConf.Entrypoint = imageConf.Entrypoint
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
When entrypoint=[""], daemon said:
panic: Error response from daemon: No command specified
But in https://docs.docker.com/engine/api/v1.37/#operation/ContainerCreate said:
```
Entrypoint | stringThe entry point for the container as a string or an array of strings.

If the array consists of exactly one empty string ([""]) then the entry point is reset to system default (i.e., the entry point used by docker when there is no ENTRYPOINT instruction in the Dockerfile).
```
So, daemon should not response an error.

**- How I did it**
in daemon/commit.go, I checked this situation to set the default entrypoint.

**- How to verify it**
test code:
```go
package main

import (
    "os"

    "github.com/docker/docker/client"
    "github.com/docker/docker/api/types"
    "github.com/docker/docker/api/types/container"
    "github.com/docker/docker/pkg/stdcopy"

    "golang.org/x/net/context"
)

func main() {
    ctx := context.Background()
    cli, err := client.NewEnvClient()
    if err != nil {
        panic(err)
    }

    // entryPoint is [""]
    entryPoint := []string{""}
    resp, err := cli.ContainerCreate(ctx, &container.Config{
        Image: "redis",
        Entrypoint:  entryPoint,
    }, nil, nil, "")
    if err != nil {
        panic(err)
    }

    if err := cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
        panic(err)
    }

    statusCh, errCh := cli.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
    select {
    case err := <-errCh:
        if err != nil {
            panic(err)
        }
    case <-statusCh:
    }

    out, err := cli.ContainerLogs(ctx, resp.ID, types.ContainerLogsOptions{ShowStdout: true})
    if err != nil {
        panic(err)
    }

    stdcopy.StdCopy(os.Stdout, os.Stderr, out)
}
```

**- Description for the changelog**
When len(EntryPoint[0]) == 0, the daemon should set the default entrypoint.


**- A picture of a cute animal**
![ufr465u fy6uh 4b l 81s](https://user-images.githubusercontent.com/783424/45620461-9b290500-baaf-11e8-857a-5aafbdb0ffc3.png)
