### PR TITLE
TestSwarmContainerEndpointOptions: fix debug

### DIFF
--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -344,21 +344,21 @@ func (s *DockerSwarmSuite) TestSwarmContainerEndpointOptions(c *check.C) {
 	c.Assert(err, checker.IsNil, check.Commentf("%s", out))
 	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
 
-	_, err = d.Cmd("run", "-d", "--net=foo", "--name=first", "--net-alias=first-alias", "busybox:glibc", "top")
+	out, err = d.Cmd("run", "-d", "--net=foo", "--name=first", "--net-alias=first-alias", "busybox:glibc", "top")
 	c.Assert(err, checker.IsNil, check.Commentf("%s", out))
 
-	_, err = d.Cmd("run", "-d", "--net=foo", "--name=second", "busybox:glibc", "top")
+	out, err = d.Cmd("run", "-d", "--net=foo", "--name=second", "busybox:glibc", "top")
 	c.Assert(err, checker.IsNil, check.Commentf("%s", out))
 
-	_, err = d.Cmd("run", "-d", "--net=foo", "--net-alias=third-alias", "busybox:glibc", "top")
+	out, err = d.Cmd("run", "-d", "--net=foo", "--net-alias=third-alias", "busybox:glibc", "top")
 	c.Assert(err, checker.IsNil, check.Commentf("%s", out))
 
 	// ping first container and its alias, also ping third and anonymous container by its alias
-	_, err = d.Cmd("exec", "second", "ping", "-c", "1", "first")
+	out, err = d.Cmd("exec", "second", "ping", "-c", "1", "first")
 	c.Assert(err, check.IsNil, check.Commentf("%s", out))
-	_, err = d.Cmd("exec", "second", "ping", "-c", "1", "first-alias")
+	out, err = d.Cmd("exec", "second", "ping", "-c", "1", "first-alias")
 	c.Assert(err, check.IsNil, check.Commentf("%s", out))
-	_, err = d.Cmd("exec", "second", "ping", "-c", "1", "third-alias")
+	out, err = d.Cmd("exec", "second", "ping", "-c", "1", "third-alias")
 	c.Assert(err, check.IsNil, check.Commentf("%s", out))
 }
 


### PR DESCRIPTION
In case of failure, stale out was printed.

Fixes: 6212ea669b4e92b3

Found during analysis of test failure like the following:

01:28:49.436 
01:28:49.436 ----------------------------------------------------------------------
01:28:49.436 FAIL: docker_cli_swarm_test.go:340: DockerSwarmSuite.TestSwarmContainerEndpointOptions
01:28:49.436 
01:28:49.436 [d9936cbb33a13] waiting for daemon to start
01:28:49.436 [d9936cbb33a13] daemon started
01:28:49.436 
01:28:49.436 docker_cli_swarm_test.go:348:
01:28:49.436     c.Assert(err, checker.IsNil, check.Commentf("%s", out))
01:28:49.436 ... value *exec.ExitError = &exec.ExitError{ProcessState:(*os.ProcessState)(0xc0008da200), Stderr:[]uint8(nil)} ("exit status 125")
01:28:49.437 ... enp0ai1ixwecue5w696pgzggp
01:28:49.437 
01:28:49.437 
01:28:49.437 [d9936cbb33a13] exiting daemon
01:28:52.285 
01:28:52.285 ----------------------------------------------------------------------

(the above is from https://jenkins.dockerproject.org/job/Docker-PRs-s390x/11487/console, which comes from https://github.com/moby/moby/pull/37833, but it's not unique).