### PR TITLE
Support for external daemon plugins

### DIFF
--- a/daemon/plugin/plugin.go
+++ b/daemon/plugin/plugin.go
@@ -1,0 +1,241 @@
+package plugin // import "github.com/docker/docker/daemon/plugin"
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/docker/docker/daemon"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+const (
+	// GRPCPlugin implements a grpc service
+	GRPCPlugin Type = "io.docker.grpc.v1"
+)
+
+// Type is the type of the plugin
+type Type string
+
+func (t Type) String() string { return string(t) }
+
+var (
+	// ErrNoType is returned when no type is specified
+	ErrNoType = errors.New("plugin: no type")
+	// ErrNoPluginID is returned when no id is specified
+	ErrNoPluginID = errors.New("plugin: no id")
+
+	// ErrSkipPlugin is used when a plugin is not initialized and should not be loaded,
+	// this allows the plugin loader differentiate between a plugin which is configured
+	// not to load and one that fails to load.
+	ErrSkipPlugin = errors.New("skip plugin")
+
+	// ErrInvalidRequires will be thrown if the requirements for a plugin are
+	// defined in an invalid manner.
+	ErrInvalidRequires = errors.New("invalid requires")
+)
+
+// Context is used for plugin inititalization
+type Context struct {
+	Context context.Context
+	Config  interface{}
+	Daemon  *daemon.Daemon
+
+	Meta *Meta // plugins can fill in metadata at init.
+
+	plugins *Set
+}
+
+// NewContext returns a new plugin Context
+func NewContext(ctx context.Context, r *Registration, plugins *Set, d *daemon.Daemon) *Context {
+	return &Context{
+		Context: ctx,
+		Daemon:  d,
+		Meta:    &Meta{},
+		plugins: plugins,
+	}
+}
+
+// Get returns the first plugin by its type
+func (i *Context) Get(t Type) (interface{}, error) {
+	return i.plugins.Get(t)
+}
+
+// Meta contains information gathered from the registration and initialization
+// process.
+type Meta struct {
+	Platforms []ocispec.Platform // platforms supported by plugin
+}
+
+// Plugin represents an initialized plugin, used with an init context.
+type Plugin struct {
+	Registration *Registration // registration, as initialized
+	Config       interface{}   // config, as initialized
+	Meta         *Meta
+
+	instance interface{}
+	err      error // will be set if there was an error initializing the plugin
+}
+
+// Err returns the errors during initialization.
+// returns nil if not error was encountered
+func (p *Plugin) Err() error {
+	return p.err
+}
+
+// Instance returns the instance and any initialization error of the plugin
+func (p *Plugin) Instance() (interface{}, error) {
+	return p.instance, p.err
+}
+
+// Set defines a plugin collection, used with Context.
+type Set struct {
+	ordered     []*Plugin // order of initialization
+	byTypeAndID map[Type]map[string]*Plugin
+}
+
+// NewPluginSet returns an initialized plugin set
+func NewPluginSet() *Set {
+	return &Set{
+		byTypeAndID: make(map[Type]map[string]*Plugin),
+	}
+}
+
+// Add a plugin to the set
+func (ps *Set) Add(p *Plugin) error {
+	if byID, typeok := ps.byTypeAndID[p.Registration.Type]; !typeok {
+		ps.byTypeAndID[p.Registration.Type] = map[string]*Plugin{
+			p.Registration.ID: p,
+		}
+	} else if _, idok := byID[p.Registration.ID]; !idok {
+		byID[p.Registration.ID] = p
+	} else {
+		return errors.Wrapf(errdefs.ErrAlreadyExists, "plugin %v already initialized", p.Registration.URI())
+	}
+
+	ps.ordered = append(ps.ordered, p)
+	return nil
+}
+
+// Get returns the first plugin by its type
+func (ps *Set) Get(t Type) (interface{}, error) {
+	for _, v := range ps.byTypeAndID[t] {
+		return v.Instance()
+	}
+	return nil, errors.Wrapf(errdefs.ErrNotFound, "no plugins registered for %s", t)
+}
+
+// GetAll plugins in the set
+func (i *Context) GetAll() []*Plugin {
+	return i.plugins.ordered
+}
+
+// GetByType returns all plugins with the specific type.
+func (i *Context) GetByType(t Type) (map[string]*Plugin, error) {
+	p, ok := i.plugins.byTypeAndID[t]
+	if !ok {
+		return nil, errors.Wrapf(errdefs.ErrNotFound, "no plugins registered for %s", t)
+	}
+
+	return p, nil
+}
+
+// IsSkipPlugin returns true if the error is skipping the plugin
+func IsSkipPlugin(err error) bool {
+	return errors.Cause(err) == ErrSkipPlugin
+}
+
+// Registration contains information for registering a plugin
+type Registration struct {
+	// Type of the plugin
+	Type Type
+	// ID of the plugin
+	ID string
+	// Config specific to the plugin
+	Config interface{}
+	// Requires is a list of plugins that the registered plugin requires to be available
+	Requires []Type
+
+	// InitFn is called when initializing a plugin. The registration and
+	// context are passed in. The init function may modify the registration to
+	// add exports, capabilities and platform support declarations.
+	InitFn func(*Context) (interface{}, error)
+}
+
+// Init the registered plugin
+func (r *Registration) Init(ic *Context) *Plugin {
+	p, err := r.InitFn(ic)
+	return &Plugin{
+		Registration: r,
+		Config:       ic.Config,
+		Meta:         ic.Meta,
+		instance:     p,
+		err:          err,
+	}
+}
+
+// URI returns the full plugin URI
+func (r *Registration) URI() string {
+	return fmt.Sprintf("%s.%s", r.Type, r.ID)
+}
+
+var register = struct {
+	sync.RWMutex
+	r []*Registration
+}{}
+
+// Register allows plugins to register
+func Register(r *Registration) {
+	register.Lock()
+	defer register.Unlock()
+	if r.Type == "" {
+		panic(ErrNoType)
+	}
+	if r.ID == "" {
+		panic(ErrNoPluginID)
+	}
+
+	var last bool
+	for _, requires := range r.Requires {
+		if requires == "*" {
+			last = true
+		}
+	}
+	if last && len(r.Requires) != 1 {
+		panic(ErrInvalidRequires)
+	}
+
+	register.r = append(register.r, r)
+}
+
+// Graph returns the list of registered plugins
+func Graph() (ordered []*Registration) {
+	register.RLock()
+	defer register.RUnlock()
+
+	added := map[*Registration]bool{}
+	for _, r := range register.r {
+		pluginChildren(r.ID, r.Requires, added, &ordered)
+		if !added[r] {
+			ordered = append(ordered, r)
+			added[r] = true
+		}
+	}
+	return ordered
+}
+
+func pluginChildren(id string, types []Type, added map[*Registration]bool, ordered *[]*Registration) {
+	for _, t := range types {
+		for _, r := range register.r {
+			if r.ID != id && (t == "*" || r.Type == t) {
+				pluginChildren(r.ID, r.Requires, added, ordered)
+				if !added[r] {
+					*ordered = append(*ordered, r)
+					added[r] = true
+				}
+			}
+		}
+	}
+}

