### PR TITLE
devicemapper: remove path after umount

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -2264,6 +2264,9 @@ func (devices *DeviceSet) unmountAndDeactivateAll(dir string) {
 		// and the device will be released when that container dies.
 		if err := unix.Unmount(fullname, unix.MNT_DETACH); err != nil && err != unix.EINVAL {
 			logger.Warnf("Shutdown unmounting %s, error: %s", fullname, err)
+		} else if err == nil {
+			logger.Debugf("Remove %s", fullname)
+			os.RemoveAll(fullname)
 		}
 
 		if devInfo, err := devices.lookupDevice(name); err != nil {


### PR DESCRIPTION
Remove unmounted directory to reduce files leak mentioned by #41307

Signed-off-by: jingrui <jingrui@huawei.com>


