### PR TITLE
Had `HasExperimental()` to cluster backend

### DIFF
--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -61,6 +61,7 @@ type Backend interface {
 	PluginManager() *plugin.Manager
 	PluginGetter() *plugin.Store
 	GetAttachmentStore() *networkSettings.AttachmentStore
+	HasExperimental() bool
 }
 
 // VolumeBackend is used by an executor to perform volume operations

--- a/daemon/cluster/executor/container/executor.go
+++ b/daemon/cluster/executor/container/executor.go
@@ -229,8 +229,7 @@ func (e *executor) Controller(t *api.Task) (exec.Controller, error) {
 		}
 		switch runtimeKind {
 		case string(swarmtypes.RuntimePlugin):
-			info, _ := e.backend.SystemInfo()
-			if !info.ExperimentalBuild {
+			if !e.backend.HasExperimental() {
 				return ctlr, fmt.Errorf("runtime type %q only supported in experimental", swarmtypes.RuntimePlugin)
 			}
 			c, err := plugin.NewController(e.pluginBackend, t)

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -144,8 +144,7 @@ func (c *Cluster) CreateService(s types.ServiceSpec, encodedAuth string, queryRe
 		case *swarmapi.TaskSpec_Generic:
 			switch serviceSpec.Task.GetGeneric().Kind {
 			case string(types.RuntimePlugin):
-				info, _ := c.config.Backend.SystemInfo()
-				if !info.ExperimentalBuild {
+				if !c.config.Backend.HasExperimental() {
 					return fmt.Errorf("runtime type %q only supported in experimental", types.RuntimePlugin)
 				}
 				if s.TaskTemplate.PluginSpec == nil {


### PR DESCRIPTION
It's already defined on the daemon. This allows us to not call
`SystemInfo` which is failry heavy and potentially can even error.

Takes care of todo item from Derek's containerd integration PR.
https://github.com/moby/moby/blob/51c412f26e03ac564ace2de5a8a43c900ef80ef7/daemon/cluster/services.go#L148-L149