### PR TITLE
mkimage/debootstrap: Fix illegal apt config syntax

### DIFF
--- a/contrib/mkimage/debootstrap
+++ b/contrib/mkimage/debootstrap
@@ -151,7 +151,7 @@ if [ -d "$rootfsDir/etc/apt/apt.conf.d" ]; then
 		# "8.273 MB".
 
 		Acquire::GzipIndexes "true";
-		Acquire::CompressionTypes::Order:: "gz";
+		Acquire::CompressionTypes::Order "gz";
 	EOF
 
 	# update "autoremove" configuration to be aggressive about removing suggests deps that weren't manually installed


### PR DESCRIPTION
Fixes #39642

**- What I did**
Fixed the syntax error

**- How I did it**
Changed the offending line

**- How to verify it**
Try to reproduce #39642 after merge into master. No error in `cupt` should be caused anymore

**- Description for the changelog**
Fix syntax error in apt.conf file causing errors in `cupt`

:mouse2:
