### PR TITLE
client: use canonical names for HTTP Headers

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -238,14 +238,14 @@ func (cli *Client) addHeaders(req *http.Request, headers headers) *http.Request 
 	// Add CLI Config's HTTP Headers BEFORE we set the Docker headers
 	// then the user can't change OUR headers
 	for k, v := range cli.customHTTPHeaders {
-		if versions.LessThan(cli.version, "1.25") && k == "User-Agent" {
+		if versions.LessThan(cli.version, "1.25") && http.CanonicalHeaderKey(k) == "User-Agent" {
 			continue
 		}
 		req.Header.Set(k, v)
 	}
 
 	for k, v := range headers {
-		req.Header[k] = v
+		req.Header[http.CanonicalHeaderKey(k)] = v
 	}
 	return req
 }


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

