### PR TITLE
Fix pkg/pools staticcheck SA6002

### DIFF
--- a/pkg/pools/pools.go
+++ b/pkg/pools/pools.go
@@ -62,24 +62,23 @@ type bufferPool struct {
 func newBufferPoolWithSize(size int) *bufferPool {
 	return &bufferPool{
 		pool: sync.Pool{
-			New: func() interface{} { return make([]byte, size) },
+			New: func() interface{} { s := make([]byte, size); return &s },
 		},
 	}
 }
 
-func (bp *bufferPool) Get() []byte {
-	return bp.pool.Get().([]byte)
+func (bp *bufferPool) Get() *[]byte {
+	return bp.pool.Get().(*[]byte)
 }
 
-func (bp *bufferPool) Put(b []byte) {
-	//nolint:staticcheck // TODO changing this to a pointer makes tests fail. Investigate if we should change or not (otherwise remove this TODO)
+func (bp *bufferPool) Put(b *[]byte) {
 	bp.pool.Put(b)
 }
 
 // Copy is a convenience wrapper which uses a buffer to avoid allocation in io.Copy.
 func Copy(dst io.Writer, src io.Reader) (written int64, err error) {
 	buf := buffer32KPool.Get()
-	written, err = io.CopyBuffer(dst, src, buf)
+	written, err = io.CopyBuffer(dst, src, *buf)
 	buffer32KPool.Put(buf)
 	return
 }


### PR DESCRIPTION
change bufferPool use pointer instead byte slice

Signed-off-by: HuanHuan Ye <logindaveye@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
fix staticcheck [SA6002](https://staticcheck.io/docs/checks#SA6002) in pkg/pools/pools.go

**- How I did it**
change bufferPool struct use pointer instead byte slice

**- How to verify it**
```golangci-lint run pkg/pools/```

**- Description for the changelog**
Fix pkg/pools staticcheck SA6002
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/8220938/65850031-aa5bb780-e37f-11e9-9aa3-87fc7d92ed8f.png)
