### PR TITLE
oldName release too early when docker rename

### DIFF
--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -74,6 +74,8 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 				daemon.containersReplica.ReleaseName(newName + k)
 			}
 			daemon.releaseName(newName)
+		} else {
+			daemon.releaseName(oldName)
 		}
 	}()
 
@@ -81,7 +83,6 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 		daemon.linkIndex.unlink(oldName+k, v, container)
 		daemon.containersReplica.ReleaseName(oldName + k)
 	}
-	daemon.releaseName(oldName)
 	if err = container.CheckpointTo(daemon.containersReplica); err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
When I review code in daemon/rename.go, I think there is a flaw in this code. May be need to improve.

If I run: `docker rename redis01 redis0`
In https://github.com/moby/moby/blob/4f0d95fa6ee7f865597c03b9e63702cdcb0f7067/daemon/rename.go#L84
there is a code: daemon.releaseName(oldName)
oldName is released when succ.

But there is a defer in https://github.com/moby/moby/blob/4f0d95fa6ee7f865597c03b9e63702cdcb0f7067/daemon/rename.go#L69
daemon.reserveName(container.ID, oldName) when there is an error.

After release old Name in line 84, there are many operations which may raise an error.
If there is an error, container should change back it's old name redis01.
If in this time, if oldName=redis01 is used by another container? What will be happened?

For example, there is a small probability, if in another window, I run this command:
`docker rename redisps0 redis01`
oldName=redis01 is released before, this command can success. Then redis01 is used by this container.

**- How I did it**
**put releaseName(oldName) in defer, when there is no err, oldName will be released at last.**

**- How to verify it**
raise a fake error in https://github.com/moby/moby/blob/4f0d95fa6ee7f865597c03b9e63702cdcb0f7067/container/container.go#L193 to simulate this situation.

```go
func (container *Container) CheckpointTo(store ViewDB) error {
        deepCopy, err := container.toDisk()
        if container.Name == "/redis0" {
                wt := 10 * time.Second
                <-time.After(wt)
                err = fmt.Errorf("FakeError")
        }
        if err != nil {
                return err
        }
        return store.Save(deepCopy)
}
```

**- Description for the changelog**
There is a flaw in "daemon\rename.go". It may make a container lose his name when rename failure.