### PR TITLE
[19.03 backport] daemon/cluster: add a missing Unlock

### DIFF
--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -33,6 +33,7 @@ func (c *Cluster) Init(req types.InitRequest) (string, error) {
 			// API handlers to finish before shutting down the node.
 			c.mu.Lock()
 			if !c.nr.nodeState.IsManager() {
+				c.mu.Unlock()
 				return "", errSwarmNotManager
 			}
 			c.mu.Unlock()


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/40594