### PR TITLE
vendor: libnetwork 9e99af28df21367340c95a3863e31808d689c92a

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: "${LIBNETWORK_COMMIT:=2e24aed516bd5c836e11378bb457dd612aa868ed}"
+: "${LIBNETWORK_COMMIT:=9e99af28df21367340c95a3863e31808d689c92a}"
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -41,7 +41,7 @@ github.com/grpc-ecosystem/go-grpc-middleware        3c51f7f332123e8be5a157c0802a
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        2e24aed516bd5c836e11378bb457dd612aa868ed
+github.com/docker/libnetwork                        9e99af28df21367340c95a3863e31808d689c92a
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/controller.go
+++ b/vendor/github.com/docker/libnetwork/controller.go
@@ -1020,12 +1020,7 @@ func (c *controller) addNetwork(n *network) error {
 func (c *controller) Networks() []Network {
 	var list []Network
 
-	networks, err := c.getNetworksFromStore()
-	if err != nil {
-		logrus.Error(err)
-	}
-
-	for _, n := range networks {
+	for _, n := range c.getNetworksFromStore() {
 		if n.inDelete {
 			continue
 		}

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -689,6 +689,12 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 	bridgeAlreadyExists := bridgeIface.exists()
 	if !bridgeAlreadyExists {
 		bridgeSetup.queueStep(setupDevice)
+		bridgeSetup.queueStep(setupDefaultSysctl)
+	}
+
+	// For the default bridge, set expected sysctls
+	if config.DefaultBridge {
+		bridgeSetup.queueStep(setupDefaultSysctl)
 	}
 
 	// Even if a bridge exists try to setup IPv4.

--- a/vendor/github.com/docker/libnetwork/iptables/firewalld.go
+++ b/vendor/github.com/docker/libnetwork/iptables/firewalld.go
@@ -19,20 +19,46 @@ const (
 	// Ebtables point to bridge table
 	Ebtables IPV = "eb"
 )
+
 const (
-	dbusInterface = "org.fedoraproject.FirewallD1"
-	dbusPath      = "/org/fedoraproject/FirewallD1"
+	dbusInterface  = "org.fedoraproject.FirewallD1"
+	dbusPath       = "/org/fedoraproject/FirewallD1"
+	dbusConfigPath = "/org/fedoraproject/FirewallD1/config"
+	dockerZone     = "docker"
 )
 
 // Conn is a connection to firewalld dbus endpoint.
 type Conn struct {
-	sysconn *dbus.Conn
-	sysobj  dbus.BusObject
-	signal  chan *dbus.Signal
+	sysconn    *dbus.Conn
+	sysObj     dbus.BusObject
+	sysConfObj dbus.BusObject
+	signal     chan *dbus.Signal
+}
+
+// ZoneSettings holds the firewalld zone settings, documented in
+// https://firewalld.org/documentation/man-pages/firewalld.dbus.html
+type ZoneSettings struct {
+	version            string
+	name               string
+	description        string
+	unused             bool
+	target             string
+	services           []string
+	ports              [][]interface{}
+	icmpBlocks         []string
+	masquerade         bool
+	forwardPorts       [][]interface{}
+	interfaces         []string
+	sourceAddresses    []string
+	richRules          []string
+	protocols          []string
+	sourcePorts        [][]interface{}
+	icmpBlockInversion bool
 }
 
 var (
-	connection       *Conn
+	connection *Conn
+
 	firewalldRunning bool      // is Firewalld service running
 	onReloaded       []*func() // callbacks when Firewalld has been reloaded
 )
@@ -51,6 +77,9 @@ func FirewalldInit() error {
 	}
 	if connection != nil {
 		go signalHandler()
+		if err := setupDockerZone(); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -76,8 +105,8 @@ func (c *Conn) initConnection() error {
 	}
 
 	// This never fails, even if the service is not running atm.
-	c.sysobj = c.sysconn.Object(dbusInterface, dbus.ObjectPath(dbusPath))
-
+	c.sysObj = c.sysconn.Object(dbusInterface, dbus.ObjectPath(dbusPath))
+	c.sysConfObj = c.sysconn.Object(dbusInterface, dbus.ObjectPath(dbusConfigPath))
 	rule := fmt.Sprintf("type='signal',path='%s',interface='%s',sender='%s',member='Reloaded'",
 		dbusPath, dbusInterface, dbusInterface)
 	c.sysconn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, rule)
@@ -150,7 +179,7 @@ func checkRunning() bool {
 	var err error
 
 	if connection != nil {
-		err = connection.sysobj.Call(dbusInterface+".getDefaultZone", 0).Store(&zone)
+		err = connection.sysObj.Call(dbusInterface+".getDefaultZone", 0).Store(&zone)
 		return err == nil
 	}
 	return false
@@ -160,8 +189,115 @@ func checkRunning() bool {
 func Passthrough(ipv IPV, args ...string) ([]byte, error) {
 	var output string
 	logrus.Debugf("Firewalld passthrough: %s, %s", ipv, args)
-	if err := connection.sysobj.Call(dbusInterface+".direct.passthrough", 0, ipv, args).Store(&output); err != nil {
+	if err := connection.sysObj.Call(dbusInterface+".direct.passthrough", 0, ipv, args).Store(&output); err != nil {
 		return nil, err
 	}
 	return []byte(output), nil
+}
+
+// getDockerZoneSettings converts the ZoneSettings struct into a interface slice
+func getDockerZoneSettings() []interface{} {
+	settings := ZoneSettings{
+		version:     "1.0",
+		name:        dockerZone,
+		description: "zone for docker bridge network interfaces",
+		target:      "ACCEPT",
+	}
+	slice := []interface{}{
+		settings.version,
+		settings.name,
+		settings.description,
+		settings.unused,
+		settings.target,
+		settings.services,
+		settings.ports,
+		settings.icmpBlocks,
+		settings.masquerade,
+		settings.forwardPorts,
+		settings.interfaces,
+		settings.sourceAddresses,
+		settings.richRules,
+		settings.protocols,
+		settings.sourcePorts,
+		settings.icmpBlockInversion,
+	}
+	return slice
+
+}
+
+// setupDockerZone creates a zone called docker in firewalld which includes docker interfaces to allow
+// container networking
+func setupDockerZone() error {
+	var zones []string
+	// Check if zone exists
+	if err := connection.sysObj.Call(dbusInterface+".zone.getZones", 0).Store(&zones); err != nil {
+		return err
+	}
+	if contains(zones, dockerZone) {
+		logrus.Infof("Firewalld: %s zone already exists, returning", dockerZone)
+		return nil
+	}
+	logrus.Debugf("Firewalld: creating %s zone", dockerZone)
+
+	settings := getDockerZoneSettings()
+	// Permanent
+	if err := connection.sysConfObj.Call(dbusInterface+".config.addZone", 0, dockerZone, settings).Err; err != nil {
+		return err
+	}
+	// Reload for change to take effect
+	if err := connection.sysObj.Call(dbusInterface+".reload", 0).Err; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AddInterfaceFirewalld adds the interface to the trusted zone
+func AddInterfaceFirewalld(intf string) error {
+	var intfs []string
+	// Check if interface is already added to the zone
+	if err := connection.sysObj.Call(dbusInterface+".zone.getInterfaces", 0, dockerZone).Store(&intfs); err != nil {
+		return err
+	}
+	// Return if interface is already part of the zone
+	if contains(intfs, intf) {
+		logrus.Infof("Firewalld: interface %s already part of %s zone, returning", intf, dockerZone)
+		return nil
+	}
+
+	logrus.Debugf("Firewalld: adding %s interface to %s zone", intf, dockerZone)
+	// Runtime
+	if err := connection.sysObj.Call(dbusInterface+".zone.addInterface", 0, dockerZone, intf).Err; err != nil {
+		return err
+	}
+	return nil
+}
+
+// DelInterfaceFirewalld removes the interface from the trusted zone
+func DelInterfaceFirewalld(intf string) error {
+	var intfs []string
+	// Check if interface is part of the zone
+	if err := connection.sysObj.Call(dbusInterface+".zone.getInterfaces", 0, dockerZone).Store(&intfs); err != nil {
+		return err
+	}
+	// Remove interface if it exists
+	if !contains(intfs, intf) {
+		return fmt.Errorf("Firewalld: unable to find interface %s in %s zone", intf, dockerZone)
+	}
+
+	logrus.Debugf("Firewalld: removing %s interface from %s zone", intf, dockerZone)
+	// Runtime
+	if err := connection.sysObj.Call(dbusInterface+".zone.removeInterface", 0, dockerZone, intf).Err; err != nil {
+		return err
+	}
+	return nil
+}
+
+func contains(list []string, val string) bool {
+	for _, v := range list {
+		if v == val {
+			return true
+		}
+	}
+	return false
 }

--- a/vendor/github.com/docker/libnetwork/iptables/iptables.go
+++ b/vendor/github.com/docker/libnetwork/iptables/iptables.go
@@ -146,6 +146,19 @@ func ProgramChain(c *ChainInfo, bridgeName string, hairpinMode, enable bool) err
 		return errors.New("Could not program chain, missing chain name")
 	}
 
+	// Either add or remove the interface from the firewalld zone
+	if firewalldRunning {
+		if enable {
+			if err := AddInterfaceFirewalld(bridgeName); err != nil {
+				return err
+			}
+		} else {
+			if err := DelInterfaceFirewalld(bridgeName); err != nil {
+				return err
+			}
+		}
+	}
+
 	switch c.Table {
 	case Nat:
 		preroute := []string{

--- a/vendor/github.com/docker/libnetwork/network.go
+++ b/vendor/github.com/docker/libnetwork/network.go
@@ -1181,7 +1181,8 @@ func (n *network) createEndpoint(name string, options ...EndpointOption) (Endpoi
 	ep.locator = n.getController().clusterHostID()
 	ep.network, err = ep.getNetworkFromStore()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get network during CreateEndpoint: %v", err)
+		logrus.Errorf("failed to get network during CreateEndpoint: %v", err)
+		return nil, err
 	}
 	n = ep.network
 


### PR DESCRIPTION
supersedes https://github.com/moby/moby/pull/40933
closes https://github.com/moby/moby/pull/40933

full diff: https://github.com/docker/libnetwork/compare/2e24aed516bd5c836e11378bb457dd612aa868ed...9e99af28df21367340c95a3863e31808d689c92a

- docker/libnetwork#2548 Add docker interfaces to firewalld docker zone
    - fixes docker/for-linux#957 DNS Not Resolving under Network [CentOS8]
    - fixes docker/libnetwork#2496 Port Forwarding does not work on RHEL 8 with Firewalld running with FirewallBackend=nftables
- store.getNetworksFromStore() remove unused error return
- docker/libnetwork#2554 Fix 'failed to get network during CreateEndpoint'
    - fixes/addresses docker/for-linux#888 failed to get network during CreateEndpoint
- docker/libnetwork#2558 [master] bridge: disable IPv6 router advertisements
- docker/libnetwork#2563 log error instead if disabling IPv6 router advertisement failed
    - fixes docker/for-linux#1033 Shouldn't be fatal: Unable to disable IPv6 router advertisement: open /proc/sys/net/ipv6/conf/docker0/accept_ra: read-only file system

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

