### PR TITLE
Revert "homedir: add cgo or osusergo buildtag constraints for unix"

### DIFF
--- a/pkg/homedir/homedir_unix.go
+++ b/pkg/homedir/homedir_unix.go
@@ -16,8 +16,11 @@ func Key() string {
 // Get returns the home directory of the current user with the help of
 // environment variables depending on the target operating system.
 // Returned path should be used with "path/filepath" to form new paths.
-// If compiling statically, ensure the osusergo build tag is used.
-// If needing to do nss lookups, do not compile statically.
+//
+// If linking statically with cgo enabled against glibc, ensure the
+// osusergo build tag is used.
+//
+// If needing to do nss lookups, do not disable cgo or set osusergo.
 func Get() string {
 	home := os.Getenv(Key())
 	if home == "" {

--- a/pkg/homedir/homedir_unix.go
+++ b/pkg/homedir/homedir_unix.go
@@ -1,4 +1,4 @@
-// +build !windows,cgo !windows,osusergo
+// +build !windows
 
 package homedir // import "github.com/docker/docker/pkg/homedir"
 


### PR DESCRIPTION
This reverts #39994 and slightly clarifies doc update of homedir.Get() added by #39975 

### Revert "homedir: add cgo or osusergo buildtag constraints for unix"

TL;DR: there is no way to do this right.

We do know that in some combination of build tags set (or unset),
linker flags, environment variables, and libc implementation, this package
won't work right. In fact, there is one specific combination:

1. `CGO_ENABLED=1` (or unset)
2. static binary is being built (e.g. `go build` is run with `-extldflags -static`)
3. `go build` links the binary against glibc
4. `osusergo` is not set

This particular combination results in the following legitimate linker warning:

> cgo_lookup_unix.go: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking

If this warning is ignored and the resulting binary is used on a system
with files from a different glibc version (or without those files), it
could result in a segfault.

The commit being reverted tried to guard against such possibility,
but the problem is, we can only use build tags to account for items
1 and 4 from the above list, while items 2 and 3 do not result in
any build tags being set or unset, making this guard excessive.

Remove it.

This reverts commit 023b072288eab3c9e768d4aeeb917f27f06034c7.

### pkg/homedir: clarify Get() docs wrt static linking

This clarifies comments about static linking made in commit a8608b5b67c.
    
* There are two ways to create a static binary, one is to disable
cgo, the other is to set linker flags. When cgo is disabled,
there is no need to use osusergo build tag.
    
* osusergo only needs to be set when linking against glibc.


@tiborvass @thaJeztah @cpuguy83 PTAL