### PR TITLE
typo fix retreived

### DIFF
--- a/volume/service/opts/opts.go
+++ b/volume/service/opts/opts.go
@@ -58,7 +58,7 @@ func WithGetDriver(name string) GetOption {
 }
 
 // WithGetReference indicates to `Get` to increment the reference count for the
-// retreived volume with the provided reference ID.
+// retrieved volume with the provided reference ID.
 func WithGetReference(ref string) GetOption {
 	return func(o *GetConfig) {
 		o.Reference = ref


### PR DESCRIPTION
typo fix for volume/service/opts/opts.go
