### PR TITLE
Update Dockerfile to skip source copy for speed up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -236,5 +236,7 @@ WORKDIR /go/src/github.com/docker/docker
 VOLUME /var/lib/docker
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]
+
+FROM dev AS final
 # Upload docker source
 COPY . /go/src/github.com/docker/docker

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ DOCKER_ENVS := \
 	-e KEEPBUNDLE \
 	-e DOCKER_BUILD_ARGS \
 	-e DOCKER_BUILD_GOGC \
+	-e DOCKER_BUILD_OPTS \
 	-e DOCKER_BUILD_PKGS \
 	-e DOCKER_BUILDKIT \
 	-e DOCKER_BASH_COMPLETION_PATH \
@@ -107,6 +108,9 @@ INTERACTIVE := $(shell [ -t 0 ] && echo 1 || echo 0)
 ifeq ($(INTERACTIVE), 1)
 	DOCKER_FLAGS += -t
 endif
+ifeq ($(BIND_DIR), .)
+	DOCKER_BUILD_OPTS += --target=dev
+endif
 
 DOCKER_RUN_DOCKER := $(DOCKER_FLAGS) "$(DOCKER_IMAGE)"
 
@@ -123,7 +127,7 @@ dynbinary: build ## build the linux dynbinaries
 
 build: bundles
 	$(warning The docker client CLI has moved to github.com/docker/cli. For a dev-test cycle involving the CLI, run:${\n} DOCKER_CLI_PATH=/host/path/to/cli/binary make shell ${\n} then change the cli and compile into a binary at the same location.${\n})
-	docker build ${BUILD_APT_MIRROR} ${DOCKER_BUILD_ARGS} -t "$(DOCKER_IMAGE)" -f "$(DOCKERFILE)" .
+	docker build ${BUILD_APT_MIRROR} ${DOCKER_BUILD_ARGS} ${DOCKER_BUILD_OPTS} -t "$(DOCKER_IMAGE)" -f "$(DOCKERFILE)" .
 
 bundles:
 	mkdir bundles


### PR DESCRIPTION
Will skip the COPY command which copies the whole source code to
the container if BIND_DIR=. is supplied to the make command to
speed up the development build.

Also update .gitignore, add *.tmp, to stop git from tracking
Dockerfile.dev.tmp which is created in the above process, and
any other .tmp file in the future.

Signed-off-by: Mohammad Nasirifar <farnasirim@gmail.com>

Addresses the requirement raised in #36413 and closes #36413.

**- A picture of a cute animal (not mandatory but encouraged)**

![Sorry, no punch line](https://i.pinimg.com/236x/d4/7d/f0/d47df0a11725b7bdb9bada6b6f501360--ground-squirrel-wild-animals.jpg)