### PR TITLE
Add regression tests for pull errors from a manifest list

### DIFF
--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -263,10 +263,11 @@ func (s *DockerHubPullSuite) TestPullClientDisconnect(c *check.C) {
 }
 
 // Regression test for https://github.com/docker/docker/issues/26429
+// Regression test for https://github.com/moby/moby/pull/38574
 func (s *DockerSuite) TestPullLinuxImageFailsOnWindows(c *check.C) {
 	testRequires(c, DaemonIsWindows, Network)
 	_, _, err := dockerCmdWithError("pull", "ubuntu")
-	assert.ErrorContains(c, err, "no matching manifest")
+	assert.ErrorContains(c, err, "no matching manifest for windows")
 }
 
 // Regression test for https://github.com/docker/docker/issues/28892
@@ -274,4 +275,11 @@ func (s *DockerSuite) TestPullWindowsImageFailsOnLinux(c *check.C) {
 	testRequires(c, DaemonIsLinux, Network)
 	_, _, err := dockerCmdWithError("pull", "microsoft/nanoserver")
 	assert.ErrorContains(c, err, "cannot be used on this platform")
+}
+
+// Regression test for https://github.com/moby/moby/pull/38574
+func (s *DockerSuite) TestPullWindowsImageFromManifestListFailsOnLinux(c *check.C) {
+	testRequires(c, DaemonIsLinux, Network)
+	_, _, err := dockerCmdWithError("pull", "mcr.microsoft.com/windows/nanoserver:1809")
+	assert.ErrorContains(c, err, "no matching manifest for linux")
 }


### PR DESCRIPTION
**- What I did**

Add regression tests for #38574
The error message musn't show `no matching manifest for unknown`, but the operating system of the Docker engine.

**- How I did it**

**- How to verify it**

Pull `ubuntu` on a Windows machine
```
$ docker pull ubuntu
Using default tag: latest
latest: Pulling from library/ubuntu
no matching manifest for windows/amd64 in the manifest list entries
```

Pull the Windows nanoserver image on a Linux machine

```
$ docker pull mcr.microsoft.com/windows/nanoserver:1809
1809: Pulling from windows/nanoserver
no matching manifest for linux/arm/v7 in the manifest list entries
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

