### PR TITLE
update containerd vendor and binary to v1.4.1

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=09814d48d50816305a8e6c1a4ae3e2bcc4ba725a}" # v1.4.0
+: "${CONTAINERD_COMMIT:=c623d1b36f09f8ef6536a057bd658b3aa8632828}" # v1.4.1
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/vendor.conf
+++ b/vendor.conf
@@ -123,7 +123,7 @@ github.com/googleapis/gax-go                        317e0006254c44a0ac427cc52a0e
 google.golang.org/genproto                          3f1135a288c9a07e340ae8ba4cc6c7065a3160e8
 
 # containerd
-github.com/containerd/containerd                    09814d48d50816305a8e6c1a4ae3e2bcc4ba725a # v1.4.0
+github.com/containerd/containerd                    c623d1b36f09f8ef6536a057bd658b3aa8632828 # v1.4.1
 github.com/containerd/fifo                          f15a3290365b9d2627d189e619ab4008e0069caf
 github.com/containerd/continuity                    efbc4488d8fe1bdc16bde3b2d2990d9b3a899165
 github.com/containerd/cgroups                       318312a373405e5e91134d8063d04d59768a1bff

--- a/vendor/github.com/containerd/containerd/contrib/seccomp/seccomp_default.go
+++ b/vendor/github.com/containerd/containerd/contrib/seccomp/seccomp_default.go
@@ -55,6 +55,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"accept",
 				"accept4",
 				"access",
+				"adjtimex",
 				"alarm",
 				"bind",
 				"brk",
@@ -93,6 +94,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"exit",
 				"exit_group",
 				"faccessat",
+				"faccessat2",
 				"fadvise64",
 				"fadvise64_64",
 				"fallocate",
@@ -173,6 +175,9 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"ioprio_set",
 				"io_setup",
 				"io_submit",
+				"io_uring_enter",
+				"io_uring_register",
+				"io_uring_setup",
 				"ipc",
 				"kill",
 				"lchown",
@@ -190,6 +195,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"lstat",
 				"lstat64",
 				"madvise",
+				"membarrier",
 				"memfd_create",
 				"mincore",
 				"mkdir",
@@ -224,6 +230,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"_newselect",
 				"open",
 				"openat",
+				"openat2",
 				"pause",
 				"pipe",
 				"pipe2",
@@ -233,11 +240,13 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"prctl",
 				"pread64",
 				"preadv",
+				"preadv2",
 				"prlimit64",
 				"pselect6",
 				"pselect6_time64",
 				"pwrite64",
 				"pwritev",
+				"pwritev2",
 				"read",
 				"readahead",
 				"readlink",
@@ -344,7 +353,6 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				"sync_file_range",
 				"syncfs",
 				"sysinfo",
-				"syslog",
 				"tee",
 				"tgkill",
 				"time",
@@ -412,6 +420,28 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 			Args: []specs.LinuxSeccompArg{
 				{
 					Index: 0,
+					Value: 0x20000,
+					Op:    specs.OpEqualTo,
+				},
+			},
+		},
+		{
+			Names:  []string{"personality"},
+			Action: specs.ActAllow,
+			Args: []specs.LinuxSeccompArg{
+				{
+					Index: 0,
+					Value: 0x20008,
+					Op:    specs.OpEqualTo,
+				},
+			},
+		},
+		{
+			Names:  []string{"personality"},
+			Action: specs.ActAllow,
+			Args: []specs.LinuxSeccompArg{
+				{
+					Index: 0,
 					Value: 0xffffffff,
 					Op:    specs.OpEqualTo,
 				},
@@ -427,11 +457,20 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 
 	// include by arch
 	switch runtime.GOARCH {
+	case "ppc64le":
+		s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
+			Names: []string{
+				"sync_file_range2",
+			},
+			Action: specs.ActAllow,
+			Args:   []specs.LinuxSeccompArg{},
+		})
 	case "arm", "arm64":
 		s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
 			Names: []string{
 				"arm_fadvise64_64",
 				"arm_sync_file_range",
+				"sync_file_range2",
 				"breakpoint",
 				"cacheflush",
 				"set_tls",
@@ -488,9 +527,11 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 					"mount",
 					"name_to_handle_at",
 					"perf_event_open",
+					"quotactl",
 					"setdomainname",
 					"sethostname",
 					"setns",
+					"syslog",
 					"umount",
 					"umount2",
 					"unshare",
@@ -551,7 +592,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				Names: []string{
 					"settimeofday",
 					"stime",
-					"adjtimex",
+					"clock_settime",
 				},
 				Action: specs.ActAllow,
 				Args:   []specs.LinuxSeccompArg{},
@@ -559,6 +600,12 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 		case "CAP_SYS_TTY_CONFIG":
 			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
 				Names:  []string{"vhangup"},
+				Action: specs.ActAllow,
+				Args:   []specs.LinuxSeccompArg{},
+			})
+		case "CAP_SYSLOG":
+			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
+				Names:  []string{"syslog"},
 				Action: specs.ActAllow,
 				Args:   []specs.LinuxSeccompArg{},
 			})

--- a/vendor/github.com/containerd/containerd/runtime/v1/shim/service.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/shim/service.go
@@ -514,7 +514,7 @@ func (s *Service) checkProcesses(e runc.Exit) {
 	}
 	s.mu.Unlock()
 	if p == nil {
-		log.G(s.context).Infof("process with id:%d wasn't found", e.Pid)
+		log.G(s.context).Debugf("process with id:%d wasn't found", e.Pid)
 		return
 	}
 	if ip, ok := p.(*process.Init); ok {

--- a/vendor/github.com/containerd/containerd/vendor.conf
+++ b/vendor/github.com/containerd/containerd/vendor.conf
@@ -86,9 +86,9 @@ sigs.k8s.io/structured-merge-diff/v3                v3.0.0
 sigs.k8s.io/yaml                                    v1.2.0
 
 # cni dependencies
-github.com/containerd/go-cni                        v1.0.0
-github.com/containernetworking/cni                  v0.7.1
-github.com/containernetworking/plugins              v0.7.6
+github.com/containerd/go-cni                        v1.0.1
+github.com/containernetworking/cni                  v0.8.0
+github.com/containernetworking/plugins              v0.8.6
 github.com/fsnotify/fsnotify                        v1.4.9
 
 # image decrypt depedencies

--- a/vendor/github.com/containerd/containerd/version/version.go
+++ b/vendor/github.com/containerd/containerd/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.4.0+unknown"
+	Version = "1.4.1+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.


### PR DESCRIPTION
relates to https://github.com/containerd/containerd/pull/4564

full diff: https://github.com/containerd/compare/v1.4.0...v1.4.1

Welcome to the v1.4.1 release of containerd!

The first patch release for `containerd` 1.4 includes a fix for v1 shims hanging
on exit and exec when the log pipe fills up along with other minor changes.

Notable Updates:

* Always consume shim logs to prevent logs in the shim from blocking
* Fix error deleting v2 bundle directory when removing rootfs returns `ErrNotExist`
* Fix metrics monitoring of v2 runtime tasks
* Fix incorrect stat for Windows containers
* Fix devmapper device deletion on rollback
* Update seccomp default profile
