### PR TITLE
[WIP] cleanup container validation

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -231,8 +231,8 @@ func (daemon *Daemon) setHostConfig(container *container.Container, hostConfig *
 	return container.CheckpointTo(daemon.containersReplica)
 }
 
-// verifyContainerSettings performs validation of the hostConfig.
-func (daemon *Daemon) verifyContainerSettings(platform string, hostConfig *containertypes.HostConfig, update bool) (warnings []string, err error) {
+// validateContainerHostConfig performs validation of the hostConfig.
+func (daemon *Daemon) validateContainerHostConfig(platform string, hostConfig *containertypes.HostConfig, update bool) (warnings []string, err error) {
 	// First perform verification of settings common across all platforms.
 	if err := validateHostConfig(hostConfig, platform); err != nil {
 		return warnings, err

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -231,13 +231,9 @@ func (daemon *Daemon) setHostConfig(container *container.Container, hostConfig *
 	return container.CheckpointTo(daemon.containersReplica)
 }
 
-// verifyContainerSettings performs validation of the hostconfig and config
-// structures.
-func (daemon *Daemon) verifyContainerSettings(platform string, hostConfig *containertypes.HostConfig, config *containertypes.Config, update bool) (warnings []string, err error) {
+// verifyContainerSettings performs validation of the hostConfig.
+func (daemon *Daemon) verifyContainerSettings(platform string, hostConfig *containertypes.HostConfig, update bool) (warnings []string, err error) {
 	// First perform verification of settings common across all platforms.
-	if err = validateContainerConfig(config, platform); err != nil {
-		return warnings, err
-	}
 	if err := validateHostConfig(hostConfig, platform); err != nil {
 		return warnings, err
 	}

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -232,14 +232,14 @@ func (daemon *Daemon) setHostConfig(container *container.Container, hostConfig *
 }
 
 // validateContainerHostConfig performs validation of the hostConfig.
-func (daemon *Daemon) validateContainerHostConfig(platform string, hostConfig *containertypes.HostConfig, update bool) (warnings []string, err error) {
+func (daemon *Daemon) validateContainerHostConfig(platform string, hostConfig *containertypes.HostConfig) (warnings []string, err error) {
 	// First perform verification of settings common across all platforms.
 	if err := validateHostConfig(hostConfig, platform); err != nil {
 		return warnings, err
 	}
 
 	// Now do platform-specific verification
-	warnings, err = verifyPlatformContainerSettings(daemon, hostConfig, update)
+	warnings, err = verifyPlatformContainerSettings(daemon, hostConfig)
 	for _, w := range warnings {
 		logrus.Warn(w)
 	}

--- a/daemon/container_unix_test.go
+++ b/daemon/container_unix_test.go
@@ -37,7 +37,7 @@ func TestContainerWarningHostAndPublishPorts(t *testing.T) {
 			},
 		}
 		d := &Daemon{configStore: cs}
-		wrns, err := d.validateContainerHostConfig("", hostConfig, false)
+		wrns, err := d.validateContainerHostConfig("", hostConfig)
 		assert.NilError(t, err)
 		assert.DeepEqual(t, tc.warnings, wrns)
 	}

--- a/daemon/container_unix_test.go
+++ b/daemon/container_unix_test.go
@@ -37,7 +37,7 @@ func TestContainerWarningHostAndPublishPorts(t *testing.T) {
 			},
 		}
 		d := &Daemon{configStore: cs}
-		wrns, err := d.verifyContainerSettings("", hostConfig, &containertypes.Config{}, false)
+		wrns, err := d.verifyContainerSettings("", hostConfig, false)
 		assert.NilError(t, err)
 		assert.DeepEqual(t, tc.warnings, wrns)
 	}

--- a/daemon/container_unix_test.go
+++ b/daemon/container_unix_test.go
@@ -37,7 +37,7 @@ func TestContainerWarningHostAndPublishPorts(t *testing.T) {
 			},
 		}
 		d := &Daemon{configStore: cs}
-		wrns, err := d.verifyContainerSettings("", hostConfig, false)
+		wrns, err := d.validateContainerHostConfig("", hostConfig, false)
 		assert.NilError(t, err)
 		assert.DeepEqual(t, tc.warnings, wrns)
 	}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -72,6 +72,11 @@ func (daemon *Daemon) containerCreate(opts createOpts) (containertypes.Container
 		}
 	}
 
