### PR TITLE
Adding builder version

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -44,6 +44,8 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 		info.Swarm = s.cluster.Info()
 	}
 
+	info.Builder = build.BuilderVersion(*s.features)
+
 	if versions.LessThan(httputils.VersionFromContext(ctx), "1.25") {
 		// TODO: handle this conversion in engine-api
 		type oldInfo struct {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -146,6 +146,7 @@ type Commit struct {
 // GET "/info"
 type Info struct {
 	ID                 string
+	Builder            BuilderVersion
 	Containers         int
 	ContainersRunning  int
 	ContainersPaused   int

--- a/integration/system/info_test.go
+++ b/integration/system/info_test.go
@@ -35,7 +35,8 @@ func TestInfoAPI(t *testing.T) {
 		"KernelVersion",
 		"Driver",
 		"ServerVersion",
-		"SecurityOptions"}
+		"SecurityOptions",
+		"Builder"}
 
 	out := fmt.Sprintf("%+v", info)
 	for _, linePrefix := range stringsToCheck {


### PR DESCRIPTION
Signed-off-by: Krystian Wojcicki <kwojcicki@sympatico.ca>

fixes #38518 

**- What I did**

Added a builderversion to the info struct

**- How I did it**

Called the build.BuilderVersion function in the getInfo function

**- How to verify it**

```docker info``` wont show the info at the moment will have to make another PR for that but in the mean time the test shows the field is present in the API call.

**- Description for the changelog**
Added BuilderVersion to info API call.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/2487946/51504538-8a670380-1daf-11e9-94e6-b31fde3d74b5.png)
