### PR TITLE
Add support of setting hugepage limit on container cgroup sandbox

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -210,6 +210,23 @@ definitions:
       PathInContainer: "/dev/deviceName"
       CgroupPermissions: "mrw"
 
+  HugepageLimit:
+    type: "object"
+    description: |
+      HugepageLimit corresponds to the file`hugetlb.<hugepagesize>.limit_in_byte` in container level cgroup.
+      For example, `PageSize=1GB`, `Limit=1073741824` means setting `1073741824` bytes to hugetlb.1GB.limit_in_bytes.
+    properties:
+      PageSize:
+        type: "string"
+        example: "1GB"
+      Limit:
+        type: "integer"
+        format: "uint64"
+        example: 1073741824
+    example:
+      PageSize: "1GB"
+      Limit: 1073741824
+
   DeviceRequest:
     type: "object"
     description: "A request for devices to be sent to device drivers"
@@ -519,6 +536,11 @@ definitions:
             Hard:
               description: "Hard limit"
               type: "integer"
+      HugepageLimits:
+        description: "List of hugepage limits to limit the HugeTLB usage of container per page size"
+        type: "array"
+        items:
+          $ref: "#/definitions/HugepageLimit"
       # Applicable to Windows
       CpuCount:
         description: |
@@ -4725,6 +4747,7 @@ paths:
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0
+                HugepageLimits: []
                 KernelMemory: 0
                 NanoCPUs: 500000
                 CpuPercent: 80

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -213,7 +213,7 @@ definitions:
   HugepageLimit:
     type: "object"
     description: |
-      HugepageLimit corresponds to the file`hugetlb.<hugepagesize>.limit_in_byte` in container level cgroup.
+      HugepageLimit corresponds to the file`hugetlb.<hugepagesize>.limit_in_bytes` in container level cgroup.
       For example, `PageSize=1GB`, `Limit=1073741824` means setting `1073741824` bytes to hugetlb.1GB.limit_in_bytes.
     properties:
       PageSize:

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -292,7 +292,7 @@ type HugepageLimit struct {
 	// The values of <unit-prefix> are intended to be parsed using base 1024("1KB" = 1024, "1MB" = 1048576, etc).
 	PageSize string
 	// limit in bytes of hugepagesize HugeTLB usage.
-	Limit uint64
+	Limit int64
 }
 
 // RestartPolicy represents the restart policies of the container.

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -284,6 +284,17 @@ type DeviceMapping struct {
 	CgroupPermissions string
 }
 
