### PR TITLE
fixes 38169: name filter error in swarm network ls

### DIFF
--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -25,7 +25,6 @@ func (c *Cluster) GetNetworks(filter filters.Args) ([]apitypes.NetworkResource, 
 		f = &swarmapi.ListNetworksRequest_Filters{}
 
 		if filter.Contains("name") {
-			f.Names = filter.Get("name")
 			f.NamePrefixes = filter.Get("name")
 		}
 


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
As mentioned in issue #38169, docker network ls --filter 'name=***' can't work for swarm.

For code in https://github.com/moby/moby/blob/master/daemon/cluster/networks.go#L29
The code wants to support filter by name prefix.

But:

For swarm networks such as:
```
root@dockerdemo:~# docker network ls --filter 'scope=swarm'
NETWORK ID          NAME                DRIVER              SCOPE
z18s6f27zrsp        foo_default         overlay             swarm
8bq7s28i7wz5        ingress             overlay             swarm
```
With filter name=<prefix>:
```
root@dockerdemo:~# docker network ls --filter 'scope=swarm' --filter 'name=foo'
NETWORK ID          NAME                DRIVER              SCOPE
```

With filter name=<full_name>
```
root@dockerdemo:~# docker network ls --filter 'scope=swarm' --filter 'name=foo_default'
NETWORK ID          NAME                DRIVER              SCOPE
z18s6f27zrsp        foo_default         overlay             swarm
```

**- How I did it**
We can't use filter by full name and by prefix at the same time.
So, remove filter by full name.

**- How to verify it**
After this patch:
```
root@dockerdemo:~# docker network ls --filter 'scope=swarm' --filter 'name=foo'
NETWORK ID          NAME                DRIVER              SCOPE
z18s6f27zrsp        foo_default         overlay             swarm
root@dockerdemo:~#
```

**- Description for the changelog**
make list network filter by name prefix for swarm work.
Future work:
For doc(https://github.com/docker/cli/blob/ca3d286ded7c1bb0b6d61274b99bf4eb2f98d355/docs/reference/commandline/network_ls.md): we should support filter by a part of name, not only filter by name prefix.

**- A picture of a cute animal (not mandatory but encouraged)**
![n o wn5glp4xjfbgq evcv](https://user-images.githubusercontent.com/783424/48297087-4320e480-e4db-11e8-83c6-4b602c7a89b7.png)
