### PR TITLE
[optimization]optimize TarStream for overlay2

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -546,6 +546,12 @@ func (d *Driver) Remove(id string) error {
 	return nil
 }
 
+//GetDiffPath return the diff directory
+func (d *Driver) GetDiffPath(id string) containerfs.ContainerFS {
+	diffPath = path.Join(d.dir(id), "diff")
+	return containerfs.NewLocalContainerFS(mergedDir)
+}
+
 // Get creates and mounts the required file system for the given id and returns the mount path.
 func (d *Driver) Get(id, mountLabel string) (_ containerfs.ContainerFS, retErr error) {
 	d.locker.Lock(id)

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -548,8 +548,8 @@ func (d *Driver) Remove(id string) error {
 
 //GetDiffPath return the diff directory
 func (d *Driver) GetDiffPath(id string) containerfs.ContainerFS {
-	diffPath = path.Join(d.dir(id), "diff")
-	return containerfs.NewLocalContainerFS(mergedDir)
+	diffPath := path.Join(d.dir(id), "diff")
+	return containerfs.NewLocalContainerFS(diffPath)
 }
 
 // Get creates and mounts the required file system for the given id and returns the mount path.

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/distribution"
 	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/pkg/containerfs"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/pkg/stringid"
@@ -738,18 +739,34 @@ type naiveDiffPathDriver struct {
 
 type fileGetPutter struct {
 	storage.FileGetter
-	driver graphdriver.Driver
-	id     string
+	driver     graphdriver.Driver
+	id         string
+	isOverlay2 bool
 }
 
 func (w *fileGetPutter) Close() error {
+	if w.isOverlay2 {
+		//do nothing
+		return nil
+	}
 	return w.driver.Put(w.id)
 }
 
 func (n *naiveDiffPathDriver) DiffGetter(id string) (graphdriver.FileGetCloser, error) {
-	p, err := n.Driver.Get(id, "")
-	if err != nil {
-		return nil, err
+
+	var p containerfs.ContainerFS
+	isOverlay2 := false
+	if inter, ok := n.Driver.(interface {
+		GetDiffPath(id string) containerfs.ContainerFS
+	}); ok {
+		p = inter.GetDiffPath(id)
+		isOverlay2 = true
+	} else {
+		var err error
+		p, err = n.Driver.Get(id, "")
+		if err != nil {
+			return nil, err
+		}
 	}
-	return &fileGetPutter{storage.NewPathFileGetter(p.Path()), n.Driver, id}, nil
+	return &fileGetPutter{storage.NewPathFileGetter(p.Path()), n.Driver, id, isOverlay2}, nil
 }


### PR DESCRIPTION
Signed-off-by: yifang.jy <yifang.jy@alibaba-inc.com>


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The tarstream actually only needs the data of the current layer, and if the driver's get function is called, it is too heavy. Especially in the business customization process, if  use remote disk as lowerdir(in some company like us), the get function needs to prepare the remote disk first and then mount it into overlay2. This process is very long and the remote disk will eventually not be used.

This is a hack way, is there a simpler or more general way to optimize?

This is just an example, for demonstration purposes.
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

