### PR TITLE
Concurrent graph copy

### DIFF
--- a/daemon/graphdriver/vfs/copy_linux.go
+++ b/daemon/graphdriver/vfs/copy_linux.go
@@ -2,6 +2,6 @@ package vfs // import "github.com/docker/docker/daemon/graphdriver/vfs"
 
 import "github.com/docker/docker/daemon/graphdriver/copy"
 
-func dirCopy(srcDir, dstDir string) error {
-	return copy.DirCopy(srcDir, dstDir, copy.Content, false)
+func dirCopy(srcDir, dstDir string, concurrency int) error {
+	return copy.DirCopyWithConcurrency(srcDir, dstDir, copy.Content, false, concurrency)
 }

--- a/daemon/graphdriver/vfs/copy_unsupported.go
+++ b/daemon/graphdriver/vfs/copy_unsupported.go
@@ -4,6 +4,6 @@ package vfs // import "github.com/docker/docker/daemon/graphdriver/vfs"
 
 import "github.com/docker/docker/pkg/chrootarchive"
 
-func dirCopy(srcDir, dstDir string) error {
+func dirCopy(srcDir, dstDir string, concurrency int) error {
 	return chrootarchive.NewArchiver(nil).CopyWithTar(srcDir, dstDir)
 }

--- a/layer/layer_test.go
+++ b/layer/layer_test.go
@@ -12,18 +12,18 @@ import (
 
 	"github.com/containerd/continuity/driver"
 	"github.com/docker/docker/daemon/graphdriver"
-	"github.com/docker/docker/daemon/graphdriver/vfs"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/containerfs"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/stringid"
 	digest "github.com/opencontainers/go-digest"
+
+	// This is to load the VFS driver, so it doesn't get treated as a plugin
+	_ "github.com/docker/docker/daemon/graphdriver/vfs"
 )
 
 func init() {
 	graphdriver.ApplyUncompressedLayer = archive.UnpackLayer
-	defaultArchiver := archive.NewDefaultArchiver()
-	vfs.CopyDir = defaultArchiver.CopyWithTar
 }
 
 func newVFSGraphDriver(td string) (graphdriver.Driver, error) {


### PR DESCRIPTION
This is a carry of #38034
Closes #38034

I squashed commits for an easier rebase.

---

- What I did
I made copies concurrent for VFS, and Overlay1.

- How I did it
I started with adding a benchmark to the tests to give me a baseline. On my test system that gave me about ~1081927574 ns/op. I slowly improved the performance throughout the commits, and increased performance to about 552743671 ns/op in the final tests. I parallizes

- How to verify it
There are attached benchmarks, and tests

- Description for the changelog
Make VFS Faster.