### PR TITLE
Added option to change allocation range of published ports

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -85,6 +85,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.Var(opts.NewNamedListOptsRef("node-generic-resources", &conf.NodeGenericResources, opts.ValidateSingleGenericResource), "node-generic-resource", "Advertise user-defined resource")
 
 	flags.IntVar(&conf.NetworkControlPlaneMTU, "network-control-plane-mtu", config.DefaultNetworkMtu, "Network Control plane MTU")
+	flags.StringVar(&conf.PublishedDynamicPortRange, "published-dynamic-port-range", "", "Published port allocator range")
 
 	conf.MaxConcurrentDownloads = &maxConcurrentDownloads
 	conf.MaxConcurrentUploads = &maxConcurrentUploads

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -102,6 +102,8 @@ type NetworkConfig struct {
 	DefaultAddressPools opts.PoolsOpt `json:"default-address-pools,omitempty"`
 	// NetworkControlPlaneMTU allows to specify the control plane MTU, this will allow to optimize the network use in some components
 	NetworkControlPlaneMTU int `json:"network-control-plane-mtu,omitempty"`
+	// Port allocator range
+	PublishedDynamicPortRange string `json:"published-dynamic-port-range,omitempty"`
 }
 
 // CommonTLSOptions defines TLS configuration for the daemon server.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1417,6 +1417,10 @@ func (daemon *Daemon) networkOptions(dconfig *config.Config, pg plugingetter.Plu
 
 	options = append(options, nwconfig.OptionNetworkControlPlaneMTU(dconfig.NetworkControlPlaneMTU))
 
+	if len(dconfig.NetworkConfig.PublishedDynamicPortRange) > 0 {
+		options = append(options, nwconfig.OptionDynamicPortRange(dconfig.PublishedDynamicPortRange))
+	}
+
 	return options, nil
 }
 

--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: ${LIBNETWORK_COMMIT:=0025177e3dabbe0de151be0957dcaff149d43536}
+: ${LIBNETWORK_COMMIT:=79c19d09290f1a4a83e8bc786db3bf974473eda0}
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/gofrs/flock                              392e7fae8f1b0bdbd67dad7237d2
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        0025177e3dabbe0de151be0957dcaff149d43536
+github.com/docker/libnetwork                        79c19d09290f1a4a83e8bc786db3bf974473eda0
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/config/config.go
+++ b/vendor/github.com/docker/libnetwork/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -13,6 +14,7 @@ import (
 	"github.com/docker/libnetwork/ipamutils"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/portallocator"
 	"github.com/sirupsen/logrus"
 )
 
@@ -235,6 +237,23 @@ func OptionExperimental(exp bool) Option {
 	return func(c *Config) {
 		logrus.Debugf("Option Experimental: %v", exp)
 		c.Daemon.Experimental = exp
+	}
+}
+
+// OptionDynamicPortRange function returns an option setter for service port allocation range
+func OptionDynamicPortRange(in string) Option {
+	return func(c *Config) {
+		start, end := 0, 0
+		if len(in) > 0 {
+			n, err := fmt.Sscanf(in, "%d-%d", &start, &end)
+			if n != 2 || err != nil {
+				logrus.Errorf("Failed to parse range string with err %v", err)
+				return
+			}
+		}
+		if err := portallocator.Get().SetPortRange(start, end); err != nil {
+			logrus.Errorf("Failed to set port range with err %v", err)
+		}
 	}
 }
 

