### PR TITLE
Add daemon options required by buildkit tests

### DIFF
--- a/testutil/daemon/ops.go
+++ b/testutil/daemon/ops.go
@@ -7,6 +7,16 @@ import (
 // Option is used to configure a daemon.
 type Option func(*Daemon)
 
+// WithContainerdSocket sets the --containerd option on the daemon.
+// Use an empty string to remove the option.
+//
+// If unset the --containerd option will be used with a default value.
+func WithContainerdSocket(socket string) Option {
+	return func(d *Daemon) {
+		d.containerdSocket = socket
+	}
+}
+
 // WithDefaultCgroupNamespaceMode sets the default cgroup namespace mode for the daemon
 func WithDefaultCgroupNamespaceMode(mode string) Option {
 	return func(d *Daemon) {


### PR DESCRIPTION
These options were added to make buildkit tests run in #40023, however they need to be merged first so that the version of docker vendored in moby/buildkit#1164 can be updated to include them.

/cc @tiborvass