### PR TITLE
Jenkinsfile: remove e2e image stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,14 +214,6 @@ pipeline {
                                 '''
                             }
                         }
-                        stage("Build e2e image") {
-                            steps {
-                                sh '''
-                                echo "Building e2e image"
-                                docker build --build-arg DOCKER_GITCOMMIT=${GIT_COMMIT} -t moby-e2e-test -f Dockerfile.e2e .
-                                '''
-                            }
-                        }
                     }
 
                     post {


### PR DESCRIPTION
The image that's built is not pushed anywhere, and is just
building the same as the main image already builds, so didn't
add value.

