### PR TITLE
integration: fix TestBuildUserNamespaceValidateCapabilitiesAreV2 not using frozen image

### DIFF
--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/testutil/fakecontext"
+	"github.com/docker/docker/testutil/fixtures/load"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
 )
@@ -36,7 +37,13 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	defer os.RemoveAll(tmp)
 
 	dUserRemap := daemon.New(t)
-	dUserRemap.StartWithBusybox(t, "--userns-remap", "default")
+	dUserRemap.Start(t, "--userns-remap", "default")
+	ctx := context.Background()
+	clientUserRemap := dUserRemap.NewClientT(t)
+
+	err = load.FrozenImagesLinux(clientUserRemap, "buildpack-deps:buster")
+	assert.NilError(t, err)
+
 	dUserRemapRunning := true
 	defer func() {
 		if dUserRemapRunning {
@@ -49,11 +56,9 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 		RUN setcap CAP_NET_BIND_SERVICE=+eip /bin/sleep
 	`
 
-	ctx := context.Background()
 	source := fakecontext.New(t, "", fakecontext.WithDockerfile(dockerfile))
 	defer source.Close()
 
-	clientUserRemap := dUserRemap.NewClientT(t)
 	resp, err := clientUserRemap.ImageBuild(ctx,
 		source.AsTarReader(t),
 		types.ImageBuildOptions{
@@ -89,7 +94,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	dUserRemapRunning = false
 
 	dNoUserRemap := daemon.New(t)
-	dNoUserRemap.StartWithBusybox(t)
+	dNoUserRemap.Start(t)
 	defer dNoUserRemap.Stop(t)
 
 	clientNoUserRemap := dNoUserRemap.NewClientT(t)


### PR DESCRIPTION
Commit f2f5106c92fb9399844dcb7315fe23f3612e7cea (https://github.com/moby/moby/pull/41740) added this test to verify loading of images that were built with user-namespaces enabled.

However, because this test spins up a new daemon, not the daemon that's set up by the test-suite's `TestMain()` (which loads the frozen images).

As a result, the `debian:bullseye` image was pulled from Docker Hub when running the test;

    Calling POST /v1.41/images/load?quiet=1
    Applying tar in /go/src/github.com/docker/docker/bundles/test-integration/TestBuildUserNamespaceValidateCapabilitiesAreV2/d4d366b15997b/root/165536.165536/overlay2/3f7f9375197667acaf7bc810b34689c21f8fed9c52c6765c032497092ca023d6/diff" storage-driver=overlay
    Applied tar sha256:845f0e5159140e9dbcad00c0326c2a506fbe375aa1c229c43f082867d283149c to 3f7f9375197667acaf7bc810b34689c21f8fed9c52c6765c032497092ca023d6, size: 5922359
    Calling POST /v1.41/build?buildargs=null&cachefrom=null&cgroupparent=&cpuperiod=0&cpuquota=0&cpusetcpus=&cpusetmems=&cpushares=0&dockerfile=&labels=null&memory=0&memswap=0&networkmode=&rm=0&shmsize=0&t=capabilities%3A1.0&target=&ulimits=null&version=
    Trying to pull debian from https://registry-1.docker.io v2
    Fetching manifest from remote" digest="sha256:f169dbadc9021fc0b08e371d50a772809286a167f62a8b6ae86e4745878d283d" error="<nil>" remote="docker.io/library/debian:bullseye
    Pulling ref from V2 registry: debian:bullseye
    ...

This patch updates `TestBuildUserNamespaceValidateCapabilitiesAreV2` to load the frozen image. `StartWithBusybox` is also changed to `Start`, because the test is not using the busybox image, so there's no need to load it.

In a followup, we should probably add some utilities to make this easier to set up (and to allow passing the list frozen images that we want to load, without having to "hard-code" the image name to load).


