### PR TITLE
[19.03] Revert "Jenkinsfile: temporarily pin windows image to 10.0.17763.973"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -829,7 +829,7 @@ pipeline {
                         TESTRUN_DRIVE          = 'd'
                         TESTRUN_SUBDIR         = "CI"
                         WINDOWS_BASE_IMAGE     = 'mcr.microsoft.com/windows/servercore'
-                        WINDOWS_BASE_IMAGE_TAG = '10.0.17763.973' // TODO switch back to using ltsc2019 once the image is fixed
+                        WINDOWS_BASE_IMAGE_TAG = 'ltsc2019'
                     }
                     agent {
                         node {


### PR DESCRIPTION
This reverts commit c694d603645fe60da7e2d646016159a01c599454 (https://github.com/moby/moby/pull/40551) - equivalent of https://github.com/moby/moby/pull/40512 on master

Machines in CI have been updated, and now work again on the latest images, so reverting this change here as well.
