### PR TITLE
Fix missing import

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/volume"
 	volumemounts "github.com/docker/docker/volume/mounts"
 	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/38361

This import got lost after commit https://github.com/moby/moby/commit/56cc56b0fa806bf8fc3a288a533314331d44cdfa (https://github.com/moby/moby/pull/38126) was merged, likely because the PR was built against an outdated master and https://github.com/moby/moby/pull/38316 was just merged before the PR.

