### PR TITLE
integration-cli: getContainerCount() fix trimming prefix

### DIFF
--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -63,7 +63,7 @@ func getContainerCount(c *check.C) int {
 	for _, line := range lines {
 		if strings.Contains(line, containers) {
 			output := strings.TrimSpace(line)
-			output = strings.TrimLeft(output, containers)
+			output = strings.TrimPrefix(output, containers)
 			output = strings.Trim(output, " ")
 			containerCount, err := strconv.Atoi(output)
 			assert.NilError(c, err)


### PR DESCRIPTION
splitting this from https://github.com/moby/moby/pull/39668

caught by staticcheck:

```
integration-cli/docker_utils_test.go:66:29: SA1024: cutset contains duplicate characters (staticcheck)
```


