### PR TITLE
vendor: containerd v1.4.0

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -123,7 +123,7 @@ github.com/googleapis/gax-go                        317e0006254c44a0ac427cc52a0e
 google.golang.org/genproto                          3f1135a288c9a07e340ae8ba4cc6c7065a3160e8
 
 # containerd
-github.com/containerd/containerd                    e9f94064b9616ab36a8a51d632a63f97f7783c3d # v1.4.0-rc.1
+github.com/containerd/containerd                    09814d48d50816305a8e6c1a4ae3e2bcc4ba725a # v1.4.0
 github.com/containerd/fifo                          f15a3290365b9d2627d189e619ab4008e0069caf
 github.com/containerd/continuity                    efbc4488d8fe1bdc16bde3b2d2990d9b3a899165
 github.com/containerd/cgroups                       318312a373405e5e91134d8063d04d59768a1bff

--- a/vendor/github.com/containerd/containerd/version/version.go
+++ b/vendor/github.com/containerd/containerd/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.4.0-rc.1+unknown"
+	Version = "1.4.0+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
follow-up to https://github.com/moby/moby/pull/40982

This is just to align to a tagged version, but given that the containerd
go-api is not considered "stable", we may switch back to a commit from
"master" at some point if needed.

No local changes.

