### PR TITLE
fixes #39145: Correct copy paste mistage in pkg/mount/mountinfo_freebsd.go that cau…

### DIFF
--- a/pkg/mount/mountinfo_freebsd.go
+++ b/pkg/mount/mountinfo_freebsd.go
@@ -13,8 +13,8 @@ import (
 	"unsafe"
 )
 
-// Parse /proc/self/mountinfo because comparing Dev and ino does not work from
-// bind mounts.
+
+//parseMountTable returns information about mounted filesystems
 func parseMountTable(filter FilterFunc) ([]*Info, error) {
 	var rawEntries *C.struct_statfs
 
@@ -37,7 +37,7 @@ func parseMountTable(filter FilterFunc) ([]*Info, error) {
 
 		if filter != nil {
 			// filter out entries we're not interested in
-			skip, stop = filter(p)
+			skip, stop = filter(&mountinfo)
 			if skip {
 				continue
 			}


### PR DESCRIPTION
…sed compile errors.

Signed-off-by: Stig Larsson <stig@larsson.dev>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed copy paste error

**- How I did it**
By renaming a variable.

**- How to verify it**
It builds

**- Description for the changelog**
Fixed issue where the pkg/mount package didn't build on FreeBSD


**- A picture of a cute animal (not mandatory but encouraged)**

