### PR TITLE
mkimage: Fix Debian security presence check

### DIFF
--- a/contrib/mkimage/debootstrap
+++ b/contrib/mkimage/debootstrap
@@ -193,7 +193,7 @@ if [ -z "$DONT_TOUCH_SOURCES_LIST" ]; then
 	case "$lsbDist" in
 		debian)
 			# updates and security!
-			if curl -o /dev/null -s --head --fail "http://security.debian.org/dists/$suite/updates/main/binary-$(rootfs_chroot dpkg --print-architecture)/Packages.gz"; then
+			if curl -o /dev/null -s --head --location --fail "http://security.debian.org/dists/$suite/updates/main/binary-$(rootfs_chroot dpkg --print-architecture)/Packages.gz"; then
 				(
 					set -x
 					sed -i "


### PR DESCRIPTION
Add Location following since security redirects to security-cdn and caused the repository to be added on Debian unstable.

Signed-off-by: Mattias Jernberg <nostrad@gmail.com>