### PR TITLE
Client: always call ensureReaderClosed

### DIFF
--- a/client/build_cancel.go
+++ b/client/build_cancel.go
@@ -11,10 +11,6 @@ func (cli *Client) BuildCancel(ctx context.Context, id string) error {
 	query.Set("id", id)
 
 	serverResp, err := cli.post(ctx, "/build/cancel", query, nil, nil)
-	if err != nil {
-		return err
-	}
-	defer ensureReaderClosed(serverResp)
-
-	return nil
+	ensureReaderClosed(serverResp)
+	return err
 }

--- a/client/build_prune.go
+++ b/client/build_prune.go
@@ -31,11 +31,11 @@ func (cli *Client) BuildCachePrune(ctx context.Context, opts types.BuildCachePru
 	query.Set("filters", filters)
 
 	serverResp, err := cli.post(ctx, "/build/prune", query, nil, nil)
+	defer ensureReaderClosed(serverResp)
 
 	if err != nil {
 		return nil, err
 	}
-	defer ensureReaderClosed(serverResp)
 
 	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
 		return nil, fmt.Errorf("Error retrieving disk usage: %v", err)

--- a/client/checkpoint_list.go
+++ b/client/checkpoint_list.go
@@ -18,11 +18,11 @@ func (cli *Client) CheckpointList(ctx context.Context, container string, options
 	}
 
 	resp, err := cli.get(ctx, "/containers/"+container+"/checkpoints", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return checkpoints, wrapResponseError(err, resp, "container", container)
 	}
 
 	err = json.NewDecoder(resp.body).Decode(&checkpoints)
-	ensureReaderClosed(resp)
 	return checkpoints, err
 }

--- a/client/config_create.go
+++ b/client/config_create.go
@@ -15,11 +15,11 @@ func (cli *Client) ConfigCreate(ctx context.Context, config swarm.ConfigSpec) (t
 		return response, err
 	}
 	resp, err := cli.post(ctx, "/configs/create", nil, config, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return response, err
 	}
 
 	err = json.NewDecoder(resp.body).Decode(&response)
-	ensureReaderClosed(resp)
 	return response, err
 }

--- a/client/config_inspect.go
+++ b/client/config_inspect.go
@@ -18,10 +18,10 @@ func (cli *Client) ConfigInspectWithRaw(ctx context.Context, id string) (swarm.C
 		return swarm.Config{}, nil, err
 	}
 	resp, err := cli.get(ctx, "/configs/"+id, nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return swarm.Config{}, nil, wrapResponseError(err, resp, "config", id)
 	}
-	defer ensureReaderClosed(resp)
 
 	body, err := ioutil.ReadAll(resp.body)
 	if err != nil {

--- a/client/config_list.go
+++ b/client/config_list.go
@@ -27,12 +27,12 @@ func (cli *Client) ConfigList(ctx context.Context, options types.ConfigListOptio
 	}
 
 	resp, err := cli.get(ctx, "/configs", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, err
 	}
 
 	var configs []swarm.Config
 	err = json.NewDecoder(resp.body).Decode(&configs)
-	ensureReaderClosed(resp)
 	return configs, err
 }

--- a/client/config_remove.go
+++ b/client/config_remove.go
@@ -8,6 +8,6 @@ func (cli *Client) ConfigRemove(ctx context.Context, id string) error {
 		return err
 	}
 	resp, err := cli.delete(ctx, "/configs/"+id, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return wrapResponseError(err, resp, "config", id)
 }

--- a/client/container_commit.go
+++ b/client/container_commit.go
@@ -45,11 +45,11 @@ func (cli *Client) ContainerCommit(ctx context.Context, container string, option
 
 	var response types.IDResponse
 	resp, err := cli.post(ctx, "/commit", query, options.Config, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return response, err
 	}
 
 	err = json.NewDecoder(resp.body).Decode(&response)
-	ensureReaderClosed(resp)
 	return response, err
 }

