### PR TITLE
[19.03 backport] SELinux: fix ENOTSUP errors not being detected when relabeling

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -20,7 +20,6 @@ import (
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -147,7 +146,7 @@ func (container *Container) CopyImagePathContent(v volume.Volume, destination st
 			logrus.Warnf("error while unmounting volume %s: %v", v.Name(), err)
 		}
 	}()
-	if err := label.Relabel(path, container.MountLabel, true); err != nil && err != unix.ENOTSUP {
+	if err := label.Relabel(path, container.MountLabel, true); err != nil && !errors.Is(err, syscall.ENOTSUP) {
 		return err
 	}
 	return copyExistingContents(rootfs, path)

--- a/volume/mounts/mounts.go
+++ b/volume/mounts/mounts.go
@@ -113,7 +113,7 @@ func (m *MountPoint) Setup(mountLabel string, rootIDs idtools.Identity, checkFun
 			return
 		}
 		err = label.Relabel(sourcePath, mountLabel, label.IsShared(m.Mode))
-		if err == syscall.ENOTSUP {
+		if errors.Is(err, syscall.ENOTSUP) {
 			err = nil
 		}
 		if err != nil {


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/40945
cherry-pick was clean

Commit 12c7541f1f2d616967f9eecce182789de7e2a238 (https://github.com/moby/moby/pull/40546 / https://github.com/moby/moby/pull/40547) updated the opencontainers/selinux dependency to v1.3.1, which had a breaking change in the errors that were returned.

Before v1.3.1, the "raw" `syscall.ENOTSUP` was returned if the underlying filesystem did not support xattrs, but later versions wrapped the error, which caused our detection to fail.

This patch uses `errors.Is()` to check for the underlying error. This requires github.com/pkg/errors v0.9.1 or above (older versions could use `errors.Cause()`, but are not compatible with "native" wrapping of errors in Go 1.13 and up, and could potentially cause these errors to not being detected again.

Fixes https://github.com/moby/moby/issues/40944 for 19.03 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
Fix Mounting Docker NFS Volume with selinux enabled failing with "operation not supported"
```

**- A picture of a cute animal (not mandatory but encouraged)**
