### PR TITLE
bump libnetwork 90afbb01e1d8acacb505a092744ea42b9f167377

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: ${LIBNETWORK_COMMIT:=0025177e3dabbe0de151be0957dcaff149d43536}
+: "${LIBNETWORK_COMMIT:=90afbb01e1d8acacb505a092744ea42b9f167377}"
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/gofrs/flock                              392e7fae8f1b0bdbd67dad7237d2
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        0025177e3dabbe0de151be0957dcaff149d43536
+github.com/docker/libnetwork                        90afbb01e1d8acacb505a092744ea42b9f167377
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/controller.go
+++ b/vendor/github.com/docker/libnetwork/controller.go
@@ -825,7 +825,7 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 
 	err = c.addNetwork(network)
 	if err != nil {
-		if strings.Contains(err.Error(), "restoring existing network") {
+		if _, ok := err.(types.MaskableError); ok {
 			// This error can be ignored and set this boolean
 			// value to skip a refcount increment for configOnly networks
 			skipCfgEpCount = true

--- a/vendor/github.com/docker/libnetwork/firewall_linux.go
+++ b/vendor/github.com/docker/libnetwork/firewall_linux.go
@@ -2,7 +2,6 @@ package libnetwork
 
 import (
 	"github.com/docker/libnetwork/iptables"
-	"github.com/docker/libnetwork/netlabel"
 	"github.com/sirupsen/logrus"
 )
 
@@ -10,42 +9,13 @@ const userChain = "DOCKER-USER"
 
 func (c *controller) arrangeUserFilterRule() {
 	c.Lock()
-
-	if c.hasIPTablesEnabled() {
-		arrangeUserFilterRule()
-	}
-
+	arrangeUserFilterRule()
 	c.Unlock()
-
 	iptables.OnReloaded(func() {
 		c.Lock()
-
-		if c.hasIPTablesEnabled() {
-			arrangeUserFilterRule()
-		}
-
+		arrangeUserFilterRule()
 		c.Unlock()
 	})
-}
-
-func (c *controller) hasIPTablesEnabled() bool {
-	// Locking c should be handled in the calling method.
-	if c.cfg == nil || c.cfg.Daemon.DriverCfg[netlabel.GenericData] == nil {
-		return false
-	}
-
-	genericData, ok := c.cfg.Daemon.DriverCfg[netlabel.GenericData]
-	if !ok {
-		return false
-	}
-
-	optMap := genericData.(map[string]interface{})
-	enabled, ok := optMap["EnableIPTables"].(bool)
-	if !ok {
-		return false
-	}
-
-	return enabled
 }
 
 // This chain allow users to configure firewall policies in a way that persists

--- a/vendor/github.com/docker/libnetwork/vendor.conf
+++ b/vendor/github.com/docker/libnetwork/vendor.conf
@@ -51,5 +51,5 @@ golang.org/x/sync                       1d60e4601c6fd243af51cc01ddf169918a5407ca
 github.com/pkg/errors                   ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
 github.com/ishidawataru/sctp            6e2cb1366111dcf547c13531e3a263a067715847
 
-gotest.tools                            b6e20af1ed078cd01a6413b734051a292450b4cb # v2.1.0
+gotest.tools                            1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0 
 github.com/google/go-cmp                3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0


### PR DESCRIPTION
full diff: https://github.com/docker/libnetwork/compare/0025177e3dabbe0de151be0957dcaff149d43536...90afbb01e1d8acacb505a092744ea42b9f167377

includes:

- docker/libnetwork#/2459 Fix Error Check in NewNetwork
- docker/libnetwork#/2466 Revert "Merge pull request #2339 from phyber/iptables-check"
    - reverts docker/libnetwork#/2339 controller: Check if IPTables is enabled for arrangeUserFilterRule
    - re-opens docker/libnetwork#2158 dockerd when run with --iptables=false modifies iptables by adding DOCKER-USER
    - re-opens moby/moby#35777 With iptables=false dockerd still creates DOCKER-USER chain and rules
    - re-opens docker/for-linux#136 dockerd --iptables=false adds DOCKER-USER chain and modify FORWARD chain anyway


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

