### PR TITLE
Use build args to override binary commits in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,7 @@ FROM runtime-dev-cross-${CROSS} AS runtime-dev
 
 FROM base AS tomlv
 ENV INSTALL_BINARY_NAME=tomlv
+ARG TOMLV_COMMIT
 COPY hack/dockerfile/install/install.sh ./install.sh
 COPY hack/dockerfile/install/$INSTALL_BINARY_NAME.installer ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
@@ -146,6 +147,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM base AS vndr
 ENV INSTALL_BINARY_NAME=vndr
+ARG VNDR_COMMIT
 COPY hack/dockerfile/install/install.sh ./install.sh
 COPY hack/dockerfile/install/$INSTALL_BINARY_NAME.installer ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
@@ -154,6 +156,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM dev-base AS containerd
 ARG DEBIAN_FRONTEND
+ARG CONTAINERD_COMMIT
 RUN --mount=type=cache,sharing=locked,id=moby-containerd-aptlib,target=/var/lib/apt \
 	--mount=type=cache,sharing=locked,id=moby-containerd-aptcache,target=/var/cache/apt \
 		apt-get update && apt-get install -y --no-install-recommends \
@@ -167,6 +170,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM dev-base AS proxy
 ENV INSTALL_BINARY_NAME=proxy
+ARG LIBNETWORK_COMMIT
 COPY hack/dockerfile/install/install.sh ./install.sh
 COPY hack/dockerfile/install/$INSTALL_BINARY_NAME.installer ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
@@ -175,6 +179,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM base AS golangci_lint
 ENV INSTALL_BINARY_NAME=golangci_lint
+ARG GOLANGCI_LINT_COMMIT
 COPY hack/dockerfile/install/install.sh ./install.sh
 COPY hack/dockerfile/install/$INSTALL_BINARY_NAME.installer ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
@@ -183,6 +188,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM base AS gotestsum
 ENV INSTALL_BINARY_NAME=gotestsum
+ARG GOTESTSUM_COMMIT
 COPY hack/dockerfile/install/install.sh ./install.sh
 COPY hack/dockerfile/install/$INSTALL_BINARY_NAME.installer ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
@@ -191,6 +197,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM dev-base AS dockercli
 ENV INSTALL_BINARY_NAME=dockercli
+ARG DOCKERCLI_CHANNEL
+ARG DOCKERCLI_VERSION
 COPY hack/dockerfile/install/install.sh ./install.sh
 COPY hack/dockerfile/install/$INSTALL_BINARY_NAME.installer ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
@@ -199,6 +207,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM runtime-dev AS runc
 ENV INSTALL_BINARY_NAME=runc
+ARG RUNC_COMMIT
+ARG RUNC_BUILDTAGS
 COPY hack/dockerfile/install/install.sh ./install.sh
 COPY hack/dockerfile/install/$INSTALL_BINARY_NAME.installer ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
@@ -207,6 +217,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM dev-base AS tini
 ARG DEBIAN_FRONTEND
+ARG TINI_COMMIT
 RUN --mount=type=cache,sharing=locked,id=moby-tini-aptlib,target=/var/lib/apt \
 	--mount=type=cache,sharing=locked,id=moby-tini-aptcache,target=/var/cache/apt \
 		apt-get update && apt-get install -y --no-install-recommends \
@@ -221,6 +232,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM dev-base AS rootlesskit
 ENV INSTALL_BINARY_NAME=rootlesskit
