### PR TITLE
bump up rootlesskit to v0.9.4

### DIFF
--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# v0.9.2
-: ${ROOTLESSKIT_COMMIT:=eefbc3f7fb73d9a993605c9ff9a36bfcad6c1270}
+# v0.9.4
+: ${ROOTLESSKIT_COMMIT:=0fec9adac6b078aa8616da47e9d75f663ca3f492}
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
Now `rootlesskit-docker-proxy` returns detailed error message on exposing privileged ports: https://github.com/rootless-containers/rootlesskit/pull/136

Full changes: https://github.com/rootless-containers/rootlesskit/compare/v0.9.2...v0.9.4

--- 

Before:
```console
$ docker --context=rootless run -it -p 80:80 --rm alpine
docker: Error response from daemon: driver failed programming external connectiv
ity on endpoint clever_euclid (77c992ce4056362ee89727f4d2d96c349bbb9013b14f4f201
2412f2fbc94718e): Error starting userland proxy:.
```

After:
```console
$ docker --context=rootless run -it -p 80:80 --rm alpine
docker: Error response from daemon: driver failed programming external connectiv
ity on endpoint brave_murdock (71e0f00b4a8555cefd15d984d15f4dc255e4caa2ca5cc72df
8a04e463afc13b2): Error starting userland proxy: error while calling PortManager
.AddPort(): cannot expose privileged port 80, you might need to add "net.ipv4.ip
_unprivileged_port_start=0" (currently 1024) to /etc/sysctl.conf, or set CAP_NET
_BIND_SERVICE on rootlesskit binary: listen tcp 0.0.0.0:80: bind: permission den
ied.
```