### PR TITLE
[WIP] Attach: use epoll to check for client close

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -59,7 +59,7 @@ type monitorBackend interface {
 
 // attachBackend includes function to implement to provide container attaching functionality.
 type attachBackend interface {
-	ContainerAttach(name string, c *backend.ContainerAttachConfig) error
+	ContainerAttach(ctx context.Context, name string, c *backend.ContainerAttachConfig) error
 }
 
 // systemBackend includes functions to implement to provide system wide containers functionality

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -59,7 +59,7 @@ type ImageBackend interface {
 // ExecBackend contains the interface methods required for executing containers
 type ExecBackend interface {
 	// ContainerAttachRaw attaches to container.
-	ContainerAttachRaw(cID string, stdin io.ReadCloser, stdout, stderr io.Writer, stream bool, attached chan struct{}) error
+	ContainerAttachRaw(ctx context.Context, cID string, stdin io.ReadCloser, stdout, stderr io.Writer, stream bool, attached chan struct{}) error
 	// ContainerCreate creates a new Docker container and returns potential warnings
 	ContainerCreate(config types.ContainerCreateConfig) (container.ContainerCreateCreatedBody, error)
 	// ContainerRm removes a container specified by `id`.

--- a/builder/dockerfile/containerbackend.go
+++ b/builder/dockerfile/containerbackend.go
@@ -47,7 +47,7 @@ func (c *containerManager) Run(ctx context.Context, cID string, stdout, stderr i
 	attached := make(chan struct{})
 	errCh := make(chan error)
 	go func() {
-		errCh <- c.backend.ContainerAttachRaw(cID, nil, stdout, stderr, true, attached)
+		errCh <- c.backend.ContainerAttachRaw(ctx, cID, nil, stdout, stderr, true, attached)
 	}()
 	select {
 	case err := <-errCh:

--- a/builder/dockerfile/mockbackend_test.go
+++ b/builder/dockerfile/mockbackend_test.go
@@ -24,7 +24,7 @@ type MockBackend struct {
 	makeImageCacheFunc  func(cacheFrom []string) builder.ImageCache
 }
 
-func (m *MockBackend) ContainerAttachRaw(cID string, stdin io.ReadCloser, stdout, stderr io.Writer, stream bool, attached chan struct{}) error {
+func (m *MockBackend) ContainerAttachRaw(ctx context.Context, cID string, stdin io.ReadCloser, stdout, stderr io.Writer, stream bool, attached chan struct{}) error {
 	return nil
 }
 

--- a/container/stream/attach.go
+++ b/container/stream/attach.go
@@ -57,7 +57,7 @@ func (c *Config) AttachStreams(cfg *AttachConfig) {
 }
 
 // CopyStreams starts goroutines to copy data in and out to/from the container
-func (c *Config) CopyStreams(ctx context.Context, cfg *AttachConfig) <-chan error {
+func CopyStreams(ctx context.Context, cfg *AttachConfig) <-chan error {
 	var group errgroup.Group
 
 	// Connect stdin of container to the attach stdin stream.

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -243,7 +243,7 @@ func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.R
 		CloseStdin: true,
 	}
 	ec.StreamConfig.AttachStreams(&attachConfig)
-	attachErr := ec.StreamConfig.CopyStreams(ctx, &attachConfig)
+	attachErr := stream.CopyStreams(ctx, &attachConfig)
 
 	// Synchronize with libcontainerd event loop
 	ec.Lock()


### PR DESCRIPTION
This prevents leaks on attach where there is no data to read from the
stdio streams of the container, and as such the `io.Copy` just blocks.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

