### PR TITLE
Dockerfile.windows: trim .0 from Go versions

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -214,7 +214,7 @@ RUN `
   Download-File $location C:\gitsetup.zip; `
   `
   Write-Host INFO: Downloading go...; `
-  Download-File $('https://golang.org/dl/go'+$Env:GO_VERSION+'.windows-amd64.zip') C:\go.zip; `
+  Download-File $('https://golang.org/dl/go'+$Env:GO_VERSION.TrimEnd('.0')"+'.windows-amd64.zip') C:\go.zip; `
   `
   Write-Host INFO: Downloading compiler 1 of 3...; `
   Download-File https://raw.githubusercontent.com/jhowardmsft/docker-tdmgcc/master/gcc.zip C:\gcc.zip; `


### PR DESCRIPTION
This was an oversight when changing the Dockerfile to use a build-arg in https://github.com/moby/moby/pull/39548; the Windows Dockerfile downloads the Go binaries, which never have a trailing `.0`.

This patch makes sure that the trailing zero (if any) is removed.

