### PR TITLE
daemon: Use short libnetwork ID in exec-root

### DIFF
--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/pkg/idtools"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/libnetwork"
 	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/executor/oci"
@@ -100,11 +101,12 @@ func (iface *lnInterface) Set(s *specs.Spec) {
 		logrus.WithError(iface.err).Error("failed to set networking spec")
 		return
 	}
+	shortNetCtlrID := stringid.TruncateID(iface.provider.NetworkController.ID())
 	// attach netns to bridge within the container namespace, using reexec in a prestart hook
 	s.Hooks = &specs.Hooks{
 		Prestart: []specs.Hook{{
 			Path: filepath.Join("/proc", strconv.Itoa(os.Getpid()), "exe"),
-			Args: []string{"libnetwork-setkey", "-exec-root=" + iface.provider.Config().Daemon.ExecRoot, iface.sbx.ContainerID(), iface.provider.NetworkController.ID()},
+			Args: []string{"libnetwork-setkey", "-exec-root=" + iface.provider.Config().Daemon.ExecRoot, iface.sbx.ContainerID(), shortNetCtlrID},
 		}},
 	}
 }

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/oci/caps"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/mount"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/rootless/specconv"
 	volumemounts "github.com/docker/docker/volume/mounts"
 	"github.com/opencontainers/runc/libcontainer/apparmor"
@@ -66,13 +67,14 @@ func WithLibnetwork(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		for _, ns := range s.Linux.Namespaces {
 			if ns.Type == "network" && ns.Path == "" && !c.Config.NetworkDisabled {
 				target := filepath.Join("/proc", strconv.Itoa(os.Getpid()), "exe")
+				shortNetCtlrID := stringid.TruncateID(daemon.netController.ID())
 				s.Hooks.Prestart = append(s.Hooks.Prestart, specs.Hook{
 					Path: target,
 					Args: []string{
 						"libnetwork-setkey",
 						"-exec-root=" + daemon.configStore.GetExecRoot(),
 						c.ID,
-						daemon.netController.ID(),
+						shortNetCtlrID,
 					},
 				})
 			}

--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: ${LIBNETWORK_COMMIT:=96bcc0dae898308ed659c5095526788a602f4726}
+: ${LIBNETWORK_COMMIT:=0025177e3dabbe0de151be0957dcaff149d43536}
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/gofrs/flock                              392e7fae8f1b0bdbd67dad7237d2
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        96bcc0dae898308ed659c5095526788a602f4726
+github.com/docker/libnetwork                        0025177e3dabbe0de151be0957dcaff149d43536
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ipv6.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ipv6.go
@@ -70,7 +70,7 @@ func setupBridgeIPv6(config *networkConfiguration, i *bridgeInterface) error {
 		Dst:       config.AddressIPv6,
 	})
 	if err != nil && !os.IsExist(err) {
-		logrus.Errorf("Could not add route to IPv6 network %s via device %s", config.AddressIPv6.String(), config.BridgeName)
+		logrus.Errorf("Could not add route to IPv6 network %s via device %s: %s", config.AddressIPv6.String(), config.BridgeName, err)
 	}
 
 	return nil

--- a/vendor/github.com/docker/libnetwork/ipvs/constants.go
+++ b/vendor/github.com/docker/libnetwork/ipvs/constants.go
@@ -144,6 +144,17 @@ const (
 	// a statically assigned hash table by their source IP
 	// addresses.
 	SourceHashing = "sh"
+
+	// WeightedRoundRobin assigns jobs to real servers proportionally
+	// to there real servers' weight. Servers with higher weights
+	// receive new jobs first and get more jobs than servers
+	// with lower weights. Servers with equal weights get
+	// an equal distribution of new jobs
+	WeightedRoundRobin = "wrr"
+
+	// WeightedLeastConnection assigns more jobs to servers
+	// with fewer jobs and relative to the real servers' weight
+	WeightedLeastConnection = "wlc"
 )
 
 const (

--- a/vendor/github.com/docker/libnetwork/store.go
+++ b/vendor/github.com/docker/libnetwork/store.go
@@ -80,30 +80,15 @@ func (c *controller) getStores() []datastore.DataStore {
 }
 
 func (c *controller) getNetworkFromStore(nid string) (*network, error) {
-	for _, store := range c.getStores() {
-		n := &network{id: nid, ctrlr: c}
-		err := store.GetObject(datastore.Key(n.Key()...), n)
-		// Continue searching in the next store if the key is not found in this store
-		if err != nil {
-			if err != datastore.ErrKeyNotFound {
-				logrus.Debugf("could not find network %s: %v", nid, err)
-			}
-			continue
-		}
-
-		ec := &endpointCnt{n: n}
-		err = store.GetObject(datastore.Key(ec.Key()...), ec)
-		if err != nil && !n.inDelete {
-			return nil, fmt.Errorf("could not find endpoint count for network %s: %v", n.Name(), err)
-		}
-
-		n.epCnt = ec
-		if n.scope == "" {
-			n.scope = store.Scope()
-		}
-		return n, nil
+	ns, err := c.getNetworksFromStore()
+	if err != nil {
+		return nil, err
 	}
-
+	for _, n := range ns {
+		if n.id == nid {
+			return n, nil
+		}
+	}
 	return nil, fmt.Errorf("network %s not found", nid)
 }
 


### PR DESCRIPTION
Signed-off-by: Grant Millar <rid@cylo.io>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Use short controller ID in libnetwork-setkey in order to avoid https://github.com/moby/moby/issues/39608 where using a custom exec-root which contains > 27 chars before the controller ID causes the daemon to fail starting with:

```
failed to start daemon: Error initializing network controller: error obtaining controller instance: listen unix /cylostore/sdj/9598/var/run/docker/libnetwork/b2757cb82eadaaea94aab22529663e38c3bf799369f5b578fe8a5bb4bcefe0f0.sock: bind: invalid argument
```

This happens due to hitting the UNIX_PATH_MAX limit (which is 108, ours is 115 in the example above). The patch gives us 79 chars to play with vs 27.

**- How I did it**
Truncate the libnetwork controller ID, and submitted patches on libnetwork to accept the new format in https://github.com/docker/libnetwork/pull/2443

**- How to verify it**
```
root@58a4fa1735b4:/go/src/github.com/docker/docker# ls -la /var/run/docker/libnetwork/
total 8
drw------- 2 root root 4096 Aug 29 08:19 .
drwx------ 6 root root 4096 Aug 29 08:19 ..
srw------- 1 root root    0 Aug 29 08:19 ce6597205a18.sock
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use short libnetwork ID in exec-root

**- A picture of a cute animal (not mandatory but encouraged)**
![Funny-Unusual-Weird-Animal-Pictures-1](https://user-images.githubusercontent.com/3407496/63923748-fe047980-ca3e-11e9-92c1-4680cf9f9169.jpg)

