### PR TITLE
Fix getting the operating system on Darwin

### DIFF
--- a/pkg/parsers/operatingsystem/operatingsystem_unix.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_unix.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 // GetOperatingSystem gets the name of the current operating system.
@@ -15,7 +16,7 @@ func GetOperatingSystem() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(osName), nil
+	return strings.TrimSpace(string(osName)), nil
 }
 
 // GetOperatingSystemVersion gets the version of the current operating system, as a string.


### PR DESCRIPTION
This fixes getting the operating system on Darwin.

This used to return `darwin\n`, but now returns `darwin`

And hey, here's a cool frog:
![](https://media1.giphy.com/media/GdRG4WHGgmNTq/giphy.gif)