### PR TITLE
[19.03 backport] bump google.golang.org/grpc v1.23.1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -73,7 +73,7 @@ github.com/opencontainers/go-digest                 279bed98673dd5bef374d3b6e4b0
 # get go-zfs packages
 github.com/mistifyio/go-zfs                         f784269be439d704d3dfa1906f45dd848fed2beb
 
-google.golang.org/grpc                              6eaf6f47437a6b4e2153a190160ef39a92c7eceb # v1.23.0
+google.golang.org/grpc                              39e8a7b072a67ca2a75f57fa2e0d50995f5b22f6 # v1.23.1
 
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in

--- a/vendor/google.golang.org/grpc/internal/transport/http2_server.go
+++ b/vendor/google.golang.org/grpc/internal/transport/http2_server.go
@@ -138,7 +138,10 @@ func newHTTP2Server(conn net.Conn, config *ServerConfig) (_ ServerTransport, err
 	}
 	framer := newFramer(conn, writeBufSize, readBufSize, maxHeaderListSize)
 	// Send initial settings as connection preface to client.
-	var isettings []http2.Setting
+	isettings := []http2.Setting{{
+		ID:  http2.SettingMaxFrameSize,
+		Val: http2MaxFrameLen,
+	}}
 	// TODO(zhaoq): Have a better way to signal "no limit" because 0 is
 	// permitted in the HTTP2 spec.
 	maxStreams := config.MaxStreams

--- a/vendor/google.golang.org/grpc/internal/transport/http_util.go
+++ b/vendor/google.golang.org/grpc/internal/transport/http_util.go
@@ -667,6 +667,7 @@ func newFramer(conn net.Conn, writeBufferSize, readBufferSize int, maxHeaderList
 		writer: w,
 		fr:     http2.NewFramer(w, r),
 	}
+	f.fr.SetMaxReadFrameSize(http2MaxFrameLen)
 	// Opt-in to Frame reuse API on framer to reduce garbage.
 	// Frames aren't safe to read from after a subsequent call to ReadFrame.
 	f.fr.SetReuseFrames()

--- a/vendor/google.golang.org/grpc/version.go
+++ b/vendor/google.golang.org/grpc/version.go
@@ -19,4 +19,4 @@
 package grpc
 
 // Version is the current grpc version.
-const Version = "1.23.0"
+const Version = "1.23.1"


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/40108

full diff: https://github.com/grpc/grpc-go/compare/v1.23.0...v1.23.1

- grpc-go#3018 server: set and advertise max frame size of 16KB
- grpc/grpc-go#3017 grpclb: fix deadlock in grpclb connection cache
    - Before the fix, if the timer to remove a SubConn fires at the
      same time NewSubConn cancels the timer, it caused a mutex leak
      and deadlock.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

