### PR TITLE
integration-cli: rely less on CLI output format

### DIFF
--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -391,23 +391,17 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *testing.T) {
 
 	// daemon config file
 	configFilePath := "test.json"
-	configFile, err := os.Create(configFilePath)
-	assert.NilError(c, err)
 	defer os.Remove(configFilePath)
 
 	daemonConfig := `{"labels":["foo=bar"]}`
-	_, err = configFile.Write([]byte(daemonConfig))
-	assert.NilError(c, configFile.Close())
+	err := ioutil.WriteFile(configFilePath, []byte(daemonConfig), 0644)
 	assert.NilError(c, err)
 	s.d.Start(c, "--config-file="+configFilePath)
 
 	info := s.d.Info(c)
 
-	configFile, err = os.Create(configFilePath)
-	assert.NilError(c, err)
 	daemonConfig = `{"max-concurrent-downloads":1,"labels":["bar=foo"], "shutdown-timeout": 10}`
-	_, err = fmt.Fprintf(configFile, "%s", daemonConfig)
-	assert.NilError(c, configFile.Close())
+	err = ioutil.WriteFile(configFilePath, []byte(daemonConfig), 0644)
 	assert.NilError(c, err)
 
 	assert.NilError(c, s.d.Signal(unix.SIGHUP))
@@ -448,13 +442,10 @@ func (s *DockerDaemonSuite) TestDaemonEventsWithFilters(c *testing.T) {
 
 	// daemon config file
 	configFilePath := "test.json"
-	configFile, err := os.Create(configFilePath)
-	assert.NilError(c, err)
 	defer os.Remove(configFilePath)
 
 	daemonConfig := `{"labels":["foo=bar"]}`
-	_, err = configFile.Write([]byte(daemonConfig))
-	assert.NilError(c, configFile.Close())
+	err := ioutil.WriteFile(configFilePath, []byte(daemonConfig), 0644)
 	assert.NilError(c, err)
 	s.d.Start(c, "--config-file="+configFilePath)
 

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -396,41 +396,30 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *testing.T) {
 	defer os.Remove(configFilePath)
 
 	daemonConfig := `{"labels":["foo=bar"]}`
-	fmt.Fprintf(configFile, "%s", daemonConfig)
-	configFile.Close()
-	s.d.Start(c, fmt.Sprintf("--config-file=%s", configFilePath))
-
-	// Get daemon ID
-	out, err := s.d.Cmd("info")
+	_, err = configFile.Write([]byte(daemonConfig))
+	assert.NilError(c, configFile.Close())
 	assert.NilError(c, err)
-	daemonID := ""
-	daemonName := ""
-	for _, line := range strings.Split(out, "\n") {
-		if strings.HasPrefix(line, "ID: ") {
-			daemonID = strings.TrimPrefix(line, "ID: ")
-		} else if strings.HasPrefix(line, "Name: ") {
-			daemonName = strings.TrimPrefix(line, "Name: ")
-		}
-	}
-	assert.Assert(c, daemonID != "")
+	s.d.Start(c, "--config-file="+configFilePath)
+
+	info := s.d.Info(c)
 
 	configFile, err = os.Create(configFilePath)
 	assert.NilError(c, err)
 	daemonConfig = `{"max-concurrent-downloads":1,"labels":["bar=foo"], "shutdown-timeout": 10}`
-	fmt.Fprintf(configFile, "%s", daemonConfig)
-	configFile.Close()
+	_, err = fmt.Fprintf(configFile, "%s", daemonConfig)
+	assert.NilError(c, configFile.Close())
+	assert.NilError(c, err)
 
 	assert.NilError(c, s.d.Signal(unix.SIGHUP))
-
 	time.Sleep(3 * time.Second)
 
-	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c))
+	out, err := s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c))
 	assert.NilError(c, err)
 
 	// only check for values known (daemon ID/name) or explicitly set above,
 	// otherwise just check for names being present.
 	expectedSubstrings := []string{
-		" daemon reload " + daemonID + " ",
+		" daemon reload " + info.ID + " ",
 		"(allow-nondistributable-artifacts=[",
 		" cluster-advertise=, ",
 		" cluster-store=, ",
@@ -444,7 +433,7 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *testing.T) {
 		" live-restore=",
 		" max-concurrent-downloads=1, ",
 		" max-concurrent-uploads=5, ",
-		" name=" + daemonName,
+		" name=" + info.Name,
 		" registry-mirrors=[",
 		" runtimes=",
 		" shutdown-timeout=10)",
@@ -464,44 +453,33 @@ func (s *DockerDaemonSuite) TestDaemonEventsWithFilters(c *testing.T) {
 	defer os.Remove(configFilePath)
 
 	daemonConfig := `{"labels":["foo=bar"]}`
-	fmt.Fprintf(configFile, "%s", daemonConfig)
-	configFile.Close()
-	s.d.Start(c, fmt.Sprintf("--config-file=%s", configFilePath))
-
-	// Get daemon ID
-	out, err := s.d.Cmd("info")
+	_, err = configFile.Write([]byte(daemonConfig))
+	assert.NilError(c, configFile.Close())
 	assert.NilError(c, err)
-	daemonID := ""
-	daemonName := ""
-	for _, line := range strings.Split(out, "\n") {
-		if strings.HasPrefix(line, "ID: ") {
-			daemonID = strings.TrimPrefix(line, "ID: ")
-		} else if strings.HasPrefix(line, "Name: ") {
-			daemonName = strings.TrimPrefix(line, "Name: ")
-		}
-	}
-	assert.Assert(c, daemonID != "")
-	assert.NilError(c, s.d.Signal(unix.SIGHUP))
+	s.d.Start(c, "--config-file="+configFilePath)
 
+	info := s.d.Info(c)
+
+	assert.NilError(c, s.d.Signal(unix.SIGHUP))
 	time.Sleep(3 * time.Second)
 
-	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", fmt.Sprintf("daemon=%s", daemonID))
+	out, err := s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", fmt.Sprintf("daemon=%s", info.ID))
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("daemon reload %s", daemonID)))
+	assert.Assert(c, strings.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
 
-	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", fmt.Sprintf("daemon=%s", daemonName))
+	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", fmt.Sprintf("daemon=%s", info.ID))
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("daemon reload %s", daemonID)))
+	assert.Assert(c, strings.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
 
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", "daemon=foo")
 	assert.NilError(c, err)
-	assert.Assert(c, !strings.Contains(out, fmt.Sprintf("daemon reload %s", daemonID)))
+	assert.Assert(c, !strings.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
 
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", "type=daemon")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("daemon reload %s", daemonID)))
+	assert.Assert(c, strings.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
 
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", "type=container")
 	assert.NilError(c, err)
-	assert.Assert(c, !strings.Contains(out, fmt.Sprintf("daemon reload %s", daemonID)))
+	assert.Assert(c, !strings.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
 }

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli/build"
 	"golang.org/x/sys/unix"
 	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 )
 
 // #5979
@@ -434,7 +435,7 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *testing.T) {
 	}
 
 	for _, s := range expectedSubstrings {
-		assert.Check(c, strings.Contains(out, s))
+		assert.Check(c, is.Contains(out, s))
 	}
 }
 


### PR DESCRIPTION
Running these tests with a different version of the CLI caused some failures because the tests relied on the CLI's output format.

Although these tests should be rewritten to use the API directly, in the meantime this makes them slightly more reliable.


