### PR TITLE
Re-enable disable deprecate-integration-cli

### DIFF
--- a/hack/validate/default
+++ b/hack/validate/default
@@ -13,4 +13,4 @@ export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . ${SCRIPTDIR}/toml
 . ${SCRIPTDIR}/changelog-well-formed
 . ${SCRIPTDIR}/changelog-date-descending
-#. ${SCRIPTDIR}/deprecate-integration-cli
+. ${SCRIPTDIR}/deprecate-integration-cli


### PR DESCRIPTION
with https://github.com/moby/moby/pull/39799 merged, we can re-enable this check

This reverts commit beadc92e0781a32854f4cbb8389804a06730c351.


**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

