### PR TITLE
Windows CI: Fix collecting the logs of the daemon under test

### DIFF
--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -1038,6 +1038,7 @@ Finally {
 
     # Save the daemon under test log
     if ($daemonStarted -eq 1) {
+        Set-Location "$env:SOURCES_DRIVE`:\$env:SOURCES_SUBDIR\src\github.com\docker\docker"
         Write-Host -ForegroundColor Green "INFO: Saving daemon under test log ($env:TEMP\dut.out) to bundles\CIDUT.out"
         Copy-Item  "$env:TEMP\dut.out" "bundles\CIDUT.out" -Force -ErrorAction SilentlyContinue
         Write-Host -ForegroundColor Green "INFO: Saving daemon under test log ($env:TEMP\dut.err) to bundles\CIDUT.err"


### PR DESCRIPTION
**- What I did**

This PR fixes an issue we discussed in https://github.com/moby/moby/pull/40599. Sometimes the logs of the daemon under test couldn't be found.

**- How I did it**

I first ran a test to show me the current dir in the script, and indeed in some cases the script was a sub folder, and the Copy-Item silently continues if the target folder doesn't exist.

![cidut](https://user-images.githubusercontent.com/207759/93516951-0621a680-f92b-11ea-80b6-017bb7524321.jpg)

**- How to verify it**

The Windows builds should now always have artifacts with the CIDUT.out / CIDUT.err files in it.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

<img width="169" alt="cidut 2 tahun" src="https://user-images.githubusercontent.com/207759/93517161-5ac52180-f92b-11ea-898e-61e219903e9f.png">
