### PR TITLE
Resolve image

### DIFF
--- a/client/container_create.go
+++ b/client/container_create.go
@@ -38,11 +38,13 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 		query.Set("name", containerName)
 	}
 
-	resolvedImage, err := cli.getImage(ctx, config)
-	if err != nil {
-		return response, err
+	if config != nil {
+		resolvedImage, err := cli.getImage(ctx, config)
+		if err != nil {
+			return response, err
+		}
+		config.Image = resolvedImage
 	}
-	config.Image = resolvedImage
 
 	body := configWrapper{
 		Config:           config,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Create container doesn't take care of the image id. Hence, if we pass image id, it will fail to fetch (after trying to fetch from docker hub) and then will error out. **

**- If we pass image id, we resolve that to the image name and then pass it to function.**

**- Description for the changelog**
It's basically the fix for this command
`docker run -d a123456`
where, `a123456` is the image id which is locally present. This code will now resolve this image id and return the image name. 

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6952642/81184914-95f33380-8fce-11ea-9d9b-27e42693857e.png)

