### PR TITLE
Update SECURITY.md to have an option to keep name anonymous if requested

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,4 +6,4 @@ The Moby maintainers take security seriously. If you discover a security issue, 
 
 Please **DO NOT** file a public issue, instead send your report privately to security@docker.com.
 
-Security reports are greatly appreciated and we will publicly thank you for it. We also like to send gifts—if you're into schwag, make sure to let us know. We currently do not offer a paid security bounty program, but are not ruling it out in the future.
+Security reports are greatly appreciated and we will publicly thank you for it, although we keep your name confidential if you request it. We also like to send gifts—if you're into schwag, make sure to let us know. We currently do not offer a paid security bounty program, but are not ruling it out in the future.


### PR DESCRIPTION
Update SECURITY.md to have an option to keep name anonymous if requested

Note this is a follow up on #39378, think it makes sense to allow people keep their name confidential for vulnerability findings.

/cc @cpuguy83 @justincormack @thaJeztah 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
