### PR TITLE
use containerd/cgroups to detect cgroups v2

### DIFF
--- a/cmd/dockerd/config_unix.go
+++ b/cmd/dockerd/config_unix.go
@@ -5,11 +5,11 @@ package main
 import (
 	"os/exec"
 
+	"github.com/containerd/cgroups"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/rootless"
 	units "github.com/docker/go-units"
-	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
@@ -66,7 +66,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) error {
 	// Note that defaultUserlandProxyPath and honorXDG are configured according to the value of rootless.RunningWithRootlessKit, not the value of --rootless.
 	flags.BoolVar(&conf.Rootless, "rootless", rootless.RunningWithRootlessKit(), "Enable rootless mode; typically used with RootlessKit")
 	defaultCgroupNamespaceMode := "host"
-	if cgroups.IsCgroup2UnifiedMode() {
+	if cgroups.Mode() == cgroups.Unified {
 		defaultCgroupNamespaceMode = "private"
 	}
 	flags.StringVar(&conf.CgroupNamespaceMode, "default-cgroupns-mode", defaultCgroupNamespaceMode, `Default mode for containers cgroup namespace ("host" | "private")`)

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/cgroups"
 	statsV1 "github.com/containerd/cgroups/stats/v1"
 	statsV2 "github.com/containerd/cgroups/v2/stats"
 	"github.com/containerd/containerd/sys"
@@ -43,7 +44,6 @@ import (
 	"github.com/docker/libnetwork/options"
 	lntypes "github.com/docker/libnetwork/types"
 	"github.com/moby/sys/mount"
-	"github.com/opencontainers/runc/libcontainer/cgroups"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
@@ -362,11 +362,11 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConf
 	if hostConfig.CgroupnsMode.IsEmpty() {
 		// for cgroup v2: unshare cgroupns even for privileged containers
 		// https://github.com/containers/libpod/pull/4374#issuecomment-549776387
-		if hostConfig.Privileged && !cgroups.IsCgroup2UnifiedMode() {
+		if hostConfig.Privileged && cgroups.Mode() != cgroups.Unified {
 			hostConfig.CgroupnsMode = containertypes.CgroupnsMode("host")
 		} else {
 			m := "host"
-			if cgroups.IsCgroup2UnifiedMode() {
+			if cgroups.Mode() == cgroups.Unified {
 				m = "private"
 			}
 			if daemon.configStore != nil {
@@ -637,7 +637,7 @@ func UsingSystemd(config *config.Config) bool {
 		return true
 	}
 	// On cgroup v2 hosts, default to systemd driver
-	if getCD(config) == "" && cgroups.IsCgroup2UnifiedMode() && IsRunningSystemd() {
+	if getCD(config) == "" && cgroups.Mode() == cgroups.Unified && IsRunningSystemd() {
 		return true
 	}
 	return false
@@ -758,7 +758,7 @@ func verifyDaemonSettings(conf *config.Config) error {
 		}
 	}
 
-	if conf.Rootless && UsingSystemd(conf) && !cgroups.IsCgroup2UnifiedMode() {
+	if conf.Rootless && UsingSystemd(conf) && cgroups.Mode() != cgroups.Unified {
 		return fmt.Errorf("exec-opt native.cgroupdriver=systemd requires cgroup v2 for rootless mode")
 	}
 

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	cdcgroups "github.com/containerd/cgroups"
 	"github.com/containerd/containerd/containers"
 	coci "github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/sys"
@@ -89,7 +90,7 @@ func WithRootless(daemon *Daemon) coci.SpecOpts {
 	return func(_ context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
 		var v2Controllers []string
 		if daemon.getCgroupDriver() == cgroupSystemdDriver {
-			if !cgroups.IsCgroup2UnifiedMode() {
+			if cdcgroups.Mode() != cdcgroups.Unified {
 				return errors.New("rootless systemd driver doesn't support cgroup v1")
 			}
 			rootlesskitParentEUID := os.Getenv("ROOTLESSKIT_PARENT_EUID")
@@ -814,7 +815,7 @@ func WithCgroups(daemon *Daemon, c *container.Container) coci.SpecOpts {
 			return nil
 		}
 
-		if cgroups.IsCgroup2UnifiedMode() {
+		if cdcgroups.Mode() == cdcgroups.Unified {
 			return errors.New("daemon-scoped cpu-rt-period and cpu-rt-runtime are not implemented for cgroup v2")
 		}
 

--- a/daemon/start_unix.go
+++ b/daemon/start_unix.go
@@ -3,9 +3,9 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"github.com/containerd/cgroups"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
-	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -27,7 +27,7 @@ func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Contain
 		rt.Shim = defaultV2ShimConfig(daemon.configStore, p)
 	}
 	if rt.Shim.Binary == linuxShimV1 {
-		if cgroups.IsCgroup2UnifiedMode() {
+		if cgroups.Mode() == cgroups.Unified {
 			return "", nil, errdefs.InvalidParameter(errors.Errorf("runtime %q is not supported while cgroups v2 (unified hierarchy) is being used", container.HostConfig.Runtime))
 		}
 		logrus.Warnf("Configured runtime %q is deprecated and will be removed in the next release", container.HostConfig.Runtime)

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	cdcgroups "github.com/containerd/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -56,7 +57,7 @@ func New(quiet bool, options ...Opt) *SysInfo {
 	for _, o := range options {
 		o(&opts)
 	}
-	if cgroups.IsCgroup2UnifiedMode() {
+	if cdcgroups.Mode() == cdcgroups.Unified {
 		return newV2(quiet, &opts)
 	}
 


### PR DESCRIPTION
libcontainer does not guarantee a stable API, and is not intended for external consumers. This patch replaces some uses of libcontainer/cgroups with containerd/cgroups.

relates to https://github.com/containerd/containerd/pull/4678#discussion_r519074318 (and some other discussions about libcontainer uses)

Looks like the remaining uses of libcontainer/cgroups are now to initialise the cpurt controller, and to detect which cgroups are supported (for `docker info`); I didn't find equivalents for that yet in containerd/cgroups, but possibly we can add those