### PR TITLE
bugfix: fix fail to resolve real graph path from soft link

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1367,14 +1367,9 @@ func (daemon *Daemon) PluginGetter() *plugin.Store {
 // CreateDaemonRoot creates the root for the daemon
 func CreateDaemonRoot(config *config.Config) error {
 	// get the canonical path to the Docker root directory
-	var realRoot string
-	if _, err := os.Stat(config.Root); err != nil && os.IsNotExist(err) {
-		realRoot = config.Root
-	} else {
-		realRoot, err = getRealPath(config.Root)
-		if err != nil {
-			return fmt.Errorf("Unable to get the full path to root (%s): %s", config.Root, err)
-		}
+	realRoot, err := getRealPath(config.Root)
+	if err != nil {
+		return err
 	}
 
 	idMapping, err := setupRemappedRoot(config)


### PR DESCRIPTION
assume that /tmp/link is a soft link to /home/link, if we use
/tmp/link/docker as a graph path, and /tmp/link/docker is not exist,
docker can not get the real path.

```
$ ls -l /tmp/link
lrwxrwxrwx 1 root root 10 11月 20 16:22 /tmp/link -> /home/link

$ service docker restart

$ docker info | grep Root
Docker Root Dir: /tmp/link/docker
```

Signed-off-by: Ace-Tang <aceapril@126.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

make docker get real graph path from a soft link path.

```
create a directory /home/link, and link /tmp/link to it
$ sudo mkdir /home/link

$ sudo ln -s /home/link /tmp/link

$ ls -l /tmp/link
lrwxrwxrwx 1 root root 10 11月 20 16:22 /tmp/link -> /home/link

set /tmp/link/docker(this directory should not be exist before start docker) as a docker graph, restart docker, check docker info
$ docker info | grep Root
WARNING: No swap limit support
Docker Root Dir: /tmp/link/docker
```

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![ff73a6cb1d746b486e54c7fb31d5ff1b](https://user-images.githubusercontent.com/10334997/48762499-2019e000-ece6-11e8-91cd-d315adcab1c1.jpg)

