### PR TITLE
container.ConfigFilePath: use same signature on Windows

### DIFF
--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -202,6 +202,6 @@ func (container *Container) ConfigsDirPath() string {
 }
 
 // ConfigFilePath returns the path to the on-disk location of a config.
-func (container *Container) ConfigFilePath(configRef swarmtypes.ConfigReference) string {
-	return filepath.Join(container.ConfigsDirPath(), configRef.ConfigID)
+func (container *Container) ConfigFilePath(configRef swarmtypes.ConfigReference) (string, error) {
+	return filepath.Join(container.ConfigsDirPath(), configRef.ConfigID), nil
 }

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -55,7 +55,10 @@ func (daemon *Daemon) setupConfigDir(c *container.Container) (setupErr error) {
 			continue
 		}
 
-		fPath := c.ConfigFilePath(*configRef)
+		fPath, err := c.ConfigFilePath(*configRef)
+		if err != nil {
+			return errors.Wrap(err, "error getting config file path for container")
+		}
 		log := logrus.WithFields(logrus.Fields{"name": configRef.File.Name, "path": fPath})
 
 		log.Debug("injecting config")


### PR DESCRIPTION
This made my IDE unhappy; `ConfigFilePath` is an exported function, so it makes sense to use the same signature for both Linux and Windows.

This patch also adds error handling (same as on Linux), even though the current implementation will never return an error (it's good practice to handle errors, so I assumed this would be the right approach)

Also renaming a variable to make comparing implementations of `setupSecretDir` easier