### PR TITLE
Set locale to fix yamlllint

### DIFF
--- a/hack/validate/swagger
+++ b/hack/validate/swagger
@@ -8,6 +8,6 @@ files=( $(validate_diff --diff-filter=ACMR --name-only -- 'api/swagger.yaml' || 
 unset IFS
 
 if [ ${#files[@]} -gt 0 ]; then
-	yamllint -c ${SCRIPTDIR}/.swagger-yamllint api/swagger.yaml
+	LANG=C.UTF-8 yamllint -c ${SCRIPTDIR}/.swagger-yamllint api/swagger.yaml
 	swagger validate api/swagger.yaml
 fi


### PR DESCRIPTION
Attempting to fix this error (which looks to depend on the environment in which CI is running);

```
21:16:00 Traceback (most recent call last):
21:16:00 File "/usr/local/bin/yamllint", line 11, in <module>
21:16:00 sys.exit(run())
21:16:00 File "/usr/local/lib/python3.5/dist-packages/yamllint/cli.py", line 170, in run
21:16:00 problems = linter.run(f, conf, filepath)
21:16:00 File "/usr/local/lib/python3.5/dist-packages/yamllint/linter.py", line 233, in run
21:16:00 content = input.read()
21:16:00 File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
21:16:00 return codecs.ascii_decode(input, self.errors)[0]
21:16:00 UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 123522: ordinal not in range(128)
21:16:00 Build step 'Execute shell' marked build as failure
```


