### PR TITLE
Windows CI: Add support for testing with containerd

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -166,12 +166,15 @@ FROM microsoft/windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG GO_VERSION=1.16.7
+ARG CONTAINERD_VERSION=1.5.5
 ARG GOTESTSUM_COMMIT=v0.5.3
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
+#  - CONTAINERD_VERSION must be consistent with 'hack/dockerfile/install/containerd.installer' used by Linux.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
 ENV GO_VERSION=${GO_VERSION} `
+    CONTAINERD_VERSION=${CONTAINERD_VERSION} `
     GIT_VERSION=2.11.1 `
     GOPATH=C:\gopath `
     GO111MODULE=off `
@@ -211,7 +214,7 @@ RUN `
     } `
   } `
   `
-  setx /M PATH $('C:\git\cmd;C:\git\usr\bin;'+$Env:PATH+';C:\gcc\bin;C:\go\bin'); `
+  setx /M PATH $('C:\git\cmd;C:\git\usr\bin;'+$Env:PATH+';C:\gcc\bin;C:\go\bin;C:\containerd\bin'); `
   `
   Write-Host INFO: Downloading git...; `
   $location='https://www.nuget.org/api/v2/package/GitForWindows/'+$Env:GIT_VERSION; `
@@ -251,6 +254,16 @@ RUN `
   Remove-Item C:\runtime.zip; `
   Remove-Item C:\binutils.zip; `
   Remove-Item C:\gitsetup.zip; `
