### PR TITLE
add vfs quota for daemon storage-opts

### DIFF
--- a/daemon/graphdriver/vfs/quota_linux.go
+++ b/daemon/graphdriver/vfs/quota_linux.go
@@ -7,6 +7,7 @@ import (
 
 type driverQuota struct {
 	quotaCtl *quota.Control
+	quotaOpt quota.Quota
 }
 
 func setupDriverQuota(driver *Driver) {
@@ -15,6 +16,15 @@ func setupDriverQuota(driver *Driver) {
 	} else if err != quota.ErrQuotaNotSupported {
 		logrus.Warnf("Unable to setup quota: %v\n", err)
 	}
+}
+
+func (d *Driver) setQuotaOpt(size uint64) error {
+	d.quotaOpt.Size = size
+	return nil
+}
+
+func (d *Driver) getQuotaOpt() uint64 {
+	return d.quotaOpt.Size
 }
 
 func (d *Driver) setupQuota(dir string, size uint64) error {

--- a/daemon/graphdriver/vfs/quota_unsupported.go
+++ b/daemon/graphdriver/vfs/quota_unsupported.go
@@ -11,6 +11,14 @@ func setupDriverQuota(driver *Driver) error {
 	return nil
 }
 
+func (d *Driver) setQuotaOpt(size uint64) error {
+	return quota.ErrQuotaNotSupported
+}
+
+func (d *Driver) getQuotaOpt() uint64 {
+	return 0
+}
+
 func (d *Driver) setupQuota(dir string, size uint64) error {
 	return quota.ErrQuotaNotSupported
 }


### PR DESCRIPTION
Signed-off-by: fanjiyun <fan.jiyun@zte.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
fixes [#38592](https://github.com/moby/moby/issues/38592)
It relies on [#35231](https://github.com/moby/moby/pull/35231)

**- How I did it**
add a size option for daemon storage-opts in the xfs graphdriver,  
We can override the quota size by the "--storage-opt size" when create a new container.

**- How to verify it**
1. edit /etc/docker/daemon.json, and set the size option.
cat /etc/docker/daemon.json
{
"graph":"/home/docker",
"storage-driver":"vfs",
"storage-opts": ["size=512M"]
}
2. start a container without " --storage-opt size". 
the size of the roofts is quota with 512M, a value of the size option in the daemon.json
docker run -it --name f3 mynginx:v1 /bin/bash
3. start a container with " --storage-opt size=1G", and we can see the size of the roofts is 1.0G.
docker run -it --name f2 --storage-opt size=1G mynginx:v1 /bin/bash

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

