### PR TITLE
Tailor CI for ARM, skip legacy integration test.

### DIFF
--- a/hack/ci/arm
+++ b/hack/ci/arm
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 hack/test/unit
 
-hack/make.sh \
+TEST_SKIP_INTEGRATION_CLI=1 hack/make.sh \
 	binary-daemon \
 	dynbinary \
 	test-integration


### PR DESCRIPTION
Signed-off-by: Michael Zhao <michael.zhao@arm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This PR is trying to make a minimal test set (without legacy integration test cases) for ARM. 
Introduce a new environment variable SKIP_LEGACY_INTEGRATION_TEST to control whether legacy integration test cases are ignored or not. 

**- How I did it**

- Introduce a new environment variable SKIP_LEGACY_INTEGRATION_TEST, default value is "no". 
- If it's set to "yes" or anything rather than "no", legacy integration suites will be skipped.
- In arm CI, SKIP_LEGACY_INTEGRATION_TEST is set to "yes".
- CI for other architecture's are not impacted.

**- How to verify it**
Run "make test-integration" on an ARM machine.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
See the discussion in issue: https://github.com/moby/moby/issues/39479
Backgroud: CI on arm (32 and 64 bit) architecture took too long time to finish. So the CI for it was stopped. Now I am trying to bring it back, and try to set a minimal set in it to save time.

**- A picture of a cute animal (not mandatory but encouraged)**
<img src="https://www.telegraph.co.uk/content/dam/news/2016/07/23/103872971_Mandatory_Credit_Photo_by_Huw_Evans-REX-Shutterstock_5780863o__A_squirrel_invades_the_pitc_trans_NvBQzQNjv4BqnpV-GRdD2fQt8qdeuHLgxdBbmO-kKPcMjZpO6V3FYuw.jpg?imwidth=1400" >

