### PR TITLE
daemon: use shim v2 by default

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1756,10 +1756,6 @@ func (daemon *Daemon) setupSeccompProfile() error {
 	return nil
 }
 
-func (daemon *Daemon) useShimV2() bool {
-	return cgroups.IsCgroup2UnifiedMode()
-}
-
 // RawSysInfo returns *sysinfo.SysInfo .
 func (daemon *Daemon) RawSysInfo(quiet bool) *sysinfo.SysInfo {
 	var opts []sysinfo.Opt

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -654,10 +654,6 @@ func (daemon *Daemon) initRuntimes(_ map[string]types.Runtime) error {
 func setupResolvConf(config *config.Config) {
 }
 
-func (daemon *Daemon) useShimV2() bool {
-	return true
-}
-
 // RawSysInfo returns *sysinfo.SysInfo .
 func (daemon *Daemon) RawSysInfo(quiet bool) *sysinfo.SysInfo {
 	return sysinfo.New(quiet)

--- a/daemon/start_unix.go
+++ b/daemon/start_unix.go
@@ -44,7 +44,7 @@ func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Contain
 	if err != nil {
 		return nil, err
 	}
-	if daemon.useShimV2() {
+	if !daemon.disableShimV2 {
 		opts := &v2runcoptions.Options{
 			BinaryName: path,
 			Root: filepath.Join(daemon.configStore.ExecRoot,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

containerd has three shim binaries:

* containerd-shim: implements shim API v1.
* containerd-shim-runc-v1: implements shim API v2. Introduced in containerd v1.2.
* containerd-shim-runc-v2: implements shim API v2. Introduced in containerd v1.3.

We have been using containerd-shim on cgroup v1 mode, containerd-shim-runc-v2 on cgroup v2 mode.

This commit changes the daemon to use containerd-shim-runc-v2 by default regardless to the cgroup mode.

To provide a workaround for potential regression issues, the daemon supports switching back to shim v1 mode via an env var `MOBY_DISABLE_SHIM_V2=1`.

The env var is only intended to be used as a workaround and is deprecated from its birth.
(So there is no daemon.json flag and no output in `docker info`)

The env var is discarded on cgroup v2 hosts, as shim v1 does not support cgroup v2.

Fix #41107

**- How I did it**
Updated `*Daemon.useShimV2()` to use shim v2 by default.

Requires containerd v1.3.0 or later. Using v1.3.5 or later is recommended. v1.3.0-v1.3.4 doesn't pass `TestContainerStartOnDaemonRestart` due to lack of https://github.com/containerd/containerd/pull/4329 .

**- How to verify it**
* Run some containers, and make sure `containerd-shim-runc-v2` processes are launched.
* Make sure it can be switched back to `containerd-shim` by launching `dockerd` with `MOBY_DISABLE_SHIM_V2=1`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
daemon: use shim v2 by default. Requires containerd v1.3.0 or later. Using v1.3.5 or later is recommended.

**- A picture of a cute animal (not mandatory but encouraged)**
🐧 
