### PR TITLE
Add missing default address pool fields to swagger

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2465,6 +2465,22 @@ definitions:
         description: "Whether there is currently a root CA rotation in progress for the swarm"
         type: "boolean"
         example: false
+      DefaultAddrPool:
+        description: |
+          Default Address Pool specifies default subnet pools for global scope networks.
+        type: "array"
+        items:
+          type: "string"
+          format: "CIDR"
+          example: ["10.10.0.0/16", "20.20.0.0/16"]
+      SubnetSize:
+        description: |
+          SubnetSize specifies the subnet size of the networks created from the default subnet pool
+        type: "integer"
+        format: "uint32"
+        maximum: 29
+        default: 24
+        example: 24
 
   JoinTokens:
     description: |


### PR DESCRIPTION
Looks like we missed these. These fields were added in https://github.com/moby/moby/pull/37558, so this will have to be back ported to docs for that version of the API