### PR TITLE
fix gotestsum.installer installing wrong version

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -262,15 +262,12 @@ RUN `
 RUN `
   Function Build-GoTestSum() { `
     Write-Host "INFO: Building gotestsum version $Env:GOTESTSUM_COMMIT in $Env:GOPATH"; `
-    $env:GO111MODULE = 'on'; `
-    &go get -d "gotest.tools/gotestsum@${Env:GOTESTSUM_COMMIT}"; `
-    $env:GO111MODULE = 'off'; `
-    if ($LASTEXITCODE -ne 0) {  `
-      Throw '"Failed getting gotestsum sources..."'  `
-    }; `
-    $env:GO111MODULE = 'on'; `
-    &go build -buildmode=exe -o "${Env:GOPATH}\bin\gotestsum.exe" gotest.tools/gotestsum; `
-    $env:GO111MODULE = 'off'; `
+    $Env:GO111MODULE = 'on'; `
+    $tmpGobin = "${Env:GOBIN_TMP}"; `
+    $Env:GOBIN = """${Env:GOPATH}`\bin"""; `
+    &go get -buildmode=exe "gotest.tools/gotestsum@${Env:GOTESTSUM_COMMIT}"; `
+    $Env:GOBIN = "${tmpGobin}"; `
+    $Env:GO111MODULE = 'off'; `
     if ($LASTEXITCODE -ne 0) {  `
       Throw '"gotestsum build failed..."'; `
     } `

--- a/hack/dockerfile/install/gotestsum.installer
+++ b/hack/dockerfile/install/gotestsum.installer
@@ -5,5 +5,5 @@
 install_gotestsum() (
 	set -e
 	export GO111MODULE=on
-	GOBIN="${PREFIX}" go get ${GO_BUILDMODE} "gotest.tools/gotestsum@${GOTESTSUM_COMMIT}"
+	GOBIN="${PREFIX}" go get "gotest.tools/gotestsum@${GOTESTSUM_COMMIT}"
 )

--- a/hack/dockerfile/install/gotestsum.installer
+++ b/hack/dockerfile/install/gotestsum.installer
@@ -5,7 +5,5 @@
 install_gotestsum() (
 	set -e
 	export GO111MODULE=on
-	go get -d "gotest.tools/gotestsum@${GOTESTSUM_COMMIT}"
-	go build ${GO_BUILDMODE} -o "${PREFIX}/gotestsum" 'gotest.tools/gotestsum'
-
+	GOBIN="${PREFIX}" go get ${GO_BUILDMODE} "gotest.tools/gotestsum@${GOTESTSUM_COMMIT}"
 )


### PR DESCRIPTION
When using go modules, `go build` will always fetch the latest
version of the package, so ignores the version we previously `go get`'d.

Instead of running `go get` and `go build` separately, this patch uses
`go get` (without the `-d` option) to do it all in one step.

Given that this binary is only used for testing, and only used inside the
Dockerfile, we should consider inlining this step in the Dockerfile itself,
but keeping that separate for now.

