### PR TITLE
Run imageservice.Cleanup() also before daemon start

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1061,6 +1061,13 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		TrustKey:                  trustKey,
 	})
 
+	// Image cleanup on some graph drivers (e.g. windowsfilter) takes so much time
+	// that it is not able to run during default 15 seconds shutdown timeout
+	// that why we run cleanup also just before daemon starts.
+	if !d.configStore.LiveRestoreEnabled {
+		d.imageService.Cleanup()
+	}
+
 	go d.execCommandGC()
 
 	d.containerd, err = libcontainerd.NewClient(ctx, d.containerdCli, filepath.Join(config.ExecRoot, "containerd"), config.ContainerdNamespace, d)

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/docker/docker/container"
 	daemonevents "github.com/docker/docker/daemon/events"
@@ -159,9 +160,10 @@ func (i *ImageService) GetLayerMountID(cid string, os string) (string, error) {
 	return i.layerStores[os].GetMountID(cid)
 }
 
-// Cleanup resources before the process is shutdown.
-// called from daemon.go Daemon.Shutdown()
+// Cleanup resources before the process is started/shutdown.
+// called from daemon.go Daemon.NewDaemon() and Daemon.Shutdown()
 func (i *ImageService) Cleanup() {
+	cleanupStart := time.Now()
 	for os, ls := range i.layerStores {
 		if ls != nil {
 			if err := ls.Cleanup(); err != nil {
@@ -169,6 +171,7 @@ func (i *ImageService) Cleanup() {
 			}
 		}
 	}
+	logrus.Infof("ImageService cleanup took %.2f seconds", time.Since(cleanupStart).Seconds())
 }
 
 // GraphDriverForOS returns the name of the graph drvier

--- a/integration/plugin/graphdriver/external_test.go
+++ b/integration/plugin/graphdriver/external_test.go
@@ -378,7 +378,7 @@ func testExternalGraphDriver(ext string, ec map[string]*graphEventsCounter) func
 			assert.Check(t, ec[ext].gets >= 1)
 			assert.Check(t, ec[ext].puts >= 1)
 			assert.Check(t, is.Equal(ec[ext].stats, 5))
-			assert.Check(t, is.Equal(ec[ext].cleanups, 2))
+			assert.Check(t, is.Equal(ec[ext].cleanups, 4))
 			assert.Check(t, ec[ext].applydiff >= 1)
 			assert.Check(t, is.Equal(ec[ext].changes, 1))
 			assert.Check(t, is.Equal(ec[ext].diffsize, 0))


### PR DESCRIPTION
**- What I did**
Added image cleanup for Windows which run just before Docker daemon start.

**- How to verify it**
- Create folder under *C:\ProgramData\docker\windowsfilter* which contains suffix *-removing*
- Start dockerd on debug mode and look that you see messages like these:
```
time="2018-12-20T14:56:46.714139100+01:00" level=debug msg="Listener created for HTTP on npipe (//./pipe/docker_engine)"
time="2018-12-20T14:56:46.728139900+01:00" level=info msg="Windows default isolation mode: process"
time="2018-12-20T14:56:46.728139900+01:00" level=debug msg="Stackdump - waiting signal at Global\\docker-daemon-2652"
time="2018-12-20T14:56:46.728139900+01:00" level=debug msg="Using default logging driver json-file"
time="2018-12-20T14:56:46.728139900+01:00" level=debug msg="[graphdriver] trying provided driver: windowsfilter"
time="2018-12-20T14:56:46.728139900+01:00" level=debug msg="WindowsGraphDriver InitFilter at C:\\ProgramData\\docker\\windowsfilter"
time="2018-12-20T14:56:46.729139000+01:00" level=debug msg="Initialized graph driver windowsfilter"
time="2018-12-20T14:56:46.907151800+01:00" level=debug msg="Max Concurrent Downloads: 3"
time="2018-12-20T14:56:46.907151800+01:00" level=debug msg="Max Concurrent Uploads: 5"
time="2018-12-20T14:56:46.909157500+01:00" level=debug msg="hcsshim::DestroyLayer path C:\\ProgramData\\docker\\windowsfilter\\ff12aee57608aa51015d317f49f1d795a334920b732d7be91e26fc9c2407e279-removing"
time="2018-12-20T14:56:47.101257900+01:00" level=debug msg="hcsshim::DestroyLayer succeeded path=C:\\ProgramData\\docker\\windowsfilter\\ff12aee57608aa51015d317f49f1d795a334920b732d7be91e26fc9c2407e279-removing"
time="2018-12-20T14:56:47.101257900+01:00" level=info msg="Cleaned up ff12aee57608aa51015d317f49f1d795a334920b732d7be91e26fc9c2407e279-removing"
time="2018-12-20T14:56:47.101257900+01:00" level=info msg="Loading containers: start."
```

Partly solves docker/for-win#745

Layers which misses *-removing* suffix still need to be find using https://github.com/jhowardmsft/docker-leak-check or https://gist.github.com/olljanat/340b4033eb24d8d33ec75f2c3c3b6b3d
