### PR TITLE
Move "OOM Kill disable" warning to the daemon

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -351,8 +351,5 @@ func (daemon *Daemon) verifyContainerSettings(platform string, hostConfig *conta
 	if warnings, err = verifyPlatformContainerSettings(daemon, hostConfig, config, update); err != nil {
 		return warnings, err
 	}
-	if hostConfig.NetworkMode.IsHost() && len(hostConfig.PortBindings) > 0 {
-		warnings = append(warnings, "Published ports are discarded when using host network mode")
-	}
 	return warnings, err
 }

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -607,6 +607,10 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 		warnings = append(warnings, "IPv4 forwarding is disabled. Networking will not work.")
 		logrus.Warn("IPv4 forwarding is disabled. Networking will not work")
 	}
+	if hostConfig.NetworkMode.IsHost() && len(hostConfig.PortBindings) > 0 {
+		warnings = append(warnings, "Published ports are discarded when using host network mode")
+	}
+
 	// check for various conflicting options with user namespaces
 	if daemon.configStore.RemappedRoot != "" && hostConfig.UsernsMode.IsPrivate() {
 		if hostConfig.Privileged {

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -422,7 +422,10 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 		}
 		resources.OomKillDisable = nil
 	}
-
+	if resources.OomKillDisable != nil && *resources.OomKillDisable && resources.Memory == 0 {
+		warnings = append(warnings, "OOM killer is disabled for the container, but no memory limit is set, this can result in the system running out of resources.")
+		logrus.Warn("OOM killer is disabled for the container, but no memory limit is set, this can result in the system running out of resources.")
+	}
 	if resources.PidsLimit != 0 && !sysInfo.PidsLimit {
 		warnings = append(warnings, "Your kernel does not support pids limit capabilities or the cgroup is not mounted. PIDs limit discarded.")
 		logrus.Warn("Your kernel does not support pids limit capabilities or the cgroup is not mounted. PIDs limit discarded.")

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -354,8 +354,7 @@ func adaptSharedNamespaceContainer(daemon containerGetter, hostConfig *container
 	}
 }
 
