### PR TITLE
Minor docs touch-ups for KernelMemoryTCP support

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -429,8 +429,9 @@ definitions:
         description: "Kernel memory limit in bytes."
         type: "integer"
         format: "int64"
+        example: 209715200
       KernelMemoryTCP:
-        description: "Sets hard limit for kernel TCP buffer memory."
+        description: "Hard limit for kernel TCP buffer memory (in bytes)."
         type: "integer"
         format: "int64"
       MemoryReservation:

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -329,7 +329,7 @@ type Resources struct {
 	DeviceCgroupRules    []string        // List of rule to be added to the device cgroup
 	DiskQuota            int64           // Disk limit (in bytes)
 	KernelMemory         int64           // Kernel memory limit (in bytes)
-	KernelMemoryTCP      int64           // Sets hard limit for kernel TCP buffer memory
+	KernelMemoryTCP      int64           // Hard limit for kernel TCP buffer memory (in bytes)
 	MemoryReservation    int64           // Memory soft limit (in bytes)
 	MemorySwap           int64           // Total memory usage (memory + swap); set `-1` to enable unlimited swap
 	MemorySwappiness     *int64          // Tuning container memory swappiness behaviour


### PR DESCRIPTION
follow up for https://github.com/moby/moby/pull/37043 with some minor nits that were remaining from the review