### PR TITLE
ci: update golangci-lint v1.23.8

### DIFF
--- a/hack/dockerfile/install/golangci_lint.installer
+++ b/hack/dockerfile/install/golangci_lint.installer
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-: "${GOLANGCI_LINT_COMMIT=v1.20.0}"
+: "${GOLANGCI_LINT_COMMIT=v1.23.8}"
 
 install_golangci_lint() {
 	echo "Installing golangci-lint version ${GOLANGCI_LINT_COMMIT}"


### PR DESCRIPTION
full diff: https://github.com/golangci/golangci-lint/compare/v1.20.0...v1.23.8


