### PR TITLE
Jenkinsfile: ensure all containers are cleaned up

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -701,6 +701,8 @@ pipeline {
                             sh '''
                             echo "Ensuring container killed."
                             docker rm -vf docker-pr$BUILD_NUMBER || true
+                            cids=$(docker ps -aq -f name=docker-pr${BUILD_NUMBER}-*)
+                            [ -n "$cids" ] && docker rm -vf $cids || true
                             '''
 
                             sh '''


### PR DESCRIPTION
By convention, containers spawned by jenkins jobs have the name:
docker-pr${BUILD_NUMBER}

That works fine for jobs with a single container. This commit cleans up
when multiple containers are spawned with the convention that their names
share the same "docker-pr${BUILD_NUMBER}-" prefix.

Signed-off-by: Tibor Vass <tibor@docker.com>