### PR TITLE
fixes some container link errors

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -38,6 +38,7 @@ import (
 	registrytypes "github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/v2/daemon/internal/nri"
+	"github.com/moby/moby/v2/daemon/names"
 	"github.com/moby/sys/user"
 	"github.com/moby/sys/userns"
 	"github.com/opencontainers/selinux/go-selinux"
@@ -769,6 +770,9 @@ func (daemon *Daemon) restartSwarmContainers(ctx context.Context, cfg *configSto
 }
 
 func (daemon *Daemon) registerLink(parent, child *container.Container, alias string) error {
+	if !names.RestrictedNamePattern.MatchString(strings.TrimPrefix(alias, "/")) {
+		return cerrdefs.ErrInvalidArgument.WithMessage(fmt.Sprintf("Invalid link alias name (%s), only %s are allowed", alias, names.RestrictedNameChars))
+	}
 	fullName := path.Join(parent.Name, alias)
 	if err := daemon.containersReplica.ReserveName(fullName, child.ID); err != nil {
 		if cerrdefs.IsConflict(err) {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -770,8 +770,8 @@ func (daemon *Daemon) restartSwarmContainers(ctx context.Context, cfg *configSto
 }
 
 func (daemon *Daemon) registerLink(parent, child *container.Container, alias string) error {
-	if !names.RestrictedNamePattern.MatchString(strings.TrimPrefix(alias, "/")) {
-		return cerrdefs.ErrInvalidArgument.WithMessage(fmt.Sprintf("Invalid link alias name (%s), only %s are allowed", alias, names.RestrictedNameChars))
+	if len(strings.Fields(alias)) > 1 {
+		return cerrdefs.ErrInvalidArgument.WithMessage(fmt.Sprintf("Invalid link alias name (%s), can't contain white spaces", alias))
 	}
 	fullName := path.Join(parent.Name, alias)
 	if err := daemon.containersReplica.ReserveName(fullName, child.ID); err != nil {

--- a/daemon/pkg/opts/opts.go
+++ b/daemon/pkg/opts/opts.go
@@ -371,11 +371,14 @@ func ParseLink(val string) (string, string, error) {
 	// This is kept because we can actually get a HostConfig with links
 	// from an already created container and the format is not `foo:bar`
 	// but `/foo:/c1/bar`
+	// futhermore, we need to deal with `foo:/c1/bar`, or `foo:c1/bar`
+	name := arr[0]
+
 	if strings.HasPrefix(arr[0], "/") {
-		_, alias := path.Split(arr[1])
-		return arr[0][1:], alias, nil
+		name = arr[0][1:]
 	}
-	return arr[0], arr[1], nil
+	_, alias := path.Split(arr[1])
+	return name, alias, nil
 }
 
 // MemBytes is a type for human readable memory bytes (like 128M, 2g, etc)

--- a/daemon/pkg/opts/opts.go
+++ b/daemon/pkg/opts/opts.go
@@ -377,7 +377,11 @@ func ParseLink(val string) (string, string, error) {
 	if strings.HasPrefix(arr[0], "/") {
 		name = arr[0][1:]
 	}
-	_, alias := path.Split(arr[1])
+	// For /test/, we need to clean
+	_, alias := path.Split(path.Clean(arr[1]))
+	if len(alias) == 0 {
+		return "", "", fmt.Errorf("bad format for links: %s", val)
+	}
 	return name, alias, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
When create container with option --link, there are some errors:
1. ~~If with `--link /redisrrr:/ubunturedis/redisr --link /redissto:/sto/redisr`, the second link will be lost without any prompt errors;~~ In order to be compatible with previous habits, keep the original way;
2. If with `--link redisrrr:/ubunturedis/redisr`, or `--link redisrrr:ubunturedis/redisr`, this will cause alise name like this: /a/b/c, it will cause remove wrong link when `docker rm --link`;
3. If with `--link "redisrrr:a b"`, it can run the container, but in container, there are two host a, b in /etc/hosts.

**- How I did it**
1. in daemon/daemon.go, in func registerLink, check the alias name ~~, and return the err when ErrNameReserved~~;
2. in opts/opts.go, in func ParseLink, to deal with more situations.

**- How to verify it**
After fix:
```
root@dockerdemo:~/moby# docker create -it --name=ubunturedis12 --link "/redisrrr:/ubunturedis/redisr bb" --link /redissto:/sto/redisr --entrypoint=/bin/bash docker.acmcoder.com/public/ubuntu:ssh
Error response from daemon: Invalid link alias name (redisr bb), can't contain white spaces
```
```
root@dockerdemo:~/moby# docker create -it --name=ubunturedis13 --link "/redisrrr:bb" --link redissto:/sto/redisr --entrypoint=/bin/bash docker.acmcoder.com/public/ubuntu:ssh
4a7a1e8499a0468cead60f919f9dbef17cb25ee94d53d25075644f46dae2114e
root@dockerdemo:~/moby# docker create -it --name=ubunturedis14 --link "/redisrrr:bb" --link redissto:sto/redisr --entrypoint=/bin/bash docker.acmcoder.com/public/ubuntu:ssh
544bfdf1a0d08742fe69083269ae3fc72ae165107cbfba4428494f09b486f969
```

**- Description for the changelog**
fix some container link errors

**- A picture of a cute animal**
![uk du8n c09t 33zwgra](https://user-images.githubusercontent.com/783424/45992848-6e33ae00-c0be-11e8-8bee-098f5d236c3b.png)
