### PR TITLE
Support containerd-based graphdriver

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -953,6 +953,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 			PluginGetter:              d.PluginStore,
 			ExperimentalEnabled:       config.Experimental,
 			OS:                        operatingSystem,
+			ContainerdClient:          d.containerdCli,
 		})
 		if err != nil {
 			return nil, err

--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -84,7 +84,7 @@ type Driver struct {
 
 // Init returns a new AUFS driver.
 // An error is returned if AUFS is not supported.
-func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap, _ *graphdriver.InitOptions) (graphdriver.Driver, error) {
 	// Try to load the aufs kernel module
 	if err := supportsAufs(); err != nil {
 		logger.Error(err)

--- a/daemon/graphdriver/aufs/aufs_test.go
+++ b/daemon/graphdriver/aufs/aufs_test.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 func testInit(dir string, t testing.TB) graphdriver.Driver {
-	d, err := Init(dir, nil, nil, nil)
+	d, err := Init(dir, nil, nil, nil, nil)
 	if err != nil {
 		if err == graphdriver.ErrNotSupported {
 			t.Skip(err)

--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -50,7 +50,7 @@ type btrfsOptions struct {
 
 // Init returns a new BTRFS driver.
 // An error is returned if BTRFS is not supported.
-func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap, _ *graphdriver.InitOptions) (graphdriver.Driver, error) {
 
 	// Perform feature detection on /var/lib/docker/btrfs if it's an existing directory.
 	// This covers situations where /var/lib/docker/btrfs is a mount, and on a different

--- a/daemon/graphdriver/containerd/containerd.go
+++ b/daemon/graphdriver/containerd/containerd.go
@@ -1,0 +1,830 @@
+// +build linux
+
+package containerd // import "github.com/docker/docker/daemon/graphdriver/containerd"
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/leases"
+	mount "github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/layer"
+	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/containerfs"
+	"github.com/docker/docker/pkg/idtools"
+	"github.com/docker/docker/pkg/locker"
+	"github.com/docker/docker/pkg/parsers"
+	"github.com/docker/docker/pkg/stringid"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	driverName = "containerd"
+
+	// namespace used by this graphdriver in containerd
+	namespace = "moby"
+
+	// labels used for leveraging "remote" snapshots.
+	labelSnapshotRef                   = "containerd.io/snapshot.ref"
+	targetRefLabel                     = "containerd.io/snapshot/remote/stargz.reference"
+	targetDigestLabel                  = "containerd.io/snapshot/remote/stargz.digest"
+	targetImageLayersLabel             = "containerd.io/snapshot/remote/stargz.layers"
+	labelSnapshotInflatedContentDiffID = "containerd.io/snapshot/moby.inflated-diff"
+	labelSnapshotContentRef            = "containerd.io/snapshot/moby.content-ref"
+	labelSnapshotContentNamespace      = "containerd.io/snapshot/moby.content-namespace"
+
+	// labels used for resource management.
+	labelGCRoot       = "containerd.io/gc.root"
+	labelGCRefContent = "containerd.io/gc.ref.content"
+)
+
+// Driver contains information about the home directory and the list of mounts and
+// contents that are created using this driver.
+type Driver struct {
+	home    string
+	uidMaps []idtools.IDMap
+	gidMaps []idtools.IDMap
+
+	store           content.Store
+	snapshotter     snapshots.Snapshotter
+	snapshotterName string
+	withLease       withLeaseFunc
+
+	locker    *locker.Locker
+	naiveDiff graphdriver.DiffDriver
+
+	// TODO: ===== manage these data on disc ======
+	contentID  map[string]string // binds layer ids to contents in the content store
+	snapshotID map[string]string // binds layer ids to snapshots in the snapshotter
+	// ====================================================
+}
+
+var (
+	logger                 = logrus.WithField("storage-driver", driverName)
+	builtinStore           content.Store         // should be used only for tests
+	builtinSnapshotter     snapshots.Snapshotter // should be used only for tests
+	builtinSnapshotterName string                // should be used only for tests
+)
+
+func init() {
+	graphdriver.Register(driverName, Init)
+}
+
+// Init returns the contaierd-based graphdriver. This driver also
+// leverages content store for inflated contents management corresponding to
+// snapshots.
+func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap, opt *graphdriver.InitOptions) (graphdriver.Driver, error) {
+	var (
+		cs     content.Store
+		sn     snapshots.Snapshotter
+		wl     withLeaseFunc
+		snName string
+	)
+	if name, err := parseName(options); err == nil && opt != nil && opt.ContainerdClient != nil {
+		sn = opt.ContainerdClient.SnapshotService(name)
+		cs = opt.ContainerdClient.ContentStore()
+		wl = withLeaseFuncFromContainerd(opt.ContainerdClient)
+		snName = name
+	} else if builtinSnapshotter != nil && builtinSnapshotterName != "" && builtinStore != nil {
+		// for tests
+		sn = builtinSnapshotter
+		cs = builtinStore
+		wl = func(ctx context.Context) (context.Context, func(context.Context) error, error) {
+			return ctx, func(_ context.Context) error { return nil }, nil
+		}
+		snName = builtinSnapshotterName
+	} else {
+		return nil, fmt.Errorf("containerd client and snapshotter name must be provided")
+	}
+
+	rootUID, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
+	if err != nil {
+		return nil, err
+	}
+	// Create the driver home dir
+	if err := idtools.MkdirAllAndChown(home, 0700, idtools.Identity{UID: rootUID, GID: rootGID}); err != nil {
+		return nil, err
+	}
+
+	d := &Driver{
+		home:            home,
+		uidMaps:         uidMaps,
+		gidMaps:         gidMaps,
+		store:           cs,
+		snapshotter:     sn,
+		snapshotterName: snName,
+		snapshotID:      make(map[string]string),
+		contentID:       make(map[string]string),
+		locker:          locker.New(),
+		withLease:       wl,
+	}
+
+	d.naiveDiff = graphdriver.NewNaiveDiffDriver(d, uidMaps, gidMaps)
+
+	return d, nil
+}
+
+func (d *Driver) Capabilities() graphdriver.Capabilities {
+	// We don't use tar-split and provide diff tar blobs from content store
+	// which previously applied by user.
+	// TODO: What should be "exact diff" if user didn't invoke "DiffApply"
+	//       and didn't provide any diff tarball for this driver?
+	return graphdriver.Capabilities{
+		ReproducesExactDiffs: true,
+	}
+}
+
+// String retuns the name of this graphdriver.
+func (d *Driver) String() string {
+	return driverName
+}
+
+// Status returns information about the background snapshotter.
+func (d *Driver) Status() [][2]string {
+	return [][2]string{
+		{"Backing Snapshotter", d.snapshotterName},
+	}
+}
+
+// GetMetadata returns information about snapshot and content binded to
+// the specified layer ID.
+func (d *Driver) GetMetadata(id string) (map[string]string, error) {
+	d.locker.Lock(id)
+	defer d.locker.Unlock(id)
+
+	var (
+		info = make(map[string]string)
+		ctx  = namedCtx() // TODO: timeout?
+	)
+
+	// Get the information about snapshot
+	sID, ok := d.snapshotID[id]
+	if !ok {
+		return nil, fmt.Errorf("snapshot doesn't registered for given id %q", id)
+	}
+	sinfo, err := d.snapshotter.Stat(ctx, sID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to stat snapshot %q(key=%q)", id, sID)
+	}
+	info["SnapshotKind"] = sinfo.Kind.String()
+	info["SnapshotName"] = sinfo.Name
+	info["SnapshotParent"] = sinfo.Parent
+	info["SnapshotCreated"] = sinfo.Created.String()
+	info["SnapshotUpdated"] = sinfo.Updated.String()
+	info["SnapshotLabels"] = ""
+	for k, v := range sinfo.Labels {
+		info["SnapshotLabels"] += fmt.Sprintf("%q: %q, ", k, v)
+	}
+
+	// Get the information about content
+	cID, ok := d.contentID[id]
+	if !ok {
+		return nil, fmt.Errorf("content doesnt't registered for given id %q", id)
+	}
+	dgst, err := digest.Parse(cID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse registered cID %q for layer %q", cID, id)
+	}
+	if st, err := d.store.Status(ctx, id); err == nil {
+		// Get the written-in-progress information
+		info["ContentRef"] = st.Ref
+		info["ContentOffset"] = fmt.Sprintf("%d", st.Offset)
+		info["ContentTotal"] = fmt.Sprintf("%d", st.Total)
+		info["ContentExpected"] = st.Expected.String()
+		info["ContentStartedAt"] = st.StartedAt.String()
+		info["ContentUpdatedAt"] = st.UpdatedAt.String()
+	} else {
+		// Get the committed content information
+		cinfo, err := d.store.Info(ctx, dgst)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get info of %q for layer %q", dgst, id)
+		}
+		info["ContentDigest"] = cinfo.Digest.String()
+		info["ContentSize"] = fmt.Sprintf("%d", cinfo.Size)
+		info["ContentCreatedAt"] = cinfo.CreatedAt.String()
+		info["ContentUpdatedAt"] = cinfo.UpdatedAt.String()
+		info["ContentLabels"] = ""
+		for k, v := range cinfo.Labels {
+			info["ContentLabels"] += fmt.Sprintf("%q: %q, ", k, v)
+		}
+	}
+
+	return info, nil
+}
+
+// Cleanup any state created by the snapshotter when daemon is being shutdown.
+func (d *Driver) Cleanup() error {
+	if c, ok := d.snapshotter.(snapshots.Cleaner); ok {
+		return c.Cleanup(namedCtx())
+	}
+	return nil
+}
+
+// CreateReadWrite creates a new, empty snapshot that is ready to be used as
+// the storage for a container.
+func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts) error {
+	return d.create(id, parent, opts)
+}
+
+// Create creates a new, empty snapshot with the specified id and parent and
+// options passed in opts.
+func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
+	return d.create(id, parent, opts)
+}
+
+func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) error {
+	d.locker.Lock(id)
+	defer d.locker.Unlock(id)
+
+	if _, ok := d.snapshotID[id]; ok {
+		return fmt.Errorf("layer (id=%q) already exists", id)
+	}
+
+	ctx, done, err := d.withLease(namedCtx()) // TODO: timeout?
+	if err != nil {
+		return err
+	}
+	defer done(ctx)
+
+	var psID string
+	if parent != "" {
+		var ok bool
+		psID, ok = d.snapshotID[parent]
+		if !ok {
+			return fmt.Errorf("snapshot isn't registered for given id %q", parent)
+		}
+		info, err := d.snapshotter.Stat(ctx, psID)
+		if err != nil {
+			return errors.Wrapf(err, "failed to stat parent layer %q(key=%q)",
+				parent, psID)
+		}
+
+		// If the parent snapshot hasn't been committed yet, commit it now so that
+		// we can add a new snapshot on the top of it.
+		// TODO1: This snapshot still should be able to be modified? Committed snapshot
+		//        can't be modified anymore.
+		// TODO2: The original active snapshot isn't accessible after this commit. This
+		//        means if the user references the mountpoint of active snapshot there
+		//        is no guarantee that the mountpoint will be still accssesible.
+		//        See also: https://github.com/containerd/containerd/commit/5e8218a63b468ea7ca19fe043c109cda45784570
+		if info.Kind != snapshots.KindCommitted {
+			labels := info.Labels
+			if labels == nil {
+				labels = make(map[string]string)
+			}
+
+			// We manually manage the lifecycle of this resource.
+			labels[labelGCRoot] = time.Now().UTC().Format(time.RFC3339)
+
+			// Refer the content corresponding to this snapshot for preventing the content
+			// getting deleted by GC.
+			if pcID, ok := d.contentID[parent]; ok {
+				labels[labelGCRefContent] = pcID
+			}
+
+			var newname string
+			for i := 0; i < 3; i++ {
+				if newname, err = uniqueKey(); err != nil {
+					continue
+				}
+				if err = d.snapshotter.Commit(ctx, newname, psID, snapshots.WithLabels(labels)); err == nil {
+					break
+				} else if err != nil && !errdefs.IsAlreadyExists(err) {
+					return errors.Wrapf(err, "failed to commit parent layer %q(key=%q)", parent, psID)
+				}
+				// Key conflicts. try with other key
+			}
+
+			// Update key to the committed one
+			psID, d.snapshotID[parent] = newname, newname
+		}
+	}
+
+	var (
+		target *graphdriver.TargetOpts
+		labels map[string]string
+	)
+	if opts != nil && opts.TargetInfo != nil {
+		// TODO: check all opts are filled
+		target = opts.TargetInfo
+
+		// NOTE: The target information of this layer is passed. So we search the snapshot
+		// and content in containerd and return "already exist" error if both of them exist.
+		// This is usable for "remote layer" functionality which let backing snapshotter
+		// to prepare snapshots from underlying remote storages, without pulling and providing
+		// image contents from user-side.
+		// This leverages containerd's remote snapshotters.
+		layers := ""
+		for _, l := range target.ImageLayers {
+			layers += fmt.Sprintf("%s,", l.String())
+		}
+		labels = map[string]string{
+
+			// The basic information of targetting snapshot
+			labelSnapshotRef:       target.MountChainID.String(),
+			targetRefLabel:         target.ImageRef,
+			targetDigestLabel:      target.LayerDigest.String(),
+			targetImageLayersLabel: layers,
+
+			// The following labels helps snapshotter to prepare contents from backing remote
+			// storages and enables us to refer these contents later.
+			labelSnapshotInflatedContentDiffID: target.ContentDiffID.String(),
+			labelSnapshotContentNamespace:      namespace,
+			labelSnapshotContentRef:            id,
+
+			// Refer the content corresponding to this snapshot for preventing the content
+			// getting deleted by GC.
+			labelGCRefContent: target.ContentDiffID.String(),
+		}
+	} else {
+		labels = make(map[string]string)
+	}
+	// We manually manage the lifecycle of this resource.
+	labels[labelGCRoot] = time.Now().UTC().Format(time.RFC3339)
+
+	// Preapre snapshot
+	var sID string
+	for i := 0; i < 3; i++ {
+		var err error
+		if sID, err = uniqueKey(); err != nil {
+			continue
+		}
+		if _, err = d.snapshotter.Prepare(ctx, sID, psID, snapshots.WithLabels(labels)); err == nil {
+			// Succeeded to prepare
+			d.snapshotID[id] = sID
+			return nil
+		} else if err != nil && !errdefs.IsAlreadyExists(err) {
+			// Failed to prepare
+			return errors.Wrapf(err, "failed to prepare snapshot %q for layer %q", sID, id)
+		}
+
+		// We are getting already exists error.
+		// The possible reasons could be the following so we need to figure out which one here.
+		// - Key conflicts.
+		// - The snapshot is provided by snapshotter by the ChainID.
+		if target == nil || target.MountChainID.String() == "" {
+			continue // Key conflicts. try with other key
+		}
+		chainID := target.MountChainID.String()
+		if _, err = d.snapshotter.Stat(ctx, chainID); err != nil {
+			continue // Key conflicts. try with other key
+		}
+
+		// This layer is provided by snapshotter. Check the content existence.
+		sID = chainID
+		err = nil
+		diffID := target.ContentDiffID
+		if diffID.String() == "" {
+			d.snapshotter.Remove(ctx, sID)
+			return fmt.Errorf("DiffID must be provided not only ChainID for layer %q", id)
+		}
+		// TODO: Check the Expected digest here but currently containerd doesn't support
+		//       getting `Expected` field by `Status`.
+		if _, err = d.store.Status(ctx, id); err != nil /* || st.Expected.String() != diffID.String() */ {
+			// Corresponding content isn't written-in-progress.
+			// Let's check if the content exists as a commtted content.
+			if _, err = d.store.Info(ctx, diffID); err != nil {
+				d.snapshotter.Remove(ctx, sID)
+				return errors.Wrapf(err, "failed to get content (DiffID=%q) for layer %q", diffID, id)
+			}
+		}
+
+		// The content also exists. Return layer.ErrAlreadyExists.
+		d.snapshotID[id] = sID
+		d.contentID[id] = diffID.String() // Register the DiffID as a content key
+
+		// Tell the client that this layer exists
+		return errors.Wrapf(layer.ErrAlreadyExists, "snapshot and content are alredy exists for layer %q", id)
+	}
+
+	return errors.Wrapf(err, "failed to create layer %q", id)
+}
+
+// Remove attempts to remove the snapshot and the contents corresponding to the layer.
+func (d *Driver) Remove(id string) error {
+	d.locker.Lock(id)
+	defer d.locker.Unlock(id)
+
+	sID, ok := d.snapshotID[id]
+	if !ok {
+		return fmt.Errorf("snapshot doesn't registered for given id %q", id)
+	}
+	// The referencing content will be garbage collected by containerd
+	if err := d.snapshotter.Remove(namedCtx(), sID); err != nil {
+		return errors.Wrapf(err, "failed to remove snapshot %q(key=%q)", id, sID)
+	}
+
+	delete(d.snapshotID, id)
+	delete(d.contentID, id)
+	return nil
+}
+
+// Get returns the mountpoint for the snapshot referred to by this id.
+func (d *Driver) Get(id, mountLabel string) (_ containerfs.ContainerFS, retErr error) {
+	d.locker.Lock(id)
+	defer d.locker.Unlock(id)
+
+	sID, ok := d.snapshotID[id]
+	if !ok {
+		return nil, fmt.Errorf("snapshot isn't registered for given id %q", id)
+	}
+
+	ctx, done, err := d.withLease(namedCtx()) // TODO: timeout?
+	if err != nil {
+		return nil, err
+	}
+	defer done(ctx)
+
+	dir := d.dir(id)
+	rootUID, rootGID, err := idtools.GetRootUIDGID(d.uidMaps, d.gidMaps)
+	if err != nil {
+		return nil, err
+	}
+	if err := idtools.MkdirAndChown(dir, 0700, idtools.Identity{UID: rootUID, GID: rootGID}); err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if retErr != nil {
+			if rmErr := unix.Rmdir(dir); rmErr != nil && !os.IsNotExist(rmErr) {
+				logger.Debugf("Failed to remove %s: %v: %v", id, rmErr, err)
+			}
+		}
+	}()
+
+	info, err := d.snapshotter.Stat(ctx, sID)
+	if err != nil {
+		retErr = err
+		return
+	}
+	var m []mount.Mount
+	if info.Kind == snapshots.KindActive {
+		if m, retErr = d.snapshotter.Mounts(ctx, sID); retErr != nil {
+			return
+		}
+	} else {
+		if info.Labels == nil {
+			info.Labels = make(map[string]string)
+		}
+		labelGCRefSnapshot := fmt.Sprintf("containerd.io/gc.ref.snapshot.%s", d.snapshotterName)
+
+		// readonly view
+		for i := 0; i < 3; i++ {
+			var vKey string
+			vKey, retErr = uniqueKey()
+			if retErr != nil {
+				continue
+			}
+			// reference the view for the original snapshot so that the view won't
+			// be removed by GC.
+			info.Labels[labelGCRefSnapshot] = vKey
+			if _, retErr = d.snapshotter.Update(ctx, info, "labels."+labelGCRefSnapshot); retErr != nil {
+				retErr = errors.Wrap(err, "failed to configure GC")
+				return
+			}
+			if _, retErr = d.snapshotter.View(ctx, vKey, sID); retErr == nil || !errdefs.IsAlreadyExists(retErr) {
+				break
+			}
+			// Key conflicts. try with other key
+		}
+		if retErr != nil {
+			return
+		}
+	}
+	if err := mount.All(m, dir); err != nil {
+		retErr = err
+		return
+	}
+	return containerfs.NewLocalContainerFS(dir), nil
+}
+
+// Put unmounts the mount path created for the give id.
+func (d *Driver) Put(id string) error {
+	d.locker.Lock(id)
+	defer d.locker.Unlock(id)
+
+	dir := d.dir(id)
+	if err := mount.Unmount(dir, 0); err != nil {
+		return errors.Wrapf(err, "failed to unmount layer %q on %q", id, dir)
+
+	}
+	if err := unix.Rmdir(dir); err != nil && !os.IsNotExist(err) {
+		logger.Debugf("Failed to remove %s: %v", id, err)
+	}
+	return nil
+}
+
+// Exists returns whether a layer with the specified ID exists on this driver.
+func (d *Driver) Exists(id string) bool {
+	d.locker.Lock(id)
+	defer d.locker.Unlock(id)
+
+	sID, ok := d.snapshotID[id]
+	if !ok {
+		return false
+	}
+	_, err := d.snapshotter.Stat(namedCtx(), sID)
+	return err == nil
+}
+
+// ApplyDiff applies the new layer into a root
+func (d *Driver) ApplyDiff(id string, parent string, diff io.Reader) (int64, error) {
+	// TODO: Reduce the restriction; but currently most use-cases in moby seem to be covered?
+	if !d.isParent(id, parent) {
+		return 0, fmt.Errorf("layer %q isn't registered against %q", id, parent)
+	}
+
+	d.locker.Lock(id)
+	if _, ok := d.contentID[id]; ok {
+		d.locker.Unlock(id)
+		return 0, fmt.Errorf("applying diff to %q on %q twice isn't supported", id, parent)
+	}
+	d.locker.Unlock(id)
+
+	ctx, done, err := d.withLease(namedCtx()) // TODO: timeout?
+	if err != nil {
+		return 0, err
+	}
+	defer done(ctx)
+
+	// Open the content writer and provide the diff stream to the
+	// content store as well as applying the diff to the targetting snapshot
+	cw, err := content.OpenWriter(ctx, d.store, content.WithRef(id))
+	if err != nil {
+		return 0, err
+	}
+	defer cw.Close()
+	digester := digest.Canonical.Digester()
+	dr := io.TeeReader(diff, io.MultiWriter(cw, digester.Hash()))
+	applySize, err := d.naiveDiff.ApplyDiff(id, parent, dr)
+	if err != nil {
+		return 0, err
+	}
+	io.Copy(ioutil.Discard, dr) // makes sure all contents to be read
+
+	// Configure the prepared snapshot
+	d.locker.Lock(id)
+	defer d.locker.Unlock(id)
+	sID, ok := d.snapshotID[id]
+	if !ok {
+		if aErr := d.store.Abort(ctx, id); aErr != nil {
+			logger.Debugf("Failed to abort %s: %v", id, aErr)
+		}
+		return 0, fmt.Errorf("snapshot %q isn't registered for %q", id, parent)
+	}
+	diffID := digester.Digest()
+	info, err := d.snapshotter.Stat(ctx, sID)
+	if err != nil {
+		return 0, err
+	}
+	if info.Labels == nil {
+		info.Labels = make(map[string]string)
+	}
+	info.Labels[labelGCRefContent] = diffID.String()
+	if _, err := d.snapshotter.Update(ctx, info, "labels."+labelGCRefContent); err != nil {
+		if aErr := d.store.Abort(ctx, id); aErr != nil {
+			logger.Debugf("Failed to abort %s: %v", id, aErr)
+		}
+		return 0, errors.Wrap(err, "failed to configure GC")
+	}
+
+	// Finally, commit the provided diff contents
+	if err := cw.Commit(ctx, 0, diffID); err != nil && !errdefs.IsAlreadyExists(err) {
+		if aErr := d.store.Abort(ctx, id); aErr != nil {
+			logger.Debugf("Failed to abort %s: %v", id, aErr)
+		}
+		return 0, err
+	}
+	d.contentID[id] = diffID.String()
+
+	return applySize, nil
+}
+
+// DiffSize calculates the changes between the specified id
+// and its parent and returns the size in bytes of the changes
+// relative to its base filesystem directory.
+func (d *Driver) DiffSize(id, parent string) (size int64, err error) {
+	// TODO: Reduce the restriction; but currently most use-cases in moby seem to be covered?
+	if !d.isParent(id, parent) {
+		return 0, fmt.Errorf("layer diff %q isn't registered against %q", id, parent)
+	}
+
+	d.locker.Lock(id)
+	defer d.locker.Unlock(id)
+
+	// get the size in the snapshotter
+	key, ok := d.snapshotID[id]
+	if !ok {
+		return 0, fmt.Errorf("layer isn't registered for given id %q", id)
+	}
+	ctx := namedCtx() // TODO: timeout?
+	usage, err := d.snapshotter.Usage(ctx, key)
+	if err != nil {
+		return 0, err
+	}
+	size += usage.Size
+
+	// get the size in the content store (if exists the contents)
+	if status, err := d.store.Status(ctx, id); err == nil {
+		size += status.Total // This is in progress so can be changed
+	}
+	diffID, ok := d.contentID[id]
+	if ok {
+		dgst, err := digest.Parse(diffID)
+		if err != nil {
+			return 0, errors.Wrapf(err, "failed to parse diffID %q of layer %q", diffID, id)
+		}
+		if info, err := d.store.Info(ctx, dgst); err == nil {
+			size += info.Size
+		}
+	}
+
+	return size, nil
+}
+
+// Diff produces an archive of the changes between the specified
+// layer and its parent layer which may be "".
+func (d *Driver) Diff(id, parent string) (io.ReadCloser, error) {
+	// TODO: Reduce the restriction; but currently most use-cases in moby seem to be covered?
+	if !d.isParent(id, parent) {
+		return nil, fmt.Errorf("layer diff %q isn't registered against %q", id, parent)
+	}
+
+	d.locker.Lock(id)
+	if _, ok := d.snapshotID[id]; !ok {
+		d.locker.Unlock(id)
+		return nil, fmt.Errorf("layer %q isn't registered", id)
+	}
+	cID, ok := d.contentID[id]
+	if !ok {
+		d.locker.Unlock(id)
+		// The content isn't registered by DiffApply. We cannot provide any content.
+		// TODO: write it also to the content store.
+		return d.naiveDiff.Diff(id, parent)
+	}
+	d.locker.Unlock(id)
+
+	diffID, err := digest.Parse(cID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse diffID %q for layer %q", cID, id)
+	}
+	ctx := namedCtx() // TODO: timeout?
+	info, err := d.store.Info(ctx, diffID)
+	if err != nil {
+		// Wait for writing completion
+		doneCh := make(chan content.Info)
+		errCh := make(chan error)
+		go func() {
+			for {
+				var err error
+
+				// Check if the content is written in progress
+				// TODO: Check the Expected digest here but currently containerd
+				//       doesn't support getting `Expected` field by `Status`.
+				if _, err = d.store.Status(ctx, id); err == nil /* && st.Expected == diffID */ {
+					// writing (diffing) in progress
+					time.Sleep(time.Second)
+					continue
+				}
+
+				// Check if the content exists as a committed content
+				if info, err = d.store.Info(ctx, diffID); err == nil {
+					doneCh <- info
+					return
+				}
+
+				// failed to find content
+				errCh <- fmt.Errorf("data lost; layer %q: %v", id, err)
+				return
+			}
+		}()
+		select {
+		case <-time.After(30 * time.Minute):
+			return nil, fmt.Errorf("timed out for writing diff content of %q", id)
+		case err := <-errCh:
+			return nil, errors.Wrapf(err, "failed to get diff of %q", id)
+		case info = <-doneCh:
+		}
+	}
+	r, err := d.store.ReaderAt(ctx, ocispec.Descriptor{
+		Digest: diffID,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get diff reader of %q", id)
+	}
+	return ioutil.NopCloser(io.NewSectionReader(r, 0, info.Size)), nil
+}
+
+// Changes produces a list of changes between the specified layer and its
+// parent layer.
+func (d *Driver) Changes(id, parent string) ([]archive.Change, error) {
+	return d.naiveDiff.Changes(id, parent)
+}
+
+func (d *Driver) isParent(id, parent string) bool {
+	d.locker.Lock(id)
+	defer d.locker.Unlock(id)
+
+	key, ok := d.snapshotID[id]
+	if !ok {
+		return false
+	}
+
+	pKey := ""
+	if parent != "" {
+		var ok bool
+		pKey, ok = d.snapshotID[parent]
+		if !ok {
+			return false
+		}
+	}
+	info, err := d.snapshotter.Stat(namedCtx(), key)
+	if err != nil {
+		return false
+	}
+	if info.Parent != pKey {
+		return false
+	}
+	return true
+}
+
+func (d *Driver) dir(id string) string {
+	return path.Join(d.home, id)
+}
+
+type withLeaseFunc func(ctx context.Context) (context.Context, func(context.Context) error, error)
+
+func withLeaseFuncFromContainerd(ctd *containerd.Client) func(ctx context.Context) (context.Context, func(context.Context) error, error) {
+	lm := ctd.LeasesService()
+	return func(ctx context.Context) (context.Context, func(context.Context) error, error) {
+		if _, ok := leases.FromContext(ctx); ok {
+			return ctx, func(context.Context) error {
+				return nil
+			}, nil
+		}
+
+		l, err := lm.Create(ctx, leases.WithRandomID(), leases.WithExpiration(24*time.Hour))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		ctx = leases.WithLease(ctx, l.ID)
+		return ctx, func(ctx context.Context) error {
+			return lm.Delete(ctx, l)
+		}, nil
+	}
+}
+
+func namedCtx() context.Context {
+	return namespaces.WithNamespace(context.Background(), namespace)
+}
+
+func uniqueKey() (string, error) {
+	for i := 0; i < 5; i++ {
+		key := stringid.GenerateRandomID()
+		if _, err := digest.Parse(key); err == nil {
+			// Key mustn't conflict with digests.
+			// containerd's remote snapshotters uses digests as keys internally
+			continue
+		}
+		return key, nil
+	}
+	return "", fmt.Errorf("failed to generate unique key that doesn't match digest")
+}
+
+func parseName(options []string) (string, error) {
+	var names []string
+	for _, option := range options {
+		key, val, err := parsers.ParseKeyValueOpt(option)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to parse option")
+		}
+		key = strings.ToLower(key)
+		switch key {
+		case "snapshotter.name":
+			names = append(names, val)
+		default:
+			return "", fmt.Errorf("snapshotter: unknown option %s", key)
+		}
+	}
+	if len(names) == 1 && names[0] != "" {
+		return names[0], nil
+	}
+	return "", fmt.Errorf("Exactly one snapshotter name must be specified but got: %v", names)
+}

