### PR TITLE
Add support for zstd compressed layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -298,7 +298,8 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             vim-common \
             xfsprogs \
             xz-utils \
-            zip
+            zip \
+            zstd
 
 
 # Switch to use iptables instead of nftables (to match the CI hosts)


### PR DESCRIPTION
This allows docker to decompress layers that are compressed with
zstd (https://github.com/facebook/zstd).
This is only for layer decompression.

Since zstd support is part of the OCI spec, we should probably handle it
here.

Closes #28394