### PR TITLE
API: remove deprecated "filter" parameter for API v1.41 and up

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -231,10 +231,12 @@ func (s *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter, 
 		return err
 	}
 
-	filterParam := r.Form.Get("filter")
-	// FIXME(vdemeester) This has been deprecated in 1.13, and is target for removal for v17.12
-	if filterParam != "" {
-		imageFilters.Add("reference", filterParam)
+	version := httputils.VersionFromContext(ctx)
+	if versions.LessThan(version, "1.41") {
+		filterParam := r.Form.Get("filter")
+		if filterParam != "" {
+			imageFilters.Add("reference", filterParam)
+		}
 	}
 
 	images, err := s.backend.Images(imageFilters, httputils.BoolValue(r, "all"), false)

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,6 +17,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.41](https://docs.docker.com/engine/api/v1.41/) documentation
 
+* The `filter` (singular) query parameter, which was deprecated in favor of the
+  `filters` option in Docker 1.13, has now been removed from the `GET /images/json`
+  endpoint. The parameter remains available when using API version 1.40 or below.
 * `GET /services` now returns `Capabilities` as part of the `ContainerSpec`.
 * `GET /services/{id}` now returns `Capabilities` as part of the `ContainerSpec`.
 * `POST /services/create` now accepts `Capabilities` as part of the `ContainerSpec`.


### PR DESCRIPTION
This query-parameter was deprecated in docker 1.13 in commit 820b809e70df8b9c7af00256182c48d935972a5c (https://github.com/moby/moby/pull/27872), and scheduled for removal in docker 17.12, so we should remove it for the next API version.

