### PR TITLE
registry: fix mtls config dir passing

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -190,6 +190,17 @@ func (daemon *Daemon) RegistryHosts() docker.RegistryHosts {
 		}
 	}
 
+	certsDir := registry.CertsDir()
+	if fis, err := ioutil.ReadDir(certsDir); err == nil {
+		for _, fi := range fis {
+			if _, ok := m[fi.Name()]; !ok {
+				m[fi.Name()] = bkconfig.RegistryConfig{
+					TLSConfigDir: []string{filepath.Join(certsDir, fi.Name())},
+				}
+			}
+		}
+	}
+
 	return resolver.NewRegistryConfig(m)
 }
 

--- a/registry/config_unix.go
+++ b/registry/config_unix.go
@@ -2,10 +2,25 @@
 
 package registry // import "github.com/docker/docker/registry"
 
-var (
-	// CertsDir is the directory where certificates are stored
-	CertsDir = "/etc/docker/certs.d"
+import (
+	"path/filepath"
+
+	"github.com/docker/docker/pkg/homedir"
+	"github.com/docker/docker/rootless"
 )
+
+// CertsDir is the directory where certificates are stored
+func CertsDir() string {
+	d := "/etc/docker/certs.d"
+
+	if rootless.RunningWithRootlessKit() {
+		configHome, err := homedir.GetConfigHome()
+		if err == nil {
+			d = filepath.Join(configHome, "docker/certs.d")
+		}
+	}
+	return d
+}
 
 // cleanPath is used to ensure that a directory name is valid on the target
 // platform. It will be passed in something *similar* to a URL such as

--- a/registry/config_windows.go
+++ b/registry/config_windows.go
@@ -7,7 +7,9 @@ import (
 )
 
 // CertsDir is the directory where certificates are stored
-var CertsDir = os.Getenv("programdata") + `\docker\certs.d`
+func CertsDir() string {
+	return os.Getenv("programdata") + `\docker\certs.d`
+}
 
 // cleanPath is used to ensure that a directory name is valid on the target
 // platform. It will be passed in something *similar* to a URL such as

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -14,8 +14,6 @@ import (
 	"time"
 
 	"github.com/docker/distribution/registry/client/transport"
-	"github.com/docker/docker/pkg/homedir"
-	"github.com/docker/docker/rootless"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/sirupsen/logrus"
 )
@@ -28,16 +26,7 @@ var (
 
 // HostCertsDir returns the config directory for a specific host
 func HostCertsDir(hostname string) (string, error) {
-	certsDir := CertsDir
-
-	if rootless.RunningWithRootlessKit() {
-		configHome, err := homedir.GetConfigHome()
-		if err != nil {
-			return "", err
-		}
-
-		certsDir = filepath.Join(configHome, "docker/certs.d")
-	}
+	certsDir := CertsDir()
 
 	hostDir := filepath.Join(certsDir, cleanPath(hostname))
 
@@ -50,7 +39,7 @@ func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
 
 	tlsConfig.InsecureSkipVerify = !isSecure
 
-	if isSecure && CertsDir != "" {
+	if isSecure && CertsDir() != "" {
 		hostDir, err := HostCertsDir(hostname)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
https://github.com/moby/moby/pull/40814 doesn't pass mtls config dirs for registries that are not mentioned in main config json. A better approach would be to use a callback so adding new directories would not require a restart but that requires changes to buildkit.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>