### PR TITLE
WIP build tests are broken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -279,5 +279,8 @@ VOLUME /var/lib/docker
 ENTRYPOINT ["hack/dind"]
 
 FROM dev AS final
+
+ENV TEST_FILTER=TestBuildWithEmptyLayers
+
 # Upload docker source
 COPY . /go/src/github.com/docker/docker

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -258,7 +258,7 @@ func TestBuildLabelWithTargets(t *testing.T) {
 
 func TestBuildWithEmptyLayers(t *testing.T) {
 	dockerfile := `
-		FROM    busybox
+		FROM    nosuchimage
 		COPY    1/ /target/
 		COPY    2/ /target/
 		COPY    3/ /target/
@@ -279,9 +279,11 @@ func TestBuildWithEmptyLayers(t *testing.T) {
 			ForceRemove: true,
 		})
 	assert.NilError(t, err)
-	_, err = io.Copy(ioutil.Discard, resp.Body)
+	out := bytes.NewBuffer(nil)
+	_, err = io.Copy(out, resp.Body)
 	resp.Body.Close()
 	assert.NilError(t, err)
+	//assert.Check(t, is.Contains(out.String(), "Successfully built"))
 }
 
 // TestBuildMultiStageOnBuild checks that ONBUILD commands are applied to


### PR DESCRIPTION
I noticed this while working on a fix; it looks like the build tests are horribly broken, and some don't detect failures; some tests check the output for a successful build using string-matching (which is probably not ideal), but not sure what the correct approach would be.

Opening this PR to illustrate the problem; in this PR I modified a test to _fail_, but the test actually reports `PASS`:

```
13:33:37 Running integration-test (iteration 1)
13:33:37 Running /go/src/github.com/docker/docker/integration/build flags=-test.v -test.timeout=5m  -test.run TestBuildWithEmptyLayers
13:33:46 Loaded image: buildpack-deps:jessie
13:33:46 Loaded image: busybox:latest
13:33:46 Loaded image: busybox:glibc
13:33:46 Loaded image: debian:jessie
13:33:46 Loaded image: hello-world:latest
13:33:46 INFO: Testing against a local daemon
13:33:46 === RUN   TestBuildWithEmptyLayers
13:33:47 --- PASS: TestBuildWithEmptyLayers (1.08s)
13:33:47 PASS
```