### PR TITLE
Add flag to configure containerd healthcheck delay.

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -44,6 +44,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.StringVar(&conf.ExecRoot, "exec-root", defaultExecRoot, "Root directory for execution state files")
 	flags.StringVar(&conf.ContainerdAddr, "containerd", "", "containerd grpc address")
 	flags.BoolVar(&conf.CriContainerd, "cri-containerd", false, "start containerd with cri")
+	flags.IntVar(&conf.ContainerdHealthcheckDelay, "containerd-healthcheck-delay", 0, "Delay (in seconds) between successful containerd daemon healthchecks")
 
 	// "--graph" is "soft-deprecated" in favor of "data-root". This flag was added
 	// before Docker 1.0, so won't be removed, only hidden, to discourage its usage.

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -550,6 +550,8 @@ func (cli *DaemonCli) getContainerdDaemonOpts() ([]supervisor.DaemonOpt, error) 
 		opts = append(opts, supervisor.WithPlugin("cri", nil))
 	}
 
+	opts = append(opts, supervisor.WithHealthcheckDelay(time.Duration(cli.Config.ContainerdHealthcheckDelay)*time.Second))
+
 	return opts, nil
 }
 

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -246,6 +246,8 @@ type CommonConfig struct {
 
 	ContainerdNamespace       string `json:"containerd-namespace,omitempty"`
 	ContainerdPluginNamespace string `json:"containerd-plugin-namespace,omitempty"`
+	// Delay (in seconds) between successful containerd daemon healthchecks
+	ContainerdHealthcheckDelay int `json:"containerd-healthcheck-delay,omitempty"`
 }
 
 // IsValueSet returns true if a configuration value

--- a/libcontainerd/supervisor/remote_daemon_options.go
+++ b/libcontainerd/supervisor/remote_daemon_options.go
@@ -1,5 +1,7 @@
 package supervisor // import "github.com/docker/docker/libcontainerd/supervisor"
 
+import "time"
+
 // WithRemoteAddr sets the external containerd socket to connect to.
 func WithRemoteAddr(addr string) DaemonOpt {
 	return func(r *remote) error {
@@ -50,6 +52,15 @@ func WithMetricsAddress(addr string) DaemonOpt {
 func WithPlugin(name string, conf interface{}) DaemonOpt {
 	return func(r *remote) error {
 		r.pluginConfs.Plugins[name] = conf
+		return nil
+	}
+}
+
+// WithHealthcheckDelay configures the delay between successful
+// healthchecks of the containerd daemon.
+func WithHealthcheckDelay(delay time.Duration) DaemonOpt {
+	return func(r *remote) error {
+		r.healthcheckDelay = delay
 		return nil
 	}
 }


### PR DESCRIPTION
On my laptop I don't really need containerd to be healthchecked at 500ms
intervals, or hardly ever really.
Given that other types of environments have different needs I figured
let's make this configurable.