### PR TITLE
Adding OS version info to nodes' `Info` struct and to the system info's API

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3840,6 +3840,17 @@ definitions:
           or "Windows Server 2016 Datacenter"
         type: "string"
         example: "Alpine Linux v3.5"
+      OSVersion:
+        description: |
+          Version of the host's operating system
+
+          <p><br /></p>
+
+          > **Note**: The information returned in this field, including its
+          > very existence, and the formatting of values, should not be considered
+          > stable, and may change without notice.
+        type: "string"
+        example: "16.04"
       OSType:
         description: |
           Generic type of the operating system of the host, as returned by the

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -177,6 +177,7 @@ type Info struct {
 	NEventsListener    int
 	KernelVersion      string
 	OperatingSystem    string
+	OSVersion          string
 	OSType             string
 	Architecture       string
 	IndexServerAddress string

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1061,6 +1061,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		info.KernelVersion,
 		info.OperatingSystem,
 		info.OSType,
+		info.OSVersion,
 		info.ID,
 	).Set(1)
 	engineCpus.Set(float64(info.NCPU))

--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -17,6 +17,7 @@ const metricsPluginType = "MetricsCollector"
 var (
 	containerActions          metrics.LabeledTimer
 	networkActions            metrics.LabeledTimer
+	hostInfoFunctions         metrics.LabeledTimer
 	engineInfo                metrics.LabeledGauge
 	engineCpus                metrics.Gauge
 	engineMemory              metrics.Gauge
@@ -38,6 +39,7 @@ func init() {
 	} {
 		containerActions.WithValues(a).Update(0)
 	}
+	hostInfoFunctions = ns.NewLabeledTimer("host_info_functions", "The number of seconds it takes to call functions gathering info about the host", "function")
 
 	networkActions = ns.NewLabeledTimer("network_actions", "The number of seconds it takes to process each network action", "action")
 	engineInfo = ns.NewLabeledGauge("engine", "The information related to the engine and the OS it is running on", metrics.Unit("info"),
@@ -45,8 +47,10 @@ func init() {
 		"commit",
 		"architecture",
 		"graphdriver",
-		"kernel", "os",
+		"kernel",
+		"os",
 		"os_type",
+		"os_version",
 		"daemon_id", // ID is a randomly generated unique identifier (e.g. UUID4)
 	)
 	engineCpus = ns.NewGauge("engine_cpus", "The number of cpus that the host system of the engine has", metrics.Unit("cpus"))

--- a/pkg/parsers/operatingsystem/operatingsystem_linux.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_linux.go
@@ -26,6 +26,24 @@ var (
 
 // GetOperatingSystem gets the name of the current operating system.
 func GetOperatingSystem() (string, error) {
+	if prettyName, err := getValueFromOsRelease("PRETTY_NAME"); err != nil {
+		return "", err
+	} else if prettyName != "" {
+		return prettyName, nil
+	}
+
+	// If not set, defaults to PRETTY_NAME="Linux"
+	// c.f. http://www.freedesktop.org/software/systemd/man/os-release.html
+	return "Linux", nil
+}
+
+// GetOperatingSystemVersion gets the version of the current operating system, as a string.
+func GetOperatingSystemVersion() (string, error) {
+	return getValueFromOsRelease("VERSION_ID")
+}
+
+// parses the os-release file and returns the value associated with `key`
+func getValueFromOsRelease(key string) (string, error) {
 	osReleaseFile, err := os.Open(etcOsRelease)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -38,28 +56,25 @@ func GetOperatingSystem() (string, error) {
 	}
 	defer osReleaseFile.Close()
 
-	var prettyName string
+	var value string
+	keyWithTrailingEqual := key + "="
 	scanner := bufio.NewScanner(osReleaseFile)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix(line, "PRETTY_NAME=") {
+		if strings.HasPrefix(line, keyWithTrailingEqual) {
 			data := strings.SplitN(line, "=", 2)
-			prettyNames, err := shellwords.Parse(data[1])
+			values, err := shellwords.Parse(data[1])
 			if err != nil {
-				return "", fmt.Errorf("PRETTY_NAME is invalid: %s", err.Error())
+				return "", fmt.Errorf("%s is invalid: %s", key, err.Error())
 			}
-			if len(prettyNames) != 1 {
-				return "", fmt.Errorf("PRETTY_NAME needs to be enclosed by quotes if they have spaces: %s", data[1])
+			if len(values) != 1 {
+				return "", fmt.Errorf("%s needs to be enclosed by quotes if they have spaces: %s", key, data[1])
 			}
-			prettyName = prettyNames[0]
+			value = values[0]
 		}
 	}
-	if prettyName != "" {
-		return prettyName, nil
-	}
-	// If not set, defaults to PRETTY_NAME="Linux"
-	// c.f. http://www.freedesktop.org/software/systemd/man/os-release.html
-	return "Linux", nil
+
+	return value, nil
 }
 
 // IsContainerized returns true if we are running inside a container.

--- a/pkg/parsers/operatingsystem/operatingsystem_unix.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_unix.go
@@ -4,6 +4,7 @@ package operatingsystem // import "github.com/docker/docker/pkg/parsers/operatin
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 )
 
@@ -15,6 +16,12 @@ func GetOperatingSystem() (string, error) {
 		return "", err
 	}
 	return string(osName), nil
+}
+
+// GetOperatingSystemVersion gets the version of the current operating system, as a string.
+func GetOperatingSystemVersion() (string, error) {
+	// there's no standard unix way of getting this, sadly...
+	return "", fmt.Error("Unsupported on generic unix")
 }
 
 // IsContainerized returns true if we are running inside a container.

--- a/pkg/parsers/operatingsystem/operatingsystem_windows.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_windows.go
@@ -3,45 +3,57 @@ package operatingsystem // import "github.com/docker/docker/pkg/parsers/operatin
 import (
 	"fmt"
 
+	"github.com/docker/docker/pkg/system"
 	"golang.org/x/sys/windows/registry"
 )
 
 // GetOperatingSystem gets the name of the current operating system.
 func GetOperatingSystem() (string, error) {
+	os, err := withCurrentVersionRegistryKey(func(key registry.Key) (os string, err error) {
+		if os, _, err = key.GetStringValue("ProductName"); err != nil {
+			return "", err
+		}
 
-	// Default return value
-	ret := "Unknown Operating System"
+		releaseId, _, err := key.GetStringValue("ReleaseId")
+		if err != nil {
+			return
+		}
+		os = fmt.Sprintf("%s Version %s", os, releaseId)
 
-	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
-	if err != nil {
-		return ret, err
+		buildNumber, _, err := key.GetStringValue("CurrentBuildNumber")
+		if err != nil {
+			return
+		}
+		ubr, _, err := key.GetIntegerValue("UBR")
+		if err != nil {
+			return
+		}
+		os = fmt.Sprintf("%s (OS Build %s.%d)", os, buildNumber, ubr)
+
+		return
+	})
+
+	if os == "" {
+		// Default return value
+		os = "Unknown Operating System"
 	}
-	defer k.Close()
 
-	pn, _, err := k.GetStringValue("ProductName")
+	return os, err
+}
+
+func withCurrentVersionRegistryKey(f func(registry.Key) (string, error)) (string, error) {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
 	if err != nil {
-		return ret, err
+		return "", err
 	}
-	ret = pn
+	defer key.Close()
+	return f(key)
+}
 
-	ri, _, err := k.GetStringValue("ReleaseId")
-	if err != nil {
-		return ret, err
-	}
-	ret = fmt.Sprintf("%s Version %s", ret, ri)
-
-	cbn, _, err := k.GetStringValue("CurrentBuildNumber")
-	if err != nil {
-		return ret, err
-	}
-
-	ubr, _, err := k.GetIntegerValue("UBR")
-	if err != nil {
-		return ret, err
-	}
-	ret = fmt.Sprintf("%s (OS Build %s.%d)", ret, cbn, ubr)
-
-	return ret, nil
+// GetOperatingSystemVersion gets the version of the current operating system, as a string.
+func GetOperatingSystemVersion() (string, error) {
+	version := system.GetOSVersion()
+	return fmt.Sprintf("%d.%d.%d", version.MajorVersion, version.MinorVersion, version.Build), nil
 }
 
 // IsContainerized returns true if we are running inside a container.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This patch adds the OS' version to nodes' `Info` struct and to the system info's API.

This is needed so that we can add OS version constraints in Swarmkit, which
does require the engine to report its host's OS version (see
https://github.com/docker/swarmkit/issues/2770#issuecomment-437211288).

**- How I did it**

The OS version is parsed from the `os-release` file on Linux, and from the
`ReleaseId` string value of the `SOFTWARE\Microsoft\Windows NT\CurrentVersion`
registry key on Windows.

**- How to verify it**

Unit test included.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Adding OS version info to the system info's API (`/info`)

**- A picture of a cute animal (not mandatory but encouraged)**

