### PR TITLE
rootless: support `--exec-opt native.cgroupdriver=systemd`

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -599,15 +599,13 @@ func verifyPlatformContainerResources(resources *containertypes.Resources, sysIn
 }
 
 func (daemon *Daemon) getCgroupDriver() string {
+	if UsingSystemd(daemon.configStore) {
+		return cgroupSystemdDriver
+	}
 	if daemon.Rootless() {
 		return cgroupNoneDriver
 	}
-	cgroupDriver := cgroupFsDriver
-
-	if UsingSystemd(daemon.configStore) {
-		cgroupDriver = cgroupSystemdDriver
-	}
-	return cgroupDriver
+	return cgroupFsDriver
 }
 
 // getCD gets the raw value of the native.cgroupdriver option, if set.

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# v0.7.1
-: ${ROOTLESSKIT_COMMIT:=76c4e26750da3986fa0e741464fbf0fcd55bea71}
+# v0.8.0
+: ${ROOTLESSKIT_COMMIT:=ce88a431e6a7cf891ebb68b10bfc6a5724b9ae72}
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Support rootless cgroup.

Requires cgroup v2 host with crun.
Tested with Ubuntu 19.10 (kernel 5.3, systemd 242), crun v0.12.1.


**- How I did it**

Using systemd.

**- How to verify it**
* Install Ubuntu 19.10
* Install containerd master
* Install crun v0.12.1
* Add `systemd.unified_cgroup_hierarchy=1` to the kernel cmdline
* (Optional) To enable the CPU controller:
```console
$ cat > /etc/systemd/system/user@.service.d/foo.conf << EOF
[Service]
# default: Delegate=pids memory
Delegate=pids memory cpu
EOF
```

Start a daemon:

```console
$ dockerd-rootless.sh \
  --experimental \
  --exec-opt native.cgroupdriver=systemd \
  --add-runtime crun=crun \
  --default-runtime=crun
```

Verify:
```console
$ export DOCKER_HOST=unix:///run/user/1001/docker.sock

$ docker  run -d --memory 32M --cpus 0.5 nginx:alpine
71500664473ea71aff8360ba31db7eaee4b11fba19c4fdd467ceaa49c2fef7e0


$ cat /sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/user.slice/docker-71500664473ea71aff8360ba31db7eaee4b11fba19c4fdd467ceaa49c2fef7e0.scope/memory.max 
33554432

$ cat /sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/user.slice/docker-71500664473ea71aff8360ba31db7eaee4b11fba19c4fdd467ceaa49c2fef7e0.scope/cpu.max 
50000 100000
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
rootless: support `--exec-opt native.cgroupdriver=systemd`


**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
