### PR TITLE
Add BuilderVersion to docker info command (#38518)

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -73,6 +73,7 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 			info.OperatingSystem = "<unknown>"
 		}
 	}
+	info.BuilderVersion = build.BuilderVersion(*s.features)
 	return httputils.WriteJSON(w, http.StatusOK, info)
 }
 

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -190,6 +190,7 @@ type Info struct {
 	Name               string
 	Labels             []string
 	ExperimentalBuild  bool
+	BuilderVersion     BuilderVersion
 	ServerVersion      string
 	ClusterStore       string
 	ClusterAdvertise   string


### PR DESCRIPTION
I guess @kwojcicki has been working on this issue.
If he has a PR, ignore mine and use his instead.

**- What I did**
Added a new field **BuilderVersion BuilderVersion** to type **Info**
Set field BuilderVersion on **getInfo()**

**- How I did it**
Field BuilderVersion is set by calling **build.BuilderVersion()** on function **getInfo()**

**- How to verify it**
Run command **docker info** and check if information **Default builder** is there.
If builder is not **buildkit** then BuilderVersion will be an empty string and will not be shown on docker info (see api/server/router/build/build.go func BuilderVersion)

**- Description for the changelog**
Added BuilderVersion to docker info command

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/7150450/51450778-31e52700-1d19-11e9-9ed2-237f42c56294.png)