--- a/daemon/plugin/plugin_test.go
+++ b/daemon/plugin/plugin_test.go
@@ -1,0 +1,31 @@
+package plugin // import "github.com/docker/docker/daemon/plugin"
+
+import (
+	"fmt"
+	"testing"
+)
+
+func init() {
+	Register(&Registration{
+		Type: GRPCPlugin,
+		ID:   "testplugin",
+		InitFn: func(ic *Context) (interface{}, error) {
+			return struct{}{}, nil
+		},
+	})
+}
+
+func TestDaemonPluginInit(t *testing.T) {
+	plugins := Graph()
+	registered := false
+	for _, p := range plugins {
+		fmt.Println(p.URI())
+		if p.URI() == "io.docker.grpc.v1.testplugin" {
+			registered = true
+		}
+	}
+
+	if !registered {
+		t.Fatal("expected test plugin to be registered")
+	}
+}


### PR DESCRIPTION
This adds support for external daemon plugins (currently GRPC).  This is a light port of the containerd plugin model where plugins can `Register` as a daemon plugin.  These are then initialized at init and can operate directly with the daemon.  This is useful, for example, if a plugin needs to operate on an internal system such as the content store that is not accessible via the API.

An example plugin could be something like this:

```go
// local implements the api/server/router/grpc.Backend interface
type local struct {}

func init() {
        plugin.Register(&plugin.PluginRegistration{
                Type: plugin.GRPCPlugin,
                ID:   "foo",
                InitFn: func(ic *plugin.PluginContext) (interface{}, error) {
                        return &local{}, nil
                },
        })
}
```

Then plugins can simply be included at build time with a blank import:

```go
import (
        ...
        _ "github.com/ehazlett/foo/plugin"
)
```