### PR TITLE
daemon: archive: pause containers before doing filesystem operations

### DIFF
--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -38,6 +38,10 @@ func (daemon *Daemon) containerPause(container *container.Container) error {
 		return errContainerIsRestarting(container.ID)
 	}
 
+	return daemon.containerLockedPause(container)
+}
+
+func (daemon *Daemon) containerLockedPause(container *container.Container) error {
 	if err := daemon.containerd.Pause(context.Background(), container.ID); err != nil {
 		return fmt.Errorf("Cannot pause container %s: %s", container.ID, err)
 	}
@@ -50,6 +54,5 @@ func (daemon *Daemon) containerPause(container *container.Container) error {
 	if err := container.CheckpointTo(daemon.containersReplica); err != nil {
 		logrus.WithError(err).Warn("could not save container to disk")
 	}
-
 	return nil
 }

--- a/daemon/unpause.go
+++ b/daemon/unpause.go
@@ -27,6 +27,10 @@ func (daemon *Daemon) containerUnpause(container *container.Container) error {
 		return fmt.Errorf("Container %s is not paused", container.ID)
 	}
 
+	return daemon.containerLockedUnpause(container)
+}
+
+func (daemon *Daemon) containerLockedUnpause(container *container.Container) error {
 	if err := daemon.containerd.Resume(context.Background(), container.ID); err != nil {
 		return fmt.Errorf("Cannot unpause container %s: %s", container.ID, err)
 	}


### PR DESCRIPTION
(Note: This PR was made public after discussions with the Docker security team, if you find a security vulnerability please report it directly to <security@docker.com>.)

There are certain classes of attacks (as evidenced in CVE-2018-15664)
which are caused by our allowing container processes to be executing
while we are doing filesystem operations on the container. In
particular, [there are trivial TOCTOU races in symlink resolution and
scoping that can be exploited][1].

The most complete solution to this problem would be to modify
chrootarchive so that all of the archive operations occur with the root
as the container rootfs (and not the parent directory, which is what
causes the vulnerability since the parent is attacker-controlled).
Unfortunately, changes to this core piece of Docker are almost
impossible (the TarUntar interface has many copies and reimplementations
that would all need to be modified to be able to handle a new "root"
argument).

So, we instead settle for the next-best option which is to pause the
container during our usage of the filesystem. This is far from an ideal
solution (you can image some attack scenarios such as shared volume
mounts) where this is ineffectual but it does block the most basic
attack.

[I am currently working on some new kernel functionality that would allow
for much safer resolution of paths inside untrusted roots][2], but as
above it would be difficult to modify Docker to use it. I am working on
adding support to [filepath-securejoin][3] though (however this will
require quite a few inteface changes).

[1]: https://bugzilla.suse.com/show_bug.cgi?id=1096726
[2]: https://lwn.net/Articles/767547/
[3]: https://github.com/cyphar/filepath-securejoin

Fixes: CVE-2018-15664
Signed-off-by: Aleksa Sarai <asarai@suse.de>