### PR TITLE
homedir: add cgo or osusergo buildtag constraints for unix

### DIFF
--- a/pkg/homedir/homedir_unix.go
+++ b/pkg/homedir/homedir_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,cgo !windows,osusergo
 
 package homedir // import "github.com/docker/docker/pkg/homedir"
 


### PR DESCRIPTION
This is to ensure that users of the homedir package cannot
compile statically (CGO_ENABLED=0) without also setting the osusergo
build tag.

Signed-off-by: Tibor Vass <tibor@docker.com>