### PR TITLE
rootless: support forwarding signals from RootlessKit to dockerd

### DIFF
--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# v0.9.1
-: ${ROOTLESSKIT_COMMIT:=db9657404cd538820e9e83d90dab2a78d8b833e6}
+# v0.9.2
+: ${ROOTLESSKIT_COMMIT:=eefbc3f7fb73d9a993605c9ff9a36bfcad6c1270}
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
support forwarding signals from RootlessKit to dockerd

**- How I did it**

See https://github.com/rootless-containers/rootlesskit/pull/127

RootlessKit changes: https://github.com/rootless-containers/rootlesskit/compare/v0.9.1...v0.9.2


**- How to verify it**

Before:
```console
$ dockerd-rootless.sh --experimental
...
INFO[2020-03-15T11:02:16.526051714+09:00] API listen on /run/user/1001/docker.sock     
^C
$ echo $?
130
```

After:
```console
$ dockerd-rootless.sh --experimental
...
INFO[2020-03-15T11:02:42.263959577+09:00] API listen on /run/user/1001/docker.sock     
^CINFO[2020-03-15T11:02:43.493624366+09:00] Processing signal 'interrupt'                
INFO[2020-03-15T11:02:43.494655209+09:00] Processing signal 'interrupt'                
INFO[2020-03-15T11:02:43.495386457+09:00] stopping event stream following graceful shutdown  error="<nil>" module=libcontainerd namespace=moby
INFO[2020-03-15T11:02:43.495546067+09:00] Daemon shutdown complete                     
INFO[2020-03-15T11:02:43.495566660+09:00] stopping event stream following graceful shutdown  error="context canceled" module=libcontainerd namespace=plugins.moby
INFO[2020-03-15T11:02:43.495587614+09:00] stopping healthcheck following graceful shutdown  module=libcontainerd
INFO[2020-03-15T11:02:43.495986508+09:00] Processing signal 'interrupt'
$ echo $?
0
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
rootless: support forwarding signals from RootlessKit to dockerd


**- A picture of a cute animal (not mandatory but encouraged)**
🐧 
