### PR TITLE
mount: add BindOptions.NonRecursive (API v1.40)

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -465,6 +465,16 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 		hostConfig.AutoRemove = false
 	}
 
+	// When using API 1.39 and under, BindOptions.NonRecursive should be ignored because it
+	// was added in API 1.40.
+	if hostConfig != nil && versions.LessThan(version, "1.40") {
+		for _, m := range hostConfig.Mounts {
+			if bo := m.BindOptions; bo != nil {
+				bo.NonRecursive = false
+			}
+		}
+	}
+
 	ccr, err := s.backend.ContainerCreate(types.ContainerCreateConfig{
 		Name:             name,
 		Config:           config,

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -265,6 +265,10 @@ definitions:
               - "rshared"
               - "slave"
               - "rslave"
+          NonRecursive:
+            description: "Disable recursive bind mount."
+            type: "boolean"
+            default: false
       VolumeOptions:
         description: "Optional configuration for the `volume` type."
         type: "object"

--- a/api/types/mount/mount.go
+++ b/api/types/mount/mount.go
@@ -79,7 +79,8 @@ const (
 
 // BindOptions defines options specific to mounts of type "bind".
 type BindOptions struct {
-	Propagation Propagation `json:",omitempty"`
+	Propagation  Propagation `json:",omitempty"`
+	NonRecursive bool        `json:",omitempty"`
 }
 
 // VolumeOptions represents the options for a mount of type volume.

--- a/container/mounts_unix.go
+++ b/container/mounts_unix.go
@@ -4,9 +4,10 @@ package container // import "github.com/docker/docker/container"
 
 // Mount contains information for a mount operation.
 type Mount struct {
-	Source      string `json:"source"`
-	Destination string `json:"destination"`
-	Writable    bool   `json:"writable"`
-	Data        string `json:"data"`
-	Propagation string `json:"mountpropagation"`
+	Source       string `json:"source"`
+	Destination  string `json:"destination"`
+	Writable     bool   `json:"writable"`
+	Data         string `json:"data"`
+	Propagation  string `json:"mountpropagation"`
+	NonRecursive bool   `json:"nonrecursive"`
 }

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -321,6 +321,12 @@ func containerToGRPC(c *types.ContainerSpec) (*swarmapi.ContainerSpec, error) {
 			} else if string(m.BindOptions.Propagation) != "" {
 				return nil, fmt.Errorf("invalid MountPropagation: %q", m.BindOptions.Propagation)
 			}
+
+			if m.BindOptions.NonRecursive {
+				// TODO(AkihiroSuda): NonRecursive is unsupported for Swarm-mode now because of mutual vendoring
+				// across moby and swarmkit. Will be available soon after the moby PR gets merged.
+				return nil, fmt.Errorf("invalid NonRecursive: %q", m.BindOptions.Propagation)
+			}
 		}
 
 		if m.VolumeOptions != nil {

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -565,7 +565,11 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 			}
 		}
 
-		opts := []string{"rbind"}
+		bindMode := "rbind"
+		if m.NonRecursive {
+			bindMode = "bind"
+		}
+		opts := []string{bindMode}
 		if !m.Writable {
 			opts = append(opts, "ro")
 		}

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/mount"
@@ -57,6 +58,9 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 				Destination: m.Destination,
 				Writable:    m.RW,
 				Propagation: string(m.Propagation),
+			}
+			if m.Spec.Type == mounttypes.TypeBind && m.Spec.BindOptions != nil {
+				mnt.NonRecursive = m.Spec.BindOptions.NonRecursive
 			}
 			if m.Volume != nil {
 				attributes := map[string]string{
@@ -129,11 +133,15 @@ func (daemon *Daemon) mountVolumes(container *container.Container) error {
 			return err
 		}
 
-		opts := "rbind,ro"
-		if m.Writable {
-			opts = "rbind,rw"
+		bindMode := "rbind"
+		if m.NonRecursive {
+			bindMode = "bind"
 		}
-
+		writeMode := "ro"
+		if m.Writable {
+			writeMode = "rw"
+		}
+		opts := strings.Join([]string{bindMode, writeMode}, ",")
 		if err := mount.Mount(m.Source, dest, bindMountType, opts); err != nil {
 			return err
 		}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -27,6 +27,8 @@ keywords: "API, Docker, rcli, REST, documentation"
   on the node.label. The format of the label filter is `node.label=<key>`/`node.label=<key>=<value>`
   to return those with the specified labels, or `node.label!=<key>`/`node.label!=<key>=<value>`
   to return those without the specified labels.
+* `POST /containers/create`, `GET /containers/{id}/json`, and `GET /containers/json` now supports
+  `BindOptions.NonRecursive`.
 
 ## V1.39 API changes
 

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	containertypes "github.com/docker/docker/api/types/container"
+	mounttypes "github.com/docker/docker/api/types/mount"
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/go-connections/nat"
@@ -65,6 +66,13 @@ func WithTty(tty bool) func(*TestContainerConfig) {
 func WithWorkingDir(dir string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {
 		c.Config.WorkingDir = dir
+	}
+}
+
+// WithMount adds an mount
+func WithMount(m mounttypes.Mount) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.HostConfig.Mounts = append(c.HostConfig.Mounts, m)
 	}
 }
 

--- a/integration/internal/container/states.go
+++ b/integration/internal/container/states.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/client"
+	"github.com/pkg/errors"
 	"gotest.tools/poll"
 )
 
@@ -37,5 +38,22 @@ func IsInState(ctx context.Context, client client.APIClient, containerID string,
 			}
 		}
 		return poll.Continue("waiting for container to be one of (%s), currently %s", strings.Join(state, ", "), inspect.State.Status)
