### PR TITLE
Fix output targets getting double nested.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -353,10 +353,10 @@ FROM scratch AS binary
 COPY --from=build-binary /build/bundles/ /
 
 FROM scratch AS dynbinary
-COPY --from=build-dynbinary /build/ /
+COPY --from=build-dynbinary /build/bundles/ /
 
 FROM scratch AS cross
-COPY --from=build-cross /build/ /
+COPY --from=build-cross /build/bundles/ /
 
 FROM dev AS final
 COPY . /go/src/github.com/docker/docker


### PR DESCRIPTION
Targets are going to bundles/bundles instead of just bundles/. This is
because there is `bundles` in the actual built binaries as well as the
output dir being set to bundles.