### PR TITLE
Windows CI: Force Download-File function to use TLS 1.2 (fix to RS1 CI)

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -205,6 +205,7 @@ RUN `
       Throw ("Failed to download " + $source) `
       }`
     } else { `
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
       $webClient = New-Object System.Net.WebClient; `
       $webClient.DownloadFile($source, $target); `
     } `


### PR DESCRIPTION
**- What I did**
I noticed that RS1 CI from master have been [broken for a while](https://ci-next.docker.com/public/blue/organizations/jenkins/moby/activity?branch=master) that is because .NET version which RS1 uses does not have TLS 1.2 enabled by default and nuget.org does not have TLS 1.1 enabled anymore.

This PR will set both RS1 and RS5 to use TLS 1.2 only for downloads.

**- How I did it**
Minor change to Download-File PowerShell function function.

**- How to verify it**
Pass CI on RS5 will proof that this does not cause new issues.

**- A picture of a cute animal (not mandatory but encouraged)**
![371695,xcitefun-cute-animals-pictures-41](https://user-images.githubusercontent.com/6213926/93712907-55e9b300-fb61-11ea-8704-2e8454fa8676.jpg)
