### PR TITLE
Update array length check logic for preventing off-by-one error

### DIFF
--- a/daemon/daemon_linux.go
+++ b/daemon/daemon_linux.go
@@ -44,7 +44,7 @@ func (daemon *Daemon) cleanupMountsFromReaderByID(reader io.Reader, id string, u
 	regexps := getCleanPatterns(id)
 	sc := bufio.NewScanner(reader)
 	for sc.Scan() {
-		if fields := strings.Fields(sc.Text()); len(fields) >= 4 {
+		if fields := strings.Fields(sc.Text()); len(fields) > 4 {
 			if mnt := fields[4]; strings.HasPrefix(mnt, daemon.root) {
 				for _, p := range regexps {
 					if p.MatchString(mnt) {


### PR DESCRIPTION
Array length should be greater than or equal to 5, when accessing index 4

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Prevent off-by-one error.
Though `/proc/[pid]/mountinfo` has somewhat fixed format, this change will decrease possibility of runtime panic.

**- How I did it**
Update array length verification logic.

**- How to verify it**
```go
package main

import (
	"fmt"
	"strings"
)

func main() {
	mountinfo := "2 2 0:2 /"
	if fields := strings.Fields(mountinfo); len(fields) >= 4 {
		mnt := fields[4]
		fmt.Println(mnt)
	}
}
```
Code above will make a runtime panic.

**- Description for the changelog**
Update array length check logic for preventing off-by-one error
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
🐈 
![cat](https://user-images.githubusercontent.com/43400316/96402426-d0652b80-1210-11eb-805f-0fd15b5a6788.jpg)

