### PR TITLE
Proposal: Check if buffer is empty on CopyToContainer

### DIFF
--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -1,6 +1,7 @@
 package client // import "github.com/docker/docker/client"
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -37,6 +38,16 @@ func (cli *Client) CopyToContainer(ctx context.Context, containerID, dstPath str
 	if !options.AllowOverwriteDirWithFile {
 		query.Set("noOverwriteDirNonDir", "true")
 	}
+
+	// Only way to check if content was read before or is empty is trying to read it
+	var buf []byte
+	n, err := content.Read(buf)
+	if err != nil || n == 0 {
+		return fmt.Errorf("Empty or used reader received")
+	}
+
+	// If content is not empty, then returns buffer to its original reader
+	content = bytes.NewReader(buf)
 
 	if options.CopyUIDGID {
 		query.Set("copyUIDGID", "true")


### PR DESCRIPTION
Signed-off-by: Vieira Neto <vieiranetoc@gmail.com>
This commit refers to #39045
fix #39045 
Please provide the following information:
-->

**- What I did**
Added a way to verify if tar reader is empty before trying to send it to container

**- How I did it**
Saved to a temp buff and checked if read returns an error or 0 read bytes

**- How to verify it**
Passing an empty reader or an already read reader to cli.CopyToContainer

**- Description for the changelog**
Passing an already read Reader to cli.CopyToContainer throws an error instead of perfoming a null operation

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/12820045/55923214-dec59680-5bda-11e9-980b-f3ee0471f3ff.png)

