### PR TITLE
mkimage-yum.sh: Fix install of additional packages

### DIFF
--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -43,10 +43,10 @@ while getopts ":y:p:g:t:h" opt; do
             usage
             ;;
         p)
-            install_packages+=("\"$OPTARG\"")
+            install_packages+=("$OPTARG")
             ;;
         g)
-            install_groups+=("\"$OPTARG\"")
+            install_groups+=("$OPTARG")
             ;;
         t)
             version="$OPTARG"
@@ -94,13 +94,13 @@ fi
 if [[ -n "$install_groups" ]];
 then
     yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs \
-        --setopt=group_package_types=mandatory -y groupinstall "${install_groups[*]}"
+        --setopt=group_package_types=mandatory -y groupinstall "${install_groups[@]}"
 fi
 
 if [[ -n "$install_packages" ]];
 then
     yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs \
-        --setopt=group_package_types=mandatory -y install "${install_packages[*]}"
+        --setopt=group_package_types=mandatory -y install "${install_packages[@]}"
 fi
 
 yum -c "$yum_config" --installroot="$target" -y clean all


### PR DESCRIPTION
The mkimage-yum.sh script fails to install additional
packages (passed with -p package-name), because the
package name is quoted twice.


**- What I did**
Remove the additional quotes around package/group names added to the install_* arrays.

**- How I did it**

**- How to verify it**
Run mkimage-yum.sh -p yum-utils myimage , and yum-utils will be installed

**- Description for the changelog**
mkimage-yum.sh: Remove extra quoting around additional package/group names

**- A picture of a cute animal (not mandatory but encouraged)**

