### PR TITLE
Fix problem with go 1.12

### DIFF
--- a/pkg/system/mknod.go
+++ b/pkg/system/mknod.go
@@ -9,7 +9,7 @@ import (
 // Mknod creates a filesystem node (file, device special file or named pipe) named path
 // with attributes specified by mode and dev.
 func Mknod(path string, mode uint32, dev int) error {
-	return unix.Mknod(path, mode, dev)
+	return unix.Mknod(path, mode, uint64(dev))
 }
 
 // Mkdev is used to build the value of linux devices (in /dev/) which specifies major


### PR DESCRIPTION
While trying to compile gitlab-runner which includes this package the following error message is displayed:
```
===>  Building for gitlab-runner-11.7.0
executors/docker/bindata.go
# github.com/docker/docker/pkg/system
src/github.com/docker/docker/pkg/system/mknod.go:12:22: cannot use dev (type int) as type uint64 in argument to syscall.Mknod
*** Error code 2
```

The patch was provided here: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=236131
