### PR TITLE
DaemonCli: Move check into startMetricsServer

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -208,14 +208,10 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 		return errors.Wrap(err, "failed to validate authorization plugin")
 	}
 
-	// TODO: move into startMetricsServer()
-	if cli.Config.MetricsAddress != "" {
-		if !d.HasExperimental() {
-			return errors.Wrap(err, "metrics-addr is only supported when experimental is enabled")
-		}
-		if err := startMetricsServer(cli.Config.MetricsAddress); err != nil {
-			return err
-		}
+	cli.d = d
+
+	if err := cli.startMetricsServer(cli.Config.MetricsAddress); err != nil {
+		return err
 	}
 
 	c, err := createAndStartCluster(cli, d)
@@ -229,8 +225,6 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	d.RestartSwarmContainers()
 
 	logrus.Info("Daemon has completed initialization")
-
-	cli.d = d
 
 	routerOptions, err := newRouterOptions(cli.Config, d)
 	if err != nil {

--- a/cmd/dockerd/metrics.go
+++ b/cmd/dockerd/metrics.go
@@ -5,10 +5,19 @@ import (
 	"net/http"
 
 	"github.com/docker/go-metrics"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
-func startMetricsServer(addr string) error {
+func (cli *DaemonCli) startMetricsServer(addr string) error {
+	if addr == "" {
+		return nil
+	}
+
+	if !cli.d.HasExperimental() {
+		return errors.New("metrics-addr is only supported when experimental is enabled")
+	}
+
 	if err := allocateDaemonPort(addr); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix TODO: move into startMetricsServer()
Fix errors.Wrap return nil when passed err is nil

Signed-off-by: HuanHuan Ye <logindaveye@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
In DaemonCli.start() method. 
fix TODO move startMetricsServer prepare check into startMetricsServer()
fix return nil when daemon not HasExperimental

**- How I did it**
change function startMetricsServer() to DaemonCli's method
use errors.New() replace errors.Wrap()

**- How to verify it**
```./bundles/binary-daemon/dockerd-dev   --metrics-addr 0.0.0.0:7878 -D```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
DaemonCli: Move check into startMetricsServer

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/8220938/64695876-b9152400-d4cf-11e9-95b6-a7fe0416012f.png)
