### PR TITLE
Don't re-create volumes (fixes #40047)

### DIFF
--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -61,11 +61,17 @@ func (s *VolumesService) GetDriverList() []string {
 //
 // A good example for a reference ID is a container's ID.
 // When whatever is going to reference this volume is removed the caller should defeference the volume by calling `Release`.
-func (s *VolumesService) Create(ctx context.Context, name, driverName string, opts ...opts.CreateOption) (*types.Volume, error) {
+func (s *VolumesService) Create(ctx context.Context, name, driverName string, options ...opts.CreateOption) (*types.Volume, error) {
 	if name == "" {
 		name = stringid.GenerateRandomID()
 	}
-	v, err := s.vs.Create(ctx, name, driverName, opts...)
+
+	oldV, err := s.Get(ctx, name, opts.WithGetDriver(driverName))
+	if err == nil {
+		return oldV, nil
+	}
+
+	v, err := s.vs.Create(ctx, name, driverName, options...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed #40047
**- How I did it**
Added a check so if volume is already created `Create` method just returns it.
**- How to verify it**
Run a new `TestServiceCreateLogs` unit test
**- Description for the changelog**
Don't re-create volumes (#40047) 
**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/19504461/69825595-dcbf4f00-1220-11ea-980f-5e8f9fb32d6a.png)
