### PR TITLE
vendor: bump google/shlex b3f49c06ffaeef, beorn7/perks v1.0.1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -30,7 +30,7 @@ github.com/moby/buildkit                            4f4e03067523b2fc5ca2f17514a5
 github.com/tonistiigi/fsutil                        3bbb99cdbd76619ab717299830c60f6f2a533a6b
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7
-github.com/google/shlex                             6f45313302b9c56850fc17f99e40caebce98c716
+github.com/google/shlex                             e7afc7fbc51079733e9468cdfd1efcd7d196cd1d
 github.com/opentracing-contrib/go-stdlib            b1a47cfbdd7543e70e9ef3e73d0802ad306cc1cc
 github.com/mitchellh/hashstructure                  2bca23e0e452137f789efbc8610126fd8b94f73b
 github.com/gofrs/flock                              392e7fae8f1b0bdbd67dad7237d23f618feb6dbb # v0.7.1

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/Azure/go-ansiterm                        d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim                        b3f49c06ffaeef24d09c6c08ec8ec8425a0303e2
+github.com/Microsoft/hcsshim                        b3f49c06ffaeef24d09c6c08ec8ec8425a0303e2 # v0.8.7
 github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
 github.com/docker/libtrust                          9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/golang/gddo                              72a348e765d293ed6d1ded7b699591f14d6cd921

--- a/vendor.conf
+++ b/vendor.conf
@@ -144,7 +144,7 @@ code.cloudfoundry.org/clock                         02e53af36e6c978af692887ed449
 
 # prometheus
 github.com/prometheus/client_golang                 c5b7fccd204277076155f10851dad72b76a49317 # v0.8.0
-github.com/beorn7/perks                             e7f67b54abbeac9c40a31de0f81159e4cafebd6a
+github.com/beorn7/perks                             37c8de3658fcb183f997c4e13e8337516ab753e6 # v1.0.1
 github.com/prometheus/client_model                  6f3806018612930941127f2a7c6c453ba2c527d2
 github.com/prometheus/common                        7600349dcfe1abd18d72d3a1770870d9800a7801
 github.com/prometheus/procfs                        7d6f385de8bea29190f15ba9931442a0eaef9af7

--- a/vendor/github.com/beorn7/perks/go.mod
+++ b/vendor/github.com/beorn7/perks/go.mod
@@ -1,0 +1,3 @@
+module github.com/beorn7/perks
+
+go 1.11

--- a/vendor/github.com/google/shlex/go.mod
+++ b/vendor/github.com/google/shlex/go.mod
@@ -1,0 +1,3 @@
+module github.com/google/shlex
+
+go 1.13

--- a/vendor/github.com/google/shlex/shlex.go
+++ b/vendor/github.com/google/shlex/shlex.go
@@ -253,7 +253,6 @@ func (t *Tokenizer) scanStream() (*Token, error) {
 					}
 				case spaceRuneClass:
 					{
-						t.input.UnreadRune()
 						token := &Token{
 							tokenType: tokenType,
 							value:     string(value)}


### PR DESCRIPTION
### vendor: add "v0.8.7" comment to Microsoft/hcsshim vendor

Commit `b3f49c06ffaeef24d09c6c08ec8ec8425a0303e2` was tagged as `v0.8.7`, so add a comment to the vendor.conf


### vendor: bump google/shlex e7afc7fbc51079733e9468cdfd1efcd7d196cd1d

full diff: https://github.com/google/shlex/compare/6f45313302b9c56850fc17f99e40caebce98c716...e7afc7fbc51079733e9468cdfd1efcd7d196cd1d

- google/shlex#2 Remove unnecessary UnreadRune call
- google/shlex#3 Add go.mod


### vendor: bump beorn7/perks v1.0.1

full diff: https://github.com/beorn7/perks/compare/e7f67b54abbeac9c40a31de0f81159e4cafebd6a...v1.0.1

adds go module support
