### PR TITLE
vendor: update moby/ipvs v1.0.1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -54,7 +54,7 @@ github.com/hashicorp/serf                           598c54895cc5a7b1a24a398d635e
 github.com/docker/libkv                             458977154600b9f23984d9f4b82e79570b5ae12b
 github.com/vishvananda/netns                        0a2b9b5464df8343199164a0321edf3313202f7e
 github.com/vishvananda/netlink                      f049be6f391489d3f374498fe0c8df8449258372 # v1.1.0
-github.com/moby/ipvs                                8f137da6850a975020f4f739c589d293dd3a9d7b # v1.0.0
+github.com/moby/ipvs                                4566ccea0e08d68e9614c3e7a64a23b850c4bb35 # v1.0.1
 
 # When updating, consider updating TOMLV_COMMIT in hack/dockerfile/install/tomlv.installer accordingly
 github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1


### PR DESCRIPTION
full diff: https://github.com/moby/ipvs/compare/v1.0.0...v1.0.1

- Fix compatibility issue on older kernels (< 3.18) where the address
  family attribute for destination servers do not exist
- Fix the stats attribute check when parsing destination addresses
- NetlinkSocketsTimeout should be a constant


