### PR TITLE
testutil: change some remaining options to be a daemon.Option

### DIFF
--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -26,7 +26,7 @@ func TestBuildSquashParent(t *testing.T) {
 	if !testEnv.DaemonInfo.ExperimentalBuild {
 		skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
 
-		d := daemon.New(t, daemon.WithExperimental)
+		d := daemon.New(t, daemon.WithExperimental())
 		d.StartWithBusybox(t)
 		defer d.Stop(t)
 		client = d.NewClientT(t)

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -54,7 +54,7 @@ func NewSwarm(t *testing.T, testEnv *environment.Execution, ops ...daemon.Option
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	if testEnv.DaemonInfo.ExperimentalBuild {
-		ops = append(ops, daemon.WithExperimental)
+		ops = append(ops, daemon.WithExperimental())
 	}
 	d := daemon.New(t, ops...)
 	d.StartAndSwarmInit(t)

--- a/integration/plugin/authz/main_test.go
+++ b/integration/plugin/authz/main_test.go
@@ -51,7 +51,7 @@ func setupTest(t *testing.T) func() {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	environment.ProtectAll(t, testEnv)
 
-	d = daemon.New(t, daemon.WithExperimental)
+	d = daemon.New(t, daemon.WithExperimental())
 
 	return func() {
 		if d != nil {

--- a/integration/plugin/graphdriver/external_test.go
+++ b/integration/plugin/graphdriver/external_test.go
@@ -54,7 +54,7 @@ func TestExternalGraphDriver(t *testing.T) {
 	sserver := setupPluginViaSpecFile(t, ec)
 	jserver := setupPluginViaJSONFile(t, ec)
 	// Create daemon
-	d := daemon.New(t, daemon.WithExperimental)
+	d := daemon.New(t, daemon.WithExperimental())
 	c := d.NewClientT(t)
 
 	for _, tc := range []struct {
@@ -410,7 +410,7 @@ func TestGraphdriverPluginV2(t *testing.T) {
 	skip.If(t, os.Getenv("DOCKER_ENGINE_GOARCH") != "amd64")
 	skip.If(t, !requirement.Overlay2Supported(testEnv.DaemonInfo.KernelVersion))
 
-	d := daemon.New(t, daemon.WithExperimental)
+	d := daemon.New(t, daemon.WithExperimental())
 	d.Start(t)
 	defer d.Stop(t)
 

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -33,7 +33,7 @@ func testServiceCreateInit(daemonEnabled bool) func(t *testing.T) {
 		var ops = []daemon.Option{}
 
 		if daemonEnabled {
-			ops = append(ops, daemon.WithInit)
+			ops = append(ops, daemon.WithInit())
 		}
 		d := swarm.NewSwarm(t, testEnv, ops...)
 		defer d.Stop(t)

--- a/integration/service/plugin_test.go
+++ b/integration/service/plugin_test.go
@@ -56,12 +56,12 @@ func TestServicePlugin(t *testing.T) {
 	assert.NilError(t, err)
 	d.Stop(t)
 
-	d1 := swarm.NewSwarm(t, testEnv, daemon.WithExperimental)
+	d1 := swarm.NewSwarm(t, testEnv, daemon.WithExperimental())
 	defer d1.Stop(t)
-	d2 := daemon.New(t, daemon.WithExperimental, daemon.WithSwarmPort(daemon.DefaultSwarmPort+1))
+	d2 := daemon.New(t, daemon.WithExperimental(), daemon.WithSwarmPort(daemon.DefaultSwarmPort+1))
 	d2.StartAndSwarmJoin(t, d1, true)
 	defer d2.Stop(t)
-	d3 := daemon.New(t, daemon.WithExperimental, daemon.WithSwarmPort(daemon.DefaultSwarmPort+2))
+	d3 := daemon.New(t, daemon.WithExperimental(), daemon.WithSwarmPort(daemon.DefaultSwarmPort+2))
 	d3.StartAndSwarmJoin(t, d1, false)
 	defer d3.Stop(t)
 

--- a/testutil/daemon/ops.go
+++ b/testutil/daemon/ops.go
@@ -31,8 +31,10 @@ func WithExperimental() Option {
 }
 
 // WithInit sets the daemon init
-func WithInit(d *Daemon) {
-	d.init = true
+func WithInit() Option {
+	return func(d *Daemon) {
+		d.init = true
+	}
 }
 
 // WithDockerdBinary sets the dockerd binary to the specified one

--- a/testutil/daemon/ops.go
+++ b/testutil/daemon/ops.go
@@ -85,7 +85,7 @@ func WithEnvironment(e environment.Execution) Option {
 }
 
 // WithStorageDriver sets store driver option
-func WithStorageDriver(driver string) func(d *Daemon) {
+func WithStorageDriver(driver string) Option {
 	return func(d *Daemon) {
 		d.storageDriver = driver
 	}

--- a/testutil/daemon/ops.go
+++ b/testutil/daemon/ops.go
@@ -17,7 +17,7 @@ func WithDefaultCgroupNamespaceMode(mode string) Option {
 }
 
 // WithTestLogger causes the daemon to log certain actions to the provided test.
-func WithTestLogger(t testing.TB) func(*Daemon) {
+func WithTestLogger(t testing.TB) Option {
 	return func(d *Daemon) {
 		d.log = t
 	}

--- a/testutil/daemon/ops.go
+++ b/testutil/daemon/ops.go
@@ -24,8 +24,10 @@ func WithTestLogger(t testing.TB) Option {
 }
 
 // WithExperimental sets the daemon in experimental mode
-func WithExperimental(d *Daemon) {
-	d.experimental = true
+func WithExperimental() Option {
+	return func(d *Daemon) {
+		d.experimental = true
+	}
 }
 
 // WithInit sets the daemon init


### PR DESCRIPTION
~based on top of https://github.com/moby/moby/pull/40012 (I'll rebase once that's merged)~ rebased

Follow-up to https://github.com/moby/moby/pull/39942, which didn't update all options to be a `Option`, which caused those remaining options to not be grouped under `Option` in the docs;

Before this change:

<img width="531" alt="Screenshot 2019-09-30 at 14 27 39" src="https://user-images.githubusercontent.com/1804568/65878491-7b007700-e38e-11e9-9c6b-afe14ede0d8d.png">


After this change:

<img width="571" alt="Screenshot 2019-09-30 at 14 45 27" src="https://user-images.githubusercontent.com/1804568/65879884-1abf0480-e391-11e9-8dd0-652fda536051.png">
