### PR TITLE
integration-cli: fix golint issues

### DIFF
--- a/integration-cli/checker/checker.go
+++ b/integration-cli/checker/checker.go
@@ -9,32 +9,38 @@ import (
 	"gotest.tools/assert/cmp"
 )
 
+// Compare defines the interface to compare values
 type Compare func(x interface{}) assert.BoolOrComparison
 
+// False checks if the value is false
 func False() Compare {
 	return func(x interface{}) assert.BoolOrComparison {
 		return !x.(bool)
 	}
 }
 
+// True checks if the value is true
 func True() Compare {
 	return func(x interface{}) assert.BoolOrComparison {
 		return x
 	}
 }
 
+// Equals checks if the value is equal to the given value
 func Equals(y interface{}) Compare {
 	return func(x interface{}) assert.BoolOrComparison {
 		return cmp.Equal(x, y)
 	}
 }
 
+// Contains checks if the value contains the given value
 func Contains(y interface{}) Compare {
 	return func(x interface{}) assert.BoolOrComparison {
 		return cmp.Contains(x, y)
 	}
 }
 
+// Not checks if two values are not
 func Not(c Compare) Compare {
 	return func(x interface{}) assert.BoolOrComparison {
 		r := c(x)
@@ -49,30 +55,30 @@ func Not(c Compare) Compare {
 	}
 }
 
+// DeepEquals checks if two values are equal
 func DeepEquals(y interface{}) Compare {
 	return func(x interface{}) assert.BoolOrComparison {
 		return cmp.DeepEqual(x, y)
 	}
 }
 
+// DeepEquals compares if two values are deepequal
 func HasLen(y int) Compare {
 	return func(x interface{}) assert.BoolOrComparison {
 		return cmp.Len(x, y)
 	}
 }
 
+// DeepEquals checks if the given value is nil
 func IsNil() Compare {
 	return func(x interface{}) assert.BoolOrComparison {
 		return cmp.Nil(x)
 	}
 }
 
+// GreaterThan checks if the value is greater than the given value
 func GreaterThan(y int) Compare {
 	return func(x interface{}) assert.BoolOrComparison {
 		return x.(int) > y
 	}
-}
-
-func NotNil() Compare {
-	return Not(IsNil())
 }


### PR DESCRIPTION
```
docker/integration-cli/checker/checker.go
Line 12: warning: exported type Compare should have comment or be unexported (golint)
Line 14: warning: exported function False should have comment or be unexported (golint)
Line 20: warning: exported function True should have comment or be unexported (golint)
Line 26: warning: exported function Equals should have comment or be unexported (golint)
Line 32: warning: exported function Contains should have comment or be unexported (golint)
Line 38: warning: exported function Not should have comment or be unexported (golint)
Line 52: warning: exported function DeepEquals should have comment or be unexported (golint)
Line 58: warning: exported function HasLen should have comment or be unexported (golint)
Line 64: warning: exported function IsNil should have comment or be unexported (golint)
Line 70: warning: exported function GreaterThan should have comment or be unexported (golint)
Line 76: warning: exported function NotNil should have comment or be unexported (golint)
```

