### PR TITLE
Fix testcase name

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5952,7 +5952,7 @@ func (s *DockerSuite) TestBuildCopyFromWindowsIsCaseInsensitive(c *check.C) {
 }
 
 // #33176
-func (s *DockerSuite) TestBuildMulitStageResetScratch(c *check.C) {
+func (s *DockerSuite) TestBuildMultiStageResetScratch(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 
 	dockerfile := `


### PR DESCRIPTION
TestBuildMulitStageResetScratch testcase was actually meant to be
TestBuildMulitStageResetScratch

Fixes #39772

Signed-off-by: Vitaly Ostrosablin <tmp6154@yandex.ru>