### PR TITLE
dockerd-rootless.sh: remove confusing code comment

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -3,8 +3,6 @@
 #
 # Usage: dockerd-rootless.sh --experimental [DOCKERD_OPTIONS]
 # Currently, specifying --experimental is mandatory.
-# Also, to expose ports, you need to specify
-# --userland-proxy-path=/path/to/rootlesskit-docker-proxy
 #
 # External dependencies:
 # * newuidmap and newgidmap needs to be installed.


### PR DESCRIPTION
`--userland-proxy-path` is automatically set by dockerd: https://github.com/moby/moby/blob/e6c1820ef5de8c198b4ddec74440a7ea7b331194/cmd/dockerd/config_unix.go#L46
