### PR TITLE
[19.03 backport] vendor: vishvananda/netns db3c7e526aae966c4ccfa6c8189b693d6ac5d202

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -50,7 +50,7 @@ github.com/hashicorp/go-sockaddr                    c7188e74f6acae5a989bdc959aa7
 github.com/hashicorp/go-multierror                  886a7fbe3eb1c874d46f623bfa70af45f425b3d1 # v1.0.0
 github.com/hashicorp/serf                           598c54895cc5a7b1a24a398d635e8c0ea0959870
 github.com/docker/libkv                             458977154600b9f23984d9f4b82e79570b5ae12b
-github.com/vishvananda/netns                        7109fa855b0ff1ebef7fbd2f6aa613e8db7cfbc0
+github.com/vishvananda/netns                        0a2b9b5464df8343199164a0321edf3313202f7e
 github.com/vishvananda/netlink                      a2ad57a690f3caf3015351d2d6e1c0b95c349752
 
 # When updating, consider updating TOMLV_COMMIT in hack/dockerfile/install/tomlv.installer accordingly

--- a/vendor.conf
+++ b/vendor.conf
@@ -50,7 +50,7 @@ github.com/hashicorp/go-sockaddr                    c7188e74f6acae5a989bdc959aa7
 github.com/hashicorp/go-multierror                  886a7fbe3eb1c874d46f623bfa70af45f425b3d1 # v1.0.0
 github.com/hashicorp/serf                           598c54895cc5a7b1a24a398d635e8c0ea0959870
 github.com/docker/libkv                             458977154600b9f23984d9f4b82e79570b5ae12b
-github.com/vishvananda/netns                        0a2b9b5464df8343199164a0321edf3313202f7e
+github.com/vishvananda/netns                        db3c7e526aae966c4ccfa6c8189b693d6ac5d202
 github.com/vishvananda/netlink                      a2ad57a690f3caf3015351d2d6e1c0b95c349752
 
 # When updating, consider updating TOMLV_COMMIT in hack/dockerfile/install/tomlv.installer accordingly

--- a/vendor/github.com/vishvananda/netns/go.mod
+++ b/vendor/github.com/vishvananda/netns/go.mod
@@ -1,0 +1,3 @@
+module github.com/vishvananda/netns
+
+go 1.12

--- a/vendor/github.com/vishvananda/netns/go.mod
+++ b/vendor/github.com/vishvananda/netns/go.mod
@@ -1,3 +1,5 @@
 module github.com/vishvananda/netns
 
 go 1.12
+
+require golang.org/x/sys v0.0.0-20200217220822-9197077df867

--- a/vendor/github.com/vishvananda/netns/netns_linux.go
+++ b/vendor/github.com/vishvananda/netns/netns_linux.go
@@ -6,46 +6,30 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
-)
 
-// SYS_SETNS syscall allows changing the namespace of the current process.
-var SYS_SETNS = map[string]uintptr{
-	"386":     346,
-	"amd64":   308,
-	"arm64":   268,
-	"arm":     375,
-	"mips":    4344,
-	"mipsle":  4344,
-	"mips64le":  4344,
-	"ppc64":   350,
-	"ppc64le": 350,
-	"riscv64": 268,
-	"s390x":   339,
-}[runtime.GOARCH]
+	"golang.org/x/sys/unix"
+)
 
 // Deprecated: use syscall pkg instead (go >= 1.5 needed).
 const (
-	CLONE_NEWUTS  = 0x04000000 /* New utsname group? */
-	CLONE_NEWIPC  = 0x08000000 /* New ipcs */
-	CLONE_NEWUSER = 0x10000000 /* New user namespace */
-	CLONE_NEWPID  = 0x20000000 /* New pid namespace */
-	CLONE_NEWNET  = 0x40000000 /* New network namespace */
-	CLONE_IO      = 0x80000000 /* Get io context */
+	CLONE_NEWUTS  = 0x04000000   /* New utsname group? */
+	CLONE_NEWIPC  = 0x08000000   /* New ipcs */
+	CLONE_NEWUSER = 0x10000000   /* New user namespace */
+	CLONE_NEWPID  = 0x20000000   /* New pid namespace */
+	CLONE_NEWNET  = 0x40000000   /* New network namespace */
+	CLONE_IO      = 0x80000000   /* Get io context */
+	bindMountPath = "/run/netns" /* Bind mount path for named netns */
 )
 
 // Setns sets namespace using syscall. Note that this should be a method
 // in syscall but it has not been added.
 func Setns(ns NsHandle, nstype int) (err error) {
-	_, _, e1 := syscall.Syscall(SYS_SETNS, uintptr(ns), uintptr(nstype), 0)
-	if e1 != 0 {
-		err = e1
-	}
-	return
+	return unix.Setns(int(ns), nstype)
 }
 
 // Set sets the current network namespace to the namespace represented
@@ -57,21 +41,64 @@ func Set(ns NsHandle) (err error) {
 // New creates a new network namespace, sets it as current and returns
 // a handle to it.
 func New() (ns NsHandle, err error) {
-	if err := syscall.Unshare(CLONE_NEWNET); err != nil {
+	if err := unix.Unshare(CLONE_NEWNET); err != nil {
 		return -1, err
 	}
 	return Get()
 }
 
+// NewNamed creates a new named network namespace and returns a handle to it
+func NewNamed(name string) (NsHandle, error) {
+	if _, err := os.Stat(bindMountPath); os.IsNotExist(err) {
+		err = os.MkdirAll(bindMountPath, 0755)
+		if err != nil {
+			return None(), err
+		}
+	}
+
+	newNs, err := New()
+	if err != nil {
+		return None(), err
+	}
+
+	namedPath := path.Join(bindMountPath, name)
+
+	f, err := os.OpenFile(namedPath, os.O_CREATE|os.O_EXCL, 0444)
+	if err != nil {
+		return None(), err
+	}
+	f.Close()
+
+	nsPath := fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), syscall.Gettid())
+	err = syscall.Mount(nsPath, namedPath, "bind", syscall.MS_BIND, "")
+	if err != nil {
+		return None(), err
+	}
+
+	return newNs, nil
+}
+
+// DeleteNamed deletes a named network namespace
+func DeleteNamed(name string) error {
+	namedPath := path.Join(bindMountPath, name)
+
+	err := syscall.Unmount(namedPath, syscall.MNT_DETACH)
+	if err != nil {
+		return err
+	}
+
+	return os.Remove(namedPath)
+}
+
 // Get gets a handle to the current threads network namespace.
 func Get() (NsHandle, error) {
-	return GetFromThread(os.Getpid(), syscall.Gettid())
+	return GetFromThread(os.Getpid(), unix.Gettid())
 }
 
 // GetFromPath gets a handle to a network namespace
 // identified by the path
 func GetFromPath(path string) (NsHandle, error) {
-	fd, err := syscall.Open(path, syscall.O_RDONLY, 0)
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/41283. Added one extra commit to account for the netns bump not in 19.03 from https://github.com/moby/moby/commit/e26e1cc5c1c7ffd1948bb3bf21714347eeaf3752 (https://github.com/moby/moby/pull/40683)

full diff: https://github.com/vishvananda/netns/compare/0a2b9b5464df8343199164a0321edf3313202f7e...db3c7e526aae966c4ccfa6c8189b693d6ac5d202

- Use golang.org/x/sys/unix instead of syscall
- Set O_CLOEXEC when opening a network namespace
    - Fixes https://github.com/moby/moby/issues/41136 "the container‘s netns fds leak, causing the container netns to not
      clean up successfully after the container stops"
- Allows to create and delete named network namespaces

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->



