### PR TITLE
[19.03] vendor: moby/buildkit v0.6.4-26-ga1e4f48e

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -26,7 +26,7 @@ github.com/imdario/mergo                            7c29201646fa3de8506f70121347
 golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af2b83e6acac3c
 
 # buildkit
-github.com/moby/buildkit                            4cb720ef6483b43020c9037726de47353ac8ad9b # v0.6.4-20-g4cb720ef
+github.com/moby/buildkit                            a1e4f48e712360e6292819e55285e1bbacce99d4 # v0.6.4-26-ga1e4f48e
 github.com/tonistiigi/fsutil                        6c909ab392c173a4264ae1bfcbc0450b9aac0c7d
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7

--- a/vendor/github.com/moby/buildkit/cache/contenthash/filehash.go
+++ b/vendor/github.com/moby/buildkit/cache/contenthash/filehash.go
@@ -40,6 +40,9 @@ func NewFileHash(path string, fi os.FileInfo) (hash.Hash, error) {
 }
 
 func NewFromStat(stat *fstypes.Stat) (hash.Hash, error) {
+	// Clear the socket bit since archive/tar.FileInfoHeader does not handle it
+	stat.Mode &^= uint32(os.ModeSocket)
+
 	fi := &statInfo{stat}
 	hdr, err := tar.FileInfoHeader(fi, stat.Linkname)
 	if err != nil {

--- a/vendor/github.com/moby/buildkit/cache/remotecache/v1/cachestorage.go
+++ b/vendor/github.com/moby/buildkit/cache/remotecache/v1/cachestorage.go
@@ -220,6 +220,7 @@ func (cs *cacheResultStorage) LoadWithParents(ctx context.Context, res solver.Ca
 
 	m := map[string]solver.Result{}
 
+	visited := make(map[*item]struct{})
 	if err := v.walkAllResults(func(i *item) error {
 		if i.result == nil {
 			return nil
@@ -236,7 +237,7 @@ func (cs *cacheResultStorage) LoadWithParents(ctx context.Context, res solver.Ca
 			m[id] = worker.NewWorkerRefResult(ref, cs.w)
 		}
 		return nil
-	}); err != nil {
+	}, visited); err != nil {
 		for _, v := range m {
 			v.Release(context.TODO())
 		}

--- a/vendor/github.com/moby/buildkit/cache/remotecache/v1/chains.go
+++ b/vendor/github.com/moby/buildkit/cache/remotecache/v1/chains.go
@@ -128,13 +128,17 @@ func (c *item) LinkFrom(rec solver.CacheExporterRecord, index int, selector stri
 	c.links[index][link{src: src, selector: selector}] = struct{}{}
 }
 
-func (c *item) walkAllResults(fn func(i *item) error) error {
+func (c *item) walkAllResults(fn func(i *item) error, visited map[*item]struct{}) error {
+	if _, ok := visited[c]; ok {
+		return nil
+	}
+	visited[c] = struct{}{}
 	if err := fn(c); err != nil {
 		return err
 	}
 	for _, links := range c.links {
 		for l := range links {
-			if err := l.src.walkAllResults(fn); err != nil {
+			if err := l.src.walkAllResults(fn, visited); err != nil {
 				return err
 			}
 		}

--- a/vendor/github.com/moby/buildkit/source/git/gitsource.go
+++ b/vendor/github.com/moby/buildkit/source/git/gitsource.go
@@ -272,8 +272,9 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context) (out cache.ImmutableRe
 		}
 		args = append(args, "origin")
 		if !isCommitSHA(ref) {
-			args = append(args, ref+":tags/"+ref)
-			// local refs are needed so they would be advertised on next fetches
+			args = append(args, "--force", ref+":tags/"+ref)
+			// local refs are needed so they would be advertised on next fetches. Force is used
+			// in case the ref is a branch and it now points to a different commit sha
 			// TODO: is there a better way to do this?
 		}
 		if _, err := gitWithinDir(ctx, gitDir, "", args...); err != nil {


### PR DESCRIPTION
full diff: https://github.com/moby/buildkit/compare/4cb720ef6483b43020c9037726de47353ac8ad9b...a1e4f48e712360e6292819e55285e1bbacce99d4

Brings in the cherry-picks from moby/buildkit#1596 and moby/buildkit#1598 :

- Add --force flag in git fetch command
- Fix socket handling during copy (Treat unix sockets as regular files)
- Remotecache: Only visit each item once when walking results.
