### PR TITLE
api/types: remove errdefs dependency

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -30,7 +30,7 @@ func (n *networkRouter) getNetworksList(ctx context.Context, w http.ResponseWrit
 	}
 
 	if err := network.ValidateFilters(filter); err != nil {
-		return err
+		return errdefs.InvalidParameter(err)
 	}
 
 	var list []types.NetworkResource

--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -1,7 +1,6 @@
 package network // import "github.com/docker/docker/api/types/network"
 import (
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/errdefs"
 )
 
 // Address represents an IP address
@@ -123,5 +122,5 @@ var acceptedFilters = map[string]bool{
 
 // ValidateFilters validates the list of filter args with the available filters.
 func ValidateFilters(filter filters.Args) error {
-	return errdefs.InvalidParameter(filter.Validate(acceptedFilters))
+	return filter.Validate(acceptedFilters)
 }


### PR DESCRIPTION
This prevents projects that import only the api/types package from
also having to use the errdefs package (and because of that, containerd)
as a dependency.

Relates to https://github.com/moby/libnetwork/pull/2561 and https://github.com/moby/libnetwork/pull/2559#discussion_r434545503 
