### PR TITLE
Remove refs to jhowardmsft from .go code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,10 +6,10 @@
 builder/**                              @tonistiigi
 contrib/mkimage/**                      @tianon
 daemon/graphdriver/devmapper/**         @rhvgoyal 
-daemon/graphdriver/lcow/**              @johnstep @jhowardmsft
+daemon/graphdriver/lcow/**              @johnstep
 daemon/graphdriver/overlay/**           @dmcgowan
 daemon/graphdriver/overlay2/**          @dmcgowan
-daemon/graphdriver/windows/**           @johnstep @jhowardmsft
+daemon/graphdriver/windows/**           @johnstep
 daemon/logger/awslogs/**                @samuelkarp  
 hack/**                                 @tianon
 plugin/**                               @cpuguy83

--- a/container/container.go
+++ b/container/container.go
@@ -257,7 +257,7 @@ func (container *Container) WriteHostConfig() (*containertypes.HostConfig, error
 
 // SetupWorkingDirectory sets up the container's working directory as set in container.Config.WorkingDir
 func (container *Container) SetupWorkingDirectory(rootIdentity idtools.Identity) error {
-	// TODO @jhowardmsft, @gupta-ak LCOW Support. This will need revisiting.
+	// TODO: LCOW Support. This will need revisiting.
 	// We will need to do remote filesystem operations here.
 	if container.OS != runtime.GOOS {
 		return nil

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -97,7 +97,7 @@ func (c *containerAdapter) pullImage(ctx context.Context) error {
 	pr, pw := io.Pipe()
 	metaHeaders := map[string][]string{}
 	go func() {
-		// TODO @jhowardmsft LCOW Support: This will need revisiting as
+		// TODO LCOW Support: This will need revisiting as
 		// the stack is built up to include LCOW support for swarm.
 		err := c.imageBackend.PullImage(ctx, c.container.image(), "", nil, metaHeaders, authConfig, pw)
 		pw.CloseWithError(err)

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -201,7 +201,7 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 	// On RS5, we allow (but don't strictly support) process isolation on Client SKUs.
 	// Prior to RS5, we don't allow process isolation on Client SKUs.
 	// @engine maintainers. This block should not be removed. It partially enforces licensing
-	// restrictions on Windows. Ping @jhowardmsft if there are concerns or PRs to change this.
+	// restrictions on Windows. Ping Microsoft folks if there are concerns or PRs to change this.
 	if !hyperv && system.IsWindowsClient() && osv.Build < 17763 {
 		return warnings, fmt.Errorf("Windows client operating systems earlier than version 1809 can only run Hyper-V containers")
 	}
@@ -604,7 +604,7 @@ func (daemon *Daemon) setDefaultIsolation() error {
 	osv := system.GetOSVersion()
 
 	// On client SKUs, default to Hyper-V. @engine maintainers. This
-	// should not be removed. Ping @jhowardmsft is there are PRs to
+	// should not be removed. Ping Microsoft folks is there are PRs to
 	// to change this.
 	if system.IsWindowsClient() {
 		daemon.defaultIsolation = containertypes.Isolation("hyperv")
@@ -628,7 +628,7 @@ func (daemon *Daemon) setDefaultIsolation() error {
 				if system.IsWindowsClient() && osv.Build < 17763 {
 					// On RS5, we allow (but don't strictly support) process isolation on Client SKUs.
 					// @engine maintainers. This block should not be removed. It partially enforces licensing
-					// restrictions on Windows. Ping @jhowardmsft if there are concerns or PRs to change this.
+					// restrictions on Windows. Ping Microsoft folks if there are concerns or PRs to change this.
 					return fmt.Errorf("Windows client operating systems earlier than version 1809 can only run Hyper-V containers")
 				}
 				daemon.defaultIsolation = containertypes.Isolation("process")

--- a/daemon/graphdriver/lcow/lcow.go
+++ b/daemon/graphdriver/lcow/lcow.go
@@ -1,6 +1,5 @@
 // +build windows
 
-// Maintainer:  jhowardmsft
 // Locale:      en-gb
 // About:       Graph-driver for Linux Containers On Windows (LCOW)
 //

--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -286,7 +286,7 @@ func (d *Driver) Remove(id string) error {
 		// in RS1 and RS2 building during enumeration when a silo is going away
 		// for example under it, in HCS. AccessIsDenied added to fix 30278.
 		//
-		// TODO @jhowardmsft - For RS3, we can remove the retries. Also consider
+		// TODO: For RS3, we can remove the retries. Also consider
 		// using platform APIs (if available) to get this more succinctly. Also
 		// consider enhancing the Remove() interface to have context of why
 		// the remove is being called - that could improve efficiency by not

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -370,7 +370,7 @@ func (daemon *Daemon) setWindowsCredentialSpec(c *container.Container, s *specs.
 }
 
 // Sets the Linux-specific fields of the OCI spec
-// TODO: @jhowardmsft LCOW Support. We need to do a lot more pulling in what can
+// TODO: LCOW Support. We need to do a lot more pulling in what can
 // be pulled in from oci_linux.go.
 func (daemon *Daemon) createSpecLinuxFields(c *container.Container, s *specs.Spec) error {
 	s.Root = &specs.Root{

--- a/daemon/start_windows.go
+++ b/daemon/start_windows.go
@@ -15,7 +15,7 @@ func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Contain
 		return opts, nil
 	}
 
-	// TODO @jhowardmsft (containerd) - Probably need to revisit LCOW options here
+	// TODO (containerd) - Probably need to revisit LCOW options here
 	// rather than blindly ignoring them.
 
 	// LCOW options.

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -89,7 +89,7 @@ func (s *DockerSuite) TestAttachMultipleAndRestart(c *testing.T) {
 }
 
 func (s *DockerSuite) TestAttachTTYWithoutStdin(c *testing.T) {
-	// TODO @jhowardmsft. Figure out how to get this running again reliable on Windows.
+	// TODO: Figure out how to get this running again reliable on Windows.
 	// It works by accident at the moment. Sometimes. I've gone back to v1.13.0 and see the same.
 	// On Windows, docker run -d -ti busybox causes the container to exit immediately.
 	// Obviously a year back when I updated the test, that was not the case. However,

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -390,7 +390,7 @@ func (s *DockerSuite) TestBuildCacheAdd(c *testing.T) {
 }
 
 func (s *DockerSuite) TestBuildLastModified(c *testing.T) {
-	// Temporary fix for #30890. TODO @jhowardmsft figure out what
+	// Temporary fix for #30890. TODO: figure out what
 	// has changed in the master busybox image.
 	testRequires(c, DaemonIsLinux)
 
@@ -1347,7 +1347,7 @@ func (s *DockerSuite) TestBuildWindowsWorkdirProcessing(c *testing.T) {
 // One functional test for end-to-end
 func (s *DockerSuite) TestBuildWindowsAddCopyPathProcessing(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
-	// TODO Windows (@jhowardmsft). Needs a follow-up PR to 22181 to
+	// TODO Windows. Needs a follow-up PR to 22181 to
 	// support backslash such as .\\ being equivalent to ./ and c:\\ being
 	// equivalent to c:/. This is not currently (nor ever has been) supported
 	// by docker on the Windows platform.

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -238,7 +238,7 @@ func (c *client) createWindows(id string, spec *specs.Spec, runtimeOptions inter
 
 	if configuration.HvPartition {
 		// We don't currently support setting the utility VM image explicitly.
-		// TODO @swernli/jhowardmsft circa RS5, this may be re-locatable.
+		// TODO circa RS5, this may be re-locatable.
 		if spec.Windows.HyperV.UtilityVMPath != "" {
 			return errors.New("runtime does not support an explicit utility VM path for Hyper-V containers")
 		}

--- a/opts/opts_windows.go
+++ b/opts/opts_windows.go
@@ -1,7 +1,6 @@
 package opts // import "github.com/docker/docker/opts"
 
 // TODO Windows. Identify bug in GOLang 1.5.1+ and/or Windows Server 2016 TP5.
-// @jhowardmsft, @swernli.
 //
 // On Windows, this mitigates a problem with the default options of running
 // a docker client against a local docker daemon on TP5.


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

As many of you know, I'm retiring imminently. And will be leaving Microsoft and changing my GitHub handle. While there's still logistics in rehosting binaries used to other repos under my GitHub handle, this removes the references in `.go` code.