### PR TITLE
go vet fix for TestfillLicense

### DIFF
--- a/daemon/licensing_test.go
+++ b/daemon/licensing_test.go
@@ -8,7 +8,7 @@ import (
 	"gotest.tools/assert"
 )
 
-func TestfillLicense(t *testing.T) {
+func TestFillLicense(t *testing.T) {
 	v := &types.Info{}
 	d := &Daemon{
 		root: "/var/lib/docker/",


### PR DESCRIPTION
This small fix renames `TestfillLicense` to `TestFillLicense`
as otherwise go vet reports:
```
$ go tool vet daemon/licensing_test.go
daemon/licensing_test.go:11: TestfillLicense has malformed name: first letter after 'Test' must not be lowercase
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

