### PR TITLE
daemon: fail early if rootless && cgroupdriver == "systemd" && cgroup v1

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -791,6 +791,10 @@ func verifyDaemonSettings(conf *config.Config) error {
 		}
 	}
 
+	if conf.Rootless && UsingSystemd(conf) && !cgroups.IsCgroup2UnifiedMode() {
+		return fmt.Errorf("exec-opt native.cgroupdriver=systemd requires cgroup v2 for rootless mode")
+	}
+
 	if conf.DefaultRuntime == "" {
 		conf.DefaultRuntime = config.StockRuntimeName
 	}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
fail early if rootless && cgroupdriver == "systemd" && cgroup v1

**- How I did it**

**- How to verify it**
```console
$ dockerd-rootless.sh   --exec-opt native.cgroupdriver=systemd  --experimental
failed to start daemon: exec-opt native.cgroupdriver=systemd requires cgroup v2 for rootless mode
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
:penguin: