### PR TITLE
Added "github.com/pkg/errors" to import

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/volume"
 	volumemounts "github.com/docker/docker/volume/mounts"
 	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )


### PR DESCRIPTION
"github.com/pkg/errors" wasn't imported on merge #38316 
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed undefined "errors" on line 394 in github.com/docker/docker/container/container_unix.go

**- How I did it**
Imported "github.com/pkg/errors" package in github.com/docker/docker/container/container_unix.go

**- How to verify it**
Will no longer get following error when trying to build:
`# github.com/docker/docker/container
.gopath/src/github.com/docker/docker/container/container_unix.go:394:6: undefined: errors
`
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Package "github.com/pkg/errors" wasn't imported and prevented docker from being built.
