### PR TITLE
Document ambiguous Version field for ServiceUpdate

### DIFF
--- a/client/service_update.go
+++ b/client/service_update.go
@@ -10,7 +10,9 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 )
 
-// ServiceUpdate updates a Service.
+// ServiceUpdate updates a Service. The version number is required to avoid conflicting writes.
+// It should be the value as set *before* the update. You can find this value in the Meta field
+// of swarm.Service, which can be found using ServiceInspectWithRaw.
 func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (types.ServiceUpdateResponse, error) {
 	var (
 		query   = url.Values{}


### PR DESCRIPTION
Currently, the behaviour for the version field in ServiceUpdate()
is vague. Without an correct version number, users are unable to
successfully run ServiceUpdate(), which is a pretty critical method
for scaling services (for example).

**- What I did**

Added extra documentation on the `client.ServiceUpdate()` method detailing what the `version` field does, why it's there, and how to find it.

**- Description for the changelog**
Update documentation for version field in `client.ServiceUpdate`

![Cute duck](https://tailandfur.com/wp-content/uploads/2014/03/cute-duck-pictures.jpg)

As referenced in [#38047](https://github.com/moby/moby/issues/38047#issuecomment-431784910), [#30794](https://github.com/moby/moby/issues/30794#issuecomment-429741548) and fix [#38040](https://github.com/moby/moby/pull/38040)

