### PR TITLE
[IGNORE FOR NOW - WIP] Mitigate Restart on RS5+

### DIFF
--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -657,6 +657,10 @@ func (s *DockerSuite) TestEventsFilterImageInContainerAction(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsContainerRestart(c *check.C) {
+	// See block comment in docker_cli_restart_test.go explaining why this test
+	// is temporarily turned on on RS5 and later.
+	testRequires(c, NotWindowsRS5Plus)
+
 	dockerCmd(c, "run", "-d", "--name=testEvent", "--restart=on-failure:3", "busybox", "false")
 
 	// wait until test2 is auto removed.


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This is a mitigation on RS5+ for https://github.com/moby/moby/issues/38114#issuecomment-437956101. The kernel team here is tracking a resource leak issue for a (hopeful) future Windows update. For now, the only reliable way to get the RS5 CI servers running stable is to disable almost all of the restart tests. 

