### PR TITLE
Improve Dockerfile.e2e

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -36,11 +36,11 @@ ENV DOCKER_GITCOMMIT=${DOCKER_GITCOMMIT:-undefined}
 COPY . .
 
 # Build DockerSuite.TestBuild* dependency
-RUN CGO_ENABLED=0 go build -buildmode=pie -o /output/httpserver github.com/docker/docker/contrib/httpserver
+RUN CGO_ENABLED=0 go build -buildmode=pie -o /build/httpserver github.com/docker/docker/contrib/httpserver
 
-# Build the integration tests and copy the resulting binaries to /output/tests
+# Build the integration tests and copy the resulting binaries to /build/tests
 RUN hack/make.sh build-integration-test-binary
-RUN mkdir -p /output/tests && find . -name test.main -exec cp --parents '{}' /output/tests \;
+RUN mkdir -p /build/tests && find . -name test.main -exec cp --parents '{}' /build/tests \;
 
 ## Generate testing image
 FROM alpine:3.9 as runner
@@ -73,6 +73,6 @@ COPY integration/build/testdata /tests/integration/build/testdata
 COPY integration-cli/fixtures   /tests/integration-cli/fixtures
 
 COPY --from=frozen-images /build/ /docker-frozen-images
-COPY --from=builder /output/httpserver /tests/contrib/httpserver/httpserver
-COPY --from=builder /output/tests /tests
+COPY --from=builder /build/httpserver /tests/contrib/httpserver/httpserver
+COPY --from=builder /build/tests /tests
 COPY --from=builder /usr/local/bin/docker /usr/bin/docker

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -44,7 +44,7 @@ ARG DOCKER_GITCOMMIT
 ENV DOCKER_GITCOMMIT=${DOCKER_GITCOMMIT:-undefined}
 COPY . .
 RUN hack/make.sh build-integration-test-binary
-RUN mkdir -p /build/tests && find . -name test.main -exec cp --parents '{}' /build/tests \;
+RUN mkdir -p /build/ && find . -name test.main -exec cp --parents '{}' /build \;
 
 ## Generate testing image
 FROM alpine:3.9 as runner
@@ -77,4 +77,4 @@ COPY integration-cli/fixtures   /tests/integration-cli/fixtures
 COPY --from=frozen-images /build/ /docker-frozen-images
 COPY --from=dockercli     /build/ /usr/bin/
 COPY --from=contrib       /build/ /tests/contrib/
-COPY --from=builder /build/tests /tests
+COPY --from=builder       /build/ /tests/

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -39,7 +39,7 @@ RUN hack/make.sh build-integration-test-binary
 RUN mkdir -p /output/tests && find . -name test.main -exec cp --parents '{}' /output/tests \;
 
 ## Step 2: Generate testing image
-FROM alpine:3.8 as runner
+FROM alpine:3.9 as runner
 
 # GNU tar is used for generating the emptyfs image
 RUN apk --no-cache add \

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,5 +1,4 @@
-## Step 1: Build tests
-FROM golang:1.12.4-alpine as builder
+FROM golang:1.12.4-alpine as base
 
 RUN apk --no-cache add \
     bash \
@@ -9,17 +8,22 @@ RUN apk --no-cache add \
     lvm2-dev \
     jq
 
+RUN mkdir -p /build/
 RUN mkdir -p /go/src/github.com/docker/docker/
 WORKDIR /go/src/github.com/docker/docker/
 
-# Generate frozen images
-COPY contrib/download-frozen-image-v2.sh contrib/download-frozen-image-v2.sh
-RUN contrib/download-frozen-image-v2.sh /output/docker-frozen-images \
+FROM base AS frozen-images
+# Get useful and necessary Hub images so we can "docker load" locally instead of pulling
+COPY contrib/download-frozen-image-v2.sh /
+RUN /download-frozen-image-v2.sh /build \
 	buildpack-deps:jessie@sha256:dd86dced7c9cd2a724e779730f0a53f93b7ef42228d4344b25ce9a42a1486251 \
 	busybox:latest@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0 \
 	busybox:glibc@sha256:0b55a30394294ab23b9afd58fab94e61a923f5834fba7ddbae7f8e0c11ba85e6 \
 	debian:jessie@sha256:287a20c5f73087ab406e6b364833e3fb7b3ae63ca0eb3486555dc27ed32c6e60 \
 	hello-world:latest@sha256:be0cd392e45be79ffeffa6b05338b98ebb16c87b255f48e297ec7f98e123905c
