### PR TITLE
Use MemAvailable instead of MemFree to estimate actual available memory

### DIFF
--- a/pkg/system/meminfo_linux.go
+++ b/pkg/system/meminfo_linux.go
@@ -27,6 +27,7 @@ func ReadMemInfo() (*MemInfo, error) {
 func parseMemInfo(reader io.Reader) (*MemInfo, error) {
 	meminfo := &MemInfo{}
 	scanner := bufio.NewScanner(reader)
+	memAvailable := int64(-1)
 	for scanner.Scan() {
 		// Expected format: ["MemTotal:", "1234", "kB"]
 		parts := strings.Fields(scanner.Text())
@@ -48,12 +49,17 @@ func parseMemInfo(reader io.Reader) (*MemInfo, error) {
 			meminfo.MemTotal = bytes
 		case "MemFree:":
 			meminfo.MemFree = bytes
+		case "MemAvailable:":
+			memAvailable = bytes
 		case "SwapTotal:":
 			meminfo.SwapTotal = bytes
 		case "SwapFree:":
 			meminfo.SwapFree = bytes
 		}
 
+	}
+	if memAvailable != -1 {
+		meminfo.MemFree = memAvailable
 	}
 
 	// Handle errors that may have occurred during the reading of the file.

--- a/pkg/system/meminfo_unix_test.go
+++ b/pkg/system/meminfo_unix_test.go
@@ -14,8 +14,9 @@ func TestMemInfo(t *testing.T) {
 	const input = `
 	MemTotal:      1 kB
 	MemFree:       2 kB
-	SwapTotal:     3 kB
-	SwapFree:      4 kB
+	MemAvailable:  3 kB
+	SwapTotal:     4 kB
+	SwapFree:      5 kB
 	Malformed1:
 	Malformed2:    1
 	Malformed3:    2 MB
@@ -28,13 +29,13 @@ func TestMemInfo(t *testing.T) {
 	if meminfo.MemTotal != 1*units.KiB {
 		t.Fatalf("Unexpected MemTotal: %d", meminfo.MemTotal)
 	}
-	if meminfo.MemFree != 2*units.KiB {
+	if meminfo.MemFree != 3*units.KiB {
 		t.Fatalf("Unexpected MemFree: %d", meminfo.MemFree)
 	}
-	if meminfo.SwapTotal != 3*units.KiB {
+	if meminfo.SwapTotal != 4*units.KiB {
 		t.Fatalf("Unexpected SwapTotal: %d", meminfo.SwapTotal)
 	}
-	if meminfo.SwapFree != 4*units.KiB {
+	if meminfo.SwapFree != 5*units.KiB {
 		t.Fatalf("Unexpected SwapFree: %d", meminfo.SwapFree)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I used MemAvailable instead of MemFree when Linux kernel supports it. Linux kernel version >=3.14 shows how much memory is actually available via MemAvailable.
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773

**- How I did it**
I modified parseMemInfo method to handle MemAvailable from "/proc/meminfo"

**- How to verify it**
I modified "meminfo_unix_test.go" to test whether this change can handle MemAvailable

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use MemAvailable instead of MemFree to estimate actual available memory

**- A picture of a cute animal (not mandatory but encouraged)**