--- a/daemon/graphdriver/containerd/containerd_test.go
+++ b/daemon/graphdriver/containerd/containerd_test.go
@@ -1,0 +1,129 @@
+// +build linux
+
+package containerd // import "github.com/docker/docker/daemon/graphdriver/containerd"
+
+import (
+	"io/ioutil"
+	"os"
+	"sync"
+	"testing"
+
+	content "github.com/containerd/containerd/content/local"
+	"github.com/containerd/containerd/snapshots/overlay"
+	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/daemon/graphdriver/graphtest"
+	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/reexec"
+)
+
+func init() {
+	graphdriver.ApplyUncompressedLayer = archive.ApplyUncompressedLayer
+
+	reexec.Init()
+}
+
+var (
+	cleanup   func()
+	cleanupMu sync.Mutex
+)
+
+func addCleanup(f func()) {
+	cleanupMu.Lock()
+	defer cleanupMu.Unlock()
+	oldCleanup := cleanup
+	cleanup = func() {
+		if oldCleanup != nil {
+			defer oldCleanup()
+		}
+		f()
+	}
+}
+
+// This avoids creating a new driver for each test if all tests are run
+// Make sure to put new tests between TestSnapshotterSetup and TestSnapshotterTeardown
+func TestSnapshotterSetup(t *testing.T) {
+	// Prepare snapshotter
+	snRoot, err := ioutil.TempDir("", "temp-snapshotter")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addCleanup(func() { os.RemoveAll(snRoot) })
+	builtinSnapshotterName = "overlayfs"
+	builtinSnapshotter, err = overlay.NewSnapshotter(snRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Prepare content store
+	csRoot, err := ioutil.TempDir("", "temp-content")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addCleanup(func() { os.RemoveAll(csRoot) })
+	builtinStore, err = content.NewStore(csRoot)
+
+	graphtest.GetDriver(t, driverName)
+}
+
+func TestSnapshotterCreateEmpty(t *testing.T) {
+	graphtest.DriverTestCreateEmpty(t, driverName)
+}
+
+func TestSnapshotterCreateBase(t *testing.T) {
+	graphtest.DriverTestCreateBase(t, driverName)
+}
+
+func TestSnapshotterCreateSnap(t *testing.T) {
+	graphtest.DriverTestCreateSnap(t, driverName)
+}
+
+func TestSnapshotter128LayerRead(t *testing.T) {
+	graphtest.DriverTestDeepLayerRead(t, 128, driverName)
+}
+
+func TestSnapshotterTeardown(t *testing.T) {
+	graphtest.PutDriver(t)
+	cleanupMu.Lock()
+	defer cleanupMu.Unlock()
+	if cleanup != nil {
+		cleanup()
+	}
+}
+
+// Benchmarks should always setup new driver
+
+func BenchmarkExists(b *testing.B) {
+	graphtest.DriverBenchExists(b, driverName)
+}
+
+func BenchmarkGetEmpty(b *testing.B) {
+	graphtest.DriverBenchGetEmpty(b, driverName)
+}
+
+func BenchmarkDiffBase(b *testing.B) {
+	graphtest.DriverBenchDiffBase(b, driverName)
+}
+
+func BenchmarkDiffSmallUpper(b *testing.B) {
+	graphtest.DriverBenchDiffN(b, 10, 10, driverName)
+}
+
+func BenchmarkDiff10KFileUpper(b *testing.B) {
+	graphtest.DriverBenchDiffN(b, 10, 10000, driverName)
+}
+
+func BenchmarkDiff10KFilesBottom(b *testing.B) {
+	graphtest.DriverBenchDiffN(b, 10000, 10, driverName)
+}
+
+func BenchmarkDiffApply100(b *testing.B) {
+	graphtest.DriverBenchDiffApplyN(b, 100, driverName)
+}
+
+func BenchmarkDiff20Layers(b *testing.B) {
+	graphtest.DriverBenchDeepLayerDiff(b, 20, driverName)
+}
+
+func BenchmarkRead20Layers(b *testing.B) {
+	graphtest.DriverBenchDeepLayerRead(b, 20, driverName)
+}

--- a/daemon/graphdriver/devmapper/devmapper_test.go
+++ b/daemon/graphdriver/devmapper/devmapper_test.go
@@ -114,7 +114,7 @@ func testChangeLoopBackSize(t *testing.T, delta, expectDataSize, expectMetaDataS
 	d, err := Init(driver.home, []string{
 		fmt.Sprintf("dm.loopdatasize=%d", defaultDataLoopbackSize+delta),
 		fmt.Sprintf("dm.loopmetadatasize=%d", defaultMetaDataLoopbackSize+delta),
-	}, nil, nil)
+	}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("error creating devicemapper driver: %v", err)
 	}

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -35,7 +35,7 @@ type Driver struct {
 }
 
 // Init creates a driver with the given home and the set of options.
