### PR TITLE
bump buildkit to c7bb575343df0cbfeab8b5b28149630b8153fcc6

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -26,7 +26,7 @@ github.com/imdario/mergo v0.3.6
 golang.org/x/sync 1d60e4601c6fd243af51cc01ddf169918a5407ca
 
 # buildkit
-github.com/moby/buildkit 520201006c9dc676da9cf9655337ac711f7f127d 
+github.com/moby/buildkit c7bb575343df0cbfeab8b5b28149630b8153fcc6
 github.com/tonistiigi/fsutil f567071bed2416e4d87d260d3162722651182317
 github.com/grpc-ecosystem/grpc-opentracing 8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go 1361b9cd60be79c4c3a7fa9841b3c132e40066a7

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert.go
@@ -35,7 +35,7 @@ const (
 	localNameContext = "context"
 	historyComment   = "buildkit.dockerfile.v0"
 
-	DefaultCopyImage = "tonistiigi/copy:v0.1.5@sha256:eab89b76ffbb3c807663a67a41e8be31b8a0e362d7fb074a55bddace563a28bb"
+	DefaultCopyImage = "tonistiigi/copy:v0.1.7@sha256:9aab7d9ab369c6daf4831bf0653f7592110ab4b7e8a33fee2b9dca546e9d3089"
 )
 
 type ConvertOpt struct {
@@ -212,7 +212,7 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 				eg.Go(func() error {
 					ref, err := reference.ParseNormalizedNamed(d.stage.BaseName)
 					if err != nil {
-						return err
+						return errors.Wrapf(err, "failed to parse stage name %q", d.stage.BaseName)
 					}
 					platform := d.platform
 					if platform == nil {
@@ -653,7 +653,7 @@ func dispatchCopy(d *dispatchState, c instructions.SourcesAndDest, sourceState l
 	img := llb.Image(opt.copyImage, llb.MarkImageInternal, llb.Platform(opt.buildPlatforms[0]), WithInternalName("helper image for file operations"))
 
 	dest := path.Join(".", pathRelativeToWorkingDir(d.state, c.Dest()))
-	if c.Dest() == "." || c.Dest()[len(c.Dest())-1] == filepath.Separator {
+	if c.Dest() == "." || c.Dest() == "" || c.Dest()[len(c.Dest())-1] == filepath.Separator {
 		dest += string(filepath.Separator)
 	}
 	args := []string{"copy"}

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_runmount.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_runmount.go
@@ -136,7 +136,7 @@ func parseMount(value string) (*Mount, error) {
 				roAuto = false
 				continue
 			case "required":
-				if m.Type == "secret" {
+				if m.Type == "secret" || m.Type == "ssh" {
 					m.Required = true
 					continue
 				}

--- a/vendor/github.com/moby/buildkit/frontend/gateway/grpcclient/client.go
+++ b/vendor/github.com/moby/buildkit/frontend/gateway/grpcclient/client.go
@@ -356,6 +356,9 @@ func (r *reference) ReadFile(ctx context.Context, req client.ReadRequest) ([]byt
 }
 
 func (r *reference) ReadDir(ctx context.Context, req client.ReadDirRequest) ([]*fstypes.Stat, error) {
+	if err := r.c.caps.Supports(pb.CapReadDir); err != nil {
+		return nil, err
+	}
 	rdr := &pb.ReadDirRequest{
 		DirPath:        req.Path,
 		IncludePattern: req.IncludePattern,
@@ -369,6 +372,9 @@ func (r *reference) ReadDir(ctx context.Context, req client.ReadDirRequest) ([]*
 }
 
 func (r *reference) StatFile(ctx context.Context, req client.StatRequest) (*fstypes.Stat, error) {
+	if err := r.c.caps.Supports(pb.CapStatFile); err != nil {
+		return nil, err
+	}
 	rdr := &pb.StatFileRequest{
 		Path: req.Path,
 		Ref:  r.id,

--- a/vendor/github.com/moby/buildkit/snapshot/blobmapping/snapshotter.go
+++ b/vendor/github.com/moby/buildkit/snapshot/blobmapping/snapshotter.go
@@ -107,9 +107,20 @@ func (s *Snapshotter) GetBlob(ctx context.Context, key string) (digest.Digest, d
 // Checks that there is a blob in the content store.
 // If same blob has already been set then this is a noop.
 func (s *Snapshotter) SetBlob(ctx context.Context, key string, diffID, blobsum digest.Digest) error {
-	_, err := s.opt.Content.Info(ctx, blobsum)
+	info, err := s.opt.Content.Info(ctx, blobsum)
 	if err != nil {
 		return err
+	}
+	if _, ok := info.Labels["containerd.io/uncompressed"]; !ok {
+		labels := map[string]string{
+			"containerd.io/uncompressed": diffID.String(),
+		}
+		if _, err := s.opt.Content.Update(ctx, content.Info{
+			Digest: blobsum,
+			Labels: labels,
+		}, "labels.containerd.io/uncompressed"); err != nil {
+			return err
+		}
 	}
 	md, _ := s.opt.MetadataStore.Get(key)
 

--- a/vendor/github.com/moby/buildkit/solver/index.go
+++ b/vendor/github.com/moby/buildkit/solver/index.go
@@ -211,10 +211,12 @@ func (ei *edgeIndex) getAllMatches(k *CacheKey) []string {
 			for _, d := range dd {
 				ll := CacheInfoLink{Input: Index(i), Digest: k.Digest(), Output: k.Output(), Selector: d.Selector}
 				for _, ckID := range d.CacheKey.CacheKey.indexIDs {
-					if l, ok := ei.items[ckID].links[ll]; ok {
-						if _, ok := l[m]; ok {
-							found = true
-							break
+					if item, ok := ei.items[ckID]; ok {
+						if l, ok := item.links[ll]; ok {
+							if _, ok := l[m]; ok {
+								found = true
+								break
+							}
 						}
 					}
 				}

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go
@@ -302,7 +302,7 @@ func (e *execOp) getSSHMountable(ctx context.Context, m *pb.Mount) (cache.Mounta
 			return nil, nil
 		}
 		if st, ok := status.FromError(err); ok && st.Code() == codes.Unimplemented {
-			return nil, errors.Errorf("no ssh forwarded from the client")
+			return nil, errors.Errorf("no SSH key %q forwarded from the client", m.SSHOpt.ID)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
https://github.com/moby/buildkit/compare/520201006c9dc676da9cf9655337ac711f7f127d...c7bb575343df0cbfeab8b5b28149630b8153fcc6

Relevant changes:

- https://github.com/moby/buildkit/pull/667 gateway: check for `ReadDir` and `StatFile` caps on client side
- https://github.com/moby/buildkit/pull/668 dockerfile: fix ssh required option
- https://github.com/moby/buildkit/pull/669 dockerfile: update default copy image
- https://github.com/moby/buildkit/pull/670 solver: specify SSH key ID in error message when required key was not forwarded
- https://github.com/moby/buildkit/pull/673 solver: fix possible nil dereference
- https://github.com/moby/buildkit/pull/672 fix setting uncompressed label on content
- https://github.com/moby/buildkit/pull/680 dockerfile: fix empty dest directory panic
  - fixes https://github.com/moby/buildkit/issues/679
