### PR TITLE
Remove skip evaluation of symlinks to data root on IoT Core

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/docker/pkg/fileutils"
 	"google.golang.org/grpc"
 
 	"github.com/containerd/containerd"
@@ -765,7 +766,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	if err != nil {
 		return nil, fmt.Errorf("Unable to get the TempDir under %s: %s", config.Root, err)
 	}
-	realTmp, err := getRealPath(tmp)
+	realTmp, err := fileutils.ReadSymlinkedDirectory(tmp)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to get the full path to the TempDir (%s): %s", tmp, err)
 	}
@@ -1447,7 +1448,7 @@ func CreateDaemonRoot(config *config.Config) error {
 	if _, err := os.Stat(config.Root); err != nil && os.IsNotExist(err) {
 		realRoot = config.Root
 	} else {
-		realRoot, err = getRealPath(config.Root)
+		realRoot, err = fileutils.ReadSymlinkedDirectory(config.Root)
 		if err != nil {
 			return fmt.Errorf("Unable to get the full path to root (%s): %s", config.Root, err)
 		}

--- a/daemon/daemon_linux.go
+++ b/daemon/daemon_linux.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/docker/docker/daemon/config"
-	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/libnetwork/resolvconf"
 	"github.com/pkg/errors"
@@ -121,10 +120,6 @@ func getCleanPatterns(id string) (regexps []*regexp.Regexp) {
 		}
 	}
 	return
-}
-
-func getRealPath(path string) (string, error) {
-	return fileutils.ReadSymlinkedDirectory(path)
 }
 
 func shouldUnmountRoot(root string, info *mount.Info) bool {

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/pkg/containerfs"
-	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/platform"
@@ -649,16 +648,6 @@ func setupDaemonProcess(config *config.Config) error {
 
 func (daemon *Daemon) setupSeccompProfile() error {
 	return nil
-}
-
-func getRealPath(path string) (string, error) {
-	if system.IsIoTCore() {
-		// Due to https://github.com/golang/go/issues/20506, path expansion
-		// does not work correctly on the default IoT Core configuration.
-		// TODO @darrenstahlmsft remove this once golang/go/20506 is fixed
-		return path, nil
-	}
-	return fileutils.ReadSymlinkedDirectory(path)
 }
 
 func (daemon *Daemon) loadRuntimes() error {

--- a/pkg/system/syscall_windows.go
+++ b/pkg/system/syscall_windows.go
@@ -120,8 +120,6 @@ func IsWindowsClient() bool {
 
 // IsIoTCore returns true if the currently running image is based off of
 // Windows 10 IoT Core.
-// @engine maintainers - this function should not be removed or modified as it
-// is used to enforce licensing restrictions on Windows.
 func IsIoTCore() bool {
 	var returnedProductType uint32
 	r1, _, err := procGetProductInfo.Call(6, 1, 0, 0, uintptr(unsafe.Pointer(&returnedProductType)))

--- a/pkg/system/syscall_windows.go
+++ b/pkg/system/syscall_windows.go
@@ -55,7 +55,6 @@ var (
 	ntuserApiset                  = windows.NewLazyDLL("ext-ms-win-ntuser-window-l1-1-0")
 	modadvapi32                   = windows.NewLazySystemDLL("advapi32.dll")
 	procGetVersionExW             = modkernel32.NewProc("GetVersionExW")
-	procGetProductInfo            = modkernel32.NewProc("GetProductInfo")
 	procSetNamedSecurityInfo      = modadvapi32.NewProc("SetNamedSecurityInfoW")
 	procGetSecurityDescriptorDacl = modadvapi32.NewProc("GetSecurityDescriptorDacl")
 )
@@ -116,20 +115,6 @@ func IsWindowsClient() bool {
 	}
 	const verNTWorkstation = 0x00000001
 	return osviex.ProductType == verNTWorkstation
-}
-
-// IsIoTCore returns true if the currently running image is based off of
-// Windows 10 IoT Core.
-func IsIoTCore() bool {
-	var returnedProductType uint32
-	r1, _, err := procGetProductInfo.Call(6, 1, 0, 0, uintptr(unsafe.Pointer(&returnedProductType)))
-	if r1 == 0 {
-		logrus.Warnf("GetProductInfo failed - assuming this is not IoT: %v", err)
-		return false
-	}
-	const productIoTUAP = 0x0000007B
-	const productIoTUAPCommercial = 0x00000083
-	return returnedProductType == productIoTUAP || returnedProductType == productIoTUAPCommercial
 }
 
 // Unmount is a platform-specific helper function to call


### PR DESCRIPTION
This fix was added in https://github.com/moby/moby/pull/33498/commits/8e71b1e210dc0eff980f39271d6c1dd48d87024e (https://github.com/moby/moby/pull/33498) to work around a go issue (https://github.com/golang/go/issues/20506).

That issue was fixed in https://github.com/golang/go/commit/66c03d39f3aa65ec522c41e56c569391786539a7,
which is part of Go 1.10 and up. This reverts the changes that were made in
8e71b1e210dc0eff980f39271d6c1dd48d87024e, and are no longer needed.