-func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysinfo.SysInfo, update bool) ([]string, error) {
-	warnings := []string{}
+func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysinfo.SysInfo, update bool) (warnings []string, err error) {
 	fixMemorySwappiness(resources)
 
 	// memory subsystem checks and adjustments
@@ -364,13 +363,11 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 	}
 	if resources.Memory > 0 && !sysInfo.MemoryLimit {
 		warnings = append(warnings, "Your kernel does not support memory limit capabilities or the cgroup is not mounted. Limitation discarded.")
-		logrus.Warn("Your kernel does not support memory limit capabilities or the cgroup is not mounted. Limitation discarded.")
 		resources.Memory = 0
 		resources.MemorySwap = -1
 	}
 	if resources.Memory > 0 && resources.MemorySwap != -1 && !sysInfo.SwapLimit {
 		warnings = append(warnings, "Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.")
-		logrus.Warn("Your kernel does not support swap limit capabilities,or the cgroup is not mounted. Memory limited without swap.")
 		resources.MemorySwap = -1
 	}
 	if resources.Memory > 0 && resources.MemorySwap > 0 && resources.MemorySwap < resources.Memory {
@@ -381,7 +378,6 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 	}
 	if resources.MemorySwappiness != nil && !sysInfo.MemorySwappiness {
 		warnings = append(warnings, "Your kernel does not support memory swappiness capabilities or the cgroup is not mounted. Memory swappiness discarded.")
-		logrus.Warn("Your kernel does not support memory swappiness capabilities, or the cgroup is not mounted. Memory swappiness discarded.")
 		resources.MemorySwappiness = nil
 	}
 	if resources.MemorySwappiness != nil {
@@ -392,7 +388,6 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 	}
 	if resources.MemoryReservation > 0 && !sysInfo.MemoryReservation {
 		warnings = append(warnings, "Your kernel does not support memory soft limit capabilities or the cgroup is not mounted. Limitation discarded.")
-		logrus.Warn("Your kernel does not support memory soft limit capabilities or the cgroup is not mounted. Limitation discarded.")
 		resources.MemoryReservation = 0
 	}
 	if resources.MemoryReservation > 0 && resources.MemoryReservation < linuxMinMemory {
@@ -403,7 +398,6 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 	}
 	if resources.KernelMemory > 0 && !sysInfo.KernelMemory {
 		warnings = append(warnings, "Your kernel does not support kernel memory limit capabilities or the cgroup is not mounted. Limitation discarded.")
-		logrus.Warn("Your kernel does not support kernel memory limit capabilities or the cgroup is not mounted. Limitation discarded.")
 		resources.KernelMemory = 0
 	}
 	if resources.KernelMemory > 0 && resources.KernelMemory < linuxMinMemory {
@@ -411,24 +405,20 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 	}
 	if resources.KernelMemory > 0 && !kernel.CheckKernelVersion(4, 0, 0) {
 		warnings = append(warnings, "You specified a kernel memory limit on a kernel older than 4.0. Kernel memory limits are experimental on older kernels, it won't work as expected and can cause your system to be unstable.")
-		logrus.Warn("You specified a kernel memory limit on a kernel older than 4.0. Kernel memory limits are experimental on older kernels, it won't work as expected and can cause your system to be unstable.")
 	}
 	if resources.OomKillDisable != nil && !sysInfo.OomKillDisable {
 		// only produce warnings if the setting wasn't to *disable* the OOM Kill; no point
 		// warning the caller if they already wanted the feature to be off
 		if *resources.OomKillDisable {
 			warnings = append(warnings, "Your kernel does not support OomKillDisable. OomKillDisable discarded.")
-			logrus.Warn("Your kernel does not support OomKillDisable. OomKillDisable discarded.")
 		}
 		resources.OomKillDisable = nil
 	}
 	if resources.OomKillDisable != nil && *resources.OomKillDisable && resources.Memory == 0 {
 		warnings = append(warnings, "OOM killer is disabled for the container, but no memory limit is set, this can result in the system running out of resources.")
-		logrus.Warn("OOM killer is disabled for the container, but no memory limit is set, this can result in the system running out of resources.")
 	}
 	if resources.PidsLimit != 0 && !sysInfo.PidsLimit {
 		warnings = append(warnings, "Your kernel does not support pids limit capabilities or the cgroup is not mounted. PIDs limit discarded.")
-		logrus.Warn("Your kernel does not support pids limit capabilities or the cgroup is not mounted. PIDs limit discarded.")
 		resources.PidsLimit = 0
 	}
 
@@ -455,12 +445,10 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 
 	if resources.CPUShares > 0 && !sysInfo.CPUShares {
 		warnings = append(warnings, "Your kernel does not support CPU shares or the cgroup is not mounted. Shares discarded.")
-		logrus.Warn("Your kernel does not support CPU shares or the cgroup is not mounted. Shares discarded.")
 		resources.CPUShares = 0
 	}
 	if resources.CPUPeriod > 0 && !sysInfo.CPUCfsPeriod {
 		warnings = append(warnings, "Your kernel does not support CPU cfs period or the cgroup is not mounted. Period discarded.")
-		logrus.Warn("Your kernel does not support CPU cfs period or the cgroup is not mounted. Period discarded.")
 		resources.CPUPeriod = 0
 	}
 	if resources.CPUPeriod != 0 && (resources.CPUPeriod < 1000 || resources.CPUPeriod > 1000000) {
@@ -468,7 +456,6 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 	}
 	if resources.CPUQuota > 0 && !sysInfo.CPUCfsQuota {
 		warnings = append(warnings, "Your kernel does not support CPU cfs quota or the cgroup is not mounted. Quota discarded.")
-		logrus.Warn("Your kernel does not support CPU cfs quota or the cgroup is not mounted. Quota discarded.")
 		resources.CPUQuota = 0
 	}
 	if resources.CPUQuota > 0 && resources.CPUQuota < 1000 {
@@ -476,14 +463,12 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 	}
 	if resources.CPUPercent > 0 {
 		warnings = append(warnings, fmt.Sprintf("%s does not support CPU percent. Percent discarded.", runtime.GOOS))
-		logrus.Warnf("%s does not support CPU percent. Percent discarded.", runtime.GOOS)
 		resources.CPUPercent = 0
 	}
 
 	// cpuset subsystem checks and adjustments
 	if (resources.CpusetCpus != "" || resources.CpusetMems != "") && !sysInfo.Cpuset {
 		warnings = append(warnings, "Your kernel does not support cpuset or the cgroup is not mounted. Cpuset discarded.")
-		logrus.Warn("Your kernel does not support cpuset or the cgroup is not mounted. Cpuset discarded.")
 		resources.CpusetCpus = ""
 		resources.CpusetMems = ""
 	}
