### PR TITLE
Return more context on awslogs create failure

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -375,13 +375,17 @@ func (l *logStream) create() error {
 		if l.logCreateGroup {
 			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == resourceNotFoundCode {
 				if err := l.createLogGroup(); err != nil {
-					return err
+					return errors.Wrap(err, "failed to create Cloudwatch log group")
 				}
-				return l.createLogStream()
+				err := l.createLogStream()
+				if err != nil {
+					return errors.Wrap(err, "failed to create Cloudwatch log stream")
+				}
+				return nil
 			}
 		}
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to create Cloudwatch log stream")
 		}
 	}
 


### PR DESCRIPTION
Currently, if an api call failure happens when awslogs is initializing it can be ambiguous as to which call actually failed. This change provides more context when create() fails by wrapping the errors noting which call failed.

Signed-off-by: Cody Roseborough <crrosebo@amazon.com>

/cc @samuelkarp 