### PR TITLE
[19.03 backport] swagger: fix MemTotal units in SystemInfo endpoint

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4467,7 +4467,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -3599,7 +3599,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -3604,7 +3604,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -3633,7 +3633,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -3615,7 +3615,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -3628,7 +3628,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -3648,7 +3648,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -3702,7 +3702,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -4345,7 +4345,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -4467,7 +4467,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/41432

MemTotal represents bytes, not kilobytes. See Linux[1] and Windows[2]
implementations.

[1]: https://github.com/moby/moby/blob/f50a40e889fdaeebf14fce1d494f95e60092d21d/pkg/system/meminfo_linux.go#L49
[2]: https://github.com/moby/moby/blob/f50a40e889fdaeebf14fce1d494f95e60092d21d/pkg/system/meminfo_windows.go#L40

Signed-off-by: Nikolay Edigaryev <edigaryev@gmail.com>
(cherry picked from commit 13e0ba700ad53e6c97e91c8775376a7eff175555)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

