### PR TITLE
pkg/mount: remove unused ParseTmpfsOptions

### DIFF
--- a/pkg/mount/flags.go
+++ b/pkg/mount/flags.go
@@ -135,15 +135,3 @@ func parseOptions(options string) (int, string) {
 	}
 	return flag, strings.Join(data, ",")
 }
-
-// ParseTmpfsOptions parse fstab type mount options into flags and data
-func ParseTmpfsOptions(options string) (int, string, error) {
-	flags, data := parseOptions(options)
-	for _, o := range strings.Split(data, ",") {
-		opt := strings.SplitN(o, "=", 2)
-		if !validFlags[opt[0]] {
-			return 0, "", fmt.Errorf("Invalid tmpfs option %q", opt)
-		}
-	}
-	return flags, data, nil
-}


### PR DESCRIPTION
This function was previously used on the client to validate tmpfs options, but is no longer used since b9b8d8b364a14b6f827c9db94f651dda372ed253 (https://github.com/moby/moby/pull/28440), as this validation is platform-specific, so should be handled by the daemon.

Removing this function as it's no longer used anywhere.


**- A picture of a cute animal (not mandatory but encouraged)**

![mouse_lemur](https://user-images.githubusercontent.com/1804568/53241418-ecae6f00-36a1-11e9-88cd-df3b4beddec0.jpg)

image: [mouse lemur, fieldmuseum.org](https://www.fieldmuseum.org/blog/ridiculously-cute-mouse-lemurs-hold-key-madagascars-past)