### PR TITLE
Updated check_config with cgroupv2 controllers

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -162,6 +162,20 @@ echo 'Generally Necessary:'
 printf -- '- '
 if [ "$(stat -f -c %t /sys/fs/cgroup 2> /dev/null)" = '63677270' ]; then
 	wrap_good 'cgroup hierarchy' 'cgroupv2'
+	cgroupv2ControllerFile='/sys/fs/cgroup/cgroup.controllers'
+	if [ -f "$cgroupv2ControllerFile" ]; then
+		echo '  Controllers:'
+		for controller in cpu cpuset io memory pids; do
+			if grep -qE '(^| )'"$controller"'($| )' "$cgroupv2ControllerFile"; then
+				echo "  - $(wrap_good "$controller" 'available')"
+			else
+				echo "  - $(wrap_bad "$controller" 'missing')"
+			fi
+		done
+	else
+		wrap_bad "$cgroupv2ControllerFile" 'nonexistent??'
+	fi
+	# TODO find an efficient way to check if cgroup.freeze exists in subdir
 else
 	cgroupSubsystemDir="$(sed -rne '/^[^ ]+ ([^ ]+) cgroup ([^ ]*,)?(cpu|cpuacct|cpuset|devices|freezer|memory)[, ].*$/ { s//\1/p; q }' /proc/mounts)"
 	cgroupDir="$(dirname "$cgroupSubsystemDir")"
@@ -220,6 +234,10 @@ fi
 
 if [ "$kernelMajor" -lt 5 ] || [ "$kernelMajor" -eq 5 -a "$kernelMinor" -le 2 ]; then
 	check_flags NF_NAT_NEEDED
+fi
+# check availability of BPF_CGROUP_DEVICE support
+if [ "$kernelMajor" -ge 5 ] || ([ "$kernelMajor" -eq 4 ] && [ "$kernelMinor" -ge 15 ]); then
+	check_flags CGROUP_BPF
 fi
 
 echo


### PR DESCRIPTION
Fixes #41874 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added cgroupv2 available controllers and check for CONFIG_CGROUP_BPF in contrib/check-config.sh
**- How I did it**
1. Reading the /sys/fs/cgroup/cgroup.controllers file for available controllers
2. Added a new CheckFlag for CONFIG_CGROUP_BPF to BPF_CGROUP_DEVICE support
**- How to verify it**
**Output :**
Ran on Linux 5.4.0-62-generic
![image](https://user-images.githubusercontent.com/6939749/105042532-5ef47d80-5a8a-11eb-8c73-43143cac1a01.png)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update in contrib/check-config.sh cgroupv2 controllers and CONFIG_CGROUP_BPF

**- A picture of a cute animal (not mandatory but encouraged)**

