### PR TITLE
[wip] Update containerd runtime to v1.2.0

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=9f2e07b1fc1342d1c48fe4d7bbb94cb6d1bf278b # v1.1.4
+CONTAINERD_COMMIT=c4446665cb9c30056f4998ed953e6d4ff22c7c39 # v1.2.0
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
Updated to v1.2.0. (c4446665cb9c30056f4998ed953e6d4ff22c7c39)

changes since the last bump: https://github.com/containerd/containerd/compare/405518591d1d94adebc110782da8205110bf7cd5...v1.2.0

- https://github.com/containerd/containerd/pull/2742 bugfix: return the context error during event subscribe
- https://github.com/containerd/containerd/pull/2729 runtime-v2: add validation for runtime name
- https://github.com/containerd/containerd/pull/2741 Update cri to f913714917d2456d7e65a0be84962b1ce8acb487
  - fixes https://github.com/containerd/cri/issues/942 Use Authorizer for image registry auth 
  - fixes https://github.com/containerd/cri/issues/948 IPAM IP leakage
  - Support runtime type specific configuration.


updated to current master, which should be pretty close to v1.2.0 GA (not tagged yet), and includes the fix for the failures here;

diff since v1.2.0-rc.2: https://github.com/containerd/containerd/compare/v1.2.0-rc.2...405518591d1d94adebc110782da8205110bf7cd5

- https://github.com/containerd/containerd/pull/2724 Update runc to 58592df56734acf62e574865fe40b9e53e
- https://github.com/containerd/containerd/pull/2725 enhance: split config from server package
- https://github.com/containerd/containerd/pull/2727 allow idempotence when adding a task to cgroup metrics collection


release notes: https://github.com/containerd/containerd/releases/tag/v1.2.0-rc.2

full diff since rc.1: https://github.com/containerd/containerd/compare/v1.2.0-rc.1...v1.2.0-rc.2

Possibly relevant changes;

- https://github.com/containerd/containerd/pull/2721 add memory limit, pid info into metric subcommand
- https://github.com/containerd/containerd/pull/2714 Fix writer deadlock in local store
- https://github.com/containerd/containerd/pull/2720 Fix stress test for image config opt requirements
- https://github.com/containerd/containerd/pull/2691 bugfix: cache empty layer for docker schema1 image
- https://github.com/containerd/containerd/pull/2717 Set uncompressed label on diff when already exists
- https://github.com/containerd/containerd/pull/2702 Update cri to 8506fe836677cc3bb23a16b68145128243d843b5
- https://github.com/containerd/containerd/pull/2688 decode spec in `ctr c info`

full diff since rc.0: https://github.com/containerd/containerd/compare/v1.2.0-rc.0...v1.2.0-rc.1

- New V2 Runtime with a stable gRPC interface for managing containers through
  external shims.
- Updated CRI Plugin, validated against Kubernetes v1.11 and v1.12, but it is
  also compatible with Kubernetes v1.10.
- Support for Kubernetes Runtime Class, introduced in Kubernetes 1.12
- A new proxy plugin configuration has been added to allow external
  snapshotters be connected to containerd using gRPC.-
- A new Install method on the containerd client allows users to publish host
  level binaries using standard container build tooling and container
  distribution tooling to download containerd related binaries on their systems.
- Add support for cleaning up leases and content ingests to garbage collections.
- Improved multi-arch image support using more precise matching and ranking
- Some Minor API additions

