### PR TITLE
integration-cli: prevent out of range in TestEventsContainerEvents

### DIFF
--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -84,9 +84,11 @@ func (s *DockerSuite) TestEventsContainerEvents(c *testing.T) {
 	events := strings.Split(out, "\n")
 	events = events[:len(events)-1]
 
-	assert.Assert(c, len(events) >= 5) //Missing expected event
 	containerEvents := eventActionsByIDAndType(c, events, "container-events-test", "container")
-	assert.Assert(c, is.DeepEqual(containerEvents[:5], []string{"create", "attach", "start", "die", "destroy"}), out)
+	if len(containerEvents) > 5 {
+		containerEvents = containerEvents[:5]
+	}
+	assert.Assert(c, is.DeepEqual(containerEvents, []string{"create", "attach", "start", "die", "destroy"}), out)
 }
 
 func (s *DockerSuite) TestEventsContainerEventsAttrSort(c *testing.T) {


### PR DESCRIPTION
Prevents the test from panicking;

```
--- FAIL: TestDockerSuite/TestEventsContainerEvents (1.19s)
    suite.go:65: test suite panicked: runtime error: slice bounds out of range [:5] with capacity 4
        goroutine 3978 [running]:
        runtime/debug.Stack(0xc0026e3908, 0x1ad9bc0, 0xc0008100c0)
        	/usr/local/go/src/runtime/debug/stack.go:24 +0x9d
        github.com/docker/docker/internal/test/suite.failOnPanic(0xc00185e600)
        	/go/src/github.com/docker/docker/internal/test/suite/suite.go:65 +0x57
        panic(0x1ad9bc0, 0xc0008100c0)
        	/usr/local/go/src/runtime/panic.go:679 +0x1b2
        github.com/docker/docker/integration-cli.(*DockerSuite).TestEventsContainerEvents(0x2f7d7a8, 0xc00185e600)
        	/go/src/github.com/docker/docker/integration-cli/docker_cli_events_test.go:89 +0x3c5
        reflect.Value.call(0xc0000c4f00, 0xc0008036c0, 0x13, 0x1bfd18b, 0x4, 0xc000e8df30, 0x2, 0x2, 0xc00075c618, 0x40d903, ...)
        	/usr/local/go/src/reflect/value.go:460 +0x5f6
        reflect.Value.Call(0xc0000c4f00, 0xc0008036c0, 0x13, 0xc00075c730, 0x2, 0x2, 0xf, 0x0, 0x0)
        	/usr/local/go/src/reflect/value.go:321 +0xb4
        github.com/docker/docker/internal/test/suite.Run.func2(0xc00185e600)
        	/go/src/github.com/docker/docker/internal/test/suite/suite.go:57 +0x2c2
        testing.tRunner(0xc00185e600, 0xc0008dbea0)
        	/usr/local/go/src/testing/testing.go:909 +0xc9
        created by testing.(*T).Run
        	/usr/local/go/src/testing/testing.go:960 +0x350
```

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

