### PR TITLE
Add info OSVersion to API changelog.

### DIFF
--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -28,6 +28,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   `private` to create the container in its own private cgroup namespace.  The per-daemon
   default is `host`, and can be changed by using the`CgroupNamespaceMode` daemon configuration
   parameter.
+* `GET /info` now  returns an `OSVersion` field, containing the operating system's
+  version. This change is not versioned, and affects all API versions if the daemon
+  has this patch.
 
 ## v1.40 API changes
 


### PR DESCRIPTION
This was added in d363a1881ec256e1be5a48a90046ff16e84ddc02 (moby/moby#38349),
but not yet added to the API history.

