### PR TITLE
Export the LogT type and use it in the options

### DIFF
--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -28,11 +28,12 @@ import (
 	"gotest.tools/assert"
 )
 
-type logT interface {
+// LogT is the subset of the testing.TB interface used by the daemon.
+type LogT interface {
 	Logf(string, ...interface{})
 }
 
-// nopLog is a no-op implementation of logT that is used in daemons created by
+// nopLog is a no-op implementation of LogT that is used in daemons created by
 // NewDaemon (where no testing.TB is available).
 type nopLog struct{}
 
@@ -71,7 +72,7 @@ type Daemon struct {
 	experimental               bool
 	init                       bool
 	dockerdBinary              string
-	log                        logT
+	log                        LogT
 	pidFile                    string
 	args                       []string
 

--- a/testutil/daemon/ops.go
+++ b/testutil/daemon/ops.go
@@ -1,8 +1,6 @@
 package daemon
 
 import (
-	"testing"
-
 	"github.com/docker/docker/testutil/environment"
 )
 
@@ -17,7 +15,7 @@ func WithDefaultCgroupNamespaceMode(mode string) Option {
 }
 
 // WithTestLogger causes the daemon to log certain actions to the provided test.
-func WithTestLogger(t testing.TB) Option {
+func WithTestLogger(t LogT) Option {
 	return func(d *Daemon) {
 		d.log = t
 	}


### PR DESCRIPTION
**- What I did**

Exported the `LogT` type so that buildkit integration tests can use the `WithTestLogger` option even though they don't have access to the original `testing.T`.


**- Description for the changelog**

Probably not changelog worthy.

/cc @tonistiigi who suggested this solution.

