### PR TITLE
Move DefaultCapabilities() to caps package

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -139,7 +139,7 @@ func WithApparmor(c *container.Container) coci.SpecOpts {
 func WithCapabilities(c *container.Container) coci.SpecOpts {
 	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
 		capabilities, err := caps.TweakCapabilities(
-			oci.DefaultCapabilities(),
+			caps.DefaultCapabilities(),
 			c.HostConfig.CapAdd,
 			c.HostConfig.CapDrop,
 			c.HostConfig.Capabilities,

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -390,7 +390,7 @@ func (daemon *Daemon) createSpecLinuxFields(c *container.Container, s *specs.Spe
 	// Note these are against the UVM.
 	setResourcesInSpec(c, s, true) // LCOW is Hyper-V only
 
-	capabilities, err := caps.TweakCapabilities(oci.DefaultCapabilities(), c.HostConfig.CapAdd, c.HostConfig.CapDrop, c.HostConfig.Capabilities, c.HostConfig.Privileged)
+	capabilities, err := caps.TweakCapabilities(caps.DefaultCapabilities(), c.HostConfig.CapAdd, c.HostConfig.CapDrop, c.HostConfig.Capabilities, c.HostConfig.Privileged)
 	if err != nil {
 		return fmt.Errorf("linux spec capabilities: %v", err)
 	}

--- a/oci/caps/defaults.go
+++ b/oci/caps/defaults.go
@@ -1,0 +1,21 @@
+package caps // import "github.com/docker/docker/oci/caps"
+
+// DefaultCapabilities returns a Linux kernel default capabilities
+func DefaultCapabilities() []string {
+	return []string{
+		"CAP_CHOWN",
+		"CAP_DAC_OVERRIDE",
+		"CAP_FSETID",
+		"CAP_FOWNER",
+		"CAP_MKNOD",
+		"CAP_NET_RAW",
+		"CAP_SETGID",
+		"CAP_SETUID",
+		"CAP_SETFCAP",
+		"CAP_SETPCAP",
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SYS_CHROOT",
+		"CAP_KILL",
+		"CAP_AUDIT_WRITE",
+	}
+}

--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -4,32 +4,13 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/docker/docker/oci/caps"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func iPtr(i int64) *int64        { return &i }
 func u32Ptr(i int64) *uint32     { u := uint32(i); return &u }
 func fmPtr(i int64) *os.FileMode { fm := os.FileMode(i); return &fm }
-
-// DefaultCapabilities returns a Linux kernel default capabilities
-func DefaultCapabilities() []string {
-	return []string{
-		"CAP_CHOWN",
-		"CAP_DAC_OVERRIDE",
-		"CAP_FSETID",
-		"CAP_FOWNER",
-		"CAP_MKNOD",
-		"CAP_NET_RAW",
-		"CAP_SETGID",
-		"CAP_SETUID",
-		"CAP_SETFCAP",
-		"CAP_SETPCAP",
-		"CAP_NET_BIND_SERVICE",
-		"CAP_SYS_CHROOT",
-		"CAP_KILL",
-		"CAP_AUDIT_WRITE",
-	}
-}
 
 // DefaultSpec returns the default spec used by docker for the current Platform
 func DefaultSpec() specs.Spec {
@@ -60,10 +41,10 @@ func DefaultLinuxSpec() specs.Spec {
 		Version: specs.Version,
 		Process: &specs.Process{
 			Capabilities: &specs.LinuxCapabilities{
-				Bounding:    DefaultCapabilities(),
-				Permitted:   DefaultCapabilities(),
-				Inheritable: DefaultCapabilities(),
-				Effective:   DefaultCapabilities(),
+				Bounding:    caps.DefaultCapabilities(),
+				Permitted:   caps.DefaultCapabilities(),
+				Inheritable: caps.DefaultCapabilities(),
+				Effective:   caps.DefaultCapabilities(),
 			},
 		},
 		Root: &specs.Root{},


### PR DESCRIPTION
**- What I did**
Allow to reference DefaultCapabilities() from client projects (like my PR https://github.com/docker/cli/pull/1940 ) without breaking cross OS compile.

**- How I did it**
Moved oci.DefaultCapabilities() to caps package.

**- How to verify it**
CI passes.