### PR TITLE
LCOW: Don't fail image push when files have spaces

### DIFF
--- a/daemon/graphdriver/lcow/lcow.go
+++ b/daemon/graphdriver/lcow/lcow.go
@@ -1104,6 +1104,11 @@ func (fgc *fileGetCloserFromSVM) Get(filename string) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("inconsistency detected: couldn't get short container path for %+v in utility VM %s", fgc.mvd, fgc.svm.config.Name)
 	}
 	file := path.Join(actualContainerPath, filename)
+
+	// Ugly fix for MSFT internal bug VSO#19696554
+	// If a file name contains a space, pushing an image fails.
+	// Using solution from https://groups.google.com/forum/#!topic/Golang-Nuts/DpldsmrhPio to escape for shell execution
+	file = "'" + strings.Join(strings.Split(file, "'"), `'"'"'`) + "'"
 	if err := fgc.svm.runProcess(fmt.Sprintf("cat %s", file), nil, outOut, errOut); err != nil {
 		logrus.Debugf("cat %s failed: %s", file, errOut.String())
 		return nil, err


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Reported internally at Microsoft through VSO#19696554.
Using the solution from https://groups.google.com/forum/#!topic/Golang-Nuts/DpldsmrhPio
to quote file name and escape single quotes (https://play.golang.org/p/ntk8EEGjfk)

Simple repro steps are something like:

On an ubuntu box run something like
```
docker run -d --rm -p 5000:5000 registry:latest
hostname-I to get the ip address
```

On Windows start the daemon adding `--insecure-registry 10.124.186.18:5000`
(or whatever the IP address from above was)

```
docker run -it alpine sh
/ # echo bar > "with space"​
/ # echo foo > 'single quote space'
/ # exit

docker ps -a
docker commit <containerid>
(note the first few of the image id)
docker tag <first few> 10.124.186.18:5000/test
docker push 10.124.186.18:5000/test
```

Resulting error when pushing the image:

```
PS E:\docker\build\19696554> docker push 10.124.186.18:5000/simpletest2
The push refers to repository [10.124.186.18:5000/simpletest2]​
d328d7f5f277: Pushing [==================================================>]  74.24kB/74.24kB​
503e53e365f3: Layer already exists​
svm.runProcess: command cat /tmp/d59/single quote space failed with exit code 1​
PS E:\docker\build\19696554>
```

After this change pushing the image:
```
PS E:\docker\build\19696554> docker push 10.124.186.18:5000/simpletest2
The push refers to repository [10.124.186.18:5000/simpletest2]
d328d7f5f277: Pushing [==================================================>]  74.24kB/74.24kB
503e53e365f3: Layer already exists
latest: digest: sha256:b9828a2d2a3d2421a4c342f48b7936714b3d8409dc32c103da5f3fb13b54bdbf size: 735
PS E:\docker\build\19696554>
```

