### PR TITLE
[WIP] Add hugepage limit to specResource

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -210,6 +210,23 @@ definitions:
       PathInContainer: "/dev/deviceName"
       CgroupPermissions: "mrw"
 
+  HugepageLimit:
+    type: "object"
+    description: |
+      HugepageLimit corresponds to the file`hugetlb.<hugepagesize>.limit_in_byte` in container level cgroup.
+      For example, `PageSize=1GB`, `Limit=1073741824` means setting `1073741824` bytes to hugetlb.1GB.limit_in_bytes.
+    properties:
+      PageSize:
+        type: "string"
+        example: "1GB"
+      Limit:
+        type: "integer"
+        format: "uint64"
+        example: 1073741824
+    example:
+      PageSize: "1GB"
+      Limit: 1073741824
+
   DeviceRequest:
     type: "object"
     description: "A request for devices to be sent to device drivers"
@@ -519,6 +536,11 @@ definitions:
             Hard:
               description: "Hard limit"
               type: "integer"
+      HugepageLimits:
+        description: "List of hugepage limits to limit the HugeTLB usage of container per page size"
+        type: "array"
+        items:
+          $ref: "#/definitions/HugepageLimit"
       # Applicable to Windows
       CpuCount:
         description: |
@@ -4725,6 +4747,7 @@ paths:
                 Memory: 0
                 MemorySwap: 0
                 MemoryReservation: 0
+                HugepageLimits: []
                 KernelMemory: 0
                 NanoCPUs: 500000
                 CpuPercent: 80

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -284,6 +284,17 @@ type DeviceMapping struct {
 	CgroupPermissions string
 }
 
+// HugepageLimit corresponds to the file`hugetlb.<hugepagesize>.limit_in_byte` in container level cgroup.
+// For example, `PageSize=1GB`, `Limit=1073741824` means setting `1073741824` bytes to hugetlb.1GB.limit_in_bytes.
+type HugepageLimit struct {
+	// The value of PageSize has the format <size><unit-prefix>B (2MB, 1GB),
+	// and must match the <hugepagesize> of the corresponding control file found in `hugetlb.<hugepagesize>.limit_in_bytes`.
+	// The values of <unit-prefix> are intended to be parsed using base 1024("1KB" = 1024, "1MB" = 1048576, etc).
+	PageSize string
+	// limit in bytes of hugepagesize HugeTLB usage.
+	Limit    uint64
+}
+
 // RestartPolicy represents the restart policies of the container.
 type RestartPolicy struct {
 	Name              string
@@ -369,6 +380,7 @@ type Resources struct {
 	OomKillDisable       *bool           // Whether to disable OOM Killer or not
 	PidsLimit            *int64          // Setting PIDs limit for a container; Set `0` or `-1` for unlimited, or `null` to not change.
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
+	HugepageLimits       []HugepageLimit // List of hugepage limits to limit the HugeTLB usage of container per page size
 
 	// Applicable to Windows
 	CPUCount           int64  `json:"CpuCount"`   // CPU count

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -258,6 +258,19 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 	return err
 }
 
+func getHugepageResources(config containertypes.Resources) []specs.LinuxHugepageLimit {
+	var hugepages []specs.LinuxHugepageLimit
+
+	for _, hugepage := range config.HugepageLimits {
+		hugepages = append(hugepages, specs.LinuxHugepageLimit{
+			Pagesize: hugepage.PageSize,
+			Limit:    hugepage.Limit,
+		})
+	}
+
+	return hugepages
+}
+
 func getBlkioThrottleDevices(devs []*blkiodev.ThrottleDevice) ([]specs.LinuxThrottleDevice, error) {
 	var throttleDevices []specs.LinuxThrottleDevice
 	var stat unix.Stat_t

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -875,14 +875,16 @@ func WithResources(c *container.Container) coci.SpecOpts {
 
 		memoryRes := getMemoryResources(r)
 		cpuRes, err := getCPUResources(r)
+		hugepageRes := getHugepageResources(r)
 		if err != nil {
 			return err
 		}
 		blkioWeight := r.BlkioWeight
 
 		specResources := &specs.LinuxResources{
-			Memory: memoryRes,
-			CPU:    cpuRes,
+			Memory:         memoryRes,
+			CPU:            cpuRes,
+			HugepageLimits: hugepageRes,
 			BlockIO: &specs.LinuxBlockIO{
 				Weight:                  &blkioWeight,
 				WeightDevice:            weightDevices,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This PR is related to https://github.com/moby/moby/pull/40160.

Hugepage limit will be delivered via Dockershim(https://github.com/kubernetes/enhancements/pull/1199, https://github.com/kubernetes/kubernetes/pull/84701).
Added delivered hugepage limit into the `HugepageLimits` field, because `specResource` follows OCI-spec.

Currently only Linux is considered.

**- How I did it**
TBD

**- How to verify it**
TBD

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
TBD

@bg-chun
