### PR TITLE
docker.service: Add multi-user.target to After= in unit file

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network-online.target docker.socket firewalld.service
+After=network-online.target docker.socket firewalld.service multi-user.target
 Wants=network-online.target
 Requires=docker.socket
 


### PR DESCRIPTION
After installing docker on Arch, and enabling the docker.service, I noticed that the time to boot my computer increased substantially. I traced this down to a dependency chain involving docker, and I believe that I have a solution that maintains the correct functionality of the docker.service unit file, while also preventing the hang when booting.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I noticed on my Arch machine that the time to reach multi-user.target was delayed by several seconds because docker.service was waiting for a network connection. This was preventing the launch of the graphical environment until my Wi-Fi was connected, adding about six seconds to my boot.

I added the multi-user.target to the After list on the docker.service unit file in hopes that it would allow multi-user.target to complete before docker.service. This seemed to work, and I think that it would make a good contribution to the unit file. The docker.service still starts up at boot, but it no longer stalls the graphical environment.

**- How I did it**
I used systemd-analyse and systemctl to locate what was causing my slow boot problem. I found that because socker.service requires network-online.target and is wanted by multi-user.target, the critical chain of services for the graphical.target included waiting for NetworkManager-wait-online.service. This meant that my computer was waiting until after my wifi connection was established to show me a login screen. By adding multi-user.target to the After list on my unit file, this situation was avoided.

**- How to verify it**
Add multi-user.target to the After= list in docker.service so that multi-user.target does not wait for docker.service (and consequently wait for network-online.target).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

-- After=network-online.target docker.socket firewalld.service
++ After=network-online.target docker.socket firewalld.service multi-user.target
