### PR TITLE
Add config for reaction and topissues bots

### DIFF
--- a/.github/reaction.yml
+++ b/.github/reaction.yml
@@ -1,0 +1,5 @@
+# Configuration for https://probot.github.io/apps/reaction/
+exemptLabels: []
+reactionComment: >
+  :wave: @{comment-author}, did you mean to use
+  a [reaction](https://git.io/vhzhC) instead?

--- a/.github/topissuebot.yml
+++ b/.github/topissuebot.yml
@@ -1,0 +1,4 @@
+# Configuration for https://probot.github.io/apps/topissues/
+labelName: ":thumbsup: Top Issue!"
+labelColor: "f442c2"
+numberOfIssuesToLabel: 50


### PR DESCRIPTION
**- What I did**
Added configurations for 
- [Reaction Comments](https://probot.github.io/apps/reaction/) bot which deletes reaction comments, such as +1, and encourages the use of GitHub reactions.
- [Top Issues](https://probot.github.io/apps/topissues/) bot which labels issues with the most 👍 reactions

NOTE: this PR only adds configurations for these bots. Someone with admin rights must enable them after this one is merged.

Related to #35490

**- How to verify it**
These bots are enabled to playground repository https://github.com/olljanat/moby-bot-lab/

**- A picture of a cute animal (not mandatory but encouraged)**
![bg robot-chameleon-1920x1200](https://user-images.githubusercontent.com/6213926/50494820-3d04aa00-0a2e-11e9-94df-bb627572ea93.jpg)

