### PR TITLE
hack: Have TIMEOUT take -test.count into account when testing for flakiness

### DIFF
--- a/hack/make/test-integration-flaky
+++ b/hack/make/test-integration-flaky
@@ -19,8 +19,19 @@ echo "Running stress test for them."
 
 (
     TESTARRAY=$(echo "$new_tests" | sed 's/+func //' | awk -F'\\(' '{print $1}' | tr '\n' '|')
-    export TESTFLAGS="-test.count 5 -test.run ${TESTARRAY%?}"
+    # Note: TEST_REPEAT will make the test suite run 5 times, restarting the daemon
+    # whereas testcount will make each test run 5 times in a row under the same daemon.
+    # This will make a total of 25 runs for each test in TESTARRAY.
     export TEST_REPEAT=5
+    local testcount=5
+    # However, TIMEOUT needs to take testcount into account, or a premature time out may happen.
+    # The following ugliness will:
+    # - remove last character (usually 'm' from '10m')
+    # - multiply by testcount
+    # - add last character back
+    export TIMEOUT=$((${TIMEOUT::-1} * $testcount))${TIMEOUT:$((${#TIMEOUT}-1)):1}
+
+    export TESTFLAGS="-test.count $testcount -test.run ${TESTARRAY%?}"
     echo "Using test flags: $TESTFLAGS"
     source hack/make/test-integration
 )


### PR DESCRIPTION
Follow up to https://github.com/moby/moby/pull/38523/files#r254905817

Ping @olljanat @thaJeztah @tianon @vdemeester 