### PR TITLE
Dockerfile: move yamllint to its own stage, and update to 1.23.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,6 +167,7 @@ FROM dev-base AS yamllint
 RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-dev-aptcache,target=/var/cache/apt \
         apt-get update && apt-get install -y --no-install-recommends \
+            zlib1g-dev \
             python3-dev \
             python3-pip \
             python3-setuptools \

--- a/Dockerfile
+++ b/Dockerfile
@@ -163,6 +163,22 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,src=hack/dockerfile/install,target=/tmp/install \
         PREFIX=/build /tmp/install/install.sh vndr
 
+FROM dev-base AS yamllint
+RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
+    --mount=type=cache,sharing=locked,id=moby-dev-aptcache,target=/var/cache/apt \
+        apt-get update && apt-get install -y --no-install-recommends \
+            python3-dev \
+            python3-pip \
+            python3-setuptools \
+            python3-wheel
+
+ARG YAMLLINT_VERSION=1.16.0
+RUN --mount=type=cache,sharing=locked,id=moby-dev-piplocal,target=/root/.local \
+    --mount=type=cache,sharing=locked,id=moby-dev-pipcache,target=/root/.cache \
+        pip3 install --user pyinstaller yamllint==${YAMLLINT_VERSION} \
+        && /root/.local/bin/pyinstaller --onefile --distpath=/build /root/.local/bin/yamllint \
+        && /build/yamllint --version
+
 FROM dev-base AS containerd
 ARG DEBIAN_FRONTEND
 RUN --mount=type=cache,sharing=locked,id=moby-containerd-aptlib,target=/var/lib/apt \
@@ -273,9 +289,6 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             libprotobuf-c1 \
             net-tools \
             pigz \
-            python3-pip \
-            python3-setuptools \
-            python3-wheel \
             sudo \
             thin-provisioning-tools \
             uidmap \
@@ -292,12 +305,11 @@ RUN update-alternatives --set iptables  /usr/sbin/iptables-legacy  || true \
  && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true \
  && update-alternatives --set arptables /usr/sbin/arptables-legacy || true
 
-RUN pip3 install yamllint==1.16.0
-
 COPY --from=dockercli     /build/ /usr/local/cli
 COPY --from=frozen-images /build/ /docker-frozen-images
 COPY --from=swagger       /build/ /usr/local/bin/
 COPY --from=tomlv         /build/ /usr/local/bin/
+COPY --from=yamllint      /build/ /usr/local/bin/
 COPY --from=tini          /build/ /usr/local/bin/
 COPY --from=registry      /build/ /usr/local/bin/
 COPY --from=criu          /build/ /usr/local/

--- a/Dockerfile
+++ b/Dockerfile
@@ -172,7 +172,7 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             python3-setuptools \
             python3-wheel
 
-ARG YAMLLINT_VERSION=1.16.0
+ARG YAMLLINT_VERSION=1.23.0
 RUN --mount=type=cache,sharing=locked,id=moby-dev-piplocal,target=/root/.local \
     --mount=type=cache,sharing=locked,id=moby-dev-pipcache,target=/root/.cache \
         pip3 install --user pyinstaller yamllint==${YAMLLINT_VERSION} \


### PR DESCRIPTION
Keeps the final stage a bit cleaner again
