### PR TITLE
dockerd: add --print-default-{seccomp,apparmor} profile

### DIFF
--- a/daemon/apparmor_default.go
+++ b/daemon/apparmor_default.go
@@ -4,9 +4,11 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"fmt"
+	"io"
 
 	aaprofile "github.com/docker/docker/profiles/apparmor"
 	"github.com/opencontainers/runc/libcontainer/apparmor"
+	"github.com/pkg/errors"
 )
 
 // Define constants for native driver
@@ -33,4 +35,12 @@ func ensureDefaultAppArmorProfile() error {
 	}
 
 	return nil
+}
+
+// PrintDefaultAppArmorProfile dumps the default profile to out
+func PrintDefaultAppArmorProfile(out io.Writer) error {
+	if apparmor.IsEnabled() {
+		return aaprofile.Default(out, defaultApparmorProfile)
+	}
+	return errors.New("apparmor is not enabled for this host or unsupported in this build")
 }

--- a/daemon/apparmor_default_unsupported.go
+++ b/daemon/apparmor_default_unsupported.go
@@ -2,6 +2,17 @@
 
 package daemon // import "github.com/docker/docker/daemon"
 
+import (
+	"io"
+
+	"github.com/pkg/errors"
+)
+
 func ensureDefaultAppArmorProfile() error {
 	return nil
+}
+
+// PrintDefaultAppArmorProfile dumps the default profile to out
+func PrintDefaultAppArmorProfile(out io.Writer) error {
+	return errors.New("apparmor is unsupported in this build")
 }

--- a/daemon/seccomp_disabled.go
+++ b/daemon/seccomp_disabled.go
@@ -5,10 +5,12 @@ package daemon // import "github.com/docker/docker/daemon"
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/containerd/containerd/containers"
 	coci "github.com/containerd/containerd/oci"
 	"github.com/docker/docker/container"
+	"github.com/pkg/errors"
 )
 
 var supportsSeccomp = false
@@ -21,4 +23,9 @@ func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		}
 		return nil
 	}
+}
+
+// PrintDefaultSeccompProfile dumps the default profile to out
+func PrintDefaultSeccompProfile(out io.Writer) error {
+	return errors.New("seccomp is unsupported in this build")
 }

--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -4,7 +4,9 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/containerd/containerd/containers"
 	coci "github.com/containerd/containerd/oci"
@@ -58,4 +60,15 @@ func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		s.Linux.Seccomp = profile
 		return nil
 	}
+}
+
+// PrintDefaultSeccompProfile dumps the default profile to out
+func PrintDefaultSeccompProfile(out io.Writer) error {
+	b, err := json.MarshalIndent(seccomp.DefaultProfile(), "", "\t")
+	if err != nil {
+		return err
+	}
+	b = append(b, []byte("\n")...)
+	_, err = out.Write(b)
+	return err
 }

--- a/daemon/seccomp_unsupported.go
+++ b/daemon/seccomp_unsupported.go
@@ -4,10 +4,12 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
+	"io"
 
 	"github.com/containerd/containerd/containers"
 	coci "github.com/containerd/containerd/oci"
 	"github.com/docker/docker/container"
+	"github.com/pkg/errors"
 )
 
 var supportsSeccomp = false
@@ -17,4 +19,9 @@ func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
 		return nil
 	}
+}
+
+// PrintDefaultSeccompProfile dumps the default profile to out
+func PrintDefaultSeccompProfile(out io.Writer) error {
+	return errors.New("seccomp is unsupported in this build")
 }

--- a/profiles/apparmor/apparmor.go
+++ b/profiles/apparmor/apparmor.go
@@ -65,9 +65,8 @@ func macroExists(m string) bool {
 	return err == nil
 }
 
-// InstallDefault generates a default profile in a temp directory determined by
-// os.TempDir(), then loads the profile into the kernel using 'apparmor_parser'.
-func InstallDefault(name string) error {
+// Default generates a default profile to out in the human-readable text format.
+func Default(out io.Writer, name string) error {
 	p := profileData{
 		Name: name,
 	}
@@ -91,6 +90,12 @@ func InstallDefault(name string) error {
 	}
 	p.DaemonProfile = daemonProfile
 
+	return p.generateDefault(out)
+}
+
+// InstallDefault generates a default profile in a temp directory determined by
+// os.TempDir(), then loads the profile into the kernel using 'apparmor_parser'.
+func InstallDefault(name string) error {
 	// Install to a temporary directory.
 	f, err := ioutil.TempFile("", name)
 	if err != nil {
@@ -101,7 +106,7 @@ func InstallDefault(name string) error {
 	defer f.Close()
 	defer os.Remove(profilePath)
 
-	if err := p.generateDefault(f); err != nil {
+	if err = Default(f, name); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
added `--print-default-{seccomp,apparmor} profile` to `dockerd`, so that the user can inspect the default configuration

Fix https://github.com/moby/moby/issues/33060

**- How to verify it**

```console
$ dockerd --print-default-seccomp-profile
{
        "defaultAction": "SCMP_ACT_ERRNO",
        "archMap": [
                {
                        "architecture": "SCMP_ARCH_X86_64",
                        "subArchitectures": [
                                "SCMP_ARCH_X86",
                                "SCMP_ARCH_X32"
                        ]
                },
...
                {
                        "names": [
                                "syslog"
                        ],
                        "action": "SCMP_ACT_ALLOW",
                        "args": [],
                        "comment": "",
                        "includes": {
                                "caps": [
                                        "CAP_SYSLOG"
                                ]
                        },
                        "excludes": {}
                }
        ]
}
```

```console
$ dockerd --print-default-apparmor-profile


#include <tunables/global>


profile docker-default flags=(attach_disconnected,mediate_deleted) {

  #include <abstractions/base>


  network,
  capability,
  file,
  umount,


  signal (receive) peer=unconfined
,

  signal (send,receive) peer=docker-default,


  deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
  # deny write to files not in /proc/<number>/** or /proc/sys/**
  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
  deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
  deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
  deny @{PROC}/sysrq-trigger rwklx,
  deny @{PROC}/kcore rwklx,

  deny mount,

  deny /sys/[^f]*/** wklx,
  deny /sys/f[^s]*/** wklx,
  deny /sys/fs/[^c]*/** wklx,
  deny /sys/fs/c[^g]*/** wklx,
  deny /sys/fs/cg[^r]*/** wklx,
  deny /sys/firmware/** rwklx,
  deny /sys/kernel/security/** rwklx,


  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
  ptrace (trace,read,tracedby,readby) peer=docker-default,

}
```

**- Description for the changelog**
dockerd: add --dump-default-{seccomp,apparmor} profile
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

:penguin:
