### PR TITLE
Update windows container utility to fix compilation on gcc-mingw-w64 8.3 

### DIFF
--- a/hack/make/containerutility
+++ b/hack/make/containerutility
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-CONTAINER_UTILITY_COMMIT=e004a1415a433447369e315b9d7df357102be0d2 # v0.9.0
+: "${CONTAINER_UTILITY_COMMIT:=aa1ba87e99b68e0113bd27ec26c60b88f9d4ccd9}"
 
 (
 	git clone https://github.com/docker/windows-container-utility.git "$GOPATH/src/github.com/docker/windows-container-utility"

--- a/hack/make/containerutility
+++ b/hack/make/containerutility
@@ -8,13 +8,6 @@ set -e
 	cd "$GOPATH/src/github.com/docker/windows-container-utility"
 	git checkout -q "$CONTAINER_UTILITY_COMMIT"
 
-	# TODO remove this temporary fix once https://github.com/docker/windows-container-utility/pull/2 is merged
-	sed -i \
-		-e 's|-nostdinc ||g' \
-		-e 's|-I/usr/lib/gcc/x86_64-w64-mingw32/6.3-win32/include ||g' \
-		-e 's|-I/usr/x86_64-w64-mingw32/include ||g' \
-		"$GOPATH/src/github.com/docker/windows-container-utility/Makefile"
-
 	echo Building: ${DEST}/containerutility.exe
 
 	(


### PR DESCRIPTION
- bump windows-container-utility aa1ba87e99b68e0113bd27ec26c60b88f9d4ccd9
    - full diff: https://github.com/docker/windows-container-utility/compare/e004a1415a433447369e315b9d7df357102be0d2...aa1ba87e99b68e0113bd27ec26c60b88f9d4ccd9
    - Use standard include paths instead of hard-coding
- revert 25a1bf53d29e6424d4e9688952129a03c62fdef6 "Fix containerutility compilation on gcc-mingw-w64 8.3" (part of https://github.com/moby/moby/pull/39880)
