### PR TITLE
Integration: use testenv.APIClient()

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -25,7 +25,7 @@ import (
 func TestBuildWithRemoveAndForceRemove(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	defer setupTest(t)()
-	t.Parallel()
+
 	cases := []struct {
 		name                           string
 		dockerfile                     string

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/internal/test/fakecontext"
-	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
@@ -89,7 +88,7 @@ func TestBuildWithRemoveAndForceRemove(t *testing.T) {
 		},
 	}
 
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestCreateFailsWhenIdentifierDoesNotExist(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	testCases := []struct {
 		doc           string
@@ -65,7 +65,7 @@ func TestCreateFailsWhenIdentifierDoesNotExist(t *testing.T) {
 
 func TestCreateWithInvalidEnv(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	testCases := []struct {
 		env           string
@@ -108,7 +108,7 @@ func TestCreateTmpfsMountsTarget(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	testCases := []struct {
 		target        string
@@ -150,7 +150,7 @@ func TestCreateWithCustomMaskedPaths(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	testCases := []struct {
@@ -229,7 +229,7 @@ func TestCreateWithCustomReadonlyPaths(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	testCases := []struct {

--- a/integration/container/diff_test.go
+++ b/integration/container/diff_test.go
@@ -7,7 +7,6 @@ import (
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/pkg/archive"
 	"gotest.tools/assert"
 	"gotest.tools/poll"
@@ -17,7 +16,7 @@ import (
 func TestDiff(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client, container.WithCmd("sh", "-c", `mkdir /foo; echo xyzzy > /foo/bar`))

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/skip"
@@ -22,7 +21,7 @@ func TestExecWithCloseStdin(t *testing.T) {
 	defer setupTest(t)()
 
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	// run top with detached mode
 	cID := container.Run(t, ctx, client)
@@ -89,7 +88,7 @@ func TestExec(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows", "FIXME. Probably needs to wait for container to be in running state.")
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	cID := container.Run(t, ctx, client, container.WithTty(true), container.WithWorkingDir("/root"))
 

--- a/integration/container/export_test.go
+++ b/integration/container/export_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/test/daemon"
-	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
@@ -23,7 +22,7 @@ func TestExportContainerAndImportImage(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client, container.WithCmd("true"))

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -9,7 +9,6 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/poll"
 	"gotest.tools/skip"
 )
@@ -20,7 +19,7 @@ func TestHealthCheckWorkdir(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	cID := container.Run(t, ctx, client, container.WithTty(true), container.WithWorkingDir("/foo"), func(c *container.TestContainerConfig) {
 		c.Config.Healthcheck = &containertypes.HealthConfig{

--- a/integration/container/ipcmode_test.go
+++ b/integration/container/ipcmode_test.go
@@ -13,7 +13,6 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/test/daemon"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/fs"
@@ -61,7 +60,7 @@ func testIpcNonePrivateShareable(t *testing.T, mode string, mustBeMounted bool, 
 	hostCfg := containertypes.HostConfig{
 		IpcMode: containertypes.IpcMode(mode),
 	}
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	resp, err := client.ContainerCreate(ctx, &cfg, &hostCfg, nil, "")
@@ -132,7 +131,7 @@ func testIpcContainer(t *testing.T, donorMode string, mustWork bool) {
 		IpcMode: containertypes.IpcMode(donorMode),
 	}
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	// create and start the "donor" container
 	resp, err := client.ContainerCreate(ctx, &cfg, &hostCfg, nil, "")

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestKillContainerInvalidSignal(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 	id := container.Run(t, ctx, client)
 
@@ -33,7 +33,7 @@ func TestKillContainerInvalidSignal(t *testing.T) {
 func TestKillContainer(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows", "TODO Windows: FIXME. No SIGWINCH")
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	testCases := []struct {
 		doc    string
@@ -73,7 +73,7 @@ func TestKillContainer(t *testing.T) {
 func TestKillWithStopSignalAndRestartPolicies(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows", "Windows only supports 1.25 or later")
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	testCases := []struct {
 		doc        string
@@ -114,7 +114,7 @@ func TestKillStoppedContainer(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows", "Windows only supports 1.25 or later")
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	id := container.Create(t, ctx, client)
 	err := client.ContainerKill(ctx, id, "SIGKILL")
 	assert.Assert(t, is.ErrorContains(err, ""))
@@ -154,7 +154,7 @@ func TestInspectOomKilledTrue(t *testing.T) {
 
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	cID := container.Run(t, ctx, client, container.WithCmd("sh", "-c", "x=a; while true; do x=$x$x$x$x; done"), func(c *container.TestContainerConfig) {
 		c.HostConfig.Resources.Memory = 32 * 1024 * 1024
@@ -172,7 +172,7 @@ func TestInspectOomKilledFalse(t *testing.T) {
 
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	cID := container.Run(t, ctx, client, container.WithCmd("sh", "-c", "echo hello world"))
 

--- a/integration/container/links_linux_test.go
+++ b/integration/container/links_linux_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/skip"
@@ -22,7 +21,7 @@ func TestLinksEtcHostsContentMatch(t *testing.T) {
 	skip.If(t, os.IsNotExist(err))
 
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client, container.WithNetworkMode("host"))
@@ -38,7 +37,7 @@ func TestLinksContainerNames(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	containerA := "first_" + t.Name()

--- a/integration/container/logs_test.go
+++ b/integration/container/logs_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/pkg/stdcopy"
 	"gotest.tools/assert"
 	"gotest.tools/skip"
@@ -19,7 +18,7 @@ func TestLogsFollowTailEmpty(t *testing.T) {
 	// FIXME(vdemeester) fails on a e2e run on linux...
 	skip.If(t, testEnv.IsRemoteDaemon())
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	id := container.Run(t, ctx, client, container.WithCmd("sleep", "100000"))

--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/system"
 	"gotest.tools/assert"
@@ -87,9 +86,9 @@ func TestContainerNetworkMountsNoChown(t *testing.T) {
 
 func TestMountDaemonRoot(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows" || testEnv.IsRemoteDaemon())
-	t.Parallel()
 
-	client := request.NewAPIClient(t)
+	defer setupTest(t)()
+	client := testEnv.APIClient()
 	ctx := context.Background()
 	info, err := client.Info(ctx)
 	if err != nil {
@@ -255,7 +254,7 @@ func TestContainerBindMountNonRecursive(t *testing.T) {
 	nonRecursiveVerifier := []string{"test", "!", "-f", "/foo/mnt/file"}
 
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	containers := []string{
 		container.Run(t, ctx, client, container.WithMount(implicit), container.WithCmd(recursiveVerifier...)),
 		container.Run(t, ctx, client, container.WithMount(recursive), container.WithCmd(recursiveVerifier...)),

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/go-connections/nat"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
@@ -22,6 +21,7 @@ import (
 )
 
 func TestNetworkNat(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	skip.If(t, testEnv.IsRemoteDaemon())
 
 	defer setupTest(t)()
@@ -58,6 +58,7 @@ func TestNetworkLocalhostTCPNat(t *testing.T) {
 }
 
 func TestNetworkLoopbackNat(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	skip.If(t, testEnv.IsRemoteDaemon())
 
 	defer setupTest(t)()
@@ -67,7 +68,7 @@ func TestNetworkLoopbackNat(t *testing.T) {
 
 	endpoint := getExternalAddress(t)
 
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client, container.WithCmd("sh", "-c", fmt.Sprintf("stty raw && nc -w 5 %s 8080", endpoint.String())), container.WithTty(true), container.WithNetworkMode("container:"+serverContainerID))
@@ -88,7 +89,8 @@ func TestNetworkLoopbackNat(t *testing.T) {
 }
 
 func startServerContainer(t *testing.T, msg string, port int) string {
-	client := request.NewAPIClient(t)
+	t.Helper()
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client, container.WithName("server-"+t.Name()), container.WithCmd("sh", "-c", fmt.Sprintf("echo %q | nc -lp %d", msg, port)), container.WithExposedPorts(fmt.Sprintf("%d/tcp", port)), func(c *container.TestContainerConfig) {
@@ -107,7 +109,7 @@ func startServerContainer(t *testing.T, msg string, port int) string {
 }
 
 func getExternalAddress(t *testing.T) net.IP {
-	skip.If(t, testEnv.OSType == "windows", "FIXME")
+	t.Helper()
 	iface, err := net.InterfaceByName("eth0")
 	skip.If(t, err != nil, "Test not running with `make test-integration`. Interface eth0 not found: %s", err)
 

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -22,7 +22,7 @@ func TestPause(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows" && testEnv.DaemonInfo.Isolation == "process")
 
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client)
@@ -54,7 +54,7 @@ func TestPauseFailsOnWindowsServerContainers(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "windows" || testEnv.DaemonInfo.Isolation != "process")
 
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client)
@@ -68,7 +68,7 @@ func TestPauseStopPausedContainer(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.31"), "broken in earlier versions")
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client)

--- a/integration/container/ps_test.go
+++ b/integration/container/ps_test.go
@@ -7,14 +7,13 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
 
 func TestPsFilter(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	prev := container.Create(t, ctx, client)

--- a/integration/container/remove_test.go
+++ b/integration/container/remove_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/fs"
@@ -30,7 +29,7 @@ func TestRemoveContainerWithRemovedVolume(t *testing.T) {
 
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 
@@ -56,7 +55,7 @@ func TestRemoveContainerWithRemovedVolume(t *testing.T) {
 func TestRemoveContainerWithVolume(t *testing.T) {
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 
@@ -81,7 +80,7 @@ func TestRemoveContainerWithVolume(t *testing.T) {
 func TestRemoveContainerRunning(t *testing.T) {
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	cID := container.Run(t, ctx, client)
 
@@ -92,7 +91,7 @@ func TestRemoveContainerRunning(t *testing.T) {
 func TestRemoveContainerForceRemoveRunning(t *testing.T) {
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	cID := container.Run(t, ctx, client)
 
@@ -105,7 +104,7 @@ func TestRemoveContainerForceRemoveRunning(t *testing.T) {
 func TestRemoveInvalidContainer(t *testing.T) {
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	err := client.ContainerRemove(ctx, "unknown", types.ContainerRemoveOptions{})
 	assert.Check(t, is.ErrorContains(err, "No such container"))

--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/pkg/stringid"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
@@ -27,7 +26,7 @@ func TestRenameLinkedContainer(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	aName := "a0" + t.Name()
 	bName := "b0" + t.Name()
@@ -52,7 +51,7 @@ func TestRenameLinkedContainer(t *testing.T) {
 func TestRenameStoppedContainer(t *testing.T) {
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	oldName := "first_name" + t.Name()
 	cID := container.Run(t, ctx, client, container.WithName(oldName), container.WithCmd("sh"))
@@ -74,7 +73,7 @@ func TestRenameStoppedContainer(t *testing.T) {
 func TestRenameRunningContainerAndReuse(t *testing.T) {
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	oldName := "first_name" + t.Name()
 	cID := container.Run(t, ctx, client, container.WithName(oldName))
@@ -102,7 +101,7 @@ func TestRenameRunningContainerAndReuse(t *testing.T) {
 func TestRenameInvalidName(t *testing.T) {
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	oldName := "first_name" + t.Name()
 	cID := container.Run(t, ctx, client, container.WithName(oldName))
@@ -127,7 +126,7 @@ func TestRenameAnonymousContainer(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	networkName := "network1" + t.Name()
 	_, err := client.NetworkCreate(ctx, networkName, types.NetworkCreate{})
@@ -173,7 +172,7 @@ func TestRenameAnonymousContainer(t *testing.T) {
 func TestRenameContainerWithSameName(t *testing.T) {
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	oldName := "old" + t.Name()
 	cID := container.Run(t, ctx, client, container.WithName(oldName))
@@ -196,7 +195,7 @@ func TestRenameContainerWithLinkedContainer(t *testing.T) {
 
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	db1Name := "db1" + t.Name()
 	db1ID := container.Run(t, ctx, client, container.WithName(db1Name))

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	req "github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
@@ -20,7 +19,7 @@ import (
 func TestResize(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client)
@@ -38,7 +37,7 @@ func TestResizeWithInvalidSize(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.32"), "broken in earlier versions")
 	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client)
@@ -53,7 +52,7 @@ func TestResizeWithInvalidSize(t *testing.T) {
 
 func TestResizeWhenContainerNotStarted(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client, container.WithCmd("echo"))

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -10,7 +10,6 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/poll"
@@ -23,7 +22,7 @@ func TestKernelTCPMemory(t *testing.T) {
 	skip.If(t, !testEnv.DaemonInfo.KernelMemoryTCP)
 
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	const (
@@ -54,7 +53,7 @@ func TestNISDomainname(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	const (

--- a/integration/container/stats_test.go
+++ b/integration/container/stats_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/poll"
@@ -20,7 +19,7 @@ func TestStats(t *testing.T) {
 	skip.If(t, !testEnv.DaemonInfo.MemoryLimit)
 
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	info, err := client.Info(ctx)

--- a/integration/container/stop_linux_test.go
+++ b/integration/container/stop_linux_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	"gotest.tools/icmd"
 	"gotest.tools/poll"
@@ -22,7 +21,7 @@ import (
 // waiting is not limited (issue #35311).
 func TestStopContainerWithTimeout(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	testCmd := container.WithCmd("sh", "-c", "sleep 2 && exit 42")
@@ -76,7 +75,7 @@ func TestDeleteDevicemapper(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot start daemon on remote test run")
 
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	id := container.Run(t, ctx, client, container.WithName("foo-"+t.Name()), container.WithCmd("echo"))

--- a/integration/container/stop_test.go
+++ b/integration/container/stop_test.go
@@ -6,14 +6,13 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	"gotest.tools/poll"
 )
 
 func TestStopContainerWithRestartPolicyAlways(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	names := []string{"verifyRestart1-" + t.Name(), "verifyRestart2-" + t.Name()}

--- a/integration/container/stop_windows_test.go
+++ b/integration/container/stop_windows_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	"gotest.tools/poll"
 	"gotest.tools/skip"
@@ -19,7 +18,7 @@ import (
 func TestStopContainerWithTimeout(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows")
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	testCmd := container.WithCmd("sh", "-c", "sleep 2 && exit 42")

--- a/integration/container/update_linux_test.go
+++ b/integration/container/update_linux_test.go
@@ -67,8 +67,6 @@ func TestUpdateMemory(t *testing.T) {
 }
 
 func TestUpdateCPUQuota(t *testing.T) {
-	t.Parallel()
-
 	defer setupTest(t)()
 	client := request.NewAPIClient(t)
 	ctx := context.Background()

--- a/integration/container/update_linux_test.go
+++ b/integration/container/update_linux_test.go
@@ -9,7 +9,6 @@ import (
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/poll"
@@ -22,7 +21,7 @@ func TestUpdateMemory(t *testing.T) {
 	skip.If(t, !testEnv.DaemonInfo.SwapLimit)
 
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
@@ -68,7 +67,7 @@ func TestUpdateMemory(t *testing.T) {
 
 func TestUpdateCPUQuota(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client)

--- a/integration/container/update_test.go
+++ b/integration/container/update_test.go
@@ -7,7 +7,6 @@ import (
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/poll"
@@ -15,7 +14,7 @@ import (
 
 func TestUpdateRestartPolicy(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client, container.WithCmd("sh", "-c", "sleep 1 && false"), func(c *container.TestContainerConfig) {
@@ -48,7 +47,7 @@ func TestUpdateRestartPolicy(t *testing.T) {
 
 func TestUpdateRestartWithAutoRemove(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {

--- a/integration/image/commit_test.go
+++ b/integration/image/commit_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/skip"
@@ -17,7 +16,7 @@ func TestCommitInheritsEnv(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.36"), "broken in earlier versions")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	cID1 := container.Create(t, ctx, client)

--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/internal/testutil"
 	"gotest.tools/skip"
 )
@@ -19,7 +18,8 @@ func TestImportExtremelyLargeImageWorks(t *testing.T) {
 	skip.If(t, runtime.GOARCH == "arm64", "effective test will be time out")
 	skip.If(t, testEnv.OSType == "windows", "TODO enable on windows")
 
-	client := request.NewAPIClient(t)
+	defer setupTest(t)()
+	client := testEnv.APIClient()
 
 	// Construct an empty tar archive with about 8GB of junk padding at the
 	// end. This should not cause any crashes (the padding should be mostly

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -14,7 +13,7 @@ import (
 // Regression : #38171
 func TestImagesFilterMultiReference(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	name := "images_filter_multi_reference"

--- a/integration/image/remove_test.go
+++ b/integration/image/remove_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/skip"
@@ -16,7 +15,7 @@ func TestRemoveImageOrphaning(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME")
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	img := "test-container-orphaning"
 

--- a/integration/image/tag_test.go
+++ b/integration/image/tag_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/internal/testutil"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
@@ -15,7 +14,7 @@ import (
 // tagging a named image in a new unprefixed repo should work
 func TestTagUnprefixedRepoByNameOrName(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	// By name
@@ -33,7 +32,7 @@ func TestTagUnprefixedRepoByNameOrName(t *testing.T) {
 // TODO (yongtang): Migrate to unit tests
 func TestTagInvalidReference(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	invalidRepos := []string{"fo$z$", "Foo@3cc", "Foo$3", "Foo*3", "Fo^3", "Foo!3", "F)xcz(", "fo%asd", "FOO/bar"}
@@ -72,7 +71,7 @@ func TestTagInvalidReference(t *testing.T) {
 // ensure we allow the use of valid tags
 func TestTagValidPrefixedRepo(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	validRepos := []string{"fooo/bar", "fooaa/test", "foooo:t", "HOSTNAME.DOMAIN.COM:443/foo/bar"}
@@ -86,7 +85,7 @@ func TestTagValidPrefixedRepo(t *testing.T) {
 // tag an image with an existed tag name without -f option should work
 func TestTagExistedNameWithoutForce(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	err := client.ImageTag(ctx, "busybox:latest", "busybox:test")
@@ -98,7 +97,7 @@ func TestTagExistedNameWithoutForce(t *testing.T) {
 func TestTagOfficialNames(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows")
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	names := []string{
@@ -128,7 +127,7 @@ func TestTagOfficialNames(t *testing.T) {
 // ensure tags can not match digests
 func TestTagMatchesDigest(t *testing.T) {
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	digest := "busybox@sha256:abcdef76720241213f5303bda7704ec4c2ef75613173910a56fb1b6e20251507"

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -28,7 +28,7 @@ func TestEventsExecDie(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows", "FIXME. Suspect may need to wait until container is running before exec")
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	cID := container.Run(t, ctx, client)
 
@@ -78,7 +78,7 @@ func TestEventsBackwardsCompatible(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows", "Windows doesn't support back-compat messages")
 	defer setupTest(t)()
 	ctx := context.Background()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 
 	since := request.DaemonTime(ctx, t, client, testEnv)
 	ts := strconv.FormatInt(since.Unix(), 10)

--- a/integration/system/info_linux_test.go
+++ b/integration/system/info_linux_test.go
@@ -7,14 +7,14 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/docker/docker/internal/test/request"
 	req "github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
 
 func TestInfoBinaryCommits(t *testing.T) {
-	client := request.NewAPIClient(t)
+	defer setupTest(t)()
+	client := testEnv.APIClient()
 
 	info, err := client.Info(context.Background())
 	assert.NilError(t, err)

--- a/integration/system/info_test.go
+++ b/integration/system/info_test.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 
 	"github.com/docker/docker/internal/test/daemon"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/skip"
 )
 
 func TestInfoAPI(t *testing.T) {
-	client := request.NewAPIClient(t)
+	defer setupTest(t)()
+	client := testEnv.APIClient()
 
 	info, err := client.Info(context.Background())
 	assert.NilError(t, err)

--- a/integration/system/login_test.go
+++ b/integration/system/login_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration/internal/requirement"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/skip"
@@ -16,7 +15,8 @@ import (
 func TestLoginFailsWithBadCredentials(t *testing.T) {
 	skip.If(t, !requirement.HasHubConnectivity(t))
 
-	client := request.NewAPIClient(t)
+	defer setupTest(t)()
+	client := testEnv.APIClient()
 
 	config := types.AuthConfig{
 		Username: "no-user",

--- a/integration/system/version_test.go
+++ b/integration/system/version_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
 
 func TestVersion(t *testing.T) {
-	client := request.NewAPIClient(t)
+	defer setupTest(t)()
+	client := testEnv.APIClient()
 
 	version, err := client.ServerVersion(context.Background())
 	assert.NilError(t, err)

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -22,7 +22,7 @@ import (
 func TestVolumesCreateAndList(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	name := t.Name()
@@ -52,7 +52,7 @@ func TestVolumesCreateAndList(t *testing.T) {
 func TestVolumesRemove(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows", "FIXME")
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
@@ -78,7 +78,7 @@ func TestVolumesRemove(t *testing.T) {
 func TestVolumesInspect(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
 	defer setupTest(t)()
-	client := request.NewAPIClient(t)
+	client := testEnv.APIClient()
 	ctx := context.Background()
 
 	now := time.Now()


### PR DESCRIPTION
A client is already created in `testenv.New()`, so we can just as well use that one, instead of creating a new client.
