### PR TITLE
Warn (and remove) on empty env-var names instead of failing

### DIFF
--- a/opts/env.go
+++ b/opts/env.go
@@ -17,8 +17,8 @@ import (
 // The only validation here is to check if name is empty, per #25099
 func ValidateEnv(val string) (string, error) {
 	k, _, ok := strings.Cut(val, "=")
-	if k == "" {
-		return "", errors.New("invalid environment variable: " + val)
+	if strings.TrimSpace(k) == "" {
+		return "", errors.Errorf("invalid environment variable: %q", val)
 	}
 	if ok {
 		return val, nil

--- a/opts/env_test.go
+++ b/opts/env_test.go
@@ -13,7 +13,7 @@ func TestValidateEnv(t *testing.T) {
 	type testCase struct {
 		value    string
 		expected string
-		err      error
+		err      string
 	}
 	tests := []testCase{
 		{
@@ -54,7 +54,7 @@ func TestValidateEnv(t *testing.T) {
 		},
 		{
 			value: "=a",
-			err:   fmt.Errorf("invalid environment variable: =a"),
+			err:   fmt.Sprintf("invalid environment variable: %q", "=a"),
 		},
 		{
 			value:    "PATH=",
@@ -90,7 +90,15 @@ func TestValidateEnv(t *testing.T) {
 		},
 		{
 			value: "=",
-			err:   fmt.Errorf("invalid environment variable: ="),
+			err:   fmt.Sprintf("invalid environment variable: %q", "="),
+		},
+		{
+			value: "  =",
+			err:   fmt.Sprintf("invalid environment variable: %q", "  ="),
+		},
+		{
+			value: "     ",
+			err:   fmt.Sprintf("invalid environment variable: %q", "     "),
 		},
 	}
 
@@ -99,7 +107,6 @@ func TestValidateEnv(t *testing.T) {
 		tests = append(tests, testCase{
 			value:    "PaTh",
 			expected: fmt.Sprintf("PaTh=%v", os.Getenv("PATH")),
-			err:      nil,
 		})
 	}
 
@@ -108,10 +115,10 @@ func TestValidateEnv(t *testing.T) {
 		t.Run(tc.value, func(t *testing.T) {
 			actual, err := ValidateEnv(tc.value)
 
-			if tc.err == nil {
+			if tc.err == "" {
 				assert.NilError(t, err)
 			} else {
-				assert.Error(t, err, tc.err.Error())
+				assert.Equal(t, err.Error(), tc.err)
 			}
 			assert.Equal(t, actual, tc.expected)
 		})


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/38439

This patch;

- Improves validation of empty env-var names to account for additional white-space
- Instead of failing the container, produce a warning, and strip the empty env-var
- Improves the error-message, but putting quotes around the value (making it easier
  to find the issue)

Before this patch, creating a container with an empty env-var would fail;

```bash
docker run --rm --name test -e "" busybox
invalid argument "" for "-e, --env" flag: invalid environment variable:
See 'docker run --help'.
```

However, the validation was too specific, and would fail to detect env-var
names containing only white-space:

```bash
docker run --rm --name test -e " = " -e "  " busybox

docker container create --name test -e " = " -e "  " busybox
5816ece7bc80289055a725783e18a2c3d7df21b3debdcc09cd99dc532868354a

docker container inspect --format '{{json .Config.Env}}' test
[" = ","  ","PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]

curl -s \
  --unix-socket /var/run/docker.sock \
  -X POST \
  "http://localhost/v1.37/containers/create?name=test" \
  -H "Content-Type: application/json" \
  -d '{"Image": "busybox:latest","Env":[""],"HostConfig":{"AutoRemove":true}}'

{"message":"invalid environment variable: "}
```

With this patch applied, both empty and whitespace-only env-var names are detected,
and instead of failing the container, the empty env-vars are removed, and a
warning is returned instead:

```bash
docker run --rm --name test -e " = " -e "  " busybox
WARNING: invalid environment variable: " = "
WARNING: invalid environment variable: "  "

docker container create --name test -e " = " -e "  " busybox
WARNING: invalid environment variable: " = "
WARNING: invalid environment variable: "  "
25106252d65e322fc45fb3f0164584cf4854fa0d6f47ced423e4490c2197868b

docker container inspect --format '{{json .Config.Env}}' test
["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]

curl -s \
  --unix-socket /var/run/docker.sock \
  -X POST \
  "http://localhost/v1.37/containers/create?name=test" \
  -H "Content-Type: application/json" \
  -d '{"Image": "busybox:latest","Env":[""],"HostConfig":{"AutoRemove":true}}'

{"Id":"f3fd9ef61df36d8bc24c7d9d06d697e7609321002167f7aca4dc13b7c8d25a01","Warnings":["invalid environment variable: \"\""]}
```

With this patch applied, building from a base-image that contains an invalid
environment variable no longer fails, but still informs the user that an
invalid environment variable was found;

```bash
docker inspect --format '{{json .Config.Env}}' invalid
["","PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]
```

```
docker build -t frominvalid -<<'EOF'
FROM invalid
ENV hello=world
RUN echo $hello
EOF
```

Produces a _warning_ during build, but won't make the build fail:

```
Sending build context to Docker daemon  2.048kB
Step 1/3 : FROM invalid
 ---> 2037e217e3a9
Step 2/3 : ENV hello=world
 ---> [Warning] invalid environment variable: ""
 ---> Running in eb382e91cadb
Removing intermediate container eb382e91cadb
 ---> c4689179039b
Step 3/3 : RUN echo $hello
 ---> [Warning] invalid environment variable: ""
 ---> Running in 92dbf1c16168
world
Removing intermediate container 92dbf1c16168
 ---> e032e46a8bcd
Successfully built e032e46a8bcd
Successfully tagged frominvalid:latest
```

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

