### PR TITLE
builder-next: fix layer access bug

### DIFF
--- a/builder/builder-next/adapters/snapshot/leasemanager.go
+++ b/builder/builder-next/adapters/snapshot/leasemanager.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/containerd/containerd/leases"
 	"github.com/sirupsen/logrus"
+	bolt "go.etcd.io/bbolt"
 )
 
 type sLM struct {
@@ -99,6 +100,15 @@ func (l *sLM) addRef(lID, sID string) {
 
 	if load {
 		l.s.getLayer(sID, true)
+		if _, ok := l.s.chainID(sID); ok {
+			l.s.db.Update(func(tx *bolt.Tx) error {
+				b, err := tx.CreateBucketIfNotExists([]byte(lID))
+				if err != nil {
+					return err
+				}
+				return b.Put(keyChainID, []byte(sID))
+			})
+		}
 	}
 }
 

--- a/builder/builder-next/adapters/snapshot/snapshot.go
+++ b/builder/builder-next/adapters/snapshot/snapshot.go
@@ -167,10 +167,11 @@ func (s *snapshotter) getLayer(key string, withCommitted bool) (layer.Layer, err
 				s.mu.Unlock()
 				return nil, errors.WithStack(err)
 			}
+			s.mu.Unlock()
 			if id == "" {
-				s.mu.Unlock()
 				return nil, nil
 			}
+			return s.getLayer(string(id), withCommitted)
 		}
 		var err error
 		l, err = s.opt.LayerStore.Get(id)


### PR DESCRIPTION
fixes #40858

After switch to leases all ref IDs use generated IDs meaning that
EnsureLayer hack needs to save the chainID for pulled layers.

@tao12345666333 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
