### PR TITLE
Dockerfile.e2e: simplify apk calls

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,14 +1,13 @@
 ## Step 1: Build tests
 FROM golang:1.11.0-alpine3.7 as builder
 
-RUN apk add --update \
+RUN apk --no-cache add \
     bash \
     btrfs-progs-dev \
     build-base \
     curl \
     lvm2-dev \
-    jq \
-    && rm -rf /var/cache/apk/*
+    jq
 
 RUN mkdir -p /go/src/github.com/docker/docker/
 WORKDIR /go/src/github.com/docker/docker/
@@ -43,7 +42,7 @@ RUN mkdir -p /output/tests && find . -name test.main -exec cp --parents '{}' /ou
 FROM alpine:3.7 as runner
 
 # GNU tar is used for generating the emptyfs image
-RUN apk add --update \
+RUN apk --no-cache add \
     bash \
     ca-certificates \
     g++ \
@@ -51,8 +50,7 @@ RUN apk add --update \
     iptables \
     pigz \
     tar \
-    xz \
-    && rm -rf /var/cache/apk/*
+    xz
 
 # Add an unprivileged user to be used for tests which need it
 RUN addgroup docker && adduser -D -G docker unprivilegeduser -s /bin/ash


### PR DESCRIPTION
As of Alpine Linux 3.3 (or 3.2?) there exists a new --no-cache
option for apk. It allows users to install packages with an index
that is updated and used on-the-fly and not cached locally.

This avoids the need to use --update and remove /var/cache/apk/*
when done installing packages.