### PR TITLE
builder/remotecontext: use lowercase for error

### DIFF
--- a/builder/dockerfile/internals_test.go
+++ b/builder/dockerfile/internals_test.go
@@ -50,7 +50,7 @@ func TestDockerfileOutsideTheBuildContext(t *testing.T) {
 	contextDir, cleanup := createTestTempDir(t, "", "builder-dockerfile-test")
 	defer cleanup()
 
-	expectedError := "Forbidden path outside the build context: ../../Dockerfile ()"
+	expectedError := "path outside the build context: ../../Dockerfile ()"
 	if runtime.GOOS == "windows" {
 		expectedError = "failed to resolve scoped path ../../Dockerfile ()"
 	}

--- a/builder/remotecontext/detect.go
+++ b/builder/remotecontext/detect.go
@@ -185,7 +185,7 @@ func FullPath(remote builder.Source, path string) (string, error) {
 		if runtime.GOOS == "windows" {
 			return "", fmt.Errorf("failed to resolve scoped path %s (%s): %s. Possible cause is a forbidden path outside the build context", path, fullPath, err)
 		}
-		return "", fmt.Errorf("Forbidden path outside the build context: %s (%s)", path, fullPath) // backwards compat with old error
+		return "", fmt.Errorf("forbidden path outside the build context: %s (%s)", path, fullPath) // backwards compat with old error
 	}
 	return fullPath, nil
 }


### PR DESCRIPTION
Errors should not be capitalized. This error was marked as "being compatible" with the old error, However, looking at the original error that was in place before d1faf3df27207af111daf4bd0191478c374dbc55, I noticed that the error was lowercase before, so it should be ok to change it back to be lowercase.

