### PR TITLE
Add types.VolumeListOptions for a more consistent API

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -581,6 +581,11 @@ type ConfigListOptions struct {
 	Filters filters.Args
 }
 
+// VolumeListOptions holds parameters to list volumes
+type VolumeListOptions struct {
+	Filters filters.Args
+}
+
 // PushResult contains the tag, manifest digest, and manifest size from the
 // push. It's used to signal this information to the trust code in the client
 // so it can sign the manifest if necessary.

--- a/client/interface.go
+++ b/client/interface.go
@@ -175,7 +175,7 @@ type VolumeAPIClient interface {
 	VolumeCreate(ctx context.Context, options volumetypes.VolumeCreateBody) (types.Volume, error)
 	VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error)
 	VolumeInspectWithRaw(ctx context.Context, volumeID string) (types.Volume, []byte, error)
-	VolumeList(ctx context.Context, filter filters.Args) (volumetypes.VolumeListOKBody, error)
+	VolumeList(ctx context.Context, options types.VolumeListOptions) (volumetypes.VolumeListOKBody, error)
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
 	VolumesPrune(ctx context.Context, pruneFilter filters.Args) (types.VolumesPruneReport, error)
 }

--- a/client/volume_list.go
+++ b/client/volume_list.go
@@ -5,18 +5,19 @@ import (
 	"encoding/json"
 	"net/url"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	volumetypes "github.com/docker/docker/api/types/volume"
 )
 
 // VolumeList returns the volumes configured in the docker host.
-func (cli *Client) VolumeList(ctx context.Context, filter filters.Args) (volumetypes.VolumeListOKBody, error) {
+func (cli *Client) VolumeList(ctx context.Context, options types.VolumeListOptions) (volumetypes.VolumeListOKBody, error) {
 	var volumes volumetypes.VolumeListOKBody
 	query := url.Values{}
 
-	if filter.Len() > 0 {
+	if options.Filters.Len() > 0 {
 		//nolint:staticcheck // ignore SA1019 for old code
-		filterJSON, err := filters.ToParamWithVersion(cli.version, filter)
+		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
 		if err != nil {
 			return volumes, err
 		}

--- a/client/volume_list_test.go
+++ b/client/volume_list_test.go
@@ -21,7 +21,7 @@ func TestVolumeListError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.VolumeList(context.Background(), filters.NewArgs())
+	_, err := client.VolumeList(context.Background(), types.VolumeListOptions{})
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
 	}
@@ -88,7 +88,7 @@ func TestVolumeList(t *testing.T) {
 			}),
 		}
 
-		volumeResponse, err := client.VolumeList(context.Background(), listCase.filters)
+		volumeResponse, err := client.VolumeList(context.Background(), types.VolumeListOptions{Filters: listCase.filters})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/integration/container/remove_test.go
+++ b/integration/container/remove_test.go
@@ -72,7 +72,9 @@ func TestRemoveContainerWithVolume(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	volumes, err := client.VolumeList(ctx, filters.NewArgs(filters.Arg("name", volName)))
+	volumes, err := client.VolumeList(ctx, types.VolumeListOptions{
+		Filters: filters.NewArgs(filters.Arg("name", volName)),
+	})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(0, len(volumes.Volumes)))
 }

--- a/integration/plugin/authz/authz_plugin_v2_test.go
+++ b/integration/plugin/authz/authz_plugin_v2_test.go
@@ -104,7 +104,7 @@ func TestAuthZPluginV2RejectVolumeRequests(t *testing.T) {
 	assert.Assert(t, err != nil)
 	assert.Assert(t, strings.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
 
-	_, err = c.VolumeList(context.Background(), filters.Args{})
+	_, err = c.VolumeList(context.Background(), types.VolumeListOptions{})
 	assert.Assert(t, err != nil)
 	assert.Assert(t, strings.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
 

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/testutil/request"
@@ -44,7 +43,7 @@ func TestVolumesCreateAndList(t *testing.T) {
 	}
 	assert.Check(t, is.DeepEqual(vol, expected, cmpopts.EquateEmpty()))
 
-	volList, err := client.VolumeList(ctx, filters.Args{})
+	volList, err := client.VolumeList(ctx, types.VolumeListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, len(volList.Volumes) > 0)
 

--- a/testutil/environment/clean.go
+++ b/testutil/environment/clean.go
@@ -125,7 +125,7 @@ func removeImage(ctx context.Context, t testing.TB, apiclient client.ImageAPICli
 
 func deleteAllVolumes(t testing.TB, c client.VolumeAPIClient, protectedVolumes map[string]struct{}) {
 	t.Helper()
-	volumes, err := c.VolumeList(context.Background(), filters.Args{})
+	volumes, err := c.VolumeList(context.Background(), types.VolumeListOptions{})
 	assert.Check(t, err, "failed to list volumes")
 
 	for _, v := range volumes.Volumes {

--- a/testutil/environment/protect.go
+++ b/testutil/environment/protect.go
@@ -211,7 +211,7 @@ func ProtectVolumes(t testing.TB, testEnv *Execution) {
 func getExistingVolumes(t testing.TB, testEnv *Execution) []string {
 	t.Helper()
 	client := testEnv.APIClient()
-	volumeList, err := client.VolumeList(context.Background(), filters.Args{})
+	volumeList, err := client.VolumeList(context.Background(), types.VolumeListOptions{})
 	assert.NilError(t, err, "failed to list volumes")
 
 	var volumes []string


### PR DESCRIPTION
Had this branch lying around, and dusted it off a bit; this brings the VolumeList() in line with the other functions, and would allow for more easy future expansion of options that can be passed