### PR TITLE
[19.03 backport] Jenkinsfile: temporarily pin windows image to 10.0.17763.973

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -829,7 +829,7 @@ pipeline {
                         TESTRUN_DRIVE          = 'd'
                         TESTRUN_SUBDIR         = "CI"
                         WINDOWS_BASE_IMAGE     = 'mcr.microsoft.com/windows/servercore'
-                        WINDOWS_BASE_IMAGE_TAG = 'ltsc2019'
+                        WINDOWS_BASE_IMAGE_TAG = '10.0.17763.973' // TODO switch back to using ltsc2019 once the image is fixed
                     }
                     agent {
                         node {


### PR DESCRIPTION
The latest `ltsc2019` image (`10.0.17763.1039`) appear to be broken,
and even a `RUN Write-Host hello` hangs.

Temporarily switching back to an older version so that CI doesn't fail.


This is a workaround related  to https://github.com/moby/moby/issues/40525#issuecomment-587993478

> Please see:  [https://support.microsoft.com/en-us/help/4542617/you-may-encounter-issues-when-using-windows-server-docker-container-im](https://support.microsoft.com/en-us/help/4542617/you-may-encounter-issues-when-using-windows-server-docker-container-im) for the latest status.

