### PR TITLE
Extend xattrs support for security.* and user.pax.*

### DIFF
--- a/builder/remotecontext/filehash.go
+++ b/builder/remotecontext/filehash.go
@@ -24,7 +24,7 @@ func NewFileHash(path, name string, fi os.FileInfo) (hash.Hash, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := archive.ReadSecurityXattrToTarHeader(path, hdr); err != nil {
+	if err := archive.ReadWhitelistedXattrToTarHeader(path, hdr); err != nil {
 		return nil, err
 	}
 	tsh := &tarsumHash{hdr: hdr, Hash: sha256.New()}

--- a/integration/build/testdata/Dockerfile.testBuildPreserveXattrs
+++ b/integration/build/testdata/Dockerfile.testBuildPreserveXattrs
@@ -1,0 +1,23 @@
+FROM alpine AS base
+RUN apk add --no-cache attr
+
+FROM base AS testdata
+
+# Create a test-file and set a whitelisted extended attribute. Verify the attribute is set
+RUN mkdir -p /testdir && touch /testdir/testfile \
+ && setfattr -n user.pax.flags -v ok /testdir/testfile \
+ && test "$(getfattr -n user.pax.flags --only-values testdir/testfile)" = "ok" || { echo "failed to set xattr 'user.pax.flags'"; exit 1; }
+
+# Verify the attribute is preserved in the image
+FROM testdata AS original
+RUN test "$(getfattr -n user.pax.flags --only-values testdir/testfile)" = "ok" || { echo "xattr 'user.pax.flags' was not preserved on original file"; exit 1; }
+
+# Verify the attribute is preserved when (recursively) copying a directory
+FROM base AS copy_dir
+COPY --from=testdata /testdir /testdir-copy
+RUN test "$(getfattr -n user.pax.flags --only-values testdir-copy/testfile)" = "ok" || { echo "xattr 'user.pax.flags' was not preserved on copied directory"; exit 1; }
+
+# Verify the attribute is preserved when copying a file
+FROM base AS copy_file
+COPY --from=testdata /testdir/testfile /testfile-copy
+RUN test "$(getfattr -n user.pax.flags --only-values testfile-copy)" = "ok" || { echo "xattr 'user.pax.flags' was not preserved on copied file"; exit 1; }

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -1197,6 +1197,10 @@ func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 			hdr.Name = filepath.Base(dst)
 			hdr.Mode = int64(chmodTarEntry(os.FileMode(hdr.Mode)))
 
+			if err := ReadWhitelistedXattrToTarHeader(src, hdr); err != nil {
+				return err
+			}
+
 			if err := remapIDs(archiver.IDMapping, hdr); err != nil {
 				return err
 			}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -115,6 +115,10 @@ const (
 	modeISSOCK = 0140000 // Socket
 )
 
+const (
+	paxSchilyXattr = "SCHILY.xattrs."
+)
+
 // IsArchivePath checks if the (possibly compressed) file at the given path
 // starts with a tar file header.
 func IsArchivePath(path string) bool {
@@ -414,11 +418,15 @@ func ReadWhitelistedXattrToTarHeader(path string, hdr *tar.Header) error {
 	}
 
 	hdr.Xattrs = make(map[string]string, len(xattrs))
+	if hdr.PAXRecords == nil {
+		hdr.PAXRecords = make(map[string]string, len(xattrs))
+	}
 
 	for _, name := range xattrs {
 		xattr, _ := system.Lgetxattr(path, name)
 		if xattr != nil {
 			hdr.Xattrs[name] = string(xattr)
+			hdr.PAXRecords[paxSchilyXattr+name] = string(xattr)
 		}
 	}
 	return nil
@@ -690,8 +698,14 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 		}
 	}
 
+	var xattrs map[string]string
+	if hdr.Xattrs != nil {
+		xattrs = hdr.Xattrs
+	} else if hdr.PAXRecords != nil {
+		xattrs = getPAXSchilyXattr(hdr.PAXRecords)
+	}
 	var errors []string
-	for key, value := range hdr.Xattrs {
+	for key, value := range xattrs {
 		if err := system.Lsetxattr(path, key, []byte(value), 0); err != nil {
 			if err == syscall.ENOTSUP || err == syscall.EPERM {
 				// We ignore errors here because not all graphdrivers support
@@ -744,6 +758,22 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 		}
 	}
 	return nil
+}
+
+// getPAXSchilyXattr copies extended attributes from "SCHILY.xattrs" namespace
+// in PAXRecords and returns them as a new map, where key is xattr name and
+// value is xattr value
+func getPAXSchilyXattr(PAXRecords map[string]string) map[string]string {
+	schilyXattrs := make(map[string]string)
+
+	for key, value := range PAXRecords {
+		if strings.HasPrefix(key, paxSchilyXattr) {
+			key = key[len(paxSchilyXattr):]
+			schilyXattrs[key] = value
+		}
+	}
+
+	return schilyXattrs
 }
 
 // Tar creates an archive from the directory at `path`, and returns it as a

--- a/pkg/containerfs/archiver.go
+++ b/pkg/containerfs/archiver.go
@@ -146,6 +146,11 @@ func (archiver *Archiver) CopyFileWithTar(src, dst string) (retErr error) {
 			hdr.AccessTime = time.Time{}
 			hdr.ChangeTime = time.Time{}
 			hdr.Name = dstDriver.Base(dst)
+
+			if err := archive.ReadWhitelistedXattrToTarHeader(src, hdr); err != nil {
+				return err
+			}
+
 			if dstDriver.OS() == "windows" {
 				hdr.Mode = int64(chmodTarEntry(os.FileMode(hdr.Mode)))
 			} else {

--- a/pkg/system/xattrs_linux.go
+++ b/pkg/system/xattrs_linux.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package system // import "github.com/docker/docker/pkg/system"
 
 import "golang.org/x/sys/unix"
@@ -5,6 +7,7 @@ import "golang.org/x/sys/unix"
 // Lgetxattr retrieves the value of the extended attribute identified by attr
 // and associated with the given path in the file system.
 // It will returns a nil slice and nil error if the xattr is not set.
+// It doesn't follow symlinks.
 func Lgetxattr(path string, attr string) ([]byte, error) {
 	// Start with a 128 length byte array
 	dest := make([]byte, 128)
@@ -32,6 +35,44 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 
 // Lsetxattr sets the value of the extended attribute identified by attr
 // and associated with the given path in the file system.
+// It doesn't follow symlinks.
 func Lsetxattr(path string, attr string, data []byte, flags int) error {
 	return unix.Lsetxattr(path, attr, data, flags)
+}
+
+// Llistxattr lists extended attributes associated with the given path in the
+// file system. It doesn't follow symlinks.
+func Llistxattr(path string) ([]string, error) {
+	size, err := unix.Llistxattr(path, nil)
+	if err != nil {
+		if err == unix.ENOTSUP || err == unix.EOPNOTSUPP {
+			// filesystem does not support extended attributes
+			return nil, nil
+		}
+		return nil, err
+	}
+	if size <= 0 {
+		return nil, nil
+	}
+
+	buf := make([]byte, size)
+	read, err := unix.Llistxattr(path, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return stringsFromByteSlice(buf[:read]), nil
+}
+
+// stringsFromByteSlice converts a sequence of attributes to a []string.
+func stringsFromByteSlice(buf []byte) []string {
+	var result []string
+	off := 0
+	for i, b := range buf {
+		if b == 0 {
+			result = append(result, string(buf[off:i]))
+			off = i + 1
+		}
+	}
+	return result
 }

--- a/pkg/system/xattrs_unsupported.go
+++ b/pkg/system/xattrs_unsupported.go
@@ -11,3 +11,8 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 func Lsetxattr(path string, attr string, data []byte, flags int) error {
 	return ErrNotSupportedPlatform
 }
+
+// Llistxattr is not supported on platforms other than linux.
+func Llistxattr(path string) ([]string, error) {
+	return nil, ErrNotSupportedPlatform
+}


### PR DESCRIPTION
Fixes #35699
Fixes #40375

Based on [WIP] PR from @thaJeztah :
https://github.com/moby/moby/pull/40087

**- What I did**

- Added whitelist for xattrs copied to the tar header. Whitelist includes user.pax. and security. namespaces. Before only security.capability xattrs were copied
- Added xattrs to PAXRecords SCHILY.xattr namespace in the tar header - Xattrs field is deprecated
- Fixed the legacy builder, so that it preserves xattrs on file copy

**- How I did it**

- I modified and renamed ReadSecurityXattrToTarHeader() to use whitelist instead of simple filter for security.capability. I added Llistxattr to the system package to list all xattrs assigned to the file.
- I added  ReadWhitelistedXattrToTarHeader() to CopyFileWithTar() - archiver interface - to preserve xattrs on file copy.
- I modified ReadWhitelistedXattrToTarHeader() to store xattrs in PAXRecords, and createTarFile() to read xattrs from PAXRecords if no xattrs in Xattrs.

**- How to verify it**

Run TestBuildPreserveXattrs

Run test described here:

https://github.com/moby/moby/issues/40375

More information in commit messages 

**- Description for the changelog**

Added archiver's support for xattrs other than security.capability

**- A picture of a cute animal (not mandatory but encouraged)**

