### PR TITLE
[19.03] vendor buildkit b26cff2413cc6a466f8739262efa13bd126f8fc7

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -26,7 +26,7 @@ github.com/imdario/mergo                            7c29201646fa3de8506f70121347
 golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af2b83e6acac3c
 
 # buildkit
-github.com/moby/buildkit                            ebcef1f69af0bbca077efa9a960a481e579a0e89 # v0.6.4
+github.com/moby/buildkit                            b26cff2413cc6a466f8739262efa13bd126f8fc7 # v0.6.4 + aa7df97d7136e732561b59f87a38ad52d46d3b19
 github.com/tonistiigi/fsutil                        6c909ab392c173a4264ae1bfcbc0450b9aac0c7d
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7


### PR DESCRIPTION
full diff: https://github.com/moby/buildkit/compare/v0.6.4...b26cff2413cc6a466f8739262efa13bd126f8fc7

- solver: avoid looping over same keys in loadwithparents 


brings in a backport of https://github.com/moby/buildkit/pull/1413

to address:

- moby/buildkit#1313
- moby/moby#40624
- docker/buildx#240
