### PR TITLE
Add a warning about symlink escapes. 

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -1,4 +1,8 @@
+// Package archive handles making container tar archives
 package archive // import "github.com/docker/docker/pkg/archive"
+// BUG(justincormack): This package does not handle symlink escapes safely in
+// general, as we only use it in a chroot environment where symlink espcapes are not
+// possible. Be careful using this code in a different environment.
 
 import (
 	"archive/tar"


### PR DESCRIPTION
This package is not safe if used outside a chroot or mount namespace.

Signed-off-by: Justin Cormack <justin@specialbusservice.com>

