### PR TITLE
Format code with gofmt -s from go-1.12.1

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1887,7 +1887,7 @@ func (s *DockerSuite) TestRunBindMounts(c *check.C) {
 
 	if testEnv.OSType == "windows" {
 		// Disabled prior to RS5 due to how volumes are mapped
-		testRequires(c,  DaemonIsWindowsAtLeastBuild(17763))
+		testRequires(c, DaemonIsWindowsAtLeastBuild(17763))
 	}
 
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()


### PR DESCRIPTION
This should eliminate a bunch of new (go-1.12.1 related) validation
errors telling that the code is not formatted with `gofmt -s`.

Patch generated with:

> git ls-files | grep -v ^vendor/ | grep .go$ | xargs gofmt -s -w

Signed-off-by: JieJhih Jhang <aawer12345tw@yahoo.com.tw>
