### PR TITLE
integration/internal/container: fix a goroutine leak bug 

### DIFF
--- a/integration/internal/container/exec.go
+++ b/integration/internal/container/exec.go
@@ -57,7 +57,7 @@ func Exec(ctx context.Context, cli client.APIClient, id string, cmd []string) (E
 
 	// read the output
 	var outBuf, errBuf bytes.Buffer
-	outputDone := make(chan error)
+	outputDone := make(chan error, 1)
 
 	go func() {
 		// StdCopy demultiplexes the stream into two buffers


### PR DESCRIPTION
**- What I did**
Avoid a goroutine leak bug by changing an unbuffered channel into a channel with 1 buffer.
In the code below, if `select` chooses `case <-ctx.Done()`, then the child goroutine will be blocked at `outputDone <- err` and leaked. 
https://github.com/moby/moby/blob/a09e6e323e55e1a9b21df9c2c555f5668df3ac9b/integration/internal/container/exec.go#L60-L77

**- How to verify it**
The change in this patch is very safe: the `case err := <-outputDone` in the parent goroutine will still be blocked until `outputDone <- err` is executed, but `outputDone <- err` will never be blocked.
This fix is similar to https://github.com/kubernetes/kubernetes/pull/5316

**- Description for the changelog**
NONE

