### PR TITLE
Reject null manifests during tar import

### DIFF
--- a/daemon/images/image_exporter.go
+++ b/daemon/images/image_exporter.go
@@ -17,7 +17,7 @@ func (i *ImageService) ExportImage(names []string, outStream io.Writer) error {
 }
 
 // LoadImage uploads a set of images into the repository. This is the
-// complement of ImageExport.  The input stream is an uncompressed tar
+// complement of ExportImage.  The input stream is an uncompressed tar
 // ball containing images and metadata.
 func (i *ImageService) LoadImage(inTar io.ReadCloser, outStream io.Writer, quiet bool) error {
 	imageExporter := tarexport.NewTarExporter(i.imageStore, i.layerStores, i.referenceStore, i)

--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -63,6 +63,10 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 		return err
 	}
 
+	if err := validateManifest(manifest); err != nil {
+		return err
+	}
+
 	var parentLinks []parentLink
 	var imageIDsStr string
 	var imageRefCount int
@@ -429,4 +433,14 @@ func checkCompatibleOS(imageOS string) error {
 	}
 
 	return system.ValidatePlatform(p)
+}
+
+func validateManifest(manifest []manifestItem) error {
+	// a nil manifest usually indicates a bug, so don't just silently fail.
+	// if someone really needs to pass an empty manifest, they can pass [].
+	if manifest == nil {
+		return errors.New("invalid manifest, manifest cannot be null (but can be [])")
+	}
+
+	return nil
 }

--- a/image/tarexport/load_test.go
+++ b/image/tarexport/load_test.go
@@ -1,0 +1,37 @@
+package tarexport
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestValidateManifest(t *testing.T) {
+	cases := map[string]struct {
+		manifest    []manifestItem
+		valid       bool
+		errContains string
+	}{
+		"nil": {
+			manifest:    nil,
+			valid:       false,
+			errContains: "manifest cannot be null",
+		},
+		"non-nil": {
+			manifest: []manifestItem{},
+			valid:    true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := validateManifest(tc.manifest)
+			if tc.valid {
+				assert.Check(t, is.Nil(err))
+			} else {
+				assert.Check(t, is.ErrorContains(err, tc.errContains))
+			}
+		})
+	}
+}


### PR DESCRIPTION
**- What I did**

I was using [kaniko](https://github.com/GoogleContainerTools/kaniko) to build images, which erroneously produced a tarball with a manifest containing `null`. Surprisingly, docker accepted the manifest but... didn't do anything.

This is not outlined in the docker spec, but I believe `null` manifests should be rejected (`[]` is okay!). It would have saved me a bunch of time, and I can't imagine anyone intentionally importing `null` as an image (even `[]` is questionable).

This change rejects null manifests. For a quick brief on how go JSON decodes null and [], see:
https://play.golang.org/p/kGuoI0x1xyc

**- How I did it**

I just added a check for a nil manifest

**- How to verify it**

I followed the [guide](https://github.com/moby/moby/blob/8891c58a433a823ce0a65b57efff45f32ee9cb45/docs/contributing/set-up-dev-env.md) to get a dev env running, then:
```shell
$ printf 'null' > manifest.json
$ tar -czf invalid.tar manifest.json
$ root@31d06c589959:/go/src/github.com/docker/docker# docker load -i invalid.tar 
invalid manifest, manifest cannot be null (but can be [])
```

**- Description for the changelog**
reject tarballs with `null` manifests on import


**- A picture of a cute animal (not mandatory but encouraged)**
![Screenshot_2020-12-26 Messenger](https://user-images.githubusercontent.com/6404517/103143831-8a4bad00-4716-11eb-9873-5ef6417ca488.png)
