### PR TITLE
[20.10 backport] rootless: prevent the service hanging when stopping (set systemd KillMode to mixed) 

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -307,6 +307,7 @@ install_systemd() {
 			TasksMax=infinity
 			Delegate=yes
 			Type=simple
+			KillMode=mixed
 
 			[Install]
 			WantedBy=default.target


### PR DESCRIPTION
Cherry-pick https://github.com/moby/moby/pull/41947