### PR TITLE
Remove version-checks for containerd and runc

### DIFF
--- a/dockerversion/version_lib.go
+++ b/dockerversion/version_lib.go
@@ -10,8 +10,6 @@ const (
 	Version               = "library-import"
 	BuildTime             = "library-import"
 	IAmStatic             = "library-import"
-	ContainerdCommitID    = "library-import"
-	RuncCommitID          = "library-import"
 	InitCommitID          = "library-import"
 	PlatformName          = ""
 	ProductName           = ""

--- a/hack/make/.go-autogen
+++ b/hack/make/.go-autogen
@@ -19,7 +19,6 @@ const (
 	Version               string = "$VERSION"
 	BuildTime             string = "$BUILDTIME"
 	IAmStatic             string = "${IAMSTATIC:-true}"
-	ContainerdCommitID    string = "${CONTAINERD_COMMIT}"
 	PlatformName          string = "${PLATFORM}"
 	ProductName           string = "${PRODUCT}"
 	DefaultProductLicense string = "${DEFAULT_PRODUCT_LICENSE}"
@@ -37,7 +36,6 @@ package dockerversion
 // Default build-time variable for library-import.
 // This file is overridden on build with build-time information.
 const (
-	RuncCommitID string = "${RUNC_COMMIT}"
 	InitCommitID string = "${TINI_COMMIT}"
 )
 


### PR DESCRIPTION
With containerd reaching 1.0, the runtime now has a stable API, so there's no need to do a check if the installed version matches the expected version.

Current versions of Docker now also package containerd and runc separately, and can be _updated_ separately.

