### PR TITLE
bump libnetwork to 09cdcc8c0eab3946c2d70e8f6225b05baf1e90d1

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=83d30db53600b9c084d35fb1d560f97f8b34ab24
+LIBNETWORK_COMMIT=09cdcc8c0eab3946c2d70e8f6225b05baf1e90d1
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -39,7 +39,7 @@ github.com/gofrs/flock                              7f43ea2e6a643ad441fc12d0ecc0
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        83d30db53600b9c084d35fb1d560f97f8b34ab24
+github.com/docker/libnetwork                        09cdcc8c0eab3946c2d70e8f6225b05baf1e90d1
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/controller.go
+++ b/vendor/github.com/docker/libnetwork/controller.go
@@ -706,9 +706,10 @@ const overlayDSROptionString = "dsr"
 // are network specific and modeled in a generic way.
 func (c *controller) NewNetwork(networkType, name string, id string, options ...NetworkOption) (Network, error) {
 	var (
-		cap *driverapi.Capability
-		err error
-		t   *network
+		cap            *driverapi.Capability
+		err            error
+		t              *network
+		skipCfgEpCount bool
 	)
 
 	if id != "" {
@@ -801,8 +802,9 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 		if err = t.applyConfigurationTo(network); err != nil {
 			return nil, types.InternalErrorf("Failed to apply configuration: %v", err)
 		}
+		network.generic[netlabel.Internal] = network.internal
 		defer func() {
-			if err == nil {
+			if err == nil && !skipCfgEpCount {
 				if err := t.getEpCnt().IncEndpointCnt(); err != nil {
 					logrus.Warnf("Failed to update reference count for configuration network %q on creation of network %q: %v",
 						t.Name(), network.Name(), err)
@@ -823,7 +825,13 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 
 	err = c.addNetwork(network)
 	if err != nil {
-		return nil, err
+		if strings.Contains(err.Error(), "restoring existing network") {
+			// This error can be ignored and set this boolean
+			// value to skip a refcount increment for configOnly networks
+			skipCfgEpCount = true
+		} else {
+			return nil, err
+		}
 	}
 	defer func() {
 		if err != nil {

--- a/vendor/github.com/docker/libnetwork/drivers/ipvlan/ipvlan_network.go
+++ b/vendor/github.com/docker/libnetwork/drivers/ipvlan/ipvlan_network.go
@@ -60,9 +60,13 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 		// empty parent and --internal are handled the same. Set here to update k/v
 		config.Internal = true
 	}
-	err = d.createNetwork(config)
+	foundExisting, err := d.createNetwork(config)
 	if err != nil {
 		return err
+	}
+
+	if foundExisting {
+		return types.InternalMaskableErrorf("restoring existing network %s", config.ID)
 	}
 	// update persistent db, rollback on fail
 	err = d.storeUpdate(config)
@@ -76,12 +80,18 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 }
 
 // createNetwork is used by new network callbacks and persistent network cache
-func (d *driver) createNetwork(config *configuration) error {
+func (d *driver) createNetwork(config *configuration) (bool, error) {
+	foundExisting := false
 	networkList := d.getNetworks()
 	for _, nw := range networkList {
 		if config.Parent == nw.config.Parent {
-			return fmt.Errorf("network %s is already using parent interface %s",
-				getDummyName(stringid.TruncateID(nw.config.ID)), config.Parent)
+			if config.ID != nw.config.ID {
+				return false, fmt.Errorf("network %s is already using parent interface %s",
+					getDummyName(stringid.TruncateID(nw.config.ID)), config.Parent)
+			}
+			logrus.Debugf("Create Network for the same ID %s\n", config.ID)
+			foundExisting = true
+			break
 		}
 	}
 	if !parentExists(config.Parent) {
@@ -89,9 +99,10 @@ func (d *driver) createNetwork(config *configuration) error {
 		if config.Internal {
 			err := createDummyLink(config.Parent, getDummyName(stringid.TruncateID(config.ID)))
 			if err != nil {
-				return err
+				return false, err
 			}
 			config.CreatedSlaveLink = true
+
 			// notify the user in logs they have limited communications
 			if config.Parent == getDummyName(stringid.TruncateID(config.ID)) {
 				logrus.Debugf("Empty -o parent= and --internal flags limit communications to other containers inside of network: %s",
@@ -102,22 +113,24 @@ func (d *driver) createNetwork(config *configuration) error {
 			//  a valid example is 'eth0.10' for a parent iface 'eth0' with a vlan id '10'
 			err := createVlanLink(config.Parent)
 			if err != nil {
-				return err
+				return false, err
 			}
 			// if driver created the networks slave link, record it for future deletion
 			config.CreatedSlaveLink = true
 		}
 	}
-	n := &network{
-		id:        config.ID,
-		driver:    d,
-		endpoints: endpointTable{},
-		config:    config,
+	if !foundExisting {
+		n := &network{
+			id:        config.ID,
+			driver:    d,
+			endpoints: endpointTable{},
+			config:    config,
+		}
+		// add the network
+		d.addNetwork(n)
 	}
-	// add the *network
-	d.addNetwork(n)
 
-	return nil
+	return foundExisting, nil
 }
 
 // DeleteNetwork the network for the specified driver type
@@ -182,10 +195,12 @@ func parseNetworkOptions(id string, option options.Generic) (*configuration, err
 		}
 	}
 	// setting the parent to "" will trigger an isolated network dummy parent link
-	if _, ok := option[netlabel.Internal]; ok {
-		config.Internal = true
-		// empty --parent= and --internal are handled the same.
-		config.Parent = ""
+	if val, ok := option[netlabel.Internal]; ok {
+		if internal, ok := val.(bool); ok && internal {
+			config.Internal = true
+			// empty --parent= and --internal are handled the same.
+			config.Parent = ""
+		}
 	}
 	return config, nil
 }

--- a/vendor/github.com/docker/libnetwork/drivers/ipvlan/ipvlan_store.go
+++ b/vendor/github.com/docker/libnetwork/drivers/ipvlan/ipvlan_store.go
@@ -55,7 +55,14 @@ func (d *driver) initStore(option map[string]interface{}) error {
 			return types.InternalErrorf("ipvlan driver failed to initialize data store: %v", err)
 		}
 
-		return d.populateNetworks()
+		err = d.populateNetworks()
+		if err != nil {
+			return err
+		}
+		err = d.populateEndpoints()
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -73,7 +80,7 @@ func (d *driver) populateNetworks() error {
 	}
 	for _, kvo := range kvol {
 		config := kvo.(*configuration)
-		if err = d.createNetwork(config); err != nil {
+		if _, err = d.createNetwork(config); err != nil {
 			logrus.Warnf("could not create ipvlan network for id %s from persistent state", config.ID)
 		}
 	}

--- a/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_store.go
+++ b/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_store.go
@@ -55,7 +55,15 @@ func (d *driver) initStore(option map[string]interface{}) error {
 			return types.InternalErrorf("macvlan driver failed to initialize data store: %v", err)
 		}
 
-		return d.populateNetworks()
+		err = d.populateNetworks()
+		if err != nil {
+			return err
+		}
+		err = d.populateEndpoints()
+		if err != nil {
+			return err
+		}
+
 	}
 
 	return nil
@@ -73,7 +81,7 @@ func (d *driver) populateNetworks() error {
 	}
 	for _, kvo := range kvol {
 		config := kvo.(*configuration)
-		if err = d.createNetwork(config); err != nil {
+		if _, err = d.createNetwork(config); err != nil {
 			logrus.Warnf("Could not create macvlan network for id %s from persistent state", config.ID)
 		}
 	}

--- a/vendor/github.com/docker/libnetwork/iptables/iptables.go
+++ b/vendor/github.com/docker/libnetwork/iptables/iptables.go
@@ -72,11 +72,13 @@ func (e ChainError) Error() string {
 }
 
 func probe() {
-	if out, err := exec.Command("modprobe", "-va", "nf_nat").CombinedOutput(); err != nil {
-		logrus.Warnf("Running modprobe nf_nat failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+	path, err := exec.LookPath("iptables")
+	if err != nil {
+		logrus.Warnf("Failed to find iptables: %v", err)
+		return
 	}
-	if out, err := exec.Command("modprobe", "-va", "xt_conntrack").CombinedOutput(); err != nil {
-		logrus.Warnf("Running modprobe xt_conntrack failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+	if out, err := exec.Command(path, "--wait", "-t", "nat", "-L", "-n").CombinedOutput(); err != nil {
+		logrus.Warnf("Running iptables --wait -t nat -L -n failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
 	}
 }
 

--- a/vendor/github.com/docker/libnetwork/ipvs/netlink.go
+++ b/vendor/github.com/docker/libnetwork/ipvs/netlink.go
@@ -422,8 +422,11 @@ func assembleDestination(attrs []syscall.NetlinkRouteAttr) (*Destination, error)
 		attrType := int(attr.Attr.Type)
 
 		switch attrType {
+
+		case ipvsDestAttrAddressFamily:
+			d.AddressFamily = native.Uint16(attr.Value)
 		case ipvsDestAttrAddress:
-			ip, err := parseIP(attr.Value, syscall.AF_INET)
+			ip, err := parseIP(attr.Value, d.AddressFamily)
 			if err != nil {
 				return nil, err
 			}
@@ -438,8 +441,6 @@ func assembleDestination(attrs []syscall.NetlinkRouteAttr) (*Destination, error)
 			d.UpperThreshold = native.Uint32(attr.Value)
 		case ipvsDestAttrLowerThreshold:
 			d.LowerThreshold = native.Uint32(attr.Value)
-		case ipvsDestAttrAddressFamily:
-			d.AddressFamily = native.Uint16(attr.Value)
 		case ipvsDestAttrActiveConnections:
 			d.ActiveConnections = int(native.Uint16(attr.Value))
 		case ipvsDestAttrInactiveConnections:

--- a/vendor/github.com/docker/libnetwork/ns/init_linux.go
+++ b/vendor/github.com/docker/libnetwork/ns/init_linux.go
@@ -76,12 +76,8 @@ func NlHandle() *netlink.Handle {
 func getSupportedNlFamilies() []int {
 	fams := []int{syscall.NETLINK_ROUTE}
 	// NETLINK_XFRM test
-	if err := loadXfrmModules(); err != nil {
-		if checkXfrmSocket() != nil {
-			logrus.Warnf("Could not load necessary modules for IPSEC rules: %v", err)
-		} else {
-			fams = append(fams, syscall.NETLINK_XFRM)
-		}
+	if err := checkXfrmSocket(); err != nil {
+		logrus.Warnf("Could not load necessary modules for IPSEC rules: %v", err)
 	} else {
 		fams = append(fams, syscall.NETLINK_XFRM)
 	}
@@ -97,16 +93,6 @@ func getSupportedNlFamilies() []int {
 	}
 
 	return fams
-}
-
-func loadXfrmModules() error {
-	if out, err := exec.Command("modprobe", "-va", "xfrm_user").CombinedOutput(); err != nil {
-		return fmt.Errorf("Running modprobe xfrm_user failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
-	}
-	if out, err := exec.Command("modprobe", "-va", "xfrm_algo").CombinedOutput(); err != nil {
-		return fmt.Errorf("Running modprobe xfrm_algo failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
-	}
-	return nil
 }
 
 // API check on required xfrm modules (xfrm_user, xfrm_algo)


### PR DESCRIPTION
full diff: https://github.com/docker/libnetwork/compare/83d30db53600b9c084d35fb1d560f97f8b34ab24...09cdcc8c0eab3946c2d70e8f6225b05baf1e90d1

changes included:

- docker/libnetwork#2416 Fix hardcoded AF_INET for IPv6 address handling
- docker/libnetwork#2411 Macvlan network handles netlabel.Internal wrong
  - fixes docker/libnetwork#2410 Macvlan network handles netlabel.Internal wrong
- docker/libnetwork#2414 Allow network with --config-from to be --internal
  - fixes docker/libnetwork#2413 Network with --config-from does not honor --internal
- docker/libnetwork#2351 Use fewer modprobes
  - relates to moby/moby#38930 Use fewer modprobes
- docker/libnetwork#2415 Support dockerd and system restarts for ipvlan and macvlan networks
  - carry of docker/libnetwork#2295 phantom ip/mac vlan network after a powercycle
  - fixes docker/libnetwork#1743 Phantom docker network


