### PR TITLE
Fix COPY --from with userns and non zero uid/gid files

### DIFF
--- a/pkg/containerfs/archiver.go
+++ b/pkg/containerfs/archiver.go
@@ -186,8 +186,8 @@ func (archiver *Archiver) IdentityMapping() *idtools.IdentityMapping {
 }
 
 func remapIDs(idMapping *idtools.IdentityMapping, hdr *tar.Header) error {
-	ids, err := idMapping.ToHost(idtools.Identity{UID: hdr.Uid, GID: hdr.Gid})
-	hdr.Uid, hdr.Gid = ids.UID, ids.GID
+	var err error
+	hdr.Uid, hdr.Gid, err = idMapping.ToContainer(idtools.Identity{UID: hdr.Uid, GID: hdr.Gid})
 	return err
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed using `COPY --from` with userns enabled and files that have non-zero UID/GID.

```dockerfile
FROM busybox AS foo
RUN touch x && chown 1:1 x

FROM busybox
COPY --from=foo x /
```

**- How I did it**
Modified `remapIDs` to map from host to container instead of container to host.

**- How to verify it**
Need to make sure there isn't a code path that does need this to map from container->host, as than I'm unsure how to fix this and it will obviously break that.

The described `Dockerfile` can be made into a test, but I was unsure on where to place it.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix `COPY --from` with userns and non-zero UID/GID files.

Fixes #34645 