### PR TITLE
Fix regression in handling of NotFound err during startup ENGCORE-929

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -336,7 +336,7 @@ func (daemon *Daemon) restore() error {
 			}
 			if !alive && process != nil {
 				ec, exitedAt, err = process.Delete(context.Background())
-				if err != nil {
+				if err != nil && !errdefs.IsNotFound(err) {
 					logrus.WithError(err).Errorf("Failed to delete container %s from containerd", c.ID)
 					return
 				}


### PR DESCRIPTION
**- What I did**
Address a regression during daemon startup introduced in https://github.com/moby/moby/pull/38931.

fixes https://github.com/moby/moby/issues/39623
fixes https://github.com/moby/moby/issues/39742
fixes https://github.com/docker/for-win/issues/4463
fixes https://github.com/microsoft/navcontainerhelper/issues/548

**- How I did it**
Added (back) proper handling of NotFound err

**- How to verify it**
Start a container in Windows like: 
```
docker run -d --restart always --name testcontainer --network nat -p 8080:80 mcr.microsoft.com/windows/servercore:ltsc2019 ping -t 127.0.0.1
```
and Restart-Computer.
After reboot, make sure container comes back up properly and is not a zombie.

**- Description for the changelog**
Fix regression in reboot of Windows daemon

**- A picture of a cute animal (not mandatory but encouraged)**
