### PR TITLE
integration-cli: fix DockerNetworkSuite not being run

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -132,7 +132,7 @@ func TestDockerExternalVolumeSuite(t *testing.T) {
 func TestDockerNetworkSuite(t *testing.T) {
 	ensureTestEnvSetup(t)
 	testRequires(t, DaemonIsLinux)
-	suite.Run(t, &DockerExternalVolumeSuite{ds: &DockerSuite{}})
+	suite.Run(t, &DockerNetworkSuite{ds: &DockerSuite{}})
 }
 
 func TestDockerHubPullSuite(t *testing.T) {


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/40010

noticed this in https://github.com/moby/moby/issues/40010, where it was reported that (e.g.) `TestDockerNetworkSuite/TestExternalVolumeDriverBindExternalVolume` was failing, but that test should not be part of `TestDockerNetworkSuite`. Then I noticed that the actual network tests (e.g. `TestDockerNetworkLsDefault`) were not running 🙀 😅 