### PR TITLE
pkg/mount: fix compile failure on Windows (move linux-only stubs0

### DIFF
--- a/pkg/mount/deprecated.go
+++ b/pkg/mount/deprecated.go
@@ -4,50 +4,7 @@ package mount // import "github.com/docker/docker/pkg/mount"
 // Use github.com/moby/sys/mount and github.com/moby/sys/mountinfo instead.
 
 import (
-	sysmount "github.com/moby/sys/mount"
 	"github.com/moby/sys/mountinfo"
-)
-
-// Deprecated: use github.com/moby/sys/mount instead.
-//nolint:golint
-var (
-	Mount            = sysmount.Mount
-	ForceMount       = sysmount.Mount // a deprecated synonym
-	Unmount          = sysmount.Unmount
-	RecursiveUnmount = sysmount.RecursiveUnmount
-)
-
-// Deprecated: use github.com/moby/sys/mount instead.
-//nolint:golint
-const (
-	RDONLY      = sysmount.RDONLY
-	NOSUID      = sysmount.NOSUID
-	NOEXEC      = sysmount.NOEXEC
-	SYNCHRONOUS = sysmount.SYNCHRONOUS
-	NOATIME     = sysmount.NOATIME
-	BIND        = sysmount.BIND
-	DIRSYNC     = sysmount.DIRSYNC
-	MANDLOCK    = sysmount.MANDLOCK
-	NODEV       = sysmount.NODEV
-	NODIRATIME  = sysmount.NODIRATIME
-	UNBINDABLE  = sysmount.UNBINDABLE
-	RUNBINDABLE = sysmount.RUNBINDABLE
-	PRIVATE     = sysmount.PRIVATE
-	RPRIVATE    = sysmount.RPRIVATE
-	SHARED      = sysmount.SHARED
-	RSHARED     = sysmount.RSHARED
-	SLAVE       = sysmount.SLAVE
-	RSLAVE      = sysmount.RSLAVE
-	RBIND       = sysmount.RBIND
-	RELATIME    = sysmount.RELATIME
-	REMOUNT     = sysmount.REMOUNT
-	STRICTATIME = sysmount.STRICTATIME
-)
-
-// Deprecated: use github.com/moby/sys/mount instead.
-//nolint:golint
-var (
-	MergeTmpfsOptions = sysmount.MergeTmpfsOptions
 )
 
 //nolint:golint

--- a/pkg/mount/deprecated_linux.go
+++ b/pkg/mount/deprecated_linux.go
@@ -7,13 +7,45 @@ import (
 // Deprecated: use github.com/moby/sys/mount instead.
 //nolint:golint
 var (
-	MakeMount       = sysmount.MakeMount
-	MakeShared      = sysmount.MakeShared
-	MakeRShared     = sysmount.MakeRShared
-	MakePrivate     = sysmount.MakePrivate
-	MakeRPrivate    = sysmount.MakeRPrivate
-	MakeSlave       = sysmount.MakeSlave
-	MakeRSlave      = sysmount.MakeRSlave
-	MakeUnbindable  = sysmount.MakeUnbindable
-	MakeRUnbindable = sysmount.MakeRUnbindable
+	ForceMount        = sysmount.Mount // a deprecated synonym
+	MakeMount         = sysmount.MakeMount
+	MakePrivate       = sysmount.MakePrivate
+	MakeRPrivate      = sysmount.MakeRPrivate
+	MakeRShared       = sysmount.MakeRShared
+	MakeRSlave        = sysmount.MakeRSlave
+	MakeRUnbindable   = sysmount.MakeRUnbindable
+	MakeShared        = sysmount.MakeShared
+	MakeSlave         = sysmount.MakeSlave
+	MakeUnbindable    = sysmount.MakeUnbindable
+	MergeTmpfsOptions = sysmount.MergeTmpfsOptions
+	Mount             = sysmount.Mount
+	RecursiveUnmount  = sysmount.RecursiveUnmount
+	Unmount           = sysmount.Unmount
+)
+
+// Deprecated: use github.com/moby/sys/mount instead.
+//nolint:golint
+const (
+	RDONLY      = sysmount.RDONLY
+	NOSUID      = sysmount.NOSUID
+	NOEXEC      = sysmount.NOEXEC
+	SYNCHRONOUS = sysmount.SYNCHRONOUS
+	NOATIME     = sysmount.NOATIME
+	BIND        = sysmount.BIND
+	DIRSYNC     = sysmount.DIRSYNC
+	MANDLOCK    = sysmount.MANDLOCK
+	NODEV       = sysmount.NODEV
+	NODIRATIME  = sysmount.NODIRATIME
+	UNBINDABLE  = sysmount.UNBINDABLE
+	RUNBINDABLE = sysmount.RUNBINDABLE
+	PRIVATE     = sysmount.PRIVATE
+	RPRIVATE    = sysmount.RPRIVATE
+	SHARED      = sysmount.SHARED
+	RSHARED     = sysmount.RSHARED
+	SLAVE       = sysmount.SLAVE
+	RSLAVE      = sysmount.RSLAVE
+	RBIND       = sysmount.RBIND
+	RELATIME    = sysmount.RELATIME
+	REMOUNT     = sysmount.REMOUNT
+	STRICTATIME = sysmount.STRICTATIME
 )


### PR DESCRIPTION
Fixes the compile failure introduced in https://github.com/moby/moby/pull/41458, but somehow didn't cause Windows CI to report a failure 😞  https://github.com/moby/moby/pull/41458#issuecomment-722306672

For reference: I didn't look too closely if we're now stubbing all functions that were previously available on Windows; we're planning on removing these stubs altogether, and most of these should not be called on Windows (as they were non-functional or produced an error)