### PR TITLE
docs: fix typos in API docs

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1274,7 +1274,7 @@ definitions:
     type: "object"
     properties:
       Bridge:
-        description: Name of the network'a bridge (for example, `docker0`).
+        description: Name of the network's bridge (for example, `docker0`).
         type: "string"
         example: "docker0"
       SandboxID:
@@ -10050,7 +10050,7 @@ paths:
                 description: |
                   Address or interface to use for data path traffic (format:
                   `<ip|interface>`), for example,  `192.168.1.1`, or an interface,
-                  like `eth0`. If `DataPathAddr` is unspecified, the same addres
+                  like `eth0`. If `DataPathAddr` is unspecified, the same address
                   as `AdvertiseAddr` is used.
 
                   The `DataPathAddr` specifies the address that global scope

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -898,7 +898,7 @@ definitions:
     type: "object"
     properties:
       Bridge:
-        description: Name of the network'a bridge (for example, `docker0`).
+        description: Name of the network's bridge (for example, `docker0`).
         type: "string"
         example: "docker0"
       SandboxID:

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -903,7 +903,7 @@ definitions:
     type: "object"
     properties:
       Bridge:
-        description: Name of the network'a bridge (for example, `docker0`).
+        description: Name of the network's bridge (for example, `docker0`).
         type: "string"
         example: "docker0"
       SandboxID:

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -914,7 +914,7 @@ definitions:
     type: "object"
     properties:
       Bridge:
-        description: Name of the network'a bridge (for example, `docker0`).
+        description: Name of the network's bridge (for example, `docker0`).
         type: "string"
         example: "docker0"
       SandboxID:

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -890,7 +890,7 @@ definitions:
     type: "object"
     properties:
       Bridge:
-        description: Name of the network'a bridge (for example, `docker0`).
+        description: Name of the network's bridge (for example, `docker0`).
         type: "string"
         example: "docker0"
       SandboxID:

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -890,7 +890,7 @@ definitions:
     type: "object"
     properties:
       Bridge:
-        description: Name of the network'a bridge (for example, `docker0`).
+        description: Name of the network's bridge (for example, `docker0`).
         type: "string"
         example: "docker0"
       SandboxID:

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -893,7 +893,7 @@ definitions:
     type: "object"
     properties:
       Bridge:
-        description: Name of the network'a bridge (for example, `docker0`).
+        description: Name of the network's bridge (for example, `docker0`).
         type: "string"
         example: "docker0"
       SandboxID:

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -904,7 +904,7 @@ definitions:
     type: "object"
     properties:
       Bridge:
-        description: Name of the network'a bridge (for example, `docker0`).
+        description: Name of the network's bridge (for example, `docker0`).
         type: "string"
         example: "docker0"
       SandboxID:

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -1184,7 +1184,7 @@ definitions:
     type: "object"
     properties:
       Bridge:
-        description: Name of the network'a bridge (for example, `docker0`).
+        description: Name of the network's bridge (for example, `docker0`).
         type: "string"
         example: "docker0"
       SandboxID:
@@ -9679,7 +9679,7 @@ paths:
                 description: |
                   Address or interface to use for data path traffic (format:
                   `<ip|interface>`), for example,  `192.168.1.1`, or an interface,
-                  like `eth0`. If `DataPathAddr` is unspecified, the same addres
+                  like `eth0`. If `DataPathAddr` is unspecified, the same address
                   as `AdvertiseAddr` is used.
 
                   The `DataPathAddr` specifies the address that global scope

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -1243,7 +1243,7 @@ definitions:
     type: "object"
     properties:
       Bridge:
-        description: Name of the network'a bridge (for example, `docker0`).
+        description: Name of the network's bridge (for example, `docker0`).
         type: "string"
         example: "docker0"
       SandboxID:
@@ -9880,7 +9880,7 @@ paths:
                 description: |
                   Address or interface to use for data path traffic (format:
                   `<ip|interface>`), for example,  `192.168.1.1`, or an interface,
-                  like `eth0`. If `DataPathAddr` is unspecified, the same addres
+                  like `eth0`. If `DataPathAddr` is unspecified, the same address
                   as `AdvertiseAddr` is used.
 
                   The `DataPathAddr` specifies the address that global scope

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -1274,7 +1274,7 @@ definitions:
     type: "object"
     properties:
       Bridge:
-        description: Name of the network'a bridge (for example, `docker0`).
+        description: Name of the network's bridge (for example, `docker0`).
         type: "string"
         example: "docker0"
       SandboxID:
@@ -10050,7 +10050,7 @@ paths:
                 description: |
                   Address or interface to use for data path traffic (format:
                   `<ip|interface>`), for example,  `192.168.1.1`, or an interface,
-                  like `eth0`. If `DataPathAddr` is unspecified, the same addres
+                  like `eth0`. If `DataPathAddr` is unspecified, the same address
                   as `AdvertiseAddr` is used.
 
                   The `DataPathAddr` specifies the address that global scope


### PR DESCRIPTION
carry of https://github.com/moby/moby/pull/41844
closes https://github.com/moby/moby/pull/41844