### PR TITLE
Fix docker ps --filter publish

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -551,23 +551,19 @@ func includeContainerInList(container *container.Snapshot, ctx *listContext) ite
 		}
 	}
 
-	if len(ctx.publish) > 0 {
-		shouldSkip := true
-		for port := range ctx.publish {
-			if _, ok := container.PortBindings[port]; ok {
+	if len(ctx.expose) > 0 || len(ctx.publish) > 0 {
+		var (
+			shouldSkip    bool = true
+			publishedPort nat.Port
+			exposedPort   nat.Port
+		)
+		for _, port := range container.Ports {
+			publishedPort = nat.Port(fmt.Sprintf("%d/%s", port.PublicPort, port.Type))
+			exposedPort = nat.Port(fmt.Sprintf("%d/%s", port.PrivatePort, port.Type))
+			if ok := ctx.publish[publishedPort]; ok {
 				shouldSkip = false
 				break
-			}
-		}
-		if shouldSkip {
-			return excludeContainer
-		}
-	}
-
-	if len(ctx.expose) > 0 {
-		shouldSkip := true
-		for port := range ctx.expose {
-			if _, ok := container.ExposedPorts[port]; ok {
+			} else if ok := ctx.expose[exposedPort]; ok {
 				shouldSkip = false
 				break
 			}

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -816,29 +816,44 @@ func (s *DockerSuite) TestPsListContainersFilterPorts(c *testing.T) {
 	out, _ = dockerCmd(c, "run", "-d", "--expose=8080", "busybox", "top")
 	id2 := strings.TrimSpace(out)
 
+	out, _ = dockerCmd(c, "run", "-d", "-p", "1090:90", "busybox", "top")
+	id3 := strings.TrimSpace(out)
+
 	out, _ = dockerCmd(c, "ps", "--no-trunc", "-q")
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id1))
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
+	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id3))
+
 	out, _ = dockerCmd(c, "ps", "--no-trunc", "-q", "--filter", "publish=80-8080/udp")
 	assert.Assert(c, strings.TrimSpace(out) != id1)
 	assert.Assert(c, strings.TrimSpace(out) != id2)
+	assert.Assert(c, strings.TrimSpace(out) != id3)
 
 	out, _ = dockerCmd(c, "ps", "--no-trunc", "-q", "--filter", "expose=8081")
 	assert.Assert(c, strings.TrimSpace(out) != id1)
 	assert.Assert(c, strings.TrimSpace(out) != id2)
+	assert.Assert(c, strings.TrimSpace(out) != id3)
 
 	out, _ = dockerCmd(c, "ps", "--no-trunc", "-q", "--filter", "publish=80-81")
-	assert.Equal(c, strings.TrimSpace(out), id1)
+	assert.Assert(c, strings.TrimSpace(out) != id1)
 	assert.Assert(c, strings.TrimSpace(out) != id2)
+	assert.Assert(c, strings.TrimSpace(out) != id3)
 
 	out, _ = dockerCmd(c, "ps", "--no-trunc", "-q", "--filter", "expose=80/tcp")
 	assert.Equal(c, strings.TrimSpace(out), id1)
 	assert.Assert(c, strings.TrimSpace(out) != id2)
+	assert.Assert(c, strings.TrimSpace(out) != id3)
+
+	out, _ = dockerCmd(c, "ps", "--no-trunc", "-q", "--filter", "publish=1090")
+	assert.Assert(c, strings.TrimSpace(out) != id1)
+	assert.Assert(c, strings.TrimSpace(out) != id2)
+	assert.Equal(c, strings.TrimSpace(out), id3)
 
 	out, _ = dockerCmd(c, "ps", "--no-trunc", "-q", "--filter", "expose=8080/tcp")
 	out = RemoveOutputForExistingElements(out, existingContainers)
 	assert.Assert(c, strings.TrimSpace(out) != id1)
 	assert.Equal(c, strings.TrimSpace(out), id2)
+	assert.Assert(c, strings.TrimSpace(out) != id3)
 }
 
 func (s *DockerSuite) TestPsNotShowLinknamesOfDeletedContainer(c *testing.T) {


### PR DESCRIPTION


**- What I did**
Fixed the filter on published ports when using the command `docker ps --filter publish`

**- How I did it**

I checked on `PublicPort` value inside `container.Ports` instead of `types.Snapshot.PublishedPorts`.

I also did the same on `--filter expose`. I checked on `PrivatePort` instead on `types.Snapshot.ExposedPorts`

**- How to verify it**
I followed the same steps like #40405 

First, create some test containers:

```docker run -d --name test_no_ports nginx:alpine
docker run -d --name test_port_1080 -p 1080:80 nginx:alpine
docker run -d --name test_port_1090 -p 1090:80 nginx:alpine
docker run -d --name test_port_80_random -p 80 nginx:alpine
docker run -d --name test_port_all_random -P nginx:alpine


docker ps --filter name=test_

CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                   NAMES
3ce8232cdd04        nginx:alpine        "nginx -g 'daemon of…"   6 seconds ago       Up 6 seconds        0.0.0.0:32775->80/tcp   test_port_all_random
7f8fad7a0eb9        nginx:alpine        "nginx -g 'daemon of…"   7 seconds ago       Up 6 seconds        0.0.0.0:32774->80/tcp   test_port_80_random
3870ccc2f8f7        nginx:alpine        "nginx -g 'daemon of…"   7 seconds ago       Up 6 seconds        0.0.0.0:1090->80/tcp    test_port_1090
aa565211513e        nginx:alpine        "nginx -g 'daemon of…"   8 seconds ago       Up 7 seconds        0.0.0.0:1080->80/tcp    test_port_1080
c4a1c6e0e99b        nginx:alpine        "nginx -g 'daemon of…"   8 seconds ago       Up 7 seconds        80/tcp                  test_no_ports
```

Now, if you filter on publish ports:

```

docker ps --filter name=test_ --filter publish=1090
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                 NAME
3870ccc2f8f7        nginx:alpine        "nginx -g 'daemon of…"   21 seconds ago      Up 20 seconds       0.0.0.0:1090->80/tcp    test_port_1090

```

We can find that the filter is applied successfully

**- Description for the changelog**
fix filter on `docker ps --filter publish`. Also change `docker ps --filter expose`

**- A picture of a cute animal (not mandatory but encouraged)**



Fixes #40405 