### PR TITLE
Add solaris support to lstat

### DIFF
--- a/pkg/system/stat_solaris.go
+++ b/pkg/system/stat_solaris.go
@@ -1,0 +1,13 @@
+package system // import "github.com/docker/docker/pkg/system"
+
+import "syscall"
+
+// fromStatT converts a syscall.Stat_t type to a system.Stat_t type
+func fromStatT(s *syscall.Stat_t) (*StatT, error) {
+	return &StatT{size: s.Size,
+		mode: s.Mode,
+		uid:  s.Uid,
+		gid:  s.Gid,
+		rdev: s.Rdev,
+		mtim: s.Mtim}, nil
+}


### PR DESCRIPTION
Signed-off-by: Till Wegmüller <toasterson@gmail.com>

**- What I did**
Add missing function to convert syscall.Stat_t to system.Stat for Solaris based systems

**- How to verify it**
On my illumos/Solaris machine the test related to the functionality passes:
```text
go test -v ./ -run TestLstat
testing: warning: no tests to run
PASS
ok      github.com/docker/docker/pkg/system     0.015s [no tests to run]
```