### PR TITLE
Add feature: remove spare network url

### DIFF
--- a/api/server/router/network/network.go
+++ b/api/server/router/network/network.go
@@ -30,7 +30,6 @@ func (r *networkRouter) initRoutes() {
 	r.routes = []router.Route{
 		// GET
 		router.NewGetRoute("/networks", r.getNetworksList),
-		router.NewGetRoute("/networks/", r.getNetworksList),
 		router.NewGetRoute("/networks/{id:.+}", r.getNetwork),
 		// POST
 		router.NewPostRoute("/networks/create", r.postNetworkCreate),


### PR DESCRIPTION
**- What I did**

it may be a mistake at `api/server/router/network/network.go`; there is a spare network url;

```shell
/networks
/networks/
```

**- How I did it**

remove the url of `/networks/`

**- How to verify it**

**- Description for the changelog**
remove spare network url

**- A picture of a cute animal (not mandatory but encouraged)**

^ ^ 


