### PR TITLE
EnsureRemoveAll, RecursiveUnmount: don't call Mounted around Unmount

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -144,9 +144,7 @@ func RecursiveUnmount(target string) error {
 		err = unmount(m.Mountpoint, mntDetach)
 		if err != nil {
 			if i == len(mounts)-1 { // last mount
-				if mounted, e := Mounted(m.Mountpoint); e != nil || mounted {
-					return err
-				}
+				return err
 			} else {
 				// This is some submount, we can ignore this error for now, the final unmount will fail if this is a real problem
 				logrus.WithError(err).Warnf("Failed to unmount submount %s", m.Mountpoint)

--- a/pkg/system/rm.go
+++ b/pkg/system/rm.go
@@ -63,12 +63,8 @@ func EnsureRemoveAll(dir string) error {
 			return err
 		}
 
-		if mounted, _ := mount.Mounted(pe.Path); mounted {
-			if e := mount.Unmount(pe.Path); e != nil {
-				if mounted, _ := mount.Mounted(pe.Path); mounted {
-					return errors.Wrapf(e, "error while removing %s", dir)
-				}
-			}
+		if e := mount.Unmount(pe.Path); e != nil {
+			return errors.Wrapf(e, "error while removing %s", dir)
 		}
 
 		if exitOnErr[pe.Path] == maxRetry {


### PR DESCRIPTION
### "pkg/system".EnsureRemoveAll()

* Call to `mount.Mounted()` is very expensive and it's redundant
   to call it before `Unmount()`.

* Calling `mount.Mounted()` after an error from `Unmount()` is
   questionable -- if unmounting failed, the mount is probably
   still there anyway, it doesn't make sense to check it.

### "pkg/system".RecursiveUnmount()

* same as item 2 above

This should result in faster code with no change in functionality.

@cpuguy83 PTAL