### PR TITLE
Makefile: force using buildkit if USE_BUILDX is not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ DOCKER_BUILDX_CLI_PLUGIN_PATH ?= ~/.docker/cli-plugins/docker-buildx
 BUILDX ?= $(shell if [ -x "$(DOCKER_BUILDX_CLI_PLUGIN_PATH)" ]; then echo $(DOCKER_BUILDX_CLI_PLUGIN_PATH); fi)
 endif
 
+ifndef USE_BUILDX
+DOCKER_BUILDKIT := 1
+export DOCKER_BUILDKIT
+endif
+
 BUILDX ?= bundles/buildx
 DOCKER ?= docker
 


### PR DESCRIPTION
introduced in https://github.com/moby/moby/pull/39340

Before this change:

```
unset DOCKER_BUILDKIT

make build
docker build  --build-arg=CROSS=false  -t "docker-dev:require-buildkit" -f "Dockerfile" .
Sending build context to Docker daemon  50.01MB
Error response from daemon: Dockerfile parse error line 17: Unknown flag: mount
make: *** [build] Error 1
```

After this change:

```
unset DOCKER_BUILDKIT

make build
docker build  --build-arg=CROSS=false  -t "docker-dev:require-buildkit" -f "Dockerfile" .
[+] Building 5.2s (71/71) FINISHED
 => [internal] load .dockerignore                                                                     0.1s
...
...
 => => exporting layers                                                                               0.9s
 => => writing image sha256:1ea4128a0e7f3bdee47de1675252609d9d6071e32da24a2aafee9fba96b2404b          0.0s
 => => naming to docker.io/library/docker-dev:require-buildkit                                        0.0s
...

