### PR TITLE
Improve integration test detector

### DIFF
--- a/hack/make/test-integration-flaky
+++ b/hack/make/test-integration-flaky
@@ -2,28 +2,34 @@
 set -e -o pipefail
 
 source hack/validate/.validate
-new_tests=$(
-	validate_diff --diff-filter=ACMR --unified=0 -- 'integration/*_test.go' |
-	grep -E '^(\+func )(.*)(\*testing)' || true
-)
 
-if [ -z "$new_tests" ]; then
-	echo 'No new tests added to integration.'
-	return
-fi
 
-echo
-echo "Found new integrations tests:"
-echo "$new_tests"
-echo "Running stress test for them."
+run_integration_flaky() {
+	new_tests=$(
+		validate_diff --diff-filter=ACMR --unified=0 -- 'integration/*_test.go' |
+			grep -E '^(\+func Test)(.*)(\*testing\.T\))' || true
+	)
 
-(
-	TESTARRAY=$(echo "$new_tests" | sed 's/+func //' | awk -F'\\(' '{print $1}' | tr '\n' '|')
-	# Note: TEST_REPEAT will make the test suite run 5 times, restarting the daemon
-	# and each test will run 5 times in a row under the same daemon.
-	# This will make a total of 25 runs for each test in TESTARRAY.
-	export TEST_REPEAT=5
-	export TESTFLAGS="-test.count ${TEST_REPEAT} -test.run ${TESTARRAY%?}"
-	echo "Using test flags: $TESTFLAGS"
-	source hack/make/test-integration
-)
+	if [ -z "$new_tests" ]; then
+		echo 'No new tests added to integration.'
+		return
+	fi
+
+	echo
+	echo "Found new integrations tests:"
+	echo "$new_tests"
+	echo "Running stress test for them."
+
+	(
+		TESTARRAY=$(echo "$new_tests" | sed 's/+func //' | awk -F'\\(' '{print $1}' | tr '\n' '|')
+		# Note: TEST_REPEAT will make the test suite run 5 times, restarting the daemon
+		# and each test will run 5 times in a row under the same daemon.
+		# This will make a total of 25 runs for each test in TESTARRAY.
+		export TEST_REPEAT=5
+		export TESTFLAGS="-test.count ${TEST_REPEAT} -test.run ${TESTARRAY%?}"
+		echo "Using test flags: $TESTFLAGS"
+		source hack/make/test-integration
+	)
+}
+
+run_integration_flaky


### PR DESCRIPTION
The "new test" detector in test-integration-flaky was a bit flaky since
it would detect function signatures that are not new tests.

In addition, the test calls `return` outside of a function which is not
allowed.

Example issue this fixes, from https://jenkins.dockerproject.org/job/Docker-PRs/55263/console

```
19:03:43 Found new integrations tests:
19:03:43 +func setupPluginViaSpecFile(t *testing.T, ec map[string]*graphEventsCounter, dir string) *http.Server {
19:03:43 +func setupPluginViaJSONFile(t *testing.T, ec map[string]*graphEventsCounter, dir string) *http.Server {
```

This is still not perfect because sometimes tests just get moved around and git thinks it's new, but at least this fixes the immediate issue.