### PR TITLE
Fix bug in gotestsum installer causing dependencies to not be downloaded

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -262,29 +262,16 @@ RUN `
 RUN `
   Function Build-GoTestSum() { `
     Write-Host "INFO: Building gotestsum version $Env:GOTESTSUM_COMMIT in $Env:GOPATH"; `
-    $optsForGet = @('"get"', '"-d"', '"gotest.tools/gotestsum"'); `
-    &go $optsForGet; `
-    $savedExitCode = $LASTEXITCODE; `
-    if ($savedExitCode -ne 0) {  `
+    $env:GO111MODULE = 'on'; `
+    &go get -d "gotest.tools/gotestsum@${Env:GOTESTSUM_COMMIT}"; `
+    $env:GO111MODULE = 'off'; `
+    if ($LASTEXITCODE -ne 0) {  `
       Throw '"Failed getting gotestsum sources..."'  `
     }; `
-    Write-Host "INFO:     Sources obtained for gotestsum..."; `
-    $GotestsumPath=Join-Path -Path $Env:GOPATH -ChildPath "src\gotest.tools\gotestsum"; `
-    Push-Location $GotestsumPath; `
-    $optsForCheckout = @('"checkout"', '"-q"', """$Env:GOTESTSUM_COMMIT"""); `
-    &git $optsForCheckout; `
-    $savedExitCode = $LASTEXITCODE; `
-    if ($savedExitCode -eq 0) { `
-      Write-Host "INFO:     Checkout done for gotestsum..."; `
-      $optsForBuild = @('"build"', '"-buildmode=exe"'); `
-      &go $optsForBuild; `
-      $savedExitCode = $LASTEXITCODE; `
-    } else { `
-      Throw '"gotestsum checkout failed..."'; `
-    } `
-    Pop-Location; `
-    `
-    if ($savedExitCode -ne 0) {  `
+    $env:GO111MODULE = 'on'; `
+    &go build -buildmode=exe -o "${Env:GOPATH}\bin\gotestsum.exe" gotest.tools/gotestsum; `
+    $env:GO111MODULE = 'off'; `
+    if ($LASTEXITCODE -ne 0) {  `
       Throw '"gotestsum build failed..."'; `
     } `
     Write-Host "INFO:     Build done for gotestsum..."; `

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -528,11 +528,7 @@ Try {
             Throw "ERROR: Failed to docker cp the daemon binary (dockerd.exe) to $env:TEMP\binary"
         }
 
-        $GotestsumBinRelLocationInContainer="src\gotest.tools\gotestsum\gotestsum.exe"
-        if (-not($LastExitCode -eq 0)) {
-            Throw "ERROR: Failed to docker cp the gotestsum binary (gotestsum.exe) to $env:TEMP\binary"
-        }
-        docker cp "$COMMITHASH`:c`:\gopath\$GotestsumBinRelLocationInContainer" $env:TEMP\binary\
+        docker cp "$COMMITHASH`:c`:\gopath\bin\gotestsum.exe" $env:TEMP\binary\
         if (-not (Test-Path "$env:TEMP\binary\gotestsum.exe")) {
             Throw "ERROR: gotestsum.exe not found...." `
         }

--- a/hack/dockerfile/install/gotestsum.installer
+++ b/hack/dockerfile/install/gotestsum.installer
@@ -2,10 +2,10 @@
 
 : ${GOTESTSUM_COMMIT:=v0.3.5}
 
-install_gotestsum() {
-	echo "Installing gotestsum version $GOTESTSUM_COMMIT"
-	go get -d gotest.tools/gotestsum
-	cd "$GOPATH/src/gotest.tools/gotestsum"
-	git checkout -q "$GOTESTSUM_COMMIT"
+install_gotestsum() (
+	set -e
+	export GO111MODULE=on
+	go get -d "gotest.tools/gotestsum@${GOTESTSUM_COMMIT}"
 	go build -buildmode=pie -o "${PREFIX}/gotestsum" 'gotest.tools/gotestsum'
-}
+
+)

--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -94,7 +94,7 @@ param(
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 $pushed=$False  # To restore the directory if we have temporarily pushed to one.
-Set-Variable GOTESTSUM_LOCATION -option Constant -value "$env:GOPATH/src/gotest.tools/gotestsum"
+Set-Variable GOTESTSUM_LOCATION -option Constant -value "$env:GOPATH/bin/"
 
 # Utility function to get the commit ID of the repository
 Function Get-GitCommit() {


### PR DESCRIPTION
Building gotestsum started to fail after the repository removed some
dependencies on master.

What happens is that first, we `go get` the package (with go modules disabled);

    GO111MODULE=off go get -d gotest.tools/gotestsum

Which gets the latest version from master, and fetches the dependencies used
on master. Then we checkout the version we want to install (for example `v0.3.5`)
and run go build.

However, `v0.3.5` depends on logrus, and given that we ran `go get` for `master`,
that dependency was not fetched, and build fails.

This patch modifies the installer to use go modules (alternatively we could
probably run `go get .` after checking out the `v0.3.5` version),

**We need to modify all installers**, as it looks like this is a standard pattern
we use, but other dependencies were not failing (yet), so this patch only
addresses the immediate failure.

