### PR TITLE
Add a TODO in the Dockerfile regarding nftables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -286,7 +286,8 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             zip
 
 
-# Switch to use iptables instead of nftables (to match the host machine)
+# Switch to use iptables instead of nftables (to match the CI hosts)
+# TODO use some kind of runtime auto-detection instead if/when nftables is supported (https://github.com/moby/moby/issues/26824)
 RUN update-alternatives --set iptables  /usr/sbin/iptables-legacy  || true \
  && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true \
  && update-alternatives --set arptables /usr/sbin/arptables-legacy || true


### PR DESCRIPTION
Someday, we'll hopefully support nftables directly and will likely then need some kind of in-container runtime detection (perhaps based on loaded modules or something similar).  This updates the related `Dockerfile` comment accordingly (linking to what I think is the appropriate `nftables` tracking issue, https://github.com/moby/moby/issues/26824).

(This is as discussed in https://github.com/moby/moby/pull/40558#discussion_r384179651 :innocent:)

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/161631/75297329-6fea2f80-57e4-11ea-810d-f99e34170ccc.png)