@@ -505,7 +490,6 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 	// blkio subsystem checks and adjustments
 	if resources.BlkioWeight > 0 && !sysInfo.BlkioWeight {
 		warnings = append(warnings, "Your kernel does not support Block I/O weight or the cgroup is not mounted. Weight discarded.")
-		logrus.Warn("Your kernel does not support Block I/O weight or the cgroup is not mounted. Weight discarded.")
 		resources.BlkioWeight = 0
 	}
 	if resources.BlkioWeight > 0 && (resources.BlkioWeight < 10 || resources.BlkioWeight > 1000) {
@@ -516,28 +500,23 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 	}
 	if len(resources.BlkioWeightDevice) > 0 && !sysInfo.BlkioWeightDevice {
 		warnings = append(warnings, "Your kernel does not support Block I/O weight_device or the cgroup is not mounted. Weight-device discarded.")
-		logrus.Warn("Your kernel does not support Block I/O weight_device or the cgroup is not mounted. Weight-device discarded.")
 		resources.BlkioWeightDevice = []*pblkiodev.WeightDevice{}
 	}
 	if len(resources.BlkioDeviceReadBps) > 0 && !sysInfo.BlkioReadBpsDevice {
 		warnings = append(warnings, "Your kernel does not support BPS Block I/O read limit or the cgroup is not mounted. Block I/O BPS read limit discarded.")
-		logrus.Warn("Your kernel does not support BPS Block I/O read limit or the cgroup is not mounted. Block I/O BPS read limit discarded")
 		resources.BlkioDeviceReadBps = []*pblkiodev.ThrottleDevice{}
 	}
 	if len(resources.BlkioDeviceWriteBps) > 0 && !sysInfo.BlkioWriteBpsDevice {
 		warnings = append(warnings, "Your kernel does not support BPS Block I/O write limit or the cgroup is not mounted. Block I/O BPS write limit discarded.")
-		logrus.Warn("Your kernel does not support BPS Block I/O write limit or the cgroup is not mounted. Block I/O BPS write limit discarded.")
 		resources.BlkioDeviceWriteBps = []*pblkiodev.ThrottleDevice{}
 
 	}
 	if len(resources.BlkioDeviceReadIOps) > 0 && !sysInfo.BlkioReadIOpsDevice {
 		warnings = append(warnings, "Your kernel does not support IOPS Block read limit or the cgroup is not mounted. Block I/O IOPS read limit discarded.")
-		logrus.Warn("Your kernel does not support IOPS Block I/O read limit in IO or the cgroup is not mounted. Block I/O IOPS read limit discarded.")
 		resources.BlkioDeviceReadIOps = []*pblkiodev.ThrottleDevice{}
 	}
 	if len(resources.BlkioDeviceWriteIOps) > 0 && !sysInfo.BlkioWriteIOpsDevice {
 		warnings = append(warnings, "Your kernel does not support IOPS Block write limit or the cgroup is not mounted. Block I/O IOPS write limit discarded.")
-		logrus.Warn("Your kernel does not support IOPS Block I/O write limit or the cgroup is not mounted. Block I/O IOPS write limit discarded.")
 		resources.BlkioDeviceWriteIOps = []*pblkiodev.ThrottleDevice{}
 	}
 
