### PR TITLE
fixes docker pull failed

### DIFF
--- a/registry/auth.go
+++ b/registry/auth.go
@@ -1,6 +1,7 @@
 package registry // import "github.com/docker/docker/registry"
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -271,6 +272,10 @@ func PingV2Registry(endpoint *url.URL, transport http.RoundTripper) (challenge.M
 		return nil, false, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, false, fmt.Errorf("ping to a invalid registry. ")
+	}
 
 	versions := auth.APIVersions(resp, DefaultRegistryVersionHeader)
 	for _, pingVersion := range versions {


### PR DESCRIPTION
My docker registry is running on port 80, and another application is hold port 443, when I run docker pull llh.com/aa:v3.0, docker will try to visit https://llh.com, but not visit http://llh.com although I have config the insecure-registries.

Signed-off-by: longhui.li <longhui.li@woqutech.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
We should check http status code when `PingV2Registry`

**- How I did it**
Add http status code check, return err if code is `StatusNotFound`
I have checked docker-registry's code, it will return 200,400,500,401, but cann't to be 404.

**- How to verify it**
run `docker pull   llh.com/aa:v3.0` again

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

