### PR TITLE
Increase grpc limit for GetConfigs api

### DIFF
--- a/daemon/cluster/configs.go
+++ b/daemon/cluster/configs.go
@@ -7,6 +7,7 @@ import (
 	types "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/daemon/cluster/convert"
 	swarmapi "github.com/docker/swarmkit/api"
+	"google.golang.org/grpc"
 )
 
 // GetConfig returns a config from a managed swarm cluster
@@ -44,7 +45,8 @@ func (c *Cluster) GetConfigs(options apitypes.ConfigListOptions) ([]types.Config
 	defer cancel()
 
 	r, err := state.controlClient.ListConfigs(ctx,
-		&swarmapi.ListConfigsRequest{Filters: filters})
+		&swarmapi.ListConfigsRequest{Filters: filters},
+		grpc.MaxCallRecvMsgSize(defaultRecvSizeForListResponse))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Dani Louca <dani.louca@docker.com>

```
unable to list existing configs: Error response from daemon: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (14514307 vs. 4194304)
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This is change complements https://github.com/moby/moby/pull/38103 and increase the GRP limit the same way for list configs 

**- How I did it**
Used the same approach as in https://github.com/moby/moby/pull/38103

**- How to verify it**
Create a large list of configs to bypass the 4MB default GRPC limit and run `docker config ls`

**- Description for the changelog**
Increase GRPC limit for GetConfigs

