### PR TITLE
hack/test/unit: fix custom TESTFLAGS not working

### DIFF
--- a/hack/test/unit
+++ b/hack/test/unit
@@ -13,7 +13,7 @@
 set -eu -o pipefail
 
 BUILDFLAGS=( -tags 'netgo seccomp libdm_no_deferred_remove' )
-TESTFLAGS+="-test.timeout=${TIMEOUT:-5m}"
+TESTFLAGS+=" -test.timeout=${TIMEOUT:-5m}"
 TESTDIRS="${TESTDIRS:-./...}"
 exclude_paths='/vendor/|/integration'
 pkg_list=$(go list $TESTDIRS | grep -vE "($exclude_paths)")


### PR DESCRIPTION
The `-test.timeout=5m` was glued directly after the current `TESTFLAGS`,
causing them to be non-functional;

Before:

    make TESTDEBUG=1 TESTDIRS='github.com/docker/docker/pkg/filenotify' TESTFLAGS='-test.run TestPollerEvent' test-unit
    + mkdir -p bundles
    + gotestsum --format=standard-quiet --jsonfile=bundles/go-test-report.json --junitfile=bundles/junit-report.xml -- -tags 'netgo seccomp libdm_no_deferred_remove' -cover -coverprofile=bundles/profile.out -covermode=atomic -test.run TestPollerEvent-test.timeout=5m github.com/docker/docker/pkg/filenotify
    testing: warning: no tests to run
    ok  	github.com/docker/docker/pkg/filenotify	0.003s	coverage: 0.0% of statements [no tests to run]

    DONE 0 tests in 0.298s

After:

    make TESTDEBUG=1 TESTDIRS='github.com/docker/docker/pkg/filenotify' TESTFLAGS='-test.run TestPollerEvent' test-unit
    + mkdir -p bundles
    + gotestsum --format=standard-quiet --jsonfile=bundles/go-test-report.json --junitfile=bundles/junit-report.xml -- -tags 'netgo seccomp libdm_no_deferred_remove' -cover -coverprofile=bundles/profile.out -covermode=atomic -test.run TestPollerEvent -test.timeout=5m github.com/docker/docker/pkg/filenotify
    ok  	github.com/docker/docker/pkg/filenotify	0.608s	coverage: 44.7% of statements

    DONE 1 tests in 0.922s
