### PR TITLE
[DON'T MERGE] preview PR for fix retry loop for hcsshim:GetContainers 

### DIFF
--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -294,10 +294,15 @@ func (d *Driver) Remove(id string) error {
 		// not required.
 		computeSystems, err = hcsshim.GetContainers(hcsshim.ComputeSystemQuery{})
 		if err != nil {
+<<<<<<< HEAD
 			if osversion.Build() >= osversion.RS3 {
 				return err
 			}
 			if (err == hcsshim.ErrVmcomputeOperationInvalidState) || (err == hcsshim.ErrVmcomputeOperationAccessIsDenied) {
+=======
+			if (osv.Build < 15139) &&
+				(hcsshim.IsOperationInvalidState(err) || hcsshim.IsOperationAccessIsDenied(err)) {
+>>>>>>> 837b2aa9a8 (fix retry loop)
 				if retryCount >= 500 {
 					break
 				}


### PR DESCRIPTION
This is preview PR that fixes flaky test 'TestStartReturnCorrectExitCode' on windows RS1. 
Caused by outdated error check returned by hcsshim::GetContainers in retry loop:
https://github.com/moby/moby/blob/5ec31380a5d3ea92fc68e53cd1fc96f11ac02e6e/daemon/graphdriver/windows/windows.go#L276
It was discovered and investigated in https://github.com/moby/moby/pull/38580#issuecomment-455403438

