### PR TITLE
Fix potential ip overlap with node LB (method 2)

### DIFF
--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -349,6 +349,7 @@ func (c *containerAdapter) checkMounts() error {
 
 func (c *containerAdapter) start(ctx context.Context) error {
 	if err := c.checkMounts(); err != nil {
+		c.removeNetworks(ctx)
 		return err
 	}
 

--- a/daemon/cluster/executor/container/attachment.go
+++ b/daemon/cluster/executor/container/attachment.go
@@ -64,9 +64,7 @@ func (nc *networkAttacherController) Terminate(ctx context.Context) error {
 }
 
 func (nc *networkAttacherController) Remove(ctx context.Context) error {
-	// Try removing the network referenced in this task in case this
-	// task is the last one referencing it
-	return nc.adapter.removeNetworks(ctx)
+	return nil
 }
 
 func (nc *networkAttacherController) Close() error {

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -947,6 +947,14 @@ func (daemon *Daemon) tryDetachContainerFromClusterNetwork(network libnetwork.Ne
 			}
 		}
 	}
+	if daemon.clusterProvider != nil && network.Info().Dynamic() && !network.Info().Ingress() {
+		if err := daemon.DeleteManagedNetwork(network.ID()); err != nil {
+			var activeEndpointsError *libnetwork.ActiveEndpointsError
+			if !errors.As(err, &activeEndpointsError) {
+				logrus.WithError(err).Warnf("error deleting network %s", network.ID())
+			}
+		}
+	}
 	attributes := map[string]string{
 		"container": container.ID,
 	}

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/mount"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/testutil/daemon"
@@ -205,21 +206,26 @@ func ServiceWithPidsLimit(limit int64) ServiceSpecOpt {
 	}
 }
 
