### PR TITLE
Fixes #38978 should kill all children process when delete the task

### DIFF
--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -515,7 +515,7 @@ func (c *client) DeleteTask(ctx context.Context, containerID string) (uint32, ti
 		return 255, time.Now(), nil
 	}
 
-	status, err := p.(containerd.Task).Delete(ctx)
+	status, err := p.(containerd.Task).Delete(ctx, containerd.WithProcessKill)
 	if err != nil {
 		return 255, time.Now(), nil
 	}


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
Since containerd v1.2.0-rc.0, if we use `PIDNamespace`, the shim service will not call `runc` `KillAll` method to kill all the children process when the container's main process exited.
So, it will cause the issue #38978.

**- How I did it**
To fixes #38978 , we should call `KillAll` when `DeleteTask`. It is safe because there were no two containers with the same cgroup path.
As discussed in https://github.com/containerd/containerd/pull/3149 , we may not remove `pidnamespace` check because containerd should support containers with the same cgroup path.

**- How to verify it**
The container with the same pid namespace can be stopped.

**- Description for the changelog**
add `containerd.WithProcessKill` when delete a task in containerd.
