### PR TITLE
More useful default display settings for service logs

### DIFF
--- a/client/service_logs.go
+++ b/client/service_logs.go
@@ -23,13 +23,14 @@ func (cli *Client) ServiceLogs(ctx context.Context, serviceID string, options ty
 		query.Set("stderr", "1")
 	}
 
+	ts, err := timetypes.GetTimestamp("1h", time.Now())
 	if options.Since != "" {
-		ts, err := timetypes.GetTimestamp(options.Since, time.Now())
-		if err != nil {
-			return nil, errors.Wrap(err, `invalid value for "since"`)
-		}
-		query.Set("since", ts)
+		ts, err = timetypes.GetTimestamp(options.Since, time.Now())
 	}
+	if err != nil {
+		return nil, errors.Wrap(err, `invalid value for "since"`)
+	}
+	query.Set("since", ts)
 
 	if options.Timestamps {
 		query.Set("timestamps", "1")


### PR DESCRIPTION
**- What I did**
Set more useful default settings for logging.

**- How I did it**
* Store 20 pcs of 5 MB log files instead of 5 pcs of 20 MB log files.
* Use 1 hour as default setting for *docker service logs ...* command instead of infinity.

**- How to verify it**
No really need to verify but more likely to decide if we can do this kind of change to default settings?

Hopefully fixes: #35011 or at least reduces it symptoms.