### PR TITLE
Remove overlay2 native diff

### DIFF
--- a/daemon/graphdriver/overlay2/check.go
+++ b/daemon/graphdriver/overlay2/check.go
@@ -8,97 +8,10 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"syscall"
 
-	"github.com/docker/docker/pkg/system"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
-
-// doesSupportNativeDiff checks whether the filesystem has a bug
-// which copies up the opaque flag when copying up an opaque
-// directory or the kernel enable CONFIG_OVERLAY_FS_REDIRECT_DIR.
-// When these exist naive diff should be used.
-func doesSupportNativeDiff(d string) error {
-	td, err := ioutil.TempDir(d, "opaque-bug-check")
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := os.RemoveAll(td); err != nil {
-			logger.Warnf("Failed to remove check directory %v: %v", td, err)
-		}
-	}()
-
-	// Make directories l1/d, l1/d1, l2/d, l3, work, merged
-	if err := os.MkdirAll(filepath.Join(td, "l1", "d"), 0755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(td, "l1", "d1"), 0755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(td, "l2", "d"), 0755); err != nil {
-		return err
-	}
-	if err := os.Mkdir(filepath.Join(td, "l3"), 0755); err != nil {
-		return err
-	}
-	if err := os.Mkdir(filepath.Join(td, "work"), 0755); err != nil {
-		return err
-	}
-	if err := os.Mkdir(filepath.Join(td, "merged"), 0755); err != nil {
-		return err
-	}
-
-	// Mark l2/d as opaque
-	if err := system.Lsetxattr(filepath.Join(td, "l2", "d"), "trusted.overlay.opaque", []byte("y"), 0); err != nil {
-		return errors.Wrap(err, "failed to set opaque flag on middle layer")
-	}
-
-	opts := fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", path.Join(td, "l2"), path.Join(td, "l1"), path.Join(td, "l3"), path.Join(td, "work"))
-	if err := unix.Mount("overlay", filepath.Join(td, "merged"), "overlay", 0, opts); err != nil {
-		return errors.Wrap(err, "failed to mount overlay")
-	}
-	defer func() {
-		if err := unix.Unmount(filepath.Join(td, "merged"), 0); err != nil {
-			logger.Warnf("Failed to unmount check directory %v: %v", filepath.Join(td, "merged"), err)
-		}
-	}()
-
-	// Touch file in d to force copy up of opaque directory "d" from "l2" to "l3"
-	if err := ioutil.WriteFile(filepath.Join(td, "merged", "d", "f"), []byte{}, 0644); err != nil {
-		return errors.Wrap(err, "failed to write to merged directory")
-	}
-
-	// Check l3/d does not have opaque flag
-	xattrOpaque, err := system.Lgetxattr(filepath.Join(td, "l3", "d"), "trusted.overlay.opaque")
-	if err != nil {
-		return errors.Wrap(err, "failed to read opaque flag on upper layer")
-	}
-	if string(xattrOpaque) == "y" {
-		return errors.New("opaque flag erroneously copied up, consider update to kernel 4.8 or later to fix")
-	}
-
-	// rename "d1" to "d2"
-	if err := os.Rename(filepath.Join(td, "merged", "d1"), filepath.Join(td, "merged", "d2")); err != nil {
-		// if rename failed with syscall.EXDEV, the kernel doesn't have CONFIG_OVERLAY_FS_REDIRECT_DIR enabled
-		if err.(*os.LinkError).Err == syscall.EXDEV {
-			return nil
-		}
-		return errors.Wrap(err, "failed to rename dir in merged directory")
-	}
-	// get the xattr of "d2"
-	xattrRedirect, err := system.Lgetxattr(filepath.Join(td, "l3", "d2"), "trusted.overlay.redirect")
-	if err != nil {
-		return errors.Wrap(err, "failed to read redirect flag on upper layer")
-	}
-
-	if string(xattrRedirect) == "d1" {
-		return errors.New("kernel has CONFIG_OVERLAY_FS_REDIRECT_DIR enabled")
-	}
-
-	return nil
-}
 
 // supportsMultipleLowerDir checks if the system supports multiple lowerdirs,
 // which is required for the overlay2 driver. On 4.x kernels, multiple lowerdirs

--- a/daemon/graphdriver/overlay2/overlay_test.go
+++ b/daemon/graphdriver/overlay2/overlay_test.go
@@ -28,10 +28,6 @@ func skipIfNaive(t *testing.T) {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(td)
-
-	if useNaiveDiff(td) {
-		t.Skipf("Cannot run test with naive diff")
-	}
 }
 
 // This avoids creating a new driver for each test if all tests are run

--- a/pkg/archive/archive_linux.go
+++ b/pkg/archive/archive_linux.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/docker/docker/pkg/system"
 	"golang.org/x/sys/unix"
 )
 
@@ -18,48 +17,6 @@ func getWhiteoutConverter(format WhiteoutFormat) tarWhiteoutConverter {
 }
 
 type overlayWhiteoutConverter struct{}
