### PR TITLE
Add configurable volume plugin API timeout

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -70,6 +70,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.Var(opts.NewNamedListOptsRef("node-generic-resources", &conf.NodeGenericResources, opts.ValidateSingleGenericResource), "node-generic-resource", "Advertise user-defined resource")
 
 	flags.IntVar(&conf.NetworkControlPlaneMTU, "network-control-plane-mtu", config.DefaultNetworkMtu, "Network Control plane MTU")
+	flags.IntVar(&conf.VolumePluginAPITimeout, "volume-plugin-api-timeout", config.DefaultVolumePluginAPITimeout, "Timeout (in seconds) for volume plugin API's to complete")
 
 	// "--deprecated-key-path" is to allow configuration of the key used
 	// for the daemon ID and the deprecated image signing. It was never

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -43,6 +43,8 @@ const (
 	DisableNetworkBridge = "none"
 	// DefaultInitBinary is the name of the default init binary
 	DefaultInitBinary = "docker-init"
+	// DefaultVolumePluginAPITimeout is the default timeout (in seconds) for volume plugin API calls
+	DefaultVolumePluginAPITimeout = 120
 )
 
 // flatOptions contains configuration keys
@@ -229,6 +231,8 @@ type CommonConfig struct {
 	Features map[string]bool `json:"features,omitempty"`
 
 	Builder BuilderConfig `json:"builder,omitempty"`
+
+	VolumePluginAPITimeout int `json:"volume-plugin-api-timeout,omitempty"`
 }
 
 // IsValueSet returns true if a configuration value

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -634,6 +634,7 @@ func (daemon *Daemon) IsSwarmCompatible() error {
 // requests from the webserver.
 func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.Store) (daemon *Daemon, err error) {
 	setDefaultMtu(config)
+	setDefaultVolumePluginTImeout(config)
 
 	registryService, err := registry.NewService(config.ServiceOptions)
 	if err != nil {
@@ -884,7 +885,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		return nil, err
 	}
 
-	d.volumes, err = volumesservice.NewVolumeService(config.Root, d.PluginStore, rootIDs, d)
+	d.volumes, err = volumesservice.NewVolumeService(config.Root, d.PluginStore, rootIDs, d, time.Duration(config.VolumePluginAPITimeout)*time.Second)
 	if err != nil {
 		return nil, err
 	}
@@ -1249,6 +1250,14 @@ func setDefaultMtu(conf *config.Config) {
 		return
 	}
 	conf.Mtu = config.DefaultNetworkMtu
+}
+
+func setDefaultVolumePluginTImeout(conf *config.Config) {
+	// do nothing if the config does not have the default 0 value.
+	if conf.VolumePluginAPITimeout != 0 {
+		return
+	}
+	conf.VolumePluginAPITimeout = config.DefaultVolumePluginAPITimeout
 }
 
 // IsShuttingDown tells whether the daemon is shutting down or not

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -118,7 +118,7 @@ func initDaemonWithVolumeStore(tmp string) (*Daemon, error) {
 		repository: tmp,
 		root:       tmp,
 	}
-	daemon.volumes, err = volumesservice.NewVolumeService(tmp, nil, idtools.Identity{UID: 0, GID: 0}, daemon)
+	daemon.volumes, err = volumesservice.NewVolumeService(tmp, nil, idtools.Identity{UID: 0, GID: 0}, daemon, 120)
 	if err != nil {
 		return nil, err
 	}

