### PR TITLE
vendor: docker/libnetwork d0951081b35fa4216fc4f0064bf065beeb55a74b

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: "${LIBNETWORK_COMMIT:=9e99af28df21367340c95a3863e31808d689c92a}"
+: "${LIBNETWORK_COMMIT:=d0951081b35fa4216fc4f0064bf065beeb55a74b}"
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -41,7 +41,7 @@ github.com/grpc-ecosystem/go-grpc-middleware        3c51f7f332123e8be5a157c0802a
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        9e99af28df21367340c95a3863e31808d689c92a
+github.com/docker/libnetwork                        d0951081b35fa4216fc4f0064bf065beeb55a74b
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/controller.go
+++ b/vendor/github.com/docker/libnetwork/controller.go
@@ -53,7 +53,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/discovery"
-	"github.com/docker/docker/pkg/locker"
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/docker/pkg/stringid"
@@ -70,6 +69,7 @@ import (
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/osl"
 	"github.com/docker/libnetwork/types"
+	"github.com/moby/locker"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/netlink_deprecated_linux.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/netlink_deprecated_linux.go
@@ -7,8 +7,6 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
-
-	"github.com/docker/libnetwork/netutils"
 )
 
 const (
@@ -106,7 +104,7 @@ func ioctlSetMacAddress(name, addr string) error {
 	return nil
 }
 
-func ioctlCreateBridge(name string, setMacAddr bool) error {
+func ioctlCreateBridge(name, macAddr string) error {
 	if len(name) >= ifNameSize {
 		return fmt.Errorf("Interface name %s too long", name)
 	}
@@ -124,8 +122,5 @@ func ioctlCreateBridge(name string, setMacAddr bool) error {
 	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, uintptr(s), ioctlBrAdd, uintptr(unsafe.Pointer(nameBytePtr))); err != 0 {
 		return err
 	}
-	if setMacAddr {
-		return ioctlSetMacAddress(name, netutils.GenerateRandomMAC().String())
-	}
-	return nil
+	return ioctlSetMacAddress(name, macAddr)
 }

--- a/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_network.go
@@ -3,7 +3,6 @@ package macvlan
 import (
 	"fmt"
 
-	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/netlabel"
@@ -17,15 +16,7 @@ import (
 // CreateNetwork the network for the specified driver type
 func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	defer osl.InitOSContext()()
-	kv, err := kernel.GetKernelVersion()
-	if err != nil {
-		return fmt.Errorf("failed to check kernel version for %s driver support: %v", macvlanType, err)
-	}
-	// ensure Kernel version is >= v3.9 for macvlan support
-	if kv.Kernel < macvlanKernelVer || (kv.Kernel == macvlanKernelVer && kv.Major < macvlanMajorVer) {
-		return fmt.Errorf("kernel version failed to meet the minimum macvlan kernel requirement of %d.%d, found %d.%d.%d",
-			macvlanKernelVer, macvlanMajorVer, kv.Kernel, kv.Major, kv.Minor)
-	}
+
 	// reject a null v4 network
 	if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
 		return fmt.Errorf("ipv4 pool is empty")

--- a/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_setup.go
+++ b/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_setup.go
@@ -11,9 +11,7 @@ import (
 )
 
 const (
-	dummyPrefix      = "dm-" // macvlan prefix for dummy parent interface
-	macvlanKernelVer = 3     // minimum macvlan kernel support
-	macvlanMajorVer  = 9     // minimum macvlan major kernel support
+	dummyPrefix = "dm-" // macvlan prefix for dummy parent interface
 )
 
 // Create the macvlan slave specifying the source name

--- a/vendor/github.com/docker/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
+++ b/vendor/github.com/docker/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/docker/docker/pkg/system"
+	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/drivers/windows"
 	"github.com/docker/libnetwork/netlabel"
@@ -34,7 +34,7 @@ var (
 	//Server 2016 (RS1) does not support concurrent add/delete of endpoints.  Therefore, we need
 	//to use this mutex and serialize the add/delete of endpoints on RS1.
 	endpointMu   sync.Mutex
-	windowsBuild = system.GetOSVersion().Build
+	windowsBuild = osversion.Build()
 )
 
 func validateID(nid, eid string) error {
@@ -155,7 +155,7 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 
 	hnsEndpoint.Policies = append(hnsEndpoint.Policies, paPolicy)
 
-	if system.GetOSVersion().Build > 16236 {
+	if osversion.Build() > 16236 {
 		natPolicy, err := json.Marshal(hcsshim.PaPolicy{
 			Type: "OutBoundNAT",
 		})

--- a/vendor/github.com/docker/libnetwork/drivers/windows/windows.go
+++ b/vendor/github.com/docker/libnetwork/drivers/windows/windows.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/docker/docker/pkg/system"
+	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
@@ -217,7 +217,7 @@ func (d *driver) parseNetworkOptions(id string, genericOptions map[string]string
 			}
 			config.VSID = uint(vsid)
 		case EnableOutboundNat:
-			if system.GetOSVersion().Build <= 16236 {
+			if osversion.Build() <= 16236 {
 				return nil, fmt.Errorf("Invalid network option. OutboundNat is not supported on this OS version")
 			}
 			b, err := strconv.ParseBool(value)

--- a/vendor/github.com/docker/libnetwork/service_windows.go
+++ b/vendor/github.com/docker/libnetwork/service_windows.go
@@ -4,7 +4,7 @@ import (
 	"net"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/docker/docker/pkg/system"
+	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/sirupsen/logrus"
 )
 
@@ -27,7 +27,7 @@ func (n *network) addLBBackend(ip net.IP, lb *loadBalancer) {
 	vip := lb.vip
 	ingressPorts := lb.service.ingressPorts
 
-	if system.GetOSVersion().Build > 16236 {
+	if osversion.Build() > 16236 {
 		lb.Lock()
 		defer lb.Unlock()
 		//find the load balancer IP for the network.
@@ -128,7 +128,7 @@ func (n *network) rmLBBackend(ip net.IP, lb *loadBalancer, rmService bool, fullR
 		return
 	}
 
-	if system.GetOSVersion().Build > 16236 {
+	if osversion.Build() > 16236 {
 		if numEnabledBackends(lb) > 0 {
 			//Reprogram HNS (actually VFP) with the existing backends.
 			n.addLBBackend(ip, lb)

--- a/vendor/github.com/docker/libnetwork/types/types.go
+++ b/vendor/github.com/docker/libnetwork/types/types.go
@@ -591,8 +591,6 @@ func (br badRequest) Error() string {
 }
 func (br badRequest) BadRequest() {}
 
-type maskBadRequest string
-
 type notFound string
 
 func (nf notFound) Error() string {
@@ -613,8 +611,6 @@ func (ns noService) Error() string {
 	return string(ns)
 }
 func (ns noService) NoService() {}
-
-type maskNoService string
 
 type timeout string
 

--- a/vendor/github.com/docker/libnetwork/vendor.conf
+++ b/vendor/github.com/docker/libnetwork/vendor.conf
@@ -1,61 +1,53 @@
-github.com/Azure/go-ansiterm            d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/BurntSushi/toml              3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
-github.com/containerd/cgroups  	 bf292b21730f0be58f47cd194dcf447dca57e200
-github.com/Microsoft/go-winio           6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
-github.com/Microsoft/hcsshim            b3f49c06ffaeef24d09c6c08ec8ec8425a0303e2 # v0.8.7
-github.com/armon/go-metrics             eb0af217e5e9747e41dd5303755356b62d28e3ec
-github.com/armon/go-radix               e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
-github.com/containerd/continuity        004b46473808b3e7a4a3049c20e4376c91eb966d
-github.com/coreos/etcd                  fca8add78a9d926166eb739b8e4a124434025ba3 # v3.3.9
-github.com/coreos/go-semver             8ab6407b697782a06568d4b7f1db25550ec2e4c6 # v0.2.0
-github.com/deckarep/golang-set          ef32fa3046d9f249d399f98ebaf9be944430fd1d
-go.etcd.io/bbolt                        7ee3ded59d4835e10f3e7d0f7603c42aa5e83820 # v1.3.1-etcd.8
+github.com/Azure/go-ansiterm                        d6e3b3328b783f23731bc4d058875b0371ff8109
+github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
+github.com/containerd/cgroups                       318312a373405e5e91134d8063d04d59768a1bff
+github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
+github.com/Microsoft/hcsshim                        9dcb42f100215f8d375b4a9265e5bba009217a85 # moby branch
+github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec
+github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
+github.com/coreos/etcd                              d57e8b8d97adfc4a6c224fe116714bf1a1f3beb9 # v3.3.12
+github.com/coreos/go-semver                         8ab6407b697782a06568d4b7f1db25550ec2e4c6 # v0.2.0
+github.com/deckarep/golang-set                      ef32fa3046d9f249d399f98ebaf9be944430fd1d
+go.etcd.io/bbolt                                    232d8fc87f50244f9c808f4745759e08a304c029 # v1.3.5
 
-github.com/docker/docker                dbe4a30928d418e0570891a09703bcbc0e4997a1
-github.com/docker/distribution          0d3efadf0154c2b8a4e7b6621fff9809655cc580
-github.com/docker/go-connections        7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0
-github.com/docker/go-events             9461782956ad83b30282bf90e31fa6a70c255ba9
-github.com/docker/go-units              47565b4f722fb6ceae66b95f853feed578a4a51c # v0.3.3
-github.com/docker/libkv                 458977154600b9f23984d9f4b82e79570b5ae12b
+github.com/docker/docker                            7ca355652fe0e2f7401d424d65a81dc248360127
+github.com/moby/term                                73f35e472e8f0a3f91347164138ce6bd73b756a9
+github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0
+github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
+github.com/docker/libkv                             458977154600b9f23984d9f4b82e79570b5ae12b
 
-github.com/gogo/protobuf                ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
-github.com/golang/protobuf              aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
-google.golang.org/grpc                  7a6a684ca69eb4cae85ad0a484f2e531598c047b # v1.12.2
-google.golang.org/genproto              694d95ba50e67b2e363f3483057db5d4910c18f9
+github.com/gogo/protobuf                            5628607bb4c51c3157aacc3a50f0ab707582b805 # v1.3.1
 
-github.com/godbus/dbus/v5               37bf87eef99d69c4f1d3528bd66e3a87dc201472 # v5.0.3
-github.com/gorilla/mux                  c5c6c98bc25355028a63748a498942a6398ccd22 # v1.7.1
-github.com/hashicorp/consul             9a9cc9341bb487651a0399e3fc5e1e8a42e62dd9 # v0.5.2
-github.com/hashicorp/errwrap            8a6fb523712970c966eefc6b39ed2c5e74880354 # v1.0.0
-github.com/hashicorp/go-msgpack         71c2886f5a673a35f909803f38ece5810165097b
-github.com/hashicorp/go-multierror      886a7fbe3eb1c874d46f623bfa70af45f425b3d1 # v1.0.0
-github.com/hashicorp/memberlist         3d8438da9589e7b608a83ffac1ef8211486bcb7c
-github.com/hashicorp/golang-lru         7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
-github.com/sean-/seed                   e2103e2c35297fb7e17febb81e49b312087a2372
-github.com/hashicorp/go-sockaddr        c7188e74f6acae5a989bdc959aa779f8b9f42faf # v1.0.2
-github.com/hashicorp/serf               598c54895cc5a7b1a24a398d635e8c0ea0959870
-github.com/mattn/go-shellwords          02e3cf038dcea8290e44424da473dd12be796a8a # v1.0.3
-github.com/miekg/dns                    6c0c4e6581f8e173cc562c8b3363ab984e4ae071 # v1.1.27
-github.com/opencontainers/go-digest     279bed98673dd5bef374d3b6e4b09e2af76183bf # v1.0.0-rc1
-github.com/opencontainers/image-spec    d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
-github.com/opencontainers/runc          2b18fe1d885ee5083ef9f0838fee39b62d653e30
-github.com/opencontainers/runtime-spec  29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
-github.com/samuel/go-zookeeper          d0e0d8e11f318e000a8cc434616d69e329edc374
-github.com/sirupsen/logrus              8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f # v1.4.1
-github.com/konsorten/go-windows-terminal-sequences   5c8c8bd35d3832f5d134ae1e1e375b69a4d25242 # v1.0.1
-github.com/ugorji/go                    b4c50a2b199d93b13dc15e78929cfb23bfdf21ab # v1.1.1
-github.com/urfave/cli                   a65b733b303f0055f8d324d805f393cd3e7a7904
-github.com/vishvananda/netlink          f049be6f391489d3f374498fe0c8df8449258372 # v1.1.0
-github.com/vishvananda/netns            0a2b9b5464df8343199164a0321edf3313202f7e
-golang.org/x/crypto                     b7391e95e576cacdcdd422573063bc057239113d
-golang.org/x/net                        a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1
-golang.org/x/sys                        d455e41777fca6e8a5a79e34a14b8368bc11d9ba
-golang.org/x/sync                       1d60e4601c6fd243af51cc01ddf169918a5407ca
-github.com/pkg/errors                   ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
-github.com/ishidawataru/sctp            6e2cb1366111dcf547c13531e3a263a067715847
-go.opencensus.io                        9c377598961b706d1542bd2d84d538b5094d596e # v0.22.0
+github.com/godbus/dbus/v5                           37bf87eef99d69c4f1d3528bd66e3a87dc201472 # v5.0.3
+github.com/gorilla/mux                              98cb6bf42e086f6af920b965c38cacc07402d51b # v1.8.0
+github.com/hashicorp/consul                         9a9cc9341bb487651a0399e3fc5e1e8a42e62dd9 # v0.5.2
+github.com/hashicorp/errwrap                        8a6fb523712970c966eefc6b39ed2c5e74880354 # v1.0.0
+github.com/hashicorp/go-msgpack                     71c2886f5a673a35f909803f38ece5810165097b
+github.com/hashicorp/go-multierror                  886a7fbe3eb1c874d46f623bfa70af45f425b3d1 # v1.0.0
+github.com/hashicorp/memberlist                     3d8438da9589e7b608a83ffac1ef8211486bcb7c
+github.com/hashicorp/golang-lru                     7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
+github.com/sean-/seed                               e2103e2c35297fb7e17febb81e49b312087a2372
+github.com/hashicorp/go-sockaddr                    c7188e74f6acae5a989bdc959aa779f8b9f42faf # v1.0.2
+github.com/hashicorp/serf                           598c54895cc5a7b1a24a398d635e8c0ea0959870
+github.com/miekg/dns                                6c0c4e6581f8e173cc562c8b3363ab984e4ae071 # v1.1.27
+github.com/opencontainers/runtime-spec              4d89ac9fbff6c455f46a5bb59c6b1bb7184a5e43 # v1.0.3-0.20200728170252-4d89ac9fbff6
+github.com/samuel/go-zookeeper                      d0e0d8e11f318e000a8cc434616d69e329edc374
+github.com/sirupsen/logrus                          60c74ad9be0d874af0ab0daef6ab07c5c5911f0d # v1.6.0
+github.com/konsorten/go-windows-terminal-sequences  edb144dfd453055e1e49a3d8b410a660b5a87613 # v1.0.3
+github.com/ugorji/go                                b4c50a2b199d93b13dc15e78929cfb23bfdf21ab # v1.1.1
+github.com/urfave/cli                               a65b733b303f0055f8d324d805f393cd3e7a7904
+github.com/vishvananda/netlink                      f049be6f391489d3f374498fe0c8df8449258372 # v1.1.0
+github.com/vishvananda/netns                        db3c7e526aae966c4ccfa6c8189b693d6ac5d202
+golang.org/x/crypto                                 75b288015ac94e66e3d6715fb68a9b41bf046ec2
+golang.org/x/net                                    ab34263943818b32f575efc978a3d24e80b04bd7
+golang.org/x/sys                                    ed371f2e16b4b305ee99df548828de367527b76b
+golang.org/x/sync                                   cd5d95a43a6e21273425c7ae415d3df9ea832eeb
+github.com/pkg/errors                               614d223910a179a466c1767a985424175c39b465 # v0.9.1
+github.com/ishidawataru/sctp                        6e2cb1366111dcf547c13531e3a263a067715847
+go.opencensus.io                                    9c377598961b706d1542bd2d84d538b5094d596e # v0.22.0
 
-gotest.tools                            1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
-github.com/google/go-cmp                3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0
+gotest.tools/v3                                     bb0d8a963040ea5048dcef1a14d8f8b58a33d4b3 # v3.0.2
+github.com/google/go-cmp                            3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0
 
-github.com/moby/ipvs                    4566ccea0e08d68e9614c3e7a64a23b850c4bb35 # v1.0.1
+github.com/moby/ipvs                                4566ccea0e08d68e9614c3e7a64a23b850c4bb35 # v1.0.1
+github.com/moby/locker                              281af2d563954745bea9d1487c965f24d30742fe # v1.0.1


### PR DESCRIPTION
full diff: https://github.com/docker/libnetwork/compare/9e99af28df21367340c95a3863e31808d689c92a...d0951081b35fa4216fc4f0064bf065beeb55a74b

- docker/libnetwork#2560 types: remove some dead code
- docker/libnetwork#2562 client/mflag: remove use of docker/docker/pkg/homedir
- docker/libnetwork#2576 Skip redundant kernel version checks
- docker/libnetwork#2583 vendor: update docker to 7ca355652fe0e2f7401d424d65a81dc248360127 and reduce dependency graph

