### PR TITLE
hack: update default CLI version to 20.10.21

### DIFF
--- a/hack/dockerfile/install/dockercli.installer
+++ b/hack/dockerfile/install/dockercli.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 : ${DOCKERCLI_CHANNEL:=stable}
-: ${DOCKERCLI_VERSION:=17.06.2-ce}
+: ${DOCKERCLI_VERSION:=20.10.21}
 
 install_dockercli() {
 	echo "Install docker/cli version $DOCKERCLI_VERSION from $DOCKERCLI_CHANNEL"


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>
