### PR TITLE
api/types: omit empty DefaultAddressPools

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -210,8 +210,8 @@ type Info struct {
 	RuncCommit          Commit
 	InitCommit          Commit
 	SecurityOptions     []string
-	ProductLicense      string `json:",omitempty"`
-	DefaultAddressPools []NetworkAddressPool
+	ProductLicense      string               `json:",omitempty"`
+	DefaultAddressPools []NetworkAddressPool `json:",omitempty"`
 	Warnings            []string
 }
 


### PR DESCRIPTION
Also a small follow-up to https://github.com/moby/moby/pull/40714

I was revendoring moby in the CLI, and realised that we didn't add an omit_empty to this field; I think it would be ok to add that