### PR TITLE
Fix docker crash when creating namespaces with UID in /etc/subuid and /etc/subgid

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1203,11 +1203,32 @@ func setupRemappedRoot(config *config.Config) (*idtools.IdentityMapping, error) 
 		// update remapped root setting now that we have resolved them to actual names
 		config.RemappedRoot = fmt.Sprintf("%s:%s", username, groupname)
 
+		// try with username:groupname, uid:groupname, username:gid, uid:gid,
+		// but keep the original error message (err)
 		mappings, err := idtools.NewIdentityMapping(username, groupname)
-		if err != nil {
+		if err == nil {
+			return mappings, nil
+		}
+		user, lookupErr := idtools.LookupUser(username)
+		if lookupErr != nil {
 			return nil, errors.Wrap(err, "Can't create ID mappings")
 		}
-		return mappings, nil
+		logrus.Infof("Can't create ID mappings with username:groupname %s:%s, try uid:groupname %d:%s", username, groupname, user.Uid, groupname)
+		mappings, lookupErr = idtools.NewIdentityMapping(fmt.Sprintf("%d", user.Uid), groupname)
+		if lookupErr == nil {
+			return mappings, nil
+		}
+		logrus.Infof("Can't create ID mappings with uid:groupname %d:%s, try username:gid %s:%d", user.Uid, groupname, username, user.Gid)
+		mappings, lookupErr = idtools.NewIdentityMapping(username, fmt.Sprintf("%d", user.Gid))
+		if lookupErr == nil {
+			return mappings, nil
+		}
+		logrus.Infof("Can't create ID mappings with username:gid %s:%d, try uid:gid %d:%d", username, user.Gid, user.Uid, user.Gid)
+		mappings, lookupErr = idtools.NewIdentityMapping(fmt.Sprintf("%d", user.Uid), fmt.Sprintf("%d", user.Gid))
+		if lookupErr == nil {
+			return mappings, nil
+		}
+		return nil, errors.Wrap(err, "Can't create ID mappings")
 	}
 	return &idtools.IdentityMapping{}, nil
 }


### PR DESCRIPTION
This fix tries to address the issue raised in #39353 where docker crash when creating namespaces with UID in /etc/subuid and /etc/subgid.

The issue was that, mapping to `/etc/sub[u,g]id` in docker does not allow numeric ID.

This fix fixes the issue by probing other combinations (uid:groupname, username:gid, uid:gid) when normal username:groupname fails.

This fix fixes #39353.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
