### PR TITLE
Remove redundant "os.IsNotExist" checks on os.RemoveAll()

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -331,7 +331,7 @@ func (daemon *Daemon) cleanupSecretDir(c *container.Container) {
 	if err := mount.RecursiveUnmount(dir); err != nil {
 		logrus.WithField("dir", dir).WithError(err).Warn("Error while attempting to unmount dir, this may prevent removal of container.")
 	}
-	if err := os.RemoveAll(dir); err != nil && !os.IsNotExist(err) {
+	if err := os.RemoveAll(dir); err != nil {
 		logrus.WithField("dir", dir).WithError(err).Error("Error removing dir.")
 	}
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -144,7 +144,7 @@ func (pm *Manager) HandleExitEvent(id string) error {
 		return err
 	}
 
-	if err := os.RemoveAll(filepath.Join(pm.config.ExecRoot, id)); err != nil && !os.IsNotExist(err) {
+	if err := os.RemoveAll(filepath.Join(pm.config.ExecRoot, id)); err != nil {
 		logrus.WithError(err).WithField("id", id).Error("Could not remove plugin bundle dir")
 	}
 

--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -239,7 +239,7 @@ func (pm *Manager) upgradePlugin(p *v2.Plugin, configDigest, manifestDigest dige
 
 	defer func() {
 		if err != nil {
-			if rmErr := os.RemoveAll(orig); rmErr != nil && !os.IsNotExist(rmErr) {
+			if rmErr := os.RemoveAll(orig); rmErr != nil {
 				logrus.WithError(rmErr).WithField("dir", backup).Error("error cleaning up after failed upgrade")
 				return
 			}
@@ -250,7 +250,7 @@ func (pm *Manager) upgradePlugin(p *v2.Plugin, configDigest, manifestDigest dige
 				logrus.WithError(rmErr).WithField("plugin", p.Name()).Errorf("error cleaning up plugin upgrade dir: %s", tmpRootFSDir)
 			}
 		} else {
-			if rmErr := os.RemoveAll(backup); rmErr != nil && !os.IsNotExist(rmErr) {
+			if rmErr := os.RemoveAll(backup); rmErr != nil {
 				logrus.WithError(rmErr).WithField("dir", backup).Error("error cleaning up old plugin root after successful upgrade")
 			}
 


### PR DESCRIPTION
`os.RemoveAll()` should never return this error. From the docs:

> If the path does not exist, RemoveAll returns nil (no error).


**- A picture of a cute animal (not mandatory but encouraged)**

