### PR TITLE
Improve rootless Docker overlay support detection

### DIFF
--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -229,7 +229,7 @@ func supportsOverlay() error {
 		defer os.RemoveAll(merged)
 	}
 
-	if mkdirSucc == false {
+	if !mkdirSucc {
 		logrus.WithError(err).WithField("storage-driver", "overlay").Error("could not create temporary directory, so assuming that 'overlay' is not supported")
 		return graphdriver.ErrNotSupported
 	}

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -3,7 +3,6 @@
 package overlay // import "github.com/docker/docker/daemon/graphdriver/overlay"
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -201,29 +200,27 @@ func parseOptions(options []string) (*overlayOptions, error) {
 
 func supportsOverlay() error {
 	// Access overlay filesystem so that Linux loads it (if possible).
-	mountTarget, err := ioutil.TempDir("", "supportsOverlay")
+	lower, err := ioutil.TempDir("", "overlayLower")
+	upper, err := ioutil.TempDir("", "overlayUpper")
+	work, err := ioutil.TempDir("", "overlayWork")
+	merged, err := ioutil.TempDir("", "overlayMerged")
 	if err != nil {
-		logrus.WithError(err).WithField("storage-driver", "overlay2").Error("could not create temporary directory, so assuming that 'overlay' is not supported")
+		logrus.WithError(err).WithField("storage-driver", "overlay").Error("could not create temporary directory, so assuming that 'overlay' is not supported")
 		return graphdriver.ErrNotSupported
 	}
-	/* The mounting will fail--after the module has been loaded.*/
-	defer os.RemoveAll(mountTarget)
-	unix.Mount("overlay", mountTarget, "overlay", 0, "")
 
-	f, err := os.Open("/proc/filesystems")
-	if err != nil {
-		return err
+	defer os.RemoveAll(lower)
+	defer os.RemoveAll(upper)
+	defer os.RemoveAll(work)
+	defer os.RemoveAll(merged)
+	// Attempt to perform an overlay mount to determine whether the current user (and system) can support it
+	if err := unix.Mount("overlay", merged, "overlay", 0, fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work)); err != nil {
+		logrus.WithField("storage-driver", "overlay").Error("'overlay' not supported on this host.")
+		return graphdriver.ErrNotSupported
 	}
-	defer f.Close()
 
-	s := bufio.NewScanner(f)
-	for s.Scan() {
-		if s.Text() == "nodev\toverlay" {
-			return nil
-		}
-	}
-	logrus.WithField("storage-driver", "overlay").Error("'overlay' not found as a supported filesystem on this host. Please ensure kernel is new enough and has overlay support loaded.")
-	return graphdriver.ErrNotSupported
+	defer unix.Unmount(merged, 0)
+	return nil
 }
 
 func (d *Driver) String() string {

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -304,7 +304,7 @@ func supportsOverlay() error {
 		defer os.RemoveAll(merged)
 	}
 
-	if mkdirSucc == false {
+	if !mkdirSucc {
 		logrus.WithError(err).WithField("storage-driver", "overlay2").Error("could not create temporary directory, so assuming that 'overlay2' is not supported")
 		return graphdriver.ErrNotSupported
 	}


### PR DESCRIPTION
Signed-off-by: Brian Turek <brian.turek@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed overlay support detection for rootless Docker on CentOS (and other non-Ubuntu based distros).  The current implementation causes runtime errors when running rootless Docker on CentOS due lack of mounting permissions.  See docker/for-linux#836 and docker-library/docker#193 for related tickets

**- How I did it**
Current overlay detection works by merely checking for filesystem support for overlay rather than overlay support for that particular user (i.e. Ubuntu allows non-root users to use overlay, CentOS does not).  This patch changes the logic to attempt a real overlay mount and determine overlay support by checking whether than mount was successful.

Note that this is literally the first time I've written Go so constructive criticism is appreciated.

**- How to verify it**

- Run the new dockerd binary as rootless on CentOS, the storage-driver falls back to `vfs`
- Run the new dockerd binary as root on CentOS, the storage-driver is `overlay2`
- Run the new dockerd binary as rootless on Ubuntu, the storage-driver is `overlay2`
- Run the new dockerd binary as root on Ubuntu, the storage-driver is `overlay2`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Improve rootless Docker overlay support detection

**- A picture of a cute animal (not mandatory but encouraged)**

