### PR TITLE
fix linting in pkg/mount

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -140,10 +140,9 @@ func RecursiveUnmount(target string) error {
 		if err != nil {
 			if i == len(mounts)-1 { // last mount
 				return err
-			} else {
-				// This is some submount, we can ignore this error for now, the final unmount will fail if this is a real problem
-				logrus.WithError(err).Warnf("Failed to unmount submount %s", m.Mountpoint)
 			}
+			// This is some submount, we can ignore this error for now, the final unmount will fail if this is a real problem
+			logrus.WithError(err).Warnf("Failed to unmount submount %s", m.Mountpoint)
 		}
 
 		logrus.Debugf("Unmounted %s", m.Mountpoint)


### PR DESCRIPTION
We recently updated golangci-lint, which is checking for some additional linting rules, causing a failure in code that was just merged to master; 5bd02b8a860ac054055de3ca5aba5b028627b4e6 (https://github.com/moby/moby/pull/40637)

