### PR TITLE
Ignore default address-pools on API < 1.39

### DIFF
--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -27,6 +27,12 @@ func (sr *swarmRouter) initCluster(ctx context.Context, w http.ResponseWriter, r
 		}
 		return errdefs.InvalidParameter(err)
 	}
+	version := httputils.VersionFromContext(ctx)
+	// DefaultAddrPool and SubnetSize were added in API 1.39. Ignore on older API versions.
+	if versions.LessThan(version, "1.39") {
+		req.DefaultAddrPool = nil
+		req.SubnetSize = 0
+	}
 	nodeID, err := sr.backend.Init(req)
 	if err != nil {
 		logrus.Errorf("Error initializing swarm: %v", err)


### PR DESCRIPTION
These options were added in API 1.39, so should be ignored when using an older version of the API.

relates to https://github.com/moby/moby/pull/37558


