### PR TITLE
 Remove use of deprecated client.NewClient()

### DIFF
--- a/client/hijack_test.go
+++ b/client/hijack_test.go
@@ -78,7 +78,7 @@ func TestTLSCloseWriter(t *testing.T) {
 	serverURL, err := url.Parse(ts.URL)
 	assert.NilError(t, err)
 
-	client, err := NewClient("tcp://"+serverURL.Host, "", ts.Client(), nil)
+	client, err := NewClientWithOpts(WithHost("tcp://"+serverURL.Host), WithHTTPClient(ts.Client()))
 	assert.NilError(t, err)
 
 	resp, err := client.postHijacked(context.Background(), "/asdf", url.Values{}, nil, map[string][]string{"Content-Type": {"text/plain"}})

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1443,8 +1443,7 @@ func (s *DockerSuite) TestPutContainerArchiveErrSymlinkInVolumeToReadOnlyRootfs(
 	// Attempt to extract to a symlink in the volume which points to a
 	// directory outside the volume. This should cause an error because the
 	// rootfs is read-only.
-	var httpClient *http.Client
-	cli, err := client.NewClient(request.DaemonHost(), "v1.20", httpClient, map[string]string{})
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("v1.20"))
 	c.Assert(err, checker.IsNil)
 
 	err = cli.CopyToContainer(context.Background(), cID, "/vol2/symlinkToAbsDir", nil, types.CopyToContainerOptions{})

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -24,9 +24,7 @@ import (
 	"time"
 
 	"github.com/cloudflare/cfssl/helpers"
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 	moby_daemon "github.com/docker/docker/daemon"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/cli"
@@ -3007,8 +3005,7 @@ func (s *DockerDaemonSuite) TestFailedPluginRemove(c *check.C) {
 	testRequires(c, DaemonIsLinux, IsAmd64, testEnv.IsLocalDaemon)
 	d := daemon.New(c, dockerBinary, dockerdBinary)
 	d.Start(c)
-	cli, err := client.NewClient(d.Sock(), api.DefaultVersion, nil, nil)
-	c.Assert(err, checker.IsNil)
+	cli := d.NewClientT(c)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
 	defer cancel()


### PR DESCRIPTION
Follow-up to https://github.com/moby/moby/pull/38603