### PR TITLE
daemon: add ability for custom AppArmor profiles

### DIFF
--- a/cmd/dockerd/config_unix.go
+++ b/cmd/dockerd/config_unix.go
@@ -59,6 +59,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.Int64Var(&conf.CPURealtimePeriod, "cpu-rt-period", 0, "Limit the CPU real-time period in microseconds for the parent cgroup for all containers")
 	flags.Int64Var(&conf.CPURealtimeRuntime, "cpu-rt-runtime", 0, "Limit the CPU real-time runtime in microseconds for the parent cgroup for all containers")
 	flags.StringVar(&conf.SeccompProfile, "seccomp-profile", "", "Path to seccomp profile")
+	flags.StringVar(&conf.AppArmorProfile, "apparmor-profile", "", "Path to apparmor profile")
 	flags.Var(&conf.ShmSize, "default-shm-size", "Default shm size for containers")
 	flags.BoolVar(&conf.NoNewPrivileges, "no-new-privileges", false, "Set no-new-privileges by default for new containers")
 	flags.StringVar(&conf.IpcMode, "default-ipc-mode", config.DefaultIpcMode, `Default mode for containers ipc ("shareable" | "private")`)

--- a/daemon/apparmor_default.go
+++ b/daemon/apparmor_default.go
@@ -15,23 +15,45 @@ const (
 	defaultAppArmorProfile    = "docker-default"
 )
 
