### PR TITLE
Reformat vendor.conf and pin all deps by git-sha

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,164 +1,166 @@
-# the following lines are in sorted order, FYI
-github.com/Azure/go-ansiterm d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim ba3d6667710fa905116f39a19d059c4c1016be7c
-github.com/Microsoft/go-winio c599b533b43b1363d7d7c6cfda5ede70ed73ff13
-github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
-github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git
-github.com/golang/gddo 9b12a26f3fbd7397dee4e20939ddca719d840d2a
-github.com/google/uuid v1.1.1
-github.com/gorilla/mux v1.7.0
-github.com/Microsoft/opengcs a10967154e143a36014584a6f664344e3bb0aa64
-github.com/konsorten/go-windows-terminal-sequences f55edac94c9bbba5d6182a4be46d86a2c9b5b50e # v1.0.2
-github.com/kr/pty 521317be5ebc228a0f0ede099fa2a0b5ece22e49 # v1.1.4
-github.com/mattn/go-shellwords a72fbe27a1b0ed0df2f02754945044ce1456608b # v1.0.5
-github.com/sirupsen/logrus 8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f # v1.4.1
-github.com/tchap/go-patricia a7f0089c6f496e8e70402f61733606daa326cac5 # v2.3.0
-github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3 # v0.1.0
-golang.org/x/net eb5bcb51f2a31c7d5141d810b70815c05d9c9146
-golang.org/x/sys 4b34438f7a67ee5f45cc6132e2bad873a20324e9
-github.com/docker/go-units 47565b4f722fb6ceae66b95f853feed578a4a51c # v0.3.3
-github.com/docker/go-connections 7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0
-golang.org/x/text f21a4dfb5e38f5895301dc265a8def02365cc3d0 # v0.3.0
-gotest.tools 1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
-github.com/google/go-cmp v0.2.0
+github.com/Azure/go-ansiterm                        d6e3b3328b783f23731bc4d058875b0371ff8109
+github.com/Microsoft/hcsshim                        ba3d6667710fa905116f39a19d059c4c1016be7c
+github.com/Microsoft/go-winio                       c599b533b43b1363d7d7c6cfda5ede70ed73ff13
+github.com/docker/libtrust                          9cbd2a1374f46905c68a4eb3694a130610adc62a
+github.com/go-check/check                           4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git
+github.com/golang/gddo                              9b12a26f3fbd7397dee4e20939ddca719d840d2a
+github.com/google/uuid                              0cd6bf5da1e1c83f8b45653022c74f71af0538a4 # v1.1.1
+github.com/gorilla/mux                              a7962380ca08b5a188038c69871b8d3fbdf31e89 # v1.7.0
+github.com/Microsoft/opengcs                        a10967154e143a36014584a6f664344e3bb0aa64
 
-github.com/RackSec/srslog a4725f04ec91af1a91b380da679d6e0c2f061e59
-github.com/imdario/mergo 7c29201646fa3de8506f701213473dd407f19646 # v0.3.7
-golang.org/x/sync e225da77a7e68af35c70ccbf71af2b83e6acac3c
+github.com/konsorten/go-windows-terminal-sequences  f55edac94c9bbba5d6182a4be46d86a2c9b5b50e # v1.0.2
+github.com/kr/pty                                   521317be5ebc228a0f0ede099fa2a0b5ece22e49 # v1.1.4
+github.com/mattn/go-shellwords                      a72fbe27a1b0ed0df2f02754945044ce1456608b # v1.0.5
+github.com/sirupsen/logrus                          8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f # v1.4.1
+github.com/tchap/go-patricia                        a7f0089c6f496e8e70402f61733606daa326cac5 # v2.3.0
+github.com/vdemeester/shakers                       24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3 # v0.1.0
+golang.org/x/net                                    eb5bcb51f2a31c7d5141d810b70815c05d9c9146
+golang.org/x/sys                                    4b34438f7a67ee5f45cc6132e2bad873a20324e9
+github.com/docker/go-units                          47565b4f722fb6ceae66b95f853feed578a4a51c # v0.3.3
+github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0
+golang.org/x/text                                   f21a4dfb5e38f5895301dc265a8def02365cc3d0 # v0.3.0
+gotest.tools                                        1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
+github.com/google/go-cmp                            3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0
+
+github.com/RackSec/srslog                           a4725f04ec91af1a91b380da679d6e0c2f061e59
+github.com/imdario/mergo                            7c29201646fa3de8506f701213473dd407f19646 # v0.3.7
+golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af2b83e6acac3c
 
 # buildkit
