### PR TITLE
seccomp: add pidfd syscalls

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -232,6 +232,8 @@
 				"openat",
 				"openat2",
 				"pause",
+				"pidfd_open",
+				"pidfd_send_signal",
 				"pipe",
 				"pipe2",
 				"poll",

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -723,6 +723,7 @@
 		{
 			"names": [
 				"kcmp",
+				"pidfd_getfd",
 				"process_vm_readv",
 				"process_vm_writev",
 				"ptrace"

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -624,6 +624,7 @@ func DefaultProfile() *Seccomp {
 		{
 			Names: []string{
 				"kcmp",
+				"pidfd_getfd",
 				"process_vm_readv",
 				"process_vm_writev",
 				"ptrace",

--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -225,6 +225,8 @@ func DefaultProfile() *Seccomp {
 				"openat",
 				"openat2",
 				"pause",
+				"pidfd_open",
+				"pidfd_send_signal",
 				"pipe",
 				"pipe2",
 				"poll",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added `pidfd_{getfd, open, send_signal}` syscalls into default seccomp profile, closes issue #41664.

**- How I did it**

By adding syscall names into the json file.

**- How to verify it**

See https://github.com/docker/for-linux/issues/1142 reproduction steps.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add support for pidfd_* syscalls into default seccomp profile. Closes #41664


**- A picture of a cute animal (not mandatory but encouraged)**

[Maybe this Bernese Mountain Dog will do](https://mikroskeem.eu/doggo.png)
