### PR TITLE
Move HostGatewayName const to opts, and change vars to consts

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -118,7 +118,7 @@ func (daemon *Daemon) buildSandboxOptions(container *container.Container) ([]lib
 		// If the IP Address is a string called "host-gateway", replace this
 		// value with the IP address stored in the daemon level HostGatewayIP
 		// config variable
-		if parts[1] == network.HostGatewayName {
+		if parts[1] == opts.HostGatewayName {
 			gateway := daemon.configStore.HostGatewayIP.String()
 			if gateway == "" {
 				return nil, fmt.Errorf("unable to derive the IP value for host-gateway")

--- a/daemon/network/constants.go
+++ b/daemon/network/constants.go
@@ -1,8 +1,0 @@
-package network
-
-const (
-	// HostGatewayName is the string value that can be passed
-	// to the IPAddr section in --add-host that is replaced by
-	// the value of HostGatewayIP daemon config value
-	HostGatewayName = "host-gateway"
-)

--- a/opts/hosts.go
+++ b/opts/hosts.go
@@ -8,11 +8,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/pkg/homedir"
 )
 
-var (
+const (
 	// DefaultHTTPPort Default HTTP Port used if only the protocol is provided to -H flag e.g. dockerd -H tcp://
 	// These are the IANA registered port numbers for use with Docker
 	// see http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=docker
@@ -23,11 +22,15 @@ var (
 	// Docker daemon by default always listens on the default unix socket
 	DefaultUnixSocket = "/var/run/docker.sock"
 	// DefaultTCPHost constant defines the default host string used by docker on Windows
-	DefaultTCPHost = fmt.Sprintf("tcp://%s:%d", DefaultHTTPHost, DefaultHTTPPort)
+	DefaultTCPHost = "tcp://" + DefaultHTTPHost + ":2375"
 	// DefaultTLSHost constant defines the default host string used by docker for TLS sockets
-	DefaultTLSHost = fmt.Sprintf("tcp://%s:%d", DefaultHTTPHost, DefaultTLSHTTPPort)
+	DefaultTLSHost = "tcp://" + DefaultHTTPHost + ":2376"
 	// DefaultNamedPipe defines the default named pipe used by docker on Windows
 	DefaultNamedPipe = `//./pipe/docker_engine`
+	// HostGatewayName is the string value that can be passed
+	// to the IPAddr section in --add-host that is replaced by
+	// the value of HostGatewayIP daemon config value
+	HostGatewayName = "host-gateway"
 )
 
 // ValidateHost validates that the specified string is a valid host and returns it.
@@ -171,7 +174,7 @@ func ValidateExtraHost(val string) (string, error) {
 		return "", fmt.Errorf("bad format for add-host: %q", val)
 	}
 	// Skip IPaddr validation for special "host-gateway" string
-	if arr[1] != network.HostGatewayName {
+	if arr[1] != HostGatewayName {
 		if _, err := ValidateIPAddress(arr[1]); err != nil {
 			return "", fmt.Errorf("invalid IP address in add-host: %q", arr[1])
 		}


### PR DESCRIPTION
This prevents consumers of the opts package to also having to
depend on daemon/network, and everything related.

We can probably change some of the other constants to strings,
for easier concatenating, and need to review the windows-specific
"127.0.0.1" (instead of "localhost"), which may no longer be
needed.

