### PR TITLE
Fix swarm leave hanging

### DIFF
--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -300,7 +300,7 @@ func (n *nodeRunner) Stop() error {
 	if n.swarmNode == nil {
 		// even though the swarm node is nil we still may need
 		// to send a node leave event to perform any cleanup required.
-		if(n.cluster != nil) {
+		if n.cluster != nil {
 			n.cluster.SendClusterEvent(lncluster.EventNodeLeave)
 		}
 		n.mu.Unlock()

--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -298,6 +298,11 @@ func (n *nodeRunner) Stop() error {
 		n.cancelReconnect = nil
 	}
 	if n.swarmNode == nil {
+		// even though the swarm node is nil we still may need
+		// to send a node leave event to perform any cleanup required.
+		if(n.cluster != nil) {
+			n.cluster.SendClusterEvent(lncluster.EventNodeLeave))
+		}
 		n.mu.Unlock()
 		return nil
 	}

--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -301,7 +301,7 @@ func (n *nodeRunner) Stop() error {
 		// even though the swarm node is nil we still may need
 		// to send a node leave event to perform any cleanup required.
 		if(n.cluster != nil) {
-			n.cluster.SendClusterEvent(lncluster.EventNodeLeave))
+			n.cluster.SendClusterEvent(lncluster.EventNodeLeave)
 		}
 		n.mu.Unlock()
 		return nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This fixes a problem where if a node is removed on one leader and a ```docker swarm leave --force``` command is issued on the node the client hangs. The reason for this is the agent has been stopped thanks to the previous node removal command from the swarm leader and then in the DaemonLeavesCluster method in daemon.go it waits for the agent to stop. Since the agent is already stopped this hangs forever. 

This PR fixes the following issue: https://github.com/docker/for-linux/issues/499

**- How I did it**
To fix this I added a call to send the EventNodeLeave event which handles any cleanup when a node leaves. This ensures the agent stopped message is received in DaemonLeavesCluster.

**- How to verify it**
Execute ```docker node rm -f``` on a node in a cluster and then execute ```docker swarm leave -f``` on the node which was removed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

