### PR TITLE
allow dockerd builds without cgo

### DIFF
--- a/daemon/graphdriver/copy/copy.go
+++ b/daemon/graphdriver/copy/copy.go
@@ -2,14 +2,6 @@
 
 package copy // import "github.com/docker/docker/daemon/graphdriver/copy"
 
-/*
-#include <linux/fs.h>
-
-#ifndef FICLONE
-#define FICLONE		_IOW(0x94, 9, int)
-#endif
-*/
-import "C"
 import (
 	"container/list"
 	"fmt"
@@ -50,7 +42,7 @@ func copyRegular(srcPath, dstPath string, fileinfo os.FileInfo, copyWithFileRang
 	defer dstFile.Close()
 
 	if *copyWithFileClone {
-		_, _, err = unix.Syscall(unix.SYS_IOCTL, dstFile.Fd(), C.FICLONE, srcFile.Fd())
+		err = fiClone(srcFile, dstFile)
 		if err == nil {
 			return nil
 		}

--- a/daemon/graphdriver/copy/copy_cgo.go
+++ b/daemon/graphdriver/copy/copy_cgo.go
@@ -1,0 +1,22 @@
+// +build linux,cgo
+
+package copy // import "github.com/docker/docker/daemon/graphdriver/copy"
+
+/*
+#include <linux/fs.h>
+
+#ifndef FICLONE
+#define FICLONE		_IOW(0x94, 9, int)
+#endif
+*/
+import "C"
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func fiClone(srcFile, dstFile *os.File) error {
+	_, _, err := unix.Syscall(unix.SYS_IOCTL, dstFile.Fd(), C.FICLONE, srcFile.Fd())
+	return err
+}

--- a/daemon/graphdriver/copy/copy_nocgo.go
+++ b/daemon/graphdriver/copy/copy_nocgo.go
@@ -1,0 +1,13 @@
+// +build linux,!cgo
+
+package copy // import "github.com/docker/docker/daemon/graphdriver/copy"
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func fiClone(srcFile, dstFile *os.File) error {
+	return unix.ENOSYS
+}

--- a/daemon/graphdriver/quota/projectquota.go
+++ b/daemon/graphdriver/quota/projectquota.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!exclude_disk_quota
 
 //
 // projectquota.go - implements XFS project quota controls
@@ -62,19 +62,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
-
-// Quota limit params - currently we only control blocks hard limit
-type Quota struct {
-	Size uint64
-}
-
-// Control - Context to be used by storage driver (e.g. overlay)
-// who wants to apply project quotas to container dirs
-type Control struct {
-	backingFsBlockDev string
-	nextProjectID     uint32
-	quotas            map[string]uint32
-}
 
 // NewControl - initialize project quota support.
 // Test to make sure that quota can be set on a test dir and find

--- a/daemon/graphdriver/quota/projectquota_unsupported.go
+++ b/daemon/graphdriver/quota/projectquota_unsupported.go
@@ -1,0 +1,18 @@
+// +build linux,exclude_disk_quota
+
+package quota // import "github.com/docker/docker/daemon/graphdriver/quota"
+
+func NewControl(basePath string) (*Control, error) {
+	return nil, ErrQuotaNotSupported
+}
+
+// SetQuota - assign a unique project id to directory and set the quota limits
+// for that project id
+func (q *Control) SetQuota(targetPath string, quota Quota) error {
+	return ErrQuotaNotSupported
+}
+
+// GetQuota - get the quota limits of a directory that was configured with SetQuota
+func (q *Control) GetQuota(targetPath string, quota *Quota) error {
+	return ErrQuotaNotSupported
+}

--- a/daemon/graphdriver/quota/types.go
+++ b/daemon/graphdriver/quota/types.go
@@ -1,0 +1,16 @@
+// +build linux
+
+package quota // import "github.com/docker/docker/daemon/graphdriver/quota"
+
+// Quota limit params - currently we only control blocks hard limit
+type Quota struct {
+	Size uint64
+}
+
+// Control - Context to be used by storage driver (e.g. overlay)
+// who wants to apply project quotas to container dirs
+type Control struct {
+	backingFsBlockDev string
+	nextProjectID     uint32
+	quotas            map[string]uint32
+}

--- a/daemon/stats/collector_unix.go
+++ b/daemon/stats/collector_unix.go
@@ -9,12 +9,8 @@ import (
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/system"
+	"golang.org/x/sys/unix"
 )
-
-/*
-#include <unistd.h>
-*/
-import "C"
 
 // platformNewStatsCollector performs platform specific initialisation of the
 // Collector structure.
@@ -70,13 +66,10 @@ func (s *Collector) getSystemCPUUsage() (uint64, error) {
 }
 
 func (s *Collector) getNumberOnlineCPUs() (uint32, error) {
-	i, err := C.sysconf(C._SC_NPROCESSORS_ONLN)
-	// According to POSIX - errno is undefined after successful
-	// sysconf, and can be non-zero in several cases, so look for
-	// error in returned value not in errno.
-	// (https://sourceware.org/bugzilla/show_bug.cgi?id=21536)
-	if i == -1 {
+	var cpuset unix.CPUSet
+	err := unix.SchedGetaffinity(0, &cpuset)
+	if err != nil {
 		return 0, err
 	}
-	return uint32(i), nil
+	return uint32(cpuset.Count()), nil
 }


### PR DESCRIPTION
These patches allow building usable dockerd without the need of cgo. No changes to the current default way how we produce binaries.

Changes are in three areas:

Quota - uses cgo extensively but is an optional feature with feature detection already in caller. Add a new build tag that can be used to build without it.

Copy - cgo used for the ioctl based fast copy that has been replaced with the syscall. Change is to skip this check on !cgo . The copy_file_range and fallback methods still provide the feature. As it is only used for constant I could also just hardcode it in !cgo version if we want to keep it.

Stats: uses sysconf. Replaced with `unix.SchedGetaffinity`