### PR TITLE
Integration: remove redundant checks in IPVLAN tests

### DIFF
--- a/integration/network/ipvlan/ipvlan_test.go
+++ b/integration/network/ipvlan/ipvlan_test.go
@@ -22,7 +22,6 @@ import (
 
 func TestDockerNetworkIpvlanPersistance(t *testing.T) {
 	// verify the driver automatically provisions the 802.1q link (di-dummy0.70)
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, !ipvlanKernelSupport(t), "Kernel doesn't support ipvlan")
 
@@ -50,7 +49,6 @@ func TestDockerNetworkIpvlanPersistance(t *testing.T) {
 }
 
 func TestDockerNetworkIpvlan(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, !ipvlanKernelSupport(t), "Kernel doesn't support ipvlan")
 

--- a/integration/network/ipvlan/ipvlan_test.go
+++ b/integration/network/ipvlan/ipvlan_test.go
@@ -25,7 +25,7 @@ func TestDockerNetworkIpvlanPersistance(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, !ipvlanKernelSupport(t), "Kernel doesn't support ipvlan")
 
-	d := daemon.New(t, daemon.WithExperimental)
+	d := daemon.New(t)
 	d.StartWithBusybox(t)
 	defer d.Stop(t)
 
@@ -85,7 +85,7 @@ func TestDockerNetworkIpvlan(t *testing.T) {
 			test: testIpvlanAddressing,
 		},
 	} {
-		d := daemon.New(t, daemon.WithExperimental)
+		d := daemon.New(t)
 		d.StartWithBusybox(t)
 		c := d.NewClientT(t)
 

--- a/integration/network/ipvlan/ipvlan_test.go
+++ b/integration/network/ipvlan/ipvlan_test.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package ipvlan
+package ipvlan // import "github.com/docker/docker/integration/network/ipvlan"
 
 import (
 	"context"

--- a/integration/network/ipvlan/main_test.go
+++ b/integration/network/ipvlan/main_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package ipvlan // import "github.com/docker/docker/integration/network/ipvlan"
 
 import (

--- a/integration/network/ipvlan/main_windows_test.go
+++ b/integration/network/ipvlan/main_windows_test.go
@@ -1,0 +1,1 @@
+package ipvlan // import "github.com/docker/docker/integration/network/ipvlan"


### PR DESCRIPTION
- These tests are not built on Windows, and require a local daemon, so there's not need to check the platform as part of the test itself.
- Since https://github.com/moby/moby/pull/38983/commits/3ab093d5670e8d59f6ae0c4604b8fcabf1582854 (https://github.com/moby/moby/pull/38983), IPVLAN is no longer experimental, so remove the experimental daemon option
- don't build the package on Windows, and adding a missing "import" comment