### PR TITLE
Enables custom splunk host name, by a new --log-opt parameter  splunk-host-name

### DIFF
--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -41,6 +41,7 @@ const (
 	splunkVerifyConnectionKey     = "splunk-verify-connection"
 	splunkGzipCompressionKey      = "splunk-gzip"
 	splunkGzipCompressionLevelKey = "splunk-gzip-level"
+	splunkHostNameKey             = "splunk-host-name"
 	envKey                        = "env"
 	envRegexKey                   = "env-regex"
 	labelsKey                     = "labels"
@@ -150,6 +151,11 @@ func init() {
 // New creates splunk logger driver using configuration passed in context
 func New(info logger.Info) (logger.Logger, error) {
 	hostname, err := info.Hostname()
+
+	if info.Config[splunkHostNameKey] != "" {
+		hostname = info.Config[splunkHostNameKey]
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("%s: cannot access hostname to set source field", driverName)
 	}
@@ -565,6 +571,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case envKey:
 		case envRegexKey:
 		case labelsKey:
+		case splunkHostNameKey:
 		case tagKey:
 		default:
 			return fmt.Errorf("unknown log opt '%s' for %s log driver", key, driverName)


### PR DESCRIPTION
Signed-off-by: Anton Mo-Eriksson <anter491@student.liu.se>

**- What I did**
Added a new --log-opt parameter for customizing the hostname when using Splunk logging, issue #36810.

**- How I did it**
Updates the available infrastructure for --log-opt parameters and extended it with one new.

**- How to verify it**
Added unit test for it and manually set up a test environment in the self build docker container.

1. Build docker 
 ``` make BIND_DIR=. shell ```
2. Start Dockerd 
``` hack/make.sh binary && make install && dockerd -D & ```
3. Start a splunk conatiner:
``` docker run -d -p 8000:8000 -e 'SPLUNK_START_ARGS=--accept-license' -e 'SPLUNK_PASSWORD=@Docker491' splunk/splunk:latest```
4. Jump into the splunk container
``` docker exec-it SPLUNK_CONTAINER /bin/bash```
5. Setup splunk 
``` opt/splunk/bin/splunk login && opt/splunk/bin/splunk start && opt/splunk/bin/splunk http-event-collector create docker-token "this is a DOCKER TOKEN" -sourcetype catalina -uri "https://localhost:8089" && opt/splunk/bin/splunk http-event-collector update -enable-ssl 0  -uri "https://localhost:8089" && opt/splunk/bin/splunk http-event-collector enable -uri https://localhost:8089```
6. Find the IP if the splunk container
```docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' SPLUNK_CONTAINER_NAME```
7. Starta dummy Nginx container with some log opt
``` docker run -p 80:80 --log-driver=splunk --log-opt splunk-url=http://172.18.0.2:8088 --log-opt splunk-token=<INSERT TOKEN HERE> --log-opt splunk-host-name=Cool-Name --log-opt splunk-insecureskipverify=true nginx ```
8. Curles Nginx
```curl localhost:80?name=Test-to-log-dummy-data```
9. Serach for the loggs in the splunk container:
``` /opt/splunk/bin/splunk search host="*" -uri https://localhost:8089 ```


**- Description for the changelog**
Added a new --log-opt parameter for customizing the hostname when using Splunk logging.


**- A picture of a cute animal (not mandatory but encouraged)**

