### PR TITLE
Add image cache for image store

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -78,6 +78,18 @@ type Image struct {
 	computedID ID
 }
 
+// Meta store image meta info
+type Meta struct {
+	ID      ID
+	Parent  ID
+	OS      string
+	Created time.Time
+	Labels  map[string]string
+	Layer   layer.Layer
+
+	children map[ID]struct{}
+}
+
 // RawJSON returns the immutable JSON associated with the image.
 func (img *Image) RawJSON() []byte {
 	return img.rawJSON


### PR DESCRIPTION
In a system with hundreds of docker images stored, periodically calling of
api `/images/json` from process like kubelet will make dockerd daemon
a cpu hog. This patch add cache for docker images to avoid computing
sha256 hash and json decoding each time they are retrieved thus reducing
dockerd cpu overhead drastically.

Signed-off-by: Wenlin Wu <fzuwwl@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Improve dockerd's performance on systems with hundreds of docker images stored.

**- How I did it**
Add image cache for image store.

**- How to verify it**
To verify, you need to prepare a system with hundreds of docker images stored, and a simple shell script to query docker api `/images/json` every seconds is enough to create the payload. You will see the cpu usage of dockerd decrease drastically after applying this patch.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add image cache for image store.

**- A picture of a cute animal (not mandatory but encouraged)**

