### PR TITLE
fix: close event message chan

### DIFF
--- a/client/events.go
+++ b/client/events.go
@@ -23,6 +23,7 @@ func (cli *Client) Events(ctx context.Context, options types.EventsOptions) (<-c
 
 	started := make(chan struct{})
 	go func() {
+		defer close(messages)
 		defer close(errs)
 
 		query, err := buildEventsQueryParams(cli.version, options)


### PR DESCRIPTION
I think you guys forgot to close the message event channel since no one can close it outside due to the receive-only channel type.