### PR TITLE
[19.03 backport] Added garbage collector for image layers

### DIFF
--- a/integration/image/remove_unix_test.go
+++ b/integration/image/remove_unix_test.go
@@ -1,0 +1,88 @@
+// +build !windows
+
+package image // import "github.com/docker/docker/integration/image"
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"syscall"
+	"testing"
+	"unsafe"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/internal/test/daemon"
+	"github.com/docker/docker/internal/test/fakecontext"
+	"gotest.tools/assert"
+	"gotest.tools/skip"
+)
+
+// This is a regression test for #38488
+// It ensures that orphan layers can be found and cleaned up
+// after unsuccessful image removal
+func TestRemoveImageGarbageCollector(t *testing.T) {
+	// This test uses very platform specific way to prevent
+	// daemon for remove image layer.
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, os.Getenv("DOCKER_ENGINE_GOARCH") != "amd64")
+
+	// Create daemon with overlay2 graphdriver because vfs uses disk differently
+	// and this test case would not work with it.
+	d := daemon.New(t, daemon.WithStorageDriver("overlay2"), daemon.WithImageService)
+	d.Start(t)
+	defer d.Stop(t)
+
+	ctx := context.Background()
+	client := d.NewClientT(t)
+	i := d.ImageService()
+
+	img := "test-garbage-collector"
+
+	// Build a image with multiple layers
+	dockerfile := `FROM busybox
+	RUN echo echo Running... > /run.sh`
+	source := fakecontext.New(t, "", fakecontext.WithDockerfile(dockerfile))
+	defer source.Close()
+	resp, err := client.ImageBuild(ctx,
+		source.AsTarReader(t),
+		types.ImageBuildOptions{
+			Remove:      true,
+			ForceRemove: true,
+			Tags:        []string{img},
+		})
+	assert.NilError(t, err)
+	_, err = io.Copy(ioutil.Discard, resp.Body)
+	resp.Body.Close()
+	assert.NilError(t, err)
+	image, _, err := client.ImageInspectWithRaw(ctx, img)
+	assert.NilError(t, err)
+
+	// Mark latest image layer to immutable
+	data := image.GraphDriver.Data
+	file, _ := os.Open(data["UpperDir"])
+	attr := 0x00000010
+	fsflags := uintptr(0x40086602)
+	argp := uintptr(unsafe.Pointer(&attr))
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, file.Fd(), fsflags, argp)
+	assert.Equal(t, "errno 0", errno.Error())
+
+	// Try to remove the image, it should generate error
+	// but marking layer back to mutable before checking errors (so we don't break CI server)
+	_, err = client.ImageRemove(ctx, img, types.ImageRemoveOptions{})
+	attr = 0x00000000
+	argp = uintptr(unsafe.Pointer(&attr))
+	_, _, errno = syscall.Syscall(syscall.SYS_IOCTL, file.Fd(), fsflags, argp)
+	assert.Equal(t, "errno 0", errno.Error())
+	assert.ErrorContains(t, err, "permission denied")
+
+	// Verify that layer remaining on disk
+	dir, _ := os.Stat(data["UpperDir"])
+	assert.Equal(t, "true", strconv.FormatBool(dir.IsDir()))
+
+	// Run imageService.Cleanup() and make sure that layer was removed from disk
+	i.Cleanup()
+	dir, err = os.Stat(data["UpperDir"])
+	assert.ErrorContains(t, err, "no such file or directory")
+}

--- a/integration/image/remove_unix_test.go
+++ b/integration/image/remove_unix_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"unsafe"
@@ -75,7 +76,11 @@ func TestRemoveImageGarbageCollector(t *testing.T) {
 	argp = uintptr(unsafe.Pointer(&attr))
 	_, _, errno = syscall.Syscall(syscall.SYS_IOCTL, file.Fd(), fsflags, argp)
 	assert.Equal(t, "errno 0", errno.Error())
-	assert.ErrorContains(t, err, "permission denied")
+	assert.Assert(t, err != nil)
+	errStr := err.Error()
+	if !(strings.Contains(errStr, "permission denied") || strings.Contains(errStr, "operation not permitted")) {
+		t.Errorf("ImageRemove error not an permission error %s", errStr)
+	}
 
 	// Verify that layer remaining on disk
 	dir, _ := os.Stat(data["UpperDir"])

--- a/internal/test/daemon/daemon.go
+++ b/internal/test/daemon/daemon.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/internal/test"
 	"github.com/docker/docker/internal/test/request"
 	"github.com/docker/docker/opts"
@@ -77,6 +78,7 @@ type Daemon struct {
 	init          bool
 	dockerdBinary string
 	log           logT
+	imageService  *images.ImageService
 
 	// swarm related field
 	swarmListenAddr string
@@ -719,4 +721,9 @@ func cleanupRaftDir(t testingT, rootPath string) {
 			t.Logf("error removing %v: %v", dir, err)
 		}
 	}
+}
+
+// ImageService returns the Daemon's ImageService
+func (d *Daemon) ImageService() *images.ImageService {
+	return d.imageService
 }

