### PR TITLE
docker-py: fix linting, generate junit.xml, save bundles, and various improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,6 +83,23 @@ pipeline {
                             post {
                                 always {
                                     junit testResults: 'bundles/test-docker-py/junit-report.xml', allowEmptyResults: true
+
+                                    sh '''
+                                    echo "Ensuring container killed."
+                                    docker rm -vf docker-pr$BUILD_NUMBER || true
+                                    '''
+
+                                    sh '''
+                                    echo 'Chowning /workspace to jenkins user'
+                                    docker run --rm -v "$WORKSPACE:/workspace" busybox chown -R "$(id -u):$(id -g)" /workspace
+                                    '''
+
+                                    sh '''
+                                    echo 'Creating docker-py-bundles.tar.gz'
+                                    tar -czf docker-py-bundles.tar.gz bundles/test-docker-py/*.xml bundles/test-docker-py/*.log
+                                    '''
+
+                                    archiveArtifacts artifacts: 'docker-py-bundles.tar.gz'
                                 }
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,11 @@ pipeline {
                                     test-docker-py
                                 '''
                             }
+                            post {
+                                always {
+                                    junit testResults: 'bundles/test-docker-py/junit-report.xml', allowEmptyResults: true
+                                }
+                            }
                         }
                         stage("Static") {
                             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
                                   -e DOCKER_GRAPHDRIVER \
                                   docker:${GIT_COMMIT} \
                                   hack/make.sh \
-                                    binary-daemon \
+                                    dynbinary-daemon \
                                     test-docker-py
                                 '''
                             }

--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -26,7 +26,7 @@ source hack/make/.integration-test-helpers
 	case "${docker_host_scheme}" in
 		unix)
 			# trim the tcp:// scheme, and bind-mount the docker socket into the container
-			run_opts="-v ${DOCKER_HOST#unix://}:/var/run/docker.sock"
+			run_opts="--mount type=bind,src=${DOCKER_HOST#unix://},dst=/var/run/docker.sock"
 			;;
 
 		tcp)

--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -7,21 +7,21 @@ source hack/make/.integration-test-helpers
 # TODO docker 17.06 cli client used in CI fails to build using a sha;
 # unable to prepare context: unable to 'git clone' to temporary context directory: error fetching: error: no such remote ref ead0bb9e08c13dd3d1712759491eee06bf5a5602
 #: exit status 128
-: ${DOCKER_PY_COMMIT:=4.0.2}
+: "${DOCKER_PY_COMMIT:=4.0.2}"
 
 # custom options to pass py.test
 # TODO remove these skip once we update to a docker-py version that has https://github.com/docker/docker-py/pull/2369, https://github.com/docker/docker-py/pull/2380, https://github.com/docker/docker-py/pull/2382
-: ${PY_TEST_OPTIONS:="\
+: "${PY_TEST_OPTIONS:=\
 --deselect=tests/integration/api_swarm_test.py::SwarmTest::test_init_swarm_data_path_addr \
 --deselect=tests/integration/api_exec_test.py::ExecTest::test_detach_with_arg \
 --deselect=tests/integration/api_exec_test.py::ExecDemuxTest::test_exec_command_tty_stream_no_demux \
 --deselect=tests/integration/api_build_test.py::BuildTest::test_build_invalid_platform \
 --deselect=tests/integration/api_image_test.py::PullImageTest::test_pull_invalid_platform \
-"}
+}"
 (
 	bundle .integration-daemon-start
 
-	docker_host_scheme=`echo "${DOCKER_HOST}" | cut -d: -f1 -`
+	docker_host_scheme=$(echo "${DOCKER_HOST}" | cut -d: -f1 -)
 
 	case "${docker_host_scheme}" in
 		unix)
@@ -48,14 +48,16 @@ source hack/make/.integration-test-helpers
 			[ -n "${TESTDEBUG}" ] && set -x
 			[ -z "${TESTDEBUG}" ] && build_opts="--quiet"
 			[ -f /.dockerenv ] || build_opts="${build_opts} --network=host"
-			exec docker build ${build_opts} -t ${docker_py_image} -f tests/Dockerfile "https://github.com/docker/docker-py.git#${DOCKER_PY_COMMIT}"
+			# shellcheck disable=SC2086
+			exec docker build ${build_opts} -t "${docker_py_image}" -f tests/Dockerfile "https://github.com/docker/docker-py.git#${DOCKER_PY_COMMIT}"
 		)
 	fi
 
 	echo INFO: Starting docker-py tests...
 	(
 		[ -n "${TESTDEBUG}" ] && set -x
-		exec docker run -t --rm ${run_opts} ${docker_py_image} pytest ${PY_TEST_OPTIONS} tests/integration
+		# shellcheck disable=SC2086
+		exec docker run -t --rm ${run_opts} "${docker_py_image}" pytest ${PY_TEST_OPTIONS} tests/integration
 	)
 	bundle .integration-daemon-stop
 ) 2>&1 | tee -a "$DEST/test.log"

--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -57,7 +57,7 @@ source hack/make/.integration-test-helpers
 	(
 		[ -n "${TESTDEBUG}" ] && set -x
 		# shellcheck disable=SC2086
-		exec docker run -t --rm ${run_opts} "${docker_py_image}" pytest ${PY_TEST_OPTIONS} tests/integration
+		exec docker run --rm ${run_opts} "${docker_py_image}" pytest ${PY_TEST_OPTIONS} tests/integration
 	)
 	bundle .integration-daemon-stop
 ) 2>&1 | tee -a "$DEST/test.log"

--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -17,6 +17,7 @@ source hack/make/.integration-test-helpers
 --deselect=tests/integration/api_exec_test.py::ExecDemuxTest::test_exec_command_tty_stream_no_demux \
 --deselect=tests/integration/api_build_test.py::BuildTest::test_build_invalid_platform \
 --deselect=tests/integration/api_image_test.py::PullImageTest::test_pull_invalid_platform \
+--junitxml=${DEST}/junit-report.xml \
 }"
 (
 	bundle .integration-daemon-start
@@ -56,8 +57,8 @@ source hack/make/.integration-test-helpers
 	echo INFO: Starting docker-py tests...
 	(
 		[ -n "${TESTDEBUG}" ] && set -x
-		# shellcheck disable=SC2086
-		exec docker run --rm ${run_opts} "${docker_py_image}" pytest ${PY_TEST_OPTIONS} tests/integration
+		# shellcheck disable=SC2086,SC2140
+		exec docker run --rm ${run_opts} --mount type=bind,"src=${ABS_DEST}","dst=/src/${DEST}" "${docker_py_image}" pytest ${PY_TEST_OPTIONS} tests/integration
 	)
 	bundle .integration-daemon-stop
 ) 2>&1 | tee -a "$DEST/test.log"


### PR DESCRIPTION
Addresses parts of https://github.com/moby/moby/issues/39675

~built on top of https://github.com/moby/moby/pull/39714 to get CI green~


- fix linting issues reported by shellcheck
- run without tty to disable color output
- use --mount for bind-mounting docker.sock
- output junit.xml for test-results and send them to Jenkins
- build dynamic binary for docker-py, to match makefile
    This also makes sure that we can test all functionality of the daemon, because some features are not available on static binaries.
- save docker-py artifacts
