### PR TITLE
errdefs: remove unneeded recursive calls

### DIFF
--- a/errdefs/http_helpers.go
+++ b/errdefs/http_helpers.go
@@ -136,9 +136,6 @@ func statusCodeFromGRPCError(err error) int {
 	case codes.Unavailable: // code 14
 		return http.StatusServiceUnavailable
 	default:
-		if e, ok := err.(causer); ok {
-			return statusCodeFromGRPCError(e.Cause())
-		}
 		// codes.Canceled(1)
 		// codes.Unknown(2)
 		// codes.DeadlineExceeded(4)
@@ -163,10 +160,6 @@ func statusCodeFromDistributionError(err error) int {
 		}
 	case errcode.ErrorCoder:
 		return errs.ErrorCode().Descriptor().HTTPStatusCode
-	default:
-		if e, ok := err.(causer); ok {
-			return statusCodeFromDistributionError(e.Cause())
-		}
 	}
 	return http.StatusInternalServerError
 }


### PR DESCRIPTION
The `statusCodeFromGRPCError` and `statusCodeFromDistributionError`
helpers are used by `GetHTTPErrorStatusCode`, which already recurses
if the error implements the `Causer` interface.

