### PR TITLE
Replace deprecated microsoft/windowsservercore:latest image

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -63,10 +63,11 @@
 #
 #
 # 3. Build a docker image with the components required to build the docker binaries from source
-#    by running one of the following:
+#    by running one of the following, specifying the Windows version you're building on. For example,
+#    the following commands build the binaries on Windows Server 1607 ("RS1"):
 #
-#    >>   docker build -t nativebuildimage -f Dockerfile.windows .          
-#    >>   docker build -t nativebuildimage -f Dockerfile.windows -m 2GB .    (if using Hyper-V containers)
+#    >>   docker build -t nativebuildimage --build-arg WINDOWS_VERSION=1607 -f Dockerfile.windows .
+#    >>   docker build -t nativebuildimage --build-arg WINDOWS_VERSION=1607 -f Dockerfile.windows -m 2GB .    (if using Hyper-V containers)
 #
 #
 # 4. Build the docker executable binaries by running one of the following:
@@ -152,15 +153,14 @@
 # -----------------------------------------------------------------------------------------
 
 
+# Extremely important. If using this Dockerfile in process isolated containers,
+# the kernel of the host must match the container image, and hence would fail
+# between Windows Server 2016 (aka RS1) and Windows Server 2019 (aka RS5).
+ARG WINDOWS_VERSION=${WINDOWS_VERSION:-1809}
+
 # The number of build steps below are explicitly minimised to improve performance.
 
-# Extremely important - do not change the following line to reference a "specific" image, 
-# such as `mcr.microsoft.com/windows/servercore:ltsc2019`. If using this Dockerfile in process
-# isolated containers, the kernel of the host must match the container image, and hence
-# would fail between Windows Server 2016 (aka RS1) and Windows Server 2019 (aka RS5).
-# It is expected that the image `microsoft/windowsservercore:latest` is present, and matches
-# the hosts kernel version before doing a build. 
-FROM microsoft/windowsservercore
+FROM mcr.microsoft.com/windows/servercore:${WINDOWS_VERSION}
 
 # Use PowerShell as the default shell
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -282,6 +282,9 @@ ENTRYPOINT ["powershell.exe"]
 
 # Set the working directory to the location of the sources
 WORKDIR ${GOPATH}\src\github.com\docker\docker
+
+ARG WINDOWS_VERSION
+ENV WINDOWS_VERSION=${WINDOWS_VERSION}
 
 # Copy the sources into the container
 COPY . .

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -66,8 +66,8 @@
 #    by running one of the following, specifying the Windows version you're building on. For example,
 #    the following commands build the binaries on Windows Server 1607 ("RS1"):
 #
-#    >>   docker build -t nativebuildimage --build-arg WINDOWS_VERSION=1607 -f Dockerfile.windows .
-#    >>   docker build -t nativebuildimage --build-arg WINDOWS_VERSION=1607 -f Dockerfile.windows -m 2GB .    (if using Hyper-V containers)
+#    >>   docker build -t nativebuildimage --build-arg WINDOWS_BASE_IMAGE_TAG=1607 -f Dockerfile.windows .
+#    >>   docker build -t nativebuildimage --build-arg WINDOWS_BASE_IMAGE_TAG=1607 -f Dockerfile.windows -m 2GB .    (if using Hyper-V containers)
 #
 #
 # 4. Build the docker executable binaries by running one of the following:
@@ -156,11 +156,12 @@
 # Extremely important. If using this Dockerfile in process isolated containers,
 # the kernel of the host must match the container image, and hence would fail
 # between Windows Server 2016 (aka RS1) and Windows Server 2019 (aka RS5).
-ARG WINDOWS_VERSION=${WINDOWS_VERSION:-1809}
+ARG WINDOWS_BASE_IMAGE=mcr.microsoft.com/windows/servercore
+ARG WINDOWS_BASE_IMAGE_TAG=1809
 
 # The number of build steps below are explicitly minimised to improve performance.
 
-FROM mcr.microsoft.com/windows/servercore:${WINDOWS_VERSION}
+FROM ${WINDOWS_BASE_IMAGE}:${WINDOWS_BASE_IMAGE_TAG}
 
 # Use PowerShell as the default shell
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -283,8 +284,8 @@ ENTRYPOINT ["powershell.exe"]
 # Set the working directory to the location of the sources
 WORKDIR ${GOPATH}\src\github.com\docker\docker
 
-ARG WINDOWS_VERSION
-ENV WINDOWS_VERSION=${WINDOWS_VERSION}
+ARG WINDOWS_BASE_IMAGE_TAG
+ENV WINDOWS_BASE_IMAGE_TAG=${WINDOWS_BASE_IMAGE_TAG}
 
 # Copy the sources into the container
 COPY . .

