### PR TITLE
Integration: skip TestInfoDebug on Windows

### DIFF
--- a/integration/system/info_test.go
+++ b/integration/system/info_test.go
@@ -70,6 +70,7 @@ func TestInfoAPIWarnings(t *testing.T) {
 
 func TestInfoDebug(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME: test starts daemon with -H unix://.....")
 
 	d := daemon.New(t)
 	d.Start(t, "--debug")


### PR DESCRIPTION
The test starts a new daemon, but attempts to run it with overlay2,
and using a unix:// socket, which doesn't really work on Windows.

```
00:14:14.623  --- FAIL: TestInfoDebug (0.01s)
00:14:14.623      info_test.go:75: [dbe75bf7729f3] failed to start daemon with arguments [--containerd /var/run/docker/containerd/containerd.sock --data-root D:\gopath\src\github.com\docker\docker\bundles\tmp\TestInfoDebug\dbe75bf7729f3\root --exec-root C:\windows\TEMP\dxr\dbe75bf7729f3 --pidfile D:\gopath\src\github.com\docker\docker\bundles\tmp\TestInfoDebug\dbe75bf7729f3\docker.pid --userland-proxy=true --containerd-namespace dbe75bf7729f3 --containerd-plugins-namespace dbe75bf7729f3p --host unix://C:\windows\TEMP\docker-integration\dbe75bf7729f3.sock --storage-driver overlay2 --debug] : protocol not available
00:14:14.623  === RUN   TestInfoInsecureRegistries
00:14:14.623  --- FAIL: TestInfoInsecureRegistries (0.00s)
00:14:14.623      info_test.go:100: [d3c745c16a39c] failed to start daemon with arguments [--containerd /var/run/docker/containerd/containerd.sock --data-root D:\gopath\src\github.com\docker\docker\bundles\tmp\TestInfoInsecureRegistries\d3c745c16a39c\root --exec-root C:\windows\TEMP\dxr\d3c745c16a39c --pidfile D:\gopath\src\github.com\docker\docker\bundles\tmp\TestInfoInsecureRegistries\d3c745c16a39c\docker.pid --userland-proxy=true --containerd-namespace d3c745c16a39c --containerd-plugins-namespace d3c745c16a39cp --host unix://C:\windows\TEMP\docker-integration\d3c745c16a39c.sock --debug --storage-driver overlay2 --insecure-registry=192.168.1.0/24 --insecure-registry=insecurehost.com:5000] : protocol not available
00:14:14.623  === RUN   TestInfoRegistryMirrors
00:14:14.623  --- FAIL: TestInfoRegistryMirrors (0.01s)
00:14:14.623      info_test.go:124: [d277126ad0515] failed to start daemon with arguments [--containerd /var/run/docker/containerd/containerd.sock --data-root D:\gopath\src\github.com\docker\docker\bundles\tmp\TestInfoRegistryMirrors\d277126ad0515\root --exec-root C:\windows\TEMP\dxr\d277126ad0515 --pidfile D:\gopath\src\github.com\docker\docker\bundles\tmp\TestInfoRegistryMirrors\d277126ad0515\docker.pid --userland-proxy=true --containerd-namespace d277126ad0515 --containerd-plugins-namespace d277126ad0515p --host unix://C:\windows\TEMP\docker-integration\d277126ad0515.sock --debug --storage-driver overlay2 --registry-mirror=https://192.168.1.2 --registry-mirror=http://registry.mirror.com:5000] : protocol not available
```

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