--- a/volume/drivers/extpoint_test.go
+++ b/volume/drivers/extpoint_test.go
@@ -2,12 +2,13 @@ package drivers // import "github.com/docker/docker/volume/drivers"
 
 import (
 	"testing"
+	"time"
 
 	volumetestutils "github.com/docker/docker/volume/testutils"
 )
 
 func TestGetDriver(t *testing.T) {
-	s := NewStore(nil)
+	s := NewStore(nil, time.Minute*1)
 	_, err := s.GetDriver("missing")
 	if err == nil {
 		t.Fatal("Expected error, was nil")

--- a/volume/drivers/proxy.go
+++ b/volume/drivers/proxy.go
@@ -10,17 +10,13 @@ import (
 	"github.com/docker/docker/volume"
 )
 
-const (
-	longTimeout  = 2 * time.Minute
-	shortTimeout = 1 * time.Minute
-)
-
 type client interface {
 	CallWithOptions(string, interface{}, interface{}, ...func(*plugins.RequestOpts)) error
 }
 
 type volumeDriverProxy struct {
 	client
+	pluginAPITimeout time.Duration
 }
 
 type volumeDriverProxyCreateRequest struct {
@@ -41,7 +37,7 @@ func (pp *volumeDriverProxy) Create(name string, opts map[string]string) (err er
 	req.Name = name
 	req.Opts = opts
 
-	if err = pp.CallWithOptions("VolumeDriver.Create", req, &ret, plugins.WithRequestTimeout(longTimeout)); err != nil {
+	if err = pp.CallWithOptions("VolumeDriver.Create", req, &ret, plugins.WithRequestTimeout(pp.pluginAPITimeout)); err != nil {
 		return
 	}
 
@@ -68,7 +64,7 @@ func (pp *volumeDriverProxy) Remove(name string) (err error) {
 
 	req.Name = name
 
-	if err = pp.CallWithOptions("VolumeDriver.Remove", req, &ret, plugins.WithRequestTimeout(shortTimeout)); err != nil {
+	if err = pp.CallWithOptions("VolumeDriver.Remove", req, &ret, plugins.WithRequestTimeout(pp.pluginAPITimeout)); err != nil {
 		return
 	}
 
@@ -96,7 +92,7 @@ func (pp *volumeDriverProxy) Path(name string) (mountpoint string, err error) {
 
 	req.Name = name
 
-	if err = pp.CallWithOptions("VolumeDriver.Path", req, &ret, plugins.WithRequestTimeout(shortTimeout)); err != nil {
+	if err = pp.CallWithOptions("VolumeDriver.Path", req, &ret, plugins.WithRequestTimeout(pp.pluginAPITimeout)); err != nil {
 		return
 	}
 
@@ -128,7 +124,7 @@ func (pp *volumeDriverProxy) Mount(name string, id string) (mountpoint string, e
 	req.Name = name
 	req.ID = id
 
-	if err = pp.CallWithOptions("VolumeDriver.Mount", req, &ret, plugins.WithRequestTimeout(longTimeout)); err != nil {
+	if err = pp.CallWithOptions("VolumeDriver.Mount", req, &ret, plugins.WithRequestTimeout(pp.pluginAPITimeout)); err != nil {
 		return
 	}
 
@@ -159,7 +155,7 @@ func (pp *volumeDriverProxy) Unmount(name string, id string) (err error) {
 	req.Name = name
 	req.ID = id
 
-	if err = pp.CallWithOptions("VolumeDriver.Unmount", req, &ret, plugins.WithRequestTimeout(shortTimeout)); err != nil {
+	if err = pp.CallWithOptions("VolumeDriver.Unmount", req, &ret, plugins.WithRequestTimeout(pp.pluginAPITimeout)); err != nil {
 		return
 	}
 
@@ -184,7 +180,7 @@ func (pp *volumeDriverProxy) List() (volumes []*proxyVolume, err error) {
 		ret volumeDriverProxyListResponse
 	)
 
-	if err = pp.CallWithOptions("VolumeDriver.List", req, &ret, plugins.WithRequestTimeout(shortTimeout)); err != nil {
+	if err = pp.CallWithOptions("VolumeDriver.List", req, &ret, plugins.WithRequestTimeout(pp.pluginAPITimeout)); err != nil {
 		return
 	}
 
@@ -214,7 +210,7 @@ func (pp *volumeDriverProxy) Get(name string) (volume *proxyVolume, err error) {
 
 	req.Name = name
 
-	if err = pp.CallWithOptions("VolumeDriver.Get", req, &ret, plugins.WithRequestTimeout(shortTimeout)); err != nil {
+	if err = pp.CallWithOptions("VolumeDriver.Get", req, &ret, plugins.WithRequestTimeout(pp.pluginAPITimeout)); err != nil {
 		return
 	}
 
@@ -241,7 +237,7 @@ func (pp *volumeDriverProxy) Capabilities() (capabilities volume.Capability, err
 		ret volumeDriverProxyCapabilitiesResponse
 	)
 
-	if err = pp.CallWithOptions("VolumeDriver.Capabilities", req, &ret, plugins.WithRequestTimeout(shortTimeout)); err != nil {
+	if err = pp.CallWithOptions("VolumeDriver.Capabilities", req, &ret, plugins.WithRequestTimeout(pp.pluginAPITimeout)); err != nil {
 		return
 	}
 

--- a/volume/drivers/proxy_test.go
+++ b/volume/drivers/proxy_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/go-connections/tlsconfig"
@@ -63,7 +64,7 @@ func TestVolumeRequestError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	driver := volumeDriverProxy{client}
+	driver := volumeDriverProxy{client: client, pluginAPITimeout: time.Duration(120) * time.Second}
 
 	if err = driver.Create("volume", nil); err == nil {
 		t.Fatal("Expected error, was nil")

--- a/volume/service/restore_test.go
+++ b/volume/service/restore_test.go
@@ -20,7 +20,7 @@ func TestRestore(t *testing.T) {
 	assert.NilError(t, err)
 	defer os.RemoveAll(dir)
 
-	drivers := volumedrivers.NewStore(nil)
+	drivers := volumedrivers.NewStore(nil, 120)
 	driverName := "test-restore"
 	drivers.Register(volumetestutils.NewFakeDriver(driverName), driverName)
 

--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -3,6 +3,7 @@ package service // import "github.com/docker/docker/volume/service"
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -35,8 +36,8 @@ type VolumesService struct {
 }
 
 // NewVolumeService creates a new volume service
-func NewVolumeService(root string, pg plugingetter.PluginGetter, rootIDs idtools.Identity, logger volumeEventLogger) (*VolumesService, error) {
-	ds := drivers.NewStore(pg)
+func NewVolumeService(root string, pg plugingetter.PluginGetter, rootIDs idtools.Identity, logger volumeEventLogger, timeout time.Duration) (*VolumesService, error) {
+	ds := drivers.NewStore(pg, timeout)
 	if err := setupDefaultDriver(ds, root, rootIDs); err != nil {
 		return nil, err
 	}

--- a/volume/service/service_linux_test.go
+++ b/volume/service/service_linux_test.go
@@ -20,7 +20,7 @@ import (
 func TestLocalVolumeSize(t *testing.T) {
 	t.Parallel()
 
-	ds := volumedrivers.NewStore(nil)
+	ds := volumedrivers.NewStore(nil, 120)
 	dir, err := ioutil.TempDir("", t.Name())
 	assert.Assert(t, err)
 	defer os.RemoveAll(dir)

--- a/volume/service/service_test.go
+++ b/volume/service/service_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/errdefs"
@@ -19,7 +20,7 @@ import (
 func TestServiceCreate(t *testing.T) {
 	t.Parallel()
 
-	ds := volumedrivers.NewStore(nil)
+	ds := volumedrivers.NewStore(nil, time.Minute*1)
 	assert.Assert(t, ds.Register(testutils.NewFakeDriver("d1"), "d1"))
 	assert.Assert(t, ds.Register(testutils.NewFakeDriver("d2"), "d2"))
 
@@ -52,7 +53,7 @@ func TestServiceCreate(t *testing.T) {
 func TestServiceList(t *testing.T) {
 	t.Parallel()
 
-	ds := volumedrivers.NewStore(nil)
+	ds := volumedrivers.NewStore(nil, time.Minute*1)
 	assert.Assert(t, ds.Register(testutils.NewFakeDriver("d1"), "d1"))
 	assert.Assert(t, ds.Register(testutils.NewFakeDriver("d2"), "d2"))
 
@@ -107,7 +108,7 @@ func TestServiceList(t *testing.T) {
 func TestServiceRemove(t *testing.T) {
 	t.Parallel()
 
-	ds := volumedrivers.NewStore(nil)
+	ds := volumedrivers.NewStore(nil, time.Minute*1)
 	assert.Assert(t, ds.Register(testutils.NewFakeDriver("d1"), "d1"))
 
 	service, cleanup := newTestService(t, ds)
@@ -124,7 +125,7 @@ func TestServiceRemove(t *testing.T) {
 func TestServiceGet(t *testing.T) {
 	t.Parallel()
 
-	ds := volumedrivers.NewStore(nil)
+	ds := volumedrivers.NewStore(nil, time.Minute*1)
 	assert.Assert(t, ds.Register(testutils.NewFakeDriver("d1"), "d1"))
 
 	service, cleanup := newTestService(t, ds)
@@ -161,7 +162,7 @@ func TestServiceGet(t *testing.T) {
 func TestServicePrune(t *testing.T) {
 	t.Parallel()
 
-	ds := volumedrivers.NewStore(nil)
+	ds := volumedrivers.NewStore(nil, time.Minute*1)
 	assert.Assert(t, ds.Register(testutils.NewFakeDriver(volume.DefaultDriverName), volume.DefaultDriverName))
 	assert.Assert(t, ds.Register(testutils.NewFakeDriver("other"), "other"))
 

--- a/volume/service/store_test.go
+++ b/volume/service/store_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/volume"
 	volumedrivers "github.com/docker/docker/volume/drivers"
@@ -91,7 +92,7 @@ func TestList(t *testing.T) {
 	assert.NilError(t, err)
 	defer os.RemoveAll(dir)
 
-	drivers := volumedrivers.NewStore(nil)
+	drivers := volumedrivers.NewStore(nil, time.Minute*1)
 	drivers.Register(volumetestutils.NewFakeDriver("fake"), "fake")
 	drivers.Register(volumetestutils.NewFakeDriver("fake2"), "fake2")
 
@@ -266,7 +267,7 @@ func TestDefererencePluginOnCreateError(t *testing.T) {
 	}
 
 	pg := volumetestutils.NewFakePluginGetter(p)
-	s.drivers = volumedrivers.NewStore(pg)
+	s.drivers = volumedrivers.NewStore(pg, time.Minute*1)
 
 	ctx := context.Background()
 	// create a good volume so we have a plugin reference
@@ -378,7 +379,7 @@ func setupTest(t *testing.T) (*VolumeStore, func()) {
 		assert.Check(t, err)
 	}
 
-	s, err := NewStore(dir, volumedrivers.NewStore(nil))
+	s, err := NewStore(dir, volumedrivers.NewStore(nil, time.Minute*1))
 	assert.Check(t, err)
 	return s, func() {
 		s.Shutdown()


### PR DESCRIPTION
Previously we had hard coded timeouts for volume API calls
to plugins. These don't work in every situation and something
a little bit more flexible is required. This change allows
for a user to configure the API to meet their needs, but keeps
the default values pretty much the same as before.

Note that this is a different timeout than the optional
`--timeout` specified when enabling a plugin. This new config
option `volume-plugin-api-timeout` is very specific to volume
plugins that may require long running API calls for operations
like Mount/Unmount to complete successfully.

fixes #37835 

**- What I did**
Removed the hard coded plugin timeout values in favor of configurable options.

**- How I did it**
This change adds a new config option `volume-plugin-api-timeout` and pipes that value into the volume plugin client code in the volume service. It replaces the hard coded timeout values.

**- How to verify it**
Set the `volume-plugin-api-timeout` to a value lower than the `--timeout` provided when enabling the plugin. You will see API calls to the plugins timeout after the shorter amount of time. Note that these are no longer the hard coded 1 or 2 min timeouts.

**- Description for the changelog**
Added `volume-plugin-api-timeout` option to daemon config

