### PR TITLE
Fix jobs-related bug in task conversion

### DIFF
--- a/daemon/cluster/convert/task.go
+++ b/daemon/cluster/convert/task.go
@@ -51,6 +51,12 @@ func TaskFromGRPC(t swarmapi.Task) (types.Task, error) {
 		task.NetworksAttachments = append(task.NetworksAttachments, networkAttachmentFromGRPC(na))
 	}
 
+	if t.JobIteration != nil {
+		task.JobIteration = &types.Version{
+			Index: t.JobIteration.Index,
+		}
+	}
+
 	if t.Status.PortStatus == nil {
 		return task, nil
 	}
@@ -63,12 +69,6 @@ func TaskFromGRPC(t swarmapi.Task) (types.Task, error) {
 			TargetPort:    p.TargetPort,
 			PublishedPort: p.PublishedPort,
 		})
-	}
-
-	if t.JobIteration != nil {
-		task.JobIteration = &types.Version{
-			Index: t.JobIteration.Index,
-		}
 	}
 
 	return task, nil


### PR DESCRIPTION
**- What I did**

Fixed a bug in task conversion code which would result in JobVersion being missing if the Task had no ports exposed.

**- How I did it**

Moved the JobVersion conversion logic above a chunk of code that returns early if PortConfig is nil.

Noticed this while working on some cluster volumes related code.

**- How to verify it**

There weren't tests before, and there aren't tests now, but it's a quick visual fix. I don't want to get too far into the weeks of writing tests for the cluster/convert package.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixed a bug where a job Task would not include the job version if it did not have ports exposed.