### PR TITLE
Bump Libnetwork to latest refpoint

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: "${LIBNETWORK_COMMIT:=90afbb01e1d8acacb505a092744ea42b9f167377}"
+: "${LIBNETWORK_COMMIT:=feeff4f0a3fd2a2bb19cf67c826082c66ffaaed9}"
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/gofrs/flock                              392e7fae8f1b0bdbd67dad7237d2
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        90afbb01e1d8acacb505a092744ea42b9f167377
+github.com/docker/libnetwork                        feeff4f0a3fd2a2bb19cf67c826082c66ffaaed9
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/config/config.go
+++ b/vendor/github.com/docker/libnetwork/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -13,6 +14,7 @@ import (
 	"github.com/docker/libnetwork/ipamutils"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/osl"
+	"github.com/docker/libnetwork/portallocator"
 	"github.com/sirupsen/logrus"
 )
 
@@ -235,6 +237,23 @@ func OptionExperimental(exp bool) Option {
 	return func(c *Config) {
 		logrus.Debugf("Option Experimental: %v", exp)
 		c.Daemon.Experimental = exp
+	}
+}
+
+// OptionDynamicPortRange function returns an option setter for service port allocation range
+func OptionDynamicPortRange(in string) Option {
+	return func(c *Config) {
+		start, end := 0, 0
+		if len(in) > 0 {
+			n, err := fmt.Sscanf(in, "%d-%d", &start, &end)
+			if n != 2 || err != nil {
+				logrus.Errorf("Failed to parse range string with err %v", err)
+				return
+			}
+		}
+		if err := portallocator.Get().SetPortRange(start, end); err != nil {
+			logrus.Errorf("Failed to set port range with err %v", err)
+		}
 	}
 }
 

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/setup_device.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/setup_device.go
@@ -35,18 +35,17 @@ func setupDevice(config *networkConfiguration, i *bridgeInterface) error {
 		setMac = kv.Kernel > 3 || (kv.Kernel == 3 && kv.Major >= 3)
 	}
 
+	if setMac {
+		hwAddr := netutils.GenerateRandomMAC()
+		i.Link.Attrs().HardwareAddr = hwAddr
+		logrus.Debugf("Setting bridge mac address to %s", hwAddr)
+	}
+
 	if err = i.nlh.LinkAdd(i.Link); err != nil {
 		logrus.Debugf("Failed to create bridge %s via netlink. Trying ioctl", config.BridgeName)
 		return ioctlCreateBridge(config.BridgeName, setMac)
 	}
 
-	if setMac {
-		hwAddr := netutils.GenerateRandomMAC()
-		if err = i.nlh.LinkSetHardwareAddr(i.Link, hwAddr); err != nil {
-			return fmt.Errorf("failed to set bridge mac-address %s : %s", hwAddr, err.Error())
-		}
-		logrus.Debugf("Setting bridge mac address to %s", hwAddr)
-	}
 	return err
 }
 

--- a/vendor/github.com/docker/libnetwork/drivers/overlay/overlay.go
+++ b/vendor/github.com/docker/libnetwork/drivers/overlay/overlay.go
@@ -378,7 +378,7 @@ func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) 
 			}
 		}
 		if err := d.updateKeys(newKey, priKey, delKey); err != nil {
-			logrus.Warn(err)
+			return err
 		}
 	default:
 	}

