### PR TITLE
[19.03 backport] Check for context error that is wrapped in url.Error

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -143,8 +143,7 @@ func (cli *Client) doRequest(ctx context.Context, req *http.Request) (serverResp
 
 		// Don't decorate context sentinel errors; users may be comparing to
 		// them directly.
-		switch err {
-		case context.Canceled, context.DeadlineExceeded:
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return serverResp, err
 		}
 


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/41292