### PR TITLE
Make sure to delete symbolic link files when storage layer creation failed

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -350,7 +350,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr
 	defer func() {
 		// Clean up on failure
 		if retErr != nil {
-			os.RemoveAll(dir)
+			d.Remove(id)
 		}
 	}()
 


### PR DESCRIPTION
…ailed

Signed-off-by: Zhangjianming <zhang.jianming7@zte.com.cn>

**- What I did**
fix symbolic link files may remain when storage layer creation failed using the overlay2 storage driver.
**- How I did it**
Replace os.Removeall() with d.Remove()
**- How to verify it**

**- Description for the changelog**
Make sure to delete symbolic link files when storage layer creation failed


**- A picture of a cute animal (not mandatory but encouraged)**

