### PR TITLE
Temporarily disable TestCheckpoint

### DIFF
--- a/integration/container/checkpoint_test.go
+++ b/integration/container/checkpoint_test.go
@@ -30,6 +30,7 @@ func containerExec(t *testing.T, client client.APIClient, cID string, cmd []stri
 }
 
 func TestCheckpoint(t *testing.T) {
+	t.Skip("TestCheckpoint is broken; see https://github.com/moby/moby/issues/38963")
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, !testEnv.DaemonInfo.ExperimentalBuild)
 


### PR DESCRIPTION
this test is failing almost every time, so let's disable for now

tracked through https://github.com/moby/moby/issues/38963