### PR TITLE
new storage driver: fuse-overlayfs

### DIFF
--- a/daemon/graphdriver/driver_linux.go
+++ b/daemon/graphdriver/driver_linux.go
@@ -44,11 +44,13 @@ const (
 	FsMagicZfs = FsMagic(0x2fc12fc1)
 	// FsMagicOverlay filesystem id for overlay
 	FsMagicOverlay = FsMagic(0x794C7630)
+	// FsMagicFUSE filesystem id for FUSE
+	FsMagicFUSE = FsMagic(0x65735546)
 )
 
 var (
 	// List of drivers that should be used in an order
-	priority = "btrfs,zfs,overlay2,aufs,overlay,devicemapper,vfs"
+	priority = "btrfs,zfs,overlay2,fuse-overlayfs,aufs,overlay,devicemapper,vfs"
 
 	// FsNames maps filesystem id to name of the filesystem.
 	FsNames = map[FsMagic]string{
@@ -58,6 +60,7 @@ var (
 		FsMagicEcryptfs:    "ecryptfs",
 		FsMagicExtfs:       "extfs",
 		FsMagicF2fs:        "f2fs",
+		FsMagicFUSE:        "fuse",
 		FsMagicGPFS:        "gpfs",
 		FsMagicJffs2Fs:     "jffs2",
 		FsMagicJfs:         "jfs",

--- a/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs_test.go
+++ b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs_test.go
@@ -1,0 +1,85 @@
+// +build linux
+
+package fuseoverlayfs // import "github.com/docker/docker/daemon/graphdriver/fuse-overlayfs"
+
+import (
+	"testing"
+
+	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/daemon/graphdriver/graphtest"
+	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/reexec"
+)
+
+func init() {
+	// Do not sure chroot to speed run time and allow archive
+	// errors or hangs to be debugged directly from the test process.
+	untar = archive.UntarUncompressed
+	graphdriver.ApplyUncompressedLayer = archive.ApplyUncompressedLayer
+
+	reexec.Init()
+}
+
+// This avoids creating a new driver for each test if all tests are run
+// Make sure to put new tests between TestFUSEOverlayFSSetup and TestFUSEOverlayFSTeardown
+func TestFUSEOverlayFSSetup(t *testing.T) {
+	graphtest.GetDriver(t, driverName)
+}
+
+func TestFUSEOverlayFSCreateEmpty(t *testing.T) {
+	graphtest.DriverTestCreateEmpty(t, driverName)
+}
+
+func TestFUSEOverlayFSCreateBase(t *testing.T) {
+	graphtest.DriverTestCreateBase(t, driverName)
+}
+
+func TestFUSEOverlayFSCreateSnap(t *testing.T) {
+	graphtest.DriverTestCreateSnap(t, driverName)
+}
+
+func TestFUSEOverlayFS128LayerRead(t *testing.T) {
+	graphtest.DriverTestDeepLayerRead(t, 128, driverName)
+}
+
+func TestFUSEOverlayFSTeardown(t *testing.T) {
+	graphtest.PutDriver(t)
+}
+
+// Benchmarks should always setup new driver
+
+func BenchmarkExists(b *testing.B) {
+	graphtest.DriverBenchExists(b, driverName)
+}
+
+func BenchmarkGetEmpty(b *testing.B) {
+	graphtest.DriverBenchGetEmpty(b, driverName)
+}
+
+func BenchmarkDiffBase(b *testing.B) {
+	graphtest.DriverBenchDiffBase(b, driverName)
+}
+
+func BenchmarkDiffSmallUpper(b *testing.B) {
+	graphtest.DriverBenchDiffN(b, 10, 10, driverName)
+}
+
+func BenchmarkDiff10KFileUpper(b *testing.B) {
+	graphtest.DriverBenchDiffN(b, 10, 10000, driverName)
+}
+
+func BenchmarkDiff10KFilesBottom(b *testing.B) {
+	graphtest.DriverBenchDiffN(b, 10000, 10, driverName)
+}
+
+func BenchmarkDiffApply100(b *testing.B) {
+	graphtest.DriverBenchDiffApplyN(b, 100, driverName)
+}
+
+func BenchmarkDiff20Layers(b *testing.B) {
+	graphtest.DriverBenchDeepLayerDiff(b, 20, driverName)
+}
+
+func BenchmarkRead20Layers(b *testing.B) {
+	graphtest.DriverBenchDeepLayerRead(b, 20, driverName)
+}

--- a/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs_unsupported.go
+++ b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs_unsupported.go
@@ -1,0 +1,3 @@
+// +build !linux
+
+package fuseoverlayfs // import "github.com/docker/docker/daemon/graphdriver/fuse-overlayfs"

--- a/daemon/graphdriver/overlayutils/randomid.go
+++ b/daemon/graphdriver/overlayutils/randomid.go
@@ -1,6 +1,6 @@
 // +build linux
 
-package overlay2 // import "github.com/docker/docker/daemon/graphdriver/overlay2"
+package overlayutils // import "github.com/docker/docker/daemon/graphdriver/overlayutils"
 
 import (
 	"crypto/rand"
@@ -11,11 +11,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
-// generateID creates a new random string identifier with the given length
-func generateID(l int) string {
+// GenerateID creates a new random string identifier with the given length
+func GenerateID(l int, logger *logrus.Entry) string {
 	const (
 		// ensures we backoff for less than 450ms total. Use the following to
 		// select new value, in units of 10ms:

--- a/daemon/graphdriver/register/register_fuseoverlayfs.go
+++ b/daemon/graphdriver/register/register_fuseoverlayfs.go
@@ -1,0 +1,8 @@
+// +build !exclude_graphdriver_fuseoverlayfs,linux
+
+package register // import "github.com/docker/docker/daemon/graphdriver/register"
+
+import (
+	// register the fuse-overlayfs graphdriver
+	_ "github.com/docker/docker/daemon/graphdriver/fuse-overlayfs"
+)


### PR DESCRIPTION





<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added a new storage driver: `fuse-overlayfs`.

`fuse-overlayfs` provides rootless overlayfs functionality without depending on any kernel patch.

Aside from rootless, `fuse-overlayfs` could be potentially used for eliminating `chown()` calls that happen in userns-remap mode, because `fuse-overlayfs` also provides shiftfs functionality.

System requirements:
* [fuse-overlayfs](https://github.com/containers/fuse-overlayfs) needs to be installed. Tested with 0.7.6.
* kernel >= 4.18

Fix #40218

**- How I did it**

The implementation is based on Podman's `overlay` driver which supports both kernel-mode overlayfs and fuse-overlayfs in the single driver instance:
https://github.com/containers/storage/blob/39a8d5ed/drivers/overlay/overlay.go

However, Moby's implementation aims to decouple `fuse-overlayfs` driver from the kernel-mode driver (`overlay2`) for simplicity.


**- How to verify it**


```console
$ go test -exec sudo -v ./daemon/graphdriver/fuse-overlayfs
=== RUN   TestFUSEOverlayFSSetup
--- PASS: TestFUSEOverlayFSSetup (0.00s)
=== RUN   TestFUSEOverlayFSCreateEmpty
--- PASS: TestFUSEOverlayFSCreateEmpty (0.00s)
=== RUN   TestFUSEOverlayFSCreateBase
--- PASS: TestFUSEOverlayFSCreateBase (0.00s)
=== RUN   TestFUSEOverlayFSCreateSnap
--- PASS: TestFUSEOverlayFSCreateSnap (0.02s)
=== RUN   TestFUSEOverlayFS128LayerRead
--- PASS: TestFUSEOverlayFS128LayerRead (4.32s)
=== RUN   TestFUSEOverlayFSTeardown
--- PASS: TestFUSEOverlayFSTeardown (0.09s)
PASS
ok      github.com/docker/docker/daemon/graphdriver/fuse-overlayfs      4.450s
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
new storage driver: fuse-overlayfs

**- A picture of a cute animal (not mandatory but encouraged)**

:penguin: