### PR TITLE
Add article to pull access denied error message

### DIFF
--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -71,7 +71,7 @@ func (e notFoundError) Error() string {
 	switch e.cause.Code {
 	case errcode.ErrorCodeDenied:
 		// ErrorCodeDenied is used when access to the repository was denied
-		return errors.Wrapf(e.cause, "pull access denied for %s, repository does not exist or may require 'docker login'", reference.FamiliarName(e.ref)).Error()
+		return errors.Wrapf(e.cause, "pull access denied for %s, the repository does not exist or may require 'docker login'", reference.FamiliarName(e.ref)).Error()
 	case v2.ErrorCodeManifestUnknown:
 		return errors.Wrapf(e.cause, "manifest for %s not found", reference.FamiliarString(e.ref)).Error()
 	case v2.ErrorCodeNameUnknown:

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -100,11 +100,11 @@ func (s *DockerHubPullSuite) TestPullNonExistingImage(c *testing.T) {
 	for record := range recordChan {
 		if len(record.option) == 0 {
 			assert.ErrorContains(c, record.err, "", "expected non-zero exit status when pulling non-existing image: %s", record.out)
-			assert.Assert(c, strings.Contains(record.out, fmt.Sprintf("pull access denied for %s, repository does not exist or may require 'docker login'", record.e.repo)), "expected image not found error messages")
+			assert.Assert(c, strings.Contains(record.out, fmt.Sprintf("pull access denied for %s, the repository does not exist or may require 'docker login'", record.e.repo)), "expected image not found error messages")
 		} else {
 			// pull -a on a nonexistent registry should fall back as well
 			assert.ErrorContains(c, record.err, "", "expected non-zero exit status when pulling non-existing image: %s", record.out)
-			assert.Assert(c, strings.Contains(record.out, fmt.Sprintf("pull access denied for %s, repository does not exist or may require 'docker login'", record.e.repo)), "expected image not found error messages")
+			assert.Assert(c, strings.Contains(record.out, fmt.Sprintf("pull access denied for %s, the repository does not exist or may require 'docker login'", record.e.repo)), "expected image not found error messages")
 			assert.Assert(c, !strings.Contains(record.out, "unauthorized"), `message should not contain "unauthorized"`)
 		}
 	}


### PR DESCRIPTION
The spelling fix was suggested to me by Grammarly when I pasted such error in our internal issue tracker.

The change to `vendor` source is submitted separately at https://github.com/containerd/containerd/pull/4248