### PR TITLE
vendor: github.com/moby/term bea5bbe245bf407372d477f1361d2ff042d2f556

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -7,7 +7,7 @@ github.com/google/uuid                              0cd6bf5da1e1c83f8b45653022c7
 github.com/gorilla/mux                              98cb6bf42e086f6af920b965c38cacc07402d51b # v1.8.0
 github.com/Microsoft/opengcs                        a10967154e143a36014584a6f664344e3bb0aa64
 github.com/moby/locker                              281af2d563954745bea9d1487c965f24d30742fe # v1.0.1
-github.com/moby/term                                7f0af18e79f2784809e9cef63d0df5aa2c79d76e
+github.com/moby/term                                bea5bbe245bf407372d477f1361d2ff042d2f556
 
 # Note that this dependency uses submodules, providing the github.com/moby/sys/mount,
 # github.com/moby/sys/mountinfo, and github.com/moby/sys/symlink modules. Our vendoring

--- a/vendor/github.com/moby/term/go.mod
+++ b/vendor/github.com/moby/term/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
-	github.com/creack/pty v1.1.9
+	github.com/creack/pty v1.1.11
 	github.com/google/go-cmp v0.4.0
 	github.com/pkg/errors v0.9.1 // indirect
 	golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a

--- a/vendor/github.com/moby/term/term_windows.go
+++ b/vendor/github.com/moby/term/term_windows.go
@@ -71,19 +71,22 @@ func StdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
 	// go-ansiterm hasn't switch to x/sys/windows.
 	// TODO: switch back to x/sys/windows once go-ansiterm has switched
 	if emulateStdin {
-		stdIn = windowsconsole.NewAnsiReader(windows.STD_INPUT_HANDLE)
+		h := uint32(windows.STD_INPUT_HANDLE)
+		stdIn = windowsconsole.NewAnsiReader(int(h))
 	} else {
 		stdIn = os.Stdin
 	}
 
 	if emulateStdout {
-		stdOut = windowsconsole.NewAnsiWriter(windows.STD_OUTPUT_HANDLE)
+		h := uint32(windows.STD_OUTPUT_HANDLE)
+		stdOut = windowsconsole.NewAnsiWriter(int(h))
 	} else {
 		stdOut = os.Stdout
 	}
 
 	if emulateStderr {
-		stdErr = windowsconsole.NewAnsiWriter(windows.STD_ERROR_HANDLE)
+		h := uint32(windows.STD_ERROR_HANDLE)
+		stdErr = windowsconsole.NewAnsiWriter(int(h))
 	} else {
 		stdErr = os.Stderr
 	}


### PR DESCRIPTION
full diff: https://github.com/moby/term/compare/7f0af18e79f2784809e9cef63d0df5aa2c79d76e...bea5bbe245bf407372d477f1361d2ff042d2f556

- Fix windows integer overflow on GOOS=windows, GOARCH=arm
- go.mod: github.com/creack/pty v1.1.11
  - v1.1.11: Add arm support for OpenBSD
  - v1.1.10: Fix CTTY to work with go1.15
- CI: fix Go version matrix, and drop go 1.12, add go 1.15
- CI: remove "sudo" to fix incorrect Go versions (incorrect PATH, GOROOT)


**- Description for the changelog**

```
 Fix windows integer overflow on GOOS=windows, GOARCH=arm
```

**- A picture of a cute animal (not mandatory but encouraged)**

