### PR TITLE
daemon/stats: use const for clockTicksPerSecond

### DIFF
--- a/daemon/stats/collector.go
+++ b/daemon/stats/collector.go
@@ -19,9 +19,6 @@ type Collector struct {
 	interval   time.Duration
 	publishers map[*container.Container]*pubsub.Publisher
 	bufReader  *bufio.Reader
-
-	// The following fields are not set on Windows currently.
-	clockTicksPerSecond uint64
 }
 
 // NewCollector creates a stats collector that will poll the supervisor with the specified interval
@@ -33,9 +30,6 @@ func NewCollector(supervisor supervisor, interval time.Duration) *Collector {
 		bufReader:  bufio.NewReaderSize(nil, 128),
 	}
 	s.cond = sync.NewCond(&s.m)
-
-	platformNewStatsCollector(s)
-
 	return s
 }
 

--- a/daemon/stats/collector_unix.go
+++ b/daemon/stats/collector_unix.go
@@ -8,17 +8,17 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/opencontainers/runc/libcontainer/system"
 	"golang.org/x/sys/unix"
 )
 
-// platformNewStatsCollector performs platform specific initialisation of the
-// Collector structure.
-func platformNewStatsCollector(s *Collector) {
-	s.clockTicksPerSecond = uint64(system.GetClockTicks())
-}
-
-const nanoSecondsPerSecond = 1e9
+const (
+	// The value comes from `C.sysconf(C._SC_CLK_TCK)`, and
+	// on Linux it's a constant which is safe to be hard coded,
+	// so we can avoid using cgo here. For details, see:
+	// https://github.com/containerd/cgroups/pull/12
+	clockTicksPerSecond  = 100
+	nanoSecondsPerSecond = 1e9
+)
 
 // getSystemCPUUsage returns the host system's cpu usage in
 // nanoseconds. An error is returned if the format of the underlying
@@ -59,7 +59,7 @@ func (s *Collector) getSystemCPUUsage() (uint64, error) {
 				totalClockTicks += v
 			}
 			return (totalClockTicks * nanoSecondsPerSecond) /
-				s.clockTicksPerSecond, nil
+				clockTicksPerSecond, nil
 		}
 	}
 	return 0, fmt.Errorf("invalid stat format. Error trying to parse the '/proc/stat' file")

--- a/daemon/stats/collector_windows.go
+++ b/daemon/stats/collector_windows.go
@@ -1,10 +1,5 @@
 package stats // import "github.com/docker/docker/daemon/stats"
 
-// platformNewStatsCollector performs platform specific initialisation of the
-// Collector structure. This is a no-op on Windows.
-func platformNewStatsCollector(s *Collector) {
-}
-
 // getSystemCPUUsage returns the host system's cpu usage in
 // nanoseconds. An error is returned if the format of the underlying
 // file does not match. This is a no-op on Windows.


### PR DESCRIPTION
See the discussion on https://github.com/moby/moby/pull/41178#discussion_r450124125

The value comes from `C.sysconf(C._SC_CLK_TCK)`, and on Linux it's a constant which is safe to be hard coded. See for example in the Musl libc source code https://git.musl-libc.org/cgit/musl/tree/src/conf/sysconf.c#n29

This removes the github.com/opencontainers/runc/libcontainer/system dependency from this package.

