### PR TITLE
hack/validate/vendor: print diff for modified files

### DIFF
--- a/hack/validate/vendor
+++ b/hack/validate/vendor
@@ -13,6 +13,7 @@ validate_vendor_diff(){
 		vndr
 		# check if any files have changed
 		diffs="$(git status --porcelain -- vendor 2>/dev/null)"
+		mfiles="$(echo "$diffs" | awk '/^ M / {print $2}')"
 		if [ "$diffs" ]; then
 			{
 				echo 'The result of vndr differs'
@@ -21,6 +22,9 @@ validate_vendor_diff(){
 				echo
 				echo 'Please vendor your package with github.com/LK4D4/vndr.'
 				echo
+				if [ -n "$mfiles" ] ; then
+					git diff -- "$mfiles"
+				fi
 			} >&2
 			false
 		else

--- a/hack/validate/vendor
+++ b/hack/validate/vendor
@@ -38,10 +38,9 @@ validate_vendor_diff(){
 # 1. make sure all the vendored packages are used
 # 2. make sure all the packages contain license information (just warning, because it can cause false-positive)
 validate_vendor_used() {
-	pkgs=$(mawk '/^[a-zA-Z0-9]/ { print $1 }' < vendor.conf)
-	for f in $pkgs; do
-	if ls -d "vendor/$f"  > /dev/null 2>&1; then
-		found=$(find "vendor/$f" -iregex '.*LICENSE.*' -or -iregex '.*COPYRIGHT.*' -or -iregex '.*COPYING.*' | wc -l)
+	for f in $(mawk '/^[a-zA-Z0-9]/ { print $1 }' vendor.conf); do
+	if [ -d "vendor/$f" ]; then
+		found=$(echo "vendor/$f/"* | grep -iEc '/(LICENSE|COPYING)')
 		if [ "$found" -eq 0 ]; then
 		echo "WARNING: could not find copyright information for $f"
 		fi

--- a/hack/validate/vendor
+++ b/hack/validate/vendor
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${SCRIPTDIR}/.validate"
 
 validate_vendor_diff(){
@@ -40,9 +40,9 @@ validate_vendor_diff(){
 validate_vendor_used() {
 	pkgs=$(mawk '/^[a-zA-Z0-9]/ { print $1 }' < vendor.conf)
 	for f in $pkgs; do
-	if ls -d vendor/$f  > /dev/null 2>&1; then
-		found=$(find vendor/$f -iregex '.*LICENSE.*' -or -iregex '.*COPYRIGHT.*' -or -iregex '.*COPYING.*' | wc -l)
-		if [ $found -eq 0 ]; then
+	if ls -d "vendor/$f"  > /dev/null 2>&1; then
+		found=$(find "vendor/$f" -iregex '.*LICENSE.*' -or -iregex '.*COPYRIGHT.*' -or -iregex '.*COPYING.*' | wc -l)
+		if [ "$found" -eq 0 ]; then
 		echo "WARNING: could not find copyright information for $f"
 		fi
 	else


### PR DESCRIPTION
In case some files were modified (rather than merely added
or removed), we're curious to see the diff for those.

Idea-by: @thaJeztah 

While at it,
* fix some shellcheck warnings;
* optimize/simplify `validate_vendor_used`.