### PR TITLE
Refactor few spec generation ops

### DIFF
--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -1,6 +1,8 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
+
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/exec"
 	"github.com/docker/docker/oci/caps"
@@ -54,6 +56,6 @@ func (daemon *Daemon) execSetPlatformOpt(c *container.Container, ec *exec.Config
 		}
 		p.ApparmorProfile = appArmorProfile
 	}
-	daemon.setRlimits(&specs.Spec{Process: p}, c)
-	return nil
+	s := &specs.Spec{Process: p}
+	return WithRlimits(daemon, c)(context.Background(), nil, nil, s)
 }

--- a/daemon/seccomp_disabled.go
+++ b/daemon/seccomp_disabled.go
@@ -3,17 +3,22 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/containerd/containerd/containers"
+	coci "github.com/containerd/containerd/oci"
 	"github.com/docker/docker/container"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 var supportsSeccomp = false
 
-func setSeccomp(daemon *Daemon, rs *specs.Spec, c *container.Container) error {
-	if c.SeccompProfile != "" && c.SeccompProfile != "unconfined" {
-		return fmt.Errorf("seccomp profiles are not supported on this daemon, you cannot specify a custom seccomp profile")
+// WithSeccomp sets the seccomp profile
+func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
+	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
+		if c.SeccompProfile != "" && c.SeccompProfile != "unconfined" {
+			return fmt.Errorf("seccomp profiles are not supported on this daemon, you cannot specify a custom seccomp profile")
+		}
+		return nil
 	}
-	return nil
 }

--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -3,8 +3,11 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/containerd/containerd/containers"
+	coci "github.com/containerd/containerd/oci"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/profiles/seccomp"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -13,43 +16,46 @@ import (
 
 var supportsSeccomp = true
 
-func setSeccomp(daemon *Daemon, rs *specs.Spec, c *container.Container) error {
-	var profile *specs.LinuxSeccomp
-	var err error
+// WithSeccomp sets the seccomp profile
+func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
+	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
+		var profile *specs.LinuxSeccomp
+		var err error
 
-	if c.HostConfig.Privileged {
-		return nil
-	}
+		if c.HostConfig.Privileged {
+			return nil
+		}
 
-	if !daemon.seccompEnabled {
-		if c.SeccompProfile != "" && c.SeccompProfile != "unconfined" {
-			return fmt.Errorf("Seccomp is not enabled in your kernel, cannot run a custom seccomp profile.")
+		if !daemon.seccompEnabled {
+			if c.SeccompProfile != "" && c.SeccompProfile != "unconfined" {
+				return fmt.Errorf("Seccomp is not enabled in your kernel, cannot run a custom seccomp profile.")
+			}
+			logrus.Warn("Seccomp is not enabled in your kernel, running container without default profile.")
+			c.SeccompProfile = "unconfined"
 		}
-		logrus.Warn("Seccomp is not enabled in your kernel, running container without default profile.")
-		c.SeccompProfile = "unconfined"
-	}
-	if c.SeccompProfile == "unconfined" {
-		return nil
-	}
-	if c.SeccompProfile != "" {
-		profile, err = seccomp.LoadProfile(c.SeccompProfile, rs)
-		if err != nil {
-			return err
+		if c.SeccompProfile == "unconfined" {
+			return nil
 		}
-	} else {
-		if daemon.seccompProfile != nil {
-			profile, err = seccomp.LoadProfile(string(daemon.seccompProfile), rs)
+		if c.SeccompProfile != "" {
+			profile, err = seccomp.LoadProfile(c.SeccompProfile, s)
 			if err != nil {
 				return err
 			}
 		} else {
-			profile, err = seccomp.GetDefaultProfile(rs)
-			if err != nil {
-				return err
+			if daemon.seccompProfile != nil {
+				profile, err = seccomp.LoadProfile(string(daemon.seccompProfile), s)
+				if err != nil {
+					return err
+				}
+			} else {
+				profile, err = seccomp.GetDefaultProfile(s)
+				if err != nil {
+					return err
+				}
 			}
 		}
-	}
 
-	rs.Linux.Seccomp = profile
-	return nil
+		s.Linux.Seccomp = profile
+		return nil
+	}
 }

--- a/daemon/seccomp_unsupported.go
+++ b/daemon/seccomp_unsupported.go
@@ -2,4 +2,19 @@
 
 package daemon // import "github.com/docker/docker/daemon"
 
+import (
+	"context"
+
+	"github.com/containerd/containerd/containers"
+	coci "github.com/containerd/containerd/oci"
+	"github.com/docker/docker/container"
+)
+
 var supportsSeccomp = false
+
+// WithSeccomp sets the seccomp profile
+func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
+	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
+		return nil
+	}
+}


### PR DESCRIPTION
This starts the refactor of docker spec generation to containerd SpecOpts.

This improves sharing of opts for other services and projects.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>

