### PR TITLE
Switch all Dockerfiles to use "buster" variant

### DIFF
--- a/Dockerfile.buildx
+++ b/Dockerfile.buildx
@@ -2,7 +2,7 @@ ARG GO_VERSION=1.13.12
 ARG BUILDX_COMMIT=v0.3.1
 ARG BUILDX_REPO=https://github.com/docker/buildx.git
 
-FROM golang:${GO_VERSION}-stretch AS build
+FROM golang:${GO_VERSION}-buster AS build
 ARG BUILDX_REPO
 RUN git clone "${BUILDX_REPO}" /buildx
 WORKDIR /buildx
@@ -21,6 +21,6 @@ RUN GOOS="${GOOS}" GOARCH="${GOARCH}" BUILDX_COMMIT="${BUILDX_COMMIT}"; \
     "; \
     go build -mod=vendor -ldflags "${ldflags}" -o /usr/bin/buildx ./cmd/buildx
 
-FROM golang:${GO_VERSION}-stretch
+FROM golang:${GO_VERSION}-buster
 COPY --from=build /usr/bin/buildx /usr/bin/buildx
 ENTRYPOINT ["/usr/bin/buildx"]

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -7,7 +7,7 @@
 
 ARG GO_VERSION=1.13.12
 
-FROM golang:${GO_VERSION}-stretch
+FROM golang:${GO_VERSION}-buster
 ENV GO111MODULE=off
 
 # allow replacing httpredir or deb mirror


### PR DESCRIPTION
Commit 4e3ab9e9fbca682f75eb350c8ad4312282869a03 (https://github.com/moby/moby/pull/39880) switched the main Dockerfile to the "buster" variant, but did not update some of the other Dockerfiles.

