### PR TITLE
builder-next: close progress on layer export error

### DIFF
--- a/builder/builder-next/exporter/export.go
+++ b/builder/builder-next/exporter/export.go
@@ -117,12 +117,12 @@ func (e *imageExporterInstance) Export(ctx context.Context, inp exporter.Source)
 		layersDone := oneOffProgress(ctx, "exporting layers")
 
 		if err := ref.Finalize(ctx, true); err != nil {
-			return nil, err
+			return nil, layersDone(err)
 		}
 
 		diffIDs, err := e.opt.Differ.EnsureLayer(ctx, ref.ID())
 		if err != nil {
-			return nil, err
+			return nil, layersDone(err)
 		}
 
 		diffs = make([]digest.Digest, len(diffIDs))


### PR DESCRIPTION
Close progress on layer export error instead of leaving the build hanging.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
