### PR TITLE
rootless: allow exposing dockerd TCP socket easily

### DIFF
--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -75,6 +75,17 @@ You can just use the upstream Docker client but you need to set the socket path 
 $ docker -H unix://$XDG_RUNTIME_DIR/docker.sock run -d nginx
 ```
 
+### Expose Docker API socket via TCP
+
+To expose the Docker API socket via TCP, you need to launch `dockerd-rootless.sh` with `DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="-p 0.0.0.0:2376:2376/tcp"`.
+
+```console
+$ DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="-p 0.0.0.0:2376:2376/tcp" \
+ dockerd-rootless.sh --experimental \
+ -H tcp://0.0.0.0:2376 \
+ --tlsverify --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem
+```
+
 ### Routing ping packets
 
 To route ping packets, you need to set up `net.ipv4.ping_group_range` properly as the root.
@@ -86,8 +97,8 @@ $ sudo sh -c "echo 0   2147483647  > /proc/sys/net/ipv4/ping_group_range"
 ### Changing network stack
 
 `dockerd-rootless.sh` uses [slirp4netns](https://github.com/rootless-containers/slirp4netns) (if installed) or [VPNKit](https://github.com/moby/vpnkit) as the network stack by default.
-These network stacks run in userspace and might have performance overhead. See [RootlessKit documentation](https://github.com/rootless-containers/rootlesskit/tree/v0.4.0#network-drivers) for further information.
+These network stacks run in userspace and might have performance overhead. See [RootlessKit documentation](https://github.com/rootless-containers/rootlesskit/tree/v0.6.0#network-drivers) for further information.
 
 Optionally, you can use `lxc-user-nic` instead for the best performance.
-To use `lxc-user-nic`, you need to edit [`/etc/lxc/lxc-usernet`](https://github.com/rootless-containers/rootlesskit/tree/v0.4.0#--netlxc-user-nic-experimental) and set `$DOCKERD_ROOTLESS_ROOTLESSKIT_NET=lxc-user-nic`.
+To use `lxc-user-nic`, you need to edit [`/etc/lxc/lxc-usernet`](https://github.com/rootless-containers/rootlesskit/tree/v0.6.0#--netlxc-user-nic-experimental) and set `$DOCKERD_ROOTLESS_ROOTLESSKIT_NET=lxc-user-nic`.
 

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# v0.4.1
-ROOTLESSKIT_COMMIT=27a0c7a2483732b33d4192c1d178c83c6b9e202d
+# v0.6.0
+ROOTLESSKIT_COMMIT=2fcff6ceae968a1d895e6205e5154b107247356f
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION


Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

allow exposing dockerd TCP socket easily in rootless mode

**- How I did it**

By bumping up RootlessKit from v0.4.1 to v0.6.0:
https://github.com/rootless-containers/rootlesskit/compare/27a0c7a2483732b33d4192c1d178c83c6b9e202d...2fcff6ceae968a1d895e6205e5154b107247356f

**- How to verify it**

```console
$ DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="-p 0.0.0.0:2376:2376/tcp" \
 dockerd-rootless.sh --experimental \
 -H tcp://0.0.0.0:2376 \
 --tlsverify --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
rootless: allow exposing dockerd TCP socket easily

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/9248427/61016597-2242c300-a3cb-11e9-8031-07ecb9ef466d.png)
https://pixabay.com/photos/animal-avian-bird-cold-nature-1867125/
