### PR TITLE
Use existing Windows image for test instead of microsoft/nanoserver

### DIFF
--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -266,12 +266,12 @@ func (s *DockerHubPullSuite) TestPullClientDisconnect(c *check.C) {
 func (s *DockerSuite) TestPullLinuxImageFailsOnWindows(c *check.C) {
 	testRequires(c, DaemonIsWindows, Network)
 	_, _, err := dockerCmdWithError("pull", "ubuntu")
-	assert.ErrorContains(c, err, "no matching manifest")
+	assert.ErrorContains(c, err, "no matching manifest for windows")
 }
 
 // Regression test for https://github.com/docker/docker/issues/28892
 func (s *DockerSuite) TestPullWindowsImageFailsOnLinux(c *check.C) {
 	testRequires(c, DaemonIsLinux, Network)
-	_, _, err := dockerCmdWithError("pull", "microsoft/nanoserver")
-	assert.ErrorContains(c, err, "cannot be used on this platform")
+	_, _, err := dockerCmdWithError("pull", "mcr.microsoft.com/windows/servercore:ltsc2019")
+	assert.ErrorContains(c, err, "no matching manifest for linux")
 }


### PR DESCRIPTION
**- What I did**

Fix the test TestPullWindowsImageFailsOnLinux  as the latest tag is no longer available as seen in https://jenkins.dockerproject.org/job/Docker-PRs/53794/console
Also improve the tests to check `no matching manifest for ...` does not contain `unknown`.

**- How I did it**

**- How to verify it**

make test-integration

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

_the animal is invisible as the latest tag_