--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -21,10 +21,10 @@ func (cli *Client) ContainerStatPath(ctx context.Context, containerID, path stri
 
 	urlStr := "/containers/" + containerID + "/archive"
 	response, err := cli.head(ctx, urlStr, query, nil)
+	defer ensureReaderClosed(response)
 	if err != nil {
 		return types.ContainerPathStat{}, wrapResponseError(err, response, "container:path", containerID+":"+path)
 	}
-	defer ensureReaderClosed(response)
 	return getContainerPathStatFromHeader(response.header)
 }
 
@@ -45,10 +45,10 @@ func (cli *Client) CopyToContainer(ctx context.Context, containerID, dstPath str
 	apiPath := "/containers/" + containerID + "/archive"
 
 	response, err := cli.putRaw(ctx, apiPath, query, content, nil)
+	defer ensureReaderClosed(response)
 	if err != nil {
 		return wrapResponseError(err, response, "container:path", containerID+":"+dstPath)
 	}
-	defer ensureReaderClosed(response)
 
 	// TODO this code converts non-error status-codes (e.g., "204 No Content") into an error; verify if this is the desired behavior
 	if response.statusCode != http.StatusOK {

--- a/client/container_create.go
+++ b/client/container_create.go
@@ -42,11 +42,11 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 	}
 
 	serverResp, err := cli.post(ctx, "/containers/create", query, body, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return response, err
 	}
 
 	err = json.NewDecoder(serverResp.body).Decode(&response)
-	ensureReaderClosed(serverResp)
 	return response, err
 }

--- a/client/container_diff.go
+++ b/client/container_diff.go
@@ -13,11 +13,11 @@ func (cli *Client) ContainerDiff(ctx context.Context, containerID string) ([]con
 	var changes []container.ContainerChangeResponseItem
 
 	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/changes", url.Values{}, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return changes, err
 	}
 
 	err = json.NewDecoder(serverResp.body).Decode(&changes)
-	ensureReaderClosed(serverResp)
 	return changes, err
 }

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -16,11 +16,11 @@ func (cli *Client) ContainerExecCreate(ctx context.Context, container string, co
 	}
 
 	resp, err := cli.post(ctx, "/containers/"+container+"/exec", nil, config, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return response, err
 	}
 	err = json.NewDecoder(resp.body).Decode(&response)
-	ensureReaderClosed(resp)
 	return response, err
 }
 

--- a/client/container_inspect.go
+++ b/client/container_inspect.go
@@ -16,10 +16,10 @@ func (cli *Client) ContainerInspect(ctx context.Context, containerID string) (ty
 		return types.ContainerJSON{}, objectNotFoundError{object: "container", id: containerID}
 	}
 	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", nil, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return types.ContainerJSON{}, wrapResponseError(err, serverResp, "container", containerID)
 	}
-	defer ensureReaderClosed(serverResp)
 
 	var response types.ContainerJSON
 	err = json.NewDecoder(serverResp.body).Decode(&response)
@@ -36,10 +36,10 @@ func (cli *Client) ContainerInspectWithRaw(ctx context.Context, containerID stri
 		query.Set("size", "1")
 	}
 	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", query, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return types.ContainerJSON{}, nil, wrapResponseError(err, serverResp, "container", containerID)
 	}
-	defer ensureReaderClosed(serverResp)
 
 	body, err := ioutil.ReadAll(serverResp.body)
 	if err != nil {

--- a/client/container_list.go
+++ b/client/container_list.go
@@ -45,12 +45,12 @@ func (cli *Client) ContainerList(ctx context.Context, options types.ContainerLis
 	}
 
 	resp, err := cli.get(ctx, "/containers/json", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, err
 	}
 
 	var containers []types.Container
 	err = json.NewDecoder(resp.body).Decode(&containers)
-	ensureReaderClosed(resp)
 	return containers, err
 }

