### PR TITLE
Adding ability to change max download attempts

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/registry"
 	"github.com/spf13/pflag"
-	"github.com/docker/docker/distribution/xfer"
+	//"github.com/docker/docker/distribution/xfer"
 )
 
 const (

--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -85,7 +85,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 
 	conf.MaxConcurrentDownloads = &maxConcurrentDownloads
 	conf.MaxConcurrentUploads = &maxConcurrentUploads
-	xfer.MaxDownloadAttempts = &maxDownloadAttempts
+	conf.MaxDownloadAttempts = &maxDownloadAttempts
 	return nil
 }
 

--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -16,7 +16,7 @@ const (
 
 // installCommonConfigFlags adds flags to the pflag.FlagSet to configure the daemon
 func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
-	var maxConcurrentDownloads, maxConcurrentUploads int
+	var maxConcurrentDownloads, maxConcurrentUploads, maxDownloadAttempts int
 	defaultPidFile, err := getDefaultPidFile()
 	if err != nil {
 		return err
@@ -69,6 +69,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.StringVar(&conf.CorsHeaders, "api-cors-header", "", "Set CORS headers in the Engine API")
 	flags.IntVar(&maxConcurrentDownloads, "max-concurrent-downloads", config.DefaultMaxConcurrentDownloads, "Set the max concurrent downloads for each pull")
 	flags.IntVar(&maxConcurrentUploads, "max-concurrent-uploads", config.DefaultMaxConcurrentUploads, "Set the max concurrent uploads for each push")
+	flags.IntVar(&maxDownloadAttempts, "max-concurrent-uploads", config.DefaultDownloadAttempts, "Set the max download attempts for each pull")
 	flags.IntVar(&conf.ShutdownTimeout, "shutdown-timeout", defaultShutdownTimeout, "Set the default shutdown timeout")
 	flags.IntVar(&conf.NetworkDiagnosticPort, "network-diagnostic-port", 0, "TCP port number of the network diagnostic server")
 	flags.MarkHidden("network-diagnostic-port")
@@ -83,6 +84,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 
 	conf.MaxConcurrentDownloads = &maxConcurrentDownloads
 	conf.MaxConcurrentUploads = &maxConcurrentUploads
+	conf.MaxDownloadAttempts = &maxDownloadAttempts
 	return nil
 }
 

--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -69,7 +69,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.StringVar(&conf.CorsHeaders, "api-cors-header", "", "Set CORS headers in the Engine API")
 	flags.IntVar(&maxConcurrentDownloads, "max-concurrent-downloads", config.DefaultMaxConcurrentDownloads, "Set the max concurrent downloads for each pull")
 	flags.IntVar(&maxConcurrentUploads, "max-concurrent-uploads", config.DefaultMaxConcurrentUploads, "Set the max concurrent uploads for each push")
-	flags.IntVar(&maxDownloadAttempts, "max-concurrent-uploads", config.DefaultDownloadAttempts, "Set the max download attempts for each pull")
+	flags.IntVar(&maxDownloadAttempts, "max-download-attemtps", config.DefaultDownloadAttempts, "Set the max download attempts for each pull")
 	flags.IntVar(&conf.ShutdownTimeout, "shutdown-timeout", defaultShutdownTimeout, "Set the default shutdown timeout")
 	flags.IntVar(&conf.NetworkDiagnosticPort, "network-diagnostic-port", 0, "TCP port number of the network diagnostic server")
 	flags.MarkHidden("network-diagnostic-port")

--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/registry"
 	"github.com/spf13/pflag"
-	//"github.com/docker/docker/distribution/xfer"
+	"github.com/docker/docker/distribution/xfer"
 )
 
 const (
@@ -85,7 +85,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 
 	conf.MaxConcurrentDownloads = &maxConcurrentDownloads
 	conf.MaxConcurrentUploads = &maxConcurrentUploads
-	conf.MaxDownloadAttempts = &maxDownloadAttempts
+	xfer.MaxDownloadAttempts = &maxDownloadAttempts
 	return nil
 }
 

--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/registry"
 	"github.com/spf13/pflag"
-	"github.com/docker/docker/distribution/xfer"
 )
 
 const (
@@ -85,7 +84,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 
 	conf.MaxConcurrentDownloads = &maxConcurrentDownloads
 	conf.MaxConcurrentUploads = &maxConcurrentUploads
-	xfer.MaxDownloadAttempts = &maxDownloadAttempts
+	conf.MaxDownloadAttempts = &maxDownloadAttempts
 	return nil
 }
 

--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/registry"
 	"github.com/spf13/pflag"
+	"github.com/docker/docker/distribution/xfer"
 )
 
 const (
@@ -84,7 +85,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 
 	conf.MaxConcurrentDownloads = &maxConcurrentDownloads
 	conf.MaxConcurrentUploads = &maxConcurrentUploads
-	conf.MaxDownloadAttempts = &maxDownloadAttempts
+	xfer.MaxDownloadAttempts = &maxDownloadAttempts
 	return nil
 }
 

--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -85,6 +85,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 
 	conf.MaxConcurrentDownloads = &maxConcurrentDownloads
 	conf.MaxConcurrentUploads = &maxConcurrentUploads
+	conf.MaxDownloadAttempts = &maxDownloadAttempts
 	xfer.MaxDownloadAttempts = &maxDownloadAttempts
 	return nil
 }

--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -85,7 +85,6 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 
 	conf.MaxConcurrentDownloads = &maxConcurrentDownloads
 	conf.MaxConcurrentUploads = &maxConcurrentUploads
-	conf.MaxDownloadAttempts = &maxDownloadAttempts
 	xfer.MaxDownloadAttempts = &maxDownloadAttempts
 	return nil
 }

--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -69,7 +69,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.StringVar(&conf.CorsHeaders, "api-cors-header", "", "Set CORS headers in the Engine API")
 	flags.IntVar(&maxConcurrentDownloads, "max-concurrent-downloads", config.DefaultMaxConcurrentDownloads, "Set the max concurrent downloads for each pull")
 	flags.IntVar(&maxConcurrentUploads, "max-concurrent-uploads", config.DefaultMaxConcurrentUploads, "Set the max concurrent uploads for each push")
