### PR TITLE
[19.03 backport] Fix gcplogs memory/connection leak

### DIFF
--- a/daemon/logger/gcplogs/gcplogging.go
+++ b/daemon/logger/gcplogs/gcplogging.go
@@ -53,6 +53,7 @@ func init() {
 }
 
 type gcplogs struct {
+	client    *logging.Client
 	logger    *logging.Logger
 	instance  *instanceInfo
 	container *containerInfo
@@ -169,6 +170,7 @@ func New(info logger.Info) (logger.Logger, error) {
 	}
 
 	l := &gcplogs{
+		client: c,
 		logger: lg,
 		container: &containerInfo{
 			Name:      info.ContainerName,
@@ -236,7 +238,7 @@ func (l *gcplogs) Log(m *logger.Message) error {
 
 func (l *gcplogs) Close() error {
 	l.logger.Flush()
-	return nil
+	return l.client.Close()
 }
 
 func (l *gcplogs) Name() string {


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/41513
fixes https://github.com/moby/moby/issues/41512

The cloud logging client should be closed when the log driver is closed. Otherwise dockerd will keep a gRPC connection to the logging endpoint open indefinitely.

This results in a slow leak of tcp sockets (1) and memory (~200Kb) any time that a container using `--log-driver=gcplogs` is terminates.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
* Fix gcplogs memory/connection leak
```


**- A picture of a cute animal (not mandatory but encouraged)**

