### PR TITLE
[DO NOT MERGE] Go 1.12 testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM golang:1.11.4 AS base
+FROM golang:1.12beta1 AS base
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org
 RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,5 +1,5 @@
 ## Step 1: Build tests
-FROM golang:1.11.4-alpine3.8 as builder
+FROM golang:1.12beta1-alpine3.8 as builder
 
 RUN apk --no-cache add \
     bash \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-FROM golang:1.11.4-stretch
+FROM golang:1.12beta1
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -161,7 +161,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
-ENV GO_VERSION=1.11.4 `
+ENV GO_VERSION=1.12beta1 `
     GIT_VERSION=2.11.1 `
     GOPATH=C:\go `
     FROM_DOCKERFILE=1

--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -101,6 +101,7 @@ test_env() {
 			PATH="$PATH" \
 			TEMP="$TEMP" \
 			TEST_CLIENT_BINARY="$TEST_CLIENT_BINARY" \
+			XDG_CACHE_HOME="$ABS_DEST/.cache" \
 			"$@"
 	)
 }

--- a/integration/plugin/logging/helpers_test.go
+++ b/integration/plugin/logging/helpers_test.go
@@ -30,8 +30,7 @@ func ensurePlugin(t *testing.T, name string) string {
 		t.Fatal(err)
 	}
 
-	cmd := exec.Command(goBin, "build", "-o", installPath, "./"+filepath.Join("cmd", name))
-	cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
+	cmd := exec.Command(goBin, "build", "-tags", "netgo", "-o", installPath, "./"+filepath.Join("cmd", name))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatal(errors.Wrapf(err, "error building basic plugin bin: %s", string(out)))
 	}

--- a/integration/plugin/volumes/helpers_test.go
+++ b/integration/plugin/volumes/helpers_test.go
@@ -36,8 +36,7 @@ func ensurePlugin(t *testing.T, name string) string {
 		t.Fatal(err)
 	}
 
-	cmd := exec.Command(goBin, "build", "-o", installPath, "./"+filepath.Join("cmd", name))
-	cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
+	cmd := exec.Command(goBin, "build", "-tags", "netgo", "-o", installPath, "./"+filepath.Join("cmd", name))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatal(errors.Wrapf(err, "error building basic plugin bin: %s", string(out)))
 	}

--- a/internal/test/fixtures/plugin/plugin.go
+++ b/internal/test/fixtures/plugin/plugin.go
@@ -207,8 +207,8 @@ func ensureBasicPluginBin() (string, error) {
 	}
 	installPath := filepath.Join(os.Getenv("GOPATH"), "bin", name)
 	sourcePath := filepath.Join("github.com", "docker", "docker", "internal", "test", "fixtures", "plugin", "basic")
-	cmd := exec.Command(goBin, "build", "-o", installPath, sourcePath)
-	cmd.Env = append(cmd.Env, "GOPATH="+os.Getenv("GOPATH"), "CGO_ENABLED=0")
+	cmd := exec.Command(goBin, "build", "-tags", "netgo", "-o", installPath, sourcePath)
+	cmd.Env = append(cmd.Env, "GOPATH="+os.Getenv("GOPATH"))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", errors.Wrapf(err, "error building basic plugin bin: %s", string(out))
 	}


### PR DESCRIPTION
This PR is created just to run CI

----

Fix integration plugin tests wrt Go 1.12
    
For some reason still mysterious to me, Go 1.12 beta1 doesn't
like the environment in which we run `go build` to build dummy
plugins for tests, giving an error message like this one:
    
> 00:13:28.931 helpers_test.go:36: error building basic plugin bin: build cache is required, but could not be located: GOCACHE is not defined and neither $XDG_CACHE_HOME nor $HOME are defined
    
It's a bit misleading since setting $HOME, or $XDG_CACHE_HOME, or
$GOCACHE env var is not helping to fix the error. What happens is
to remove the `CGO_ENABLED=0` variable, replacing it with the
`-tags netgo` which should result in the same binary.
    
[v2: also patch internal/test/fixtures/plugin/plugin.go]
