### PR TITLE
allow running of single integration test

### DIFF
--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -20,8 +20,12 @@ integration_api_dirs=${TEST_INTEGRATION_DIR:-"$(
 	grep -vE '(^./integration($|/internal)|/testdata)')"}
 
 run_test_integration() {
-	[[ "$TESTFLAGS" != *-check.f* ]] && run_test_integration_suites
-	run_test_integration_legacy_suites
+	if [[ "$TESTFLAGS" != *-check.f* ]]; then
+		run_test_integration_suites
+	fi
+	if [[ "$TESTFLAGS" != *-test.run* ]]; then
+		run_test_integration_legacy_suites
+	fi
 }
 
 run_test_integration_suites() {

--- a/hack/test/e2e-run.sh
+++ b/hack/test/e2e-run.sh
@@ -17,8 +17,12 @@ integration_api_dirs=${TEST_INTEGRATION_DIR:-"$(
 	grep -vE '(^/tests/integration($|/internal)|/testdata)')"}
 
 run_test_integration() {
-	[[ "$TESTFLAGS" != *-check.f* ]] && run_test_integration_suites
-	run_test_integration_legacy_suites
+	if [[ "$TESTFLAGS" != *-check.f* ]]; then
+		run_test_integration_suites
+	fi
+	if [[ "$TESTFLAGS" != *-test.run* ]]; then
+		run_test_integration_legacy_suites
+	fi
 }
 
 run_test_integration_suites() {


### PR DESCRIPTION
We can already run a specific `integration-cli` test like so:
```
$ make TESTFLAGS='-check.f ^DockerSwarmSuite' test-integration
```

And now with this PR, we can specify just to run the new `integration` tests:
```
$ make TESTFLAGS='-test.run ^TestService' test-integration
```