### PR TITLE
Fix status code for missing --volumes-from container

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -95,12 +95,12 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 	for _, v := range hostConfig.VolumesFrom {
 		containerID, mode, err := parser.ParseVolumesFrom(v)
 		if err != nil {
-			return err
+			return errdefs.InvalidParameter(err)
 		}
 
 		c, err := daemon.GetContainer(containerID)
 		if err != nil {
-			return err
+			return errdefs.InvalidParameter(err)
 		}
 
 		for _, m := range c.MountPoints {

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -621,3 +621,18 @@ func TestCreateDifferentPlatform(t *testing.T) {
 		assert.Assert(t, client.IsErrNotFound(err), err)
 	})
 }
+
+func TestCreateVolumesFromNonExistingContainer(t *testing.T) {
+	defer setupTest(t)()
+	cli := testEnv.APIClient()
+
+	_, err := cli.ContainerCreate(
+		context.Background(),
+		&container.Config{Image: "busybox"},
+		&container.HostConfig{VolumesFrom: []string{"nosuchcontainer"}},
+		nil,
+		nil,
+		"",
+	)
+	assert.Check(t, errdefs.IsInvalidParameter(err))
+}


### PR DESCRIPTION
fixes https://github.com/docker/cli/issues/2594 "Misleading error when using --volumes-from DOESNOTEXIST, docker complains about the image"

If the container specified in `--volumes-from` did not exist, the
API returned a 404 status, which was interpreted by the CLI as the
specified _image_ to be missing (even if that was not the case).

This patch changes these error to return a 400 (bad request);

Before this change:

    # make sure the image is present
    docker pull busybox
    docker create --volumes-from=nosuchcontainer busybox
    # Unable to find image 'busybox:latest' locally
    # latest: Pulling from library/busybox
    # Digest: sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209
    # Status: Image is up to date for busybox:latest
    # Error response from daemon: No such container: nosuchcontainer

After this change:

    # make sure the image is present
    docker pull busybox
    docker create --volumes-from=nosuchcontainer busybox
    # Error response from daemon: No such container: nosuchcontainer


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
* Fix incorrect status code being returned by the API, leading to `docker run` and `docker create` triggering am image pull when using `--volumes-from` that's pointing to a non-existing container.
```

**- A picture of a cute animal (not mandatory but encouraged)**

