### PR TITLE
[19.03 backport] dockerd-rootless.sh: support new containerd shim socket path convention

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -88,6 +88,6 @@ else
 	[ $_DOCKERD_ROOTLESS_CHILD = 1 ]
 	# remove the symlinks for the existing files in the parent namespace if any,
 	# so that we can create our own files in our mount namespace.
-	rm -f /run/docker /run/xtables.lock
+	rm -f /run/docker /run/containerd /run/xtables.lock
 	exec dockerd $@
 fi


### PR DESCRIPTION
The new shim socket path convention hardcodes `/run/containerd`: https://github.com/containerd/containerd/pull/4343

`dockerd-rootless.sh` is updated to hide the rootful `/run/containerd` from the mount namespace of the rootless dockerd.


Cherry-pick #41156