--- a/internal/test/daemon/ops.go
+++ b/internal/test/daemon/ops.go
@@ -63,3 +63,10 @@ func WithEnvironment(e environment.Execution) func(*Daemon) {
 		}
 	}
 }
+
+// WithStorageDriver sets store driver option
+func WithStorageDriver(driver string) func(d *Daemon) {
+	return func(d *Daemon) {
+		d.storageDriver = driver
+	}
+}

--- a/internal/test/daemon/ops_unix.go
+++ b/internal/test/daemon/ops_unix.go
@@ -1,0 +1,34 @@
+// +build !windows
+
+package daemon
+
+import (
+	"path/filepath"
+	"runtime"
+
+	"github.com/docker/docker/daemon/images"
+	"github.com/docker/docker/layer"
+
+	// register graph drivers
+	_ "github.com/docker/docker/daemon/graphdriver/register"
+	"github.com/docker/docker/pkg/idtools"
+)
+
+// WithImageService sets imageService options
+func WithImageService(d *Daemon) {
+	layerStores := make(map[string]layer.Store)
+	os := runtime.GOOS
+	layerStores[os], _ = layer.NewStoreFromOptions(layer.StoreOptions{
+		Root:                      d.Root,
+		MetadataStorePathTemplate: filepath.Join(d.RootDir(), "image", "%s", "layerdb"),
+		GraphDriver:               d.storageDriver,
+		GraphDriverOptions:        nil,
+		IDMapping:                 &idtools.IdentityMapping{},
+		PluginGetter:              nil,
+		ExperimentalEnabled:       false,
+		OS:                        os,
+	})
+	d.imageService = images.NewImageService(images.ImageServiceConfig{
+		LayerStores: layerStores,
+	})
+}

