### PR TITLE
Add `FromClient` to test env execution

### DIFF
--- a/internal/test/environment/environment.go
+++ b/internal/test/environment/environment.go
@@ -34,13 +34,18 @@ type PlatformDefaults struct {
 }
 
 // New creates a new Execution struct
+// This is configured useing the env client (see client.FromEnv)
 func New() (*Execution, error) {
-	client, err := client.NewClientWithOpts(client.FromEnv)
+	c, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create client")
 	}
+	return FromClient(c)
+}
 
-	info, err := client.Info(context.Background())
+// FromClient creates a new Execution environment from the passed in client
+func FromClient(c *client.Client) (*Execution, error) {
+	info, err := c.Info(context.Background())
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get info from daemon")
 	}
@@ -48,7 +53,7 @@ func New() (*Execution, error) {
 	osType := getOSType(info)
 
 	return &Execution{
-		client:            client,
+		client:            c,
 		DaemonInfo:        info,
 		OSType:            osType,
 		PlatformDefaults:  getPlatformDefaults(info, osType),


### PR DESCRIPTION
While working on other tests I noticed that environment.Execution cannot
be used for anything but the pre-configured daemon, however this can
come in handy for being able share daemons across multiple tests that
currently spin up a new daemon.
The execution env also seems to be misused in some of these cases.
