### PR TITLE
containerd.installer: refactor

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -1,36 +1,31 @@
 #!/bin/sh
+set -e
 
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
 : "${CONTAINERD_COMMIT:=814b7956fafc7a0980ea07e950f983d0837e5578}" # v1.3.4
 
-install_containerd() {
+install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"
 	git clone https://github.com/containerd/containerd.git "$GOPATH/src/github.com/containerd/containerd"
 	cd "$GOPATH/src/github.com/containerd/containerd"
 	git checkout -q "$CONTAINERD_COMMIT"
 
-	(
+	export BUILDTAGS='netgo osusergo static_build'
+	export EXTRA_FLAGS='-buildmode=pie'
+	export EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"'
 
-		export BUILDTAGS='netgo osusergo static_build'
-		export EXTRA_FLAGS='-buildmode=pie'
-		export EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"'
+	# Reset build flags to nothing if we want a dynbinary
+	if [ "$1" = "dynamic" ]; then
+		export BUILDTAGS=''
+		export EXTRA_FLAGS=''
+		export EXTRA_LDFLAGS=''
+	fi
+	make
 
-		# Reset build flags to nothing if we want a dynbinary
-		if [ "$1" = "dynamic" ]; then
-			export BUILDTAGS=''
-			export EXTRA_FLAGS=''
-			export EXTRA_LDFLAGS=''
-		fi
-
-		make
-	)
-
-	mkdir -p "${PREFIX}"
-
-	cp bin/containerd "${PREFIX}/containerd"
-	cp bin/containerd-shim "${PREFIX}/containerd-shim"
-	cp bin/containerd-shim-runc-v2 "${PREFIX}/containerd-shim-runc-v2"
-	cp bin/ctr "${PREFIX}/ctr"
-}
+	install -D bin/containerd "${PREFIX}/containerd"
+	install -D bin/containerd-shim "${PREFIX}/containerd-shim"
+	install -D bin/containerd-shim-runc-v2 "${PREFIX}/containerd-shim-runc-v2"
+	install -D bin/ctr "${PREFIX}/ctr"
+)


### PR DESCRIPTION
- add `set -e` to prevent linting warnings
- use `install` instead of `cp`
- use a subshell for the whole function, instead of starting one
  inside it.

