### PR TITLE
[19.03 backport] api docs: fix broken link on GitHub

### DIFF
--- a/docs/api/v1.18.md
+++ b/docs/api/v1.18.md
@@ -19,7 +19,7 @@ redirect_from:
 ## 1. Brief introduction
 
  - The daemon listens on `unix:///var/run/docker.sock` but you can
-   [Bind Docker to another host/port or a Unix socket](../reference/commandline/dockerd.md#bind-docker-to-another-host-port-or-a-unix-socket).
+   [Bind Docker to another host/port or a Unix socket](https://docs.docker.com/engine/reference/commandline/dockerd/#bind-docker-to-another-host-port-or-a-unix-socket).
  - The API tends to be REST, but for some complex commands, like `attach`
    or `pull`, the HTTP connection is hijacked to transport `stdout`,
    `stdin` and `stderr`.
@@ -1234,7 +1234,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../reference/builder.md#add)).
+command*](https://docs.docker.com/engine/reference/builder/#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,

--- a/docs/api/v1.19.md
+++ b/docs/api/v1.19.md
@@ -19,7 +19,7 @@ redirect_from:
 ## 1. Brief introduction
 
  - The daemon listens on `unix:///var/run/docker.sock` but you can
-   [Bind Docker to another host/port or a Unix socket](../reference/commandline/dockerd.md#bind-docker-to-another-host-port-or-a-unix-socket).
+   [Bind Docker to another host/port or a Unix socket](https://docs.docker.com/engine/reference/commandline/dockerd/#bind-docker-to-another-host-port-or-a-unix-socket).
  - The API tends to be REST. However, for some complex commands, like `attach`
    or `pull`, the HTTP connection is hijacked to transport `stdout`,
    `stdin` and `stderr`.
@@ -1276,7 +1276,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../reference/builder.md#add)).
+command*](https://docs.docker.com/engine/reference/builder/#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,

--- a/docs/api/v1.20.md
+++ b/docs/api/v1.20.md
@@ -19,7 +19,7 @@ redirect_from:
 ## 1. Brief introduction
 
  - The daemon listens on `unix:///var/run/docker.sock` but you can
-   [Bind Docker to another host/port or a Unix socket](../reference/commandline/dockerd.md#bind-docker-to-another-host-port-or-a-unix-socket).
+   [Bind Docker to another host/port or a Unix socket](https://docs.docker.com/engine/reference/commandline/dockerd/#bind-docker-to-another-host-port-or-a-unix-socket).
  - The API tends to be REST. However, for some complex commands, like `attach`
    or `pull`, the HTTP connection is hijacked to transport `stdout`,
    `stdin` and `stderr`.
@@ -1407,7 +1407,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../reference/builder.md#add)).
+command*](https://docs.docker.com/engine/reference/builder/#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,

--- a/docs/api/v1.21.md
+++ b/docs/api/v1.21.md
@@ -19,7 +19,7 @@ redirect_from:
 ## 1. Brief introduction
 
  - The daemon listens on `unix:///var/run/docker.sock` but you can
-   [Bind Docker to another host/port or a Unix socket](../reference/commandline/dockerd.md#bind-docker-to-another-host-port-or-a-unix-socket).
+   [Bind Docker to another host/port or a Unix socket](https://docs.docker.com/engine/reference/commandline/dockerd/#bind-docker-to-another-host-port-or-a-unix-socket).
  - The API tends to be REST. However, for some complex commands, like `attach`
    or `pull`, the HTTP connection is hijacked to transport `stdout`,
    `stdin` and `stderr`.
@@ -1488,7 +1488,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../reference/builder.md#add)).
+command*](https://docs.docker.com/engine/reference/builder/#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,
@@ -1526,7 +1526,7 @@ or being killed.
         these values at build-time. Docker uses the `buildargs` as the environment
         context for command(s) run via the Dockerfile's `RUN` instruction or for
         variable expansion in other Dockerfile instructions. This is not meant for
-        passing secret values. [Read more about the buildargs instruction](../reference/builder.md#arg)
+        passing secret values. [Read more about the buildargs instruction](https://docs.docker.com/engine/reference/builder/#arg)
 
 **Request Headers**:
 

--- a/docs/api/v1.22.md
+++ b/docs/api/v1.22.md
@@ -19,7 +19,7 @@ redirect_from:
 ## 1. Brief introduction
 
  - The daemon listens on `unix:///var/run/docker.sock` but you can
-   [Bind Docker to another host/port or a Unix socket](../reference/commandline/dockerd.md#bind-docker-to-another-host-port-or-a-unix-socket).
+   [Bind Docker to another host/port or a Unix socket](https://docs.docker.com/engine/reference/commandline/dockerd/#bind-docker-to-another-host-port-or-a-unix-socket).
  - The API tends to be REST. However, for some complex commands, like `attach`
    or `pull`, the HTTP connection is hijacked to transport `stdout`,
    `stdin` and `stderr`.
@@ -1669,7 +1669,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../reference/builder.md#add)).
+command*](https://docs.docker.com/engine/reference/builder/#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,
@@ -1707,7 +1707,7 @@ or being killed.
         these values at build-time. Docker uses the `buildargs` as the environment
         context for command(s) run via the Dockerfile's `RUN` instruction or for
         variable expansion in other Dockerfile instructions. This is not meant for
-        passing secret values. [Read more about the buildargs instruction](../reference/builder.md#arg)
+        passing secret values. [Read more about the buildargs instruction](https://docs.docker.com/engine/reference/builder/#arg)
 -   **shmsize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
 
 **Request Headers**:

--- a/docs/api/v1.23.md
+++ b/docs/api/v1.23.md
@@ -19,7 +19,7 @@ redirect_from:
 ## 1. Brief introduction
 
  - The daemon listens on `unix:///var/run/docker.sock` but you can
-   [Bind Docker to another host/port or a Unix socket](../reference/commandline/dockerd.md#bind-docker-to-another-host-port-or-a-unix-socket).
+   [Bind Docker to another host/port or a Unix socket](https://docs.docker.com/engine/reference/commandline/dockerd/#bind-docker-to-another-host-port-or-a-unix-socket).
  - The API tends to be REST. However, for some complex commands, like `attach`
    or `pull`, the HTTP connection is hijacked to transport `stdout`,
    `stdin` and `stderr`.
@@ -1703,7 +1703,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../reference/builder.md#add)).
+command*](https://docs.docker.com/engine/reference/builder/#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,
@@ -1741,7 +1741,7 @@ or being killed.
         these values at build-time. Docker uses the `buildargs` as the environment
         context for command(s) run via the Dockerfile's `RUN` instruction or for
         variable expansion in other Dockerfile instructions. This is not meant for
-        passing secret values. [Read more about the buildargs instruction](../reference/builder.md#arg)
+        passing secret values. [Read more about the buildargs instruction](https://docs.docker.com/engine/reference/builder/#arg)
 -   **shmsize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
 -   **labels** – JSON map of string pairs for labels to set on the image.
 

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -19,7 +19,7 @@ redirect_from:
 ## 1. Brief introduction
 
  - The daemon listens on `unix:///var/run/docker.sock` but you can
-   [Bind Docker to another host/port or a Unix socket](../reference/commandline/dockerd.md#bind-docker-to-another-host-port-or-a-unix-socket).
+   [Bind Docker to another host/port or a Unix socket](https://docs.docker.com/engine/reference/commandline/dockerd/#bind-docker-to-another-host-port-or-a-unix-socket).
  - The API tends to be REST. However, for some complex commands, like `attach`
    or `pull`, the HTTP connection is hijacked to transport `stdout`,
    `stdin` and `stderr`.
@@ -1718,7 +1718,7 @@ the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
 which are accessible in the build context (See the [*ADD build
-command*](../reference/builder.md#add)).
+command*](https://docs.docker.com/engine/reference/builder/#add)).
 
 The Docker daemon performs a preliminary validation of the `Dockerfile` before
 starting the build, and returns an error if the syntax is incorrect. After that,
@@ -1756,7 +1756,7 @@ or being killed.
         these values at build-time. Docker uses the `buildargs` as the environment
         context for command(s) run via the Dockerfile's `RUN` instruction or for
         variable expansion in other Dockerfile instructions. This is not meant for
-        passing secret values. [Read more about the buildargs instruction](../reference/builder.md#arg)
+        passing secret values. [Read more about the buildargs instruction](https://docs.docker.com/engine/reference/builder/#arg)
 -   **shmsize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
 -   **labels** – JSON map of string pairs for labels to set on the image.
 


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/40798

The pages that were linked to have moved, so changing the
links to point to docs.docker.com instead.

