### PR TITLE
daemon/ProcessEvent: make sure to cancel the contexts

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -54,9 +54,9 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 			if err != nil {
 				logrus.WithError(err).Warnf("failed to delete container %s from containerd", c.ID)
 			}
-			ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
-
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			c.StreamConfig.Wait(ctx)
+			cancel()
 			c.Reset(false)
 
 			exitStatus := container.ExitStatus{
@@ -125,8 +125,9 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 			execConfig.ExitCode = &ec
 			execConfig.Running = false
 
-			ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			execConfig.StreamConfig.Wait(ctx)
+			cancel()
 
 			if err := execConfig.CloseStreams(); err != nil {
 				logrus.Errorf("failed to cleanup exec %s streams: %s", c.ID, err)


### PR DESCRIPTION
Reported by govet linter:
```
daemon/monitor.go:57:9: lostcancel: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak (govet)
			ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
			     ^
daemon/monitor.go:128:9: lostcancel: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak (govet)
			ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
			     ^
```
Fixes: b5f28865efebb14c66d5580dfa7bf0634b5e3241 ("Handle blocked I/O of exec'd processes", PR https://github.com/moby/moby/pull/39383)