### PR TITLE
Make `ErrorResponse` implement `Error`

### DIFF
--- a/api/types/error_response_ext.go
+++ b/api/types/error_response_ext.go
@@ -1,0 +1,6 @@
+package types
+
+// Error returns the error message
+func (e ErrorResponse) Error() string {
+	return e.Message
+}


### PR DESCRIPTION
This allows an `ErrorResponse` to be used directly as an error type.