### PR TITLE
Add curators rights for olljanat

### DIFF
--- a/.DEREK.yml
+++ b/.DEREK.yml
@@ -8,6 +8,7 @@ curators:
   - fntlnz
   - gianarb
   - mgoelzer
+  - olljanat
   - programmerq
   - rheinwein
   - ripcurld0

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -78,6 +78,7 @@
 			"chanwit",
 			"fntlnz",
 			"gianarb",
+			"olljanat",
 			"programmerq",
 			"rheinwein",
 			"ripcurld",
@@ -399,6 +400,11 @@
 	Name = "Jana Radhakrishnan"
 	Email = "mrjana@docker.com"
 	GitHub = "mrjana"
+
+	[people.olljanat]
+	Name = "Olli Janatuinen"
+	Email = "olli.janatuinen@gmail.com"
+	GitHub = "olljanat"
 
 	[people.programmerq]
 	Name = "Jeff Anderson"


### PR DESCRIPTION
I would like to be able to rebuild these failing PR builds so maintainers don't need to worry about them. 
