### PR TITLE
Add IMAGE_NAME attribute to journald log events

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -71,6 +71,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		"CONTAINER_ID_FULL": info.ContainerID,
 		"CONTAINER_NAME":    info.Name(),
 		"CONTAINER_TAG":     tag,
+		"IMAGE_NAME":        info.ImageName(),
 		"SYSLOG_IDENTIFIER": tag,
 	}
 	extraAttrs, err := info.ExtraAttributes(sanitizeKeyMod)


### PR DESCRIPTION
Signed-off-by: Rohit Kapur <rkapur@flatiron.com>
Closes #21497

**- What I did**
Adds a new key - IMAGE_NAME - that contains the image:tag value to journald log messages. Note that this makes use of `Info.ImageName()` to retrieve the value, which doesn't return the tag if its value is `latest`.

**- How I did it**
Updated the journald logging driver

**- How to verify it**
```
docker run -it --log-driver=journald ubuntu echo "Hello world"
journalctl -t ubuntu -o json --all
```
The journald entry returned should have `IMAGE_NAME` as one of the keys

**- Description for the changelog**
Add IMAGE_NAME attribute to journald log event

**- A picture of a cute animal (not mandatory but encouraged)**
[cat](https://imgur.com/a/TWR4fOo)
