### PR TITLE
pkg/system: make EnsureRemoveAll unix-specific

### DIFF
--- a/pkg/system/rm_unix.go
+++ b/pkg/system/rm_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package system // import "github.com/docker/docker/pkg/system"
 
 import (

--- a/pkg/system/rm_windows.go
+++ b/pkg/system/rm_windows.go
@@ -1,0 +1,6 @@
+package system
+
+import "os"
+
+// EnsureRemoveAll is an alias to os.RemoveAll on Windows
+var EnsureRemoveAll = os.RemoveAll


### PR DESCRIPTION
The tricks performed by EnsureRemoveAll only make sense for Linux and
other Unices, so separate it out, and make EnsureRemoveAll for Windows
just an alias of os.RemoveAll.

This makes sure RecursiveUnmount is not called on Windows.

Related to: https://github.com/moby/moby/pull/41458