### PR TITLE
Make errdefs implement error interface

### DIFF
--- a/errdefs/defs.go
+++ b/errdefs/defs.go
@@ -2,73 +2,87 @@ package errdefs // import "github.com/docker/docker/errdefs"
 
 // ErrNotFound signals that the requested object doesn't exist
 type ErrNotFound interface {
+	error
 	NotFound()
 }
 
 // ErrInvalidParameter signals that the user input is invalid
 type ErrInvalidParameter interface {
+	error
 	InvalidParameter()
 }
 
 // ErrConflict signals that some internal state conflicts with the requested action and can't be performed.
 // A change in state should be able to clear this error.
 type ErrConflict interface {
+	error
 	Conflict()
 }
 
 // ErrUnauthorized is used to signify that the user is not authorized to perform a specific action
 type ErrUnauthorized interface {
+	error
 	Unauthorized()
 }
 
 // ErrUnavailable signals that the requested action/subsystem is not available.
 type ErrUnavailable interface {
+	error
 	Unavailable()
 }
 
 // ErrForbidden signals that the requested action cannot be performed under any circumstances.
 // When a ErrForbidden is returned, the caller should never retry the action.
 type ErrForbidden interface {
+	error
 	Forbidden()
 }
 
 // ErrSystem signals that some internal error occurred.
 // An example of this would be a failed mount request.
 type ErrSystem interface {
+	error
 	System()
 }
 
 // ErrNotModified signals that an action can't be performed because it's already in the desired state
 type ErrNotModified interface {
+	error
 	NotModified()
 }
 
 // ErrAlreadyExists is a special case of ErrConflict which signals that the desired object already exists
 type ErrAlreadyExists interface {
+	error
 	AlreadyExists()
 }
 
 // ErrNotImplemented signals that the requested action/feature is not implemented on the system as configured.
 type ErrNotImplemented interface {
+	error
 	NotImplemented()
 }
 
 // ErrUnknown signals that the kind of error that occurred is not known.
 type ErrUnknown interface {
+	error
 	Unknown()
 }
 
 // ErrCancelled signals that the action was cancelled.
 type ErrCancelled interface {
+	error
 	Cancelled()
 }
 
 // ErrDeadline signals that the deadline was reached before the action completed.
 type ErrDeadline interface {
+	error
 	DeadlineExceeded()
 }
 
 // ErrDataLoss indicates that data was lost or there is data corruption.
 type ErrDataLoss interface {
+	error
 	DataLoss()
 }


### PR DESCRIPTION
This is a bit theorerical, because all the associated utilities only accept an `error` as argument, but the errdef types did not require errors to implement the error interface

Before this patch, this compiled:

    type notAnError struct{}
    func (notAnError) NotFound()         {}

    var _ ErrNotFound = notAnError{}

After this patch was applied, the example above will fail to compile

