### PR TITLE
TestDaemonRestartIpcMode: move to integration

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2896,47 +2896,6 @@ func (s *DockerDaemonSuite) TestDaemonStartWithIpcModes(c *check.C) {
 	}
 }
 
-// TestDaemonRestartIpcMode makes sure a container keeps its ipc mode
-// (derived from daemon default) even after the daemon is restarted
-// with a different default ipc mode.
-func (s *DockerDaemonSuite) TestDaemonRestartIpcMode(c *check.C) {
-	f, err := ioutil.TempFile("", "test-daemon-ipc-config-restart")
-	c.Assert(err, checker.IsNil)
-	file := f.Name()
-	defer os.Remove(file)
-	c.Assert(f.Close(), checker.IsNil)
-
-	config := []byte(`{"default-ipc-mode": "private"}`)
-	c.Assert(ioutil.WriteFile(file, config, 0644), checker.IsNil)
-	s.d.StartWithBusybox(c, "--config-file", file)
-
-	// check the container is created with private ipc mode as per daemon default
-	name := "ipc1"
-	_, err = s.d.Cmd("run", "-d", "--name", name, "--restart=always", "busybox", "top")
-	c.Assert(err, checker.IsNil)
-	m, err := s.d.InspectField(name, ".HostConfig.IpcMode")
-	c.Assert(err, check.IsNil)
-	c.Assert(m, checker.Equals, "private")
-
-	// restart the daemon with shareable default ipc mode
-	config = []byte(`{"default-ipc-mode": "shareable"}`)
-	c.Assert(ioutil.WriteFile(file, config, 0644), checker.IsNil)
-	s.d.Restart(c, "--config-file", file)
-
-	// check the container is still having private ipc mode
-	m, err = s.d.InspectField(name, ".HostConfig.IpcMode")
-	c.Assert(err, check.IsNil)
-	c.Assert(m, checker.Equals, "private")
-
-	// check a new container is created with shareable ipc mode as per new daemon default
-	name = "ipc2"
-	_, err = s.d.Cmd("run", "-d", "--name", name, "busybox", "top")
-	c.Assert(err, checker.IsNil)
-	m, err = s.d.InspectField(name, ".HostConfig.IpcMode")
-	c.Assert(err, check.IsNil)
-	c.Assert(m, checker.Equals, "shareable")
-}
-
 // TestFailedPluginRemove makes sure that a failed plugin remove does not block
 // the daemon from starting
 func (s *DockerDaemonSuite) TestFailedPluginRemove(c *check.C) {

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/test/request"
@@ -96,12 +95,11 @@ func TestKillWithStopSignalAndRestartPolicies(t *testing.T) {
 		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			ctx := context.Background()
-			id := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
-				c.Config.StopSignal = tc.stopsignal
-				c.HostConfig.RestartPolicy = containertypes.RestartPolicy{
-					Name: "always",
-				}
-			})
+			id := container.Run(t, ctx, client,
+				container.WithRestartPolicy("always"),
+				func(c *container.TestContainerConfig) {
+					c.Config.StopSignal = tc.stopsignal
+				})
 			err := client.ContainerKill(ctx, id, "TERM")
 			assert.NilError(t, err)
 

--- a/integration/container/stop_test.go
+++ b/integration/container/stop_test.go
@@ -17,9 +17,11 @@ func TestStopContainerWithRestartPolicyAlways(t *testing.T) {
 
 	names := []string{"verifyRestart1-" + t.Name(), "verifyRestart2-" + t.Name()}
 	for _, name := range names {
-		container.Run(t, ctx, client, container.WithName(name), container.WithCmd("false"), func(c *container.TestContainerConfig) {
-			c.HostConfig.RestartPolicy.Name = "always"
-		})
+		container.Run(t, ctx, client,
+			container.WithName(name),
+			container.WithCmd("false"),
+			container.WithRestartPolicy("always"),
+		)
 	}
 
 	for _, name := range names {

--- a/integration/container/update_test.go
+++ b/integration/container/update_test.go
@@ -50,9 +50,7 @@ func TestUpdateRestartWithAutoRemove(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
-		c.HostConfig.AutoRemove = true
-	})
+	cID := container.Run(t, ctx, client, container.WithAutoRemove)
 
 	_, err := client.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
 		RestartPolicy: containertypes.RestartPolicy{

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -128,17 +128,11 @@ func WithIPv6(network, ip string) func(*TestContainerConfig) {
 // WithLogDriver sets the log driver to use for the container
 func WithLogDriver(driver string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {
-		if c.HostConfig == nil {
-			c.HostConfig = &containertypes.HostConfig{}
-		}
 		c.HostConfig.LogConfig.Type = driver
 	}
 }
 
 // WithAutoRemove sets the container to be removed on exit
 func WithAutoRemove(c *TestContainerConfig) {
-	if c.HostConfig == nil {
-		c.HostConfig = &containertypes.HostConfig{}
-	}
 	c.HostConfig.AutoRemove = true
 }

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -136,3 +136,10 @@ func WithLogDriver(driver string) func(*TestContainerConfig) {
 func WithAutoRemove(c *TestContainerConfig) {
 	c.HostConfig.AutoRemove = true
 }
+
+// WithRestartPolicy sets container's restart policy
+func WithRestartPolicy(policy string) func(c *TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.HostConfig.RestartPolicy.Name = policy
+	}
+}


### PR DESCRIPTION
The core of this PR is last commit, which moves the `TestDaemonRestartIpcMode` test case from integration-cli to integration. The test logic itself has not changed, except these two things:
* the new test sets default-ipc-mode via command line rather than via daemon.json (less code);
* the new test uses current API version (which should fix test failure in #38700).

Other commits are some minor cleanups; please see individual commit descriptions for details.
