### PR TITLE
Unify the defer syntax

### DIFF
--- a/client/container_inspect.go
+++ b/client/container_inspect.go
@@ -19,10 +19,10 @@ func (cli *Client) ContainerInspect(ctx context.Context, containerID string) (ty
 	if err != nil {
 		return types.ContainerJSON{}, wrapResponseError(err, serverResp, "container", containerID)
 	}
+	defer ensureReaderClosed(serverResp)
 
 	var response types.ContainerJSON
 	err = json.NewDecoder(serverResp.body).Decode(&response)
-	ensureReaderClosed(serverResp)
 	return response, err
 }
 


### PR DESCRIPTION
A simple change to unify the http stream closing syntax.





<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**