### PR TITLE
Add API support for PidsLimit on services

### DIFF
--- a/api/server/router/swarm/helpers.go
+++ b/api/server/router/swarm/helpers.go
@@ -97,9 +97,10 @@ func adjustForAPIVersion(cliVersion string, service *swarm.ServiceSpec) {
 	}
 	if versions.LessThan(cliVersion, "1.41") {
 		if service.TaskTemplate.ContainerSpec != nil {
-			// Capabilities for docker swarm services weren't supported before
-			// API version 1.41
+			// Capabilities and PidsLimit for docker swarm services weren't
+			// supported before API version 1.41
 			service.TaskTemplate.ContainerSpec.Capabilities = nil
+			service.TaskTemplate.ContainerSpec.PidsLimit = 0
 		}
 
 		// jobs were only introduced in API version 1.41. Nil out both Job

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2967,6 +2967,13 @@ definitions:
             description: "Run an init inside the container that forwards signals and reaps processes. This field is omitted if empty, and the default (as configured on the daemon) is used."
             type: "boolean"
             x-nullable: true
+          PidsLimit:
+            description: |
+              Tune a container's PIDs limit. Set `0` for unlimited.
+            type: "integer"
+            format: "int64"
+            default: 0
+            example: 100
           Sysctls:
             description: |
               Set kernel namedspaced parameters (sysctls) in the container.

--- a/api/types/swarm/container.go
+++ b/api/types/swarm/container.go
@@ -72,6 +72,7 @@ type ContainerSpec struct {
 	Secrets      []*SecretReference  `json:",omitempty"`
 	Configs      []*ConfigReference  `json:",omitempty"`
 	Isolation    container.Isolation `json:",omitempty"`
+	PidsLimit    int64               `json:",omitempty"`
 	Sysctls      map[string]string   `json:",omitempty"`
 	Capabilities []string            `json:",omitempty"`
 }

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -36,6 +36,7 @@ func containerSpecFromGRPC(c *swarmapi.ContainerSpec) *types.ContainerSpec {
 		Configs:      configReferencesFromGRPC(c.Configs),
 		Isolation:    IsolationFromGRPC(c.Isolation),
 		Init:         initFromGRPC(c.Init),
+		PidsLimit:    c.PidsLimit,
 		Sysctls:      c.Sysctls,
 		Capabilities: c.Capabilities,
 	}
@@ -263,6 +264,7 @@ func containerToGRPC(c *types.ContainerSpec) (*swarmapi.ContainerSpec, error) {
 		Secrets:      secretReferencesToGRPC(c.Secrets),
 		Isolation:    isolationToGRPC(c.Isolation),
 		Init:         initToGRPC(c.Init),
+		PidsLimit:    c.PidsLimit,
 		Sysctls:      c.Sysctls,
 		Capabilities: c.Capabilities,
 	}

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -431,6 +431,12 @@ func (c *containerConfig) volumeCreateRequest(mount *api.Mount) *volumetypes.Vol
 func (c *containerConfig) resources() enginecontainer.Resources {
 	resources := enginecontainer.Resources{}
 
+	// set pids limit
+	pidsLimit := c.spec().PidsLimit
+	if pidsLimit > 0 {
+		resources.PidsLimit = &pidsLimit
+	}
+
 	// If no limits are specified let the engine use its defaults.
 	//
 	// TODO(aluzzardi): We might want to set some limits anyway otherwise

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -30,6 +30,12 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /services/{id}/update` now accepts `Capabilities` as part of the `ContainerSpec`.
 * `GET /tasks` now  returns `Capabilities` as part of the `ContainerSpec`.
 * `GET /tasks/{id}` now  returns `Capabilities` as part of the `ContainerSpec`.
+* `GET /services` now returns `PidsLimit` as part of the `ContainerSpec`.
+* `GET /services/{id}` now returns `PidsLimit` as part of the `ContainerSpec`.
+* `POST /services/create` now accepts `PidsLimit` as part of the `ContainerSpec`.
+* `POST /services/{id}/update` now accepts `PidsLimit` as part of the `ContainerSpec`.
+* `GET /tasks` now  returns `PidsLimit` as part of the `ContainerSpec`.
+* `GET /tasks/{id}` now  returns `PidsLimit` as part of the `ContainerSpec`.
 * `POST /containers/create` on Linux now accepts the `HostConfig.CgroupnsMode` property.
   Set the property to `host` to create the container in the daemon's cgroup namespace, or
   `private` to create the container in its own private cgroup namespace.  The per-daemon

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -196,6 +196,14 @@ func ServiceWithCapabilities(Capabilities []string) ServiceSpecOpt {
 	}
 }
 
+// ServiceWithPidsLimit sets the PidsLimit option of the service's ContainerSpec.
+func ServiceWithPidsLimit(limit int64) ServiceSpecOpt {
+	return func(spec *swarmtypes.ServiceSpec) {
+		ensureContainerSpec(spec)
+		spec.TaskTemplate.ContainerSpec.PidsLimit = limit
+	}
+}
+
 // GetRunningTasks gets the list of running tasks for a service
 func GetRunningTasks(t *testing.T, c client.ServiceAPIClient, serviceID string) []swarmtypes.Task {
 	t.Helper()


### PR DESCRIPTION
continues the work started in https://github.com/docker/swarmkit/pull/2415 (vendored through https://github.com/moby/moby/pull/35326)

addresses the API side of https://github.com/moby/moby/issues/28618