### PR TITLE
Fix docker logs hangs after stop container when using journald

### DIFF
--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -305,6 +305,9 @@ func (s *journald) followJournal(logWatcher *logger.LogWatcher, j *C.sd_journal,
 		// Notify the other goroutine that its work is done.
 		C.close(pfd[1])
 		cursor = <-newCursor
+	case <-logWatcher.WatchProducerGone():
+		C.close(pfd[1])
+		cursor = <-newCursor
 	}
 
 	return cursor


### PR DESCRIPTION
Fix when using journald as log-driver, docker logs -f <containerID> hangs
after the container is exited. LogWatcher.WatchProducerGone() returns a
channel receiver to receive notification once container is gone.

fixes https://github.com/docker/for-linux/issues/575

Signed-off-by: Danni Xia <xiadanni1@huawei.com>

**- What I did**
fix https://github.com/docker/for-linux/issues/575

**- How I did it**
Add logWatcher.WatchProducerGone() to receive notification when container is gone.

**- How to verify it**
`docker logs -f $(docker run -d --rm --log-driver journald busybox sh -c "for i in \$(seq 1 10); do echo logline \$i; sleep 1; done")`
Verify that docker logs process can exit. 

