### PR TITLE
Add since filter to containers/images/networks prune

### DIFF
--- a/client/container_prune_test.go
+++ b/client/container_prune_test.go
@@ -40,9 +40,18 @@ func TestContainersPrune(t *testing.T) {
 	noDanglingFilters := filters.NewArgs()
 	noDanglingFilters.Add("dangling", "false")
 
+	danglingSinceFilters := filters.NewArgs()
+	danglingSinceFilters.Add("dangling", "true")
+	danglingSinceFilters.Add("since", "2016-12-15T18:00")
+
 	danglingUntilFilters := filters.NewArgs()
 	danglingUntilFilters.Add("dangling", "true")
 	danglingUntilFilters.Add("until", "2016-12-15T14:00")
+
+	danglingSinceUntilFilters := filters.NewArgs()
+	danglingSinceUntilFilters.Add("dangling", "true")
+	danglingSinceUntilFilters.Add("since", "2016-12-15T18:00")
+	danglingSinceUntilFilters.Add("until", "2016-12-15T14:00")
 
 	labelFilters := filters.NewArgs()
 	labelFilters.Add("dangling", "true")
@@ -56,6 +65,7 @@ func TestContainersPrune(t *testing.T) {
 		{
 			filters: filters.Args{},
 			expectedQueryParams: map[string]string{
+				"since":   "",
 				"until":   "",
 				"filter":  "",
 				"filters": "",
@@ -64,22 +74,43 @@ func TestContainersPrune(t *testing.T) {
 		{
 			filters: danglingFilters,
 			expectedQueryParams: map[string]string{
+				"since":   "",
 				"until":   "",
 				"filter":  "",
 				"filters": `{"dangling":{"true":true}}`,
 			},
 		},
 		{
+			filters: danglingSinceFilters,
+			expectedQueryParams: map[string]string{
+				"since":   "",
+				"until":   "",
+				"filter":  "",
+				"filters": `{"dangling":{"true":true},"since":{"2016-12-15T18:00":true}}`,
+			},
+		},
+		{
 			filters: danglingUntilFilters,
 			expectedQueryParams: map[string]string{
+				"since":   "",
 				"until":   "",
 				"filter":  "",
 				"filters": `{"dangling":{"true":true},"until":{"2016-12-15T14:00":true}}`,
 			},
 		},
 		{
+			filters: danglingSinceUntilFilters,
+			expectedQueryParams: map[string]string{
+				"since":   "",
+				"until":   "",
+				"filter":  "",
+				"filters": `{"dangling":{"true":true},"since":{"2016-12-15T18:00":true},"until":{"2016-12-15T14:00":true}}`,
+			},
+		},
+		{
 			filters: noDanglingFilters,
 			expectedQueryParams: map[string]string{
+				"since":   "",
 				"until":   "",
 				"filter":  "",
 				"filters": `{"dangling":{"false":true}}`,
@@ -88,6 +119,7 @@ func TestContainersPrune(t *testing.T) {
 		{
 			filters: labelFilters,
 			expectedQueryParams: map[string]string{
+				"since":   "",
 				"until":   "",
 				"filter":  "",
 				"filters": `{"dangling":{"true":true},"label":{"label1=foo":true,"label2!=bar":true}}`,

--- a/client/image_prune_test.go
+++ b/client/image_prune_test.go
@@ -51,6 +51,7 @@ func TestImagesPrune(t *testing.T) {
 		{
 			filters: filters.Args{},
 			expectedQueryParams: map[string]string{
+				"since":   "",
 				"until":   "",
 				"filter":  "",
 				"filters": "",
@@ -59,6 +60,7 @@ func TestImagesPrune(t *testing.T) {
 		{
 			filters: danglingFilters,
 			expectedQueryParams: map[string]string{
+				"since":   "",
 				"until":   "",
 				"filter":  "",
 				"filters": `{"dangling":{"true":true}}`,
@@ -68,6 +70,7 @@ func TestImagesPrune(t *testing.T) {
 			filters: noDanglingFilters,
 			expectedQueryParams: map[string]string{
 				"until":   "",
+				"since":   "",
 				"filter":  "",
 				"filters": `{"dangling":{"false":true}}`,
 			},
@@ -75,6 +78,7 @@ func TestImagesPrune(t *testing.T) {
 		{
 			filters: labelFilters,
 			expectedQueryParams: map[string]string{
+				"since":   "",
 				"until":   "",
 				"filter":  "",
 				"filters": `{"dangling":{"true":true},"label":{"label1=foo":true,"label2!=bar":true}}`,

--- a/client/network_prune_test.go
+++ b/client/network_prune_test.go
@@ -52,6 +52,7 @@ func TestNetworksPrune(t *testing.T) {
 		{
 			filters: filters.Args{},
 			expectedQueryParams: map[string]string{
+				"since":   "",
 				"until":   "",
 				"filter":  "",
 				"filters": "",
@@ -60,6 +61,7 @@ func TestNetworksPrune(t *testing.T) {
 		{
 			filters: danglingFilters,
 			expectedQueryParams: map[string]string{
+				"since":   "",
 				"until":   "",
 				"filter":  "",
 				"filters": `{"dangling":{"true":true}}`,
@@ -68,6 +70,7 @@ func TestNetworksPrune(t *testing.T) {
 		{
 			filters: noDanglingFilters,
 			expectedQueryParams: map[string]string{
+				"since":   "",
 				"until":   "",
 				"filter":  "",
 				"filters": `{"dangling":{"false":true}}`,
@@ -76,6 +79,7 @@ func TestNetworksPrune(t *testing.T) {
 		{
 			filters: labelFilters,
 			expectedQueryParams: map[string]string{
+				"since":   "",
 				"until":   "",
 				"filter":  "",
 				"filters": `{"dangling":{"true":true},"label":{"label1=foo":true,"label2!=bar":true}}`,

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -6395,6 +6395,7 @@ paths:
             Filters to process on the prune list, encoded as JSON (a `map[string][]string`).
 
             Available filters:
+            - `since=<timestamp>` Prune containers created after this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
             - `until=<timestamp>` Prune containers created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
             - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune containers with (or without, in case `label!=...` is used) the specified labels.
           type: "string"
@@ -7176,6 +7177,7 @@ paths:
             - `dangling=<boolean>` When set to `true` (or `1`), prune only
                unused *and* untagged images. When set to `false`
                (or `0`), all unused images are pruned.
+            - `since=<string>` Prune images created after this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
             - `until=<string>` Prune images created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
             - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune images with (or without, in case `label!=...` is used) the specified labels.
           type: "string"
@@ -8575,6 +8577,7 @@ paths:
             Filters to process on the prune list, encoded as JSON (a `map[string][]string`).
 
             Available filters:
+            - `since=<timestamp>` Prune networks created after this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
             - `until=<timestamp>` Prune networks created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
             - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune networks with (or without, in case `label!=...` is used) the specified labels.
           type: "string"

--- a/integration/container/prune_test.go
+++ b/integration/container/prune_test.go
@@ -1,0 +1,35 @@
+package container // import "github.com/docker/docker/integration/container"
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/testutil/request"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/poll"
+)
+
+func TestPruneSince(t *testing.T) {
+	defer setupTest(t)()
+
+	ctx := context.Background()
+	client := testEnv.APIClient()
+
+	cID1 := container.Run(ctx, t, client, container.WithCmd("true"))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID1, "exited"), poll.WithDelay(100*time.Millisecond))
+
+	since := request.DaemonUnixTime(ctx, t, client, testEnv)
+
+	cID2 := container.Run(ctx, t, client, container.WithCmd("true"))
+	poll.WaitOn(t, container.IsInState(ctx, client, cID2, "exited"), poll.WithDelay(100*time.Millisecond))
+
+	args := filters.NewArgs()
+	args.UnmarshalJSON([]byte(fmt.Sprintf(`{"since": {"%s": true}}`, since)))
+	report, _ := client.ContainersPrune(ctx, args)
+	assert.Assert(t, reflect.DeepEqual(report.ContainersDeleted, []string{cID2}))
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Implemented `since` filter in `/containers/prune` , `/images/prune`, `/networks/prune` (also added some tests and updated docs for it). I thought it might be better to have this filter considering we already have `until` filter. 

**- How I did it**
Changed `daemon/prune.go` file and implemented `since` flag. Also added some tests in `integration/container/prune_test.go`.

**- How to verify it**
Run `integration/container/prune_test.go`, which I added some test for this enhancement.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add `since` filter to containers/images/networks prune

**- A picture of a cute animal (not mandatory but encouraged)**
![Screen Shot 2020-04-23 at 15 24 52](https://user-images.githubusercontent.com/25544414/80066271-98896e00-8576-11ea-9818-db27a2fe70e1.png)

Resolves: #40879 
