### PR TITLE
`ONBUILD {RUN,CMD,ENTRYPOINT}` may also contain `@SH`

### DIFF
--- a/contrib/syntax/vim/syntax/dockerfile.vim
+++ b/contrib/syntax/vim/syntax/dockerfile.vim
@@ -11,7 +11,7 @@ let b:current_syntax = "dockerfile"
 
 syntax case ignore
 
-syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL|MAINTAINER|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR)\s/
+syntax match dockerfileKeyword /\v^\s*%(ONBUILD\s+)?%(ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL|MAINTAINER|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR)\s/
 highlight link dockerfileKeyword Keyword
 
 syntax region dockerfileString start=/\v"/ skip=/\v\\./ end=/\v"/
@@ -27,5 +27,5 @@ let s:current_syntax = b:current_syntax
 unlet b:current_syntax
 syntax include @SH syntax/sh.vim
 let b:current_syntax = s:current_syntax
-syntax region shLine matchgroup=dockerfileKeyword start=/\v^\s*(RUN|CMD|ENTRYPOINT)\s/ end=/\v$/ contains=@SH
+syntax region shLine matchgroup=dockerfileKeyword start=/\v^\s*%(ONBUILD\s+)?%(RUN|CMD|ENTRYPOINT)\s/ end=/\v$/ contains=@SH
 " since @SH will handle "\" as part of the same line automatically, this "just works" for line continuation too, but with the caveat that it will highlight "RUN echo '" followed by a newline as if it were a block because the "'" is shell line continuation...  not sure how to fix that just yet (TODO)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Update `vim` syntax highlighting.

**- How I did it**

With `vim`, naturally.

**- How to verify it**

Use `vim` ... you get the idea.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

`vim` syntax updated to recognize shell commands in `ONBUILD`




Fixes a quirk of the highlighting; namely that until now, this:

    RUN echo "hi!"

...has been treated as though it may contain shell, while:

    ONBUILD RUN echo "hi!"

...hasn't.

Signed-off-by: Chris Weyl <cweyl@alumni.drew.edu>