### PR TITLE
update containerd to v1.3.6

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=9b6f3ec0307a825c38617b93ad55162b5bb94234}" # v1.3.5
+: "${CONTAINERD_COMMIT:=be75852b8d7849474a20192f9ed1bf34fdd454f1}" # v1.3.6
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
Full diff https://github.com/containerd/containerd/compare/v1.3.5...v1.3.6

The sixth patch release for containerd 1.3 includes a release process fix to not require the latest libseccomp. Prior
releases in this series were pinned to libseccomp 2.3.3 and this update corrects the error in the v1.3.5 release which
linked to the latest libseccomp.

# Notable Updates
Pin libseccomp to 2.3.3 for the GH Actions-based release.yml containerd/containerd#4352

----
There are no substantive changes in this upgrade. :)
