### PR TITLE
Enable DNS Lookups for CIFS Volumes

### DIFF
--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -97,11 +97,12 @@ func (v *localVolume) mount() error {
 		return fmt.Errorf("missing device in volume options")
 	}
 	mountOpts := v.opts.MountOpts
-	if v.opts.MountType == "nfs" {
+	switch v.opts.MountType {
+	case "nfs", "cifs":
 		if addrValue := getAddress(v.opts.MountOpts); addrValue != "" && net.ParseIP(addrValue).To4() == nil {
 			ipAddr, err := net.ResolveIPAddr("ip", addrValue)
 			if err != nil {
-				return errors.Wrapf(err, "error resolving passed in nfs address")
+				return errors.Wrapf(err, "error resolving passed in network volume address")
 			}
 			mountOpts = strings.Replace(mountOpts, "addr="+addrValue, "addr="+ipAddr.String(), 1)
 		}


### PR DESCRIPTION
This comes from an old suggestion (https://github.com/docker/cli/issues/706#issuecomment-371157691) on an issue we were having and has since popped up again.  For NFS volumes, Docker will do an IP lookup on the volume name.  This is not done for CIFS volumes, which forces you to add the volume via IP address instead.  This change will enable the IP lookup also for CIFS volumes.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

For CIFS network volumes, trigger an IP address lookup.  Change error message to be generic "network volume" instead of NFS.

**- How I did it**

Change the If statement to a switch (for future expandability), triggering the lookup for CIFS volumes and Network volumes)

**- How to verify it**

Mount a CIFS volume by name

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Enable DNS Lookups for CIFS Volumes

**- A picture of a cute animal (not mandatory but encouraged)**
