### PR TITLE
client: define "Opt" type

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -107,7 +107,7 @@ func CheckRedirect(req *http.Request, via []*http.Request) error {
 // It won't send any version information if the version number is empty. It is
 // highly recommended that you set a version or your client may break if the
 // server is upgraded.
-func NewClientWithOpts(ops ...func(*Client) error) (*Client, error) {
+func NewClientWithOpts(ops ...Opt) (*Client, error) {
 	client, err := defaultHTTPClient(DefaultDockerHost)
 	if err != nil {
 		return nil, err

--- a/client/options.go
+++ b/client/options.go
@@ -12,6 +12,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Opt is a configuration option to initialize a client
+type Opt func(*Client) error
+
 // FromEnv configures the client with values from environment variables.
 //
 // Supported environment variables:
@@ -55,13 +58,13 @@ func FromEnv(c *Client) error {
 // WithDialer applies the dialer.DialContext to the client transport. This can be
 // used to set the Timeout and KeepAlive settings of the client.
 // Deprecated: use WithDialContext
-func WithDialer(dialer *net.Dialer) func(*Client) error {
+func WithDialer(dialer *net.Dialer) Opt {
 	return WithDialContext(dialer.DialContext)
 }
 
 // WithDialContext applies the dialer to the client transport. This can be
 // used to set the Timeout and KeepAlive settings of the client.
-func WithDialContext(dialContext func(ctx context.Context, network, addr string) (net.Conn, error)) func(*Client) error {
+func WithDialContext(dialContext func(ctx context.Context, network, addr string) (net.Conn, error)) Opt {
 	return func(c *Client) error {
 		if transport, ok := c.client.Transport.(*http.Transport); ok {
 			transport.DialContext = dialContext
@@ -72,7 +75,7 @@ func WithDialContext(dialContext func(ctx context.Context, network, addr string)
 }
 
 // WithHost overrides the client host with the specified one.
-func WithHost(host string) func(*Client) error {
+func WithHost(host string) Opt {
 	return func(c *Client) error {
 		hostURL, err := ParseHostURL(host)
 		if err != nil {
@@ -90,7 +93,7 @@ func WithHost(host string) func(*Client) error {
 }
 
 // WithHTTPClient overrides the client http client with the specified one
-func WithHTTPClient(client *http.Client) func(*Client) error {
+func WithHTTPClient(client *http.Client) Opt {
 	return func(c *Client) error {
 		if client != nil {
 			c.client = client
@@ -100,7 +103,7 @@ func WithHTTPClient(client *http.Client) func(*Client) error {
 }
 
 // WithHTTPHeaders overrides the client default http headers
-func WithHTTPHeaders(headers map[string]string) func(*Client) error {
+func WithHTTPHeaders(headers map[string]string) Opt {
 	return func(c *Client) error {
 		c.customHTTPHeaders = headers
 		return nil
@@ -108,7 +111,7 @@ func WithHTTPHeaders(headers map[string]string) func(*Client) error {
 }
 
 // WithScheme overrides the client scheme with the specified one
-func WithScheme(scheme string) func(*Client) error {
+func WithScheme(scheme string) Opt {
 	return func(c *Client) error {
 		c.scheme = scheme
 		return nil
@@ -116,7 +119,7 @@ func WithScheme(scheme string) func(*Client) error {
 }
 
 // WithTLSClientConfig applies a tls config to the client transport.
-func WithTLSClientConfig(cacertPath, certPath, keyPath string) func(*Client) error {
+func WithTLSClientConfig(cacertPath, certPath, keyPath string) Opt {
 	return func(c *Client) error {
 		opts := tlsconfig.Options{
 			CAFile:             cacertPath,
@@ -137,7 +140,7 @@ func WithTLSClientConfig(cacertPath, certPath, keyPath string) func(*Client) err
 }
 
 // WithVersion overrides the client version with the specified one
-func WithVersion(version string) func(*Client) error {
+func WithVersion(version string) Opt {
 	return func(c *Client) error {
 		c.version = version
 		c.manualOverride = true

--- a/internal/test/request/request.go
+++ b/internal/test/request/request.go
@@ -25,11 +25,11 @@ import (
 )
 
 // NewAPIClient returns a docker API client configured from environment variables
-func NewAPIClient(t assert.TestingT, ops ...func(*client.Client) error) client.APIClient {
+func NewAPIClient(t assert.TestingT, ops ...client.Opt) client.APIClient {
 	if ht, ok := t.(test.HelperT); ok {
 		ht.Helper()
 	}
-	ops = append([]func(*client.Client) error{client.FromEnv}, ops...)
+	ops = append([]client.Opt{client.FromEnv}, ops...)
 	clt, err := client.NewClientWithOpts(ops...)
 	assert.NilError(t, err)
 	return clt


### PR DESCRIPTION
Minor improvement, but makes defining a list of options a bit cleaner, and more descriptive;

Before:

```go
opts := make([]func(*client.Client) error, 0)
```

After:

```go
opts := make([]client.Opt, 0)
```

