### PR TITLE
Only add CONTAINER_PARTIAL_MESSAGE if not the last partial

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -104,7 +104,7 @@ func (s *journald) Log(msg *logger.Message) error {
 	for k, v := range s.vars {
 		vars[k] = v
 	}
-	if msg.PLogMetaData != nil {
+	if msg.PLogMetaData != nil && !msg.PLogMetaData.Last {
 		vars["CONTAINER_PARTIAL_MESSAGE"] = "true"
 	}
 


### PR DESCRIPTION
Addresses #38045

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Adjust the journald logging driver so that, when writing message partials to journald, all but the last partial are annotated with `CONTAINER_PARTIAL_MESSAGE=true`

**- How I did it**

Transferred the relevant logic from the json-file driver

**- How to verify it**

Cause a container using the journald log driver to emit a long message (>16k), and verify that the `docker logs` output is terminated by `\r\n` instead of just `\r` 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix journald log driver to correctly mark message partials (ensures end-of-line isn't truncated from long events)

**- A picture of a cute animal (not mandatory but encouraged)**

![capybara](https://user-images.githubusercontent.com/984924/46993836-35d33d00-d15d-11e8-9b33-5693a1126030.jpg)
