### PR TITLE
On OpenRC docker needs to start after cgroups

### DIFF
--- a/contrib/init/openrc/docker.initd
+++ b/contrib/init/openrc/docker.initd
@@ -17,6 +17,10 @@ rc_ulimit="${DOCKER_ULIMIT:--c unlimited -n 1048576 -u unlimited}"
 
 retry="${DOCKER_RETRY:-TERM/60/KILL/10}"
 
+depend() {
+	need sysfs cgroups
+}
+
 start_pre() {
 	checkpath -f -m 0644 -o root:docker "$DOCKER_LOGFILE"
 }


### PR DESCRIPTION
Add `cgroups` service dependency to docker OpenRC init script.

Docker should start after the cgroups init script runs.

Not sure why nobody except me has ever hit this, but this is technically
more correct. The best kind of correct.

https://www.eastman.org/sites/default/files/Animal%20House_1978__37_1920X1240.jpg