### PR TITLE
WIP added entry for running unit tests with junit report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,6 @@ dockerversion/version_autogen.go
 dockerversion/version_autogen_unix.go
 vendor/pkg/
 coverage.txt
+go-test.out
 profile.out
+junit-report.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -163,6 +163,12 @@ COPY hack/dockerfile/install/install.sh ./install.sh
 COPY hack/dockerfile/install/$INSTALL_BINARY_NAME.installer ./
 RUN PREFIX=/build ./install.sh $INSTALL_BINARY_NAME
 
+FROM base AS gojunitreport
+ENV INSTALL_BINARY_NAME=gojunitreport
+COPY hack/dockerfile/install/install.sh ./install.sh
+COPY hack/dockerfile/install/$INSTALL_BINARY_NAME.installer ./
+RUN PREFIX=/build ./install.sh $INSTALL_BINARY_NAME
+
 FROM base AS gometalinter
 ENV INSTALL_BINARY_NAME=gometalinter
 COPY hack/dockerfile/install/install.sh ./install.sh
@@ -235,6 +241,7 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends
 COPY --from=swagger /build/swagger* /usr/local/bin/
 COPY --from=frozen-images /build/ /docker-frozen-images
+COPY --from=gojunitreport /build/ /usr/local/bin/
 COPY --from=gometalinter /build/ /usr/local/bin/
 COPY --from=tomlv /build/ /usr/local/bin/
 COPY --from=vndr /build/ /usr/local/bin/

--- a/hack/dockerfile/install/gojunitreport.installer
+++ b/hack/dockerfile/install/gojunitreport.installer
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+GOJUNITREPORT_COMMIT=af01ea7f8024089b458d804d5cdf190f962a9a0c
+
+install_gojunitreport() {
+	echo "Installing go-junit-report version $GOJUNITREPORT_COMMIT"
+	go get -d github.com/jstemmer/go-junit-report
+	cd "$GOPATH/src/github.com/jstemmer/go-junit-report"
+	git checkout -q "$GOJUNITREPORT_COMMIT"
+	go build -buildmode=pie -o "${PREFIX}/go-junit-report" "github.com/jstemmer/go-junit-report"
+}

--- a/hack/test/unit-junit
+++ b/hack/test/unit-junit
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Run unit tests
+#
+# TESTFLAGS - add additional test flags. Ex:
+#
+#   TESTFLAGS="-v -run TestBuild" hack/test/unit
+#
+# TESTDIRS - run tests for specified packages. Ex:
+#
+#    TESTDIRS="./pkg/term" hack/test/unit
+#
+set -eu -o pipefail
+
+TESTFLAGS+=" -test.timeout=${TIMEOUT:-5m}"
+BUILDFLAGS=( -tags "netgo seccomp libdm_no_deferred_remove" )
+TESTDIRS="${TESTDIRS:-"./..."}"
+
+exclude_paths="/vendor/|/integration"
+pkg_list=$(go list $TESTDIRS | grep -vE "($exclude_paths)")
+
+for pkg in $pkg_list; do
+    go test "${BUILDFLAGS[@]}" \
+        -v \
+        -cover \
+        -coverprofile=profile.out \
+        -covermode=atomic \
+        ${TESTFLAGS} \
+        "${pkg}" | tee tmp-go-test.out
+
+    if test -f tmp-go-test.out; then
+        cat tmp-go-test.out >> go-test.out
+        rm tmp-go-test.out
+    fi
+
+    if test -f profile.out; then
+        cat profile.out >> coverage.txt
+        rm profile.out
+    fi
+done
+
+cat go-test.out | go-junit-report > junit-report.xml


### PR DESCRIPTION
Create entry point for running the unit tests only with junit xml output. The junit xml output can then be used for graphical reporting of test success and failures in jenkins.