--- a/vendor/github.com/docker/libnetwork/endpoint.go
+++ b/vendor/github.com/docker/libnetwork/endpoint.go
@@ -498,11 +498,14 @@ func (ep *endpoint) sbJoin(sb *sandbox, options ...EndpointOption) (err error) {
 	}
 
 	if doUpdateHostsFile(n, sb) {
-		address := ""
-		if ip := ep.getFirstInterfaceAddress(); ip != nil {
-			address = ip.String()
+		var addresses []string
+		if ip := ep.getFirstInterfaceIPv4Address(); ip != nil {
+			addresses = append(addresses, ip.String())
 		}
-		if err = sb.updateHostsFile(address); err != nil {
+		if ip := ep.getFirstInterfaceIPv6Address(); ip != nil {
+			addresses = append(addresses, ip.String())
+		}
+		if err = sb.updateHostsFile(addresses); err != nil {
 			return err
 		}
 	}
@@ -912,12 +915,23 @@ func (ep *endpoint) getSandbox() (*sandbox, bool) {
 	return ps, ok
 }
 
-func (ep *endpoint) getFirstInterfaceAddress() net.IP {
+func (ep *endpoint) getFirstInterfaceIPv4Address() net.IP {
 	ep.Lock()
 	defer ep.Unlock()
 
 	if ep.iface.addr != nil {
 		return ep.iface.addr.IP
+	}
+
+	return nil
+}
+
+func (ep *endpoint) getFirstInterfaceIPv6Address() net.IP {
+	ep.Lock()
+	defer ep.Unlock()
+
+	if ep.iface.addrv6 != nil {
+		return ep.iface.addrv6.IP
 	}
 
 	return nil

--- a/vendor/github.com/docker/libnetwork/portallocator/portallocator.go
+++ b/vendor/github.com/docker/libnetwork/portallocator/portallocator.go
@@ -3,16 +3,35 @@ package portallocator
 import (
 	"errors"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"net"
 	"sync"
 )
 
-const (
-	// DefaultPortRangeStart indicates the first port in port range
-	DefaultPortRangeStart = 49153
-	// DefaultPortRangeEnd indicates the last port in port range
-	DefaultPortRangeEnd = 65535
+var (
+	// defaultPortRangeStart indicates the first port in port range
+	defaultPortRangeStart = 49153
+	// defaultPortRangeEnd indicates the last port in port range
+	// consistent with default /proc/sys/net/ipv4/ip_local_port_range
+	// upper bound on linux
+	defaultPortRangeEnd = 60999
 )
+
+func sanitizePortRange(start int, end int) (newStart, newEnd int, err error) {
+	if start > defaultPortRangeEnd || end < defaultPortRangeStart || start > end {
+		return 0, 0, fmt.Errorf("Request out allowed range [%v, %v]",
+			defaultPortRangeStart, defaultPortRangeEnd)
+	}
+	err = nil
+	newStart, newEnd = start, end
+	if start < defaultPortRangeStart {
+		newStart = defaultPortRangeStart
+	}
+	if end > defaultPortRangeEnd {
+		newEnd = defaultPortRangeEnd
+	}
+	return
+}
 
 type ipMapping map[string]protoMap
 
@@ -92,11 +111,19 @@ func Get() *PortAllocator {
 	return instance
 }
 
-func newInstance() *PortAllocator {
+func getDefaultPortRange() (int, int) {
 	start, end, err := getDynamicPortRange()
-	if err != nil {
-		start, end = DefaultPortRangeStart, DefaultPortRangeEnd
+	if err == nil {
+		start, end, err = sanitizePortRange(start, end)
 	}
+	if err != nil {
+		start, end = defaultPortRangeStart, defaultPortRangeEnd
+	}
+	return start, end
+}
+
+func newInstance() *PortAllocator {
+	start, end := getDefaultPortRange()
 	return &PortAllocator{
 		ipMap: ipMapping{},
 		Begin: start,
@@ -167,6 +194,35 @@ func (p *PortAllocator) ReleasePort(ip net.IP, proto string, port int) error {
 		return nil
 	}
 	delete(protomap[proto].p, port)
+	return nil
+}
+
+// SetPortRange sets dynamic port allocation range.
+// if both portBegin and portEnd are 0, the port range reverts to default
+// value. Otherwise they are sanitized against the default values to
+// ensure their validity.
+func (p *PortAllocator) SetPortRange(portBegin, portEnd int) error {
+	// if begin and end is zero, revert to default values
+	var begin, end int
+	var err error
+	if portBegin == 0 && portEnd == 0 {
+		begin, end = getDefaultPortRange()
+
+	} else {
+		begin, end, err = sanitizePortRange(portBegin, portEnd)
+		if err != nil {
+			return err
+		}
+	}
+	logrus.Debugf("Setting up port allocator to range %v-%v, current %v-%v",
+		begin, end, p.Begin, p.End)
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	if p.Begin == begin && p.End == end {
+		return nil
+	}
+	p.ipMap = ipMapping{}
+	p.Begin, p.End = begin, end
 	return nil
 }
 

--- a/vendor/github.com/docker/libnetwork/portallocator/portallocator_freebsd.go
+++ b/vendor/github.com/docker/libnetwork/portallocator/portallocator_freebsd.go
@@ -8,7 +8,7 @@ import (
 
 func getDynamicPortRange() (start int, end int, err error) {
 	portRangeKernelSysctl := []string{"net.inet.ip.portrange.hifirst", "net.ip.portrange.hilast"}
-	portRangeFallback := fmt.Sprintf("using fallback port range %d-%d", DefaultPortRangeStart, DefaultPortRangeEnd)
+	portRangeFallback := fmt.Sprintf("using fallback port range %d-%d", defaultPortRangeStart, defaultPortRangeEnd)
 	portRangeLowCmd := exec.Command("/sbin/sysctl", portRangeKernelSysctl[0])
 	var portRangeLowOut bytes.Buffer
 	portRangeLowCmd.Stdout = &portRangeLowOut

--- a/vendor/github.com/docker/libnetwork/portallocator/portallocator_linux.go
+++ b/vendor/github.com/docker/libnetwork/portallocator/portallocator_linux.go
@@ -8,7 +8,7 @@ import (
 
 func getDynamicPortRange() (start int, end int, err error) {
 	const portRangeKernelParam = "/proc/sys/net/ipv4/ip_local_port_range"
-	portRangeFallback := fmt.Sprintf("using fallback port range %d-%d", DefaultPortRangeStart, DefaultPortRangeEnd)
+	portRangeFallback := fmt.Sprintf("using fallback port range %d-%d", defaultPortRangeStart, defaultPortRangeEnd)
 	file, err := os.Open(portRangeKernelParam)
 	if err != nil {
 		return 0, 0, fmt.Errorf("port allocator - %s due to error: %v", portRangeFallback, err)

--- a/vendor/github.com/docker/libnetwork/portallocator/portallocator_windows.go
+++ b/vendor/github.com/docker/libnetwork/portallocator/portallocator_windows.go
@@ -1,10 +1,10 @@
 package portallocator
 
-const (
-	StartPortRange = 60000
-	EndPortRange   = 65000
-)
+func init() {
+	defaultPortRangeStart = 60000
+	defaultPortRangeEnd = 65000
+}
 
 func getDynamicPortRange() (start int, end int, err error) {
-	return StartPortRange, EndPortRange, nil
+	return defaultPortRangeStart, defaultPortRangeEnd, nil
 }

--- a/vendor/github.com/docker/libnetwork/sandbox_dns_unix.go
+++ b/vendor/github.com/docker/libnetwork/sandbox_dns_unix.go
@@ -98,8 +98,8 @@ func (sb *sandbox) buildHostsFile() error {
 	return etchosts.Build(sb.config.hostsPath, "", sb.config.hostName, sb.config.domainName, extraContent)
 }
 
-func (sb *sandbox) updateHostsFile(ifaceIP string) error {
-	if ifaceIP == "" {
+func (sb *sandbox) updateHostsFile(ifaceIPs []string) error {
+	if ifaceIPs == nil || len(ifaceIPs) == 0 {
 		return nil
 	}
 
@@ -120,7 +120,10 @@ func (sb *sandbox) updateHostsFile(ifaceIP string) error {
 		mhost = fmt.Sprintf("%s %s", fqdn, parts[0])
 	}
 
-	extraContent := []etchosts.Record{{Hosts: mhost, IP: ifaceIP}}
+	var extraContent []etchosts.Record
+	for _, ip := range ifaceIPs {
+		extraContent = append(extraContent, etchosts.Record{Hosts: mhost, IP: ip})
+	}
 
 	sb.addHostsEntries(extraContent)
 	return nil

--- a/vendor/github.com/docker/libnetwork/sandbox_dns_windows.go
+++ b/vendor/github.com/docker/libnetwork/sandbox_dns_windows.go
@@ -18,7 +18,7 @@ func (sb *sandbox) setupResolutionFiles() error {
 func (sb *sandbox) restorePath() {
 }
 
-func (sb *sandbox) updateHostsFile(ifaceIP string) error {
+func (sb *sandbox) updateHostsFile(ifaceIP []string) error {
 	return nil
 }
 


### PR DESCRIPTION
Commits:
feeff4f0 Merge pull request #2380 from liskin/bridge-atomic-hwaddr
fec6476d Merge pull request #2489 from suwang48404/doc
8757597e Added document describing libnetwork traffic flow.
eaea5722 Merge pull request #2445 from kdomanski/ipv6-addr-in-hosts
1680ce71 Merge pull request #2462 from arkodg/fix-key-spi-panic
4420ee92 Fix panic in drivers/overlay/encryption.go
57178323 Merge pull request #2472 from thaJeztah/bump_golang_1.12.12
f741dc9c Update Golang 1.12.12 (CVE-2019-17596)
79c19d09 Merge pull request #2461 from suwang48404/master
94facacc Added API to set ephemeral port allocator range.

Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>