### PR TITLE
compression: add support for the zstd algorithm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -276,7 +276,8 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             vim-common \
             xfsprogs \
             xz-utils \
-            zip
+            zip \
+            zstd
 
 
 # Switch to use iptables instead of nftables (to match the CI hosts)

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -135,6 +135,13 @@ func TestDecompressStreamXz(t *testing.T) {
 	testDecompressStream(t, "xz", "xz -f")
 }
 
+func TestDecompressStreamZstd(t *testing.T) {
+	if _, err := exec.LookPath("zstd"); err != nil {
+		t.Skip("zstd not installed")
+	}
+	testDecompressStream(t, "zst", "zstd -f")
+}
+
 func TestCompressStreamXzUnsupported(t *testing.T) {
 	dest, err := os.Create(tmp + "dest")
 	if err != nil {
@@ -208,6 +215,13 @@ func TestExtensionXz(t *testing.T) {
 	output := compression.Extension()
 	if output != "tar.xz" {
 		t.Fatalf("The extension of a xz archive should be 'tar.xz'")
+	}
+}
+func TestExtensionZstd(t *testing.T) {
+	compression := Zstd
+	output := compression.Extension()
+	if output != "tar.zst" {
+		t.Fatalf("The extension of a zstd archive should be 'tar.zst'")
 	}
 }
 


### PR DESCRIPTION
zstd is a compression algorithm that has a very fast decoder, while
providing also good compression ratios.  The fast decoder makes it
suitable for container images, as decompressing the tarballs is a very
expensive operation.

https://github.com/opencontainers/image-spec/pull/788 added support
for zstd to the OCI image specs.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>


**- What I did**

added read support for layers compressed with zstd

**- How I did it**

added a new zstd compression format to pkg/archive

**- How to verify it**

try pulling an image compressed with zstd, e.g. `docker pull gscrivano/zstd-chunked:fedora33`

**- Description for the changelog**

support zstd compressed layers

**- A picture of a cute animal (not mandatory but encouraged)**

