### PR TITLE
[19.03] update containerd runtime v1.2.13

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=35bd7a5f69c13e1563af8a93431411cd9ecf5021 # v1.2.12
+CONTAINERD_COMMIT=7ad184331fa3e55e52b890ea95e65ba581ae3429 # v1.2.13
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
- addresses https://github.com/moby/moby/issues/40514 docker run/build using echo commands hangs forever, centos 7
- addresses https://github.com/docker-library/docker/issues/216 Docker-in-Docker 19.03.6 hangs during execution
- addresses https://gitlab.com/gitlab-org/gitlab-runner/issues/6697 Job execution hangs when latest docker:dind (version 19.03.6 and "floating" ones) is used
- addresses https://gitlab.com/gitlab-com/support-forum/issues/5194 CI runs that involve the building of a Docker container are hanging causing a CI timeout

The thirteenth patch release for `containerd` 1.2 fixes a regression introduced
in v1.2.12 that caused container/shim to hang on single core machines, fixes an
issue with blkio, and updates the Golang runtime to 1.12.17.

* Fix container pid race condition
* Update containerd/cgroups dependency to address blkio issue
* Set octet-stream content-type on PUT request
* Pin to libseccomp 2.3.3 to preserve compatibility with hosts that do not have libseccomp 2.4 or higher installed
* Update Golang runtime to 1.12.17, which includes a fix to the runtime

full diff: https://github.com/containerd/containerd/compare/v1.2.12...v1.2.13


