### PR TITLE
Split docker-py tests from main image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,17 +70,6 @@ RUN set -x \
 	   esac \
 	&& rm -rf "$GOPATH"
 
-
-
-FROM base AS docker-py
-# Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT 8b246db271a85d6541dc458838627e89c683e42f
-RUN git clone https://github.com/docker/docker-py.git /build \
-	&& cd /build \
-	&& git checkout -q $DOCKER_PY_COMMIT
-
-
-
 FROM base AS swagger
 # Install go-swagger for validating swagger.yaml
 ENV GO_SWAGGER_COMMIT c28258affb0b6251755d92489ef685af8d4ff3eb
@@ -189,14 +178,6 @@ RUN apt-get update && apt-get install -y \
 	g++-mingw-w64-x86-64 \
 	net-tools \
 	pigz \
-	python-backports.ssl-match-hostname \
-	python-dev \
-	python-mock \
-	python-pip \
-	python-requests \
-	python-setuptools \
-	python-websocket \
-	python-wheel \
 	thin-provisioning-tools \
 	vim \
 	vim-common \
@@ -217,15 +198,6 @@ COPY --from=proxy /build/ /usr/local/bin/
 COPY --from=dockercli /build/ /usr/local/cli
 COPY --from=registry /build/registry* /usr/local/bin/
 COPY --from=criu /build/ /usr/local/
-COPY --from=docker-py /build/ /docker-py
-# TODO: This is for the docker-py tests, which shouldn't really be needed for
-# this image, but currently CI is expecting to run this image. This should be
-# split out into a separate image, including all the `python-*` deps installed
-# above.
-RUN cd /docker-py \
-	&& pip install docker-pycreds==0.2.1 \
-	&& pip install yamllint==1.5.0 \
-	&& pip install -r test-requirements.txt
 
 ENV PATH=/usr/local/cli:$PATH
 ENV DOCKER_BUILDTAGS apparmor seccomp selinux
@@ -237,3 +209,28 @@ VOLUME /var/lib/docker
 ENTRYPOINT ["hack/dind"]
 # Upload docker source
 COPY . /go/src/github.com/docker/docker
+
+FROM dev AS test
+# Install python packages
+RUN apt-get update && apt-get install -y \
+	python-backports.ssl-match-hostname \
+	python-dev \
+	python-mock \
+	python-pip \
+	python-requests \
+	python-setuptools \
+	python-websocket \
+	python-wheel \
+	--no-install-recommends
+# Get the "docker-py" source so we can run their integration tests
+ENV DOCKER_PY_COMMIT 8b246db271a85d6541dc458838627e89c683e42f
+RUN git clone https://github.com/docker/docker-py.git /docker-py \
+	&& cd /docker-py \
+	&& git checkout -q $DOCKER_PY_COMMIT
+## Install docker-py requirements
+RUN cd /docker-py \
+	&& pip install docker-pycreds==0.2.1 \
+	&& pip install yamllint==1.5.0 \
+	&& pip install -r test-requirements.txt
+
+FROM dev


### PR DESCRIPTION
Signed-off-by: Adriell Matthew Julius Dagasuan <adrielldagasuan@gmail.com>

**- What I did**
Addressed: #36415. Moved the docker-py tests from main docker-dev image into another docker-test image that will be used for testing

**- How I did it**
Removed the docker-py section from the main Dockerfile
Removed the installation of python-* packages from the main Dockerfile
Created Dockerfile.test as another image used for testing docker-py (and potentially other test scenarios)
Updated Makefile to build Dockerfile.test and use the image for testing

**- How to verify it**
Run `make test-docker-py`. It should build 2 images.
Verify that a docker-test image was created alongside the docker-dev image.
Verify that the docker-test image is larger than the docker-dev image, with the extra docker-py objects as well as the python-* packages.

| REPOSITORY | TAG | IMAGE ID | SIZE |
| ------------- | ---- | ---------- | ----- |
| docker-test | 36145-splitting-docker-py-section | 859613acb285 | 2.04GB |
| docker-dev | 36145-splitting-docker-py-section | 89a6ffee61b3 | 1.94GB |

Verify that the docker-dev image does not have the /docker-py directory by doing
`docker run ... docker-dev:<tag> bash -c "ls /"`


**- Description for the changelog**
Moved docker-py tests off the main docker-dev image into separate docker-test image


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/10193674/46258579-d4c22d00-c4ff-11e8-9e74-24c71c4a4b6a.png)
