### PR TITLE
Dockerfile.e2e: copy test sources

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -40,12 +40,11 @@ RUN CGO_ENABLED=0 go build -buildmode=pie -o /build/httpserver/httpserver github
 FROM base AS builder
 
 # Set tag and add sources
-ARG DOCKER_GITCOMMIT
-ENV DOCKER_GITCOMMIT=${DOCKER_GITCOMMIT:-undefined}
 COPY . .
 # Copy test sources tests that use assert can print errors
 RUN mkdir -p /build${PWD} && find integration integration-cli -name \*_test.go -exec cp --parents '{}' /build${PWD} \;
 # Build and install test binaries
+ARG DOCKER_GITCOMMIT=undefined
 RUN hack/make.sh build-integration-test-binary
 RUN mkdir -p /build/tests && find . -name test.main -exec cp --parents '{}' /build/tests \;
 

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -43,8 +43,11 @@ FROM base AS builder
 ARG DOCKER_GITCOMMIT
 ENV DOCKER_GITCOMMIT=${DOCKER_GITCOMMIT:-undefined}
 COPY . .
+# Copy test sources tests that use assert can print errors
+RUN mkdir -p /build${PWD} && find integration integration-cli -name \*_test.go -exec cp --parents '{}' /build${PWD} \;
+# Build and install test binaries
 RUN hack/make.sh build-integration-test-binary
-RUN mkdir -p /build/ && find . -name test.main -exec cp --parents '{}' /build \;
+RUN mkdir -p /build/tests && find . -name test.main -exec cp --parents '{}' /build/tests \;
 
 ## Generate testing image
 FROM alpine:3.9 as runner
@@ -77,4 +80,4 @@ COPY integration-cli/fixtures   /tests/integration-cli/fixtures
 COPY --from=frozen-images /build/ /docker-frozen-images
 COPY --from=dockercli     /build/ /usr/bin/
 COPY --from=contrib       /build/ /tests/contrib/
-COPY --from=builder       /build/ /tests/
+COPY --from=builder       /build/ /


### PR DESCRIPTION
(this is a quick followup to #39116)

Package "gotest.tools/assert" uses source introspection to
print more info in case of assertion failure. When source code
is not available, it prints an error instead.

In other words, before this commit:

> --- SKIP: TestCgroupDriverSystemdMemoryLimit (0.00s)
>     cgroupdriver_systemd_test.go:32: failed to parse source file: /go/src/github.com/docker/docker/integration/system/cgroupdriver_systemd_test.go: open /go/src/github.com/docker/docker/integration/system/cgroupdriver_systemd_test.go: no such file or directory
>     cgroupdriver_systemd_test.go:32:

and after:

> --- SKIP: TestCgroupDriverSystemdMemoryLimit (0.09s)
>    cgroupdriver_systemd_test.go:32: !hasSystemd()

This increases the resulting image size by about 2 MB
on my system (from 758 to 760 MB).
