### PR TITLE
[WIP] bump go-swagger to 0.21.1 + golang 1.13 fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,14 +60,16 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM base AS swagger
 # Install go-swagger for validating swagger.yaml
-ENV GO_SWAGGER_COMMIT c28258affb0b6251755d92489ef685af8d4ff3eb
+# Version: 0.20.1 + golang 1.13 fix
+ENV GO_SWAGGER_COMMIT 4042f8256534e999e907faded70e3542b786b4cf
 RUN --mount=type=cache,target=/root/.cache/go-build \
 	--mount=type=cache,target=/go/pkg/mod \
 		set -x \
 		&& export GOPATH="$(mktemp -d)" \
 		&& git clone https://github.com/go-swagger/go-swagger.git "$GOPATH/src/github.com/go-swagger/go-swagger" \
-		&& (cd "$GOPATH/src/github.com/go-swagger/go-swagger" && git checkout -q "$GO_SWAGGER_COMMIT") \
-		&& go build -o /build/swagger github.com/go-swagger/go-swagger/cmd/swagger \
+		&& (cd "$GOPATH/src/github.com/go-swagger/go-swagger" \
+			&& git checkout -q "$GO_SWAGGER_COMMIT" \
+			&& GO111MODULE=on go build -o /build/swagger ./cmd/swagger) \
 		&& rm -rf "$GOPATH"
 
 FROM base AS frozen-images

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -270,7 +270,7 @@ definitions:
         type: "string"
       Type:
         description: |
-          The mount type. Available types:
+          Mount type. Available types are:
 
           - `bind` Mounts a file or directory from the host into the container. Must exist prior to creating the container.
           - `volume` Creates a volume with the given name and options (or uses a pre-existing volume with the same name and options). These are **not** removed when the container is removed.


### PR DESCRIPTION
This includes the following fix: 

 * https://github.com/go-swagger/go-swagger/pull/2059

to avoid swagger panic:

> panic: object has no key "default"

when it is compiled by golang 1.13

* v2: add `go mod download` since vendor is no more
* v3: add `GO111MODULE=on`
* v4: run `go build` for local package, remove `go mod download`
* v5: move `GO111MODULE=on` to right before `go build`
