### PR TITLE
Fix "Removing bundles/" not actually removing bundles

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -183,7 +183,7 @@ bundle() {
 main() {
 	if [ -z "${KEEPBUNDLE-}" ]; then
 		echo "Removing bundles/"
-		rm -rf "bundles/*"
+		rm -rf bundles/*
 		echo
 	fi
 	mkdir -p bundles


### PR DESCRIPTION
Before:

Running `ls -la bundles/` before, and after removing:

    ls -la bundles/
    total 16
    drwxr-xr-x  7 root root  224 Jul 12 12:25 .
    drwxr-xr-x  1 root root 4096 Jul 12 12:30 ..
    drwxr-xr-x  2 root root   64 Jul 12 10:00 dynbinary
    drwxr-xr-x  6 root root  192 Jul 12 12:25 dynbinary-daemon
    lrwxrwxrwx  1 root root    1 Jul 12 12:25 latest -> .
    drwxr-xr-x 92 root root 2944 Jul 12 12:29 test-integration

    Removing bundles/

    ls -la bundles/
    total 16
    drwxr-xr-x  7 root root  224 Jul 12 12:25 .
    drwxr-xr-x  1 root root 4096 Jul 12 12:30 ..
    drwxr-xr-x  2 root root   64 Jul 12 10:00 dynbinary
    drwxr-xr-x  6 root root  192 Jul 12 12:25 dynbinary-daemon
    lrwxrwxrwx  1 root root    1 Jul 12 12:25 latest -> .
    drwxr-xr-x 92 root root 2944 Jul 12 12:29 test-integration

After:

Running `ls -la bundles/` before, and after removing:

    ls -la bundles/
    total 16
    drwxr-xr-x  7 root root  224 Jul 12 12:25 .
    drwxr-xr-x  1 root root 4096 Jul 12 12:30 ..
    drwxr-xr-x  2 root root   64 Jul 12 10:00 dynbinary
    drwxr-xr-x  6 root root  192 Jul 12 12:25 dynbinary-daemon
    lrwxrwxrwx  1 root root    1 Jul 12 12:25 latest -> .
    drwxr-xr-x 92 root root 2944 Jul 12 12:29 test-integration

    Removing bundles/

    ls -la bundles/
    total 4
    drwxr-xr-x 2 root root   64 Jul 12 12:25 .
    drwxr-xr-x 1 root root 4096 Jul 12 12:30 ..


