### PR TITLE
hack/make/.go-autogen: fix typo in LDFLAGS variable

### DIFF
--- a/hack/make/.go-autogen
+++ b/hack/make/.go-autogen
@@ -6,7 +6,7 @@ source hack/dockerfile/install/runc.installer
 source hack/dockerfile/install/tini.installer
 source hack/dockerfile/install/containerd.installer
 
-LDFLAGS="${LDFALGS} \
+LDFLAGS="${LDFLAGS} \
 	-X github.com/docker/docker/dockerversion.Version=${VERSION} \
 	-X github.com/docker/docker/dockerversion.GitCommit=${GITCOMMIT} \
 	-X github.com/docker/docker/dockerversion.BuildTime=${BUILDTIME} \


### PR DESCRIPTION
Introduced in https://github.com/moby/moby/commit/675b414f56063826457cbc8f0c165af67198bfa8 (https://github.com/moby/moby/pull/40180)

