### PR TITLE
Add sigprocmask to default seccomp profile

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -314,6 +314,7 @@
 				"sigaltstack",
 				"signalfd",
 				"signalfd4",
+				"sigprocmask",
 				"sigreturn",
 				"socket",
 				"socketcall",

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -307,6 +307,7 @@ func DefaultProfile() *types.Seccomp {
 				"sigaltstack",
 				"signalfd",
 				"signalfd4",
+				"sigprocmask",
 				"sigreturn",
 				"socket",
 				"socketcall",


### PR DESCRIPTION
### Description for the changelog
Seccomp: add sigprocmask (used by x86 glibc) to default seccomp profile