### PR TITLE
docker info: silence unhandleable warnings

### DIFF
--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -130,22 +130,38 @@ func (daemon *Daemon) fillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) 
 			// blkio weight is not available on cgroup v1 since kernel 5.0.
 			// Warning is not printed on cgroup v1, because there is no action user can take.
 			// On cgroup v2, blkio weight is implemented using io.weight
-			v.Warnings = append(v.Warnings, "WARNING: No blkio weight support")
+			v.Warnings = append(v.Warnings, "WARNING: No io.weight support")
 		}
 		if !sysInfo.BlkioWeightDevice && v.CgroupVersion == "2" {
-			v.Warnings = append(v.Warnings, "WARNING: No blkio weight_device support")
+			v.Warnings = append(v.Warnings, "WARNING: No io.weight (per device) support")
 		}
 		if !sysInfo.BlkioReadBpsDevice {
-			v.Warnings = append(v.Warnings, "WARNING: No blkio throttle.read_bps_device support")
+			if v.CgroupVersion == "2" {
+				v.Warnings = append(v.Warnings, "WARNING: No io.max (rbps) support")
+			} else {
+				v.Warnings = append(v.Warnings, "WARNING: No blkio throttle.read_bps_device support")
+			}
 		}
 		if !sysInfo.BlkioWriteBpsDevice {
-			v.Warnings = append(v.Warnings, "WARNING: No blkio throttle.write_bps_device support")
+			if v.CgroupVersion == "2" {
+				v.Warnings = append(v.Warnings, "WARNING: No io.max (wbps) support")
+			} else {
+				v.Warnings = append(v.Warnings, "WARNING: No blkio throttle.write_bps_device support")
+			}
 		}
 		if !sysInfo.BlkioReadIOpsDevice {
-			v.Warnings = append(v.Warnings, "WARNING: No blkio throttle.read_iops_device support")
+			if v.CgroupVersion == "2" {
+				v.Warnings = append(v.Warnings, "WARNING: No io.max (riops) support")
+			} else {
+				v.Warnings = append(v.Warnings, "WARNING: No blkio throttle.read_iops_device support")
+			}
 		}
 		if !sysInfo.BlkioWriteIOpsDevice {
-			v.Warnings = append(v.Warnings, "WARNING: No blkio throttle.write_iops_device support")
+			if v.CgroupVersion == "2" {
+				v.Warnings = append(v.Warnings, "WARNING: No io.max (wiops) support")
+			} else {
+				v.Warnings = append(v.Warnings, "WARNING: No blkio throttle.write_iops_device support")
+			}
 		}
 	}
 	if !v.IPv4Forwarding {

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -100,10 +100,14 @@ func (daemon *Daemon) fillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) 
 		if !v.SwapLimit {
 			v.Warnings = append(v.Warnings, "WARNING: No swap limit support")
 		}
-		if !v.KernelMemoryTCP {
+		if !v.KernelMemoryTCP && v.CgroupVersion == "1" {
+			// kernel memory is not available for cgroup v2.
+			// Warning is not printed on cgroup v2, because there is no action user can take.
 			v.Warnings = append(v.Warnings, "WARNING: No kernel memory TCP limit support")
 		}
-		if !v.OomKillDisable {
+		if !v.OomKillDisable && v.CgroupVersion == "1" {
+			// oom kill disable is not available for cgroup v2.
+			// Warning is not printed on cgroup v2, because there is no action user can take.
 			v.Warnings = append(v.Warnings, "WARNING: No oom kill disable support")
 		}
 		if !v.CPUCfsQuota {
@@ -122,10 +126,13 @@ func (daemon *Daemon) fillPlatformInfo(v *types.Info, sysInfo *sysinfo.SysInfo) 
 			v.Warnings = append(v.Warnings, "WARNING: Support for cgroup v2 is experimental")
 		}
 		// TODO add fields for these options in types.Info
-		if !sysInfo.BlkioWeight {
+		if !sysInfo.BlkioWeight && v.CgroupVersion == "2" {
+			// blkio weight is not available on cgroup v1 since kernel 5.0.
+			// Warning is not printed on cgroup v1, because there is no action user can take.
+			// On cgroup v2, blkio weight is implemented using io.weight
 			v.Warnings = append(v.Warnings, "WARNING: No blkio weight support")
 		}
-		if !sysInfo.BlkioWeightDevice {
+		if !sysInfo.BlkioWeightDevice && v.CgroupVersion == "2" {
 			v.Warnings = append(v.Warnings, "WARNING: No blkio weight_device support")
 		}
 		if !sysInfo.BlkioReadBpsDevice {


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/41790

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

The following warnings in `docker info` are now discarded, because there is no action user can actually take.

On cgroup v1:
- "WARNING: No blkio weight support"
- "WARNING: No blkio weight_device support"

On cgroup v2:
- "WARNING: No kernel memory TCP limit support"
- "WARNING: No oom kill disable support"

`docker run` still prints warnings when the missing feature is being attempted to use.


**- How I did it**

See the code

**- How to verify it**
Run `docker info`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
docker info: silence unhandleable warnings


**- A picture of a cute animal (not mandatory but encouraged)**

:penguin: