### PR TITLE
testutil/daemon: group options under type

### DIFF
--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -31,7 +31,7 @@ type Daemon struct {
 // New returns a Daemon instance to be used for testing.
 // This will create a directory such as d123456789 in the folder specified by $DOCKER_INTEGRATION_DAEMON_DEST or $DEST.
 // The daemon will not automatically start.
-func New(t testingT, dockerBinary string, dockerdBinary string, ops ...func(*daemon.Daemon)) *Daemon {
+func New(t testingT, dockerBinary string, dockerdBinary string, ops ...daemon.Option) *Daemon {
 	ops = append(ops, daemon.WithDockerdBinary(dockerdBinary))
 	d := daemon.New(t, ops...)
 	return &Daemon{

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -49,7 +49,7 @@ func ContainerPoll(config *poll.Settings) {
 }
 
 // NewSwarm creates a swarm daemon for testing
-func NewSwarm(t *testing.T, testEnv *environment.Execution, ops ...func(*daemon.Daemon)) *daemon.Daemon {
+func NewSwarm(t *testing.T, testEnv *environment.Execution, ops ...daemon.Option) *daemon.Daemon {
 	t.Helper()
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -30,7 +30,7 @@ func TestServiceCreateInit(t *testing.T) {
 
 func testServiceCreateInit(daemonEnabled bool) func(t *testing.T) {
 	return func(t *testing.T) {
-		var ops = []func(*daemon.Daemon){}
+		var ops = []daemon.Option{}
 
 		if daemonEnabled {
 			ops = append(ops, daemon.WithInit)

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -94,7 +94,7 @@ type Daemon struct {
 // New returns a Daemon instance to be used for testing.
 // This will create a directory such as d123456789 in the folder specified by $DOCKER_INTEGRATION_DAEMON_DEST or $DEST.
 // The daemon will not automatically start.
-func New(t testingT, ops ...func(*Daemon)) *Daemon {
+func New(t testingT, ops ...Option) *Daemon {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}

--- a/testutil/daemon/ops.go
+++ b/testutil/daemon/ops.go
@@ -2,8 +2,11 @@ package daemon
 
 import "github.com/docker/docker/testutil/environment"
 
+// Option is used to configure a daemon.
+type Option func(*Daemon)
+
 // WithDefaultCgroupNamespaceMode sets the default cgroup namespace mode for the daemon
-func WithDefaultCgroupNamespaceMode(mode string) func(*Daemon) {
+func WithDefaultCgroupNamespaceMode(mode string) Option {
 	return func(d *Daemon) {
 		d.defaultCgroupNamespaceMode = mode
 	}
@@ -21,49 +24,49 @@ func WithInit(d *Daemon) {
 }
 
 // WithDockerdBinary sets the dockerd binary to the specified one
-func WithDockerdBinary(dockerdBinary string) func(*Daemon) {
+func WithDockerdBinary(dockerdBinary string) Option {
 	return func(d *Daemon) {
 		d.dockerdBinary = dockerdBinary
 	}
 }
 
 // WithSwarmPort sets the swarm port to use for swarm mode
-func WithSwarmPort(port int) func(*Daemon) {
+func WithSwarmPort(port int) Option {
 	return func(d *Daemon) {
 		d.SwarmPort = port
 	}
 }
 
 // WithSwarmListenAddr sets the swarm listen addr to use for swarm mode
-func WithSwarmListenAddr(listenAddr string) func(*Daemon) {
+func WithSwarmListenAddr(listenAddr string) Option {
 	return func(d *Daemon) {
 		d.swarmListenAddr = listenAddr
 	}
 }
 
 // WithSwarmDefaultAddrPool sets the swarm default address pool to use for swarm mode
-func WithSwarmDefaultAddrPool(defaultAddrPool []string) func(*Daemon) {
+func WithSwarmDefaultAddrPool(defaultAddrPool []string) Option {
 	return func(d *Daemon) {
 		d.DefaultAddrPool = defaultAddrPool
 	}
 }
 
 // WithSwarmDefaultAddrPoolSubnetSize sets the subnet length mask of swarm default address pool to use for swarm mode
-func WithSwarmDefaultAddrPoolSubnetSize(subnetSize uint32) func(*Daemon) {
+func WithSwarmDefaultAddrPoolSubnetSize(subnetSize uint32) Option {
 	return func(d *Daemon) {
 		d.SubnetSize = subnetSize
 	}
 }
 
 // WithSwarmDataPathPort sets the  swarm datapath port to use for swarm mode
-func WithSwarmDataPathPort(datapathPort uint32) func(*Daemon) {
+func WithSwarmDataPathPort(datapathPort uint32) Option {
 	return func(d *Daemon) {
 		d.DataPathPort = datapathPort
 	}
 }
 
 // WithEnvironment sets options from testutil/environment.Execution struct
-func WithEnvironment(e environment.Execution) func(*Daemon) {
+func WithEnvironment(e environment.Execution) Option {
 	return func(d *Daemon) {
 		if e.DaemonInfo.ExperimentalBuild {
 			d.experimental = true


### PR DESCRIPTION
This adds a type for the options used to configure `"testutil/daemon".Daemon`. The only real purpose this serves is to group them under the type in the documentation, making it more obvious what functions are used for configuration and which are not.