### PR TITLE
Added changes to integrate with the new Jenkins ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,39 +1,7 @@
-def withGithubStatus(String context, Closure cl) {
-  def setGithubStatus = { String state ->
-    try {
-      def backref = "${BUILD_URL}flowGraphTable/"
-      def reposSourceURL = scm.repositories[0].getURIs()[0].toString()
-      step(
-        $class: 'GitHubCommitStatusSetter',
-        contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
-        errorHandlers: [[$class: 'ShallowAnyErrorHandler']],
-        reposSource: [$class: 'ManuallyEnteredRepositorySource', url: reposSourceURL],
-        statusBackrefSource: [$class: 'ManuallyEnteredBackrefSource', backref: backref],
-        statusResultSource: [$class: 'ConditionalStatusResultSource', results: [[$class: 'AnyBuildResult', state: state]]],
-      )
-    } catch (err) {
-      echo "Exception from GitHubCommitStatusSetter for $context: $err"
-    }
-  }
-
-  setGithubStatus 'PENDING'
-
-  try {
-    cl()
-	} catch (err) {
-    // AbortException signals a "normal" build failure.
-    if (!(err instanceof hudson.AbortException)) {
-      echo "Exception in withGithubStatus for $context: $err"
-		}
-		setGithubStatus 'FAILURE'
-		throw err
-	}
-	setGithubStatus 'SUCCESS'
-}
-
-
 pipeline {
   agent none
+
+
   options {
     buildDiscarder(logRotator(daysToKeepStr: '30'))
     timeout(time: 3, unit: 'HOURS')
@@ -44,8 +12,8 @@ pipeline {
         booleanParam(name: 'z', defaultValue: true, description: 'IBM Z (s390x) Build/Test')
         booleanParam(name: 'powerpc', defaultValue: true, description: 'PowerPC (ppc64le) Build/Test')
         booleanParam(name: 'vendor', defaultValue: true, description: 'Vendor')
-        booleanParam(name: 'windowsRS1', defaultValue: true, description: 'Windows 2016 (RS1) Build/Test')
-        booleanParam(name: 'windowsRS5', defaultValue: true, description: 'Windows 2019 (RS5) Build/Test')
+        booleanParam(name: 'windowsRS1', defaultValue: false, description: 'Windows 2016 (RS1) Build/Test')
+        booleanParam(name: 'windowsRS5', defaultValue: false, description: 'Windows 2019 (RS5) Build/Test')
   }
   stages {
     stage('Build') {
@@ -55,13 +23,10 @@ pipeline {
             beforeAgent true
             expression { params.janky }
           }
-          agent {
-            node {
-              label 'ubuntu-1604-overlay2-stable'
-            }
-          }
+          agent { label 'amd64 && ubuntu-1804 && overlay2' }
+          environment { DOCKER_BUILDKIT='1' }
+
           steps {
-            withGithubStatus('janky') {
               sh '''
                 # todo: include ip_vs in base image
                 sudo modprobe ip_vs
@@ -84,7 +49,6 @@ pipeline {
                 echo "Building e2e image"
                 docker build --build-arg DOCKER_GITCOMMIT=$GITCOMMIT -t moby-e2e-test -f Dockerfile.e2e .
               '''
-            }
           }
           post {
             always {
@@ -96,10 +60,11 @@ pipeline {
                 docker run --rm -v "$WORKSPACE:/workspace" busybox chown -R "$(id -u):$(id -g)" /workspace
               '''
               sh '''
-                echo "Creating bundles.tar.gz"
-                (find bundles -name '*.log' -o -name '*.prof' -o -name integration.test | xargs tar -czf bundles.tar.gz) || true
+                echo "Creating janky-bundles.tar.gz"
+                (find bundles -name '*.log' -o -name '*.prof' -o -name integration.test | xargs tar -czf janky-bundles.tar.gz) || true
               '''
-              archiveArtifacts artifacts: 'bundles.tar.gz'
+              archiveArtifacts artifacts: 'janky-bundles.tar.gz'
+              deleteDir()
             }
           }
         }
@@ -108,13 +73,9 @@ pipeline {
             beforeAgent true
             expression { params.experimental }
           }
-          agent {
-            node {
-              label 'ubuntu-1604-aufs-stable'
-            }
-          }
+          agent { label 'amd64 && ubuntu-1804 && overlay2' }
+          environment { DOCKER_BUILDKIT='1' }
           steps {
-            withGithubStatus('experimental') {
               sh '''
                 GITCOMMIT=$(git rev-parse --short HEAD)
                 docker build --rm --force-rm --build-arg APT_MIRROR=cdn-fastly.deb.debian.org -t docker:${GITCOMMIT}-exp .
@@ -128,7 +89,6 @@ pipeline {
                     docker:${GITCOMMIT}-exp \
                     hack/ci/experimental
               '''
-            }
           }
           post {
             always {
@@ -141,9 +101,13 @@ pipeline {
               '''
               sh '''
                 echo "Creating bundles.tar.gz"
-                (find bundles -name '*.log' -o -name '*.prof' -o -name integration.test | xargs tar -czf bundles.tar.gz) || true
+                (find bundles -name '*.log' -o -name '*.prof' -o -name integration.test | xargs tar -czf experimental-bundles.tar.gz) || true
               '''
-              archiveArtifacts artifacts: 'bundles.tar.gz'
+              sh '''
+                make clean
+              '''
+              archiveArtifacts artifacts: 'experimental-bundles.tar.gz'
+              deleteDir()
             }
           }
         }
@@ -152,13 +116,8 @@ pipeline {
             beforeAgent true
             expression { params.z }
           }
-          agent {
-            node {
-              label 's390x-ubuntu-1604'
-            }
-          }
+          agent { label 's390x-ubuntu-1604' }
           steps {
-            withGithubStatus('z') {
               sh '''
                 GITCOMMIT=$(git rev-parse --short HEAD)
 
@@ -175,7 +134,6 @@ pipeline {
                     docker-s390x:$GITCOMMIT \
                     hack/ci/z
               '''
-            }
           }
           post {
             always {
@@ -188,9 +146,10 @@ pipeline {
               '''
               sh '''
                 echo "Creating bundles.tar.gz"
-                find bundles -name '*.log' | xargs tar -czf bundles.tar.gz
+                find bundles -name '*.log' | xargs tar -czf s390x-bundles.tar.gz
               '''
-              archiveArtifacts artifacts: 'bundles.tar.gz'
+              archiveArtifacts artifacts: 's390x-bundles.tar.gz'
+              deleteDir()
             }
           }
         }
@@ -199,13 +158,8 @@ pipeline {
             beforeAgent true
             expression { params.powerpc }
           }
-          agent {
-            node {
-              label 'ppc64le-ubuntu-1604'
-            }
-          }
+          agent { label 'ppc64le-ubuntu-1604' }
           steps {
-            withGithubStatus('powerpc') {
               sh '''
                 GITCOMMIT=$(git rev-parse --short HEAD)
 
@@ -222,7 +176,6 @@ pipeline {
                     docker-powerpc:$GITCOMMIT \
                     hack/ci/powerpc
               '''
-            }
           }
           post {
             always {
@@ -235,9 +188,10 @@ pipeline {
               '''
               sh '''
                 echo "Creating bundles.tar.gz"
-                find bundles -name '*.log' | xargs tar -czf bundles.tar.gz
+                find bundles -name '*.log' | xargs tar -czf powerpc-bundles.tar.gz
               '''
-              archiveArtifacts artifacts: 'bundles.tar.gz'
+              archiveArtifacts artifacts: 'powerpc-bundles.tar.gz'
+              deleteDir()
             }
           }
         }
@@ -246,13 +200,9 @@ pipeline {
             beforeAgent true
             expression { params.vendor }
           }
-          agent {
-            node {
-              label 'ubuntu-1604-aufs-stable'
-            }
-          }
+          agent { label 'amd64 && ubuntu-1804 && overlay2' }
+          environment { DOCKER_BUILDKIT='1' }
           steps {
-            withGithubStatus('vendor') {
               sh '''
                 GITCOMMIT=$(git rev-parse --short HEAD)
 
@@ -266,7 +216,6 @@ pipeline {
                   -e TIMEOUT=120m dockerven:$GITCOMMIT \
                   hack/validate/vendor
               '''
-            }
           }
         }
         stage('windowsRS1') {
@@ -281,13 +230,11 @@ pipeline {
             }
           }
           steps {
-            withGithubStatus('windowsRS1') {
               powershell '''
                 $ErrorActionPreference = 'Stop'
                 .\\hack\\ci\\windows.ps1
                 exit $LastExitCode
               '''
-            }
           }
         }
         stage('windowsRS5-process') {
@@ -302,13 +249,11 @@ pipeline {
             }
           }
           steps {
-            withGithubStatus('windowsRS5-process') {
               powershell '''
                 $ErrorActionPreference = 'Stop'
                 .\\hack\\ci\\windows.ps1
                 exit $LastExitCode
               '''
-            }
           }
         }
       }


### PR DESCRIPTION
**Description**

This PR contains the code to trigger the job on the new Jenkins set up at: ci.docker.com/public.  It is removing the reference to `withGithubStatus` in moby and instead it should pick up from our internal jenkins integration setup

Finally the windows pet machines have been set to false, so that we do not test windows builds as there is no communication between the new Jenkins and these windows machines

**How it was done**

I removed references to withGithubStatus and set the job to not run on the windows nodes

**Verification**

Testing this was a little funky.  The way I went about testing these changes was: 
1. Create a Jenkins job here: https://ci.docker.com/public/job/moby-test/job/ze-moby/
2.  Next I created two PRs
    - This PR tests the jobs and makes sure that they run: https://github.com/zelahi/moby/pull/1/files.  The corresponding Jenkins job is here: https://ci.docker.com/public/job/moby-test/job/ze-moby/view/change-requests/job/PR-1/
    - This PR tests to make sure the Jenkins notifications are getting populated: https://github.com/zelahi/moby/pull/2
- The corresponding Jenkins job is here: https://ci.docker.com/public/job/moby-test/job/ze-moby/view/change-requests/job/PR-2/

For the first test, it looks like the `janky` job times out after 3 hours.  We may want to shorten the timeout period for janky but overall the communication with the new Jenkins machines looks to work as expected

**Changelog Description**

Integrate moby/moby ci with ci.docker.com/public

**Cute animal pic**

![image](https://user-images.githubusercontent.com/5545603/61814487-0e508580-adfd-11e9-9912-4ef9f9f2e4a8.png)




@psftw 