### PR TITLE
builder: fix detection of experimental --stream option (deprecated)

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -85,10 +85,6 @@ func (bm *BuildManager) Build(ctx context.Context, config backend.BuildConfig) (
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	if config.Options.SessionID != "" {
-		return nil, errors.New("experimental session with v1 builder is no longer supported, use builder version v2 (BuildKit) instead")
-	}
-
 	builderOptions := builderOptions{
 		Options:        config.Options,
 		ProgressWriter: config.ProgressWriter,

--- a/builder/remotecontext/detect.go
+++ b/builder/remotecontext/detect.go
@@ -33,12 +33,7 @@ func Detect(config backend.BuildConfig) (remote builder.Source, dockerfile *pars
 	case remoteURL == "":
 		remote, dockerfile, err = newArchiveRemote(config.Source, dockerfilePath)
 	case remoteURL == ClientSessionRemote:
-		res, err := parser.Parse(config.Source)
-		if err != nil {
-			return nil, nil, errdefs.InvalidParameter(err)
-		}
-
-		return nil, res, nil
+		return nil, nil, errdefs.InvalidParameter(errors.New("experimental session with v1 builder is no longer supported, use builder version v2 (BuildKit) instead"))
 	case urlutil.IsGitURL(remoteURL):
 		remote, dockerfile, err = newGitRemote(remoteURL, dockerfilePath)
 	case urlutil.IsURL(remoteURL):


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/41647

Commit 6ca3ec88ae9e1435abbed665ec598c00058659da deprecated (https://github.com/moby/moby/pull/39983) the experimental `--stream` option for the legacy builder, adding an error message is a client attempted to use this feature.

However, the detection used the session-ID (`session=xxx` query parameter), which happens to be set automatically by the CLI if it detects that the daemon has session support. Because of this, builds fail when trying to perform them on a daemon with the `--experimental` flag set.

This patch changes the detection to look for the `remote` query parameter, which is set to "client-session" when using the `--stream` option with the classic (non-Buildkit) builder.

Before this change, running `docker build` with an older (19.03 or older) cli against a daemon with `--experimental` enabled caused an error:

```console
$ dockerd --experimental &
$ docker pull docker:18.09
$ docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock docker:18.09 sh -c 'echo "FROM scratch" | docker build -'

Sending build context to Docker daemon  2.048kB
Error response from daemon: experimental session with v1 builder is no longer supported, use builder version v2 (BuildKit) instead

$ docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock -w /foo docker:18.09 sh -c 'echo "FROM scratch" > Dockerfile && docker build --stream .'
Error response from daemon: experimental session with v1 builder is no longer supported, use builder version v2 (BuildKit) instead
```

With this patch, the error only occurs when trying to use the experimental `--stream` option:

```console
$ dockerd --experimental &
$ docker pull docker:18.09
$ docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock docker:18.09 sh -c 'echo "FROM scratch" | docker build -'

Step 1/1 : FROM scratch
 --->
No image was generated. Is your Dockerfile empty?

$ docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock -w /foo docker:18.09 sh -c 'echo "FROM scratch" > Dockerfile && docker build --stream .'

Error response from daemon: experimental session with v1 builder is no longer supported, use builder version v2 (BuildKit) instead
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

