### PR TITLE
apparmor: allow readby and tracedby

### DIFF
--- a/profiles/apparmor/template.go
+++ b/profiles/apparmor/template.go
@@ -44,7 +44,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 
 {{if ge .Version 208095}}
   # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
-  ptrace (trace,read) peer={{.Name}},
+  ptrace (trace,read,tracedby,readby) peer={{.Name}},
 {{end}}
 }
 `


### PR DESCRIPTION
Fixes audit errors such as:

type=AVC msg=audit(1550236803.810:143):
apparmor="DENIED" operation="ptrace" profile="docker-default"
pid=3181 comm="ps" requested_mask="readby" denied_mask="readby"
peer="docker-default"

audit(1550236375.918:3): apparmor="DENIED" operation="ptrace"
profile="docker-default" pid=2267 comm="ps"
requested_mask="tracedby" denied_mask="tracedby"
peer="docker-default"

Signed-off-by: Goldwyn Rodrigues <rgoldwyn@suse.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

