### PR TITLE
Fix TestBuildWithSession, TestBuildSquashParent using wrong daemon during test

### DIFF
--- a/integration/build/build_session_test.go
+++ b/integration/build/build_session_test.go
@@ -27,7 +27,7 @@ func TestBuildWithSession(t *testing.T) {
 	d.StartWithBusybox(t)
 	defer d.Stop(t)
 
-	client := testEnv.APIClient()
+	client := d.NewClientT(t)
 
 	dockerfile := `
 		FROM busybox

--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -26,7 +26,7 @@ func TestBuildSquashParent(t *testing.T) {
 	d.StartWithBusybox(t)
 	defer d.Stop(t)
 
-	client := testEnv.APIClient()
+	client := d.NewClientT(t)
 
 	dockerfile := `
 		FROM busybox


### PR DESCRIPTION
These tests were spinning up a new daemon, but after the daemon was spun up, the default test-daemon was used by the client.
