### PR TITLE
Removed dependency on go.

### DIFF
--- a/contrib/download-frozen-image-v2.sh
+++ b/contrib/download-frozen-image-v2.sh
@@ -7,8 +7,20 @@ set -eo pipefail
 # debian                           latest              f6fab3b798be        10 weeks ago        85.1 MB
 # debian                           latest              f6fab3b798be3174f45aa1eb731f8182705555f89c9026d8c1ef230cbf8301dd   10 weeks ago        85.1 MB
 
+# Since go is only used for getting env. variables, we mock it when go is not installed
+if ! which go > /dev/null; then
+	go() {
+		if [[ "$1" == "env" ]]; then
+			env | grep "$2" | sed 's .*=  '
+		else
+			echo "error: go not found!"
+			exit 1
+		fi
+	}
+fi
+
 # check if essential commands are in our PATH
-for cmd in curl jq go; do
+for cmd in curl jq; do
 	if ! command -v $cmd &> /dev/null; then
 		echo >&2 "error: \"$cmd\" not found!"
 		exit 1


### PR DESCRIPTION
**- What I did**
Removed `go` dependency for `contrib/download-frozen-image-v2.sh` script.

**- How I did it**
Since `go` is only used for getting env variables, I mocked the behavior using `env`, `grep` and `sed`.

**- How to verify it**
Run the script or the added part of code in terminal.

**- Description for the changelog**
N/A
