### PR TITLE
Remove Extra Space in Code Comment in ping.go

### DIFF
--- a/client/ping.go
+++ b/client/ping.go
@@ -17,7 +17,7 @@ func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 	var ping types.Ping
 
 	// Using cli.buildRequest() + cli.doRequest() instead of cli.sendRequest()
-	// because ping requests are used during  API version negotiation, so we want
+	// because ping requests are used during API version negotiation, so we want
 	// to hit the non-versioned /_ping endpoint, not /v1.xx/_ping
 	req, err := cli.buildRequest(http.MethodHead, path.Join(cli.basePath, "/_ping"), nil, nil)
 	if err != nil {


### PR DESCRIPTION
**- What I did**

Removed extra space in code comment from `ping.go`. Noticed it while looking through source of `Ping(ctx *context.Context)`. 

**- Description for the changelog**

Removed extra space from code comment in `ping.go`

