### PR TITLE
vendor: update buildkit to v0.6.1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -27,7 +27,7 @@ github.com/imdario/mergo                            7c29201646fa3de8506f70121347
 golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af2b83e6acac3c
 
 # buildkit
-github.com/moby/buildkit                            f5a55a9516d1c6e2ade9bec22b83259caeed3a84 
+github.com/moby/buildkit                            be0d75f074e7a4b0f5b5877c719213a3f5057e60 # v0.6.1
 github.com/tonistiigi/fsutil                        3bbb99cdbd76619ab717299830c60f6f2a533a6b
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7

--- a/vendor/github.com/moby/buildkit/cache/remotecache/import.go
+++ b/vendor/github.com/moby/buildkit/cache/remotecache/import.go
@@ -111,7 +111,7 @@ func (ci *contentCacheImporter) importInlineCache(ctx context.Context, dt []byte
 	}
 
 	var mu sync.Mutex
-	cc := v1.NewCacheChains()
+	var cMap = map[digest.Digest]*v1.CacheChains{}
 
 	eg, ctx := errgroup.WithContext(ctx)
 	for dgst, dt := range m {
@@ -183,11 +183,12 @@ func (ci *contentCacheImporter) importInlineCache(ctx context.Context, dt []byte
 				if err != nil {
 					return errors.WithStack(err)
 				}
-
-				mu.Lock()
+				cc := v1.NewCacheChains()
 				if err := v1.ParseConfig(config, layers, cc); err != nil {
 					return err
 				}
+				mu.Lock()
+				cMap[dgst] = cc
 				mu.Unlock()
 				return nil
 			})
@@ -198,11 +199,17 @@ func (ci *contentCacheImporter) importInlineCache(ctx context.Context, dt []byte
 		return nil, err
 	}
 
