### PR TITLE
Revert "Add limit to page size used by overlay2 driver"

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -604,15 +604,6 @@ func (d *Driver) Get(id, mountLabel string) (_ containerfs.ContainerFS, retErr e
 
 	pageSize := unix.Getpagesize()
 
-	// Go can return a larger page size than supported by the system
-	// as of go 1.7. This will be fixed in 1.8 and this block can be
-	// removed when building with 1.8.
-	// See https://github.com/golang/go/commit/1b9499b06989d2831e5b156161d6c07642926ee1
-	// See https://github.com/docker/docker/issues/27384
-	if pageSize > 4096 {
-		pageSize = 4096
-	}
-
 	// Use relative paths and mountFrom when the mount data has exceeded
 	// the page size. The mount syscall fails if the mount data cannot
 	// fit within a page and relative links make the mount data much


### PR DESCRIPTION
This reverts commit 520034e35b463e8c9d69ac78b52a4e5df958bc04 (https://github.com/moby/moby/pull/27520)

Go 1.8 has shipped, and we're now on Go 1.11, so this should be ok to remove

