### PR TITLE
integration-cli: remove unneeded sprintf's in asserts 

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1220,7 +1220,7 @@ func (s *DockerSuite) TestContainerAPIDeleteRemoveVolume(c *testing.T) {
 	assert.NilError(c, err)
 
 	_, err = os.Stat(source)
-	assert.Assert(c, os.IsNotExist(err), fmt.Sprintf("expected to get ErrNotExist error, got %v", err))
+	assert.Assert(c, os.IsNotExist(err), "expected to get ErrNotExist error, got %v", err)
 }
 
 // Regression test for https://github.com/docker/docker/issues/6231

--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"bufio"
-	"fmt"
 	"io/ioutil"
 	"os/exec"
 	"strings"
@@ -52,7 +51,7 @@ func (s *DockerSuite) TestAttachClosedOnContainerStop(c *testing.T) {
 	case err := <-errChan:
 		tty.Close()
 		out, _ := ioutil.ReadAll(pty)
-		assert.Assert(c, err == nil, fmt.Sprintf("out: %v", string(out)))
+		assert.Assert(c, err == nil, "out: %v", string(out))
 	case <-time.After(attachWait):
 		c.Fatal("timed out without attach returning")
 	}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4738,7 +4738,7 @@ func (s *DockerSuite) TestBuildTagEvent(c *testing.T) {
 		}
 	}
 
