### PR TITLE
testing: Init plugin config when for tests

### DIFF
--- a/testutil/fixtures/plugin/plugin.go
+++ b/testutil/fixtures/plugin/plugin.go
@@ -91,6 +91,7 @@ func CreateInRegistry(ctx context.Context, repo string, auth *types.AuthConfig, 
 	}
 
 	var cfg Config
+	cfg.PluginConfig = &types.PluginConfig{}
 	for _, o := range opts {
 		o(&cfg)
 	}


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/40932

This fixes a panic when running this test for me locally.

---

This is not panicing on CI because CI has `TEST_SKIP_INTEGRATION_CLI=1` 👎 