### PR TITLE
vendor.conf: reserve space for downstream projects

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -164,3 +164,5 @@ github.com/morikuni/aec                             39771216ff4c63d11f5e604076f9
 github.com/docker/go-metrics                        d466d4f6fd960e01820085bd7e1a24426ee7ef18
 
 github.com/opencontainers/selinux                   0bb7b9fa9ba5c1120e9d22caed4961fca4228408 # v1.2.1
+
+# DO NOT EDIT BELOW THIS LINE -------- reserved for downstream projects --------


### PR DESCRIPTION
This helps merge conflicts in situations where downstream projects (such as Docker EE) have additional dependencies.

