### PR TITLE
Windows CI: Make sure that CI fails on any error

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -166,7 +166,7 @@ FROM microsoft/windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG GO_VERSION=1.13.15
-ARG GOTESTSUM_COMMIT=v0.3.5
+ARG GOTESTSUM_COMMIT=v0.5.3
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1014,11 +1014,12 @@ pipeline {
                             junit testResults: 'bundles/junit-report-*.xml', allowEmptyResults: true
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to create bundles.tar.gz') {
                                 powershell '''
+                                cd $env:WORKSPACE
                                 $bundleName="windowsRS1-integration"
                                 Write-Host -ForegroundColor Green "Creating ${bundleName}-bundles.zip"
 
                                 # archiveArtifacts does not support env-vars to , so save the artifacts in a fixed location
-                                Compress-Archive -Path "${env:TEMP}/CIDUT.out", "${env:TEMP}/CIDUT.err", "${env:TEMP}/testresults/unittests/junit-report-unit-tests.xml" -CompressionLevel Optimal -DestinationPath "${bundleName}-bundles.zip"
+                                Compress-Archive -Path "bundles/CIDUT.out", "bundles/CIDUT.err", "bundles/junit-report-*.xml" -CompressionLevel Optimal -DestinationPath "${bundleName}-bundles.zip"
                                 '''
 
                                 archiveArtifacts artifacts: '*-bundles.zip', allowEmptyArchive: true
@@ -1075,11 +1076,12 @@ pipeline {
                             junit testResults: 'bundles/junit-report-*.xml', allowEmptyResults: true
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to create bundles.tar.gz') {
                                 powershell '''
+                                cd $env:WORKSPACE
                                 $bundleName="windowsRS5-integration"
                                 Write-Host -ForegroundColor Green "Creating ${bundleName}-bundles.zip"
 
                                 # archiveArtifacts does not support env-vars to , so save the artifacts in a fixed location
-                                Compress-Archive -Path "${env:TEMP}/CIDUT.out", "${env:TEMP}/CIDUT.err", "${env:TEMP}/junit-report-*.xml" -CompressionLevel Optimal -DestinationPath "${bundleName}-bundles.zip"
+                                Compress-Archive -Path "bundles/CIDUT.out", "bundles/CIDUT.err", "bundles/junit-report-*.xml" -CompressionLevel Optimal -DestinationPath "${bundleName}-bundles.zip"
                                 '''
 
                                 archiveArtifacts artifacts: '*-bundles.zip', allowEmptyArchive: true

--- a/hack/dockerfile/install/gotestsum.installer
+++ b/hack/dockerfile/install/gotestsum.installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-: ${GOTESTSUM_COMMIT:=v0.3.5}
+: ${GOTESTSUM_COMMIT:=v0.5.3}
 
 install_gotestsum() (
 	set -e


### PR DESCRIPTION
**- What I did**
On Windows CI tests are called using path:
Jenkins -> PowerShell -> gotestsum -> go test

gotestsum automatically return any exit code coming from go test and these changes make sure that if gotestsum exit code is not zero we exit using 1 to Jenkins too.

Also changed gotestsum to use "standard-verbose" format which is same than `-test.v` go test.

Also make sure that all outputs ends up to artifact.

**- How I did it**
Fixed PowerShell script and Jenkinsfile.

**- How to verify it**
CI passed on here and you can see that on #38469 where I also included this one broken integration test made CI failing https://ci-next.docker.com/public/blue/organizations/jenkins/moby/detail/PR-38469/19/pipeline/252 and it fails fast without need wait all tests to run.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6213926/93373036-7104ac00-f85d-11ea-92e5-2c87ad9ceb12.png)

Fixes #39576
Fixes #40069