### PR TITLE
Bump swarmkit to 7d5d33b97794440462a04acdd3f31914da8f66f3

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -126,7 +126,7 @@ github.com/containerd/ttrpc 2a805f71863501300ae1976d29f0454ae003e85a
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 
 # cluster
-github.com/docker/swarmkit 9f271c2963d18a7c60d2c4001fb418ca4037df19
+github.com/docker/swarmkit 7d5d33b97794440462a04acdd3f31914da8f66f3
 github.com/gogo/protobuf v1.0.0
 github.com/cloudflare/cfssl 1.3.2
 github.com/fernet/fernet-go 1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2

--- a/vendor/github.com/docker/swarmkit/agent/agent.go
+++ b/vendor/github.com/docker/swarmkit/agent/agent.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bytes"
+	"context"
 	"math/rand"
 	"reflect"
 	"sync"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/vendor/github.com/docker/swarmkit/agent/errors.go
+++ b/vendor/github.com/docker/swarmkit/agent/errors.go
@@ -13,10 +13,5 @@ var (
 	errAgentStarted    = errors.New("agent: already started")
 	errAgentNotStarted = errors.New("agent: not started")
 
-	errTaskNoController         = errors.New("agent: no task controller")
-	errTaskNotAssigned          = errors.New("agent: task not assigned")
-	errTaskStatusUpdateNoChange = errors.New("agent: no change in task status")
-	errTaskUnknown              = errors.New("agent: task unknown")
-
-	errTaskInvalid = errors.New("task: invalid")
+	errTaskUnknown = errors.New("agent: task unknown")
 )

--- a/vendor/github.com/docker/swarmkit/agent/exec/controller.go
+++ b/vendor/github.com/docker/swarmkit/agent/exec/controller.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/swarmkit/protobuf/ptypes"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // Controller controls execution of a task.

--- a/vendor/github.com/docker/swarmkit/agent/exec/controller_stub.go
+++ b/vendor/github.com/docker/swarmkit/agent/exec/controller_stub.go
@@ -1,10 +1,11 @@
 package exec
 
 import (
-	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
+	"context"
 	"runtime"
 	"strings"
+
+	"github.com/docker/swarmkit/api"
 )
 
 // StubController implements the Controller interface,

--- a/vendor/github.com/docker/swarmkit/agent/exec/executor.go
+++ b/vendor/github.com/docker/swarmkit/agent/exec/executor.go
@@ -1,8 +1,9 @@
 package exec
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 // Executor provides controllers for tasks.

--- a/vendor/github.com/docker/swarmkit/agent/helpers.go
+++ b/vendor/github.com/docker/swarmkit/agent/helpers.go
@@ -1,6 +1,6 @@
 package agent
 
-import "golang.org/x/net/context"
+import "context"
 
 // runctx blocks until the function exits, closed is closed, or the context is
 // cancelled. Call as part of go statement.

--- a/vendor/github.com/docker/swarmkit/agent/reporter.go
+++ b/vendor/github.com/docker/swarmkit/agent/reporter.go
@@ -1,12 +1,12 @@
 package agent
 
 import (
+	"context"
 	"reflect"
 	"sync"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
-	"golang.org/x/net/context"
 )
 
 // StatusReporter receives updates to task status. Method may be called

