### PR TITLE
build-arg add support BUILDKIT_SYNTAX

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -353,11 +353,17 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 		}
 	}
 
+	frontEnd := "dockerfile.v0"
+	if syntax := opt.Options.BuildArgs["BUILDKIT_SYNTAX"]; syntax != nil {
+		frontendAttrs["source"] = *syntax
+		frontEnd = "gateway.v0"
+	}
+
 	req := &controlapi.SolveRequest{
 		Ref:           id,
 		Exporter:      exporterName,
 		ExporterAttrs: exporterAttrs,
-		Frontend:      "dockerfile.v0",
+		Frontend:      frontEnd,
 		FrontendAttrs: frontendAttrs,
 		Session:       opt.Options.SessionID,
 		Cache:         cache,


### PR DESCRIPTION
**- What I did**

We are running a shared cluster to provide `docker build` service for hundreds of projects, and it's a lot of work if we want to change the `frontend` because we need update all the Dockerfiles (through  ` # syntax`  line), which are maintained by different teams.

I see that buildctl can specify the frontend via command line (https://github.com/moby/buildkit#building-a-dockerfile-using-external-frontend), so I propose that we add this support to `docker build` command line too.

**- How I did it**
Add support `BUILDKIT_SYNTAX` in `--build-arg` , so that we can use external frontend without change `Dockerfile`.

**- How to verify it**
```
export DOCKER_BUILDKIT=1
docker build -t mytest -f Dockerfile --build-arg "BUILDKIT_SYNTAX=mydockerfile" .
[+] Building 9.1s (9/9) FINISHED                                                                           
 => resolve image config for docker.io/library/mydockerfile:latest                                    0.0s
 => CACHED docker-image://docker.io/library/mydockerfile:latest                                       0.0s
 => [internal] load .dockerignore                                                                     2.1s
 => => transferring context: 2B                                                                       0.0s
 => [internal] load build definition from Dockerfile                                                  2.9s
 => => transferring dockerfile: 91B                                                                   0.0s
 => [internal] load metadata for docker.io/library/redis:latest                                       0.0s
 => [internal] load build context                                                                     1.3s
 => => transferring context: 2B                                                                       0.0s
 => [1/2] FROM docker.io/library/redis                                                                0.0s
 => CACHED [2/2] COPY a* /root                                                                        0.0s
 => exporting to image                                                                                1.6s
 => => exporting layers                                                                               0.0s
 => => writing image sha256:89b0a5f2d11dcbe2bcbf9b2601623a1e4c6f737b467efb4067057a3ad7047bb9          0.2s
 => => naming to docker.io/library/mytest                                                             0.0s
```
