### PR TITLE
Add vpnkit back to binary targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -338,6 +338,7 @@ COPY --from=runc        /build/ /usr/local/bin/
 COPY --from=containerd  /build/ /usr/local/bin/
 COPY --from=rootlesskit /build/ /usr/local/bin/
 COPY --from=proxy       /build/ /usr/local/bin/
+COPY --from=vpnkit      /vpnkit /usr/local/bin/vpnkit.x86_64
 WORKDIR /go/src/github.com/docker/docker
 
 FROM binary-base AS build-binary


### PR DESCRIPTION
This was removed after refactoring the Dockerfile in #40180

Related to #40459