### PR TITLE
Add new PidsLimit options to API version history

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -460,7 +460,8 @@ definitions:
         type: "boolean"
         x-nullable: true
       PidsLimit:
-        description: "Tune a container's pids limit. Set 0 or -1 for unlimited. Leave null to not change"
+        description: |
+          Tune a container's PIDs limit. Set `0` or `-1` for unlimited, or `null` to not change.
         type: "integer"
         format: "int64"
         x-nullable: true

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -334,7 +334,7 @@ type Resources struct {
 	MemorySwap           int64           // Total memory usage (memory + swap); set `-1` to enable unlimited swap
 	MemorySwappiness     *int64          // Tuning container memory swappiness behaviour
 	OomKillDisable       *bool           // Whether to disable OOM Killer or not
-	PidsLimit            *int64          // Setting pids limit for a container
+	PidsLimit            *int64          // Setting PIDs limit for a container; Set `0` or `-1` for unlimited, or `null` to not change.
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
 
 	// Applicable to Windows

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -43,6 +43,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   `BindOptions.NonRecursive`.
 * `POST /swarm/init` now accepts a `DataPathPort` property to set data path port number.
 * `GET /info` now returns information about `DataPathPort` that is currently used in swarm
+* `GET /info` now returns `PidsLimit` boolean to indicate if the host kernel has
+  PID limit support enabled.
+
 * `GET /swarm` endpoint now returns DataPathPort info
 * `POST /containers/create` now takes `KernelMemoryTCP` field to set hard limit for kernel TCP buffer memory.
 * `GET /service` now  returns `MaxReplicas` as part of the `Placement`.
@@ -50,8 +53,12 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /service/create` and `POST /services/(id or name)/update` now take the field `MaxReplicas`
   as part of the service `Placement`, allowing to specify maximum replicas per node for the service.
 * `GET /containers` now returns `Capabilities` field as part of the `HostConfig`.
-* `GET /containers/{id}` now returns `Capabilities` field as part of the `HostConfig`.
-* `POST /containers/create` now takes `Capabilities` field to set exact list kernel capabilities to be available for      container (this overrides the default set).
+* `GET /containers/{id}` now returns a `Capabilities` field as part of the `HostConfig`.
+* `POST /containers/create` now takes a `Capabilities` field to set the list of
+  kernel capabilities to be available for the container (this overrides the default
+  set).
+* `POST /containers/{id}/update` now accepts a `PidsLimit` field to tune a container's
+  PID limit. Set `0` or `-1` for unlimited. Leave `null` to not change the current value.
 
 ## V1.39 API changes
 


### PR DESCRIPTION
follow-up to https://github.com/moby/moby/pull/32519 to update the API version history; Also made some minor tweaks to the swagger and GoDoc