### PR TITLE
seccomp: whitelist io_pgetevents()

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -162,6 +162,7 @@
 				"ioctl",
 				"io_destroy",
 				"io_getevents",
+				"io_pgetevents",
 				"ioprio_get",
 				"ioprio_set",
 				"io_setup",

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -155,6 +155,7 @@ func DefaultProfile() *types.Seccomp {
 				"ioctl",
 				"io_destroy",
 				"io_getevents",
+				"io_pgetevents",
 				"ioprio_get",
 				"ioprio_set",
 				"io_setup",


### PR DESCRIPTION
io_pgetevents() is a new Linux system call. It is similar to io_getevents()
that is already whitelisted, and adds no special abilities over that system call.

Allow that system call to enable applications that use it.

Fixes #38894.

Signed-off-by: Avi Kivity <avi@scylladb.com>

