### PR TITLE
Deprecate legacy overlay storage driver, and add warning

### DIFF
--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -314,7 +314,7 @@ func isEmptyDir(name string) bool {
 func isDeprecated(name string) bool {
 	switch name {
 	// NOTE: when deprecating a driver, update daemon.fillDriverInfo() accordingly
-	case "devicemapper":
+	case "devicemapper", "overlay":
 		return true
 	}
 	return false

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -195,6 +195,7 @@ type Options struct {
 func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, error) {
 	if name != "" {
 		logrus.Debugf("[graphdriver] trying provided driver: %s", name) // so the logs show specified driver
+		logDeprecatedWarning(name)
 		return GetDriver(name, pg, config)
 	}
 
@@ -232,6 +233,7 @@ func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, err
 			}
 
 			logrus.Infof("[graphdriver] using prior storage driver: %s", name)
+			logDeprecatedWarning(name)
 			return driver, nil
 		}
 	}
@@ -245,6 +247,7 @@ func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, err
 			}
 			return nil, err
 		}
+		logDeprecatedWarning(name)
 		return driver, nil
 	}
 
@@ -257,6 +260,7 @@ func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, err
 			}
 			return nil, err
 		}
+		logDeprecatedWarning(name)
 		return driver, nil
 	}
 	return nil, fmt.Errorf("No supported storage backend found")
@@ -304,4 +308,21 @@ func isEmptyDir(name string) bool {
 		return true
 	}
 	return false
+}
+
+// isDeprecated checks if a storage-driver is marked "deprecated"
+func isDeprecated(name string) bool {
+	switch name {
+	// NOTE: when deprecating a driver, update daemon.fillDriverInfo() accordingly
+	case "devicemapper":
+		return true
+	}
+	return false
+}
+
+// logDeprecatedWarning logs a warning if the given storage-driver is marked "deprecated"
+func logDeprecatedWarning(name string) {
+	if isDeprecated(name) {
+		logrus.Warnf("[graphdriver] WARNING: the %s storage-driver is deprecated, and will be removed in a future release", name)
+	}
 }

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -131,6 +131,10 @@ func (daemon *Daemon) fillDriverInfo(v *types.Info) {
 		if len(daemon.graphDrivers) > 1 {
 			drivers += fmt.Sprintf(" (%s) ", os)
 		}
+		switch gd {
+		case "devicemapper":
+			v.Warnings = append(v.Warnings, fmt.Sprintf("WARNING: the %s storage-driver is deprecated, and will be removed in a future release.", gd))
+		}
 	}
 	drivers = strings.TrimSpace(drivers)
 

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -132,7 +132,7 @@ func (daemon *Daemon) fillDriverInfo(v *types.Info) {
 			drivers += fmt.Sprintf(" (%s) ", os)
 		}
 		switch gd {
-		case "devicemapper":
+		case "devicemapper", "overlay":
 			v.Warnings = append(v.Warnings, fmt.Sprintf("WARNING: the %s storage-driver is deprecated, and will be removed in a future release.", gd))
 		}
 	}


### PR DESCRIPTION
Related deprecation note PR: https://github.com/docker/cli/pull/1425

This PR is built on top of https://github.com/moby/moby/pull/38017, but I can rebase once that's merged


The `overlay` storage driver is deprecated in favor of the `overlay2` storage
driver, which has all the benefits of `overlay`, without its limitations (excessive
inode consumption). The legacy `overlay` storage driver will be removed in a future
release. Users of the `overlay` storage driver should migrate to the `overlay2`
storage driver.

The legacy `overlay` storage driver allowed using overlayFS-backed filesystems
on pre 4.x kernels. Now that all supported distributions are able to run `overlay2`
(as they are either on kernel 4.x, or have support for multiple lowerdirs
backported), there is no reason to keep maintaining the `overlay` storage driver.