### PR TITLE
bump libnetwork to ebcade70ad1059b070d0040d798ecca359bc5fed

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=1a06131fb8a047d919f7deaf02a4c414d7884b83
+LIBNETWORK_COMMIT=ebcade70ad1059b070d0040d798ecca359bc5fed
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -39,7 +39,7 @@ github.com/gofrs/flock 7f43ea2e6a643ad441fc12d0ecc0d3388b300c53 # v0.7.0
 #get libnetwork packages
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork 1a06131fb8a047d919f7deaf02a4c414d7884b83
+github.com/docker/libnetwork ebcade70ad1059b070d0040d798ecca359bc5fed
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/agent.go
+++ b/vendor/github.com/docker/libnetwork/agent.go
@@ -378,6 +378,9 @@ func (c *controller) agentClose() {
 	c.agent = nil
 	c.Unlock()
 
+	// when the agent is closed the cluster provider should be cleaned up
+	c.SetClusterProvider(nil)
+
 	if agent == nil {
 		return
 	}

--- a/vendor/github.com/docker/libnetwork/default_gateway.go
+++ b/vendor/github.com/docker/libnetwork/default_gateway.go
@@ -181,10 +181,8 @@ func (c *controller) defaultGwNetwork() (Network, error) {
 	defer func() { <-procGwNetwork }()
 
 	n, err := c.NetworkByName(libnGWNetwork)
-	if err != nil {
-		if _, ok := err.(types.NotFoundError); ok {
-			n, err = c.createGWNetwork()
-		}
+	if _, ok := err.(types.NotFoundError); ok {
+		n, err = c.createGWNetwork()
 	}
 	return n, err
 }

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ip_forwarding.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ip_forwarding.go
@@ -48,7 +48,7 @@ func setupIPForwarding(enableIPTables bool) error {
 		iptables.OnReloaded(func() {
 			logrus.Debug("Setting the default DROP policy on firewall reload")
 			if err := iptables.SetDefaultPolicy(iptables.Filter, "FORWARD", iptables.Drop); err != nil {
-				logrus.Warnf("Settig the default DROP policy on firewall reload failed, %v", err)
+				logrus.Warnf("Setting the default DROP policy on firewall reload failed, %v", err)
 			}
 		})
 	}

--- a/vendor/github.com/docker/libnetwork/drivers_experimental_linux.go
+++ b/vendor/github.com/docker/libnetwork/drivers_experimental_linux.go
@@ -1,9 +1,0 @@
-package libnetwork
-
-import "github.com/docker/libnetwork/drivers/ipvlan"
-
-func additionalDrivers() []initializer {
-	return []initializer{
-		{ipvlan.Init, "ipvlan"},
-	}
-}

--- a/vendor/github.com/docker/libnetwork/drivers_linux.go
+++ b/vendor/github.com/docker/libnetwork/drivers_linux.go
@@ -3,6 +3,7 @@ package libnetwork
 import (
 	"github.com/docker/libnetwork/drivers/bridge"
 	"github.com/docker/libnetwork/drivers/host"
+	"github.com/docker/libnetwork/drivers/ipvlan"
 	"github.com/docker/libnetwork/drivers/macvlan"
 	"github.com/docker/libnetwork/drivers/null"
 	"github.com/docker/libnetwork/drivers/overlay"
@@ -13,14 +14,11 @@ func getInitializers(experimental bool) []initializer {
 	in := []initializer{
 		{bridge.Init, "bridge"},
 		{host.Init, "host"},
+		{ipvlan.Init, "ipvlan"},
 		{macvlan.Init, "macvlan"},
 		{null.Init, "null"},
-		{remote.Init, "remote"},
 		{overlay.Init, "overlay"},
-	}
-
-	if experimental {
-		in = append(in, additionalDrivers()...)
+		{remote.Init, "remote"},
 	}
 	return in
 }

--- a/vendor/github.com/docker/libnetwork/iptables/iptables.go
+++ b/vendor/github.com/docker/libnetwork/iptables/iptables.go
@@ -87,16 +87,11 @@ func initFirewalld() {
 }
 
 func detectIptables() {
-	path, err := exec.LookPath("iptables-legacy") // debian has iptables-legacy and iptables-nft now
+	path, err := exec.LookPath("iptables")
 	if err != nil {
-		path, err = exec.LookPath("iptables")
-		if err != nil {
-			return
-		}
+		return
 	}
-
 	iptablesPath = path
-
 	supportsXlock = exec.Command(iptablesPath, "--wait", "-L", "-n").Run() == nil
 	mj, mn, mc, err := GetVersion()
 	if err != nil {

--- a/vendor/github.com/docker/libnetwork/ipvs/ipvs.go
+++ b/vendor/github.com/docker/libnetwork/ipvs/ipvs.go
@@ -68,6 +68,13 @@ type Destination struct {
 // DstStats defines IPVS destination (real server) statistics
 type DstStats SvcStats
 
+// Config defines IPVS timeout configuration
+type Config struct {
+	TimeoutTCP    time.Duration
+	TimeoutTCPFin time.Duration
+	TimeoutUDP    time.Duration
+}
+
 // Handle provides a namespace specific ipvs handle to program ipvs
 // rules.
 type Handle struct {
@@ -187,4 +194,14 @@ func (i *Handle) GetService(s *Service) (*Service, error) {
 	}
 
 	return res[0], nil
+}
+
+// GetConfig returns the current timeout configuration
+func (i *Handle) GetConfig() (*Config, error) {
+	return i.doGetConfigCmd()
+}
+
+// SetConfig set the current timeout configuration. 0: no change
+func (i *Handle) SetConfig(c *Config) error {
+	return i.doSetConfigCmd(c)
 }

--- a/vendor/github.com/docker/libnetwork/ipvs/netlink.go
+++ b/vendor/github.com/docker/libnetwork/ipvs/netlink.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"github.com/sirupsen/logrus"
@@ -501,6 +502,60 @@ func (i *Handle) doGetDestinationsCmd(s *Service, d *Destination) ([]*Destinatio
 		res = append(res, dest)
 	}
 	return res, nil
+}
+
+// parseConfig given a ipvs netlink response this function will respond with a valid config entry, an error otherwise
+func (i *Handle) parseConfig(msg []byte) (*Config, error) {
+	var c Config
+
+	//Remove General header for this message
+	hdr := deserializeGenlMsg(msg)
+	attrs, err := nl.ParseRouteAttr(msg[hdr.Len():])
+	if err != nil {
+		return nil, err
+	}
+
+	for _, attr := range attrs {
+		attrType := int(attr.Attr.Type)
+		switch attrType {
+		case ipvsCmdAttrTimeoutTCP:
+			c.TimeoutTCP = time.Duration(native.Uint32(attr.Value)) * time.Second
+		case ipvsCmdAttrTimeoutTCPFin:
+			c.TimeoutTCPFin = time.Duration(native.Uint32(attr.Value)) * time.Second
+		case ipvsCmdAttrTimeoutUDP:
+			c.TimeoutUDP = time.Duration(native.Uint32(attr.Value)) * time.Second
+		}
+	}
+
+	return &c, nil
+}
+
+// doGetConfigCmd a wrapper function to be used by GetConfig
+func (i *Handle) doGetConfigCmd() (*Config, error) {
+	msg, err := i.doCmdWithoutAttr(ipvsCmdGetConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := i.parseConfig(msg[0])
+	if err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+// doSetConfigCmd a wrapper function to be used by SetConfig
+func (i *Handle) doSetConfigCmd(c *Config) error {
+	req := newIPVSRequest(ipvsCmdSetConfig)
+	req.Seq = atomic.AddUint32(&i.seq, 1)
+
+	req.AddData(nl.NewRtAttr(ipvsCmdAttrTimeoutTCP, nl.Uint32Attr(uint32(c.TimeoutTCP.Seconds()))))
+	req.AddData(nl.NewRtAttr(ipvsCmdAttrTimeoutTCPFin, nl.Uint32Attr(uint32(c.TimeoutTCPFin.Seconds()))))
+	req.AddData(nl.NewRtAttr(ipvsCmdAttrTimeoutUDP, nl.Uint32Attr(uint32(c.TimeoutUDP.Seconds()))))
+
+	_, err := execute(i.sock, req, 0)
+
+	return err
 }
 
 // IPVS related netlink message format explained

--- a/vendor/github.com/docker/libnetwork/netutils/utils_linux.go
+++ b/vendor/github.com/docker/libnetwork/netutils/utils_linux.go
@@ -94,10 +94,12 @@ func ElectInterfaceAddresses(name string) ([]*net.IPNet, []*net.IPNet, error) {
 	}
 
 	if link == nil || len(v4Nets) == 0 {
-		// Choose from predefined local scope  networks
+		// Choose from predefined local scope networks
 		v4Net, err := FindAvailableNetwork(ipamutils.PredefinedLocalScopeDefaultNetworks)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("%s, PredefinedLocalScopeDefaultNetworks List: %+v",
+				err.Error(),
+				ipamutils.PredefinedLocalScopeDefaultNetworks)
 		}
 		v4Nets = append(v4Nets, v4Net)
 	}

--- a/vendor/github.com/docker/libnetwork/network.go
+++ b/vendor/github.com/docker/libnetwork/network.go
@@ -396,11 +396,9 @@ func (n *network) validateConfiguration() error {
 					driverOptions map[string]string
 					opts          interface{}
 				)
-				switch data.(type) {
-				case map[string]interface{}:
-					opts = data.(map[string]interface{})
-				case map[string]string:
-					opts = data.(map[string]string)
+				switch t := data.(type) {
+				case map[string]interface{}, map[string]string:
+					opts = t
 				}
 				ba, err := json.Marshal(opts)
 				if err != nil {

--- a/vendor/github.com/docker/libnetwork/networkdb/cluster.go
+++ b/vendor/github.com/docker/libnetwork/networkdb/cluster.go
@@ -288,7 +288,12 @@ func (nDB *NetworkDB) rejoinClusterBootStrap() {
 		return
 	}
 
-	myself, _ := nDB.nodes[nDB.config.NodeID]
+	myself, ok := nDB.nodes[nDB.config.NodeID]
+	if !ok {
+		nDB.RUnlock()
+		logrus.Warnf("rejoinClusterBootstrap unable to find local node info using ID:%v", nDB.config.NodeID)
+		return
+	}
 	bootStrapIPs := make([]string, 0, len(nDB.bootStrapIP))
 	for _, bootIP := range nDB.bootStrapIP {
 		// botostrap IPs are usually IP:port from the Join
@@ -352,7 +357,7 @@ func (nDB *NetworkDB) reconnectNode() {
 	nDB.bulkSync([]string{node.Name}, true)
 }
 
-// For timing the entry deletion in the repaer APIs that doesn't use monotonic clock
+// For timing the entry deletion in the reaper APIs that doesn't use monotonic clock
 // source (time.Now, Sub etc.) should be avoided. Hence we use reapTime in every
 // entry which is set initially to reapInterval and decremented by reapPeriod every time
 // the reaper runs. NOTE nDB.reapTableEntries updates the reapTime with a readlock. This


### PR DESCRIPTION
full diff: https://github.com/docker/libnetwork/compare/1a06131fb8a047d919f7deaf02a4c414d7884b83...ebcade70ad1059b070d0040d798ecca359bc5fed

relevant changes:

- docker/libnetwork#2349 IPVS: Add support for GetConfig/SetConfig
- docker/libnetwork#2343 Revert "debian has iptables-legacy and iptables-nft now"
- docker/libnetwork#2230 Moving IPVLAN driver out of experimental
- docker/libnetwork#2307 Fix for problem where agent is stopped and does not restart
- docker/libnetwork#2303 Touch-up error-message and godoc for ConfigVXLANUDPPort
- docker/libnetwork#2325 Fix possible nil pointer exception
- docker/libnetwork#2302 Use sync.RWMutex for VXLANUDPPort
- docker/libnetwork#2306 Improve error if auto-selecting IP-range failed

