### PR TITLE
rootless: optional support for lxc-user-nic SUID binary

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -9,7 +9,9 @@
 # External dependencies:
 # * newuidmap and newgidmap needs to be installed.
 # * /etc/subuid and /etc/subgid needs to be configured for the current user.
-# * Either slirp4netns (v0.3+) or VPNKit needs to be installed.
+# * Either one of slirp4netns (v0.3+), VPNKit, lxc-user-nic needs to be installed.
+#   slirp4netns is used by default if installed. Otherwise fallsback to VPNKit.
+#   The default value can be overridden with $DOCKERD_ROOTLESS_ROOTLESSKIT_NET=(slirp4netns|vpnkit|lxc-user-nic)
 #
 # See the documentation for the further information.
 
@@ -35,24 +37,32 @@ if [ -z $rootlesskit ]; then
 	exit 1
 fi
 
-net=""
-mtu=""
-if which slirp4netns >/dev/null 2>&1; then
-	if slirp4netns --help | grep -- --disable-host-loopback; then
-		net=slirp4netns
-		mtu=65520
-	else
-		echo "slirp4netns does not support --disable-host-loopback. Falling back to VPNKit."
+: "${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:=}"
+: "${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:=}"
+net=$DOCKERD_ROOTLESS_ROOTLESSKIT_NET
+mtu=$DOCKERD_ROOTLESS_ROOTLESSKIT_MTU
+if [ -z $net ]; then
+	if which slirp4netns >/dev/null 2>&1; then
+		if slirp4netns --help | grep -- --disable-host-loopback; then
+			net=slirp4netns
+			if [ -z $mtu ]; then
+				mtu=65520
+			fi
+		else
+			echo "slirp4netns does not support --disable-host-loopback. Falling back to VPNKit."
+		fi
+	fi
+	if [ -z $net ]; then
+		if which vpnkit >/dev/null 2>&1; then
+			net=vpnkit
+		else
+			echo "Either slirp4netns (v0.3+) or vpnkit needs to be installed"
+			exit 1
+		fi
 	fi
 fi
-if [ -z $net ]; then
-	if which vpnkit >/dev/null 2>&1; then
-		net=vpnkit
-		mtu=1500
-	else
-		echo "Either slirp4netns (v0.3+) or vpnkit needs to be installed"
-		exit 1
-	fi
+if [ -z $mtu ]; then
+	mtu=1500
 fi
 
 if [ -z $_DOCKERD_ROOTLESS_CHILD ]; then
@@ -66,7 +76,8 @@ if [ -z $_DOCKERD_ROOTLESS_CHILD ]; then
 	#         (by either systemd-networkd or NetworkManager)
 	# * /run: copy-up is required so that we can create /run/docker (hardcoded for plugins) in our namespace
 	$rootlesskit \
-		--net=$net --mtu=$mtu --disable-host-loopback --port-driver=builtin \
+		--net=$net --mtu=$mtu \
+		--disable-host-loopback --port-driver=builtin \
 		--copy-up=/etc --copy-up=/run \
 		$DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS \
 		$0 $@

--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -20,7 +20,6 @@ $ grep ^$(whoami): /etc/subgid
 penguin:231072:65536
 ```
 
-* Either [slirp4netns](https://github.com/rootless-containers/slirp4netns) (v0.3+) or [VPNKit](https://github.com/moby/vpnkit) needs to be installed. slirp4netns is preferred for the best performance.
 
 ### Distribution-specific hint
 
@@ -82,3 +81,12 @@ To route ping packets, you need to set up `net.ipv4.ping_group_range` properly a
 ```console
 $ sudo sh -c "echo 0   2147483647  > /proc/sys/net/ipv4/ping_group_range"
 ```
+
+### Changing network stack
+
+`dockerd-rootless.sh` uses [slirp4netns](https://github.com/rootless-containers/slirp4netns) (if installed) or [VPNKit](https://github.com/moby/vpnkit) as the network stack by default.
+These network stacks run in userspace and might have performance overhead. See [RootlessKit documentation](https://github.com/rootless-containers/rootlesskit/tree/v0.4.0#network-drivers) for further information.
+
+Optionally, you can use `lxc-user-nic` instead for the best performance.
+To use `lxc-user-nic`, you need to edit [`/etc/lxc/lxc-usernet`](https://github.com/rootless-containers/rootlesskit/tree/v0.4.0#--netlxc-user-nic-experimental) and set `$DOCKERD_ROOTLESS_ROOTLESSKIT_NET=lxc-user-nic`.
+

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# v0.3.0
-ROOTLESSKIT_COMMIT=70e0502f328bc5ffb14692a7ea41abb77196043b
+# v0.4.0
+ROOTLESSKIT_COMMIT=e92d5e772ee7e103aecf380c5874a40c52876ff0
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added support for `lxc-user-nic`.
`lxc-user-nic` can eliminate slirp overhead but needs `/etc/lxc/lxc-usernet` to be configured for the current user.

To use lxc-user-nic, `$DOCKERD_ROOTLESS_ROOTLESSKIT_NET=lxc-user-nic` also needs to be set.


**- How I did it**

By updating RootlessKit from v0.3.0 to v0.4.0:
https://github.com/rootless-containers/rootlesskit/compare/70e0502f328bc5ffb14692a7ea41abb77196043b...e92d5e772ee7e103aecf380c5874a40c52876ff0


**- How to verify it**
```console
$ cat /etc/lxc/lxc-usernet
# USERNAME TYPE BRIDGE COUNT
penguin    veth lxcbr0 1
```

```console
$ DOCKERD_ROOTLESS_ROOTLESSKIT_NET=lxc-user-nic contrib/dockerd-rootless.sh --experimental
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
rootless: optional support for lxc-user-nic SUID binary

**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:

