### PR TITLE
[19.03] builder-next: avoid double unmounting mountable

### DIFF
--- a/builder/builder-next/adapters/snapshot/snapshot.go
+++ b/builder/builder-next/adapters/snapshot/snapshot.go
@@ -480,6 +480,9 @@ func (m *mountable) Release() error {
 	}
 
 	m.mounts = nil
+	defer func() {
+		m.release = nil
+	}()
 	return m.release()
 }
 


### PR DESCRIPTION
backport https://github.com/moby/moby/pull/39754

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
(cherry picked from commit 9ea2cf320ad2687a51aea1ed849f86f465cbc1d9)
