### PR TITLE
hack/ci/windows.ps1: fix Go version check (due to trailing .0)

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -214,7 +214,8 @@ RUN `
   Download-File $location C:\gitsetup.zip; `
   `
   Write-Host INFO: Downloading go...; `
-  Download-File $('https://golang.org/dl/go'+$Env:GO_VERSION.TrimEnd('.0')"+'.windows-amd64.zip') C:\go.zip; `
+  $dlGoVersion=$Env:GO_VERSION -replace '\.0$',''; `
+  Download-File "https://golang.org/dl/go${dlGoVersion}.windows-amd64.zip" C:\go.zip; `
   `
   Write-Host INFO: Downloading compiler 1 of 3...; `
   Download-File https://raw.githubusercontent.com/jhowardmsft/docker-tdmgcc/master/gcc.zip C:\gcc.zip; `

--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -134,7 +134,7 @@ Function Check-InContainer() {
 # outside of a container where it may be out of date with master.
 Function Verify-GoVersion() {
     Try {
-        $goVersionDockerfile=(Select-String -Path ".\Dockerfile" -Pattern "^ARG[\s]+GO_VERSION=(.*)$").Matches.groups[1].Value.TrimEnd(".0")
+        $goVersionDockerfile=(Select-String -Path ".\Dockerfile" -Pattern "^ARG[\s]+GO_VERSION=(.*)$").Matches.groups[1].Value -replace '\.0$',''
         $goVersionInstalled=(go version).ToString().Split(" ")[2].SubString(2)
     }
     Catch [Exception] {


### PR DESCRIPTION
(taken from https://github.com/moby/moby/pull/39549)

Similar to the fix I did in https://github.com/moby/moby/pull/39582, but where I made the wrong assumption that the `GO_VERSION` variable on Linux and Windows would be the same. However, the Windows Dockerfile downloads the Go binaries, which (unlike the Golang images) do not have a trailing `.0` in their version.

