### PR TITLE
Integration: cleanup custom "docker0" bridge after tests

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -589,6 +589,10 @@ func (s *DockerDaemonSuite) TearDownTest(ctx context.Context, c *testing.T) {
 		s.d.Stop(c)
 	}
 	s.ds.TearDownTest(ctx, c)
+
+	// Some tests in this Suite make modifications to the "docker0" bridge.
+	// Remove the bridge afterwards to force the next test to re-create it
+	deleteInterface(c, "docker0")
 }
 
 func (s *DockerDaemonSuite) TearDownSuite(ctx context.Context, c *testing.T) {

--- a/integration-cli/check_unix_test.go
+++ b/integration-cli/check_unix_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+
+	"gotest.tools/v3/icmd"
+)
+
+func createInterface(c *testing.T, ifType string, ifName string, ipNet string) {
+	icmd.RunCommand("ip", "link", "add", "name", ifName, "type", ifType).Assert(c, icmd.Success)
+	icmd.RunCommand("ifconfig", ifName, ipNet, "up").Assert(c, icmd.Success)
+}
+
+func deleteInterface(c *testing.T, ifName string) {
+	if icmd.RunCommand("ip", "link", "show", ifName).ExitCode != 0 {
+		return
+	}
+	icmd.RunCommand("ip", "link", "delete", ifName).Assert(c, icmd.Success)
+	icmd.RunCommand("iptables", "-t", "nat", "--flush").Assert(c, icmd.Success)
+	icmd.RunCommand("iptables", "--flush").Assert(c, icmd.Success)
+}

