### PR TITLE
daemon: un-export internal functions, and some minor refactoring

### DIFF
--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -65,8 +65,8 @@ func (cli *DaemonCli) getPlatformContainerdDaemonOpts() ([]supervisor.DaemonOpt,
 	opts := []supervisor.DaemonOpt{
 		supervisor.WithOOMScore(cli.Config.OOMScoreAdjust),
 		supervisor.WithPlugin("linux", &linux.Config{
-			Shim:        daemon.DefaultShimBinary,
-			Runtime:     daemon.DefaultRuntimeBinary,
+			Shim:        config.DefaultShimBinary,
+			Runtime:     config.DefaultRuntimeBinary,
 			RuntimeRoot: filepath.Join(cli.Config.Root, "runc"),
 			ShimDebug:   cli.Config.Debug,
 		}),

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -44,7 +44,12 @@ const (
 	DisableNetworkBridge = "none"
 	// DefaultInitBinary is the name of the default init binary
 	DefaultInitBinary = "docker-init"
-
+	// DefaultShimBinary is the default shim to be used by containerd if none
+	// is specified
+	DefaultShimBinary = "containerd-shim"
+	// DefaultRuntimeBinary is the default runtime to be used by
+	// containerd if none is specified
+	DefaultRuntimeBinary = "runc"
 	// StockRuntimeName is the reserved name/alias used to represent the
 	// OCI runtime being shipped with the docker daemon package.
 	StockRuntimeName = "runc"

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -751,7 +751,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	}
 
 	// Ensure that we have a correct root key limit for launching containers.
-	if err := ModifyRootKeyLimit(); err != nil {
+	if err := modifyRootKeyLimit(); err != nil {
 		logrus.Warnf("unable to modify root key limit, number of containers could be limited by this quota: %v", err)
 	}
 

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -638,14 +638,20 @@ func UsingSystemd(config *config.Config) bool {
 		return true
 	}
 	// On cgroup v2 hosts, default to systemd driver
-	if getCD(config) == "" && cgroups.Mode() == cgroups.Unified && IsRunningSystemd() {
+	if getCD(config) == "" && cgroups.Mode() == cgroups.Unified && isRunningSystemd() {
 		return true
 	}
 	return false
 }
 
-// IsRunningSystemd is from https://github.com/opencontainers/runc/blob/46be7b612e2533c494e6a251111de46d8e286ed5/libcontainer/cgroups/systemd/common.go#L27-L33
-func IsRunningSystemd() bool {
+// isRunningSystemd checks whether the host was booted with systemd as its init
+// system. This functions similarly to systemd's `sd_booted(3)`: internally, it
+// checks whether /run/systemd/system/ exists and is a directory.
+// http://www.freedesktop.org/software/systemd/man/sd_booted.html
+//
+// NOTE: This function comes from package github.com/coreos/go-systemd/util
+// It was borrowed here to avoid a dependency on cgo.
+func isRunningSystemd() bool {
 	fi, err := os.Lstat("/run/systemd/system")
 	if err != nil {
 		return false

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -621,8 +621,8 @@ func getCD(config *config.Config) string {
 	return ""
 }
 
-// VerifyCgroupDriver validates native.cgroupdriver
-func VerifyCgroupDriver(config *config.Config) error {
+// verifyCgroupDriver validates native.cgroupdriver
+func verifyCgroupDriver(config *config.Config) error {
 	cd := getCD(config)
 	if cd == "" || cd == cgroupFsDriver || cd == cgroupSystemdDriver {
 		return nil
@@ -768,7 +768,7 @@ func verifyDaemonSettings(conf *config.Config) error {
 	if !conf.BridgeConfig.EnableIPTables && conf.BridgeConfig.EnableIPMasq {
 		conf.BridgeConfig.EnableIPMasq = false
 	}
-	if err := VerifyCgroupDriver(conf); err != nil {
+	if err := verifyCgroupDriver(conf); err != nil {
 		return err
 	}
 	if conf.CgroupParent != "" && UsingSystemd(conf) {

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -57,14 +57,6 @@ import (
 const (
 	isWindows = false
 
-	// DefaultShimBinary is the default shim to be used by containerd if none
-	// is specified
-	DefaultShimBinary = "containerd-shim"
-
-	// DefaultRuntimeBinary is the default runtime to be used by
-	// containerd if none is specified
-	DefaultRuntimeBinary = "runc"
-
 	// See https://git.kernel.org/cgit/linux/kernel/git/tip/tip.git/tree/kernel/sched/sched.h?id=8cd9234c64c584432f6992fe944ca9e46ca8ea76#n269
 	linuxMinCPUShares = 2
 	linuxMaxCPUShares = 262144

--- a/daemon/keys.go
+++ b/daemon/keys.go
@@ -18,10 +18,10 @@ const (
 	rootKeyByteMultiplier = 25
 )
 
-// ModifyRootKeyLimit checks to see if the root key limit is set to
+// modifyRootKeyLimit checks to see if the root key limit is set to
 // at least 1000000 and changes it to that limit along with the maxbytes
 // allocated to the keys at a 25 to 1 multiplier.
-func ModifyRootKeyLimit() error {
+func modifyRootKeyLimit() error {
 	value, err := readRootKeyLimit(rootKeyFile)
 	if err != nil {
 		return err

--- a/daemon/keys_unsupported.go
+++ b/daemon/keys_unsupported.go
@@ -2,7 +2,7 @@
 
 package daemon // import "github.com/docker/docker/daemon"
 
-// ModifyRootKeyLimit is a noop on unsupported platforms.
-func ModifyRootKeyLimit() error {
+// modifyRootKeyLimit is a noop on unsupported platforms.
+func modifyRootKeyLimit() error {
 	return nil
 }

--- a/daemon/reload_unix.go
+++ b/daemon/reload_unix.go
@@ -19,7 +19,7 @@ func (daemon *Daemon) reloadPlatform(conf *config.Config, attributes map[string]
 
 	if conf.IsValueSet("runtimes") {
 		// Always set the default one
-		conf.Runtimes[config.StockRuntimeName] = types.Runtime{Path: DefaultRuntimeBinary}
+		conf.Runtimes[config.StockRuntimeName] = types.Runtime{Path: config.DefaultRuntimeBinary}
 		if err := daemon.initRuntimes(conf.Runtimes); err != nil {
 			return err
 		}


### PR DESCRIPTION
- daemon: un-export IsRunningSystemd()
    This utility was added after 19.03, and is only used in the daemon code
    itself, so we can un-export it, until there's an external use for it.
  
    Also updated the description, because the runc code already copied it
    from coreos/go-systemd, so better to describe the actual source.
- daemon: use sync.Once for systemd detection
- daemon: un-export VerifyCgroupDriver()
- daemon: un-export ModifyRootKeyLimit()
- daemon: move DefaultShimBinary, DefaultRuntimeBinary to config package
