### PR TITLE
integration-cli: use subtests for TestSwarmNetworkCreateDup

### DIFF
--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1522,19 +1522,17 @@ func (s *DockerSwarmSuite) TestSwarmNetworkCreateDup(c *testing.T) {
 	d := s.AddDaemon(c, true, true)
 	drivers := []string{"bridge", "overlay"}
 	for i, driver1 := range drivers {
-		nwName := fmt.Sprintf("network-test-%d", i)
 		for _, driver2 := range drivers {
-			c.Logf("Creating a network named %q with %q, then %q",
-				nwName, driver1, driver2)
-			out, err := d.Cmd("network", "create", "--driver", driver1, nwName)
-			assert.NilError(c, err, "out: %v", out)
-			out, err = d.Cmd("network", "create", "--driver", driver2, nwName)
-			assert.Assert(c, strings.Contains(out, fmt.Sprintf("network with name %s already exists", nwName)), out)
-			assert.ErrorContains(c, err, "")
-			c.Logf("As expected, the attempt to network %q with %q failed: %s",
-				nwName, driver2, out)
-			out, err = d.Cmd("network", "rm", nwName)
-			assert.NilError(c, err, "out: %v", out)
+			c.Run(fmt.Sprintf("driver %s then %s", driver1, driver2), func(c *testing.T) {
+				nwName := fmt.Sprintf("network-test-%d", i)
+				out, err := d.Cmd("network", "create", "--driver", driver1, nwName)
+				assert.NilError(c, err, "out: %v", out)
+				out, err = d.Cmd("network", "create", "--driver", driver2, nwName)
+				assert.Assert(c, strings.Contains(out, fmt.Sprintf("network with name %s already exists", nwName)), out)
+				assert.ErrorContains(c, err, "")
+				out, err = d.Cmd("network", "rm", nwName)
+				assert.NilError(c, err, "out: %v", out)
+			})
 		}
 	}
 }


### PR DESCRIPTION
This makes the test less noisy, and won't print the `failed: Error ...` messages,
which were confusing.

Also, running as a subtest allows tracking failures individually through the
junit.xml files.

Before:

    === RUN   TestDockerSwarmSuite/TestSwarmNetworkCreateDup
        --- PASS: TestDockerSwarmSuite/TestSwarmNetworkCreateDup (3.00s)
            daemon.go:26: Creating a new daemon at: "/go/src/github.com/docker/docker/bundles/test-integration/TestDockerSwarmSuite/TestSwarmNetworkCreateDup"
            docker_cli_swarm_test.go:1527: Creating a network named "network-test-0" with "bridge", then "bridge"
            docker_cli_swarm_test.go:1534: As expected, the attempt to network "network-test-0" with "bridge" failed: Error response from daemon: network with name network-test-0 already exists
            docker_cli_swarm_test.go:1527: Creating a network named "network-test-0" with "bridge", then "overlay"
            docker_cli_swarm_test.go:1534: As expected, the attempt to network "network-test-0" with "overlay" failed: Error response from daemon: network with name network-test-0 already exists
            docker_cli_swarm_test.go:1527: Creating a network named "network-test-1" with "overlay", then "bridge"
            docker_cli_swarm_test.go:1534: As expected, the attempt to network "network-test-1" with "bridge" failed: Error response from daemon: network with name network-test-1 already exists
            docker_cli_swarm_test.go:1527: Creating a network named "network-test-1" with "overlay", then "overlay"
            docker_cli_swarm_test.go:1534: As expected, the attempt to network "network-test-1" with "overlay" failed: Error response from daemon: network with name network-test-1 already exists

After:

    === RUN   TestDockerSwarmSuite
    === RUN   TestDockerSwarmSuite/TestSwarmNetworkCreateDup
    === RUN   TestDockerSwarmSuite/TestSwarmNetworkCreateDup/driver_bridge_then_bridge
    === RUN   TestDockerSwarmSuite/TestSwarmNetworkCreateDup/driver_bridge_then_overlay
    === RUN   TestDockerSwarmSuite/TestSwarmNetworkCreateDup/driver_overlay_then_bridge
    === RUN   TestDockerSwarmSuite/TestSwarmNetworkCreateDup/driver_overlay_then_overlay
    --- PASS: TestDockerSwarmSuite (8.12s)
        --- PASS: TestDockerSwarmSuite/TestSwarmNetworkCreateDup (8.12s)
            daemon.go:26: Creating a new daemon at: "/go/src/github.com/docker/docker/bundles/test-integration/TestDockerSwarmSuite/TestSwarmNetworkCreateDup"
            --- PASS: TestDockerSwarmSuite/TestSwarmNetworkCreateDup/driver_bridge_then_bridge (0.52s)
            --- PASS: TestDockerSwarmSuite/TestSwarmNetworkCreateDup/driver_bridge_then_overlay (0.31s)
            --- PASS: TestDockerSwarmSuite/TestSwarmNetworkCreateDup/driver_overlay_then_bridge (0.17s)
            --- PASS: TestDockerSwarmSuite/TestSwarmNetworkCreateDup/driver_overlay_then_overlay (0.12s)


