### PR TITLE
Windows: don't override size storage-option if it's set

### DIFF
--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -489,9 +489,13 @@ func hostConfigFromOptions(options *types.ImageBuildOptions, isWCOW bool) *conta
 	// For WCOW, the default of 20GB hard-coded in the platform
 	// is too small for builder scenarios where many users are
 	// using RUN statements to install large amounts of data.
-	// Use 127GB as that's the default size of a VHD in Hyper-V.
-	if isWCOW {
-		hc.StorageOpt = make(map[string]string)
+	// If no custom size is set, use 127GB for containers that
+	// are started during build, as that's the default size of
+	// a VHD in Hyper-V.
+	if isWCOW && hc.StorageOpt["size"] == "" {
+		if hc.StorageOpt == nil {
+			hc.StorageOpt = make(map[string]string)
+		}
 		hc.StorageOpt["size"] = "127GB"
 	}
 


### PR DESCRIPTION
Splitting this from https://github.com/moby/moby/pull/39846

Partially addresses https://github.com/moby/moby/issues/34947 (https://github.com/moby/moby/issues/34947#issuecomment-510078008)

Only set the size option if no custom size was configured on the daemon.

Previously, the storage-driver size for hyper-v containers used during build was always overridden with a fixed 127GB value. While this made sense to allow for building images that required more space than the default (40GB) size, it also caused a _custom_ size configured on the daemon to be ignored (for example, situations where the size is explicitly limited to a _lower_ size, or situations where a size larger than 127GB was needed).

This patch only increases the default (40GB) size for containers used during build, if no custom value was configured on the daemon.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
* Windows: respect custom storage-driver size for hyper-v containers used during build
```
