### PR TITLE
build Dockerfile allows arg for base build FROM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ ARG GO_VERSION=1.13.8
 ARG DEBIAN_FRONTEND=noninteractive
 ARG VPNKIT_VERSION=0.4.0
 ARG DOCKER_BUILDTAGS="apparmor seccomp selinux"
+ARG GOLANG_IMAGE="golang:${GO_VERSION}-buster"
 
-FROM golang:${GO_VERSION}-buster AS base
+FROM ${GOLANG_IMAGE} AS base
 RUN echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 ARG APT_MIRROR
 RUN sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list \


### PR DESCRIPTION
**- What I did**

- Allow an overridge ARG to specify an alternate GOLANG build environments 

**- How I did it**

- Dockerfile now has an ARG for fully specifying GOLANG base image used for build
- Base image defaults to current patter

** Why I did it **

https://github.com/moby/moby/issues/40756

* This allows testing of alternate GOLANG environments
* Required downstream (EE) for things like FIPS testing

**- How to verify it**

- Test that the normal default build still builds using the GOLANG buster build as expected
- Test that the override works

**- Description for the changelog**

Allow an overridge ARG to specify an alternate GOLANG build environments 

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://i.redd.it/n1ep7qdfwam41.jpg)

Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>
