### PR TITLE
prevent panic if TINI_COMMIT isn't set during build

### DIFF
--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -72,7 +72,9 @@ func (daemon *Daemon) fillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) 
 			v.InitCommit.ID = "N/A"
 		} else {
 			v.InitCommit.ID = commit
-			v.InitCommit.Expected = dockerversion.InitCommitID[0:len(commit)]
+			if len(dockerversion.InitCommitID) > len(commit) {
+				v.InitCommit.Expected = dockerversion.InitCommitID[0:len(commit)]
+			}
 		}
 	} else {
 		logrus.Warnf("failed to retrieve %s version: %s", defaultInitBinary, err)


### PR DESCRIPTION
extracted from https://github.com/moby/moby/pull/40094

If `TINI_COMMIT` isn't set, `.go-autogen` sets an empty value as the "expected" commit. Attempting to truncate the value caused a panic in that situation.

