### PR TITLE
Add missing Platform to swagger definition for /containers/{id}/json

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4924,6 +4924,8 @@ paths:
                 type: "integer"
               Driver:
                 type: "string"
+              Platform:
+                type: "string"
               MountLabel:
                 type: "string"
               ProcessLabel:


### PR DESCRIPTION
**- What I did**

Looked too much as the code to try to find where Platform was in interface `/containers/{id}/json`

**- How I did it**

Compared the swagger.yaml against api/types/types.go

**- How to verify it**

Found swagger.yaml to be deficient

**- Description for the changelog**

Add missing Platform to swagger definition for /containers/{id}/json

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/462287/63909541-631f9580-ca66-11e9-9e58-a40c84c14ca0.png)

