### PR TITLE
Clean up abruptly terminated layer transactions data

### DIFF
--- a/layer/filestore_test.go
+++ b/layer/filestore_test.go
@@ -160,6 +160,116 @@ func TestFileMetadataStore_StartTransaction(t *testing.T) {
 		t.Errorf("An error was expected for empty cacheID")
 	}
 	if errTx != nil {
-		t.Errorf("nil shuld be returned instead of the transaction in case of an error")
+		_ = errTx.Cancel()
+		t.Errorf("nil should be returned instead of a transaction instance in the case of an error")
 	}
+
+	tx, err := fms.StartTransaction("test-start-transaction")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Cancel()
+
+	txData, err := fms.ListExistingTransactions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(txData) != 1 {
+		t.Errorf("Expected single transaction")
+	} else {
+		cacheID, err := txData[0].GetCacheID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cacheID != "test-start-transaction" {
+			t.Errorf("Unexpected cache ID in the started transaction: %s", cacheID)
+		}
+	}
+}
+
+func TestFileMetadataStore_ListExistingTransactions(t *testing.T) {
+	fms, _, cleanup := newFileMetadataStore(t)
+	defer cleanup()
+
+	t.Run("no tmp directory", func(t *testing.T) {
+		list, err := fms.ListExistingTransactions()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(list) != 0 {
+			t.Errorf("Existing transactions returned when unexpected: %s", list)
+		}
+	})
+
+	t.Run("new transactions case", func(t *testing.T) {
+		tx1, err := fms.StartTransaction("1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx1.Cancel()
+		tx2, err := fms.StartTransaction("2")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx2.Cancel()
+		list, err := fms.ListExistingTransactions()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(list) != 2 {
+			t.Errorf("Expected 2 existing transactions, but got %d", len(list))
+		}
+
+		tx1.Commit(randomLayerID(42))
+		list, err = fms.ListExistingTransactions()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(list) != 1 {
+			t.Errorf("Expected 1 existing transaction after committing another, but got %d", len(list))
+		} else {
+			if cacheID, err := list[0].GetCacheID(); err != nil {
+				t.Fatal(err)
+			} else if cacheID != "2" {
+				t.Errorf("Wrong cache ID of the only existing transaction: %s", cacheID)
+			}
+		}
+
+		tx2.Cancel()
+		list, err = fms.ListExistingTransactions()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(list) != 0 {
+			t.Errorf("Expected none existing transactions, but got %d", len(list))
+		}
+	})
+
+	t.Run("clean up case", func(t *testing.T) {
+		tx1, err := fms.StartTransaction(stringid.GenerateRandomID())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx1.Cancel()
+
+		list, err := fms.ListExistingTransactions()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(list) == 1 {
+			err = list[0].Delete()
+			if err != nil {
+				t.Fatal(err)
+			}
+			newlist, err := fms.ListExistingTransactions()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(newlist) != 0 {
+				t.Errorf("Unexpected transactions data: %s", newlist)
+			}
+		} else {
+			t.Errorf("Expected only one transaction, but got %s", list)
+		}
+	})
 }

--- a/layer/filestore_test.go
+++ b/layer/filestore_test.go
@@ -56,7 +56,7 @@ func TestCommitFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tx, err := fms.StartTransaction()
+	tx, err := fms.StartTransaction(stringid.GenerateRandomID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestStartTransactionFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := fms.StartTransaction()
+	_, err := fms.StartTransaction(stringid.GenerateRandomID())
 	if err == nil {
 		t.Fatalf("Expected error starting transaction with invalid layer parent directory")
 	}
@@ -90,7 +90,7 @@ func TestStartTransactionFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tx, err := fms.StartTransaction()
+	tx, err := fms.StartTransaction(stringid.GenerateRandomID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func TestGetOrphan(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tx, err := fms.StartTransaction()
+	tx, err := fms.StartTransaction(stringid.GenerateRandomID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,5 +148,18 @@ func TestGetOrphan(t *testing.T) {
 	}
 	if len(orphanLayers) != 1 {
 		t.Fatalf("Expected to have one orphan layer")
+	}
+}
+
+func TestFileMetadataStore_StartTransaction(t *testing.T) {
+	fms, _, cleanup := newFileMetadataStore(t)
+	defer cleanup()
+
+	errTx, err := fms.StartTransaction("")
+	if err == nil {
+		t.Errorf("An error was expected for empty cacheID")
+	}
+	if errTx != nil {
+		t.Errorf("nil shuld be returned instead of the transaction in case of an error")
 	}
 }

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -321,12 +321,14 @@ func (ls *layerStore) registerWithDescriptor(ts io.Reader, parent ChainID, descr
 		descriptor:     descriptor,
 	}
 
-	if err = ls.driver.Create(layer.cacheID, pid, nil); err != nil {
+	// New transaction should be persisted before we do any operations with the graph driver
+	// to avoid a possibility of having an FS layer not referenced from the layer store.
+	tx, err := ls.store.StartTransaction(layer.cacheID)
+	if err != nil {
 		return nil, err
 	}
 
-	tx, err := ls.store.StartTransaction()
-	if err != nil {
+	if err = ls.driver.Create(layer.cacheID, pid, nil); err != nil {
 		return nil, err
 	}
 

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -78,8 +78,7 @@ func NewStoreFromOptions(options StoreOptions) (Store, error) {
 }
 
 // newStoreFromGraphDriver creates a new Store instance using the provided
-// metadata store and graph driver. The metadata store will be used to restore
-// the Store.
+// root directory and graph driver. The data in the root directory will be used to restore the Store.
 func newStoreFromGraphDriver(root string, driver graphdriver.Driver, os string) (Store, error) {
 	if !system.IsOSSupported(os) {
 		return nil, fmt.Errorf("failed to initialize layer store as operating system '%s' is not supported", os)
@@ -125,6 +124,21 @@ func newStoreFromGraphDriver(root string, driver graphdriver.Driver, os string) 
 			logrus.Debugf("Failed to load mount %s: %s", mount, err)
 		}
 	}
+
+	// We just created the layer store, no new transactions could have been started.
+	// It's a good moment to run the clean up procedure.
+	txData, err := ls.store.ListExistingTransactions()
+	if err != nil {
+		return nil, err
+	}
+	// Data deletion can take time. So once we identify what needs to be deleted,
+	// we start the operation in background.
+	go func() {
+		deletedCacheIDs := ls.prune(txData)
+		if len(deletedCacheIDs) > 0 {
+			logrus.Infof("Pruned %d unused graph driver layers", len(deletedCacheIDs))
+		}
+	}()
 
 	return ls, nil
 }
@@ -788,6 +802,28 @@ func (ls *layerStore) DriverStatus() [][2]string {
 
 func (ls *layerStore) DriverName() string {
 	return ls.driver.String()
+}
+
+func (ls *layerStore) prune(txData []fileMetadataTxData) []string {
+	treatedCacheIDs := make([]string, 0, len(txData))
+
+	for _, tx := range txData {
+		if cacheID, err := tx.GetCacheID(); err == nil {
+			if err := ls.driver.Remove(cacheID); err == nil {
+				logrus.Debugf("Deleted layer %s", cacheID)
+				treatedCacheIDs = append(treatedCacheIDs, cacheID)
+			} else {
+				logrus.Debugf("Failed to delete layer %s: %s", cacheID, err)
+			}
+		} else {
+			logrus.Errorf("Failed to read cacheID from tx [%s] data: %s", tx, err)
+		}
+		if err := tx.Delete(); err != nil {
+			logrus.Errorf("Failed to delete tx [%s] data that should be pruned: %s", tx, err)
+		}
+	}
+
+	return treatedCacheIDs
 }
 
 type naiveDiffPathDriver struct {

--- a/layer/layer_store_test.go
+++ b/layer/layer_store_test.go
@@ -1,0 +1,28 @@
+package layer
+
+import "testing"
+
+func TestLayerStore_prune(t *testing.T) {
+	s, _, cleanup := newTestStore(t)
+	defer cleanup()
+
+	lStore, ok := s.(*layerStore)
+	if !ok {
+		t.Fatalf("Unexpected store implementation %s", s)
+	}
+
+	// Start new transaction with cacheID that is not committed or canceled.
+	_, err := lStore.store.StartTransaction("test-prune")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txData, err := lStore.store.ListExistingTransactions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheIDs := lStore.prune(txData)
+	if len(cacheIDs) != 1 {
+		t.Errorf("1 directory was expected to be removed, but got %s", cacheIDs)
+	}
+}

--- a/layer/migration.go
+++ b/layer/migration.go
@@ -123,7 +123,7 @@ func (ls *layerStore) RegisterByGraphID(graphID string, parent ChainID, diffID D
 		return existingLayer.getReference(), nil
 	}
 
-	tx, err := ls.store.StartTransaction()
+	tx, err := ls.store.StartTransaction(layer.cacheID)
 	if err != nil {
 		return nil, err
 	}

--- a/layer/ro_layer.go
+++ b/layer/ro_layer.go
@@ -132,9 +132,6 @@ func storeLayer(tx *fileMetadataTransaction, layer *roLayer) error {
 	if err := tx.SetSize(layer.size); err != nil {
 		return err
 	}
-	if err := tx.SetCacheID(layer.cacheID); err != nil {
-		return err
-	}
 	// Do not store empty descriptors
 	if layer.descriptor.Digest != "" {
 		if err := tx.SetDescriptor(layer.descriptor); err != nil {


### PR DESCRIPTION
Working with IoT/Edge device fleets at Balena, we faced a problem when the files in `/var/lib/docker/{storage-driver}` folder fill up the disk space while not being actually used - the graph driver FS layers can be not referred by any engine layers.
The root cause of this problem is the scenario when the engine daemon process is abruptly terminated during the layer transaction (download and extraction). The reason for such termination may be very different, but has to be taken as something that cannot be avoided: no one can guarantee a power cord will not be unplugged from the device. 

This change has 2 commits.

The first one changes the transaction creation code in a way it ensures that graph driver layer ID (cacheID) is persisted when a transaction is started (as opposed to storing it right before the commit). The change also tweaks the new layer registration code to avoid any graph driver interactions before the new cacheID is persisted.

The second commit adds new behavior: clean-up of the abruptly terminated transaction data on the engine daemon start (on `layerStore` creation). Before a `layerStore` can be used by other components, we read its `tmp` directory to find leftovers from the previous process run. These folders (and referred graph driver folders) will not be re-used, so we safely start a background process that deletes all this data.

**- Description for the changelog**
Clean up abruptly terminated layer transactions data
