### PR TITLE
integration-cli: Skip windows specific isolation requirements on non-windows

### DIFF
--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -166,10 +166,13 @@ func (s *DockerSuite) TestRestartContainerwithGoodContainer(c *testing.T) {
 }
 
 func (s *DockerSuite) TestRestartContainerSuccess(c *testing.T) {
+	testRequires(c, testEnv.IsLocalDaemon)
 	// Skipped for Hyper-V isolated containers. Test is currently written
 	// such that it assumes there is a host process to kill. In Hyper-V
 	// containers, the process is inside the utility VM, not on the host.
-	testRequires(c, testEnv.IsLocalDaemon, IsolationIsProcess)
+	if DaemonIsWindows() {
+		testRequires(c, IsolationIsProcess)
+	}
 
 	out := runSleepingContainer(c, "-d", "--restart=always")
 	id := strings.TrimSpace(out)
@@ -239,10 +242,13 @@ func (s *DockerSuite) TestRestartWithPolicyUserDefinedNetwork(c *testing.T) {
 }
 
 func (s *DockerSuite) TestRestartPolicyAfterRestart(c *testing.T) {
+	testRequires(c, testEnv.IsLocalDaemon)
 	// Skipped for Hyper-V isolated containers. Test is currently written
 	// such that it assumes there is a host process to kill. In Hyper-V
 	// containers, the process is inside the utility VM, not on the host.
-	testRequires(c, testEnv.IsLocalDaemon, IsolationIsProcess)
+	if DaemonIsWindows() {
+		testRequires(c, IsolationIsProcess)
+	}
 
 	out := runSleepingContainer(c, "-d", "--restart=always")
 	id := strings.TrimSpace(out)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4227,7 +4227,7 @@ func (s *DockerSuite) TestRunWindowsWithCPUPercent(c *testing.T) {
 }
 
 func (s *DockerSuite) TestRunProcessIsolationWithCPUCountCPUSharesAndCPUPercent(c *testing.T) {
-	testRequires(c, DaemonIsWindows, IsolationIsProcess)
+	testRequires(c, IsolationIsProcess)
 
 	out, _ := dockerCmd(c, "run", "--cpu-count=1", "--cpu-shares=1000", "--cpu-percent=80", "--name", "test", "busybox", "echo", "testing")
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "WARNING: Conflicting options: CPU count takes priority over CPU shares on Windows Server Containers. CPU shares discarded"))
@@ -4244,7 +4244,7 @@ func (s *DockerSuite) TestRunProcessIsolationWithCPUCountCPUSharesAndCPUPercent(
 }
 
 func (s *DockerSuite) TestRunHypervIsolationWithCPUCountCPUSharesAndCPUPercent(c *testing.T) {
-	testRequires(c, DaemonIsWindows, IsolationIsHyperv)
+	testRequires(c, IsolationIsHyperv)
 
 	out, _ := dockerCmd(c, "run", "--cpu-count=1", "--cpu-shares=1000", "--cpu-percent=80", "--name", "test", "busybox", "echo", "testing")
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "testing"))


### PR DESCRIPTION
…ments on non-windows

After the commit faaffd5d6d7f ("Windows:Disable 2 restart test when
Hyper-V") some tests became skipped on linux:

SKIP: docker_cli_restart_test.go:167: DockerSuite.TestRestartContainerSuccess (unmatched requirement IsolationIsProcess)
SKIP: docker_cli_restart_test.go:240: DockerSuite.TestRestartPolicyAfterRestart (unmatched requirement IsolationIsProcess)

But AFAIU it is highly unlikely that we actually meant to skip them on linux.

fixes #39625

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>