### PR TITLE
Possible improvement for #40063

### DIFF
--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -53,6 +53,7 @@ const (
 	retryWaitKey          = "fluentd-retry-wait"
 	maxRetriesKey         = "fluentd-max-retries"
 	asyncConnectKey       = "fluentd-async-connect"
+	asyncStopKey          = "fluentd-async-stop"
 	subSecondPrecisionKey = "fluentd-sub-second-precision"
 )
 
@@ -118,6 +119,13 @@ func New(info logger.Info) (logger.Logger, error) {
 		}
 	}
 
+	asyncStop := false
+	if info.Config[asyncStopKey] != "" {
+		if asyncStop, err = strconv.ParseBool(info.Config[asyncStopKey]); err != nil {
+			return nil, err
+		}
+	}
+
 	subSecondPrecision := false
 	if info.Config[subSecondPrecisionKey] != "" {
 		if subSecondPrecision, err = strconv.ParseBool(info.Config[subSecondPrecisionKey]); err != nil {
@@ -134,6 +142,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		RetryWait:          retryWait,
 		MaxRetry:           maxRetries,
 		Async:              asyncConnect,
+		AsyncStop:          asyncStop,
 		SubSecondPrecision: subSecondPrecision,
 	}
 
@@ -199,6 +208,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case retryWaitKey:
 		case maxRetriesKey:
 		case asyncConnectKey:
+		case asyncStopKey:
 		case subSecondPrecisionKey:
 			// Accepted
 		default:


### PR DESCRIPTION
**- What I did**

Added a config option to ensure fluentd logger will stop on Close(). Possible improvement/fix for #40063 

**- How I did it**

Refer https://github.com/fluent/fluent-logger-golang/pull/77 (depends on this change being accepted by fluent-logger-golang team)

**- How to verify it**

 * Set `fluentd-async-connect` and `fluentd-async-stop` to `true`
 * Generate some logs
 * Make fluentd unavailable
 * `docker stop <...>`
 * Container should stop after a maximum time of `fluentd-max-retries * 60s` (as docker currently does not set fluent's `max_retry_wait` which defaults to 60s)

**- Description for the changelog**

Prevent fluentd unavailability blocking container stop indefinitely