### PR TITLE
chrootarchive: fix "conversion from int to string yields a string of one rune"

### DIFF
--- a/pkg/chrootarchive/archive_test.go
+++ b/pkg/chrootarchive/archive_test.go
@@ -99,7 +99,8 @@ func TestChrootUntarWithHugeExcludesList(t *testing.T) {
 	// 65534 entries of 64-byte strings ~= 4MB of environment space which should overflow
 	// on most systems when passed via environment or command line arguments
 	excludes := make([]string, 65534)
-	for i := 0; i < 65534; i++ {
+	var i rune
+	for i = 0; i < 65534; i++ {
 		excludes[i] = strings.Repeat(string(i), 64)
 	}
 	options.ExcludePatterns = excludes


### PR DESCRIPTION
update test to fix go 1.15 linting failure:

    pkg/chrootarchive/archive_test.go:103:32: conversion from int to string yields a string of one rune

relates to golang/go 32479