--- a/opts/hosts_windows.go
+++ b/opts/hosts_windows.go
@@ -10,9 +10,9 @@ const (
 	// (and daemon as this is local) is not physically on a network, and the DNS
 	// cache is flushed (ipconfig /flushdns), then the client will pause for
 	// exactly one second when connecting to the daemon for calls. For example
-	// using docker run windowsservercore cmd, the CLI will send a create followed
-	// by an attach. You see the delay between the attach finishing and the attach
-	// being seen by the daemon.
+	// using docker run mcr.microsoft.com/windows/servercore:1607 cmd, the CLI will
+	// send a create followed by an attach. You see the delay between the attach
+	// finishing and the attach being seen by the daemon.
 	//
 	// Here's some daemon debug logs with additional debug spew put in. The
 	// AfterWriteJSON log is the very last thing the daemon does as part of the

--- a/testutil/environment/environment.go
+++ b/testutil/environment/environment.go
@@ -83,21 +83,19 @@ func getPlatformDefaults(info types.Info, osType string) PlatformDefaults {
 		}
 	case "windows":
 		var baseImage string
+		// Default to Windows Server 2019
+		baseImageRepo := "mcr.microsoft.com/windows/servercore"
+		baseImageTag := "1809"
+
 		if overrideBaseImage := os.Getenv("WINDOWS_BASE_IMAGE"); overrideBaseImage != "" {
-			baseImage = overrideBaseImage
-			if overrideBaseImageTag := os.Getenv("WINDOWS_BASE_IMAGE_TAG"); overrideBaseImageTag != "" {
-				baseImage = baseImage + ":" + overrideBaseImageTag
-			}
-		} else {
-			baseImageRepo := "mcr.microsoft.com/windows/servercore"
-			baseImageTag := "1809"
-
-			if windowsVersion := os.Getenv("WINDOWS_VERSION"); windowsVersion != "" {
-				baseImageTag = windowsVersion
-			}
-
-			baseImage = baseImageRepo + ":" + baseImageTag
+			// When setting `WINDOWS_BASE_IMAGE`, assume it's a full reference, including tag
+			baseImageRepo = overrideBaseImage
+			baseImageTag = ""
 		}
+		if overrideBaseImageTag := os.Getenv("WINDOWS_BASE_IMAGE_TAG"); overrideBaseImageTag != "" {
+			baseImageTag = overrideBaseImageTag
+		}
+		baseImage = baseImageRepo + ":" + baseImageTag
 		fmt.Println("INFO: Windows Base image is", baseImage)
 		return PlatformDefaults{
 			BaseImage:            baseImage,

--- a/testutil/environment/environment.go
+++ b/testutil/environment/environment.go
@@ -82,14 +82,23 @@ func getPlatformDefaults(info types.Info, osType string) PlatformDefaults {
 			ContainerStoragePath: toSlash(containersPath),
 		}
 	case "windows":
-		baseImage := "microsoft/windowsservercore"
+		var baseImage string
 		if overrideBaseImage := os.Getenv("WINDOWS_BASE_IMAGE"); overrideBaseImage != "" {
 			baseImage = overrideBaseImage
 			if overrideBaseImageTag := os.Getenv("WINDOWS_BASE_IMAGE_TAG"); overrideBaseImageTag != "" {
 				baseImage = baseImage + ":" + overrideBaseImageTag
 			}
+		} else {
+			baseImageRepo := "mcr.microsoft.com/windows/servercore"
+			baseImageTag := "1809"
+
+			if windowsVersion := os.Getenv("WINDOWS_VERSION"); windowsVersion != "" {
+				baseImageTag = windowsVersion
+			}
+
+			baseImage = baseImageRepo + ":" + baseImageTag
 		}
-		fmt.Println("INFO: Windows Base image is ", baseImage)
+		fmt.Println("INFO: Windows Base image is", baseImage)
 		return PlatformDefaults{
 			BaseImage:            baseImage,
 			VolumesConfigPath:    filepath.FromSlash(volumesPath),


### PR DESCRIPTION
Microsoft recently deprecated the :latest tag, and removed those
images from Docker Hub. This means that the current Dockerfile could
no longer be built.

> We are deprecating the 'latest' tag across all our Windows base images to encourage
> better container practices. **At the beginning of the 2019 calendar year, we will
> no longer publish the tag**; We'll yank it from the available tags list.

(see https://techcommunity.microsoft.com/t5/Containers/Windows-Server-2019-Now-Available/ba-p/382430)

CI still kept running because those machines are prepared (the base image is pre-loaded on those machines).

