### PR TITLE
Do not require "experimental" for metrics API

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -204,8 +204,8 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 
 	cli.d = d
 
-	if err := cli.startMetricsServer(cli.Config.MetricsAddress); err != nil {
-		return err
+	if err := startMetricsServer(cli.Config.MetricsAddress); err != nil {
+		return errors.Wrap(err, "failed to start metrics server")
 	}
 
 	c, err := createAndStartCluster(cli, d)

--- a/daemon/metrics_unix.go
+++ b/daemon/metrics_unix.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/pkg/plugins"
@@ -28,7 +29,10 @@ func (daemon *Daemon) listenMetricsSock() (string, error) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", metrics.Handler())
 	go func() {
-		http.Serve(l, mux)
+		logrus.Debugf("metrics API listening on %s", l.Addr())
+		if err := http.Serve(l, mux); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			logrus.WithError(err).Error("error serving metrics API")
+		}
 	}()
 	daemon.metricsPluginListener = l
 	return path, nil


### PR DESCRIPTION
This removes the requirement to enable experimental on the daemon to expose the prometheus metrics
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

