### PR TITLE
Check ipvlan is enabled before testing

### DIFF
--- a/integration/network/ipvlan/ipvlan_test.go
+++ b/integration/network/ipvlan/ipvlan_test.go
@@ -4,7 +4,10 @@ package ipvlan
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -425,7 +428,21 @@ func testIpvlanAddressing(client dclient.APIClient) func(*testing.T) {
 	}
 }
 
-// ensure Kernel version is >= v4.2 for ipvlan support
+// ensure ipvlan is supported and enabled
+var (
+	once            sync.Once
+	ipvlanSupported bool
+)
+
 func ipvlanKernelSupport() bool {
-	return n.CheckKernelMajorVersionGreaterOrEqualThen(4, 2)
+	once.Do(func() {
+		_, err := os.Stat("/sys/module/ipvlan")
+		if err == nil {
+			ipvlanSupported = true
+		} else if !os.IsNotExist(err) {
+			fmt.Printf("WARNING: ipvlanKernelSupport: stat failed: %v\n", err)
+		}
+	})
+
+	return ipvlanSupported
 }


### PR DESCRIPTION
@kolyshkin @thaJeztah @jim-docker PTAL

**- What I did**

  change integration test to check ipvlan is enabled before running the ipvlan tests

**- How I did it**

  check /sys/module/ipvlan
  based on Kir's patch (minus the modprobe)

**- How to verify it**

  run integration test with and without ipvlan enabled

**- Description for the changelog**

  before running the ipvlan tests, actually check ipvlan is enabled.

Signed-off-by: Tim Tsai <tim.tsai@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->




<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
