### PR TITLE
[WIP]: Janky: fail CI if codecov fails + detect Jenkins CI

### DIFF
--- a/hack/ci/janky
+++ b/hack/ci/janky
@@ -4,10 +4,11 @@ set -eu -o pipefail
 
 hack/validate/default
 hack/test/unit
+
+JENKINS_URL=https://jenkins.dockerproject.org \
 bash <(curl -s https://codecov.io/bash) \
     -f coverage.txt \
-    -C "$GIT_SHA1" || \
-    echo 'Codecov failed to upload'
+    -C "$GIT_SHA1" -Z
 
 hack/make.sh \
 	binary-daemon \


### PR DESCRIPTION
**- What I did**
WIP, Trying to get codecov reports visible on CI statuses before all builds are finished.

**- How I did it**

**- How to verify it**

