### PR TITLE
hack: have integration-cli use gotestsum codepath

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -307,10 +307,10 @@ pipeline {
                                 TEST_INTEGRATION_DEST=1 CONTAINER_NAME=${CONTAINER_NAME}-1 TEST_SKIP_INTEGRATION_CLI=1 run_tests test-integration-flaky &
 
                                 # integration-cli first set
-                                TEST_INTEGRATION_DEST=2 CONTAINER_NAME=${CONTAINER_NAME}-2 TEST_SKIP_INTEGRATION=1 TESTFLAGS="-test.run /(DockerSuite|DockerNetworkSuite|DockerHubPullSuite|DockerRegistrySuite|DockerSchema1RegistrySuite|DockerRegistryAuthTokenSuite|DockerRegistryAuthHtpasswdSuite)/" run_tests &
+                                TEST_INTEGRATION_DEST=2 CONTAINER_NAME=${CONTAINER_NAME}-2 TEST_SKIP_INTEGRATION=1 TESTFLAGS="-test.run Test(DockerSuite|DockerNetworkSuite|DockerHubPullSuite|DockerRegistrySuite|DockerSchema1RegistrySuite|DockerRegistryAuthTokenSuite|DockerRegistryAuthHtpasswdSuite)/" run_tests &
 
                                 # integration-cli second set
-                                TEST_INTEGRATION_DEST=3 CONTAINER_NAME=${CONTAINER_NAME}-3 TEST_SKIP_INTEGRATION=1 TESTFLAGS="-test.run /(DockerSwarmSuite|DockerDaemonSuite|DockerExternalVolumeSuite)/" run_tests &
+                                TEST_INTEGRATION_DEST=3 CONTAINER_NAME=${CONTAINER_NAME}-3 TEST_SKIP_INTEGRATION=1 TESTFLAGS="-test.run Test(DockerSwarmSuite|DockerDaemonSuite|DockerExternalVolumeSuite)/" run_tests &
 
                                 set +x
                                 c=0

--- a/docs/contributing/test.md
+++ b/docs/contributing/test.md
@@ -174,13 +174,13 @@ flag's value is passed as arguments to the `go test` command. For example, from
 your local host you can run the `TestBuild` test with this command:
 
 ```bash
-$ TESTFLAGS='-test.run /DockerSuite/TestBuild*' make test-integration
+$ TESTFLAGS='-test.run TestDockerSuite/TestBuild*' make test-integration
 ```
 
 To run the same test inside your Docker development container, you do this:
 
 ```bash
-# TESTFLAGS='-test.run /DockerSuite/TestBuild*' hack/make.sh binary test-integration
+# TESTFLAGS='-test.run TestDockerSuite/TestBuild*' hack/make.sh binary test-integration
 ```
 
 ## Test the Windows binary against a Linux daemon
@@ -228,11 +228,11 @@ run a Bash terminal on Windows.
     ```
 
     Should you wish to run a single test such as one with the name
-    'TestExample', you can pass in `TESTFLAGS='-test.run //TestExample'`. For
+    'TestExample', you can pass in `TESTFLAGS='-test.run /TestExample'`. For
     example
 
     ```bash
-    $ TESTFLAGS='-test.run //TestExample' hack/make.sh binary test-integration
+    $ TESTFLAGS='-test.run /TestExample' hack/make.sh binary test-integration
     ```
 
 You can now choose to make changes to the Moby source or the tests. If you

--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -3,7 +3,7 @@
 # For integration-cli test, we use [gocheck](https://labix.org/gocheck), if you want
 # to run certain tests on your local host, you should run with command:
 #
-#     TESTFLAGS='-test.run /DockerSuite/TestBuild*' ./hack/make.sh binary test-integration
+#     TESTFLAGS='-test.run TestDockerSuite/TestBuild*' ./hack/make.sh binary test-integration
 #
 
 if [ -z "${MAKEDIR}" ]; then

--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -47,16 +47,17 @@ integration_api_dirs="${TEST_INTEGRATION_DIR:-$(go list  -test -f '{{- if ne .Fo
 run_test_integration() {
 	set_platform_timeout
 	if [ -z "${TEST_SKIP_INTEGRATION}" ]; then
-		run_test_integration_suites
+		run_test_integration_suites "${integration_api_dirs}"
 	fi
 	if [ -z "${TEST_SKIP_INTEGRATION_CLI}" ]; then
-		run_test_integration_legacy_suites
+		TIMEOUT=360m run_test_integration_suites integration-cli
 	fi
 }
 
 run_test_integration_suites() {
 	local flags="-test.v -test.timeout=${TIMEOUT} $TESTFLAGS"
-	for dir in ${integration_api_dirs}; do
+	local dirs="$1"
+	for dir in ${dirs}; do
 		if ! (
 			cd "$dir"
 			# Create a useful package name based on the tests's $dir. We need to take
@@ -82,16 +83,6 @@ run_test_integration_suites() {
 				-- go tool test2json -p "${pkgname}" -t ./test.main ${flags}
 		); then exit 1; fi
 	done
-}
-
-run_test_integration_legacy_suites() {
-	(
-		flags="-test.v -test.timeout=360m $TESTFLAGS"
-		cd integration-cli
-		echo "Running $PWD flags=${flags}"
-		# shellcheck disable=SC2086
-		test_env ./test.main $flags
-	)
 }
 
 build_test_suite_binaries() {

--- a/internal/test/suite/suite.go
+++ b/internal/test/suite/suite.go
@@ -30,13 +30,12 @@ func Run(t *testing.T, suite interface{}) {
 	}()
 
 	methodFinder := reflect.TypeOf(suite)
-	suiteName := methodFinder.Elem().Name()
 	for index := 0; index < methodFinder.NumMethod(); index++ {
 		method := methodFinder.Method(index)
 		if !methodFilter(method.Name, method.Type) {
 			continue
 		}
-		t.Run(suiteName+"/"+method.Name, func(t *testing.T) {
+		t.Run(method.Name, func(t *testing.T) {
 			defer failOnPanic(t)
 
 			if !suiteSetupDone {


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>

This also removes the master test named `Test`, replaced by one test per suite. Review last commit for that.