### PR TITLE
Add DefaultAddressPools to docker info

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4676,6 +4676,25 @@ definitions:
           such as number of nodes, and expiration are included.
         type: "string"
         example: "Community Engine"
+      DefaultAddressPools:
+        description: |
+          List of custom default address pools for local networks, which can be
+          specified in the daemon.json file or dockerd option.
+
+          Example: a Base "10.10.0.0/16" with Size 24 will define the set of 256
+          10.10.[0-255].0/24 address pools.
+        type: "array"
+        items:
+          type: "object"
+          properties:
+            Base:
+              description: "The network address in CIDR format"
+              type: "string"
+              example: "10.10.0.0/16"
+            Size:
+              description: "The network pool size"
+              type: "integer"
+              example: "24"
       Warnings:
         description: |
           List of warnings / informational messages about missing features, or

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -203,20 +203,27 @@ type Info struct {
 	// LiveRestoreEnabled determines whether containers should be kept
 	// running when the daemon is shutdown or upon daemon start if
 	// running containers are detected
-	LiveRestoreEnabled bool
-	Isolation          container.Isolation
-	InitBinary         string
-	ContainerdCommit   Commit
-	RuncCommit         Commit
-	InitCommit         Commit
-	SecurityOptions    []string
-	ProductLicense     string `json:",omitempty"`
-	Warnings           []string
+	LiveRestoreEnabled  bool
+	Isolation           container.Isolation
+	InitBinary          string
+	ContainerdCommit    Commit
+	RuncCommit          Commit
+	InitCommit          Commit
+	SecurityOptions     []string
+	ProductLicense      string `json:",omitempty"`
+	DefaultAddressPools []NetworkAddressPool
+	Warnings            []string
 }
 
 // KeyValue holds a key/value pair
 type KeyValue struct {
 	Key, Value string
+}
+
+// NetworkAddressPool is a temp struct used by Info struct
+type NetworkAddressPool struct {
+	Base string
+	Size int
 }
 
 // SecurityOpt contains the name and options of a security option

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -78,6 +78,7 @@ func (daemon *Daemon) SystemInfo() *types.Info {
 	daemon.fillPluginsInfo(v)
 	daemon.fillSecurityOptions(v, sysInfo)
 	daemon.fillLicense(v)
+	daemon.fillDefaultAddressPools(v)
 
 	if v.DefaultRuntime == config.LinuxV1RuntimeName {
 		v.Warnings = append(v.Warnings, fmt.Sprintf("Configured default runtime %q is deprecated and will be removed in the next release.", config.LinuxV1RuntimeName))
@@ -226,6 +227,15 @@ func (daemon *Daemon) fillAPIInfo(v *types.Info) {
 			v.Warnings = append(v.Warnings, fmt.Sprintf("WARNING: API is accessible on https://%s without TLS client verification.%s", addr, warn))
 			continue
 		}
+	}
+}
+
+func (daemon *Daemon) fillDefaultAddressPools(v *types.Info) {
+	for _, pool := range daemon.configStore.DefaultAddressPools.Value() {
+		v.DefaultAddressPools = append(v.DefaultAddressPools, types.NetworkAddressPool{
+			Base: pool.Base,
+			Size: pool.Size,
+		})
 	}
 }
 


### PR DESCRIPTION
**- What I did**
This PR will enhance `docker info` following #40388 :

> Things to enhance:
> show the current value as part of the output of docker info (so that the user can see the configured value)

_Originally posted by @thaJeztah in https://github.com/moby/moby/issues/40388#issuecomment-576238514_

**- How I did it**
add `DefaultAddressPools` field to `API "/info"`

**- How to verify it**
Steps to verify: 
```
# cat /etc/docker/daemon.json 
{
  "default-address-pools": [ { "base": "10.123.0.0/16", "size": 24 }, { "base": "10.12.0.0/16", "size": 24 } ]
}
# curl --unix-socket /var/run/docker.sock http:/v1.41/info 2>/dev/null  |  jq ."DefaultAddressPools" 
[
  {
    "size": 24,
    "base": "10.123.0.0/16"
  },
  {
    "size": 24,
    "base": "10.12.0.0/16"
  }
]
```

**- Description for the changelog**
Add "Default Address Pools" to docker info output
