### PR TITLE
Support adding any log info field to extra attrs

### DIFF
--- a/daemon/logger/factory.go
+++ b/daemon/logger/factory.go
@@ -119,6 +119,7 @@ func GetLogDriver(name string) (Creator, error) {
 var builtInLogOpts = map[string]bool{
 	"mode":            true,
 	"max-buffer-size": true,
+	logInfoKey:        true,
 }
 
 // ValidateLogOpts checks the options for the given log driver. The

--- a/daemon/logger/loginfo_test.go
+++ b/daemon/logger/loginfo_test.go
@@ -1,0 +1,128 @@
+package logger
+
+import (
+	"testing"
+
+	"github.com/docker/docker/errdefs"
+)
+
+func TestExtraAttributes(t *testing.T) {
+	type testCase struct {
+		desc    string
+		info    *Info
+		expect  map[string]string
+		errTest func(*testing.T, error)
+	}
+
+	noErr := func(t *testing.T, err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	invalidParam := func(t *testing.T, err error) {
+		t.Helper()
+		if !errdefs.IsInvalidParameter(err) {
+			t.Fatalf("expected invalid parameter error, got: %T --  %v", err, err)
+		}
+	}
+
+	for _, tc := range []testCase{
+		{desc: "no extra", info: &Info{}, errTest: noErr},
+		{desc: "incorrect field value", info: &Info{Config: map[string]string{logInfoKey: "NotAField"}}, errTest: invalidParam},
+		{
+			desc: "container env",
+			info: &Info{
+				Config:       map[string]string{envKey: "FOO,NOTEXIST"},
+				ContainerEnv: []string{"FOO=foo", "BAR=bar"},
+			},
+			expect:  map[string]string{"FOO": "foo"},
+			errTest: noErr,
+		},
+		{
+			desc: "container env regex",
+			info: &Info{
+				Config:       map[string]string{envRegexKey: "(FOO|BAR)"},
+				ContainerEnv: []string{"FOO=foo", "BAR=bar", "QUUX=quux"},
+			},
+			expect:  map[string]string{"FOO": "foo", "BAR": "bar"},
+			errTest: noErr,
+		},
+		{
+			desc: "container labels",
+			info: &Info{
+				Config:          map[string]string{labelKey: "com.docker.test-a-thing,com.docker.test-not-exist"},
+				ContainerLabels: map[string]string{"com.docker.test-a-thing": "foo"},
+			},
+			expect:  map[string]string{"com.docker.test-a-thing": "foo"},
+			errTest: noErr,
+		},
+		{
+			desc: "with info field", info: &Info{
+				ContainerImageID: "myImage",
+				Config:           map[string]string{logInfoKey: "ContainerImageID"},
+			},
+			expect:  map[string]string{"ContainerImageID": "myImage"},
+			errTest: noErr,
+		},
+		{
+			desc: "with multiple info fields",
+			info: &Info{
+				ContainerImageID:   "myImageID",
+				ContainerImageName: "myImageName",
+				ContainerID:        "myID",
+				Config:             map[string]string{logInfoKey: "ContainerImageID,ContainerImageName,ContainerID"},
+			},
+			expect:  map[string]string{"ContainerID": "myID", "ContainerImageID": "myImageID", "ContainerImageName": "myImageName"},
+			errTest: noErr,
+		},
+		{
+			desc: "all thing things",
+			info: &Info{
+				ContainerID:        "myID",
+				ContainerImageName: "myImage",
+				ContainerImageID:   "myImageID",
+				ContainerLabels:    map[string]string{"com.docker.test-a-thing": "banana"},
+				ContainerEnv:       []string{"FOO=foo", "BAR=bar", "BAZ=baz"},
+				Config: map[string]string{
+					labelKey:    "com.docker.test-a-thing",
+					envKey:      "FOO",
+					envRegexKey: "(FOO|BAR)",
+					logInfoKey:  "ContainerImageName,ContainerID",
+				},
+			},
+			expect: map[string]string{
+				"FOO":                     "foo",
+				"com.docker.test-a-thing": "banana",
+				"BAR":                     "bar",
+				"ContainerImageName":      "myImage",
+				"ContainerID":             "myID",
+			},
+			errTest: noErr,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			tc := tc
+			t.Parallel()
+
+			actual, err := tc.info.ExtraAttributes(nil)
+			tc.errTest(t, err)
+
+			if len(actual) != len(tc.expect) {
+				t.Fatalf("expected:\n%v\n\nactual:\n%v", tc.expect, actual)
+			}
+
+			for k, v := range actual {
+				ev, ok := tc.expect[k]
+				if !ok {
+					t.Fatalf("unexpected key: %s", ev)
+				}
+
+				if v != ev {
+					t.Fatalf("unexpected value for key %q, expected: %q, got: %q", k, ev, v)
+				}
+			}
+		})
+	}
+}

--- a/integration/container/logs_test.go
+++ b/integration/container/logs_test.go
@@ -1,9 +1,13 @@
 package container // import "github.com/docker/docker/integration/container"
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration/internal/container"
@@ -32,4 +36,34 @@ func TestLogsFollowTailEmpty(t *testing.T) {
 
 	_, err = stdcopy.StdCopy(ioutil.Discard, ioutil.Discard, logs)
 	assert.Check(t, err)
+}
+
+func TestLogsExtraLogInfo(t *testing.T) {
+	defer setupTest(t)()
+	client := request.NewAPIClient(t)
+	ctx := context.Background()
+
+	id := container.Run(t, ctx, client, container.WithCmd("echo", "hello"), container.WithLogOpt("loginfo", "ContainerID"))
+
+	logs, err := client.ContainerLogs(ctx, id, types.ContainerLogsOptions{ShowStdout: true, Details: true})
+	assert.Check(t, err)
+	defer logs.Close()
+
+	buf := bytes.NewBuffer(nil)
+	ch := make(chan error, 1)
+	go func() {
+		_, err := stdcopy.StdCopy(buf, buf, logs)
+		ch <- err
+	}()
+
+	select {
+	case err := <-ch:
+		assert.Check(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout waiting for log copy to finish")
+	}
+
+	expected := fmt.Sprintf("ContainerID=%s", id)
+	actual := strings.Fields(buf.String())[0]
+	assert.Equal(t, expected, actual)
 }

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -135,6 +135,20 @@ func WithLogDriver(driver string) func(*TestContainerConfig) {
 	}
 }
 
+// WithLogOpt adds the log option to the log config.
+// First argument is the option key name, second is the value to set.
+func WithLogOpt(key, value string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		if c.HostConfig == nil {
+			c.HostConfig = &containertypes.HostConfig{}
+		}
+		if c.HostConfig.LogConfig.Config == nil {
+			c.HostConfig.LogConfig.Config = make(map[string]string)
+		}
+		c.HostConfig.LogConfig.Config[key] = value
+	}
+}
+
 // WithAutoRemove sets the container to be removed on exit
 func WithAutoRemove(c *TestContainerConfig) {
 	if c.HostConfig == nil {


### PR DESCRIPTION
Adds a new generic log-opt "loginfo" which takes a comma separated list
of field names from the log info struct.

This is somewhat supported by way of log tags, however log tags mean
different things for different drivers and is not always desirable (e.g.
fluentd uses log tags for routing).

This allows populating the "extras" map with any field from the log info
struct.

Note I chose to make sure that the fields used by log tag templates are
the same field names used for extras. This could be extended further to
support some actual templating (via some new log-opt key).


 ---

This is essentially carrying #27859 with a simpler implementation and that doesn't add any new fields for users to have to figure out since it is the same field names as used in templates for log tags.

Closes #27859