### PR TITLE
registry.loginV2(): minor cleanup

### DIFF
--- a/registry/auth.go
+++ b/registry/auth.go
@@ -77,22 +77,21 @@ func (err fallbackError) Error() string {
 // endpoint will be pinged to get authorization challenges. These challenges
 // will be used to authenticate against the registry to validate credentials.
 func loginV2(authConfig *types.AuthConfig, endpoint APIEndpoint, userAgent string) (string, string, error) {
-	logrus.Debugf("attempting v2 login to registry endpoint %s", strings.TrimRight(endpoint.URL.String(), "/")+"/v2/")
+	var (
+		endpointStr          = strings.TrimRight(endpoint.URL.String(), "/") + "/v2/"
+		modifiers            = Headers(userAgent, nil)
+		authTransport        = transport.NewTransport(NewTransport(endpoint.TLSConfig), modifiers...)
+		credentialAuthConfig = *authConfig
+		creds                = loginCredentialStore{authConfig: &credentialAuthConfig}
+	)
 
-	modifiers := Headers(userAgent, nil)
-	authTransport := transport.NewTransport(NewTransport(endpoint.TLSConfig), modifiers...)
-
-	credentialAuthConfig := *authConfig
-	creds := loginCredentialStore{
-		authConfig: &credentialAuthConfig,
-	}
+	logrus.Debugf("attempting v2 login to registry endpoint %s", endpointStr)
 
 	loginClient, foundV2, err := v2AuthHTTPClient(endpoint.URL, authTransport, modifiers, creds, nil)
 	if err != nil {
 		return "", "", err
 	}
 
-	endpointStr := strings.TrimRight(endpoint.URL.String(), "/") + "/v2/"
 	req, err := http.NewRequest(http.MethodGet, endpointStr, nil)
 	if err != nil {
 		if !foundV2 {


### PR DESCRIPTION
just some minor cleaning up; construct the endpoint-path once instead of twice, and grouping all variable declarations at the start.

