### PR TITLE
Make journald log plugin implement the sized logger interface

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -6,19 +6,28 @@ package journald // import "github.com/docker/docker/daemon/logger/journald"
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 	"unicode"
 
 	"github.com/coreos/go-systemd/journal"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/loggerutils"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
-const name = "journald"
+const (
+	name = "journald"
+
+	// defaultSize specified by the corresponding LineMax configuration in journald
+	// https://www.freedesktop.org/software/systemd/man/journald.conf.html#LineMax=
+	defaultSize = 48 * 1024
+)
 
 type journald struct {
 	mu      sync.Mutex
+	size    int
 	vars    map[string]string // additional variables and values to send to the journal along with the log message
 	readers map[*logger.LogWatcher]struct{}
 	closed  bool
@@ -81,7 +90,17 @@ func New(info logger.Info) (logger.Logger, error) {
 	for k, v := range extraAttrs {
 		vars[k] = v
 	}
-	return &journald{vars: vars, readers: make(map[*logger.LogWatcher]struct{})}, nil
+
+	size := defaultSize
+	if maxSizeStr, ok := info.Config["max-line-length"]; ok {
+		maxSize, err := strconv.Atoi(maxSizeStr)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert max-line-length configuration into an integer")
+		}
+		size = maxSize
+	}
+
+	return &journald{size: size, vars: vars, readers: make(map[*logger.LogWatcher]struct{})}, nil
 }
 
 // We don't actually accept any options, but we have to supply a callback for
@@ -93,6 +112,7 @@ func validateLogOpt(cfg map[string]string) error {
 		case "env":
 		case "env-regex":
 		case "tag":
+		case "max-line-length":
 		default:
 			return fmt.Errorf("unknown log opt '%s' for journald log driver", key)
 		}
@@ -121,4 +141,8 @@ func (s *journald) Log(msg *logger.Message) error {
 
 func (s *journald) Name() string {
 	return name
+}
+
+func (s *journald) BufSize() int {
+	return s.size
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #38129 

**- What I did**
Update the journald log driver to satisfy the `SizedLogger` interface

**- How I did it**
Added a field to the journald struct. This field will default to the journal default of 48k, but can be set by using the `max-line-length` log option.

**- How to verify it**
Wrote a small script which logs lines of configurable length, then tested it against a daemon using the journald logging backend. A 30k long line with no daemon log options configured became a single entry in the journal. After adding a max line length of 20k, the line was split between two events.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update the journald log driver to be a sized logger, defaulting to 48k and configurable with the "max-line-length" log option.

**- A picture of a cute animal (not mandatory but encouraged)**
![dik dik](https://i.ytimg.com/vi/ds4J42JsD7E/maxresdefault.jpg)