+	}
+}
+
+// IsSuccessful verifies state.Status == "exited" && state.ExitCode == 0
+func IsSuccessful(ctx context.Context, client client.APIClient, containerID string) func(log poll.LogT) poll.Result {
+	return func(log poll.LogT) poll.Result {
+		inspect, err := client.ContainerInspect(ctx, containerID)
+		if err != nil {
+			return poll.Error(err)
+		}
+		if inspect.State.Status == "exited" {
+			if inspect.State.ExitCode == 0 {
+				return poll.Success()
+			}
+			return poll.Error(errors.Errorf("expected exit code 0, got %d", inspect.State.ExitCode))
+		}
+		return poll.Continue("waiting for container to be \"exited\", currently %s", inspect.State.Status)
 	}
 }

--- a/volume/mounts/linux_parser.go
+++ b/volume/mounts/linux_parser.go
@@ -97,6 +97,9 @@ func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSour
 			return &errMountConfig{mnt, fmt.Errorf("must not set ReadOnly mode when using anonymous volumes")}
 		}
 	case mount.TypeTmpfs:
+		if mnt.BindOptions != nil {
+			return &errMountConfig{mnt, errExtraField("BindOptions")}
+		}
 		if len(mnt.Source) != 0 {
 			return &errMountConfig{mnt, errExtraField("Source")}
 		}


### PR DESCRIPTION
This allows non-recursive bind-mount, i.e. mount(2) with "bind" rather than "rbind".

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Support non-recursive bind-mount.
Related to https://github.com/moby/moby/issues/37838 .

**- How I did it**

* Added `NonRecursive` to `BindOptions`.
* Bumped up API version to v1.40
* Swarm-mode will be supported via a separate PR, because of mutual vendoring

**- How to verify it**

CLI: https://github.com/docker/cli/pull/1430
```console
$ mountpoint /run
/run is a mountpoint
$ docker run --rm --mount type=bind,src=/,target=/host,readonly busybox touch /host/run/compromise_success
$ docker run --rm --mount type=bind,src=/,target=/host,readonly,bind-nonrecursive busybox touch /host/run/compromise_fail
touch: /host/run/compromise_fail: Read-only file system
$ sudo ls /run/compromise_*
/run/compromise_success
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

mount: add BindOptions.NonRecursive (API v1.40)

**- A picture of a cute animal (not mandatory but encouraged)**
https://upload.wikimedia.org/wikipedia/commons/2/28/Kaiserpinguine_mit_Jungen.jpg

![penguins](https://upload.wikimedia.org/wikipedia/commons/2/28/Kaiserpinguine_mit_Jungen.jpg)