### PR TITLE
Jenkinsfile: fix typo buidx -> buildx

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -502,7 +502,7 @@ pipeline {
                             steps {
                                 sh '''
                                 make bundles/buildx
-                                bundles/buidx build --load --force-rm --build-arg APT_MIRROR -t docker:${GIT_COMMIT} .
+                                bundles/buildx build --load --force-rm --build-arg APT_MIRROR -t docker:${GIT_COMMIT} .
                                 '''
                             }
                         }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I noticed a typo when looking at past commits (c04ea1133d / #39340 )

**- How I did it**
N/A

**- How to verify it**
I didn't.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix Jenkinsfile buidx typo


**- A picture of a cute animal (not mandatory but encouraged)**

