### PR TITLE
Update containerd to v1.2.1-rc.0

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=aa537a67b3a9026c423a63dbaf71e4cc0776b2ad # v1.2.0-13-g8afcade1
+CONTAINERD_COMMIT=de1f167ab96338a9f5c2b17347abf84bdf1dd411 # v1.2.1-rc.0
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/vendor.conf
+++ b/vendor.conf
@@ -118,7 +118,7 @@ github.com/googleapis/gax-go v2.0.0
 google.golang.org/genproto 694d95ba50e67b2e363f3483057db5d4910c18f9
 
 # containerd
-github.com/containerd/containerd aa537a67b3a9026c423a63dbaf71e4cc0776b2ad # v1.2.0
+github.com/containerd/containerd de1f167ab96338a9f5c2b17347abf84bdf1dd411 # v1.2.1-rc.0
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
 github.com/containerd/cgroups 5e610833b72089b37d0e615de9a92dfc043757c2

--- a/vendor/github.com/containerd/containerd/README.md
+++ b/vendor/github.com/containerd/containerd/README.md
@@ -224,8 +224,7 @@ This will be the best place to discuss design and implementation.
 
 For sync communication we have a community slack with a #containerd channel that everyone is welcome to join and chat about development.
 
-**Slack:** Catch us in the #containerd and #containerd-dev channels on dockercommunity.slack.com.
-[Click here for an invite to docker community slack.](https://join.slack.com/t/dockercommunity/shared_invite/enQtNDY4MDc1Mzc0MzIwLTgxZDBlMmM4ZGEyNDc1N2FkMzlhODJkYmE1YTVkYjM1MDE3ZjAwZjBkOGFlOTJkZjRmZGYzNjYyY2M3ZTUxYzQ)
+**Slack:** https://join.slack.com/t/dockercommunity/shared_invite/enQtNDM4NjAwNDMyOTUwLWZlMDZmYWRjZjk4Zjc5ZGQ5NWZkOWI1Yjk2NGE3ZWVlYjYxM2VhYjczOWIyZDFhZTE3NTUwZWQzMjhmNGYyZTg
 
 ### Reporting security issues
 
@@ -250,8 +249,3 @@ Please find all these core project documents, including the:
  * and [Contributing guidelines](https://github.com/containerd/project/blob/master/CONTRIBUTING.md)
 
 information in our [`containerd/project`](https://github.com/containerd/project) repository.
-
-## Adoption
-
-Interested to see who is using containerd? Are you using containerd in a project?
-Please add yourself via pull request to our [ADOPTERS.md](./ADOPTERS.md) file.

--- a/vendor/github.com/containerd/containerd/remotes/docker/resolver.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/resolver.go
@@ -75,7 +75,7 @@ type ResolverOptions struct {
 
 	// Credentials provides username and secret given a host.
 	// If username is empty but a secret is given, that secret
-	// is interpreted as a long lived token.
+	// is interpretted as a long lived token.
 	// Deprecated: use Authorizer
 	Credentials func(string) (string, string, error)
 

--- a/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/init.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/init.go
@@ -356,6 +356,9 @@ func (p *Init) kill(ctx context.Context, signal uint32, all bool) error {
 
 // KillAll processes belonging to the init process
 func (p *Init) KillAll(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	err := p.runtime.Kill(ctx, p.id, int(syscall.SIGKILL), &runc.KillOpts{
 		All: true,
 	})

--- a/vendor/github.com/containerd/containerd/runtime/v1/shim/service_linux.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/shim/service_linux.go
@@ -49,9 +49,11 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 		cwg.Add(1)
 		go func() {
 			cwg.Done()
-			p := bufPool.Get().(*[]byte)
-			defer bufPool.Put(p)
-			io.CopyBuffer(epollConsole, in, *p)
+			bp := bufPool.Get().(*[]byte)
+			defer bufPool.Put(bp)
+			io.CopyBuffer(epollConsole, in, *bp)
+			// we need to shutdown epollConsole when pipe broken
+			epollConsole.Shutdown(p.epoller.CloseConsole)
 		}()
 	}
 

--- a/vendor/github.com/containerd/containerd/vendor.conf
+++ b/vendor/github.com/containerd/containerd/vendor.conf
@@ -21,7 +21,7 @@ github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 github.com/golang/protobuf v1.1.0
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353 # v1.0.1-45-geba862d
 github.com/opencontainers/runc 10d38b660a77168360df3522881e2dc2be5056bd
-github.com/sirupsen/logrus v1.0.3
+github.com/sirupsen/logrus v1.0.0
 github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
 golang.org/x/net b3756b4b77d7b13260a0a2ec658753cf48922eac
 google.golang.org/grpc v1.12.0
@@ -43,7 +43,7 @@ github.com/google/go-cmp v0.1.0
 go.etcd.io/bbolt v1.3.1-etcd.8
 
 # cri dependencies
-github.com/containerd/cri f913714917d2456d7e65a0be84962b1ce8acb487 # release/1.2 branch
+github.com/containerd/cri 2bb57d27203d82fc79c496aea724aec593b2705a # release/1.2 branch
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0
@@ -81,9 +81,9 @@ k8s.io/kubernetes v1.12.0
 k8s.io/utils cd34563cd63c2bd7c6fe88a73c4dcf34ed8a67cb
 
 # zfs dependencies
-github.com/containerd/zfs 9f6ef3b1fe5144bd91fe5855b4eba81bc0d17d03
+github.com/containerd/zfs 9a0b8b8b5982014b729cd34eb7cd7a11062aa6ec
 github.com/mistifyio/go-zfs 166add352731e515512690329794ee593f1aaff2
 github.com/pborman/uuid c65b2f87fee37d1c7854c9164a450713c28d50cd
 
 # aufs dependencies
-github.com/containerd/aufs da3cf16bfbe68ba8f114f1536a05c01528a25434
+github.com/containerd/aufs ffa39970e26ad01d81f540b21e65f9c1841a5f92


### PR DESCRIPTION
The previous update used a commit from master. Now that all the fixes are backported to the containerd 1.2 release branch, we can switch back to that branch.

planning to backport this to docker engine 18.09.1


full diff for the containerd runtime; https://github.com/containerd/containerd/compare/aa537a67b3a9026c423a63dbaf71e4cc0776b2ad..v1.2.0-rc.0
