### PR TITLE
docs: fix double "the" in existing API versions

### DIFF
--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -6196,7 +6196,7 @@ paths:
 
 
             For example, the build arg `FOO=bar` would become `{"FOO":"bar"}` in JSON. This would result in the
-            the query parameter `buildargs={"FOO":"bar"}`. Note that `{"FOO":"bar"}` should be URI component encoded.
+            query parameter `buildargs={"FOO":"bar"}`. Note that `{"FOO":"bar"}` should be URI component encoded.
 
 
             [Read more about the buildargs instruction.](https://docs.docker.com/engine/reference/builder/#arg)

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -6257,7 +6257,7 @@ paths:
 
 
             For example, the build arg `FOO=bar` would become `{"FOO":"bar"}` in JSON. This would result in the
-            the query parameter `buildargs={"FOO":"bar"}`. Note that `{"FOO":"bar"}` should be URI component encoded.
+            query parameter `buildargs={"FOO":"bar"}`. Note that `{"FOO":"bar"}` should be URI component encoded.
 
 
             [Read more about the buildargs instruction.](https://docs.docker.com/engine/reference/builder/#arg)

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -7004,7 +7004,7 @@ paths:
 
 
             For example, the build arg `FOO=bar` would become `{"FOO":"bar"}` in JSON. This would result in the
-            the query parameter `buildargs={"FOO":"bar"}`. Note that `{"FOO":"bar"}` should be URI component encoded.
+            query parameter `buildargs={"FOO":"bar"}`. Note that `{"FOO":"bar"}` should be URI component encoded.
 
 
             [Read more about the buildargs instruction.](https://docs.docker.com/engine/reference/builder/#arg)

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -7142,7 +7142,7 @@ paths:
 
 
             For example, the build arg `FOO=bar` would become `{"FOO":"bar"}` in JSON. This would result in the
-            the query parameter `buildargs={"FOO":"bar"}`. Note that `{"FOO":"bar"}` should be URI component encoded.
+            query parameter `buildargs={"FOO":"bar"}`. Note that `{"FOO":"bar"}` should be URI component encoded.
 
 
             [Read more about the buildargs instruction.](https://docs.docker.com/engine/reference/builder/#arg)

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -7310,7 +7310,7 @@ paths:
 
 
             For example, the build arg `FOO=bar` would become `{"FOO":"bar"}` in JSON. This would result in the
-            the query parameter `buildargs={"FOO":"bar"}`. Note that `{"FOO":"bar"}` should be URI component encoded.
+            query parameter `buildargs={"FOO":"bar"}`. Note that `{"FOO":"bar"}` should be URI component encoded.
 
 
             [Read more about the buildargs instruction.](https://docs.docker.com/engine/reference/builder/#arg)


### PR DESCRIPTION
Backport of 2db5676c6e827ce311a87224cf5f2e3ae8b68afd (https://github.com/moby/moby/pull/41924) to the swagger files used in the documentation

