### PR TITLE
Remove "docs maintainers" section

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -50,15 +50,6 @@
 			"yongtang"
 		]
 
-	[Org."Docs maintainers"]
-
-	# TODO Describe the docs maintainers role.
-
-		people = [
-			"misty",
-			"thajeztah"
-		]
-
 	[Org.Curators]
 
 	# The curators help ensure that incoming issues and pull requests are properly triaged and
@@ -386,11 +377,6 @@
 	Name = "Morgan Bauer"
 	Email = "mbauer@us.ibm.com"
 	GitHub = "mhbauer"
-
-	[people.misty]
-	Name = "Misty Stanley-Jones"
-	Email = "misty@docker.com"
-	GitHub = "mistyhacks"
 
 	[people.mlaventure]
 	Name = "Kenfe-Mickaël Laventure"


### PR DESCRIPTION
The docs maintainers role was in the maintainers file
from way back when the documentation was still in this
repository.

Now that the documentation has moved to its own repository,
we should no longer need this section.

@moby/moby-maintainers 

/cc @mistyhacks 🤗 (let me know if you prefer to be added to the "alumni" list here, then I'll write up something nice 🎉 )
