### PR TITLE
do not kill containerd during dockerd is starting

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -137,6 +137,8 @@ func (daemon *Daemon) Kill(container *containerpkg.Container) error {
 		return errNotRunning(container.ID)
 	}
 
+	waitStop := container.GetWaitStop()
+
 	// 1. Send SIGKILL
 	if err := daemon.killPossiblyDeadProcess(container, int(syscall.SIGKILL)); err != nil {
 		// While normally we might "return err" here we're not going to
@@ -171,7 +173,7 @@ func (daemon *Daemon) Kill(container *containerpkg.Container) error {
 
 	// Wait for exit with no timeout.
 	// Ignore returned status.
-	<-container.Wait(context.Background(), containerpkg.WaitConditionNotRunning)
+	<-container.Wait3(context.Background(), containerpkg.WaitConditionNotRunning, waitStop)
 
 	return nil
 }


### PR DESCRIPTION
add wait time for containerd kill if healthcheck failed, as daemon
restore will fail because containerd is killed, which causes container
remove stuck after.

fix #41768

