### PR TITLE
overlay2: add redirect_dir=on

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -236,7 +236,8 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	params := []struct {
 		name, value string
 	}{
-		{name: "index", value: "off"}, // moby/moby#37970
+		{name: "index", value: "off"},       // moby/moby#37970
+		{name: "redirect_dir", value: "on"}, // moby/moby#39566
 	}
 	for _, opt := range params {
 		_, err = os.Stat("/sys/module/overlay/parameters/" + opt.name)


### PR DESCRIPTION
As reported in https://github.com/moby/moby/issues/39566, there are bad side effects in case overlayfs' `redirect_dir` parameter is not enabled, by setting an appropriate mount option.
    
Note that
    
1. We do not change a parameter globally as there may be others depending on its current value.
2. We do not check a parameter's current value, as it might change any time.

Tested locally, here's the effect of the change:
```
$ journalctl -u docker -b0 | grep -E 'indexOff|extraOpts'
Jul 29 16:36:23 kd dockerd[2881]: time="2019-07-29T16:36:23.459985932-07:00" level=debug msg="backingFs=extfs, projectQuotaSupported=false, indexOff=\"index=off,\"" storage-driver=overlay2
Jul 30 14:47:17 kd dockerd[19177]: time="2019-07-30T14:47:17.515083218-07:00" level=debug msg="backingFs=extfs, projectQuotaSupported=false, extraOpts=\"index=off,redirect_dir=on,\"" storage-driver=overlay2
```