### PR TITLE
Dockerfile: Use APT_MIRROR for security.debian.org as well

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@
 ARG CROSS="false"
 
 FROM golang:1.12.7 AS base
-# allow replacing httpredir or deb mirror
-ARG APT_MIRROR=deb.debian.org
-RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
+ARG APT_MIRROR
+RUN sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list \
+ && sed -ri "s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g" /etc/apt/sources.list
 
 FROM base AS criu
 # Install CRIU for checkpoint/restore support


### PR DESCRIPTION
The fastly cdn mirror we're using also mirrors the debian security
repostory;

```
Welcome to deb.debian.org (fastly instance)!

This is deb.debian.org. This service provides mirrors for the following Debian archive repositories:

/debian/
/debian-debug/
/debian-ports/
/debian-security/
The server deb.debian.org does not have packages itself, but the name has SRV records in DNS that let apt in stretch and later find places.
```

Before:

```
18:02:06  ---> Running in 9a57f74bb090
18:02:06 Get:1 http://security.debian.org/debian-security stretch/updates InRelease [94.3 kB]
18:02:06 Ign:2 http://cdn-fastly.deb.debian.org/debian stretch InRelease
18:02:06 Get:3 http://cdn-fastly.deb.debian.org/debian stretch-updates InRelease [91.0 kB]
18:02:06 Get:4 http://cdn-fastly.deb.debian.org/debian stretch Release [118 kB]
18:02:06 Get:5 http://cdn-fastly.deb.debian.org/debian stretch Release.gpg [2434 B]
18:02:06 Get:6 http://security.debian.org/debian-security stretch/updates/main ppc64el Packages [478 kB]
18:02:07 Get:7 http://cdn-fastly.deb.debian.org/debian stretch-updates/main ppc64el Packages [27.3 kB]
18:02:07 Get:8 http://cdn-fastly.deb.debian.org/debian stretch/main ppc64el Packages [6903 kB]
18:02:08 Fetched 7713 kB in 2s (3032 kB/s)
```

After:

```
10:21:29  ---> Running in d46a1f8b118c
10:21:29 Ign:1 http://cdn-fastly.deb.debian.org/debian stretch InRelease
10:21:29 Get:2 http://cdn-fastly.deb.debian.org/debian-security stretch/updates InRelease [94.3 kB]
10:21:29 Get:3 http://cdn-fastly.deb.debian.org/debian stretch-updates InRelease [91.0 kB]
10:21:29 Get:4 http://cdn-fastly.deb.debian.org/debian stretch Release [118 kB]
10:21:29 Get:5 http://cdn-fastly.deb.debian.org/debian stretch Release.gpg [2434 B]
10:21:29 Get:6 http://cdn-fastly.deb.debian.org/debian-security stretch/updates/main ppc64el Packages [478 kB]
10:21:30 Get:7 http://cdn-fastly.deb.debian.org/debian stretch-updates/main ppc64el Packages [27.3 kB]
10:21:30 Get:8 http://cdn-fastly.deb.debian.org/debian stretch/main ppc64el Packages [6903 kB]
10:21:32 Fetched 7713 kB in 2s (3020 kB/s)
```