### PR TITLE
Fix converting status code to error canceled

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -110,11 +110,16 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 	if err != nil {
 		return serverResponse{}, err
 	}
+
 	resp, err := cli.doRequest(ctx, req)
-	if err != nil {
-		return resp, errdefs.FromStatusCode(err, resp.statusCode)
+	switch {
+	case errors.Is(err, context.Canceled):
+		return serverResponse{}, errdefs.Cancelled(err)
+	case errors.Is(err, context.DeadlineExceeded):
+		return serverResponse{}, errdefs.Deadline(err)
+	case err == nil:
+		err = cli.checkResponseErr(resp)
 	}
-	err = cli.checkResponseErr(resp)
 	return resp, errdefs.FromStatusCode(err, resp.statusCode)
 }
 


### PR DESCRIPTION
closes #41752 

**- How to verify it**
go test errdefs/http_helpers_test.go 

**- Description for the changelog**
Fix converting status code to error canceled