### PR TITLE
Add riscv64 support to the build scripts

### DIFF
--- a/daemon/graphdriver/quota/projectquota.go
+++ b/daemon/graphdriver/quota/projectquota.go
@@ -1,4 +1,4 @@
-// +build linux,!exclude_disk_quota
+// +build linux,!exclude_disk_quota,cgo
 
 //
 // projectquota.go - implements XFS project quota controls

--- a/daemon/graphdriver/quota/projectquota_unsupported.go
+++ b/daemon/graphdriver/quota/projectquota_unsupported.go
@@ -1,4 +1,4 @@
-// +build linux,exclude_disk_quota
+// +build linux,exclude_disk_quota linux,!cgo
 
 package quota // import "github.com/docker/docker/daemon/graphdriver/quota"
 

--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -70,9 +70,9 @@ hash_files() {
 		esac
 	fi
 
-	# -buildmode=pie is not supported on Windows and Linux on mips.
+	# -buildmode=pie is not supported on Windows and Linux on mips and riscv64.
 	case "$(go env GOOS)/$(go env GOARCH)" in
-		windows/* | linux/mips*) ;;
+		windows/* | linux/mips* | linux/riscv*) ;;
 
 		*)
 			BUILDFLAGS+=("-buildmode=pie")


### PR DESCRIPTION
**- What I did**

Added riscv64 architecture support to the scripts used to build Docker
and it's dependencies.

**- How I did it**

Added support to build scripts.

**- How to verify it**

Run `./hack/make.sh binary` on riscv64 host.

**- Description for the changelog**

Support riscv64 on the build scripts. 

