### PR TITLE
Jenkinsfile hack for auto-cancellation.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,12 +25,23 @@ pipeline {
         TIMEOUT             = '120m'
     }
     stages {
+        stage('pr-hack') {
+            when { changeRequest() }
+            steps {
+                script {
+                    echo "Workaround for PR auto-cancel feature. Borrowed from https://issues.jenkins-ci.org/browse/JENKINS-43353"
+                    def buildNumber = env.BUILD_NUMBER as int
+                    if (buildNumber > 1) milestone(buildNumber - 1)
+                    milestone(buildNumber)
+                }
+            }
+        }
         stage('DCO-check') {
             when {
                 beforeAgent true
                 expression { !params.skip_dco }
             }
-            agent { label 'linux' }
+            agent { label 'amd64 && ubuntu-1804 && overlay2' }
             steps {
                 sh '''
                 docker run --rm \


### PR DESCRIPTION
This change will cause Jenkins to only build the
latest HEAD of a PR branch, cancelling any
previous builds that may already be in progress.
This will decrease feedback time and help mitigate
resource contention.

NOTE: You can trust me as I've validated this elsewhere, but if you would like to validate it here, someone will need to add me as Collaborator on moby/moby. At that point my Jenkinsfile changes will actually get picked up and I can bump this PR a few times to demonstrate.

![cat](https://i.imgur.com/w6GOZmf.jpg)