### PR TITLE
Cleanup volume integration tests

### DIFF
--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -2,7 +2,7 @@ package volume
 
 import (
 	"context"
-	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -37,7 +37,7 @@ func TestVolumesCreateAndList(t *testing.T) {
 		Driver:     "local",
 		Scope:      "local",
 		Name:       name,
-		Mountpoint: fmt.Sprintf("%s/volumes/%s/_data", testEnv.DaemonInfo.DockerRootDir, name),
+		Mountpoint: filepath.Join(testEnv.DaemonInfo.DockerRootDir, "volumes", name, "_data"),
 	}
 	assert.Check(t, is.DeepEqual(vol, expected, cmpopts.EquateEmpty()))
 

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -20,7 +20,6 @@ import (
 
 func TestVolumesCreateAndList(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
@@ -77,7 +76,6 @@ func TestVolumesRemove(t *testing.T) {
 
 func TestVolumesInspect(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -82,33 +82,19 @@ func TestVolumesInspect(t *testing.T) {
 	client := request.NewAPIClient(t)
 	ctx := context.Background()
 
-	// sampling current time minus a minute so to now have false positive in case of delays
-	now := time.Now().Truncate(time.Minute)
-
-	name := t.Name()
-	_, err := client.VolumeCreate(ctx, volumetypes.VolumeCreateBody{
-		Name: name,
-	})
+	now := time.Now()
+	vol, err := client.VolumeCreate(ctx, volumetypes.VolumeCreateBody{})
 	assert.NilError(t, err)
 
-	vol, err := client.VolumeInspect(ctx, name)
+	inspected, err := client.VolumeInspect(ctx, vol.Name)
 	assert.NilError(t, err)
 
-	expected := types.Volume{
-		// Ignore timestamp of CreatedAt
-		CreatedAt:  vol.CreatedAt,
-		Driver:     "local",
-		Scope:      "local",
-		Name:       name,
-		Mountpoint: fmt.Sprintf("%s/volumes/%s/_data", testEnv.DaemonInfo.DockerRootDir, name),
-	}
-	assert.Check(t, is.DeepEqual(vol, expected, cmpopts.EquateEmpty()))
+	assert.Check(t, is.DeepEqual(inspected, vol, cmpopts.EquateEmpty()))
 
-	// comparing CreatedAt field time for the new volume to now. Removing a minute from both to avoid false positive
-	testCreatedAt, err := time.Parse(time.RFC3339, strings.TrimSpace(vol.CreatedAt))
+	// comparing CreatedAt field time for the new volume to now. Truncate to 1 minute precision to avoid false positive
+	createdAt, err := time.Parse(time.RFC3339, strings.TrimSpace(inspected.CreatedAt))
 	assert.NilError(t, err)
-	testCreatedAt = testCreatedAt.Truncate(time.Minute)
-	assert.Check(t, is.Equal(testCreatedAt.Equal(now), true), "Time Volume is CreatedAt not equal to current time")
+	assert.Check(t, createdAt.Truncate(time.Minute).Equal(now.Truncate(time.Minute)), "CreatedAt (%s) not equal to creation time (%s)", createdAt, now)
 }
 
 func getPrefixAndSlashFromDaemonPlatform() (prefix, slash string) {


### PR DESCRIPTION
Some changes to these tests;

### Improvements to TestVolumesInspect

- use the volume-information that's returned by VolumeCreate as "expected"
- don't use an explict name for the volume, as it was only used to reference
  the volume for inspection
- improve the test-output on failure, so that "expected" and "actual" values
  are printed

Without this patch applied;

    === RUN   TestVolumesInspect
    --- FAIL: TestVolumesInspect (0.02s)
     	volume_test.go:108: assertion failed: false (bool) != true (true bool): Time Volume is CreatedAt not equal to current time
    FAIL

With this patch applied;

    === RUN   TestVolumesInspect
    --- FAIL: TestVolumesInspect (0.02s)
        volume_test.go:95: assertion failed: expression is false: createdAt.Truncate(time.Minute).Equal(now.Truncate(time.Minute)): CreatedAt (2018-11-01 16:15:20 +0000 UTC) not equal to creation time (2018-11-01 16:15:20.2421166 +0000 UTC m=+13.733512701)
    FAIL


### Integration test: `TestVolumesCreateAndList ()` use `filepath.Join()` to make path cross-platform

### Enable volume tests on Windows

These tests don't seem to have anything Linux-specific, so enable them on Windows