### PR TITLE
Set TIMEOUT according to architecture.

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -150,15 +150,6 @@ ORIG_BUILDFLAGS=( -tags "autogen netgo osusergo static_build $DOCKER_BUILDTAGS" 
 
 BUILDFLAGS=( ${BUILDFLAGS} "${ORIG_BUILDFLAGS[@]}" )
 
-# Test timeout.
-if [ "${DOCKER_ENGINE_GOARCH}" == "arm64" ] || [ "${DOCKER_ENGINE_GOARCH}" == "arm" ]; then
-	: ${TIMEOUT:=10m}
-elif [ "${DOCKER_ENGINE_GOARCH}" == "windows" ]; then
-	: ${TIMEOUT:=8m}
-else
-	: ${TIMEOUT:=5m}
-fi
-
 LDFLAGS_STATIC_DOCKER="
 	$LDFLAGS_STATIC
 	-extldflags \"$EXTLDFLAGS_STATIC\"

--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -20,6 +20,7 @@ integration_api_dirs=${TEST_INTEGRATION_DIR:-"$(
 	grep -vE '(^./integration($|/internal)|/testdata)')"}
 
 run_test_integration() {
+	set_platform_timeout
 	if [[ "$TESTFLAGS" != *-check.f* ]]; then
 		run_test_integration_suites
 	fi
@@ -108,10 +109,9 @@ test_env() {
 			"$@"
 	)
 }
-   
 
 error_on_leaked_containerd_shims() {
-	if [ "$(go env GOOS)" == 'windows' ]; then
+	if [ "$(go env GOOS)" = 'windows' ]; then
 		return
 	fi
 
@@ -122,5 +122,25 @@ error_on_leaked_containerd_shims() {
 		kill -9 ${leftovers} 2> /dev/null
 		echo "!!!! WARNING you have left over shim(s), Cleanup your test !!!!"
 		exit 1
+	fi
+}
+
+set_platform_timeout() {
+	# Test timeout.
+	if [ "${DOCKER_ENGINE_GOARCH}" = "arm64" ] || [ "${DOCKER_ENGINE_GOARCH}" = "arm" ]; then
+		: ${TIMEOUT:=10m}
+	elif [ "${DOCKER_ENGINE_GOARCH}" = "windows" ]; then
+		: ${TIMEOUT:=8m}
+	else
+		: ${TIMEOUT:=5m}
+	fi
+
+	if [ "${TEST_REPEAT}" -gt 1 ]; then
+		# TIMEOUT needs to take TEST_REPEAT into account, or a premature time out may happen.
+		# The following ugliness will:
+		# - remove last character (usually 'm' from '10m')
+		# - multiply by testcount
+		# - add last character back
+		TIMEOUT=$((${TIMEOUT::-1} * ${TEST_REPEAT}))${TIMEOUT:$((${#TIMEOUT}-1)):1}
 	fi
 }

--- a/hack/make/test-integration-flaky
+++ b/hack/make/test-integration-flaky
@@ -20,18 +20,10 @@ echo "Running stress test for them."
 (
     TESTARRAY=$(echo "$new_tests" | sed 's/+func //' | awk -F'\\(' '{print $1}' | tr '\n' '|')
     # Note: TEST_REPEAT will make the test suite run 5 times, restarting the daemon
-    # whereas testcount will make each test run 5 times in a row under the same daemon.
+    # and each test will run 5 times in a row under the same daemon.
     # This will make a total of 25 runs for each test in TESTARRAY.
     export TEST_REPEAT=5
-    local testcount=5
-    # However, TIMEOUT needs to take testcount into account, or a premature time out may happen.
-    # The following ugliness will:
-    # - remove last character (usually 'm' from '10m')
-    # - multiply by testcount
-    # - add last character back
-    export TIMEOUT=$((${TIMEOUT::-1} * $testcount))${TIMEOUT:$((${#TIMEOUT}-1)):1}
-
-    export TESTFLAGS="-test.count $testcount -test.run ${TESTARRAY%?}"
+    export TESTFLAGS="-test.count ${TEST_REPEAT} -test.run ${TESTARRAY%?}"
     echo "Using test flags: $TESTFLAGS"
     source hack/make/test-integration
 )

--- a/hack/test/e2e-run.sh
+++ b/hack/test/e2e-run.sh
@@ -2,7 +2,7 @@
 set -e -u -o pipefail
 
 ARCH=$(uname -m)
-if [ "$ARCH" == "x86_64" ]; then
+if [ "$ARCH" = "x86_64" ]; then
   ARCH="amd64"
 fi
 
@@ -17,6 +17,7 @@ integration_api_dirs=${TEST_INTEGRATION_DIR:-"$(
 	grep -vE '(^/tests/integration($|/internal)|/testdata)')"}
 
 run_test_integration() {
+	set_platform_timeout
 	if [[ "$TESTFLAGS" != *-check.f* ]]; then
 		run_test_integration_suites
 	fi
@@ -70,6 +71,17 @@ test_env() {
 			TEST_CLIENT_BINARY="$TEST_CLIENT_BINARY" \
 			"$@"
 	)
+}
+
+set_platform_timeout() {
+	# Test timeout.
+	if [ "${DOCKER_ENGINE_GOARCH}" = "arm64" ] || [ "${DOCKER_ENGINE_GOARCH}" = "arm" ]; then
+		: ${TIMEOUT:=10m}
+	elif [ "${DOCKER_ENGINE_GOARCH}" = "windows" ]; then
+		: ${TIMEOUT:=8m}
+	else
+		: ${TIMEOUT:=5m}
+	fi
 }
 
 sh /scripts/ensure-emptyfs.sh


### PR DESCRIPTION
Signed-off-by: Michael Zhao <michael.zhao@arm.com>

**- What's the problem**
The TIMEOUT setting in integration test don't work:
https://github.com/moby/moby/blob/master/hack/make.sh#L154
On arm/arm64 architecture, TIMEOUT is set to default value "5m" which is not enough, and many test cases failed.
The problem was caused by missing "DOCKER_ENGINE_GOARCH".

**- What I did**
Pass environment variable DOCKER_ENGINE_GOARCH into container.

**- How I did it**
Add DOCKER_ENGINE_GOARCH in docker environment variables.

**- How to verify it**
Run "make test-integration" on arm/arm64, failures due to timeout should be avoided.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
