### PR TITLE
docker-py: skip flaky AttachContainerTest::test_attach_no_stream (again)

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -14,7 +14,8 @@ source hack/make/.integration-test-helpers
 # This option can be used to temporarily skip flaky tests (using the `--deselect`
 # flag) until they are fixed upstream. For example:
 # --deselect=tests/integration/api_container_test.py::AttachContainerTest::test_attach_no_stream
-: "${PY_TEST_OPTIONS:=--junitxml=${DEST}/junit-report.xml}"
+# TODO re-enable test after https://github.com/docker/docker-py/issues/2513 has been resolved
+: "${PY_TEST_OPTIONS:=--junitxml=${DEST}/junit-report.xml --deselect=tests/integration/api_container_test.py::AttachContainerTest::test_attach_no_stream}"
 (
 	bundle .integration-daemon-start
 


### PR DESCRIPTION
relates to https://github.com/docker/docker-py/issues/2513

This test was disabled in the past (https://github.com/moby/moby/pull/39848), but re-enabled when we upgraded docker-py to 4.2.0 (https://github.com/moby/moby/pull/40467).

The test looks to be still flaky though, so skipping it again:

```
[2020-02-10T23:40:44.429Z] =================================== FAILURES ===================================
[2020-02-10T23:40:44.429Z] __________________ AttachContainerTest.test_attach_no_stream ___________________
[2020-02-10T23:40:44.429Z] tests/integration/api_container_test.py:1250: in test_attach_no_stream
[2020-02-10T23:40:44.429Z]     assert output == 'hello\n'.encode(encoding='ascii')
[2020-02-10T23:40:44.429Z] E   AssertionError: assert b'' == b'hello\n'
[2020-02-10T23:40:44.429Z] E     Right contains more items, first extra item: 104
[2020-02-10T23:40:44.429Z] E     Use -v to get the full diff
[2020-02-10T23:40:44.429Z] ------- generated xml file: /src/bundles/test-docker-py/junit-report.xml -------
````

