### PR TITLE
Dockerfile.buildx: update buildx to v0.5.1

### DIFF
--- a/Dockerfile.buildx
+++ b/Dockerfile.buildx
@@ -1,5 +1,5 @@
 ARG GO_VERSION=1.13.15
-ARG BUILDX_COMMIT=v0.3.1
+ARG BUILDX_COMMIT=v0.5.1
 ARG BUILDX_REPO=https://github.com/docker/buildx.git
 
 FROM golang:${GO_VERSION}-buster AS build


### PR DESCRIPTION
will conflict with https://github.com/moby/moby/pull/40884, but need to have another look at that one for the build-cache pruning.

full diff: https://github.com/docker/buildx/compare/v0.3.1...v0.5.1

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

