### PR TITLE
added hack/ci/master as entry point for master codeline checks

### DIFF
--- a/hack/ci/master
+++ b/hack/ci/master
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Entrypoint for jenkins master CI build
+set -eu -o pipefail
+
+hack/validate/default
+hack/test/unit
+
+hack/make.sh \
+	binary-daemon \
+	dynbinary \
+	test-docker-py \
+	test-integration \
+	cross


### PR DESCRIPTION
Currently, the [Docker Master jenkins jobs](https://jenkins.dockerproject.org/job/Docker%20Master/) run this:
```
docker build --rm --force-rm --build-arg APT_MIRROR=cdn-fastly.deb.debian.org -t docker:master .
docker run --rm -t --privileged \
    	-v "$WORKSPACE/bundles:/go/src/github.com/docker/docker/bundles" \
  	-v "$WORKSPACE/.git:/go/src/github.com/docker/docker/.git" \
    	--name docker-master$BUILD_NUMBER \
        -e DOCKER_GRAPHDRIVER \
        -e DOCKER_EXECDRIVER=native \
  	-e DOCKER_GITCOMMIT=${GITCOMMIT} \
        -e TIMEOUT="90m" \
        docker:master sh -c "hack/validate/default && hack/test/unit && hack/make.sh"
```

Where the default order of tests to run in `hack/make.sh` is:
https://github.com/moby/moby/blob/48da116486059e57e1962234d6751b4b977ee1c8/hack/make.sh#L57-L66

However, since #39068 was merged, the Docker Master jenkins jobs have been [failing](https://jenkins.dockerproject.org/job/Docker%20Master/10684/label=ubuntu-1604-aufs-stable/console) with symptoms similar to #39570:
```
Status: Downloaded newer image for python:3.6-jessie
 ---> 890456b21ed5
Step 3/17 : RUN apt-get update && apt-get -y install     gnupg2     pass     curl
 ---> Running in 76b7ac82c248
Err http://deb.debian.org jessie InRelease
Err http://security.debian.org jessie/updates InRelease
Err http://deb.debian.org jessie Release.gpg
  Temporary failure resolving 'deb.debian.org'
Err http://security.debian.org jessie/updates Release.gpg
  Temporary failure resolving 'security.debian.org'
Reading package lists...
W: Failed to fetch http://deb.debian.org/debian/dists/jessie/InRelease  
W: Failed to fetch http://security.debian.org/debian-security/dists/jessie/updates/InRelease  
W: Failed to fetch http://deb.debian.org/debian/dists/jessie/Release.gpg  Temporary failure resolving 'deb.debian.org'
W: Failed to fetch http://security.debian.org/debian-security/dists/jessie/updates/Release.gpg Temporary failure resolving 'security.debian.org'
W: Some index files failed to download. They have been ignored, or old ones used instead.
Reading package lists...
Building dependency tree...
Reading state information...
Package gnupg2 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
E: Package 'gnupg2' has no installation candidate
E: Unable to locate package pass
The command '/bin/sh -c apt-get update && apt-get -y install     gnupg2     pass     curl' returned a non-zero code: 100
Build timed out (after 180 minutes). Marking the build as aborted.
Build was aborted
```

So, this PR will make sure the `docker-py` tests are run before `test-integration` tests in the `hack/ci/master` entry point script that will be used in the `Docker Master` jobs while PR #39562 is worked on to fix the issue with `docker-py`.
