### PR TITLE
Yet better mountinfo parser

### DIFF
--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -148,7 +148,7 @@ func lookupZfsDataset(rootdir string) (string, error) {
 	}
 	wantedDev := stat.Dev
 
-	mounts, err := mount.GetMounts(nil)
+	mounts, err := mount.GetMounts(mount.FstypeFilter("zfs"))
 	if err != nil {
 		return "", err
 	}
@@ -158,7 +158,7 @@ func lookupZfsDataset(rootdir string) (string, error) {
 			continue // may fail on fuse file systems
 		}
 
-		if stat.Dev == wantedDev && m.Fstype == "zfs" {
+		if stat.Dev == wantedDev {
 			return m.Source, nil
 		}
 	}

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -3,7 +3,6 @@ package mount // import "github.com/docker/docker/pkg/mount"
 import (
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -40,44 +39,6 @@ func (e *mountError) Error() string {
 // Cause returns the underlying cause of the error
 func (e *mountError) Cause() error {
 	return e.err
-}
-
-// FilterFunc is a type defining a callback function
-// to filter out unwanted entries. It takes a pointer
-// to an Info struct (not fully populated, currently
-// only Mountpoint is filled in), and returns two booleans:
-//  - skip: true if the entry should be skipped
-//  - stop: true if parsing should be stopped after the entry
-type FilterFunc func(*Info) (skip, stop bool)
-
-// PrefixFilter discards all entries whose mount points
-// do not start with a prefix specified
-func PrefixFilter(prefix string) FilterFunc {
-	return func(m *Info) (bool, bool) {
-		skip := !strings.HasPrefix(m.Mountpoint, prefix)
-		return skip, false
-	}
-}
-
-// SingleEntryFilter looks for a specific entry
-func SingleEntryFilter(mp string) FilterFunc {
-	return func(m *Info) (bool, bool) {
-		if m.Mountpoint == mp {
-			return false, true // don't skip, stop now
-		}
-		return true, false // skip, keep going
-	}
-}
-
-// ParentsFilter returns all entries whose mount points
-// can be parents of a path specified, discarding others.
-// For example, given `/var/lib/docker/something`, entries
-// like `/var/lib/docker`, `/var` and `/` are returned.
-func ParentsFilter(path string) FilterFunc {
-	return func(m *Info) (bool, bool) {
-		skip := !strings.HasPrefix(path, m.Mountpoint)
-		return skip, false
-	}
 }
 
 // GetMounts retrieves a list of mounts for the current running process,

--- a/pkg/mount/mountinfo_filters.go
+++ b/pkg/mount/mountinfo_filters.go
@@ -42,3 +42,15 @@ func ParentsFilter(path string) FilterFunc {
 		return skip, false
 	}
 }
+
+// FstypeFilter returns all entries that match provided fstype(s).
+func FstypeFilter(fstype ...string) FilterFunc {
+	return func(m *Info) (bool, bool) {
+		for _, t := range fstype {
+			if m.Fstype == t {
+				return false, false // don't skeep, keep going
+			}
+		}
+		return true, false // skip, keep going
+	}
+}

--- a/pkg/mount/mountinfo_filters.go
+++ b/pkg/mount/mountinfo_filters.go
@@ -1,0 +1,44 @@
+package mount
+
+import "strings"
+
+// FilterFunc is a type defining a callback function for GetMount(),
+// used to filter out mountinfo entries we're not interested in.
+//
+// It takes a pointer to the Info struct (not fully populated,
+// currently only Mountpoint is filled in), and returns two booleans:
+//
+//  - skip: true if the entry should be skipped
+//  - stop: true if parsing should be stopped after the entry
+type FilterFunc func(*Info) (skip, stop bool)
+
+// PrefixFilter discards all entries whose mount points
+// do not start with a specific prefix
+func PrefixFilter(prefix string) FilterFunc {
+	return func(m *Info) (bool, bool) {
+		skip := !strings.HasPrefix(m.Mountpoint, prefix)
+		return skip, false
+	}
+}
+
+// SingleEntryFilter looks for a specific entry
+func SingleEntryFilter(mp string) FilterFunc {
+	return func(m *Info) (bool, bool) {
+		if m.Mountpoint == mp {
+			return false, true // don't skip, stop now
+		}
+		return true, false // skip, keep going
+	}
+}
+
+// ParentsFilter returns all entries whose mount points
+// can be parents of a path specified, discarding others.
+//
+// For example, given `/var/lib/docker/something`, entries
+// like `/var/lib/docker`, `/var` and `/` are returned.
+func ParentsFilter(path string) FilterFunc {
+	return func(m *Info) (bool, bool) {
+		skip := !strings.HasPrefix(path, m.Mountpoint)
+		return skip, false
+	}
+}

--- a/pkg/mount/mountinfo_freebsd.go
+++ b/pkg/mount/mountinfo_freebsd.go
@@ -33,6 +33,7 @@ func parseMountTable(filter FilterFunc) ([]*Info, error) {
 		var mountinfo Info
 		var skip, stop bool
 		mountinfo.Mountpoint = C.GoString(&entry.f_mntonname[0])
+		mountinfo.Fstype = C.GoString(&entry.f_fstypename[0])
 
 		if filter != nil {
 			// filter out entries we're not interested in
@@ -43,7 +44,6 @@ func parseMountTable(filter FilterFunc) ([]*Info, error) {
 		}
 
 		mountinfo.Source = C.GoString(&entry.f_mntfromname[0])
-		mountinfo.Fstype = C.GoString(&entry.f_fstypename[0])
 
 		out = append(out, &mountinfo)
 		if stop {

--- a/pkg/mount/mountinfo_linux.go
+++ b/pkg/mount/mountinfo_linux.go
@@ -71,11 +71,12 @@ func parseInfoFile(r io.Reader, filter FilterFunc) ([]*Info, error) {
 		p := &Info{}
 
 		// Fill in the fields that a filter might check
-		// (currently just the Mountpoint)
+		// (currently only Mountpoint and Fstype)
 		p.Mountpoint, err = strconv.Unquote(`"` + fields[4] + `"`)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Parsing '%s' failed: unable to unquote mount point field", fields[4])
 		}
+		p.Fstype = fields[sepIdx+1]
 
 		// Run a filter soon so we can skip parsing/adding entries
 		// the caller is not interested in
@@ -116,7 +117,6 @@ func parseInfoFile(r io.Reader, filter FilterFunc) ([]*Info, error) {
 			p.Optional = strings.Join(fields[6:sepIdx-1], " ")
 		}
 
-		p.Fstype = fields[sepIdx+1]
 		p.Source = fields[sepIdx+2]
 		p.VfsOpts = fields[sepIdx+3]
 

--- a/pkg/mount/mountinfo_linux.go
+++ b/pkg/mount/mountinfo_linux.go
@@ -36,6 +36,12 @@ func parseInfoFile(r io.Reader, filter FilterFunc) ([]*Info, error) {
 		   (9) filesystem type:  name of filesystem of the form "type[.subtype]"
 		   (10) mount source:  filesystem specific information or "none"
 		   (11) super options:  per super block options
+
+		   In other words, we have:
+		    * 6 mandatory fields	(1)..(6)
+		    * 0 or more optional fields	(7)
+		    * a separator field		(8)
+		    * 3 mandatory fields	(9)..(11)
 		*/
 
 		text := s.Text()
@@ -46,7 +52,43 @@ func parseInfoFile(r io.Reader, filter FilterFunc) ([]*Info, error) {
 			return nil, fmt.Errorf("Parsing '%s' failed: not enough fields (%d)", text, numFields)
 		}
 
+		// separator field
+		sepIdx := numFields - 4
+		// In Linux <= 3.9 mounting a cifs with spaces in a share
+		// name (like "//srv/My Docs") _may_ end up having a space
+		// in the last field of mountinfo (like "unc=//serv/My Docs").
+		// Since kernel 3.10-rc1, cifs option "unc=" is ignored,
+		// so spaces should not appear.
+		//
+		// Check for a separator, and work around the spaces bug
+		for fields[sepIdx] != "-" {
+			sepIdx--
+			if sepIdx == 5 {
+				return nil, errors.Errorf("Parsing '%s' failed: missing - separator", text)
+			}
+		}
+
 		p := &Info{}
+
+		// Fill in the fields that a filter might check
+		// (currently just the Mountpoint)
+		p.Mountpoint, err = strconv.Unquote(`"` + fields[4] + `"`)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Parsing '%s' failed: unable to unquote mount point field", fields[4])
+		}
+
+		// Run a filter soon so we can skip parsing/adding entries
+		// the caller is not interested in
+		var skip, stop bool
+		if filter != nil {
+			skip, stop = filter(p)
+			if skip {
+				continue
+			}
+		}
+
+		// Fill in the rest of the fields
+
 		// ignore any numbers parsing errors, as there should not be any
 		p.ID, _ = strconv.Atoi(fields[0])
 		p.Parent, _ = strconv.Atoi(fields[1])
@@ -62,52 +104,21 @@ func parseInfoFile(r io.Reader, filter FilterFunc) ([]*Info, error) {
 			return nil, errors.Wrapf(err, "Parsing '%s' failed: unable to unquote root field", fields[3])
 		}
 
-		p.Mountpoint, err = strconv.Unquote(`"` + fields[4] + `"`)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Parsing '%s' failed: unable to unquote mount point field", fields[4])
-		}
 		p.Opts = fields[5]
 
-		var skip, stop bool
-		if filter != nil {
-			// filter out entries we're not interested in
-			skip, stop = filter(p)
-			if skip {
-				continue
-			}
+		// zero or more optional fields
+		switch {
+		case sepIdx == 6:
+			// zero, do nothing
+		case sepIdx == 7:
+			p.Optional = fields[6]
+		default:
+			p.Optional = strings.Join(fields[6:sepIdx-1], " ")
 		}
 
-		// one or more optional fields, when a separator (-)
-		i := 6
-		for ; i < numFields && fields[i] != "-"; i++ {
-			switch i {
-			case 6:
-				p.Optional = fields[6]
-			default:
-				/* NOTE there might be more optional fields before the such as
-				   fields[7]...fields[N] (where N < sepIndex), although
-				   as of Linux kernel 4.15 the only known ones are
-				   mount propagation flags in fields[6]. The correct
-				   behavior is to ignore any unknown optional fields.
-				*/
-			}
-		}
-		if i == numFields {
-			return nil, fmt.Errorf("Parsing '%s' failed: missing separator ('-')", text)
-		}
-
-		// There should be 3 fields after the separator...
-		if i+4 > numFields {
-			return nil, fmt.Errorf("Parsing '%s' failed: not enough fields after a separator", text)
-		}
-		// ... but in Linux <= 3.9 mounting a cifs with spaces in a share name
-		// (like "//serv/My Documents") _may_ end up having a space in the last field
-		// of mountinfo (like "unc=//serv/My Documents"). Since kernel 3.10-rc1, cifs
-		// option unc= is ignored,  so a space should not appear. In here we ignore
-		// those "extra" fields caused by extra spaces.
-		p.Fstype = fields[i+1]
-		p.Source = fields[i+2]
-		p.VfsOpts = fields[i+3]
+		p.Fstype = fields[sepIdx+1]
+		p.Source = fields[sepIdx+2]
+		p.VfsOpts = fields[sepIdx+3]
 
 		out = append(out, p)
 		if stop {

--- a/pkg/mount/mountinfo_linux_test.go
+++ b/pkg/mount/mountinfo_linux_test.go
@@ -69,7 +69,7 @@ const (
 247 35 253:35 / /var/lib/docker/devicemapper/mnt/5fec11304b6f4713fea7b6ccdcc1adc0a1966187f590fe25a8227428a8df275d rw,relatime shared:229 - ext4 /dev/mapper/docker-253:2-425882-5fec11304b6f4713fea7b6ccdcc1adc0a1966187f590fe25a8227428a8df275d rw,seclabel,discard,stripe=16,data=ordered
 31 21 0:23 / /DATA/foo_bla_bla rw,relatime - cifs //foo/BLA\040BLA\040BLA/ rw,sec=ntlm,cache=loose,unc=\\foo\BLA BLA BLA,username=my_login,domain=mydomain.com,uid=12345678,forceuid,gid=12345678,forcegid,addr=10.1.30.10,file_mode=0755,dir_mode=0755,nounix,rsize=61440,wsize=65536,actimeo=1`
 
-	ubuntuMountInfo = `15 20 0:14 / /sys rw,nosuid,nodev,noexec,relatime - sysfs sysfs rw
+	ubuntuMountinfo = `15 20 0:14 / /sys rw,nosuid,nodev,noexec,relatime - sysfs sysfs rw
 16 20 0:3 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
 17 20 0:5 / /dev rw,relatime - devtmpfs udev rw,size=1015140k,nr_inodes=253785,mode=755
 18 17 0:11 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=000
@@ -436,7 +436,7 @@ func TestParseFedoraMountinfo(t *testing.T) {
 }
 
 func TestParseUbuntuMountinfo(t *testing.T) {
-	r := bytes.NewBuffer([]byte(ubuntuMountInfo))
+	r := bytes.NewBuffer([]byte(ubuntuMountinfo))
 	_, err := parseInfoFile(r, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -553,4 +553,17 @@ func TestParseMountinfoFilters(t *testing.T) {
 	assert.NilError(t, err)
 	// there should be 4 results returned: /sys/fs/cgroup/cpu,cpuacct /sys/fs/cgroup /sys /
 	assert.Equal(t, 4, len(infos))
+}
+
+func BenchmarkParseMountinfo(b *testing.B) {
+	buf := []byte(fedoraMountinfo + "\n" + ubuntuMountinfo + "\n" + gentooMountinfo)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r := bytes.NewReader(buf)
+		_, err := parseInfoFile(r, PrefixFilter("/sys"))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/pkg/mount/mountinfo_linux_test.go
+++ b/pkg/mount/mountinfo_linux_test.go
@@ -535,6 +535,8 @@ func TestParseMountinfoFilters(t *testing.T) {
 		{PrefixFilter("nonexistent"), 0},
 		// 4 entries: /sys/fs/cgroup/cpu,cpuacct /sys/fs/cgroup /sys /
 		{ParentsFilter("/sys/fs/cgroup/cpu,cpuacct"), 4},
+		{FstypeFilter("pstore"), 1},
+		{FstypeFilter("proc", "sysfs"), 2},
 	}
 
 	var r bytes.Reader


### PR DESCRIPTION
* Speed up mountinfo parser a little bit further
* Change the separator field search logic
* Add FstypeFilter and use it in zfs gd
* Add some tests and benchmarks

See individual commits for details.

WRT performance -- it's hard to do a clean test but there is an improvement up to 20% depending on the scenario.