### PR TITLE
WIP: Use buildkit on Windows CI

### DIFF
--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -338,7 +338,7 @@ func (d *Driver) Remove(id string) error {
 		// If permission denied, it's possible that the scratch is still mounted, an
 		// artifact after a hard daemon crash for example. Worth a shot to try detaching it
 		// before retrying the rename.
-		if detachErr := vhd.DetachVhd(filepath.Join(layerPath, "sandbox.vhdx")); detachErr != nil {
+		if detachErr := vhd.DetachVhd(filepath.Join(layerPath, "sandbox.vhdx")); detachErr != nil && detachErr != syscall.EINVAL {
 			return errors.Wrapf(err, "failed to detach VHD: %s", detachErr)
 		}
 		if renameErr := os.Rename(layerPath, tmpLayerPath); renameErr != nil && !os.IsNotExist(renameErr) {

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -409,7 +409,7 @@ Try {
     # Redirect to a temporary location. 
     $TEMPORIG=$env:TEMP
     $env:TEMP="$env:TESTRUN_DRIVE`:\$env:TESTRUN_SUBDIR\CI-$COMMITHASH"
-    $env:LOCALAPPDATA="$TEMP\localappdata"
+    $env:LOCALAPPDATA="$env:TEMP\localappdata"
     $errorActionPreference='Stop'
     New-Item -ItemType Directory "$env:TEMP" -ErrorAction SilentlyContinue | Out-Null
     New-Item -ItemType Directory "$env:TEMP\userprofile" -ErrorAction SilentlyContinue  | Out-Null

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -119,6 +119,7 @@ $FinallyColour="Cyan"
 #$env:INTEGRATION_IN_CONTAINER="yes"
 #$env:WINDOWS_BASE_IMAGE=""
 #$env:SKIP_COPY_GO="yes"
+$env:DOCKER_BUILDKIT=1
 
 Function Nuke-Everything {
     $ErrorActionPreference = 'SilentlyContinue'


### PR DESCRIPTION
**- What I did**
Enabled buildkit on Windows CI.

Partly address of #39040

**- How I did it**
Included `$env:DOCKER_BUILDKIT=1` to Windows CI script.

**- How to verify it**
Pass CI

Still WIP because non-merged PRs:
- #39290
- #39259
are included (needed to pass CI).