### PR TITLE
skip frequently flaky DockerSwarmSuite tests

### DIFF
--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -290,6 +290,7 @@ func (s *DockerSwarmSuite) TestAPISwarmLeaderProxy(c *check.C) {
 }
 
 func (s *DockerSwarmSuite) TestAPISwarmLeaderElection(c *check.C) {
+	c.Skip("Flaky")
 	if runtime.GOARCH == "s390x" {
 		c.Skip("Disabled on s390x")
 	}

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1433,6 +1433,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithSocketAsVolume(c *check.C) {
 // os.Kill should kill daemon ungracefully, leaving behind container mounts.
 // A subsequent daemon restart should clean up said mounts.
 func (s *DockerDaemonSuite) TestCleanupMountsAfterDaemonAndContainerKill(c *check.C) {
+	c.Skip("Flaky")
 	d := daemon.New(c, dockerBinary, dockerdBinary, testdaemon.WithEnvironment(testEnv.Execution))
 	d.StartWithBusybox(c)
 

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1315,6 +1315,7 @@ func (s *DockerSwarmSuite) TestSwarmRotateUnlockKey(c *check.C) {
 // This one keeps the leader up, and asserts that other manager nodes in the cluster also have their unlock
 // key rotated.
 func (s *DockerSwarmSuite) TestSwarmClusterRotateUnlockKey(c *check.C) {
+	c.Skip("Flaky")
 	if runtime.GOARCH == "s390x" {
 		c.Skip("Disabled on s390x")
 	}


### PR DESCRIPTION
From the [latest 25 merged PRs to moby/moby repo](https://github.com/moby/moby/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+closed%3A%3C2019-07-10+), the PRs with failed `integration-cli` tests were merged because the tests were known to be flaky. I scanned through them all and created this PR to skip those tests.

* #38885 DockerSwarmSuite.TestSwarmClusterRotateUnlockKey
* #39061 DockerSwarmSuite.TestCleanupMountsAfterDaemonAndContainerKill
* #32673 DockerSwarmSuite.TestAPISwarmLeaderElection

Related: #39499