### PR TITLE
container: make hostconfig.json non-world-readable (0600)

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -43,7 +43,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const configFileName = "config.v2.json"
+const (
+	configFileName     = "config.v2.json"
+	hostConfigFileName = "hostconfig.json"
+)
 
 // ExitStatus provides exit reasons for a container.
 type ExitStatus struct {
@@ -158,12 +161,9 @@ func (container *Container) FromDisk() error {
 	return container.readHostConfig()
 }
 
-// toDisk saves the container configuration on disk and returns a deep copy.
+// toDisk writes the container's configuration (config.v2.json, hostconfig.json)
+// to disk and returns a deep copy.
 func (container *Container) toDisk() (*Container, error) {
-	var (
-		buf      bytes.Buffer
-		deepCopy Container
-	)
 	pth, err := container.ConfigPath()
 	if err != nil {
 		return nil, err
@@ -176,11 +176,13 @@ func (container *Container) toDisk() (*Container, error) {
 	}
 	defer f.Close()
 
+	var buf bytes.Buffer
 	w := io.MultiWriter(&buf, f)
 	if err := json.NewEncoder(w).Encode(container); err != nil {
 		return nil, err
 	}
 
+	var deepCopy Container
 	if err := json.NewDecoder(&buf).Decode(&deepCopy); err != nil {
 		return nil, err
 	}
@@ -188,7 +190,6 @@ func (container *Container) toDisk() (*Container, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return &deepCopy, nil
 }
 
@@ -348,7 +349,7 @@ func (container *Container) ExitOnNext() {
 
 // HostConfigPath returns the path to the container's JSON hostconfig
 func (container *Container) HostConfigPath() (string, error) {
-	return container.GetRootResourcePath("hostconfig.json")
+	return container.GetRootResourcePath(hostConfigFileName)
 }
 
 // ConfigPath returns the path to the container's JSON config

--- a/container/container.go
+++ b/container/container.go
@@ -244,7 +244,7 @@ func (container *Container) WriteHostConfig() (*containertypes.HostConfig, error
 		return nil, err
 	}
 
-	f, err := ioutils.NewAtomicFileWriter(pth, 0644)
+	f, err := ioutils.NewAtomicFileWriter(pth, 0600)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/17310 "644 permissions for config.json and the like security issue" (together with https://github.com/moby/moby/pull/34419, which updated permissions for `config.v2.json`

When writing container's `hostconfig.json`, permissions were set to 0644 (world-readable). While this is not a security concern (as the `/var/lib/docker/containers` directory has `0700` or `0701` permissions), there is no need to have these permissions, as this file is only accessed by the daemon.

Looking at history for file permissions;

- 06b53e3fc7aca2b3dae32edab08c7662d3e9e7e8 (first implementation) used `0666` (world-writable)
- cf1a6c08fa03aa7020f8f5b414bb9349a9c8371a refactored the code, and removed explicit permissions
- ea3cbd3274664f5b16fce78d7df036f6b5c94e30 introduced atomic writes, and brought back the explicit `0666` permissions
- 3ec8fed7476704f061891d4c421c615da49e30c7 (https://github.com/moby/moby/pull/27962) removed world-writable bits, but kept world-readable


This patch updates the permissions to `0600`, matching what's used for `config.v2.json`, which was updated in ae52cea3ab46e1e728606349fb6baa9a8203f3ed, but forgot to update `hostconfig.json`.

The second commit is some small cleanup/refactoring 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
- change permissions on container `hostconfig.json` files to `0600` (was `0644`)
```


**- A picture of a cute animal (not mandatory but encouraged)**

