### PR TITLE
registry: add a critical section to protect authTransport.modReq

### DIFF
--- a/registry/session.go
+++ b/registry/session.go
@@ -133,7 +133,9 @@ func (tr *authTransport) RoundTrip(orig *http.Request) (*http.Response, error) {
 	}
 	resp, err := tr.RoundTripper.RoundTrip(req)
 	if err != nil {
+		tr.mu.Lock()
 		delete(tr.modReq, orig)
+		tr.mu.Unlock()
 		return nil, err
 	}
 	if len(resp.Header["X-Docker-Token"]) > 0 {


### PR DESCRIPTION
closes #39502

**- What I did**
I made sure that there would be no data race of `tr.modReq`. `tr.modReq` is a map. Among 5 usages of this field, 4 of them are protected by critical sections, but 1 delete operation is not protected. This is dangerous, because data race of map will crash all running goroutines.

**- How I did it**
Added `tr.mu.Lock()` and `tr.mu.Unlock()` to protect `delete(tr.modReq,orig)`.

**- How to verify it**
All other 4 usages of `tr.modReq` are protected by `tr.mu.Lock()`.

**- Description for the changelog**
NONE

