### PR TITLE
vendor: update go-events to fix alignment for 32bit systems

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/gofrs/flock                              392e7fae8f1b0bdbd67dad7237d2
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
 github.com/docker/libnetwork                        ef149a924dfde2e506ea3cb3f617d7d0fa96b8ee
-github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
+github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec
 github.com/hashicorp/go-msgpack                     71c2886f5a673a35f909803f38ece5810165097b

--- a/vendor/github.com/docker/go-events/retry.go
+++ b/vendor/github.com/docker/go-events/retry.go
@@ -203,8 +203,8 @@ type ExponentialBackoffConfig struct {
 // ExponentialBackoff implements random backoff with exponentially increasing
 // bounds as the number consecutive failures increase.
 type ExponentialBackoff struct {
+	failures uint64 // consecutive failure counter (needs to be 64-bit aligned)
 	config   ExponentialBackoffConfig
-	failures uint64 // consecutive failure counter.
 }
 
 // NewExponentialBackoff returns an exponential backoff strategy with the


### PR DESCRIPTION
- relates to moby/buildkit#1111
- relates to moby/buildkit#1079
- relates to docker/buildx#129

full diff: https://github.com/docker/go-events/compare/9461782956ad83b30282bf90e31fa6a70c255ba9...e31b211e4f1cd09aa76fe4ac244571fab96ae47f


follow up to the changes in https://github.com/moby/moby/pull/39543 and https://github.com/docker/engine/pull/363, so marking for cherry-pick