### PR TITLE
Rework pkg/loopback to fix #39155 and mitigate loop module race conditions

### DIFF
--- a/pkg/loopback/attach_loopback.go
+++ b/pkg/loopback/attach_loopback.go
@@ -119,7 +119,6 @@ func openNextAvailableLoopback(sparseFile *os.File) (loopFile *os.File, err erro
 			} else {
 				logrus.Errorf("Lost race to attach open loopback device (%d attempts)", openAttempts)
 			}
-			break // switch
 		case attachErrorStateNextFree:
 			logrus.Errorf("Error retrieving the next available loopback: %s", typedErr.underlying)
 			return

--- a/pkg/loopback/attach_loopback.go
+++ b/pkg/loopback/attach_loopback.go
@@ -99,7 +99,7 @@ func openNextAvailableLoopback(sparseFile *os.File) (loopFile *os.File, err erro
 	modCtx := &concreteLoopModuleContext{}
 
 	for i := 0; i < openAttempts; i++ {
-		loopFileAttempt, created, typedErr := modCtx.AttachToNextAvailableDevice(sparseFile)
+		loopFileAttempt, created, typedErr := attachToNextAvailableDevice(modCtx, sparseFile)
 		if created >= 0 {
 			loopName = fmt.Sprintf(loopFormat, created)
 			logrus.Warnf("Tried to forcibly create loopback device %s", loopName)

--- a/pkg/loopback/attach_loopback.go
+++ b/pkg/loopback/attach_loopback.go
@@ -5,10 +5,12 @@ package loopback // import "github.com/docker/docker/pkg/loopback"
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
+	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 // Loopback related errors
@@ -24,85 +26,136 @@ func stringToLoopName(src string) [LoNameSize]uint8 {
 	return dst
 }
 
-func openNextAvailableLoopback(modCtx loopModuleContext, sparseFile *os.File) (loopFile *os.File, err error) {
-	// Try to retrieve the next available loopback device via syscall.
-	startIndex, err := modCtx.GetNextFreeDeviceIndex()
-	// If it fails, we discard error and start looping for a
-	// loopback from index 0.
-	if err != nil {
-		logrus.Debugf("Error retrieving the next available loopback: %s", err)
-		startIndex = 0
-	}
+// The following handles the free-open race by sleeping for some random
+// interval between 0ms and 64ms, up to 32 times for an absolute maximum
+// delay of 2048ms (kernel time notwithstanding).
+//
+// We assume that the tick frequency of the kernel is, at its lowest,
+// 250Hz, which gives us a period of 4ms. Experiments indicate that disjoint
+// sleep times within a tick period's distance end up colliding with each
+// other and require more attempts to not race each other. Using an expected
+// tick period of 4ms with a maximum sleep time of 64ms gives us 16 discrete
+// tick windows to work with. Using a maximum sleep time of 32ms would only
+// give us 8 discrete tick windows.
+//
+// If we assume a burst mode of usage where 32 threads simultaneously race
+// each other for access to an open loop device, and no other threads attempt
+// to access an open loop device while these 32 are attempting to access an
+// open loop device, this attempt loop will succeed 100% of the time. However,
+// the moment you add one more thread, you introduce the possibility of
+// racing all the other threads past the maximum attempt count, and never
+// managing to access an open loop device.
+//
+// Let's use a 33 thread race as an example. If we were using a 32ms maximum
+// sleep time on a kernel with a 250Hz tick rate, we would have 8 tick windows
+// to work with on each attempt, and as per the pigeonhole principle
+// two threads are guaranteed to race each other for the first 24 attempts.
+// Of the 9 remaining threads, 8 will always succeed. There is a non-zero
+// chance that the 9th thread will not. The probability of the 9th thread
+// succeeding is the probability that the 9th thread races another thread
+// for the same tick window on every every attempt, i.e.
+//
+// 8! / 8^8 ~= 0.0024
+//
+// This only gives us two 9s of reliability for that 33rd thread succeeding.
+//
+// With a 64ms maximum sleep time and a 4ms tick period, we now have 16 tick
+// windows to work with on every attempt. This means that the pigeonhole
+// principle only applies to 32 threads for the first 16 attempts, and for
+// the 33rd thread, now treated as the 17th thread after the first 16 attempts,
+// the probability that it will race another thread for the same tick window
+// on every remaining attempt is now
+//
+// 16! / 16^16 ~= 1.134e-6
+//
+// Which gives us five 9s of reliability for that 33rd thread succeeding.
+const (
+	openAttempts = 32
+	maxSleepTime = 64
+)
 
-	// Start looking for a free /dev/loop from the startIndex
-	for index := startIndex;; index++ {
-		target := fmt.Sprintf(loopFormat, index) // defined in loop_module.go
-		fi, err := os.Stat(target)
+var (
+	rngLauncher sync.Once
+	rngChan     chan time.Duration
+)
 
-		// Sometimes we don't have udev managing device nodes for us
-		// (e.g. during unit testing inside of another Docker host), or
-		// sometimes udev is slow and we managed to get here before it
-		// creates the nodes for us. In both cases, since /dev/loop-control
-		// advised us that this loop device was free, we'll just directly make
-		// a device node for it.
-		//
-		// The worst case for udev would be that we manage to create the
-		// device node before it does; that should merely result in a few more
-		// error messages but otherwise shouldn't cause problems.
-		if index == startIndex && err != nil && os.IsNotExist(err) {
-			logrus.Warnf("Trying to forcibly create loopback device %s", target)
-			fi, err = modCtx.MakeIndexNode(index)
-		}
-		if err != nil {
-			if os.IsNotExist(err) {
-				logrus.Error("There are no more loopback devices available.")
+func getSleepTime() time.Duration {
+	rngLauncher.Do(func () {
+		rngChan = make(chan time.Duration)
+		go (func() {
+			gen := rand.New(rand.NewSource(time.Now().UnixNano()))
+			for {
+				rngChan <- time.Duration(gen.Int31n(maxSleepTime+1)) * time.Millisecond
 			}
-			return nil, ErrAttachLoopbackDevice
+		})()
+	})
+	return <-rngChan
+}
+
+func openNextAvailableLoopback(sparseFile *os.File) (loopFile *os.File, err error) {
+	var loopName string
+	// This is nil'd out on success, otherwise this is what we want to return
+	err = ErrAttachLoopbackDevice
+	modCtx := &concreteLoopModuleContext{}
+
+	for i := 0; i < openAttempts; i++ {
+		loopFileAttempt, created, typedErr := modCtx.AttachToNextAvailableDevice(sparseFile)
+		if created >= 0 {
+			loopName = fmt.Sprintf(loopFormat, created)
+			logrus.Warnf("Tried to forcibly create loopback device %s", loopName)
 		}
-
-		if fi.Mode()&os.ModeDevice != os.ModeDevice {
-			logrus.Errorf("Loopback device %s is not a block device.", target)
-			continue
+		if typedErr == nil {
+			err = nil
+			loopFile = loopFileAttempt
+			return
 		}
-
-		// OpenFile adds O_CLOEXEC
-		loopFile, err = os.OpenFile(target, os.O_RDWR, 0644)
-		if err != nil {
-			logrus.Errorf("Error opening loopback device: %s", err)
-			return nil, ErrAttachLoopbackDevice
-		}
-
-		// Try to attach to the loop file
-		if err := ioctlLoopSetFd(loopFile.Fd(), sparseFile.Fd()); err != nil {
-			loopFile.Close()
-
-			// If the error is EBUSY, then try the next loopback
-			if err != unix.EBUSY {
-				logrus.Errorf("Cannot set up loopback device %s: %s", target, err)
-				return nil, ErrAttachLoopbackDevice
+		switch typedErr.atState {
+		case attachErrorStateAttachFd:
+			if i < (openAttempts - 1) {
+				sleepTime := getSleepTime()
+				sleepTimeMs := sleepTime / time.Millisecond
+				logrus.Warnf("Lost race to attach to open loopback device (attempt %d of %d, sleep %dms)", i+1, openAttempts, sleepTimeMs)
+				time.Sleep(sleepTime)
+			} else {
+				logrus.Errorf("Lost race to attach open loopback device (%d attempts)", openAttempts)
 			}
-
-			// Otherwise, we keep going with the loop
-			continue
+			break // switch
+		case attachErrorStateNextFree:
+			logrus.Errorf("Error retrieving the next available loopback: %s", typedErr.underlying)
+			return
+		case attachErrorStateMknod:
+			if created < 0 {
+				panic(errors.New("Expected created device index"))
+			}
+			logrus.Errorf("Error creating loopback device %s: %s", loopName, typedErr.underlying)
+			return
+		case attachErrorStateStat:
+			logrus.Errorf("Could not stat loopback device: %s", typedErr.underlying)
+			return
+		case attachErrorStateModeCheck:
+			logrus.Error("Reported loopback device was not a block device")
+			return
+		case attachErrorStateOpenBlock:
+			logrus.Errorf("Could not open loopback device: %s", typedErr.underlying)
+			return
 		}
-		// In case of success, we finished. Break the loop.
-		break
+	}
+	return
+}
+
+func setAutoClear(loopFile *os.File) error {
+	loopInfo := &loopInfo64{
+		loFileName: stringToLoopName(loopFile.Name()),
+		loOffset:   0,
+		loFlags:    LoFlagsAutoClear,
 	}
 
-	// This can't happen, but let's be sure
-	if loopFile == nil {
-		logrus.Errorf("Unreachable code reached! Error attaching %s to a loopback device.", sparseFile.Name())
-		return nil, ErrAttachLoopbackDevice
-	}
-
-	return loopFile, nil
+	return ioctlLoopSetStatus64(loopFile.Fd(), loopInfo)
 }
 
 // AttachLoopDevice attaches the given sparse file to the next
 // available loopback device. It returns an opened *os.File.
 func AttachLoopDevice(sparseName string) (loop *os.File, err error) {
-	modCtx := &concreteLoopModuleContext{}
-
 	// OpenFile adds O_CLOEXEC
 	sparseFile, err := os.OpenFile(sparseName, os.O_RDWR, 0644)
 	if err != nil {
@@ -111,19 +164,12 @@ func AttachLoopDevice(sparseName string) (loop *os.File, err error) {
 	}
 	defer sparseFile.Close()
 
-	loopFile, err := openNextAvailableLoopback(modCtx, sparseFile)
+	loopFile, err := openNextAvailableLoopback(sparseFile)
 	if err != nil {
 		return nil, err
 	}
 
-	// Set the status of the loopback device
-	loopInfo := &loopInfo64{
-		loFileName: stringToLoopName(loopFile.Name()),
-		loOffset:   0,
-		loFlags:    LoFlagsAutoClear,
-	}
-
-	if err := ioctlLoopSetStatus64(loopFile.Fd(), loopInfo); err != nil {
+	if err := setAutoClear(loopFile); err != nil {
 		logrus.Errorf("Cannot set up loopback device info: %s", err)
 
 		// If the call failed, then free the loopback device

--- a/pkg/loopback/attach_loopback.go
+++ b/pkg/loopback/attach_loopback.go
@@ -80,7 +80,7 @@ var (
 )
 
 func getSleepTime() time.Duration {
-	rngLauncher.Do(func () {
+	rngLauncher.Do(func() {
 		rngChan = make(chan time.Duration)
 		go (func() {
 			gen := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/pkg/loopback/attach_loopback_test.go
+++ b/pkg/loopback/attach_loopback_test.go
@@ -1,0 +1,99 @@
+// +build linux,cgo
+
+package loopback // import "github.com/docker/docker/pkg/loopback"
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sync"
+	"testing"
+)
+
+const maxOpenDevices = 8 // As per daemon/graphdriver/devmapper_test.go: 8's a good number
+
+func TestFindOpenRaceResolution(t *testing.T) {
+	modCtx := &concreteLoopModuleContext{}
+	backingFiles := []*os.File{}
+
+	defer (func() {
+		for _, fp := range backingFiles {
+			fp.Close()
+		}
+	})()
+
+	t.Log("Perform initial create")
+	for i := 0; i < maxOpenDevices; i++ {
+		// Step 1: open up to maxOpenDevices for our internal usage
+		backingFile, err := ioutil.TempFile("", "docker-loopback-test.*.img") 
+		if err != nil {
+			t.Fatalf("Could not create temporary file: %s", err)
+		}
+
+		loopFile, created, typedErr := modCtx.AttachToNextAvailableDevice(backingFile)
+		if created >= 0 {
+			t.Logf("Attempted to create loop device file %s", fmt.Sprintf(loopFormat, created))
+		}
+		if typedErr != nil {
+			// We _may_ have run out of devices here, but this is not fatal.
+			// If we have any devices at all, we can likely run these tests.
+			// If we have none, we'll just skip the test entirely.
+			t.Logf("Error opening next loop device at state %s: %s", attachErrorString(typedErr.atState), typedErr.underlying)
+			backingFile.Close()
+			break
+		} else {
+			if err := ioctlLoopClrFd(loopFile.Fd()); err != nil {
+				t.Fatalf("Could not clear loop device file descriptor: %s", err)
+			}
+			loopFile.Close()
+		}
+
+		backingFiles = append(backingFiles, backingFile)
+	}
+
+	if len(backingFiles) == 0 {
+		t.Skip("Could not open any loop devices")
+	}
+
+	// Step 2: Open as many devices as we just did, but in parallel
+	var (
+		goroutineLaunchWg sync.WaitGroup
+		goroutineReturn   chan error = make(chan error)
+		returnCount       int
+		errorCount        int
+	)
+	t.Log("Launching goroutines")
+	goroutineLaunchWg.Add(1)
+	for _, backingFile := range backingFiles {
+		go (func(fp *os.File) {
+			// Wait until all goroutines have been spawned before attempting
+			// to attach to a loop device. This increases the likelihood of
+			// triggering a race condition.
+			goroutineLaunchWg.Wait()
+
+			loopFile, err := openNextAvailableLoopback(fp)
+			if err == nil {
+				err = setAutoClear(loopFile)
+				loopFile.Close()
+			}
+			goroutineReturn <- err
+		})(backingFile)
+	}
+	goroutineLaunchWg.Done()
+
+	t.Log("Getting errors")
+	for returnCount < len(backingFiles) {
+		err := <- goroutineReturn
+		t.Log("Got error")
+		returnCount += 1
+
+		if err != nil {
+			t.Logf("Error attaching to loop device: %s", err)
+			errorCount += 1
+		}
+	}
+
+	if errorCount > 0 {
+		t.Fail()
+	}
+}

--- a/pkg/loopback/attach_loopback_test.go
+++ b/pkg/loopback/attach_loopback_test.go
@@ -66,11 +66,11 @@ func (fi *createOnNoStatFileInfo) Sys() interface{} {
 }
 
 type createOnNoStatModuleContext struct {
-	nextFreeDeviceIndexCount    int
-	performMknodCount           int
-	setLoopFileFdCount          int
-	sentinelLoopFile            os.File
-	sentinelSparseFile          os.File
+	nextFreeDeviceIndexCount int
+	performMknodCount        int
+	setLoopFileFdCount       int
+	sentinelLoopFile         os.File
+	sentinelSparseFile       os.File
 }
 
 func (ctx *createOnNoStatModuleContext) performPathStat(path string) (os.FileInfo, error) {
@@ -87,8 +87,8 @@ func (ctx *createOnNoStatModuleContext) getNextFreeDeviceIndex() (int, error) {
 
 func (ctx *createOnNoStatModuleContext) getBaseDeviceNodeStat() (*syscall.Stat_t, error) {
 	return &syscall.Stat_t{
-		Uid: 0,
-		Gid: 0,
+		Uid:  0,
+		Gid:  0,
 		Mode: 0640,
 	}, nil
 }
@@ -145,7 +145,7 @@ func TestFindOpenRaceResolution(t *testing.T) {
 	t.Log("Perform initial create")
 	for i := 0; i < maxOpenDevices; i++ {
 		// Step 1: open up to maxOpenDevices for our internal usage
-		backingFile, err := ioutil.TempFile("", "docker-loopback-test.*.img") 
+		backingFile, err := ioutil.TempFile("", "docker-loopback-test.*.img")
 		if err != nil {
 			t.Fatalf("Could not create temporary file: %s", err)
 		}
@@ -203,7 +203,7 @@ func TestFindOpenRaceResolution(t *testing.T) {
 
 	t.Log("Getting errors")
 	for returnCount < len(backingFiles) {
-		err := <- goroutineReturn
+		err := <-goroutineReturn
 		t.Log("Got error")
 		returnCount++
 

--- a/pkg/loopback/ioctl.go
+++ b/pkg/loopback/ioctl.go
@@ -9,11 +9,15 @@ import (
 )
 
 func ioctlLoopCtlGetFree(fd uintptr) (int, error) {
-	index, err := unix.IoctlGetInt(int(fd), LoopCtlGetFree)
-	if err != nil {
+	// The ioctl interface for /dev/loop-control (since Linux 3.1) is a bit
+	// off compared to what you'd expect: instead of writing an integer to a
+	// parameter pointer like unix.IoctlGetInt() expects, it returns the first
+	// available loop device index directly.
+	ioctlReturn, _, err := unix.Syscall(unix.SYS_IOCTL, fd, LoopCtlGetFree, 0)
+	if err != 0 {
 		return 0, err
 	}
-	return index, nil
+	return int(ioctlReturn), nil
 }
 
 func ioctlLoopSetFd(loopFd, sparseFd uintptr) error {

--- a/pkg/loopback/loop_module.go
+++ b/pkg/loopback/loop_module.go
@@ -14,10 +14,10 @@ import (
 )
 
 const (
-	loopMajorDev = 7 // see /usr/include/linux/major.h
-	loopControl = "/dev/loop-control"
-	loopFormat = "/dev/loop%d"
-	loopZero = "/dev/loop0"
+	loopMajorDev      = 7 // see /usr/include/linux/major.h
+	loopControl       = "/dev/loop-control"
+	loopFormat        = "/dev/loop%d"
+	loopZero          = "/dev/loop0"
 	sysfsModuleFormat = "/sys/module/loop/parameters/%s"
 )
 
@@ -25,7 +25,7 @@ type attachErrorState = int
 
 const (
 	attachErrorStateNextFree = attachErrorState(iota)
-	attachErrorStateMknod // Only occurs when creating a new loop device
+	attachErrorStateMknod    // Only occurs when creating a new loop device
 	attachErrorStateStat
 	attachErrorStateModeCheck
 	attachErrorStateOpenBlock
@@ -33,7 +33,7 @@ const (
 )
 
 type attachError struct {
-	atState attachErrorState
+	atState    attachErrorState
 	underlying error
 }
 
@@ -174,7 +174,7 @@ func attachToNextAvailableDevice(ctx loopModuleContext, sparseFile *os.File) (lo
 	index, underlying := ctx.getNextFreeDeviceIndex()
 	if underlying != nil {
 		err = &attachError{
-			atState: attachErrorStateNextFree,
+			atState:    attachErrorStateNextFree,
 			underlying: underlying,
 		}
 		return
@@ -189,12 +189,12 @@ func attachToNextAvailableDevice(ctx loopModuleContext, sparseFile *os.File) (lo
 	if underlying != nil {
 		if createdIndex >= 0 {
 			err = &attachError{
-				atState: attachErrorStateMknod,
+				atState:    attachErrorStateMknod,
 				underlying: underlying,
 			}
 		} else {
 			err = &attachError{
-				atState: attachErrorStateStat,
+				atState:    attachErrorStateStat,
 				underlying: underlying,
 			}
 		}
@@ -205,7 +205,7 @@ func attachToNextAvailableDevice(ctx loopModuleContext, sparseFile *os.File) (lo
 	// and have to bail out now.
 	if fi.Mode()&os.ModeDevice != os.ModeDevice {
 		err = &attachError{
-			atState: attachErrorStateModeCheck,
+			atState:    attachErrorStateModeCheck,
 			underlying: syscall.EINVAL,
 		}
 		return
@@ -215,7 +215,7 @@ func attachToNextAvailableDevice(ctx loopModuleContext, sparseFile *os.File) (lo
 	loopFile, underlying = ctx.openDeviceFile(target)
 	if underlying != nil {
 		err = &attachError{
-			atState: attachErrorStateOpenBlock,
+			atState:    attachErrorStateOpenBlock,
 			underlying: underlying,
 		}
 		return
@@ -225,7 +225,7 @@ func attachToNextAvailableDevice(ctx loopModuleContext, sparseFile *os.File) (lo
 		loopFile.Close()
 		loopFile = nil
 		err = &attachError{
-			atState: attachErrorStateAttachFd,
+			atState:    attachErrorStateAttachFd,
 			underlying: underlying,
 		}
 	}
@@ -233,7 +233,7 @@ func attachToNextAvailableDevice(ctx loopModuleContext, sparseFile *os.File) (lo
 	return
 }
 
-type concreteLoopModuleContext struct {}
+type concreteLoopModuleContext struct{}
 
 func (ctx *concreteLoopModuleContext) performPathStat(path string) (os.FileInfo, error) {
 	return os.Stat(path)

--- a/pkg/loopback/loop_module.go
+++ b/pkg/loopback/loop_module.go
@@ -33,25 +33,6 @@ const (
 	attachErrorStateAttachFd
 )
 
-func attachErrorStateString(aes attachErrorState) string {
-	switch aes {
-	case attachErrorStateNextFree:
-		return "nextFree"
-	case attachErrorStateMknod:
-		return "mknod"
-	case attachErrorStateStat:
-		return "stat"
-	case attachErrorStateModeCheck:
-		return "modeCheck"
-	case attachErrorStateOpenBlock:
-		return "openBlock"
-	case attachErrorStateAttachFd:
-		return "attachFd"
-	default:
-		return "?"
-	}
-}
-
 type attachError struct {
 	atState attachErrorState
 	underlying error

--- a/pkg/loopback/loop_module.go
+++ b/pkg/loopback/loop_module.go
@@ -22,6 +22,49 @@ const (
 	sysfsModuleFormat = "/sys/module/loop/parameters/%s"
 )
 
+type attachErrorState = int
+
+const (
+	attachErrorStateNextFree = attachErrorState(iota)
+	attachErrorStateMknod // Only occurs when creating a new loop device
+	attachErrorStateStat
+	attachErrorStateModeCheck
+	attachErrorStateOpenBlock
+	attachErrorStateAttachFd
+)
+
+func attachErrorString(aes attachErrorState) string {
+	switch aes {
+	case attachErrorStateNextFree:
+		return "nextFree"
+	case attachErrorStateMknod:
+		return "mknod"
+	case attachErrorStateStat:
+		return "stat"
+	case attachErrorStateModeCheck:
+		return "modeCheck"
+	case attachErrorStateOpenBlock:
+		return "openBlock"
+	case attachErrorStateAttachFd:
+		return "attachFd"
+	default:
+		return "?"
+	}
+}
+
+type attachError struct {
+	atState attachErrorState
+	underlying error
+}
+
+func (attachErr *attachError) Error() string {
+	return attachErr.underlying.Error()
+}
+
+func (attachErr *attachError) Underlying() error {
+	return attachErr.underlying
+}
+
 type loopModuleContext interface {
 	PerformPathStat(path string) (os.FileInfo, error)
 	GetNextFreeDeviceIndex() (int, error)
@@ -32,6 +75,16 @@ type loopModuleContext interface {
 	GetMknodDeviceNumber(index int) (int, error)
 	PerformMknod(path string, mode uint32, dev int) error
 	MakeIndexNode(index int) (os.FileInfo, error)
+	OpenDeviceFile(path string) (*os.File, error)
+	SetLoopFileFd(loopFile *os.File, sparseFile *os.File) error
+	// Returns:
+	// 1. The open loop device file, if applicable
+	// 2. The index of the loop device file that was created,
+	//    or -1 if no device file was created.
+	// 3. The error that occurred, or nil if no error occurred.
+	//    Note that err.atState == attachErrorStateMknod implies that
+	//    the index of the loop device is >= 0.
+	AttachToNextAvailableDevice(*os.File) (*os.File, int, *attachError)
 }
 
 func getNextFreeDeviceIndex() (int, error) {
@@ -107,6 +160,15 @@ func getPartitionShift(ctx loopModuleContext) (uint, error) {
 	return uint(bits.Len(maxPart)), nil
 }
 
+func getMknodDeviceNumber(ctx loopModuleContext, index int) (int, error) {
+	partShift, err := ctx.GetPartitionShift()
+	if err != nil {
+		return 0, err
+	}
+	minorDev := int64(index << partShift)
+	return int(system.Mkdev(loopMajorDev, minorDev)), nil
+}
+
 func directIndexMknod(ctx loopModuleContext, index int) (os.FileInfo, error) {
 	loopPath := fmt.Sprintf(loopFormat, index)
 	// If the file already exists we don't need to create it
@@ -131,6 +193,79 @@ func directIndexMknod(ctx loopModuleContext, index int) (os.FileInfo, error) {
 		}
 	}
 	return ctx.PerformPathStat(loopPath)
+}
+
+func openDeviceFile(path string) (*os.File, error) {
+	// OpenFile adds O_CLOEXEC
+	return os.OpenFile(path, os.O_RDWR, 0644)
+}
+
+func setLoopFileFd(loopFile *os.File, sparseFile *os.File) error {
+	return ioctlLoopSetFd(loopFile.Fd(), sparseFile.Fd())
+}
+
+func attachNextAvailableDevice(ctx loopModuleContext, sparseFile *os.File) (loopFile *os.File, createdIndex int, err *attachError) {
+	createdIndex = -1
+	index, underlying := ctx.GetNextFreeDeviceIndex()
+	if underlying != nil {
+		err = &attachError{
+			atState: attachErrorStateNextFree,
+			underlying: underlying,
+		}
+		return
+	}
+
+	target := fmt.Sprintf(loopFormat, index)
+	fi, underlying := ctx.PerformPathStat(target)
+	if underlying != nil && os.IsNotExist(underlying) {
+		createdIndex = index
+		fi, underlying = ctx.MakeIndexNode(index)
+	}
+	if underlying != nil {
+		if createdIndex >= 0 {
+			err = &attachError{
+				atState: attachErrorStateMknod,
+				underlying: underlying,
+			}
+		} else {
+			err = &attachError{
+				atState: attachErrorStateStat,
+				underlying: underlying,
+			}
+		}
+		return
+	}
+
+	// If, for some reason, we end up with a non-device file, we can't use it
+	// and have to bail out now.
+	if fi.Mode()&os.ModeDevice != os.ModeDevice {
+		err = &attachError{
+			atState: attachErrorStateModeCheck,
+			underlying: syscall.EINVAL,
+		}
+		return
+	}
+
+	// OpenFile adds O_CLOEXEC
+	loopFile, underlying = ctx.OpenDeviceFile(target)
+	if underlying != nil {
+		err = &attachError{
+			atState: attachErrorStateOpenBlock,
+			underlying: underlying,
+		}
+		return
+	}
+
+	if underlying = ctx.SetLoopFileFd(loopFile, sparseFile); underlying != nil {
+		loopFile.Close()
+		loopFile = nil
+		err = &attachError{
+			atState: attachErrorStateAttachFd,
+			underlying: underlying,
+		}
+	}
+
+	return
 }
 
 type concreteLoopModuleContext struct {}
@@ -160,12 +295,7 @@ func (ctx *concreteLoopModuleContext) GetPartitionShift() (uint, error) {
 }
 
 func (ctx *concreteLoopModuleContext) GetMknodDeviceNumber(index int) (int, error) {
-	partShift, err := ctx.GetPartitionShift()
-	if err != nil {
-		return 0, err
-	}
-	minorDev := int64(index << partShift)
-	return int(system.Mkdev(loopMajorDev, minorDev)), nil
+	return getMknodDeviceNumber(ctx, index)
 }
 
 func (ctx *concreteLoopModuleContext) PerformMknod(path string, mode uint32, dev int) error {
@@ -174,4 +304,16 @@ func (ctx *concreteLoopModuleContext) PerformMknod(path string, mode uint32, dev
 
 func (ctx *concreteLoopModuleContext) MakeIndexNode(index int) (os.FileInfo, error) {
 	return directIndexMknod(ctx, index)
+}
+
+func (ctx *concreteLoopModuleContext) OpenDeviceFile(path string) (*os.File, error) {
+	return openDeviceFile(path)
+}
+
+func (ctx *concreteLoopModuleContext) SetLoopFileFd(loopFile *os.File, sparseFile *os.File) error {
+	return setLoopFileFd(loopFile, sparseFile)
+}
+
+func (ctx *concreteLoopModuleContext) AttachToNextAvailableDevice(sparseFile *os.File) (*os.File, int, *attachError) {
+	return attachNextAvailableDevice(ctx, sparseFile)
 }

--- a/pkg/loopback/loop_module.go
+++ b/pkg/loopback/loop_module.go
@@ -33,7 +33,7 @@ const (
 	attachErrorStateAttachFd
 )
 
-func attachErrorString(aes attachErrorState) string {
+func attachErrorStateString(aes attachErrorState) string {
 	switch aes {
 	case attachErrorStateNextFree:
 		return "nextFree"

--- a/pkg/loopback/loop_module.go
+++ b/pkg/loopback/loop_module.go
@@ -55,7 +55,7 @@ type loopModuleContext interface {
 }
 
 func getNextFreeDeviceIndexViaLoopControl() (int, error) {
-	f, err := os.OpenFile("/dev/loop-control", os.O_RDONLY, 0644)
+	f, err := os.OpenFile(loopControl, os.O_RDONLY, 0644)
 	if err != nil {
 		return 0, err
 	}
@@ -144,7 +144,7 @@ func directIndexMknod(ctx loopModuleContext, index int) (os.FileInfo, error) {
 		return nil, err
 	}
 
-	if err = ctx.performMknod(loopPath, uint32(baseStats.Mode|syscall.S_IFBLK), deviceNumber); err != nil {
+	if err = ctx.performMknod(loopPath, baseStats.Mode|syscall.S_IFBLK, deviceNumber); err != nil {
 		// If the mknod call failed because it already exists, we're fine
 		if asErrno, ok := err.(syscall.Errno); !ok || asErrno != syscall.EEXIST {
 			return nil, err

--- a/pkg/loopback/loop_module.go
+++ b/pkg/loopback/loop_module.go
@@ -1,0 +1,177 @@
+// +build linux,cgo
+
+package loopback // import "github.com/docker/docker/pkg/loopback"
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"math/bits"
+	"os"
+	"strconv"
+	"syscall"
+
+	"github.com/docker/docker/pkg/system"
+)
+
+const (
+	loopMajorDev = 7 // see /usr/include/linux/major.h
+	loopControl = "/dev/loop-control"
+	loopFormat = "/dev/loop%d"
+	loopZero = "/dev/loop0"
+	sysfsModuleFormat = "/sys/module/loop/parameters/%s"
+)
+
+type loopModuleContext interface {
+	PerformPathStat(path string) (os.FileInfo, error)
+	GetNextFreeDeviceIndex() (int, error)
+	GetBaseDeviceNodeStat() (*syscall.Stat_t, error)
+	OpenSysfsParameterFile(param string) (io.ReadCloser, error)
+	GetMaxPartitionParameter() (uint, error)
+	GetPartitionShift() (uint, error)
+	GetMknodDeviceNumber(index int) (int, error)
+	PerformMknod(path string, mode uint32, dev int) error
+	MakeIndexNode(index int) (os.FileInfo, error)
+}
+
+func getNextFreeDeviceIndex() (int, error) {
+	f, err := os.OpenFile("/dev/loop-control", os.O_RDONLY, 0644)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	index, err := ioctlLoopCtlGetFree(f.Fd())
+	if index < 0 {
+		index = 0
+	}
+	return index, err
+}
+
+// getBaseDeviceNodeStat inspects /dev/loop0 to collect uid,gid, and mode for
+// the loop0 device on the system. If it does not exist we assume 0,0,0660 for
+// the stat data (the defaults at least for Ubuntu 18.10).
+//
+// Stolen from daemon/devmapper/graphdriver/devmapper/devmapper_test.go.
+func getBaseDeviceNodeStat(ctx loopModuleContext) (*syscall.Stat_t, error) {
+	loop0, err := ctx.PerformPathStat(loopZero)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &syscall.Stat_t{
+				Uid:  0,
+				Gid:  0,
+				Mode: 0660,
+			}, nil
+		}
+		return nil, err
+	}
+	return loop0.Sys().(*syscall.Stat_t), nil
+}
+
+func openLoopModuleSysfsParameter(param string) (io.ReadCloser, error) {
+	return os.Open(fmt.Sprintf(sysfsModuleFormat, param))
+}
+
+func getMaxPartitionParameter(ctx loopModuleContext) (uint, error) {
+	fp, err := ctx.OpenSysfsParameterFile("max_part")
+	if err != nil {
+		// This parameter is expected to exist for the forseseeable future
+		// but it wouldn't hurt to handle the case where it's missing.
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	defer fp.Close()
+
+	scanner := bufio.NewScanner(fp)
+	scanner.Scan()
+	// io.EOF isn't treated as an error by scanner.Err()
+	if err = scanner.Err(); err != nil {
+		return 0, err
+	}
+
+	maxPart, err := strconv.ParseUint(scanner.Text(), 10, 0)
+	return uint(maxPart), err
+}
+
+func getPartitionShift(ctx loopModuleContext) (uint, error) {
+	maxPart, err := ctx.GetMaxPartitionParameter()
+	if err != nil {
+		return 0, err
+	}
+	// see drivers/block/loop.c in the Linux kernel sources
+	// part_shift = fls(max_part) as set at module init time,
+	// i.e. part_shift is the offset of the most significant
+	// set bit of max_part as passed as a module parameter.
+	return uint(bits.Len(maxPart)), nil
+}
+
+func directIndexMknod(ctx loopModuleContext, index int) (os.FileInfo, error) {
+	loopPath := fmt.Sprintf(loopFormat, index)
+	// If the file already exists we don't need to create it
+	if incumbentStat, err := ctx.PerformPathStat(loopPath); err == nil {
+		return incumbentStat, nil
+	}
+
+	baseStats, err := ctx.GetBaseDeviceNodeStat()
+	if err != nil {
+		return nil, err
+	}
+
+	deviceNumber, err := ctx.GetMknodDeviceNumber(index)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = ctx.PerformMknod(loopPath, uint32(baseStats.Mode|syscall.S_IFBLK), deviceNumber); err != nil {
+		// If the mknod call failed because it already exists, we're fine
+		if asErrno, ok := err.(syscall.Errno); !ok || asErrno != syscall.EEXIST {
+			return nil, err
+		}
+	}
+	return ctx.PerformPathStat(loopPath)
+}
+
+type concreteLoopModuleContext struct {}
+
+func (ctx *concreteLoopModuleContext) PerformPathStat(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}
+
+func (ctx *concreteLoopModuleContext) GetNextFreeDeviceIndex() (int, error) {
+	return getNextFreeDeviceIndex()
+}
+
+func (ctx *concreteLoopModuleContext) GetBaseDeviceNodeStat() (*syscall.Stat_t, error) {
+	return getBaseDeviceNodeStat(ctx)
+}
+
+func (ctx *concreteLoopModuleContext) OpenSysfsParameterFile(param string) (io.ReadCloser, error) {
+	return openLoopModuleSysfsParameter(param)
+}
+
+func (ctx *concreteLoopModuleContext) GetMaxPartitionParameter() (uint, error) {
+	return getMaxPartitionParameter(ctx)
+}
+
+func (ctx *concreteLoopModuleContext) GetPartitionShift() (uint, error) {
+	return getPartitionShift(ctx)
+}
+
+func (ctx *concreteLoopModuleContext) GetMknodDeviceNumber(index int) (int, error) {
+	partShift, err := ctx.GetPartitionShift()
+	if err != nil {
+		return 0, err
+	}
+	minorDev := int64(index << partShift)
+	return int(system.Mkdev(loopMajorDev, minorDev)), nil
+}
+
+func (ctx *concreteLoopModuleContext) PerformMknod(path string, mode uint32, dev int) error {
+	return system.Mknod(path, mode, dev)
+}
+
+func (ctx *concreteLoopModuleContext) MakeIndexNode(index int) (os.FileInfo, error) {
+	return directIndexMknod(ctx, index)
+}


### PR DESCRIPTION
The root cause of issue #39155 is that `pkg/loopback` attempts to open
a loop device, the `loop` module allocates a new loop device because all
others are busy, but the container is not seeing an appropriate
`/dev/loopX` device being created. Inside the `moby` unit test
container, there is no `udev`, so the natural consequence is that the
`loop` module communicates a free device index that is not visible to
the tests.

This reworking of `pkg/loopback` fixes #39155, and handles some other outstanding issues as well:

1. The `/dev` filesystem is no longer probed scanning for open loop
   devices; this reworking appropriately uses the `loop` module
   userspace API to determine the next free index. (Previously, this
   API was not being used correctly, hence the need for `/dev` scanning)
2. `loop` device nodes are forcibly created if the `loop` module reports
   them as free but they do not exist on the filesystem, solving a race
   condition between the daemon and `udev` even outside of unit testing.
3. Race conditions between determining the next free device index and
   acquiring said device for file attachment are handled by way of
   random sleep intervals, which makes the race condition mitigation
   appropriate for both in-process races and environmental races, e.g.
   some other OCI implementation uses the `loop` module at the exact
   same time.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Internally reworked `pkg/loopback` to fix #39155, without altering the external API.

**- How I did it**
- Fixed `ioctlLoopCtlGetFree` to use the `loop` module `ioctl` interface properly, so that the next free loop device index is actually captured.
- Created new file `loop_module.go` with an interface and implementation to automatically create a device node for the reported next free loop device index if a suitable node does not already exist.
- Replaced file scan loop in `openNextAvailableLoopback` with a retry system based on random sleep intervals, so that races between next-free and open are mitigated by non-overlapping sleep intervals.

**- How to verify it**
Unit tests for the new interfaces have been provided for both device node creation and race condition mitigation; and are automatically run as part of the unit test suite.

**- Description for the changelog**
Reworked `pkg/loopback` to automatically create device nodes, eliminating `udev` race conditions; also mitigating race conditions around attaching to loop devices.