### PR TITLE
[19.03] docker/libnetwork 55e924b8a84231a065879156c0de95aefc5f5435 (bump_19.03 branch)

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: ${LIBNETWORK_COMMIT:=026aabaa659832804b01754aaadd2c0f420c68b6} # bump_19.03 branch
+: ${LIBNETWORK_COMMIT:=55e924b8a84231a065879156c0de95aefc5f5435} # bump_19.03 branch
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/gofrs/flock                              7f43ea2e6a643ad441fc12d0ecc0
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        026aabaa659832804b01754aaadd2c0f420c68b6 # bump_19.03 branch
+github.com/docker/libnetwork                        55e924b8a84231a065879156c0de95aefc5f5435 # bump_19.03 branch
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/service_linux.go
+++ b/vendor/github.com/docker/libnetwork/service_linux.go
@@ -67,11 +67,12 @@ func (n *network) findLBEndpointSandbox() (*endpoint, *sandbox, error) {
 	if !ok {
 		return nil, nil, fmt.Errorf("Unable to get sandbox for %s(%s) in for %s", ep.Name(), ep.ID(), n.ID())
 	}
-	ep = sb.getEndpoint(ep.ID())
-	if ep == nil {
+	var sep *endpoint
+	sep = sb.getEndpoint(ep.ID())
+	if sep == nil {
 		return nil, nil, fmt.Errorf("Load balancing endpoint %s(%s) removed from %s", ep.Name(), ep.ID(), n.ID())
 	}
-	return ep, sb, nil
+	return sep, sb, nil
 }
 
 // Searches the OS sandbox for the name of the endpoint interface


### PR DESCRIPTION
Bumping 19.03 libnework to address nil deference: moby/libnetwork#2595