### PR TITLE
Use unique names in integration/service/plugin_test.go

### DIFF
--- a/integration/service/plugin_test.go
+++ b/integration/service/plugin_test.go
@@ -31,9 +31,9 @@ func TestServicePlugin(t *testing.T) {
 	reg := registry.NewV2(t)
 	defer reg.Close()
 
-	repo := path.Join(registry.DefaultURL, "swarm", "test:v1")
-	repo2 := path.Join(registry.DefaultURL, "swarm", "test:v2")
-	name := "test"
+	name := "test-" + strings.ToLower(t.Name())
+	repo := path.Join(registry.DefaultURL, "swarm", name+":v1")
+	repo2 := path.Join(registry.DefaultURL, "swarm", name+":v2")
 
 	d := daemon.New(t)
 	d.StartWithBusybox(t)


### PR DESCRIPTION
- What I did
changed integration/service/plugin_test.go to use unique names.
Part of #36583

- How I did it
Added t.Name() to resources names.

- How to verify it

- Description for the changelog
Modified integration/service/plugin_test.go to use unique names.

- A picture of a cute animal (not mandatory but encouraged)

