### PR TITLE
vendor: update gotest.tools v3.0.2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -17,7 +17,7 @@ golang.org/x/sys                                    6d18c012aee9febd81bbf9806760
 github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0
 golang.org/x/text                                   f21a4dfb5e38f5895301dc265a8def02365cc3d0 # v0.3.0
-gotest.tools/v3                                     ab4a870b92ce57a83881fbeb535a137a20d664b7 # v3.0.1
+gotest.tools/v3                                     bb0d8a963040ea5048dcef1a14d8f8b58a33d4b3 # v3.0.2
 github.com/google/go-cmp                            3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0
 github.com/syndtr/gocapability                      d98352740cb2c55f81556b63d4a1ec64c5a319c2
 

--- a/vendor/gotest.tools/v3/assert/assert.go
+++ b/vendor/gotest.tools/v3/assert/assert.go
@@ -119,12 +119,8 @@ func assert(
 		return true
 
 	case error:
-		// Handle nil structs which implement error as a nil error
-		if reflect.ValueOf(check).IsNil() {
-			return true
-		}
-		msg := "error is not nil: "
-		t.Log(format.WithCustomMessage(failureMessage+msg+check.Error(), msgAndArgs...))
+		msg := failureMsgFromError(check)
+		t.Log(format.WithCustomMessage(failureMessage+msg, msgAndArgs...))
 
 	case cmp.Comparison:
 		success = runComparison(t, argSelector, check, msgAndArgs...)
@@ -177,6 +173,15 @@ func logFailureFromBool(t TestingT, msgAndArgs ...interface{}) {
 	}
 
 	t.Log(format.WithCustomMessage(failureMessage+msg, msgAndArgs...))
+}
+
+func failureMsgFromError(err error) string {
+	// Handle errors with non-nil types
+	v := reflect.ValueOf(err)
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		return fmt.Sprintf("error is not nil: error has type %T", err)
+	}
+	return "error is not nil: " + err.Error()
 }
 
 func boolFailureMessage(expr ast.Expr) (string, error) {


### PR DESCRIPTION
follow-up to https://github.com/moby/moby/pull/40472, https://github.com/moby/moby/pull/40501, and https://github.com/moby/moby/pull/40502

full diff: https://github.com/gotestyourself/gotest.tools/compare/v3.0.1...v3.0.2

- assert: Fix NilError, error non-nil type
    - fixes: Typed nil errors should not pass "NilError"
    - fixes: "reflect: call of reflect.Value.IsNil on struct Value" for struct error type


