### PR TITLE
replace json.Unmarshal with NewFromJSON in Create

### DIFF
--- a/image/store.go
+++ b/image/store.go
@@ -1,7 +1,6 @@
 package image // import "github.com/docker/docker/image"
 
 import (
-	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -118,8 +117,8 @@ func (is *store) restore() error {
 }
 
 func (is *store) Create(config []byte) (ID, error) {
-	var img Image
-	err := json.Unmarshal(config, &img)
+	var img *Image
+	img, err := NewFromJSON(config)
 	if err != nil {
 		return "", err
 	}

--- a/image/store_test.go
+++ b/image/store_test.go
@@ -10,6 +10,14 @@ import (
 	"gotest.tools/v3/assert/cmp"
 )
 
+func TestCreate(t *testing.T) {
+	is, cleanup := defaultImageStore(t)
+	defer cleanup()
+
+	_, err := is.Create([]byte(`{}`))
+	assert.Check(t, cmp.Error(err, "invalid image JSON, no RootFS key"))
+}
+
 func TestRestore(t *testing.T) {
 	fs, cleanup := defaultFSStoreBackend(t)
 	defer cleanup()


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/41683

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Reuse `NewFromJSON` to handle no `rootfs` key situation in `image/store.go` to solve the issue in #41683

**- How I did it**

Simply replace the `json.Unmarshal` function with `NewFromJSON` in `image/image.go`

**- How to verify it**

Running this (mainly modified from https://github.com/moby/moby/issues/41683) will show `invalid image JSON, no RootFS`:

```go
package main

import (
    "github.com/docker/docker/image"
    "os"
    "io/ioutil"
    "runtime"
    "github.com/docker/docker/layer"
    "fmt"
)


type mockLayerGetReleaser struct{}

func (ls *mockLayerGetReleaser) Get(layer.ChainID) (layer.Layer, error) {
        return nil, nil
}

func (ls *mockLayerGetReleaser) Release(layer.Layer) ([]layer.Metadata, error) {
        return nil, nil
}

func main(){
    tmpdir, err := ioutil.TempDir("", "images-fs-store")
    defer os.RemoveAll(tmpdir)
    if err != nil {
        fmt.Print(err)
        os.Exit(1)
    }
    fsBackend, err := image.NewFSStoreBackend(tmpdir)
    if err != nil {
        fmt.Print(err)
        os.Exit(1)
    }
    mlgrMap := make(map[string]image.LayerGetReleaser)
    mlgrMap[runtime.GOOS] = &mockLayerGetReleaser{}
    store, err := image.NewImageStore(fsBackend, mlgrMap)
    if err != nil {
        fmt.Print(err)
        os.Exit(1)
    }
    _, err = store.Create([]byte(`{}`))
    if err != nil {
        fmt.Print(err)
        os.Exit(1)
    }
}

```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Handle an image json that `rootfs` key is not present.

**- A picture of a cute animal (not mandatory but encouraged)**
🐕 