### PR TITLE
[19.03] vendor: buildkit dc6afa0f755f6cbb7e85f0df4ff4b87ec280cb32 (v0.6.4-15-gdc6afa0f)

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -26,7 +26,7 @@ github.com/imdario/mergo                            7c29201646fa3de8506f70121347
 golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af2b83e6acac3c
 
 # buildkit
-github.com/moby/buildkit                            a7d7b7f1e6bfc102810079f13212de6a869c494b # v0.6.4-11-ga7d7b7f1
+github.com/moby/buildkit                            dc6afa0f755f6cbb7e85f0df4ff4b87ec280cb32 # v0.6.4-15-gdc6afa0f
 github.com/tonistiigi/fsutil                        6c909ab392c173a4264ae1bfcbc0450b9aac0c7d
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7


### PR DESCRIPTION
full diff: https://github.com/moby/buildkit/compare/a7d7b7f1e6bfc102810079f13212de6a869c494b...dc6afa0f755f6cbb7e85f0df4ff4b87ec280cb32

- solver: avoid recursive loop on cache-export
    - fixes moby/buildkit#1336 --export-cache option crashes buildkitd on custom frontend
    - fixes moby/buildkit#1313 Dockerd / buildkit in a infinite loop and burning cpu
    - fixes moby/moby#41044 19.03.9 goroutine stack exceeds 1000000000-byte limit
    - fixes moby/moby#40993 Multistage docker build fails with unexpected EOF


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
- Builder Next: avoid recursive loop on cache-export
```

**- A picture of a cute animal (not mandatory but encouraged)**

