### PR TITLE
Integration: remove redundant kernel version check for MACVlan

### DIFF
--- a/integration/network/macvlan/macvlan_test.go
+++ b/integration/network/macvlan/macvlan_test.go
@@ -20,7 +20,6 @@ import (
 func TestDockerNetworkMacvlanPersistance(t *testing.T) {
 	// verify the driver automatically provisions the 802.1q link (dm-dummy0.60)
 	skip.If(t, testEnv.IsRemoteDaemon)
-	skip.If(t, !macvlanKernelSupport(), "Kernel doesn't support macvlan")
 
 	d := daemon.New(t)
 	d.StartWithBusybox(t)
@@ -43,7 +42,6 @@ func TestDockerNetworkMacvlanPersistance(t *testing.T) {
 
 func TestDockerNetworkMacvlan(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
-	skip.If(t, !macvlanKernelSupport(), "Kernel doesn't support macvlan")
 
 	for _, tc := range []struct {
 		name string
@@ -270,9 +268,4 @@ func testMacvlanAddressing(client client.APIClient) func(*testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, strings.Contains(result.Combined(), "default via 2001:db8:abca::254 dev eth0"))
 	}
-}
-
-// ensure Kernel version is >= v3.9 for macvlan support
-func macvlanKernelSupport() bool {
-	return n.CheckKernelMajorVersionGreaterOrEqualThen(3, 9)
 }

--- a/integration/network/macvlan/macvlan_test.go
+++ b/integration/network/macvlan/macvlan_test.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package macvlan
+package macvlan // import "github.com/docker/docker/integration/network/macvlan"
 
 import (
 	"context"

--- a/integration/network/macvlan/main_test.go
+++ b/integration/network/macvlan/main_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package macvlan // import "github.com/docker/docker/integration/network/macvlan"
 
 import (

--- a/integration/network/macvlan/main_windows_test.go
+++ b/integration/network/macvlan/main_windows_test.go
@@ -1,0 +1,1 @@
+package macvlan // import "github.com/docker/docker/integration/network/macvlan"


### PR DESCRIPTION
The daemon requires kernel 3.10 or up to start, so there's no need to check if the daemon is kernel 3.8 or up.

https://github.com/moby/moby/blob/3d21b86e0a44932bfb4a3f882d8a7c9065432d40/daemon/daemon_unix.go#L319-L324
