### PR TITLE
Make binary: install all containerd shims to bundles

### DIFF
--- a/hack/make/binary-daemon
+++ b/hack/make/binary-daemon
@@ -14,7 +14,7 @@ copy_binaries() {
 		return
 	fi
 	echo "Copying nested executables into $dir"
-	for file in containerd containerd-shim ctr runc docker-init docker-proxy rootlesskit rootlesskit-docker-proxy dockerd-rootless.sh; do
+	for file in containerd containerd-shim containerd-shim-runc-v2 ctr runc docker-init docker-proxy rootlesskit rootlesskit-docker-proxy dockerd-rootless.sh; do
 		cp -f "$(command -v "$file")" "$dir/"
 		if [ "$hash" = "hash" ]; then
 			hash_files "$dir/$file"


### PR DESCRIPTION
The containerd.installer was updated to also copy `containerd-shim-runc-v2` (in https://github.com/moby/moby/pull/40658), but `hack/make/binary-daemon` did not copy it to the bundles directory.
