### PR TITLE
docs: add example calculations to container stats API

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5994,6 +5994,16 @@ paths:
         * `cpu_stats`: `cpu_usage.percpu_usage`
         * `memory_stats`: `max_usage` and `failcnt`
         Also, `memory_stats.stats` fields are incompatible with cgroup v1.
+
+        To calculate the values shown by the `stats` command of the docker cli tool
+        the following formulas can be used:
+        * used_memory = `memory_stats.usage - memory_stats.stats.cache`
+        * available_memory = `memory_stats.limit`
+        * Memory usage % = `(used_memory / available_memory) * 100.0`
+        * cpu_delta = `cpu_stats.cpu_usage.total_usage - precpu_stats.cpu_usage.total_usage`
+        * system_cpu_delta = `cpu_stats.system_cpu_usage - precpu_stats.system_cpu_usage`
+        * number_cpus = `lenght(cpu_stats.cpu_usage.percpu_usage)` or `cpu_stats.online_cpus`
+        * CPU usage % = `(cpu_delta / system_cpu_delta) * number_cpus * 100.0`
       operationId: "ContainerStats"
       produces: ["application/json"]
       responses:


### PR DESCRIPTION
Signed-off-by: Velko Ivanov <vivanov@deeperplane.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

addresses https://github.com/docker/docker.github.io/issues/11167

**- What I did**
Added some formulas to the docs for calculating container stats from data obtained by the API. They are the same that are used in the cli tool for the `stats` command.

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Added examples for calculating container stats from data obtained by the API
