### PR TITLE
rootless: harden slirp4netns with mount namespace and seccomp

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -39,6 +39,9 @@ fi
 
 : "${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:=}"
 : "${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:=}"
+# if slirp4netns v0.4.0+ is installed, slirp4netns is hardened using sandbox (mount namespace) and seccomp
+: "${DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SANDBOX:=auto}"
+: "${DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SECCOMP:=auto}"
 net=$DOCKERD_ROOTLESS_ROOTLESSKIT_NET
 mtu=$DOCKERD_ROOTLESS_ROOTLESSKIT_MTU
 if [ -z $net ]; then
@@ -77,6 +80,8 @@ if [ -z $_DOCKERD_ROOTLESS_CHILD ]; then
 	# * /run: copy-up is required so that we can create /run/docker (hardcoded for plugins) in our namespace
 	exec $rootlesskit \
 		--net=$net --mtu=$mtu \
+		--slirp4netns-sandbox=$DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SANDBOX \
+		--slirp4netns-seccomp=$DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SECCOMP \
 		--disable-host-loopback --port-driver=builtin \
 		--copy-up=/etc --copy-up=/run \
 		$DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS \

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# v0.6.0
-ROOTLESSKIT_COMMIT=2fcff6ceae968a1d895e6205e5154b107247356f
+# v0.7.0
+ROOTLESSKIT_COMMIT=791ac8cb209a107505cd1ca5ddf23a49913e176c
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

When slirp4netns v0.4.0+ is used, now slirp4netns is hardened using
[mount namespace ("sandbox")](https://github.com/rootless-containers/slirp4netns/blob/f9503feb2adcd33ad817f954d294f2076de80f45/sandbox.c#L43) and [seccomp](https://github.com/rootless-containers/slirp4netns/blob/f9503feb2adcd33ad817f954d294f2076de80f45/seccompfilter.c#L6) to mitigate potential
vulnerabilities.



**- How I did it**

bump up rootlesskit: https://github.com/rootless-containers/rootlesskit/compare/2fcff6ceae968a1d895e6205e5154b107247356f...791ac8cb209a107505cd1ca5ddf23a49913e176c


**- How to verify it**

Run rootless mode with slirp4netns v0.4.0+ installed

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
rootless: harden slirp4netns with mount namespace and seccomp


**- A picture of a cute animal (not mandatory but encouraged)**

:penguin: