### PR TITLE
Fix TEST_FILTER to work for both "integration" and "integration-cli"

### DIFF
--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -21,7 +21,6 @@ setup_integration_test_filter() {
 	if [ -z "${TEST_FILTER}" ]; then
 		return
 	fi
-	TESTFLAGS+="-test.run ${TEST_FILTER}"
 
 	local dirs
 	dirs=$(grep -rIlE --include '*_test.go' "func .*${TEST_FILTER}.*\(. \*testing\.T\)" ./integration*/ | xargs -I file dirname file | uniq)
@@ -30,6 +29,8 @@ setup_integration_test_filter() {
 		if [ -z "${TEST_INTEGRATION_DIR}" ]; then
 			echo "Skipping integration tests since the supplied filter \"${TEST_FILTER}\" omits all integration tests"
 			TEST_SKIP_INTEGRATION=1
+		else
+			TESTFLAGS+=" -test.run ${TEST_FILTER}"
 		fi
 	fi
 
@@ -37,12 +38,18 @@ setup_integration_test_filter() {
 		if echo "$dirs" | grep -vq '^./integration-cli$'; then
 			TEST_SKIP_INTEGRATION_CLI=1
 			echo "Skipping integration-cli tests since the supplied filter \"${TEST_FILTER}\" omits all integration-cli tests"
+		else
+			TESTFLAGS+=" -test.run /${TEST_FILTER}"
 		fi
 	fi
 }
 
 setup_integration_test_filter
-integration_api_dirs="${TEST_INTEGRATION_DIR:-$(go list  -test -f '{{- if ne .ForTest "" -}}{{- .Dir -}}{{- end -}}'  ./integration/...)}"
+if [ -z "${TEST_SKIP_INTEGRATION}" ] && [ -z "${TEST_INTEGRATION_DIR}" ]; then
+	integration_api_dirs="$(go list -test -f '{{- if ne .ForTest "" -}}{{- .Dir -}}{{- end -}}'  ./integration/...)"
+else
+	integration_api_dirs="${TEST_INTEGRATION_DIR}"
+fi
 
 run_test_integration() {
 	set_platform_timeout


### PR DESCRIPTION
The `TEST_FILTER` variable allows running a single integration or integration-cli
test. However, it failed to work properly for integration-cli tests.

Before:
-----------

    # Filtering "integration" tests works:
    make TEST_FILTER=TestInspectCpusetInConfigPre120 test-integration
    ...
    DONE 1 tests in 18.331s

    # But running a single test in "integration-cli" did not:

    make TEST_FILTER=TestSwarmNetworkCreateIssue27866 test-integration
    ...
    DONE 0 tests in 17.314s

Trying to manually add the `/` prefix, didn't work either, because that made the
"grep" fail to find which test-suites to run/skip:

    make TEST_FILTER=/TestSwarmNetworkCreateIssue27866 test-integration
    ---> Making bundle: test-integration (in bundles/test-integration)
    make: *** [test-integration] Error 1

After:
-----------

    make TEST_FILTER=TestInspectCpusetInConfigPre120 test-integration
    ...
    DONE 1 tests in 18.331s

    make TEST_FILTER=TestSwarmNetworkCreateIssue27866 test-integration
    ...
    DONE 12 tests in 26.527s

Note that the `12` tests is still a bit misleading, because every _suite_ is
started (which is counted as a test), but no tests are run. This is still
something that could be improved on.

This patch also makes a small modification to the code that's setting
`integration_api_dirs`, and no longer runs `go list` if not needed.

