### PR TITLE
fixes checkpoint rm fail

### DIFF
--- a/daemon/checkpoint.go
+++ b/daemon/checkpoint.go
@@ -95,7 +95,7 @@ func (daemon *Daemon) CheckpointDelete(name string, config types.CheckpointDelet
 	}
 	checkpointDir, err := getCheckpointDir(config.CheckpointDir, config.CheckpointID, name, container.ID, container.CheckpointDir(), false)
 	if err == nil {
-		return os.RemoveAll(filepath.Join(checkpointDir, config.CheckpointID))
+		return os.RemoveAll(checkpointDir)
 	}
 	return err
 }


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
docker checkpoint rm <container id> <checkpoint id>
Have no errors, but the checkpoint is not really deleted.

**- How I did it**
The deleted path is error.
When delete, no need "filepath.Join(checkpointDir, config.CheckpointID)"
Because "checkpointDir" containes "config.CheckpointID" after call func name "getCheckpointDir".

**- How to verify it**
Before fix:
```
root@dockerdemo:~/checkpoints# docker checkpoint ls redis2
CHECKPOINT NAME
redis2-2
root@dockerdemo:~/checkpoints# docker checkpoint rm redis2 redis2-2
root@dockerdemo:~/checkpoints#
root@dockerdemo:~/checkpoints# ls /var/lib/docker/containers/8b5ff6aa250b78dd8a672ee60ff239afda716e4bedc3f77acb4a70c4535b3eba/checkpoints/redis2-2/
cgroup.img   core-13.img  descriptors.json  fs-1.img      inetsk.img       ipcns-var-10.img  mountpoints-12.img  pagemap-1.img   pipes.img      route6-9.img  seccomp.img              tmpfs-dev-48.tar.gz.img  tmpfs-dev-51.tar.gz.img
config.json  core-14.img  eventpoll.img     ids-1.img     inventory.img    iptables-9.img    netdev-9.img        pages-1.img     pstree.img     route-9.img   sigacts-1.img            tmpfs-dev-49.tar.gz.img  unixsk.img
core-12.img  core-1.img   fdinfo-2.img      ifaddr-9.img  ip6tables-9.img  mm-1.img          netns-9.img         pipes-data.img  reg-files.img  rule-9.img    tmpfs-dev-45.tar.gz.img  tmpfs-dev-50.tar.gz.img  utsns-11.img
```

After fix:
```
root@dockerdemo:~/checkpoints# docker checkpoint rm redis2 redis2-2
root@dockerdemo:~/checkpoints# docker checkpoint ls redis2
CHECKPOINT NAME
root@dockerdemo:~/checkpoints#
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

