### PR TITLE
Update createSpec to use errdefs

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -955,7 +955,7 @@ func (daemon *Daemon) getNetworkedContainer(containerID, connectedContainerID st
 		return nil, err
 	}
 	if containerID == nc.ID {
-		return nil, fmt.Errorf("cannot join own network")
+		return nil, errdefs.InvalidParameter(fmt.Errorf("cannot join own network"))
 	}
 	if !nc.IsRunning() {
 		err := fmt.Errorf("cannot join network of a non running container: %s", connectedContainerID)

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -153,7 +153,15 @@ func (daemon *Daemon) containerStart(container *container.Container, checkpoint 
 
 	spec, err := daemon.createSpec(container)
 	if err != nil {
-		return errdefs.System(err)
+		// daemon.createSpec has been updated to return all errdefs errors.
+		// However, this update may have been incomplete, and some things may
+		// have changed. To ensure that, no matter what, we get a valid error
+		// type, we will match on all known error types, and then wrap this
+		// error in "Unknown" if it is none of them
+		if !errdefs.IsKnownErrorType(err) {
+			return errdefs.Unknown(err)
+		}
+		return err
 	}
 
 	if resetRestartManager {

--- a/errdefs/helpers_test.go
+++ b/errdefs/helpers_test.go
@@ -3,6 +3,8 @@ package errdefs // import "github.com/docker/docker/errdefs"
 import (
 	"errors"
 	"testing"
+
+	pkgErrors "github.com/pkg/errors"
 )
 
 var errTest = errors.New("this is a test")
@@ -19,6 +21,9 @@ func TestNotFound(t *testing.T) {
 	if !IsNotFound(e) {
 		t.Fatalf("expected not found error, got: %T", e)
 	}
+	if !IsKnownErrorType(e) {
+		t.Fatalf("expected NotFound to be known error type")
+	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
@@ -31,6 +36,9 @@ func TestConflict(t *testing.T) {
 	e := Conflict(errTest)
 	if !IsConflict(e) {
 		t.Fatalf("expected conflict error, got: %T", e)
+	}
+	if !IsKnownErrorType(e) {
+		t.Fatalf("expected Conflict to be known error type")
 	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
@@ -45,6 +53,9 @@ func TestForbidden(t *testing.T) {
 	if !IsForbidden(e) {
 		t.Fatalf("expected forbidden error, got: %T", e)
 	}
+	if !IsKnownErrorType(e) {
+		t.Fatalf("expected Forbidden to be known error type")
+	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
@@ -57,6 +68,9 @@ func TestInvalidParameter(t *testing.T) {
 	e := InvalidParameter(errTest)
 	if !IsInvalidParameter(e) {
 		t.Fatalf("expected invalid argument error, got %T", e)
+	}
+	if !IsKnownErrorType(e) {
+		t.Fatalf("expected InvalidParameter to be known error type")
 	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
@@ -71,6 +85,9 @@ func TestNotImplemented(t *testing.T) {
 	if !IsNotImplemented(e) {
 		t.Fatalf("expected not implemented error, got %T", e)
 	}
+	if !IsKnownErrorType(e) {
+		t.Fatalf("expected NotImplemented to be known error type")
+	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
@@ -83,6 +100,9 @@ func TestNotModified(t *testing.T) {
 	e := NotModified(errTest)
 	if !IsNotModified(e) {
 		t.Fatalf("expected not modified error, got %T", e)
+	}
+	if !IsKnownErrorType(e) {
+		t.Fatalf("expected NotModified to be known error type")
 	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
@@ -97,6 +117,9 @@ func TestAlreadyExists(t *testing.T) {
 	if !IsAlreadyExists(e) {
 		t.Fatalf("expected already exists error, got %T", e)
 	}
+	if !IsKnownErrorType(e) {
+		t.Fatalf("expected AlreadyExists to be known error type")
+	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
@@ -109,6 +132,9 @@ func TestUnauthorized(t *testing.T) {
 	e := Unauthorized(errTest)
 	if !IsUnauthorized(e) {
 		t.Fatalf("expected unauthorized error, got %T", e)
+	}
+	if !IsKnownErrorType(e) {
+		t.Fatalf("expected Unauthorized to be known error type")
 	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
@@ -123,6 +149,9 @@ func TestUnknown(t *testing.T) {
 	if !IsUnknown(e) {
 		t.Fatalf("expected unknown error, got %T", e)
 	}
+	if !IsKnownErrorType(e) {
+		t.Fatalf("expected Unknown to be known error type")
+	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
@@ -135,6 +164,9 @@ func TestCancelled(t *testing.T) {
 	e := Cancelled(errTest)
 	if !IsCancelled(e) {
 		t.Fatalf("expected cancelled error, got %T", e)
+	}
+	if !IsKnownErrorType(e) {
+		t.Fatalf("expected Canceled to be known error type")
 	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
@@ -149,6 +181,9 @@ func TestDeadline(t *testing.T) {
 	if !IsDeadline(e) {
 		t.Fatalf("expected deadline error, got %T", e)
 	}
+	if !IsKnownErrorType(e) {
+		t.Fatalf("expected Deadline to be known error type")
+	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
@@ -161,6 +196,9 @@ func TestDataLoss(t *testing.T) {
 	e := DataLoss(errTest)
 	if !IsDataLoss(e) {
 		t.Fatalf("expected data loss error, got %T", e)
+	}
+	if !IsKnownErrorType(e) {
+		t.Fatalf("expected DataLoss to be known error type")
 	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
@@ -175,6 +213,9 @@ func TestUnavailable(t *testing.T) {
 	if !IsUnavailable(e) {
 		t.Fatalf("expected unavaillable error, got %T", e)
 	}
+	if !IsKnownErrorType(e) {
+		t.Fatalf("expected Unavailable to be known error type")
+	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
@@ -188,7 +229,21 @@ func TestSystem(t *testing.T) {
 	if !IsSystem(e) {
 		t.Fatalf("expected system error, got %T", e)
 	}
+	if !IsKnownErrorType(e) {
+		t.Fatalf("expected System to be known error type")
+	}
 	if cause := e.(causal).Cause(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
+	}
+}
+
+func TestKnownErrorTypeRecursive(t *testing.T) {
+	e := pkgErrors.Wrap(
+		pkgErrors.Wrap(Unknown(errTest), "wrapping this error"),
+		"wrapping it again",
+	)
+
+	if !IsKnownErrorType(e) {
+		t.Fatalf("expected a wrapped error to still be a known error type")
 	}
 }

--- a/errdefs/is.go
+++ b/errdefs/is.go
@@ -112,3 +112,32 @@ func IsDataLoss(err error) bool {
 	_, ok := getImplementer(err).(ErrDataLoss)
 	return ok
 }
+
+// IsKnownErrorType returns if the passed in error is one of the error types
+// defined in this package. Note that "Unknown" is a known error type.
+func IsKnownErrorType(err error) bool {
+	// this code is almost identical to the code in getImplementer, but instead
+	// of returning the error, it returns a boolean
+	switch e := err.(type) {
+	case
+		ErrNotFound,
+		ErrInvalidParameter,
+		ErrConflict,
+		ErrUnauthorized,
+		ErrUnavailable,
+		ErrForbidden,
+		ErrSystem,
+		ErrNotModified,
+		ErrAlreadyExists,
+		ErrNotImplemented,
+		ErrCancelled,
+		ErrDeadline,
+		ErrDataLoss,
+		ErrUnknown:
+		return true
+	case causer:
+		return IsKnownErrorType(e.Cause())
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Signed-off-by: Drew Erny <drew.erny@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Updates the createSpec method, for both Windows and Linux systems, to return all errors in terms of errdefs. Makes easy changes in dependencies of those methods as well, if bringing them to use all errdefs errors was trivial. Includes comments annotating why each errdef type was chosen for each particular error.

/cc @cpuguy83, done as promised in exchange for #38632 being accepted.

**- How I did it**

Carefully step through createSpec and its dependencies, and wrapped each error in an `errdefs` helper function before it was returned

**- How to verify it**

You sort of have to review it by hand. This function is really bad in terms of complexity, so a comprehensive test case to cover it would be prohibitively difficult to write.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

