### PR TITLE
Make sure that layers are removed from layerdb after succefull layer …

### DIFF
--- a/integration/image/remove_unix_test.go
+++ b/integration/image/remove_unix_test.go
@@ -110,4 +110,10 @@ func TestRemoveImageGarbageCollector(t *testing.T) {
 	i.Cleanup()
 	_, err = os.Stat(data["UpperDir"])
 	assert.Assert(t, os.IsNotExist(err))
+
+	// Make sure that removal pending layers does not exist on layerdb either
+	layerdbItems, _ := ioutil.ReadDir(filepath.Join(d.RootDir(), "/image/overlay2/layerdb/sha256"))
+	for _, folder := range layerdbItems {
+		assert.Equal(t, false, strings.HasSuffix(folder.Name(), "-removing"))
+	}
 }

--- a/layer/filestore.go
+++ b/layer/filestore.go
@@ -403,7 +403,7 @@ func (fms *fileMetadataStore) Remove(layer ChainID, cache string) error {
 		return err
 	}
 	for _, f := range files {
-		if !strings.HasSuffix(f.Name(), "-removing") || !strings.HasPrefix(f.Name(), dgst.String()) {
+		if !strings.HasSuffix(f.Name(), "-removing") || !strings.HasPrefix(f.Name(), dgst.Encoded()) {
 			continue
 		}
 

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -419,11 +419,11 @@ func (ls *layerStore) Map() map[ChainID]Layer {
 func (ls *layerStore) deleteLayer(layer *roLayer, metadata *Metadata) error {
 	// Rename layer digest folder first so we detect orphan layer(s)
 	// if ls.driver.Remove fails
-	dir := ls.store.getLayerDirectory(layer.chainID)
+	var dir string
 	for {
 		dgst := digest.Digest(layer.chainID)
 		tmpID := fmt.Sprintf("%s-%s-removing", dgst.Hex(), stringid.GenerateRandomID())
-		dir := filepath.Join(ls.store.root, string(dgst.Algorithm()), tmpID)
+		dir = filepath.Join(ls.store.root, string(dgst.Algorithm()), tmpID)
 		err := os.Rename(ls.store.getLayerDirectory(layer.chainID), dir)
 		if os.IsExist(err) {
 			continue


### PR DESCRIPTION
**- What I did**
I noticed that image layer garbage collector (which was introduced on #39193 ) does remove layer references from layerdb folder. This change fix that logic.

**- How I did it**
Cleanup (which currently runs on daemon shutdown): Changed `dgst.String()` which contains value `<hash algorithm>:<digest>` to `dgst.Encoded()` which actually contains only digest.

Layer delete when daemon is running: Corrected `dir` variable definition so it will get value from for loop so https://github.com/moby/moby/blob/a4a0429eec76dc2bb7d7649b8c851b2ec0f0beeb/layer/layer_store.go#L437 will find correct folder and will be able to remove it.

**- How to verify it**
Updated integration test to verify that there is not folders with `-removal` -suffix left to layerdb folders.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6213926/69826309-40df1480-121b-11ea-8c23-adda258ffb43.png)

