### PR TITLE
vendor: bump libnetwork 6659f7f4d8c1ec7a412a33f8973423ad38d22982

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: "${LIBNETWORK_COMMIT:=feeff4f0a3fd2a2bb19cf67c826082c66ffaaed9}"
+: "${LIBNETWORK_COMMIT:=6659f7f4d8c1ec7a412a33f8973423ad38d22982}"
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/gofrs/flock                              392e7fae8f1b0bdbd67dad7237d2
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        feeff4f0a3fd2a2bb19cf67c826082c66ffaaed9
+github.com/docker/libnetwork                        6659f7f4d8c1ec7a412a33f8973423ad38d22982
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -68,9 +68,11 @@ type networkConfiguration struct {
 	EnableIPv6           bool
 	EnableIPMasquerade   bool
 	EnableICC            bool
+	InhibitIPv4          bool
 	Mtu                  int
 	DefaultBindingIP     net.IP
 	DefaultBridge        bool
+	HostIP               net.IP
 	ContainerIfacePrefix string
 	// Internal fields set after ipam data parsing
 	AddressIPv4        *net.IPNet
@@ -243,6 +245,10 @@ func (c *networkConfiguration) fromLabels(labels map[string]string) error {
 			if c.EnableICC, err = strconv.ParseBool(value); err != nil {
 				return parseErr(label, value, err.Error())
 			}
+		case InhibitIPv4:
+			if c.InhibitIPv4, err = strconv.ParseBool(value); err != nil {
+				return parseErr(label, value, err.Error())
+			}
 		case DefaultBridge:
 			if c.DefaultBridge, err = strconv.ParseBool(value); err != nil {
 				return parseErr(label, value, err.Error())
@@ -253,6 +259,10 @@ func (c *networkConfiguration) fromLabels(labels map[string]string) error {
 			}
 		case netlabel.ContainerIfacePrefix:
 			c.ContainerIfacePrefix = value
+		case netlabel.HostIP:
+			if c.HostIP = net.ParseIP(value); c.HostIP == nil {
+				return parseErr(label, value, "nil ip")
+			}
 		}
 	}
 
@@ -699,7 +709,7 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 
 		// We ensure that the bridge has the expectedIPv4 and IPv6 addresses in
 		// the case of a previously existing device.
-		{bridgeAlreadyExists, setupVerifyAndReconcile},
+		{bridgeAlreadyExists && !config.InhibitIPv4, setupVerifyAndReconcile},
 
 		// Enable IPv6 Forwarding
 		{enableIPv6Forwarding, setupIPv6Forwarding},

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/bridge_store.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/bridge_store.go
@@ -137,10 +137,12 @@ func (ncfg *networkConfiguration) MarshalJSON() ([]byte, error) {
 	nMap["EnableIPv6"] = ncfg.EnableIPv6
 	nMap["EnableIPMasquerade"] = ncfg.EnableIPMasquerade
 	nMap["EnableICC"] = ncfg.EnableICC
+	nMap["InhibitIPv4"] = ncfg.InhibitIPv4
 	nMap["Mtu"] = ncfg.Mtu
 	nMap["Internal"] = ncfg.Internal
 	nMap["DefaultBridge"] = ncfg.DefaultBridge
 	nMap["DefaultBindingIP"] = ncfg.DefaultBindingIP.String()
+	nMap["HostIP"] = ncfg.HostIP.String()
 	nMap["DefaultGatewayIPv4"] = ncfg.DefaultGatewayIPv4.String()
 	nMap["DefaultGatewayIPv6"] = ncfg.DefaultGatewayIPv6.String()
 	nMap["ContainerIfacePrefix"] = ncfg.ContainerIfacePrefix
@@ -183,6 +185,10 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 		ncfg.ContainerIfacePrefix = v.(string)
 	}
 
+	if v, ok := nMap["HostIP"]; ok {
+		ncfg.HostIP = net.ParseIP(v.(string))
+	}
+
 	ncfg.DefaultBridge = nMap["DefaultBridge"].(bool)
 	ncfg.DefaultBindingIP = net.ParseIP(nMap["DefaultBindingIP"].(string))
 	ncfg.DefaultGatewayIPv4 = net.ParseIP(nMap["DefaultGatewayIPv4"].(string))
@@ -192,6 +198,7 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 	ncfg.EnableIPv6 = nMap["EnableIPv6"].(bool)
 	ncfg.EnableIPMasquerade = nMap["EnableIPMasquerade"].(bool)
 	ncfg.EnableICC = nMap["EnableICC"].(bool)
+	ncfg.InhibitIPv4 = nMap["InhibitIPv4"].(bool)
 	ncfg.Mtu = int(nMap["Mtu"].(float64))
 	if v, ok := nMap["Internal"]; ok {
 		ncfg.Internal = v.(bool)

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/labels.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/labels.go
@@ -10,6 +10,9 @@ const (
 	// EnableICC label
 	EnableICC = "com.docker.network.bridge.enable_icc"
 
+	// InhibitIPv4 label
+	InhibitIPv4 = "com.docker.network.bridge.inhibit_ipv4"
+
 	// DefaultBindingIP label
 	DefaultBindingIP = "com.docker.network.bridge.host_binding_ipv4"
 

--- a/vendor/github.com/docker/libnetwork/netlabel/labels.go
+++ b/vendor/github.com/docker/libnetwork/netlabel/labels.go
@@ -53,6 +53,9 @@ const (
 
 	// ContainerIfacePrefix can be used to override the interface prefix used inside the container
 	ContainerIfacePrefix = Prefix + ".container_iface_prefix"
+
+	// HostIP is the Source-IP Address used to SNAT container traffic
+	HostIP = Prefix + ".host_ipv4"
 )
 
 var (

--- a/vendor/github.com/docker/libnetwork/osl/namespace_linux.go
+++ b/vendor/github.com/docker/libnetwork/osl/namespace_linux.go
@@ -38,9 +38,15 @@ var (
 	gpmChan            = make(chan chan struct{})
 	prefix             = defaultPrefix
 	loadBalancerConfig = map[string]*kernel.OSValue{
+		// disables any special handling on port reuse of existing IPVS connection table entries
+		// more info: https://github.com/torvalds/linux/blob/master/Documentation/networking/ipvs-sysctl.txt#L25:1
+		"net.ipv4.vs.conn_reuse_mode": {Value: "0", CheckFn: nil},
 		// expires connection from the IPVS connection table when the backend is not available
 		// more info: https://github.com/torvalds/linux/blob/master/Documentation/networking/ipvs-sysctl.txt#L126:1
 		"net.ipv4.vs.expire_nodest_conn": {Value: "1", CheckFn: nil},
+		// expires persistent connections to destination servers with weights set to 0
+		// more info: https://github.com/torvalds/linux/blob/master/Documentation/networking/ipvs-sysctl.txt#L144:1
+		"net.ipv4.vs.expire_quiescent_template": {Value: "1", CheckFn: nil},
 	}
 )
 

--- a/vendor/github.com/docker/libnetwork/vendor.conf
+++ b/vendor/github.com/docker/libnetwork/vendor.conf
@@ -1,7 +1,8 @@
 github.com/Azure/go-ansiterm            d6e3b3328b783f23731bc4d058875b0371ff8109
 github.com/BurntSushi/toml              3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
-github.com/Microsoft/go-winio           c599b533b43b1363d7d7c6cfda5ede70ed73ff13
-github.com/Microsoft/hcsshim            ba3d6667710fa905116f39a19d059c4c1016be7c
+github.com/containerd/cgroups  	 bf292b21730f0be58f47cd194dcf447dca57e200
+github.com/Microsoft/go-winio           6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
+github.com/Microsoft/hcsshim            b3f49c06ffaeef24d09c6c08ec8ec8425a0303e2 # v0.8.7
 github.com/armon/go-metrics             eb0af217e5e9747e41dd5303755356b62d28e3ec
 github.com/armon/go-radix               e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/codegangsta/cli              a65b733b303f0055f8d324d805f393cd3e7a7904
@@ -30,6 +31,7 @@ github.com/hashicorp/errwrap            8a6fb523712970c966eefc6b39ed2c5e74880354
 github.com/hashicorp/go-msgpack         71c2886f5a673a35f909803f38ece5810165097b
 github.com/hashicorp/go-multierror      886a7fbe3eb1c874d46f623bfa70af45f425b3d1 # v1.0.0
 github.com/hashicorp/memberlist         3d8438da9589e7b608a83ffac1ef8211486bcb7c
+github.com/hashicorp/golang-lru         7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
 github.com/sean-/seed                   e2103e2c35297fb7e17febb81e49b312087a2372
 github.com/hashicorp/go-sockaddr        c7188e74f6acae5a989bdc959aa779f8b9f42faf # v1.0.2
 github.com/hashicorp/serf               598c54895cc5a7b1a24a398d635e8c0ea0959870
@@ -40,7 +42,8 @@ github.com/opencontainers/image-spec    d60099175f88c47cd379c4738d158884749ed235
 github.com/opencontainers/runc          2b18fe1d885ee5083ef9f0838fee39b62d653e30
 github.com/opencontainers/runtime-spec  29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
 github.com/samuel/go-zookeeper          d0e0d8e11f318e000a8cc434616d69e329edc374
-github.com/sirupsen/logrus              f006c2ac4710855cf0f916dd6b77acf6b048dc6e # v1.0.3
+github.com/sirupsen/logrus              8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f # v1.4.1
+github.com/konsorten/go-windows-terminal-sequences   5c8c8bd35d3832f5d134ae1e1e375b69a4d25242 # v1.0.1
 github.com/ugorji/go                    b4c50a2b199d93b13dc15e78929cfb23bfdf21ab # v1.1.1
 github.com/vishvananda/netlink          a2ad57a690f3caf3015351d2d6e1c0b95c349752 # v1.0.0
 github.com/vishvananda/netns            7109fa855b0ff1ebef7fbd2f6aa613e8db7cfbc0
@@ -50,6 +53,7 @@ golang.org/x/sys                        d455e41777fca6e8a5a79e34a14b8368bc11d9ba
 golang.org/x/sync                       1d60e4601c6fd243af51cc01ddf169918a5407ca
 github.com/pkg/errors                   ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
 github.com/ishidawataru/sctp            6e2cb1366111dcf547c13531e3a263a067715847
+go.opencensus.io                        9c377598961b706d1542bd2d84d538b5094d596e # v0.22.0
 
 gotest.tools                            1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0 
 github.com/google/go-cmp                3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0


### PR DESCRIPTION
full diff: https://github.com/docker/libnetwork/compare/feeff4f0a3fd2a2bb19cf67c826082c66ffaaed9...6659f7f4d8c1ec7a412a33f8973423ad38d22982

includes:

- docker/libnetwork#2317 Allow bridge net driver to skip IPv4 configuration of bridge interface
    - adds support for a `com.docker.network.bridge.inhibit_ipv4` label/configuration
    - fixes moby/moby#37430 Prevent bridge network driver from setting IPv4 address on bridge interface
- docker/libnetwork#2454 Support for com.docker.network.host_ipv4 driver label
    - fixes moby/moby#30053 Unable to choose outbound (external) IP for containers
- docker/libnetwork#2491 Improving load balancer performance
    - fixes moby/moby#35082 [SWARM] Very poor performance for ingress network with lots of parallel requests

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
- Add support for a `com.docker.network.bridge.inhibit_ipv4` driver label to skip IPv4 configuration of bridge interface docker/libnetwork#2317
- Add support for a ` com.docker.network.host_ipv4` driver label to choose outbound (external) IP for containers docker/libnetwork#2454
- Improve load balancer performance for ingress network with lots of parallel requests docker/libnetwork#2491
```

**- A picture of a cute animal (not mandatory but encouraged)**

