### PR TITLE
[19.03 backport] bump up rootlesskit to v0.9.4

### DIFF
--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# v0.7.1
-: ${ROOTLESSKIT_COMMIT:=76c4e26750da3986fa0e741464fbf0fcd55bea71}
+# v0.9.4
+: ${ROOTLESSKIT_COMMIT:=0fec9adac6b078aa8616da47e9d75f663ca3f492}
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
Now `rootlesskit-docker-proxy` returns detailed error message on
exposing privileged ports: https://github.com/rootless-containers/rootlesskit/pull/136

Full changes: https://github.com/rootless-containers/rootlesskit/compare/v0.7.1...v0.9.4

Backport of https://github.com/moby/moby/pull/40860
