### PR TITLE
integration-cli: run goimports

### DIFF
--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -15,6 +15,7 @@ import (
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/icmd"
+	"gotest.tools/skip"
 )
 
 func (s *DockerSuite) TestPsListContainersBase(c *testing.T) {


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>

Compile error introduced by #39945