### PR TITLE
rootless: graduate from experimental

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -408,7 +408,6 @@ pipeline {
                         }
                         stage("Integration tests") {
                             environment {
-                                DOCKER_EXPERIMENTAL = '1'
                                 DOCKER_ROOTLESS = '1'
                                 TEST_SKIP_INTEGRATION_CLI = '1'
                             }

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -102,20 +102,18 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 
 	if cli.Config.Experimental {
 		logrus.Warn("Running experimental build")
-		if cli.Config.IsRootless() {
-			logrus.Warn("Running in rootless mode. Cgroups, AppArmor, and CRIU are disabled.")
-		}
-		if rootless.RunningWithRootlessKit() {
-			logrus.Info("Running with RootlessKit integration")
-			if !cli.Config.IsRootless() {
-				return fmt.Errorf("rootless mode needs to be enabled for running with RootlessKit")
-			}
-		}
-	} else {
-		if cli.Config.IsRootless() {
-			return fmt.Errorf("rootless mode is supported only when running in experimental mode")
+	}
+
+	if cli.Config.IsRootless() {
+		logrus.Warn("Running in rootless mode. This mode has feature limitations.")
+	}
+	if rootless.RunningWithRootlessKit() {
+		logrus.Info("Running with RootlessKit integration")
+		if !cli.Config.IsRootless() {
+			return fmt.Errorf("rootless mode needs to be enabled for running with RootlessKit")
 		}
 	}
+
 	// return human-friendly error before creating files
 	if runtime.GOOS == "linux" && os.Geteuid() != 0 {
 		return fmt.Errorf("dockerd needs to be started with root. To see how to run dockerd in rootless mode with unprivileged user, see the documentation")

--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 # dockerd-rootless.sh executes dockerd in rootless mode.
 #
-# Usage: dockerd-rootless.sh --experimental [DOCKERD_OPTIONS]
-# Currently, specifying --experimental is mandatory.
+# Usage: dockerd-rootless.sh [DOCKERD_OPTIONS]
 #
 # External dependencies:
 # * newuidmap and newgidmap needs to be installed.
@@ -11,7 +10,7 @@
 #   slirp4netns is used by default if installed. Otherwise fallsback to VPNKit.
 #   The default value can be overridden with $DOCKERD_ROOTLESS_ROOTLESSKIT_NET=(slirp4netns|vpnkit|lxc-user-nic)
 #
-# See the documentation for the further information.
+# See the documentation for the further information: https://docs.docker.com/engine/security/rootless/
 
 set -e -x
 if ! [ -w $XDG_RUNTIME_DIR ]; then

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -65,10 +65,6 @@ fi
 
 dockerd="dockerd"
 if [ -n "$DOCKER_ROOTLESS" ]; then
-	if [ -z "$DOCKER_EXPERIMENTAL" ]; then
-		echo >&2 '# DOCKER_ROOTLESS requires DOCKER_EXPERIMENTAL to be set'
-		exit 1
-	fi
 	if [ -z "$TEST_SKIP_INTEGRATION_CLI" ]; then
 		echo >&2 '# DOCKER_ROOTLESS requires TEST_SKIP_INTEGRATION_CLI to be set'
 		exit 1

--- a/hack/make/run
+++ b/hack/make/run
@@ -39,10 +39,6 @@ fi
 dockerd="dockerd"
 socket=/var/run/docker.sock
 if [ -n "$DOCKER_ROOTLESS" ]; then
-	if [ -z "$DOCKER_EXPERIMENTAL" ]; then
-		echo >&2 '# DOCKER_ROOTLESS requires DOCKER_EXPERIMENTAL to be set'
-		exit 1
-	fi
 	user="unprivilegeduser"
 	uid=$(id -u $user)
 	# shellcheck disable=SC2174

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -204,7 +204,7 @@ func New(t testing.TB, ops ...Option) *Daemon {
 				t.Skip("DOCKER_ROOTLESS doesn't support DOCKER_USERLANDPROXY=false")
 			}
 		}
-		ops = append(ops, WithRootlessUser("unprivilegeduser"), WithExperimental())
+		ops = append(ops, WithRootlessUser("unprivilegeduser"))
 	}
 
 	d, err := NewDaemon(dest, ops...)


### PR DESCRIPTION
Close #40484

Note that the support for cgroup v2 isn't ready for production yet, regardless to rootful or rootless.
