### PR TITLE
Allow overriding repository and branch in validate scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ DOCKERFILE := $(shell bash -c 'source hack/make/.detect-daemon-osarch && echo $$
 DOCKER_GITCOMMIT := $(shell git rev-parse --short HEAD || echo unsupported)
 export DOCKER_GITCOMMIT
 
+# allow overriding the repository and branch that validation scripts are running
+# against these are used in hack/validate/.validate to check what changed in the PR.
+export VALIDATE_REPO
+export VALIDATE_BRANCH
+
 # env vars passed through directly to Docker's build scripts
 # to allow things like `make KEEPBUNDLE=1 binary` easily
 # `project/PACKAGERS.md` have some limited documentation of some of these
@@ -47,6 +52,8 @@ DOCKER_ENVS := \
 	-e TESTDIRS \
 	-e TESTFLAGS \
 	-e TIMEOUT \
+	-e VALIDATE_REPO \
+	-e VALIDATE_BRANCH \
 	-e HTTP_PROXY \
 	-e HTTPS_PROXY \
 	-e NO_PROXY \

--- a/hack/validate/.validate
+++ b/hack/validate/.validate
@@ -6,8 +6,8 @@ if [ -z "$VALIDATE_UPSTREAM" ]; then
 	# this is kind of an expensive check, so let's not do this twice if we
 	# are running more than one validate bundlescript
 
-	VALIDATE_REPO='https://github.com/docker/docker.git'
-	VALIDATE_BRANCH='master'
+	VALIDATE_REPO="${VALIDATE_REPO:-https://github.com/docker/docker.git}"
+	VALIDATE_BRANCH="${VALIDATE_BRANCH:-master}"
 
 	VALIDATE_HEAD="$(git rev-parse --verify HEAD)"
 


### PR DESCRIPTION
When running CI in other repositories (e.g. Docker's downstream
docker/engine repository), or other branches, the validation
scripts were calculating the list of changes based on the wrong
information.

This lead to weird failures in CI in a branch where these values
were not updated ':-) (CI on a pull request failed because it detected
that new tests were added to the deprecated `integration-cli` test-suite,
but the pull request did not actually make changes in that area).

This patch allows overriding the target repository (and branch)
to compare to (without having to edit the scripts).
