### PR TITLE
[19.03] vendor: docker/libnetwork 026aabaa659832804b01754aaadd2c0f420c68b6 (bump_19.03 branch)

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: ${LIBNETWORK_COMMIT:=153d0769a1181bf591a9637fd487a541ec7db1e6} # bump_19.03 branch
+: ${LIBNETWORK_COMMIT:=026aabaa659832804b01754aaadd2c0f420c68b6} # bump_19.03 branch
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/gofrs/flock                              7f43ea2e6a643ad441fc12d0ecc0
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        153d0769a1181bf591a9637fd487a541ec7db1e6 # bump_19.03 branch
+github.com/docker/libnetwork                        026aabaa659832804b01754aaadd2c0f420c68b6 # bump_19.03 branch
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/setup_device.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/setup_device.go
@@ -63,7 +63,7 @@ func setupDefaultSysctl(config *networkConfiguration, i *bridgeInterface) error 
 		return nil
 	}
 	if err := ioutil.WriteFile(sysPath, []byte{'0', '\n'}, 0644); err != nil {
-		return fmt.Errorf("libnetwork: Unable to disable IPv6 router advertisement: %v", err)
+		logrus.WithError(err).Warn("unable to disable IPv6 router advertisement")
 	}
 	return nil
 }

--- a/vendor/github.com/docker/libnetwork/network.go
+++ b/vendor/github.com/docker/libnetwork/network.go
@@ -1181,7 +1181,8 @@ func (n *network) createEndpoint(name string, options ...EndpointOption) (Endpoi
 	ep.locator = n.getController().clusterHostID()
 	ep.network, err = ep.getNetworkFromStore()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get network during CreateEndpoint: %v", err)
+		logrus.Errorf("failed to get network during CreateEndpoint: %v", err)
+		return nil, err
 	}
 	n = ep.network
 

--- a/vendor/github.com/docker/libnetwork/store.go
+++ b/vendor/github.com/docker/libnetwork/store.go
@@ -103,8 +103,7 @@ func (c *controller) getNetworkFromStore(nid string) (*network, error) {
 		}
 		return n, nil
 	}
-
-	return nil, fmt.Errorf("network %s not found", nid)
+	return nil, ErrNoSuchNetwork(nid)
 }
 
 func (c *controller) getNetworksForScope(scope string) ([]*network, error) {


### PR DESCRIPTION
full diff: https://github.com/docker/libnetwork/compare/153d0769a1181bf591a9637fd487a541ec7db1e6...026aabaa659832804b01754aaadd2c0f420c68b6

-  https://github.com/docker/libnetwork/pull/2565 Fix 'failed to get network during CreateEndpoint'
    - backport of https://github.com/docker/libnetwork/pull/2554
    - addresses https://github.com/docker/for-linux/issues/888
    - possibly addresses https://github.com/moby/moby/issues/35288
    - possibly addresses https://github.com/moby/libnetwork/issues/2341
    - possibly addresses https://github.com/moby/libnetwork/issues/2015
- https://github.com/docker/libnetwork/pull/2567 log error instead if disabling IPv6 router advertisement failed
    - backport of https://github.com/docker/libnetwork/pull/2563
    - fixes https://github.com/docker/for-linux/issues/1033

Note that we may want to have the local changes from https://github.com/moby/moby/pull/41011 as well, but that one isn't merged yet on master


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

