### PR TITLE
Use net/http instead of x/ctxhttp

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context/ctxhttp"
 )
 
 // serverResponse is a wrapper for http API responses.
@@ -129,7 +128,8 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 func (cli *Client) doRequest(ctx context.Context, req *http.Request) (serverResponse, error) {
 	serverResp := serverResponse{statusCode: -1, reqURL: req.URL}
 
-	resp, err := ctxhttp.Do(ctx, cli.client, req)
+	req = req.WithContext(ctx)
+	resp, err := cli.client.Do(req)
 	if err != nil {
 		if cli.scheme != "https" && strings.Contains(err.Error(), "malformed HTTP response") {
 			return serverResp, fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)


### PR DESCRIPTION
x/ctxhttp is no longer needed here since we can set the context on the request directly (go1.8?).

This is still, unfortunately, a transitive dependency.