### PR TITLE
Added container ID to containerd task delete event messages

### DIFF
--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -862,6 +862,13 @@ func (c *client) processEventStream(ctx context.Context, ns string) {
 				ei = libcontainerdtypes.EventInfo{
 					ContainerID: t.ContainerID,
 				}
+			case *apievents.TaskDelete:
+				c.logger.WithFields(logrus.Fields{
+					"topic":     ev.Topic,
+					"type":      reflect.TypeOf(t),
+					"container": t.ContainerID},
+				).Info("ignoring event")
+				continue
 			default:
 				c.logger.WithFields(logrus.Fields{
 					"topic": ev.Topic,


### PR DESCRIPTION
Signed-off-by: Cam <gh@sparr.email>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

capture TaskDelete messages in the switch statement so we can add the container ID context to them, as this can help users see at what time exactly containerd deleted the container.

logs look like this before change:

```
time="2020-10-30T20:45:36.367977633Z" level=info msg="ignoring event" module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
```

to this after change:

```
time="2020-10-30T21:07:28.511151518Z" level=info msg="ignoring event" container=cdf7bcc6bf37f0ab733a8f0d469b66c1c23581da9a2e0543cb01d2e9afb99401 module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Added container ID to containerd task delete event messages



