### PR TITLE
Add ability to override the version in make.ps1

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -351,6 +351,8 @@ Try {
 
     # Get the version of docker (eg 17.04.0-dev)
     $dockerVersion="0.0.0-dev"
+    # Overwrite dockerVersion if VERSION Environment variable is available
+    if (Test-Path Env:\VERSION) { $dockerVersion=$env:VERSION }
 
     # Give a warning if we are not running in a container and are building binaries or running unit tests.
     # Not relevant for validation tests as these are fine to run outside of a container.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Checks for environment variable VERSION if it exists then it sets dockerVersion to VERSION.

**- How I did it**
Just added a simple check for the `VERSION` env variable in the script and set the `dockerVersion` variable to `VERSION` if `VERSION` is present

We've actually been using this particular commit to build windows server binaries with the correct version since 18.09.

**- How to verify it**
Running something like:
```
docker run --name binaries -e VERSION="some-random-version" nativebuildimage hack\make.ps1 -Binary
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
< no changelog entry needed >
```


**- A picture of a cute animal (not mandatory but encouraged)**
<details>

<summary> . </summary>

![okay](https://media.giphy.com/media/EWkFDlijAJuRW/giphy.gif)

</details>


CC @jhowardmsft, @johnstep, @StefanScherer