### PR TITLE
Revert "aufs: remove mntL"

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -28,12 +28,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -82,6 +80,7 @@ type Driver struct {
 	pathCache     map[string]string
 	naiveDiff     graphdriver.DiffDriver
 	locker        *locker.Locker
+	mntL          sync.Mutex
 }
 
 // Init returns a new AUFS driver.
@@ -619,14 +618,14 @@ func (a *Driver) aufsMount(ro []string, rw, target, mountLabel string) (err erro
 		bp += copy(b[bp:], layer)
 	}
 
-	// random 4 characters in the 0-9a-z range (e.g. "g6dz")
-	rnd := strconv.FormatInt(int64(1e9+rand.Uint32()%1e9), 36)[1:5]
-	opts := "dio,xino=/dev/shm/aufs." + rnd
+	opts := "dio,xino=/dev/shm/aufs.xino"
 	if useDirperm() {
 		opts += ",dirperm1"
 	}
 	data := label.FormatMountLabel(fmt.Sprintf("%s,%s", string(b[:bp]), opts), mountLabel)
+	a.mntL.Lock()
 	err = unix.Mount("none", target, "aufs", 0, data)
+	a.mntL.Unlock()
 	if err != nil {
 		err = errors.Wrap(err, "mount target="+target+" data="+data)
 		return
@@ -642,7 +641,9 @@ func (a *Driver) aufsMount(ro []string, rw, target, mountLabel string) (err erro
 			bp += copy(b[bp:], layer)
 		}
 		data := label.FormatMountLabel(string(b[:bp]), mountLabel)
+		a.mntL.Lock()
 		err = unix.Mount("none", target, "aufs", unix.MS_REMOUNT, data)
+		a.mntL.Unlock()
 		if err != nil {
 			err = errors.Wrap(err, "mount target="+target+" flags=MS_REMOUNT data="+data)
 			return


### PR DESCRIPTION
Commit e2989c4d487c87 (PR #39266) says:

> With the suffix added, the possibility to hit the race is extremely
> low, and we don't have to do any locking.

Probability theory just laughed in my face this weekend, as this has
actually happened once in 6050000 containers created, on a high-end
hardware with 1000 parallel "docker create" running (took a few days).

One way to work around this is increase the randomness by adding more
characters, which will further decrease the probability, but won't
eliminate it entirely. Another is to fix it upstream (done, see the
link below, but the fix might not be packported to Ubuntu).

Overall, as much as I like this solution, I think we need to
revert it :-\

See-also: https://github.com/sfjro/aufs5-standalone/commit/abf61326f49535

This reverts commit e2989c4d487c8706a7e0ba82e9f22fa21e5207bc.