### PR TITLE
testutil: fix WithExperimental also setting "init"

### DIFF
--- a/testutil/daemon/ops.go
+++ b/testutil/daemon/ops.go
@@ -26,7 +26,6 @@ func WithTestLogger(t testing.TB) func(*Daemon) {
 // WithExperimental sets the daemon in experimental mode
 func WithExperimental(d *Daemon) {
 	d.experimental = true
-	d.init = true
 }
 
 // WithInit sets the daemon init


### PR DESCRIPTION
Looks like this was overlooked in the review of the PR that added this; e401b88e59e098745744917c555d549f08353e6d (https://github.com/moby/moby/pull/37183)

There is a separate option for `WithInit`, so this option should not automatically enable it when starting  a daemon with experimental enabled.

