### PR TITLE
Removed deprecated CloseNotifier logic

### DIFF
--- a/hack/validate/golangci-lint.yml
+++ b/hack/validate/golangci-lint.yml
@@ -62,10 +62,6 @@ issues:
     - text: "SA1019: hdr.Xattrs is deprecated: Use PAXRecords instead"
       linters:
         - staticcheck
-    # FIXME temporarily suppress these. See #39929
-    - text: "SA1019: http.CloseNotifier is deprecated"
-      linters:
-        - staticcheck
     # FIXME temporarily suppress these. See #39926
     - text: "SA1019: httputil.NewClientConn is deprecated"
       linters:

--- a/pkg/authorization/response.go
+++ b/pkg/authorization/response.go
@@ -15,7 +15,6 @@ import (
 type ResponseModifier interface {
 	http.ResponseWriter
 	http.Flusher
-	http.CloseNotifier
 
 	// RawBody returns the current http content
 	RawBody() []byte
@@ -153,16 +152,6 @@ func (rm *responseModifier) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 		return nil, nil, fmt.Errorf("Internal response writer doesn't support the Hijacker interface")
 	}
 	return hijacker.Hijack()
-}
-
-// CloseNotify uses the internal close notify API of the wrapped http.ResponseWriter
-func (rm *responseModifier) CloseNotify() <-chan bool {
-	closeNotifier, ok := rm.rw.(http.CloseNotifier)
-	if !ok {
-		logrus.Error("Internal response writer doesn't support the CloseNotifier interface")
-		return nil
-	}
-	return closeNotifier.CloseNotify()
 }
 
 // Flush uses the internal flush API of the wrapped http.ResponseWriter


### PR DESCRIPTION
Signed-off-by: Justen Martin <jmart@the-coder.com>

closes #39929

**- What I did**
Removed ClosedNotifier from the ResponseModifier interface in `pkg/authorization/response.go`
**- How I did it**
Traced through the code and old prs, couldn't find any current usage of the method/interface so I went ahead and deleted it
**- How to verify it**
Ran tests, not sure if there is a more comprehensive way to validate this?
**- Description for the changelog**
Removed legacy usage of deprecated interface http.CloseNotifier.


**- A picture of a cute animal (not mandatory but encouraged)**

