### PR TITLE
Fluentd: add fluentd-async, fluentd-request-ack, and deprecate fluentd-async-connect 

### DIFF
--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -39,21 +39,21 @@ type location struct {
 const (
 	name = "fluentd"
 
-	defaultProtocol    = "tcp"
+	defaultBufferLimit = 1024 * 1024
 	defaultHost        = "127.0.0.1"
 	defaultPort        = 24224
-	defaultBufferLimit = 1024 * 1024
+	defaultProtocol    = "tcp"
 
 	// logger tries to reconnect 2**32 - 1 times
 	// failed (and panic) after 204 years [ 1.5 ** (2**32 - 1) - 1 seconds]
-	defaultRetryWait  = 1000
 	defaultMaxRetries = math.MaxInt32
+	defaultRetryWait  = 1000
 
 	addressKey            = "fluentd-address"
-	bufferLimitKey        = "fluentd-buffer-limit"
-	retryWaitKey          = "fluentd-retry-wait"
-	maxRetriesKey         = "fluentd-max-retries"
 	asyncConnectKey       = "fluentd-async-connect"
+	bufferLimitKey        = "fluentd-buffer-limit"
+	maxRetriesKey         = "fluentd-max-retries"
+	retryWaitKey          = "fluentd-retry-wait"
 	subSecondPrecisionKey = "fluentd-sub-second-precision"
 )
 
@@ -195,11 +195,12 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case "labels":
 		case "labels-regex":
 		case "tag":
+
 		case addressKey:
-		case bufferLimitKey:
-		case retryWaitKey:
-		case maxRetriesKey:
 		case asyncConnectKey:
+		case bufferLimitKey:
+		case maxRetriesKey:
+		case retryWaitKey:
 		case subSecondPrecisionKey:
 			// Accepted
 		default:

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/loggerutils"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/urlutil"
 	units "github.com/docker/go-units"
 	"github.com/fluent/fluent-logger-golang/fluent"
@@ -71,17 +72,17 @@ func init() {
 func New(info logger.Info) (logger.Logger, error) {
 	loc, err := parseAddress(info.Config[addressKey])
 	if err != nil {
-		return nil, err
+		return nil, errdefs.InvalidParameter(err)
 	}
 
 	tag, err := loggerutils.ParseLogTag(info, loggerutils.DefaultTemplate)
 	if err != nil {
-		return nil, err
+		return nil, errdefs.InvalidParameter(err)
 	}
 
 	extra, err := info.ExtraAttributes(nil)
 	if err != nil {
-		return nil, err
+		return nil, errdefs.InvalidParameter(err)
 	}
 
 	bufferLimit := defaultBufferLimit

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -53,6 +53,7 @@ const (
 	asyncConnectKey       = "fluentd-async-connect" // deprecated option (use fluent-async instead)
 	bufferLimitKey        = "fluentd-buffer-limit"
 	maxRetriesKey         = "fluentd-max-retries"
+	requestAckKey         = "fluentd-request-ack"
 	retryWaitKey          = "fluentd-retry-wait"
 	subSecondPrecisionKey = "fluentd-sub-second-precision"
 )
@@ -148,6 +149,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case asyncConnectKey:
 		case bufferLimitKey:
 		case maxRetriesKey:
+		case requestAckKey:
 		case retryWaitKey:
 		case subSecondPrecisionKey:
 			// Accepted
@@ -221,6 +223,13 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 		}
 	}
 
+	requestAck := false
+	if cfg[requestAckKey] != "" {
+		if requestAck, err = strconv.ParseBool(cfg[requestAckKey]); err != nil {
+			return config, err
+		}
+	}
+
 	config = fluent.Config{
 		FluentPort:         loc.port,
 		FluentHost:         loc.host,
@@ -232,6 +241,7 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 		Async:              async,
 		AsyncConnect:       asyncConnect,
 		SubSecondPrecision: subSecondPrecision,
+		RequestAck:         requestAck,
 	}
 
 	return config, nil

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -90,6 +90,12 @@ keywords: "API, Docker, rcli, REST, documentation"
   option, which remains funtional, but will be removed in a future release. Users
   are encouraged to use the `fluentd-async` option going forward. This change is
   not versioned, and affects all API versions if the daemon has this patch.
+* `POST /containers/create` now accepts a `fluentd-request-ack` option in
+  `HostConfig.LogConfig.Config` when using the Fluentd logging driver. If enabled,
+  the Fluentd logging driver sends the chunk option with a unique ID. The server
+  will respond with an acknowledgement. This option improves the reliability of
+  the message transmission. This change is not versioned, and affects all API
+  versions if the daemon has this patch.
 * `POST /containers/create`, `GET /containers/{id}/json`, and `GET /containers/json` now supports
   `BindOptions.NonRecursive`.
 * `POST /swarm/init` now accepts a `DataPathPort` property to set data path port number.

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -85,6 +85,11 @@ keywords: "API, Docker, rcli, REST, documentation"
   on the node.label. The format of the label filter is `node.label=<key>`/`node.label=<key>=<value>`
   to return those with the specified labels, or `node.label!=<key>`/`node.label!=<key>=<value>`
   to return those without the specified labels.
+* `POST /containers/create` now accepts a `fluentd-async` option in `HostConfig.LogConfig.Config`
+  when using the Fluentd logging driver. This option deprecates the `fluentd-async-connect`
+  option, which remains funtional, but will be removed in a future release. Users
+  are encouraged to use the `fluentd-async` option going forward. This change is
+  not versioned, and affects all API versions if the daemon has this patch.
 * `POST /containers/create`, `GET /containers/{id}/json`, and `GET /containers/json` now supports
   `BindOptions.NonRecursive`.
 * `POST /swarm/init` now accepts a `DataPathPort` property to set data path port number.


### PR DESCRIPTION
~Follow up to https://github.com/moby/moby/pull/39074 (first two commits are from that PR; I'll rebase once that's merged)~ (rebased)

- closes https://github.com/moby/moby/pull/40332

- Some minor refactoring; the driver now not only validates if options are supported, but also if their value can be parsed (producing an error earlier, instead of when instantiating a driver)
- Add `fluentd-async` option, deprecate `fluentd-async-connect`. This ia a rename of the old option. The old option remains functional, but when used will log a deprecation warning in fluentd.  If both the new, and old option is set, a "conflicting options" error is produced. This change is not versioned, and affects all API versions.
- Add `fluentd-request-ack` option. This adds a new `fluentd-request-ack` logging option for the Fluentd logging driver. If enabled, the server will respond with an acknowledgement. This option improves the reliability of the message transmission. This change is not versioned, and affects all API versions.