### PR TITLE
pkg/system: remove unused CommandLineToArgv

### DIFF
--- a/pkg/system/syscall_unix.go
+++ b/pkg/system/syscall_unix.go
@@ -9,9 +9,3 @@ import "golang.org/x/sys/unix"
 func Unmount(dest string) error {
 	return unix.Unmount(dest, 0)
 }
-
-// CommandLineToArgv should not be used on Unix.
-// It simply returns commandLine in the only element in the returned array.
-func CommandLineToArgv(commandLine string) ([]string, error) {
-	return []string{commandLine}, nil
-}

--- a/pkg/system/syscall_windows.go
+++ b/pkg/system/syscall_windows.go
@@ -104,29 +104,6 @@ func Unmount(_ string) error {
 	return nil
 }
 
-// CommandLineToArgv wraps the Windows syscall to turn a commandline into an argument array.
-func CommandLineToArgv(commandLine string) ([]string, error) {
-	var argc int32
-
-	argsPtr, err := windows.UTF16PtrFromString(commandLine)
-	if err != nil {
-		return nil, err
-	}
-
-	argv, err := windows.CommandLineToArgv(argsPtr, &argc)
-	if err != nil {
-		return nil, err
-	}
-	defer windows.LocalFree(windows.Handle(uintptr(unsafe.Pointer(argv))))
-
-	newArgs := make([]string, argc)
-	for i, v := range (*argv)[:argc] {
-		newArgs[i] = windows.UTF16ToString((*v)[:])
-	}
-
-	return newArgs, nil
-}
-
 // HasWin32KSupport determines whether containers that depend on win32k can
 // run on this machine. Win32k is the driver used to implement windowing.
 func HasWin32KSupport() bool {


### PR DESCRIPTION
This function was added in 9c4570a958df42d1ad19364b1a8da55b891d850a (https://github.com/moby/moby/pull/20662), but appears to never have been used.

Removing it, as it's not used in the codebase and, from a quick search on GitHub, also doesn't look to be used by other projects.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

