### PR TITLE
pkg/aaparser: support parsing version like "3.0.0-beta1"

### DIFF
--- a/pkg/aaparser/aaparser.go
+++ b/pkg/aaparser/aaparser.go
@@ -56,6 +56,9 @@ func parseVersion(output string) (int, error) {
 	words := strings.Split(lines[0], " ")
 	version := words[len(words)-1]
 
+	// trim "-beta1" suffix from version="3.0.0-beta1" if exists
+	version = strings.SplitN(version, "-", 2)[0]
+
 	// split by major minor version
 	v := strings.Split(version, ".")
 	if len(v) == 0 || len(v) > 3 {

--- a/pkg/aaparser/aaparser_test.go
+++ b/pkg/aaparser/aaparser_test.go
@@ -59,6 +59,20 @@ Copyright 2009-2012 Canonical Ltd.
 `,
 			version: 314159,
 		},
+		{
+			output: `AppArmor parser version 3.0.0-beta1
+Copyright (C) 1999-2008 Novell Inc.
+Copyright 2009-2018 Canonical Ltd.
+`,
+			version: 300000,
+		},
+		{
+			output: `AppArmor parser version 3.0.0-beta1-foo-bar
+Copyright (C) 1999-2008 Novell Inc.
+Copyright 2009-2018 Canonical Ltd.
+`,
+			version: 300000,
+		},
 	}
 
 	for _, v := range versions {


### PR DESCRIPTION
Fix #41517

