### PR TITLE
Allow system.MkDirAll() to be used as drop-in for os.MkDirAll()

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -133,7 +133,7 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 		return err
 	}
 
-	if err := system.MkdirAll(cli.Config.ExecRoot, 0700, ""); err != nil {
+	if err := system.MkdirAll(cli.Config.ExecRoot, 0700); err != nil {
 		return err
 	}
 

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -41,7 +41,7 @@ func (container *Container) CreateSecretSymlinks() error {
 		if err != nil {
 			return err
 		}
-		if err := system.MkdirAll(filepath.Dir(resolvedPath), 0, ""); err != nil {
+		if err := system.MkdirAll(filepath.Dir(resolvedPath), 0); err != nil {
 			return err
 		}
 		if err := os.Symlink(filepath.Join(containerInternalSecretMountPath, r.SecretID), resolvedPath); err != nil {
@@ -91,7 +91,7 @@ func (container *Container) CreateConfigSymlinks() error {
 		if err != nil {
 			return err
 		}
-		if err := system.MkdirAll(filepath.Dir(resolvedPath), 0, ""); err != nil {
+		if err := system.MkdirAll(filepath.Dir(resolvedPath), 0); err != nil {
 			return err
 		}
 		if err := os.Symlink(filepath.Join(containerInternalConfigsDirPath, configRef.ConfigID), resolvedPath); err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -772,7 +772,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	}
 	if runtime.GOOS == "windows" {
 		if _, err := os.Stat(realTmp); err != nil && os.IsNotExist(err) {
-			if err := system.MkdirAll(realTmp, 0700, ""); err != nil {
+			if err := system.MkdirAll(realTmp, 0700); err != nil {
 				return nil, fmt.Errorf("Unable to create the TempDir (%s): %s", realTmp, err)
 			}
 		}
@@ -834,7 +834,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	// Create the directory where we'll store the runtime scripts (i.e. in
 	// order to support runtimeArgs)
 	daemonRuntimes := filepath.Join(config.Root, "runtimes")
-	if err := system.MkdirAll(daemonRuntimes, 0700, ""); err != nil {
+	if err := system.MkdirAll(daemonRuntimes, 0700); err != nil {
 		return nil, err
 	}
 	if err := d.loadRuntimes(); err != nil {
@@ -842,7 +842,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	}
 
 	if runtime.GOOS == "windows" {
-		if err := system.MkdirAll(filepath.Join(config.Root, "credentialspecs"), 0, ""); err != nil {
+		if err := system.MkdirAll(filepath.Join(config.Root, "credentialspecs"), 0); err != nil {
 			return nil, err
 		}
 	}
@@ -981,7 +981,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 
 	trustDir := filepath.Join(config.Root, "trust")
 
-	if err := system.MkdirAll(trustDir, 0700, ""); err != nil {
+	if err := system.MkdirAll(trustDir, 0700); err != nil {
 		return nil, err
 	}
 

--- a/daemon/trustkey.go
+++ b/daemon/trustkey.go
@@ -17,7 +17,7 @@ import (
 // TODO: this should use more of libtrust.LoadOrCreateTrustKey which may need
 // a refactor or this function to be moved into libtrust
 func loadOrCreateTrustKey(trustKeyPath string) (libtrust.PrivateKey, error) {
-	err := system.MkdirAll(filepath.Dir(trustKeyPath), 0755, "")
+	err := system.MkdirAll(filepath.Dir(trustKeyPath), 0755)
 	if err != nil {
 		return nil, err
 	}

--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -83,7 +83,7 @@ func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (Da
 	}
 	r.setDefaults()
 
-	if err := system.MkdirAll(stateDir, 0700, ""); err != nil {
+	if err := system.MkdirAll(stateDir, 0700); err != nil {
 		return nil, err
 	}
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -1134,7 +1134,7 @@ func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 		dst = filepath.Join(dst, filepath.Base(src))
 	}
 	// Create the holding directory if necessary
-	if err := system.MkdirAll(filepath.Dir(dst), 0700, ""); err != nil {
+	if err := system.MkdirAll(filepath.Dir(dst), 0700); err != nil {
 		return err
 	}
 

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -84,7 +84,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			parentPath := filepath.Join(dest, parent)
 
 			if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
-				err = system.MkdirAll(parentPath, 0600, "")
+				err = system.MkdirAll(parentPath, 0600)
 				if err != nil {
 					return 0, err
 				}

--- a/pkg/chrootarchive/archive_test.go
+++ b/pkg/chrootarchive/archive_test.go
@@ -49,7 +49,7 @@ func TestChrootTarUntar(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	src := filepath.Join(tmpdir, "src")
-	if err := system.MkdirAll(src, 0700, ""); err != nil {
+	if err := system.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := ioutil.WriteFile(filepath.Join(src, "toto"), []byte("hello toto"), 0644); err != nil {
@@ -63,7 +63,7 @@ func TestChrootTarUntar(t *testing.T) {
 		t.Fatal(err)
 	}
 	dest := filepath.Join(tmpdir, "src")
-	if err := system.MkdirAll(dest, 0700, ""); err != nil {
+	if err := system.MkdirAll(dest, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := Untar(stream, dest, &archive.TarOptions{ExcludePatterns: []string{"lolo"}}); err != nil {
@@ -81,7 +81,7 @@ func TestChrootUntarWithHugeExcludesList(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	src := filepath.Join(tmpdir, "src")
-	if err := system.MkdirAll(src, 0700, ""); err != nil {
+	if err := system.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := ioutil.WriteFile(filepath.Join(src, "toto"), []byte("hello toto"), 0644); err != nil {
@@ -92,7 +92,7 @@ func TestChrootUntarWithHugeExcludesList(t *testing.T) {
 		t.Fatal(err)
 	}
 	dest := filepath.Join(tmpdir, "dest")
-	if err := system.MkdirAll(dest, 0700, ""); err != nil {
+	if err := system.MkdirAll(dest, 0700); err != nil {
 		t.Fatal(err)
 	}
 	options := &archive.TarOptions{}
@@ -181,7 +181,7 @@ func TestChrootTarUntarWithSymlink(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	src := filepath.Join(tmpdir, "src")
-	if err := system.MkdirAll(src, 0700, ""); err != nil {
+	if err := system.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := prepareSourceDirectory(10, src, false); err != nil {
@@ -205,7 +205,7 @@ func TestChrootCopyWithTar(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	src := filepath.Join(tmpdir, "src")
-	if err := system.MkdirAll(src, 0700, ""); err != nil {
+	if err := system.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := prepareSourceDirectory(10, src, true); err != nil {
@@ -252,7 +252,7 @@ func TestChrootCopyFileWithTar(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	src := filepath.Join(tmpdir, "src")
-	if err := system.MkdirAll(src, 0700, ""); err != nil {
+	if err := system.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := prepareSourceDirectory(10, src, true); err != nil {
@@ -297,7 +297,7 @@ func TestChrootUntarPath(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	src := filepath.Join(tmpdir, "src")
-	if err := system.MkdirAll(src, 0700, ""); err != nil {
+	if err := system.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := prepareSourceDirectory(10, src, false); err != nil {
@@ -359,7 +359,7 @@ func TestChrootUntarEmptyArchiveFromSlowReader(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	dest := filepath.Join(tmpdir, "dest")
-	if err := system.MkdirAll(dest, 0700, ""); err != nil {
+	if err := system.MkdirAll(dest, 0700); err != nil {
 		t.Fatal(err)
 	}
 	stream := &slowEmptyTarReader{size: 10240, chunkSize: 1024}
@@ -376,7 +376,7 @@ func TestChrootApplyEmptyArchiveFromSlowReader(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	dest := filepath.Join(tmpdir, "dest")
-	if err := system.MkdirAll(dest, 0700, ""); err != nil {
+	if err := system.MkdirAll(dest, 0700); err != nil {
 		t.Fatal(err)
 	}
 	stream := &slowEmptyTarReader{size: 10240, chunkSize: 1024}
@@ -393,7 +393,7 @@ func TestChrootApplyDotDotFile(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	src := filepath.Join(tmpdir, "src")
-	if err := system.MkdirAll(src, 0700, ""); err != nil {
+	if err := system.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := ioutil.WriteFile(filepath.Join(src, "..gitme"), []byte(""), 0644); err != nil {
@@ -404,7 +404,7 @@ func TestChrootApplyDotDotFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	dest := filepath.Join(tmpdir, "dest")
-	if err := system.MkdirAll(dest, 0700, ""); err != nil {
+	if err := system.MkdirAll(dest, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := ApplyLayer(dest, stream); err != nil {

--- a/pkg/containerfs/archiver.go
+++ b/pkg/containerfs/archiver.go
@@ -113,7 +113,7 @@ func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 	// os.MkdirAll on not-Windows and changed for Windows.
 	if dstDriver.OS() == "windows" {
 		// Now we are WCOW
-		if err := system.MkdirAll(filepath.Dir(dst), 0700, ""); err != nil {
+		if err := system.MkdirAll(filepath.Dir(dst), 0700); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -59,7 +59,7 @@ func mkdirAs(path string, mode os.FileMode, owner Identity, mkAll, chownExisting
 				paths = append(paths, dirPath)
 			}
 		}
-		if err := system.MkdirAll(path, mode, ""); err != nil {
+		if err := system.MkdirAll(path, mode); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/idtools/idtools_windows.go
+++ b/pkg/idtools/idtools_windows.go
@@ -11,7 +11,7 @@ import (
 // Ownership is handled elsewhere, but in the future could be support here
 // too.
 func mkdirAs(path string, mode os.FileMode, owner Identity, mkAll, chownExisting bool) error {
-	if err := system.MkdirAll(path, mode, ""); err != nil {
+	if err := system.MkdirAll(path, mode); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -37,7 +37,7 @@ func New(path string) (*PIDFile, error) {
 		return nil, err
 	}
 	// Note MkdirAll returns nil if a directory already exists
-	if err := system.MkdirAll(filepath.Dir(path), os.FileMode(0755), ""); err != nil {
+	if err := system.MkdirAll(filepath.Dir(path), os.FileMode(0755)); err != nil {
 		return nil, err
 	}
 	if err := ioutil.WriteFile(path, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {

--- a/pkg/system/filesys_unix.go
+++ b/pkg/system/filesys_unix.go
@@ -8,14 +8,14 @@ import (
 	"path/filepath"
 )
 
-// MkdirAllWithACL is a wrapper for MkdirAll on unix systems.
+// MkdirAllWithACL is a wrapper for os.MkdirAll on unix systems.
 func MkdirAllWithACL(path string, perm os.FileMode, sddl string) error {
-	return MkdirAll(path, perm, sddl)
+	return os.MkdirAll(path, perm)
 }
 
 // MkdirAll creates a directory named path along with any necessary parents,
 // with permission specified by attribute perm for all dir created.
-func MkdirAll(path string, perm os.FileMode, sddl string) error {
+func MkdirAll(path string, perm os.FileMode) error {
 	return os.MkdirAll(path, perm)
 }
 

--- a/pkg/system/filesys_windows.go
+++ b/pkg/system/filesys_windows.go
@@ -26,9 +26,10 @@ func MkdirAllWithACL(path string, perm os.FileMode, sddl string) error {
 	return mkdirall(path, true, sddl)
 }
 
-// MkdirAll implementation that is volume path aware for Windows.
-func MkdirAll(path string, _ os.FileMode, sddl string) error {
-	return mkdirall(path, false, sddl)
+// MkdirAll implementation that is volume path aware for Windows. It can be used
+// as a drop-in replacement for os.MkdirAll()
+func MkdirAll(path string, _ os.FileMode) error {
+	return mkdirall(path, false, "")
 }
 
 // mkdirall is a custom version of os.MkdirAll modified for use on Windows


### PR DESCRIPTION
also renamed the non-windows variant of this file to be consistent with other files in this package


