### PR TITLE
Builder: Add 1 buffer to two channels to avoid blocking goroutine

### DIFF
--- a/builder/dockerfile/containerbackend.go
+++ b/builder/dockerfile/containerbackend.go
@@ -45,7 +45,7 @@ var errCancelled = errors.New("build cancelled")
 // Run a container by ID
 func (c *containerManager) Run(ctx context.Context, cID string, stdout, stderr io.Writer) (err error) {
 	attached := make(chan struct{})
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() {
 		errCh <- c.backend.ContainerAttachRaw(cID, nil, stdout, stderr, true, attached)
 	}()

--- a/integration/plugin/logging/read_test.go
+++ b/integration/plugin/logging/read_test.go
@@ -73,7 +73,7 @@ func TestReadPluginNoRead(t *testing.T) {
 
 			buf := bytes.NewBuffer(nil)
 
-			errCh := make(chan error)
+			errCh := make(chan error, 1)
 			go func() {
 				_, err := stdcopy.StdCopy(buf, buf, logs)
 				errCh <- err


### PR DESCRIPTION
**- What I did**
Avoid two potential goroutine leaks by adding 1 buffer to the channels.
In the code below, if the function returns at line 75, then the child goroutine created at Line 49 will be leaked. 
https://github.com/moby/moby/blob/e9b4655bc98563602d961c72fc62cb20cc143515/builder/dockerfile/containerbackend.go#L48-L56
https://github.com/moby/moby/blob/e9b4655bc98563602d961c72fc62cb20cc143515/builder/dockerfile/containerbackend.go#L72-L76

A similar patch is for errCh in the following code
https://github.com/moby/moby/blob/e9b4655bc98563602d961c72fc62cb20cc143515/integration/plugin/logging/read_test.go#L76-L87

**- How to verify it**
This patch is very safe. After adding one buffer to the channels, the semantics of the program will not be changed because receive will still be blocking, except that the child goroutine can always be ended.
This patch is similar to #40144

**- Description for the changelog**
NONE

