### PR TITLE
WIP: Enable engine plugin tests to Windows

### DIFF
--- a/integration-cli/docker_cli_daemon_plugins_test.go
+++ b/integration-cli/docker_cli_daemon_plugins_test.go
@@ -1,13 +1,11 @@
-// +build linux
-
 package main
 
 import (
+	"syscall"
 	"strings"
 
 	"github.com/docker/docker/pkg/mount"
 	"github.com/go-check/check"
-	"golang.org/x/sys/unix"
 	"gotest.tools/assert"
 	"gotest.tools/icmd"
 )
@@ -143,7 +141,7 @@ func (s *DockerDaemonSuite) TestDaemonShutdownWithPlugins(c *check.C) {
 	}
 
 	for {
-		if err := unix.Kill(s.d.Pid(), 0); err == unix.ESRCH {
+		if err := s.d.Kill(); err == syscall.ESRCH {
 			break
 		}
 	}


### PR DESCRIPTION
**- What I did**
I was planning to port some volume plugin for Windows and noticed that integration tests engine plugin are not currently enabled for Windows.

**- How I did it**
So did minor modifications to make those tests working on Windows.

**- How to verify it**
Pass CI.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6213926/57650167-d219d100-75d2-11e9-8b4d-d12caf2953c0.png)

