### PR TITLE
Bump swarmkit to ebe39a32e3ed4c3a3783a02c11cccf388818694c

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -130,7 +130,7 @@ github.com/containerd/ttrpc                         0be804eadb152bc3b3c20c5edc31
 github.com/gogo/googleapis                          01e0f9cca9b92166042241267ee2a5cdf5cff46c # v1.3.2
 
 # cluster
-github.com/docker/swarmkit                          49e35619b18200845c9365c1e953440c28868002
+github.com/docker/swarmkit                          ebe39a32e3ed4c3a3783a02c11cccf388818694c
 github.com/gogo/protobuf                            5628607bb4c51c3157aacc3a50f0ab707582b805 # v1.3.1
 github.com/golang/protobuf                          d23c5127dc24889085f8ccea5c9d560a57a879d8 # v1.3.3
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2

--- a/vendor/github.com/docker/swarmkit/agent/storage.go
+++ b/vendor/github.com/docker/swarmkit/agent/storage.go
@@ -131,7 +131,9 @@ func PutTask(tx *bolt.Tx, task *api.Task) error {
 
 // PutTaskStatus updates the status for the task with id.
 func PutTaskStatus(tx *bolt.Tx, id string, status *api.TaskStatus) error {
-	return withCreateTaskBucketIfNotExists(tx, id, func(bkt *bolt.Bucket) error {
+	// this used to be withCreateTaskBucketIfNotExists, but that could lead
+	// to weird race conditions, and was not necessary.
+	return withTaskBucket(tx, id, func(bkt *bolt.Bucket) error {
 		p, err := proto.Marshal(status)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Bumps swarmkit vendoring.

Includes docker/swarmkit#2938, which fixes tasks.db growing out of control on worker nodes.

relates to / addresses:

- https://github.com/moby/moby/issues/34827 "single manager docker swarm stuck in Down state after reboot"
- https://github.com/docker/swarmkit/issues/2367 Swarm's tasks.db takes up lots of disk space
- https://github.com/docker/swarmkit/issues/2672 Possible bugs in task reaper
- https://github.com/moby/moby/issues/40573 Docker 19.03.6 crash



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix a bug where the tasks.db file grows uncontrolled on Swarm worker nodes.
