### PR TITLE
fix swagger.yaml #39484

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5543,8 +5543,6 @@ paths:
           description: "no error"
         304:
           description: "container already started"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
         404:
           description: "no such container"
           schema:
@@ -5576,8 +5574,6 @@ paths:
           description: "no error"
         304:
           description: "container already stopped"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
         404:
           description: "no such container"
           schema:


### PR DESCRIPTION
- relates to moby/moby#39484 Swagger API: container start or stop api response is incorrect
- closes moby/moby#39253 API: Make response body empty when starting a started container or stopping a stopped container
- relates to https://github.com/docker-php/docker-php/issues/337 Stopping an already stopped container throws a serializer exception

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
fix swagger.yaml

**- How I did it**
fix start or stop container response body

**- How to verify it**
check swagger.yaml

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Swagger API: container start or stop api response is incorrect

**- A picture of a cute animal (not mandatory but encouraged)**

