### PR TITLE
Narrow dependencies of pkg/system

### DIFF
--- a/pkg/system/path.go
+++ b/pkg/system/path.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-
-	"github.com/containerd/continuity/pathdriver"
 )
 
 const defaultUnixPathEnv = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -27,6 +25,12 @@ func DefaultPathEnv(os string) string {
 
 }
 
+// PathVerifier defines the subset of a PathDriver that CheckSystemDriveAndRemoveDriveLetter
+// actually uses in order to avoid system depending on containerd/continuity.
+type PathVerifier interface {
+	IsAbs(string) bool
+}
+
 // CheckSystemDriveAndRemoveDriveLetter verifies that a path, if it includes a drive letter,
 // is the system drive.
 // On Linux: this is a no-op.
@@ -42,7 +46,7 @@ func DefaultPathEnv(os string) string {
 // a			--> a
 // /a			--> \a
 // d:\			--> Fail
-func CheckSystemDriveAndRemoveDriveLetter(path string, driver pathdriver.PathDriver) (string, error) {
+func CheckSystemDriveAndRemoveDriveLetter(path string, driver PathVerifier) (string, error) {
 	if runtime.GOOS != "windows" || LCOWSupported() {
 		return path, nil
 	}


### PR DESCRIPTION
CheckSystemDriveAndRemoveDriveLetter depends on pathdriver.PathDriver
unnecessarily. This depends on the minimal interface that it actually
needs, to avoid callers from unnecessarily bringing in a
containerd/continuity dependency.

Signed-off-by: Jon Johnson <jonjohnson@google.com>

**- What I did**

Reduce dependencies of pkg/system/path.go

**- How I did it**

Define an interface locally instead of using the interface from an external package.

**- How to verify it**

No behavior should change.

**- A picture of a cute animal (not mandatory but encouraged)**

My puggle, Grace Anne:

![image](https://user-images.githubusercontent.com/17863526/64395063-be74f900-d00d-11e9-8e39-cc3ed5daf23d.png)

