### PR TITLE
distribution: modify warning logic when pulling v2 schema1 manifests

### DIFF
--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -188,7 +188,7 @@ func (p *v2Pusher) pushV2Tag(ctx context.Context, ref reference.NamedTagged, id 
 
 		logrus.Warnf("failed to upload schema2 manifest: %v - falling back to schema1", err)
 
-		msg := schema1DeprecationMessage(ref)
+		msg := fmt.Sprintf("[DEPRECATION NOTICE] registry v2 schema1 support will be removed in an upcoming release. Please contact admins of the %s registry NOW to avoid future disruption. More information at https://docs.docker.com/registry/spec/deprecated-schema-v1/", reference.Domain(ref))
 		logrus.Warn(msg)
 		progress.Message(p.config.ProgressOutput, "", msg)
 

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -156,7 +156,3 @@ func (th *existingTokenHandler) AuthorizeRequest(req *http.Request, params map[s
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", th.token))
 	return nil
 }
-
-func schema1DeprecationMessage(ref reference.Named) string {
-	return fmt.Sprintf("[DEPRECATION NOTICE] registry v2 schema1 support will be removed in an upcoming release. Please contact admins of the %s registry NOW to avoid future disruption.", reference.Domain(ref))
-}


### PR DESCRIPTION
The warning message should have been for push only, since there are images pushed with v2 schema1 years ago that we still want to be able to pull.

The warning on pull was incorrectly asking to contact registry admins.
It is kept on push however.

Pulling manifest lists with v2 schema1 manifests will not be supported thus
there is a warning for those, but wording changed to suggest repository author
to upgrade.

Finally, a milder warning on regular pull is kept ONLY for DockerHub users
in order to incite moving away from schema1.

Signed-off-by: Tibor Vass <tibor@docker.com>

Closes #39701

Refs:
- https://github.com/moby/moby/pull/39365/commits/d35f8f4329bef6de0db3457959d81a32c2a530c6
- https://github.com/moby/moby/pull/39384#issuecomment-514381796

cc @dmcgowan @tonistiigi @josephschorr @thaJeztah 

Needs to be backported to Docker 19.03