### PR TITLE
Remove code duplication and consolidate networkIsRemoved

### DIFF
--- a/integration/internal/network/states.go
+++ b/integration/internal/network/states.go
@@ -1,0 +1,20 @@
+package network
+
+import (
+	"context"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"gotest.tools/poll"
+)
+
+// IsRemoved verifies the network is removed.
+func IsRemoved(ctx context.Context, client client.NetworkAPIClient, networkID string) func(log poll.LogT) poll.Result {
+	return func(log poll.LogT) poll.Result {
+		_, err := client.NetworkInspect(ctx, networkID, types.NetworkInspectOptions{})
+		if err == nil {
+			return poll.Continue("waiting for network %s to be removed", networkID)
+		}
+		return poll.Success()
+	}
+}

--- a/integration/network/inspect_test.go
+++ b/integration/network/inspect_test.go
@@ -91,7 +91,7 @@ func TestInspectNetwork(t *testing.T) {
 	err = client.NetworkRemove(context.Background(), overlayID)
 	assert.NilError(t, err)
 
-	poll.WaitOn(t, networkIsRemoved(client, overlayID), poll.WithTimeout(1*time.Minute), poll.WithDelay(10*time.Second))
+	poll.WaitOn(t, network.IsRemoved(context.Background(), client, overlayID), poll.WithTimeout(1*time.Minute), poll.WithDelay(10*time.Second))
 }
 
 func serviceRunningTasksCount(client client.ServiceAPIClient, serviceID string, instances uint64) func(log poll.LogT) poll.Result {
@@ -114,16 +114,6 @@ func serviceRunningTasksCount(client client.ServiceAPIClient, serviceID string, 
 		default:
 			return poll.Continue("task count at %d waiting for %d", len(tasks), instances)
 		}
-	}
-}
-
-func networkIsRemoved(client client.NetworkAPIClient, networkID string) func(log poll.LogT) poll.Result {
-	return func(log poll.LogT) poll.Result {
-		_, err := client.NetworkInspect(context.Background(), networkID, types.NetworkInspectOptions{})
-		if err == nil {
-			return poll.Continue("waiting for network %s to be removed", networkID)
-		}
-		return poll.Success()
 	}
 }
 

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -122,7 +122,7 @@ func TestCreateServiceMultipleTimes(t *testing.T) {
 	err = client.NetworkRemove(context.Background(), overlayID)
 	assert.NilError(t, err)
 
-	poll.WaitOn(t, networkIsRemoved(client, overlayID), poll.WithTimeout(1*time.Minute), poll.WithDelay(10*time.Second))
+	poll.WaitOn(t, network.IsRemoved(context.Background(), client, overlayID), poll.WithTimeout(1*time.Minute), poll.WithDelay(10*time.Second))
 }
 
 func TestCreateServiceConflict(t *testing.T) {
@@ -228,9 +228,9 @@ func TestCreateWithDuplicateNetworkNames(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Make sure networks have been destroyed.
-	poll.WaitOn(t, networkIsRemoved(client, n3), poll.WithTimeout(1*time.Minute), poll.WithDelay(10*time.Second))
-	poll.WaitOn(t, networkIsRemoved(client, n2), poll.WithTimeout(1*time.Minute), poll.WithDelay(10*time.Second))
-	poll.WaitOn(t, networkIsRemoved(client, n1), poll.WithTimeout(1*time.Minute), poll.WithDelay(10*time.Second))
+	poll.WaitOn(t, network.IsRemoved(context.Background(), client, n3), poll.WithTimeout(1*time.Minute), poll.WithDelay(10*time.Second))
+	poll.WaitOn(t, network.IsRemoved(context.Background(), client, n2), poll.WithTimeout(1*time.Minute), poll.WithDelay(10*time.Second))
+	poll.WaitOn(t, network.IsRemoved(context.Background(), client, n1), poll.WithTimeout(1*time.Minute), poll.WithDelay(10*time.Second))
 }
 
 func TestCreateServiceSecretFileMode(t *testing.T) {
@@ -509,16 +509,6 @@ func serviceIsRemoved(client client.ServiceAPIClient, serviceID string) func(log
 		})
 		if err == nil {
 			return poll.Continue("waiting for service %s to be deleted", serviceID)
-		}
-		return poll.Success()
-	}
-}
-
-func networkIsRemoved(client client.NetworkAPIClient, networkID string) func(log poll.LogT) poll.Result {
-	return func(log poll.LogT) poll.Result {
-		_, err := client.NetworkInspect(context.Background(), networkID, types.NetworkInspectOptions{})
-		if err == nil {
-			return poll.Continue("waiting for network %s to be removed", networkID)
 		}
 		return poll.Success()
 	}


### PR DESCRIPTION
This fix removes code duplication and consolidates networkIsRemoved
into one place.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
