### PR TITLE
Fix build errors on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,13 +99,14 @@ BIND_DIR := $(if $(BINDDIR),$(BINDDIR),$(if $(DOCKER_HOST),,bundles))
 
 # DOCKER_MOUNT can be overriden, but use at your own risk!
 ifndef DOCKER_MOUNT
-DOCKER_MOUNT := $(if $(BIND_DIR),-v "$(CURDIR)/$(BIND_DIR):/go/src/github.com/docker/docker/$(BIND_DIR)")
+CUR_DIR := $(shell bash -c 'echo $$(pwd)')
+DOCKER_MOUNT := $(if $(BIND_DIR),-v "$(CUR_DIR)/$(BIND_DIR):/go/src/github.com/docker/docker/$(BIND_DIR)")
 DOCKER_MOUNT := $(if $(DOCKER_BINDDIR_MOUNT_OPTS),$(DOCKER_MOUNT):$(DOCKER_BINDDIR_MOUNT_OPTS),$(DOCKER_MOUNT))
 
 # This allows the test suite to be able to run without worrying about the underlying fs used by the container running the daemon (e.g. aufs-on-aufs), so long as the host running the container is running a supported fs.
 # The volume will be cleaned up when the container is removed due to `--rm`.
 # Note that `BIND_DIR` will already be set to `bundles` if `DOCKER_HOST` is not set (see above BIND_DIR line), in such case this will do nothing since `DOCKER_MOUNT` will already be set.
-DOCKER_MOUNT := $(if $(DOCKER_MOUNT),$(DOCKER_MOUNT),-v /go/src/github.com/docker/docker/bundles) -v "$(CURDIR)/.git:/go/src/github.com/docker/docker/.git"
+DOCKER_MOUNT := $(if $(DOCKER_MOUNT),$(DOCKER_MOUNT),-v /go/src/github.com/docker/docker/bundles) -v "$(CUR_DIR)/.git:/go/src/github.com/docker/docker/.git"
 
 DOCKER_MOUNT_CACHE := -v docker-dev-cache:/root/.cache
 DOCKER_MOUNT_CLI := $(if $(DOCKER_CLI_PATH),-v $(shell dirname $(DOCKER_CLI_PATH)):/usr/local/cli,)
@@ -248,7 +249,7 @@ validate: build ## validate DCO, Seccomp profile generation, gofmt,\n./pkg/ isol
 	$(DOCKER_RUN_DOCKER) hack/validate/all
 
 win: build ## cross build the binary for windows
-	$(DOCKER_RUN_DOCKER) DOCKER_CROSSPLATFORMS=windows/amd64 hack/make.sh cross
+	$(DOCKER_RUN_DOCKER) env DOCKER_CROSSPLATFORMS=windows/amd64 hack/make.sh cross
 
 .PHONY: swagger-gen
 swagger-gen:


### PR DESCRIPTION
**- What I did**

1. Fixed #41519
2. Fixed a build issue when building from the Docker MSYS shell (Docker Toolbox) on Windows - because the path contains a colon on Windows, the -v flag passed to docker would not work when running `make win` (inside the `DOCKER_MOUNT` variable). 

**- How I did it**

1. Added a call to `env` to make the `eval` command work inside the `dind` script
2. Replaced `CURDIR` with a custom variable that is set to the value of `$(pwd)`

**- How to verify it**

Compile on Windows by running `make win`

**- Description for the changelog**

Fixed build errors on Windows hosts 