### PR TITLE
It only does release network when container is really removed.

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -137,6 +137,7 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 	selinuxFreeLxcContexts(container.ProcessLabel)
 	daemon.idIndex.Delete(container.ID)
 	daemon.containers.Delete(container.ID)
+	daemon.releaseNetwork(container)
 	daemon.containersReplica.Delete(container)
 	if e := daemon.removeMountPoints(container, removeVolume); e != nil {
 		logrus.Error(e)

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -227,8 +227,6 @@ func (daemon *Daemon) containerStart(container *container.Container, checkpoint 
 // Cleanup releases any network resources allocated to the container along with any rules
 // around how containers are linked together.  It also unmounts the container's root filesystem.
 func (daemon *Daemon) Cleanup(container *container.Container) {
-	daemon.releaseNetwork(container)
-
 	if err := container.UnmountIpcMount(); err != nil {
 		logrus.Warnf("%s cleanup: failed to unmount IPC: %s", container.ID, err)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did**
Hope for occupying container network during a stop lifecycle but the original code releases network no matter stop or remove.

**- What I did**
Only releases network after a successfully container removing, rather than releases it when containers stopped.

Once if the PR merged, I'll submit another PR for Calico libnetwork-plugin to reload the fixed-IP (or to request a new if any) when starting.

For now, this PR doesn't affect Calico libnetwork-plugin’s work.

**- How I did it**
Moved the daemon.releaseNetwork invoking to daemon.cleanupContainer from daemon.Cleanup

**- How to verify it**
- Run containers with Bridge network and stop them, and make sure the network sandbox (includes veth devices) weren't deleted.
- Run container with Calico network and stop it, the sandbox hadn't deleted, and the requested Calico IP addresses are still assigned, the workloadEndpoints are there too.
- Start the containers, verify the sandbox / Calico info. were upgraded.
- Remove the containers, all relative devices were deleted, and Calico data were upgraded correctly.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
![My Cute Daughter](https://pbs.twimg.com/media/EE0l_KaU0AEZl4V?format=jpg&name=4096x4096)
