### PR TITLE
Make test work with rootless mode

### DIFF
--- a/integration/container/daemon_linux_test.go
+++ b/integration/container/daemon_linux_test.go
@@ -193,7 +193,7 @@ func TestRestartDaemonWithRestartingContainer(t *testing.T) {
 	defer d.Cleanup(t)
 
 	d.StartWithBusybox(t, "--iptables=false")
-	defer d.Kill()
+	defer d.Stop(t)
 
 	ctx := context.Background()
 	client := d.NewClientT(t)
@@ -203,8 +203,7 @@ func TestRestartDaemonWithRestartingContainer(t *testing.T) {
 	// We will manipulate the on disk state later
 	id := container.Create(ctx, t, client, container.WithRestartPolicy("always"), container.WithCmd("/bin/sh", "-c", "exit 1"))
 
-	// SIGKILL the daemon
-	assert.NilError(t, d.Kill())
+	d.Stop(t)
 
 	configPath := filepath.Join(d.Root, "containers", id, "config.v2.json")
 	configBytes, err := ioutil.ReadFile(configPath)


### PR DESCRIPTION
Using `d.Kill()` with rootless mode causes the restarted daemon to not
be able to start containerd (it times out).

Originally this was SIGKILLing the daemon because we were hoping to not
have to manipulate on disk state, but since we need to anyway we can
shut it down normally.

I also tested this to ensure the test fails correctly without the fix
that the test was added to check for.