-	keysStorage, resultStorage, err := v1.NewCacheKeyStorage(cc, w)
-	if err != nil {
-		return nil, err
+	cms := make([]solver.CacheManager, 0, len(cMap))
+
+	for _, cc := range cMap {
+		keysStorage, resultStorage, err := v1.NewCacheKeyStorage(cc, w)
+		if err != nil {
+			return nil, err
+		}
+		cms = append(cms, solver.NewCacheManager(id, keysStorage, resultStorage))
 	}
-	return solver.NewCacheManager(id, keysStorage, resultStorage), nil
+
+	return solver.NewCombinedCacheManager(cms, nil), nil
 }
 
 func (ci *contentCacheImporter) allDistributionManifests(ctx context.Context, dt []byte, m map[digest.Digest][]byte) error {

--- a/vendor/github.com/moby/buildkit/cache/remotecache/inline/inline.go
+++ b/vendor/github.com/moby/buildkit/cache/remotecache/inline/inline.go
@@ -31,6 +31,12 @@ func (ce *exporter) Finalize(ctx context.Context) (map[string]string, error) {
 	return nil, nil
 }
 
+func (ce *exporter) reset() {
+	cc := v1.NewCacheChains()
+	ce.CacheExporterTarget = cc
+	ce.chains = cc
+}
+
 func (ce *exporter) ExportForLayers(layers []digest.Digest) ([]byte, error) {
 	config, descs, err := ce.chains.Marshal()
 	if err != nil {
@@ -82,6 +88,7 @@ func (ce *exporter) ExportForLayers(layers []digest.Digest) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	ce.reset()
 
 	return dt, nil
 }

--- a/vendor/github.com/moby/buildkit/cache/remotecache/v1/utils.go
+++ b/vendor/github.com/moby/buildkit/cache/remotecache/v1/utils.go
@@ -78,10 +78,14 @@ func sortConfig(cc *CacheConfig) {
 				if ri.Inputs[i][j].Selector != rj.Inputs[i][j].Selector {
 					return ri.Inputs[i][j].Selector < rj.Inputs[i][j].Selector
 				}
-				return cc.Records[ri.Inputs[i][j].LinkIndex].Digest < cc.Records[rj.Inputs[i][j].LinkIndex].Digest
+				inputDigesti := cc.Records[ri.Inputs[i][j].LinkIndex].Digest
+				inputDigestj := cc.Records[rj.Inputs[i][j].LinkIndex].Digest
+				if inputDigesti != inputDigestj {
+					return inputDigesti < inputDigestj
+				}
 			}
 		}
-		return ri.Digest < rj.Digest
+		return false
 	})
 	for i, l := range sortedRecords {
 		l.newIndex = i

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/builder/build.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/builder/build.go
@@ -49,6 +49,7 @@ const (
 	keyNameContext             = "contextkey"
 	keyNameDockerfile          = "dockerfilekey"
 	keyContextSubDir           = "contextsubdir"
+	keyContextKeepGitDir       = "build-arg:BUILDKIT_CONTEXT_KEEP_GIT_DIR"
 )
 
 var httpPrefix = regexp.MustCompile(`^https?://`)
@@ -129,7 +130,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 
 	var buildContext *llb.State
 	isScratchContext := false
-	if st, ok := detectGitContext(opts[localNameContext]); ok {
+	if st, ok := detectGitContext(opts[localNameContext], opts[keyContextKeepGitDir]); ok {
 		if !forceLocalDockerfile {
 			src = *st
 		}
@@ -451,10 +452,17 @@ func filter(opt map[string]string, key string) map[string]string {
 	return m
 }
 
-func detectGitContext(ref string) (*llb.State, bool) {
+func detectGitContext(ref, gitContext string) (*llb.State, bool) {
 	found := false
 	if httpPrefix.MatchString(ref) && gitUrlPathWithFragmentSuffix.MatchString(ref) {
 		found = true
+	}
+
+	keepGit := false
+	if gitContext != "" {
+		if v, err := strconv.ParseBool(gitContext); err == nil {
+			keepGit = v
+		}
 	}
 
 	for _, prefix := range []string{"git://", "github.com/", "git@"} {
@@ -472,7 +480,12 @@ func detectGitContext(ref string) (*llb.State, bool) {
 	if len(parts) > 1 {
 		branch = parts[1]
 	}
-	st := llb.Git(parts[0], branch, dockerfile2llb.WithInternalName("load git source "+ref))
+	gitOpts := []llb.GitOption{dockerfile2llb.WithInternalName("load git source " + ref)}
+	if keepGit {
+		gitOpts = append(gitOpts, llb.KeepGitDir())
+	}
+
+	st := llb.Git(parts[0], branch, gitOpts...)
 	return &st, true
 }
 

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert.go
@@ -746,9 +746,9 @@ func dispatchCopyFileOp(d *dispatchState, c instructions.SourcesAndDest, sourceS
 			}}, copyOpt...)
 
 			if a == nil {
-				a = llb.Copy(sourceState, src, dest, opts...)
+				a = llb.Copy(sourceState, filepath.Join("/", src), dest, opts...)
 			} else {
-				a = a.Copy(sourceState, src, dest, opts...)
+				a = a.Copy(sourceState, filepath.Join("/", src), dest, opts...)
 			}
 		}
 	}

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/moby/buildkit/solver/pb"
 	"github.com/pkg/errors"
 )
 
@@ -113,7 +114,7 @@ func dispatchRunMounts(d *dispatchState, c *instructions.RunCommand, sources []*
 		}
 		if mount.ReadOnly {
 			mountOpts = append(mountOpts, llb.Readonly)
-		} else if mount.Type == instructions.MountTypeBind {
+		} else if mount.Type == instructions.MountTypeBind && opt.llbCaps.Supports(pb.CapExecMountBindReadWriteNoOuput) == nil {
 			mountOpts = append(mountOpts, llb.ForceNoOutput)
 		}
 		if mount.Type == instructions.MountTypeCache {

--- a/vendor/github.com/moby/buildkit/solver/combinedcache.go
+++ b/vendor/github.com/moby/buildkit/solver/combinedcache.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func newCombinedCacheManager(cms []CacheManager, main CacheManager) CacheManager {
+func NewCombinedCacheManager(cms []CacheManager, main CacheManager) CacheManager {
 	return &combinedCacheManager{cms: cms, main: main}
 }
 
@@ -80,7 +80,7 @@ func (cm *combinedCacheManager) Load(ctx context.Context, rec *CacheRecord) (res
 			res.Result.Release(context.TODO())
 		}
 	}()
-	if rec.cacheManager != cm.main {
+	if rec.cacheManager != cm.main && cm.main != nil {
 		for _, res := range results {
 			if _, err := cm.main.Save(res.CacheKey, res.Result, res.CacheResult.CreatedAt); err != nil {
 				return nil, err
@@ -91,6 +91,9 @@ func (cm *combinedCacheManager) Load(ctx context.Context, rec *CacheRecord) (res
 }
 
 func (cm *combinedCacheManager) Save(key *CacheKey, s Result, createdAt time.Time) (*ExportableCacheKey, error) {
+	if cm.main == nil {
+		return nil, nil
+	}
 	return cm.main.Save(key, s, createdAt)
 }
 

--- a/vendor/github.com/moby/buildkit/solver/jobs.go
+++ b/vendor/github.com/moby/buildkit/solver/jobs.go
@@ -141,7 +141,7 @@ func (s *state) combinedCacheManager() CacheManager {
 		return s.mainCache
 	}
 
-	return newCombinedCacheManager(cms, s.mainCache)
+	return NewCombinedCacheManager(cms, s.mainCache)
 }
 
 func (s *state) Release() {

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go
@@ -256,7 +256,7 @@ func (e *execOp) getRefCacheDir(ctx context.Context, ref cache.ImmutableRef, id 
 }
 
 func (e *execOp) getRefCacheDirNoCache(ctx context.Context, key string, ref cache.ImmutableRef, id string, m *pb.Mount, block bool) (cache.MutableRef, error) {
-	makeMutable := func(cache.ImmutableRef) (cache.MutableRef, error) {
+	makeMutable := func(ref cache.ImmutableRef) (cache.MutableRef, error) {
 		desc := fmt.Sprintf("cached mount %s from exec %s", m.Dest, strings.Join(e.op.Meta.Args, " "))
 		return e.cm.New(ctx, ref, cache.WithRecordType(client.UsageRecordTypeCacheMount), cache.WithDescription(desc), cache.CachePolicyRetain)
 	}
@@ -585,7 +585,7 @@ func (e *execOp) Exec(ctx context.Context, inputs []solver.Result) ([]solver.Res
 			mountable = ref
 		}
 
-		makeMutable := func(cache.ImmutableRef) (cache.MutableRef, error) {
+		makeMutable := func(ref cache.ImmutableRef) (cache.MutableRef, error) {
 			desc := fmt.Sprintf("mount %s from exec %s", m.Dest, strings.Join(e.op.Meta.Args, " "))
 			return e.cm.New(ctx, ref, cache.WithDescription(desc))
 		}
@@ -606,7 +606,7 @@ func (e *execOp) Exec(ctx context.Context, inputs []solver.Result) ([]solver.Res
 					outputs = append(outputs, active)
 					mountable = active
 				}
-			} else if ref == nil {
+			} else if (!m.Readonly || ref == nil) && m.Dest != pb.RootMount {
 				// this case is empty readonly scratch without output that is not really useful for anything but don't error
 				active, err := makeMutable(ref)
 				if err != nil {

--- a/vendor/github.com/moby/buildkit/solver/pb/caps.go
+++ b/vendor/github.com/moby/buildkit/solver/pb/caps.go
@@ -30,19 +30,20 @@ const (
 
 	CapBuildOpLLBFileName apicaps.CapID = "source.buildop.llbfilename"
 
-	CapExecMetaBase            apicaps.CapID = "exec.meta.base"
-	CapExecMetaProxy           apicaps.CapID = "exec.meta.proxyenv"
-	CapExecMetaNetwork         apicaps.CapID = "exec.meta.network"
-	CapExecMetaSecurity        apicaps.CapID = "exec.meta.security"
-	CapExecMetaSetsDefaultPath apicaps.CapID = "exec.meta.setsdefaultpath"
-	CapExecMountBind           apicaps.CapID = "exec.mount.bind"
-	CapExecMountCache          apicaps.CapID = "exec.mount.cache"
-	CapExecMountCacheSharing   apicaps.CapID = "exec.mount.cache.sharing"
-	CapExecMountSelector       apicaps.CapID = "exec.mount.selector"
-	CapExecMountTmpfs          apicaps.CapID = "exec.mount.tmpfs"
-	CapExecMountSecret         apicaps.CapID = "exec.mount.secret"
-	CapExecMountSSH            apicaps.CapID = "exec.mount.ssh"
-	CapExecCgroupsMounted      apicaps.CapID = "exec.cgroup"
+	CapExecMetaBase                  apicaps.CapID = "exec.meta.base"
+	CapExecMetaProxy                 apicaps.CapID = "exec.meta.proxyenv"
+	CapExecMetaNetwork               apicaps.CapID = "exec.meta.network"
+	CapExecMetaSecurity              apicaps.CapID = "exec.meta.security"
+	CapExecMetaSetsDefaultPath       apicaps.CapID = "exec.meta.setsdefaultpath"
+	CapExecMountBind                 apicaps.CapID = "exec.mount.bind"
+	CapExecMountBindReadWriteNoOuput apicaps.CapID = "exec.mount.bind.readwrite-nooutput"
+	CapExecMountCache                apicaps.CapID = "exec.mount.cache"
+	CapExecMountCacheSharing         apicaps.CapID = "exec.mount.cache.sharing"
+	CapExecMountSelector             apicaps.CapID = "exec.mount.selector"
+	CapExecMountTmpfs                apicaps.CapID = "exec.mount.tmpfs"
+	CapExecMountSecret               apicaps.CapID = "exec.mount.secret"
+	CapExecMountSSH                  apicaps.CapID = "exec.mount.ssh"
+	CapExecCgroupsMounted            apicaps.CapID = "exec.cgroup"
 
 	CapFileBase apicaps.CapID = "file.base"
 
@@ -189,6 +190,12 @@ func init() {
 
 	Caps.Init(apicaps.Cap{
 		ID:      CapExecMountBind,
+		Enabled: true,
+		Status:  apicaps.CapStatusExperimental,
+	})
+
+	Caps.Init(apicaps.Cap{
+		ID:      CapExecMountBindReadWriteNoOuput,
 		Enabled: true,
 		Status:  apicaps.CapStatusExperimental,
 	})


### PR DESCRIPTION
Fixes:
- cache-from from manifest lists https://github.com/moby/buildkit/pull/1129
- git context with keeping the .git directory https://github.com/moby/buildkit/pull/1132
- `COPY --from` with relative source path https://github.com/moby/buildkit/pull/1125
- readwrite mounts handling https://github.com/moby/buildkit/pull/1124

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
