### PR TITLE
daemon: remove migration code from docker 1.11 to 1.12

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -301,15 +301,6 @@ func (daemon *Daemon) restore() error {
 				mapLock.Unlock()
 				return
 			}
-
-			// The LogConfig.Type is empty if the container was created before docker 1.12 with default log driver.
-			// We should rewrite it to use the daemon defaults.
-			// Fixes https://github.com/docker/docker/issues/22536
-			if c.HostConfig.LogConfig.Type == "" {
-				if err := daemon.mergeAndVerifyLogConfig(&c.HostConfig.LogConfig); err != nil {
-					log.WithError(err).Error("failed to verify log config for container")
-				}
-			}
 		}(c)
 	}
 	group.Wait()


### PR DESCRIPTION
This code was added in 391441c28baec698f0e3f42d88e116291e8a8e98 (https://github.com/moby/moby/pull/22575), to fix upgrades from docker 1.11 to 1.12 with existing containers (https://github.com/moby/moby/issues/22536).

Given that any container after 1.12 should have the correct configuration already, it should be safe to assume this upgrade logic is no longer needed.