+# See also ensureFrozenImagesLinux() in "integration-cli/fixtures_linux_daemon_test.go" (which needs to be updated when adding images to this list)
+
+FROM base AS builder
 
 # Install dockercli
 # Please edit hack/dockerfile/install/<name>.installer to update them.
@@ -38,7 +42,7 @@ RUN CGO_ENABLED=0 go build -buildmode=pie -o /output/httpserver github.com/docke
 RUN hack/make.sh build-integration-test-binary
 RUN mkdir -p /output/tests && find . -name test.main -exec cp --parents '{}' /output/tests \;
 
-## Step 2: Generate testing image
+## Generate testing image
 FROM alpine:3.9 as runner
 
 # GNU tar is used for generating the emptyfs image
@@ -64,7 +68,7 @@ COPY integration-cli/fixtures   /tests/integration-cli/fixtures
 COPY hack/test/e2e-run.sh /scripts/run.sh
 COPY hack/make/.ensure-emptyfs /scripts/ensure-emptyfs.sh
 
-COPY --from=builder /output/docker-frozen-images /docker-frozen-images
+COPY --from=frozen-images /build/ /docker-frozen-images
 COPY --from=builder /output/httpserver /tests/contrib/httpserver/httpserver
 COPY --from=builder /output/tests /tests
 COPY --from=builder /usr/local/bin/docker /usr/bin/docker

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -29,17 +29,20 @@ COPY hack/dockerfile/install/install.sh ./install.sh
 COPY hack/dockerfile/install/$INSTALL_BINARY_NAME.installer ./
 RUN PREFIX=/build ./install.sh $INSTALL_BINARY_NAME
 
+# Build DockerSuite.TestBuild* dependency
+FROM base AS contrib
+COPY contrib/syscall-test           /build/syscall-test
+COPY contrib/httpserver/Dockerfile  /build/httpserver/Dockerfile
+COPY contrib/httpserver             contrib/httpserver
+RUN CGO_ENABLED=0 go build -buildmode=pie -o /build/httpserver/httpserver github.com/docker/docker/contrib/httpserver
+
+# Build the integration tests and copy the resulting binaries to /build/tests
 FROM base AS builder
 
 # Set tag and add sources
 ARG DOCKER_GITCOMMIT
 ENV DOCKER_GITCOMMIT=${DOCKER_GITCOMMIT:-undefined}
 COPY . .
-
-# Build DockerSuite.TestBuild* dependency
-RUN CGO_ENABLED=0 go build -buildmode=pie -o /build/httpserver github.com/docker/docker/contrib/httpserver
-
-# Build the integration tests and copy the resulting binaries to /build/tests
 RUN hack/make.sh build-integration-test-binary
 RUN mkdir -p /build/tests && find . -name test.main -exec cp --parents '{}' /build/tests \;
 
@@ -67,13 +70,11 @@ RUN apk --no-cache add \
 COPY hack/test/e2e-run.sh       /scripts/run.sh
 COPY hack/make/.ensure-emptyfs  /scripts/ensure-emptyfs.sh
 
-COPY contrib/httpserver/Dockerfile /tests/contrib/httpserver/Dockerfile
-COPY contrib/syscall-test /tests/contrib/syscall-test
 COPY integration/testdata       /tests/integration/testdata
 COPY integration/build/testdata /tests/integration/build/testdata
 COPY integration-cli/fixtures   /tests/integration-cli/fixtures
 
 COPY --from=frozen-images /build/ /docker-frozen-images
 COPY --from=dockercli     /build/ /usr/bin/
-COPY --from=builder /build/httpserver /tests/contrib/httpserver/httpserver
+COPY --from=contrib       /build/ /tests/contrib/
 COPY --from=builder /build/tests /tests

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -33,7 +33,7 @@ RUN ./hack/dockerfile/install/install.sh dockercli
 # Set tag and add sources
 ARG DOCKER_GITCOMMIT
 ENV DOCKER_GITCOMMIT=${DOCKER_GITCOMMIT:-undefined}
-ADD . .
+COPY . .
 
 # Build DockerSuite.TestBuild* dependency
 RUN CGO_ENABLED=0 go build -buildmode=pie -o /output/httpserver github.com/docker/docker/contrib/httpserver
@@ -44,6 +44,13 @@ RUN mkdir -p /output/tests && find . -name test.main -exec cp --parents '{}' /ou
 
 ## Generate testing image
 FROM alpine:3.9 as runner
