### PR TITLE
Fix base.Dial is deprecated: Use DialContext instead

### DIFF
--- a/hack/validate/golangci-lint.yml
+++ b/hack/validate/golangci-lint.yml
@@ -46,10 +46,6 @@ issues:
     - text: "G202: SQL string concatenation"
       linters:
         - gosec
-    # FIXME temporarily suppress these. See #39925
-    - text: "SA1019: base.Dial is deprecated"
-      linters:
-        - staticcheck
     # FIXME temporarily suppress these. See #39928
     - text: "SA1019: grpc.WithDialer is deprecated"
       linters:

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/docker/distribution/registry/client/transport"
-	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/sirupsen/logrus"
 )
@@ -176,16 +175,12 @@ func NewTransport(tlsConfig *tls.Config) *http.Transport {
 
 	base := &http.Transport{
 		Proxy:               http.ProxyFromEnvironment,
-		Dial:                direct.Dial,
+		DialContext:         direct.DialContext,
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     tlsConfig,
 		// TODO(dmcgowan): Call close idle connections when complete and use keep alive
 		DisableKeepAlives: true,
 	}
 
-	proxyDialer, err := sockets.DialerFromEnvironment(direct)
-	if err == nil {
-		base.Dial = proxyDialer.Dial
-	}
 	return base
 }


### PR DESCRIPTION
1.Change base.Dial to base.DailContext.
2.Remove proxyDialer that was previously used to configure a
net.Dialer to route proxy.Dialer which will route the connections
through the proxy using the connections through a SOCKS proxy.
SOCKS proxies are now supported by configuring only http.Transport.Proxy,
and no longer require changing http.Transport.Dial.

Signed-off-by: HuanHuan Ye <logindaveye@gmail.com>

fixes #39925

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix #39925 Fixme: SA1019: base.Dial is deprecated: Use DialContext instead

**- How I did it**
1.Change base.Dial to base.DailContext.
2.Remove proxyDialer that was previously used to configure a
net.Dialer to route proxy.Dialer which will route the connections
through the proxy using the connections through a SOCKS proxy.
SOCKS proxies are now supported by configuring only http.Transport.Proxy,
and no longer require changing http.Transport.Dial.

**- How to verify it**
maybe in ci lint

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix base.Dial is deprecated: Use DialContext instead

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/8220938/65147170-25ec6900-da50-11e9-9e50-9a05a7551ef7.png)

