### PR TITLE
Allow to push an image without tagging it in the registry

### DIFF
--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -36,6 +36,6 @@ type importExportBackend interface {
 
 type registryBackend interface {
 	PullImage(ctx context.Context, image, tag string, platform *specs.Platform, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
-	PushImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
+	PushImage(ctx context.Context, image, tag string, tagInRegistry bool, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
 	SearchRegistryForImages(ctx context.Context, filtersArgs string, term string, limit int, authConfig *types.AuthConfig, metaHeaders map[string][]string) (*registry.SearchResults, error)
 }

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -126,13 +126,21 @@ func (s *imageRouter) postImagesPush(ctx context.Context, w http.ResponseWriter,
 
 	image := vars["name"]
 	tag := r.Form.Get("tag")
+	tagInRegistry := true
+	if tagInRegistryString := r.Form.Get("registry-tag"); tagInRegistryString != "" {
+		parsed, err := strconv.ParseBool(tagInRegistryString)
+		if err != nil {
+			return err
+		}
+		tagInRegistry = parsed
+	}
 
 	output := ioutils.NewWriteFlusher(w)
 	defer output.Close()
 
 	w.Header().Set("Content-Type", "application/json")
 
-	if err := s.backend.PushImage(ctx, image, tag, metaHeaders, authConfig, output); err != nil {
+	if err := s.backend.PushImage(ctx, image, tag, tagInRegistry, metaHeaders, authConfig, output); err != nil {
 		if !output.Flushed() {
 			return err
 		}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6837,6 +6837,11 @@ paths:
           in: "query"
           description: "The tag to associate with the image on the registry."
           type: "string"
+        - name: "registry-tag"
+          in: "query"
+          type: "boolean"
+          default: true
+          description: "Tag the manifest in the registry (if false, push the manifest can only be retrieved by digest)"
         - name: "X-Registry-Auth"
           in: "header"
           description: "A base64-encoded auth configuration. [See the authentication section for details.](#section/Authentication)"

--- a/client/image_push.go
+++ b/client/image_push.go
@@ -15,7 +15,7 @@ import (
 // It executes the privileged function if the operation is unauthorized
 // and it tries one more time.
 // It's up to the caller to handle the io.ReadCloser and close it properly.
-func (cli *Client) ImagePush(ctx context.Context, image string, options types.ImagePushOptions) (io.ReadCloser, error) {
+func (cli *Client) ImagePush(ctx context.Context, image string, options types.ImagePushOptions, tagInRegistry bool) (io.ReadCloser, error) {
 	ref, err := reference.ParseNormalizedNamed(image)
 	if err != nil {
 		return nil, err
@@ -34,6 +34,9 @@ func (cli *Client) ImagePush(ctx context.Context, image string, options types.Im
 
 	query := url.Values{}
 	query.Set("tag", tag)
+	if !tagInRegistry {
+		query.Set("registry-tag", "false")
+	}
 
 	resp, err := cli.tryImagePush(ctx, name, query, options.RegistryAuth)
 	if errdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {

--- a/client/interface.go
+++ b/client/interface.go
@@ -95,7 +95,7 @@ type ImageAPIClient interface {
 	ImageList(ctx context.Context, options types.ImageListOptions) ([]types.ImageSummary, error)
 	ImageLoad(ctx context.Context, input io.Reader, quiet bool) (types.ImageLoadResponse, error)
 	ImagePull(ctx context.Context, ref string, options types.ImagePullOptions) (io.ReadCloser, error)
-	ImagePush(ctx context.Context, ref string, options types.ImagePushOptions) (io.ReadCloser, error)
+	ImagePush(ctx context.Context, ref string, options types.ImagePushOptions, tagInRegistry bool) (io.ReadCloser, error)
 	ImageRemove(ctx context.Context, image string, options types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error)
 	ImageSearch(ctx context.Context, term string, options types.ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)

--- a/daemon/images/image_push.go
+++ b/daemon/images/image_push.go
@@ -14,7 +14,7 @@ import (
 )
 
 // PushImage initiates a push operation on the repository named localName.
-func (i *ImageService) PushImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error {
+func (i *ImageService) PushImage(ctx context.Context, image, tag string, tagInRegistry bool, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error {
 	start := time.Now()
 	ref, err := reference.ParseNormalizedNamed(image)
 	if err != nil {
@@ -43,14 +43,15 @@ func (i *ImageService) PushImage(ctx context.Context, image, tag string, metaHea
 
 	imagePushConfig := &distribution.ImagePushConfig{
 		Config: distribution.Config{
-			MetaHeaders:      metaHeaders,
-			AuthConfig:       authConfig,
-			ProgressOutput:   progress.ChanOutput(progressChan),
-			RegistryService:  i.registryService,
-			ImageEventLogger: i.LogImageEvent,
-			MetadataStore:    i.distributionMetadataStore,
-			ImageStore:       distribution.NewImageConfigStoreFromStore(i.imageStore),
-			ReferenceStore:   i.referenceStore,
+			MetaHeaders:        metaHeaders,
+			AuthConfig:         authConfig,
+			ProgressOutput:     progress.ChanOutput(progressChan),
+			RegistryService:    i.registryService,
+			ImageEventLogger:   i.LogImageEvent,
+			MetadataStore:      i.distributionMetadataStore,
+			ImageStore:         distribution.NewImageConfigStoreFromStore(i.imageStore),
+			ReferenceStore:     i.referenceStore,
+			ApplyTagInRegistry: tagInRegistry,
 		},
 		ConfigMediaType: schema2.MediaTypeImageConfig,
 		LayerStores:     distribution.NewLayerProvidersFromStores(i.layerStores),

--- a/distribution/config.go
+++ b/distribution/config.go
@@ -48,6 +48,8 @@ type Config struct {
 	ReferenceStore refstore.Store
 	// RequireSchema2 ensures that only schema2 manifests are used.
 	RequireSchema2 bool
+	// ApplyTagInRegistry indicates if the manifest should be tagged or will only be retrieved by digest
+	ApplyTagInRegistry bool
 }
 
 // ImagePullConfig stores pull configuration.

--- a/distribution/push_v1.go
+++ b/distribution/push_v1.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/image"
-	"github.com/docker/docker/image/v1"
+	v1 "github.com/docker/docker/image/v1"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progress"
@@ -354,7 +354,7 @@ func (p *v1Pusher) pushImageToEndpoint(ctx context.Context, endpoint string, ima
 				return err
 			}
 		}
-		if topImage, isTopImage := img.(*v1TopImage); isTopImage {
+		if topImage, isTopImage := img.(*v1TopImage); isTopImage && p.config.ApplyTagInRegistry {
 			for _, tag := range tags[topImage.imageID] {
 				progress.Messagef(p.config.ProgressOutput, "", "Pushing tag for rev [%s] on {%s}", stringid.TruncateID(v1ID), endpoint+"repositories/"+reference.Path(p.repoInfo.Name)+"/tags/"+tag)
 				if err := p.session.PushRegistryTag(p.repoInfo.Name, v1ID, tag, endpoint); err != nil {


### PR DESCRIPTION
**- What I did**

Currently, there is no way to push an image to a registry without tagging it. This can lead to registry polution, the purpose of this image is only to be part of a manifest list (e.g.: multi-arch image, or docker-app CNABs).
This adds a query parameter "registry-tag bool" defaulted to true to get
the same behavior as before by default, that allows to push an image
without tagging it.

**- How I did it**

see description above

**- How to verify it**

// TODO: need help with testability

@thaJeztah, for a bit of context, this is to avoid having to rely on dirty hacks like: https://github.com/docker/app/pull/506