### PR TITLE
integration-cli: remove defaultSleepImage constant

### DIFF
--- a/integration-cli/benchmark_test.go
+++ b/integration-cli/benchmark_test.go
@@ -28,7 +28,7 @@ func (s *DockerSuite) BenchmarkConcurrentContainerActions(c *check.C) {
 			go func() {
 				defer innerGroup.Done()
 				for i := 0; i < numIterations; i++ {
-					args := []string{"run", "-d", defaultSleepImage}
+					args := []string{"run", "-d", "busybox"}
 					args = append(args, sleepCommandForDaemonPlatform()...)
 					out, _, err := dockerCmdWithError(args...)
 					if err != nil {

--- a/integration-cli/docker_cli_service_scale_test.go
+++ b/integration-cli/docker_cli_service_scale_test.go
@@ -14,11 +14,11 @@ func (s *DockerSwarmSuite) TestServiceScale(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	service1Name := "TestService1"
-	service1Args := append([]string{"service", "create", "--detach", "--no-resolve-image", "--name", service1Name, defaultSleepImage}, sleepCommandForDaemonPlatform()...)
+	service1Args := append([]string{"service", "create", "--detach", "--no-resolve-image", "--name", service1Name, "busybox"}, sleepCommandForDaemonPlatform()...)
 
 	// global mode
 	service2Name := "TestService2"
-	service2Args := append([]string{"service", "create", "--detach", "--no-resolve-image", "--name", service2Name, "--mode=global", defaultSleepImage}, sleepCommandForDaemonPlatform()...)
+	service2Args := append([]string{"service", "create", "--detach", "--no-resolve-image", "--name", service2Name, "--mode=global", "busybox"}, sleepCommandForDaemonPlatform()...)
 
 	// Create services
 	_, err := d.Cmd(service1Args...)

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -347,7 +347,7 @@ func getInspectBody(c *check.C, version, id string) []byte {
 // Run a long running idle task in a background container using the
 // system-specific default image and command.
 func runSleepingContainer(c *check.C, extraArgs ...string) string {
-	return runSleepingContainerInImage(c, defaultSleepImage, extraArgs...)
+	return runSleepingContainerInImage(c, "busybox", extraArgs...)
 }
 
 // Run a long running idle task in a background container using the specified

--- a/integration-cli/test_vars_unix_test.go
+++ b/integration-cli/test_vars_unix_test.go
@@ -7,8 +7,4 @@ const (
 	isUnixCli = true
 
 	expectedFileChmod = "-rw-r--r--"
-
-	// On Unix variants, the busybox image comes with the `top` command which
-	// runs indefinitely while still being interruptible by a signal.
-	defaultSleepImage = "busybox"
 )

--- a/integration-cli/test_vars_windows_test.go
+++ b/integration-cli/test_vars_windows_test.go
@@ -8,8 +8,4 @@ const (
 
 	// this is the expected file permission set on windows: gh#11395
 	expectedFileChmod = "-rwxr-xr-x"
-
-	// On Windows, the busybox image doesn't have the `top` command, so we rely
-	// on `sleep` with a high duration.
-	defaultSleepImage = "busybox"
 )


### PR DESCRIPTION
Both Linux and Windows now use busybox, so no need to keep a constant for this.

