### PR TITLE
Skip some root tests

### DIFF
--- a/daemon/oci_linux_test.go
+++ b/daemon/oci_linux_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/libnetwork"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
 )
 
 func setupFakeDaemon(t *testing.T, c *container.Container) *Daemon {
@@ -62,6 +63,7 @@ func cleanupFakeContainer(c *container.Container) {
 // in "Duplicate mount point" error from the engine.
 // https://github.com/moby/moby/issues/35455
 func TestTmpfsDevShmNoDupMount(t *testing.T) {
+	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	c := &container.Container{
 		ShmPath: "foobar", // non-empty, for c.IpcMounts() to work
 		HostConfig: &containertypes.HostConfig{
@@ -84,6 +86,7 @@ func TestTmpfsDevShmNoDupMount(t *testing.T) {
 // the resulting /dev/shm mount is NOT made read-only.
 // https://github.com/moby/moby/issues/36503
 func TestIpcPrivateVsReadonly(t *testing.T) {
+	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	c := &container.Container{
 		HostConfig: &containertypes.HostConfig{
 			IpcMode:        containertypes.IpcMode("private"),
@@ -108,6 +111,7 @@ func TestIpcPrivateVsReadonly(t *testing.T) {
 // TestSysctlOverride ensures that any implicit sysctls (such as
 // Config.Domainname) are overridden by an explicit sysctl in the HostConfig.
 func TestSysctlOverride(t *testing.T) {
+	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	c := &container.Container{
 		Config: &containertypes.Config{
 			Hostname:   "foobar",
@@ -149,6 +153,7 @@ func TestSysctlOverride(t *testing.T) {
 // TestSysctlOverrideHost ensures that any implicit network sysctls are not set
 // with host networking
 func TestSysctlOverrideHost(t *testing.T) {
+	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	c := &container.Container{
 		Config: &containertypes.Config{},
 		HostConfig: &containertypes.HostConfig{

--- a/pkg/chrootarchive/archive_unix_test.go
+++ b/pkg/chrootarchive/archive_unix_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/pkg/archive"
 	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/skip"
 )
 
 // Test for CVE-2018-15664
@@ -23,6 +24,7 @@ import (
 // some path outside of a container's rootfs that we do not copy data to a
 // container path that will actually overwrite data on the host
 func TestUntarWithMaliciousSymlinks(t *testing.T) {
+	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	dir, err := ioutil.TempDir("", t.Name())
 	assert.NilError(t, err)
 	defer os.RemoveAll(dir)
@@ -84,6 +86,7 @@ func TestUntarWithMaliciousSymlinks(t *testing.T) {
 // some path outside of a container's rootfs that we do not unwittingly leak
 // host data into the archive.
 func TestTarWithMaliciousSymlinks(t *testing.T) {
+	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	dir, err := ioutil.TempDir("", t.Name())
 	assert.NilError(t, err)
 	// defer os.RemoveAll(dir)

--- a/plugin/manager_linux_test.go
+++ b/plugin/manager_linux_test.go
@@ -175,6 +175,7 @@ func (e *executorWithRunning) Signal(id string, signal int) error {
 }
 
 func TestPluginAlreadyRunningOnStartup(t *testing.T) {
+	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	t.Parallel()
 
 	root, err := ioutil.TempDir("", t.Name())


### PR DESCRIPTION
Hello, here are two patches to conditionally skip tests that require root, for you to consider.

**More context**

In Debian we have a patch that skips privileged tests, under one big, ugly patch: https://salsa.debian.org/docker-team/docker/-/blob/master/debian/patches/test--skip-privileged-unit-tests.patch

I'm working on splitting this patch into smaller patches, so that I can submit what's relevant here in this PR.

Thanks !