--- a/client/container_prune.go
+++ b/client/container_prune.go
@@ -23,10 +23,10 @@ func (cli *Client) ContainersPrune(ctx context.Context, pruneFilters filters.Arg
 	}
 
 	serverResp, err := cli.post(ctx, "/containers/prune", query, nil, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return report, err
 	}
-	defer ensureReaderClosed(serverResp)
 
 	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
 		return report, fmt.Errorf("Error retrieving disk usage: %v", err)

--- a/client/container_remove.go
+++ b/client/container_remove.go
@@ -22,6 +22,6 @@ func (cli *Client) ContainerRemove(ctx context.Context, containerID string, opti
 	}
 
 	resp, err := cli.delete(ctx, "/containers/"+containerID, query, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return wrapResponseError(err, resp, "container", containerID)
 }

--- a/client/container_top.go
+++ b/client/container_top.go
@@ -18,11 +18,11 @@ func (cli *Client) ContainerTop(ctx context.Context, containerID string, argumen
 	}
 
 	resp, err := cli.get(ctx, "/containers/"+containerID+"/top", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return response, err
 	}
 
 	err = json.NewDecoder(resp.body).Decode(&response)
-	ensureReaderClosed(resp)
 	return response, err
 }

--- a/client/container_update.go
+++ b/client/container_update.go
@@ -11,12 +11,11 @@ import (
 func (cli *Client) ContainerUpdate(ctx context.Context, containerID string, updateConfig container.UpdateConfig) (container.ContainerUpdateOKBody, error) {
 	var response container.ContainerUpdateOKBody
 	serverResp, err := cli.post(ctx, "/containers/"+containerID+"/update", nil, updateConfig, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return response, err
 	}
 
 	err = json.NewDecoder(serverResp.body).Decode(&response)
-
-	ensureReaderClosed(serverResp)
 	return response, err
 }

--- a/client/disk_usage.go
+++ b/client/disk_usage.go
@@ -13,10 +13,10 @@ func (cli *Client) DiskUsage(ctx context.Context) (types.DiskUsage, error) {
 	var du types.DiskUsage
 
 	serverResp, err := cli.get(ctx, "/system/df", nil, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return du, err
 	}
-	defer ensureReaderClosed(serverResp)
 
 	if err := json.NewDecoder(serverResp.body).Decode(&du); err != nil {
 		return du, fmt.Errorf("Error retrieving disk usage: %v", err)

--- a/client/distribution_inspect.go
+++ b/client/distribution_inspect.go
@@ -28,11 +28,11 @@ func (cli *Client) DistributionInspect(ctx context.Context, image, encodedRegist
 	}
 
 	resp, err := cli.get(ctx, "/distribution/"+image+"/json", url.Values{}, headers)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return distributionInspect, err
 	}
 
 	err = json.NewDecoder(resp.body).Decode(&distributionInspect)
-	ensureReaderClosed(resp)
 	return distributionInspect, err
 }

--- a/client/image_history.go
+++ b/client/image_history.go
@@ -12,11 +12,11 @@ import (
 func (cli *Client) ImageHistory(ctx context.Context, imageID string) ([]image.HistoryResponseItem, error) {
 	var history []image.HistoryResponseItem
 	serverResp, err := cli.get(ctx, "/images/"+imageID+"/history", url.Values{}, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return history, err
 	}
 
 	err = json.NewDecoder(serverResp.body).Decode(&history)
-	ensureReaderClosed(serverResp)
 	return history, err
 }

--- a/client/image_inspect.go
+++ b/client/image_inspect.go
@@ -15,10 +15,10 @@ func (cli *Client) ImageInspectWithRaw(ctx context.Context, imageID string) (typ
 		return types.ImageInspect{}, nil, objectNotFoundError{object: "image", id: imageID}
 	}
 	serverResp, err := cli.get(ctx, "/images/"+imageID+"/json", nil, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return types.ImageInspect{}, nil, wrapResponseError(err, serverResp, "image", imageID)
 	}
-	defer ensureReaderClosed(serverResp)
 
 	body, err := ioutil.ReadAll(serverResp.body)
 	if err != nil {

--- a/client/image_list.go
+++ b/client/image_list.go
@@ -35,11 +35,11 @@ func (cli *Client) ImageList(ctx context.Context, options types.ImageListOptions
 	}
 
 	serverResp, err := cli.get(ctx, "/images/json", query, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return images, err
 	}
 
 	err = json.NewDecoder(serverResp.body).Decode(&images)
-	ensureReaderClosed(serverResp)
 	return images, err
 }

--- a/client/image_prune.go
+++ b/client/image_prune.go
@@ -23,10 +23,10 @@ func (cli *Client) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (
 	}
 
 	serverResp, err := cli.post(ctx, "/images/prune", query, nil, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return report, err
 	}
-	defer ensureReaderClosed(serverResp)
 
 	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
 		return report, fmt.Errorf("Error retrieving disk usage: %v", err)

--- a/client/image_remove.go
+++ b/client/image_remove.go
@@ -21,11 +21,11 @@ func (cli *Client) ImageRemove(ctx context.Context, imageID string, options type
 
 	var dels []types.ImageDeleteResponseItem
 	resp, err := cli.delete(ctx, "/images/"+imageID, query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return dels, wrapResponseError(err, resp, "image", imageID)
 	}
 
 	err = json.NewDecoder(resp.body).Decode(&dels)
-	ensureReaderClosed(resp)
 	return dels, err
 }

--- a/client/image_search.go
+++ b/client/image_search.go
@@ -29,6 +29,7 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options types.I
 	}
 
 	resp, err := cli.tryImageSearch(ctx, query, options.RegistryAuth)
+	defer ensureReaderClosed(resp)
 	if errdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
 		newAuthHeader, privilegeErr := options.PrivilegeFunc()
 		if privilegeErr != nil {
@@ -41,7 +42,6 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options types.I
 	}
 
 	err = json.NewDecoder(resp.body).Decode(&results)
-	ensureReaderClosed(resp)
 	return results, err
 }
 

