### PR TITLE
Deprecate AuFS storage driver, and add warning

### DIFF
--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -319,7 +319,7 @@ func isEmptyDir(name string) bool {
 func isDeprecated(name string) bool {
 	switch name {
 	// NOTE: when deprecating a driver, update daemon.fillDriverInfo() accordingly
-	case "devicemapper", "overlay":
+	case "aufs", "devicemapper", "overlay":
 		return true
 	}
 	return false

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -132,7 +132,7 @@ func (daemon *Daemon) fillDriverInfo(v *types.Info) {
 			drivers += fmt.Sprintf(" (%s) ", os)
 		}
 		switch gd {
-		case "devicemapper", "overlay":
+		case "aufs", "devicemapper", "overlay":
 			v.Warnings = append(v.Warnings, fmt.Sprintf("WARNING: the %s storage-driver is deprecated, and will be removed in a future release.", gd))
 		}
 	}


### PR DESCRIPTION
Related deprecation note PR: docker/cli#1484

The `aufs` storage driver is deprecated in favor of `overlay2`, and will
be removed in a future release. Users of the `aufs` storage driver are
recommended to migrate to a different storage driver, such as `overlay2`, which
is now the default storage driver.

The `aufs` storage driver facilitates running Docker on distros that have no
support for OverlayFS, such as Ubuntu 14.04 LTS, which originally shipped with
a 3.14 kernel.

Now that Ubuntu 14.04 is no longer a supported distro for Docker, and `overlay2`
is available to all supported distros (as they are either on kernel 4.x, or have
support for multiple lowerdirs backported), there is no reason to continue
maintenance of the `aufs` storage driver.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
* Deprecate `aufs` storage driver [moby/moby#38090](https://github.com/moby/moby/pull/38090)
```
