### PR TITLE
integration: run build session tests on non-experimental

### DIFF
--- a/integration/build/build_session_test.go
+++ b/integration/build/build_session_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/versions"
 	dclient "github.com/docker/docker/client"
-	"github.com/docker/docker/internal/test/daemon"
 	"github.com/docker/docker/internal/test/fakecontext"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/moby/buildkit/session"
@@ -23,18 +23,9 @@ import (
 
 func TestBuildWithSession(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "experimental in older versions")
 
-	var client dclient.APIClient
-	if !testEnv.DaemonInfo.ExperimentalBuild {
-		skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
-
-		d := daemon.New(t, daemon.WithExperimental)
-		d.StartWithBusybox(t)
-		defer d.Stop(t)
-		client = d.NewClientT(t)
-	} else {
-		client = testEnv.APIClient()
-	}
+	client := testEnv.APIClient()
 
 	dockerfile := `
 		FROM busybox

--- a/integration/session/session_test.go
+++ b/integration/session/session_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/docker/docker/internal/test/daemon"
+	"github.com/docker/docker/api/types/versions"
 	req "github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
@@ -13,17 +13,10 @@ import (
 
 func TestSessionCreate(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows", "FIXME")
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "experimental in older versions")
 
 	defer setupTest(t)()
 	daemonHost := req.DaemonHost()
-	if !testEnv.DaemonInfo.ExperimentalBuild {
-		skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
-
-		d := daemon.New(t, daemon.WithExperimental)
-		d.StartWithBusybox(t)
-		defer d.Stop(t)
-		daemonHost = d.Sock()
-	}
 
 	res, body, err := req.Post("/session",
 		req.Host(daemonHost),
@@ -41,17 +34,10 @@ func TestSessionCreate(t *testing.T) {
 
 func TestSessionCreateWithBadUpgrade(t *testing.T) {
 	skip.If(t, testEnv.OSType == "windows", "FIXME")
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "experimental in older versions")
 
 	defer setupTest(t)()
 	daemonHost := req.DaemonHost()
-	if !testEnv.DaemonInfo.ExperimentalBuild {
-		skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
-
-		d := daemon.New(t, daemon.WithExperimental)
-		d.StartWithBusybox(t)
-		defer d.Stop(t)
-		daemonHost = d.Sock()
-	}
 
 	res, body, err := req.Post("/session", req.Host(daemonHost))
 	assert.NilError(t, err)


### PR DESCRIPTION
The session endpoint is no longer experimental since 01c9e7082eba71cbe60ce2e47acb9aad2c83c7ef (https://github.com/moby/moby/pull/37686), so we don't need to start an experimental daemon.

```bash
make TESTFLAGS='-test.run ^(TestSession|TestBuildWithSession)' test-integration   

Running /go/src/github.com/docker/docker/integration/build
INFO: Testing against a local daemon
=== RUN   TestBuildWithSession
--- PASS: TestBuildWithSession (6.50s)
PASS

...

Running /go/src/github.com/docker/docker/integration/session
INFO: Testing against a local daemon
=== RUN   TestSessionCreate
--- PASS: TestSessionCreate (0.02s)
=== RUN   TestSessionCreateWithBadUpgrade
--- PASS: TestSessionCreateWithBadUpgrade (0.03s)
PASS
```
