### PR TITLE
Fix `make shell`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -341,6 +341,8 @@ RUN mkdir -p hack \
   && chmod +x hack/dind-systemd
 ENTRYPOINT ["hack/dind-systemd"]
 
+FROM dev-systemd-${SYSTEMD} AS dev
+
 FROM runtime-dev AS binary-base
 ARG DOCKER_GITCOMMIT=HEAD
 ENV DOCKER_GITCOMMIT=${DOCKER_GITCOMMIT}
@@ -392,5 +394,5 @@ COPY --from=build-dynbinary /build/bundles/ /
 FROM scratch AS cross
 COPY --from=build-cross /build/bundles/ /
 
-FROM dev-systemd-${SYSTEMD} AS final
+FROM dev AS final
 COPY . /go/src/github.com/docker/docker


### PR DESCRIPTION
a3292263a3cb29c972b41511aeb0a3e36c8468c7 broke `make shell` which is
trying to build the `dev` Dockerfile stage which no longer exists after
the change.

This adds the stage back.