### PR TITLE
Add shim config for custom runtimes for plugins

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -965,8 +965,12 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		}
 
 		var rt types.Runtime
-		if runtime := config.GetRuntime(config.GetDefaultRuntimeName()); runtime != nil {
-			rt = *runtime
+		if runtime.GOOS != "windows" {
+			rtPtr, err := d.getRuntime(config.GetDefaultRuntimeName())
+			if err != nil {
+				return nil, err
+			}
+			rt = *rtPtr
 		}
 		return pluginexec.New(ctx, getPluginExecRoot(config.Root), pluginCli, config.ContainerdPluginNamespace, m, rt)
 	}

--- a/daemon/runtime_windows.go
+++ b/daemon/runtime_windows.go
@@ -1,0 +1,10 @@
+package daemon
+
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/pkg/errors"
+)
+
+func (daemon *Daemon) getRuntime(name string) (*types.Runtime, error) {
+	return nil, errors.New("not implemented")
+}

--- a/daemon/start_unix.go
+++ b/daemon/start_unix.go
@@ -3,11 +3,7 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
-	"github.com/containerd/cgroups"
 	"github.com/docker/docker/container"
-	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // getLibcontainerdCreateOptions callers must hold a lock on the container
@@ -18,19 +14,9 @@ func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Contain
 		container.CheckpointTo(daemon.containersReplica)
 	}
 
-	rt := daemon.configStore.GetRuntime(container.HostConfig.Runtime)
-	if rt.Shim == nil {
-		p, err := daemon.rewriteRuntimePath(container.HostConfig.Runtime, rt.Path, rt.Args)
-		if err != nil {
-			return "", nil, translateContainerdStartErr(container.Path, container.SetExitCode, err)
-		}
-		rt.Shim = defaultV2ShimConfig(daemon.configStore, p)
-	}
-	if rt.Shim.Binary == linuxShimV1 {
-		if cgroups.Mode() == cgroups.Unified {
-			return "", nil, errdefs.InvalidParameter(errors.Errorf("runtime %q is not supported while cgroups v2 (unified hierarchy) is being used", container.HostConfig.Runtime))
-		}
-		logrus.Warnf("Configured runtime %q is deprecated and will be removed in the next release", container.HostConfig.Runtime)
+	rt, err := daemon.getRuntime(container.HostConfig.Runtime)
+	if err != nil {
+		return "", nil, translateContainerdStartErr(container.Path, container.SetExitCode, err)
 	}
 
 	return rt.Shim.Binary, rt.Shim.Opts, nil


### PR DESCRIPTION
This fixes a panic when an admin specifies a custom default runtime,
when a plugin is started the shim config is nil.

Fixes docker/for-linux#1169
fixes https://github.com/docker/for-linux/issues/1185