### PR TITLE
Explicitly set `rw` / `ro` for mounts

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -451,17 +451,6 @@ var (
 	}
 )
 
-// inSlice tests whether a string is contained in a slice of strings or not.
-// Comparison is case sensitive
-func inSlice(slice []string, s string) bool {
-	for _, ss := range slice {
-		if s == ss {
-			return true
-		}
-	}
-	return false
-}
-
 func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []container.Mount) error {
 	userMounts := make(map[string]struct{})
 	for _, m := range mounts {
@@ -498,13 +487,13 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 
 		defaultMounts = append(defaultMounts, m)
 	}
-
 	s.Mounts = defaultMounts
+
 	for _, m := range mounts {
 		if m.Source == "tmpfs" {
 			data := m.Data
 			parser := volumemounts.NewParser("linux")
-			options := []string{"noexec", "nosuid", "nodev", string(parser.DefaultPropagationMode())}
+			options := []string{"rw", "noexec", "nosuid", "nodev", string(parser.DefaultPropagationMode())}
 			if data != "" {
 				options = append(options, strings.Split(data, ",")...)
 			}
@@ -573,7 +562,9 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 			bindMode = "bind"
 		}
 		opts := []string{bindMode}
-		if !m.Writable {
+		if m.Writable {
+			opts = append(opts, "rw")
+		} else {
 			opts = append(opts, "ro")
 		}
 		if pFlag != 0 {
@@ -604,18 +595,16 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 				continue
 			}
 			if _, ok := userMounts[m.Destination]; !ok {
-				if !inSlice(m.Options, "ro") {
-					s.Mounts[i].Options = append(s.Mounts[i].Options, "ro")
-				}
+				makeReadOnly(&s.Mounts[i])
 			}
 		}
 	}
 
 	if c.HostConfig.Privileged {
-		// clear readonly for /sys
+		// make /sys writeable
 		for i := range s.Mounts {
 			if s.Mounts[i].Destination == "/sys" {
-				clearReadOnly(&s.Mounts[i])
+				makeWritable(&s.Mounts[i])
 			}
 		}
 		s.Linux.ReadonlyPaths = nil
@@ -627,7 +616,7 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 	if uidMap := daemon.idMapping.UIDs(); uidMap != nil || c.HostConfig.Privileged {
 		for i, m := range s.Mounts {
 			if m.Type == "cgroup" {
-				clearReadOnly(&s.Mounts[i])
+				makeWritable(&s.Mounts[i])
 			}
 		}
 	}
@@ -877,12 +866,36 @@ func (daemon *Daemon) createSpec(c *container.Container) (retSpec *specs.Spec, e
 	return &s, nil
 }
 
-func clearReadOnly(m *specs.Mount) {
-	var opt []string
+func makeWritable(m *specs.Mount) {
+	var found bool
+	opt := m.Options[:0]
 	for _, o := range m.Options {
+		if o == "rw" {
+			found = true
+		}
 		if o != "ro" {
 			opt = append(opt, o)
 		}
+	}
+	if !found {
+		opt = append(opt, "rw")
+	}
+	m.Options = opt
+}
+
+func makeReadOnly(m *specs.Mount) {
+	var found bool
+	opt := m.Options[:0]
+	for _, o := range m.Options {
+		if o == "ro" {
+			found = true
+		}
+		if o != "rw" {
+			opt = append(opt, o)
+		}
+	}
+	if !found {
+		opt = append(opt, "ro")
 	}
 	m.Options = opt
 }

--- a/daemon/oci_linux_test.go
+++ b/daemon/oci_linux_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/network"
+	"github.com/docker/docker/oci"
 	"github.com/docker/docker/pkg/containerfs"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/libnetwork"
@@ -147,4 +148,131 @@ func TestGetSourceMount(t *testing.T) {
 	assert.NilError(t, err)
 	_, _, err = getSourceMount(cwd)
 	assert.NilError(t, err)
+}
+
+// TestMountsHaveWriteMode checks that every mount has a write-mode set (either 'ro' or 'rw')
+func TestMountsHaveWriteMode(t *testing.T) {
+	d := Daemon{idMapping: &idtools.IdentityMapping{}}
+	c := &container.Container{HostConfig: &containertypes.HostConfig{}}
+
+	spec := oci.DefaultSpec()
+	err := setMounts(&d, &spec, c, []container.Mount{})
+	assert.Check(t, err)
+
+	for _, m := range spec.Mounts {
+		hasWriteMode := inSlice(m.Options, "rw") || inSlice(m.Options, "ro")
+		assert.Check(t, hasWriteMode, "expected mount to have 'ro' or 'rw': %s", m.Options)
+	}
+}
+
+func TestSetMount(t *testing.T) {
+	d := Daemon{idMapping: &idtools.IdentityMapping{}}
+	c := &container.Container{HostConfig: &containertypes.HostConfig{}}
+	spec := oci.DefaultSpec()
+
+	tests := []struct {
+		name       string
+		hc         containertypes.HostConfig
+		userMounts []container.Mount
+		expected   map[string][]string
+	}{
+		{
+			name: "default",
+			userMounts: []container.Mount{
+				{
+					Source:      "/readonly",
+					Destination: "/readonly",
+					Writable:    false,
+				},
+				{
+					Source:      "/writable",
+					Destination: "/writable",
+					Writable:    true,
+				},
+			},
+			expected: map[string][]string{
+				"/readonly":      {"ro"},
+				"/writable":      {"rw"},
+				"/proc":          {"rw"},
+				"/dev":           {"rw"},
+				"/dev/pts":       {"rw"},
+				"/sys":           {"ro"},
+				"/sys/fs/cgroup": {"ro"},
+				"/dev/mqueue":    {"rw"},
+				"/dev/shm":       {"rw"},
+			},
+		},
+		{
+			name: "privileged",
+			hc:   containertypes.HostConfig{Privileged: true},
+			expected: map[string][]string{
+				"/proc":          {"rw"},
+				"/dev":           {"rw"},
+				"/dev/pts":       {"rw"},
+				"/sys":           {"rw"},
+				"/sys/fs/cgroup": {"rw"},
+				"/dev/mqueue":    {"rw"},
+				"/dev/shm":       {"rw"},
+			},
+		},
+		{
+			name: "readonly",
+			hc:   containertypes.HostConfig{ReadonlyRootfs: true},
+			userMounts: []container.Mount{
+				{
+					Source:      "/readonly",
+					Destination: "/readonly",
+					Writable:    false,
+				},
+				{
+					Source:      "/writable",
+					Destination: "/writable",
+					Writable:    true,
+				},
+			},
+			expected: map[string][]string{
+				"/readonly":      {"ro"},
+				"/writable":      {"rw"},
+				"/proc":          {"rw"},
+				"/dev":           {"rw"},
+				"/dev/pts":       {"rw"},
+				"/sys":           {"ro"},
+				"/sys/fs/cgroup": {"ro"},
+				"/dev/mqueue":    {"rw"},
+				"/dev/shm":       {"rw"},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c.HostConfig = &tc.hc
+			s := spec
+			if c.HostConfig.ReadonlyRootfs {
+				// TODO why does setMounts look at spec.Root.Readonly, and not at HostConfig?
+				s.Root.Readonly = true
+			}
+			err := setMounts(&d, &s, c, []container.Mount{})
+			assert.Check(t, err)
+
+			for _, m := range spec.Mounts {
+				if expectedOpts, ok := tc.expected[m.Destination]; ok {
+					for _, opt := range expectedOpts {
+						assert.Check(t, inSlice(m.Options, opt), "option %q not found for mount %q", opt, m.Destination)
+					}
+				}
+			}
+
+		})
+	}
+}
+
+// inSlice tests whether a string is contained in a slice of strings or not.
+// Comparison is case sensitive
+func inSlice(slice []string, s string) bool {
+	for _, ss := range slice {
+		if s == ss {
+			return true
+		}
+	}
+	return false
 }

--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -73,25 +73,25 @@ func DefaultLinuxSpec() specs.Spec {
 			Destination: "/proc",
 			Type:        "proc",
 			Source:      "proc",
-			Options:     []string{"nosuid", "noexec", "nodev"},
+			Options:     []string{"rw", "nosuid", "noexec", "nodev"},
 		},
 		{
 			Destination: "/dev",
 			Type:        "tmpfs",
 			Source:      "tmpfs",
-			Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+			Options:     []string{"rw", "nosuid", "strictatime", "mode=755", "size=65536k"},
 		},
 		{
 			Destination: "/dev/pts",
 			Type:        "devpts",
 			Source:      "devpts",
-			Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
+			Options:     []string{"rw", "nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
 		},
 		{
 			Destination: "/sys",
 			Type:        "sysfs",
 			Source:      "sysfs",
-			Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+			Options:     []string{"ro", "nosuid", "noexec", "nodev"},
 		},
 		{
 			Destination: "/sys/fs/cgroup",
@@ -103,13 +103,13 @@ func DefaultLinuxSpec() specs.Spec {
 			Destination: "/dev/mqueue",
 			Type:        "mqueue",
 			Source:      "mqueue",
-			Options:     []string{"nosuid", "noexec", "nodev"},
+			Options:     []string{"rw", "nosuid", "noexec", "nodev"},
 		},
 		{
 			Destination: "/dev/shm",
 			Type:        "tmpfs",
 			Source:      "shm",
-			Options:     []string{"nosuid", "noexec", "nodev", "mode=1777"},
+			Options:     []string{"rw", "nosuid", "noexec", "nodev", "mode=1777"},
 		},
 	}
 


### PR DESCRIPTION
The current code assumed that mounts were mounted "read-write" by default, and added "ro" to make them read-only.

In some situations, omitting the "rw" option could result in `sysfs` mounts becoming read-only (possibly inheriting defaults from the host).

This patch changes the approach to always set either "ro" or "rw", instead of omitting these options (thus ambiguous).

A similar fix was already implemented in containerd/cri
https://github.com/containerd/cri/pull/763/commits/a5d1332e8fd2b44cd4d00823d38f8e0c8fcf6c5d


relates to https://github.com/moby/moby/issues/24000
