### PR TITLE
Make client return "rich" errors (take 2)

### DIFF
--- a/api/server/httputils/errors_deprecated.go
+++ b/api/server/httputils/errors_deprecated.go
@@ -1,0 +1,9 @@
+package httputils // import "github.com/docker/docker/api/server/httputils"
+import "github.com/docker/docker/errdefs"
+
+// GetHTTPErrorStatusCode retrieves status code from error message.
+//
+// Deprecated: use errdefs.GetHTTPErrorStatusCode
+func GetHTTPErrorStatusCode(err error) int {
+	return errdefs.GetHTTPErrorStatusCode(err)
+}

--- a/api/server/httputils/errors_test.go
+++ b/api/server/httputils/errors_test.go
@@ -1,0 +1,93 @@
+package httputils
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/docker/docker/errdefs"
+	"gotest.tools/assert"
+)
+
+func TestFromStatusCode(t *testing.T) {
+	testErr := fmt.Errorf("some error occurred")
+
+	testCases := []struct {
+		err    error
+		status int
+		check  func(error) bool
+	}{
+		{
+			err:    testErr,
+			status: http.StatusNotFound,
+			check:  errdefs.IsNotFound,
+		},
+		{
+			err:    testErr,
+			status: http.StatusBadRequest,
+			check:  errdefs.IsInvalidParameter,
+		},
+		{
+			err:    testErr,
+			status: http.StatusConflict,
+			check:  errdefs.IsConflict,
+		},
+		{
+			err:    testErr,
+			status: http.StatusUnauthorized,
+			check:  errdefs.IsUnauthorized,
+		},
+		{
+			err:    testErr,
+			status: http.StatusServiceUnavailable,
+			check:  errdefs.IsUnavailable,
+		},
+		{
+			err:    testErr,
+			status: http.StatusForbidden,
+			check:  errdefs.IsForbidden,
+		},
+		{
+			err:    testErr,
+			status: http.StatusNotModified,
+			check:  errdefs.IsNotModified,
+		},
+		{
+			err:    testErr,
+			status: http.StatusNotImplemented,
+			check:  errdefs.IsNotImplemented,
+		},
+		{
+			err:    testErr,
+			status: http.StatusInternalServerError,
+			check:  errdefs.IsSystem,
+		},
+		{
+			err:    errdefs.Unknown(testErr),
+			status: http.StatusInternalServerError,
+			check:  errdefs.IsUnknown,
+		},
+		{
+			err:    errdefs.DataLoss(testErr),
+			status: http.StatusInternalServerError,
+			check:  errdefs.IsDataLoss,
+		},
+		{
+			err:    errdefs.Deadline(testErr),
+			status: http.StatusInternalServerError,
+			check:  errdefs.IsDeadline,
+		},
+		{
+			err:    errdefs.Cancelled(testErr),
+			status: http.StatusInternalServerError,
+			check:  errdefs.IsCancelled,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(http.StatusText(tc.status), func(t *testing.T) {
+			err := FromStatusCode(tc.err, tc.status)
+			assert.Check(t, tc.check(err), "unexpected error-type %T", err)
+		})
+	}
+}

--- a/api/server/httputils/httputils.go
+++ b/api/server/httputils/httputils.go
@@ -7,9 +7,13 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
+	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/status"
 )
 
 // APIVersionKey is the client's requested API version.
@@ -86,6 +90,28 @@ func VersionFromContext(ctx context.Context) string {
 	}
 
 	return ""
