### PR TITLE
Move cgroup info changes to API v1.40

### DIFF
--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -22,11 +22,6 @@ keywords: "API, Docker, rcli, REST, documentation"
   `private` to create the container in its own private cgroup namespace.  The per-daemon
   default is `host`, and can be changed by using the`CgroupNamespaceMode` daemon configuration
   parameter.
-* `GET /info` now includes `name=rootless` in `SecurityOptions` when the daemon is running in
-  rootless mode.  This change is not versioned, and affects all API versions if the daemon has
-  this patch.
-* `GET /info` now returns `none` as `CgroupDriver` when the daemon is running in rootless mode.
-  This change is not versioned, and affects all API versions if the daemon has this patch.
 
 ## v1.40 API changes
 
@@ -64,6 +59,11 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /info` now returns information about `DataPathPort` that is currently used in swarm
 * `GET /info` now returns `PidsLimit` boolean to indicate if the host kernel has
   PID limit support enabled.
+* `GET /info` now includes `name=rootless` in `SecurityOptions` when the daemon is running in
+  rootless mode.  This change is not versioned, and affects all API versions if the daemon has
+  this patch.
+* `GET /info` now returns `none` as `CgroupDriver` when the daemon is running in rootless mode.
+  This change is not versioned, and affects all API versions if the daemon has this patch.
 * `POST /containers/create` now accepts `DeviceRequests` as part of `HostConfig`.
   Can be used to set Nvidia GPUs.
 * `GET /swarm` endpoint now returns DataPathPort info


### PR DESCRIPTION
quick follow-up to https://github.com/moby/moby/pull/39299, so that the changes are listed under API v1.40, which is what 19.03 uses