### PR TITLE
Remove default oom score adj

### DIFF
--- a/cmd/dockerd/config_unix.go
+++ b/cmd/dockerd/config_unix.go
@@ -52,7 +52,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.StringVar(&conf.CgroupParent, "cgroup-parent", "", "Set parent cgroup for all containers")
 	flags.StringVar(&conf.RemappedRoot, "userns-remap", "", "User/Group setting for user namespaces")
 	flags.BoolVar(&conf.LiveRestoreEnabled, "live-restore", false, "Enable live restore of docker when containers are still running")
-	flags.IntVar(&conf.OOMScoreAdjust, "oom-score-adjust", -500, "Set the oom_score_adj for the daemon")
+	flags.IntVar(&conf.OOMScoreAdjust, "oom-score-adjust", 0, "Set the oom_score_adj for the daemon")
 	flags.BoolVar(&conf.Init, "init", false, "Run an init in the container to forward signals and reap processes")
 	flags.StringVar(&conf.InitPath, "init-path", "", "Path to the docker-init binary")
 	flags.Int64Var(&conf.CPURealtimePeriod, "cpu-rt-period", 0, "Limit the CPU real-time period in microseconds for the parent cgroup for all containers")

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -88,6 +88,7 @@ type Daemon struct {
 	DefaultAddrPool []string
 	SubnetSize      uint32
 	DataPathPort    uint32
+	OOMScoreAdjust  int
 	// cached information
 	CachedInfo types.Info
 }
@@ -206,6 +207,7 @@ func New(t testing.TB, ops ...Option) *Daemon {
 		}
 		ops = append(ops, WithRootlessUser("unprivilegeduser"))
 	}
+	ops = append(ops, WithOOMScoreAdjust(-500))
 
 	d, err := NewDaemon(dest, ops...)
 	assert.NilError(t, err, "could not create daemon at %q", dest)

--- a/testutil/daemon/ops.go
+++ b/testutil/daemon/ops.go
@@ -115,3 +115,10 @@ func WithRootlessUser(username string) Option {
 		d.rootlessUser = u
 	}
 }
+
+// WithOOMScoreAdjust sets OOM score for the daemon
+func WithOOMScoreAdjust(score int) Option {
+	return func(d *Daemon) {
+		d.OOMScoreAdjust = score
+	}
+}


### PR DESCRIPTION
Related:

- [x] https://github.com/docker/docker-ce-packaging/pull/501 systemd: set OOMScoreAdjust for dockerd
- [ ] https://github.com/docker-library/docker/pull/258 Explicitly set `--oom-score-adjust` to `-500`

**- What I did**

This removes the default `-500` oom-score-adjust from the daemon. The test utilities are updated to keep the old default, as our tests start the daemon manually (not through systemd)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
Remove default oom score for dockerd. When starting the daemon manually (not through systemd), users should set the `--oom-score-adjust=-500` daemon option to preserve the old behavior.
```

**- A picture of a cute animal (not mandatory but encouraged)**

