### PR TITLE
vendor konsorten/go-windows-terminal-sequences v1.0.3

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -9,7 +9,7 @@ github.com/Microsoft/opengcs                        a10967154e143a36014584a6f664
 github.com/moby/term                                063f2cd0b49dbb0752774d1cb649998d91424fea
 
 github.com/creack/pty                               3a6a957789163cacdfe0e291617a1c8e80612c11 # v1.1.9
-github.com/konsorten/go-windows-terminal-sequences  f55edac94c9bbba5d6182a4be46d86a2c9b5b50e # v1.0.2
+github.com/konsorten/go-windows-terminal-sequences  edb144dfd453055e1e49a3d8b410a660b5a87613 # v1.0.3
 github.com/mattn/go-shellwords                      36a9b3c57cb5caa559ff63fb7e9b585f1c00df75 # v1.0.6
 github.com/sirupsen/logrus                          839c75faf7f98a33d445d181f3018b5c3409a45e # v1.4.2
 github.com/tchap/go-patricia                        a7f0089c6f496e8e70402f61733606daa326cac5 # v2.3.0

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/README.md
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/README.md
@@ -27,6 +27,7 @@ We thank all the authors who provided code to this library:
 
 * Felix Kollmann
 * Nicolas Perraut
+* @dirty49374
 
 ## License
 

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/sequences.go
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/sequences.go
@@ -4,7 +4,6 @@ package sequences
 
 import (
 	"syscall"
-	"unsafe"
 )
 
 var (
@@ -27,7 +26,7 @@ func EnableVirtualTerminalProcessing(stream syscall.Handle, enable bool) error {
 		mode &^= ENABLE_VIRTUAL_TERMINAL_PROCESSING
 	}
 
-	ret, _, err := setConsoleMode.Call(uintptr(unsafe.Pointer(stream)), uintptr(mode))
+	ret, _, err := setConsoleMode.Call(uintptr(stream), uintptr(mode))
 	if ret == 0 {
 		return err
 	}


### PR DESCRIPTION
full diff: https://github.com/konsorten/go-windows-terminal-sequences/compare/v1.0.2...v1.0.3

Fixes a panic when using logrus on Go 1.14

relates to https://github.com/moby/moby/pull/40353
