### PR TITLE
Makefile: make help: fix newline wrapping, and missing targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ cross: build ## cross build the binaries for darwin, freebsd and\nwindows
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary binary cross
 
 help: ## this help
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_-]+:.*?## / {gsub("\\\\n",sprintf("\n%22c",""), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 install: ## install the linux binaries
 	KEEPBUNDLE=1 hack/make.sh install-binary


### PR DESCRIPTION
This patch;

- adds support for multiple newlines
- removes the 1-space indentation of wrapped lines
- allows numerical characters in targets (0-9)

Given these targets:

```Makefile
.PHONY: foobar
foobar: ## runs the foobar lorum ipsum.\nand so pn\nand so on
	echo foobar

.PHONY: e2e-tests
e2e-tests: ## runs the end-to-end tests
	echo e2e-tests
```

Before this change, the output of `make help` was

```
foobar               runs the foobar lorum ipsum.
                      and so pn\nand so on
```

After this change, the output is:

```
foobar               runs the foobar lorum ipsum.
                     and so pn
                     and so on
e2e-tests            runs the end-to-end tests
```

