### PR TITLE
Fix trick for `make BINDDIR=. shell` and `COPY .`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -299,19 +299,21 @@ WORKDIR /go/src/github.com/docker/docker
 VOLUME /var/lib/docker
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]
+
+FROM dev AS src
 COPY . /go/src/github.com/docker/docker
 
-FROM dev AS build-binary
+FROM src AS build-binary
 ARG DOCKER_GITCOMMIT=HEAD
 RUN --mount=type=cache,target=/root/.cache/go-build \
 	hack/make.sh binary
 
-FROM dev AS build-dynbinary
+FROM src AS build-dynbinary
 ARG DOCKER_GITCOMMIT=HEAD
 RUN --mount=type=cache,target=/root/.cache/go-build \
 	hack/make.sh dynbinary
 
-FROM dev AS build-cross
+FROM src AS build-cross
 ARG DOCKER_GITCOMMIT=HEAD
 ARG DOCKER_CROSSPLATFORMS=""
 RUN --mount=type=cache,target=/root/.cache/go-build \
@@ -326,4 +328,4 @@ COPY --from=build-dynbinary /go/src/github.com/docker/docker/bundles/ /
 FROM scratch AS cross
 COPY --from=build-cross /go/src/github.com/docker/docker/bundles/ /
 
-FROM dev AS final
+FROM src AS final

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,11 @@ install: ## install the linux binaries
 run: build ## run the docker daemon in a container
 	$(DOCKER_RUN_DOCKER) sh -c "KEEPBUNDLE=1 hack/make.sh install-binary run"
 
+ifeq ($(BIND_DIR), .)
 shell: DOCKER_BUILD_ARGS += --target=dev
+else
+shell: DOCKER_BUILD_ARGS += --target=final
+endif
 shell: BUILDX_BUILD_EXTRA_OPTS += --load
 shell: build  ## start a shell inside the build env
 	$(DOCKER_RUN_DOCKER) bash


### PR DESCRIPTION
This was inadvertently removed when updating the Dockerfile for buildkit
specific features.

Trick selects a different build target depending on if the source is
going to be bind-mounted in anyway, which prevents the need to copy the
whole source tree to the builder.

introduced in https://github.com/moby/moby/pull/39340