### PR TITLE
bugfix: fetch the right device number which great than 255

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -191,8 +191,8 @@ func getBlkioWeightDevices(config containertypes.Resources) ([]specs.LinuxWeight
 		}
 		weight := weightDevice.Weight
 		d := specs.LinuxWeightDevice{Weight: &weight}
-		d.Major = int64(stat.Rdev / 256)
-		d.Minor = int64(stat.Rdev % 256)
+		d.Major = int64(unix.Major(stat.Rdev))
+		d.Minor = int64(unix.Minor(stat.Rdev))
 		blkioWeightDevices = append(blkioWeightDevices, d)
 	}
 
@@ -262,8 +262,8 @@ func getBlkioThrottleDevices(devs []*blkiodev.ThrottleDevice) ([]specs.LinuxThro
 			return nil, err
 		}
 		d := specs.LinuxThrottleDevice{Rate: d.Rate}
-		d.Major = int64(stat.Rdev / 256)
-		d.Minor = int64(stat.Rdev % 256)
+		d.Major = int64(unix.Major(stat.Rdev))
+		d.Minor = int64(unix.Minor(stat.Rdev))
 		throttleDevices = append(throttleDevices, d)
 	}
 


### PR DESCRIPTION
Signed-off-by: frankyang <yyb196@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

fix a bug which cause an error like :
`write 4349:48 0 to blkio.throttle.read_bps_device: write /sys/fs/cgroup/blkio/xxx/cid/blkio.throttle.read_bps_device: no such device`

the container has config `"BlkioDeviceReadBps":[{"Path":"/dev/vdt","Rate":0}]`

and I foud `stat /dev/vdt` and `ls -l /dev/vdt` has different out of device number, which is correct:
```

#ls -l /dev/vdt
brw-rw---- 1 root disk 253, 304 May 9 17:03 /dev/vdt

#stat /dev/vdt | grep type
Device: 6h/6d Inode: 56051004	Links: 1	Device type: fd, 130

```

Someone in docker forum ran into the same problem: https://forums.docker.com/t/docker-run-device-read-bps-option-not-working/68044 in his case is the major number greater than 255.

**- How I did it**
I correct the way in which we get major and minor device number according to the method `new_encode_dev` in linux kernel.

**- How to verify it**
I add two unit test cases.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

