### PR TITLE
Improve 'no matching manifest' error message

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -756,7 +756,7 @@ func (p *v2Puller) pullManifestList(ctx context.Context, ref reference.Named, mf
 	manifestMatches := filterManifests(mfstList.Manifests, platform)
 
 	if len(manifestMatches) == 0 {
-		errMsg := fmt.Sprintf("no matching manifest for %s in the manifest list entries", platforms.Format(platform))
+		errMsg := fmt.Sprintf("no matching manifest for %s in the manifest list entries", formatPlatform(platform))
 		logrus.Debugf(errMsg)
 		return "", "", errors.New(errMsg)
 	}

--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -2,8 +2,10 @@ package distribution // import "github.com/docker/docker/distribution"
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -11,6 +13,7 @@ import (
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/reference"
 	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -180,5 +183,25 @@ func TestValidateManifest(t *testing.T) {
 	verifiedManifest, err = verifySchema1Manifest(&badSignedManifest, expectedDigest)
 	if err == nil || !strings.HasPrefix(err.Error(), "image verification failed for digest") {
 		t.Fatal("expected validateManifest to fail with digest error")
+	}
+}
+
+func TestFormatPlatform(t *testing.T) {
+	var platform specs.Platform
+	var result = formatPlatform(platform)
+	if strings.HasPrefix(result, "unknown") {
+		t.Fatal("expected formatPlatform to show a known platform")
+	}
+	if !strings.HasPrefix(result, runtime.GOOS) {
+		t.Fatal("expected formatPlatform to show the current platform")
+	}
+	if runtime.GOOS == "windows" {
+		if !strings.HasPrefix(result, "windows") {
+			t.Fatal("expected formatPlatform to show windows platform")
+		}
+		matches, _ := regexp.MatchString("windows.* [0-9]", result)
+		if !matches {
+			t.Fatal(fmt.Sprintf("expected formatPlatform to show windows platform with a version, but got '%s'", result))
+		}
 	}
 }

--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -58,3 +58,10 @@ func withDefault(p specs.Platform) specs.Platform {
 	}
 	return p
 }
+
+func formatPlatform(platform specs.Platform) string {
+	if platform.OS == "" {
+		platform = platforms.DefaultSpec()
+	}
+	return platforms.Format(platform)
+}

--- a/distribution/pull_v2_windows.go
+++ b/distribution/pull_v2_windows.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema2"
@@ -135,4 +136,11 @@ func checkImageCompatibility(imageOS, imageOSVersion string) error {
 		}
 	}
 	return nil
+}
+
+func formatPlatform(platform specs.Platform) string {
+	if platform.OS == "" {
+		platform = platforms.DefaultSpec()
+	}
+	return fmt.Sprintf("%s %s", platforms.Format(platform), system.GetOSVersion().ToString())
 }


### PR DESCRIPTION
fixes #38199

**- What I did**

I improved the error message when someone tries to pull an image, but the manifest list only has manifests that doesn't match the current platform. At the moment only

```
no matching manifest for unknown in the manifest list entries
```

appears. The current platform is shown as "unknown" which is not helpful to see if someone is running Docker Desktop on Windows 10 with Linux containers or if the Windows OS version does not match.

Even on a Linux system we can reproduce the problem when we try to pull the newest nanoserver image which is a manifest list:

```
$ docker pull mcr.microsoft.com/windows/nanoserver:1809
1809: Pulling from windows/nanoserver
no matching manifest for unknown in the manifest list entries
```

**- How I did it**

For Windows the error message now shows windows/amd64 and the OS version number instead of "unknown".
For other platforms the error message now shows OS with the current CPU architecture instead of "unknown".

**- How to verify it**

```
make test-unit
```

There are unit tests.

A new Docker engine on Windows now shows a much more detailed error message

```
$ docker pull ubuntu
Using default tag: latest
latest: Pulling from library/ubuntu
no matching manifest for windows/amd64 10.0.17763 in the manifest list entries
```

**- Description for the changelog**

Show the current platform and architecture when pulling from a manifest list doesn't find any match.

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="503" alt="koala" src="https://user-images.githubusercontent.com/207759/51187714-b29cc100-18dc-11e9-9663-b2dd7024a133.png">
