### PR TITLE
Add client.WithTimeout() option

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
@@ -98,6 +99,14 @@ func WithHTTPClient(client *http.Client) Opt {
 		if client != nil {
 			c.client = client
 		}
+		return nil
+	}
+}
+
+// WithTimeout configures the time limit for requests made by the HTTP client
+func WithTimeout(timeout time.Duration) Opt {
+	return func(c *Client) error {
+		c.client.Timeout = timeout
 		return nil
 	}
 }

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -1,0 +1,16 @@
+package client
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+)
+
+func TestOptionWithTimeout(t *testing.T) {
+	timeout := 10 * time.Second
+	c, err := NewClientWithOpts(WithTimeout(timeout))
+	assert.NilError(t, err)
+	assert.Check(t, c.client != nil)
+	assert.Equal(t, c.client.Timeout, timeout)
+}


### PR DESCRIPTION
This would allow setting the timeout option without having to construct a custom client.