### PR TITLE
Bump fsnotify to HEAD.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -101,7 +101,7 @@ github.com/philhofer/fwd                            bb6d471dc95d4fe11e432687f8b7
 github.com/tinylib/msgp                             3b556c64540842d4f82967be066a7f7fffc3adad
 
 # fsnotify
-github.com/fsnotify/fsnotify                        c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9 # v1.4.7
+github.com/fsnotify/fsnotify                        1485a34d5d5723fea214f5710708e19a831720e4 # v1.4.7-11-g1485a34
 
 # awslogs deps
 github.com/aws/aws-sdk-go                           9ed0c8de252f04ac45a65358377103d5a1aa2d92 # v1.12.66

--- a/vendor/github.com/fsnotify/fsnotify/README.md
+++ b/vendor/github.com/fsnotify/fsnotify/README.md
@@ -14,7 +14,7 @@ Cross platform: Windows, Linux, BSD and macOS.
 |----------|----------|----------|
 |inotify   |Linux 2.6.27 or later, Android\*|Supported [![Build Status](https://travis-ci.org/fsnotify/fsnotify.svg?branch=master)](https://travis-ci.org/fsnotify/fsnotify)|
 |kqueue    |BSD, macOS, iOS\*|Supported [![Build Status](https://travis-ci.org/fsnotify/fsnotify.svg?branch=master)](https://travis-ci.org/fsnotify/fsnotify)|
-|ReadDirectoryChangesW|Windows|Supported [![Build status](https://ci.appveyor.com/api/projects/status/ivwjubaih4r0udeh/branch/master?svg=true)](https://ci.appveyor.com/project/NathanYoungman/fsnotify/branch/master)|
+|ReadDirectoryChangesW|Windows|Supported [![Build Status](https://travis-ci.org/fsnotify/fsnotify.svg?branch=master)](https://travis-ci.org/fsnotify/fsnotify)|
 |FSEvents  |macOS         |[Planned](https://github.com/fsnotify/fsnotify/issues/11)|
 |FEN       |Solaris 11    |[In Progress](https://github.com/fsnotify/fsnotify/issues/12)|
 |fanotify  |Linux 2.6.37+ | |

--- a/vendor/github.com/fsnotify/fsnotify/fsnotify.go
+++ b/vendor/github.com/fsnotify/fsnotify/fsnotify.go
@@ -63,4 +63,6 @@ func (e Event) String() string {
 }
 
 // Common errors that can be reported by a watcher
-var ErrEventOverflow = errors.New("fsnotify queue overflow")
+var (
+	ErrEventOverflow = errors.New("fsnotify queue overflow")
+)

--- a/vendor/github.com/fsnotify/fsnotify/inotify_poller.go
+++ b/vendor/github.com/fsnotify/fsnotify/inotify_poller.go
@@ -40,12 +40,12 @@ func newFdPoller(fd int) (*fdPoller, error) {
 	poller.fd = fd
 
 	// Create epoll fd
-	poller.epfd, errno = unix.EpollCreate1(0)
+	poller.epfd, errno = unix.EpollCreate1(unix.EPOLL_CLOEXEC)
 	if poller.epfd == -1 {
 		return nil, errno
 	}
 	// Create pipe; pipe[0] is the read end, pipe[1] the write end.
-	errno = unix.Pipe2(poller.pipe[:], unix.O_NONBLOCK)
+	errno = unix.Pipe2(poller.pipe[:], unix.O_NONBLOCK|unix.O_CLOEXEC)
 	if errno != nil {
 		return nil, errno
 	}


### PR DESCRIPTION
This specifically has a fix for leaking epoll fd's.

Full diff: https://github.com/fsnotify/fsnotify/commit/1485a34d5d5723fea214f5710708e19a831720e4