### PR TITLE
Do not enable kmem on RHEL7 kernels

### DIFF
--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -4,10 +4,15 @@
 RUNC_COMMIT=9f1e94488e5e478e084fef997f022565b64b01d9
 
 install_runc() {
-	# Do not build with ambient capabilities support
-	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp apparmor selinux"}"
+	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting
+	if uname -r | grep -q '^3\.10\.0.*\.el7\.'; then
+		: ${RUNC_NOKMEM='nokmem'}
+	fi
 
-	echo "Install runc version $RUNC_COMMIT"
+	# Do not build with ambient capabilities support
+	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp apparmor selinux $RUNC_NOKMEM"}"
+
+	echo "Install runc version $RUNC_COMMIT (build tags: $RUNC_BUILDTAGS)"
 	git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"
 	cd "$GOPATH/src/github.com/opencontainers/runc"
 	git checkout -q "$RUNC_COMMIT"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # When updating RUNC_COMMIT, also update runc in vendor.conf accordingly
-RUNC_COMMIT=a00bf0190895aa465a5fbed0268888e2c8ddfe85
+RUNC_COMMIT=9f1e94488e5e478e084fef997f022565b64b01d9
 
 install_runc() {
 	# Do not build with ambient capabilities support

--- a/vendor.conf
+++ b/vendor.conf
@@ -75,7 +75,7 @@ github.com/pborman/uuid v1.0
 google.golang.org/grpc v1.12.0
 
 # This does not need to match RUNC_COMMIT as it is used for helper packages but should be newer or equal
-github.com/opencontainers/runc 58592df56734acf62e574865fe40b9e53e967910
+github.com/opencontainers/runc 9f1e94488e5e478e084fef997f022565b64b01d9
 github.com/opencontainers/runtime-spec 5684b8af48c1ac3b1451fa499724e30e3c20a294 # v1.0.1-49-g5684b8a
 github.com/opencontainers/image-spec v1.0.1
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0

--- a/vendor/github.com/opencontainers/runc/README.md
+++ b/vendor/github.com/opencontainers/runc/README.md
@@ -263,3 +263,7 @@ PIDFile=/run/mycontainerid.pid
 [Install]
 WantedBy=multi-user.target
 ```
+
+## License
+
+The code and docs are released under the [Apache 2.0 license](LICENSE).

--- a/vendor/github.com/opencontainers/runc/libcontainer/README.md
+++ b/vendor/github.com/opencontainers/runc/libcontainer/README.md
@@ -323,6 +323,7 @@ generated when building libcontainer with docker.
 
 ## Copyright and license
 
-Code and documentation copyright 2014 Docker, inc. Code released under the Apache 2.0 license.
-Docs released under Creative commons.
-
+Code and documentation copyright 2014 Docker, inc.
+The code and documentation are released under the [Apache 2.0 license](../LICENSE).
+The documentation is also released under Creative Commons Attribution 4.0 International License.
+You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.


### PR DESCRIPTION
### 1. bump runc
Changes: https://github.com/opencontainers/runc/compare/a00bf0190895...9f1e94488e5e4

This is primarily to pull in https://github.com/opencontainers/runc/pull/1921

### 2. runc.installer: add nokmem build tag for rhel7 kernel
    
In case we're running on RHEL7 kernel, which has non-working
and broken kernel memory controller, add 'nokmem' build tag
so that runc never enables kmem accounting.
    
For more info, see the following runc commit:
https://github.com/opencontainers/runc/commit/6a2c1559684
    
This behavior can be overriden by having `RUNC_NOKMEM` environment
variable set (e.g. to empty value to disable setting nokmem).
