### PR TITLE
Fix a potential hang when starting after a non-clean shutdown

### DIFF
--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -288,6 +288,7 @@ func (d *Daemon) Cleanup(t testing.TB) {
 func (d *Daemon) Start(t testing.TB, args ...string) {
 	t.Helper()
 	if err := d.StartWithError(args...); err != nil {
+		d.DumpStackAndQuit() // in case the daemon is stuck
 		t.Fatalf("[%s] failed to start daemon with arguments %v : %v", d.id, d.args, err)
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This fixes a hang discovered by Docker Desktop users when migrating to v3.0.0: when docker is stopped abruptly - which can happen on Windows Restart with WSL2, restarting could potentially hang.

**- How I did it**

Previous startup sequence used to call "containerStop" on containers that were persisted with a running state but are not alive when restarting (can happen on non-clean shutdown).
This call was made before fixing-up the RunningState of the container, and tricked the daemon to trying to kill a non-existing process and ultimately hang.

The fix is very simple - just add a condition on calling containerStop.

**- How to verify it**

We need to work on a synthetic test for that. I need guidance there.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixes an issue where docker would hang at startup after an abrupt shutdown.


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1677333/102598251-06912f80-411c-11eb-83b2-41bf9a628c9d.png)
