### PR TITLE
Ignore Intellij based IDE project settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ test.main
 .editorconfig
 .gopath/
 .go-pkg-cache/
+.idea/
 autogen/
 bundles/
 cmd/dockerd/dockerd


### PR DESCRIPTION
IDEs that are based on [intellij](https://www.jetbrains.com/idea/) such
as [GoLand](https://www.jetbrains.com/go/) create a `.idea` to save
local settings for the user.

Add the `.idea` folder to prevent users from accidentally committing it.


**- What I did**
Ignore Intellij based IDE project settings
**- How I did it**
Add `.idea` to `.gitignore`
**- How to verify it**
```
touch .idea/test
git status -s
```

**- Description for the changelog**
Ignore Intellij based IDE project settings

**- A picture of a cute animal (not mandatory but encouraged)**
[Cute penguin 🐧 ](http://www.awesomelycute.com/gallery/2015/05/cute-baby-penguin-8.jpg)
