### PR TITLE
Mitigates chances of uint64 overflow in Unix stats collector 

### DIFF
--- a/daemon/stats/collector_unix_test.go
+++ b/daemon/stats/collector_unix_test.go
@@ -1,0 +1,46 @@
+// +build !windows
+
+package stats // import "github.com/docker/docker/daemon/stats"
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCollector_cpuNanoSeconds(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     io.Reader
+		expected uint64
+	}{
+		{
+			name:     "zero",
+			data:     strings.NewReader("cpu  0 0 0 0 0 0 0 0 0\n"),
+			expected: 0,
+		},
+		{
+			name:     "large",
+			data:     strings.NewReader("cpu  403617957 265046558 675564912 22209554016 632456172 0 41772895 0 0\n"),
+			expected: 242280125100000000,
+		},
+		{
+			name:     "currentMax",
+			data:     strings.NewReader("cpu  1844674407370 0 0 0 0 0 0 0 0\n"),
+			expected: 18446744073700000000,
+		},
+	}
+
+	collector := Collector{bufReader: bufio.NewReaderSize(nil, 128)}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := collector.cpuNanoSeconds(tt.data)
+			assert.NilError(t, err)
+			assert.Equal(t, tt.expected, actual, "expected %v got %v", tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes #41915 

**- What I did**

Reduced the chance of a potential uint64 overflow.

**- How I did it**

Divided big constant before using it as a factor.

**- How to verify it**

If possible, find a machine with a large number of cores and get `/proc/stat` information from it.

If the number of ticks is large enough, the uint64 will overflow.

Using number from a sample many core VM in GCP.

```
~$ cat /proc/stat
cpu  391560803 250677279 651257224 21492460706 617141613 0 40558038 0 0 0
```

Dividing the large factor before using it gives us the correct result: https://play.golang.org/p/Lqqnj-nK_Le

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Reduce chance of uint64 overflow in unix stat collector by dividing before multiplying.

**- A picture of a cute animal (not mandatory but encouraged)**
![LuckyDaCat](https://user-images.githubusercontent.com/1643994/105532857-46f64700-5ca0-11eb-92f3-9152d1f12ab3.jpg)

