### PR TITLE
api: clarify "v" option behavior in the container remove endpoint

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6923,7 +6923,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.25.yaml
+++ b/docs/api/v1.25.yaml
@@ -4021,7 +4021,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.26.yaml
+++ b/docs/api/v1.26.yaml
@@ -4026,7 +4026,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.27.yaml
+++ b/docs/api/v1.27.yaml
@@ -4101,7 +4101,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -4193,7 +4193,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -4227,7 +4227,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -4450,7 +4450,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -4520,7 +4520,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -5757,7 +5757,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -5762,7 +5762,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -5798,7 +5798,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -5785,7 +5785,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -5809,7 +5809,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -5836,7 +5836,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -5897,7 +5897,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -6617,7 +6617,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -6755,7 +6755,7 @@ paths:
           type: "string"
         - name: "v"
           in: "query"
-          description: "Remove the volumes associated with the container."
+          description: "Remove anonymous volumes associated with the container."
           type: "boolean"
           default: false
         - name: "force"


### PR DESCRIPTION
Current description of the "v" option doesn't explain what happens to the volumes that are still in use by other containers. Turns out that the only volumes that are removed are unnamed ones: https://github.com/moby/moby/blob/a24a71c50f34d53710cccaa4d5e5f62169c5e1dc/daemon/mounts.go#L34-L38

Perhaps a good way of clarifying this behavior would be adapting the description from `docker rm --help`.

As for the `docs/api/v1.*.yaml` changes — they seem to be applicable, since the origin of this behavior dates way back to the [2016 or v1.11](https://github.com/moby/moby/commit/dd7d1c8a02d8693aa4f381f82c5bbdcad9a5ff58).