### PR TITLE
Fix handling of error-conditions in WalkFunc's to prevent panics

### DIFF
--- a/daemon/graphdriver/lcow/lcow.go
+++ b/daemon/graphdriver/lcow/lcow.go
@@ -140,8 +140,8 @@ type layerDetails struct {
 
 // deletefiles is a helper function for initialisation where we delete any
 // left-over scratch files in case we were previously forcibly terminated.
-func deletefiles(path string, f os.FileInfo, err error) error {
-	if strings.HasSuffix(f.Name(), ".vhdx") {
+func deletefiles(path string, f os.FileInfo, _ error) error {
+	if f != nil && strings.HasSuffix(f.Name(), ".vhdx") {
 		logrus.Warnf("lcowdriver: init: deleting stale scratch file %s", path)
 		return os.Remove(path)
 	}

--- a/daemon/graphdriver/lcow/remotefs_pathdriver.go
+++ b/daemon/graphdriver/lcow/remotefs_pathdriver.go
@@ -141,7 +141,7 @@ func (l *lcowfs) Walk(root string, walkFn filepath.WalkFunc) error {
 func (l *lcowfs) walk(path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
 	err := walkFn(path, info, nil)
 	if err != nil {
-		if info.IsDir() && err == filepath.SkipDir {
+		if info != nil && info.IsDir() && err == filepath.SkipDir {
 			return nil
 		}
 		return err

--- a/oci/devices_linux.go
+++ b/oci/devices_linux.go
@@ -62,7 +62,7 @@ func DevicesFromPath(pathOnHost, pathInContainer, cgroupPermissions string) (dev
 
 			// mount the internal devices recursively
 			// TODO check if additional errors should be handled or logged
-			_ = filepath.Walk(resolvedPathOnHost, func(dpath string, f os.FileInfo, _ error) error {
+			_ = filepath.Walk(resolvedPathOnHost, func(dpath string, _ os.FileInfo, _ error) error {
 				childDevice, e := devices.DeviceFromPath(dpath, cgroupPermissions)
 				if e != nil {
 					// ignore the device

--- a/pkg/archive/utils_test.go
+++ b/pkg/archive/utils_test.go
@@ -141,7 +141,7 @@ func testBreakout(untarFn string, tmpdir string, headers []*tar.Header) error {
 	// that any file whose content matches exactly victim/hello, managed somehow
 	// to access victim/hello.
 	return filepath.Walk(dest, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() {
+		if info != nil && info.IsDir() {
 			if err != nil {
 				// skip directory if error
 				return filepath.SkipDir

--- a/testutil/daemon/daemon_unix.go
+++ b/testutil/daemon/daemon_unix.go
@@ -23,7 +23,7 @@ func cleanupNetworkNamespace(t testing.TB, d *Daemon) {
 	// cleaned up when a new daemon is instantiated with a
 	// new exec root.
 	netnsPath := filepath.Join(d.execRoot, "netns")
-	filepath.Walk(netnsPath, func(path string, info os.FileInfo, err error) error {
+	filepath.Walk(netnsPath, func(path string, _ os.FileInfo, _ error) error {
 		if err := unix.Unmount(path, unix.MNT_DETACH); err != nil && err != unix.EINVAL && err != unix.ENOENT {
 			t.Logf("[%s] unmount of %s failed: %v", d.id, path, err)
 		}


### PR DESCRIPTION
If an error occurs, fileInfo can be nil;
https://github.com/golang/go/blob/go1.13.12/src/path/filepath/path.go#L376-L378

This adds some checks to functions to prevent a panic in that situation.

