### PR TITLE
Fix error handling when go command is missing

### DIFF
--- a/contrib/download-frozen-image-v2.sh
+++ b/contrib/download-frozen-image-v2.sh
@@ -6,14 +6,14 @@ set -eo pipefail
 
 # debian                           latest              f6fab3b798be        10 weeks ago        85.1 MB
 # debian                           latest              f6fab3b798be3174f45aa1eb731f8182705555f89c9026d8c1ef230cbf8301dd   10 weeks ago        85.1 MB
-if ! command -v curl &> /dev/null; then
-	echo >&2 'error: "curl" not found!'
-	exit 1
-fi
-if ! command -v jq &> /dev/null; then
-	echo >&2 'error: "jq" not found!'
-	exit 1
-fi
+
+# check if essential commands are in our PATH
+for cmd in curl jq go; do
+	if ! command -v $cmd &> /dev/null; then
+		echo >&2 "error: \"$cmd\" not found!"
+		exit 1
+	fi
+done
 
 usage() {
 	echo "usage: $0 dir image[:tag][@digest] ..."


### PR DESCRIPTION
Signed-off-by: Mark Jeromin <mark.jeromin@sysfrog.net>

Fixes #38070 **_download-frozen-image-v2.sh does not contain a check to detect if go is in the PATH_**

**- What I did**
I added a test to check that `go` is in the user's shell `$PATH`, otherwise it will print a friendly error message `error: "go" not found!` when `go` is not in the `$PATH`. 

**- How I did it**
@thaJeztah suggested a solution that doesn't increase the complexity of the script much, so I consolidated the tests into a single loop. This allows a consistent error message for missing commands, rather than three (or more) separate tests (ie. `curl`, `jq`, `go`).

**- Description for the changelog**
Refactor error handling for missing commands.

![jack 016-xl](https://user-images.githubusercontent.com/4604605/47830486-67095b00-dd62-11e8-9d11-8a3f2d7c4c42.jpg)




