### PR TITLE
integration-cli: TestDockerNetworkConnectLinkLocalIP return on failure

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1377,9 +1377,9 @@ func (s *DockerNetworkSuite) TestDockerNetworkConnectLinkLocalIP(c *testing.T) {
 	assertNwIsAvailable(c, "n0")
 
 	// run a container with incorrect link-local address
-	_, _, err := dockerCmdWithError("run", "--link-local-ip", "169.253.5.5", "busybox", "top")
+	_, _, err := dockerCmdWithError("run", "--link-local-ip", "169.253.5.5", "busybox", "true")
 	assert.ErrorContains(c, err, "")
-	_, _, err = dockerCmdWithError("run", "--link-local-ip", "2001:db8::89", "busybox", "top")
+	_, _, err = dockerCmdWithError("run", "--link-local-ip", "2001:db8::89", "busybox", "true")
 	assert.ErrorContains(c, err, "")
 
 	// run two containers with link-local ip on the test network


### PR DESCRIPTION
Similar to #40043

Without this PR, the `TestDockerNetworkConnectLinkLocalIP` test could hang because it is waiting on a `top` run to exit which it never will.

cc @arkodg 