### PR TITLE
jhowardmsft --> lowenna

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -33,10 +33,10 @@
 			"dnephin",
 			"duglin",
 			"estesp",
-			"jhowardmsft",
 			"johnstep",
 			"justincormack",
 			"kolyshkin",
+			"lowenna",
 			"mhbauer",
 			"mlaventure",
 			"runcom",
@@ -338,11 +338,6 @@
 	Email = "james@lovedthanlost.net"
 	GitHub = "jamtur01"
 
-	[people.jhowardmsft]
-	Name = "John Howard"
-	Email = "jhoward@microsoft.com"
-	GitHub = "jhowardmsft"
-
 	[people.jessfraz]
 	Name = "Jessie Frazelle"
 	Email = "jess@linux.com"
@@ -367,6 +362,11 @@
 	Name = "Alexander Morozov"
 	Email = "lk4d4@docker.com"
 	GitHub = "lk4d4"
+
+	[people.lowenna]
+	Name = "John Howard"
+	Email = "github@lowenna.com"
+	GitHub = "lowenna"
 
 	[people.mavenugo]
 	Name = "Madhu Venugopal"


### PR DESCRIPTION
Signed-off-by: John Howard <github@lowenna.com>

I've now changed my `jhowardmsft` username to `lowenna` since today is my last day at Microsoft (retiring). Updating `MAINTAINERS` tp reflect the change.

Shadow, who sadly passed away last month
![shadow](https://user-images.githubusercontent.com/10522484/65796102-aa11b100-e120-11e9-85a9-bd97a37a6670.jpg)

And Painter, now living in England.
![painter](https://user-images.githubusercontent.com/10522484/65796111-ac740b00-e120-11e9-9228-aad17719ce7d.jpg)
