### PR TITLE
loggerutils: add critical section to protect w.maxFiles

### DIFF
--- a/daemon/logger/loggerutils/logfile.go
+++ b/daemon/logger/loggerutils/logfile.go
@@ -283,6 +283,8 @@ func compressFile(fileName string, lastTimestamp time.Time) {
 
 // MaxFiles return maximum number of files
 func (w *LogFile) MaxFiles() int {
+	w.rotateMu.Lock()
+	defer w.rotateMu.Unlock()
 	return w.maxFiles
 }
 


### PR DESCRIPTION
_I made a PR for this fix before but I forgot to sign the commit. I closed [the old PR](https://github.com/moby/moby/pull/39489). You could ignore it and just look at this PR._

**- Description**
In package daemon/logger/loggerutils, `w.maxFiles` is always protected by `w.rotateMu` since initialization, except once: `func (w *LogFile) MaxFiles()` read `w.maxFiles` without a Lock. 

It is fine in current version because `func (w *LogFile) MaxFiles()` is never used in moby XD. However I believe adding Lock&Unlock before it would make it safer.

**- What I did**
I think using `w.rotateMu` here is fine. It is only Locked and Unlocked in 2 functions, which I will show below.
```Go
// MaxFiles return maximum number of files
func (w *LogFile) MaxFiles() int {
+++	w.rotateMu.Lock()
+++	defer w.rotateMu.Unlock()
	return w.maxFiles
}
```

**- How to verify it**
Here is all usages of `w.maxFiles` and `w.rotateMu`.
File: [daemon/logger/loggerutils/logfile.go](https://github.com/moby/moby/blob/master/daemon/logger/loggerutils/logfile.go)
```Go
//Line 169 to 206
func (w *LogFile) checkCapacityAndRotate() error {
	...
	if w.currentSize >= w.capacity {
		w.rotateMu.Lock()
		...
		if err := rotate(fname, w.maxFiles, w.compress); err != nil {
			w.rotateMu.Unlock()
			return err
		}
		...
		if w.maxFiles <= 1 || !w.compress {
			w.rotateMu.Unlock()
			return nil
		}

		go func() {
			compressFile(fname+".1", w.lastTimestamp)
			w.rotateMu.Unlock()
		}()
	}
	...
}

//Line 285 to 287 (Before my PR)
func (w *LogFile) MaxFiles() int {
	return w.maxFiles
}

//Line 379 to 432
func (w *LogFile) openRotatedFiles(config logger.ReadConfig) (files []*os.File, err error) {
	w.rotateMu.Lock()
	defer w.rotateMu.Unlock()
	...

	for i := w.maxFiles; i > 1; i-- {
		...
	}
	...
}
```

**- PS**
I am developing a static concurrency bug checker and testing it on open-source Go projects. Since Moby is such a mature project and a static checker has its limitations, most bugs I find are only trivial ones or just bad practices in Moby. I will only report the ones that I believe might be a threat in the future. I hope I am not troubling you too much.