### PR TITLE
Add alias for hostname if hostname != container name

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -674,6 +674,18 @@ func (daemon *Daemon) updateNetworkConfig(container *container.Container, n libn
 		if addShortID {
 			endpointConfig.Aliases = append(endpointConfig.Aliases, shortID)
 		}
+		if container.Name != container.Config.Hostname {
+			addHostname := true
+			for _, alias := range endpointConfig.Aliases {
+				if alias == container.Config.Hostname {
+					addHostname = false
+					break
+				}
+			}
+			if addHostname {
+				endpointConfig.Aliases = append(endpointConfig.Aliases, container.Config.Hostname)
+			}
+		}
 	}
 
 	if err := validateNetworkingConfig(n, endpointConfig); err != nil {

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -10,6 +10,7 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration/internal/container"
+	net "github.com/docker/docker/integration/internal/network"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/poll"
@@ -92,4 +93,38 @@ func TestNISDomainname(t *testing.T) {
 	assert.Assert(t, is.Len(res.Stderr(), 0))
 	assert.Equal(t, 0, res.ExitCode)
 	assert.Check(t, is.Equal(domainname, strings.TrimSpace(res.Stdout())))
+}
+
+func TestHostnameDnsResolution(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+
+	defer setupTest(t)()
+	client := testEnv.APIClient()
+	ctx := context.Background()
+
+	const (
+		hostname = "foobar"
+	)
+
+	// using user defined network as we want to use internal DNS
+	netName := "foobar-net"
+	net.CreateNoError(t, context.Background(), client, netName, net.WithDriver("bridge"))
+
+	cID := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
+		c.Config.Hostname = hostname
+		c.HostConfig.NetworkMode = containertypes.NetworkMode(netName)
+	})
+
+	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
+
+	inspect, err := client.ContainerInspect(ctx, cID)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(hostname, inspect.Config.Hostname))
+
+	// Clear hosts file so ping will use DNS for hostname resolution
+	res, err := container.Exec(ctx, client, cID,
+		[]string{"sh", "-c", "echo 127.0.0.1 localhost | tee /etc/hosts && ping -c 1 foobar"})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("", res.Stderr()))
+	assert.Equal(t, 0, res.ExitCode)
 }


### PR DESCRIPTION
**- What I did**
As part of investigation #33408 I noticed that if user defines custom hostname then that hostname is not resolvable from other containers on same network.

**- How I did it**
Added logic which adds alias if to all user defined networks if hostname != container name and user have not added that alias himself.

**- How to verify it**
Included unit test which failed to error:
```
Running /go/src/github.com/docker/docker/integration/container
INFO: Testing against a local daemon
=== RUN   TestHostnameDnsResolution
--- FAIL: TestHostnameDnsResolution (3.64s)
    run_linux_test.go:128: assertion failed: 
        --- ←
        +++ →
        @@ -1 +1,2 @@
        +ping: bad address 'foobar'
         
        
    run_linux_test.go:129: assertion failed: 0 (int) != 1 (res.ExitCode int)
FAIL
```
without this one.

You can also try deploy stack:
```yaml
version: '3.7'
networks:
    test:
services:
  busybox:
    image: busybox
    command: tail -f /dev/null
    deploy:
      replicas: 2
    hostname: "busybox-{{.Task.Slot}}"
    networks:
      - test
```
and ping containers with each others hostnames.


It is also worth of mention that user is also able to set same hostname to multiple containers with stack like:
```yaml
version: '3.7'
networks:
    test:
services:
  test:
    image: busybox
    command: tail -f /dev/null
    deploy:
      replicas: 2
    hostname: busybox
    networks:
      - test
```
but it does matter as it is totally valid DNS configuration to have multiple records with same name (DNS round robin) and container uses hosts file as default name resolution source (=> application inside of container will get containers own IP when if they try resolve container hostname).

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6213926/57572205-d0f47280-741f-11e9-8cc2-b4786be38014.png)

