### PR TITLE
awslogs & archive: prevent 2 goroutine leaks in test functions

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -345,7 +345,7 @@ func TestLogNonBlockingBufferFull(t *testing.T) {
 		logNonBlocking: true,
 	}
 	stream.messages <- &logger.Message{}
-	errorCh := make(chan error)
+	errorCh := make(chan error, 1)
 	started := make(chan bool)
 	go func() {
 		started <- true

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -217,7 +217,7 @@ func TestCmdStreamLargeStderr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to start command: %s", err)
 	}
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() {
 		_, err := io.Copy(ioutil.Discard, out)
 		errCh <- err


### PR DESCRIPTION
**- What I did**
Prevent 2 goroutines from being leaked in test functions.
Normally I wouldn't fix 2 bugs in 2 packages together, but these 2 bugs are almost the same and the fix is harmless, so I just submit 1 PR to fix them both.

**- How I did it**
Add 1 buffer to the channel. In this way, the receive operation in main test goroutine will still be blocked until send, but the send operation in child goroutine will not be blocked. 
Note that t.Fatal() won't stop the blocking of the child goroutine: ["Calling FailNow does not stop those other goroutines." ](https://golang.org/pkg/testing/#T.FailNow)

**- How to verify it**
I learnt the pattern of this kind of bugs from https://github.com/kubernetes/kubernetes/pull/5316

**- Description for the changelog**
NONE

