### PR TITLE
Swagger: fix "task logs" outside of "tasks" section

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9767,6 +9767,7 @@ paths:
           description: "Only return this number of log lines from the end of the logs. Specify as an integer or `all` to output all log lines."
           type: "string"
           default: "all"
+      tags: ["Task"]
   /secrets:
     get:
       summary: "List secrets"


### PR DESCRIPTION
before this change, it appeared at the top level of the navigation, instead of being inside the "Tasks" section;

Before:

<img width="273" alt="screen shot 2019-01-14 at 17 02 53" src="https://user-images.githubusercontent.com/1804568/51124475-af430000-181e-11e9-912b-6ab1ac38a1d8.png">

After:

<img width="257" alt="screen shot 2019-01-14 at 17 04 01" src="https://user-images.githubusercontent.com/1804568/51124473-af430000-181e-11e9-9633-e512cf9b1314.png">
