### PR TITLE
builder-next: reset identitymapping if empty

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -90,6 +90,10 @@ type Builder struct {
 func New(opt Opt) (*Builder, error) {
 	reqHandler := newReqBodyHandler(tracing.DefaultTransport)
 
+	if opt.IdentityMapping != nil && opt.IdentityMapping.Empty() {
+		opt.IdentityMapping = nil
+	}
+
 	c, err := newController(reqHandler, opt)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
fixes #39442
introduced in https://github.com/moby/moby/pull/39349

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
