### PR TITLE
Simplify daemon.overlaySupportsSelinux(), fix use of bufio.Scanner.Err()

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -838,25 +838,14 @@ func overlaySupportsSelinux() (bool, error) {
 	}
 	defer f.Close()
 
-	var symAddr, symType, symName, text string
-
 	s := bufio.NewScanner(f)
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return false, err
-		}
-
-		text = s.Text()
-		if _, err := fmt.Sscanf(text, "%s %s %s", &symAddr, &symType, &symName); err != nil {
-			return false, fmt.Errorf("Scanning '%s' failed: %s", text, err)
-		}
-
-		// Check for presence of symbol security_inode_copy_up.
-		if symName == "security_inode_copy_up" {
+		if strings.HasSuffix(s.Text(), " security_inode_copy_up") {
 			return true, nil
 		}
 	}
-	return false, nil
+
+	return false, s.Err()
 }
 
 // configureKernelSecuritySupport configures and validates security support for the kernel

--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -236,10 +236,6 @@ func parseSubidFile(path, username string) (ranges, error) {
 
 	s := bufio.NewScanner(subidFile)
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return rangeList, err
-		}
-
 		text := strings.TrimSpace(s.Text())
 		if text == "" || strings.HasPrefix(text, "#") {
 			continue
@@ -260,5 +256,6 @@ func parseSubidFile(path, username string) (ranges, error) {
 			rangeList = append(rangeList, subIDRange{startid, length})
 		}
 	}
-	return rangeList, nil
+
+	return rangeList, s.Err()
 }


### PR DESCRIPTION
### fix use of bufio.Scanner.Err

The Err() method should be called after the Scan() loop, not inside it.

Found by: `git grep -A3 -F '.Scan()'`

### daemon.overlaySupportsSelinux: simplify check

1. Sscanf is very slow, and we don't use the first two fields -- get rid of it.
    
2. Since the field we search for is at the end of line and prepended by
       a space, we can just use strings.HaveSuffix.
    
3. Error checking for bufio.Scanner should be done after the Scan()
       loop, not inside it.
