### PR TITLE
Fix stopped containers with restart-policy showing as "restarting"

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -85,6 +85,8 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerd.EventType, ei libc
 			}
 			daemon.LogContainerEventWithAttributes(c, "die", attributes)
 			daemon.Cleanup(c)
+			daemon.setStateCounter(c)
+			cpErr := c.CheckpointTo(daemon.containersReplica)
 
 			if err == nil && restart {
 				go func() {
@@ -101,6 +103,8 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerd.EventType, ei libc
 					if err != nil {
 						c.Lock()
 						c.SetStopped(&exitStatus)
+						daemon.setStateCounter(c)
+						c.CheckpointTo(daemon.containersReplica)
 						c.Unlock()
 						defer daemon.autoRemove(c)
 						if err != restartmanager.ErrRestartCanceled {
@@ -110,8 +114,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerd.EventType, ei libc
 				}()
 			}
 
-			daemon.setStateCounter(c)
-			return c.CheckpointTo(daemon.containersReplica)
+			return cpErr
 		}
 
 		if execConfig := c.ExecCommands.Get(ei.ProcessID); execConfig != nil {


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/38720 Flaky test: DockerDaemonSuite.TestDaemonRestartUnlessStopped

When manually stopping a container with a restart-policy, the container
would show as "restarting" in `docker ps` whereas its actual state
is "exited".

Stopping a container with a restart policy shows the container as "restarting"

    docker run -d --name test --restart unless-stopped busybox false

    docker stop test

    docker ps
    CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                       PORTS               NAMES
    7e07409fa1d3        busybox             "false"             5 minutes ago       Restarting (1) 4 minutes ago                     test

However, inspecting the same container shows that it's exited:

    docker inspect test --format '{{ json .State }}'
    {
      "Status": "exited",
      "Running": false,
      "Paused": false,
      "Restarting": false,
      "OOMKilled": false,
      "Dead": false,
      "Pid": 0,
      "ExitCode": 1,
      "Error": "",
      "StartedAt": "2019-02-14T13:26:27.6091648Z",
      "FinishedAt": "2019-02-14T13:26:27.689427Z"
    }

And killing the container confirms this;

    docker kill test
    Error response from daemon: Cannot kill container: test: Container 7e07409fa1d36dc8d8cb8f25cf12ee1168ad9040183b85fafa73ee2c1fcf9361 is not running

    docker run -d --name test --restart unless-stopped busybox false

    docker stop test

    docker ps
    CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                PORTS               NAMES
    d0595237054a        busybox             "false"             5 minutes ago       Restarting (1)       4 minutes ago                       exit

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**