### PR TITLE
docker-py: skip broken ImageCollectionTest::test_pull_multiple, and re-enable fixed tests

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -10,14 +10,9 @@ source hack/make/.integration-test-helpers
 : "${DOCKER_PY_COMMIT:=4.1.0}"
 
 # custom options to pass py.test
-# TODO remove these skip once we update to a docker-py version that has https://github.com/docker/docker-py/pull/2369, https://github.com/docker/docker-py/pull/2380, https://github.com/docker/docker-py/pull/2382
 : "${PY_TEST_OPTIONS:=\
---deselect=tests/integration/api_swarm_test.py::SwarmTest::test_init_swarm_data_path_addr \
 --deselect=tests/integration/api_container_test.py::AttachContainerTest::test_attach_no_stream \
---deselect=tests/integration/api_exec_test.py::ExecTest::test_detach_with_arg \
 --deselect=tests/integration/api_exec_test.py::ExecDemuxTest::test_exec_command_tty_stream_no_demux \
---deselect=tests/integration/api_build_test.py::BuildTest::test_build_invalid_platform \
---deselect=tests/integration/api_image_test.py::PullImageTest::test_pull_invalid_platform \
 --junitxml=${DEST}/junit-report.xml \
 }"
 (

--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -10,9 +10,11 @@ source hack/make/.integration-test-helpers
 : "${DOCKER_PY_COMMIT:=4.1.0}"
 
 # custom options to pass py.test
+# TODO remove these skip once we update to a docker-py version that has https://github.com/docker/docker-py/pull/2485
 : "${PY_TEST_OPTIONS:=\
 --deselect=tests/integration/api_container_test.py::AttachContainerTest::test_attach_no_stream \
 --deselect=tests/integration/api_exec_test.py::ExecDemuxTest::test_exec_command_tty_stream_no_demux \
+--deselect=tests/integration/models_images_test.py::ImageCollectionTest::test_pull_multiple \
 --junitxml=${DEST}/junit-report.xml \
 }"
 (


### PR DESCRIPTION
### re-enable tests that were fixed:

https://github.com/docker/docker-py/pull/2369, https://github.com/docker/docker-py/pull/2380, and https://github.com/docker/docker-py/pull/2382 are included in docker-py v4.1.0, so we can re-enable these tests


### docker-py: skip broken ImageCollectionTest::test_pull_multiple

The ImageCollectionTest.test_pull_multiple test performs a `docker pull` without
a `:tag` specified) to pull all tags of the given repository (image).

After pulling the image, the image(s) pulled are checked to verify if the list
of images contains the `:latest` tag.

However, the test assumes that all tags of the image are tags for the same
version of the image (same digest), and thus a *single* image is returned, which
is not always the case.

Currently, the `hello-world:latest` and `hello-world:linux` tags point to a
different digest, therefore the `client.images.pull()` returns multiple images:
one image for digest, making the test fail:

    =================================== FAILURES ===================================
    ____________________ ImageCollectionTest.test_pull_multiple ____________________
    tests/integration/models_images_test.py:90: in test_pull_multiple
        assert len(images) == 1
    E   AssertionError: assert 2 == 1
    E    +  where 2 = len([<Image: 'hello-world:linux'>, <Image: 'hello-world:latest'>])

This patch temporarily skips the broken test until it is fixed upstream (PR: https://github.com/docker/docker-py/pull/2485).

