### PR TITLE
Remove some outdated terminology where possible

### DIFF
--- a/builder/dockerfile/copy_windows.go
+++ b/builder/dockerfile/copy_windows.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-var pathBlacklist = map[string]bool{
+var pathDenyList = map[string]bool{
 	"c:\\":        true,
 	"c:\\windows": true,
 }
@@ -98,7 +98,7 @@ func validateCopySourcePath(imageSource *imageMount, origPath, platform string) 
 			p = filepath.Join("c:\\", p)
 		}
 	}
-	if _, blacklisted := pathBlacklist[p]; blacklisted {
+	if _, ok := pathDenyList[p]; ok {
 		return errors.New("copy from c:\\ or c:\\windows is not allowed on windows")
 	}
 	return nil

--- a/distribution/xfer/transfer.go
+++ b/distribution/xfer/transfer.go
@@ -42,7 +42,7 @@ type Transfer interface {
 	Close()
 	Done() <-chan struct{}
 	Released() <-chan struct{}
-	Broadcast(masterProgressChan <-chan progress.Progress)
+	Broadcast(mainProgressChan <-chan progress.Progress)
 }
 
 type transfer struct {
@@ -66,7 +66,7 @@ type transfer struct {
 	// the transfer is no longer tracked by the transfer manager.
 	released chan struct{}
 
-	// broadcastDone is true if the master progress channel has closed.
+	// broadcastDone is true if the main progress channel has closed.
 	broadcastDone bool
 	// closed is true if Close has been called
 	closed bool
@@ -95,14 +95,14 @@ func NewTransfer() Transfer {
 }
 
 // Broadcast copies the progress and error output to all viewers.
-func (t *transfer) Broadcast(masterProgressChan <-chan progress.Progress) {
+func (t *transfer) Broadcast(mainProgressChan <-chan progress.Progress) {
 	for {
 		var (
 			p  progress.Progress
 			ok bool
 		)
 		select {
-		case p, ok = <-masterProgressChan:
+		case p, ok = <-mainProgressChan:
 		default:
 			// We've depleted the channel, so now we can handle
 			// reads on broadcastSyncChan to let detaching watchers
@@ -110,7 +110,7 @@ func (t *transfer) Broadcast(masterProgressChan <-chan progress.Progress) {
 			select {
 			case <-t.broadcastSyncChan:
 				continue
-			case p, ok = <-masterProgressChan:
+			case p, ok = <-mainProgressChan:
 			}
 		}
 
@@ -353,10 +353,10 @@ func (tm *transferManager) Transfer(key string, xferFunc DoFunc, progressOutput 
 		tm.waitingTransfers = append(tm.waitingTransfers, start)
 	}
 
-	masterProgressChan := make(chan progress.Progress)
-	xfer := xferFunc(masterProgressChan, start, inactive)
+	mainProgressChan := make(chan progress.Progress)
+	xfer := xferFunc(mainProgressChan, start, inactive)
 	watcher := xfer.Watch(progressOutput)
-	go xfer.Broadcast(masterProgressChan)
+	go xfer.Broadcast(mainProgressChan)
 	tm.transfers[key] = xfer
 
 	// When the transfer is finished, remove from the map.

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -298,17 +298,17 @@ func (pm *Manager) GC() {
 	pm.muGC.Lock()
 	defer pm.muGC.Unlock()
 
-	whitelist := make(map[digest.Digest]struct{})
+	used := make(map[digest.Digest]struct{})
 	for _, p := range pm.config.Store.GetAll() {
-		whitelist[p.Config] = struct{}{}
+		used[p.Config] = struct{}{}
 		for _, b := range p.Blobsums {
-			whitelist[b] = struct{}{}
+			used[b] = struct{}{}
 		}
 	}
 
 	ctx := context.TODO()
 	pm.blobStore.Walk(ctx, func(info content.Info) error {
-		_, ok := whitelist[info.Digest]
+		_, ok := used[info.Digest]
 		if ok {
 			return nil
 		}

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -40,7 +40,7 @@ func arches() []types.Architecture {
 	}
 }
 
-// DefaultProfile defines the whitelist for the default seccomp profile.
+// DefaultProfile defines the allowed syscalls for the default seccomp profile.
 func DefaultProfile() *types.Seccomp {
 	syscalls := []*types.Syscall{
 		{


### PR DESCRIPTION
- Replace uses of blacklist/whitelist where possible
- Replace uses of master/slave where possible


There's still some occurrences in the code that are not under our control ((r)slave mount propagation, "master" branches in git repositories we reference (and our own master branch), master/slave for IPVlan interfaces, and `--whitelist` used by vndr (I'll open a PR for that)