### PR TITLE
swagger: clarify the meaning of Image field in ContainerInspect endpoint

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5086,7 +5086,7 @@ paths:
                 x-nullable: true
                 $ref: "#/definitions/ContainerState"
               Image:
-                description: "The container's image"
+                description: "The container's image ID"
                 type: "string"
               ResolvConfPath:
                 type: "string"


### PR DESCRIPTION
"Container's image" term is rather ambiguous: it can be both a name and an ID.

[Looking at the sources](https://github.com/moby/moby/blob/a6a47d1a4944799ffbe3657d4dae68e0829a0dc6/daemon/inspect.go#L170), it's actually an image ID, so bring some clarity.