### PR TITLE
fix integration test case TestExternalGraphDriver failed in mips arch

### DIFF
--- a/integration/plugin/graphdriver/external_test.go
+++ b/integration/plugin/graphdriver/external_test.go
@@ -395,12 +395,12 @@ func testGraphDriverPull(c client.APIClient, d *daemon.Daemon) func(*testing.T) 
 		defer d.Stop(t)
 		ctx := context.Background()
 
-		r, err := c.ImagePull(ctx, "busybox:latest@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0", types.ImagePullOptions{})
+		r, err := c.ImagePull(ctx, "busybox:latest@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209", types.ImagePullOptions{})
 		assert.NilError(t, err)
 		_, err = io.Copy(ioutil.Discard, r)
 		assert.NilError(t, err)
 
-		container.Run(ctx, t, c, container.WithImage("busybox:latest@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0"))
+		container.Run(ctx, t, c, container.WithImage("busybox:latest@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209"))
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: limeidan <limeidan@loongson.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

make the integration test case TestExternalGraphDriver pass in mips arch.

**- How I did it**

replace the specified image with one support mips arch's version

**- How to verify it**

run integration test case in mips arch

**- Description for the changelog**
<!--
when I run the integration test in loongson's loongnix os which based on mips architecture, the test case TestExternalGraphDriver failed, err info shows that the image `bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0` not found, i pull the image separately, found that it does not support mips arch, so I changed it to a support one.
-->


**- A picture of a cute animal (not mandatory but encouraged)**

