### PR TITLE
Add PIDFile to docker.service unit file to make systemd clean up pid file more reliably

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -29,6 +29,8 @@ KillMode=process
 Restart=on-failure
 StartLimitBurst=3
 StartLimitInterval=60s
+# ensure to cleanup pid file when the daemon stops
+PIDFile=/var/run/docker.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -10,7 +10,8 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd -H fd://
+# explicitly set the PID file path to be aligned with PIDFile option in this file 
+ExecStart=/usr/bin/dockerd -H fd:// --pidfile /var/run/docker.pid
 ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576
 # Having non-zero Limit*s causes performance problems due to accounting overhead


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
In docker.service unit file, add a PIDFile option with the default pid file path of docker.

**- Why I did**

In the case of a high churn process system there is an edge case where the process is killed and the process id is assigned to a new running process before systemd can restart the process and see that no process is running under the old pid. When the in-use PIDs is close to the system capacity, it's likely that the PID has been reused by some other process. The dockerd does a check to see if the pid file exist and the process id in the file is running[3]. In this case, docker will fail to restart since the pid file contains a valid, running process.

So configuring the PIDFile in docker.service, systemd will help cleanup the pid file more reliably.

**- How I did it**

Updated the docker.service

**- How to verify it**

Try to simulate the high churn behavior.

Before the change:
```
# sudo su
# systemctl stop docker
# echo "1" > /var/run/docker.pid
# systemctl start docker
Job for docker.service failed because the control process exited with error code.
See "systemctl status docker.service" and "journalctl -xe" for details.
# docker ps
error during connect: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.40/containers/json: read unix @->/var/run/docker.sock: read: connection reset by peer
# docker ps
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

After the change:
```
# systemctl daemon-reload
# systemctl stop docker
# echo "1" > /var/run/docker.pid
# systemctl start docker
Job for docker.service failed because the control process exited with error code.
See "systemctl status docker.service" and "journalctl -xe" for details.
# docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
# systemctl status docker
● docker.service - Docker Application Container Engine
   Loaded: loaded (/etc/systemd/system/docker.service; disabled; vendor preset: disabled)
   Active: active (running) since Thu 2020-08-27 21:20:30 UTC; 6s ago
     Docs: https://docs.docker.com
  Process: 50532 ExecStopPost=/bin/echo docker daemon exited (code=exited, status=0/SUCCESS)
  Process: 50541 ExecStartPre=/bin/sh -c if [[ -f /var/lib/docker/daemon.json ]]; then cp -f /var/lib/docker/daemon.json /etc/docker/daemon.json; fi (code=exited, status=0/SUCCESS)
 Main PID: 50542 (dockerd)
    Tasks: 8
   Memory: 36.1M
      CPU: 206ms
   CGroup: /system.slice/docker.service
           └─50542 /usr/bin/dockerd --registry-mirror=https://mirror.gcr.io --host=fd:// --containerd=/var/run/containerd/containerd.sock
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add PIDFile to docker.service unit file to make systemd clean up pid file more reliably

