### PR TITLE
fix "stat.Rdev" in TestFromStatT test case invalid operation mismatch…

### DIFF
--- a/pkg/system/stat_unix_test.go
+++ b/pkg/system/stat_unix_test.go
@@ -31,7 +31,8 @@ func TestFromStatT(t *testing.T) {
 	if stat.Gid != s.GID() {
 		t.Fatal("got invalid gid")
 	}
-	if stat.Rdev != s.Rdev() {
+	//nolint:unconvert // conversion needed to fix mismatch types on mips64el
+	if uint64(stat.Rdev) != s.Rdev() {
 		t.Fatal("got invalid rdev")
 	}
 	if stat.Mtim != s.Mtim() {


### PR DESCRIPTION
> compile error the "stat.Rdev" variable and "s.Rdev" mismatched types;
> convert "stat.Rdev" type to uint64 explicitly;
> 
> Signed-off-by: liuxiaodong [liuxiaodong@loongson.cn](mailto:liuxiaodong@loongson.cn)
> 
> **- What I did**
> fix "stat.Rdev" in TestFromStatT test case invalid operation mismatched types on mips64el
> **- How I did it**
> run unit test hack/test/unit, found this error:
> ./stat_unix_test.go:34:15: invalid operation: stat.Rdev != s.Rdev() (mismatched types uint32 and uint64)
> **- How to verify it**
> convert "stat.Rdev" type to uint64 explicitly.
> run go test github.com/docker/docker/pkg/system/ command inside docker Dev container, expect output:
> ok github.com/docker/docker/pkg/system 0.049s
> **- Description for the changelog**
> 
> fix "stat.Rdev" in TestFromStatT test case invalid operation mismatched types on mips64el
> 
> **- A picture of a cute animal (not mandatory but encouraged)**

Just to help update for https://github.com/moby/moby/pull/40705

cc @XiaodongLoong 