### PR TITLE
vendor: pkg/errors v0.9.1, mespath/go-jmespath v0.3.0

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -152,7 +152,7 @@ github.com/prometheus/client_model                  d1d2010b5beead3fa1c5f271a5cf
 github.com/prometheus/common                        287d3e634a1e550c9e463dd7e5a75a422c614505 # v0.7.0
 github.com/prometheus/procfs                        6d489fc7f1d9cd890a250f3ea3431b1744b9623f # v0.0.8
 github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
-github.com/pkg/errors                               ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
+github.com/pkg/errors                               614d223910a179a466c1767a985424175c39b465 # v0.9.1
 github.com/grpc-ecosystem/go-grpc-prometheus        c225b8c3b01faf2899099b768856a9e916e5087b # v1.2.0
 github.com/cespare/xxhash/v2                        d7df74196a9e781ede915320c11c378c1b2f3a1f # v2.1.1
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -143,7 +143,7 @@ github.com/hashicorp/go-memdb                       cb9a474f84cc5e41b273b20c6927
 github.com/hashicorp/go-immutable-radix             826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
 github.com/hashicorp/golang-lru                     7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
 github.com/coreos/pkg                               3ac0863d7acf3bc44daf49afef8919af12f704ef # v3
-code.cloudfoundry.org/clock                         02e53af36e6c978af692887ed449b74026d76fec
+code.cloudfoundry.org/clock                         02e53af36e6c978af692887ed449b74026d76fec # v1.0.0
 
 # prometheus
 github.com/prometheus/client_golang                 c42bebe5a5cddfc6b28cd639103369d8a75dfa89 # v1.3.0
@@ -160,7 +160,7 @@ github.com/cespare/xxhash/v2                        d7df74196a9e781ede915320c11c
 github.com/spf13/cobra                              ef82de70bb3f60c65fb8eebacbb2d122ef517385 # v0.0.3
 github.com/spf13/pflag                              583c0c0531f06d5278b7d917446061adc344b5cd # v1.0.1
 github.com/inconshreveable/mousetrap                76626ae9c91c4f2a10f34cad8ce83ea42c93bb75 # v1.0.0
-github.com/morikuni/aec                             39771216ff4c63d11f5e604076f9c45e8be1067b
+github.com/morikuni/aec                             39771216ff4c63d11f5e604076f9c45e8be1067b # v1.0.0
 
 # metrics
 github.com/docker/go-metrics                        b619b3592b65de4f087d9f16863a7e6ff905973c # v0.0.1

--- a/vendor.conf
+++ b/vendor.conf
@@ -106,7 +106,7 @@ github.com/fsnotify/fsnotify                        45d7d09e39ef4ac08d493309fa03
 
 # awslogs deps
 github.com/aws/aws-sdk-go                           2590bc875c54c9fda225d8e4e56a9d28d90c6a47 # v1.28.11
-github.com/jmespath/go-jmespath                     c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5 # see https://github.com/aws/aws-sdk-go/blob/2590bc875c54c9fda225d8e4e56a9d28d90c6a47/Gopkg.toml#L42
+github.com/jmespath/go-jmespath                     2d053f87d1d7f9f48196ae04cf3daea4273d207d # v0.3.0
 
 # logentries
 github.com/bsphere/le_go                            7a984a84b5492ae539b79b62fb4a10afc63c7bcf

--- a/vendor/github.com/jmespath/go-jmespath/README.md
+++ b/vendor/github.com/jmespath/go-jmespath/README.md
@@ -4,4 +4,84 @@
 
 
 