--- a/client/info.go
+++ b/client/info.go
@@ -13,10 +13,10 @@ import (
 func (cli *Client) Info(ctx context.Context) (types.Info, error) {
 	var info types.Info
 	serverResp, err := cli.get(ctx, "/info", url.Values{}, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return info, err
 	}
-	defer ensureReaderClosed(serverResp)
 
 	if err := json.NewDecoder(serverResp.body).Decode(&info); err != nil {
 		return info, fmt.Errorf("Error reading remote info: %v", err)

--- a/client/login.go
+++ b/client/login.go
@@ -13,6 +13,7 @@ import (
 // It returns unauthorizedError when the authentication fails.
 func (cli *Client) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
 	resp, err := cli.post(ctx, "/auth", url.Values{}, auth, nil)
+	defer ensureReaderClosed(resp)
 
 	if err != nil {
 		return registry.AuthenticateOKBody{}, err
@@ -20,6 +21,5 @@ func (cli *Client) RegistryLogin(ctx context.Context, auth types.AuthConfig) (re
 
 	var response registry.AuthenticateOKBody
 	err = json.NewDecoder(resp.body).Decode(&response)
-	ensureReaderClosed(resp)
 	return response, err
 }

--- a/client/network_create.go
+++ b/client/network_create.go
@@ -15,11 +15,11 @@ func (cli *Client) NetworkCreate(ctx context.Context, name string, options types
 	}
 	var response types.NetworkCreateResponse
 	serverResp, err := cli.post(ctx, "/networks/create", nil, networkCreateRequest, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return response, err
 	}
 
-	json.NewDecoder(serverResp.body).Decode(&response)
-	ensureReaderClosed(serverResp)
+	err = json.NewDecoder(serverResp.body).Decode(&response)
 	return response, err
 }

--- a/client/network_inspect.go
+++ b/client/network_inspect.go
@@ -34,10 +34,10 @@ func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, 
 		query.Set("scope", options.Scope)
 	}
 	resp, err = cli.get(ctx, "/networks/"+networkID, query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return networkResource, nil, wrapResponseError(err, resp, "network", networkID)
 	}
-	defer ensureReaderClosed(resp)
 
 	body, err := ioutil.ReadAll(resp.body)
 	if err != nil {

--- a/client/network_list.go
+++ b/client/network_list.go
@@ -22,10 +22,10 @@ func (cli *Client) NetworkList(ctx context.Context, options types.NetworkListOpt
 	}
 	var networkResources []types.NetworkResource
 	resp, err := cli.get(ctx, "/networks", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return networkResources, err
 	}
 	err = json.NewDecoder(resp.body).Decode(&networkResources)
-	ensureReaderClosed(resp)
 	return networkResources, err
 }

--- a/client/network_prune.go
+++ b/client/network_prune.go
@@ -23,10 +23,10 @@ func (cli *Client) NetworksPrune(ctx context.Context, pruneFilters filters.Args)
 	}
 
 	serverResp, err := cli.post(ctx, "/networks/prune", query, nil, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return report, err
 	}
-	defer ensureReaderClosed(serverResp)
 
 	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
 		return report, fmt.Errorf("Error retrieving network prune report: %v", err)

--- a/client/network_remove.go
+++ b/client/network_remove.go
@@ -5,6 +5,6 @@ import "context"
 // NetworkRemove removes an existent network from the docker host.
 func (cli *Client) NetworkRemove(ctx context.Context, networkID string) error {
 	resp, err := cli.delete(ctx, "/networks/"+networkID, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return wrapResponseError(err, resp, "network", networkID)
 }

--- a/client/node_inspect.go
+++ b/client/node_inspect.go
@@ -15,10 +15,10 @@ func (cli *Client) NodeInspectWithRaw(ctx context.Context, nodeID string) (swarm
 		return swarm.Node{}, nil, objectNotFoundError{object: "node", id: nodeID}
 	}
 	serverResp, err := cli.get(ctx, "/nodes/"+nodeID, nil, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return swarm.Node{}, nil, wrapResponseError(err, serverResp, "node", nodeID)
 	}
-	defer ensureReaderClosed(serverResp)
 
 	body, err := ioutil.ReadAll(serverResp.body)
 	if err != nil {

--- a/client/node_list.go
+++ b/client/node_list.go
@@ -25,12 +25,12 @@ func (cli *Client) NodeList(ctx context.Context, options types.NodeListOptions) 
 	}
 
 	resp, err := cli.get(ctx, "/nodes", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, err
 	}
 
 	var nodes []swarm.Node
 	err = json.NewDecoder(resp.body).Decode(&nodes)
-	ensureReaderClosed(resp)
 	return nodes, err
 }

--- a/client/node_remove.go
+++ b/client/node_remove.go
@@ -15,6 +15,6 @@ func (cli *Client) NodeRemove(ctx context.Context, nodeID string, options types.
 	}
 
 	resp, err := cli.delete(ctx, "/nodes/"+nodeID, query, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return wrapResponseError(err, resp, "node", nodeID)
 }

--- a/client/ping.go
+++ b/client/ping.go
@@ -38,10 +38,10 @@ func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 		return ping, err
 	}
 	serverResp, err = cli.doRequest(ctx, req)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return ping, err
 	}
