### PR TITLE
Change socket location to /run/docker.sock

### DIFF
--- a/contrib/init/systemd/docker.socket
+++ b/contrib/init/systemd/docker.socket
@@ -3,7 +3,9 @@ Description=Docker Socket for the API
 PartOf=docker.service
 
 [Socket]
-ListenStream=/var/run/docker.sock
+# If /var/run is not implemented as a symlink to /run, you may need to
+# specify ListenStream=/var/run/docker.sock instead.
+ListenStream=/run/docker.sock
 SocketMode=0660
 SocketUser=root
 SocketGroup=docker


### PR DESCRIPTION
This change resolves systemd warning:

```
/usr/lib/systemd/system/docker.socket:5: ListenStream= references a path below legacy directory /var/run/, updating /var/run/docker.sock → /run/docker.sock; please update the unit file accordingly.
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Update the location of docker socket to use `/run` directory

**- How I did it**
By editing the file :)

**- How to verify it**
I used the changed file locally and it worked.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Change location of docker socket to `/run/docker.sock`

**- A picture of a cute animal (not mandatory but encouraged)**

![cat](https://user-images.githubusercontent.com/1718963/58475107-60529300-814d-11e9-9a93-651902b1f570.jpg)

