### PR TITLE
Move docker-py tests to the end

### DIFF
--- a/hack/ci/janky
+++ b/hack/ci/janky
@@ -12,7 +12,7 @@ bash <(curl -s https://codecov.io/bash) \
 hack/make.sh \
 	binary-daemon \
 	dynbinary \
-	test-docker-py \
 	test-integration-flaky \
 	test-integration \
-	cross
+	cross \
+	test-docker-py


### PR DESCRIPTION
These tests have bad output and its hard to figure out what went wrong
when one of them fails.  Move them to the end to atleast get the real
test output first and better debug things.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>