### PR TITLE
Zap a fixed windows folder, add build number to folder inside

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -743,7 +743,7 @@ pipeline {
                         SOURCES_DRIVE          = 'd'
                         SOURCES_SUBDIR         = 'gopath'
                         TESTRUN_DRIVE          = 'd'
-                        TESTRUN_SUBDIR         = "CI-$BUILD_NUMBER"
+                        TESTRUN_SUBDIR         = "CI"
                         WINDOWS_BASE_IMAGE     = 'mcr.microsoft.com/windows/servercore'
                         WINDOWS_BASE_IMAGE_TAG = 'ltsc2016'
                     }
@@ -804,7 +804,7 @@ pipeline {
                         SOURCES_DRIVE          = 'd'
                         SOURCES_SUBDIR         = 'gopath'
                         TESTRUN_DRIVE          = 'd'
-                        TESTRUN_SUBDIR         = "CI-$BUILD_NUMBER"
+                        TESTRUN_SUBDIR         = "CI"
                         WINDOWS_BASE_IMAGE     = 'mcr.microsoft.com/windows/servercore'
                         WINDOWS_BASE_IMAGE_TAG = 'ltsc2019'
                     }

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -51,6 +51,15 @@ Write-Host -ForegroundColor Red "-----------------------------------------------
 #                        TESTRUN_DRIVE\TESTRUN_SUBDIR\CI-<CommitID> or
 #                        d:\CI\CI-<CommitID>
 #
+# Optional environment variables help in CI:
+#
+#    BUILD_NUMBER + BRANCH_NAME   are optional variables to be added to the directory below TESTRUN_SUBDIR
+#                        to have individual folder per CI build. If some files couldn't be
+#                        cleaned up and we want to re-run the build in CI.
+#                        Hence, the daemon under test is run under
+#                        TESTRUN_DRIVE\TESTRUN_SUBDIR\PR-<PR-Number>\<BuildNumber> or
+#                        d:\CI\PR-<PR-Number>\<BuildNumber>
+#
 # In addition, the following variables can control the run configuration:
 #
 #    DOCKER_DUT_DEBUG         if defined starts the daemon under test in debug mode.
@@ -428,7 +437,12 @@ Try {
 
     # Redirect to a temporary location. 
     $TEMPORIG=$env:TEMP
-    $env:TEMP="$env:TESTRUN_DRIVE`:\$env:TESTRUN_SUBDIR\CI-$COMMITHASH"
+    if ($null -eq $env:BUILD_NUMBER) {
+      $env:TEMP="$env:TESTRUN_DRIVE`:\$env:TESTRUN_SUBDIR\CI-$COMMITHASH"
+    } else {
+      # individual temporary location per CI build that better matches the BUILD_URL
+      $env:TEMP="$env:TESTRUN_DRIVE`:\$env:TESTRUN_SUBDIR\$env:BRANCH_NAME\$env:BUILD_NUMBER"
+    }
     $env:LOCALAPPDATA="$env:TEMP\localappdata"
     $errorActionPreference='Stop'
     New-Item -ItemType Directory "$env:TEMP" -ErrorAction SilentlyContinue | Out-Null


### PR DESCRIPTION

**- What I did**

The docker ci zap should be run on a fixed windows folder to cleanup previous temp folders as well to increase free disk space. For CI it still should create individual temp folders per CI build, even after a rebuild without a code change. So, add the BUILD_NUMBER to the folder inside the TESTRUN_SUBDIR folder.

We saw out of disk errors on some agents after CI had canceled builds after pushing new code to a running PR build. Probably other folders could not be cleaned up which caused the full disk.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

