### PR TITLE
builder: fix inefficient networking config

### DIFF
--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/network"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 )
 
 const networkName = "bridge"
@@ -100,10 +101,10 @@ func (iface *lnInterface) Set(s *specs.Spec) {
 
 func (iface *lnInterface) Close() error {
 	<-iface.ready
-	err := iface.sbx.Delete()
-	if iface.err != nil {
-		// iface.err takes precedence over cleanup errors
-		return iface.err
-	}
-	return err
+	go func() {
+		if err := iface.sbx.Delete(); err != nil {
+			logrus.Errorf("failed to delete builder network sandbox: %v", err)
+		}
+	}()
+	return iface.err
 }

--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@ -63,13 +63,13 @@ func (iface *lnInterface) init(c libnetwork.NetworkController, n libnetwork.Netw
 	defer close(iface.ready)
 	id := identity.NewID()
 
-	ep, err := n.CreateEndpoint(id)
+	ep, err := n.CreateEndpoint(id, libnetwork.CreateOptionDisableResolution())
 	if err != nil {
 		iface.err = err
 		return
 	}
 
-	sbx, err := c.NewSandbox(id)
+	sbx, err := c.NewSandbox(id, libnetwork.OptionUseExternalKey())
 	if err != nil {
 		iface.err = err
 		return


### PR DESCRIPTION
The default config performs badly and causes inefficient work in the callback hook. Set the options that would be enabled in default bridge network for regular containers to fix that.

The second commit is lower priority and just speeds up the deletion path a bit. I think this is acceptable optimization for builder path.

The performance difference is significant, always at least 100-200ms and in one machine where I tested, the difference is almost a second per container.

@fcrisciani @tiborvass @AkihiroSuda @andrewhsu 