### PR TITLE
Exec inspect field should be "ID" not "ExecID"

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -50,7 +50,7 @@ type ContainerCommitOptions struct {
 
 // ContainerExecInspect holds information returned by exec inspect.
 type ContainerExecInspect struct {
-	ExecID      string
+	ExecID      string `json:"ID"`
 	ContainerID string
 	Running     bool
 	ExitCode    int

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -102,6 +102,10 @@ func TestExec(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
+	inspect, err := client.ContainerExecInspect(ctx, id.ID)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(inspect.ExecID, id.ID))
+
 	resp, err := client.ContainerExecAttach(ctx, id.ID,
 		types.ExecStartCheck{
 			Detach: false,


### PR DESCRIPTION
Fixes the client to actually decode the exec ID in the response.