### PR TITLE
Ignore xattr errors on copy (fixes #38155)

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/containerd/continuity/fs"
 	"github.com/docker/docker/api/types"
@@ -388,6 +389,18 @@ func (container *Container) DetachAndUnmount(volumeEventLog func(name, action st
 	return container.UnmountVolumes(volumeEventLog)
 }
 
+// ignoreUnsupportedXAttrs ignores errors when extended attributes
+// are not supported
+func ignoreUnsupportedXAttrs() fs.CopyDirOpt {
+	xeh := func(dst, src, xattrKey string, err error) error {
+		if errors.Cause(err) != syscall.ENOTSUP {
+			return err
+		}
+		return nil
+	}
+	return fs.WithXAttrErrorHandler(xeh)
+}
+
 // copyExistingContents copies from the source to the destination and
 // ensures the ownership is appropriately set.
 func copyExistingContents(source, destination string) error {
@@ -399,7 +412,7 @@ func copyExistingContents(source, destination string) error {
 		// destination is not empty, do not copy
 		return nil
 	}
-	return fs.CopyDir(destination, source)
+	return fs.CopyDir(destination, source, ignoreUnsupportedXAttrs())
 }
 
 // TmpfsMounts returns the list of tmpfs mounts

--- a/vendor.conf
+++ b/vendor.conf
@@ -120,7 +120,7 @@ google.golang.org/genproto 694d95ba50e67b2e363f3483057db5d4910c18f9
 # containerd
 github.com/containerd/containerd 9b32062dc1f5a7c2564315c269b5059754f12b9d # v1.2.1
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
-github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
+github.com/containerd/continuity 004b46473808b3e7a4a3049c20e4376c91eb966d
 github.com/containerd/cgroups 5e610833b72089b37d0e615de9a92dfc043757c2
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
 github.com/containerd/cri 0ca1e3c2b73b5c38e72f29bb76338d0078b23d6c # release/1.2 branch

--- a/vendor/github.com/containerd/continuity/LICENSE
+++ b/vendor/github.com/containerd/continuity/LICENSE
@@ -1,6 +1,7 @@
+
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -175,28 +176,16 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright {yyyy} {name of copyright owner}
+   Copyright The containerd Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/vendor/github.com/containerd/continuity/README.md
+++ b/vendor/github.com/containerd/continuity/README.md
@@ -72,3 +72,13 @@ If you change the proto file you will need to rebuild the generated Go with `go 
 ```console
 $ go generate ./proto
 ```
+
+## Project details
+
+continuity is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
+As a containerd sub-project, you will find the:
+ * [Project governance](https://github.com/containerd/project/blob/master/GOVERNANCE.md),
+ * [Maintainers](https://github.com/containerd/project/blob/master/MAINTAINERS),
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/master/CONTRIBUTING.md)
+
+information in our [`containerd/project`](https://github.com/containerd/project) repository.

--- a/vendor/github.com/containerd/continuity/fs/copy_linux.go
+++ b/vendor/github.com/containerd/continuity/fs/copy_linux.go
@@ -59,6 +59,8 @@ func copyFileInfo(fi os.FileInfo, name string) error {
 	return nil
 }
 
+const maxSSizeT = int64(^uint(0) >> 1)
+
 func copyFileContent(dst, src *os.File) error {
 	st, err := src.Stat()
 	if err != nil {
@@ -71,7 +73,16 @@ func copyFileContent(dst, src *os.File) error {
 	dstFd := int(dst.Fd())
 
 	for size > 0 {
-		n, err := unix.CopyFileRange(srcFd, nil, dstFd, nil, int(size), 0)
+		// Ensure that we are never trying to copy more than SSIZE_MAX at a
+		// time and at the same time avoids overflows when the file is larger
+		// than 4GB on 32-bit systems.
+		var copySize int
+		if size > maxSSizeT {
+			copySize = int(maxSSizeT)
+		} else {
+			copySize = int(size)
+		}
+		n, err := unix.CopyFileRange(srcFd, nil, dstFd, nil, copySize, 0)
 		if err != nil {
 			if (err != unix.ENOSYS && err != unix.EXDEV) || !first {
 				return errors.Wrap(err, "copy file range failed")
@@ -90,18 +101,34 @@ func copyFileContent(dst, src *os.File) error {
 	return nil
 }
 
-func copyXAttrs(dst, src string) error {
+func copyXAttrs(dst, src string, xeh XAttrErrorHandler) error {
 	xattrKeys, err := sysx.LListxattr(src)
 	if err != nil {
-		return errors.Wrapf(err, "failed to list xattrs on %s", src)
+		e := errors.Wrapf(err, "failed to list xattrs on %s", src)
+		if xeh != nil {
+			e = xeh(dst, src, "", e)
+		}
+		return e
 	}
 	for _, xattr := range xattrKeys {
 		data, err := sysx.LGetxattr(src, xattr)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get xattr %q on %s", xattr, src)
+			e := errors.Wrapf(err, "failed to get xattr %q on %s", xattr, src)
+			if xeh != nil {
+				if e = xeh(dst, src, xattr, e); e == nil {
+					continue
+				}
+			}
+			return e
 		}
 		if err := sysx.LSetxattr(dst, xattr, data, 0); err != nil {
-			return errors.Wrapf(err, "failed to set xattr %q on %s", xattr, dst)
+			e := errors.Wrapf(err, "failed to set xattr %q on %s", xattr, dst)
+			if xeh != nil {
+				if e = xeh(dst, src, xattr, e); e == nil {
+					continue
+				}
+			}
+			return e
 		}
 	}
 

--- a/vendor/github.com/containerd/continuity/fs/copy_unix.go
+++ b/vendor/github.com/containerd/continuity/fs/copy_unix.go
@@ -69,18 +69,34 @@ func copyFileContent(dst, src *os.File) error {
 	return err
 }
 
-func copyXAttrs(dst, src string) error {
+func copyXAttrs(dst, src string, xeh XAttrErrorHandler) error {
 	xattrKeys, err := sysx.LListxattr(src)
 	if err != nil {
-		return errors.Wrapf(err, "failed to list xattrs on %s", src)
+		e := errors.Wrapf(err, "failed to list xattrs on %s", src)
+		if xeh != nil {
+			e = xeh(dst, src, "", e)
+		}
+		return e
 	}
 	for _, xattr := range xattrKeys {
 		data, err := sysx.LGetxattr(src, xattr)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get xattr %q on %s", xattr, src)
+			e := errors.Wrapf(err, "failed to get xattr %q on %s", xattr, src)
+			if xeh != nil {
+				if e = xeh(dst, src, xattr, e); e == nil {
+					continue
+				}
+			}
+			return e
 		}
 		if err := sysx.LSetxattr(dst, xattr, data, 0); err != nil {
-			return errors.Wrapf(err, "failed to set xattr %q on %s", xattr, dst)
+			e := errors.Wrapf(err, "failed to set xattr %q on %s", xattr, dst)
+			if xeh != nil {
+				if e = xeh(dst, src, xattr, e); e == nil {
+					continue
+				}
+			}
+			return e
 		}
 	}
 

--- a/vendor/github.com/containerd/continuity/fs/copy_windows.go
+++ b/vendor/github.com/containerd/continuity/fs/copy_windows.go
@@ -40,7 +40,7 @@ func copyFileContent(dst, src *os.File) error {
 	return err
 }
 
-func copyXAttrs(dst, src string) error {
+func copyXAttrs(dst, src string, xeh XAttrErrorHandler) error {
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Dimitris Mandalidis <dimitris.mandalidis@gmail.com>

**- What I did**
Allowed copy an existing folder, ignoring xattr set errors when the target filesystem doesn't support xattr.

**- How I did it**
Updated containerd/continuity to take advantage of newly-introduced `CopyDirOpt`. Passed `fs.WithAllowXAttrErrors` at `fs.CopyDir` of `container_unix.go#copyExistingContents` to ignore xattr set errors

**- How to verify it**
* Setup an empty NFS share 
* Build a docker image with a dummy folder containing a simple file
* Run the image as a service in a SELinux-enabled installation and map the dummy folder to the empty NFS share. 
* File should be copied without problems although NFS doesn't support extended attributes

**- Description for the changelog**
Ignore extended attributes set errors during copy.

Fixes #38155