### PR TITLE
Vendor in Libnetwork changes

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: "${LIBNETWORK_COMMIT:=5c6a95bfb20c61571a00f913c6b91959ede84e8d}"
+: "${LIBNETWORK_COMMIT:=fa125a3512ee0f6187721c88582bf8c4378bd4d7}"
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -47,7 +47,7 @@ github.com/grpc-ecosystem/go-grpc-middleware        3c51f7f332123e8be5a157c0802a
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        5c6a95bfb20c61571a00f913c6b91959ede84e8d 
+github.com/docker/libnetwork                        fa125a3512ee0f6187721c88582bf8c4378bd4d7 
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/portmapper/mapper.go
+++ b/vendor/github.com/docker/libnetwork/portmapper/mapper.go
@@ -151,20 +151,16 @@ func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart,
 	}
 
 	containerIP, containerPort := getIPAndPort(m.container)
-	if pm.checkIP(hostIP) {
-		if err := pm.AppendForwardingTableEntry(m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort); err != nil {
-			return nil, err
-		}
+	if err := pm.AppendForwardingTableEntry(m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort); err != nil {
+		return nil, err
 	}
 
 	cleanup := func() error {
 		// need to undo the iptables rules before we return
 		m.userlandProxy.Stop()
-		if pm.checkIP(hostIP) {
-			pm.DeleteForwardingTableEntry(m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort)
-			if err := pm.Allocator.ReleasePort(hostIP, m.proto, allocatedHostPort); err != nil {
-				return err
-			}
+		pm.DeleteForwardingTableEntry(m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort)
+		if err := pm.Allocator.ReleasePort(hostIP, m.proto, allocatedHostPort); err != nil {
+			return err
 		}
 
 		return nil

--- a/vendor/github.com/docker/libnetwork/portmapper/mapper_linux.go
+++ b/vendor/github.com/docker/libnetwork/portmapper/mapper_linux.go
@@ -44,11 +44,3 @@ func (pm *PortMapper) forward(action iptables.Action, proto string, sourceIP net
 	}
 	return pm.chain.Forward(action, sourceIP, sourcePort, proto, containerIP, containerPort, pm.bridgeName)
 }
-
-// checkIP checks if IP is valid and matching to chain version
-func (pm *PortMapper) checkIP(ip net.IP) bool {
-	if pm.chain == nil || pm.chain.IPTable.Version == iptables.IPv4 {
-		return ip.To4() != nil
-	}
-	return ip.To16() != nil
-}

--- a/vendor/github.com/docker/libnetwork/portmapper/proxy.go
+++ b/vendor/github.com/docker/libnetwork/portmapper/proxy.go
@@ -19,6 +19,16 @@ type userlandProxy interface {
 	Stop() error
 }
 
+// ipVersion refers to IP version - v4 or v6
+type ipVersion string
+
+const (
+	// IPv4 is version 4
+	ipv4 ipVersion = "4"
+	// IPv4 is version 6
+	ipv6 ipVersion = "6"
+)
+
 // proxyCommand wraps an exec.Cmd to run the userland TCP and UDP
 // proxies as separate processes.
 type proxyCommand struct {
@@ -77,21 +87,27 @@ func (p *proxyCommand) Stop() error {
 // port allocations on bound port, because without userland proxy we using
 // iptables rules and not net.Listen
 type dummyProxy struct {
-	listener io.Closer
-	addr     net.Addr
+	listener  io.Closer
+	addr      net.Addr
+	ipVersion ipVersion
 }
 
 func newDummyProxy(proto string, hostIP net.IP, hostPort int) (userlandProxy, error) {
+	// detect version of hostIP to bind only to correct version
+	version := ipv4
+	if hostIP.To4() == nil {
+		version = ipv6
+	}
 	switch proto {
 	case "tcp":
 		addr := &net.TCPAddr{IP: hostIP, Port: hostPort}
-		return &dummyProxy{addr: addr}, nil
+		return &dummyProxy{addr: addr, ipVersion: version}, nil
 	case "udp":
 		addr := &net.UDPAddr{IP: hostIP, Port: hostPort}
-		return &dummyProxy{addr: addr}, nil
+		return &dummyProxy{addr: addr, ipVersion: version}, nil
 	case "sctp":
 		addr := &sctp.SCTPAddr{IPAddrs: []net.IPAddr{{IP: hostIP}}, Port: hostPort}
-		return &dummyProxy{addr: addr}, nil
+		return &dummyProxy{addr: addr, ipVersion: version}, nil
 	default:
 		return nil, fmt.Errorf("Unknown addr type: %s", proto)
 	}
@@ -100,19 +116,19 @@ func newDummyProxy(proto string, hostIP net.IP, hostPort int) (userlandProxy, er
 func (p *dummyProxy) Start() error {
 	switch addr := p.addr.(type) {
 	case *net.TCPAddr:
-		l, err := net.ListenTCP("tcp", addr)
+		l, err := net.ListenTCP("tcp"+string(p.ipVersion), addr)
 		if err != nil {
 			return err
 		}
 		p.listener = l
 	case *net.UDPAddr:
-		l, err := net.ListenUDP("udp", addr)
+		l, err := net.ListenUDP("udp"+string(p.ipVersion), addr)
 		if err != nil {
 			return err
 		}
 		p.listener = l
 	case *sctp.SCTPAddr:
-		l, err := sctp.ListenSCTP("sctp", addr)
+		l, err := sctp.ListenSCTP("sctp"+string(p.ipVersion), addr)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Brings in https://github.com/moby/libnetwork/pull/2604
fixes https://github.com/moby/moby/issues/41822 "Upgrade to 20.10 fails to release ports published to IPv6 literal addresses"
