### PR TITLE
Add TC for com.docker.network.host_ipv4 label

### DIFF
--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/skip"
 )
 
@@ -88,4 +90,29 @@ func TestNetworkInvalidJSON(t *testing.T) {
 			assert.Check(t, is.Contains(string(buf), "got EOF while reading request body"))
 		})
 	}
+}
+
+func TestHostIPv4BridgeLabel(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.IsRemoteDaemon)
+	d := daemon.New(t)
+	d.Start(t)
+	defer d.Stop(t)
+	c := d.NewClientT(t)
+	defer c.Close()
+	ctx := context.Background()
+
+	ipv4SNATAddr := "172.0.0.172"
+	// Create a bridge network with --opt com.docker.network.host_ipv4=172.0.0.172
+	bridgeName := "hostIPv4Bridge"
+	network.CreateNoError(ctx, t, c, bridgeName,
+		network.WithDriver("bridge"),
+		network.WithOption("com.docker.network.host_ipv4", ipv4SNATAddr),
+		network.WithOption("com.docker.network.bridge.name", bridgeName),
+	)
+	out, err := c.NetworkInspect(ctx, bridgeName, types.NetworkInspectOptions{Verbose: true})
+	assert.NilError(t, err)
+	assert.Assert(t, len(out.IPAM.Config) > 0)
+	// Make sure the SNAT rule exists
+	icmd.RunCommand("iptables", "-t", "nat", "-C", "POSTROUTING", "-s", out.IPAM.Config[0].Subnet, "!", "-o", bridgeName, "-j", "SNAT", "--to-source", ipv4SNATAddr).Assert(t, icmd.Success)
 }


### PR DESCRIPTION
This PR adds a testcase for the com.docker.network.host_ipv4
label committed via https://github.com/docker/libnetwork/pull/2454