### PR TITLE
enforce reserve internal labels.

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -326,19 +326,6 @@ func (cli *DaemonCli) reloadConfig() {
 		}
 		cli.authzMiddleware.SetPlugins(c.AuthorizationPlugins)
 
-		// The namespaces com.docker.*, io.docker.*, org.dockerproject.* have been documented
-		// to be reserved for Docker's internal use, but this was never enforced.  Allowing
-		// configured labels to use these namespaces are deprecated for 18.05.
-		//
-		// The following will check the usage of such labels, and report a warning for deprecation.
-		//
-		// TODO: At the next stable release, the validation should be folded into the other
-		// configuration validation functions and an error will be returned instead, and this
-		// block should be deleted.
-		if err := config.ValidateReservedNamespaceLabels(c.Labels); err != nil {
-			logrus.Warnf("Configured labels using reserved namespaces is deprecated: %s", err)
-		}
-
 		if err := cli.d.Reload(c); err != nil {
 			logrus.Errorf("Error reconfiguring the daemon: %v", err)
 			return
@@ -445,18 +432,6 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 	newLabels, err := config.GetConflictFreeLabels(conf.Labels)
 	if err != nil {
 		return nil, err
-	}
-	// The namespaces com.docker.*, io.docker.*, org.dockerproject.* have been documented
-	// to be reserved for Docker's internal use, but this was never enforced.  Allowing
-	// configured labels to use these namespaces are deprecated for 18.05.
-	//
-	// The following will check the usage of such labels, and report a warning for deprecation.
-	//
-	// TODO: At the next stable release, the validation should be folded into the other
-	// configuration validation functions and an error will be returned instead, and this
-	// block should be deleted.
-	if err := config.ValidateReservedNamespaceLabels(newLabels); err != nil {
-		logrus.Warnf("Configured labels using reserved namespaces is deprecated: %s", err)
 	}
 	conf.Labels = newLabels
 

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -308,25 +308,6 @@ func GetConflictFreeLabels(labels []string) ([]string, error) {
 	return newLabels, nil
 }
 
-// ValidateReservedNamespaceLabels errors if the reserved namespaces com.docker.*,
-// io.docker.*, org.dockerproject.* are used in a configured engine label.
-//
-// TODO: This is a separate function because we need to warn users first of the
-// deprecation.  When we return an error, this logic can be added to Validate
-// or GetConflictFreeLabels instead of being here.
-func ValidateReservedNamespaceLabels(labels []string) error {
-	for _, label := range labels {
-		lowered := strings.ToLower(label)
-		if strings.HasPrefix(lowered, "com.docker.") || strings.HasPrefix(lowered, "io.docker.") ||
-			strings.HasPrefix(lowered, "org.dockerproject.") {
-			return fmt.Errorf(
-				"label %s not allowed: the namespaces com.docker.*, io.docker.*, and org.dockerproject.* are reserved for Docker's internal use",
-				label)
-		}
-	}
-	return nil
-}
-
 // Reload reads the configuration in the host and reloads the daemon and server.
 func Reload(configFile string, flags *pflag.FlagSet, reload func(*Config)) error {
 	logrus.Infof("Got signal to reload configuration, reloading from: %s", configFile)

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -188,40 +188,6 @@ func TestFindConfigurationConflictsWithMergedValues(t *testing.T) {
 	}
 }
 
-func TestValidateReservedNamespaceLabels(t *testing.T) {
-	for _, validLabels := range [][]string{
-		nil, // no error if there are no labels
-		{ // no error if there aren't any reserved namespace labels
-			"hello=world",
-			"label=me",
-		},
-		{ // only reserved namespaces that end with a dot are invalid
-			"com.dockerpsychnotreserved.label=value",
-			"io.dockerproject.not=reserved",
-			"org.docker.not=reserved",
-		},
-	} {
-		assert.Check(t, ValidateReservedNamespaceLabels(validLabels))
-	}
-
-	for _, invalidLabel := range []string{
-		"com.docker.feature=enabled",
-		"io.docker.configuration=0",
-		"org.dockerproject.setting=on",
-		// casing doesn't matter
-		"COM.docker.feature=enabled",
-		"io.DOCKER.CONFIGURATION=0",
-		"Org.Dockerproject.Setting=on",
-	} {
-		err := ValidateReservedNamespaceLabels([]string{
-			"valid=label",
-			invalidLabel,
-			"another=valid",
-		})
-		assert.Check(t, is.ErrorContains(err, invalidLabel))
-	}
-}
-
 func TestValidateConfigurationErrors(t *testing.T) {
 	intPtr := func(i int) *int { return &i }
 

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -254,12 +254,23 @@ func validateDomain(val string) (string, error) {
 	return "", fmt.Errorf("%s is not a valid domain", val)
 }
 
-// ValidateLabel validates that the specified string is a valid label, and returns it.
+// ValidateLabel validates that the specified string is a valid label,
+// it does not use the reserved namespaces com.docker.*, io.docker.*, org.dockerproject.*
+// and returns it.
 // Labels are in the form on key=value.
 func ValidateLabel(val string) (string, error) {
 	if strings.Count(val, "=") < 1 {
 		return "", fmt.Errorf("bad attribute format: %s", val)
 	}
+
+	lowered := strings.ToLower(val)
+	if strings.HasPrefix(lowered, "com.docker.") || strings.HasPrefix(lowered, "io.docker.") ||
+		strings.HasPrefix(lowered, "org.dockerproject.") {
+		return "", fmt.Errorf(
+			"label %s is not allowed: the namespaces com.docker.*, io.docker.*, and org.dockerproject.* are reserved for internal use",
+			val)
+	}
+
 	return val, nil
 }
 


### PR DESCRIPTION
The namespaces com.docker.*, io.docker.*, org.dockerproject.*
have been documented to be reserved for Docker's internal use.

Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**


**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Enforce reserve internal labels.

**- A picture of a cute animal (not mandatory but encouraged)**

