### PR TITLE
fix buildkit nil panic when frontend image exists

### DIFF
--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -151,7 +151,7 @@ func (is *Source) ResolveImageConfig(ctx context.Context, ref string, opt llb.Re
 	case source.ResolveModePreferLocal:
 		img, err := is.resolveLocal(ref)
 		if err == nil {
-			if !platformMatches(img, opt.Platform) {
+			if opt.Platform != nil && !platformMatches(img, opt.Platform) {
 				logrus.WithField("ref", ref).Debugf("Requested build platform %s does not match local image platform %s, checking remote",
 					path.Join(opt.Platform.OS, opt.Platform.Architecture, opt.Platform.Variant),
 					path.Join(img.OS, img.Architecture, img.Variant),


### PR DESCRIPTION
**- What I did**
Fix the nil panic in builder-next

**- How I did it**
I got a nil panic with these steps:

Dockerfile :
```
# cat Dockerfile
# syntax = docker/dockerfile:1.0-experimental
FROM redis
COPY a* /
```
The frontend image exists on the server:
```
# docker images |grep 1.0-experimental
docker/dockerfile                        1.0-experimental    70387ff0e5d2        17 months ago       16.3MB
```
A panic will be as follows when docker build with `export DOCKER_BUILDKIT=1`
```
Jul 29 07:15:10 localhost dockerd: panic: runtime error: invalid memory address or nil pointer dereference
Jul 29 07:15:10 localhost dockerd: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x56484879dad0]
Jul 29 07:15:10 localhost dockerd: goroutine 486 [running]:
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/builder/builder-next/adapters/containerimage.platformMatches(0xc000bea000, 0x0, 0x2c)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/builder/builder-next/adapters/containerimage/pull.go:923 +0x100
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/builder/builder-next/adapters/containerimage.(*imageSource).ResolveImageConfig(0xc000aa35f0, 0x564849bbf420, 0xc000a69560, 0xc0007d1560, 0x2c, 0x0, 0x0, 0x0, 0xc000bbac80, 0x45, ...)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/builder/builder-next/adapters/containerimage/pull.go:151 +0x1ab
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/builder/builder-next/worker.(*Worker).ResolveImageConfig(0xc000a3ec00, 0x564849bbf420, 0xc000a69560, 0xc0007d1560, 0x2c, 0x0, 0x0, 0x0, 0xc000bbac80, 0x45, ...)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/builder/builder-next/worker/worker.go:205 +0xe5
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver.(*llbBridge).ResolveImageConfig.func1(0x564849bbf420, 0xc000a69560, 0xc000a0ff50, 0x0)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver/bridge.go:275 +0xee
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver.inVertexContext(0x564849bbf420, 0xc000a69560, 0xc000bbac80, 0x45, 0xc0004fba40, 0x37, 0xc000a10170, 0x0, 0x0)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver/solver.go:349 +0x25c
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver.(*llbBridge).ResolveImageConfig(0xc00083f3b0, 0x564849bbf420, 0xc000729560, 0xc0007d1560, 0x2c, 0x0, 0x0, 0x0, 0xc000bbac80, 0x45, ...)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver/bridge.go:274 +0x2ad
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/gateway.(*gatewayFrontend).Solve(0xc000ace8f0, 0x564849bbf420, 0xc000729560, 0x564849bace20, 0xc00083f3b0, 0xc000729380, 0xc000a69440, 0x0, 0x0, 0x0)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/gateway/gateway.go:123 +0x17c8
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver.(*llbBridge).Solve(0xc00083f3b0, 0x564849bbf420, 0xc000729560, 0x0, 0x564848a6c98e, 0xa, 0xc000729380, 0xc000a69440, 0x0, 0x0, ...)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver/bridge.go:135 +0x11e
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/gateway/forwarder.(*bridgeClient).Solve(0xc0002d9c80, 0x564849bbf420, 0xc000729560, 0x0, 0x564848a6c98e, 0xa, 0xc000729380, 0xc000a69440, 0x0, 0x0, ...)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/gateway/forwarder/forward.go:47 +0x157
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/dockerfile/builder.forwardGateway(0x564849bbf420, 0xc000729560, 0x564849bbffe0, 0xc0002d9c80, 0xc0007d14db, 0x22, 0xc0007d14db, 0x22, 0x1, 0x1, ...)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/dockerfile/builder/build.go:506 +0x281
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/dockerfile/builder.Build(0x564849bbf420, 0xc000729560, 0x564849bbffe0, 0xc0002d9c80, 0xc000729380, 0x0, 0xc00083f400)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/dockerfile/builder/build.go:326 +0x19d5
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/gateway/forwarder.(*GatewayForwarder).Solve(0xc000ab1fc0, 0x564849bbf420, 0xc000729560, 0x564849bace20, 0xc00083f3b0, 0xc000729380, 0x0, 0x0, 0x0, 0x0)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/frontend/gateway/forwarder/frontend.go:33 +0x176
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver.(*llbBridge).Solve(0xc00083f3b0, 0x564849bbf420, 0xc000729560, 0x0, 0x564848a7299a, 0xd, 0xc000729380, 0x0, 0x0, 0x0, ...)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver/bridge.go:135 +0x11e
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver.(*Solver).Solve(0xc000af67e0, 0x564849bbf420, 0xc000729560, 0xc0007188c1, 0x19, 0x0, 0x564848a7299a, 0xd, 0xc000729380, 0x0, ...)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/solver/llbsolver/solver.go:127 +0x39f
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/vendor/github.com/moby/buildkit/control.(*Controller).Solve(0xc000c185a0, 0x564849bbf360, 0xc00027e640, 0xc000bc0c60, 0x0, 0x0, 0x0)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/control/control.go:276 +0x501
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/builder/builder-next.(*Builder).Build.func2(0xc0007a5f68, 0x0)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/builder/builder-next/builder.go:381 +0x76
Jul 29 07:15:10 localhost dockerd: github.com/docker/docker/vendor/golang.org/x/sync/errgroup.(*Group).Go.func1(0xc000729410, 0xc00083f310)
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/vendor/golang.org/x/sync/errgroup/errgroup.go:57 +0x66
Jul 29 07:15:10 localhost dockerd: created by github.com/docker/docker/vendor/golang.org/x/sync/errgroup.(*Group).Go
Jul 29 07:15:10 localhost dockerd: /go/src/github.com/docker/docker/vendor/golang.org/x/sync/errgroup/errgroup.go:54 +0x68
Jul 29 07:15:10 localhost systemd: docker.service: main process exited, code=exited, status=2/INVALIDARGUMENT
Jul 29 07:15:10 localhost systemd: Unit docker.service entered failed state.
Jul 29 07:15:10 localhost systemd: docker.service failed.
```

**- How to verify it**
After this PR, docker build successfully
