### PR TITLE
Deprecate '--cluster-xx' options and add warning

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -70,11 +70,11 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.Var(opts.NewNamedMapOpts("log-opts", conf.LogConfig.Config, nil), "log-opt", "Default log driver options for containers")
 
 	flags.StringVar(&conf.ClusterAdvertise, "cluster-advertise", "", "Address or interface name to advertise")
-	_ = flags.MarkDeprecated("cluster-advertise", "Deprecated option.")
+	_ = flags.MarkDeprecated("cluster-advertise", "Swarm classic is deprecated. Please use Swarm-mode (docker swarm init)")
 	flags.StringVar(&conf.ClusterStore, "cluster-store", "", "URL of the distributed storage backend")
-	_ = flags.MarkDeprecated("cluster-store", "Deprecated option.")
+	_ = flags.MarkDeprecated("cluster-store", "Swarm classic is deprecated. Please use Swarm-mode (docker swarm init)")
 	flags.Var(opts.NewNamedMapOpts("cluster-store-opts", conf.ClusterOpts, nil), "cluster-store-opt", "Set cluster store options")
-	_ = flags.MarkDeprecated("cluster-store-opts", "Deprecated option.")
+	_ = flags.MarkDeprecated("cluster-store-opts", "Swarm classic is deprecated. Please use Swarm-mode (docker swarm init)")
 
 	flags.StringVar(&conf.CorsHeaders, "api-cors-header", "", "Set CORS headers in the Engine API")
 	flags.IntVar(&maxConcurrentDownloads, "max-concurrent-downloads", config.DefaultMaxConcurrentDownloads, "Set the max concurrent downloads for each pull")

--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -68,9 +68,14 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.Var(opts.NewNamedListOptsRef("labels", &conf.Labels, opts.ValidateLabel), "label", "Set key=value labels to the daemon")
 	flags.StringVar(&conf.LogConfig.Type, "log-driver", "json-file", "Default driver for container logs")
 	flags.Var(opts.NewNamedMapOpts("log-opts", conf.LogConfig.Config, nil), "log-opt", "Default log driver options for containers")
+
 	flags.StringVar(&conf.ClusterAdvertise, "cluster-advertise", "", "Address or interface name to advertise")
+	_ = flags.MarkDeprecated("cluster-advertise", "Deprecated option.")
 	flags.StringVar(&conf.ClusterStore, "cluster-store", "", "URL of the distributed storage backend")
+	_ = flags.MarkDeprecated("cluster-store", "Deprecated option.")
 	flags.Var(opts.NewNamedMapOpts("cluster-store-opts", conf.ClusterOpts, nil), "cluster-store-opt", "Set cluster store options")
+	_ = flags.MarkDeprecated("cluster-store-opts", "Deprecated option.")
+
 	flags.StringVar(&conf.CorsHeaders, "api-cors-header", "", "Set CORS headers in the Engine API")
 	flags.IntVar(&maxConcurrentDownloads, "max-concurrent-downloads", config.DefaultMaxConcurrentDownloads, "Set the max concurrent downloads for each pull")
 	flags.IntVar(&maxConcurrentUploads, "max-concurrent-uploads", config.DefaultMaxConcurrentUploads, "Set the max concurrent uploads for each push")

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -85,6 +85,7 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	if cli.Config, err = loadDaemonCliConfig(opts); err != nil {
 		return err
 	}
+	warnOnDeprecatedConfigOptions(cli.Config)
 
 	if err := configureDaemonLogs(cli.Config); err != nil {
 		return err
@@ -467,6 +468,18 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 	}
 
 	return conf, nil
+}
+
+func warnOnDeprecatedConfigOptions(config *config.Config) {
+	if config.ClusterAdvertise != "" {
+		logrus.Warn(`The "cluster-advertise" option is deprecated. To be removed soon.`)
+	}
+	if config.ClusterStore != "" {
+		logrus.Warn(`The "cluster-store" option is deprecated. To be removed soon.`)
+	}
+	if len(config.ClusterOpts) > 0 {
+		logrus.Warn(`The "cluster-store-opt" option is deprecated. To be removed soon.`)
+	}
 }
 
 func initRouter(opts routerOptions) {


### PR DESCRIPTION
**- What I did**
Deprecated `--cluster-advertise`, `--cluster-store` , `--cluster-store-opt` flags from dockerd CLI.
 - logged warning when used

**- How to verify it**
```
$ dockerd --cluster-advertise 192.168.1.5:2376 --cluster-store etcd://192.168.1.6:2379
Flag --cluster-advertise has been deprecated, Deprecated option.
Flag --cluster-store has been deprecated, Deprecated option.
WARN[2020-02-12T17:43:14.108302242Z] The "cluster-advertise" option is deprecated. To be removed soon. 
WARN[2020-02-12T17:43:14.108351655Z] The "cluster-store" option is deprecated. To be removed soon. 
...
```
```
$ cat /etc/docker/daemon.json 
{
	"cluster-store": "etcd://192.168.1.5:1257",
	"cluster-store-opts": {},
	"cluster-advertise": "192.168.1.6:3123"
}
```

```
$ dockerd
WARN[2020-02-12T17:47:20.767700485Z] The "cluster-advertise" option is deprecated. To be removed soon. 
WARN[2020-02-12T17:47:20.767745964Z] The "cluster-store" option is deprecated. To be removed soon. 
INFO[2020-02-12T17:47:20.767757515Z] Starting up                                  
INFO[2020-02-12T17:47:20.768774398Z] libcontainerd: started new containerd process  pid=582
INFO[2020-02-12T17:47:20.768816420Z] parsed scheme: "unix"                         module=grpc
...
```

**- A picture of a cute animal (not mandatory but encouraged)**
<img src="https://user-images.githubusercontent.com/809903/74362906-ca899180-4dc9-11ea-896a-acd60b61961f.png" width="50%">

Co-authored-by: Yves Brissaud <yves.brissaud@gmail.com>

Signed-off-by: Anca Iordache <anca.iordache@docker.com>

relates to https://github.com/moby/moby/issues/40383

