### PR TITLE
Run TestImportExtremelyLargeImageWorks in parallel

### DIFF
--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -9,17 +9,24 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/internal/test/daemon"
 	"github.com/docker/docker/internal/testutil"
 	"gotest.tools/skip"
 )
 
 // Ensure we don't regress on CVE-2017-14992.
 func TestImportExtremelyLargeImageWorks(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
 	skip.If(t, runtime.GOARCH == "arm64", "effective test will be time out")
 	skip.If(t, testEnv.OSType == "windows", "TODO enable on windows")
+	t.Parallel()
 
-	defer setupTest(t)()
-	client := testEnv.APIClient()
+	// Spin up a new daemon, so that we can run this test in parallel (it's a slow test)
+	d := daemon.New(t)
+	d.Start(t)
+	defer d.Stop(t)
+
+	client := d.NewClientT(t)
 
 	// Construct an empty tar archive with about 8GB of junk padding at the
 	// end. This should not cause any crashes (the padding should be mostly


### PR DESCRIPTION
This is a slow test, taking over two minutes to complete, so spin up a new daemon for this test and run it in parallel.


follow-up to https://github.com/moby/moby/pull/38473 (see https://github.com/moby/moby/pull/38473#discussion_r244966065); ~I'll rebase once that PR is merged~