### PR TITLE
[19.03] Exec inspect field should be "ID" not "ExecID"

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -50,7 +50,7 @@ type ContainerCommitOptions struct {
 
 // ContainerExecInspect holds information returned by exec inspect.
 type ContainerExecInspect struct {
-	ExecID      string
+	ExecID      string `json:"ID"`
 	ContainerID string
 	Running     bool
 	ExitCode    int

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -102,6 +102,10 @@ func TestExec(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
+	inspect, err := client.ContainerExecInspect(ctx, id.ID)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(inspect.ExecID, id.ID))
+
 	resp, err := client.ContainerExecAttach(ctx, id.ID,
 		types.ExecStartCheck{
 			Detach: false,


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/40475

Signed-off-by: Brian Goff <cpuguy83@gmail.com>
(cherry picked from commit cc993a9cbf40c1a94b5bada84f1d759b72df5c4e) 
Signed-off-by: Brian Goff <cpuguy83@gmail.com>