### PR TITLE
Fix empty WithVersion blocking version negotiation

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -265,6 +265,26 @@ func TestNegotiateAPVersionOverride(t *testing.T) {
 	assert.Check(t, is.Equal(expected, client.version))
 }
 
+// TestNegotiateAPIVersionWithEmptyVersion asserts that initializing a client
+// with an empty version string does still allow API-version negotiation
+func TestNegotiateAPIVersionWithEmptyVersion(t *testing.T) {
+	client, err := NewClientWithOpts(WithVersion(""))
+	assert.NilError(t, err)
+
+	client.NegotiateAPIVersionPing(types.Ping{APIVersion: "1.35"})
+	assert.Equal(t, client.version, "1.35")
+}
+
+// TestNegotiateAPIVersionWithFixedVersion asserts that initializing a client
+// with an fixed version disables API-version negotiation
+func TestNegotiateAPIVersionWithFixedVersion(t *testing.T) {
+	client, err := NewClientWithOpts(WithVersion("1.35"))
+	assert.NilError(t, err)
+
+	client.NegotiateAPIVersionPing(types.Ping{APIVersion: "1.31"})
+	assert.Equal(t, client.version, "1.35")
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (rtf roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/client/options.go
+++ b/client/options.go
@@ -139,11 +139,14 @@ func WithTLSClientConfig(cacertPath, certPath, keyPath string) Opt {
 	}
 }
 
-// WithVersion overrides the client version with the specified one
+// WithVersion overrides the client version with the specified one. If an empty
+// version is specified, the value will be ignored to allow version negotiation.
 func WithVersion(version string) Opt {
 	return func(c *Client) error {
-		c.version = version
-		c.manualOverride = true
+		if version != "" {
+			c.version = version
+			c.manualOverride = true
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
commit 3d72963ab8fd43aab4e4387867f1b9ae99e61262 (https://github.com/moby/moby/pull/38909) fixed situations where a version negotiation could override the version, even though a client was initialized with a fixed version.

In situations where the "fixed" version is empty, we should ignore the option, and treat the client as "not having a fixed version", so that API version negotiation can still be performed.

