### PR TITLE
fix --cluster-store-opt deprecation annotation

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -74,7 +74,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.StringVar(&conf.ClusterStore, "cluster-store", "", "URL of the distributed storage backend")
 	_ = flags.MarkDeprecated("cluster-store", "Swarm classic is deprecated. Please use Swarm-mode (docker swarm init)")
 	flags.Var(opts.NewNamedMapOpts("cluster-store-opts", conf.ClusterOpts, nil), "cluster-store-opt", "Set cluster store options")
-	_ = flags.MarkDeprecated("cluster-store-opts", "Swarm classic is deprecated. Please use Swarm-mode (docker swarm init)")
+	_ = flags.MarkDeprecated("cluster-store-opt", "Swarm classic is deprecated. Please use Swarm-mode (docker swarm init)")
 
 	flags.StringVar(&conf.CorsHeaders, "api-cors-header", "", "Set CORS headers in the Engine API")
 	flags.IntVar(&maxConcurrentDownloads, "max-concurrent-downloads", config.DefaultMaxConcurrentDownloads, "Set the max concurrent downloads for each pull")


### PR DESCRIPTION
Commit 1470697b6763ee8674dd48f55250a34bcdcb10b2 (https://github.com/moby/moby/pull/40510) marked this flag as deprecated, but inadvertedtly used the plural (which is used for `daemon.json`, but not for the flag name.

This fixes the inccorect name of the flag.

relates to https://github.com/moby/moby/issues/40383
