### PR TITLE
Rename DCO check param in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         booleanParam(name: 'ppc64le', defaultValue: true, description: 'PowerPC (ppc64le) Build/Test')
         booleanParam(name: 'windowsRS1', defaultValue: false, description: 'Windows 2016 (RS1) Build/Test')
         booleanParam(name: 'windowsRS5', defaultValue: true, description: 'Windows 2019 (RS5) Build/Test')
-        booleanParam(name: 'skip_dco', defaultValue: false, description: 'Skip the DCO check')
+        booleanParam(name: 'dco', defaultValue: true, description: 'Run the DCO check')
     }
     environment {
         DOCKER_BUILDKIT     = '1'
@@ -41,7 +41,7 @@ pipeline {
         stage('DCO-check') {
             when {
                 beforeAgent true
-                expression { !params.skip_dco }
+                expression { params.dco }
             }
             agent { label 'amd64 && ubuntu-1804 && overlay2' }
             steps {
@@ -266,7 +266,7 @@ pipeline {
                                 sh '''
                                 # todo: include ip_vs in base image
                                 sudo modprobe ip_vs
-                
+
                                 docker build --force-rm --build-arg APT_MIRROR -t docker:${GIT_COMMIT} .
                                 '''
                             }
@@ -276,7 +276,7 @@ pipeline {
                                 sh '''#!/bin/bash
                                 # bash is needed so 'jobs -p' works properly
                                 # it also accepts setting inline envvars for functions without explicitly exporting
- 
+
                                 run_tests() {
                                         [ -n "$TESTDEBUG" ] && rm= || rm=--rm;
                                         docker run $rm -t --privileged \


### PR DESCRIPTION
Previously it was a negative parameter for skiping the DCO check, but
this is different from other checks. It was requested that I change this
in #40023 by @thaJeztah but I'm factoring it out into a new PR to reduce the diff size since this is an unrelated change.

**EDIT:** left off the DCO to check that this works (and it does). Definitely not just because I forgot it as usual.