### PR TITLE
bump containerd to v1.2.0-13-g8afcade1

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=9f2e07b1fc1342d1c48fe4d7bbb94cb6d1bf278b # v1.1.4
+CONTAINERD_COMMIT=c4446665cb9c30056f4998ed953e6d4ff22c7c39 # v1.2.0
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=c4446665cb9c30056f4998ed953e6d4ff22c7c39 # v1.2.0
+CONTAINERD_COMMIT=8afcade1a6041b8301b6f6d8b88bae909993b989 # v1.2.0-13-g8afcade1
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
Follow-up to https://github.com/moby/moby/pull/37932

~~Update runc binary:~~ removed this bump, as it was updated already in https://github.com/moby/moby/pull/38128

- ~~https://github.com/opencontainers/runc/compare/a00bf0190895aa465a5fbed0268888e2c8ddfe85...58592df56734acf62e574865fe40b9e53e967910~~
  - ~~https://github.com/opencontainers/runc/pull/1632 libcontainer: intelrdt: add support for Intel RDT/MBA in runc~~
  - ~~https://github.com/opencontainers/runc/pull/1880 libcontainer: CurrentGroupSubGIDs -> CurrentUserSubGIDs~~

Update containerd; changes since v1.2.0 (https://github.com/moby/moby/pull/37932)

- https://github.com/containerd/containerd/compare/v1.2.0...8afcade1a6041b8301b6f6d8b88bae909993b989
  - https://github.com/containerd/containerd/pull/2435 Bump to Go 1.11.0
  - https://github.com/containerd/containerd/pull/2745 Change unsupported snapshot warnings to INFO
  - https://github.com/containerd/containerd/pull/2746 Bump aufs for unsupported errors
  - https://github.com/containerd/containerd/pull/2743 bugfix: optimize shim lock in runtime v1 avoid dead lock
  - https://github.com/containerd/containerd/pull/2747 bugfix: CloseIO should return correct status code
  - https://github.com/containerd/containerd/pull/2748 Increase reaper buffer size and non-blocking send