### PR TITLE
fix hack/dockerfile/install/containerd.installer lf statement's operator

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -19,7 +19,7 @@ install_containerd() {
 		export EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"'
 
 		# Reset build flags to nothing if we want a dynbinary
-		if [ "$1" == "dynamic" ]; then
+		if [ "$1" = "dynamic" ]; then
 			export BUILDTAGS=''
 			export EXTRA_FLAGS=''
 			export EXTRA_LDFLAGS=''


### PR DESCRIPTION
Signed-off-by: Rong Gao <gaoronggood@163.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Change `hack/dockerfile/install` package's shell interpreter from `sh` to `bash`.  In original `sh` interpreter situation, `if` statement shown below will throw an error when `$1` is empty.

https://github.com/moby/moby/blob/cbb885b07af59225eef12a8159e70d1485616d57/hack/dockerfile/install/containerd.installer#L22

error log:
```shell
hack/dockerfile/install/containerd.installer: 22: [: unexpected operator
```
This script is not run directly and always invoked by `hack/dockerfile/install/install.sh` whose interpreter is `bash`, so the error is not revealed.  but this is truly a bad smell.



**- How I did it**
~~this PR changes shell interpreter to bash and tests by `[ ]` statement instead of `[[ ]]` according to [google shell style advice](https://google.github.io/styleguide/shell.xml)~~

change lf statment's operator from `==` to `=`

**- How to verify it**
I run Makefile and everything is OK.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

