### PR TITLE
Windows: Disable 2 restart tests on Hyper-V isolation

### DIFF
--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -164,7 +164,10 @@ func (s *DockerSuite) TestRestartContainerwithGoodContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestRestartContainerSuccess(c *check.C) {
-	testRequires(c, testEnv.IsLocalDaemon)
+	// Skipped for Hyper-V isolated containers. Test is currently written
+	// such that it assumes there is a host process to kill. In Hyper-V
+	// containers, the process is inside the utility VM, not on the host.
+	testRequires(c, testEnv.IsLocalDaemon, IsolationIsProcess)
 
 	out := runSleepingContainer(c, "-d", "--restart=always")
 	id := strings.TrimSpace(out)
@@ -234,7 +237,10 @@ func (s *DockerSuite) TestRestartWithPolicyUserDefinedNetwork(c *check.C) {
 }
 
 func (s *DockerSuite) TestRestartPolicyAfterRestart(c *check.C) {
-	testRequires(c, testEnv.IsLocalDaemon)
+	// Skipped for Hyper-V isolated containers. Test is currently written
+	// such that it assumes there is a host process to kill. In Hyper-V
+	// containers, the process is inside the utility VM, not on the host.
+	testRequires(c, testEnv.IsLocalDaemon, IsolationIsProcess)
 
 	out := runSleepingContainer(c, "-d", "--restart=always")
 	id := strings.TrimSpace(out)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Two restart tests are being disabled here for Hyper-V isolation due to the way they are designed. They both assume they can kill a host process to force a restart. This is not possible in Hyper-V isolation as the process is running in a utility VM, not the host.