### PR TITLE
vendor: bump etcd v3.3.27

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -62,7 +62,7 @@ github.com/google/btree                             479b5e81b0a93ec038d201b0b33d
 
 github.com/samuel/go-zookeeper                      d0e0d8e11f318e000a8cc434616d69e329edc374
 github.com/deckarep/golang-set                      ef32fa3046d9f249d399f98ebaf9be944430fd1d
-github.com/coreos/etcd                              2c834459e1aab78a5d5219c7dfe42335fc4b617a # v3.3.25
+github.com/coreos/etcd                              973882f697a8db3d59815bf132c6c506434334bd # v3.3.27
 github.com/coreos/go-semver                         8ab6407b697782a06568d4b7f1db25550ec2e4c6 # v0.2.0
 github.com/hashicorp/consul                         9a9cc9341bb487651a0399e3fc5e1e8a42e62dd9 # v0.5.2
 github.com/miekg/dns                                6c0c4e6581f8e173cc562c8b3363ab984e4ae071 # v1.1.27

--- a/vendor/github.com/coreos/etcd/pkg/fileutil/lock_linux.go
+++ b/vendor/github.com/coreos/etcd/pkg/fileutil/lock_linux.go
@@ -29,7 +29,7 @@ import (
 //
 // constants from /usr/include/bits/fcntl-linux.h
 const (
-	F_OFD_GETLK  = 37
+	F_OFD_GETLK  = 36
 	F_OFD_SETLK  = 37
 	F_OFD_SETLKW = 38
 )

--- a/vendor/github.com/coreos/etcd/version/version.go
+++ b/vendor/github.com/coreos/etcd/version/version.go
@@ -26,7 +26,7 @@ import (
 var (
 	// MinClusterVersion is the min cluster version this etcd binary is compatible with.
 	MinClusterVersion = "3.0.0"
-	Version           = "3.3.25"
+	Version           = "3.3.27"
 	APIVersion        = "unknown"
 
 	// Git SHA Value will be set during build


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/31182

Bump etcd to v3.3.27, which includes https://github.com/etcd-io/etcd/pull/12552,
to fix https://github.com/moby/moby/issues/31182

Full diff: https://github.com/coreos/etcd/compare/v3.3.25...v3.3.27

~This is a draft, pending a 3.3.26 release (https://github.com/etcd-io/etcd/issues/12698)~