### PR TITLE
[19.03 backport] update containerd binary v1.3.7

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: ${CONTAINERD_COMMIT:=36cf5b690dcc00ff0f34ff7799209050c3d0c59a} # v1.3.0
+: ${CONTAINERD_COMMIT:=c7a4f874b3267c499484aae602d1257b12d69e40} # v1.3.1
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: ${CONTAINERD_COMMIT:=ff48f57fc83a8c44cf4ad5d672424a98ba37ded6} # v1.3.2
+: "${CONTAINERD_COMMIT:=d76c121f76a5fc8a462dc64594aea72fe18e1178}" # v1.3.3
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: ${CONTAINERD_COMMIT:=c7a4f874b3267c499484aae602d1257b12d69e40} # v1.3.1
+: ${CONTAINERD_COMMIT:=ff48f57fc83a8c44cf4ad5d672424a98ba37ded6} # v1.3.2
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: ${CONTAINERD_COMMIT:=7ad184331fa3e55e52b890ea95e65ba581ae3429} # v1.2.13
+: ${CONTAINERD_COMMIT:=36cf5b690dcc00ff0f34ff7799209050c3d0c59a} # v1.3.0
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=9b6f3ec0307a825c38617b93ad55162b5bb94234}" # v1.3.5
+: "${CONTAINERD_COMMIT:=be75852b8d7849474a20192f9ed1bf34fdd454f1}" # v1.3.6
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=be75852b8d7849474a20192f9ed1bf34fdd454f1}" # v1.3.6
+: "${CONTAINERD_COMMIT:=8fba4e9a7d01810a393d5d25a3621dc101981175}" # v1.3.7
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=814b7956fafc7a0980ea07e950f983d0837e5578}" # v1.3.4
+: "${CONTAINERD_COMMIT:=9b6f3ec0307a825c38617b93ad55162b5bb94234}" # v1.3.5
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=d76c121f76a5fc8a462dc64594aea72fe18e1178}" # v1.3.3
+: "${CONTAINERD_COMMIT:=814b7956fafc7a0980ea07e950f983d0837e5578}" # v1.3.4
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
moved from https://github.com/docker/engine/pull/421

back ports of updating the containerd binaries from:

- https://github.com/moby/moby/pull/39713 bump containerd and dependencies to v1.3.0
- https://github.com/moby/moby/pull/40295 Update containerd to v1.3.2
- https://github.com/moby/moby/pull/40469 update containerd binary to v1.3.3
- https://github.com/moby/moby/pull/40822 update containerd to v1.3.4
- https://github.com/moby/moby/pull/41159 update containerd to v1.3.5
- https://github.com/moby/moby/pull/41169 update containerd to v1.3.6
- https://github.com/moby/moby/pull/41310 update containerd to v1.3.7


this is to see if integration tests work fine if we would update the existing 19.03 version to the latest containerd

full diff: https://github.com/containerd/containerd/compare/v1.2.13..v1.3.7

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
