### PR TITLE
Resume healthcheck when daemon restarts

### DIFF
--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -25,6 +27,7 @@ func TestDaemonRestartKillContainers(t *testing.T) {
 		xRunning            bool
 		xRunningLiveRestore bool
 		xStart              bool
+		xHealthCheck        bool
 	}
 
 	for _, tc := range []testCase{
@@ -41,6 +44,20 @@ func TestDaemonRestartKillContainers(t *testing.T) {
 			xRunning:            true,
 			xRunningLiveRestore: true,
 			xStart:              true,
+		},
+		{
+			desc: "container with restart=always and with healthcheck",
+			config: &container.Config{Image: "busybox", Cmd: []string{"top"},
+				Healthcheck: &container.HealthConfig{
+					Test:     []string{"CMD-SHELL", "sleep 1"},
+					Interval: time.Second,
+				},
+			},
+			hostConfig:          &container.HostConfig{RestartPolicy: container.RestartPolicy{Name: "always"}},
+			xRunning:            true,
+			xRunningLiveRestore: true,
+			xStart:              true,
+			xHealthCheck:        true,
 		},
 		{
 			desc:       "container created should not be restarted",
@@ -107,9 +124,32 @@ func TestDaemonRestartKillContainers(t *testing.T) {
 
 					}
 					assert.Equal(t, expected, running, "got unexpected running state, expected %v, got: %v", expected, running)
+
+					if c.xHealthCheck {
+						startTime := time.Now()
+						ctxPoll, cancel := context.WithTimeout(ctx, 30*time.Second)
+						defer cancel()
+						poll.WaitOn(t, pollForNewHealthCheck(ctxPoll, client, startTime, resp.ID), poll.WithDelay(100*time.Millisecond))
+					}
 					// TODO(cpuguy83): test pause states... this seems to be rather undefined currently
 				})
 			}
 		}
+	}
+}
+
+func pollForNewHealthCheck(ctx context.Context, client *client.Client, startTime time.Time, containerID string) func(log poll.LogT) poll.Result {
+	return func(log poll.LogT) poll.Result {
+		inspect, err := client.ContainerInspect(ctx, containerID)
+		if err != nil {
+			return poll.Error(err)
+		}
+		healthChecksTotal := len(inspect.State.Health.Log)
+		if healthChecksTotal > 0 {
+			if inspect.State.Health.Log[healthChecksTotal-1].Start.After(startTime) {
+				return poll.Success()
+			}
+		}
+		return poll.Continue("waiting for a new container healthcheck")
 	}
 }


### PR DESCRIPTION
Call updateHealthMonitor for alive non-paused containers when daemon restarts.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**What I did**

Fix issue #41871 feat. @ealessandria-orange


**- How I did it**

While dockerd restores, call updateHealthMonitor for non paused alive containers.

**- How to verify it**

At dockerd restart, containers' healthcheck is still running.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix issue #41871 
