### PR TITLE
Allow 'until' filters to accept formats as described in docs

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	apitime "github.com/docker/docker/api/types/time"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/images"
@@ -586,11 +587,20 @@ func toBuildkitPruneInfo(opts types.BuildCachePruneOptions) (client.PruneInfo, e
 	case 0:
 		// nothing to do
 	case 1:
-		var err error
-		until, err = time.ParseDuration(untilValues[0])
-		if err != nil {
-			return client.PruneInfo{}, errors.Wrapf(err, "%q filter expects a duration (e.g., '24h')", filterKey)
+		genErr := func(err error) (client.PruneInfo, error) {
+			return client.PruneInfo{}, errors.Wrapf(err,
+				"%q filter expects a duration or an RFC 3339 date-time (e.g., '24h', '2006-01-02T15:04:05')",
+				filterKey)
 		}
+		ts, err := apitime.GetTimestamp(untilValues[0], time.Now())
+		if err != nil {
+			return genErr(err)
+		}
+		secs, nsecs, err := apitime.ParseTimestamps(ts, -1)
+		if err != nil {
+			return genErr(err) 
+		}
+		until = time.Until(time.Unix(int64(secs), int64(nsecs)))
 	default:
 		return client.PruneInfo{}, errMultipleFilterValues{}
 	}

--- a/builder/builder-next/builder_test.go
+++ b/builder/builder-next/builder_test.go
@@ -1,0 +1,62 @@
+package buildkit
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"gotest.tools/assert"
+)
+
+func makeTestBuildCachePruneOptions(untilDuration string) types.BuildCachePruneOptions {
+	arg := filters.Arg("until", untilDuration)
+	return types.BuildCachePruneOptions{
+		All: false,
+		KeepStorage: 50000,
+		Filters: filters.NewArgs(arg),
+	}
+}
+
+func TestToBuildKitPruneInfoUntilFormats(t *testing.T) {
+	now := time.Now().UTC()
+	tenHours, _ := time.ParseDuration("24h")
+	tenHoursAgoTs := now.Add(-tenHours).Unix()
+	tenHoursAgoTime := time.Unix(tenHoursAgoTs, 0)
+	testCases := []string{
+		"24h",
+		strconv.Itoa(int(tenHoursAgoTs)),
+		tenHoursAgoTime.Format(time.RFC3339),
+		tenHoursAgoTime.Format(time.RFC3339Nano),
+		tenHoursAgoTime.Format("2006-01-02T15:04:05"),
+		tenHoursAgoTime.Format("2006-01-02T15:04:05.999999999"),
+	}
+
+	getCaseResult := func (testCase string) time.Duration {
+		pruneOptions := makeTestBuildCachePruneOptions(testCase)
+		result, err := toBuildkitPruneInfo(pruneOptions)
+		if err != nil {
+			t.Fatalf("An until argument of format %s should be accepted", testCase)
+		}
+		return result.KeepDuration
+	}
+
+ 	for i, testCase := range(testCases) {
+		result := getCaseResult(testCase)
+		resultSecs := result.Seconds()
+		assert.Assert(t, resultSecs >= -86401 && resultSecs <= -86400, testCase, resultSecs, i)
+	}
+
+	testCases = []string{
+		tenHoursAgoTime.Format("2006-01-02Z07:00"),
+		tenHoursAgoTime.Format("2006-01-02"),
+	}
+
+	for i, testCase := range(testCases) {
+		result := getCaseResult(testCase)
+		resultHours := int(result.Hours())
+		truncated := -24 - now.Hour()
+		assert.Assert(t, resultHours >= (truncated - 1) && resultHours <= truncated, testCase, resultHours, i)
+	}
+}


### PR DESCRIPTION
**- What I did**
Added support for more `until` parameters for `system prune --filter` to match the docs: https://docs.docker.com/engine/reference/commandline/system_prune/ 
Fixes #40253 

**- How I did it**
This attempts to interpret the user input as each supported format in order, accepting the first that doesn't return an error. 

**- How to verify it**
Run `docker system prune --force --all --filter "until=<ts-or-date-string>"` using the listed supported formats from the docs

**- Description for the changelog**
`system prune --filter` "until" parameter allows all formats listed on in the docs 


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/5347968/69612677-0b50e600-0fe5-11ea-80a4-623b80dbdc70.png)

