### PR TITLE
Windows: Case (in-)sensitivity for volume parser

### DIFF
--- a/volume/mounts/parser_test.go
+++ b/volume/mounts/parser_test.go
@@ -299,7 +299,6 @@ func TestParseMountRaw(t *testing.T) {
 	tester := func(parser Parser, set parseMountRawTestSet) {
 
 		for _, path := range set.valid {
-
 			if _, err := parser.ParseMountRaw(path, "local"); err != nil {
 				t.Errorf("ParseMountRaw(`%q`) should succeed: error %q", path, err)
 			}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes https://github.com/moby/moby/issues/36613. This was kind of interesting, as removing the case-insensitivity (I think I just put it there some 3 or more years ago to make life easier and long since forgot about it as Windows at this level is generally case insensitive and way before I had thought about LCOW) found another 'bug' (I say bug, but the code was doing the right thing, just for the wrong reason) which looks to have been introduced part by me, and part by refactoring of this code a year or more back. Case caught by the unit tests.

That bug was that the reserved name check has nothing whatsoever to do with the fix for 26329, but that's where it was in the code. Was very confused trying to figure out what its purpose was in that 26329-fix block, or which it was checking destination rather than source. Anyway, moved it to the right place and all is well.

After this, you can now do something such as the following - note the target directory inside the container as the important bit - the host casing is irrelevant as Windows here is case-insensitive. Similarly in the Windows case, the target casing is irrelevant.

LCOW:
```
PS E:\> docker run --rm -v c:\CaSeOnHoSt:/bar/humbuG:rW alpine ls /bar
humbuG
PS E:\> docker run --rm -v c:\caseonhost:/bar/humbuG:rW alpine ls /bar
humbuG
PS E:\> docker run --rm -v C:\CaSeOnHoSt:/bar/humbug alpine ls /bar
humbug
PS E:\>
```

WCOW:
```
PS E:\> docker run --rm -v c:\CaSeOnHoSt:c:/bar/humbuG:rW microsoft/nanoserver cmd /s /c dir c:\bar
 Volume in drive C has no label.
 Volume Serial Number is 106A-BF5E

 Directory of c:\bar

09/25/2018  04:10 PM    <DIR>          .
09/25/2018  04:10 PM    <DIR>          ..
09/25/2018  04:08 PM    <DIR>          humbuG
               0 File(s)              0 bytes
               3 Dir(s)  21,299,740,672 bytes free
PS E:\> docker run --rm -v c:\caseonhost:c:/bar/humbuG:rW microsoft/nanoserver cmd /s /c dir c:\bar
 Volume in drive C has no label.
 Volume Serial Number is 106A-BF5E

 Directory of c:\bar

09/25/2018  04:11 PM    <DIR>          .
09/25/2018  04:11 PM    <DIR>          ..
09/25/2018  04:08 PM    <DIR>          humbuG
               0 File(s)              0 bytes
               3 Dir(s)  21,299,732,480 bytes free
PS E:\>
```

@DHowett-MSFT @dnperfors FYI


@johnstep PTAL.




Note: You cannot, at least in RS5, unfortunately do the following after this fix - mapping two directories /a and /A in LCOW located in the same folder. Need to figure out where that is, but likely a platform issue at this point in HCS.  However, you couldn't do it before either haha.

```
docker run --rm -v c:\UPPER:/foo/A -v c:\lower:/foo/a alpine ls -l /foo
e:\go\src\github.com\docker\cli\binary\docker.exe: Error response from daemon: CreateComputeSystem b3ba52af987bff00224d5aebeb656172271c25acb9c0b54dcd1941cd765257c6: The object already exists.
(extra info: {"SystemType":"container","Name":"b3ba52af987bff00224d5aebeb656172271c25acb9c0b54dcd1941cd765257c6","Owner":"docker","LayerFolderPath":"C:\\control\\lcow\\b3ba52af987bff00224d5aebeb656172271c25acb9c0b54dcd1941cd765257c6","Layers":[{"ID":"2e2ab5f1-6ea9-557b-af6c-c401a2a3db37","Path":"C:\\control\\lcow\\fb27f0fc7fbad278718cab180f3e0dcc238fc8509560b5db3e79804b0de1ec4a\\layer.vhd"}],"MappedDirectories":[{"HostPath":"c:\\UPPER","ContainerPath":"/tmp/gcs/b3ba52af987bff00224d5aebeb656172271c25acb9c0b54dcd1941cd765257c6/binds/foo/A","ReadOnly":false,"BandwidthMaximum":0,"IOPSMaximum":0,"CreateInUtilityVM":true,"LinuxMetadata":true},{"HostPath":"c:\\lower","ContainerPath":"/tmp/gcs/b3ba52af987bff00224d5aebeb656172271c25acb9c0b54dcd1941cd765257c6/binds/foo/a","ReadOnly":false,"BandwidthMaximum":0,"IOPSMaximum":0,"CreateInUtilityVM":true,"LinuxMetadata":true}],"HvPartition":true,"EndpointList":["C54594FC-A983-4D70-9E37-DC73734C4885"],"HvRuntime":{"ImagePath":"C:\\Program Files\\Linux Containers","LinuxInitrdFile":"initrd.img","LinuxKernelFile":"kernel"},"AllowUnqualifiedDNSQuery":true,"ContainerType":"linux","TerminateOnLastHandleClosed":true}).
PS C:\>
```