-github.com/moby/buildkit b3028967ae6259c9a31c1a1deeccd30fe3469cce
-github.com/tonistiigi/fsutil 3bbb99cdbd76619ab717299830c60f6f2a533a6b
-github.com/grpc-ecosystem/grpc-opentracing 8e809c8a86450a29b90dcc9efbf062d0fe6d9746
-github.com/opentracing/opentracing-go 1361b9cd60be79c4c3a7fa9841b3c132e40066a7
-github.com/google/shlex 6f45313302b9c56850fc17f99e40caebce98c716
-github.com/opentracing-contrib/go-stdlib  b1a47cfbdd7543e70e9ef3e73d0802ad306cc1cc
-github.com/mitchellh/hashstructure 2bca23e0e452137f789efbc8610126fd8b94f73b
-github.com/gofrs/flock 7f43ea2e6a643ad441fc12d0ecc0d3388b300c53 # v0.7.0
+github.com/moby/buildkit                            b3028967ae6259c9a31c1a1deeccd30fe3469cce
+github.com/tonistiigi/fsutil                        3bbb99cdbd76619ab717299830c60f6f2a533a6b
+github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
+github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7
+github.com/google/shlex                             6f45313302b9c56850fc17f99e40caebce98c716
+github.com/opentracing-contrib/go-stdlib            b1a47cfbdd7543e70e9ef3e73d0802ad306cc1cc
+github.com/mitchellh/hashstructure                  2bca23e0e452137f789efbc8610126fd8b94f73b
+github.com/gofrs/flock                              7f43ea2e6a643ad441fc12d0ecc0d3388b300c53 # v0.7.0
 
-#get libnetwork packages
+# libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork 48f846327bbe6a0dce0c556e8dc9f5bb939d5c16
-github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
-github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
-github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
-github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
-github.com/hashicorp/memberlist 3d8438da9589e7b608a83ffac1ef8211486bcb7c
-github.com/sean-/seed e2103e2c35297fb7e17febb81e49b312087a2372
-github.com/hashicorp/go-sockaddr 6d291a969b86c4b633730bfc6b8b9d64c3aafed9
-github.com/hashicorp/go-multierror fcdddc395df1ddf4247c69bd436e84cfa0733f7e
-github.com/hashicorp/serf 598c54895cc5a7b1a24a398d635e8c0ea0959870
-github.com/docker/libkv 458977154600b9f23984d9f4b82e79570b5ae12b
-github.com/vishvananda/netns 604eaf189ee867d8c147fafc28def2394e878d25
-github.com/vishvananda/netlink b2de5d10e38ecce8607e6b438b6d174f389a004e
+github.com/docker/libnetwork                        48f846327bbe6a0dce0c556e8dc9f5bb939d5c16
+github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
+github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
+github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec
+github.com/hashicorp/go-msgpack                     71c2886f5a673a35f909803f38ece5810165097b
+github.com/hashicorp/memberlist                     3d8438da9589e7b608a83ffac1ef8211486bcb7c
+github.com/sean-/seed                               e2103e2c35297fb7e17febb81e49b312087a2372
+github.com/hashicorp/go-sockaddr                    6d291a969b86c4b633730bfc6b8b9d64c3aafed9
+github.com/hashicorp/go-multierror                  fcdddc395df1ddf4247c69bd436e84cfa0733f7e
+github.com/hashicorp/serf                           598c54895cc5a7b1a24a398d635e8c0ea0959870
+github.com/docker/libkv                             458977154600b9f23984d9f4b82e79570b5ae12b
+github.com/vishvananda/netns                        604eaf189ee867d8c147fafc28def2394e878d25
+github.com/vishvananda/netlink                      b2de5d10e38ecce8607e6b438b6d174f389a004e
 
 # When updating, consider updating TOMLV_COMMIT in hack/dockerfile/install/tomlv.installer accordingly
