### PR TITLE
daemon.initCgroupsPath fix unhandled error in recursion

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1555,7 +1555,9 @@ func (daemon *Daemon) initCgroupsPath(path string) error {
 
 	// Recursively create cgroup to ensure that the system and all parent cgroups have values set
 	// for the period and runtime as this limits what the children can be set to.
-	daemon.initCgroupsPath(filepath.Dir(path))
+	if err := daemon.initCgroupsPath(filepath.Dir(path)); err != nil {
+		return err
+	}
 
 	mnt, root, err := cgroups.FindCgroupMountpointAndRoot("", "cpu")
 	if err != nil {


### PR DESCRIPTION
This was added in 56f77d5ade945b3b8816a6c8acb328b7c6dce9a7 (https://github.com/moby/moby/pull/23430), but I don't see a mention of errors being deliberately ignored here, so this might just have been missed during review

