### PR TITLE
Add more API doc details on service update version.

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9360,7 +9360,10 @@ paths:
 
         - name: "version"
           in: "query"
-          description: "The version number of the service object being updated. This is required to avoid conflicting writes."
+          description: "The version number of the service object being updated.
+          This is required to avoid conflicting writes.
+          This version number should be the value as currently set on the service *before* the update.
+          You can find the current version by calling `GET /services/{id}`"
           required: true
           type: "integer"
         - name: "registryAuthFrom"


### PR DESCRIPTION
Hopefully this removes some confusion as to what this version number
should be.

![image](https://user-images.githubusercontent.com/799078/46961148-f6b9c480-d054-11e8-8665-b3673b624776.png)

Closes #30794