### PR TITLE
logger/gelf: use compression level 0 by default

### DIFF
--- a/daemon/logger/gelf/gelf.go
+++ b/daemon/logger/gelf/gelf.go
@@ -154,6 +154,7 @@ func newGELFUDPWriter(address string, info logger.Info) (gelf.Writer, error) {
 		}
 	}
 
+	gelfWriter.CompressionLevel = 0 // no compression by default
 	if v, ok := info.Config["gelf-compression-level"]; ok {
 		val, err := strconv.Atoi(v)
 		if err != nil {


### PR DESCRIPTION
go-gelf package used by dockerd uses gzip compression by default,
which is costly in terms of CPU. Since the data is sent over the
network, it's a trade-off between CPU and network bandwidth.
    
This comes from observing the internal infrastructure on which
dockerd writes containers' logs to one of its containers
(which itself does something else with those logs). With
default gzip -1 compression, dockerd was using 150-220% CPU,
which decreased to about 30% without compression.

In addition, there are multiple reports of gelf using
too much CPU:
    
* https://github.com/moby/moby/issues/19665
* https://github.com/moby/moby/issues/19209
    
With this commit, we disable compression but the output
produced is still gzip-compatible. This is done because
there are reports that Logstash only got support for
uncompressed log messages recently (see https://github.com/logstash-plugins/logstash-input-gelf/pull/48).

**- Description for the changelog**

* log/gelf: default compression level set to 0 to prioritize saving CPU over network bandwidth