### PR TITLE
Feature request: docker restart --checkpoint (daemon, API, client)

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -37,7 +37,7 @@ type stateBackend interface {
 	ContainerPause(name string) error
 	ContainerRename(oldName, newName string) error
 	ContainerResize(name string, height, width int) error
-	ContainerRestart(name string, seconds *int) error
+	ContainerRestart(name string, seconds *int, checkpoint string, checkpointDir string) error
 	ContainerRm(name string, config *types.ContainerRmConfig) error
 	ContainerStart(name string, hostConfig *container.HostConfig, checkpoint string, checkpointDir string) error
 	ContainerStop(name string, seconds *int) error

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -279,7 +279,10 @@ func (s *containerRouter) postContainersRestart(ctx context.Context, w http.Resp
 		seconds = &valSeconds
 	}
 
-	if err := s.backend.ContainerRestart(vars["name"], seconds); err != nil {
+	checkpoint := r.Form.Get("checkpoint")
+	checkpointDir := r.Form.Get("checkpoint-dir")
+
+	if err := s.backend.ContainerRestart(vars["name"], seconds, checkpoint, checkpointDir); err != nil {
 		return err
 	}
 

--- a/client/container_restart.go
+++ b/client/container_restart.go
@@ -5,16 +5,23 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/docker/docker/api/types"
 	timetypes "github.com/docker/docker/api/types/time"
 )
 
 // ContainerRestart stops and starts a container again.
 // It makes the daemon to wait for the container to be up again for
 // a specific amount of time, given the timeout.
-func (cli *Client) ContainerRestart(ctx context.Context, containerID string, timeout *time.Duration) error {
+func (cli *Client) ContainerRestart(ctx context.Context, containerID string, timeout *time.Duration, options types.ContainerStartOptions) error {
 	query := url.Values{}
 	if timeout != nil {
 		query.Set("t", timetypes.DurationToSecondsString(*timeout))
+	}
+	if len(options.CheckpointID) != 0 {
+		query.Set("checkpoint", options.CheckpointID)
+	}
+	if len(options.CheckpointDir) != 0 {
+		query.Set("checkpoint-dir", options.CheckpointDir)
 	}
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/restart", query, nil, nil)
 	ensureReaderClosed(resp)

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -18,7 +18,7 @@ func TestContainerRestartError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 	timeout := 0 * time.Second
-	err := client.ContainerRestart(context.Background(), "nothing", &timeout)
+	err := client.ContainerRestart(context.Background(), "nothing", &timeout, types.ContainerStartOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -45,7 +45,7 @@ func TestContainerRestart(t *testing.T) {
 		}),
 	}
 	timeout := 100 * time.Second
-	err := client.ContainerRestart(context.Background(), "container_id", &timeout)
+	err := client.ContainerRestart(context.Background(), "container_id", &timeout, types.ContainerStartOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
 )
 

--- a/client/interface.go
+++ b/client/interface.go
@@ -64,7 +64,7 @@ type ContainerAPIClient interface {
 	ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error
 	ContainerRename(ctx context.Context, container, newContainerName string) error
 	ContainerResize(ctx context.Context, container string, options types.ResizeOptions) error
-	ContainerRestart(ctx context.Context, container string, timeout *time.Duration) error
+	ContainerRestart(ctx context.Context, container string, timeout *time.Duration, options types.ContainerStartOptions) error  // TODO create separate types.ContainerRestartOptions?
 	ContainerStatPath(ctx context.Context, container, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (types.ContainerStats, error)
 	ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error

--- a/client/interface.go
+++ b/client/interface.go
@@ -64,7 +64,7 @@ type ContainerAPIClient interface {
 	ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error
 	ContainerRename(ctx context.Context, container, newContainerName string) error
 	ContainerResize(ctx context.Context, container string, options types.ResizeOptions) error
-	ContainerRestart(ctx context.Context, container string, timeout *time.Duration, options types.ContainerStartOptions) error // TODO create separate types.ContainerRestartOptions?
+	ContainerRestart(ctx context.Context, container string, timeout *time.Duration, options types.ContainerStartOptions) error
 	ContainerStatPath(ctx context.Context, container, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (types.ContainerStats, error)
 	ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error

--- a/client/interface.go
+++ b/client/interface.go
@@ -64,7 +64,7 @@ type ContainerAPIClient interface {
 	ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error
 	ContainerRename(ctx context.Context, container, newContainerName string) error
 	ContainerResize(ctx context.Context, container string, options types.ResizeOptions) error
-	ContainerRestart(ctx context.Context, container string, timeout *time.Duration, options types.ContainerStartOptions) error  // TODO create separate types.ContainerRestartOptions?
+	ContainerRestart(ctx context.Context, container string, timeout *time.Duration, options types.ContainerStartOptions) error // TODO create separate types.ContainerRestartOptions?
 	ContainerStatPath(ctx context.Context, container, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (types.ContainerStats, error)
 	ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error

--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -14,7 +14,7 @@ import (
 // timeout, ContainerRestart will wait forever until a graceful
 // stop. Returns an error if the container cannot be found, or if
 // there is an underlying error at any stage of the restart.
-func (daemon *Daemon) ContainerRestart(name string, seconds *int) error {
+func (daemon *Daemon) ContainerRestart(name string, seconds *int, checkpoint string, checkpointDir string) error {
 	container, err := daemon.GetContainer(name)
 	if err != nil {
 		return err
@@ -23,7 +23,7 @@ func (daemon *Daemon) ContainerRestart(name string, seconds *int) error {
 		stopTimeout := container.StopTimeout()
 		seconds = &stopTimeout
 	}
-	if err := daemon.containerRestart(container, *seconds); err != nil {
+	if err := daemon.containerRestart(container, *seconds, checkpoint, checkpointDir); err != nil {
 		return fmt.Errorf("Cannot restart container %s: %v", name, err)
 	}
 	return nil
@@ -34,7 +34,7 @@ func (daemon *Daemon) ContainerRestart(name string, seconds *int) error {
 // container. When stopping, wait for the given duration in seconds to
 // gracefully stop, before forcefully terminating the container. If
 // given a negative duration, wait forever for a graceful stop.
-func (daemon *Daemon) containerRestart(container *container.Container, seconds int) error {
+func (daemon *Daemon) containerRestart(container *container.Container, seconds int, checkpoint string, checkpointDir string) error {
 
 	// Determine isolation. If not specified in the hostconfig, use daemon default.
 	actualIsolation := container.HostConfig.Isolation
@@ -74,7 +74,7 @@ func (daemon *Daemon) containerRestart(container *container.Container, seconds i
 		}
 	}
 
-	if err := daemon.containerStart(container, "", "", true); err != nil {
+	if err := daemon.containerStart(container, checkpoint, checkpointDir, true); err != nil {
 		return err
 	}
 

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -954,7 +954,7 @@ func (s *DockerSuite) TestContainerAPIRestart(c *check.C) {
 	defer cli.Close()
 
 	timeout := 1 * time.Second
-	err = cli.ContainerRestart(context.Background(), name, &timeout)
+	err = cli.ContainerRestart(context.Background(), name, &timeout, types.ContainerStartOptions{})
 	assert.NilError(c, err)
 
 	c.Assert(waitInspect(name, "{{ .State.Restarting  }} {{ .State.Running  }}", "false true", 15*time.Second), checker.IsNil)
@@ -970,7 +970,7 @@ func (s *DockerSuite) TestContainerAPIRestartNotimeoutParam(c *check.C) {
 	assert.NilError(c, err)
 	defer cli.Close()
 
-	err = cli.ContainerRestart(context.Background(), name, nil)
+	err = cli.ContainerRestart(context.Background(), name, nil, types.ContainerStartOptions{})
 	assert.NilError(c, err)
 
 	c.Assert(waitInspect(name, "{{ .State.Restarting  }} {{ .State.Running  }}", "false true", 15*time.Second), checker.IsNil)


### PR DESCRIPTION
Implements feature request #39342 

**- What I did**
Added support for `--checkpoint` and `--checkpoint-dir` parameters to container `restart` function, analogous to container `start` function. As explained in #39342, this will be helpful when restarting containers from a checkpoint over and over again (single command vs `docker stop` followed by `docker start --checkpoint`).

**- How I did it**
Functionality already exists for `start`, so this is mostly copy & paste.

**- How to verify it**
* Unit and integration tests are passing.
* Verified locally:

```
$ docker run --name counter --rm busybox /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'

0
1
2

$ docker checkpoint create --leave-running counter cp1

3
4
5

$ docker restart --checkpoint cp1 counter

3
4
5
```

**- Description for the changelog**
Adding `--checkpoint` and `--checkpoint-dir` to daemon, API, and client. If accepted, I'll follow-up with an update to the CLI project as well.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/336447/59150751-ba2d4580-89f6-11e9-85ca-3c4d85561aaa.png)
