### PR TITLE
Fixes for reading journald logs

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -21,7 +21,6 @@ type journald struct {
 	mu      sync.Mutex
 	vars    map[string]string // additional variables and values to send to the journal along with the log message
 	readers map[*logger.LogWatcher]struct{}
-	closed  bool
 }
 
 func init() {

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -216,12 +216,12 @@ drain:
 			// the stream that we would have
 			// assigned that value.
 			source := ""
-			if C.get_priority(j, &priority) != 0 {
-				source = ""
-			} else if priority == C.int(journal.PriErr) {
-				source = "stderr"
-			} else if priority == C.int(journal.PriInfo) {
-				source = "stdout"
+			if C.get_priority(j, &priority) == 0 {
+				if priority == C.int(journal.PriErr) {
+					source = "stderr"
+				} else if priority == C.int(journal.PriInfo) {
+					source = "stdout"
+				}
 			}
 			// Retrieve the values of any variables we're adding to the journal.
 			var attrs []backend.LogAttr

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -330,12 +330,12 @@ func (s *journald) readLogs(logWatcher *logger.LogWatcher, config logger.ReadCon
 	// here, potentially while the goroutine that uses them is still
 	// running.  Otherwise, close them when we return from this function.
 	following := false
-	defer func(pfollowing *bool) {
-		if !*pfollowing {
+	defer func() {
+		if !following {
 			close(logWatcher.Msg)
 		}
 		C.sd_journal_close(j)
-	}(&following)
+	}()
 	// Remove limits on the size of data items that we'll retrieve.
 	rc = C.sd_journal_set_data_threshold(j, C.size_t(0))
 	if rc != 0 {


### PR DESCRIPTION
closes https://github.com/moby/moby/pull/39305
closes https://github.com/moby/moby/pull/36254
fixes https://github.com/moby/moby/issues/27343
fixes https://github.com/docker/for-linux/issues/575


This series is an attempt to straighten out journald log reading (i.e using `docker logs` for a container with journald log driver. In particular, it should fix at least two issues:
* https://github.com/moby/moby/issues/27343 (stale opened fd when the journal is frequently rotated and/or the reader is following for a long time);
* https://github.com/docker/for-linux/issues/575 (`docker logs --follow` not exiting once a container is gone).

In addition, it should improve code readability and fix some minor bugs, like
* `docker logs --tail=0` not working properly (which seems to be useless until one adds `--follow`);
* `docker logs --since` off-by-one record wrt timestamps;
* (potential?) goroutine leak when a following reader disappears early (same as https://github.com/moby/moby/issues/37391 but for journald).

Finally, this PR reduces the code size a bit:
>  2 files changed, 108 insertions(+), 159 deletions(-)

## Testing notes

Note that current CI does not test journald log driver in any way (which might be the reason why it's in so unfortunate state). Therefore, I have tested the results manually and also by running all `TestLogs*` tests from the `integration-cli/` (the result is, a number of test case failures decreased substiantially).

A potential followup to this PR would be to move the above mentioned tests to integration, and make sure CI runs those with log drivers other than the default (`json-file`).

## Known bugs

NOTE: _These are not newly introduced bugs; they were there before and are not fixed by this PR_

* `--follow` is impossible to implement entirely correct due to async nature of journald log writing; therefore it's possible that it would end up earlier than all the container logs are shown. The possibility of this depends on the system load (mostly I/O) as well as the value of `waitTimeout` in `followJournal()`.

* because of the above, `--follow` does not exits immediately, there's a waiting period which amounts to about a second;

* sometimes reading container logs right after it has finished (such as in `docker wait $ID && docker logs $ID`) does not produce any output; the reason is the same async nature of the journald writing.

* In some corner cases `\n` is lost from the logs; here's a repro:
```sh
$ ID=$(docker run -d busybox sh -c 'for i in $(seq 1 32767); do echo -n = >> a.a; done; echo >> a.a; cat a.a'); docker wait $ID; sleep 1; docker logs $ID | od -c
0
0000000   =   =   =   =   =   =   =   =   =   =   =   =   =   =   =   =
*
0077760   =   =   =   =   =   =   =   =   =   =   =   =   =   =   =  \n
0100000

$ ID=$(docker run -d busybox sh -c 'for i in $(seq 1 32768); do echo -n = >> a.a; done; echo >> a.a; cat a.a'); docker wait $ID; sleep 1; docker logs $ID | od -c
0
0000000   =   =   =   =   =   =   =   =   =   =   =   =   =   =   =   =
*
0100000

$ ID=$(docker run -d busybox sh -c 'for i in $(seq 1 32769); do echo -n = >> a.a; done; echo >> a.a; cat a.a'); docker wait $ID; sleep 1; docker logs $ID | od -c
0
0000000   =   =   =   =   =   =   =   =   =   =   =   =   =   =   =   =
*
0100000   =  \n
0100002
```

Note in the second run (the one with `seq 1 32768`) the `\n` in the end is lost. There is the same bug in local driver for `seq 1 16384` or more, and I guess it's not super critical.

This work is partially based on prior PR https://github.com/moby/moby/pull/36254 by @nalind

## A picture of a cute animal

![image](https://user-images.githubusercontent.com/4522509/54254880-d19d8500-4512-11e9-88c1-cedb344d855b.png)
_image source: https://www.youtube.com/watch?v=K9e3Ime75C0_