### PR TITLE
vendor: github.com/containerd/continuity 180525291bb77dea7062ac4281fcd38e2a3d76c5

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -132,7 +132,7 @@ google.golang.org/genproto                          3f1135a288c9a07e340ae8ba4cc6
 # containerd
 github.com/containerd/containerd                    0edc412565dcc6e3d6125ff9e4b009ad4b89c638 # master (v1.5.0-dev)
 github.com/containerd/fifo                          0724c46b320cf96bb172a0550c19a4b1fca4dacb
-github.com/containerd/continuity                    efbc4488d8fe1bdc16bde3b2d2990d9b3a899165
+github.com/containerd/continuity                    180525291bb77dea7062ac4281fcd38e2a3d76c5
 github.com/containerd/cgroups                       0b889c03f102012f1d93a97ddd3ef71cd6f4f510
 github.com/containerd/console                       5d7e1412f07b502a01029ea20e20e0d2be31fa7c # v1.0.1
 github.com/containerd/go-runc                       16b287bc67d069a60fa48db15f330b790b74365b

--- a/vendor/github.com/containerd/continuity/README.md
+++ b/vendor/github.com/containerd/continuity/README.md
@@ -63,6 +63,10 @@ $ stat -c %a Makefile
 $ ./bin/continuity verify . /tmp/a.pb
 ```
 
+## Platforms
+
+continuity primarily targets Linux.  continuity may compile for and work on
+other operating systems, but those platforms are not tested.
 
 ## Contribution Guide
 ### Building Proto Package

--- a/vendor/github.com/containerd/continuity/devices/devices_unix.go
+++ b/vendor/github.com/containerd/continuity/devices/devices_unix.go
@@ -56,7 +56,7 @@ func Mknod(p string, mode os.FileMode, maj, min int) error {
 		m |= unix.S_IFIFO
 	}
 
-	return unix.Mknod(p, m, int(dev))
+	return mknod(p, m, dev)
 }
 
 // syscallMode returns the syscall-specific mode bits from Go's portable mode bits.

--- a/vendor/github.com/containerd/continuity/devices/mknod_freebsd.go
+++ b/vendor/github.com/containerd/continuity/devices/mknod_freebsd.go
@@ -1,0 +1,25 @@
+// +build freebsd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package devices
+
+import "golang.org/x/sys/unix"
+
+func mknod(path string, mode uint32, dev uint64) (err error) {
+	return unix.Mknod(path, mode, dev)
+}

--- a/vendor/github.com/containerd/continuity/devices/mknod_unix.go
+++ b/vendor/github.com/containerd/continuity/devices/mknod_unix.go
@@ -1,0 +1,25 @@
+// +build linux darwin solaris
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package devices
+
+import "golang.org/x/sys/unix"
+
+func mknod(path string, mode uint32, dev uint64) (err error) {
+	return unix.Mknod(path, mode, int(dev))
+}

--- a/vendor/github.com/containerd/continuity/fs/copy_darwinopenbsdsolaris.go
+++ b/vendor/github.com/containerd/continuity/fs/copy_darwinopenbsdsolaris.go
@@ -1,0 +1,40 @@
+// +build darwin openbsd solaris
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+func copyDevice(dst string, fi os.FileInfo) error {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("unsupported stat type")
+	}
+	return unix.Mknod(dst, uint32(fi.Mode()), int(st.Rdev))
+}
+
+func utimesNano(name string, atime, mtime syscall.Timespec) error {
+	timespec := []syscall.Timespec{atime, mtime}
+	return syscall.UtimesNano(name, timespec)
+}

--- a/vendor/github.com/containerd/continuity/fs/copy_freebsd.go
+++ b/vendor/github.com/containerd/continuity/fs/copy_freebsd.go
@@ -1,0 +1,42 @@
+// +build freebsd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+func copyDevice(dst string, fi os.FileInfo) error {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("unsupported stat type")
+	}
+	return unix.Mknod(dst, uint32(fi.Mode()), st.Rdev)
+}
+
+func utimesNano(name string, atime, mtime syscall.Timespec) error {
+	at := unix.NsecToTimespec(atime.Nano())
+	mt := unix.NsecToTimespec(mtime.Nano())
+	utimes := [2]unix.Timespec{at, mt}
+	return unix.UtimesNanoAt(unix.AT_FDCWD, name, utimes[0:], unix.AT_SYMLINK_NOFOLLOW)
+}

--- a/vendor/github.com/containerd/continuity/fs/copy_unix.go
+++ b/vendor/github.com/containerd/continuity/fs/copy_unix.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/containerd/continuity/sysx"
 	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 )
 
 func copyFileInfo(fi os.FileInfo, name string) error {
@@ -53,8 +52,7 @@ func copyFileInfo(fi os.FileInfo, name string) error {
 		}
 	}
 
-	timespec := []syscall.Timespec{StatAtime(st), StatMtime(st)}
-	if err := syscall.UtimesNano(name, timespec); err != nil {
+	if err := utimesNano(name, StatAtime(st), StatMtime(st)); err != nil {
 		return errors.Wrapf(err, "failed to utime %s", name)
 	}
 
@@ -101,12 +99,4 @@ func copyXAttrs(dst, src string, xeh XAttrErrorHandler) error {
 	}
 
 	return nil
-}
-
-func copyDevice(dst string, fi os.FileInfo) error {
-	st, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		return errors.New("unsupported stat type")
-	}
-	return unix.Mknod(dst, uint32(fi.Mode()), int(st.Rdev))
 }

--- a/vendor/github.com/containerd/continuity/fs/du_unix.go
+++ b/vendor/github.com/containerd/continuity/fs/du_unix.go
@@ -25,6 +25,14 @@ import (
 	"syscall"
 )
 
+// blocksUnitSize is the unit used by `st_blocks` in `stat` in bytes.
+// See https://man7.org/linux/man-pages/man2/stat.2.html
+//   st_blocks
+//     This field indicates the number of blocks allocated to the
+//     file, in 512-byte units.  (This may be smaller than
+//     st_size/512 when the file has holes.)
+const blocksUnitSize = 512
+
 type inode struct {
 	// TODO(stevvooe): Can probably reduce memory usage by not tracking
 	// device, but we can leave this right for now.
@@ -33,9 +41,9 @@ type inode struct {
 
 func newInode(stat *syscall.Stat_t) inode {
 	return inode{
-		// Dev is uint32 on darwin/bsd, uint64 on linux/solaris
+		// Dev is uint32 on darwin/bsd, uint64 on linux/solaris/freebsd
 		dev: uint64(stat.Dev), // nolint: unconvert
-		// Ino is uint32 on bsd, uint64 on darwin/linux/solaris
+		// Ino is uint32 on bsd, uint64 on darwin/linux/solaris/freebsd
 		ino: uint64(stat.Ino), // nolint: unconvert
 	}
 }
@@ -59,10 +67,11 @@ func diskUsage(ctx context.Context, roots ...string) (Usage, error) {
 			default:
 			}
 
-			inoKey := newInode(fi.Sys().(*syscall.Stat_t))
+			stat := fi.Sys().(*syscall.Stat_t)
+			inoKey := newInode(stat)
 			if _, ok := inodes[inoKey]; !ok {
 				inodes[inoKey] = struct{}{}
-				size += fi.Size()
+				size += stat.Blocks * blocksUnitSize
 			}
 
 			return nil
@@ -89,10 +98,11 @@ func diffUsage(ctx context.Context, a, b string) (Usage, error) {
 		}
 
 		if kind == ChangeKindAdd || kind == ChangeKindModify {
-			inoKey := newInode(fi.Sys().(*syscall.Stat_t))
+			stat := fi.Sys().(*syscall.Stat_t)
+			inoKey := newInode(stat)
 			if _, ok := inodes[inoKey]; !ok {
 				inodes[inoKey] = struct{}{}
-				size += fi.Size()
+				size += stat.Blocks * blocksUnitSize
 			}
 
 			return nil

--- a/vendor/github.com/containerd/continuity/go.mod
+++ b/vendor/github.com/containerd/continuity/go.mod
@@ -4,20 +4,16 @@ go 1.13
 
 require (
 	bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898
-	github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4
+	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/protobuf v1.2.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/onsi/ginkgo v1.10.1 // indirect
-	github.com/onsi/gomega v1.7.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0-rc1
-	github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7
-	github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2
+	github.com/opencontainers/go-digest v1.0.0
+	github.com/pkg/errors v0.9.1
+	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee
 	github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
-	golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3 // indirect
+	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd // indirect
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
-	golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e
-	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
-	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
+	golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3
 )


### PR DESCRIPTION
full diff: https://github.com/containerd/continuity/compare/efbc4488d8fe1bdc16bde3b2d2990d9b3a899165...180525291bb77dea7062ac4281fcd38e2a3d76c5

- GH Actions: test against Go 1.15
- go.mod: update various dependencies to latest released versions
    - go.mod: logrus v1.6.0
    - go.mod: github.com/pkg/errors v0.9.1
    - go.mod: github.com/dustin/go-humanize v1.0.0
    - go.mod: github.com/opencontainers/go-digest v1.0.0
- go.mod: golang.org/x/sys to v0.0.0-20201201145000-ef89a241ccb3 to include riscv64 support
- Fix usage calculation to account for sparse files
- Fix incorrect usage calculation
- Add check to compare against du output
- Support FreeBSD

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

