### PR TITLE
Make mount.Mount() faster^W great again

### DIFF
--- a/pkg/archive/archive_linux.go
+++ b/pkg/archive/archive_linux.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/containerd/continuity/fs"
+	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/system"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -152,9 +153,8 @@ func mknodChar0Overlay(cleansedOriginalPath string) error {
 		return errors.Wrapf(err, "failed to create a dummy lower file %s", lowerDummy)
 	}
 	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work)
-	// docker/pkg/mount.Mount() requires procfs to be mounted. So we use syscall.Mount() directly instead.
-	if err := syscall.Mount("overlay", merged, "overlay", uintptr(0), mOpts); err != nil {
-		return errors.Wrapf(err, "failed to mount overlay (%s) on %s", mOpts, merged)
+	if err := mount.Mount("overlay", merged, "overlay", mOpts); err != nil {
+		return err
 	}
 	mergedDummy := filepath.Join(merged, dummyBase)
 	if err := os.Remove(mergedDummy); err != nil {
@@ -237,9 +237,8 @@ func createDirWithOverlayOpaque(tmp string) (string, error) {
 		return "", errors.Wrapf(err, "failed to create a dummy lower directory %s", lowerDummy)
 	}
 	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work)
-	// docker/pkg/mount.Mount() requires procfs to be mounted. So we use syscall.Mount() directly instead.
-	if err := syscall.Mount("overlay", merged, "overlay", uintptr(0), mOpts); err != nil {
-		return "", errors.Wrapf(err, "failed to mount overlay (%s) on %s", mOpts, merged)
+	if err := mount.Mount("overlay", merged, "overlay", mOpts); err != nil {
+		return "", err
 	}
 	mergedDummy := filepath.Join(merged, dummyBase)
 	if err := os.Remove(mergedDummy); err != nil {

--- a/pkg/archive/archive_linux_test.go
+++ b/pkg/archive/archive_linux_test.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/docker/pkg/system"
 	rsystem "github.com/opencontainers/runc/libcontainer/system"
@@ -204,11 +205,11 @@ func supportsOverlay(dir string) error {
 		}
 	}
 	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work)
-	if err := syscall.Mount("overlay", merged, "overlay", uintptr(0), mOpts); err != nil {
-		return errors.Wrapf(err, "failed to mount overlay (%s) on %s", mOpts, merged)
+	if err := mount.Mount("overlay", merged, "overlay", mOpts); err != nil {
+		return err
 	}
-	if err := syscall.Unmount(merged, 0); err != nil {
-		return errors.Wrapf(err, "failed to unmount %s", merged)
+	if err := mount.Unmount(merged); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -105,7 +105,7 @@ func Mount(device, target, mType, options string) error {
 	return mount(device, target, mType, uintptr(flag), data)
 }
 
-// Mount will mount filesystem according to the specified configuration.
+// ForceMount will mount filesystem according to the specified configuration.
 // Options must be specified like the mount or fstab unix commands:
 // "opt1=val1,opt2=val2". See flags.go for supported option flags.
 //

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -97,24 +97,19 @@ func Mounted(mountpoint string) (bool, error) {
 	return len(entries) > 0, nil
 }
 
-// Mount will mount filesystem according to the specified configuration, on the
-// condition that the target path is *not* already mounted. Options must be
-// specified like the mount or fstab unix commands: "opt1=val1,opt2=val2". See
-// flags.go for supported option flags.
+// Mount will mount filesystem according to the specified configuration.
+// Options must be specified like the mount or fstab unix commands:
+// "opt1=val1,opt2=val2". See flags.go for supported option flags.
 func Mount(device, target, mType, options string) error {
 	flag, data := parseOptions(options)
-	if flag&REMOUNT != REMOUNT {
-		if mounted, err := Mounted(target); err != nil || mounted {
-			return err
-		}
-	}
 	return mount(device, target, mType, uintptr(flag), data)
 }
 
-// ForceMount will mount a filesystem according to the specified configuration,
-// *regardless* if the target path is not already mounted. Options must be
-// specified like the mount or fstab unix commands: "opt1=val1,opt2=val2". See
-// flags.go for supported option flags.
+// Mount will mount filesystem according to the specified configuration.
+// Options must be specified like the mount or fstab unix commands:
+// "opt1=val1,opt2=val2". See flags.go for supported option flags.
+//
+// Deprecated: use Mount instead.
 func ForceMount(device, target, mType, options string) error {
 	flag, data := parseOptions(options)
 	return mount(device, target, mType, uintptr(flag), data)


### PR DESCRIPTION
### pkg/mount.Mount: speedup (remove Mounted check)

This was added in PR #6669 (commit f87afda1234) because it was
otherwise impossible to do a re-mount of already mounted file system.

It is way better to just remove the Mounted() check altogether.

This change might potentially lead to multiple mounts to the same
mount point, so I audited all the users (except tests) and it looks
like no one is doing that:

 * volume/local maintains 'mounted' flag for every volume
 * pkg/chrootarchive already calls Mounted() before Mount()
   (so it actually parsed /proc/self/mountinfo twice, oops!)
 * daemon.mountVolumes() is called for docker cp only, and
   it is called once
 * daemon/graphdriver/zfs keeps track of 'mounted' status
 * daemon/graphdriver/devmapper: ditto
 * daemon.createSecretsDir() is only called once during container start

Surely I might have easily missed something so this needs a careful
review.

### pkg/archive: use mount pkg
    
It makes sense to use mount package here because
 - it no longer requires /proc to be mounted
 - it provides verbose errors so the caller doesn't have to

### TODO (not for this PR, just in general)
 * [ ] switch more users to mount.Mount/Unmount because of better errors

@thaJeztah @cpuguy83 @dmcgowan PTAL