### PR TITLE
libcontainerd: move hcsshim import to windows-only file

### DIFF
--- a/libcontainerd/remote/client_linux.go
+++ b/libcontainerd/remote/client_linux.go
@@ -94,6 +94,10 @@ func WithBundle(bundleDir string, ociSpec *specs.Spec) containerd.NewContainerOp
 	}
 }
 
+func withLogLevel(_ logrus.Level) containerd.NewTaskOpts {
+	panic("Not implemented")
+}
+
 func newFIFOSet(bundleDir, processID string, withStdin, withTerminal bool) *cio.FIFOSet {
 	config := cio.Config{
 		Terminal: withTerminal,

--- a/libcontainerd/remote/client_windows.go
+++ b/libcontainerd/remote/client_windows.go
@@ -10,10 +10,10 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"
-
 	libcontainerdtypes "github.com/docker/docker/libcontainerd/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 const runtimeName = "io.containerd.runhcs.v1"
@@ -46,6 +46,16 @@ func WithBundle(bundleDir string, ociSpec *specs.Spec) containerd.NewContainerOp
 		}
 		c.Labels[DockerContainerBundlePath] = bundleDir
 		return os.MkdirAll(bundleDir, 0755)
+	}
+}
+
+func withLogLevel(level logrus.Level) containerd.NewTaskOpts {
+	// Make sure we set the runhcs options to debug if we are at debug level.
+	return func(_ context.Context, _ *containerd.Client, info *containerd.TaskInfo) error {
+		if level == logrus.DebugLevel {
+			info.Options = &options.Options{Debug: true}
+		}
+		return nil
 	}
 }
 


### PR DESCRIPTION
This reduces the dependency-graph when building packages for
Linux only.

fixes https://github.com/moby/moby/issues/40067 "Please move the github.com/Microsoft/hcsshim import to some windows specific file"


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

