### PR TITLE
Remove unneeded check for binary-commits

### DIFF
--- a/integration/system/info_linux_test.go
+++ b/integration/system/info_linux_test.go
@@ -20,15 +20,12 @@ func TestInfoBinaryCommits(t *testing.T) {
 	assert.NilError(t, err)
 
 	assert.Check(t, "N/A" != info.ContainerdCommit.ID)
-	assert.Check(t, is.Equal(testEnv.DaemonInfo.ContainerdCommit.Expected, info.ContainerdCommit.Expected))
 	assert.Check(t, is.Equal(info.ContainerdCommit.Expected, info.ContainerdCommit.ID))
 
 	assert.Check(t, "N/A" != info.InitCommit.ID)
-	assert.Check(t, is.Equal(testEnv.DaemonInfo.InitCommit.Expected, info.InitCommit.Expected))
 	assert.Check(t, is.Equal(info.InitCommit.Expected, info.InitCommit.ID))
 
 	assert.Check(t, "N/A" != info.RuncCommit.ID)
-	assert.Check(t, is.Equal(testEnv.DaemonInfo.RuncCommit.Expected, info.RuncCommit.Expected))
 	assert.Check(t, is.Equal(info.RuncCommit.Expected, info.RuncCommit.ID))
 }
 


### PR DESCRIPTION
This check was not important anymore; we're only interested if the API returns a matching commit for each binary.
