### PR TITLE
builder/remotecontext: allow ssh:// for remote context URLs

### DIFF
--- a/builder/remotecontext/git/gitutils.go
+++ b/builder/remotecontext/git/gitutils.go
@@ -209,7 +209,7 @@ func isGitTransport(str string) bool {
 	}
 
 	switch getScheme(str) {
-	case "git", "http", "https":
+	case "git", "http", "https", "ssh":
 		return true
 	}
 

--- a/builder/remotecontext/git/gitutils_test.go
+++ b/builder/remotecontext/git/gitutils_test.go
@@ -83,6 +83,32 @@ func TestParseRemoteURL(t *testing.T) {
 				subdir: "mydir/mysubdir/",
 			},
 		},
+		{
+			doc: "ssh, no url-fragment",
+			url: "ssh://github.com/user/repo.git",
+			expected: gitRepo{
+				remote: "ssh://github.com/user/repo.git",
+				ref:    "master",
+			},
+		},
+		{
+			doc: "ssh, with url-fragment",
+			url: "ssh://github.com/user/repo.git#mybranch:mydir/mysubdir/",
+			expected: gitRepo{
+				remote: "ssh://github.com/user/repo.git",
+				ref:    "mybranch",
+				subdir: "mydir/mysubdir/",
+			},
+		},
+		{
+			doc: "ssh, with url-fragment and user",
+			url: "ssh://foo%40barcorp.com@github.com/user/repo.git#mybranch:mydir/mysubdir/",
+			expected: gitRepo{
+				remote: "ssh://foo%40barcorp.com@github.com/user/repo.git",
+				ref:    "mybranch",
+				subdir: "mydir/mysubdir/",
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
~marked as "WIP", as this is based on top of https://github.com/moby/moby/pull/40178~

relates to https://github.com/docker/cli/issues/2164 "Docker build cannot resolve git context with html escapes"


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

