### PR TITLE
Amend (swagger) docs for builder version, and change type

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -52,8 +52,6 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 		info.Swarm = s.cluster.Info()
 	}
 
-	info.Builder = build.BuilderVersion(*s.features)
-
 	if versions.LessThan(httputils.VersionFromContext(ctx), "1.25") {
 		// TODO: handle this conversion in engine-api
 		type oldInfo struct {
@@ -82,6 +80,9 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 		if info.OperatingSystem == "" {
 			info.OperatingSystem = "<unknown>"
 		}
+	}
+	if versions.GreaterThanOrEqualTo(httputils.VersionFromContext(ctx), "1.40") {
+		info.Builder = string(build.BuilderVersion(*s.features))
 	}
 	return httputils.WriteJSON(w, http.StatusOK, info)
 }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3584,6 +3584,17 @@ definitions:
           > should not be considered stable.
         type: "string"
         example: "7TRN:IPZB:QYBB:VPBQ:UMPP:KARE:6ZNR:XE6T:7EWV:PKF4:ZOJD:TPYS"
+      Builder:
+        description: |
+          Default docker builder version as set in the daemon configuration. The
+          client should follow this version when performing a build, but is
+          allowed to choose a different version.
+
+          If this value is not set, or empty, it is up to the client to choose
+          which builder to use.
+        type: "string"
+        x-nullable: true
+        example: "2"
       Containers:
         description: "Total number of containers on the host."
         type: "integer"

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -146,7 +146,7 @@ type Commit struct {
 // GET "/info"
 type Info struct {
 	ID                 string
-	Builder            BuilderVersion
+	Builder            string `json:",omitempty"`
 	Containers         int
 	ContainersRunning  int
 	ContainersPaused   int

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -47,9 +47,10 @@ keywords: "API, Docker, rcli, REST, documentation"
   `BindOptions.NonRecursive`.
 * `POST /swarm/init` now accepts a `DataPathPort` property to set data path port number.
 * `GET /info` now returns information about `DataPathPort` that is currently used in swarm
+* `GET /info` now returns a `Builder` field, containing the default builder version
+  to use, if configured on the daemon.
 * `GET /info` now returns `PidsLimit` boolean to indicate if the host kernel has
   PID limit support enabled.
-
 * `GET /swarm` endpoint now returns DataPathPort info
 * `POST /containers/create` now takes `KernelMemoryTCP` field to set hard limit for kernel TCP buffer memory.
 * `GET /service` now  returns `MaxReplicas` as part of the `Placement`.


### PR DESCRIPTION
Document the `Builder` field that was added in API v1.40, and change its type to a plain "string".

We might still want to consider to either change this info to a "Builder" struct (allowing us to expand the information that's included in future) or to revert this field, and use the `Builder-Version` header to obtain this information, until we have more information to include.


follow-up to https://github.com/moby/moby/pull/38609
