### PR TITLE
ContainerCreate shouldn't return warnings=nil. Fix #38222

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -75,6 +75,10 @@ func (daemon *Daemon) containerCreate(params types.ContainerCreateConfig, manage
 	}
 	containerActions.WithValues("create").UpdateSince(start)
 
+	if warnings == nil {
+		warnings = make(string[], 0) // Create an empty slice to avoid https://github.com/moby/moby/issues/38222
+	}
+
 	return containertypes.ContainerCreateCreatedBody{ID: container.ID, Warnings: warnings}, nil
 }
 

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -76,7 +76,7 @@ func (daemon *Daemon) containerCreate(params types.ContainerCreateConfig, manage
 	containerActions.WithValues("create").UpdateSince(start)
 
 	if warnings == nil {
-		warnings = make(string[], 0) // Create an empty slice to avoid https://github.com/moby/moby/issues/38222
+		warnings = make([]string, 0) // Create an empty slice to avoid https://github.com/moby/moby/issues/38222
 	}
 
 	return containertypes.ContainerCreateCreatedBody{ID: container.ID, Warnings: warnings}, nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I've fixed #38222.

**- How I did it**
If warnings == `nil`, create an empty slice to avoid bug.

**- How to verify it**
See #38222.

**- Description for the changelog**
Fix ContainerCreate output (fix #38222)
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![default](https://user-images.githubusercontent.com/19504461/51542268-e7c08a80-1e6b-11e9-83b4-bbb5d541d9a9.png)

