### PR TITLE
Make healthcheck buffer size configurable

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -617,6 +617,9 @@ definitions:
       StartPeriod:
         description: "Start period for the container to initialize before starting health-retries countdown in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit."
         type: "integer"
+      BufferSize:
+        description: "Longest healthcheck probe output message to store in bytes. 0 means inherit."
+        type: "integer"
 
   Health:
     description: |

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -436,6 +436,7 @@ func healthConfigFromGRPC(h *swarmapi.HealthConfig) *container.HealthConfig {
 		Timeout:     timeout,
 		Retries:     int(h.Retries),
 		StartPeriod: startPeriod,
+		BufferSize : int(h.BufferSize),
 	}
 }
 
@@ -446,6 +447,7 @@ func healthConfigToGRPC(h *container.HealthConfig) *swarmapi.HealthConfig {
 		Timeout:     gogotypes.DurationProto(h.Timeout),
 		Retries:     int32(h.Retries),
 		StartPeriod: gogotypes.DurationProto(h.StartPeriod),
+		BufferSize:  int32(h.BufferSize),
 	}
 }
 

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -347,6 +347,7 @@ func (c *containerConfig) healthcheck() *enginecontainer.HealthConfig {
 		Timeout:     timeout,
 		Retries:     int(hcSpec.Retries),
 		StartPeriod: startPeriod,
+		BufferSize:  int(hcSpec.BufferSize),
 	}
 }
 

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -93,6 +93,9 @@ func merge(userConf, imageConf *containertypes.Config) error {
 			if userConf.Healthcheck.Retries == 0 {
 				userConf.Healthcheck.Retries = imageConf.Healthcheck.Retries
 			}
+			if userConf.Healthcheck.BufferSize == 0 {
+				userConf.Healthcheck.BufferSize = imageConf.Healthcheck.BufferSize
+			}
 		}
 	}
 

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -343,6 +343,9 @@ func validateHealthCheck(healthConfig *containertypes.HealthConfig) error {
 	if healthConfig.StartPeriod != 0 && healthConfig.StartPeriod < containertypes.MinimumDuration {
 		return errors.Errorf("StartPeriod in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
 	}
+	if healthConfig.BufferSize < 0 {
+		return errors.Errorf("BufferSize in Healthcheck cannot be negative")
+	}
 	return nil
 }
 

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -92,7 +92,7 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container
 	}
 	d.LogContainerEventWithAttributes(cntr, "exec_create: "+execConfig.Entrypoint+" "+strings.Join(execConfig.Args, " "), attributes)
 
-	output := &limitedBuffer{limit: defaultMaxOutputLen}
+	output := &limitedBuffer{limit: cntr.Config.Healthcheck.BufferSize}
 	err = d.ContainerExecStart(ctx, execConfig.ID, nil, output, output)
 	if err != nil {
 		return nil, err

--- a/daemon/health_test.go
+++ b/daemon/health_test.go
@@ -152,4 +152,11 @@ func TestHealthStates(t *testing.T) {
 	if c.State.Health.FailingStreak != 0 {
 		t.Errorf("Expecting FailingStreak=0, but got %d\n", c.State.Health.FailingStreak)
 	}
+
+	// Test buffer size
+
+	reset(c)
+	c.Config.Healthcheck.BufferSize = 4096
+
+	// TODO: implement buffer size tests
 }

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -466,6 +466,7 @@ func TestCreateWithInvalidHealthcheckParams(t *testing.T) {
 		timeout     time.Duration
 		retries     int
 		startPeriod time.Duration
+		bufferSize  int
 		expectedErr string
 	}{
 		{
@@ -504,6 +505,13 @@ func TestCreateWithInvalidHealthcheckParams(t *testing.T) {
 			startPeriod: 100 * time.Microsecond,
 			expectedErr: fmt.Sprintf("StartPeriod in Healthcheck cannot be less than %s", container.MinimumDuration),
 		},
+		{
+			doc:         "test invalid BufferSize in Healthcheck: less than 0",
+			interval:    time.Second,
+			timeout:     time.Second,
+			bufferSize:  -10,
+			expectedErr: "BufferSize in Healthcheck cannot be negative",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -520,6 +528,9 @@ func TestCreateWithInvalidHealthcheckParams(t *testing.T) {
 			}
 			if tc.startPeriod != 0 {
 				cfg.Healthcheck.StartPeriod = tc.startPeriod
+			}
+			if tc.bufferSize != 0 {
+				cfg.Healthcheck.BufferSize = tc.bufferSize
 			}
 
 			resp, err := client.ContainerCreate(ctx, &cfg, &container.HostConfig{}, nil, "")


### PR DESCRIPTION
Please see the corresponding [CLI PR](https://github.com/docker/cli/pull/2498)

Signed-off-by: Denis Novozhilov <348558+gloomybrain@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I've added an ability for an end-user to regulate what amount of healthcheck output gets stored after execution. 

**- How I did it**
There is a new cli parameter `--health-buffer-size` that regulates how much can we store of the latests healthcheck output. There are no logical changes, just parameter propagation and small changes of the size limit check.

**- How to verify it**
This should be verified in conjunction with the CLI PR (see the link at the top). Passing `--health-buffer-size` should lead to having a configured amount of data in the [`Log` array](https://docs.docker.com/engine/api/v1.40/#operation/ContainerInspect)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
I've [added the `limit` field to the LimitedBuffer struct](https://github.com/moby/moby/compare/master...gloomybrain:configure-healthcheck-buffer-size?expand=1#diff-e9ee36fa14ba54512c7e7b0918c7b1d0R330) and leveraged this field in the healthcheck output handler.`

**- A picture of a cute animal (not mandatory but encouraged)**
![cute-animal](https://user-images.githubusercontent.com/348558/80959150-de63f300-8e0e-11ea-9395-3ac38a7c4829.jpg)
