### PR TITLE
fix client.HTTPClient() not returning a copy

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -252,7 +252,8 @@ func (cli *Client) DaemonHost() string {
 
 // HTTPClient returns a copy of the HTTP client bound to the server
 func (cli *Client) HTTPClient() *http.Client {
-	return &*cli.client
+	c := *cli.client
+	return &c
 }
 
 // ParseHostURL parses a url string, validates the string is a host url, and


### PR DESCRIPTION
taken from https://github.com/moby/moby/pull/39668

```
14:26:43 client/client.go:255:9: SA4001: &*x will be simplified to x. It will not copy x. (staticcheck)
14:26:43 	return &*cli.client
```

