### PR TITLE
Dockerfile: Update CRIU version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get install -y \
 
 FROM runtime-dev AS criu
 # Install CRIU for checkpoint/restore support
-ENV CRIU_VERSION 3.6
+ENV CRIU_VERSION 3.11
 # Install dependency packages specific to criu
 RUN apt-get update && apt-get install -y \
 	libaio-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update && apt-get install -y \
 	&& mkdir -p /usr/src/criu \
 	&& curl -sSL https://github.com/checkpoint-restore/criu/archive/v${CRIU_VERSION}.tar.gz | tar -C /usr/src/criu/ -xz --strip-components=1 \
 	&& cd /usr/src/criu \
-	&& make \
+	&& make -j $(nproc) \
 	&& make PREFIX=/build/ install-criu
 
 FROM base AS registry


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

* Copied CRIU dependencies into runtime-dev
* Updated CRIU version to 3.11
* Add `-j` argument to `make` when building CRIU

**- How to verify it**

```
make BIND_DIR=. shell
```
Inside the container:
```
mkdir /etc/docker
echo "{\"experimental\": true}" >> /etc/docker/daemon.json
./hack/make.sh binary install-binary
dockerd
```
In a different terminal:
```
docker exec -it <container-id> bash
```
Where `<container-id>` the can be obtained from `docker ps`. Then inside the container:
```
docker run -d --name looper --security-opt seccomp:unconfined busybox  \
         /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
docker checkpoint create looper checkpoint1
docker start --checkpoint checkpoint1 looper
```

**- Description for the changelog**
The changes in this PR make it easier to test docker's checkpoint/restore functionality with the latest version of CRIU.
