### PR TITLE
[WIP] Use whitelist for xattrs

### DIFF
--- a/integration/build/testdata/Dockerfile.testBuildPreserveXattrs
+++ b/integration/build/testdata/Dockerfile.testBuildPreserveXattrs
@@ -1,0 +1,23 @@
+FROM alpine AS base
+RUN apk add --no-cache attr
+
+FROM base AS testdata
+
+# Create a test-file and set a whitelisted extended attribute. Verify the attribute is set
+RUN mkdir -p /testdir && touch /testdir/testfile \
+ && setfattr -n user.pax.flags -v ok /testdir/testfile \
+ && test "$(getfattr -n user.pax.flags --only-values testdir/testfile)" = "ok" || { echo "failed to set xattr 'user.pax.flags'"; exit 1; }
+
+# Verify the attribute is preserved in the image
+FROM testdata AS original
+RUN test "$(getfattr -n user.pax.flags --only-values testdir/testfile)" = "ok" || { echo "xattr 'user.pax.flags' was not preserved on original file"; exit 1; }
+
+# Verify the attribute is preserved when (recursively) copying a directory
+FROM base AS copy_dir
+COPY --from=testdata /testdir /testdir-copy
+RUN test "$(getfattr -n user.pax.flags --only-values testdir-copy/testfile)" = "ok" || { echo "xattr 'user.pax.flags' was not preserved on copied directory"; exit 1; }
+
+# Verify the attribute is preserved when copying a file
+FROM base AS copy_file
+COPY --from=testdata /testdir/testfile /testfile-copy
+RUN test "$(getfattr -n user.pax.flags --only-values testfile-copy)" = "ok" || { echo "xattr 'user.pax.flags' was not preserved on copied file"; exit 1; }


### PR DESCRIPTION
addresses https://github.com/moby/moby/issues/35699

Before this patch:

    DOCKER_BUILDKIT=0 docker build --no-cache -<<'EOF'
    FROM alpine
    RUN apk add --no-cache attr
    RUN touch /testfile \
     && setfattr -n user.pax.flags -v ok /testfile

    RUN test "$(getfattr -n user.pax.flags --only-values testfile)" = "ok"
    EOF

    getfattr: testdir/testfile: No such file or directory
    The command '/bin/sh -c test "$(getfattr -n user.pax.flags --only-values testdir/testfile)" = "ok"' returned a non-zero code: 1

With this patch:

    DOCKER_BUILDKIT=0 docker build --no-cache -<<'EOF'
    FROM alpine
    RUN apk add --no-cache attr
    RUN touch /testfile \
     && setfattr -n user.pax.flags -v ok /testfile

    RUN test "$(getfattr -n user.pax.flags --only-values testfile)" = "ok"
    EOF

    Successfully built 5ecde85b467d

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

