### PR TITLE
Make client return "rich" errors

### DIFF
--- a/api/server/httputils/errors.go
+++ b/api/server/httputils/errors.go
@@ -72,6 +72,52 @@ func GetHTTPErrorStatusCode(err error) int {
 	return statusCode
 }
 
+// FromStatusCode creates an errdef error, based on the provided status-code
+func FromStatusCode(err error, statusCode int) error {
+	if err == nil {
+		return err
+	}
+	switch statusCode {
+	case http.StatusNotFound:
+		err = errdefs.NotFound(err)
+	case http.StatusBadRequest:
+		err = errdefs.InvalidParameter(err)
+	case http.StatusConflict:
+		err = errdefs.Conflict(err)
+	case http.StatusUnauthorized:
+		err = errdefs.Unauthorized(err)
+	case http.StatusServiceUnavailable:
+		err = errdefs.Unavailable(err)
+	case http.StatusForbidden:
+		err = errdefs.Forbidden(err)
+	case http.StatusNotModified:
+		err = errdefs.NotModified(err)
+	case http.StatusNotImplemented:
+		err = errdefs.NotImplemented(err)
+	case http.StatusInternalServerError:
+		if !errdefs.IsSystem(err) && !errdefs.IsUnknown(err) && !errdefs.IsDataLoss(err) && !errdefs.IsDeadline(err) && !errdefs.IsCancelled(err) {
+			err = errdefs.System(err)
+		}
+	default:
+		logrus.WithFields(logrus.Fields{
+			"module":      "api",
+			"status_code": fmt.Sprintf("%d", statusCode),
+		}).Debugf("FIXME: Got an status-code for which error does not match any expected type!!!: %d", statusCode)
+
+		switch {
+		case statusCode >= 200 && statusCode < 400:
+			// it's a client error
+		case statusCode >= 400 && statusCode < 500:
+			err = errdefs.InvalidParameter(err)
+		case statusCode >= 500 && statusCode < 600:
+			err = errdefs.System(err)
+		default:
+			err = errdefs.Unknown(err)
+		}
+	}
+	return err
+}
+
 func apiVersionSupportsJSONErrors(version string) bool {
 	const firstAPIVersionWithJSONErrors = "1.23"
 	return version == "" || versions.GreaterThan(version, firstAPIVersionWithJSONErrors)

--- a/api/server/httputils/errors_test.go
+++ b/api/server/httputils/errors_test.go
@@ -1,0 +1,93 @@
+package httputils
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/docker/docker/errdefs"
+	"gotest.tools/assert"
+)
+
+func TestFromStatusCode(t *testing.T) {
+	testErr := fmt.Errorf("some error occurred")
+
+	testCases := []struct {
+		err    error
+		status int
+		check  func(error) bool
+	}{
+		{
+			err:    testErr,
+			status: http.StatusNotFound,
+			check:  errdefs.IsNotFound,
+		},
+		{
+			err:    testErr,
+			status: http.StatusBadRequest,
+			check:  errdefs.IsInvalidParameter,
+		},
+		{
+			err:    testErr,
+			status: http.StatusConflict,
+			check:  errdefs.IsConflict,
+		},
+		{
+			err:    testErr,
+			status: http.StatusUnauthorized,
+			check:  errdefs.IsUnauthorized,
+		},
+		{
+			err:    testErr,
+			status: http.StatusServiceUnavailable,
+			check:  errdefs.IsUnavailable,
+		},
+		{
+			err:    testErr,
+			status: http.StatusForbidden,
+			check:  errdefs.IsForbidden,
+		},
+		{
+			err:    testErr,
+			status: http.StatusNotModified,
+			check:  errdefs.IsNotModified,
+		},
+		{
+			err:    testErr,
+			status: http.StatusNotImplemented,
+			check:  errdefs.IsNotImplemented,
+		},
+		{
+			err:    testErr,
+			status: http.StatusInternalServerError,
+			check:  errdefs.IsSystem,
+		},
+		{
+			err:    errdefs.Unknown(testErr),
+			status: http.StatusInternalServerError,
+			check:  errdefs.IsUnknown,
+		},
+		{
+			err:    errdefs.DataLoss(testErr),
+			status: http.StatusInternalServerError,
+			check:  errdefs.IsDataLoss,
+		},
+		{
+			err:    errdefs.Deadline(testErr),
+			status: http.StatusInternalServerError,
+			check:  errdefs.IsDeadline,
+		},
+		{
+			err:    errdefs.Cancelled(testErr),
+			status: http.StatusInternalServerError,
+			check:  errdefs.IsCancelled,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(http.StatusText(tc.status), func(t *testing.T) {
+			err := FromStatusCode(tc.err, tc.status)
+			assert.Check(t, tc.check(err), "unexpected error-type %T", err)
+		})
+	}
+}

--- a/api/server/httputils/errors_test.go
+++ b/api/server/httputils/errors_test.go
@@ -91,3 +91,25 @@ func TestFromStatusCode(t *testing.T) {
 		})
 	}
 }
