### PR TITLE
Pass container labels as annotations in OCI spec

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -914,6 +914,19 @@ func WithUser(c *container.Container) coci.SpecOpts {
 	}
 }
 
+// WithLabels sets the container's annotations
+func WithLabels(c *container.Container) coci.SpecOpts {
+	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
+		if s.Annotations == nil {
+			s.Annotations = make(map[string]string)
+		}
+		for k, v := range c.Config.Labels {
+			s.Annotations[k] = v
+		}
+		return nil
+	}
+}
+
 func (daemon *Daemon) createSpec(c *container.Container) (retSpec *specs.Spec, err error) {
 	var (
 		opts []coci.SpecOpts
@@ -934,6 +947,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (retSpec *specs.Spec, e
 		WithLibnetwork(daemon, c),
 		WithApparmor(c),
 		WithSelinux(c),
+		WithLabels(c),
 		WithOOMScore(&c.HostConfig.OomScoreAdj),
 	)
 	if c.NoNewPrivileges {


### PR DESCRIPTION
Docker container labels and OCI container annotations have the same meaning.

Annotations can be used by container runtime tools. For example, runc handles the org.criu.config annotation. Overall, it is a good way (only one?) to pass custom options to container runtime tools.

Links:
https://github.com/opencontainers/image-spec/blob/master/annotations.md
https://github.com/opencontainers/runc/blob/master/docs/checkpoint-restore.md