### PR TITLE
daemon: use constants for AppArmor and Seccomp

### DIFF
--- a/daemon/apparmor_default.go
+++ b/daemon/apparmor_default.go
@@ -11,7 +11,8 @@ import (
 
 // Define constants for native driver
 const (
-	defaultApparmorProfile = "docker-default"
+	unconfinedAppArmorProfile = "unconfined"
+	defaultApparmorProfile    = "docker-default"
 )
 
 func ensureDefaultAppArmorProfile() error {

--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -24,7 +24,7 @@ func (daemon *Daemon) saveApparmorConfig(container *container.Container) error {
 		}
 
 	} else {
-		container.AppArmorProfile = "unconfined"
+		container.AppArmorProfile = unconfinedAppArmorProfile
 	}
 	return nil
 }

--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -38,12 +38,12 @@ func (daemon *Daemon) execSetPlatformOpt(c *container.Container, ec *exec.Config
 		} else if c.HostConfig.Privileged {
 			// `docker exec --privileged` does not currently disable AppArmor
 			// profiles. Privileged configuration of the container is inherited
-			appArmorProfile = "unconfined"
+			appArmorProfile = unconfinedAppArmorProfile
 		} else {
-			appArmorProfile = "docker-default"
+			appArmorProfile = defaultApparmorProfile
 		}
 
-		if appArmorProfile == "docker-default" {
+		if appArmorProfile == defaultApparmorProfile {
 			// Unattended upgrades and other fun services can unload AppArmor
 			// profiles inadvertently. Since we cannot store our profile in
 			// /etc/apparmor.d, nor can we practically add other ways of

--- a/daemon/exec_linux_test.go
+++ b/daemon/exec_linux_test.go
@@ -49,5 +49,5 @@ func TestExecSetPlatformOptPrivileged(t *testing.T) {
 	c.HostConfig = &containertypes.HostConfig{Privileged: true}
 	err = d.execSetPlatformOpt(c, ec, p)
 	assert.NilError(t, err)
-	assert.Equal(t, "unconfined", p.ApparmorProfile)
+	assert.Equal(t, unconfinedAppArmorProfile, p.ApparmorProfile)
 }

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -111,12 +111,12 @@ func WithApparmor(c *container.Container) coci.SpecOpts {
 			if c.AppArmorProfile != "" {
 				appArmorProfile = c.AppArmorProfile
 			} else if c.HostConfig.Privileged {
-				appArmorProfile = "unconfined"
+				appArmorProfile = unconfinedAppArmorProfile
 			} else {
-				appArmorProfile = "docker-default"
+				appArmorProfile = defaultApparmorProfile
 			}
 
-			if appArmorProfile == "docker-default" {
+			if appArmorProfile == defaultApparmorProfile {
 				// Unattended upgrades and other fun services can unload AppArmor
 				// profiles inadvertently. Since we cannot store our profile in
 				// /etc/apparmor.d, nor can we practically add other ways of

--- a/daemon/seccomp_disabled.go
+++ b/daemon/seccomp_disabled.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/docker/container"
 )
 
-var supportsSeccomp = false
+const supportsSeccomp = false
 
 // WithSeccomp sets the seccomp profile
 func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {

--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var supportsSeccomp = true
+const supportsSeccomp = true
 
 // WithSeccomp sets the seccomp profile
 func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {

--- a/daemon/seccomp_unsupported.go
+++ b/daemon/seccomp_unsupported.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/docker/container"
 )
 
-var supportsSeccomp = false
+const supportsSeccomp = false
 
 // WithSeccomp sets the seccomp profile
 func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {


### PR DESCRIPTION
- use constants for AppArmor profiles
- make supportsSeccomp a const instead of a variable