### PR TITLE
Update busybox-static

### DIFF
--- a/contrib/mkimage/busybox-static
+++ b/contrib/mkimage/busybox-static
@@ -2,6 +2,7 @@
 set -e
 
 rootfsDir="$1"
+[ "$rootfsDir" = "/" ] && exit 5  # prevent erasure of your working system....
 shift
 
 busybox="$(which busybox 2> /dev/null || true)"
@@ -17,17 +18,17 @@ if ! ldd "$busybox" 2>&1 | grep -q 'not a dynamic executable'; then
 fi
 
 mkdir -p "$rootfsDir/bin"
-rm -f "$rootfsDir/bin/busybox" # just in case
+# rm -f "$rootfsDir/bin/busybox" # uncomment if u dont trust unclean directory.... just in case
 cp "$busybox" "$rootfsDir/bin/busybox"
 
 (
 	cd "$rootfsDir"
 
 	IFS=$'\n'
-	modules=($(bin/busybox --list-modules))
+	modules=$((bin/busybox --list-modules))
 	unset IFS
-
-	for module in "${modules[@]}"; do
+	cd ./bin 
+	for module in "${modules}"; do
 		mkdir -p "$(dirname "$module")"
 		ln -sf /bin/busybox "$module"
 	done


### PR DESCRIPTION
list busybox modules statement does not work. fixed.
prevent script from running if $1 = / 
comment out rm -rf statement. it is dangerous...... 
cd into bin directory  to get the links in the bin directory, not the current work directory. this error results in a non working image...
removed [ ], they cause links to be created with no function... (?)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: rens groenewegen <rens.groenewegen@xs4all.nl>