--- a/integration-cli/check_windows_test.go
+++ b/integration-cli/check_windows_test.go
@@ -1,0 +1,7 @@
+package main
+
+import "testing"
+
+func createInterface(c *testing.T, ifType string, ifName string, ipNet string) {}
+
+func deleteInterface(c *testing.T, ifName string) {}

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -556,6 +556,9 @@ func createInterface(c *testing.T, ifType string, ifName string, ipNet string) {
 }
 
 func deleteInterface(c *testing.T, ifName string) {
+	if icmd.RunCommand("ip", "link", "show", ifName).ExitCode != 0 {
+		return
+	}
 	icmd.RunCommand("ip", "link", "delete", ifName).Assert(c, icmd.Success)
 	icmd.RunCommand("iptables", "-t", "nat", "--flush").Assert(c, icmd.Success)
 	icmd.RunCommand("iptables", "--flush").Assert(c, icmd.Success)

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -550,20 +550,6 @@ func (s *DockerDaemonSuite) TestDaemonBridgeNone(c *testing.T) {
 	assert.Assert(c, strings.Contains(out, "No such network"))
 }
 
-func createInterface(c *testing.T, ifType string, ifName string, ipNet string) {
-	icmd.RunCommand("ip", "link", "add", "name", ifName, "type", ifType).Assert(c, icmd.Success)
-	icmd.RunCommand("ifconfig", ifName, ipNet, "up").Assert(c, icmd.Success)
-}
-
-func deleteInterface(c *testing.T, ifName string) {
-	if icmd.RunCommand("ip", "link", "show", ifName).ExitCode != 0 {
-		return
-	}
-	icmd.RunCommand("ip", "link", "delete", ifName).Assert(c, icmd.Success)
-	icmd.RunCommand("iptables", "-t", "nat", "--flush").Assert(c, icmd.Success)
-	icmd.RunCommand("iptables", "--flush").Assert(c, icmd.Success)
-}
-
 func (s *DockerDaemonSuite) TestDaemonBridgeIP(c *testing.T) {
 	// TestDaemonBridgeIP Steps
 	// 1. Delete the existing docker0 Bridge

--- a/integration/network/helpers.go
+++ b/integration/network/helpers.go
@@ -31,6 +31,9 @@ func CreateVlanInterface(ctx context.Context, t *testing.T, master, slave, id st
 
 // DeleteInterface deletes a network interface
 func DeleteInterface(ctx context.Context, t *testing.T, ifName string) {
+	if icmd.RunCommand(ctx, "ip", "link", "show", ifName).ExitCode != 0 {
+		return
+	}
 	testutil.RunCommand(ctx, "ip", "link", "delete", ifName).Assert(t, icmd.Success)
 	testutil.RunCommand(ctx, "iptables", "-t", "nat", "--flush").Assert(t, icmd.Success)
 	testutil.RunCommand(ctx, "iptables", "--flush").Assert(t, icmd.Success)

--- a/integration/network/helpers_windows.go
+++ b/integration/network/helpers_windows.go
@@ -3,11 +3,17 @@ package network
 import (
 	"context"
 	"fmt"
+	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"gotest.tools/v3/assert/cmp"
 )
+
+// DeleteInterface deletes a network interface
+func DeleteInterface(_ context.Context, _ *testing.T, _ string) cmp.Comparison {
+	panic("DeleteInterface is not implemented on Windows")
+}
 
 // IsNetworkAvailable provides a comparison to check if a docker network is available
 func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name string) cmp.Comparison {

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -13,18 +13,9 @@ import (
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
-
-// delInterface removes given network interface
-func delInterface(ctx context.Context, t *testing.T, ifName string) {
-	t.Helper()
-	testutil.RunCommand(ctx, "ip", "link", "delete", ifName).Assert(t, icmd.Success)
-	testutil.RunCommand(ctx, "iptables", "-t", "nat", "--flush").Assert(t, icmd.Success)
-	testutil.RunCommand(ctx, "iptables", "--flush").Assert(t, icmd.Success)
-}
 
 func TestDaemonRestartWithLiveRestore(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
@@ -64,7 +55,7 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 	ctx := testutil.StartSpan(baseContext, t)
 
 	defaultNetworkBridge := "docker0"
-	delInterface(ctx, t, defaultNetworkBridge)
+	DeleteInterface(ctx, t, defaultNetworkBridge)
 	d := daemon.New(t)
 	defer d.Stop(t)
 	d.Start(t,
@@ -97,7 +88,7 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 	out, err = c.NetworkInspect(ctx, name, types.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	assert.Equal(t, out.IPAM.Config[0].Subnet, "175.33.1.0/24")
-	delInterface(ctx, t, defaultNetworkBridge)
+	DeleteInterface(ctx, t, defaultNetworkBridge)
 }
 
 func TestDaemonRestartWithExistingNetwork(t *testing.T) {
@@ -132,7 +123,7 @@ func TestDaemonRestartWithExistingNetwork(t *testing.T) {
 	out1, err := c.NetworkInspect(ctx, name, types.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	assert.Equal(t, out1.IPAM.Config[0].Subnet, networkip)
-	delInterface(ctx, t, defaultNetworkBridge)
+	DeleteInterface(ctx, t, defaultNetworkBridge)
 }
 
 func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
@@ -185,7 +176,7 @@ func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
 
 	assert.Check(t, out1.IPAM.Config[0].Subnet != networkip)
 	assert.Check(t, out1.IPAM.Config[0].Subnet != networkip2)
-	delInterface(ctx, t, defaultNetworkBridge)
+	DeleteInterface(ctx, t, defaultNetworkBridge)
 }
 
 func TestDaemonWithBipAndDefaultNetworkPool(t *testing.T) {
@@ -212,7 +203,7 @@ func TestDaemonWithBipAndDefaultNetworkPool(t *testing.T) {
 	assert.NilError(t, err)
 	// Make sure BIP IP doesn't get override with new default address pool .
 	assert.Equal(t, out.IPAM.Config[0].Subnet, "172.60.0.0/16")
-	delInterface(ctx, t, defaultNetworkBridge)
+	DeleteInterface(ctx, t, defaultNetworkBridge)
 }
 
 func TestServiceWithPredefinedNetwork(t *testing.T) {


### PR DESCRIPTION
hopefully addresses https://github.com/moby/moby/issues/39570

~this also reverts https://github.com/moby/moby/pull/39068/commits/6aafe0fd9ed34c4d91adde62c86e47518274a5e8 (added in https://github.com/moby/moby/pull/39068)~

### DockerDaemonSuite: cleanup "docker0" in TearDownTest
Some tests in the `DockerDaemonSuite` make modifications to the "docker0" bridge, which affects
tests running after them if they do not delete and re-create the interface.

This may also explain the `test_init_swarm_data_path_addr ` in `docker-py` failing:

```
E docker.errors.APIError: 400 Client Error: Bad Request ("interface eth0 has more than one IPv6 address (2001:db8:1::242:ac11:2 and fe80::42:acff:fe11:2)")
```

Which may be caused by `TestDaemonIPv6FixedCIDRAndMac `:

```
s.d.StartWithBusybox(c, "--ipv6", "--fixed-cidr-v6=2001:db8:1::/64")
```

The following tests remove the `docker0` interface:

- `DockerDaemonSuite.TestDaemonIPv6FixedCIDR`
- `DockerDaemonSuite.TestDaemonIPv6FixedCIDRAndMac`
- `DockerDaemonSuite.TestDaemonIPv6HostMode`
- `DockerDaemonSuite.TestDaemonBridgeIP`
- `DockerDaemonSuite.TestDaemonDefaultGatewayIPv4Implicit`
- `DockerDaemonSuite.TestDaemonDefaultGatewayIPv4Explicit`
- `DockerDaemonSuite.TestDaemonDefaultGatewayIPv4ExplicitOutsideContainerSubnet`
- `DockerDaemonSuite.TestDaemonDefaultNetworkInvalidClusterConfig`
- `DockerDaemonSuite.TestBridgeIPIsExcludedFromAllocatorPool`

This patch removes `docker0` after each test in the `DockerDaemonSuite`, to force
the next test to re-create it with the default configuration.

### integration/network: cleanup custom "docker0" bridge

These tests modify the "docker0" bridge. Use a consistent approach to make sure the modified bridge is cleaned up afterwards.
