### PR TITLE
integration-cli: Fix `SA1019: httputil.ClientConn is deprecated`

### DIFF
--- a/hack/validate/golangci-lint.yml
+++ b/hack/validate/golangci-lint.yml
@@ -86,10 +86,6 @@ issues:
     - text: "SA1019: httputil.NewClientConn is deprecated"
       linters:
         - staticcheck
-    # FIXME temporarily suppress these. See #39927
-    - text: "SA1019: httputil.ClientConn is deprecated"
-      linters:
-        - staticcheck
     # FIXME temporarily suppress these (related to the ones above)
     - text: "SA1019: httputil.ErrPersistEOF is deprecated"
       linters:

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -65,11 +65,11 @@ func (s *DockerSuite) TestExecResizeImmediatelyAfterExecStart(c *testing.T) {
 		}
 
 		payload := bytes.NewBufferString(`{"Tty":true}`)
-		conn, _, err := sockRequestHijack(http.MethodPost, fmt.Sprintf("/exec/%s/start", execID), payload, "application/json", request.DaemonHost())
+		wc, _, err := requestHijack(http.MethodPost, fmt.Sprintf("/exec/%s/start", execID), payload, "application/json", request.DaemonHost())
 		if err != nil {
 			return errors.Wrap(err, "failed to start the exec")
 		}
-		defer conn.Close()
+		defer wc.Close()
 
 		_, rc, err := request.Post(fmt.Sprintf("/exec/%s/resize?h=24&w=80", execID), request.ContentType("text/plain"))
 		if err != nil {


### PR DESCRIPTION
Rewrite sockRequestHijack to requestHijack which use writable Response.Body
```
// As of Go 1.12, the Body will also implement io.Writer
// on a successful "101 Switching Protocols" response,
// as used by WebSockets and HTTP/2's "h2c" mode.
Body io.ReadCloser
```

TestPostContainersAttach and TestExecResizeImmediatelyAfterExecStart
replace all sockRequestHijack to requestHijack.

Signed-off-by: HuanHuan Ye <logindaveye@gmail.com>

fixes #39927

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix `SA1019: httputil.ClientConn is deprecated`

**- How I did it**
Rewrite sockRequestHijack to requestHijack which use writable Response.Body
https://github.com/golang/go/issues/28030#issuecomment-427223449

**- How to verify it**
Maybe in CI golangci-lint

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
integration-cli: Fix `SA1019: httputil.ClientConn is deprecated`

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/8220938/66651119-d3742600-ec64-11e9-9e20-92327809da59.png)

