### PR TITLE
API: Move "x-nullable: true" from type PortBinding to type PortMap

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1154,6 +1154,7 @@ definitions:
     type: "object"
     additionalProperties:
       type: "array"
+      x-nullable: true
       items:
         $ref: "#/definitions/PortBinding"
     example:
@@ -1178,7 +1179,6 @@ definitions:
       PortBinding represents a binding between a host IP address and a host
       port.
     type: "object"
-    x-nullable: true
     properties:
       HostIp:
         description: "Host IP address that the container's port is mapped to."


### PR DESCRIPTION
Currently the API spec would allow `"443/tcp": [null]`, but what should
be allowed is `"443/tcp": null`