### PR TITLE
MAINTAINERS: update Akihiro Suda's email address

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -17,7 +17,9 @@ AJ Bowen <aj@soulshake.net>
 AJ Bowen <aj@soulshake.net> <aj@gandi.net>
 AJ Bowen <aj@soulshake.net> <amy@gandi.net>
 Akihiro Matsushima <amatsusbit@gmail.com> <amatsus@users.noreply.github.com>
-Akihiro Suda <suda.akihiro@lab.ntt.co.jp> <suda.kyoto@gmail.com>
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> <suda.kyoto@gmail.com>
+Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp> <suda.akihiro@lab.ntt.co.jp>
 Aleksa Sarai <asarai@suse.de>
 Aleksa Sarai <asarai@suse.de> <asarai@suse.com>
 Aleksa Sarai <asarai@suse.de> <cyphar@cyphar.com>

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -240,7 +240,7 @@
 
 	[people.akihirosuda]
 	Name = "Akihiro Suda"
-	Email = "suda.akihiro@lab.ntt.co.jp"
+	Email = "akihiro.suda.cz@hco.ntt.co.jp"
 	GitHub = "AkihiroSuda"
 
 	[people.aluzzardi]


### PR DESCRIPTION
No affiliation change (NTT).

The former email address will continue to be available for the time
being.

For daily communication, I still prefer to use my gmail.com address.

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
