### PR TITLE
vendor: golang.org/x/crypto 1d94cc7ab1c630336ab82ccb9c9cda72a875c382

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -133,7 +133,7 @@ github.com/golang/protobuf                          aa810b61a9c79d51363740d207bb
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2
 github.com/fernet/fernet-go                         9eac43b88a5efb8651d24de9b68e87567e029736
 github.com/google/certificate-transparency-go       37a384cd035e722ea46e55029093e26687138edf # v1.0.20
-golang.org/x/crypto                                 69ecbb4d6d5dab05e49161c6e77ea40a030884e1
+golang.org/x/crypto                                 1d94cc7ab1c630336ab82ccb9c9cda72a875c382
 golang.org/x/time                                   fbb02b2291d28baffd63558aa44b4b56f178d650
 github.com/hashicorp/go-memdb                       cb9a474f84cc5e41b273b20c6927680b2a8776ad
 github.com/hashicorp/go-immutable-radix             826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git


### PR DESCRIPTION
full diff: https://github.com/golang/crypto/compare/69ecbb4d6d5dab05e49161c6e77ea40a030884e1...1d94cc7ab1c630336ab82ccb9c9cda72a875c382

(no local changes)


Doing a around across repositories to update in preparation of a security release that was announced for tomorrow (so that we can update again with just the changes related to that fix);

https://groups.google.com/d/msgid/golang-announce/CA%2B2K_Kox3xkjj6gWkp%3DY6fmp7sO4T%2BbgudjjZZ%3Duwgp476pmEw%40mail.gmail.com