@@ -581,8 +560,7 @@ func UsingSystemd(config *config.Config) bool {
 
 // verifyPlatformContainerSettings performs platform-specific validation of the
 // hostconfig and config structures.
-func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.HostConfig, config *containertypes.Config, update bool) ([]string, error) {
-	var warnings []string
+func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.HostConfig, config *containertypes.Config, update bool) (warnings []string, err error) {
 	sysInfo := sysinfo.New(true)
 
 	w, err := verifyContainerResources(&hostConfig.Resources, sysInfo, update)
@@ -605,7 +583,6 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 	// ip-forwarding does not affect container with '--net=host' (or '--net=none')
 	if sysInfo.IPv4ForwardingDisabled && !(hostConfig.NetworkMode.IsHost() || hostConfig.NetworkMode.IsNone()) {
 		warnings = append(warnings, "IPv4 forwarding is disabled. Networking will not work.")
-		logrus.Warn("IPv4 forwarding is disabled. Networking will not work")
 	}
 	if hostConfig.NetworkMode.IsHost() && len(hostConfig.PortBindings) > 0 {
 		warnings = append(warnings, "Published ports are discarded when using host network mode")

--- a/daemon/daemon_unix_test.go
+++ b/daemon/daemon_unix_test.go
@@ -11,6 +11,9 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/config"
+	"github.com/docker/docker/pkg/sysinfo"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 )
 
 type fakeContainerGetter struct {
@@ -265,4 +268,111 @@ func TestNetworkOptions(t *testing.T) {
 	if _, err := daemon.networkOptions(dconfigWrong, nil, nil); err == nil {
 		t.Fatal("Expected networkOptions error, got nil")
 	}
+}
+
+func TestVerifyContainerResources(t *testing.T) {
+	t.Parallel()
+	var (
+		no  = false
+		yes = true
+	)
+
+	withMemoryLimit := func(si *sysinfo.SysInfo) {
+		si.MemoryLimit = true
+	}
+	withSwapLimit := func(si *sysinfo.SysInfo) {
+		si.SwapLimit = true
+	}
+	withOomKillDisable := func(si *sysinfo.SysInfo) {
+		si.OomKillDisable = true
+	}
+
+	tests := []struct {
+		name             string
+		resources        containertypes.Resources
+		sysInfo          sysinfo.SysInfo
+		update           bool
+		expectedWarnings []string
+	}{
+		{
+			name:             "no-oom-kill-disable",
+			resources:        containertypes.Resources{},
+			sysInfo:          sysInfo(t, withMemoryLimit),
+			expectedWarnings: []string{},
+		},
+		{
+			name: "oom-kill-disable-disabled",
+			resources: containertypes.Resources{
+				OomKillDisable: &no,
+			},
+			sysInfo:          sysInfo(t, withMemoryLimit),
+			expectedWarnings: []string{},
+		},
+		{
+			name: "oom-kill-disable-not-supported",
+			resources: containertypes.Resources{
+				OomKillDisable: &yes,
+			},
+			sysInfo: sysInfo(t, withMemoryLimit),
+			expectedWarnings: []string{
+				"Your kernel does not support OomKillDisable. OomKillDisable discarded.",
+			},
+		},
+		{
+			name: "oom-kill-disable-without-memory-constraints",
+			resources: containertypes.Resources{
+				OomKillDisable: &yes,
+				Memory:         0,
+			},
+			sysInfo: sysInfo(t, withMemoryLimit, withOomKillDisable, withSwapLimit),
+			expectedWarnings: []string{
+				"OOM killer is disabled for the container, but no memory limit is set, this can result in the system running out of resources.",
+			},
+		},
+		{
+			name: "oom-kill-disable-with-memory-constraints-but-no-memory-limit-support",
+			resources: containertypes.Resources{
+				OomKillDisable: &yes,
+				Memory:         linuxMinMemory,
+			},
+			sysInfo: sysInfo(t, withOomKillDisable),
+			expectedWarnings: []string{
+				"Your kernel does not support memory limit capabilities or the cgroup is not mounted. Limitation discarded.",
+				"OOM killer is disabled for the container, but no memory limit is set, this can result in the system running out of resources.",
+			},
+		},
+		{
+			name: "oom-kill-disable-with-memory-constraints",
+			resources: containertypes.Resources{
+				OomKillDisable: &yes,
+				Memory:         linuxMinMemory,
+			},
+			sysInfo:          sysInfo(t, withMemoryLimit, withOomKillDisable, withSwapLimit),
+			expectedWarnings: []string{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			warnings, err := verifyContainerResources(&tc.resources, &tc.sysInfo, tc.update)
+			assert.NilError(t, err)
+			for _, w := range tc.expectedWarnings {
+				assert.Assert(t, is.Contains(warnings, w))
+			}
+		})
+	}
+}
+
+func sysInfo(t *testing.T, opts ...func(*sysinfo.SysInfo)) sysinfo.SysInfo {
+	t.Helper()
+	si := sysinfo.SysInfo{}
+
+	for _, opt := range opts {
+		opt(&si)
+	}
+
+	if si.OomKillDisable {
+		t.Log(t.Name(), "OOM disable supported")
+	}
+	return si
 }

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -75,8 +75,7 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConf
 	return nil
 }
 
-func verifyContainerResources(resources *containertypes.Resources, isHyperv bool) ([]string, error) {
-	warnings := []string{}
+func verifyContainerResources(resources *containertypes.Resources, isHyperv bool) (warnings []string, err error) {
 	fixMemorySwappiness(resources)
 	if !isHyperv {
 		// The processor resource controls are mutually exclusive on
@@ -85,18 +84,15 @@ func verifyContainerResources(resources *containertypes.Resources, isHyperv bool
 		if resources.CPUCount > 0 {
 			if resources.CPUShares > 0 {
 				warnings = append(warnings, "Conflicting options: CPU count takes priority over CPU shares on Windows Server Containers. CPU shares discarded")
-				logrus.Warn("Conflicting options: CPU count takes priority over CPU shares on Windows Server Containers. CPU shares discarded")
 				resources.CPUShares = 0
 			}
 			if resources.CPUPercent > 0 {
 				warnings = append(warnings, "Conflicting options: CPU count takes priority over CPU percent on Windows Server Containers. CPU percent discarded")
-				logrus.Warn("Conflicting options: CPU count takes priority over CPU percent on Windows Server Containers. CPU percent discarded")
 				resources.CPUPercent = 0
 			}
 		} else if resources.CPUShares > 0 {
 			if resources.CPUPercent > 0 {
 				warnings = append(warnings, "Conflicting options: CPU shares takes priority over CPU percent on Windows Server Containers. CPU percent discarded")
-				logrus.Warn("Conflicting options: CPU shares takes priority over CPU percent on Windows Server Containers. CPU percent discarded")
 				resources.CPUPercent = 0
 			}
 		}
@@ -131,7 +127,6 @@ func verifyContainerResources(resources *containertypes.Resources, isHyperv bool
 			resources.NanoCPUs = ((resources.NanoCPUs + 1e9/2) / 1e9) * 1e9
 			warningString := fmt.Sprintf("Your current OS version does not support Hyper-V containers with NanoCPUs greater than 1000000000 but not divisible by 1000000000. NanoCPUs rounded to %d", resources.NanoCPUs)
 			warnings = append(warnings, warningString)
-			logrus.Warn(warningString)
 		}
 	}
 
@@ -191,8 +186,7 @@ func verifyContainerResources(resources *containertypes.Resources, isHyperv bool
 
 // verifyPlatformContainerSettings performs platform-specific validation of the
 // hostconfig and config structures.
-func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.HostConfig, config *containertypes.Config, update bool) ([]string, error) {
-	warnings := []string{}
+func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.HostConfig, config *containertypes.Config, update bool) (warnings []string, err error) {
 	osv := system.GetOSVersion()
 	hyperv := daemon.runAsHyperVContainer(hostConfig)
 


### PR DESCRIPTION
Relates to https://github.com/docker/cli/pull/1571

Disabling the oom-killer for a container without setting a memory limit
is dangerous, as it can result in the container consuming unlimited memory,
without the kernel being able to kill it. A check for this situation is curently
done in the CLI, but other consumers of the API won't receive this warning.

This patch adds a check for this situation to the daemon, so that all consumers
of the API will receive this warning.

This patch will have one side-effect; docker cli's that also perform this check
client-side will print the warning twice; this can be addressed by disabling
the cli-side check for newer API versions, but will generate a bit of extra
noise when using an older CLI.

With this patch applied (and a cli that does not take the new warning into account);

```
docker create --oom-kill-disable busybox
WARNING: OOM killer is disabled for the container, but no memory limit is set, this can result in the system running out of resources.
669933b9b237fa27da699483b5cf15355a9027050825146587a0e5be0d848adf

docker run --rm --oom-kill-disable busybox
WARNING: Disabling the OOM killer on containers without setting a '-m/--memory' limit may be dangerous.
WARNING: OOM killer is disabled for the container, but no memory limit is set, this can result in the system running out of resources.
```



**- How to verify it**

```
make BIND_DIR=. TESTDIRS='github.com/docker/docker/daemon/' TESTFLAGS='-test.run ^TestVerifyContainerResources$' test-unit
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
+ Return warnings when creating a container with OOM-kill-disabled, but no memory-constraints set
```