+}
+
+// MakeErrorHandler makes an HTTP handler that decodes a Docker error and
+// returns it in the response.
+func MakeErrorHandler(err error) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		statusCode := errdefs.GetHTTPErrorStatusCode(err)
+		vars := mux.Vars(r)
+		if apiVersionSupportsJSONErrors(vars["version"]) {
+			response := &types.ErrorResponse{
+				Message: err.Error(),
+			}
+			WriteJSON(w, statusCode, response)
+		} else {
+			http.Error(w, status.Convert(err).Message(), statusCode)
+		}
+	}
+}
+
+func apiVersionSupportsJSONErrors(version string) bool {
+	const firstAPIVersionWithJSONErrors = "1.23"
+	return version == "" || versions.GreaterThan(version, firstAPIVersionWithJSONErrors)
 }
 
 // matchesContentType validates the content type against the expected one

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -589,7 +589,7 @@ func (s *containerRouter) postContainersAttach(ctx context.Context, w http.Respo
 		// Remember to close stream if error happens
 		conn, _, errHijack := hijacker.Hijack()
 		if errHijack == nil {
-			statusCode := httputils.GetHTTPErrorStatusCode(err)
+			statusCode := errdefs.GetHTTPErrorStatusCode(err)
 			statusText := http.StatusText(statusCode)
 			fmt.Fprintf(conn, "HTTP/1.1 %d %s\r\nContent-Type: application/vnd.docker.raw-stream\r\n\r\n%s\r\n", statusCode, statusText, err.Error())
 			httputils.CloseStreams(conn)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/server/router"
 	"github.com/docker/docker/api/server/router/debug"
 	"github.com/docker/docker/dockerversion"
+	"github.com/docker/docker/errdefs"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 )
@@ -139,7 +140,7 @@ func (s *Server) makeHTTPHandler(handler httputils.APIFunc) http.HandlerFunc {
 		}
 
 		if err := handlerFunc(ctx, w, r, vars); err != nil {
-			statusCode := httputils.GetHTTPErrorStatusCode(err)
+			statusCode := errdefs.GetHTTPErrorStatusCode(err)
 			if statusCode >= 500 {
 				logrus.Errorf("Handler for %s %s returned error: %v", r.Method, r.URL.Path, err)
 			}

--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/errdefs"
+	containerderrors "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	ctdreference "github.com/containerd/containerd/reference"
@@ -36,7 +36,7 @@ import (
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/resolver"
 	"github.com/moby/buildkit/util/tracing"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -654,7 +654,7 @@ func showProgress(ctx context.Context, ongoing *jobs, cs content.Store, pw progr
 			if !j.done {
 				info, err := cs.Info(context.TODO(), j.Digest)
 				if err != nil {
-					if errdefs.IsNotFound(err) {
+					if containerderrors.IsNotFound(err) {
 						// pw.Write(j.Digest.String(), progress.Status{
 						// 	Action: "waiting",
 						// })

--- a/client/checkpoint_create_test.go
+++ b/client/checkpoint_create_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestCheckpointCreateError(t *testing.T) {
@@ -24,6 +25,9 @@ func TestCheckpointCreateError(t *testing.T) {
 
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/checkpoint_delete_test.go
+++ b/client/checkpoint_delete_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestCheckpointDeleteError(t *testing.T) {
@@ -23,6 +24,9 @@ func TestCheckpointDeleteError(t *testing.T) {
 
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/checkpoint_list_test.go
+++ b/client/checkpoint_list_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestCheckpointListError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestCheckpointListError(t *testing.T) {
 	_, err := client.CheckpointList(context.Background(), "container_id", types.CheckpointListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/config_create_test.go
+++ b/client/config_create_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -33,6 +34,9 @@ func TestConfigCreateError(t *testing.T) {
 	_, err := client.ConfigCreate(context.Background(), swarm.ConfigSpec{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/config_inspect_test.go
+++ b/client/config_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
@@ -57,6 +58,9 @@ func TestConfigInspectError(t *testing.T) {
 	_, _, err := client.ConfigInspectWithRaw(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/config_list_test.go
+++ b/client/config_list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -35,6 +36,9 @@ func TestConfigListError(t *testing.T) {
 	_, err := client.ConfigList(context.Background(), types.ConfigListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/config_remove_test.go
+++ b/client/config_remove_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -31,6 +32,9 @@ func TestConfigRemoveError(t *testing.T) {
 	err := client.ConfigRemove(context.Background(), "config_id")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/config_update_test.go
+++ b/client/config_update_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -32,6 +33,9 @@ func TestConfigUpdateError(t *testing.T) {
 	err := client.ConfigUpdate(context.Background(), "config_id", swarm.Version{}, swarm.ConfigSpec{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_commit_test.go
+++ b/client/container_commit_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerCommitError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestContainerCommitError(t *testing.T) {
 	_, err := client.ContainerCommit(context.Background(), "nothing", types.ContainerCommitOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -50,6 +50,7 @@ func (cli *Client) CopyToContainer(ctx context.Context, containerID, dstPath str
 	}
 	defer ensureReaderClosed(response)
 
+	// TODO this code converts non-error status-codes (e.g., "204 No Content") into an error; verify if this is the desired behavior
 	if response.statusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status code from daemon: %d", response.statusCode)
 	}
@@ -69,6 +70,7 @@ func (cli *Client) CopyFromContainer(ctx context.Context, containerID, srcPath s
 		return nil, types.ContainerPathStat{}, wrapResponseError(err, response, "container:path", containerID+":"+srcPath)
 	}
 
+	// TODO this code converts non-error status-codes (e.g., "204 No Content") into an error; verify if this is the desired behavior
 	if response.statusCode != http.StatusOK {
 		return nil, types.ContainerPathStat{}, fmt.Errorf("unexpected status code from daemon: %d", response.statusCode)
 	}

--- a/client/container_copy_test.go
+++ b/client/container_copy_test.go
@@ -121,6 +121,7 @@ func TestCopyToContainerNotFoundError(t *testing.T) {
 	}
 }
 
+// TODO TestCopyToContainerNotStatusOKError expects a non-error status-code ("204 No Content") to produce an error; verify if this is the desired behavior
 func TestCopyToContainerNotStatusOKError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusNoContent, "No content")),
@@ -200,6 +201,7 @@ func TestCopyFromContainerNotFoundError(t *testing.T) {
 	}
 }
 
+// TODO TestCopyFromContainerNotStatusOKError expects a non-error status-code ("204 No Content") to produce an error; verify if this is the desired behavior
 func TestCopyFromContainerNotStatusOKError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusNoContent, "No content")),

--- a/client/container_copy_test.go
+++ b/client/container_copy_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerStatPathError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestContainerStatPathError(t *testing.T) {
 	_, err := client.ContainerStatPath(context.Background(), "container_id", "path")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 
@@ -102,6 +106,9 @@ func TestCopyToContainerError(t *testing.T) {
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
 	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
+	}
 }
 
 func TestCopyToContainerNotFoundError(t *testing.T) {
@@ -177,6 +184,9 @@ func TestCopyFromContainerError(t *testing.T) {
 	_, _, err := client.CopyFromContainer(context.Background(), "container_id", "path/to/file")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_create.go
+++ b/client/container_create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/url"
-	"strings"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
@@ -44,9 +43,6 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 
 	serverResp, err := cli.post(ctx, "/containers/create", query, body, nil)
 	if err != nil {
-		if serverResp.statusCode == 404 && strings.Contains(err.Error(), "No such image") {
-			return response, objectNotFoundError{object: "image", id: config.Image}
-		}
 		return response, err
 	}
 

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerCreateError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestContainerCreateError(t *testing.T) {
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error while testing StatusInternalServerError, got %v", err)
 	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error while testing StatusInternalServerError, got %T", err)
+	}
 
 	// 404 doesn't automatically means an unknown image
 	client = &Client{
@@ -30,6 +34,9 @@ func TestContainerCreateError(t *testing.T) {
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error while testing StatusNotFound, got %v", err)
 	}
+	if err == nil || !IsErrNotFound(err) {
+		t.Fatalf("expected a Server Error while testing StatusNotFound, got %T", err)
+	}
 }
 
 func TestContainerCreateImageNotFound(t *testing.T) {
@@ -38,7 +45,7 @@ func TestContainerCreateImageNotFound(t *testing.T) {
 	}
 	_, err := client.ContainerCreate(context.Background(), &container.Config{Image: "unknown_image"}, nil, nil, "unknown")
 	if err == nil || !IsErrNotFound(err) {
-		t.Fatalf("expected an imageNotFound error, got %v", err)
+		t.Fatalf("expected an imageNotFound error, got %v, %T", err, err)
 	}
 }
 

--- a/client/container_diff_test.go
+++ b/client/container_diff_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerDiffError(t *testing.T) {
@@ -21,7 +22,9 @@ func TestContainerDiffError(t *testing.T) {
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
-
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
+	}
 }
 
 func TestContainerDiff(t *testing.T) {

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerExecCreateError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestContainerExecCreateError(t *testing.T) {
 	_, err := client.ContainerExecCreate(context.Background(), "container_id", types.ExecConfig{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 
@@ -76,6 +80,9 @@ func TestContainerExecStartError(t *testing.T) {
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
+	}
 }
 
 func TestContainerExecStart(t *testing.T) {
@@ -119,6 +126,9 @@ func TestContainerExecInspectError(t *testing.T) {
 	_, err := client.ContainerExecInspect(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_export_test.go
+++ b/client/container_export_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerExportError(t *testing.T) {
@@ -17,6 +19,9 @@ func TestContainerExportError(t *testing.T) {
 	_, err := client.ContainerExport(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -22,6 +23,9 @@ func TestContainerInspectError(t *testing.T) {
 	_, err := client.ContainerInspect(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_kill_test.go
+++ b/client/container_kill_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerKillError(t *testing.T) {
@@ -17,6 +19,9 @@ func TestContainerKillError(t *testing.T) {
 	err := client.ContainerKill(context.Background(), "nothing", "SIGKILL")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerListError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestContainerListError(t *testing.T) {
 	_, err := client.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_pause_test.go
+++ b/client/container_pause_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerPauseError(t *testing.T) {
@@ -17,6 +19,9 @@ func TestContainerPauseError(t *testing.T) {
 	err := client.ContainerPause(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_rename_test.go
+++ b/client/container_rename_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerRenameError(t *testing.T) {
@@ -17,6 +19,9 @@ func TestContainerRenameError(t *testing.T) {
 	err := client.ContainerRename(context.Background(), "nothing", "newNothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_resize_test.go
+++ b/client/container_resize_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerResizeError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestContainerResizeError(t *testing.T) {
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
+	}
 }
 
 func TestContainerExecResizeError(t *testing.T) {
@@ -29,6 +33,9 @@ func TestContainerExecResizeError(t *testing.T) {
 	err := client.ContainerExecResize(context.Background(), "exec_id", types.ResizeOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerRestartError(t *testing.T) {
@@ -19,6 +21,9 @@ func TestContainerRestartError(t *testing.T) {
 	err := client.ContainerRestart(context.Background(), "nothing", &timeout)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_start_test.go
+++ b/client/container_start_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerStartError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestContainerStartError(t *testing.T) {
 	err := client.ContainerStart(context.Background(), "nothing", types.ContainerStartOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_stats_test.go
+++ b/client/container_stats_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerStatsError(t *testing.T) {
@@ -17,6 +19,9 @@ func TestContainerStatsError(t *testing.T) {
 	_, err := client.ContainerStats(context.Background(), "nothing", false)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerStopError(t *testing.T) {
@@ -19,6 +21,9 @@ func TestContainerStopError(t *testing.T) {
 	err := client.ContainerStop(context.Background(), "nothing", &timeout)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_top_test.go
+++ b/client/container_top_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerTopError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestContainerTopError(t *testing.T) {
 	_, err := client.ContainerTop(context.Background(), "nothing", []string{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_unpause_test.go
+++ b/client/container_unpause_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerUnpauseError(t *testing.T) {
@@ -17,6 +19,9 @@ func TestContainerUnpauseError(t *testing.T) {
 	err := client.ContainerUnpause(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_update_test.go
+++ b/client/container_update_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerUpdateError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestContainerUpdateError(t *testing.T) {
 	_, err := client.ContainerUpdate(context.Background(), "nothing", container.UpdateConfig{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/container_wait_test.go
+++ b/client/container_wait_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestContainerWaitError(t *testing.T) {
@@ -26,6 +27,9 @@ func TestContainerWaitError(t *testing.T) {
 	case err := <-errC:
 		if err.Error() != "Error response from daemon: Server error" {
 			t.Fatalf("expected a Server Error, got %v", err)
+		}
+		if !errdefs.IsSystem(err) {
+			t.Fatalf("expected a Server Error, got %T", err)
 		}
 	}
 }

--- a/client/disk_usage_test.go
+++ b/client/disk_usage_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestDiskUsageError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestDiskUsageError(t *testing.T) {
 	_, err := client.DiskUsage(context.Background())
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/errors.go
+++ b/client/errors.go
@@ -33,9 +33,10 @@ func ErrorConnectionFailed(host string) error {
 	return errConnectionFailed{host: host}
 }
 
+// Deprecated: use the errdefs.NotFound() interface instead. Kept for backward compatibility
 type notFound interface {
 	error
-	NotFound()
+	NotFound() bool
 }
 
 // IsErrNotFound returns true if the error is a NotFound error, which is returned

--- a/client/errors.go
+++ b/client/errors.go
@@ -35,7 +35,7 @@ func ErrorConnectionFailed(host string) error {
 
 type notFound interface {
 	error
-	NotFound() bool // Is the error a NotFound error
+	NotFound()
 }
 
 // IsErrNotFound returns true if the error is a NotFound error, which is returned
@@ -52,9 +52,7 @@ type objectNotFoundError struct {
 	id     string
 }
 
-func (e objectNotFoundError) NotFound() bool {
-	return true
-}
+func (e objectNotFoundError) NotFound() {}
 
 func (e objectNotFoundError) Error() string {
 	return fmt.Sprintf("Error: No such %s: %s", e.object, e.id)

--- a/client/events_test.go
+++ b/client/events_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestEventsErrorInOptions(t *testing.T) {
@@ -54,6 +55,9 @@ func TestEventsErrorFromServer(t *testing.T) {
 	err := <-errs
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/go-units"
 )
 
@@ -22,6 +23,9 @@ func TestImageBuildError(t *testing.T) {
 	_, err := client.ImageBuild(context.Background(), nil, types.ImageBuildOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_create_test.go
+++ b/client/image_create_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageCreateError(t *testing.T) {
@@ -19,6 +20,9 @@ func TestImageCreateError(t *testing.T) {
 	_, err := client.ImageCreate(context.Background(), "reference", types.ImageCreateOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_history_test.go
+++ b/client/image_history_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageHistoryError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestImageHistoryError(t *testing.T) {
 	_, err := client.ImageHistory(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_import_test.go
+++ b/client/image_import_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageImportError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestImageImportError(t *testing.T) {
 	_, err := client.ImageImport(context.Background(), types.ImageImportSource{}, "image:tag", types.ImageImportOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -23,6 +24,9 @@ func TestImageInspectError(t *testing.T) {
 	_, _, err := client.ImageInspectWithRaw(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageListError(t *testing.T) {
@@ -22,6 +23,9 @@ func TestImageListError(t *testing.T) {
 	_, err := client.ImageList(context.Background(), types.ImageListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_load_test.go
+++ b/client/image_load_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageLoadError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestImageLoadError(t *testing.T) {
 	_, err := client.ImageLoad(context.Background(), nil, true)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -3,12 +3,12 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"io"
-	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 // ImagePull requests the docker host to pull an image from a remote registry.
@@ -35,7 +35,7 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options types.I
 	}
 
 	resp, err := cli.tryImageCreate(ctx, query, options.RegistryAuth)
-	if resp.statusCode == http.StatusUnauthorized && options.PrivilegeFunc != nil {
+	if errdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
 		newAuthHeader, privilegeErr := options.PrivilegeFunc()
 		if privilegeErr != nil {
 			return nil, privilegeErr

--- a/client/image_pull_test.go
+++ b/client/image_pull_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImagePullReferenceParseError(t *testing.T) {
@@ -32,6 +33,9 @@ func TestImagePullAnyError(t *testing.T) {
 	_, err := client.ImagePull(context.Background(), "myimage", types.ImagePullOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_push.go
+++ b/client/image_push.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"io"
-	"net/http"
 	"net/url"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 // ImagePush requests the docker host to push an image to a remote registry.
@@ -36,7 +36,7 @@ func (cli *Client) ImagePush(ctx context.Context, image string, options types.Im
 	query.Set("tag", tag)
 
 	resp, err := cli.tryImagePush(ctx, name, query, options.RegistryAuth)
-	if resp.statusCode == http.StatusUnauthorized && options.PrivilegeFunc != nil {
+	if errdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
 		newAuthHeader, privilegeErr := options.PrivilegeFunc()
 		if privilegeErr != nil {
 			return nil, privilegeErr

--- a/client/image_push_test.go
+++ b/client/image_push_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImagePushReferenceError(t *testing.T) {
@@ -37,6 +38,9 @@ func TestImagePushAnyError(t *testing.T) {
 	_, err := client.ImagePush(context.Background(), "myimage", types.ImagePushOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_save_test.go
+++ b/client/image_save_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageSaveError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestImageSaveError(t *testing.T) {
 	_, err := client.ImageSave(context.Background(), []string{"nothing"})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_search.go
+++ b/client/image_search.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/errdefs"
 )
 
 // ImageSearch makes the docker host to search by a term in a remote registry.
@@ -29,7 +29,7 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options types.I
 	}
 
 	resp, err := cli.tryImageSearch(ctx, query, options.RegistryAuth)
-	if resp.statusCode == http.StatusUnauthorized && options.PrivilegeFunc != nil {
+	if errdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
 		newAuthHeader, privilegeErr := options.PrivilegeFunc()
 		if privilegeErr != nil {
 			return results, privilegeErr

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageSearchAnyError(t *testing.T) {
@@ -22,6 +23,9 @@ func TestImageSearchAnyError(t *testing.T) {
 	_, err := client.ImageSearch(context.Background(), "some-image", types.ImageSearchOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestImageTagError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestImageTagError(t *testing.T) {
 	err := client.ImageTag(context.Background(), "image_id", "repo:tag")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/info_test.go
+++ b/client/info_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestInfoServerError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestInfoServerError(t *testing.T) {
 	_, err := client.Info(context.Background())
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/login.go
+++ b/client/login.go
@@ -3,7 +3,6 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"encoding/json"
-	"net/http"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
@@ -15,9 +14,6 @@ import (
 func (cli *Client) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
 	resp, err := cli.post(ctx, "/auth", url.Values{}, auth, nil)
 
-	if resp.statusCode == http.StatusUnauthorized {
-		return registry.AuthenticateOKBody{}, unauthorizedError{err}
-	}
 	if err != nil {
 		return registry.AuthenticateOKBody{}, err
 	}

--- a/client/network_connect_test.go
+++ b/client/network_connect_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNetworkConnectError(t *testing.T) {
@@ -22,6 +23,9 @@ func TestNetworkConnectError(t *testing.T) {
 	err := client.NetworkConnect(context.Background(), "network_id", "container_id", nil)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNetworkCreateError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestNetworkCreateError(t *testing.T) {
 	_, err := client.NetworkCreate(context.Background(), "mynetwork", types.NetworkCreate{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/network_disconnect_test.go
+++ b/client/network_disconnect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNetworkDisconnectError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestNetworkDisconnectError(t *testing.T) {
 	err := client.NetworkDisconnect(context.Background(), "network_id", "container_id", false)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/network_list_test.go
+++ b/client/network_list_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNetworkListError(t *testing.T) {
@@ -24,6 +25,9 @@ func TestNetworkListError(t *testing.T) {
 	})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/network_prune_test.go
+++ b/client/network_prune_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -27,6 +28,9 @@ func TestNetworksPruneError(t *testing.T) {
 	_, err := client.NetworksPrune(context.Background(), filters)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/network_remove_test.go
+++ b/client/network_remove_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNetworkRemoveError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestNetworkRemoveError(t *testing.T) {
 	err := client.NetworkRemove(context.Background(), "network_id")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/node_inspect_test.go
+++ b/client/node_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -22,6 +23,9 @@ func TestNodeInspectError(t *testing.T) {
 	_, _, err := client.NodeInspectWithRaw(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/node_list_test.go
+++ b/client/node_list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNodeListError(t *testing.T) {
@@ -23,6 +24,9 @@ func TestNodeListError(t *testing.T) {
 	_, err := client.NodeList(context.Background(), types.NodeListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/node_remove_test.go
+++ b/client/node_remove_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNodeRemoveError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestNodeRemoveError(t *testing.T) {
 	err := client.NodeRemove(context.Background(), "node_id", types.NodeRemoveOptions{Force: false})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/node_update_test.go
+++ b/client/node_update_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestNodeUpdateError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestNodeUpdateError(t *testing.T) {
 	err := client.NodeUpdate(context.Background(), "node_id", swarm.Version{}, swarm.NodeSpec{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/ping.go
+++ b/client/ping.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 // Ping pings the server and returns the value of the "Docker-Experimental",
@@ -49,7 +49,7 @@ func parsePingResponse(cli *Client, resp serverResponse) (types.Ping, error) {
 	var ping types.Ping
 	if resp.header == nil {
 		err := cli.checkResponseErr(resp)
-		return ping, httputils.FromStatusCode(err, resp.statusCode)
+		return ping, errdefs.FromStatusCode(err, resp.statusCode)
 	}
 	ping.APIVersion = resp.header.Get("API-Version")
 	ping.OSType = resp.header.Get("OSType")
@@ -60,5 +60,5 @@ func parsePingResponse(cli *Client, resp serverResponse) (types.Ping, error) {
 		ping.BuilderVersion = types.BuilderVersion(bv)
 	}
 	err := cli.checkResponseErr(resp)
-	return ping, httputils.FromStatusCode(err, resp.statusCode)
+	return ping, errdefs.FromStatusCode(err, resp.statusCode)
 }

--- a/client/plugin_disable_test.go
+++ b/client/plugin_disable_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestPluginDisableError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestPluginDisableError(t *testing.T) {
 	err := client.PluginDisable(context.Background(), "plugin_name", types.PluginDisableOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/plugin_enable_test.go
+++ b/client/plugin_enable_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestPluginEnableError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestPluginEnableError(t *testing.T) {
 	err := client.PluginEnable(context.Background(), "plugin_name", types.PluginEnableOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/plugin_inspect_test.go
+++ b/client/plugin_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -22,6 +23,9 @@ func TestPluginInspectError(t *testing.T) {
 	_, _, err := client.PluginInspectWithRaw(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/plugin_install.go
+++ b/client/plugin_install.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"net/http"
 	"net/url"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -78,7 +78,7 @@ func (cli *Client) tryPluginPull(ctx context.Context, query url.Values, privileg
 
 func (cli *Client) checkPluginPermissions(ctx context.Context, query url.Values, options types.PluginInstallOptions) (types.PluginPrivileges, error) {
 	resp, err := cli.tryPluginPrivileges(ctx, query, options.RegistryAuth)
-	if resp.statusCode == http.StatusUnauthorized && options.PrivilegeFunc != nil {
+	if errdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
 		// todo: do inspect before to check existing name before checking privileges
 		newAuthHeader, privilegeErr := options.PrivilegeFunc()
 		if privilegeErr != nil {

--- a/client/plugin_list_test.go
+++ b/client/plugin_list_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestPluginListError(t *testing.T) {
@@ -22,6 +23,9 @@ func TestPluginListError(t *testing.T) {
 	_, err := client.PluginList(context.Background(), filters.NewArgs())
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/plugin_push_test.go
+++ b/client/plugin_push_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestPluginPushError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestPluginPushError(t *testing.T) {
 	_, err := client.PluginPush(context.Background(), "plugin_name", "")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/plugin_remove_test.go
+++ b/client/plugin_remove_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestPluginRemoveError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestPluginRemoveError(t *testing.T) {
 	err := client.PluginRemove(context.Background(), "plugin_name", types.PluginRemoveOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/plugin_set_test.go
+++ b/client/plugin_set_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestPluginSetError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestPluginSetError(t *testing.T) {
 	err := client.PluginSet(context.Background(), "plugin_name", []string{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/request.go
+++ b/client/request.go
@@ -13,9 +13,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -121,10 +121,10 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 	}
 	resp, err := cli.doRequest(ctx, req)
 	if err != nil {
-		return resp, httputils.FromStatusCode(err, resp.statusCode)
+		return resp, errdefs.FromStatusCode(err, resp.statusCode)
 	}
 	err = cli.checkResponseErr(resp)
-	return resp, httputils.FromStatusCode(err, resp.statusCode)
+	return resp, errdefs.FromStatusCode(err, resp.statusCode)
 }
 
 func (cli *Client) doRequest(ctx context.Context, req *http.Request) (serverResponse, error) {

--- a/client/request.go
+++ b/client/request.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/pkg/errors"
@@ -120,9 +121,10 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 	}
 	resp, err := cli.doRequest(ctx, req)
 	if err != nil {
-		return resp, err
+		return resp, httputils.FromStatusCode(err, resp.statusCode)
 	}
-	return resp, cli.checkResponseErr(resp)
+	err = cli.checkResponseErr(resp)
+	return resp, httputils.FromStatusCode(err, resp.statusCode)
 }
 
 func (cli *Client) doRequest(ctx context.Context, req *http.Request) (serverResponse, error) {

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -87,6 +88,9 @@ func TestPlainTextError(t *testing.T) {
 	_, err := client.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/secret_create_test.go
+++ b/client/secret_create_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -33,6 +34,9 @@ func TestSecretCreateError(t *testing.T) {
 	_, err := client.SecretCreate(context.Background(), swarm.SecretSpec{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/secret_inspect_test.go
+++ b/client/secret_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
@@ -34,6 +35,9 @@ func TestSecretInspectError(t *testing.T) {
 	_, _, err := client.SecretInspectWithRaw(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/secret_list_test.go
+++ b/client/secret_list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -35,6 +36,9 @@ func TestSecretListError(t *testing.T) {
 	_, err := client.SecretList(context.Background(), types.SecretListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/secret_remove_test.go
+++ b/client/secret_remove_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -31,6 +32,9 @@ func TestSecretRemoveError(t *testing.T) {
 	err := client.SecretRemove(context.Background(), "secret_id")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/secret_update_test.go
+++ b/client/secret_update_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -32,6 +33,9 @@ func TestSecretUpdateError(t *testing.T) {
 	err := client.SecretUpdate(context.Background(), "secret_id", swarm.Version{}, swarm.SecretSpec{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/assert"
@@ -26,6 +27,9 @@ func TestServiceCreateError(t *testing.T) {
 	_, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, types.ServiceCreateOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/service_inspect_test.go
+++ b/client/service_inspect_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -23,6 +24,9 @@ func TestServiceInspectError(t *testing.T) {
 	_, _, err := client.ServiceInspectWithRaw(context.Background(), "nothing", types.ServiceInspectOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/service_list_test.go
+++ b/client/service_list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestServiceListError(t *testing.T) {
@@ -23,6 +24,9 @@ func TestServiceListError(t *testing.T) {
 	_, err := client.ServiceList(context.Background(), types.ServiceListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/service_update_test.go
+++ b/client/service_update_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestServiceUpdateError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestServiceUpdateError(t *testing.T) {
 	_, err := client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{}, types.ServiceUpdateOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/swarm_init_test.go
+++ b/client/swarm_init_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestSwarmInitError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestSwarmInitError(t *testing.T) {
 	_, err := client.SwarmInit(context.Background(), swarm.InitRequest{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/swarm_inspect_test.go
+++ b/client/swarm_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestSwarmInspectError(t *testing.T) {
@@ -21,6 +22,9 @@ func TestSwarmInspectError(t *testing.T) {
 	_, err := client.SwarmInspect(context.Background())
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/swarm_join_test.go
+++ b/client/swarm_join_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestSwarmJoinError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestSwarmJoinError(t *testing.T) {
 	err := client.SwarmJoin(context.Background(), swarm.JoinRequest{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/swarm_leave_test.go
+++ b/client/swarm_leave_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestSwarmLeaveError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestSwarmLeaveError(t *testing.T) {
 	err := client.SwarmLeave(context.Background(), false)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/swarm_unlock_test.go
+++ b/client/swarm_unlock_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestSwarmUnlockError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestSwarmUnlockError(t *testing.T) {
 	err := client.SwarmUnlock(context.Background(), swarm.UnlockRequest{UnlockKey: "SWMKEY-1-y6guTZNTwpQeTL5RhUfOsdBdXoQjiB2GADHSRJvbXeU"})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/swarm_update_test.go
+++ b/client/swarm_update_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestSwarmUpdateError(t *testing.T) {
@@ -20,6 +21,9 @@ func TestSwarmUpdateError(t *testing.T) {
 	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, swarm.UpdateFlags{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/task_inspect_test.go
+++ b/client/task_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -22,6 +23,9 @@ func TestTaskInspectError(t *testing.T) {
 	_, _, err := client.TaskInspectWithRaw(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/task_list_test.go
+++ b/client/task_list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestTaskListError(t *testing.T) {
@@ -23,6 +24,9 @@ func TestTaskListError(t *testing.T) {
 	_, err := client.TaskList(context.Background(), types.TaskListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/volume_create_test.go
+++ b/client/volume_create_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestVolumeCreateError(t *testing.T) {
@@ -22,6 +23,9 @@ func TestVolumeCreateError(t *testing.T) {
 	_, err := client.VolumeCreate(context.Background(), volumetypes.VolumeCreateBody{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/volume_list_test.go
+++ b/client/volume_list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	volumetypes "github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/errdefs"
 )
 
 func TestVolumeListError(t *testing.T) {
@@ -23,6 +24,9 @@ func TestVolumeListError(t *testing.T) {
 	_, err := client.VolumeList(context.Background(), filters.NewArgs())
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/client/volume_remove_test.go
+++ b/client/volume_remove_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
 )
 
 func TestVolumeRemoveError(t *testing.T) {
@@ -18,6 +20,9 @@ func TestVolumeRemoveError(t *testing.T) {
 	err := client.VolumeRemove(context.Background(), "volume_id", false)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if !errdefs.IsSystem(err) {
+		t.Fatalf("expected a Server Error, got %T", err)
 	}
 }
 

--- a/errdefs/http_helpers_test.go
+++ b/errdefs/http_helpers_test.go
@@ -1,11 +1,10 @@
-package httputils
+package errdefs
 
 import (
 	"fmt"
 	"net/http"
 	"testing"
 
-	"github.com/docker/docker/errdefs"
 	"gotest.tools/assert"
 )
 
@@ -20,67 +19,67 @@ func TestFromStatusCode(t *testing.T) {
 		{
 			err:    testErr,
 			status: http.StatusNotFound,
-			check:  errdefs.IsNotFound,
+			check:  IsNotFound,
 		},
 		{
 			err:    testErr,
 			status: http.StatusBadRequest,
-			check:  errdefs.IsInvalidParameter,
+			check:  IsInvalidParameter,
 		},
 		{
 			err:    testErr,
 			status: http.StatusConflict,
-			check:  errdefs.IsConflict,
+			check:  IsConflict,
 		},
 		{
 			err:    testErr,
 			status: http.StatusUnauthorized,
-			check:  errdefs.IsUnauthorized,
+			check:  IsUnauthorized,
 		},
 		{
 			err:    testErr,
 			status: http.StatusServiceUnavailable,
-			check:  errdefs.IsUnavailable,
+			check:  IsUnavailable,
 		},
 		{
 			err:    testErr,
 			status: http.StatusForbidden,
-			check:  errdefs.IsForbidden,
+			check:  IsForbidden,
 		},
 		{
 			err:    testErr,
 			status: http.StatusNotModified,
-			check:  errdefs.IsNotModified,
+			check:  IsNotModified,
 		},
 		{
 			err:    testErr,
 			status: http.StatusNotImplemented,
-			check:  errdefs.IsNotImplemented,
+			check:  IsNotImplemented,
 		},
 		{
 			err:    testErr,
 			status: http.StatusInternalServerError,
-			check:  errdefs.IsSystem,
+			check:  IsSystem,
 		},
 		{
-			err:    errdefs.Unknown(testErr),
+			err:    Unknown(testErr),
 			status: http.StatusInternalServerError,
-			check:  errdefs.IsUnknown,
+			check:  IsUnknown,
 		},
 		{
-			err:    errdefs.DataLoss(testErr),
+			err:    DataLoss(testErr),
 			status: http.StatusInternalServerError,
-			check:  errdefs.IsDataLoss,
+			check:  IsDataLoss,
 		},
 		{
-			err:    errdefs.Deadline(testErr),
+			err:    Deadline(testErr),
 			status: http.StatusInternalServerError,
-			check:  errdefs.IsDeadline,
+			check:  IsDeadline,
 		},
 		{
-			err:    errdefs.Cancelled(testErr),
+			err:    Cancelled(testErr),
 			status: http.StatusInternalServerError,
-			check:  errdefs.IsCancelled,
+			check:  IsCancelled,
 		},
 	}
 

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"testing"
 	"time"
 
@@ -13,10 +12,10 @@ import (
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/integration/internal/swarm"
 	"github.com/docker/docker/internal/test/daemon"
-	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/poll"
@@ -129,6 +128,9 @@ func TestCreateServiceConflict(t *testing.T) {
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)
+	c := d.NewClientT(t)
+	defer c.Close()
+	ctx := context.Background()
 
 	serviceName := "TestService_" + t.Name()
 	serviceSpec := []swarm.ServiceSpecOpt{
@@ -138,18 +140,9 @@ func TestCreateServiceConflict(t *testing.T) {
 	swarm.CreateService(t, d, serviceSpec...)
 
 	spec := swarm.CreateServiceSpec(t, serviceSpec...)
-	res, body, err := request.Post(
-		"/services/create",
-		request.Host(d.Sock()),
-		request.JSONBody(spec),
-		request.JSON,
-	)
-	assert.NilError(t, err)
-	assert.Equal(t, res.StatusCode, http.StatusConflict)
-
-	buf, err := request.ReadBody(body)
-	assert.NilError(t, err)
-	assert.Check(t, is.Contains(string(buf), "service "+serviceName+" already exists"))
+	_, err := c.ServiceCreate(ctx, spec, types.ServiceCreateOptions{})
+	assert.Check(t, errdefs.IsConflict(err))
+	assert.ErrorContains(t, err, "service "+serviceName+" already exists")
 }
 
 func TestCreateServiceMaxReplicas(t *testing.T) {


### PR DESCRIPTION
closes https://github.com/moby/moby/pull/38467
Alternative to https://github.com/moby/moby/pull/38467, but without preserving the original status code (only transforming status codes back to either a known `errdef` or to a "generic" system/invalidrequest error

The API client currently discards HTTP-status codes that are returned from the daemon. As a result, users of the API client that want to implement logic based on the type of error returned, will have to resort to string-matching (which is brittle).


This PR is a first attempt to make the client return more useful errors;

- Errors that are returned by the API are converted back into `errdef` errors, so that it's easy to check the type of error (`errdef.IsNotFound(err)`, `errdef.IsConflict(err)`)
- The original HTTP status code is returned, so that for errors that have no 1-1 mapping to an errdef will preserve the status-code for further handling

With this patch, something like the below will be possible;

```go
package main

import (
	"context"
	"fmt"

	"github.com/docker/docker/api/server/httputils"
	"github.com/docker/docker/api/types"
	"github.com/docker/docker/api/types/container"
	"github.com/docker/docker/client"
	"github.com/docker/docker/errdefs"
)

func main() {
	ctx := context.Background()
	cli, err := client.NewClientWithOpts(client.FromEnv)
	if err != nil {
		panic(err)
	}
	cli.NegotiateAPIVersion(ctx)

	_, err = cli.ImagePull(ctx, "docker.io/library/alpine", types.ImagePullOptions{})
	if err != nil {
		panic(err)
	}

	_, err = cli.ContainerCreate(ctx, &container.Config{
		Image: "nosuchimage",
		Cmd:   []string{"echo", "hello world"},
	}, nil, nil, "")
	if err != nil {
		fmt.Println(err.Error())
		if errdefs.IsNotFound(err) {
			fmt.Println("it's a 'not found' error")
		}
		fmt.Println("status code: ", httputils.GetHTTPErrorStatusCode(err))
	}

	_, err = cli.ContainerCreate(ctx, &container.Config{
		Image: "invalid@@@name",
		Cmd:   []string{"echo", "hello world"},
	}, nil, nil, "")
	if err != nil {
		fmt.Println(err.Error())
		if errdefs.IsInvalidParameter(err) {
			fmt.Println("it's an 'invalid parameter' error")
		}
		fmt.Println("status code: ", httputils.GetHTTPErrorStatusCode(err))
	}
}
```


### Feedback needed

- I was a bit in doubt where we want the helpers/types for the new errors defined;
  - the api/server/httputils package? (could make sense, because it deals with the conversion from errdefs errors to HTTP errors)
  - the errdefs package? (I think we want to keep that package separated from any HTTP-specific logic
  - in the client? (there's already some error-handling stuff in client/errors.go); could make sense, because there are also client-side errors that could be defined there
- Is returning the HTTP status too low-level, and should we limit to only converting back to errdef Errors?
- As a follow-up; do we want a conversion from error-types to exit-codes for the cli itself?


