### PR TITLE
Adjust StdCopy so that it can handle headless streams(Previous commit branch error, now resubmit from master branch)

### DIFF
--- a/pkg/stdcopy/stdcopy.go
+++ b/pkg/stdcopy/stdcopy.go
@@ -81,7 +81,7 @@ func NewStdWriter(w io.Writer, t StdType) io.Writer {
 	}
 }
 
-// StdCopy is a modified version of io.Copy.
+// StdCopy is a modified version of io.Copy.(When the container turns on the tty, StdCopy and io.Copy() are the same function)
 //
 // StdCopy will demultiplex `src`, assuming that it contains two streams,
 // previously multiplexed together using a StdWriter instance.
@@ -91,6 +91,8 @@ func NewStdWriter(w io.Writer, t StdType) io.Writer {
 // In other words: if `err` is non nil, it indicates a real underlying error.
 //
 // `written` will hold the total number of bytes written to `dstout` and `dsterr`.
+//
+// when container turns on tty,StdCopy will not demultiplex `src`, direct copy of content to 'dstout'
 func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error) {
 	var (
 		buf       = make([]byte, startingBufLen)
@@ -135,7 +137,21 @@ func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error)
 			// to outstream if Systemerr is the stream
 			out = nil
 		default:
-			return 0, fmt.Errorf("Unrecognized input header: %d", buf[stdWriterFdIndex])
+			// If container turn on tty,it will come here
+			nw,ew = dstout.Write(buf)
+
+			if nil != ew {
+				return 0, ew
+			}
+
+			temNr,er :=  io.Copy(dstout,src)
+			if nil != er {
+				return 0, er
+			}
+
+			written = int64(nw) + temNr
+
+			return written, nil
 		}
 
 		// Retrieve the size of the frame
@@ -172,94 +188,6 @@ func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error)
 
 		// Write the retrieved frame (without header)
 		nw, ew = out.Write(buf[stdWriterPrefixLen : frameSize+stdWriterPrefixLen])
