### PR TITLE
Vendor check to succeed even if copyright information is not found

### DIFF
--- a/hack/validate/vendor
+++ b/hack/validate/vendor
@@ -40,8 +40,7 @@ validate_vendor_diff(){
 validate_vendor_used() {
 	for f in $(mawk '/^[a-zA-Z0-9]/ { print $1 }' vendor.conf); do
 	if [ -d "vendor/$f" ]; then
-		found=$(echo "vendor/$f/"* | grep -iEc '/(LICENSE|COPYING)')
-		if [ "$found" -eq 0 ]; then
+		if ! echo "vendor/$f"/* | grep -qiEc '/(LICENSE|COPYING)'; then
 		echo "WARNING: could not find copyright information for $f"
 		fi
 	else


### PR DESCRIPTION
**- What I did**
The documentation for validate_vendor_used in hack/validate/vendor states
that a warning will be emitted if license information cannot be found in
a vendored package. However, because the script is run with pipefail set
(owing to the inclusion of the common validation script .validate) and
`grep -c` is used, the entire script will fail whenever license information
cannot be found in a vendored package.

I updated the hack/validate/vendor script to ensure the function's behaviour
is consistent with the documentation.

**- Description for the changelog**
Vendor check to succeed even if copyright information is not found