### PR TITLE
Implement new mount type "localbind" on Linux

### DIFF
--- a/api/types/mount/mount.go
+++ b/api/types/mount/mount.go
@@ -11,6 +11,8 @@ type Type string
 const (
 	// TypeBind is the type for mounting host dir
 	TypeBind Type = "bind"
+	// TypeLocalBind is the type for internal bind mounts within the container
+	TypeLocalBind Type = "localbind"
 	// TypeVolume is the type for remote storage volumes
 	TypeVolume Type = "volume"
 	// TypeTmpfs is the type for mounting tmpfs

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -217,7 +217,7 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			}
 		}
 
-		if mp.Type == mounttypes.TypeBind {
+		if mp.Type == mounttypes.TypeBind || mp.Type == mounttypes.TypeLocalBind {
 			mp.SkipMountpointCreation = true
 		}
 

--- a/daemon/volumes_linux.go
+++ b/daemon/volumes_linux.go
@@ -13,6 +13,9 @@ import (
 // from holding private references to a mount within the daemon root, which
 // can cause issues when the daemon attempts to remove the mountpoint.
 func (daemon *Daemon) validateBindDaemonRoot(m mount.Mount) (bool, error) {
+	// This excludes mount.TypeLocalBind as well. This is on purpose.
+	// The container owns all the mounts in its fs root, so the problems this is intended
+	// to prevent cannot occur in the localbind case as far as I understand.
 	if m.Type != mount.TypeBind {
 		return false, nil
 	}


### PR DESCRIPTION
Implement new mount type "localbind" on Linux (closes #39134).

**- What I did**

A local bind mount is a bind mount where the source path is inside the container (i.e. '/' is the container's root, not the host's root.)

Without this feature it is not easy to use bind mounts for their original intended purposes inside a container. It is of course possible by starting a container with `CAP_SYS_ADMIN` and doing the mounts manually, but this is often undesirable. It also means mount configuration is spread between multiple locations.

NOTE: I have very lightly tested this by hand. Wanted to get some initial feedback before investing more time in it. Please let me know if this direction seems acceptable.

**- How I did it**

The implementation delays the processing of the `Source` path for this mount type until the list of mounts is produced in `setupMounts`. It is of course possible to resolve the source path to a host path much earlier, but storing such a derived value in the mount's persistent configuration seemed wrong. (And storing a path that is valid only inside the container in a field that normally contains paths valid on the host seemed doubly wrong, so I did not consider it.)

On Windows trying to use this mount type will give an error stating the mount type is unknown. It's probably easy to implement for Windows, but I have no easy way to test it so I thought it best to leave it out for now.

This works without patches to docker cli or docker-compose.

**- How to verify it**

```
docker -D -H 172.17.0.2 run --rm -it --mount type=localbind,source=/etc,target=/mnt debian:9 /bin/bash
```

And verify that the container's /etc is mounted at /mnt.

**- Description for the changelog**

New mount type "localbind" on Linux for bind mounting between two paths inside the container.

**- A picture of a cute animal (not mandatory but encouraged)**

![brbz7kk8ixf21](https://user-images.githubusercontent.com/14318781/57025817-895c3280-6c38-11e9-8a58-5350e351bcde.jpg)

