### PR TITLE
Volume plugin tests [integration/plugin/volumes] should always be executed - checks for OS Type should happen within the test

### DIFF
--- a/integration/plugin/volumes/main_test.go
+++ b/integration/plugin/volumes/main_test.go
@@ -19,9 +19,6 @@ func TestMain(m *testing.M) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	if testEnv.OSType != "linux" {
-		os.Exit(0)
-	}
 	err = environment.EnsureFrozenImagesLinux(testEnv)
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
The current check for OS type in  integration/plugin/volumes is premature. The test will never even get to run on "disallowed" OS types. No result [PASS/FAIL/SKIP] will be shown in the output. With certain tools like go testsum, the test will always flagged as a failure on such OS types.

This can be fixed by removing the check in places before the actual test.

Signed-off-by: vikrambirsingh <vikrambir.singh@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Removed OS Type check from a test in the main function

**- How I did it**


**- How to verify it**
Running the test on all OS Types should produce result [PASS/FAIL/SKIP]

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Removed a premature check for OSType to check if the test should be skipped.

**- A picture of a cute animal (not mandatory but encouraged)**

