### PR TITLE
Bump runc 1.0.0-rc8, opencontainers/selinux v1.2.2

### DIFF
--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -4,7 +4,7 @@
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-RUNC_COMMIT=029124da7af7360afa781a0234d1b083550f797c # v1.0.0-rc7-6-g029124da
+RUNC_COMMIT=425e105d5a03fabd737a126ad93d62a9eeede87f # v1.0.0-rc8
 
 install_runc() {
 	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting

--- a/vendor.conf
+++ b/vendor.conf
@@ -80,7 +80,7 @@ google.golang.org/grpc                              7a6a684ca69eb4cae85ad0a484f2
 # the containerd project first, and update both after that is merged.
 # This commit does not need to match RUNC_COMMIT as it is used for helper
 # packages but should be newer or equal.
-github.com/opencontainers/runc                      029124da7af7360afa781a0234d1b083550f797c # v1.0.0-rc7-6-g029124da
+github.com/opencontainers/runc                      425e105d5a03fabd737a126ad93d62a9eeede87f # v1.0.0-rc8
 github.com/opencontainers/runtime-spec              29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
 github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
 github.com/seccomp/libseccomp-golang                32f571b70023028bd57d9288c20efbcb237f3ce0

--- a/vendor.conf
+++ b/vendor.conf
@@ -162,6 +162,6 @@ github.com/morikuni/aec                             39771216ff4c63d11f5e604076f9
 # metrics
 github.com/docker/go-metrics                        d466d4f6fd960e01820085bd7e1a24426ee7ef18
 
-github.com/opencontainers/selinux                   0bb7b9fa9ba5c1120e9d22caed4961fca4228408 # v1.2.1
+github.com/opencontainers/selinux                   3a1f366feb7aecbf7a0e71ac4cea88b31597de9e # v1.2.2
 
 # DO NOT EDIT BELOW THIS LINE -------- reserved for downstream projects --------

--- a/vendor/github.com/opencontainers/runc/vendor.conf
+++ b/vendor/github.com/opencontainers/runc/vendor.conf
@@ -5,7 +5,7 @@ github.com/opencontainers/runtime-spec 29686dbc5559d93fb1ef402eeda3e35c38d75af4
 # Core libcontainer functionality.
 github.com/checkpoint-restore/go-criu v3.11
 github.com/mrunalp/fileutils ed869b029674c0e9ce4c0dfa781405c2d9946d08
-github.com/opencontainers/selinux v1.2.1
+github.com/opencontainers/selinux v1.2.2
 github.com/seccomp/libseccomp-golang 84e90a91acea0f4e51e62bc1a75de18b1fc0790f
 github.com/sirupsen/logrus a3f95b5c423586578a4e099b11a46c2479628cac
 github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
@@ -406,7 +406,14 @@ func SocketLabel() (string, error) {
 // SetKeyLabel takes a process label and tells the kernel to assign the
 // label to the next kernel keyring that gets created
 func SetKeyLabel(label string) error {
-	return writeCon("/proc/self/attr/keycreate", label)
+	err := writeCon("/proc/self/attr/keycreate", label)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if label == "" && os.IsPermission(err) && !GetEnabled() {
+		return nil
+	}
+	return err
 }
 
 // KeyLabel retrieves the current kernel keyring label setting


### PR DESCRIPTION
runc v1.0.0-rc8 wasn't tagged yet, but took the commit of the version bump


- runc diff: https://github.com/opencontainers/runc/compare/029124da7af7360afa781a0234d1b083550f797c...425e105d5a03fabd737a126ad93d62a9eeede87f
  - opencontainers/runc#2043 Vendor in latest selinux code for keycreate errors
- selinux diff: https://github.com/opencontainers/selinux/compare/v1.2.1...v1.2.2
  - opencontainers/selinux#51 Older kernels do not support keyring labeling