### PR TITLE
Fix volume CreatedAt being altered on initialization

### DIFF
--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -90,7 +90,7 @@ func (v *localVolume) mount() error {
 }
 
 func (v *localVolume) CreatedAt() (time.Time, error) {
-	fileInfo, err := os.Stat(v.path)
+	fileInfo, err := os.Stat(filepath.Dir(v.path))
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/volume/local/local_windows.go
+++ b/volume/local/local_windows.go
@@ -37,7 +37,7 @@ func (v *localVolume) mount() error {
 }
 
 func (v *localVolume) CreatedAt() (time.Time, error) {
-	fileInfo, err := os.Stat(v.path)
+	fileInfo, err := os.Stat(filepath.Dir(v.path))
 	if err != nil {
 		return time.Time{}, err
 	}


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/38274
- fixes https://github.com/moby/moby/issues/44364

The CreatedAt date was determined from the volume's `_data` directory (`/var/lib/docker/volumes/<volumename>/_data`). However, when initializing a volume, this directory is updated, causing the date to change.

Instead of using the `_data` directory, use its parent directory, which is not updated afterwards, and should reflect the time that the volume was created.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


