### PR TITLE
Migrate several tests in integration-cli to integration

### DIFF
--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -15,24 +15,6 @@ import (
 	"gotest.tools/assert"
 )
 
-func (s *DockerSuite) TestAPIOptionsRoute(c *check.C) {
-	resp, _, err := request.Do("/", request.Method(http.MethodOptions))
-	assert.NilError(c, err)
-	assert.Equal(c, resp.StatusCode, http.StatusOK)
-}
-
-func (s *DockerSuite) TestAPIGetEnabledCORS(c *check.C) {
-	res, body, err := request.Get("/version")
-	assert.NilError(c, err)
-	assert.Equal(c, res.StatusCode, http.StatusOK)
-	body.Close()
-	// TODO: @runcom incomplete tests, why old integration tests had this headers
-	// and here none of the headers below are in the response?
-	//c.Log(res.Header)
-	//assert.Equal(c, res.Header.Get("Access-Control-Allow-Origin"), "*")
-	//assert.Equal(c, res.Header.Get("Access-Control-Allow-Headers"), "Origin, X-Requested-With, Content-Type, Accept, X-Registry-Auth")
-}
-
 func (s *DockerSuite) TestAPIClientVersionOldNotSupported(c *check.C) {
 	if testEnv.OSType != runtime.GOOS {
 		c.Skip("Daemon platform doesn't match test platform")

--- a/integration/system/options_test.go
+++ b/integration/system/options_test.go
@@ -1,0 +1,24 @@
+package system
+
+import (
+	"net/http"
+	"testing"
+
+	req "github.com/docker/docker/internal/test/request"
+	"gotest.tools/assert"
+)
+
+func TestAPIOptionsRoute(t *testing.T) {
+	defer setupTest(t)()
+
+	resp, _, err := req.Do("/", req.Method(http.MethodOptions))
+	assert.NilError(t, err)
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+}
+
+func TestAPIGetEnabledCORS(t *testing.T) {
+	resp, body, err := req.Get("/version")
+	assert.NilError(t, err)
+	defer body.Close()
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+}

--- a/integration/system/options_test.go
+++ b/integration/system/options_test.go
@@ -1,8 +1,14 @@
 package system
 
 import (
+	"net"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"testing"
+	"time"
+
+	"github.com/docker/docker/internal/test/daemon"
 
 	req "github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
@@ -17,8 +23,29 @@ func TestAPIOptionsRoute(t *testing.T) {
 }
 
 func TestAPIGetEnabledCORS(t *testing.T) {
-	resp, body, err := req.Get("/version")
+	defer setupTest(t)()
+
+	d := daemon.New(t)
+
+	d.Start(t, "--api-cors-header='*'")
+	defer d.Stop(t)
+
+	daemonURL, err := url.Parse(d.Sock())
 	assert.NilError(t, err)
-	defer body.Close()
+
+	conn, err := net.DialTimeout(daemonURL.Scheme, daemonURL.Path, time.Second*10)
+	assert.NilError(t, err)
+
+	c := httputil.NewClientConn(conn, nil)
+
+	req, err := http.NewRequest("GET", "/_ping", nil)
+	assert.NilError(t, err)
+
+	resp, err := c.Do(req)
+	assert.NilError(t, err)
+
 	assert.Equal(t, resp.StatusCode, http.StatusOK)
+
+	assert.Equal(t, len(resp.Header["Access-Control-Allow-Origin"]), 1)
+	assert.Equal(t, resp.Header["Access-Control-Allow-Origin"][0], "'*'")
 }


### PR DESCRIPTION
This fix moves TestAPIOptionsRoute and TestAPIGetEnabledCORS to new integration tests

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>