### PR TITLE
Consider WINDOWS_BASE_IMAGE_TAG override when setting Windows base image

### DIFF
--- a/internal/test/environment/environment.go
+++ b/internal/test/environment/environment.go
@@ -78,10 +78,13 @@ func getPlatformDefaults(info types.Info, osType string) PlatformDefaults {
 		}
 	case "windows":
 		baseImage := "microsoft/windowsservercore"
-		if override := os.Getenv("WINDOWS_BASE_IMAGE"); override != "" {
-			baseImage = override
-			fmt.Println("INFO: Windows Base image is ", baseImage)
+		if overrideBaseImage := os.Getenv("WINDOWS_BASE_IMAGE"); overrideBaseImage != "" {
+			baseImage = overrideBaseImage
+			if overrideBaseImageTag := os.Getenv("WINDOWS_BASE_IMAGE_TAG"); overrideBaseImageTag != "" {
+				baseImage = baseImage + ":" + overrideBaseImageTag
+			}
 		}
+		fmt.Println("INFO: Windows Base image is ", baseImage)
 		return PlatformDefaults{
 			BaseImage:            baseImage,
 			VolumesConfigPath:    filepath.FromSlash(volumesPath),


### PR DESCRIPTION
**- What I did**
Added look up of WINDOWS_BASE_IMAGE_TAG environment variable when determining the Windows base image for tests.

**- How I did it**
Enhanced logic in environment.go that sets PlatformDefaults to look up WINDOWS_BASE_IMAGE_TAG from environment vars

**- How to verify it**
In the test environment, specify:
```
$env:WINDOWS_BASE_IMAGE="mcr.microsoft.com/windows/servercore"	
$env:WINDOWS_BASE_IMAGE_TAG="ltsc2019"
```
to make sure the correct base image gets picked up.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

