### PR TITLE
Set 127GB default sandbox size for WCOW, and ensure storage-opts is honoured on all paths under WCOW and LCOW

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -187,23 +187,6 @@ func (daemon *Daemon) create(opts createOpts) (retC *container.Container, retErr
 
 	ctr.HostConfig.StorageOpt = opts.params.HostConfig.StorageOpt
 
-	// Fixes: https://github.com/moby/moby/issues/34074 and
-	// https://github.com/docker/for-win/issues/999.
-	// Merge the daemon's storage options if they aren't already present. We only
-	// do this on Windows as there's no effective sandbox size limit other than
-	// physical on Linux.
-	if isWindows {
-		if ctr.HostConfig.StorageOpt == nil {
-			ctr.HostConfig.StorageOpt = make(map[string]string)
-		}
-		for _, v := range daemon.configStore.GraphOptions {
-			opt := strings.SplitN(v, "=", 2)
-			if _, ok := ctr.HostConfig.StorageOpt[opt[0]]; !ok {
-				ctr.HostConfig.StorageOpt[opt[0]] = opt[1]
-			}
-		}
-	}
-
 	// Set RWLayer for container after mount labels have been set
 	rwLayer, err := daemon.imageService.CreateLayer(ctr, setupInitLayer(daemon.idMapping))
 	if err != nil {

--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -363,7 +363,7 @@ Function Run-IntegrationTests() {
         $pinfo.FileName = "gotestsum.exe"
         $pinfo.WorkingDirectory = "$($PWD.Path)"
         $pinfo.UseShellExecute = $false
-        $pinfo.Arguments = "--format=standard-verbose --jsonfile=$jsonFilePath --junitfile=$xmlFilePath -- $env:INTEGRATION_TESTFLAGS"
+        $pinfo.Arguments = "--format=standard-verbose --jsonfile=$jsonFilePath --junitfile=$xmlFilePath -- -test.timeout=60m $env:INTEGRATION_TESTFLAGS"
         $p = New-Object System.Diagnostics.Process
         $p.StartInfo = $pinfo
         $p.Start() | Out-Null

--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -285,7 +285,7 @@ func TestContainerVolumesMountedAsShared(t *testing.T) {
 
 	// Convert this directory into a shared mount point so that we do
 	// not rely on propagation properties of parent mount.
-	if err := mount.Mount(tmpDir1.Path(), tmpDir1.Path(), "none", "bind,private"); err != nil {
+	if err := mount.MakePrivate(tmpDir1.Path()); err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
@@ -293,7 +293,7 @@ func TestContainerVolumesMountedAsShared(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	if err := mount.Mount("none", tmpDir1.Path(), "none", "shared"); err != nil {
+	if err := mount.MakeShared(tmpDir1.Path()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -342,7 +342,7 @@ func TestContainerVolumesMountedAsSlave(t *testing.T) {
 
 	// Convert this directory into a shared mount point so that we do
 	// not rely on propagation properties of parent mount.
-	if err := mount.Mount(tmpDir1.Path(), tmpDir1.Path(), "none", "bind,private"); err != nil {
+	if err := mount.MakePrivate(tmpDir1.Path()); err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
@@ -350,7 +350,7 @@ func TestContainerVolumesMountedAsSlave(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	if err := mount.Mount("none", tmpDir1.Path(), "none", "shared"); err != nil {
+	if err := mount.MakeShared(tmpDir1.Path()); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
**- What I did**

* Applied the 127GB WCOW default sandbox size for `RUN` (introduced in #35925) to all WCOW sandboxes.
* * Also ensured this default applies whether WCOW was chosen by explicit `--platform windows` or by image-based or defaulted platform choice.
* Ensures the `storage-opts` overrides the 127GB default sandbox size when both are applied.
* * Supplants: #40256
* * Addresses: https://github.com/moby/moby/issues/34947#issuecomment-510078008
* Applied the `storage-opts` setting for _dockerd.exe_ to all WCOW and LCOW sandboxes, not just the ones underlying a container, i.e. not just `RUN` and `docker run`.
* * This means we validate `lcow.sandboxsize` (it cannot be less than 20GB) at startup rather than waiting until someone runs a container.
* * Fixes: #37352
* * Another occurrence: https://github.com/adamrehn/ue4-docker/issues/99#issuecomment-706268305 onwards.

**- How I did it**

* Moved the 127GB WCOW default from the Builder internals to the Windows Filter GraphDriver.
* Processed daemon `storage-opts` in the Windows Filter and LCOW GraphDrivers `initfn` instead of merging them into the container-creation parameters.
* Worked around the limited storage on the Windows RS5 Jenkins build node by detecting when the test passed but the container build failed, see 695b151a18299ade7c70dfe3babc8d77b7f5aba6.

TODO: Update the [documentation](https://docs.docker.com/engine/reference/commandline/dockerd/#size) for the new effective default value of `--storage-opts size`. [Source](https://github.com/docker/cli/blob/master/docs/reference/commandline/dockerd.md).

**- How to verify it**

* Added `TestBuildWCOWSandboxSize` to the integration test suite
* * Creates a 21GB file (and immediately deletes it) to confirm the `RUN` sandbox is > 20GB.
* * Attempts to copy three 7GB files from a previous layer into a new layer, to confirm the `COPY` sandbox is > 20GB.
* Manual testing of storage-opts can be done either by hand, or using the `DOCKER_STORAGE_OPTS` env-var for the integration test script. Setting `size=20GB` will cause `TestBuildWCOWSandboxSize` to fail.
* * If the first failure line (the `RUN fsutil && delete` call) is deleted, it should then also fail on the last step (the `COPY --from`).
* * This test could be split into two, one for the `RUN` sandbox and one for the `COPY` sandbox, if that's useful. The `RUN` test has almost-zero time or space overhead where it is, as fsutil creates an empty file, and we delete it before it's archived into a layer.
* * TODO: Think of some way to automate this? To adjust `DOCKER_STORAGE_OPTS` for CI, we'd need a separate pipeline stage. That probably needs separate discussion. And special tests that detect correctly running out of space in `docker build`.
* Manual testing with `docker run --isolation=hyperv -it --rm mcr.microsoft.com/windows/servercore:2004` showed that storage-opts was taking effect, and if not supplied, a 127GB sandbox was used.

**- Description for the changelog**

On Windows, all WCOW read-write layers default to 127GB of free space (up from 20GB in most cases), and all WCOW and LCOW layers will honour the [`size` option](https://docs.docker.com/engine/reference/commandline/dockerd/#size) and [`lcow.sandboxsize` option](https://docs.docker.com/engine/reference/commandline/dockerd/#lcowsandboxsize) (repsectively) in the daemon's `storage-opts` configuration

**- A picture of a cute animal (not mandatory but encouraged)**

[![](https://i.imgur.com/1oMXHEo.jpeg)](https://imgur.com/1oMXHEo)