-	defer ensureReaderClosed(serverResp)
 	return parsePingResponse(cli, serverResp)
 }
 

--- a/client/plugin_create.go
+++ b/client/plugin_create.go
@@ -18,9 +18,6 @@ func (cli *Client) PluginCreate(ctx context.Context, createContext io.Reader, cr
 	query.Set("name", createOptions.RepoName)
 
 	resp, err := cli.postRaw(ctx, "/plugins/create", query, createContext, headers)
-	if err != nil {
-		return err
-	}
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/plugin_inspect.go
+++ b/client/plugin_inspect.go
@@ -15,11 +15,11 @@ func (cli *Client) PluginInspectWithRaw(ctx context.Context, name string) (*type
 		return nil, nil, objectNotFoundError{object: "plugin", id: name}
 	}
 	resp, err := cli.get(ctx, "/plugins/"+name+"/json", nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, nil, wrapResponseError(err, resp, "plugin", name)
 	}
 
-	defer ensureReaderClosed(resp)
 	body, err := ioutil.ReadAll(resp.body)
 	if err != nil {
 		return nil, nil, err

--- a/client/plugin_list.go
+++ b/client/plugin_list.go
@@ -22,11 +22,11 @@ func (cli *Client) PluginList(ctx context.Context, filter filters.Args) (types.P
 		query.Set("filters", filterJSON)
 	}
 	resp, err := cli.get(ctx, "/plugins", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return plugins, wrapResponseError(err, resp, "plugin", "")
 	}
 
 	err = json.NewDecoder(resp.body).Decode(&plugins)
-	ensureReaderClosed(resp)
 	return plugins, err
 }

--- a/client/plugin_remove.go
+++ b/client/plugin_remove.go
@@ -15,6 +15,6 @@ func (cli *Client) PluginRemove(ctx context.Context, name string, options types.
 	}
 
 	resp, err := cli.delete(ctx, "/plugins/"+name, query, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return wrapResponseError(err, resp, "plugin", name)
 }

--- a/client/secret_create.go
+++ b/client/secret_create.go
@@ -15,11 +15,11 @@ func (cli *Client) SecretCreate(ctx context.Context, secret swarm.SecretSpec) (t
 		return response, err
 	}
 	resp, err := cli.post(ctx, "/secrets/create", nil, secret, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return response, err
 	}
 
 	err = json.NewDecoder(resp.body).Decode(&response)
-	ensureReaderClosed(resp)
 	return response, err
 }

