### PR TITLE
Revert "Remove TestSearchCmdOptions test"

### DIFF
--- a/integration-cli/docker_cli_search_test.go
+++ b/integration-cli/docker_cli_search_test.go
@@ -44,6 +44,54 @@ func (s *DockerSuite) TestSearchStarsOptionWithWrongParameter(c *check.C) {
 	assert.Assert(c, strings.Contains(out, "invalid syntax"), "couldn't find the invalid value warning")
 }
 
+func (s *DockerSuite) TestSearchCmdOptions(c *check.C) {
+	testRequires(c, Network, DaemonIsLinux)
+
+	out, _ := dockerCmd(c, "search", "--help")
+	assert.Assert(c, strings.Contains(out, "Usage:\tdocker search [OPTIONS] TERM"))
+
+	outSearchCmd, _ := dockerCmd(c, "search", "busybox")
+	assert.Assert(c, strings.Count(outSearchCmd, "\n") > 3, outSearchCmd)
+	outSearchCmdNotrunc, _ := dockerCmd(c, "search", "--no-trunc=true", "busybox")
+	assert.Assert(c, len(outSearchCmd) <= len(outSearchCmdNotrunc), "The no-trunc option can't take effect.")
+
+	outSearchCmdautomated, _ := dockerCmd(c, "search", "--filter", "is-automated=true", "busybox") //The busybox is a busybox base image, not an AUTOMATED image.
+	outSearchCmdautomatedSlice := strings.Split(outSearchCmdautomated, "\n")
+	for i := range outSearchCmdautomatedSlice {
+		assert.Assert(c, !strings.HasPrefix(outSearchCmdautomatedSlice[i], "busybox "), "The busybox is not an AUTOMATED image: %s", outSearchCmdautomated)
+	}
+
+	outSearchCmdNotOfficial, _ := dockerCmd(c, "search", "--filter", "is-official=false", "busybox") //The busybox is a busybox base image, official image.
+	outSearchCmdNotOfficialSlice := strings.Split(outSearchCmdNotOfficial, "\n")
+	for i := range outSearchCmdNotOfficialSlice {
+		assert.Assert(c, !strings.HasPrefix(outSearchCmdNotOfficialSlice[i], "busybox "), "The busybox is not an OFFICIAL image: %s", outSearchCmdNotOfficial)
+	}
+
+	outSearchCmdOfficial, _ := dockerCmd(c, "search", "--filter", "is-official=true", "busybox") //The busybox is a busybox base image, official image.
+	outSearchCmdOfficialSlice := strings.Split(outSearchCmdOfficial, "\n")
+	assert.Equal(c, len(outSearchCmdOfficialSlice), 3) // 1 header, 1 line, 1 carriage return
+	assert.Assert(c, strings.HasPrefix(outSearchCmdOfficialSlice[1], "busybox "), "The busybox is an OFFICIAL image: %s", outSearchCmdOfficial)
+
+	outSearchCmdStars, _ := dockerCmd(c, "search", "--filter", "stars=10", "busybox")
+	assert.Assert(c, strings.Count(outSearchCmdStars, "\n") <= strings.Count(outSearchCmd, "\n"), "Number of images with 10+ stars should be less than that of all images:\noutSearchCmdStars: %s\noutSearch: %s\n", outSearchCmdStars, outSearchCmd)
+
+	dockerCmd(c, "search", "--filter", "is-automated=true", "--filter", "stars=2", "--no-trunc=true", "busybox")
+
+	// --automated deprecated since Docker 1.13
+	outSearchCmdautomated1, _ := dockerCmd(c, "search", "--automated=true", "busybox") //The busybox is a busybox base image, not an AUTOMATED image.
+	outSearchCmdautomatedSlice1 := strings.Split(outSearchCmdautomated1, "\n")
+	for i := range outSearchCmdautomatedSlice1 {
+		assert.Assert(c, !strings.HasPrefix(outSearchCmdautomatedSlice1[i], "busybox "), "The busybox is not an AUTOMATED image: %s", outSearchCmdautomated)
+	}
+
+	// -s --stars deprecated since Docker 1.13
+	outSearchCmdStars1, _ := dockerCmd(c, "search", "--stars=2", "busybox")
+	assert.Assert(c, strings.Count(outSearchCmdStars1, "[OK]") <= strings.Count(outSearchCmd, "[OK]"), "The quantity of images with stars should be less than that of all images: %s", outSearchCmdStars1)
+
+	// -s --stars deprecated since Docker 1.13
+	dockerCmd(c, "search", "--stars=2", "--automated=true", "--no-trunc=true", "busybox")
+}
+
 // search for repos which start with "ubuntu-" on the central registry
 func (s *DockerSuite) TestSearchOnCentralRegistryWithDash(c *check.C) {
 	testRequires(c, Network, DaemonIsLinux)

--- a/integration-cli/docker_cli_search_test.go
+++ b/integration-cli/docker_cli_search_test.go
@@ -71,20 +71,6 @@ func (s *DockerSuite) TestSearchCmdOptions(c *check.C) {
 	assert.Assert(c, strings.Count(outSearchCmdStars, "\n") <= strings.Count(outSearchCmd, "\n"), "Number of images with 10+ stars should be less than that of all images:\noutSearchCmdStars: %s\noutSearch: %s\n", outSearchCmdStars, outSearchCmd)
 
 	dockerCmd(c, "search", "--filter", "is-automated=true", "--filter", "stars=2", "--no-trunc=true", "busybox")
-
-	// --automated deprecated since Docker 1.13
-	outSearchCmdautomated1, _ := dockerCmd(c, "search", "--automated=true", "busybox") //The busybox is a busybox base image, not an AUTOMATED image.
-	outSearchCmdautomatedSlice1 := strings.Split(outSearchCmdautomated1, "\n")
-	for i := range outSearchCmdautomatedSlice1 {
-		assert.Assert(c, !strings.HasPrefix(outSearchCmdautomatedSlice1[i], "busybox "), "The busybox is not an AUTOMATED image: %s", outSearchCmdautomated)
-	}
-
-	// -s --stars deprecated since Docker 1.13
-	outSearchCmdStars1, _ := dockerCmd(c, "search", "--stars=2", "busybox")
-	assert.Assert(c, strings.Count(outSearchCmdStars1, "[OK]") <= strings.Count(outSearchCmd, "[OK]"), "The quantity of images with stars should be less than that of all images: %s", outSearchCmdStars1)
-
-	// -s --stars deprecated since Docker 1.13
-	dockerCmd(c, "search", "--stars=2", "--automated=true", "--no-trunc=true", "busybox")
 }
 
 // search for repos which start with "ubuntu-" on the central registry

--- a/integration-cli/docker_cli_search_test.go
+++ b/integration-cli/docker_cli_search_test.go
@@ -32,16 +32,6 @@ func (s *DockerSuite) TestSearchStarsOptionWithWrongParameter(c *check.C) {
 	out, _, err = dockerCmdWithError("search", "-f", "is-official=a", "busybox")
 	assert.ErrorContains(c, err, "", out)
 	assert.Assert(c, strings.Contains(out, "Invalid filter"), "couldn't find the invalid filter warning")
-
-	// -s --stars deprecated since Docker 1.13
-	out, _, err = dockerCmdWithError("search", "--stars=a", "busybox")
-	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, strings.Contains(out, "invalid syntax"), "couldn't find the invalid value warning")
-
-	// -s --stars deprecated since Docker 1.13
-	out, _, err = dockerCmdWithError("search", "-s=-1", "busybox")
-	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, strings.Contains(out, "invalid syntax"), "couldn't find the invalid value warning")
 }
 
 func (s *DockerSuite) TestSearchCmdOptions(c *check.C) {

--- a/integration-cli/docker_cli_search_test.go
+++ b/integration-cli/docker_cli_search_test.go
@@ -74,29 +74,15 @@ func (s *DockerSuite) TestSearchOnCentralRegistryWithDash(c *check.C) {
 func (s *DockerSuite) TestSearchWithLimit(c *check.C) {
 	testRequires(c, Network, DaemonIsLinux)
 
-	limit := 10
-	out, _, err := dockerCmdWithError("search", fmt.Sprintf("--limit=%d", limit), "docker")
-	assert.NilError(c, err)
-	outSlice := strings.Split(out, "\n")
-	assert.Equal(c, len(outSlice), limit+2) // 1 header, 1 carriage return
+	for _, limit := range []int{10, 50, 100} {
+		out, _, err := dockerCmdWithError("search", fmt.Sprintf("--limit=%d", limit), "docker")
+		assert.NilError(c, err)
+		outSlice := strings.Split(out, "\n")
+		assert.Equal(c, len(outSlice), limit+2) // 1 header, 1 carriage return
+	}
 
-	limit = 50
-	out, _, err = dockerCmdWithError("search", fmt.Sprintf("--limit=%d", limit), "docker")
-	assert.NilError(c, err)
-	outSlice = strings.Split(out, "\n")
-	assert.Equal(c, len(outSlice), limit+2) // 1 header, 1 carriage return
-
-	limit = 100
-	out, _, err = dockerCmdWithError("search", fmt.Sprintf("--limit=%d", limit), "docker")
-	assert.NilError(c, err)
-	outSlice = strings.Split(out, "\n")
-	assert.Equal(c, len(outSlice), limit+2) // 1 header, 1 carriage return
-
-	limit = 0
-	_, _, err = dockerCmdWithError("search", fmt.Sprintf("--limit=%d", limit), "docker")
-	assert.ErrorContains(c, err, "")
-
-	limit = 200
-	_, _, err = dockerCmdWithError("search", fmt.Sprintf("--limit=%d", limit), "docker")
-	assert.ErrorContains(c, err, "")
+	for _, limit := range []int{-1, 0, 101} {
+		_, _, err := dockerCmdWithError("search", fmt.Sprintf("--limit=%d", limit), "docker")
+		assert.ErrorContains(c, err, "")
+	}
 }

--- a/integration-cli/docker_cli_search_test.go
+++ b/integration-cli/docker_cli_search_test.go
@@ -10,8 +10,6 @@ import (
 
 // search for repos named  "registry" on the central registry
 func (s *DockerSuite) TestSearchOnCentralRegistry(c *check.C) {
-	testRequires(c, Network, DaemonIsLinux)
-
 	out, _ := dockerCmd(c, "search", "busybox")
 	assert.Assert(c, strings.Contains(out, "Busybox base image."), "couldn't find any repository named (or containing) 'Busybox base image.'")
 }
@@ -35,8 +33,6 @@ func (s *DockerSuite) TestSearchStarsOptionWithWrongParameter(c *check.C) {
 }
 
 func (s *DockerSuite) TestSearchCmdOptions(c *check.C) {
-	testRequires(c, Network, DaemonIsLinux)
-
 	outSearchCmd, _ := dockerCmd(c, "search", "busybox")
 	assert.Assert(c, strings.Count(outSearchCmd, "\n") > 3, outSearchCmd)
 
@@ -65,15 +61,11 @@ func (s *DockerSuite) TestSearchCmdOptions(c *check.C) {
 
 // search for repos which start with "ubuntu-" on the central registry
 func (s *DockerSuite) TestSearchOnCentralRegistryWithDash(c *check.C) {
-	testRequires(c, Network, DaemonIsLinux)
-
 	dockerCmd(c, "search", "ubuntu-")
 }
 
 // test case for #23055
 func (s *DockerSuite) TestSearchWithLimit(c *check.C) {
-	testRequires(c, Network, DaemonIsLinux)
-
 	for _, limit := range []int{10, 50, 100} {
 		out, _, err := dockerCmdWithError("search", fmt.Sprintf("--limit=%d", limit), "docker")
 		assert.NilError(c, err)

--- a/integration-cli/docker_cli_search_test.go
+++ b/integration-cli/docker_cli_search_test.go
@@ -47,13 +47,8 @@ func (s *DockerSuite) TestSearchStarsOptionWithWrongParameter(c *check.C) {
 func (s *DockerSuite) TestSearchCmdOptions(c *check.C) {
 	testRequires(c, Network, DaemonIsLinux)
 
-	out, _ := dockerCmd(c, "search", "--help")
-	assert.Assert(c, strings.Contains(out, "Usage:\tdocker search [OPTIONS] TERM"))
-
 	outSearchCmd, _ := dockerCmd(c, "search", "busybox")
 	assert.Assert(c, strings.Count(outSearchCmd, "\n") > 3, outSearchCmd)
-	outSearchCmdNotrunc, _ := dockerCmd(c, "search", "--no-trunc=true", "busybox")
-	assert.Assert(c, len(outSearchCmd) <= len(outSearchCmdNotrunc), "The no-trunc option can't take effect.")
 
 	outSearchCmdautomated, _ := dockerCmd(c, "search", "--filter", "is-automated=true", "busybox") //The busybox is a busybox base image, not an AUTOMATED image.
 	outSearchCmdautomatedSlice := strings.Split(outSearchCmdautomated, "\n")


### PR DESCRIPTION
This reverts commit 21e662c77468d1e3fc4efaa049021e2ad0e49b4d.

see https://github.com/moby/moby/pull/39257#issuecomment-494789534 😓 

Also made some additional improvements;

- removed checks for client-only functionality (as we're testing against a fixed version of the cli)
- improved some boundary checks and small refactor
- enabled the tests on windows

@cpuguy83 @kolyshkin PTAL (I'll close if we're ok with the PR being merged 🤗)
