### PR TITLE
Builder: fix "COPY --from" to non-existing directory on Windows

### DIFF
--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -556,13 +556,15 @@ func copyFile(archiver Archiver, source, dest *copyEndpoint, identity *idtools.I
 			return errors.Wrapf(err, "failed to create new directory")
 		}
 	} else {
+		// Normal containers
 		if identity == nil {
-			if err := os.MkdirAll(filepath.Dir(dest.path), 0755); err != nil {
+			// Use system.MkdirAll here, which is a custom version of os.MkdirAll
+			// modified for use on Windows to handle volume GUID paths (\\?\{dae8d3ac-b9a1-11e9-88eb-e8554b2ba1db}\path\)
+			if err := system.MkdirAll(filepath.Dir(dest.path), 0755, ""); err != nil {
 				return err
 			}
 		} else {
 			if err := idtools.MkdirAllAndChownNew(filepath.Dir(dest.path), 0755, *identity); err != nil {
-				// Normal containers
 				return errors.Wrapf(err, "failed to create new directory")
 			}
 		}

--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -340,6 +340,7 @@ Function Run-IntegrationTests() {
         Write-Host "Running $($PWD.Path)"
         $pinfo = New-Object System.Diagnostics.ProcessStartInfo
         $pinfo.FileName = "$($PWD.Path)\test.exe"
+        $pinfo.WorkingDirectory = "$($PWD.Path)"
         $pinfo.RedirectStandardError = $true
         $pinfo.UseShellExecute = $false
         $pinfo.Arguments = $env:INTEGRATION_TESTFLAGS

--- a/integration/build/testdata/Dockerfile.TestBuildMultiStageCopy
+++ b/integration/build/testdata/Dockerfile.TestBuildMultiStageCopy
@@ -1,0 +1,20 @@
+FROM busybox AS base
+RUN mkdir existingdir
+
+FROM base AS source
+RUN echo "Hello World" > /hello
+
+FROM base AS copy_to_root
+COPY --from=source /hello /hello
+
+FROM base AS copy_to_newdir
+COPY --from=source /hello /newdir/hello
+
+FROM base AS copy_to_newdir_nested
+COPY --from=source /hello /newdir/newsubdir/hello
+
+FROM base AS copy_to_existingdir
+COPY --from=source /hello /existingdir/hello
+
+FROM base AS copy_to_newsubdir
+COPY --from=source /hello /existingdir/newsubdir/hello


### PR DESCRIPTION
fixes docker/for-win#4349
built on top of https://github.com/moby/moby/pull/39698

This fixes a regression introduced in 6d87f19142f86b8fee75af721b583a306202f228 (https://github.com/moby/moby/pull/38599),
causing `COPY --from` to fail if the target directory does not exist:

```Dockerfile
FROM mcr.microsoft.com/windows/servercore:ltsc2019 as s1
RUN echo "Hello World" > /hello

FROM mcr.microsoft.com/windows/servercore:ltsc2019
COPY --from=s1 /hello /hello/another/world
```

Would produce an error:

```
Step 4/4 : COPY --from=s1 /hello /hello/another/world
failed to copy files: mkdir \\?: The filename, directory name, or volume label syntax is incorrect.
```

The cause for this was that Go's `os.MkdirAll()` does not support/detect volume GUID paths
(`\\?\Volume{dae8d3ac-b9a1-11e9-88eb-e8554b2ba1db}\hello\another}`), and as a result
attempted to create the volume as a directory (`\\?`), causing it to fail.

This patch replaces `os.MkdirAll()` with our own `system.MkdirAll()` function, which
is capable of detecting GUID volumes.


**- How to verify it**

To verify (on Linux; don't know the equivalent on Windows, LOL):

```
make TEST_FILTER=TestBuildMultiStageCopy test-integration

...
INFO: Testing against a local daemon
=== RUN   TestBuildMultiStageCopy
=== RUN   TestBuildMultiStageCopy/copy_to_root
=== RUN   TestBuildMultiStageCopy/copy_to_newdir
=== RUN   TestBuildMultiStageCopy/copy_to_newdir_nested
=== RUN   TestBuildMultiStageCopy/copy_to_existingdir
=== RUN   TestBuildMultiStageCopy/copy_to_newsubdir
--- PASS: TestBuildMultiStageCopy (11.32s)
    --- PASS: TestBuildMultiStageCopy/copy_to_root (5.76s)
    --- PASS: TestBuildMultiStageCopy/copy_to_newdir (1.33s)
    --- PASS: TestBuildMultiStageCopy/copy_to_newdir_nested (1.41s)
    --- PASS: TestBuildMultiStageCopy/copy_to_existingdir (1.34s)
    --- PASS: TestBuildMultiStageCopy/copy_to_newsubdir (1.48s)
PASS
...
```



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
