### PR TITLE
Unhide containerd-namespace flags

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -97,11 +97,9 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	conf.MaxDownloadAttempts = &maxDownloadAttempts
 
 	flags.StringVar(&conf.ContainerdNamespace, "containerd-namespace", daemon.ContainersNamespace, "Containerd namespace to use")
-	if err := flags.MarkHidden("containerd-namespace"); err != nil {
-		return err
-	}
 	flags.StringVar(&conf.ContainerdPluginNamespace, "containerd-plugins-namespace", containerd.PluginNamespace, "Containerd namespace to use for plugins")
-	return flags.MarkHidden("containerd-plugins-namespace")
+
+	return nil
 }
 
 func installRegistryServiceFlags(options *registry.ServiceOptions, flags *pflag.FlagSet) {


### PR DESCRIPTION
The daemon expects to manage/handle everything going into the containerd namespace it uses, and things break when it shares that namespace with a second instance, so we should expose these flags and expect users that want two daemons sharing a containerd instance to use separate namespaces for them.

**- Description for the changelog**

- expose `--containerd-namespace` for running multiple daemons against the same `containerd` instance

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/161631/98298162-6667b880-1f6a-11eb-8182-cbc1bed2ecec.png)
