### PR TITLE
pkg/devicemapper: fix invalid usage of reflect.SliceHeader

### DIFF
--- a/pkg/devicemapper/devmapper_wrapper.go
+++ b/pkg/devicemapper/devmapper_wrapper.go
@@ -150,12 +150,11 @@ func dmTaskGetDepsFct(task *cdmTask) *Deps {
 	}
 
 	// golang issue: https://github.com/golang/go/issues/11925
-	hdr := reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(uintptr(unsafe.Pointer(Cdeps)) + unsafe.Sizeof(*Cdeps))),
-		Len:  int(Cdeps.count),
-		Cap:  int(Cdeps.count),
-	}
-	devices := *(*[]C.uint64_t)(unsafe.Pointer(&hdr))
+	var devices []C.uint64_t
+	devicesHdr := (*reflect.SliceHeader)(unsafe.Pointer(&devices))
+	devicesHdr.Data = uintptr(unsafe.Pointer(uintptr(unsafe.Pointer(Cdeps)) + unsafe.Sizeof(*Cdeps)))
+	devicesHdr.Len = int(Cdeps.count)
+	devicesHdr.Cap = int(Cdeps.count)
 
 	deps := &Deps{
 		Count:  uint32(Cdeps.count),


### PR DESCRIPTION
The current usage of reflect.SliceHeader violates rule 6th of
unsafe.Pointer conversion. In short, reflect.SliceHeader could not be
used as plain struct.

See https://golang.org/pkg/unsafe/#Pointer
