### PR TITLE
[19.03] Fix rate limiting for logger, increase refill rate

### DIFF
--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -508,7 +508,9 @@ func (r *controller) Logs(ctx context.Context, publisher exec.LogPublisher, opti
 	var (
 		// use a rate limiter to keep things under control but also provides some
 		// ability coalesce messages.
-		limiter = rate.NewLimiter(rate.Every(time.Second), 10<<20) // 10 MB/s
+		// this will implement a "token bucket" of size 10 MB, initially full and refilled
+		// at rate 10 MB tokens per second.
+		limiter = rate.NewLimiter(10<<20, 10<<20) // 10 MB/s
 		msgctx  = api.LogContext{
 			NodeID:    r.task.NodeID,
 			ServiceID: r.task.ServiceID,


### PR DESCRIPTION
Backports #39360 to 19.03

---

Signed-off-by: Ethan Mosbaugh <ethan@replicated.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

fixes #38640 

**- How I did it**

The rate limiter will get refilled at a rate of 1 token per second. My understanding of the code it is intended to get refilled at a rate of 10M / second.

https://github.com/moby/moby/blob/39c8e88068d9994c632231c74845ff08fe580e7f/vendor/golang.org/x/time/rate/rate.go#L31-L37

**- How to verify it**

```bash
$ docker service create --name lotsologs --restart-condition on-failure -d debian:stretch-slim bash -c "for i in \$(seq 1 60000); do cat /dev/urandom | tr -dc 'a-zA-Z0-9 ' | fold -w 256 | head -n 1; done"
y0uhc0ulyxcqe2r5gehfzeiks
```

wait a while for the logs to fill up

```
$ docker service logs lotsologs > tmp # hangs
^C
$ ls -lh tmp
-rw-rw-r-- 1 ethan ethan 12M Jun 12 21:07 tmp
```

**- Description for the changelog**

Fixed an issue that caused requests for docker swarm service and task logs to hang indefinitely for logs with size greater than 10 MB.

**- A picture of a cute animal (not mandatory but encouraged)**

![Gizmo PNG](https://user-images.githubusercontent.com/371319/59385656-aeed5900-8d19-11e9-961b-353be678dfdf.png)


