### PR TITLE
Adds PartialLogMetadata to encode protobuf for logger plugins

### DIFF
--- a/daemon/logger/adapter.go
+++ b/daemon/logger/adapter.go
@@ -39,6 +39,13 @@ func (a *pluginAdapter) Log(msg *Message) error {
 	a.buf.TimeNano = msg.Timestamp.UnixNano()
 	a.buf.Partial = msg.PLogMetaData != nil
 	a.buf.Source = msg.Source
+	if msg.PLogMetaData != nil {
+		a.buf.PartialLogMetadata = &logdriver.PartialLogEntryMetadata{
+			Id:      msg.PLogMetaData.ID,
+			Last:    msg.PLogMetaData.Last,
+			Ordinal: int32(msg.PLogMetaData.Ordinal),
+		}
+	}
 
 	err := a.enc.Encode(&a.buf)
 	a.buf.Reset()


### PR DESCRIPTION
Signed-off-by: Alexei Margasov <alexei38@yandex.ru>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added PartialLogMetadata to encode protobuf for logger plugins

**- How I did it**

**- How to verify it**

Write a plug-in which uses data of PartialLogMetadata
https://github.com/cpuguy83/docker-log-driver-test/issues/7

**- Description for the changelog**
Added PartialLogMetadata to encode protobuf for logger plugins


**- A picture of a cute animal (not mandatory but encouraged)**

