### PR TITLE
Fixups for 39695 - edit comments, redundant asserts

### DIFF
--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -559,7 +559,10 @@ func copyFile(archiver Archiver, source, dest *copyEndpoint, identity *idtools.I
 		// Normal containers
 		if identity == nil {
 			// Use system.MkdirAll here, which is a custom version of os.MkdirAll
-			// modified for use on Windows to handle volume GUID paths (\\?\{dae8d3ac-b9a1-11e9-88eb-e8554b2ba1db}\path\)
+			// modified for use on Windows to handle volume GUID paths. These paths
+			// are of the form \\?\Volume{<GUID>}\<path>. An example would be:
+			// \\?\Volume{dae8d3ac-b9a1-11e9-88eb-e8554b2ba1db}\bin\busybox.exe
+
 			if err := system.MkdirAll(filepath.Dir(dest.path), 0755, ""); err != nil {
 				return err
 			}

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -170,7 +170,6 @@ func TestBuildMultiStageCopy(t *testing.T) {
 			assert.NilError(t, err)
 
 			out := bytes.NewBuffer(nil)
-			assert.NilError(t, err)
 			_, err = io.Copy(out, resp.Body)
 			_ = resp.Body.Close()
 			if err != nil {
@@ -604,7 +603,6 @@ func TestBuildPreserveOwnership(t *testing.T) {
 			assert.NilError(t, err)
 
 			out := bytes.NewBuffer(nil)
-			assert.NilError(t, err)
 			_, err = io.Copy(out, resp.Body)
 			_ = resp.Body.Close()
 			if err != nil {


### PR DESCRIPTION
follow-up to https://github.com/moby/moby/pull/39695

1. Modify comments added in 5858a99267822b93e2d304d876bab84d05b227c6 (https://github.com/moby/moby/pull/39695)
Windows Volume GUID path format is: \\?\Volume{<GUID Value>}\<path>
Rewrote the example given in comments to conform to the format..

2. Remove two redundant asserts[assert.NilError]. They are redundant
because the last statement will not change the value of err.

Signed-off-by: Vikram bir Singh <vikrambir.singh@docker.com>

**- What I did**
Modified comments and redundant asserts.

**- How I did it**
Edited comments, removed the redundant asserts.

**- How to verify it**
Code inspection is the best way to verify these changes. 
The only other way that I can think of verifying the redundant asserts is to 
create an environment where they would be fired and verify they appear twice as failures.

**- Description for the changelog**
Fixups for 39695 - edit comments, redundant asserts

**- A picture of a cute animal (not mandatory but encouraged)**
