### PR TITLE
Remove unused useShimV2()

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -654,10 +654,6 @@ func (daemon *Daemon) initRuntimes(_ map[string]types.Runtime) error {
 func setupResolvConf(config *config.Config) {
 }
 
-func (daemon *Daemon) useShimV2() bool {
-	return true
-}
-
 // RawSysInfo returns *sysinfo.SysInfo .
 func (daemon *Daemon) RawSysInfo(quiet bool) *sysinfo.SysInfo {
 	return sysinfo.New(quiet)

--- a/libcontainerd/libcontainerd_windows.go
+++ b/libcontainerd/libcontainerd_windows.go
@@ -13,7 +13,6 @@ import (
 // NewClient creates a new libcontainerd client from a containerd client
 func NewClient(ctx context.Context, cli *containerd.Client, stateDir, ns string, b libcontainerdtypes.Backend) (libcontainerdtypes.Client, error) {
 	if !system.ContainerdRuntimeSupported() {
-		// useShimV2 is ignored for windows
 		return local.NewClient(ctx, cli, stateDir, ns, b)
 	}
 	return remote.NewClient(ctx, cli, stateDir, ns, b)


### PR DESCRIPTION
This function was removed in the Linux code as part of f63f73a4a8f531813d6b46a2347cab4bfd210df7 (https://github.com/moby/moby/pull/41182), but was not removed in the Windows code.

