### PR TITLE
builder-next: close build context upload on cancel

### DIFF
--- a/builder/builder-next/reqbodyhandler.go
+++ b/builder/builder-next/reqbodyhandler.go
@@ -35,6 +35,7 @@ func (h *reqBodyHandler) newRequest(rc io.ReadCloser) (string, func()) {
 		h.mu.Lock()
 		delete(h.requests, id)
 		h.mu.Unlock()
+		rc.Close()
 	}
 }
 


### PR DESCRIPTION
fix https://github.com/moby/buildkit/issues/1138

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
