### PR TITLE
Update runc binary to v1.0.0-rc92

### DIFF
--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -4,7 +4,7 @@
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-: ${RUNC_COMMIT:=24a3cf88a7ae5f4995f6750654c0e2ca61ef4bb2} # v1.0.0-rc91
+: ${RUNC_COMMIT:=ff819c7e9184c13b7c2607fe6c30ae19403a7aff} # v1.0.0-rc92
 
 install_runc() {
 	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting


### PR DESCRIPTION
full diff https://github.com/opencontainers/runc/compare/v1.0.0-rc91...v1.0.0-rc92

> This release contains a hotfix to solve a regression in v1.0.0-rc91 that
> concerns Docker (this only affects Docker's vendoring of libcontainer,
> not the usage of runc as the runtime):
> 
> Fix helpers used by Docker to correctly handle symlinks in /dev (when running
> with --privileged containers).
> As well as some other improvements:
> 
> Updates to CRIU support.
> Improvements to cgroupfs performance and correctness.
> Static Linking Notices
> The runc binary distributed with this release are statically linked with
> the following GNU LGPL-2.1 licensed libraries, with runc acting
> as a "work that uses the Library":
> 
> libseccomp
> The versions of these libraries were not modified from their upstream versions,
> but in order to comply with the LGPL-2.1 (§6(a)), we have attached the
> complete source code for those libraries which (when combined with the attached
> runc source code) may be used to exercise your rights under the LGPL-2.1.
> 
> However we strongly suggest that you make use of your distribution's packages
> or download them from the authoritative upstream sources, especially since
> these libraries are related to the security of your containers.
