### PR TITLE
Update dockerd default network mtu

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1249,6 +1249,7 @@ func setDefaultMtu(conf *config.Config) {
 		return
 	}
 	conf.Mtu = getMinimumNetworkMtu()
+	logrus.Warnf("Network MTU not configured, defaulting to %d, which may be suboptimal", conf.Mtu)
 }
 
 // IsShuttingDown tells whether the daemon is shutting down or not

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1248,7 +1248,7 @@ func setDefaultMtu(conf *config.Config) {
 	if conf.Mtu != 0 {
 		return
 	}
-	conf.Mtu = config.DefaultNetworkMtu
+	conf.Mtu = getMinimumNetworkMtu()
 }
 
 // IsShuttingDown tells whether the daemon is shutting down or not

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1546,39 +1546,6 @@ func getMinimumNetworkMtu() int {
 		}
 	}
 
-	// mtu information config of Route config
-	if routes, err := netlink.RouteList(nil, 0); err == nil {
-		for _, route := range routes {
-			// default route with "advmss" or "mtu" configured
-			if route.AdvMSS > 0 {
-				// IP Header Size + TCP Header Size
-				if tmpMtu := route.AdvMSS + 40; tmpMtu > minimumNetworkMtu && tmpMtu < minNetworkMtu {
-					minNetworkMtu = tmpMtu
-				}
-			}
-			if route.MTU > 0 && route.MTU > minimumNetworkMtu && route.MTU < minNetworkMtu {
-				minNetworkMtu = route.MTU
-			}
-			// Special Route for special network with "advmss" or "mtu" configured
-			// for example: ip route add 10.1.0.0/16 via 10.1.0.2 advmss 1360 mtu 1400
-			if route.Dst == nil {
-				continue
-			}
-			if rs, err := netlink.RouteGet(route.Dst.IP); err == nil {
-				for _, r := range rs {
-					if r.AdvMSS > 0 {
-						// IP Header Size + TCP Header Size
-						if tmpMtu := r.AdvMSS + 40; tmpMtu > minimumNetworkMtu && tmpMtu < minNetworkMtu {
-							minNetworkMtu = tmpMtu
-						}
-					}
-					if r.MTU > 0 && r.MTU > minimumNetworkMtu && r.MTU < minNetworkMtu {
-						minNetworkMtu = r.MTU
-					}
-				}
-			}
-		}
-	}
 	if minNetworkMtu > maximumNetworkMtu {
 		return config.DefaultNetworkMtu
 	}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -664,3 +664,7 @@ func (daemon *Daemon) initRuntimes(_ map[string]types.Runtime) error {
 
 func setupResolvConf(config *config.Config) {
 }
+
+func getMinimumNetworkMtu() int {
+	return config.DefaultNetworkMtu
+}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Set default network mtu as the minimum of
system's available interfaces's network mtu,
not always 1500

**- How I did it**
When docker start, if "mtu" didn't config,
get system's all avaliable interfaces's mtu,
find the minimum value.

**- How to verify it**
Consider this system interface information output

```
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: ens33: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1400 qdisc pfifo_fast state UP group default qlen 1000
    link/ether c3:0b:39:56:2c:d1 brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.3/24 brd 10.0.2.3.255 scope global dynamic ens33
       valid_lft 1285sec preferred_lft 1285sec
    inet6 fe80::88a6:b4e3:8129:5223/64 scope link
       valid_lft forever preferred_lft forever
3: ens34: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1400 qdisc pfifo_fast state UP group default qlen 1000
    link/ether c3:0c:29:81:af:de brd ff:ff:ff:ff:ff:ff
    inet 10.0.0.3/24 brd 10.0.0.255 scope global dynamic ens34
       valid_lft 979sec preferred_lft 979sec
    inet6 fe80::33cd:677e:6255:22e3/64 scope link
       valid_lft forever preferred_lft forever
```

When "dockerd" start and didn't config "mtu",
the default network mtu will be **1400** (min(1400, 1500, 65536)),
instead of **1500**, and this will affect all container run under this "dockerd".

This can prevent some network problem cause by Incorrect network mtu,
especially when interface configured network mtu less than **1500**
and user didn't config "mtu" when start dockerd.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Set default network mtu as the minimum of
system's available interfaces's network mtu,
not always 1500

**- A picture of a cute animal (not mandatory but encouraged)**

