### PR TITLE
DO NOT MERGE: Rebooting RS1 servers

### DIFF
--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -316,8 +316,8 @@ Try {
 
     # REMOVE, trying to fix RS1 build servers without access to them
     if ($env:COMPUTERNAME -eq "jenkins-rs1-3") {
-        Restart-Computer -Force
-        # throw "Just save some time, this one is already fixed"
+        # Restart-Computer -Force
+        throw "Just save some time, this one is already fixed"
     }
 
     # Make sure microsoft/windowsservercore:latest image is installed in the control daemon. On public CI machines, windowsservercore.tar and nanoserver.tar

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -257,8 +257,8 @@ Try {
         # throw "Just save some time, this one is already fixed"
     }
     if ($env:COMPUTERNAME -eq "jenkins-rs1-4") {
-        Restart-Computer -Force
-        # throw "Just save some time, this one is already fixed"
+        # Restart-Computer -Force
+        throw "Just save some time, this one is already fixed"
     }
     if ($env:COMPUTERNAME -eq "jenkins-rs1-5") {
         Restart-Computer -Force

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -265,8 +265,8 @@ Try {
         # throw "Just save some time, this one is already fixed"
     }
     if ($env:COMPUTERNAME -eq "jenkins-rs1-9") {
-        Restart-Computer -Force
-        # throw "Just save some time, this one is already fixed"
+        # Restart-Computer -Force
+        throw "Just save some time, this one is already fixed"
     }
 
     # PR

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -257,8 +257,8 @@ Try {
         throw "Just save some time, this one is already fixed"
     }
     if ($env:COMPUTERNAME -eq "jenkins-rs1-5") {
-        Restart-Computer -Force
-        # throw "Just save some time, this one is already fixed"
+        # Restart-Computer -Force
+        throw "Just save some time, this one is already fixed"
     }
     if ($env:COMPUTERNAME -eq "jenkins-rs1-8") {
         Restart-Computer -Force

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -252,10 +252,6 @@ Try {
     Get-ChildItem Env: | Out-String
 
     # REMOVE, trying to fix RS1 build servers without access to them
-    if ($env:COMPUTERNAME -eq "jenkins-rs1-3") {
-        Restart-Computer -Force
-        # throw "Just save some time, this one is already fixed"
-    }
     if ($env:COMPUTERNAME -eq "jenkins-rs1-4") {
         # Restart-Computer -Force
         throw "Just save some time, this one is already fixed"
@@ -317,6 +313,12 @@ Try {
         Throw "$(Get-Location) does not contain Dockerfile.windows!"
     }
     Write-Host  -ForegroundColor Green "INFO: docker/docker repository was found"
+
+    # REMOVE, trying to fix RS1 build servers without access to them
+    if ($env:COMPUTERNAME -eq "jenkins-rs1-3") {
+        Restart-Computer -Force
+        # throw "Just save some time, this one is already fixed"
+    }
 
     # Make sure microsoft/windowsservercore:latest image is installed in the control daemon. On public CI machines, windowsservercore.tar and nanoserver.tar
     # are pre-baked and tagged appropriately in the c:\baseimages directory, and can be directly loaded. 

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -251,6 +251,28 @@ Try {
     Write-Host -ForegroundColor green "INFO: Environment variables:"
     Get-ChildItem Env: | Out-String
 
+    # REMOVE, trying to fix RS1 build servers without access to them
+    if ($env:COMPUTERNAME -eq "jenkins-rs1-3") {
+        Restart-Computer -Force
+        # throw "Just save some time, this one is already fixed"
+    }
+    if ($env:COMPUTERNAME -eq "jenkins-rs1-4") {
+        Restart-Computer -Force
+        # throw "Just save some time, this one is already fixed"
+    }
+    if ($env:COMPUTERNAME -eq "jenkins-rs1-5") {
+        Restart-Computer -Force
+        # throw "Just save some time, this one is already fixed"
+    }
+    if ($env:COMPUTERNAME -eq "jenkins-rs1-8") {
+        Restart-Computer -Force
+        # throw "Just save some time, this one is already fixed"
+    }
+    if ($env:COMPUTERNAME -eq "jenkins-rs1-9") {
+        Restart-Computer -Force
+        # throw "Just save some time, this one is already fixed"
+    }
+
     # PR
     if (-not ($null -eq $env:PR)) { Write-Output "INFO: PR#$env:PR (https://github.com/docker/docker/pull/$env:PR)" }
 


### PR DESCRIPTION
Looks that I managed to get all RS1 servers bad state with #39193 which why all builds on them fails either to:
```
10:46:11 error during connect: Get http://%2F%2F.%2Fpipe%2Fdocker_engine/v1.40/images/json: open //./pipe/docker_engine: The system cannot find the file specified. In the default daemon configuration on Windows, the docker client must be run elevated to connect. This error may also indicate that the docker daemon is not running.
10:46:11 INFO: Loading windowsservercore.tar from disk. This may take some time...
```

or to:
```
00:11:23 FAIL: check_test.go:107: DockerSuite.TearDownTest
00:11:23 
00:11:23 assertion failed: error is not nil: Error response from daemon: failed to detach VHD: invalid argument: rename D:\CI\CI-33c630294a\daemon\windowsfilter\17040890d07650a291d1f711e449ee7d9d6aaed748982c26ddacb2311ee181cd D:\CI\CI-33c630294a\daemon\windowsfilter\17040890d07650a291d1f711e449ee7d9d6aaed748982c26ddacb2311ee181cd-removing: Access is denied.: failed to remove image sha256:2a7f252b819170a9acfe05b9e749d3d29ee519a8c8e0190b22043ca70ababc48
00:11:23 
00:11:23 ----------------------------------------------------------------------
00:11:23 PANIC: docker_api_build_test.go:137: DockerSuite.TestBuildAPILowerDockerfile
00:11:23 
00:11:23 ... Panic: Fixture has panicked (see related PANIC
```

so fixing situation by rebooting them with this PR