### PR TITLE
builder-next: fix squash

### DIFF
--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -82,8 +82,8 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 	if !useBuildKit {
 		stdout := config.ProgressWriter.StdoutFormatter
 		fmt.Fprintf(stdout, "Successfully built %s\n", stringid.TruncateID(imageID))
-		err = tagger.TagImages(image.ID(imageID))
 	}
+	err = tagger.TagImages(image.ID(imageID))
 	return imageID, err
 }
 


### PR DESCRIPTION
Tagger was not called for BuildKit-mode.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed `DOCKER_BUILDKIT=1 docker build --squash`.
Previously, squash itself was working but the resulting image in the store was not tagged with the squashed image ID.

**- How I did it**

Call `tagger.TagImages`

**- How to verify it**

`DOCKER_BUILDKIT=1 docker build --squash`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
builder-next: fix squash

**- A picture of a cute animal (not mandatory but encouraged)**
:penguin: