### PR TITLE
seccomp: remove the unused query_module(2)

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -695,8 +695,7 @@
 			"names": [
 				"delete_module",
 				"init_module",
-				"finit_module",
-				"query_module"
+				"finit_module"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [],

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -598,7 +598,6 @@ func DefaultProfile() *types.Seccomp {
 				"delete_module",
 				"init_module",
 				"finit_module",
-				"query_module",
 			},
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Removed the unused query_module(2) from seccomp default settings.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
query_module(2)  is only in kernels before Linux 2.6.
http://man7.org/linux/man-pages/man2/query_module.2.html
So, this syscall should not be set here.

**- A picture of a cute animal (not mandatory but encouraged)**