### PR TITLE
Use type aliases to reduce unneeded type-conversions

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -163,7 +163,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 }
 
 func parseVersion(s string) (types.BuilderVersion, error) {
-	switch types.BuilderVersion(s) {
+	switch s {
 	case types.BuilderV1:
 		return types.BuilderV1, nil
 	case types.BuilderBuildKit:

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -336,7 +336,7 @@ func (s *containerRouter) postContainersWait(ctx context.Context, w http.Respons
 		if err := httputils.ParseForm(r); err != nil {
 			return err
 		}
-		switch container.WaitCondition(r.Form.Get("condition")) {
+		switch r.Form.Get("condition") {
 		case container.WaitConditionNextExit:
 			waitCondition = containerpkg.WaitConditionNextExit
 		case container.WaitConditionRemoved:

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -32,7 +32,7 @@ func (s *systemRouter) pingHandler(ctx context.Context, w http.ResponseWriter, r
 
 	builderVersion := build.BuilderVersion(*s.features)
 	if bv := builderVersion; bv != "" {
-		w.Header().Set("Builder-Version", string(bv))
+		w.Header().Set("Builder-Version", bv)
 	}
 	if r.Method == http.MethodHead {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -199,7 +199,7 @@ type ImageBuildOutput struct {
 }
 
 // BuilderVersion sets the version of underlying builder to use
-type BuilderVersion string
+type BuilderVersion = string
 
 const (
 	// BuilderV1 is the first generation builder in docker daemon

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -322,7 +322,7 @@ func (rp *RestartPolicy) IsSame(tp *RestartPolicy) bool {
 
 // LogMode is a type to define the available modes for logging
 // These modes affect how logs are handled when log messages start piling up.
-type LogMode string
+type LogMode = string
 
 // Available logging modes
 const (

--- a/api/types/container/waitcondition.go
+++ b/api/types/container/waitcondition.go
@@ -2,7 +2,7 @@ package container // import "github.com/docker/docker/api/types/container"
 
 // WaitCondition is a type used to specify a container state for which
 // to wait.
-type WaitCondition string
+type WaitCondition = string
 
 // Possible WaitCondition Values.
 //

--- a/api/types/mount/mount.go
+++ b/api/types/mount/mount.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Type represents the type of a mount.
-type Type string
+type Type = string
 
 // Type constants
 const (
@@ -36,7 +36,7 @@ type Mount struct {
 }
 
 // Propagation represents the propagation of a mount.
-type Propagation string
+type Propagation = string
 
 const (
 	// PropagationRPrivate RPRIVATE
@@ -64,7 +64,7 @@ var Propagations = []Propagation{
 }
 
 // Consistency represents the consistency requirements of a mount.
-type Consistency string
+type Consistency = string
 
 const (
 	// ConsistencyFull guarantees bind mount-like consistency

--- a/api/types/swarm/network.go
+++ b/api/types/swarm/network.go
@@ -18,7 +18,7 @@ type EndpointSpec struct {
 }
 
 // ResolutionMode represents a resolution mode.
-type ResolutionMode string
+type ResolutionMode = string
 
 const (
 	// ResolutionModeVIP VIP
@@ -41,7 +41,7 @@ type PortConfig struct {
 
 // PortConfigPublishMode represents the mode in which the port is to
 // be published.
-type PortConfigPublishMode string
+type PortConfigPublishMode = string
 
 const (
 	// PortConfigPublishModeIngress is used for ports published
@@ -53,7 +53,7 @@ const (
 )
 
 // PortConfigProtocol represents the protocol of a port.
-type PortConfigProtocol string
+type PortConfigProtocol = string
 
 const (
 	// TODO(stevvooe): These should be used generally, not just for PortConfig.

--- a/api/types/swarm/node.go
+++ b/api/types/swarm/node.go
@@ -25,7 +25,7 @@ type NodeSpec struct {
 }
 
 // NodeRole represents the role of a node.
-type NodeRole string
+type NodeRole = string
 
 const (
 	// NodeRoleWorker WORKER
@@ -35,7 +35,7 @@ const (
 )
 
 // NodeAvailability represents the availability of a node.
-type NodeAvailability string
+type NodeAvailability = string
 
 const (
 	// NodeAvailabilityActive ACTIVE
@@ -82,7 +82,7 @@ type NodeStatus struct {
 }
 
 // Reachability represents the reachability of a node.
-type Reachability string
+type Reachability = string
 
 const (
 	// ReachabilityUnknown UNKNOWN
@@ -101,7 +101,7 @@ type ManagerStatus struct {
 }
 
 // NodeState represents the state of a node.
-type NodeState string
+type NodeState = string
 
 const (
 	// NodeStateUnknown UNKNOWN

--- a/api/types/swarm/runtime.go
+++ b/api/types/swarm/runtime.go
@@ -1,10 +1,10 @@
 package swarm // import "github.com/docker/docker/api/types/swarm"
 
 // RuntimeType is the type of runtime used for the TaskSpec
-type RuntimeType string
+type RuntimeType = string
 
 // RuntimeURL is the proto type url
-type RuntimeURL string
+type RuntimeURL = string
 
 const (
 	// RuntimeContainer is the container based runtime

--- a/api/types/swarm/service.go
+++ b/api/types/swarm/service.go
@@ -50,7 +50,7 @@ type ServiceMode struct {
 }
 
 // UpdateState is the state of a service update.
-type UpdateState string
+type UpdateState = string
 
 const (
 	// UpdateStateUpdating is the updating state.

--- a/api/types/swarm/swarm.go
+++ b/api/types/swarm/swarm.go
@@ -127,7 +127,7 @@ type CAConfig struct {
 }
 
 // ExternalCAProtocol represents type of external CA.
-type ExternalCAProtocol string
+type ExternalCAProtocol = string
 
 // ExternalCAProtocolCFSSL CFSSL
 const ExternalCAProtocolCFSSL ExternalCAProtocol = "cfssl"
@@ -180,7 +180,7 @@ type UnlockRequest struct {
 }
 
 // LocalNodeState represents the state of the local node.
-type LocalNodeState string
+type LocalNodeState = string
 
 const (
 	// LocalNodeStateInactive INACTIVE

--- a/api/types/swarm/task.go
+++ b/api/types/swarm/task.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TaskState represents the state of a task.
-type TaskState string
+type TaskState = string
 
 const (
 	// TaskStateNew NEW
@@ -171,7 +171,7 @@ type RestartPolicy struct {
 }
 
 // RestartPolicyCondition represents when to restart.
-type RestartPolicyCondition string
+type RestartPolicyCondition = string
 
 const (
 	// RestartPolicyConditionNone NONE

--- a/client/container_wait.go
+++ b/client/container_wait.go
@@ -33,7 +33,7 @@ func (cli *Client) ContainerWait(ctx context.Context, containerID string, condit
 	errC := make(chan error, 1)
 
 	query := url.Values{}
-	query.Set("condition", string(condition))
+	query.Set("condition", condition)
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/wait", query, nil, nil)
 	if err != nil {

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -133,7 +133,7 @@ func (cli *Client) imageBuildOptionsToQuery(options types.ImageBuildOptions) (ur
 	if options.BuildID != "" {
 		query.Set("buildid", options.BuildID)
 	}
-	query.Set("version", string(options.Version))
+	query.Set("version", options.Version)
 
 	if options.Outputs != nil {
 		outputsJSON, err := json.Marshal(options.Outputs)

--- a/client/ping.go
+++ b/client/ping.go
@@ -59,7 +59,7 @@ func parsePingResponse(cli *Client, resp serverResponse) (types.Ping, error) {
 		ping.Experimental = true
 	}
 	if bv := resp.header.Get("Builder-Version"); bv != "" {
-		ping.BuilderVersion = types.BuilderVersion(bv)
+		ping.BuilderVersion = bv
 	}
 	err := cli.checkResponseErr(resp)
 	return ping, errdefs.FromStatusCode(err, resp.statusCode)

--- a/container/container.go
+++ b/container/container.go
@@ -411,7 +411,7 @@ func (container *Container) StartLogger() (logger.Logger, error) {
 		return nil, err
 	}
 
-	if containertypes.LogMode(cfg.Config["mode"]) == containertypes.LogModeNonBlock {
+	if cfg.Config["mode"] == containertypes.LogModeNonBlock {
 		bufferSize := int64(-1)
 		if s, exists := cfg.Config["max-buffer-size"]; exists {
 			bufferSize, err = units.RAMInBytes(s)

--- a/container/container_unit_test.go
+++ b/container/container_unit_test.go
@@ -108,7 +108,7 @@ func TestContainerLogPathSetForRingLogger(t *testing.T) {
 			LogConfig: container.LogConfig{
 				Type: jsonfilelog.Name,
 				Config: map[string]string{
-					"mode": string(container.LogModeNonBlock),
+					"mode": container.LogModeNonBlock,
 				},
 			},
 		},

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -78,7 +78,7 @@ func (container *Container) NetworkMounts() []Mount {
 				Source:      container.ResolvConfPath,
 				Destination: "/etc/resolv.conf",
 				Writable:    writable,
-				Propagation: string(parser.DefaultPropagationMode()),
+				Propagation: parser.DefaultPropagationMode(),
 			})
 		}
 	}
@@ -96,7 +96,7 @@ func (container *Container) NetworkMounts() []Mount {
 				Source:      container.HostnamePath,
 				Destination: "/etc/hostname",
 				Writable:    writable,
-				Propagation: string(parser.DefaultPropagationMode()),
+				Propagation: parser.DefaultPropagationMode(),
 			})
 		}
 	}
@@ -114,7 +114,7 @@ func (container *Container) NetworkMounts() []Mount {
 				Source:      container.HostsPath,
 				Destination: "/etc/hosts",
 				Writable:    writable,
-				Propagation: string(parser.DefaultPropagationMode()),
+				Propagation: parser.DefaultPropagationMode(),
 			})
 		}
 	}
@@ -212,7 +212,7 @@ func (container *Container) IpcMounts() []Mount {
 		Source:      container.ShmPath,
 		Destination: "/dev/shm",
 		Writable:    true,
-		Propagation: string(parser.DefaultPropagationMode()),
+		Propagation: parser.DefaultPropagationMode(),
 	})
 
 	return mounts

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -75,13 +75,13 @@ func containerSpecFromGRPC(c *swarmapi.ContainerSpec) *types.ContainerSpec {
 		mount := mounttypes.Mount{
 			Target:   m.Target,
 			Source:   m.Source,
-			Type:     mounttypes.Type(strings.ToLower(swarmapi.Mount_MountType_name[int32(m.Type)])),
+			Type:     strings.ToLower(swarmapi.Mount_MountType_name[int32(m.Type)]),
 			ReadOnly: m.ReadOnly,
 		}
 
 		if m.BindOptions != nil {
 			mount.BindOptions = &mounttypes.BindOptions{
-				Propagation:  mounttypes.Propagation(strings.ToLower(swarmapi.Mount_BindOptions_MountPropagation_name[int32(m.BindOptions.Propagation)])),
+				Propagation:  strings.ToLower(swarmapi.Mount_BindOptions_MountPropagation_name[int32(m.BindOptions.Propagation)]),
 				NonRecursive: m.BindOptions.NonRecursive,
 			}
 		}
@@ -323,16 +323,16 @@ func containerToGRPC(c *types.ContainerSpec) (*swarmapi.ContainerSpec, error) {
 			ReadOnly: m.ReadOnly,
 		}
 
-		if mountType, ok := swarmapi.Mount_MountType_value[strings.ToUpper(string(m.Type))]; ok {
+		if mountType, ok := swarmapi.Mount_MountType_value[strings.ToUpper(m.Type)]; ok {
 			mount.Type = swarmapi.Mount_MountType(mountType)
-		} else if string(m.Type) != "" {
+		} else if m.Type != "" {
 			return nil, fmt.Errorf("invalid MountType: %q", m.Type)
 		}
 
 		if m.BindOptions != nil {
-			if mountPropagation, ok := swarmapi.Mount_BindOptions_MountPropagation_value[strings.ToUpper(string(m.BindOptions.Propagation))]; ok {
+			if mountPropagation, ok := swarmapi.Mount_BindOptions_MountPropagation_value[strings.ToUpper(m.BindOptions.Propagation)]; ok {
 				mount.BindOptions = &swarmapi.Mount_BindOptions{Propagation: swarmapi.Mount_BindOptions_MountPropagation(mountPropagation)}
-			} else if string(m.BindOptions.Propagation) != "" {
+			} else if m.BindOptions.Propagation != "" {
 				return nil, fmt.Errorf("invalid MountPropagation: %q", m.BindOptions.Propagation)
 			}
 

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -95,7 +95,7 @@ func endpointSpecFromGRPC(es *swarmapi.EndpointSpec) *types.EndpointSpec {
 	var endpointSpec *types.EndpointSpec
 	if es != nil {
 		endpointSpec = &types.EndpointSpec{}
-		endpointSpec.Mode = types.ResolutionMode(strings.ToLower(es.Mode.String()))
+		endpointSpec.Mode = strings.ToLower(es.Mode.String())
 
 		for _, portState := range es.Ports {
 			endpointSpec.Ports = append(endpointSpec.Ports, swarmPortConfigToAPIPortConfig(portState))
@@ -129,8 +129,8 @@ func endpointFromGRPC(e *swarmapi.Endpoint) types.Endpoint {
 func swarmPortConfigToAPIPortConfig(portConfig *swarmapi.PortConfig) types.PortConfig {
 	return types.PortConfig{
 		Name:          portConfig.Name,
-		Protocol:      types.PortConfigProtocol(strings.ToLower(swarmapi.PortConfig_Protocol_name[int32(portConfig.Protocol)])),
-		PublishMode:   types.PortConfigPublishMode(strings.ToLower(swarmapi.PortConfig_PublishMode_name[int32(portConfig.PublishMode)])),
+		Protocol:      strings.ToLower(swarmapi.PortConfig_Protocol_name[int32(portConfig.Protocol)]),
+		PublishMode:   strings.ToLower(swarmapi.PortConfig_PublishMode_name[int32(portConfig.PublishMode)]),
 		TargetPort:    portConfig.TargetPort,
 		PublishedPort: portConfig.PublishedPort,
 	}

--- a/daemon/cluster/convert/node.go
+++ b/daemon/cluster/convert/node.go
@@ -14,11 +14,11 @@ func NodeFromGRPC(n swarmapi.Node) types.Node {
 	node := types.Node{
 		ID: n.ID,
 		Spec: types.NodeSpec{
-			Role:         types.NodeRole(strings.ToLower(n.Spec.DesiredRole.String())),
-			Availability: types.NodeAvailability(strings.ToLower(n.Spec.Availability.String())),
+			Role:         strings.ToLower(n.Spec.DesiredRole.String()),
+			Availability: strings.ToLower(n.Spec.Availability.String()),
 		},
 		Status: types.NodeStatus{
-			State:   types.NodeState(strings.ToLower(n.Status.State.String())),
+			State:   strings.ToLower(n.Status.State.String()),
 			Message: n.Status.Message,
 			Addr:    n.Status.Addr,
 		},
@@ -62,7 +62,7 @@ func NodeFromGRPC(n swarmapi.Node) types.Node {
 	if n.ManagerStatus != nil {
 		node.ManagerStatus = &types.ManagerStatus{
 			Leader:       n.ManagerStatus.Leader,
-			Reachability: types.Reachability(strings.ToLower(n.ManagerStatus.Reachability.String())),
+			Reachability: strings.ToLower(n.ManagerStatus.Reachability.String()),
 			Addr:         n.ManagerStatus.Addr,
 		}
 	}
@@ -78,13 +78,13 @@ func NodeSpecToGRPC(s types.NodeSpec) (swarmapi.NodeSpec, error) {
 			Labels: s.Labels,
 		},
 	}
-	if role, ok := swarmapi.NodeRole_value[strings.ToUpper(string(s.Role))]; ok {
+	if role, ok := swarmapi.NodeRole_value[strings.ToUpper(s.Role)]; ok {
 		spec.DesiredRole = swarmapi.NodeRole(role)
 	} else {
 		return swarmapi.NodeSpec{}, fmt.Errorf("invalid Role: %q", s.Role)
 	}
 
-	if availability, ok := swarmapi.NodeSpec_Availability_value[strings.ToUpper(string(s.Availability))]; ok {
+	if availability, ok := swarmapi.NodeSpec_Availability_value[strings.ToUpper(s.Availability)]; ok {
 		spec.Availability = swarmapi.NodeSpec_Availability(availability)
 	} else {
 		return swarmapi.NodeSpec{}, fmt.Errorf("invalid Availability: %q", s.Availability)

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -111,7 +111,7 @@ func serviceSpecFromGRPC(spec *swarmapi.ServiceSpec) (*types.ServiceSpec, error)
 		taskTemplate.Runtime = types.RuntimeContainer
 	case *swarmapi.TaskSpec_Generic:
 		switch t.Generic.Kind {
-		case string(types.RuntimePlugin):
+		case types.RuntimePlugin:
 			taskTemplate.Runtime = types.RuntimePlugin
 		default:
 			return nil, fmt.Errorf("unknown task runtime type: %s", t.Generic.Payload.TypeUrl)
@@ -216,9 +216,9 @@ func ServiceSpecToGRPC(s types.ServiceSpec) (swarmapi.ServiceSpec, error) {
 			}
 			spec.Task.Runtime = &swarmapi.TaskSpec_Generic{
 				Generic: &swarmapi.GenericRuntimeSpec{
-					Kind: string(types.RuntimePlugin),
+					Kind: types.RuntimePlugin,
 					Payload: &gogotypes.Any{
-						TypeUrl: string(types.RuntimeURLPlugin),
+						TypeUrl: types.RuntimeURLPlugin,
 						Value:   pluginSpec,
 					},
 				},
@@ -289,13 +289,13 @@ func ServiceSpecToGRPC(s types.ServiceSpec) (swarmapi.ServiceSpec, error) {
 
 		spec.Endpoint = &swarmapi.EndpointSpec{}
 
-		spec.Endpoint.Mode = swarmapi.EndpointSpec_ResolutionMode(swarmapi.EndpointSpec_ResolutionMode_value[strings.ToUpper(string(s.EndpointSpec.Mode))])
+		spec.Endpoint.Mode = swarmapi.EndpointSpec_ResolutionMode(swarmapi.EndpointSpec_ResolutionMode_value[strings.ToUpper(s.EndpointSpec.Mode)])
 
 		for _, portConfig := range s.EndpointSpec.Ports {
 			spec.Endpoint.Ports = append(spec.Endpoint.Ports, &swarmapi.PortConfig{
 				Name:          portConfig.Name,
-				Protocol:      swarmapi.PortConfig_Protocol(swarmapi.PortConfig_Protocol_value[strings.ToUpper(string(portConfig.Protocol))]),
-				PublishMode:   swarmapi.PortConfig_PublishMode(swarmapi.PortConfig_PublishMode_value[strings.ToUpper(string(portConfig.PublishMode))]),
+				Protocol:      swarmapi.PortConfig_Protocol(swarmapi.PortConfig_Protocol_value[strings.ToUpper(portConfig.Protocol)]),
+				PublishMode:   swarmapi.PortConfig_PublishMode(swarmapi.PortConfig_PublishMode_value[strings.ToUpper(portConfig.PublishMode)]),
 				TargetPort:    portConfig.TargetPort,
 				PublishedPort: portConfig.PublishedPort,
 			})
@@ -522,7 +522,7 @@ func restartPolicyToGRPC(p *types.RestartPolicy) (*swarmapi.RestartPolicy, error
 		case types.RestartPolicyConditionAny:
 			rp.Condition = swarmapi.RestartOnAny
 		default:
-			if string(p.Condition) != "" {
+			if p.Condition != "" {
 				return nil, fmt.Errorf("invalid RestartCondition: %q", p.Condition)
 			}
 			rp.Condition = swarmapi.RestartOnAny
@@ -696,7 +696,7 @@ func taskSpecFromGRPC(taskSpec swarmapi.TaskSpec) (types.TaskSpec, error) {
 		g := taskSpec.GetGeneric()
 		if g != nil {
 			switch g.Kind {
-			case string(types.RuntimePlugin):
+			case types.RuntimePlugin:
 				var p runtime.PluginSpec
 				if err := proto.Unmarshal(g.Payload.Value, &p); err != nil {
 					return t, errors.Wrap(err, "error unmarshalling plugin spec")

--- a/daemon/cluster/convert/service_test.go
+++ b/daemon/cluster/convert/service_test.go
@@ -35,18 +35,11 @@ func TestServiceConvertFromGRPCRuntimeContainer(t *testing.T) {
 	}
 
 	svc, err := ServiceFromGRPC(gs)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if svc.Spec.TaskTemplate.Runtime != swarmtypes.RuntimeContainer {
-		t.Fatalf("expected type %s; received %T", swarmtypes.RuntimeContainer, svc.Spec.TaskTemplate.Runtime)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, svc.Spec.TaskTemplate.Runtime, swarmtypes.RuntimeContainer)
 }
 
 func TestServiceConvertFromGRPCGenericRuntimePlugin(t *testing.T) {
-	kind := string(swarmtypes.RuntimePlugin)
-	url := swarmtypes.RuntimeURLPlugin
 	gs := swarmapi.Service{
 		Meta: swarmapi.Meta{
 			Version: swarmapi.Version{
@@ -62,9 +55,9 @@ func TestServiceConvertFromGRPCGenericRuntimePlugin(t *testing.T) {
 			Task: swarmapi.TaskSpec{
 				Runtime: &swarmapi.TaskSpec_Generic{
 					Generic: &swarmapi.GenericRuntimeSpec{
-						Kind: kind,
+						Kind: swarmtypes.RuntimePlugin,
 						Payload: &google_protobuf3.Any{
-							TypeUrl: string(url),
+							TypeUrl: swarmtypes.RuntimeURLPlugin,
 						},
 					},
 				},
@@ -73,13 +66,8 @@ func TestServiceConvertFromGRPCGenericRuntimePlugin(t *testing.T) {
 	}
 
 	svc, err := ServiceFromGRPC(gs)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if svc.Spec.TaskTemplate.Runtime != swarmtypes.RuntimePlugin {
-		t.Fatalf("expected type %s; received %T", swarmtypes.RuntimePlugin, svc.Spec.TaskTemplate.Runtime)
-	}
+	assert.NilError(t, err)
+	assert.Equal(t, svc.Spec.TaskTemplate.Runtime, swarmtypes.RuntimePlugin)
 }
 
 func TestServiceConvertToGRPCGenericRuntimePlugin(t *testing.T) {
@@ -102,10 +90,7 @@ func TestServiceConvertToGRPCGenericRuntimePlugin(t *testing.T) {
 	if !ok {
 		t.Fatal("expected type swarmapi.TaskSpec_Generic")
 	}
-
-	if v.Generic.Payload.TypeUrl != string(swarmtypes.RuntimeURLPlugin) {
-		t.Fatalf("expected url %s; received %s", swarmtypes.RuntimeURLPlugin, v.Generic.Payload.TypeUrl)
-	}
+	assert.Equal(t, v.Generic.Payload.TypeUrl, swarmtypes.RuntimeURLPlugin)
 }
 
 func TestServiceConvertToGRPCContainerRuntime(t *testing.T) {

--- a/daemon/cluster/convert/swarm.go
+++ b/daemon/cluster/convert/swarm.go
@@ -63,7 +63,7 @@ func SwarmFromGRPC(c swarmapi.Cluster) types.Swarm {
 
 	for _, ca := range c.Spec.CAConfig.ExternalCAs {
 		swarm.Spec.CAConfig.ExternalCAs = append(swarm.Spec.CAConfig.ExternalCAs, &types.ExternalCA{
-			Protocol: types.ExternalCAProtocol(strings.ToLower(ca.Protocol.String())),
+			Protocol: strings.ToLower(ca.Protocol.String()),
 			URL:      ca.URL,
 			Options:  ca.Options,
 			CACert:   string(ca.CACert),
@@ -132,7 +132,7 @@ func MergeSwarmSpecToGRPC(s types.Spec, spec swarmapi.ClusterSpec) (swarmapi.Clu
 	spec.CAConfig.ForceRotate = s.CAConfig.ForceRotate
 
 	for _, ca := range s.CAConfig.ExternalCAs {
-		protocol, ok := swarmapi.ExternalCA_CAProtocol_value[strings.ToUpper(string(ca.Protocol))]
+		protocol, ok := swarmapi.ExternalCA_CAProtocol_value[strings.ToUpper(ca.Protocol)]
 		if !ok {
 			return swarmapi.ClusterSpec{}, fmt.Errorf("invalid protocol: %q", ca.Protocol)
 		}

--- a/daemon/cluster/convert/task.go
+++ b/daemon/cluster/convert/task.go
@@ -23,11 +23,11 @@ func TaskFromGRPC(t swarmapi.Task) (types.Task, error) {
 		NodeID:      t.NodeID,
 		Spec:        taskSpec,
 		Status: types.TaskStatus{
-			State:   types.TaskState(strings.ToLower(t.Status.State.String())),
+			State:   strings.ToLower(t.Status.State.String()),
 			Message: t.Status.Message,
 			Err:     t.Status.Err,
 		},
-		DesiredState:     types.TaskState(strings.ToLower(t.DesiredState.String())),
+		DesiredState:     strings.ToLower(t.DesiredState.String()),
 		GenericResources: GenericResourcesFromGRPC(t.AssignedGenericResources),
 	}
 
@@ -58,8 +58,8 @@ func TaskFromGRPC(t swarmapi.Task) (types.Task, error) {
 	for _, p := range t.Status.PortStatus.Ports {
 		task.Status.PortStatus.Ports = append(task.Status.PortStatus.Ports, types.PortConfig{
 			Name:          p.Name,
-			Protocol:      types.PortConfigProtocol(strings.ToLower(swarmapi.PortConfig_Protocol_name[int32(p.Protocol)])),
-			PublishMode:   types.PortConfigPublishMode(strings.ToLower(swarmapi.PortConfig_PublishMode_name[int32(p.PublishMode)])),
+			Protocol:      strings.ToLower(swarmapi.PortConfig_Protocol_name[int32(p.Protocol)]),
+			PublishMode:   strings.ToLower(swarmapi.PortConfig_PublishMode_name[int32(p.PublishMode)]),
 			TargetPort:    p.TargetPort,
 			PublishedPort: p.PublishedPort,
 		})

--- a/daemon/cluster/executor/container/executor.go
+++ b/daemon/cluster/executor/container/executor.go
@@ -225,7 +225,7 @@ func (e *executor) Controller(t *api.Task) (exec.Controller, error) {
 			return ctlr, err
 		}
 		switch runtimeKind {
-		case string(swarmtypes.RuntimePlugin):
+		case swarmtypes.RuntimePlugin:
 			if !e.backend.HasExperimental() {
 				return ctlr, fmt.Errorf("runtime type %q only supported in experimental", swarmtypes.RuntimePlugin)
 			}

--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -147,7 +147,7 @@ func (n *nodeRunner) start(conf nodeStartConfig) error {
 		PluginGetter:     n.cluster.config.Backend.PluginGetter(),
 	}
 	if conf.availability != "" {
-		avail, ok := swarmapi.NodeSpec_Availability_value[strings.ToUpper(string(conf.availability))]
+		avail, ok := swarmapi.NodeSpec_Availability_value[strings.ToUpper(conf.availability)]
 		if !ok {
 			return fmt.Errorf("invalid Availability: %q", conf.availability)
 		}

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -53,7 +53,7 @@ func (c *Cluster) GetServices(options apitypes.ServiceListOptions) ([]types.Serv
 
 	if len(options.Filters.Get("runtime")) == 0 {
 		// Default to using the container runtime filter
-		options.Filters.Add("runtime", string(types.RuntimeContainer))
+		options.Filters.Add("runtime", types.RuntimeContainer)
 	}
 
 	filters := &swarmapi.ListServicesRequest_Filters{
@@ -200,7 +200,7 @@ func (c *Cluster) CreateService(s types.ServiceSpec, encodedAuth string, queryRe
 		// handle other runtimes here
 		case *swarmapi.TaskSpec_Generic:
 			switch serviceSpec.Task.GetGeneric().Kind {
-			case string(types.RuntimePlugin):
+			case types.RuntimePlugin:
 				if !c.config.Backend.HasExperimental() {
 					return fmt.Errorf("runtime type %q only supported in experimental", types.RuntimePlugin)
 				}
@@ -309,7 +309,7 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec typ
 			return fmt.Errorf("invalid task spec: spec type %q not supported", types.RuntimeNetworkAttachment)
 		case *swarmapi.TaskSpec_Generic:
 			switch serviceSpec.Task.GetGeneric().Kind {
-			case string(types.RuntimePlugin):
+			case types.RuntimePlugin:
 				if spec.TaskTemplate.PluginSpec == nil {
 					return errors.New("plugin spec must be set")
 				}

--- a/daemon/logger/factory.go
+++ b/daemon/logger/factory.go
@@ -136,14 +136,14 @@ func ValidateLogOpts(name string, cfg map[string]string) error {
 		return nil
 	}
 
-	switch containertypes.LogMode(cfg["mode"]) {
+	switch cfg["mode"] {
 	case containertypes.LogModeBlocking, containertypes.LogModeNonBlock, containertypes.LogModeUnset:
 	default:
 		return fmt.Errorf("logger: logging mode not supported: %s", cfg["mode"])
 	}
 
 	if s, ok := cfg["max-buffer-size"]; ok {
-		if containertypes.LogMode(cfg["mode"]) != containertypes.LogModeNonBlock {
+		if cfg["mode"] != containertypes.LogModeNonBlock {
 			return fmt.Errorf("logger: max-buffer-size option is only supported with 'mode=%s'", containertypes.LogModeNonBlock)
 		}
 		if _, err := units.RAMInBytes(s); err != nil {

--- a/daemon/logger/loggerutils/cache/local_cache.go
+++ b/daemon/logger/loggerutils/cache/local_cache.go
@@ -36,7 +36,7 @@ func WithLocalCache(l logger.Logger, info logger.Info) (logger.Logger, error) {
 		return nil, errors.Wrap(err, "error initializing local log cache driver")
 	}
 
-	if info.Config["mode"] == container.LogModeUnset || container.LogMode(info.Config["mode"]) == container.LogModeNonBlock {
+	if info.Config["mode"] == container.LogModeUnset || info.Config["mode"] == container.LogModeNonBlock {
 		var size int64 = -1
 		if s, exists := info.Config["max-buffer-size"]; exists {
 			size, err = units.RAMInBytes(s)

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -589,7 +589,7 @@ func WithMounts(daemon *Daemon, c *container.Container) coci.SpecOpts {
 			if m.Source == "tmpfs" {
 				data := m.Data
 				parser := volumemounts.NewParser("linux")
-				options := []string{"noexec", "nosuid", "nodev", string(parser.DefaultPropagationMode())}
+				options := []string{"noexec", "nosuid", "nodev", parser.DefaultPropagationMode()}
 				if data != "" {
 					options = append(options, strings.Split(data, ",")...)
 				}

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -57,7 +57,7 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 				Source:      path,
 				Destination: m.Destination,
 				Writable:    m.RW,
-				Propagation: string(m.Propagation),
+				Propagation: m.Propagation,
 			}
 			if m.Spec.Type == mounttypes.TypeBind && m.Spec.BindOptions != nil {
 				mnt.NonRecursive = m.Spec.BindOptions.NonRecursive
@@ -68,7 +68,7 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 					"container":   c.ID,
 					"destination": m.Destination,
 					"read/write":  strconv.FormatBool(m.RW),
-					"propagation": string(m.Propagation),
+					"propagation": m.Propagation,
 				}
 				daemon.LogVolumeEvent(m.Volume.Name(), "mount", attributes)
 			}

--- a/libcontainerd/types/types.go
+++ b/libcontainerd/types/types.go
@@ -10,7 +10,7 @@ import (
 )
 
 // EventType represents a possible event from libcontainerd
-type EventType string
+type EventType = string
 
 // Event constants used when reporting events
 const (

--- a/volume/mounts/linux_parser.go
+++ b/volume/mounts/linux_parser.go
@@ -145,8 +145,7 @@ var linuxPropagationModes = map[mount.Propagation]bool{
 const linuxDefaultPropagationMode = mount.PropagationRPrivate
 
 func linuxGetPropagation(mode string) mount.Propagation {
-	for _, o := range strings.Split(mode, ",") {
-		prop := mount.Propagation(o)
+	for _, prop := range strings.Split(mode, ",") {
 		if linuxPropagationModes[prop] {
 			return prop
 		}
@@ -156,7 +155,7 @@ func linuxGetPropagation(mode string) mount.Propagation {
 
 func linuxHasPropagation(mode string) bool {
 	for _, o := range strings.Split(mode, ",") {
-		if linuxPropagationModes[mount.Propagation(o)] {
+		if linuxPropagationModes[o] {
 			return true
 		}
 	}
@@ -180,11 +179,11 @@ func linuxValidMountMode(mode string) bool {
 			rwModeCount++
 		case linuxLabelModes[o]:
 			labelModeCount++
-		case linuxPropagationModes[mount.Propagation(o)]:
+		case linuxPropagationModes[o]:
 			propagationModeCount++
 		case copyModeExists(o):
 			copyModeCount++
-		case linuxConsistencyModes[mount.Consistency(o)]:
+		case linuxConsistencyModes[o]:
 			consistencyModeCount++
 		default:
 			return false

--- a/volume/mounts/windows_parser.go
+++ b/volume/mounts/windows_parser.go
@@ -438,7 +438,7 @@ func (p *windowsParser) ParseVolumesFrom(spec string) (string, string, error) {
 }
 
 func (p *windowsParser) DefaultPropagationMode() mount.Propagation {
-	return mount.Propagation("")
+	return ""
 }
 
 func (p *windowsParser) ConvertTmpfsOptions(opt *mount.TmpfsOptions, readOnly bool) (string, error) {


### PR DESCRIPTION
I was reviewing https://github.com/opencontainers/runtime-spec/pull/1063, and thought to have a look if we could use aliases in our code to simplify / reduce unneeded conversions