### PR TITLE
Fix curl progress flags

### DIFF
--- a/contrib/download-frozen-image-v1.sh
+++ b/contrib/download-frozen-image-v1.sh
@@ -84,7 +84,7 @@ while [ $# -gt 0 ]; do
 			echo "skipping existing ${imageId:0:12}"
 			continue
 		fi
-		curl -SL --progress -H "Authorization: Token $token" "https://registry-1.docker.io/v1/images/$imageId/layer" -o "$dir/$imageId/layer.tar" # -C -
+		curl -SL --progress-bar -H "Authorization: Token $token" "https://registry-1.docker.io/v1/images/$imageId/layer" -o "$dir/$imageId/layer.tar" # -C -
 	done
 	echo
 done

--- a/contrib/download-frozen-image-v2.sh
+++ b/contrib/download-frozen-image-v2.sh
@@ -160,7 +160,7 @@ handle_single_manifest_v2() {
 					continue
 				fi
 				local token="$(curl -fsSL "$authBase/token?service=$authService&scope=repository:$image:pull" | jq --raw-output '.token')"
-				fetch_blob "$token" "$image" "$layerDigest" "$dir/$layerTar" --progress
+				fetch_blob "$token" "$image" "$layerDigest" "$dir/$layerTar" --progress-bar
 				;;
 
 			*)
@@ -304,7 +304,7 @@ while [ $# -gt 0 ]; do
 					continue
 				fi
 				token="$(curl -fsSL "$authBase/token?service=$authService&scope=repository:$image:pull" | jq --raw-output '.token')"
-				fetch_blob "$token" "$image" "$imageLayer" "$dir/$layerId/layer.tar" --progress
+				fetch_blob "$token" "$image" "$imageLayer" "$dir/$layerId/layer.tar" --progress-bar
 			done
 			;;
 


### PR DESCRIPTION
**- What I did**

Fix wrong curl progress flags

**- How I did it**

Change `--progress` to `--progress-bar` on calls to `curl` and `fetch-blob` (which in turn calls `curl`)

**- How to verify it**

```
./contrib/download-frozen-image-v2.sh dummy ubuntu:latest
```

will run successfully

**- Description for the changelog**

Change `--progress` to `--progress-bar` on calls to `curl` and `fetch-blob` (which in turn calls `curl`)

