### PR TITLE
Dockerfile: fix golang-ci-lint installer

### DIFF
--- a/hack/dockerfile/install/golangci_lint.installer
+++ b/hack/dockerfile/install/golangci_lint.installer
@@ -3,17 +3,8 @@
 : "${GOLANGCI_LINT_COMMIT=v1.23.8}"
 
 install_golangci_lint() {
-	echo "Installing golangci-lint version ${GOLANGCI_LINT_COMMIT}"
-	go get -d github.com/golangci/golangci-lint/cmd/golangci-lint
-	cd "$GOPATH/src/github.com/golangci/golangci-lint/" || exit 1
-	git checkout -q "${GOLANGCI_LINT_COMMIT}"
-
-	version="$(git describe --tags)"
-	commit="$(git rev-parse --short HEAD)"
-	commitDate="$(git show -s --format=%cd)"
-
-	go build \
-		${GO_BUILDMODE} \
-		-ldflags "-s -w -X \"main.version=${version}\" -X \"main.commit=${commit}\" -X \"main.date=${commitDate}\"" \
-		-o "${PREFIX}/golangci-lint" "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	set -e
+	export GO111MODULE=on
+	GOBIN="${PREFIX}" go get "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_COMMIT}"
+	"${PREFIX}"/golangci-lint --version
 }


### PR DESCRIPTION
Similar fix as https://github.com/moby/moby/pull/41151

We were using "go get", whith would try to fetch some dependencies that are not in the version we're installing,

    go get -d github.com/golangci/golangci-lint/cmd/golangci-lint

Causing the build to fail;

    package 4d63.com/gochecknoglobals/checknoglobals: unrecognized import path "4d63.com/gochecknoglobals/checknoglobals" (parse https://4d63.com/gochecknoglobals/checknoglobals?go-get=1: no go-import meta tags ())

