### PR TITLE
allocateNetwork: fix network sandbox not cleaned up on failure

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -527,12 +527,14 @@ func (daemon *Daemon) updateContainerNetworkSettings(container *container.Contai
 }
 
 func (daemon *Daemon) allocateNetwork(container *container.Container) (retErr error) {
-	start := time.Now()
-	controller := daemon.netController
-
 	if daemon.netController == nil {
 		return nil
 	}
+
+	var (
+		start      = time.Now()
+		controller = daemon.netController
+	)
 
 	// Cleanup any stale sandbox left over due to ungraceful daemon shutdown
 	if err := controller.SandboxDestroy(container.ID); err != nil {

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -526,7 +526,7 @@ func (daemon *Daemon) updateContainerNetworkSettings(container *container.Contai
 	}
 }
 
-func (daemon *Daemon) allocateNetwork(container *container.Container) error {
+func (daemon *Daemon) allocateNetwork(container *container.Container) (retErr error) {
 	start := time.Now()
 	controller := daemon.netController
 
@@ -594,7 +594,7 @@ func (daemon *Daemon) allocateNetwork(container *container.Container) error {
 			}
 			updateSandboxNetworkSettings(container, sb)
 			defer func() {
-				if err != nil {
+				if retErr != nil {
 					sb.Delete()
 				}
 			}()


### PR DESCRIPTION
The defer function was checking for the local `err` variable, not on the error that was returned by the function. As a result, the sandbox would never be cleaned up for containers that used "none" networking, and a failiure occured during setup.

The second commit is a small refactor; allocateNetwork() can return early, in which case these variables were unused, so assign them later in the function.

Looks like this was introduced in https://github.com/moby/moby/pull/31996 (which was created to address https://github.com/moby/moby/issues/31597)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->



