### PR TITLE
Fix go-vet issue

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -164,6 +164,7 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	if cli.Config.ContainerdAddr == "" && runtime.GOOS != "windows" {
 		systemContainerdAddr, ok, err := systemContainerdRunning(cli.Config.IsRootless())
 		if err != nil {
+			cancel()
 			return errors.Wrap(err, "could not determine whether the system containerd is running")
 		}
 		if !ok {


### PR DESCRIPTION
This fix fixes the following issue with `go vet`:
```
$ go tool vet cmd/dockerd/daemon.go
cmd/dockerd/daemon.go:163: the cancel function is not used on all paths (possible context leak)
cmd/dockerd/daemon.go:167: this return statement may be reached without using the cancel var defined on line 163
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
