### PR TITLE
[19.03 backport] builder: fix concurrent map write

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -241,7 +241,9 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 		}
 
 		defer func() {
+			b.mu.Lock()
 			delete(b.jobs, buildID)
+			b.mu.Unlock()
 		}()
 	}
 


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/40772
fixes https://github.com/moby/moby/issues/40752