### PR TITLE
Jenkinsfile: add stage for Windows 2022 (SAC)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
         booleanParam(name: 'ppc64le', defaultValue: true, description: 'PowerPC (ppc64le) Build/Test')
         booleanParam(name: 'windowsRS1', defaultValue: false, description: 'Windows 2016 (RS1) Build/Test')
         booleanParam(name: 'windowsRS5', defaultValue: true, description: 'Windows 2019 (RS5) Build/Test')
-        booleanParam(name: 'windows1903', defaultValue: true, description: 'Windows 1903 (SAC) Build/Test')
+        booleanParam(name: 'windows2022', defaultValue: true, description: 'Windows 2022 (SAC) Build/Test')
         booleanParam(name: 'dco', defaultValue: true, description: 'Run the DCO check')
     }
     environment {
@@ -1170,10 +1170,10 @@ pipeline {
                         }
                     }
                 }
-                stage('windows-1903') {
+                stage('win-2022') {
                     when {
                         beforeAgent true
-                        expression { params.windows1903 }
+                        expression { params.windows2022 }
                     }
                     environment {
                         DOCKER_BUILDKIT        = '0'
@@ -1184,12 +1184,12 @@ pipeline {
                         TESTRUN_DRIVE          = 'd'
                         TESTRUN_SUBDIR         = "CI"
                         WINDOWS_BASE_IMAGE     = 'mcr.microsoft.com/windows/servercore'
-                        WINDOWS_BASE_IMAGE_TAG = '1903'
+                        WINDOWS_BASE_IMAGE_TAG = '2022'
                     }
                     agent {
                         node {
                             customWorkspace 'd:\\gopath\\src\\github.com\\docker\\docker'
-                            label 'windows-1903'
+                            label 'windows-2022'
                         }
                     }
                     stages {
@@ -1216,7 +1216,7 @@ pipeline {
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to create bundles.zip') {
                                 powershell '''
                                 cd $env:WORKSPACE
-                                $bundleName="windows-1903-integration"
+                                $bundleName="win-2022-integration"
                                 Write-Host -ForegroundColor Green "Creating ${bundleName}-bundles.zip"
 
                                 # archiveArtifacts does not support env-vars to , so save the artifacts in a fixed location

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1183,8 +1183,9 @@ pipeline {
                         SOURCES_SUBDIR         = 'gopath'
                         TESTRUN_DRIVE          = 'd'
                         TESTRUN_SUBDIR         = "CI"
-                        WINDOWS_BASE_IMAGE     = 'mcr.microsoft.com/windows/servercore'
-                        WINDOWS_BASE_IMAGE_TAG = '2022'
+                        // TODO switch to mcr.microsoft.com/windows/servercore:2022 once published
+                        WINDOWS_BASE_IMAGE     = 'mcr.microsoft.com/windows/servercore/insider'
+                        WINDOWS_BASE_IMAGE_TAG = '10.0.20295.1'
                     }
                     agent {
                         node {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1212,6 +1212,7 @@ pipeline {
                     }
                     post {
                         always {
+                            junit testResults: 'bundles/junit-report-*.xml', allowEmptyResults: true
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to create bundles.zip') {
                                 powershell '''
                                 cd $env:WORKSPACE
@@ -1219,7 +1220,7 @@ pipeline {
                                 Write-Host -ForegroundColor Green "Creating ${bundleName}-bundles.zip"
 
                                 # archiveArtifacts does not support env-vars to , so save the artifacts in a fixed location
-                                Compress-Archive -Path "bundles/CIDUT.out", "bundles/CIDUT.err", -CompressionLevel Optimal -DestinationPath "${bundleName}-bundles.zip"
+                                Compress-Archive -Path "bundles/CIDUT.out", "bundles/CIDUT.err", "bundles/junit-report-*.xml" -CompressionLevel Optimal -DestinationPath "${bundleName}-bundles.zip"
                                 '''
 
                                 archiveArtifacts artifacts: '*-bundles.zip', allowEmptyArchive: true

--- a/pkg/archive/changes_test.go
+++ b/pkg/archive/changes_test.go
@@ -8,10 +8,14 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/Microsoft/hcsshim/osversion"
+	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/system"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
@@ -246,6 +250,18 @@ func TestChangesWithChangesGH13590(t *testing.T) {
 
 // Create a directory, copy it, make sure we report no changes between the two
 func TestChangesDirsEmpty(t *testing.T) {
+	// Note we parse kernel.GetKernelVersion rather than system.GetOSVersion
+	// as test binaries aren't manifested, so would otherwise report the wrong
+	// build number.
+	if runtime.GOOS == "windows" {
+		v, err := kernel.GetKernelVersion()
+		assert.NilError(t, err)
+		build, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
+		if build >= osversion.V19H1 {
+			t.Skip("FIXME: broken on Windows 1903 and up; see #39846")
+		}
+	}
+
 	src, err := ioutil.TempDir("", "docker-changes-test")
 	assert.NilError(t, err)
 	defer os.RemoveAll(src)
@@ -328,6 +344,18 @@ func mutateSampleDir(t *testing.T, root string) {
 }
 
 func TestChangesDirsMutated(t *testing.T) {
+	// Note we parse kernel.GetKernelVersion rather than system.GetOSVersion
+	// as test binaries aren't manifested, so would otherwise report the wrong
+	// build number.
+	if runtime.GOOS == "windows" {
+		v, err := kernel.GetKernelVersion()
+		assert.NilError(t, err)
+		build, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
+		if build >= osversion.V19H1 {
+			t.Skip("FIXME: broken on Windows 1903 and up; see #39846")
+		}
+	}
+
 	src, err := ioutil.TempDir("", "docker-changes-test")
 	assert.NilError(t, err)
 	createSampleDir(t, src)


### PR DESCRIPTION
This adds a stage to test against the current SAC (Semi Annual Channel),
which allows us to catch possible regressions on upcoming LTS versions.

addresses [ENGCORE-832](https://docker.atlassian.net/browse/ENGCORE-832)
