### PR TITLE
Dockerfile.e2e fix TestBuildPreserveOwnership

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -57,7 +57,9 @@ RUN addgroup docker && adduser -D -G docker unprivilegeduser -s /bin/ash
 
 COPY contrib/httpserver/Dockerfile /tests/contrib/httpserver/Dockerfile
 COPY contrib/syscall-test /tests/contrib/syscall-test
-COPY integration-cli/fixtures /tests/integration-cli/fixtures
+COPY integration/testdata       /tests/integration/testdata
+COPY integration/build/testdata /tests/integration/build/testdata
+COPY integration-cli/fixtures   /tests/integration-cli/fixtures
 
 COPY hack/test/e2e-run.sh /scripts/run.sh
 COPY hack/make/.ensure-emptyfs /scripts/ensure-emptyfs.sh


### PR DESCRIPTION
The Dockerfile missed some fixtures, which caused this test
fail when running from this image.

I also noticed some other fixtures missing in integration-cli,
where the image had symlinks to some certificates, but the
original files were not included;

```
|-- integration-cli
    |-- fixtures
    |   |-- auth
    |   |   `-- docker-credential-shell-test
    |   |-- credentialspecs
    |   |   `-- valid.json
    |   |-- https
    |   |   |-- ca.pem -> ../../../integration/testdata/https/ca.pem
    |   |   |-- client-cert.pem -> ../../../integration/testdata/https/client-cert.pem
    |   |   |-- client-key.pem -> ../../../integration/testdata/https/client-key.pem
    |   |   |-- client-rogue-cert.pem
    |   |   |-- client-rogue-key.pem
    |   |   |-- server-cert.pem -> ../../../integration/testdata/https/server-cert.pem
    |   |   |-- server-key.pem -> ../../../integration/testdata/https/server-key.pem
    |   |   |-- server-rogue-cert.pem
    |   |   `-- server-rogue-key.pem
```

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

