### PR TITLE
Jenkinsfile: shorten stage names for consistency and to fit Jenkins UI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,10 +8,10 @@ pipeline {
         timestamps()
     }
     parameters {
-        booleanParam(name: 'unit_validate', defaultValue: true, description: 'x86 unit tests and vendor check')
-        booleanParam(name: 'janky', defaultValue: true, description: 'x86 Build/Test')
-        booleanParam(name: 'z', defaultValue: true, description: 'IBM Z (s390x) Build/Test')
-        booleanParam(name: 'powerpc', defaultValue: true, description: 'PowerPC (ppc64le) Build/Test')
+        booleanParam(name: 'unit_validate', defaultValue: true, description: 'amd64 (x86_64) unit tests and vendor check')
+        booleanParam(name: 'amd64', defaultValue: true, description: 'amd64 (x86_64) Build/Test')
+        booleanParam(name: 's390x', defaultValue: true, description: 'IBM Z (s390x) Build/Test')
+        booleanParam(name: 'ppc64le', defaultValue: true, description: 'PowerPC (ppc64le) Build/Test')
         booleanParam(name: 'windowsRS1', defaultValue: true, description: 'Windows 2016 (RS1) Build/Test')
         booleanParam(name: 'windowsRS5', defaultValue: true, description: 'Windows 2019 (RS5) Build/Test')
         booleanParam(name: 'skip_dco', defaultValue: false, description: 'Skip the DCO check')
@@ -230,10 +230,10 @@ pipeline {
                         }
                     }
                 }
-                stage('janky') {
+                stage('amd64') {
                     when {
                         beforeAgent true
-                        expression { params.janky }
+                        expression { params.amd64 }
                     }
                     agent { label 'amd64 && ubuntu-1804 && overlay2' }
 
@@ -336,7 +336,7 @@ pipeline {
 
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to create bundles.tar.gz') {
                                 sh '''
-                                bundleName=janky
+                                bundleName=amd64
                                 echo "Creating ${bundleName}-bundles.tar.gz"
                                 # exclude overlay2 directories
                                 find bundles -path '*/root/*overlay2' -prune -o -type f \\( -name '*.log' -o -name '*.prof' \\) -print | xargs tar -czf ${bundleName}-bundles.tar.gz
@@ -351,10 +351,10 @@ pipeline {
                         }
                     }
                 }
-                stage('z') {
+                stage('s390x') {
                     when {
                         beforeAgent true
-                        expression { params.z }
+                        expression { params.s390x }
                     }
                     agent { label 's390x-ubuntu-1604' }
                     // s390x machines run on Docker 18.06, and buildkit has some bugs on that version
@@ -448,11 +448,11 @@ pipeline {
                         }
                     }
                 }
-                stage('z-master') {
+                stage('s390x integration-cli') {
                     when {
                         beforeAgent true
                         branch 'master'
-                        expression { params.z }
+                        expression { params.s390x }
                     }
                     agent { label 's390x-ubuntu-1604' }
                     // s390x machines run on Docker 18.06, and buildkit has some bugs on that version
@@ -526,13 +526,13 @@ pipeline {
                         }
                     }
                 }
-                stage('powerpc') {
+                stage('ppc64le') {
                     when {
                         beforeAgent true
-                        expression { params.powerpc }
+                        expression { params.ppc64le }
                     }
                     agent { label 'ppc64le-ubuntu-1604' }
-                    // power machines run on Docker 18.06, and buildkit has some bugs on that version
+                    // ppc64le machines run on Docker 18.06, and buildkit has some bugs on that version
                     environment { DOCKER_BUILDKIT = '0' }
 
                     stages {
@@ -606,7 +606,7 @@ pipeline {
 
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to create bundles.tar.gz') {
                                 sh '''
-                                bundleName=powerpc-integration
+                                bundleName=ppc64le-integration
                                 echo "Creating ${bundleName}-bundles.tar.gz"
                                 # exclude overlay2 directories
                                 find bundles -path '*/root/*overlay2' -prune -o -type f \\( -name '*.log' -o -name '*.prof' \\) -print | xargs tar -czf ${bundleName}-bundles.tar.gz
@@ -621,14 +621,14 @@ pipeline {
                         }
                     }
                 }
-                stage('powerpc-master') {
+                stage('ppc64le integration-cli') {
                     when {
                         beforeAgent true
                         branch 'master'
-                        expression { params.powerpc }
+                        expression { params.ppc64le }
                     }
                     agent { label 'ppc64le-ubuntu-1604' }
-                    // power machines run on Docker 18.06, and buildkit has some bugs on that version
+                    // ppc64le machines run on Docker 18.06, and buildkit has some bugs on that version
                     environment { DOCKER_BUILDKIT = '0' }
 
                     stages {
@@ -682,7 +682,7 @@ pipeline {
 
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to create bundles.tar.gz') {
                                 sh '''
-                                bundleName=powerpc-integration-cli
+                                bundleName=ppc64le-integration-cli
                                 echo "Creating ${bundleName}-bundles.tar.gz"
                                 # exclude overlay2 directories
                                 find bundles -path '*/root/*overlay2' -prune -o -type f \\( -name '*.log' -o -name '*.prof' \\) -print | xargs tar -czf ${bundleName}-bundles.tar.gz
@@ -697,7 +697,7 @@ pipeline {
                         }
                     }
                 }
-                stage('windowsRS1') {
+                stage('win-RS1') {
                     when {
                         beforeAgent true
                         expression { params.windowsRS1 }
@@ -758,7 +758,7 @@ pipeline {
                         }
                     }
                 }
-                stage('windowsRS5-process') {
+                stage('win-RS5') {
                     when {
                         beforeAgent true
                         expression { params.windowsRS5 }


### PR DESCRIPTION
The Blue Ocean UI truncates names, which makes it possible to distinguish which Windows stage is RS1 or RS5. This patch shortens those names so that they fit in the Blue Ocean UI.

Other stages and parameters were renamed as well to better reflect what they're running;

Before             | After
-------------------|--------------------------------
janky              | amd64
power              | ppc64le
power-master       | ppc64le integration-cli
windowsRS1         | win-RS1
windowsRS5-process | win-RS5
z                  | s390x
z-master           | s390x integration-cli

And before/after screenshots of the Blue Ocean view;

<img width="286" alt="Screenshot 2019-09-10 at 10 10 32" src="https://user-images.githubusercontent.com/1804568/64596986-3dbf4f80-d3b5-11e9-8f0f-6cdeac7acdb0.png"> <img width="253" alt="Screenshot 2019-09-10 at 10 24 21" src="https://user-images.githubusercontent.com/1804568/64596987-3dbf4f80-d3b5-11e9-8f42-78bcfe6403da.png">


