### PR TITLE
Skip deprecated storage-drivers in auto-selection

### DIFF
--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -253,6 +253,11 @@ func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, err
 
 	// Check all registered drivers if no priority driver is found
 	for name, initFunc := range drivers {
+		if isDeprecated(name) {
+			// Deprecated storage-drivers are skipped in automatic selection, but
+			// can be selected through configuration.
+			continue
+		}
 		driver, err := initFunc(filepath.Join(config.Root, name), config.DriverOptions, config.UIDMaps, config.GIDMaps)
 		if err != nil {
 			if IsDriverNotSupported(err) {

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -314,7 +314,7 @@ func isEmptyDir(name string) bool {
 func isDeprecated(name string) bool {
 	switch name {
 	// NOTE: when deprecating a driver, update daemon.fillDriverInfo() accordingly
-	case "devicemapper":
+	case "devicemapper", "overlay":
 		return true
 	}
 	return false

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -195,6 +195,7 @@ type Options struct {
 func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, error) {
 	if name != "" {
 		logrus.Debugf("[graphdriver] trying provided driver: %s", name) // so the logs show specified driver
+		logDeprecatedWarning(name)
 		return GetDriver(name, pg, config)
 	}
 
@@ -232,6 +233,7 @@ func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, err
 			}
 
 			logrus.Infof("[graphdriver] using prior storage driver: %s", name)
+			logDeprecatedWarning(name)
 			return driver, nil
 		}
 	}
@@ -245,6 +247,7 @@ func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, err
 			}
 			return nil, err
 		}
+		logDeprecatedWarning(name)
 		return driver, nil
 	}
 
@@ -257,6 +260,7 @@ func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, err
 			}
 			return nil, err
 		}
+		logDeprecatedWarning(name)
 		return driver, nil
 	}
 	return nil, fmt.Errorf("No supported storage backend found")
@@ -304,4 +308,21 @@ func isEmptyDir(name string) bool {
 		return true
 	}
 	return false
+}
+
+// isDeprecated checks if a storage-driver is marked "deprecated"
+func isDeprecated(name string) bool {
+	switch name {
+	// NOTE: when deprecating a driver, update daemon.fillDriverInfo() accordingly
+	case "devicemapper":
+		return true
+	}
+	return false
+}
+
+// logDeprecatedWarning logs a warning if the given storage-driver is marked "deprecated"
+func logDeprecatedWarning(name string) {
+	if isDeprecated(name) {
+		logrus.Warnf("[graphdriver] WARNING: the %s storage-driver is deprecated, and will be removed in a future release", name)
+	}
 }

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -131,6 +131,10 @@ func (daemon *Daemon) fillDriverInfo(v *types.Info) {
 		if len(daemon.graphDrivers) > 1 {
 			drivers += fmt.Sprintf(" (%s) ", os)
 		}
+		switch gd {
+		case "devicemapper":
+			v.Warnings = append(v.Warnings, fmt.Sprintf("WARNING: the %s storage-driver is deprecated, and will be removed in a future release.", gd))
+		}
 	}
 	drivers = strings.TrimSpace(drivers)
 

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -132,7 +132,7 @@ func (daemon *Daemon) fillDriverInfo(v *types.Info) {
 			drivers += fmt.Sprintf(" (%s) ", os)
 		}
 		switch gd {
-		case "devicemapper":
+		case "devicemapper", "overlay":
 			v.Warnings = append(v.Warnings, fmt.Sprintf("WARNING: the %s storage-driver is deprecated, and will be removed in a future release.", gd))
 		}
 	}


### PR DESCRIPTION
This PR is built on top of https://github.com/moby/moby/pull/38018; I can rebase once that's merged

Related PRs:

- https://github.com/moby/moby/pull/38017 Deprecate "devicemapper" storage driver, and add warning 
- https://github.com/moby/moby/pull/38018 Deprecate legacy overlay storage driver, and add warning 
- https://github.com/docker/cli/pull/1424 Deprecate "devicemapper" storage driver. 
- https://github.com/docker/cli/pull/1425 Deprecate legacy overlay storage driver 


Discourage users from using deprecated storage-drivers
by skipping them when automatically selecting a storage-
driver.

This change does not affect existing installations, because
existing state will take precedence.

Users can still use deprecated drivers by manually configuring
the daemon to use a specific driver.