### PR TITLE
[Draft] Allow filtering `system/df` endpoint actions

### DIFF
--- a/api/server/router/system/backend.go
+++ b/api/server/router/system/backend.go
@@ -15,7 +15,7 @@ import (
 type Backend interface {
 	SystemInfo() *types.Info
 	SystemVersion() types.Version
-	SystemDiskUsage(ctx context.Context) (*types.DiskUsage, error)
+	SystemDiskUsage(ctx context.Context, containers, images, volumes, layerSize bool) (*types.DiskUsage, error)
 	SubscribeToEvents(since, until time.Time, ef filters.Args) ([]events.Message, chan interface{})
 	UnsubscribeFromEvents(chan interface{})
 	AuthenticateToRegistry(ctx context.Context, authConfig *types.AuthConfig) (string, string, error)

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -530,6 +530,15 @@ type ShimConfig struct {
 	Opts   interface{}
 }
 
+// DiskUsageOptions holds parameters to filter the types of disk usage desired in the response.
+type DiskUsageOptions struct {
+	NoContainers bool
+	NoImages     bool
+	NoVolumes    bool
+	NoLayerSize  bool
+	NoBuildCache bool
+}
+
 // DiskUsage contains response of Engine API:
 // GET "/system/df"
 type DiskUsage struct {

--- a/client/disk_usage.go
+++ b/client/disk_usage.go
@@ -4,15 +4,39 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/docker/docker/api/types"
 )
 
 // DiskUsage requests the current data usage from the daemon
 func (cli *Client) DiskUsage(ctx context.Context) (types.DiskUsage, error) {
+	return cli.DiskUsageWithOptions(ctx, types.DiskUsageOptions{})
+}
+
+// DiskUsageWithOptions requests the current data usage from the daemon
+func (cli *Client) DiskUsageWithOptions(ctx context.Context, options types.DiskUsageOptions) (types.DiskUsage, error) {
 	var du types.DiskUsage
 
-	serverResp, err := cli.get(ctx, "/system/df", nil, nil)
+	query := url.Values{}
+
+	if options.NoContainers {
+		query.Set("containers", "0")
+	}
+	if options.NoImages {
+		query.Set("images", "0")
+	}
+	if options.NoVolumes {
+		query.Set("volumes", "0")
+	}
+	if options.NoLayerSize {
+		query.Set("layer-size", "0")
+	}
+	if options.NoBuildCache {
+		query.Set("build-cache", "0")
+	}
+
+	serverResp, err := cli.get(ctx, "/system/df", query, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return du, err

--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -10,41 +10,49 @@ import (
 )
 
 // SystemDiskUsage returns information about the daemon data disk usage
-func (daemon *Daemon) SystemDiskUsage(ctx context.Context) (*types.DiskUsage, error) {
+func (daemon *Daemon) SystemDiskUsage(ctx context.Context, containers, images, volumes, layerSize bool) (
+	*types.DiskUsage, error) {
+
 	if !atomic.CompareAndSwapInt32(&daemon.diskUsageRunning, 0, 1) {
 		return nil, fmt.Errorf("a disk usage operation is already running")
 	}
 	defer atomic.StoreInt32(&daemon.diskUsageRunning, 0)
 
-	// Retrieve container list
-	allContainers, err := daemon.Containers(&types.ContainerListOptions{
-		Size: true,
-		All:  true,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve container list: %v", err)
+	var err error
+	usage := &types.DiskUsage{}
+
+	if containers {
+		// Retrieve container list
+		usage.Containers, err = daemon.Containers(&types.ContainerListOptions{
+			Size: true,
+			All:  true,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve container list: %v", err)
+		}
 	}
 
-	// Get all top images with extra attributes
-	allImages, err := daemon.imageService.Images(filters.NewArgs(), false, true)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve image list: %v", err)
+	if images {
+		// Get all top images with extra attributes
+		usage.Images, err = daemon.imageService.Images(filters.NewArgs(), false, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve image list: %v", err)
+		}
 	}
 
-	localVolumes, err := daemon.volumes.LocalVolumesSize(ctx)
-	if err != nil {
-		return nil, err
+	if volumes {
+		usage.Volumes, err = daemon.volumes.LocalVolumesSize(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	allLayersSize, err := daemon.imageService.LayerDiskUsage(ctx)
-	if err != nil {
-		return nil, err
+	if layerSize {
+		usage.LayersSize, err = daemon.imageService.LayerDiskUsage(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return &types.DiskUsage{
-		LayersSize: allLayersSize,
-		Containers: allContainers,
-		Volumes:    localVolumes,
-		Images:     allImages,
-	}, nil
+	return usage, nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This PR offers an option for helping with #31951, by allowing the user to exclude the parts of the disk usage they don’t care about.

**- How I did it**
The thinking here is that this endpoint remains backwards compatible with older API versions, and if you hit an older API with the new request type, the arguments simply get ignored and get get all the info back.

**- How to verify it**
Check you can still run `docker system df`. The tests added I think do a reasonable job of checking the client behaviour.

To verify the behaviour directly, I used the following commands on an Ubuntu 20.04 VM:
```bash
$ curl --unix-socket /var/run/docker.sock 'http://localhost/system/df?containers=0&images=0&volumes=0'
{"LayersSize":13336,"Images":null,"Containers":null,"Volumes":null,"BuildCache":null,"BuilderSize":0}
```

```bash
$ curl --unix-socket /var/run/docker.sock 'http://localhost/system/df'
{"LayersSize":13336,"Images":[{"Containers":0,"Created":1578014497,"Id":"sha256:bf756fb1ae65adf866bd8c456593cd24beb6a0a061dedf42b26a993176745f6b","Labels":null,"ParentId":"","RepoDigests":["hello-world@sha256:e7c70bb24b462baa86c102610182e3efcb12a04854e8c582838d92970a09f323"],"RepoTags":["hello-world:latest"],"SharedSize":0,"Size":13336,"VirtualSize":13336}],"Containers":[],"Volumes":[],"BuildCache":null,"BuilderSize":0}
```

**- Description for the changelog**
TODO

