### PR TITLE
integration: windows.ps1: turn defender error into a warning

### DIFF
--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -274,7 +274,7 @@ Try {
         }
       }
     } Catch {}
-    if ($defender) { Throw "ERROR: Windows Defender real time protection must be disabled for integration tests" }
+    if ($defender) { Write-Host -ForegroundColor Magenta "WARN: Windows Defender real time protection is enabled, which may cause some integration tests to fail" }
 
     # Make sure SOURCES_DRIVE is set
     if ($null -eq $env:SOURCES_DRIVE) { Throw "ERROR: Environment variable SOURCES_DRIVE is not set" }


### PR DESCRIPTION
addresses https://github.com/moby/moby/pull/39747#commitcomment-34840193 / https://github.com/moby/moby/pull/39747#issuecomment-525194482

Some integration tests are known to fail if Windows Defender is
enabled. On the machines that run our CI, defender is disabled
for that reason.

Contributors likely will have defender enabled, and because of
that are currently not able to run the integration tests.

This patch changes the ERROR into a WARNING, so that contributors
can still run (a limited set of) the integration tests, but get
informed that some may fail.

We should make this requirement more specific, and only skip
tests that are known to require defender to be disabled, but
while that's not yet in place, let's print a warning instead.

