### PR TITLE
Makefile: allow extending the makefile using includes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,3 +265,7 @@ bundles/buildx: bundles ## build buildx CLI tool
 		. && \
 		id=$$(docker create moby-buildx:$(BUILDX_COMMIT)); \
 		if [ -n "$${id}" ]; then docker cp $${id}:/usr/bin/buildx $@ && touch $@; docker rm -f $${id}; fi
+
+
+# allow extending the makefile by adding includes in the hack/makefiles/ directory
+-include hack/makefiles/*.mk

--- a/hack/makefiles/README.md
+++ b/hack/makefiles/README.md
@@ -1,0 +1,11 @@
+This directory allows extending the top-level Makefile by adding custom
+makefile include files (`.mk`).
+
+For example:
+
+```bash
+echo -e "hello:\n\t@echo hello world\n" > hack/makefiles/hello.mk
+
+make hello
+# hello world
+```


### PR DESCRIPTION
This allows for downstream repositories to extend the Makefile
by adding additional functionality to the `hack/makefiles/` directory.

For example;

```bash
echo -e "hello:\n\t@echo hello world\n" > hack/makefiles/hello.mk

make hello
# hello world
```