### PR TITLE
Cleanup "address" when connecting over a UNIX socket

### DIFF
--- a/internal/test/daemon/daemon.go
+++ b/internal/test/daemon/daemon.go
@@ -630,7 +630,9 @@ func (d *Daemon) getClientConfig() (*clientConfig, error) {
 		return nil, err
 	}
 	transport.DisableKeepAlives = true
-
+	if proto == "unix" {
+		addr = filepath.Base(addr)
+	}
 	return &clientConfig{
 		transport: transport,
 		scheme:    scheme,


### PR DESCRIPTION
When connecting with the daemon using a UNIX socket, the HTTP hostname was set, based
on the socket location, which was generating some noise in the test-logs.

Given that the actual hostname is not important (the URL just has to be well-formed),
the hostname/address can be cleaned up to reduce the noise.

This patch strips the path from the `addr`, and keeps `<random-id>.sock` as address.

Before:

    daemon.go:329: [d15d31ba75501] error pinging daemon on start: Get http://%2Ftmp%2Fdocker-integration%2Fd15d31ba75501.sock/_ping: dial unix /tmp/docker-integration/d15d31ba75501.sock: connect: no such file or directory

After:

    daemon.go:329: [d15d31ba75501] error pinging daemon on start: Get http://d15d31ba75501.sock/_ping: dial unix /tmp/docker-integration/d15d31ba75501.sock: connect: no such file or directory

