### PR TITLE
API: split types for Resources Reservations and Limits

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -625,6 +625,20 @@ definitions:
         type: "integer"
         format: "int64"
 
+  Limit:
+    description: |
+      An object describing a limit on resources which can be requested by a task.
+    type: "object"
+    properties:
+      NanoCPUs:
+        type: "integer"
+        format: "int64"
+        example: 4000000000
+      MemoryBytes:
+        type: "integer"
+        format: "int64"
+        example: 8272408576
+
   ResourceObject:
     description: |
       An object describing the resources which can be advertised by a node and
@@ -3262,7 +3276,7 @@ definitions:
         properties:
           Limits:
             description: "Define resources limits."
-            $ref: "#/definitions/ResourceObject"
+            $ref: "#/definitions/Limit"
           Reservation:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"

--- a/api/types/swarm/task.go
+++ b/api/types/swarm/task.go
@@ -91,11 +91,18 @@ type TaskSpec struct {
 	Runtime RuntimeType `json:",omitempty"`
 }
 
-// Resources represents resources (CPU/Memory).
+// Resources represents resources (CPU/Memory) which can be advertised by a
+// node and requested to be reserved for a task.
 type Resources struct {
 	NanoCPUs         int64             `json:",omitempty"`
 	MemoryBytes      int64             `json:",omitempty"`
 	GenericResources []GenericResource `json:",omitempty"`
+}
+
+// Limit describes limits on resources which can be requested by a task.
+type Limit struct {
+	NanoCPUs    int64 `json:",omitempty"`
+	MemoryBytes int64 `json:",omitempty"`
 }
 
 // GenericResource represents a "user defined" resource which can
@@ -125,7 +132,7 @@ type DiscreteGenericResource struct {
 
 // ResourceRequirements represents resources requirements.
 type ResourceRequirements struct {
-	Limits       *Resources `json:",omitempty"`
+	Limits       *Limit     `json:",omitempty"`
 	Reservations *Resources `json:",omitempty"`
 }
 

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -401,7 +401,7 @@ func resourcesFromGRPC(res *swarmapi.ResourceRequirements) *types.ResourceRequir
 	if res != nil {
 		resources = &types.ResourceRequirements{}
 		if res.Limits != nil {
-			resources.Limits = &types.Resources{
+			resources.Limits = &types.Limit{
 				NanoCPUs:    res.Limits.NanoCPUs,
 				MemoryBytes: res.Limits.MemoryBytes,
 			}


### PR DESCRIPTION
This introduces A new type (`ResourceLimit`), which allows "Limits" and "Reservations" to have different options, as it's not possible to make "Reservations" for some kind of limits.

The `GenericResources` have been removed from the new type (and thus from `Limits`); the API did not handle specifying `GenericResources` as a _Limit_ (only as _Reservations_), and this field would therefore always be empty (omitted) in the `Limits` case.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

