### PR TITLE
Add realChroot for non linux/windows

### DIFF
--- a/pkg/chrootarchive/chroot_unix.go
+++ b/pkg/chrootarchive/chroot_unix.go
@@ -10,3 +10,7 @@ func chroot(path string) error {
 	}
 	return unix.Chdir("/")
 }
+
+func realChroot(path string) error {
+	return chroot(path)
+}


### PR DESCRIPTION
3029e765e241ea2b5249868705dbf9095bc4d529 (https://github.com/moby/moby/pull/39292) broke compilation on
non-Linux/Windows systems.
This change fixes that.

Fixes #39437