### PR TITLE
Improve error-handling when combining "-p" / "--publish" with "host" network

### DIFF
--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -176,7 +176,11 @@ func (c *Cluster) GetService(input string, insertDefaults bool) (swarm.Service, 
 func (c *Cluster) CreateService(s swarm.ServiceSpec, encodedAuth string, queryRegistry bool) (*swarm.ServiceCreateResponse, error) {
 	var resp *swarm.ServiceCreateResponse
 	err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
-		err := c.populateNetworkID(ctx, state.controlClient, &s)
+		err := validateServiceSpec(&s)
+		if err != nil {
+			return err
+		}
+		err = c.populateNetworkID(ctx, state.controlClient, &s)
 		if err != nil {
 			return err
 		}
@@ -278,7 +282,11 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec swa
 	var resp *swarm.ServiceUpdateResponse
 
 	err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
-		err := c.populateNetworkID(ctx, state.controlClient, &spec)
+		err := validateServiceSpec(&spec)
+		if err != nil {
+			return err
+		}
+		err = c.populateNetworkID(ctx, state.controlClient, &spec)
 		if err != nil {
 			return err
 		}
@@ -661,4 +669,16 @@ func (c *Cluster) imageWithDigestString(ctx context.Context, image string, authC
 // formatting is hardcoded, but could me made smarter in the future
 func digestWarning(image string) string {
 	return fmt.Sprintf("image %s could not be accessed on a registry to record\nits digest. Each node will access %s independently,\npossibly leading to different nodes running different\nversions of the image.\n", image, image)
+}
+
+// validateServiceSpec validates that there are no published ports in network host mode
+func validateServiceSpec(s *swarm.ServiceSpec) error {
+	if len(s.EndpointSpec.Ports) > 0 {
+		for _, network := range s.TaskTemplate.Networks {
+			if network.Target == "host" {
+				return errdefs.Conflict(errors.New("cannot bind ports in host network mode"))
+			}
+		}
+	}
+	return nil
 }

--- a/daemon/cluster/services_test.go
+++ b/daemon/cluster/services_test.go
@@ -1,0 +1,56 @@
+package cluster
+
+import (
+	types "github.com/docker/docker/api/types/swarm"
+	"gotest.tools/v3/assert"
+	"testing"
+)
+
+func TestValidateServiceSpecWithPublishedPortsAndHostNetwork(t *testing.T) {
+	portConfig := types.PortConfig{}
+	ports := make([]types.PortConfig, 1)
+	ports[0] = portConfig
+	e := types.EndpointSpec{
+		Ports: ports,
+	}
+	task := types.TaskSpec{}
+	networks := make([]types.NetworkAttachmentConfig, 1)
+	networks[0].Target = "host"
+	task.Networks = networks
+	s := types.ServiceSpec{
+		EndpointSpec: &e,
+		TaskTemplate: task,
+	}
+	err := validateServiceSpec(&s)
+	assert.Error(t, err, "cannot bind ports in host network mode")
+}
+
+func TestValidateServiceSpecWithPublishedPorts(t *testing.T) {
+	portConfig := types.PortConfig{}
+	ports := make([]types.PortConfig, 1)
+	ports[0] = portConfig
+	e := types.EndpointSpec{
+		Ports: ports,
+	}
+	task := types.TaskSpec{}
+	s := types.ServiceSpec{
+		EndpointSpec: &e,
+		TaskTemplate: task,
+	}
+	err := validateServiceSpec(&s)
+	assert.NilError(t, err)
+}
+
+func TestValidateServiceSpecWithHostNetwork(t *testing.T) {
+	e := types.EndpointSpec{}
+	task := types.TaskSpec{}
+	networks := make([]types.NetworkAttachmentConfig, 1)
+	networks[0].Target = "host"
+	task.Networks = networks
+	s := types.ServiceSpec{
+		EndpointSpec: &e,
+		TaskTemplate: task,
+	}
+	err := validateServiceSpec(&s)
+	assert.NilError(t, err)
+}

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -276,6 +276,9 @@ func validateHostConfig(hostConfig *containertypes.HostConfig) (warnings []strin
 			return warnings, err
 		}
 	}
+	if len(hostConfig.PortBindings) > 0 && hostConfig.NetworkMode.IsHost() {
+		return errors.New("cannot bind ports in host network mode")
+	}
 	if err := validatePortBindings(hostConfig.PortBindings); err != nil {
 		return warnings, err
 	}

--- a/daemon/container_unix_test.go
+++ b/daemon/container_unix_test.go
@@ -11,34 +11,58 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-// TestContainerWarningHostAndPublishPorts that a warning is returned when setting network mode to host and specifying published ports.
+// TestContainerErrorHostAndPublishPorts asserts that an error is returned when binding ports while using network host mode upon starting a container.
 // This should not be tested on Windows because Windows doesn't support "host" network mode.
-func TestContainerWarningHostAndPublishPorts(t *testing.T) {
-	testCases := []struct {
-		ports    network.PortMap
-		warnings []string
-	}{
-		{ports: network.PortMap{}},
-		{ports: network.PortMap{
-			network.MustParsePort("8080"): []network.PortBinding{{HostPort: "8989"}},
-		}, warnings: []string{"Published ports are discarded when using host network mode"}},
+func TestContainerErrorHostAndPublishPorts(t *testing.T) {
+	// muteLogs()
+	hostConfig := &containertypes.HostConfig{
+		Runtime:     "runc",
+		NetworkMode: "host",
+		PortBindings: nat.PortMap{
+			"8080": []nat.PortBinding{{HostPort: "8989"}},
+		},
 	}
-	muteLogs(t)
+	cs := &config.Config{
+		CommonUnixConfig: config.CommonUnixConfig{
+			Runtimes: map[string]types.Runtime{"runc": {}},
+		},
+	}
+	d := &Daemon{configStore: cs}
+	_, err := d.verifyContainerSettings("", hostConfig, &containertypes.Config{}, false)
+	assert.Error(t, err, "cannot bind ports in host network mode")
+}
 
-	for _, tc := range testCases {
-		hostConfig := &containertypes.HostConfig{
-			Runtime:      "runc",
-			NetworkMode:  "host",
-			PortBindings: tc.ports,
-		}
-		d := &Daemon{}
-		cfg, err := config.New()
-		assert.NilError(t, err)
-		rts, err := setupRuntimes(cfg)
-		assert.NilError(t, err)
-		daemonCfg := &configStore{Config: *cfg, Runtimes: rts}
-		wrns, err := d.verifyContainerSettings(daemonCfg, hostConfig, &containertypes.Config{}, false)
-		assert.NilError(t, err)
-		assert.DeepEqual(t, tc.warnings, wrns)
+// TestContainerHostAndNoPublishedPorts asserts that there are no errors returned when using network host mode with no publied ports.
+func TestContainerHostAndNoPublishedPorts(t *testing.T) {
+	// muteLogs()
+	hostConfig := &containertypes.HostConfig{
+		Runtime:     "runc",
+		NetworkMode: "host",
 	}
+	cs := &config.Config{
+		CommonUnixConfig: config.CommonUnixConfig{
+			Runtimes: map[string]types.Runtime{"runc": {}},
+		},
+	}
+	d := &Daemon{configStore: cs}
+	_, err := d.verifyContainerSettings("", hostConfig, &containertypes.Config{}, false)
+	assert.NilError(t, err)
+}
+
+// TestContainerHostAndNoPubliedPorts asserts that there are no errors returned when publishing ports without using network host mode.
+func TestContainerPublishedPortsAndNoHost(t *testing.T) {
+	hostConfig := &containertypes.HostConfig{
+		Runtime: "runc",
+		PortBindings: nat.PortMap{
+			"8080": []nat.PortBinding{{HostPort: "8989"}},
+		},
+	}
+	cs := &config.Config{
+		CommonUnixConfig: config.CommonUnixConfig{
+			Runtimes: map[string]types.Runtime{"runc": {}},
+		},
+	}
+	d := &Daemon{configStore: cs}
+	_, err := d.verifyContainerSettings("", hostConfig, &containertypes.Config{}, false)
+	assert.NilError(t, err)
 }


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Regarding services :
      * Return an *error* when attempting to create a service using host networking and 
       publishing/mapping ports.
      * The error message is `cannot bind ports in host network mode`.
      * Earlier this was silently ignored and the service was created successfully. 
      * The service then would fail to be deployed with the error message `container cannot be disconnected from host network or connected to host network`
      * Now the service *doesn't get created in the first place*.
2. Regarding Container `docker run`:
     * Return a similar error when attempting to run a container with host networking mode and publishing / mapping ports.
     * Earlier the container would run normally with the following warning : 
      ` WARNING: Published ports are discarded when using host network mode`
     * Now it shows an error with the message `cannot bind ports in host network mode` instead of the warning.

**This fixes issue** #40306 

**- How I did it**
1. Regarding Services: 
    * By validating the serviceSpec upon creating, updating services and returning an error if there are published ports with host networking.
    * Unit tests were added to check the following test cases : 
            1. Published ports with host networking *(invalid)* and the error is asserted.
            2. Published ports *(valid)* and `nill` error is asserted.
            3. Host networking *(valid)* and `nill` error is asserted.
2. Regarding container `docker run`: 
     * By adding an extra validation upon validating the host config when attempting to run a container.
     * And returning an error if there are published/mapped ports when using host networking.
     * Get rid of the warning returned earlier as there is no reason for it now.
     * Unit tests were added to check the following test cases : 
            1. Published ports with host networking *(invalid)* and the error is asserted.
            2. Published ports *(valid)* and `nill` error is asserted.
            3. Host networking *(valid)* and `nill` error is asserted.

The changes were implemented in the *daemon* so that the error is produced regardless of which tool is used to connect with the API.

**- How to verify it**
1. By running the unit tests for the *daemon*  , *cluster* packages.
2. By trying to run a container with published ports and host networking and observing the returned error.
```
docker run -d --name foo --network=host -p 80:8080 nginx:alpine
Error response from daemon: cannot bind ports in host network mode
```
3. By trying to create a service with published ports and host networking and observing the returned error.
```
docker service create --name foo --network host --publish target=80,published=8000 nginx:alpine
Error response from daemon: cannot bind ports in host network mode
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Improve error-handling when combining "-p" / "--publish" with "host" network for services

**- A picture of a cute animal (not mandatory but encouraged)**

![Fuzzy Duck](https://user-images.githubusercontent.com/30473620/75632228-bedbfe80-5c02-11ea-830c-d078e21f8cb1.jpg)
