### PR TITLE
Pass underlying network error in ErrorConnectionFailed

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -134,8 +134,7 @@ func (cli *Client) doRequest(ctx context.Context, req *http.Request) (serverResp
 
 		// Don't decorate context sentinel errors; users may be comparing to
 		// them directly.
-		switch err {
-		case context.Canceled, context.DeadlineExceeded:
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return serverResp, err
 		}
 


### PR DESCRIPTION
**- What I did**
I changed the check for context error returned by net/http.Client.Do
**- How I did it**
by using github.com/pkg/errors.Is that searches for desired error in err's chain
**- How to verify it**
I've encountered shallow error message telling me to check if docker daemon is running but actual problem was in context deadline exceeding. To verify pass to client a context with a deadline that is in the past.
**- Description for the changelog**
Fixes context errors being treated as connectivity error in client

**- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Evgeniy Makhrov <e.makhrov@corp.badoo.com>