### PR TITLE
pkg/system: replace more uses of "syscall"

### DIFF
--- a/pkg/system/path_windows.go
+++ b/pkg/system/path_windows.go
@@ -1,24 +1,27 @@
 package system // import "github.com/docker/docker/pkg/system"
 
-import "syscall"
+import "golang.org/x/sys/windows"
 
 // GetLongPathName converts Windows short pathnames to full pathnames.
 // For example C:\Users\ADMIN~1 --> C:\Users\Administrator.
 // It is a no-op on non-Windows platforms
 func GetLongPathName(path string) (string, error) {
 	// See https://groups.google.com/forum/#!topic/golang-dev/1tufzkruoTg
-	p := syscall.StringToUTF16(path)
+	p, err := windows.UTF16FromString(path)
+	if err != nil {
+		return "", err
+	}
 	b := p // GetLongPathName says we can reuse buffer
-	n, err := syscall.GetLongPathName(&p[0], &b[0], uint32(len(b)))
+	n, err := windows.GetLongPathName(&p[0], &b[0], uint32(len(b)))
 	if err != nil {
 		return "", err
 	}
 	if n > uint32(len(b)) {
 		b = make([]uint16, n)
-		_, err = syscall.GetLongPathName(&p[0], &b[0], uint32(len(b)))
+		_, err = windows.GetLongPathName(&p[0], &b[0], uint32(len(b)))
 		if err != nil {
 			return "", err
 		}
 	}
-	return syscall.UTF16ToString(b), nil
+	return windows.UTF16ToString(b), nil
 }


### PR DESCRIPTION
follow-up to 069fdc8a083cb1663e4f86fe3fd9b9a1aebc3e54 (https://github.com/moby/moby/pull/33399), replacing more uses of the syscall package in favor of their "unix", "windows" equivalents in golang.org/x/sys.


