### PR TITLE
Fix AppArmor profile docker-default /proc/sys rule

### DIFF
--- a/profiles/apparmor/template.go
+++ b/profiles/apparmor/template.go
@@ -35,7 +35,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
-  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
+  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9/]*}/** w,
   deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
   deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
   deny @{PROC}/sysrq-trigger rwklx,


### PR DESCRIPTION
The current docker-default AppArmor profile intends to block write
access to everything in `/proc`, except for `/proc/<pid>` and
`/proc/sys/kernel/shm*`.

Currently the rules block access to everything in `/proc/sys`, and do
not successfully allow access to `/proc/sys/kernel/shm*`. Specifically,
a path like /proc/sys/kernel/shmmax matches this part of the pattern:

    deny @{PROC}/{[^1-9][^0-9][^0-9][^0-9]*     }/** w,
         /proc  / s     y     s     /     kernel /shmmax

This patch updates the rule so that it works as intended.

Closes #39791

Signed-off-by: Phil Sphicas <phil.sphicas@att.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Updated docker-default AppArmor profile to match intention of allowing write access to /proc/sys/kernel/shm*

**- How I did it**
Modified the fileglob in the deny rule

**- How to verify it**
With the updated profile, this should return `success`:

```bash
docker run --privileged --security-opt apparmor=docker-default --rm -it ubuntu bash -c ">> /proc/sys/kernel/shmmax && echo success"
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix AppArmor profile docker-default /proc/sys rule

**- A picture of a cute animal (not mandatory but encouraged)**

