### PR TITLE
[19.03 backport] AppArmor fixes

### DIFF
--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -31,6 +31,9 @@ profile /usr/bin/docker (attach_disconnected, complain) {
   @{DOCKER_GRAPH_PATH}/** rwl,
   @{DOCKER_GRAPH_PATH}/network/files/boltdb.db k,
   @{DOCKER_GRAPH_PATH}/network/files/local-kv.db k,
+  # For user namespaces:
+  @{DOCKER_GRAPH_PATH}/[0-9]*.[0-9]*/network/files/boltdb.db k,
+  @{DOCKER_GRAPH_PATH}/[0-9]*.[0-9]*/network/files/local-kv.db k,
 
   # For non-root client use:
   /dev/urandom r,

--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -29,10 +29,8 @@ profile /usr/bin/docker (attach_disconnected, complain) {
   capability,
   owner /** rw,
   @{DOCKER_GRAPH_PATH}/** rwl,
-  @{DOCKER_GRAPH_PATH}/linkgraph.db k,
   @{DOCKER_GRAPH_PATH}/network/files/boltdb.db k,
   @{DOCKER_GRAPH_PATH}/network/files/local-kv.db k,
-  @{DOCKER_GRAPH_PATH}/[0-9]*.[0-9]*/linkgraph.db k,
 
   # For non-root client use:
   /dev/urandom r,


### PR DESCRIPTION
backports of:

- https://github.com/moby/moby/pull/39991 AppArmor: remove rules for linkgraph.db SQLite database
- https://github.com/moby/moby/pull/39992 AppArmor: add missing rules for running in userns