### PR TITLE
Make new namespaces for tar cmd's

### DIFF
--- a/pkg/chrootarchive/archive_unix.go
+++ b/pkg/chrootarchive/archive_unix.go
@@ -51,6 +51,10 @@ func untar() {
 		fatal(err)
 	}
 
+	if err := dropCapabilities(); err != nil {
+		fatal(err)
+	}
+
 	if err := archive.Unpack(os.Stdin, dst, &options); err != nil {
 		fatal(err)
 	}
@@ -144,6 +148,10 @@ func tar() {
 
 	if err := realChroot(root); err != nil {
 		fatal(err)
+	}
+
+	if err := dropCapabilities(); err != nil {
+		fatal(errors.Wrap(err, "error dropping capabilities"))
 	}
 
 	var options archive.TarOptions

--- a/pkg/chrootarchive/archive_unix.go
+++ b/pkg/chrootarchive/archive_unix.go
@@ -24,6 +24,10 @@ import (
 // chroot and rexec.
 func untar() {
 	runtime.LockOSThread()
+	if err := setupMountNS(); err != nil {
+		fatal(err)
+	}
+
 	flag.Parse()
 
 	var options archive.TarOptions
@@ -89,6 +93,7 @@ func invokeUnpack(decompressedArchive io.Reader, dest string, options *archive.T
 
 	cmd := reexec.Command("docker-untar", dest, root)
 	cmd.Stdin = decompressedArchive
+	configureSysProc(cmd)
 
 	cmd.ExtraFiles = append(cmd.ExtraFiles, r)
 	output := bytes.NewBuffer(nil)
@@ -120,6 +125,11 @@ func invokeUnpack(decompressedArchive io.Reader, dest string, options *archive.T
 
 func tar() {
 	runtime.LockOSThread()
+
+	if err := setupMountNS(); err != nil {
+		fatal(err)
+	}
+
 	flag.Parse()
 
 	src := flag.Arg(0)
@@ -176,6 +186,7 @@ func invokePack(srcPath string, options *archive.TarOptions, root string) (io.Re
 	}
 
 	cmd := reexec.Command("docker-tar", relSrc, root)
+	configureSysProc(cmd)
 
 	errBuff := bytes.NewBuffer(nil)
 	cmd.Stderr = errBuff

--- a/pkg/chrootarchive/chroot_linux.go
+++ b/pkg/chrootarchive/chroot_linux.go
@@ -23,19 +23,6 @@ func chroot(path string) (err error) {
 	if sys.RunningInUserNS() {
 		return realChroot(path)
 	}
-	if err := unix.Unshare(unix.CLONE_NEWNS); err != nil {
-		return fmt.Errorf("Error creating mount namespace before pivot: %v", err)
-	}
-
-	// Make everything in new ns slave.
-	// Don't use `private` here as this could race where the mountns gets a
-	//   reference to a mount and an unmount from the host does not propagate,
-	//   which could potentially cause transient errors for other operations,
-	//   even though this should be relatively small window here `slave` should
-	//   not cause any problems.
-	if err := mount.MakeRSlave("/"); err != nil {
-		return err
-	}
 
 	if mounted, _ := mountinfo.Mounted(path); !mounted {
 		if err := mount.Mount(path, path, "bind", "rbind,rw"); err != nil {

--- a/pkg/chrootarchive/cmd_linux.go
+++ b/pkg/chrootarchive/cmd_linux.go
@@ -1,0 +1,41 @@
+package chrootarchive
+
+import (
+	"os/exec"
+	"syscall"
+
+	"github.com/docker/docker/pkg/mount"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+func configureSysProc(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &unix.SysProcAttr{
+		Cloneflags: unix.CLONE_NEWNET | unix.CLONE_NEWPID | unix.CLONE_NEWIPC | unix.CLONE_NEWUTS | unix.CLONE_NEWNS,
+		Pdeathsig:  syscall.SIGKILL,
+	}
+}
+
+// As part of setting up this process we created a new mount ns and a new pid ns.
+// This configures the mount ns to take advantage of that to further isolate the process.
+func setupMountNS() error {
+	// Make everything in new ns slave.
+	// Don't use `private` here as this could race where the mountns gets a
+	//   reference to a mount and an unmount from the host does not propagate,
+	//   which could potentially cause transient errors for other operations,
+	//   even though this should be relatively small window here `slave` should
+	//   not cause any problems.
+	if err := mount.MakeRSlave("/"); err != nil {
+		return errors.Wrap(err, "error remounting rootfs as with slave mounts")
+	}
+
+	// Remount /proc so it is accounting for the new namespaces
+	if err := mount.Unmount("/proc"); err != nil {
+		return errors.Wrap(err, "error unmounting /proc")
+	}
+
+	if err := unix.Mount("proc", "/proc", "proc", 0, "hidepid=2"); err != nil {
+		return errors.Wrap(err, "error remounting /proc")
+	}
+	return nil
+}

--- a/pkg/chrootarchive/cmd_unsupported.go
+++ b/pkg/chrootarchive/cmd_unsupported.go
@@ -10,3 +10,7 @@ func configureSysProc(cmd *exec.Cmd) {
 func setupMountNS() error {
 	return nil
 }
+
+func dropCapabilities() error {
+	return nil
+}

--- a/pkg/chrootarchive/cmd_unsupported.go
+++ b/pkg/chrootarchive/cmd_unsupported.go
@@ -1,0 +1,12 @@
+// +build !linux
+
+package chrootarchive
+
+import "os/exec"
+
+func configureSysProc(cmd *exec.Cmd) {
+}
+
+func setupMountNS() error {
+	return nil
+}

--- a/pkg/chrootarchive/diff_unix.go
+++ b/pkg/chrootarchive/diff_unix.go
@@ -27,13 +27,18 @@ type applyLayerResponse struct {
 // used on Windows as it does not support chroot, hence no point sandboxing
 // through chroot and rexec.
 func applyLayer() {
-
 	var (
 		tmpDir  string
 		err     error
 		options *archive.TarOptions
 	)
+
 	runtime.LockOSThread()
+
+	if err := setupMountNS(); err != nil {
+		fatal(err)
+	}
+
 	flag.Parse()
 
 	inUserns := sys.RunningInUserNS()
@@ -111,6 +116,7 @@ func applyLayerHandler(dest string, layer io.Reader, options *archive.TarOptions
 	cmd := reexec.Command("docker-applyLayer", dest)
 	cmd.Stdin = layer
 	cmd.Env = append(cmd.Env, fmt.Sprintf("OPT=%s", data))
+	configureSysProc(cmd)
 
 	outBuf, errBuf := new(bytes.Buffer), new(bytes.Buffer)
 	cmd.Stdout, cmd.Stderr = outBuf, errBuf

--- a/pkg/chrootarchive/diff_unix.go
+++ b/pkg/chrootarchive/diff_unix.go
@@ -46,6 +46,10 @@ func applyLayer() {
 		fatal(err)
 	}
 
+	if err := dropCapabilities(); err != nil {
+		fatal(err)
+	}
+
 	// We need to be able to set any perms
 	oldmask, err := system.Umask(0)
 	defer system.Umask(oldmask)


### PR DESCRIPTION
This is an easy win to decrease the blast radius if these commands are
able to be compromised in the future.

I decided not to create a new mount ns since this isn't generally useful
unless we also make make the namespace private. It's probably better to
just drop the ability to mount/unmount.

We can probably support user namespaces here (if the container has
userns), however I think this will require messing around with our tar
options, so not doing this here.