### PR TITLE
devicemapper: remove some dead / unused code

### DIFF
--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -60,13 +60,10 @@ var (
 	ErrUdevWait             = errors.New("wait on udev cookie failed")
 	ErrSetDevDir            = errors.New("dm_set_dev_dir failed")
 	ErrGetLibraryVersion    = errors.New("dm_get_library_version failed")
-	ErrCreateRemoveTask     = errors.New("Can't create task of type deviceRemove")
-	ErrRunRemoveDevice      = errors.New("running RemoveDevice failed")
 	ErrInvalidAddNode       = errors.New("Invalid AddNode type")
 	ErrBusy                 = errors.New("Device is Busy")
 	ErrDeviceIDExists       = errors.New("Device Id Exists")
 	ErrEnxio                = errors.New("No such device or address")
-	ErrEnoData              = errors.New("No data available")
 )
 
 var (

--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -48,7 +48,6 @@ var (
 	ErrTaskSetName          = errors.New("dm_task_set_name failed")
 	ErrTaskSetMessage       = errors.New("dm_task_set_message failed")
 	ErrTaskSetAddNode       = errors.New("dm_task_set_add_node failed")
-	ErrTaskSetRo            = errors.New("dm_task_set_ro failed")
 	ErrTaskAddTarget        = errors.New("dm_task_add_target failed")
 	ErrTaskSetSector        = errors.New("dm_task_set_sector failed")
 	ErrTaskGetDeps          = errors.New("dm_task_get_deps failed")
@@ -195,13 +194,6 @@ func (t *Task) setAddNode(addNode AddNodeType) error {
 	}
 	if res := DmTaskSetAddNode(t.unmanaged, addNode); res != 1 {
 		return ErrTaskSetAddNode
-	}
-	return nil
-}
-
-func (t *Task) setRo() error {
-	if res := DmTaskSetRo(t.unmanaged); res != 1 {
-		return ErrTaskSetRo
 	}
 	return nil
 }

--- a/pkg/devicemapper/devmapper_wrapper.go
+++ b/pkg/devicemapper/devmapper_wrapper.go
@@ -74,7 +74,6 @@ var (
 	DmTaskSetCookie           = dmTaskSetCookieFct
 	DmTaskSetMessage          = dmTaskSetMessageFct
 	DmTaskSetName             = dmTaskSetNameFct
-	DmTaskSetRo               = dmTaskSetRoFct
 	DmTaskSetSector           = dmTaskSetSectorFct
 	DmUdevWait                = dmUdevWaitFct
 	DmUdevSetSyncSupport      = dmUdevSetSyncSupportFct
@@ -130,10 +129,6 @@ func dmTaskSetCookieFct(task *cdmTask, cookie *uint, flags uint16) int {
 
 func dmTaskSetAddNodeFct(task *cdmTask, addNode AddNodeType) int {
 	return int(C.dm_task_set_add_node((*C.struct_dm_task)(task), C.dm_add_node_t(addNode)))
-}
-
-func dmTaskSetRoFct(task *cdmTask) int {
-	return int(C.dm_task_set_ro((*C.struct_dm_task)(task)))
 }
 
 func dmTaskAddTargetFct(task *cdmTask,


### PR DESCRIPTION
These were marked by the linter in https://github.com/moby/moby/pull/39668

- Removes `task.setRo()` and related functions, errors
- Removes unused errors

