### PR TITLE
Don't try to load plugin without name

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -254,6 +254,9 @@ func get(name string) (*Plugin, error) {
 
 // Get returns the plugin given the specified name and requested implementation.
 func Get(name, imp string) (*Plugin, error) {
+	if name == "" {
+		return nil, errors.New("Unable to find plugin without name")
+	}
 	pl, err := get(name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This can happen when you have --config-only network
Such attempt will fail anyway and it will create 15s delay in container
startup

- fixes #35099
- fixes #35876

**- How I did it**

Plugin manager throws error in case plugin name is empty

**- How to verify it**

Follow instructions in #35099

**- Description for the changelog**

Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:

Fix for startup delay of container with config-only/config-from network