### PR TITLE
AppArmor: remove rules for linkgraph.db SQLite database

### DIFF
--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -29,10 +29,8 @@ profile /usr/bin/docker (attach_disconnected, complain) {
   capability,
   owner /** rw,
   @{DOCKER_GRAPH_PATH}/** rwl,
-  @{DOCKER_GRAPH_PATH}/linkgraph.db k,
   @{DOCKER_GRAPH_PATH}/network/files/boltdb.db k,
   @{DOCKER_GRAPH_PATH}/network/files/local-kv.db k,
-  @{DOCKER_GRAPH_PATH}/[0-9]*.[0-9]*/linkgraph.db k,
 
   # For non-root client use:
   /dev/urandom r,


### PR DESCRIPTION
Commit 0f9f99500c40f2a46682967ca358cd2346fd5e13 (https://github.com/moby/moby/pull/16032) removed the use of SQLite for managing container links, and commit f8119bb7a76b5c42defb6e0a2dc67bd77ad29a5e (https://github.com/moby/moby/pull/30208) removed the migration tool, and SQLite dependency.

