### PR TITLE
fix "stat.Rdev" in TestFromStatT test case  invalid operation mismatched types on mips64el

### DIFF
--- a/pkg/system/stat_unix_test.go
+++ b/pkg/system/stat_unix_test.go
@@ -31,7 +31,7 @@ func TestFromStatT(t *testing.T) {
 	if stat.Gid != s.GID() {
 		t.Fatal("got invalid gid")
 	}
-	if stat.Rdev != s.Rdev() {
+	if uint64(stat.Rdev) != s.Rdev() {
 		t.Fatal("got invalid rdev")
 	}
 	if stat.Mtim != s.Mtim() {


### PR DESCRIPTION
compile error the "stat.Rdev" variable and "s.Rdev" mismatched types; 
convert "stat.Rdev" type to uint64 explicitly;

Signed-off-by: liuxiaodong <liuxiaodong@loongson.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
fix "stat.Rdev" in TestFromStatT test case  invalid operation mismatched types on mips64el
**- How I did it**
run unit test hack/test/unit, found this error:
./stat_unix_test.go:34:15: invalid operation: stat.Rdev != s.Rdev() (mismatched types uint32 and uint64) 
**- How to verify it**
convert "stat.Rdev" type to uint64 explicitly.
run go test github.com/docker/docker/pkg/system/ command inside docker Dev container, expect output:
ok  	github.com/docker/docker/pkg/system	0.049s
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix "stat.Rdev" in TestFromStatT test case  invalid operation mismatched types on mips64el

**- A picture of a cute animal (not mandatory but encouraged)**

