### PR TITLE
integration-cli: fix golint (copy/paste whoops)

### DIFF
--- a/integration-cli/checker/checker.go
+++ b/integration-cli/checker/checker.go
@@ -62,14 +62,14 @@ func DeepEquals(y interface{}) Compare {
 	}
 }
 
-// DeepEquals compares if two values are deepequal
+// HasLen checks if the value has the expected number of elements
 func HasLen(y int) Compare {
 	return func(x interface{}) assert.BoolOrComparison {
 		return cmp.Len(x, y)
 	}
 }
 
-// DeepEquals checks if the given value is nil
+// IsNil checks if the value is nil
 func IsNil() Compare {
 	return func(x interface{}) assert.BoolOrComparison {
 		return cmp.Nil(x)


### PR DESCRIPTION
These were accidentally wrong due to a sloppy copy/paste issue. Interestingly,
CI passed on the PR that added it (6397dd4d3123e0a1b89298d0a2cfe5388410a74f (https://github.com/moby/moby/pull/39959)),
possibly because of this issue, it stopped linting?

    WARN [runner/golint] Golint: can't lint 4 files: no file name for file &{Doc:<nil> Package:23044677 Name:quota Decls:[0xc02cc3fa40 0xc02cc3fac0 0xc02cc3fb40 0xc02cc3fbc0 0xc02cc62ab0 0xc02cc62c00] Scope:scope 0xc02cc5c340 {
     	var ErrQuotaNotSupported
     	type errQuotaNotSupported
     }
     Imports:[0xc02cc62930] Unresolved:[errdefs nil string] Comments:[0xc02cbc9ae0 0xc02cbc9c60]}

