### PR TITLE
Fix for DNS name resolution after performing init with --force-new-cluster

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -239,7 +239,7 @@ func (c *Cluster) newNodeRunner(conf nodeStartConfig) (*nodeRunner, error) {
 		return nil, err
 	}
 
-	c.config.Backend.DaemonJoinsCluster(c)
+	c.config.Backend.DaemonJoinsCluster(c, conf.forceNewCluster)
 
 	return nr, nil
 }

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -51,7 +51,7 @@ type Backend interface {
 	SystemInfo() (*types.Info, error)
 	Containers(config *types.ContainerListOptions) ([]*types.Container, error)
 	SetNetworkBootstrapKeys([]*networktypes.EncryptionKey) error
-	DaemonJoinsCluster(provider cluster.Provider)
+	DaemonJoinsCluster(provider cluster.Provider, forceNewCluster bool)
 	DaemonLeavesCluster()
 	IsSwarmCompatible() error
 	SubscribeToEvents(since, until time.Time, filter filters.Args) ([]events.Message, chan interface{})

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -647,7 +647,15 @@ func (daemon *Daemon) registerLink(parent, child *container.Container, alias str
 
 // DaemonJoinsCluster informs the daemon has joined the cluster and provides
 // the handler to query the cluster component
-func (daemon *Daemon) DaemonJoinsCluster(clusterProvider cluster.Provider) {
+func (daemon *Daemon) DaemonJoinsCluster(clusterProvider cluster.Provider, forceNewCluster bool) {
+	// When forcing a new cluster, first clean up the existing agent
+	// ensuring that a new one will be created and started
+	if(forceNewCluster) {
+		daemon.setClusterProvider(nil)
+		// Wait for the networking cluster agent to stop
+		daemon.netController.AgentStopWait()
+	}
+	
 	daemon.setClusterProvider(clusterProvider)
 }
 


### PR DESCRIPTION
- What I did
This fixes a problem where the agent on a controller is stopped when a node leaves a swarm and is never restarted. I've added
a flag to the DaemonJoinsCluster method to indicate the case where a force init is being done. When that flag is set the existing agent is cleaned up
by setting the cluster provider to nil and waiting for the agent to stop. When the cluster provider is set after, the agent is setup properly. This PR 
fixes the following issue : https://github.com/docker/for-linux/issues/495

- How I did it
 Added a flag indicating that this is a force new cluster situation and the agent should be cleaned up before setting the cluster provider.
 
- How to verify it

1. Using the following Docker file build an image on each node called demo.

```
FROM ubuntu

RUN apt update
RUN apt install dnsutils -y

CMD /bin/bash -c "while true; do nslookup tasks.demo; sleep 2; done"
```

2. execute swarm init on one of the nodes
3. create a network `docker network create --scope swarm --driver overlay --attachable test`
4. create a service `docker service create --network test --mode global --name demo demo`
5. verify that the tasks.demo endpoint resolves to two ip addresses docker service logs demo
6. now execute docker swarm init --force-new-cluster on one of the nodes
7. demote and remove the other node and also, remove the service and network
8. recreate the service and network on the remaining node
9. have a third node join the remaining node
10. Previously, at this point node 3 would resolve tasks.demo to be it's container's ip but the tasks.demo would not resolve on the first node. Also the container on each node could not reach the container on the other node using it's ip. With this fix in place this would work as we expect and each task would be resolved to the respective ips.

- Description for the changelog
Fix a problem with DNS resolution after performing a cluster init with the --force-new-cluster option set

- A picture of a cute animal (not mandatory but encouraged)