-	flags.IntVar(&maxDownloadAttempts, "max-download-attemtps", config.DefaultDownloadAttempts, "Set the max download attempts for each pull")
+	flags.IntVar(&maxDownloadAttempts, "max-download-attempts", config.DefaultDownloadAttempts, "Set the max download attempts for each pull")
 	flags.IntVar(&conf.ShutdownTimeout, "shutdown-timeout", defaultShutdownTimeout, "Set the default shutdown timeout")
 	flags.IntVar(&conf.NetworkDiagnosticPort, "network-diagnostic-port", 0, "TCP port number of the network diagnostic server")
 	flags.MarkHidden("network-diagnostic-port")

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -31,6 +31,10 @@ const (
 	// maximum number of uploads that
 	// may take place at a time for each push.
 	DefaultMaxConcurrentUploads = 5
+	// DefaultDownloadAttempts is the default value for
+	// maximum number of attempts that
+	// may take place at a time for each pull when the connection is lost.
+	DefaultDownloadAttempts = 5
 	// StockRuntimeName is the reserved name/alias used to represent the
 	// OCI runtime being shipped with the docker daemon package.
 	StockRuntimeName = "runc"
@@ -159,6 +163,10 @@ type CommonConfig struct {
 	// MaxConcurrentUploads is the maximum number of uploads that
 	// may take place at a time for each push.
 	MaxConcurrentUploads *int `json:"max-concurrent-uploads,omitempty"`
+
+	// MaxDownloadAttempts is the maximum number of attempts that
+	// may take place at a time for each push.
+	MaxDownloadAttempts *int `json:"max-download-attempts,omitempty"`
 
 	// ShutdownTimeout is the timeout value (in seconds) the daemon will wait for the container
 	// to stop when daemon is being shutdown
@@ -519,7 +527,7 @@ func findConfigurationConflicts(config map[string]interface{}, flags *pflag.Flag
 
 // Validate validates some specific configs.
 // such as config.DNS, config.Labels, config.DNSSearch,
-// as well as config.MaxConcurrentDownloads, config.MaxConcurrentUploads.
+// as well as config.MaxConcurrentDownloads, config.MaxConcurrentUploads and config.MaxDownloadAttempts.
 func Validate(config *Config) error {
 	// validate DNS
 	for _, dns := range config.DNS {
@@ -548,6 +556,10 @@ func Validate(config *Config) error {
 	// validate MaxConcurrentUploads
 	if config.MaxConcurrentUploads != nil && *config.MaxConcurrentUploads < 0 {
 		return fmt.Errorf("invalid max concurrent uploads: %d", *config.MaxConcurrentUploads)
+	}
+	// validate MaxDownloadAttempts
+	if config.MaxDownloadAttempts != nil && *config.MaxDownloadAttempts < 0 {
+		return fmt.Errorf("invalid max concurrent uploads: %d", *config.MaxDownloadAttempts)
 	}
 
 	// validate that "default" runtime is not reset

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -559,7 +559,7 @@ func Validate(config *Config) error {
 	}
 	// validate MaxDownloadAttempts
 	if config.MaxDownloadAttempts != nil && *config.MaxDownloadAttempts < 0 {
-		return fmt.Errorf("invalid max concurrent uploads: %d", *config.MaxDownloadAttempts)
+		return fmt.Errorf("invalid max download attempts: %d", *config.MaxDownloadAttempts)
 	}
 
 	// validate that "default" runtime is not reset

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -294,6 +294,17 @@ func TestValidateConfigurationErrors(t *testing.T) {
 		{
 			config: &Config{
 				CommonConfig: CommonConfig{
+					MaxDownloadAttemts: &minusNumber,
+					// This is weird...
+					ValuesSet: map[string]interface{}{
+						"max-download-attempts": -1,
+					},
+				},
+			},
+		},
+		{
+			config: &Config{
+				CommonConfig: CommonConfig{
 					NodeGenericResources: []string{"foo"},
 				},
 			},
@@ -358,6 +369,17 @@ func TestValidateConfiguration(t *testing.T) {
 					// This is weird...
 					ValuesSet: map[string]interface{}{
 						"max-concurrent-uploads": -1,
+					},
+				},
+			},
+		},
+		{
+			config: &Config{
+				CommonConfig: CommonConfig{
+					MaxDownloadAttemts: &minusNumber,
+					// This is weird...
+					ValuesSet: map[string]interface{}{
+						"max-download-attempts": -1,
 					},
 				},
 			},

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -294,7 +294,7 @@ func TestValidateConfigurationErrors(t *testing.T) {
 		{
 			config: &Config{
 				CommonConfig: CommonConfig{
-					MaxDownloadAttemts: &minusNumber,
+					MaxDownloadAttempts: &minusNumber,
 					// This is weird...
 					ValuesSet: map[string]interface{}{
 						"max-download-attempts": -1,
@@ -376,7 +376,7 @@ func TestValidateConfiguration(t *testing.T) {
 		{
 			config: &Config{
 				CommonConfig: CommonConfig{
-					MaxDownloadAttemts: &minusNumber,
+					MaxDownloadAttempts: &minusNumber,
 					// This is weird...
 					ValuesSet: map[string]interface{}{
 						"max-download-attempts": -1,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1054,7 +1054,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 
 	go d.execCommandGC()
 
-	xfer.MaxDownloadAttempts = *config.MaxDownloadAttempts
+	xfer.MaxDownloadAttempts = config.MaxDownloadAttempts
 
 	d.containerd, err = libcontainerd.NewClient(ctx, d.containerdCli, filepath.Join(config.ExecRoot, "containerd"), ContainersNamespace, d)
 	if err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1048,7 +1048,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		LayerStores:               layerStores,
 		MaxConcurrentDownloads:    *config.MaxConcurrentDownloads,
 		MaxConcurrentUploads:      *config.MaxConcurrentUploads,
-		MaxDownloadAttempts:	   *config.MaxDownloadAttempts
+		MaxDownloadAttempts:	   *config.MaxDownloadAttempts,
 		ReferenceStore:            rs,
 		RegistryService:           registryService,
 	})

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1055,7 +1055,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	go d.execCommandGC()
 
 	// set max download attempts 
-	xfer.MaxDownloadAttempts = *config.MaxDownloadAttempts
+	xfer.MaxDownloadAttempts = config.MaxDownloadAttempts
 
 	d.containerd, err = libcontainerd.NewClient(ctx, d.containerdCli, filepath.Join(config.ExecRoot, "containerd"), ContainersNamespace, d)
 	if err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -43,7 +43,6 @@ import (
 	"github.com/moby/buildkit/util/resolver"
 	"github.com/moby/buildkit/util/tracing"
 	"github.com/sirupsen/logrus"
-	//"github.com/docker/docker/distribution/xfer"
 
 	// register graph drivers
 	_ "github.com/docker/docker/daemon/graphdriver/register"

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1055,9 +1055,6 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 
 	go d.execCommandGC()
 
-	// set max download attempts 
-	//xfer.MaxDownloadAttempts = config.MaxDownloadAttempts
-
 	d.containerd, err = libcontainerd.NewClient(ctx, d.containerdCli, filepath.Join(config.ExecRoot, "containerd"), ContainersNamespace, d)
 	if err != nil {
 		return nil, err

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1047,6 +1047,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		LayerStores:               layerStores,
 		MaxConcurrentDownloads:    *config.MaxConcurrentDownloads,
 		MaxConcurrentUploads:      *config.MaxConcurrentUploads,
+		MaxDownloadAttempts:	   *config.MaxDownloadAttempts,
 		ReferenceStore:            rs,
 		RegistryService:           registryService,
 	})

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1054,6 +1054,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 
 	go d.execCommandGC()
 
+	// set max download attempts 
 	xfer.MaxDownloadAttempts = config.MaxDownloadAttempts
 
 	d.containerd, err = libcontainerd.NewClient(ctx, d.containerdCli, filepath.Join(config.ExecRoot, "containerd"), ContainersNamespace, d)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -43,6 +43,7 @@ import (
 	"github.com/moby/buildkit/util/resolver"
 	"github.com/moby/buildkit/util/tracing"
 	"github.com/sirupsen/logrus"
+	"github.com/docker/docker/distribution/xfer"
 
 	// register graph drivers
 	_ "github.com/docker/docker/daemon/graphdriver/register"
@@ -1052,6 +1053,8 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	})
 
 	go d.execCommandGC()
+
+	xfer.MaxDownloadAttempts = *config.MaxDownloadAttempts
 
 	d.containerd, err = libcontainerd.NewClient(ctx, d.containerdCli, filepath.Join(config.ExecRoot, "containerd"), ContainersNamespace, d)
 	if err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1055,7 +1055,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	go d.execCommandGC()
 
 	// set max download attempts 
-	xfer.MaxDownloadAttempts = config.MaxDownloadAttempts
+	xfer.MaxDownloadAttempts = *config.MaxDownloadAttempts
 
 	d.containerd, err = libcontainerd.NewClient(ctx, d.containerdCli, filepath.Join(config.ExecRoot, "containerd"), ContainersNamespace, d)
 	if err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1047,7 +1047,6 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		LayerStores:               layerStores,
 		MaxConcurrentDownloads:    *config.MaxConcurrentDownloads,
 		MaxConcurrentUploads:      *config.MaxConcurrentUploads,
-		MaxDownloadAttempts:	   *config.MaxDownloadAttempts,
 		ReferenceStore:            rs,
 		RegistryService:           registryService,
 	})

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -43,7 +43,7 @@ import (
 	"github.com/moby/buildkit/util/resolver"
 	"github.com/moby/buildkit/util/tracing"
 	"github.com/sirupsen/logrus"
-	"github.com/docker/docker/distribution/xfer"
+	//"github.com/docker/docker/distribution/xfer"
 
 	// register graph drivers
 	_ "github.com/docker/docker/daemon/graphdriver/register"
@@ -1048,6 +1048,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		LayerStores:               layerStores,
 		MaxConcurrentDownloads:    *config.MaxConcurrentDownloads,
 		MaxConcurrentUploads:      *config.MaxConcurrentUploads,
+		MaxDownloadAttempts:	   *config.MaxDownloadAttempts
 		ReferenceStore:            rs,
 		RegistryService:           registryService,
 	})
@@ -1055,7 +1056,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	go d.execCommandGC()
 
 	// set max download attempts 
-	xfer.MaxDownloadAttempts = config.MaxDownloadAttempts
+	//xfer.MaxDownloadAttempts = config.MaxDownloadAttempts
 
 	d.containerd, err = libcontainerd.NewClient(ctx, d.containerdCli, filepath.Join(config.ExecRoot, "containerd"), ContainersNamespace, d)
 	if err != nil {

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -37,7 +37,6 @@ type ImageServiceConfig struct {
 	LayerStores               map[string]layer.Store
 	MaxConcurrentDownloads    int
 	MaxConcurrentUploads      int
-	MaxDownloadAttempts		  int
 	ReferenceStore            dockerreference.Store
 	RegistryService           registry.Service
 }
@@ -46,7 +45,6 @@ type ImageServiceConfig struct {
 func NewImageService(config ImageServiceConfig) *ImageService {
 	logrus.Debugf("Max Concurrent Downloads: %d", config.MaxConcurrentDownloads)
 	logrus.Debugf("Max Concurrent Uploads: %d", config.MaxConcurrentUploads)
-	logrus.Debugf("Max DownloadAttemtps: %d", config.MaxDownloadAttempts)
 	return &ImageService{
 		containers:                config.ContainerStore,
 		distributionMetadataStore: config.DistributionMetadataStore,

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -37,7 +37,7 @@ type ImageServiceConfig struct {
 	LayerStores               map[string]layer.Store
 	MaxConcurrentDownloads    int
 	MaxConcurrentUploads      int
-	MaxDownloadAttempts 	  int
+	MaxDownloadAttempts		  int
 	ReferenceStore            dockerreference.Store
 	RegistryService           registry.Service
 }

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -37,6 +37,7 @@ type ImageServiceConfig struct {
 	LayerStores               map[string]layer.Store
 	MaxConcurrentDownloads    int
 	MaxConcurrentUploads      int
+	MaxDownloadAttempts 	  int
 	ReferenceStore            dockerreference.Store
 	RegistryService           registry.Service
 }
@@ -45,7 +46,7 @@ type ImageServiceConfig struct {
 func NewImageService(config ImageServiceConfig) *ImageService {
 	logrus.Debugf("Max Concurrent Downloads: %d", config.MaxConcurrentDownloads)
 	logrus.Debugf("Max Concurrent Uploads: %d", config.MaxConcurrentUploads)
-	
+	logrus.Debugf("Max Download Attempts: %d", config.MaxDownloadAttempts)
 	return &ImageService{
 		containers:                config.ContainerStore,
 		distributionMetadataStore: config.DistributionMetadataStore,

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -37,6 +37,7 @@ type ImageServiceConfig struct {
 	LayerStores               map[string]layer.Store
 	MaxConcurrentDownloads    int
 	MaxConcurrentUploads      int
+	MaxDownloadAttempts		  int
 	ReferenceStore            dockerreference.Store
 	RegistryService           registry.Service
 }
@@ -45,10 +46,11 @@ type ImageServiceConfig struct {
 func NewImageService(config ImageServiceConfig) *ImageService {
 	logrus.Debugf("Max Concurrent Downloads: %d", config.MaxConcurrentDownloads)
 	logrus.Debugf("Max Concurrent Uploads: %d", config.MaxConcurrentUploads)
+	logrus.Debugf("Max Download Attempts: %d", config.MaxDownloadAttempts)
 	return &ImageService{
 		containers:                config.ContainerStore,
 		distributionMetadataStore: config.DistributionMetadataStore,
-		downloadManager:           xfer.NewLayerDownloadManager(config.LayerStores, config.MaxConcurrentDownloads),
+		downloadManager:           xfer.NewLayerDownloadManager(config.LayerStores, config.MaxConcurrentDownloads, config.MaxConcurrentDownloads),
 		eventsService:             config.EventsService,
 		imageStore:                config.ImageStore,
 		layerStores:               config.LayerStores,

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -50,7 +50,7 @@ func NewImageService(config ImageServiceConfig) *ImageService {
 	return &ImageService{
 		containers:                config.ContainerStore,
 		distributionMetadataStore: config.DistributionMetadataStore,
-		downloadManager:           xfer.NewLayerDownloadManager(config.LayerStores, config.MaxConcurrentDownloads, config.MaxDownloadAttempts),
+		downloadManager:           xfer.NewLayerDownloadManager(config.LayerStores, config.MaxConcurrentDownloads),
 		eventsService:             config.EventsService,
 		imageStore:                config.ImageStore,
 		layerStores:               config.LayerStores,

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -37,7 +37,6 @@ type ImageServiceConfig struct {
 	LayerStores               map[string]layer.Store
 	MaxConcurrentDownloads    int
 	MaxConcurrentUploads      int
-	MaxDownloadAttempts		  int
 	ReferenceStore            dockerreference.Store
 	RegistryService           registry.Service
 }
@@ -46,7 +45,6 @@ type ImageServiceConfig struct {
 func NewImageService(config ImageServiceConfig) *ImageService {
 	logrus.Debugf("Max Concurrent Downloads: %d", config.MaxConcurrentDownloads)
 	logrus.Debugf("Max Concurrent Uploads: %d", config.MaxConcurrentUploads)
-	logrus.Debugf("Max Download Attempts: %d", config.MaxDownloadAttempts)
 	return &ImageService{
 		containers:                config.ContainerStore,
 		distributionMetadataStore: config.DistributionMetadataStore,

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -37,6 +37,7 @@ type ImageServiceConfig struct {
 	LayerStores               map[string]layer.Store
 	MaxConcurrentDownloads    int
 	MaxConcurrentUploads      int
+	MaxDownloadAttempts		  int
 	ReferenceStore            dockerreference.Store
 	RegistryService           registry.Service
 }
@@ -45,10 +46,11 @@ type ImageServiceConfig struct {
 func NewImageService(config ImageServiceConfig) *ImageService {
 	logrus.Debugf("Max Concurrent Downloads: %d", config.MaxConcurrentDownloads)
 	logrus.Debugf("Max Concurrent Uploads: %d", config.MaxConcurrentUploads)
+	logrus.Debugf("Max DownloadAttemtps: %d", config.MaxDownloadAttempts)
 	return &ImageService{
 		containers:                config.ContainerStore,
 		distributionMetadataStore: config.DistributionMetadataStore,
-		downloadManager:           xfer.NewLayerDownloadManager(config.LayerStores, config.MaxConcurrentDownloads),
+		downloadManager:           xfer.NewLayerDownloadManager(config.LayerStores, config.MaxConcurrentDownloads, config.MaxDownloadAttempts),
 		eventsService:             config.EventsService,
 		imageStore:                config.ImageStore,
 		layerStores:               config.LayerStores,

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -37,7 +37,6 @@ type ImageServiceConfig struct {
 	LayerStores               map[string]layer.Store
 	MaxConcurrentDownloads    int
 	MaxConcurrentUploads      int
-	MaxDownloadAttempts		  int
 	ReferenceStore            dockerreference.Store
 	RegistryService           registry.Service
 }
@@ -46,7 +45,7 @@ type ImageServiceConfig struct {
 func NewImageService(config ImageServiceConfig) *ImageService {
 	logrus.Debugf("Max Concurrent Downloads: %d", config.MaxConcurrentDownloads)
 	logrus.Debugf("Max Concurrent Uploads: %d", config.MaxConcurrentUploads)
-	logrus.Debugf("Max DownloadAttempts: %d", config.MaxDownloadAttempts)
+	
 	return &ImageService{
 		containers:                config.ContainerStore,
 		distributionMetadataStore: config.DistributionMetadataStore,

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -37,6 +37,7 @@ type ImageServiceConfig struct {
 	LayerStores               map[string]layer.Store
 	MaxConcurrentDownloads    int
 	MaxConcurrentUploads      int
+	MaxDownloadAttempts		  int
 	ReferenceStore            dockerreference.Store
 	RegistryService           registry.Service
 }
@@ -45,6 +46,7 @@ type ImageServiceConfig struct {
 func NewImageService(config ImageServiceConfig) *ImageService {
 	logrus.Debugf("Max Concurrent Downloads: %d", config.MaxConcurrentDownloads)
 	logrus.Debugf("Max Concurrent Uploads: %d", config.MaxConcurrentUploads)
+	logrus.Debugf("Max DownloadAttempts: %d", config.MaxDownloadAttempts)
 	return &ImageService{
 		containers:                config.ContainerStore,
 		distributionMetadataStore: config.DistributionMetadataStore,

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -50,7 +50,7 @@ func NewImageService(config ImageServiceConfig) *ImageService {
 	return &ImageService{
 		containers:                config.ContainerStore,
 		distributionMetadataStore: config.DistributionMetadataStore,
-		downloadManager:           xfer.NewLayerDownloadManager(config.LayerStores, config.MaxConcurrentDownloads, config.MaxConcurrentDownloads),
+		downloadManager:           xfer.NewLayerDownloadManager(config.LayerStores, config.MaxConcurrentDownloads, config.MaxDownloadAttempts),
 		eventsService:             config.EventsService,
 		imageStore:                config.ImageStore,
 		layerStores:               config.LayerStores,

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -16,7 +16,7 @@ import (
 // - Daemon debug log level
 // - Daemon max concurrent downloads
 // - Daemon max concurrent uploads
-// - xfer max download attempts
+// - Daemon max download attempts
 // - Daemon shutdown timeout (in seconds)
 // - Cluster discovery (reconfigure and restart)
 // - Daemon labels
@@ -45,7 +45,7 @@ func (daemon *Daemon) Reload(conf *config.Config) (err error) {
 	}
 	daemon.reloadDebug(conf, attributes)
 	daemon.reloadMaxConcurrentDownloadsAndUploads(conf, attributes)
-	daemon.reloadMaxDownloadAttempts(conf, attributes)
+	//daemon.reloadMaxDownloadAttempts(conf, attributes)
 	daemon.reloadShutdownTimeout(conf, attributes)
 	daemon.reloadFeatures(conf, attributes)
 
@@ -114,19 +114,19 @@ func (daemon *Daemon) reloadMaxConcurrentDownloadsAndUploads(conf *config.Config
 
 // reloadMaxDownloadAttempts updates configuration with max concurrent
 // download attempts when a connection is lost and updates the passed attributes
-func (daemon *Daemon) reloadMaxDownloadAttempts(conf *config.Config, attributes map[string]string) {
+//func (daemon *Daemon) reloadMaxDownloadAttempts(conf *config.Config, attributes map[string]string) {
 	// If no value is set for max-download-attempts we assume it is the default value
 	// We always "reset" as the cost is lightweight and easy to maintain.
-	maxDownloadAttempts := config.DefaultDownloadAttempts
-	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
-		maxDownloadAttempts = *conf.MaxDownloadAttempts
-	}
-	daemon.configStore.MaxConcurrentDownloads = &maxDownloadAttempts
-	logrus.Debugf("Reset Max Download Attempts: %d", *daemon.configStore.MaxDownloadAttempts)
+//	maxDownloadAttempts := config.DefaultDownloadAttempts
+//	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
+//		maxDownloadAttempts = *conf.MaxDownloadAttempts
+//	}
+//	daemon.configStore.MaxDownloadAttempts = &maxDownloadAttempts
+//	logrus.Debugf("Reset Max Download Attempts: %d", *daemon.configStore.MaxDownloadAttempts)
 
 	// prepare reload event attributes with updatable configurations
-	attributes["max-download-attempts"] = fmt.Sprintf("%d", *daemon.configStore.MaxDownloadAttempts)
-}
+//	attributes["max-download-attempts"] = fmt.Sprintf("%d", *daemon.configStore.MaxDownloadAttempts)
+//}
 
 // reloadShutdownTimeout updates configuration with daemon shutdown timeout option
 // and updates the passed attributes

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -122,7 +122,7 @@ func (daemon *Daemon) reloadMaxDownloadAttempts(conf *config.Config, attributes 
 	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
 		maxDownloadAttempts = *conf.MaxDownloadAttempts
 	}
-	xfer.MaxDownloadAttempts = &maxDownloadAttempts
+	daemon.configStore.MaxConcurrentDownloads = &maxDownloadAttempts
 	logrus.Debugf("Reset Max Download Attempts: %d", *daemon.configStore.MaxDownloadAttempts)
 
 	// prepare reload event attributes with updatable configurations

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/discovery"
 	"github.com/sirupsen/logrus"
-	"github.com/docker/docker/distribution/xfer"
 )
 
 // Reload reads configuration changes and modifies the

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -115,19 +115,19 @@ func (daemon *Daemon) reloadMaxConcurrentDownloadsAndUploads(conf *config.Config
 
 // reloadMaxDownloadAttempts updates configuration with max concurrent
 // download attempts when a connection is lost and updates the passed attributes
-//func (daemon *Daemon) reloadMaxDownloadAttempts(conf *config.Config, attributes map[string]string) {
+func (daemon *Daemon) reloadMaxDownloadAttempts(conf *config.Config, attributes map[string]string) {
 	// If no value is set for max-download-attempts we assume it is the default value
 	// We always "reset" as the cost is lightweight and easy to maintain.
-//	maxDownloadAttempts := config.DefaultDownloadAttempts
-//	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
-//		maxDownloadAttempts = *conf.MaxDownloadAttempts
-//	}
-//	xfer.MaxDownloadAttempts = &maxDownloadAttempts
-//	logrus.Debugf("Reset Max Download Attempts: %d", *xfer.MaxDownloadAttempts)
+	maxDownloadAttempts := config.DefaultDownloadAttempts
+	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
+		maxDownloadAttempts = *conf.MaxDownloadAttempts
+	}
+	xfer.MaxDownloadAttempts = &maxDownloadAttempts
+	logrus.Debugf("Reset Max Download Attempts: %d", *xfer.MaxDownloadAttempts)
 
 	// prepare reload event attributes with updatable configurations
-//	attributes["max-download-attempts"] = fmt.Sprintf("%d", *xfer.MaxDownloadAttempts)
-//}
+	attributes["max-download-attempts"] = fmt.Sprintf("%d", *xfer.MaxDownloadAttempts)
+}
 
 // reloadShutdownTimeout updates configuration with daemon shutdown timeout option
 // and updates the passed attributes

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -125,10 +125,6 @@ func (daemon *Daemon) reloadMaxDownloadAttempts(conf *config.Config, attributes 
 	xfer.MaxDownloadAttempts = &maxDownloadAttempts
 	logrus.Debugf("Reset Max Download Attempts: %d", *xfer.MaxDownloadAttempts)
 
-	if daemon.imageService != nil {
-		daemon.imageService.UpdateConfig(&maxDownloadAttempts)
-	}
-
 	// prepare reload event attributes with updatable configurations
 	attributes["max-download-attempts"] = fmt.Sprintf("%d", *xfer.MaxDownloadAttempts)
 }

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -123,10 +123,10 @@ func (daemon *Daemon) reloadMaxDownloadAttempts(conf *config.Config, attributes 
 		maxDownloadAttempts = *conf.MaxDownloadAttempts
 	}
 	xfer.MaxDownloadAttempts = &maxDownloadAttempts
-	logrus.Debugf("Reset Max Download Attempts: %d", *xfer.MaxDownloadAttempts)
+	logrus.Debugf("Reset Max Download Attempts: %d", *daemon.configStore.MaxDownloadAttempts)
 
 	// prepare reload event attributes with updatable configurations
-	attributes["max-download-attempts"] = fmt.Sprintf("%d", *xfer.MaxDownloadAttempts)
+	attributes["max-download-attempts"] = fmt.Sprintf("%d", *daemon.configStore.MaxDownloadAttempts)
 }
 
 // reloadShutdownTimeout updates configuration with daemon shutdown timeout option

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -46,7 +46,7 @@ func (daemon *Daemon) Reload(conf *config.Config) (err error) {
 	daemon.reloadDebug(conf, attributes)
 	daemon.reloadMaxConcurrentDownloadsAndUploads(conf, attributes)
 	// FIX ME
-	//daemon.reloadMaxDownloadAttempts(conf, attributes)
+	daemon.reloadMaxDownloadAttempts(conf, attributes)
 	daemon.reloadShutdownTimeout(conf, attributes)
 	daemon.reloadFeatures(conf, attributes)
 
@@ -116,19 +116,19 @@ func (daemon *Daemon) reloadMaxConcurrentDownloadsAndUploads(conf *config.Config
 // FIX ME, it cannot find daemon.configStore.MaxDownloadAttempts
 // reloadMaxDownloadAttempts updates configuration with max concurrent
 // download attempts when a connection is lost and updates the passed attributes
-//func (daemon *Daemon) reloadMaxDownloadAttempts(conf *config.Config, attributes map[string]string) {
+func (daemon *Daemon) reloadMaxDownloadAttempts(conf *config.Config, attributes map[string]string) {
 	// If no value is set for max-download-attempts we assume it is the default value
 	// We always "reset" as the cost is lightweight and easy to maintain.
-//	maxDownloadAttempts := config.DefaultDownloadAttempts
-//	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
-//		maxDownloadAttempts = *conf.MaxDownloadAttempts
-//	}
-//	daemon.configStore.MaxDownloadAttempts = &maxDownloadAttempts
-//	logrus.Debugf("Reset Max Download Attempts: %d", *daemon.configStore.MaxDownloadAttempts)
+	maxDownloadAttempts := config.DefaultDownloadAttempts
+	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
+		maxDownloadAttempts = *conf.MaxDownloadAttempts
+	}
+	daemon.configStore.MaxDownloadAttempts = &maxDownloadAttempts
+	logrus.Debugf("Reset Max Download Attempts: %d", *daemon.configStore.MaxDownloadAttempts)
 
 	// prepare reload event attributes with updatable configurations
-//	attributes["max-download-attempts"] = fmt.Sprintf("%d", *daemon.configStore.MaxDownloadAttempts)
-//}
+	attributes["max-download-attempts"] = fmt.Sprintf("%d", *daemon.configStore.MaxDownloadAttempts)
+}
 
 // reloadShutdownTimeout updates configuration with daemon shutdown timeout option
 // and updates the passed attributes

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -45,7 +45,6 @@ func (daemon *Daemon) Reload(conf *config.Config) (err error) {
 	}
 	daemon.reloadDebug(conf, attributes)
 	daemon.reloadMaxConcurrentDownloadsAndUploads(conf, attributes)
-	// FIX ME
 	daemon.reloadMaxDownloadAttempts(conf, attributes)
 	daemon.reloadShutdownTimeout(conf, attributes)
 	daemon.reloadFeatures(conf, attributes)
@@ -113,7 +112,6 @@ func (daemon *Daemon) reloadMaxConcurrentDownloadsAndUploads(conf *config.Config
 	attributes["max-concurrent-uploads"] = fmt.Sprintf("%d", *daemon.configStore.MaxConcurrentUploads)
 }
 
-// FIX ME, it cannot find daemon.configStore.MaxDownloadAttempts
 // reloadMaxDownloadAttempts updates configuration with max concurrent
 // download attempts when a connection is lost and updates the passed attributes
 func (daemon *Daemon) reloadMaxDownloadAttempts(conf *config.Config, attributes map[string]string) {

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -115,19 +115,19 @@ func (daemon *Daemon) reloadMaxConcurrentDownloadsAndUploads(conf *config.Config
 
 // reloadMaxDownloadAttempts updates configuration with max concurrent
 // download attempts when a connection is lost and updates the passed attributes
-func (daemon *Daemon) reloadMaxDownloadAttempts(conf *config.Config, attributes map[string]string) {
+//func (daemon *Daemon) reloadMaxDownloadAttempts(conf *config.Config, attributes map[string]string) {
 	// If no value is set for max-download-attempts we assume it is the default value
 	// We always "reset" as the cost is lightweight and easy to maintain.
-	maxDownloadAttempts := config.DefaultDownloadAttempts
-	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
-		maxDownloadAttempts = *conf.MaxDownloadAttempts
-	}
-	xfer.MaxDownloadAttempts = &maxDownloadAttempts
-	logrus.Debugf("Reset Max Download Attempts: %d", *xfer.MaxDownloadAttempts)
+//	maxDownloadAttempts := config.DefaultDownloadAttempts
+//	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
+//		maxDownloadAttempts = *conf.MaxDownloadAttempts
+//	}
+//	xfer.MaxDownloadAttempts = &maxDownloadAttempts
+//	logrus.Debugf("Reset Max Download Attempts: %d", *xfer.MaxDownloadAttempts)
 
 	// prepare reload event attributes with updatable configurations
-	attributes["max-download-attempts"] = fmt.Sprintf("%d", *xfer.MaxDownloadAttempts)
-}
+//	attributes["max-download-attempts"] = fmt.Sprintf("%d", *xfer.MaxDownloadAttempts)
+//}
 
 // reloadShutdownTimeout updates configuration with daemon shutdown timeout option
 // and updates the passed attributes

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -45,6 +45,7 @@ func (daemon *Daemon) Reload(conf *config.Config) (err error) {
 	}
 	daemon.reloadDebug(conf, attributes)
 	daemon.reloadMaxConcurrentDownloadsAndUploads(conf, attributes)
+	// FIX ME
 	//daemon.reloadMaxDownloadAttempts(conf, attributes)
 	daemon.reloadShutdownTimeout(conf, attributes)
 	daemon.reloadFeatures(conf, attributes)
@@ -112,6 +113,7 @@ func (daemon *Daemon) reloadMaxConcurrentDownloadsAndUploads(conf *config.Config
 	attributes["max-concurrent-uploads"] = fmt.Sprintf("%d", *daemon.configStore.MaxConcurrentUploads)
 }
 
+// FIX ME, it cannot find daemon.configStore.MaxDownloadAttempts
 // reloadMaxDownloadAttempts updates configuration with max concurrent
 // download attempts when a connection is lost and updates the passed attributes
 //func (daemon *Daemon) reloadMaxDownloadAttempts(conf *config.Config, attributes map[string]string) {

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -122,15 +122,15 @@ func (daemon *Daemon) reloadMaxDownloadAttempts(conf *config.Config, attributes 
 	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
 		maxDownloadAttempts = *conf.MaxDownloadAttempts
 	}
-	xfer.maxDownloadAttempts = &maxDownloadAttempts
-	logrus.Debugf("Reset Max Download Attempts: %d", *xfer.maxDownloadAttempts)
+	xfer.MaxDownloadAttempts = &maxDownloadAttempts
+	logrus.Debugf("Reset Max Download Attempts: %d", *xfer.MaxDownloadAttempts)
 
 	if daemon.imageService != nil {
 		daemon.imageService.UpdateConfig(&maxDownloadAttempts)
 	}
 
 	// prepare reload event attributes with updatable configurations
-	attributes["max-download-attempts"] = fmt.Sprintf("%d", *xfer.maxDownloadAttempts)
+	attributes["max-download-attempts"] = fmt.Sprintf("%d", *xfer.MaxDownloadAttempts)
 }
 
 // reloadShutdownTimeout updates configuration with daemon shutdown timeout option

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -16,9 +16,13 @@ import (
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/system"
 	"github.com/sirupsen/logrus"
+	"github.com/docker/docker/daemon/config"
 )
 
-maxDownloadAttempts := config.DefaultDownloadAttempts
+maxDownloadAttempts = config.DefaultDownloadAttempts
+if config.Config.IsValueSet("max-download-attempts") && config.Config.MaxDownloadAttempts != nil {
+	maxDownloadAttempts = *config.Config.MaxDownloadAttempts
+}
 
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -19,7 +19,7 @@ import (
 	"github.com/docker/docker/daemon/config"
 )
 
-maxDownloadAttempts := config.DefaultDownloadAttempts
+var maxDownloadAttempts := config.DefaultDownloadAttempts
 if config.Config.IsValueSet("max-download-attempts") && config.Config.MaxDownloadAttempts != nil {
 	maxDownloadAttempts = *config.Config.MaxDownloadAttempts
 }

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -19,9 +19,6 @@ import (
 	
 )
 
-// MaxDownloadAttempts is specified in the config file, with a default value of 5. 
-//var MaxDownloadAttempts int
-
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between
 // layers.

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -30,6 +30,8 @@ func MaxDownloadAttempts(conf *config.Config) int {
 	return maxDownloadAttempts
 }
 
+maxDownloadAttempts = MaxDownloadAttempts()
+
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between
 // layers.

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -296,7 +296,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				}
 
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == maxDownloadAttempts {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries == MaxDownloadAttempts {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var MaxDownloadAttempts int
+var MaxDownloadAttempts *int
 
 //func MaxDownloadAttempts(conf *config.Config) int {
 //	// If no value is set for max-download-attempts we assume it is the default value

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -20,10 +20,9 @@ import (
 )
 
 var maxDownloadAttempts = config.DefaultDownloadAttempts
-
-if config.Config.IsValueSet("max-download-attempts") && config.Config.MaxDownloadAttempts != nil {
-	maxDownloadAttempts = *config.Config.MaxDownloadAttempts
-}
+//if *config.Config.IsValueSet("max-download-attempts") && *config.Config.MaxDownloadAttempts != nil {
+	//maxDownloadAttempts = *config.Config.MaxDownloadAttempts
+//}
 
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -297,7 +297,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				}
 
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == *config.Config.MaxDownloadAttempts {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries == *config.MaxDownloadAttempts {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -30,7 +30,7 @@ func MaxDownloadAttempts(conf *config.Config) int {
 	return maxDownloadAttempts
 }
 
-var maxDownloadAttempts = MaxDownloadAttempts()
+var maxDownloadAttempts = MaxDownloadAttempts(*config.Config)
 
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -20,7 +20,7 @@ import (
 )
 
 // MaxDownloadAttempts is specified in the config file, with a default value of 5. 
-var MaxDownloadAttempts *int
+var MaxDownloadAttempts int
 
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between
@@ -285,7 +285,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				}
 				
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == *MaxDownloadAttempts {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries == MaxDownloadAttempts {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -19,7 +19,7 @@ import (
 	"github.com/docker/docker/daemon/config"
 )
 
-func MaxDownloadAttempts(conf *config.Config) {
+func MaxDownloadAttempts(conf *config.Config) int {
 	// If no value is set for max-download-attempts we assume it is the default value
 	// We always "reset" as the cost is lightweight and easy to maintain.
 	maxDownloadAttempts := config.DefaultDownloadAttempts

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -295,7 +295,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 					return
 				}
 
-				logrus.Errorf("Download failed, retrying: %v, max attempts: %a, current attempt: %c", err, *MaxDownloadAttempts, retries)
+				logrus.Errorf("Download failed, retrying: %v", err)
 				delay := retries * 5
 				ticker := time.NewTicker(ldm.waitDuration)
 

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -19,9 +19,9 @@ import (
 	"github.com/docker/docker/daemon/config"
 )
 
-var maxDownloadAttempts = config.DefaultDownloadAttempts
-if *config.Config.IsValueSet("max-download-attempts") && *config.Config.MaxDownloadAttempts != nil {
-	//maxDownloadAttempts = *config.Config.MaxDownloadAttempts
+maxDownloadAttempts := config.DefaultDownloadAttempts
+if config.Config.IsValueSet("max-download-attempts") && config.Config.MaxDownloadAttempts != nil {
+	maxDownloadAttempts = *config.Config.MaxDownloadAttempts
 }
 
 // LayerDownloadManager figures out which layers need to be downloaded, then

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -30,7 +30,7 @@ func MaxDownloadAttempts(conf *config.Config) int {
 	return maxDownloadAttempts
 }
 
-var maxDownloadAttempts = MaxDownloadAttempts(config.Config)
+var maxDownloadAttempts = MaxDownloadAttempts(config)
 
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -20,7 +20,7 @@ import (
 )
 
 // MaxDownloadAttempts is specified in the config file, with a default value of 5. 
-var MaxDownloadAttempts int
+//var MaxDownloadAttempts int
 
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+maxDownloadAttempts int
 maxDownloadAttempts := daemon.configStore.MaxDownloadAttempts
 
 // LayerDownloadManager figures out which layers need to be downloaded, then

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -296,7 +296,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				}
 
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == &MaxDownloadAttempts {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries == MaxDownloadAttempts {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -19,7 +19,7 @@ import (
 	"github.com/docker/docker/daemon/config"
 )
 
-maxDownloadAttempts = config.DefaultDownloadAttempts
+var maxDownloadAttempts = config.DefaultDownloadAttempts
 if config.Config.IsValueSet("max-download-attempts") && config.Config.MaxDownloadAttempts != nil {
 	maxDownloadAttempts = *config.Config.MaxDownloadAttempts
 }

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -296,20 +296,12 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				default:
 				}
 				
-				//if *MaxDownloadAttempts != nil {
-				//logrus.Debugf("*MaxdownloadAttempts not nil")
-				//}
 				
-				if &MaxDownloadAttempts != nil {
-				logrus.Debugf("&MaxdownloadAttempts not nil")
-				}
-
-				if MaxDownloadAttempts != nil {
-					logrus.Debugf("MaxdownloadAttempts not nil")
-				}
-
+				logrus.Debugf(*MaxDownloadAttempts, &MaxDownloadAttempts, MaxDownloadAttempts)
+				
+				
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == *MaxDownloadAttempts {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries == MaxDownloadAttempts {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -164,10 +164,10 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 
 		var xferFunc DoFunc
 		if topDownload != nil {
-			xferFunc = ldm.makeDownloadFunc(descriptor, "", topDownload, os, ldm.maxDownloadAttempts)
+			xferFunc = ldm.makeDownloadFunc(descriptor, "", topDownload, os)
 			defer topDownload.Transfer.Release(watcher)
 		} else {
-			xferFunc = ldm.makeDownloadFunc(descriptor, rootFS.ChainID(), nil, os, ldm.maxDownloadAttempts)
+			xferFunc = ldm.makeDownloadFunc(descriptor, rootFS.ChainID(), nil, os)
 		}
 		topDownloadUncasted, watcher = ldm.tm.Transfer(transferKey, xferFunc, progressOutput)
 		topDownload = topDownloadUncasted.(*downloadTransfer)

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -296,7 +296,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				}
 
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == MaxDownloadAttempts {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries == *MaxDownloadAttempts {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -297,7 +297,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				}
 
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == config.MaxConcurrentUploads {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries == *config.MaxConcurrentUploads {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -30,7 +30,7 @@ func MaxDownloadAttempts(conf *config.Config) int {
 	return maxDownloadAttempts
 }
 
-var maxDownloadAttempts = MaxDownloadAttempts(*config.Config)
+var maxDownloadAttempts = MaxDownloadAttempts(config.Config)
 
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -303,6 +303,8 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				retries++
 				if _, isDNR := err.(DoNotRetry); isDNR || retries == *MaxDownloadAttempts {
 					logrus.Errorf("Download failed: %v", err)
+					logrus.Errorf("Max attempts: %v", *MaxDownloadAttempts)
+					logrus.Errorf("current attempt: %v", retries)
 					d.err = err
 					return
 				}

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -296,9 +296,9 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				default:
 				}
 				
-				if *MaxDownloadAttempts != nil {
-				logrus.Debugf("*MaxdownloadAttempts not nil")
-				}
+				//if *MaxDownloadAttempts != nil {
+				//logrus.Debugf("*MaxdownloadAttempts not nil")
+				//}
 				
 				if &MaxDownloadAttempts != nil {
 				logrus.Debugf("&MaxdownloadAttempts not nil")

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -19,9 +19,10 @@ import (
 	"github.com/docker/docker/daemon/config"
 )
 
-var maxDownloadAttempts := config.DefaultDownloadAttempts
-if config.Config.IsValueSet("max-download-attempts") && config.Config.MaxDownloadAttempts != nil {
-	maxDownloadAttempts = *config.Config.MaxDownloadAttempts
+var maxDownloadAttempts = config.DefaultDownloadAttempts
+conf = *config.Config
+if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
+	maxDownloadAttempts = *conf.MaxDownloadAttempts
 }
 
 // LayerDownloadManager figures out which layers need to be downloaded, then

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -297,7 +297,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				}
 
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == *config.MaxConcurrentUploads {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries == *config.Config.MaxDownloadAttempts {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -297,11 +297,11 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				}
 				
 				
-				logrus.Debugf(*MaxDownloadAttempts, &MaxDownloadAttempts, MaxDownloadAttempts)
+				//logrus.Debugf(*MaxDownloadAttempts, &MaxDownloadAttempts, MaxDownloadAttempts)
 				
 				
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == MaxDownloadAttempts {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries == *MaxDownloadAttempts {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const maxDownloadAttempts = 5
+maxDownloadAttempts := daemon.configStore.MaxDownloadAttempts
 
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -296,7 +296,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				}
 
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == MaxDownloadAttempts {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries == int(MaxDownloadAttempts) {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -19,20 +19,8 @@ import (
 	
 )
 
+// MaxDownloadAttempts is specified in the config file, with a default value of 5. 
 var MaxDownloadAttempts *int
-
-//func MaxDownloadAttempts(conf *config.Config) int {
-//	// If no value is set for max-download-attempts we assume it is the default value
-//	// We always "reset" as the cost is lightweight and easy to maintain.
-//	maxDownloadAttempts := config.DefaultDownloadAttempts
-//	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
-//		maxDownloadAttempts = *conf.MaxDownloadAttempts
-//	}
-//
-//	return maxDownloadAttempts
-//}
-
-//var maxDownloadAttempts = MaxDownloadAttempts(config)
 
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -224,7 +224,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 // complete before the registration step, and registers the downloaded data
 // on top of parentDownload's resulting layer. Otherwise, it registers the
 // layer on top of the ChainID given by parentLayer.
-func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor, parentLayer layer.ChainID, parentDownload *downloadTransfer, os string, maxDownloadAttempts int) DoFunc {
+func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor, parentLayer layer.ChainID, parentDownload *downloadTransfer, os string) DoFunc {
 	return func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) Transfer {
 		d := &downloadTransfer{
 			Transfer:   NewTransfer(),
@@ -284,7 +284,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				}
 				
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == maxDownloadAttempts {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries == ldm.maxDownloadAttempts {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -295,6 +295,8 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				default:
 				}
 
+				logrus.Debugf("Max Download Attempts: %d", *MaxDownloadAttempts)
+				
 				retries++
 				if _, isDNR := err.(DoNotRetry); isDNR || retries == *MaxDownloadAttempts {
 					logrus.Errorf("Download failed: %v", err)

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -26,9 +26,10 @@ var MaxDownloadAttempts int
 // registers and downloads those, taking into account dependencies between
 // layers.
 type LayerDownloadManager struct {
-	layerStores  map[string]layer.Store
-	tm           TransferManager
-	waitDuration time.Duration
+	layerStores  		map[string]layer.Store
+	tm           		TransferManager
+	waitDuration 		time.Duration
+	maxDownloadAttempts	int
 }
 
 // SetConcurrency sets the max concurrent downloads for each pull
@@ -37,11 +38,12 @@ func (ldm *LayerDownloadManager) SetConcurrency(concurrency int) {
 }
 
 // NewLayerDownloadManager returns a new LayerDownloadManager.
-func NewLayerDownloadManager(layerStores map[string]layer.Store, concurrencyLimit int, options ...func(*LayerDownloadManager)) *LayerDownloadManager {
+func NewLayerDownloadManager(layerStores map[string]layer.Store, concurrencyLimit int, downloadattempts int, options ...func(*LayerDownloadManager)) *LayerDownloadManager {
 	manager := LayerDownloadManager{
-		layerStores:  layerStores,
-		tm:           NewTransferManager(concurrencyLimit),
-		waitDuration: time.Second,
+		layerStores:  			layerStores,
+		tm:           			NewTransferManager(concurrencyLimit),
+		waitDuration: 			time.Second,
+		maxDownloadAttempts:	downloadattempts
 	}
 	for _, option := range options {
 		option(&manager)
@@ -165,10 +167,10 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 
 		var xferFunc DoFunc
 		if topDownload != nil {
-			xferFunc = ldm.makeDownloadFunc(descriptor, "", topDownload, os)
+			xferFunc = ldm.makeDownloadFunc(descriptor, "", topDownload, os, ldm.maxDownloadAttempts)
 			defer topDownload.Transfer.Release(watcher)
 		} else {
-			xferFunc = ldm.makeDownloadFunc(descriptor, rootFS.ChainID(), nil, os)
+			xferFunc = ldm.makeDownloadFunc(descriptor, rootFS.ChainID(), nil, os, ldm.maxDownloadAttempts)
 		}
 		topDownloadUncasted, watcher = ldm.tm.Transfer(transferKey, xferFunc, progressOutput)
 		topDownload = topDownloadUncasted.(*downloadTransfer)
@@ -225,7 +227,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 // complete before the registration step, and registers the downloaded data
 // on top of parentDownload's resulting layer. Otherwise, it registers the
 // layer on top of the ChainID given by parentLayer.
-func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor, parentLayer layer.ChainID, parentDownload *downloadTransfer, os string) DoFunc {
+func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor, parentLayer layer.ChainID, parentDownload *downloadTransfer, os string, maxDownloadAttempts int) DoFunc {
 	return func(progressChan chan<- progress.Progress, start <-chan struct{}, inactive chan<- struct{}) Transfer {
 		d := &downloadTransfer{
 			Transfer:   NewTransfer(),
@@ -285,7 +287,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				}
 				
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == MaxDownloadAttempts {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries == maxDownloadAttempts {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -307,7 +307,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 					return
 				}
 
-				logrus.Errorf("Download failed, retrying: %v", err)
+				logrus.Errorf("Download failed, retrying: %v, max attempts: %a, current attempt: %c", err, *MaxDownloadAttempts, retries)
 				delay := retries * 5
 				ticker := time.NewTicker(ldm.waitDuration)
 

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -19,7 +19,7 @@ import (
 	"github.com/docker/docker/daemon/config"
 )
 
-//var MaxDownloadAttempts *int
+var MaxDownloadAttempts *int
 
 //func MaxDownloadAttempts(conf *config.Config) int {
 //	// If no value is set for max-download-attempts we assume it is the default value
@@ -295,9 +295,21 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 					return
 				default:
 				}
+				
+				if *MaxDownloadAttempts != nil {
+				logrus.Debugf("*MaxdownloadAttempts not nil")
+				}
+				
+				if &MaxDownloadAttempts != nil {
+				logrus.Debugf("&MaxdownloadAttempts not nil")
+				}
+
+				if MaxDownloadAttempts != nil {
+					logrus.Debugf("MaxdownloadAttempts not nil")
+				}
 
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == *config.MaxDownloadAttempts {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries == *MaxDownloadAttempts {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var maxDownloadAttempts int
+var MaxDownloadAttempts int
 
 //func MaxDownloadAttempts(conf *config.Config) int {
 //	// If no value is set for max-download-attempts we assume it is the default value

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -16,9 +16,10 @@ import (
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/system"
 	"github.com/sirupsen/logrus"
+	"github.com/docker/docker/daemon/config"
 )
 
-var MaxDownloadAttempts *int
+//var MaxDownloadAttempts *int
 
 //func MaxDownloadAttempts(conf *config.Config) int {
 //	// If no value is set for max-download-attempts we assume it is the default value
@@ -295,10 +296,8 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				default:
 				}
 
-				logrus.Debugf("Max Download Attempts: %d", *MaxDownloadAttempts)
-				
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == *MaxDownloadAttempts {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries == config.MaxConcurrentUploads {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -30,7 +30,7 @@ func MaxDownloadAttempts(conf *config.Config) int {
 	return maxDownloadAttempts
 }
 
-maxDownloadAttempts = MaxDownloadAttempts()
+var maxDownloadAttempts = MaxDownloadAttempts()
 
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -19,10 +19,15 @@ import (
 	"github.com/docker/docker/daemon/config"
 )
 
-var maxDownloadAttempts = config.DefaultDownloadAttempts
-conf = *config.Config
-if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
-	maxDownloadAttempts = *conf.MaxDownloadAttempts
+func MaxDownloadAttempts(conf *config.Config) {
+	// If no value is set for max-download-attempts we assume it is the default value
+	// We always "reset" as the cost is lightweight and easy to maintain.
+	maxDownloadAttempts := config.DefaultDownloadAttempts
+	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
+		maxDownloadAttempts = *conf.MaxDownloadAttempts
+	}
+
+	return maxDownloadAttempts
 }
 
 // LayerDownloadManager figures out which layers need to be downloaded, then

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/system"
 	"github.com/sirupsen/logrus"
-	"github.com/docker/docker/daemon/config"
 )
 
 var maxDownloadAttempts int

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -43,7 +43,7 @@ func NewLayerDownloadManager(layerStores map[string]layer.Store, concurrencyLimi
 		layerStores:  			layerStores,
 		tm:           			NewTransferManager(concurrencyLimit),
 		waitDuration: 			time.Second,
-		maxDownloadAttempts:	downloadattempts
+		maxDownloadAttempts:	downloadattempts,
 	}
 	for _, option := range options {
 		option(&manager)

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -296,7 +296,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				}
 
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == int(MaxDownloadAttempts) {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries == &MaxDownloadAttempts {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -20,6 +20,7 @@ import (
 )
 
 var maxDownloadAttempts = config.DefaultDownloadAttempts
+
 if config.Config.IsValueSet("max-download-attempts") && config.Config.MaxDownloadAttempts != nil {
 	maxDownloadAttempts = *config.Config.MaxDownloadAttempts
 }

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -302,9 +302,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				
 				retries++
 				if _, isDNR := err.(DoNotRetry); isDNR || retries == *MaxDownloadAttempts {
-					logrus.Errorf("Download failed: %v", err)
-					logrus.Errorf("Max attempts: %v", *MaxDownloadAttempts)
-					logrus.Errorf("current attempt: %v", retries)
+					logrus.Errorf("Download failed: %v, max attempts: %a, current attempt: %c", err, *MaxDownloadAttempts, retries)
 					d.err = err
 					return
 				}

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -284,10 +284,6 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				default:
 				}
 				
-				
-				//logrus.Debugf(*MaxDownloadAttempts, &MaxDownloadAttempts, MaxDownloadAttempts)
-				
-				
 				retries++
 				if _, isDNR := err.(DoNotRetry); isDNR || retries == *MaxDownloadAttempts {
 					logrus.Errorf("Download failed: %v", err)

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -16,7 +16,7 @@ import (
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/system"
 	"github.com/sirupsen/logrus"
-	"github.com/docker/docker/daemon/config"
+	
 )
 
 var MaxDownloadAttempts *int

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -18,8 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-maxDownloadAttempts int
-maxDownloadAttempts := daemon.configStore.MaxDownloadAttempts
+maxDownloadAttempts := config.DefaultDownloadAttempts
 
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -302,7 +302,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				
 				retries++
 				if _, isDNR := err.(DoNotRetry); isDNR || retries == *MaxDownloadAttempts {
-					logrus.Errorf("Download failed: %v, max attempts: %a, current attempt: %c", err, *MaxDownloadAttempts, retries)
+					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return
 				}

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -19,18 +19,20 @@ import (
 	"github.com/docker/docker/daemon/config"
 )
 
-func MaxDownloadAttempts(conf *config.Config) int {
-	// If no value is set for max-download-attempts we assume it is the default value
-	// We always "reset" as the cost is lightweight and easy to maintain.
-	maxDownloadAttempts := config.DefaultDownloadAttempts
-	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
-		maxDownloadAttempts = *conf.MaxDownloadAttempts
-	}
+var maxDownloadAttempts int
 
-	return maxDownloadAttempts
-}
+//func MaxDownloadAttempts(conf *config.Config) int {
+//	// If no value is set for max-download-attempts we assume it is the default value
+//	// We always "reset" as the cost is lightweight and easy to maintain.
+//	maxDownloadAttempts := config.DefaultDownloadAttempts
+//	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
+//		maxDownloadAttempts = *conf.MaxDownloadAttempts
+//	}
+//
+//	return maxDownloadAttempts
+//}
 
-var maxDownloadAttempts = MaxDownloadAttempts(config)
+//var maxDownloadAttempts = MaxDownloadAttempts(config)
 
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -20,9 +20,9 @@ import (
 )
 
 var maxDownloadAttempts = config.DefaultDownloadAttempts
-//if *config.Config.IsValueSet("max-download-attempts") && *config.Config.MaxDownloadAttempts != nil {
+if *config.Config.IsValueSet("max-download-attempts") && *config.Config.MaxDownloadAttempts != nil {
 	//maxDownloadAttempts = *config.Config.MaxDownloadAttempts
-//}
+}
 
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 const maxDownloadConcurrency = 3
+
 *MaxDownloadAttempts = 5
 
 type mockLayer struct {

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -21,7 +21,7 @@ import (
 
 const maxDownloadConcurrency = 3
 
-*MaxDownloadAttempts = 5
+MaxDownloadAttempts = &maxDownloadConcurrency
 
 type mockLayer struct {
 	layerData bytes.Buffer

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -21,7 +21,7 @@ import (
 
 const maxDownloadConcurrency = 3
 
-MaxDownloadAttempts = &maxDownloadConcurrency
+const maxDownloadAttempts = 5
 
 type mockLayer struct {
 	layerData bytes.Buffer
@@ -272,7 +272,7 @@ func TestSuccessfulDownload(t *testing.T) {
 	layerStore := &mockLayerStore{make(map[layer.ChainID]*mockLayer)}
 	lsMap := make(map[string]layer.Store)
 	lsMap[runtime.GOOS] = layerStore
-	ldm := NewLayerDownloadManager(lsMap, maxDownloadConcurrency, func(m *LayerDownloadManager) { m.waitDuration = time.Millisecond })
+	ldm := NewLayerDownloadManager(lsMap, maxDownloadConcurrency, maxDownloadAttempts, func(m *LayerDownloadManager) { m.waitDuration = time.Millisecond })
 
 	progressChan := make(chan progress.Progress)
 	progressDone := make(chan struct{})
@@ -336,7 +336,7 @@ func TestCancelledDownload(t *testing.T) {
 	layerStore := &mockLayerStore{make(map[layer.ChainID]*mockLayer)}
 	lsMap := make(map[string]layer.Store)
 	lsMap[runtime.GOOS] = layerStore
-	ldm := NewLayerDownloadManager(lsMap, maxDownloadConcurrency, func(m *LayerDownloadManager) { m.waitDuration = time.Millisecond })
+	ldm := NewLayerDownloadManager(lsMap, maxDownloadConcurrency, maxDownloadAttempts, func(m *LayerDownloadManager) { m.waitDuration = time.Millisecond })
 	progressChan := make(chan progress.Progress)
 	progressDone := make(chan struct{})
 

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const maxDownloadConcurrency = 3
-const MaxDownloadAttempts = 5
+MaxDownloadAttempts = 5
 
 type mockLayer struct {
 	layerData bytes.Buffer

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const maxDownloadConcurrency = 3
-var xfer.MaxDownloadAttempts = 5
+MaxDownloadAttempts = &5
 
 type mockLayer struct {
 	layerData bytes.Buffer

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const maxDownloadConcurrency = 3
-const maxDownloadAttempts = 5
+const MaxDownloadAttempts = 5
 
 type mockLayer struct {
 	layerData bytes.Buffer

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const maxDownloadConcurrency = 3
-MaxDownloadAttempts = &5
+*MaxDownloadAttempts = 5
 
 type mockLayer struct {
 	layerData bytes.Buffer

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const maxDownloadConcurrency = 3
-var MaxDownloadAttempts = 5
+xfer.MaxDownloadAttempts = 5
 
 type mockLayer struct {
 	layerData bytes.Buffer

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const maxDownloadConcurrency = 3
-xfer.MaxDownloadAttempts = 5
+var xfer.MaxDownloadAttempts = 5
 
 type mockLayer struct {
 	layerData bytes.Buffer

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 const maxDownloadConcurrency = 3
-var MaxDownloadAttempts = xfer.MaxDownloadAttempts
 
 type mockLayer struct {
 	layerData bytes.Buffer

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const maxDownloadConcurrency = 3
-MaxDownloadAttempts = 5
+var MaxDownloadAttempts = 5
 
 type mockLayer struct {
 	layerData bytes.Buffer

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 const maxDownloadConcurrency = 3
+MaxDownloadAttempts = 5
 
 type mockLayer struct {
 	layerData bytes.Buffer

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 const maxDownloadConcurrency = 3
+const maxDownloadAttempts = 5
 
 type mockLayer struct {
 	layerData bytes.Buffer

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const maxDownloadConcurrency = 3
-MaxDownloadAttempts = 5
+var MaxDownloadAttempts = xfer.MaxDownloadAttempts
 
 type mockLayer struct {
 	layerData bytes.Buffer


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Moby works perfectly when you are in a situation when one has a good and stable internet connection. Operating in area's where internet connectivity is likely to be lost in undetermined intervals, like a satellite connection or 4G/LTE in rural area's, can become a problem when pulling a new image. When connection is lost while image layers are being pulled, Moby will try to reconnect up to 5 times. If this fails, the incompletely downloaded layers are lost will need to be completely downloaded again during the next pull request. This means that we are using more data than we might have to.

Pulling a layer multiple times from the start can become costly over a satellite or 4G/LTE connection. As these techniques (especially 4G) quite common in IoT and Moby is used to run Azure IoT Edge devices, I would like to add a settable maximum download attempts. The maximum download attempts is currently set at 5 (distribution/xfer/download.go). I would like to change this constant to a variable that the user can set. The default will still be 5, so nothing will change from the current version unless specified when starting the daemon with the added flag or in the config file.

**- How I did it**
I added a default value of 5 for DefaultMaxDownloadAttempts and a settable max-download-attempts in the daemon config file. It is also added to the config of dockerd so it can be set with a flag when starting the daemon. This value gets stored in the imageService of the daemon when it is initiated and can be passed to the NewLayerDownloadManager as a parameter. It will be stored in the LayerDownloadManager when initiated. This enables us to set the max amount of retries in makeDownoadFunc equal to the max download attempts.

**- How to verify it**
You can pull this version and test in a development container. Either create a config file /etc/docker/daemon.json with `{"max-download-attempts"=3}`, or use `dockerd --max-download-attempts=3 -D &` to start up the dockerd. Start downloading a container and disconnect from the internet whilst downloading. The result would be that it stops pulling after three attempts.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added ability to change the number of reconnect attempts during connection loss while pulling an image by adding max-download-attempts to the config file.

**- A picture of a cute animal (not mandatory but encouraged)**
![cute animal](https://user-images.githubusercontent.com/29096411/60098457-e0bce180-9755-11e9-8f13-63574073fe90.jpg)

