### PR TITLE
Add support for setting GOARM in cross target.

### DIFF
--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -80,6 +80,7 @@ case "$(go env GOOS)/$(go env GOARCH)" in
 esac
 
 echo "Building: $DEST/$BINARY_FULLNAME"
+echo "GOOS=\"${GOOS}\" GOARCH=\"${GOARCH}\" GOARM=\"${GOARM}\""
 go build \
 	-o "$DEST/$BINARY_FULLNAME" \
 	"${BUILDFLAGS[@]}" \

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -18,8 +18,14 @@ for platform in ${DOCKER_CROSSPLATFORMS}; do
 	(
 		export KEEPDEST=1
 		export DEST="${DEST}/${platform}" # bundles/VERSION/cross/GOOS/GOARCH/docker-VERSION
-		export GOOS=${platform%/*}
-		export GOARCH=${platform##*/}
+		export GOOS=${platform%%/*}
+		export GOARCH=${platform#*/}
+
+		if [[ "${GOARCH}" = "arm/"* ]]; then
+			GOARM=${GOARCH##*/v}
+			GOARCH=${GOARCH%/v*}
+			export GOARM
+		fi
 
 		echo "Cross building: ${DEST}"
 		mkdir -p "${DEST}"

--- a/project/PACKAGERS.md
+++ b/project/PACKAGERS.md
@@ -233,6 +233,27 @@ following:
 This will create "./bundles/$VERSION/dynbinary-client/docker-$VERSION", which for
 client-only builds is the important file to grab and install as appropriate.
 
+### Cross Compilation
+
+Limited cross compilation is supported due to requiring cgo for critical
+functionality (such as seccomp support).
+
+To cross compile run `make cross`. You can specify the platforms to target by
+setting the `DOCKER_CROSSPLATFORMS` environment variable to a list of platforms
+in the format `<GOOS>/<GOARCH>`. Specify multiple platforms by using a space
+in between each desired platform.
+
+For setting arm variants, you can specify the `GOARM` value by append `/v<GOARM>`
+to your `<GOOS>/arm`. Example:
+
+```
+make DOCKER_CROSSPLATFORMS=linux/arm/v7 cross
+```
+
+This will create a linux binary targeting arm 7.
+
+See `hack/make/.binary` for supported cross compliation platforms.
+
 ## System Dependencies
 
 ### Runtime Dependencies


### PR DESCRIPTION
This adds to the existing format of `<GOOS>/<GOARCH>` to allow for
`<GOOS>/arm/v<GOARM>`