### PR TITLE
Testcase: Change time comparison logic.

### DIFF
--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -103,7 +103,7 @@ func TestVolumesInspect(t *testing.T) {
 	// comparing CreatedAt field time for the new volume to now. Truncate to 1 minute precision to avoid false positive
 	createdAt, err := time.Parse(time.RFC3339, strings.TrimSpace(inspected.CreatedAt))
 	assert.NilError(t, err)
-	assert.Check(t, createdAt.Truncate(time.Minute).Equal(now.Truncate(time.Minute)), "CreatedAt (%s) not equal to creation time (%s)", createdAt, now)
+	assert.Check(t, createdAt.Unix()-now.Unix() < 60, "CreatedAt (%s) exceeds creation time (%s) 60s", createdAt, now)
 }
 
 func TestVolumesInvalidJSON(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This is part of https://github.com/moby/moby/pull/39786 .
Change `TestVolumesInspect` testcase time comparison logic.

cc @thaJeztah 

