### PR TITLE
fixes display text in Multiple IDs found with provided prefix

### DIFF
--- a/pkg/truncindex/truncindex.go
+++ b/pkg/truncindex/truncindex.go
@@ -108,7 +108,7 @@ func (idx *TruncIndex) Get(s string) (string, error) {
 		if id != "" {
 			// we haven't found the ID if there are two or more IDs
 			id = ""
-			return ErrAmbiguousPrefix{prefix: string(prefix)}
+			return ErrAmbiguousPrefix{prefix: s}
 		}
 		id = string(prefix)
 		return nil


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/38345


Signed-off-by: Lifubang <lifubang@acmcoder.com>

A simple improvement:
```
root@dockerdemo:~/moby# docker inspect eb
[]
Error response from daemon: Multiple IDs found with provided prefix: ebefe0365a6b63a22f155914056624dde6fa7917c3c21d42dbcdf982a1c77847
```

ebefe0365a6b63a22f155914056624dde6fa7917c3c21d42dbcdf982a1c77847 is not a prefx. It should be eb.
If you want to display result id, I think we should display the two ids found by prefix "eb". Why display the second one, not the first one?

So, I this it should be:
```
root@dockerdemo:~/moby# docker inspect eb
[]
Error response from daemon: Multiple IDs found with provided prefix: eb
```