--- a/layer/filestore_test.go
+++ b/layer/filestore_test.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -100,5 +101,52 @@ func TestStartTransactionFailure(t *testing.T) {
 
 	if err := tx.Cancel(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestGetOrphan(t *testing.T) {
+	fms, td, cleanup := newFileMetadataStore(t)
+	defer cleanup()
+
+	layerRoot := filepath.Join(td, "sha256")
+	if err := os.MkdirAll(layerRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := fms.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	layerid := randomLayerID(5)
+	err = tx.Commit(layerid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	layerPath := fms.getLayerDirectory(layerid)
+	if err := ioutil.WriteFile(filepath.Join(layerPath, "cache-id"), []byte(stringid.GenerateRandomID()), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	orphanLayers, err := fms.getOrphan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(orphanLayers) != 0 {
+		t.Fatalf("Expected to have zero orphan layers")
+	}
+
+	layeridSplit := strings.Split(layerid.String(), ":")
+	newPath := filepath.Join(layerRoot, fmt.Sprintf("%s-%s-removing", layeridSplit[1], stringid.GenerateRandomID()))
+	err = os.Rename(layerPath, newPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	orphanLayers, err = fms.getOrphan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(orphanLayers) != 1 {
+		t.Fatalf("Expected to have one orphan layer")
 	}
 }


### PR DESCRIPTION
moved from https://github.com/docker/engine/pull/268

backport of

- [x] https://github.com/moby/moby/pull/39193 Added garbage collector for image layers
- [x] https://github.com/moby/moby/pull/39862 Implement code review comments in 39748
  - replaces https://github.com/moby/moby/pull/39748 Avoid using invalid value of cacheID on fail path
- [x] https://github.com/moby/moby/pull/39591 Add extra permission check in removal test
- [x] https://github.com/moby/moby/pull/39715 Unit test for getOrphan

Minor conflict because https://github.com/moby/moby/commit/072400fc4b8d6a38a2007d41072b765666a4c288 (https://github.com/moby/moby/pull/38377) is not in the 19.03 branch;

```patch
diff --cc internal/test/daemon/daemon.go
index bb8451db8c,4705d2f4ee..0000000000
--- a/internal/test/daemon/daemon.go
+++ b/internal/test/daemon/daemon.go
@@@ -60,16 -61,18 +61,31 @@@ type Daemon struct
        UseDefaultHost    bool
        UseDefaultTLSHost bool

++<<<<<<< HEAD
 +      id            string
 +      logFile       *os.File
 +      cmd           *exec.Cmd
 +      storageDriver string
 +      userlandProxy bool
 +      execRoot      string
 +      experimental  bool
 +      init          bool
 +      dockerdBinary string
 +      log           logT
++=======
+       id                         string
+       logFile                    *os.File
+       cmd                        *exec.Cmd
+       storageDriver              string
+       userlandProxy              bool
+       defaultCgroupNamespaceMode string
+       execRoot                   string
+       experimental               bool
+       init                       bool
+       dockerdBinary              string
+       log                        logT
+       imageService               *images.ImageService
++>>>>>>> 213681b66a... First step to implement full garbage collector for image layers

        // swarm related field
        swarmListenAddr string
```





**- What I did**
Added garbage collector for image layers

Closes #38488 and most probably #39247 too.
and with #38401 also https://github.com/docker/for-win/issues/745

**- How I did it**
Added logic which marks layers to be under removal by renaming layer digest folder to contain **-\<int\>-removing** suffix. That way we are able keep track that which layers are not anymore complete (=> which need to be re-downloaded if needed) and we are also able run clean up routine for those. 

**- How to verify it**
Reproduce issue like it is described on #38488
also notice bug with missing content on comment https://github.com/moby/moby/issues/38488#issuecomment-492801678

Run daemon on debug mode and stop it.

You will see log like this and orphan layer will disappear from disk.
```
DEBU[2019-05-17T02:22:21.349871543+03:00] start clean shutdown of all containers with a 15 seconds timeout... 
DEBU[2019-05-17T02:22:21.350859348+03:00] found 2 orphan layers                        
DEBU[2019-05-17T02:22:21.350918187+03:00] removing orphan layer, chain ID: sha256:3fc64803ca2de7279269048fe2b8b3c73d4536448c87c32375b2639ac168a48b , cache ID: 5ccabfe0f839144bcbb30b7eae3d65e89fd93e34b411a9ba37b753c6cadc939c 
DEBU[2019-05-17T02:22:21.352871349+03:00] Removing folder: /var/lib/docker/image/overlay2/layerdb/sha256/3fc64803ca2de7279269048fe2b8b3c73d4536448c87c32375b2639ac168a48b-0-removing 
DEBU[2019-05-17T02:22:21.353409212+03:00] Removing folder: /var/lib/docker/image/overlay2/layerdb/sha256/3fc64803ca2de7279269048fe2b8b3c73d4536448c87c32375b2639ac168a48b-1-removing 
DEBU[2019-05-17T02:22:21.353901755+03:00] removing orphan layer, chain ID: sha256:3fc64803ca2de7279269048fe2b8b3c73d4536448c87c32375b2639ac168a48b , cache ID: 4594ad5ca4f2ae9046141506d857fe9e94d68727809813d653b98353a43dd5fc 
DEBU[2019-05-17T02:22:21.356055301+03:00] Unix socket /var/run/docker/libnetwork/60b87c485747cb08641761e12ba27e169f4a9430efd4748121f1ce4d0fd3d536.sock doesn't exist. cannot accept client connections 
DEBU[2019-05-17T02:22:21.356174192+03:00] Cleaning up old mountid : start.             
INFO[2019-05-17T02:22:21.356225827+03:00] stopping event stream following graceful shutdown  error="<nil>" module=libcontainerd namespace=moby
DEBU[2019-05-17T02:22:21.356871850+03:00] Cleaning up old mountid : done.              
DEBU[2019-05-17T02:22:21.357264017+03:00] Clean shutdown succeeded 
```

and if you do same test on Windows this is what you will see:
```
time="2019-05-16T23:31:11.505667200Z" level=debug msg="start clean shutdown of all containers with a 35 seconds timeout..."
time="2019-05-16T23:31:11.510504700Z" level=debug msg="found 1 orphan layers"
time="2019-05-16T23:31:11.511193900Z" level=debug msg="removing orphan layer, chain ID: sha256:cc83dc73fcbf0e8b0ce6bce79e23643e9ffc7773af69f831e7d1f2f5764d44b2 , cache ID: bc365c16a135afa6ee813b7f550d7723d135157a0080dc1c25489314f938b656"
time="2019-05-16T23:31:11.511193900Z" level=debug msg="hcsshim::GetComputeSystems - Begin Operation"
time="2019-05-16T23:31:11.512310200Z" level=debug msg="HCS ComputeSystem Query" json="{}"
time="2019-05-16T23:31:11.513192900Z" level=debug msg="hcsshim::GetComputeSystems - End Operation - Success"
time="2019-05-16T23:31:11.514189800Z" level=debug msg="hcsshim::DestroyLayer" path="C:\\ProgramData\\docker\\windowsfilter\\bc365c16a135afa6ee813b7f550d7723d135157a0080dc1c25489314f938b656-removing"
time="2019-05-16T23:31:11.678774400Z" level=debug msg="hcsshim::DestroyLayer - succeeded" path="C:\\ProgramData\\docker\\windowsfilter\\bc365c16a135afa6ee813b7f550d7723d135157a0080dc1c25489314f938b656-removing"
time="2019-05-16T23:31:11.678774400Z" level=debug msg="Removing folder: C:\\ProgramData\\docker\\image\\windowsfilter\\layerdb\\sha256\\cc83dc73fcbf0e8b0ce6bce79e23643e9ffc7773af69f831e7d1f2f5764d44b2-0-removing"
time="2019-05-16T23:31:11.687751900Z" level=debug msg="Clean shutdown succeeded"
```

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6213926/57404181-09a80800-71e4-11e9-9c4a-2f870d289b8d.png)