### PR TITLE
Fix CVE-2019-14271 loading of nsswitch based config inside chroot under Glibc

### DIFF
--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -4,12 +4,21 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
+	"os/user"
 	"path/filepath"
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
 )
+
+func init() {
+	// initialize nss libraries in Glibc so that the dynamic libraries are loaded in the host
+	// environment not in the chroot from untrusted files.
+	_, _ = user.Lookup("docker")
+	_, _ = net.LookupHost("localhost")
+}
 
 // NewArchiver returns a new Archiver which uses chrootarchive.Untar
 func NewArchiver(idMapping *idtools.IdentityMapping) *archive.Archiver {


### PR DESCRIPTION
Initialize nss libraries in Glibc so that the dynamic libraries are loaded in the host environment not in the chroot from untrusted files.

[CVE-2019-14271](https://nvd.nist.gov/vuln/detail/CVE-2019-14271) may allow unprivileged access to host system while copying files from a malicious container image with `docker cp` command.

**Affected versions**: v19.03.0. Older Docker versions are not affected by this issue.
 
This fix is included in the already released [Docker v19.03.1](https://github.com/docker/docker-ce/releases/v19.03.1). Users of Docker v19.03.0 are advised to upgrade.

The patch was previously reviewed internally by maintainers under GitHub security advisory.
If you find security issues in Moby, please follow responsible disclosure guidelines by sending an email to security@docker.com.