### PR TITLE
Revert "validate: temporarily disable deprecate-integration-cli as part of a revert"

### DIFF
--- a/hack/validate/default
+++ b/hack/validate/default
@@ -14,4 +14,4 @@ export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . ${SCRIPTDIR}/toml
 . ${SCRIPTDIR}/changelog-well-formed
 . ${SCRIPTDIR}/changelog-date-descending
-#. ${SCRIPTDIR}/deprecate-integration-cli
+. ${SCRIPTDIR}/deprecate-integration-cli


### PR DESCRIPTION
This reverts commit 3f1cdd5364d87f9a4fa4f62428f4e4bccbb594e4.

Signed-off-by: Tibor Vass <tibor@docker.com>
