### PR TITLE
Also trim "~..." from AppArmor versions

### DIFF
--- a/pkg/aaparser/aaparser.go
+++ b/pkg/aaparser/aaparser.go
@@ -58,6 +58,8 @@ func parseVersion(output string) (int, error) {
 
 	// trim "-beta1" suffix from version="3.0.0-beta1" if exists
 	version = strings.SplitN(version, "-", 2)[0]
+	// also trim "~..." suffix used historically (https://gitlab.com/apparmor/apparmor/-/commit/bca67d3d27d219d11ce8c9cc70612bd637f88c10)
+	version = strings.SplitN(version, "~", 2)[0]
 
 	// split by major minor version
 	v := strings.Split(version, ".")

--- a/pkg/aaparser/aaparser_test.go
+++ b/pkg/aaparser/aaparser_test.go
@@ -44,6 +44,14 @@ Copyright 2009-2012 Canonical Ltd.
 			version: 205000,
 		},
 		{
+			output: `AppArmor parser version 2.2.0~rc2
+Copyright (C) 1999-2008 Novell Inc.
+Copyright 2009-2012 Canonical Ltd.
+
+`,
+			version: 202000,
+		},
+		{
 			output: `AppArmor parser version 2.9.95
 Copyright (C) 1999-2008 Novell Inc.
 Copyright 2009-2012 Canonical Ltd.


### PR DESCRIPTION
**- What I did**

Asked Canonical (who in turn had spoken to AppArmor upstream maintainers) whether we needed to trim `~...` from AppArmor versions too (https://github.com/moby/moby/pull/41518#discussion_r502026365). :smile:

**- How I did it**

I found https://gitlab.com/apparmor/apparmor/-/commit/bca67d3d27d219d11ce8c9cc70612bd637f88c10 as a good example of the historical `~` versions, and copied the implementation of #41518 to also trim `~...`. :smile:

**- How to verify it**

Go back in time to AppArmor `2.7.0~rc2` :thinking:

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/161631/95520868-1999bd80-097d-11eb-9259-939a9a05b5fc.png)