--- a/client/secret_inspect.go
+++ b/client/secret_inspect.go
@@ -18,10 +18,10 @@ func (cli *Client) SecretInspectWithRaw(ctx context.Context, id string) (swarm.S
 		return swarm.Secret{}, nil, objectNotFoundError{object: "secret", id: id}
 	}
 	resp, err := cli.get(ctx, "/secrets/"+id, nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return swarm.Secret{}, nil, wrapResponseError(err, resp, "secret", id)
 	}
-	defer ensureReaderClosed(resp)
 
 	body, err := ioutil.ReadAll(resp.body)
 	if err != nil {

--- a/client/secret_list.go
+++ b/client/secret_list.go
@@ -27,12 +27,12 @@ func (cli *Client) SecretList(ctx context.Context, options types.SecretListOptio
 	}
 
 	resp, err := cli.get(ctx, "/secrets", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, err
 	}
 
 	var secrets []swarm.Secret
 	err = json.NewDecoder(resp.body).Decode(&secrets)
-	ensureReaderClosed(resp)
 	return secrets, err
 }

--- a/client/secret_remove.go
+++ b/client/secret_remove.go
@@ -8,6 +8,6 @@ func (cli *Client) SecretRemove(ctx context.Context, id string) error {
 		return err
 	}
 	resp, err := cli.delete(ctx, "/secrets/"+id, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return wrapResponseError(err, resp, "secret", id)
 }

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -72,6 +72,7 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 
 	var response types.ServiceCreateResponse
 	resp, err := cli.post(ctx, "/services/create", nil, service, headers)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return response, err
 	}
@@ -82,7 +83,6 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 		response.Warnings = append(response.Warnings, digestWarning(service.TaskTemplate.ContainerSpec.Image))
 	}
 
-	ensureReaderClosed(resp)
 	return response, err
 }
 

