### PR TITLE
docs: add mention of DefaultAddressPools to API history

### DIFF
--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,7 +17,10 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.41](https://docs.docker.com/engine/api/v1.41/) documentation
 
-* `GET /info` now returns an `CgroupVersion` field, containing the cgroup version.
+* `GET /info` now returns a `CgroupVersion` field, containing the cgroup version.
+* `GET /info` now returns a `DefaultAddressPools` field, containing a list of
+  custom default address pools for local networks, which can be specified in the
+  `daemon.json` file or `--default-address-pool` dockerd option.
 * `POST /services/create` and `POST /services/{id}/update` now supports `BindOptions.NonRecursive`.
 * The `ClusterStore` and `ClusterAdvertise` fields in `GET /info` are deprecated
   and are now omitted if they contain an empty value. This change is not versioned,


### PR DESCRIPTION
small follow-up to https://github.com/moby/moby/pull/40714. I didn't want to block merging of that PR because of this 😅 