### PR TITLE
do not stop health check before sending signal

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -64,8 +64,6 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, sig int)
 	container.Lock()
 	defer container.Unlock()
 
-	daemon.stopHealthchecks(container)
-
 	if !container.Running {
 		return errNotRunning(container.ID)
 	}

--- a/integration-cli/docker_cli_health_test.go
+++ b/integration-cli/docker_cli_health_test.go
@@ -165,3 +165,29 @@ ENTRYPOINT /bin/sh -c "sleep 600"`))
 	waitForHealthStatus(c, name, "starting", "healthy")
 
 }
+
+// GitHub #37263
+func (s *DockerSuite) TestHealthKillContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux) // busybox doesn't work on Windows
+
+	imageName := "testhealth"
+	buildImageSuccessfully(c, imageName, build.WithDockerfile(`FROM busybox
+HEALTHCHECK --interval=1s --timeout=5s --retries=5 CMD /bin/sh -c "sleep 1"
+ENTRYPOINT /bin/sh -c "sleep 600"`))
+
+	name := "test_health_kill"
+	dockerCmd(c, "run", "-d", "--name", name, imageName)
+	defer func() {
+		dockerCmd(c, "rm", "-f", name)
+		dockerCmd(c, "rmi", imageName)
+	}()
+
+	// Start
+	dockerCmd(c, "start", name)
+	waitForHealthStatus(c, name, "starting", "healthy")
+
+	dockerCmd(c, "kill", "-s", "SIGINT", name)
+	out, _ := dockerCmd(c, "inspect", "--format={{.State.Health.Status}}", name)
+	c.Check(out, checker.Equals, "healthy\n")
+
+}

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -9,6 +9,7 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
+	"gotest.tools/assert"
 	"gotest.tools/poll"
 	"gotest.tools/skip"
 )
@@ -30,6 +31,34 @@ func TestHealthCheckWorkdir(t *testing.T) {
 	})
 
 	poll.WaitOn(t, pollForHealthStatus(ctx, client, cID, types.Healthy), poll.WithDelay(100*time.Millisecond))
+}
+
+// GitHub #37263
+// Do not stop healthchecks just because we sent a signal to the container
+func TestHealthKillContainer(t *testing.T) {
+	defer setupTest(t)()
+
+	ctx := context.Background()
+	client := testEnv.APIClient()
+
+	id := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
+		c.Config.Healthcheck = &containertypes.HealthConfig{
+			Test:     []string{"CMD-SHELL", "sleep 1"},
+			Interval: time.Second,
+			Retries:  5,
+		}
+	})
+
+	ctxPoll, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	poll.WaitOn(t, pollForHealthStatus(ctxPoll, client, id, "healthy"), poll.WithDelay(100*time.Millisecond))
+
+	err := client.ContainerKill(ctx, id, "SIGUSR1")
+	assert.NilError(t, err)
+
+	ctxPoll, cancel = context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	poll.WaitOn(t, pollForHealthStatus(ctxPoll, client, id, "healthy"), poll.WithDelay(100*time.Millisecond))
 }
 
 func pollForHealthStatus(ctx context.Context, client client.APIClient, containerID string, healthStatus string) func(log poll.LogT) poll.Result {


### PR DESCRIPTION
Docker daemon always stops healthcheck before sending signal to a
container now. However, when we use "docker kill" to send signals
other than SIGTERM or SIGKILL to a container, such as SIGINT,
daemon still stops container health check though container process
handles the signal normally and continues to work.

carry and closes #37263

Signed-off-by: Ruilin Li <liruilin4@huawei.com>

