### PR TITLE
[DNM] Trigger CI with runc@master

### DIFF
--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -4,7 +4,7 @@
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-: ${RUNC_COMMIT:=ff819c7e9184c13b7c2607fe6c30ae19403a7aff} # v1.0.0-rc92
+: ${RUNC_COMMIT:=cc988c1036a570883a4ee2a2037de82fed7dec4f} # Feb 2, 2021
 
 install_runc() {
 	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting


### PR DESCRIPTION
#### ~~Context~~
~~containerd CI seems failing with runc@master: https://github.com/containerd/containerd/pull/4678~~
~~Triggering Moby CI with runc@master might be helpful for analyzing the failure~~