### PR TITLE
info: add warnings about missing blkio cgroup support

### DIFF
--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -124,6 +124,25 @@ func (daemon *Daemon) fillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) 
 		if v.CgroupVersion == "2" {
 			v.Warnings = append(v.Warnings, "WARNING: Support for cgroup v2 is experimental")
 		}
+		// TODO add fields for these options in types.Info
+		if !sysInfo.BlkioWeight {
+			v.Warnings = append(v.Warnings, "WARNING: No blkio weight support")
+		}
+		if !sysInfo.BlkioWeightDevice {
+			v.Warnings = append(v.Warnings, "WARNING: No blkio weight_device support")
+		}
+		if !sysInfo.BlkioReadBpsDevice {
+			v.Warnings = append(v.Warnings, "WARNING: No blkio throttle.read_bps_device support")
+		}
+		if !sysInfo.BlkioWriteBpsDevice {
+			v.Warnings = append(v.Warnings, "WARNING: No blkio throttle.write_bps_device support")
+		}
+		if !sysInfo.BlkioReadIOpsDevice {
+			v.Warnings = append(v.Warnings, "WARNING: No blkio throttle.read_iops_device support")
+		}
+		if !sysInfo.BlkioWriteIOpsDevice {
+			v.Warnings = append(v.Warnings, "WARNING: No blkio throttle.write_iops_device support")
+		}
 	}
 	if !v.IPv4Forwarding {
 		v.Warnings = append(v.Warnings, "WARNING: IPv4 forwarding is disabled")


### PR DESCRIPTION
These warnings were only logged, and could therefore be overlooked by users. This patch makes these more visible by returning them as warnings in the API response.

We should probably consider adding "boolean" (?) fields for these as well, so that they can be consumed in other ways. In addition, some of these warnings could potentially be grouped to reduce the number of warnings that are printed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

