### PR TITLE
cmd/dockerd: sd_notify STOPPING=1 when shutting down

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -184,7 +184,7 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	}, logrus.StandardLogger())
 
 	// Notify that the API is active, but before daemon is set up.
-	preNotifySystem()
+	preNotifyReady()
 
 	pluginStore := plugin.NewStore()
 
@@ -242,13 +242,15 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 	go cli.api.Wait(serveAPIWait)
 
 	// after the daemon is done setting up we can notify systemd api
-	notifySystem()
+	notifyReady()
 
 	// Daemon is fully initialized and handling API traffic
 	// Wait for serve API to complete
 	errAPI := <-serveAPIWait
 	c.Cleanup()
 
+	// notify systemd that we're shutting down
+	notifyStopping()
 	shutdownDaemon(d)
 
 	// Stop notification processing and any background processes

--- a/cmd/dockerd/daemon_freebsd.go
+++ b/cmd/dockerd/daemon_freebsd.go
@@ -1,9 +1,13 @@
 package main
 
-// preNotifySystem sends a message to the host when the API is active, but before the daemon is
-func preNotifySystem() {
+// preNotifyReady sends a message to the host when the API is active, but before the daemon is
+func preNotifyReady() {
 }
 
-// notifySystem sends a message to the host when the server is ready to be used
-func notifySystem() {
+// notifyReady sends a message to the host when the server is ready to be used
+func notifyReady() {
+}
+
+// notifyStopping sends a message to the host when the server is shutting down
+func notifyStopping() {
 }

--- a/cmd/dockerd/daemon_linux.go
+++ b/cmd/dockerd/daemon_linux.go
@@ -2,12 +2,17 @@ package main
 
 import systemdDaemon "github.com/coreos/go-systemd/v22/daemon"
 
-// preNotifySystem sends a message to the host when the API is active, but before the daemon is
-func preNotifySystem() {
+// preNotifyReady sends a message to the host when the API is active, but before the daemon is
+func preNotifyReady() {
 }
 
-// notifySystem sends a message to the host when the server is ready to be used
-func notifySystem() {
+// notifyReady sends a message to the host when the server is ready to be used
+func notifyReady() {
 	// Tell the init daemon we are accepting requests
 	go systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyReady)
+}
+
+// notifyStopping sends a message to the host when the server is shutting down
+func notifyStopping() {
+	go systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyStopping)
 }

--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -27,8 +27,8 @@ func getDaemonConfDir(root string) (string, error) {
 	return filepath.Join(root, `\config`), nil
 }
 
-// preNotifySystem sends a message to the host when the API is active, but before the daemon is
-func preNotifySystem() {
+// preNotifyReady sends a message to the host when the API is active, but before the daemon is
+func preNotifyReady() {
 	// start the service now to prevent timeouts waiting for daemon to start
 	// but still (eventually) complete all requests that are sent after this
 	if service != nil {
@@ -39,8 +39,12 @@ func preNotifySystem() {
 	}
 }
 
-// notifySystem sends a message to the host when the server is ready to be used
-func notifySystem() {
+// notifyReady sends a message to the host when the server is ready to be used
+func notifyReady() {
+}
+
+// notifyStopping sends a message to the host when the server is shutting down
+func notifyStopping() {
 }
 
 // notifyShutdown is called after the daemon shuts down but before the process exits.


### PR DESCRIPTION
Signal systemd when we start shutting down to complement the "READY" notify
that was originally implemented in 97088ebef7c638f8175d7c61934642eeb2c054c4 (https://github.com/moby/moby/pull/3060; related to https://github.com/moby/moby/issues/2322)

From [sd_notify(3)](https://www.freedesktop.org/software/systemd/man/sd_notify.html#STOPPING=1)

> STOPPING=1
> Tells the service manager that the service is beginning its shutdown. This is useful
> to allow the service manager to track the service's internal state, and present it to
> the user.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
- systemd: send sd_notify STOPPING=1 when shutting down
```


**- A picture of a cute animal (not mandatory but encouraged)**

