### PR TITLE
Update docs to remove restriction of tty resize

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5475,7 +5475,7 @@ paths:
   /containers/{id}/resize:
     post:
       summary: "Resize a container TTY"
-      description: "Resize the TTY for a container. You must restart the container for the resize to take effect."
+      description: "Resize the TTY for a container."
       operationId: "ContainerResize"
       consumes:
         - "application/octet-stream"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Update misleading docs.

**- How I did it**

Removed sentences which are not valid & misleading.

**- How to verify it**

1. Create container eg. via ```docker run -it debian:latest /bin/bash```
2. Run in shell following command ```tputs colls```
3. Run on host command: ```curl -X POST -N --unix-socket /var/run/docker.sock 'http:///containers/d84b9b382a38/resize?w=120&h=120' -v -L```
4. Run in container shell following command ```tputs colls``` to see changes

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Not applicable.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://media2.giphy.com/media/kzSzftlGVwGOI/giphy.gif)