### PR TITLE
Dockerfile: add back yamllint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -222,6 +222,8 @@ RUN apt-get update && apt-get install -y \
 	g++-mingw-w64-x86-64 \
 	net-tools \
 	pigz \
+	python3-pip \
+	python3-setuptools \
 	thin-provisioning-tools \
 	vim \
 	vim-common \
@@ -233,6 +235,9 @@ RUN apt-get update && apt-get install -y \
 	libnet1 \
 	libnl-3-200 \
 	--no-install-recommends
+
+RUN pip3 install yamllint==1.16.0
+
 COPY --from=swagger /build/swagger* /usr/local/bin/
 COPY --from=frozen-images /build/ /docker-frozen-images
 COPY --from=gometalinter /build/ /usr/local/bin/


### PR DESCRIPTION
This was inadvertedly removed in 7bfe48cc00318f9d4cf388237855012aafac56b0 (https://github.com/moby/moby/pull/39068), because it was documented as a dependency for docker-py, but actually used to validate the swagger file.


