### PR TITLE
Handle the error case when fixed-cidr-ipv6 is empty and ipv6 is enabled

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1018,7 +1018,9 @@ func initBridgeDriver(controller libnetwork.NetworkController, config *config.Co
 		ipamV6Conf     *libnetwork.IpamConf
 	)
 
-	if config.BridgeConfig.FixedCIDRv6 != "" {
+	if config.BridgeConfig.EnableIPv6 && config.BridgeConfig.FixedCIDRv6 == "" {
+		return errdefs.InvalidParameter(errors.New("IPv6 is enabled for the default bridge, but no subnet is configured. Specify an IPv6 subnet using --fixed-cidr-v6"))
+	} else if config.BridgeConfig.FixedCIDRv6 != "" {
 		_, fCIDRv6, err := net.ParseCIDR(config.BridgeConfig.FixedCIDRv6)
 		if err != nil {
 			return err


### PR DESCRIPTION
When IPv6 is enabled, make sure fixed-cidr-ipv6 is set
by the user since there is no default IPv6 local subnet
in the IPAM

Fixes : https://github.com/docker/for-linux/issues/829

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Handled the error case when `fixed-cidr-ipv6` is empty and `ipv6` is enabled

**- How to verify it**

```
dockerd --ipv6 &
[1] 465
failed to start daemon: Error initializing network controller: Please specify a IPv6 subnet using --fixed-cidr-v6 when IPv6 is enabled on the default bridge
1]+  Exit 1                  dockerd --ipv6
```