### PR TITLE
Fix double "unix://" scheme in TestInfoAPIWarnings

### DIFF
--- a/integration/system/info_test.go
+++ b/integration/system/info_test.go
@@ -50,7 +50,7 @@ func TestInfoAPIWarnings(t *testing.T) {
 	client, err := d.NewClient()
 	assert.NilError(t, err)
 
-	d.StartWithBusybox(t, "--iptables=false", "-H=0.0.0.0:23756", "-H=unix://"+d.Sock())
+	d.StartWithBusybox(t, "-H=0.0.0.0:23756", "-H="+d.Sock())
 	defer d.Stop(t)
 
 	info, err := client.Info(context.Background())


### PR DESCRIPTION
`d.Sock()` already returns the socket-path including the `unix://` scheme.

Also removed `--iptables=false`, as it didn't really seem nescessary for this test.

Relates to https://github.com/moby/moby/pull/37684



