### PR TITLE
containerd.installer: install containerd-shim-runc-v2

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -31,5 +31,6 @@ install_containerd() {
 
 	cp bin/containerd "${PREFIX}/containerd"
 	cp bin/containerd-shim "${PREFIX}/containerd-shim"
+	cp bin/containerd-shim-runc-v2 "${PREFIX}/containerd-shim-runc-v2"
 	cp bin/ctr "${PREFIX}/ctr"
 }


### PR DESCRIPTION
cgroup2 mode requires `containerd-shim-runc-v2` (containerd v1.4).
