### PR TITLE
Windows graphdriver - Ignore "invalid argument" error if detach fails during Remove

### DIFF
--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -338,7 +338,7 @@ func (d *Driver) Remove(id string) error {
 		// If permission denied, it's possible that the scratch is still mounted, an
 		// artifact after a hard daemon crash for example. Worth a shot to try detaching it
 		// before retrying the rename.
-		if detachErr := vhd.DetachVhd(filepath.Join(layerPath, "sandbox.vhdx")); detachErr != nil {
+		if detachErr := vhd.DetachVhd(filepath.Join(layerPath, "sandbox.vhdx")); detachErr != nil && detachErr != syscall.EINVAL {
 			return errors.Wrapf(err, "failed to detach VHD: %s", detachErr)
 		}
 		if renameErr := os.Rename(layerPath, tmpLayerPath); renameErr != nil && !os.IsNotExist(renameErr) {


### PR DESCRIPTION
I noticed that all RS1 build servers are now failing on `DockerSuite.TearDownTest` because removing some image fails to Detach error.

One example from https://jenkins.dockerproject.org/job/Docker-PRs-WoW-RS1/25390/console (build server: azure-windows-rs1-3)
```
12:02:03 PASS: docker_cli_attach_test.go:21: DockerSuite.TestAttachMultipleAndRestart	2.881s
12:02:03 SKIP: docker_cli_attach_test.go:169: DockerSuite.TestAttachPausedContainer (unmatched requirement IsPausable)
12:02:03 SKIP: docker_cli_attach_test.go:91: DockerSuite.TestAttachTTYWithoutStdin (unmatched requirement DaemonIsLinux)
12:02:10 
12:02:10 ----------------------------------------------------------------------
12:02:10 FAIL: check_test.go:107: DockerSuite.TearDownTest
12:02:10 
12:02:10 assertion failed: error is not nil: Error response from daemon: failed to detach VHD: invalid argument: rename D:\CI\CI-c7d9599e3d\daemon\windowsfilter\dcf157c16f7aabd876ebcd1a12205d1a72c8a2e7c1ea74f1e2e462f77b2bed21 D:\CI\CI-c7d9599e3d\daemon\windowsfilter\dcf157c16f7aabd876ebcd1a12205d1a72c8a2e7c1ea74f1e2e462f77b2bed21-removing: Access is denied.: failed to remove image sha256:46d5dd6a99ea91d9e5168fbae66738fdc0293fca658216327202a8dd140bd305
```
That detach logic was added by #37712 but looks to be that time to time layer actually gets detached without that call and now it fails to `syscall.EINVAL` ( invalid argument) on https://github.com/microsoft/go-winio/blob/dcdaf955de651d5b5caff082fc6026f69f9fc31d/vhd/zvhd.go#L83
but as it is just extra try for detach it is should be safe to ignore and try name again.

Needed to get RS1 CI servers working again.

Related to #39259 and #39193
