### PR TITLE
 fluentd log driver. failed parse last partial message in fluentd #38951

### DIFF
--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -165,6 +165,9 @@ func (f *fluentd) Log(msg *logger.Message) error {
 	}
 	if msg.PLogMetaData != nil {
 		data["partial_message"] = "true"
+		data["partial_id"] = msg.PLogMetaData.ID
+		data["partial_ordinal"] = strconv.Itoa(msg.PLogMetaData.Ordinal)
+		data["partial_last"] = strconv.FormatBool(msg.PLogMetaData.Last)
 	}
 
 	ts := msg.Timestamp


### PR DESCRIPTION
I use fluentd logging driver
In my containers the log it is more than 16 kb
Such the log are marked with partial_message flag

fluent-plugin-concat waited for the message which came without partial_message from stopped to stick together the message for further transfer


Signed-off-by: Alexei Margasov <alexei38@yandex.ru>
