### PR TITLE
Update container name pattern in swagger.yaml

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4611,9 +4611,9 @@ paths:
       parameters:
         - name: "name"
           in: "query"
-          description: "Assign the specified name to the container. Must match `/?[a-zA-Z0-9_-]+`."
+          description: "Assign the specified name to the container. Must match `/?[a-zA-Z0-9][a-zA-Z0-9_.-]+`."
           type: "string"
-          pattern: "/?[a-zA-Z0-9_-]+"
+          pattern: "^/?[a-zA-Z0-9][a-zA-Z0-9_.-]+$"
         - name: "body"
           in: "body"
           description: "Container to create"


### PR DESCRIPTION
**- What I did**
Fix inconsistent container name regex in API reference

**- How I did it**
Update container name pattern in swagger.yaml to follow the pattern declared here https://github.com/moby/moby/blob/be97c66708c24727836a22247319ff2943d91a03/daemon/names/names.go#L5-L9

**- Description for the changelog*
Update inconsistent API reference

**- A picture of a cute animal (not mandatory but encouraged)**
![whale](https://cdn.pixabay.com/photo/2013/07/13/12/09/animal-159277_960_720.png)

closes #39067