+
+ENV DOCKER_REMOTE_DAEMON=1
+ENV DOCKER_INTEGRATION_DAEMON_DEST=/
+ENTRYPOINT ["/scripts/run.sh"]
+
+# Add an unprivileged user to be used for tests which need it
+RUN addgroup docker && adduser -D -G docker unprivilegeduser -s /bin/ash
 
 # GNU tar is used for generating the emptyfs image
 RUN apk --no-cache add \
@@ -56,8 +63,8 @@ RUN apk --no-cache add \
     tar \
     xz
 
-# Add an unprivileged user to be used for tests which need it
-RUN addgroup docker && adduser -D -G docker unprivilegeduser -s /bin/ash
+COPY hack/test/e2e-run.sh       /scripts/run.sh
+COPY hack/make/.ensure-emptyfs  /scripts/ensure-emptyfs.sh
 
 COPY contrib/httpserver/Dockerfile /tests/contrib/httpserver/Dockerfile
 COPY contrib/syscall-test /tests/contrib/syscall-test
@@ -65,14 +72,7 @@ COPY integration/testdata       /tests/integration/testdata
 COPY integration/build/testdata /tests/integration/build/testdata
 COPY integration-cli/fixtures   /tests/integration-cli/fixtures
 
-COPY hack/test/e2e-run.sh /scripts/run.sh
-COPY hack/make/.ensure-emptyfs /scripts/ensure-emptyfs.sh
-
 COPY --from=frozen-images /build/ /docker-frozen-images
 COPY --from=builder /output/httpserver /tests/contrib/httpserver/httpserver
 COPY --from=builder /output/tests /tests
 COPY --from=builder /usr/local/bin/docker /usr/bin/docker
-
-ENV DOCKER_REMOTE_DAEMON=1 DOCKER_INTEGRATION_DAEMON_DEST=/
-
-ENTRYPOINT ["/scripts/run.sh"]

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -23,12 +23,13 @@ RUN /download-frozen-image-v2.sh /build \
 	hello-world:latest@sha256:be0cd392e45be79ffeffa6b05338b98ebb16c87b255f48e297ec7f98e123905c
 # See also ensureFrozenImagesLinux() in "integration-cli/fixtures_linux_daemon_test.go" (which needs to be updated when adding images to this list)
 
-FROM base AS builder
+FROM base AS dockercli
+ENV INSTALL_BINARY_NAME=dockercli
+COPY hack/dockerfile/install/install.sh ./install.sh
+COPY hack/dockerfile/install/$INSTALL_BINARY_NAME.installer ./
+RUN PREFIX=/build ./install.sh $INSTALL_BINARY_NAME
 
-# Install dockercli
-# Please edit hack/dockerfile/install/<name>.installer to update them.
-COPY hack/dockerfile/install hack/dockerfile/install
-RUN ./hack/dockerfile/install/install.sh dockercli
+FROM base AS builder
 
 # Set tag and add sources
 ARG DOCKER_GITCOMMIT
@@ -73,6 +74,6 @@ COPY integration/build/testdata /tests/integration/build/testdata
 COPY integration-cli/fixtures   /tests/integration-cli/fixtures
 
 COPY --from=frozen-images /build/ /docker-frozen-images
+COPY --from=dockercli     /build/ /usr/bin/
 COPY --from=builder /build/httpserver /tests/contrib/httpserver/httpserver
 COPY --from=builder /build/tests /tests
-COPY --from=builder /usr/local/bin/docker /usr/bin/docker

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -623,29 +623,6 @@ func (s *DockerSuite) TestContainerAPICreateMultipleNetworksConfig(c *check.C) {
 	c.Assert(msg, checker.Contains, "net3")
 }
 
