### PR TITLE
Fix mistake in docs/contributing/test.md running specific unit test #38096

### DIFF
--- a/docs/contributing/test.md
+++ b/docs/contributing/test.md
@@ -148,7 +148,7 @@ You can use the `TESTDIRS` environment variable to run unit tests for
 a single package.
 
 ```bash
-$ TESTDIRS='opts' make test-unit
+$ TESTDIRS='github.com/docker/docker/opts' make test-unit
 ```
 
 You can also use the `TESTFLAGS` environment variable to run a single test. The
@@ -163,7 +163,7 @@ On unit tests, it's better to use `TESTFLAGS` in combination with
 `TESTDIRS` to make it quicker to run a specific test.
 
 ```bash
-$ TESTDIRS='opts' TESTFLAGS='-test.run ^TestValidateIPAddress$' make test-unit
+$ TESTDIRS='github.com/docker/docker/opts' TESTFLAGS='-test.run $^TestValidateIPAddress$' make test-unit
 ```
 
 ## Run integration tests


### PR DESCRIPTION
**- What I did**
Fixes #38096

**- How I did it**
Updating the docs with more specific path when running specific unit tests

**- How to verify it**
Running the code bellow.

```sh
$ TESTDIRS='github.com/docker/docker/opts' TESTFLAGS='-test.run $^TestValidateIPAddress$' make test-unit
```

**- Description for the changelog**
Corrected running specific unit tests script in docs

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/6409113/49224742-597adb80-f3c9-11e8-9b23-760de3837161.png)