### PR TITLE
Fix Error in daemon_unix.go and docker_cli_run_unit_test.go

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -461,7 +461,7 @@ func verifyPlatformContainerResources(resources *containertypes.Resources, sysIn
 		resources.MemoryReservation = 0
 	}
 	if resources.MemoryReservation > 0 && resources.MemoryReservation < linuxMinMemory {
-		return warnings, fmt.Errorf("Minimum memory reservation allowed is 4MB")
+		return warnings, fmt.Errorf("Minimum memory reservation allowed is 6MB")
 	}
 	if resources.Memory > 0 && resources.MemoryReservation > 0 && resources.Memory < resources.MemoryReservation {
 		return warnings, fmt.Errorf("Minimum memory limit can not be less than memory reservation limit, see usage")

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -697,7 +697,7 @@ func (s *DockerSuite) TestRunWithMemoryReservationInvalid(c *testing.T) {
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), expected), "run container should fail with invalid memory reservation")
 	out, _, err = dockerCmdWithError("run", "--memory-reservation", "1k", "busybox", "true")
 	assert.ErrorContains(c, err, "")
-	expected = "Minimum memory reservation allowed is 4MB"
+	expected = "Minimum memory reservation allowed is 6MB"
 	assert.Assert(c, strings.Contains(strings.TrimSpace(out), expected), "run container should fail with invalid memory reservation")
 }
 


### PR DESCRIPTION
Signed-off-by: gunadhya <6939749+gunadhya@users.noreply.github.com>
fixes #41852
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
https://github.com/moby/moby/blob/4d6bc59f8102965258068facc2f064e69af0e688/integration-cli/docker_cli_run_unix_test.go#L700 
https://github.com/moby/moby/blob/8891c58a433a823ce0a65b57efff45f32ee9cb45/daemon/daemon_unix.go#L464
Fixed the error message as requested https://github.com/moby/moby/issues/41852#issue-778176274

**- How I did it**
Changed the error message from 4MB to 6MB

**- How to verify it**
https://github.com/gunadhya/moby/commit/64465f3b5fbde37ee165893248d80b24e51102aa

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
error message stating the minimum memory reservation allowed is changed from 4MB to 6MB

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/6939749/103641798-4e1b1680-4f78-11eb-96bf-fbca33476839.png)
