### PR TITLE
imporve hardcoded CC on cross compile

### DIFF
--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -44,27 +44,27 @@ if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARC
 	# must be cross-compiling!
 	case "$(go env GOOS)/$(go env GOARCH)" in
 		windows/amd64)
-			export CC=x86_64-w64-mingw32-gcc
+			export CC="${CC:-x86_64-w64-mingw32-gcc}"
 			export CGO_ENABLED=1
 			;;
 		linux/arm)
 			case "${GOARM}" in
 			5|"")
-				export CC=arm-linux-gnueabi-gcc
+				export CC="${CC:-arm-linux-gnueabi-gcc}"
 				export CGO_ENABLED=1
 				;;
 			7)
-				export CC=arm-linux-gnueabihf-gcc
+				export CC="${CC:-arm-linux-gnueabihf-gcc}"
 				export CGO_ENABLED=1
 				;;
 			esac
 			;;
 		linux/arm64)
-			export CC=aarch64-linux-gnu-gcc
+			export CC="${CC:-aarch64-linux-gnu-gcc}"
 			export CGO_ENABLED=1
 			;;
 		linux/amd64)
-			export CC=x86_64-linux-gnu-gcc
+			export CC="${CC:-x86_64-linux-gnu-gcc}"
 			export CGO_ENABLED=1
 			;;
 	esac


### PR DESCRIPTION
Since commit applied in moby [61a3285 Support cross-compile for arm]
it hardcoded var-CC to support cross-compile for arm

Correct it with "${parameter:-word}" format, it is helpful for user
define toolchains

(Use Default Values.  If parameter is unset or null, the expansion of
word is substituted.  Otherwise, the value of parameter is substituted.)

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

