### PR TITLE
Disable integration/system tests that are failing on Windows with error "protocol not available" 

### DIFF
--- a/integration/system/info_test.go
+++ b/integration/system/info_test.go
@@ -91,6 +91,7 @@ func TestInfoDebug(t *testing.T) {
 
 func TestInfoInsecureRegistries(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME: test starts daemon with -H unix://.....")
 
 	const (
 		registryCIDR = "192.168.1.0/24"
@@ -115,6 +116,7 @@ func TestInfoInsecureRegistries(t *testing.T) {
 
 func TestInfoRegistryMirrors(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "FIXME: test starts daemon with -H unix://.....")
 
 	const (
 		registryMirror1 = "https://192.168.1.2"


### PR DESCRIPTION
The tests starts a new daemon, but attempts to run it with overlay2,
and using a unix:// socket, which doesn't really work on Windows.

https://github.com/moby/moby/pull/40155 tried to disable such tests but missed two of them.
They are being disabled with this change.

relates to https://github.com/moby/moby/issues/40156 "Integration: fix TestInfoDebug and other tests that spin up daemons for Windows"

Signed-off-by: vikrambirsingh <vikrambir.singh@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Disabled two tests that were supposed to have been disabled by #40155 but got missed out

**- How I did it**
Skipped tests if OS is Windows

**- How to verify it**
Checks will verify that there are no failures on RS5

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Skip all integration/system tests on Windows that are using unix:// socket

**- A picture of a cute animal (not mandatory but encouraged)**
