### PR TITLE
Fix nil pointer derefence on failure to connect to containerd

### DIFF
--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -311,6 +311,8 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 				delay = time.After(time.Duration(transientFailureCount) * 200 * time.Millisecond)
 				continue
 			}
+			client.Close()
+			client = nil
 		}
 
 		if system.IsProcessAlive(r.daemonPid) {
@@ -318,8 +320,6 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 			r.killDaemon()
 		}
 
-		client.Close()
-		client = nil
 		r.daemonPid = -1
 		delay = nil
 		transientFailureCount = 0


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

As reported in #38636 Docker will crash if it fails to connect to containerd before the timeout is reached. Although the underlying cause seems to be containerd stuck doing an fdatasync there's a nil pointer dereference if the connection to containerd fails.

**- How I did it**

Moved the offending code to where we know the pointer can be used safely.

**- How to verify it**

It's hard to reproduce the underlying issue causing containerd to hang when doing a fdatasync. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix nil pointer derefence on failure to connect to containerd.

**- A picture of a cute animal (not mandatory but encouraged)**

