### PR TITLE
dockerfile: retry curl with 1m interval on github API errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get install -y \
 	protobuf-c-compiler \
 	python-protobuf \
 	&& mkdir -p /usr/src/criu \
-	&& curl -sSL https://github.com/checkpoint-restore/criu/archive/v${CRIU_VERSION}.tar.gz | tar -C /usr/src/criu/ -xz --strip-components=1 \
+	&& for i in {1..5}; do [ $i -gt 1 ] && sleep 1m; curl -sSL https://github.com/checkpoint-restore/criu/archive/v${CRIU_VERSION}.tar.gz | tar -C /usr/src/criu/ -xz --strip-components=1 && break; done \
 	&& cd /usr/src/criu \
 	&& make \
 	&& make PREFIX=/build/ install-criu


### PR DESCRIPTION
Running make build fails accidentaly on github.com API ratelimits for curl, retry them.

See https://github.com/moby/moby/issues/37639 for more info.

