### PR TITLE
plugin: fix a double RLock bug

### DIFF
--- a/plugin/store.go
+++ b/plugin/store.go
@@ -188,9 +188,7 @@ func (ps *Store) GetAllByCap(capability string) ([]plugingetter.CompatPlugin, er
 	 * bypassing the daemon. For such tests, this check is necessary.
 	 */
 	if ps != nil {
-		ps.RLock()
 		result = ps.getAllByCap(capability)
-		ps.RUnlock()
 	}
 
 	// Lookup with legacy model


### PR DESCRIPTION
**- What I did**
The following code has a double RLock bug:
https://github.com/moby/moby/blob/9fee52d5441526450ce88934dfb01ed726b9e284/plugin/store.go#L191-L193
https://github.com/moby/moby/blob/9fee52d5441526450ce88934dfb01ed726b9e284/plugin/store.go#L75-L78
This PR deleted the outer RLock and RUnlock. They are redundant.

**- How I did it**
Removed line 191 and line 193.

**- How to verify it**
RLock followed by another RLock is buggy, due to Go's implementation of RLock. If another thread tries to acquire a Lock between the two RLock, then both threads will be blocked.
```Go
Thread 1 acquires the first RLock
Thread 2 blocks at acquiring Lock
Thread 1 blocks at acquiring the second RLock
```

**- Description for the changelog**
Removes a redundant RLock and RUnlock

**- A picture of a cute animal (not mandatory but encouraged)**
🐒
