### PR TITLE
Add support for custom seccomp in privileged containers

### DIFF
--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -25,9 +25,6 @@ func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		if c.SeccompProfile == "unconfined" {
 			return nil
 		}
-		if c.HostConfig.Privileged {
-			return nil
-		}
 		if !daemon.seccompEnabled {
 			if c.SeccompProfile != "" {
 				return fmt.Errorf("seccomp is not enabled in your kernel, cannot run a custom seccomp profile")
@@ -42,6 +39,9 @@ func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 				return err
 			}
 		} else {
+			if c.HostConfig.Privileged {
+				return nil
+			}
 			if daemon.seccompProfile != nil {
 				profile, err = seccomp.LoadProfile(string(daemon.seccompProfile), s)
 				if err != nil {

--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -22,18 +22,18 @@ func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		var profile *specs.LinuxSeccomp
 		var err error
 
+		if c.SeccompProfile == "unconfined" {
+			return nil
+		}
 		if c.HostConfig.Privileged {
 			return nil
 		}
-
 		if !daemon.seccompEnabled {
-			if c.SeccompProfile != "" && c.SeccompProfile != "unconfined" {
+			if c.SeccompProfile != "" {
 				return fmt.Errorf("seccomp is not enabled in your kernel, cannot run a custom seccomp profile")
 			}
 			logrus.Warn("seccomp is not enabled in your kernel, running container without default profile")
 			c.SeccompProfile = "unconfined"
-		}
-		if c.SeccompProfile == "unconfined" {
 			return nil
 		}
 		if c.SeccompProfile != "" {

--- a/daemon/seccomp_linux_test.go
+++ b/daemon/seccomp_linux_test.go
@@ -1,0 +1,200 @@
+// +build linux,seccomp
+
+package daemon // import "github.com/docker/docker/daemon"
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	coci "github.com/containerd/containerd/oci"
+	config "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/container"
+	doci "github.com/docker/docker/oci"
+	"github.com/docker/docker/profiles/seccomp"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"gotest.tools/v3/assert"
+)
+
+func TestWithSeccomp(t *testing.T) {
+
+	type expected struct {
+		daemon  *Daemon
+		c       *container.Container
+		inSpec  coci.Spec
+		outSpec coci.Spec
+		err     error
+		comment string
+	}
+
+	for _, x := range []expected{
+		{
+			comment: "unconfined seccompProfile runs unconfined",
+			daemon: &Daemon{
+				seccompEnabled: true,
+			},
+			c: &container.Container{
+				SeccompProfile: "unconfined",
+				HostConfig: &config.HostConfig{
+					Privileged: false,
+				},
+			},
+			inSpec:  doci.DefaultLinuxSpec(),
+			outSpec: doci.DefaultLinuxSpec(),
+		},
+		{
+			comment: "privileged container w/ custom profile runs unconfined",
+			daemon: &Daemon{
+				seccompEnabled: true,
+			},
+			c: &container.Container{
+				SeccompProfile: "{ \"defaultAction\": \"SCMP_ACT_LOG\" }",
+				HostConfig: &config.HostConfig{
+					Privileged: true,
+				},
+			},
+			inSpec:  doci.DefaultLinuxSpec(),
+			outSpec: doci.DefaultLinuxSpec(),
+		},
+		{
+			comment: "privileged container w/ default runs unconfined",
+			daemon: &Daemon{
+				seccompEnabled: true,
+			},
+			c: &container.Container{
+				SeccompProfile: "",
+				HostConfig: &config.HostConfig{
+					Privileged: true,
+				},
+			},
+			inSpec:  doci.DefaultLinuxSpec(),
+			outSpec: doci.DefaultLinuxSpec(),
+		},
+		{
+			comment: "privileged container w/ daemon profile runs unconfined",
+			daemon: &Daemon{
+				seccompEnabled: true,
+				seccompProfile: []byte("{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }"),
+			},
+			c: &container.Container{
+				SeccompProfile: "",
+				HostConfig: &config.HostConfig{
+					Privileged: true,
+				},
+			},
+			inSpec:  doci.DefaultLinuxSpec(),
+			outSpec: doci.DefaultLinuxSpec(),
+		},
+		{
+			comment: "custom profile when seccomp is disabled returns error",
+			daemon: &Daemon{
+				seccompEnabled: false,
+			},
+			c: &container.Container{
+				SeccompProfile: "{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }",
+				HostConfig: &config.HostConfig{
+					Privileged: false,
+				},
+			},
+			inSpec:  doci.DefaultLinuxSpec(),
+			outSpec: doci.DefaultLinuxSpec(),
+			err:     fmt.Errorf("seccomp is not enabled in your kernel, cannot run a custom seccomp profile"),
+		},
+		{
+			comment: "empty profile name loads default profile",
+			daemon: &Daemon{
+				seccompEnabled: true,
+			},
+			c: &container.Container{
+				SeccompProfile: "",
+				HostConfig: &config.HostConfig{
+					Privileged: false,
+				},
+			},
+			inSpec: doci.DefaultLinuxSpec(),
+			outSpec: func() coci.Spec {
+				s := doci.DefaultLinuxSpec()
+				profile, _ := seccomp.GetDefaultProfile(&s)
+				s.Linux.Seccomp = profile
+				return s
+			}(),
+		},
+		{
+			comment: "load container's profile",
+			daemon: &Daemon{
+				seccompEnabled: true,
+			},
+			c: &container.Container{
+				SeccompProfile: "{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }",
+				HostConfig: &config.HostConfig{
+					Privileged: false,
+				},
+			},
+			inSpec: doci.DefaultLinuxSpec(),
+			outSpec: func() coci.Spec {
+				s := doci.DefaultLinuxSpec()
+				profile := &specs.LinuxSeccomp{
+					DefaultAction: specs.LinuxSeccompAction("SCMP_ACT_ERRNO"),
+				}
+				s.Linux.Seccomp = profile
+				return s
+			}(),
+		},
+		{
+			comment: "load daemon's profile",
+			daemon: &Daemon{
+				seccompEnabled: true,
+				seccompProfile: []byte("{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }"),
+			},
+			c: &container.Container{
+				SeccompProfile: "",
+				HostConfig: &config.HostConfig{
+					Privileged: false,
+				},
+			},
+			inSpec: doci.DefaultLinuxSpec(),
+			outSpec: func() coci.Spec {
+				s := doci.DefaultLinuxSpec()
+				profile := &specs.LinuxSeccomp{
+					DefaultAction: specs.LinuxSeccompAction("SCMP_ACT_ERRNO"),
+				}
+				s.Linux.Seccomp = profile
+				return s
+			}(),
+		},
+		{
+			comment: "load prioritise container profile over daemon's",
+			daemon: &Daemon{
+				seccompEnabled: true,
+				seccompProfile: []byte("{ \"defaultAction\": \"SCMP_ACT_ERRNO\" }"),
+			},
+			c: &container.Container{
+				SeccompProfile: "{ \"defaultAction\": \"SCMP_ACT_LOG\" }",
+				HostConfig: &config.HostConfig{
+					Privileged: false,
+				},
+			},
+			inSpec: doci.DefaultLinuxSpec(),
+			outSpec: func() coci.Spec {
+				s := doci.DefaultLinuxSpec()
+				profile := &specs.LinuxSeccomp{
+					DefaultAction: specs.LinuxSeccompAction("SCMP_ACT_LOG"),
+				}
+				s.Linux.Seccomp = profile
+				return s
+			}(),
+		},
+	} {
+
+		opts := WithSeccomp(x.daemon, x.c)
+		err := opts(nil, nil, nil, &x.inSpec)
+
+		if !reflect.DeepEqual(err, x.err) {
+			t.Fatalf("%s\nexpected:\n\t%v\n\ngot:\n\t%v", x.comment, x.err, err)
+		}
+		if !reflect.DeepEqual(x.inSpec, x.outSpec) {
+			t.Errorf("%s", x.comment)
+		}
+		assert.DeepEqual(t, x.inSpec, x.outSpec)
+	}
+}

--- a/daemon/seccomp_linux_test.go
+++ b/daemon/seccomp_linux_test.go
@@ -43,7 +43,7 @@ func TestWithSeccomp(t *testing.T) {
 			outSpec: doci.DefaultLinuxSpec(),
 		},
 		{
-			comment: "privileged container w/ custom profile runs unconfined",
+			comment: "privileged container w/ custom profile honours profile",
 			daemon: &Daemon{
 				seccompEnabled: true,
 			},
@@ -53,8 +53,16 @@ func TestWithSeccomp(t *testing.T) {
 					Privileged: true,
 				},
 			},
-			inSpec:  doci.DefaultLinuxSpec(),
-			outSpec: doci.DefaultLinuxSpec(),
+			inSpec: doci.DefaultLinuxSpec(),
+			outSpec: func() coci.Spec {
+				s := doci.DefaultLinuxSpec()
+				profile := &specs.LinuxSeccomp{
+					DefaultAction: specs.LinuxSeccompAction("SCMP_ACT_LOG"),
+				}
+				s.Linux.Seccomp = profile
+				return s
+			}(),
+			err: nil,
 		},
 		{
 			comment: "privileged container w/ default runs unconfined",


### PR DESCRIPTION
Add support for custom seccomp in privileged containers.
This expands on changes from another PR which adds unit tests to increase seccomp coverage and regression.

![image](https://user-images.githubusercontent.com/5452977/89593318-bd180600-d846-11ea-89ab-3fe29ea2d218.png)

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
Add support for custom seccomp in privileged containers
-->

Fixes #41321
Signed-off-by: Paulo Gomes <pjbgf@linux.com>