### PR TITLE
daemon: add "no_btrfs" build-tag to disable BTRFS storage driver

### DIFF
--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!no_btrfs
 
 package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"
 

--- a/daemon/graphdriver/btrfs/btrfs_test.go
+++ b/daemon/graphdriver/btrfs/btrfs_test.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!no_btrfs
 
 package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"
 

--- a/daemon/graphdriver/btrfs/dummy_unsupported.go
+++ b/daemon/graphdriver/btrfs/dummy_unsupported.go
@@ -1,3 +1,3 @@
-// +build !linux !cgo
+// +build !linux !cgo linux,no_btrfs
 
 package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"

--- a/daemon/graphdriver/btrfs/version.go
+++ b/daemon/graphdriver/btrfs/version.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!no_btrfs
 
 package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"
 

--- a/daemon/graphdriver/btrfs/version_test.go
+++ b/daemon/graphdriver/btrfs/version_test.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!no_btrfs
 
 package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"
 

--- a/daemon/graphdriver/register/register_btrfs.go
+++ b/daemon/graphdriver/register/register_btrfs.go
@@ -1,4 +1,4 @@
-// +build !exclude_graphdriver_btrfs,linux
+// +build !exclude_graphdriver_btrfs,linux linux,!no_btrfs
 
 package register // import "github.com/docker/docker/daemon/graphdriver/register"
 

--- a/project/PACKAGERS.md
+++ b/project/PACKAGERS.md
@@ -173,7 +173,7 @@ for all graphdrivers are built in.
 
 To disable btrfs:
 ```bash
-export DOCKER_BUILDTAGS='exclude_graphdriver_btrfs'
+export DOCKER_BUILDTAGS='no_btrfs'
 ```
 
 To disable devicemapper:


### PR DESCRIPTION
btrfs was marked [deprecated in RHEL/CentOS 7.4][1]:

> Red Hat Enterprise Linux 7.4 introduces the last planned update to this
> feature. Btrfs has been deprecated, which means Red Hat will not be moving
> Btrfs to a fully supported feature and it will be removed in a future major
> release of Red Hat Enterprise Linux. (BZ#1477977)

And [removed in RHEL/CentOS 8][2]:

> The Btrfs file system has been removed in Red Hat Enterprise Linux 8. This
> includes the following components:
>
>  - The `btrfs.ko` kernel module
>  - The `btrfs-progs` package
>  - The snapper package
>
> You can no longer create, mount, or install on Btrfs file systems in Red Hat
> Enterprise Linux 8. The Anaconda installer and the Kickstart commands no longer
> support Btrfs.

This patch adds a `no_btrfs` build-tag to allow building the daemon on
platforms that do not support btrfs.

[1]: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/7.4_release_notes/index
[2]: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/considerations_in_adopting_rhel_8/file-systems-and-storage_considerations-in-adopting-rhel-8