-
-func (overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, path string, fi os.FileInfo) (wo *tar.Header, err error) {
-	// convert whiteouts to AUFS format
-	if fi.Mode()&os.ModeCharDevice != 0 && hdr.Devmajor == 0 && hdr.Devminor == 0 {
-		// we just rename the file and make it normal
-		dir, filename := filepath.Split(hdr.Name)
-		hdr.Name = filepath.Join(dir, WhiteoutPrefix+filename)
-		hdr.Mode = 0600
-		hdr.Typeflag = tar.TypeReg
-		hdr.Size = 0
-	}
-
-	if fi.Mode()&os.ModeDir != 0 {
-		// convert opaque dirs to AUFS format by writing an empty file with the prefix
-		opaque, err := system.Lgetxattr(path, "trusted.overlay.opaque")
-		if err != nil {
-			return nil, err
-		}
-		if len(opaque) == 1 && opaque[0] == 'y' {
-			if hdr.Xattrs != nil {
-				delete(hdr.Xattrs, "trusted.overlay.opaque")
-			}
-
-			// create a header for the whiteout file
-			// it should inherit some properties from the parent, but be a regular file
-			wo = &tar.Header{
-				Typeflag:   tar.TypeReg,
-				Mode:       hdr.Mode & int64(os.ModePerm),
-				Name:       filepath.Join(hdr.Name, WhiteoutOpaqueDir),
-				Size:       0,
-				Uid:        hdr.Uid,
-				Uname:      hdr.Uname,
-				Gid:        hdr.Gid,
-				Gname:      hdr.Gname,
-				AccessTime: hdr.AccessTime,
-				ChangeTime: hdr.ChangeTime,
-			}
-		}
-	}
-
-	return
-}
 
 func (overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, path string) (bool, error) {
 	base := filepath.Base(path)

--- a/pkg/archive/archive_linux_test.go
+++ b/pkg/archive/archive_linux_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/pkg/system"
-	"golang.org/x/sys/unix"
 	"gotest.tools/assert"
 	"gotest.tools/skip"
 )
@@ -28,7 +27,7 @@ func setupOverlayTestDir(t *testing.T, src string) {
 	err := os.Mkdir(filepath.Join(src, "d1"), 0700)
 	assert.NilError(t, err)
 
-	err = system.Lsetxattr(filepath.Join(src, "d1"), "trusted.overlay.opaque", []byte("y"), 0)
+	err = ioutil.WriteFile(filepath.Join(src, "d1", WhiteoutOpaqueDir), []byte{}, 0700)
 	assert.NilError(t, err)
 
 	err = ioutil.WriteFile(filepath.Join(src, "d1", "f1"), []byte{}, 0600)
@@ -38,7 +37,7 @@ func setupOverlayTestDir(t *testing.T, src string) {
 	err = os.Mkdir(filepath.Join(src, "d2"), 0750)
 	assert.NilError(t, err)
 
-	err = system.Lsetxattr(filepath.Join(src, "d2"), "trusted.overlay.opaque", []byte("y"), 0)
+	err = ioutil.WriteFile(filepath.Join(src, "d2", WhiteoutOpaqueDir), []byte{}, 0750)
 	assert.NilError(t, err)
 
 	err = ioutil.WriteFile(filepath.Join(src, "d2", "f1"), []byte{}, 0660)
@@ -48,11 +47,12 @@ func setupOverlayTestDir(t *testing.T, src string) {
 	err = os.Mkdir(filepath.Join(src, "d3"), 0700)
 	assert.NilError(t, err)
 
-	err = system.Mknod(filepath.Join(src, "d3", "f1"), unix.S_IFCHR, 0)
+	err = ioutil.WriteFile(filepath.Join(src, "d3", WhiteoutPrefix+"f1"), []byte{}, 0600)
 	assert.NilError(t, err)
 }
 
 func checkOpaqueness(t *testing.T, path string, opaque string) {
+	t.Helper()
 	xattrOpaque, err := system.Lgetxattr(path, "trusted.overlay.opaque")
 	assert.NilError(t, err)
 
@@ -63,6 +63,7 @@ func checkOpaqueness(t *testing.T, path string, opaque string) {
 }
 
 func checkOverlayWhiteout(t *testing.T, path string) {
+	t.Helper()
 	stat, err := os.Stat(path)
 	assert.NilError(t, err)
 
@@ -76,6 +77,7 @@ func checkOverlayWhiteout(t *testing.T, path string) {
 }
 
 func checkFileMode(t *testing.T, path string, perm os.FileMode) {
+	t.Helper()
 	stat, err := os.Stat(path)
 	assert.NilError(t, err)
 


### PR DESCRIPTION
Native diff can be problematic when encountering extended attributes unknown to the tar writer.
For this reason naive diff is used when certain features are detected, leading to potentially inconsistent diff results depending on the kernel version.
Additionally since new kernel features may cause further issues in the future, naive diff must be used for new kernel versions, leading to many hosts already using naive diff.
Using overlayfs's interpretation of a change also differs from the diff algorithm used by Docker, picking up files which may have been copied up, but never modified.

Note: native diffing was originally added to get around a diff algorithm bug in Docker which has since been fixed. It was kept because it is faster, however my view is always that diff correctness is way more important than diff performance. In containerd, we do not support using just the upper directory to create a diff.
