### PR TITLE
Configure log-format earlier, and small refactor

### DIFF
--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -146,7 +146,6 @@ func TestLoadDaemonCliConfigWithLogLevel(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, loadedConfig != nil)
 	assert.Check(t, is.Equal("warn", loadedConfig.LogLevel))
-	assert.Check(t, is.Equal(logrus.WarnLevel, logrus.GetLevel()))
 }
 
 func TestLoadDaemonConfigWithEmbeddedOptions(t *testing.T) {
@@ -179,4 +178,23 @@ func TestLoadDaemonConfigWithRegistryOptions(t *testing.T) {
 	assert.Check(t, is.Len(loadedConfig.AllowNondistributableArtifacts, 1))
 	assert.Check(t, is.Len(loadedConfig.Mirrors, 1))
 	assert.Check(t, is.Len(loadedConfig.InsecureRegistries, 1))
+}
+
+func TestConfigureDaemonLogs(t *testing.T) {
+	conf := &config.Config{}
+	err := configureDaemonLogs(conf)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(logrus.InfoLevel, logrus.GetLevel()))
+
+	conf.LogLevel = "warn"
+	err = configureDaemonLogs(conf)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(logrus.WarnLevel, logrus.GetLevel()))
+
+	conf.LogLevel = "foobar"
+	err = configureDaemonLogs(conf)
+	assert.Error(t, err, "unable to parse logging level: foobar")
+
+	// log level should not be changed after a failure
+	assert.Check(t, is.Equal(logrus.WarnLevel, logrus.GetLevel()))
 }

--- a/cmd/dockerd/docker.go
+++ b/cmd/dockerd/docker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/dockerversion"
+	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/docker/pkg/term"
 	"github.com/moby/buildkit/util/apicaps"
@@ -53,6 +54,12 @@ func main() {
 	if reexec.Init() {
 		return
 	}
+
+	// initial log formatting; this setting is updated after the daemon configuration is loaded.
+	logrus.SetFormatter(&logrus.TextFormatter{
+		TimestampFormat: jsonmessage.RFC3339NanoFixed,
+		FullTimestamp:   true,
+	})
 
 	// Set terminal emulation based on platform as required.
 	_, stdout, stderr := term.StdStreams()

--- a/cmd/dockerd/options.go
+++ b/cmd/dockerd/options.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -9,7 +8,6 @@ import (
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/opts"
 	"github.com/docker/go-connections/tlsconfig"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
 
@@ -104,19 +102,5 @@ func (o *daemonOptions) SetDefaultOptions(flags *pflag.FlagSet) {
 				tlsOptions.KeyFile = ""
 			}
 		}
-	}
-}
-
-// setLogLevel sets the logrus logging level
-func setLogLevel(logLevel string) {
-	if logLevel != "" {
-		lvl, err := logrus.ParseLevel(logLevel)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to parse logging level: %s\n", logLevel)
-			os.Exit(1)
-		}
-		logrus.SetLevel(lvl)
-	} else {
-		logrus.SetLevel(logrus.InfoLevel)
 	}
 }


### PR DESCRIPTION
Some messages are logged before the logrus format was set, therefore resulting in inconsistent log-message formatting during startup;

Before this patch;

```
dockerd --experimental
WARN[0000] Running experimental build
INFO[2018-11-24T11:24:05.615249610Z] libcontainerd: started new containerd process  pid=132
INFO[2018-11-24T11:24:05.615348322Z] parsed scheme: "unix"                         module=grpc
...
```

With this patch applied;

```
dockerd --experimental
WARN[2018-11-24T13:41:51.199057259Z] Running experimental build
INFO[2018-11-24T13:41:51.200412645Z] libcontainerd: started new containerd process  pid=293
INFO[2018-11-24T13:41:51.200523051Z] parsed scheme: "unix"                         module=grpc
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
- Fix logging format during startup [moby/moby#38266](https://github.com/moby/moby/pull/38266)
```


