### PR TITLE
Dockerfile: add python3-wheel back again (for yamllint)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -248,6 +248,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	pigz \
 	python3-pip \
 	python3-setuptools \
+	python3-wheel \
 	thin-provisioning-tools \
 	vim \
 	vim-common \


### PR DESCRIPTION
Although the Dockerfile builds without it, adding wheel back
should save some time

```
00:45:28  #14 10.70 Building wheels for collected packages: pathspec, pyyaml
00:45:28  #14 10.70   Running setup.py bdist_wheel for pathspec: started
00:45:28  #14 10.88   Running setup.py bdist_wheel for pathspec: finished with status 'error'
00:45:28  #14 10.88   Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-mbotnxes/pathspec/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpg9pl4u6kpip-wheel- --python-tag cp35:
00:45:28  #14 10.88   usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
00:45:28  #14 10.88      or: -c --help [cmd1 cmd2 ...]
00:45:28  #14 10.88      or: -c --help-commands
00:45:28  #14 10.88      or: -c cmd --help
00:45:28  #14 10.88
00:45:28  #14 10.88   error: invalid command 'bdist_wheel'
00:45:28  #14 10.88
00:45:28  #14 10.88   ----------------------------------------
00:45:28  #14 10.88   Failed building wheel for pathspec
00:45:28  #14 10.88   Running setup.py clean for pathspec
00:45:28  #14 11.05   Running setup.py bdist_wheel for pyyaml: started
00:45:28  #14 11.25   Running setup.py bdist_wheel for pyyaml: finished with status 'error'
00:45:28  #14 11.25   Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-mbotnxes/pyyaml/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpyci_xi0bpip-wheel- --python-tag cp35:
00:45:28  #14 11.25   usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
00:45:28  #14 11.25      or: -c --help [cmd1 cmd2 ...]
00:45:28  #14 11.25      or: -c --help-commands
00:45:28  #14 11.25      or: -c cmd --help
00:45:28  #14 11.25
00:45:28  #14 11.25   error: invalid command 'bdist_wheel'
00:45:28  #14 11.25
00:45:28  #14 11.25   ----------------------------------------
00:45:28  #14 11.25   Failed building wheel for pyyaml
00:45:28  #14 11.25   Running setup.py clean for pyyaml
00:45:28  #14 11.44 Failed to build pathspec pyyaml
00:45:28  #14 11.45 Installing collected packages: pathspec, pyyaml, yamllint
00:45:28  #14 11.45   Running setup.py install for pathspec: started
00:45:29  #14 11.73     Running setup.py install for pathspec: finished with status 'done'
00:45:29  #14 11.73   Running setup.py install for pyyaml: started
00:45:29  #14 12.05     Running setup.py install for pyyaml: finished with status 'done'
00:45:29  #14 12.12 Successfully installed pathspec-0.5.9 pyyaml-5.1.2 yamllint-1.16.0
```

