### PR TITLE
pkg/system: minor cleanups and remove use of deprecated system.GetOSVersion()

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -223,8 +223,7 @@ func verifyDaemonSettings(config *config.Config) error {
 func checkSystem() error {
 	// Validate the OS version. Note that dockerd.exe must be manifested for this
 	// call to return the correct version.
-	osv := system.GetOSVersion()
-	if osv.MajorVersion < 10 {
+	if osversion.Get().MajorVersion < 10 {
 		return fmt.Errorf("This version of Windows does not support the docker daemon")
 	}
 	if osversion.Build() < osversion.RS1 {

--- a/pkg/parsers/operatingsystem/operatingsystem_windows.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_windows.go
@@ -3,7 +3,7 @@ package operatingsystem // import "github.com/docker/docker/pkg/parsers/operatin
 import (
 	"fmt"
 
-	"github.com/docker/docker/pkg/system"
+	"github.com/Microsoft/hcsshim/osversion"
 	"golang.org/x/sys/windows/registry"
 )
 
@@ -52,7 +52,7 @@ func withCurrentVersionRegistryKey(f func(registry.Key) (string, error)) (string
 
 // GetOperatingSystemVersion gets the version of the current operating system, as a string.
 func GetOperatingSystemVersion() (string, error) {
-	version := system.GetOSVersion()
+	version := osversion.Get()
 	return fmt.Sprintf("%d.%d.%d", version.MajorVersion, version.MinorVersion, version.Build), nil
 }
 

--- a/pkg/system/syscall_windows.go
+++ b/pkg/system/syscall_windows.go
@@ -99,7 +99,7 @@ func IsWindowsClient() bool {
 
 // Unmount is a platform-specific helper function to call
 // the unmount syscall. Not supported on Windows
-func Unmount(dest string) error {
+func Unmount(_ string) error {
 	return nil
 }
 
@@ -120,7 +120,7 @@ func CommandLineToArgv(commandLine string) ([]string, error) {
 
 	newArgs := make([]string, argc)
 	for i, v := range (*argv)[:argc] {
-		newArgs[i] = string(windows.UTF16ToString((*v)[:]))
+		newArgs[i] = windows.UTF16ToString((*v)[:])
 	}
 
 	return newArgs, nil
@@ -147,7 +147,7 @@ func GetSecurityDescriptorDacl(securityDescriptor *byte, daclPresent *uint32, da
 	r1, _, e1 := syscall.Syscall6(procGetSecurityDescriptorDacl.Addr(), 4, uintptr(unsafe.Pointer(securityDescriptor)), uintptr(unsafe.Pointer(daclPresent)), uintptr(unsafe.Pointer(dacl)), uintptr(unsafe.Pointer(daclDefaulted)), 0, 0)
 	if r1 == 0 {
 		if e1 != 0 {
-			result = syscall.Errno(e1)
+			result = e1
 		} else {
 			result = syscall.EINVAL
 		}

--- a/pkg/system/syscall_windows.go
+++ b/pkg/system/syscall_windows.go
@@ -86,8 +86,6 @@ func GetOSVersion() OSVersion {
 }
 
 // IsWindowsClient returns true if the SKU is client
-// @engine maintainers - this function should not be removed or modified as it
-// is used to enforce licensing restrictions on Windows.
 func IsWindowsClient() bool {
 	osviex := &osVersionInfoEx{OSVersionInfoSize: 284}
 	r1, _, err := procGetVersionExW.Call(uintptr(unsafe.Pointer(osviex)))


### PR DESCRIPTION
Relates to https://github.com/moby/moby/pull/39100 / https://github.com/moby/moby/pull/40135. See individual commits for details