### PR TITLE
IPv6 iptables config option

### DIFF
--- a/cmd/dockerd/config_unix.go
+++ b/cmd/dockerd/config_unix.go
@@ -34,6 +34,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	flags.BoolVar(&conf.EnableSelinuxSupport, "selinux-enabled", false, "Enable selinux support")
 	flags.Var(opts.NewNamedUlimitOpt("default-ulimits", &conf.Ulimits), "default-ulimit", "Default ulimits for containers")
 	flags.BoolVar(&conf.BridgeConfig.EnableIPTables, "iptables", true, "Enable addition of iptables rules")
+	flags.BoolVar(&conf.BridgeConfig.EnableIP6Tables, "ip6tables", false, "Enable addition of ip6tables rules")
 	flags.BoolVar(&conf.BridgeConfig.EnableIPForward, "ip-forward", true, "Enable net.ipv4.ip_forward")
 	flags.BoolVar(&conf.BridgeConfig.EnableIPMasq, "ip-masq", true, "Enable IP masquerading")
 	flags.BoolVar(&conf.BridgeConfig.EnableIPv6, "ipv6", false, "Enable IPv6 networking")

--- a/daemon/config/config_unix.go
+++ b/daemon/config/config_unix.go
@@ -54,6 +54,7 @@ type BridgeConfig struct {
 	// Fields below here are platform specific.
 	EnableIPv6          bool   `json:"ipv6,omitempty"`
 	EnableIPTables      bool   `json:"iptables,omitempty"`
+	EnableIP6Tables     bool   `json:"ip6tables,omitempty"`
 	EnableIPForward     bool   `json:"ip-forward,omitempty"`
 	EnableIPMasq        bool   `json:"ip-masq,omitempty"`
 	EnableUserlandProxy bool   `json:"userland-proxy,omitempty"`

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -911,6 +911,7 @@ func driverOptions(config *config.Config) []nwconfig.Option {
 	bridgeConfig := options.Generic{
 		"EnableIPForwarding":  config.BridgeConfig.EnableIPForward,
 		"EnableIPTables":      config.BridgeConfig.EnableIPTables,
+		"EnableIP6Tables":     config.BridgeConfig.EnableIP6Tables,
 		"EnableUserlandProxy": config.BridgeConfig.EnableUserlandProxy,
 		"UserlandProxyPath":   config.BridgeConfig.UserlandProxyPath}
 	bridgeOption := options.Generic{netlabel.GenericData: bridgeConfig}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -746,6 +746,9 @@ func verifyDaemonSettings(conf *config.Config) error {
 	if !conf.BridgeConfig.EnableIPTables && !conf.BridgeConfig.InterContainerCommunication {
 		return fmt.Errorf("You specified --iptables=false with --icc=false. ICC=false uses iptables to function. Please set --icc or --iptables to true")
 	}
+	if conf.BridgeConfig.EnableIP6Tables && !conf.Experimental {
+		return fmt.Errorf("ip6tables rules are only available if experimental features are enabled")
+	}
 	if !conf.BridgeConfig.EnableIPTables && conf.BridgeConfig.EnableIPMasq {
 		conf.BridgeConfig.EnableIPMasq = false
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

~~**Note: This requires pull request moby/moby#41604 to be merged first**~~ (already merged)

**- What I did**
Added an config option to enable the IPv6 iptables rule creation based on moby/libnetwork#2572.

This should close #25407.
fixes https://github.com/moby/moby/issues/21614

**- How I did it**
Add a config option `ip6tables` (like `iptables` for IPv4) which can be used to enable the IPv6 iptables rule creation.
By default this option is disabled too keep backward compatibility.

**- How to verify it**
To enable this functionality it is required to enable ipv6, set a fixed cidr and enable the ip6itpables.

This can be done for example via CLI parameters on the daemon:
```
dockerd --ipv6 --fixed-cidr-v6 fd00:dead:beef::/48 --ip6tables
```
or by setting the configurations inside the `daemon.json`.

Now a container can be started and if a port is published the IPv6 NAT iptables rules are also created.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
`--ip6tables` enables IPv6 iptables rules (only if experimental)

