### PR TITLE
Add openat2 and faccessat2 to default seccomp profile.

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -229,6 +229,7 @@
 				"_newselect",
 				"open",
 				"openat",
+				"openat2",
 				"pause",
 				"pipe",
 				"pipe2",

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -94,6 +94,7 @@
 				"exit",
 				"exit_group",
 				"faccessat",
+				"faccessat2",
 				"fadvise64",
 				"fadvise64_64",
 				"fallocate",

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -87,6 +87,7 @@ func DefaultProfile() *types.Seccomp {
 				"exit",
 				"exit_group",
 				"faccessat",
+				"faccessat2",
 				"fadvise64",
 				"fadvise64_64",
 				"fallocate",

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -222,6 +222,7 @@ func DefaultProfile() *types.Seccomp {
 				"_newselect",
 				"open",
 				"openat",
+				"openat2",
 				"pause",
 				"pipe",
 				"pipe2",


### PR DESCRIPTION
follow up to https://github.com/moby/moby/pull/41344#discussion_r469919978

Note: `openat2()`  first appeared in Linux 5.6. And Glibc does not provide a wrapper for this system call; call it using
       `syscall(2)`.

ref: https://man7.org/linux/man-pages/man2/openat2.2.html
