### PR TITLE
Dockerfile: make static binary target simpler to consume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -359,7 +359,13 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         hack/make.sh cross
 
 FROM scratch AS binary
-COPY --from=build-binary /build/bundles/ /
+COPY --from=containerd  /build/ /
+COPY --from=runc        /build/ /
+COPY --from=rootlesskit /build/ /
+COPY --from=proxy       /build/ /
+COPY --from=vpnkit      /vpnkit /
+COPY --from=dockercli   /build/ /
+COPY --from=build-binary /build/bundles/binary-daemon/dockerd /build/bundles/binary-daemon/docker-init /
 
 FROM scratch AS dynbinary
 COPY --from=build-dynbinary /build/bundles/ /

--- a/hack/dockerfile/install/dockercli.installer
+++ b/hack/dockerfile/install/dockercli.installer
@@ -8,7 +8,7 @@ install_dockercli() {
 
 	arch=$(uname -m)
 	# No official release of these platforms
-	if [ "$arch" != "x86_64" ] && [ "$arch" != "s390x" ] && [ "$arch" != "armhf" ]; then
+	if [ "$arch" != "x86_64" ] && [ "$arch" != "armhf" ]; then
 		build_dockercli
 		return
 	fi

--- a/hack/dockerfile/install/dockercli.installer
+++ b/hack/dockerfile/install/dockercli.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 : ${DOCKERCLI_CHANNEL:=stable}
-: ${DOCKERCLI_VERSION:=17.06.2-ce}
+: ${DOCKERCLI_VERSION:=19.03.6}
 
 install_dockercli() {
 	echo "Install docker/cli version $DOCKERCLI_VERSION from $DOCKERCLI_CHANNEL"
@@ -21,10 +21,8 @@ install_dockercli() {
 }
 
 build_dockercli() {
-	git clone https://github.com/docker/docker-ce "$GOPATH/tmp/docker-ce"
-	cd "$GOPATH/tmp/docker-ce"
-	git checkout -q "v$DOCKERCLI_VERSION"
 	mkdir -p "$GOPATH/src/github.com/docker"
-	mv components/cli "$GOPATH/src/github.com/docker/cli"
+	git clone -b "v$DOCKERCLI_VERSION" https://github.com/docker/cli "$GOPATH/src/github.com/docker/cli"
+	cd "$GOPATH/src/github.com/docker/cli"
 	go build -buildmode=pie -o "${PREFIX}/docker" "github.com/docker/cli/cmd/docker"
 }


### PR DESCRIPTION
This way, one can build a static docker with this one-liner:

```
docker build -o bin/ --target binary --build-arg DOCKERCLI_VERSION=19.03.5 .
```

Signed-off-by: Tibor Vass <tibor@docker.com>

PTAL @cpuguy83 @seemethere @tonistiigi @arkodg if you think this would need pipeline script adjustments, let me know.

TODO: dynamic, and cross.