### PR TITLE
ServiceCreate/ServiceUpdate: refactor and fix potential NPE

### DIFF
--- a/client/service_create.go
+++ b/client/service_create.go
@@ -44,9 +44,7 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 			if img, imgPlatforms, err := imageDigestAndPlatforms(ctx, cli, service.TaskTemplate.ContainerSpec.Image, options.EncodedRegistryAuth); err != nil {
 				resolveWarning = digestWarning(service.TaskTemplate.ContainerSpec.Image)
 			} else {
-				if img != "" {
-					service.TaskTemplate.ContainerSpec.Image = img
-				}
+				service.TaskTemplate.ContainerSpec.Image = img
 				if len(imgPlatforms) > 0 {
 					if service.TaskTemplate.Placement == nil {
 						service.TaskTemplate.Placement = &swarm.Placement{}
@@ -63,9 +61,7 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 			if img, imgPlatforms, err := imageDigestAndPlatforms(ctx, cli, service.TaskTemplate.PluginSpec.Remote, options.EncodedRegistryAuth); err != nil {
 				resolveWarning = digestWarning(service.TaskTemplate.PluginSpec.Remote)
 			} else {
-				if img != "" {
-					service.TaskTemplate.PluginSpec.Remote = img
-				}
+				service.TaskTemplate.PluginSpec.Remote = img
 				if len(imgPlatforms) > 0 {
 					if service.TaskTemplate.Placement == nil {
 						service.TaskTemplate.Placement = &swarm.Placement{}
@@ -123,7 +119,7 @@ func imageDigestAndPlatforms(ctx context.Context, cli DistributionAPIClient, ima
 
 // imageWithDigestString takes an image string and a digest, and updates
 // the image string if it didn't originally contain a digest. It returns
-// an empty string if there are no updates.
+// image unmodified in other situations.
 func imageWithDigestString(image string, dgst digest.Digest) string {
 	namedRef, err := reference.ParseNormalizedNamed(image)
 	if err == nil {
@@ -135,7 +131,7 @@ func imageWithDigestString(image string, dgst digest.Digest) string {
 			}
 		}
 	}
-	return ""
+	return image
 }
 
 // imageWithTagString takes an image string, and returns a tagged image

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -52,9 +52,7 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 			if img, imgPlatforms, err := imageDigestAndPlatforms(ctx, cli, service.TaskTemplate.ContainerSpec.Image, options.EncodedRegistryAuth); err != nil {
 				resolveWarning = digestWarning(service.TaskTemplate.ContainerSpec.Image)
 			} else {
-				if img != "" {
-					service.TaskTemplate.ContainerSpec.Image = img
-				}
+				service.TaskTemplate.ContainerSpec.Image = img
 				if len(imgPlatforms) > 0 {
 					if service.TaskTemplate.Placement == nil {
 						service.TaskTemplate.Placement = &swarm.Placement{}
@@ -71,9 +69,7 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 			if img, imgPlatforms, err := imageDigestAndPlatforms(ctx, cli, service.TaskTemplate.PluginSpec.Remote, options.EncodedRegistryAuth); err != nil {
 				resolveWarning = digestWarning(service.TaskTemplate.PluginSpec.Remote)
 			} else {
-				if img != "" {
-					service.TaskTemplate.PluginSpec.Remote = img
-				}
+				service.TaskTemplate.PluginSpec.Remote = img
 				if len(imgPlatforms) > 0 {
 					if service.TaskTemplate.Placement == nil {
 						service.TaskTemplate.Placement = &swarm.Placement{}

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -49,34 +49,14 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 			service.TaskTemplate.ContainerSpec.Image = taggedImg
 		}
 		if options.QueryRegistry {
-			if img, imgPlatforms, err := imageDigestAndPlatforms(ctx, cli, service.TaskTemplate.ContainerSpec.Image, options.EncodedRegistryAuth); err != nil {
-				resolveWarning = digestWarning(service.TaskTemplate.ContainerSpec.Image)
-			} else {
-				service.TaskTemplate.ContainerSpec.Image = img
-				if len(imgPlatforms) > 0 {
-					if service.TaskTemplate.Placement == nil {
-						service.TaskTemplate.Placement = &swarm.Placement{}
-					}
-					service.TaskTemplate.Placement.Platforms = imgPlatforms
-				}
-			}
+			resolveWarning = resolveContainerSpecImage(ctx, cli, &service.TaskTemplate, options.EncodedRegistryAuth)
 		}
 	case service.TaskTemplate.PluginSpec != nil:
 		if taggedImg := imageWithTagString(service.TaskTemplate.PluginSpec.Remote); taggedImg != "" {
 			service.TaskTemplate.PluginSpec.Remote = taggedImg
 		}
 		if options.QueryRegistry {
-			if img, imgPlatforms, err := imageDigestAndPlatforms(ctx, cli, service.TaskTemplate.PluginSpec.Remote, options.EncodedRegistryAuth); err != nil {
-				resolveWarning = digestWarning(service.TaskTemplate.PluginSpec.Remote)
-			} else {
-				service.TaskTemplate.PluginSpec.Remote = img
-				if len(imgPlatforms) > 0 {
-					if service.TaskTemplate.Placement == nil {
-						service.TaskTemplate.Placement = &swarm.Placement{}
-					}
-					service.TaskTemplate.Placement.Platforms = imgPlatforms
-				}
-			}
+			resolveWarning = resolvePluginSpecRemote(ctx, cli, &service.TaskTemplate, options.EncodedRegistryAuth)
 		}
 	}
 

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -15,8 +15,8 @@ import (
 // of swarm.Service, which can be found using ServiceInspectWithRaw.
 func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (types.ServiceUpdateResponse, error) {
 	var (
-		query   = url.Values{}
-		distErr error
+		query    = url.Values{}
+		response = types.ServiceUpdateResponse{}
 	)
 
 	headers := map[string][]string{
@@ -38,46 +38,52 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 	query.Set("version", strconv.FormatUint(version.Index, 10))
 
 	if err := validateServiceSpec(service); err != nil {
-		return types.ServiceUpdateResponse{}, err
+		return response, err
 	}
 
-	var imgPlatforms []swarm.Platform
 	// ensure that the image is tagged
-	if service.TaskTemplate.ContainerSpec != nil {
+	var resolveWarning string
+	switch {
+	case service.TaskTemplate.ContainerSpec != nil:
 		if taggedImg := imageWithTagString(service.TaskTemplate.ContainerSpec.Image); taggedImg != "" {
 			service.TaskTemplate.ContainerSpec.Image = taggedImg
 		}
 		if options.QueryRegistry {
-			var img string
-			img, imgPlatforms, distErr = imageDigestAndPlatforms(ctx, cli, service.TaskTemplate.ContainerSpec.Image, options.EncodedRegistryAuth)
-			if img != "" {
-				service.TaskTemplate.ContainerSpec.Image = img
+			if img, imgPlatforms, err := imageDigestAndPlatforms(ctx, cli, service.TaskTemplate.ContainerSpec.Image, options.EncodedRegistryAuth); err != nil {
+				resolveWarning = digestWarning(service.TaskTemplate.ContainerSpec.Image)
+			} else {
+				if img != "" {
+					service.TaskTemplate.ContainerSpec.Image = img
+				}
+				if len(imgPlatforms) > 0 {
+					if service.TaskTemplate.Placement == nil {
+						service.TaskTemplate.Placement = &swarm.Placement{}
+					}
+					service.TaskTemplate.Placement.Platforms = imgPlatforms
+				}
 			}
 		}
-	}
-
-	// ensure that the image is tagged
-	if service.TaskTemplate.PluginSpec != nil {
+	case service.TaskTemplate.PluginSpec != nil:
 		if taggedImg := imageWithTagString(service.TaskTemplate.PluginSpec.Remote); taggedImg != "" {
 			service.TaskTemplate.PluginSpec.Remote = taggedImg
 		}
 		if options.QueryRegistry {
-			var img string
-			img, imgPlatforms, distErr = imageDigestAndPlatforms(ctx, cli, service.TaskTemplate.PluginSpec.Remote, options.EncodedRegistryAuth)
-			if img != "" {
-				service.TaskTemplate.PluginSpec.Remote = img
+			if img, imgPlatforms, err := imageDigestAndPlatforms(ctx, cli, service.TaskTemplate.PluginSpec.Remote, options.EncodedRegistryAuth); err != nil {
+				resolveWarning = digestWarning(service.TaskTemplate.PluginSpec.Remote)
+			} else {
+				if img != "" {
+					service.TaskTemplate.PluginSpec.Remote = img
+				}
+				if len(imgPlatforms) > 0 {
+					if service.TaskTemplate.Placement == nil {
+						service.TaskTemplate.Placement = &swarm.Placement{}
+					}
+					service.TaskTemplate.Placement.Platforms = imgPlatforms
+				}
 			}
 		}
 	}
 
-	if service.TaskTemplate.Placement == nil && len(imgPlatforms) > 0 {
-		service.TaskTemplate.Placement = &swarm.Placement{}
-	}
-	if len(imgPlatforms) > 0 {
-		service.TaskTemplate.Placement.Platforms = imgPlatforms
-	}
-
-	var response types.ServiceUpdateResponse
 	resp, err := cli.post(ctx, "/services/"+serviceID+"/update", query, service, headers)
 	defer ensureReaderClosed(resp)
 	if err != nil {
@@ -85,9 +91,8 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 	}
 
 	err = json.NewDecoder(resp.body).Decode(&response)
-
-	if distErr != nil {
-		response.Warnings = append(response.Warnings, digestWarning(service.TaskTemplate.ContainerSpec.Image))
+	if resolveWarning != "" {
+		response.Warnings = append(response.Warnings, resolveWarning)
 	}
 
 	return response, err


### PR DESCRIPTION
- `ContainerSpec` and `PluginSpec` are mutually exclusive, so instead of using two separate if-statements, combine them in a switch.
- Use local variables (at cost of some slight duplication)
- Fix a potential NPE if image-digest resolution failed for a `PluginSpec`.  The code was always using `ContainerSpec.Image` to create a `digestWarning`,  but in case we're resoling the digest for a `PluginSpec`, `ContainerSpec`  will be `nil` (as they're mutually exclusive). This issue was introduced in  https://github.com/moby/moby/commit/72c3bcf2a533a827402945e3a55872e2db4fb024 (https://github.com/moby/moby/pull/33575), where the new `PluginSpec` path  was added.
- imageWithDigestString: return image unmodified if there are no changes
  Instead of returning an empty string, return the image unmodified
- extract logic for resolving image/plugin digest and platform
