### PR TITLE
update vendor golang.org/x/sys

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -13,7 +13,7 @@ github.com/mattn/go-shellwords                      36a9b3c57cb5caa559ff63fb7e9b
 github.com/sirupsen/logrus                          839c75faf7f98a33d445d181f3018b5c3409a45e # v1.4.2
 github.com/tchap/go-patricia                        a7f0089c6f496e8e70402f61733606daa326cac5 # v2.3.0
 golang.org/x/net                                    f3200d17e092c607f615320ecaad13d87ad9a2b3
-golang.org/x/sys                                    c990c680b611ac1aeb7d8f2af94a825f98d69720
+golang.org/x/sys                                    6d18c012aee9febd81bbf9806760c8c4480e870d
 github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0
 golang.org/x/text                                   f21a4dfb5e38f5895301dc265a8def02365cc3d0 # v0.3.0


### PR DESCRIPTION
execute "docker run -it {image name} /bin/sh" no response on mip64el platform;
EpollEvent struct define lack a field named PadFd;
add the field "PadFd";
execcute docker run -it {image} /bin/sh for test after rebuilded.