### PR TITLE
Fix docker inspect for dutimgVersion

### DIFF
--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -725,7 +725,7 @@ Try {
     
         # Inspect the pulled or loaded image to get the version directly
         $ErrorActionPreference = "SilentlyContinue"
-        $dutimgVersion = $(&"$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" inspect  $($env:WINDOWS_BASE_IMAGE) --format "{{.OsVersion}}")
+        $dutimgVersion = $(&"$env:TEMP\binary\docker-$COMMITHASH" "-H=$($DASHH_CUT)" inspect "$($env:WINDOWS_BASE_IMAGE):$env:WINDOWS_BASE_IMAGE_TAG" --format "{{.OsVersion}}")
         $ErrorActionPreference = "Stop"
         Write-Host -ForegroundColor Green $("INFO: Version of $($env:WINDOWS_BASE_IMAGE):$env:WINDOWS_BASE_IMAGE_TAG is '"+$dutimgVersion+"'")
     }


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

Minor fix to show the OS Version of the image that is running in docker under test.

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="186" alt="le canard" src="https://user-images.githubusercontent.com/207759/64015318-90cb1400-cb24-11e9-8c00-344f07b7f6d9.png">

A duck or a cat/dog with a cactus on its head? 😂 Thanks Duolingo.