--- a/client/service_inspect.go
+++ b/client/service_inspect.go
@@ -20,10 +20,10 @@ func (cli *Client) ServiceInspectWithRaw(ctx context.Context, serviceID string, 
 	query := url.Values{}
 	query.Set("insertDefaults", fmt.Sprintf("%v", opts.InsertDefaults))
 	serverResp, err := cli.get(ctx, "/services/"+serviceID, query, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return swarm.Service{}, nil, wrapResponseError(err, serverResp, "service", serviceID)
 	}
-	defer ensureReaderClosed(serverResp)
 
 	body, err := ioutil.ReadAll(serverResp.body)
 	if err != nil {

--- a/client/service_list.go
+++ b/client/service_list.go
@@ -24,12 +24,12 @@ func (cli *Client) ServiceList(ctx context.Context, options types.ServiceListOpt
 	}
 
 	resp, err := cli.get(ctx, "/services", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, err
 	}
 
 	var services []swarm.Service
 	err = json.NewDecoder(resp.body).Decode(&services)
-	ensureReaderClosed(resp)
 	return services, err
 }

--- a/client/service_remove.go
+++ b/client/service_remove.go
@@ -5,6 +5,6 @@ import "context"
 // ServiceRemove kills and removes a service.
 func (cli *Client) ServiceRemove(ctx context.Context, serviceID string) error {
 	resp, err := cli.delete(ctx, "/services/"+serviceID, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return wrapResponseError(err, resp, "service", serviceID)
 }

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -79,6 +79,7 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 
 	var response types.ServiceUpdateResponse
 	resp, err := cli.post(ctx, "/services/"+serviceID+"/update", query, service, headers)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return response, err
 	}
@@ -89,6 +90,5 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 		response.Warnings = append(response.Warnings, digestWarning(service.TaskTemplate.ContainerSpec.Image))
 	}
 
-	ensureReaderClosed(resp)
 	return response, err
 }

