### PR TITLE
[19.03 backport] allocateNetwork: fix network sandbox not cleaned up on failure

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -509,7 +509,7 @@ func (daemon *Daemon) updateContainerNetworkSettings(container *container.Contai
 	}
 }
 
-func (daemon *Daemon) allocateNetwork(container *container.Container) error {
+func (daemon *Daemon) allocateNetwork(container *container.Container) (retErr error) {
 	start := time.Now()
 	controller := daemon.netController
 
@@ -577,7 +577,7 @@ func (daemon *Daemon) allocateNetwork(container *container.Container) error {
 			}
 			updateSandboxNetworkSettings(container, sb)
 			defer func() {
-				if err != nil {
+				if retErr != nil {
 					sb.Delete()
 				}
 			}()


### PR DESCRIPTION
partial backport (only the first commit) of https://github.com/moby/moby/pull/41020


The defer function was checking for the local `err` variable, not on the error that was returned by the function. As a result, the sandbox would never be cleaned up for containers that used "none" networking, and a failiure occured during setup.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

