### PR TITLE
Windows: Tie busybox to specific version

### DIFF
--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -776,9 +776,9 @@ Try {
                 # This is a temporary hack for nanoserver
                 if ($env:WINDOWS_BASE_IMAGE -ne "microsoft/windowsservercore") {
                     Write-Host -ForegroundColor Red "HACK HACK HACK - Building 64-bit nanoserver busybox image"
-                    $(& "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" build -t busybox https://raw.githubusercontent.com/jhowardmsft/busybox64/master/Dockerfile | Out-Host)
+                    $(& "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" build -t busybox https://raw.githubusercontent.com/jhowardmsft/busybox64/v1.0/Dockerfile | Out-Host)
                 } else {
-                    $(& "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" build -t busybox https://raw.githubusercontent.com/jhowardmsft/busybox/master/Dockerfile | Out-Host)
+                    $(& "$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" build -t busybox https://raw.githubusercontent.com/jhowardmsft/busybox/v1.0/Dockerfile | Out-Host)
                 }
                 $ErrorActionPreference = "Stop"
                 if (-not($LastExitCode -eq 0)) {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Rather than just use "master".  (An aside, I need to bump busybox to a v1.1 shortly which will break CI until I put a further PR into moby to fix up those tests. And the best bit is that the tests will remove the 'windowsisms' and act exactly like the Linux versions).

@thaJeztah @vdemeester @johnstep PTAL
