### PR TITLE
fixes can't remove link like /a/b/c

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -52,12 +52,12 @@ func (daemon *Daemon) rmLink(container *container.Container, name string) error 
 	if name[0] != '/' {
 		name = "/" + name
 	}
-	parent, n := path.Split(name)
-	if parent == "/" {
+	nameParts := strings.Split(path.Clean(name), "/")
+	if len(nameParts) < 3 {
 		return fmt.Errorf("Conflict, cannot remove the default name of the container")
 	}
 
-	parent = strings.TrimSuffix(parent, "/")
+	parent := "/" + nameParts[1]
 	pe, err := daemon.containersReplica.Snapshot().GetID(parent)
 	if err != nil {
 		return fmt.Errorf("Cannot get parent %s for name %s", parent, name)
@@ -68,7 +68,7 @@ func (daemon *Daemon) rmLink(container *container.Container, name string) error 
 	if parentContainer != nil {
 		daemon.linkIndex.unlink(name, container, parentContainer)
 		if err := daemon.updateNetwork(parentContainer); err != nil {
-			logrus.Debugf("Could not update network to remove link %s: %v", n, err)
+			logrus.Debugf("Could not update network to remove link %s: %v", container.Name, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
```
docker run -dit --name=testlink --link redis:/test/redis --entrypoint=/bin/bash docker.acmcoder.com/public/ubuntu:ssh
```
```
docker inspect testlink
"Links": [
      "/redis:/testlink/test/redis"
 ],
```
```
root@dockerdemo:~/moby# docker rm --link /testlink/test/redis
Error response from daemon: Cannot get parent /testlink/test for name /testlink/test/redis
```

**- How I did it**
It the fault of `parent, n := path.Split(name)`
If name=="/a/b/c", the parent will be /a/b/
So, just take the first part of the name as parent

**- How to verify it**
```
root@dockerdemo:~/moby# docker rm --link testlink/test/redis
testlink/test/redis
```
```
root@dockerdemo:~/moby# docker inspect testlink
"Links": null,
```

**- Description for the changelog**
change func in daemon/delete.go to get the true parent of a link.