### PR TITLE
docs: fix builder-version swagger

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8023,7 +8023,7 @@ paths:
             API-Version:
               type: "string"
               description: "Max API Version the server supports"
-            BuildKit-Version:
+            Builder-Version:
               type: "string"
               description: "Default version of docker image builder"
             Docker-Experimental:
@@ -8062,7 +8062,7 @@ paths:
             API-Version:
               type: "string"
               description: "Max API Version the server supports"
-            BuildKit-Version:
+            Builder-Version:
               type: "string"
               description: "Default version of docker image builder"
             Docker-Experimental:

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -7712,7 +7712,7 @@ paths:
             API-Version:
               type: "string"
               description: "Max API Version the server supports"
-            BuildKit-Version:
+            Builder-Version:
               type: "string"
               description: "Default version of docker image builder"
             Docker-Experimental:

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -7855,7 +7855,7 @@ paths:
             API-Version:
               type: "string"
               description: "Max API Version the server supports"
-            BuildKit-Version:
+            Builder-Version:
               type: "string"
               description: "Default version of docker image builder"
             Docker-Experimental:
@@ -7894,7 +7894,7 @@ paths:
             API-Version:
               type: "string"
               description: "Max API Version the server supports"
-            BuildKit-Version:
+            Builder-Version:
               type: "string"
               description: "Default version of docker image builder"
             Docker-Experimental:


### PR DESCRIPTION
The field is called `Builder-Version` https://github.com/moby/moby/blob/837ee91cb9295a86dec176da07ee598304535dbb/api/server/router/system/system_routes.go#L35

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
