### PR TITLE
Add test coverage to seccomp.

### DIFF
--- a/daemon/seccomp_linux_test.go
+++ b/daemon/seccomp_linux_test.go
@@ -1,0 +1,198 @@
+// +build linux,seccomp
+
+package daemon // import "github.com/docker/docker/daemon"
+
+import (
+	"testing"
+
+	coci "github.com/containerd/containerd/oci"
+	config "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/container"
+	doci "github.com/docker/docker/oci"
+	"github.com/docker/docker/profiles/seccomp"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"gotest.tools/v3/assert"
+)
+
+func TestWithSeccomp(t *testing.T) {
+
+	type expected struct {
+		daemon  *Daemon
+		c       *container.Container
+		inSpec  coci.Spec
+		outSpec coci.Spec
+		err     string
+		comment string
+	}
+
+	for _, x := range []expected{
+		{
+			comment: "unconfined seccompProfile runs unconfined",
+			daemon: &Daemon{
+				seccompEnabled: true,
+			},
+			c: &container.Container{
+				SeccompProfile: "unconfined",
+				HostConfig: &config.HostConfig{
+					Privileged: false,
+				},
+			},
+			inSpec:  doci.DefaultLinuxSpec(),
+			outSpec: doci.DefaultLinuxSpec(),
+		},
+		{
+			comment: "privileged container w/ custom profile runs unconfined",
+			daemon: &Daemon{
+				seccompEnabled: true,
+			},
+			c: &container.Container{
+				SeccompProfile: "{ \"defaultAction\": \"SCMP_ACT_LOG\" }",
+				HostConfig: &config.HostConfig{
+					Privileged: true,
+				},
+			},
+			inSpec:  doci.DefaultLinuxSpec(),
+			outSpec: doci.DefaultLinuxSpec(),
+		},
+		{
+			comment: "privileged container w/ default runs unconfined",
+			daemon: &Daemon{
+				seccompEnabled: true,
+			},
+			c: &container.Container{
+				SeccompProfile: "",
+				HostConfig: &config.HostConfig{
+					Privileged: true,
+				},
+			},
+			inSpec:  doci.DefaultLinuxSpec(),
+			outSpec: doci.DefaultLinuxSpec(),
+		},
+		{
+			comment: "privileged container w/ daemon profile runs unconfined",
+			daemon: &Daemon{
+				seccompEnabled: true,
+				seccompProfile: []byte("{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }"),
+			},
+			c: &container.Container{
+				SeccompProfile: "",
+				HostConfig: &config.HostConfig{
+					Privileged: true,
+				},
+			},
+			inSpec:  doci.DefaultLinuxSpec(),
+			outSpec: doci.DefaultLinuxSpec(),
+		},
+		{
+			comment: "custom profile when seccomp is disabled returns error",
+			daemon: &Daemon{
+				seccompEnabled: false,
+			},
+			c: &container.Container{
+				SeccompProfile: "{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }",
+				HostConfig: &config.HostConfig{
+					Privileged: false,
+				},
+			},
+			inSpec:  doci.DefaultLinuxSpec(),
+			outSpec: doci.DefaultLinuxSpec(),
+			err:     "seccomp is not enabled in your kernel, cannot run a custom seccomp profile",
+		},
+		{
+			comment: "empty profile name loads default profile",
+			daemon: &Daemon{
+				seccompEnabled: true,
+			},
+			c: &container.Container{
+				SeccompProfile: "",
+				HostConfig: &config.HostConfig{
+					Privileged: false,
+				},
+			},
+			inSpec: doci.DefaultLinuxSpec(),
+			outSpec: func() coci.Spec {
+				s := doci.DefaultLinuxSpec()
+				profile, _ := seccomp.GetDefaultProfile(&s)
+				s.Linux.Seccomp = profile
+				return s
+			}(),
+		},
+		{
+			comment: "load container's profile",
+			daemon: &Daemon{
+				seccompEnabled: true,
+			},
+			c: &container.Container{
+				SeccompProfile: "{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }",
+				HostConfig: &config.HostConfig{
+					Privileged: false,
+				},
+			},
+			inSpec: doci.DefaultLinuxSpec(),
+			outSpec: func() coci.Spec {
+				s := doci.DefaultLinuxSpec()
+				profile := &specs.LinuxSeccomp{
+					DefaultAction: specs.LinuxSeccompAction("SCMP_ACT_ERRNO"),
+				}
+				s.Linux.Seccomp = profile
+				return s
+			}(),
+		},
+		{
+			comment: "load daemon's profile",
+			daemon: &Daemon{
+				seccompEnabled: true,
+				seccompProfile: []byte("{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }"),
+			},
+			c: &container.Container{
+				SeccompProfile: "",
+				HostConfig: &config.HostConfig{
+					Privileged: false,
+				},
+			},
+			inSpec: doci.DefaultLinuxSpec(),
+			outSpec: func() coci.Spec {
+				s := doci.DefaultLinuxSpec()
+				profile := &specs.LinuxSeccomp{
+					DefaultAction: specs.LinuxSeccompAction("SCMP_ACT_ERRNO"),
+				}
+				s.Linux.Seccomp = profile
+				return s
+			}(),
+		},
+		{
+			comment: "load prioritise container profile over daemon's",
+			daemon: &Daemon{
+				seccompEnabled: true,
+				seccompProfile: []byte("{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }"),
+			},
+			c: &container.Container{
+				SeccompProfile: "{ \"defaultAction\": \"SCMP_ACT_LOG\" }",
+				HostConfig: &config.HostConfig{
+					Privileged: false,
+				},
+			},
+			inSpec: doci.DefaultLinuxSpec(),
+			outSpec: func() coci.Spec {
+				s := doci.DefaultLinuxSpec()
+				profile := &specs.LinuxSeccomp{
+					DefaultAction: specs.LinuxSeccompAction("SCMP_ACT_LOG"),
+				}
+				s.Linux.Seccomp = profile
+				return s
+			}(),
+		},
+	} {
+		t.Run(x.comment, func(t *testing.T) {
+			opts := WithSeccomp(x.daemon, x.c)
+			err := opts(nil, nil, nil, &x.inSpec)
+
+			assert.DeepEqual(t, x.inSpec, x.outSpec)
+			if x.err != "" {
+				assert.Error(t, err, x.err)
+			} else {
+				assert.NilError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Created tests to make seccomp behaviour explicit and increase our regression cover.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
Add unit tests for seccomp
-->


![image](https://user-images.githubusercontent.com/5452977/89593448-1849f880-d847-11ea-9148-c4f3b63ac654.png)

This relates to https://github.com/moby/moby/issues/28011
Signed-off-by: Paulo Gomes <pjbgf@linux.com>