### PR TITLE
update image - microsoft/windowsservercore:latest does not exist anymore

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -160,7 +160,7 @@
 # would fail between Windows Server 2016 (aka RS1) and Windows Server 2019 (aka RS5).
 # It is expected that the image `microsoft/windowsservercore:latest` is present, and matches
 # the hosts kernel version before doing a build. 
-FROM microsoft/windowsservercore
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 # Use PowerShell as the default shell
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]


### PR DESCRIPTION
Signed-off-by: Espen Suenson <mail@espensuenson.dk>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