-// ServiceWithRestartAttempts sets the RestartAttempts option of the service's ContainerSpec.
-func ServiceWithRestartAttempts(n uint64) ServiceSpecOpt {
+// ServiceWithRestartPolicy sets the RestartPolicy option of the service's ContainerSpec.
+func ServiceWithRestartPolicy(restartPolicy *swarmtypes.RestartPolicy) ServiceSpecOpt {
 	return func(spec *swarmtypes.ServiceSpec) {
-		attempts := new(uint64)
-		*attempts = n
-		restartPolicy := swarmtypes.RestartPolicy{MaxAttempts: attempts}
-		spec.TaskTemplate.RestartPolicy = &restartPolicy
+		spec.TaskTemplate.RestartPolicy = restartPolicy
 	}
 }
 
-// ServiceWithHealthCheck sets the health-check option of the service's ContainerSpec.
+// ServiceWithHealthCheck sets the HealthCheck option of the service's ContainerSpec.
 func ServiceWithHealthCheck(healthConfig *container.HealthConfig) ServiceSpecOpt {
 	return func(spec *swarmtypes.ServiceSpec) {
 		ensureContainerSpec(spec)
 		spec.TaskTemplate.ContainerSpec.Healthcheck = healthConfig
+	}
+}
+
+// ServiceWithMount sets the mount option of the service's ContainerSpec.
+func ServiceWithMount(m []mount.Mount) ServiceSpecOpt {
+	return func(spec *swarmtypes.ServiceSpec) {
+		ensureContainerSpec(spec)
+		spec.TaskTemplate.ContainerSpec.Mounts = m
 	}
 }
 

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
@@ -201,6 +202,24 @@ func ServiceWithPidsLimit(limit int64) ServiceSpecOpt {
 	return func(spec *swarmtypes.ServiceSpec) {
 		ensureContainerSpec(spec)
 		spec.TaskTemplate.ContainerSpec.PidsLimit = limit
+	}
+}
+
+// ServiceWithRestartAttempts sets the RestartAttempts option of the service's ContainerSpec.
+func ServiceWithRestartAttempts(n uint64) ServiceSpecOpt {
+	return func(spec *swarmtypes.ServiceSpec) {
+		attempts := new(uint64)
+		*attempts = n
+		restartPolicy := swarmtypes.RestartPolicy{MaxAttempts: attempts}
+		spec.TaskTemplate.RestartPolicy = &restartPolicy
+	}
+}
+
+// ServiceWithHealthCheck sets the health-check option of the service's ContainerSpec.
+func ServiceWithHealthCheck(healthConfig *container.HealthConfig) ServiceSpecOpt {
+	return func(spec *swarmtypes.ServiceSpec) {
+		ensureContainerSpec(spec)
+		spec.TaskTemplate.ContainerSpec.Healthcheck = healthConfig
 	}
 }
 

--- a/integration/network/lb_cleanup_test.go
+++ b/integration/network/lb_cleanup_test.go
@@ -1,0 +1,183 @@
+package network // import "github.com/docker/docker/integration/network"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/integration/internal/network"
+	"github.com/docker/docker/integration/internal/swarm"
+	"github.com/docker/docker/testutil/daemon"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/poll"
+	"gotest.tools/v3/skip"
+)
+
+func pollSetting(config *poll.Settings) {
+	config.Timeout = 100 * time.Second
+	config.Delay = 100 * time.Millisecond
+	if runtime.GOARCH == "arm64" || runtime.GOARCH == "arm" {
+		config.Timeout = 500 * time.Second
+	}
+}
+
+func createService(t *testing.T, d *daemon.Daemon, cmd []string, net, serviceName string) (serviceID string) {
+	replicas := uint64(1)
+	serviceID = swarm.CreateService(t, d,
+		swarm.ServiceWithReplicas(replicas),
+		swarm.ServiceWithName(serviceName),
+		swarm.ServiceWithNetwork(net),
+		swarm.ServiceWithCommand(cmd),
+		swarm.ServiceWithRestartAttempts(uint64(1)),
+	)
+	return
+}
+
+func createServiceWithHealthCheck(t *testing.T, d *daemon.Daemon, cmd []string,
+	net, serviceName string, healthConfig *container.HealthConfig) (serviceID string) {
+	replicas := uint64(1)
+	serviceID = swarm.CreateService(t, d,
+		swarm.ServiceWithReplicas(replicas),
+		swarm.ServiceWithName(serviceName),
+		swarm.ServiceWithNetwork(net),
+		swarm.ServiceWithCommand(cmd),
+		swarm.ServiceWithRestartAttempts(uint64(1)),
+		swarm.ServiceWithHealthCheck(healthConfig),
+	)
+	return
+}
+
+func checkNetworkRemoved(ctx context.Context, t *testing.T, c *client.Client, net string) error {
+	// network removal is asynchronous, retry testing at most 30 secs.
+	for count := 0; count < 6; count++ {
+		time.Sleep(5 * time.Second)
+		nr, err := c.NetworkInspect(ctx, net, types.NetworkInspectOptions{})
+		assert.NilError(t, err)
+		if nr.Containers == nil {
+			return nil
+		}
+	}
+	return errors.New("assertNetworkRemoved failed")
+}
+
+func testNormalService(t *testing.T, d *daemon.Daemon, c *client.Client, net string) {
+	fmt.Println("Running testNormalService ...")
+	ctx := context.Background()
+	cmd := []string{"sleep", "3d"}
+	serviceID := createService(t, d, cmd, net, "testNormalService")
+	poll.WaitOn(t, swarm.RunningTasksCount(c, serviceID, uint64(1)), pollSetting)
+	err := c.ServiceRemove(ctx, serviceID)
+	assert.NilError(t, err)
+	err = checkNetworkRemoved(ctx, t, c, net)
+	assert.NilError(t, err)
+}
+
+func testStartServiceFail(t *testing.T, d *daemon.Daemon, c *client.Client, net string) {
+	fmt.Println("Running testStartServiceFail ...")
+	ctx := context.Background()
+	cmd := []string{"non-existing-file"}
+	serviceID := createService(t, d, cmd, net, "testStartServiceFail")
+	poll.WaitOn(t, swarm.FailedTasksCount(c, serviceID, uint64(2)), pollSetting)
+	err := checkNetworkRemoved(ctx, t, c, net)
+	assert.NilError(t, err)
+	err = c.ServiceRemove(ctx, serviceID)
+	assert.NilError(t, err)
+}
+
+func testServiceCompletion(t *testing.T, d *daemon.Daemon, c *client.Client, net string) {
+	fmt.Println("Running testServiceCompletion ...")
+	ctx := context.Background()
+	cmd := []string{"true"}
+	serviceID := createService(t, d, cmd, net, "testServiceCompletion")
+	poll.WaitOn(t, swarm.CompletedTasksCount(c, serviceID, uint64(2)), pollSetting)
+	err := checkNetworkRemoved(ctx, t, c, net)
+	assert.NilError(t, err)
+	err = c.ServiceRemove(ctx, serviceID)
+	assert.NilError(t, err)
+}
+
+func testServiceExitFail(t *testing.T, d *daemon.Daemon, c *client.Client, net string) {
+	fmt.Println("Running testServiceExitFail ...")
+	ctx := context.Background()
+	cmd := []string{"false"}
+	serviceID := createService(t, d, cmd, net, "testServiceExitFail")
+	poll.WaitOn(t, swarm.FailedTasksCount(c, serviceID, uint64(2)), pollSetting)
+	err := checkNetworkRemoved(ctx, t, c, net)
+	assert.NilError(t, err)
+	err = c.ServiceRemove(ctx, serviceID)
+	assert.NilError(t, err)
+}
+
+func testServiceHealthCheckFail(t *testing.T, d *daemon.Daemon, c *client.Client, net string) {
+	fmt.Println("Running testServiceHealthCheckFail ...")
+	ctx := context.Background()
+	cmd := []string{"sleep", "3d"}
+	healthConfig := container.HealthConfig{
+		Test:        []string{"CMD-SHELL", "false"},
+		Interval:    time.Second,
+		Timeout:     time.Second,
+		StartPeriod: time.Second,
+		Retries:     1,
+	}
+	serviceID := createServiceWithHealthCheck(t, d, cmd, net, "testServiceHealthCheckFail", &healthConfig)
+	poll.WaitOn(t, swarm.FailedTasksCount(c, serviceID, uint64(2)), pollSetting)
+	err := checkNetworkRemoved(ctx, t, c, net)
+	assert.NilError(t, err)
+	err = c.ServiceRemove(ctx, serviceID)
+	assert.NilError(t, err)
+}
+
+func testServiceHealthCheckExitEarly(t *testing.T, d *daemon.Daemon, c *client.Client, net string) {
+	fmt.Println("Running testServiceHealthCheckExitEarly ...")
+	ctx := context.Background()
+	cmd := []string{"sleep", "1s"}
+	healthConfig := container.HealthConfig{
+		Test:        []string{"CMD-SHELL", "false"},
+		Interval:    time.Second,
+		Timeout:     time.Second,
+		StartPeriod: time.Second,
+		Retries:     3,
+	}
+	serviceID := createServiceWithHealthCheck(t, d, cmd, net, "testServiceHealthCheckExitEarly", &healthConfig)
+	poll.WaitOn(t, swarm.CompletedTasksCount(c, serviceID, uint64(2)), pollSetting)
+	err := checkNetworkRemoved(ctx, t, c, net)
+	assert.NilError(t, err)
+	err = c.ServiceRemove(ctx, serviceID)
+	assert.NilError(t, err)
+}
+
+func TestNodeLBCleanup(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows")
+	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support Swarm-mode")
+	defer setupTest(t)()
+	d := swarm.NewSwarm(t, testEnv)
+	defer d.Stop(t)
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	ctx := context.Background()
+
+	// create an overlay network
+	net := "ol_" + t.Name()
+	netID := network.CreateNoError(ctx, t, c, net,
+		network.WithDriver("overlay"))
+
+	testNormalService(t, d, c, net)
+	testStartServiceFail(t, d, c, net)
+	testServiceCompletion(t, d, c, net)
+	testServiceExitFail(t, d, c, net)
+	testServiceHealthCheckFail(t, d, c, net)
+	testServiceHealthCheckExitEarly(t, d, c, net)
+
+	err := c.NetworkRemove(ctx, netID)
+	assert.NilError(t, err)
+	err = d.SwarmLeave(t, true)
+	assert.NilError(t, err)
+
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes #40989

Signed-off-by: Xinfeng Liu xinfeng.liu@gmail.com

**- What I did**
Call network removal for overlay network on container exit.

**- How I did it**
   - Add network removal code to `tryDetachContainerFromClusterNetwork()` in
    `daemon/container_operations.go` to make sure network removal on overlay
    nework is called when container exits.  Also for swarmkit controller, we don't have to worry network removal in task shutdown.

  - ~~Add network removal for task container startup failure.~~
    _Update_: when task container fails to startup, the `CleanUp()` in `daemon/start.go` will also be called, so the network removal will be called too.  
    
   - Add task shutdown codes in a few other places where task container should not continue to run.

  - Add `removeNetworks()` in `Prepare()` of `daemon/cluster/executor/container/controller.go`.

  - Bring over PR 41011 to make an integrated fix.

**- How to verify it**
Added test cases in CI.
- test NormalService
- test ServiceStartFail
- test ServiceCompletion
- test ServiceExitFail
- test ServiceHealthCheckFail
- test ServiceHealthCheckExitEarly
- test ServiceInvalidMount

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix potential IP overlapping with node LB when container exits itself or container creation/startup fails.

**- A picture of a cute animal (not mandatory but encouraged)**