--- a/vendor/github.com/docker/swarmkit/agent/resource.go
+++ b/vendor/github.com/docker/swarmkit/agent/resource.go
@@ -1,8 +1,9 @@
 package agent
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 type resourceAllocator struct {

--- a/vendor/github.com/docker/swarmkit/agent/session.go
+++ b/vendor/github.com/docker/swarmkit/agent/session.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"time"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/connectionbroker"
 	"github.com/docker/swarmkit/log"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -17,7 +17,6 @@ import (
 
 var (
 	dispatcherRPCTimeout = 5 * time.Second
-	errSessionDisconnect = errors.New("agent: session disconnect") // instructed to disconnect
 	errSessionClosed     = errors.New("agent: session closed")
 )
 
@@ -137,7 +136,7 @@ func (s *session) start(ctx context.Context, description *api.NodeDescription) e
 	// `ctx` is done and hence fail to propagate the timeout error to the agent.
 	// If the error is not propogated to the agent, the agent will not close
 	// the session or rebuild a new session.
-	sessionCtx, cancelSession := context.WithCancel(ctx)
+	sessionCtx, cancelSession := context.WithCancel(ctx) // nolint: vet
 
 	// Need to run Session in a goroutine since there's no way to set a
 	// timeout for an individual Recv call in a stream.
@@ -160,7 +159,7 @@ func (s *session) start(ctx context.Context, description *api.NodeDescription) e
 	select {
 	case err := <-errChan:
 		if err != nil {
-			return err
+			return err // nolint: vet
 		}
 	case <-time.After(dispatcherRPCTimeout):
 		cancelSession()

--- a/vendor/github.com/docker/swarmkit/agent/task.go
+++ b/vendor/github.com/docker/swarmkit/agent/task.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/api/equality"
 	"github.com/docker/swarmkit/log"
-	"golang.org/x/net/context"
 )
 
 // taskManager manages all aspects of task execution and reporting for an agent

--- a/vendor/github.com/docker/swarmkit/agent/worker.go
+++ b/vendor/github.com/docker/swarmkit/agent/worker.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"sync"
 
 	"github.com/docker/swarmkit/agent/exec"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/watch"
 	"github.com/sirupsen/logrus"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/net/context"
 )
 
 // Worker implements the core task management logic and persistence. It

--- a/vendor/github.com/docker/swarmkit/api/genericresource/resource_management.go
+++ b/vendor/github.com/docker/swarmkit/api/genericresource/resource_management.go
@@ -2,6 +2,7 @@ package genericresource
 
 import (
 	"fmt"
+
 	"github.com/docker/swarmkit/api"
 )
 

--- a/vendor/github.com/docker/swarmkit/api/genericresource/validate.go
+++ b/vendor/github.com/docker/swarmkit/api/genericresource/validate.go
@@ -2,6 +2,7 @@ package genericresource
 
 import (
 	"fmt"
+
 	"github.com/docker/swarmkit/api"
 )
 

--- a/vendor/github.com/docker/swarmkit/ca/auth.go
+++ b/vendor/github.com/docker/swarmkit/ca/auth.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509/pkix"
 	"strings"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"

--- a/vendor/github.com/docker/swarmkit/ca/certificates.go
+++ b/vendor/github.com/docker/swarmkit/ca/certificates.go
@@ -2,6 +2,7 @@ package ca
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -31,7 +32,6 @@ import (
 	"github.com/docker/swarmkit/ioutils"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"

--- a/vendor/github.com/docker/swarmkit/ca/config.go
+++ b/vendor/github.com/docker/swarmkit/ca/config.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"context"
 	cryptorand "crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
@@ -23,8 +24,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/credentials"
-
-	"golang.org/x/net/context"
 )
 
 const (
@@ -32,7 +31,6 @@ const (
 	rootCAKeyFilename   = "swarm-root-ca.key"
 	nodeTLSCertFilename = "swarm-node.crt"
 	nodeTLSKeyFilename  = "swarm-node.key"
-	nodeCSRFilename     = "swarm-node.csr"
 
 	// DefaultRootCN represents the root CN that we should create roots CAs with by default
 	DefaultRootCN = "swarm-ca"
@@ -626,10 +624,10 @@ func calculateRandomExpiry(validFrom, validUntil time.Time) time.Duration {
 	if maxValidity-minValidity < 1 {
 		randomExpiry = minValidity
 	} else {
-		randomExpiry = rand.Intn(maxValidity-minValidity) + int(minValidity)
+		randomExpiry = rand.Intn(maxValidity-minValidity) + minValidity
 	}
 
-	expiry := validFrom.Add(time.Duration(randomExpiry) * time.Minute).Sub(time.Now())
+	expiry := time.Until(validFrom.Add(time.Duration(randomExpiry) * time.Minute))
 	if expiry < 0 {
 		return 0
 	}

--- a/vendor/github.com/docker/swarmkit/ca/external.go
+++ b/vendor/github.com/docker/swarmkit/ca/external.go
@@ -2,6 +2,7 @@ package ca
 
 import (
 	"bytes"
+	"context"
 	cryptorand "crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
@@ -21,7 +22,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"golang.org/x/net/context/ctxhttp"
 )
 

--- a/vendor/github.com/docker/swarmkit/ca/forward.go
+++ b/vendor/github.com/docker/swarmkit/ca/forward.go
@@ -1,7 +1,8 @@
 package ca
 
 import (
-	"golang.org/x/net/context"
+	"context"
+
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 )

--- a/vendor/github.com/docker/swarmkit/ca/renewer.go
+++ b/vendor/github.com/docker/swarmkit/ca/renewer.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // RenewTLSExponentialBackoff sets the exponential backoff when trying to renew TLS certificates that have expired

--- a/vendor/github.com/docker/swarmkit/ca/server.go
+++ b/vendor/github.com/docker/swarmkit/ca/server.go
@@ -2,6 +2,7 @@ package ca
 
 import (
 	"bytes"
+	"context"
 	"crypto/subtle"
 	"crypto/x509"
 	"sync"
@@ -15,7 +16,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/vendor/github.com/docker/swarmkit/ca/transport.go
+++ b/vendor/github.com/docker/swarmkit/ca/transport.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -9,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/credentials"
 )
 
@@ -17,12 +17,6 @@ var (
 	// alpnProtoStr is the specified application level protocols for gRPC.
 	alpnProtoStr = []string{"h2"}
 )
-
-type timeoutError struct{}
-
-func (timeoutError) Error() string   { return "mutablecredentials: Dial timed out" }
-func (timeoutError) Timeout() bool   { return true }
-func (timeoutError) Temporary() bool { return true }
 
 // MutableTLSCreds is the credentials required for authenticating a connection using TLS.
 type MutableTLSCreds struct {

--- a/vendor/github.com/docker/swarmkit/log/context.go
+++ b/vendor/github.com/docker/swarmkit/log/context.go
@@ -1,10 +1,10 @@
 package log
 
 import (
+	"context"
 	"path"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/vendor/github.com/docker/swarmkit/log/grpc.go
+++ b/vendor/github.com/docker/swarmkit/log/grpc.go
@@ -1,8 +1,9 @@
 package log
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/grpclog"
 )
 

--- a/vendor/github.com/docker/swarmkit/manager/allocator/allocator.go
+++ b/vendor/github.com/docker/swarmkit/manager/allocator/allocator.go
@@ -1,6 +1,7 @@
 package allocator
 
 import (
+	"context"
 	"sync"
 
 	"github.com/docker/docker/pkg/plugingetter"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/manager/allocator/cnmallocator"
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 // Allocator controls how the allocation stage in the manager is handled.

--- a/vendor/github.com/docker/swarmkit/manager/allocator/cnmallocator/networkallocator.go
+++ b/vendor/github.com/docker/swarmkit/manager/allocator/cnmallocator/networkallocator.go
@@ -1,6 +1,7 @@
 package cnmallocator
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -16,7 +17,6 @@ import (
 	"github.com/docker/swarmkit/manager/allocator/networkallocator"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const (
@@ -815,8 +815,7 @@ func (na *cnmNetworkAllocator) resolveDriver(n *api.Network) (*networkDriver, er
 
 	d, drvcap := na.drvRegistry.Driver(dName)
 	if d == nil {
-		var err error
-		err = na.loadDriver(dName)
+		err := na.loadDriver(dName)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/docker/swarmkit/manager/allocator/cnmallocator/portallocator.go
+++ b/vendor/github.com/docker/swarmkit/manager/allocator/cnmallocator/portallocator.go
@@ -407,12 +407,12 @@ func (ps *portSpace) allocate(p *api.PortConfig) (err error) {
 	}
 	defer func() {
 		if err != nil {
-			ps.dynamicPortSpace.Release(uint64(swarmPort))
+			ps.dynamicPortSpace.Release(swarmPort)
 		}
 	}()
 
 	// Make sure we allocate the same port from the master space.
-	if err = ps.masterPortSpace.GetSpecificID(uint64(swarmPort)); err != nil {
+	if err = ps.masterPortSpace.GetSpecificID(swarmPort); err != nil {
 		return
 	}
 

--- a/vendor/github.com/docker/swarmkit/manager/allocator/network.go
+++ b/vendor/github.com/docker/swarmkit/manager/allocator/network.go
@@ -1,6 +1,7 @@
 package allocator
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/protobuf/ptypes"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/vendor/github.com/docker/swarmkit/manager/constraint/constraint.go
+++ b/vendor/github.com/docker/swarmkit/manager/constraint/constraint.go
@@ -56,7 +56,7 @@ func Parse(env []string) ([]Constraint, error) {
 			part0 := strings.TrimSpace(parts[0])
 			// validate key
 			matched := alphaNumeric.MatchString(part0)
-			if matched == false {
+			if !matched {
 				return nil, fmt.Errorf("key '%s' is invalid", part0)
 			}
 
@@ -64,7 +64,7 @@ func Parse(env []string) ([]Constraint, error) {
 
 			// validate Value
 			matched = valuePattern.MatchString(part1)
-			if matched == false {
+			if !matched {
 				return nil, fmt.Errorf("value '%s' is invalid", part1)
 			}
 			// TODO(dongluochen): revisit requirements to see if globing or regex are useful

--- a/vendor/github.com/docker/swarmkit/manager/controlapi/cluster.go
+++ b/vendor/github.com/docker/swarmkit/manager/controlapi/cluster.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/swarmkit/manager/encryption"
 	"github.com/docker/swarmkit/manager/state/store"
 	gogotypes "github.com/gogo/protobuf/types"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/vendor/github.com/docker/swarmkit/manager/controlapi/config.go
+++ b/vendor/github.com/docker/swarmkit/manager/controlapi/config.go
@@ -2,6 +2,7 @@ package controlapi
 
 import (
 	"bytes"
+	"context"
 	"strings"
 
 	"github.com/docker/swarmkit/api"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/vendor/github.com/docker/swarmkit/manager/controlapi/network.go
+++ b/vendor/github.com/docker/swarmkit/manager/controlapi/network.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"net"
 
 	"github.com/docker/docker/pkg/plugingetter"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/swarmkit/manager/allocator"
 	"github.com/docker/swarmkit/manager/allocator/networkallocator"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/vendor/github.com/docker/swarmkit/manager/controlapi/node.go
+++ b/vendor/github.com/docker/swarmkit/manager/controlapi/node.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/raft/membership"
 	"github.com/docker/swarmkit/manager/state/store"
 	gogotypes "github.com/gogo/protobuf/types"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/vendor/github.com/docker/swarmkit/manager/controlapi/secret.go
+++ b/vendor/github.com/docker/swarmkit/manager/controlapi/secret.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"crypto/subtle"
 	"strings"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/vendor/github.com/docker/swarmkit/manager/controlapi/service.go
+++ b/vendor/github.com/docker/swarmkit/manager/controlapi/service.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strings"
@@ -18,7 +19,6 @@ import (
 	"github.com/docker/swarmkit/protobuf/ptypes"
 	"github.com/docker/swarmkit/template"
 	gogotypes "github.com/gogo/protobuf/types"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -197,7 +197,7 @@ func validateHealthCheck(hc *api.HealthConfig) error {
 		if err != nil {
 			return err
 		}
-		if interval != 0 && interval < time.Duration(minimumDuration) {
+		if interval != 0 && interval < minimumDuration {
 			return status.Errorf(codes.InvalidArgument, "ContainerSpec: Interval in HealthConfig cannot be less than %s", minimumDuration)
 		}
 	}
@@ -207,7 +207,7 @@ func validateHealthCheck(hc *api.HealthConfig) error {
 		if err != nil {
 			return err
 		}
-		if timeout != 0 && timeout < time.Duration(minimumDuration) {
+		if timeout != 0 && timeout < minimumDuration {
 			return status.Errorf(codes.InvalidArgument, "ContainerSpec: Timeout in HealthConfig cannot be less than %s", minimumDuration)
 		}
 	}
@@ -217,7 +217,7 @@ func validateHealthCheck(hc *api.HealthConfig) error {
 		if err != nil {
 			return err
 		}
-		if sp != 0 && sp < time.Duration(minimumDuration) {
+		if sp != 0 && sp < minimumDuration {
 			return status.Errorf(codes.InvalidArgument, "ContainerSpec: StartPeriod in HealthConfig cannot be less than %s", minimumDuration)
 		}
 	}

--- a/vendor/github.com/docker/swarmkit/manager/controlapi/task.go
+++ b/vendor/github.com/docker/swarmkit/manager/controlapi/task.go
@@ -1,11 +1,12 @@
 package controlapi
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/api/naming"
 	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/vendor/github.com/docker/swarmkit/manager/dispatcher/dispatcher.go
+++ b/vendor/github.com/docker/swarmkit/manager/dispatcher/dispatcher.go
@@ -1,6 +1,7 @@
 package dispatcher
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strconv"
@@ -21,7 +22,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -1090,14 +1090,10 @@ func (d *Dispatcher) moveTasksToOrphaned(nodeID string) error {
 				task.Status.State = api.TaskStateOrphaned
 			}
 
-			if err := batch.Update(func(tx store.Tx) error {
-				err := store.UpdateTask(tx, task)
-				if err != nil {
-					return err
-				}
-
-				return nil
-			}); err != nil {
+			err := batch.Update(func(tx store.Tx) error {
+				return store.UpdateTask(tx, task)
+			})
+			if err != nil {
 				return err
 			}
 

--- a/vendor/github.com/docker/swarmkit/manager/dispatcher/nodes.go
+++ b/vendor/github.com/docker/swarmkit/manager/dispatcher/nodes.go
@@ -156,7 +156,7 @@ func (s *nodeStore) Heartbeat(id, sid string) (time.Duration, error) {
 		return 0, err
 	}
 	period := s.periodChooser.Choose() // base period for node
-	grace := period * time.Duration(s.gracePeriodMultiplierNormal)
+	grace := period * s.gracePeriodMultiplierNormal
 	rn.mu.Lock()
 	rn.Heartbeat.Update(grace)
 	rn.Heartbeat.Beat()

--- a/vendor/github.com/docker/swarmkit/manager/health/health.go
+++ b/vendor/github.com/docker/swarmkit/manager/health/health.go
@@ -8,10 +8,10 @@
 package health
 
 import (
+	"context"
 	"sync"
 
 	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/vendor/github.com/docker/swarmkit/manager/keymanager/keymanager.go
+++ b/vendor/github.com/docker/swarmkit/manager/keymanager/keymanager.go
@@ -6,6 +6,7 @@ package keymanager
 // which is used to exchange service discovery and overlay network control
 // plane information. It can also be used to encrypt overlay data traffic.
 import (
+	"context"
 	cryptorand "crypto/rand"
 	"encoding/binary"
 	"sync"
@@ -15,7 +16,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/vendor/github.com/docker/swarmkit/manager/logbroker/broker.go
+++ b/vendor/github.com/docker/swarmkit/manager/logbroker/broker.go
@@ -1,6 +1,7 @@
 package logbroker
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/watch"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/vendor/github.com/docker/swarmkit/manager/logbroker/subscription.go
+++ b/vendor/github.com/docker/swarmkit/manager/logbroker/subscription.go
@@ -1,6 +1,7 @@
 package logbroker
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/watch"
-	"golang.org/x/net/context"
 )
 
 type subscription struct {

--- a/vendor/github.com/docker/swarmkit/manager/manager.go
+++ b/vendor/github.com/docker/swarmkit/manager/manager.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -45,7 +46,6 @@ import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -1002,9 +1002,7 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 			cluster = store.GetCluster(tx, clusterID)
 		})
 		if cluster.DefaultAddressPool != nil {
-			for _, address := range cluster.DefaultAddressPool {
-				m.config.NetworkConfig.DefaultAddrPool = append(m.config.NetworkConfig.DefaultAddrPool, address)
-			}
+			m.config.NetworkConfig.DefaultAddrPool = append(m.config.NetworkConfig.DefaultAddrPool, cluster.DefaultAddressPool...)
 			m.config.NetworkConfig.SubnetSize = cluster.SubnetSize
 		}
 	}

--- a/vendor/github.com/docker/swarmkit/manager/metrics/collector.go
+++ b/vendor/github.com/docker/swarmkit/manager/metrics/collector.go
@@ -188,7 +188,6 @@ func (c *Collector) handleNodeEvent(event events.Event) {
 	if newNode != nil {
 		nodesMetric.WithValues(strings.ToLower(newNode.Status.State.String())).Inc(1)
 	}
-	return
 }
 
 func (c *Collector) handleTaskEvent(event events.Event) {
@@ -218,8 +217,6 @@ func (c *Collector) handleTaskEvent(event events.Event) {
 			strings.ToLower(newTask.Status.State.String()),
 		).Inc(1)
 	}
-
-	return
 }
 
 func (c *Collector) handleServiceEvent(event events.Event) {

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/global/global.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/global/global.go
@@ -1,6 +1,8 @@
 package global
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/constraint"
@@ -9,7 +11,6 @@ import (
 	"github.com/docker/swarmkit/manager/orchestrator/taskinit"
 	"github.com/docker/swarmkit/manager/orchestrator/update"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 type globalService struct {
@@ -584,12 +585,4 @@ func (g *Orchestrator) SlotTuple(t *api.Task) orchestrator.SlotTuple {
 		ServiceID: t.ServiceID,
 		NodeID:    t.NodeID,
 	}
-}
-
-func isTaskCompleted(t *api.Task, restartPolicy api.RestartPolicy_RestartCondition) bool {
-	if t == nil || t.DesiredState <= api.TaskStateRunning {
-		return false
-	}
-	return restartPolicy == api.RestartOnNone ||
-		(restartPolicy == api.RestartOnFailure && t.Status.State == api.TaskStateCompleted)
 }

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/replicated/replicated.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/replicated/replicated.go
@@ -1,12 +1,13 @@
 package replicated
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/orchestrator/restart"
 	"github.com/docker/swarmkit/manager/orchestrator/update"
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 // An Orchestrator runs a reconciliation loop to create and destroy

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/replicated/services.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/replicated/services.go
@@ -1,6 +1,7 @@
 package replicated
 
 import (
+	"context"
 	"sort"
 
 	"github.com/docker/go-events"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 // This file provices service-level orchestration. It observes changes to

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/replicated/slot.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/replicated/slot.go
@@ -1,10 +1,11 @@
 package replicated
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 type slotsByRunningState []orchestrator.Slot

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/replicated/tasks.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/replicated/tasks.go
@@ -1,13 +1,14 @@
 package replicated
 
 import (
+	"context"
+
 	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/orchestrator/taskinit"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 // This file provides task-level orchestration. It observes changes to task

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/restart/restart.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/restart/restart.go
@@ -2,6 +2,7 @@ package restart
 
 import (
 	"container/list"
+	"context"
 	"errors"
 	"sync"
 	"time"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	gogotypes "github.com/gogo/protobuf/types"
-	"golang.org/x/net/context"
 )
 
 const defaultOldTaskTimeout = time.Minute

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/service.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/service.go
@@ -1,10 +1,11 @@
 package orchestrator
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 // IsReplicatedService checks if a service is a replicated service.

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/taskinit/init.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/taskinit/init.go
@@ -1,6 +1,7 @@
 package taskinit
 
 import (
+	"context"
 	"sort"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/swarmkit/manager/orchestrator/restart"
 	"github.com/docker/swarmkit/manager/state/store"
 	gogotypes "github.com/gogo/protobuf/types"
-	"golang.org/x/net/context"
 )
 
 // InitHandler defines orchestrator's action to fix tasks at start.
@@ -80,7 +80,7 @@ func CheckTasks(ctx context.Context, s *store.MemoryStore, readTx store.ReadTx, 
 				}
 				if err == nil {
 					restartTime := timestamp.Add(restartDelay)
-					calculatedRestartDelay := restartTime.Sub(time.Now())
+					calculatedRestartDelay := time.Until(restartTime)
 					if calculatedRestartDelay < restartDelay {
 						restartDelay = calculatedRestartDelay
 					}

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/taskreaper/task_reaper.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/taskreaper/task_reaper.go
@@ -1,6 +1,7 @@
 package taskreaper
 
 import (
+	"context"
 	"sort"
 	"sync"
 	"time"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/update/updater.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/update/updater.go
@@ -1,13 +1,12 @@
 package update
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"

--- a/vendor/github.com/docker/swarmkit/manager/raftselector/raftselector.go
+++ b/vendor/github.com/docker/swarmkit/manager/raftselector/raftselector.go
@@ -1,9 +1,8 @@
 package raftselector
 
 import (
+	"context"
 	"errors"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/grpc"
 )

--- a/vendor/github.com/docker/swarmkit/manager/resourceapi/allocator.go
+++ b/vendor/github.com/docker/swarmkit/manager/resourceapi/allocator.go
@@ -1,6 +1,7 @@
 package resourceapi
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/identity"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/protobuf/ptypes"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/vendor/github.com/docker/swarmkit/manager/role_manager.go
+++ b/vendor/github.com/docker/swarmkit/manager/role_manager.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"time"
 
 	"github.com/docker/swarmkit/api"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/raft/membership"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/pivotal-golang/clock"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/vendor/github.com/docker/swarmkit/manager/scheduler/nodeinfo.go
+++ b/vendor/github.com/docker/swarmkit/manager/scheduler/nodeinfo.go
@@ -1,12 +1,12 @@
 package scheduler
 
 import (
+	"context"
 	"time"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/api/genericresource"
 	"github.com/docker/swarmkit/log"
-	"golang.org/x/net/context"
 )
 
 // hostPortSpec specifies a used host port.

--- a/vendor/github.com/docker/swarmkit/manager/scheduler/scheduler.go
+++ b/vendor/github.com/docker/swarmkit/manager/scheduler/scheduler.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"time"
 
 	"github.com/docker/swarmkit/api"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/protobuf/ptypes"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/vendor/github.com/docker/swarmkit/manager/state/proposer.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/proposer.go
@@ -1,8 +1,9 @@
 package state
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 // A Change includes a version number and a set of store actions from a

--- a/vendor/github.com/docker/swarmkit/manager/state/raft/raft.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/raft/raft.go
@@ -1,6 +1,7 @@
 package raft
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math"
@@ -30,7 +31,6 @@ import (
 	"github.com/pivotal-golang/clock"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -1182,11 +1182,8 @@ func (n *Node) CanRemoveMember(id uint64) bool {
 	}
 
 	nquorum := (len(members)-1)/2 + 1
-	if nreachable < nquorum {
-		return false
-	}
 
-	return true
+	return nreachable >= nquorum
 }
 
 func (n *Node) removeMember(ctx context.Context, id uint64) error {
@@ -1591,10 +1588,7 @@ func (n *Node) ProposeValue(ctx context.Context, storeAction []api.StoreAction, 
 	defer cancel()
 	_, err := n.processInternalRaftRequest(ctx, &api.InternalRaftRequest{Action: storeAction}, cb)
 
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // GetVersion returns the sequence information for the current raft round.

--- a/vendor/github.com/docker/swarmkit/manager/state/raft/storage.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/raft/storage.go
@@ -1,6 +1,7 @@
 package raft
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/coreos/etcd/raft"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/raft/storage"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/vendor/github.com/docker/swarmkit/manager/state/raft/storage/storage.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/raft/storage/storage.go
@@ -1,12 +1,11 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
-
-	"golang.org/x/net/context"
 
 	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/coreos/etcd/raft/raftpb"

--- a/vendor/github.com/docker/swarmkit/manager/state/raft/storage/walwrap.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/raft/storage/walwrap.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/encryption"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // This package wraps the github.com/coreos/etcd/wal package, and encrypts

--- a/vendor/github.com/docker/swarmkit/manager/state/raft/transport/peer.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/raft/transport/peer.go
@@ -1,11 +1,10 @@
 package transport
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/vendor/github.com/docker/swarmkit/manager/state/raft/transport/transport.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/raft/transport/transport.go
@@ -3,11 +3,10 @@
 package transport
 
 import (
+	"context"
 	"net"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"google.golang.org/grpc"

--- a/vendor/github.com/docker/swarmkit/manager/state/raft/util.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/raft/util.go
@@ -1,9 +1,8 @@
 package raft
 
 import (
+	"context"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state"

--- a/vendor/github.com/docker/swarmkit/manager/state/store/memory.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/store/memory.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"runtime"
@@ -18,7 +19,6 @@ import (
 	"github.com/docker/swarmkit/watch"
 	gogotypes "github.com/gogo/protobuf/types"
 	memdb "github.com/hashicorp/go-memdb"
-	"golang.org/x/net/context"
 )
 
 const (
@@ -689,7 +689,7 @@ func (tx readTx) findIterators(table string, by By, checkType func(By) error) ([
 		}
 		return []memdb.ResultIterator{it}, nil
 	case bySlot:
-		it, err := tx.memDBTx.Get(table, indexSlot, v.serviceID+"\x00"+strconv.FormatUint(uint64(v.slot), 10))
+		it, err := tx.memDBTx.Get(table, indexSlot, v.serviceID+"\x00"+strconv.FormatUint(v.slot, 10))
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/docker/swarmkit/manager/watchapi/server.go
+++ b/vendor/github.com/docker/swarmkit/manager/watchapi/server.go
@@ -1,11 +1,11 @@
 package watchapi
 
 import (
+	"context"
 	"errors"
 	"sync"
 
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/vendor/github.com/docker/swarmkit/node/node.go
+++ b/vendor/github.com/docker/swarmkit/node/node.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"io/ioutil"
@@ -35,7 +36,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/status"
@@ -1204,19 +1204,16 @@ func (s *persistentRemotes) Observe(peer api.Peer, weight int) {
 	s.c.Broadcast()
 	if err := s.save(); err != nil {
 		logrus.Errorf("error writing cluster state file: %v", err)
-		return
 	}
-	return
 }
+
 func (s *persistentRemotes) Remove(peers ...api.Peer) {
 	s.Lock()
 	defer s.Unlock()
 	s.Remotes.Remove(peers...)
 	if err := s.save(); err != nil {
 		logrus.Errorf("error writing cluster state file: %v", err)
-		return
 	}
-	return
 }
 
 func (s *persistentRemotes) save() error {


### PR DESCRIPTION
full diff: https://github.com/docker/swarmkit/compare/9f271c2963d18a7c60d2c4001fb418ca4037df19...7d5d33b97794440462a04acdd3f31914da8f66f3

- https://github.com/docker/swarmkit/pull/2681 Handle an edge case in CA rotation where we reclaim CA service from an external CA
- https://github.com/docker/swarmkit/pull/2750 Use gometalinter; switch from x/net/context -> context