### PR TITLE
support `--privileged --cgroupns=private` on cgroup v1

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -711,10 +711,6 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 		if !sysInfo.CgroupNamespaces {
 			warnings = append(warnings, "Your kernel does not support cgroup namespaces.  Cgroup namespace setting discarded.")
 		}
-
-		if hostConfig.Privileged && !cgroups.IsCgroup2UnifiedMode() {
-			return warnings, fmt.Errorf("privileged mode is incompatible with private cgroup namespaces on cgroup v1 host.  You must run the container in the host cgroup namespace when running privileged mode")
-		}
 	}
 
 	return warnings, nil

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -339,10 +339,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 			if !cgroupNsMode.Valid() {
 				return fmt.Errorf("invalid cgroup namespace mode: %v", cgroupNsMode)
 			}
-
-			// for cgroup v2: unshare cgroupns even for privileged containers
-			// https://github.com/containers/libpod/pull/4374#issuecomment-549776387
-			if cgroupNsMode.IsPrivate() && (cgroups.IsCgroup2UnifiedMode() || !c.HostConfig.Privileged) {
+			if cgroupNsMode.IsPrivate() {
 				nsCgroup := specs.LinuxNamespace{Type: "cgroup"}
 				setNamespace(s, nsCgroup)
 			}

--- a/integration/container/run_cgroupns_linux_test.go
+++ b/integration/container/run_cgroupns_linux_test.go
@@ -114,9 +114,8 @@ func TestCgroupNamespacesRunPrivilegedAndPrivate(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon())
 	skip.If(t, !requirement.CgroupNamespacesEnabled())
 
-	// Running with both privileged and cgroupns=private is not allowed
-	errStr := "privileged mode is incompatible with private cgroup namespaces on cgroup v1 host.  You must run the container in the host cgroup namespace when running privileged mode"
-	testCreateFailureWithCgroupNs(t, "private", errStr, container.WithPrivileged(true), container.WithCgroupnsMode("private"))
+	containerCgroup, daemonCgroup := testRunWithCgroupNs(t, "private", container.WithPrivileged(true), container.WithCgroupnsMode("private"))
+	assert.Assert(t, daemonCgroup != containerCgroup)
 }
 
 func TestCgroupNamespacesRunInvalidMode(t *testing.T) {


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Support `--privileged --cgroupns=private` on cgroup v1

Fix #40788

**- How I did it**

Eliminated extra check

**- How to verify it**

```console
$ docker run -d --name=nginx --privileged --cgroupns=private nginx:alpine
$ sudo lsns
...
4026532679 cgroup      3  1601 root             nginx: master process nginx -g daemon off;
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
support `--privileged --cgroupns=private` on cgroup v1


**- A picture of a cute animal (not mandatory but encouraged)**
