### PR TITLE
since and until should be epoch time

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4368,6 +4368,17 @@ definitions:
           IP address and ports at which this node can be reached.
         type: "string"
 
+  UnixTimestampWithNanos:
+    description: |
+      Represents a UNIX timestamp commonly refered to as epoch time with optional nanosecond precision.
+      This is the number of seconds that have elapsed since `1970-01-01T00:00:00Z`.  The `number` notation
+      recognizes up to 9 decimal places `.000000001` being one nanosecond.
+    anyOf:
+      - type: integer
+        format: int64
+      - type: number
+        format: double
+    example: 1552404408.123456789
 paths:
   /containers/json:
     get:
@@ -7338,12 +7349,16 @@ paths:
       parameters:
         - name: "since"
           in: "query"
-          description: "Show events created since this timestamp then stream new events."
-          type: "string"
+          description: "Show events created since this timestamp then stream new events. This is a UNIX timestamp with nanosecond precision."
+          schema:
+            $ref: "#/definitions/UnixTimestampWithNanos"
+          example: 1552403443
         - name: "until"
           in: "query"
-          description: "Show events created until this timestamp then stop streaming."
-          type: "string"
+          description: "Show events created until this timestamp then stop streaming. This is a UNIX timestamp with nanosecond precision."
+          schema:
+            $ref: "#/definitions/UnixTimestampWithNanos"
+          example: 1552403443.123456789
         - name: "filters"
           in: "query"
           description: |

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4375,7 +4375,6 @@ definitions:
       recognizes up to 9 decimal places `.000000001` being one nanosecond.
     type: number
     format: double
-    example: 1552404408.123456789
 paths:
   /containers/json:
     get:
@@ -7347,15 +7346,11 @@ paths:
         - name: "since"
           in: "query"
           description: "Show events created since this timestamp then stream new events. This is a UNIX timestamp with nanosecond precision."
-          schema:
-            $ref: "#/definitions/UnixTimestampWithNanos"
-          example: 1552403443
+          $ref: "#/definitions/UnixTimestampWithNanos"
         - name: "until"
           in: "query"
           description: "Show events created until this timestamp then stop streaming. This is a UNIX timestamp with nanosecond precision."
-          schema:
-            $ref: "#/definitions/UnixTimestampWithNanos"
-          example: 1552403443.123456789
+          $ref: "#/definitions/UnixTimestampWithNanos"
         - name: "filters"
           in: "query"
           description: |

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4373,11 +4373,8 @@ definitions:
       Represents a UNIX timestamp commonly refered to as epoch time with optional nanosecond precision.
       This is the number of seconds that have elapsed since `1970-01-01T00:00:00Z`.  The `number` notation
       recognizes up to 9 decimal places `.000000001` being one nanosecond.
-    anyOf:
-      - type: integer
-        format: int64
-      - type: number
-        format: double
+    type: number
+    format: double
     example: 1552404408.123456789
 paths:
   /containers/json:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Tried using ISO Date time format but it failed with the API call.  The error looked like it was doing a string to integer conversion.  I surmised that this is epoch time.

**- How I did it**
Changed the documentation

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Corrected `since` and `until` API documentation to match implementation


**- A picture of a cute animal (not mandatory but encouraged)**

