### PR TITLE
Use 17.06 stable channel for CLI used in CI

### DIFF
--- a/hack/dockerfile/install/dockercli.installer
+++ b/hack/dockerfile/install/dockercli.installer
@@ -1,22 +1,22 @@
 #!/bin/sh
 
-DOCKERCLI_CHANNEL=${DOCKERCLI_CHANNEL:-edge}
-DOCKERCLI_VERSION=${DOCKERCLI_VERSION:-17.06.0-ce}
+DOCKERCLI_CHANNEL=${DOCKERCLI_CHANNEL:-stable}
+DOCKERCLI_VERSION=${DOCKERCLI_VERSION:-17.06.2-ce}
 
 install_dockercli() {
 	echo "Install docker/cli version $DOCKERCLI_VERSION from $DOCKERCLI_CHANNEL"
 
 	arch=$(uname -m)
 	# No official release of these platforms
-	if [ "$arch" != "x86_64" ] && [ "$arch" != "s390x" ]; then
+	if [ "$arch" != "x86_64" ] && [ "$arch" != "s390x" ] && [ "$arch" != "armhf" ]; then
 		build_dockercli
 		return
 	fi
 
 	url=https://download.docker.com/linux/static
 	curl -Ls "${url}/${DOCKERCLI_CHANNEL}/${arch}/docker-${DOCKERCLI_VERSION}.tgz" | tar -xz docker/docker
-	mkdir -p ${PREFIX}
-	mv docker/docker ${PREFIX}/
+	mkdir -p "${PREFIX}"
+	mv docker/docker "${PREFIX}/"
 	rmdir docker
 }
 

--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -394,8 +394,8 @@ Try {
         if ($Daemon) { Execute-Build "daemon" "daemon" "dockerd" }
         if ($Client) {
             # Get the Docker channel and version from the environment, or use the defaults.
-            if (-not ($channel = $env:DOCKERCLI_CHANNEL)) { $channel = "edge" }
-            if (-not ($version = $env:DOCKERCLI_VERSION)) { $version = "17.06.0-ce" }
+            if (-not ($channel = $env:DOCKERCLI_CHANNEL)) { $channel = "stable" }
+            if (-not ($version = $env:DOCKERCLI_VERSION)) { $version = "17.06.2-ce" }
 
             # Download the zip file and extract the client executable.
             Write-Host "INFO: Downloading docker/cli version $version from $channel..."


### PR DESCRIPTION
Update to the latest patch release of 17.06.2. This keeps the same API requirements.

This also enables pre-built binaries for armhf instead of compiling from source.


