### PR TITLE
[RFC] errdefs: remove "ErrAlreadyExists" because it's not an error

### DIFF
--- a/errdefs/defs.go
+++ b/errdefs/defs.go
@@ -43,11 +43,6 @@ type ErrNotModified interface {
 	NotModified()
 }
 
-// ErrAlreadyExists is a special case of ErrConflict which signals that the desired object already exists
-type ErrAlreadyExists interface {
-	AlreadyExists()
-}
-
 // ErrNotImplemented signals that the requested action/feature is not implemented on the system as configured.
 type ErrNotImplemented interface {
 	NotImplemented()

--- a/errdefs/helpers.go
+++ b/errdefs/helpers.go
@@ -130,22 +130,6 @@ func NotModified(err error) error {
 	return errNotModified{err}
 }
 
-type errAlreadyExists struct{ error }
-
-func (errAlreadyExists) AlreadyExists() {}
-
-func (e errAlreadyExists) Cause() error {
-	return e.error
-}
-
-// AlreadyExists is a helper to create an error of the class with the same name from any error type
-func AlreadyExists(err error) error {
-	if err == nil || IsAlreadyExists(err) {
-		return err
-	}
-	return errAlreadyExists{err}
-}
-
 type errNotImplemented struct{ error }
 
 func (errNotImplemented) NotImplemented() {}

--- a/errdefs/helpers_test.go
+++ b/errdefs/helpers_test.go
@@ -89,19 +89,6 @@ func TestNotModified(t *testing.T) {
 	}
 }
 
-func TestAlreadyExists(t *testing.T) {
-	if IsAlreadyExists(errTest) {
-		t.Fatalf("did not expect already exists error, got %T", errTest)
-	}
-	e := AlreadyExists(errTest)
-	if !IsAlreadyExists(e) {
-		t.Fatalf("expected already exists error, got %T", e)
-	}
-	if cause := e.(causal).Cause(); cause != errTest {
-		t.Fatalf("causual should be errTest, got: %v", cause)
-	}
-}
-
 func TestUnauthorized(t *testing.T) {
 	if IsUnauthorized(errTest) {
 		t.Fatalf("did not expect unauthorized error, got %T", errTest)

--- a/errdefs/http_helpers.go
+++ b/errdefs/http_helpers.go
@@ -28,7 +28,7 @@ func GetHTTPErrorStatusCode(err error) int {
 		statusCode = http.StatusNotFound
 	case IsInvalidParameter(err):
 		statusCode = http.StatusBadRequest
-	case IsConflict(err) || IsAlreadyExists(err):
+	case IsConflict(err):
 		statusCode = http.StatusConflict
 	case IsUnauthorized(err):
 		statusCode = http.StatusUnauthorized

--- a/errdefs/is.go
+++ b/errdefs/is.go
@@ -15,7 +15,6 @@ func getImplementer(err error) error {
 		ErrForbidden,
 		ErrSystem,
 		ErrNotModified,
-		ErrAlreadyExists,
 		ErrNotImplemented,
 		ErrCancelled,
 		ErrDeadline,
@@ -74,12 +73,6 @@ func IsSystem(err error) bool {
 // IsNotModified returns if the passed in error is a NotModified error
 func IsNotModified(err error) bool {
 	_, ok := getImplementer(err).(ErrNotModified)
-	return ok
-}
-
-// IsAlreadyExists returns if the passed in error is a AlreadyExists error
-func IsAlreadyExists(err error) bool {
-	_, ok := getImplementer(err).(ErrAlreadyExists)
 	return ok
 }
 


### PR DESCRIPTION
The `ErrAlreadyExists` error is used for 304 statuses, which is not an error-condition, so should probably not be defined as part of the errdefs package.

This patch removes the `ErrAlreadyExists` interface, and related helpers, as it was currently not used.

Note that a 304 status can fulfil certain use-cases, but (refering to https://www.codetinkerer.com/2015/12/04/choosing-an-http-status-code.html) could probably be handled by a 200 OK, unless we want to perform caching in the client.

If we do want to use 304 statuses, perhaps we need a separate class of "errors" for this (?).


