### PR TITLE
Windows CI: Enable more integration tests

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestBuildWithRemoveAndForceRemove(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 
 	cases := []struct {
@@ -189,7 +188,6 @@ func TestBuildMultiStageCopy(t *testing.T) {
 
 func TestBuildMultiStageParentConfig(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.35"), "broken in earlier versions")
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	dockerfile := `
 		FROM busybox AS stage0
 		ENV WHO=parent
@@ -341,7 +339,6 @@ func TestBuildWithEmptyLayers(t *testing.T) {
 // #35652
 func TestBuildMultiStageOnBuild(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.33"), "broken in earlier versions")
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	// test both metadata and layer based commands as they may be implemented differently
 	dockerfile := `FROM busybox AS stage1
@@ -448,7 +445,6 @@ COPY bar /`
 // docker/for-linux#135
 // #35641
 func TestBuildMultiStageLayerLeak(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.37"), "broken in earlier versions")
 	ctx := context.TODO()
 	defer setupTest(t)()

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -22,7 +22,6 @@ import (
 
 func TestCopyFromContainerPathDoesNotExist(t *testing.T) {
 	defer setupTest(t)()
-	skip.If(t, testEnv.OSType == "windows")
 
 	ctx := context.Background()
 	apiclient := testEnv.APIClient()
@@ -48,7 +47,6 @@ func TestCopyFromContainerPathIsNotDir(t *testing.T) {
 
 func TestCopyToContainerPathDoesNotExist(t *testing.T) {
 	defer setupTest(t)()
-	skip.If(t, testEnv.OSType == "windows")
 
 	ctx := context.Background()
 	apiclient := testEnv.APIClient()

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -85,7 +85,6 @@ func TestExecWithCloseStdin(t *testing.T) {
 
 func TestExec(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.35"), "broken in earlier versions")
-	skip.If(t, testEnv.OSType == "windows", "FIXME. Probably needs to wait for container to be in running state.")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := testEnv.APIClient()
@@ -118,7 +117,11 @@ func TestExec(t *testing.T) {
 	assert.NilError(t, err)
 	out := string(r)
 	assert.NilError(t, err)
-	assert.Assert(t, is.Contains(out, "PWD=/tmp"), "exec command not running in expected /tmp working directory")
+	expected := "PWD=/tmp"
+	if testEnv.OSType == "windows" {
+		expected = "PWD=C:/tmp"
+	}
+	assert.Assert(t, is.Contains(out, expected), "exec command not running in expected /tmp working directory")
 	assert.Assert(t, is.Contains(out, "FOO=BAR"), "exec command not running with expected environment variable FOO")
 }
 

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -30,7 +30,6 @@ func TestKillContainerInvalidSignal(t *testing.T) {
 }
 
 func TestKillContainer(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "TODO Windows: FIXME. No SIGWINCH")
 	defer setupTest(t)()
 	client := testEnv.APIClient()
 
@@ -38,27 +37,32 @@ func TestKillContainer(t *testing.T) {
 		doc    string
 		signal string
 		status string
+		skipOs string
 	}{
 		{
 			doc:    "no signal",
 			signal: "",
 			status: "exited",
+			skipOs: "",
 		},
 		{
 			doc:    "non killing signal",
 			signal: "SIGWINCH",
 			status: "running",
+			skipOs: "windows",
 		},
 		{
 			doc:    "killing signal",
 			signal: "SIGTERM",
 			status: "exited",
+			skipOs: "",
 		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
+			skip.If(t, testEnv.OSType == tc.skipOs, "Windows does not support SIGWINCH")
 			ctx := context.Background()
 			id := container.Run(ctx, t, client)
 			err := client.ContainerKill(ctx, id, tc.signal)

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -40,7 +40,6 @@ func TestNetworkNat(t *testing.T) {
 }
 
 func TestNetworkLocalhostTCPNat(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	skip.If(t, testEnv.IsRemoteDaemon)
 
 	defer setupTest(t)()

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestResize(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	client := testEnv.APIClient()
 	ctx := context.Background()

--- a/integration/image/remove_test.go
+++ b/integration/image/remove_test.go
@@ -9,11 +9,9 @@ import (
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/skip"
 )
 
 func TestRemoveImageOrphaning(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := testEnv.APIClient()

--- a/integration/image/tag_test.go
+++ b/integration/image/tag_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/skip"
 )
 
 // tagging a named image in a new unprefixed repo should work
@@ -95,7 +94,6 @@ func TestTagExistedNameWithoutForce(t *testing.T) {
 // ensure tagging using official names works
 // ensure all tags result in the same name
 func TestTagOfficialNames(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows")
 	defer setupTest(t)()
 	client := testEnv.APIClient()
 	ctx := context.Background()

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/skip"
 )
 
 func TestVolumesCreateAndList(t *testing.T) {
@@ -61,7 +60,6 @@ func TestVolumesCreateAndList(t *testing.T) {
 }
 
 func TestVolumesRemove(t *testing.T) {
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	client := testEnv.APIClient()
 	ctx := context.Background()


### PR DESCRIPTION
**- What I did**
After seeing too many times that any Docker and Windows updates cannot be installed without testing all features which we need I decided fix the root cause, the fact that most of the integration tests are disabled on Windows CI.

So on this PR I enabled those tests what can be enabled with minimal changes to code.

**- How I did it**
I started enabling those tests and figured out the fact that work was actually started already on #37715 but (source: https://github.com/moby/moby/pull/37715#issuecomment-425276677)
> However, note that none of the integration tests are actually run with this PR, just the integration-cli tests.

so on #39240 added needed logic to Windows CI that those tests actually run.

Then year 2019 passed and on February I reopened this one and did find out that Windows CI was shown as passed even some tests actually failed so on #40599 I finally fixed that issue.

After getting Windows CI working correctly I noticed that there is acutally much less tests which can be enabled than I was originally thinking because many tests will need more modifications to working on Windows and because of the fact that there is open bugs on Windows #39191 #40998 #41354


**- How to verify it**
Look the CI log:
```
[2020-09-19T08:22:36.684Z] --- PASS: TestBuildWithRemoveAndForceRemove (0.02s)
[2020-09-19T08:22:36.684Z]     --- PASS: TestBuildWithRemoveAndForceRemove/successful_build_with_no_removal (12.98s)
[2020-09-19T08:22:36.684Z]     --- PASS: TestBuildWithRemoveAndForceRemove/failed_build_with_remove_and_force_remove (13.00s)
[2020-09-19T08:22:36.684Z]     --- PASS: TestBuildWithRemoveAndForceRemove/failed_build_with_no_removal (13.07s)
[2020-09-19T08:22:36.684Z]     --- PASS: TestBuildWithRemoveAndForceRemove/successful_build_with_remove_and_force_remove (16.16s)
[2020-09-19T08:22:36.684Z]     --- PASS: TestBuildWithRemoveAndForceRemove/successful_build_with_remove (8.19s)
[2020-09-19T08:22:36.684Z]     --- PASS: TestBuildWithRemoveAndForceRemove/failed_build_with_remove (8.25s)

[2020-09-19T08:22:46.658Z] === RUN   TestBuildMultiStageParentConfig
[2020-09-19T08:22:48.835Z] --- PASS: TestBuildMultiStageParentConfig (1.83s)

[2020-09-19T08:22:49.801Z] === RUN   TestBuildMultiStageOnBuild
[2020-09-19T08:23:00.120Z] --- PASS: TestBuildMultiStageOnBuild (10.61s)

[2020-09-19T08:23:00.120Z] === RUN   TestBuildMultiStageLayerLeak
[2020-09-19T08:23:10.445Z] --- PASS: TestBuildMultiStageLayerLeak (9.24s)

[2020-09-19T08:23:15.527Z] === RUN   TestCopyFromContainerPathDoesNotExist
[2020-09-19T08:23:15.985Z] --- PASS: TestCopyFromContainerPathDoesNotExist (0.20s)

[2020-09-19T08:23:15.986Z] === RUN   TestCopyToContainerPathDoesNotExist
[2020-09-19T08:23:15.986Z] --- PASS: TestCopyToContainerPathDoesNotExist (0.22s)

[2020-09-19T08:23:18.628Z] === RUN   TestExec
[2020-09-19T08:23:20.166Z] --- PASS: TestExec (1.76s)

[2020-09-19T08:23:23.242Z] === RUN   TestKillContainer/killing_signal
[2020-09-19T08:23:25.522Z] --- PASS: TestKillContainer (3.37s)
[2020-09-19T08:23:25.522Z]     --- PASS: TestKillContainer/no_signal (1.43s)
[2020-09-19T08:23:25.522Z]     --- PASS: TestKillContainer/non_killing_signal (0.00s)
[2020-09-19T08:23:25.522Z]     --- PASS: TestKillContainer/killing_signal (1.90s)

[2020-09-19T08:23:27.059Z] === RUN   TestNetworkLocalhostTCPNat
[2020-09-19T08:23:28.595Z] --- PASS: TestNetworkLocalhostTCPNat (1.85s)

[2020-09-19T08:23:45.081Z] === RUN   TestResize
[2020-09-19T08:23:46.623Z] --- PASS: TestResize (1.51s)

[2020-09-19T08:24:18.770Z] === RUN   TestRemoveImageOrphaning
[2020-09-19T08:24:19.229Z] --- PASS: TestRemoveImageOrphaning (0.68s)

[2020-09-19T08:24:19.688Z] === RUN   TestTagOfficialNames
[2020-09-19T08:24:19.688Z] --- PASS: TestTagOfficialNames (0.08s)

[2020-09-19T08:24:53.629Z] === RUN   TestVolumesCreateAndList
[2020-09-19T08:24:53.629Z] --- PASS: TestVolumesCreateAndList (0.05s)

[2020-09-19T08:24:53.629Z] === RUN   TestVolumesRemove
[2020-09-19T08:24:53.629Z] --- PASS: TestVolumesRemove (0.06s)
```

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6213926/93664410-70dff880-fa77-11ea-8fd1-58fa07e89f30.png)
