### PR TITLE
Add Git auto signoff hook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,6 +300,11 @@ Use your real name (sorry, no pseudonyms or anonymous contributions.)
 If you set your `user.name` and `user.email` git configs, you can sign your
 commit automatically with `git commit -s`.
 
+You can enable local git [prepare-commit-msg](contrib/git/hooks/prepare-commit-msg) hook to do this automatically:
+```bash
+install -pm 755 $(git rev-parse --show-toplevel)/contrib/git/hooks/prepare-commit-msg $(git rev-parse --git-path hooks/prepare-commit-msg)
+```
+
 ### How can I become a maintainer?
 
 The procedures for adding new maintainers are explained in the 

--- a/contrib/git/hooks/prepare-commit-msg
+++ b/contrib/git/hooks/prepare-commit-msg
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# An example hook script to prepare the commit log message.
+# Called by "git commit" with the name of the file that has the
+# commit message, followed by the description of the commit
+# message's source.  The hook's purpose is to edit the commit
+# message file.  If the hook fails with a non-zero status,
+# the commit is aborted.
+#
+# To enable this hook, rename this file to "prepare-commit-msg".
+
+# This hook includes three examples. The first one removes the
+# "# Please enter the commit message..." help message.
+#
+# The second includes the output of "git diff --name-status -r"
+# into the message, just before the "git status" output.  It is
+# commented because it doesn't cope with --amend or with squashed
+# commits.
+#
+# The third example adds a Signed-off-by line to the message, that can
+# still be edited.  This is rarely a good idea.
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+SHA1=$3
+
+/usr/bin/perl -i.bak -ne 'print unless(m/^. Please enter the commit message/..m/^#$/)' "$COMMIT_MSG_FILE"
+
+# case "$COMMIT_SOURCE,$SHA1" in
+#  ,|template,)
+#    /usr/bin/perl -i.bak -pe '
+#       print "\n" . `git diff --cached --name-status -r`
+# 	 if /^#/ && $first++ == 0' "$COMMIT_MSG_FILE" ;;
+#  *) ;;
+# esac
+
+# SOB=$(git var GIT_COMMITTER_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+# git interpret-trailers --in-place --trailer "$SOB" "$COMMIT_MSG_FILE"
+# if test -z "$COMMIT_SOURCE"
+# then
+#   /usr/bin/perl -i.bak -pe 'print "\n" if !$first_line++' "$COMMIT_MSG_FILE"
+# fi

--- a/contrib/git/hooks/prepare-commit-msg
+++ b/contrib/git/hooks/prepare-commit-msg
@@ -1,42 +1,26 @@
 #!/bin/sh
 #
-# An example hook script to prepare the commit log message.
+# A hook script to prepare the commit log message.
 # Called by "git commit" with the name of the file that has the
 # commit message, followed by the description of the commit
 # message's source.  The hook's purpose is to edit the commit
 # message file.  If the hook fails with a non-zero status,
 # the commit is aborted.
 #
-# To enable this hook, rename this file to "prepare-commit-msg".
+# To enable this hook, invoke:
+# install -pm 755 $(git rev-parse --show-toplevel)/contrib/git/hooks/prepare-commit-msg $(git rev-parse --git-path hooks/prepare-commit-msg)
 
-# This hook includes three examples. The first one removes the
-# "# Please enter the commit message..." help message.
-#
-# The second includes the output of "git diff --name-status -r"
-# into the message, just before the "git status" output.  It is
-# commented because it doesn't cope with --amend or with squashed
-# commits.
-#
-# The third example adds a Signed-off-by line to the message, that can
+# This adds a Signed-off-by line to the message, that can
 # still be edited.  This is rarely a good idea.
 
 COMMIT_MSG_FILE=$1
 COMMIT_SOURCE=$2
 SHA1=$3
 
-/usr/bin/perl -i.bak -ne 'print unless(m/^. Please enter the commit message/..m/^#$/)' "$COMMIT_MSG_FILE"
+perl -i.bak -ne 'print unless(m/^. Please enter the commit message/..m/^#$/)' "$COMMIT_MSG_FILE"
 
-# case "$COMMIT_SOURCE,$SHA1" in
-#  ,|template,)
-#    /usr/bin/perl -i.bak -pe '
-#       print "\n" . `git diff --cached --name-status -r`
-# 	 if /^#/ && $first++ == 0' "$COMMIT_MSG_FILE" ;;
-#  *) ;;
-# esac
-
-# SOB=$(git var GIT_COMMITTER_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
-# git interpret-trailers --in-place --trailer "$SOB" "$COMMIT_MSG_FILE"
-# if test -z "$COMMIT_SOURCE"
-# then
-#   /usr/bin/perl -i.bak -pe 'print "\n" if !$first_line++' "$COMMIT_MSG_FILE"
-# fi
+SOB=$(git var GIT_COMMITTER_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+git interpret-trailers --in-place --trailer "$SOB" "$COMMIT_MSG_FILE"
+if test -z "$COMMIT_SOURCE"; then
+	perl -i.bak -pe 'print "\n" if !$first_line++' "$COMMIT_MSG_FILE"
+fi


### PR DESCRIPTION
**- What I did**

1. add example hook. [git/templates/hooks--prepare-commit-msg.sample](https://github.com/git/git/blob/v2.20.1/templates/hooks--prepare-commit-msg.sample)
2. enabled needed section
3. updated contributing odc

NOTE: This PR has been dogfooded by the same PR ;)

**- How I did it**

with ❤️ 

**- How to verify it**

1. checkout this branch
2. invoke the mentioned command
3. make some commit
4. `git show` that commit

**- Description for the changelog**

Add example Git hook to make all commits include `Signed-Off-By` lines.

**- A picture of a cute animal (not mandatory but encouraged)**

![49503067_583369698782658_6457083193202835456_n](https://user-images.githubusercontent.com/199095/50765686-6075f300-127f-11e9-809a-1bc8fdf5f966.jpg)