-func (s *DockerSuite) TestContainerAPICreateWithHostName(c *check.C) {
-	domainName := "test-domain"
-	hostName := "test-hostname"
-	config := containertypes.Config{
-		Image:      "busybox",
-		Hostname:   hostName,
-		Domainname: domainName,
-	}
-
-	cli, err := client.NewClientWithOpts(client.FromEnv)
-	assert.NilError(c, err)
-	defer cli.Close()
-
-	container, err := cli.ContainerCreate(context.Background(), &config, &containertypes.HostConfig{}, &networktypes.NetworkingConfig{}, "")
-	assert.NilError(c, err)
-
-	containerJSON, err := cli.ContainerInspect(context.Background(), container.ID)
-	assert.NilError(c, err)
-
-	c.Assert(containerJSON.Config.Hostname, checker.Equals, hostName, check.Commentf("Mismatched Hostname"))
-	c.Assert(containerJSON.Config.Domainname, checker.Equals, domainName, check.Commentf("Mismatched Domainname"))
-}
-
 func (s *DockerSuite) TestContainerAPICreateBridgeNetworkMode(c *check.C) {
 	// Windows does not support bridge
 	testRequires(c, DaemonIsLinux)

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -468,6 +468,7 @@ RUN for g in $(seq 0 8); do dd if=/dev/urandom of=rnd bs=1K count=1 seek=$((1024
 }
 
 func TestBuildWithEmptyDockerfile(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "broken in earlier versions")
 	ctx := context.TODO()
 	defer setupTest(t)()
 

--- a/integration/container/ipcmode_linux_test.go
+++ b/integration/container/ipcmode_linux_test.go
@@ -300,12 +300,14 @@ func TestDaemonIpcModeShareableFromConfig(t *testing.T) {
 // by default, even when the daemon default is private.
 func TestIpcModeOlderClient(t *testing.T) {
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "requires a daemon with DefaultIpcMode: private")
+	c := testEnv.APIClient()
+	skip.If(t, versions.LessThan(c.ClientVersion(), "1.40"), "requires client API >= 1.40")
+
 	t.Parallel()
 
 	ctx := context.Background()
 
 	// pre-check: default ipc mode in daemon is private
-	c := testEnv.APIClient()
 	cID := container.Create(t, ctx, c, container.WithAutoRemove)
 
 	inspect, err := c.ContainerInspect(ctx, cID)

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -50,6 +50,10 @@ func TestKernelTCPMemory(t *testing.T) {
 }
 
 func TestNISDomainname(t *testing.T) {
+	// Older versions of the daemon would concatenate hostname and domainname,
+	// so hostname "foobar" and domainname "baz.cyphar.com" would produce
+	// `foobar.baz.cyphar.com` as hostname.
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "skip test from new feature")
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 
 	defer setupTest(t)()

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -6,12 +6,15 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/versions"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
+	"gotest.tools/skip"
 )
 
 // Regression : #38171
 func TestImagesFilterMultiReference(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "broken in earlier versions")
 	defer setupTest(t)()
 	client := testEnv.APIClient()
 	ctx := context.Background()

--- a/integration/system/ping_test.go
+++ b/integration/system/ping_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestPingCacheHeaders(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "skip test from new feature")
 	defer setupTest(t)()
 
 	res, _, err := request.Get("/_ping")

--- a/integration/system/uuid_test.go
+++ b/integration/system/uuid_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/docker/docker/api/types/versions"
 	"github.com/google/uuid"
 	"gotest.tools/assert"
+	"gotest.tools/skip"
 )
 
 func TestUUIDGeneration(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "ID format changed")
 	defer setupTest(t)()
 
 	c := testEnv.APIClient()
@@ -16,5 +19,5 @@ func TestUUIDGeneration(t *testing.T) {
 	assert.NilError(t, err)
 
 	_, err = uuid.Parse(info.ID)
-	assert.NilError(t, err)
+	assert.NilError(t, err, info.ID)
 }

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -40,12 +40,20 @@ func TestVolumesCreateAndList(t *testing.T) {
 	}
 	assert.Check(t, is.DeepEqual(vol, expected, cmpopts.EquateEmpty()))
 
-	volumes, err := client.VolumeList(ctx, filters.Args{})
+	volList, err := client.VolumeList(ctx, filters.Args{})
 	assert.NilError(t, err)
+	assert.Assert(t, len(volList.Volumes) > 0)
 
-	assert.Check(t, is.Equal(len(volumes.Volumes), 1))
-	assert.Check(t, volumes.Volumes[0] != nil)
-	assert.Check(t, is.DeepEqual(*volumes.Volumes[0], expected, cmpopts.EquateEmpty()))
+	volumes := volList.Volumes[:0]
+	for _, v := range volList.Volumes {
+		if v.Name == vol.Name {
+			volumes = append(volumes, v)
+		}
+	}
+
+	assert.Check(t, is.Equal(len(volumes), 1))
+	assert.Check(t, volumes[0] != nil)
+	assert.Check(t, is.DeepEqual(*volumes[0], expected, cmpopts.EquateEmpty()))
 }
 
 func TestVolumesRemove(t *testing.T) {


### PR DESCRIPTION
follow-up to https://github.com/moby/moby/pull/39115 (first commit is from that PR)

See individual commits for details

To test (if you're running on Docker 18.09 (API v1.39)):

```bash
docker build -t moby-e2e-test -f Dockerfile.e2e .

docker run -it --rm \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -e DOCKER_API_VERSION=1.39 \
  moby-e2e-test
```