### PR TITLE
oci/deviceCgroup(): remove redundant variable

### DIFF
--- a/oci/devices_linux.go
+++ b/oci/devices_linux.go
@@ -25,10 +25,9 @@ func Device(d *configs.Device) specs.LinuxDevice {
 }
 
 func deviceCgroup(d *configs.Device) specs.LinuxDeviceCgroup {
-	t := string(d.Type)
 	return specs.LinuxDeviceCgroup{
 		Allow:  true,
-		Type:   t,
+		Type:   string(d.Type),
 		Major:  &d.Major,
 		Minor:  &d.Minor,
 		Access: d.Permissions,


### PR DESCRIPTION
noticed this when looking at another PR


Was also wondering why `Device` is exported, as it's only used within this package (it was added in https://github.com/moby/moby/commit/53b9b99e5cd19d9913c56c07276a2d4d83b9befd, but didn't see a mention why it was exported)

@tiborvass 