-	assert.Assert(c, foundTag, fmt.Sprintf("No tag event found:\n%s", out))
+	assert.Assert(c, foundTag, "No tag event found:\n%s", out)
 }
 
 // #15780

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -252,7 +252,7 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *testing.T) {
 
 	// make sure repo shown, tag=<none>, digest = $digest1
 	re1 := regexp.MustCompile(`\s*` + repoName + `\s*<none>\s*` + digest1.String() + `\s`)
-	assert.Assert(c, re1.MatchString(out), fmt.Sprintf("expected %q: %s", re1.String(), out))
+	assert.Assert(c, re1.MatchString(out), "expected %q: %s", re1.String(), out)
 	// setup image2
 	digest2, err := setupImageWithTag(c, "tag2")
 	//error setting up image
@@ -270,11 +270,11 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *testing.T) {
 	out, _ = dockerCmd(c, "images", "--digests")
 
 	// make sure repo shown, tag=<none>, digest = $digest1
-	assert.Assert(c, re1.MatchString(out), fmt.Sprintf("expected %q: %s", re1.String(), out))
+	assert.Assert(c, re1.MatchString(out), "expected %q: %s", re1.String(), out)
 
 	// make sure repo shown, tag=<none>, digest = $digest2
 	re2 := regexp.MustCompile(`\s*` + repoName + `\s*<none>\s*` + digest2.String() + `\s`)
-	assert.Assert(c, re2.MatchString(out), fmt.Sprintf("expected %q: %s", re2.String(), out))
+	assert.Assert(c, re2.MatchString(out), "expected %q: %s", re2.String(), out)
 
 	// pull tag1
 	dockerCmd(c, "pull", repoName+":tag1")
@@ -284,9 +284,9 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *testing.T) {
 
 	// make sure image 1 has repo, tag, <none> AND repo, <none>, digest
 	reWithDigest1 := regexp.MustCompile(`\s*` + repoName + `\s*tag1\s*` + digest1.String() + `\s`)
-	assert.Assert(c, reWithDigest1.MatchString(out), fmt.Sprintf("expected %q: %s", reWithDigest1.String(), out))
+	assert.Assert(c, reWithDigest1.MatchString(out), "expected %q: %s", reWithDigest1.String(), out)
 	// make sure image 2 has repo, <none>, digest
-	assert.Assert(c, re2.MatchString(out), fmt.Sprintf("expected %q: %s", re2.String(), out))
+	assert.Assert(c, re2.MatchString(out), "expected %q: %s", re2.String(), out)
 
 	// pull tag 2
 	dockerCmd(c, "pull", repoName+":tag2")
@@ -295,22 +295,22 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *testing.T) {
 	out, _ = dockerCmd(c, "images", "--digests")
 
 	// make sure image 1 has repo, tag, digest
-	assert.Assert(c, reWithDigest1.MatchString(out), fmt.Sprintf("expected %q: %s", reWithDigest1.String(), out))
+	assert.Assert(c, reWithDigest1.MatchString(out), "expected %q: %s", reWithDigest1.String(), out)
 
 	// make sure image 2 has repo, tag, digest
 	reWithDigest2 := regexp.MustCompile(`\s*` + repoName + `\s*tag2\s*` + digest2.String() + `\s`)
-	assert.Assert(c, reWithDigest2.MatchString(out), fmt.Sprintf("expected %q: %s", reWithDigest2.String(), out))
+	assert.Assert(c, reWithDigest2.MatchString(out), "expected %q: %s", reWithDigest2.String(), out)
 
 	// list images
 	out, _ = dockerCmd(c, "images", "--digests")
 
 	// make sure image 1 has repo, tag, digest
-	assert.Assert(c, reWithDigest1.MatchString(out), fmt.Sprintf("expected %q: %s", reWithDigest1.String(), out))
+	assert.Assert(c, reWithDigest1.MatchString(out), "expected %q: %s", reWithDigest1.String(), out)
 	// make sure image 2 has repo, tag, digest
-	assert.Assert(c, reWithDigest2.MatchString(out), fmt.Sprintf("expected %q: %s", reWithDigest2.String(), out))
+	assert.Assert(c, reWithDigest2.MatchString(out), "expected %q: %s", reWithDigest2.String(), out)
 	// make sure busybox has tag, but not digest
 	busyboxRe := regexp.MustCompile(`\s*busybox\s*latest\s*<none>\s`)
-	assert.Assert(c, busyboxRe.MatchString(out), fmt.Sprintf("expected %q: %s", busyboxRe.String(), out))
+	assert.Assert(c, busyboxRe.MatchString(out), "expected %q: %s", busyboxRe.String(), out)
 }
 
 func (s *DockerRegistrySuite) TestListDanglingImagesWithDigests(c *testing.T) {
@@ -328,7 +328,7 @@ func (s *DockerRegistrySuite) TestListDanglingImagesWithDigests(c *testing.T) {
 
 	// make sure repo shown, tag=<none>, digest = $digest1
 	re1 := regexp.MustCompile(`\s*` + repoName + `\s*<none>\s*` + digest1.String() + `\s`)
-	assert.Assert(c, re1.MatchString(out), fmt.Sprintf("expected %q: %s", re1.String(), out))
+	assert.Assert(c, re1.MatchString(out), "expected %q: %s", re1.String(), out)
 	// setup image2
 	digest2, err := setupImageWithTag(c, "dangle2")
 	//error setting up image
@@ -346,11 +346,11 @@ func (s *DockerRegistrySuite) TestListDanglingImagesWithDigests(c *testing.T) {
 	out, _ = dockerCmd(c, "images", "--digests", "--filter=dangling=true")
 
 	// make sure repo shown, tag=<none>, digest = $digest1
-	assert.Assert(c, re1.MatchString(out), fmt.Sprintf("expected %q: %s", re1.String(), out))
+	assert.Assert(c, re1.MatchString(out), "expected %q: %s", re1.String(), out)
 
 	// make sure repo shown, tag=<none>, digest = $digest2
 	re2 := regexp.MustCompile(`\s*` + repoName + `\s*<none>\s*` + digest2.String() + `\s`)
-	assert.Assert(c, re2.MatchString(out), fmt.Sprintf("expected %q: %s", re2.String(), out))
+	assert.Assert(c, re2.MatchString(out), "expected %q: %s", re2.String(), out)
 
 	// pull dangle1 tag
 	dockerCmd(c, "pull", repoName+":dangle1")
@@ -360,9 +360,9 @@ func (s *DockerRegistrySuite) TestListDanglingImagesWithDigests(c *testing.T) {
 
 	// make sure image 1 has repo, tag, <none> AND repo, <none>, digest
 	reWithDigest1 := regexp.MustCompile(`\s*` + repoName + `\s*dangle1\s*` + digest1.String() + `\s`)
-	assert.Assert(c, !reWithDigest1.MatchString(out), fmt.Sprintf("unexpected %q: %s", reWithDigest1.String(), out))
+	assert.Assert(c, !reWithDigest1.MatchString(out), "unexpected %q: %s", reWithDigest1.String(), out)
 	// make sure image 2 has repo, <none>, digest
-	assert.Assert(c, re2.MatchString(out), fmt.Sprintf("expected %q: %s", re2.String(), out))
+	assert.Assert(c, re2.MatchString(out), "expected %q: %s", re2.String(), out)
 
 	// pull dangle2 tag
 	dockerCmd(c, "pull", repoName+":dangle2")
@@ -371,19 +371,19 @@ func (s *DockerRegistrySuite) TestListDanglingImagesWithDigests(c *testing.T) {
 	out, _ = dockerCmd(c, "images", "--digests")
 
 	// make sure image 1 has repo, tag, digest
-	assert.Assert(c, reWithDigest1.MatchString(out), fmt.Sprintf("expected %q: %s", reWithDigest1.String(), out))
+	assert.Assert(c, reWithDigest1.MatchString(out), "expected %q: %s", reWithDigest1.String(), out)
 
 	// make sure image 2 has repo, tag, digest
 	reWithDigest2 := regexp.MustCompile(`\s*` + repoName + `\s*dangle2\s*` + digest2.String() + `\s`)
-	assert.Assert(c, reWithDigest2.MatchString(out), fmt.Sprintf("expected %q: %s", reWithDigest2.String(), out))
+	assert.Assert(c, reWithDigest2.MatchString(out), "expected %q: %s", reWithDigest2.String(), out)
 
 	// list images, no longer dangling, should not match
 	out, _ = dockerCmd(c, "images", "--digests", "--filter=dangling=true")
 
 	// make sure image 1 has repo, tag, digest
-	assert.Assert(c, !reWithDigest1.MatchString(out), fmt.Sprintf("unexpected %q: %s", reWithDigest1.String(), out))
+	assert.Assert(c, !reWithDigest1.MatchString(out), "unexpected %q: %s", reWithDigest1.String(), out)
 	// make sure image 2 has repo, tag, digest
-	assert.Assert(c, !reWithDigest2.MatchString(out), fmt.Sprintf("unexpected %q: %s", reWithDigest2.String(), out))
+	assert.Assert(c, !reWithDigest2.MatchString(out), "unexpected %q: %s", reWithDigest2.String(), out)
 }
 
 func (s *DockerRegistrySuite) TestInspectImageWithDigests(c *testing.T) {
@@ -643,7 +643,7 @@ func (s *DockerRegistrySuite) TestPullFailsWithAlteredLayer(c *testing.T) {
 	assert.Assert(c, exitStatus != 0, "expected a non-zero exit status")
 
 	expectedErrorMsg := fmt.Sprintf("filesystem layer verification failed for digest %s", targetLayerDigest)
-	assert.Assert(c, strings.Contains(out, expectedErrorMsg), fmt.Sprintf("expected error message in output: %s", out))
+	assert.Assert(c, strings.Contains(out, expectedErrorMsg), "expected error message in output: %s", out)
 }
 
 // TestPullFailsWithAlteredLayer tests that a `docker pull` fails when
@@ -686,5 +686,5 @@ func (s *DockerSchema1RegistrySuite) TestPullFailsWithAlteredLayer(c *testing.T)
 	assert.Assert(c, exitStatus != 0, "expected a non-zero exit status")
 
 	expectedErrorMsg := fmt.Sprintf("filesystem layer verification failed for digest %s", targetLayerDigest)
-	assert.Assert(c, strings.Contains(out, expectedErrorMsg), fmt.Sprintf("expected error message in output: %s", out))
+	assert.Assert(c, strings.Contains(out, expectedErrorMsg), "expected error message in output: %s", out)
 }

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -72,7 +71,7 @@ func (s *DockerSuite) TestCommitHardlink(c *testing.T) {
 	chunks := strings.Split(strings.TrimSpace(firstOutput), " ")
 	inode := chunks[0]
 	chunks = strings.SplitAfterN(strings.TrimSpace(firstOutput), " ", 2)
-	assert.Assert(c, strings.Contains(chunks[1], chunks[0]), fmt.Sprintf("Failed to create hardlink in a container. Expected to find %q in %q", inode, chunks[1:]))
+	assert.Assert(c, strings.Contains(chunks[1], chunks[0]), "Failed to create hardlink in a container. Expected to find %q in %q", inode, chunks[1:])
 	imageID, _ := dockerCmd(c, "commit", "hardlinks", "hardlinks")
 	imageID = strings.TrimSpace(imageID)
 
@@ -81,7 +80,7 @@ func (s *DockerSuite) TestCommitHardlink(c *testing.T) {
 	chunks = strings.Split(strings.TrimSpace(secondOutput), " ")
 	inode = chunks[0]
 	chunks = strings.SplitAfterN(strings.TrimSpace(secondOutput), " ", 2)
-	assert.Assert(c, strings.Contains(chunks[1], chunks[0]), fmt.Sprintf("Failed to create hardlink in a container. Expected to find %q in %q", inode, chunks[1:]))
+	assert.Assert(c, strings.Contains(chunks[1], chunks[0]), "Failed to create hardlink in a container. Expected to find %q in %q", inode, chunks[1:])
 }
 
 func (s *DockerSuite) TestCommitTTY(c *testing.T) {

--- a/integration-cli/docker_cli_cp_from_container_test.go
+++ b/integration-cli/docker_cli_cp_from_container_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -150,7 +149,7 @@ func (s *DockerSuite) TestCpFromCaseB(c *testing.T) {
 	err := runDockerCp(c, srcPath, dstDir, nil)
 	assert.ErrorContains(c, err, "")
 
-	assert.Assert(c, isCpDirNotExist(err), fmt.Sprintf("expected DirNotExists error, but got %T: %s", err, err))
+	assert.Assert(c, isCpDirNotExist(err), "expected DirNotExists error, but got %T: %s", err, err)
 }
 
 // C. SRC specifies a file and DST exists as a file. This should overwrite
@@ -195,7 +194,7 @@ func (s *DockerSuite) TestCpFromCaseD(c *testing.T) {
 
 	// Ensure that dstPath doesn't exist.
 	_, err := os.Stat(dstPath)
-	assert.Assert(c, os.IsNotExist(err), fmt.Sprintf("did not expect dstPath %q to exist", dstPath))
+	assert.Assert(c, os.IsNotExist(err), "did not expect dstPath %q to exist", dstPath)
 
 	assert.Assert(c, runDockerCp(c, srcPath, dstDir, nil) == nil)
 
@@ -266,7 +265,7 @@ func (s *DockerSuite) TestCpFromCaseF(c *testing.T) {
 	err := runDockerCp(c, srcDir, dstFile, nil)
 	assert.ErrorContains(c, err, "")
 
-	assert.Assert(c, isCpCannotCopyDir(err), fmt.Sprintf("expected ErrCannotCopyDir error, but got %T: %s", err, err))
+	assert.Assert(c, isCpCannotCopyDir(err), "expected ErrCannotCopyDir error, but got %T: %s", err, err)
 }
 
 // G. SRC specifies a directory and DST exists as a directory. This should copy
@@ -358,7 +357,7 @@ func (s *DockerSuite) TestCpFromCaseI(c *testing.T) {
 	err := runDockerCp(c, srcDir, dstFile, nil)
 	assert.ErrorContains(c, err, "")
 
-	assert.Assert(c, isCpCannotCopyDir(err), fmt.Sprintf("expected ErrCannotCopyDir error, but got %T: %s", err, err))
+	assert.Assert(c, isCpCannotCopyDir(err), "expected ErrCannotCopyDir error, but got %T: %s", err, err)
 }
 
 // J. SRC specifies a directory's contents only and DST exists as a directory.

--- a/integration-cli/docker_cli_cp_to_container_test.go
+++ b/integration-cli/docker_cli_cp_to_container_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -158,7 +157,7 @@ func (s *DockerSuite) TestCpToCaseB(c *testing.T) {
 	err := runDockerCp(c, srcPath, dstDir, nil)
 	assert.ErrorContains(c, err, "")
 
-	assert.Assert(c, isCpDirNotExist(err), fmt.Sprintf("expected DirNotExists error, but got %T: %s", err, err))
+	assert.Assert(c, isCpDirNotExist(err), "expected DirNotExists error, but got %T: %s", err, err)
 }
 
 // C. SRC specifies a file and DST exists as a file. This should overwrite
@@ -288,7 +287,7 @@ func (s *DockerSuite) TestCpToCaseF(c *testing.T) {
 	err := runDockerCp(c, srcDir, dstFile, nil)
 	assert.ErrorContains(c, err, "")
 
-	assert.Assert(c, isCpCannotCopyDir(err), fmt.Sprintf("expected ErrCannotCopyDir error, but got %T: %s", err, err))
+	assert.Assert(c, isCpCannotCopyDir(err), "expected ErrCannotCopyDir error, but got %T: %s", err, err)
 }
 
 // G. SRC specifies a directory and DST exists as a directory. This should copy
@@ -393,7 +392,7 @@ func (s *DockerSuite) TestCpToCaseI(c *testing.T) {
 	err := runDockerCp(c, srcDir, dstFile, nil)
 	assert.ErrorContains(c, err, "")
 
-	assert.Assert(c, isCpCannotCopyDir(err), fmt.Sprintf("expected ErrCannotCopyDir error, but got %T: %s", err, err))
+	assert.Assert(c, isCpCannotCopyDir(err), "expected ErrCannotCopyDir error, but got %T: %s", err, err)
 }
 
 // J. SRC specifies a directory's contents only and DST exists as a directory.
@@ -462,7 +461,7 @@ func (s *DockerSuite) TestCpToErrReadOnlyRootfs(c *testing.T) {
 	err := runDockerCp(c, srcPath, dstPath, nil)
 	assert.ErrorContains(c, err, "")
 
-	assert.Assert(c, isCpCannotCopyReadOnly(err), fmt.Sprintf("expected ErrContainerRootfsReadonly error, but got %T: %s", err, err))
+	assert.Assert(c, isCpCannotCopyReadOnly(err), "expected ErrContainerRootfsReadonly error, but got %T: %s", err, err)
 
 	// Ensure that dstPath doesn't exist.
 	assert.Assert(c, containerStartOutputEquals(c, containerID, "") == nil)
@@ -489,7 +488,7 @@ func (s *DockerSuite) TestCpToErrReadOnlyVolume(c *testing.T) {
 	err := runDockerCp(c, srcPath, dstPath, nil)
 	assert.ErrorContains(c, err, "")
 
-	assert.Assert(c, isCpCannotCopyReadOnly(err), fmt.Sprintf("expected ErrVolumeReadonly error, but got %T: %s", err, err))
+	assert.Assert(c, isCpCannotCopyReadOnly(err), "expected ErrVolumeReadonly error, but got %T: %s", err, err)
 
 	// Ensure that dstPath doesn't exist.
 	assert.Assert(c, containerStartOutputEquals(c, containerID, "") == nil)

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -36,7 +36,7 @@ func (s *DockerSuite) TestCreateArgs(c *testing.T) {
 	}
 
 	err := json.Unmarshal([]byte(out), &containers)
-	assert.Assert(c, err == nil, fmt.Sprintf("Error inspecting the container: %s", err))
+	assert.Assert(c, err == nil, "Error inspecting the container: %s", err)
 	assert.Equal(c, len(containers), 1)
 
 	cont := containers[0]
@@ -95,12 +95,12 @@ func (s *DockerSuite) TestCreateHostConfig(c *testing.T) {
 	}
 
 	err := json.Unmarshal([]byte(out), &containers)
-	assert.Assert(c, err == nil, fmt.Sprintf("Error inspecting the container: %s", err))
+	assert.Assert(c, err == nil, "Error inspecting the container: %s", err)
 	assert.Equal(c, len(containers), 1)
 
 	cont := containers[0]
-	assert.Assert(c, cont.HostConfig != nil, fmt.Sprintf("Expected HostConfig, got none"))
-	assert.Assert(c, cont.HostConfig.PublishAllPorts, fmt.Sprintf("Expected PublishAllPorts, got false"))
+	assert.Assert(c, cont.HostConfig != nil, "Expected HostConfig, got none")
+	assert.Assert(c, cont.HostConfig.PublishAllPorts, "Expected PublishAllPorts, got false")
 }
 
 func (s *DockerSuite) TestCreateWithPortRange(c *testing.T) {
@@ -116,12 +116,12 @@ func (s *DockerSuite) TestCreateWithPortRange(c *testing.T) {
 		}
 	}
 	err := json.Unmarshal([]byte(out), &containers)
-	assert.Assert(c, err == nil, fmt.Sprintf("Error inspecting the container: %s", err))
+	assert.Assert(c, err == nil, "Error inspecting the container: %s", err)
 	assert.Equal(c, len(containers), 1)
 
 	cont := containers[0]
 
-	assert.Assert(c, cont.HostConfig != nil, fmt.Sprintf("Expected HostConfig, got none"))
+	assert.Assert(c, cont.HostConfig != nil, "Expected HostConfig, got none")
 	assert.Equal(c, len(cont.HostConfig.PortBindings), 4, fmt.Sprintf("Expected 4 ports bindings, got %d", len(cont.HostConfig.PortBindings)))
 
 	for k, v := range cont.HostConfig.PortBindings {
@@ -146,11 +146,11 @@ func (s *DockerSuite) TestCreateWithLargePortRange(c *testing.T) {
 	}
 
 	err := json.Unmarshal([]byte(out), &containers)
-	assert.Assert(c, err == nil, fmt.Sprintf("Error inspecting the container: %s", err))
+	assert.Assert(c, err == nil, "Error inspecting the container: %s", err)
 	assert.Equal(c, len(containers), 1)
 
 	cont := containers[0]
-	assert.Assert(c, cont.HostConfig != nil, fmt.Sprintf("Expected HostConfig, got none"))
+	assert.Assert(c, cont.HostConfig != nil, "Expected HostConfig, got none")
 	assert.Equal(c, len(cont.HostConfig.PortBindings), 65535)
 
 	for k, v := range cont.HostConfig.PortBindings {
@@ -178,7 +178,7 @@ func (s *DockerSuite) TestCreateVolumesCreated(c *testing.T) {
 	dockerCmd(c, "create", "--name", name, "-v", prefix+slash+"foo", "busybox")
 
 	dir, err := inspectMountSourceField(name, prefix+slash+"foo")
-	assert.Assert(c, err == nil, fmt.Sprintf("Error getting volume host path: %q", err))
+	assert.Assert(c, err == nil, "Error getting volume host path: %q", err)
 
 	if _, err := os.Stat(dir); err != nil && os.IsNotExist(err) {
 		c.Fatalf("Volume was not created")

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -131,7 +131,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartUnlessStopped(c *testing.T) {
 		var format string
 		for name, shouldRun := range m {
 			out, err := s.d.Cmd("ps")
-			assert.Assert(c, err == nil, fmt.Sprintf("run ps: %v", out))
+			assert.Assert(c, err == nil, "run ps: %v", out)
 			if shouldRun {
 				format = "%scontainer %q is not running"
 			} else {
@@ -217,7 +217,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithInvalidBasesize(c *testing.T) {
 
 	if newBasesizeBytes < oldBasesizeBytes {
 		err := s.d.RestartWithError("--storage-opt", fmt.Sprintf("dm.basesize=%d", newBasesizeBytes))
-		assert.Assert(c, err != nil, fmt.Sprintf("daemon should not have started as new base device size is less than existing base device size: %v", err))
+		assert.Assert(c, err != nil, "daemon should not have started as new base device size is less than existing base device size: %v", err)
 		// 'err != nil' is expected behaviour, no new daemon started,
 		// so no need to stop daemon.
 		if err != nil {
@@ -241,11 +241,11 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithIncreasedBasesize(c *testing.T)
 	}
 
 	err := s.d.RestartWithError("--storage-opt", fmt.Sprintf("dm.basesize=%d", newBasesizeBytes))
-	assert.Assert(c, err == nil, fmt.Sprintf("we should have been able to start the daemon with increased base device size: %v", err))
+	assert.Assert(c, err == nil, "we should have been able to start the daemon with increased base device size: %v", err)
 
 	basesizeAfterRestart := getBaseDeviceSize(c, s.d)
 	newBasesize, err := convertBasesize(newBasesizeBytes)
-	assert.Assert(c, err == nil, fmt.Sprintf("Error in converting base device size: %v", err))
+	assert.Assert(c, err == nil, "Error in converting base device size: %v", err)
 	assert.Equal(c, newBasesize, basesizeAfterRestart, "Basesize passed is not equal to Basesize set")
 	s.d.Stop(c)
 }
@@ -1750,7 +1750,7 @@ func (s *DockerDaemonSuite) TestBridgeIPIsExcludedFromAllocatorPool(c *testing.T
 			break
 		}
 		ip, err := s.d.Cmd("inspect", "--format", "'{{.NetworkSettings.IPAddress}}'", contName)
-		assert.Assert(c, err == nil, fmt.Sprintf("%s", ip))
+		assert.Assert(c, err == nil, "%s", ip)
 
 		assert.Assert(c, ip != bridgeIP)
 		cont++
@@ -1780,7 +1780,7 @@ func (s *DockerDaemonSuite) TestDaemonNoSpaceLeftOnDeviceError(c *testing.T) {
 
 	// pull a repository large enough to overfill the mounted filesystem
 	pullOut, err := s.d.Cmd("pull", "debian:stretch")
-	assert.Assert(c, err != nil, fmt.Sprintf("%s", pullOut))
+	assert.Assert(c, err != nil, "%s", pullOut)
 	assert.Assert(c, strings.Contains(pullOut, "no space left on device"))
 }
 
@@ -1855,7 +1855,7 @@ func (s *DockerDaemonSuite) TestDaemonCgroupParent(c *testing.T) {
 	out, err := s.d.Cmd("run", "--name", name, "busybox", "cat", "/proc/self/cgroup")
 	assert.NilError(c, err)
 	cgroupPaths := ParseCgroupPaths(string(out))
-	assert.Assert(c, len(cgroupPaths) != 0, fmt.Sprintf("unexpected output - %q", string(out)))
+	assert.Assert(c, len(cgroupPaths) != 0, "unexpected output - %q", string(out))
 	out, err = s.d.Cmd("inspect", "-f", "{{.Id}}", name)
 	assert.NilError(c, err)
 	id := strings.TrimSpace(string(out))
@@ -1867,7 +1867,7 @@ func (s *DockerDaemonSuite) TestDaemonCgroupParent(c *testing.T) {
 			break
 		}
 	}
-	assert.Assert(c, found, fmt.Sprintf("Cgroup path for container (%s) doesn't found in cgroups file: %s", expectedCgroup, cgroupPaths))
+	assert.Assert(c, found, "Cgroup path for container (%s) doesn't found in cgroups file: %s", expectedCgroup, cgroupPaths)
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithLinks(c *testing.T) {
@@ -2007,7 +2007,7 @@ func (s *DockerDaemonSuite) TestCleanupMountsAfterDaemonCrash(c *testing.T) {
 	// the following check for mounts being cleared is pointless.
 	skipMountCheck := false
 	mountOut, err := ioutil.ReadFile("/proc/self/mountinfo")
-	assert.Assert(c, err == nil, fmt.Sprintf("Output: %s", mountOut))
+	assert.Assert(c, err == nil, "Output: %s", mountOut)
 	if !strings.Contains(string(mountOut), id) {
 		skipMountCheck = true
 	}
@@ -2032,7 +2032,7 @@ func (s *DockerDaemonSuite) TestCleanupMountsAfterDaemonCrash(c *testing.T) {
 	}
 	// Now, container mounts should be gone.
 	mountOut, err = ioutil.ReadFile("/proc/self/mountinfo")
-	assert.Assert(c, err == nil, fmt.Sprintf("Output: %s", mountOut))
+	assert.Assert(c, err == nil, "Output: %s", mountOut)
 	comment := fmt.Sprintf("%s is still mounted from older daemon start:\nDaemon root repository %s\n%s", id, s.d.Root, mountOut)
 	assert.Equal(c, strings.Contains(string(mountOut), id), false, comment)
 }
@@ -2229,8 +2229,8 @@ func (s *DockerDaemonSuite) TestDaemonDiscoveryBackendConfigReload(c *testing.T)
 	out, err := s.d.Cmd("info")
 	assert.NilError(c, err)
 
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("Cluster Store: consul://consuladdr:consulport/some/path")))
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("Cluster Advertise: 192.168.56.100:0")))
+	assert.Assert(c, strings.Contains(out, "Cluster Store: consul://consuladdr:consulport/some/path"))
+	assert.Assert(c, strings.Contains(out, "Cluster Advertise: 192.168.56.100:0"))
 }
 
 // Test for #21956
@@ -2376,11 +2376,11 @@ func (s *DockerDaemonSuite) TestDaemonDNSFlagsInHostMode(c *testing.T) {
 
 	expectedOutput := "nameserver 1.2.3.4"
 	out, _ := s.d.Cmd("run", "--net=host", "busybox", "cat", "/etc/resolv.conf")
-	assert.Assert(c, strings.Contains(out, expectedOutput), fmt.Sprintf("Expected '%s', but got %q", expectedOutput, out))
+	assert.Assert(c, strings.Contains(out, expectedOutput), "Expected '%s', but got %q", expectedOutput, out)
 	expectedOutput = "search example.com"
-	assert.Assert(c, strings.Contains(out, expectedOutput), fmt.Sprintf("Expected '%s', but got %q", expectedOutput, out))
+	assert.Assert(c, strings.Contains(out, expectedOutput), "Expected '%s', but got %q", expectedOutput, out)
 	expectedOutput = "options timeout:3"
-	assert.Assert(c, strings.Contains(out, expectedOutput), fmt.Sprintf("Expected '%s', but got %q", expectedOutput, out))
+	assert.Assert(c, strings.Contains(out, expectedOutput), "Expected '%s', but got %q", expectedOutput, out)
 }
 
 func (s *DockerDaemonSuite) TestRunWithRuntimeFromConfigFile(c *testing.T) {
@@ -2555,10 +2555,10 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithAutoRemoveContainer(c *testing.
 
 	// top1 will exist after daemon restarts
 	out, err := s.d.Cmd("run", "-d", "--name", "top1", "busybox:latest", "top")
-	assert.Assert(c, err == nil, fmt.Sprintf("run top1: %v", out))
+	assert.Assert(c, err == nil, "run top1: %v", out)
 	// top2 will be removed after daemon restarts
 	out, err = s.d.Cmd("run", "-d", "--rm", "--name", "top2", "busybox:latest", "top")
-	assert.Assert(c, err == nil, fmt.Sprintf("run top2: %v", out))
+	assert.Assert(c, err == nil, "run top2: %v", out)
 
 	out, err = s.d.Cmd("ps")
 	assert.NilError(c, err)
@@ -2714,13 +2714,13 @@ func (s *DockerDaemonSuite) TestExecWithUserAfterLiveRestore(c *testing.T) {
 
 	out1, err := s.d.Cmd("exec", "-u", "test", "top", "id")
 	// uid=100(test) gid=101(test) groups=101(test)
-	assert.Assert(c, err == nil, fmt.Sprintf("Output: %s", out1))
+	assert.Assert(c, err == nil, "Output: %s", out1)
 
 	// restart daemon.
 	s.d.Restart(c, "--live-restore")
 
 	out2, err := s.d.Cmd("exec", "-u", "test", "top", "id")
-	assert.Assert(c, err == nil, fmt.Sprintf("Output: %s", out2))
+	assert.Assert(c, err == nil, "Output: %s", out2)
 	assert.Equal(c, out2, out1, fmt.Sprintf("Output: before restart '%s', after restart '%s'", out1, out2))
 
 	out, err = s.d.Cmd("stop", "top")
@@ -2773,7 +2773,7 @@ func (s *DockerDaemonSuite) TestRestartPolicyWithLiveRestore(c *testing.T) {
 		StartedAt time.Time
 	}
 	out, err = s.d.Cmd("inspect", "-f", "{{json .State}}", id)
-	assert.Assert(c, err == nil, fmt.Sprintf("output: %s", out))
+	assert.Assert(c, err == nil, "output: %s", out)
 
 	var origState state
 	err = json.Unmarshal([]byte(strings.TrimSpace(out)), &origState)
@@ -2799,7 +2799,7 @@ func (s *DockerDaemonSuite) TestRestartPolicyWithLiveRestore(c *testing.T) {
 		}
 
 		out, err := s.d.Cmd("inspect", "-f", "{{json .State}}", id)
-		assert.Assert(c, err == nil, fmt.Sprintf("output: %s", out))
+		assert.Assert(c, err == nil, "output: %s", out)
 
 		var newState state
 		err = json.Unmarshal([]byte(strings.TrimSpace(out)), &newState)

--- a/integration-cli/docker_cli_external_volume_driver_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_test.go
@@ -297,7 +297,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverNamed(c *testing.T) 
 	p := hostVolumePath("external-volume-test")
 	_, err = os.Lstat(p)
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, os.IsNotExist(err), fmt.Sprintf("Expected volume path in host to not exist: %s, %v\n", p, err))
+	assert.Assert(c, os.IsNotExist(err), "Expected volume path in host to not exist: %s, %v\n", p, err)
 
 	assert.Equal(c, s.ec.activations, 1)
 	assert.Equal(c, s.ec.creations, 1)

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -98,7 +98,7 @@ func (s *DockerSuite) TestHistoryHumanOptionFalse(c *testing.T) {
 		sizeString := lines[i][startIndex:endIndex]
 
 		_, err := strconv.Atoi(strings.TrimSpace(sizeString))
-		assert.Assert(c, err == nil, fmt.Sprintf("The size '%s' was not an Integer", sizeString))
+		assert.Assert(c, err == nil, "The size '%s' was not an Integer", sizeString)
 	}
 }
 

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -52,7 +52,7 @@ func (s *DockerSuite) TestInfoEnsureSucceeds(c *testing.T) {
 	}
 
 	for _, linePrefix := range stringsToCheck {
-		assert.Assert(c, strings.Contains(out, linePrefix), fmt.Sprintf("couldn't find string %v in output", linePrefix))
+		assert.Assert(c, strings.Contains(out, linePrefix), "couldn't find string %v in output", linePrefix)
 	}
 }
 

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -118,7 +118,7 @@ func (s *DockerSuite) TestInspectTypeFlagWithInvalidValue(c *testing.T) {
 	dockerCmd(c, "run", "--name=busybox", "-d", "busybox", "true")
 
 	out, exitCode, err := dockerCmdWithError("inspect", "--type=foobar", "busybox")
-	assert.Assert(c, err != nil, fmt.Sprintf("%d", exitCode))
+	assert.Assert(c, err != nil, "%d", exitCode)
 	assert.Equal(c, exitCode, 1, fmt.Sprintf("%s", err))
 	assert.Assert(c, strings.Contains(out, "not a valid value for --type"))
 }
@@ -129,7 +129,7 @@ func (s *DockerSuite) TestInspectImageFilterInt(c *testing.T) {
 	out := inspectField(c, imageTest, "Size")
 
 	size, err := strconv.Atoi(out)
-	assert.Assert(c, err == nil, fmt.Sprintf("failed to inspect size of the image: %s, %v", out, err))
+	assert.Assert(c, err == nil, "failed to inspect size of the image: %s, %v", out, err)
 
 	//now see if the size turns out to be the same
 	formatStr := fmt.Sprintf("--format={{eq .Size %d}}", size)
@@ -151,7 +151,7 @@ func (s *DockerSuite) TestInspectContainerFilterInt(c *testing.T) {
 	out = inspectField(c, id, "State.ExitCode")
 
 	exitCode, err := strconv.Atoi(out)
-	assert.Assert(c, err == nil, fmt.Sprintf("failed to inspect exitcode of the container: %s, %v", out, err))
+	assert.Assert(c, err == nil, "failed to inspect exitcode of the container: %s, %v", out, err)
 
 	//now get the exit code to verify
 	formatStr := fmt.Sprintf("--format={{eq .State.ExitCode %d}}", exitCode)
@@ -171,12 +171,12 @@ func (s *DockerSuite) TestInspectImageGraphDriver(c *testing.T) {
 	deviceID := inspectField(c, imageTest, "GraphDriver.Data.DeviceId")
 
 	_, err := strconv.Atoi(deviceID)
-	assert.Assert(c, err == nil, fmt.Sprintf("failed to inspect DeviceId of the image: %s, %v", deviceID, err))
+	assert.Assert(c, err == nil, "failed to inspect DeviceId of the image: %s, %v", deviceID, err)
 
 	deviceSize := inspectField(c, imageTest, "GraphDriver.Data.DeviceSize")
 
 	_, err = strconv.ParseUint(deviceSize, 10, 64)
-	assert.Assert(c, err == nil, fmt.Sprintf("failed to inspect DeviceSize of the image: %s, %v", deviceSize, err))
+	assert.Assert(c, err == nil, "failed to inspect DeviceSize of the image: %s, %v", deviceSize, err)
 }
 
 func (s *DockerSuite) TestInspectContainerGraphDriver(c *testing.T) {
@@ -196,12 +196,12 @@ func (s *DockerSuite) TestInspectContainerGraphDriver(c *testing.T) {
 	assert.Assert(c, imageDeviceID != deviceID)
 
 	_, err := strconv.Atoi(deviceID)
-	assert.Assert(c, err == nil, fmt.Sprintf("failed to inspect DeviceId of the image: %s, %v", deviceID, err))
+	assert.Assert(c, err == nil, "failed to inspect DeviceId of the image: %s, %v", deviceID, err)
 
 	deviceSize := inspectField(c, out, "GraphDriver.Data.DeviceSize")
 
 	_, err = strconv.ParseUint(deviceSize, 10, 64)
-	assert.Assert(c, err == nil, fmt.Sprintf("failed to inspect DeviceSize of the image: %s, %v", deviceSize, err))
+	assert.Assert(c, err == nil, "failed to inspect DeviceSize of the image: %s, %v", deviceSize, err)
 }
 
 func (s *DockerSuite) TestInspectBindMountPoint(c *testing.T) {
@@ -288,7 +288,7 @@ func (s *DockerSuite) TestInspectLogConfigNoType(c *testing.T) {
 	out := inspectFieldJSON(c, "test", "HostConfig.LogConfig")
 
 	err := json.NewDecoder(strings.NewReader(out)).Decode(&logConfig)
-	assert.Assert(c, err == nil, fmt.Sprintf("%v", out))
+	assert.Assert(c, err == nil, "%v", out)
 
 	assert.Equal(c, logConfig.Type, "json-file")
 	assert.Equal(c, logConfig.Config["max-file"], "42", fmt.Sprintf("%v", logConfig))

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -27,7 +27,7 @@ func (s *DockerSuite) TestLinksInvalidContainerTarget(c *testing.T) {
 	out, _, err := dockerCmdWithError("run", "--link", "bogus:alias", "busybox", "true")
 
 	// an invalid container target should produce an error
-	assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err != nil, "out: %s", out)
 	// an invalid container target should produce an error
 	// note: convert the output to lowercase first as the error string
 	// capitalization was changed after API version 1.32
@@ -169,7 +169,7 @@ func (s *DockerSuite) TestLinksUpdateOnRestart(c *testing.T) {
 	getIP := func(hosts []byte, hostname string) string {
 		re := regexp.MustCompile(fmt.Sprintf(`(\S*)\t%s`, regexp.QuoteMeta(hostname)))
 		matches := re.FindSubmatch(hosts)
-		assert.Assert(c, matches != nil, fmt.Sprintf("Hostname %s have no matches in hosts", hostname))
+		assert.Assert(c, matches != nil, "Hostname %s have no matches in hosts", hostname)
 		return string(matches[1])
 	}
 	ip := getIP(content, "one")
@@ -220,7 +220,7 @@ func (s *DockerSuite) TestLinksNetworkHostContainer(c *testing.T) {
 	out, _, err := dockerCmdWithError("run", "--name", "should_fail", "--link", "host_container:tester", "busybox", "true")
 
 	// Running container linking to a container with --net host should have failed
-	assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err != nil, "out: %s", out)
 	// Running container linking to a container with --net host should have failed
 	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictHostNetworkAndLinks.Error()))
 }

--- a/integration-cli/docker_cli_netmode_test.go
+++ b/integration-cli/docker_cli_netmode_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -20,7 +19,7 @@ const stringCheckPS = "PID   USER"
 // stop the tests.
 func dockerCmdWithFail(c *testing.T, args ...string) (string, int) {
 	out, status, err := dockerCmdWithError(args...)
-	assert.Assert(c, err != nil, fmt.Sprintf("%v", out))
+	assert.Assert(c, err != nil, "%v", out)
 	return out, status
 }
 

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -403,7 +403,7 @@ func (s *DockerSuite) TestDockerNetworkDeleteMultiple(c *testing.T) {
 	// contains active container, its deletion should fail.
 	out, _, err := dockerCmdWithError("network", "rm", "testDelMulti0", "testDelMulti1", "testDelMulti2")
 	// err should not be nil due to deleting testDelMulti2 failed.
-	assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err != nil, "out: %s", out)
 	// testDelMulti2 should fail due to network has active endpoints
 	assert.Assert(c, strings.Contains(out, "has active endpoints"))
 	assertNwNotAvailable(c, "testDelMulti0")
@@ -1298,7 +1298,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkConnectPreferredIP(c *testing.T) {
 
 	// Still it should fail to connect to the default network with a specified IP (whatever ip)
 	out, _, err := dockerCmdWithError("network", "connect", "--ip", "172.21.55.44", "bridge", "c0")
-	assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err != nil, "out: %s", out)
 	assert.Assert(c, strings.Contains(out, runconfig.ErrUnsupportedNetworkAndIP.Error()))
 }
 
@@ -1336,10 +1336,10 @@ func (s *DockerNetworkSuite) TestDockerNetworkUnsupportedRequiredIP(c *testing.T
 	assertNwIsAvailable(c, "n0")
 
 	out, _, err := dockerCmdWithError("run", "-d", "--ip", "172.28.99.88", "--net", "n0", "busybox", "top")
-	assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err != nil, "out: %s", out)
 	assert.Assert(c, strings.Contains(out, runconfig.ErrUnsupportedNetworkNoSubnetAndIP.Error()))
 	out, _, err = dockerCmdWithError("run", "-d", "--ip6", "2001:db8:1234::9988", "--net", "n0", "busybox", "top")
-	assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err != nil, "out: %s", out)
 	assert.Assert(c, strings.Contains(out, runconfig.ErrUnsupportedNetworkNoSubnetAndIP.Error()))
 	dockerCmd(c, "network", "rm", "n0")
 	assertNwNotAvailable(c, "n0")
@@ -1347,7 +1347,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkUnsupportedRequiredIP(c *testing.T
 
 func checkUnsupportedNetworkAndIP(c *testing.T, nwMode string) {
 	out, _, err := dockerCmdWithError("run", "-d", "--net", nwMode, "--ip", "172.28.99.88", "--ip6", "2001:db8:1234::9988", "busybox", "top")
-	assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err != nil, "out: %s", out)
 	assert.Assert(c, strings.Contains(out, runconfig.ErrUnsupportedNetworkAndIP.Error()))
 }
 
@@ -1474,8 +1474,8 @@ func (s *DockerNetworkSuite) TestDockerNetworkDisconnectDefault(c *testing.T) {
 	dockerCmd(c, "start", containerName)
 	assert.Assert(c, waitRun(containerName) == nil)
 	networks := inspectField(c, containerName, "NetworkSettings.Networks")
-	assert.Assert(c, strings.Contains(networks, netWorkName1), fmt.Sprintf(fmt.Sprintf("Should contain '%s' network", netWorkName1)))
-	assert.Assert(c, strings.Contains(networks, netWorkName2), fmt.Sprintf(fmt.Sprintf("Should contain '%s' network", netWorkName2)))
+	assert.Assert(c, strings.Contains(networks, netWorkName1), fmt.Sprintf("Should contain '%s' network", netWorkName1))
+	assert.Assert(c, strings.Contains(networks, netWorkName2), fmt.Sprintf("Should contain '%s' network", netWorkName2))
 	assert.Assert(c, !strings.Contains(networks, "bridge"), "Should not contain 'bridge' network")
 }
 
@@ -1538,11 +1538,11 @@ func (s *DockerSuite) TestUserDefinedNetworkConnectDisconnectAlias(c *testing.T)
 
 	// verify the alias option is rejected when running on predefined network
 	out, _, err := dockerCmdWithError("run", "--rm", "--name=any", "--net-alias=any", "busybox:glibc", "top")
-	assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err != nil, "out: %s", out)
 	assert.Assert(c, strings.Contains(out, runconfig.ErrUnsupportedNetworkAndAlias.Error()))
 	// verify the alias option is rejected when connecting to predefined network
 	out, _, err = dockerCmdWithError("network", "connect", "--alias=any", "bridge", "first")
-	assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err != nil, "out: %s", out)
 	assert.Assert(c, strings.Contains(out, runconfig.ErrUnsupportedNetworkAndAlias.Error()))
 }
 

--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -428,7 +428,7 @@ func (s *DockerSuite) TestPluginUpgrade(c *testing.T) {
 
 	// make sure "v2" does not exists
 	_, err = os.Stat(filepath.Join(testEnv.DaemonInfo.DockerRootDir, "plugins", id, "rootfs", "v2"))
-	assert.Assert(c, os.IsNotExist(err), fmt.Sprintf("%s", out))
+	assert.Assert(c, os.IsNotExist(err), "%s", out)
 
 	dockerCmd(c, "plugin", "disable", "-f", plugin)
 	dockerCmd(c, "plugin", "upgrade", "--grant-all-permissions", "--skip-remote-check", plugin, pluginV2)

--- a/integration-cli/docker_cli_port_test.go
+++ b/integration-cli/docker_cli_port_test.go
@@ -104,7 +104,7 @@ func (s *DockerSuite) TestPortList(c *testing.T) {
 			"-p", "9090-9092:80",
 			"busybox", "top")
 		// Exhausted port range did not return an error
-		assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+		assert.Assert(c, err != nil, "out: %s", out)
 
 		for i := 0; i < 3; i++ {
 			dockerCmd(c, "rm", "-f", IDs[i])
@@ -120,7 +120,7 @@ func (s *DockerSuite) TestPortList(c *testing.T) {
 			"-p", invalidRange,
 			"busybox", "top")
 		// Port range should have returned an error
-		assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+		assert.Assert(c, err != nil, "out: %s", out)
 	}
 
 	// test host range:container range spec.
@@ -299,7 +299,7 @@ func (s *DockerSuite) TestPortHostBinding(c *testing.T) {
 
 	out, _, err = dockerCmdWithError("run", "--net=host", "busybox", "nc", "localhost", "9876")
 	// Port is still bound after the Container is removed
-	assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err != nil, "out: %s", out)
 }
 
 func (s *DockerSuite) TestPortExposeHostBinding(c *testing.T) {
@@ -311,7 +311,7 @@ func (s *DockerSuite) TestPortExposeHostBinding(c *testing.T) {
 	out, _ = dockerCmd(c, "port", firstID, "80")
 
 	_, exposedPort, err := net.SplitHostPort(out)
-	assert.Assert(c, err == nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err == nil, "out: %s", out)
 
 	dockerCmd(c, "run", "--net=host", "busybox",
 		"nc", "localhost", strings.TrimSpace(exposedPort))
@@ -321,7 +321,7 @@ func (s *DockerSuite) TestPortExposeHostBinding(c *testing.T) {
 	out, _, err = dockerCmdWithError("run", "--net=host", "busybox",
 		"nc", "localhost", strings.TrimSpace(exposedPort))
 	// Port is still bound after the Container is removed
-	assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err != nil, "out: %s", out)
 }
 
 func (s *DockerSuite) TestPortBindingOnSandbox(c *testing.T) {

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -175,7 +175,7 @@ func (s *DockerSuite) TestPsListContainersSize(c *testing.T) {
 	assert.Equal(c, foundID, id[:12], fmt.Sprintf("Expected id %s, got %s", id[:12], foundID))
 	expectedSize := fmt.Sprintf("%dB", 2+baseBytes)
 	foundSize := lines[1][sizeIndex:]
-	assert.Assert(c, strings.Contains(foundSize, expectedSize), fmt.Sprintf("Expected size %q, got %q", expectedSize, foundSize))
+	assert.Assert(c, strings.Contains(foundSize, expectedSize), "Expected size %q, got %q", expectedSize, foundSize)
 }
 
 func (s *DockerSuite) TestPsListContainersFilterStatus(c *testing.T) {
@@ -442,11 +442,11 @@ func (s *DockerSuite) TestPsListContainersFilterExited(c *testing.T) {
 	secondZero, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 
 	out, _, err := dockerCmdWithError("run", "--name", "nonzero1", "busybox", "false")
-	assert.Assert(c, err != nil, fmt.Sprintf("Should fail. out: %s", out))
+	assert.Assert(c, err != nil, "Should fail. out: %s", out)
 	firstNonZero := getIDByName(c, "nonzero1")
 
 	out, _, err = dockerCmdWithError("run", "--name", "nonzero2", "busybox", "false")
-	assert.Assert(c, err != nil, fmt.Sprintf("Should fail. out: %s", out))
+	assert.Assert(c, err != nil, "Should fail. out: %s", out)
 	secondNonZero := getIDByName(c, "nonzero2")
 
 	// filter containers by exited=0
@@ -516,7 +516,7 @@ func (s *DockerSuite) TestPsListContainersFilterCreated(c *testing.T) {
 
 	// Make sure it DOESN'T show up w/o a '-a' for normal 'ps'
 	out, _ = dockerCmd(c, "ps", "-q")
-	assert.Assert(c, !strings.Contains(out, shortCID), fmt.Sprintf("Should have not seen '%s' in ps output:\n%s", shortCID, out))
+	assert.Assert(c, !strings.Contains(out, shortCID), "Should have not seen '%s' in ps output:\n%s", shortCID, out)
 	// Make sure it DOES show up as 'Created' for 'ps -a'
 	out, _ = dockerCmd(c, "ps", "-a")
 
@@ -526,7 +526,7 @@ func (s *DockerSuite) TestPsListContainersFilterCreated(c *testing.T) {
 			continue
 		}
 		hits++
-		assert.Assert(c, strings.Contains(line, "Created"), fmt.Sprintf("Missing 'Created' on '%s'", line))
+		assert.Assert(c, strings.Contains(line, "Created"), "Missing 'Created' on '%s'", line)
 	}
 
 	assert.Equal(c, hits, 1, fmt.Sprintf("Should have seen '%s' in ps -a output once:%d\n%s", shortCID, hits, out))
@@ -602,7 +602,7 @@ func (s *DockerSuite) TestPsNotShowPortsOfStoppedContainer(c *testing.T) {
 	out, _ = dockerCmd(c, "ps", "-l")
 	lines = strings.Split(strings.TrimSpace(string(out)), "\n")
 	fields = strings.Fields(lines[1])
-	assert.Assert(c, fields[len(fields)-2] != expected, fmt.Sprintf("Should not got %v", expected))
+	assert.Assert(c, fields[len(fields)-2] != expected, "Should not got %v", expected)
 }
 
 func (s *DockerSuite) TestPsShowMounts(c *testing.T) {

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -26,7 +26,7 @@ func (s *DockerSuite) TestRmiWithContainerFails(c *testing.T) {
 	// Container is using image, should not be able to rmi
 	assert.ErrorContains(c, err, "")
 	// Container is using image, error message should contain errSubstr
-	assert.Assert(c, strings.Contains(out, errSubstr), fmt.Sprintf("Container: %q", cleanedContainerID))
+	assert.Assert(c, strings.Contains(out, errSubstr), "Container: %q", cleanedContainerID)
 	// make sure it didn't delete the busybox name
 	images, _ := dockerCmd(c, "images")
 	// The name 'busybox' should not have been removed from images
@@ -99,7 +99,7 @@ func (s *DockerSuite) TestRmiImgIDMultipleTag(c *testing.T) {
 
 	imagesAfter = cli.DockerCmd(c, "images", "-a").Combined()
 	// rmi -f failed, image still exists
-	assert.Assert(c, !strings.Contains(imagesAfter, imgID[:12]), fmt.Sprintf("ImageID:%q; ImagesAfter: %q", imgID, imagesAfter))
+	assert.Assert(c, !strings.Contains(imagesAfter, imgID[:12]), "ImageID:%q; ImagesAfter: %q", imgID, imagesAfter)
 }
 
 func (s *DockerSuite) TestRmiImgIDForce(c *testing.T) {
@@ -209,7 +209,7 @@ func (s *DockerSuite) TestRmiForceWithMultipleRepositories(c *testing.T) {
 	assert.Assert(c, !strings.Contains(out, "Untagged: "+tag1))
 	// Check built image still exists
 	images, _ := dockerCmd(c, "images", "-a")
-	assert.Assert(c, strings.Contains(images, imageName), fmt.Sprintf("Built image missing %q; Images: %q", imageName, images))
+	assert.Assert(c, strings.Contains(images, imageName), "Built image missing %q; Images: %q", imageName, images)
 }
 
 func (s *DockerSuite) TestRmiBlank(c *testing.T) {
@@ -217,9 +217,9 @@ func (s *DockerSuite) TestRmiBlank(c *testing.T) {
 	// Should have failed to delete ' ' image
 	assert.ErrorContains(c, err, "")
 	// Wrong error message generated
-	assert.Assert(c, !strings.Contains(out, "no such id"), fmt.Sprintf("out: %s", out))
+	assert.Assert(c, !strings.Contains(out, "no such id"), "out: %s", out)
 	// Expected error message not generated
-	assert.Assert(c, strings.Contains(out, "image name cannot be blank"), fmt.Sprintf("out: %s", out))
+	assert.Assert(c, strings.Contains(out, "image name cannot be blank"), "out: %s", out)
 }
 
 func (s *DockerSuite) TestRmiContainerImageNotFound(c *testing.T) {
@@ -244,7 +244,7 @@ func (s *DockerSuite) TestRmiContainerImageNotFound(c *testing.T) {
 	out, _, err := dockerCmdWithError("rmi", "-f", imageIds[0])
 	// The image of the running container should not be removed.
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "image is being used by running container"), fmt.Sprintf("out: %s", out))
+	assert.Assert(c, strings.Contains(out, "image is being used by running container"), "out: %s", out)
 }
 
 // #13422

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3210,7 +3210,7 @@ func (s *DockerSuite) TestRunCreateContainerFailedCleanUp(c *testing.T) {
 	assert.Assert(c, err != nil, "Expected docker run to fail!")
 
 	containerID, err := inspectFieldWithError(name, "Id")
-	assert.Assert(c, err != nil, fmt.Sprintf("Expected not to have this container: %s!", containerID))
+	assert.Assert(c, err != nil, "Expected not to have this container: %s!", containerID)
 	assert.Equal(c, containerID, "", fmt.Sprintf("Expected not to have this container: %s!", containerID))
 }
 
@@ -3946,7 +3946,7 @@ func (s *DockerSuite) TestRunAttachFailedNoLeak(c *testing.T) {
 	// We will need the following `inspect` to diagnose the issue if test fails (#21247)
 	out1, err1 := dockerCmd(c, "inspect", "--format", "{{json .State}}", "test")
 	out2, err2 := dockerCmd(c, "inspect", "--format", "{{json .State}}", "fail")
-	assert.Assert(c, err != nil, fmt.Sprintf("Command should have failed but succeeded with: %s\nContainer 'test' [%+v]: %s\nContainer 'fail' [%+v]: %s", out, err1, out1, err2, out2))
+	assert.Assert(c, err != nil, "Command should have failed but succeeded with: %s\nContainer 'test' [%+v]: %s\nContainer 'fail' [%+v]: %s", out, err1, out1, err2, out2)
 	// check for windows error as well
 	// TODO Windows Post TP5. Fix the error message string
 	assert.Assert(c, strings.Contains(string(out), "port is already allocated") ||
@@ -4032,9 +4032,9 @@ func (s *DockerSuite) TestRunDNSInHostMode(c *testing.T) {
 	expectedOutput2 := "search example.com"
 	expectedOutput3 := "options timeout:3"
 	out := cli.DockerCmd(c, "run", "--dns=1.2.3.4", "--dns-search=example.com", "--dns-opt=timeout:3", "--net=host", "busybox", "cat", "/etc/resolv.conf").Combined()
-	assert.Assert(c, strings.Contains(out, expectedOutput1), fmt.Sprintf("Expected '%s', but got %q", expectedOutput1, out))
-	assert.Assert(c, strings.Contains(out, expectedOutput2), fmt.Sprintf("Expected '%s', but got %q", expectedOutput2, out))
-	assert.Assert(c, strings.Contains(out, expectedOutput3), fmt.Sprintf("Expected '%s', but got %q", expectedOutput3, out))
+	assert.Assert(c, strings.Contains(out, expectedOutput1), "Expected '%s', but got %q", expectedOutput1, out)
+	assert.Assert(c, strings.Contains(out, expectedOutput2), "Expected '%s', but got %q", expectedOutput2, out)
+	assert.Assert(c, strings.Contains(out, expectedOutput3), "Expected '%s', but got %q", expectedOutput3, out)
 }
 
 // Test case for #21976
@@ -4043,14 +4043,14 @@ func (s *DockerSuite) TestRunAddHostInHostMode(c *testing.T) {
 
 	expectedOutput := "1.2.3.4\textra"
 	out, _ := dockerCmd(c, "run", "--add-host=extra:1.2.3.4", "--net=host", "busybox", "cat", "/etc/hosts")
-	assert.Assert(c, strings.Contains(out, expectedOutput), fmt.Sprintf("Expected '%s', but got %q", expectedOutput, out))
+	assert.Assert(c, strings.Contains(out, expectedOutput), "Expected '%s', but got %q", expectedOutput, out)
 }
 
 func (s *DockerSuite) TestRunRmAndWait(c *testing.T) {
 	dockerCmd(c, "run", "--name=test", "--rm", "-d", "busybox", "sh", "-c", "sleep 3;exit 2")
 
 	out, code, err := dockerCmdWithError("wait", "test")
-	assert.Assert(c, err == nil, fmt.Sprintf("out: %s; exit code: %d", out, code))
+	assert.Assert(c, err == nil, "out: %s; exit code: %d", out, code)
 	assert.Equal(c, out, "2\n", "exit code: %d", code)
 	assert.Equal(c, code, 0)
 }
@@ -4136,7 +4136,7 @@ func (s *DockerSuite) TestRunStoppedLoggingDriverNoLeak(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("run", "--name=fail", "--log-driver=splunk", "busybox", "true")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "failed to initialize logging driver"), fmt.Sprintf("error should be about logging driver, got output %s", out))
+	assert.Assert(c, strings.Contains(out, "failed to initialize logging driver"), "error should be about logging driver, got output %s", out)
 	// NGoroutines is not updated right away, so we need to wait before failing
 	assert.Assert(c, waitForGoroutines(nroutines) == nil)
 }
@@ -4156,8 +4156,8 @@ func (s *DockerSuite) TestRunCredentialSpecFailures(c *testing.T) {
 	}
 	for _, attempt := range attempts {
 		_, _, err := dockerCmdWithError("run", "--security-opt=credentialspec="+attempt.value, "busybox", "true")
-		assert.Assert(c, err != nil, fmt.Sprintf("%s expected non-nil err", attempt.value))
-		assert.Assert(c, strings.Contains(err.Error(), attempt.expectedError), fmt.Sprintf("%s expected %s got %s", attempt.value, attempt.expectedError, err))
+		assert.Assert(c, err != nil, "%s expected non-nil err", attempt.value)
+		assert.Assert(c, strings.Contains(err.Error(), attempt.expectedError), "%s expected %s got %s", attempt.value, attempt.expectedError, err)
 	}
 }
 
@@ -4488,11 +4488,11 @@ func (s *DockerSuite) TestRunMount(c *testing.T) {
 			_, _, err := dockerCmdWithError(append([]string{"run", "-i", "-d", "--name", cName},
 				append(opts, []string{"busybox", "top"}...)...)...)
 			if testCase.valid {
-				assert.Assert(c, err == nil, fmt.Sprintf("got error while creating a container with %v (%s)", opts, cName))
-				assert.Assert(c, testCase.fn(cName) == nil, fmt.Sprintf("got error while executing test for %v (%s)", opts, cName))
+				assert.Assert(c, err == nil, "got error while creating a container with %v (%s)", opts, cName)
+				assert.Assert(c, testCase.fn(cName) == nil, "got error while executing test for %v (%s)", opts, cName)
 				dockerCmd(c, "rm", "-f", cName)
 			} else {
-				assert.Assert(c, err != nil, fmt.Sprintf("got nil while creating a container with %v (%s)", opts, cName))
+				assert.Assert(c, err != nil, "got nil while creating a container with %v (%s)", opts, cName)
 			}
 		}
 	}

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -69,8 +69,8 @@ func (s *DockerSuite) TestRunWithVolumesIsRecursive(c *testing.T) {
 
 	// Create a temporary tmpfs mount.
 	tmpfsDir := filepath.Join(tmpDir, "tmpfs")
-	assert.Assert(c, os.MkdirAll(tmpfsDir, 0777) == nil, fmt.Sprintf("failed to mkdir at %s", tmpfsDir))
-	assert.Assert(c, mount.Mount("tmpfs", tmpfsDir, "tmpfs", "") == nil, fmt.Sprintf("failed to create a tmpfs mount at %s", tmpfsDir))
+	assert.Assert(c, os.MkdirAll(tmpfsDir, 0777) == nil, "failed to mkdir at %s", tmpfsDir)
+	assert.Assert(c, mount.Mount("tmpfs", tmpfsDir, "tmpfs", "") == nil, "failed to create a tmpfs mount at %s", tmpfsDir)
 
 	f, err := ioutil.TempFile(tmpfsDir, "touch-me")
 	assert.NilError(c, err)
@@ -671,10 +671,10 @@ func (s *DockerSuite) TestRunWithSwappinessInvalid(c *testing.T) {
 	out, _, err := dockerCmdWithError("run", "--memory-swappiness", "101", "busybox", "true")
 	assert.ErrorContains(c, err, "")
 	expected := "Valid memory swappiness range is 0-100"
-	assert.Assert(c, strings.Contains(out, expected), fmt.Sprintf("Expected output to contain %q, not %q", out, expected))
+	assert.Assert(c, strings.Contains(out, expected), "Expected output to contain %q, not %q", out, expected)
 	out, _, err = dockerCmdWithError("run", "--memory-swappiness", "-10", "busybox", "true")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, expected), fmt.Sprintf("Expected output to contain %q, not %q", out, expected))
+	assert.Assert(c, strings.Contains(out, expected), "Expected output to contain %q, not %q", out, expected)
 }
 
 func (s *DockerSuite) TestRunWithMemoryReservation(c *testing.T) {

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -136,13 +136,13 @@ func (s *DockerSuite) TestSaveImageId(c *testing.T) {
 
 	var err error
 	tarCmd.Stdin, err = saveCmd.StdoutPipe()
-	assert.Assert(c, err == nil, fmt.Sprintf("cannot set stdout pipe for tar: %v", err))
+	assert.Assert(c, err == nil, "cannot set stdout pipe for tar: %v", err)
 	grepCmd := exec.Command("grep", cleanedLongImageID)
 	grepCmd.Stdin, err = tarCmd.StdoutPipe()
-	assert.Assert(c, err == nil, fmt.Sprintf("cannot set stdout pipe for grep: %v", err))
+	assert.Assert(c, err == nil, "cannot set stdout pipe for grep: %v", err)
 
-	assert.Assert(c, tarCmd.Start() == nil, fmt.Sprintf("tar failed with error: %v", err))
-	assert.Assert(c, saveCmd.Start() == nil, fmt.Sprintf("docker save failed with error: %v", err))
+	assert.Assert(c, tarCmd.Start() == nil, "tar failed with error: %v", err)
+	assert.Assert(c, saveCmd.Start() == nil, "docker save failed with error: %v", err)
 	defer func() {
 		saveCmd.Wait()
 		tarCmd.Wait()
@@ -151,7 +151,7 @@ func (s *DockerSuite) TestSaveImageId(c *testing.T) {
 
 	out, _, err = runCommandWithOutput(grepCmd)
 
-	assert.Assert(c, err == nil, fmt.Sprintf("failed to save repo with image ID: %s, %v", out, err))
+	assert.Assert(c, err == nil, "failed to save repo with image ID: %s, %v", out, err)
 }
 
 // save a repo and try to load it using flags
@@ -263,7 +263,7 @@ func (s *DockerSuite) TestSaveDirectoryPermissions(c *testing.T) {
 
 	name := "save-directory-permissions"
 	tmpDir, err := ioutil.TempDir("", "save-layers-with-directories")
-	assert.Assert(c, err == nil, fmt.Sprintf("failed to create temporary directory: %s", err))
+	assert.Assert(c, err == nil, "failed to create temporary directory: %s", err)
 	extractionDirectory := filepath.Join(tmpDir, "image-extraction-dir")
 	os.Mkdir(extractionDirectory, 0777)
 

--- a/integration-cli/docker_cli_service_create_test.go
+++ b/integration-cli/docker_cli_service_create_test.go
@@ -76,7 +76,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithSecretSimple(c *testing.T) {
 		},
 		Data: []byte("TESTINGDATA"),
 	})
-	assert.Assert(c, id != "", fmt.Sprintf("secrets: %s", id))
+	assert.Assert(c, id != "", "secrets: %s", id)
 
 	out, err := d.Cmd("service", "create", "--detach", "--no-resolve-image", "--name", serviceName, "--secret", testName, "busybox", "top")
 	assert.NilError(c, err, out)
@@ -118,7 +118,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithSecretSourceTargetPaths(c *testi
 			},
 			Data: []byte("TESTINGDATA " + testName + " " + testTarget),
 		})
-		assert.Assert(c, id != "", fmt.Sprintf("secrets: %s", id))
+		assert.Assert(c, id != "", "secrets: %s", id)
 
 		secretFlags = append(secretFlags, "--secret", fmt.Sprintf("source=%s,target=%s", testName, testTarget))
 	}
@@ -174,7 +174,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithSecretReferencedTwice(c *testing
 		},
 		Data: []byte("TESTINGDATA"),
 	})
-	assert.Assert(c, id != "", fmt.Sprintf("secrets: %s", id))
+	assert.Assert(c, id != "", "secrets: %s", id)
 
 	serviceName := "svc"
 	out, err := d.Cmd("service", "create", "--detach", "--no-resolve-image", "--name", serviceName, "--secret", "source=mysecret,target=target1", "--secret", "source=mysecret,target=target2", "busybox", "top")
@@ -224,7 +224,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithConfigSimple(c *testing.T) {
 		},
 		Data: []byte("TESTINGDATA"),
 	})
-	assert.Assert(c, id != "", fmt.Sprintf("configs: %s", id))
+	assert.Assert(c, id != "", "configs: %s", id)
 
 	out, err := d.Cmd("service", "create", "--detach", "--no-resolve-image", "--name", serviceName, "--config", testName, "busybox", "top")
 	assert.NilError(c, err, out)
@@ -265,7 +265,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithConfigSourceTargetPaths(c *testi
 			},
 			Data: []byte("TESTINGDATA " + testName + " " + testTarget),
 		})
-		assert.Assert(c, id != "", fmt.Sprintf("configs: %s", id))
+		assert.Assert(c, id != "", "configs: %s", id)
 
 		configFlags = append(configFlags, "--config", fmt.Sprintf("source=%s,target=%s", testName, testTarget))
 	}
@@ -321,7 +321,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithConfigReferencedTwice(c *testing
 		},
 		Data: []byte("TESTINGDATA"),
 	})
-	assert.Assert(c, id != "", fmt.Sprintf("configs: %s", id))
+	assert.Assert(c, id != "", "configs: %s", id)
 
 	serviceName := "svc"
 	out, err := d.Cmd("service", "create", "--detach", "--no-resolve-image", "--name", serviceName, "--config", "source=myconfig,target=target1", "--config", "source=myconfig,target=target2", "busybox", "top")

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -20,7 +20,7 @@ func (s *DockerSuite) TestStartAttachReturnsOnError(c *testing.T) {
 	// Expect this to fail because the above container is stopped, this is what we want
 	out, _, err := dockerCmdWithError("run", "--name", "test2", "--link", "test:test", "busybox")
 	// err shouldn't be nil because container test2 try to link to stopped container
-	assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err != nil, "out: %s", out)
 
 	ch := make(chan error)
 	go func() {
@@ -78,7 +78,7 @@ func (s *DockerSuite) TestStartRecordError(c *testing.T) {
 	// Expect this to fail and records error because of ports conflict
 	out, _, err := dockerCmdWithError("run", "-d", "--name", "test2", "-p", "9999:9999", "busybox", "top")
 	// err shouldn't be nil because docker run will fail
-	assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err != nil, "out: %s", out)
 
 	stateErr = inspectField(c, "test2", "State.Error")
 	assert.Assert(c, strings.Contains(stateErr, "port is already allocated"))
@@ -100,7 +100,7 @@ func (s *DockerSuite) TestStartPausedContainer(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("start", "testing")
 	// an error should have been shown that you cannot start paused container
-	assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err != nil, "out: %s", out)
 	// an error should have been shown that you cannot start paused container
 	assert.Assert(c, strings.Contains(strings.ToLower(out), "cannot start a paused container, try unpause instead"))
 }
@@ -128,7 +128,7 @@ func (s *DockerSuite) TestStartMultipleContainers(c *testing.T) {
 	expErr := "failed to start containers: [child_first]"
 	out, _, err := dockerCmdWithError("start", "child_first", "parent", "child_second")
 	// err shouldn't be nil because start will fail
-	assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+	assert.Assert(c, err != nil, "out: %s", out)
 	// output does not correspond to what was expected
 	if !(strings.Contains(out, expOut) || strings.Contains(err.Error(), expErr)) {
 		c.Fatalf("Expected out: %v with err: %v  but got out: %v with err: %v", expOut, expErr, out, err)
@@ -156,7 +156,7 @@ func (s *DockerSuite) TestStartAttachMultipleContainers(c *testing.T) {
 	for _, option := range []string{"-a", "-i", "-ai"} {
 		out, _, err := dockerCmdWithError("start", option, "test1", "test2", "test3")
 		// err shouldn't be nil because start will fail
-		assert.Assert(c, err != nil, fmt.Sprintf("out: %s", out))
+		assert.Assert(c, err != nil, "out: %s", out)
 		// output does not correspond to what was expected
 		assert.Assert(c, strings.Contains(out, "you cannot start and attach multiple containers at once"))
 	}

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -171,7 +171,7 @@ func (s *DockerSwarmSuite) TestSwarmIncompatibleDaemon(c *testing.T) {
 func (s *DockerSwarmSuite) TestSwarmServiceTemplatingHostname(c *testing.T) {
 	d := s.AddDaemon(c, true, true)
 	hostname, err := d.Cmd("node", "inspect", "--format", "{{.Description.Hostname}}", "self")
-	assert.Assert(c, err == nil, fmt.Sprintf("%s", hostname))
+	assert.Assert(c, err == nil, "%s", hostname)
 
 	out, err := d.Cmd("service", "create", "--detach", "--no-resolve-image", "--name", "test", "--hostname", "{{.Service.Name}}-{{.Task.Slot}}-{{.Node.Hostname}}", "busybox", "top")
 	assert.NilError(c, err, out)
@@ -614,7 +614,7 @@ func (s *DockerSwarmSuite) TestPsListContainersFilterIsTask(c *testing.T) {
 	assert.NilError(c, err, out)
 	lines := strings.Split(strings.Trim(out, "\n "), "\n")
 	assert.Equal(c, len(lines), 1)
-	assert.Assert(c, lines[0] != bareID, fmt.Sprintf("Expected not %s, but got it for is-task label, output %q", bareID, out))
+	assert.Assert(c, lines[0] != bareID, "Expected not %s, but got it for is-task label, output %q", bareID, out)
 }
 
 const globalNetworkPlugin = "global-network-plugin"
@@ -847,7 +847,7 @@ func (s *DockerSwarmSuite) TestSwarmServiceTTY(c *testing.T) {
 
 	out, err = d.Cmd("exec", id, "cat", "/status")
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, expectedOutput), fmt.Sprintf("Expected '%s', but got %q", expectedOutput, out))
+	assert.Assert(c, strings.Contains(out, expectedOutput), "Expected '%s', but got %q", expectedOutput, out)
 	// Remove service
 	out, err = d.Cmd("service", "rm", name)
 	assert.NilError(c, err, out)
@@ -869,7 +869,7 @@ func (s *DockerSwarmSuite) TestSwarmServiceTTY(c *testing.T) {
 
 	out, err = d.Cmd("exec", id, "cat", "/status")
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, expectedOutput), fmt.Sprintf("Expected '%s', but got %q", expectedOutput, out))
+	assert.Assert(c, strings.Contains(out, expectedOutput), "Expected '%s', but got %q", expectedOutput, out)
 }
 
 func (s *DockerSwarmSuite) TestSwarmServiceTTYUpdate(c *testing.T) {
@@ -954,9 +954,9 @@ func (s *DockerSwarmSuite) TestDNSConfig(c *testing.T) {
 	expectedOutput3 := "options timeout:3"
 	out, err = d.Cmd("exec", id, "cat", "/etc/resolv.conf")
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, expectedOutput1), fmt.Sprintf("Expected '%s', but got %q", expectedOutput1, out))
-	assert.Assert(c, strings.Contains(out, expectedOutput2), fmt.Sprintf("Expected '%s', but got %q", expectedOutput2, out))
-	assert.Assert(c, strings.Contains(out, expectedOutput3), fmt.Sprintf("Expected '%s', but got %q", expectedOutput3, out))
+	assert.Assert(c, strings.Contains(out, expectedOutput1), "Expected '%s', but got %q", expectedOutput1, out)
+	assert.Assert(c, strings.Contains(out, expectedOutput2), "Expected '%s', but got %q", expectedOutput2, out)
+	assert.Assert(c, strings.Contains(out, expectedOutput3), "Expected '%s', but got %q", expectedOutput3, out)
 }
 
 func (s *DockerSwarmSuite) TestDNSConfigUpdate(c *testing.T) {
@@ -1043,7 +1043,7 @@ func (s *DockerSwarmSuite) TestSwarmInitLocked(c *testing.T) {
 	d := s.AddDaemon(c, false, false)
 
 	outs, err := d.Cmd("swarm", "init", "--autolock")
-	assert.Assert(c, err == nil, fmt.Sprintf("%s", outs))
+	assert.Assert(c, err == nil, "%s", outs)
 	unlockKey := getUnlockKey(d, c, outs)
 
 	assert.Equal(c, getNodeStatus(c, d), swarm.LocalNodeStateActive)
@@ -1068,15 +1068,15 @@ func (s *DockerSwarmSuite) TestSwarmInitLocked(c *testing.T) {
 	assert.Equal(c, getNodeStatus(c, d), swarm.LocalNodeStateActive)
 
 	outs, err = d.Cmd("node", "ls")
-	assert.Assert(c, err == nil, fmt.Sprintf("%s", outs))
+	assert.Assert(c, err == nil, "%s", outs)
 	assert.Assert(c, !strings.Contains(outs, "Swarm is encrypted and needs to be unlocked"))
 	outs, err = d.Cmd("swarm", "update", "--autolock=false")
-	assert.Assert(c, err == nil, fmt.Sprintf("%s", outs))
+	assert.Assert(c, err == nil, "%s", outs)
 
 	checkSwarmLockedToUnlocked(c, d)
 
 	outs, err = d.Cmd("node", "ls")
-	assert.Assert(c, err == nil, fmt.Sprintf("%s", outs))
+	assert.Assert(c, err == nil, "%s", outs)
 	assert.Assert(c, !strings.Contains(outs, "Swarm is encrypted and needs to be unlocked"))
 }
 
@@ -1084,7 +1084,7 @@ func (s *DockerSwarmSuite) TestSwarmLeaveLocked(c *testing.T) {
 	d := s.AddDaemon(c, false, false)
 
 	outs, err := d.Cmd("swarm", "init", "--autolock")
-	assert.Assert(c, err == nil, fmt.Sprintf("%s", outs))
+	assert.Assert(c, err == nil, "%s", outs)
 
 	// It starts off locked
 	d.RestartNode(c)
@@ -1099,13 +1099,13 @@ func (s *DockerSwarmSuite) TestSwarmLeaveLocked(c *testing.T) {
 	assert.Assert(c, strings.Contains(outs, "Swarm is encrypted and locked."))
 	// It is OK for user to leave a locked swarm with --force
 	outs, err = d.Cmd("swarm", "leave", "--force")
-	assert.Assert(c, err == nil, fmt.Sprintf("%s", outs))
+	assert.Assert(c, err == nil, "%s", outs)
 
 	info = d.SwarmInfo(c)
 	assert.Equal(c, info.LocalNodeState, swarm.LocalNodeStateInactive)
 
 	outs, err = d.Cmd("swarm", "init")
-	assert.Assert(c, err == nil, fmt.Sprintf("%s", outs))
+	assert.Assert(c, err == nil, "%s", outs)
 
 	info = d.SwarmInfo(c)
 	assert.Equal(c, info.LocalNodeState, swarm.LocalNodeStateActive)
@@ -1125,7 +1125,7 @@ func (s *DockerSwarmSuite) TestSwarmLockUnlockCluster(c *testing.T) {
 
 	// enable autolock
 	outs, err := d1.Cmd("swarm", "update", "--autolock")
-	assert.Assert(c, err == nil, fmt.Sprintf("%s", outs))
+	assert.Assert(c, err == nil, "%s", outs)
 	unlockKey := getUnlockKey(d1, c, outs)
 
 	// The ones that got the cluster update should be set to locked
@@ -1147,7 +1147,7 @@ func (s *DockerSwarmSuite) TestSwarmLockUnlockCluster(c *testing.T) {
 
 	// leave it locked, and set the cluster to no longer autolock
 	outs, err = d1.Cmd("swarm", "update", "--autolock=false")
-	assert.Assert(c, err == nil, fmt.Sprintf("out: %v", outs))
+	assert.Assert(c, err == nil, "out: %v", outs)
 
 	// the ones that got the update are now set to unlocked
 	for _, d := range []*daemon.Daemon{d1, d3} {
@@ -1177,7 +1177,7 @@ func (s *DockerSwarmSuite) TestSwarmJoinPromoteLocked(c *testing.T) {
 
 	// enable autolock
 	outs, err := d1.Cmd("swarm", "update", "--autolock")
-	assert.Assert(c, err == nil, fmt.Sprintf("out: %v", outs))
+	assert.Assert(c, err == nil, "out: %v", outs)
 	unlockKey := getUnlockKey(d1, c, outs)
 
 	// joined workers start off unlocked
@@ -1233,13 +1233,13 @@ func (s *DockerSwarmSuite) TestSwarmRotateUnlockKey(c *testing.T) {
 	d := s.AddDaemon(c, true, true)
 
 	outs, err := d.Cmd("swarm", "update", "--autolock")
-	assert.Assert(c, err == nil, fmt.Sprintf("out: %v", outs))
+	assert.Assert(c, err == nil, "out: %v", outs)
 	unlockKey := getUnlockKey(d, c, outs)
 
 	// Rotate multiple times
 	for i := 0; i != 3; i++ {
 		outs, err = d.Cmd("swarm", "unlock-key", "-q", "--rotate")
-		assert.Assert(c, err == nil, fmt.Sprintf("out: %v", outs))
+		assert.Assert(c, err == nil, "out: %v", outs)
 		// Strip \n
 		newUnlockKey := outs[:len(outs)-1]
 		assert.Assert(c, newUnlockKey != "")
@@ -1320,13 +1320,13 @@ func (s *DockerSwarmSuite) TestSwarmClusterRotateUnlockKey(c *testing.T) {
 	d3 := s.AddDaemon(c, true, true)
 
 	outs, err := d1.Cmd("swarm", "update", "--autolock")
-	assert.Assert(c, err == nil, fmt.Sprintf("%s", outs))
+	assert.Assert(c, err == nil, "%s", outs)
 	unlockKey := getUnlockKey(d1, c, outs)
 
 	// Rotate multiple times
 	for i := 0; i != 3; i++ {
 		outs, err = d1.Cmd("swarm", "unlock-key", "-q", "--rotate")
-		assert.Assert(c, err == nil, fmt.Sprintf("%s", outs))
+		assert.Assert(c, err == nil, "%s", outs)
 		// Strip \n
 		newUnlockKey := outs[:len(outs)-1]
 		assert.Assert(c, newUnlockKey != "")
@@ -1385,7 +1385,7 @@ func (s *DockerSwarmSuite) TestSwarmClusterRotateUnlockKey(c *testing.T) {
 						continue
 					}
 				}
-				assert.Assert(c, err == nil, fmt.Sprintf("%s", outs))
+				assert.Assert(c, err == nil, "%s", outs)
 				assert.Assert(c, !strings.Contains(outs, "Swarm is encrypted and needs to be unlocked"))
 				break
 			}
@@ -1401,7 +1401,7 @@ func (s *DockerSwarmSuite) TestSwarmAlternateLockUnlock(c *testing.T) {
 	for i := 0; i < 2; i++ {
 		// set to lock
 		outs, err := d.Cmd("swarm", "update", "--autolock")
-		assert.Assert(c, err == nil, fmt.Sprintf("out: %v", outs))
+		assert.Assert(c, err == nil, "out: %v", outs)
 		assert.Assert(c, strings.Contains(outs, "docker swarm unlock"))
 		unlockKey := getUnlockKey(d, c, outs)
 
@@ -1414,7 +1414,7 @@ func (s *DockerSwarmSuite) TestSwarmAlternateLockUnlock(c *testing.T) {
 		assert.Equal(c, getNodeStatus(c, d), swarm.LocalNodeStateActive)
 
 		outs, err = d.Cmd("swarm", "update", "--autolock=false")
-		assert.Assert(c, err == nil, fmt.Sprintf("out: %v", outs))
+		assert.Assert(c, err == nil, "out: %v", outs)
 
 		checkSwarmLockedToUnlocked(c, d)
 	}
@@ -1440,7 +1440,7 @@ func (s *DockerSwarmSuite) TestExtraHosts(c *testing.T) {
 	expectedOutput := "1.2.3.4\texample.com"
 	out, err = d.Cmd("exec", id, "cat", "/etc/hosts")
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, expectedOutput), fmt.Sprintf("Expected '%s', but got %q", expectedOutput, out))
+	assert.Assert(c, strings.Contains(out, expectedOutput), "Expected '%s', but got %q", expectedOutput, out)
 }
 
 func (s *DockerSwarmSuite) TestSwarmManagerAddress(c *testing.T) {
@@ -1950,7 +1950,7 @@ func (s *DockerSwarmSuite) TestSwarmClusterEventsSecret(c *testing.T) {
 		},
 		Data: []byte("TESTINGDATA"),
 	})
-	assert.Assert(c, id != "", fmt.Sprintf("secrets: %s", id))
+	assert.Assert(c, id != "", "secrets: %s", id)
 
 	waitForEvent(c, d, "0", "-f scope=swarm", "secret create "+id, defaultRetryCount)
 
@@ -1970,7 +1970,7 @@ func (s *DockerSwarmSuite) TestSwarmClusterEventsConfig(c *testing.T) {
 		},
 		Data: []byte("TESTINGDATA"),
 	})
-	assert.Assert(c, id != "", fmt.Sprintf("configs: %s", id))
+	assert.Assert(c, id != "", "configs: %s", id)
 
 	waitForEvent(c, d, "0", "-f scope=swarm", "config create "+id, defaultRetryCount)
 
@@ -1982,7 +1982,7 @@ func (s *DockerSwarmSuite) TestSwarmClusterEventsConfig(c *testing.T) {
 
 func getUnlockKey(d *daemon.Daemon, c *testing.T, autolockOutput string) string {
 	unlockKey, err := d.Cmd("swarm", "unlock-key", "-q")
-	assert.Assert(c, err == nil, fmt.Sprintf("%s", unlockKey))
+	assert.Assert(c, err == nil, "%s", unlockKey)
 	unlockKey = strings.TrimSuffix(unlockKey, "\n")
 
 	// Check that "docker swarm init --autolock" or "docker swarm update --autolock"

--- a/integration-cli/docker_cli_userns_test.go
+++ b/integration-cli/docker_cli_userns_test.go
@@ -59,7 +59,7 @@ func (s *DockerDaemonSuite) TestDaemonUserNamespaceRootSetting(c *testing.T) {
 	assert.Equal(c, statNotExists.GID(), uint32(gid), "Created directory not owned by remapped root GID")
 
 	pid, err := s.d.Cmd("inspect", "--format={{.State.Pid}}", "userns")
-	assert.Assert(c, err == nil, fmt.Sprintf("Could not inspect running container: out: %q", pid))
+	assert.Assert(c, err == nil, "Could not inspect running container: out: %q", pid)
 	// check the uid and gid maps for the PID to ensure root is remapped
 	// (cmd = cat /proc/<pid>/uid_map | grep -E '0\s+9999\s+1')
 	_, err = RunCommandPipelineWithOutput(
@@ -80,7 +80,7 @@ func (s *DockerDaemonSuite) TestDaemonUserNamespaceRootSetting(c *testing.T) {
 
 	// use host usernamespace
 	out, err = s.d.Cmd("run", "-d", "--name", "userns_skip", "--userns", "host", "busybox", "sh", "-c", "touch /goofy/testfile; top")
-	assert.Assert(c, err == nil, fmt.Sprintf("Output: %s", out))
+	assert.Assert(c, err == nil, "Output: %s", out)
 	user = s.findUser(c, "userns_skip")
 	// userns are skipped, user is root
 	assert.Equal(c, user, "root")
@@ -89,7 +89,7 @@ func (s *DockerDaemonSuite) TestDaemonUserNamespaceRootSetting(c *testing.T) {
 // findUser finds the uid or name of the user of the first process that runs in a container
 func (s *DockerDaemonSuite) findUser(c *testing.T, container string) string {
 	out, err := s.d.Cmd("top", container)
-	assert.Assert(c, err == nil, fmt.Sprintf("Output: %s", out))
+	assert.Assert(c, err == nil, "Output: %s", out)
 	rows := strings.Split(out, "\n")
 	if len(rows) < 2 {
 		// No process rows founds

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -146,13 +146,13 @@ func (s *DockerSuite) TestVolumeCLILsFilterDangling(c *testing.T) {
 
 	// Filter "dangling" volumes; only "dangling" (unused) volumes should be in the output
 	assert.Assert(c, strings.Contains(out, "testnotinuse1\n"), "expected volume 'testnotinuse1' in output")
-	assert.Assert(c, !strings.Contains(out, "testisinuse1\n"), fmt.Sprintf("volume 'testisinuse1' in output, but not expected"))
-	assert.Assert(c, !strings.Contains(out, "testisinuse2\n"), fmt.Sprintf("volume 'testisinuse2' in output, but not expected"))
+	assert.Assert(c, !strings.Contains(out, "testisinuse1\n"), "volume 'testisinuse1' in output, but not expected")
+	assert.Assert(c, !strings.Contains(out, "testisinuse2\n"), "volume 'testisinuse2' in output, but not expected")
 	out, _ = dockerCmd(c, "volume", "ls", "--filter", "dangling=1")
 	// Filter "dangling" volumes; only "dangling" (unused) volumes should be in the output, dangling also accept 1
 	assert.Assert(c, strings.Contains(out, "testnotinuse1\n"), "expected volume 'testnotinuse1' in output")
-	assert.Assert(c, !strings.Contains(out, "testisinuse1\n"), fmt.Sprintf("volume 'testisinuse1' in output, but not expected"))
-	assert.Assert(c, !strings.Contains(out, "testisinuse2\n"), fmt.Sprintf("volume 'testisinuse2' in output, but not expected"))
+	assert.Assert(c, !strings.Contains(out, "testisinuse1\n"), "volume 'testisinuse1' in output, but not expected")
+	assert.Assert(c, !strings.Contains(out, "testisinuse2\n"), "volume 'testisinuse2' in output, but not expected")
 	out, _ = dockerCmd(c, "volume", "ls", "--filter", "dangling=0")
 	// dangling=0 is same as dangling=false case
 	assert.Assert(c, !strings.Contains(out, "testnotinuse1\n"), "expected volume 'testnotinuse1' in output")
@@ -235,7 +235,7 @@ func (s *DockerSuite) TestVolumeCLIInspectTmplError(c *testing.T) {
 	name := strings.TrimSpace(out)
 
 	out, exitCode, err := dockerCmdWithError("volume", "inspect", "--format='{{ .FooBar }}'", name)
-	assert.Assert(c, err != nil, fmt.Sprintf("Output: %s", out))
+	assert.Assert(c, err != nil, "Output: %s", out)
 	assert.Equal(c, exitCode, 1, fmt.Sprintf("Output: %s", out))
 	assert.Assert(c, strings.Contains(out, "Template parsing error"))
 }
@@ -474,7 +474,7 @@ func (s *DockerSuite) TestDuplicateMountpointsForVolumesFrom(c *testing.T) {
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), data1))
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), data2))
 	out, _, err := dockerCmdWithError("run", "--name=app", "--volumes-from=data1", "--volumes-from=data2", "-d", "busybox", "top")
-	assert.Assert(c, err == nil, fmt.Sprintf("Out: %s", out))
+	assert.Assert(c, err == nil, "Out: %s", out)
 
 	// Only the second volume will be referenced, this is backward compatible
 	out, _ = dockerCmd(c, "inspect", "--format", "{{(index .Mounts 0).Name}}", "app")
@@ -516,7 +516,7 @@ func (s *DockerSuite) TestDuplicateMountpointsForVolumesFromAndBind(c *testing.T
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), data2))
 	// /tmp/data is automatically created, because we are not using the modern mount API here
 	out, _, err := dockerCmdWithError("run", "--name=app", "--volumes-from=data1", "--volumes-from=data2", "-v", "/tmp/data:/tmp/data", "-d", "busybox", "top")
-	assert.Assert(c, err == nil, fmt.Sprintf("Out: %s", out))
+	assert.Assert(c, err == nil, "Out: %s", out)
 
 	// No volume will be referenced (mount is /tmp/data), this is backward compatible
 	out, _ = dockerCmd(c, "inspect", "--format", "{{(index .Mounts 0).Name}}", "app")

--- a/integration-cli/docker_hub_pull_suite_test.go
+++ b/integration-cli/docker_hub_pull_suite_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
@@ -62,7 +61,7 @@ func (s *DockerHubPullSuite) TearDownTest(c *testing.T) {
 // output. The function fails the test when the command returns an error.
 func (s *DockerHubPullSuite) Cmd(c *testing.T, name string, arg ...string) string {
 	out, err := s.CmdWithError(name, arg...)
-	assert.Assert(c, err == nil, fmt.Sprintf("%q failed with errors: %s, %v", strings.Join(arg, " "), out, err))
+	assert.Assert(c, err == nil, "%q failed with errors: %s, %v", strings.Join(arg, " "), out, err)
 	return out
 }
 

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -82,7 +82,7 @@ func inspectFieldAndUnmarshall(c *testing.T, name, field string, output interfac
 	str := inspectFieldJSON(c, name, field)
 	err := json.Unmarshal([]byte(str), output)
 	if c != nil {
-		assert.Assert(c, err == nil, fmt.Sprintf("failed to unmarshal: %v", err))
+		assert.Assert(c, err == nil, "failed to unmarshal: %v", err)
 	}
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/moby/moby/pull/39799 https://github.com/moby/moby/pull/39799#discussion_r317793062

>the `fmt.Sprintf(..)` is not needed, `assert.Equal()` already takes a format-string; https://github.com/moby/moby/blob/c147e9e1a45b1c66bc5773814b53bcd27132557c/vendor/gotest.tools/assert/assert.go#L256



> ```go
> func TestFoo(t *testing.T) {
> 	assert.Equal(t, "one", "two", "bla %s bla", "bla")
> }
> ```
> 
> ```
> === RUN   TestFoo
> --- FAIL: TestFoo (0.00s)
>     debug_test.go:48: assertion failed: one (string) != two (string): bla bla bla
> FAIL
> 
> Process finished with exit code 1
> ```

Replaced using a bit of grep-ing;

```
find . -name "*_test.go" -exec sed -E -i 's#assert.Assert\((.*), fmt.Sprintf\((.*)\)\)$#assert.Assert\(\1, \2\)#g' '{}' \;
```
