### PR TITLE
Add ci info to docs

### DIFF
--- a/docs/contributing/test.md
+++ b/docs/contributing/test.md
@@ -238,6 +238,14 @@ run a Bash terminal on Windows.
 You can now choose to make changes to the Moby source or the tests. If you
 make any changes, just run these commands again.
 
+## [Public CI infrastructure](ci.docker.com/public)
+
+The current infrastructure is maintained here: [Moby ci job](https://ci.docker.com/public/job/moby).  The Jenkins infrastructure is for the Moby project is maintained and
+managed by Docker Inc.  All contributions against the Jenkinsfile are
+appreciated and welcomed!  However we might not be able to fully provide the
+infrastructure to test against various architectures in our CI pipelines.  All
+jobs can be triggered and re-ran by the Moby maintainers
+
 ## Where to go next
 
 Congratulations, you have successfully completed the basics you need to


### PR DESCRIPTION
Added information regarding our new Jenkins ci on moby/moby

Signed-off-by: zelahi <elahi.zuhayr@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added notes regarding our ci.docker.com/public infra in the testing section

**- How I did it**
Added a section in the test.md section

**- How to verify it**
Looked through the documentation and provided the minimum info to understand the infrastructure

**- Description for the changelog**
No changelog description required


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/5545603/62087567-09ce0780-b217-11e9-9b02-146fc4446874.png)


