### PR TITLE
Guard img.RootFS for Store.Create()

### DIFF
--- a/image/store.go
+++ b/image/store.go
@@ -124,6 +124,10 @@ func (is *store) Create(config []byte) (ID, error) {
 		return "", err
 	}
 
+	if img.RootFS == nil {
+		return "", errors.New("rootfs should be present in config")
+	}
+
 	// Must reject any config that references diffIDs from the history
 	// which aren't among the rootfs layers.
 	rootFSLayers := make(map[layer.DiffID]struct{})


### PR DESCRIPTION
Signed-off-by: Jim Lin <b04705003@ntu.edu.tw>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add a check for `store.create` in `image/store.go` to solve the issue in https://github.com/moby/moby/issues/41683

**- How I did it**

Simply add a `if` statement in that function

**- How to verify it**

You can use the code in this issue to test it https://github.com/moby/moby/issues/41683

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Handle the zero length of the input `config` for store.Create.


**- A picture of a cute animal (not mandatory but encouraged)**
🦄 