-github.com/BurntSushi/toml 3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
-github.com/samuel/go-zookeeper d0e0d8e11f318e000a8cc434616d69e329edc374
-github.com/deckarep/golang-set ef32fa3046d9f249d399f98ebaf9be944430fd1d
-github.com/coreos/etcd v3.3.9
-github.com/coreos/go-semver v0.2.0
-github.com/ugorji/go v1.1.1
-github.com/hashicorp/consul v0.5.2
-github.com/miekg/dns v1.0.7
-github.com/ishidawataru/sctp 07191f837fedd2f13d1ec7b5f885f0f3ec54b1cb
-go.etcd.io/bbolt v1.3.1-etcd.8
+github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
+github.com/samuel/go-zookeeper                      d0e0d8e11f318e000a8cc434616d69e329edc374
+github.com/deckarep/golang-set                      ef32fa3046d9f249d399f98ebaf9be944430fd1d
+github.com/coreos/etcd                              fca8add78a9d926166eb739b8e4a124434025ba3 # v3.3.9
+github.com/coreos/go-semver                         8ab6407b697782a06568d4b7f1db25550ec2e4c6 # v0.2.0
+github.com/ugorji/go                                b4c50a2b199d93b13dc15e78929cfb23bfdf21ab # v1.1.1
+github.com/hashicorp/consul                         9a9cc9341bb487651a0399e3fc5e1e8a42e62dd9 # v0.5.2
+github.com/miekg/dns                                e57bf427e68187a27e22adceac868350d7a7079b # v1.0.7
+github.com/ishidawataru/sctp                        07191f837fedd2f13d1ec7b5f885f0f3ec54b1cb
+go.etcd.io/bbolt                                    7ee3ded59d4835e10f3e7d0f7603c42aa5e83820 # v1.3.1-etcd.8
 
 # get graph and distribution packages
-github.com/docker/distribution 0d3efadf0154c2b8a4e7b6621fff9809655cc580
-github.com/vbatts/tar-split v0.11.0
-github.com/opencontainers/go-digest v1.0.0-rc1
+github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
+github.com/vbatts/tar-split                         620714a4c508c880ac1bdda9c8370a2b19af1a55 # v0.11.0
+github.com/opencontainers/go-digest                 279bed98673dd5bef374d3b6e4b09e2af76183bf # v1.0.0-rc1
 
 # get go-zfs packages
-github.com/mistifyio/go-zfs 22c9b32c84eb0d0c6f4043b6e90fc94073de92fa
-github.com/pborman/uuid v1.0
+github.com/mistifyio/go-zfs                         22c9b32c84eb0d0c6f4043b6e90fc94073de92fa
+github.com/pborman/uuid                             a97ce2ca70fa5a848076093f05e639a89ca34d06 # v1.0
 
-google.golang.org/grpc 7a6a684ca69eb4cae85ad0a484f2e531598c047b # v1.12.2
+google.golang.org/grpc                              7a6a684ca69eb4cae85ad0a484f2e531598c047b # v1.12.2
 
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
 # This commit does not need to match RUNC_COMMIT as it is used for helper
 # packages but should be newer or equal.
-github.com/opencontainers/runc 029124da7af7360afa781a0234d1b083550f797c # v1.0.0-rc7-6-g029124da
-github.com/opencontainers/runtime-spec 29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
-github.com/opencontainers/image-spec v1.0.1
-github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
+github.com/opencontainers/runc                      029124da7af7360afa781a0234d1b083550f797c # v1.0.0-rc7-6-g029124da
+github.com/opencontainers/runtime-spec              29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
+github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
+github.com/seccomp/libseccomp-golang                32f571b70023028bd57d9288c20efbcb237f3ce0
 
 # libcontainer deps (see src/github.com/opencontainers/runc/Godeps/Godeps.json)
-github.com/coreos/go-systemd v17
-github.com/godbus/dbus v4.0.0
-github.com/syndtr/gocapability 2c00daeb6c3b45114c80ac44119e7b8801fdd852
-github.com/golang/protobuf v1.2.0
+github.com/coreos/go-systemd                        39ca1b05acc7ad1220e09f133283b8859a8b71ab # v17
+github.com/godbus/dbus                              5f6efc7ef2759c81b7ba876593971bfce311eab3 # v4.0.0
+github.com/syndtr/gocapability                      2c00daeb6c3b45114c80ac44119e7b8801fdd852
+github.com/golang/protobuf                          aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
 
 # gelf logging driver deps
-github.com/Graylog2/go-gelf 4143646226541087117ff2f83334ea48b3201841
+github.com/Graylog2/go-gelf                         4143646226541087117ff2f83334ea48b3201841
 
-github.com/fluent/fluent-logger-golang v1.3.0
 # fluent-logger-golang deps
