### PR TITLE
don't set cpu.shares to 0 in OCI config.json

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -142,10 +142,11 @@ func getCPUResources(config containertypes.Resources) (*specs.LinuxCPU, error) {
 	if config.CPUShares < 0 {
 		return nil, fmt.Errorf("shares: invalid argument")
 	}
-	if config.CPUShares >= 0 {
+	if config.CPUShares > 0 {
 		shares := uint64(config.CPUShares)
 		cpu.Shares = &shares
 	}
+	// cpu.Shares is kept nil if config.CPUShares == 0
 
 	if config.CpusetCpus != "" {
 		cpu.Cpus = config.CpusetCpus


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Keep `cpu.shares` in OCI config.json to be unset if the value is zero.
Most OCI runtimes accept (and ignore) `cpu.shares` to be zero, but zero is not really a valid configuration.

ref: https://github.com/containers/crun/issues/383#issuecomment-636870693

**- How to verify it**
```console
$ docker run -d nginx:alpine  
c7f33aaaaf60b3b87056475694a383f30cdf1c5f65bcd23a74fcae8843a81274
$ jq .linux.resources.cpu < /run/docker/containerd/daemon/io.containerd.runtime.v2.task/moby/c7f33aaaaf60b3b87056475694a383f30cdf1c5f65bcd23a74fcae8843a81274/config.json 
{}
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
don't set cpu.shares to 0 in OCI config.json

**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
