### PR TITLE
TestResumableRequestHeaderTooMuchFailures: prepare for Go 1.14 changes

### DIFF
--- a/registry/resumable/resumablerequestreader_test.go
+++ b/registry/resumable/resumablerequestreader_test.go
@@ -75,9 +75,10 @@ func TestResumableRequestHeaderTooMuchFailures(t *testing.T) {
 	}
 	defer resreq.Close()
 
-	expectedError := `Get I%27m%20not%20an%20url: unsupported protocol scheme ""`
 	read, err := resreq.Read([]byte{})
-	assert.Check(t, is.Error(err, expectedError))
+	assert.Assert(t, err != nil)
+	assert.Check(t, is.ErrorContains(err, "unsupported protocol scheme"))
+	assert.Check(t, is.ErrorContains(err, "I%27m%20not%20an%20url"))
 	assert.Check(t, is.Equal(0, read))
 }
 


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/40434
relates to https://github.com/moby/moby/pull/40353

Go 1.14 adds quotes around the invalid scheme in the error returned (See golang/go@64cfe9f and golang/go#29261)

Go 1.13:

    Get I%27m%20not%20an%20url: unsupported protocol scheme ""

Go 1.14:

    Get "I%27m%20not%20an%20url": unsupported protocol scheme ""

This patch updates the test to detect both versions of the error