--- a/client/swarm_get_unlock_key.go
+++ b/client/swarm_get_unlock_key.go
@@ -10,12 +10,12 @@ import (
 // SwarmGetUnlockKey retrieves the swarm's unlock key.
 func (cli *Client) SwarmGetUnlockKey(ctx context.Context) (types.SwarmUnlockKeyResponse, error) {
 	serverResp, err := cli.get(ctx, "/swarm/unlockkey", nil, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return types.SwarmUnlockKeyResponse{}, err
 	}
 
 	var response types.SwarmUnlockKeyResponse
 	err = json.NewDecoder(serverResp.body).Decode(&response)
-	ensureReaderClosed(serverResp)
 	return response, err
 }

--- a/client/swarm_init.go
+++ b/client/swarm_init.go
@@ -10,12 +10,12 @@ import (
 // SwarmInit initializes the swarm.
 func (cli *Client) SwarmInit(ctx context.Context, req swarm.InitRequest) (string, error) {
 	serverResp, err := cli.post(ctx, "/swarm/init", nil, req, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return "", err
 	}
 
 	var response string
 	err = json.NewDecoder(serverResp.body).Decode(&response)
-	ensureReaderClosed(serverResp)
 	return response, err
 }

--- a/client/swarm_inspect.go
+++ b/client/swarm_inspect.go
@@ -10,12 +10,12 @@ import (
 // SwarmInspect inspects the swarm.
 func (cli *Client) SwarmInspect(ctx context.Context) (swarm.Swarm, error) {
 	serverResp, err := cli.get(ctx, "/swarm", nil, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return swarm.Swarm{}, err
 	}
 
 	var response swarm.Swarm
 	err = json.NewDecoder(serverResp.body).Decode(&response)
-	ensureReaderClosed(serverResp)
 	return response, err
 }

--- a/client/task_inspect.go
+++ b/client/task_inspect.go
@@ -15,10 +15,10 @@ func (cli *Client) TaskInspectWithRaw(ctx context.Context, taskID string) (swarm
 		return swarm.Task{}, nil, objectNotFoundError{object: "task", id: taskID}
 	}
 	serverResp, err := cli.get(ctx, "/tasks/"+taskID, nil, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return swarm.Task{}, nil, wrapResponseError(err, serverResp, "task", taskID)
 	}
-	defer ensureReaderClosed(serverResp)
 
 	body, err := ioutil.ReadAll(serverResp.body)
 	if err != nil {

--- a/client/task_list.go
+++ b/client/task_list.go
@@ -24,12 +24,12 @@ func (cli *Client) TaskList(ctx context.Context, options types.TaskListOptions) 
 	}
 
 	resp, err := cli.get(ctx, "/tasks", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, err
 	}
 
 	var tasks []swarm.Task
 	err = json.NewDecoder(resp.body).Decode(&tasks)
-	ensureReaderClosed(resp)
 	return tasks, err
 }

--- a/client/version.go
+++ b/client/version.go
@@ -10,12 +10,12 @@ import (
 // ServerVersion returns information of the docker client and server host.
 func (cli *Client) ServerVersion(ctx context.Context) (types.Version, error) {
 	resp, err := cli.get(ctx, "/version", nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return types.Version{}, err
 	}
 
 	var server types.Version
 	err = json.NewDecoder(resp.body).Decode(&server)
-	ensureReaderClosed(resp)
 	return server, err
 }

--- a/client/volume_create.go
+++ b/client/volume_create.go
@@ -12,10 +12,10 @@ import (
 func (cli *Client) VolumeCreate(ctx context.Context, options volumetypes.VolumeCreateBody) (types.Volume, error) {
 	var volume types.Volume
 	resp, err := cli.post(ctx, "/volumes/create", nil, options, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return volume, err
 	}
 	err = json.NewDecoder(resp.body).Decode(&volume)
-	ensureReaderClosed(resp)
 	return volume, err
 }

--- a/client/volume_inspect.go
+++ b/client/volume_inspect.go
@@ -23,10 +23,10 @@ func (cli *Client) VolumeInspectWithRaw(ctx context.Context, volumeID string) (t
 
 	var volume types.Volume
 	resp, err := cli.get(ctx, "/volumes/"+volumeID, nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return volume, nil, wrapResponseError(err, resp, "volume", volumeID)
 	}
-	defer ensureReaderClosed(resp)
 
 	body, err := ioutil.ReadAll(resp.body)
 	if err != nil {

--- a/client/volume_list.go
+++ b/client/volume_list.go
@@ -22,11 +22,11 @@ func (cli *Client) VolumeList(ctx context.Context, filter filters.Args) (volumet
 		query.Set("filters", filterJSON)
 	}
 	resp, err := cli.get(ctx, "/volumes", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return volumes, err
 	}
 
 	err = json.NewDecoder(resp.body).Decode(&volumes)
-	ensureReaderClosed(resp)
 	return volumes, err
 }

--- a/client/volume_prune.go
+++ b/client/volume_prune.go
@@ -23,10 +23,10 @@ func (cli *Client) VolumesPrune(ctx context.Context, pruneFilters filters.Args) 
 	}
 
 	serverResp, err := cli.post(ctx, "/volumes/prune", query, nil, nil)
+	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return report, err
 	}
-	defer ensureReaderClosed(serverResp)
 
 	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
 		return report, fmt.Errorf("Error retrieving volume prune report: %v", err)

--- a/client/volume_remove.go
+++ b/client/volume_remove.go
@@ -16,6 +16,6 @@ func (cli *Client) VolumeRemove(ctx context.Context, volumeID string, force bool
 		}
 	}
 	resp, err := cli.delete(ctx, "/volumes/"+volumeID, query, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return wrapResponseError(err, resp, "volume", volumeID)
 }


### PR DESCRIPTION
Unlike a plain `net/http/client.Do()`, requests made through client/request use the `sendRequest` function, which parses the server response, and may convert non-transport errors into errors (through `cli.checkResponseErr()`).

This means that we cannot assume that no reader was opened if an error is returned.

This patch changes various locations where `ensureReaderClosed` was only called in the non-error situation, and uses a `defer` to make sure it's always called.

`ensureReaderClosed` itself already checks if the response's body was set, so in situations where the error was due to a transport error, calling `ensureReaderClosed` should be a no-op.

