### PR TITLE
unit test on TestParseSignal failed within pkg/signal package on mips64el

### DIFF
--- a/pkg/signal/signal_linux_mipsx.go
+++ b/pkg/signal/signal_linux_mipsx.go
@@ -35,7 +35,7 @@ var SignalMap = map[string]syscall.Signal{
 	"PWR":      unix.SIGPWR,
 	"QUIT":     unix.SIGQUIT,
 	"SEGV":     unix.SIGSEGV,
-	"SIGEMT":   unix.SIGEMT,
+	"EMT":      unix.SIGEMT,
 	"STOP":     unix.SIGSTOP,
 	"SYS":      unix.SIGSYS,
 	"TERM":     unix.SIGTERM,


### PR DESCRIPTION
unit test on TestParseSignal failed within pkg/signal package on mips64el

Signed-off-by: liuxiaodong <liuxiaodong@loongson.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I excute unit test on engine, but the TestParseSignal test case failed within pkg/signal package on mips64el platform.
**- How I did it**
excute hack/test/unit inside Dev container.
error log :
signal_test.go:20: assertion failed: error is not nil: Invalid signal: SIGEMT
signal_test.go:22: assertion failed:

When "ParseSignal" function parse sigStr from SignalMap, it find the signal object with key ("SIG"+sigStr). But EMT signal named "SIGEMT" in SignalMap structrue, so the real key is "SIGSIGEMT" , and cannot find the target signal.
**- How to verify it**
modify "SIGEMT" to "EMT" in SignalMap structrue.
then type, go test github.com/docker/docker/pkg/signal -count=1
expect,
ok github.com/docker/docker/pkg/signal	5.364s
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
unit test on TestParseSignal failed within pkg/signal package on mips64el

**- A picture of a cute animal (not mandatory but encouraged)**