+// HugepageLimit corresponds to the file`hugetlb.<hugepagesize>.limit_in_byte` in container level cgroup.
+// For example, `PageSize=1GB`, `Limit=1073741824` means setting `1073741824` bytes to hugetlb.1GB.limit_in_bytes.
+type HugepageLimit struct {
+	// The value of PageSize has the format <size><unit-prefix>B (2MB, 1GB),
+	// and must match the <hugepagesize> of the corresponding control file found in `hugetlb.<hugepagesize>.limit_in_bytes`.
+	// The values of <unit-prefix> are intended to be parsed using base 1024("1KB" = 1024, "1MB" = 1048576, etc).
+	PageSize string
+	// limit in bytes of hugepagesize HugeTLB usage.
+	Limit uint64
+}
+
 // RestartPolicy represents the restart policies of the container.
 type RestartPolicy struct {
 	Name              string
@@ -369,6 +380,7 @@ type Resources struct {
 	OomKillDisable       *bool           // Whether to disable OOM Killer or not
 	PidsLimit            *int64          // Setting PIDs limit for a container; Set `0` or `-1` for unlimited, or `null` to not change.
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
+	HugepageLimits       []HugepageLimit // List of hugepage limits to limit the HugeTLB usage of container per page size
 
 	// Applicable to Windows
 	CPUCount           int64  `json:"CpuCount"`   // CPU count

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -284,7 +284,7 @@ type DeviceMapping struct {
 	CgroupPermissions string
 }
 
-// HugepageLimit corresponds to the file`hugetlb.<hugepagesize>.limit_in_byte` in container level cgroup.
+// HugepageLimit corresponds to the file`hugetlb.<hugepagesize>.limit_in_bytes` in container level cgroup.
 // For example, `PageSize=1GB`, `Limit=1073741824` means setting `1073741824` bytes to hugetlb.1GB.limit_in_bytes.
 type HugepageLimit struct {
 	// The value of PageSize has the format <size><unit-prefix>B (2MB, 1GB),

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -579,10 +579,9 @@ func verifyPlatformContainerResources(resources *containertypes.Resources, sysIn
 			validHugepageLimits := []containertypes.HugepageLimit{}
 			for _, hpl := range resources.HugepageLimits {
 				if _, exist := sysInfo.HugetlbLimits[hpl.PageSize]; !exist {
-					warnings = append(warnings, "Your kernel does not has %v hugepage.", hpl.PageSize)
-				} else {
-					validHugepageLimits = append(validHugepageLimits, hpl)
+					return warnings, fmt.Errorf("Your kernel does not have %s hugepage", hpl.PageSize)
 				}
+				validHugepageLimits = append(validHugepageLimits, hpl)
 			}
 			resources.HugepageLimits = validHugepageLimits
 		}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -258,6 +258,19 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 	return err
 }
 
+func getHugepageResources(config containertypes.Resources) []specs.LinuxHugepageLimit {
+	var hugepages []specs.LinuxHugepageLimit
+
+	for _, hugepage := range config.HugepageLimits {
+		hugepages = append(hugepages, specs.LinuxHugepageLimit{
+			Pagesize: hugepage.PageSize,
+			Limit:    hugepage.Limit,
+		})
+	}
+
+	return hugepages
+}
+
 func getBlkioThrottleDevices(devs []*blkiodev.ThrottleDevice) ([]specs.LinuxThrottleDevice, error) {
 	var throttleDevices []specs.LinuxThrottleDevice
 	var stat unix.Stat_t

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -875,14 +875,16 @@ func WithResources(c *container.Container) coci.SpecOpts {
 
 		memoryRes := getMemoryResources(r)
 		cpuRes, err := getCPUResources(r)
+		hugepageRes := getHugepageResources(r)
 		if err != nil {
 			return err
 		}
 		blkioWeight := r.BlkioWeight
 
 		specResources := &specs.LinuxResources{
-			Memory: memoryRes,
-			CPU:    cpuRes,
+			Memory:         memoryRes,
+			CPU:            cpuRes,
+			HugepageLimits: hugepageRes,
 			BlockIO: &specs.LinuxBlockIO{
 				Weight:                  &blkioWeight,
 				WeightDevice:            weightDevices,

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -1,6 +1,8 @@
 package sysinfo // import "github.com/docker/docker/pkg/sysinfo"
 
-import "github.com/docker/docker/pkg/parsers"
+import (
+	"github.com/docker/docker/pkg/parsers"
+)
 
 // SysInfo stores information about which features a kernel supports.
 // TODO Windows: Factor out platform specific capabilities.
@@ -11,6 +13,7 @@ type SysInfo struct {
 	Seccomp bool
 
 	cgroupMemInfo
+	cgroupHugetlbInfo
 	cgroupCPUInfo
 	cgroupBlkioInfo
 	cgroupCpusetInfo
@@ -101,6 +104,11 @@ type cgroupCpusetInfo struct {
 
 	// Available Cpuset's memory nodes
 	Mems string
+}
+
+type cgroupHugetlbInfo struct {
+	// Whether hugetlb limit is supported or not
+	HugetlbLimits map[string]bool
 }
 
 type cgroupPids struct {


### PR DESCRIPTION
Signed-off-by: Byonggon Chun <bg.chun@samsung.com>


**- What I did**
Based on Hugepages Enhancement in Kubernetes, It will support container isolation of hugepages.
[Associated KEP has been updated](https://github.com/kubernetes/enhancements/pull/1199), and [CRI message will be updated](https://github.com/kubernetes/kubernetes/pull/83614) to have hugepage limit for a container(in 1.17 or 1.18 rel).

It means the individual container will have own limit for hugepages on their container level cgroup sandbox.

To support `container isolation of hugepages`, dockershim and docker should be updated.
1) Dockershim of kubelet will be updated to set hugepage limit on [Resources](https://github.com/moby/moby/blob/7cb46617fcc1071963ab59d81082eab3e3ef8f9d/api/types/container/host_config.go#L340-L378) structure of docker.
2) But there is no field for hugepage in the resource structure, so the structure should be updated.
    then we can update dockershim, it is a kind of chicken and egg issue.
3) at the last, The function([WithResources](https://github.com/moby/moby/blob/7cb46617fcc1071963ab59d81082eab3e3ef8f9d/daemon/oci_linux.go#L852-L904)) will be updated to set hugepage limit on oci runtime spec.

For the above work, This pr is opened for part 2 and part3

Followings are CRI and Resources struct update proposals.
- CRI Update Proposal(KEP Update PR Merged)
```
message LinuxContainerResources {
    ...
    string cpuset_mems = 7;
    // List of HugepageLimits to limit the HugeTLB usage of container per page size. Default: nil (not specified).
    repeated HugepageLimit hugepage_limits = 8;
}
// HugepageLimit corresponds to the file`hugetlb.<hugepagesize>.limit_in_byte` in container level cgroup.
// For example, `PageSize=1GB`, `Limit=1073741824` means setting `1073741824` bytes to hugetlb.1GB.limit_in_bytes.
message HugepageLimit {
    // The value of PageSize has the format <size><unit-prefix>B (2MB, 1GB),
    // and must match the <hugepagesize> of the corresponding control file found in `hugetlb.<hugepagesize>.limit_in_bytes`.
    // The values of <unit-prefix> are intended to be parsed using base 1024("1KB" = 1024, "1MB" = 1048576, etc).
    string page_size = 1;
    // limit in bytes of hugepagesize HugeTLB usage.
    uint64 limit = 2;
}
```
- Resource Struct Update Proposal
```
// Resources contains container's resources (cgroups config, ulimits...)
type Resources struct {
        ...
	HugepageLimits       []HugepageLimit // List of hugepage limits to limit the HugeTLB usage of container per page size
```

Here are related PRs from Kubernetes.
Hugepage PRs Tracker: https://github.com/kubernetes/kubernetes/issues/84526
Hugepages KEP update: https://github.com/kubernetes/enhancements/pull/1199
CRI update: https://github.com/kubernetes/kubernetes/pull/83614
[WIP]Kubelet update: https://github.com/kubernetes/kubernetes/pull/84154
[WIP]Dockershim update:https://github.com/kubernetes/kubernetes/pull/84701