### PR TITLE
vendor: update buildkit to f238f1ef

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -27,7 +27,7 @@ github.com/imdario/mergo                            7c29201646fa3de8506f70121347
 golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af2b83e6acac3c
 
 # buildkit
-github.com/moby/buildkit                            8c0fa8fdec187d8f259a349d2da16dc2dc5f144a # v0.5.0
+github.com/moby/buildkit                            f238f1efb04f00bf0cc147141fda9ddb55c8bc49
 github.com/tonistiigi/fsutil                        3bbb99cdbd76619ab717299830c60f6f2a533a6b
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7

--- a/vendor/github.com/moby/buildkit/client/llb/exec.go
+++ b/vendor/github.com/moby/buildkit/client/llb/exec.go
@@ -177,7 +177,7 @@ func (e *ExecOp) Marshal(c *Constraints) (digest.Digest, []byte, *pb.OpMetadata,
 		addCap(&e.constraints, pb.CapExecMetaNetwork)
 	}
 
-	if e.meta.Security != SecurityModeInsecure {
+	if e.meta.Security != SecurityModeSandbox {
 		addCap(&e.constraints, pb.CapExecMetaSecurity)
 	}
 

--- a/vendor/github.com/moby/buildkit/client/solve.go
+++ b/vendor/github.com/moby/buildkit/client/solve.go
@@ -410,9 +410,6 @@ func parseCacheOptions(opt SolveOpt) (*cacheOptions, error) {
 			if csDir == "" {
 				return nil, errors.New("local cache importer requires src")
 			}
-			if err := os.MkdirAll(csDir, 0755); err != nil {
-				return nil, err
-			}
 			cs, err := contentlocal.NewStore(csDir)
 			if err != nil {
 				return nil, err

--- a/vendor/github.com/moby/buildkit/control/gateway/gateway.go
+++ b/vendor/github.com/moby/buildkit/control/gateway/gateway.go
@@ -63,7 +63,9 @@ func (gwf *GatewayForwarder) lookupForwarder(ctx context.Context) (gateway.LLBBr
 
 	go func() {
 		<-ctx.Done()
+		gwf.mu.Lock()
 		gwf.updateCond.Broadcast()
+		gwf.mu.Unlock()
 	}()
 
 	gwf.mu.RLock()

--- a/vendor/github.com/moby/buildkit/executor/oci/spec_unix.go
+++ b/vendor/github.com/moby/buildkit/executor/oci/spec_unix.go
@@ -95,6 +95,23 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 		Options:     []string{"ro", "nosuid", "noexec", "nodev"},
 	})
 
+	if processMode == NoProcessSandbox {
+		var maskedPaths []string
+		for _, s := range s.Linux.MaskedPaths {
+			if !hasPrefix(s, "/proc") {
+				maskedPaths = append(maskedPaths, s)
+			}
+		}
+		s.Linux.MaskedPaths = maskedPaths
+		var readonlyPaths []string
+		for _, s := range s.Linux.ReadonlyPaths {
+			if !hasPrefix(s, "/proc") {
+				readonlyPaths = append(readonlyPaths, s)
+			}
+		}
+		s.Linux.ReadonlyPaths = readonlyPaths
+	}
+
 	if meta.SecurityMode == pb.SecurityMode_INSECURE {
 		//make sysfs rw mount for insecure mode.
 		for _, m := range s.Mounts {

--- a/vendor/github.com/moby/buildkit/frontend/gateway/grpcclient/client.go
+++ b/vendor/github.com/moby/buildkit/frontend/gateway/grpcclient/client.go
@@ -28,6 +28,8 @@ type GrpcClient interface {
 }
 
 func New(ctx context.Context, opts map[string]string, session, product string, c pb.LLBBridgeClient, w []client.WorkerInfo) (GrpcClient, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
 	resp, err := c.Ping(ctx, &pb.PingRequest{})
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/moby/buildkit/session/grpchijack/dial.go
+++ b/vendor/github.com/moby/buildkit/session/grpchijack/dial.go
@@ -46,6 +46,7 @@ type conn struct {
 
 	closedOnce sync.Once
 	readMu     sync.Mutex
+	writeMu    sync.Mutex
 	err        error
 	closeCh    chan struct{}
 }
@@ -79,6 +80,8 @@ func (c *conn) Read(b []byte) (n int, err error) {
 }
 
 func (c *conn) Write(b []byte) (int, error) {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
 	m := &controlapi.BytesMessage{Data: b}
 	if err := c.stream.SendMsg(m); err != nil {
 		return 0, err
@@ -93,7 +96,9 @@ func (c *conn) Close() (err error) {
 		}()
 
 		if cs, ok := c.stream.(grpc.ClientStream); ok {
+			c.writeMu.Lock()
 			err = cs.CloseSend()
+			c.writeMu.Unlock()
 			if err != nil {
 				return
 			}
@@ -106,6 +111,7 @@ func (c *conn) Close() (err error) {
 			err = c.stream.RecvMsg(m)
 			if err != nil {
 				if err != io.EOF {
+					c.readMu.Unlock()
 					return
 				}
 				err = nil

--- a/vendor/github.com/moby/buildkit/session/manager.go
+++ b/vendor/github.com/moby/buildkit/session/manager.go
@@ -162,7 +162,9 @@ func (sm *Manager) Get(ctx context.Context, id string) (Caller, error) {
 	go func() {
 		select {
 		case <-ctx.Done():
+			sm.mu.Lock()
 			sm.updateCondition.Broadcast()
+			sm.mu.Unlock()
 		}
 	}()
 

--- a/vendor/github.com/moby/buildkit/solver/jobs.go
+++ b/vendor/github.com/moby/buildkit/solver/jobs.go
@@ -404,7 +404,9 @@ func (jl *Solver) Get(id string) (*Job, error) {
 
 	go func() {
 		<-ctx.Done()
+		jl.mu.Lock()
 		jl.updateCond.Broadcast()
+		jl.mu.Unlock()
 	}()
 
 	jl.mu.RLock()

--- a/vendor/github.com/moby/buildkit/util/progress/progress.go
+++ b/vendor/github.com/moby/buildkit/util/progress/progress.go
@@ -101,7 +101,9 @@ func (pr *progressReader) Read(ctx context.Context) ([]*Progress, error) {
 		select {
 		case <-done:
 		case <-ctx.Done():
+			pr.mu.Lock()
 			pr.cond.Broadcast()
+			pr.mu.Unlock()
 		}
 	}()
 	pr.mu.Lock()
@@ -163,7 +165,9 @@ func pipe() (*progressReader, *progressWriter, func()) {
 	pr.cond = sync.NewCond(&pr.mu)
 	go func() {
 		<-ctx.Done()
+		pr.mu.Lock()
 		pr.cond.Broadcast()
+		pr.mu.Unlock()
 	}()
 	pw := &progressWriter{
 		reader: pr,


### PR DESCRIPTION
Brings in following fixes:

- https://github.com/moby/buildkit/pull/999 - check for circular dependency in convert
- https://github.com/moby/buildkit/pull/1002 cwd created with correct user
- https://github.com/moby/buildkit/pull/996 Add missing locks around broadcasts
- https://github.com/moby/buildkit/pull/936 Support for upgrading grpc

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
