### PR TITLE
update libnetwork to fix iptables compatibility on debian

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=d7b61745d16675c9f548b19f06fda80d422a74f0
+LIBNETWORK_COMMIT=49627167f0585504fd78ed8827529aec57a9618d
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -36,8 +36,8 @@ github.com/mitchellh/hashstructure 2bca23e0e452137f789efbc8610126fd8b94f73b
 
 #get libnetwork packages
 
-# When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
-github.com/docker/libnetwork d7b61745d16675c9f548b19f06fda80d422a74f0
+# When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
+github.com/docker/libnetwork 49627167f0585504fd78ed8827529aec57a9618d
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/iptables/iptables.go
+++ b/vendor/github.com/docker/libnetwork/iptables/iptables.go
@@ -87,11 +87,16 @@ func initFirewalld() {
 }
 
 func detectIptables() {
-	path, err := exec.LookPath("iptables")
+	path, err := exec.LookPath("iptables-legacy") // debian has iptables-legacy and iptables-nft now
 	if err != nil {
-		return
+		path, err = exec.LookPath("iptables")
+		if err != nil {
+			return
+		}
 	}
+
 	iptablesPath = path
+
 	supportsXlock = exec.Command(iptablesPath, "--wait", "-L", "-n").Run() == nil
 	mj, mn, mc, err := GetVersion()
 	if err != nil {


### PR DESCRIPTION
Fixes a compatibility issue on recent debian versions, where iptables now uses
nft by default.

brings in https://github.com/docker/libnetwork/pull/2285
fixes https://github.com/moby/moby/issues/38099

full diff: https://github.com/docker/libnetwork/compare/d7b61745d16675c9f548b19f06fda80d422a74f0...49627167f0585504fd78ed8827529aec57a9618d
