### PR TITLE
Replace waitAndAssert in config_test.go with poll.WaitOn

### DIFF
--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
+	"gotest.tools/poll"
 	"gotest.tools/skip"
 )
 
@@ -268,18 +269,26 @@ func TestTemplatedConfig(t *testing.T) {
 	)
 
 	var tasks []swarmtypes.Task
-	waitAndAssert(t, 60*time.Second, func(t *testing.T) bool {
+	getRunningTasks := func(log poll.LogT) poll.Result {
 		tasks = swarm.GetRunningTasks(t, client, serviceID)
-		return len(tasks) > 0
-	})
+		if len(tasks) > 0 {
+			return poll.Success()
+		}
+		return poll.Continue("task still waiting")
+	}
+	poll.WaitOn(t, getRunningTasks, swarm.ServicePoll, poll.WithTimeout(1*time.Minute))
 
 	task := tasks[0]
-	waitAndAssert(t, 60*time.Second, func(t *testing.T) bool {
+	getTask := func(log poll.LogT) poll.Result {
 		if task.NodeID == "" || (task.Status.ContainerStatus == nil || task.Status.ContainerStatus.ContainerID == "") {
 			task, _, _ = client.TaskInspectWithRaw(context.Background(), task.ID)
 		}
-		return task.NodeID != "" && task.Status.ContainerStatus != nil && task.Status.ContainerStatus.ContainerID != ""
-	})
+		if task.NodeID != "" && task.Status.ContainerStatus != nil && task.Status.ContainerStatus.ContainerID != "" {
+			return poll.Success()
+		}
+		return poll.Continue("task still waiting")
+	}
+	poll.WaitOn(t, getTask, swarm.ServicePoll, poll.WithTimeout(1*time.Minute))
 
 	attach := swarm.ExecTask(t, d, task, types.ExecConfig{
 		Cmd:          []string{"/bin/cat", "/" + templatedConfigName},
@@ -305,22 +314,6 @@ func assertAttachedStream(t *testing.T, attach types.HijackedResponse, expect st
 	_, err := stdcopy.StdCopy(buf, buf, attach.Reader)
 	assert.NilError(t, err)
 	assert.Check(t, is.Contains(buf.String(), expect))
-}
-
-func waitAndAssert(t *testing.T, timeout time.Duration, f func(*testing.T) bool) {
-	t.Helper()
-	after := time.After(timeout)
-	for {
-		select {
-		case <-after:
-			t.Fatalf("timed out waiting for condition")
-		default:
-		}
-		if f(t) {
-			return
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
 }
 
 func TestConfigInspect(t *testing.T) {


### PR DESCRIPTION
This fix replaces waitAndAssert in config_test.go with poll.WaitOn
so that the testing is consistent with all other tests in integration.

Also, config_test.go uses to wait and sleep for 2 * (1 minutes) to get the task
info. This fix combined those two sleep and wait for 1 mins. Think 1 min
is enough for config test.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

