### PR TITLE
solved the issue “restoring container from a custom checkpoint-dir is broken”

### DIFF
--- a/daemon/start.go
+++ b/daemon/start.go
@@ -115,11 +115,6 @@ func (daemon *Daemon) containerStart(container *container.Container, checkpoint 
 		return errdefs.Conflict(errors.New("container is marked for removal and cannot be started"))
 	}
 
-	if checkpointDir != "" {
-		// TODO(mlaventure): how would we support that?
-		return errdefs.Forbidden(errors.New("custom checkpointdir is not supported"))
-	}
-
 	// if we encounter an error during start we need to ensure that any other
 	// setup has been cleaned up properly
 	defer func() {


### PR DESCRIPTION
execute the command:
$ docker run -d --name looper2 --security-opt seccomp:unconfined busybox \
         /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'

$ docker checkpoint create --checkpoint-dir=/tmp looper2 checkpoint2

$ docker create --name looper-clone --security-opt seccomp:unconfined busybox \
         /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'

$ docker start --checkpoint-dir=/tmp --checkpoint=checkpoint2 looper-clone
report a error:
Error response from daemon: custom checkpointdir is not supported
To fix this error, I execute the command according to https://github.com/moby/moby/issues/37344 rst0git'answer added a "mv" command.
Then I restore container successfully.
I read related code and found this commit can fix this error, and I verified it on docker-ce version 19.03.4 on mips64el arch.

Signed-off-by: Xiaodong Liu <liuxiaodong@loongson.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

