### PR TITLE
vendor: roll back docker/distribution to v2.7.1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -73,7 +73,7 @@ github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac
 github.com/modern-go/reflect2                       94122c33edd36123c84d5368cfb2b69df93a0ec8 # v1.0.1
 
 # get graph and distribution packages
-github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
+github.com/docker/distribution                      2461543d988979529609e8cb6fca9ca190dc48da # v2.7.1
 github.com/vbatts/tar-split                         80a436fd6164c557b131f7c59ed69bd81af69761 # v0.11.2
 github.com/opencontainers/go-digest                 ea51bea511f75cfa3ef6098cc253c5c3609b037a # v1.0.0
 

--- a/vendor/github.com/docker/distribution/manifest/manifestlist/manifestlist.go
+++ b/vendor/github.com/docker/distribution/manifest/manifestlist/manifestlist.go
@@ -163,7 +163,7 @@ func FromDescriptorsWithMediaType(descriptors []ManifestDescriptor, mediaType st
 		},
 	}
 
-	m.Manifests = make([]ManifestDescriptor, len(descriptors))
+	m.Manifests = make([]ManifestDescriptor, len(descriptors), len(descriptors))
 	copy(m.Manifests, descriptors)
 
 	deserialized := DeserializedManifestList{
@@ -177,7 +177,7 @@ func FromDescriptorsWithMediaType(descriptors []ManifestDescriptor, mediaType st
 
 // UnmarshalJSON populates a new ManifestList struct from JSON data.
 func (m *DeserializedManifestList) UnmarshalJSON(b []byte) error {
-	m.canonical = make([]byte, len(b))
+	m.canonical = make([]byte, len(b), len(b))
 	// store manifest list in canonical
 	copy(m.canonical, b)
 

--- a/vendor/github.com/docker/distribution/manifest/ocischema/builder.go
+++ b/vendor/github.com/docker/distribution/manifest/ocischema/builder.go
@@ -48,7 +48,7 @@ func NewManifestBuilder(bs distribution.BlobService, configJSON []byte, annotati
 // valid media type for oci image manifests currently: "" or "application/vnd.oci.image.manifest.v1+json"
 func (mb *Builder) SetMediaType(mediaType string) error {
 	if mediaType != "" && mediaType != v1.MediaTypeImageManifest {
-		return errors.New("invalid media type for OCI image manifest")
+		return errors.New("Invalid media type for OCI image manifest")
 	}
 
 	mb.mediaType = mediaType

--- a/vendor/github.com/docker/distribution/manifest/ocischema/manifest.go
+++ b/vendor/github.com/docker/distribution/manifest/ocischema/manifest.go
@@ -87,7 +87,7 @@ func FromStruct(m Manifest) (*DeserializedManifest, error) {
 
 // UnmarshalJSON populates a new Manifest struct from JSON data.
 func (m *DeserializedManifest) UnmarshalJSON(b []byte) error {
-	m.canonical = make([]byte, len(b))
+	m.canonical = make([]byte, len(b), len(b))
 	// store manifest in canonical
 	copy(m.canonical, b)
 

--- a/vendor/github.com/docker/distribution/manifest/schema1/manifest.go
+++ b/vendor/github.com/docker/distribution/manifest/schema1/manifest.go
@@ -108,7 +108,7 @@ type SignedManifest struct {
 
 // UnmarshalJSON populates a new SignedManifest struct from JSON data.
 func (sm *SignedManifest) UnmarshalJSON(b []byte) error {
-	sm.all = make([]byte, len(b))
+	sm.all = make([]byte, len(b), len(b))
 	// store manifest and signatures in all
 	copy(sm.all, b)
 
@@ -124,7 +124,7 @@ func (sm *SignedManifest) UnmarshalJSON(b []byte) error {
 	}
 
 	// sm.Canonical stores the canonical manifest JSON
-	sm.Canonical = make([]byte, len(bytes))
+	sm.Canonical = make([]byte, len(bytes), len(bytes))
 	copy(sm.Canonical, bytes)
 
 	// Unmarshal canonical JSON into Manifest object

--- a/vendor/github.com/docker/distribution/manifest/schema1/reference_builder.go
+++ b/vendor/github.com/docker/distribution/manifest/schema1/reference_builder.go
@@ -58,7 +58,7 @@ func (mb *referenceManifestBuilder) Build(ctx context.Context) (distribution.Man
 func (mb *referenceManifestBuilder) AppendReference(d distribution.Describable) error {
 	r, ok := d.(Reference)
 	if !ok {
-		return fmt.Errorf("unable to add non-reference type to v1 builder")
+		return fmt.Errorf("Unable to add non-reference type to v1 builder")
 	}
 
 	// Entries need to be prepended

--- a/vendor/github.com/docker/distribution/manifest/schema2/manifest.go
+++ b/vendor/github.com/docker/distribution/manifest/schema2/manifest.go
@@ -106,7 +106,7 @@ func FromStruct(m Manifest) (*DeserializedManifest, error) {
 
 // UnmarshalJSON populates a new Manifest struct from JSON data.
 func (m *DeserializedManifest) UnmarshalJSON(b []byte) error {
-	m.canonical = make([]byte, len(b))
+	m.canonical = make([]byte, len(b), len(b))
 	// store manifest in canonical
 	copy(m.canonical, b)
 

--- a/vendor/github.com/docker/distribution/manifests.go
+++ b/vendor/github.com/docker/distribution/manifests.go
@@ -87,7 +87,7 @@ func ManifestMediaTypes() (mediaTypes []string) {
 // UnmarshalFunc implements manifest unmarshalling a given MediaType
 type UnmarshalFunc func([]byte) (Manifest, Descriptor, error)
 
-var mappings = make(map[string]UnmarshalFunc)
+var mappings = make(map[string]UnmarshalFunc, 0)
 
 // UnmarshalManifest looks up manifest unmarshal functions based on
 // MediaType

--- a/vendor/github.com/docker/distribution/reference/normalize.go
+++ b/vendor/github.com/docker/distribution/reference/normalize.go
@@ -56,35 +56,6 @@ func ParseNormalizedNamed(s string) (Named, error) {
 	return named, nil
 }
 
-// ParseDockerRef normalizes the image reference following the docker convention. This is added
-// mainly for backward compatibility.
-// The reference returned can only be either tagged or digested. For reference contains both tag
-// and digest, the function returns digested reference, e.g. docker.io/library/busybox:latest@
-// sha256:7cc4b5aefd1d0cadf8d97d4350462ba51c694ebca145b08d7d41b41acc8db5aa will be returned as
-// docker.io/library/busybox@sha256:7cc4b5aefd1d0cadf8d97d4350462ba51c694ebca145b08d7d41b41acc8db5aa.
-func ParseDockerRef(ref string) (Named, error) {
-	named, err := ParseNormalizedNamed(ref)
-	if err != nil {
-		return nil, err
-	}
-	if _, ok := named.(NamedTagged); ok {
-		if canonical, ok := named.(Canonical); ok {
-			// The reference is both tagged and digested, only
-			// return digested.
-			newNamed, err := WithName(canonical.Name())
-			if err != nil {
-				return nil, err
-			}
-			newCanonical, err := WithDigest(newNamed, canonical.Digest())
-			if err != nil {
-				return nil, err
-			}
-			return newCanonical, nil
-		}
-	}
-	return TagNameOnly(named), nil
-}
-
 // splitDockerDomain splits a repository name to domain and remotename string.
 // If no valid domain is found, the default domain is used. Repository name
 // needs to be already validated before.

--- a/vendor/github.com/docker/distribution/reference/reference.go
+++ b/vendor/github.com/docker/distribution/reference/reference.go
@@ -205,7 +205,7 @@ func Parse(s string) (Reference, error) {
 	var repo repository
 
 	nameMatch := anchoredNameRegexp.FindStringSubmatch(matches[1])
-	if len(nameMatch) == 3 {
+	if nameMatch != nil && len(nameMatch) == 3 {
 		repo.domain = nameMatch[1]
 		repo.path = nameMatch[2]
 	} else {

--- a/vendor/github.com/docker/distribution/registry/api/errcode/errors.go
+++ b/vendor/github.com/docker/distribution/registry/api/errcode/errors.go
@@ -207,11 +207,11 @@ func (errs Errors) MarshalJSON() ([]byte, error) {
 	for _, daErr := range errs {
 		var err Error
 
-		switch daErr := daErr.(type) {
+		switch daErr.(type) {
 		case ErrorCode:
-			err = daErr.WithDetail(nil)
+			err = daErr.(ErrorCode).WithDetail(nil)
 		case Error:
-			err = daErr
+			err = daErr.(Error)
 		default:
 			err = ErrorCodeUnknown.WithDetail(daErr)
 

--- a/vendor/github.com/docker/distribution/registry/api/v2/urls.go
+++ b/vendor/github.com/docker/distribution/registry/api/v2/urls.go
@@ -252,3 +252,15 @@ func appendValuesURL(u *url.URL, values ...url.Values) *url.URL {
 	u.RawQuery = merged.Encode()
 	return u
 }
+
+// appendValues appends the parameters to the url. Panics if the string is not
+// a url.
+func appendValues(u string, values ...url.Values) string {
+	up, err := url.Parse(u)
+
+	if err != nil {
+		panic(err) // should never happen
+	}
+
+	return appendValuesURL(up, values...).String()
+}

--- a/vendor/github.com/docker/distribution/registry/client/auth/challenge/authchallenge.go
+++ b/vendor/github.com/docker/distribution/registry/client/auth/challenge/authchallenge.go
@@ -117,8 +117,8 @@ func init() {
 		var t octetType
 		isCtl := c <= 31 || c == 127
 		isChar := 0 <= c && c <= 127
-		isSeparator := strings.ContainsRune(" \t\"(),/:;<=>?@[]\\{}", rune(c))
-		if strings.ContainsRune(" \t\r\n", rune(c)) {
+		isSeparator := strings.IndexRune(" \t\"(),/:;<=>?@[]\\{}", rune(c)) >= 0
+		if strings.IndexRune(" \t\r\n", rune(c)) >= 0 {
 			t |= isSpace
 		}
 		if isChar && !isCtl && !isSeparator {

--- a/vendor/github.com/docker/distribution/vendor.conf
+++ b/vendor/github.com/docker/distribution/vendor.conf
@@ -7,7 +7,7 @@ github.com/beorn7/perks 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
 github.com/bugsnag/bugsnag-go b1d153021fcd90ca3f080db36bec96dc690fb274
 github.com/bugsnag/osext 0dd3f918b21bec95ace9dc86c7e70266cfc5c702
 github.com/bugsnag/panicwrap e2c28503fcd0675329da73bf48b33404db873782
-github.com/denverdino/aliyungo 6df11717a253d9c7d4141f9af4deaa7c580cd531
+github.com/denverdino/aliyungo afedced274aa9a7fcdd47ac97018f0f8db4e5de2
 github.com/dgrijalva/jwt-go a601269ab70c205d26370c16f7c81e9017c14e04
 github.com/docker/go-metrics 399ea8c73916000c64c2c76e8da00ca82f8387ab
 github.com/docker/libtrust fa567046d9b14f6aa788882a950d69651d230b21


### PR DESCRIPTION
Now that we no longer need the ParseDockerRef utility, we can roll back this package to the latest release.


