### PR TITLE
Support cross-compile for arm

### DIFF
--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -47,6 +47,26 @@ if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARC
 			export CC=x86_64-w64-mingw32-gcc
 			export CGO_ENABLED=1
 			;;
+		linux/arm)
+			case "${GOARM}" in
+			5|"")
+				export CC=arm-linux-gnueabi-gcc
+				export CGO_ENABLED=1
+				;;
+			7)
+				export CC=arm-linux-gnueabihf-gcc
+				export CGO_ENABLED=1
+				;;
+			esac
+			;;
+		linux/arm64)
+			export CC=aarch64-linux-gnu-gcc
+			export CGO_ENABLED=1
+			;;
+		linux/amd64)
+			export CC=x86_64-linux-gnu-gcc
+			export CGO_ENABLED=1
+			;;
 	esac
 fi
 


### PR DESCRIPTION
Pretty much cross-compile doesn't work because  of this:

> profiles/seccomp/seccomp.go:13:2: build constraints exclude all Go files in /go/src/github.com/docker/docker/vendor/github.com/seccomp/libseccomp-golang

This changes adds a new Dockerfile target for cross compilation with the
necessary arch specific libseccomp packages and CC toolchains.