### PR TITLE
Update API version to v1.40

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api // import "github.com/docker/docker/api"
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion = "1.39"
+	DefaultVersion = "1.40"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -186,10 +186,10 @@ func (sr *swarmRouter) createService(ctx context.Context, w http.ResponseWriter,
 		if versions.LessThan(cliVersion, "1.30") {
 			queryRegistry = true
 		}
-		if versions.LessThan(cliVersion, "1.39") {
+		if versions.LessThan(cliVersion, "1.40") {
 			if service.TaskTemplate.ContainerSpec != nil {
 				// Sysctls for docker swarm services weren't supported before
-				// API version 1.39
+				// API version 1.40
 				service.TaskTemplate.ContainerSpec.Sysctls = nil
 			}
 		}
@@ -229,10 +229,10 @@ func (sr *swarmRouter) updateService(ctx context.Context, w http.ResponseWriter,
 		if versions.LessThan(cliVersion, "1.30") {
 			queryRegistry = true
 		}
-		if versions.LessThan(cliVersion, "1.39") {
+		if versions.LessThan(cliVersion, "1.40") {
 			if service.TaskTemplate.ContainerSpec != nil {
 				// Sysctls for docker swarm services weren't supported before
-				// API version 1.39
+				// API version 1.40
 				service.TaskTemplate.ContainerSpec.Sysctls = nil
 			}
 		}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.39"
+basePath: "/v1.40"
 info:
   title: "Docker Engine API"
-  version: "1.39"
+  version: "1.40"
   x-logo:
     url: "https://docs.docker.com/images/logo-docker-main.png"
   description: |
@@ -49,8 +49,8 @@ info:
     the URL is not supported by the daemon, a HTTP `400 Bad Request` error message
     is returned.
 
-    If you omit the version-prefix, the current version of the API (v1.39) is used.
-    For example, calling `/info` is the same as calling `/v1.39/info`. Using the
+    If you omit the version-prefix, the current version of the API (v1.40) is used.
+    For example, calling `/info` is the same as calling `/v1.40/info`. Using the
     API without a version-prefix is deprecated and will be removed in a future release.
 
     Engine releases in the near future should support this version of the API,

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,11 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.40 API changes
+
+[Docker Engine API v1.40](https://docs.docker.com/engine/api/v1.40/) documentation
+
+
 ## V1.39 API changes
 
 [Docker Engine API v1.39](https://docs.docker.com/engine/api/v1.39/) documentation

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,6 +17,12 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.40](https://docs.docker.com/engine/api/v1.40/) documentation
 
+* `GET /services` now returns `Sysctls` as part of the `ContainerSpec`.
+* `GET /services/{id}` now returns `Sysctls` as part of the `ContainerSpec`.
+* `POST /services/create` now accepts `Sysctls` as part of the `ContainerSpec`.
+* `POST /services/{id}/update` now accepts `Sysctls` as part of the `ContainerSpec`.
+* `GET /tasks` now  returns `Sysctls` as part of the `ContainerSpec`.
+* `GET /tasks/{id}` now  returns `Sysctls` as part of the `ContainerSpec`.
 
 ## V1.39 API changes
 
@@ -35,12 +41,6 @@ keywords: "API, Docker, rcli, REST, documentation"
   on the node.label. The format of the label filter is `node.label=<key>`/`node.label=<key>=<value>`
   to return those with the specified labels, or `node.label!=<key>`/`node.label!=<key>=<value>`
   to return those without the specified labels.
-* `GET /services` now returns `Sysctls` as part of the `ContainerSpec`.
-* `GET /services/{id}` now returns `Sysctls` as part of the `ContainerSpec`.
-* `POST /services/create` now accepts `Sysctls` as part of the `ContainerSpec`.
-* `POST /services/{id}/update` now accepts `Sysctls` as part of the `ContainerSpec`.
-* `GET /tasks` now  returns `Sysctls` as part of the `ContainerSpec`.
-* `GET /tasks/{id}` now  returns `Sysctls` as part of the `ContainerSpec`.
 
 ## V1.38 API changes
 

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -23,6 +23,10 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /services/{id}/update` now accepts `Sysctls` as part of the `ContainerSpec`.
 * `GET /tasks` now  returns `Sysctls` as part of the `ContainerSpec`.
 * `GET /tasks/{id}` now  returns `Sysctls` as part of the `ContainerSpec`.
+* `GET /nodes` now supports a filter type `node.label` filter to filter nodes based
+  on the node.label. The format of the label filter is `node.label=<key>`/`node.label=<key>=<value>`
+  to return those with the specified labels, or `node.label!=<key>`/`node.label!=<key>=<value>`
+  to return those without the specified labels.
 
 ## V1.39 API changes
 
@@ -37,10 +41,6 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /swarm/init` now accepts a `DefaultAddrPool` property to set global scope default address pool
 * `POST /swarm/init` now accepts a `SubnetSize` property to set global scope networks by giving the
   length of the subnet masks for every such network
-* `GET /nodes` now supports a filter type `node.label` filter to filter nodes based
-  on the node.label. The format of the label filter is `node.label=<key>`/`node.label=<key>=<value>`
-  to return those with the specified labels, or `node.label!=<key>`/`node.label!=<key>=<value>`
-  to return those without the specified labels.
 
 ## V1.38 API changes
 

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -339,8 +339,8 @@ func TestCreateServiceConfigFileMode(t *testing.T) {
 // anything up in the test environment
 func TestCreateServiceSysctls(t *testing.T) {
 	skip.If(
-		t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"),
-		"setting service sysctls is unsupported before api v1.39",
+		t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"),
+		"setting service sysctls is unsupported before api v1.40",
 	)
 
 	defer setupTest(t)()


### PR DESCRIPTION
Some features were merged after API v1.39 shipped as part of the Docker 18.09 betas; this PR updates the API version to 1.40, and corrects the minimal API version for those features.

- Move support for sysctl options in services to API v1.40 - This feature was added in 14da20f5e79fc322208ec49edce34e0b575d8973 (https://github.com/moby/moby/pull/37701), which was merged after API v1.39 shipped as part of the Docker 18.09
- Move support for filtering on node labels to API v1.40 - This feature was added in 514ce73391d065136a2cdfe9f0348dfe1bcc5c43 (https://github.com/moby/moby/pull/37650), which was merged after API v1.39 shipped as part of the Docker 18.09


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
+ Update API version to 1.40 [moby/moby#38089](https://github.com/moby/moby/pull/38089)
```



**- A picture of a cute animal (not mandatory but encouraged)**

![cute_owl_by_helmuttt-dahymkr](https://user-images.githubusercontent.com/1804568/47571201-47c09700-d938-11e8-9a9e-5db15bd93f06.jpg)


image: ["Cute Owl by HELMUTTT"](https://www.deviantart.com/helmuttt/art/Cute-Owl-634830795)