### PR TITLE
Revert "Add multi-user.target to After="

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network-online.target docker.socket firewalld.service multi-user.target
+After=network-online.target docker.socket firewalld.service
 Wants=network-online.target
 Requires=docker.socket
 


### PR DESCRIPTION
This reverts commit 0ca7456e5284d4aa9f3e37e69c7c93eff4420d3d,
which caused the docker service to not be starting, or delayed
starting the service in certain conditions.

relates to / introduced in https://github.com/moby/moby/pull/41297 / https://github.com/docker/docker-ce-packaging/pull/488 systemd: add multi-user.target to After list

relates to https://github.com/moby/moby/issues/41767 `systemctl docker start` get stuck in cloud-init
relates to https://github.com/docker/for-linux/issues/1161 Docker service not starting in centos 7.9
relates to https://github.com/docker/for-linux/issues/1162 Docker 20.10 daemon takes 5 minutes to start after reboot
relates to https://github.com/docker/machine/issues/4858 Latest docker release (20.10.0) doesn't work with docker-machine

