### PR TITLE
Fix 'failed to get network during CreateEndpoint'

### DIFF
--- a/daemon/cluster/executor/container/attachment.go
+++ b/daemon/cluster/executor/container/attachment.go
@@ -64,9 +64,7 @@ func (nc *networkAttacherController) Terminate(ctx context.Context) error {
 }
 
 func (nc *networkAttacherController) Remove(ctx context.Context) error {
-	// Try removing the network referenced in this task in case this
-	// task is the last one referencing it
-	return nc.adapter.removeNetworks(ctx)
+	return nil
 }
 
 func (nc *networkAttacherController) Close() error {

--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -211,6 +211,7 @@ func (r *controller) Start(ctx context.Context) error {
 				// Retry network creation again if we
 				// failed because some of the networks
 				// were not found.
+				log.G(ctx).WithError(lnErr).Debugf("Network not found when starting container %s, will recreate the networks", r.adapter.container.name())
 				if err := r.adapter.createNetworks(ctx); err != nil {
 					return err
 				}

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -940,11 +940,15 @@ func (daemon *Daemon) disconnectFromNetwork(container *container.Container, n li
 
 func (daemon *Daemon) tryDetachContainerFromClusterNetwork(network libnetwork.Network, container *container.Container) {
 	if daemon.clusterProvider != nil && network.Info().Dynamic() && !container.Managed {
+		// For container created from `docker run --net <attachable-overlay-network>`
 		if err := daemon.clusterProvider.DetachNetwork(network.Name(), container.ID); err != nil {
 			logrus.Warnf("error detaching from network %s: %v", network.Name(), err)
 			if err := daemon.clusterProvider.DetachNetwork(network.ID(), container.ID); err != nil {
 				logrus.Warnf("error detaching from network %s: %v", network.ID(), err)
 			}
+		}
+		if err := daemon.DeleteManagedNetwork(network.ID()); err != nil {
+			logrus.WithError(err).Warnf("error deleting network %s", network.ID())
 		}
 	}
 	attributes := map[string]string{


### PR DESCRIPTION
Fixes https://github.com/docker/for-linux/issues/888 

This is a race condition issue. Before starting container, the code ensures the network exists on the node, then during creating endpoint (as part of steps in starting container), the network does not exist anymore then the error `failed to get network during CreateEndpoint` occurs.

So far I have known about 2 scenarios causing this problem:

1. During above short period of starting container, another container is stopped and at that time it is the last container on the network on the node, so the network is removed.
For a sample scenario, see my analysis at https://github.com/docker/for-linux/issues/888#issuecomment-628350989

2. Restarting a container that was started via `docker run --net <attachable network>`
See: https://github.com/docker/for-linux/issues/888#issuecomment-572348123 
The reason is that this kind of container has a hiden correspondent swarkit task, after container is stopped, swarmkit will remove this task and call network-deletion to remove the network if it is the last container on this network on the node. The problem is that this network-deletion is asynchronizedly done by a goroutine which is different from container stop/start goroutine. This race condition causes `failed to get network during CreateEndpoint` during container starting.  

Signed-off-by: Xinfeng Liu <xinfeng.liu@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix 'failed to get network during CreateEndpoint' during container starting.

**- How I did it**
- For scenario 1 above:
Change the error type to `libnetwork.ErrNoSuchNetwork`, so `Start()` in `daemon/cluster/executor/container/controller.go` will recreate the network.

- For scenario 2 above:
Move network-deletion logic to `tryDetachContainerFromClusterNetwork()` in `daemon/container_operations.go`. So we make sure the network deleting is done before containerStop returns.

**- How to verify it**
- For scenario 1 above:
The issue is not easily recreated deliberately. I tested many times using `docker stack deploy` and 'docker  service update --force` randomly, and could recreated the issue occasionaly. 

From the log of my test, I can verify my fix works as expected.

The container `test_web.1.6uo4tek9dcioirebj7iejl105` ran into the "network not found" error, and the network got recreated.
```
May 22 04:44:02 dev dockerd[4151]: time="2020-05-22T04:44:02.841844037Z" level=warning msg="Network not found when starting container test_web.1.6uo4tek9dcioirebj7iejl105, will create again" error="network test_mynet not found" module=node/agent/taskmanager node.id=m2hs3p1lvm7ahtb7znft4xw88 service.id=0vig3v0cch757i526gymw9ued task.id=6uo4tek9dcioirebj7iejl105
```

From `docker service ps` output at the same time, the task `6uo4tek9dcio` did not fail.
```
Fri 22 May 2020 04:44:02 AM UTC
ID                  NAME                IMAGE                 NODE                DESIRED STATE       CURRENT STATE                     ERROR               PORTS
6uo4tek9dcio        test_web.1          nginx:stable-alpine   dev                 Running             Starting less than a second ago
jj3vjrrcwhzy         \_ test_web.1      nginx:stable-alpine   dev                 Shutdown            Shutdown less than a second ago
3h188v77mjob         \_ test_web.1      nginx:alpine          dev                 Shutdown            Shutdown 1 second ago          
vh4gaf7wt6w7         \_ test_web.1      nginx:stable-alpine   dev                 Shutdown            Shutdown 12 seconds ago        

Fri 22 May 2020 04:44:05 AM UTC
ID                  NAME                IMAGE                 NODE                DESIRED STATE       CURRENT STATE             ERROR               PORTS
6uo4tek9dcio        test_web.1          nginx:stable-alpine   dev                 Running             Running 1 second ago           
jj3vjrrcwhzy         \_ test_web.1      nginx:stable-alpine   dev                 Shutdown            Shutdown 3 seconds ago         
3h188v77mjob         \_ test_web.1      nginx:alpine          dev                 Shutdown            Shutdown 4 seconds ago         
vh4gaf7wt6w7         \_ test_web.1      nginx:stable-alpine   dev                 Shutdown            Shutdown 15 seconds ago        
```

Not sure if there's a need to add multiple retries in `createNetworks()`. This issue should not have happen if the PR https://github.com/moby/moby/pull/40997#issuecomment-631397535 is merged.

- For scenario 2 above.
It can be recreated reliably. I will try adding tests in CI.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix 'failed to get network during CreateEndpoint' during container starting.

**- A picture of a cute animal (not mandatory but encouraged)**

