### PR TITLE
Add note to Dockerfile.windows to not change `FROM`

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -153,6 +153,13 @@
 
 
 # The number of build steps below are explicitly minimised to improve performance.
+
+# Extremely important - do not change the following line to reference a "specific" image, 
+# such as `mcr.microsoft.com/windows/servercore:ltsc2019`. If using this Dockerfile in process
+# isolated containers, the kernel of the host must match the container image, and hence
+# would fail between Windows Server 2016 (aka RS1) and Windows Server 2019 (aka RS5).
+# It is expected that the image `microsoft/windowsservercore:latest` is present, and matches
+# the hosts kernel version before doing a build. 
 FROM microsoft/windowsservercore
 
 # Use PowerShell as the default shell


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Adds a note to Dockerfile.windows to ensure that the base image isn't updated such as per this comment: https://github.com/moby/moby/pull/38465/files#r245402930

@thaJeztah PTAL