### PR TITLE
Remove a network during task SHUTDOWN instead of REMOVE

### DIFF
--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -376,6 +376,15 @@ func (r *controller) Shutdown(ctx context.Context) error {
 		return err
 	}
 
+	// Try removing networks referenced in this task in case this
+	// task is the last one referencing it
+	if err := r.adapter.removeNetworks(ctx); err != nil {
+		if isUnknownContainer(err) {
+			return nil
+		}
+		return err
+	}
+
 	return nil
 }
 
@@ -417,15 +426,6 @@ func (r *controller) Remove(ctx context.Context) error {
 		}
 		// This may fail if the task was already shut down.
 		log.G(ctx).WithError(err).Debug("shutdown failed on removal")
-	}
-
-	// Try removing networks referenced in this task in case this
-	// task is the last one referencing it
-	if err := r.adapter.removeNetworks(ctx); err != nil {
-		if isUnknownContainer(err) {
-			return nil
-		}
-		return err
 	}
 
 	if err := r.adapter.remove(ctx); err != nil {


### PR DESCRIPTION
Make sure the LB sandbox is removed when a service is updated
with a --network-rm option

Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Ensured that the LoadBalancer Sandbox is deleted when a service is updated with --network-rm option

**- How I did it**

Removed the removeNetworks logic from task REMOVE to task SHUTDOWN

**- How to verify it**
```
docker network create -d overlay netTest1
docker network create -d overlay netTest2
docker service create  --name test --network netTest1 --network netTest2 --replicas 2 nginx
docker service update --network-rm netTest2 test
docker network inspect netTest2  # Make sure there are no endpoints including LB

```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

