### PR TITLE
Fix Microsecond -> Millisecond.

### DIFF
--- a/internal/test/daemon/daemon.go
+++ b/internal/test/daemon/daemon.go
@@ -352,7 +352,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 
 				select {
 				case <-ctx.Done():
-				case <-time.After(500 * time.Microsecond):
+				case <-time.After(500 * time.Millisecond):
 				}
 				continue
 			}


### PR DESCRIPTION
A bit too quick on the trigger on some text completion I think...

![image](https://user-images.githubusercontent.com/799078/61165419-1f33f980-a4d5-11e9-8c4a-0e29db48812a.png)

