### PR TITLE
[19.03] vendor: containerd 481103c8793316c118d9f795cde18060847c370e

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -117,7 +117,7 @@ github.com/googleapis/gax-go                        317e0006254c44a0ac427cc52a0e
 google.golang.org/genproto                          694d95ba50e67b2e363f3483057db5d4910c18f9
 
 # containerd
-github.com/containerd/containerd                    7c1e88399ec0b0b077121d9d5ad97e647b11c870
+github.com/containerd/containerd                    481103c8793316c118d9f795cde18060847c370e
 github.com/containerd/fifo                          a9fb20d87448d386e6d50b1f2e1fa70dcf0de43c
 github.com/containerd/continuity                    aaeac12a7ffcd198ae25440a9dff125c2e2703a7
 github.com/containerd/cgroups                       5fbad35c2a7e855762d3c60f2e474ffcad0d470a

--- a/vendor/github.com/containerd/containerd/platforms/compare.go
+++ b/vendor/github.com/containerd/containerd/platforms/compare.go
@@ -29,11 +29,48 @@ type MatchComparer interface {
 // Only returns a match comparer for a single platform
 // using default resolution logic for the platform.
 //
+// For ARMv8, will also match ARMv7, ARMv6 and ARMv5 (for 32bit runtimes)
 // For ARMv7, will also match ARMv6 and ARMv5
 // For ARMv6, will also match ARMv5
 func Only(platform specs.Platform) MatchComparer {
 	platform = Normalize(platform)
 	if platform.Architecture == "arm" {
+		if platform.Variant == "v8" {
+			return orderedPlatformComparer{
+				matchers: []Matcher{
+					&matcher{
+						Platform: platform,
+					},
+					&matcher{
+						Platform: specs.Platform{
+							Architecture: platform.Architecture,
+							OS:           platform.OS,
+							OSVersion:    platform.OSVersion,
+							OSFeatures:   platform.OSFeatures,
+							Variant:      "v7",
+						},
+					},
+					&matcher{
+						Platform: specs.Platform{
+							Architecture: platform.Architecture,
+							OS:           platform.OS,
+							OSVersion:    platform.OSVersion,
+							OSFeatures:   platform.OSFeatures,
+							Variant:      "v6",
+						},
+					},
+					&matcher{
+						Platform: specs.Platform{
+							Architecture: platform.Architecture,
+							OS:           platform.OS,
+							OSVersion:    platform.OSVersion,
+							OSFeatures:   platform.OSFeatures,
+							Variant:      "v5",
+						},
+					},
+				},
+			}
+		}
 		if platform.Variant == "v7" {
 			return orderedPlatformComparer{
 				matchers: []Matcher{

--- a/vendor/github.com/containerd/containerd/platforms/cpuinfo.go
+++ b/vendor/github.com/containerd/containerd/platforms/cpuinfo.go
@@ -97,7 +97,7 @@ func getCPUVariant() string {
 	}
 
 	switch variant {
-	case "8":
+	case "8", "AArch64":
 		variant = "v8"
 	case "7", "7M", "?(12)", "?(13)", "?(14)", "?(15)", "?(16)", "?(17)":
 		variant = "v7"

--- a/vendor/github.com/containerd/containerd/runtime/v1/shim/client/client.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/shim/client/client.go
@@ -98,9 +98,9 @@ func WithStart(binary, address, daemonAddress, cgroup string, debug bool, exitHa
 			cmd.Wait()
 			exitHandler()
 			if stdoutLog != nil {
-				stderrLog.Close()
+				stdoutLog.Close()
 			}
-			if stdoutLog != nil {
+			if stderrLog != nil {
 				stderrLog.Close()
 			}
 		}()

--- a/vendor/github.com/containerd/containerd/runtime/v1/shim/service.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/shim/service.go
@@ -554,7 +554,7 @@ func shouldKillAllOnExit(bundlePath string) (bool, error) {
 
 	if bundleSpec.Linux != nil {
 		for _, ns := range bundleSpec.Linux.Namespaces {
-			if ns.Type == specs.PIDNamespace {
+			if ns.Type == specs.PIDNamespace && ns.Path == "" {
 				return false, nil
 			}
 		}


### PR DESCRIPTION
full diff: https://github.com/containerd/containerd/compare/7c1e88399ec0b0b077121d9d5ad97e647b11c870...481103c8793316c118d9f795cde18060847c370e

- Fix error handling for task deletion
- Snapshots/devmapper: deactivate thin device after committed
- Fix fd leak of shim log
- Fix killall when use pidnamespace
- Improve ARM platform matching

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
- Improve ARM platform matching
```

