### PR TITLE
fixes error when use strings.Join(arguments, " ") if arguments contains space

### DIFF
--- a/client/container_top.go
+++ b/client/container_top.go
@@ -14,6 +14,8 @@ func (cli *Client) ContainerTop(ctx context.Context, containerID string, argumen
 	var response container.ContainerTopOKBody
 	query := url.Values{}
 	if len(arguments) > 0 {
+		// TODO: when we agree on which version support this feature,
+		// we need to add a version check to compatible with docker/cli with old api version
 		argsjson, err := json.Marshal(arguments)
 		if err != nil {
 			return response, err

--- a/client/container_top.go
+++ b/client/container_top.go
@@ -4,17 +4,21 @@ import (
 	"context"
 	"encoding/json"
 	"net/url"
-	"strings"
 
 	"github.com/docker/docker/api/types/container"
 )
 
 // ContainerTop shows process information from within a container.
+// for `docker top redisstor -C "sto redis-server"`, we can't use string.Join(arguments, " ")
 func (cli *Client) ContainerTop(ctx context.Context, containerID string, arguments []string) (container.ContainerTopOKBody, error) {
 	var response container.ContainerTopOKBody
 	query := url.Values{}
 	if len(arguments) > 0 {
-		query.Set("ps_args", strings.Join(arguments, " "))
+		argsjson, err := json.Marshal(arguments)
+		if err != nil {
+			return response, err
+		}
+		query.Set("ps_args", string(argsjson))
 	}
 
 	resp, err := cli.get(ctx, "/containers/"+containerID+"/top", query, nil)

--- a/client/container_top_test.go
+++ b/client/container_top_test.go
@@ -39,8 +39,8 @@ func TestContainerTop(t *testing.T) {
 			}
 			query := req.URL.Query()
 			args := query.Get("ps_args")
-			if args != "arg1 arg2" {
-				return nil, fmt.Errorf("args not set in URL query properly. Expected 'arg1 arg2', got %v", args)
+			if args != "[\"arg1\",\"arg2\"]" {
+				return nil, fmt.Errorf("args not set in URL query properly. Expected '[\"arg1\",\"arg2\"]', got %v", args)
 			}
 
 			b, err := json.Marshal(container.ContainerTopOKBody{

--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -5,6 +5,7 @@ package daemon // import "github.com/docker/docker/daemon"
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -135,12 +136,20 @@ func psPidsArg(pids []uint32) string {
 // "-ef" if no args are given.  An error is returned if the container
 // is not found, or is not running, or if there are any problems
 // running ps, or parsing the output.
-func (daemon *Daemon) ContainerTop(name string, psArgs string) (*container.ContainerTopOKBody, error) {
-	if psArgs == "" {
-		psArgs = "-ef"
+// to deal with `docker top redisstor -C "sto redis-server"`,
+// we change the second arg to json format
+func (daemon *Daemon) ContainerTop(name string, psArgsJSON string) (*container.ContainerTopOKBody, error) {
+	var args []string
+	if err := json.Unmarshal([]byte(psArgsJSON), &args); err != nil {
+		// It's just to be compatible with docker/cli before use the latest interface
+		// TODO: when docker/cli use the latest interface, here can return the err
+		args = fieldsASCII(psArgsJSON)
+	}
+	if len(args) == 0 {
+		args = append(args, "-ef")
 	}
 
-	if err := validatePSArgs(psArgs); err != nil {
+	if err := validatePSArgs(strings.Join(args, " ")); err != nil {
 		return nil, err
 	}
 
@@ -162,7 +171,6 @@ func (daemon *Daemon) ContainerTop(name string, psArgs string) (*container.Conta
 		return nil, err
 	}
 
-	args := strings.Split(psArgs, " ")
 	pids := psPidsArg(procs)
 	output, err := exec.Command("ps", append(args, pids)...).Output()
 	if err != nil {

--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -141,8 +141,7 @@ func psPidsArg(pids []uint32) string {
 func (daemon *Daemon) ContainerTop(name string, psArgsJSON string) (*container.ContainerTopOKBody, error) {
 	var args []string
 	if err := json.Unmarshal([]byte(psArgsJSON), &args); err != nil {
-		// It's just to be compatible with docker/cli before use the latest interface
-		// TODO: when docker/cli use the latest interface, here can return the err
+		// It's just to be compatible with docker/cli with old api version
 		args = fieldsASCII(psArgsJSON)
 	}
 	if len(args) == 0 {


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
Commands such as:
`docker top redis -C "bash redis-server"`
`docker top redis -o "cmd pid`
Because in docker/cli, it use strings.Join(arguments, " ") to pass the arguments to the dockerd backend,
so, when params in ps args contain space, psArg in func ContainerTop in file daemon/top_unix.go will become "-C bash redis-server" / "-o cmd pid". After split and passed to ps command, it will raise a error.
Furthermore, we can use this feature to own other container's process.

I also updated client/container_top.go to patch docker/cli. But before patch it, in daemon, I leave a todo in top_unix.go to ompatible with docker/cli before use the latest interface. This todo will be achieved After patched docker/cli,.

**- How I did it**
When pass the ps arguments from docker/cli to dockerd backend, use json to encode the args.

**- How to verify it**
`docker top redis -C "bash redis-server"`
`docker top redis -o "cmd pid`

**- Description for the changelog**
Change the way of encode the arguments in docker top.
