### PR TITLE
gitutils: add validation for ref (CVE-2019-13139)

### DIFF
--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -102,6 +102,11 @@ func parseRemoteURL(remoteURL string) (gitRepo, error) {
 		u.Fragment = ""
 		repo.remote = u.String()
 	}
+
+	if strings.HasPrefix(repo.ref, "-") {
+		return gitRepo{}, errors.Errorf("invalid refspec: %s", repo.ref)
+	}
+
 	return repo, nil
 }
 
@@ -124,7 +129,7 @@ func fetchArgs(remoteURL string, ref string) []string {
 		args = append(args, "--depth", "1")
 	}
 
-	return append(args, "origin", ref)
+	return append(args, "origin", "--", ref)
 }
 
 // Check if a given git URL supports a shallow git clone,


### PR DESCRIPTION
From a fix that @tonistiigi created, this PR adds validation for git ref so it can't be misinterpreted as a flag. `fetch --` is a cleaner option but as it is theoretically possible to also hit it in checkout there's a custom validation as well.

Thanks to @staaldraad for pointing this issue out originally.

cc @justincormack 