### PR TITLE
vendor: docker/libnetwork b3507428be5b458cb0e2b4086b13531fb0706e46

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-: "${LIBNETWORK_COMMIT:=fa125a3512ee0f6187721c88582bf8c4378bd4d7}"
+: "${LIBNETWORK_COMMIT:=b3507428be5b458cb0e2b4086b13531fb0706e46}"
 
 install_proxy() {
 	case "$1" in

--- a/integration-cli/docker_cli_port_test.go
+++ b/integration-cli/docker_cli_port_test.go
@@ -161,7 +161,7 @@ func assertPortList(c *testing.T, out string, expected []string) error {
 	// of the CLI used an incorrect output format for mappings on IPv6 addresses
 	// for example, "80/tcp -> :::80" instead of "80/tcp -> [::]:80".
 	oldFormat := func(mapping string) string {
-		old := strings.Replace(mapping, "-> [", "-> ", 1)
+		old := strings.Replace(mapping, "[", "", 1)
 		old = strings.Replace(old, "]:", ":", 1)
 		return old
 	}

--- a/integration-cli/docker_cli_port_test.go
+++ b/integration-cli/docker_cli_port_test.go
@@ -20,13 +20,13 @@ func (s *DockerSuite) TestPortList(c *testing.T) {
 
 	out, _ = dockerCmd(c, "port", firstID, "80")
 
-	err := assertPortList(c, out, []string{"0.0.0.0:9876"})
+	err := assertPortList(c, out, []string{"0.0.0.0:9876", "[::]:9876"})
 	// Port list is not correct
 	assert.NilError(c, err)
 
 	out, _ = dockerCmd(c, "port", firstID)
 
-	err = assertPortList(c, out, []string{"80/tcp -> 0.0.0.0:9876"})
+	err = assertPortList(c, out, []string{"80/tcp -> 0.0.0.0:9876", "80/tcp -> [::]:9876"})
 	// Port list is not correct
 	assert.NilError(c, err)
 
@@ -42,7 +42,7 @@ func (s *DockerSuite) TestPortList(c *testing.T) {
 
 	out, _ = dockerCmd(c, "port", ID, "80")
 
-	err = assertPortList(c, out, []string{"0.0.0.0:9876"})
+	err = assertPortList(c, out, []string{"0.0.0.0:9876", "[::]:9876"})
 	// Port list is not correct
 	assert.NilError(c, err)
 
@@ -50,8 +50,11 @@ func (s *DockerSuite) TestPortList(c *testing.T) {
 
 	err = assertPortList(c, out, []string{
 		"80/tcp -> 0.0.0.0:9876",
+		"80/tcp -> [::]:9876",
 		"81/tcp -> 0.0.0.0:9877",
+		"81/tcp -> [::]:9877",
 		"82/tcp -> 0.0.0.0:9878",
+		"82/tcp -> [::]:9878",
 	})
 	// Port list is not correct
 	assert.NilError(c, err)
@@ -69,7 +72,7 @@ func (s *DockerSuite) TestPortList(c *testing.T) {
 
 	out, _ = dockerCmd(c, "port", ID, "80")
 
-	err = assertPortList(c, out, []string{"0.0.0.0:9876", "0.0.0.0:9999"})
+	err = assertPortList(c, out, []string{"0.0.0.0:9876", "[::]:9876", "0.0.0.0:9999", "[::]:9999"})
 	// Port list is not correct
 	assert.NilError(c, err)
 
@@ -78,8 +81,12 @@ func (s *DockerSuite) TestPortList(c *testing.T) {
 	err = assertPortList(c, out, []string{
 		"80/tcp -> 0.0.0.0:9876",
 		"80/tcp -> 0.0.0.0:9999",
+		"80/tcp -> [::]:9876",
+		"80/tcp -> [::]:9999",
 		"81/tcp -> 0.0.0.0:9877",
+		"81/tcp -> [::]:9877",
 		"82/tcp -> 0.0.0.0:9878",
+		"82/tcp -> [::]:9878",
 	})
 	// Port list is not correct
 	assert.NilError(c, err)
@@ -94,7 +101,10 @@ func (s *DockerSuite) TestPortList(c *testing.T) {
 
 			out, _ = dockerCmd(c, "port", IDs[i])
 
-			err = assertPortList(c, out, []string{fmt.Sprintf("80/tcp -> 0.0.0.0:%d", 9090+i)})
+			err = assertPortList(c, out, []string{
+				fmt.Sprintf("80/tcp -> 0.0.0.0:%d", 9090+i),
+				fmt.Sprintf("80/tcp -> [::]:%d", 9090+i),
+			})
 			// Port list is not correct
 			assert.NilError(c, err)
 		}
@@ -127,9 +137,13 @@ func (s *DockerSuite) TestPortList(c *testing.T) {
 
 	err = assertPortList(c, out, []string{
 		"80/tcp -> 0.0.0.0:9800",
+		"80/tcp -> [::]:9800",
 		"81/tcp -> 0.0.0.0:9801",
+		"81/tcp -> [::]:9801",
 		"82/tcp -> 0.0.0.0:9802",
+		"82/tcp -> [::]:9802",
 		"83/tcp -> 0.0.0.0:9803",
+		"83/tcp -> [::]:9803",
 	})
 	// Port list is not correct
 	assert.NilError(c, err)
@@ -305,7 +319,7 @@ func (s *DockerSuite) TestPortHostBinding(c *testing.T) {
 
 	out, _ = dockerCmd(c, "port", firstID, "80")
 
-	err := assertPortList(c, out, []string{"0.0.0.0:9876"})
+	err := assertPortList(c, out, []string{"0.0.0.0:9876", "[::]:9876"})
 	// Port list is not correct
 	assert.NilError(c, err)
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -47,7 +47,7 @@ github.com/grpc-ecosystem/go-grpc-middleware        3c51f7f332123e8be5a157c0802a
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        fa125a3512ee0f6187721c88582bf8c4378bd4d7 
+github.com/docker/libnetwork                        b3507428be5b458cb0e2b4086b13531fb0706e46
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/iptables/iptables.go
+++ b/vendor/github.com/docker/libnetwork/iptables/iptables.go
@@ -512,8 +512,14 @@ func filterOutput(start time.Time, output []byte, args ...string) []byte {
 // Raw calls 'iptables' system command, passing supplied arguments.
 func (iptable IPTable) Raw(args ...string) ([]byte, error) {
 	if firewalldRunning {
+		// select correct IP version for firewalld
+		ipv := Iptables
+		if iptable.Version == IPv6 {
+			ipv = IP6Tables
+		}
+
 		startTime := time.Now()
-		output, err := Passthrough(Iptables, args...)
+		output, err := Passthrough(ipv, args...)
 		if err == nil || !strings.Contains(err.Error(), "was not provided by any .service files") {
 			return filterOutput(startTime, output, args...), err
 		}


### PR DESCRIPTION
also somewhat related to https://github.com/moby/moby/issues/28589, which discusses the "implicit" binding of IPv6

depends on:

- [x] https://github.com/moby/moby/pull/42021 Update rootlesskit to v0.13.1 to fix handling of IPv6 addresses
    - [x] https://github.com/rootless-containers/rootlesskit/pull/213 Refactor ParsePortSpec to handle IPv6 addresses, and improve validation
- [x] https://github.com/moby/moby/pull/42050 CI: update tests to be more resilient against CLI output format and for libnetwork changes
- [x] ~https://github.com/moby/moby/pull/42102~ https://github.com/moby/moby/pull/42179 update rootlesskit to v0.14.0
    - [x] https://github.com/rootless-containers/rootlesskit/pull/232 Port API: support specifying IP version explicitly ("tcp4", "tcp6")

full diff: https://github.com/docker/libnetwork/compare/fa125a3512ee0f6187721c88582bf8c4378bd4d7...b3507428be5b458cb0e2b4086b13531fb0706e46

- fixed IPv6 iptables rules for enabled firewalld (https://github.com/moby/libnetwork/pull/2609)
    - fixes https://github.com/moby/moby/issues/41861 "Docker uses 'iptables' instead of 'ip6tables' for IPv6 NAT rule, crashes" 
- Fix regression in https://github.com/moby/libnetwork/pull/2608
    - introduced in "Fix IPv6 Port Forwarding for the Bridge Driver" (https://github.com/moby/libnetwork/pull/2604)
    - fixes https://github.com/moby/libnetwork/issues/2607 "IPv4 and IPv6 addresses are not bound by default anymore"
    - fixes https://github.com/moby/moby/issues/41858 "IPv6 is no longer proxied by default anymore"
- Use hostIP to decide on Portmapper version (https://github.com/moby/libnetwork/pull/2616)
    - fixes docker-proxy not being stopped correctly

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

