### PR TITLE
When the host is configured with two different DNS (non-master-slave …

### DIFF
--- a/vendor/github.com/docker/libnetwork/resolver.go
+++ b/vendor/github.com/docker/libnetwork/resolver.go
@@ -533,6 +533,7 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 			}
 			if resp.Answer == nil || answers == 0 {
 				logrus.Debugf("[resolver] external DNS %s:%s did not return any %s records for %q", proto, extDNS.IPStr, queryType, name)
+				continue
 			}
 			resp.Compress = true
 			break


### PR DESCRIPTION
…architecture), the first DNS cannot be resolved, try the second DNS resolution.

**- What I did**
In the production environment, when two different DNS (non-master-slave architecture) are configured, my domain name is configured in the second DNS, but when the first DNS cannot be resolved, the error message is directly returned, and the second is not tried. 
**- How I did it**
When the first DNS cannot be resolved, try the second DNS resolution after returning the error.
**- How to verify it**

**- Description for the changelog**
<!--
When the first DNS cannot be resolved, try the second DNS resolution after returning the error.
-->

