### PR TITLE
docker-py: skip flaky AttachContainerTest::test_attach_no_stream

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -13,6 +13,7 @@ source hack/make/.integration-test-helpers
 # TODO remove these skip once we update to a docker-py version that has https://github.com/docker/docker-py/pull/2369, https://github.com/docker/docker-py/pull/2380, https://github.com/docker/docker-py/pull/2382
 : "${PY_TEST_OPTIONS:=\
 --deselect=tests/integration/api_swarm_test.py::SwarmTest::test_init_swarm_data_path_addr \
+--deselect=tests/integration/api_container_test.py::AttachContainerTest::test_attach_no_stream \
 --deselect=tests/integration/api_exec_test.py::ExecTest::test_detach_with_arg \
 --deselect=tests/integration/api_exec_test.py::ExecDemuxTest::test_exec_command_tty_stream_no_demux \
 --deselect=tests/integration/api_build_test.py::BuildTest::test_build_invalid_platform \


### PR DESCRIPTION
Seen failing a couple of times, e.g. https://github.com/moby/moby/pull/39842#issuecomment-527137286:

```
[2019-09-02T08:40:15.796Z] =================================== FAILURES ===================================
[2019-09-02T08:40:15.796Z] __________________ AttachContainerTest.test_attach_no_stream ___________________
[2019-09-02T08:40:15.796Z] tests/integration/api_container_test.py:1250: in test_attach_no_stream
[2019-09-02T08:40:15.796Z]     assert output == 'hello\n'.encode(encoding='ascii')
[2019-09-02T08:40:15.796Z] E   AssertionError: assert b'' == b'hello\n'
[2019-09-02T08:40:15.796Z] E     Right contains more items, first extra item: 104
[2019-09-02T08:40:15.796Z] E     Use -v to get the full diff
```

Perhaps this needs a change similar to https://github.com/docker/docker-py/commit/ef043559c4bbd3d1fbc06277160c253fab6df879 (https://github.com/docker/docker-py/pull/2307)

