### PR TITLE
integration-cli: make testRequires() a Helper

### DIFF
--- a/integration-cli/requirement/requirement.go
+++ b/integration-cli/requirement/requirement.go
@@ -1,29 +1,25 @@
 package requirement // import "github.com/docker/docker/integration-cli/requirement"
 
 import (
-	"fmt"
 	"path"
 	"reflect"
 	"runtime"
 	"strings"
+	"testing"
 )
-
-// SkipT is the interface required to skip tests
-type SkipT interface {
-	Skip(...interface{})
-}
 
 // Test represent a function that can be used as a requirement validation.
 type Test func() bool
 
 // Is checks if the environment satisfies the requirements
 // for the test to run or skips the tests.
-func Is(s SkipT, requirements ...Test) {
+func Is(t *testing.T, requirements ...Test) {
+	t.Helper()
 	for _, r := range requirements {
 		isValid := r()
 		if !isValid {
 			requirementFunc := runtime.FuncForPC(reflect.ValueOf(r).Pointer()).Name()
-			s.Skip(fmt.Sprintf("unmatched requirement %s", extractRequirement(requirementFunc)))
+			t.Skipf("unmatched requirement %s", extractRequirement(requirementFunc))
 		}
 	}
 }

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -190,6 +191,7 @@ func TODOBuildkit() bool {
 
 // testRequires checks if the environment satisfies the requirements
 // for the test to run or skips the tests.
-func testRequires(c interface{}, requirements ...requirement.Test) {
-	requirement.Is(c.(requirement.SkipT), requirements...)
+func testRequires(t *testing.T, requirements ...requirement.Test) {
+	t.Helper()
+	requirement.Is(t, requirements...)
 }


### PR DESCRIPTION
Make this utility a helper, so that the "skip" message is printing the location of the test, instead of the location of the helper, which is what it's printing now:

    requirement.go:26: unmatched requirement bridgeNfIptables


