### PR TITLE
Swagger/API update "standalone" API fields

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3717,44 +3717,6 @@ definitions:
           on Windows.
         type: "string"
         example: "/var/lib/docker"
-      SystemStatus:
-        description: |
-          Status information about this node (standalone Swarm API).
-
-          <p><br /></p>
-
-          > **Note**: The information returned in this field is only propagated
-          > by the Swarm standalone API, and is empty (`null`) when using
-          > built-in swarm mode.
-        type: "array"
-        items:
-          type: "array"
-          items:
-            type: "string"
-        example:
-          - ["Role", "primary"]
-          - ["State", "Healthy"]
-          - ["Strategy", "spread"]
-          - ["Filters", "health, port, containerslots, dependency, affinity, constraint, whitelist"]
-          - ["Nodes", "2"]
-          - [" swarm-agent-00", "192.168.99.102:2376"]
-          - ["  └ ID", "5CT6:FBGO:RVGO:CZL4:PB2K:WCYN:2JSV:KSHH:GGFW:QOPG:6J5Q:IOZ2|192.168.99.102:2376"]
-          - ["  └ Status", "Healthy"]
-          - ["  └ Containers", "1 (1 Running, 0 Paused, 0 Stopped)"]
-          - ["  └ Reserved CPUs", "0 / 1"]
-          - ["  └ Reserved Memory", "0 B / 1.021 GiB"]
-          - ["  └ Labels", "kernelversion=4.4.74-boot2docker, operatingsystem=Boot2Docker 17.06.0-ce (TCL 7.2); HEAD : 0672754 - Thu Jun 29 00:06:31 UTC 2017, ostype=linux, provider=virtualbox, storagedriver=aufs"]
-          - ["  └ UpdatedAt", "2017-08-09T10:03:46Z"]
-          - ["  └ ServerVersion", "17.06.0-ce"]
-          - [" swarm-manager", "192.168.99.101:2376"]
-          - ["  └ ID", "TAMD:7LL3:SEF7:LW2W:4Q2X:WVFH:RTXX:JSYS:XY2P:JEHL:ZMJK:JGIW|192.168.99.101:2376"]
-          - ["  └ Status", "Healthy"]
-          - ["  └ Containers", "2 (2 Running, 0 Paused, 0 Stopped)"]
-          - ["  └ Reserved CPUs", "0 / 1"]
-          - ["  └ Reserved Memory", "0 B / 1.021 GiB"]
-          - ["  └ Labels", "kernelversion=4.4.74-boot2docker, operatingsystem=Boot2Docker 17.06.0-ce (TCL 7.2); HEAD : 0672754 - Thu Jun 29 00:06:31 UTC 2017, ostype=linux, provider=virtualbox, storagedriver=aufs"]
-          - ["  └ UpdatedAt", "2017-08-09T10:04:11Z"]
-          - ["  └ ServerVersion", "17.06.0-ce"]
       Plugins:
         $ref: "#/definitions/PluginsInfo"
       MemoryLimit:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4942,9 +4942,6 @@ paths:
                 type: "string"
               LogPath:
                 type: "string"
-              Node:
-                description: "TODO"
-                type: "object"
               Name:
                 type: "string"
               RestartCount:

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -154,7 +154,7 @@ type Info struct {
 	Images             int
 	Driver             string
 	DriverStatus       [][2]string
-	SystemStatus       [][2]string // SystemStatus is only propagated by the Swarm standalone API
+	SystemStatus       [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
 	Plugins            PluginsInfo
 	MemoryLimit        bool
 	SwapLimit          bool

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -154,7 +154,7 @@ type Info struct {
 	Images             int
 	Driver             string
 	DriverStatus       [][2]string
-	SystemStatus       [][2]string
+	SystemStatus       [][2]string // SystemStatus is only propagated by the Swarm standalone API
 	Plugins            PluginsInfo
 	MemoryLimit        bool
 	SwapLimit          bool
@@ -318,7 +318,7 @@ type ContainerState struct {
 }
 
 // ContainerNode stores information about the node that a container
-// is running on.  It's only available in Docker Swarm
+// is running on.  It's only used by the Docker Swarm standalone API
 type ContainerNode struct {
 	ID        string
 	IPAddress string `json:"IP"`
@@ -342,7 +342,7 @@ type ContainerJSONBase struct {
 	HostnamePath    string
 	HostsPath       string
 	LogPath         string
-	Node            *ContainerNode `json:",omitempty"`
+	Node            *ContainerNode `json:",omitempty"` // Node is only propagated by Docker Swarm standalone API
 	Name            string
 	RestartCount    int
 	Driver          string

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -88,6 +88,8 @@ func TestContainerInspect(t *testing.T) {
 	}
 }
 
+// TestContainerInspectNode tests that the "Node" field is included in the "inspect"
+// output. This information is only present when connected to a Swarm standalone API.
 func TestContainerInspectNode(t *testing.T) {
 	client := &Client{
 		client: newMockClient(func(req *http.Request) (*http.Response, error) {

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -31,6 +31,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /info` now  returns an `OSVersion` field, containing the operating system's
   version. This change is not versioned, and affects all API versions if the daemon
   has this patch.
+* `GET /info` no longer returns the `SystemStatus` field if it does not have a
+  value set. This change is not versioned, and affects all API versions if the
+  daemon has this patch.
 * `GET /services` now accepts query parameter `status`. When set `true`,
   services returned will include `ServiceStatus`, which provides Desired and
   Running task counts for the service.


### PR DESCRIPTION
closes https://github.com/moby/moby/pull/39821
replaces https://github.com/moby/moby/pull/39821

Update docs/descriptions of fields that are only used by the Swarm standalone API (https://github.com/docker/swarm), and omit the `SystemStatus` field if it's not set.