### PR TITLE
oci/caps: refactor, remove unused code, and improved error messages

### DIFF
--- a/oci/caps/utils.go
+++ b/oci/caps/utils.go
@@ -19,10 +19,11 @@ func init() {
 	allCaps = make([]string, min(int(last+1), len(rawCaps)))
 	capabilityList = make(Capabilities, min(int(last+1), len(rawCaps)))
 	for i, c := range rawCaps {
+		capName := "CAP_" + strings.ToUpper(c.String())
 		if c > last {
+			capabilityList[capName] = nil
 			continue
 		}
-		capName := "CAP_" + strings.ToUpper(c.String())
 		allCaps[i] = capName
 		capabilityList[capName] = &CapabilityMapping{
 			Key:   capName,
@@ -89,8 +90,10 @@ func NormalizeLegacyCapabilities(caps []string) ([]string, error) {
 		if !strings.HasPrefix(c, "CAP_") {
 			c = "CAP_" + c
 		}
-		if _, ok := capabilityList[c]; !ok {
+		if v, ok := capabilityList[c]; !ok {
 			return nil, errdefs.InvalidParameter(fmt.Errorf("unknown capability: %q", c))
+		} else if v == nil {
+			return nil, errdefs.InvalidParameter(fmt.Errorf("capability not supported by your kernel: %q", c))
 		}
 		normalized = append(normalized, c)
 	}

--- a/oci/caps/utils.go
+++ b/oci/caps/utils.go
@@ -12,10 +12,6 @@ var capabilityList Capabilities
 
 func init() {
 	last := capability.CAP_LAST_CAP
-	// hack for RHEL6 which has no /proc/sys/kernel/cap_last_cap
-	if last == capability.Cap(63) {
-		last = capability.CAP_BLOCK_SUSPEND
-	}
 	for _, cap := range capability.List() {
 		if cap > last {
 			continue

--- a/oci/caps/utils.go
+++ b/oci/caps/utils.go
@@ -24,7 +24,7 @@ func init() {
 		}
 		capName := "CAP_" + strings.ToUpper(c.String())
 		allCaps[i] = capName
-		capabilityList[i] = &CapabilityMapping{
+		capabilityList[capName] = &CapabilityMapping{
 			Key:   capName,
 			Value: c,
 		}
@@ -48,7 +48,7 @@ type (
 		Value capability.Cap `json:"value,omitempty"`
 	}
 	// Capabilities contains all CapabilityMapping
-	Capabilities []*CapabilityMapping
+	Capabilities map[string]*CapabilityMapping
 )
 
 // String returns <key> of CapabilityMapping
@@ -89,7 +89,7 @@ func NormalizeLegacyCapabilities(caps []string) ([]string, error) {
 		if !strings.HasPrefix(c, "CAP_") {
 			c = "CAP_" + c
 		}
-		if !inSlice(allCaps, c) {
+		if _, ok := capabilityList[c]; !ok {
 			return nil, errdefs.InvalidParameter(fmt.Errorf("unknown capability: %q", c))
 		}
 		normalized = append(normalized, c)

--- a/oci/caps/utils.go
+++ b/oci/caps/utils.go
@@ -8,18 +8,24 @@ import (
 	"github.com/syndtr/gocapability/capability"
 )
 
-var capabilityList Capabilities
+var (
+	allCaps        []string
+	capabilityList Capabilities
+)
 
 func init() {
 	last := capability.CAP_LAST_CAP
 	rawCaps := capability.List()
+	allCaps = make([]string, min(int(last+1), len(rawCaps)))
 	capabilityList = make(Capabilities, min(int(last+1), len(rawCaps)))
 	for i, c := range rawCaps {
 		if c > last {
 			continue
 		}
+		capName := "CAP_" + strings.ToUpper(c.String())
+		allCaps[i] = capName
 		capabilityList[i] = &CapabilityMapping{
-			Key:   "CAP_" + strings.ToUpper(c.String()),
+			Key:   capName,
 			Value: c,
 		}
 	}
@@ -52,11 +58,7 @@ func (c *CapabilityMapping) String() string {
 
 // GetAllCapabilities returns all of the capabilities
 func GetAllCapabilities() []string {
-	output := make([]string, len(capabilityList))
-	for i, c := range capabilityList {
-		output[i] = c.String()
-	}
-	return output
+	return allCaps
 }
 
 // inSlice tests whether a string is contained in a slice of strings or not.
@@ -78,7 +80,6 @@ const allCapabilities = "ALL"
 func NormalizeLegacyCapabilities(caps []string) ([]string, error) {
 	var normalized []string
 
-	valids := GetAllCapabilities()
 	for _, c := range caps {
 		c = strings.ToUpper(c)
 		if c == allCapabilities {
@@ -88,7 +89,7 @@ func NormalizeLegacyCapabilities(caps []string) ([]string, error) {
 		if !strings.HasPrefix(c, "CAP_") {
 			c = "CAP_" + c
 		}
-		if !inSlice(valids, c) {
+		if !inSlice(allCaps, c) {
 			return nil, errdefs.InvalidParameter(fmt.Errorf("unknown capability: %q", c))
 		}
 		normalized = append(normalized, c)

--- a/oci/caps/utils.go
+++ b/oci/caps/utils.go
@@ -12,17 +12,24 @@ var capabilityList Capabilities
 
 func init() {
 	last := capability.CAP_LAST_CAP
-	for _, c := range capability.List() {
+	rawCaps := capability.List()
+	capabilityList = make(Capabilities, min(int(last+1), len(rawCaps)))
+	for i, c := range rawCaps {
 		if c > last {
 			continue
 		}
-		capabilityList = append(capabilityList,
-			&CapabilityMapping{
-				Key:   "CAP_" + strings.ToUpper(c.String()),
-				Value: c,
-			},
-		)
+		capabilityList[i] = &CapabilityMapping{
+			Key:   "CAP_" + strings.ToUpper(c.String()),
+			Value: c,
+		}
 	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 type (

--- a/oci/caps/utils.go
+++ b/oci/caps/utils.go
@@ -12,14 +12,14 @@ var capabilityList Capabilities
 
 func init() {
 	last := capability.CAP_LAST_CAP
-	for _, cap := range capability.List() {
-		if cap > last {
+	for _, c := range capability.List() {
+		if c > last {
 			continue
 		}
 		capabilityList = append(capabilityList,
 			&CapabilityMapping{
-				Key:   "CAP_" + strings.ToUpper(cap.String()),
-				Value: cap,
+				Key:   "CAP_" + strings.ToUpper(c.String()),
+				Value: c,
 			},
 		)
 	}
@@ -46,8 +46,8 @@ func (c *CapabilityMapping) String() string {
 // GetAllCapabilities returns all of the capabilities
 func GetAllCapabilities() []string {
 	output := make([]string, len(capabilityList))
-	for i, capability := range capabilityList {
-		output[i] = capability.String()
+	for i, c := range capabilityList {
+		output[i] = c.String()
 	}
 	return output
 }


### PR DESCRIPTION
- oci/caps: rename some vars that conflicted with imports / built-ins
- oci/caps: minor optimization in init
- oci/caps: generate list of all capabilities on "init"
- oci/caps: use map for capabilities to simplify lookup
- oci/caps: improve error message for unsupported capabilities
    A capability can either be invalid, or not supported by the kernel on which we're running. This patch changes the error message produced to reflect if the capability is invalid/unknown, or a known capability, but not supported by the kernel version.
- oci/caps: remove unused `GetCapability()` and `ValidateCapabilities()`
- oci/caps: simplify, and remove types that were not needed
  The `CapabilityMapping` and `Capabilities` types appeared to be only used locally, and added unneeded complexity. This patch removes those types, and simplifies the logic to use a map that maps names to `capability.Cap`s
- oci/caps: remove hack for RHEL6 kernels
    We no longer support these kernels, so we can remove the workaround