### PR TITLE
cgroup v1: change the default runtime to io.containerd.runc.v2

### DIFF
--- a/daemon/runtime_unix.go
+++ b/daemon/runtime_unix.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -34,16 +33,9 @@ func configureRuntimes(conf *config.Config) {
 	if conf.Runtimes == nil {
 		conf.Runtimes = make(map[string]types.Runtime)
 	}
-	conf.Runtimes[config.StockRuntimeName] = types.Runtime{Path: defaultRuntimeName, Shim: getShimConfig(conf, defaultRuntimeName)}
 	conf.Runtimes[config.LinuxV1RuntimeName] = types.Runtime{Path: defaultRuntimeName, Shim: defaultV1ShimConfig(conf, defaultRuntimeName)}
 	conf.Runtimes[config.LinuxV2RuntimeName] = types.Runtime{Path: defaultRuntimeName, Shim: defaultV2ShimConfig(conf, defaultRuntimeName)}
-}
-
-func getShimConfig(conf *config.Config, runtimePath string) *types.ShimConfig {
-	if cgroups.IsCgroup2UnifiedMode() {
-		return defaultV2ShimConfig(conf, runtimePath)
-	}
-	return defaultV1ShimConfig(conf, runtimePath)
+	conf.Runtimes[config.StockRuntimeName] = conf.Runtimes[config.LinuxV2RuntimeName]
 }
 
 func defaultV2ShimConfig(conf *config.Config, runtimePath string) *types.ShimConfig {

--- a/daemon/start_unix.go
+++ b/daemon/start_unix.go
@@ -24,7 +24,7 @@ func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Contain
 		if err != nil {
 			return "", nil, translateContainerdStartErr(container.Path, container.SetExitCode, err)
 		}
-		rt.Shim = getShimConfig(daemon.configStore, p)
+		rt.Shim = defaultV2ShimConfig(daemon.configStore, p)
 	}
 	if rt.Shim.Binary == linuxShimV1 {
 		if cgroups.IsCgroup2UnifiedMode() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Changed the default runtime to `io.containerd.runc.v2`.

Fix #41107
Replace #41115

The previous default runtime `io.containerd.runtime.v1.linux` is being deprecated (https://github.com/containerd/containerd/issues/4365)

`io.containerd.runc.v2` is available since containerd v1.3.0.
 Using v1.3.5 or later is recommended.  v1.3.0-v1.3.4 doesn't pass `TestContainerStartOnDaemonRestart`.

**- How to verify it**

Run some containers and make sure `containerd-shim-runc-v2` processes are running

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
cgroup v1: change the default runtime to io.containerd.runc.v2. Requires containerd v1.3.0 or later. v1.3.5 or later is recommended.

**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
