### PR TITLE
Fix TestSwarmClusterRotateUnlockKey

### DIFF
--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1312,7 +1312,7 @@ func (s *DockerSwarmSuite) TestSwarmRotateUnlockKey(c *check.C) {
 			// an issue sometimes prevents leader to be available right away
 			outs, err = d.Cmd("node", "ls")
 			if err != nil && retry < 5 {
-				if strings.Contains(err.Error(), "swarm does not have a leader") {
+				if strings.Contains(outs, "swarm does not have a leader") {
 					retry++
 					time.Sleep(3 * time.Second)
 					continue
@@ -1404,7 +1404,7 @@ func (s *DockerSwarmSuite) TestSwarmClusterRotateUnlockKey(c *check.C) {
 				// an issue sometimes prevents leader to be available right away
 				outs, err = d.Cmd("node", "ls")
 				if err != nil && retry < 5 {
-					if strings.Contains(err.Error(), "swarm does not have a leader") {
+					if strings.Contains(outs, "swarm does not have a leader") {
 						retry++
 						time.Sleep(3 * time.Second)
 						continue


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/38885 Flaky test: DockerSwarmSuite.TestSwarmClusterRotateUnlockKey
- addresses https://github.com/moby/moby/issues/39499 flaky DockerSwarmSuite tests
- addresses https://github.com/moby/moby/issues/37306 EPIC: flaky tests
- addresses https://github.com/moby/moby/issues/33041 flaky test: DockerSwarmSuite.TearDownTest on PowerPC

TestSwarmClusterRotateUnlockKey had been identified as a flaky test. It turns out that the test code was wrong: where we should have been checking the string output of a command, we were instead checking the value of the error. This means that the error case we were expecting was not being matched, and the test was failing when it should have just retried.