### PR TITLE
Add a note about updating runc / runc vendoring

### DIFF
--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 # When updating RUNC_COMMIT, also update runc in vendor.conf accordingly
+# The version of runc should match the version that is used by the containerd
+# version that is used. If you need to update runc, open a pull request in
+# the containerd project first, and update both after that is merged.
 RUNC_COMMIT=9f1e94488e5e478e084fef997f022565b64b01d9
 
 install_runc() {

--- a/vendor.conf
+++ b/vendor.conf
@@ -74,7 +74,11 @@ github.com/pborman/uuid v1.0
 
 google.golang.org/grpc v1.12.0
 
-# This does not need to match RUNC_COMMIT as it is used for helper packages but should be newer or equal
+# The version of runc should match the version that is used by the containerd
+# version that is used. If you need to update runc, open a pull request in
+# the containerd project first, and update both after that is merged.
+# This commit does not need to match RUNC_COMMIT as it is used for helper
+# packages but should be newer or equal.
 github.com/opencontainers/runc 9f1e94488e5e478e084fef997f022565b64b01d9
 github.com/opencontainers/runtime-spec 5684b8af48c1ac3b1451fa499724e30e3c20a294 # v1.0.1-49-g5684b8a
 github.com/opencontainers/image-spec v1.0.1


### PR DESCRIPTION
Containerd should be "leading" when specifying which version of runc to use.
From the RUNC.MD document in the containerd repository
(https://github.com/containerd/containerd/blob/b1e202c32724e82779544365528a1a082
b335553/RUNC.md);

> We depend on a specific runc version when dealing with advanced features. You
> should have a specific runc build for development. The current supported runc
> commit is described in vendor.conf. Please refer to the line that starts with
> github.com/opencontainers/runc.

This patch adds a note to vendor.conf and runc.installer to describe the order
in which runc should be updated.

