### PR TITLE
fix container startup failure when parent directory of root directory is symbolic link

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1475,22 +1475,11 @@ func (daemon *Daemon) PluginGetter() *plugin.Store {
 
 // CreateDaemonRoot creates the root for the daemon
 func CreateDaemonRoot(config *config.Config) error {
-	// get the canonical path to the Docker root directory
-	var realRoot string
-	if _, err := os.Stat(config.Root); err != nil && os.IsNotExist(err) {
-		realRoot = config.Root
-	} else {
-		realRoot, err = fileutils.ReadSymlinkedDirectory(config.Root)
-		if err != nil {
-			return fmt.Errorf("Unable to get the full path to root (%s): %s", config.Root, err)
-		}
-	}
-
 	idMapping, err := setupRemappedRoot(config)
 	if err != nil {
 		return err
 	}
-	return setupDaemonRoot(config, realRoot, idMapping.RootPair())
+	return setupDaemonRoot(config, idMapping.RootPair())
 }
 
 // checkpointAndSave grabs a container lock to safely call container.CheckpointTo

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -27,6 +27,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/containerfs"
+	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/mount"
@@ -1255,32 +1256,38 @@ func setupRemappedRoot(config *config.Config) (*idtools.IdentityMapping, error) 
 	return &idtools.IdentityMapping{}, nil
 }
 
-func setupDaemonRoot(config *config.Config, rootDir string, rootIdentity idtools.Identity) error {
-	config.Root = rootDir
+func setupDaemonRoot(config *config.Config, rootIdentity idtools.Identity) error {
 	// the docker root metadata directory needs to have execute permissions for all users (g+x,o+x)
 	// so that syscalls executing as non-root, operating on subdirectories of the graph root
 	// (e.g. mounted layers of a container) can traverse this path.
 	// The user namespace support will create subdirectories for the remapped root host uid:gid
 	// pair owned by that same uid:gid pair for proper write access to those needed metadata and
 	// layer content subtrees.
-	if _, err := os.Stat(rootDir); err == nil {
+	if _, err := os.Stat(config.Root); err == nil {
 		// root current exists; verify the access bits are correct by setting them
-		if err = os.Chmod(rootDir, 0711); err != nil {
+		if err = os.Chmod(config.Root, 0711); err != nil {
 			return err
 		}
 	} else if os.IsNotExist(err) {
 		// no root exists yet, create it 0711 with root:root ownership
-		if err := os.MkdirAll(rootDir, 0711); err != nil {
+		if err := os.MkdirAll(config.Root, 0711); err != nil {
 			return err
 		}
 	}
+
+	// get the canonical path to the Docker root directory
+	realRoot, err := fileutils.ReadSymlinkedDirectory(config.Root)
+	if err != nil {
+		return fmt.Errorf("Unable to get the full path to root (%s): %s", config.Root, err)
+	}
+	config.Root = realRoot
 
 	// if user namespaces are enabled we will create a subtree underneath the specified root
 	// with any/all specified remapped root uid/gid options on the daemon creating
 	// a new subdirectory with ownership set to the remapped uid/gid (so as to allow
 	// `chdir()` to work for containers namespaced to that uid/gid)
 	if config.RemappedRoot != "" {
-		config.Root = filepath.Join(rootDir, fmt.Sprintf("%d.%d", rootIdentity.UID, rootIdentity.GID))
+		config.Root = filepath.Join(realRoot, fmt.Sprintf("%d.%d", rootIdentity.UID, rootIdentity.GID))
 		logrus.Debugf("Creating user namespaced daemon root: %s", config.Root)
 		// Create the root directory if it doesn't exist
 		if err := idtools.MkdirAllAndChown(config.Root, 0700, rootIdentity); err != nil {

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/pkg/containerfs"
+	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/platform"
@@ -471,12 +472,19 @@ func setupRemappedRoot(config *config.Config) (*idtools.IdentityMapping, error) 
 	return &idtools.IdentityMapping{}, nil
 }
 
-func setupDaemonRoot(config *config.Config, rootDir string, rootIdentity idtools.Identity) error {
-	config.Root = rootDir
+func setupDaemonRoot(config *config.Config, rootIdentity idtools.Identity) error {
 	// Create the root directory if it doesn't exists
 	if err := system.MkdirAllWithACL(config.Root, 0, system.SddlAdministratorsLocalSystem); err != nil {
 		return err
 	}
+
+	// get the canonical path to the Docker root directory
+	realRoot, err := fileutils.ReadSymlinkedDirectory(config.Root)
+	if err != nil {
+		return fmt.Errorf("Unable to get the full path to root (%s): %s", config.Root, err)
+	}
+	config.Root = realRoot
+
 	return nil
 }
 


### PR DESCRIPTION
… a soft link

Signed-off-by: Zhangjianming <zhang.jianming7@zte.com.cn>

**- What I did**
fix container startup failure when parent directory of root directory is symbolic link

**- How I did it**
Put the canonical path to get the Docker root directory into the setupDaemonRoot function

**- How to verify it**

- mkdir /tmp/test
- ln -s /tmp/test  /paasroot
- Set docker root directory to “/paasroot/docker”
- Run `docker run -it --rm busybox` 

```
$ docker run -it --rm busybox
docker: Error response from daemon: OCI runtime create failed: /paasroot/docker/devicemapper/mnt/7f42cde596b8786173fa89af890e58fc144db179bb397c09818e528c0da63685/rootfs is not an absolute path or is a symlink: unknown.
```

**- Description for the changelog**
fix container startup failure when parent directory of root directory is symbolic link

**- A picture of a cute animal (not mandatory but encouraged)**