+ARG ROOTLESSKIT_COMMIT
 COPY hack/dockerfile/install/install.sh ./install.sh
 COPY hack/dockerfile/install/$INSTALL_BINARY_NAME.installer ./
 RUN --mount=type=cache,target=/root/.cache/go-build \

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=36cf5b690dcc00ff0f34ff7799209050c3d0c59a # v1.3.0
+: ${CONTAINERD_COMMIT:=36cf5b690dcc00ff0f34ff7799209050c3d0c59a} # v1.3.0
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/dockercli.installer
+++ b/hack/dockerfile/install/dockercli.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-DOCKERCLI_CHANNEL=${DOCKERCLI_CHANNEL:-stable}
-DOCKERCLI_VERSION=${DOCKERCLI_VERSION:-17.06.2-ce}
+: ${DOCKERCLI_CHANNEL:=stable}
+: ${DOCKERCLI_VERSION:=17.06.2-ce}
 
 install_dockercli() {
 	echo "Install docker/cli version $DOCKERCLI_VERSION from $DOCKERCLI_CHANNEL"

--- a/hack/dockerfile/install/gotestsum.installer
+++ b/hack/dockerfile/install/gotestsum.installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-GOTESTSUM_COMMIT='v0.3.5'
+: ${GOTESTSUM_COMMIT:=v0.3.5}
 
 install_gotestsum() {
 	echo "Installing gotestsum version $GOTESTSUM_COMMIT"

--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=96bcc0dae898308ed659c5095526788a602f4726
+: ${LIBNETWORK_COMMIT:=96bcc0dae898308ed659c5095526788a602f4726}
 
 install_proxy() {
 	case "$1" in

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # v0.7.0
-ROOTLESSKIT_COMMIT=791ac8cb209a107505cd1ca5ddf23a49913e176c
+: ${ROOTLESSKIT_COMMIT:=791ac8cb209a107505cd1ca5ddf23a49913e176c}
 
 install_rootlesskit() {
 	case "$1" in

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -4,7 +4,7 @@
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-RUNC_COMMIT=3e425f80a8c931f88e6d94a8c831b9d5aa481657 # v1.0.0-rc8-92-g84373aaa
+: ${RUNC_COMMIT:=3e425f80a8c931f88e6d94a8c831b9d5aa481657} # v1.0.0-rc8-92-g84373aaa
 
 install_runc() {
 	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting

--- a/hack/dockerfile/install/tini.installer
+++ b/hack/dockerfile/install/tini.installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-TINI_COMMIT=fec3683b971d9c3ef73f284f176672c44b448662 # v0.18.0
+: ${TINI_COMMIT:=fec3683b971d9c3ef73f284f176672c44b448662} # v0.18.0
 
 install_tini() {
 	echo "Install tini version $TINI_COMMIT"

--- a/hack/dockerfile/install/tomlv.installer
+++ b/hack/dockerfile/install/tomlv.installer
@@ -2,7 +2,7 @@
 
 # When updating TOMLV_COMMIT, consider updating github.com/BurntSushi/toml
 # in vendor.conf accordingly
-TOMLV_COMMIT=3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
+: ${TOMLV_COMMIT:=3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005} # v0.3.1
 
 install_tomlv() {
 	echo "Install tomlv version $TOMLV_COMMIT"

--- a/hack/dockerfile/install/vndr.installer
+++ b/hack/dockerfile/install/vndr.installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VNDR_COMMIT=f5ab8fc5fb64d66b5c6e55a0bcb58b2e92362fa0
+: ${VNDR_COMMIT:=f5ab8fc5fb64d66b5c6e55a0bcb58b2e92362fa0}
 
 install_vndr() {
 	echo "Install vndr version $VNDR_COMMIT"


### PR DESCRIPTION
Signed-off-by: Justen Martin <jmart@the-coder.com>

closes #36412

**- What I did**
modified dockerfile to allow the overriding of binary commits through build args

**- How I did it**
added `ARG` directives to appropriate build stages in dockerfile and updated corresponding install scripts to override env variables when build arg is provided

**- How to verify it**
1. Confirm the image builds without any build args
2. For each new build arg, add a `--build-arg` flag and confirm through the build output that the correct value was used

**- Description for the changelog**
Several new build arguments were added to override binary commits in order to specify specific versions for testing

**- A picture of a cute animal (not mandatory but encouraged)**
![Cute-Animals-3-cute-animals-30317887-500-356](https://user-images.githubusercontent.com/1485680/64818730-4610b980-d572-11e9-8c3a-8a2ae50b5a85.jpg)
