### PR TITLE
Fix flaky test TestServiceUpdateSecrets

### DIFF
--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -32,7 +32,7 @@ func TestServiceUpdateLabel(t *testing.T) {
 	service.Spec.Labels["foo"] = "bar"
 	_, err := cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceIsUpdated(cli, serviceID), swarm.ServicePoll)
+	poll.WaitOn(t, serviceSpecIsUpdated(cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(t, cli, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar"}))
 
@@ -40,21 +40,21 @@ func TestServiceUpdateLabel(t *testing.T) {
 	service.Spec.Labels["foo2"] = "bar"
 	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceIsUpdated(cli, serviceID), swarm.ServicePoll)
+	poll.WaitOn(t, serviceSpecIsUpdated(cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(t, cli, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar", "foo2": "bar"}))
 
 	delete(service.Spec.Labels, "foo2")
 	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceIsUpdated(cli, serviceID), swarm.ServicePoll)
+	poll.WaitOn(t, serviceSpecIsUpdated(cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(t, cli, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar"}))
 
 	delete(service.Spec.Labels, "foo")
 	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceIsUpdated(cli, serviceID), swarm.ServicePoll)
+	poll.WaitOn(t, serviceSpecIsUpdated(cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(t, cli, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{}))
 
@@ -62,7 +62,7 @@ func TestServiceUpdateLabel(t *testing.T) {
 	service.Spec.Labels["foo"] = "bar"
 	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceIsUpdated(cli, serviceID), swarm.ServicePoll)
+	poll.WaitOn(t, serviceSpecIsUpdated(cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(t, cli, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar"}))
 
@@ -213,6 +213,20 @@ func serviceIsUpdated(client client.ServiceAPIClient, serviceID string) func(log
 			if service.UpdateStatus != nil {
 				return poll.Continue("waiting for service %s to be updated, state: %s, message: %s", serviceID, service.UpdateStatus.State, service.UpdateStatus.Message)
 			}
+			return poll.Continue("waiting for service %s to be updated", serviceID)
+		}
+	}
+}
+
+func serviceSpecIsUpdated(client client.ServiceAPIClient, serviceID string, serviceOldVersion uint64) func(log poll.LogT) poll.Result {
+	return func(log poll.LogT) poll.Result {
+		service, _, err := client.ServiceInspectWithRaw(context.Background(), serviceID, types.ServiceInspectOptions{})
+		switch {
+		case err != nil:
+			return poll.Error(err)
+		case service.Version.Index > serviceOldVersion:
+			return poll.Success()
+		default:
 			return poll.Continue("waiting for service %s to be updated", serviceID)
 		}
 	}

--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -207,10 +207,13 @@ func serviceIsUpdated(client client.ServiceAPIClient, serviceID string) func(log
 		switch {
 		case err != nil:
 			return poll.Error(err)
-		case service.UpdateStatus == nil || service.UpdateStatus.State == swarmtypes.UpdateStateCompleted:
+		case service.UpdateStatus != nil && service.UpdateStatus.State == swarmtypes.UpdateStateCompleted:
 			return poll.Success()
 		default:
-			return poll.Continue("waiting for service %s to be updated, state: %s, message: %s", serviceID, service.UpdateStatus.State, service.UpdateStatus.Message)
+			if service.UpdateStatus != nil {
+				return poll.Continue("waiting for service %s to be updated, state: %s, message: %s", serviceID, service.UpdateStatus.State, service.UpdateStatus.Message)
+			}
+			return poll.Continue("waiting for service %s to be updated", serviceID)
 		}
 	}
 }


### PR DESCRIPTION
**- What I did**
Alternative for #38474 to solve #37547

**- How I did it**
Took original commit from #38474 as baseline and added new serviceSpecIsUpdated() function which checks only that service version is updated when only updating service labels.

**- How to verify it**
Run CI builds couple of times and survive without TestServiceUpdateSecrets or TestServiceUpdateConfigs failures.
