### PR TITLE
Masked /proc/asound

### DIFF
--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -114,6 +114,7 @@ func DefaultLinuxSpec() specs.Spec {
 
 	s.Linux = &specs.Linux{
 		MaskedPaths: []string{
+			"/proc/asound",
 			"/proc/acpi",
 			"/proc/kcore",
 			"/proc/keys",
@@ -125,7 +126,6 @@ func DefaultLinuxSpec() specs.Spec {
 			"/sys/firmware",
 		},
 		ReadonlyPaths: []string{
-			"/proc/asound",
 			"/proc/bus",
 			"/proc/fs",
 			"/proc/irq",


### PR DESCRIPTION
**- What I did**
Fixes #38285

**- How I did it**
Moved /proc/asound to `MaskedPath`

**- How to verify it**
Start some video or audio like Youtube or Spotify

Run:

```bash
$ docker run --rm ubuntu:latest bash -c "sleep 7; cat /proc/asound/card*/pcm*p/sub*/status | grep state | cut -d ' ' -f2 | grep RUNNING || echo 'not running'"
```
This need to print 'not running'

**- Description for the changelog**
Moved /proc/asound to MaskedPath

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6409113/49261334-d8ebc780-f428-11e8-819d-44bac9aff83d.png)

