### PR TITLE
fixes check container name in api router

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/versions"
 	containerpkg "github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/names"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/signal"
@@ -30,6 +31,10 @@ func (s *containerRouter) postCommit(ctx context.Context, w http.ResponseWriter,
 	}
 
 	if err := httputils.CheckForJSON(r); err != nil {
+		return err
+	}
+
+	if valid, err := names.ValidateName(r.Form.Get("container")); !valid {
 		return err
 	}
 
@@ -100,6 +105,9 @@ func (s *containerRouter) getContainersStats(ctx context.Context, w http.Respons
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
+	if valid, err := names.ValidateName(vars["name"]); !valid {
+		return err
+	}
 
 	stream := httputils.BoolValueOrDefault(r, "stream", true)
 	if !stream {
@@ -117,6 +125,9 @@ func (s *containerRouter) getContainersStats(ctx context.Context, w http.Respons
 
 func (s *containerRouter) getContainersLogs(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+	if valid, err := names.ValidateName(vars["name"]); !valid {
 		return err
 	}
 
@@ -156,6 +167,9 @@ func (s *containerRouter) getContainersLogs(ctx context.Context, w http.Response
 }
 
 func (s *containerRouter) getContainersExport(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if valid, err := names.ValidateName(vars["name"]); !valid {
+		return err
+	}
 	return s.backend.ContainerExport(vars["name"], w)
 }
 
@@ -197,6 +211,9 @@ func (s *containerRouter) postContainersStart(ctx context.Context, w http.Respon
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
+	if valid, err := names.ValidateName(vars["name"]); !valid {
+		return err
+	}
 
 	checkpoint := r.Form.Get("checkpoint")
 	checkpointDir := r.Form.Get("checkpoint-dir")
@@ -210,6 +227,9 @@ func (s *containerRouter) postContainersStart(ctx context.Context, w http.Respon
 
 func (s *containerRouter) postContainersStop(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+	if valid, err := names.ValidateName(vars["name"]); !valid {
 		return err
 	}
 
@@ -232,6 +252,9 @@ func (s *containerRouter) postContainersStop(ctx context.Context, w http.Respons
 
 func (s *containerRouter) postContainersKill(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+	if valid, err := names.ValidateName(vars["name"]); !valid {
 		return err
 	}
 
@@ -269,6 +292,9 @@ func (s *containerRouter) postContainersRestart(ctx context.Context, w http.Resp
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
+	if valid, err := names.ValidateName(vars["name"]); !valid {
+		return err
+	}
 
 	var seconds *int
 	if tmpSeconds := r.Form.Get("t"); tmpSeconds != "" {
@@ -292,6 +318,9 @@ func (s *containerRouter) postContainersPause(ctx context.Context, w http.Respon
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
+	if valid, err := names.ValidateName(vars["name"]); !valid {
+		return err
+	}
 
 	if err := s.backend.ContainerPause(vars["name"]); err != nil {
 		return err
@@ -304,6 +333,9 @@ func (s *containerRouter) postContainersPause(ctx context.Context, w http.Respon
 
 func (s *containerRouter) postContainersUnpause(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+	if valid, err := names.ValidateName(vars["name"]); !valid {
 		return err
 	}
 
@@ -336,6 +368,9 @@ func (s *containerRouter) postContainersWait(ctx context.Context, w http.Respons
 			waitCondition = containerpkg.WaitConditionRemoved
 			legacyRemovalWaitPre134 = versions.LessThan(version, "1.34")
 		}
+	}
+	if valid, err := names.ValidateName(vars["name"]); !valid {
+		return err
 	}
 
 	// Note: the context should get canceled if the client closes the
@@ -379,6 +414,9 @@ func (s *containerRouter) postContainersWait(ctx context.Context, w http.Respons
 }
 
 func (s *containerRouter) getContainersChanges(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if valid, err := names.ValidateName(vars["name"]); !valid {
+		return err
+	}
 	changes, err := s.backend.ContainerChanges(vars["name"])
 	if err != nil {
 		return err
@@ -389,6 +427,9 @@ func (s *containerRouter) getContainersChanges(ctx context.Context, w http.Respo
 
 func (s *containerRouter) getContainersTop(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+	if valid, err := names.ValidateName(vars["name"]); !valid {
 		return err
 	}
 
@@ -402,6 +443,9 @@ func (s *containerRouter) getContainersTop(ctx context.Context, w http.ResponseW
 
 func (s *containerRouter) postContainerRename(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+	if valid, err := names.ValidateName(vars["name"]); !valid {
 		return err
 	}
 
@@ -419,6 +463,9 @@ func (s *containerRouter) postContainerUpdate(ctx context.Context, w http.Respon
 		return err
 	}
 	if err := httputils.CheckForJSON(r); err != nil {
+		return err
+	}
+	if valid, err := names.ValidateName(vars["name"]); !valid {
 		return err
 	}
 
@@ -483,6 +530,11 @@ func (s *containerRouter) deleteContainers(ctx context.Context, w http.ResponseW
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
+	if !httputils.BoolValue(r, "link") {
+		if valid, err := names.ValidateName(vars["name"]); !valid {
+			return err
+		}
+	}
 
 	name := vars["name"]
 	config := &types.ContainerRmConfig{
@@ -504,6 +556,9 @@ func (s *containerRouter) postContainersResize(ctx context.Context, w http.Respo
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
+	if valid, err := names.ValidateName(vars["name"]); !valid {
+		return err
+	}
 
 	height, err := strconv.Atoi(r.Form.Get("h"))
 	if err != nil {
@@ -523,6 +578,9 @@ func (s *containerRouter) postContainersAttach(ctx context.Context, w http.Respo
 		return err
 	}
 	containerName := vars["name"]
+	if valid, err := names.ValidateName(containerName); !valid {
+		return err
+	}
 
 	_, upgrade := r.Header["Upgrade"]
 	detachKeys := r.FormValue("detachKeys")
@@ -586,6 +644,9 @@ func (s *containerRouter) wsContainersAttach(ctx context.Context, w http.Respons
 		return err
 	}
 	containerName := vars["name"]
+	if valid, err := names.ValidateName(containerName); !valid {
+		return err
+	}
 
 	var err error
 	detachKeys := r.FormValue("detachKeys")

--- a/api/server/router/container/copy.go
+++ b/api/server/router/container/copy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/daemon/names"
 	gddohttputil "github.com/golang/gddo/httputil"
 )
 
@@ -32,6 +33,9 @@ func (s *containerRouter) postContainersCopy(ctx context.Context, w http.Respons
 		return nil
 	}
 	if err := httputils.CheckForJSON(r); err != nil {
+		return err
+	}
+	if valid, err := names.ValidateName(vars["name"]); !valid {
 		return err
 	}
 
@@ -75,6 +79,9 @@ func (s *containerRouter) headContainersArchive(ctx context.Context, w http.Resp
 	if err != nil {
 		return err
 	}
+	if valid, err := names.ValidateName(v.Name); !valid {
+		return err
+	}
 
 	stat, err := s.backend.ContainerStatPath(v.Name, v.Path)
 	if err != nil {
@@ -112,6 +119,9 @@ func (s *containerRouter) getContainersArchive(ctx context.Context, w http.Respo
 	if err != nil {
 		return err
 	}
+	if valid, err := names.ValidateName(v.Name); !valid {
+		return err
+	}
 
 	tarArchive, stat, err := s.backend.ContainerArchivePath(v.Name, v.Path)
 	if err != nil {
@@ -130,6 +140,9 @@ func (s *containerRouter) getContainersArchive(ctx context.Context, w http.Respo
 func (s *containerRouter) putContainersArchive(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	v, err := httputils.ArchiveFormValues(r, vars)
 	if err != nil {
+		return err
+	}
+	if valid, err := names.ValidateName(v.Name); !valid {
 		return err
 	}
 

--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/daemon/names"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/sirupsen/logrus"
@@ -41,6 +42,9 @@ func (s *containerRouter) postContainerExecCreate(ctx context.Context, w http.Re
 		return err
 	}
 	name := vars["name"]
+	if valid, err := names.ValidateName(name); !valid {
+		return err
+	}
 
 	execConfig := &types.ExecConfig{}
 	if err := json.NewDecoder(r.Body).Decode(execConfig); err != nil {
@@ -81,6 +85,9 @@ func (s *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 		stdin, inStream           io.ReadCloser
 		stdout, stderr, outStream io.Writer
 	)
+	if valid, err := names.ValidateName(execName); !valid {
+		return err
+	}
 
 	execStartCheck := &types.ExecStartCheck{}
 	if err := json.NewDecoder(r.Body).Decode(execStartCheck); err != nil {
@@ -134,6 +141,9 @@ func (s *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 
 func (s *containerRouter) postContainerExecResize(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+	if valid, err := names.ValidateName(vars["name"]); !valid {
 		return err
 	}
 	height, err := strconv.Atoi(r.Form.Get("h"))

--- a/api/server/router/container/inspect.go
+++ b/api/server/router/container/inspect.go
@@ -5,10 +5,30 @@ import (
 	"net/http"
 
 	"github.com/docker/docker/api/server/httputils"
+	"github.com/docker/docker/daemon/names"
 )
+
+func containerNotFound(id string) error {
+	return objNotFoundError{"container", id}
+}
+
+type objNotFoundError struct {
+	object string
+	id     string
+}
+
+func (e objNotFoundError) Error() string {
+	return "No such " + e.object + ": " + e.id
+}
+
+func (e objNotFoundError) NotFound() {}
 
 // getContainersByName inspects container's configuration and serializes it as json.
 func (s *containerRouter) getContainersByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if valid, err := names.ValidateName(vars["name"]); !valid && err != nil {
+		// for compatible with old, we need to raise a fake containerNotFound error
+		return containerNotFound(vars["name"])
+	}
 	displaySize := httputils.BoolValue(r, "size")
 
 	version := httputils.VersionFromContext(ctx)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -9,6 +9,7 @@ import (
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/names"
 	"github.com/docker/docker/errdefs"
 	_ "github.com/docker/docker/pkg/discovery/memory"
 	"github.com/docker/docker/pkg/idtools"
@@ -130,13 +131,13 @@ func TestValidContainerNames(t *testing.T) {
 	validNames := []string{"word-word", "word_word", "1weoid"}
 
 	for _, name := range invalidNames {
-		if validContainerNamePattern.MatchString(name) {
+		if names.RestrictedNamePattern.MatchString(name) {
 			t.Fatalf("%q is not a valid container name and was returned as valid.", name)
 		}
 	}
 
 	for _, name := range validNames {
-		if !validContainerNamePattern.MatchString(name) {
+		if !names.RestrictedNamePattern.MatchString(name) {
 			t.Fatalf("%q is a valid container name and was returned as invalid.", name)
 		}
 	}

--- a/daemon/names.go
+++ b/daemon/names.go
@@ -2,20 +2,13 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/names"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-)
-
-var (
-	validContainerNameChars   = names.RestrictedNameChars
-	validContainerNamePattern = names.RestrictedNamePattern
 )
 
 func (daemon *Daemon) registerName(container *container.Container) error {
@@ -56,8 +49,8 @@ func (daemon *Daemon) generateIDAndName(name string) (string, string, error) {
 }
 
 func (daemon *Daemon) reserveName(id, name string) (string, error) {
-	if !validContainerNamePattern.MatchString(strings.TrimPrefix(name, "/")) {
-		return "", errdefs.InvalidParameter(errors.Errorf("Invalid container name (%s), only %s are allowed", name, validContainerNameChars))
+	if valid, e := names.ValidateContainerName(name); !valid {
+		return "", e
 	}
 	if name[0] != '/' {
 		name = "/" + name

--- a/daemon/names/names.go
+++ b/daemon/names/names.go
@@ -1,9 +1,32 @@
 package names // import "github.com/docker/docker/daemon/names"
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+
+	"github.com/docker/docker/errdefs"
+	"github.com/pkg/errors"
+)
 
 // RestrictedNameChars collects the characters allowed to represent a name, normally used to validate container and volume names.
 const RestrictedNameChars = `[a-zA-Z0-9][a-zA-Z0-9_.-]`
 
 // RestrictedNamePattern is a regular expression to validate names against the collection of restricted characters.
 var RestrictedNamePattern = regexp.MustCompile(`^` + RestrictedNameChars + `+$`)
+
+// ValidateContainerName is to check container's name is valid or not
+func ValidateContainerName(name string) (bool, error) {
+	valid := RestrictedNamePattern.MatchString(strings.TrimPrefix(name, "/"))
+	if valid {
+		return valid, nil
+	}
+	return valid, errdefs.InvalidParameter(errors.Errorf("Invalid container name (%s), only %s are allowed", name, RestrictedNameChars))
+}
+
+// ValidateName is to check container's name is valid or not
+func ValidateName(name string) (bool, error) {
+	if len(name) == 0 {
+		return true, nil
+	}
+	return ValidateContainerName(name)
+}

--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -2,6 +2,7 @@ package container // import "github.com/docker/docker/integration/container"
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -207,7 +208,7 @@ func TestRenameContainerWithLinkedContainer(t *testing.T) {
 	err := client.ContainerRename(ctx, app1Name, app2Name)
 	assert.NilError(t, err)
 
-	inspect, err := client.ContainerInspect(ctx, app2Name+"/mysql")
+	inspect, err := client.ContainerInspect(ctx, app2Name)
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal(db1ID, inspect.ID))
+	assert.Check(t, is.Equal("/"+db1Name+":/"+app2Name+"/mysql", strings.Join(inspect.HostConfig.Links, "")))
 }


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
**ubunturedis/redisrr is not a container name.**
Not in swarm, just in docker:
Why api like `curl -d "" http://localhost:8410/containers/ubunturedis/redisrr/stop` can work.
```
root@dockerdemo:~# docker ps
CONTAINER ID        IMAGE                                     COMMAND                  CREATED             STATUS              PORTS               NAMES
82cbd046de2d        docker.acmcoder.com/public/ubuntu:ssh     "/bin/bash"              5 hours ago         Up 5 hours                              ubunturedis
2f2b1bcda0f1        docker.acmcoder.com/public/redis:testps   "/sto 6379"              16 hours ago        Up 1 second         6379/tcp            redisps
1c03134d6d52        ea65df922582                              "docker-entrypoint.s…"   2 weeks ago         Up 5 hours          6379/tcp            redisrr
root@dockerdemo:~# curl -d "" http://localhost:8410/containers/ubunturedis/redisrr/stop
root@dockerdemo:~# docker ps
CONTAINER ID        IMAGE                                     COMMAND             CREATED             STATUS              PORTS               NAMES
82cbd046de2d        docker.acmcoder.com/public/ubuntu:ssh     "/bin/bash"         5 hours ago         Up 5 hours                              ubunturedis
2f2b1bcda0f1        docker.acmcoder.com/public/redis:testps   "/sto 6379"         16 hours ago        Up 26 seconds       6379/tcp            redisps
```
container with name redisrr is stopped.

Because redisrr is linked by ubunturedis.
Even though redisrr's name is changed, ubunturedis/redisrr can be stopped through api.

So I add a name check in container api router.

**- How I did it**
Before need to call service in api, check container's name first.
**There are two special cases:**
1. docker rm --link, is different from docker rm;
2. docker inspect ***, after check name, we should return a NotFound err, but not InvalidParameter, because we need to find image or other things.

**- How to verify it**
```
root@dockerdemo:~/moby# curl -d "" http://localhost:8410/containers/ubunturedis%2Fredisrr/stop
{"message":"Invalid container name (ubunturedis/redisrr), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed"}
root@dockerdemo:~/moby# curl http://localhost:8410/containers/ubunturedis/redisrr/json
{"message":"Invalid container name (ubunturedis/redisrr), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed"}
root@dockerdemo:~/moby# curl http://localhost:8410/containers/redisrr/json
{"Id":"1c03134d6d52889cc48e276faa2e7dc761a82a33de9333c39e645cdda9206ff2","....
```

**- Description for the changelog**
add container's name check first before call real service in container api router.

**- A picture of a cute animal**
![timg](https://user-images.githubusercontent.com/783424/45893385-9e98f500-bdfd-11e8-9239-f39bc905770a.jpg)
