### PR TITLE
Add warnings for deprecated "cluster" functions, and deprecate API fields

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4186,7 +4186,7 @@ definitions:
 
           <p><br /></p>
 
-          > **Note**: This field is only propagated when using standalone Swarm
+          > **Deprecated**: This field is only propagated when using standalone Swarm
           > mode, and overlay networking using an external k/v store. Overlay
           > networks with Swarm mode enabled use the built-in raft store, and
           > this field will be empty.
@@ -4200,7 +4200,7 @@ definitions:
 
           <p><br /></p>
 
-          > **Note**: This field is only propagated when using standalone Swarm
+          > **Deprecated**: This field is only propagated when using standalone Swarm
           > mode, and overlay networking using an external k/v store. Overlay
           > networks with Swarm mode enabled use the built-in raft store, and
           > this field will be empty.

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -194,8 +194,8 @@ type Info struct {
 	Labels             []string
 	ExperimentalBuild  bool
 	ServerVersion      string
-	ClusterStore       string
-	ClusterAdvertise   string
+	ClusterStore       string `json:",omitempty"` // Deprecated: host-discovery and overlay networks with external k/v stores are deprecated
+	ClusterAdvertise   string `json:",omitempty"` // Deprecated: host-discovery and overlay networks with external k/v stores are deprecated
 	Runtimes           map[string]Runtime
 	DefaultRuntime     string
 	Swarm              swarm.Info

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -159,15 +159,18 @@ type CommonConfig struct {
 	// ClusterStore is the storage backend used for the cluster information. It is used by both
 	// multihost networking (to store networks and endpoints information) and by the node discovery
 	// mechanism.
+	// Deprecated: host-discovery and overlay networks with external k/v stores are deprecated
 	ClusterStore string `json:"cluster-store,omitempty"`
 
 	// ClusterOpts is used to pass options to the discovery package for tuning libkv settings, such
 	// as TLS configuration settings.
+	// Deprecated: host-discovery and overlay networks with external k/v stores are deprecated
 	ClusterOpts map[string]string `json:"cluster-store-opts,omitempty"`
 
 	// ClusterAdvertise is the network endpoint that the Engine advertises for the purpose of node
 	// discovery. This should be a 'host:port' combination on which that daemon instance is
 	// reachable by other hosts.
+	// Deprecated: host-discovery and overlay networks with external k/v stores are deprecated
 	ClusterAdvertise string `json:"cluster-advertise,omitempty"`
 
 	// MaxConcurrentDownloads is the maximum number of downloads that

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,6 +17,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.41](https://docs.docker.com/engine/api/v1.41/) documentation
 
+* The `ClusterStore` and `ClusterAdvertise` fields in `GET /info` are deprecated
+  and are now omitted if they contain an empty value. This change is not versioned,
+  and affects all API versions if the daemon has this patch.
 * The `filter` (singular) query parameter, which was deprecated in favor of the
   `filters` option in Docker 1.13, has now been removed from the `GET /images/json`
   endpoint. The parameter remains available when using API version 1.40 or below.


### PR DESCRIPTION
relates to https://github.com/moby/moby/issues/40383
follow-up to https://github.com/moby/moby/pull/40510

- Add warning about deprecated "cluster" options to "docker info"
- API: deprecate /info "ClusterStore" and "ClusterAdvertise" fields
