### PR TITLE
Jenkinsfile: temporarily pin windows image to 10.0.17763.973

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -970,7 +970,7 @@ pipeline {
                         TESTRUN_DRIVE          = 'd'
                         TESTRUN_SUBDIR         = "CI"
                         WINDOWS_BASE_IMAGE     = 'mcr.microsoft.com/windows/servercore'
-                        WINDOWS_BASE_IMAGE_TAG = 'ltsc2019'
+                        WINDOWS_BASE_IMAGE_TAG = '10.0.17763.973' // TODO switch back to using ltsc2019 once the image is fixed
                     }
                     agent {
                         node {


### PR DESCRIPTION
The latest `ltsc2019` image (`10.0.17763.1039`) appear to be broken,
and even a `RUN Write-Host hello` hangs.

Temporarily switching back to an older version so that CI doesn't fail.

