### PR TITLE
Fix windows log file rotation with readers

### DIFF
--- a/daemon/logger/loggerutils/file_unix.go
+++ b/daemon/logger/loggerutils/file_unix.go
@@ -7,3 +7,7 @@ import "os"
 func openFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 	return os.OpenFile(name, flag, perm)
 }
+
+func open(name string) (*os.File, error) {
+	return os.Open(name)
+}

--- a/daemon/logger/loggerutils/file_windows.go
+++ b/daemon/logger/loggerutils/file_windows.go
@@ -8,6 +8,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+func open(name string) (*os.File, error) {
+	return openFile(name, os.O_RDONLY, 0)
+}
+
 func openFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 	if name == "" {
 		return nil, &os.PathError{Op: "open", Path: name, Err: syscall.ENOENT}

--- a/daemon/logger/loggerutils/file_windows.go
+++ b/daemon/logger/loggerutils/file_windows.go
@@ -4,8 +4,6 @@ import (
 	"os"
 	"syscall"
 	"unsafe"
-
-	"github.com/pkg/errors"
 )
 
 func open(name string) (*os.File, error) {
@@ -18,7 +16,7 @@ func openFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 	}
 	h, err := syscallOpen(fixLongPath(name), flag|syscall.O_CLOEXEC, syscallMode(perm))
 	if err != nil {
-		return nil, errors.Wrap(err, "error opening file")
+		return nil, &os.PathError{Op: "open", Path: name, Err: err}
 	}
 	return os.NewFile(uintptr(h), name), nil
 }


### PR DESCRIPTION
This fixes the case where log rotation fails on Windows while there are
clients reading container logs.

Fixes https://github.com/moby/moby/issues/40999