--- a/vendor/github.com/docker/libnetwork/controller.go
+++ b/vendor/github.com/docker/libnetwork/controller.go
@@ -825,7 +825,7 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 
 	err = c.addNetwork(network)
 	if err != nil {
-		if strings.Contains(err.Error(), "restoring existing network") {
+		if _, ok := err.(types.MaskableError); ok {
 			// This error can be ignored and set this boolean
 			// value to skip a refcount increment for configOnly networks
 			skipCfgEpCount = true

--- a/vendor/github.com/docker/libnetwork/firewall_linux.go
+++ b/vendor/github.com/docker/libnetwork/firewall_linux.go
@@ -2,7 +2,6 @@ package libnetwork
 
 import (
 	"github.com/docker/libnetwork/iptables"
-	"github.com/docker/libnetwork/netlabel"
 	"github.com/sirupsen/logrus"
 )
 
@@ -10,42 +9,13 @@ const userChain = "DOCKER-USER"
 
 func (c *controller) arrangeUserFilterRule() {
 	c.Lock()
-
-	if c.hasIPTablesEnabled() {
-		arrangeUserFilterRule()
-	}
-
+	arrangeUserFilterRule()
 	c.Unlock()
-
 	iptables.OnReloaded(func() {
 		c.Lock()
-
-		if c.hasIPTablesEnabled() {
-			arrangeUserFilterRule()
-		}
-
+		arrangeUserFilterRule()
 		c.Unlock()
 	})
-}
-
-func (c *controller) hasIPTablesEnabled() bool {
-	// Locking c should be handled in the calling method.
-	if c.cfg == nil || c.cfg.Daemon.DriverCfg[netlabel.GenericData] == nil {
-		return false
-	}
-
-	genericData, ok := c.cfg.Daemon.DriverCfg[netlabel.GenericData]
-	if !ok {
-		return false
-	}
-
-	optMap := genericData.(map[string]interface{})
-	enabled, ok := optMap["EnableIPTables"].(bool)
-	if !ok {
-		return false
-	}
-
-	return enabled
 }
 
 // This chain allow users to configure firewall policies in a way that persists

--- a/vendor/github.com/docker/libnetwork/portallocator/portallocator.go
+++ b/vendor/github.com/docker/libnetwork/portallocator/portallocator.go
@@ -3,16 +3,35 @@ package portallocator
 import (
 	"errors"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"net"
 	"sync"
 )
 
-const (
-	// DefaultPortRangeStart indicates the first port in port range
-	DefaultPortRangeStart = 49153
-	// DefaultPortRangeEnd indicates the last port in port range
-	DefaultPortRangeEnd = 65535
+var (
+	// defaultPortRangeStart indicates the first port in port range
+	defaultPortRangeStart = 49153
+	// defaultPortRangeEnd indicates the last port in port range
+	// consistent with default /proc/sys/net/ipv4/ip_local_port_range
+	// upper bound on linux
+	defaultPortRangeEnd = 60999
 )
+
+func sanitizePortRange(start int, end int) (newStart, newEnd int, err error) {
+	if start > defaultPortRangeEnd || end < defaultPortRangeStart || start > end {
+		return 0, 0, fmt.Errorf("Request out allowed range [%v, %v]",
+			defaultPortRangeStart, defaultPortRangeEnd)
+	}
+	err = nil
+	newStart, newEnd = start, end
+	if start < defaultPortRangeStart {
+		newStart = defaultPortRangeStart
+	}
+	if end > defaultPortRangeEnd {
+		newEnd = defaultPortRangeEnd
+	}
+	return
+}
 
 type ipMapping map[string]protoMap
 
@@ -92,11 +111,19 @@ func Get() *PortAllocator {
 	return instance
 }
 
-func newInstance() *PortAllocator {
+func getDefaultPortRange() (int, int) {
 	start, end, err := getDynamicPortRange()
-	if err != nil {
-		start, end = DefaultPortRangeStart, DefaultPortRangeEnd
+	if err == nil {
+		start, end, err = sanitizePortRange(start, end)
 	}
+	if err != nil {
+		start, end = defaultPortRangeStart, defaultPortRangeEnd
+	}
+	return start, end
+}
+
+func newInstance() *PortAllocator {
+	start, end := getDefaultPortRange()
 	return &PortAllocator{
 		ipMap: ipMapping{},
 		Begin: start,
@@ -167,6 +194,35 @@ func (p *PortAllocator) ReleasePort(ip net.IP, proto string, port int) error {
 		return nil
 	}
 	delete(protomap[proto].p, port)
+	return nil
+}
+
+// SetPortRange sets dynamic port allocation range.
+// if both portBegin and portEnd are 0, the port range reverts to default
+// value. Otherwise they are sanitized against the default values to
+// ensure their validity.
+func (p *PortAllocator) SetPortRange(portBegin, portEnd int) error {
+	// if begin and end is zero, revert to default values
+	var begin, end int
+	var err error
+	if portBegin == 0 && portEnd == 0 {
+		begin, end = getDefaultPortRange()
+
+	} else {
+		begin, end, err = sanitizePortRange(portBegin, portEnd)
+		if err != nil {
+			return err
+		}
+	}
+	logrus.Debugf("Setting up port allocator to range %v-%v, current %v-%v",
+		begin, end, p.Begin, p.End)
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	if p.Begin == begin && p.End == end {
+		return nil
+	}
+	p.ipMap = ipMapping{}
+	p.Begin, p.End = begin, end
 	return nil
 }
 

--- a/vendor/github.com/docker/libnetwork/portallocator/portallocator_freebsd.go
+++ b/vendor/github.com/docker/libnetwork/portallocator/portallocator_freebsd.go
@@ -8,7 +8,7 @@ import (
 
 func getDynamicPortRange() (start int, end int, err error) {
 	portRangeKernelSysctl := []string{"net.inet.ip.portrange.hifirst", "net.ip.portrange.hilast"}
-	portRangeFallback := fmt.Sprintf("using fallback port range %d-%d", DefaultPortRangeStart, DefaultPortRangeEnd)
+	portRangeFallback := fmt.Sprintf("using fallback port range %d-%d", defaultPortRangeStart, defaultPortRangeEnd)
 	portRangeLowCmd := exec.Command("/sbin/sysctl", portRangeKernelSysctl[0])
 	var portRangeLowOut bytes.Buffer
 	portRangeLowCmd.Stdout = &portRangeLowOut

--- a/vendor/github.com/docker/libnetwork/portallocator/portallocator_linux.go
+++ b/vendor/github.com/docker/libnetwork/portallocator/portallocator_linux.go
@@ -8,7 +8,7 @@ import (
 
 func getDynamicPortRange() (start int, end int, err error) {
 	const portRangeKernelParam = "/proc/sys/net/ipv4/ip_local_port_range"
-	portRangeFallback := fmt.Sprintf("using fallback port range %d-%d", DefaultPortRangeStart, DefaultPortRangeEnd)
+	portRangeFallback := fmt.Sprintf("using fallback port range %d-%d", defaultPortRangeStart, defaultPortRangeEnd)
 	file, err := os.Open(portRangeKernelParam)
 	if err != nil {
 		return 0, 0, fmt.Errorf("port allocator - %s due to error: %v", portRangeFallback, err)

--- a/vendor/github.com/docker/libnetwork/portallocator/portallocator_windows.go
+++ b/vendor/github.com/docker/libnetwork/portallocator/portallocator_windows.go
@@ -1,10 +1,10 @@
 package portallocator
 
-const (
-	StartPortRange = 60000
-	EndPortRange   = 65000
-)
+func init() {
+	defaultPortRangeStart = 60000
+	defaultPortRangeEnd = 65000
+}
 
 func getDynamicPortRange() (start int, end int, err error) {
-	return StartPortRange, EndPortRange, nil
+	return defaultPortRangeStart, defaultPortRangeEnd, nil
 }

--- a/vendor/github.com/docker/libnetwork/vendor.conf
+++ b/vendor/github.com/docker/libnetwork/vendor.conf
@@ -51,5 +51,5 @@ golang.org/x/sync                       1d60e4601c6fd243af51cc01ddf169918a5407ca
 github.com/pkg/errors                   ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
 github.com/ishidawataru/sctp            6e2cb1366111dcf547c13531e3a263a067715847
 
-gotest.tools                            b6e20af1ed078cd01a6413b734051a292450b4cb # v2.1.0
+gotest.tools                            1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0 
 github.com/google/go-cmp                3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0


### PR DESCRIPTION
published-dynamic-port-range may be specified in command line 
dockerd ... -- published-dynamic-port-range="50000-60000" 
or in /etc/docker/daemon.json
published-dynamic-port-range:"50000-60000" specify the range used by
docker engine to allocate published service ports.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added published-dynamic-port-range option to allow user to change published service port 
range,

**- How I did it**
works in libnetwork and docker engine

**- How to verify it**
add/change published-dynamic-port-range is /etc/docker/daemon.json, and kill -SIGHUP DOCKERD_PID, and "docker run -p 80 SOME_WEB_SERVICE_IMG", the published port should 
be allocated from new range.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Allow user to change range of allocated published ports.

**- A picture of a cute animal (not mandatory but encouraged)**

