### PR TITLE
Use a regex to match labels

### DIFF
--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -189,6 +189,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case "env":
 		case "env-regex":
 		case "labels":
+		case "labels-regex":
 		case "tag":
 		case addressKey:
 		case bufferLimitKey:

--- a/daemon/logger/gcplogs/gcplogging.go
+++ b/daemon/logger/gcplogs/gcplogging.go
@@ -18,14 +18,15 @@ import (
 const (
 	name = "gcplogs"
 
-	projectOptKey  = "gcp-project"
-	logLabelsKey   = "labels"
-	logEnvKey      = "env"
-	logEnvRegexKey = "env-regex"
-	logCmdKey      = "gcp-log-cmd"
-	logZoneKey     = "gcp-meta-zone"
-	logNameKey     = "gcp-meta-name"
-	logIDKey       = "gcp-meta-id"
+	projectOptKey     = "gcp-project"
+	logLabelsKey      = "labels"
+	logLabelsRegexKey = "labels-regex"
+	logEnvKey         = "env"
+	logEnvRegexKey    = "env-regex"
+	logCmdKey         = "gcp-log-cmd"
+	logZoneKey        = "gcp-meta-zone"
+	logNameKey        = "gcp-meta-name"
+	logIDKey          = "gcp-meta-id"
 )
 
 var (
@@ -210,7 +211,7 @@ func New(info logger.Info) (logger.Logger, error) {
 func ValidateLogOpts(cfg map[string]string) error {
 	for k := range cfg {
 		switch k {
-		case projectOptKey, logLabelsKey, logEnvKey, logEnvRegexKey, logCmdKey, logZoneKey, logNameKey, logIDKey:
+		case projectOptKey, logLabelsKey, logLabelsRegexKey, logEnvKey, logEnvRegexKey, logCmdKey, logZoneKey, logNameKey, logIDKey:
 		default:
 			return fmt.Errorf("%q is not a valid option for the gcplogs driver", k)
 		}

--- a/daemon/logger/gelf/gelf.go
+++ b/daemon/logger/gelf/gelf.go
@@ -207,6 +207,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case "gelf-address":
 		case "tag":
 		case "labels":
+		case "labels-regex":
 		case "env":
 		case "env-regex":
 		case "gelf-compression-level":

--- a/daemon/logger/gelf/gelf_test.go
+++ b/daemon/logger/gelf/gelf_test.go
@@ -98,6 +98,7 @@ func TestUDPValidateLogOpt(t *testing.T) {
 		"gelf-address":           "udp://127.0.0.1:12201",
 		"tag":                    "testtag",
 		"labels":                 "testlabel",
+		"labels-regex":           "testlabel-regex",
 		"env":                    "testenv",
 		"env-regex":              "testenv-regex",
 		"gelf-compression-level": "9",

--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -90,6 +90,7 @@ func validateLogOpt(cfg map[string]string) error {
 	for key := range cfg {
 		switch key {
 		case "labels":
+		case "labels-regex":
 		case "env":
 		case "env-regex":
 		case "tag":

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -156,6 +156,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case "max-size":
 		case "compress":
 		case "labels":
+		case "labels-regex":
 		case "env":
 		case "env-regex":
 		case "tag":

--- a/daemon/logger/jsonfilelog/jsonfilelog_test.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog_test.go
@@ -277,12 +277,12 @@ func TestJSONFileLoggerWithLabelsEnv(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 	filename := filepath.Join(tmp, "container.log")
-	config := map[string]string{"labels": "rack,dc", "env": "environ,debug,ssl", "env-regex": "^dc"}
+	config := map[string]string{"labels": "rack,dc", "labels-regex": "^loc", "env": "environ,debug,ssl", "env-regex": "^dc"}
 	l, err := New(logger.Info{
 		ContainerID:     cid,
 		LogPath:         filename,
 		Config:          config,
-		ContainerLabels: map[string]string{"rack": "101", "dc": "lhr"},
+		ContainerLabels: map[string]string{"rack": "101", "dc": "lhr", "location": "here"},
 		ContainerEnv:    []string{"environ=production", "debug=false", "port=10001", "ssl=true", "dc_region=west"},
 	})
 	if err != nil {
@@ -308,6 +308,7 @@ func TestJSONFileLoggerWithLabelsEnv(t *testing.T) {
 	expected := map[string]string{
 		"rack":      "101",
 		"dc":        "lhr",
+		"location":  "here",
 		"environ":   "production",
 		"debug":     "false",
 		"ssl":       "true",

--- a/daemon/logger/logentries/logentries.go
+++ b/daemon/logger/logentries/logentries.go
@@ -100,6 +100,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case "env":
 		case "env-regex":
 		case "labels":
+		case "labels-regex":
 		case "tag":
 		case key:
 		default:

--- a/daemon/logger/loginfo.go
+++ b/daemon/logger/loginfo.go
@@ -41,6 +41,22 @@ func (info *Info) ExtraAttributes(keyMod func(string) string) (map[string]string
 		}
 	}
 
+	labelsRegex, ok := info.Config["labels-regex"]
+	if ok && len(labels) > 0 {
+		re, err := regexp.Compile(labelsRegex)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range info.ContainerLabels {
+			if re.MatchString(k) {
+				if keyMod != nil {
+					k = keyMod(k)
+				}
+				extra[k] = v
+			}
+		}
+	}
+
 	envMapping := make(map[string]string)
 	for _, e := range info.ContainerEnv {
 		if kv := strings.SplitN(e, "=", 2); len(kv) == 2 {

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -44,6 +44,7 @@ const (
 	envKey                        = "env"
 	envRegexKey                   = "env-regex"
 	labelsKey                     = "labels"
+	labelsRegexKey                = "labels-regex"
 	tagKey                        = "tag"
 )
 
@@ -565,6 +566,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case envKey:
 		case envRegexKey:
 		case labelsKey:
+		case labelsRegexKey:
 		case tagKey:
 		default:
 			return fmt.Errorf("unknown log opt '%s' for %s log driver", key, driverName)

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -189,6 +189,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case "env":
 		case "env-regex":
 		case "labels":
+		case "labels-regex":
 		case "syslog-address":
 		case "syslog-facility":
 		case "syslog-tls-ca-cert":

--- a/daemon/logger/syslog/syslog_test.go
+++ b/daemon/logger/syslog/syslog_test.go
@@ -137,6 +137,7 @@ func TestValidateLogOpt(t *testing.T) {
 		"env":                    "http://127.0.0.1",
 		"env-regex":              "abc",
 		"labels":                 "labelA",
+		"labels-regex":           "def",
 		"syslog-address":         "udp://1.2.3.4:1111",
 		"syslog-facility":        "daemon",
 		"syslog-tls-ca-cert":     "/etc/ca-certificates/custom/ca.pem",


### PR DESCRIPTION
**- What I did**
I added an option to the log drivers to include as attributes the labels that match a regex. (Similar to #27561).

Documentation update in available in docker/docker.github.io#8037
**- How I did it**
I added the `--labels-regex` option to the logging drivers.
I added code to scan and match container labels against the regex supplied in the above option. I add these matching variables to the 'extra' map in the log driver.
**- How to verify it**
I updated `gelf_test.go`, `jsonfilelog_test.go` and `syslog_test.go` to test the new option.
**- Description for the changelog**
Allow the log drivers to pick up labels that match a supplied regular expression.

**- A picture of a cute animal (not mandatory but encouraged)**
![20190101_202730_](https://user-images.githubusercontent.com/9640353/51281750-3f2da900-19db-11e9-9a30-6ba1da5a02c5.jpg)
