### PR TITLE
docker-py: skip PullImageTest::test_pull_invalid_platform

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -16,7 +16,7 @@ source hack/make/.integration-test-helpers
 --deselect=tests/integration/api_exec_test.py::ExecTest::test_detach_with_arg \
 --deselect=tests/integration/api_exec_test.py::ExecDemuxTest::test_exec_command_tty_stream_no_demux \
 --deselect=tests/integration/api_build_test.py::BuildTest::test_build_invalid_platform \
---deselect=tests/integration/api_image_test.py::PullImageTest::test_build_invalid_platform \
+--deselect=tests/integration/api_image_test.py::PullImageTest::test_pull_invalid_platform \
 "}
 (
 	bundle .integration-daemon-start


### PR DESCRIPTION
This test causes docker-py to fail if the daemon is running with `--experimental` enabled

and remove `PullImageTest::test_build_invalid_platform` from the list,
which was a copy/paste error in f8cde0b32d86fa2df71ec65adc3d45f862b3ea33 (https://github.com/moby/moby/pull/39709)


This can be removed once we run the `docker-py` tests on a version of docker-py that has https://github.com/docker/docker-py/pull/2382
