### PR TITLE
overlay[2]: rm extra checks in init

### DIFF
--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -3,7 +3,6 @@
 package overlay // import "github.com/docker/docker/daemon/graphdriver/overlay"
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -123,10 +122,6 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 
-	if err := supportsOverlay(); err != nil {
-		return nil, graphdriver.ErrNotSupported
-	}
-
 	// Perform feature detection on /var/lib/docker/overlay if it's an existing directory.
 	// This covers situations where /var/lib/docker/overlay is a mount, and on a different
 	// filesystem than /var/lib/docker.
@@ -134,6 +129,11 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	testdir := home
 	if _, err := os.Stat(testdir); os.IsNotExist(err) {
 		testdir = filepath.Dir(testdir)
+	}
+
+	if err := overlayutils.SupportsOverlay(testdir, false); err != nil {
+		logrus.WithField("storage-driver", "overlay").Error(err)
+		return nil, graphdriver.ErrNotSupported
 	}
 
 	fsMagic, err := graphdriver.GetFSMagic(testdir)
@@ -197,33 +197,6 @@ func parseOptions(options []string) (*overlayOptions, error) {
 		}
 	}
 	return o, nil
-}
-
-func supportsOverlay() error {
-	// Access overlay filesystem so that Linux loads it (if possible).
-	mountTarget, err := ioutil.TempDir("", "supportsOverlay")
-	if err != nil {
-		logrus.WithError(err).WithField("storage-driver", "overlay2").Error("could not create temporary directory, so assuming that 'overlay' is not supported")
-		return graphdriver.ErrNotSupported
-	}
-	/* The mounting will fail--after the module has been loaded.*/
-	defer os.RemoveAll(mountTarget)
-	unix.Mount("overlay", mountTarget, "overlay", 0, "")
-
-	f, err := os.Open("/proc/filesystems")
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	s := bufio.NewScanner(f)
-	for s.Scan() {
-		if s.Text() == "nodev\toverlay" {
-			return nil
-		}
-	}
-	logrus.WithField("storage-driver", "overlay").Error("'overlay' not found as a supported filesystem on this host. Please ensure kernel is new enough and has overlay support loaded.")
-	return graphdriver.ErrNotSupported
 }
 
 func (d *Driver) String() string {

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -136,20 +136,6 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, graphdriver.ErrNotSupported
 	}
 
-	fsMagic, err := graphdriver.GetFSMagic(testdir)
-	if err != nil {
-		return nil, err
-	}
-	if fsName, ok := graphdriver.FsNames[fsMagic]; ok {
-		backingFs = fsName
-	}
-
-	switch fsMagic {
-	case graphdriver.FsMagicAufs, graphdriver.FsMagicBtrfs, graphdriver.FsMagicEcryptfs, graphdriver.FsMagicNfsFs, graphdriver.FsMagicOverlay, graphdriver.FsMagicZfs:
-		logrus.WithField("storage-driver", "overlay").Errorf("'overlay' is not supported over %s", backingFs)
-		return nil, graphdriver.ErrIncompatibleFS
-	}
-
 	supportsDType, err := fsutils.SupportsDType(testdir)
 	if err != nil {
 		return nil, err

--- a/daemon/graphdriver/overlay2/check.go
+++ b/daemon/graphdriver/overlay2/check.go
@@ -99,35 +99,3 @@ func doesSupportNativeDiff(d string) error {
 
 	return nil
 }
-
-// supportsMultipleLowerDir checks if the system supports multiple lowerdirs,
-// which is required for the overlay2 driver. On 4.x kernels, multiple lowerdirs
-// are always available (so this check isn't needed), and backported to RHEL and
-// CentOS 3.x kernels (3.10.0-693.el7.x86_64 and up). This function is to detect
-// support on those kernels, without doing a kernel version compare.
-func supportsMultipleLowerDir(d string) error {
-	td, err := ioutil.TempDir(d, "multiple-lowerdir-check")
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := os.RemoveAll(td); err != nil {
-			logger.Warnf("Failed to remove check directory %v: %v", td, err)
-		}
-	}()
-
-	for _, dir := range []string{"lower1", "lower2", "upper", workDirName, mergedDirName} {
-		if err := os.Mkdir(filepath.Join(td, dir), 0755); err != nil {
-			return err
-		}
-	}
-
-	opts := fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", path.Join(td, "lower2"), path.Join(td, "lower1"), path.Join(td, "upper"), path.Join(td, workDirName))
-	if err := unix.Mount("overlay", filepath.Join(td, mergedDirName), "overlay", 0, opts); err != nil {
-		return errors.Wrap(err, "failed to mount overlay")
-	}
-	if err := unix.Unmount(filepath.Join(td, mergedDirName), 0); err != nil {
-		logger.Warnf("Failed to unmount check directory %v: %v", filepath.Join(td, mergedDirName), err)
-	}
-	return nil
-}

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -180,7 +180,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		if opts.overrideKernelCheck {
 			logger.Warn("Using pre-4.0.0 kernel for overlay2, mount failures may require kernel update")
 		} else {
-			if err := supportsMultipleLowerDir(testdir); err != nil {
+			if err := overlayutils.SupportsMultipleLowerDir(testdir); err != nil {
 				logger.Debugf("Multiple lower dirs not supported: %v", err)
 				return nil, graphdriver.ErrNotSupported
 			}

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -27,7 +27,6 @@ import (
 	"github.com/docker/docker/pkg/locker"
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/parsers"
-	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/system"
 	units "github.com/docker/go-units"
 	rsystem "github.com/opencontainers/runc/libcontainer/system"
@@ -132,12 +131,6 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 
-	// require kernel 4.0.0 to ensure multiple lower dirs are supported
-	v, err := kernel.GetKernelVersion()
-	if err != nil {
-		return nil, err
-	}
-
 	// Perform feature detection on /var/lib/docker/overlay2 if it's an existing directory.
 	// This covers situations where /var/lib/docker/overlay2 is a mount, and on a different
 	// filesystem than /var/lib/docker.
@@ -150,30 +143,6 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	if err := overlayutils.SupportsOverlay(testdir, true); err != nil {
 		logger.Error(err)
 		return nil, graphdriver.ErrNotSupported
-	}
-
-	fsMagic, err := graphdriver.GetFSMagic(testdir)
-	if err != nil {
-		return nil, err
-	}
-	if fsName, ok := graphdriver.FsNames[fsMagic]; ok {
-		backingFs = fsName
-	}
-
-	switch fsMagic {
-	case graphdriver.FsMagicAufs, graphdriver.FsMagicEcryptfs, graphdriver.FsMagicNfsFs, graphdriver.FsMagicOverlay, graphdriver.FsMagicZfs:
-		logger.Errorf("'overlay2' is not supported over %s", backingFs)
-		return nil, graphdriver.ErrIncompatibleFS
-	case graphdriver.FsMagicBtrfs:
-		// Support for OverlayFS on BTRFS was added in kernel 4.7
-		// See https://btrfs.wiki.kernel.org/index.php/Changelog
-		if kernel.CompareKernelVersion(*v, kernel.VersionInfo{Kernel: 4, Major: 7, Minor: 0}) < 0 {
-			if !opts.overrideKernelCheck {
-				logger.Errorf("'overlay2' requires kernel 4.7 to use on %s", backingFs)
-				return nil, graphdriver.ErrIncompatibleFS
-			}
-			logger.Warn("Using pre-4.7.0 kernel for overlay2 on btrfs, may require kernel update")
-		}
 	}
 
 	supportsDType, err := fsutils.SupportsDType(testdir)

--- a/daemon/graphdriver/overlayutils/overlayutils.go
+++ b/daemon/graphdriver/overlayutils/overlayutils.go
@@ -4,8 +4,15 @@ package overlayutils // import "github.com/docker/docker/daemon/graphdriver/over
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
 
 	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 // ErrDTypeNotSupported denotes that the backing filesystem doesn't support d_type.
@@ -22,4 +29,37 @@ func ErrDTypeNotSupported(driver, backingFs string) error {
 	msg += " Backing filesystems without d_type support are not supported."
 
 	return graphdriver.NotSupportedError(msg)
+}
+
+// SupportsMultipleLowerDir checks if the system supports multiple lowerdirs,
+// which is required for the overlay2 driver. On 4.x kernels, multiple lowerdirs
+// are always available (so this check isn't needed), and backported to RHEL and
+// CentOS 3.x kernels (3.10.0-693.el7.x86_64 and up). This function is to detect
+// support on those kernels, without doing a kernel version compare.
+func SupportsMultipleLowerDir(d string) error {
+	td, err := ioutil.TempDir(d, "multiple-lowerdir-check")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := os.RemoveAll(td); err != nil {
+			logrus.Warnf("Failed to remove check directory %v: %v", td, err)
+		}
+	}()
+
+	for _, dir := range []string{"lower1", "lower2", "upper", "work", "merged"} {
+		if err := os.Mkdir(filepath.Join(td, dir), 0755); err != nil {
+			return err
+		}
+	}
+
+	mnt := filepath.Join(td, "merged")
+	opts := fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", path.Join(td, "lower2"), path.Join(td, "lower1"), path.Join(td, "upper"), path.Join(td, "work"))
+	if err := unix.Mount("overlay", mnt, "overlay", 0, opts); err != nil {
+		return errors.Wrap(err, "failed to mount overlay")
+	}
+	if err := unix.Unmount(mnt, 0); err != nil {
+		logrus.Warnf("Failed to unmount check directory %v: %v", mnt, err)
+	}
+	return nil
 }


### PR DESCRIPTION
_This builds on top of (and currently includes) https://github.com/moby/moby/pull/40194_

Now that we do check if overlay is working by performing an actual
overlayfs mount, there's no need in extra checks for the kernel version
or the filesystem type. Actual mount check is sufficient.

Reported-by: @snajpa