### PR TITLE
Implement exec kill API

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -18,6 +18,7 @@ type execBackend interface {
 	ContainerExecInspect(id string) (*backend.ExecInspect, error)
 	ContainerExecResize(name string, height, width int) error
 	ContainerExecStart(ctx context.Context, name string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error
+	ContainerExecKill(ctx context.Context, name string, sig uint64) error
 	ExecExists(name string) (bool, error)
 }
 

--- a/api/server/router/container/container.go
+++ b/api/server/router/container/container.go
@@ -58,6 +58,7 @@ func (r *containerRouter) initRoutes() {
 		router.NewPostRoute("/containers/{name:.*}/exec", r.postContainerExecCreate),
 		router.NewPostRoute("/exec/{name:.*}/start", r.postContainerExecStart),
 		router.NewPostRoute("/exec/{name:.*}/resize", r.postContainerExecResize),
+		router.NewPostRoute("/exec/{name:.*}/kill", r.postContainerExecKill),
 		router.NewPostRoute("/containers/{name:.*}/rename", r.postContainerRename),
 		router.NewPostRoute("/containers/{name:.*}/update", r.postContainerUpdate),
 		router.NewPostRoute("/containers/prune", r.postContainersPrune),

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7766,6 +7766,34 @@ paths:
           required: true
           type: "string"
       tags: ["Exec"]
+  /exec/{id}/kill:
+    post:
+      summary: "Kill an exec instance"
+      description: "Kill an exec instance."
+      operationId: "ExecKill"
+      responses:
+        204:
+          description: "No error"
+        404:
+          description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "Exec instance ID"
+          required: true
+          type: "string"
+        - name: "signal"
+          in: "query"
+          description: "Signal to send to the container as an integer or string (e.g. `SIGINT`)"
+          type: "string"
+          default: "SIGKILL"
+      tags: ["Exec"]
 
   /volumes:
     get:

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -275,6 +275,11 @@ type ExecStartCheck struct {
 	Tty bool
 }
 
+// ExecKillOptions is a temp struct used by execKill
+type ExecKillOptions struct {
+	Force bool
+}
+
 // HealthcheckResult stores information about a single run of a healthcheck probe
 type HealthcheckResult struct {
 	Start    time.Time // Start is the time this check started

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -3,6 +3,7 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"encoding/json"
+	"net/url"
 
 	"github.com/docker/docker/api/types"
 )
@@ -51,4 +52,14 @@ func (cli *Client) ContainerExecInspect(ctx context.Context, execID string) (typ
 	err = json.NewDecoder(resp.body).Decode(&response)
 	ensureReaderClosed(resp)
 	return response, err
+}
+
+// ContainerExecKill kills an exec process on the docker host.
+func (cli *Client) ContainerExecKill(ctx context.Context, execID, signal string) error {
+	query := url.Values{}
+	query.Set("signal", signal)
+
+	resp, err := cli.post(ctx, "/exec/"+execID+"/kill", query, nil, nil)
+	ensureReaderClosed(resp)
+	return err
 }

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -154,3 +154,33 @@ func TestContainerExecInspect(t *testing.T) {
 		t.Fatalf("expected ContainerID `container_id`, got %s", inspect.ContainerID)
 	}
 }
+
+func TestContainerExecKillError(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	}
+
+	err := client.ContainerExecKill(context.Background(), "nothing", "TERM")
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerExecKill(t *testing.T) {
+	expectedURL := "/exec/exec_id/kill"
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			return &http.Response{
+				StatusCode: http.StatusNoContent,
+			}, nil
+		}),
+	}
+
+	err := client.ContainerExecKill(context.Background(), "exec_id", "TERM")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/client/interface.go
+++ b/client/interface.go
@@ -54,6 +54,7 @@ type ContainerAPIClient interface {
 	ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error)
 	ContainerExecResize(ctx context.Context, execID string, options types.ResizeOptions) error
 	ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error
+	ContainerExecKill(ctx context.Context, execID, signal string) error
 	ContainerExport(ctx context.Context, container string) (io.ReadCloser, error)
 	ContainerInspect(ctx context.Context, container string) (types.ContainerJSON, error)
 	ContainerInspectWithRaw(ctx context.Context, container string, getSize bool) (types.ContainerJSON, []byte, error)