-func ensureDefaultAppArmorProfile() error {
-	if apparmor.IsEnabled() {
-		loaded, err := aaprofile.IsLoaded(defaultAppArmorProfile)
-		if err != nil {
-			return fmt.Errorf("Could not check if %s AppArmor profile was loaded: %s", defaultAppArmorProfile, err)
-		}
+// installDefaultAppArmorProfile installs the configured default daemon
+// profile, overwriting any existing profile (if installed).
+func (daemon *Daemon) installDefaultAppArmorProfile() error {
+	if !apparmor.IsEnabled() {
+		return nil
+	}
 
-		// Nothing to do.
-		if loaded {
-			return nil
-		}
-
-		// Load the profile.
-		if err := aaprofile.InstallDefault(defaultAppArmorProfile); err != nil {
-			return fmt.Errorf("AppArmor enabled on system but the %s profile could not be loaded: %s", defaultAppArmorProfile, err)
-		}
+	// Load the profile.
+	var err error
+	if daemon.appArmorProfile != nil {
+		err = aaprofile.InstallCustom(daemon.appArmorProfile, defaultAppArmorProfile)
+	} else {
+		err = aaprofile.InstallDefault(defaultAppArmorProfile)
+	}
+	if err != nil {
+		return fmt.Errorf("AppArmor enabled on system but the %s profile could not be loaded: %s", defaultAppArmorProfile, err)
 	}
 
 	return nil
+}
+
+// ensureDefaultAppArmorProfile installs the configured default daemon profile
+// (using installDefaultAppArmorProfile) if the profile is not already loaded
+// (otherwise it does nothing).
+func (daemon *Daemon) ensureDefaultAppArmorProfile() error {
+	if !apparmor.IsEnabled() {
+		return nil
+	}
+
+	loaded, err := aaprofile.IsLoaded(defaultAppArmorProfile)
+	if err != nil {
+		return fmt.Errorf("Could not check if %s AppArmor profile was loaded: %s", defaultAppArmorProfile, err)
+	}
+
+	// Nothing to do.
+	if loaded {
+		return nil
+	}
+
+	// Load the profile.
+	return daemon.installDefaultAppArmorProfile()
 }

--- a/daemon/apparmor_default_unsupported.go
+++ b/daemon/apparmor_default_unsupported.go
@@ -2,6 +2,10 @@
 
 package daemon // import "github.com/docker/docker/daemon"
 
-func ensureDefaultAppArmorProfile() error {
+func (daemon *Daemon) installDefaultAppArmorProfile() error {
+	return nil
+}
+
+func (daemon *Daemon) ensureDefaultAppArmorProfile() error {
 	return nil
 }

--- a/daemon/config/config_unix.go
+++ b/daemon/config/config_unix.go
@@ -34,6 +34,7 @@ type Config struct {
 	Init                 bool                     `json:"init,omitempty"`
 	InitPath             string                   `json:"init-path,omitempty"`
 	SeccompProfile       string                   `json:"seccomp-profile,omitempty"`
+	AppArmorProfile      string                   `json:"apparmor-profile,omitempty"`
 	ShmSize              opts.MemBytes            `json:"default-shm-size,omitempty"`
 	NoNewPrivileges      bool                     `json:"no-new-privileges,omitempty"`
 	IpcMode              string                   `json:"default-ipc-mode,omitempty"`

--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -10,7 +10,7 @@ import (
 func (daemon *Daemon) saveAppArmorConfig(container *container.Container) error {
 	container.AppArmorProfile = "" // we don't care about the previous value.
 
-	if !daemon.apparmorEnabled {
+	if !daemon.appArmorEnabled {
 		return nil // if apparmor is disabled there is nothing to do here.
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 
 	"github.com/docker/docker/pkg/fileutils"
@@ -101,7 +102,7 @@ type Daemon struct {
 	discoveryWatcher  discovery.Reloader
 	root              string
 	seccompEnabled    bool
-	apparmorEnabled   bool
+	appArmorEnabled   bool
 	shutdown          bool
 	idMapping         *idtools.IdentityMapping
 	// TODO: move graphDrivers field to an InfoService
@@ -122,6 +123,9 @@ type Daemon struct {
 
 	seccompProfile     []byte
 	seccompProfilePath string
+
+	appArmorProfile     *template.Template
+	appArmorProfilePath string
 
 	diskUsageRunning int32
 	pruneRunning     int32
@@ -845,6 +849,9 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	if err := d.setupSeccompProfile(); err != nil {
 		return nil, err
 	}
+	if err := d.setupAppArmorProfile(); err != nil {
+		return nil, err
+	}
 
 	// Set the default isolation mode (only applicable on Windows)
 	if err := d.setDefaultIsolation(); err != nil {
@@ -853,11 +860,6 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 
 	if err := configureMaxThreads(config); err != nil {
 		logrus.Warnf("Failed to configure golang's threads limit: %v", err)
-	}
-
-	// ensureDefaultAppArmorProfile does nothing if apparmor is disabled
-	if err := ensureDefaultAppArmorProfile(); err != nil {
-		logrus.Errorf(err.Error())
 	}
 
 	daemonRepo := filepath.Join(config.Root, "containers")
@@ -1094,7 +1096,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	d.root = config.Root
 	d.idMapping = idMapping
 	d.seccompEnabled = sysInfo.Seccomp
-	d.apparmorEnabled = sysInfo.AppArmor
+	d.appArmorEnabled = sysInfo.AppArmor
 
 	d.linkIndex = newLinkIndex()
 

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -647,6 +647,10 @@ func (daemon *Daemon) setupSeccompProfile() error {
 	return nil
 }
 
+func (daemon *Daemon) setupAppArmorProfile() error {
+	return nil
+}
+
 func (daemon *Daemon) loadRuntimes() error {
 	return nil
 }

--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -46,7 +46,7 @@ func (daemon *Daemon) execSetPlatformOpt(c *container.Container, ec *exec.Config
 			// telling the system to keep our profile loaded, in order to make
 			// sure that we keep the default profile enabled we dynamically
 			// reload it if necessary.
-			if err := ensureDefaultAppArmorProfile(); err != nil {
+			if err := daemon.ensureDefaultAppArmorProfile(); err != nil {
 				return err
 			}
 		}

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -180,7 +180,11 @@ func (daemon *Daemon) fillPluginsInfo(v *types.Info) {
 func (daemon *Daemon) fillSecurityOptions(v *types.Info, sysInfo *sysinfo.SysInfo) {
 	var securityOptions []string
 	if sysInfo.AppArmor {
-		securityOptions = append(securityOptions, "name=apparmor")
+		profile := daemon.appArmorProfilePath
+		if profile == "" {
+			profile = "default"
+		}
+		securityOptions = append(securityOptions, fmt.Sprintf("name=apparmor,profile=%s", profile))
 	}
 	if sysInfo.Seccomp && supportsSeccomp {
 		profile := daemon.seccompProfilePath

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -125,8 +125,8 @@ func WithSelinux(c *container.Container) coci.SpecOpts {
 	}
 }
 
-// WithApparmor sets the apparmor profile
-func WithApparmor(c *container.Container) coci.SpecOpts {
+// WithAppArmor sets the AppArmor profile.
+func WithAppArmor(daemon *Daemon, c *container.Container) coci.SpecOpts {
 	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
 		if apparmor.IsEnabled() {
 			var appArmorProfile string
@@ -139,13 +139,13 @@ func WithApparmor(c *container.Container) coci.SpecOpts {
 			}
 
 			if appArmorProfile == defaultAppArmorProfile {
-				// Unattended upgrades and other fun services can unload AppArmor
-				// profiles inadvertently. Since we cannot store our profile in
-				// /etc/apparmor.d, nor can we practically add other ways of
-				// telling the system to keep our profile loaded, in order to make
-				// sure that we keep the default profile enabled we dynamically
-				// reload it if necessary.
-				if err := ensureDefaultAppArmorProfile(); err != nil {
+				// Unattended upgrades and other fun services can unload
+				// AppArmor profiles inadvertently. Since we cannot store our
+				// profile in /etc/apparmor.d, nor can we practically add other
+				// ways of telling the system to keep our profile loaded, in
+				// order to make sure that we keep the default profile enabled
+				// we dynamically reload it if necessary.
+				if err := daemon.ensureDefaultAppArmorProfile(); err != nil {
 					return err
 				}
 			}
@@ -1025,7 +1025,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (retSpec *specs.Spec, e
 		WithSeccomp(daemon, c),
 		WithMounts(daemon, c),
 		WithLibnetwork(daemon, c),
-		WithApparmor(c),
+		WithAppArmor(daemon, c),
 		WithSelinux(c),
 		WithOOMScore(&c.HostConfig.OomScoreAdj),
 	)

--- a/hack/validate/default
+++ b/hack/validate/default
@@ -5,6 +5,7 @@
 export SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 . "${SCRIPTDIR}"/dco
+. "${SCRIPTDIR}"/default-apparmor
 . "${SCRIPTDIR}"/default-seccomp
 . "${SCRIPTDIR}"/pkg-imports
 . "${SCRIPTDIR}"/swagger

--- a/hack/validate/default-apparmor
+++ b/hack/validate/default-apparmor
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+export SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPTDIR}/.validate"
+
+IFS=$'\n'
+files=($(validate_diff --diff-filter=ACMR --name-only -- 'profiles/apparmor' || true))
+unset IFS
+
+if [ -n "${TEST_FORCE_VALIDATE:-}" ] || [ ${#files[@]} -gt 0 ]; then
+	# We run 'go generate' and see if we have a diff afterwards
+	go generate ./profiles/apparmor/ > /dev/null
+	# Let see if the working directory is clean
+	diffs="$(git status --porcelain -- profiles/apparmor 2> /dev/null)"
+	if [ "$diffs" ]; then
+		{
+			echo 'The result of go generate ./profiles/apparmor/ differs'
+			echo
+			echo "$diffs"
+			echo
+			echo 'Please re-run go generate ./profiles/apparmor/'
+			echo
+		} >&2
+		false
+	else
+		echo 'Congratulations!  AppArmor profile generation is done correctly.'
+	fi
+fi

--- a/profiles/apparmor/default-profile
+++ b/profiles/apparmor/default-profile
@@ -1,15 +1,4 @@
-// +build linux
 
-package apparmor // import "github.com/docker/docker/profiles/apparmor"
-
-// NOTE: This profile is replicated in containerd and libpod. If you make a
-//       change to this profile, please make follow-up PRs to those projects so
-//       that these rules can be synchronised (because any issue with this
-//       profile will likely affect libpod and containerd).
-// TODO: Move this to a common project so we can maintain it in one spot.
-
-// baseTemplate defines the default apparmor profile for containers.
-const baseTemplate = `
 # NOTE: This profile is a Go template, which is necessary for the container
 #       runtime to be able to effectively handle different distributions. If
 #       you plan to modify and this template, be aware that some of these
@@ -89,11 +78,4 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
   ptrace (trace,read,tracedby,readby) peer={{.Name}},
 {{end}}
-}
-`
-
-// BaseTemplate returns the string form of the default AppArmor profile
-// template.
-func BaseTemplate() string {
-	return baseTemplate
 }

--- a/profiles/apparmor/generate.go
+++ b/profiles/apparmor/generate.go
@@ -1,0 +1,27 @@
+// +build ignore
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/profiles/apparmor"
+)
+
+// Saves the default AppArmor profile as a Go template so people can use it as a
+// base for their own custom profiles.
+func main() {
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	f := filepath.Join(wd, "default-profile")
+
+	// write the default profile to the file
+	tmpl := apparmor.BaseTemplate()
+	if err := ioutil.WriteFile(f, []byte(tmpl), 0644); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
This is a long-requested feature, and it solves several usability
problems with the default AppArmor profile:

 1. The profile is completely opaque because we don't write to
    /etc/apparmor.d anymore -- this leads to lots of headaches when
    trying to run certain semi-privileged programs inside containers.
    It's much nicer to be able to have a starting point for a custom
    AppArmor profile.

 2. Changes to AppArmor have broken backwards compatibility in the past
    (leading to containers not working properly) -- the poster-child for
    this problem was signal mediation. In order to fix this problem,
    distributions had to patch Docker when it would've been much nicer
    to provide a hotfix in the form of a custom configuration they could
    apply to their hosts.

It also bridges the feature gap between the default seccomp profile
(which has been configurable for a very long time). This patch also
fixes a few minor bugs in the AppArmor profile implementation (notably,
Docker would not forcefully load its built-in profile at start time --
meaning a Docker update wouldn't actually update the profile).

This feature should probably be ported to other container runtimes
(containerd, podman/cri-o, etc) so that we can continue with the effort
to merge all of the disparate AppArmor profile implementations. Ideally
they would all use the same template variables too.

![Ebpy84MVAAACp1W](https://user-images.githubusercontent.com/2888411/93022324-29e3a480-f62c-11ea-8a22-a4620e6bd7c3.jpeg)

Mostly fixes #33060
Signed-off-by: Aleksa Sarai <asarai@suse.de>