### PR TITLE
[WIP] docker-py: use pip to install dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN set -x \
 
 FROM base AS docker-py
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT 8b246db271a85d6541dc458838627e89c683e42f
+ENV DOCKER_PY_COMMIT ac922192959870774ad8428344d9faa0555f7ba6
 RUN git clone https://github.com/docker/docker-py.git /build \
 	&& cd /build \
 	&& git checkout -q $DOCKER_PY_COMMIT
@@ -184,6 +184,9 @@ RUN apt-get update && apt-get install -y \
 	jq \
 	libcap2-bin \
 	libdevmapper-dev \
+# libffi-dev and libssl-dev appear to be required for compiling paramiko on s390x/ppc64le
+	libffi-dev \
+	libssl-dev \
 	libudev-dev \
 	libsystemd-dev \
 	binutils-mingw-w64 \
@@ -192,6 +195,8 @@ RUN apt-get update && apt-get install -y \
 	pigz \
 	python-backports.ssl-match-hostname \
 	python-dev \
+# python-cffi appears to be required for compiling paramiko on s390x/ppc64le
+	python-cffi \
 	python-mock \
 	python-pip \
 	python-requests \
@@ -224,7 +229,8 @@ COPY --from=docker-py /build/ /docker-py
 # split out into a separate image, including all the `python-*` deps installed
 # above.
 RUN cd /docker-py \
-	&& pip install docker-pycreds==0.2.1 \
+	&& pip install docker-pycreds==0.4.0 \
+	&& pip install paramiko==2.4.2 \
 	&& pip install yamllint==1.5.0 \
 	&& pip install -r test-requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,8 @@ RUN set -x \
 
 FROM base AS docker-py
 
-RUN apt-get update && apt-get install -y \
+RUN if [ "x86_64" != `uname -m` ]; then exit 0; fi; \
+	apt-get update && apt-get install -y \
 # libffi-dev is required for compiling paramiko
 	libffi-dev \
 	python3-dev \
@@ -83,15 +84,17 @@ RUN apt-get update && apt-get install -y \
 	python3-setuptools \
 	--no-install-recommends
 
-
 # Get the "docker-py" source so we can run their integration tests
 ENV DOCKER_PY_COMMIT ac922192959870774ad8428344d9faa0555f7ba6
 WORKDIR /docker-py
-RUN git clone https://github.com/docker/docker-py.git . \
- && git checkout -q $DOCKER_PY_COMMIT
 
-RUN python3 -m venv .
-RUN . bin/activate && pip install --ignore-installed -r requirements.txt -r test-requirements.txt
+RUN if [ "x86_64" != `uname -m` ]; then exit 0; fi; \
+	git clone https://github.com/docker/docker-py.git . \
+	&& git checkout -q $DOCKER_PY_COMMIT
+
+RUN if [ "x86_64" != `uname -m` ]; then exit 0; fi; python3 -m venv .
+RUN if [ "x86_64" != `uname -m` ]; then exit 0; fi; . bin/activate \
+	&& pip install --ignore-installed -r requirements.txt -r test-requirements.txt
 
 
 


### PR DESCRIPTION
follow-up to https://github.com/moby/moby/pull/38524

This makes sure that we have all the requirements installed and that they have the right version.
    
Moved the installation earlier in the Dockerfile, as docker-py is not so frequently updated in this repository, so optimizing for caching.
    
Removed all the apt-packages that are not needed.