### PR TITLE
Update containerd to v1.3.2

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: ${CONTAINERD_COMMIT:=c7a4f874b3267c499484aae602d1257b12d69e40} # v1.3.1
+: ${CONTAINERD_COMMIT:=ff48f57fc83a8c44cf4ad5d672424a98ba37ded6} # v1.3.2
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Only update containerd to v1.3.2

> Welcome to the v1.3.2 release of containerd!

> The second patch release for containerd 1.3 includes a fix for a race condition
related to the reported pid on exit when called from Docker.

> ### Runtime
> * Fix containerd pid race condition containerd/containerd#3857
> * Use cached process state to reduce exec cost containerd/containerd#3711
> ### CRI
> * Added insecure_skip_verify option in the registry tls config to allow skipping registry certificate verification containerd/containerd#3847


Full diff here https://github.com/containerd/containerd/compare/v1.3.1...v1.3.2