### PR TITLE
API: Change type of RemotrAddrs to array of strings in operation SwarmJoin

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9119,7 +9119,9 @@ paths:
                 type: "string"
               RemoteAddrs:
                 description: "Addresses of manager nodes already participating in the swarm."
-                type: "string"
+                type: "array"
+                items:
+                  type: "string"
               JoinToken:
                 description: "Secret token for joining this swarm."
                 type: "string"


### PR DESCRIPTION
The type of property `RemotrAddrs` should be array of strings instead of string.