### PR TITLE
[20.10 backport] pkg/archive: allow mknodding FIFO inside userns

### DIFF
--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -81,11 +81,6 @@ func getFileUIDGID(stat interface{}) (idtools.Identity, error) {
 // handleTarTypeBlockCharFifo is an OS-specific helper function used by
 // createTarFile to handle the following types of header: Block; Char; Fifo
 func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
-	if sys.RunningInUserNS() {
-		// cannot create a device if running in user namespace
-		return nil
-	}
-
 	mode := uint32(hdr.Mode & 07777)
 	switch hdr.Typeflag {
 	case tar.TypeBlock:
@@ -96,7 +91,12 @@ func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
 		mode |= unix.S_IFIFO
 	}
 
-	return system.Mknod(path, mode, int(system.Mkdev(hdr.Devmajor, hdr.Devminor)))
+	err := system.Mknod(path, mode, int(system.Mkdev(hdr.Devmajor, hdr.Devminor)))
+	if errors.Is(err, syscall.EPERM) && sys.RunningInUserNS() {
+		// In most cases, cannot create a device if running in user namespace
+		err = nil
+	}
+	return err
 }
 
 func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {


### PR DESCRIPTION
Cherry-pick #41892

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix #41803

Also attempt to mknod devices.
Mknodding devices are likely to fail, but still worth trying when running with a seccomp user notification.


**- How I did it**
By allowing mknodding FIFO inside userns.

**- How to verify it**
`docker pull docker.io/gitlab/gitlab-ee:13.6.3-ee.0` with rootless

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

:penguin:
