### PR TITLE
Update service networks documentation

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2995,16 +2995,10 @@ definitions:
         description: "Runtime is the type of runtime specified for the task executor."
         type: "string"
       Networks:
+        description: "Specifies which networks the service should attach to."
         type: "array"
         items:
-          type: "object"
-          properties:
-            Target:
-              type: "string"
-            Aliases:
-              type: "array"
-              items:
-                type: "string"
+          $ref: "#/definitions/NetworkAttachmentConfig"
       LogDriver:
         description: "Specifies the log driver to use for tasks created from this spec. If not present, the default one for the swarm will be used, finally falling back to the engine default if not specified."
         type: "object"
@@ -3250,17 +3244,11 @@ definitions:
               - "stop-first"
               - "start-first"
       Networks:
-        description: "Array of network names or IDs to attach the service to."
+        description: "Specifies which networks the service should attach to."
         type: "array"
         items:
-          type: "object"
-          properties:
-            Target:
-              type: "string"
-            Aliases:
-              type: "array"
-              items:
-                type: "string"
+          $ref: "#/definitions/NetworkAttachmentConfig"
+
       EndpointSpec:
         $ref: "#/definitions/EndpointSpec"
 
@@ -4442,6 +4430,24 @@ definitions:
         description: |
           IP address and ports at which this node can be reached.
         type: "string"
+
+  NetworkAttachmentConfig:
+    description: "Specifies how a service should be attached to a particular network."
+    type: "object"
+    properties:
+      Target:
+        description: "The target network for attachment. Must be a network name or ID."
+        type: "string"
+      Aliases:
+        description: "Discoverable alternate names for the service on this network."
+        type: "array"
+        items:
+          type: "string"
+      DriverOpts:
+        description: "Driver attachment options for the network target"
+        type: "object"
+        additionalProperties:
+          type: "string"
 
 paths:
   /containers/json:


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/32917

This PR updates the documentation for the `/services/` API. It fixes some issues around the `Networks` parameter.

The previous description stated that an array of names / ids could be passed when the API in reality expects objects in the form of `NetworkAttachmentConfig`. This is fixed by updating the description and adding a definition for `NetworkAttachmentConfig`.

Also it's quite confusing that `Networks` can both be specified in the service spec and in the `TaskTemplate`. From my understanding the correct way to pass `Networks` is through `TaskTemplate`: https://github.com/moby/moby/blob/aa8249ae1b8b613a9ddb3b00b3974d94e7010506/daemon/cluster/networks.go#L304-L306

I have not found any official information about `Networks` in the service spec being deprecated but it would probably be good to write something about this in the description for this parameter. Not really sure about the correct wording for this so I would glad to get some advice here.

The `Networks` parameter in the service spec also crashes when clicked, looks like this issue https://github.com/moby/moby/issues/32917. This makes it extra confusing with the current description about expecting an array of ids / names since the expected format can't be expanded.