### PR TITLE
Follow up to PR 38407

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -1498,10 +1498,9 @@ func TestValidateLogOptionsForceFlushIntervalSeconds(t *testing.T) {
 			err := ValidateLogOpt(cfg)
 			if tc.shouldErr {
 				expectedErr := "must specify a positive integer for log opt 'awslogs-force-flush-interval-seconds': " + tc.input
-				assert.Check(t, err != nil, "Expected an error")
-				assert.Check(t, is.Equal(err.Error(), expectedErr), "Received invalid error")
+				assert.Error(t, err, expectedErr)
 			} else {
-				assert.Check(t, err == nil, "Unexpected error")
+				assert.NilError(t, err)
 			}
 		})
 	}
@@ -1528,10 +1527,9 @@ func TestValidateLogOptionsMaxBufferedEvents(t *testing.T) {
 			err := ValidateLogOpt(cfg)
 			if tc.shouldErr {
 				expectedErr := "must specify a positive integer for log opt 'awslogs-max-buffered-events': " + tc.input
-				assert.Check(t, err != nil, "Expected an error")
-				assert.Check(t, is.Equal(err.Error(), expectedErr), "Received invalid error")
+				assert.Error(t, err, expectedErr)
 			} else {
-				assert.Check(t, err == nil, "Unexpected error")
+				assert.NilError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
This fix is a follow up to PR #38407 to use `assert.Error` and `assert.NilError` when appropriate

See https://github.com/moby/moby/pull/38407#pullrequestreview-188526437 and https://github.com/moby/moby/pull/38407#pullrequestreview-188526416

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
