### PR TITLE
refactored integration/service/instead_test.go to ues unique resource…

### DIFF
--- a/integration/service/inspect_test.go
+++ b/integration/service/inspect_test.go
@@ -27,7 +27,7 @@ func TestInspect(t *testing.T) {
 
 	var now = time.Now()
 	var instances uint64 = 2
-	serviceSpec := fullSwarmServiceSpec("test-service-inspect", instances)
+	serviceSpec := fullSwarmServiceSpec("test-service-inspect"+t.Name(), instances)
 
 	ctx := context.Background()
 	resp, err := client.ServiceCreate(ctx, serviceSpec, types.ServiceCreateOptions{


### PR DESCRIPTION
What I did
changed integration/service/inspect_test.go to use unique names.
Part of #36583

How I did it
Added t.Name() to resources names.

How to verify it

Description for the changelog
Modified integration/service/inspect_test.go to use unique names.

A picture of a cute animal (not mandatory but encouraged)
