### PR TITLE
swarm: fix API version detection

### DIFF
--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -225,15 +225,13 @@ func (sr *swarmRouter) createService(ctx context.Context, w http.ResponseWriter,
 
 	// Get returns "" if the header does not exist
 	encodedAuth := r.Header.Get("X-Registry-Auth")
-	cliVersion := r.Header.Get("version")
 	queryRegistry := false
-	if cliVersion != "" {
-		if versions.LessThan(cliVersion, "1.30") {
+	if v := httputils.VersionFromContext(ctx); v != "" {
+		if versions.LessThan(v, "1.30") {
 			queryRegistry = true
 		}
-		adjustForAPIVersion(cliVersion, &service)
+		adjustForAPIVersion(v, &service)
 	}
-
 	resp, err := sr.backend.CreateService(service, encodedAuth, queryRegistry)
 	if err != nil {
 		logrus.Errorf("Error creating service %s: %v", service.Name, err)
@@ -265,13 +263,12 @@ func (sr *swarmRouter) updateService(ctx context.Context, w http.ResponseWriter,
 	flags.EncodedRegistryAuth = r.Header.Get("X-Registry-Auth")
 	flags.RegistryAuthFrom = r.URL.Query().Get("registryAuthFrom")
 	flags.Rollback = r.URL.Query().Get("rollback")
-	cliVersion := r.Header.Get("version")
 	queryRegistry := false
-	if cliVersion != "" {
-		if versions.LessThan(cliVersion, "1.30") {
+	if v := httputils.VersionFromContext(ctx); v != "" {
+		if versions.LessThan(v, "1.30") {
 			queryRegistry = true
 		}
-		adjustForAPIVersion(cliVersion, &service)
+		adjustForAPIVersion(v, &service)
 	}
 
 	resp, err := sr.backend.UpdateService(vars["id"], version, service, flags, queryRegistry)


### PR DESCRIPTION
I noticed this while testing some variations of API versions in https://github.com/moby/moby/pull/39882, but using cURL instead of the docker cli  or docker client.

While the docker cli may be sending a "version" header, this header is not part of the API, or at least should not determin what API version is used.

This code was added in c0afd9c873183604e57282e1cf47605c1f1e4d43 (https://github.com/moby/moby/pull/32388), to adjust the handling of requests when an older version of the API was used, but because the code relied on the "version" header set by the CLI, it didn't work with other clients (e.g. when using cURL to make an API request).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


