### PR TITLE
Makefile: switch to POSIX mode to handle errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.POSIX:
+
 .PHONY: all binary dynbinary build cross help install manpages run shell test test-docker-py test-integration test-unit validate win
 
 ifdef USE_BUILDX


### PR DESCRIPTION
similar to https://github.com/docker/docker-ce-packaging/pull/510 and https://github.com/moby/sys/pull/19#discussion_r445698069

also see https://github.com/docker/docker-ce-packaging/pull/504#issuecomment-737078670


> .POSIX
>
> The application shall ensure that this special target is specified without prerequisites
> or commands. If it appears as the first non-comment line in the makefile, make shall
> process the makefile as specified by this section; otherwise, the behavior of make is
> unspecified.

Running the makefile with `.POSIX` runs shells with the `-e` options, which helps with
handling errors; without this, make can complet "succesfully", even if shell commands
in a target fail.

Note that this patch does not change behavior on macOS, which runs an older version of
GNU make that does not support these options.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

