### PR TITLE
Add endpoint for generating support dumps.

### DIFF
--- a/api/server/router/debug/debug.go
+++ b/api/server/router/debug/debug.go
@@ -3,6 +3,7 @@ package debug // import "github.com/docker/docker/api/server/router/debug"
 import (
 	"context"
 	"expvar"
+	"io"
 	"net/http"
 	"net/http/pprof"
 
@@ -12,9 +13,9 @@ import (
 
 // NewRouter creates a new debug router
 // The debug router holds endpoints for debug the daemon, such as those for pprof.
-func NewRouter() router.Router {
+func NewRouter(b Backend) router.Router {
 	r := &debugRouter{}
-	r.initRoutes()
+	r.initRoutes(b)
 	return r
 }
 
@@ -22,15 +23,21 @@ type debugRouter struct {
 	routes []router.Route
 }
 
-func (r *debugRouter) initRoutes() {
+// Backend for debugging
+type Backend interface {
+	SupportDump(context.Context) (io.Reader, error)
+}
+
+func (r *debugRouter) initRoutes(b Backend) {
 	r.routes = []router.Route{
-		router.NewGetRoute("/vars", frameworkAdaptHandler(expvar.Handler())),
-		router.NewGetRoute("/pprof/", frameworkAdaptHandlerFunc(pprof.Index)),
-		router.NewGetRoute("/pprof/cmdline", frameworkAdaptHandlerFunc(pprof.Cmdline)),
-		router.NewGetRoute("/pprof/profile", frameworkAdaptHandlerFunc(pprof.Profile)),
-		router.NewGetRoute("/pprof/symbol", frameworkAdaptHandlerFunc(pprof.Symbol)),
-		router.NewGetRoute("/pprof/trace", frameworkAdaptHandlerFunc(pprof.Trace)),
-		router.NewGetRoute("/pprof/{name}", handlePprof),
+		router.NewGetRoute("/debug/vars", frameworkAdaptHandler(expvar.Handler())),
+		router.NewGetRoute("/debug/pprof/", frameworkAdaptHandlerFunc(pprof.Index)),
+		router.NewGetRoute("/debug/pprof/cmdline", frameworkAdaptHandlerFunc(pprof.Cmdline)),
+		router.NewGetRoute("/debug/pprof/profile", frameworkAdaptHandlerFunc(pprof.Profile)),
+		router.NewGetRoute("/debug/pprof/symbol", frameworkAdaptHandlerFunc(pprof.Symbol)),
+		router.NewGetRoute("/debug/pprof/trace", frameworkAdaptHandlerFunc(pprof.Trace)),
+		router.NewGetRoute("/debug/pprof/{name}", handlePprof),
+		router.NewPostRoute("/debug/dump", handleDumpFunc(b)),
 	}
 }
 

--- a/api/server/router/debug/debug_routes.go
+++ b/api/server/router/debug/debug_routes.go
@@ -1,12 +1,36 @@
 package debug // import "github.com/docker/docker/api/server/router/debug"
 
 import (
+	"compress/gzip"
 	"context"
 	"net/http"
 	"net/http/pprof"
+
+	"github.com/docker/docker/api/server/httputils"
+	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/pkg/pools"
+	"github.com/pkg/errors"
 )
 
 func handlePprof(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	pprof.Handler(vars["name"]).ServeHTTP(w, r)
 	return nil
+}
+
+func handleDumpFunc(b Backend) httputils.APIFunc {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+		dump, err := b.SupportDump(ctx)
+		if err != nil {
+			return err
+		}
+
+		w.Header().Set("Content-Type", "application/x-tar")
+		w.Header().Set("Content-Encoding", "gzip")
+
+		out := ioutils.NewWriteFlusher(gzip.NewWriter(w))
+		if _, err = pools.Copy(out, dump); err != nil {
+			return errors.Wrap(err, "error copying support dump to client")
+		}
+		return nil
+	}
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/server/middleware"
 	"github.com/docker/docker/api/server/router"
-	"github.com/docker/docker/api/server/router/debug"
 	"github.com/docker/docker/dockerversion"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
@@ -179,13 +178,6 @@ func (s *Server) createMux() *mux.Router {
 			m.Path(versionMatcher + r.Path()).Methods(r.Method()).Handler(f)
 			m.Path(r.Path()).Methods(r.Method()).Handler(f)
 		}
-	}
-
-	debugRouter := debug.NewRouter()
-	s.routers = append(s.routers, debugRouter)
-	for _, r := range debugRouter.Routes() {
-		f := s.makeHTTPHandler(r.Handler())
-		m.Path("/debug" + r.Path()).Handler(f)
 	}
 
 	notFoundHandler := httputils.MakeErrorHandler(pageNotFoundError{})

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -145,6 +145,12 @@ tags:
     x-displayName: "Plugins"
   - name: "System"
     x-displayName: "System"
+  - name: "Debug"
+    x-displayName: "Debug"
+    description: |
+      Get information for debug purposes.
+      Note that generally endpoints listed here are not considered stable.
+      Both the endpoint itself and the content of any given endpoint may change over time.
 
 definitions:
   Port:
@@ -10254,3 +10260,19 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
       tags: ["Session (experimental)"]
+  /debug/dump:
+    post:
+      Summary: |
+        Generate a support debug dump which is sent in the response body. This is itended for human consumption.
+        These dumps can be submitted along side bug reports for analysis. The support dump will be gzip compressed.
+      produces:
+        - "application/x-tar"
+      responses:
+        200:
+          description: "Support dump successfully generated and is in the response body"
+        500:
+          description: "server error"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+      operationId: "DebugDump"
+      tags: ["Debug"]

--- a/client/debug_dump.go
+++ b/client/debug_dump.go
@@ -1,0 +1,19 @@
+package client // import "github.com/docker/docker/client"
+
+import (
+	"context"
+	"io"
+	"net/url"
+)
+
+// GenerateSupportDump requests the daemon to send a support dump.
+// The returned stream is a tar+gz containing information that is often requested
+// when debugging issues.
+// This should be suitable for submitting with bug reports.
+func (cli *Client) GenerateSupportDump(ctx context.Context) (io.ReadCloser, error) {
+	resp, err := cli.post(ctx, "/debug/dump", url.Values{}, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return resp.body, nil
+}

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/api/server/router/build"
 	checkpointrouter "github.com/docker/docker/api/server/router/checkpoint"
 	"github.com/docker/docker/api/server/router/container"
+	debugrouter "github.com/docker/docker/api/server/router/debug"
 	distributionrouter "github.com/docker/docker/api/server/router/distribution"
 	"github.com/docker/docker/api/server/router/image"
 	"github.com/docker/docker/api/server/router/network"
@@ -492,6 +493,7 @@ func initRouter(opts routerOptions) {
 		swarmrouter.NewRouter(opts.cluster),
 		pluginrouter.NewRouter(opts.daemon.PluginManager()),
 		distributionrouter.NewRouter(opts.daemon.ImageService()),
+		debugrouter.NewRouter(opts.daemon),
 	}
 
 	if opts.daemon.NetworkControllerEnabled() {

--- a/daemon/debug.go
+++ b/daemon/debug.go
@@ -1,0 +1,89 @@
+package daemon
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// SupportDump returns a tar with details often required to debug user issues.
+// The format of this tar is not stable and is intended for human consumption.
+func (daemon *Daemon) SupportDump(ctx context.Context) (io.Reader, error) {
+	buf := bytes.NewBuffer(nil)
+	w := tar.NewWriter(buf)
+	defer w.Close()
+	defer w.Flush()
+
+	stacksBuf := make([]byte, 16384)
+	n := runtime.Stack(stacksBuf, true)
+
+	err := w.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     filepath.Base(os.Args[0]) + "-goroutines.txt",
+		ModTime:  time.Now(),
+		Size:     int64(n),
+		Mode:     0644,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "error writing tar header for daemon goroutines")
+	}
+
+	if _, err := w.Write(stacksBuf[:n]); err != nil {
+		return nil, errors.Wrap(err, "error writing daemon goroutine dump to tar")
+	}
+
+	version, err := json.MarshalIndent(daemon.SystemVersion(), "", "\t")
+	if err != nil {
+		return nil, errors.Wrap(err, "error marshalling daemon version")
+	}
+
+	err = w.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "version.txt",
+		ModTime:  time.Now(),
+		Size:     int64(len(version)),
+		Mode:     0644,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "error writing tar header for version.txt")
+	}
+
+	if _, err := w.Write(version); err != nil {
+		return nil, errors.Wrap(err, "error writing version file to tar")
+	}
+
+	info, err := daemon.SystemInfo()
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting system info")
+	}
+	infoB, err := json.MarshalIndent(info, "", "\t")
+	if err != nil {
+		return nil, errors.Wrap(err, "error marshaling daemon info")
+	}
+
+	err = w.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "daemoninfo.txt",
+		ModTime:  time.Now(),
+		Size:     int64(len(infoB)),
+		Mode:     0644,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "error writing info tar header")
+	}
+	if _, err := w.Write(infoB); err != nil {
+		return nil, errors.Wrap(err, "error writing daemon info to tar")
+	}
+
+	// TODO(@cpuguy83): Add containerd stack dump
+
+	return buf, nil
+}


### PR DESCRIPTION
This provides a single endpoint to collect debug information that can be
used by clients to generate a support dump from the daemon.

Ideally this would contain data for all supporting components such as
containerd, buildkitd, and anything else in the future. I have left
these as a todo for now as this will require some refactoring.

Related to #31924

---

Some thoughts on this... I  keep going back and forth on weather or not we should provide something lower level here and let the client build whatever they want... e.g. the client might hit some endpoint that gets the stack trace for dockerd, a separate one for containerd, and other subcomponents and combine this in docker/cli into a tar.gz rather than just sending a tar.gz with all of the above.