### PR TITLE
[WIP] Add new device path types for window container

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -279,13 +279,15 @@ func (daemon *Daemon) createSpecWindowsFields(c *container.Container, s *specs.S
 		if osversion.Build() < osversion.RS5 {
 			return errors.New("device assignment requires Windows builds RS5 (17763+) or later")
 		}
+		listDevicePathTypes := []string{"class", "gpu", "vpci-location-path", "vpci-class-guid"}
+		_strTypeCheck := strings.Join(append([]string{""}, append(listDevicePathTypes, "")...), "||")
 		for _, deviceMapping := range c.HostConfig.Devices {
 			srcParts := strings.SplitN(deviceMapping.PathOnHost, "/", 2)
 			if len(srcParts) != 2 {
 				return errors.New("invalid device assignment path")
 			}
-			if srcParts[0] != "class" {
-				return errors.Errorf("invalid device assignment type: '%s' should be 'class'", srcParts[0])
+			if strings.Contains(_strTypeCheck, "||"+srcParts[0]+"||") {
+				return errors.Errorf("invalid device assignment type: '%s' should be in '%s'", srcParts[0], strings.Join(listDevicePathTypes, ", "))
 			}
 			wd := specs.WindowsDevice{
 				ID:     srcParts[1],


### PR DESCRIPTION
Signed-off-by: Quang Kieu <quangkieu1993@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Update windows device path check logic to support new hcshim device path types
**- How I did it**

- Define a list of supported path types.
- Join that list with separator to an approved string, prepended and appended the string with the same separator
- Per Assigned path type is prepended and appended the string with the same separator
- Each path type would be check if contains in approved string above

**- How to verify it**
WIP
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Support new windows device path types [class, gpu, vpci-location-path, vpci-class-guid]

**- A picture of a cute animal (not mandatory but encouraged)**

