### PR TITLE
Fix issue with removing setuid bits 

### DIFF
--- a/builder/dockerfile/copy_unix.go
+++ b/builder/dockerfile/copy_unix.go
@@ -38,8 +38,18 @@ func fixPermissions(source, destination string, identity idtools.Identity, overr
 			return err
 		}
 
+		srcSt, err := os.Stat(source)
+		if err != nil {
+			return err
+		}
+
 		fullpath = filepath.Join(destination, cleaned)
-		return os.Lchown(fullpath, identity.UID, identity.GID)
+		err = os.Lchown(fullpath, identity.UID, identity.GID)
+		if err != nil {
+			return err
+		}
+
+		return os.Chmod(fullpath, srcSt.Mode())
 	})
 }
 


### PR DESCRIPTION
Performing syscall lchown in most unix systems will clear setuid/setgid bit from file

Fixes: #36239 

**- What I did**
Fix bug with missing setuid/setgid bits on files in resulting image after docker build command

**- How I did it**
In function fixPermissions we perform copy of source file permissions after issuing lchown syscall.

**- How to verify it**
I have used the following script to verify it in my build of docker:
```
#!/bin/bash
cd /opt

touch 1.bin
chmod 700 1.bin
chmod u+xs 1.bin
echo -e 'FROM busybox:latest\nADD 1.bin /1.bin' > Dockerfile
docker build -t test .
```


**- Description for the changelog**
Fix issue with setuid/setgid bits on files when copy files during docker build process