### PR TITLE
plugin: Add No-Lock version of resolvePluginID to fix double Rlock

### DIFF
--- a/plugin/store.go
+++ b/plugin/store.go
@@ -248,10 +248,8 @@ func (ps *Store) CallHandler(p *v2.Plugin) {
 	}
 }
 
+// resolvePluginID must be protected by ps.RLock
 func (ps *Store) resolvePluginID(idOrName string) (string, error) {
-	ps.RLock() // todo: fix
-	defer ps.RUnlock()
-
 	if validFullID.MatchString(idOrName) {
 		return idOrName, nil
 	}


### PR DESCRIPTION
**- What I did**
Fix a double RLock in `GetV2Plugin()` in plugin/store.go.

**- How I did it**
Add a new function `resolvePluginIDNoLock()` which has all the content of the original `resolvePluginID()` except the lock. Then make `resolvePluginID()` call the NoLock version with lock protection. Replace the call to `resolvePluginID()` in `GetV2Plugin()` with the NoLock version.

**- How to verify it**
As the [https://golang.org/pkg/sync/](https://golang.org/pkg/sync/) says about RLock:
`It should not be used for recursive read locking; a blocked Lock call excludes new readers from acquiring the lock.`
So double read lock should also be avoided.

The first lock is in `GetV2Plugin()`. Then it calls `resolvePluginID()`, where the second lock resides.

After the patch, the second lock is removed.

**- Description for the changelog**
Add a new function `resolvePluginIDNoLock()` which has all the content of the original `resolvePluginID()` except the lock. Then make `resolvePluginID()` call the NoLock version with lock protection. Replace the call to `resolvePluginID()` in `GetV2Plugin()` with the NoLock version.

**- A picture of a cute animal (not mandatory but encouraged)**
![rabbit](https://user-images.githubusercontent.com/11943383/80509029-65e2d980-89ab-11ea-842e-86a5f81f75c8.jpg)

