### PR TITLE
Expand chown value of COPY command #35018

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -27,7 +27,7 @@ github.com/imdario/mergo                            7c29201646fa3de8506f70121347
 golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af2b83e6acac3c
 
 # buildkit
-github.com/moby/buildkit                            b3028967ae6259c9a31c1a1deeccd30fe3469cce
+github.com/moby/buildkit                            155bfa5a801a72f670a1e0e0eb07c023405806ab
 github.com/tonistiigi/fsutil                        3bbb99cdbd76619ab717299830c60f6f2a533a6b
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7

--- a/vendor/github.com/moby/buildkit/README.md
+++ b/vendor/github.com/moby/buildkit/README.md
@@ -218,8 +218,8 @@ buildctl build ... --import-cache type=registry,ref=localhost:5000/myrepo:buildc
 #### To/From local filesystem
 
 ```
-buildctl build ... --export-cache type=local,src=path/to/input-dir
-buildctl build ... --import-cache type=local,dest=path/to/output-dir
+buildctl build ... --export-cache type=local,dest=path/to/input-dir
+buildctl build ... --import-cache type=local,src=path/to/output-dir
 ```
 
 The directory layout conforms to OCI Image Spec v1.0.
@@ -228,11 +228,11 @@ The directory layout conforms to OCI Image Spec v1.0.
 * `mode=min` (default): only export layers for the resulting image
 * `mode=max`: export all the layers of all intermediate steps
 * `ref=docker.io/user/image:tag`: reference for `registry` cache exporter
-* `src=path/to/output-dir`: directory for `local` cache exporter
+* `dest=path/to/output-dir`: directory for `local` cache exporter
 
 #### `--import-cache` options
 * `ref=docker.io/user/image:tag`: reference for `registry` cache importer
-* `dest=path/to/input-dir`: directory for `local` cache importer
+* `src=path/to/input-dir`: directory for `local` cache importer
 * `digest=sha256:deadbeef`: digest of the manifest list to import for `local` cache importer. Defaults to the digest of "latest" tag in `index.json`
 
 ### Other

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands.go
@@ -200,6 +200,11 @@ type CopyCommand struct {
 
 // Expand variables
 func (c *CopyCommand) Expand(expander SingleWordExpander) error {
+	expandedChown, err := expander(c.Chown)
+	if err != nil {
+		return err
+	}
+	c.Chown = expandedChown
 	return expandSliceInPlace(c.SourcesAndDest, expander)
 }
 


### PR DESCRIPTION
Signed-off-by: Hao Hu <hao.hu.fr@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Provide a simple implementation for issue #35018

**- How I did it**
Expand the value of chown of COPY command

**- How to verify it**
Create a Dockerfile containing COPY chown=${envvar}, then use either ENV or ARG to set the value of envvar. Please note that the value should be valid for the current image. Then, see if the copy command is correctly executed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/2564015/55660308-f204ea80-5805-11e9-9c31-3e9a6319807d.png)
