### PR TITLE
35991- make `--device` works at privileged mode

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -275,6 +275,22 @@ func validateHostConfig(hostConfig *containertypes.HostConfig, platform string) 
 	if hostConfig == nil {
 		return nil
 	}
+
+	if hostConfig.Privileged {
+		for _, deviceMapping := range hostConfig.Devices {
+			if deviceMapping.PathOnHost == deviceMapping.PathInContainer {
+				continue
+			}
+			if _, err := os.Stat(deviceMapping.PathInContainer); err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				return errors.Wrap(err, "error stating device path in container")
+			}
+			return errors.Errorf("container device path: %s must be different from any host device path for privileged mode containers", deviceMapping.PathInContainer)
+		}
+	}
+
 	if hostConfig.AutoRemove && !hostConfig.RestartPolicy.IsNone() {
 		return errors.Errorf("can't create 'AutoRemove' container with restart policy")
 	}

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -276,21 +276,6 @@ func validateHostConfig(hostConfig *containertypes.HostConfig, platform string) 
 		return nil
 	}
 
-	if hostConfig.Privileged {
-		for _, deviceMapping := range hostConfig.Devices {
-			if deviceMapping.PathOnHost == deviceMapping.PathInContainer {
-				continue
-			}
-			if _, err := os.Stat(deviceMapping.PathInContainer); err != nil {
-				if os.IsNotExist(err) {
-					continue
-				}
-				return errors.Wrap(err, "error stating device path in container")
-			}
-			return errors.Errorf("container device path: %s must be different from any host device path for privileged mode containers", deviceMapping.PathInContainer)
-		}
-	}
-
 	if hostConfig.AutoRemove && !hostConfig.RestartPolicy.IsNone() {
 		return errors.Errorf("can't create 'AutoRemove' container with restart policy")
 	}

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -16,6 +16,7 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
 	daemonconfig "github.com/docker/docker/daemon/config"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/oci"
 	"github.com/docker/docker/oci/caps"
 	"github.com/docker/docker/pkg/idtools"

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -826,11 +826,6 @@ func WithDevices(daemon *Daemon, c *container.Container) coci.SpecOpts {
 					logrus.WithField("container", c.ID).Warnf("path in container %s already exists in privileged mode", deviceMapping.PathInContainer)
 					continue
 				}
-				// check if the path exists in the container. need to create a device only if the
-				// path does not exists.
-				if _, err := os.Stat(deviceMapping.PathInContainer); !os.IsNotExist(err) {
-					return errors.Errorf("container device path: %s must be different from any host device path for privileged mode containers", deviceMapping.PathInContainer)
-				}
 				d, _, err := oci.DevicesFromPath(deviceMapping.PathOnHost, deviceMapping.PathInContainer, "rwm")
 				if err != nil {
 					return err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**- What I did**
Fixes issue [#35991](https://github.com/moby/moby/issues/35991). Most changes have been taken from PR #36258, since it was not being actively worked on.

Changes:
-  `--device` flag will not be ignored in privileged mode

**- How I did it**
When creating the container spec for privileged containers, the device mapping is also included along with the entries from `/dev`. Since the container is already privileged, the cgroup permissions will be `rwm` for all the devices.

**- How to verify it**
Test Cases:
**1.** When the same host and container device is specified
Host
```
# docker run -it --rm --privileged --device /dev/sdc:/dev/sdc ubuntu:18.04
```
Daemon Logs
```
WARN[2019-12-06T13:28:23.599463805Z] path in container /dev/sdc already exists in privileged mode  container=00350c5f59fe356178d2fea5f1de29d7205a45c76cb3a1c6cb723061dfcccd56
```
**2.** When two different path in `/dev` is specified
Host
```
# docker run -it --rm --privileged --device /dev/sdc:/dev/sdx ubuntu:18.04
```
Container
```
root@55cdc2bb2a40:/# ls -l /dev | grep sdc 
brw-rw---- 1 root disk      8,  32 Dec  6 13:31 sdc
root@55cdc2bb2a40:/# ls -l /dev | grep sdx 
brw-rw---- 1 root disk      8,  32 Dec  6 13:31 sdx
```
**3.** When a path other than `/dev` is specified
Host
```
# docker run -it --rm --privileged --device /dev/sdc:/data ubuntu:18.04
```
Container
```
root@15572380927b:/# ls -l | grep data
brw-rw----   1 root disk 8, 32 Dec  6 13:33 data
root@15572380927b:/# ls -l /dev | grep sdc 
brw-rw---- 1 root disk      8,  32 Dec  6 13:33 sdc
```
**4.** Device mapped with a different permission
Host
```
# docker run -it --rm --privileged --device /dev/sdc:/data:r ubuntu:18.04
```
Daemon Logs
```
WARN[2019-12-06T13:35:17.899953587Z] custom r permissions for device /dev/sdc are ignored in privileged mode  container=bd02db4980eebc4180af75fee403bef986565c711ca96d74778e29cdbf191eab
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
The `--device` flag in `docker run` will now be honored when the container is started in privileged mode.

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-2.jpg)
