### PR TITLE
Fix running in privileged mode against a daemon with --default-cgroupns-mode=host

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -361,11 +361,15 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConf
 
 	// Set default cgroup namespace mode, if unset for container
 	if hostConfig.CgroupnsMode.IsEmpty() {
-		m := config.DefaultCgroupNamespaceMode
-		if daemon.configStore != nil {
-			m = daemon.configStore.CgroupNamespaceMode
+		if hostConfig.Privileged {
+			hostConfig.CgroupnsMode = containertypes.CgroupnsMode("host")
+		} else {
+			m := config.DefaultCgroupNamespaceMode
+			if daemon.configStore != nil {
+				m = daemon.configStore.CgroupNamespaceMode
+			}
+			hostConfig.CgroupnsMode = containertypes.CgroupnsMode(m)
 		}
-		hostConfig.CgroupnsMode = containertypes.CgroupnsMode(m)
 	}
 
 	adaptSharedNamespaceContainer(daemon, hostConfig)

--- a/integration/container/run_cgroupns_linux_test.go
+++ b/integration/container/run_cgroupns_linux_test.go
@@ -68,7 +68,7 @@ func TestCgroupNamespacesRun(t *testing.T) {
 func TestCgroupNamespacesRunPrivileged(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	skip.If(t, testEnv.IsRemoteDaemon())
-	skip.If(t, requirement.CgroupNamespacesEnabled())
+	skip.If(t, !requirement.CgroupNamespacesEnabled())
 
 	// When the daemon defaults to private cgroup namespaces, privileged containers
 	// launched should not be inside their own cgroup namespaces


### PR DESCRIPTION
As per https://github.com/moby/moby/pull/38377#issuecomment-512894271

Two changes:
* Flip the cgroup ns check in `TestCgroupNamespacesRunPrivileged()`: it requires cgroup namespaces to be enabled, not the other way around.
* Explicitly set the cgroup namespace mode to `host` when running with `--privileged`, rather than falling back to the host default