### PR TITLE
Don't set default platform on container create

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,8 @@ RUN /download-frozen-image-v2.sh /build \
         busybox:latest@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209 \
         busybox:glibc@sha256:1f81263701cddf6402afe9f33fca0266d9fff379e59b1748f33d3072da71ee85 \
         debian:buster@sha256:46d659005ca1151087efa997f1039ae45a7bf7a2cbbe2d17d3dcbda632a3ee9a \
-        hello-world:latest@sha256:d58e752213a51785838f9eed2b7a498ffa1cb3aa7f946dda11af39286c3db9a9
+        hello-world:latest@sha256:d58e752213a51785838f9eed2b7a498ffa1cb3aa7f946dda11af39286c3db9a9 \
+        arm32v7/hello-world:latest@sha256:50b8560ad574c779908da71f7ce370c0a2471c098d44d1c8f6b513c5a55eeeb1
 # See also ensureFrozenImagesLinux() in "integration-cli/fixtures_linux_daemon_test.go" (which needs to be updated when adding images to this list)
 
 FROM base AS cross-false

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -510,17 +510,6 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 			}
 			platform = &p
 		}
-		defaultPlatform := platforms.DefaultSpec()
-		if platform == nil {
-			platform = &defaultPlatform
-		}
-		if platform.OS == "" {
-			platform.OS = defaultPlatform.OS
-		}
-		if platform.Architecture == "" {
-			platform.Architecture = defaultPlatform.Architecture
-			platform.Variant = defaultPlatform.Variant
-		}
 	}
 
 	if hostConfig != nil && hostConfig.PidsLimit != nil && *hostConfig.PidsLimit <= 0 {

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	networktypes "github.com/docker/docker/api/types/network"
@@ -16,6 +17,7 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/runconfig"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -59,8 +61,10 @@ func (daemon *Daemon) containerCreate(opts createOpts) (containertypes.Container
 	}
 
 	os := runtime.GOOS
+	var img *image.Image
 	if opts.params.Config.Image != "" {
-		img, err := daemon.imageService.GetImage(opts.params.Config.Image, opts.params.Platform)
+		var err error
+		img, err = daemon.imageService.GetImage(opts.params.Config.Image, opts.params.Platform)
 		if err == nil {
 			os = img.OS
 		}
@@ -75,6 +79,19 @@ func (daemon *Daemon) containerCreate(opts createOpts) (containertypes.Container
 	warnings, err := daemon.verifyContainerSettings(os, opts.params.HostConfig, opts.params.Config, false)
 	if err != nil {
 		return containertypes.ContainerCreateCreatedBody{Warnings: warnings}, errdefs.InvalidParameter(err)
+	}
+
+	if img != nil && opts.params.Platform == nil {
+		p := platforms.DefaultSpec()
+		imgPlat := v1.Platform{
+			OS:           img.OS,
+			Architecture: img.Architecture,
+			Variant:      img.Variant,
+		}
+
+		if !platforms.Only(p).Match(imgPlat) {
+			warnings = append(warnings, fmt.Sprintf("The requested image's platform (%s) does not match the detected host platform (%s) and no specific platform was requested", platforms.Format(imgPlat), platforms.Format(p)))
+		}
 	}
 
 	err = verifyNetworkingConfig(opts.params.NetworkingConfig)

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -508,3 +508,23 @@ func TestCreateVolumesFromNonExistingContainer(t *testing.T) {
 	)
 	assert.Check(t, errdefs.IsInvalidParameter(err))
 }
+
+// Test that we can create a container from an image that is for a different platform even if a platform was not specified
+// This is for the regression detailed here: https://github.com/moby/moby/issues/41552
+func TestCreatePlatformSpecificImageNoPlatform(t *testing.T) {
+	defer setupTest(t)()
+
+	skip.If(t, testEnv.DaemonInfo.Architecture == "arm", "test only makes sense to run on non-arm systems")
+	skip.If(t, testEnv.OSType != "linux", "test image is only available on linux")
+	cli := testEnv.APIClient()
+
+	_, err := cli.ContainerCreate(
+		context.Background(),
+		&container.Config{Image: "arm32v7/hello-world"},
+		&container.HostConfig{},
+		nil,
+		nil,
+		"",
+	)
+	assert.NilError(t, err)
+}


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/41552

This fixes a regression based on expectations of the runtime:

```
docker pull arm32v7/alpine
docker run arm32v7/alpine
```

Without this change, the `docker run` will fail due to platform
matching on non-arm32v7 systems, even though the image could run
(assuming the system is setup correctly).

This also emits a warning to make sure that the user is aware that a
platform that does not match the default platform of the system is being
run, for the cases like:

```
docker pull --platform armhf busybox
docker run busybox
```

Not typically an issue if the requests are done together like that, but
if the image was already there and someone did `docker run` without an
explicit `--platform`, they may very well be expecting to run a native
version of the image instead of the armhf one.

This warning does add some extra noise in the case of platform specific
images being run, such as `arm32v7/alpine`, but this can be supressed by
explicitly setting the platform.