### PR TITLE
[19.03 backport] LCOW: fix using wrong shell for healthchecks

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
-	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/exec"
@@ -65,7 +64,7 @@ type cmdProbe struct {
 func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container) (*types.HealthcheckResult, error) {
 	cmdSlice := strslice.StrSlice(cntr.Config.Healthcheck.Test)[1:]
 	if p.shell {
-		cmdSlice = append(getShell(cntr.Config), cmdSlice...)
+		cmdSlice = append(getShell(cntr), cmdSlice...)
 	}
 	entrypoint, args := d.getEntrypointAndArgs(strslice.StrSlice{}, cmdSlice)
 	execConfig := exec.NewConfig()
@@ -370,11 +369,14 @@ func min(x, y int) int {
 	return y
 }
 
-func getShell(config *containertypes.Config) []string {
-	if len(config.Shell) != 0 {
-		return config.Shell
+func getShell(cntr *container.Container) []string {
+	if len(cntr.Config.Shell) != 0 {
+		return cntr.Config.Shell
 	}
 	if runtime.GOOS != "windows" {
+		return []string{"/bin/sh", "-c"}
+	}
+	if cntr.OS != runtime.GOOS {
 		return []string{"/bin/sh", "-c"}
 	}
 	return []string{"cmd", "/S", "/C"}


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39389
fixes https://github.com/docker/compose/issues/6445
fixes https://github.com/moby/moby/issues/38577

As reported in docker/compose#6445, when deploying a Linux
container on Windows (LCOW), the daemon made the wrong assumption
when deciding which shell to use to execute the healthcheck, looking
at the host's platform instead of the container's platform.

This patch adds a check for the container's platform when deploying
on Windows, and sets the correct shell.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

