### PR TITLE
Fix syslog empty lines

### DIFF
--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/image"
+	layerpkg "github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/containerfs"
@@ -153,7 +154,19 @@ func (b *Builder) exportImage(state *dispatchState, layer builder.RWLayer, paren
 	}
 
 	state.imageID = exportedImage.ImageID()
-	b.imageSources.Add(newImageMount(exportedImage, newLayer), platform)
+
+	// if new layer is empty, next build stage should base on the parent layer #40591
+	if layerpkg.IsEmpty(newLayer.DiffID()) {
+		parentImageMount, err := b.imageSources.Get(parentImage.ImageID(), true, b.platform)
+		if err != nil {
+			return errors.Wrap(err, "failed to get parent image mount")
+		}
+		parentLayer := parentImageMount.layer
+		b.imageSources.Add(newImageMount(exportedImage, parentLayer), platform)
+	} else {
+		b.imageSources.Add(newImageMount(exportedImage, newLayer), platform)
+	}
+
 	return nil
 }
 

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -132,6 +132,10 @@ func New(info logger.Info) (logger.Logger, error) {
 }
 
 func (s *syslogger) Log(msg *logger.Message) error {
+	if len(msg.Line) == 0 {
+		return nil
+	}
+
 	line := string(msg.Line)
 	source := msg.Source
 	logger.PutMessage(msg)

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -643,6 +643,37 @@ func TestBuildPlatformInvalid(t *testing.T) {
 	assert.Assert(t, errdefs.IsInvalidParameter(err))
 }
 
+// Test case in #40591
+func TestBuildWithCopyEmptyDir(t *testing.T) {
+	dockerfile := `
+                FROM    busybox
+                COPY    emptydir /var
+                COPY    dir /opt
+        `
+	ctx := context.Background()
+	source := fakecontext.New(t, "",
+		fakecontext.WithDockerfile(dockerfile),
+		fakecontext.WithDir("emptydir"),
+		fakecontext.WithFile("dir/emptydirtest", "emptydirtest"))
+	defer source.Close()
+
+	apiclient := testEnv.APIClient()
+	resp, err := apiclient.ImageBuild(ctx,
+		source.AsTarReader(t),
+		types.ImageBuildOptions{
+			Remove:      true,
+			ForceRemove: true,
+			NoCache:     true,
+		})
+	assert.NilError(t, err)
+
+	out := bytes.NewBuffer(nil)
+	_, err = io.Copy(out, resp.Body)
+	resp.Body.Close()
+	assert.NilError(t, err)
+	assert.Check(t, is.Contains(out.String(), "Successfully built"))
+}
+
 func writeTarRecord(t *testing.T, w *tar.Writer, fn, contents string) {
 	err := w.WriteHeader(&tar.Header{
 		Name:     fn,

--- a/testutil/fakecontext/context.go
+++ b/testutil/fakecontext/context.go
@@ -78,6 +78,13 @@ func WithBinaryFiles(files map[string]*bytes.Buffer) func(*Fake) error {
 	}
 }
 
+// WithDir adds an empty directory in the build context
+func WithDir(dir string) func(*Fake) error {
+	return func(ctx *Fake) error {
+		return ctx.addDir(dir)
+	}
+}
+
 // Fake creates directories that can be used as a build context
 type Fake struct {
 	Dir string
@@ -98,6 +105,11 @@ func (f *Fake) addFile(file string, content []byte) error {
 	}
 	return ioutil.WriteFile(fp, content, 0644)
 
+}
+
+func (f *Fake) addDir(dir string) error {
+	fp := filepath.Join(f.Dir, filepath.FromSlash(dir))
+	return os.Mkdir(fp, 0755)
 }
 
 // Delete a file at a path


### PR DESCRIPTION
**- What I did**
This is a trivial fix for #41010 

**- How I did it**
add empty check and return directly 
```
func (s *syslogger) Log(msg *logger.Message) error {
	if len(msg.Line) == 0 {
		return nil
	}
```

