### PR TITLE
pkg/archive: escape ":" symbol in overlay lowerdir

### DIFF
--- a/pkg/archive/archive_linux.go
+++ b/pkg/archive/archive_linux.go
@@ -152,7 +152,9 @@ func mknodChar0Overlay(cleansedOriginalPath string) error {
 	if err := ioutil.WriteFile(lowerDummy, []byte{}, 0600); err != nil {
 		return errors.Wrapf(err, "failed to create a dummy lower file %s", lowerDummy)
 	}
-	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work)
+	// lowerdir needs ":" to be escaped: https://github.com/moby/moby/issues/40939#issuecomment-627098286
+	lowerEscaped := strings.ReplaceAll(lower, ":", "\\:")
+	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerEscaped, upper, work)
 	if err := mount.Mount("overlay", merged, "overlay", mOpts); err != nil {
 		return err
 	}
@@ -236,7 +238,9 @@ func createDirWithOverlayOpaque(tmp string) (string, error) {
 	if err := os.MkdirAll(lowerDummy, 0700); err != nil {
 		return "", errors.Wrapf(err, "failed to create a dummy lower directory %s", lowerDummy)
 	}
-	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work)
+	// lowerdir needs ":" to be escaped: https://github.com/moby/moby/issues/40939#issuecomment-627098286
+	lowerEscaped := strings.ReplaceAll(lower, ":", "\\:")
+	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerEscaped, upper, work)
 	if err := mount.Mount("overlay", merged, "overlay", mOpts); err != nil {
 		return "", err
 	}


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix #40939

**- How I did it**


`ReplaceAll(lower, ":", "\\:")`, because lowerdir needs escaping:
https://github.com/torvalds/linux/blob/v5.4/fs/overlayfs/super.c#L835-L853


**- How to verify it**

Run `docker pull osixia/phpldapadmin:stable` on rootless with overlay2 on Ubuntu/Debian.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

🐧 