### PR TITLE
Remove string-matching deadline errors

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -161,12 +161,7 @@ func (cli *Client) doRequest(req *http.Request) (*http.Response, error) {
 
 	// Don't decorate context sentinel errors; users may be comparing to
 	// them directly.
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return nil, err
-	}
-
-	type timeoutError interface{ Timeout() bool }
-	if e, ok := err.(timeoutError); ok && e.Timeout() {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) {
 		return nil, err
 	}
 

--- a/client/request.go
+++ b/client/request.go
@@ -165,6 +165,11 @@ func (cli *Client) doRequest(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
+	type timeoutError interface{ Timeout() bool }
+	if e, ok := err.(timeoutError); ok && e.Timeout() {
+		return nil, err
+	}
+
 	if errors.Is(err, os.ErrPermission) {
 		// Don't include request errors (Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/version"),
 		// which are irrelevant if we weren't able to connect.

--- a/daemon/cluster/controllers/plugin/controller_test.go
+++ b/daemon/cluster/controllers/plugin/controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -172,12 +173,10 @@ func TestWaitDisabled(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	type timeoutError interface{ Timeout() bool }
-
 	select {
 	case <-chEvent:
 		<-ctxWaitReady.Done()
-		if err, ok := ctxWaitReady.Err().(timeoutError); ok && err.Timeout() {
+		if err := ctxWaitReady.Err(); os.IsTimeout(err) {
 			t.Fatal(err)
 		}
 		select {
@@ -255,12 +254,10 @@ func TestWaitEnabled(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	type timeoutError interface{ Timeout() bool }
-
 	select {
 	case <-chEvent:
 		<-ctxWaitReady.Done()
-		if err, ok := ctxWaitReady.Err().(timeoutError); ok && err.Timeout() {
+		if err := ctxWaitReady.Err(); os.IsTimeout(err) {
 			t.Fatal(err)
 		}
 		select {

--- a/daemon/cluster/controllers/plugin/controller_test.go
+++ b/daemon/cluster/controllers/plugin/controller_test.go
@@ -172,10 +172,12 @@ func TestWaitDisabled(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	type timeoutError interface{ Timeout() bool }
+
 	select {
 	case <-chEvent:
 		<-ctxWaitReady.Done()
-		if err := ctxWaitReady.Err(); err == context.DeadlineExceeded {
+		if err, ok := ctxWaitReady.Err().(timeoutError); ok && err.Timeout() {
 			t.Fatal(err)
 		}
 		select {
@@ -253,10 +255,12 @@ func TestWaitEnabled(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	type timeoutError interface{ Timeout() bool }
+
 	select {
 	case <-chEvent:
 		<-ctxWaitReady.Done()
-		if err := ctxWaitReady.Err(); err == context.DeadlineExceeded {
+		if err, ok := ctxWaitReady.Err().(timeoutError); ok && err.Timeout() {
 			t.Fatal(err)
 		}
 		select {

--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -379,8 +379,10 @@ func (n *nodeRunner) enableReconnectWatcher() {
 	n.cancelReconnect = cancel
 
 	go func() {
+		type timeoutError interface{ Timeout() bool }
+
 		<-delayCtx.Done()
-		if delayCtx.Err() != context.DeadlineExceeded {
+		if _, ok := delayCtx.Err().(timeoutError); !ok {
 			return
 		}
 		n.mu.Lock()

--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -379,10 +380,8 @@ func (n *nodeRunner) enableReconnectWatcher() {
 	n.cancelReconnect = cancel
 
 	go func() {
-		type timeoutError interface{ Timeout() bool }
-
 		<-delayCtx.Done()
-		if _, ok := delayCtx.Err().(timeoutError); !ok {
+		if errors.Is(delayCtx.Err(), context.DeadlineExceeded) || os.IsTimeout(delayCtx.Err()) {
 			return
 		}
 		n.mu.Lock()

--- a/errdefs/helpers.go
+++ b/errdefs/helpers.go
@@ -294,16 +294,17 @@ func DataLoss(err error) error {
 
 // FromContext returns the error class from the passed in context
 func FromContext(ctx context.Context) error {
-	e := ctx.Err()
-	if e == nil {
+	err := ctx.Err()
+	if err == nil {
 		return nil
 	}
 
-	if e == context.Canceled {
-		return Cancelled(e)
+	if err == context.Canceled {
+		return Cancelled(err)
 	}
-	if e == context.DeadlineExceeded {
-		return Deadline(e)
+	type timeoutError interface{ Timeout() bool }
+	if e, ok := err.(timeoutError); ok && e.Timeout() {
+		return Deadline(err)
 	}
-	return Unknown(e)
+	return Unknown(err)
 }

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -27,6 +27,7 @@ import (
 	testdaemon "github.com/moby/moby/v2/internal/testutil/daemon"
 	"github.com/moby/moby/v2/internal/testutil/request"
 	"github.com/moby/swarmkit/v2/ca"
+	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/poll"
@@ -311,9 +312,14 @@ func (s *DockerSwarmSuite) TestAPISwarmLeaderElection(c *testing.T) {
 			// clear these out before each run
 			leader = nil
 			followers = nil
+			type timeoutError interface{ Timeout() bool }
 			for _, d := range nodes {
 				n := d.GetNode(ctx, t, d.NodeID(), func(err error) bool {
-					if strings.Contains(err.Error(), context.DeadlineExceeded.Error()) || strings.Contains(err.Error(), "swarm does not have a leader") {
+					if e, ok := errors.Cause(err).(timeoutError); ok && e.Timeout() {
+						lastErr = err
+						return true
+					}
+					if strings.Contains(err.Error(), "swarm does not have a leader") {
 						lastErr = err
 						return true
 					}

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -312,10 +312,9 @@ func (s *DockerSwarmSuite) TestAPISwarmLeaderElection(c *testing.T) {
 			// clear these out before each run
 			leader = nil
 			followers = nil
-			type timeoutError interface{ Timeout() bool }
 			for _, d := range nodes {
 				n := d.GetNode(ctx, t, d.NodeID(), func(err error) bool {
-					if e, ok := errors.Cause(err).(timeoutError); ok && e.Timeout() {
+					if os.IsTimeout(errors.Cause(err)) {
 						lastErr = err
 						return true
 					}

--- a/pkg/ioutils/readers_test.go
+++ b/pkg/ioutils/readers_test.go
@@ -43,10 +43,13 @@ func TestCancelReadCloser(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	crc := NewCancelReadCloser(ctx, io.NopCloser(&perpetualReader{}))
+	type timeoutError interface{ Timeout() bool }
 	for {
 		var buf [128]byte
 		_, err := crc.Read(buf[:])
 		if errors.Is(err, context.DeadlineExceeded) {
+			break
+		} else if e, ok := err.(timeoutError); ok && e.Timeout() {
 			break
 		} else if err != nil {
 			t.Fatalf("got unexpected error: %v", err)

--- a/pkg/ioutils/readers_test.go
+++ b/pkg/ioutils/readers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -43,13 +44,12 @@ func TestCancelReadCloser(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	crc := NewCancelReadCloser(ctx, io.NopCloser(&perpetualReader{}))
-	type timeoutError interface{ Timeout() bool }
 	for {
 		var buf [128]byte
 		_, err := crc.Read(buf[:])
 		if errors.Is(err, context.DeadlineExceeded) {
 			break
-		} else if e, ok := err.(timeoutError); ok && e.Timeout() {
+		} else if os.IsTimeout(err) {
 			break
 		} else if err != nil {
 			t.Fatalf("got unexpected error: %v", err)


### PR DESCRIPTION

I noticed we were doing this in a couple of places, and recalled I changed this for one test in https://github.com/moby/moby/pull/39168

Thought it couldn't hurt to take that approach in other places as well