### PR TITLE
Dockerfile: switch to "stable" dockerfile front-end

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.1.7-experimental
+# syntax=docker/dockerfile:1.2
 
 ARG CROSS="false"
 ARG SYSTEMD="false"


### PR DESCRIPTION
The `RUN --mount` options have been promoted to the stable channel, so we can switch from "experimental" to "stable".

Note that the syntax directive should no longer be needed now, but it's good practice to add a syntax-directive, to allow building on older versions of docker.

