### PR TITLE
cli: fix images filter when use multi reference filter

### DIFF
--- a/daemon/images/images.go
+++ b/daemon/images/images.go
@@ -152,6 +152,9 @@ func (i *ImageService) Images(imageFilters filters.Args, all bool, withExtraAttr
 					if matchErr != nil {
 						return nil, matchErr
 					}
+					if found {
+						break
+					}
 				}
 				if !found {
 					continue

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -1,0 +1,50 @@
+package image // import "github.com/docker/docker/integration/image"
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/internal/test/request"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+)
+
+// Regression : #38171
+func TestImagesFilterMultiReference(t *testing.T) {
+	defer setupTest(t)()
+	client := request.NewAPIClient(t)
+	ctx := context.Background()
+
+	name := "images_filter_multi_reference"
+	repoTags := []string{
+		name + ":v1",
+		name + ":v2",
+		name + ":v3",
+		name + ":v4",
+	}
+
+	for _, repoTag := range repoTags {
+		err := client.ImageTag(ctx, "busybox:latest", repoTag)
+		assert.NilError(t, err)
+	}
+
+	filter := filters.NewArgs()
+	filter.Add("reference", repoTags[0])
+	filter.Add("reference", repoTags[1])
+	filter.Add("reference", repoTags[2])
+	options := types.ImageListOptions{
+		All:     false,
+		Filters: filter,
+	}
+	images, err := client.ImageList(ctx, options)
+	assert.NilError(t, err)
+
+	assert.Check(t, is.Equal(len(images[0].RepoTags), 3))
+	for _, repoTag := range images[0].RepoTags {
+		if repoTag != repoTags[0] && repoTag != repoTags[1] && repoTag != repoTags[2] {
+			t.Errorf("list images doesn't match any repoTag we expected, repoTag: %s", repoTag)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
fix #38164 , to refuse `docker images -f ` undefined behavior when use multi reference filter.

**- How I did it**
just add a judge statement when filter image ref.

**- How to verify it**
run `docker images`
```
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
hello-world         latest              4ab4c602aa5e        2 months ago        1.84kB
img2                test1               4ab4c602aa5e        2 months ago        1.84kB
img                 test1               4ab4c602aa5e        2 months ago        1.84kB
img                 test2               4ab4c602aa5e        2 months ago        1.84kB
```
run `docker images -f reference=img:* -f reference=hello-*`
```
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
hello-world         latest              4ab4c602aa5e        2 months ago        1.84kB
img                 test1               4ab4c602aa5e        2 months ago        1.84kB
img                 test2               4ab4c602aa5e        2 months ago        1.84kB
```

run `docker images -f reference=img:* -f reference=hello-* -f reference=img2:*`

```
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
hello-world         latest              4ab4c602aa5e        2 months ago        1.84kB
img2                test1               4ab4c602aa5e        2 months ago        1.84kB
img                 test1               4ab4c602aa5e        2 months ago        1.84kB
img                 test2               4ab4c602aa5e        2 months ago        1.84kB
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix #38164 , to refuse `docker images -f ` undefined behavior when use multi reference filter.

**- A picture of a cute animal (not mandatory but encouraged)**
None.
