### PR TITLE
rootless: launch rootlesskit with --propagation=rslave

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -82,6 +82,7 @@ if [ -z $_DOCKERD_ROOTLESS_CHILD ]; then
 		--slirp4netns-seccomp=$DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SECCOMP \
 		--disable-host-loopback --port-driver=builtin \
 		--copy-up=/etc --copy-up=/run \
+		--propagation=rslave \
 		$DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS \
 		$0 $@
 else

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# v0.8.0
-: ${ROOTLESSKIT_COMMIT:=ce88a431e6a7cf891ebb68b10bfc6a5724b9ae72}
+# v0.9.1
+: ${ROOTLESSKIT_COMMIT:=db9657404cd538820e9e83d90dab2a78d8b833e6}
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Launch `rootlesskit` with `--propagation=rslave`.
The propagation was previously set to `rprivate` and didn't propagate mounts from the host mount namespace into the daemon's mount namespace.

Further information about `--propagation`: https://github.com/rootless-containers/rootlesskit/tree/v0.9.1#mount-propagation

> ## Mount propagation
> The mount namespace created by RootlessKit has `rprivate` propagation by default.
> 
> Starting with v0.9.0, the propagation can be set to `rslave` by specifying `--propagation=rslave`.
> 
> The propagation can be also set to `rshared`, but known not to work with `--copy-up`.
>
>  Note that `rslave` and `rshared` do not work as expected when the host root filesystem isn't mounted with "shared".
> (Use `findmnt -n -l -o propagation /` to inspect the current mount flag.)


**- How I did it**
Bumped up RootlessKit from v0.8.0 to v0.9.1:  https://github.com/rootless-containers/rootlesskit/compare/v0.8.0...v0.9.1

**- How to verify it**
* Run `docker run -it --rm -v /:/host alpine` as rootless.
* Mount something on `/mnt/somewhere` on the host.
* Make sure the mounted filesystem appears as `/host/mnt/somewhere` inside the container.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
rootless: launch rootlesskit with --propagation=rslave

**- A picture of a cute animal (not mandatory but encouraged)**

:penguin:
