### PR TITLE
Use Microsoft/hcsshim constants and deprecate pkg/system.GetOsVersion()

### DIFF
--- a/cmd/dockerd/service_windows.go
+++ b/cmd/dockerd/service_windows.go
@@ -12,7 +12,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/docker/docker/pkg/system"
+	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"golang.org/x/sys/windows"
@@ -171,7 +171,7 @@ func registerService() error {
 
 	// This dependency is required on build 14393 (RS1)
 	// it is added to the platform in newer builds
-	if system.GetOSVersion().Build == 14393 {
+	if osversion.Build() == osversion.RS1 {
 		depends = append(depends, "ConDrv")
 	}
 

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/Microsoft/hcsshim/osversion"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
@@ -275,7 +276,7 @@ func (daemon *Daemon) createSpecWindowsFields(c *container.Container, s *specs.S
 		if isHyperV {
 			return errors.New("device assignment is not supported for HyperV containers")
 		}
-		if system.GetOSVersion().Build < 17763 {
+		if osversion.Build() < osversion.RS5 {
 			return errors.New("device assignment requires Windows builds RS5 (17763+) or later")
 		}
 		for _, deviceMapping := range c.HostConfig.Devices {

--- a/distribution/pull_v2_windows.go
+++ b/distribution/pull_v2_windows.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
@@ -65,7 +66,7 @@ func (ld *v2LayerDescriptor) open(ctx context.Context) (distribution.ReadSeekClo
 }
 
 func filterManifests(manifests []manifestlist.ManifestDescriptor, p specs.Platform) []manifestlist.ManifestDescriptor {
-	version := system.GetOSVersion()
+	version := osversion.Get()
 	osVersion := fmt.Sprintf("%d.%d.%d", version.MajorVersion, version.MinorVersion, version.Build)
 	logrus.Debugf("will prefer Windows entries with version %s", osVersion)
 
@@ -123,7 +124,7 @@ func (mbv manifestsByVersion) Swap(i, j int) {
 // Fixes https://github.com/moby/moby/issues/36184.
 func checkImageCompatibility(imageOS, imageOSVersion string) error {
 	if imageOS == "windows" {
-		hostOSV := system.GetOSVersion()
+		hostOSV := osversion.Get()
 		splitImageOSVersion := strings.Split(imageOSVersion, ".") // eg 10.0.16299.nnnn
 		if len(splitImageOSVersion) >= 3 {
 			if imageOSBuild, err := strconv.Atoi(splitImageOSVersion[2]); err == nil {
@@ -142,5 +143,5 @@ func formatPlatform(platform specs.Platform) string {
 	if platform.OS == "" {
 		platform = platforms.DefaultSpec()
 	}
-	return fmt.Sprintf("%s %s", platforms.Format(platform), system.GetOSVersion().ToString())
+	return fmt.Sprintf("%s %s", platforms.Format(platform), osversion.Get().ToString())
 }

--- a/integration-cli/docker_api_containers_windows_test.go
+++ b/integration-cli/docker_api_containers_windows_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	winio "github.com/Microsoft/go-winio"
+	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
@@ -19,7 +20,7 @@ import (
 )
 
 func (s *DockerSuite) TestContainersAPICreateMountsBindNamedPipe(c *testing.T) {
-	testRequires(c, testEnv.IsLocalDaemon, DaemonIsWindowsAtLeastBuild(16299)) // Named pipe support was added in RS3
+	testRequires(c, testEnv.IsLocalDaemon, DaemonIsWindowsAtLeastBuild(osversion.RS3)) // Named pipe support was added in RS3
 
 	// Create a host pipe to map into the container
 	hostPipeName := fmt.Sprintf(`\\.\pipe\docker-cli-test-pipe-%x`, rand.Uint64())

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
@@ -59,10 +60,12 @@ func (s *DockerSuite) TestAPIImagesFilter(c *testing.T) {
 
 func (s *DockerSuite) TestAPIImagesSaveAndLoad(c *testing.T) {
 	if runtime.GOOS == "windows" {
+		// Note we parse kernel.GetKernelVersion rather than osversion.Build()
+		// as test binaries aren't manifested, so would otherwise report build 9200.
 		v, err := kernel.GetKernelVersion()
 		assert.NilError(c, err)
-		build, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
-		if build <= 16299 {
+		buildNumber, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
+		if buildNumber <= osversion.RS3 {
 			c.Skip("Temporarily disabled on RS3 and older because they are too slow. See #39909")
 		}
 	}
@@ -139,10 +142,12 @@ func (s *DockerSuite) TestAPIImagesHistory(c *testing.T) {
 
 func (s *DockerSuite) TestAPIImagesImportBadSrc(c *testing.T) {
 	if runtime.GOOS == "windows" {
+		// Note we parse kernel.GetKernelVersion rather than osversion.Build()
+		// as test binaries aren't manifested, so would otherwise report build 9200.
 		v, err := kernel.GetKernelVersion()
 		assert.NilError(c, err)
-		build, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
-		if build == 16299 {
+		buildNumber, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
+		if buildNumber == osversion.RS3 {
 			c.Skip("Temporarily disabled on RS3 builds")
 		}
 	}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
@@ -1880,7 +1881,7 @@ func (s *DockerSuite) TestRunBindMounts(c *testing.T) {
 
 	if testEnv.OSType == "windows" {
 		// Disabled prior to RS5 due to how volumes are mapped
-		testRequires(c, DaemonIsWindowsAtLeastBuild(17763))
+		testRequires(c, DaemonIsWindowsAtLeastBuild(osversion.RS5))
 	}
 
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
@@ -3915,16 +3916,16 @@ func (s *DockerSuite) TestRunNamedVolumesFromNotRemoved(c *testing.T) {
 }
 
 func (s *DockerSuite) TestRunAttachFailedNoLeak(c *testing.T) {
-	// TODO @msabansal - https://github.com/moby/moby/issues/35023. Duplicate
-	// port mappings are not errored out on RS3 builds. Temporarily disabling
-	// this test pending further investigation. Note we parse kernel.GetKernelVersion
-	// rather than system.GetOSVersion as test binaries aren't manifested, so would
-	// otherwise report build 9200.
 	if runtime.GOOS == "windows" {
+		// TODO @msabansal - https://github.com/moby/moby/issues/35023. Duplicate
+		// port mappings are not errored out on RS3 builds. Temporarily disabling
+		// this test pending further investigation. Note we parse kernel.GetKernelVersion
+		// rather than osversion.Build() as test binaries aren't manifested, so would
+		// otherwise report build 9200.
 		v, err := kernel.GetKernelVersion()
 		assert.NilError(c, err)
-		build, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
-		if build == 16299 {
+		buildNumber, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
+		if buildNumber == osversion.RS3 {
 			c.Skip("Temporarily disabled on RS3 builds")
 		}
 	}
@@ -4532,7 +4533,7 @@ func (s *DockerSuite) TestRunAddDeviceCgroupRule(c *testing.T) {
 
 // Verifies that running as local system is operating correctly on Windows
 func (s *DockerSuite) TestWindowsRunAsSystem(c *testing.T) {
-	testRequires(c, DaemonIsWindowsAtLeastBuild(15000))
+	testRequires(c, DaemonIsWindowsAtLeastBuild(osversion.RS3))
 	out, _ := dockerCmd(c, "run", "--net=none", `--user=nt authority\system`, "--hostname=XYZZY", minimalBaseImage(), "cmd", "/c", `@echo %USERNAME%`)
 	assert.Equal(c, strings.TrimSpace(out), "XYZZY$")
 }

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Microsoft/hcsshim/osversion"
+
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"gotest.tools/assert"
@@ -196,7 +198,7 @@ func (s *DockerSuite) TestStartReturnCorrectExitCode(c *testing.T) {
 		v, err := kernel.GetKernelVersion()
 		assert.NilError(c, err)
 		build, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
-		if build < 16299 {
+		if build < osversion.RS3 {
 			c.Skip("FLAKY on Windows RS1, see #38521")
 		}
 	}

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim"
+	"github.com/Microsoft/hcsshim/osversion"
 	opengcs "github.com/Microsoft/opengcs/client"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
@@ -318,7 +319,7 @@ func (c *client) createWindows(id string, spec *specs.Spec, runtimeOptions inter
 		}
 	}
 	configuration.MappedDirectories = mds
-	if len(mps) > 0 && system.GetOSVersion().Build < 16299 { // RS3
+	if len(mps) > 0 && osversion.Build() < osversion.RS3 {
 		return errors.New("named pipe mounts are not supported on this version of Windows")
 	}
 	configuration.MappedPipes = mps
@@ -328,7 +329,7 @@ func (c *client) createWindows(id string, spec *specs.Spec, runtimeOptions inter
 		if configuration.HvPartition {
 			return errors.New("device assignment is not supported for HyperV containers")
 		}
-		if system.GetOSVersion().Build < 17763 { // RS5
+		if osversion.Build() < osversion.RS5 {
 			return errors.New("device assignment requires Windows builds RS5 (17763+) or later")
 		}
 		for _, d := range spec.Windows.Devices {
@@ -519,7 +520,7 @@ func (c *client) createLinux(id string, spec *specs.Spec, runtimeOptions interfa
 				ReadOnly:          readonly,
 			}
 			// If we are 1803/RS4+ enable LinuxMetadata support by default
-			if system.GetOSVersion().Build >= 17134 {
+			if osversion.Build() >= osversion.RS4 {
 				md.LinuxMetadata = true
 			}
 			mds = append(mds, md)

--- a/pkg/system/init_windows.go
+++ b/pkg/system/init_windows.go
@@ -18,8 +18,7 @@ var (
 
 // InitLCOW sets whether LCOW is supported or not. Requires RS5+
 func InitLCOW(experimental bool) {
-	v := GetOSVersion()
-	if experimental && v.Build >= osversion.RS5 {
+	if experimental && osversion.Build() >= osversion.RS5 {
 		lcowSupported = true
 	}
 }

--- a/pkg/system/syscall_windows.go
+++ b/pkg/system/syscall_windows.go
@@ -5,6 +5,7 @@ import (
 	"syscall"
 	"unsafe"
 
+	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
 )
@@ -61,12 +62,7 @@ var (
 
 // OSVersion is a wrapper for Windows version information
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms724439(v=vs.85).aspx
-type OSVersion struct {
-	Version      uint32
-	MajorVersion uint8
-	MinorVersion uint8
-	Build        uint16
-}
+type OSVersion osversion.OSVersion
 
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms724833(v=vs.85).aspx
 type osVersionInfoEx struct {
@@ -85,18 +81,9 @@ type osVersionInfoEx struct {
 
 // GetOSVersion gets the operating system version on Windows. Note that
 // dockerd.exe must be manifested to get the correct version information.
+// Deprecated: use github.com/Microsoft/hcsshim/osversion.Get() instead
 func GetOSVersion() OSVersion {
-	var err error
-	osv := OSVersion{}
-	osv.Version, err = windows.GetVersion()
-	if err != nil {
-		// GetVersion never fails.
-		panic(err)
-	}
-	osv.MajorVersion = uint8(osv.Version & 0xFF)
-	osv.MinorVersion = uint8(osv.Version >> 8 & 0xFF)
-	osv.Build = uint16(osv.Version >> 16)
-	return osv
+	return OSVersion(osversion.Get())
 }
 
 func (osv OSVersion) ToString() string {

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/Azure/go-ansiterm                        d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim                        672e52e9209d1e53718c1b6a7d68cc9272654ab5
+github.com/Microsoft/hcsshim                        2226e083fc390003ae5aa8325c3c92789afa0e7a
 github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
 github.com/docker/libtrust                          9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/golang/gddo                              72a348e765d293ed6d1ded7b699591f14d6cd921

--- a/vendor/github.com/Microsoft/hcsshim/osversion/osversion_windows.go
+++ b/vendor/github.com/Microsoft/hcsshim/osversion/osversion_windows.go
@@ -46,6 +46,12 @@ func Get() OSVersion {
 	return osv
 }
 
+// Build gets the build-number on Windows
+// The calling application must be manifested to get the correct version information.
+func Build() uint16 {
+	return Get().Build
+}
+
 func (osv OSVersion) ToString() string {
 	return fmt.Sprintf("%d.%d.%d", osv.MajorVersion, osv.MinorVersion, osv.Build)
 }


### PR DESCRIPTION
Use hcsshim as the source of truth. Also bumps hcsshim;

- https://github.com/Microsoft/hcsshim/compare/672e52e9209d1e53718c1b6a7d68cc9272654ab5...2226e083fc390003ae5aa8325c3c92789afa0e7a
- ~https://github.com/Microsoft/go-winio/compare/c599b533b43b1363d7d7c6cfda5ede70ed73ff13...84b4ab48a50763fe7b3abcef38e5205c12027fac~