### PR TITLE
Wait for c8d process exit instead of polling API

### DIFF
--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -300,6 +300,7 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 				delay = 100 * time.Millisecond
 				continue
 			}
+			logrus.WithField("address", r.GRPC.Address).Debug("Created containerd monitoring client")
 		}
 
 		if client != nil {
@@ -313,6 +314,14 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 				}
 
 				transientFailureCount = 0
+
+				select {
+				case <-r.daemonWaitCh:
+				case <-ctx.Done():
+				}
+
+				// Set a small delay in case there is a recurring failure (or bug in this code)
+				// to ensure we don't end up in a super tight loop.
 				delay = 500 * time.Millisecond
 				continue
 			}


### PR DESCRIPTION
In the containerd supervisor, instead of polling the healthcheck API
every 500 milliseconds we can just wait for the process to exit.

Related to #40095