### PR TITLE
Fixes #40591 builder copy empty dir

### DIFF
--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/image"
+	layerpkg "github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/containerfs"
@@ -153,7 +154,19 @@ func (b *Builder) exportImage(state *dispatchState, layer builder.RWLayer, paren
 	}
 
 	state.imageID = exportedImage.ImageID()
-	b.imageSources.Add(newImageMount(exportedImage, newLayer), platform)
+
+	// if new layer is empty, next build stage should base on the parent layer #40591
+	if layerpkg.IsEmpty(newLayer.DiffID()) {
+		parentImageMount, err := b.imageSources.Get(parentImage.ImageID(), true, b.platform)
+		if err != nil {
+			return errors.Wrap(err, "failed to get parent image mount")
+		}
+		parentLayer := parentImageMount.layer
+		b.imageSources.Add(newImageMount(exportedImage, parentLayer), platform)
+	} else {
+		b.imageSources.Add(newImageMount(exportedImage, newLayer), platform)
+	}
+
 	return nil
 }
 

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -643,6 +643,37 @@ func TestBuildPlatformInvalid(t *testing.T) {
 	assert.Assert(t, errdefs.IsInvalidParameter(err))
 }
 
+// Test case in #40591
+func TestBuildWithCopyEmptyDir(t *testing.T) {
+	dockerfile := `
+                FROM    busybox
+                COPY    emptydir /var
+                COPY    dir /opt
+        `
+	ctx := context.Background()
+	source := fakecontext.New(t, "",
+		fakecontext.WithDockerfile(dockerfile),
+		fakecontext.WithDir("emptydir"),
+		fakecontext.WithFile("dir/emptydirtest", "emptydirtest"))
+	defer source.Close()
+
+	apiclient := testEnv.APIClient()
+	resp, err := apiclient.ImageBuild(ctx,
+		source.AsTarReader(t),
+		types.ImageBuildOptions{
+			Remove:      true,
+			ForceRemove: true,
+			NoCache:     true,
+		})
+	assert.NilError(t, err)
+
+	out := bytes.NewBuffer(nil)
+	_, err = io.Copy(out, resp.Body)
+	resp.Body.Close()
+	assert.NilError(t, err)
+	assert.Check(t, is.Contains(out.String(), "Successfully built"))
+}
+
 func writeTarRecord(t *testing.T, w *tar.Writer, fn, contents string) {
 	err := w.WriteHeader(&tar.Header{
 		Name:     fn,

--- a/testutil/fakecontext/context.go
+++ b/testutil/fakecontext/context.go
@@ -78,6 +78,13 @@ func WithBinaryFiles(files map[string]*bytes.Buffer) func(*Fake) error {
 	}
 }
 
+// WithDir adds an empty directory in the build context
+func WithDir(dir string) func(*Fake) error {
+	return func(ctx *Fake) error {
+		return ctx.addDir(dir)
+	}
+}
+
 // Fake creates directories that can be used as a build context
 type Fake struct {
 	Dir string
@@ -98,6 +105,11 @@ func (f *Fake) addFile(file string, content []byte) error {
 	}
 	return ioutil.WriteFile(fp, content, 0644)
 
+}
+
+func (f *Fake) addDir(dir string) error {
+	fp := filepath.Join(f.Dir, filepath.FromSlash(dir))
+	return os.Mkdir(fp, 0755)
 }
 
 // Delete a file at a path


### PR DESCRIPTION
**- What I did**
It fixes #40591, to avoid docker build failed with "layer does not exist" when COPY an empty dir, 

**- How I did it**
The bug exists in `builder/dockerfile/internals.exportImage`, if current layer is empty in stage s1, `image.NewChildImage` will skip this layer (not add the DiffID to RootFS) but it still add current layer to imageSources, which caused that the next stage s2 run based on this empty layer actually, but when `CreateImage`, the chainID calculated based on RootFS is mismatched with the chainID of stage s2 layer, so build failed.
I changed to add parent layer if current layer is empty, keep the same logic as `NewChildImage`

**- How to verify it**
I add a new integration-test "TestBuildWithCopyEmptyDir", it fails everytime with DeviceMapper storage, and can PASS after this PR.

Test before fix
```
#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# GITCOMMIT = 38f52c9fec-unsupported
# The version you are building is listed as unsupported because
# there are some files in the git repository that are in an uncommitted state.
# Commit these changes, or add to .gitignore to remove the -unsupported from the version.
# Here is the current list:
 M integration/build/build_test.go
 M testutil/fakecontext/context.go
#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Removing bundles/

---> Making bundle: dynbinary (in bundles/dynbinary)
Building: bundles/dynbinary-daemon/dockerd-dev
GOOS="" GOARCH="" GOARM=""
Created binary: bundles/dynbinary-daemon/dockerd-dev

---> Making bundle: test-integration (in bundles/test-integration)
SCRIPTDIR=/go/src/github.com/docker/docker/hack
HOSTNAME=b91aaa5d057c
DOCKER_STORAGE_OPTS=dm.override_udev_sync_check=true,dm.use_deferred_removal=true,dm.use_deferred_deletion=true
DEST=bundles/test-integration
PWD=/go/src/github.com/docker/docker
container=docker
HOME=/root
TEST_INTEGRATION_DIR=/go/src/github.com/docker/docker/integration/build
GOLANG_VERSION=1.13.8
TERM=xterm
DOCKER_PKG=github.com/docker/docker
SHLVL=1
TIMEOUT=30m
DOCKER_BUILDTAGS=apparmor seccomp selinux journald
DOCKER_GRAPHDRIVER=devicemapper
GO111MODULE=off
DOCKER_EXPERIMENTAL=y
TEST_SKIP_INTEGRATION_CLI=true
PATH=/usr/local/cli:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
MAKEDIR=/go/src/github.com/docker/docker/hack/make
TEST_FILTER=TestBuildWithCopyEmptyDir
GOPATH=/go
PKG_CONFIG=pkg-config
_=/usr/bin/env
Building test suite binary /go/src/github.com/docker/docker/integration/build/test.main
---> Making bundle: .integration-daemon-start (in bundles/test-integration)
Using test binary docker
# DOCKER_EXPERIMENTAL is set: starting daemon with experimental features enabled! 
INFO: Waiting for daemon to start...
Starting dockerd
.
---> Making bundle: .integration-daemon-setup (in bundles/test-integration)
---> Making bundle: .ensure-emptyfs (in bundles/test-integration)
Error: No such image: emptyfs
Running integration-test (iteration 1)
Running /go/src/github.com/docker/docker/integration/build (amd64.integration.build) flags=-test.v -test.timeout=30m  -test.run TestBuildWithCopyEmptyDir
Loaded image: buildpack-deps:jessie
Loaded image: busybox:latest
Loaded image: busybox:glibc
Loaded image: debian:jessie
Loaded image: hello-world:latest
INFO: Testing against a local daemon
=== RUN   TestBuildWithCopyEmptyDir
--- FAIL: TestBuildWithCopyEmptyDir (40.66s)
    build_test.go:673: assertion failed: string "{\"stream\":\"Step 1/3 : FROM    busybox\"}\r\n{\"stream\":\"\\n\"}\r\n{\"stream\":\" ---\\u003e 6ad733544a63\\n\"}\r\n{\"stream\":\"Step 2/3 : COPY    emptydir /var\"}\r\n{\"stream\":\"\\n\"}\r\n{\"stream\":\" ---\\u003e cb9faad76fb6\\n\"}\r\n{\"stream\":\"Step 3/3 : COPY    dir /opt\"}\r\n{\"stream\":\"\\n\"}\r\n{\"errorDetail\":{\"message\":\"failed to export image: failed to create image: failed to get layer sha256:4fe73bdf15f05e0d21c11046503627099eb5c2200bcc8831d21ff049a4139767: layer does not exist\"},\"error\":\"failed to export image: failed to create image: failed to get layer sha256:4fe73bdf15f05e0d21c11046503627099eb5c2200bcc8831d21ff049a4139767: layer does not exist\"}\r\n" does not contain "Successfully built"
FAIL

=== Failed
=== FAIL: amd64.integration.build TestBuildWithCopyEmptyDir (40.66s)
    build_test.go:673: assertion failed: string "{\"stream\":\"Step 1/3 : FROM    busybox\"}\r\n{\"stream\":\"\\n\"}\r\n{\"stream\":\" ---\\u003e 6ad733544a63\\n\"}\r\n{\"stream\":\"Step 2/3 : COPY    emptydir /var\"}\r\n{\"stream\":\"\\n\"}\r\n{\"stream\":\" ---\\u003e cb9faad76fb6\\n\"}\r\n{\"stream\":\"Step 3/3 : COPY    dir /opt\"}\r\n{\"stream\":\"\\n\"}\r\n{\"errorDetail\":{\"message\":\"failed to export image: failed to create image: failed to get layer sha256:4fe73bdf15f05e0d21c11046503627099eb5c2200bcc8831d21ff049a4139767: layer does not exist\"},\"error\":\"failed to export image: failed to create image: failed to get layer sha256:4fe73bdf15f05e0d21c11046503627099eb5c2200bcc8831d21ff049a4139767: layer does not exist\"}\r\n" does not contain "Successfully built"


DONE 1 tests, 1 failure in 244.974s
---> Making bundle: .integration-daemon-stop (in bundles/test-integration)
Removing test suite binaries
```

Test after fix

```
#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# GITCOMMIT = 38f52c9fec-unsupported
# The version you are building is listed as unsupported because
# there are some files in the git repository that are in an uncommitted state.
# Commit these changes, or add to .gitignore to remove the -unsupported from the version.
# Here is the current list:
 M builder/dockerfile/internals.go
 M integration/build/build_test.go
 M testutil/fakecontext/context.go
#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Removing bundles/

---> Making bundle: dynbinary (in bundles/dynbinary)
Building: bundles/dynbinary-daemon/dockerd-dev
GOOS="" GOARCH="" GOARM=""
Created binary: bundles/dynbinary-daemon/dockerd-dev

---> Making bundle: test-integration (in bundles/test-integration)
SCRIPTDIR=/go/src/github.com/docker/docker/hack
HOSTNAME=a406af34b943
DOCKER_STORAGE_OPTS=dm.override_udev_sync_check=true,dm.use_deferred_removal=true,dm.use_deferred_deletion=true
DEST=bundles/test-integration
PWD=/go/src/github.com/docker/docker
container=docker
HOME=/root
TEST_INTEGRATION_DIR=/go/src/github.com/docker/docker/integration/build
GOLANG_VERSION=1.13.8
TERM=xterm
DOCKER_PKG=github.com/docker/docker
SHLVL=1
TIMEOUT=30m
DOCKER_BUILDTAGS=apparmor seccomp selinux journald
DOCKER_GRAPHDRIVER=devicemapper
GO111MODULE=off
DOCKER_EXPERIMENTAL=y
TEST_SKIP_INTEGRATION_CLI=true
PATH=/usr/local/cli:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
MAKEDIR=/go/src/github.com/docker/docker/hack/make
GOPATH=/go
PKG_CONFIG=pkg-config
_=/usr/bin/env
Building test suite binary /go/src/github.com/docker/docker/integration/build/test.main
---> Making bundle: .integration-daemon-start (in bundles/test-integration)
Using test binary docker
# DOCKER_EXPERIMENTAL is set: starting daemon with experimental features enabled! 
INFO: Waiting for daemon to start...
Starting dockerd
.
---> Making bundle: .integration-daemon-setup (in bundles/test-integration)
---> Making bundle: .ensure-emptyfs (in bundles/test-integration)
Error: No such image: emptyfs
Running integration-test (iteration 1)
Running /go/src/github.com/docker/docker/integration/build (amd64.integration.build) flags=-test.v -test.timeout=30m 
Loaded image: buildpack-deps:jessie
Loaded image: busybox:latest
Loaded image: busybox:glibc
Loaded image: debian:jessie
Loaded image: hello-world:latest
INFO: Testing against a local daemon
=== RUN   TestCgroupNamespacesBuild
--- SKIP: TestCgroupNamespacesBuild (0.00s)
    build_cgroupns_linux_test.go:75: !requirement.CgroupNamespacesEnabled()
=== RUN   TestCgroupNamespacesBuildDaemonHostMode
--- SKIP: TestCgroupNamespacesBuildDaemonHostMode (0.00s)
    build_cgroupns_linux_test.go:86: !requirement.CgroupNamespacesEnabled()
=== RUN   TestBuildWithSession
--- SKIP: TestBuildWithSession (0.00s)
    build_session_test.go:25: TODO: BuildKit
=== RUN   TestBuildSquashParent
...
=== RUN   TestBuildWithCopyEmptyDir
--- PASS: TestBuildWithCopyEmptyDir (21.27s)
PASS

=== Skipped
=== SKIP: amd64.integration.build TestCgroupNamespacesBuild (0.00s)
    build_cgroupns_linux_test.go:75: !requirement.CgroupNamespacesEnabled()

=== SKIP: amd64.integration.build TestCgroupNamespacesBuildDaemonHostMode (0.00s)
    build_cgroupns_linux_test.go:86: !requirement.CgroupNamespacesEnabled()

=== SKIP: amd64.integration.build TestBuildWithSession (0.00s)
    build_session_test.go:25: TODO: BuildKit


DONE 33 tests, 3 skipped in 1843.238s
---> Making bundle: .integration-daemon-stop (in bundles/test-integration)
Removing test suite binaries
```

**- Description for the changelog**
Fixes docker build failed with layer does not exist when COPY empty dir
