### PR TITLE
bump docker/go-units v0.4.0

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -16,7 +16,7 @@ github.com/tchap/go-patricia                        a7f0089c6f496e8e70402f617336
 github.com/vdemeester/shakers                       24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3 # v0.1.0
 golang.org/x/net                                    eb5bcb51f2a31c7d5141d810b70815c05d9c9146
 golang.org/x/sys                                    4b34438f7a67ee5f45cc6132e2bad873a20324e9
-github.com/docker/go-units                          47565b4f722fb6ceae66b95f853feed578a4a51c # v0.3.3
+github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0
 golang.org/x/text                                   f21a4dfb5e38f5895301dc265a8def02365cc3d0 # v0.3.0
 gotest.tools                                        1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0

--- a/vendor/github.com/docker/go-units/duration.go
+++ b/vendor/github.com/docker/go-units/duration.go
@@ -18,7 +18,7 @@ func HumanDuration(d time.Duration) string {
 		return fmt.Sprintf("%d seconds", seconds)
 	} else if minutes := int(d.Minutes()); minutes == 1 {
 		return "About a minute"
-	} else if minutes < 46 {
+	} else if minutes < 60 {
 		return fmt.Sprintf("%d minutes", minutes)
 	} else if hours := int(d.Hours() + 0.5); hours == 1 {
 		return "About an hour"

--- a/vendor/github.com/docker/go-units/ulimit.go
+++ b/vendor/github.com/docker/go-units/ulimit.go
@@ -96,8 +96,13 @@ func ParseUlimit(val string) (*Ulimit, error) {
 		return nil, fmt.Errorf("too many limit value arguments - %s, can only have up to two, `soft[:hard]`", parts[1])
 	}
 
-	if soft > *hard {
-		return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: %d > %d", soft, *hard)
+	if *hard != -1 {
+		if soft == -1 {
+			return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: soft: -1 (unlimited), hard: %d", *hard)
+		}
+		if soft > *hard {
+			return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: %d > %d", soft, *hard)
+		}
 	}
 
 	return &Ulimit{Name: parts[0], Soft: soft, Hard: *hard}, nil


### PR DESCRIPTION
relevant changes:

- docker/go-units#33 Fix handling of unlimited (-1) ulimit values
  - relates to https://github.com/moby/moby/issues/39125, 
- docker/go-units#34 Revert 46 minute threshold
  - relates to https://github.com/moby/moby/issues/38807

