### PR TITLE
builder-next: avoid double unmounting mountable

### DIFF
--- a/builder/builder-next/adapters/snapshot/snapshot.go
+++ b/builder/builder-next/adapters/snapshot/snapshot.go
@@ -480,6 +480,9 @@ func (m *mountable) Release() error {
 	}
 
 	m.mounts = nil
+	defer func() {
+		m.release = nil
+	}()
 	return m.release()
 }
 


### PR DESCRIPTION
fixes https://github.com/moby/buildkit/issues/1134

buildkit side protection in https://github.com/moby/buildkit/pull/1137

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
