### PR TITLE
bump up rootlesskit

### DIFF
--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# v0.3.0-beta.0
-ROOTLESSKIT_COMMIT=ed2671442965115b84ecf82d4831cc48747d89b8
+# v0.3.0
+ROOTLESSKIT_COMMIT=70e0502f328bc5ffb14692a7ea41abb77196043b
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
Changes: https://github.com/rootless-containers/rootlesskit/compare/ed2671442965115b84ecf82d4831cc48747d89b8...70e0502f328bc5ffb14692a7ea41abb77196043b

Contains the fix for running RootlessKit+VPNKit instances simultaneously with multiple users: https://github.com/rootless-containers/rootlesskit/issues/56

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
