### PR TITLE
daemon/images.SquashImage(): use UTC for "Created"

### DIFF
--- a/daemon/images/images.go
+++ b/daemon/images/images.go
@@ -317,7 +317,6 @@ func (i *ImageService) SquashImage(id, parent string) (string, error) {
 		newImage.History[i] = hi
 	}
 
-	now := time.Now()
 	var historyComment string
 	if len(parent) > 0 {
 		historyComment = fmt.Sprintf("merge %s to %s", id, parent)
@@ -325,6 +324,7 @@ func (i *ImageService) SquashImage(id, parent string) (string, error) {
 		historyComment = fmt.Sprintf("create new from %s", id)
 	}
 
+	now := time.Now().UTC()
 	newImage.History = append(newImage.History, image.History{
 		Created: now,
 		Comment: historyComment,


### PR DESCRIPTION
Other locations look to use UTC for this field. Relates to https://github.com/moby/moby/pull/41884/files#r560427156

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

