### PR TITLE
[19.03] Enable build on Dragonfly/NetBSD

### DIFF
--- a/client/client_unix.go
+++ b/client/client_unix.go
@@ -1,4 +1,4 @@
-// +build linux freebsd openbsd darwin
+// +build linux freebsd openbsd netbsd darwin dragonfly
 
 package client // import "github.com/docker/docker/client"
 


### PR DESCRIPTION
**- What I did**

Enable build on Dragonfly/NetBSD as it is required by upcoming Swarm support in the prometheus monitoring system.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Enable building the client for Dragonfly/NetBSD


**- A picture of a cute animal (not mandatory but encouraged)**

![image](http://blog.usu.edu/behave/files/2014/10/Smart-sheep.jpg)([source](http://blog.usu.edu/behave/2014/10/20/barnyard-animal-furthers-cure-research-for-huntingtons-disease/))