### PR TITLE
Update nvidia_devices to call into nvidia-container-runtime-hook

### DIFF
--- a/daemon/nvidia_linux.go
+++ b/daemon/nvidia_linux.go
@@ -39,8 +39,8 @@ func init() {
 		capset:     capset,
 		updateSpec: setNvidiaGPUs,
 	}
-	for c := range capset {
-		nvidiaDriver.capset[c] = struct{}{}
+	for c := range allNvidiaCaps {
+		nvidiaDriver.capset[string(c)] = struct{}{}
 	}
 	registerDeviceDriver("nvidia", nvidiaDriver)
 }

--- a/pkg/capabilities/caps.go
+++ b/pkg/capabilities/caps.go
@@ -19,5 +19,6 @@ anyof:
 		}
 		return andList
 	}
+	// match anything
 	return nil
 }


### PR DESCRIPTION
This PR changes 2 things:
1. We changes the behavior of nvidia_devices to call into nvidia-container-runtime-hook rather than call into the nvidia-container-cli.
2. We fix the nvidia driver's registration which only registered two caps (gpu and nvidia)

The reason 1. is needed is because the the nvidia-container-runtime-hook operates on the nvidia container images (thorugh the [env API](https://github.com/NVIDIA/nvidia-container-runtime#environment-variables-oci-spec)) as well as some other features related to logging, debugging, ...
The nvidia-container-cli does not read the OCI spec, keeping the CLI would have the unfortunate behavior of breaking all the NVIDIA images (nvidia/cuda).

As we move towards a Device Plugin model, the topic of environment variables and how we can transition towards a better model will be one of the main discussion points.
In a future patch this hook binary will be a Device Plugin on it's own and call into the nvidia-container-cli.

Signed-off-by: Renaud Gaubert <rgaubert@nvidia.com>
cc @tiborvass 

Notes after this patch is applied, the following tests passes:
```
nvidia-smi -L
GPU 0: GeForce GTX 1070 (UUID: GPU-604ac76c-d9cf-fef3-62e9-d92044ab6e52)
GPU 1: GeForce GTX 1070 (UUID: GPU-6a2e4b48-c3ac-f34e-df41-88c04acb0709)
sudo ./build/docker run -it --gpus all nvidia/cuda nvidia-smi -L
GPU 0: GeForce GTX 1070 (UUID: GPU-604ac76c-d9cf-fef3-62e9-d92044ab6e52)
GPU 1: GeForce GTX 1070 (UUID: GPU-6a2e4b48-c3ac-f34e-df41-88c04acb0709)
sudo ./build/docker run -it --gpus 1 nvidia/cuda nvidia-smi -L
GPU 0: GeForce GTX 1070 (UUID: GPU-604ac76c-d9cf-fef3-62e9-d92044ab6e52)
sudo ./build/docker run -it --gpus device=1 nvidia/cuda nvidia-smi -L
GPU 0: GeForce GTX 1070 (UUID: GPU-6a2e4b48-c3ac-f34e-df41-88c04acb0709)
sudo ./build/docker run -it --gpus all,capabilities=utility debian:8-slim nvidia-smi -L
GPU 0: GeForce GTX 1070 (UUID: GPU-604ac76c-d9cf-fef3-62e9-d92044ab6e52)
GPU 1: GeForce GTX 1070 (UUID: GPU-6a2e4b48-c3ac-f34e-df41-88c04acb0709)
```

**- A picture of a cute animal (not mandatory but encouraged)**
![maxresdefault](https://user-images.githubusercontent.com/2519571/55039226-973aea00-4fe0-11e9-8eb6-12c65fb92248.jpg)

