### PR TITLE
[19.03] vendor: update buildkit v0.6.4

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -26,7 +26,7 @@ github.com/imdario/mergo                            7c29201646fa3de8506f70121347
 golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af2b83e6acac3c
 
 # buildkit
-github.com/moby/buildkit                            57e8ad52170d713233569f6d467e609d2b0f90c9
+github.com/moby/buildkit                            ebcef1f69af0bbca077efa9a960a481e579a0e89 # v0.6.4
 github.com/tonistiigi/fsutil                        6c909ab392c173a4264ae1bfcbc0450b9aac0c7d
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7


### PR DESCRIPTION
full diff: https://github.com/moby/buildkit/compare/57e8ad52170d713233569f6d467e609d2b0f90c9...v0.6.4

- moby/buildkit#1374 [v0.6] ops: fix deadlock on releasing shared mounts
    - backport of moby/buildkit#1355 ops: fix deadlock on releasing shared mounts
    - fixes moby/buildkit#1322 Deadlock on cache mounts

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

