### PR TITLE
Set Init=true by default on container create

### DIFF
--- a/api/server/router/container/container.go
+++ b/api/server/router/container/container.go
@@ -10,13 +10,25 @@ type containerRouter struct {
 	backend Backend
 	decoder httputils.ContainerDecoder
 	routes  []router.Route
+	opts    RouteOptions
+}
+
+// RouteOptions is used to allow configuration of default values
+type RouteOptions struct {
+	Create CreateOptions
+}
+
+// CreateOptions are used by the container create route to change certain default values
+type CreateOptions struct {
+	EnableContainerInit *bool
 }
 
 // NewRouter initializes a new container router
-func NewRouter(b Backend, decoder httputils.ContainerDecoder) router.Router {
+func NewRouter(b Backend, decoder httputils.ContainerDecoder, opts RouteOptions) router.Router {
 	r := &containerRouter{
 		backend: b,
 		decoder: decoder,
+		opts:    opts,
 	}
 	r.initRoutes()
 	return r

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -497,6 +497,14 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 		}
 	}
 
+	if hostConfig != nil && versions.GreaterThanOrEqualTo(version, "1.41") && hostConfig.Init == nil {
+		v := true
+		if s.opts.Create.EnableContainerInit != nil {
+			v = *s.opts.Create.EnableContainerInit
+		}
+		hostConfig.Init = &v
+	}
+
 	if hostConfig != nil && hostConfig.PidsLimit != nil && *hostConfig.PidsLimit <= 0 {
 		// Don't set a limit if either no limit was specified, or "unlimited" was
 		// explicitly set.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -497,6 +497,7 @@ definitions:
         description: "Run an init inside the container that forwards signals and reaps processes. This field is omitted if empty, and the default (as configured on the daemon) is used."
         type: "boolean"
         x-nullable: true
+        default: true
       PidsLimit:
         description: |
           Tune a container's PIDs limit. Set `0` or `-1` for unlimited, or `null` to not change.

--- a/cmd/dockerd/config_unix.go
+++ b/cmd/dockerd/config_unix.go
@@ -53,7 +53,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.StringVar(&conf.RemappedRoot, "userns-remap", "", "User/Group setting for user namespaces")
 	flags.BoolVar(&conf.LiveRestoreEnabled, "live-restore", false, "Enable live restore of docker when containers are still running")
 	flags.IntVar(&conf.OOMScoreAdjust, "oom-score-adjust", -500, "Set the oom_score_adj for the daemon")
-	flags.BoolVar(&conf.Init, "init", false, "Run an init in the container to forward signals and reap processes")
+	flags.Var(opts.BoolPtr(conf.Init), "init", "Run an init in the container to forward signals and reap processes")
 	flags.StringVar(&conf.InitPath, "init-path", "", "Path to the docker-init binary")
 	flags.Int64Var(&conf.CPURealtimePeriod, "cpu-rt-period", 0, "Limit the CPU real-time period in microseconds for the parent cgroup for all containers")
 	flags.Int64Var(&conf.CPURealtimeRuntime, "cpu-rt-runtime", 0, "Limit the CPU real-time runtime in microseconds for the parent cgroup for all containers")

--- a/daemon/config/config_unix.go
+++ b/daemon/config/config_unix.go
@@ -31,7 +31,7 @@ type Config struct {
 	CPURealtimePeriod    int64                    `json:"cpu-rt-period,omitempty"`
 	CPURealtimeRuntime   int64                    `json:"cpu-rt-runtime,omitempty"`
 	OOMScoreAdjust       int                      `json:"oom-score-adjust,omitempty"`
-	Init                 bool                     `json:"init,omitempty"`
+	Init                 *bool                    `json:"init,omitempty"`
 	InitPath             string                   `json:"init-path,omitempty"`
 	SeccompProfile       string                   `json:"seccomp-profile,omitempty"`
 	ShmSize              opts.MemBytes            `json:"default-shm-size,omitempty"`

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -743,7 +743,7 @@ func WithCommonOptions(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		// host namespace or another container's pid namespace where we already have an init
 		if c.HostConfig.PidMode.IsPrivate() {
 			if (c.HostConfig.Init != nil && *c.HostConfig.Init) ||
-				(c.HostConfig.Init == nil && daemon.configStore.Init) {
+				(c.HostConfig.Init == nil && (daemon.configStore.Init != nil && *daemon.configStore.Init)) {
 				s.Process.Args = append([]string{inContainerInitPath, "--", c.Path}, c.Args...)
 				path := daemon.configStore.InitPath
 				if path == "" {

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -61,6 +61,8 @@ keywords: "API, Docker, rcli, REST, documentation"
   service.
 * `GET /tasks/{id}` now includes `JobIteration` on the task if spawned from a
   job-mode service.
+* `POST /containers/create` now sets `HostConfig.Init=true` by default. If your container already
+  runs an init process, you should set this to false. You can also change this default in the daemon config.
 
 ## v1.40 API changes
 

--- a/opts/bool.go
+++ b/opts/bool.go
@@ -1,0 +1,50 @@
+package opts
+
+import (
+	"errors"
+
+	"github.com/spf13/pflag"
+)
+
+// BoolPtr returns a flag type that uses a bool pointer for a tri-value state.
+func BoolPtr(v *bool) pflag.Value {
+	return &boolPtr{v}
+}
+
+type boolPtr struct {
+	v *bool
+}
+
+func (b *boolPtr) Set(value string) error {
+	switch value {
+	case "":
+		return nil
+	case "true":
+		v := true
+		b.v = &v
+	case "false":
+		v := false
+		b.v = &v
+	default:
+		return errors.New("invalid value for bool flag")
+	}
+	return nil
+}
+
+func (b *boolPtr) String() string {
+	if b.v == nil {
+		return ""
+	}
+	if *b.v {
+		return "true"
+	}
+	return "false"
+}
+
+func (b *boolPtr) Type() string {
+	return "bool"
+}
+
+func (b *boolPtr) IsBool() bool {
+	return true
+}


### PR DESCRIPTION
This means any new containers, unless explicitly specified, created with
API version 1.41 will have init enabled by default. This default can be
controlled by the daemon-level `--init` setting.