### PR TITLE
Remove 'deny mount' in the apparmor template

### DIFF
--- a/profiles/apparmor/template.go
+++ b/profiles/apparmor/template.go
@@ -32,8 +32,6 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   deny @{PROC}/sysrq-trigger rwklx,
   deny @{PROC}/kcore rwklx,
 
-  deny mount,
-
   deny /sys/[^f]*/** wklx,
   deny /sys/f[^s]*/** wklx,
   deny /sys/fs/[^c]*/** wklx,


### PR DESCRIPTION
Fixes issue #40421 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Make use of mount(2) controllable entirely through the seccomp mechanism.

**- How I did it**
This commit removes `deny mount` from `profiles/apparmor/template.go`, so use of `mount(2)` can be controlled entirely by capabilities and seccomp profiles.

**- How to verify it**

1. Start a container which uses `mount(2)` with `CAP_SYS_ADMIN`:
```
$ docker run -it --rm --cap-add=sys_admin --device=/dev/fuse quay.io/buildah/stable:v1.12.0
```

2. Ensure that applications relying on `mount(2)` work:
```
[root@569b80ed8c15 /]# buildah from alpine
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
`mount(2)` is now gated solely by seccomp


**- A picture of a cute animal (not mandatory but encouraged)**

![](https://1.bp.blogspot.com/-cyEvO4ydWaQ/TdWhf7YSk3I/AAAAAAAAALw/gmE0j7lByQs/s1600/4886047043_39be3343c5_b.jpg)

Signed-off-by: Daniel Ferenczi <daniel.ferenczi@protonmail.com>