-See http://jmespath.org for more info.
+go-jmespath is a GO implementation of JMESPath,
+which is a query language for JSON.  It will take a JSON
+document and transform it into another JSON document
+through a JMESPath expression.
+
+Using go-jmespath is really easy.  There's a single function
+you use, `jmespath.search`:
+
+
+```go
+> import "github.com/jmespath/go-jmespath"
+>
+> var jsondata = []byte(`{"foo": {"bar": {"baz": [0, 1, 2, 3, 4]}}}`) // your data
+> var data interface{}
+> err := json.Unmarshal(jsondata, &data)
+> result, err := jmespath.Search("foo.bar.baz[2]", data)
+result = 2
+```
+
+In the example we gave the ``search`` function input data of
+`{"foo": {"bar": {"baz": [0, 1, 2, 3, 4]}}}` as well as the JMESPath
+expression `foo.bar.baz[2]`, and the `search` function evaluated
+the expression against the input data to produce the result ``2``.
+
+The JMESPath language can do a lot more than select an element
+from a list.  Here are a few more examples:
+
+```go
+> var jsondata = []byte(`{"foo": {"bar": {"baz": [0, 1, 2, 3, 4]}}}`) // your data
+> var data interface{}
+> err := json.Unmarshal(jsondata, &data)
+> result, err := jmespath.search("foo.bar", data)
+result = { "baz": [ 0, 1, 2, 3, 4 ] }
+
+
+> var jsondata  = []byte(`{"foo": [{"first": "a", "last": "b"},
+                           {"first": "c", "last": "d"}]}`) // your data
+> var data interface{}
+> err := json.Unmarshal(jsondata, &data)
+> result, err := jmespath.search({"foo[*].first", data)
+result [ 'a', 'c' ]
+
+
+> var jsondata = []byte(`{"foo": [{"age": 20}, {"age": 25},
+                           {"age": 30}, {"age": 35},
+                           {"age": 40}]}`) // your data
+> var data interface{}
+> err := json.Unmarshal(jsondata, &data)
+> result, err := jmespath.search("foo[?age > `30`]")
+result = [ { age: 35 }, { age: 40 } ]
+```
+
+You can also pre-compile your query. This is usefull if 
+you are going to run multiple searches with it:
+
+```go
+	> var jsondata = []byte(`{"foo": "bar"}`)
+	> var data interface{}
+    > err := json.Unmarshal(jsondata, &data)
+	> precompiled, err := Compile("foo")
+	> if err != nil{
+    >   // ... handle the error
+    > }
+    > result, err := precompiled.Search(data)
+	result = "bar"
+```
+
+## More Resources
+
+The example above only show a small amount of what
+a JMESPath expression can do.  If you want to take a
+tour of the language, the *best* place to go is the
+[JMESPath Tutorial](http://jmespath.org/tutorial.html).
+
+One of the best things about JMESPath is that it is
+implemented in many different programming languages including
+python, ruby, php, lua, etc.  To see a complete list of libraries,
+check out the [JMESPath libraries page](http://jmespath.org/libraries.html).
+
+And finally, the full JMESPath specification can be found
+on the [JMESPath site](http://jmespath.org/specification.html).

--- a/vendor/github.com/jmespath/go-jmespath/api.go
+++ b/vendor/github.com/jmespath/go-jmespath/api.go
@@ -2,7 +2,7 @@ package jmespath
 
 import "strconv"
 
-// JMESPath is the epresentation of a compiled JMES path query. A JMESPath is
+// JMESPath is the representation of a compiled JMES path query. A JMESPath is
 // safe for concurrent use by multiple goroutines.
 type JMESPath struct {
 	ast  ASTNode

--- a/vendor/github.com/jmespath/go-jmespath/go.mod
+++ b/vendor/github.com/jmespath/go-jmespath/go.mod
@@ -1,0 +1,5 @@
+module github.com/jmespath/go-jmespath
+
+go 1.14
+
+require github.com/stretchr/testify v1.5.1

--- a/vendor/github.com/jmespath/go-jmespath/parser.go
+++ b/vendor/github.com/jmespath/go-jmespath/parser.go
@@ -137,7 +137,7 @@ func (p *Parser) Parse(expression string) (ASTNode, error) {
 	}
 	if p.current() != tEOF {
 		return ASTNode{}, p.syntaxError(fmt.Sprintf(
-			"Unexpected token at the end of the expresssion: %s", p.current()))
+			"Unexpected token at the end of the expression: %s", p.current()))
 	}
 	return parsed, nil
 }

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -41,11 +41,18 @@ default:
 
 [Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
 
+## Roadmap
+
+With the upcoming [Go2 error proposals](https://go.googlesource.com/proposal/+/master/design/go2draft.md) this package is moving into maintenance mode. The roadmap for a 1.0 release is as follows:
+
+- 0.9. Remove pre Go 1.9 and Go 1.10 support, address outstanding pull requests (if possible)
+- 1.0. Final release.
+
 ## Contributing
 
-We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+Because of the Go2 errors changes, this package is not accepting proposals for new functionality. With that said, we welcome pull requests, bug fixes and issue reports. 
 
-Before proposing a change, please discuss your change by raising an issue.
+Before sending a PR, please discuss your change by raising an issue.
 
 ## License
 

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -82,7 +82,7 @@
 //
 //     if err, ok := err.(stackTracer); ok {
 //             for _, f := range err.StackTrace() {
-//                     fmt.Printf("%+s:%d", f)
+//                     fmt.Printf("%+s:%d\n", f, f)
 //             }
 //     }
 //
@@ -158,6 +158,9 @@ type withStack struct {
 }
 
 func (w *withStack) Cause() error { return w.error }
+
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (w *withStack) Unwrap() error { return w.error }
 
 func (w *withStack) Format(s fmt.State, verb rune) {
 	switch verb {
@@ -240,6 +243,9 @@ type withMessage struct {
 
 func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
 func (w *withMessage) Cause() error  { return w.cause }
+
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (w *withMessage) Unwrap() error { return w.cause }
 
 func (w *withMessage) Format(s fmt.State, verb rune) {
 	switch verb {

--- a/vendor/github.com/pkg/errors/go113.go
+++ b/vendor/github.com/pkg/errors/go113.go
@@ -1,0 +1,38 @@
+// +build go1.13
+
+package errors
+
+import (
+	stderrors "errors"
+)
+
+// Is reports whether any error in err's chain matches target.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+func Is(err, target error) bool { return stderrors.Is(err, target) }
+
+// As finds the first error in err's chain that matches target, and if so, sets
+// target to that error value and returns true.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error matches target if the error's concrete value is assignable to the value
+// pointed to by target, or if the error has a method As(interface{}) bool such that
+// As(target) returns true. In the latter case, the As method is responsible for
+// setting target.
+//
+// As will panic if target is not a non-nil pointer to either a type that implements
+// error, or to any interface type. As returns false if err is nil.
+func As(err error, target interface{}) bool { return stderrors.As(err, target) }
+
+// Unwrap returns the result of calling the Unwrap method on err, if err's
+// type contains an Unwrap method returning error.
+// Otherwise, Unwrap returns nil.
+func Unwrap(err error) error {
+	return stderrors.Unwrap(err)
+}


### PR DESCRIPTION
- vendor: add version comments for some dependencies
- vendor: jmespath/go-jmespath v0.3.0
  This update is just adding some typo-fixes and adding a go.mod, but pins it to a tagged release; https://github.com/jmespath/go-jmespath/compare/c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5...v0.3.0
- vendor: pkgs/errors v0.9.1 https://github.com/pkg/errors/compare/v0.8.1...v0.9.1