### PR TITLE
Switch buildkit copy image to a docker org based one

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -221,7 +221,9 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 
 	id := identity.NewID()
 
-	frontendAttrs := map[string]string{}
+	frontendAttrs := map[string]string{
+		"override-copy-image": "docker.io/docker/dockerfile-copy:v0.1.7@sha256:4211460d4df58cca572825b93e437c09dac6387d88910fe07ac8f7c78d52e0ce",
+	}
 
 	if opt.Options.Target != "" {
 		frontendAttrs["target"] = opt.Options.Target


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Switched the image being used for `copy` in the buildkit builder to be one that is based in the `docker` organization

**- How I did it**
Built the new image from https://github.com/tonistiigi/copy with the modifications found in https://github.com/tonistiigi/copy/pull/14 using:

```
buildctl build --frontend dockerfile.v0 --local context=. --local dockerfile=. --frontend-opt platform="linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x,linux/ppc64le" --progress=plain --exporter=image --exporter-opt name=docker/dockerfile-copy:v0.1.7 --exporter-opt push=true
```


**- How to verify it**

Ran a fresh instance with the new `dockerd` created with this pull request and built this image with the buildkit builder:

```
FROM alpine
COPY . /
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
* Buildkit copy image switch to image hosted in the `docker` hub organization
```


**- A picture of a cute animal (not mandatory but encouraged)**
![bird with arms](https://i.pinimg.com/originals/a8/28/d2/a828d287cc124cc427ac1b45392d2e02.jpg)
