### PR TITLE
Bump Golang to 1.12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM golang:1.11.5 AS base
+FROM golang:1.12.1 AS base
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org
 RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,5 +1,5 @@
 ## Step 1: Build tests
-FROM golang:1.11.5-alpine3.8 as builder
+FROM golang:1.12.1-alpine3.9 as builder
 
 RUN apk --no-cache add \
     bash \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-FROM golang:1.11.5-stretch
+FROM golang:1.12.1
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -168,7 +168,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
-ENV GO_VERSION=1.11.5 `
+ENV GO_VERSION=1.12.1 `
     GIT_VERSION=2.11.1 `
     GOPATH=C:\go `
     FROM_DOCKERFILE=1


### PR DESCRIPTION
Follow-up to https://github.com/moby/moby/pull/38402 and https://github.com/moby/moby/pull/38403


Opening this PR to updates to Golang 1.12, and see if there are regressions / issues 


Job                 | Status | Notes
--------------------|--------------------|------------------------------------------------------------------------------
docker-py           | :white_check_mark: | fixed by https://github.com/moby/moby/pull/38758
experimental        | :white_check_mark: | 
Janky (amd64)       | :white_check_mark: | ~flaky test failing (https://github.com/moby/moby/issues/38720)~ resolved by https://github.com/moby/moby/pull/38737
powerpc (ppc64le)   | :white_check_mark:                | ~Go regression https://github.com/golang/go/issues/30283~ resolved by https://github.com/golang/go/commit/2d3474043cd35ba06d3566df520e8550c479944f
windowsRS1          | :white_check_mark:                | ~Go regression https://github.com/golang/go/issues/30307~ resolved by https://github.com/golang/go/commit/c55fb33612cd35741a19137b73e77bb226a4635f
windowsRS5-process  | :white_check_mark:                | ~Go regression https://github.com/golang/go/issues/30307~ resolved by https://github.com/golang/go/commit/c55fb33612cd35741a19137b73e77bb226a4635f (same as above)
z (s390x)           | :white_check_mark: | 