### PR TITLE
Enable checkpoint/restore of containers with TTY

### DIFF
--- a/daemon/checkpoint.go
+++ b/daemon/checkpoint.go
@@ -63,10 +63,6 @@ func (daemon *Daemon) CheckpointCreate(name string, config types.CheckpointCreat
 		return fmt.Errorf("Container %s not running", name)
 	}
 
-	if container.Config.Tty {
-		return fmt.Errorf("checkpoint not support on containers with tty")
-	}
-
 	if !validCheckpointNamePattern.MatchString(config.CheckpointID) {
 		return fmt.Errorf("Invalid checkpoint ID (%s), only %s are allowed", config.CheckpointID, validCheckpointNameChars)
 	}


### PR DESCRIPTION
CRIU supports checkpoint and restore of tty devices since version 2.12
which was released on 8th of March 2017. Support for this functionality
was implemented with opencontainers/runc@1c43d09 (checkpoint: add
support for containers with terminals) and containerd/containerd@60daa41
(Allow to checkpoint and restore a container with console).

Therefore, we can enable the support in moby/docker.

Signed-off-by: Radostin Stoyanov <rstoyanov1@gmail.com>

**- How to verify it**
```
$ docker run -dit --name apache-app -p 8080:80 httpd:2.4
$ curl http://localhost:8080
<html><body><h1>It works!</h1></body></html>
$ docker checkpoint create apache-app c1
$ docker start --checkpoint c1 apache-app
$ curl http://localhost:8080
<html><body><h1>It works!</h1></body></html>
```