### PR TITLE
[19.03] vendor: moby/buildkit v0.6.4-20-g4cb720ef

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -26,7 +26,7 @@ github.com/imdario/mergo                            7c29201646fa3de8506f70121347
 golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af2b83e6acac3c
 
 # buildkit
-github.com/moby/buildkit                            dc6afa0f755f6cbb7e85f0df4ff4b87ec280cb32 # v0.6.4-15-gdc6afa0f
+github.com/moby/buildkit                            4cb720ef6483b43020c9037726de47353ac8ad9b # v0.6.4-20-g4cb720ef
 github.com/tonistiigi/fsutil                        6c909ab392c173a4264ae1bfcbc0450b9aac0c7d
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7

--- a/vendor/github.com/moby/buildkit/cache/contenthash/tarsum.go
+++ b/vendor/github.com/moby/buildkit/cache/contenthash/tarsum.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 // WriteV1TarsumHeaders writes a tar header to a writer in V1 tarsum format.
@@ -38,7 +39,9 @@ func v1TarHeaderSelect(h *tar.Header) (orderedHeaders [][2]string) {
 	// Get extended attributes.
 	xAttrKeys := make([]string, len(h.Xattrs))
 	for k := range h.Xattrs {
-		xAttrKeys = append(xAttrKeys, k)
+		if k == "security.capability" || !strings.HasPrefix(k, "security.") && !strings.HasPrefix(k, "system.") {
+			xAttrKeys = append(xAttrKeys, k)
+		}
 	}
 	sort.Strings(xAttrKeys)
 

--- a/vendor/github.com/moby/buildkit/cache/remotecache/inline/inline.go
+++ b/vendor/github.com/moby/buildkit/cache/remotecache/inline/inline.go
@@ -72,7 +72,7 @@ func (ce *exporter) ExportForLayers(layers []digest.Digest) ([]byte, error) {
 		return nil, nil
 	}
 
-	cache := map[digest.Digest]int{}
+	cache := map[int]int{}
 
 	// reorder layers based on the order in the image
 	for i, r := range cfg.Records {
@@ -93,14 +93,14 @@ func (ce *exporter) ExportForLayers(layers []digest.Digest) ([]byte, error) {
 	return dt, nil
 }
 
-func getSortedLayerIndex(idx int, layers []v1.CacheLayer, cache map[digest.Digest]int) int {
+func getSortedLayerIndex(idx int, layers []v1.CacheLayer, cache map[int]int) int {
 	if idx == -1 {
 		return -1
 	}
 	l := layers[idx]
-	if i, ok := cache[l.Blob]; ok {
+	if i, ok := cache[idx]; ok {
 		return i
 	}
-	cache[l.Blob] = getSortedLayerIndex(l.ParentIndex, layers, cache) + 1
-	return cache[l.Blob]
+	cache[idx] = getSortedLayerIndex(l.ParentIndex, layers, cache) + 1
+	return cache[idx]
 }


### PR DESCRIPTION
full diff: https://github.com/moby/buildkit/compare/dc6afa0f755f6cbb7e85f0df4ff4b87ec280cb32...4cb720ef6483b43020c9037726de47353ac8ad9b

- https://github.com/moby/buildkit/pull/1572 contenthash: ignore system and security xattrs in calculation
    - fixes moby/buildkit#1330 COPY cache not re-used depending on SELinux environment
    - fixes https://github.com/moby/moby/issues/39003#issuecomment-574615437
- https://github.com/moby/buildkit/pull/1572 contenthash: allow security.capability in cache checksum
- https://github.com/moby/buildkit/pull/1572 inline cache: fix handling of duplicate blobs
    - fixes moby/buildkit#1388 cache-from working unreliably

