### PR TITLE
[19.03 backport] Fix bug in gotestsum installer causing dependencies to not be downloaded

### DIFF
--- a/hack/dockerfile/install/gotestsum.installer
+++ b/hack/dockerfile/install/gotestsum.installer
@@ -2,10 +2,10 @@
 
 : ${GOTESTSUM_COMMIT:=v0.3.5}
 
-install_gotestsum() {
-	echo "Installing gotestsum version $GOTESTSUM_COMMIT"
-	go get -d gotest.tools/gotestsum
-	cd "$GOPATH/src/gotest.tools/gotestsum"
-	git checkout -q "$GOTESTSUM_COMMIT"
+install_gotestsum() (
+	set -e
+	export GO111MODULE=on
+	go get -d "gotest.tools/gotestsum@${GOTESTSUM_COMMIT}"
 	go build -buildmode=pie -o "${PREFIX}/gotestsum" 'gotest.tools/gotestsum'
-}
+
+)


### PR DESCRIPTION
backport of the Linux-related changes of https://github.com/moby/moby/pull/40979
the Windows Dockerfile in the 19.03 branch does not yet install gotestsum, so no changes were needed for Windows


Building gotestsum started to fail after the repository removed some
dependencies on master.

What happens is that first, we `go get` the package (with go modules disabled);

    GO111MODULE=off go get -d gotest.tools/gotestsum

Which gets the latest version from master, and fetches the dependencies used
on master. Then we checkout the version we want to install (for example `v0.3.5`)
and run go build.

However, `v0.3.5` depends on logrus, and given that we ran `go get` for `master`,
that dependency was not fetched, and build fails.

This patch modifies the installer to use go modules (alternatively we could
probably run `go get .` after checking out the `v0.3.5` version),

We need to modify all installers, as it looks like this is a standard pattern
we use, but other dependencies were not failing (yet), so this patch only
addresses the immediate failure.

