### PR TITLE
update containerd to v1.3.5

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=814b7956fafc7a0980ea07e950f983d0837e5578}" # v1.3.4
+: "${CONTAINERD_COMMIT:=9b6f3ec0307a825c38617b93ad55162b5bb94234}" # v1.3.5
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
Full diff https://github.com/containerd/containerd/compare/v1.3.4...v1.3.5

The fifth patch release for containerd 1.3 includes bug fixes related to clean-up of I/O and shim processes.

## Notable Updates
Cleanup allocated resources in case of a binary I/O error containerd/containerd#4278
Fix image usage calculation error containerd/containerd#4276
Make killing shims more resilient containerd/containerd#4307
shim v2 runc: propagate options.Root to Cleanup containerd/containerd#4329
Bump Golang 1.13.12 containerd/containerd#4337