### PR TITLE
run windowsRS1 check job after merge to master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -697,9 +697,10 @@ pipeline {
                         }
                     }
                 }
-                stage('windowsRS1') {
+                stage('windowsRS1-master') {
                     when {
                         beforeAgent true
+                        branch 'master'
                         expression { params.windowsRS1 }
                     }
                     environment {


### PR DESCRIPTION
Regarding issue #39532, the `windowsRS1` PR checks are well over the 60-minute time limit desired for PRs (#39651) by being the longest pole at 100 minutes. Additionally, the `windowsRS1` are consistently flaky on various tests: 10 out of the [last 19 PRs merged this week](https://github.com/moby/moby/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+merged%3A2019-09-04..2019-09-10) have `windowsRS1` failures.

We still have `windowsRS5` PR checks and I suggest we open a separate PR to reduce flakiness and runtime of `windowsRS1` PR checks after this one is merged.

cc @StefanScherer @vikramhh @thaJeztah @ddebroy 