### PR TITLE
Fix unmount redeclaration on darwin in github.com/docker/docker/pkg/m…

### DIFF
--- a/pkg/mount/mounter_unsupported.go
+++ b/pkg/mount/mounter_unsupported.go
@@ -5,7 +5,3 @@ package mount // import "github.com/docker/docker/pkg/mount"
 func mount(device, target, mType string, flag uintptr, data string) error {
 	panic("Not implemented")
 }
-
-func unmount(target string, flag int) error {
-	panic("Not implemented")
-}

--- a/pkg/mount/unmount_unsupported.go
+++ b/pkg/mount/unmount_unsupported.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package mount // import "github.com/docker/docker/pkg/mount"
+
+func unmount(target string, flag int) error {
+	panic("Not implemented")
+}


### PR DESCRIPTION
Signed-off-by: Fabian Kramm kramm@covexo.com 

We use the moby project as a dependency in our project and unfortunately it does not compile under darwin (without cgo) on the current master version anymore. The compile error we get is:

```
# github.com/docker/docker/pkg/mount
pkg/mount/unmount_unix.go:7:6: unmount redeclared in this block
        previous declaration at pkg/mount/mounter_unsupported.go:9:39
```

**- How to reproduce**
Clone the moby project into `$GOPATH/src/github.com/docker/docker` and run `GOOS=darwin go install "github.com/docker/docker/pkg/mount"` and you will see the above error.

**- What I did**
Fixed the compile error in darwin

**- How I did it**
Moved the unmount function declaration away from "github.com/docker/docker/pkg/mount/mounter_unsupported.go" to a new file "github.com/docker/docker/pkg/mount/unmount_unsupported.go" that is only included in windows, where the unmount function is not declared.

**- How to verify it**
1. Clone the fork into `$GOPATH/src/github.com/docker/docker`
2. Checkout master branch
3. Run `GOOS=darwin go install "github.com/docker/docker/pkg/mount"`
4. Switch branch to fix-darwin-compile
5. Run `GOOS=darwin go install "github.com/docker/docker/pkg/mount"` again and you shouldn't see the error message anymore

**- A picture of a cute animal (not mandatory but encouraged)**
![Cute dog](http://www.cutestpaw.com/wp-content/uploads/2011/11/hipster-puppies.jpg)
