### PR TITLE
API: Make response body empty when starting a started container or stopping a stopped container

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5519,8 +5519,6 @@ paths:
           description: "no error"
         304:
           description: "container already started"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
         404:
           description: "no such container"
           schema:
@@ -5552,8 +5550,6 @@ paths:
           description: "no error"
         304:
           description: "container already stopped"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
         404:
           description: "no such container"
           schema:


### PR DESCRIPTION
Currently the API says an `ErrorResponse` is returned when starting an already started container or stopping an already stopped container. Actually an empty response is returned in both cases.