### PR TITLE
Enable DNS Lookups for CIFS Volumes

### DIFF
--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -97,11 +97,12 @@ func (v *localVolume) mount() error {
 		return fmt.Errorf("missing device in volume options")
 	}
 	mountOpts := v.opts.MountOpts
-	if v.opts.MountType == "nfs" {
+	switch v.opts.MountType {
+	case "nfs", "cifs":
 		if addrValue := getAddress(v.opts.MountOpts); addrValue != "" && net.ParseIP(addrValue).To4() == nil {
 			ipAddr, err := net.ResolveIPAddr("ip", addrValue)
 			if err != nil {
-				return errors.Wrapf(err, "error resolving passed in nfs address")
+				return errors.Wrapf(err, "error resolving passed in network volume address")
 			}
 			mountOpts = strings.Replace(mountOpts, "addr="+addrValue, "addr="+ipAddr.String(), 1)
 		}


### PR DESCRIPTION
fixes https://github.com/docker/cli/issues/706

This comes from an old suggestion (https://github.com/docker/cli/issues/706#issuecomment-371157691) on an issue we were having and has since popped up again.  For NFS volumes, Docker will do an IP lookup on the volume name.  This is not done for CIFS volumes, which forces you to add the volume via IP address instead.  This change will enable the IP lookup also for CIFS volumes.

Signed-off-by: Shu-Wai Chow <shu-wai.chow@seattlechildrens.org>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add an IP address lookup for CIFS network volumes.

**- How I did it**

Change the special case triggered by an if statement to a switch cause triggered by both nfs and cifs volumes.  This should enable future cases if necessary.

**- How to verify it**

Add a CIFS volume using a name instead of an IP Address.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Enable DNS Lookups for CIFS Volumes

**- A picture of a cute animal (not mandatory but encouraged)**
