### PR TITLE
new security-opt: privileged-without-host-devices (for safe DinD with Kata)

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -99,13 +99,14 @@ type Container struct {
 	attachContext  *attachContext
 
 	// Fields here are specific to Unix platforms
-	AppArmorProfile string
-	HostnamePath    string
-	HostsPath       string
-	ShmPath         string
-	ResolvConfPath  string
-	SeccompProfile  string
-	NoNewPrivileges bool
+	AppArmorProfile              string
+	HostnamePath                 string
+	HostsPath                    string
+	ShmPath                      string
+	ResolvConfPath               string
+	SeccompProfile               string
+	NoNewPrivileges              bool
+	PrivilegedWithoutHostDevices bool
 
 	// Fields here are specific to Windows
 	NetworkSharedContainerID string            `json:"-"`

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -211,6 +211,10 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 			container.NoNewPrivileges = true
 			continue
 		}
+		if opt == "privileged-without-host-devices" {
+			container.PrivilegedWithoutHostDevices = true
+			continue
+		}
 		if opt == "disable" {
 			labelOpts = append(labelOpts, "disable")
 			continue
@@ -240,6 +244,12 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 				return fmt.Errorf("invalid --security-opt 2: %q", opt)
 			}
 			container.NoNewPrivileges = noNewPrivileges
+		case "privileged-without-host-devices":
+			pwohd, err := strconv.ParseBool(con[1])
+			if err != nil {
+				return fmt.Errorf("invalid --security-opt 2: %q", opt)
+			}
+			container.PrivilegedWithoutHostDevices = pwohd
 		default:
 			return fmt.Errorf("invalid --security-opt 2: %q", opt)
 		}

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -873,7 +873,10 @@ func WithDevices(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		var devs []specs.LinuxDevice
 		devPermissions := s.Linux.Resources.Devices
 
-		if c.HostConfig.Privileged && !userns.RunningInUserNS() {
+		if c.PrivilegedWithoutHostDevices && !c.HostConfig.Privileged {
+			return errors.New("privileged-without-host-devices requires privileged mode to be enabled")
+		}
+		if c.HostConfig.Privileged && !userns.RunningInUserNS() && !c.PrivilegedWithoutHostDevices {
 			hostDevices, err := devices.HostDevices()
 			if err != nil {
 				return err


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

`docker run --runtime=kata --privileged` is insecure despite of Kata's
VM isolation because host devices are visible to the container. https://github.com/kata-containers/runtime/issues/1568

This commit adds a new security-opt `privileged-without-host-devices` to
allow privileged mode without mounting host devices.
The daemon returns an error if the opt is specified but privileged is
not specified.

A common use-case of this is to run Docker-in-Docker securely with Kata.

Fixes https://github.com/moby/moby/issues/39697
Relates to https://github.com/containerd/cri/pull/1225 https://github.com/cri-o/cri-o/pull/2730

**- How I did it**

Added a new security-opt

**- How to verify it**

CLI: https://github.com/docker/cli/pull/2037

Without `privileged-without-host-devices`
```console
$ docker run -it --rm --runtime=kata --privileged alpine
/ # ls -l /dev/sda
brw-rw----    1 root     disk        8, 128 Aug  8 18:15 /dev/sda
/ # hexdump -C /dev/sda
(host disk is leaked)
```

With `privileged-without-host-devices`:
```console
$ docker run -it --rm --runtime=kata --privileged --security-opt privileged-without-host-devices alpine
/ # ls -l /dev
total 0
crw--w----    1 root     tty       136,   0 Aug  8 18:26 console
lrwxrwxrwx    1 root     root            13 Aug  8 18:26 fd -> /proc/self/fd
crw-rw-rw-    1 root     root        1,   7 Aug  8 18:26 full
drwxrwxrwt    2 root     root            40 Aug  8 18:26 mqueue
crw-rw-rw-    1 root     root        1,   3 Aug  8 18:26 null
lrwxrwxrwx    1 root     root             8 Aug  8 18:26 ptmx -> pts/ptmx
drwxr-xr-x    2 root     root             0 Aug  8 18:26 pts
crw-rw-rw-    1 root     root        1,   8 Aug  8 18:26 random
drwxrwxrwt    2 root     root            40 Aug  8 18:26 shm
lrwxrwxrwx    1 root     root            15 Aug  8 18:26 stderr -> /proc/self/fd/2
lrwxrwxrwx    1 root     root            15 Aug  8 18:26 stdin -> /proc/self/fd/0
lrwxrwxrwx    1 root     root            15 Aug  8 18:26 stdout -> /proc/self/fd/1
crw-rw-rw-    1 root     root        5,   0 Aug  8 18:26 tty
crw-rw-rw-    1 root     root        1,   9 Aug  8 18:26 urandom
crw-rw-rw-    1 root     root        1,   5 Aug  8 18:26 zero
/ # ls -l /dev/sda
ls: /dev/sda: No such file or directory
/ # mknod /dev/sda b 8 128
/ # hexdump -C /dev/sda
hexdump: /dev/sda: No such device or address
hexdump: /dev/sda: Bad file descriptor
```

Verified with Kata 1.8.0

**- Description for the changelog**

new security-opt: privileged-without-host-devices


**- A picture of a cute animal (not mandatory but encouraged)**

