### PR TITLE
ImageBuildOptions struct to use OCI Platform type

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	units "github.com/docker/go-units"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // CheckpointCreateOptions holds parameters to create a checkpoint from a container
@@ -180,7 +181,7 @@ type ImageBuildOptions struct {
 	ExtraHosts  []string // List of extra hosts
 	Target      string
 	SessionID   string
-	Platform    string
+	Platform    *specs.Platform
 	// Version specifies the version of the unerlying builder to use
 	Version BuilderVersion
 	// BuildID is an optional identifier that can be passed together with the

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -19,7 +19,6 @@ import (
 	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/streamformatter"
-	"github.com/docker/docker/pkg/system"
 	"github.com/docker/libnetwork"
 	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/client"
@@ -295,17 +294,8 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 		frontendAttrs["image-resolve-mode"] = "default"
 	}
 
-	if opt.Options.Platform != "" {
-		// same as in newBuilder in builder/dockerfile.builder.go
-		// TODO: remove once opt.Options.Platform is of type specs.Platform
-		sp, err := platforms.Parse(opt.Options.Platform)
-		if err != nil {
-			return nil, err
-		}
-		if err := system.ValidatePlatform(sp); err != nil {
-			return nil, err
-		}
-		frontendAttrs["platform"] = opt.Options.Platform
+	if opt.Options.Platform != nil {
+		frontendAttrs["platform"] = platforms.Format(*opt.Options.Platform)
 	}
 
 	switch opt.Options.NetworkMode {

--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -83,7 +83,7 @@ type copier struct {
 }
 
 func copierFromDispatchRequest(req dispatchRequest, download sourceDownloader, imageSource *imageMount) copier {
-	platform := req.builder.platform
+	platform := req.builder.platform()
 	if platform == nil {
 		// May be nil if not explicitly set in API/dockerfile
 		platform = &specs.Platform{}

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -147,7 +147,7 @@ func (d *dispatchRequest) getImageMount(imageRefOrID string) (*imageMount, error
 		imageRefOrID = stage.Image
 		localOnly = true
 	}
-	return d.builder.imageSources.Get(imageRefOrID, localOnly, d.builder.platform)
+	return d.builder.imageSources.Get(imageRefOrID, localOnly, d.builder.platform())
 }
 
 // FROM [--platform=platform] imagename[:tag | @digest] [AS build-stage-name]
@@ -239,7 +239,7 @@ func (d *dispatchRequest) getImageOrStage(name string, platform *specs.Platform)
 	}
 
 	if platform == nil {
-		platform = d.builder.platform
+		platform = d.builder.platform()
 	}
 
 	// Windows cannot support a container with no base image unless it is LCOW.

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -176,7 +176,7 @@ func (b *Builder) performCopy(req dispatchRequest, inst copyInstruction) error {
 		return err
 	}
 
-	imageMount, err := b.imageSources.Get(state.imageID, true, req.builder.platform)
+	imageMount, err := b.imageSources.Get(state.imageID, true, req.builder.platform())
 	if err != nil {
 		return errors.Wrapf(err, "failed to get destination image %q", state.imageID)
 	}
@@ -199,7 +199,7 @@ func (b *Builder) performCopy(req dispatchRequest, inst copyInstruction) error {
 	if inst.chownStr != "" {
 		identity, err = parseChownFlag(b, state, inst.chownStr, destInfo.root.Path(), b.idMapping)
 		if err != nil {
-			if b.options.Platform != "windows" {
+			if b.platform().OS != "windows" {
 				return errors.Wrapf(err, "unable to convert uid/gid chown string to host mapping")
 			}
 
@@ -448,7 +448,7 @@ func (b *Builder) probeAndCreate(dispatchState *dispatchState, runConfig *contai
 func (b *Builder) create(runConfig *container.Config) (string, error) {
 	logrus.Debugf("[BUILDER] Command to be executed: %v", runConfig.Cmd)
 
-	isWCOW := runtime.GOOS == "windows" && b.platform != nil && b.platform.OS == "windows"
+	isWCOW := runtime.GOOS == "windows" && b.platform() != nil && b.platform().OS == "windows"
 	hostConfig := hostConfigFromOptions(b.options, isWCOW)
 	container, err := b.containerManager.Create(runConfig, hostConfig)
 	if err != nil {

--- a/builder/dockerfile/internals_linux_test.go
+++ b/builder/dockerfile/internals_linux_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/idtools"
 	"gotest.tools/v3/assert"
@@ -48,6 +49,11 @@ othergrp:x:6666:
 		createTestTempFile(t, filepath.Join(contextDir, "etc"), filename, content, 0644)
 	}
 
+	platformLinux, err := platforms.Parse("linux")
+	if err != nil {
+		t.Fatalf("error parsing platform 'linux': %v", err)
+	}
+
 	// positive tests
 	for _, testcase := range []struct {
 		builder   *Builder
@@ -58,7 +64,7 @@ othergrp:x:6666:
 		expected  idtools.Identity
 	}{
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &types.ImageBuildOptions{Platform: &platformLinux}},
 			name:      "UIDNoMap",
 			chownStr:  "1",
 			idMapping: unmapped,
@@ -66,7 +72,7 @@ othergrp:x:6666:
 			expected:  idtools.Identity{UID: 1, GID: 1},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &types.ImageBuildOptions{Platform: &platformLinux}},
 			name:      "UIDGIDNoMap",
 			chownStr:  "0:1",
 			idMapping: unmapped,
@@ -74,7 +80,7 @@ othergrp:x:6666:
 			expected:  idtools.Identity{UID: 0, GID: 1},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &types.ImageBuildOptions{Platform: &platformLinux}},
 			name:      "UIDWithMap",
 			chownStr:  "0",
 			idMapping: remapped,
@@ -82,7 +88,7 @@ othergrp:x:6666:
 			expected:  idtools.Identity{UID: 100000, GID: 100000},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &types.ImageBuildOptions{Platform: &platformLinux}},
 			name:      "UIDGIDWithMap",
 			chownStr:  "1:33",
 			idMapping: remapped,
@@ -90,7 +96,7 @@ othergrp:x:6666:
 			expected:  idtools.Identity{UID: 100001, GID: 100033},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &types.ImageBuildOptions{Platform: &platformLinux}},
 			name:      "UserNoMap",
 			chownStr:  "bin:5555",
 			idMapping: unmapped,
@@ -98,7 +104,7 @@ othergrp:x:6666:
 			expected:  idtools.Identity{UID: 1, GID: 5555},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &types.ImageBuildOptions{Platform: &platformLinux}},
 			name:      "GroupWithMap",
 			chownStr:  "0:unicorn",
 			idMapping: remapped,
@@ -106,7 +112,7 @@ othergrp:x:6666:
 			expected:  idtools.Identity{UID: 100000, GID: 101002},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &types.ImageBuildOptions{Platform: &platformLinux}},
 			name:      "UserOnlyWithMap",
 			chownStr:  "unicorn",
 			idMapping: remapped,
@@ -131,7 +137,7 @@ othergrp:x:6666:
 		descr     string
 	}{
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &types.ImageBuildOptions{Platform: &platformLinux}},
 			name:      "BadChownFlagFormat",
 			chownStr:  "bob:1:555",
 			idMapping: unmapped,
@@ -139,7 +145,7 @@ othergrp:x:6666:
 			descr:     "invalid chown string format: bob:1:555",
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &types.ImageBuildOptions{Platform: &platformLinux}},
 			name:      "UserNoExist",
 			chownStr:  "bob",
 			idMapping: unmapped,
@@ -147,7 +153,7 @@ othergrp:x:6666:
 			descr:     "can't find uid for user bob: no such user: bob",
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &types.ImageBuildOptions{Platform: &platformLinux}},
 			name:      "GroupNoExist",
 			chownStr:  "root:bob",
 			idMapping: unmapped,

