### PR TITLE
Temporarily disable CAP_PERFMON, CAP_BPF, and CAP_CHECKPOINT_RESTORE

### DIFF
--- a/oci/caps/utils.go
+++ b/oci/caps/utils.go
@@ -16,6 +16,18 @@ func init() {
 	if last == capability.Cap(63) {
 		last = capability.CAP_BLOCK_SUSPEND
 	}
+	if last > capability.CAP_AUDIT_READ {
+		// Prevents docker from setting CAP_PERFMON, CAP_BPF, and CAP_CHECKPOINT_RESTORE
+		// capabilities on privileged (or CAP_ALL) containers on Kernel 5.8 and up.
+		// While these kernels support these capabilities, the current release of
+		// runc ships with an older version of /gocapability/capability, and does
+		// not know about them, causing an error to be produced.
+		//
+		// FIXME remove once https://github.com/opencontainers/runc/commit/6dfbe9b80707b1ca188255e8def15263348e0f9a
+		//       is included in a runc release and once we stop supporting containerd 1.3.x
+		//       (which ships with runc v1.0.0-rc92)
+		last = capability.CAP_AUDIT_READ
+	}
 	for _, cap := range capability.List() {
 		if cap > last {
 			continue


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/41562

This prevents docker from setting `CAP_PERFMON`, `CAP_BPF`, and `CAP_CHECKPOINT_RESTORE`
capabilities on `--privileged` (or `CAP_ALL`) containers on Kernel 5.8 and up.

While these kernels support these capabilities, the current release of runc ships with an older version of gocapability/capability, and does not know about them, causing an error to be produced.

We can remove this restriction once https://github.com/opencontainers/runc/commit/6dfbe9b80707b1ca188255e8def15263348e0f9a is included in a runc release and once we stop supporting containerd 1.3.x (which ships with runc v1.0.0-rc92).

Thanks to @aiordache  for reporting.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

