### PR TITLE
seccomp: allow syscall membarrier

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -187,6 +187,7 @@
 				"lstat",
 				"lstat64",
 				"madvise",
+				"membarrier",
 				"memfd_create",
 				"mincore",
 				"mkdir",

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -180,6 +180,7 @@ func DefaultProfile() *types.Seccomp {
 				"lstat",
 				"lstat64",
 				"madvise",
+				"membarrier",
 				"memfd_create",
 				"mincore",
 				"mkdir",


### PR DESCRIPTION
**- What I did**

Allow syscall `membarrier` in the default seccomp profile in order to fix memory coherency issues leading to segfault errors on Alpine containers. It was firstly noticed with AWS EC2 instances running the docker image `node:10-alpine` and failing almost all the time.
We could also reproduce it locally when slowing down the node process with ltrace.

The [musl libc  uses indeed the syscall](https://github.com/bminor/musl/blob/33338ebc853d37c80f0f236cc7a92cb0acc6aace/ldso/dynlink.c#L1579) in its implementation of `dlopen()`, leading to memory incoherence when used concurrently, which is the case with node's libuv.

**- How I did it**

Add membarrier to the list of allowed syscalls.

**- How to verify it**

Write a test using membarrier.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

seccomp: allow syscall membarrier