### PR TITLE
cgroup2: unshare cgroupns by default regardless to API version

### DIFF
--- a/api/server/router/container/container.go
+++ b/api/server/router/container/container.go
@@ -10,13 +10,15 @@ type containerRouter struct {
 	backend Backend
 	decoder httputils.ContainerDecoder
 	routes  []router.Route
+	cgroup2 bool
 }
 
 // NewRouter initializes a new container router
-func NewRouter(b Backend, decoder httputils.ContainerDecoder) router.Router {
+func NewRouter(b Backend, decoder httputils.ContainerDecoder, cgroup2 bool) router.Router {
 	r := &containerRouter{
 		backend: b,
 		decoder: decoder,
+		cgroup2: cgroup2,
 	}
 	r.initRoutes()
 	return r

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -497,8 +497,8 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 			hostConfig.IpcMode = container.IpcMode("shareable")
 		}
 	}
-	if hostConfig != nil && versions.LessThan(version, "1.41") {
-		// Older clients expect the default to be "host"
+	if hostConfig != nil && versions.LessThan(version, "1.41") && !s.cgroup2 {
+		// Older clients expect the default to be "host" on cgroup v1 hosts
 		if hostConfig.CgroupnsMode.IsEmpty() {
 			hostConfig.CgroupnsMode = container.CgroupnsMode("host")
 		}

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -462,7 +462,7 @@ func initRouter(opts routerOptions) {
 	routers := []router.Router{
 		// we need to add the checkpoint router before the container router or the DELETE gets masked
 		checkpointrouter.NewRouter(opts.daemon, decoder),
-		container.NewRouter(opts.daemon, decoder),
+		container.NewRouter(opts.daemon, decoder, opts.daemon.RawSysInfo(true).CgroupUnified),
 		image.NewRouter(opts.daemon.ImageService()),
 		systemrouter.NewRouter(opts.daemon, opts.cluster, opts.buildkit, opts.features),
 		volume.NewRouter(opts.daemon.VolumesService()),


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix #41071

[cgroup2 mode sets `cgroupns=private` by default ](https://github.com/moby/moby/blob/fa38a6cd21fec539066a2e3429b98b33f6427dfe/cmd/dockerd/config_unix.go#L68-L72]), but the default was overridden to `host` when API < 1.41.


**- How to verify it**

```console
$ sudo ls -l /proc/1/ns/cgroup
lrwxrwxrwx 1 root root 0 Jun  5 18:04 /proc/1/ns/cgroup -> 'cgroup:[4026531835]'
$ DOCKER_API_VERSION=1.40 docker run --rm alpine ls -l /proc/1/ns/cgroup
lrwxrwxrwx    1 root     root             0 Jun  5 09:04 /proc/1/ns/cgroup -> cgroup:[4026532639]
```

**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
