### PR TITLE
aufs: retry umount on ebusy, ignore ENOENT in graphdriver.Mounted

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -313,9 +313,6 @@ func (a *Driver) Remove(id string) error {
 	for {
 		mounted, err := a.mounted(mountpoint)
 		if err != nil {
-			if os.IsNotExist(err) {
-				break
-			}
 			return err
 		}
 		if !mounted {

--- a/daemon/graphdriver/driver_linux.go
+++ b/daemon/graphdriver/driver_linux.go
@@ -118,6 +118,9 @@ func (c *defaultChecker) IsMounted(path string) bool {
 func Mounted(fsType FsMagic, mountPath string) (bool, error) {
 	var buf unix.Statfs_t
 	if err := unix.Statfs(mountPath, &buf); err != nil {
+		if err == unix.ENOENT { // not exist, thus not mounted
+			err = nil
+		}
 		return false, err
 	}
 	return FsMagic(buf.Type) == fsType, nil


### PR DESCRIPTION
Two followup aufs fixes.

## graphdriver.Mounted(): ignore ENOENT
    
In case statfs() returns ENOENT, do not return an error, but rather
treat this as "not mounted".
    
Related to commit d42dbdd3d48d.

## aufs: retry unmount on EBUSY
    
For some reason, retrying to unmount in case of getting EBUSY error was
only performed in Remove(), but not Put().
    
I have done some testing on Ubuntu 18.04 with aufs, performing massively
parallel container creation, and sometimes unmount fails on Put with
EBUSY, while creating a container from a shell script
    
> Error response from daemon: device or resource busy
    
and in docker log, with debug turned on:
    
> level=debug msg="Failed to unmount ID-init aufs: device or resource busy"
> level=error msg="Handler for POST /v1.30/containers/create returned error: device or resource busy"

(note: this was repro'd on 17.06 thus the 1.30)
    
Some additional debugging revealed that it's the kernel who's
holding the mount, in other words it's not a mount leak or
some userspace process.
    
This commit:
    
* implements retry on EBUSY in Unmount()
* calls Unmount() from Remove()

As a result, I am now seeing occasional

``` 
"aufs unmount /var/lib/docker/aufs/mnt/ID-init failed with EBUSY (retrying 1/3)"
```
(actual sha was replaced by ID)