### PR TITLE
daemon: various nits and small fixes

### DIFF
--- a/daemon/apparmor_default.go
+++ b/daemon/apparmor_default.go
@@ -12,14 +12,14 @@ import (
 // Define constants for native driver
 const (
 	unconfinedAppArmorProfile = "unconfined"
-	defaultApparmorProfile    = "docker-default"
+	defaultAppArmorProfile    = "docker-default"
 )
 
 func ensureDefaultAppArmorProfile() error {
 	if apparmor.IsEnabled() {
-		loaded, err := aaprofile.IsLoaded(defaultApparmorProfile)
+		loaded, err := aaprofile.IsLoaded(defaultAppArmorProfile)
 		if err != nil {
-			return fmt.Errorf("Could not check if %s AppArmor profile was loaded: %s", defaultApparmorProfile, err)
+			return fmt.Errorf("Could not check if %s AppArmor profile was loaded: %s", defaultAppArmorProfile, err)
 		}
 
 		// Nothing to do.
@@ -28,8 +28,8 @@ func ensureDefaultAppArmorProfile() error {
 		}
 
 		// Load the profile.
-		if err := aaprofile.InstallDefault(defaultApparmorProfile); err != nil {
-			return fmt.Errorf("AppArmor enabled on system but the %s profile could not be loaded: %s", defaultApparmorProfile, err)
+		if err := aaprofile.InstallDefault(defaultAppArmorProfile); err != nil {
+			return fmt.Errorf("AppArmor enabled on system but the %s profile could not be loaded: %s", defaultAppArmorProfile, err)
 		}
 	}
 

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -27,15 +27,15 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, c *backend.ContainerA
 		}
 	}
 
-	container, err := daemon.GetContainer(prefixOrName)
+	ctr, err := daemon.GetContainer(prefixOrName)
 	if err != nil {
 		return err
 	}
-	if container.IsPaused() {
+	if ctr.IsPaused() {
 		err := fmt.Errorf("container %s is paused, unpause the container before attach", prefixOrName)
 		return errdefs.Conflict(err)
 	}
-	if container.IsRestarting() {
+	if ctr.IsRestarting() {
 		err := fmt.Errorf("container %s is restarting, wait until the container is running", prefixOrName)
 		return errdefs.Conflict(err)
 	}
@@ -44,11 +44,11 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, c *backend.ContainerA
 		UseStdin:   c.UseStdin,
 		UseStdout:  c.UseStdout,
 		UseStderr:  c.UseStderr,
-		TTY:        container.Config.Tty,
-		CloseStdin: container.Config.StdinOnce,
+		TTY:        ctr.Config.Tty,
+		CloseStdin: ctr.Config.StdinOnce,
 		DetachKeys: keys,
 	}
-	container.StreamConfig.AttachStreams(&cfg)
+	ctr.StreamConfig.AttachStreams(&cfg)
 
 	inStream, outStream, errStream, err := c.GetStreams()
 	if err != nil {
@@ -56,7 +56,7 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, c *backend.ContainerA
 	}
 	defer inStream.Close()
 
-	if !container.Config.Tty && c.MuxStreams {
+	if !ctr.Config.Tty && c.MuxStreams {
 		errStream = stdcopy.NewStdWriter(errStream, stdcopy.Stderr)
 		outStream = stdcopy.NewStdWriter(outStream, stdcopy.Stdout)
 	}
@@ -71,7 +71,7 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, c *backend.ContainerA
 		cfg.Stderr = errStream
 	}
 
-	if err := daemon.containerAttach(container, &cfg, c.Logs, c.Stream); err != nil {
+	if err := daemon.containerAttach(ctr, &cfg, c.Logs, c.Stream); err != nil {
 		fmt.Fprintf(outStream, "Error attaching: %s\n", err)
 	}
 	return nil
@@ -79,7 +79,7 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, c *backend.ContainerA
 
 // ContainerAttachRaw attaches the provided streams to the container's stdio
 func (daemon *Daemon) ContainerAttachRaw(prefixOrName string, stdin io.ReadCloser, stdout, stderr io.Writer, doStream bool, attached chan struct{}) error {
-	container, err := daemon.GetContainer(prefixOrName)
+	ctr, err := daemon.GetContainer(prefixOrName)
 	if err != nil {
 		return err
 	}
@@ -87,10 +87,10 @@ func (daemon *Daemon) ContainerAttachRaw(prefixOrName string, stdin io.ReadClose
 		UseStdin:   stdin != nil,
 		UseStdout:  stdout != nil,
 		UseStderr:  stderr != nil,
-		TTY:        container.Config.Tty,
-		CloseStdin: container.Config.StdinOnce,
+		TTY:        ctr.Config.Tty,
+		CloseStdin: ctr.Config.StdinOnce,
 	}
-	container.StreamConfig.AttachStreams(&cfg)
+	ctr.StreamConfig.AttachStreams(&cfg)
 	close(attached)
 	if cfg.UseStdin {
 		cfg.Stdin = stdin
@@ -102,7 +102,7 @@ func (daemon *Daemon) ContainerAttachRaw(prefixOrName string, stdin io.ReadClose
 		cfg.Stderr = stderr
 	}
 
-	return daemon.containerAttach(container, &cfg, false, doStream)
+	return daemon.containerAttach(ctr, &cfg, false, doStream)
 }
 
 func (daemon *Daemon) containerAttach(c *container.Container, cfg *stream.AttachConfig, logs, doStream bool) error {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -92,20 +92,20 @@ func (daemon *Daemon) containerRoot(id string) string {
 // Load reads the contents of a container from disk
 // This is typically done at startup.
 func (daemon *Daemon) load(id string) (*container.Container, error) {
-	container := daemon.newBaseContainer(id)
+	ctr := daemon.newBaseContainer(id)
 
-	if err := container.FromDisk(); err != nil {
+	if err := ctr.FromDisk(); err != nil {
 		return nil, err
 	}
-	if err := label.ReserveLabel(container.ProcessLabel); err != nil {
+	if err := label.ReserveLabel(ctr.ProcessLabel); err != nil {
 		return nil, err
 	}
 
-	if container.ID != id {
-		return container, fmt.Errorf("Container %s is stored at %s", container.ID, id)
+	if ctr.ID != id {
+		return ctr, fmt.Errorf("Container %s is stored at %s", ctr.ID, id)
 	}
 
-	return container, nil
+	return ctr, nil
 }
 
 // Register makes a container object usable by the daemon as <container.ID>

--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/docker/errdefs"
 )
 
-func (daemon *Daemon) saveApparmorConfig(container *container.Container) error {
+func (daemon *Daemon) saveAppArmorConfig(container *container.Container) error {
 	container.AppArmorProfile = "" // we don't care about the previous value.
 
 	if !daemon.apparmorEnabled {
@@ -20,7 +20,7 @@ func (daemon *Daemon) saveApparmorConfig(container *container.Container) error {
 
 	if !container.HostConfig.Privileged {
 		if container.AppArmorProfile == "" {
-			container.AppArmorProfile = defaultApparmorProfile
+			container.AppArmorProfile = defaultAppArmorProfile
 		}
 
 	} else {

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -61,33 +61,33 @@ func (daemon *Daemon) setupLinkedContainers(container *container.Container) ([]s
 func (daemon *Daemon) getIpcContainer(id string) (*container.Container, error) {
 	errMsg := "can't join IPC of container " + id
 	// Check the container exists
-	container, err := daemon.GetContainer(id)
+	ctr, err := daemon.GetContainer(id)
 	if err != nil {
 		return nil, errors.Wrap(err, errMsg)
 	}
 	// Check the container is running and not restarting
-	if err := daemon.checkContainer(container, containerIsRunning, containerIsNotRestarting); err != nil {
+	if err := daemon.checkContainer(ctr, containerIsRunning, containerIsNotRestarting); err != nil {
 		return nil, errors.Wrap(err, errMsg)
 	}
 	// Check the container ipc is shareable
-	if st, err := os.Stat(container.ShmPath); err != nil || !st.IsDir() {
+	if st, err := os.Stat(ctr.ShmPath); err != nil || !st.IsDir() {
 		if err == nil || os.IsNotExist(err) {
 			return nil, errors.New(errMsg + ": non-shareable IPC (hint: use IpcMode:shareable for the donor container)")
 		}
 		// stat() failed?
-		return nil, errors.Wrap(err, errMsg+": unexpected error from stat "+container.ShmPath)
+		return nil, errors.Wrap(err, errMsg+": unexpected error from stat "+ctr.ShmPath)
 	}
 
-	return container, nil
+	return ctr, nil
 }
 
-func (daemon *Daemon) getPidContainer(container *container.Container) (*container.Container, error) {
-	containerID := container.HostConfig.PidMode.Container()
-	container, err := daemon.GetContainer(containerID)
+func (daemon *Daemon) getPidContainer(ctr *container.Container) (*container.Container, error) {
+	containerID := ctr.HostConfig.PidMode.Container()
+	ctr, err := daemon.GetContainer(containerID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot join PID of a non running container: %s", containerID)
 	}
-	return container, daemon.checkContainer(container, containerIsRunning, containerIsNotRestarting)
+	return ctr, daemon.checkContainer(ctr, containerIsRunning, containerIsNotRestarting)
 }
 
 func containerIsRunning(c *container.Container) error {

--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -4,6 +4,6 @@ import (
 	"github.com/docker/docker/container"
 )
 
-func (daemon *Daemon) saveApparmorConfig(container *container.Container) error {
+func (daemon *Daemon) saveAppArmorConfig(container *container.Container) error {
 	return nil
 }

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -90,7 +90,7 @@ func (daemon *Daemon) containerCreate(opts createOpts) (containertypes.Container
 		return containertypes.ContainerCreateCreatedBody{Warnings: warnings}, errdefs.InvalidParameter(err)
 	}
 
-	container, err := daemon.create(opts)
+	ctr, err := daemon.create(opts)
 	if err != nil {
 		return containertypes.ContainerCreateCreatedBody{Warnings: warnings}, err
 	}
@@ -100,16 +100,16 @@ func (daemon *Daemon) containerCreate(opts createOpts) (containertypes.Container
 		warnings = make([]string, 0) // Create an empty slice to avoid https://github.com/moby/moby/issues/38222
 	}
 
-	return containertypes.ContainerCreateCreatedBody{ID: container.ID, Warnings: warnings}, nil
+	return containertypes.ContainerCreateCreatedBody{ID: ctr.ID, Warnings: warnings}, nil
 }
 
 // Create creates a new container from the given configuration with a given name.
 func (daemon *Daemon) create(opts createOpts) (retC *container.Container, retErr error) {
 	var (
-		container *container.Container
-		img       *image.Image
-		imgID     image.ID
-		err       error
+		ctr   *container.Container
+		img   *image.Image
+		imgID image.ID
+		err   error
 	)
 
 	os := runtime.GOOS
@@ -153,22 +153,22 @@ func (daemon *Daemon) create(opts createOpts) (retC *container.Container, retErr
 		return nil, errdefs.InvalidParameter(err)
 	}
 
-	if container, err = daemon.newContainer(opts.params.Name, os, opts.params.Config, opts.params.HostConfig, imgID, opts.managed); err != nil {
+	if ctr, err = daemon.newContainer(opts.params.Name, os, opts.params.Config, opts.params.HostConfig, imgID, opts.managed); err != nil {
 		return nil, err
 	}
 	defer func() {
 		if retErr != nil {
-			if err := daemon.cleanupContainer(container, true, true); err != nil {
+			if err := daemon.cleanupContainer(ctr, true, true); err != nil {
 				logrus.Errorf("failed to cleanup container on create error: %v", err)
 			}
 		}
 	}()
 
-	if err := daemon.setSecurityOptions(container, opts.params.HostConfig); err != nil {
+	if err := daemon.setSecurityOptions(ctr, opts.params.HostConfig); err != nil {
 		return nil, err
 	}
 
-	container.HostConfig.StorageOpt = opts.params.HostConfig.StorageOpt
+	ctr.HostConfig.StorageOpt = opts.params.HostConfig.StorageOpt
 
 	// Fixes: https://github.com/moby/moby/issues/34074 and
 	// https://github.com/docker/for-win/issues/999.
@@ -176,38 +176,38 @@ func (daemon *Daemon) create(opts createOpts) (retC *container.Container, retErr
 	// do this on Windows as there's no effective sandbox size limit other than
 	// physical on Linux.
 	if isWindows {
-		if container.HostConfig.StorageOpt == nil {
-			container.HostConfig.StorageOpt = make(map[string]string)
+		if ctr.HostConfig.StorageOpt == nil {
+			ctr.HostConfig.StorageOpt = make(map[string]string)
 		}
 		for _, v := range daemon.configStore.GraphOptions {
 			opt := strings.SplitN(v, "=", 2)
-			if _, ok := container.HostConfig.StorageOpt[opt[0]]; !ok {
-				container.HostConfig.StorageOpt[opt[0]] = opt[1]
+			if _, ok := ctr.HostConfig.StorageOpt[opt[0]]; !ok {
+				ctr.HostConfig.StorageOpt[opt[0]] = opt[1]
 			}
 		}
 	}
 
 	// Set RWLayer for container after mount labels have been set
-	rwLayer, err := daemon.imageService.CreateLayer(container, setupInitLayer(daemon.idMapping))
+	rwLayer, err := daemon.imageService.CreateLayer(ctr, setupInitLayer(daemon.idMapping))
 	if err != nil {
 		return nil, errdefs.System(err)
 	}
-	container.RWLayer = rwLayer
+	ctr.RWLayer = rwLayer
 
 	rootIDs := daemon.idMapping.RootPair()
 
-	if err := idtools.MkdirAndChown(container.Root, 0700, rootIDs); err != nil {
+	if err := idtools.MkdirAndChown(ctr.Root, 0700, rootIDs); err != nil {
 		return nil, err
 	}
-	if err := idtools.MkdirAndChown(container.CheckpointDir(), 0700, rootIDs); err != nil {
-		return nil, err
-	}
-
-	if err := daemon.setHostConfig(container, opts.params.HostConfig); err != nil {
+	if err := idtools.MkdirAndChown(ctr.CheckpointDir(), 0700, rootIDs); err != nil {
 		return nil, err
 	}
 
-	if err := daemon.createContainerOSSpecificSettings(container, opts.params.Config, opts.params.HostConfig); err != nil {
+	if err := daemon.setHostConfig(ctr, opts.params.HostConfig); err != nil {
+		return nil, err
+	}
+
+	if err := daemon.createContainerOSSpecificSettings(ctr, opts.params.Config, opts.params.HostConfig); err != nil {
 		return nil, err
 	}
 
@@ -217,15 +217,15 @@ func (daemon *Daemon) create(opts createOpts) (retC *container.Container, retErr
 	}
 	// Make sure NetworkMode has an acceptable value. We do this to ensure
 	// backwards API compatibility.
-	runconfig.SetDefaultNetModeIfBlank(container.HostConfig)
+	runconfig.SetDefaultNetModeIfBlank(ctr.HostConfig)
 
-	daemon.updateContainerNetworkSettings(container, endpointsConfigs)
-	if err := daemon.Register(container); err != nil {
+	daemon.updateContainerNetworkSettings(ctr, endpointsConfigs)
+	if err := daemon.Register(ctr); err != nil {
 		return nil, err
 	}
-	stateCtr.set(container.ID, "stopped")
-	daemon.LogContainerEvent(container, "create")
-	return container, nil
+	stateCtr.set(ctr.ID, "stopped")
+	daemon.LogContainerEvent(ctr, "create")
+	return ctr, nil
 }
 
 func toHostConfigSelinuxLabels(labels []string) []string {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -993,8 +993,8 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	}
 
 	lgrMap := make(map[string]image.LayerGetReleaser)
-	for os, ls := range layerStores {
-		lgrMap[os] = ls
+	for los, ls := range layerStores {
+		lgrMap[los] = ls
 	}
 	imageStore, err := image.NewImageStore(ifs, lgrMap)
 	if err != nil {

--- a/daemon/daemon_linux.go
+++ b/daemon/daemon_linux.go
@@ -127,7 +127,7 @@ func shouldUnmountRoot(root string, info *mountinfo.Info) bool {
 	if !strings.HasSuffix(root, info.Root) {
 		return false
 	}
-	return hasMountinfoOption(info.Optional, sharedPropagationOption)
+	return hasMountInfoOption(info.Optional, sharedPropagationOption)
 }
 
 // setupResolvConf sets the appropriate resolv.conf file if not specified

--- a/daemon/daemon_linux.go
+++ b/daemon/daemon_linux.go
@@ -39,7 +39,7 @@ func (daemon *Daemon) cleanupMountsFromReaderByID(reader io.Reader, id string, u
 	if daemon.root == "" {
 		return nil
 	}
-	var errors []string
+	var errs []string
 
 	regexps := getCleanPatterns(id)
 	sc := bufio.NewScanner(reader)
@@ -50,7 +50,7 @@ func (daemon *Daemon) cleanupMountsFromReaderByID(reader io.Reader, id string, u
 					if p.MatchString(mnt) {
 						if err := unmount(mnt); err != nil {
 							logrus.Error(err)
-							errors = append(errors, err.Error())
+							errs = append(errs, err.Error())
 						}
 					}
 				}
@@ -62,8 +62,8 @@ func (daemon *Daemon) cleanupMountsFromReaderByID(reader io.Reader, id string, u
 		return err
 	}
 
-	if len(errors) > 0 {
-		return fmt.Errorf("Error cleaning up mounts:\n%v", strings.Join(errors, "\n"))
+	if len(errs) > 0 {
+		return fmt.Errorf("Error cleaning up mounts:\n%v", strings.Join(errs, "\n"))
 	}
 
 	logrus.Debugf("Cleaning up old mountid %v: done.", id)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -82,15 +82,15 @@ func TestGetContainer(t *testing.T) {
 	daemon.reserveName(c4.ID, c4.Name)
 	daemon.reserveName(c5.ID, c5.Name)
 
-	if container, _ := daemon.GetContainer("3cdbd1aa394fd68559fd1441d6eff2ab7c1e6363582c82febfaa8045df3bd8de"); container != c2 {
+	if ctr, _ := daemon.GetContainer("3cdbd1aa394fd68559fd1441d6eff2ab7c1e6363582c82febfaa8045df3bd8de"); ctr != c2 {
 		t.Fatal("Should explicitly match full container IDs")
 	}
 
-	if container, _ := daemon.GetContainer("75fb0b8009"); container != c4 {
+	if ctr, _ := daemon.GetContainer("75fb0b8009"); ctr != c4 {
 		t.Fatal("Should match a partial ID")
 	}
 
-	if container, _ := daemon.GetContainer("drunk_hawking"); container != c2 {
+	if ctr, _ := daemon.GetContainer("drunk_hawking"); ctr != c2 {
 		t.Fatal("Should match a full name")
 	}
 
@@ -99,7 +99,7 @@ func TestGetContainer(t *testing.T) {
 		t.Fatal("Should match a full name even though it collides with another container's ID")
 	}
 
-	if container, _ := daemon.GetContainer("d22d69a2b896"); container != c5 {
+	if ctr, _ := daemon.GetContainer("d22d69a2b896"); ctr != c5 {
 		t.Fatal("Should match a container where the provided prefix is an exact match to the its name, and is also a prefix for its ID")
 	}
 
@@ -176,8 +176,8 @@ func TestContainerInitDNS(t *testing.T) {
 "UpdateDns":false,"Volumes":{},"VolumesRW":{},"AppliedVolumesFrom":null}`
 
 	// Container struct only used to retrieve path to config file
-	container := &container.Container{Root: containerPath}
-	configPath, err := container.ConfigPath()
+	ctr := &container.Container{Root: containerPath}
+	configPath, err := ctr.ConfigPath()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,7 +190,7 @@ func TestContainerInitDNS(t *testing.T) {
 "Devices":[],"NetworkMode":"bridge","IpcMode":"","PidMode":"","CapAdd":null,"CapDrop":null,"RestartPolicy":{"Name":"no","MaximumRetryCount":0},
 "SecurityOpt":null,"ReadonlyRootfs":false,"Ulimits":null,"LogConfig":{"Type":"","Config":null},"CgroupParent":""}`
 
-	hostConfigPath, err := container.HostConfigPath()
+	hostConfigPath, err := ctr.HostConfigPath()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -384,11 +384,11 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConf
 	adaptSharedNamespaceContainer(daemon, hostConfig)
 
 	var err error
-	opts, err := daemon.generateSecurityOpt(hostConfig)
+	secOpts, err := daemon.generateSecurityOpt(hostConfig)
 	if err != nil {
 		return err
 	}
-	hostConfig.SecurityOpt = append(hostConfig.SecurityOpt, opts...)
+	hostConfig.SecurityOpt = append(hostConfig.SecurityOpt, secOpts...)
 	if hostConfig.OomKillDisable == nil {
 		defaultOomKillDisable := false
 		hostConfig.OomKillDisable = &defaultOomKillDisable
@@ -1310,7 +1310,7 @@ func setupDaemonRoot(config *config.Config, rootDir string, rootIdentity idtools
 }
 
 func setupDaemonRootPropagation(cfg *config.Config) error {
-	rootParentMount, options, err := getSourceMount(cfg.Root)
+	rootParentMount, mountOptions, err := getSourceMount(cfg.Root)
 	if err != nil {
 		return errors.Wrap(err, "error getting daemon root's parent mount")
 	}
@@ -1326,7 +1326,7 @@ func setupDaemonRootPropagation(cfg *config.Config) error {
 		}
 	}()
 
-	if hasMountInfoOption(options, sharedPropagationOption, slavePropagationOption) {
+	if hasMountInfoOption(mountOptions, sharedPropagationOption, slavePropagationOption) {
 		cleanupOldFile = true
 		return nil
 	}
@@ -1745,11 +1745,11 @@ func (daemon *Daemon) initCgroupsPath(path string) error {
 	}
 
 	path = filepath.Join(mnt, root, path)
-	sysinfo := sysinfo.New(true)
-	if err := maybeCreateCPURealTimeFile(sysinfo.CPURealtimePeriod, daemon.configStore.CPURealtimePeriod, "cpu.rt_period_us", path); err != nil {
+	sysInfo := sysinfo.New(true)
+	if err := maybeCreateCPURealTimeFile(sysInfo.CPURealtimePeriod, daemon.configStore.CPURealtimePeriod, "cpu.rt_period_us", path); err != nil {
 		return err
 	}
-	return maybeCreateCPURealTimeFile(sysinfo.CPURealtimeRuntime, daemon.configStore.CPURealtimeRuntime, "cpu.rt_runtime_us", path)
+	return maybeCreateCPURealTimeFile(sysInfo.CPURealtimeRuntime, daemon.configStore.CPURealtimeRuntime, "cpu.rt_runtime_us", path)
 }
 
 func maybeCreateCPURealTimeFile(sysinfoPresent bool, configValue int64, file string, path string) error {

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1326,7 +1326,7 @@ func setupDaemonRootPropagation(cfg *config.Config) error {
 		}
 	}()
 
-	if hasMountinfoOption(options, sharedPropagationOption, slavePropagationOption) {
+	if hasMountInfoOption(options, sharedPropagationOption, slavePropagationOption) {
 		cleanupOldFile = true
 		return nil
 	}

--- a/daemon/daemon_unix_test.go
+++ b/daemon/daemon_unix_test.go
@@ -24,11 +24,11 @@ type fakeContainerGetter struct {
 }
 
 func (f *fakeContainerGetter) GetContainer(cid string) (*container.Container, error) {
-	container, ok := f.containers[cid]
+	ctr, ok := f.containers[cid]
 	if !ok {
 		return nil, errors.New("container not found")
 	}
-	return container, nil
+	return ctr, nil
 }
 
 // Unix test as uses settings which are not available on Windows
@@ -138,85 +138,85 @@ func TestAdjustCPUSharesNoAdjustment(t *testing.T) {
 
 // Unix test as uses settings which are not available on Windows
 func TestParseSecurityOptWithDeprecatedColon(t *testing.T) {
-	container := &container.Container{}
-	config := &containertypes.HostConfig{}
+	ctr := &container.Container{}
+	cfg := &containertypes.HostConfig{}
 
 	// test apparmor
-	config.SecurityOpt = []string{"apparmor=test_profile"}
-	if err := parseSecurityOpt(container, config); err != nil {
+	cfg.SecurityOpt = []string{"apparmor=test_profile"}
+	if err := parseSecurityOpt(ctr, cfg); err != nil {
 		t.Fatalf("Unexpected parseSecurityOpt error: %v", err)
 	}
-	if container.AppArmorProfile != "test_profile" {
-		t.Fatalf("Unexpected AppArmorProfile, expected: \"test_profile\", got %q", container.AppArmorProfile)
+	if ctr.AppArmorProfile != "test_profile" {
+		t.Fatalf("Unexpected AppArmorProfile, expected: \"test_profile\", got %q", ctr.AppArmorProfile)
 	}
 
 	// test seccomp
 	sp := "/path/to/seccomp_test.json"
-	config.SecurityOpt = []string{"seccomp=" + sp}
-	if err := parseSecurityOpt(container, config); err != nil {
+	cfg.SecurityOpt = []string{"seccomp=" + sp}
+	if err := parseSecurityOpt(ctr, cfg); err != nil {
 		t.Fatalf("Unexpected parseSecurityOpt error: %v", err)
 	}
-	if container.SeccompProfile != sp {
-		t.Fatalf("Unexpected AppArmorProfile, expected: %q, got %q", sp, container.SeccompProfile)
+	if ctr.SeccompProfile != sp {
+		t.Fatalf("Unexpected AppArmorProfile, expected: %q, got %q", sp, ctr.SeccompProfile)
 	}
 
 	// test valid label
-	config.SecurityOpt = []string{"label=user:USER"}
-	if err := parseSecurityOpt(container, config); err != nil {
+	cfg.SecurityOpt = []string{"label=user:USER"}
+	if err := parseSecurityOpt(ctr, cfg); err != nil {
 		t.Fatalf("Unexpected parseSecurityOpt error: %v", err)
 	}
 
 	// test invalid label
-	config.SecurityOpt = []string{"label"}
-	if err := parseSecurityOpt(container, config); err == nil {
+	cfg.SecurityOpt = []string{"label"}
+	if err := parseSecurityOpt(ctr, cfg); err == nil {
 		t.Fatal("Expected parseSecurityOpt error, got nil")
 	}
 
 	// test invalid opt
-	config.SecurityOpt = []string{"test"}
-	if err := parseSecurityOpt(container, config); err == nil {
+	cfg.SecurityOpt = []string{"test"}
+	if err := parseSecurityOpt(ctr, cfg); err == nil {
 		t.Fatal("Expected parseSecurityOpt error, got nil")
 	}
 }
 
 func TestParseSecurityOpt(t *testing.T) {
-	container := &container.Container{}
-	config := &containertypes.HostConfig{}
+	ctr := &container.Container{}
+	cfg := &containertypes.HostConfig{}
 
 	// test apparmor
-	config.SecurityOpt = []string{"apparmor=test_profile"}
-	if err := parseSecurityOpt(container, config); err != nil {
+	cfg.SecurityOpt = []string{"apparmor=test_profile"}
+	if err := parseSecurityOpt(ctr, cfg); err != nil {
 		t.Fatalf("Unexpected parseSecurityOpt error: %v", err)
 	}
-	if container.AppArmorProfile != "test_profile" {
-		t.Fatalf("Unexpected AppArmorProfile, expected: \"test_profile\", got %q", container.AppArmorProfile)
+	if ctr.AppArmorProfile != "test_profile" {
+		t.Fatalf("Unexpected AppArmorProfile, expected: \"test_profile\", got %q", ctr.AppArmorProfile)
 	}
 
 	// test seccomp
 	sp := "/path/to/seccomp_test.json"
-	config.SecurityOpt = []string{"seccomp=" + sp}
-	if err := parseSecurityOpt(container, config); err != nil {
+	cfg.SecurityOpt = []string{"seccomp=" + sp}
+	if err := parseSecurityOpt(ctr, cfg); err != nil {
 		t.Fatalf("Unexpected parseSecurityOpt error: %v", err)
 	}
-	if container.SeccompProfile != sp {
-		t.Fatalf("Unexpected SeccompProfile, expected: %q, got %q", sp, container.SeccompProfile)
+	if ctr.SeccompProfile != sp {
+		t.Fatalf("Unexpected SeccompProfile, expected: %q, got %q", sp, ctr.SeccompProfile)
 	}
 
 	// test valid label
-	config.SecurityOpt = []string{"label=user:USER"}
-	if err := parseSecurityOpt(container, config); err != nil {
+	cfg.SecurityOpt = []string{"label=user:USER"}
+	if err := parseSecurityOpt(ctr, cfg); err != nil {
 		t.Fatalf("Unexpected parseSecurityOpt error: %v", err)
 	}
 
 	// test invalid label
-	config.SecurityOpt = []string{"label"}
-	if err := parseSecurityOpt(container, config); err == nil {
+	cfg.SecurityOpt = []string{"label"}
+	if err := parseSecurityOpt(ctr, cfg); err == nil {
 		t.Fatal("Expected parseSecurityOpt error, got nil")
 	}
 
 	// test invalid opt
-	config.SecurityOpt = []string{"test"}
-	if err := parseSecurityOpt(container, config); err == nil {
+	cfg.SecurityOpt = []string{"test"}
+	if err := parseSecurityOpt(ctr, cfg); err == nil {
 		t.Fatal("Expected parseSecurityOpt error, got nil")
 	}
 }
@@ -225,28 +225,28 @@ func TestParseNNPSecurityOptions(t *testing.T) {
 	daemon := &Daemon{
 		configStore: &config.Config{NoNewPrivileges: true},
 	}
-	container := &container.Container{}
-	config := &containertypes.HostConfig{}
+	ctr := &container.Container{}
+	cfg := &containertypes.HostConfig{}
 
 	// test NNP when "daemon:true" and "no-new-privileges=false""
-	config.SecurityOpt = []string{"no-new-privileges=false"}
+	cfg.SecurityOpt = []string{"no-new-privileges=false"}
 
-	if err := daemon.parseSecurityOpt(container, config); err != nil {
+	if err := daemon.parseSecurityOpt(ctr, cfg); err != nil {
 		t.Fatalf("Unexpected daemon.parseSecurityOpt error: %v", err)
 	}
-	if container.NoNewPrivileges {
-		t.Fatalf("container.NoNewPrivileges should be FALSE: %v", container.NoNewPrivileges)
+	if ctr.NoNewPrivileges {
+		t.Fatalf("container.NoNewPrivileges should be FALSE: %v", ctr.NoNewPrivileges)
 	}
 
 	// test NNP when "daemon:false" and "no-new-privileges=true""
 	daemon.configStore.NoNewPrivileges = false
-	config.SecurityOpt = []string{"no-new-privileges=true"}
+	cfg.SecurityOpt = []string{"no-new-privileges=true"}
 
-	if err := daemon.parseSecurityOpt(container, config); err != nil {
+	if err := daemon.parseSecurityOpt(ctr, cfg); err != nil {
 		t.Fatalf("Unexpected daemon.parseSecurityOpt error: %v", err)
 	}
-	if !container.NoNewPrivileges {
-		t.Fatalf("container.NoNewPrivileges should be TRUE: %v", container.NoNewPrivileges)
+	if !ctr.NoNewPrivileges {
+		t.Fatalf("container.NoNewPrivileges should be TRUE: %v", ctr.NoNewPrivileges)
 	}
 }
 

--- a/daemon/debugtrap_unix.go
+++ b/daemon/debugtrap_unix.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func (d *Daemon) setupDumpStackTrap(root string) {
+func (daemon *Daemon) setupDumpStackTrap(root string) {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, unix.SIGUSR1)
 	go func() {

--- a/daemon/debugtrap_unsupported.go
+++ b/daemon/debugtrap_unsupported.go
@@ -2,6 +2,6 @@
 
 package daemon // import "github.com/docker/docker/daemon"
 
-func (d *Daemon) setupDumpStackTrap(_ string) {
+func (daemon *Daemon) setupDumpStackTrap(_ string) {
 	return
 }

--- a/daemon/debugtrap_windows.go
+++ b/daemon/debugtrap_windows.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func (d *Daemon) setupDumpStackTrap(root string) {
+func (daemon *Daemon) setupDumpStackTrap(root string) {
 	// Windows does not support signals like *nix systems. So instead of
 	// trapping on SIGUSR1 to dump stacks, we wait on a Win32 event to be
 	// signaled. ACL'd to builtin administrators and local system

--- a/daemon/events_test.go
+++ b/daemon/events_test.go
@@ -15,7 +15,7 @@ func TestLogContainerEventCopyLabels(t *testing.T) {
 	_, l, _ := e.Subscribe()
 	defer e.Evict(l)
 
-	container := &container.Container{
+	ctr := &container.Container{
 		ID:   "container_id",
 		Name: "container_name",
 		Config: &containertypes.Config{
@@ -29,10 +29,10 @@ func TestLogContainerEventCopyLabels(t *testing.T) {
 	daemon := &Daemon{
 		EventsService: e,
 	}
-	daemon.LogContainerEvent(container, "create")
+	daemon.LogContainerEvent(ctr, "create")
 
-	if _, mutated := container.Config.Labels["image"]; mutated {
-		t.Fatalf("Expected to not mutate the container labels, got %q", container.Config.Labels)
+	if _, mutated := ctr.Config.Labels["image"]; mutated {
+		t.Fatalf("Expected to not mutate the container labels, got %q", ctr.Config.Labels)
 	}
 
 	validateTestAttributes(t, l, map[string]string{
@@ -46,7 +46,7 @@ func TestLogContainerEventWithAttributes(t *testing.T) {
 	_, l, _ := e.Subscribe()
 	defer e.Evict(l)
 
-	container := &container.Container{
+	ctr := &container.Container{
 		ID:   "container_id",
 		Name: "container_name",
 		Config: &containertypes.Config{
@@ -63,7 +63,7 @@ func TestLogContainerEventWithAttributes(t *testing.T) {
 		"node": "2",
 		"foo":  "bar",
 	}
-	daemon.LogContainerEventWithAttributes(container, "create", attributes)
+	daemon.LogContainerEventWithAttributes(ctr, "create", attributes)
 
 	validateTestAttributes(t, l, map[string]string{
 		"node": "1",

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -25,17 +25,17 @@ import (
 // Seconds to wait after sending TERM before trying KILL
 const termProcessTimeout = 10 * time.Second
 
-func (d *Daemon) registerExecCommand(container *container.Container, config *exec.Config) {
+func (daemon *Daemon) registerExecCommand(container *container.Container, config *exec.Config) {
 	// Storing execs in container in order to kill them gracefully whenever the container is stopped or removed.
 	container.ExecCommands.Add(config.ID, config)
 	// Storing execs in daemon for easy access via Engine API.
-	d.execCommands.Add(config.ID, config)
+	daemon.execCommands.Add(config.ID, config)
 }
 
 // ExecExists looks up the exec instance and returns a bool if it exists or not.
 // It will also return the error produced by `getConfig`
-func (d *Daemon) ExecExists(name string) (bool, error) {
-	if _, err := d.getExecConfig(name); err != nil {
+func (daemon *Daemon) ExecExists(name string) (bool, error) {
+	if _, err := daemon.getExecConfig(name); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -43,8 +43,8 @@ func (d *Daemon) ExecExists(name string) (bool, error) {
 
 // getExecConfig looks up the exec instance by name. If the container associated
 // with the exec instance is stopped or paused, it will return an error.
-func (d *Daemon) getExecConfig(name string) (*exec.Config, error) {
-	ec := d.execCommands.Get(name)
+func (daemon *Daemon) getExecConfig(name string) (*exec.Config, error) {
+	ec := daemon.execCommands.Get(name)
 	if ec == nil {
 		return nil, errExecNotFound(name)
 	}
@@ -54,7 +54,7 @@ func (d *Daemon) getExecConfig(name string) (*exec.Config, error) {
 	// saying the container isn't running, we should return a 404 so that
 	// the user sees the same error now that they will after the
 	// 5 minute clean-up loop is run which erases old/dead execs.
-	container := d.containers.Get(ec.ContainerID)
+	container := daemon.containers.Get(ec.ContainerID)
 	if container == nil {
 		return nil, containerNotFound(name)
 	}
@@ -70,13 +70,13 @@ func (d *Daemon) getExecConfig(name string) (*exec.Config, error) {
 	return ec, nil
 }
 
-func (d *Daemon) unregisterExecCommand(container *container.Container, execConfig *exec.Config) {
+func (daemon *Daemon) unregisterExecCommand(container *container.Container, execConfig *exec.Config) {
 	container.ExecCommands.Delete(execConfig.ID, execConfig.Pid)
-	d.execCommands.Delete(execConfig.ID, execConfig.Pid)
+	daemon.execCommands.Delete(execConfig.ID, execConfig.Pid)
 }
 
-func (d *Daemon) getActiveContainer(name string) (*container.Container, error) {
-	container, err := d.GetContainer(name)
+func (daemon *Daemon) getActiveContainer(name string) (*container.Container, error) {
+	container, err := daemon.GetContainer(name)
 	if err != nil {
 		return nil, err
 	}
@@ -94,14 +94,14 @@ func (d *Daemon) getActiveContainer(name string) (*container.Container, error) {
 }
 
 // ContainerExecCreate sets up an exec in a running container.
-func (d *Daemon) ContainerExecCreate(name string, config *types.ExecConfig) (string, error) {
-	cntr, err := d.getActiveContainer(name)
+func (daemon *Daemon) ContainerExecCreate(name string, config *types.ExecConfig) (string, error) {
+	cntr, err := daemon.getActiveContainer(name)
 	if err != nil {
 		return "", err
 	}
 
 	cmd := strslice.StrSlice(config.Cmd)
-	entrypoint, args := d.getEntrypointAndArgs(strslice.StrSlice{}, cmd)
+	entrypoint, args := daemon.getEntrypointAndArgs(strslice.StrSlice{}, cmd)
 
 	keys := []byte{}
 	if config.DetachKeys != "" {
@@ -125,7 +125,7 @@ func (d *Daemon) ContainerExecCreate(name string, config *types.ExecConfig) (str
 	execConfig.User = config.User
 	execConfig.WorkingDir = config.WorkingDir
 
-	linkedEnv, err := d.setupLinkedContainers(cntr)
+	linkedEnv, err := daemon.setupLinkedContainers(cntr)
 	if err != nil {
 		return "", err
 	}
@@ -137,12 +137,12 @@ func (d *Daemon) ContainerExecCreate(name string, config *types.ExecConfig) (str
 		execConfig.WorkingDir = cntr.Config.WorkingDir
 	}
 
-	d.registerExecCommand(cntr, execConfig)
+	daemon.registerExecCommand(cntr, execConfig)
 
 	attributes := map[string]string{
 		"execID": execConfig.ID,
 	}
-	d.LogContainerEventWithAttributes(cntr, "exec_create: "+execConfig.Entrypoint+" "+strings.Join(execConfig.Args, " "), attributes)
+	daemon.LogContainerEventWithAttributes(cntr, "exec_create: "+execConfig.Entrypoint+" "+strings.Join(execConfig.Args, " "), attributes)
 
 	return execConfig.ID, nil
 }
@@ -150,13 +150,13 @@ func (d *Daemon) ContainerExecCreate(name string, config *types.ExecConfig) (str
 // ContainerExecStart starts a previously set up exec instance. The
 // std streams are set up.
 // If ctx is cancelled, the process is terminated.
-func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.Reader, stdout io.Writer, stderr io.Writer) (err error) {
+func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.Reader, stdout io.Writer, stderr io.Writer) (err error) {
 	var (
 		cStdin           io.ReadCloser
 		cStdout, cStderr io.Writer
 	)
 
-	ec, err := d.getExecConfig(name)
+	ec, err := daemon.getExecConfig(name)
 	if err != nil {
 		return errExecNotFound(name)
 	}
@@ -175,12 +175,12 @@ func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.R
 	ec.Running = true
 	ec.Unlock()
 
-	c := d.containers.Get(ec.ContainerID)
+	c := daemon.containers.Get(ec.ContainerID)
 	logrus.Debugf("starting exec command %s in container %s", ec.ID, c.ID)
 	attributes := map[string]string{
 		"execID": ec.ID,
 	}
-	d.LogContainerEventWithAttributes(c, "exec_start: "+ec.Entrypoint+" "+strings.Join(ec.Args, " "), attributes)
+	daemon.LogContainerEventWithAttributes(c, "exec_start: "+ec.Entrypoint+" "+strings.Join(ec.Args, " "), attributes)
 
 	defer func() {
 		if err != nil {
@@ -220,7 +220,7 @@ func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.R
 
 	p := &specs.Process{}
 	if runtime.GOOS != "windows" {
-		container, err := d.containerdCli.LoadContainer(ctx, ec.ContainerID)
+		container, err := daemon.containerdCli.LoadContainer(ctx, ec.ContainerID)
 		if err != nil {
 			return err
 		}
@@ -239,7 +239,7 @@ func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.R
 		p.Cwd = "/"
 	}
 
-	if err := d.execSetPlatformOpt(c, ec, p); err != nil {
+	if err := daemon.execSetPlatformOpt(c, ec, p); err != nil {
 		return err
 	}
 
@@ -260,7 +260,7 @@ func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.R
 	// Synchronize with libcontainerd event loop
 	ec.Lock()
 	c.ExecCommands.Lock()
-	systemPid, err := d.containerd.Exec(ctx, c.ID, ec.ID, p, cStdin != nil, ec.InitializeStdio)
+	systemPid, err := daemon.containerd.Exec(ctx, c.ID, ec.ID, p, cStdin != nil, ec.InitializeStdio)
 	// the exec context should be ready, or error happened.
 	// close the chan to notify readiness
 	close(ec.Started)
@@ -276,7 +276,7 @@ func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.R
 	select {
 	case <-ctx.Done():
 		logrus.Debugf("Sending TERM signal to process %v in container %v", name, c.ID)
-		d.containerd.SignalProcess(ctx, c.ID, name, int(signal.SignalMap["TERM"]))
+		daemon.containerd.SignalProcess(ctx, c.ID, name, int(signal.SignalMap["TERM"]))
 
 		timeout := time.NewTimer(termProcessTimeout)
 		defer timeout.Stop()
@@ -284,7 +284,7 @@ func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.R
 		select {
 		case <-timeout.C:
 			logrus.Infof("Container %v, process %v failed to exit within %v of signal TERM - using the force", c.ID, name, termProcessTimeout)
-			d.containerd.SignalProcess(ctx, c.ID, name, int(signal.SignalMap["KILL"]))
+			daemon.containerd.SignalProcess(ctx, c.ID, name, int(signal.SignalMap["KILL"]))
 		case <-attachErr:
 			// TERM signal worked
 		}
@@ -297,7 +297,7 @@ func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.R
 			attributes := map[string]string{
 				"execID": ec.ID,
 			}
-			d.LogContainerEventWithAttributes(c, "exec_detach", attributes)
+			daemon.LogContainerEventWithAttributes(c, "exec_detach", attributes)
 		}
 	}
 	return nil
@@ -305,16 +305,16 @@ func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.R
 
 // execCommandGC runs a ticker to clean up the daemon references
 // of exec configs that are no longer part of the container.
-func (d *Daemon) execCommandGC() {
+func (daemon *Daemon) execCommandGC() {
 	for range time.Tick(5 * time.Minute) {
 		var (
 			cleaned          int
-			liveExecCommands = d.containerExecIds()
+			liveExecCommands = daemon.containerExecIds()
 		)
-		for id, config := range d.execCommands.Commands() {
+		for id, config := range daemon.execCommands.Commands() {
 			if config.CanRemove {
 				cleaned++
-				d.execCommands.Delete(id, config.Pid)
+				daemon.execCommands.Delete(id, config.Pid)
 			} else {
 				if _, exists := liveExecCommands[id]; !exists {
 					config.CanRemove = true
@@ -329,9 +329,9 @@ func (d *Daemon) execCommandGC() {
 
 // containerExecIds returns a list of all the current exec ids that are in use
 // and running inside a container.
-func (d *Daemon) containerExecIds() map[string]struct{} {
+func (daemon *Daemon) containerExecIds() map[string]struct{} {
 	ids := map[string]struct{}{}
-	for _, c := range d.containers.List() {
+	for _, c := range daemon.containers.List() {
 		for _, id := range c.ExecCommands.List() {
 			ids[id] = struct{}{}
 		}

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -54,18 +54,18 @@ func (daemon *Daemon) getExecConfig(name string) (*exec.Config, error) {
 	// saying the container isn't running, we should return a 404 so that
 	// the user sees the same error now that they will after the
 	// 5 minute clean-up loop is run which erases old/dead execs.
-	container := daemon.containers.Get(ec.ContainerID)
-	if container == nil {
+	ctr := daemon.containers.Get(ec.ContainerID)
+	if ctr == nil {
 		return nil, containerNotFound(name)
 	}
-	if !container.IsRunning() {
-		return nil, fmt.Errorf("Container %s is not running: %s", container.ID, container.State.String())
+	if !ctr.IsRunning() {
+		return nil, fmt.Errorf("Container %s is not running: %s", ctr.ID, ctr.State.String())
 	}
-	if container.IsPaused() {
-		return nil, errExecPaused(container.ID)
+	if ctr.IsPaused() {
+		return nil, errExecPaused(ctr.ID)
 	}
-	if container.IsRestarting() {
-		return nil, errContainerIsRestarting(container.ID)
+	if ctr.IsRestarting() {
+		return nil, errContainerIsRestarting(ctr.ID)
 	}
 	return ec, nil
 }
@@ -76,21 +76,21 @@ func (daemon *Daemon) unregisterExecCommand(container *container.Container, exec
 }
 
 func (daemon *Daemon) getActiveContainer(name string) (*container.Container, error) {
-	container, err := daemon.GetContainer(name)
+	ctr, err := daemon.GetContainer(name)
 	if err != nil {
 		return nil, err
 	}
 
-	if !container.IsRunning() {
-		return nil, errNotRunning(container.ID)
+	if !ctr.IsRunning() {
+		return nil, errNotRunning(ctr.ID)
 	}
-	if container.IsPaused() {
+	if ctr.IsPaused() {
 		return nil, errExecPaused(name)
 	}
-	if container.IsRestarting() {
-		return nil, errContainerIsRestarting(container.ID)
+	if ctr.IsRestarting() {
+		return nil, errContainerIsRestarting(ctr.ID)
 	}
-	return container, nil
+	return ctr, nil
 }
 
 // ContainerExecCreate sets up an exec in a running container.
@@ -220,11 +220,11 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, stdin
 
 	p := &specs.Process{}
 	if runtime.GOOS != "windows" {
-		container, err := daemon.containerdCli.LoadContainer(ctx, ec.ContainerID)
+		ctr, err := daemon.containerdCli.LoadContainer(ctx, ec.ContainerID)
 		if err != nil {
 			return err
 		}
-		spec, err := container.Spec(ctx)
+		spec, err := ctr.Spec(ctx)
 		if err != nil {
 			return err
 		}

--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -40,10 +40,10 @@ func (daemon *Daemon) execSetPlatformOpt(c *container.Container, ec *exec.Config
 			// profiles. Privileged configuration of the container is inherited
 			appArmorProfile = unconfinedAppArmorProfile
 		} else {
-			appArmorProfile = defaultApparmorProfile
+			appArmorProfile = defaultAppArmorProfile
 		}
 
-		if appArmorProfile == defaultApparmorProfile {
+		if appArmorProfile == defaultAppArmorProfile {
 			// Unattended upgrades and other fun services can unload AppArmor
 			// profiles inadvertently. Since we cannot store our profile in
 			// /etc/apparmor.d, nor can we practically add other ways of

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -14,26 +14,26 @@ import (
 // ContainerExport writes the contents of the container to the given
 // writer. An error is returned if the container cannot be found.
 func (daemon *Daemon) ContainerExport(name string, out io.Writer) error {
-	container, err := daemon.GetContainer(name)
+	ctr, err := daemon.GetContainer(name)
 	if err != nil {
 		return err
 	}
 
-	if isWindows && container.OS == "windows" {
+	if isWindows && ctr.OS == "windows" {
 		return fmt.Errorf("the daemon on this operating system does not support exporting Windows containers")
 	}
 
-	if container.IsDead() {
-		err := fmt.Errorf("You cannot export container %s which is Dead", container.ID)
+	if ctr.IsDead() {
+		err := fmt.Errorf("You cannot export container %s which is Dead", ctr.ID)
 		return errdefs.Conflict(err)
 	}
 
-	if container.IsRemovalInProgress() {
-		err := fmt.Errorf("You cannot export container %s which is being removed", container.ID)
+	if ctr.IsRemovalInProgress() {
+		err := fmt.Errorf("You cannot export container %s which is being removed", ctr.ID)
 		return errdefs.Conflict(err)
 	}
 
-	data, err := daemon.containerExport(container)
+	data, err := daemon.containerExport(ctr)
 	if err != nil {
 		return fmt.Errorf("Error exporting container %s: %v", name, err)
 	}
@@ -65,7 +65,7 @@ func (daemon *Daemon) containerExport(container *container.Container) (arch io.R
 		return nil, err
 	}
 
-	archive, err := archivePath(basefs, basefs.Path(), &archive.TarOptions{
+	archv, err := archivePath(basefs, basefs.Path(), &archive.TarOptions{
 		Compression: archive.Uncompressed,
 		UIDMaps:     daemon.idMapping.UIDs(),
 		GIDMaps:     daemon.idMapping.GIDs(),
@@ -74,8 +74,8 @@ func (daemon *Daemon) containerExport(container *container.Container) (arch io.R
 		rwlayer.Unmount()
 		return nil, err
 	}
-	arch = ioutils.NewReadCloserWrapper(archive, func() error {
-		err := archive.Close()
+	arch = ioutils.NewReadCloserWrapper(archv, func() error {
+		err := archv.Close()
 		rwlayer.Unmount()
 		daemon.imageService.ReleaseLayer(rwlayer, container.OS)
 		return err

--- a/daemon/inspect_linux.go
+++ b/daemon/inspect_linux.go
@@ -20,38 +20,38 @@ func setPlatformSpecificContainerFields(container *container.Container, contJSON
 
 // containerInspectPre120 gets containers for pre 1.20 APIs.
 func (daemon *Daemon) containerInspectPre120(name string) (*v1p19.ContainerJSON, error) {
-	container, err := daemon.GetContainer(name)
+	ctr, err := daemon.GetContainer(name)
 	if err != nil {
 		return nil, err
 	}
 
-	container.Lock()
-	defer container.Unlock()
+	ctr.Lock()
+	defer ctr.Unlock()
 
-	base, err := daemon.getInspectData(container)
+	base, err := daemon.getInspectData(ctr)
 	if err != nil {
 		return nil, err
 	}
 
 	volumes := make(map[string]string)
 	volumesRW := make(map[string]bool)
-	for _, m := range container.MountPoints {
+	for _, m := range ctr.MountPoints {
 		volumes[m.Destination] = m.Path()
 		volumesRW[m.Destination] = m.RW
 	}
 
 	config := &v1p19.ContainerConfig{
-		Config:          container.Config,
-		MacAddress:      container.Config.MacAddress,
-		NetworkDisabled: container.Config.NetworkDisabled,
-		ExposedPorts:    container.Config.ExposedPorts,
-		VolumeDriver:    container.HostConfig.VolumeDriver,
-		Memory:          container.HostConfig.Memory,
-		MemorySwap:      container.HostConfig.MemorySwap,
-		CPUShares:       container.HostConfig.CPUShares,
-		CPUSet:          container.HostConfig.CpusetCpus,
+		Config:          ctr.Config,
+		MacAddress:      ctr.Config.MacAddress,
+		NetworkDisabled: ctr.Config.NetworkDisabled,
+		ExposedPorts:    ctr.Config.ExposedPorts,
+		VolumeDriver:    ctr.HostConfig.VolumeDriver,
+		Memory:          ctr.HostConfig.Memory,
+		MemorySwap:      ctr.HostConfig.MemorySwap,
+		CPUShares:       ctr.HostConfig.CPUShares,
+		CPUSet:          ctr.HostConfig.CpusetCpus,
 	}
-	networkSettings := daemon.getBackwardsCompatibleNetworkSettings(container.NetworkSettings)
+	networkSettings := daemon.getBackwardsCompatibleNetworkSettings(ctr.NetworkSettings)
 
 	return &v1p19.ContainerJSON{
 		ContainerJSONBase: base,

--- a/daemon/list_test.go
+++ b/daemon/list_test.go
@@ -69,8 +69,8 @@ func setupContainerWithName(t *testing.T, name string, daemon *Daemon) *containe
 }
 
 func containerListContainsName(containers []*types.Container, name string) bool {
-	for _, container := range containers {
-		for _, containerName := range container.Names {
+	for _, ctr := range containers {
+		for _, containerName := range ctr.Names {
 			if containerName == name {
 				return true
 			}

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -33,20 +33,20 @@ func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, c
 	if !(config.ShowStdout || config.ShowStderr) {
 		return nil, false, errdefs.InvalidParameter(errors.New("You must choose at least one stream"))
 	}
-	container, err := daemon.GetContainer(containerName)
+	ctr, err := daemon.GetContainer(containerName)
 	if err != nil {
 		return nil, false, err
 	}
 
-	if container.RemovalInProgress || container.Dead {
+	if ctr.RemovalInProgress || ctr.Dead {
 		return nil, false, errdefs.Conflict(errors.New("can not get logs from container which is dead or marked for removal"))
 	}
 
-	if container.HostConfig.LogConfig.Type == "none" {
+	if ctr.HostConfig.LogConfig.Type == "none" {
 		return nil, false, logger.ErrReadLogsNotSupported{}
 	}
 
-	cLog, cLogCreated, err := daemon.getLogger(container)
+	cLog, cLogCreated, err := daemon.getLogger(ctr)
 	if err != nil {
 		return nil, false, err
 	}
@@ -157,7 +157,7 @@ func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, c
 			}
 		}
 	}()
-	return messageChan, container.Config.Tty, nil
+	return messageChan, ctr.Config.Tty, nil
 }
 
 func (daemon *Daemon) getLogger(container *container.Container) (l logger.Logger, created bool, err error) {

--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -115,8 +115,8 @@ func (ctr *stateCounter) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(ctr.desc, prometheus.GaugeValue, float64(stopped), "stopped")
 }
 
-func (d *Daemon) cleanupMetricsPlugins() {
-	ls := d.PluginStore.GetAllManagedPluginsByCap(metricsPluginType)
+func (daemon *Daemon) cleanupMetricsPlugins() {
+	ls := daemon.PluginStore.GetAllManagedPluginsByCap(metricsPluginType)
 	var wg sync.WaitGroup
 	wg.Add(len(ls))
 
@@ -137,8 +137,8 @@ func (d *Daemon) cleanupMetricsPlugins() {
 	}
 	wg.Wait()
 
-	if d.metricsPluginListener != nil {
-		d.metricsPluginListener.Close()
+	if daemon.metricsPluginListener != nil {
+		daemon.metricsPluginListener.Close()
 	}
 }
 

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -430,12 +430,12 @@ func getIpamConfig(data []network.IPAMConfig) ([]*libnetwork.IpamConf, []*libnet
 
 // UpdateContainerServiceConfig updates a service configuration.
 func (daemon *Daemon) UpdateContainerServiceConfig(containerName string, serviceConfig *clustertypes.ServiceConfig) error {
-	container, err := daemon.GetContainer(containerName)
+	ctr, err := daemon.GetContainer(containerName)
 	if err != nil {
 		return err
 	}
 
-	container.NetworkSettings.Service = serviceConfig
+	ctr.NetworkSettings.Service = serviceConfig
 	return nil
 }
 
@@ -443,24 +443,24 @@ func (daemon *Daemon) UpdateContainerServiceConfig(containerName string, service
 // network. If either cannot be found, an err is returned. If the
 // network cannot be set up, an err is returned.
 func (daemon *Daemon) ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error {
-	container, err := daemon.GetContainer(containerName)
+	ctr, err := daemon.GetContainer(containerName)
 	if err != nil {
 		return err
 	}
-	return daemon.ConnectToNetwork(container, networkName, endpointConfig)
+	return daemon.ConnectToNetwork(ctr, networkName, endpointConfig)
 }
 
 // DisconnectContainerFromNetwork disconnects the given container from
 // the given network. If either cannot be found, an err is returned.
 func (daemon *Daemon) DisconnectContainerFromNetwork(containerName string, networkName string, force bool) error {
-	container, err := daemon.GetContainer(containerName)
+	ctr, err := daemon.GetContainer(containerName)
 	if err != nil {
 		if force {
 			return daemon.ForceEndpointDelete(containerName, networkName)
 		}
 		return err
 	}
-	return daemon.DisconnectFromNetwork(container, networkName, force)
+	return daemon.DisconnectFromNetwork(ctr, networkName, force)
 }
 
 // GetNetworkDriverList returns the list of plugins drivers
@@ -485,10 +485,10 @@ func (daemon *Daemon) GetNetworkDriverList() []string {
 
 	networks := daemon.netController.Networks()
 
-	for _, network := range networks {
-		if !pluginMap[network.Type()] {
-			pluginList = append(pluginList, network.Type())
-			pluginMap[network.Type()] = true
+	for _, nw := range networks {
+		if !pluginMap[nw.Type()] {
+			pluginList = append(pluginList, nw.Type())
+			pluginMap[nw.Type()] = true
 		}
 	}
 

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -135,10 +135,10 @@ func WithApparmor(c *container.Container) coci.SpecOpts {
 			} else if c.HostConfig.Privileged {
 				appArmorProfile = unconfinedAppArmorProfile
 			} else {
-				appArmorProfile = defaultApparmorProfile
+				appArmorProfile = defaultAppArmorProfile
 			}
 
-			if appArmorProfile == defaultApparmorProfile {
+			if appArmorProfile == defaultAppArmorProfile {
 				// Unattended upgrades and other fun services can unload AppArmor
 				// profiles inadvertently. Since we cannot store our profile in
 				// /etc/apparmor.d, nor can we practically add other ways of
@@ -397,9 +397,9 @@ const (
 	slavePropagationOption  = "master:"
 )
 
-// hasMountinfoOption checks if any of the passed any of the given option values
+// hasMountInfoOption checks if any of the passed any of the given option values
 // are set in the passed in option string.
-func hasMountinfoOption(opts string, vals ...string) bool {
+func hasMountInfoOption(opts string, vals ...string) bool {
 	for _, opt := range strings.Split(opts, " ") {
 		for _, val := range vals {
 			if strings.HasPrefix(opt, val) {
@@ -417,7 +417,7 @@ func ensureShared(path string) error {
 		return err
 	}
 	// Make sure source mount point is shared.
-	if !hasMountinfoOption(optionalOpts, sharedPropagationOption) {
+	if !hasMountInfoOption(optionalOpts, sharedPropagationOption) {
 		return errors.Errorf("path %s is mounted on %s but it is not a shared mount", path, sourceMount)
 	}
 	return nil
@@ -430,7 +430,7 @@ func ensureSharedOrSlave(path string) error {
 		return err
 	}
 
-	if !hasMountinfoOption(optionalOpts, sharedPropagationOption, slavePropagationOption) {
+	if !hasMountInfoOption(optionalOpts, sharedPropagationOption, slavePropagationOption) {
 		return errors.Errorf("path %s is mounted on %s but it is not a shared or slave mount", path, sourceMount)
 	}
 	return nil

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -290,7 +290,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 				setNamespace(s, nsUser)
 			}
 		case ipcMode.IsHost():
-			oci.RemoveNamespace(s, specs.LinuxNamespaceType("ipc"))
+			oci.RemoveNamespace(s, "ipc")
 		case ipcMode.IsEmpty():
 			// A container was created by an older version of the daemon.
 			// The default behavior used to be what is now called "shareable".
@@ -304,28 +304,32 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 
 		// pid
 		if c.HostConfig.PidMode.IsContainer() {
-			ns := specs.LinuxNamespace{Type: "pid"}
 			pc, err := daemon.getPidContainer(c)
 			if err != nil {
 				return err
 			}
-			ns.Path = fmt.Sprintf("/proc/%d/ns/pid", pc.State.GetPID())
+			ns := specs.LinuxNamespace{
+				Type: "pid",
+				Path: fmt.Sprintf("/proc/%d/ns/pid", pc.State.GetPID()),
+			}
 			setNamespace(s, ns)
 			if userNS {
 				// to share a PID namespace, they must also share a user namespace
-				nsUser := specs.LinuxNamespace{Type: "user"}
-				nsUser.Path = fmt.Sprintf("/proc/%d/ns/user", pc.State.GetPID())
+				nsUser := specs.LinuxNamespace{
+					Type: "user",
+					Path: fmt.Sprintf("/proc/%d/ns/user", pc.State.GetPID()),
+				}
 				setNamespace(s, nsUser)
 			}
 		} else if c.HostConfig.PidMode.IsHost() {
-			oci.RemoveNamespace(s, specs.LinuxNamespaceType("pid"))
+			oci.RemoveNamespace(s, "pid")
 		} else {
 			ns := specs.LinuxNamespace{Type: "pid"}
 			setNamespace(s, ns)
 		}
 		// uts
 		if c.HostConfig.UTSMode.IsHost() {
-			oci.RemoveNamespace(s, specs.LinuxNamespaceType("uts"))
+			oci.RemoveNamespace(s, "uts")
 			s.Hostname = ""
 		}
 

--- a/daemon/oci_linux_test.go
+++ b/daemon/oci_linux_test.go
@@ -54,7 +54,7 @@ func setupFakeDaemon(t *testing.T, c *container.Container) *Daemon {
 }
 
 func cleanupFakeContainer(c *container.Container) {
-	os.RemoveAll(c.Root)
+	_ = os.RemoveAll(c.Root)
 }
 
 // TestTmpfsDevShmNoDupMount checks that a user-specified /dev/shm tmpfs

--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -10,11 +10,11 @@ import (
 
 // ContainerPause pauses a container
 func (daemon *Daemon) ContainerPause(name string) error {
-	container, err := daemon.GetContainer(name)
+	ctr, err := daemon.GetContainer(name)
 	if err != nil {
 		return err
 	}
-	return daemon.containerPause(container)
+	return daemon.containerPause(ctr)
 }
 
 // containerPause pauses the container execution without stopping the process.

--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -15,15 +15,15 @@ import (
 // stop. Returns an error if the container cannot be found, or if
 // there is an underlying error at any stage of the restart.
 func (daemon *Daemon) ContainerRestart(name string, seconds *int) error {
-	container, err := daemon.GetContainer(name)
+	ctr, err := daemon.GetContainer(name)
 	if err != nil {
 		return err
 	}
 	if seconds == nil {
-		stopTimeout := container.StopTimeout()
+		stopTimeout := ctr.StopTimeout()
 		seconds = &stopTimeout
 	}
-	if err := daemon.containerRestart(container, *seconds); err != nil {
+	if err := daemon.containerRestart(ctr, *seconds); err != nil {
 		return fmt.Errorf("Cannot restart container %s: %v", name, err)
 	}
 	return nil

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -164,7 +164,7 @@ func (daemon *Daemon) containerStart(container *container.Container, checkpoint 
 		container.HasBeenManuallyStopped = false
 	}
 
-	if err := daemon.saveApparmorConfig(container); err != nil {
+	if err := daemon.saveAppArmorConfig(container); err != nil {
 		return err
 	}
 

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -23,24 +23,24 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *containertypes.Hos
 		return errdefs.InvalidParameter(errors.New("checkpoint is only supported in experimental mode"))
 	}
 
-	container, err := daemon.GetContainer(name)
+	ctr, err := daemon.GetContainer(name)
 	if err != nil {
 		return err
 	}
 
 	validateState := func() error {
-		container.Lock()
-		defer container.Unlock()
+		ctr.Lock()
+		defer ctr.Unlock()
 
-		if container.Paused {
+		if ctr.Paused {
 			return errdefs.Conflict(errors.New("cannot start a paused container, try unpause instead"))
 		}
 
-		if container.Running {
+		if ctr.Running {
 			return containerNotModifiedError{running: true}
 		}
 
-		if container.RemovalInProgress || container.Dead {
+		if ctr.RemovalInProgress || ctr.Dead {
 			return errdefs.Conflict(errors.New("container is marked for removal and cannot be started"))
 		}
 		return nil
@@ -56,26 +56,26 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *containertypes.Hos
 		// creating a container, not during start.
 		if hostConfig != nil {
 			logrus.Warn("DEPRECATED: Setting host configuration options when the container starts is deprecated and has been removed in Docker 1.12")
-			oldNetworkMode := container.HostConfig.NetworkMode
-			if err := daemon.setSecurityOptions(container, hostConfig); err != nil {
+			oldNetworkMode := ctr.HostConfig.NetworkMode
+			if err := daemon.setSecurityOptions(ctr, hostConfig); err != nil {
 				return errdefs.InvalidParameter(err)
 			}
 			if err := daemon.mergeAndVerifyLogConfig(&hostConfig.LogConfig); err != nil {
 				return errdefs.InvalidParameter(err)
 			}
-			if err := daemon.setHostConfig(container, hostConfig); err != nil {
+			if err := daemon.setHostConfig(ctr, hostConfig); err != nil {
 				return errdefs.InvalidParameter(err)
 			}
-			newNetworkMode := container.HostConfig.NetworkMode
+			newNetworkMode := ctr.HostConfig.NetworkMode
 			if string(oldNetworkMode) != string(newNetworkMode) {
 				// if user has change the network mode on starting, clean up the
 				// old networks. It is a deprecated feature and has been removed in Docker 1.12
-				container.NetworkSettings.Networks = nil
-				if err := container.CheckpointTo(daemon.containersReplica); err != nil {
+				ctr.NetworkSettings.Networks = nil
+				if err := ctr.CheckpointTo(daemon.containersReplica); err != nil {
 					return errdefs.System(err)
 				}
 			}
-			container.InitDNSHostConfig()
+			ctr.InitDNSHostConfig()
 		}
 	} else {
 		if hostConfig != nil {
@@ -85,17 +85,17 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *containertypes.Hos
 
 	// check if hostConfig is in line with the current system settings.
 	// It may happen cgroups are umounted or the like.
-	if _, err = daemon.verifyContainerSettings(container.OS, container.HostConfig, nil, false); err != nil {
+	if _, err = daemon.verifyContainerSettings(ctr.OS, ctr.HostConfig, nil, false); err != nil {
 		return errdefs.InvalidParameter(err)
 	}
 	// Adapt for old containers in case we have updates in this function and
 	// old containers never have chance to call the new function in create stage.
 	if hostConfig != nil {
-		if err := daemon.adaptContainerSettings(container.HostConfig, false); err != nil {
+		if err := daemon.adaptContainerSettings(ctr.HostConfig, false); err != nil {
 			return errdefs.InvalidParameter(err)
 		}
 	}
-	return daemon.containerStart(container, checkpoint, checkpointDir, true)
+	return daemon.containerStart(ctr, checkpoint, checkpointDir, true)
 }
 
 // containerStart prepares the container to run by setting up everything the

--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -144,20 +144,20 @@ func (daemon *Daemon) ContainerTop(name string, psArgs string) (*container.Conta
 		return nil, err
 	}
 
-	container, err := daemon.GetContainer(name)
+	ctr, err := daemon.GetContainer(name)
 	if err != nil {
 		return nil, err
 	}
 
-	if !container.IsRunning() {
-		return nil, errNotRunning(container.ID)
+	if !ctr.IsRunning() {
+		return nil, errNotRunning(ctr.ID)
 	}
 
-	if container.IsRestarting() {
-		return nil, errContainerIsRestarting(container.ID)
+	if ctr.IsRestarting() {
+		return nil, errContainerIsRestarting(ctr.ID)
 	}
 
-	procs, err := daemon.containerd.ListPids(context.Background(), container.ID)
+	procs, err := daemon.containerd.ListPids(context.Background(), ctr.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -184,6 +184,6 @@ func (daemon *Daemon) ContainerTop(name string, psArgs string) (*container.Conta
 	if err != nil {
 		return nil, err
 	}
-	daemon.LogContainerEvent(container, "top")
+	daemon.LogContainerEvent(ctr, "top")
 	return procList, nil
 }

--- a/daemon/unpause.go
+++ b/daemon/unpause.go
@@ -10,33 +10,33 @@ import (
 
 // ContainerUnpause unpauses a container
 func (daemon *Daemon) ContainerUnpause(name string) error {
-	container, err := daemon.GetContainer(name)
+	ctr, err := daemon.GetContainer(name)
 	if err != nil {
 		return err
 	}
-	return daemon.containerUnpause(container)
+	return daemon.containerUnpause(ctr)
 }
 
 // containerUnpause resumes the container execution after the container is paused.
-func (daemon *Daemon) containerUnpause(container *container.Container) error {
-	container.Lock()
-	defer container.Unlock()
+func (daemon *Daemon) containerUnpause(ctr *container.Container) error {
+	ctr.Lock()
+	defer ctr.Unlock()
 
 	// We cannot unpause the container which is not paused
-	if !container.Paused {
-		return fmt.Errorf("Container %s is not paused", container.ID)
+	if !ctr.Paused {
+		return fmt.Errorf("Container %s is not paused", ctr.ID)
 	}
 
-	if err := daemon.containerd.Resume(context.Background(), container.ID); err != nil {
-		return fmt.Errorf("Cannot unpause container %s: %s", container.ID, err)
+	if err := daemon.containerd.Resume(context.Background(), ctr.ID); err != nil {
+		return fmt.Errorf("Cannot unpause container %s: %s", ctr.ID, err)
 	}
 
-	container.Paused = false
-	daemon.setStateCounter(container)
-	daemon.updateHealthMonitor(container)
-	daemon.LogContainerEvent(container, "unpause")
+	ctr.Paused = false
+	daemon.setStateCounter(ctr)
+	daemon.updateHealthMonitor(ctr)
+	daemon.LogContainerEvent(ctr, "unpause")
 
-	if err := container.CheckpointTo(daemon.containersReplica); err != nil {
+	if err := ctr.CheckpointTo(daemon.containersReplica); err != nil {
 		logrus.WithError(err).Warn("could not save container to disk")
 	}
 

--- a/daemon/volumes_linux_test.go
+++ b/daemon/volumes_linux_test.go
@@ -34,12 +34,12 @@ func TestBindDaemonRoot(t *testing.T) {
 				"source is /":       "/",
 			} {
 				t.Run(desc, func(t *testing.T) {
-					mount := mount.Mount{
+					mnt := mount.Mount{
 						Type:        mount.TypeBind,
 						Source:      source,
 						BindOptions: test.opts,
 					}
-					needsProp, err := d.validateBindDaemonRoot(mount)
+					needsProp, err := d.validateBindDaemonRoot(mnt)
 					if (err != nil) != test.err {
 						t.Fatalf("expected err=%v, got: %v", test.err, err)
 					}

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -82,12 +82,12 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 	// metadata, the ownership must be set properly for potential container
 	// remapped root (user namespaces)
 	rootIDs := daemon.idMapping.RootPair()
-	for _, mount := range netMounts {
+	for _, mnt := range netMounts {
 		// we should only modify ownership of network files within our own container
 		// metadata repository. If the user specifies a mount path external, it is
 		// up to the user to make sure the file has proper ownership for userns
-		if strings.Index(mount.Source, daemon.repository) == 0 {
-			if err := os.Chown(mount.Source, rootIDs.UID, rootIDs.GID); err != nil {
+		if strings.Index(mnt.Source, daemon.repository) == 0 {
+			if err := os.Chown(mnt.Source, rootIDs.UID, rootIDs.GID); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
- address some minor linting issues
- rename variables that collide with imported package names
- consistently use `daemon` as receiver name
- some capitalisation nits