### PR TITLE
pkg/authorization: Fix test failures on macOS

### DIFF
--- a/pkg/authorization/authz_unix_test.go
+++ b/pkg/authorization/authz_unix_test.go
@@ -32,7 +32,7 @@ func TestAuthZRequestPluginError(t *testing.T) {
 	server.start()
 	defer server.stop()
 
-	authZPlugin := createTestPlugin(t)
+	authZPlugin := createTestPlugin(t, server.socketAddress())
 
 	request := Request{
 		User:           "user",
@@ -63,7 +63,7 @@ func TestAuthZRequestPlugin(t *testing.T) {
 	server.start()
 	defer server.stop()
 
-	authZPlugin := createTestPlugin(t)
+	authZPlugin := createTestPlugin(t, server.socketAddress())
 
 	request := Request{
 		User:           "user",
@@ -95,7 +95,7 @@ func TestAuthZResponsePlugin(t *testing.T) {
 	server.start()
 	defer server.stop()
 
-	authZPlugin := createTestPlugin(t)
+	authZPlugin := createTestPlugin(t, server.socketAddress())
 
 	request := Request{
 		User:        "user",
@@ -262,13 +262,8 @@ func TestResponseModifierOverride(t *testing.T) {
 }
 
 // createTestPlugin creates a new sample authorization plugin
-func createTestPlugin(t *testing.T) *authorizationPlugin {
-	pwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	client, err := plugins.NewClient("unix:///"+path.Join(pwd, pluginAddress), &tlsconfig.Options{InsecureSkipVerify: true})
+func createTestPlugin(t *testing.T, socketAddress string) *authorizationPlugin {
+	client, err := plugins.NewClient("unix:///"+socketAddress, &tlsconfig.Options{InsecureSkipVerify: true})
 	if err != nil {
 		t.Fatalf("Failed to create client %v", err)
 	}
@@ -285,12 +280,23 @@ type authZPluginTestServer struct {
 	// response stores the response sent from the plugin to the daemon
 	replayResponse Response
 	server         *httptest.Server
+	tmpDir         string
+}
+
+func (t *authZPluginTestServer) socketAddress() string {
+	return path.Join(t.tmpDir, pluginAddress)
 }
 
 // start starts the test server that implements the plugin
 func (t *authZPluginTestServer) start() {
+	var err error
+	t.tmpDir, err = ioutil.TempDir("", "authz")
+	if err != nil {
+		t.t.Fatal(err)
+	}
+
 	r := mux.NewRouter()
-	l, err := net.Listen("unix", pluginAddress)
+	l, err := net.Listen("unix", t.socketAddress())
 	if err != nil {
 		t.t.Fatal(err)
 	}
@@ -311,7 +317,7 @@ func (t *authZPluginTestServer) start() {
 // stop stops the test server that implements the plugin
 func (t *authZPluginTestServer) stop() {
 	t.server.Close()
-	os.Remove(pluginAddress)
+	_ = os.RemoveAll(t.tmpDir)
 	if t.listener != nil {
 		t.listener.Close()
 	}

--- a/pkg/authorization/middleware_unix_test.go
+++ b/pkg/authorization/middleware_unix_test.go
@@ -18,7 +18,7 @@ func TestMiddlewareWrapHandler(t *testing.T) {
 	server.start()
 	defer server.stop()
 
-	authZPlugin := createTestPlugin(t)
+	authZPlugin := createTestPlugin(t, server.socketAddress())
 	pluginNames := []string{authZPlugin.name}
 
 	var pluginGetter plugingetter.PluginGetter


### PR DESCRIPTION
On macOS, unit tests were failing with
```
root@c4101a75c792:/go/src/github.com/docker/docker/pkg/authorization# go test .
--- FAIL: TestAuthZRequestPluginError (0.00s)
    authz_unix_test.go:295: listen unix authz-test-plugin.sock: bind: file name too long
--- FAIL: TestAuthZRequestPlugin (0.00s)
    authz_unix_test.go:295: listen unix authz-test-plugin.sock: bind: file name too long
--- FAIL: TestAuthZResponsePlugin (0.00s)
    authz_unix_test.go:295: listen unix authz-test-plugin.sock: bind: file name too long
time="2020-04-07T10:07:04Z" level=warning msg="Request body is larger than: '1048576' skipping body"
--- FAIL: TestMiddlewareWrapHandler (0.00s)
    authz_unix_test.go:295: listen unix authz-test-plugin.sock: bind: file name too long
FAIL
FAIL	github.com/docker/docker/pkg/authorization	0.120s
```
This change moves the socket creation from a working test directory to a tmp directory,
so the path is shorter.

**- Description for the changelog**
Fix unit test failures for authorization package on macOS

