### PR TITLE
windows: skip TestJSONFileLoggerWithOpts on sharing violation

### DIFF
--- a/daemon/logger/jsonfilelog/jsonfilelog_test.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog_test.go
@@ -183,6 +183,10 @@ func TestJSONFileLoggerWithOpts(t *testing.T) {
 
 	penUlt, err := ioutil.ReadFile(filename + ".1")
 	if err != nil {
+		if isSharingViolation(err) {
+			// Catch flakiness due to: "The process cannot access the file because it is being used by another process."
+			t.Skipf("FLAKY_TEST: skipping remainder of test: got sharing violation error: %v", err)
+		}
 		if !os.IsNotExist(err) {
 			t.Fatal(err)
 		}

--- a/daemon/logger/jsonfilelog/jsonfilelog_unix_test.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog_unix_test.go
@@ -1,0 +1,7 @@
+//+build !windows
+
+package jsonfilelog
+
+func isSharingViolation(_ error) bool {
+	return false
+}

--- a/daemon/logger/jsonfilelog/jsonfilelog_windows_test.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog_windows_test.go
@@ -1,0 +1,17 @@
+package jsonfilelog
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func isSharingViolation(err error) bool {
+	switch err := err.(type) {
+	case *os.PathError:
+		if err.Err == windows.ERROR_SHARING_VIOLATION {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
hopefully addresses https://github.com/moby/moby/issues/36801

This test is ocassionally failing because we run into a Windows sharing violation:

```
--- FAIL: TestJSONFileLoggerWithOpts (0.07s)
    jsonfilelog_test.go:187: open C:\Users\ContainerAdministrator\AppData\Local\Temp\docker-logger-344571653\container.log.1: The process cannot access the file because it is being used by another process.
```

This patch attempts to skip the test if we encounter this situation.

