### PR TITLE
TestRenameAnonymousContainer: fix error msg

### DIFF
--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -165,7 +165,7 @@ func TestRenameAnonymousContainer(t *testing.T) {
 
 	inspect, err := client.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal(0, inspect.State.ExitCode), "container %s exited with the wrong exitcode: %+v", cID, inspect)
+	assert.Check(t, is.Equal(0, inspect.State.ExitCode), "container %s exited with the wrong exitcode: %s", cID, inspect.State.Error)
 }
 
 // TODO: should be a unit test


### PR DESCRIPTION
A recent CI run (https://jenkins.dockerproject.org/job/Docker-PRs-experimental/43541/console, from https://github.com/moby/moby/pull/38452) shows a (seemingly random) failure from this test:

> 00:14:37.289 --- FAIL: TestRenameAnonymousContainer (1.75s)
> 00:14:37.289 rename_test.go:169: assertion failed: 0 (int) != 1 (inspect.State.ExitCode int): container baac251d5a1cb2221ffedf6f10acbad166b90e3549601e96d908e76762675a81 exited with the wrong exitcode: {ContainerJSONBase:0xc0007a4840 Mounts:[] Config:0xc000714500 NetworkSettings:0xc000235b00}

Apparently, printing the whole `inspect` value does not make any sense.
Let's output `inspect.State.Error` instead, maybe it will help to
figure out what is going on here.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

