### PR TITLE
[Context-Switch] Foundation of fast context switch

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -162,9 +162,13 @@ func TestClientWithContext(t *testing.T) {
 	s, err := contextstore.NewStore(storeDir)
 	assert.Check(t, err)
 	for _, c := range contexts {
-		t.Run(c.name, func(t *testing.T) {
+		t.Run(c.name+"_create", func(t *testing.T) {
 			err = context.SetDockerEndpoint(s, c.name, c.host, c.apiVersion, c.ca, c.cert, c.key, c.skipTLSVerify)
 			assert.Check(t, err)
+		})
+	}
+	for _, c := range contexts {
+		t.Run(c.name+"_consume", func(t *testing.T) {
 			client, err := NewClientWithOpts(WithContextStoreOrEnv(storeDir, c.name))
 			assert.Check(t, err)
 			if c.host == "" {

--- a/client/context.go
+++ b/client/context.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/docker/docker/client/context"
+	"github.com/docker/docker/pkg/contextstore"
+	"github.com/pkg/errors"
+)
+
+func loadContext(c *Client, s contextstore.Store, ctxName string) error {
+	ctxMeta, err := s.GetContextMetadata(ctxName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to retrieve context metadata: %s", err)
+	}
+	ctx, err := context.Parse(ctxName, ctxMeta)
+	if err != nil {
+		return err
+	}
+
+	if ctx.Host != "" {
+		if err = WithHost(ctx.Host)(c); err != nil {
+			return err
+		}
+	}
+
+	tlsCfg, err := ctx.LoadTLSConfig(s)
+	if err != nil {
+		return err
+	}
+	if tlsCfg != nil {
+		if transport, ok := c.client.Transport.(*http.Transport); ok {
+			transport.TLSClientConfig = tlsCfg
+		} else {
+			return errors.Errorf("cannot apply tls config to transport: %T", c.client.Transport)
+		}
+	}
+
+	version := os.Getenv("DOCKER_API_VERSION")
+	if version == "" {
+		version = ctx.APIVersion
+	}
+	if version != "" {
+		c.version = version
+		c.manualOverride = true
+	}
+	return nil
+}

--- a/client/context.go
+++ b/client/context.go
@@ -12,7 +12,7 @@ import (
 func loadContext(c *Client, s contextstore.Store, ctxName string) error {
 	ctxMeta, err := s.GetContextMetadata(ctxName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to retrieve context metadata: %s", err)
+		return errors.Wrap(err, "failed to retrieve context metadata")
 	}
 	ctx, err := context.Parse(ctxName, ctxMeta)
 	if err != nil {

--- a/client/context/consts.go
+++ b/client/context/consts.go
@@ -1,0 +1,15 @@
+package context
+
+const (
+	// DockerContextEnvVar is the environment variable used to override default context
+	DockerContextEnvVar = "DOCKER_CONTEXT"
+
+	// internal keys for endpoint metadata and TLS data
+	hostKey           = "host"
+	apiVersionKey     = "apiVersion"
+	skipTLSVerifyKey  = "skipTLSVerify"
+	dockerEndpointKey = "docker"
+	caKey             = "ca.pem"
+	certKey           = "cert.pem"
+	keyKey            = "key.pem"
+)

--- a/client/context/load.go
+++ b/client/context/load.go
@@ -1,0 +1,123 @@
+package context
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+
+	"github.com/docker/docker/pkg/contextstore"
+	"github.com/docker/go-connections/tlsconfig"
+	"github.com/pkg/errors"
+)
+
+// Context is a typed wrapper around a context-store context
+type Context struct {
+	Name          string
+	Host          string
+	SkipTLSVerify bool
+	APIVersion    string
+}
+
+// TLSData holds ca/cert/key raw data
+type TLSData struct {
+	CA   []byte
+	Key  []byte
+	Cert []byte
+}
+
+// LoadTLSData loads TLS materials for the context
+func (c *Context) LoadTLSData(s contextstore.Store) (*TLSData, error) {
+	tlsFiles, err := s.ListContextTLSFiles(c.Name)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to retrieve context tls info")
+	}
+	if epTLSFiles, ok := tlsFiles[dockerEndpointKey]; ok {
+		var tlsData TLSData
+		for _, f := range epTLSFiles {
+			data, err := s.GetContextTLSData(c.Name, dockerEndpointKey, f)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to retrieve context tls info")
+			}
+			switch f {
+			case caKey:
+				tlsData.CA = data
+			case certKey:
+				tlsData.Cert = data
+			case keyKey:
+				tlsData.Key = data
+			}
+		}
+		return &tlsData, nil
+	}
+	return nil, nil
+}
+
+// LoadTLSConfig extracts a context docker endpoint TLS config
+func (c *Context) LoadTLSConfig(s contextstore.Store) (*tls.Config, error) {
+	tlsData, err := c.LoadTLSData(s)
+	if err != nil {
+		return nil, err
+	}
+	if tlsData != nil || c.SkipTLSVerify {
+		var tlsOpts []func(*tls.Config)
+		if tlsData != nil && tlsData.CA != nil {
+			certPool := x509.NewCertPool()
+			if !certPool.AppendCertsFromPEM(tlsData.CA) {
+				return nil, errors.New("failed to retrieve context tls info: ca.pem seems invalid")
+			}
+			tlsOpts = append(tlsOpts, func(cfg *tls.Config) {
+				cfg.RootCAs = certPool
+			})
+		}
+		if tlsData != nil && tlsData.Key != nil && tlsData.Cert != nil {
+			x509cert, err := tls.X509KeyPair(tlsData.Cert, tlsData.Key)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to retrieve context tls info: %s", err)
+			}
+			tlsOpts = append(tlsOpts, func(cfg *tls.Config) {
+				cfg.Certificates = []tls.Certificate{x509cert}
+			})
+		}
+		if c.SkipTLSVerify {
+			tlsOpts = append(tlsOpts, func(cfg *tls.Config) {
+				cfg.InsecureSkipVerify = true
+			})
+		}
+		return tlsconfig.ClientDefault(tlsOpts...), nil
+	}
+	return nil, nil
+}
+
+func getMetaString(meta map[string]interface{}, key string) (string, bool) {
+	v, ok := meta[key]
+	if !ok {
+		return "", false
+	}
+	r, ok := v.(string)
+	return r, ok
+}
+
+func getMetaBool(meta map[string]interface{}, key string) (bool, bool) {
+	v, ok := meta[key]
+	if !ok {
+		return false, false
+	}
+	r, ok := v.(bool)
+	return r, ok
+}
+
+// Parse parses a context docker endpoint metadata into a typed Context structure
+func Parse(name string, metadata contextstore.ContextMetadata) (*Context, error) {
+	ep, ok := metadata.Endpoints[dockerEndpointKey]
+	if !ok {
+		return nil, errors.New("cannot find docker endpoint in context")
+	}
+	host, _ := getMetaString(ep, hostKey)
+	skipTLSVerify, _ := getMetaBool(ep, skipTLSVerifyKey)
+	apiVersion, _ := getMetaString(ep, apiVersionKey)
+	return &Context{
+		Name:          name,
+		Host:          host,
+		SkipTLSVerify: skipTLSVerify,
+		APIVersion:    apiVersion,
+	}, nil
+}

--- a/client/context/save.go
+++ b/client/context/save.go
@@ -1,0 +1,54 @@
+package context
+
+import (
+	"os"
+
+	"github.com/docker/docker/pkg/contextstore"
+)
+
+// SetDockerEndpoint set the docker endpoint of a context
+func SetDockerEndpoint(s contextstore.Store, name, host, apiVersion string, ca, cert, key []byte, skipTLSVerify bool) error {
+	ctxMeta, err := s.GetContextMetadata(name)
+	switch {
+	case os.IsNotExist(err):
+		ctxMeta = contextstore.ContextMetadata{
+			Endpoints: make(map[string]contextstore.EndpointMetadata),
+			Metadata:  make(map[string]interface{}),
+		}
+	case err != nil:
+		return err
+	}
+	epMeta := make(contextstore.EndpointMetadata)
+	epMeta[hostKey] = host
+	if apiVersion != "" {
+		epMeta[apiVersionKey] = apiVersion
+	}
+	if skipTLSVerify {
+		epMeta[skipTLSVerifyKey] = true
+	}
+	ctxMeta.Endpoints[dockerEndpointKey] = epMeta
+	err = s.CreateOrUpdateContext(name, ctxMeta)
+	if err != nil {
+		return err
+	}
+	return s.ResetContextEndpointTLSMaterial(name, dockerEndpointKey, createEnpointTLSData(ca, cert, key))
+}
+
+func createEnpointTLSData(ca, cert, key []byte) *contextstore.EndpointTLSData {
+	if ca == nil && cert == nil && key == nil {
+		return nil
+	}
+	result := contextstore.EndpointTLSData{
+		Files: make(map[string][]byte),
+	}
+	if ca != nil {
+		result.Files[caKey] = ca
+	}
+	if cert != nil {
+		result.Files[certKey] = cert
+	}
+	if key != nil {
+		result.Files[keyKey] = key
+	}
+	return &result
+}

--- a/client/context/save.go
+++ b/client/context/save.go
@@ -6,7 +6,7 @@ import (
 	"github.com/docker/docker/pkg/contextstore"
 )
 
-// SetDockerEndpoint set the docker endpoint of a context
+// SetDockerEndpoint sets the docker endpoint of a context
 func SetDockerEndpoint(s contextstore.Store, name, host, apiVersion string, ca, cert, key []byte, skipTLSVerify bool) error {
 	ctxMeta, err := s.GetContextMetadata(name)
 	switch {

--- a/client/context/save.go
+++ b/client/context/save.go
@@ -27,8 +27,7 @@ func SetDockerEndpoint(s contextstore.Store, name, host, apiVersion string, ca, 
 		epMeta[skipTLSVerifyKey] = true
 	}
 	ctxMeta.Endpoints[dockerEndpointKey] = epMeta
-	err = s.CreateOrUpdateContext(name, ctxMeta)
-	if err != nil {
+	if err := s.CreateOrUpdateContext(name, ctxMeta); err != nil {
 		return err
 	}
 	return s.ResetContextEndpointTLSMaterial(name, dockerEndpointKey, createEnpointTLSData(ca, cert, key))

--- a/pkg/contextstore/doc.go
+++ b/pkg/contextstore/doc.go
@@ -1,0 +1,22 @@
+// Package contextstore provides a generic way to store credentials to connect to virtually any kind of remote system
+// the `context` term comes from the similar feature in Kubernetes kubectl config files.
+//
+// conceptually, a context is a set of metadata and TLS data, that can be used to connect to various endpoints
+// of the remote system. TLS data and metadata are stored separately, so that in the future, we will be able to store sensitive
+// information in a more secure way, depending on the os we are running on (e.g.: on Windows we could use the user Certificate Store, on Mac OS the user Keychain...)
+//
+// current implementation is purely file based with the following structure:
+// ${CONTEXT_ROOT}
+//   - config.json: contains the current "default" context
+//   - meta/
+//     - context1/meta.json: contains context medata (key/value pairs) as well as a list of endpoints (themselves containing key/value pair metadata)
+//     - contexts/can/also/be/folded/like/this/meta.json: same as context1, but for a context named `contexts/can/also/be/folded/like/this`
+//   - tls/
+//     - context1/endpoint1/: directory containing TLS data for the endpoint1 in context1
+//
+// the context store itself has abolutely no knowledge about a docker or a kubernetes endpoint should contain in term of metadata or TLS config
+// client code is responsible for generating and parsing endpoint metadata and TLS files
+// The multi-endpoint approach of this package allows to combine many different endpoints in the same "context" (e.g., the Docker CLI
+// will be able for a single context to define both a docker endpoint and a Kubernetes endpoint for the same cluster, and also specify which
+// orchestrator to use by default when deploying a compose stack on this cluster)
+package contextstore

--- a/pkg/contextstore/metadata_test.go
+++ b/pkg/contextstore/metadata_test.go
@@ -9,27 +9,28 @@ import (
 	"gotest.tools/assert"
 )
 
+var testMetadata = ContextMetadata{
+	Metadata: map[string]interface{}{
+		"baz": "foo",
+	},
+	Endpoints: map[string]EndpointMetadata{
+		"test-ep": {
+			"foo": "bar",
+		},
+	},
+}
+
 func TestMetadataMarshalling(t *testing.T) {
 	var ctxMeta ContextMetadata
-	expected := ContextMetadata{
-		Metadata: map[string]interface{}{
-			"baz": "foo",
-		},
-		Endpoints: map[string]EndpointMetadata{
-			"test-ep": {
-				"foo": "bar",
-			},
-		},
-	}
-	bytes, err := json.Marshal(&expected)
+	bytes, err := json.Marshal(&testMetadata)
 	assert.NilError(t, err)
 	err = json.Unmarshal(bytes, &ctxMeta)
 	assert.NilError(t, err)
-	assert.DeepEqual(t, ctxMeta, expected)
+	assert.DeepEqual(t, ctxMeta, testMetadata)
 }
 
 func TestMetadataGetNotExisting(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "TestMetadataGetNotExisting")
+	testDir, err := ioutil.TempDir("", t.Name())
 	assert.NilError(t, err)
 	defer os.RemoveAll(testDir)
 	testee := metadataStore{root: testDir}
@@ -38,20 +39,10 @@ func TestMetadataGetNotExisting(t *testing.T) {
 }
 
 func TestMetadataCreateGetRemove(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "TestMetadataCreateGet")
+	testDir, err := ioutil.TempDir("", t.Name())
 	assert.NilError(t, err)
 	defer os.RemoveAll(testDir)
 	testee := metadataStore{root: testDir}
-	expected := ContextMetadata{
-		Metadata: map[string]interface{}{
-			"baz": "foo",
-		},
-		Endpoints: map[string]EndpointMetadata{
-			"test-ep": {
-				"foo": "bar",
-			},
-		},
-	}
 	expected2 := ContextMetadata{
 		Metadata: map[string]interface{}{
 			"baz": "foo",
@@ -65,11 +56,11 @@ func TestMetadataCreateGetRemove(t *testing.T) {
 			},
 		},
 	}
-	err = testee.createOrUpdate("test-context", expected)
+	err = testee.createOrUpdate("test-context", testMetadata)
 	assert.NilError(t, err)
 	meta, err := testee.get("test-context")
 	assert.NilError(t, err)
-	assert.DeepEqual(t, meta, expected)
+	assert.DeepEqual(t, meta, testMetadata)
 
 	// update
 
@@ -86,7 +77,7 @@ func TestMetadataCreateGetRemove(t *testing.T) {
 }
 
 func TestMetadataList(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "TestMetadataList")
+	testDir, err := ioutil.TempDir("", t.Name())
 	assert.NilError(t, err)
 	defer os.RemoveAll(testDir)
 	testee := metadataStore{root: testDir}

--- a/pkg/contextstore/metadata_test.go
+++ b/pkg/contextstore/metadata_test.go
@@ -1,7 +1,6 @@
 package contextstore
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -20,22 +19,13 @@ var testMetadata = ContextMetadata{
 	},
 }
 
-func TestMetadataMarshalling(t *testing.T) {
-	var ctxMeta ContextMetadata
-	bytes, err := json.Marshal(&testMetadata)
-	assert.NilError(t, err)
-	err = json.Unmarshal(bytes, &ctxMeta)
-	assert.NilError(t, err)
-	assert.DeepEqual(t, ctxMeta, testMetadata)
-}
-
 func TestMetadataGetNotExisting(t *testing.T) {
 	testDir, err := ioutil.TempDir("", t.Name())
 	assert.NilError(t, err)
 	defer os.RemoveAll(testDir)
 	testee := metadataStore{root: testDir}
 	_, err = testee.get("noexist")
-	assert.Equal(t, true, os.IsNotExist(err))
+	assert.Assert(t, os.IsNotExist(err))
 }
 
 func TestMetadataCreateGetRemove(t *testing.T) {
@@ -58,6 +48,8 @@ func TestMetadataCreateGetRemove(t *testing.T) {
 	}
 	err = testee.createOrUpdate("test-context", testMetadata)
 	assert.NilError(t, err)
+	// create a new instance to check it does not depend on some sort of state
+	testee = metadataStore{root: testDir}
 	meta, err := testee.get("test-context")
 	assert.NilError(t, err)
 	assert.DeepEqual(t, meta, testMetadata)
@@ -73,7 +65,7 @@ func TestMetadataCreateGetRemove(t *testing.T) {
 	assert.NilError(t, testee.remove("test-context"))
 	assert.NilError(t, testee.remove("test-context")) // support duplicate remove
 	_, err = testee.get("test-context")
-	assert.Equal(t, true, os.IsNotExist(err))
+	assert.Assert(t, os.IsNotExist(err))
 }
 
 func TestMetadataList(t *testing.T) {

--- a/pkg/contextstore/metadata_test.go
+++ b/pkg/contextstore/metadata_test.go
@@ -1,0 +1,119 @@
+package contextstore
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestMetadataMarshalling(t *testing.T) {
+	var ctxMeta ContextMetadata
+	expected := ContextMetadata{
+		Metadata: map[string]interface{}{
+			"baz": "foo",
+		},
+		Endpoints: map[string]EndpointMetadata{
+			"test-ep": {
+				"foo": "bar",
+			},
+		},
+	}
+	bytes, err := json.Marshal(&expected)
+	assert.NilError(t, err)
+	err = json.Unmarshal(bytes, &ctxMeta)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, ctxMeta, expected)
+}
+
+func TestMetadataGetNotExisting(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "TestMetadataGetNotExisting")
+	assert.NilError(t, err)
+	defer os.RemoveAll(testDir)
+	testee := metadataStore{root: testDir}
+	_, err = testee.get("noexist")
+	assert.Equal(t, true, os.IsNotExist(err))
+}
+
+func TestMetadataCreateGetRemove(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "TestMetadataCreateGet")
+	assert.NilError(t, err)
+	defer os.RemoveAll(testDir)
+	testee := metadataStore{root: testDir}
+	expected := ContextMetadata{
+		Metadata: map[string]interface{}{
+			"baz": "foo",
+		},
+		Endpoints: map[string]EndpointMetadata{
+			"test-ep": {
+				"foo": "bar",
+			},
+		},
+	}
+	expected2 := ContextMetadata{
+		Metadata: map[string]interface{}{
+			"baz": "foo",
+		},
+		Endpoints: map[string]EndpointMetadata{
+			"test-ep": {
+				"foo": "bar",
+			},
+			"test-ep2": {
+				"foo": "bar",
+			},
+		},
+	}
+	err = testee.createOrUpdate("test-context", expected)
+	assert.NilError(t, err)
+	meta, err := testee.get("test-context")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, meta, expected)
+
+	// update
+
+	err = testee.createOrUpdate("test-context", expected2)
+	assert.NilError(t, err)
+	meta, err = testee.get("test-context")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, meta, expected2)
+
+	assert.NilError(t, testee.remove("test-context"))
+	assert.NilError(t, testee.remove("test-context")) // support duplicate remove
+	_, err = testee.get("test-context")
+	assert.Equal(t, true, os.IsNotExist(err))
+}
+
+func TestMetadataList(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "TestMetadataList")
+	assert.NilError(t, err)
+	defer os.RemoveAll(testDir)
+	testee := metadataStore{root: testDir}
+	wholeData := map[string]ContextMetadata{
+		"simple": {
+			Metadata: map[string]interface{}{"foo": "bar"},
+		},
+		"simple2": {
+			Metadata: map[string]interface{}{"foo": "bar"},
+		},
+		"nested/context": {
+			Metadata: map[string]interface{}{"foo": "bar"},
+		},
+		"nestedwith-parent/context": {
+			Metadata: map[string]interface{}{"foo": "bar"},
+		},
+		"nestedwith-parent": {
+			Metadata: map[string]interface{}{"foo": "bar"},
+		},
+	}
+
+	for k, s := range wholeData {
+		err = testee.createOrUpdate(k, s)
+		assert.NilError(t, err)
+	}
+
+	data, err := testee.list()
+	assert.NilError(t, err)
+	assert.DeepEqual(t, data, wholeData)
+}

--- a/pkg/contextstore/metadatastore.go
+++ b/pkg/contextstore/metadatastore.go
@@ -1,0 +1,104 @@
+package contextstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+const metadataDir = "meta"
+const metaFile = "meta.json"
+
+type metadataStore struct {
+	root string
+}
+
+func (s *metadataStore) contextDir(name string) string {
+	return filepath.Join(s.root, name)
+}
+
+func (s *metadataStore) createOrUpdate(name string, meta ContextMetadata) error {
+	contextDir := s.contextDir(name)
+	err := os.MkdirAll(contextDir, 0755)
+	if err != nil {
+		return err
+	}
+	bytes, err := json.Marshal(&meta)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filepath.Join(contextDir, metaFile), bytes, 0644)
+}
+
+func (s *metadataStore) get(name string) (ContextMetadata, error) {
+	contextDir := s.contextDir(name)
+	bytes, err := ioutil.ReadFile(filepath.Join(contextDir, metaFile))
+	if err != nil {
+		return ContextMetadata{}, err
+	}
+	var r ContextMetadata
+	err = json.Unmarshal(bytes, &r)
+	return r, err
+}
+
+func (s *metadataStore) remove(name string) error {
+	contextDir := s.contextDir(name)
+	return os.RemoveAll(contextDir)
+}
+
+func (s *metadataStore) list() (map[string]ContextMetadata, error) {
+	ctxNames, err := listRecursivelyMetadataDirs(s.root)
+	if err != nil {
+		return nil, err
+	}
+	res := make(map[string]ContextMetadata)
+	for _, name := range ctxNames {
+		res[name], err = s.get(name)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func isContextDir(path string) bool {
+	s, err := os.Stat(filepath.Join(path, metaFile))
+	if err != nil {
+		return false
+	}
+	return !s.IsDir()
+}
+
+func listRecursivelyMetadataDirs(root string) ([]string, error) {
+	fis, err := ioutil.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+	var result []string
+	for _, fi := range fis {
+		if fi.IsDir() {
+			if isContextDir(filepath.Join(root, fi.Name())) {
+				result = append(result, fi.Name())
+			}
+			subs, err := listRecursivelyMetadataDirs(filepath.Join(root, fi.Name()))
+			if err != nil {
+				return nil, err
+			}
+			for _, s := range subs {
+				result = append(result, fmt.Sprintf("%s/%s", fi.Name(), s))
+			}
+		}
+	}
+	return result, nil
+}
+
+// EndpointMetadata contains metadata about an endpoint
+type EndpointMetadata map[string]interface{}
+
+// ContextMetadata contains metadata about a context and its endpoints
+type ContextMetadata struct {
+	Metadata  map[string]interface{}      `json:"metadata,omitempty"`
+	Endpoints map[string]EndpointMetadata `json:"endpoints,omitempty"`
+}

--- a/pkg/contextstore/metadatastore.go
+++ b/pkg/contextstore/metadatastore.go
@@ -8,8 +8,10 @@ import (
 	"path/filepath"
 )
 
-const metadataDir = "meta"
-const metaFile = "meta.json"
+const (
+	metadataDir = "meta"
+	metaFile    = "meta.json"
+)
 
 type metadataStore struct {
 	root string
@@ -21,8 +23,7 @@ func (s *metadataStore) contextDir(name string) string {
 
 func (s *metadataStore) createOrUpdate(name string, meta ContextMetadata) error {
 	contextDir := s.contextDir(name)
-	err := os.MkdirAll(contextDir, 0755)
-	if err != nil {
+	if err := os.MkdirAll(contextDir, 0755); err != nil {
 		return err
 	}
 	bytes, err := json.Marshal(&meta)
@@ -92,13 +93,4 @@ func listRecursivelyMetadataDirs(root string) ([]string, error) {
 		}
 	}
 	return result, nil
-}
-
-// EndpointMetadata contains metadata about an endpoint
-type EndpointMetadata map[string]interface{}
-
-// ContextMetadata contains metadata about a context and its endpoints
-type ContextMetadata struct {
-	Metadata  map[string]interface{}      `json:"metadata,omitempty"`
-	Endpoints map[string]EndpointMetadata `json:"endpoints,omitempty"`
 }

--- a/pkg/contextstore/store.go
+++ b/pkg/contextstore/store.go
@@ -1,0 +1,290 @@
+package contextstore
+
+import (
+	"archive/tar"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const configFileName = "config.json"
+
+// Store provides a context store for easily remembering endpoints configuration
+type Store interface {
+	GetCurrentContext() string
+	SetCurrentContext(name string) error
+	ListContexts() (map[string]ContextMetadata, error)
+	CreateOrUpdateContext(name string, meta ContextMetadata) error
+	GetContextMetadata(name string) (ContextMetadata, error)
+	ResetContextTLSMaterial(name string, data *ContextTLSData) error
+	ResetContextEndpointTLSMaterial(contextName string, endpointName string, data *EndpointTLSData) error
+	ListContextTLSFiles(name string) (map[string]EndpointFiles, error)
+	GetContextTLSData(contextName, endpointName, fileName string) ([]byte, error)
+	Export(name string) io.ReadCloser
+	Import(name string, reader io.Reader) error
+	Remove(name string) error
+}
+type store struct {
+	configFile     string
+	currentContext string
+	meta           *metadataStore
+	tls            *tlsStore
+}
+
+// NewStore creates a store from a given directory.
+// If the directory does not exist or is empty, initialize it
+func NewStore(dir string) (Store, error) {
+	metaRoot := filepath.Join(dir, metadataDir)
+	tlsRoot := filepath.Join(dir, tlsDir)
+	configFile := filepath.Join(dir, configFileName)
+	err := os.MkdirAll(metaRoot, 0755)
+	if err != nil {
+		return nil, err
+	}
+	err = os.MkdirAll(tlsRoot, 0700)
+	if err != nil {
+		return nil, err
+	}
+	_, err = os.Stat(configFile)
+
+	switch {
+	case os.IsNotExist(err):
+		//create default file
+		err = ioutil.WriteFile(configFile, []byte("{}"), 0644)
+		if err != nil {
+			return nil, err
+		}
+	case err != nil:
+		return nil, err
+	}
+
+	configBytes, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return nil, err
+	}
+	var cfg config
+	err = json.Unmarshal(configBytes, &cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &store{
+		configFile:     configFile,
+		currentContext: cfg.CurrentContext,
+		meta: &metadataStore{
+			root: metaRoot,
+		},
+		tls: &tlsStore{
+			root: tlsRoot,
+		},
+	}, nil
+}
+
+func (s *store) GetCurrentContext() string {
+	return s.currentContext
+}
+
+func (s *store) SetCurrentContext(name string) error {
+	cfg := config{CurrentContext: name}
+	configBytes, err := json.Marshal(&cfg)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(s.configFile, configBytes, 0644)
+	if err != nil {
+		return err
+	}
+	s.currentContext = name
+	return nil
+}
+
+func (s *store) ListContexts() (map[string]ContextMetadata, error) {
+	return s.meta.list()
+}
+
+func (s *store) CreateOrUpdateContext(name string, meta ContextMetadata) error {
+	return s.meta.createOrUpdate(name, meta)
+}
+
+func (s *store) GetContextMetadata(name string) (ContextMetadata, error) {
+	return s.meta.get(name)
+}
+
+func (s *store) ResetContextTLSMaterial(name string, data *ContextTLSData) error {
+	err := s.tls.removeAllContextData(name)
+	if err != nil {
+		return err
+	}
+	if data != nil {
+		for ep, files := range data.Endpoints {
+			for fileName, data := range files.Files {
+				err = s.tls.createOrUpdate(name, ep, fileName, data)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (s *store) ResetContextEndpointTLSMaterial(contextName string, endpointName string, data *EndpointTLSData) error {
+	err := s.tls.removeAllEndpointData(contextName, endpointName)
+	if err != nil {
+		return err
+	}
+	if data != nil {
+		for fileName, data := range data.Files {
+			err = s.tls.createOrUpdate(contextName, endpointName, fileName, data)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *store) ListContextTLSFiles(name string) (map[string]EndpointFiles, error) {
+	return s.tls.listContextData(name)
+}
+
+func (s *store) GetContextTLSData(contextName, endpointName, fileName string) ([]byte, error) {
+	return s.tls.getData(contextName, endpointName, fileName)
+}
+
+func (s *store) Export(name string) io.ReadCloser {
+	reader, writer := io.Pipe()
+	go func() {
+		tw := tar.NewWriter(writer)
+		defer tw.Flush()
+		defer tw.Close()
+		defer writer.Close()
+		meta, err := s.meta.get(name)
+		if err != nil {
+			writer.CloseWithError(err)
+			return
+		}
+		metaBytes, err := json.Marshal(&meta)
+		if err != nil {
+			writer.CloseWithError(err)
+			return
+		}
+		if err = tw.WriteHeader(&tar.Header{
+			Name: metaFile,
+			Mode: 0644,
+			Size: int64(len(metaBytes)),
+		}); err != nil {
+			writer.CloseWithError(err)
+			return
+		}
+		if _, err = tw.Write(metaBytes); err != nil {
+			writer.CloseWithError(err)
+			return
+		}
+		if err = appendDirToArchive(s.tls.contextDir(name), "tls/", tw); err != nil {
+			writer.CloseWithError(err)
+			return
+		}
+	}()
+	return reader
+}
+
+func (s *store) Import(name string, reader io.Reader) error {
+	tr := tar.NewReader(reader)
+	metaDir := s.meta.contextDir(name)
+	if err := os.MkdirAll(metaDir, 0755); err != nil {
+		return err
+	}
+	tlsDir := s.tls.contextDir(name)
+	if err := os.MkdirAll(tlsDir, 0700); err != nil {
+		return err
+	}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if hdr.Name == metaFile {
+			data, err := ioutil.ReadAll(tr)
+			if err != nil {
+				return err
+			}
+			if err = ioutil.WriteFile(filepath.Join(metaDir, metaFile), data, 0644); err != nil {
+				return err
+			}
+		} else if strings.HasPrefix(hdr.Name, "tls/") {
+			relative := strings.TrimPrefix(hdr.Name, "tls/")
+			path := filepath.Join(tlsDir, relative)
+			dir := filepath.Dir(path)
+			if err = os.MkdirAll(dir, 0700); err != nil {
+				return err
+			}
+			data, err := ioutil.ReadAll(tr)
+			if err != nil {
+				return err
+			}
+			if err = ioutil.WriteFile(path, data, 0600); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (s *store) Remove(name string) error {
+	if err := s.meta.remove(name); err != nil {
+		return err
+	}
+	return s.tls.removeAllContextData(name)
+}
+
+func appendDirToArchive(path, inArchivePrefix string, tw *tar.Writer) error {
+	entries, err := ioutil.ReadDir(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			if err = appendDirToArchive(filepath.Join(path, entry.Name()), inArchivePrefix+entry.Name()+"/", tw); err != nil {
+				return err
+			}
+		} else {
+			if err = tw.WriteHeader(&tar.Header{
+				Mode: 0600,
+				Name: inArchivePrefix + entry.Name(),
+				Size: entry.Size(),
+			}); err != nil {
+				return err
+			}
+			bytes, err := ioutil.ReadFile(filepath.Join(path, entry.Name()))
+			if err != nil {
+				return err
+			}
+			if _, err = tw.Write(bytes); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+type config struct {
+	CurrentContext string `json:"current_context,omitempty"`
+}
+
+// EndpointTLSData represents tls data for a given endpoint
+type EndpointTLSData struct {
+	Files map[string][]byte
+}
+
+// ContextTLSData represents tls data for a whole context
+type ContextTLSData struct {
+	Endpoints map[string]EndpointTLSData
+}

--- a/pkg/contextstore/store_test.go
+++ b/pkg/contextstore/store_test.go
@@ -65,9 +65,9 @@ func TestExportImport(t *testing.T) {
 		},
 	})
 	assert.NilError(t, err)
-	r := s.Export("source")
+	r := Export("source", s)
 	defer r.Close()
-	err = s.Import("dest", r)
+	err = Import("dest", s, r)
 	assert.NilError(t, err)
 	srcMeta, err := s.GetContextMetadata("source")
 	assert.NilError(t, err)
@@ -110,7 +110,7 @@ func TestRemove(t *testing.T) {
 			"file1": []byte("test-data"),
 		},
 	}))
-	assert.NilError(t, s.Remove("source"))
+	assert.NilError(t, s.RemoveContext("source"))
 	_, err = s.GetContextMetadata("source")
 	assert.Check(t, os.IsNotExist(err))
 	f, err := s.ListContextTLSFiles("source")

--- a/pkg/contextstore/store_test.go
+++ b/pkg/contextstore/store_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestStoreInitScratch(t *testing.T) {
-	dirname, err := ioutil.TempDir("", "test-store-init-scratch")
+	dirname, err := ioutil.TempDir("", t.Name())
 	assert.NilError(t, err)
 	defer os.RemoveAll(dirname)
 	testDir := filepath.Join(dirname, "test")
@@ -18,10 +18,10 @@ func TestStoreInitScratch(t *testing.T) {
 	assert.NilError(t, err)
 	metaFS, err := os.Stat(filepath.Join(testDir, metadataDir))
 	assert.NilError(t, err)
-	assert.Equal(t, metaFS.IsDir(), true)
+	assert.Assert(t, metaFS.IsDir())
 	tlsFS, err := os.Stat(filepath.Join(testDir, tlsDir))
 	assert.NilError(t, err)
-	assert.Equal(t, tlsFS.IsDir(), true)
+	assert.Assert(t, tlsFS.IsDir())
 
 	// check that we can create a store from existing dir
 	_, err = NewStore(testDir)
@@ -29,7 +29,7 @@ func TestStoreInitScratch(t *testing.T) {
 }
 
 func TestSetGetCurrentContext(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "TestSetGetCurrentContext")
+	testDir, err := ioutil.TempDir("", t.Name())
 	assert.NilError(t, err)
 	defer os.RemoveAll(testDir)
 	store1, err := NewStore(testDir)
@@ -42,7 +42,7 @@ func TestSetGetCurrentContext(t *testing.T) {
 }
 
 func TestExportImport(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "TestSetGetCurrentContext")
+	testDir, err := ioutil.TempDir("", t.Name())
 	assert.NilError(t, err)
 	defer os.RemoveAll(testDir)
 	s, err := NewStore(testDir)
@@ -88,7 +88,7 @@ func TestExportImport(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "TestRemove")
+	testDir, err := ioutil.TempDir("", t.Name())
 	assert.NilError(t, err)
 	defer os.RemoveAll(testDir)
 	s, err := NewStore(testDir)

--- a/pkg/contextstore/store_test.go
+++ b/pkg/contextstore/store_test.go
@@ -1,0 +1,119 @@
+package contextstore
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestStoreInitScratch(t *testing.T) {
+	dirname, err := ioutil.TempDir("", "test-store-init-scratch")
+	assert.NilError(t, err)
+	defer os.RemoveAll(dirname)
+	testDir := filepath.Join(dirname, "test")
+	_, err = NewStore(testDir)
+	assert.NilError(t, err)
+	metaFS, err := os.Stat(filepath.Join(testDir, metadataDir))
+	assert.NilError(t, err)
+	assert.Equal(t, metaFS.IsDir(), true)
+	tlsFS, err := os.Stat(filepath.Join(testDir, tlsDir))
+	assert.NilError(t, err)
+	assert.Equal(t, tlsFS.IsDir(), true)
+
+	// check that we can create a store from existing dir
+	_, err = NewStore(testDir)
+	assert.NilError(t, err)
+}
+
+func TestSetGetCurrentContext(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "TestSetGetCurrentContext")
+	assert.NilError(t, err)
+	defer os.RemoveAll(testDir)
+	store1, err := NewStore(testDir)
+	assert.NilError(t, err)
+	err = store1.SetCurrentContext("test")
+	assert.NilError(t, err)
+	store2, err := NewStore(testDir)
+	assert.NilError(t, err)
+	assert.Equal(t, "test", store2.GetCurrentContext())
+}
+
+func TestExportImport(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "TestSetGetCurrentContext")
+	assert.NilError(t, err)
+	defer os.RemoveAll(testDir)
+	s, err := NewStore(testDir)
+	assert.NilError(t, err)
+	err = s.CreateOrUpdateContext("source",
+		ContextMetadata{
+			Endpoints: map[string]EndpointMetadata{
+				"ep1": map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+			Metadata: map[string]interface{}{
+				"bar": "baz",
+			},
+		})
+	assert.NilError(t, err)
+	err = s.ResetContextEndpointTLSMaterial("source", "ep1", &EndpointTLSData{
+		Files: map[string][]byte{
+			"file1": []byte("test-data"),
+		},
+	})
+	assert.NilError(t, err)
+	r := s.Export("source")
+	defer r.Close()
+	err = s.Import("dest", r)
+	assert.NilError(t, err)
+	srcMeta, err := s.GetContextMetadata("source")
+	assert.NilError(t, err)
+	destMeta, err := s.GetContextMetadata("dest")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, destMeta, srcMeta)
+	srcFileList, err := s.ListContextTLSFiles("source")
+	assert.NilError(t, err)
+	destFileList, err := s.ListContextTLSFiles("dest")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, srcFileList, destFileList)
+	srcData, err := s.GetContextTLSData("source", "ep1", "file1")
+	assert.NilError(t, err)
+	assert.Equal(t, "test-data", string(srcData))
+	destData, err := s.GetContextTLSData("dest", "ep1", "file1")
+	assert.NilError(t, err)
+	assert.Equal(t, "test-data", string(destData))
+}
+
+func TestRemove(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "TestRemove")
+	assert.NilError(t, err)
+	defer os.RemoveAll(testDir)
+	s, err := NewStore(testDir)
+	assert.NilError(t, err)
+	err = s.CreateOrUpdateContext("source",
+		ContextMetadata{
+			Endpoints: map[string]EndpointMetadata{
+				"ep1": map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+			Metadata: map[string]interface{}{
+				"bar": "baz",
+			},
+		})
+	assert.NilError(t, err)
+	assert.NilError(t, s.ResetContextEndpointTLSMaterial("source", "ep1", &EndpointTLSData{
+		Files: map[string][]byte{
+			"file1": []byte("test-data"),
+		},
+	}))
+	assert.NilError(t, s.Remove("source"))
+	_, err = s.GetContextMetadata("source")
+	assert.Check(t, os.IsNotExist(err))
+	f, err := s.ListContextTLSFiles("source")
+	assert.NilError(t, err)
+	assert.Equal(t, 0, len(f))
+}

--- a/pkg/contextstore/tls_test.go
+++ b/pkg/contextstore/tls_test.go
@@ -1,0 +1,79 @@
+package contextstore
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestTlsCreateUpdateGetRemove(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "TestTlsCreateUpdateGetRemove")
+	assert.NilError(t, err)
+	defer os.RemoveAll(testDir)
+	testee := tlsStore{root: testDir}
+	_, err = testee.getData("test-ctx", "test-ep", "test-data")
+	assert.Equal(t, true, os.IsNotExist(err))
+
+	err = testee.createOrUpdate("test-ctx", "test-ep", "test-data", []byte("data"))
+	assert.NilError(t, err)
+	data, err := testee.getData("test-ctx", "test-ep", "test-data")
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), "data")
+	err = testee.createOrUpdate("test-ctx", "test-ep", "test-data", []byte("data2"))
+	assert.NilError(t, err)
+	data, err = testee.getData("test-ctx", "test-ep", "test-data")
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), "data2")
+
+	err = testee.remove("test-ctx", "test-ep", "test-data")
+	assert.NilError(t, err)
+	err = testee.remove("test-ctx", "test-ep", "test-data")
+	assert.NilError(t, err)
+
+	_, err = testee.getData("test-ctx", "test-ep", "test-data")
+	assert.Equal(t, true, os.IsNotExist(err))
+}
+
+func TestTlsListAndBatchRemove(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "TestTlsListAndBatchRemove")
+	assert.NilError(t, err)
+	defer os.RemoveAll(testDir)
+	testee := tlsStore{root: testDir}
+
+	all := map[string]EndpointFiles{
+		"ep1": {"f1", "f2", "f3"},
+		"ep2": {"f1", "f2", "f3"},
+		"ep3": {"f1", "f2", "f3"},
+	}
+
+	ep1ep2 := map[string]EndpointFiles{
+		"ep1": {"f1", "f2", "f3"},
+		"ep2": {"f1", "f2", "f3"},
+	}
+
+	for name, files := range all {
+		for _, file := range files {
+			err = testee.createOrUpdate("test-ctx", name, file, []byte("data"))
+			assert.NilError(t, err)
+		}
+	}
+
+	resAll, err := testee.listContextData("test-ctx")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, resAll, all)
+
+	err = testee.removeAllEndpointData("test-ctx", "ep3")
+	assert.NilError(t, err)
+	resEp1ep2, err := testee.listContextData("test-ctx")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, resEp1ep2, ep1ep2)
+
+	err = testee.removeAllContextData("test-ctx")
+	assert.NilError(t, err)
+	resEmpty, err := testee.listContextData("test-ctx")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, resEmpty, map[string]EndpointFiles{})
+
+}

--- a/pkg/contextstore/tlsstore.go
+++ b/pkg/contextstore/tlsstore.go
@@ -1,0 +1,85 @@
+package contextstore
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+const tlsDir = "tls"
+
+type tlsStore struct {
+	root string
+}
+
+func (s *tlsStore) contextDir(name string) string {
+	return filepath.Join(s.root, name)
+}
+
+func (s *tlsStore) endpointDir(contextName, name string) string {
+	return filepath.Join(s.root, contextName, name)
+}
+
+func (s *tlsStore) filePath(contextName, endpointName, filename string) string {
+	return filepath.Join(s.root, contextName, endpointName, filename)
+}
+
+func (s *tlsStore) createOrUpdate(contextName, endpointName, filename string, data []byte) error {
+	epdir := s.endpointDir(contextName, endpointName)
+	err := os.MkdirAll(epdir, 0700)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(s.filePath(contextName, endpointName, filename), data, 0600)
+}
+
+func (s *tlsStore) getData(contextName, endpointName, filename string) ([]byte, error) {
+	return ioutil.ReadFile(s.filePath(contextName, endpointName, filename))
+}
+
+func (s *tlsStore) remove(contextName, endpointName, filename string) error {
+	err := os.Remove(s.filePath(contextName, endpointName, filename))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+func (s *tlsStore) removeAllEndpointData(contextName, endpointName string) error {
+	return os.RemoveAll(s.endpointDir(contextName, endpointName))
+}
+
+func (s *tlsStore) removeAllContextData(contextName string) error {
+	return os.RemoveAll(s.contextDir(contextName))
+}
+
+func (s *tlsStore) listContextData(contextName string) (map[string]EndpointFiles, error) {
+	epFSs, err := ioutil.ReadDir(s.contextDir(contextName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]EndpointFiles{}, nil
+		}
+		return nil, err
+	}
+	r := make(map[string]EndpointFiles)
+	for _, epFS := range epFSs {
+		if epFS.IsDir() {
+			epDir := s.endpointDir(contextName, epFS.Name())
+			fss, err := ioutil.ReadDir(epDir)
+			if err != nil {
+				return nil, err
+			}
+			var files EndpointFiles
+			for _, fs := range fss {
+				if !fs.IsDir() {
+					files = append(files, fs.Name())
+				}
+			}
+			r[epFS.Name()] = files
+		}
+	}
+	return r, nil
+}
+
+// EndpointFiles is a slice of strings representing file names
+type EndpointFiles []string

--- a/pkg/contextstore/tlsstore.go
+++ b/pkg/contextstore/tlsstore.go
@@ -26,8 +26,7 @@ func (s *tlsStore) filePath(contextName, endpointName, filename string) string {
 
 func (s *tlsStore) createOrUpdate(contextName, endpointName, filename string, data []byte) error {
 	epdir := s.endpointDir(contextName, endpointName)
-	err := os.MkdirAll(epdir, 0700)
-	if err != nil {
+	if err := os.MkdirAll(epdir, 0700); err != nil {
 		return err
 	}
 	return ioutil.WriteFile(s.filePath(contextName, endpointName, filename), data, 0600)


### PR DESCRIPTION
**- What I did**
This is the foundation of a feature we at Docker want to bring to the docker client ecosystem: A way to store credentials to connect to different clusters and quickly switch from one to the other. The UX related to this PR will mostly appear in PRs against docker CLI, but everything required to interact with the docker context-store will live in the moby/moby repo (mostly to avoid dependent projects to have to vendor Docker cli)

**- How I did it**
First, I introduced a pkg/contextstore package that does the actual context storage. A context is a named entity that contains arbitrary metadata, and references named endpoints (on the moby/moby side only one endpoint is actually created/consumed, but on the CLI side, we'll complement those contexts with endpoints targeting Kubernetes for our Compose on Kubernetes support). An endpoint also contains arbitrary metadata plus references to TLS materials. The contextstore actually stores metadata and TLS material in different directories to make it easy to put different access rights on them, or put sensitive data on an encrypted filesystem.

Then the client/context package provides facilities to create and parse docker contexts and endpoints in order to configure a client

Client package has been updated with a new WithContextStoreOrEnv that will interact with the context store to configure the client, or fallback to the "legacy" environment variables if there is no context data.

**- How to verify it**

The PR comes with unit tests. User testing will be available soon with the docker/cli PRs coming

**- Description for the changelog**

Introduce a context store to make it easy to store and use different sets of credentials to connect to different engines

