### PR TITLE
make network filter more flexible

### DIFF
--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -3,6 +3,7 @@ package cluster // import "github.com/docker/docker/daemon/cluster"
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	apitypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -25,8 +26,16 @@ func (c *Cluster) GetNetworks(filter filters.Args) ([]apitypes.NetworkResource, 
 		f = &swarmapi.ListNetworksRequest_Filters{}
 
 		if filter.Contains("name") {
-			f.Names = filter.Get("name")
-			f.NamePrefixes = filter.Get("name")
+			fullName := filter.Get("name")
+
+			for _, v := range fullName {
+				if strings.Contains(v, "*") {
+					f.NamePrefixes = append(f.NamePrefixes, strings.Split(v, "*")[0])
+				} else {
+					f.Names = append(f.Names, v)
+				}
+			}
+
 		}
 
 		if filter.Contains("id") {


### PR DESCRIPTION
Signed-off-by: JieJhih aawer12345tw@yahoo.com.tw

**- What I did**
As mentioned in PR #38172, docker network ls --filter 'name=***' can't work for swarm.
**- How I did it**
use specfic flag ``*`` to distinguish name or prefix
**- Description for the changelog**
List network filter that name or prefix distinguish by ``* ``.


**- A picture of a cute animal (not mandatory but encouraged)**

