### PR TITLE
integration-cli: don't load busybox image on every daemon start

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -312,7 +312,7 @@ func (s *DockerSwarmSuite) AddDaemon(c *testing.T, joinSwarm, manager bool) *dae
 			d.StartAndSwarmInit(c)
 		}
 	} else {
-		d.StartNode(c)
+		d.StartNodeWithBusybox(c)
 	}
 
 	s.daemonsLock.Lock()

--- a/internal/test/daemon/swarm.go
+++ b/internal/test/daemon/swarm.go
@@ -36,7 +36,7 @@ func (d *Daemon) RestartNode(t testingT) {
 	}
 	// avoid networking conflicts
 	d.Stop(t)
-	d.StartWithBusybox(t, startArgs...)
+	d.Start(t, startArgs...)
 }
 
 // StartAndSwarmInit starts the daemon (with busybox) and init the swarm

--- a/internal/test/daemon/swarm.go
+++ b/internal/test/daemon/swarm.go
@@ -20,12 +20,19 @@ var (
 	startArgs = []string{"--iptables=false", "--swarm-default-advertise-addr=lo"}
 )
 
-// StartNode starts daemon to be used as a swarm node
+// StartNode (re)starts the daemon
 func (d *Daemon) StartNode(t testingT) {
 	if ht, ok := t.(test.HelperT); ok {
 		ht.Helper()
 	}
-	// avoid networking conflicts
+	d.Start(t, startArgs...)
+}
+
+// StartNodeWithBusybox starts daemon to be used as a swarm node, and loads the busybox image
+func (d *Daemon) StartNodeWithBusybox(t testingT) {
+	if ht, ok := t.(test.HelperT); ok {
+		ht.Helper()
+	}
 	d.StartWithBusybox(t, startArgs...)
 }
 
@@ -41,7 +48,7 @@ func (d *Daemon) RestartNode(t testingT) {
 
 // StartAndSwarmInit starts the daemon (with busybox) and init the swarm
 func (d *Daemon) StartAndSwarmInit(t testingT) {
-	d.StartNode(t)
+	d.StartNodeWithBusybox(t)
 	d.SwarmInit(t, swarm.InitRequest{})
 }
 
@@ -50,7 +57,7 @@ func (d *Daemon) StartAndSwarmJoin(t testingT, leader *Daemon, manager bool) {
 	if th, ok := t.(test.HelperT); ok {
 		th.Helper()
 	}
-	d.StartNode(t)
+	d.StartNodeWithBusybox(t)
 
 	tokens := leader.JoinTokens(t)
 	token := tokens.Worker


### PR DESCRIPTION
The `RestartNode` and `StartNode` functions also loaded the busybox image, which in most cases was not needed (as the daemon was already created and had the busybox image loaded).

This PR;

- Changes the `RestartNode` function to not load the busybox image
- Adds separate `StartNode` and `StartNodeWithBusybox` functions to be more explicit what they do.
- Replace most occurrences of `StartNodeWithBusybox` with `StartNode`
