### PR TITLE
TestCgroupDriverSystemdMemoryLimit: use skip.If()

### DIFF
--- a/integration/system/cgroupdriver_systemd_test.go
+++ b/integration/system/cgroupdriver_systemd_test.go
@@ -29,11 +29,8 @@ func hasSystemd() bool {
 //  https://github.com/moby/moby/issues/35123
 func TestCgroupDriverSystemdMemoryLimit(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	skip.If(t, !hasSystemd())
 	t.Parallel()
-
-	if !hasSystemd() {
-		t.Skip("systemd not available")
-	}
 
 	d := daemon.New(t)
 	c := d.NewClientT(t)


### PR DESCRIPTION
just a nit; cleaning up some local branches/changes 😅 