### PR TITLE
TestLoginFailsWithBadCredentials: prepare for Go 1.14 changes

### DIFF
--- a/integration/system/login_test.go
+++ b/integration/system/login_test.go
@@ -23,6 +23,7 @@ func TestLoginFailsWithBadCredentials(t *testing.T) {
 		Password: "no-password",
 	}
 	_, err := client.RegistryLogin(context.Background(), config)
-	expected := "Error response from daemon: Get https://registry-1.docker.io/v2/: unauthorized: incorrect username or password"
-	assert.Check(t, is.Error(err, expected))
+	assert.Assert(t, err != nil)
+	assert.Check(t, is.ErrorContains(err, "unauthorized: incorrect username or password"))
+	assert.Check(t, is.ErrorContains(err, "https://registry-1.docker.io/v2/"))
 }


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/40353


Go 1.14 adds quotes around the url in the error returned:

    === FAIL: arm64.integration.system TestLoginFailsWithBadCredentials (0.27s)
        TestLoginFailsWithBadCredentials: login_test.go:27: assertion failed: expected error "Error response from daemon: Get https://registry-1.docker.io/v2/: unauthorized: incorrect username or password", got "Error response from daemon: Get \"https://registry-1.docker.io/v2/\": unauthorized: incorrect username or password"
            Error response from daemon: Get "https://registry-1.docker.io/v2/": unauthorized: incorrect username or password

