### PR TITLE
pkg/sysinfo.applyPIDSCgroupInfo: optimize

### DIFF
--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -95,7 +95,7 @@ func New(quiet bool, options ...Opt) *SysInfo {
 	return sysInfo
 }
 
-// applyMemoryCgroupInfo reads the memory information from the memory cgroup mount point.
+// applyMemoryCgroupInfo adds the memory cgroup controller information to the info.
 func applyMemoryCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
 	var warnings []string
 	mountPoint, ok := cgMounts["memory"]
@@ -133,7 +133,7 @@ func applyMemoryCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
 	return warnings
 }
 
-// applyCPUCgroupInfo reads the cpu information from the cpu cgroup mount point.
+// applyCPUCgroupInfo adds the cpu cgroup controller information to the info.
 func applyCPUCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
 	var warnings []string
 	mountPoint, ok := cgMounts["cpu"]
@@ -170,7 +170,7 @@ func applyCPUCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
 	return warnings
 }
 
-// applyBlkioCgroupInfo reads the blkio information from the blkio cgroup mount point.
+// applyBlkioCgroupInfo adds the blkio cgroup controller information to the info.
 func applyBlkioCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
 	var warnings []string
 	mountPoint, ok := cgMounts["blkio"]
@@ -211,7 +211,7 @@ func applyBlkioCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
 	return warnings
 }
 
-// applyCPUSetCgroupInfo reads the cpuset information from the cpuset cgroup mount point.
+// applyCPUSetCgroupInfo adds the cpuset cgroup controller information to the info.
 func applyCPUSetCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
 	var warnings []string
 	mountPoint, ok := cgMounts["cpuset"]
@@ -238,7 +238,7 @@ func applyCPUSetCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
 	return warnings
 }
 
-// applyPIDSCgroupInfo reads the pids information from the pids cgroup mount point.
+// applyPIDSCgroupInfo adds whether the pids cgroup controller is available to the info.
 func applyPIDSCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
 	var warnings []string
 	_, ok := cgMounts["pids"]
@@ -250,7 +250,7 @@ func applyPIDSCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
 	return warnings
 }
 
-// applyDevicesCgroupInfo reads the pids information from the devices cgroup mount point.
+// applyDevicesCgroupInfo adds whether the devices cgroup controller is available to the info.
 func applyDevicesCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
 	var warnings []string
 	_, ok := cgMounts["devices"]
@@ -267,7 +267,7 @@ func applyNetworkingInfo(info *SysInfo, _ map[string]string) []string {
 	return warnings
 }
 
-// applyAppArmorInfo adds AppArmor information to the info.
+// applyAppArmorInfo adds whether AppArmor is enabled to the info.
 func applyAppArmorInfo(info *SysInfo, _ map[string]string) []string {
 	var warnings []string
 	if _, err := os.Stat("/sys/kernel/security/apparmor"); !os.IsNotExist(err) {
@@ -278,7 +278,7 @@ func applyAppArmorInfo(info *SysInfo, _ map[string]string) []string {
 	return warnings
 }
 
-// applyCgroupNsInfo adds cgroup namespace information to the info.
+// applyCgroupNsInfo adds whether cgroupns is enabled to the info.
 func applyCgroupNsInfo(info *SysInfo, _ map[string]string) []string {
 	var warnings []string
 	if _, err := os.Stat("/proc/self/ns/cgroup"); !os.IsNotExist(err) {

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -239,11 +239,11 @@ func applyCPUSetCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
 }
 
 // applyPIDSCgroupInfo reads the pids information from the pids cgroup mount point.
-func applyPIDSCgroupInfo(info *SysInfo, _ map[string]string) []string {
+func applyPIDSCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
 	var warnings []string
-	_, err := cgroups.FindCgroupMountpoint("", "pids")
-	if err != nil {
-		warnings = append(warnings, err.Error())
+	_, ok := cgMounts["pids"]
+	if !ok {
+		warnings = append(warnings, "Unable to find pids cgroup in mounts")
 		return warnings
 	}
 	info.PidsLimit = true


### PR DESCRIPTION
For some reason, commit 69cf03700fed7 (PR #18697) chose not to use information
already fetched, and called `cgroups.FindCgroupMountpoint()` instead.

This is not a cheap call, as it has to parse the whole nine yards
of /proc/self/mountinfo, and the info which it tries to get (whether
the pids controller is present) is already available from `cgMounts` map.
