### PR TITLE
builder: ensure libnetwork state files do not leak

### DIFF
--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@ -3,6 +3,7 @@
 package buildkit
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -25,11 +26,24 @@ import (
 const networkName = "bridge"
 
 func newExecutor(root, cgroupParent string, net libnetwork.NetworkController, dnsConfig *oci.DNSConfig, rootless bool, idmap *idtools.IdentityMapping) (executor.Executor, error) {
+	netRoot := filepath.Join(root, "net")
 	networkProviders := map[pb.NetMode]network.Provider{
-		pb.NetMode_UNSET: &bridgeProvider{NetworkController: net, Root: filepath.Join(root, "net")},
+		pb.NetMode_UNSET: &bridgeProvider{NetworkController: net, Root: netRoot},
 		pb.NetMode_HOST:  network.NewHostProvider(),
 		pb.NetMode_NONE:  network.NewNoneProvider(),
 	}
+
+	// make sure net state directory is cleared from previous state
+	fis, err := ioutil.ReadDir(netRoot)
+	if err == nil {
+		for _, fi := range fis {
+			fp := filepath.Join(netRoot, fi.Name())
+			if err := os.RemoveAll(fp); err != nil {
+				logrus.WithError(err).Errorf("failed to delete old network state: %v", fp)
+			}
+		}
+	}
+
 	return runcexecutor.New(runcexecutor.Opt{
 		Root:                filepath.Join(root, "executor"),
 		CommandCandidates:   []string{"runc"},
@@ -117,7 +131,10 @@ func (iface *lnInterface) Close() error {
 	if iface.sbx != nil {
 		go func() {
 			if err := iface.sbx.Delete(); err != nil {
-				logrus.Errorf("failed to delete builder network sandbox: %v", err)
+				logrus.WithError(err).Errorf("failed to delete builder network sandbox")
+			}
+			if err := os.RemoveAll(filepath.Join(iface.provider.Root, iface.sbx.ContainerID())); err != nil {
+				logrus.WithError(err).Errorf("failed to delete builder sandbox directory")
 			}
 		}()
 	}


### PR DESCRIPTION
Apparently calling `sandbox.Delete` is not enough to remove all the libnetwork state files, eg. the hosts and resolv.conf file. So to avoid leaks clean up the sandbox state directory manually.

Looking at what happens on regular containers, it seems that netns is cleaned up by finalized and not directly by code. This could be investigated more in the future as could leak on restarts etc. The hosts/resolv.conf is stored in container state directory and cleaned up with container afaics.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
