### PR TITLE
Add GoDoc to fix linting validation

### DIFF
--- a/api/types/filters/parse.go
+++ b/api/types/filters/parse.go
@@ -36,6 +36,7 @@ func NewArgs(initialArgs ...KeyValuePair) Args {
 	return args
 }
 
+// Keys returns all the keys in list of Args
 func (args Args) Keys() []string {
 	keys := make([]string, 0, len(args.fields))
 	for k := range args.fields {

--- a/daemon/config/builder.go
+++ b/daemon/config/builder.go
@@ -16,8 +16,10 @@ type BuilderGCRule struct {
 	KeepStorage string          `json:",omitempty"`
 }
 
+// BuilderGCFilter contains garbage-collection filter rules for a BuildKit builder
 type BuilderGCFilter filters.Args
 
+// MarshalJSON returns a JSON byte representation of the BuilderGCFilter
 func (x *BuilderGCFilter) MarshalJSON() ([]byte, error) {
 	f := filters.Args(*x)
 	keys := f.Keys()
@@ -32,6 +34,7 @@ func (x *BuilderGCFilter) MarshalJSON() ([]byte, error) {
 	return json.Marshal(arr)
 }
 
+// UnmarshalJSON fills the BuilderGCFilter values structure from JSON input
 func (x *BuilderGCFilter) UnmarshalJSON(data []byte) error {
 	var arr []string
 	f := filters.NewArgs()


### PR DESCRIPTION
The validate step in CI was broken, due to a combination of 086b4541cf9d27d9c2654f316a6f69b0d9caedd9 (https://github.com/moby/moby/pull/39964), fbdd437d295595e88466b33a550a8707b9ebb709 and 85733620ebea3da75abe7d732043354aa0883f8a (https://github.com/moby/moby/pull/39979) being merged to master.

```
api/types/filters/parse.go:39:1: exported method `Args.Keys` should have comment or be unexported (golint)
func (args Args) Keys() []string {
^
daemon/config/builder.go:19:6: exported type `BuilderGCFilter` should have comment or be unexported (golint)
type BuilderGCFilter filters.Args
     ^
daemon/config/builder.go:21:1: exported method `BuilderGCFilter.MarshalJSON` should have comment or be unexported (golint)
func (x *BuilderGCFilter) MarshalJSON() ([]byte, error) {
^
daemon/config/builder.go:35:1: exported method `BuilderGCFilter.UnmarshalJSON` should have comment or be unexported (golint)
func (x *BuilderGCFilter) UnmarshalJSON(data []byte) error {
^
```

