### PR TITLE
integration-cli: don't log "Creating new daemon" logs, and print correct line numbers

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -349,6 +349,7 @@ func (s *DockerSwarmSuite) SetUpTest(c *testing.T) {
 }
 
 func (s *DockerSwarmSuite) AddDaemon(c *testing.T, joinSwarm, manager bool) *daemon.Daemon {
+	c.Helper()
 	d := daemon.New(c, dockerBinary, dockerdBinary,
 		testdaemon.WithEnvironment(testEnv.Execution),
 		testdaemon.WithSwarmPort(defaultSwarmPort+s.portIndex),

--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -22,6 +22,7 @@ type Daemon struct {
 // This will create a directory such as d123456789 in the folder specified by $DOCKER_INTEGRATION_DAEMON_DEST or $DEST.
 // The daemon will not automatically start.
 func New(t testing.TB, dockerBinary string, dockerdBinary string, ops ...daemon.Option) *Daemon {
+	t.Helper()
 	ops = append(ops, daemon.WithDockerdBinary(dockerdBinary))
 	d := daemon.New(t, ops...)
 	return &Daemon{
@@ -78,9 +79,10 @@ func (d *Daemon) inspectFieldWithError(name, field string) (string, error) {
 
 // CheckActiveContainerCount returns the number of active containers
 // FIXME(vdemeester) should re-use ActivateContainers in some way
-func (d *Daemon) CheckActiveContainerCount(c *testing.T) (interface{}, string) {
+func (d *Daemon) CheckActiveContainerCount(t *testing.T) (interface{}, string) {
+	t.Helper()
 	out, err := d.Cmd("ps", "-q")
-	assert.NilError(c, err)
+	assert.NilError(t, err)
 	if len(strings.TrimSpace(out)) == 0 {
 		return 0, ""
 	}

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -148,9 +148,8 @@ func New(t testing.TB, ops ...Option) *Daemon {
 
 	assert.Check(t, dest != "", "Please set the DOCKER_INTEGRATION_DAEMON_DEST or the DEST environment variable")
 
-	t.Logf("Creating a new daemon at: %q", dest)
 	d, err := NewDaemon(dest, ops...)
-	assert.NilError(t, err, "could not create daemon")
+	assert.NilError(t, err, "could not create daemon at %q", dest)
 
 	return d
 }


### PR DESCRIPTION
Two improvements;

### integration-cli: mark some test-helpers as helpers

Before:

    daemon.go:26: Creating a new daemon at: "/go/src/github.com/docker/docker/bundles/test-integration/TestDockerSwarmSuite/TestSwarmNetworkCreateDup"

After:

    docker_cli_swarm_test.go:1522: Creating a new daemon at: "/go/src/github.com/docker/docker/bundles/test-integration/TestDockerSwarmSuite/TestSwarmNetworkCreateDup"


### testutil: no more "Creating a new daemon at"

Instead of logging on the "happy path", add more details when
we fail to create a daemon. Now that we base the path of the
daemon on the test-name, it should still be easy to find.

Before:

    make TEST_FILTER=TestSwarmNetworkCreateIssue27866 test-integration
    ...
    === RUN   TestDockerSwarmSuite
    === RUN   TestDockerSwarmSuite/TestSwarmNetworkCreateIssue27866
    --- PASS: TestDockerSwarmSuite (7.47s)
        --- PASS: TestDockerSwarmSuite/TestSwarmNetworkCreateIssue27866 (7.47s)
            docker_cli_swarm_test.go:1499: Creating a new daemon at: "/go/src/github.com/docker/docker/bundles/test-integration/TestDockerSwarmSuite/TestSwarmNetworkCreateIssue27866"

After:

    make TEST_FILTER=TestSwarmNetworkCreateIssue27866 test-integration
    ...
    === RUN   TestDockerSwarmSuite
    === RUN   TestDockerSwarmSuite/TestSwarmNetworkCreateIssue27866
    --- PASS: TestDockerSwarmSuite (8.67s)
        --- PASS: TestDockerSwarmSuite/TestSwarmNetworkCreateIssue27866 (8.67s)
