### PR TITLE
Fix error handling of incorrect --platform values

### DIFF
--- a/errdefs/http_helpers.go
+++ b/errdefs/http_helpers.go
@@ -177,7 +177,7 @@ func statusCodeFromDistributionError(err error) int {
 }
 
 // statusCodeFromContainerdError returns status code for containerd errors when
-// consumed directory (not through gRPC)
+// consumed directly (not through gRPC)
 func statusCodeFromContainerdError(err error) int {
 	switch {
 	case containerderrors.IsInvalidArgument(err):

--- a/errdefs/http_helpers.go
+++ b/errdefs/http_helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	containerderrors "github.com/containerd/containerd/errdefs"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
@@ -44,6 +45,10 @@ func GetHTTPErrorStatusCode(err error) int {
 		statusCode = http.StatusInternalServerError
 	default:
 		statusCode = statusCodeFromGRPCError(err)
+		if statusCode != http.StatusInternalServerError {
+			return statusCode
+		}
+		statusCode = statusCodeFromContainerdError(err)
 		if statusCode != http.StatusInternalServerError {
 			return statusCode
 		}
@@ -169,4 +174,25 @@ func statusCodeFromDistributionError(err error) int {
 		}
 	}
 	return http.StatusInternalServerError
+}
+
+// statusCodeFromContainerdError returns status code for containerd errors when
+// consumed directory (not through gRPC)
+func statusCodeFromContainerdError(err error) int {
+	switch {
+	case containerderrors.IsInvalidArgument(err):
+		return http.StatusBadRequest
+	case containerderrors.IsNotFound(err):
+		return http.StatusNotFound
+	case containerderrors.IsAlreadyExists(err):
+		return http.StatusConflict
+	case containerderrors.IsFailedPrecondition(err):
+		return http.StatusPreconditionFailed
+	case containerderrors.IsUnavailable(err):
+		return http.StatusServiceUnavailable
+	case containerderrors.IsNotImplemented(err):
+		return http.StatusNotImplemented
+	default:
+		return http.StatusInternalServerError
+	}
 }

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/test/fakecontext"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"gotest.tools/assert"
@@ -560,6 +561,35 @@ func TestBuildPreserveOwnership(t *testing.T) {
 			assert.NilError(t, err)
 		})
 	}
+}
+
+func TestBuildPlatformInvalid(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "experimental in older versions")
+
+	ctx := context.Background()
+	defer setupTest(t)()
+
+	dockerfile := `FROM busybox
+`
+
+	buf := bytes.NewBuffer(nil)
+	w := tar.NewWriter(buf)
+	writeTarRecord(t, w, "Dockerfile", dockerfile)
+	err := w.Close()
+	assert.NilError(t, err)
+
+	apiclient := testEnv.APIClient()
+	_, err = apiclient.ImageBuild(ctx,
+		buf,
+		types.ImageBuildOptions{
+			Remove:      true,
+			ForceRemove: true,
+			Platform:    "foobar",
+		})
+
+	assert.Assert(t, err != nil)
+	assert.ErrorContains(t, err, "unknown operating system or architecture")
+	assert.Assert(t, errdefs.IsInvalidParameter(err))
 }
 
 func writeTarRecord(t *testing.T, w *tar.Writer, fn, contents string) {

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -1,0 +1,24 @@
+package image
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/errdefs"
+	"gotest.tools/assert"
+	"gotest.tools/skip"
+)
+
+func TestImagePullPlatformInvalid(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.40"), "experimental in older versions")
+	defer setupTest(t)()
+	client := testEnv.APIClient()
+	ctx := context.Background()
+
+	_, err := client.ImagePull(ctx, "docker.io/library/hello-world:latest", types.ImagePullOptions{Platform: "foobar"})
+	assert.Assert(t, err != nil)
+	assert.ErrorContains(t, err, "unknown operating system or architecture")
+	assert.Assert(t, errdefs.IsInvalidParameter(err))
+}


### PR DESCRIPTION
Relates to https://github.com/docker/docker-py/pull/2382#issue-297611082

### errdefs: convert containerd errors to the correct status code

In situations where the containerd error is consumed directly
and not received over gRPC, errors were not translated.

### Add regression tests for invalid platform status codes

Before we handled containerd errors, using an invalid platform produced a 500 status:

```bash
curl -v \
-X POST \
--unix-socket /var/run/docker.sock \
"http://localhost:2375/v1.40/images/create?fromImage=hello-world&platform=foobar&tag=latest" \
-H "Content-Type: application/json"
```

```
* Connected to localhost (docker.sock) port 80 (#0)
> POST /v1.40/images/create?fromImage=hello-world&platform=foobar&tag=latest HTTP/1.1
> Host: localhost:2375
> User-Agent: curl/7.54.0
> Accept: */*
> Content-Type: application/json
>
< HTTP/1.1 500 Internal Server Error
< Api-Version: 1.40
< Content-Length: 85
< Content-Type: application/json
< Date: Mon, 15 Jul 2019 15:25:44 GMT
< Docker-Experimental: true
< Ostype: linux
< Server: Docker/19.03.0-rc2 (linux)
<
{"message":"\"foobar\": unknown operating system or architecture: invalid argument"}
```

That problem is now fixed, and the API correctly returns a 4xx status:

```bash
curl -v \
-X POST \
--unix-socket /var/run/docker.sock \
"http://localhost:2375/v1.40/images/create?fromImage=hello-world&platform=foobar&tag=latest" \
-H "Content-Type: application/json"
```

```
* Connected to localhost (/var/run/docker.sock) port 80 (#0)
> POST /v1.40/images/create?fromImage=hello-world&platform=foobar&tag=latest HTTP/1.1
> Host: localhost:2375
> User-Agent: curl/7.52.1
> Accept: */*
> Content-Type: application/json
>
< HTTP/1.1 400 Bad Request
< Api-Version: 1.41
< Content-Type: application/json
< Docker-Experimental: true
< Ostype: linux
< Server: Docker/dev (linux)
< Date: Mon, 15 Jul 2019 15:13:42 GMT
< Content-Length: 85
<
{"message":"\"foobar\": unknown operating system or architecture: invalid argument"}
* Curl_http_done: called premature == 0
```

This patch adds tests to validate the behaviour


**- How to verify it**

```bash
make \
  DOCKER_GRAPHDRIVER=vfs \
  TESTDIRS='github.com/docker/docker/integration/image' \
  TESTFLAGS='-test.run ^TestImagePullPlatformInvalid$' \
  binary test-integration


make \
  DOCKER_GRAPHDRIVER=vfs \
  TESTDIRS='github.com/docker/docker/integration/build' \
  TESTFLAGS='-test.run ^TestBuildPlatformInvalid$' \
  binary test-integration
```


**- Description for the changelog**

```Markdown
* Fix `POST /images/create` returning a 500 status code when providing an incorrect platform option
* Fix `POST /build` returning a 500 status code when providing an incorrect platform option
```