### PR TITLE
archive: fix race condition in cmdStream

### DIFF
--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -1332,7 +1332,9 @@ func TestPigz(t *testing.T) {
 	_, err := exec.LookPath("unpigz")
 	if err == nil {
 		t.Log("Tested whether Pigz is used, as it installed")
-		assert.Equal(t, reflect.TypeOf(contextReaderCloserWrapper.Reader), reflect.TypeOf(&io.PipeReader{}))
+		// For the command wait wrapper
+		cmdWaitCloserWrapper := contextReaderCloserWrapper.Reader.(*ioutils.ReadCloserWrapper)
+		assert.Equal(t, reflect.TypeOf(cmdWaitCloserWrapper.Reader), reflect.TypeOf(&io.PipeReader{}))
 	} else {
 		t.Log("Tested whether Pigz is not used, as it not installed")
 		assert.Equal(t, reflect.TypeOf(contextReaderCloserWrapper.Reader), reflect.TypeOf(&gzip.Reader{}))


### PR DESCRIPTION
**- What I did**

Fixed a race condition, see details in issue #39859

**- How I did it**

Ensured that `cmd.Wait` is done, before any clean up happens.

**- How to verify it**

There is a reproducer at https://github.com/stbenjam/docker-race-reproducer.  Run the code as-is, and then apply the changes in this PR to vendor/github.com/docker/docker/pkg/archive/archive.go.  You'll see the issue is fixed.

**- Description for the changelog**

Fixed a race condition in cmdStream to ensure that we wait for the command to exit before any clean up.

**- A picture of a cute animal (not mandatory but encouraged)**

My dog, Tilly:

![dogTilly](https://user-images.githubusercontent.com/429763/64188696-e2371400-ce40-11e9-991a-935888625062.jpg)


