### PR TITLE
vendor: sort imports to prevent vendoring race condition

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -88,11 +88,12 @@ github.com/opencontainers/runtime-spec              29686dbc5559d93fb1ef402eeda3
 github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
 github.com/seccomp/libseccomp-golang                689e3c1541a84461afc49c1c87352a6cedf72e9c # v0.9.1
 
+# go-systemd v17 is required by github.com/coreos/pkg/capnslog/journald_formatter.go
+github.com/coreos/go-systemd                        39ca1b05acc7ad1220e09f133283b8859a8b71ab # v17
+
 # systemd integration (journald, daemon/listeners, containerd/cgroups)
 github.com/coreos/go-systemd/v22                    2d78030078ef61b3cae27f42ad6d0e46db51b339 # v22.0.0
 github.com/godbus/dbus/v5                           37bf87eef99d69c4f1d3528bd66e3a87dc201472 # v5.0.3
-# go-systemd v17 is required by github.com/coreos/pkg/capnslog/journald_formatter.go
-github.com/coreos/go-systemd                        39ca1b05acc7ad1220e09f133283b8859a8b71ab # v17
 
 # gelf logging driver deps
 github.com/Graylog2/go-gelf                         1550ee647df0510058c9d67a45c56f18911d80b8 # v2 branch


### PR DESCRIPTION


If both a "versioned" and "non-versioned" version of a dependency
exists in vendor.conf, the "longest" path should be cloned last,
otherwise the versioned dependency may be deleted when cloning its
non-versioned variant.

For example, with the following vendor.conf:

    github.com/coreos/go-systemd/v22 v22.0.0
    github.com/coreos/go-systemd v17

Running vndr would;

1. recursively delete "vendor/src/github.com/coreos/go-systemd/v22:
2. start cloning "github.com/coreos/go-systemd/v22"
3. recursively delete "vendor/src/github.com/coreos/go-systemd"
4. start cloning "github.com/coreos/go-systemd"

This would lead to a conflicting situation; step 3. will remove
the dependency that was previously cloned (or in the process
of being cloned).

This patch sorts the dependencies by import-path, cloning the
shortest import paths first, which should prevent the race condition.

This should address the issue seen in https://github.com/moby/moby/pull/40873#issuecomment-621165309

