### PR TITLE
Return a warning when running in a two-manager setup

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -50,6 +50,7 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 	}
 	if s.cluster != nil {
 		info.Swarm = s.cluster.Info()
+		info.Warnings = append(info.Warnings, info.Swarm.Warnings...)
 	}
 
 	if versions.LessThan(httputils.VersionFromContext(ctx), "1.25") {

--- a/api/types/swarm/swarm.go
+++ b/api/types/swarm/swarm.go
@@ -209,6 +209,8 @@ type Info struct {
 	Managers       int `json:",omitempty"`
 
 	Cluster *ClusterInfo `json:",omitempty"`
+
+	Warnings []string `json:",omitempty"`
 }
 
 // Peer represents a peer.

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -459,6 +459,20 @@ func (c *Cluster) Info() types.Info {
 				}
 			}
 		}
+
+		switch info.LocalNodeState {
+		case types.LocalNodeStateInactive, types.LocalNodeStateLocked, types.LocalNodeStateError:
+			// nothing to do
+		default:
+			if info.Managers == 2 {
+				const warn string = `WARNING: Running Swarm in a two-manager configuration. This configuration provides
+         no fault tolerance, and poses a high risk to loose control over the cluster.
+         Refer to https://docs.docker.com/engine/swarm/admin_guide/ to configure the
+         Swarm for fault-tolerance.`
+
+				info.Warnings = append(info.Warnings, warn)
+			}
+		}
 	}
 
 	if state.swarmNode != nil {


### PR DESCRIPTION
daemon-side implementation of https://github.com/docker/cli/pull/422

Running a cluster in a two-manager configuration effectively *doubles*
the chance of loosing control over the cluster (compared to running
in a single-manager setup). Users may have the assumption that having
two managers provides fault tolerance, so it's best to warn them if
they're using this configuration.

This patch adds a warning to the `info` response if Swarm is configured
with two managers:

    WARNING: Running Swarm in a two-manager configuration. This configuration provides
             no fault tolerance, and poses a high risk to loose control over the cluster.
             Refer to https://docs.docker.com/engine/swarm/admin_guide/ to configure the
             Swarm for fault-tolerance.

