### PR TITLE
bump libnetwork to 96bcc0dae898308ed659c5095526788a602f4726

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=92d1fbe1eb0883cf11d283cea8e658275146411d
+LIBNETWORK_COMMIT=96bcc0dae898308ed659c5095526788a602f4726
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -37,7 +37,7 @@ github.com/gofrs/flock                              7f43ea2e6a643ad441fc12d0ecc0
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        92d1fbe1eb0883cf11d283cea8e658275146411d
+github.com/docker/libnetwork                        96bcc0dae898308ed659c5095526788a602f4726
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/driverapi/driverapi.go
+++ b/vendor/github.com/docker/libnetwork/driverapi/driverapi.go
@@ -95,6 +95,11 @@ type NetworkInfo interface {
 	// TableEventRegister registers driver interest in a given
 	// table name.
 	TableEventRegister(tableName string, objType ObjectType) error
+
+	// UpdateIPamConfig updates the networks IPAM configuration
+	// based on information from the driver.  In windows, the OS (HNS) chooses
+	// the IP address space if the user does not specify an address space.
+	UpdateIpamConfig(ipV4Data []IPAMData)
 }
 
 // InterfaceInfo provides a go interface for drivers to retrieve

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ip_forwarding.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ip_forwarding.go
@@ -34,11 +34,11 @@ func setupIPForwarding(enableIPTables bool) error {
 		if err := configureIPForwarding(true); err != nil {
 			return fmt.Errorf("Enabling IP forwarding failed: %v", err)
 		}
-		// When enabling ip_forward set the default policy on forward chain to
-		// drop only if the daemon option iptables is not set to false.
-		if !enableIPTables {
-			return nil
-		}
+	}
+
+	// Set the default policy on forward chain to drop only if the
+	// daemon option iptables is not set to false.
+	if enableIPTables {
 		if err := iptables.SetDefaultPolicy(iptables.Filter, "FORWARD", iptables.Drop); err != nil {
 			if err := configureIPForwarding(false); err != nil {
 				logrus.Errorf("Disabling IP forwarding failed, %v", err)

--- a/vendor/github.com/docker/libnetwork/drivers/windows/windows.go
+++ b/vendor/github.com/docker/libnetwork/drivers/windows/windows.go
@@ -255,7 +255,7 @@ func (d *driver) DecodeTableEntry(tablename string, key string, value []byte) (s
 	return "", nil
 }
 
-func (d *driver) createNetwork(config *networkConfiguration) error {
+func (d *driver) createNetwork(config *networkConfiguration) *hnsNetwork {
 	network := &hnsNetwork{
 		id:         config.ID,
 		endpoints:  make(map[string]*hnsEndpoint),
@@ -268,7 +268,7 @@ func (d *driver) createNetwork(config *networkConfiguration) error {
 	d.networks[config.ID] = network
 	d.Unlock()
 
-	return nil
+	return network
 }
 
 // Create a new network
@@ -293,11 +293,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 		return err
 	}
 
-	err = d.createNetwork(config)
-
-	if err != nil {
-		return err
-	}
+	n := d.createNetwork(config)
 
 	// A non blank hnsid indicates that the network was discovered
 	// from HNS. No need to call HNS if this network was discovered
@@ -371,6 +367,36 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 
 		config.HnsID = hnsresponse.Id
 		genData[HNSID] = config.HnsID
+		n.created = true
+
+		defer func() {
+			if err != nil {
+				d.DeleteNetwork(n.id)
+			}
+		}()
+
+		hnsIPv4Data := make([]driverapi.IPAMData, len(hnsresponse.Subnets))
+
+		for i, subnet := range hnsresponse.Subnets {
+			var gwIP, subnetIP *net.IPNet
+
+			//The gateway returned from HNS is an IPAddress.
+			//We need to convert it to an IPNet to use as the Gateway of driverapi.IPAMData struct
+			gwCIDR := subnet.GatewayAddress + "/32"
+			_, gwIP, err = net.ParseCIDR(gwCIDR)
+			if err != nil {
+				return err
+			}
+
+			hnsIPv4Data[i].Gateway = gwIP
+			_, subnetIP, err = net.ParseCIDR(subnet.AddressPrefix)
+			if err != nil {
+				return err
+			}
+			hnsIPv4Data[i].Pool = subnetIP
+		}
+
+		nInfo.UpdateIpamConfig(hnsIPv4Data)
 
 	} else {
 		// Delete any stale HNS endpoints for this network.
@@ -387,13 +413,10 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 		} else {
 			logrus.Warnf("Error listing HNS endpoints for network %s", config.HnsID)
 		}
+
+		n.created = true
 	}
 
-	n, err := d.getNetwork(id)
-	if err != nil {
-		return err
-	}
-	n.created = true
 	return d.storeUpdate(config)
 }
 

--- a/vendor/github.com/docker/libnetwork/drivers/windows/windows_store.go
+++ b/vendor/github.com/docker/libnetwork/drivers/windows/windows_store.go
@@ -61,9 +61,7 @@ func (d *driver) populateNetworks() error {
 		if ncfg.Type != d.name {
 			continue
 		}
-		if err = d.createNetwork(ncfg); err != nil {
-			logrus.Warnf("could not create windows network for id %s hnsid %s while booting up from persistent state: %v", ncfg.ID, ncfg.HnsID, err)
-		}
+		d.createNetwork(ncfg)
 		logrus.Debugf("Network  %v (%.7s) restored", d.name, ncfg.ID)
 	}
 

--- a/vendor/github.com/docker/libnetwork/network.go
+++ b/vendor/github.com/docker/libnetwork/network.go
@@ -1938,6 +1938,22 @@ func (n *network) TableEventRegister(tableName string, objType driverapi.ObjectT
 	return nil
 }
 
+func (n *network) UpdateIpamConfig(ipV4Data []driverapi.IPAMData) {
+
+	ipamV4Config := make([]*IpamConf, len(ipV4Data))
+
+	for i, data := range ipV4Data {
+		ic := &IpamConf{}
+		ic.PreferredPool = data.Pool.String()
+		ic.Gateway = data.Gateway.IP.String()
+		ipamV4Config[i] = ic
+	}
+
+	n.Lock()
+	defer n.Unlock()
+	n.ipamV4Config = ipamV4Config
+}
+
 // Special drivers are ones which do not need to perform any network plumbing
 func (n *network) hasSpecialDriver() bool {
 	return n.Type() == "host" || n.Type() == "null"


### PR DESCRIPTION
full diff: https://github.com/docker/libnetwork/compare/92d1fbe1eb0883cf11d283cea8e658275146411d...96bcc0dae898308ed659c5095526788a602f4726

changes included:

- docker/libnetwork#2429 Updating IPAM config with results from HNS create network call
  - addresses moby/moby#38358
- docker/libnetwork#2450 Always configure iptables forward policy
  - related to moby/moby#14041 and docker/libnetwork#1526

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

