### PR TITLE
[Carry 38704] Implement exec kill API

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.52](https://docs.docker.com/reference/api/engine/version/v1.52/) documentation
 
+* `POST /exec/{id}/signal` is a new endpoint that can be used for sending a signal to an exec instance.
 * `GET /images/{name}/get` now accepts multiple `platform` query-arguments
   to allow selecting which platform(s) of a multi-platform image must be
   saved.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -10793,6 +10793,39 @@ paths:
           required: true
           type: "string"
       tags: ["Exec"]
+  /exec/{id}/signal:
+    post:
+      summary: "Send a signal to an exec instance"
+      description: |
+         Send a POSIX signal to the exec instance, defaulting to SIGKILL.
+      operationId: "ExecSignal"
+      responses:
+        204:
+          description: "No error"
+        400:
+          description: "Invalid parameter"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        404:
+          description: "No such exec instance"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "Exec instance ID"
+          required: true
+          type: "string"
+        - name: "signal"
+          in: "query"
+          description: "Signal to send to the container as an integer or string (e.g. `SIGINT`)"
+          type: "string"
+          default: "SIGKILL"
+      tags: ["Exec"]
 
   /volumes:
     get:

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -66,3 +66,8 @@ type PushResult struct {
 	Digest string
 	Size   int
 }
+
+// ExecSignalConfig holds options to signal a container
+type ExecSignalConfig struct {
+	Signal string
+}

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -74,6 +74,7 @@ type ContainerAPIClient interface {
 	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
 	ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error
 	ContainerExecStart(ctx context.Context, execID string, options ExecStartOptions) error
+	ContainerExecSignal(ctx context.Context, execID, signal string) error
 	ContainerExport(ctx context.Context, container string) (io.ReadCloser, error)
 	ContainerInspect(ctx context.Context, container string) (container.InspectResponse, error)
 	ContainerInspectWithRaw(ctx context.Context, container string, getSize bool) (container.InspectResponse, []byte, error)

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/versions"
@@ -157,4 +158,14 @@ func (cli *Client) ContainerExecInspect(ctx context.Context, execID string) (con
 	var response container.ExecInspect
 	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
+}
+
+// ContainerExecSignal send a signal to exec process on the docker host.
+func (cli *Client) ContainerExecSignal(ctx context.Context, execID, signal string) error {
+	query := url.Values{}
+	query.Set("signal", signal)
+
+	resp, err := cli.post(ctx, "/exec/"+execID+"/signal", query, nil, nil)
+	ensureReaderClosed(resp)
+	return err
 }

--- a/daemon/exec_test.go
+++ b/daemon/exec_test.go
@@ -1,0 +1,85 @@
+//go:build linux
+
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moby/moby/api/types"
+	"github.com/moby/moby/api/types/versions"
+	"github.com/moby/moby/v2/daemon/container"
+	libcontainerdtypes "github.com/moby/moby/v2/daemon/internal/libcontainerd/types"
+	"github.com/moby/moby/v2/daemon/server/httputils"
+	"github.com/moby/sys/signal"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
+)
+
+type mockContainerd struct {
+	// MockContainerdClient
+	libcontainerdtypes.Client
+	calledCtx         *context.Context
+	calledContainerID *string
+	calledID          *string
+	calledSig         *int
+}
+
+func (cd *mockContainerd) SignalProcess(ctx context.Context, containerID, id string, sig int) error {
+	cd.calledCtx = &ctx
+	cd.calledContainerID = &containerID
+	cd.calledID = &id
+	cd.calledSig = &sig
+	return nil
+}
+
+func TestContainerExecSignalNoSuchExec(t *testing.T) {
+	ctx := context.Background()
+	version := httputils.VersionFromContext(ctx)
+	skip.If(t, versions.LessThan(version, "1.42"), "skip test from new feature")
+
+	mock := mockContainerd{}
+	d := &Daemon{
+		execCommands: container.NewExecStore(),
+		containerd:   &mock,
+	}
+
+	err := d.ContainerExecSignal(ctx, "nil", types.ExecSignalConfig{Signal: "TERM"})
+	assert.ErrorContains(t, err, "No such exec instance")
+	assert.Assert(t, is.Nil(mock.calledCtx))
+	assert.Assert(t, is.Nil(mock.calledContainerID))
+	assert.Assert(t, is.Nil(mock.calledID))
+	assert.Assert(t, is.Nil(mock.calledSig))
+}
+
+func TestContainerExecSignal(t *testing.T) {
+	ctx := context.Background()
+	version := httputils.VersionFromContext(ctx)
+	skip.If(t, versions.LessThan(version, "1.42"), "skip test from new feature")
+
+	mock := mockContainerd{}
+	c := &container.Container{
+		ExecCommands: container.NewExecStore(),
+		State:        &container.State{Running: true},
+	}
+	ec := &container.ExecConfig{
+		ID: "exec",
+		// ContainerID: "container",
+		Started: make(chan struct{}),
+	}
+	d := &Daemon{
+		execCommands: container.NewExecStore(),
+		containers:   container.NewMemoryStore(),
+		containerd:   &mock,
+	}
+	d.containers.Add("container", c)
+	d.registerExecCommand(c, ec)
+
+	err := d.ContainerExecSignal(ctx, "exec", types.ExecSignalConfig{Signal: "TERM"})
+	assert.NilError(t, err)
+	assert.Equal(t, *mock.calledCtx, ctx)
+	assert.Equal(t, *mock.calledContainerID, "container")
+	assert.Equal(t, *mock.calledID, "exec")
+	assert.Equal(t, *mock.calledSig, int(signal.SignalMap["TERM"]))
+}

--- a/daemon/server/router/container/backend.go
+++ b/daemon/server/router/container/backend.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/moby/go-archive"
+	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/filters"
 	containerpkg "github.com/moby/moby/v2/daemon/container"
@@ -18,6 +19,7 @@ type execBackend interface {
 	ContainerExecInspect(id string) (*backend.ExecInspect, error)
 	ContainerExecResize(ctx context.Context, name string, height, width uint32) error
 	ContainerExecStart(ctx context.Context, name string, options backend.ExecStartConfig) error
+	ContainerExecSignal(ctx context.Context, name string, config types.ExecSignalConfig) error
 	ExecExists(name string) (bool, error)
 }
 

--- a/daemon/server/router/container/container.go
+++ b/daemon/server/router/container/container.go
@@ -52,6 +52,7 @@ func (c *containerRouter) initRoutes() {
 		router.NewPostRoute("/containers/{name:.*}/exec", c.postContainerExecCreate),
 		router.NewPostRoute("/exec/{name:.*}/start", c.postContainerExecStart),
 		router.NewPostRoute("/exec/{name:.*}/resize", c.postContainerExecResize),
+		router.NewPostRoute("/exec/{name:.*}/signal", c.postContainerExecSignal),
 		router.NewPostRoute("/containers/{name:.*}/rename", c.postContainerRename),
 		router.NewPostRoute("/containers/{name:.*}/update", c.postContainerUpdate),
 		router.NewPostRoute("/containers/prune", c.postContainersPrune, router.WithMinimumAPIVersion("1.25")),

--- a/vendor/github.com/moby/moby/api/types/types.go
+++ b/vendor/github.com/moby/moby/api/types/types.go
@@ -66,3 +66,8 @@ type PushResult struct {
 	Digest string
 	Size   int
 }
+
+// ExecSignalConfig holds options to signal a container
+type ExecSignalConfig struct {
+	Signal string
+}

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -74,6 +74,7 @@ type ContainerAPIClient interface {
 	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
 	ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error
 	ContainerExecStart(ctx context.Context, execID string, options ExecStartOptions) error
+	ContainerExecSignal(ctx context.Context, execID, signal string) error
 	ContainerExport(ctx context.Context, container string) (io.ReadCloser, error)
 	ContainerInspect(ctx context.Context, container string) (container.InspectResponse, error)
 	ContainerInspectWithRaw(ctx context.Context, container string, getSize bool) (container.InspectResponse, []byte, error)

--- a/vendor/github.com/moby/moby/client/container_exec.go
+++ b/vendor/github.com/moby/moby/client/container_exec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/versions"
@@ -157,4 +158,14 @@ func (cli *Client) ContainerExecInspect(ctx context.Context, execID string) (con
 	var response container.ExecInspect
 	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
+}
+
+// ContainerExecSignal send a signal to exec process on the docker host.
+func (cli *Client) ContainerExecSignal(ctx context.Context, execID, signal string) error {
+	query := url.Values{}
+	query.Set("signal", signal)
+
+	resp, err := cli.post(ctx, "/exec/"+execID+"/signal", query, nil, nil)
+	ensureReaderClosed(resp)
+	return err
 }


### PR DESCRIPTION
Closes #35703 #9098

Hello this is just a rebase of https://github.com/moby/moby/pull/38704

- **What I did**

I rebased https://github.com/moby/moby/pull/38704 (which has all the rest of the questions answered).

Note that I do not know go... I just really would like to have this feature implemented. I hope there is CI that can pickup any problem I generated while rebasing.



