### PR TITLE
Enable client on netbsd and dragonfly

### DIFF
--- a/client/client_unix.go
+++ b/client/client_unix.go
@@ -1,4 +1,4 @@
-// +build linux freebsd openbsd darwin solaris illumos
+// +build linux freebsd openbsd netbsd darwin solaris illumos dragonfly
 
 package client // import "github.com/docker/docker/client"
 


### PR DESCRIPTION
**- What I did**

Enable the build of the client for NetBSD. This is required for the native integration of docker swarm in the Prometheus monitoring system. Backport to the stable release is appreciated, too.

**- Description for the changelog**

client: add support for NetBSD and dragonfly

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://www.starmate.fr/wp-content/uploads/2016/01/ssh.jpg)([source](https://www.starmate.fr/se-connecter-en-ssh-sans-demande-de-mot-de-passe/))
