### PR TITLE
daemon.allocateNetwork: include original error in logs

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -536,7 +536,7 @@ func (daemon *Daemon) allocateNetwork(container *container.Container) error {
 
 	// Cleanup any stale sandbox left over due to ungraceful daemon shutdown
 	if err := controller.SandboxDestroy(container.ID); err != nil {
-		logrus.Errorf("failed to cleanup up stale network sandbox for container %s", container.ID)
+		logrus.WithError(err).Errorf("failed to cleanup up stale network sandbox for container %s", container.ID)
 	}
 
 	if container.Config.NetworkDisabled || container.HostConfig.NetworkMode.IsContainer() {


### PR DESCRIPTION
When failing to destroy a stale sandbox, we logged that the removal failed, but omitted the original error message.

