### PR TITLE
control network interface order for containers

### DIFF
--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -63,6 +63,7 @@ type EndpointSettings struct {
 	GlobalIPv6PrefixLen int
 	MacAddress          string
 	DriverOpts          map[string]string
+	Priority            int
 }
 
 // Task carries the information about one backend task

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -1083,6 +1083,11 @@ func buildJoinOptions(networkSettings *internalnetwork.Settings, n interface {
 		for k, v := range epConfig.DriverOpts {
 			joinOptions = append(joinOptions, libnetwork.EndpointOptionGeneric(options.Generic{k: v}))
 		}
+		prio := epConfig.Priority
+		//priority default to 0, so no set required
+		if prio != 0 {
+			joinOptions = append(joinOptions, libnetwork.JoinOptionPriority(prio))
+		}
 	}
 
 	return joinOptions, nil


### PR DESCRIPTION
Signed-off-by: fanjiyun <fan.jiyun@zte.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
libnetwork allows setting the priority of network interface, but I'm not sure why there's no api to support it. So, I made some changes to allow the user to control the network interface order for containers. 
related issue: [#25181](https://github.com/moby/moby/issues/25181)

Relevant PRs:
[moby/libnetwork#2550](https://github.com/moby/libnetwork/pull/2550) (open)
[docker/cli#2529](https://github.com/docker/cli/pull/2529)(open)

**- How I did it**
add some options for docker create, docker run, docker network connect. i.e.,

$ docker create --network name=my-network,**priority=1** mynginx
$ docker run --network name=my-network,**priority=2** mynginx
$ docker network connect **--priority 3** my-network my-container

priority deafult to 0, and the higher the value, the higher the priority of the network interface

**- How to verify it**

```
$ docker create --name t1 --network name=net1,priority=1 mynginx sleep 1000
$ docker network connect --priority 2 net2 t1
$ docker network connect --priority 3 net3 t1
$ docker start t1
```

network interface order: net3 > net2 > net1

```
$ docker exec t1 ifconfig  
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.20.0.2  netmask 255.255.0.0  broadcast 172.20.255.255  ---net3
		...
eth1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.19.0.3  netmask 255.255.0.0  broadcast 172.19.255.255  ---net2
		...
eth2: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.18.0.3  netmask 255.255.0.0  broadcast 172.18.255.255  ---net1
		...
```

or
	
```
$ docker run -d --name t1 --network name=net1,priority=1 mynginx:v1 sleep 1000
$ docker network connect --priority 2 net2 t1
$ docker network connect --priority 3 net3 t1
$ docker restart t1  (container restart required)

$docker exec t1 ifconfig
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.20.0.2  netmask 255.255.0.0  broadcast 172.20.255.255  ---net3
		...
eth1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.19.0.2  netmask 255.255.0.0  broadcast 172.19.255.255  ---net2
        ether 02:42:ac:13:00:02  txqueuelen 0  (Ethernet)
		...	
eth2: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.18.0.2  netmask 255.255.0.0  broadcast 172.18.255.255  ---net1
        ether 02:42:ac:12:00:02  txqueuelen 0  (Ethernet)
		...
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

