### PR TITLE
Fallback to  manifest list when no platform match

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -12,6 +12,7 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/idtools"
@@ -89,7 +90,7 @@ func (daemon *Daemon) containerCreate(opts createOpts) (containertypes.Container
 			Variant:      img.Variant,
 		}
 
-		if !platforms.Only(p).Match(imgPlat) {
+		if !images.OnlyPlatformWithFallback(p).Match(imgPlat) {
 			warnings = append(warnings, fmt.Sprintf("The requested image's platform (%s) does not match the detected host platform (%s) and no specific platform was requested", platforms.Format(imgPlat), platforms.Format(p)))
 		}
 	}

--- a/daemon/images/images_test.go
+++ b/daemon/images/images_test.go
@@ -1,0 +1,33 @@
+package images
+
+import (
+	"testing"
+
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/v3/assert"
+)
+
+func TestOnlyPlatformWithFallback(t *testing.T) {
+	p := specs.Platform{
+		OS:           "linux",
+		Architecture: "arm",
+		Variant:      "v8",
+	}
+
+	// Check no variant
+	assert.Assert(t, OnlyPlatformWithFallback(p).Match(specs.Platform{
+		OS:           p.OS,
+		Architecture: p.Architecture,
+	}))
+	// check with variant
+	assert.Assert(t, OnlyPlatformWithFallback(p).Match(specs.Platform{
+		OS:           p.OS,
+		Architecture: p.Architecture,
+		Variant:      p.Variant,
+	}))
+	// Make sure non-matches are false.
+	assert.Assert(t, !OnlyPlatformWithFallback(p).Match(specs.Platform{
+		OS:           p.OS,
+		Architecture: "amd64",
+	}))
+}


### PR DESCRIPTION
relates to / addresses https://github.com/docker/for-linux/issues/1170#issuecomment-750478242


In some cases, in fact many in the wild, an image may have the incorrect
platform on the image config.
This can lead to failures to run an image, particularly when a user
specifies a `--platform`.
Typically what we see in the wild is a manifest list with an an entry
for, as an example, linux/arm64 pointing to an image config that has
linux/amd64 on it.

This change falls back to looking up the manifest list for an image to
see if the manifest list shows the image as the correct one for that
platform.

In order to accomplish this we need to traverse the leases associated
with an image. Each image, if pulled with Docker 20.10, will have the
manifest list stored in the containerd content store with the resource
assigned to a lease keyed on the image ID.
So we look up the lease for the image, then look up the assocated
resources to find the manifest list, then check the manifest list for a
platform match, then ensure that manifest referes to our image config.

This is only used as a fallback when a user specified they want a
particular platform and the image config that we have does not match
that platform.