### PR TITLE
Add missing continues from #39193

### DIFF
--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -558,8 +558,10 @@ func copyFile(archiver Archiver, source, dest *copyEndpoint, identity *idtools.I
 	} else {
 		// Normal containers
 		if identity == nil {
-			// Use system.MkdirAll here, which is a custom version of os.MkdirAll
-			// modified for use on Windows to handle volume GUID paths (\\?\{dae8d3ac-b9a1-11e9-88eb-e8554b2ba1db}\path\)
+			// Use system.MkdirAll here, which is a  custom version of  os.MkdirAll
+			// modified for use on Windows to handle volume GUID paths. These paths 
+			// are of the form \\?\Volume{<GUID>}\<path>. An example would be:
+			// \\?\Volume{dae8d3ac-b9a1-11e9-88eb-e8554b2ba1db}\bin\busybox.exe
 			if err := system.MkdirAll(filepath.Dir(dest.path), 0755, ""); err != nil {
 				return err
 			}

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -170,7 +170,6 @@ func TestBuildMultiStageCopy(t *testing.T) {
 			assert.NilError(t, err)
 
 			out := bytes.NewBuffer(nil)
-			assert.NilError(t, err)
 			_, err = io.Copy(out, resp.Body)
 			_ = resp.Body.Close()
 			if err != nil {
@@ -604,7 +603,6 @@ func TestBuildPreserveOwnership(t *testing.T) {
 			assert.NilError(t, err)
 
 			out := bytes.NewBuffer(nil)
-			assert.NilError(t, err)
 			_, err = io.Copy(out, resp.Body)
 			_ = resp.Body.Close()
 			if err != nil {

--- a/layer/filestore.go
+++ b/layer/filestore.go
@@ -328,10 +328,12 @@ func (fms *fileMetadataStore) getOrphan() ([]roLayer, error) {
 					contentBytes, err := ioutil.ReadFile(chainFile)
 					if err != nil {
 						logrus.WithError(err).WithField("digest", dgst).Error("cannot get cache ID")
+						continue;
 					}
 					cacheID := strings.TrimSpace(string(contentBytes))
 					if cacheID == "" {
 						logrus.Errorf("invalid cache id value")
+						continue;
 					}
 
 					l := &roLayer{


### PR DESCRIPTION
**- What I did**
Modified error path to prevent adding orphaned layer when `cacheID` is not known

**- How I did it**
Added missing continue statements.

**- How to verify it**
The change is limited to error path. So it is best verified by using a debugger to break into line 333 of `layer/filestore.go` and manually changing `cacheID` to "".

**- Description for the changelog**
Add missing continue statements to the error path of detecting orphaned layers.

**- A picture of a cute animal (not mandatory but encouraged)**

