### PR TITLE
LCOW: Fix FROM scratch

### DIFF
--- a/daemon/images/image_builder.go
+++ b/daemon/images/image_builder.go
@@ -170,6 +170,9 @@ func (i *ImageService) pullForBuilder(ctx context.Context, name string, authConf
 func (i *ImageService) GetImageAndReleasableLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (builder.Image, builder.ROLayer, error) {
 	if refOrID == "" { // ie FROM scratch
 		os := runtime.GOOS
+		if runtime.GOOS == "windows" {
+			os = "linux"
+		}
 		if opts.Platform != nil {
 			os = opts.Platform.OS
 		}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Not sure when the regression happened, but looks related to the buildkit integration work. Tracked down what was going on in LCOW during a `docker build` using 

```
FROM scratch
ADD somefile.txt /
``` 

The layerstore being chosen was the Windows one (not LCOW), and the layer commit obviously fails in that case. Hence in `GetImageAndReleasableLayer` when it knows it's `FROM scratch` and it's on Windows, ensure the right layerstore is used.

