### PR TITLE
Lessen mount lock contention in layer store

### DIFF
--- a/layer/migration.go
+++ b/layer/migration.go
@@ -18,9 +18,9 @@ import (
 // after migration the layer may be retrieved by the given name.
 func (ls *layerStore) CreateRWLayerByGraphID(name, graphID string, parent ChainID) (err error) {
 	ls.mountL.Lock()
-	defer ls.mountL.Unlock()
-	m, ok := ls.mounts[name]
-	if ok {
+	m := ls.mounts[name]
+	ls.mountL.Unlock()
+	if m != nil {
 		if m.parent.chainID != parent {
 			return errors.New("name conflict, mismatched parent")
 		}

--- a/layer/mounted_layer.go
+++ b/layer/mounted_layer.go
@@ -2,6 +2,7 @@ package layer // import "github.com/docker/docker/layer"
 
 import (
 	"io"
+	"sync"
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/containerfs"
@@ -15,6 +16,7 @@ type mountedLayer struct {
 	path       string
 	layerStore *layerStore
 
+	sync.Mutex
 	references map[RWLayer]*referencedRWLayer
 }
 
@@ -62,16 +64,24 @@ func (ml *mountedLayer) getReference() RWLayer {
 	ref := &referencedRWLayer{
 		mountedLayer: ml,
 	}
+	ml.Lock()
 	ml.references[ref] = ref
+	ml.Unlock()
 
 	return ref
 }
 
 func (ml *mountedLayer) hasReferences() bool {
-	return len(ml.references) > 0
+	ml.Lock()
+	ret := len(ml.references) > 0
+	ml.Unlock()
+
+	return ret
 }
 
 func (ml *mountedLayer) deleteReference(ref RWLayer) error {
+	ml.Lock()
+	defer ml.Unlock()
 	if _, ok := ml.references[ref]; !ok {
 		return ErrLayerNotRetained
 	}
@@ -81,7 +91,9 @@ func (ml *mountedLayer) deleteReference(ref RWLayer) error {
 
 func (ml *mountedLayer) retakeReference(r RWLayer) {
 	if ref, ok := r.(*referencedRWLayer); ok {
+		ml.Lock()
 		ml.references[ref] = ref
+		ml.Unlock()
 	}
 }
 


### PR DESCRIPTION
While testing massive parallel container creation and removal, we see there's a lock contention in layer store that affects container creation performance (in other words, many threads are waiting for the lock). With this patches, container creation time (wall clock time) is about 2x to 3x less than before (measured with both aufs and overlay2 graph drivers).

The (global, per-layerstore) lock in question is held for the duration of
* CreateRWLayer()
* GetRWLayer()
* ReleaseRWLayer()
* CreateRWLayerByGraphID()

**The lock contention observed mostly between two instances of CreateRWLayer()**

Here's a stupid script I am using to test the performance before and after:
```bash
#!/bin/bash

NUMCTS=1000
PARALLEL=100

create() {
	# -v 'vol_{}:/vol'
	time ( seq $NUMCTS | parallel -j$PARALLEL docker create alpine top > /dev/null )
	echo "^^^ CREATE TIME ^^^"
}

remove() {
	time ( docker ps -qa | shuf | tail -n $NUMCTS | parallel -j$PARALLEL docker rm -f '{}' > /dev/null )
	echo "^^^ REMOVE TIME ^^^"
}

# precreate $NUMCTS containers
create
echo

# create another $NUMCTS while removing $NUMCTS containers
create &
remove &
wait

# remove the rest of it
remove
```

Results are:
1. Container creation time (the first timing print by the script) is about 40s before, about 20s after this patchset.

2. Concurrent container creation/removal time (the second and the third timing printed by the script) are about 70s before, 40s after this patchset.

3. Container removal times (last timing printed by the script) stay the same at about 30s.