### PR TITLE
Added missing Devices field to HostConfig

### DIFF
--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -405,6 +405,7 @@ type HostConfig struct {
 	CapDrop         strslice.StrSlice // List of kernel capabilities to remove from the container
 	Capabilities    []string          `json:"Capabilities"` // List of kernel capabilities to be available for container (this overrides the default set)
 	CgroupnsMode    CgroupnsMode      // Cgroup namespace mode to use for the container
+	Devices         []DeviceMapping   `json:",omitempty"` // List of the devices to map to the container
 	DNS             []string          `json:"Dns"`        // List of DNS server to lookup
 	DNSOptions      []string          `json:"DnsOptions"` // List of DNSOption to look for
 	DNSSearch       []string          `json:"DnsSearch"`  // List of DNSSearch to look for


### PR DESCRIPTION
Signed-off-by: Maxime Aubanel <maximeauba@gmail.com>
Linked issue: #41193 
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added Devices mapping field to the HostConfig structure.

**- How I did it**

By just adding the existing DeviceMapping struct it in the HostConfig struct my keyboard :P

**- How to verify it**

I don't know how to answer that question ^^ Look at the code ? lol

**- Description for the changelog**

Addition of DeviceMapping in the HostConfig structure

**- A picture of a cute animal (not mandatory but encouraged)**

[This is a dog going to the beach, how cute is that](https://pbs.twimg.com/profile_images/477022793142267904/UTHgo6G7_400x400.jpeg)