### PR TITLE
daemon: don't adjust oom-score if score is 0

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1636,6 +1636,9 @@ func setMayDetachMounts() error {
 }
 
 func setupOOMScoreAdj(score int) error {
+	if score == 0 {
+		return nil
+	}
 	f, err := os.OpenFile("/proc/self/oom_score_adj", os.O_WRONLY, 0)
 	if err != nil {
 		return err

--- a/libcontainerd/supervisor/remote_daemon_linux.go
+++ b/libcontainerd/supervisor/remote_daemon_linux.go
@@ -28,9 +28,6 @@ func (r *remote) setDefaults() {
 	if r.Debug.Address == "" {
 		r.Debug.Address = filepath.Join(r.stateDir, debugSockFile)
 	}
-	if r.OOMScore == 0 {
-		r.OOMScore = -999
-	}
 
 	for key, conf := range r.pluginConfs.Plugins {
 		if conf == nil {


### PR DESCRIPTION
relates to / addresses https://github.com/docker/for-linux/issues/1120

This patch makes two changes if --oom-score-adj is set to 0

- do not adjust the oom-score-adjust cgroup for dockerd
- do not set the hard-coded -999 score for containerd if
  containerd is running as child process

Before this change:

| oom-score-adj | dockerd       | containerd as child-process |
|---------------|---------------|-----------------------------|
| -             | -500          | -500 (same as dockerd)      |
| -100          | -100          | -100 (same as dockerd)      |
| 0             |  0            | -999 (hard-coded default)   |

With this change:

| oom-score-adj | dockerd       | containerd as child-process |
|---------------|---------------|-----------------------------|
| -             | -500          | -500 (same as dockerd)      |
| -100          | -100          | -100 (same as dockerd)      |
| 0             | not adjusted  | not adjusted                |


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
Do not adjust the OOM-score for the daemon and containerd if --oom-score-adj is 0
```

**- A picture of a cute animal (not mandatory but encouraged)**