+  `
+  Write-Host INFO: Downloading containerd; `
+  Install-Package -Force 7Zip4PowerShell; `
+  $location='https://github.com/containerd/containerd/releases/download/v'+$Env:CONTAINERD_VERSION+'/containerd-'+$Env:CONTAINERD_VERSION+'-windows-amd64.tar.gz'; `
+  Download-File $location C:\containerd.tar.gz; `
+  New-Item -Path C:\containerd -ItemType Directory; `
+  Expand-7Zip C:\containerd.tar.gz C:\; `
+  Expand-7Zip C:\containerd.tar C:\containerd; `
+  Remove-Item C:\containerd.tar.gz; `
+  Remove-Item C:\containerd.tar; `
   `
   # Ensure all directories exist that we will require below....
   $srcDir = """$Env:GOPATH`\src\github.com\docker\docker\bundles"""; `

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1308,7 +1308,7 @@ pipeline {
                                 Write-Host -ForegroundColor Green "Creating ${bundleName}-bundles.zip"
 
                                 # archiveArtifacts does not support env-vars to , so save the artifacts in a fixed location
-                                Compress-Archive -Path "bundles/CIDUT.out", "bundles/CIDUT.err", "bundles/junit-report-*.xml" -CompressionLevel Optimal -DestinationPath "${bundleName}-bundles.zip"
+                                Compress-Archive -Path "bundles/CIDUT.out", "bundles/CIDUT.err", "bundles/containerd.out", "bundles/containerd.err", "bundles/junit-report-*.xml" -CompressionLevel Optimal -DestinationPath "${bundleName}-bundles.zip"
                                 '''
 
                                 archiveArtifacts artifacts: '*-bundles.zip', allowEmptyArchive: true

--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -94,6 +94,6 @@ func newCgroupParent(config *config.Config) string {
 }
 
 func (cli *DaemonCli) initContainerD(_ context.Context) (func(time.Duration) error, error) {
-	system.InitContainerdRuntime(cli.Config.Experimental, cli.Config.ContainerdAddr)
+	system.InitContainerdRuntime(cli.Config.ContainerdAddr)
 	return nil, nil
 }

--- a/daemon/start_windows.go
+++ b/daemon/start_windows.go
@@ -8,8 +8,8 @@ import (
 
 func (daemon *Daemon) getLibcontainerdCreateOptions(_ *container.Container) (string, interface{}, error) {
 	if system.ContainerdRuntimeSupported() {
-		// Set the runtime options to debug regardless of current logging level.
-		return "", &options.Options{Debug: true}, nil
+		opts := &options.Options{}
+		return "io.containerd.runhcs.v1", opts, nil
 	}
 	return "", nil, nil
 }

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -582,8 +582,10 @@ Try {
     $env:GOPATH="$env:SOURCES_DRIVE`:\$env:SOURCES_SUBDIR"
     Write-Host -ForegroundColor Green "INFO: GOPATH=$env:GOPATH"
 
-    # Set the path to have the version of go from the image at the front
-    $env:PATH="$env:TEMP\go\bin;$env:PATH"
+    # Set the path to have:
+    # - the version of go from the image at the front
+    # - the test binaries, not the host ones.
+    $env:PATH="$env:TEMP\go\bin;$env:TEMP\binary;$env:PATH"
 
     # Set the GOROOT to be our copy of go from the image
     $env:GOROOT="$env:TEMP\go"
@@ -871,7 +873,6 @@ Try {
                                                     "`$env`:PATH`='c`:\target;'+`$env:PATH`;  `$env:DOCKER_HOST`='tcp`://'+(ipconfig | select -last 1).Substring(39)+'`:2357'; c:\target\runIntegrationCLI.ps1" | Out-Host } )
         } else  {
             $env:DOCKER_HOST=$DASHH_CUT
-            $env:PATH="$env:TEMP\binary;$env:PATH;"  # Force to use the test binaries, not the host ones.
                 $env:GO111MODULE="off"
             Write-Host -ForegroundColor Green "INFO: DOCKER_HOST at $DASHH_CUT"
 

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -18,11 +18,13 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/skip"
 )
 
 var expectedNetworkInterfaceStats = strings.Split("rx_bytes rx_dropped rx_errors rx_packets tx_bytes tx_dropped tx_errors tx_packets", " ")
 
 func (s *DockerSuite) TestAPIStatsNoStreamGetCpu(c *testing.T) {
+	skip.If(c, RuntimeIsWindowsContainerd(), "FIXME: Broken on Windows + containerd combination")
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true;usleep 100; do echo 'Hello'; done")
 
 	id := strings.TrimSpace(out)
@@ -98,6 +100,7 @@ func (s *DockerSuite) TestAPIStatsStoppedContainerInGoroutines(c *testing.T) {
 }
 
 func (s *DockerSuite) TestAPIStatsNetworkStats(c *testing.T) {
+	skip.If(c, RuntimeIsWindowsContainerd(), "FIXME: Broken on Windows + containerd combination")
 	testRequires(c, testEnv.IsLocalDaemon)
 
 	out := runSleepingContainer(c)

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -7,9 +7,11 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/integration-cli/cli"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/skip"
 )
 
 func (s *DockerSuite) TestCommitAfterContainerIsDone(c *testing.T) {
+	skip.If(c, RuntimeIsWindowsContainerd(), "FIXME: Broken on Windows + containerd combination")
 	out := cli.DockerCmd(c, "run", "-i", "-a", "stdin", "busybox", "echo", "foo").Combined()
 
 	cleanedContainerID := strings.TrimSpace(out)

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -227,6 +227,7 @@ func (s *DockerSuite) TestPsListContainersFilterStatus(c *testing.T) {
 }
 
 func (s *DockerSuite) TestPsListContainersFilterHealth(c *testing.T) {
+	skip.If(c, RuntimeIsWindowsContainerd(), "FIXME. Hang on Windows + containerd combination")
 	existingContainers := ExistingContainerIDs(c)
 	// Test legacy no health check
 	out := runSleepingContainer(c, "--name=none_legacy")

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/moby/sys/mountinfo"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
+	"gotest.tools/v3/skip"
 )
 
 // "test123" should be printed by docker run
@@ -1984,6 +1985,7 @@ func (s *DockerSuite) TestRunCidFileCheckIDLength(c *testing.T) {
 }
 
 func (s *DockerSuite) TestRunSetMacAddress(c *testing.T) {
+	skip.If(c, RuntimeIsWindowsContainerd(), "FIXME: Broken on Windows + containerd combination")
 	mac := "12:34:56:78:9a:bc"
 	var out string
 	if testEnv.OSType == "windows" {

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -181,6 +181,10 @@ func RegistryHosting() bool {
 	return err == nil
 }
 
+func RuntimeIsWindowsContainerd() bool {
+	return os.Getenv("DOCKER_WINDOWS_CONTAINERD_RUNTIME") == "1"
+}
+
 func SwarmInactive() bool {
 	return testEnv.DaemonInfo.Swarm.LocalNodeState == swarm.LocalNodeStateInactive
 }

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -17,6 +17,7 @@ import (
 
 // TestExecWithCloseStdin adds case for moby#37870 issue.
 func TestExecWithCloseStdin(t *testing.T) {
+	skip.If(t, testEnv.RuntimeIsWindowsContainerd(), "FIXME. Hang on Windows + containerd combination")
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "broken in earlier versions")
 	defer setupTest(t)()
 

--- a/pkg/system/init_windows.go
+++ b/pkg/system/init_windows.go
@@ -1,29 +1,18 @@
 package system // import "github.com/docker/docker/pkg/system"
 
-import (
-	"os"
-
-	"github.com/sirupsen/logrus"
-)
-
 var (
-	// containerdRuntimeSupported determines if ContainerD should be the runtime.
-	// As of March 2019, this is an experimental feature.
+	// containerdRuntimeSupported determines if containerd should be the runtime.
 	containerdRuntimeSupported = false
 )
 
-// InitContainerdRuntime sets whether to use ContainerD for runtime
-// on Windows. This is an experimental feature still in development, and
-// also requires an environment variable to be set (so as not to turn the
-// feature on from simply experimental which would also mean LCOW.
-func InitContainerdRuntime(experimental bool, cdPath string) {
-	if experimental && len(cdPath) > 0 && len(os.Getenv("DOCKER_WINDOWS_CONTAINERD_RUNTIME")) > 0 {
-		logrus.Warnf("Using ContainerD runtime. This feature is experimental")
+// InitContainerdRuntime sets whether to use containerd for runtime on Windows.
+func InitContainerdRuntime(cdPath string) {
+	if len(cdPath) > 0 {
 		containerdRuntimeSupported = true
 	}
 }
 
-// ContainerdRuntimeSupported returns true if the use of ContainerD runtime is supported.
+// ContainerdRuntimeSupported returns true if the use of containerd runtime is supported.
 func ContainerdRuntimeSupported() bool {
 	return containerdRuntimeSupported
 }

--- a/testutil/environment/environment.go
+++ b/testutil/environment/environment.go
@@ -162,6 +162,11 @@ func (e *Execution) IsUserNamespace() bool {
 	return root != ""
 }
 
+// RuntimeIsWindowsContainerd returns whether containerd runtime is used on Windows
+func (e *Execution) RuntimeIsWindowsContainerd() bool {
+	return os.Getenv("DOCKER_WINDOWS_CONTAINERD_RUNTIME") == "1"
+}
+
 // IsRootless returns whether the rootless mode is enabled
 func (e *Execution) IsRootless() bool {
 	return os.Getenv("DOCKER_ROOTLESS") != ""


### PR DESCRIPTION
**- What I did**
~~Set [Windows Server Preview Build 20295](https://techcommunity.microsoft.com/t5/windows-server-insiders/announcing-windows-server-preview-build-20295/m-p/2147144) and later to use ContainerD as default runtime (like agreed on https://github.com/moby/moby/issues/41455#issuecomment-811294550) and provided CI for it (by modifying Win 2022 CI added by #39846).~~

Updated to working with #42528

**- How I did it**
- Some preparation changes to tests was done on #42164
- Moved Windows + ContainerD support out from experimental mode.
- Added ContainerD support to Windows CI. Including disable for `TestExecWithCloseStdin` and `TestPsListContainersFilterHealth` which got stuck forever.
~~- Set Windows build greater or equal of 20295 defaulting to ContainerD and enabling CI for it.~~
- Disabled tests `TestAPIStatsNoStreamGetCpu` , `TestAPIStatsNetworkStats` , `TestCommitAfterContainerIsDone` and `TestRunSetMacAddress` which looks to be broken after updating to latest ContainerD version.
- Included ContainerD logs to Jenkins artifacts.

**- How to verify it**
Pass CI on Win 2022 with and without ContainerD

**- What is left to later PRs**
- Switching runtimes #42089
- Implement needed changes to be able re-enable tests.
- Decision about if Docker should start ContainerD on Windows or if that should be separated service.
- Enable CI with Hyper-V isolation #42277

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6213926/118705347-ca740f00-b820-11eb-9bf6-b9a3f132e5d3.png)

Relates to https://github.com/moby/moby/issues/41455
