### PR TITLE
ContainerCreate shouldn't return warnings=nil

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -96,6 +96,10 @@ func (daemon *Daemon) containerCreate(opts createOpts) (containertypes.Container
 	}
 	containerActions.WithValues("create").UpdateSince(start)
 
+	if warnings == nil {
+		warnings = make([]string, 0) // Create an empty slice to avoid https://github.com/moby/moby/issues/38222
+	}
+
 	return containertypes.ContainerCreateCreatedBody{ID: container.ID, Warnings: warnings}, nil
 }
 


### PR DESCRIPTION
Fixes #38222
Closes #38614 (carried)

Signed-off-by: Tibor Vass <tibor@docker.com>