### PR TITLE
Added fuzzer

### DIFF
--- a/testutil/fuzz/image_fuzz.go
+++ b/testutil/fuzz/image_fuzz.go
@@ -1,4 +1,5 @@
 // +build gofuzz
+
 package fuzz
 
 import (

--- a/testutil/fuzz/image_fuzz.go
+++ b/testutil/fuzz/image_fuzz.go
@@ -1,0 +1,43 @@
+// +build gofuzz
+package fuzz
+
+import (
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/layer"
+	"io/ioutil"
+	"os"
+	"runtime"
+)
+
+type mockLayerGetReleaser struct{}
+
+func (ls *mockLayerGetReleaser) Get(layer.ChainID) (layer.Layer, error) {
+	return nil, nil
+}
+
+func (ls *mockLayerGetReleaser) Release(layer.Layer) ([]layer.Metadata, error) {
+	return nil, nil
+}
+
+func FuzzImage(data []byte) int {
+	tmpdir, err := ioutil.TempDir("", "images-fs-store")
+	defer os.RemoveAll(tmpdir)
+	if err != nil {
+		return -1
+	}
+	fsBackend, err := image.NewFSStoreBackend(tmpdir)
+	if err != nil {
+		return -1
+	}
+	mlgrMap := make(map[string]image.LayerGetReleaser)
+	mlgrMap[runtime.GOOS] = &mockLayerGetReleaser{}
+	store, err := image.NewImageStore(fsBackend, mlgrMap)
+	if err != nil {
+		return 0
+	}
+	_, err = store.Create(data)
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
ADD FUZZER FOR `/IMAGE/STORE.GO`


**- What I did**
Added a fuzzer to` /image/` with the purpose of integrating Docker into oss-fuzz.

The fuzzer passes pseudo-random test inputs into the target application - in this case the target is Create in `/image` - with the goal of uncovering bugs and vulnerabilities.

The fuzzer is implemented by way of [go-fuzz](https://github.com/dvyukov/go-fuzz).

**- How to verify it**
My suggestion at this point is to setup continuous fuzzing through oss-fuzz. I have tested the fuzzer in this PR on oss-fuzz's infrastructure, and it runs fine on there. This integration does not require this fuzzer to be merged first, but a consent on integrating Docker would be required. 
Setting up continuous fuzzing will allow Google to run the fuzzers and notify maintainers if and when a bug is found. 
Oss-fuzz has a 90 day public disclosure policy.
As a reference, continuous fuzzing contributed to finding [this CVE](https://groups.google.com/g/kubernetes-announce/c/ALL9s73E5ck/m/4yHe8J-PBAAJ) in Kubernetes.


**- Description for the changelog**
Added a go-fuzz fuzzer for /image/store.go


Signed-off-by: Adam Korczynski <adam@adalogics.com>