### PR TITLE
[RFC] testing: start test daemons with `--init` by default

### DIFF
--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -63,6 +63,9 @@ if [  "$DOCKER_EXPERIMENTAL" ]; then
 	extra_params="$extra_params --experimental"
 fi
 
+# can't change this yet, because some tests (e.g. TestStopContainerWithTimeout) rely on the exit code (which is different with/without init)
+# extra_params="$extra_params --init"
+
 if [ -z "$DOCKER_TEST_HOST" ]; then
 	# Start apparmor if it is enabled
 	if [ -e "/sys/module/apparmor/parameters/enabled" ] && [ "$(cat /sys/module/apparmor/parameters/enabled)" == "Y" ]; then

--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -34,6 +34,7 @@ type Daemon struct {
 // The daemon will not automatically start.
 func New(t testingT, dockerBinary string, dockerdBinary string, ops ...func(*daemon.Daemon)) *Daemon {
 	ops = append(ops, daemon.WithDockerdBinary(dockerdBinary))
+	ops = append(ops, daemon.WithInit)
 	d := daemon.New(t, ops...)
 	return &Daemon{
 		Daemon:       d,

--- a/internal/test/daemon/daemon.go
+++ b/internal/test/daemon/daemon.go
@@ -126,6 +126,7 @@ func New(t testingT, ops ...func(*Daemon)) *Daemon {
 		log:             t,
 	}
 
+	ops = append(ops, WithInit)
 	for _, op := range ops {
 		op(d)
 	}
@@ -286,7 +287,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 
 	d.Wait = wait
 
-	ticker := time.NewTicker(500 * time.Millisecond)
+	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	tick := ticker.C
 


### PR DESCRIPTION
Was wondering how much difference this makes for our CI; killing containers/tasks with `--init` set saves the 10-second delay to before forcefully killing the container.