### PR TITLE
Fix seccomp profile for clone syscall

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -596,7 +596,7 @@
 			"args": [
 				{
 					"index": 0,
-					"value": 2080505856,
+					"value": 2114060288,
 					"valueTwo": 0,
 					"op": "SCMP_CMP_MASKED_EQ"
 				}
@@ -621,7 +621,7 @@
 			"args": [
 				{
 					"index": 1,
-					"value": 2080505856,
+					"value": 2114060288,
 					"valueTwo": 0,
 					"op": "SCMP_CMP_MASKED_EQ"
 				}

--- a/profiles/seccomp/fixtures/example.json
+++ b/profiles/seccomp/fixtures/example.json
@@ -7,7 +7,7 @@
             "args": [
                 {
                     "index": 0,
-                    "value": 2080505856,
+                    "value": 2114060288,
                     "valueTwo": 0,
                     "op": "SCMP_CMP_MASKED_EQ"
                 }

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -518,7 +518,7 @@ func DefaultProfile() *types.Seccomp {
 			Args: []*types.Arg{
 				{
 					Index:    0,
-					Value:    unix.CLONE_NEWNS | unix.CLONE_NEWUTS | unix.CLONE_NEWIPC | unix.CLONE_NEWUSER | unix.CLONE_NEWPID | unix.CLONE_NEWNET,
+					Value:    unix.CLONE_NEWNS | unix.CLONE_NEWUTS | unix.CLONE_NEWIPC | unix.CLONE_NEWUSER | unix.CLONE_NEWPID | unix.CLONE_NEWNET | unix.CLONE_NEWCGROUP,
 					ValueTwo: 0,
 					Op:       types.OpMaskedEqual,
 				},
@@ -536,7 +536,7 @@ func DefaultProfile() *types.Seccomp {
 			Args: []*types.Arg{
 				{
 					Index:    1,
-					Value:    unix.CLONE_NEWNS | unix.CLONE_NEWUTS | unix.CLONE_NEWIPC | unix.CLONE_NEWUSER | unix.CLONE_NEWPID | unix.CLONE_NEWNET,
+					Value:    unix.CLONE_NEWNS | unix.CLONE_NEWUTS | unix.CLONE_NEWIPC | unix.CLONE_NEWUSER | unix.CLONE_NEWPID | unix.CLONE_NEWNET | unix.CLONE_NEWCGROUP,
 					ValueTwo: 0,
 					Op:       types.OpMaskedEqual,
 				},


### PR DESCRIPTION
based on https://github.com/containerd/containerd/pull/3314

All clone flags for namespace should be denied.

