### PR TITLE
apparmor: clobber docker-default profile on start

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -377,7 +377,7 @@ func newRouterOptions(ctx context.Context, config *config.Config, d *daemon.Daem
 		Rootless:            daemon.Rootless(config),
 		IdentityMapping:     d.IdentityMapping(),
 		DNSConfig:           config.DNSConfig,
-		ApparmorProfile:     daemon.DefaultApparmorProfile(),
+		ApparmorProfile:     daemon.DefaultAppArmorProfile(),
 		UseSnapshotter:      d.UsesSnapshotter(),
 		Snapshotter:         d.ImageService().StorageDriver(),
 		ContainerdAddress:   config.ContainerdAddr,

--- a/daemon/apparmor_default.go
+++ b/daemon/apparmor_default.go
@@ -15,12 +15,21 @@ const (
 	defaultAppArmorProfile    = "docker-default"
 )
 
-// DefaultApparmorProfile returns the name of the default apparmor profile
-func DefaultApparmorProfile() string {
+// DefaultAppArmorProfile returns the name of the default apparmor profile
+func DefaultAppArmorProfile() string {
 	if apparmor.HostSupports() {
 		return defaultAppArmorProfile
 	}
 	return ""
+}
+
+func clobberDefaultAppArmorProfile() error {
+	if apparmor.HostSupports() {
+		if err := aaprofile.InstallDefault(defaultAppArmorProfile); err != nil {
+			return fmt.Errorf("AppArmor enabled on system but the %s profile could not be loaded: %s", defaultAppArmorProfile, err)
+		}
+	}
+	return nil
 }
 
 func ensureDefaultAppArmorProfile() error {
@@ -36,10 +45,7 @@ func ensureDefaultAppArmorProfile() error {
 		}
 
 		// Load the profile.
-		if err := aaprofile.InstallDefault(defaultAppArmorProfile); err != nil {
-			return fmt.Errorf("AppArmor enabled on system but the %s profile could not be loaded: %s", defaultAppArmorProfile, err)
-		}
+		return clobberDefaultAppArmorProfile()
 	}
-
 	return nil
 }

--- a/daemon/apparmor_default_unsupported.go
+++ b/daemon/apparmor_default_unsupported.go
@@ -2,11 +2,15 @@
 
 package daemon // import "github.com/docker/docker/daemon"
 
+func clobberDefaultAppArmorProfile() error {
+	return nil
+}
+
 func ensureDefaultAppArmorProfile() error {
 	return nil
 }
 
-// DefaultApparmorProfile returns an empty string.
-func DefaultApparmorProfile() string {
+// DefaultAppArmorProfile returns an empty string.
+func DefaultAppArmorProfile() string {
 	return ""
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -879,8 +879,9 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		log.G(ctx).Warnf("Failed to configure golang's threads limit: %v", err)
 	}
 
-	// ensureDefaultAppArmorProfile does nothing if apparmor is disabled
-	if err := ensureDefaultAppArmorProfile(); err != nil {
+	// Make sure we clobber any pre-existing docker-default profile to ensure
+	// that upgrades to the profile actually work smoothly.
+	if err := clobberDefaultAppArmorProfile(); err != nil {
 		log.G(ctx).Errorf(err.Error())
 	}
 


### PR DESCRIPTION
In the process of making docker-default reloading far less expensive,
567ef8e7858c ("daemon: switch to 'ensure' workflow for AppArmor
profiles") mistakenly made the initial profile load at dockerd start-up
lazy. As a result, if you have a running Docker daemon and upgrade it to
a new one with an updated AppArmor profile the new profile will not take
effect (because the old one is still loaded). The fix for this is quite
trivial, and just requires us to clobber the profile on start-up.

Carries #40615 and #37353
Fixes: 567ef8e7858c ("daemon: switch to 'ensure' workflow for AppArmor profiles")
Signed-off-by: Aleksa Sarai <asarai@suse.de>

<img height="400px" src="https://user-images.githubusercontent.com/2888411/106408989-a8ce6200-6493-11eb-8beb-f94e34e1937d.jpeg" />