### PR TITLE
Unit test for getOrphan

### DIFF
--- a/layer/filestore_test.go
+++ b/layer/filestore_test.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -100,5 +101,52 @@ func TestStartTransactionFailure(t *testing.T) {
 
 	if err := tx.Cancel(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestGetOrphan(t *testing.T) {
+	fms, td, cleanup := newFileMetadataStore(t)
+	defer cleanup()
+
+	layerRoot := filepath.Join(td, "sha256")
+	if err := os.MkdirAll(layerRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := fms.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	layerid := randomLayerID(5)
+	err = tx.Commit(layerid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	layerPath := fms.getLayerDirectory(layerid)
+	if err := ioutil.WriteFile(filepath.Join(layerPath, "cache-id"), []byte(stringid.GenerateRandomID()), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	orphanLayers, err := fms.getOrphan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(orphanLayers) != 0 {
+		t.Fatalf("Expected to have zero orphan layers")
+	}
+
+	layeridSplit := strings.Split(layerid.String(), ":")
+	newPath := filepath.Join(layerRoot, fmt.Sprintf("%s-%s-removing", layeridSplit[1], stringid.GenerateRandomID()))
+	err = os.Rename(layerPath, newPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	orphanLayers, err = fms.getOrphan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(orphanLayers) != 1 {
+		t.Fatalf("Expected to have one orphan layer")
 	}
 }


### PR DESCRIPTION
Add unit test for filestore getOrphan() which was requested on docker/engine#268


Relates to the changes made in https://github.com/moby/moby/pull/39193