### PR TITLE
Remove deprecated filter functions

### DIFF
--- a/api/types/filters/parse.go
+++ b/api/types/filters/parse.go
@@ -5,7 +5,6 @@ package filters // import "github.com/docker/docker/api/types/filters"
 
 import (
 	"encoding/json"
-	"errors"
 	"regexp"
 	"strings"
 
@@ -35,41 +34,6 @@ func NewArgs(initialArgs ...KeyValuePair) Args {
 		args.Add(arg.Key, arg.Value)
 	}
 	return args
-}
-
-// ParseFlag parses a key=value string and adds it to an Args.
-//
-// Deprecated: Use Args.Add()
-func ParseFlag(arg string, prev Args) (Args, error) {
-	filters := prev
-	if len(arg) == 0 {
-		return filters, nil
-	}
-
-	if !strings.Contains(arg, "=") {
-		return filters, ErrBadFormat
-	}
-
-	f := strings.SplitN(arg, "=", 2)
-
-	name := strings.ToLower(strings.TrimSpace(f[0]))
-	value := strings.TrimSpace(f[1])
-
-	filters.Add(name, value)
-
-	return filters, nil
-}
-
-// ErrBadFormat is an error returned when a filter is not in the form key=value
-//
-// Deprecated: this error will be removed in a future version
-var ErrBadFormat = errors.New("bad format of filter (expected name=value)")
-
-// ToParam encodes the Args as args JSON encoded string
-//
-// Deprecated: use ToJSON
-func ToParam(a Args) (string, error) {
-	return ToJSON(a)
 }
 
 // MarshalJSON returns a JSON byte representation of the Args
@@ -105,13 +69,6 @@ func ToParamWithVersion(version string, a Args) (string, error) {
 	}
 
 	return ToJSON(a)
-}
-
-// FromParam decodes a JSON encoded string into Args
-//
-// Deprecated: use FromJSON
-func FromParam(p string) (Args, error) {
-	return FromJSON(p)
 }
 
 // FromJSON decodes a JSON encoded string into Args
@@ -273,14 +230,6 @@ func (args Args) FuzzyMatch(key, source string) bool {
 		}
 	}
 	return false
-}
-
-// Include returns true if the key exists in the mapping
-//
-// Deprecated: use Contains
-func (args Args) Include(field string) bool {
-	_, ok := args.fields[field]
-	return ok
 }
 
 // Contains returns true if the key exists in the mapping

--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -8,40 +8,6 @@ import (
 	is "gotest.tools/assert/cmp"
 )
 
-func TestParseArgs(t *testing.T) {
-	// equivalent of `docker ps -f 'created=today' -f 'image.name=ubuntu*' -f 'image.name=*untu'`
-	flagArgs := []string{
-		"created=today",
-		"image.name=ubuntu*",
-		"image.name=*untu",
-	}
-	var (
-		args = NewArgs()
-		err  error
-	)
-
-	for i := range flagArgs {
-		args, err = ParseFlag(flagArgs[i], args)
-		assert.NilError(t, err)
-	}
-	assert.Check(t, is.Len(args.Get("created"), 1))
-	assert.Check(t, is.Len(args.Get("image.name"), 2))
-}
-
-func TestParseArgsEdgeCase(t *testing.T) {
-	var args Args
-	args, err := ParseFlag("", args)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if args.Len() != 0 {
-		t.Fatalf("Expected an empty Args (map), got %v", args)
-	}
-	if args, err = ParseFlag("anything", args); err == nil || err != ErrBadFormat {
-		t.Fatalf("Expected ErrBadFormat, got %v", err)
-	}
-}
-
 func TestToJSON(t *testing.T) {
 	fields := map[string]map[string]bool{
 		"created":    {"today": true},
@@ -344,17 +310,6 @@ func TestContains(t *testing.T) {
 	f.Add("status", "running")
 	if !f.Contains("status") {
 		t.Fatal("Expected to contain a status key, got false")
-	}
-}
-
-func TestInclude(t *testing.T) {
-	f := NewArgs()
-	if f.Include("status") {
-		t.Fatal("Expected to not include a status key, got true")
-	}
-	f.Add("status", "running")
-	if !f.Include("status") {
-		t.Fatal("Expected to include a status key, got false")
 	}
 }
 

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -590,7 +590,7 @@ func toBuildkitPruneInfo(opts types.BuildCachePruneOptions) (client.PruneInfo, e
 
 	bkFilter := make([]string, 0, opts.Filters.Len())
 	for cacheField := range cacheFields {
-		if opts.Filters.Include(cacheField) {
+		if opts.Filters.Contains(cacheField) {
 			values := opts.Filters.Get(cacheField)
 			switch len(values) {
 			case 0:


### PR DESCRIPTION
These were deprecated for a while, and are easy to replace with their new variants; removing them to prevent them from being used in future (noticed that builder-next inadvertently used the deprecated function) 