### PR TITLE
Make errdefs helpers idempotent

### DIFF
--- a/errdefs/helpers.go
+++ b/errdefs/helpers.go
@@ -12,8 +12,8 @@ func (e errNotFound) Cause() error {
 
 // NotFound is a helper to create an error of the class with the same name from any error type
 func NotFound(err error) error {
-	if err == nil {
-		return nil
+	if err == nil || IsNotFound(err) {
+		return err
 	}
 	return errNotFound{err}
 }
@@ -28,8 +28,8 @@ func (e errInvalidParameter) Cause() error {
 
 // InvalidParameter is a helper to create an error of the class with the same name from any error type
 func InvalidParameter(err error) error {
-	if err == nil {
-		return nil
+	if err == nil || IsInvalidParameter(err) {
+		return err
 	}
 	return errInvalidParameter{err}
 }
@@ -44,8 +44,8 @@ func (e errConflict) Cause() error {
 
 // Conflict is a helper to create an error of the class with the same name from any error type
 func Conflict(err error) error {
-	if err == nil {
-		return nil
+	if err == nil || IsConflict(err) {
+		return err
 	}
 	return errConflict{err}
 }
@@ -60,8 +60,8 @@ func (e errUnauthorized) Cause() error {
 
 // Unauthorized is a helper to create an error of the class with the same name from any error type
 func Unauthorized(err error) error {
-	if err == nil {
-		return nil
+	if err == nil || IsUnauthorized(err) {
+		return err
 	}
 	return errUnauthorized{err}
 }
@@ -76,8 +76,8 @@ func (e errUnavailable) Cause() error {
 
 // Unavailable is a helper to create an error of the class with the same name from any error type
 func Unavailable(err error) error {
-	if err == nil {
-		return nil
+	if err == nil || IsUnavailable(err) {
+		return err
 	}
 	return errUnavailable{err}
 }
@@ -92,8 +92,8 @@ func (e errForbidden) Cause() error {
 
 // Forbidden is a helper to create an error of the class with the same name from any error type
 func Forbidden(err error) error {
-	if err == nil {
-		return nil
+	if err == nil || IsForbidden(err) {
+		return err
 	}
 	return errForbidden{err}
 }
@@ -108,8 +108,8 @@ func (e errSystem) Cause() error {
 
 // System is a helper to create an error of the class with the same name from any error type
 func System(err error) error {
-	if err == nil {
-		return nil
+	if err == nil || IsSystem(err) {
+		return err
 	}
 	return errSystem{err}
 }
@@ -124,8 +124,8 @@ func (e errNotModified) Cause() error {
 
 // NotModified is a helper to create an error of the class with the same name from any error type
 func NotModified(err error) error {
-	if err == nil {
-		return nil
+	if err == nil || IsNotModified(err) {
+		return err
 	}
 	return errNotModified{err}
 }
@@ -140,8 +140,8 @@ func (e errAlreadyExists) Cause() error {
 
 // AlreadyExists is a helper to create an error of the class with the same name from any error type
 func AlreadyExists(err error) error {
-	if err == nil {
-		return nil
+	if err == nil || IsAlreadyExists(err) {
+		return err
 	}
 	return errAlreadyExists{err}
 }
@@ -156,8 +156,8 @@ func (e errNotImplemented) Cause() error {
 
 // NotImplemented is a helper to create an error of the class with the same name from any error type
 func NotImplemented(err error) error {
-	if err == nil {
-		return nil
+	if err == nil || IsNotImplemented(err) {
+		return err
 	}
 	return errNotImplemented{err}
 }
@@ -172,8 +172,8 @@ func (e errUnknown) Cause() error {
 
 // Unknown is a helper to create an error of the class with the same name from any error type
 func Unknown(err error) error {
-	if err == nil {
-		return nil
+	if err == nil || IsUnknown(err) {
+		return err
 	}
 	return errUnknown{err}
 }
@@ -188,8 +188,8 @@ func (e errCancelled) Cause() error {
 
 // Cancelled is a helper to create an error of the class with the same name from any error type
 func Cancelled(err error) error {
-	if err == nil {
-		return nil
+	if err == nil || IsCancelled(err) {
+		return err
 	}
 	return errCancelled{err}
 }
@@ -204,8 +204,8 @@ func (e errDeadline) Cause() error {
 
 // Deadline is a helper to create an error of the class with the same name from any error type
 func Deadline(err error) error {
-	if err == nil {
-		return nil
+	if err == nil || IsDeadline(err) {
+		return err
 	}
 	return errDeadline{err}
 }
@@ -220,8 +220,8 @@ func (e errDataLoss) Cause() error {
 
 // DataLoss is a helper to create an error of the class with the same name from any error type
 func DataLoss(err error) error {
-	if err == nil {
-		return nil
+	if err == nil || IsDataLoss(err) {
+		return err
 	}
 	return errDataLoss{err}
 }


### PR DESCRIPTION
Don't convert errors if they already have the right type


~Builds on top of https://github.com/moby/moby/pull/38455, so I can rebase once that one is merged~

rebased