--- a/daemon/exec_test.go
+++ b/daemon/exec_test.go
@@ -1,0 +1,74 @@
+// +build linux
+
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/exec"
+	"github.com/docker/docker/pkg/signal"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+)
+
+type mockContainerd struct {
+	MockContainerdClient
+	calledCtx         *context.Context
+	calledContainerID *string
+	calledID          *string
+	calledSig         *int
+}
+
+func (cd *mockContainerd) SignalProcess(ctx context.Context, containerID, id string, sig int) error {
+	cd.calledCtx = &ctx
+	cd.calledContainerID = &containerID
+	cd.calledID = &id
+	cd.calledSig = &sig
+	return nil
+}
+
+func TestContainerExecKillNoSuchExec(t *testing.T) {
+	mock := mockContainerd{}
+	ctx := context.Background()
+	d := &Daemon{
+		execCommands: exec.NewStore(),
+		containerd:   &mock,
+	}
+
+	err := d.ContainerExecKill(ctx, "nil", uint64(signal.SignalMap["TERM"]))
+	assert.ErrorContains(t, err, "No such exec instance")
+	assert.Assert(t, is.Nil(mock.calledCtx))
+	assert.Assert(t, is.Nil(mock.calledContainerID))
+	assert.Assert(t, is.Nil(mock.calledID))
+	assert.Assert(t, is.Nil(mock.calledSig))
+}
+
+func TestContainerExecKill(t *testing.T) {
+	mock := mockContainerd{}
+	ctx := context.Background()
+	c := &container.Container{
+		ExecCommands: exec.NewStore(),
+		State:        &container.State{Running: true},
+	}
+	ec := &exec.Config{
+		ID:          "exec",
+		ContainerID: "container",
+		Started:     make(chan struct{}),
+	}
+	d := &Daemon{
+		execCommands: exec.NewStore(),
+		containers:   container.NewMemoryStore(),
+		containerd:   &mock,
+	}
+	d.containers.Add("container", c)
+	d.registerExecCommand(c, ec)
+
+	err := d.ContainerExecKill(ctx, "exec", uint64(signal.SignalMap["TERM"]))
+	assert.NilError(t, err)
+	assert.Equal(t, *mock.calledCtx, ctx)
+	assert.Equal(t, *mock.calledContainerID, "container")
+	assert.Equal(t, *mock.calledID, "exec")
+	assert.Equal(t, *mock.calledSig, int(signal.SignalMap["TERM"]))
+}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,6 +17,7 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.40](https://docs.docker.com/engine/api/v1.40/) documentation
 
+* `POST /exec/{id}/kill` is a new endpoint that can be used for sending a signal to kill an exec instance.
 * The `/_ping` endpoint can now be accessed both using `GET` or `HEAD` requests.
   when accessed using a `HEAD` request, all headers are returned, but the body
   is empty (`Content-Length: 0`). This change is not versioned, and affects all


### PR DESCRIPTION
Closes #35703 #9098

**- What I did**

I implemented a feature to kill exec instance.

**- How I did it**

I added an API endpoint for the action and a method to call it in the client, then implemented an exec action in the daemon.

**- How to verify it**

- Run sleep container by `docker run --name exec-kill -d ubuntu:16.04 sleep infinity`
- Then, attach a process by `docker exec -d exec-kill sleep 99999`. (use different sleep time from the container command to easily identify it)
- Now, you can see the executed process by executing `ps aux`.
- You can get the exec ID by `docker inspect exec-kill | grep ExecIDs -A 3`.
- Then kill the exec instance by `curl --unix-socket /var/run/docker.sock -X DELETE "http:/v1.40/exec/<EXEC_ID>"`.
- Check if the executed process is gone by `ps aux`.

**- Description for the changelog**

Add exec kill feature with API endpoint and a client method

**- A picture of a cute animal (not mandatory but encouraged)**

![268878_2231235108554_8050336_n](https://user-images.githubusercontent.com/1162120/52536537-37291500-2d9f-11e9-93a4-d6c248a93b5c.jpg)
