### PR TITLE
GetRunningTasks: pass client instead of daemon

### DIFF
--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -269,7 +269,7 @@ func TestTemplatedConfig(t *testing.T) {
 
 	var tasks []swarmtypes.Task
 	waitAndAssert(t, 60*time.Second, func(t *testing.T) bool {
-		tasks = swarm.GetRunningTasks(t, d, serviceID)
+		tasks = swarm.GetRunningTasks(t, client, serviceID)
 		return len(tasks) > 0
 	})
 

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -303,7 +303,7 @@ func TestTemplatedSecret(t *testing.T) {
 
 	var tasks []swarmtypes.Task
 	waitAndAssert(t, 60*time.Second, func(t *testing.T) bool {
-		tasks = swarm.GetRunningTasks(t, d, serviceID)
+		tasks = swarm.GetRunningTasks(t, client, serviceID)
 		return len(tasks) > 0
 	})
 


### PR DESCRIPTION
Tests generally already have a client instance, so it
probably makes more sense to just pass it, and make
this utility a bit more flexible to use.

