### PR TITLE
testutil: remove remaining use of deprecated pkg/mount

### DIFF
--- a/api/types/mount/mount.go
+++ b/api/types/mount/mount.go
@@ -113,7 +113,7 @@ type TmpfsOptions struct {
 	// TODO(stevvooe): There are several more tmpfs flags, specified in the
 	// daemon, that are accepted. Only the most basic are added for now.
 	//
-	// From docker/docker/pkg/mount/flags.go:
+	// From https://github.com/moby/sys/blob/mount/v0.1.1/mount/flags.go#L47-L56
 	//
 	// var validFlags = map[string]bool{
 	// 	"":          true,

--- a/testutil/daemon/daemon_unix.go
+++ b/testutil/daemon/daemon_unix.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/docker/docker/pkg/mount"
+	"github.com/moby/sys/mount"
 	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
 )


### PR DESCRIPTION
looks like I missed this one in https://github.com/moby/moby/pull/41458