### PR TITLE
seccomp: allow ptrace(2) for 4.8+ kernels

### DIFF
--- a/api/types/seccomp.go
+++ b/api/types/seccomp.go
@@ -77,8 +77,9 @@ type Arg struct {
 
 // Filter is used to conditionally apply Seccomp rules
 type Filter struct {
-	Caps   []string `json:"caps,omitempty"`
-	Arches []string `json:"arches,omitempty"`
+	Caps      []string `json:"caps,omitempty"`
+	Arches    []string `json:"arches,omitempty"`
+	MinKernel string   `json:"minKernel,omitempty"`
 }
 
 // Syscall is used to match a group of syscalls in Seccomp

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -368,6 +368,18 @@
 		},
 		{
 			"names": [
+				"ptrace"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": null,
+			"comment": "",
+			"includes": {
+				"minKernel": "4.8.0"
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
 				"personality"
 			],
 			"action": "SCMP_ACT_ALLOW",

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -357,6 +357,13 @@ func DefaultProfile() *types.Seccomp {
 			Args:   []*types.Arg{},
 		},
 		{
+			Names:  []string{"ptrace"},
+			Action: types.ActAllow,
+			Includes: types.Filter{
+				MinKernel: "4.8.0",
+			},
+		},
+		{
 			Names:  []string{"personality"},
 			Action: types.ActAllow,
 			Args: []*types.Arg{


### PR DESCRIPTION
4.8+ kernels have fixed the ptrace security issues
so we can allow ptrace(2) on the default seccomp
profile if we do the kernel version check.

https://github.com/torvalds/linux/commit/93e35efb8de45393cf61ed07f7b407629bf698ea

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
