### PR TITLE
Jenkinsfile: collect junit.xml for all architectures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -335,6 +335,11 @@ pipeline {
                                   hack/test/unit
                                 '''
                             }
+                            post {
+                                always {
+                                    junit testResults: 'bundles/junit-report.xml', allowEmptyResults: true
+                                }
+                            }
                         }
                         stage("Integration tests") {
                             environment { TEST_SKIP_INTEGRATION_CLI = '1' }
@@ -495,6 +500,11 @@ pipeline {
                                   docker:${GIT_COMMIT} \
                                   hack/test/unit
                                 '''
+                            }
+                            post {
+                                always {
+                                    junit testResults: 'bundles/junit-report.xml', allowEmptyResults: true
+                                }
                             }
                         }
                         stage("Integration tests") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,6 +121,11 @@ pipeline {
                                   hack/test/unit
                                 '''
                             }
+                            post {
+                                always {
+                                    junit testResults: 'bundles/junit-report.xml', allowEmptyResults: true
+                                }
+                            }
                         }
                         stage("Validate vendor") {
                             steps {
@@ -164,7 +169,6 @@ pipeline {
                             '''
 
                             archiveArtifacts artifacts: 'unit-bundles.tar.gz'
-                            junit testResults: 'bundles/junit-report.xml', allowEmptyResults: true
                         }
                         cleanup {
                             sh 'make clean'


### PR DESCRIPTION
Addresses parts of https://github.com/moby/moby/issues/39675

- be more lenient on junit report gathering in Jenkinsfile
  In case a job fails before even generating a report file. (cherry-picked from https://github.com/moby/moby/pull/39682)
- Jenkinsfile: send junit.xml in the stage that produced it
  This will send the results directly after the tests complete, and make the stage more atomic.
- Jenkinsfile: collect junit.xml for all architectures
  Jenkins groups them per stage, so collecting them for all architectures is possible (without them conflicting or becoming ambiguous)