### PR TITLE
update containerd binary to v1.4.2

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@ set -e
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=c623d1b36f09f8ef6536a057bd658b3aa8632828}" # v1.4.1
+: "${CONTAINERD_COMMIT:=b321d358e6eef9c82fa3f3bb8826dca3724c58c6}" # v1.4.2
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
NOTE: the Dockerfile currently uses a single version of Golang for all
      stages. This means that currently, all binaries are built with Go
      1.13.x, including the containerd binary; upstream containerd switched
      to use Go 1.15.

full diff: https://github.com/containerd/containerd/compare/v1.4.1...v1.4.2

Release notes:

Welcome to the v1.4.2 release of containerd!
------------------------------------------------------

The second patch release for containerd 1.4 includes multiple minor fixes
and updates.

Notable Updates

- Fix bug limiting the number of layers by default containerd/cri#1602
- Fix selinux shared memory issue by relabeling /dev/shm containerd/cri#1605
- Fix unknown state preventing removal of containers containerd/containerd#4656
- Fix nil pointer error when restoring checkpoint containerd/containerd#4754
- Improve image pull performance when using HTTP 1.1 containerd/containerd#4653
- Update default seccomp profile for pidfd containerd/containerd#4730
- Update Go to 1.15

Windows

- Fix integer overflow on Windows containerd/containerd#4589
- Fix lcow snapshotter to read trailing tar data containerd/containerd#4628


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

