### PR TITLE
[WIP] Fix blocked container shutdown caused by non-reading attached client

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -657,14 +657,14 @@ func (container *Container) StderrPipe() io.ReadCloser {
 }
 
 // CloseStreams closes the container's stdio streams
-func (container *Container) CloseStreams() error {
-	return container.StreamConfig.CloseStreams()
+func (container *Container) CloseStreams(ctx context.Context) error {
+	return container.StreamConfig.CloseStreams(ctx)
 }
 
 // InitializeStdio is called by libcontainerd to connect the stdio.
 func (container *Container) InitializeStdio(iop *cio.DirectIO) (cio.IO, error) {
 	if err := container.startLogging(); err != nil {
-		container.Reset(false)
+		container.Reset(context.Background(), false)
 		return nil, err
 	}
 
@@ -803,7 +803,7 @@ type rio struct {
 func (i *rio) Close() error {
 	i.IO.Close()
 
-	return i.sc.CloseStreams()
+	return i.sc.CloseStreams(context.Background())
 }
 
 func (i *rio) Wait() {

--- a/container/exec.go
+++ b/container/exec.go
@@ -66,7 +66,7 @@ func (c *ExecConfig) InitializeStdio(iop *cio.DirectIO) (cio.IO, error) {
 
 // CloseStreams closes the stdio streams for the exec
 func (c *ExecConfig) CloseStreams() error {
-	return c.StreamConfig.CloseStreams()
+	return c.StreamConfig.CloseStreams(context.Background())
 }
 
 // SetExitCode sets the exec config's exit code

--- a/container/exec.go
+++ b/container/exec.go
@@ -65,8 +65,8 @@ func (c *ExecConfig) InitializeStdio(iop *cio.DirectIO) (cio.IO, error) {
 }
 
 // CloseStreams closes the stdio streams for the exec
-func (c *ExecConfig) CloseStreams() error {
-	return c.StreamConfig.CloseStreams(context.Background())
+func (c *ExecConfig) CloseStreams(ctx context.Context) error {
+	return c.StreamConfig.CloseStreams(ctx)
 }
 
 // SetExitCode sets the exec config's exit code

--- a/container/monitor.go
+++ b/container/monitor.go
@@ -12,14 +12,14 @@ const (
 )
 
 // Reset puts a container into a state where it can be restarted again.
-func (container *Container) Reset(lock bool) {
+func (container *Container) Reset(ctx context.Context, lock bool) {
 	if lock {
 		container.Lock()
 		defer container.Unlock()
 	}
 
-	if err := container.CloseStreams(); err != nil {
-		log.G(context.TODO()).Errorf("%s: %s", container.ID, err)
+	if err := container.CloseStreams(ctx); err != nil {
+		log.G(ctx).Errorf("%s: %s", container.ID, err)
 	}
 
 	// Re-create a brand new stdin pipe once the container exited
@@ -39,7 +39,7 @@ func (container *Container) Reset(lock bool) {
 			defer timer.Stop()
 			select {
 			case <-timer.C:
-				log.G(context.TODO()).Warn("Logger didn't exit in time: logs may be truncated")
+				log.G(ctx).Warn("Logger didn't exit in time: logs may be truncated")
 			case <-exit:
 			}
 		}

--- a/container/stream/streams.go
+++ b/container/stream/streams.go
@@ -90,7 +90,7 @@ func (c *Config) NewNopInputPipe() {
 }
 
 // CloseStreams ensures that the configured streams are properly closed.
-func (c *Config) CloseStreams() error {
+func (c *Config) CloseStreams(ctx context.Context) error {
 	var errors []string
 
 	if c.stdin != nil {
@@ -99,11 +99,11 @@ func (c *Config) CloseStreams() error {
 		}
 	}
 
-	if err := c.stdout.Clean(); err != nil {
+	if err := c.stdout.CleanContext(ctx); err != nil {
 		errors = append(errors, fmt.Sprintf("error close stdout: %s", err))
 	}
 
-	if err := c.stderr.Clean(); err != nil {
+	if err := c.stderr.CleanContext(ctx); err != nil {
 		errors = append(errors, fmt.Sprintf("error close stderr: %s", err))
 	}
 

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -187,7 +187,7 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, optio
 			ec.Running = false
 			exitCode := 126
 			ec.ExitCode = &exitCode
-			if err := ec.CloseStreams(); err != nil {
+			if err := ec.CloseStreams(ctx); err != nil {
 				log.G(ctx).Errorf("failed to cleanup exec %s streams: %s", ec.Container.ID, err)
 			}
 			ec.Unlock()

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -27,7 +27,10 @@ func (daemon *Daemon) setStateCounter(c *container.Container) {
 }
 
 func (daemon *Daemon) handleContainerExit(c *container.Container, e *libcontainerdtypes.EventInfo) error {
-	var exitStatus container.ExitStatus
+	var (
+		exitStatus       container.ExitStatus
+		taskDeletionDone chan struct{}
+	)
 	c.Lock()
 
 	cfg := daemon.config()
@@ -38,19 +41,33 @@ func (daemon *Daemon) handleContainerExit(c *container.Container, e *libcontaine
 
 	tsk, ok := c.Task()
 	if ok {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		es, err := tsk.Delete(ctx)
-		cancel()
-		if err != nil {
-			log.G(ctx).WithFields(log.Fields{
-				"error":     err,
-				"container": c.ID,
-			}).Warn("failed to delete container from containerd")
-		} else {
-			exitStatus = container.ExitStatus{
-				ExitCode: int(es.ExitCode()),
-				ExitedAt: es.ExitTime(),
+		taskDeletionDone = make(chan struct{})
+		go func() {
+			defer close(taskDeletionDone)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			es, err := tsk.Delete(ctx)
+			cancel()
+			if err != nil {
+				log.G(ctx).WithFields(log.Fields{
+					"error":     err,
+					"container": c.ID,
+				}).Warn("failed to delete container from containerd")
+			} else {
+				exitStatus = container.ExitStatus{
+					ExitCode: int(es.ExitCode()),
+					ExitedAt: es.ExitTime(),
+				}
 			}
+		}()
+
+		deletionIOCloseTimeout := time.NewTimer(3 * time.Second)
+		select {
+		case <-taskDeletionDone:
+			deletionIOCloseTimeout.Stop()
+		case <-deletionIOCloseTimeout.C:
+			// if tsk.Delete(ctx) did not exit after 3 seconds, try to close IO
+			// streams - they may be blocking the deletion - and continue
+			// waiting after that
 		}
 	}
 
@@ -61,6 +78,10 @@ func (daemon *Daemon) handleContainerExit(c *container.Container, e *libcontaine
 	ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
 	c.Reset(ctx, false)
 	cancel()
+
+	if taskDeletionDone != nil {
+		<-taskDeletionDone
+	}
 
 	if e != nil {
 		exitStatus.ExitCode = int(e.ExitCode)

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -191,9 +191,11 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 			execConfig.StreamConfig.Wait(ctx)
 			cancel()
 
-			if err := execConfig.CloseStreams(); err != nil {
+			ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+			if err := execConfig.CloseStreams(ctx); err != nil {
 				log.G(ctx).Errorf("failed to cleanup exec %s streams: %s", c.ID, err)
 			}
+			cancel()
 
 			exitCode = ec
 

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -58,7 +58,9 @@ func (daemon *Daemon) handleContainerExit(c *container.Container, e *libcontaine
 	c.StreamConfig.Wait(ctx)
 	cancel()
 
-	c.Reset(false)
+	ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	c.Reset(ctx, false)
+	cancel()
 
 	if e != nil {
 		exitStatus.ExitCode = int(e.ExitCode)

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -130,7 +130,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 			if err := container.CheckpointTo(daemon.containersReplica); err != nil {
 				log.G(ctx).Errorf("%s: failed saving state on start failure: %v", container.ID, err)
 			}
-			container.Reset(false)
+			container.Reset(ctx, false)
 
 			daemon.Cleanup(container)
 			// if containers AutoRemove flag is set, remove it after clean up

--- a/pkg/broadcaster/unbuffered.go
+++ b/pkg/broadcaster/unbuffered.go
@@ -1,49 +1,141 @@
 package broadcaster // import "github.com/docker/docker/pkg/broadcaster"
 
 import (
+	"context"
 	"io"
 	"sync"
 )
 
 // Unbuffered accumulates multiple io.WriteCloser by stream.
 type Unbuffered struct {
-	mu      sync.Mutex
-	writers []io.WriteCloser
+	writersUpdateMu sync.Mutex
+
+	writersWriteMu         chan struct{}
+	initWritersWriteMuOnce sync.Once
+
+	writers *[]io.WriteCloser
 }
 
 // Add adds new io.WriteCloser.
 func (w *Unbuffered) Add(writer io.WriteCloser) {
-	w.mu.Lock()
-	w.writers = append(w.writers, writer)
-	w.mu.Unlock()
+	w.lockWritersWriteMu()
+	defer w.unlockWritersWriteMu()
+
+	w.writersUpdateMu.Lock()
+	defer w.writersUpdateMu.Unlock()
+
+	if w.writers == nil {
+		w.writers = &[]io.WriteCloser{}
+	}
+	*w.writers = append(*w.writers, writer)
 }
 
 // Write writes bytes to all writers. Failed writers will be evicted during
 // this call.
 func (w *Unbuffered) Write(p []byte) (n int, err error) {
-	w.mu.Lock()
+	w.lockWritersWriteMu()
+	defer w.unlockWritersWriteMu()
+
+	w.writersUpdateMu.Lock()
+
+	// make a copy of w.writers. Even if .CleanContext sets w.writers, this
+	// Write call will still use it's valid copy
+	writers := w.writers
+
+	// release w.writersUpdateMu. This allows CleanContext to set w.writers
+	// to nil - but this Write call won't be affected by this, as it uses a copy
+	// of that pointer. We will also be able to safely iterate over *writers:
+	// clean methods never resize the slice (they only may set pointer to nil),
+	// and Add and Write require w.writersWriteMu, which we are still holding
+	w.writersUpdateMu.Unlock()
+
+	if writers == nil {
+		return
+	}
+
 	var evict []int
-	for i, sw := range w.writers {
+	for i, sw := range *writers {
 		if n, err := sw.Write(p); err != nil || n != len(p) {
 			// On error, evict the writer
 			evict = append(evict, i)
 		}
 	}
+
+	w.writersUpdateMu.Lock()
+	// at this point w.writers might have already been set to nil, but we're
+	// not affected by this as we are using a copy
 	for n, i := range evict {
-		w.writers = append(w.writers[:i-n], w.writers[i-n+1:]...)
+		*writers = append((*writers)[:i-n], (*writers)[i-n+1:]...)
 	}
-	w.mu.Unlock()
+	w.writersUpdateMu.Unlock()
+
 	return len(p), nil
+}
+
+func (w *Unbuffered) cleanUnlocked() {
+	if w.writers == nil {
+		return
+	}
+	for _, sw := range *w.writers {
+		sw.Close()
+	}
+	w.writers = nil
+}
+
+func (w *Unbuffered) cleanWithWriteLock() {
+	w.writersUpdateMu.Lock()
+	defer w.writersUpdateMu.Unlock()
+
+	w.cleanUnlocked()
 }
 
 // Clean closes and removes all writers. Last non-eol-terminated part of data
 // will be saved.
 func (w *Unbuffered) Clean() error {
-	w.mu.Lock()
-	for _, sw := range w.writers {
-		sw.Close()
-	}
-	w.writers = nil
-	w.mu.Unlock()
+	w.lockWritersWriteMu()
+	defer w.unlockWritersWriteMu()
+
+	w.cleanWithWriteLock()
 	return nil
+}
+
+// CleanContext closes and removes all writers.
+// CleanContext supports timeouts via the context to unblock and forcefully
+// close the io streams. This function should only be used if all writers
+// added to Unbuffered support concurrent calls to Close and Write: it will
+// call Close while Write may be in progress in order to forcefully close
+// writers
+func (w *Unbuffered) CleanContext(ctx context.Context) error {
+	writersWriteMu := w.getWritersWriteMu()
+
+	select {
+	case writersWriteMu <- struct{}{}:
+		defer w.unlockWritersWriteMu()
+	case <-ctx.Done():
+		// forceful cleanup - we will call w.cleanWithWriteLock() without
+		// actually holding w.writersWriteMu. This may call .Close() on a
+		// WriteCloser which is being blocked insite Write call
+	}
+
+	w.cleanWithWriteLock()
+	return ctx.Err()
+}
+
+func (w *Unbuffered) initWritersWriteMu() {
+	w.writersWriteMu = make(chan struct{}, 1)
+}
+
+func (w *Unbuffered) getWritersWriteMu() chan struct{} {
+	w.initWritersWriteMuOnce.Do(w.initWritersWriteMu)
+	return w.writersWriteMu
+}
+
+func (w *Unbuffered) lockWritersWriteMu() {
+	w.getWritersWriteMu() <- struct{}{}
+}
+
+func (w *Unbuffered) unlockWritersWriteMu() {
+	// this is never called before 'getWritersWriteMu()', so w.writersWriteMu is
+	// guaranteed to be initialized
+	<-w.writersWriteMu
 }


### PR DESCRIPTION
Fixes #41827

**- What I did**

Prevented container stop process from hanging indefinitely (causing all subsequent operations on that container to hang too) when there is a client attached to that container that is not reading container's output 

**- How I did it**

By adding a method `CleanContext` to `broadcaster.Unbuffered` that allows to put a timeout on cleanup (communicated using a `context`) - when that timeout expires, `Unbuffered` is forcibly cleaned by calling `Close` on its writers without waiting for their
`Write` operation to finish.

In more detail: we would like `CleanContext` to be able to call `Close` on a `WriteCloser` currently being blocked inside `Write` (in order to unblock it), while `Unbuffered.Write` is running. With current implementation of `Unbuffered` with a single lock it is unclear how this could be done: `Write` may hold the lock forever and there is no way to ask it to release. We also can't just ignore the lock and access `.writers` without holding it: `Unbuffered.Write` both uses and modifies `.writers`.

So the idea is to use _two_ locks instead, one of which must be held while updating `.writers` - and `Unbuffered.Write` will release it while blocking on its writers. Holding both locks means the same as holding `.mu` in original implementation - "full control" over this `Unbuffered` instance - and `.Add()` will do just that, as we don't need "forceful" semantics for it.

Also, we can use the fact that `.Clean()` does not resize `.writers` - it just sets it to `nil`. So, we can make `.writers` a pointer-to-slice instead of a slice - and have `Write` make a local copy of that pointer for itself - this will make sure `writers` in `Unbuffered.Write` remain valid. If `.CleanContext` has thrown old writers away, `Write` can change it in any way during eviction - it will just update an old (but valid) slice, that won't be used any more and will be picked up by GC after `Write` returns.

I am not sure whether current version of the fix is totally right, hence the WIP status.
I thought that closing writer that is stuck on write is better than just leaving it connected, giving up on some goroutine blocked on a `Write` to it. And it seems more aligned with what is done with `dio` in b5f28865efebb14c66d5580dfa7bf0634b5e3241.

Regarding how code is organized, maybe a simpler/more readable option would be to add a second (private) struct that will hold `writers` and a lock protecting their update [like this](https://gist.github.com/asterite3/95f5f7adabce0e60526de946c953f158). But, as you see, `Unbuffered.Write` explicitly takes/releases the lock of that private struct, so this sill kinda not perfect.

Another issue is whether it is correct to call `.Close()` while `.Write()` is running. As far as I understand, `io.WriteCloser` is not thread-safe by default, it may be an error to call it's methods simultaneously (and it does not guarantee to provide the desired effect: that `Close` will unblock `Write`). After reading the code it seems to me that most of the time writers in `Unbuffered` are `pkg/ioutil/BytesPipe`s, which are also thread-safe and work OK with interrupting `Write` with `Close`. But it is still possible to add non-thread-safe writer to `Unbuffered`, it's interface allows it and the way `container/stream.Config` uses it also allow to add any `WriteCloser` to it - on can call `Config`'s `Stdout()`, get `Unbuffered` object and call `Add` on it. This is different from how `cio.DirectIO` is made - if I understood [its code](https://github.com/containerd/containerd/tree/master/cio) correctly, its `closers` are not arbitrary `io.Closers`, but are always objects returned by `openFifo`.
So, maybe a more type-safe alternative would be to not use `Unbuffered` in `stream.Config` at all, but to add a new version of it, `broadcaster.BytesPipe`, that will ensure its writers _are_ `BytesPipe`s, and use it: [like this](https://github.com/moby/moby/compare/master...asterite3:add-broadcaster-bytespipe).

**- How to verify it**

Follow reproduction steps from #41827 and verify that container is no longer shown as running in `docker ps` after it stopped (and operations on it do not hang). 

**- Description for the changelog**

Fixed container stop sequence on daemon side being blocked indefinitely by an attached client that is not reading container's output.

**- A picture of a cute animal (not mandatory but encouraged)**
![s](https://user-images.githubusercontent.com/5569241/102715227-f4162200-42e4-11eb-8e96-dfa09fc69cd9.jpg)

