### PR TITLE
bump vndr to f5ab8fc5f, and revendor

### DIFF
--- a/hack/dockerfile/install/vndr.installer
+++ b/hack/dockerfile/install/vndr.installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VNDR_COMMIT=81cb8916aad3c8d06193f008dba3e16f82851f52
+VNDR_COMMIT=f5ab8fc5fb64d66b5c6e55a0bcb58b2e92362fa0
 
 install_vndr() {
 	echo "Install vndr version $VNDR_COMMIT"

--- a/vendor/github.com/gogo/googleapis/go.mod
+++ b/vendor/github.com/gogo/googleapis/go.mod
@@ -1,0 +1,5 @@
+module github.com/gogo/googleapis
+
+go 1.12
+
+require github.com/gogo/protobuf v1.2.1

--- a/vendor/github.com/gogo/protobuf/go.mod
+++ b/vendor/github.com/gogo/protobuf/go.mod
@@ -1,0 +1,3 @@
+module github.com/gogo/protobuf
+
+require github.com/kisielk/errcheck v1.1.0 // indirect

--- a/vendor/github.com/google/uuid/go.mod
+++ b/vendor/github.com/google/uuid/go.mod
@@ -1,0 +1,1 @@
+module github.com/google/uuid

--- a/vendor/github.com/gorilla/mux/go.mod
+++ b/vendor/github.com/gorilla/mux/go.mod
@@ -1,0 +1,1 @@
+module github.com/gorilla/mux

--- a/vendor/github.com/hashicorp/golang-lru/go.mod
+++ b/vendor/github.com/hashicorp/golang-lru/go.mod
@@ -1,0 +1,1 @@
+module github.com/hashicorp/golang-lru

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/go.mod
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/go.mod
@@ -1,0 +1,1 @@
+module github.com/konsorten/go-windows-terminal-sequences

--- a/vendor/github.com/kr/pty/go.mod
+++ b/vendor/github.com/kr/pty/go.mod
@@ -1,0 +1,1 @@
+module github.com/kr/pty

--- a/vendor/github.com/mattn/go-shellwords/go.mod
+++ b/vendor/github.com/mattn/go-shellwords/go.mod
@@ -1,0 +1,1 @@
+module github.com/mattn/go-shellwords

--- a/vendor/github.com/moby/buildkit/go.mod
+++ b/vendor/github.com/moby/buildkit/go.mod
@@ -1,0 +1,75 @@
+module github.com/moby/buildkit
+
+go 1.11
+
+require (
+	github.com/BurntSushi/toml v0.3.1
+	github.com/Microsoft/go-winio v0.4.13-0.20190408173621-84b4ab48a507
+	github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7 // indirect
+	github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58 // indirect
+	github.com/containerd/cgroups v0.0.0-20190226200435-dbea6f2bd416 // indirect
+	github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50
+	github.com/containerd/containerd v1.3.0-0.20190426060238-3a3f0aac8819
+	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+	github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260 // indirect
+	github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+	github.com/containerd/ttrpc v0.0.0-20190411181408-699c4e40d1e7 // indirect
+	github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd // indirect
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/docker/cli v0.0.0-20190321234815-f40f9c240ab0
+	github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
+	github.com/docker/docker v1.14.0-0.20190319215453-e7b5f7dbe98c
+	github.com/docker/docker-credential-helpers v0.6.0 // indirect
+	github.com/docker/go-connections v0.3.0
+	github.com/docker/go-events v0.0.0-20170721190031-9461782956ad // indirect
+	github.com/docker/libnetwork v0.8.0-dev.2.0.20190604151032-3c26b4e7495e
+	github.com/godbus/dbus v4.1.0+incompatible // indirect
+	github.com/gofrs/flock v0.7.0
+	github.com/gogo/googleapis v1.1.0
+	github.com/gogo/protobuf v1.2.0
+	github.com/golang/protobuf v1.2.0
+	github.com/google/go-cmp v0.2.0
+	github.com/google/shlex v0.0.0-20150127133951-6f45313302b9
+	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
+	github.com/hashicorp/go-immutable-radix v1.0.0
+	github.com/hashicorp/golang-lru v0.0.0-20160207214719-a0d98a5f2880
+	github.com/hashicorp/uuid v0.0.0-20160311170451-ebb0a03e909c // indirect
+	github.com/ishidawataru/sctp v0.0.0-20180213033435-07191f837fed // indirect
+	github.com/jaguilar/vt100 v0.0.0-20150826170717-2703a27b14ea
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/mitchellh/hashstructure v0.0.0-20170609045927-2bca23e0e452
+	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/image-spec v1.0.1
+	github.com/opencontainers/runc v1.0.1-0.20190307181833-2b18fe1d885e
+	github.com/opencontainers/runtime-spec v0.0.0-20180909173843-eba862dc2470
+	github.com/opentracing-contrib/go-stdlib v0.0.0-20171029140428-b1a47cfbdd75
+	github.com/opentracing/opentracing-go v0.0.0-20171003133519-1361b9cd60be
+	github.com/pkg/errors v0.8.1
+	github.com/pkg/profile v1.2.1
+	github.com/serialx/hashring v0.0.0-20190422032157-8b2912629002
+	github.com/sirupsen/logrus v1.3.0
+	github.com/stretchr/testify v1.3.0
+	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 // indirect
+	github.com/tonistiigi/fsutil v0.0.0-20190327153851-3bbb99cdbd76
+	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
+	github.com/uber/jaeger-client-go v0.0.0-20180103221425-e02c85f9069e
+	github.com/uber/jaeger-lib v1.2.1 // indirect
+	github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5
+	github.com/vishvananda/netlink v1.0.0 // indirect
+	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc // indirect
+	go.etcd.io/bbolt v1.3.2
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
+	golang.org/x/net v0.0.0-20190311183353-d8887717615a
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
+	golang.org/x/sys v0.0.0-20190303122642-d455e41777fc
+	golang.org/x/time v0.0.0-20161028155119-f51c12702a4d
+	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
+	google.golang.org/grpc v1.20.1
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gotest.tools v2.2.0+incompatible
+)
+
+replace github.com/hashicorp/go-immutable-radix => github.com/tonistiigi/go-immutable-radix v0.0.0-20170803185627-826af9ccf0fe
+
+replace github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305

--- a/vendor/github.com/sirupsen/logrus/go.mod
+++ b/vendor/github.com/sirupsen/logrus/go.mod
@@ -1,0 +1,10 @@
+module github.com/sirupsen/logrus
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.1 // indirect
+	github.com/stretchr/testify v1.2.2
+	golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33
+)

