### PR TITLE
vendor.conf: add version comments

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -126,7 +126,7 @@ github.com/containerd/containerd                    4d242818bf55542e5d7876ca276f
 github.com/containerd/fifo                          ff969a566b00877c63489baf6e8c35d60af6142c
 github.com/containerd/continuity                    26c1120b8d4107d2471b93ad78ef7ce1fc84c4c4
 github.com/containerd/cgroups                       44306b6a1d46985d916b48b4199f93a378af314f
-github.com/containerd/console                       8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6
+github.com/containerd/console                       8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6 # v1.0.0
 github.com/containerd/go-runc                       7016d3ce2328dd2cb1192b2076ebd565c4e8df0c
 github.com/containerd/typeurl                       b45ef1f1f737e10bd45b25b669df25f0da8b9ba0
 github.com/containerd/ttrpc                         0be804eadb152bc3b3c20c5edc314c4633833398

--- a/vendor.conf
+++ b/vendor.conf
@@ -128,8 +128,8 @@ github.com/containerd/continuity                    26c1120b8d4107d2471b93ad78ef
 github.com/containerd/cgroups                       44306b6a1d46985d916b48b4199f93a378af314f
 github.com/containerd/console                       8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6 # v1.0.0
 github.com/containerd/go-runc                       7016d3ce2328dd2cb1192b2076ebd565c4e8df0c
-github.com/containerd/typeurl                       b45ef1f1f737e10bd45b25b669df25f0da8b9ba0
-github.com/containerd/ttrpc                         0be804eadb152bc3b3c20c5edc314c4633833398
+github.com/containerd/typeurl                       b45ef1f1f737e10bd45b25b669df25f0da8b9ba0 # v1.0.0-13-gb45ef1f
+github.com/containerd/ttrpc                         0be804eadb152bc3b3c20c5edc314c4633833398 # v1.0.0-16-g0be804e
 github.com/gogo/googleapis                          01e0f9cca9b92166042241267ee2a5cdf5cff46c # v1.3.2
 github.com/cilium/ebpf                              60c3aa43f488292fe2ee50fb8b833b383ca8ebbb
 


### PR DESCRIPTION
These dependencies have tagged releases, and we vendor a tagged release, or have tagged releases but we're currently vendoring from master. Add a comment to give some "clue" what version we're vendoring.