### PR TITLE
Allow to attach swarm overlay networks by prefix id

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	apitypes "github.com/docker/docker/api/types"
+
 	containertypes "github.com/docker/docker/api/types/container"
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/container"
@@ -379,20 +381,31 @@ func (daemon *Daemon) findAndAttachNetwork(container *container.Container, idOrN
 	}
 
 	for {
+		var nr apitypes.NetworkResource
+
 		// In all other cases, attempt to attach to the network to
 		// trigger attachment in the swarm cluster manager.
 		if daemon.clusterProvider != nil {
 			var err error
-			config, err = daemon.clusterProvider.AttachNetwork(id, container.ID, addresses)
+			nr, err = daemon.cluster.GetNetwork(id)
+			if err != nil {
+				return nil, nil, err
+			}
+			config, err = daemon.clusterProvider.AttachNetwork(nr.ID, container.ID, addresses)
 			if err != nil {
 				return nil, nil, err
 			}
 		}
 
-		n, err = daemon.FindNetwork(id)
+		if daemon.clusterProvider != nil {
+			n, err = daemon.GetNetworkByID(nr.ID)
+		} else {
+			n, err = daemon.FindNetwork(id)
+		}
+
 		if err != nil {
 			if daemon.clusterProvider != nil {
-				if err := daemon.clusterProvider.DetachNetwork(id, container.ID); err != nil {
+				if err := daemon.clusterProvider.DetachNetwork(nr.ID, container.ID); err != nil {
 					logrus.Warnf("Could not rollback attachment for container %s to network %s: %v", container.ID, idOrName, err)
 				}
 			}


### PR DESCRIPTION
Fix for swarm overlay networks, to allow to use network prefix id for attaching
steps to reproduce (on swarm manager):
```
docker@master-ubuntu:~$ docker network create -d overlay --subnet 10.90.0.0/16 --attachable test
2pxynaf6x6ns73osfh3djihp5
docker@master-ubuntu:~$ docker network ls
NETWORK ID          NAME                                                              DRIVER              SCOPE
286e5591d39a        bridge                                                            bridge              local
14260d5e8dd5        docker_gwbridge                                                   bridge              local
f15db39321be        host                                                              host                local
jr107lomespv        ingress                                                           overlay             swarm
cad86ad056ce        none                                                              null                local
2pxynaf6x6ns        test                                                                                  swarm
docker@master-ubuntu:~$ docker run --rm -it --network 2pxynaf6x6ns centos:7
docker: Error response from daemon: Could not attach to network 2pxynaf6x6ns: rpc error: code = NotFound desc = network 2pxynaf6x6ns not found.
docker@master-ubuntu:~$ docker run --rm -it --network 2pxynaf6x6ns73osfh3djihp5 centos:7
[root@69322b8f0cc4 /]# exit
exit
docker@master-ubuntu:~$ docker run --rm -it --network test centos:7
[root@db369d3829af /]# exit
exit
```