### PR TITLE
integration-cli: remove ExecSupport check

### DIFF
--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -1,5 +1,3 @@
-// +build !test_no_exec
-
 package main
 
 import (

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -1,5 +1,3 @@
-// +build !test_no_exec
-
 package main
 
 import (

--- a/integration-cli/docker_cli_exec_unix_test.go
+++ b/integration-cli/docker_cli_exec_unix_test.go
@@ -1,4 +1,4 @@
-// +build !windows,!test_no_exec
+// +build !windows
 
 package main
 

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -140,7 +140,7 @@ func (s *DockerSuite) TestLinksNotStartedParentNotFail(c *check.C) {
 
 func (s *DockerSuite) TestLinksHostsFilesInject(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	testRequires(c, testEnv.IsLocalDaemon, ExecSupport)
+	testRequires(c, testEnv.IsLocalDaemon)
 
 	out, _ := dockerCmd(c, "run", "-itd", "--name", "one", "busybox", "top")
 	idOne := strings.TrimSpace(out)
@@ -158,7 +158,7 @@ func (s *DockerSuite) TestLinksHostsFilesInject(c *check.C) {
 
 func (s *DockerSuite) TestLinksUpdateOnRestart(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	testRequires(c, testEnv.IsLocalDaemon, ExecSupport)
+	testRequires(c, testEnv.IsLocalDaemon)
 	dockerCmd(c, "run", "-d", "--name", "one", "busybox", "top")
 	out, _ := dockerCmd(c, "run", "-d", "--name", "two", "--link", "one:onetwo", "--link", "one:one", "busybox", "top")
 	id := strings.TrimSpace(string(out))

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -805,7 +805,6 @@ func (s *DockerNetworkSuite) TestDockerPluginV2NetworkDriver(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDockerNetworkNoDiscoveryDefaultBridgeNetwork(c *check.C) {
-	testRequires(c, ExecSupport)
 	// On default bridge network built-in service discovery should not happen
 	hostsFile := "/etc/hosts"
 	bridgeName := "external-bridge"
@@ -863,7 +862,7 @@ func (s *DockerDaemonSuite) TestDockerNetworkNoDiscoveryDefaultBridgeNetwork(c *
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkAnonymousEndpoint(c *check.C) {
-	testRequires(c, ExecSupport, NotArm)
+	testRequires(c, NotArm)
 	hostsFile := "/etc/hosts"
 	cstmBridgeNw := "custom-bridge-nw"
 	cstmBridgeNw1 := "custom-bridge-nw1"

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3430,7 +3430,7 @@ func (s *DockerSuite) TestRunLoopbackWhenNetworkDisabled(c *check.C) {
 
 func (s *DockerSuite) TestRunModeNetContainerHostname(c *check.C) {
 	// Windows does not support --net=container
-	testRequires(c, DaemonIsLinux, ExecSupport)
+	testRequires(c, DaemonIsLinux)
 
 	dockerCmd(c, "run", "-i", "-d", "--name", "parent", "busybox", "top")
 	out, _ := dockerCmd(c, "exec", "parent", "cat", "/etc/hostname")

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -80,10 +80,6 @@ func UnixCli() bool {
 	return isUnixCli
 }
 
-func ExecSupport() bool {
-	return supportsExec
-}
-
 func Network() bool {
 	// Set a timeout on the GET at 15s
 	var timeout = time.Duration(15 * time.Second)

--- a/integration-cli/test_vars_exec_test.go
+++ b/integration-cli/test_vars_exec_test.go
@@ -1,8 +1,0 @@
-// +build !test_no_exec
-
-package main
-
-const (
-	// indicates docker daemon tested supports 'docker exec'
-	supportsExec = true
-)

--- a/integration-cli/test_vars_noexec_test.go
+++ b/integration-cli/test_vars_noexec_test.go
@@ -1,8 +1,0 @@
-// +build test_no_exec
-
-package main
-
-const (
-	// indicates docker daemon tested supports 'docker exec'
-	supportsExec = false
-)


### PR DESCRIPTION
All current versions of Docker support exec, so no need
to check for this.

