### PR TITLE
[19.03 backport] int-cli/TestRunInvalidCPUShares: fix for newer runc

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -765,7 +765,7 @@ func (s *DockerSuite) TestRunInvalidCPUShares(c *testing.T) {
 	testRequires(c, cpuShare, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "--cpu-shares", "1", "busybox", "echo", "test")
 	assert.ErrorContains(c, err, "", out)
-	expected := "The minimum allowed cpu-shares is 2"
+	expected := "minimum allowed cpu-shares is 2"
 	assert.Assert(c, strings.Contains(out, expected))
 
 	out, _, err = dockerCmdWithError("run", "--cpu-shares", "-1", "busybox", "echo", "test")
@@ -775,7 +775,7 @@ func (s *DockerSuite) TestRunInvalidCPUShares(c *testing.T) {
 
 	out, _, err = dockerCmdWithError("run", "--cpu-shares", "99999999", "busybox", "echo", "test")
 	assert.ErrorContains(c, err, "", out)
-	expected = "The maximum allowed cpu-shares is"
+	expected = "maximum allowed cpu-shares is"
 	assert.Assert(c, strings.Contains(out, expected))
 }
 


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/41085 for the 19.03 branch

A newer runc changed [1] a couple of certain error messages checked in this

test to be lowercased, which lead to a mismatch in this test case.

Fix is to remove "The" (which was replaced with "the").

[1] https://github.com/opencontainers/runc/pull/2441

