### PR TITLE
Use fewer modprobes

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -540,8 +540,14 @@ func xfsSupported() error {
 		return err // error text is descriptive enough
 	}
 
-	// Check if kernel supports xfs filesystem or not.
-	exec.Command("modprobe", "xfs").Run()
+	mountTarget, err := ioutil.TempDir("", "supportsXFS")
+	if err != nil {
+		return errors.Wrapf(err, "error checking for xfs support")
+	}
+
+	/* The mounting will fail--after the module has been loaded.*/
+	defer os.RemoveAll(mountTarget)
+	unix.Mount("none", mountTarget, "xfs", 0, "")
 
 	f, err := os.Open("/proc/filesystems")
 	if err != nil {

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -201,9 +200,15 @@ func parseOptions(options []string) (*overlayOptions, error) {
 }
 
 func supportsOverlay() error {
-	// We can try to modprobe overlay first before looking at
-	// proc/filesystems for when overlay is supported
-	exec.Command("modprobe", "overlay").Run()
+	// Access overlay filesystem so that Linux loads it (if possible).
+	mountTarget, err := ioutil.TempDir("", "supportsOverlay")
+	if err != nil {
+		logrus.WithError(err).WithField("storage-driver", "overlay2").Error("could not create temporary directory, so assuming that 'overlay' is not supported")
+		return graphdriver.ErrNotSupported
+	}
+	/* The mounting will fail--after the module has been loaded.*/
+	defer os.RemoveAll(mountTarget)
+	unix.Mount("overlay", mountTarget, "overlay", 0, "")
 
 	f, err := os.Open("/proc/filesystems")
 	if err != nil {

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -273,9 +272,15 @@ func parseOptions(options []string) (*overlayOptions, error) {
 }
 
 func supportsOverlay() error {
-	// We can try to modprobe overlay first before looking at
-	// proc/filesystems for when overlay is supported
-	exec.Command("modprobe", "overlay").Run()
+	// Access overlay filesystem so that Linux loads it (if possible).
+	mountTarget, err := ioutil.TempDir("", "supportsOverlay2")
+	if err != nil {
+		logrus.WithError(err).WithField("storage-driver", "overlay2").Error("could not create temporary directory, so assuming that 'overlay' is not supported")
+		return graphdriver.ErrNotSupported
+	}
+	/* The mounting will fail--after the module has been loaded.*/
+	defer os.RemoveAll(mountTarget)
+	unix.Mount("overlay", mountTarget, "overlay", 0, "")
 
 	f, err := os.Open("/proc/filesystems")
 	if err != nil {


### PR DESCRIPTION
It's not customary for user space programs to modprobe stuff in general. Modern distributions will autoload modules (if it is indeed a module and not built-in) on access anyway, so it's also not necessary to manually modprobe stuff.

Therefore, this replaces `modprobe` by actual accesses of the devices.

