### PR TITLE
vendor: bump libnetwork ef149a924dfde2e506ea3cb3f617d7d0fa96b8ee

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: "${LIBNETWORK_COMMIT:=beab24292cb13d13670985fc860215f9e296bd47}"
+: "${LIBNETWORK_COMMIT:=ef149a924dfde2e506ea3cb3f617d7d0fa96b8ee}"
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/gofrs/flock                              392e7fae8f1b0bdbd67dad7237d2
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        beab24292cb13d13670985fc860215f9e296bd47
+github.com/docker/libnetwork                        ef149a924dfde2e506ea3cb3f617d7d0fa96b8ee
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ip_forwarding.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ip_forwarding.go
@@ -34,11 +34,11 @@ func setupIPForwarding(enableIPTables bool) error {
 		if err := configureIPForwarding(true); err != nil {
 			return fmt.Errorf("Enabling IP forwarding failed: %v", err)
 		}
-	}
-
-	// Set the default policy on forward chain to drop only if the
-	// daemon option iptables is not set to false.
-	if enableIPTables {
+		// When enabling ip_forward set the default policy on forward chain to
+		// drop only if the daemon option iptables is not set to false.
+		if !enableIPTables {
+			return nil
+		}
 		if err := iptables.SetDefaultPolicy(iptables.Filter, "FORWARD", iptables.Drop); err != nil {
 			if err := configureIPForwarding(false); err != nil {
 				logrus.Errorf("Disabling IP forwarding failed, %v", err)

--- a/vendor/github.com/docker/libnetwork/resolver.go
+++ b/vendor/github.com/docker/libnetwork/resolver.go
@@ -484,7 +484,7 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 			resp, err = co.ReadMsg()
 			// Truncated DNS replies should be sent to the client so that the
 			// client can retry over TCP
-			if err != nil && !resp.Truncated {
+			if err != nil && (resp != nil && !resp.Truncated) {
 				r.forwardQueryEnd()
 				logrus.Debugf("[resolver] read from DNS server failed, %s", err)
 				continue


### PR DESCRIPTION
Full diff https://github.com/moby/libnetwork/compare/beab24292cb13d13670985fc860215f9e296bd47...ef149a924dfde2e506ea3cb3f617d7d0fa96b8ee

changes:

- https://github.com/moby/libnetwork/pull/2460 Revert "Always configure iptables forward policy" 
- https://github.com/moby/libnetwork/pull/2540 Fixes a panic in the DNS resolver 
  - this change fix https://github.com/moby/moby/issues/40715

