### PR TITLE
test: amend some misuse of channel in test functions

### DIFF
--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -407,12 +407,11 @@ func TestMaxDownloadAttempts(t *testing.T) {
 				})
 
 			progressChan := make(chan progress.Progress)
-			progressDone := make(chan struct{})
+			defer close(progressChan)
 
 			go func() {
 				for range progressChan {
 				}
-				close(progressDone)
 			}()
 
 			var currentDownloads int32

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2125,7 +2125,7 @@ func (s *DockerDaemonSuite) TestDaemonStartWithoutColors(c *testing.T) {
 	infoLog := "\x1b[36mINFO\x1b"
 
 	b := bytes.NewBuffer(nil)
-	done := make(chan bool)
+	done := make(chan bool, 1)
 
 	p, tty, err := pty.Open()
 	assert.NilError(c, err)


### PR DESCRIPTION
**- What I did**
1. Delete a useless channel `progressDone` in `TestMaxDownloadAttempts`.

2. The channel `done` in `(*DockerDaemonSuite).TestDaemonStartWithoutColors` might make a goroutine block. I change its operations so no goroutine will be blocked.

**- How to verify it**
1. Channel `progressDone` is only used once in one goroutine. It can be deleted. However, maybe it should be used somewhere else but was forgotten. If this is the case, please let me know.

2. In the code below, if `s.d.Stop(c)` calls `t.Fatal()`, `done <- true` may block, because `t.Fatal()` only kills one goroutine. Since `done` has no buffer and the value of `done` is never used, I switch all its sends and receives, and then use a `defer close(done)`. Now even if `t.Fatal()` is called, `defer close(done)` will be executed and other goroutines won't be blocked.

https://github.com/moby/moby/blob/d8772509d1a29b100c52c5c0f6cb5787a693db91/integration-cli/docker_cli_daemon_test.go#L2137-L2146

https://github.com/moby/moby/blob/d8772509d1a29b100c52c5c0f6cb5787a693db91/testutil/daemon/daemon.go#L449-L459

**- Description for the changelog**
Small changes for channel misuse in test.


**- Something else**
While writing this patch, I tried to find possible root causes of another issue #37735 
I will write my finding in that issue. Hope they can help
