### PR TITLE
Replace t.Fatal(err) with assert.NilError(t, err)

### DIFF
--- a/integration/container/update_linux_test.go
+++ b/integration/container/update_linux_test.go
@@ -81,13 +81,12 @@ func TestUpdateCPUQuota(t *testing.T) {
 		{desc: "a lower value", update: 10000},
 		{desc: "unset value", update: -1},
 	} {
-		if _, err := client.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
+		_, err := client.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
 			Resources: containertypes.Resources{
 				CPUQuota: test.update,
 			},
-		}); err != nil {
-			t.Fatal(err)
-		}
+		})
+		assert.NilError(t, err)
 
 		inspect, err := client.ContainerInspect(ctx, cID)
 		assert.NilError(t, err)

--- a/integration/plugin/volumes/helpers_test.go
+++ b/integration/plugin/volumes/helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/internal/test/fixtures/plugin"
 	"github.com/docker/docker/pkg/locker"
 	"github.com/pkg/errors"
+	"gotest.tools/assert"
 )
 
 var pluginBuildLock = locker.New()
@@ -32,9 +33,7 @@ func ensurePlugin(t *testing.T, name string) string {
 	}
 
 	goBin, err := exec.LookPath("go")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
 	cmd := exec.Command(goBin, "build", "-o", installPath, "./"+filepath.Join("cmd", name))
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
@@ -61,9 +60,7 @@ func createPlugin(t *testing.T, client plugin.CreateClient, alias, bin string, o
 	err := plugin.Create(ctx, client, alias, opts...)
 	cancel()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }
 
 func asVolumeDriver(cfg *plugin.Config) {


### PR DESCRIPTION
So that they are consistent with integration tests style

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>