### PR TITLE
Bump BurntSushi/toml to v0.3.1

### DIFF
--- a/hack/dockerfile/install/tomlv.installer
+++ b/hack/dockerfile/install/tomlv.installer
@@ -2,7 +2,7 @@
 
 # When updating TOMLV_COMMIT, consider updating github.com/BurntSushi/toml
 # in vendor.conf accordingly
-TOMLV_COMMIT=a368813c5e648fee92e5f6c30e3944ff9d5e8895
+TOMLV_COMMIT=3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
 
 install_tomlv() {
 	echo "Install tomlv version $TOMLV_COMMIT"

--- a/vendor.conf
+++ b/vendor.conf
@@ -51,8 +51,8 @@ github.com/docker/libkv 458977154600b9f23984d9f4b82e79570b5ae12b
 github.com/vishvananda/netns 604eaf189ee867d8c147fafc28def2394e878d25
 github.com/vishvananda/netlink b2de5d10e38ecce8607e6b438b6d174f389a004e
 
-# When updating, consider updating TOMLV_COMMIT in hack/dockerfile/install/tomlv accordingly
-github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
+# When updating, consider updating TOMLV_COMMIT in hack/dockerfile/install/tomlv.installer accordingly
+github.com/BurntSushi/toml 3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
 github.com/samuel/go-zookeeper d0e0d8e11f318e000a8cc434616d69e329edc374
 github.com/deckarep/golang-set ef32fa3046d9f249d399f98ebaf9be944430fd1d
 github.com/coreos/etcd v3.3.9


### PR DESCRIPTION
No code changes, but this aligns it to a tagged version, and updates some nested license files to MIT.

vndr doesn't vendor those nested files, so no code changes in the vendor directory.

full diff: https://github.com/BurntSushi/toml/compare/a368813c5e648fee92e5f6c30e3944ff9d5e8895...3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005
