### PR TITLE
[19.03] Fix crui armhf build on armv8 agents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install CRIU for checkpoint/restore support
-ENV CRIU_VERSION 3.13
+ENV CRIU_VERSION 3.14
 RUN mkdir -p /usr/src/criu \
     && curl -sSL https://github.com/checkpoint-restore/criu/archive/v${CRIU_VERSION}.tar.gz | tar -C /usr/src/criu/ -xz --strip-components=1 \
     && cd /usr/src/criu \


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

**- What I did**

This PR fixes the build error in the `crui` stage when we build static armhf binaries on ARMv8 build machines with 32bit dockerd/containerd installed. 

We normally see an error like this

```
#39 44.89 include/common/asm/atomic.h:61:2: error: #error ARM architecture version (CONFIG_ARMV*) not set or unsupported.
#39 44.89  #error ARM architecture version (CONFIG_ARMV*) not set or unsupported.
#39 44.89   ^~~~~
```

This is because crui build also runs an `uname -m` inside the Makefile and that retrieves `armv8l`.

**- How I did it**

~~Overwrite the Makefile variable `UNAME-M` with `armv7l` to make the arm build happy on these machines.~~
Update criu to v3.14 which has a fix in their [Makefile](https://github.com/checkpoint-restore/criu/commit/075f1beaf7d36cb9ea5030e1faab9661c33290ab) for it as they run the build on armv8 build machines in Travis similar to our setup.

**- How to verify it**

- Use an ARMv8 machine, install and run docker-ce, docker-ce-cli and containerd.io `armhf` deb packages and run docker and containerd services with `setarch linux32` to have an arm32 build machine.
- Run `make binary`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

<img width="727" alt="Screen Shot 2020-05-25 at 5 47 02 PM" src="https://user-images.githubusercontent.com/207759/82827963-612d1a80-9eb0-11ea-98f4-5c876225650d.png">
