### PR TITLE
Avoid using invalid value of cacheID on fail path

### DIFF
--- a/layer/filestore.go
+++ b/layer/filestore.go
@@ -328,10 +328,12 @@ func (fms *fileMetadataStore) getOrphan() ([]roLayer, error) {
 					contentBytes, err := ioutil.ReadFile(chainFile)
 					if err != nil {
 						logrus.WithError(err).WithField("digest", dgst).Error("cannot get cache ID")
+						continue
 					}
 					cacheID := strings.TrimSpace(string(contentBytes))
 					if cacheID == "" {
 						logrus.Errorf("invalid cache id value")
+						continue
 					}
 
 					l := &roLayer{


### PR DESCRIPTION
Issue introduced as a part of 213681b66a41d7728445e30125176834ce349c2a (https://github.com/moby/moby/pull/39193)

Even when we cannot obtain a valid value for cacheID, we still use it
for adding to orphaned layers list.

Fixed - if we fail to obtain cacheID, just move on to the next fileInfo.


**- What I did**
Modified error path to prevent adding orphaned layer when cacheID is not known

**- How I did it**
Added missing continue statements.

**- How to verify it**
The change is limited to error path. So it is best verified by using a debugger to break into line 333 of `layer/filestore.go` and manually changing `cacheID` to `""`.

**- Description for the changelog**
Ignore fileInfo values for which a valid cacheID cannot be determined.

**- A picture of a cute animal (not mandatory but encouraged)**
