### PR TITLE
Bump Golang 1.12.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@
 
 ARG CROSS="false"
 
-FROM golang:1.12.3 AS base
+FROM golang:1.12.4 AS base
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org
 RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,5 +1,5 @@
 ## Step 1: Build tests
-FROM golang:1.12.3-alpine as builder
+FROM golang:1.12.4-alpine as builder
 
 RUN apk --no-cache add \
     bash \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-FROM golang:1.12.3
+FROM golang:1.12.4
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -168,7 +168,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
-ENV GO_VERSION=1.12.3 `
+ENV GO_VERSION=1.12.4 `
     GIT_VERSION=2.11.1 `
     GOPATH=C:\go `
     FROM_DOCKERFILE=1


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

go1.12.4 (released 2019/04/11) fixes an issue where using the prebuilt binary.

https://github.com/golang/go/compare/go1.12.3...go1.12.4

The issue https://github.com/golang/go/issues/31293 has been fixed and closed now.

We can bump Golang to 1.12.4 

We need hold until golang  official image has been published. (wait the bot auto update or I will open a PR for it.)