### PR TITLE
dockerd-rootless.sh: add typo guard

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -18,6 +18,12 @@
 # See the documentation for the further information: https://docs.docker.com/engine/security/rootless/
 
 set -e -x
+case "$1" in
+	"check" | "install" | "uninstall")
+		echo "Did you mean 'dockerd-rootless-setuptool.sh $@' ?"
+		exit 1
+		;;
+esac
 if ! [ -w $XDG_RUNTIME_DIR ]; then
 	echo "XDG_RUNTIME_DIR needs to be set and writable"
 	exit 1


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

`dockerd-rootless.sh install` is a common typo of `dockerd-rootless-setuptool.sh install`.

Now `dockerd-rootless.sh install` shows human-readable error.


**- How I did it**

Added a human-readable error

**- How to verify it**
```console
$ dockerd-rootless.sh  install -f
+ echo Did you mean 'dockerd-rootless-setuptool.sh install -f' ?
Did you mean 'dockerd-rootless-setuptool.sh install -f' ?
+ exit 1
```


**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
