### PR TITLE
Remove use of custom "testing" interfaces

### DIFF
--- a/integration-cli/cli/build/build.go
+++ b/integration-cli/cli/build/build.go
@@ -11,6 +11,7 @@ import (
 type testingT interface {
 	Fatal(args ...interface{})
 	Fatalf(string, ...interface{})
+	Name() string
 }
 
 // WithStdinContext sets the build context from the standard input with the specified reader

--- a/integration-cli/cli/build/build.go
+++ b/integration-cli/cli/build/build.go
@@ -3,16 +3,11 @@ package build // import "github.com/docker/docker/integration-cli/cli/build"
 import (
 	"io"
 	"strings"
+	"testing"
 
 	"github.com/docker/docker/testutil/fakecontext"
 	"gotest.tools/icmd"
 )
-
-type testingT interface {
-	Fatal(args ...interface{})
-	Fatalf(string, ...interface{})
-	Name() string
-}
 
 // WithStdinContext sets the build context from the standard input with the specified reader
 func WithStdinContext(closer io.ReadCloser) func(*icmd.Cmd) func() {
@@ -59,7 +54,7 @@ func WithExternalBuildContext(ctx *fakecontext.Fake) func(*icmd.Cmd) func() {
 }
 
 // WithBuildContext sets up the build context
-func WithBuildContext(t testingT, contextOperators ...func(*fakecontext.Fake) error) func(*icmd.Cmd) func() {
+func WithBuildContext(t testing.TB, contextOperators ...func(*fakecontext.Fake) error) func(*icmd.Cmd) func() {
 	// FIXME(vdemeester) de-duplicate that
 	ctx := fakecontext.New(t, "", contextOperators...)
 	return func(cmd *icmd.Cmd) func() {
@@ -74,7 +69,7 @@ func WithFile(name, content string) func(*fakecontext.Fake) error {
 	return fakecontext.WithFile(name, content)
 }
 
-func closeBuildContext(t testingT, ctx *fakecontext.Fake) func() {
+func closeBuildContext(t testing.TB, ctx *fakecontext.Fake) func() {
 	return func() {
 		if err := ctx.Close(); err != nil {
 			t.Fatal(err)

--- a/integration-cli/cli/cli.go
+++ b/integration-cli/cli/cli.go
@@ -28,6 +28,7 @@ type testingT interface {
 	assert.TestingT
 	Fatal(args ...interface{})
 	Fatalf(string, ...interface{})
+	Name() string
 }
 
 // DockerCmd executes the specified docker command and expect a success

--- a/integration-cli/cli/cli.go
+++ b/integration-cli/cli/cli.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/integration-cli/environment"
 	"github.com/pkg/errors"
-	"gotest.tools/assert"
 	"gotest.tools/icmd"
 )
 
@@ -24,46 +24,39 @@ func SetTestEnvironment(env *environment.Execution) {
 // CmdOperator defines functions that can modify a command
 type CmdOperator func(*icmd.Cmd) func()
 
-type testingT interface {
-	assert.TestingT
-	Fatal(args ...interface{})
-	Fatalf(string, ...interface{})
-	Name() string
-}
-
 // DockerCmd executes the specified docker command and expect a success
-func DockerCmd(t testingT, args ...string) *icmd.Result {
+func DockerCmd(t testing.TB, args ...string) *icmd.Result {
 	return Docker(Args(args...)).Assert(t, icmd.Success)
 }
 
 // BuildCmd executes the specified docker build command and expect a success
-func BuildCmd(t testingT, name string, cmdOperators ...CmdOperator) *icmd.Result {
+func BuildCmd(t testing.TB, name string, cmdOperators ...CmdOperator) *icmd.Result {
 	return Docker(Build(name), cmdOperators...).Assert(t, icmd.Success)
 }
 
 // InspectCmd executes the specified docker inspect command and expect a success
-func InspectCmd(t testingT, name string, cmdOperators ...CmdOperator) *icmd.Result {
+func InspectCmd(t testing.TB, name string, cmdOperators ...CmdOperator) *icmd.Result {
 	return Docker(Inspect(name), cmdOperators...).Assert(t, icmd.Success)
 }
 
 // WaitRun will wait for the specified container to be running, maximum 5 seconds.
-func WaitRun(t testingT, name string, cmdOperators ...CmdOperator) {
+func WaitRun(t testing.TB, name string, cmdOperators ...CmdOperator) {
 	WaitForInspectResult(t, name, "{{.State.Running}}", "true", 5*time.Second, cmdOperators...)
 }
 
 // WaitExited will wait for the specified container to state exit, subject
 // to a maximum time limit in seconds supplied by the caller
-func WaitExited(t testingT, name string, timeout time.Duration, cmdOperators ...CmdOperator) {
+func WaitExited(t testing.TB, name string, timeout time.Duration, cmdOperators ...CmdOperator) {
 	WaitForInspectResult(t, name, "{{.State.Status}}", "exited", timeout, cmdOperators...)
 }
 
 // WaitRestart will wait for the specified container to restart once
-func WaitRestart(t testingT, name string, timeout time.Duration, cmdOperators ...CmdOperator) {
+func WaitRestart(t testing.TB, name string, timeout time.Duration, cmdOperators ...CmdOperator) {
 	WaitForInspectResult(t, name, "{{.RestartCount}}", "1", timeout, cmdOperators...)
 }
 
 // WaitForInspectResult waits for the specified expression to be equals to the specified expected string in the given time.
-func WaitForInspectResult(t testingT, name, expr, expected string, timeout time.Duration, cmdOperators ...CmdOperator) {
+func WaitForInspectResult(t testing.TB, name, expr, expected string, timeout time.Duration, cmdOperators ...CmdOperator) {
 	after := time.After(timeout)
 
 	args := []string{"inspect", "-f", expr, name}

--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -12,17 +12,6 @@ import (
 	"gotest.tools/icmd"
 )
 
-type testingT interface {
-	assert.TestingT
-	logT
-	Fatalf(string, ...interface{})
-	Name() string
-}
-
-type logT interface {
-	Logf(string, ...interface{})
-}
-
 // Daemon represents a Docker daemon for the testing framework.
 type Daemon struct {
 	*daemon.Daemon
@@ -32,7 +21,7 @@ type Daemon struct {
 // New returns a Daemon instance to be used for testing.
 // This will create a directory such as d123456789 in the folder specified by $DOCKER_INTEGRATION_DAEMON_DEST or $DEST.
 // The daemon will not automatically start.
-func New(t testingT, dockerBinary string, dockerdBinary string, ops ...daemon.Option) *Daemon {
+func New(t testing.TB, dockerBinary string, dockerdBinary string, ops ...daemon.Option) *Daemon {
 	ops = append(ops, daemon.WithDockerdBinary(dockerdBinary))
 	d := daemon.New(t, ops...)
 	return &Daemon{

--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -16,6 +16,7 @@ type testingT interface {
 	assert.TestingT
 	logT
 	Fatalf(string, ...interface{})
+	Name() string
 }
 
 type logT interface {

--- a/testutil/daemon/config.go
+++ b/testutil/daemon/config.go
@@ -2,10 +2,10 @@ package daemon
 
 import (
 	"context"
+	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/testutil"
 	"gotest.tools/assert"
 )
 
@@ -13,10 +13,8 @@ import (
 type ConfigConstructor func(*swarm.Config)
 
 // CreateConfig creates a config given the specified spec
-func (d *Daemon) CreateConfig(t assert.TestingT, configSpec swarm.ConfigSpec) string {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) CreateConfig(t testing.TB, configSpec swarm.ConfigSpec) string {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -26,10 +24,8 @@ func (d *Daemon) CreateConfig(t assert.TestingT, configSpec swarm.ConfigSpec) st
 }
 
 // ListConfigs returns the list of the current swarm configs
-func (d *Daemon) ListConfigs(t assert.TestingT) []swarm.Config {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) ListConfigs(t testing.TB) []swarm.Config {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -39,10 +35,8 @@ func (d *Daemon) ListConfigs(t assert.TestingT) []swarm.Config {
 }
 
 // GetConfig returns a swarm config identified by the specified id
-func (d *Daemon) GetConfig(t assert.TestingT, id string) *swarm.Config {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) GetConfig(t testing.TB, id string) *swarm.Config {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -52,10 +46,8 @@ func (d *Daemon) GetConfig(t assert.TestingT, id string) *swarm.Config {
 }
 
 // DeleteConfig removes the swarm config identified by the specified id
-func (d *Daemon) DeleteConfig(t assert.TestingT, id string) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) DeleteConfig(t testing.TB, id string) {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -65,10 +57,8 @@ func (d *Daemon) DeleteConfig(t assert.TestingT, id string) {
 
 // UpdateConfig updates the swarm config identified by the specified id
 // Currently, only label update is supported.
-func (d *Daemon) UpdateConfig(t assert.TestingT, id string, f ...ConfigConstructor) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) UpdateConfig(t testing.TB, id string, f ...ConfigConstructor) {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 

--- a/testutil/daemon/container.go
+++ b/testutil/daemon/container.go
@@ -2,17 +2,15 @@ package daemon
 
 import (
 	"context"
+	"testing"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/testutil"
 	"gotest.tools/assert"
 )
 
 // ActiveContainers returns the list of ids of the currently running containers
-func (d *Daemon) ActiveContainers(t assert.TestingT) []string {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) ActiveContainers(t testing.TB) []string {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -27,10 +25,8 @@ func (d *Daemon) ActiveContainers(t assert.TestingT) []string {
 }
 
 // FindContainerIP returns the ip of the specified container
-func (d *Daemon) FindContainerIP(t assert.TestingT, id string) string {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) FindContainerIP(t testing.TB, id string) string {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/request"
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
@@ -34,7 +33,7 @@ type logT interface {
 }
 
 // nopLog is a no-op implementation of logT that is used in daemons created by
-// NewDaemon (where no testingT is available).
+// NewDaemon (where no testing.TB is available).
 type nopLog struct{}
 
 func (nopLog) Logf(string, ...interface{}) {}
@@ -194,10 +193,8 @@ func (d *Daemon) ReadLogFile() ([]byte, error) {
 }
 
 // NewClientT creates new client based on daemon's socket path
-func (d *Daemon) NewClientT(t assert.TestingT, extraOpts ...client.Opt) *client.Client {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) NewClientT(t testing.TB, extraOpts ...client.Opt) *client.Client {
+	t.Helper()
 
 	c, err := d.NewClient(extraOpts...)
 	assert.NilError(t, err, "cannot create daemon client")
@@ -595,10 +592,8 @@ func (d *Daemon) ReloadConfig() error {
 }
 
 // LoadBusybox image into the daemon
-func (d *Daemon) LoadBusybox(t assert.TestingT) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) LoadBusybox(t testing.TB) {
+	t.Helper()
 	clientHost, err := client.NewClientWithOpts(client.FromEnv)
 	assert.NilError(t, err, "failed to create client")
 	defer clientHost.Close()
@@ -709,10 +704,8 @@ func (d *Daemon) queryRootDir() (string, error) {
 }
 
 // Info returns the info struct for this daemon
-func (d *Daemon) Info(t assert.TestingT) types.Info {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) Info(t testing.TB) types.Info {
+	t.Helper()
 	c := d.NewClientT(t)
 	info, err := c.Info(context.Background())
 	assert.NilError(t, err)

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -27,13 +28,6 @@ import (
 	"github.com/pkg/errors"
 	"gotest.tools/assert"
 )
-
-type testingT interface {
-	assert.TestingT
-	logT
-	Fatalf(string, ...interface{})
-	Name() string
-}
 
 type logT interface {
 	Logf(string, ...interface{})
@@ -143,7 +137,7 @@ func NewDaemon(workingDir string, ops ...Option) (*Daemon, error) {
 // This will create a directory such as d123456789 in the folder specified by
 // $DOCKER_INTEGRATION_DAEMON_DEST or $DEST.
 // The daemon will not automatically start.
-func New(t testingT, ops ...Option) *Daemon {
+func New(t testing.TB, ops ...Option) *Daemon {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}
@@ -224,7 +218,7 @@ func (d *Daemon) NewClient(extraOpts ...client.Opt) (*client.Client, error) {
 }
 
 // Cleanup cleans the daemon files : exec root (network namespaces, ...), swarmkit files
-func (d *Daemon) Cleanup(t testingT) {
+func (d *Daemon) Cleanup(t testing.TB) {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}
@@ -234,7 +228,7 @@ func (d *Daemon) Cleanup(t testingT) {
 }
 
 // Start starts the daemon and return once it is ready to receive requests.
-func (d *Daemon) Start(t testingT, args ...string) {
+func (d *Daemon) Start(t testing.TB, args ...string) {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}
@@ -390,7 +384,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 
 // StartWithBusybox will first start the daemon with Daemon.Start()
 // then save the busybox image from the main daemon and load it into this Daemon instance.
-func (d *Daemon) StartWithBusybox(t testingT, arg ...string) {
+func (d *Daemon) StartWithBusybox(t testing.TB, arg ...string) {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}
@@ -449,7 +443,7 @@ func (d *Daemon) DumpStackAndQuit() {
 // Stop will not delete the daemon directory. If a purged daemon is needed,
 // instantiate a new one with NewDaemon.
 // If an error occurs while starting the daemon, the test will fail.
-func (d *Daemon) Stop(t testingT) {
+func (d *Daemon) Stop(t testing.TB) {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}
@@ -537,7 +531,7 @@ out2:
 
 // Restart will restart the daemon by first stopping it and the starting it.
 // If an error occurs while starting the daemon, the test will fail.
-func (d *Daemon) Restart(t testingT, args ...string) {
+func (d *Daemon) Restart(t testing.TB, args ...string) {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}
@@ -737,7 +731,7 @@ func (d *Daemon) Info(t assert.TestingT) types.Info {
 	return info
 }
 
-func cleanupRaftDir(t testingT, rootPath string) {
+func cleanupRaftDir(t testing.TB, rootPath string) {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -138,9 +138,7 @@ func NewDaemon(workingDir string, ops ...Option) (*Daemon, error) {
 // $DOCKER_INTEGRATION_DAEMON_DEST or $DEST.
 // The daemon will not automatically start.
 func New(t testing.TB, ops ...Option) *Daemon {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	dest := os.Getenv("DOCKER_INTEGRATION_DAEMON_DEST")
 	if dest == "" {
 		dest = os.Getenv("DEST")
@@ -219,9 +217,7 @@ func (d *Daemon) NewClient(extraOpts ...client.Opt) (*client.Client, error) {
 
 // Cleanup cleans the daemon files : exec root (network namespaces, ...), swarmkit files
 func (d *Daemon) Cleanup(t testing.TB) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	// Cleanup swarmkit wal files if present
 	cleanupRaftDir(t, d.Root)
 	cleanupNetworkNamespace(t, d.execRoot)
@@ -229,9 +225,7 @@ func (d *Daemon) Cleanup(t testing.TB) {
 
 // Start starts the daemon and return once it is ready to receive requests.
 func (d *Daemon) Start(t testing.TB, args ...string) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	if err := d.StartWithError(args...); err != nil {
 		t.Fatalf("failed to start daemon with arguments %v : %v", args, err)
 	}
@@ -385,9 +379,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 // StartWithBusybox will first start the daemon with Daemon.Start()
 // then save the busybox image from the main daemon and load it into this Daemon instance.
 func (d *Daemon) StartWithBusybox(t testing.TB, arg ...string) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	d.Start(t, arg...)
 	d.LoadBusybox(t)
 }
@@ -444,9 +436,7 @@ func (d *Daemon) DumpStackAndQuit() {
 // instantiate a new one with NewDaemon.
 // If an error occurs while starting the daemon, the test will fail.
 func (d *Daemon) Stop(t testing.TB) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	err := d.StopWithError()
 	if err != nil {
 		if err != errDaemonNotStarted {
@@ -532,9 +522,7 @@ out2:
 // Restart will restart the daemon by first stopping it and the starting it.
 // If an error occurs while starting the daemon, the test will fail.
 func (d *Daemon) Restart(t testing.TB, args ...string) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	d.Stop(t)
 	d.Start(t, args...)
 }
@@ -732,9 +720,7 @@ func (d *Daemon) Info(t assert.TestingT) types.Info {
 }
 
 func cleanupRaftDir(t testing.TB, rootPath string) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	for _, p := range []string{"wal", "wal-v3-encrypted", "snap-v3-encrypted"} {
 		dir := filepath.Join(rootPath, "swarm/raft", p)
 		if err := os.RemoveAll(dir); err != nil {

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -32,13 +32,7 @@ type testingT interface {
 	assert.TestingT
 	logT
 	Fatalf(string, ...interface{})
-}
-
-type namer interface {
 	Name() string
-}
-type testNamer interface {
-	TestName() string
 }
 
 type logT interface {
@@ -157,13 +151,8 @@ func New(t testingT, ops ...Option) *Daemon {
 	if dest == "" {
 		dest = os.Getenv("DEST")
 	}
+	dest = filepath.Join(dest, t.Name())
 
-	switch v := t.(type) {
-	case namer:
-		dest = filepath.Join(dest, v.Name())
-	case testNamer:
-		dest = filepath.Join(dest, v.TestName())
-	}
 	assert.Check(t, dest != "", "Please set the DOCKER_INTEGRATION_DAEMON_DEST or the DEST environment variable")
 
 	t.Logf("Creating a new daemon at: %q", dest)

--- a/testutil/daemon/daemon_unix.go
+++ b/testutil/daemon/daemon_unix.go
@@ -9,15 +9,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/testutil"
 	"golang.org/x/sys/unix"
 	"gotest.tools/assert"
 )
 
 func cleanupNetworkNamespace(t testing.TB, execRoot string) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	// Cleanup network namespaces in the exec root of this
 	// daemon because this exec root is specific to this
 	// daemon instance and has no chance of getting

--- a/testutil/daemon/daemon_unix.go
+++ b/testutil/daemon/daemon_unix.go
@@ -7,13 +7,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"testing"
 
 	"github.com/docker/docker/testutil"
 	"golang.org/x/sys/unix"
 	"gotest.tools/assert"
 )
 
-func cleanupNetworkNamespace(t testingT, execRoot string) {
+func cleanupNetworkNamespace(t testing.TB, execRoot string) {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}
@@ -33,7 +34,7 @@ func cleanupNetworkNamespace(t testingT, execRoot string) {
 }
 
 // CgroupNamespace returns the cgroup namespace the daemon is running in
-func (d *Daemon) CgroupNamespace(t assert.TestingT) string {
+func (d *Daemon) CgroupNamespace(t testing.TB) string {
 	link, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/cgroup", d.Pid()))
 	assert.NilError(t, err)
 

--- a/testutil/daemon/daemon_windows.go
+++ b/testutil/daemon/daemon_windows.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"strconv"
+	"testing"
 
 	"golang.org/x/sys/windows"
 	"gotest.tools/assert"
@@ -22,11 +23,11 @@ func signalDaemonReload(pid int) error {
 	return fmt.Errorf("daemon reload not supported")
 }
 
-func cleanupNetworkNamespace(t testingT, execRoot string) {
+func cleanupNetworkNamespace(t testing.TB, execRoot string) {
 }
 
 // CgroupNamespace returns the cgroup namespace the daemon is running in
-func (d *Daemon) CgroupNamespace(t assert.TestingT) string {
+func (d *Daemon) CgroupNamespace(t testing.TB) string {
 	assert.Assert(t, false)
 	return "cgroup namespaces are not supported on Windows"
 }

--- a/testutil/daemon/node.go
+++ b/testutil/daemon/node.go
@@ -3,11 +3,11 @@ package daemon
 import (
 	"context"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/testutil"
 	"gotest.tools/assert"
 )
 
@@ -15,10 +15,8 @@ import (
 type NodeConstructor func(*swarm.Node)
 
 // GetNode returns a swarm node identified by the specified id
-func (d *Daemon) GetNode(t assert.TestingT, id string, errCheck ...func(error) bool) *swarm.Node {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) GetNode(t testing.TB, id string, errCheck ...func(error) bool) *swarm.Node {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -36,10 +34,8 @@ func (d *Daemon) GetNode(t assert.TestingT, id string, errCheck ...func(error) b
 }
 
 // RemoveNode removes the specified node
-func (d *Daemon) RemoveNode(t assert.TestingT, id string, force bool) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) RemoveNode(t testing.TB, id string, force bool) {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -51,10 +47,8 @@ func (d *Daemon) RemoveNode(t assert.TestingT, id string, force bool) {
 }
 
 // UpdateNode updates a swarm node with the specified node constructor
-func (d *Daemon) UpdateNode(t assert.TestingT, id string, f ...NodeConstructor) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) UpdateNode(t testing.TB, id string, f ...NodeConstructor) {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -75,10 +69,8 @@ func (d *Daemon) UpdateNode(t assert.TestingT, id string, f ...NodeConstructor) 
 }
 
 // ListNodes returns the list of the current swarm nodes
-func (d *Daemon) ListNodes(t assert.TestingT) []swarm.Node {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) ListNodes(t testing.TB) []swarm.Node {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 

--- a/testutil/daemon/plugin.go
+++ b/testutil/daemon/plugin.go
@@ -2,15 +2,15 @@ package daemon
 
 import (
 	"context"
+	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"gotest.tools/assert"
 	"gotest.tools/poll"
 )
 
 // PluginIsRunning provides a poller to check if the specified plugin is running
-func (d *Daemon) PluginIsRunning(t assert.TestingT, name string) func(poll.LogT) poll.Result {
+func (d *Daemon) PluginIsRunning(t testing.TB, name string) func(poll.LogT) poll.Result {
 	return withClient(t, d, withPluginInspect(name, func(plugin *types.Plugin, t poll.LogT) poll.Result {
 		if plugin.Enabled {
 			return poll.Success()
@@ -20,7 +20,7 @@ func (d *Daemon) PluginIsRunning(t assert.TestingT, name string) func(poll.LogT)
 }
 
 // PluginIsNotRunning provides a poller to check if the specified plugin is not running
-func (d *Daemon) PluginIsNotRunning(t assert.TestingT, name string) func(poll.LogT) poll.Result {
+func (d *Daemon) PluginIsNotRunning(t testing.TB, name string) func(poll.LogT) poll.Result {
 	return withClient(t, d, withPluginInspect(name, func(plugin *types.Plugin, t poll.LogT) poll.Result {
 		if !plugin.Enabled {
 			return poll.Success()
@@ -30,7 +30,7 @@ func (d *Daemon) PluginIsNotRunning(t assert.TestingT, name string) func(poll.Lo
 }
 
 // PluginIsNotPresent provides a poller to check if the specified plugin is not present
-func (d *Daemon) PluginIsNotPresent(t assert.TestingT, name string) func(poll.LogT) poll.Result {
+func (d *Daemon) PluginIsNotPresent(t testing.TB, name string) func(poll.LogT) poll.Result {
 	return withClient(t, d, func(c client.APIClient, t poll.LogT) poll.Result {
 		_, _, err := c.PluginInspectWithRaw(context.Background(), name)
 		if client.IsErrNotFound(err) {
@@ -44,7 +44,7 @@ func (d *Daemon) PluginIsNotPresent(t assert.TestingT, name string) func(poll.Lo
 }
 
 // PluginReferenceIs provides a poller to check if the specified plugin has the specified reference
-func (d *Daemon) PluginReferenceIs(t assert.TestingT, name, expectedRef string) func(poll.LogT) poll.Result {
+func (d *Daemon) PluginReferenceIs(t testing.TB, name, expectedRef string) func(poll.LogT) poll.Result {
 	return withClient(t, d, withPluginInspect(name, func(plugin *types.Plugin, t poll.LogT) poll.Result {
 		if plugin.PluginReference == expectedRef {
 			return poll.Success()
@@ -67,7 +67,7 @@ func withPluginInspect(name string, f func(*types.Plugin, poll.LogT) poll.Result
 
 }
 
-func withClient(t assert.TestingT, d *Daemon, f func(client.APIClient, poll.LogT) poll.Result) func(poll.LogT) poll.Result {
+func withClient(t testing.TB, d *Daemon, f func(client.APIClient, poll.LogT) poll.Result) func(poll.LogT) poll.Result {
 	return func(pt poll.LogT) poll.Result {
 		c := d.NewClientT(t)
 		return f(c, pt)

--- a/testutil/daemon/secret.go
+++ b/testutil/daemon/secret.go
@@ -2,10 +2,10 @@ package daemon
 
 import (
 	"context"
+	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/testutil"
 	"gotest.tools/assert"
 )
 
@@ -13,10 +13,8 @@ import (
 type SecretConstructor func(*swarm.Secret)
 
 // CreateSecret creates a secret given the specified spec
-func (d *Daemon) CreateSecret(t assert.TestingT, secretSpec swarm.SecretSpec) string {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) CreateSecret(t testing.TB, secretSpec swarm.SecretSpec) string {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -27,10 +25,8 @@ func (d *Daemon) CreateSecret(t assert.TestingT, secretSpec swarm.SecretSpec) st
 }
 
 // ListSecrets returns the list of the current swarm secrets
-func (d *Daemon) ListSecrets(t assert.TestingT) []swarm.Secret {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) ListSecrets(t testing.TB) []swarm.Secret {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -40,10 +36,8 @@ func (d *Daemon) ListSecrets(t assert.TestingT) []swarm.Secret {
 }
 
 // GetSecret returns a swarm secret identified by the specified id
-func (d *Daemon) GetSecret(t assert.TestingT, id string) *swarm.Secret {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) GetSecret(t testing.TB, id string) *swarm.Secret {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -53,10 +47,8 @@ func (d *Daemon) GetSecret(t assert.TestingT, id string) *swarm.Secret {
 }
 
 // DeleteSecret removes the swarm secret identified by the specified id
-func (d *Daemon) DeleteSecret(t assert.TestingT, id string) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) DeleteSecret(t testing.TB, id string) {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -66,10 +58,8 @@ func (d *Daemon) DeleteSecret(t assert.TestingT, id string) {
 
 // UpdateSecret updates the swarm secret identified by the specified id
 // Currently, only label update is supported.
-func (d *Daemon) UpdateSecret(t assert.TestingT, id string, f ...SecretConstructor) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) UpdateSecret(t testing.TB, id string, f ...SecretConstructor) {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 

--- a/testutil/daemon/service.go
+++ b/testutil/daemon/service.go
@@ -2,22 +2,20 @@ package daemon
 
 import (
 	"context"
+	"testing"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/testutil"
 	"gotest.tools/assert"
 )
 
 // ServiceConstructor defines a swarm service constructor function
 type ServiceConstructor func(*swarm.Service)
 
-func (d *Daemon) createServiceWithOptions(t assert.TestingT, opts types.ServiceCreateOptions, f ...ServiceConstructor) string {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) createServiceWithOptions(t testing.TB, opts types.ServiceCreateOptions, f ...ServiceConstructor) string {
+	t.Helper()
 	var service swarm.Service
 	for _, fn := range f {
 		fn(&service)
@@ -35,18 +33,14 @@ func (d *Daemon) createServiceWithOptions(t assert.TestingT, opts types.ServiceC
 }
 
 // CreateService creates a swarm service given the specified service constructor
-func (d *Daemon) CreateService(t assert.TestingT, f ...ServiceConstructor) string {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) CreateService(t testing.TB, f ...ServiceConstructor) string {
+	t.Helper()
 	return d.createServiceWithOptions(t, types.ServiceCreateOptions{}, f...)
 }
 
 // GetService returns the swarm service corresponding to the specified id
-func (d *Daemon) GetService(t assert.TestingT, id string) *swarm.Service {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) GetService(t testing.TB, id string) *swarm.Service {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -56,10 +50,8 @@ func (d *Daemon) GetService(t assert.TestingT, id string) *swarm.Service {
 }
 
 // GetServiceTasks returns the swarm tasks for the specified service
-func (d *Daemon) GetServiceTasks(t assert.TestingT, service string, additionalFilters ...filters.KeyValuePair) []swarm.Task {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) GetServiceTasks(t testing.TB, service string, additionalFilters ...filters.KeyValuePair) []swarm.Task {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -80,10 +72,8 @@ func (d *Daemon) GetServiceTasks(t assert.TestingT, service string, additionalFi
 }
 
 // UpdateService updates a swarm service with the specified service constructor
-func (d *Daemon) UpdateService(t assert.TestingT, service *swarm.Service, f ...ServiceConstructor) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) UpdateService(t testing.TB, service *swarm.Service, f ...ServiceConstructor) {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -96,10 +86,8 @@ func (d *Daemon) UpdateService(t assert.TestingT, service *swarm.Service, f ...S
 }
 
 // RemoveService removes the specified service
-func (d *Daemon) RemoveService(t assert.TestingT, id string) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) RemoveService(t testing.TB, id string) {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -108,10 +96,8 @@ func (d *Daemon) RemoveService(t assert.TestingT, id string) {
 }
 
 // ListServices returns the list of the current swarm services
-func (d *Daemon) ListServices(t assert.TestingT) []swarm.Service {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) ListServices(t testing.TB) []swarm.Service {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -121,10 +107,8 @@ func (d *Daemon) ListServices(t assert.TestingT) []swarm.Service {
 }
 
 // GetTask returns the swarm task identified by the specified id
-func (d *Daemon) GetTask(t assert.TestingT, id string) swarm.Task {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) GetTask(t testing.TB, id string) swarm.Task {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 

--- a/testutil/daemon/swarm.go
+++ b/testutil/daemon/swarm.go
@@ -23,25 +23,19 @@ var (
 
 // StartNode (re)starts the daemon
 func (d *Daemon) StartNode(t testing.TB) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	d.Start(t, startArgs...)
 }
 
 // StartNodeWithBusybox starts daemon to be used as a swarm node, and loads the busybox image
 func (d *Daemon) StartNodeWithBusybox(t testing.TB) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	d.StartWithBusybox(t, startArgs...)
 }
 
 // RestartNode restarts a daemon to be used as a swarm node
 func (d *Daemon) RestartNode(t testing.TB) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	// avoid networking conflicts
 	d.Stop(t)
 	d.Start(t, startArgs...)
@@ -55,9 +49,7 @@ func (d *Daemon) StartAndSwarmInit(t testing.TB) {
 
 // StartAndSwarmJoin starts the daemon (with busybox) and join the specified swarm as worker or manager
 func (d *Daemon) StartAndSwarmJoin(t testing.TB, leader *Daemon, manager bool) {
-	if th, ok := t.(testutil.HelperT); ok {
-		th.Helper()
-	}
+	t.Helper()
 	d.StartNodeWithBusybox(t)
 
 	tokens := leader.JoinTokens(t)

--- a/testutil/daemon/swarm.go
+++ b/testutil/daemon/swarm.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/testutil"
 	"github.com/pkg/errors"
 	"gotest.tools/assert"
 )
@@ -78,10 +77,8 @@ func (d *Daemon) NodeID() string {
 }
 
 // SwarmInit initializes a new swarm cluster.
-func (d *Daemon) SwarmInit(t assert.TestingT, req swarm.InitRequest) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) SwarmInit(t testing.TB, req swarm.InitRequest) {
+	t.Helper()
 	if req.ListenAddr == "" {
 		req.ListenAddr = fmt.Sprintf("%s:%d", d.swarmListenAddr, d.SwarmPort)
 	}
@@ -100,10 +97,8 @@ func (d *Daemon) SwarmInit(t assert.TestingT, req swarm.InitRequest) {
 }
 
 // SwarmJoin joins a daemon to an existing cluster.
-func (d *Daemon) SwarmJoin(t assert.TestingT, req swarm.JoinRequest) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) SwarmJoin(t testing.TB, req swarm.JoinRequest) {
+	t.Helper()
 	if req.ListenAddr == "" {
 		req.ListenAddr = fmt.Sprintf("%s:%d", d.swarmListenAddr, d.SwarmPort)
 	}
@@ -116,20 +111,18 @@ func (d *Daemon) SwarmJoin(t assert.TestingT, req swarm.JoinRequest) {
 
 // SwarmLeave forces daemon to leave current cluster.
 //
-// The passed in TestingT is only used to validate that the client was successfully created
+// The passed in testing.TB is only used to validate that the client was successfully created
 // Some tests rely on error checking the result of the actual unlock, so allow
 // the error to be returned.
-func (d *Daemon) SwarmLeave(t assert.TestingT, force bool) error {
+func (d *Daemon) SwarmLeave(t testing.TB, force bool) error {
 	cli := d.NewClientT(t)
 	defer cli.Close()
 	return cli.SwarmLeave(context.Background(), force)
 }
 
 // SwarmInfo returns the swarm information of the daemon
-func (d *Daemon) SwarmInfo(t assert.TestingT) swarm.Info {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) SwarmInfo(t testing.TB) swarm.Info {
+	t.Helper()
 	cli := d.NewClientT(t)
 	info, err := cli.Info(context.Background())
 	assert.NilError(t, err, "get swarm info")
@@ -138,10 +131,10 @@ func (d *Daemon) SwarmInfo(t assert.TestingT) swarm.Info {
 
 // SwarmUnlock tries to unlock a locked swarm
 //
-// The passed in TestingT is only used to validate that the client was successfully created
+// The passed in testing.TB is only used to validate that the client was successfully created
 // Some tests rely on error checking the result of the actual unlock, so allow
 // the error to be returned.
-func (d *Daemon) SwarmUnlock(t assert.TestingT, req swarm.UnlockRequest) error {
+func (d *Daemon) SwarmUnlock(t testing.TB, req swarm.UnlockRequest) error {
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -153,10 +146,8 @@ func (d *Daemon) SwarmUnlock(t assert.TestingT, req swarm.UnlockRequest) error {
 }
 
 // GetSwarm returns the current swarm object
-func (d *Daemon) GetSwarm(t assert.TestingT) swarm.Swarm {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) GetSwarm(t testing.TB) swarm.Swarm {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -166,10 +157,8 @@ func (d *Daemon) GetSwarm(t assert.TestingT) swarm.Swarm {
 }
 
 // UpdateSwarm updates the current swarm object with the specified spec constructors
-func (d *Daemon) UpdateSwarm(t assert.TestingT, f ...SpecConstructor) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) UpdateSwarm(t testing.TB, f ...SpecConstructor) {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -183,10 +172,8 @@ func (d *Daemon) UpdateSwarm(t assert.TestingT, f ...SpecConstructor) {
 }
 
 // RotateTokens update the swarm to rotate tokens
-func (d *Daemon) RotateTokens(t assert.TestingT) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) RotateTokens(t testing.TB) {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
@@ -203,10 +190,8 @@ func (d *Daemon) RotateTokens(t assert.TestingT) {
 }
 
 // JoinTokens returns the current swarm join tokens
-func (d *Daemon) JoinTokens(t assert.TestingT) swarm.JoinTokens {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (d *Daemon) JoinTokens(t testing.TB) swarm.JoinTokens {
+	t.Helper()
 	cli := d.NewClientT(t)
 	defer cli.Close()
 

--- a/testutil/daemon/swarm.go
+++ b/testutil/daemon/swarm.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/testutil"
@@ -21,7 +22,7 @@ var (
 )
 
 // StartNode (re)starts the daemon
-func (d *Daemon) StartNode(t testingT) {
+func (d *Daemon) StartNode(t testing.TB) {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}
@@ -29,7 +30,7 @@ func (d *Daemon) StartNode(t testingT) {
 }
 
 // StartNodeWithBusybox starts daemon to be used as a swarm node, and loads the busybox image
-func (d *Daemon) StartNodeWithBusybox(t testingT) {
+func (d *Daemon) StartNodeWithBusybox(t testing.TB) {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}
@@ -37,7 +38,7 @@ func (d *Daemon) StartNodeWithBusybox(t testingT) {
 }
 
 // RestartNode restarts a daemon to be used as a swarm node
-func (d *Daemon) RestartNode(t testingT) {
+func (d *Daemon) RestartNode(t testing.TB) {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}
@@ -47,13 +48,13 @@ func (d *Daemon) RestartNode(t testingT) {
 }
 
 // StartAndSwarmInit starts the daemon (with busybox) and init the swarm
-func (d *Daemon) StartAndSwarmInit(t testingT) {
+func (d *Daemon) StartAndSwarmInit(t testing.TB) {
 	d.StartNodeWithBusybox(t)
 	d.SwarmInit(t, swarm.InitRequest{})
 }
 
 // StartAndSwarmJoin starts the daemon (with busybox) and join the specified swarm as worker or manager
-func (d *Daemon) StartAndSwarmJoin(t testingT, leader *Daemon, manager bool) {
+func (d *Daemon) StartAndSwarmJoin(t testing.TB, leader *Daemon, manager bool) {
 	if th, ok := t.(testutil.HelperT); ok {
 		th.Helper()
 	}

--- a/testutil/environment/clean.go
+++ b/testutil/environment/clean.go
@@ -4,21 +4,19 @@ import (
 	"context"
 	"regexp"
 	"strings"
+	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/testutil"
 	"gotest.tools/assert"
 )
 
 // Clean the environment, preserving protected objects (images, containers, ...)
 // and removing everything else. It's meant to run after any tests so that they don't
 // depend on each others.
-func (e *Execution) Clean(t assert.TestingT) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (e *Execution) Clean(t testing.TB) {
+	t.Helper()
 	client := e.APIClient()
 
 	platform := e.OSType
@@ -34,10 +32,8 @@ func (e *Execution) Clean(t assert.TestingT) {
 	}
 }
 
-func unpauseAllContainers(t assert.TestingT, client client.ContainerAPIClient) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func unpauseAllContainers(t testing.TB, client client.ContainerAPIClient) {
+	t.Helper()
 	ctx := context.Background()
 	containers := getPausedContainers(ctx, t, client)
 	if len(containers) > 0 {
@@ -48,10 +44,8 @@ func unpauseAllContainers(t assert.TestingT, client client.ContainerAPIClient) {
 	}
 }
 
-func getPausedContainers(ctx context.Context, t assert.TestingT, client client.ContainerAPIClient) []types.Container {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func getPausedContainers(ctx context.Context, t testing.TB, client client.ContainerAPIClient) []types.Container {
+	t.Helper()
 	filter := filters.NewArgs()
 	filter.Add("status", "paused")
 	containers, err := client.ContainerList(ctx, types.ContainerListOptions{
@@ -65,10 +59,8 @@ func getPausedContainers(ctx context.Context, t assert.TestingT, client client.C
 
 var alreadyExists = regexp.MustCompile(`Error response from daemon: removal of container (\w+) is already in progress`)
 
-func deleteAllContainers(t assert.TestingT, apiclient client.ContainerAPIClient, protectedContainers map[string]struct{}) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func deleteAllContainers(t testing.TB, apiclient client.ContainerAPIClient, protectedContainers map[string]struct{}) {
+	t.Helper()
 	ctx := context.Background()
 	containers := getAllContainers(ctx, t, apiclient)
 	if len(containers) == 0 {
@@ -90,10 +82,8 @@ func deleteAllContainers(t assert.TestingT, apiclient client.ContainerAPIClient,
 	}
 }
 
-func getAllContainers(ctx context.Context, t assert.TestingT, client client.ContainerAPIClient) []types.Container {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func getAllContainers(ctx context.Context, t testing.TB, client client.ContainerAPIClient) []types.Container {
+	t.Helper()
 	containers, err := client.ContainerList(ctx, types.ContainerListOptions{
 		Quiet: true,
 		All:   true,
@@ -102,10 +92,8 @@ func getAllContainers(ctx context.Context, t assert.TestingT, client client.Cont
 	return containers
 }
 
-func deleteAllImages(t assert.TestingT, apiclient client.ImageAPIClient, protectedImages map[string]struct{}) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func deleteAllImages(t testing.TB, apiclient client.ImageAPIClient, protectedImages map[string]struct{}) {
+	t.Helper()
 	images, err := apiclient.ImageList(context.Background(), types.ImageListOptions{})
 	assert.Check(t, err, "failed to list images")
 
@@ -124,10 +112,8 @@ func deleteAllImages(t assert.TestingT, apiclient client.ImageAPIClient, protect
 	}
 }
 
-func removeImage(ctx context.Context, t assert.TestingT, apiclient client.ImageAPIClient, ref string) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func removeImage(ctx context.Context, t testing.TB, apiclient client.ImageAPIClient, ref string) {
+	t.Helper()
 	_, err := apiclient.ImageRemove(ctx, ref, types.ImageRemoveOptions{
 		Force: true,
 	})
@@ -137,10 +123,8 @@ func removeImage(ctx context.Context, t assert.TestingT, apiclient client.ImageA
 	assert.Check(t, err, "failed to remove image %s", ref)
 }
 
-func deleteAllVolumes(t assert.TestingT, c client.VolumeAPIClient, protectedVolumes map[string]struct{}) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func deleteAllVolumes(t testing.TB, c client.VolumeAPIClient, protectedVolumes map[string]struct{}) {
+	t.Helper()
 	volumes, err := c.VolumeList(context.Background(), filters.Args{})
 	assert.Check(t, err, "failed to list volumes")
 
@@ -157,10 +141,8 @@ func deleteAllVolumes(t assert.TestingT, c client.VolumeAPIClient, protectedVolu
 	}
 }
 
-func deleteAllNetworks(t assert.TestingT, c client.NetworkAPIClient, daemonPlatform string, protectedNetworks map[string]struct{}) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func deleteAllNetworks(t testing.TB, c client.NetworkAPIClient, daemonPlatform string, protectedNetworks map[string]struct{}) {
+	t.Helper()
 	networks, err := c.NetworkList(context.Background(), types.NetworkListOptions{})
 	assert.Check(t, err, "failed to list networks")
 
@@ -180,10 +162,8 @@ func deleteAllNetworks(t assert.TestingT, c client.NetworkAPIClient, daemonPlatf
 	}
 }
 
-func deleteAllPlugins(t assert.TestingT, c client.PluginAPIClient, protectedPlugins map[string]struct{}) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func deleteAllPlugins(t testing.TB, c client.PluginAPIClient, protectedPlugins map[string]struct{}) {
+	t.Helper()
 	plugins, err := c.PluginList(context.Background(), filters.Args{})
 	// Docker EE does not allow cluster-wide plugin management.
 	if client.IsErrNotImplemented(err) {

--- a/testutil/environment/environment.go
+++ b/testutil/environment/environment.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/fixtures/load"
 	"github.com/pkg/errors"
 	"gotest.tools/assert"
@@ -165,10 +165,7 @@ func (e *Execution) IsUserNamespace() bool {
 // HasExistingImage checks whether there is an image with the given reference.
 // Note that this is done by filtering and then checking whether there were any
 // results -- so ambiguous references might result in false-positives.
-func (e *Execution) HasExistingImage(t assert.TestingT, reference string) bool {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (e *Execution) HasExistingImage(t testing.TB, reference string) bool {
 	client := e.APIClient()
 	filter := filters.NewArgs()
 	filter.Add("dangling", "false")

--- a/testutil/environment/protect.go
+++ b/testutil/environment/protect.go
@@ -2,11 +2,11 @@ package environment
 
 import (
 	"context"
+	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	dclient "github.com/docker/docker/client"
-	"github.com/docker/docker/testutil"
 	"gotest.tools/assert"
 )
 
@@ -33,10 +33,8 @@ func newProtectedElements() protectedElements {
 // ProtectAll protects the existing environment (containers, images, networks,
 // volumes, and, on Linux, plugins) from being cleaned up at the end of test
 // runs
-func ProtectAll(t assert.TestingT, testEnv *Execution) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func ProtectAll(t testing.TB, testEnv *Execution) {
+	t.Helper()
 	ProtectContainers(t, testEnv)
 	ProtectImages(t, testEnv)
 	ProtectNetworks(t, testEnv)
@@ -48,10 +46,8 @@ func ProtectAll(t assert.TestingT, testEnv *Execution) {
 
 // ProtectContainer adds the specified container(s) to be protected in case of
 // clean
-func (e *Execution) ProtectContainer(t assert.TestingT, containers ...string) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (e *Execution) ProtectContainer(t testing.TB, containers ...string) {
+	t.Helper()
 	for _, container := range containers {
 		e.protectedElements.containers[container] = struct{}{}
 	}
@@ -59,18 +55,14 @@ func (e *Execution) ProtectContainer(t assert.TestingT, containers ...string) {
 
 // ProtectContainers protects existing containers from being cleaned up at the
 // end of test runs
-func ProtectContainers(t assert.TestingT, testEnv *Execution) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func ProtectContainers(t testing.TB, testEnv *Execution) {
+	t.Helper()
 	containers := getExistingContainers(t, testEnv)
 	testEnv.ProtectContainer(t, containers...)
 }
 
-func getExistingContainers(t assert.TestingT, testEnv *Execution) []string {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func getExistingContainers(t testing.TB, testEnv *Execution) []string {
+	t.Helper()
 	client := testEnv.APIClient()
 	containerList, err := client.ContainerList(context.Background(), types.ContainerListOptions{
 		All: true,
@@ -85,10 +77,8 @@ func getExistingContainers(t assert.TestingT, testEnv *Execution) []string {
 }
 
 // ProtectImage adds the specified image(s) to be protected in case of clean
-func (e *Execution) ProtectImage(t assert.TestingT, images ...string) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (e *Execution) ProtectImage(t testing.TB, images ...string) {
+	t.Helper()
 	for _, image := range images {
 		e.protectedElements.images[image] = struct{}{}
 	}
@@ -96,10 +86,8 @@ func (e *Execution) ProtectImage(t assert.TestingT, images ...string) {
 
 // ProtectImages protects existing images and on linux frozen images from being
 // cleaned up at the end of test runs
-func ProtectImages(t assert.TestingT, testEnv *Execution) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func ProtectImages(t testing.TB, testEnv *Execution) {
+	t.Helper()
 	images := getExistingImages(t, testEnv)
 
 	if testEnv.OSType == "linux" {
@@ -108,10 +96,8 @@ func ProtectImages(t assert.TestingT, testEnv *Execution) {
 	testEnv.ProtectImage(t, images...)
 }
 
-func getExistingImages(t assert.TestingT, testEnv *Execution) []string {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func getExistingImages(t testing.TB, testEnv *Execution) []string {
+	t.Helper()
 	client := testEnv.APIClient()
 	filter := filters.NewArgs()
 	filter.Add("dangling", "false")
@@ -145,10 +131,8 @@ func tagsFromImageSummary(image types.ImageSummary) []string {
 
 // ProtectNetwork adds the specified network(s) to be protected in case of
 // clean
-func (e *Execution) ProtectNetwork(t assert.TestingT, networks ...string) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (e *Execution) ProtectNetwork(t testing.TB, networks ...string) {
+	t.Helper()
 	for _, network := range networks {
 		e.protectedElements.networks[network] = struct{}{}
 	}
@@ -156,18 +140,14 @@ func (e *Execution) ProtectNetwork(t assert.TestingT, networks ...string) {
 
 // ProtectNetworks protects existing networks from being cleaned up at the end
 // of test runs
-func ProtectNetworks(t assert.TestingT, testEnv *Execution) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func ProtectNetworks(t testing.TB, testEnv *Execution) {
+	t.Helper()
 	networks := getExistingNetworks(t, testEnv)
 	testEnv.ProtectNetwork(t, networks...)
 }
 
-func getExistingNetworks(t assert.TestingT, testEnv *Execution) []string {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func getExistingNetworks(t testing.TB, testEnv *Execution) []string {
+	t.Helper()
 	client := testEnv.APIClient()
 	networkList, err := client.NetworkList(context.Background(), types.NetworkListOptions{})
 	assert.NilError(t, err, "failed to list networks")
@@ -180,10 +160,8 @@ func getExistingNetworks(t assert.TestingT, testEnv *Execution) []string {
 }
 
 // ProtectPlugin adds the specified plugin(s) to be protected in case of clean
-func (e *Execution) ProtectPlugin(t assert.TestingT, plugins ...string) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (e *Execution) ProtectPlugin(t testing.TB, plugins ...string) {
+	t.Helper()
 	for _, plugin := range plugins {
 		e.protectedElements.plugins[plugin] = struct{}{}
 	}
@@ -191,18 +169,14 @@ func (e *Execution) ProtectPlugin(t assert.TestingT, plugins ...string) {
 
 // ProtectPlugins protects existing plugins from being cleaned up at the end of
 // test runs
-func ProtectPlugins(t assert.TestingT, testEnv *Execution) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func ProtectPlugins(t testing.TB, testEnv *Execution) {
+	t.Helper()
 	plugins := getExistingPlugins(t, testEnv)
 	testEnv.ProtectPlugin(t, plugins...)
 }
 
-func getExistingPlugins(t assert.TestingT, testEnv *Execution) []string {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func getExistingPlugins(t testing.TB, testEnv *Execution) []string {
+	t.Helper()
 	client := testEnv.APIClient()
 	pluginList, err := client.PluginList(context.Background(), filters.Args{})
 	// Docker EE does not allow cluster-wide plugin management.
@@ -219,10 +193,8 @@ func getExistingPlugins(t assert.TestingT, testEnv *Execution) []string {
 }
 
 // ProtectVolume adds the specified volume(s) to be protected in case of clean
-func (e *Execution) ProtectVolume(t assert.TestingT, volumes ...string) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (e *Execution) ProtectVolume(t testing.TB, volumes ...string) {
+	t.Helper()
 	for _, volume := range volumes {
 		e.protectedElements.volumes[volume] = struct{}{}
 	}
@@ -230,18 +202,14 @@ func (e *Execution) ProtectVolume(t assert.TestingT, volumes ...string) {
 
 // ProtectVolumes protects existing volumes from being cleaned up at the end of
 // test runs
-func ProtectVolumes(t assert.TestingT, testEnv *Execution) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func ProtectVolumes(t testing.TB, testEnv *Execution) {
+	t.Helper()
 	volumes := getExistingVolumes(t, testEnv)
 	testEnv.ProtectVolume(t, volumes...)
 }
 
-func getExistingVolumes(t assert.TestingT, testEnv *Execution) []string {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func getExistingVolumes(t testing.TB, testEnv *Execution) []string {
+	t.Helper()
 	client := testEnv.APIClient()
 	volumeList, err := client.VolumeList(context.Background(), filters.Args{})
 	assert.NilError(t, err, "failed to list volumes")

--- a/testutil/fakecontext/context.go
+++ b/testutil/fakecontext/context.go
@@ -14,6 +14,7 @@ import (
 type testingT interface {
 	Fatal(args ...interface{})
 	Fatalf(string, ...interface{})
+	Name() string
 }
 
 // New creates a fake build context

--- a/testutil/fakecontext/context.go
+++ b/testutil/fakecontext/context.go
@@ -6,19 +6,14 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"testing"
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/testutil"
 )
 
-type testingT interface {
-	Fatal(args ...interface{})
-	Fatalf(string, ...interface{})
-	Name() string
-}
-
 // New creates a fake build context
-func New(t testingT, dir string, modifiers ...func(*Fake) error) *Fake {
+func New(t testing.TB, dir string, modifiers ...func(*Fake) error) *Fake {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}
@@ -120,7 +115,7 @@ func (f *Fake) Close() error {
 }
 
 // AsTarReader returns a ReadCloser with the contents of Dir as a tar archive.
-func (f *Fake) AsTarReader(t testingT) io.ReadCloser {
+func (f *Fake) AsTarReader(t testing.TB) io.ReadCloser {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}

--- a/testutil/fakecontext/context.go
+++ b/testutil/fakecontext/context.go
@@ -9,14 +9,11 @@ import (
 	"testing"
 
 	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/testutil"
 )
 
 // New creates a fake build context
 func New(t testing.TB, dir string, modifiers ...func(*Fake) error) *Fake {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	fakeContext := &Fake{Dir: dir}
 	if dir == "" {
 		if err := newDir(fakeContext); err != nil {
@@ -116,9 +113,7 @@ func (f *Fake) Close() error {
 
 // AsTarReader returns a ReadCloser with the contents of Dir as a tar archive.
 func (f *Fake) AsTarReader(t testing.TB) io.ReadCloser {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	reader, err := archive.TarWithOptions(f.Dir, &archive.TarOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create tar from %s: %s", f.Dir, err)

--- a/testutil/fakegit/fakegit.go
+++ b/testutil/fakegit/fakegit.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/fakecontext"
 	"github.com/docker/docker/testutil/fakestorage"
 )
@@ -48,9 +47,7 @@ func (g *FakeGit) Close() {
 
 // New create a fake git server that can be used for git related tests
 func New(c testing.TB, name string, files map[string]string, enforceLocalServer bool) *FakeGit {
-	if ht, ok := c.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	c.Helper()
 	ctx := fakecontext.New(c, "", fakecontext.WithFiles(files))
 	defer ctx.Close()
 	curdir, err := os.Getwd()

--- a/testutil/fakegit/fakegit.go
+++ b/testutil/fakegit/fakegit.go
@@ -21,6 +21,7 @@ type testingT interface {
 	skipT
 	Fatal(args ...interface{})
 	Fatalf(string, ...interface{})
+	Name() string
 }
 
 type logT interface {

--- a/testutil/fakegit/fakegit.go
+++ b/testutil/fakegit/fakegit.go
@@ -8,29 +8,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"testing"
 
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/fakecontext"
 	"github.com/docker/docker/testutil/fakestorage"
-	"gotest.tools/assert"
 )
-
-type testingT interface {
-	assert.TestingT
-	logT
-	skipT
-	Fatal(args ...interface{})
-	Fatalf(string, ...interface{})
-	Name() string
-}
-
-type logT interface {
-	Logf(string, ...interface{})
-}
-
-type skipT interface {
-	Skip(...interface{})
-}
 
 type gitServer interface {
 	URL() string
@@ -64,7 +47,7 @@ func (g *FakeGit) Close() {
 }
 
 // New create a fake git server that can be used for git related tests
-func New(c testingT, name string, files map[string]string, enforceLocalServer bool) *FakeGit {
+func New(c testing.TB, name string, files map[string]string, enforceLocalServer bool) *FakeGit {
 	if ht, ok := c.(testutil.HelperT); ok {
 		ht.Helper()
 	}

--- a/testutil/fakestorage/fixtures.go
+++ b/testutil/fakestorage/fixtures.go
@@ -12,16 +12,13 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/testutil"
 	"gotest.tools/assert"
 )
 
 var ensureHTTPServerOnce sync.Once
 
 func ensureHTTPServerImage(t testing.TB) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	var doIt bool
 	ensureHTTPServerOnce.Do(func() {
 		doIt = true

--- a/testutil/fakestorage/fixtures.go
+++ b/testutil/fakestorage/fixtures.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sync"
+	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/archive"
@@ -17,7 +18,7 @@ import (
 
 var ensureHTTPServerOnce sync.Once
 
-func ensureHTTPServerImage(t testingT) {
+func ensureHTTPServerImage(t testing.TB) {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}

--- a/testutil/fakestorage/storage.go
+++ b/testutil/fakestorage/storage.go
@@ -30,6 +30,7 @@ type testingT interface {
 	skipT
 	Fatal(args ...interface{})
 	Fatalf(string, ...interface{})
+	Name() string
 }
 
 type logT interface {

--- a/testutil/fakestorage/storage.go
+++ b/testutil/fakestorage/storage.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"testing"
 
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
@@ -23,23 +24,6 @@ import (
 )
 
 var testEnv *environment.Execution
-
-type testingT interface {
-	assert.TestingT
-	logT
-	skipT
-	Fatal(args ...interface{})
-	Fatalf(string, ...interface{})
-	Name() string
-}
-
-type logT interface {
-	Logf(string, ...interface{})
-}
-
-type skipT interface {
-	Skip(...interface{})
-}
 
 // Fake is a static file server. It might be running locally or remotely
 // on test host.
@@ -56,7 +40,7 @@ func SetTestEnvironment(env *environment.Execution) {
 }
 
 // New returns a static file server that will be use as build context.
-func New(t testingT, dir string, modifiers ...func(*fakecontext.Fake) error) Fake {
+func New(t testing.TB, dir string, modifiers ...func(*fakecontext.Fake) error) Fake {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}
@@ -149,7 +133,7 @@ func (f *remoteFileServer) Close() error {
 	})
 }
 
-func newRemoteFileServer(t testingT, ctx *fakecontext.Fake, c client.APIClient) *remoteFileServer {
+func newRemoteFileServer(t testing.TB, ctx *fakecontext.Fake, c client.APIClient) *remoteFileServer {
 	var (
 		image     = fmt.Sprintf("fileserver-img-%s", strings.ToLower(testutil.GenerateRandomAlphaOnlyString(10)))
 		container = fmt.Sprintf("fileserver-cnt-%s", strings.ToLower(testutil.GenerateRandomAlphaOnlyString(10)))

--- a/testutil/fakestorage/storage.go
+++ b/testutil/fakestorage/storage.go
@@ -41,9 +41,7 @@ func SetTestEnvironment(env *environment.Execution) {
 
 // New returns a static file server that will be use as build context.
 func New(t testing.TB, dir string, modifiers ...func(*fakecontext.Fake) error) Fake {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	if testEnv == nil {
 		t.Fatal("fakstorage package requires SetTestEnvironment() to be called before use.")
 	}

--- a/testutil/registry/registry.go
+++ b/testutil/registry/registry.go
@@ -28,6 +28,7 @@ type testingT interface {
 	logT
 	Fatal(...interface{})
 	Fatalf(string, ...interface{})
+	Name() string
 }
 
 type logT interface {

--- a/testutil/registry/registry.go
+++ b/testutil/registry/registry.go
@@ -45,9 +45,7 @@ type Config struct {
 
 // NewV2 creates a v2 registry server
 func NewV2(t testing.TB, ops ...func(*Config)) *V2 {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	c := &Config{
 		registryURL: DefaultURL,
 	}
@@ -130,9 +128,7 @@ http:
 
 // WaitReady waits for the registry to be ready to serve requests (or fail after a while)
 func (r *V2) WaitReady(t testing.TB) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	var err error
 	for i := 0; i != 50; i++ {
 		if err = r.Ping(); err == nil {
@@ -202,9 +198,7 @@ func (r *V2) WriteBlobContents(t assert.TestingT, blobDigest digest.Digest, data
 // TempMoveBlobData moves the existing data file aside, so that we can replace it with a
 // malicious blob of data for example.
 func (r *V2) TempMoveBlobData(t testing.TB, blobDigest digest.Digest) (undo func()) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	tempFile, err := ioutil.TempFile("", "registry-temp-blob-")
 	assert.NilError(t, err, "unable to get temporary blob file")
 	tempFile.Close()

--- a/testutil/registry/registry.go
+++ b/testutil/registry/registry.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"testing"
 	"time"
 
 	"github.com/docker/docker/testutil"
@@ -22,18 +23,6 @@ const (
 	// DefaultURL is the default url that will be used by the registry (if not specified otherwise)
 	DefaultURL = "127.0.0.1:5000"
 )
-
-type testingT interface {
-	assert.TestingT
-	logT
-	Fatal(...interface{})
-	Fatalf(string, ...interface{})
-	Name() string
-}
-
-type logT interface {
-	Logf(string, ...interface{})
-}
 
 // V2 represent a registry version 2
 type V2 struct {
@@ -55,7 +44,7 @@ type Config struct {
 }
 
 // NewV2 creates a v2 registry server
-func NewV2(t testingT, ops ...func(*Config)) *V2 {
+func NewV2(t testing.TB, ops ...func(*Config)) *V2 {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}
@@ -140,7 +129,7 @@ http:
 }
 
 // WaitReady waits for the registry to be ready to serve requests (or fail after a while)
-func (r *V2) WaitReady(t testingT) {
+func (r *V2) WaitReady(t testing.TB) {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}
@@ -212,7 +201,7 @@ func (r *V2) WriteBlobContents(t assert.TestingT, blobDigest digest.Digest, data
 
 // TempMoveBlobData moves the existing data file aside, so that we can replace it with a
 // malicious blob of data for example.
-func (r *V2) TempMoveBlobData(t testingT, blobDigest digest.Digest) (undo func()) {
+func (r *V2) TempMoveBlobData(t testing.TB, blobDigest digest.Digest) (undo func()) {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}

--- a/testutil/registry/registry.go
+++ b/testutil/registry/registry.go
@@ -10,8 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/testutil"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	"gotest.tools/assert"
 )
 
@@ -176,10 +175,8 @@ func (r *V2) getBlobFilename(blobDigest digest.Digest) string {
 }
 
 // ReadBlobContents read the file corresponding to the specified digest
-func (r *V2) ReadBlobContents(t assert.TestingT, blobDigest digest.Digest) []byte {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (r *V2) ReadBlobContents(t testing.TB, blobDigest digest.Digest) []byte {
+	t.Helper()
 	// Load the target manifest blob.
 	manifestBlob, err := ioutil.ReadFile(r.getBlobFilename(blobDigest))
 	assert.NilError(t, err, "unable to read blob")
@@ -187,10 +184,8 @@ func (r *V2) ReadBlobContents(t assert.TestingT, blobDigest digest.Digest) []byt
 }
 
 // WriteBlobContents write the file corresponding to the specified digest with the given content
-func (r *V2) WriteBlobContents(t assert.TestingT, blobDigest digest.Digest, data []byte) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func (r *V2) WriteBlobContents(t testing.TB, blobDigest digest.Digest, data []byte) {
+	t.Helper()
 	err := ioutil.WriteFile(r.getBlobFilename(blobDigest), data, os.FileMode(0644))
 	assert.NilError(t, err, "unable to write malicious data blob")
 }

--- a/testutil/registry/registry_mock.go
+++ b/testutil/registry/registry_mock.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"testing"
 
 	"github.com/docker/docker/testutil"
 )
@@ -28,7 +29,7 @@ func (tr *Mock) RegisterHandler(path string, h handlerFunc) {
 }
 
 // NewMock creates a registry mock
-func NewMock(t testingT) (*Mock, error) {
+func NewMock(t testing.TB) (*Mock, error) {
 	if ht, ok := t.(testutil.HelperT); ok {
 		ht.Helper()
 	}

--- a/testutil/registry/registry_mock.go
+++ b/testutil/registry/registry_mock.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-
-	"github.com/docker/docker/testutil"
 )
 
 type handlerFunc func(w http.ResponseWriter, r *http.Request)
@@ -30,9 +28,7 @@ func (tr *Mock) RegisterHandler(path string, h handlerFunc) {
 
 // NewMock creates a registry mock
 func NewMock(t testing.TB) (*Mock, error) {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+	t.Helper()
 	testReg := &Mock{handlers: make(map[string]handlerFunc)}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/testutil/request/request.go
+++ b/testutil/request/request.go
@@ -11,12 +11,12 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"testing"
 	"time"
 
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/environment"
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
@@ -25,10 +25,8 @@ import (
 )
 
 // NewAPIClient returns a docker API client configured from environment variables
-func NewAPIClient(t assert.TestingT, ops ...client.Opt) client.APIClient {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func NewAPIClient(t testing.TB, ops ...client.Opt) client.APIClient {
+	t.Helper()
 	ops = append([]client.Opt{client.FromEnv}, ops...)
 	clt, err := client.NewClientWithOpts(ops...)
 	assert.NilError(t, err)
@@ -36,10 +34,8 @@ func NewAPIClient(t assert.TestingT, ops ...client.Opt) client.APIClient {
 }
 
 // DaemonTime provides the current time on the daemon host
-func DaemonTime(ctx context.Context, t assert.TestingT, client client.APIClient, testEnv *environment.Execution) time.Time {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func DaemonTime(ctx context.Context, t testing.TB, client client.APIClient, testEnv *environment.Execution) time.Time {
+	t.Helper()
 	if testEnv.IsLocalDaemon() {
 		return time.Now()
 	}
@@ -54,10 +50,8 @@ func DaemonTime(ctx context.Context, t assert.TestingT, client client.APIClient,
 
 // DaemonUnixTime returns the current time on the daemon host with nanoseconds precision.
 // It return the time formatted how the client sends timestamps to the server.
-func DaemonUnixTime(ctx context.Context, t assert.TestingT, client client.APIClient, testEnv *environment.Execution) string {
-	if ht, ok := t.(testutil.HelperT); ok {
-		ht.Helper()
-	}
+func DaemonUnixTime(ctx context.Context, t testing.TB, client client.APIClient, testEnv *environment.Execution) string {
+	t.Helper()
 	dt := DaemonTime(ctx, t, client, testEnv)
 	return fmt.Sprintf("%d.%09d", dt.Unix(), int64(dt.Nanosecond()))
 }


### PR DESCRIPTION
Now that we no longer use `go-check` (removed in https://github.com/moby/moby/pull/39799), I _think_ we can replace these with Go's own interface., which allows us to get rid of some code-complexity.

Perhaps there's other reasons we used these interfaces though, so open to input 👍 