### PR TITLE
swagger: fix MemTotal units in SystemInfo endpoint

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4606,7 +4606,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -3599,7 +3599,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -3604,7 +3604,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -3633,7 +3633,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -3615,7 +3615,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -3628,7 +3628,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -3648,7 +3648,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -3702,7 +3702,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -4345,7 +4345,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -4467,7 +4467,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240


### PR DESCRIPTION
MemTotal represents bytes, not kilobytes.

Linux implementation:

https://github.com/moby/moby/blob/f50a40e889fdaeebf14fce1d494f95e60092d21d/pkg/system/meminfo_linux.go#L49

Windows implementation:

https://github.com/moby/moby/blob/f50a40e889fdaeebf14fce1d494f95e60092d21d/pkg/system/meminfo_windows.go#L40