### PR TITLE
Update documentation to reflect deprecation of "NewEnvClient"

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -7,8 +7,8 @@ https://docs.docker.com/engine/reference/api/
 Usage
 
 You use the library by creating a client object and calling methods on it. The
-client can be created either from environment variables with NewEnvClient, or
-configured manually with NewClient.
+client can be created either from environment variables with NewClientWithOpts(client.FromEnv),
+or configured manually with NewClient().
 
 For example, to list running containers (the equivalent of "docker ps"):
 


### PR DESCRIPTION
**- What I did**

As `NewEnvClient` is deprecated in favor of `NewClientWithOpts`, the client package documentation should reflect this. This is also the text that appears on godoc.org so it's quite important that it is correct (for newbies like me)

**- How I did it**

Changed `NewEnvClient` to `NewClientWithOpts(client.FromEnv)` in main documentation text of client package.

**- How to verify it**
 x

**- Description for the changelog**
Remove deprecated NewEnvClient from main client package documentation.

**- A picture of a cute animal (not mandatory but encouraged)**

![purrito](https://i.redd.it/2okyrw7qfqq51.jpg)