### PR TITLE
Deprecate KernelMemory

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -528,7 +528,13 @@ definitions:
         items:
           $ref: "#/definitions/DeviceRequest"
       KernelMemory:
-        description: "Kernel memory limit in bytes."
+        description: |
+          Kernel memory limit in bytes.
+
+          <p><br /></p>
+
+          > **Deprecated**: This field is deprecated as the kernel 5.4 deprecated
+          > `kmem.limit_in_bytes`.
         type: "integer"
         format: "int64"
         example: 209715200
@@ -4321,7 +4327,13 @@ definitions:
         type: "boolean"
         example: true
       KernelMemory:
-        description: "Indicates if the host has kernel memory limit support enabled."
+        description: |
+          Indicates if the host has kernel memory limit support enabled.
+
+          <p><br /></p>
+
+          > **Deprecated**: This field is deprecated as the kernel 5.4 deprecated
+          > `kmem.limit_in_bytes`.
         type: "boolean"
         example: true
       CpuCfsPeriod:

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -361,7 +361,7 @@ type Resources struct {
 	Devices              []DeviceMapping // List of devices to map inside the container
 	DeviceCgroupRules    []string        // List of rule to be added to the device cgroup
 	DeviceRequests       []DeviceRequest // List of device requests for device drivers
-	KernelMemory         int64           // Kernel memory limit (in bytes)
+	KernelMemory         int64           // Kernel memory limit (in bytes), Deprecated: kernel 5.4 deprecated kmem.limit_in_bytes
 	KernelMemoryTCP      int64           // Hard limit for kernel TCP buffer memory (in bytes)
 	MemoryReservation    int64           // Memory soft limit (in bytes)
 	MemorySwap           int64           // Total memory usage (memory + swap); set `-1` to enable unlimited swap

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -158,7 +158,7 @@ type Info struct {
 	Plugins            PluginsInfo
 	MemoryLimit        bool
 	SwapLimit          bool
-	KernelMemory       bool
+	KernelMemory       bool // Deprecated: kernel 5.4 deprecated kmem.limit_in_bytes
 	KernelMemoryTCP    bool
 	CPUCfsPeriod       bool `json:"CpuCfsPeriod"`
 	CPUCfsQuota        bool `json:"CpuCfsQuota"`

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -465,6 +465,12 @@ func verifyPlatformContainerResources(resources *containertypes.Resources, sysIn
 	if resources.Memory > 0 && resources.MemoryReservation > 0 && resources.Memory < resources.MemoryReservation {
 		return warnings, fmt.Errorf("Minimum memory limit can not be less than memory reservation limit, see usage")
 	}
+	if resources.KernelMemory > 0 {
+		// Kernel memory limit is not supported on cgroup v2.
+		// Even on cgroup v1, kernel memory limit (`kmem.limit_in_bytes`) has been deprecated since kernel 5.4.
+		// https://github.com/torvalds/linux/commit/0158115f702b0ba208ab0b5adf44cae99b3ebcc7
+		warnings = append(warnings, "Specifying a kernel memory limit is deprecated and will be removed in a future release.")
+	}
 	if resources.KernelMemory > 0 && !sysInfo.KernelMemory {
 		warnings = append(warnings, "Your kernel does not support kernel memory limit capabilities or the cgroup is not mounted. Limitation discarded.")
 		resources.KernelMemory = 0

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -100,9 +100,6 @@ func (daemon *Daemon) fillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) 
 		if !v.SwapLimit {
 			v.Warnings = append(v.Warnings, "WARNING: No swap limit support")
 		}
-		if !v.KernelMemory {
-			v.Warnings = append(v.Warnings, "WARNING: No kernel memory limit support")
-		}
 		if !v.KernelMemoryTCP {
 			v.Warnings = append(v.Warnings, "WARNING: No kernel memory TCP limit support")
 		}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -74,6 +74,8 @@ keywords: "API, Docker, rcli, REST, documentation"
   job-mode service.
 * `GET /containers/{id}/stats` now accepts a query param (`one-shot`) which, when used with `stream=false` fetches a
   single set of stats instead of waiting for two collection cycles to have 2 CPU stats over a 1 second period.
+* The `KernelMemory` field in `HostConfig.Resources` is now deprecated.
+* The `KernelMemory` field in `Info` is now deprecated.
 
 ## v1.40 API changes
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Deprecate Kernel Memory.

Kernel memory limit is not supported on cgroup v2. Even on cgroup v1, kernel memory limit (`kmem.limit_in_bytes`) has been deprecated since kernel 5.4.
https://github.com/torvalds/linux/commit/0158115f702b0ba208ab0b5adf44cae99b3ebcc7

Fix #41252


**- How to verify it**
```console
$ docker run -it --rm --kernel-memory 32m alpine
WARNING: Specifying a kernel memory limit is deprecated and will be removed in a future release.
/ #
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Deprecate KernelMemory (`docker run --kernel-memory`)

**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
