### PR TITLE
openrc: Modernize and sync settings

### DIFF
--- a/contrib/init/openrc/docker.confd
+++ b/contrib/init/openrc/docker.confd
@@ -16,6 +16,12 @@
 # where docker's pid get stored
 #DOCKER_PIDFILE="/run/docker.pid"
 
+# Settings for process limits (ulimit)
+#DOCKER_ULIMIT="-c unlimited -n 1048576 -u unlimited"
+
+# seconds to wait for sending SIGTERM and SIGKILL signals when stopping docker
+#DOCKER_RETRY="TERM/60/KILL/10"
+
 # where the docker daemon itself is run from
 #DOCKERD_BINARY="/usr/bin/dockerd"
 

--- a/contrib/init/openrc/docker.initd
+++ b/contrib/init/openrc/docker.initd
@@ -11,14 +11,18 @@ DOCKER_OUTFILE="${DOCKER_OUTFILE:-${DOCKER_LOGFILE}}"
 start_stop_daemon_args="--background \
 	--stderr \"${DOCKER_ERRFILE}\" --stdout \"${DOCKER_OUTFILE}\""
 
+extra_started_commands="reload"
+
+rc_ulimit="${DOCKER_ULIMIT:--c unlimited -n 1048576 -u unlimited}"
+
+retry="${DOCKER_RETRY:-TERM/60/KILL/10}"
+
 start_pre() {
 	checkpath -f -m 0644 -o root:docker "$DOCKER_LOGFILE"
+}
 
-	ulimit -n 1048576
-
-	# Having non-zero limits causes performance problems due to accounting overhead
-	# in the kernel. We recommend using cgroups to do container-local accounting.
-	ulimit -u unlimited
-
-	return 0
+reload() {
+        ebegin "Reloading ${RC_SVCNAME}"
+        start-stop-daemon --signal HUP --pidfile "${pidfile}"
+        eend $? "Failed to stop ${RC_SVCNAME}"
 }


### PR DESCRIPTION

Signed-off-by: Manuel Rüger <manuel@rueg.eu>


@tianon might be a good candidate to review those changes.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Use rc_ulimit for ulimit constraints
* Synchronize ulimit settings to systemd's
* Add support for reload command
* Add support for retry settings for docker stop/restart

**- How I did it**

**- How to verify it**
Run the openrc service
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Update OpenRC Service Scripts

**- A picture of a cute animal (not mandatory but encouraged)**

