### PR TITLE
Update containerd binary to v1.2.10

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=d50db0a42053864a270f648048f9a8b4f24eced3 # v1.2.9
+CONTAINERD_COMMIT=b34a5c8af56e510852c35414db4c1f4fa6172339 # v1.2.10
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Update containerd to v1.2.10

>The tenth patch release for containerd 1.2 includes only one main bug fix in the
CRI plugin, but includes updated vendors/build runtimes that fix 2 reported CVEs in
runc and the Golang 1.12 runtime respectively.
>## Notable Updates
>* Update the runc vendor to capture the fix for CVE-2019-16884. Fixed by PR #3685
>    - More details on the runc CVE in opencontainers/runc#2128, fixed by opencontainers/runc#2129

>* Update Golang runtime to 1.12.10 to handle CVE-2019-16276. More detail on the Golang CVE available in golang/go#34540
>* CRI fixes:
>    - Fix a bug that the default UNIX path is not in the default OCI config via the CRI plugin. Reported in containerd/cri#1279 and fixed by containerd/cri#1283


