### PR TITLE
Poule: Add Windows RS5 rebuild

### DIFF
--- a/poule.yml
+++ b/poule.yml
@@ -91,6 +91,11 @@
         }
       - type:       rebuild
         settings: {
+            configurations: [ windowsRS5 ],
+            label:          "rebuild/windowsRS5-process",
+        }
+      - type:       rebuild
+        settings: {
             configurations: [ z ],
             label:          "rebuild/z",
         }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Adds RS5 to the list of rebuild tags as RS5 CI is about to come online (currently argons/process-isolation only, but xenon/Hyper-V isolation won't be long to follow).

@thaJeztah 