### PR TITLE
Disable TestPsListContainersFilterExited (Windows)

### DIFF
--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -436,6 +436,10 @@ func (s *DockerSuite) TestPsListContainersFilterLabel(c *testing.T) {
 }
 
 func (s *DockerSuite) TestPsListContainersFilterExited(c *testing.T) {
+	// TODO Flaky on  Windows CI [both RS1 and RS5]
+	// On slower machines the container may not have exited
+	// yet when we filter below by exit status/exit value.
+	skip.If(c, DaemonIsWindows(), "FLAKY on Windows, see #20819")
 	runSleepingContainer(c, "--name=sleep")
 
 	firstZero, _ := dockerCmd(c, "run", "-d", "busybox", "true")


### PR DESCRIPTION
relates to https://github.com/moby/moby/issues/20819

TestPsListContainersFilterExited is flaky on both RS1 and RS5.

Disable it for Windows by making it specific to Linux.

This is a workaround - a true fix would at least retry a few times in case 
of the specific failure scenario [container not yet exited by the time we check
its exit value].

Signed-off-by: Vikram bir Singh <vikrambir.singh@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Disable TestPsListContainersFilterExited on Windows

**- How I did it**
Added a check that the daemon is a Linux daemon

**- How to verify it**
Test should not be executed on Windows but continue to be executed on Linux

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
