### PR TITLE
Be more conservative for Windows in TestFrequency for Splunk

### DIFF
--- a/daemon/logger/splunk/splunk_test.go
+++ b/daemon/logger/splunk/splunk_test.go
@@ -925,7 +925,12 @@ func TestFrequency(t *testing.T) {
 
 	// 1 to verify connection and 10 to verify that we have sent messages with required frequency,
 	// but because frequency is too small (to keep test quick), instead of 11, use 9 if context switches will be slow
-	if hec.numOfRequests < 9 {
+	expectedRequests := 9
+	if runtime.GOOS == "windows" {
+		// sometimes in Windows, this test fails with number of requests showing 8. So be more conservative.
+		expectedRequests = 7
+	}
+	if hec.numOfRequests < expectedRequests {
 		t.Fatalf("Unexpected number of requests %d", hec.numOfRequests)
 	}
 


### PR DESCRIPTION
**- What I did**
Put in a fix for https://github.com/moby/moby/issues/39544 scoped to Windows.

**- How I did it**
Reduced the conservative expected frequency for Windows to 1 below observed frequency in test VMs.

**- How to verify it**
Run the unit test in a stressed/overloaded Windows host.

**- Description for the changelog**
Be more conservative for Windows in TestFrequency unit-test for Splunk

**- A picture of a cute animal (not mandatory but encouraged)**

