### PR TITLE
bump up runc

### DIFF
--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # When updating RUNC_COMMIT, also update runc in vendor.conf accordingly
-RUNC_COMMIT=69663f0bd4b60df09991c08812a60108003fa340
+RUNC_COMMIT=a00bf0190895aa465a5fbed0268888e2c8ddfe85
 
 install_runc() {
 	# Do not build with ambient capabilities support

--- a/vendor.conf
+++ b/vendor.conf
@@ -75,7 +75,7 @@ github.com/pborman/uuid v1.0
 google.golang.org/grpc v1.12.0
 
 # This does not need to match RUNC_COMMIT as it is used for helper packages but should be newer or equal
-github.com/opencontainers/runc 00dc70017d222b178a002ed30e9321b12647af2d
+github.com/opencontainers/runc a00bf0190895aa465a5fbed0268888e2c8ddfe85
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353 # v1.0.1-45-geba862d
 github.com/opencontainers/image-spec v1.0.1
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go
@@ -186,12 +186,19 @@ type Config struct {
 	// callers keyring in this case.
 	NoNewKeyring bool `json:"no_new_keyring"`
 
-	// Rootless specifies whether the container is a rootless container.
-	Rootless bool `json:"rootless"`
-
 	// IntelRdt specifies settings for Intel RDT/CAT group that the container is placed into
 	// to limit the resources (e.g., L3 cache) the container has available
 	IntelRdt *IntelRdt `json:"intel_rdt,omitempty"`
+
+	// RootlessEUID is set when the runc was launched with non-zero EUID.
+	// Note that RootlessEUID is set to false when launched with EUID=0 in userns.
+	// When RootlessEUID is set, runc creates a new userns for the container.
+	// (config.json needs to contain userns settings)
+	RootlessEUID bool `json:"rootless_euid,omitempty"`
+
+	// RootlessCgroups is set when unlikely to have the full access to cgroups.
+	// When RootlessCgroups is set, cgroups errors are ignored.
+	RootlessCgroups bool `json:"rootless_cgroups,omitempty"`
 }
 
 type Hooks struct {

--- a/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c
+++ b/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c
@@ -82,7 +82,7 @@ struct nlconfig_t {
 	uint8_t is_setgroup;
 
 	/* Rootless container settings. */
-	uint8_t is_rootless;
+	uint8_t is_rootless_euid;	/* boolean */
 	char *uidmappath;
 	size_t uidmappath_len;
 	char *gidmappath;
@@ -100,7 +100,7 @@ struct nlconfig_t {
 #define GIDMAP_ATTR			27284
 #define SETGROUP_ATTR		27285
 #define OOM_SCORE_ADJ_ATTR	27286
-#define ROOTLESS_ATTR	    27287
+#define ROOTLESS_EUID_ATTR	27287
 #define UIDMAPPATH_ATTR	    27288
 #define GIDMAPPATH_ATTR	    27289
 
@@ -419,8 +419,8 @@ static void nl_parse(int fd, struct nlconfig_t *config)
 		case CLONE_FLAGS_ATTR:
 			config->cloneflags = readint32(current);
 			break;
-		case ROOTLESS_ATTR:
-			config->is_rootless = readint8(current);
+		case ROOTLESS_EUID_ATTR:
+			config->is_rootless_euid = readint8(current);	/* boolean */
 			break;
 		case OOM_SCORE_ADJ_ATTR:
 			config->oom_score_adj = current;
@@ -687,7 +687,7 @@ void nsexec(void)
 					 * newuidmap/newgidmap shall be used.
 					 */
 
-					if (config.is_rootless && !config.is_setgroup)
+					if (config.is_rootless_euid && !config.is_setgroup)
 						update_setgroups(child, SETGROUPS_DENY);
 
 					/* Set up mappings. */
@@ -953,7 +953,7 @@ void nsexec(void)
 			if (setgid(0) < 0)
 				bail("setgid failed");
 
-			if (!config.is_rootless && config.is_setgroup) {
+			if (!config.is_rootless_euid && config.is_setgroup) {
 				if (setgroups(0, NULL) < 0)
 					bail("setgroups failed");
 			}


### PR DESCRIPTION
Changes: https://github.com/opencontainers/runc/compare/69663f0bd4b60df09991c08812a60108003fa340...a00bf0190895aa465a5fbed0268888e2c8ddfe85

( Docker-in-LXD regression should have been fixed in https://github.com/opencontainers/runc/pull/1862 )

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>