### PR TITLE
Fix gcplogs memory/connection leak

### DIFF
--- a/daemon/logger/gcplogs/gcplogging.go
+++ b/daemon/logger/gcplogs/gcplogging.go
@@ -54,6 +54,7 @@ func init() {
 }
 
 type gcplogs struct {
+	client    *logging.Client
 	logger    *logging.Logger
 	instance  *instanceInfo
 	container *containerInfo
@@ -170,6 +171,7 @@ func New(info logger.Info) (logger.Logger, error) {
 	}
 
 	l := &gcplogs{
+		client: c,
 		logger: lg,
 		container: &containerInfo{
 			Name:      info.ContainerName,
@@ -237,7 +239,7 @@ func (l *gcplogs) Log(m *logger.Message) error {
 
 func (l *gcplogs) Close() error {
 	l.logger.Flush()
-	return nil
+	return l.client.Close()
 }
 
 func (l *gcplogs) Name() string {


### PR DESCRIPTION
The cloud logging client should be closed when the log driver is closed. Otherwise dockerd will keep a gRPC connection to the logging endpoint open indefinitely.

This results in a slow leak of tcp sockets (1) and memory (~200Kb) any time that a container using `--log-driver=gcplogs` is terminates.

fixes #41512

**Testing**
Tested locally in docker dev environment, `docker run --rm --log-driver=gcplogs hello-world` no longer grows the connection count of dockerd.

**- Description for the changelog**
Fix gcplogs memory/connection leak

