### PR TITLE
daemon: switch to semaphore-gated WaitGroup for startup tasks

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -40,6 +40,11 @@ const (
 	windowsMaxCPUPercent = 100
 )
 
+// Windows doesn't really have rlimits.
+func adjustParallelLimit(n int, limit int) int {
+	return limit
+}
+
 // Windows has no concept of an execution state directory. So use config.Root here.
 func getPluginExecRoot(root string) string {
 	return filepath.Join(root, "plugins")


### PR DESCRIPTION
Many startup tasks have to run for each container, and thus using a
WaitGroup (which doesn't have a limit to the number of parallel tasks)
can result in Docker exceeding the NOFILE limit quite trivially. A more
optimal solution is to have a parallelism limit.

In addition, several startup tasks were not parallelised previously
which resulted in very long startup times. According to my testing, 20K
dead containers resulted in ~6 minute startup times (during which time
Docker is completely unusable).

This patch fixes both issues, and the parallelStartupTimes factor chosen
(128 * NumCPU) is based on my own significant testing of the 20K
container case. This patch (on my machines) reduces the startup time
from 6 minutes to less than a minute (ideally this could be further
reduced by removing the need to scan all dead containers on startup --
but that's beyond the scope of this patchset).

In order to avoid the NOFILE limit problem, we also detect this
on-startup and if NOFILE < 2*128*NumCPU we will reduce the parallelism
factor to avoid hitting NOFILE limits (but also emit a warning since
this is almost certainly a mis-configuration).

![benchmarks](https://user-images.githubusercontent.com/2888411/49456934-04fab480-f83e-11e8-969d-69f85873bad4.png)

###### Benchmarks were done on an 8-core machine.

[![cat by Danny VB](https://farm4.staticflickr.com/3488/4051998735_5b4863ac11.jpg)](https://flic.kr/p/7b4y4a)

###### [cat](https://flic.kr/p/7b4y4a) by [Danny VB](https://www.flickr.com/photos/parismadrid/)

Signed-off-by: Aleksa Sarai <asarai@suse.de>