### PR TITLE
Fix dns fallback regression

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -286,6 +286,7 @@ pipeline {
                                 sh '''#!/bin/bash
                                 # bash is needed so 'jobs -p' works properly
                                 # it also accepts setting inline envvars for functions without explicitly exporting
+                                set -x
 
                                 run_tests() {
                                         [ -n "$TESTDEBUG" ] && rm= || rm=--rm;
@@ -335,7 +336,6 @@ pipeline {
                                 # integration-cli second set
                                 TEST_INTEGRATION_DEST=3 CONTAINER_NAME=${CONTAINER_NAME}-3 TEST_SKIP_INTEGRATION=1 TESTFLAGS="-test.run Test(DockerSwarmSuite|DockerDaemonSuite|DockerExternalVolumeSuite)/" run_tests &
 
-                                set +x
                                 c=0
                                 for job in $(jobs -p); do
                                         wait ${job} || c=$?

--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: "${LIBNETWORK_COMMIT:=ef149a924dfde2e506ea3cb3f617d7d0fa96b8ee}"
+: "${LIBNETWORK_COMMIT:=2e24aed516bd5c836e11378bb457dd612aa868ed}"
 
 install_proxy() {
 	case "$1" in

--- a/hack/make/test-integration
+++ b/hack/make/test-integration
@@ -22,6 +22,8 @@ fi
 	cleanup_test_suite_binaries
 	error_on_leaked_containerd_shims
 
+	echo exiting test-integration
+	set -x
 	exit ${testexit}
 
 ) 2>&1 | tee -a "$DEST/test.log"

--- a/integration/network/dns_test.go
+++ b/integration/network/dns_test.go
@@ -1,0 +1,35 @@
+package network // import "github.com/docker/docker/integration/network"
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/integration/internal/network"
+	"github.com/docker/docker/testutil/daemon"
+	"gotest.tools/v3/poll"
+	"gotest.tools/v3/skip"
+)
+
+func TestDaemonDNSFallback(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot start daemon on remote test run")
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, IsUserNamespace())
+
+	d := daemon.New(t)
+	d.StartWithBusybox(t, "-b", "none", "--dns", "127.127.127.1", "--dns", "8.8.8.8")
+	defer d.Stop(t)
+
+	c := d.NewClientT(t)
+	ctx := context.Background()
+
+	network.CreateNoError(ctx, t, c, "test")
+	defer c.NetworkRemove(ctx, "test")
+
+	cid := container.Run(ctx, t, c, container.WithNetworkMode("test"), container.WithCmd("nslookup", "docker.com"))
+	defer c.ContainerRemove(ctx, cid, types.ContainerRemoveOptions{Force: true})
+
+	poll.WaitOn(t, container.IsSuccessful(ctx, c, cid), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(2*time.Second))
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/gofrs/flock                              392e7fae8f1b0bdbd67dad7237d2
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        1a17fb36132631a95fe6bb055b91e24a516ad81d
+github.com/docker/libnetwork                        2e24aed516bd5c836e11378bb457dd612aa868ed
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/resolver.go
+++ b/vendor/github.com/docker/libnetwork/resolver.go
@@ -484,7 +484,7 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 			resp, err = co.ReadMsg()
 			// Truncated DNS replies should be sent to the client so that the
 			// client can retry over TCP
-			if err != nil && (resp != nil && !resp.Truncated) {
+			if err != nil && (resp == nil || !resp.Truncated) {
 				r.forwardQueryEnd()
 				logrus.Debugf("[resolver] read from DNS server failed, %s", err)
 				continue

--- a/vendor/github.com/docker/libnetwork/vendor.conf
+++ b/vendor/github.com/docker/libnetwork/vendor.conf
@@ -58,4 +58,4 @@ go.opencensus.io                        9c377598961b706d1542bd2d84d538b5094d596e
 gotest.tools                            1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
 github.com/google/go-cmp                3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0
 
-github.com/moby/ipvs                    8f137da6850a975020f4f739c589d293dd3a9d7b # v1.0.0
+github.com/moby/ipvs                    4566ccea0e08d68e9614c3e7a64a23b850c4bb35 # v1.0.1


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/41003
fixes https://github.com/moby/moby/issues/41041

Ref https://github.com/moby/libnetwork/pull/2551

To run only the test and confirm it fails if vendor commit is reverted:
```
TEST_SKIP_INTEGRATION_CLI=1 TEST_INTEGRATION_DIR=./integration/network TESTFLAGS='-test.run TestDaemonDNSFallback' make test-integration
```