### PR TITLE
hack/make.sh remove "latest" symlink

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -171,13 +171,6 @@ main() {
 	fi
 	mkdir -p bundles
 
-	# Windows and symlinks don't get along well
-	if [ "$(go env GOHOSTOS)" != 'windows' ]; then
-		rm -f bundles/latest
-		# preserve latest symlink for backward compatibility
-		ln -sf . bundles/latest
-	fi
-
 	if [ $# -lt 1 ]; then
 		bundles=(${DEFAULT_BUNDLES[@]})
 	else


### PR DESCRIPTION
This symlink was added in d42753485b71f5f26b682a187d1963ef138cd0ab(https://github.com/moby/moby/pull/12049),
to allow finding the path to the latest built binary, because at the time,
those paths were prefixed with the version or commit (e.g. `bundles/1.5.0-dev`).

Commit bac2447964c8cdfcf35f928841d60310db997c76 (https://github.com/moby/moby/pull/34685) removed the version-prefix in
paths, but kept the old symlink for backward compatiblity. However, many
things were moved since then (e.g. paths were renamed to `binary-daemon`,
and various other changes). With the symlink pointing to the symlink's parent
directory, following the symlink may result into an infinite recursion,
which can happen if scripts using wildcards / globbing to find files.

With this symlink no longer serving a real purpose, we can probably safely
remove this symlink now.

