### PR TITLE
Remove HostConfig.DiskQouta field.

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -463,10 +463,6 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/DeviceRequest"
-      DiskQuota:
-        description: "Disk limit (in bytes)."
-        type: "integer"
-        format: "int64"
       KernelMemory:
         description: "Kernel memory limit in bytes."
         type: "integer"

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -338,7 +338,6 @@ type Resources struct {
 	Devices              []DeviceMapping // List of devices to map inside the container
 	DeviceCgroupRules    []string        // List of rule to be added to the device cgroup
 	DeviceRequests       []DeviceRequest // List of device requests for device drivers
-	DiskQuota            int64           // Disk limit (in bytes)
 	KernelMemory         int64           // Kernel memory limit (in bytes)
 	KernelMemoryTCP      int64           // Hard limit for kernel TCP buffer memory (in bytes)
 	MemoryReservation    int64           // Memory soft limit (in bytes)

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -153,7 +153,6 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 		resources.CpusetMems != "" ||
 		len(resources.Devices) != 0 ||
 		len(resources.DeviceCgroupRules) != 0 ||
-		resources.DiskQuota != 0 ||
 		resources.KernelMemory != 0 ||
 		resources.MemoryReservation != 0 ||
 		resources.MemorySwap != 0 ||


### PR DESCRIPTION
Signed-off-by: Yash Murty <yashmurty@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Removed the `HostConfig.DiskQouta` field which is not used anywhere.
Further discussed in https://github.com/moby/moby/issues/38081 and https://github.com/docker/engine-api/pull/52.
As noted in the discussion by @cpuguy83 , `btrfs` does not use this field. 
> For storage drivers that support quotas, such as btrfs, quotas are passed through `StorageOpt`.

**- How I did it**
Removed it from :
`api/swagger.yaml `
`api/types/container/host_config.go`
`container/container_windows.go`

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Removed the `HostConfig.DiskQouta` field which is not used anywhere.

**- A picture of a cute animal (not mandatory but encouraged)**

