### PR TITLE
swagger: document "node.platform.(arch|os)" constraints

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3046,7 +3046,27 @@ definitions:
         type: "object"
         properties:
           Constraints:
-            description: "An array of constraints."
+            description: |
+              An array of constraint expressions to limit the set of nodes where
+              a task can be scheduled. Constraint expressions can either use a
+              _match_ (`==`) or _exclude_ (`!=`) rule. Multiple constraints find
+              nodes that satisfy every expression (AND match). Constraints can
+              match node or Docker Engine labels as follows:
+
+              node attribute       | matches                        | example
+              ---------------------|--------------------------------|-----------------------------------------------
+              `node.id`            | Node ID                        | `node.id==2ivku8v2gvtg4`
+              `node.hostname`      | Node hostname                  | `node.hostname!=node-2`
+              `node.role`          | Node role (`manager`/`worker`) | `node.role==manager`
+              `node.platform.os`   | Node operating system          | `node.platform.os==windows`
+              `node.platform.arch` | Node architecture              | `node.platform.arch==x86_64`
+              `node.labels`        | User-defined node labels       | `node.labels.security==high`
+              `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-14.04`
+
+              `engine.labels` apply to Docker Engine labels like operating system,
+              drivers, etc. Swarm administrators add `node.labels` for operational
+              purposes by using the [`node update endpoint`](#operation/NodeUpdate).
+
             type: "array"
             items:
               type: "string"
@@ -3054,6 +3074,8 @@ definitions:
               - "node.hostname!=node3.corp.example.com"
               - "node.role!=manager"
               - "node.labels.type==production"
+              - "node.platform.os==linux"
+              - "node.platform.arch==x86_64"
           Preferences:
             description: "Preferences provide a way to make the scheduler aware of factors such as topology. They are provided in order from highest to lowest precedence."
             type: "array"

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -357,6 +357,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 * The `HostConfig` field now includes `CpuCount` that represents the number of CPUs available for execution by the container. Windows daemon only.
 * `POST /services/create` and `POST /services/(id or name)/update` now accept the `TTY` parameter, which allocate a pseudo-TTY in container.
 * `POST /services/create` and `POST /services/(id or name)/update` now accept the `DNSConfig` parameter, which specifies DNS related configurations in resolver configuration file (resolv.conf) through `Nameservers`, `Search`, and `Options`.
+* `POST /services/create` and `POST /services/(id or name)/update` now support
+  `node.platform.arch` and `node.platform.os` constraints in the services 
+  `TaskSpec.Placement.Constraints` field.
 * `GET /networks/(id or name)` now includes IP and name of all peers nodes for swarm mode overlay networks.
 * `GET /plugins` list plugins.
 * `POST /plugins/pull?name=<plugin name>` pulls a plugin.


### PR DESCRIPTION
Addresses the API docs of https://github.com/docker/cli/issues/619 ("Docs missing for node platform constraints")

relates to:

- https://github.com/docker/swarmkit/pull/1678 Support constraint on platform architecture and OS
- https://github.com/docker/swarmkit/issues/1629 Add constraint support for platform os
    - vendored into this repository in https://github.com/moby/moby/pull/27784 Revendor swarmkit to 0ec7c6ee4b3185ec4e3d6bd65f8f5542b1761421

Support for these constraints was added in docker 1.13.0
(API v1.25), but never documented.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


