### PR TITLE
[19.03] update containerd binary to v1.3.9 (address CVE-2020-15257) 

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=8fba4e9a7d01810a393d5d25a3621dc101981175}" # v1.3.7
+: "${CONTAINERD_COMMIT:=7fb6e171309113ddcb8ea9599e34321550469250}" # v1.3.8
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-: "${CONTAINERD_COMMIT:=7fb6e171309113ddcb8ea9599e34321550469250}" # v1.3.8
+: "${CONTAINERD_COMMIT:=ea765aba0d05254012b0b9e595e995c09186427f}" # v1.3.9
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
## update containerd binary to v1.3.9

full diff: https://github.com/containerd/containerd/compare/v1.3.8...v1.3.9

Release notes:

Welcome to the v1.3.9 release of containerd!

The ninth patch release for containerd 1.3 is a security release to address
CVE-2020-15257. See GHSA-36xw-fx78-c5r4 for more details:
https://github.com/containerd/containerd/security/advisories/GHSA-36xw-fx78-c5r4


## update containerd binary to v1.3.8

full diff: https://github.com/containerd/containerd/compare/v1.3.7...v1.3.8

Release notes:

Welcome to the v1.3.8 release of containerd!

The eighth patch release for containerd 1.3 includes several bug fixes and updates.

Notable Updates

- Fix metrics monitoring of v2 runtime tasks
- Fix nil pointer error when restoring checkpoint
- Fix devmapper device deletion on rollback
- Fix integer overflow on Windows
- Update seccomp default profile