### PR TITLE
rootless: fix killing daemon

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -75,7 +75,7 @@ if [ -z $_DOCKERD_ROOTLESS_CHILD ]; then
 	#         namespace from being unexpectedly unmounted when `/etc/resolv.conf` is recreated on the host
 	#         (by either systemd-networkd or NetworkManager)
 	# * /run: copy-up is required so that we can create /run/docker (hardcoded for plugins) in our namespace
-	$rootlesskit \
+	exec $rootlesskit \
 		--net=$net --mtu=$mtu \
 		--disable-host-loopback --port-driver=builtin \
 		--copy-up=/etc --copy-up=/run \
@@ -86,5 +86,5 @@ else
 	# remove the symlinks for the existing files in the parent namespace if any,
 	# so that we can create our own files in our mount namespace.
 	rm -f /run/docker /run/xtables.lock
-	dockerd $@
+	exec dockerd $@
 fi

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# v0.4.0
-ROOTLESSKIT_COMMIT=e92d5e772ee7e103aecf380c5874a40c52876ff0
+# v0.4.1
+ROOTLESSKIT_COMMIT=27a0c7a2483732b33d4192c1d178c83c6b9e202d
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed the issue where the daemon kept running even when `dockerd-rootless.sh` (and its descendent) was killed.

```console
$ dockerd-rootless.sh --experimental &
$ ps
   PID TTY          TIME CMD
  1083 pts/1    00:00:00 bash
  8696 pts/1    00:00:00 dockerd-rootles
  8702 pts/1    00:00:00 rootlesskit
  8706 pts/1    00:00:00 exe
  8717 pts/1    00:00:00 slirp4netns
  8733 pts/1    00:00:00 dockerd-rootles
  8740 pts/1    00:00:00 dockerd
  8886 pts/1    00:00:00 ps
$ kill 8696
$ ps
   PID TTY          TIME CMD
  1083 pts/1    00:00:00 bash
  8702 pts/1    00:00:00 rootlesskit
  8706 pts/1    00:00:00 exe
  8717 pts/1    00:00:00 slirp4netns
  8733 pts/1    00:00:00 dockerd-rootles
  8740 pts/1    00:00:00 dockerd
  8887 pts/1    00:00:00 ps
$ kill 8702
$ ps
   PID TTY          TIME CMD
  1083 pts/1    00:00:00 bash
  8706 pts/1    00:00:00 exe
  8733 pts/1    00:00:00 dockerd-rootles
  8740 pts/1    00:00:00 dockerd
  8888 pts/1    00:00:00 ps
$ kill 8706
$ ps
   PID TTY          TIME CMD
  1083 pts/1    00:00:00 bash
  8740 pts/1    00:00:00 dockerd
  8889 pts/1    00:00:00 ps
````


The causes of the issue were:
1. The parent process of RootlessKit had invoked the child process with `Pdeathsig`, but it was invalidated after running `newuidmap` (rootless-containers/rootlesskit#65)
2. `dockerd-rootless.sh` had invoked `rootlesskit` and `dockerd` without setting up trap for propagating signals

**- How I did it**
1. updated RootlessKit to v0.4.1 with fix rootless-containers/rootlesskit#66 (full changes: https://github.com/rootless-containers/rootlesskit/compare/e92d5e7...27a0c7a)
2. updated `dockerd-rootless.sh` to `exec` the processes without forking

**- How to verify it**


```console
$ dockerd-rootless.sh --experimental &
$ ps
   PID TTY          TIME CMD
  1083 pts/1    00:00:00 bash
  8460 pts/1    00:00:00 rootlesskit
  8470 pts/1    00:00:00 exe
  8484 pts/1    00:00:00 slirp4netns
  8500 pts/1    00:00:00 dockerd
  8653 pts/1    00:00:00 ps
$ kill 8460
$ ps
   PID TTY          TIME CMD
  1083 pts/1    00:00:00 bash
  8654 pts/1    00:00:00 ps
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
rootless: fix killing daemon

**- A picture of a cute animal (not mandatory but encouraged)**
https://twitter.com/13033303/status/1128454769050128384

