### PR TITLE
Replace t.Fatal(err) with assert.NilError(err)

### DIFF
--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/internal/test/daemon"
 	"github.com/docker/docker/internal/testutil"
+	"gotest.tools/assert"
 	"gotest.tools/skip"
 )
 
@@ -34,16 +35,13 @@ func TestImportExtremelyLargeImageWorks(t *testing.T) {
 	var tarBuffer bytes.Buffer
 
 	tw := tar.NewWriter(&tarBuffer)
-	if err := tw.Close(); err != nil {
-		t.Fatal(err)
-	}
+	err := tw.Close()
+	assert.NilError(t, err)
 	imageRdr := io.MultiReader(&tarBuffer, io.LimitReader(testutil.DevZero, 8*1024*1024*1024))
 
-	_, err := client.ImageImport(context.Background(),
+	_, err = client.ImageImport(context.Background(),
 		types.ImageImportSource{Source: imageRdr, SourceName: "-"},
 		"test1234:v42",
 		types.ImageImportOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -63,7 +63,7 @@ func TestEventsExecDie(t *testing.T) {
 		assert.Equal(t, m.Actor.Attributes["execID"], id.ID)
 		assert.Equal(t, m.Actor.Attributes["exitCode"], "0")
 	case err = <-errors:
-		t.Fatal(err)
+		assert.NilError(t, err)
 	case <-time.After(time.Second * 3):
 		t.Fatal("timeout hit")
 	}
@@ -109,7 +109,7 @@ func TestEventsBackwardsCompatible(t *testing.T) {
 			if err == io.EOF {
 				break
 			}
-			t.Fatal(err)
+			assert.NilError(t, err)
 		}
 		if event.Status == "create" && event.ID == cID {
 			containerCreateEvent = &event


### PR DESCRIPTION
Replace t.Fatal(err) with assert.NilError(err) so that they are consistent with other places

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>