+
+func TestWithStatusCode(t *testing.T) {
+	testErr := fmt.Errorf("some error occurred")
+
+	type causal interface {
+		Cause() error
+	}
+
+	if IsWithStatusCode(testErr) {
+		t.Fatalf("did not expect error with status code, got %T", testErr)
+	}
+	e := WithStatusCode(testErr, 499)
+	if !IsWithStatusCode(e) {
+		t.Fatalf("expected error with status code, got %T", e)
+	}
+	if cause := e.(causal).Cause(); cause != testErr {
+		t.Fatalf("causual should be errTest, got: %v", cause)
+	}
+	if status := e.(ErrWithStatusCode).StatusCode(); status != 499 {
+		t.Fatalf("status should be 499, got: %d", status)
+	}
+}

--- a/client/checkpoint_create_test.go
+++ b/client/checkpoint_create_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestCheckpointCreateError(t *testing.T) {
@@ -24,6 +25,9 @@ func TestCheckpointCreateError(t *testing.T) {
 
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/checkpoint_delete_test.go
+++ b/client/checkpoint_delete_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestCheckpointDeleteError(t *testing.T) {
@@ -23,6 +24,9 @@ func TestCheckpointDeleteError(t *testing.T) {
 
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/checkpoint_list_test.go
+++ b/client/checkpoint_list_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestCheckpointListError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestCheckpointListError(t *testing.T) {
 	_, err := client.CheckpointList(context.Background(), "container_id", types.CheckpointListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/config_create_test.go
+++ b/client/config_create_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -33,6 +34,9 @@ func TestConfigCreateError(t *testing.T) {
 	_, err := client.ConfigCreate(context.Background(), swarm.ConfigSpec{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/config_inspect_test.go
+++ b/client/config_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
@@ -57,6 +58,9 @@ func TestConfigInspectError(t *testing.T) {
 	_, _, err := client.ConfigInspectWithRaw(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/config_list_test.go
+++ b/client/config_list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -35,6 +36,9 @@ func TestConfigListError(t *testing.T) {
 	_, err := client.ConfigList(context.Background(), types.ConfigListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/config_remove_test.go
+++ b/client/config_remove_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -31,6 +32,9 @@ func TestConfigRemoveError(t *testing.T) {
 	err := client.ConfigRemove(context.Background(), "config_id")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/config_update_test.go
+++ b/client/config_update_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -32,6 +33,9 @@ func TestConfigUpdateError(t *testing.T) {
 	err := client.ConfigUpdate(context.Background(), "config_id", swarm.Version{}, swarm.ConfigSpec{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_commit_test.go
+++ b/client/container_commit_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerCommitError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestContainerCommitError(t *testing.T) {
 	_, err := client.ContainerCommit(context.Background(), "nothing", types.ContainerCommitOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_copy_test.go
+++ b/client/container_copy_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerStatPathError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestContainerStatPathError(t *testing.T) {
 	_, err := client.ContainerStatPath(context.Background(), "container_id", "path")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 
@@ -102,6 +106,9 @@ func TestCopyToContainerError(t *testing.T) {
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
 	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
+	}
 }
 
 func TestCopyToContainerNotFoundError(t *testing.T) {
@@ -177,6 +184,9 @@ func TestCopyFromContainerError(t *testing.T) {
 	_, _, err := client.CopyFromContainer(context.Background(), "container_id", "path/to/file")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_create.go
+++ b/client/container_create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/url"
-	"strings"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
@@ -44,9 +43,6 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 
 	serverResp, err := cli.post(ctx, "/containers/create", query, body, nil)
 	if err != nil {
-		if serverResp.statusCode == 404 && strings.Contains(err.Error(), "No such image") {
-			return response, objectNotFoundError{object: "image", id: config.Image}
-		}
 		return response, err
 	}
 

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerCreateError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestContainerCreateError(t *testing.T) {
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error while testing StatusInternalServerError, got %v", err)
 	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error while testing StatusInternalServerError, got %T", err)
+	}
 
 	// 404 doesn't automatically means an unknown image
 	client = &Client{
@@ -30,6 +34,9 @@ func TestContainerCreateError(t *testing.T) {
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error while testing StatusNotFound, got %v", err)
 	}
+	if err == nil || !IsErrNotFound(err) {
+		t.Fatalf("expected a Server Error while testing StatusNotFound, got %T", err)
+	}
 }
 
 func TestContainerCreateImageNotFound(t *testing.T) {
@@ -38,7 +45,7 @@ func TestContainerCreateImageNotFound(t *testing.T) {
 	}
 	_, err := client.ContainerCreate(context.Background(), &container.Config{Image: "unknown_image"}, nil, nil, "unknown")
 	if err == nil || !IsErrNotFound(err) {
-		t.Fatalf("expected an imageNotFound error, got %v", err)
+		t.Fatalf("expected an imageNotFound error, got %v, %T", err, err)
 	}
 }
 

--- a/client/container_diff_test.go
+++ b/client/container_diff_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerDiffError(t *testing.T) {
@@ -21,7 +22,9 @@ func TestContainerDiffError(t *testing.T) {
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
-
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
+	}
 }
 
 func TestContainerDiff(t *testing.T) {

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerExecCreateError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestContainerExecCreateError(t *testing.T) {
 	_, err := client.ContainerExecCreate(context.Background(), "container_id", types.ExecConfig{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 
@@ -76,6 +80,9 @@ func TestContainerExecStartError(t *testing.T) {
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
+	}
 }
 
 func TestContainerExecStart(t *testing.T) {
@@ -119,6 +126,9 @@ func TestContainerExecInspectError(t *testing.T) {
 	_, err := client.ContainerExecInspect(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_export_test.go
+++ b/client/container_export_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerExportError(t *testing.T) {
@@ -17,6 +19,9 @@ func TestContainerExportError(t *testing.T) {
 	_, err := client.ContainerExport(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -22,6 +23,9 @@ func TestContainerInspectError(t *testing.T) {
 	_, err := client.ContainerInspect(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_kill_test.go
+++ b/client/container_kill_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerKillError(t *testing.T) {
@@ -17,6 +19,9 @@ func TestContainerKillError(t *testing.T) {
 	err := client.ContainerKill(context.Background(), "nothing", "SIGKILL")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerListError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestContainerListError(t *testing.T) {
 	_, err := client.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_pause_test.go
+++ b/client/container_pause_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerPauseError(t *testing.T) {
@@ -17,6 +19,9 @@ func TestContainerPauseError(t *testing.T) {
 	err := client.ContainerPause(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_rename_test.go
+++ b/client/container_rename_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerRenameError(t *testing.T) {
@@ -17,6 +19,9 @@ func TestContainerRenameError(t *testing.T) {
 	err := client.ContainerRename(context.Background(), "nothing", "newNothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_resize_test.go
+++ b/client/container_resize_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerResizeError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestContainerResizeError(t *testing.T) {
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
+	}
 }
 
 func TestContainerExecResizeError(t *testing.T) {
@@ -29,6 +33,9 @@ func TestContainerExecResizeError(t *testing.T) {
 	err := client.ContainerExecResize(context.Background(), "exec_id", types.ResizeOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerRestartError(t *testing.T) {
@@ -19,6 +21,9 @@ func TestContainerRestartError(t *testing.T) {
 	err := client.ContainerRestart(context.Background(), "nothing", &timeout)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_start_test.go
+++ b/client/container_start_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerStartError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestContainerStartError(t *testing.T) {
 	err := client.ContainerStart(context.Background(), "nothing", types.ContainerStartOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_stats_test.go
+++ b/client/container_stats_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerStatsError(t *testing.T) {
@@ -17,6 +19,9 @@ func TestContainerStatsError(t *testing.T) {
 	_, err := client.ContainerStats(context.Background(), "nothing", false)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerStopError(t *testing.T) {
@@ -19,6 +21,9 @@ func TestContainerStopError(t *testing.T) {
 	err := client.ContainerStop(context.Background(), "nothing", &timeout)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_top_test.go
+++ b/client/container_top_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerTopError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestContainerTopError(t *testing.T) {
 	_, err := client.ContainerTop(context.Background(), "nothing", []string{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_unpause_test.go
+++ b/client/container_unpause_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerUnpauseError(t *testing.T) {
@@ -17,6 +19,9 @@ func TestContainerUnpauseError(t *testing.T) {
 	err := client.ContainerUnpause(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_update_test.go
+++ b/client/container_update_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerUpdateError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestContainerUpdateError(t *testing.T) {
 	_, err := client.ContainerUpdate(context.Background(), "nothing", container.UpdateConfig{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_wait_test.go
+++ b/client/container_wait_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerWaitError(t *testing.T) {
@@ -26,6 +27,9 @@ func TestContainerWaitError(t *testing.T) {
 	case err := <-errC:
 		if err.Error() != "Error response from daemon: Server error" {
 			t.Fatalf("expected a Server Error, got %v", err)
+		}
+		if !errdefs.IsSystem(err) {
+			t.Fatalf("expected a Server Error, got %T", err)
 		}
 	}
 }

--- a/client/disk_usage_test.go
+++ b/client/disk_usage_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestDiskUsageError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestDiskUsageError(t *testing.T) {
 	_, err := client.DiskUsage(context.Background())
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/errors.go
+++ b/client/errors.go
@@ -35,7 +35,7 @@ func ErrorConnectionFailed(host string) error {
 
 type notFound interface {
 	error
-	NotFound() bool // Is the error a NotFound error
+	NotFound()
 }
 
 // IsErrNotFound returns true if the error is a NotFound error, which is returned
@@ -52,9 +52,7 @@ type objectNotFoundError struct {
 	id     string
 }
 
-func (e objectNotFoundError) NotFound() bool {
-	return true
-}
+func (e objectNotFoundError) NotFound() {}
 
 func (e objectNotFoundError) Error() string {
 	return fmt.Sprintf("Error: No such %s: %s", e.object, e.id)

--- a/client/events_test.go
+++ b/client/events_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestEventsErrorInOptions(t *testing.T) {
@@ -54,6 +55,9 @@ func TestEventsErrorFromServer(t *testing.T) {
 	err := <-errs
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/go-units"
 )
 
@@ -22,6 +23,9 @@ func TestImageBuildError(t *testing.T) {
 	_, err := client.ImageBuild(context.Background(), nil, types.ImageBuildOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_create_test.go
+++ b/client/image_create_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageCreateError(t *testing.T) {
@@ -19,6 +20,9 @@ func TestImageCreateError(t *testing.T) {
 	_, err := client.ImageCreate(context.Background(), "reference", types.ImageCreateOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_history_test.go
+++ b/client/image_history_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageHistoryError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestImageHistoryError(t *testing.T) {
 	_, err := client.ImageHistory(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_import_test.go
+++ b/client/image_import_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageImportError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestImageImportError(t *testing.T) {
 	_, err := client.ImageImport(context.Background(), types.ImageImportSource{}, "image:tag", types.ImageImportOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -23,6 +24,9 @@ func TestImageInspectError(t *testing.T) {
 	_, _, err := client.ImageInspectWithRaw(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageListError(t *testing.T) {
@@ -22,6 +23,9 @@ func TestImageListError(t *testing.T) {
 	_, err := client.ImageList(context.Background(), types.ImageListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_load_test.go
+++ b/client/image_load_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageLoadError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestImageLoadError(t *testing.T) {
 	_, err := client.ImageLoad(context.Background(), nil, true)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_pull_test.go
+++ b/client/image_pull_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImagePullReferenceParseError(t *testing.T) {
@@ -32,6 +33,9 @@ func TestImagePullAnyError(t *testing.T) {
 	_, err := client.ImagePull(context.Background(), "myimage", types.ImagePullOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_push_test.go
+++ b/client/image_push_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImagePushReferenceError(t *testing.T) {
@@ -37,6 +38,9 @@ func TestImagePushAnyError(t *testing.T) {
 	_, err := client.ImagePush(context.Background(), "myimage", types.ImagePushOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_save_test.go
+++ b/client/image_save_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageSaveError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestImageSaveError(t *testing.T) {
 	_, err := client.ImageSave(context.Background(), []string{"nothing"})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageSearchAnyError(t *testing.T) {
@@ -22,6 +23,9 @@ func TestImageSearchAnyError(t *testing.T) {
 	_, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageTagError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestImageTagError(t *testing.T) {
 	err := client.ImageTag(context.Background(), "image_id", "repo:tag")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/info_test.go
+++ b/client/info_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestInfoServerError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestInfoServerError(t *testing.T) {
 	_, err := client.Info(context.Background())
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/network_connect_test.go
+++ b/client/network_connect_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNetworkConnectError(t *testing.T) {
@@ -22,6 +23,9 @@ func TestNetworkConnectError(t *testing.T) {
 	err := client.NetworkConnect(context.Background(), "network_id", "container_id", nil)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNetworkCreateError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestNetworkCreateError(t *testing.T) {
 	_, err := client.NetworkCreate(context.Background(), "mynetwork", types.NetworkCreate{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/network_disconnect_test.go
+++ b/client/network_disconnect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNetworkDisconnectError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestNetworkDisconnectError(t *testing.T) {
 	err := client.NetworkDisconnect(context.Background(), "network_id", "container_id", false)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/network_list_test.go
+++ b/client/network_list_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNetworkListError(t *testing.T) {
@@ -24,6 +25,9 @@ func TestNetworkListError(t *testing.T) {
 	})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/network_prune_test.go
+++ b/client/network_prune_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -27,6 +28,9 @@ func TestNetworksPruneError(t *testing.T) {
 	_, err := client.NetworksPrune(context.Background(), filters)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/network_remove_test.go
+++ b/client/network_remove_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNetworkRemoveError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestNetworkRemoveError(t *testing.T) {
 	err := client.NetworkRemove(context.Background(), "network_id")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/node_inspect_test.go
+++ b/client/node_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -22,6 +23,9 @@ func TestNodeInspectError(t *testing.T) {
 	_, _, err := client.NodeInspectWithRaw(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/node_list_test.go
+++ b/client/node_list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNodeListError(t *testing.T) {
@@ -23,6 +24,9 @@ func TestNodeListError(t *testing.T) {
 	_, err := client.NodeList(context.Background(), types.NodeListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/node_remove_test.go
+++ b/client/node_remove_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNodeRemoveError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestNodeRemoveError(t *testing.T) {
 	err := client.NodeRemove(context.Background(), "node_id", types.NodeRemoveOptions{Force: false})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/node_update_test.go
+++ b/client/node_update_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNodeUpdateError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestNodeUpdateError(t *testing.T) {
 	err := client.NodeUpdate(context.Background(), "node_id", swarm.Version{}, swarm.NodeSpec{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/plugin_disable_test.go
+++ b/client/plugin_disable_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestPluginDisableError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestPluginDisableError(t *testing.T) {
 	err := client.PluginDisable(context.Background(), "plugin_name", types.PluginDisableOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/plugin_enable_test.go
+++ b/client/plugin_enable_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestPluginEnableError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestPluginEnableError(t *testing.T) {
 	err := client.PluginEnable(context.Background(), "plugin_name", types.PluginEnableOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/plugin_inspect_test.go
+++ b/client/plugin_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -22,6 +23,9 @@ func TestPluginInspectError(t *testing.T) {
 	_, _, err := client.PluginInspectWithRaw(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/plugin_list_test.go
+++ b/client/plugin_list_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestPluginListError(t *testing.T) {
@@ -22,6 +23,9 @@ func TestPluginListError(t *testing.T) {
 	_, err := client.PluginList(context.Background(), filters.NewArgs())
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/plugin_push_test.go
+++ b/client/plugin_push_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestPluginPushError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestPluginPushError(t *testing.T) {
 	_, err := client.PluginPush(context.Background(), "plugin_name", "")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/plugin_remove_test.go
+++ b/client/plugin_remove_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestPluginRemoveError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestPluginRemoveError(t *testing.T) {
 	err := client.PluginRemove(context.Background(), "plugin_name", types.PluginRemoveOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/plugin_set_test.go
+++ b/client/plugin_set_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestPluginSetError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestPluginSetError(t *testing.T) {
 	err := client.PluginSet(context.Background(), "plugin_name", []string{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/request.go
+++ b/client/request.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/pkg/errors"
@@ -120,9 +121,10 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 	}
 	resp, err := cli.doRequest(ctx, req)
 	if err != nil {
-		return resp, err
+		return resp, httputils.FromStatusCode(err, resp.statusCode)
 	}
-	return resp, cli.checkResponseErr(resp)
+	err = cli.checkResponseErr(resp)
+	return resp, httputils.FromStatusCode(err, resp.statusCode)
 }
 
 func (cli *Client) doRequest(ctx context.Context, req *http.Request) (serverResponse, error) {

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -87,6 +88,9 @@ func TestPlainTextError(t *testing.T) {
 	_, err := client.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/secret_create_test.go
+++ b/client/secret_create_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -33,6 +34,9 @@ func TestSecretCreateError(t *testing.T) {
 	_, err := client.SecretCreate(context.Background(), swarm.SecretSpec{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/secret_inspect_test.go
+++ b/client/secret_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
@@ -34,6 +35,9 @@ func TestSecretInspectError(t *testing.T) {
 	_, _, err := client.SecretInspectWithRaw(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/secret_list_test.go
+++ b/client/secret_list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -35,6 +36,9 @@ func TestSecretListError(t *testing.T) {
 	_, err := client.SecretList(context.Background(), types.SecretListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/secret_remove_test.go
+++ b/client/secret_remove_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -31,6 +32,9 @@ func TestSecretRemoveError(t *testing.T) {
 	err := client.SecretRemove(context.Background(), "secret_id")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/secret_update_test.go
+++ b/client/secret_update_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -32,6 +33,9 @@ func TestSecretUpdateError(t *testing.T) {
 	err := client.SecretUpdate(context.Background(), "secret_id", swarm.Version{}, swarm.SecretSpec{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/assert"
@@ -26,6 +27,9 @@ func TestServiceCreateError(t *testing.T) {
 	_, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, types.ServiceCreateOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/service_inspect_test.go
+++ b/client/service_inspect_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -23,6 +24,9 @@ func TestServiceInspectError(t *testing.T) {
 	_, _, err := client.ServiceInspectWithRaw(context.Background(), "nothing", types.ServiceInspectOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/service_list_test.go
+++ b/client/service_list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestServiceListError(t *testing.T) {
@@ -23,6 +24,9 @@ func TestServiceListError(t *testing.T) {
 	_, err := client.ServiceList(context.Background(), types.ServiceListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/service_update_test.go
+++ b/client/service_update_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestServiceUpdateError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestServiceUpdateError(t *testing.T) {
 	_, err := client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{}, types.ServiceUpdateOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/swarm_init_test.go
+++ b/client/swarm_init_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestSwarmInitError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestSwarmInitError(t *testing.T) {
 	_, err := client.SwarmInit(context.Background(), swarm.InitRequest{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/swarm_inspect_test.go
+++ b/client/swarm_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestSwarmInspectError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestSwarmInspectError(t *testing.T) {
 	_, err := client.SwarmInspect(context.Background())
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/swarm_join_test.go
+++ b/client/swarm_join_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestSwarmJoinError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestSwarmJoinError(t *testing.T) {
 	err := client.SwarmJoin(context.Background(), swarm.JoinRequest{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/swarm_leave_test.go
+++ b/client/swarm_leave_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestSwarmLeaveError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestSwarmLeaveError(t *testing.T) {
 	err := client.SwarmLeave(context.Background(), false)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/swarm_unlock_test.go
+++ b/client/swarm_unlock_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestSwarmUnlockError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestSwarmUnlockError(t *testing.T) {
 	err := client.SwarmUnlock(context.Background(), swarm.UnlockRequest{UnlockKey: "SWMKEY-1-y6guTZNTwpQeTL5RhUfOsdBdXoQjiB2GADHSRJvbXeU"})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/swarm_update_test.go
+++ b/client/swarm_update_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestSwarmUpdateError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestSwarmUpdateError(t *testing.T) {
 	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, swarm.UpdateFlags{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/task_inspect_test.go
+++ b/client/task_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -22,6 +23,9 @@ func TestTaskInspectError(t *testing.T) {
 	_, _, err := client.TaskInspectWithRaw(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/task_list_test.go
+++ b/client/task_list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestTaskListError(t *testing.T) {
@@ -23,6 +24,9 @@ func TestTaskListError(t *testing.T) {
 	_, err := client.TaskList(context.Background(), types.TaskListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/volume_create_test.go
+++ b/client/volume_create_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestVolumeCreateError(t *testing.T) {
@@ -22,6 +23,9 @@ func TestVolumeCreateError(t *testing.T) {
 	_, err := client.VolumeCreate(context.Background(), volumetypes.VolumeCreateBody{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/volume_list_test.go
+++ b/client/volume_list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestVolumeListError(t *testing.T) {
@@ -23,6 +24,9 @@ func TestVolumeListError(t *testing.T) {
 	_, err := client.VolumeList(context.Background(), filters.NewArgs())
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/volume_remove_test.go
+++ b/client/volume_remove_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestVolumeRemoveError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestVolumeRemoveError(t *testing.T) {
 	err := client.VolumeRemove(context.Background(), "volume_id", false)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"testing"
 	"time"
 
@@ -13,10 +12,10 @@ import (
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/integration/internal/swarm"
 	"github.com/docker/docker/internal/test/daemon"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/poll"
@@ -129,6 +128,9 @@ func TestCreateServiceConflict(t *testing.T) {
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)
+	c := d.NewClientT(t)
+	defer c.Close()
+	ctx := context.Background()
 
 	serviceName := "TestService_" + t.Name()
 	serviceSpec := []swarm.ServiceSpecOpt{
@@ -138,18 +140,9 @@ func TestCreateServiceConflict(t *testing.T) {
 	swarm.CreateService(t, d, serviceSpec...)
 
 	spec := swarm.CreateServiceSpec(t, serviceSpec...)
-	res, body, err := request.Post(
-		"/services/create",
-		request.Host(d.Sock()),
-		request.JSONBody(spec),
-		request.JSON,
-	)
-	assert.NilError(t, err)
-	assert.Equal(t, res.StatusCode, http.StatusConflict)
-
-	buf, err := request.ReadBody(body)
-	assert.NilError(t, err)
-	assert.Check(t, is.Contains(string(buf), "service "+serviceName+" already exists"))
+	_, err := c.ServiceCreate(ctx, spec, types.ServiceCreateOptions{})
+	assert.Check(t, errdefs.IsConflict(err))
+	assert.ErrorContains(t, err, "service "+serviceName+" already exists")
 }
 
 func TestCreateServiceMaxReplicas(t *testing.T) {


### PR DESCRIPTION
The API client currently discards HTTP-status codes that are returned from the daemon. As a result, users of the API client that want to implement logic based on the type of error returned, will have to resort to string-matching (which is brittle).


This PR is a first attempt to make the client return more useful errors;

- Errors that are returned by the API are converted back into `errdef` errors, so that it's easy to check the type of error (`errdef.IsNotFound(err)`, `errdef.IsConflict(err)`)
- The original HTTP status code is returned, so that for errors that have no 1-1 mapping to an errdef will preserve the status-code for further handling

With this patch, something like the below will be possible;

```go
package main

import (
	"context"
	"fmt"

	"github.com/docker/docker/api/server/httputils"
	"github.com/docker/docker/api/types"
	"github.com/docker/docker/api/types/container"
	"github.com/docker/docker/client"
	"github.com/docker/docker/errdefs"
)

func main() {
	ctx := context.Background()
	cli, err := client.NewClientWithOpts(client.FromEnv)
	if err != nil {
		panic(err)
	}
	cli.NegotiateAPIVersion(ctx)

	_, err = cli.ImagePull(ctx, "docker.io/library/alpine", types.ImagePullOptions{})
	if err != nil {
		panic(err)
	}

	_, err = cli.ContainerCreate(ctx, &container.Config{
		Image: "nosuchimage",
		Cmd:   []string{"echo", "hello world"},
	}, nil, nil, "")
	if err != nil {
		fmt.Println(err.Error())
		if errdefs.IsNotFound(err) {
			fmt.Println("it's a 'not found' error")
		}
		fmt.Println("status code: ", httputils.GetHTTPErrorStatusCode(err))
	}

	_, err = cli.ContainerCreate(ctx, &container.Config{
		Image: "invalid@@@name",
		Cmd:   []string{"echo", "hello world"},
	}, nil, nil, "")
	if err != nil {
		fmt.Println(err.Error())
		if errdefs.IsInvalidParameter(err) {
			fmt.Println("it's an 'invalid parameter' error")
		}
		fmt.Println("status code: ", httputils.GetHTTPErrorStatusCode(err))
	}
}
```


### Feedback needed

- I was a bit in doubt where we want the helpers/types for the new errors defined;
  - the api/server/httputils package? (could make sense, because it deals with the conversion from errdefs errors to HTTP errors)
  - the errdefs package? (I think we want to keep that package separated from any HTTP-specific logic
  - in the client? (there's already some error-handling stuff in client/errors.go); could make sense, because there are also client-side errors that could be defined there
- Is returning the HTTP status too low-level, and should we limit to only converting back to errdef Errors?
- As a follow-up; do we want a conversion from error-types to exit-codes for the cli itself?


