### PR TITLE
Network not deleted after stack is removed

### DIFF
--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -369,20 +369,17 @@ func (r *controller) Shutdown(ctx context.Context) error {
 	}
 
 	if err := r.adapter.shutdown(ctx); err != nil {
-		if isUnknownContainer(err) || isStoppedContainer(err) {
-			return nil
+		if !(isUnknownContainer(err) || isStoppedContainer(err)) {
+			return err
 		}
-
-		return err
 	}
 
 	// Try removing networks referenced in this task in case this
 	// task is the last one referencing it
 	if err := r.adapter.removeNetworks(ctx); err != nil {
-		if isUnknownContainer(err) {
-			return nil
+		if !isUnknownContainer(err) {
+			return err
 		}
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
Make sure adapter.removeNetworks executes during task Remove

Fixes https://github.com/moby/moby/issues/39225
Relates to https://github.com/moby/moby/pull/39174

Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>

**- How to verify it**
```
docker swarm init
cat > docker-compose.yml <<EOT
version: "3"
services:

  test:
    image: nginx
EOT
docker pull nginx
docker stack deploy mystack -c docker-compose.yml
sleep 50
docker stack rm mystack
docker swarm leave --force
docker network ls
```
