### PR TITLE
TestCatchAll, TestStopCatch: remove unneeded goroutine

### DIFF
--- a/pkg/signal/signal_linux_test.go
+++ b/pkg/signal/signal_linux_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"syscall"
 	"testing"
-	"time"
 
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -27,17 +26,11 @@ func TestCatchAll(t *testing.T) {
 	}
 
 	for sigStr := range listOfSignals {
-		signal, ok := SignalMap[sigStr]
-		if ok {
-			go func() {
-				time.Sleep(1 * time.Millisecond)
-				syscall.Kill(syscall.Getpid(), signal)
-			}()
-
+		if signal, ok := SignalMap[sigStr]; ok {
+			syscall.Kill(syscall.Getpid(), signal)
 			s := <-sigs
 			assert.Check(t, is.Equal(s.String(), signal.String()))
 		}
-
 	}
 }
 
@@ -45,11 +38,7 @@ func TestStopCatch(t *testing.T) {
 	signal := SignalMap["HUP"]
 	channel := make(chan os.Signal, 1)
 	CatchAll(channel)
-	go func() {
-
-		time.Sleep(1 * time.Millisecond)
-		syscall.Kill(syscall.Getpid(), signal)
-	}()
+	syscall.Kill(syscall.Getpid(), signal)
 	signalString := <-channel
 	assert.Check(t, is.Equal(signalString.String(), signal.String()))
 


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/40353


