### PR TITLE
remove group name from identity mapping

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1207,36 +1207,15 @@ func setupRemappedRoot(config *config.Config) (*idtools.IdentityMapping, error) 
 			logrus.Warn("User namespaces: root cannot be remapped with itself; user namespaces are OFF")
 			return &idtools.IdentityMapping{}, nil
 		}
-		logrus.Infof("User namespaces: ID ranges will be mapped to subuid/subgid ranges of: %s:%s", username, groupname)
+		logrus.Infof("User namespaces: ID ranges will be mapped to subuid/subgid ranges of: %s", username)
 		// update remapped root setting now that we have resolved them to actual names
 		config.RemappedRoot = fmt.Sprintf("%s:%s", username, groupname)
 
-		// try with username:groupname, uid:groupname, username:gid, uid:gid,
-		// but keep the original error message (err)
-		mappings, err := idtools.NewIdentityMapping(username, groupname)
-		if err == nil {
-			return mappings, nil
-		}
-		user, lookupErr := idtools.LookupUser(username)
-		if lookupErr != nil {
+		mappings, err := idtools.NewIdentityMapping(username)
+		if err != nil {
 			return nil, errors.Wrap(err, "Can't create ID mappings")
 		}
-		logrus.Infof("Can't create ID mappings with username:groupname %s:%s, try uid:groupname %d:%s", username, groupname, user.Uid, groupname)
-		mappings, lookupErr = idtools.NewIdentityMapping(fmt.Sprintf("%d", user.Uid), groupname)
-		if lookupErr == nil {
-			return mappings, nil
-		}
-		logrus.Infof("Can't create ID mappings with uid:groupname %d:%s, try username:gid %s:%d", user.Uid, groupname, username, user.Gid)
-		mappings, lookupErr = idtools.NewIdentityMapping(username, fmt.Sprintf("%d", user.Gid))
-		if lookupErr == nil {
-			return mappings, nil
-		}
-		logrus.Infof("Can't create ID mappings with username:gid %s:%d, try uid:gid %d:%d", username, user.Gid, user.Uid, user.Gid)
-		mappings, lookupErr = idtools.NewIdentityMapping(fmt.Sprintf("%d", user.Uid), fmt.Sprintf("%d", user.Gid))
-		if lookupErr == nil {
-			return mappings, nil
-		}
-		return nil, errors.Wrap(err, "Can't create ID mappings")
+		return mappings, nil
 	}
 	return &idtools.IdentityMapping{}, nil
 }

--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -114,31 +114,6 @@ type IdentityMapping struct {
 	gids []IDMap
 }
 
-// NewIdentityMapping takes a requested user and group name and
-// using the data from /etc/sub{uid,gid} ranges, creates the
-// proper uid and gid remapping ranges for that user/group pair
-func NewIdentityMapping(username, groupname string) (*IdentityMapping, error) {
-	subuidRanges, err := parseSubuid(username)
-	if err != nil {
-		return nil, err
-	}
-	subgidRanges, err := parseSubgid(groupname)
-	if err != nil {
-		return nil, err
-	}
-	if len(subuidRanges) == 0 {
-		return nil, fmt.Errorf("No subuid ranges found for user %q", username)
-	}
-	if len(subgidRanges) == 0 {
-		return nil, fmt.Errorf("No subgid ranges found for group %q", groupname)
-	}
-
-	return &IdentityMapping{
-		uids: createIDMap(subuidRanges),
-		gids: createIDMap(subgidRanges),
-	}, nil
-}
-
 // NewIDMappingsFromMaps creates a new mapping from two slices
 // Deprecated: this is a temporary shim while transitioning to IDMapping
 func NewIDMappingsFromMaps(uids []IDMap, gids []IDMap) *IdentityMapping {

--- a/pkg/idtools/idtools_unix_test.go
+++ b/pkg/idtools/idtools_unix_test.go
@@ -321,12 +321,7 @@ func TestNewIDMappings(t *testing.T) {
 	tempUser, err := user.Lookup(tempUser)
 	assert.Check(t, err)
 
-	gids, err := tempUser.GroupIds()
-	assert.Check(t, err)
-	group, err := user.LookupGroupId(gids[0])
-	assert.Check(t, err)
-
-	idMapping, err := NewIdentityMapping(tempUser.Username, group.Name)
+	idMapping, err := NewIdentityMapping(tempUser.Username)
 	assert.Check(t, err)
 
 	rootUID, rootGID, err := GetRootUIDGID(idMapping.UIDs(), idMapping.GIDs())


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixes #40947. 
removed a check for group name and gid in `NewIdentityMapping`  

**- How I did it**
- group name was removed from the argument of `NewIdentityMapping`
- removed caller code which used to search with gid and group name

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
remove group name from identity mapping
