### PR TITLE
Workaround for inconsistency container status

### DIFF
--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -157,7 +157,16 @@ func (cli *DaemonCli) initContainerD(ctx context.Context) error {
 				return errors.Wrap(err, "failed to generate containerd options")
 			}
 
-			r, err := supervisor.Start(ctx, filepath.Join(cli.Config.Root, "containerd"), filepath.Join(cli.Config.ExecRoot, "containerd"), opts...)
+			// Check process is running
+			hook := func() {
+				if cli.d == nil {
+					return
+				}
+				for _, c := range cli.d.List() {
+					c.CheckProcessIsRunning()
+				}
+			}
+			r, err := supervisor.Start(ctx, filepath.Join(cli.Config.Root, "containerd"), filepath.Join(cli.Config.ExecRoot, "containerd"), hook, opts...)
 			if err != nil {
 				return errors.Wrap(err, "failed to start containerd")
 			}

--- a/container/state.go
+++ b/container/state.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/system"
 	"github.com/docker/go-units"
 )
 
@@ -241,6 +242,17 @@ func (s *State) IsRunning() bool {
 	res := s.Running
 	s.Unlock()
 	return res
+}
+
+// CheckProcessIsRunning check the the process of running container is still performed.
+func (s *State) CheckProcessIsRunning() {
+	if !s.IsRunning() {
+		return
+	}
+	if !system.IsProcessAlive(s.Pid) {
+		// TODO: force set exitcode:1, better to define new exitcode
+		s.SetStopped(&ExitStatus{ExitCode: 1})
+	}
 }
 
 // GetPID holds the process id of a container.

--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -42,9 +42,10 @@ type remote struct {
 	daemonPid int
 	logger    *logrus.Entry
 
-	daemonWaitCh  chan struct{}
-	daemonStartCh chan error
-	daemonStopCh  chan struct{}
+	daemonWaitCh         chan struct{}
+	daemonStartCh        chan error
+	daemonStopCh         chan struct{}
+	handleContainerdHook func()
 
 	rootDir     string
 	stateDir    string
@@ -61,7 +62,7 @@ type Daemon interface {
 type DaemonOpt func(c *remote) error
 
 // Start starts a containerd daemon and monitors it
-func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (Daemon, error) {
+func Start(ctx context.Context, rootDir, stateDir string, hook func(), opts ...DaemonOpt) (Daemon, error) {
 	r := &remote{
 		rootDir:  rootDir,
 		stateDir: stateDir,
@@ -69,11 +70,12 @@ func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (Da
 			Root:  filepath.Join(rootDir, "daemon"),
 			State: filepath.Join(stateDir, "daemon"),
 		},
-		pluginConfs:   pluginConfigs{make(map[string]interface{})},
-		daemonPid:     -1,
-		logger:        logrus.WithField("module", "libcontainerd"),
-		daemonStartCh: make(chan error, 1),
-		daemonStopCh:  make(chan struct{}),
+		pluginConfs:          pluginConfigs{make(map[string]interface{})},
+		daemonPid:            -1,
+		logger:               logrus.WithField("module", "libcontainerd"),
+		daemonStartCh:        make(chan error, 1),
+		daemonStopCh:         make(chan struct{}),
+		handleContainerdHook: hook,
 	}
 
 	for _, opt := range opts {
@@ -97,7 +99,6 @@ func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (Da
 			return nil, err
 		}
 	}
-
 	return r, nil
 }
 func (r *remote) WaitTimeout(d time.Duration) error {
@@ -281,6 +282,10 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 				continue
 			}
 
+			// Workaround to fix inconsistency stopped status
+			go func() {
+				r.handleContainerdHook()
+			}()
 			client, err = containerd.New(r.GRPC.Address, containerd.WithTimeout(60*time.Second))
 			if err != nil {
 				r.logger.WithError(err).Error("failed connecting to containerd")


### PR DESCRIPTION
**- What I did**
Fix stopped container still report as running. 
https://github.com/moby/moby/issues/38501

**- How I did it**
 When containerd restarted, check correct container running status

**- How to verify it**
```
# dockerd-> containerd -> containerd-shim -> <runc_container_process>

$ docker run xxx
$ docker ps  ## correct, shows one container is up

# simulate the heavy scenario
$ kill -STOP <dockerd_PID>

$ kill <docker-containerd-shim_PID> or kill <runc_container_process_PID>
$ kill <docker-containerd_PID>

$ kill -CONT <dockerd_PID>
$ docker ps  ## wrong, still shows one container is up
```
After, apply the patch, the final docker ps could be correct.

Reference pull request: 
* https://github.com/projectatomic/docker/pull/339