### PR TITLE
integration-cli/build: don't panic ;)

### DIFF
--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -298,7 +298,7 @@ func (s *DockerSuite) TestBuildOnBuildCache(c *check.C) {
 
 		out, err := request.ReadBody(body)
 		assert.NilError(c, err)
-		assert.Check(c, is.Contains(string(out), "Successfully built"))
+		assert.Assert(c, is.Contains(string(out), "Successfully built"))
 		return out
 	}
 
@@ -313,7 +313,7 @@ func (s *DockerSuite) TestBuildOnBuildCache(c *check.C) {
 	out := build(dockerfile)
 
 	imageIDs := getImageIDsFromBuild(c, out)
-	assert.Check(c, is.Len(imageIDs, 2))
+	assert.Assert(c, is.Len(imageIDs, 2))
 	parentID, childID := imageIDs[0], imageIDs[1]
 
 	client := testEnv.APIClient()
@@ -457,8 +457,10 @@ COPY file /file`
 
 		out, err := request.ReadBody(body)
 		assert.NilError(c, err)
+		assert.Assert(c, is.Contains(string(out), "Successfully built"))
 
 		ids := getImageIDsFromBuild(c, out)
+		assert.Assert(c, is.Len(ids, 1))
 		return ids[len(ids)-1]
 	}
 
@@ -496,8 +498,10 @@ ADD file /file`
 
 		out, err := request.ReadBody(body)
 		assert.NilError(c, err)
+		assert.Assert(c, is.Contains(string(out), "Successfully built"))
 
 		ids := getImageIDsFromBuild(c, out)
+		assert.Assert(c, is.Len(ids, 1))
 		return ids[len(ids)-1]
 	}
 


### PR DESCRIPTION
A lack of check in the test code can lead to a panic due to
`len(ids)` being `0`.

Avoid the panic by adding appropriate checks. Note `Assert()` should be
used rather than `Check()` as if it fails we should not proceed with the
test.

Originally found in https://github.com/moby/moby/pull/38404.