### PR TITLE
integration-cli: increase healthcheck timeout

### DIFF
--- a/integration-cli/docker_cli_service_health_test.go
+++ b/integration-cli/docker_cli_service_health_test.go
@@ -28,7 +28,7 @@ func (s *DockerSwarmSuite) TestServiceHealthRun(c *check.C) {
 	result := cli.BuildCmd(c, imageName, cli.Daemon(d),
 		build.WithDockerfile(`FROM busybox
 		RUN touch /status
-		HEALTHCHECK --interval=1s --timeout=1s --retries=1\
+		HEALTHCHECK --interval=1s --timeout=5s --retries=1\
 		  CMD cat /status`),
 	)
 	result.Assert(c, icmd.Success)


### PR DESCRIPTION
Based on logs from https://github.com/moby/moby/issues/39499#issuecomment-512621697 when heathcheck takes more than a second to start (eg. under load) it fails the test. Increase the timeout to 5s.

<details>
  <summary>logs</summary>
<pre><code>time="2019-07-17T23:19:52.498392843Z" level=debug msg=event module=libcontainerd namespace=d85f04fa93bbe topic=/tasks/start
time="2019-07-17T23:19:52.503874174Z" level=debug msg=OpenMonitorChannel
time="2019-07-17T23:19:52.510244817Z" level=debug msg="waiting on events" module=node/agent/taskmanager node.id=ie3mxlvwportscwyyudnpuhla service.id=ojrg9oqjvge1qqpcak7a2s0h8 task.id=knc66796mnx72vw6d0r34d434
time="2019-07-17T23:19:52.542504206Z" level=debug msg="Calling GET /v1.41/tasks/knc66796mnx72vw6d0r34d434"
time="2019-07-17T23:19:52.643623437Z" level=debug msg="Calling GET /v1.41/tasks/knc66796mnx72vw6d0r34d434"
time="2019-07-17T23:19:52.744760798Z" level=debug msg="Calling GET /v1.41/tasks/knc66796mnx72vw6d0r34d434"
time="2019-07-17T23:19:52.845900030Z" level=debug msg="Calling GET /v1.41/tasks/knc66796mnx72vw6d0r34d434"
time="2019-07-17T23:19:52.946905343Z" level=debug msg="Calling GET /v1.41/tasks/knc66796mnx72vw6d0r34d434"
time="2019-07-17T23:19:53.047995330Z" level=debug msg="Calling GET /v1.41/tasks/knc66796mnx72vw6d0r34d434"
time="2019-07-17T23:19:53.149108843Z" level=debug msg="Calling GET /v1.41/tasks/knc66796mnx72vw6d0r34d434"
time="2019-07-17T23:19:53.250115294Z" level=debug msg="Calling GET /v1.41/tasks/knc66796mnx72vw6d0r34d434"
time="2019-07-17T23:19:53.351070988Z" level=debug msg="Calling GET /v1.41/tasks/knc66796mnx72vw6d0r34d434"
time="2019-07-17T23:19:53.452058855Z" level=debug msg="Calling GET /v1.41/tasks/knc66796mnx72vw6d0r34d434"

time="2019-07-17T23:19:53.504474494Z" level=debug msg="Running health check for container d632174bdc0c73ae12b852d9cc4d4130d9fd327593d587b78629380e99ed05f4 ..."
time="2019-07-17T23:19:53.504595827Z" level=debug msg="starting exec command 494714b6974a0edeef325c59b7f765e0bdda0ad8e30aeeebb612b5b1c0f7eb4a in container d632174bdc0c73ae12b852d9cc4d4130d9fd327593d587b78629380e99ed05f4"
time="2019-07-17T23:19:53.505731052Z" level=debug msg="attach: stdout: begin"
time="2019-07-17T23:19:53.505746565Z" level=debug msg="attach: stderr: begin"
time="2019-07-17T23:19:53.553196448Z" level=debug msg="Calling GET /v1.41/tasks/knc66796mnx72vw6d0r34d434"
time="2019-07-17T23:19:53.654341222Z" level=debug msg="Calling GET /v1.41/tasks/knc66796mnx72vw6d0r34d434"
time="2019-07-17T23:19:54.396280427Z" level=debug msg="sending heartbeat to manager { } with timeout 5s" method="(*session).heartbeat" module=node/agent node.id=ie3mxlvwportscwyyudnpuhla session.id=yi31vq6a77nej0kw4izyd12fr sessionID=yi31vq6a77nej0kw4izyd12fr
time="2019-07-17T23:19:54.504622746Z" level=debug msg="attach: stderr: end"
time="2019-07-17T23:19:54.504630690Z" level=debug msg="Health check for container d632174bdc0c73ae12b852d9cc4d4130d9fd327593d587b78629380e99ed05f4 taking too long"
time="2019-07-17T23:19:54.504627082Z" level=debug msg="attach: stdout: end"
time="2019-07-17T23:19:54.614474856Z" level=debug msg="attach done"
time="2019-07-17T23:19:54.509100420Z" level=error msg="stream copy error: reading from a closed fifo"
time="2019-07-17T23:19:54.509119396Z" level=error msg="stream copy error: reading from a closed fifo"
time="2019-07-17T23:19:54.614871332Z" level=debug msg="received heartbeat from worker {[swarm-manager] h118ubb2dfa2ofvt5nme953y8 ie3mxlvwportscwyyudnpuhla <nil> 127.0.0.1:2477}, expect next heartbeat in 5.417701717s" method="(*Dispatcher).Heartbeat"
time="2019-07-17T23:19:54.614963012Z" level=debug msg="heartbeat successful to manager { }, next heartbeat period: 5.417701717s" method="(*session).heartbeat" module=node/agent node.id=ie3mxlvwportscwyyudnpuhla session.id=yi31vq6a77nej0kw4izyd12fr sessionID=yi31vq6a77nej0kw4izyd12fr
time="2019-07-17T23:19:54.639845248Z" level=warning msg="Health check for container d632174bdc0c73ae12b852d9cc4d4130d9fd327593d587b78629380e99ed05f4 error: context deadline exceeded: unknown"
time="2019-07-17T23:19:54.643592296Z" level=debug msg="Sending kill signal 15 to container d632174bdc0c73ae12b852d9cc4d4130d9fd327593d587b78629380e99ed05f4"
</code></pre>
</details>

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
