### PR TITLE
Switch to s390x Ubuntu 18.04 (carry 40663)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -474,13 +474,7 @@ pipeline {
                         beforeAgent true
                         expression { params.s390x }
                     }
-                    agent { label 's390x-ubuntu-1604' }
-                    // s390x machines run on Docker 18.06, and buildkit has some
-                    // bugs on that version. Build and use buildx instead.
-                    environment {
-                        USE_BUILDX      = '1'
-                        DOCKER_BUILDKIT = '0'
-                    }
+                    agent { label 's390x-ubuntu-1804' }
 
                     stages {
                         stage("Print info") {
@@ -497,8 +491,7 @@ pipeline {
                         stage("Build dev image") {
                             steps {
                                 sh '''
-                                make bundles/buildx
-                                bundles/buildx build --load --force-rm --build-arg APT_MIRROR=${APT_MIRROR} -t docker:${GIT_COMMIT} .
+                                docker build --force-rm --build-arg APT_MIRROR -t docker:${GIT_COMMIT} .
                                 '''
                             }
                         }
@@ -587,13 +580,7 @@ pipeline {
                         not { changeRequest() }
                         expression { params.s390x }
                     }
-                    agent { label 's390x-ubuntu-1604' }
-                    // s390x machines run on Docker 18.06, and buildkit has some
-                    // bugs on that version. Build and use buildx instead.
-                    environment {
-                        USE_BUILDX      = '1'
-                        DOCKER_BUILDKIT = '0'
-                    }
+                    agent { label 's390x-ubuntu-1804' }
 
                     stages {
                         stage("Print info") {
@@ -610,8 +597,7 @@ pipeline {
                         stage("Build dev image") {
                             steps {
                                 sh '''
-                                make bundles/buildx
-                                bundles/buildx build --load --force-rm --build-arg APT_MIRROR -t docker:${GIT_COMMIT} .
+                                docker build --force-rm --build-arg APT_MIRROR -t docker:${GIT_COMMIT} .
                                 '''
                             }
                         }


### PR DESCRIPTION
**- What I did**

We have updated half of the s390x Jenkins agents to Ubuntu 18.04, and also have a newer Docker 
carry https://github.com/moby/moby/pull/40663

version 19.03 installed. This PR takes care of that and uses the new agents with a docker build instead of the workaround.

**- How I did it**

Adjust the Jenkinsfile :-)

**- How to verify it**

Wait for CI to get a hopefully green build.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
