### PR TITLE
[carry 37513] Honor DOCKER_BUILDKIT in integration tests

### DIFF
--- a/builder/buildutil/session.go
+++ b/builder/buildutil/session.go
@@ -1,0 +1,58 @@
+package buildutil
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+
+	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/client"
+	"github.com/moby/buildkit/session"
+	"github.com/pkg/errors"
+)
+
+const clientSessionRemote = "client-session"
+
+var nodeID = "nodeID"
+
+func isSessionSupported(c client.APIClient) bool {
+	ping, err := c.Ping(context.TODO())
+	if err != nil {
+		panic(fmt.Errorf("could not ping: %v", err))
+	}
+	return ping.Experimental && versions.GreaterThanOrEqualTo(c.ClientVersion(), "1.31")
+}
+
+func trySession(c client.APIClient, contextDir string) (*session.Session, error) {
+	var s *session.Session
+	if isSessionSupported(c) {
+		sharedKey, err := getBuildSharedKey(contextDir)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get build shared key")
+		}
+		s, err = session.NewSession(context.Background(), filepath.Base(contextDir), sharedKey)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create session")
+		}
+	}
+	return s, nil
+}
+
+func getBuildSharedKey(dir string) (string, error) {
+	// build session is hash of build dir with node based randomness
+	s := sha256.Sum256([]byte(fmt.Sprintf("%s:%s", tryNodeIdentifier(), dir)))
+	return hex.EncodeToString(s[:]), nil
+}
+
+func tryNodeIdentifier() string {
+	if nodeID == "nodeID" {
+		b := make([]byte, 32)
+		if _, err := rand.Read(b); err == nil {
+			nodeID = hex.EncodeToString(b)
+		}
+	}
+	return nodeID
+}

--- a/builder/buildutil/util.go
+++ b/builder/buildutil/util.go
@@ -1,0 +1,64 @@
+/*
+Package buildutil is a wrapper around client package for easier to use build functions.
+*/
+package buildutil
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
+)
+
+// BuildResult encapsulates the result of a build.
+type BuildResult struct {
+	types.BuildResult
+	Output []byte
+}
+
+// BuildInput specifies how to get the context.
+type BuildInput struct {
+	Context io.Reader
+}
+
+// Build will call client package's ImageBuild and parse the JSONMessage responses into an easy to consume BuildResult.
+func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions) (*BuildResult, error) {
+	ctx := context.Background()
+	br := &BuildResult{}
+	resp, err := c.ImageBuild(ctx, input.Context, options)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	dec := json.NewDecoder(resp.Body)
+	for {
+		var jm jsonmessage.JSONMessage
+		if err := dec.Decode(&jm); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return br, err
+		}
+		if jm.Error != nil {
+			return br, jm.Error
+		}
+		if jm.ID == "" {
+			br.Output = append(br.Output, []byte(jm.Stream)...)
+		}
+		if jm.Aux != nil {
+			switch jm.ID {
+			case "": // legacy builder
+				if err := json.Unmarshal(*jm.Aux, &br.BuildResult); err != nil {
+					return br, err
+				}
+				if br.ID != "" {
+					br.ID = br.ID
+				}
+			}
+		}
+	}
+	return br, nil
+}

--- a/builder/buildutil/util.go
+++ b/builder/buildutil/util.go
@@ -4,13 +4,18 @@ Package buildutil is a wrapper around client package for easier to use build fun
 package buildutil
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/filesync"
+	"github.com/sirupsen/logrus"
 )
 
 // BuildResult encapsulates the result of a build.
@@ -19,16 +24,57 @@ type BuildResult struct {
 	Output []byte
 }
 
-// BuildInput specifies how to get the context.
+// BuildInput specifies how to get the context or Dockerfile.
 type BuildInput struct {
-	Context io.Reader
+	Context    io.Reader
+	ContextDir string
+	Dockerfile []byte
 }
 
 // Build will call client package's ImageBuild and parse the JSONMessage responses into an easy to consume BuildResult.
 func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions) (*BuildResult, error) {
 	ctx := context.Background()
 	br := &BuildResult{}
-	resp, err := c.ImageBuild(ctx, input.Context, options)
+	var sess *session.Session
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	buildCtx := input.Context
+	if input.Context == nil && options.RemoteContext == "" {
+		sess, err := trySession(c, input.ContextDir)
+		if err != nil {
+			return br, err
+		}
+		if sess == nil {
+			return br, fmt.Errorf("session not supported")
+		}
+
+		dirs := make([]filesync.SyncedDir, 0, 1)
+		if input.ContextDir != "" {
+			dirs = append(dirs, filesync.SyncedDir{Dir: input.ContextDir})
+		}
+		if input.Dockerfile != nil {
+			buildCtx = bytes.NewReader(input.Dockerfile)
+		}
+		sess.Allow(filesync.NewFSSyncProvider(dirs))
+
+		options.SessionID = sess.ID()
+		options.RemoteContext = clientSessionRemote
+
+		go func() {
+			if err := sess.Run(ctx, c.DialSession); err != nil {
+				logrus.Error(err)
+				cancel()
+			}
+		}()
+	}
+
+	if sess != nil {
+		defer sess.Close()
+	}
+
+	resp, err := c.ImageBuild(ctx, buildCtx, options)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/buildutil/util.go
+++ b/builder/buildutil/util.go
@@ -1,30 +1,93 @@
 /*
 Package buildutil is a wrapper around client package for easier to use build functions.
+To be used only in tests for now.
 */
 package buildutil
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
+	controlapi "github.com/moby/buildkit/api/services/control"
+	bkclient "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/sirupsen/logrus"
+	fsutypes "github.com/tonistiigi/fsutil/types"
 )
+
+// BuildKitEnabled returns whether BuildKit was enabled through the DOCKER_BUILDKIT environment variable.
+// TODO: Remove this and allow caller to set it.
+func BuildKitEnabled() bool {
+	return os.Getenv("DOCKER_BUILDKIT") == "1"
+}
 
 // BuildResult encapsulates the result of a build.
 type BuildResult struct {
 	types.BuildResult
+
+	ss bkclient.SolveStatus
+
+	// for legacy builder
+
 	Output []byte
 }
 
