### PR TITLE
Remove "could not get checksum with tar-split" debug message

### DIFF
--- a/layer/migration.go
+++ b/layer/migration.go
@@ -15,7 +15,6 @@ import (
 func (ls *layerStore) ChecksumForGraphID(id, parent, oldTarDataPath, newTarDataPath string) (diffID DiffID, size int64, err error) {
 	defer func() {
 		if err != nil {
-			logrus.Debugf("could not get checksum for %q with tar-split: %q", id, err)
 			diffID, size, err = ls.checksumForGraphIDNoTarsplit(id, parent, newTarDataPath)
 		}
 	}()


### PR DESCRIPTION
fixes https://github.com/moby/buildkit/issues/1184

This code was originally written for v1.10 migration where it signified that layers
were recomputed from pre 1.8 layout and could possibly change the tarball checksums.

It's now being repurposed in the BuildKit adapter but there it doesn't have any
warn condition as all data generated by builder is new anyway.

Currently, debug log entries as the one below may appear in the daemon logs:

    [2019-10-02T10:00:06.690674253Z] could not get checksum for "x128nsj79yzfx4j5h6em2w2on" with tar-split: "no tar-split file"

This patch removes the debug log, as it may confuse users ("we couldn't validate
what we downloaded, but we're gonna run it anyway?")

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