--- a/vendor/github.com/tonistiigi/fsutil/go.mod
+++ b/vendor/github.com/tonistiigi/fsutil/go.mod
@@ -1,0 +1,28 @@
+module github.com/tonistiigi/fsutil
+
+require (
+	github.com/Microsoft/go-winio v0.4.11 // indirect
+	github.com/Microsoft/hcsshim v0.8.5 // indirect
+	github.com/containerd/containerd v1.2.4
+	github.com/containerd/continuity v0.0.0-20181001140422-bd77b46c8352
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/docker v0.0.0-20180531152204-71cd53e4a197
+	github.com/docker/go-units v0.3.1 // indirect
+	github.com/gogo/protobuf v1.0.0
+	github.com/google/go-cmp v0.2.0 // indirect
+	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
+	github.com/onsi/ginkgo v1.7.0 // indirect
+	github.com/onsi/gomega v1.4.3 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/opencontainers/runc v1.0.0-rc6 // indirect
+	github.com/pkg/errors v0.8.1
+	github.com/sirupsen/logrus v1.0.3 // indirect
+	github.com/stretchr/testify v1.3.0
+	golang.org/x/crypto v0.0.0-20190129210102-0709b304e793 // indirect
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
+	golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e
+	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
+	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
+	gotest.tools v2.1.0+incompatible // indirect
+)

--- a/vendor/golang.org/x/crypto/go.mod
+++ b/vendor/golang.org/x/crypto/go.mod
@@ -1,0 +1,3 @@
+module golang.org/x/crypto
+
+require golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e

--- a/vendor/golang.org/x/net/go.mod
+++ b/vendor/golang.org/x/net/go.mod
@@ -1,0 +1,6 @@
+module golang.org/x/net
+
+require (
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
+	golang.org/x/text v0.3.0
+)

--- a/vendor/golang.org/x/sync/go.mod
+++ b/vendor/golang.org/x/sync/go.mod
@@ -1,0 +1,1 @@
+module golang.org/x/sync

--- a/vendor/golang.org/x/sys/go.mod
+++ b/vendor/golang.org/x/sys/go.mod
@@ -1,0 +1,3 @@
+module golang.org/x/sys
+
+go 1.12

--- a/vendor/google.golang.org/grpc/go.mod
+++ b/vendor/google.golang.org/grpc/go.mod
@@ -1,0 +1,19 @@
+module google.golang.org/grpc
+
+require (
+	cloud.google.com/go v0.26.0 // indirect
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/client9/misspell v0.3.4
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/golang/mock v1.1.1
+	github.com/golang/protobuf v1.2.0
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3
+	golang.org/x/net v0.0.0-20190311183353-d8887717615a
+	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
+	golang.org/x/tools v0.0.0-20190311212946-11955173bddd
+	google.golang.org/appengine v1.1.0 // indirect
+	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
+	honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099
+)

--- a/vendor/gotest.tools/go.mod
+++ b/vendor/gotest.tools/go.mod
@@ -1,0 +1,8 @@
+module gotest.tools
+
+require (
+	github.com/google/go-cmp v0.2.0
+	github.com/pkg/errors v0.8.0
+	github.com/spf13/pflag v1.0.3
+	golang.org/x/tools v0.0.0-20180810170437-e96c4e24768d
+)


### PR DESCRIPTION
The latest version of `vndr` preserves `go.mod` in vendored dependencies, which makes it easier to check if other dependencies need to be updated as well


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
