### PR TITLE
int/build/TestBuildWithEmptyLayers: prevent panic

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -378,7 +378,7 @@ RUN cat somefile`
 
 	imageIDs, err := getImageIDsFromBuild(out.Bytes())
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal(3, len(imageIDs)))
+	assert.Assert(t, is.Equal(3, len(imageIDs)))
 
 	image, _, err := apiclient.ImageInspectWithRaw(context.Background(), imageIDs[2])
 	assert.NilError(t, err)


### PR DESCRIPTION
The test case panics like that (from https://github.com/moby/moby/pull/41030#issuecomment-638800101):

> build_test.go:381: assertion failed: 3 (int) != 1 (int)
> panic: runtime error: index out of range [2] with length 1 [recovered]
> panic: runtime error: index out of range [2] with length 1

The fix is trivial.