### PR TITLE
Use certs.d from XDG_CONFIG_HOME when in rootless mode (fixes #40236)

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -55,7 +55,7 @@ func hasFile(files []os.FileInfo, name string) bool {
 // provided TLS configuration.
 func ReadCertsDirectory(tlsConfig *tls.Config, directory string) error {
 	fs, err := ioutil.ReadDir(directory)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !os.IsNotExist(err) && !os.IsPermission(err) {
 		return err
 	}
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -16,6 +16,9 @@ import (
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/sirupsen/logrus"
+
+	"github.com/docker/docker/pkg/homedir"
+	"github.com/docker/docker/rootless"
 )
 
 var (
@@ -31,7 +34,19 @@ func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
 	tlsConfig.InsecureSkipVerify = !isSecure
 
 	if isSecure && CertsDir != "" {
-		hostDir := filepath.Join(CertsDir, cleanPath(hostname))
+		certsDir := CertsDir
+
+		if rootless.RunningWithRootlessKit() {
+			configHome, err := homedir.GetConfigHome()
+			if err != nil {
+				return nil, err
+			}
+
+			certsDir = filepath.Join(configHome, "docker/certs.d")
+		}
+
+		hostDir := filepath.Join(certsDir, cleanPath(hostname))
+
 		logrus.Debugf("hostDir: %s", hostDir)
 		if err := ReadCertsDirectory(tlsConfig, hostDir); err != nil {
 			return nil, err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Made Docker look for `cert.d` in `XDG_CONFIG_HOME` in rootless mode
**- How I did it**
In rootless mode, path for `certs.d` is changed to `$XDG_CONFIG_HOME/docker/certs.d`
**- How to verify it**
Check it. I think that's too simple to have a dedicated test.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use certs.d from XDG_CONFIG_HOME when in rootless mode (#40236)

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/19504461/69522763-44507280-0f73-11ea-965b-cdf4e343841e.png)
