### PR TITLE
devmapper: fix unit test

### DIFF
--- a/daemon/graphdriver/devmapper/devmapper_test.go
+++ b/daemon/graphdriver/devmapper/devmapper_test.go
@@ -34,8 +34,9 @@ func initLoopbacks() error {
 	if err != nil {
 		return err
 	}
-	// create at least 8 loopback files, ya, that is a good number
-	for i := 0; i < 8; i++ {
+	// create at least 128 loopback files, since a few first ones
+	// might be already in use by the host OS
+	for i := 0; i < 128; i++ {
 		loopPath := fmt.Sprintf("/dev/loop%d", i)
 		// only create new loopback files if they don't exist
 		if _, err := os.Stat(loopPath); err != nil {


### PR DESCRIPTION
It has been pointed out that sometimes device mapper unit tests
fail with the following diagnostics:

> --- FAIL: TestDevmapperSetup (0.02s)
>    graphtest_unix.go:44: graphdriver: loopback attach failed
>    graphtest_unix.go:48: loopback attach failed

The root cause is the absence of udev inside the container used
for testing, which causes device nodes (/dev/loop*) to not be
created.

The test suite itself already has a workaround, but it only
creates 8 devices (loop0 till loop7). It might very well be
the case that the first few devices are already used by the
system (on my laptop 15 devices are busy).

The fix is to raise the number of devices being manually created.

Fixes https://github.com/moby/moby/issues/39155