### PR TITLE
fixes integration test case TestCreateWithInvalidHealthcheckParams in…

### DIFF
--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -372,7 +373,9 @@ func TestCreateWithInvalidHealthcheckParams(t *testing.T) {
 				"Healthcheck": healthCheck,
 			}
 
-			res, body, err := request.Post("/containers/create?name="+fmt.Sprintf("test_%d_", i)+t.Name(), request.JSONBody(config))
+			name := strings.Replace(t.Name(), "/", "_", -1)
+			name = strings.Replace(name, ":", "_", -1)
+			res, body, err := request.Post("/containers/create?name="+fmt.Sprintf("test_%d_", i)+name, request.JSONBody(config))
 			assert.NilError(t, err)
 
 			if versions.LessThan(testEnv.DaemonAPIVersion(), "1.32") {


### PR DESCRIPTION
… container create test

Signed-off-by: Lifubang <lifubang@acmcoder.com>
**- What I did**
container name test_0_TestCreateWithInvalidHealthcheckParams/test_invalid_Interval_in_Healthcheck:_less_than_0s is invalid. So we need to replace /. to _

**- How I did it**
Replace them

**- How to verify it**
```
22:33:18 --- FAIL: TestCreateWithInvalidHealthcheckParams (0.01s)
22:33:18     --- FAIL: TestCreateWithInvalidHealthcheckParams/test_invalid_Interval_in_Healthcheck:_less_than_0s (0.00s)
22:33:18         create_test.go:387: assertion failed: string "{\"message\":\"Invalid container name (test_0_TestCreateWithInvalidHealthcheckParams/test_invalid_Interval_in_Healthcheck:_less_than_0s), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed\"}\n" does not contain "Interval in Healthcheck cannot be less than 1ms"
22:33:18     --- FAIL: TestCreateWithInvalidHealthcheckParams/test_invalid_StartPeriod_in_Healthcheck:_not_0_and_less_than_1ms (0.00s)
22:33:18         create_test.go:387: assertion failed: string "{\"message\":\"Invalid container name (test_4_TestCreateWithInvalidHealthcheckParams/test_invalid_StartPeriod_in_Healthcheck:_not_0_and_less_than_1ms), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed\"}\n" does not contain "StartPeriod in Healthcheck cannot be less than 1ms"
22:33:18     --- FAIL: TestCreateWithInvalidHealthcheckParams/test_invalid_Retries_in_Healthcheck:_less_than_0 (0.00s)
22:33:18         create_test.go:387: assertion failed: string "{\"message\":\"Invalid container name (test_3_TestCreateWithInvalidHealthcheckParams/test_invalid_Retries_in_Healthcheck:_less_than_0), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed\"}\n" does not contain "Retries in Healthcheck cannot be negative"
22:33:18     --- FAIL: TestCreateWithInvalidHealthcheckParams/test_invalid_Timeout_in_Healthcheck:_less_than_1ms (0.00s)
22:33:18         create_test.go:387: assertion failed: string "{\"message\":\"Invalid container name (test_2_TestCreateWithInvalidHealthcheckParams/test_invalid_Timeout_in_Healthcheck:_less_than_1ms), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed\"}\n" does not contain "Timeout in Healthcheck cannot be less than 1ms"
22:33:18     --- FAIL: TestCreateWithInvalidHealthcheckParams/test_invalid_Interval_in_Healthcheck:_larger_than_0s_but_less_than_1ms (0.00s)
22:33:18         create_test.go:387: assertion failed: string "{\"message\":\"Invalid container name (test_1_TestCreateWithInvalidHealthcheckParams/test_invalid_Interval_in_Healthcheck:_larger_than_0s_but_less_than_1ms), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed\"}\n" does not contain "Interval in Healthcheck cannot be less than 1ms"
```

**- Description for the changelog**
use a valid container name in TestCreateWithInvalidHealthcheckParams


**- A picture of a cute animal**
![uk du8n c09t 33zwgra](https://user-images.githubusercontent.com/783424/45910183-8e067000-be39-11e8-90ee-4a32d922d81b.png)

