### PR TITLE
daemon/cluster: add a missing Unlock

### DIFF
--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -33,6 +33,7 @@ func (c *Cluster) Init(req types.InitRequest) (string, error) {
 			// API handlers to finish before shutting down the node.
 			c.mu.Lock()
 			if !c.nr.nodeState.IsManager() {
+				c.mu.Unlock()
 				return "", errSwarmNotManager
 			}
 			c.mu.Unlock()


### PR DESCRIPTION
**- What I did**
The following code has a missing Unlock:
https://github.com/moby/moby/blob/9fee52d5441526450ce88934dfb01ed726b9e284/daemon/cluster/swarm.go#L32-L38
This PR adds an Unlock before return with error.

**- How to verify it**
We checked other places where this RWMutex is used, and Lock is always followed with Unlock in control-flow-graph, except in this place.

**- Description for the changelog**
Adds a missing Unlock before return with error.

**- A picture of a cute animal (not mandatory but encouraged)**
🐷
