### PR TITLE
api: fix description about logs

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5177,15 +5177,15 @@ paths:
         Note: This endpoint works only for containers with the `json-file` or `journald` logging driver.
       operationId: "ContainerLogs"
       responses:
-        101:
-          description: "logs returned as a stream"
+        200:
+          description: |
+                  logs returned as a stream in response body.
+                  For the stream format, [see the documentation for the attach endpoint](#operation/ContainerAttach).
+                  Note that unlike the attach endpoint, the logs endpoint does not upgrade the connection and does not
+                  set Content-Type.
           schema:
             type: "string"
             format: "binary"
-        200:
-          description: "logs returned as a string in response body"
-          schema:
-            type: "string"
         404:
           description: "no such container"
           schema:
@@ -5205,10 +5205,7 @@ paths:
           type: "string"
         - name: "follow"
           in: "query"
-          description: |
-            Return the logs as a stream.
-
-            This will return a `101` HTTP response with a `Connection: upgrade` header, then hijack the HTTP connection to send raw output. For more information about hijacking and the stream format, [see the documentation for the attach endpoint](#operation/ContainerAttach).
+          description: "Keep connection after returning logs."
           type: "boolean"
           default: false
         - name: "stdout"
@@ -9569,23 +9566,16 @@ paths:
     get:
       summary: "Get service logs"
       description: |
-        Get `stdout` and `stderr` logs from a service.
+        Get `stdout` and `stderr` logs from a service. See also [`/containers/{id}/logs`](#operation/ContainerLogs).
 
-        **Note**: This endpoint works only for services with the `json-file` or `journald` logging drivers.
+        **Note**: This endpoint works only for services with the `local`, `json-file` or `journald` logging drivers.
       operationId: "ServiceLogs"
-      produces:
-        - "application/vnd.docker.raw-stream"
-        - "application/json"
       responses:
-        101:
-          description: "logs returned as a stream"
+        200:
+          description: "logs returned as a stream in response body"
           schema:
             type: "string"
             format: "binary"
-        200:
-          description: "logs returned as a string in response body"
-          schema:
-            type: "string"
         404:
           description: "no such service"
           schema:
@@ -9614,10 +9604,7 @@ paths:
           default: false
         - name: "follow"
           in: "query"
-          description: |
-            Return the logs as a stream.
-
-            This will return a `101` HTTP response with a `Connection: upgrade` header, then hijack the HTTP connection to send raw output. For more information about hijacking and the stream format, [see the documentation for the attach endpoint](#operation/ContainerAttach).
+          description: "Keep connection after returning logs."
           type: "boolean"
           default: false
         - name: "stdout"
@@ -9826,23 +9813,16 @@ paths:
     get:
       summary: "Get task logs"
       description: |
-        Get `stdout` and `stderr` logs from a task.
+        Get `stdout` and `stderr` logs from a task. See also [`/containers/{id}/logs`](#operation/ContainerLogs).
 
-        **Note**: This endpoint works only for services with the `json-file` or `journald` logging drivers.
+        **Note**: This endpoint works only for services with the `local`, `json-file` or `journald` logging drivers.
       operationId: "TaskLogs"
-      produces:
-        - "application/vnd.docker.raw-stream"
-        - "application/json"
       responses:
-        101:
-          description: "logs returned as a stream"
+        200:
+          description: "logs returned as a stream in response body"
           schema:
             type: "string"
             format: "binary"
-        200:
-          description: "logs returned as a string in response body"
-          schema:
-            type: "string"
         404:
           description: "no such task"
           schema:
@@ -9871,10 +9851,7 @@ paths:
           default: false
         - name: "follow"
           in: "query"
-          description: |
-            Return the logs as a stream.
-
-            This will return a `101` HTTP response with a `Connection: upgrade` header, then hijack the HTTP connection to send raw output. For more information about hijacking and the stream format, [see the documentation for the attach endpoint](#operation/ContainerAttach).
+          description: "Keep connection after returning logs."
           type: "boolean"
           default: false
         - name: "stdout"


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

The documentation says http hijack is used for  `follow=1` but it doesn't seem actually used:

```console
$ docker run -d --name foo busybox sh -c "while sleep 1; do date; done"
$ sudo curl --include -sN --unix-socket /var/run/docker.sock 'http://docker/containers/foo/logs?stdout=1&stderr=1&follow=1' | hexdump -C
00000000  48 54 54 50 2f 31 2e 31  20 32 30 30 20 4f 4b 0d  |HTTP/1.1 200 OK.|
00000010  0a 41 70 69 2d 56 65 72  73 69 6f 6e 3a 20 31 2e  |.Api-Version: 1.|
00000020  34 30 0d 0a 44 6f 63 6b  65 72 2d 45 78 70 65 72  |40..Docker-Exper|
00000030  69 6d 65 6e 74 61 6c 3a  20 74 72 75 65 0d 0a 4f  |imental: true..O|
00000040  73 74 79 70 65 3a 20 6c  69 6e 75 78 0d 0a 53 65  |stype: linux..Se|
00000050  72 76 65 72 3a 20 44 6f  63 6b 65 72 2f 6d 61 73  |rver: Docker/mas|
00000060  74 65 72 2d 64 6f 63 6b  65 72 70 72 6f 6a 65 63  |ter-dockerprojec|
00000070  74 2d 32 30 31 39 2d 30  32 2d 32 36 20 28 6c 69  |t-2019-02-26 (li|
00000080  6e 75 78 29 0d 0a 44 61  74 65 3a 20 53 61 74 2c  |nux)..Date: Sat,|
00000090  20 30 32 20 4d 61 72 20  32 30 31 39 20 30 38 3a  | 02 Mar 2019 08:|
000000a0  31 30 3a 31 32 20 47 4d  54 0d 0a 54 72 61 6e 73  |10:12 GMT..Trans|
000000b0  66 65 72 2d 45 6e 63 6f  64 69 6e 67 3a 20 63 68  |fer-Encoding: ch|
000000c0  75 6e 6b 65 64 0d 0a 0d  0a 01 00 00 00 00 00 00  |unked...........|
000000d0  1d 53 61 74 20 4d 61 72  20 20 32 20 30 38 3a 30  |.Sat Mar  2 08:0|
000000e0  38 3a 34 32 20 55 54 43  20 32 30 31 39 0a 01 00  |8:42 UTC 2019...|
000000f0  00 00 00 00 00 1d 53 61  74 20 4d 61 72 20 20 32  |......Sat Mar  2|
00000100  20 30 38 3a 30 38 3a 34  33 20 55 54 43 20 32 30  | 08:08:43 UTC 20|
00000110  31 39 0a 01 00 00 00 00  00 00 1d 53 61 74 20 4d  |19.........Sat M|
```

Also, `follow=0` produces the same binary stream except that the connection is closed after returning the latest buffer.

@cpuguy83 @thaJeztah PTAL. 
Not sure the docs were wrong from the birth or the implementation was changed later.

