### PR TITLE
update .dockerignore to prevent '-unsupported' builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,6 @@
-.dockerignore
 .git
 .go-pkg-cache
 .gopath
 bundles
-Dockerfile
 vendor/pkg
 


### PR DESCRIPTION
When building the daemon inside the development container without bind-mounting the source-code, the git status was marked "dirty", because the `.dockerignore` and `Dockerfile` were not copied into the image (due to them being excluded by the .dockerignore):

```bash
make shell
hack/make.sh binary
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 GITCOMMIT = 98276a3439-unsupported
 The version you are building is listed as unsupported because
 there are some files in the git repository that are in an uncommitted state.
 Commit these changes, or add to .gitignore to remove the -unsupported from the version.
 Here is the current list:
 D .dockerignore
 D Dockerfile
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This patch removes those files from .dockerignore so that the git status is not marked "dirty".

Excluding the files through `.dockerignore` is only useful to prevent busting the build-cache in corner-cases where the files are modified without actual changes (e.g. whitespace-only changes, comment edited), but should not be a big issue in practice.

With this patch applied:

```bash
make shell
hack/make.sh binary

Removing bundles/

---> Making bundle: binary (in bundles/binary)
Building: bundles/binary-daemon/dockerd-dev
GOOS="" GOARCH="" GOARM=""
Created binary: bundles/binary-daemon/dockerd-dev
Copying nested executables into bundles/binary-daemon

bundles/binary-daemon/dockerd-dev --version
Docker version dev, build 7812dd38c8
```

