### PR TITLE
no need to set exec.Env to os.Environ() as it's the default

### DIFF
--- a/hack/integration-cli-on-swarm/host/dockercmd.go
+++ b/hack/integration-cli-on-swarm/host/dockercmd.go
@@ -15,7 +15,6 @@ func system(commands [][]string) error {
 		cmd := exec.Command(c[0], c[1:]...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
-		cmd.Env = os.Environ()
 		if err := cmd.Run(); err != nil {
 			return err
 		}
@@ -23,7 +22,7 @@ func system(commands [][]string) error {
 	return nil
 }
 
-func pushImage(unusedCli *client.Client, remote, local string) error {
+func pushImage(_ *client.Client, remote, local string) error {
 	// FIXME: eliminate os/exec (but it is hard to pass auth without os/exec ...)
 	return system([][]string{
 		{"docker", "image", "tag", local, remote},
@@ -31,7 +30,7 @@ func pushImage(unusedCli *client.Client, remote, local string) error {
 	})
 }
 
-func deployStack(unusedCli *client.Client, stackName, composeFilePath string) error {
+func deployStack(_ *client.Client, stackName, composeFilePath string) error {
 	// FIXME: eliminate os/exec (but stack is implemented in CLI ...)
 	return system([][]string{
 		{"docker", "stack", "deploy",
@@ -41,7 +40,7 @@ func deployStack(unusedCli *client.Client, stackName, composeFilePath string) er
 	})
 }
 
-func hasStack(unusedCli *client.Client, stackName string) bool {
+func hasStack(_ *client.Client, stackName string) bool {
 	// FIXME: eliminate os/exec (but stack is implemented in CLI ...)
 	out, err := exec.Command("docker", "stack", "ls").CombinedOutput()
 	if err != nil {
@@ -51,7 +50,7 @@ func hasStack(unusedCli *client.Client, stackName string) bool {
 	return strings.Contains(string(out), stackName)
 }
 
-func removeStack(unusedCli *client.Client, stackName string) error {
+func removeStack(_ *client.Client, stackName string) error {
 	// FIXME: eliminate os/exec (but stack is implemented in CLI ...)
 	if err := system([][]string{
 		{"docker", "stack", "rm", stackName},


### PR DESCRIPTION
@AkihiroSuda PTAL; just a minor nit that I found working on another issue.


Per the docs: https://github.com/golang/go/blob/e73f4894949c4ced611881329ff8f37805152585/src/os/exec/exec.go#L57-L60

> If Env is nil, the new process uses the current process's environment.

