### PR TITLE
Revert "Disable TestExecWindowsOpenHandles on RS5 temporarily"

### DIFF
--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -20,6 +20,15 @@ $allArgs = [Environment]::GetCommandLineArgs()
 Write-Host -ForegroundColor Red $allArgs
 Write-Host -ForegroundColor Red "----------------------------------------------------------------------------"
 
+# Trying to understand how CI servers have been build...
+ipconfig /all
+ping $env:COMPUTERNAME -4
+Get-NetAdapter
+cat c:\windows\system32\drivers\etc\hosts
+Get-NetFirewallProfile
+(Invoke-WebRequest -uri "http://ifconfig.me/ip").Content
+
+exit 1
 # -------------------------------------------------------------------------------------------
 # When executed, we rely on four variables being set in the environment:
 #


### PR DESCRIPTION
**- What I did**
Based on https://github.com/moby/moby/issues/38114#issuecomment-452074320 it should be possible to restore these tests to use.

**- How to verify it**
Let's see if RS5 passes CI