### PR TITLE
Dockerd won't start if a network with the default subnet prefix already exists in HNS.

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -33,7 +33,6 @@ import (
 
 const (
 	isWindows            = true
-	defaultNetworkSpace  = "172.16.0.0/12"
 	platformSupported    = true
 	windowsMinCPUShares  = 1
 	windowsMaxCPUShares  = 10000
@@ -424,15 +423,19 @@ func initBridgeDriver(controller libnetwork.NetworkController, config *config.Co
 		winlibnetwork.NetworkName: runconfig.DefaultDaemonNetworkMode().NetworkName(),
 	}
 
-	subnetPrefix := defaultNetworkSpace
+	var ipamOption libnetwork.NetworkOption
+	var subnetPrefix string
+
 	if config.BridgeConfig.FixedCIDR != "" {
 		subnetPrefix = config.BridgeConfig.FixedCIDR
 	}
 
-	ipamV4Conf := libnetwork.IpamConf{PreferredPool: subnetPrefix}
-	v4Conf := []*libnetwork.IpamConf{&ipamV4Conf}
-	v6Conf := []*libnetwork.IpamConf{}
-	ipamOption := libnetwork.NetworkOptionIpam("default", "", v4Conf, v6Conf, nil)
+	if subnetPrefix != "" {
+		ipamV4Conf := libnetwork.IpamConf{PreferredPool: subnetPrefix}
+		v4Conf := []*libnetwork.IpamConf{&ipamV4Conf}
+		v6Conf := []*libnetwork.IpamConf{}
+		ipamOption = libnetwork.NetworkOptionIpam("default", "", v4Conf, v6Conf, nil)
+	}
 
 	_, err := controller.NewNetwork(string(runconfig.DefaultDaemonNetworkMode()), runconfig.DefaultDaemonNetworkMode().NetworkName(), "",
 		libnetwork.NetworkOptionGeneric(options.Generic{


### PR DESCRIPTION
Dockerd won't start if a network with the default subnet prefix already exists in HNS.

Signed-off-by: Pradip Dhara <pradipd@microsoft.com>

**- What I did**
If a network in the defaultNetworkSpace  (172.16.0.0/12) already exists, dockerd won't start because it won't be able to create the default nat network.

**- How I did it**
Revert back to how we did it before commit https://github.com/moby/moby/commit/6b91ceff74f41f8cbf5c183011764b801f71a221 (https://github.com/moby/moby/pull/39100)
If the subnet is not specified, let HNS pick out the subnet.

**- How to verify it**
1. Client
Install Hyper-V (this will install default switch which uses 172.X.X.X subnet).
run dockerd.
dockerd will fail to start because the defaultNetworkSpace (172.16.0.0/12) can not be reserved.

2. Server.
Create an HNS network in powershell (you can use [hns.psm1](https://github.com/Microsoft/SDN/blob/master/Kubernetes/windows/hns.psm1))
New-HnsNetwork -Type ICS -Name Test1 -AddressPrefix "172.16.0.0/24" -Gateway "172.16.0.1"
run dockerd
dockerd will fail to start because the defaultNetworkSpace (172.16.0.0/12) can not be reserved.


**- Description for the changelog**
Let HNS choose the subnet for the default nat network instead of defaulting to 172.16.0.0/12.

**- A picture of a cute animal (not mandatory but encouraged)**

