### PR TITLE
[DNM] trigger CI with runc#2750 ("seccomp: prepend -ENOSYS stub to all filters)

### DIFF
--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -4,7 +4,7 @@
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-: ${RUNC_COMMIT:=ff819c7e9184c13b7c2607fe6c30ae19403a7aff} # v1.0.0-rc92
+: ${RUNC_COMMIT:=4160d74338577c324410142397be0776d4929bfc} # https://github.com/opencontainers/runc/pull/2750 ("seccomp: prepend -ENOSYS stub to all filters")
 
 install_runc() {
 	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting
@@ -16,7 +16,7 @@ install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp apparmor selinux $RUNC_NOKMEM"}"
 
 	echo "Install runc version $RUNC_COMMIT (build tags: $RUNC_BUILDTAGS)"
-	git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"
+	git clone https://github.com/cyphar/runc.git "$GOPATH/src/github.com/opencontainers/runc"
 	cd "$GOPATH/src/github.com/opencontainers/runc"
 	git checkout -q "$RUNC_COMMIT"
 	if [ -z "$1" ]; then


### PR DESCRIPTION
Testing compatibility of https://github.com/opencontainers/runc/pull/2750 .

Commits: https://github.com/cyphar/runc/commits/seccomp-patched-bpf

DO NOT MERGE.
