### PR TITLE
CI: Introduce flaky test finder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,9 @@ test-integration-cli: test-integration ## (DEPRECATED) use test-integration
 test-integration: build ## run the integration tests
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary test-integration
 
+test-integration-flaky: build ## run the stress test for all new integration tests
+	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary test-integration-flaky
+
 test-unit: build ## run the unit tests
 	$(DOCKER_RUN_DOCKER) hack/test/unit
 

--- a/hack/ci/janky
+++ b/hack/ci/janky
@@ -13,5 +13,6 @@ hack/make.sh \
 	binary-daemon \
 	dynbinary \
 	test-docker-py \
+	test-integration-flaky \
 	test-integration \
 	cross

--- a/hack/make/test-integration-flaky
+++ b/hack/make/test-integration-flaky
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+source hack/validate/.validate
+new_tests=$(
+    validate_diff --diff-filter=ACMR --unified=0 -- 'integration/*_test.go' |
+    grep -E '^(\+func )(.*)(\*testing)' || true
+)
+
+if [ -z "$new_tests" ]; then
+    echo 'No new tests added to integration.'
+    return
+fi
+
+echo
+echo "Found new integrations tests:"
+echo "$new_tests"
+echo "Running stress test for them."
+
+(
+    TESTARRAY=$(echo "$new_tests" | sed 's/+func //' | awk -F'\\(' '{print $1}' | tr '\n' '|')
+    export TESTFLAGS="-test.count 5 -test.run ${TESTARRAY%?}"
+    export TEST_REPEAT=5
+    echo "Using test flags: $TESTFLAGS"
+    source hack/make/test-integration
+)


### PR DESCRIPTION
**- What I did**
We all hate to see CI builds to failing randomly to flaky tests.

Lot of work will be needed before all builds will run smoothly but to make sure that any PR does not make things worse I implemented "flaky test finder" which detect new integration tests from PR commits and run stress tests for them.

**- How I did it**
Included bash script which:
- detects new tests on *integration/\*_test.go*
- will run *hack/make.sh test-integration* which five time with setting *-test.count 5 -test.run <test names>*
- => new tests are run totally 25 times before continue to normal integration tests.

**- How to verify it**
Included second commit ( https://github.com/moby/moby/pull/38523/commits/4a5d4787cc1aa38ce0e91e22f2690ea4bc3696f6 ) which contains two example flaky tests. I will drop that after design is approved.
