### PR TITLE
Do not fail integration tests if removeImage fails

### DIFF
--- a/internal/test/environment/clean.go
+++ b/internal/test/environment/clean.go
@@ -134,7 +134,6 @@ func removeImage(ctx context.Context, t assert.TestingT, apiclient client.ImageA
 	if client.IsErrNotFound(err) {
 		return
 	}
-	assert.Check(t, err, "failed to remove image %s", ref)
 }
 
 func deleteAllVolumes(t assert.TestingT, c client.VolumeAPIClient, protectedVolumes map[string]struct{}) {


### PR DESCRIPTION
I noticed that all RS1 build servers are now failing on `DockerSuite.TearDownTest` because removing some image fails.

One example from https://jenkins.dockerproject.org/job/Docker-PRs-WoW-RS1/25390/console (build server: azure-windows-rs1-3)
```
12:02:03 PASS: docker_cli_attach_test.go:21: DockerSuite.TestAttachMultipleAndRestart	2.881s
12:02:03 SKIP: docker_cli_attach_test.go:169: DockerSuite.TestAttachPausedContainer (unmatched requirement IsPausable)
12:02:03 SKIP: docker_cli_attach_test.go:91: DockerSuite.TestAttachTTYWithoutStdin (unmatched requirement DaemonIsLinux)
12:02:10 
12:02:10 ----------------------------------------------------------------------
12:02:10 FAIL: check_test.go:107: DockerSuite.TearDownTest
12:02:10 
12:02:10 assertion failed: error is not nil: Error response from daemon: failed to detach VHD: invalid argument: rename D:\CI\CI-c7d9599e3d\daemon\windowsfilter\dcf157c16f7aabd876ebcd1a12205d1a72c8a2e7c1ea74f1e2e462f77b2bed21 D:\CI\CI-c7d9599e3d\daemon\windowsfilter\dcf157c16f7aabd876ebcd1a12205d1a72c8a2e7c1ea74f1e2e462f77b2bed21-removing: Access is denied.: failed to remove image sha256:46d5dd6a99ea91d9e5168fbae66738fdc0293fca658216327202a8dd140bd305
```

another from https://jenkins.dockerproject.org/job/Docker-PRs-WoW-RS1/25389/console (build server azure-windows-rs1-9):
```
11:53:12 PASS: docker_cli_build_test.go:2190: DockerSuite.TestBuildAddFileNotFound	0.047s
11:53:17 PASS: docker_cli_build_test.go:1998: DockerSuite.TestBuildAddLocalAndRemoteFilesWithAndWithoutCache	4.845s
11:53:28 
11:53:28 ----------------------------------------------------------------------
11:53:28 FAIL: check_test.go:107: DockerSuite.TearDownTest
11:53:28 
11:53:28 assertion failed: error is not nil: Error response from daemon: failed to detach VHD: invalid argument: rename D:\CI\CI-15384a9d95\daemon\windowsfilter\6a19763aa5ea9739ec7780db26ccedf585720a1275980eac99124e021af97370 D:\CI\CI-15384a9d95\daemon\windowsfilter\6a19763aa5ea9739ec7780db26ccedf585720a1275980eac99124e021af97370-removing: Access is denied.: failed to remove image testbuildaddmultiplelocalfilewithcache:latest
```

common for those is that some point of testing Windows graphdriver is not able to remove some of the image even when there is quite a lot logic which tries to solve situation:
https://github.com/moby/moby/blob/8d760280a232f98d92440539e1e8a8f66c213bdb/daemon/graphdriver/windows/windows.go#L334-L347

However that should no matter because after image tag is removed those images will be ignored anyway and we already have solution to cleanup those from production environment with #39193

So I just removed checking for `failed to remove image` message from removeImage function.

Let's see if we now pass CI on RS1 which have been broken for a while.