### PR TITLE
Fix CPU Stat value UsageInUsermode on Windows

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -556,7 +556,7 @@ func (daemon *Daemon) stats(c *container.Container) (*types.StatsJSON, error) {
 			CPUUsage: types.CPUUsage{
 				TotalUsage:        hcss.Processor.TotalRuntime100ns,
 				UsageInKernelmode: hcss.Processor.RuntimeKernel100ns,
-				UsageInUsermode:   hcss.Processor.RuntimeKernel100ns,
+				UsageInUsermode:   hcss.Processor.RuntimeUser100ns,
 			},
 		}
 


### PR DESCRIPTION
**- What I did**
Fix CPU Stat value `UsageInUsermode` on Windows.
I did not create an issue for this PR as the fix is quite simple.

**- How I did it**
Looks like a wrong copy-paste using `RuntimeKernel100ns` twice instead of `RuntimeUser100ns`

**- How to verify it**
Any API call to `containers/id/stats` will show different values for Kernel and User, currently it's always the same value.

**- Description for the changelog**
Fix CPU Stat value `UsageInUsermode` on Windows