### PR TITLE
Slightly speed up TestAPISwarmNodeDrainPause

### DIFF
--- a/integration-cli/docker_api_swarm_node_test.go
+++ b/integration-cli/docker_api_swarm_node_test.go
@@ -79,7 +79,7 @@ func (s *DockerSwarmSuite) TestAPISwarmNodeDrainPause(c *check.C) {
 	time.Sleep(1 * time.Second) // make sure all daemons are ready to accept tasks
 
 	// start a service, expect balanced distribution
-	instances := 8
+	instances := 2
 	id := d1.CreateService(c, simpleTestService, setInstances(instances))
 
 	waitAndAssert(c, defaultReconciliationTimeout, d1.CheckActiveContainerCount, checker.GreaterThan, 0)
@@ -100,10 +100,9 @@ func (s *DockerSwarmSuite) TestAPISwarmNodeDrainPause(c *check.C) {
 
 	instances = 1
 	d1.UpdateService(c, d1.GetService(c, id), setInstances(instances))
-
 	waitAndAssert(c, defaultReconciliationTimeout*2, reducedCheck(sumAsIntegers, d1.CheckActiveContainerCount, d2.CheckActiveContainerCount), checker.Equals, instances)
 
-	instances = 8
+	instances = 2
 	d1.UpdateService(c, d1.GetService(c, id), setInstances(instances))
 
 	// drained node first so we don't get any old containers
@@ -118,9 +117,8 @@ func (s *DockerSwarmSuite) TestAPISwarmNodeDrainPause(c *check.C) {
 		n.Spec.Availability = swarm.NodeAvailabilityPause
 	})
 
-	instances = 14
+	instances = 4
 	d1.UpdateService(c, d1.GetService(c, id), setInstances(instances))
-
 	waitAndAssert(c, defaultReconciliationTimeout, d1.CheckActiveContainerCount, checker.Equals, instances-d2ContainerCount)
 	waitAndAssert(c, defaultReconciliationTimeout, d2.CheckActiveContainerCount, checker.Equals, d2ContainerCount)
 


### PR DESCRIPTION
Looks like we don't need that many replicas, to test the behavior, so let's start a few less.


let's see if it makes a big change; this is a "before" run;

```
PASS: docker_api_swarm_node_test.go:75: DockerSwarmSuite.TestAPISwarmNodeDrainPause	12.871s
```
