### PR TITLE
Fixes #41010 skip empty lines

### DIFF
--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -132,6 +132,10 @@ func New(info logger.Info) (logger.Logger, error) {
 }
 
 func (s *syslogger) Log(msg *logger.Message) error {
+	if len(msg.Line) == 0 {
+		return nil
+	}
+
 	line := string(msg.Line)
 	source := msg.Source
 	logger.PutMessage(msg)


### PR DESCRIPTION
**- What I did**
This is a trivial fix for #41010 

**- How I did it**
add empty check and return directly 
```
func (s *syslogger) Log(msg *logger.Message) error {
	if len(msg.Line) == 0 {
		return nil
	}
```
