### PR TITLE
Fix Dockerfile because of golang:1.12.7 change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV CRIU_VERSION 3.11
 # Install dependency packages specific to criu
 RUN apt-get update && apt-get install -y \
 	libnet-dev \
-	libprotobuf-c0-dev \
+	libprotobuf-c-dev \
 	libprotobuf-dev \
 	libnl-3-dev \
 	libcap-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -151,7 +151,7 @@ COPY hack/dockerfile/install/$INSTALL_BINARY_NAME.installer ./
 RUN PREFIX=/build ./install.sh $INSTALL_BINARY_NAME
 
 FROM dev-base AS containerd
-RUN apt-get update && apt-get install -y btrfs-tools
+RUN apt-get update && apt-get install -y btrfs-tools libbtrfs-dev
 ENV INSTALL_BINARY_NAME=containerd
 COPY hack/dockerfile/install/install.sh ./install.sh
 COPY hack/dockerfile/install/$INSTALL_BINARY_NAME.installer ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -214,6 +214,7 @@ RUN apt-get update && apt-get install -y \
 	btrfs-tools \
 	iptables \
 	jq \
+	libbtrfs-dev \
 	libcap2-bin \
 	libdevmapper-dev \
 	libudev-dev \


### PR DESCRIPTION
Something happened with the `golang:1.12.7` docker image recently where it is now based on `debian:buster` so some required packages are missing in the `Dockerfile`. Without this PR, failure to run:
```
$ make BIND_DIR=. shell
...
#53 4.618 E: Unable to locate package libprotobuf-c0-dev
...
```