### PR TITLE
Add fromStatT() implementation for NetBSD

### DIFF
--- a/pkg/system/stat_netbsd.go
+++ b/pkg/system/stat_netbsd.go
@@ -1,0 +1,13 @@
+package system // import "github.com/docker/docker/pkg/system"
+
+import "syscall"
+
+// fromStatT converts a syscall.Stat_t type to a system.Stat_t type
+func fromStatT(s *syscall.Stat_t) (*StatT, error) {
+	return &StatT{size: s.Size,
+		mode: uint32(s.Mode),
+		uid:  s.Uid,
+		gid:  s.Gid,
+		rdev: uint64(s.Rdev),
+		mtim: s.Mtimespec}, nil
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

When packaging [amazon-ecs-cli](https://github.com/aws/amazon-ecs-cli) in [pkgsrc-wip](https://www.pkgsrc.org/wip/) I have noticed build failure due non-existent `stat_netbsd.go`.


**- How I did it**

On a NetBSD machine that supports Go, assuming pkgsrc tree and
pkgsrc-wip tree are checked out, try:

```
% cd pkgsrc/wip/amazon-ecs-cli
% rm patches/patch-ecs-cli_vendor_github.com_docker_docker_pkg_system_stat__netbsd.go
% make mps
% make
```


**- How to verify it**

Please see above.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add `fromStatT()` implementation for NetBSD


**- A picture of a cute animal (not mandatory but encouraged)**

N/A, sorry! :)

But here a nice goat emoji!:

 🐐