### PR TITLE
make test-integration: use correct dockerd binary

### DIFF
--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -3,7 +3,7 @@
 # see test-integration for example usage of this script
 
 base="$ABS_DEST/.."
-export PATH="$base/binary-daemon:$base/dynbinary-daemon:$PATH"
+export PATH="$base/dynbinary-daemon:$base/binary-daemon:$PATH"
 
 export TEST_CLIENT_BINARY=docker
 


### PR DESCRIPTION
Here's what happens:
1. One runs `make binary` once
2. Days go by...
3. One makes changes to dockerd sources
4. One runs `make test-integration` to test the changes
5. One spends a long time figuring out why on Earth
   those changes in step 3 are ignored by step 4.
6. One writes this patch
7. ...
8. PROFIT!!

OK, so `make test-integration` builds a dockerd binary
in bundles/dynbinary-daemon/, when starts a daemon instance
for testing. The problem is, the script that starts the
daemon sets PATH to try `bundles/binary-daemon/` first,
and `bundles/dynbinary-daemon/` second.