### PR TITLE
bump vndr v0.1.0 to support versioned import paths

### DIFF
--- a/hack/dockerfile/install/vndr.installer
+++ b/hack/dockerfile/install/vndr.installer
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-: ${VNDR_COMMIT:=f5ab8fc5fb64d66b5c6e55a0bcb58b2e92362fa0}
+: "${VNDR_COMMIT:=d385c05e4c23b602dd16b3d2a1a6c710919bf02f}" # v0.1.0
 
 install_vndr() {
 	echo "Install vndr version $VNDR_COMMIT"
 	git clone https://github.com/LK4D4/vndr.git "$GOPATH/src/github.com/LK4D4/vndr"
-	cd "$GOPATH/src/github.com/LK4D4/vndr"
+	cd "$GOPATH/src/github.com/LK4D4/vndr" || exit 1
 	git checkout -q "$VNDR_COMMIT"
 	go build -buildmode=pie -v -o "${PREFIX}/vndr" .
 }


### PR DESCRIPTION
With this change, go packages/modules that use versioned
import paths (github.com/foo/bar/v2), but don't use a directory
in the repository, can now be supported.

For example:

```
github.com/coreos/go-systemd/v22 v22.0.0
```

will vendor the github.com/coreos/go-systemd repository
into `vendor/github.com/coreos/go-systemd/v22`.

full diff: https://github.com/LK4D4/vndr/compare/f5ab8fc5fb64d66b5c6e55a0bcb58b2e92362fa0...v0.1.0

- LK4D4/vndr#83 migrate bitbucket to api 2.0
    - fixes LK4D4/vndr#82 https://api.bitbucket.org/1.0/repositories/ww/goautoneg: 410 Gone
- LK4D4/vndr#86 Replace sort.Sort with sort.Strings
- LK4D4/vndr#87 support `github.com/coreos/go-systemd/v22`