+	err := daemon.adaptContainerSettings(opts.params.HostConfig, opts.params.AdjustCPUShares)
+	if err != nil {
+		return containertypes.ContainerCreateCreatedBody{}, errdefs.InvalidParameter(err)
+	}
+
 	warnings, err := daemon.verifyContainerSettings(os, opts.params.HostConfig, opts.params.Config, false)
 	if err != nil {
 		return containertypes.ContainerCreateCreatedBody{Warnings: warnings}, errdefs.InvalidParameter(err)
@@ -84,10 +89,6 @@ func (daemon *Daemon) containerCreate(opts createOpts) (containertypes.Container
 
 	if opts.params.HostConfig == nil {
 		opts.params.HostConfig = &containertypes.HostConfig{}
-	}
-	err = daemon.adaptContainerSettings(opts.params.HostConfig, opts.params.AdjustCPUShares)
-	if err != nil {
-		return containertypes.ContainerCreateCreatedBody{Warnings: warnings}, errdefs.InvalidParameter(err)
 	}
 
 	container, err := daemon.create(opts)

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -82,7 +82,7 @@ func (daemon *Daemon) containerCreate(opts createOpts) (containertypes.Container
 		return containertypes.ContainerCreateCreatedBody{}, errdefs.InvalidParameter(err)
 	}
 
-	warnings, err := daemon.validateContainerHostConfig(os, opts.params.HostConfig, false)
+	warnings, err := daemon.validateContainerHostConfig(os, opts.params.HostConfig)
 	if err != nil {
 		return containertypes.ContainerCreateCreatedBody{Warnings: warnings}, errdefs.InvalidParameter(err)
 	}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -82,7 +82,7 @@ func (daemon *Daemon) containerCreate(opts createOpts) (containertypes.Container
 		return containertypes.ContainerCreateCreatedBody{}, errdefs.InvalidParameter(err)
 	}
 
-	warnings, err := daemon.verifyContainerSettings(os, opts.params.HostConfig, false)
+	warnings, err := daemon.validateContainerHostConfig(os, opts.params.HostConfig, false)
 	if err != nil {
 		return containertypes.ContainerCreateCreatedBody{Warnings: warnings}, errdefs.InvalidParameter(err)
 	}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -77,7 +77,12 @@ func (daemon *Daemon) containerCreate(opts createOpts) (containertypes.Container
 		return containertypes.ContainerCreateCreatedBody{}, errdefs.InvalidParameter(err)
 	}
 
-	warnings, err := daemon.verifyContainerSettings(os, opts.params.HostConfig, opts.params.Config, false)
+	err = validateContainerConfig(opts.params.Config, os)
+	if err != nil {
+		return containertypes.ContainerCreateCreatedBody{}, errdefs.InvalidParameter(err)
+	}
+
+	warnings, err := daemon.verifyContainerSettings(os, opts.params.HostConfig, false)
 	if err != nil {
 		return containertypes.ContainerCreateCreatedBody{Warnings: warnings}, errdefs.InvalidParameter(err)
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1471,14 +1471,6 @@ func (daemon *Daemon) checkpointAndSave(container *container.Container) error {
 	return nil
 }
 
-// because the CLI sends a -1 when it wants to unset the swappiness value
-// we need to clear it on the server side
-func fixMemorySwappiness(resources *containertypes.Resources) {
-	if resources.MemorySwappiness != nil && *resources.MemorySwappiness == -1 {
-		resources.MemorySwappiness = nil
-	}
-}
-
 // GetAttachmentStore returns current attachment store associated with the daemon
 func (daemon *Daemon) GetAttachmentStore() *network.AttachmentStore {
 	return &daemon.attachmentStore

--- a/daemon/daemon_linux_test.go
+++ b/daemon/daemon_linux_test.go
@@ -115,7 +115,7 @@ func TestNotCleanupMounts(t *testing.T) {
 func TestValidateContainerIsolationLinux(t *testing.T) {
 	d := Daemon{}
 
-	_, err := d.validateContainerHostConfig("linux", &containertypes.HostConfig{Isolation: containertypes.IsolationHyperV}, false)
+	_, err := d.validateContainerHostConfig("linux", &containertypes.HostConfig{Isolation: containertypes.IsolationHyperV})
 	assert.Check(t, is.Error(err, "invalid isolation 'hyperv' on linux"))
 }
 

--- a/daemon/daemon_linux_test.go
+++ b/daemon/daemon_linux_test.go
@@ -115,7 +115,7 @@ func TestNotCleanupMounts(t *testing.T) {
 func TestValidateContainerIsolationLinux(t *testing.T) {
 	d := Daemon{}
 
-	_, err := d.verifyContainerSettings("linux", &containertypes.HostConfig{Isolation: containertypes.IsolationHyperV}, false)
+	_, err := d.validateContainerHostConfig("linux", &containertypes.HostConfig{Isolation: containertypes.IsolationHyperV}, false)
 	assert.Check(t, is.Error(err, "invalid isolation 'hyperv' on linux"))
 }
 

--- a/daemon/daemon_linux_test.go
+++ b/daemon/daemon_linux_test.go
@@ -115,7 +115,7 @@ func TestNotCleanupMounts(t *testing.T) {
 func TestValidateContainerIsolationLinux(t *testing.T) {
 	d := Daemon{}
 
-	_, err := d.verifyContainerSettings("linux", &containertypes.HostConfig{Isolation: containertypes.IsolationHyperV}, nil, false)
+	_, err := d.verifyContainerSettings("linux", &containertypes.HostConfig{Isolation: containertypes.IsolationHyperV}, false)
 	assert.Check(t, is.Error(err, "invalid isolation 'hyperv' on linux"))
 }
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -305,7 +305,7 @@ func TestMerge(t *testing.T) {
 func TestValidateContainerIsolation(t *testing.T) {
 	d := Daemon{}
 
-	_, err := d.verifyContainerSettings(runtime.GOOS, &containertypes.HostConfig{Isolation: containertypes.Isolation("invalid")}, nil, false)
+	_, err := d.verifyContainerSettings(runtime.GOOS, &containertypes.HostConfig{Isolation: containertypes.Isolation("invalid")}, false)
 	assert.Check(t, is.Error(err, "invalid isolation 'invalid' on "+runtime.GOOS))
 }
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -305,7 +305,7 @@ func TestMerge(t *testing.T) {
 func TestValidateContainerIsolation(t *testing.T) {
 	d := Daemon{}
 
-	_, err := d.verifyContainerSettings(runtime.GOOS, &containertypes.HostConfig{Isolation: containertypes.Isolation("invalid")}, false)
+	_, err := d.validateContainerHostConfig(runtime.GOOS, &containertypes.HostConfig{Isolation: containertypes.Isolation("invalid")}, false)
 	assert.Check(t, is.Error(err, "invalid isolation 'invalid' on "+runtime.GOOS))
 }
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -305,7 +305,7 @@ func TestMerge(t *testing.T) {
 func TestValidateContainerIsolation(t *testing.T) {
 	d := Daemon{}
 
-	_, err := d.validateContainerHostConfig(runtime.GOOS, &containertypes.HostConfig{Isolation: containertypes.Isolation("invalid")}, false)
+	_, err := d.validateContainerHostConfig(runtime.GOOS, &containertypes.HostConfig{Isolation: containertypes.Isolation("invalid")})
 	assert.Check(t, is.Error(err, "invalid isolation 'invalid' on "+runtime.GOOS))
 }
 

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -425,9 +425,7 @@ func adaptSharedNamespaceContainer(daemon containerGetter, hostConfig *container
 }
 
 // verifyPlatformContainerResources performs platform-specific validation of the container's resource-configuration
-func verifyPlatformContainerResources(resources *containertypes.Resources, sysInfo *sysinfo.SysInfo, update bool) (warnings []string, err error) {
-	fixMemorySwappiness(resources)
-
+func verifyPlatformContainerResources(resources *containertypes.Resources, sysInfo *sysinfo.SysInfo) (warnings []string, err error) {
 	// memory subsystem checks and adjustments
 	if resources.Memory != 0 && resources.Memory < linuxMinMemory {
 		return warnings, fmt.Errorf("Minimum memory limit allowed is 4MB")
@@ -444,7 +442,7 @@ func verifyPlatformContainerResources(resources *containertypes.Resources, sysIn
 	if resources.Memory > 0 && resources.MemorySwap > 0 && resources.MemorySwap < resources.Memory {
 		return warnings, fmt.Errorf("Minimum memoryswap limit should be larger than memory limit, see usage")
 	}
-	if resources.Memory == 0 && resources.MemorySwap > 0 && !update {
+	if resources.Memory == 0 && resources.MemorySwap > 0 {
 		return warnings, fmt.Errorf("You should always set the Memory limit when using Memoryswap limit, see usage")
 	}
 	if resources.MemorySwappiness != nil && !sysInfo.MemorySwappiness {
@@ -639,13 +637,13 @@ func UsingSystemd(config *config.Config) bool {
 
 // verifyPlatformContainerSettings performs platform-specific validation of the
 // hostconfig and config structures.
-func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.HostConfig, update bool) (warnings []string, err error) {
+func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.HostConfig) (warnings []string, err error) {
 	if hostConfig == nil {
 		return nil, nil
 	}
 	sysInfo := sysinfo.New(true)
 
-	w, err := verifyPlatformContainerResources(&hostConfig.Resources, sysInfo, update)
+	w, err := verifyPlatformContainerResources(&hostConfig.Resources, sysInfo)
 
 	// no matter err is nil or not, w could have data in itself.
 	warnings = append(warnings, w...)

--- a/daemon/daemon_unix_test.go
+++ b/daemon/daemon_unix_test.go
@@ -238,7 +238,6 @@ func TestVerifyPlatformContainerResources(t *testing.T) {
 		name             string
 		resources        containertypes.Resources
 		sysInfo          sysinfo.SysInfo
-		update           bool
 		expectedWarnings []string
 	}{
 		{
@@ -301,7 +300,7 @@ func TestVerifyPlatformContainerResources(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			warnings, err := verifyPlatformContainerResources(&tc.resources, &tc.sysInfo, tc.update)
+			warnings, err := verifyPlatformContainerResources(&tc.resources, &tc.sysInfo)
 			assert.NilError(t, err)
 			for _, w := range tc.expectedWarnings {
 				assert.Assert(t, is.Contains(warnings, w))

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -72,10 +72,6 @@ func (daemon *Daemon) getCgroupDriver() string {
 // adaptContainerSettings is called during container creation to modify any
 // settings necessary in the HostConfig structure.
 func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConfig, adjustCPUShares bool) error {
-	if hostConfig == nil {
-		return nil
-	}
-
 	return nil
 }
 

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -77,7 +77,6 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConf
 
 // verifyPlatformContainerResources performs platform-specific validation of the container's resource-configuration
 func verifyPlatformContainerResources(resources *containertypes.Resources, isHyperv bool) (warnings []string, err error) {
-	fixMemorySwappiness(resources)
 	if !isHyperv {
 		// The processor resource controls are mutually exclusive on
 		// Windows Server Containers, the order of precedence is
@@ -187,7 +186,7 @@ func verifyPlatformContainerResources(resources *containertypes.Resources, isHyp
 
 // verifyPlatformContainerSettings performs platform-specific validation of the
 // hostconfig and config structures.
-func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.HostConfig, update bool) (warnings []string, err error) {
+func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.HostConfig) (warnings []string, err error) {
 	if hostConfig == nil {
 		return nil, nil
 	}

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -88,7 +88,7 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *containertypes.Hos
 
 	// check if hostConfig is in line with the current system settings.
 	// It may happen cgroups are umounted or the like.
-	if _, err = daemon.verifyContainerSettings(container.OS, container.HostConfig, false); err != nil {
+	if _, err = daemon.validateContainerHostConfig(container.OS, container.HostConfig, false); err != nil {
 		return errdefs.InvalidParameter(err)
 	}
 	return daemon.containerStart(container, checkpoint, checkpointDir, true)

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -88,7 +88,7 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *containertypes.Hos
 
 	// check if hostConfig is in line with the current system settings.
 	// It may happen cgroups are umounted or the like.
-	if _, err = daemon.verifyContainerSettings(container.OS, container.HostConfig, nil, false); err != nil {
+	if _, err = daemon.verifyContainerSettings(container.OS, container.HostConfig, false); err != nil {
 		return errdefs.InvalidParameter(err)
 	}
 	return daemon.containerStart(container, checkpoint, checkpointDir, true)

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -88,7 +88,7 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *containertypes.Hos
 
 	// check if hostConfig is in line with the current system settings.
 	// It may happen cgroups are umounted or the like.
-	if _, err = daemon.validateContainerHostConfig(container.OS, container.HostConfig, false); err != nil {
+	if _, err = daemon.validateContainerHostConfig(container.OS, container.HostConfig); err != nil {
 		return errdefs.InvalidParameter(err)
 	}
 	return daemon.containerStart(container, checkpoint, checkpointDir, true)

--- a/daemon/update.go
+++ b/daemon/update.go
@@ -18,7 +18,7 @@ func (daemon *Daemon) ContainerUpdate(name string, hostConfig *container.HostCon
 		return container.ContainerUpdateOKBody{Warnings: warnings}, err
 	}
 
-	warnings, err = daemon.verifyContainerSettings(c.OS, hostConfig, nil, true)
+	warnings, err = daemon.verifyContainerSettings(c.OS, hostConfig, true)
 	if err != nil {
 		return container.ContainerUpdateOKBody{Warnings: warnings}, errdefs.InvalidParameter(err)
 	}

--- a/daemon/update.go
+++ b/daemon/update.go
@@ -18,7 +18,7 @@ func (daemon *Daemon) ContainerUpdate(name string, hostConfig *container.HostCon
 		return container.ContainerUpdateOKBody{Warnings: warnings}, err
 	}
 
-	warnings, err = daemon.verifyContainerSettings(c.OS, hostConfig, true)
+	warnings, err = daemon.validateContainerHostConfig(c.OS, hostConfig, true)
 	if err != nil {
 		return container.ContainerUpdateOKBody{Warnings: warnings}, errdefs.InvalidParameter(err)
 	}

--- a/daemon/update.go
+++ b/daemon/update.go
@@ -18,7 +18,7 @@ func (daemon *Daemon) ContainerUpdate(name string, hostConfig *container.HostCon
 		return container.ContainerUpdateOKBody{Warnings: warnings}, err
 	}
 
-	warnings, err = daemon.validateContainerHostConfig(c.OS, hostConfig, true)
+	warnings, err = daemon.validateContainerHostConfig(c.OS, hostConfig)
 	if err != nil {
 		return container.ContainerUpdateOKBody{Warnings: warnings}, errdefs.InvalidParameter(err)
 	}


### PR DESCRIPTION
Refactor some validation code to move `fixMemorySwappiness()` elsewhere than buried deep in the daemon validation, whereas it's actually use converting API requests to actual values so (I think) should be handled somewhere in the API, or at least earlier in the steps..