### PR TITLE
Add configuration validation option.

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -455,6 +455,12 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 		conf.TLSVerify = conf.TLS
 	}
 
+	if opts.Validate {
+		// If config wasn't OK we wouldn't have made it this far.
+		logrus.Infof("Config OK")
+		os.Exit(0)
+	}
+
 	return conf, nil
 }
 

--- a/cmd/dockerd/options.go
+++ b/cmd/dockerd/options.go
@@ -41,6 +41,7 @@ type daemonOptions struct {
 	TLS          bool
 	TLSVerify    bool
 	TLSOptions   *tlsconfig.Options
+	Validate     bool
 }
 
 // newDaemonOptions returns a new daemonFlags
@@ -59,6 +60,7 @@ func (o *daemonOptions) InstallFlags(flags *pflag.FlagSet) {
 	}
 
 	flags.BoolVarP(&o.Debug, "debug", "D", false, "Enable debug mode")
+	flags.BoolVar(&o.Validate, "validate", false, "Validate configuration file and exit")
 	flags.StringVarP(&o.LogLevel, "log-level", "l", "info", `Set the logging level ("debug"|"info"|"warn"|"error"|"fatal")`)
 	flags.BoolVar(&o.TLS, FlagTLS, DefaultTLSValue, "Use TLS; implied by --tlsverify")
 	flags.BoolVar(&o.TLSVerify, FlagTLSVerify, dockerTLSVerify || DefaultTLSValue, "Use TLS and verify the remote")


### PR DESCRIPTION
Fixes #36911

Add a command line option.
Add option to exit before daemon startup if validating config.

If config file is invalid we'll exit anyhow, so this just prevents
the daemon from starting if the configuration is fine.

Mainly useful for making config changes and restarting the daemon
iff the config is valid.

Signed-off-by: Rich Horwood <rjhorwood@apple.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add option to validate daemon configuration file and exit.

**- A picture of a cute animal (not mandatory but encouraged)**


