### PR TITLE
bump Graylog2/go-gelf to 1550ee647df0510058c9d67a45c56f18911d80b8

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -90,7 +90,7 @@ github.com/coreos/go-systemd                        39ca1b05acc7ad1220e09f133283
 github.com/godbus/dbus                              5f6efc7ef2759c81b7ba876593971bfce311eab3 # v4.0.0
 
 # gelf logging driver deps
-github.com/Graylog2/go-gelf                         4143646226541087117ff2f83334ea48b3201841
+github.com/Graylog2/go-gelf                         1550ee647df0510058c9d67a45c56f18911d80b8 # v2 branch
 
 # fluent-logger-golang deps
 github.com/fluent/fluent-logger-golang              7a6c9dcd7f14c2ed5d8c55c11b894e5455ee311b # v1.4.0

--- a/vendor/github.com/Graylog2/go-gelf/gelf/tcpwriter.go
+++ b/vendor/github.com/Graylog2/go-gelf/gelf/tcpwriter.go
@@ -43,7 +43,9 @@ func NewTCPWriter(addr string) (*TCPWriter, error) {
 // filled out appropriately.  In general, clients will want to use
 // Write, rather than WriteMessage.
 func (w *TCPWriter) WriteMessage(m *Message) (err error) {
-	messageBytes, err := m.toBytes()
+	buf := newBuffer()
+	defer bufPool.Put(buf)
+	messageBytes, err := m.toBytes(buf)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
https://github.com/Graylog2/go-gelf/compare/4143646226541087117ff2f83334ea48b3201841...1550ee647df0510058c9d67a45c56f18911d80b8

includes

- Graylog2/go-gelf#20 Prevent panic when unmarshalling JSON
- Graylog2/go-gelf#23 Feat: Use more precise time stamps
- Graylog2/go-gelf#31 bugfix. Not goroutine safe for TCP writer

