### PR TITLE
distribution: http.Transport use keep alive

### DIFF
--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -71,14 +71,11 @@ func NewV2Repository(
 		DualStack: true,
 	}
 
-	// TODO(dmcgowan): Call close idle connections when complete, use keep alive
 	base := &http.Transport{
 		Proxy:               http.ProxyFromEnvironment,
 		DialContext:         direct.DialContext,
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     endpoint.TLSConfig,
-		// TODO(dmcgowan): Call close idle connections when complete and use keep alive
-		DisableKeepAlives: true,
 	}
 
 	modifiers := registry.Headers(dockerversion.DockerUserAgent(ctx), metaHeaders)


### PR DESCRIPTION
registry client's http.Transport use keep alive.

Signed-off-by: HuanHuan Ye <logindaveye@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
registry client's http.Transport use keep alive.
**- How I did it**
DisableKeepAlives field use default value false
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
distribution: http.Transport use keep alive

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/8220938/70612437-dfb73800-1c41-11ea-9f4f-09ed50a7593d.png)
