### PR TITLE
Fix phrasing when referring to the freezer cgroup

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4873,7 +4873,7 @@ paths:
                       Note that a running container can be _paused_. The `Running` and `Paused`
                       booleans are not mutually exclusive:
 
-                      When pausing a container (on Linux), the cgroups freezer is used to suspend
+                      When pausing a container (on Linux), the freezer cgroup is used to suspend
                       all processes in the container. Freezing the process requires the process to
                       be running. As a result, paused containers are both `Running` _and_ `Paused`.
 
@@ -5764,9 +5764,9 @@ paths:
     post:
       summary: "Pause a container"
       description: |
-        Use the cgroups freezer to suspend all processes in a container.
+        Use the freezer cgroup to suspend all processes in a container.
 
-        Traditionally, when suspending a process the `SIGSTOP` signal is used, which is observable by the process being suspended. With the cgroups freezer the process is unaware, and unable to capture, that it is being suspended, and subsequently resumed.
+        Traditionally, when suspending a process the `SIGSTOP` signal is used, which is observable by the process being suspended. With the freezer cgroup the process is unaware, and unable to capture, that it is being suspended, and subsequently resumed.
       operationId: "ContainerPause"
       responses:
         204:

--- a/container/state.go
+++ b/container/state.go
@@ -17,7 +17,7 @@ import (
 type State struct {
 	sync.Mutex
 	// Note that `Running` and `Paused` are not mutually exclusive:
-	// When pausing a container (on Linux), the cgroups freezer is used to suspend
+	// When pausing a container (on Linux), the freezer cgroup is used to suspend
 	// all processes in the container. Freezing the process requires the process to
 	// be running. As a result, paused containers are both `Running` _and_ `Paused`.
 	Running           bool


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix phrasing when referring to the freezer cgroup

ref. http://man7.org/linux/man-pages/man7/cgroups.7.html

**- How I did it**
`N/A`

**- How to verify it**
`N/A`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix phrasing when referring to the freezer cgroup

