### PR TITLE
Fix TestDockerPluginSuite/TestPluginInstallArgs nil panic

### DIFF
--- a/testutil/fixtures/plugin/plugin.go
+++ b/testutil/fixtures/plugin/plugin.go
@@ -91,6 +91,7 @@ func CreateInRegistry(ctx context.Context, repo string, auth *types.AuthConfig, 
 	}
 
 	var cfg Config
+	cfg.PluginConfig = &types.PluginConfig{}
 	for _, o := range opts {
 		o(&cfg)
 	}


### PR DESCRIPTION
fix #40932 the embedding *types.PluginConfig is nil

Signed-off-by: HuanHuan Ye <logindaveye@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix TestDockerPluginSuite/TestPluginInstallArgs panic

**- How I did it**
fix the embedding *types.PluginConfig is nil

**- How to verify it**
go test -v --run=TestDockerPluginSuite

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

