### PR TITLE
Dockerfile: remove GOMETALINTER_OPTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -281,8 +281,6 @@ COPY --from=djs55/vpnkit@sha256:e508a17cfacc8fd39261d5b4e397df2b953690da577e2c98
 
 ENV PATH=/usr/local/cli:$PATH
 ENV DOCKER_BUILDTAGS apparmor seccomp selinux
-# Options for hack/validate/gometalinter
-ENV GOMETALINTER_OPTS="--deadline=2m"
 WORKDIR /go/src/github.com/docker/docker
 VOLUME /var/lib/docker
 # Wrap all commands in the "docker-in-docker" script to allow nested containers

--- a/hack/validate/gometalinter
+++ b/hack/validate/gometalinter
@@ -4,10 +4,11 @@ set -e -o pipefail
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # CI platforms differ, so per-platform GOMETALINTER_OPTS can be set
-# from a platform-specific Dockerfile, otherwise let's just set
+# in the Jenkinsfile, otherwise let's just set a
 # (somewhat pessimistic) default of 10 minutes.
-: ${GOMETALINTER_OPTS=--deadline=10m}
+: "${GOMETALINTER_OPTS=--deadline=10m}"
 
+# shellcheck disable=SC2086
 gometalinter \
 	${GOMETALINTER_OPTS} \
-	--config ${SCRIPTDIR}/gometalinter.json ./...
+	--config "${SCRIPTDIR}/gometalinter.json" ./...


### PR DESCRIPTION
This `ENV` was added to the Dockerfile in b96093fa56a9c085cb3123010be2430753c40cbc (https://github.com/moby/moby/pull/34759),
when the repository used per-architecture Dockerfiles, and some architectures needed
a different configuration.

Now that we use a multi-arch Dockerfile, and CI uses a Jenkinsfile, we can remove
this `ENV` from the Dockerfile, and set it in CI instead if needed.

Also updated the wording and fixed linting issues in hack/validate/gometalinter


Note that this changes the `--deadline` to use the default (10m), which probably isn't a big issue (note that on the Go 1.13 update PR, we actually run into the 2m deadline https://github.com/moby/moby/pull/39549, which is when I found that we override the default 10m)
