### PR TITLE
integration-cli: re-enable TestRunAttachFailedNoLeak on RS3

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/mount"
-	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/testutil"
@@ -3916,20 +3915,6 @@ func (s *DockerSuite) TestRunNamedVolumesFromNotRemoved(c *testing.T) {
 }
 
 func (s *DockerSuite) TestRunAttachFailedNoLeak(c *testing.T) {
-	if runtime.GOOS == "windows" {
-		// TODO @msabansal - https://github.com/moby/moby/issues/35023. Duplicate
-		// port mappings are not errored out on RS3 builds. Temporarily disabling
-		// this test pending further investigation. Note we parse kernel.GetKernelVersion
-		// rather than osversion.Build() as test binaries aren't manifested, so would
-		// otherwise report build 9200.
-		v, err := kernel.GetKernelVersion()
-		assert.NilError(c, err)
-		buildNumber, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
-		if buildNumber == osversion.RS3 {
-			c.Skip("Temporarily disabled on RS3 builds")
-		}
-	}
-
 	nroutines, err := getGoroutineNumber()
 	assert.NilError(c, err)
 


### PR DESCRIPTION
This test was temporarily disabled (see moby/moby#35023) because of a bug in
Windows RS3 and RS4 causing duplicate port mappings to not be detected, and
not causing an error.

This bug was fixed as MSFT:14083260 on 10/31/2017, and backported to RS3 in
November/December 2017 (https://github.com/moby/moby/issues/35023#issuecomment-404651457).
