### PR TITLE
update just installer of containerd to 1.2.1

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=de1f167ab96338a9f5c2b17347abf84bdf1dd411 # v1.2.1-rc.0
+CONTAINERD_COMMIT=9b32062dc1f5a7c2564315c269b5059754f12b9d # v1.2.1
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -4,7 +4,7 @@
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-RUNC_COMMIT=10d38b660a77168360df3522881e2dc2be5056bd
+RUNC_COMMIT=96ec2177ae841256168fcf76954f7177af9446eb
 
 install_runc() {
 	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting


### PR DESCRIPTION
Just update the installer of containerd and runc to line up with containerd 1.2.1 ga. This PR is meant as a quick way to get the static binaries up-to-date while #38327 is worked out.