### PR TITLE
Return container logs in string format

### DIFF
--- a/client/container_logs_test.go
+++ b/client/container_logs_test.go
@@ -149,6 +149,29 @@ func TestContainerLogs(t *testing.T) {
 	}
 }
 
+func TestContainerLogsString(t *testing.T) {
+	container := "container_id"
+	ctx := context.Background()
+
+	cli, err := NewClientWithOpts(FromEnv)
+	if err != nil {
+		log.Fatal(err)
+	}
+	cli.NegotiateAPIVersion(ctx)
+
+	temOption := types.ContainerLogsOptions{
+		ShowStdout:true,
+		ShowStderr:true,
+	}
+
+	logStr, err := cli.ContainerLogsString(ctx,container,temOption)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println(logStr)
+}
+
 func ExampleClient_ContainerLogs_withTimeout() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This interface returns the container log in string format. When we deal with container logs, we don't need to care about whether the container has a tty flag or no -tty flag, it can correctly return the logs in text form.
The purpose of this function is to simplify the call log interface and reduce the difficulty for beginners to learn container logs.

**- How I did it**
First, inside the ContainerLogsString() function, we need to determine whether the container has a tty flag. Here we need to call the ContainerIspect() function.
Secondly, according to the tty flag, different types of logs are processed in different ways. Container logs with a tty flag use io.copy() to directly copy the content to ‘stdout’.
For container logs without the tty flag, call stdcopy.StdCopy() to parse the logs to ‘stdout’.

**- How to verify it**
`

	package client // import "github.com/docker/docker/client"
	
	import (
		"bytes"
		"context"
		"fmt"
		"io"
		"io/ioutil"
		"log"
		"net/http"
		"os"
		"strings"
		"testing"
		"time"
	
		"github.com/docker/docker/api/types"
		"gotest.tools/assert"
		is "gotest.tools/assert/cmp"
	)

	func TestContainerLogsString(t *testing.T) {
		container := "container_id"
		ctx := context.Background()
	
		cli, err := NewClientWithOpts(FromEnv)
		if err != nil {
			log.Fatal(err)
		}
		cli.NegotiateAPIVersion(ctx)
	
		temOption := types.ContainerLogsOptions{
			ShowStdout:true,
			ShowStderr:true,
		}
	
		logStr, err := cli.ContainerLogsString(ctx,container,temOption)
		if err != nil {
			log.Fatal(err)
		}
	
		log.Println(logStr)
	}
`
The above code is also written in the container_logs_test.go file.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add an interface to get container logs as a string

**- A picture of a cute animal (not mandatory but encouraged)**
![sheep](https://user-images.githubusercontent.com/11941914/85004935-b6e0a400-b18a-11ea-91ed-b06bd21db32e.jpg)

