### PR TITLE
[19.03] vendor: swarmkit 0b8364e7d08aa0e972241eb59ae981a67a587a0e

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -128,7 +128,7 @@ github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266
 github.com/gogo/googleapis                          d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0
 
 # cluster
-github.com/docker/swarmkit                          062b694b46c0744d601eebef79f3f7433d808a04 # bump_v19.03 branch
+github.com/docker/swarmkit                          0b8364e7d08aa0e972241eb59ae981a67a587a0e # bump_v19.03 branch
 github.com/gogo/protobuf                            ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
 github.com/golang/protobuf                          aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2

--- a/vendor/github.com/docker/swarmkit/agent/storage.go
+++ b/vendor/github.com/docker/swarmkit/agent/storage.go
@@ -131,7 +131,9 @@ func PutTask(tx *bolt.Tx, task *api.Task) error {
 
 // PutTaskStatus updates the status for the task with id.
 func PutTaskStatus(tx *bolt.Tx, id string, status *api.TaskStatus) error {
-	return withCreateTaskBucketIfNotExists(tx, id, func(bkt *bolt.Bucket) error {
+	// this used to be withCreateTaskBucketIfNotExists, but that could lead
+	// to weird race conditions, and was not necessary.
+	return withTaskBucket(tx, id, func(bkt *bolt.Bucket) error {
 		p, err := proto.Marshal(status)
 		if err != nil {
 			return err


### PR DESCRIPTION
full diff: https://github.com/docker/swarmkit/compare/062b694b46c0744d601eebef79f3f7433d808a04...0b8364e7d08aa0e972241eb59ae981a67a587a0e

- https://github.com/docker/swarmkit/pull/2940 Fix leaking tasks.db
    - backport of https://github.com/docker/swarmkit/pull/2938
    - addresses https://github.com/moby/moby/issues/34827 "single manager docker swarm stuck in Down state after reboot"
    - addresses https://github.com/docker/swarmkit/issues/2367 Swarm's tasks.db takes up lots of disk space
    - addresses https://github.com/docker/swarmkit/issues/2672 Possible bugs in task reaper
    - addresses https://github.com/moby/moby/issues/40573 Docker 19.03.6 crash


