### PR TITLE
hack/make/binary-daemon: fix some linting issues

### DIFF
--- a/hack/make/binary-daemon
+++ b/hack/make/binary-daemon
@@ -15,16 +15,16 @@ copy_binaries() {
 	fi
 	echo "Copying nested executables into $dir"
 	for file in containerd containerd-shim ctr runc docker-init docker-proxy rootlesskit rootlesskit-docker-proxy dockerd-rootless.sh; do
-		cp -f `which "$file"` "$dir/"
-		if [ "$hash" == "hash" ]; then
+		cp -f "$(command -v "$file")" "$dir/"
+		if [ "$hash" = "hash" ]; then
 			hash_files "$dir/$file"
 		fi
 	done
 
 	# vpnkit is amd64 only
-	if which "vpnkit.$(uname -m)" 2>&1 >/dev/null; then
-		cp -f `which "vpnkit.$(uname -m)"` "$dir/vpnkit"
-		if [ "$hash" == "hash" ]; then
+	if command -v "vpnkit.$(uname -m)" 2>&1 >/dev/null; then
+		cp -f "$(command -v "vpnkit.$(uname -m)")" "$dir/vpnkit"
+		if [ "$hash" = "hash" ]; then
 			hash_files "$dir/vpnkit"
 		fi
 	fi


### PR DESCRIPTION
- Add quotes to prevent word splitting in `cp` statement (SC2046)
- Replace legacy back tics with `$()`
- Replace `which` with `command -v` (SC2230)
- Fix incorrect (`==`) comparison

