### PR TITLE
Use idtools.LookupGroup instead of parsing /etc/group file for docker.sock ownership

### DIFF
--- a/daemon/listeners/group_unix.go
+++ b/daemon/listeners/group_unix.go
@@ -6,25 +6,15 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/opencontainers/runc/libcontainer/user"
-	"github.com/pkg/errors"
+	"github.com/docker/docker/pkg/idtools"
 )
 
 const defaultSocketGroup = "docker"
 
 func lookupGID(name string) (int, error) {
-	groupFile, err := user.GetGroupPath()
-	if err != nil {
-		return -1, errors.Wrap(err, "error looking up groups")
-	}
-	groups, err := user.ParseGroupFileFilter(groupFile, func(g user.Group) bool {
-		return g.Name == name || strconv.Itoa(g.Gid) == name
-	})
-	if err != nil {
-		return -1, errors.Wrapf(err, "error parsing groups for %s", name)
-	}
-	if len(groups) > 0 {
-		return groups[0].Gid, nil
+	group, err := idtools.LookupGroup(name)
+	if err == nil {
+		return group.Gid, nil
 	}
 	gid, err := strconv.Atoi(name)
 	if err == nil {


### PR DESCRIPTION
fixes #1715 
fixes https://github.com/docker/for-linux/issues/186

*What I did*
Fix `dockerd` setting `/var/run/docker.sock`'s group to `root` rather than `docker` when `/etc/nsswitch.conf` specify external sources for groups (for example LDAP, NIS or SSS).

*How I did it*
Used the existing `idtools.LookupGroup` function instead of reading the `/etc/group` file directly. `idtools.LookupGroup` first try reading the `group` file; if it fails, it makes a system call to the `getent` program. This is an uncommon strategy in general, but ensure that `dockerd` doesn't need to be linked against `libnss`, which depend on plugins and can't therefore be statically linked.

*How to verify*
I can't unfortunately provide a viable test case since that would require the test environment to be configured to use an external identity source (LDAP, ActiveDirectory, etc). However, existing tests should at least provide the garante that the existing behavior (that is, the most common case of using the docker group defined in the `/etc/group`) is indeed maintained, and the fact that `idtools.LookupGroup` is already being used in docker indicates that it most probably provides the expected new behavior.

*Changelog*
Properly set group on docker.sock when using external group databases (LDAP, NIS, SSS...)