-func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap, _ *graphdriver.InitOptions) (graphdriver.Driver, error) {
 	deviceSet, err := NewDeviceSet(home, true, options, uidMaps, gidMaps)
 	if err != nil {
 		return nil, err

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containerd/containerd"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
 	"github.com/vbatts/tar-split/tar/storage"
 
@@ -34,10 +36,23 @@ var (
 type CreateOpts struct {
 	MountLabel string
 	StorageOpt map[string]string
+	TargetInfo *TargetOpts
+}
+
+type TargetOpts struct {
+	MountChainID  digest.Digest
+	ContentDiffID digest.Digest
+	ImageRef      string
+	LayerDigest   digest.Digest
+	ImageLayers   []digest.Digest
 }
 
 // InitFunc initializes the storage driver.
-type InitFunc func(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (Driver, error)
+type InitFunc func(root string, options []string, uidMaps, gidMaps []idtools.IDMap, opt *InitOptions) (Driver, error)
+
+type InitOptions struct {
+	ContainerdClient *containerd.Client
+}
 
 // ProtoDriver defines the basic capabilities of a driver.
 // This interface exists solely to be a minimum set of methods
@@ -162,7 +177,7 @@ func Register(name string, initFunc InitFunc) error {
 // GetDriver initializes and returns the registered driver
 func GetDriver(name string, pg plugingetter.PluginGetter, config Options) (Driver, error) {
 	if initFunc, exists := drivers[name]; exists {
-		return initFunc(filepath.Join(config.Root, name), config.DriverOptions, config.UIDMaps, config.GIDMaps)
+		return initFunc(filepath.Join(config.Root, name), config.DriverOptions, config.UIDMaps, config.GIDMaps, config.InitOptions)
 	}
 
 	pluginDriver, err := lookupPlugin(name, pg, config)
@@ -174,9 +189,9 @@ func GetDriver(name string, pg plugingetter.PluginGetter, config Options) (Drive
 }
 
 // getBuiltinDriver initializes and returns the registered driver, but does not try to load from plugins
-func getBuiltinDriver(name, home string, options []string, uidMaps, gidMaps []idtools.IDMap) (Driver, error) {
+func getBuiltinDriver(name, home string, options []string, uidMaps, gidMaps []idtools.IDMap, initOpts *InitOptions) (Driver, error) {
 	if initFunc, exists := drivers[name]; exists {
-		return initFunc(filepath.Join(home, name), options, uidMaps, gidMaps)
+		return initFunc(filepath.Join(home, name), options, uidMaps, gidMaps, initOpts)
 	}
 	logrus.Errorf("Failed to built-in GetDriver graph %s %s", name, home)
 	return nil, ErrNotSupported
@@ -189,6 +204,7 @@ type Options struct {
 	UIDMaps             []idtools.IDMap
 	GIDMaps             []idtools.IDMap
 	ExperimentalEnabled bool
+	InitOptions         *InitOptions
 }
 
 // New creates the driver and initializes it at the specified root.
@@ -211,7 +227,7 @@ func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, err
 		if _, prior := driversMap[name]; prior {
 			// of the state found from prior drivers, check in order of our priority
 			// which we would prefer
-			driver, err := getBuiltinDriver(name, config.Root, config.DriverOptions, config.UIDMaps, config.GIDMaps)
+			driver, err := getBuiltinDriver(name, config.Root, config.DriverOptions, config.UIDMaps, config.GIDMaps, config.InitOptions)
 			if err != nil {
 				// unlike below, we will return error here, because there is prior
 				// state, and now it is no longer supported/prereq/compatible, so
@@ -240,7 +256,7 @@ func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, err
 
 	// Check for priority drivers first
 	for _, name := range list {
-		driver, err := getBuiltinDriver(name, config.Root, config.DriverOptions, config.UIDMaps, config.GIDMaps)
+		driver, err := getBuiltinDriver(name, config.Root, config.DriverOptions, config.UIDMaps, config.GIDMaps, config.InitOptions)
 		if err != nil {
 			if IsDriverNotSupported(err) {
 				continue
@@ -258,7 +274,7 @@ func New(name string, pg plugingetter.PluginGetter, config Options) (Driver, err
 			// can be selected through configuration.
 			continue
 		}
-		driver, err := initFunc(filepath.Join(config.Root, name), config.DriverOptions, config.UIDMaps, config.GIDMaps)
+		driver, err := initFunc(filepath.Join(config.Root, name), config.DriverOptions, config.UIDMaps, config.GIDMaps, config.InitOptions)
 		if err != nil {
 			if IsDriverNotSupported(err) {
 				continue

--- a/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
+++ b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
@@ -81,7 +81,7 @@ func init() {
 // graphdriver.ErrNotSupported is returned.
 // If an overlay filesystem is not supported over an existing filesystem then
 // the error graphdriver.ErrIncompatibleFS is returned.
-func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap, _ *graphdriver.InitOptions) (graphdriver.Driver, error) {
 	if _, err := exec.LookPath(binary); err != nil {
 		logger.Error(err)
 		return nil, graphdriver.ErrNotSupported

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -116,7 +116,7 @@ func init() {
 // graphdriver.ErrNotSupported is returned.
 // If an overlay filesystem is not supported over an existing filesystem then
 // error graphdriver.ErrIncompatibleFS is returned.
-func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap, _ *graphdriver.InitOptions) (graphdriver.Driver, error) {
 	_, err := parseOptions(options)
 	if err != nil {
 		return nil, err

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -125,7 +125,7 @@ func init() {
 // graphdriver.ErrNotSupported is returned.
 // If an overlay filesystem is not supported over an existing filesystem then
 // the error graphdriver.ErrIncompatibleFS is returned.
-func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap, _ *graphdriver.InitOptions) (graphdriver.Driver, error) {
 	opts, err := parseOptions(options)
 	if err != nil {
 		return nil, err

--- a/daemon/graphdriver/register/register_containerd.go
+++ b/daemon/graphdriver/register/register_containerd.go
@@ -1,0 +1,8 @@
+// +build !exclude_graphdriver_containerd,linux
+
+package register // import "github.com/docker/docker/daemon/graphdriver/register"
+
+import (
+	// register the containerd-based graphdriver
+	_ "github.com/docker/docker/daemon/graphdriver/containerd"
+)

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -28,7 +28,7 @@ func init() {
 
 // Init returns a new VFS driver.
 // This sets the home directory for the driver and returns NaiveDiffDriver.
-func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap, _ *graphdriver.InitOptions) (graphdriver.Driver, error) {
 	d := &Driver{
 		home:      home,
 		idMapping: idtools.NewIDMappingsFromMaps(uidMaps, gidMaps),

--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -45,7 +45,7 @@ func (*Logger) Log(cmd []string) {
 // Init returns a new ZFS driver.
 // It takes base mount path and an array of options which are represented as key value pairs.
 // Each option is in the for key=value. 'zfs.fsname' is expected to be a valid key in the options.
-func Init(base string, opt []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+func Init(base string, opt []string, uidMaps, gidMaps []idtools.IDMap, _ *graphdriver.InitOptions) (graphdriver.Driver, error) {
 	var err error
 
 	logger := logrus.WithField("storage-driver", "zfs")

--- a/integration/plugin/graphdriver/external_test.go
+++ b/integration/plugin/graphdriver/external_test.go
@@ -147,7 +147,7 @@ func setupPlugin(t *testing.T, ec map[string]*graphEventsCounter, ext string, mu
 
 	base, err := ioutil.TempDir("", name)
 	assert.NilError(t, err)
-	vfsProto, err := vfs.Init(base, []string{}, nil, nil)
+	vfsProto, err := vfs.Init(base, []string{}, nil, nil, nil)
 	assert.NilError(t, err, "error initializing graph driver")
 	driver := graphdriver.NewNaiveDiffDriver(vfsProto, nil, nil)
 

--- a/layer/layer.go
+++ b/layer/layer.go
@@ -14,6 +14,7 @@ import (
 	"io"
 
 	"github.com/docker/distribution"
+	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/containerfs"
 	digest "github.com/opencontainers/go-digest"
@@ -55,6 +56,10 @@ var (
 	// ErrNotSupported is used when the action is not supported
 	// on the current host operating system.
 	ErrNotSupported = errors.New("not support on this host operating system")
+
+	// ErrAlreadyExists is used when the targetting layer is already
+	// exists.
+	ErrAlreadyExists = errors.New("layer already exists")
 )
 
 // ChainID is the content-addressable ID of a layer.
@@ -202,6 +207,10 @@ type Store interface {
 // descriptors for layers.
 type DescribableStore interface {
 	RegisterWithDescriptor(io.Reader, ChainID, distribution.Descriptor) (Layer, error)
+}
+
+type CheckableLayerStore interface {
+	CheckIfLayerExists(target *graphdriver.TargetOpts, parent ChainID) (Layer, error)
 }
 
 // CreateChainID returns ID for a layerDigest slice

--- a/vendor/github.com/containerd/containerd/snapshots/overlay/check.go
+++ b/vendor/github.com/containerd/containerd/snapshots/overlay/check.go
@@ -1,0 +1,88 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package overlay
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/continuity/fs"
+	"github.com/pkg/errors"
+)
+
+// supportsMultipleLowerDir checks if the system supports multiple lowerdirs,
+// which is required for the overlay snapshotter. On 4.x kernels, multiple lowerdirs
+// are always available (so this check isn't needed), and backported to RHEL and
+// CentOS 3.x kernels (3.10.0-693.el7.x86_64 and up). This function is to detect
+// support on those kernels, without doing a kernel version compare.
+//
+// Ported from moby overlay2.
+func supportsMultipleLowerDir(d string) error {
+	td, err := ioutil.TempDir(d, "multiple-lowerdir-check")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := os.RemoveAll(td); err != nil {
+			log.L.WithError(err).Warnf("Failed to remove check directory %v", td)
+		}
+	}()
+
+	for _, dir := range []string{"lower1", "lower2", "upper", "work", "merged"} {
+		if err := os.Mkdir(filepath.Join(td, dir), 0755); err != nil {
+			return err
+		}
+	}
+
+	opts := fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", filepath.Join(td, "lower2"), filepath.Join(td, "lower1"), filepath.Join(td, "upper"), filepath.Join(td, "work"))
+	m := mount.Mount{
+		Type:    "overlay",
+		Source:  "overlay",
+		Options: []string{opts},
+	}
+	dest := filepath.Join(td, "merged")
+	if err := m.Mount(dest); err != nil {
+		return errors.Wrap(err, "failed to mount overlay")
+	}
+	if err := mount.UnmountAll(dest, 0); err != nil {
+		log.L.WithError(err).Warnf("Failed to unmount check directory %v", dest)
+	}
+	return nil
+}
+
+// Supported returns nil when the overlayfs is functional on the system with the root directory.
+// Supported is not called during plugin initialization, but exposed for downstream projects which uses
+// this snapshotter as a library.
+func Supported(root string) error {
+	if err := os.MkdirAll(root, 0700); err != nil {
+		return err
+	}
+	supportsDType, err := fs.SupportsDType(root)
+	if err != nil {
+		return err
+	}
+	if !supportsDType {
+		return fmt.Errorf("%s does not support d_type. If the backing filesystem is xfs, please reformat with ftype=1 to enable d_type support", root)
+	}
+	return supportsMultipleLowerDir(root)
+}

--- a/vendor/github.com/containerd/containerd/snapshots/overlay/overlay.go
+++ b/vendor/github.com/containerd/containerd/snapshots/overlay/overlay.go
@@ -1,0 +1,513 @@
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package overlay
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/containerd/snapshots/storage"
+	"github.com/containerd/continuity/fs"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	plugin.Register(&plugin.Registration{
+		Type: plugin.SnapshotPlugin,
+		ID:   "overlayfs",
+		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
+			ic.Meta.Platforms = append(ic.Meta.Platforms, platforms.DefaultSpec())
+			ic.Meta.Exports["root"] = ic.Root
+			return NewSnapshotter(ic.Root, AsynchronousRemove)
+		},
+	})
+}
+
+// SnapshotterConfig is used to configure the overlay snapshotter instance
+type SnapshotterConfig struct {
+	asyncRemove bool
+}
+
+// Opt is an option to configure the overlay snapshotter
+type Opt func(config *SnapshotterConfig) error
+
+// AsynchronousRemove defers removal of filesystem content until
+// the Cleanup method is called. Removals will make the snapshot
+// referred to by the key unavailable and make the key immediately
+// available for re-use.
+func AsynchronousRemove(config *SnapshotterConfig) error {
+	config.asyncRemove = true
+	return nil
+}
+
+type snapshotter struct {
+	root        string
+	ms          *storage.MetaStore
+	asyncRemove bool
+}
+
+// NewSnapshotter returns a Snapshotter which uses overlayfs. The overlayfs
+// diffs are stored under the provided root. A metadata file is stored under
+// the root.
+func NewSnapshotter(root string, opts ...Opt) (snapshots.Snapshotter, error) {
+	var config SnapshotterConfig
+	for _, opt := range opts {
+		if err := opt(&config); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := os.MkdirAll(root, 0700); err != nil {
+		return nil, err
+	}
+	supportsDType, err := fs.SupportsDType(root)
+	if err != nil {
+		return nil, err
+	}
+	if !supportsDType {
+		return nil, fmt.Errorf("%s does not support d_type. If the backing filesystem is xfs, please reformat with ftype=1 to enable d_type support", root)
+	}
+	ms, err := storage.NewMetaStore(filepath.Join(root, "metadata.db"))
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.Mkdir(filepath.Join(root, "snapshots"), 0700); err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+
+	return &snapshotter{
+		root:        root,
+		ms:          ms,
+		asyncRemove: config.asyncRemove,
+	}, nil
+}
+
+// Stat returns the info for an active or committed snapshot by name or
+// key.
+//
+// Should be used for parent resolution, existence checks and to discern
+// the kind of snapshot.
+func (o *snapshotter) Stat(ctx context.Context, key string) (snapshots.Info, error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+	defer t.Rollback()
+	_, info, _, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+
+	return info, nil
+}
+
+func (o *snapshotter) Update(ctx context.Context, info snapshots.Info, fieldpaths ...string) (snapshots.Info, error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+
+	info, err = storage.UpdateInfo(ctx, info, fieldpaths...)
+	if err != nil {
+		t.Rollback()
+		return snapshots.Info{}, err
+	}
+
+	if err := t.Commit(); err != nil {
+		return snapshots.Info{}, err
+	}
+
+	return info, nil
+}
+
+// Usage returns the resources taken by the snapshot identified by key.
+//
+// For active snapshots, this will scan the usage of the overlay "diff" (aka
+// "upper") directory and may take some time.
+//
+// For committed snapshots, the value is returned from the metadata database.
+func (o *snapshotter) Usage(ctx context.Context, key string) (snapshots.Usage, error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return snapshots.Usage{}, err
+	}
+	id, info, usage, err := storage.GetInfo(ctx, key)
+	t.Rollback() // transaction no longer needed at this point.
+
+	if err != nil {
+		return snapshots.Usage{}, err
+	}
+
+	if info.Kind == snapshots.KindActive {
+		upperPath := o.upperPath(id)
+		du, err := fs.DiskUsage(ctx, upperPath)
+		if err != nil {
+			// TODO(stevvooe): Consider not reporting an error in this case.
+			return snapshots.Usage{}, err
+		}
+
+		usage = snapshots.Usage(du)
+	}
+
+	return usage, nil
+}
+
+func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	return o.createSnapshot(ctx, snapshots.KindActive, key, parent, opts)
+}
+
+func (o *snapshotter) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
+	return o.createSnapshot(ctx, snapshots.KindView, key, parent, opts)
+}
+
+// Mounts returns the mounts for the transaction identified by key. Can be
+// called on an read-write or readonly transaction.
+//
+// This can be used to recover mounts after calling View or Prepare.
+func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	s, err := storage.GetSnapshot(ctx, key)
+	t.Rollback()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get active mount")
+	}
+	return o.mounts(s), nil
+}
+
+func (o *snapshotter) Commit(ctx context.Context, name, key string, opts ...snapshots.Opt) error {
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err != nil {
+			if rerr := t.Rollback(); rerr != nil {
+				log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+			}
+		}
+	}()
+
+	// grab the existing id
+	id, _, _, err := storage.GetInfo(ctx, key)
+	if err != nil {
+		return err
+	}
+
+	usage, err := fs.DiskUsage(ctx, o.upperPath(id))
+	if err != nil {
+		return err
+	}
+
+	if _, err = storage.CommitActive(ctx, key, name, snapshots.Usage(usage), opts...); err != nil {
+		return errors.Wrap(err, "failed to commit snapshot")
+	}
+	return t.Commit()
+}
+
+// Remove abandons the snapshot identified by key. The snapshot will
+// immediately become unavailable and unrecoverable. Disk space will
+// be freed up on the next call to `Cleanup`.
+func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			if rerr := t.Rollback(); rerr != nil {
+				log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+			}
+		}
+	}()
+
+	_, _, err = storage.Remove(ctx, key)
+	if err != nil {
+		return errors.Wrap(err, "failed to remove")
+	}
+
+	if !o.asyncRemove {
+		var removals []string
+		removals, err = o.getCleanupDirectories(ctx, t)
+		if err != nil {
+			return errors.Wrap(err, "unable to get directories for removal")
+		}
+
+		// Remove directories after the transaction is closed, failures must not
+		// return error since the transaction is committed with the removal
+		// key no longer available.
+		defer func() {
+			if err == nil {
+				for _, dir := range removals {
+					if err := os.RemoveAll(dir); err != nil {
+						log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to remove directory")
+					}
+				}
+			}
+		}()
+
+	}
+
+	return t.Commit()
+}
+
+// Walk the snapshots.
+func (o *snapshotter) Walk(ctx context.Context, fn snapshots.WalkFunc, fs ...string) error {
+	ctx, t, err := o.ms.TransactionContext(ctx, false)
+	if err != nil {
+		return err
+	}
+	defer t.Rollback()
+	return storage.WalkInfo(ctx, fn, fs...)
+}
+
+// Cleanup cleans up disk resources from removed or abandoned snapshots
+func (o *snapshotter) Cleanup(ctx context.Context) error {
+	cleanup, err := o.cleanupDirectories(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, dir := range cleanup {
+		if err := os.RemoveAll(dir); err != nil {
+			log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to remove directory")
+		}
+	}
+
+	return nil
+}
+
+func (o *snapshotter) cleanupDirectories(ctx context.Context) ([]string, error) {
+	// Get a write transaction to ensure no other write transaction can be entered
+	// while the cleanup is scanning.
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	defer t.Rollback()
+	return o.getCleanupDirectories(ctx, t)
+}
+
+func (o *snapshotter) getCleanupDirectories(ctx context.Context, t storage.Transactor) ([]string, error) {
+	ids, err := storage.IDMap(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshotDir := filepath.Join(o.root, "snapshots")
+	fd, err := os.Open(snapshotDir)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+
+	dirs, err := fd.Readdirnames(0)
+	if err != nil {
+		return nil, err
+	}
+
+	cleanup := []string{}
+	for _, d := range dirs {
+		if _, ok := ids[d]; ok {
+			continue
+		}
+
+		cleanup = append(cleanup, filepath.Join(snapshotDir, d))
+	}
+
+	return cleanup, nil
+}
+
+func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, key, parent string, opts []snapshots.Opt) (_ []mount.Mount, err error) {
+	ctx, t, err := o.ms.TransactionContext(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	var td, path string
+	defer func() {
+		if err != nil {
+			if td != "" {
+				if err1 := os.RemoveAll(td); err1 != nil {
+					log.G(ctx).WithError(err1).Warn("failed to cleanup temp snapshot directory")
+				}
+			}
+			if path != "" {
+				if err1 := os.RemoveAll(path); err1 != nil {
+					log.G(ctx).WithError(err1).WithField("path", path).Error("failed to reclaim snapshot directory, directory may need removal")
+					err = errors.Wrapf(err, "failed to remove path: %v", err1)
+				}
+			}
+		}
+	}()
+
+	snapshotDir := filepath.Join(o.root, "snapshots")
+	td, err = o.prepareDirectory(ctx, snapshotDir, kind)
+	if err != nil {
+		if rerr := t.Rollback(); rerr != nil {
+			log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+		}
+		return nil, errors.Wrap(err, "failed to create prepare snapshot dir")
+	}
+	rollback := true
+	defer func() {
+		if rollback {
+			if rerr := t.Rollback(); rerr != nil {
+				log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+			}
+		}
+	}()
+
+	s, err := storage.CreateSnapshot(ctx, kind, key, parent, opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create snapshot")
+	}
+
+	if len(s.ParentIDs) > 0 {
+		st, err := os.Stat(o.upperPath(s.ParentIDs[0]))
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to stat parent")
+		}
+
+		stat := st.Sys().(*syscall.Stat_t)
+
+		if err := os.Lchown(filepath.Join(td, "fs"), int(stat.Uid), int(stat.Gid)); err != nil {
+			if rerr := t.Rollback(); rerr != nil {
+				log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
+			}
+			return nil, errors.Wrap(err, "failed to chown")
+		}
+	}
+
+	path = filepath.Join(snapshotDir, s.ID)
+	if err = os.Rename(td, path); err != nil {
+		return nil, errors.Wrap(err, "failed to rename")
+	}
+	td = ""
+
+	rollback = false
+	if err = t.Commit(); err != nil {
+		return nil, errors.Wrap(err, "commit failed")
+	}
+
+	return o.mounts(s), nil
+}
+
+func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind) (string, error) {
+	td, err := ioutil.TempDir(snapshotDir, "new-")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create temp dir")
+	}
+
+	if err := os.Mkdir(filepath.Join(td, "fs"), 0755); err != nil {
+		return td, err
+	}
+
+	if kind == snapshots.KindActive {
+		if err := os.Mkdir(filepath.Join(td, "work"), 0711); err != nil {
+			return td, err
+		}
+	}
+
+	return td, nil
+}
+
+func (o *snapshotter) mounts(s storage.Snapshot) []mount.Mount {
+	if len(s.ParentIDs) == 0 {
+		// if we only have one layer/no parents then just return a bind mount as overlay
+		// will not work
+		roFlag := "rw"
+		if s.Kind == snapshots.KindView {
+			roFlag = "ro"
+		}
+
+		return []mount.Mount{
+			{
+				Source: o.upperPath(s.ID),
+				Type:   "bind",
+				Options: []string{
+					roFlag,
+					"rbind",
+				},
+			},
+		}
+	}
+	var options []string
+
+	if s.Kind == snapshots.KindActive {
+		options = append(options,
+			fmt.Sprintf("workdir=%s", o.workPath(s.ID)),
+			fmt.Sprintf("upperdir=%s", o.upperPath(s.ID)),
+		)
+	} else if len(s.ParentIDs) == 1 {
+		return []mount.Mount{
+			{
+				Source: o.upperPath(s.ParentIDs[0]),
+				Type:   "bind",
+				Options: []string{
+					"ro",
+					"rbind",
+				},
+			},
+		}
+	}
+
+	parentPaths := make([]string, len(s.ParentIDs))
+	for i := range s.ParentIDs {
+		parentPaths[i] = o.upperPath(s.ParentIDs[i])
+	}
+
+	options = append(options, fmt.Sprintf("lowerdir=%s", strings.Join(parentPaths, ":")))
+	return []mount.Mount{
+		{
+			Type:    "overlay",
+			Source:  "overlay",
+			Options: options,
+		},
+	}
+
+}
+
+func (o *snapshotter) upperPath(id string) string {
+	return filepath.Join(o.root, "snapshots", id, "fs")
+}
+
+func (o *snapshotter) workPath(id string) string {
+	return filepath.Join(o.root, "snapshots", id, "work")
+}
+
+// Close closes the snapshotter
+func (o *snapshotter) Close() error {
+	return o.ms.Close()
+}

--- a/vendor/github.com/containerd/containerd/snapshots/storage/bolt.go
+++ b/vendor/github.com/containerd/containerd/snapshots/storage/bolt.go
@@ -1,0 +1,648 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/filters"
+	"github.com/containerd/containerd/metadata/boltutil"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/pkg/errors"
+	bolt "go.etcd.io/bbolt"
+)
+
+var (
+	bucketKeyStorageVersion = []byte("v1")
+	bucketKeySnapshot       = []byte("snapshots")
+	bucketKeyParents        = []byte("parents")
+
+	bucketKeyID     = []byte("id")
+	bucketKeyParent = []byte("parent")
+	bucketKeyKind   = []byte("kind")
+	bucketKeyInodes = []byte("inodes")
+	bucketKeySize   = []byte("size")
+
+	// ErrNoTransaction is returned when an operation is attempted with
+	// a context which is not inside of a transaction.
+	ErrNoTransaction = errors.New("no transaction in context")
+)
+
+// parentKey returns a composite key of the parent and child identifiers. The
+// parts of the key are separated by a zero byte.
+func parentKey(parent, child uint64) []byte {
+	b := make([]byte, binary.Size([]uint64{parent, child})+1)
+	i := binary.PutUvarint(b, parent)
+	j := binary.PutUvarint(b[i+1:], child)
+	return b[0 : i+j+1]
+}
+
+// parentPrefixKey returns the parent part of the composite key with the
+// zero byte separator.
+func parentPrefixKey(parent uint64) []byte {
+	b := make([]byte, binary.Size(parent)+1)
+	i := binary.PutUvarint(b, parent)
+	return b[0 : i+1]
+}
+
+// getParentPrefix returns the first part of the composite key which
+// represents the parent identifier.
+func getParentPrefix(b []byte) uint64 {
+	parent, _ := binary.Uvarint(b)
+	return parent
+}
+
+// GetInfo returns the snapshot Info directly from the metadata. Requires a
+// context with a storage transaction.
+func GetInfo(ctx context.Context, key string) (string, snapshots.Info, snapshots.Usage, error) {
+	var (
+		id uint64
+		su snapshots.Usage
+		si = snapshots.Info{
+			Name: key,
+		}
+	)
+	err := withSnapshotBucket(ctx, key, func(ctx context.Context, bkt, pbkt *bolt.Bucket) error {
+		getUsage(bkt, &su)
+		return readSnapshot(bkt, &id, &si)
+	})
+	if err != nil {
+		return "", snapshots.Info{}, snapshots.Usage{}, err
+	}
+
+	return fmt.Sprintf("%d", id), si, su, nil
+}
+
+// UpdateInfo updates an existing snapshot info's data
+func UpdateInfo(ctx context.Context, info snapshots.Info, fieldpaths ...string) (snapshots.Info, error) {
+	updated := snapshots.Info{
+		Name: info.Name,
+	}
+	err := withBucket(ctx, func(ctx context.Context, bkt, pbkt *bolt.Bucket) error {
+		sbkt := bkt.Bucket([]byte(info.Name))
+		if sbkt == nil {
+			return errors.Wrap(errdefs.ErrNotFound, "snapshot does not exist")
+		}
+		if err := readSnapshot(sbkt, nil, &updated); err != nil {
+			return err
+		}
+
+		if len(fieldpaths) > 0 {
+			for _, path := range fieldpaths {
+				if strings.HasPrefix(path, "labels.") {
+					if updated.Labels == nil {
+						updated.Labels = map[string]string{}
+					}
+
+					key := strings.TrimPrefix(path, "labels.")
+					updated.Labels[key] = info.Labels[key]
+					continue
+				}
+
+				switch path {
+				case "labels":
+					updated.Labels = info.Labels
+				default:
+					return errors.Wrapf(errdefs.ErrInvalidArgument, "cannot update %q field on snapshot %q", path, info.Name)
+				}
+			}
+		} else {
+			// Set mutable fields
+			updated.Labels = info.Labels
+		}
+		updated.Updated = time.Now().UTC()
+		if err := boltutil.WriteTimestamps(sbkt, updated.Created, updated.Updated); err != nil {
+			return err
+		}
+
+		return boltutil.WriteLabels(sbkt, updated.Labels)
+	})
+	if err != nil {
+		return snapshots.Info{}, err
+	}
+	return updated, nil
+}
+
+// WalkInfo iterates through all metadata Info for the stored snapshots and
+// calls the provided function for each. Requires a context with a storage
+// transaction.
+func WalkInfo(ctx context.Context, fn snapshots.WalkFunc, fs ...string) error {
+	filter, err := filters.ParseAll(fs...)
+	if err != nil {
+		return err
+	}
+	// TODO: allow indexes (name, parent, specific labels)
+	return withBucket(ctx, func(ctx context.Context, bkt, pbkt *bolt.Bucket) error {
+		return bkt.ForEach(func(k, v []byte) error {
+			// skip non buckets
+			if v != nil {
+				return nil
+			}
+			var (
+				sbkt = bkt.Bucket(k)
+				si   = snapshots.Info{
+					Name: string(k),
+				}
+			)
+			if err := readSnapshot(sbkt, nil, &si); err != nil {
+				return err
+			}
+			if !filter.Match(adaptSnapshot(si)) {
+				return nil
+			}
+
+			return fn(ctx, si)
+		})
+	})
+}
+
+// GetSnapshot returns the metadata for the active or view snapshot transaction
+// referenced by the given key. Requires a context with a storage transaction.
+func GetSnapshot(ctx context.Context, key string) (s Snapshot, err error) {
+	err = withBucket(ctx, func(ctx context.Context, bkt, pbkt *bolt.Bucket) error {
+		sbkt := bkt.Bucket([]byte(key))
+		if sbkt == nil {
+			return errors.Wrap(errdefs.ErrNotFound, "snapshot does not exist")
+		}
+
+		s.ID = fmt.Sprintf("%d", readID(sbkt))
+		s.Kind = readKind(sbkt)
+
+		if s.Kind != snapshots.KindActive && s.Kind != snapshots.KindView {
+			return errors.Wrapf(errdefs.ErrFailedPrecondition, "requested snapshot %v not active or view", key)
+		}
+
+		if parentKey := sbkt.Get(bucketKeyParent); len(parentKey) > 0 {
+			spbkt := bkt.Bucket(parentKey)
+			if spbkt == nil {
+				return errors.Wrap(errdefs.ErrNotFound, "parent does not exist")
+			}
+
+			s.ParentIDs, err = parents(bkt, spbkt, readID(spbkt))
+			if err != nil {
+				return errors.Wrap(err, "failed to get parent chain")
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return Snapshot{}, err
+	}
+
+	return
+}
+
+// CreateSnapshot inserts a record for an active or view snapshot with the provided parent.
+func CreateSnapshot(ctx context.Context, kind snapshots.Kind, key, parent string, opts ...snapshots.Opt) (s Snapshot, err error) {
+	switch kind {
+	case snapshots.KindActive, snapshots.KindView:
+	default:
+		return Snapshot{}, errors.Wrapf(errdefs.ErrInvalidArgument, "snapshot type %v invalid; only snapshots of type Active or View can be created", kind)
+	}
+	var base snapshots.Info
+	for _, opt := range opts {
+		if err := opt(&base); err != nil {
+			return Snapshot{}, err
+		}
+	}
+
+	err = createBucketIfNotExists(ctx, func(ctx context.Context, bkt, pbkt *bolt.Bucket) error {
+		var (
+			spbkt *bolt.Bucket
+		)
+		if parent != "" {
+			spbkt = bkt.Bucket([]byte(parent))
+			if spbkt == nil {
+				return errors.Wrapf(errdefs.ErrNotFound, "missing parent %q bucket", parent)
+			}
+
+			if readKind(spbkt) != snapshots.KindCommitted {
+				return errors.Wrapf(errdefs.ErrInvalidArgument, "parent %q is not committed snapshot", parent)
+			}
+		}
+		sbkt, err := bkt.CreateBucket([]byte(key))
+		if err != nil {
+			if err == bolt.ErrBucketExists {
+				err = errors.Wrapf(errdefs.ErrAlreadyExists, "snapshot %v", key)
+			}
+			return err
+		}
+
+		id, err := bkt.NextSequence()
+		if err != nil {
+			return errors.Wrapf(err, "unable to get identifier for snapshot %q", key)
+		}
+
+		t := time.Now().UTC()
+		si := snapshots.Info{
+			Parent:  parent,
+			Kind:    kind,
+			Labels:  base.Labels,
+			Created: t,
+			Updated: t,
+		}
+		if err := putSnapshot(sbkt, id, si); err != nil {
+			return err
+		}
+
+		if spbkt != nil {
+			pid := readID(spbkt)
+
+			// Store a backlink from the key to the parent. Store the snapshot name
+			// as the value to allow following the backlink to the snapshot value.
+			if err := pbkt.Put(parentKey(pid, id), []byte(key)); err != nil {
+				return errors.Wrapf(err, "failed to write parent link for snapshot %q", key)
+			}
+
+			s.ParentIDs, err = parents(bkt, spbkt, pid)
+			if err != nil {
+				return errors.Wrapf(err, "failed to get parent chain for snapshot %q", key)
+			}
+		}
+
+		s.ID = fmt.Sprintf("%d", id)
+		s.Kind = kind
+		return nil
+	})
+	if err != nil {
+		return Snapshot{}, err
+	}
+
+	return
+}
+
+// Remove removes a snapshot from the metastore. The string identifier for the
+// snapshot is returned as well as the kind. The provided context must contain a
+// writable transaction.
+func Remove(ctx context.Context, key string) (string, snapshots.Kind, error) {
+	var (
+		id uint64
+		si snapshots.Info
+	)
+
+	if err := withBucket(ctx, func(ctx context.Context, bkt, pbkt *bolt.Bucket) error {
+		sbkt := bkt.Bucket([]byte(key))
+		if sbkt == nil {
+			return errors.Wrapf(errdefs.ErrNotFound, "snapshot %v", key)
+		}
+
+		if err := readSnapshot(sbkt, &id, &si); err != nil {
+			return errors.Wrapf(err, "failed to read snapshot %s", key)
+		}
+
+		if pbkt != nil {
+			k, _ := pbkt.Cursor().Seek(parentPrefixKey(id))
+			if getParentPrefix(k) == id {
+				return errors.Wrap(errdefs.ErrFailedPrecondition, "cannot remove snapshot with child")
+			}
+
+			if si.Parent != "" {
+				spbkt := bkt.Bucket([]byte(si.Parent))
+				if spbkt == nil {
+					return errors.Wrapf(errdefs.ErrNotFound, "snapshot %v", key)
+				}
+
+				if err := pbkt.Delete(parentKey(readID(spbkt), id)); err != nil {
+					return errors.Wrap(err, "failed to delete parent link")
+				}
+			}
+		}
+
+		if err := bkt.DeleteBucket([]byte(key)); err != nil {
+			return errors.Wrap(err, "failed to delete snapshot")
+		}
+
+		return nil
+	}); err != nil {
+		return "", 0, err
+	}
+
+	return fmt.Sprintf("%d", id), si.Kind, nil
+}
+
+// CommitActive renames the active snapshot transaction referenced by `key`
+// as a committed snapshot referenced by `Name`. The resulting snapshot  will be
+// committed and readonly. The `key` reference will no longer be available for
+// lookup or removal. The returned string identifier for the committed snapshot
+// is the same identifier of the original active snapshot. The provided context
+// must contain a writable transaction.
+func CommitActive(ctx context.Context, key, name string, usage snapshots.Usage, opts ...snapshots.Opt) (string, error) {
+	var (
+		id   uint64
+		base snapshots.Info
+	)
+	for _, opt := range opts {
+		if err := opt(&base); err != nil {
+			return "", err
+		}
+	}
+
+	if err := withBucket(ctx, func(ctx context.Context, bkt, pbkt *bolt.Bucket) error {
+		dbkt, err := bkt.CreateBucket([]byte(name))
+		if err != nil {
+			if err == bolt.ErrBucketExists {
+				err = errdefs.ErrAlreadyExists
+			}
+			return errors.Wrapf(err, "committed snapshot %v", name)
+		}
+		sbkt := bkt.Bucket([]byte(key))
+		if sbkt == nil {
+			return errors.Wrapf(errdefs.ErrNotFound, "failed to get active snapshot %q", key)
+		}
+
+		var si snapshots.Info
+		if err := readSnapshot(sbkt, &id, &si); err != nil {
+			return errors.Wrapf(err, "failed to read active snapshot %q", key)
+		}
+
+		if si.Kind != snapshots.KindActive {
+			return errors.Wrapf(errdefs.ErrFailedPrecondition, "snapshot %q is not active", key)
+		}
+		si.Kind = snapshots.KindCommitted
+		si.Created = time.Now().UTC()
+		si.Updated = si.Created
+
+		// Replace labels, do not inherit
+		si.Labels = base.Labels
+
+		if err := putSnapshot(dbkt, id, si); err != nil {
+			return err
+		}
+		if err := putUsage(dbkt, usage); err != nil {
+			return err
+		}
+		if err := bkt.DeleteBucket([]byte(key)); err != nil {
+			return errors.Wrapf(err, "failed to delete active snapshot %q", key)
+		}
+		if si.Parent != "" {
+			spbkt := bkt.Bucket([]byte(si.Parent))
+			if spbkt == nil {
+				return errors.Wrapf(errdefs.ErrNotFound, "missing parent %q of snapshot %q", si.Parent, key)
+			}
+			pid := readID(spbkt)
+
+			// Updates parent back link to use new key
+			if err := pbkt.Put(parentKey(pid, id), []byte(name)); err != nil {
+				return errors.Wrapf(err, "failed to update parent link %q from %q to %q", pid, key, name)
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%d", id), nil
+}
+
+// IDMap returns all the IDs mapped to their key
+func IDMap(ctx context.Context) (map[string]string, error) {
+	m := map[string]string{}
+	if err := withBucket(ctx, func(ctx context.Context, bkt, _ *bolt.Bucket) error {
+		return bkt.ForEach(func(k, v []byte) error {
+			// skip non buckets
+			if v != nil {
+				return nil
+			}
+			id := readID(bkt.Bucket(k))
+			m[fmt.Sprintf("%d", id)] = string(k)
+			return nil
+		})
+	}); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+func withSnapshotBucket(ctx context.Context, key string, fn func(context.Context, *bolt.Bucket, *bolt.Bucket) error) error {
+	tx, ok := ctx.Value(transactionKey{}).(*bolt.Tx)
+	if !ok {
+		return ErrNoTransaction
+	}
+	vbkt := tx.Bucket(bucketKeyStorageVersion)
+	if vbkt == nil {
+		return errors.Wrap(errdefs.ErrNotFound, "bucket does not exist")
+	}
+	bkt := vbkt.Bucket(bucketKeySnapshot)
+	if bkt == nil {
+		return errors.Wrap(errdefs.ErrNotFound, "snapshots bucket does not exist")
+	}
+	bkt = bkt.Bucket([]byte(key))
+	if bkt == nil {
+		return errors.Wrap(errdefs.ErrNotFound, "snapshot does not exist")
+	}
+
+	return fn(ctx, bkt, vbkt.Bucket(bucketKeyParents))
+}
+
+func withBucket(ctx context.Context, fn func(context.Context, *bolt.Bucket, *bolt.Bucket) error) error {
+	tx, ok := ctx.Value(transactionKey{}).(*bolt.Tx)
+	if !ok {
+		return ErrNoTransaction
+	}
+	bkt := tx.Bucket(bucketKeyStorageVersion)
+	if bkt == nil {
+		return errors.Wrap(errdefs.ErrNotFound, "bucket does not exist")
+	}
+	return fn(ctx, bkt.Bucket(bucketKeySnapshot), bkt.Bucket(bucketKeyParents))
+}
+
+func createBucketIfNotExists(ctx context.Context, fn func(context.Context, *bolt.Bucket, *bolt.Bucket) error) error {
+	tx, ok := ctx.Value(transactionKey{}).(*bolt.Tx)
+	if !ok {
+		return ErrNoTransaction
+	}
+
+	bkt, err := tx.CreateBucketIfNotExists(bucketKeyStorageVersion)
+	if err != nil {
+		return errors.Wrap(err, "failed to create version bucket")
+	}
+	sbkt, err := bkt.CreateBucketIfNotExists(bucketKeySnapshot)
+	if err != nil {
+		return errors.Wrap(err, "failed to create snapshots bucket")
+	}
+	pbkt, err := bkt.CreateBucketIfNotExists(bucketKeyParents)
+	if err != nil {
+		return errors.Wrap(err, "failed to create parents bucket")
+	}
+	return fn(ctx, sbkt, pbkt)
+}
+
+func parents(bkt, pbkt *bolt.Bucket, parent uint64) (parents []string, err error) {
+	for {
+		parents = append(parents, fmt.Sprintf("%d", parent))
+
+		parentKey := pbkt.Get(bucketKeyParent)
+		if len(parentKey) == 0 {
+			return
+		}
+		pbkt = bkt.Bucket(parentKey)
+		if pbkt == nil {
+			return nil, errors.Wrap(errdefs.ErrNotFound, "missing parent")
+		}
+
+		parent = readID(pbkt)
+	}
+}
+
+func readKind(bkt *bolt.Bucket) (k snapshots.Kind) {
+	kind := bkt.Get(bucketKeyKind)
+	if len(kind) == 1 {
+		k = snapshots.Kind(kind[0])
+	}
+	return
+}
+
+func readID(bkt *bolt.Bucket) uint64 {
+	id, _ := binary.Uvarint(bkt.Get(bucketKeyID))
+	return id
+}
+
+func readSnapshot(bkt *bolt.Bucket, id *uint64, si *snapshots.Info) error {
+	if id != nil {
+		*id = readID(bkt)
+	}
+	if si != nil {
+		si.Kind = readKind(bkt)
+		si.Parent = string(bkt.Get(bucketKeyParent))
+
+		if err := boltutil.ReadTimestamps(bkt, &si.Created, &si.Updated); err != nil {
+			return err
+		}
+
+		labels, err := boltutil.ReadLabels(bkt)
+		if err != nil {
+			return err
+		}
+		si.Labels = labels
+	}
+
+	return nil
+}
+
+func putSnapshot(bkt *bolt.Bucket, id uint64, si snapshots.Info) error {
+	idEncoded, err := encodeID(id)
+	if err != nil {
+		return err
+	}
+
+	updates := [][2][]byte{
+		{bucketKeyID, idEncoded},
+		{bucketKeyKind, []byte{byte(si.Kind)}},
+	}
+	if si.Parent != "" {
+		updates = append(updates, [2][]byte{bucketKeyParent, []byte(si.Parent)})
+	}
+	for _, v := range updates {
+		if err := bkt.Put(v[0], v[1]); err != nil {
+			return err
+		}
+	}
+	if err := boltutil.WriteTimestamps(bkt, si.Created, si.Updated); err != nil {
+		return err
+	}
+	return boltutil.WriteLabels(bkt, si.Labels)
+}
+
+func getUsage(bkt *bolt.Bucket, usage *snapshots.Usage) {
+	usage.Inodes, _ = binary.Varint(bkt.Get(bucketKeyInodes))
+	usage.Size, _ = binary.Varint(bkt.Get(bucketKeySize))
+}
+
+func putUsage(bkt *bolt.Bucket, usage snapshots.Usage) error {
+	for _, v := range []struct {
+		key   []byte
+		value int64
+	}{
+		{bucketKeyInodes, usage.Inodes},
+		{bucketKeySize, usage.Size},
+	} {
+		e, err := encodeSize(v.value)
+		if err != nil {
+			return err
+		}
+		if err := bkt.Put(v.key, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func encodeSize(size int64) ([]byte, error) {
+	var (
+		buf         [binary.MaxVarintLen64]byte
+		sizeEncoded = buf[:]
+	)
+	sizeEncoded = sizeEncoded[:binary.PutVarint(sizeEncoded, size)]
+
+	if len(sizeEncoded) == 0 {
+		return nil, fmt.Errorf("failed encoding size = %v", size)
+	}
+	return sizeEncoded, nil
+}
+
+func encodeID(id uint64) ([]byte, error) {
+	var (
+		buf       [binary.MaxVarintLen64]byte
+		idEncoded = buf[:]
+	)
+	idEncoded = idEncoded[:binary.PutUvarint(idEncoded, id)]
+
+	if len(idEncoded) == 0 {
+		return nil, fmt.Errorf("failed encoding id = %v", id)
+	}
+	return idEncoded, nil
+}
+
+func adaptSnapshot(info snapshots.Info) filters.Adaptor {
+	return filters.AdapterFunc(func(fieldpath []string) (string, bool) {
+		if len(fieldpath) == 0 {
+			return "", false
+		}
+
+		switch fieldpath[0] {
+		case "kind":
+			switch info.Kind {
+			case snapshots.KindActive:
+				return "active", true
+			case snapshots.KindView:
+				return "view", true
+			case snapshots.KindCommitted:
+				return "committed", true
+			}
+		case "name":
+			return info.Name, true
+		case "parent":
+			return info.Parent, true
+		case "labels":
+			if len(info.Labels) == 0 {
+				return "", false
+			}
+
+			v, ok := info.Labels[strings.Join(fieldpath[1:], ".")]
+			return v, ok
+		}
+
+		return "", false
+	})
+}

--- a/vendor/github.com/containerd/containerd/snapshots/storage/metastore.go
+++ b/vendor/github.com/containerd/containerd/snapshots/storage/metastore.go
@@ -1,0 +1,115 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package storage provides a metadata storage implementation for snapshot
+// drivers. Drive implementations are responsible for starting and managing
+// transactions using the defined context creator. This storage package uses
+// BoltDB for storing metadata. Access to the raw boltdb transaction is not
+// provided, but the stored object is provided by the proto subpackage.
+package storage
+
+import (
+	"context"
+	"sync"
+
+	"github.com/containerd/containerd/snapshots"
+	"github.com/pkg/errors"
+	bolt "go.etcd.io/bbolt"
+)
+
+// Transactor is used to finalize an active transaction.
+type Transactor interface {
+	// Commit commits any changes made during the transaction. On error a
+	// caller is expected to clean up any resources which would have relied
+	// on data mutated as part of this transaction. Only writable
+	// transactions can commit, non-writable must call Rollback.
+	Commit() error
+
+	// Rollback rolls back any changes made during the transaction. This
+	// must be called on all non-writable transactions and aborted writable
+	// transaction.
+	Rollback() error
+}
+
+// Snapshot hold the metadata for an active or view snapshot transaction. The
+// ParentIDs hold the snapshot identifiers for the committed snapshots this
+// active or view is based on. The ParentIDs are ordered from the lowest base
+// to highest, meaning they should be applied in order from the first index to
+// the last index. The last index should always be considered the active
+// snapshots immediate parent.
+type Snapshot struct {
+	Kind      snapshots.Kind
+	ID        string
+	ParentIDs []string
+}
+
+// MetaStore is used to store metadata related to a snapshot driver. The
+// MetaStore is intended to store metadata related to name, state and
+// parentage. Using the MetaStore is not required to implement a snapshot
+// driver but can be used to handle the persistence and transactional
+// complexities of a driver implementation.
+type MetaStore struct {
+	dbfile string
+
+	dbL sync.Mutex
+	db  *bolt.DB
+}
+
+// NewMetaStore returns a snapshot MetaStore for storage of metadata related to
+// a snapshot driver backed by a bolt file database. This implementation is
+// strongly consistent and does all metadata changes in a transaction to prevent
+// against process crashes causing inconsistent metadata state.
+func NewMetaStore(dbfile string) (*MetaStore, error) {
+	return &MetaStore{
+		dbfile: dbfile,
+	}, nil
+}
+
+type transactionKey struct{}
+
+// TransactionContext creates a new transaction context. The writable value
+// should be set to true for transactions which are expected to mutate data.
+func (ms *MetaStore) TransactionContext(ctx context.Context, writable bool) (context.Context, Transactor, error) {
+	ms.dbL.Lock()
+	if ms.db == nil {
+		db, err := bolt.Open(ms.dbfile, 0600, nil)
+		if err != nil {
+			ms.dbL.Unlock()
+			return ctx, nil, errors.Wrap(err, "failed to open database file")
+		}
+		ms.db = db
+	}
+	ms.dbL.Unlock()
+
+	tx, err := ms.db.Begin(writable)
+	if err != nil {
+		return ctx, nil, errors.Wrap(err, "failed to start transaction")
+	}
+
+	ctx = context.WithValue(ctx, transactionKey{}, tx)
+
+	return ctx, tx, nil
+}
+
+// Close closes the metastore and any underlying database connections
+func (ms *MetaStore) Close() error {
+	ms.dbL.Lock()
+	defer ms.dbL.Unlock()
+	if ms.db == nil {
+		return nil
+	}
+	return ms.db.Close()
+}


### PR DESCRIPTION
Containerd has a pluggable architecture. Some OSS projects leverage this feature and extend it with their plugins. Especially snapshotter and content store are supported as external binary plugins and this enables widening use-cases of the runtime with lower maintaining costs.

Unfortunately, these plugins can't be used on docker because it uses graphdrivers for contents and snapshots management instead of containerd plugins. This leads to duplication of work for plugin implementers towards using their custom plugins on docker in addition to containerd.

This commit solves this issue by supporting containerd's snapshotter and content store as a graphdriver on docker.

This is related to #38043 and #38738 but I separately opened this because the scope of this PR is a bit narrower. This PR is a draft because we need to cover more edge cases and needs more tests and further optimization but this should be enough as a blueprint for the discussion.

The following is an overview of this integration.

## containerd-based graphdriver

Graphdriver manages diff contents and layer snapshots (mount points). These functionalities can be mapped to content store and snapshotter in containerd. This commit includes a graphdriver based on these plugins.

Diff content management (related to `DiffDriver` APIs) is backed by the content store. Contents provided through `ApplyDiff` are stored in it so graphdriver can provide exactly same tarball through `Diff` API for these applied contents.

Layer snapshots management (related to `ProtoDriver` APIs) is provided by snapshotter. A snapshot is `Prepare`-ed when `Create` or `CreateReadWrite` API is invoked. It's committed when it needs to be a parent for new layers. Mount points are provided through snapshotter's `View` or `Mount` APIs.

## Remote snapshotters

This commit also includes support for containerd's "remote snapshotters". They allow runtimes to use remotely mounted container rootfs without pulling images, which leads to speeding up container startup especially in cold-start cases. For more details, please refer to the https://github.com/containerd/stargz-snapshotter repo which is one of the implementations of remote snapshotters. Benchmarking result on containerd with stargz snapshotter shows performance improvement on container startup (not measured on docker yet but improvements can be expected also on it).

<img src="https://raw.githubusercontent.com/containerd/stargz-snapshotter/f572467b06155ae0a0e011c7f7374149a2b91436/docs/images/benchmarking-result-288c338.png" width="400" alt="The benchmarking result on 288c338">

The graphdriver in this patch supports remote snapshotters. Layer snapshots and diff contents can be provided without pulling images. I call it "remote graphdriver" here.

Remote graphdriver allows clients (including docker daemon core) to check if a layer exists in the graphdriver. In this patch, this checking is done through `Create` and `CreateReadWrite` APIs during `docker pull` and if any layers in the targeting image exist in graphdriver, docker skips the pull for these layers. This patch introduces `TargetOpts` options passed via `CraeteOpts` for specifying the targeting layer.

```go
type CreateOpts struct {
...
	TargetInfo *TargetOpts
}

type TargetOpts struct {
	MountChainID  digest.Digest
	ContentDiffID digest.Digest
	ImageRef      string
	LayerDigest   digest.Digest
	ImageLayers   []digest.Digest
}
```

If the snapshots (specified by ChainID) and diff contents (specified by DiffID) exist in the backing snapshotter and content store (which is backed by remote stores), the graphdriver returns `ErrAlreadyExists` to tell clients the layer existence.

In the current implementation, the layer validation (means layer provided by graphdriver has ChainID for its mount point and has DiffID for its inflated diff content) is snapshotter's responsibility but we might need more discussion for it.

The example implementation of a snapshotter which supports "remote graphdriver" is on https://github.com/ktock/stargz-snapshotter/tree/graphdriver which is a patched version of containerd/stargz-snapshotter.

## Questions

I'm keen to move the containerd-docker integration forward and any feedback and comments are very welcome.

- Could I get your comments on this design and implementation? Is the kind of "containerd-based graphdriver" acceptable? If not, are there any considerations or alternatives?
- I contained both "containerd-based graphdriver" and "remote graphdriver" in this single PR because both of them are closely related. Please tell me if I should make separated PRs.
- Please tell me anything missing in this design and implementation.
