### PR TITLE
Revert "Don't die when daemon cannot read certs.d"

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -69,7 +69,7 @@ func hasFile(files []os.FileInfo, name string) bool {
 // provided TLS configuration.
 func ReadCertsDirectory(tlsConfig *tls.Config, directory string) error {
 	fs, err := ioutil.ReadDir(directory)
-	if err != nil && !os.IsNotExist(err) && !os.IsPermission(err) {
+	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 


### PR DESCRIPTION
This reverts commit 2808762b27b9e4e94a705193c8554184f6beb151.

This exception was added for rootless mode, but superseded by the follow-up commit f4fa98f583a64d736eea1bb3a8fab755e159fdf4 in the same PR (https://github.com/moby/moby/pull/40243), which uses a different path to look for the certs when running in rootless mode

See the discussion on https://github.com/moby/moby/pull/40461#discussion_r383735957
