### PR TITLE
integration-cli: Skip TestAPIImagesSaveAndLoad on RS3 and older

### DIFF
--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -62,8 +62,8 @@ func (s *DockerSuite) TestAPIImagesSaveAndLoad(c *testing.T) {
 		v, err := kernel.GetKernelVersion()
 		assert.NilError(c, err)
 		build, _ := strconv.Atoi(strings.Split(strings.SplitN(v.String(), " ", 3)[2][1:], ".")[0])
-		if build == 16299 {
-			c.Skip("Temporarily disabled on RS3 builds")
+		if build <= 16299 {
+			c.Skip("Temporarily disabled on RS3 and older because they are too slow. See #39909")
 		}
 	}
 


### PR DESCRIPTION
addresses https://github.com/moby/moby/issues/39909

I've seen this test fail a number of times recently on RS1

Looking at failures, the test is taking a long time ro run (491.77s, which is
more than 8 minutes), so perhaps it's just too slow on RS1, which may be
because we switch to a different base image, or because we're now running
on different machines.

Compared to RS5 (still slow, but a lot faster);

```
--- PASS: Test/DockerSuite/TestAPIImagesSaveAndLoad (146.25s)
```

```
 --- FAIL: Test/DockerSuite/TestAPIImagesSaveAndLoad (491.77s)
     cli.go:45: assertion failed:
         Command:  d:\CI-5\CI-93d2cf881\binary\docker.exe inspect --format {{.Id}} sha256:69e7c1ff23be5648c494294a3808c0ea3f78616fad67bfe3b10d3a7e2be5ff02
         ExitCode: 1
         Error:    exit status 1
         Stdout:

         Stderr:   Error: No such object: sha256:69e7c1ff23be5648c494294a3808c0ea3f78616fad67bfe3b10d3a7e2be5ff02

         Failures:
         ExitCode was 1 expected 0
         Expected no error
```

