### PR TITLE
add networks.static_address supports in swarm mode

### DIFF
--- a/api/types/swarm/network.go
+++ b/api/types/swarm/network.go
@@ -99,6 +99,7 @@ type NetworkAttachmentConfig struct {
 	Target     string            `json:",omitempty"`
 	Aliases    []string          `json:",omitempty"`
 	DriverOpts map[string]string `json:",omitempty"`
+	Addresses  []string          `json:",omitempty"`
 }
 
 // NetworkAttachment represents a network attachment.


### PR DESCRIPTION
**- What I did**
add networks.static_address supports in swarm mode

**- How I did it**
pass TaskTemplate.Networks.Addresses to cluster api

**- How to verify it**

1. `git clone -b swarm-networks-static_address-support2 https://github.com/shynome/moby.git`
1. `cd moby`
1. `make BIND_DIR=. shell` into docker container
1. `hack/make.sh binary install-binary run` run dockerd server in container
1. 
    1. a newer docekr client clli
    1. `git clone -b swarm-ipv4_address-support  https://github.com/shynome/docker-client-cli.git /tmp/docker-cli`
    1. `cd /tmp/docker-cli/cmd/docker/ && docker install`
    1. It is very difficult to add fields in docker-cli, so I now use `ipv4 address` instead of `static_addresses` field
1. `docker swarm init --advertise-addr 127.0.0.1` init swarm
1. save the below content as `docker-compose.yml`
    ```yaml
    version: '3.7'

    networks:

      default:
        attachable: true
        ipam:
          driver: default
          config:
            - subnet: 10.1.5.0/24

    services:
      nginx:
        image: nginx:alpine@sha256:9b22bb6d703d52b079ae4262081f3b850009e80cd2fc53cdcb8795f3a7b452ee
        ports:
          - '80:80'
        networks:
          default:
            #static_addresses: 
            #  - '10.1.5.166'
            ipv4_address: 10.1.5.166
        deploy:  &deploy
          replicas: 1
          update_config: { parallelism: 0, failure_action: rollback, max_failure_ratio: 1, order: stop-first }
    ```
1. `docker stack deploy -c docker-compose.yml m` deploy the stack
1. `docker exec $(docker ps --filter label=com.docker.swarm.service.name=m_nginx -q) ip -4 addr` check if the ip address of the container is 10.1.5.166
1. `docker service update --force m_nginx` check again, ip will remain unchanged


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
add networks.static_address supports in swarm mode


**- A picture of a cute animal (not mandatory but encouraged)**

