### PR TITLE
Remove cocky from names-generator

### DIFF
--- a/pkg/namesgenerator/names-generator.go
+++ b/pkg/namesgenerator/names-generator.go
@@ -22,7 +22,6 @@ var (
 		"busy",
 		"charming",
 		"clever",
-		"cocky",
 		"cool",
 		"compassionate",
 		"competent",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Removed `cocky` from the names generator

Could be misinterpreted as something not too kosher as seen in #39451

fixes #39451

**- A picture of a cute animal (not mandatory but encouraged)**
