### PR TITLE
[19.03 backport] pkg/sysinfo.applyPIDSCgroupInfo: optimize

### DIFF
--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -211,11 +211,11 @@ func applyCPUSetCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
 }
 
 // applyPIDSCgroupInfo reads the pids information from the pids cgroup mount point.
-func applyPIDSCgroupInfo(info *SysInfo, _ map[string]string) []string {
+func applyPIDSCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
 	var warnings []string
-	_, err := cgroups.FindCgroupMountpoint("", "pids")
-	if err != nil {
-		warnings = append(warnings, err.Error())
+	_, ok := cgMounts["pids"]
+	if !ok {
+		warnings = append(warnings, "Unable to find pids cgroup in mounts")
 		return warnings
 	}
 	info.PidsLimit = true


### PR DESCRIPTION
backporting the first commit from https://github.com/moby/moby/pull/41014. The second commit didn't apply clean, and (while trivial to resolve), I decided not to backport that as it only updated some comments.

> For some reason, commit 69cf03700fed7 chose not to use information
> already fetched, and called cgroups.FindCgroupMountpoint() instead.
> This is not a cheap call, as it has to parse the whole nine yards
> of /proc/self/mountinfo, and the info which it tries to get (whether
> the pids controller is present) is already available from cgMounts map.

