### PR TITLE
Update containerd to v1.2.8

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=85f6aa58b8a3170aec9824568f7a31832878b603 # v1.2.7
+CONTAINERD_COMMIT=a4bc1d432a2c33aa2eed37f338dceabb93641310 # v1.2.8
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
https://github.com/containerd/containerd/releases/tag/v1.2.8

full diff: https://github.com/containerd/containerd/compare/85f6aa58b8a3170aec9824568f7a31832878b603...a4bc1d432a2c33aa2eed37f338dceabb93641310

The eighth patch release for containerd 1.2 provides a series of bug fixes, many
of them backported from the master branch to correct several known issues around
manifest lists/indexes and pulling multi-arch, CVEs related to Golang/http2,
fd leakage in the Golang runtime, a shim hang, process and image environment config
handling, and finally mount cleanup related to Cloud Foundry's use of containerd
with rootless containers.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Update containerd to v1.2.8


