### PR TITLE
[19.03] vendor: moby/buildkit v0.6.4-28-gda1f4bf1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -26,7 +26,7 @@ github.com/imdario/mergo                            7c29201646fa3de8506f70121347
 golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af2b83e6acac3c
 
 # buildkit
-github.com/moby/buildkit                            a1e4f48e712360e6292819e55285e1bbacce99d4 # v0.6.4-26-ga1e4f48e
+github.com/moby/buildkit                            da1f4bf179dcc972d023f30c0d5b4a6576ff385f # v0.6.4-28-gda1f4bf1
 github.com/tonistiigi/fsutil                        6c909ab392c173a4264ae1bfcbc0450b9aac0c7d
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7

--- a/vendor/github.com/moby/buildkit/cache/refs.go
+++ b/vendor/github.com/moby/buildkit/cache/refs.go
@@ -123,7 +123,10 @@ func (cr *cacheRecord) Size(ctx context.Context) (int64, error) {
 		cr.mu.Unlock()
 		return usage.Size, nil
 	})
-	return s.(int64), err
+	if err != nil {
+		return 0, err
+	}
+	return s.(int64), nil
 }
 
 func (cr *cacheRecord) Parent() ImmutableRef {


### PR DESCRIPTION
full diff: https://github.com/moby/buildkit/compare/a1e4f48e712360e6292819e55285e1bbacce99d4...da1f4bf179dcc972d023f30c0d5b4a6576ff385f

- https://github.com/moby/buildkit/pull/1608 [v0.6 backport] cache: avoid nil dereference
    - fixes https://github.com/moby/buildkit/issues/1510 panic: interface conversion: interface {} is nil, not int64