--- a/builder/dockerfile/internals_windows.go
+++ b/builder/dockerfile/internals_windows.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/pkg/idtools"
@@ -16,7 +15,7 @@ import (
 )
 
 func parseChownFlag(builder *Builder, state *dispatchState, chown, ctrRootPath string, identityMapping *idtools.IdentityMapping) (idtools.Identity, error) {
-	if builder.options.Platform == "windows" {
+	if builder.platform().OS == "windows" {
 		return getAccountIdentity(builder, chown, ctrRootPath, state)
 	}
 
@@ -62,13 +61,8 @@ func lookupNTAccount(builder *Builder, accountName string, state *dispatchState)
 	target := "C:\\Docker"
 	targetExecutable := target + "\\containerutility.exe"
 
-	optionsPlatform, err := platforms.Parse(builder.options.Platform)
-	if err != nil {
-		return idtools.Identity{}, err
-	}
-
 	runConfig := copyRunConfig(state.runConfig,
-		withCmdCommentString("internal run to obtain NT account information.", optionsPlatform.OS))
+		withCmdCommentString("internal run to obtain NT account information.", builder.platform().OS))
 
 	runConfig.Cmd = []string{targetExecutable, "getaccountsid", accountName}
 

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 )
@@ -124,11 +125,11 @@ func (cli *Client) imageBuildOptionsToQuery(options types.ImageBuildOptions) (ur
 	if options.SessionID != "" {
 		query.Set("session", options.SessionID)
 	}
-	if options.Platform != "" {
+	if options.Platform != nil {
 		if err := cli.NewVersionError("1.32", "platform"); err != nil {
 			return query, err
 		}
-		query.Set("platform", strings.ToLower(options.Platform))
+		query.Set("platform", strings.ToLower(platforms.Format(*options.Platform)))
 	}
 	if options.BuildID != "" {
 		query.Set("buildid", options.BuildID)


### PR DESCRIPTION
**- What I did**
Updated the ImageBuildOptions struct to contain the OCI Platform type rather than a string. This string is currently parsed downstream in the buildkit or legacy builder, as appropriate. There are comments in both of these locations calling for the present change.

**- How I did it**

**- How to verify it**
Run unit/integration test targets. Manual testing with --platform arguments on the command line or in the Dockerfile. Note that buildkit will support these flags, but the legacy builder currently does not.

**- Description for the changelog**
ImageBuildOptions struct to use OCI Platform type

**- A picture of a cute animal (not mandatory but encouraged)**

