### PR TITLE
Fix go-swagger to work with Go 1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ WORKDIR $GOPATH/src/github.com/go-swagger/go-swagger
 # Install go-swagger for validating swagger.yaml
 # This is https://github.com/kolyshkin/go-swagger/tree/golang-1.13-fix
 # TODO: move to under moby/ or fix upstream go-swagger to work for us.
-ENV GO_SWAGGER_COMMIT 5793aa66d4b4112c2602c716516e24710e4adbb5
+ENV GO_SWAGGER_COMMIT 5e6cb12f7c82ce78e45ba71fa6cb1928094db050
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=tmpfs,target=/go/src/ \


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/40353

full diff: https://github.com/kolyshkin/go-swagger/compare/5793aa66d4b4112c2602c716516e24710e4adbb5...5e6cb12f7c82ce78e45ba71fa6cb1928094db050

The template used was broken with Go 1.14, which has some stricter
rules, introduced in https://golang.org/cl/206124

```
root@b5beaed18589:/go/src/github.com/docker/docker# ./hack/generate-swagger-api.sh
2020/02/07 15:12:01 trying to read config from /go/src/github.com/docker/docker/api/swagger-gen.yaml
2020/02/07 15:12:02 rendering 1 templates for model ErrorResponse
2020/02/07 15:12:02 name field ErrorResponse
2020/02/07 15:12:02 package field types
2020/02/07 15:12:02 creating "error_response.go" in "api/types" as definition
model: template: schematype:2:18: executing "schemaType" at <(len .AllOf) gt 0>: can't give argument to non-function len .AllOf
```

This update includes the fix from https://github.com/kolyshkin/go-swagger/pull/1. Opening this as a separate pull request, so that we can backport this to release branches to prepare them for future Go updates
