### PR TITLE
Windows: skip flaky TestLogBlocking

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/docker/dockerversion"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
+	"gotest.tools/skip"
 )
 
 const (
@@ -286,6 +287,7 @@ func TestLogClosed(t *testing.T) {
 }
 
 func TestLogBlocking(t *testing.T) {
+	skip.If(t, runtime.GOOS == "windows", "FIXME: test is flaky on Windows. See #39857")
 	mockClient := newMockClient()
 	stream := &logStream{
 		client:   mockClient,


### PR DESCRIPTION
This test frequently fails on Windows RS1 (mainly), so skipping it for now on Windows. There's a tracking issue for fixing the tests in https://github.com/moby/moby/issues/39857

```
ok  	github.com/docker/docker/daemon/logger	0.525s	coverage: 43.0% of statements
time="2019-09-09T20:37:35Z" level=info msg="Trying to get region from EC2 Metadata"
time="2019-09-09T20:37:36Z" level=info msg="Log stream already exists" errorCode=ResourceAlreadyExistsException logGroupName= logStreamName= message= origError="<nil>"
--- FAIL: TestLogBlocking (0.02s)
    cloudwatchlogs_test.go:313: Expected to be able to read from stream.messages but was unable to
time="2019-09-09T20:37:36Z" level=error msg=Error
time="2019-09-09T20:37:36Z" level=error msg="Failed to put log events" errorCode=InvalidSequenceTokenException logGroupName=groupName logStreamName=streamName message="use token token" origError="<nil>"
time="2019-09-09T20:37:36Z" level=error msg="Failed to put log events" errorCode=DataAlreadyAcceptedException logGroupName=groupName logStreamName=streamName message="use token token" origError="<nil>"
time="2019-09-09T20:37:36Z" level=info msg="Data already accepted, ignoring error" errorCode=DataAlreadyAcceptedException logGroupName=groupName logStreamName=streamName message="use token token"
FAIL
coverage: 78.2% of statements
FAIL	github.com/docker/docker/daemon/logger/awslogs	0.630s
```
