### PR TITLE
Fix spurious error from "docker load"

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"reflect"
 	"runtime"
 	"strings"
 	"time"
@@ -216,6 +217,16 @@ func NewHistory(author, comment, createdBy string, isEmptyLayer bool) History {
 		Comment:    comment,
 		EmptyLayer: isEmptyLayer,
 	}
+}
+
+// Equal compares two history structs for equality
+func (h History) Equal(i History) bool {
+	if !h.Created.Equal(i.Created) {
+		return false
+	}
+	i.Created = h.Created
+
+	return reflect.DeepEqual(h, i)
 }
 
 // Exporter provides interface for loading and saving images

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -56,6 +56,29 @@ func TestMarshalKeyOrder(t *testing.T) {
 	}
 }
 
+const sampleHistoryJSON = `{
+	"created": "2021-01-13T09:35:56Z",
+	"created_by": "image_test.go"
+}`
+
+func TestHistoryEqual(t *testing.T) {
+	h := historyFromJSON(t, sampleHistoryJSON)
+	hCopy := h
+	assert.Check(t, h.Equal(hCopy))
+
+	hUTC := historyFromJSON(t, `{"created": "2021-01-13T14:00:00Z"}`)
+	hOffset0 := historyFromJSON(t, `{"created": "2021-01-13T14:00:00+00:00"}`)
+	assert.Check(t, hUTC.Created != hOffset0.Created)
+	assert.Check(t, hUTC.Equal(hOffset0))
+}
+
+func historyFromJSON(t *testing.T, historyJSON string) History {
+	var h History
+	err := json.Unmarshal([]byte(historyJSON), &h)
+	assert.Check(t, err)
+	return h
+}
+
 func TestImage(t *testing.T) {
 	cid := "50a16564e727"
 	config := &container.Config{

--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"runtime"
 
 	"github.com/containerd/containerd/platforms"
@@ -406,7 +405,7 @@ func checkValidParent(img, parent *image.Image) bool {
 		return false
 	}
 	for i, h := range parent.History {
-		if !reflect.DeepEqual(h, img.History[i]) {
+		if !h.Equal(img.History[i]) {
 			return false
 		}
 	}


### PR DESCRIPTION
**- What I did**
Fixed the spurious error "...is not a valid parent for..." when using `docker load`. Closes #41829

**- How I did it**
Added an `Equal` method to History, which normalizes UTC-equivalent times into UTC before comparison. This is used instead of `reflect.DeepEqual` in checkValidParent.

**- How to verify it**
With the following Dockerfile, on a Windows machine:
```
FROM mcr.microsoft.com/windows/nanoserver:1809
CMD ["cmd", "/C", "echo hello world"]
```
1. Run `docker build -t test-image .`
2. Run `docker save -o images.tar test-image mcr.microsoft.com/windows/nanoserver:1809`
3. Run `docker load -i images.tar`

With the patch this should work without giving an "is not a valid parent for" error message in step 3.

**- Description for the changelog**
Fix "is not a valid parent for" error from `docker load`

**- A picture of a cute animal (not mandatory but encouraged)**
🦊