### PR TITLE
ioutils: Fixed a potential data race in bytespipe

### DIFF
--- a/pkg/ioutils/bytespipe.go
+++ b/pkg/ioutils/bytespipe.go
@@ -128,8 +128,9 @@ func (bp *BytesPipe) Read(p []byte) (n int, err error) {
 	bp.mu.Lock()
 	if bp.bufLen == 0 {
 		if bp.closeErr != nil {
+			err := bp.closeErr
 			bp.mu.Unlock()
-			return 0, bp.closeErr
+			return 0, err
 		}
 		bp.wait.Wait()
 		if bp.bufLen == 0 && bp.closeErr != nil {


### PR DESCRIPTION
Fixed an inconsistence and also a potential data race in pkg/ioutils/bytespipe.go: `bp.closeErr` is read/written 8 times; 7 out of 8 times it is protected by `bp.mu.Lock()`; 1 out of 8 times it is read without a Lock.

Signed-off-by: lzhfromutsc <lzhfromustc@gmail.com>

Fixes #39438 

**- What I did**
Move the read instruction of `bp.closeErr` before  `bp.mu.Unlock()`
```Go
err := bp.closeErr
bp.mu.Unlock()
return 0, err
```
**- How to verify it**
Actually [a fix in 2016](https://github.com/moby/moby/pull/23317) did the same thing on another instruction of `bp.closeErr` in the same function.

**- Description for the changelog**
Moved a read instruction of bp.closeErr before bp.mu.Unlock() to avoid potential data race.