-		if ew != nil {
-			return 0, ew
-		}
-
-		// If the frame has not been fully written: error
-		if nw != frameSize {
-			return 0, io.ErrShortWrite
-		}
-		written += int64(nw)
-
-		// Move the rest of the buffer to the beginning
-		copy(buf, buf[frameSize+stdWriterPrefixLen:])
-		// Move the index
-		nr -= frameSize + stdWriterPrefixLen
-	}
-}
-
-// StdCopyMix is a modified version of io.Copy and it is different from StdCopy.
-// StdCopyMix is used for deserializing binary dockerlogs
-
-// As it reads from `src`, StdCopyMix will write to `dstout` only.
-//
-// StdCopyMix will read until it hits EOF on `src`. It will then return a nil error.
-// In other words: if `err` is non nil, it indicates a real underlying error.
-//
-// `written` will hold the total number of bytes written to `dstout` only.
-func StdCopyMix(dstout io.Writer, src io.Reader) (written int64, err error) {
-	var (
-		buf       = make([]byte, startingBufLen)
-		bufLen    = len(buf)
-		nr, nw    int
-		er, ew    error
-		frameSize int
-	)
-
-	for {
-		// Make sure we have at least a full header
-		for nr < stdWriterPrefixLen {
-			var nr2 int
-			nr2, er = src.Read(buf[nr:])
-			nr += nr2
-			if er == io.EOF {
-				if nr < stdWriterPrefixLen {
-					return written, nil
-				}
-				break
-			}
-			if er != nil {
-				return 0, er
-			}
-		}
-
-		stream := StdType(buf[stdWriterFdIndex])
-
-		// Retrieve the size of the frame
-		frameSize = int(binary.BigEndian.Uint32(buf[stdWriterSizeIndex : stdWriterSizeIndex+4]))
-
-		// Check if the buffer is big enough to read the frame.
-		// Extend it if necessary.
-		if frameSize+stdWriterPrefixLen > bufLen {
-			buf = append(buf, make([]byte, frameSize+stdWriterPrefixLen-bufLen+1)...)
-			bufLen = len(buf)
-		}
-
-		// While the amount of bytes read is less than the size of the frame + header, we keep reading
-		for nr < frameSize+stdWriterPrefixLen {
-			var nr2 int
-			nr2, er = src.Read(buf[nr:])
-			nr += nr2
-			if er == io.EOF {
-				if nr < frameSize+stdWriterPrefixLen {
-					return written, nil
-				}
-				break
-			}
-			if er != nil {
-				return 0, er
-			}
-		}
-
-		// we might have an error from the source mixed up in our multiplexed
-		// stream. if we do, return it.
-		if stream == Systemerr {
-			return written, fmt.Errorf("error from daemon in stream: %s", string(buf[stdWriterPrefixLen:frameSize+stdWriterPrefixLen]))
-		}
-
-		// Write the retrieved frame (without header)
-		nw, ew = dstout.Write(buf[stdWriterPrefixLen : frameSize+stdWriterPrefixLen])
 		if ew != nil {
 			return 0, ew
 		}

--- a/pkg/stdcopy/stdcopy_test.go
+++ b/pkg/stdcopy/stdcopy_test.go
@@ -114,6 +114,24 @@ func TestStdCopyWriteAndRead(t *testing.T) {
 	}
 }
 
+func TestStdCopyWriteAndReadTtyStream(t *testing.T) {
+	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
+	srcInput := new(bytes.Buffer)
+
+	writtenum, err := srcInput.Write(stdOutBytes)
+
+	t.Logf("write %d bytes",writtenum)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	written, err := StdCopy(ioutil.Discard, ioutil.Discard, srcInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Skipf("read %d bytes",written)
+}
+
 type customReader struct {
 	n            int
 	err          error


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
When we process container logs, most people will follow the example given in the official tutorial (for example: https://docs.docker.com/engine/api/sdk/examples/). This is effective in most cases. It uses the StdCopy function to distribute logs to dstout and dsterr, which seems to be a very cool feature.
However, when running the container with the -tty flag, StdCopy will not work properly. It will report "Unrecognized input header: xxx" (strictly speaking, this is not a bug). This is a very big doubt for beginners.

When we read the docker source code, we found that when tty:true, the source code is as follows: "outStream := io.Writer(wf) errStream := outStream", this is a stream without a head. When tty: false,The source code is as follows: "sysErrStream=stdcopy.NewStdWriter(outStream,stdcopy.Systemerr)
errStream=stdcopy.NewStdWriter(outStream, stdcopy.Stderr)", this is a stream with a header. After reading the source code, we can understand when to use StdCopy and when to use io.Copy. However, not everyone will read the source code. More people just call the API to complete their work.
Personally think that docker can provide a more compatible StdCopy for everyone to use, which is more friendly to beginners.
Therefore, I modified the StdCopy function, hoping that it can be compatible with the handling of container logs with tty flags turned on.

**- How I did it**
When parsing the head of the stream, determine whether StdType belongs to one of Stdin, Stdout, Stderr, and Systemerr. If it is one of them, shunt them. Otherwise, think of it as a stream without a header, copy the content directly to ‘dstdout’

**- How to verify it**
`
	
	package stdcopy // import "github.com/docker/docker/pkg/stdcopy"
	
	import (
		"bytes"
		"errors"
		"io"
		"io/ioutil"
		"strings"
		"testing"
	)

	func TestStdCopyWriteAndRead(t *testing.T) {
		stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
		stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
		buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
		if err != nil {
			t.Fatal(err)
		}
		written, err := StdCopy(ioutil.Discard, ioutil.Discard, buffer)
		if err != nil {
			t.Fatal(err)
		}
		expectedTotalWritten := len(stdOutBytes) + len(stdErrBytes)
		if written != int64(expectedTotalWritten) {
			t.Fatalf("Expected to have total of %d bytes written, got %d", expectedTotalWritten, written)
		}
	}
	
	func TestStdCopyWriteAndReadTtyStream(t *testing.T) {
		stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
		srcInput := new(bytes.Buffer)
	
		writtenum, err := srcInput.Write(stdOutBytes)
	
		t.Logf("write %d bytes",writtenum)
		if err != nil {
			t.Fatal(err)
		}
	
		written, err := StdCopy(ioutil.Discard, ioutil.Discard, srcInput)
		if err != nil {
			t.Fatal(err)
		}
		t.Skipf("read %d bytes",written)
	}
`
The above code is also written in the stdcopy_test.go file.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Enables StdCopy to handle both headed and headless streams

**- A picture of a cute animal (not mandatory but encouraged)**
![lovelybee](https://user-images.githubusercontent.com/11941914/84722678-77615e80-afb6-11ea-9664-1d4a5594fe92.jpg)

