### PR TITLE
doc: server API Correct ImagesCreate - platform parameter added in 1.32

### DIFF
--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -6238,6 +6238,11 @@ paths:
           in: "header"
           description: "A base64-encoded auth configuration. [See the authentication section for details.](#section/Authentication)"
           type: "string"
+        - name: "platform"
+          in: "query"
+          description: "Platform in the format os[/arch[/variant]]"
+          type: "string"
+          default: ""
       tags: ["Image"]
   /images/{name}/json:
     get:

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -6243,6 +6243,11 @@ paths:
           in: "header"
           description: "A base64-encoded auth configuration. [See the authentication section for details.](#section/Authentication)"
           type: "string"
+        - name: "platform"
+          in: "query"
+          description: "Platform in the format os[/arch[/variant]]"
+          type: "string"
+          default: ""
       tags: ["Image"]
   /images/{name}/json:
     get:

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -231,6 +231,7 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.32](https://docs.docker.com/engine/api/v1.32/) documentation
 
+* `POST /images/create` now accepts a `platform` parameter in the form of `os[/arch[/variant]]`.
 * `POST /containers/create` now accepts additional values for the
   `HostConfig.IpcMode` property. New values are `private`, `shareable`,
   and `none`.


### PR DESCRIPTION

**- What I did**

platform was added in 1.32 but only documented in 1.34.

**- How to verify it**

The client (cli/command/utils.go:AddPlatformFlag) and server code (api/server/router/image/image_routes.go) all refers to 1.32 as the starting API version for images/create having added the platform query parameter.

This backports the documentation from the 1.34 documentation back to 1.32/1.33

fixes: docker/docker.github.io#9305

**- How I did it**

Looked at the code.

**- Description for the changelog**

Corrected version history and v1.32/v1.33 API documentation to note the addition of platform parameter in POST /images/create.

**- A picture of a cute animal (not mandatory but encouraged)**

![2020-06-03-115516](https://user-images.githubusercontent.com/462287/83586967-2b172700-a591-11ea-8733-144ed35ac1c7.jpg)
