### PR TITLE
rm_test: fix goroutine leak

### DIFF
--- a/pkg/system/rm_test.go
+++ b/pkg/system/rm_test.go
@@ -63,7 +63,7 @@ func TestEnsureRemoveAllWithMount(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	done := make(chan struct{})
+	done := make(chan struct{}, 1)
 	go func() {
 		err = EnsureRemoveAll(dir1)
 		close(done)


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Converted the channel done to a buffered channel
**- How I did it**
There is a local unbuffered channel done . The send operation to finished will definitely be executed, but the receive operation may not, when the select chooses the timeout case. If timeout, there will be one goroutine leaked.
This PR gives the channel 1 buffer. This PR is quite safe, since the behavior of related goroutines won't change, except that when timeout, no goroutine will be leaked.
**- How to verify it**
By monitoring resource usage over time.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use a buffered channel to avoid goroutine leaking due to timeout.

**- A picture of a cute animal (not mandatory but encouraged)**