-github.com/philhofer/fwd bb6d471dc95d4fe11e432687f8b70ff496cf3136 # v1.0.0
-github.com/tinylib/msgp 3b556c64540842d4f82967be066a7f7fffc3adad
+github.com/fluent/fluent-logger-golang              8bbc2356beaf021b04c9bd5cdc76ea5a7ccb40ec # v1.3.0
+github.com/philhofer/fwd                            bb6d471dc95d4fe11e432687f8b70ff496cf3136 # v1.0.0
+github.com/tinylib/msgp                             3b556c64540842d4f82967be066a7f7fffc3adad
 
 # fsnotify
-github.com/fsnotify/fsnotify v1.4.7
+github.com/fsnotify/fsnotify                        c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9 # v1.4.7
 
 # awslogs deps
-github.com/aws/aws-sdk-go v1.12.66
-github.com/go-ini/ini v1.25.4
-github.com/jmespath/go-jmespath 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
+github.com/aws/aws-sdk-go                           9ed0c8de252f04ac45a65358377103d5a1aa2d92 # v1.12.66
+github.com/go-ini/ini                               300e940a926eb277d3901b20bdfcc54928ad3642 # v1.25.4
+github.com/jmespath/go-jmespath                     0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
 
 # logentries
-github.com/bsphere/le_go 7a984a84b5492ae539b79b62fb4a10afc63c7bcf
+github.com/bsphere/le_go                            7a984a84b5492ae539b79b62fb4a10afc63c7bcf
 
 # gcplogs deps
-golang.org/x/oauth2 ec22f46f877b4505e0117eeaab541714644fdd28
-google.golang.org/api de943baf05a022a8f921b544b7827bacaba1aed5
-go.opencensus.io v0.11.0
-cloud.google.com/go v0.23.0
-github.com/googleapis/gax-go v2.0.0
-google.golang.org/genproto 694d95ba50e67b2e363f3483057db5d4910c18f9
+golang.org/x/oauth2                                 ec22f46f877b4505e0117eeaab541714644fdd28
+google.golang.org/api                               de943baf05a022a8f921b544b7827bacaba1aed5
+go.opencensus.io                                    c3ed530f775d85e577ca652cb052a52c078aad26 # v0.11.0
+cloud.google.com/go                                 0fd7230b2a7505833d5f69b75cbd6c9582401479 # v0.23.0
+github.com/googleapis/gax-go                        317e0006254c44a0ac427cc52a0e083ff0b9622f # v2.0.0
+google.golang.org/genproto                          694d95ba50e67b2e363f3483057db5d4910c18f9
 
 # containerd
-github.com/containerd/containerd ceba56893a76f22cf0126c46d835c80fb3833408
-github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
-github.com/containerd/continuity 004b46473808b3e7a4a3049c20e4376c91eb966d
-github.com/containerd/cgroups 4994991857f9b0ae8dc439551e8bebdbb4bf66c1
-github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
-github.com/containerd/go-runc 5a6d9f37cfa36b15efba46dc7ea349fa9b7143c3
-github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
-github.com/containerd/ttrpc f02858b1457c5ca3aaec3a0803eb0d59f96e41d6
-github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
+github.com/containerd/containerd                    ceba56893a76f22cf0126c46d835c80fb3833408
+github.com/containerd/fifo                          3d5202aec260678c48179c56f40e6f38a095738c
+github.com/containerd/continuity                    004b46473808b3e7a4a3049c20e4376c91eb966d
+github.com/containerd/cgroups                       4994991857f9b0ae8dc439551e8bebdbb4bf66c1
+github.com/containerd/console                       c12b1e7919c14469339a5d38f2f8ed9b64a9de23
+github.com/containerd/go-runc                       5a6d9f37cfa36b15efba46dc7ea349fa9b7143c3
+github.com/containerd/typeurl                       a93fcdb778cd272c6e9b3028b2f42d813e785d40
+github.com/containerd/ttrpc                         f02858b1457c5ca3aaec3a0803eb0d59f96e41d6
+github.com/gogo/googleapis                          08a7655d27152912db7aaf4f983275eaf8d128ef
 
 # cluster
