### PR TITLE
hack: Remove inContainer check, it wasn't useful

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -28,30 +28,6 @@ export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export MAKEDIR="$SCRIPTDIR/make"
 export PKG_CONFIG=${PKG_CONFIG:-pkg-config}
 
-# We're a nice, sexy, little shell script, and people might try to run us;
-# but really, they shouldn't. We want to be in a container!
-inContainer="AssumeSoInitially"
-if [ "$(go env GOHOSTOS)" = 'windows' ]; then
-	if [ -z "$FROM_DOCKERFILE" ]; then
-		unset inContainer
-	fi
-else
-	if [ "$PWD" != "/go/src/$DOCKER_PKG" ]; then
-		unset inContainer
-	fi
-fi
-
-if [ -z "$inContainer" ]; then
-	{
-		echo "# WARNING! I don't seem to be running in a Docker container."
-		echo "# The result of this command might be an incorrect build, and will not be"
-		echo "# officially supported."
-		echo "#"
-		echo "# Try this instead: make all"
-		echo "#"
-	} >&2
-fi
-
 echo
 
 # List of bundles to create when no argument is passed


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The inContainer check isn't really useful anymore.


Even though it was said that we shouldn't rely on its existence back in
[2016](https://github.com/moby/moby/issues/18355#issuecomment-220484748), we're now in 2019 and this thing still exists so we should just
rely on it now to check whether or not we're in a container.

It was annoying to look at our **official builds** and see, *these builds will not be officially supported*. >.>

**- How I did it**

* Change the check in `hack/make.sh`

**- How to verify it**

* All scripts should run the same and have no functional change

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

* No changelog entry needed

**- A picture of a cute animal (not mandatory but encouraged)**

![owl](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSvxYmhlQhmEzhpT7-9-plBGl44NONoC1t-UZBV_zy0MtISdlXa)