### PR TITLE
Create SECURITY.md for GitHub security policy page

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Reporting security issues
+
+The Moby maintainers take security seriously. If you discover a security issue, please bring it to their attention right away!
+
+### Reporting a Vulnerability
+
+Please **DO NOT** file a public issue, instead send your report privately to security@docker.com.
+
+Security reports are greatly appreciated and we will publicly thank you for it. We also like to send gifts—if you're into schwag, make sure to let us know. We currently do not offer a paid security bounty program, but are not ruling it out in the future.


### PR DESCRIPTION
**- What I did:**
Added a security policy to Moby's [security policy page](https://github.com/moby/moby/security/policy) that uses a SECURITY.md file from the repository to show the project's security policy.

**- How I did it:**
By taking the current information of how to report bugs to the [Moby](https://github.com/moby/moby) project and adding it to an adequate section.

**- How to verify it:**
By going to the [security policy page](https://github.com/moby/moby/security/policy)

**- Why is this needed:**
Adding this file makes it easier for security researchers to learn about the correct place to report a vulnerability in the [Moby](https://github.com/moby/moby) project.

**- Description for the changelog**
Create SECURITY.md for GitHub security policy page

**- A picture of a cute animal (not mandatory but encouraged)**
![Cute dog!](https://thehappypuppysite.com/wp-content/uploads/2017/09/cute4.jpg)