### PR TITLE
Fix mount propagation for btrfs

### DIFF
--- a/pkg/mount/sharedsubtree_linux.go
+++ b/pkg/mount/sharedsubtree_linux.go
@@ -55,12 +55,9 @@ func ensureMountedAs(mountPoint, options string) error {
 	}
 
 	if !mounted {
-		if err := Mount(mountPoint, mountPoint, "none", "bind,rw"); err != nil {
+		if err := Mount(mountPoint, mountPoint, "none", "bind"); err != nil {
 			return err
 		}
-	}
-	if _, err = Mounted(mountPoint); err != nil {
-		return err
 	}
 
 	return ForceMount("", mountPoint, "none", options)

--- a/pkg/mount/sharedsubtree_linux.go
+++ b/pkg/mount/sharedsubtree_linux.go
@@ -48,16 +48,23 @@ func MakeRUnbindable(mountPoint string) error {
 	return ensureMountedAs(mountPoint, "runbindable")
 }
 
-func ensureMountedAs(mountPoint, options string) error {
-	mounted, err := Mounted(mountPoint)
+// MakeMount ensures that the file or directory given is a mount point,
+// bind mounting it to itself it case it is not.
+func MakeMount(mnt string) error {
+	mounted, err := Mounted(mnt)
 	if err != nil {
 		return err
 	}
+	if mounted {
+		return nil
+	}
 
-	if !mounted {
-		if err := Mount(mountPoint, mountPoint, "none", "bind"); err != nil {
-			return err
-		}
+	return Mount(mnt, mnt, "none", "bind")
+}
+
+func ensureMountedAs(mountPoint, options string) error {
+	if err := MakeMount(mountPoint); err != nil {
+		return err
 	}
 
 	return ForceMount("", mountPoint, "none", options)


### PR DESCRIPTION
For some reason, shared mount propagation between the host
and a container does not work for btrfs, unless container
root directory (i.e. graphdriver home) is a bind mount.
    
The above issue was reproduced on SLES 12sp3 + btrfs using
the following script:
    
            #!/bin/bash
            set -eux -o pipefail
    
            # DIR should not be under a subvolume
            DIR=${DIR:-/lib}
            MNT=$DIR/my-mnt
            FILE=$MNT/file
    
            ID=$(docker run -d --privileged -v $DIR:$DIR:rshared ubuntu sleep 24h)
            docker exec $ID mkdir -p $MNT
            docker exec $ID mount -t tmpfs tmpfs $MNT
            docker exec $ID touch $FILE
            ls -l $FILE
            umount $MNT
            docker rm -f $ID
    
which fails this way:
    
            + ls -l /lib/my-mnt/file
            ls: cannot access '/lib/my-mnt/file': No such file or directory
    
meaning the mount performed inside a priviledged container is not
propagated back to the host (even if all the mounts have "shared"
propagation mode).
    
The remedy to the above is to make graphdriver home a bind mount.