### PR TITLE
API: swarm: move PidsLimit to TaskTemplate.Resources

### DIFF
--- a/api/server/router/swarm/helpers.go
+++ b/api/server/router/swarm/helpers.go
@@ -97,10 +97,13 @@ func adjustForAPIVersion(cliVersion string, service *swarm.ServiceSpec) {
 	}
 	if versions.LessThan(cliVersion, "1.41") {
 		if service.TaskTemplate.ContainerSpec != nil {
-			// Capabilities and PidsLimit for docker swarm services weren't
+			// Capabilities for docker swarm services weren't
 			// supported before API version 1.41
 			service.TaskTemplate.ContainerSpec.Capabilities = nil
-			service.TaskTemplate.ContainerSpec.PidsLimit = 0
+		}
+		if service.TaskTemplate.Resources != nil && service.TaskTemplate.Resources.Limits != nil {
+			// Limits.Pids  not supported before API version 1.41
+			service.TaskTemplate.Resources.Limits.Pids = 0
 		}
 
 		// jobs were only introduced in API version 1.41. Nil out both Job

--- a/api/server/router/swarm/helpers_test.go
+++ b/api/server/router/swarm/helpers_test.go
@@ -17,8 +17,7 @@ func TestAdjustForAPIVersion(t *testing.T) {
 	spec := &swarm.ServiceSpec{
 		TaskTemplate: swarm.TaskSpec{
 			ContainerSpec: &swarm.ContainerSpec{
-				Sysctls:   expectedSysctls,
-				PidsLimit: 300,
+				Sysctls: expectedSysctls,
 				Privileges: &swarm.Privileges{
 					CredentialSpec: &swarm.CredentialSpec{
 						Config: "someconfig",
@@ -44,6 +43,11 @@ func TestAdjustForAPIVersion(t *testing.T) {
 			Placement: &swarm.Placement{
 				MaxReplicas: 222,
 			},
+			Resources: &swarm.ResourceRequirements{
+				Limits: &swarm.Limit{
+					Pids: 300,
+				},
+			},
 		},
 	}
 
@@ -55,10 +59,10 @@ func TestAdjustForAPIVersion(t *testing.T) {
 		t.Error("Sysctls was stripped from spec")
 	}
 
-	if spec.TaskTemplate.ContainerSpec.PidsLimit == 0 {
+	if spec.TaskTemplate.Resources.Limits.Pids == 0 {
 		t.Error("PidsLimit was stripped from spec")
 	}
-	if spec.TaskTemplate.ContainerSpec.PidsLimit != 300 {
+	if spec.TaskTemplate.Resources.Limits.Pids != 300 {
 		t.Error("PidsLimit did not preserve the value from spec")
 	}
 
@@ -80,7 +84,7 @@ func TestAdjustForAPIVersion(t *testing.T) {
 		t.Error("Sysctls was not stripped from spec")
 	}
 
-	if spec.TaskTemplate.ContainerSpec.PidsLimit != 0 {
+	if spec.TaskTemplate.Resources.Limits.Pids != 0 {
 		t.Error("PidsLimit was not stripped from spec")
 	}
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -638,6 +638,13 @@ definitions:
         type: "integer"
         format: "int64"
         example: 8272408576
+      Pids:
+        description: |
+          Limits the maximum number of PIDs in the container. Set `0` for unlimited.
+        type: "integer"
+        format: "int64"
+        default: 0
+        example: 100
 
   ResourceObject:
     description: |
@@ -3220,13 +3227,6 @@ definitions:
               configured on the daemon) is used.
             type: "boolean"
             x-nullable: true
-          PidsLimit:
-            description: |
-              Tune a container's PIDs limit. Set `0` for unlimited.
-            type: "integer"
-            format: "int64"
-            default: 0
-            example: 100
           Sysctls:
             description: |
               Set kernel namedspaced parameters (sysctls) in the container.

--- a/api/types/swarm/container.go
+++ b/api/types/swarm/container.go
@@ -72,7 +72,6 @@ type ContainerSpec struct {
 	Secrets      []*SecretReference  `json:",omitempty"`
 	Configs      []*ConfigReference  `json:",omitempty"`
 	Isolation    container.Isolation `json:",omitempty"`
-	PidsLimit    int64               `json:",omitempty"`
 	Sysctls      map[string]string   `json:",omitempty"`
 	Capabilities []string            `json:",omitempty"`
 }

--- a/api/types/swarm/task.go
+++ b/api/types/swarm/task.go
@@ -103,6 +103,7 @@ type Resources struct {
 type Limit struct {
 	NanoCPUs    int64 `json:",omitempty"`
 	MemoryBytes int64 `json:",omitempty"`
+	Pids        int64 `json:",omitempty"`
 }
 
 // GenericResource represents a "user defined" resource which can

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -36,7 +36,6 @@ func containerSpecFromGRPC(c *swarmapi.ContainerSpec) *types.ContainerSpec {
 		Configs:      configReferencesFromGRPC(c.Configs),
 		Isolation:    IsolationFromGRPC(c.Isolation),
 		Init:         initFromGRPC(c.Init),
-		PidsLimit:    c.PidsLimit,
 		Sysctls:      c.Sysctls,
 		Capabilities: c.Capabilities,
 	}
@@ -264,7 +263,6 @@ func containerToGRPC(c *types.ContainerSpec) (*swarmapi.ContainerSpec, error) {
 		Secrets:      secretReferencesToGRPC(c.Secrets),
 		Isolation:    isolationToGRPC(c.Isolation),
 		Init:         initToGRPC(c.Init),
-		PidsLimit:    c.PidsLimit,
 		Sysctls:      c.Sysctls,
 		Capabilities: c.Capabilities,
 	}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -31,12 +31,13 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /services/{id}/update` now accepts `Capabilities` as part of the `ContainerSpec`.
 * `GET /tasks` now  returns `Capabilities` as part of the `ContainerSpec`.
 * `GET /tasks/{id}` now  returns `Capabilities` as part of the `ContainerSpec`.
-* `GET /services` now returns `PidsLimit` as part of the `ContainerSpec`.
-* `GET /services/{id}` now returns `PidsLimit` as part of the `ContainerSpec`.
-* `POST /services/create` now accepts `PidsLimit` as part of the `ContainerSpec`.
-* `POST /services/{id}/update` now accepts `PidsLimit` as part of the `ContainerSpec`.
-* `GET /tasks` now  returns `PidsLimit` as part of the `ContainerSpec`.
-* `GET /tasks/{id}` now  returns `PidsLimit` as part of the `ContainerSpec`.
+* `GET /services` now returns `Pids` in `TaskTemplate.Resources.Limits`.
+* `GET /services/{id}` now returns `Pids` in `TaskTemplate.Resources.Limits`.
+* `POST /services/create` now accepts `Pids` in `TaskTemplate.Resources.Limits`.
+* `POST /services/{id}/update` now accepts `Pids` in `TaskTemplate.Resources.Limits`
+  to limit the maximum number of PIDs.
+* `GET /tasks` now  returns `Pids` in `TaskTemplate.Resources.Limits`.
+* `GET /tasks/{id}` now  returns `Pids` in `TaskTemplate.Resources.Limits`.
 * `POST /containers/create` on Linux now accepts the `HostConfig.CgroupnsMode` property.
   Set the property to `host` to create the container in the daemon's cgroup namespace, or
   `private` to create the container in its own private cgroup namespace.  The per-daemon

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -196,11 +196,11 @@ func ServiceWithCapabilities(Capabilities []string) ServiceSpecOpt {
 	}
 }
 
-// ServiceWithPidsLimit sets the PidsLimit option of the service's ContainerSpec.
+// ServiceWithPidsLimit sets the PidsLimit option of the service's Resources.Limits.
 func ServiceWithPidsLimit(limit int64) ServiceSpecOpt {
 	return func(spec *swarmtypes.ServiceSpec) {
-		ensureContainerSpec(spec)
-		spec.TaskTemplate.ContainerSpec.PidsLimit = limit
+		ensureResources(spec)
+		spec.TaskTemplate.Resources.Limits.Pids = limit
 	}
 }
 
@@ -233,6 +233,18 @@ func ExecTask(t *testing.T, d *daemon.Daemon, task swarmtypes.Task, config types
 	attach, err := client.ContainerExecAttach(ctx, resp.ID, startCheck)
 	assert.NilError(t, err, "error attaching to exec")
 	return attach
+}
+
+func ensureResources(spec *swarmtypes.ServiceSpec) {
+	if spec.TaskTemplate.Resources == nil {
+		spec.TaskTemplate.Resources = &swarmtypes.ResourceRequirements{}
+	}
+	if spec.TaskTemplate.Resources.Limits == nil {
+		spec.TaskTemplate.Resources.Limits = &swarmtypes.Limit{}
+	}
+	if spec.TaskTemplate.Resources.Reservations == nil {
+		spec.TaskTemplate.Resources.Reservations = &swarmtypes.Resources{}
+	}
 }
 
 func ensureContainerSpec(spec *swarmtypes.ServiceSpec) {


### PR DESCRIPTION
This is a follow up to https://github.com/moby/moby/pull/39882 (Add API support for PidsLimit on services), which implementation followed the Swarm API, where `PidsLimit` is located in `ContainerSpec`. This is not the desired place for this property, so moving the field to `TaskTemplate.Resources` in our API.

After discussing in the maintainers meeting, we decided that we should update our API to move `PidsLimit` to the right location before the 20.x release; a similar change should be made in the SwarmKit API (likely keeping the old field for backward compatibility, because it was merged some releases back (https://github.com/docker/swarmkit/pull/2415))

depends on

- [x] https://github.com/moby/moby/pull/40937 API: split types for Resources Reservations and Limits

addresses the API side of https://github.com/moby/moby/issues/28618

**- A picture of a cute animal (not mandatory but encouraged)**

