### PR TITLE
add zombie check for container when killing it

### DIFF
--- a/pkg/system/process_unix.go
+++ b/pkg/system/process_unix.go
@@ -3,6 +3,9 @@
 package system // import "github.com/docker/docker/pkg/system"
 
 import (
+	"fmt"
+	"io/ioutil"
+	"strings"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -21,4 +24,21 @@ func IsProcessAlive(pid int) bool {
 // KillProcess force-stops a process.
 func KillProcess(pid int) {
 	unix.Kill(pid, unix.SIGKILL)
+}
+
+// IsProcessZombie return true if process has a state with "Z"
+// http://man7.org/linux/man-pages/man5/proc.5.html
+func IsProcessZombie(pid int) (bool, error) {
+	statPath := fmt.Sprintf("/proc/%d/stat", pid)
+	dataBytes, err := ioutil.ReadFile(statPath)
+	if err != nil {
+		return false, err
+	}
+	data := string(dataBytes)
+	sdata := strings.SplitN(data, " ", 4)
+	if len(sdata) >= 3 && sdata[2] == "Z" {
+		return true, nil
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
An alternative fix for https://github.com/moby/moby/issues/40735.

related issues: 

- fixes https://github.com/moby/moby/issues/40735 Zombie container can't stop lead to file descriptors le
- addresses https://github.com/moby/moby/issues/39407 Docker stop container can't work, When container pid 1 becomes a zombie process
- addresses https://github.com/moby/moby/issues/35910 Cannot stop container with zombie


