### PR TITLE
daemon/graphdriver: don't unmount graphdriver root

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -554,7 +554,7 @@ func (a *Driver) Cleanup() error {
 			logger.WithError(err).WithField("method", "Cleanup()").Warn()
 		}
 	}
-	return mount.RecursiveUnmount(a.root)
+	return nil
 }
 
 func (a *Driver) aufsMount(ro []string, rw, target, mountLabel string) (err error) {

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 	units "github.com/docker/go-units"
 	"github.com/moby/locker"
-	"github.com/moby/sys/mount"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -116,15 +115,7 @@ func (d *Driver) GetMetadata(id string) (map[string]string, error) {
 
 // Cleanup unmounts a device.
 func (d *Driver) Cleanup() error {
-	err := d.DeviceSet.Shutdown(d.home)
-	umountErr := mount.RecursiveUnmount(d.home)
-
-	// in case we have two errors, prefer the one from Shutdown()
-	if err != nil {
-		return err
-	}
-
-	return umountErr
+	return d.DeviceSet.Shutdown(d.home)
 }
 
 // CreateReadWrite creates a layer that is writable for use as a container

--- a/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
+++ b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
@@ -149,7 +149,7 @@ func (d *Driver) GetMetadata(id string) (map[string]string, error) {
 // is being shutdown. For now, we just have to unmount the bind mounted
 // we had created.
 func (d *Driver) Cleanup() error {
-	return mount.RecursiveUnmount(d.home)
+	return mount.UnmountAll(d.home)
 }
 
 // CreateReadWrite creates a layer that is writable for use as a container

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -234,7 +234,7 @@ func (d *Driver) GetMetadata(id string) (map[string]string, error) {
 // is being shutdown. For now, we just have to unmount the bind mounted
 // we had created.
 func (d *Driver) Cleanup() error {
-	return mount.RecursiveUnmount(d.home)
+	return mount.UnmountAll(d.home)
 }
 
 // CreateReadWrite creates a layer that is writable for use as a container

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -308,7 +308,7 @@ func (d *Driver) GetMetadata(id string) (map[string]string, error) {
 // is being shutdown. For now, we just have to unmount the bind mounted
 // we had created.
 func (d *Driver) Cleanup() error {
-	return mount.RecursiveUnmount(d.home)
+	return mount.UnmountAll(d.home)
 }
 
 // CreateReadWrite creates a layer that is writable for use as a container

--- a/vendor.mod
+++ b/vendor.mod
@@ -54,7 +54,7 @@ require (
 	github.com/moby/ipvs v1.0.2
 	github.com/moby/locker v1.0.1
 	github.com/moby/swarmkit/v2 v2.0.0-20220721174824-48dd89375d0a
-	github.com/moby/sys/mount v0.3.3
+	github.com/moby/sys/mount v0.3.3 // FIXME(thaJeztah): See replace rule below
 	github.com/moby/sys/mountinfo v0.6.2
 	github.com/moby/sys/signal v0.7.0
 	github.com/moby/sys/symlink v0.2.0
@@ -162,6 +162,8 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 )
+
+replace github.com/moby/sys/mount => github.com/thaJeztah/sys/mount v0.1.1-0.20220818070310-e6ec1852fd37 // FIXME(thaJeztah): testing https://github.com/moby/sys/pull/62
 
 replace (
 	// More recent versions result in a panic in libnetwork.

--- a/vendor.sum
+++ b/vendor.sum
@@ -762,8 +762,6 @@ github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQ
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/swarmkit/v2 v2.0.0-20220721174824-48dd89375d0a h1:gLcTxHH4egYVhMVFWRxvWsb79Ok4kfTt1/irZNyovUY=
 github.com/moby/swarmkit/v2 v2.0.0-20220721174824-48dd89375d0a/go.mod h1:/so6Lct4y1x14UprW/loFsOe6xoXVTlvh25V36ULXNQ=
-github.com/moby/sys/mount v0.3.3 h1:fX1SVkXFJ47XWDoeFW4Sq7PdQJnV2QIDZAqjNqgEjUs=
-github.com/moby/sys/mount v0.3.3/go.mod h1:PBaEorSNTLG5t/+4EgukEQVlAvVEc6ZjTySwKdqp5K0=
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.5.0/go.mod h1:3bMD3Rg+zkqx8MRYPi7Pyb0Ie97QEBmdxbhnCLlSvSU=
@@ -997,6 +995,8 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
+github.com/thaJeztah/sys/mount v0.1.1-0.20220818070310-e6ec1852fd37 h1:FGfhs/uh9dqpGRXcPyr4LlnmbvlcnLtAUaNzTD+8fw4=
+github.com/thaJeztah/sys/mount v0.1.1-0.20220818070310-e6ec1852fd37/go.mod h1:PBaEorSNTLG5t/+4EgukEQVlAvVEc6ZjTySwKdqp5K0=
 github.com/thecodeteam/gosync v0.1.0/go.mod h1:43QHsngcnWc8GE1aCmi7PEypslflHjCzXFleuWKEb00=
 github.com/tinylib/msgp v1.1.0 h1:9fQd+ICuRIu/ue4vxJZu6/LzxN0HwMds2nq/0cFvxHU=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -661,7 +661,7 @@ github.com/moby/swarmkit/v2/volumequeue
 github.com/moby/swarmkit/v2/watch
 github.com/moby/swarmkit/v2/watch/queue
 github.com/moby/swarmkit/v2/xnet
-# github.com/moby/sys/mount v0.3.3
+# github.com/moby/sys/mount v0.3.3 => github.com/thaJeztah/sys/mount v0.1.1-0.20220818070310-e6ec1852fd37
 ## explicit; go 1.16
 github.com/moby/sys/mount
 # github.com/moby/sys/mountinfo v0.6.2
@@ -1117,6 +1117,7 @@ gotest.tools/v3/internal/format
 gotest.tools/v3/internal/source
 gotest.tools/v3/poll
 gotest.tools/v3/skip
+# github.com/moby/sys/mount => github.com/thaJeztah/sys/mount v0.1.1-0.20220818070310-e6ec1852fd37
 # github.com/armon/go-radix => github.com/armon/go-radix v0.0.0-20150105235045-e39d623f12e8
 # github.com/google/certificate-transparency-go => github.com/google/certificate-transparency-go v1.0.20
 # github.com/rexray/gocsi => github.com/dperny/gocsi v1.2.3-pre


### PR DESCRIPTION
depends on https://github.com/moby/sys/pull/62
fixes https://github.com/moby/moby/issues/39267

Most graphdrivers no longer re-mount the graphdriver root, so we should not try to unmount the root itself, to allow users to mount a custom storage location at the graphdriver's root.

Some exceptions:

- BTRFS looks to still do a remount; https://github.com/moby/moby/blob/v20.10.2/daemon/graphdriver/btrfs/btrfs.go#L86-L90
- Devicemapper's "shutdown" function calls "unmountAndDeactivateAl()", which unmounts
  all mounts https://github.com/moby/moby/blob/v20.10.2/daemon/graphdriver/devmapper/deviceset.go#L2245-L2277

NOTE: Perhaps no unmounting is needed at all, looking at;

- commit 3609b051b88565c0fe0615fd47ddb48eed549d27 (scoped "makeprivate" to graphdriver root only)
- commit 9803272f2db84df7955b16c0d847ad72cdc494d1 (removed the "makeprivate")

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
- Don't unmount graph-driver root directory on daemon shutdown, to allow custom storage mounts
```


**- A picture of a cute animal (not mandatory but encouraged)**

