### PR TITLE
OpenRC: pass extra environment variables to configure http(s) proxy for daemon

### DIFF
--- a/contrib/init/openrc/docker.confd
+++ b/contrib/init/openrc/docker.confd
@@ -25,5 +25,10 @@
 # where the docker daemon itself is run from
 #DOCKERD_BINARY="/usr/bin/dockerd"
 
+# proxy server to be used by docker daemon
+#DOCKER_HTTP_PROXY="http://proxy-server:80"
+#DOCKER_HTTPS_PROXY="https://proxy-server:443"
+#DOCKER_NO_PROXY="127.0.0.1,localhost,docker.io,*.docker.com"
+
 # any other random options you want to pass to docker
 DOCKER_OPTS=""

--- a/contrib/init/openrc/docker.confd
+++ b/contrib/init/openrc/docker.confd
@@ -28,7 +28,7 @@
 # proxy server to be used by docker daemon
 #DOCKER_HTTP_PROXY="http://proxy-server:80"
 #DOCKER_HTTPS_PROXY="https://proxy-server:443"
-#DOCKER_NO_PROXY="127.0.0.1,localhost,docker.io,*.docker.com"
+#DOCKER_NO_PROXY="127.0.0.1,localhost,*.docker.io,*.docker.com"
 
 # any other random options you want to pass to docker
 DOCKER_OPTS=""

--- a/contrib/init/openrc/docker.initd
+++ b/contrib/init/openrc/docker.initd
@@ -9,7 +9,8 @@ DOCKER_LOGFILE="${DOCKER_LOGFILE:-/var/log/${RC_SVCNAME}.log}"
 DOCKER_ERRFILE="${DOCKER_ERRFILE:-${DOCKER_LOGFILE}}"
 DOCKER_OUTFILE="${DOCKER_OUTFILE:-${DOCKER_LOGFILE}}"
 start_stop_daemon_args="--background \
-	--stderr \"${DOCKER_ERRFILE}\" --stdout \"${DOCKER_OUTFILE}\""
+	--stderr \"${DOCKER_ERRFILE}\" --stdout \"${DOCKER_OUTFILE}\" \
+	--env HTTP_PROXY=\"${DOCKER_HTTP_PROXY}\" --env HTTPS_PROXY=\"${DOCKER_HTTPS_PROXY}\" --env NO_PROXY=\"${DOCKER_NO_PROXY}\""
 
 extra_started_commands="reload"
 

--- a/contrib/init/openrc/docker.initd
+++ b/contrib/init/openrc/docker.initd
@@ -8,9 +8,14 @@ command_args="-p \"${pidfile}\" ${DOCKER_OPTS}"
 DOCKER_LOGFILE="${DOCKER_LOGFILE:-/var/log/${RC_SVCNAME}.log}"
 DOCKER_ERRFILE="${DOCKER_ERRFILE:-${DOCKER_LOGFILE}}"
 DOCKER_OUTFILE="${DOCKER_OUTFILE:-${DOCKER_LOGFILE}}"
+
+[ -z "${DOCKER_HTTP_PROXY}" ] || HTTP_PROXY_ENV="--env HTTP_PROXY=\"${DOCKER_HTTP_PROXY}\""
+[ -z "${DOCKER_HTTPS_PROXY}" ] || HTTPS_PROXY_ENV="--env HTTPS_PROXY=\"${DOCKER_HTTPS_PROXY}\""
+[ -z "${DOCKER_NO_PROXY}" ] || NO_PROXY_ENV="--env NO_PROXY=\"${DOCKER_NO_PROXY}\""
+
 start_stop_daemon_args="--background \
 	--stderr \"${DOCKER_ERRFILE}\" --stdout \"${DOCKER_OUTFILE}\" \
-	--env HTTP_PROXY=\"${DOCKER_HTTP_PROXY}\" --env HTTPS_PROXY=\"${DOCKER_HTTPS_PROXY}\" --env NO_PROXY=\"${DOCKER_NO_PROXY}\""
+	${HTTP_PROXY_ENV} ${HTTPS_PROXY_ENV} ${NO_PROXY_ENV}"
 
 extra_started_commands="reload"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Implemented https://github.com/moby/moby/issues/40201

**- How I did it**
Pass extra environment variables to docker daemon. In particular:
- `HTTP_PROXY`
- `HTTPS_PROXY`
- `NO_PROXY`

Values for env vars can be defined in openrc conf.d file as:
- `DOCKER_HTTP_PROXY`
- `DOCKER_HTTPS_PROXY`
- `DOCKER_NO_PROXY`

**- How to verify it**
Install docker on openrc-enabled system. e.g. on Gentoo:
```
# emerge docker
``` 
After installation proxy servers can be configured in `/etc/conf.d/docker` file 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
OpenRC: added support of http(s) proxy configuration for docker daemon


