### PR TITLE
image: do actual RootFS.DiffIDs copying in Clone()

### DIFF
--- a/image/rootfs.go
+++ b/image/rootfs.go
@@ -38,7 +38,7 @@ func (r *RootFS) Append(id layer.DiffID) {
 func (r *RootFS) Clone() *RootFS {
 	newRoot := NewRootFS()
 	newRoot.Type = r.Type
-	newRoot.DiffIDs = append(r.DiffIDs)
+	newRoot.DiffIDs = append([]layer.DiffID{}, r.DiffIDs...)
 	return newRoot
 }
 

--- a/image/rootfs.go
+++ b/image/rootfs.go
@@ -38,8 +38,8 @@ func (r *RootFS) Append(id layer.DiffID) {
 func (r *RootFS) Clone() *RootFS {
 	newRoot := NewRootFS()
 	newRoot.Type = r.Type
-newRoot.DiffIDs = make([]layer.DiffID, len(r.DiffIDs)
-copy(newRoot.DiffIDs, r.DiffIDs)
+	newRoot.DiffIDs = make([]layer.DiffID, len(r.DiffIDs)
+	copy(newRoot.DiffIDs, r.DiffIDs)
 	return newRoot
 }
 

--- a/image/rootfs.go
+++ b/image/rootfs.go
@@ -38,7 +38,7 @@ func (r *RootFS) Append(id layer.DiffID) {
 func (r *RootFS) Clone() *RootFS {
 	newRoot := NewRootFS()
 	newRoot.Type = r.Type
-	newRoot.DiffIDs = make([]layer.DiffID, len(r.DiffIDs)
+	newRoot.DiffIDs = make([]layer.DiffID, len(r.DiffIDs))
 	copy(newRoot.DiffIDs, r.DiffIDs)
 	return newRoot
 }

--- a/image/rootfs.go
+++ b/image/rootfs.go
@@ -38,7 +38,8 @@ func (r *RootFS) Append(id layer.DiffID) {
 func (r *RootFS) Clone() *RootFS {
 	newRoot := NewRootFS()
 	newRoot.Type = r.Type
-	newRoot.DiffIDs = append([]layer.DiffID{}, r.DiffIDs...)
+newRoot.DiffIDs = make([]layer.DiffID, len(r.DiffIDs)
+copy(newRoot.DiffIDs, r.DiffIDs)
 	return newRoot
 }
 


### PR DESCRIPTION
append(newRoot.DiffIDs) without element does nothing,
so it's probably not what was intended. Changed code 
to perform a slice copying instead.

Fixes #38834.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>

