### PR TITLE
Add fallback for pull by tag

### DIFF
--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -112,6 +112,23 @@ func TranslatePullError(err error, ref reference.Named) error {
 	return errdefs.Unknown(err)
 }
 
+func isNotFound(err error) bool {
+	switch v := err.(type) {
+	case errcode.Errors:
+		for _, e := range v {
+			if isNotFound(e) {
+				return true
+			}
+		}
+	case errcode.Error:
+		switch v.Code {
+		case errcode.ErrorCodeDenied, v2.ErrorCodeManifestUnknown, v2.ErrorCodeNameUnknown:
+			return true
+		}
+	}
+	return false
+}
+
 // continueOnError returns true if we should fallback to the next endpoint
 // as a result of this error.
 func continueOnError(err error, mirrorEndpoint bool) bool {


### PR DESCRIPTION
Some registries seem to be non-conformant and return a not found error
when pulling by digest (which docker now does all the time).
To work around this, fallback when all of the following are true:

1. Image reference is a tag
2. Tag->digest resolution succeeds
3. Fetch by resolved digest fails with a "not found" error.

This is intentionally not caching the manifests to reduce complexity for
this edge case.

Closes #41687