### PR TITLE
builder entitlements configuration added.

### DIFF
--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -195,10 +195,7 @@ func newController(rt http.RoundTripper, opt Opt) (*control.Controller, error) {
 		ResolveCacheExporterFuncs: map[string]remotecache.ResolveCacheExporterFunc{
 			"inline": inlineremotecache.ResolveCacheExporterFunc(),
 		},
-		Entitlements: []string{
-			string(entitlements.EntitlementNetworkHost),
-			// string(entitlements.EntitlementSecurityInsecure),
-		},
+		Entitlements: getEntitlements(opt.BuilderConfig),
 	})
 }
 
@@ -253,4 +250,16 @@ func parsePlatforms(platformsStr []string) ([]specs.Platform, error) {
 		out = append(out, platforms.Normalize(p))
 	}
 	return out, nil
+}
+
+func getEntitlements(conf config.BuilderConfig) []string {
+	var ents []string
+	// Incase of no config settings, NetworkHost should be enabled & SecurityInsecure must be disabled.
+	if conf.Entitlements.NetworkHost == nil || *conf.Entitlements.NetworkHost {
+		ents = append(ents, string(entitlements.EntitlementNetworkHost))
+	}
+	if conf.Entitlements.SecurityInsecure != nil && *conf.Entitlements.SecurityInsecure {
+		ents = append(ents, string(entitlements.EntitlementSecurityInsecure))
+	}
+	return ents
 }

--- a/daemon/config/builder.go
+++ b/daemon/config/builder.go
@@ -16,7 +16,14 @@ type BuilderGCConfig struct {
 	DefaultKeepStorage string          `json:",omitempty"`
 }
 
+// BuilderEntitlements contains settings to enable/disable entitlements
+type BuilderEntitlements struct {
+	NetworkHost      *bool `json:"network-host,omitempty"`
+	SecurityInsecure *bool `json:"security-insecure,omitempty"`
+}
+
 // BuilderConfig contains config for the builder
 type BuilderConfig struct {
-	GC BuilderGCConfig `json:",omitempty"`
+	GC           BuilderGCConfig     `json:",omitempty"`
+	Entitlements BuilderEntitlements `json:",omitempty"`
 }


### PR DESCRIPTION
buildkit supports entitlements like network-host and security-insecure.
this patch aims to make it configurable through daemon.json file.
by default network-host is enabled & secuirty-insecure is disabled.

Signed-off-by: Kunal Kushwaha <kunal.kushwaha@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
option to enable/disable buildkit's entitlements settings for moby
fixes part of issue discussed here https://github.com/moby/buildkit/issues/950#issuecomment-484790342

**- How I did it**
Added `entitlements` in builder config

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

