### PR TITLE
docker stats: fix 'panic: close of closed channel'

### DIFF
--- a/pkg/pubsub/publisher.go
+++ b/pkg/pubsub/publisher.go
@@ -66,8 +66,11 @@ func (p *Publisher) SubscribeTopicWithBuffer(topic topicFunc, buffer int) chan i
 // Evict removes the specified subscriber from receiving any more messages.
 func (p *Publisher) Evict(sub chan interface{}) {
 	p.m.Lock()
-	delete(p.subscribers, sub)
-	close(sub)
+	_, exists := p.subscribers[sub]
+	if exists {
+		delete(p.subscribers, sub)
+		close(sub)
+	}
 	p.m.Unlock()
 }
 


### PR DESCRIPTION
Signed-off-by: fanjiyun <fan.jiyun@zte.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
When executing “docker stats” and “docker rm” in parallel, there is a certain probability that problems "panic: close of closed channel"will occur.

"docker rm -f" call this func:
https://github.com/moby/moby/blob/7cf6dfcb9e6d0bb135039c73e1e1051e9ea6f2f6/pkg/pubsub/publisher.go#L93-L100
"docker stats" call this func:
https://github.com/moby/moby/blob/7cf6dfcb9e6d0bb135039c73e1e1051e9ea6f2f6/pkg/pubsub/publisher.go#L67-L72

Once this panic occurs, the lock of Collector will not be released and all "docker stats" and "docker rm" will be blocked.
So, I added a step to check the channel before closing it.

**- How I did it**
In the func Evict()， check whether the channel exists in the map p.subscribers.

**- How to verify it**
1. Repeated execution “docker stats $cid”.
2. At the same time, execution "docker rm -f $cid" to delete container.

However, the probability of problems is very small.
Adding time.sleep() in the code, can increase the recurrence probability.
(1) after this line, add time.sleep() 
https://github.com/moby/moby/blob/7cf6dfcb9e6d0bb135039c73e1e1051e9ea6f2f6/daemon/delete.go#L100
(2) before this line, add time.sleep() 
https://github.com/moby/moby/blob/7cf6dfcb9e6d0bb135039c73e1e1051e9ea6f2f6/daemon/stats.go#L144

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
In the func Evict(), check the channel before closing it.

**- A picture of a cute animal (not mandatory but encouraged)**

