### PR TITLE
Fix container update resetting pidslimit on older API clients

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -425,6 +425,9 @@ func (s *containerRouter) postContainerUpdate(ctx context.Context, w http.Respon
 	if err := decoder.Decode(&updateConfig); err != nil {
 		return err
 	}
+	if versions.LessThan(httputils.VersionFromContext(ctx), "1.40") {
+		updateConfig.PidsLimit = nil
+	}
 
 	hostConfig := &container.HostConfig{
 		Resources:     updateConfig.Resources,


### PR DESCRIPTION
Follow-up to https://github.com/moby/moby/pull/32519


Older API clients did not use a pointer for `PidsLimit`, so API requests would always send `0`, resulting in any previous value to be reset after an update:

### Before this patch:

(using a 17.06 Docker CLI):

```bash
docker run -dit --name test --pids-limit=16 busybox
docker container inspect --format '{{json .HostConfig.PidsLimit}}' test
16

docker container update --memory=100M --memory-swap=200M test

docker container inspect --format '{{json .HostConfig.PidsLimit}}' test
0

docker container exec test cat /sys/fs/cgroup/pids/pids.max
max
```

### With this patch applied:

(using a 17.06 Docker CLI):

```bash
docker run -dit --name test --pids-limit=16 busybox
docker container inspect --format '{{json .HostConfig.PidsLimit}}' test
16

docker container update --memory=100M --memory-swap=200M test

docker container inspect --format '{{json .HostConfig.PidsLimit}}' test
16

docker container exec test cat /sys/fs/cgroup/pids/pids.max
16
```
