### PR TITLE
Jenkinsfile: avoid errors from find

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -210,7 +210,8 @@ pipeline {
 
                             sh '''
                             echo "Creating janky-bundles.tar.gz"
-                            (find bundles -name '*.log' -o -name '*.prof' -o -name integration.test | xargs tar -czf janky-bundles.tar.gz) || true
+                            # exclude overlay2 directories
+                            find bundles -path '*/root/*overlay2' -prune -o -type f \\( -name '*.log' -o -name '*.prof' \\) -print | xargs tar -czf janky-bundles.tar.gz
                             '''
 
                             archiveArtifacts artifacts: 'janky-bundles.tar.gz'
@@ -295,8 +296,9 @@ pipeline {
                             '''
 
                             sh '''
-                            echo "Creating bundles.tar.gz"
-                            find bundles -name '*.log' | xargs tar -czf s390x-bundles.tar.gz
+                            echo "Creating s390x-bundles.tar.gz"
+                            # exclude overlay2 directories
+                            find bundles -path '*/root/*overlay2' -prune -o -type f \\( -name '*.log' -o -name '*.prof' \\) -print | xargs tar -czf s390x-bundles.tar.gz
                             '''
 
                             archiveArtifacts artifacts: 's390x-bundles.tar.gz'
@@ -379,8 +381,9 @@ pipeline {
                             '''
 
                             sh '''
-                            echo "Creating bundles.tar.gz"
-                            find bundles -name '*.log' | xargs tar -czf powerpc-bundles.tar.gz
+                            echo "Creating powerpc-bundles.tar.gz"
+                            # exclude overlay2 directories
+                            find bundles -path '*/root/*overlay2' -prune -o -type f \\( -name '*.log' -o -name '*.prof' \\) -print | xargs tar -czf powerpc-bundles.tar.gz
                             '''
 
                             archiveArtifacts artifacts: 'powerpc-bundles.tar.gz'


### PR DESCRIPTION
There are many errors like this one:

> 01:39:28.750 find: ‘bundles/test-integration/dbc77018d39a5/root/overlay2/f49953a883daceee60a481dd8e1e37b0f806d309258197d6ba0f6871236d3d47/work/work’: Permission denied

(probably caused by bad permissions)

These directories are not to be looked at when we search for logs, so
let's exclude them. While at it, let the find know we're only looking
for files.