### PR TITLE
TestCgroupNamespacesRunOlderClient: support cgroup v2

### DIFF
--- a/integration/container/run_cgroupns_linux_test.go
+++ b/integration/container/run_cgroupns_linux_test.go
@@ -130,7 +130,7 @@ func TestCgroupNamespacesRunInvalidMode(t *testing.T) {
 }
 
 // Clients before 1.40 expect containers to be created in the host cgroup namespace,
-// regardless of the default setting of the daemon
+// regardless of the default setting of the daemon, unless running with cgroup v2
 func TestCgroupNamespacesRunOlderClient(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	skip.If(t, testEnv.IsRemoteDaemon())
@@ -148,5 +148,9 @@ func TestCgroupNamespacesRunOlderClient(t *testing.T) {
 
 	daemonCgroup := d.CgroupNamespace(t)
 	containerCgroup := containerCgroupNamespace(ctx, t, client, cID)
-	assert.Assert(t, daemonCgroup == containerCgroup)
+	if testEnv.DaemonInfo.CgroupVersion != "2" {
+		assert.Assert(t, daemonCgroup == containerCgroup)
+	} else {
+		assert.Assert(t, daemonCgroup != containerCgroup)
+	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

TestCgroupNamespacesRunOlderClient: support cgroup v2.

When running with cgroup v2, cgroup namespace should be always enabled regardless to API version. (https://github.com/moby/moby/pull/41072)

**- How to verify it**

```console
$  make TEST_SKIP_INTEGRATION_CLI=1 TESTFLAGS='-test.run TestCgroupNamespacesRunOlderClient' test-integration
```