### PR TITLE
Testing: create new daemon (only) if needed

### DIFF
--- a/integration/build/build_session_test.go
+++ b/integration/build/build_session_test.go
@@ -21,13 +21,19 @@ import (
 )
 
 func TestBuildWithSession(t *testing.T) {
-	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-	d := daemon.New(t, daemon.WithExperimental)
-	d.StartWithBusybox(t)
-	defer d.Stop(t)
 
-	client := d.NewClientT(t)
+	var client dclient.APIClient
+	if !testEnv.DaemonInfo.ExperimentalBuild {
+		skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+
+		d := daemon.New(t, daemon.WithExperimental)
+		d.StartWithBusybox(t)
+		defer d.Stop(t)
+		client = d.NewClientT(t)
+	} else {
+		client = testEnv.APIClient()
+	}
 
 	dockerfile := `
 		FROM busybox

--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	dclient "github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/test/daemon"
 	"github.com/docker/docker/internal/test/fakecontext"
@@ -20,13 +21,18 @@ import (
 
 func TestBuildSquashParent(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-	skip.If(t, !testEnv.DaemonInfo.ExperimentalBuild)
-	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
-	d := daemon.New(t, daemon.WithExperimental)
-	d.StartWithBusybox(t)
-	defer d.Stop(t)
 
-	client := d.NewClientT(t)
+	var client dclient.APIClient
+	if !testEnv.DaemonInfo.ExperimentalBuild {
+		skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+
+		d := daemon.New(t, daemon.WithExperimental)
+		d.StartWithBusybox(t)
+		defer d.Stop(t)
+		client = d.NewClientT(t)
+	} else {
+		client = testEnv.APIClient()
+	}
 
 	dockerfile := `
 		FROM busybox

--- a/internal/test/daemon/daemon.go
+++ b/internal/test/daemon/daemon.go
@@ -88,6 +88,7 @@ func New(t testingT, ops ...func(*Daemon)) *Daemon {
 	if ht, ok := t.(test.HelperT); ok {
 		ht.Helper()
 	}
+	t.Log("Creating a new daemon")
 	dest := os.Getenv("DOCKER_INTEGRATION_DAEMON_DEST")
 	if dest == "" {
 		dest = os.Getenv("DEST")


### PR DESCRIPTION
Some tests were skipped if the local daemon did not have experimental features enabled; at the same time, some tests unconditionally created a new (experimental) daemon, even if the local daemon already had experimental enabled.

This patch;

- Checks if the "testEnv" is an experimental Linux daemon
- If not, and the daemon is running locally; spin up a new experimental daemon to be used during the test.

~This is a follow-up to https://github.com/moby/moby/pull/38416 - and based on that branch, so only the second commit is new~