### PR TITLE
Fix service job mode filter

### DIFF
--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -92,9 +92,9 @@ func (c *Cluster) GetServices(options apitypes.ServiceListOptions) ([]types.Serv
 			case *swarmapi.ServiceSpec_Replicated:
 				mode = "replicated"
 			case *swarmapi.ServiceSpec_ReplicatedJob:
-				mode = "replicatedjob"
+				mode = "replicated-job"
 			case *swarmapi.ServiceSpec_GlobalJob:
-				mode = "globaljob"
+				mode = "global-job"
 			}
 
 			if !options.Filters.ExactMatch("mode", mode) {


### PR DESCRIPTION
**- What I did**

Previously, filtering based on mode would fail with jobs because users expect to filter on mode `replicated-job` or `global-job`, but the filtering code was checking for `replicatedjob` or `globaljob`. Now, the filter matches the correct mode string.

**- How I did it**

Added two dashes.

**- How to verify it**

Look and behold, the strings are now correct.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixed filtering for `replicated-job` and `global-job` Service modes.