### PR TITLE
Fix windows cross builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -354,6 +354,7 @@ FROM binary-base AS build-cross
 ARG DOCKER_CROSSPLATFORMS
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,target=/go/src/github.com/docker/docker \
+    --mount=type=tmpfs,target=/go/src/github.com/docker/docker/autogen \
         hack/make.sh cross
 
 FROM scratch AS binary

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,14 @@ cross: ## cross build the binaries for darwin, freebsd and\nwindows
 
 cross: BUILD_OPTS += --build-arg CROSS=true --build-arg DOCKER_CROSSPLATFORMS
 
-binary dynbinary cross: buildx
+# This is only used to work around read-only bind mounts of the source code into
+# binary build targets. We end up mounting a tmpfs over autogen which allows us
+# to write build-time generated assets even though the source is mounted read-only
+# ...But in order to do so, this dir needs to already exist.
+autogen:
+	mkdir -p autogen
+
+binary dynbinary cross: buildx autogen
 	$(BUILD_CMD) $(BUILD_OPTS) --output=bundles/ --target=$@ $(VERSION_AUTOGEN_ARGS) .
 
 build: target = --target=final

--- a/hack/make/.go-autogen
+++ b/hack/make/.go-autogen
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-rm -rf autogen
+rm -rf autogen/*
 
 source hack/dockerfile/install/runc.installer
 source hack/dockerfile/install/tini.installer


### PR DESCRIPTION
Windows still writes to the autogen directory, but the source code is
mounted in as read-only.
In order to do enable this without taking a massive hit in doing an rw
mount (for the source code) we mount a tmpfs into the build at the
autogen dir.
In order for this to work the directory must alreay exist, so we create
it before entering the build.

Fixes #40438