### PR TITLE
client: use io.LimitedReader for reading HTTP error

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -195,9 +195,17 @@ func (cli *Client) checkResponseErr(serverResp serverResponse) error {
 		return nil
 	}
 
-	body, err := ioutil.ReadAll(serverResp.body)
+	bodyMax := 1 * 1024 * 1024 // 1 MiB
+	bodyR := &io.LimitedReader{
+		R: serverResp.body,
+		N: int64(bodyMax),
+	}
+	body, err := ioutil.ReadAll(bodyR)
 	if err != nil {
 		return err
+	}
+	if bodyR.N == 0 {
+		return fmt.Errorf("request returned %s with a message (> %d bytes) for API route and version %s, check if the server supports the requested API version", http.StatusText(serverResp.statusCode), bodyMax, serverResp.reqURL)
 	}
 	if len(body) == 0 {
 		return fmt.Errorf("request returned %s for API route and version %s, check if the server supports the requested API version", http.StatusText(serverResp.statusCode), serverResp.reqURL)

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types"
 	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 )
 
 // TestSetHostHeader should set fake host for local communications, set real host
@@ -86,4 +88,19 @@ func TestPlainTextError(t *testing.T) {
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
+}
+
+func TestInfiniteError(t *testing.T) {
+	infinitR := rand.New(rand.NewSource(42))
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			resp := &http.Response{StatusCode: http.StatusInternalServerError}
+			resp.Header = http.Header{}
+			resp.Body = ioutil.NopCloser(infinitR)
+			return resp, nil
+		}),
+	}
+
+	_, err := client.Ping(context.Background())
+	assert.Check(t, is.ErrorContains(err, "request returned Internal Server Error"))
 }


### PR DESCRIPTION

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

`client.checkResponseErr()` was hanging and consuming infinite memory
when the `serverResp.Body` `io.Reader` returns infinite stream.

This commit prohibits reading more than 1MiB.


**- How I did it**

use `io.LimitedReader` with 1 MiB limit.

**- How to verify it**

`go test -run TestInfinite -v ./client/` (hangs and consumes all memory without the fix for `request.go`)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

:penguin:
