### PR TITLE
integration: organize bundle directory per test

### DIFF
--- a/internal/test/daemon/daemon.go
+++ b/internal/test/daemon/daemon.go
@@ -34,6 +34,13 @@ type testingT interface {
 	Fatalf(string, ...interface{})
 }
 
+type namer interface {
+	Name() string
+}
+type testNamer interface {
+	TestName() string
+}
+
 type logT interface {
 	Logf(string, ...interface{})
 }
@@ -95,6 +102,12 @@ func New(t testingT, ops ...func(*Daemon)) *Daemon {
 	dest := os.Getenv("DOCKER_INTEGRATION_DAEMON_DEST")
 	if dest == "" {
 		dest = os.Getenv("DEST")
+	}
+	switch v := t.(type) {
+	case namer:
+		dest = filepath.Join(dest, v.Name())
+	case testNamer:
+		dest = filepath.Join(dest, v.TestName())
 	}
 	assert.Check(t, dest != "", "Please set the DOCKER_INTEGRATION_DAEMON_DEST or the DEST environment variable")
 


### PR DESCRIPTION
The test-integration/test=integration-cli directory contains a directory for each daemon that was created during the integration tests, which makes it a long list to browse through. In addition, some tests spin up multiple daemons, and when debugging test-failures, the daemon-logs often have to be looked at together.

This patch organizes the bundle directory to group daemon storage locations per test, making it easier to find information about all the daemons that were used in a specific test.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

