### PR TITLE
integration: wait for service update to be completed

### DIFF
--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -207,10 +207,13 @@ func serviceIsUpdated(client client.ServiceAPIClient, serviceID string) func(log
 		switch {
 		case err != nil:
 			return poll.Error(err)
-		case service.UpdateStatus == nil || service.UpdateStatus.State == swarmtypes.UpdateStateCompleted:
+		case service.UpdateStatus != nil && service.UpdateStatus.State == swarmtypes.UpdateStateCompleted:
 			return poll.Success()
 		default:
-			return poll.Continue("waiting for service %s to be updated, state: %s, message: %s", serviceID, service.UpdateStatus.State, service.UpdateStatus.Message)
+			if service.UpdateStatus != nil {
+				return poll.Continue("waiting for service %s to be updated, state: %s, message: %s", serviceID, service.UpdateStatus.State, service.UpdateStatus.Message)
+			}
+			return poll.Continue("waiting for service %s to be updated", serviceID)
 		}
 	}
 }


### PR DESCRIPTION
Wondering if this is the cause for `TestServiceUpdateConfigs` to be flaky; this code was added as part of https://github.com/moby/moby/pull/37564, and appeared to be flaky on the PR itself https://github.com/moby/moby/pull/37564#issuecomment-449941135

```
07:40:41 --- FAIL: TestServiceUpdateConfigs (2.90s)
07:40:41     daemon.go:296: [d954a5785d31c] waiting for daemon to start
07:40:41     daemon.go:328: [d954a5785d31c] daemon started
07:40:41     update_test.go:188: assertion failed: error is not nil: Error response from daemon: rpc error: code = Unknown desc = update out of sequence
07:40:41     daemon.go:283: [d954a5785d31c] exiting daemon
07:40:41 FAIL
07:40:41 ---> Making bundle: .integration-daemon-stop (in bundles/test-integration)
07:40:44 Clearing AppArmor profiles cache:.
```


relates to https://github.com/moby/moby/issues/37547


