### PR TITLE
Disable manifest v2 schema 1 push

### DIFF
--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -38,6 +38,9 @@ fi
 # intentionally open a couple bogus file descriptors to help test that they get scrubbed in containers
 exec 41>&1 42>&2
 
+# Allow pushing manifest v2 schema 1 images, as they're used to push
+# images to our test-registries for testing _pulling_ schema 2v1 images.
+export DOCKER_ALLOW_SCHEMA1_PUSH_DONOTUSE=1
 export DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
 export DOCKER_USERLANDPROXY=${DOCKER_USERLANDPROXY:-true}
 


### PR DESCRIPTION
temporary alternative for 

- https://github.com/moby/moby/pull/39384
- https://github.com/moby/moby/pull/42300

For CI, a temporary `DOCKER_ALLOW_SCHEMA1_PUSH_DONOTUSE` environment variable was added while we work out a solution for testing schema 1 pulls (which currently require pushing them to a local registry first for testing).

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

