### PR TITLE
Properly type handles to prevent overflows on 32 bit Windows targets

### DIFF
--- a/cmd/dockerd/service_windows.go
+++ b/cmd/dockerd/service_windows.go
@@ -396,8 +396,8 @@ func initPanicFile(path string) error {
 	// Update STD_ERROR_HANDLE to point to the panic file so that Go writes to
 	// it when it panics. Remember the old stderr to restore it before removing
 	// the panic file.
-	sh := windows.STD_ERROR_HANDLE
-	h, err := windows.GetStdHandle(uint32(sh))
+	sh := uint32(windows.STD_ERROR_HANDLE)
+	h, err := windows.GetStdHandle(sh)
 	if err != nil {
 		return err
 	}
@@ -421,7 +421,7 @@ func initPanicFile(path string) error {
 func removePanicFile() {
 	if st, err := panicFile.Stat(); err == nil {
 		if st.Size() == 0 {
-			sh := windows.STD_ERROR_HANDLE
+			sh := uint32(windows.STD_ERROR_HANDLE)
 			setStdHandle.Call(uintptr(sh), uintptr(oldStderr))
 			panicFile.Close()
 			os.Remove(panicFile.Name())


### PR DESCRIPTION
**- What I did**
Added types to location where Windows handle constants are used. This is needed so that on 32 bit targets the constants do not cause an overflow of the signed int32, which is the default type.

**- How I did it**
Added cast to the constants usage.

**- How to verify it**
Moby will build successfully on 32 bit Windows targets.

**- Description for the changelog**
Fix overflows on 32 bit Windows targets


**- A picture of a cute animal (not mandatory but encouraged)**
[https://upload.wikimedia.org/wikipedia/commons/2/20/Shiba_Inu.jpg](url)
