### PR TITLE
Windows: TerminateOnLastHandleClosed

### DIFF
--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -188,12 +188,13 @@ func (c *client) Create(_ context.Context, id string, spec *specs.Spec, runtimeO
 func (c *client) createWindows(id string, spec *specs.Spec, runtimeOptions interface{}) error {
 	logger := c.logger.WithField("container", id)
 	configuration := &hcsshim.ContainerConfig{
-		SystemType:              "Container",
-		Name:                    id,
-		Owner:                   defaultOwner,
-		IgnoreFlushesDuringBoot: spec.Windows.IgnoreFlushesDuringBoot,
-		HostName:                spec.Hostname,
-		HvPartition:             false,
+		SystemType:                  "Container",
+		Name:                        id,
+		Owner:                       defaultOwner,
+		IgnoreFlushesDuringBoot:     spec.Windows.IgnoreFlushesDuringBoot,
+		HostName:                    spec.Hostname,
+		HvPartition:                 false,
+		TerminateOnLastHandleClosed: true,
 	}
 
 	c.extractResourcesFromSpec(spec, configuration)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

No idea how no-one had noticed this before, but it's been like this
forever. Verified that running a container and killing the daemon
does now kill the container. (Note this is in the v1 schema path,
and already correct in the v2 schema runtime when using containerd.)

@jterry75 FYI. 