-// BuildInput specifies how to get the context or Dockerfile.
+// OutputContains returns whether the output from RUN instructions contains a specified search term.
+// In legacy builder, this will search within the entire output of the build (not just RUN instructions' output).
+func (br *BuildResult) OutputContains(b []byte) bool {
+	if !BuildKitEnabled() {
+		return bytes.Contains(br.Output, b)
+	}
+	for _, v := range br.ss.Logs {
+		if bytes.Contains(v.Data, b) {
+			return true
+		}
+	}
+	return false
+}
+
+// CacheHit looks for a Dockerfile step to match with substr and returns whether that step was cached.
+// Use randomized strings to match for best quality. Otherwise double check there are no false positives.
+func (br *BuildResult) CacheHit(substr string) bool {
+	if !BuildKitEnabled() {
+		// Parse output by finding first line matching "Using cache", that is below a line matching substr
+		s := bufio.NewScanner(bytes.NewReader(br.Output))
+		substrMatched := false
+		for s.Scan() {
+			if !substrMatched {
+				if bytes.Contains(s.Bytes(), []byte(substr)) {
+					substrMatched = true
+				}
+			} else {
+				if bytes.Equal(s.Bytes(), []byte(" ---> Using cache")) {
+					return true
+				}
+				substrMatched = false
+			}
+		}
+		return false
+	}
+	for _, v := range br.ss.Vertexes {
+		if strings.Contains(v.Name, substr) && v.Cached {
+			return true
+		}
+	}
+	return false
+}
+
+// BuildInput specifies how to get the build context or Dockerfile.
 type BuildInput struct {
 	Context    io.Reader
 	ContextDir string
@@ -40,7 +103,16 @@ func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	if BuildKitEnabled() {
+		if options.Version != "" && options.Version != types.BuilderBuildKit {
+			return br, fmt.Errorf("Conflict: buildkit was enabled but ImageBuildOptions.Version differs: %s", options.Version)
+		}
+		options.Version = types.BuilderBuildKit
+	}
+
 	buildCtx := input.Context
+
+	// if streaming
 	if input.Context == nil && options.RemoteContext == "" {
 		sess, err := trySession(c, input.ContextDir)
 		if err != nil {
@@ -52,10 +124,26 @@ func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions
 
 		dirs := make([]filesync.SyncedDir, 0, 1)
 		if input.ContextDir != "" {
-			dirs = append(dirs, filesync.SyncedDir{Dir: input.ContextDir})
+			var name string
+			if BuildKitEnabled() {
+				name = "context"
+			}
+			dirs = append(dirs, filesync.SyncedDir{Name: name, Dir: input.ContextDir, Map: resetUIDAndGID})
 		}
 		if input.Dockerfile != nil {
-			buildCtx = bytes.NewReader(input.Dockerfile)
+			if BuildKitEnabled() {
+				dd, err := ioutil.TempDir("", "dockerfiledir")
+				if err != nil {
+					return br, err
+				}
+				defer os.RemoveAll(dd)
+				if err := ioutil.WriteFile(filepath.Join(dd, "Dockerfile"), input.Dockerfile, 0644); err != nil {
+					return br, err
+				}
+				dirs = append(dirs, filesync.SyncedDir{Name: "dockerfile", Dir: dd})
+			} else {
+				buildCtx = bytes.NewReader(input.Dockerfile)
+			}
 		}
 		sess.Allow(filesync.NewFSSyncProvider(dirs))
 
@@ -76,7 +164,7 @@ func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions
 
 	resp, err := c.ImageBuild(ctx, buildCtx, options)
 	if err != nil {
-		return nil, err
+		return br, err
 	}
 	defer resp.Body.Close()
 	dec := json.NewDecoder(resp.Body)
@@ -96,7 +184,51 @@ func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions
 		}
 		if jm.Aux != nil {
 			switch jm.ID {
-			case "": // legacy builder
+			case "moby.buildkit.trace":
+				var resp controlapi.StatusResponse
+				var dt []byte
+
+				// ignoring all messages that are not understood
+				if err := json.Unmarshal(*jm.Aux, &dt); err != nil {
+					continue
+				}
+				if err := (&resp).Unmarshal(dt); err != nil {
+					continue
+				}
+
+				s := &br.ss
+				for _, v := range resp.Vertexes {
+					s.Vertexes = append(s.Vertexes, &bkclient.Vertex{
+						Digest:    v.Digest,
+						Inputs:    v.Inputs,
+						Name:      v.Name,
+						Started:   v.Started,
+						Completed: v.Completed,
+						Error:     v.Error,
+						Cached:    v.Cached,
+					})
+				}
+				for _, v := range resp.Statuses {
+					s.Statuses = append(s.Statuses, &bkclient.VertexStatus{
+						ID:        v.ID,
+						Vertex:    v.Vertex,
+						Name:      v.Name,
+						Total:     v.Total,
+						Current:   v.Current,
+						Timestamp: v.Timestamp,
+						Started:   v.Started,
+						Completed: v.Completed,
+					})
+				}
+				for _, v := range resp.Logs {
+					s.Logs = append(s.Logs, &bkclient.VertexLog{
+						Vertex:    v.Vertex,
+						Stream:    int(v.Stream),
+						Data:      v.Msg,
+						Timestamp: v.Timestamp,
+					})
+				}
+			case "", "moby.image.id":
 				if err := json.Unmarshal(*jm.Aux, &br.BuildResult); err != nil {
 					return br, err
 				}
@@ -107,4 +239,10 @@ func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions
 		}
 	}
 	return br, nil
+}
+
+func resetUIDAndGID(s *fsutypes.Stat) bool {
+	s.Uid = 0
+	s.Gid = 0
+	return true
 }

--- a/builder/buildutil/util.go
+++ b/builder/buildutil/util.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/docker/pkg/jsonmessage"
 	controlapi "github.com/moby/buildkit/api/services/control"
 	bkclient "github.com/moby/buildkit/client"
-	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/sirupsen/logrus"
 	fsutypes "github.com/tonistiigi/fsutil/types"
@@ -98,7 +97,6 @@ type BuildInput struct {
 func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions) (*BuildResult, error) {
 	ctx := context.Background()
 	br := &BuildResult{}
-	var sess *session.Session
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -113,53 +111,65 @@ func Build(c client.APIClient, input BuildInput, options types.ImageBuildOptions
 	buildCtx := input.Context
 
 	// if streaming
-	if input.Context == nil && options.RemoteContext == "" {
+	if input.Context == nil && (input.ContextDir != "" || input.Dockerfile != nil) && options.RemoteContext == "" {
 		sess, err := trySession(c, input.ContextDir)
 		if err != nil {
 			return br, err
 		}
-		if sess == nil {
-			return br, fmt.Errorf("session not supported")
-		}
+		if sess != nil {
+			defer sess.Close()
 
-		dirs := make([]filesync.SyncedDir, 0, 1)
-		if input.ContextDir != "" {
 			var name string
 			if BuildKitEnabled() {
 				name = "context"
 			}
-			dirs = append(dirs, filesync.SyncedDir{Name: name, Dir: input.ContextDir, Map: resetUIDAndGID})
-		}
-		if input.Dockerfile != nil {
-			if BuildKitEnabled() {
-				dd, err := ioutil.TempDir("", "dockerfiledir")
+
+			dirs := make([]filesync.SyncedDir, 0, 1)
+			if input.Dockerfile != nil {
+				if BuildKitEnabled() {
+					dd, err := ioutil.TempDir("", "dockerfiledir")
+					if err != nil {
+						return br, err
+					}
+					defer os.RemoveAll(dd)
+					if err := ioutil.WriteFile(filepath.Join(dd, "Dockerfile"), input.Dockerfile, 0644); err != nil {
+						return br, err
+					}
+					dirs = append(dirs, filesync.SyncedDir{Name: "dockerfile", Dir: dd})
+				} else {
+					buildCtx = ioutil.NopCloser(bytes.NewReader(input.Dockerfile))
+				}
+			}
+
+			ctxDir := input.ContextDir
+			if ctxDir == "" {
+				// TODO: provide empty string support in fsutil
+				ctxDir, err = ioutil.TempDir("", "contextdir")
 				if err != nil {
 					return br, err
 				}
-				defer os.RemoveAll(dd)
-				if err := ioutil.WriteFile(filepath.Join(dd, "Dockerfile"), input.Dockerfile, 0644); err != nil {
-					return br, err
+				defer os.RemoveAll(ctxDir)
+			}
+			dirs = append(dirs, filesync.SyncedDir{Name: name, Dir: ctxDir, Map: resetUIDAndGID})
+			sess.Allow(filesync.NewFSSyncProvider(dirs))
+
+			options.SessionID = sess.ID()
+			options.RemoteContext = clientSessionRemote
+
+			go func() {
+				if err := sess.Run(ctx, c.DialSession); err != nil {
+					logrus.Error(err)
+					cancel()
 				}
-				dirs = append(dirs, filesync.SyncedDir{Name: "dockerfile", Dir: dd})
-			} else {
+			}()
+		} else { // streaming is not available
+			if input.ContextDir != "" {
+				return br, fmt.Errorf("ContextDir not implemented without session")
+			}
+			if input.Dockerfile != nil {
 				buildCtx = bytes.NewReader(input.Dockerfile)
 			}
 		}
-		sess.Allow(filesync.NewFSSyncProvider(dirs))
-
-		options.SessionID = sess.ID()
-		options.RemoteContext = clientSessionRemote
-
-		go func() {
-			if err := sess.Run(ctx, c.DialSession); err != nil {
-				logrus.Error(err)
-				cancel()
-			}
-		}()
-	}
-
-	if sess != nil {
-		defer sess.Close()
 	}
 
 	resp, err := c.ImageBuild(ctx, buildCtx, options)

--- a/integration/build/build_session_test.go
+++ b/integration/build/build_session_test.go
@@ -2,7 +2,6 @@ package build
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -36,7 +35,7 @@ func TestBuildWithSession(t *testing.T) {
 
 	res, err := buildutil.Build(client, buildutil.BuildInput{ContextDir: fctx.Dir, Dockerfile: []byte(dockerfile)}, types.ImageBuildOptions{})
 	assert.NilError(t, err)
-	assert.Check(t, is.Contains(string(res.Output), "some content"))
+	assert.Check(t, res.OutputContains([]byte("some content")))
 
 	fctx.Add("second", "contentcontent")
 
@@ -47,8 +46,8 @@ func TestBuildWithSession(t *testing.T) {
 
 	res, err = buildutil.Build(client, buildutil.BuildInput{ContextDir: fctx.Dir, Dockerfile: []byte(dockerfile)}, types.ImageBuildOptions{})
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal(strings.Count(string(res.Output), "Using cache"), 2))
-	assert.Check(t, is.Contains(string(res.Output), "contentcontent"))
+	assert.Check(t, res.CacheHit("cat /file"))
+	assert.Check(t, res.OutputContains([]byte("contentcontent")))
 
 	du, err := client.DiskUsage(context.TODO())
 	assert.Check(t, err)
@@ -56,7 +55,7 @@ func TestBuildWithSession(t *testing.T) {
 
 	res, err = buildutil.Build(client, buildutil.BuildInput{ContextDir: fctx.Dir, Dockerfile: []byte(dockerfile)}, types.ImageBuildOptions{})
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal(strings.Count(string(res.Output), "Using cache"), 4))
+	assert.Check(t, res.CacheHit("cat /second"))
 
 	du2, err := client.DiskUsage(context.TODO())
 	assert.Check(t, err)
@@ -72,8 +71,7 @@ func TestBuildWithSession(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
-	assert.Check(t, is.Contains(string(res.Output), "Successfully built"))
-	assert.Check(t, is.Equal(strings.Count(string(res.Output), "Using cache"), 4))
+	assert.Check(t, res.CacheHit("cat /second"))
 
 	_, err = client.BuildCachePrune(context.TODO(), types.BuildCachePruneOptions{All: true})
 	assert.Check(t, err)

--- a/integration/build/build_session_test.go
+++ b/integration/build/build_session_test.go
@@ -7,12 +7,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder/buildutil"
-	"github.com/docker/docker/client"
 	"github.com/docker/docker/internal/test/daemon"
 	"github.com/docker/docker/internal/test/fakecontext"
-	"github.com/moby/buildkit/session"
-	"github.com/moby/buildkit/session/filesync"
-	"golang.org/x/sync/errgroup"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/skip"
@@ -38,8 +34,9 @@ func TestBuildWithSession(t *testing.T) {
 	)
 	defer fctx.Close()
 
-	out := testBuildWithSession(t, client, fctx.Dir, dockerfile)
-	assert.Check(t, is.Contains(out, "some content"))
+	res, err := buildutil.Build(client, buildutil.BuildInput{ContextDir: fctx.Dir, Dockerfile: []byte(dockerfile)}, types.ImageBuildOptions{})
+	assert.NilError(t, err)
+	assert.Check(t, is.Contains(string(res.Output), "some content"))
 
 	fctx.Add("second", "contentcontent")
 
@@ -48,16 +45,18 @@ func TestBuildWithSession(t *testing.T) {
 	RUN cat /second
 	`
 
-	out = testBuildWithSession(t, client, fctx.Dir, dockerfile)
-	assert.Check(t, is.Equal(strings.Count(out, "Using cache"), 2))
-	assert.Check(t, is.Contains(out, "contentcontent"))
+	res, err = buildutil.Build(client, buildutil.BuildInput{ContextDir: fctx.Dir, Dockerfile: []byte(dockerfile)}, types.ImageBuildOptions{})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(strings.Count(string(res.Output), "Using cache"), 2))
+	assert.Check(t, is.Contains(string(res.Output), "contentcontent"))
 
 	du, err := client.DiskUsage(context.TODO())
 	assert.Check(t, err)
 	assert.Check(t, du.BuilderSize > 10)
 
-	out = testBuildWithSession(t, client, fctx.Dir, dockerfile)
-	assert.Check(t, is.Equal(strings.Count(out, "Using cache"), 4))
+	res, err = buildutil.Build(client, buildutil.BuildInput{ContextDir: fctx.Dir, Dockerfile: []byte(dockerfile)}, types.ImageBuildOptions{})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(strings.Count(string(res.Output), "Using cache"), 4))
 
 	du2, err := client.DiskUsage(context.TODO())
 	assert.Check(t, err)
@@ -66,7 +65,7 @@ func TestBuildWithSession(t *testing.T) {
 	// rebuild with regular tar, confirm cache still applies
 	fctx.Add("Dockerfile", dockerfile)
 
-	res, err := buildutil.Build(
+	res, err = buildutil.Build(
 		client,
 		buildutil.BuildInput{Context: fctx.AsTarReader(t)},
 		types.ImageBuildOptions{},
@@ -82,40 +81,4 @@ func TestBuildWithSession(t *testing.T) {
 	du, err = client.DiskUsage(context.TODO())
 	assert.Check(t, err)
 	assert.Check(t, is.Equal(du.BuilderSize, int64(0)))
-}
-
-func testBuildWithSession(t *testing.T, client client.APIClient, dir, dockerfile string) (outStr string) {
-	ctx := context.Background()
-	sess, err := session.NewSession(ctx, "foo1", "foo")
-	assert.Check(t, err)
-
-	fsProvider := filesync.NewFSSyncProvider([]filesync.SyncedDir{
-		{Dir: dir},
-	})
-	sess.Allow(fsProvider)
-
-	g, ctx := errgroup.WithContext(ctx)
-
-	g.Go(func() error {
-		return sess.Run(ctx, client.DialSession)
-	})
-
-	g.Go(func() error {
-		res, err := buildutil.Build(
-			client,
-			buildutil.BuildInput{Context: strings.NewReader(dockerfile)},
-			types.ImageBuildOptions{
-				RemoteContext: "client-session",
-				SessionID:     sess.ID(),
-			},
-		)
-		assert.NilError(t, err)
-		sess.Close()
-		outStr = string(res.Output)
-		return nil
-	})
-
-	err = g.Wait()
-	assert.Check(t, err)
-	return
 }

--- a/integration/build/build_session_test.go
+++ b/integration/build/build_session_test.go
@@ -2,16 +2,14 @@ package build
 
 import (
 	"context"
-	"io/ioutil"
-	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	dclient "github.com/docker/docker/client"
+	"github.com/docker/docker/builder/buildutil"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/internal/test/daemon"
 	"github.com/docker/docker/internal/test/fakecontext"
-	"github.com/docker/docker/internal/test/request"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"golang.org/x/sync/errgroup"
@@ -40,7 +38,7 @@ func TestBuildWithSession(t *testing.T) {
 	)
 	defer fctx.Close()
 
-	out := testBuildWithSession(t, client, client.DaemonHost(), fctx.Dir, dockerfile)
+	out := testBuildWithSession(t, client, fctx.Dir, dockerfile)
 	assert.Check(t, is.Contains(out, "some content"))
 
 	fctx.Add("second", "contentcontent")
@@ -50,7 +48,7 @@ func TestBuildWithSession(t *testing.T) {
 	RUN cat /second
 	`
 
-	out = testBuildWithSession(t, client, client.DaemonHost(), fctx.Dir, dockerfile)
+	out = testBuildWithSession(t, client, fctx.Dir, dockerfile)
 	assert.Check(t, is.Equal(strings.Count(out, "Using cache"), 2))
 	assert.Check(t, is.Contains(out, "contentcontent"))
 
@@ -58,7 +56,7 @@ func TestBuildWithSession(t *testing.T) {
 	assert.Check(t, err)
 	assert.Check(t, du.BuilderSize > 10)
 
-	out = testBuildWithSession(t, client, client.DaemonHost(), fctx.Dir, dockerfile)
+	out = testBuildWithSession(t, client, fctx.Dir, dockerfile)
 	assert.Check(t, is.Equal(strings.Count(out, "Using cache"), 4))
 
 	du2, err := client.DiskUsage(context.TODO())
@@ -67,20 +65,16 @@ func TestBuildWithSession(t *testing.T) {
 
 	// rebuild with regular tar, confirm cache still applies
 	fctx.Add("Dockerfile", dockerfile)
-	// FIXME(vdemeester) use sock here
-	res, body, err := request.Do(
-		"/build",
-		request.Host(client.DaemonHost()),
-		request.Method(http.MethodPost),
-		request.RawContent(fctx.AsTarReader(t)),
-		request.ContentType("application/x-tar"))
-	assert.NilError(t, err)
-	assert.Check(t, is.DeepEqual(http.StatusOK, res.StatusCode))
 
-	outBytes, err := request.ReadBody(body)
+	res, err := buildutil.Build(
+		client,
+		buildutil.BuildInput{Context: fctx.AsTarReader(t)},
+		types.ImageBuildOptions{},
+	)
 	assert.NilError(t, err)
-	assert.Check(t, is.Contains(string(outBytes), "Successfully built"))
-	assert.Check(t, is.Equal(strings.Count(string(outBytes), "Using cache"), 4))
+
+	assert.Check(t, is.Contains(string(res.Output), "Successfully built"))
+	assert.Check(t, is.Equal(strings.Count(string(res.Output), "Using cache"), 4))
 
 	_, err = client.BuildCachePrune(context.TODO(), types.BuildCachePruneOptions{All: true})
 	assert.Check(t, err)
@@ -90,7 +84,7 @@ func TestBuildWithSession(t *testing.T) {
 	assert.Check(t, is.Equal(du.BuilderSize, int64(0)))
 }
 
-func testBuildWithSession(t *testing.T, client dclient.APIClient, daemonHost string, dir, dockerfile string) (outStr string) {
+func testBuildWithSession(t *testing.T, client client.APIClient, dir, dockerfile string) (outStr string) {
 	ctx := context.Background()
 	sess, err := session.NewSession(ctx, "foo1", "foo")
 	assert.Check(t, err)
@@ -107,25 +101,17 @@ func testBuildWithSession(t *testing.T, client dclient.APIClient, daemonHost str
 	})
 
 	g.Go(func() error {
-		// FIXME use sock here
-		res, body, err := request.Do(
-			"/build?remote=client-session&session="+sess.ID(),
-			request.Host(daemonHost),
-			request.Method(http.MethodPost),
-			request.With(func(req *http.Request) error {
-				req.Body = ioutil.NopCloser(strings.NewReader(dockerfile))
-				return nil
-			}),
+		res, err := buildutil.Build(
+			client,
+			buildutil.BuildInput{Context: strings.NewReader(dockerfile)},
+			types.ImageBuildOptions{
+				RemoteContext: "client-session",
+				SessionID:     sess.ID(),
+			},
 		)
-		if err != nil {
-			return err
-		}
-		assert.Check(t, is.DeepEqual(res.StatusCode, http.StatusOK))
-		out, err := request.ReadBody(body)
 		assert.NilError(t, err)
-		assert.Check(t, is.Contains(string(out), "Successfully built"))
 		sess.Close()
-		outStr = string(out)
+		outStr = string(res.Output)
 		return nil
 	})
 

--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -3,12 +3,12 @@ package build
 import (
 	"bytes"
 	"context"
-	"io"
 	"io/ioutil"
 	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/builder/buildutil"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/test/daemon"
 	"github.com/docker/docker/internal/test/fakecontext"
@@ -43,16 +43,13 @@ func TestBuildSquashParent(t *testing.T) {
 	defer source.Close()
 
 	name := "test"
-	resp, err := client.ImageBuild(ctx,
-		source.AsTarReader(t),
+	_, err := buildutil.Build(client,
+		buildutil.BuildInput{Context: source.AsTarReader(t)},
 		types.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Tags:        []string{name},
 		})
-	assert.NilError(t, err)
-	_, err = io.Copy(ioutil.Discard, resp.Body)
-	resp.Body.Close()
 	assert.NilError(t, err)
 
 	inspect, _, err := client.ImageInspectWithRaw(ctx, name)
@@ -60,17 +57,14 @@ func TestBuildSquashParent(t *testing.T) {
 	origID := inspect.ID
 
 	// build with squash
-	resp, err = client.ImageBuild(ctx,
-		source.AsTarReader(t),
+	_, err = buildutil.Build(client,
+		buildutil.BuildInput{Context: source.AsTarReader(t)},
 		types.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Squash:      true,
 			Tags:        []string{name},
 		})
-	assert.NilError(t, err)
-	_, err = io.Copy(ioutil.Discard, resp.Body)
-	resp.Body.Close()
 	assert.NilError(t, err)
 
 	cid := container.Run(t, ctx, client,

--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -22,6 +22,7 @@ func TestBuildSquashParent(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, !testEnv.DaemonInfo.ExperimentalBuild)
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, buildutil.BuildKitEnabled, "TODO BuildKit + --squash ?")
 	d := daemon.New(t, daemon.WithExperimental)
 	d.StartWithBusybox(t)
 	defer d.Stop(t)

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -22,6 +22,7 @@ import (
 
 func TestBuildWithRemoveAndForceRemove(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
+	skip.If(t, buildutil.BuildKitEnabled, "buildkit does not leak into container store")
 	defer setupTest(t)()
 
 	cases := []struct {
@@ -290,7 +291,7 @@ RUN cat somefile`
 	defer source.Close()
 
 	apiclient := testEnv.APIClient()
-	resp, err := buildutil.Build(apiclient,
+	res, err := buildutil.Build(apiclient,
 		buildutil.BuildInput{Context: source.AsTarReader(t)},
 		types.ImageBuildOptions{
 			Remove:      true,
@@ -299,9 +300,7 @@ RUN cat somefile`
 
 	assert.NilError(t, err)
 
-	assert.Check(t, is.Contains(string(resp.Output), "Successfully built"))
-
-	image, _, err := apiclient.ImageInspectWithRaw(context.Background(), resp.ID)
+	image, _, err := apiclient.ImageInspectWithRaw(context.Background(), res.ID)
 	assert.NilError(t, err)
 	assert.Check(t, is.Contains(image.Config.Env, "bar=baz"))
 }
@@ -344,7 +343,7 @@ COPY bar /`
 	err = w.Close()
 	assert.NilError(t, err)
 
-	resp, err := buildutil.Build(apiclient,
+	res, err := buildutil.Build(apiclient,
 		buildutil.BuildInput{Context: buf},
 		types.ImageBuildOptions{
 			Remove:      true,
@@ -352,7 +351,7 @@ COPY bar /`
 		})
 
 	assert.NilError(t, err)
-	assert.Assert(t, !strings.Contains(string(resp.Output), "Using cache"))
+	assert.Assert(t, !res.CacheHit("bar"))
 }
 
 // docker/for-linux#135
@@ -380,16 +379,13 @@ RUN [ ! -f foo ]
 	defer source.Close()
 
 	apiclient := testEnv.APIClient()
-	resp, err := buildutil.Build(apiclient,
+	_, err := buildutil.Build(apiclient,
 		buildutil.BuildInput{Context: source.AsTarReader(t)},
 		types.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
-
 	assert.NilError(t, err)
-
-	assert.Check(t, is.Contains(string(resp.Output), "Successfully built"))
 }
 
 // #37581


### PR DESCRIPTION
carry of https://github.com/moby/moby/pull/37513
closes https://github.com/moby/moby/pull/37513

This PR refactors code in `integration/build/` and honors the DOCKER_BUILDKIT environment variable.

It introduces a new `integration/build/buildutil` package that could in the future be refactored into a easier to use docker client package.

All integration (non-cli) tests should pass with or without BuildKit enabled.