### PR TITLE
rootless: prevent the service hanging when stopping (set systemd KillMode to mixed)

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -307,6 +307,7 @@ install_systemd() {
 			TasksMax=infinity
 			Delegate=yes
 			Type=simple
+			KillMode=mixed
 
 			[Install]
 			WantedBy=default.target


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix  #41944 ("Docker rootless does not exit properly if containers are running")

Now `systemctl --user stop docker` completes just with in 1 or 2 seconds.


**- How I did it**
Changed the KillMode from "control-group" (default) to "mixed"

See systemd.kill(5) https://www.freedesktop.org/software/systemd/man/systemd.kill.html

> Specifies how processes of this unit shall be killed. One of control-group, mixed, process, none.

> If set to control-group, all remaining processes in the control group of this unit will be killed on unit stop (for services: after the stop command is executed, as configured with ExecStop=). If set to mixed, the SIGTERM signal (see below) is sent to the main process while the subsequent SIGKILL signal (see below) is sent to all remaining processes of the unit's control group. If set to process, only the main process itself is killed (not recommended!). If set to none, no process is killed (strongly recommended against!). In this case, only the stop command will be executed on unit stop, but no process will be killed otherwise. Processes remaining alive after stop are left in their control group and the control group continues to exist after stop unless empty.

> Note that it is not recommended to set KillMode= to process or even none, as this allows processes to escape the service manager's lifecycle and resource management, and to remain running even while their service is considered stopped and is assumed to not consume any resources.

> Processes will first be terminated via SIGTERM (unless the signal to send is changed via KillSignal= or RestartKillSignal=). Optionally, this is immediately followed by a SIGHUP (if enabled with SendSIGHUP=). If processes still remain after the main process of a unit has exited or the delay configured via the TimeoutStopSec= has passed, the termination request is repeated with the SIGKILL signal or the signal specified via FinalKillSignal= (unless this is disabled via the SendSIGKILL= option). See kill(2) for more information.

> Defaults to control-group.

"mixed" is available since systemd 209 (2014-02-20) https://github.com/systemd/systemd/blob/57353d2909e503e3e5c7e69251ba95a31e1a72ce/NEWS#L9318

**- How to verify it**

Run some containers with rootless, and make sure `systemctl --user stop docker.service` completes in a few seconds.


```bash
$ docker --context=rootless run --name nginx -d -p 8080:80 --restart=always nginx:alpine
$ time systemctl --user stop docker

real    0m1.266s
user    0m0.005s
sys     0m0.000s

```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
rootless: prevent the service hanging when stopping (set systemd KillMode to mixed)

**- A picture of a cute animal (not mandatory but encouraged)**

:penguin: