### PR TITLE
integration-cli: update TestCreateWithWorkdir for Hyper-V isolation

### DIFF
--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -307,7 +307,15 @@ func (s *DockerSuite) TestCreateWithWorkdir(c *testing.T) {
 	// Windows does not create the workdir until the container is started
 	if testEnv.OSType == "windows" {
 		dockerCmd(c, "start", name)
+		if IsolationIsHyperv() {
+			// Hyper-V isolated containers do not allow file-operations on a
+			// running container. This test currently uses `docker cp` to verify
+			// that the WORKDIR was automatically created, which cannot be done
+			// while the container is running.
+			dockerCmd(c, "stop", name)
+		}
 	}
+	// TODO: rewrite this test to not use `docker cp` for verifying that the WORKDIR was created
 	dockerCmd(c, "cp", fmt.Sprintf("%s:%s", name, dir), prefix+slash+"tmp")
 }
 


### PR DESCRIPTION
(taken from https://github.com/moby/moby/pull/39846)

Hyper-V isolated containers do not allow file-operations on a running container. This test currently uses `docker cp` to verify that the WORKDIR was automatically created, which cannot be done while the container is running.

```
FAIL: docker_cli_create_test.go:302: DockerSuite.TestCreateWithWorkdir

assertion failed:
Command:  d:\CI-7\CI-f3768a669\binary\docker.exe cp foo:c:\home\foo\bar c:\tmp
ExitCode: 1
Error:    exit status 1
Stdout:
Stderr:   Error response from daemon: filesystem operations against a running Hyper-V container are not supported

Failures:
ExitCode was 1 expected 0
Expected no error
```
