### PR TITLE
Allow communication over internal macvlan network with config-from in swarm

### DIFF
--- a/vendor/github.com/docker/libnetwork/controller.go
+++ b/vendor/github.com/docker/libnetwork/controller.go
@@ -794,6 +794,7 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 	// From this point on, we need the network specific configuration,
 	// which may come from a configuration-only network
 	if network.configFrom != "" {
+		internal := network.internal
 		t, err = c.getConfigNetwork(network.configFrom)
 		if err != nil {
 			return nil, types.NotFoundErrorf("configuration network %q does not exist", network.configFrom)
@@ -801,6 +802,8 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 		if err = t.applyConfigurationTo(network); err != nil {
 			return nil, types.InternalErrorf("Failed to apply configuration: %v", err)
 		}
+		network.internal = internal
+		network.generic[netlabel.Internal] = true
 		defer func() {
 			if err == nil {
 				if err := t.getEpCnt().IncEndpointCnt(); err != nil {

--- a/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_joinleave.go
+++ b/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_joinleave.go
@@ -39,38 +39,40 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		return fmt.Errorf("could not find endpoint with id %s", eid)
 	}
 	// parse and match the endpoint address with the available v4 subnets
-	if len(n.config.Ipv4Subnets) > 0 {
-		s := n.getSubnetforIPv4(ep.addr)
-		if s == nil {
-			return fmt.Errorf("could not find a valid ipv4 subnet for endpoint %s", eid)
+	if !n.config.Internal {
+		if len(n.config.Ipv4Subnets) > 0 {
+			s := n.getSubnetforIPv4(ep.addr)
+			if s == nil {
+				return fmt.Errorf("could not find a valid ipv4 subnet for endpoint %s", eid)
+			}
+			v4gw, _, err := net.ParseCIDR(s.GwIP)
+			if err != nil {
+				return fmt.Errorf("gateway %s is not a valid ipv4 address: %v", s.GwIP, err)
+			}
+			err = jinfo.SetGateway(v4gw)
+			if err != nil {
+				return err
+			}
+			logrus.Debugf("Macvlan Endpoint Joined with IPv4_Addr: %s, Gateway: %s, MacVlan_Mode: %s, Parent: %s",
+				ep.addr.IP.String(), v4gw.String(), n.config.MacvlanMode, n.config.Parent)
 		}
-		v4gw, _, err := net.ParseCIDR(s.GwIP)
-		if err != nil {
-			return fmt.Errorf("gateway %s is not a valid ipv4 address: %v", s.GwIP, err)
+		// parse and match the endpoint address with the available v6 subnets
+		if len(n.config.Ipv6Subnets) > 0 {
+			s := n.getSubnetforIPv6(ep.addrv6)
+			if s == nil {
+				return fmt.Errorf("could not find a valid ipv6 subnet for endpoint %s", eid)
+			}
+			v6gw, _, err := net.ParseCIDR(s.GwIP)
+			if err != nil {
+				return fmt.Errorf("gateway %s is not a valid ipv6 address: %v", s.GwIP, err)
+			}
+			err = jinfo.SetGatewayIPv6(v6gw)
+			if err != nil {
+				return err
+			}
+			logrus.Debugf("Macvlan Endpoint Joined with IPv6_Addr: %s Gateway: %s MacVlan_Mode: %s, Parent: %s",
+				ep.addrv6.IP.String(), v6gw.String(), n.config.MacvlanMode, n.config.Parent)
 		}
-		err = jinfo.SetGateway(v4gw)
-		if err != nil {
-			return err
-		}
-		logrus.Debugf("Macvlan Endpoint Joined with IPv4_Addr: %s, Gateway: %s, MacVlan_Mode: %s, Parent: %s",
-			ep.addr.IP.String(), v4gw.String(), n.config.MacvlanMode, n.config.Parent)
-	}
-	// parse and match the endpoint address with the available v6 subnets
-	if len(n.config.Ipv6Subnets) > 0 {
-		s := n.getSubnetforIPv6(ep.addrv6)
-		if s == nil {
-			return fmt.Errorf("could not find a valid ipv6 subnet for endpoint %s", eid)
-		}
-		v6gw, _, err := net.ParseCIDR(s.GwIP)
-		if err != nil {
-			return fmt.Errorf("gateway %s is not a valid ipv6 address: %v", s.GwIP, err)
-		}
-		err = jinfo.SetGatewayIPv6(v6gw)
-		if err != nil {
-			return err
-		}
-		logrus.Debugf("Macvlan Endpoint Joined with IPv6_Addr: %s Gateway: %s MacVlan_Mode: %s, Parent: %s",
-			ep.addrv6.IP.String(), v6gw.String(), n.config.MacvlanMode, n.config.Parent)
 	}
 	iNames := jinfo.InterfaceName()
 	err = iNames.SetNames(vethName, containerVethPrefix)

--- a/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_network.go
@@ -188,8 +188,6 @@ func parseNetworkOptions(id string, option options.Generic) (*configuration, err
 	// setting the parent to "" will trigger an isolated network dummy parent link
 	if _, ok := option[netlabel.Internal]; ok {
 		config.Internal = true
-		// empty --parent= and --internal are handled the same.
-		config.Parent = ""
 	}
 
 	return config, nil


### PR DESCRIPTION
"fixes #39392"

**- What I did**
Macvlan internal network is able to interconnect containers and other systems on different nodes in VLAN.
Internal network should not change container's default gateway.

**- How I did it**
Macvlan is no longer using just dummy interface but the one from config-only network

**- How to verify it**
Create two config-only networks on two nodes and container on each node.
Containers should be able to reach each other.

**- Description for the changelog**
Allow communication over internal macvlan network with config-from in swarm