### PR TITLE
Propagate contexts down into containerd

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -33,14 +33,14 @@ type copyBackend interface {
 // stateBackend includes functions to implement to provide container state lifecycle functionality.
 type stateBackend interface {
 	ContainerCreate(config types.ContainerCreateConfig) (container.ContainerCreateCreatedBody, error)
-	ContainerKill(name string, sig uint64) error
+	ContainerKill(ctx context.Context, name string, sig uint64) error
 	ContainerPause(name string) error
 	ContainerRename(oldName, newName string) error
 	ContainerResize(name string, height, width int) error
-	ContainerRestart(name string, seconds *int) error
+	ContainerRestart(ctx context.Context, name string, seconds *int) error
 	ContainerRm(name string, config *types.ContainerRmConfig) error
-	ContainerStart(name string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error
-	ContainerStop(name string, seconds *int) error
+	ContainerStart(ctx context.Context, name string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error
+	ContainerStop(ctx context.Context, name string, seconds *int) error
 	ContainerUnpause(name string) error
 	ContainerUpdate(name string, hostConfig *container.HostConfig) (container.ContainerUpdateOKBody, error)
 	ContainerWait(ctx context.Context, name string, condition containerpkg.WaitCondition) (<-chan containerpkg.StateStatus, error)

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -207,7 +207,7 @@ func (s *containerRouter) postContainersStart(ctx context.Context, w http.Respon
 
 	checkpoint := r.Form.Get("checkpoint")
 	checkpointDir := r.Form.Get("checkpoint-dir")
-	if err := s.backend.ContainerStart(vars["name"], hostConfig, checkpoint, checkpointDir); err != nil {
+	if err := s.backend.ContainerStart(ctx, vars["name"], hostConfig, checkpoint, checkpointDir); err != nil {
 		return err
 	}
 
@@ -229,7 +229,7 @@ func (s *containerRouter) postContainersStop(ctx context.Context, w http.Respons
 		seconds = &valSeconds
 	}
 
-	if err := s.backend.ContainerStop(vars["name"], seconds); err != nil {
+	if err := s.backend.ContainerStop(ctx, vars["name"], seconds); err != nil {
 		return err
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -253,7 +253,7 @@ func (s *containerRouter) postContainersKill(ctx context.Context, w http.Respons
 		}
 	}
 
-	if err := s.backend.ContainerKill(name, uint64(sig)); err != nil {
+	if err := s.backend.ContainerKill(ctx, name, uint64(sig)); err != nil {
 		var isStopped bool
 		if errdefs.IsConflict(err) {
 			isStopped = true
@@ -286,7 +286,7 @@ func (s *containerRouter) postContainersRestart(ctx context.Context, w http.Resp
 		seconds = &valSeconds
 	}
 
-	if err := s.backend.ContainerRestart(vars["name"], seconds); err != nil {
+	if err := s.backend.ContainerRestart(ctx, vars["name"], seconds); err != nil {
 		return err
 	}
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -65,9 +65,9 @@ type ExecBackend interface {
 	// ContainerRm removes a container specified by `id`.
 	ContainerRm(name string, config *types.ContainerRmConfig) error
 	// ContainerKill stops the container execution abruptly.
-	ContainerKill(containerID string, sig uint64) error
+	ContainerKill(ctx context.Context, containerID string, sig uint64) error
 	// ContainerStart starts a new container
-	ContainerStart(containerID string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error
+	ContainerStart(ctx context.Context, containerID string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error
 	// ContainerWait stops processing until the given container is stopped.
 	ContainerWait(ctx context.Context, name string, condition containerpkg.WaitCondition) (<-chan containerpkg.StateStatus, error)
 }

--- a/builder/dockerfile/containerbackend.go
+++ b/builder/dockerfile/containerbackend.go
@@ -61,7 +61,7 @@ func (c *containerManager) Run(ctx context.Context, cID string, stdout, stderr i
 		select {
 		case <-ctx.Done():
 			logrus.Debugln("Build cancelled, killing and removing container:", cID)
-			c.backend.ContainerKill(cID, 0)
+			c.backend.ContainerKill(ctx, cID, 0)
 			c.removeContainer(cID, stdout)
 			cancelErrCh <- errCancelled
 		case <-finished:
@@ -69,7 +69,7 @@ func (c *containerManager) Run(ctx context.Context, cID string, stdout, stderr i
 		}
 	}()
 
-	if err := c.backend.ContainerStart(cID, nil, "", ""); err != nil {
+	if err := c.backend.ContainerStart(ctx, cID, nil, "", ""); err != nil {
 		close(finished)
 		logCancellationError(cancelErrCh, "error from ContainerStart: "+err.Error())
 		return err

--- a/builder/dockerfile/mockbackend_test.go
+++ b/builder/dockerfile/mockbackend_test.go
@@ -46,11 +46,11 @@ func (m *MockBackend) CommitBuildStep(c backend.CommitConfig) (image.ID, error) 
 	return "", nil
 }
 
-func (m *MockBackend) ContainerKill(containerID string, sig uint64) error {
+func (m *MockBackend) ContainerKill(ctx context.Context, containerID string, sig uint64) error {
 	return nil
 }
 
-func (m *MockBackend) ContainerStart(containerID string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error {
+func (m *MockBackend) ContainerStart(ctx context.Context, containerID string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error {
 	return nil
 }
 

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -34,8 +34,8 @@ type Backend interface {
 	SetupIngress(clustertypes.NetworkCreateRequest, string) (<-chan struct{}, error)
 	ReleaseIngress() (<-chan struct{}, error)
 	CreateManagedContainer(config types.ContainerCreateConfig) (container.ContainerCreateCreatedBody, error)
-	ContainerStart(name string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error
-	ContainerStop(name string, seconds *int) error
+	ContainerStart(ctx context.Context, name string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error
+	ContainerStop(ctx context.Context, name string, seconds *int) error
 	ContainerLogs(context.Context, string, *types.ContainerLogsOptions) (msgs <-chan *backend.LogMessage, tty bool, err error)
 	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error
 	ActivateContainerServiceBinding(containerName string) error
@@ -44,7 +44,7 @@ type Backend interface {
 	ContainerInspectCurrent(name string, size bool) (*types.ContainerJSON, error)
 	ContainerWait(ctx context.Context, name string, condition containerpkg.WaitCondition) (<-chan containerpkg.StateStatus, error)
 	ContainerRm(name string, config *types.ContainerRmConfig) error
-	ContainerKill(name string, sig uint64) error
+	ContainerKill(ctx context.Context, name string, sig uint64) error
 	SetContainerDependencyStore(name string, store exec.DependencyGetter) error
 	SetContainerSecretReferences(name string, refs []*swarmtypes.SecretReference) error
 	SetContainerConfigReferences(name string, refs []*swarmtypes.ConfigReference) error

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -352,7 +352,7 @@ func (c *containerAdapter) start(ctx context.Context) error {
 		return err
 	}
 
-	return c.backend.ContainerStart(c.container.name(), nil, "", "")
+	return c.backend.ContainerStart(ctx, c.container.name(), nil, "", "")
 }
 
 func (c *containerAdapter) inspect(ctx context.Context) (types.ContainerJSON, error) {
@@ -414,11 +414,11 @@ func (c *containerAdapter) shutdown(ctx context.Context) error {
 		stopgraceValue := int(spec.StopGracePeriod.Seconds)
 		stopgrace = &stopgraceValue
 	}
-	return c.backend.ContainerStop(c.container.name(), stopgrace)
+	return c.backend.ContainerStop(ctx, c.container.name(), stopgrace)
 }
 
 func (c *containerAdapter) terminate(ctx context.Context) error {
-	return c.backend.ContainerKill(c.container.name(), uint64(syscall.SIGKILL))
+	return c.backend.ContainerKill(ctx, c.container.name(), uint64(syscall.SIGKILL))
 }
 
 func (c *containerAdapter) remove(ctx context.Context) error {

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -1,6 +1,7 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"runtime"
@@ -175,7 +176,7 @@ func (daemon *Daemon) create(opts createOpts) (retC *container.Container, retErr
 	}
 	defer func() {
 		if retErr != nil {
-			if err := daemon.cleanupContainer(ctr, true, true); err != nil {
+			if err := daemon.cleanupContainer(context.Background(), ctr, true, true); err != nil {
 				logrus.Errorf("failed to cleanup container on create error: %v", err)
 			}
 		}

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -275,6 +275,10 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, stdin
 
 	select {
 	case <-ctx.Done():
+		// Must use a new context since the current context is done
+		ctxErr := ctx.Err()
+		ctx := context.Background()
+
 		logrus.Debugf("Sending TERM signal to process %v in container %v", name, c.ID)
 		daemon.containerd.SignalProcess(ctx, c.ID, name, int(signal.SignalMap["TERM"]))
 
@@ -288,7 +292,7 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, stdin
 		case <-attachErr:
 			// TERM signal worked
 		}
-		return ctx.Err()
+		return ctxErr
 	case err := <-attachErr:
 		if err != nil {
 			if _, ok := err.(term.EscapeError); !ok {

--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -1,6 +1,7 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
 	"fmt"
 
 	containertypes "github.com/docker/docker/api/types/container"
@@ -14,7 +15,7 @@ import (
 // timeout, ContainerRestart will wait forever until a graceful
 // stop. Returns an error if the container cannot be found, or if
 // there is an underlying error at any stage of the restart.
-func (daemon *Daemon) ContainerRestart(name string, seconds *int) error {
+func (daemon *Daemon) ContainerRestart(ctx context.Context, name string, seconds *int) error {
 	ctr, err := daemon.GetContainer(name)
 	if err != nil {
 		return err
@@ -23,7 +24,7 @@ func (daemon *Daemon) ContainerRestart(name string, seconds *int) error {
 		stopTimeout := ctr.StopTimeout()
 		seconds = &stopTimeout
 	}
-	if err := daemon.containerRestart(ctr, *seconds); err != nil {
+	if err := daemon.containerRestart(ctx, ctr, *seconds); err != nil {
 		return fmt.Errorf("Cannot restart container %s: %v", name, err)
 	}
 	return nil
@@ -34,7 +35,7 @@ func (daemon *Daemon) ContainerRestart(name string, seconds *int) error {
 // container. When stopping, wait for the given duration in seconds to
 // gracefully stop, before forcefully terminating the container. If
 // given a negative duration, wait forever for a graceful stop.
-func (daemon *Daemon) containerRestart(container *container.Container, seconds int) error {
+func (daemon *Daemon) containerRestart(ctx context.Context, container *container.Container, seconds int) error {
 
 	// Determine isolation. If not specified in the hostconfig, use daemon default.
 	actualIsolation := container.HostConfig.Isolation
@@ -60,7 +61,7 @@ func (daemon *Daemon) containerRestart(container *container.Container, seconds i
 		autoRemove := container.HostConfig.AutoRemove
 
 		container.HostConfig.AutoRemove = false
-		err := daemon.containerStop(container, seconds)
+		err := daemon.containerStop(ctx, container, seconds)
 		// restore AutoRemove irrespective of whether the stop worked or not
 		container.HostConfig.AutoRemove = autoRemove
 		// containerStop will write HostConfig to disk, we shall restore AutoRemove
@@ -74,7 +75,7 @@ func (daemon *Daemon) containerRestart(container *container.Container, seconds i
 		}
 	}
 
-	if err := daemon.containerStart(container, "", "", true); err != nil {
+	if err := daemon.containerStart(ctx, container, "", "", true); err != nil {
 		return err
 	}
 

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -18,7 +18,7 @@ import (
 // If the timeout is nil, the container's StopTimeout value is used, if set,
 // otherwise the engine default. A negative timeout value can be specified,
 // meaning no timeout, i.e. no forceful termination is performed.
-func (daemon *Daemon) ContainerStop(name string, timeout *int) error {
+func (daemon *Daemon) ContainerStop(ctx context.Context, name string, timeout *int) error {
 	container, err := daemon.GetContainer(name)
 	if err != nil {
 		return err
@@ -30,21 +30,21 @@ func (daemon *Daemon) ContainerStop(name string, timeout *int) error {
 		stopTimeout := container.StopTimeout()
 		timeout = &stopTimeout
 	}
-	if err := daemon.containerStop(container, *timeout); err != nil {
+	if err := daemon.containerStop(ctx, container, *timeout); err != nil {
 		return errdefs.System(errors.Wrapf(err, "cannot stop container: %s", name))
 	}
 	return nil
 }
 
 // containerStop sends a stop signal, waits, sends a kill signal.
-func (daemon *Daemon) containerStop(container *containerpkg.Container, seconds int) error {
+func (daemon *Daemon) containerStop(ctx context.Context, container *containerpkg.Container, seconds int) error {
 	if !container.IsRunning() {
 		return nil
 	}
 
 	stopSignal := container.StopSignal()
 	// 1. Send a stop signal
-	if err := daemon.killPossiblyDeadProcess(container, stopSignal); err != nil {
+	if err := daemon.killPossiblyDeadProcess(ctx, container, stopSignal); err != nil {
 		// While normally we might "return err" here we're not going to
 		// because if we can't stop the container by this point then
 		// it's probably because it's already stopped. Meaning, between
@@ -55,31 +55,33 @@ func (daemon *Daemon) containerStop(container *containerpkg.Container, seconds i
 		// So, instead we'll give it up to 2 more seconds to complete and if
 		// by that time the container is still running, then the error
 		// we got is probably valid and so we force kill it.
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctxT, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
 
-		if status := <-container.Wait(ctx, containerpkg.WaitConditionNotRunning); status.Err() != nil {
+		if status := <-container.Wait(ctxT, containerpkg.WaitConditionNotRunning); status.Err() != nil {
 			logrus.Infof("Container failed to stop after sending signal %d to the process, force killing", stopSignal)
-			if err := daemon.killPossiblyDeadProcess(container, 9); err != nil {
+			if err := daemon.killPossiblyDeadProcess(ctx, container, 9); err != nil {
 				return err
 			}
 		}
 	}
 
 	// 2. Wait for the process to exit on its own
-	ctx := context.Background()
+	ctxT := context.Background()
 	if seconds >= 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, time.Duration(seconds)*time.Second)
+		ctxT, cancel = context.WithTimeout(ctx, time.Duration(seconds)*time.Second)
 		defer cancel()
 	}
 
-	if status := <-container.Wait(ctx, containerpkg.WaitConditionNotRunning); status.Err() != nil {
+	if status := <-container.Wait(ctxT, containerpkg.WaitConditionNotRunning); status.Err() != nil {
 		logrus.Infof("Container %v failed to exit within %d seconds of signal %d - using the force", container.ID, seconds, stopSignal)
 		// 3. If it doesn't, then send SIGKILL
-		if err := daemon.Kill(container); err != nil {
+		if err := daemon.Kill(ctx, container); err != nil {
 			// Wait without a timeout, ignore result.
-			<-container.Wait(context.Background(), containerpkg.WaitConditionNotRunning)
+			ctxT, cancel := context.WithTimeout(ctx, time.Duration(seconds)*time.Second)
+			<-container.Wait(ctxT, containerpkg.WaitConditionNotRunning)
+			cancel()
 			logrus.Warn(err) // Don't return error because we only care that container is stopped, not what function stopped it
 		}
 	}

--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -251,6 +251,9 @@ func (c *client) Start(ctx context.Context, id, checkpointDir string, withStdin 
 	// Signal c.createIO that it can call CloseIO
 	close(stdinCloseSync)
 
+	// Use a fresh context here because start can't really be cancelled
+	// Meanwhile we can't really handle cancellation here because the workload could have started but other things may have failed.
+	ctx = context.Background()
 	if err := t.Start(ctx); err != nil {
 		if _, err := t.Delete(ctx); err != nil {
 			c.logger.WithError(err).WithField("container", id).


### PR DESCRIPTION
These requests are historically the most problematic with regards to
causing deadlocks in the engine (waiting on kill in particular).
This is also helpful because the contexts (at least the timeout) is now
propagated all the way into the containerd shim calls.