### PR TITLE
Update test.md doc to fix sample test regex

### DIFF
--- a/docs/contributing/test.md
+++ b/docs/contributing/test.md
@@ -163,7 +163,7 @@ On unit tests, it's better to use `TESTFLAGS` in combination with
 `TESTDIRS` to make it quicker to run a specific test.
 
 ```bash
-$ TESTDIRS='github.com/docker/docker/opts' TESTFLAGS='-test.run $^TestValidateIPAddress$' make test-unit
+$ TESTDIRS='github.com/docker/docker/opts' TESTFLAGS='-test.run ^TestValidateIPAddress$' make test-unit
 ```
 
 ## Run integration tests


### PR DESCRIPTION
Remove the extra dollar sign from the test regex so the command
would find the desired test.

`'-test.run $^TestValidateIPAddress$'` will not match any tests because of the extra `$`
in the beginning of the name of the test. `'-test.run ^TestValidateIPAddress$'` will.

Signed-off-by: Mohammad Nasirifar <farnasirim@gmail.com>



**- A picture of a cute animal (not mandatory but encouraged)**
![woof](https://barkpost.com/wp-content/uploads/2015/03/huskymika.jpg)
