### PR TITLE
Reboot RS5 after test run if there is less than 15 GB free disk space

### DIFF
--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -994,4 +994,14 @@ Finally {
     Nuke-Everything
     $Dur=New-TimeSpan -Start $StartTime -End $(Get-Date)
     Write-Host -ForegroundColor $FinallyColour "`nINFO: executeCI.ps1 exiting at $(date). Duration $dur`n"
+
+    # Temporary solution to avoid disk to fill on RS5
+    if ($env:COMPUTERNAME -match "jenkins-rs5-") {
+        if ((Get-Volume -DriveLetter $env:TESTRUN_DRIVE).SizeRemaining -lt 15GB) {
+            Write-Host -ForegroundColor Green "INFO: D drive is almost full, rebooting..."
+            shutdown -r -t 15
+        } else {
+            Write-Host -ForegroundColor Green "INFO: These is still enough space on D drive. Skip reboot..."
+        }
+    }
 }

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -255,6 +255,20 @@ Try {
     Write-Host -ForegroundColor green "INFO: Environment variables:"
     Get-ChildItem Env: | Out-String
 
+     # REMOVE, trying to fix RS5 build servers without access to them
+     if ($env:COMPUTERNAME -eq "jenkins-rs5-1") {
+         Restart-Computer -Force
+		 # throw "Just save some time, this one is already fixed"
+     }
+     if ($env:COMPUTERNAME -eq "jenkins-rs5-2") {
+         Restart-Computer -Force
+         # throw "Just save some time, this one is already fixed"
+     }
+     if ($env:COMPUTERNAME -eq "jenkins-rs5-3") {
+         Restart-Computer -Force
+         # throw "Just save some time, this one is already fixed"
+     }
+
     # PR
     if (-not ($env:PR -eq $Null)) { echo "INFO: PR#$env:PR (https://github.com/docker/docker/pull/$env:PR)" }
 

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -257,8 +257,8 @@ Try {
 
      # REMOVE, trying to fix RS5 build servers without access to them
      if ($env:COMPUTERNAME -eq "jenkins-rs5-1") {
-         Restart-Computer -Force
-		 # throw "Just save some time, this one is already fixed"
+         # Restart-Computer -Force
+		 throw "Just save some time, this one is already fixed"
      }
      if ($env:COMPUTERNAME -eq "jenkins-rs5-2") {
          Restart-Computer -Force

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -265,8 +265,8 @@ Try {
          # throw "Just save some time, this one is already fixed"
      }
      if ($env:COMPUTERNAME -eq "jenkins-rs5-3") {
-         Restart-Computer -Force
-         # throw "Just save some time, this one is already fixed"
+         # Restart-Computer -Force
+         throw "Just save some time, this one is already fixed"
      }
 
     # PR


### PR DESCRIPTION
Added reboot for Windows RS5 nodes which happens 15 seconds after CI build is finalized if there is less than 15 GB space left on D: -drive.

One more workaround to #38114


