### PR TITLE
Add TARGETARCH var to frozen images stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,7 @@ RUN --mount=type=cache,sharing=locked,id=moby-frozen-images-aptlib,target=/var/l
            jq
 # Get useful and necessary Hub images so we can "docker load" locally instead of pulling
 COPY contrib/download-frozen-image-v2.sh /
+ARG TARGETARCH
 RUN /download-frozen-image-v2.sh /build \
         buildpack-deps:buster@sha256:d0abb4b1e5c664828b93e8b6ac84d10bce45ee469999bef88304be04a2709491 \
         busybox:latest@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209 \


### PR DESCRIPTION
This allows the arch that buildkit passes through to be used for the
frozen image downloader.

---

Don't know why I didn't think about this on the last PR 😄 