### PR TITLE
Add support for filtering configs by names param

### DIFF
--- a/daemon/cluster/filters.go
+++ b/daemon/cluster/filters.go
@@ -110,6 +110,7 @@ func newListSecretsFilters(filter filters.Args) (*swarmapi.ListSecretsRequest_Fi
 
 func newListConfigsFilters(filter filters.Args) (*swarmapi.ListConfigsRequest_Filters, error) {
 	accepted := map[string]bool{
+		"names": true,
 		"name":  true,
 		"id":    true,
 		"label": true,
@@ -118,6 +119,7 @@ func newListConfigsFilters(filter filters.Args) (*swarmapi.ListConfigsRequest_Fi
 		return nil, err
 	}
 	return &swarmapi.ListConfigsRequest_Filters{
+		Names:        filter.Get("names"),
 		NamePrefixes: filter.Get("name"),
 		IDPrefixes:   filter.Get("id"),
 		Labels:       runconfigopts.ConvertKVStringsToMap(filter.Get("label")),

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -58,6 +58,11 @@ func TestConfigList(t *testing.T) {
 		filters  filters.Args
 		expected []string
 	}{
+		// test filter by name `config ls --filter names=xxx`
+		{
+			filters:  filters.NewArgs(filters.Arg("names", testName0)),
+			expected: []string{testName0},
+		},
 		// test filter by name `config ls --filter name=xxx`
 		{
 			filters:  filters.NewArgs(filters.Arg("name", testName0)),

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -71,6 +71,11 @@ func TestSecretList(t *testing.T) {
 		filters  filters.Args
 		expected []string
 	}{
+		// test filter by name `secret ls --filter names=xxx`
+		{
+			filters:  filters.NewArgs(filters.Arg("names", testName0)),
+			expected: []string{testName0},
+		},
 		// test filter by name `secret ls --filter name=xxx`
 		{
 			filters:  filters.NewArgs(filters.Arg("name", testName0)),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The list configs endpoint `/configs/` supports a set of filters. The [API documentation](https://docs.docker.com/engine/api/v1.39/#tag/Config) states that one of these filters is `names` which I understand is an exact match while the other filter `name` is a prefix match. When calling the API with the `names` filter a HTTP 400 is returned with the error "Invalid filter 'names'". 

This felt weird since the `/secrets/` endpoint support `names` just fine. This led me to dig into the code and from what I could find the configs-backend actually supports the `names` filter but it's just not added to the accepted filters and passed to the backend. So I fixed that.

I also added a test for secrets to be filtered by `names` (it already works fine but it had no test).

**- How I did it**
Added `names` as an accepted filter to configs listing and passed it to the backend.

**- How to verify it**
I've updated the integration test for config listing to also test the `names` filter. Without my change it fails with the error "Invalid filter 'names'" and with the change it passes just fine and returns the filtered config.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix support for adding `names` filter to config listing.
