### PR TITLE
-buildmode=pie is not supported for the mips arch

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -13,7 +13,7 @@ install_containerd() (
 	git checkout -q "$CONTAINERD_COMMIT"
 
 	export BUILDTAGS='netgo osusergo static_build'
-	export EXTRA_FLAGS='-buildmode=pie'
+	export EXTRA_FLAGS=${GO_BUILDMODE}
 	export EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"'
 
 	# Reset build flags to nothing if we want a dynbinary

--- a/hack/dockerfile/install/dockercli.installer
+++ b/hack/dockerfile/install/dockercli.installer
@@ -26,5 +26,5 @@ build_dockercli() {
 	git checkout -q "v$DOCKERCLI_VERSION"
 	mkdir -p "$GOPATH/src/github.com/docker"
 	mv components/cli "$GOPATH/src/github.com/docker/cli"
-	go build -buildmode=pie -o "${PREFIX}/docker" "github.com/docker/cli/cmd/docker"
+	go build ${GO_BUILDMODE} -o "${PREFIX}/docker" "github.com/docker/cli/cmd/docker"
 }

--- a/hack/dockerfile/install/golangci_lint.installer
+++ b/hack/dockerfile/install/golangci_lint.installer
@@ -13,7 +13,7 @@ install_golangci_lint() {
 	commitDate="$(git show -s --format=%cd)"
 
 	go build \
-		-buildmode=pie \
+		${GO_BUILDMODE} \
 		-ldflags "-s -w -X \"main.version=${version}\" -X \"main.commit=${commit}\" -X \"main.date=${commitDate}\"" \
 		-o "${PREFIX}/golangci-lint" "github.com/golangci/golangci-lint/cmd/golangci-lint"
 }

--- a/hack/dockerfile/install/gotestsum.installer
+++ b/hack/dockerfile/install/gotestsum.installer
@@ -6,6 +6,6 @@ install_gotestsum() (
 	set -e
 	export GO111MODULE=on
 	go get -d "gotest.tools/gotestsum@${GOTESTSUM_COMMIT}"
-	go build -buildmode=pie -o "${PREFIX}/gotestsum" 'gotest.tools/gotestsum'
+	go build ${GO_BUILDMODE} -o "${PREFIX}/gotestsum" 'gotest.tools/gotestsum'
 
 )

--- a/hack/dockerfile/install/install.sh
+++ b/hack/dockerfile/install/install.sh
@@ -15,6 +15,15 @@ if [ -z "$TMP_GOPATH" ]; then
 else
 	export GOPATH="$TMP_GOPATH"
 fi
+case "$(go env GOARCH)" in
+	mips* | ppc64)
+		# pie build mode is not supported on mips architectures
+		export GO_BUILDMODE=""
+		;;
+	*)
+		export GO_BUILDMODE="-buildmode=pie"
+		;;
+esac
 
 dir="$(dirname $0)"
 

--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -23,7 +23,7 @@ install_proxy() {
 
 install_proxy_dynamic() {
 	export PROXY_LDFLAGS="-linkmode=external" install_proxy
-	export BUILD_MODE="-buildmode=pie"
+	export BUILD_MODE=${GO_BUILDMODE}
 	_install_proxy
 }
 

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -21,7 +21,7 @@ install_rootlesskit() {
 
 install_rootlesskit_dynamic() {
 	export ROOTLESSKIT_LDFLAGS="-linkmode=external" install_rootlesskit
-	export BUILD_MODE="-buildmode=pie"
+	export BUILD_MODE=${GO_BUILDMODE}
 	_install_rootlesskit
 }
 

--- a/hack/dockerfile/install/shfmt.installer
+++ b/hack/dockerfile/install/shfmt.installer
@@ -7,5 +7,5 @@ install_shfmt() {
 	git clone https://github.com/mvdan/sh.git "$GOPATH/src/github.com/mvdan/sh"
 	cd "$GOPATH/src/github.com/mvdan/sh" || exit 1
 	git checkout -q "$SHFMT_COMMIT"
-	GO111MODULE=on go build -buildmode=pie -v -o "${PREFIX}/shfmt" ./cmd/shfmt
+	GO111MODULE=on go build ${GO_BUILDMODE} -v -o "${PREFIX}/shfmt" ./cmd/shfmt
 }

--- a/hack/dockerfile/install/tomlv.installer
+++ b/hack/dockerfile/install/tomlv.installer
@@ -8,5 +8,5 @@ install_tomlv() {
 	echo "Install tomlv version $TOMLV_COMMIT"
 	git clone https://github.com/BurntSushi/toml.git "$GOPATH/src/github.com/BurntSushi/toml"
 	cd "$GOPATH/src/github.com/BurntSushi/toml" && git checkout -q "$TOMLV_COMMIT"
-	go build -v -buildmode=pie -o "${PREFIX}/tomlv" "github.com/BurntSushi/toml/cmd/tomlv"
+	go build -v ${GO_BUILDMODE} -o "${PREFIX}/tomlv" "github.com/BurntSushi/toml/cmd/tomlv"
 }

--- a/hack/dockerfile/install/vndr.installer
+++ b/hack/dockerfile/install/vndr.installer
@@ -7,5 +7,5 @@ install_vndr() {
 	git clone https://github.com/LK4D4/vndr.git "$GOPATH/src/github.com/LK4D4/vndr"
 	cd "$GOPATH/src/github.com/LK4D4/vndr" || exit 1
 	git checkout -q "$VNDR_COMMIT"
-	go build -buildmode=pie -v -o "${PREFIX}/vndr" .
+	go build ${GO_BUILDMODE} -v -o "${PREFIX}/vndr" .
 }


### PR DESCRIPTION
reference:
https://github.com/docker/cli/pull/2507
https://github.com/containerd/containerd/commit/4c99c81326f4026fb8c0b8c5e10542205d99c321

Signed-off-by: Xiaodong Liu <liuxiaodong@loongson.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

