### PR TITLE
vendor: docker/swarmkit 293aa2e66279a930999044cbf6d0e590baac16ff

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -134,7 +134,7 @@ github.com/gogo/googleapis                          01e0f9cca9b92166042241267ee2
 github.com/cilium/ebpf                              60c3aa43f488292fe2ee50fb8b833b383ca8ebbb
 
 # cluster
-github.com/docker/swarmkit                          035d564a3686f5e348d861ec0c074ff26854c498
+github.com/docker/swarmkit                          293aa2e66279a930999044cbf6d0e590baac16ff
 github.com/gogo/protobuf                            5628607bb4c51c3157aacc3a50f0ab707582b805 # v1.3.1
 github.com/golang/protobuf                          d23c5127dc24889085f8ccea5c9d560a57a879d8 # v1.3.3
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2

--- a/vendor/github.com/docker/swarmkit/api/specs.pb.go
+++ b/vendor/github.com/docker/swarmkit/api/specs.pb.go
@@ -1021,7 +1021,7 @@ type ContainerSpec struct {
 	Sysctls map[string]string `protobuf:"bytes,26,rep,name=sysctls,proto3" json:"sysctls,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// CapabilityAdd sets the list of capabilities to add to the default capability list
 	CapabilityAdd []string `protobuf:"bytes,27,rep,name=capability_add,json=capabilityAdd,proto3" json:"capability_add,omitempty"`
-	// CapabilityAdd sets the list of capabilities to drop from the default capability list
+	// CapabilityDrop sets the list of capabilities to drop from the default capability list
 	CapabilityDrop []string `protobuf:"bytes,28,rep,name=capability_drop,json=capabilityDrop,proto3" json:"capability_drop,omitempty"`
 }
 

--- a/vendor/github.com/docker/swarmkit/api/specs.proto
+++ b/vendor/github.com/docker/swarmkit/api/specs.proto
@@ -358,7 +358,7 @@ message ContainerSpec {
 
 	// CapabilityAdd sets the list of capabilities to add to the default capability list
 	repeated string capability_add = 27;
-	// CapabilityAdd sets the list of capabilities to drop from the default capability list
+	// CapabilityDrop sets the list of capabilities to drop from the default capability list
 	repeated string capability_drop = 28;
 }
 


### PR DESCRIPTION
full diff: https://github.com/docker/swarmkit/compare/035d564a3686f5e348d861ec0c074ff26854c498...293aa2e66279a930999044cbf6d0e590baac16ff

- Fix bad comment on capability_drop field in protobuf def

