### PR TITLE
Write stackdumps to file

### DIFF
--- a/pkg/signal/trap.go
+++ b/pkg/signal/trap.go
@@ -100,5 +100,17 @@ func DumpStacks(dir string) (string, error) {
 	if _, err := f.Write(buf); err != nil {
 		return "", errors.Wrap(err, "failed to write goroutine stacks")
 	}
+
+	// Write to file in temp for gathering diagnostics
+	if dir == "" {
+		name := filepath.Join(os.TempDir(), fmt.Sprintf("dockerd.%d.stacks.log", os.Getpid()))
+		f, err := os.Create(name)
+		if err != nil {
+			return "", nil
+		}
+		defer f.Close()
+		f.WriteString(string(buf))
+	}
+
 	return f.Name(), nil
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Part of a diagnostics gathering effort for when things go wrong. Already have identical PRs for the containerd shim runtime (merged already), and containerd. This completes the circle and writes the stacks to a file in temp so that it can be gathered for later analysis. 

(https://github.com/Microsoft/hcsshim/pull/554 is tracking the gathering of all these logs).