### PR TITLE
Fix grpc withdialer deprecation warning

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -887,7 +887,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	gopts := []grpc.DialOption{
 		grpc.WithInsecure(),
 		grpc.WithBackoffMaxDelay(3 * time.Second),
-		grpc.WithDialer(dialer.Dialer),
+		grpc.WithContextDialer(dialer.ContextDialer),
 
 		// TODO(stevvooe): We may need to allow configuration of this on the client.
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaults.DefaultMaxRecvMsgSize)),

--- a/hack/validate/golangci-lint.yml
+++ b/hack/validate/golangci-lint.yml
@@ -46,10 +46,6 @@ issues:
     - text: "G202: SQL string concatenation"
       linters:
         - gosec
-    # FIXME temporarily suppress these. See #39928
-    - text: "SA1019: grpc.WithDialer is deprecated"
-      linters:
-        - staticcheck
     # FIXME temporarily suppress these. See #39924
     - text: "SA1019: h.Xattrs is deprecated: Use PAXRecords instead"
       linters:


### PR DESCRIPTION
closes #39928

**- What I did**
Removed deprecation warning for `grpc.WithDialer`

**- How I did it**
Replaced `WithDialer` with `WithContextDialer`, that change required me to pull in a newer version of `containerd` which ended up requiring a newer version of `buildkit`

**- How to verify it**
Ran unit tests

**- Description for the changelog**
Bumped buildkit and containerd, fixed deprecation warning for WithDialer


**- A picture of a cute animal (not mandatory but encouraged)**

![150902_WILD_CutePenguins jpg CROP cq5dam_web_1280_1280_jpeg](https://user-images.githubusercontent.com/1485680/66094378-6e7c4a00-e559-11e9-9ca3-df2b8918d8e0.jpg)


