### PR TITLE
include IPv6 address of linked containers in /etc/hosts

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -200,7 +200,14 @@ func (daemon *Daemon) buildSandboxOptions(container *container.Container) ([]lib
 		if alias != child.Name[1:] {
 			aliasList = aliasList + " " + child.Name[1:]
 		}
-		sboxOptions = append(sboxOptions, libnetwork.OptionExtraHost(aliasList, child.NetworkSettings.Networks[defaultNetName].IPAddress))
+		ipv4 := child.NetworkSettings.Networks[defaultNetName].IPAddress
+		ipv6 := child.NetworkSettings.Networks[defaultNetName].GlobalIPv6Address
+		if ipv4 != "" {
+			sboxOptions = append(sboxOptions, libnetwork.OptionExtraHost(aliasList, ipv4))
+		}
+		if ipv6 != "" {
+			sboxOptions = append(sboxOptions, libnetwork.OptionExtraHost(aliasList, ipv6))
+		}
 		cEndpointID = child.NetworkSettings.Networks[defaultNetName].EndpointID
 		if cEndpointID != "" {
 			childEndpoints = append(childEndpoints, cEndpointID)


### PR DESCRIPTION
**- What I did**
Only the linked container IPv4 address was being added to `/etc/hosts`. Now, IPv6 address will also be added if available.

Partially fixes #13228

**- How to verify it**
```
docker run -d --rm --name foo1 ubuntu:bionic sleep 60
docker run --rm --name foo2 --link foo1:foo1 ubuntu:bionic cat /etc/hosts
```

**- Description for the changelog**
Linked containers will now also have their IPv6 addresses included in /etc/hosts

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/993296/64068777-2b1e7b00-cc3d-11e9-9d33-7dc40bdaa63b.png)

