### PR TITLE
testutil.LoadBusybox() load both "regular" and "glibc" busybox variants

### DIFF
--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -698,7 +698,7 @@ func (d *Daemon) LoadBusybox(t testing.TB) {
 	defer clientHost.Close()
 
 	ctx := context.Background()
-	reader, err := clientHost.ImageSave(ctx, []string{"busybox:latest"})
+	reader, err := clientHost.ImageSave(ctx, []string{"busybox:latest", "busybox:glibc"})
 	assert.NilError(t, err, "[%s] failed to download busybox", d.id)
 	defer reader.Close()
 


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/36375, which added this variant of the busybox image

This makes sure that the swarm tests use the frozen image, instead of pulling the image from Docker Hub. We already have these images locally, so loading them (like we do for the non-glibc variant) prevents some rate limits;

    === FAIL: amd64.integration-cli TestDockerSwarmSuite/TestSwarmContainerEndpointOptions (2.71s)
        --- FAIL: TestDockerSwarmSuite/TestSwarmContainerEndpointOptions (2.71s)
            docker_cli_swarm_test.go:350: assertion failed: error is not nil: exit status 125: Unable to find image 'busybox:glibc' locally
                /usr/local/cli/docker: Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit.
                See '/usr/local/cli/docker run --help'.