-github.com/docker/swarmkit 18e7e58ea1a5ec016625a636d0d52500eea123bc
-github.com/gogo/protobuf v1.2.0
-github.com/cloudflare/cfssl 1.3.2
-github.com/fernet/fernet-go 1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2
-github.com/google/certificate-transparency-go v1.0.20
-golang.org/x/crypto 38d8ce5564a5b71b2e3a00553993f1b9a7ae852f
-golang.org/x/time fbb02b2291d28baffd63558aa44b4b56f178d650
-github.com/hashicorp/go-memdb cb9a474f84cc5e41b273b20c6927680b2a8776ad
-github.com/hashicorp/go-immutable-radix 826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
-github.com/hashicorp/golang-lru 0fb14efe8c47ae851c0034ed7a448854d3d34cf3
-github.com/coreos/pkg v3
-github.com/pivotal-golang/clock 3fd3c1944c59d9742e1cd333672181cd1a6f9fa0
-github.com/prometheus/client_golang v0.8.0
-github.com/beorn7/perks 3a771d992973f24aa725d07868b467d1ddfceaf
-github.com/prometheus/client_model 6f3806018612930941127f2a7c6c453ba2c527d2
-github.com/prometheus/common 7600349dcfe1abd18d72d3a1770870d9800a7801
-github.com/prometheus/procfs 7d6f385de8bea29190f15ba9931442a0eaef9af7
-github.com/matttproud/golang_protobuf_extensions v1.0.0
-github.com/pkg/errors 645ef00459ed84a119197bfb8d8205042c6df63d # v0.8.0
-github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+github.com/docker/swarmkit                          18e7e58ea1a5ec016625a636d0d52500eea123bc
+github.com/gogo/protobuf                            4cbf7e384e768b4e01799441fdf2a706a5635ae7 # v1.2.0
+github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2
+github.com/fernet/fernet-go                         1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2
+github.com/google/certificate-transparency-go       37a384cd035e722ea46e55029093e26687138edf # v1.0.20
+golang.org/x/crypto                                 38d8ce5564a5b71b2e3a00553993f1b9a7ae852f
+golang.org/x/time                                   fbb02b2291d28baffd63558aa44b4b56f178d650
+github.com/hashicorp/go-memdb                       cb9a474f84cc5e41b273b20c6927680b2a8776ad
+github.com/hashicorp/go-immutable-radix             826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
+github.com/hashicorp/golang-lru                     0fb14efe8c47ae851c0034ed7a448854d3d34cf3
+github.com/coreos/pkg                               3ac0863d7acf3bc44daf49afef8919af12f704ef # v3
+github.com/pivotal-golang/clock                     3fd3c1944c59d9742e1cd333672181cd1a6f9fa0
+
+# prometheus
+github.com/prometheus/client_golang                 c5b7fccd204277076155f10851dad72b76a49317 # v0.8.0
+github.com/beorn7/perks                             3a771d992973f24aa725d07868b467d1ddfceafb
+github.com/prometheus/client_model                  6f3806018612930941127f2a7c6c453ba2c527d2
+github.com/prometheus/common                        7600349dcfe1abd18d72d3a1770870d9800a7801
+github.com/prometheus/procfs                        7d6f385de8bea29190f15ba9931442a0eaef9af7
+github.com/matttproud/golang_protobuf_extensions    3247c84500bff8d9fb6d579d800f20b3e091582c # v1.0.0
+github.com/pkg/errors                               645ef00459ed84a119197bfb8d8205042c6df63d # v0.8.0
+github.com/grpc-ecosystem/go-grpc-prometheus        c225b8c3b01faf2899099b768856a9e916e5087b # v1.2.0
 
 # cli
-github.com/spf13/cobra v0.0.3
-github.com/spf13/pflag v1.0.1
-github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75 # v1.0
-github.com/morikuni/aec 39771216ff4c63d11f5e604076f9c45e8be1067b
+github.com/spf13/cobra                              ef82de70bb3f60c65fb8eebacbb2d122ef517385 # v0.0.3
+github.com/spf13/pflag                              583c0c0531f06d5278b7d917446061adc344b5cd # v1.0.1
+github.com/inconshreveable/mousetrap                76626ae9c91c4f2a10f34cad8ce83ea42c93bb75 # v1.0.0
+github.com/morikuni/aec                             39771216ff4c63d11f5e604076f9c45e8be1067b
 
 # metrics
-github.com/docker/go-metrics d466d4f6fd960e01820085bd7e1a24426ee7ef18
+github.com/docker/go-metrics                        d466d4f6fd960e01820085bd7e1a24426ee7ef18
 
-github.com/opencontainers/selinux 0bb7b9fa9ba5c1120e9d22caed4961fca4228408 # v1.2.1
+github.com/opencontainers/selinux                   0bb7b9fa9ba5c1120e9d22caed4961fca4228408 # v1.2.1


### PR DESCRIPTION
to make it better readable, and to encourage pinning by sha, but "align" to a tagged release.