### PR TITLE
test-integration: support cgroup2

### DIFF
--- a/hack/dind
+++ b/hack/dind
@@ -25,6 +25,17 @@ if ! mountpoint -q /tmp; then
 	mount -t tmpfs none /tmp
 fi
 
+# cgroup v2: enable nesting
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+	# move the init process (PID 1) from the root group to the /init group,
+	# otherwise writing subtree_control fails with EBUSY.
+	mkdir -p /sys/fs/cgroup/init
+	echo 1 > /sys/fs/cgroup/init/cgroup.procs
+	# enable controllers
+	sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
+		> /sys/fs/cgroup/cgroup.subtree_control
+fi
+
 if [ $# -gt 0 ]; then
 	exec "$@"
 fi

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -64,6 +64,13 @@ if [ "$DOCKER_EXPERIMENTAL" ]; then
 fi
 
 dockerd="dockerd"
+if [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
+	if [ -z "$TEST_SKIP_INTEGRATION_CLI" ]; then
+		echo >&2 '# cgroup v2 requires TEST_SKIP_INTEGRATION_CLI to be set'
+		exit 1
+	fi
+fi
+
 if [ -n "$DOCKER_ROOTLESS" ]; then
 	if [ -z "$TEST_SKIP_INTEGRATION_CLI" ]; then
 		echo >&2 '# DOCKER_ROOTLESS requires TEST_SKIP_INTEGRATION_CLI to be set'

--- a/integration/container/run_cgroupns_linux_test.go
+++ b/integration/container/run_cgroupns_linux_test.go
@@ -69,6 +69,7 @@ func TestCgroupNamespacesRunPrivileged(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	skip.If(t, testEnv.IsRemoteDaemon())
 	skip.If(t, !requirement.CgroupNamespacesEnabled())
+	skip.If(t, testEnv.DaemonInfo.CgroupVersion == "2", "on cgroup v2, privileged containers use private cgroupns")
 
 	// When the daemon defaults to private cgroup namespaces, privileged containers
 	// launched should not be inside their own cgroup namespaces


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

added cgroup2 support for `make integration`.

We don't have actual CI instances yet. (Can we use Fedora 32 Vagrant on either GH actions as in containerd or on Travis as in runc? )

**- How I did it**
* Modified `hack/dind` to initialize nested controllers.
* Updated integration tests to refer cgroup v2 paths.

**- How to verify it**
Tests are passing on Ubuntu 20.04 with:
`DOCKER_BUILD_ARGS="--build-arg CONTAINERD_COMMIT=bf672cccee2a0baf4720ec534a738f6003c0e5a7 --build-arg RUNC_COMMIT=0fa097fc37c5d89e4cea4fda4663d1239e12a6fe" DOCKER_EXPERIMENTAL=1 TEST_SKIP_INTEGRATION_CLI=1 make test-integration
`

Depends on containerd master (v1.4) and runc master (v1.0.0-rc91).

Currently `TEST_SKIP_INTEGRATION_CLI=1` must be specified.

**- A picture of a cute animal (not mandatory but encouraged)**

:penguin:

