### PR TITLE
containers/create: use shareable ipc by default for older clients

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -481,6 +481,13 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 		hostConfig.Capabilities = nil
 	}
 
+	// When using API older than 1.32, the client expects a new container
+	// to be created with "shareable" IPC mode, if mode is unset (empty value).
+	// Force set it to "shareable" (rather than daemon's default).
+	if hostConfig != nil && hostConfig.IpcMode.IsEmpty() && versions.LessThan(version, "1.32") {
+		hostConfig.IpcMode = container.IpcMode("shareable")
+	}
+
 	ccr, err := s.backend.ContainerCreate(types.ContainerCreateConfig{
 		Name:             name,
 		Config:           config,


### PR DESCRIPTION
Older (API < 1.32) clients are not aware of new IPC modes
(`shareable`, `private`, and `none`, introduced in commit 7120976d7419 (PR #34087)
and expect a new container to be created with IPC mode that
is now known as `shareable`.

Since the above commit, daemon default can be set to `private`,
essentially locking out such older clients from being able to
share IPC between containers (i.e. using `--ipc container:NNN`).

So, with this patch, a client which does not set any value
for IPC mode, defaults to:

 * for API < 1.32: `shareable`;
 * for API >= 1.32: daemon's default-ipc-mode